### PR TITLE
fix(tools): paginate conversations by message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to this project will be documented in this file.
 - **Execution conversation pagination now uses messages rather than rendered
   lines** — callers of `/executions/{id}/conversation` should replace
   `view_range` with `offset` and `limit`. Archive reads now report the returned
-  message interval, next offset, and selected transcript source.
+  message interval and next offset.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,13 +36,13 @@ All notable changes to this project will be documented in this file.
   kind** — consumers of `@texra-ai/agent` that switch exhaustively over a
   result event's `error.kind` must handle the new `context-window` value, which
   previously arrived as `unexpected`.
+- **Execution conversation pagination now uses messages rather than rendered
+  lines** — callers of `/executions/{id}/conversation` should replace
+  `view_range` with `offset` and `limit`. Archive reads now report the returned
+  message interval, next offset, and selected transcript source.
 
 #### Bug Fixes
 
-- **Execution conversations page by message rather than rendered line** —
-  archive reads now report the returned message interval, next offset, and
-  selected transcript source, so resumed turns can be inspected without
-  ambiguous or repeated line windows.
 - **Runs that overflow the model context window say so** — instead of a generic
   failure message, the run now reports that the conversation exceeds the
   model's context window and suggests starting a new session or reducing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@ All notable changes to this project will be documented in this file.
   previously arrived as `unexpected`.
 - **Execution conversation pagination now uses messages rather than rendered
   lines** — callers of `/executions/{id}/conversation` should replace
-  `view_range` with `offset` and `limit`. Archive reads now report the returned
-  message interval and next offset.
+  `view_range` with `offset` and `limit`. Responses report the returned message
+  interval and next offset.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Execution conversations page by message rather than rendered line** —
+  archive reads now report the returned message interval, next offset, and
+  selected transcript source, so resumed turns can be inspected without
+  ambiguous or repeated line windows.
 - **Runs that overflow the model context window say so** — instead of a generic
   failure message, the run now reports that the conversation exceeds the
   model's context window and suggests starting a new session or reducing

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -298,6 +298,17 @@ function buildExecutionsSections(ctx: ToolSectionContext): TemplateResult[] {
       buildToolUseSection('Range:', wrapInPre(`lines ${start}–${end}`)),
     );
   }
+
+  if (typeof input.offset === 'number') {
+    sections.push(
+      buildToolUseSection('Offset:', wrapInPre(String(input.offset))),
+    );
+  }
+  if (typeof input.limit === 'number') {
+    sections.push(
+      buildToolUseSection('Limit:', wrapInPre(String(input.limit))),
+    );
+  }
   return sections;
 }
 

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -293,6 +293,43 @@ return { papers, question: args.question };`;
     expect(container.textContent).not.toContain('3600s');
   });
 
+  it('renders guarded executions conversation pagination arguments', () => {
+    const valid = renderTemplate(
+      formatToolUseTemplate(
+        toolUseMessage('executions-conversation-page', {
+          toolName: 'executions',
+          input: {
+            path: '/executions/abc123/conversation',
+            offset: 0,
+            limit: 25,
+          },
+        }),
+      ),
+    );
+    const labels = [...valid.querySelectorAll('.tool-use-sublabel')].map(
+      (label) => label.textContent,
+    );
+
+    expect(labels).toEqual(['Path:', 'Offset:', 'Limit:']);
+    expect(valid.textContent).toContain('0');
+    expect(valid.textContent).toContain('25');
+
+    const invalid = renderTemplate(
+      formatToolUseTemplate(
+        toolUseMessage('executions-invalid-conversation-page', {
+          toolName: 'executions',
+          input: {
+            path: '/executions/abc123/conversation',
+            offset: '0',
+            limit: null,
+          },
+        }),
+      ),
+    );
+    expect(invalid.textContent).not.toContain('Offset:');
+    expect(invalid.textContent).not.toContain('Limit:');
+  });
+
   it('labels executions targets when the display model knows the subagents', () => {
     const message = toolUseMessage('executions-subagents', {
       toolName: 'executions',

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -10,7 +10,51 @@
  * proves conversation display, chat export, and todos all read through the
  * facade.
  */
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const launchMocks = vi.hoisted(() => ({
+  acquireResumedExecutionLease: vi.fn(),
+  buildVars: vi.fn(),
+  clearTerminalExecutionState: vi.fn(),
+  createHandler: vi.fn(),
+  hasPersistedParent: vi.fn(),
+  loadAgent: vi.fn(),
+  releaseOwnedExecutionLeaseAfterFailure: vi.fn(),
+  resolveAgent: vi.fn(),
+}));
+
+vi.mock('@agent/index', async (importActual) => ({
+  ...(await importActual<typeof import('@agent/index')>()),
+  isRemoteAgent: () => false,
+  resolveAgentForLaunch: launchMocks.resolveAgent,
+}));
+vi.mock('@agent/runtime/agentLoad', async (importActual) => ({
+  ...(await importActual<typeof import('@agent/runtime/agentLoad')>()),
+  loadAgentSettingAndPrompts: launchMocks.loadAgent,
+}));
+vi.mock('@agent/runtime/ModelFactory', async (importActual) => ({
+  ...(await importActual<typeof import('@agent/runtime/ModelFactory')>()),
+  createModelHandler: launchMocks.createHandler,
+  createModelHandlerForCompatibilityKey: launchMocks.createHandler,
+}));
+vi.mock('@agent/utils/userVars', async (importActual) => ({
+  ...(await importActual<typeof import('@agent/utils/userVars')>()),
+  buildUserVars: launchMocks.buildVars,
+}));
+vi.mock('@agent/storage/executionLifecycle', async (importActual) => ({
+  ...(await importActual<typeof import('@agent/storage/executionLifecycle')>()),
+  clearTerminalExecutionState: launchMocks.clearTerminalExecutionState,
+  hasPersistedParent: launchMocks.hasPersistedParent,
+}));
+vi.mock('@agent/storage/executionLease', async (importActual) => ({
+  ...(await importActual<typeof import('@agent/storage/executionLease')>()),
+  acquireResumedExecutionLease: launchMocks.acquireResumedExecutionLease,
+  captureOwnedExecutionLease:
+    (_executionId: ExecutionId) => (operation: () => unknown) =>
+      operation(),
+  releaseOwnedExecutionLeaseAfterFailure:
+    launchMocks.releaseOwnedExecutionLeaseAfterFailure,
+}));
 
 import { clearStoreCache, getExecutionStore } from '@agent/storage';
 import {
@@ -18,6 +62,9 @@ import {
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
 import { loadChatExportInput } from '@agent/export/loadChatExportInput';
+import { resumeToolUseFromResumeData } from '@agent/runtime/executeAgent';
+import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
+import { flowKey } from '@agent/node/persistedFlow';
 import {
   LOG_LEVELS,
   MESSAGE_TYPES,
@@ -31,6 +78,8 @@ import {
   createTempDirPlatform,
 } from '@test/support/tempDirPlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
+import { createTestSession } from '@test/support/sessionTestUtils';
+import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
 import { ExecutionsTool } from '@tools/ExecutionsTool';
 import {
   readCompletedRunConversation,
@@ -152,6 +201,13 @@ describe('completedRunArchive facade', () => {
 
   beforeEach(() => {
     clearStoreCache();
+    vi.clearAllMocks();
+    launchMocks.acquireResumedExecutionLease.mockResolvedValue('existing');
+    launchMocks.clearTerminalExecutionState.mockResolvedValue(undefined);
+    launchMocks.hasPersistedParent.mockResolvedValue(false);
+    launchMocks.releaseOwnedExecutionLeaseAfterFailure.mockImplementation(
+      async (_executionId: ExecutionId, error: unknown) => error,
+    );
   });
 
   afterEach(async () => {
@@ -256,7 +312,7 @@ describe('completedRunArchive facade', () => {
     ]);
   });
 
-  it('reconstructs both turns after a transcript writer is released and reopened', async () => {
+  it('reconstructs both turns when the production resume launch reopens the canonical writer', async () => {
     const executionId = '0aa1110aa111' as ExecutionId;
     const streamId = 'orchestrator@deepseekproT#0aa1110aa111' as StreamTabId;
     const snapshots = new StreamSnapshotStore();
@@ -277,20 +333,77 @@ describe('completedRunArchive facade', () => {
     logs.requestEviction(streamId);
     expect(logs.get(streamId)).toBeUndefined();
 
-    const resumedTurn = await logs.loadAndAcquireWriter(
+    const launchFailure = new Error('stop after resumed writer acquisition');
+    launchMocks.resolveAgent.mockReturnValue({
+      definitionPath: '/agents/orchestrator.yaml',
+    });
+    launchMocks.loadAgent.mockResolvedValue([
+      { agentCategory: AgentCategory.ToolUse },
+      {},
+    ]);
+    launchMocks.createHandler.mockResolvedValue({
+      capabilities: { supportsVision: false, supportsNativeAudio: false },
+      config: { provider: 'openai' },
+      setAgentCategory: vi.fn(),
+      setLogger: vi.fn(),
+      dispose: vi.fn(),
+    });
+    launchMocks.buildVars.mockRejectedValueOnce(launchFailure);
+
+    const config = runConfig('orchestrator');
+    const persistedResumeState = createToolUseResumeData({
+      executionId,
       streamId,
-      `${executionId}:resume`,
-    );
-    resumedTurn.appendSettled(
-      logRow(MESSAGE_TYPES.USER_MESSAGE, {
-        text: 'Now prove the second lemma.',
-      }),
-    );
-    resumedTurn.appendSettled(
-      logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Second proof.' }),
-    );
-    resumedTurn.close();
+      agentConfig: config,
+      shared: {
+        modelHandlerCompatibilityKey: 'ModelHandlerOpenAIResponse',
+      },
+    });
+    await getExecutionStore(executionId).write(flowKey(executionId), {
+      flowName: 'texra',
+      params: {},
+      shared: persistedResumeState.shared,
+      createdAt: new Date().toISOString(),
+      nodes: [],
+    });
+
+    const session = createTestSession({ transcripts: logs });
+    const loadAndAcquireWriter = logs.loadAndAcquireWriter.bind(logs);
+    const resumedWriter = vi
+      .spyOn(logs, 'loadAndAcquireWriter')
+      .mockImplementationOnce(async (requestedStreamId, ownerKey) => {
+        const writer = await loadAndAcquireWriter(requestedStreamId, ownerKey);
+        writer.appendSettled(
+          logRow(MESSAGE_TYPES.USER_MESSAGE, {
+            text: 'Now prove the second lemma.',
+          }),
+        );
+        writer.appendSettled(
+          logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Second proof.' }),
+        );
+        return writer;
+      });
+
+    try {
+      const resume = await retrieveSessionResumeData(
+        streamId,
+        executionId,
+        config,
+      );
+      expect(resume?.type).toBe('toolUse');
+      if (resume?.type !== 'toolUse') {
+        throw new Error('Expected persisted tool-use resume data');
+      }
+      expect(resume.streamId).toBe(streamId);
+      await expect(
+        resumeToolUseFromResumeData(resume, { session }),
+      ).rejects.toBe(launchFailure);
+    } finally {
+      session.dispose();
+    }
     await logs.flush();
+
+    expect(resumedWriter).toHaveBeenCalledWith(streamId, executionId);
 
     const archived = await readCompletedRunConversation(executionId);
     expect(archived).toEqual({
@@ -411,6 +524,26 @@ describe('completedRunArchive facade', () => {
 
     const todosResult = await readCompletedRunTodos(executionId);
     expect(todosResult).toEqual({ todos: [], source: 'none' });
+
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: '2026-07-07T00:00:00.000Z',
+      terminalStatus: 'completed',
+    });
+    const endpoint = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+    });
+    expect(endpoint).toEqual({
+      status: 'executed',
+      output: [
+        'Conversation (0 messages):',
+        'Source: none',
+        'Stream: none',
+        'Returned message interval: [0, 0)',
+        'Next offset: none',
+        '',
+        '',
+      ].join('\n'),
+    });
   });
 
   it('prefers the sidecar when a legacy conversation projection also exists', async () => {

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -31,6 +31,7 @@ import {
   createTempDirPlatform,
 } from '@test/support/tempDirPlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
+import { ExecutionsTool } from '@tools/ExecutionsTool';
 import {
   readCompletedRunConversation,
   readCompletedRunTodos,
@@ -253,6 +254,114 @@ describe('completedRunArchive facade', () => {
     expect(todosResult.todos).toEqual([
       { content: 'Fix the bug', status: 'completed' },
     ]);
+  });
+
+  it('reconstructs both turns after a transcript writer is released and reopened', async () => {
+    const executionId = '0aa1110aa111' as ExecutionId;
+    const streamId = 'orchestrator@deepseekproT#0aa1110aa111' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
+    await snapshots.flush();
+
+    const logs = await StreamLogStore.open();
+    logs.ensureStream(streamId);
+    const firstTurn = logs.acquireWriter(streamId, executionId);
+    firstTurn.appendSettled(
+      logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Prove the first lemma.' }),
+    );
+    firstTurn.appendSettled(
+      logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'First proof.' }),
+    );
+    firstTurn.close();
+    await logs.flush();
+    logs.requestEviction(streamId);
+    expect(logs.get(streamId)).toBeUndefined();
+
+    const resumedTurn = await logs.loadAndAcquireWriter(
+      streamId,
+      `${executionId}:resume`,
+    );
+    resumedTurn.appendSettled(
+      logRow(MESSAGE_TYPES.USER_MESSAGE, {
+        text: 'Now prove the second lemma.',
+      }),
+    );
+    resumedTurn.appendSettled(
+      logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Second proof.' }),
+    );
+    resumedTurn.close();
+    await logs.flush();
+
+    const archived = await readCompletedRunConversation(executionId);
+    expect(archived).toEqual({
+      source: 'streamLog',
+      streamId,
+      conversation: [
+        { role: 'user', content: 'Prove the first lemma.' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'First proof.' }],
+        },
+        { role: 'user', content: 'Now prove the second lemma.' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Second proof.' }],
+        },
+      ],
+    });
+
+    const endpoint = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+    });
+    expect(endpoint.status).toBe('executed');
+    expect(endpoint.output).toContain('Conversation (4 messages)');
+    expect(endpoint.output).toContain('Prove the first lemma.');
+    expect(endpoint.output).toContain('First proof.');
+    expect(endpoint.output).toContain('Now prove the second lemma.');
+    expect(endpoint.output).toContain('Second proof.');
+
+    const firstPage = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+      offset: 0,
+      limit: 2,
+    });
+    const secondPage = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+      offset: 2,
+      limit: 2,
+    });
+    expect(firstPage.output).toContain('Source: streamLog');
+    expect(firstPage.output).toContain(`Stream: ${streamId}`);
+    expect(firstPage.output).toContain('Returned message interval: [0, 2)');
+    expect(firstPage.output).toContain('Next offset: 2');
+    expect(firstPage.output).toContain('<message index="1"');
+    expect(firstPage.output).toContain('<message index="2"');
+    expect(firstPage.output).not.toContain('Now prove the second lemma.');
+    expect(secondPage.output).toContain('Returned message interval: [2, 4)');
+    expect(secondPage.output).toContain('Next offset: none');
+    expect(secondPage.output).toContain('<message index="3"');
+    expect(secondPage.output).toContain('<message index="4"');
+    expect(secondPage.output).not.toContain('Prove the first lemma.');
+
+    for (const text of [
+      'Prove the first lemma.',
+      'First proof.',
+      'Now prove the second lemma.',
+      'Second proof.',
+    ]) {
+      expect(
+        `${firstPage.output}\n${secondPage.output}`.split(text),
+      ).toHaveLength(2);
+    }
+
+    const lineRange = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+      view_range: [1, 10],
+    });
+    expect(lineRange.status).toBe('error');
+    expect(lineRange.error).toContain(
+      'Conversation pagination is message-based. Use offset and limit',
+    );
   });
 
   it('falls back to the legacy KV projections when no sidecar exists', async () => {

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -63,7 +63,8 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import { loadChatExportInput } from '@agent/export/loadChatExportInput';
 import { resumeToolUseFromResumeData } from '@agent/runtime/executeAgent';
-import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
+import { resolveAndResumeStream } from '@agent/runtime/resolveAndResumeStream';
+import { getStreamTabId } from '@agent/runtime/streamTab';
 import { flowKey } from '@agent/node/persistedFlow';
 import {
   LOG_LEVELS,
@@ -201,16 +202,11 @@ describe('completedRunArchive facade', () => {
 
   beforeEach(() => {
     clearStoreCache();
-    vi.clearAllMocks();
-    launchMocks.acquireResumedExecutionLease.mockResolvedValue('existing');
-    launchMocks.clearTerminalExecutionState.mockResolvedValue(undefined);
-    launchMocks.hasPersistedParent.mockResolvedValue(false);
-    launchMocks.releaseOwnedExecutionLeaseAfterFailure.mockImplementation(
-      async (_executionId: ExecutionId, error: unknown) => error,
-    );
+    vi.resetAllMocks();
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await cleanupTempDirs(tempDirs);
   });
 
@@ -314,9 +310,14 @@ describe('completedRunArchive facade', () => {
 
   it('reconstructs both turns when the production resume launch reopens the canonical writer', async () => {
     const executionId = '0aa1110aa111' as ExecutionId;
-    const streamId = 'orchestrator@deepseekproT#0aa1110aa111' as StreamTabId;
+    const streamId = 'orchestrator@legacyModel#0aa1110aa111' as StreamTabId;
+    const config = runConfig('orchestrator');
+    expect(
+      getStreamTabId(config.agent, config.model, { executionId }),
+    ).not.toBe(streamId);
+
     const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(streamId, config, executionId);
     await snapshots.flush();
 
     const logs = await StreamLogStore.open();
@@ -334,6 +335,12 @@ describe('completedRunArchive facade', () => {
     expect(logs.get(streamId)).toBeUndefined();
 
     const launchFailure = new Error('stop after resumed writer acquisition');
+    launchMocks.acquireResumedExecutionLease.mockResolvedValue('existing');
+    launchMocks.clearTerminalExecutionState.mockResolvedValue(undefined);
+    launchMocks.hasPersistedParent.mockResolvedValue(false);
+    launchMocks.releaseOwnedExecutionLeaseAfterFailure.mockImplementation(
+      async (_executionId: ExecutionId, error: unknown) => error,
+    );
     launchMocks.resolveAgent.mockReturnValue({
       definitionPath: '/agents/orchestrator.yaml',
     });
@@ -350,7 +357,6 @@ describe('completedRunArchive facade', () => {
     });
     launchMocks.buildVars.mockRejectedValueOnce(launchFailure);
 
-    const config = runConfig('orchestrator');
     const persistedResumeState = createToolUseResumeData({
       executionId,
       streamId,
@@ -384,26 +390,40 @@ describe('completedRunArchive facade', () => {
         return writer;
       });
 
+    const resolveResumeState = vi.fn(async (requestedStreamId: StreamTabId) => {
+      const runState = snapshots.getRunConfig(requestedStreamId);
+      const resolvedExecutionId = snapshots.getExecutionId(requestedStreamId);
+      return runState && resolvedExecutionId
+        ? { runState, executionId: resolvedExecutionId }
+        : undefined;
+    });
+    const reportFailure = vi.fn();
     try {
-      const resume = await retrieveSessionResumeData(
-        streamId,
-        executionId,
-        config,
-      );
-      expect(resume?.type).toBe('toolUse');
-      if (resume?.type !== 'toolUse') {
-        throw new Error('Expected persisted tool-use resume data');
-      }
-      expect(resume.streamId).toBe(streamId);
       await expect(
-        resumeToolUseFromResumeData(resume, { session }),
-      ).rejects.toBe(launchFailure);
+        resolveAndResumeStream(streamId, {
+          interactions: session.interactions,
+          streamStatus: session.status,
+          resolveResumeState,
+          resumeToolUse: async (resume) => {
+            await resumeToolUseFromResumeData(resume, { session });
+            return true;
+          },
+          executeWorkflow: vi.fn(async () => undefined),
+          reportFailure,
+        }),
+      ).resolves.toBe(false);
     } finally {
       session.dispose();
     }
     await logs.flush();
 
+    expect(resolveResumeState).toHaveBeenCalledWith(streamId);
+    expect(reportFailure).toHaveBeenCalledWith(streamId, launchFailure);
     expect(resumedWriter).toHaveBeenCalledWith(streamId, executionId);
+    expect(
+      launchMocks.releaseOwnedExecutionLeaseAfterFailure,
+    ).toHaveBeenCalledWith(executionId, launchFailure);
+    resumedWriter.mockRestore();
 
     const archived = await readCompletedRunConversation(executionId);
     expect(archived).toEqual({

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -84,10 +84,7 @@ import {
   formatPaginationHint,
   ViewRangeSchema,
 } from './formatting';
-import {
-  applyViewRange,
-  formatConversation,
-} from './executions/conversationFormat';
+import { formatConversation } from './executions/conversationFormat';
 import { listRunDirectoryFiles } from './executions/runDirectoryFiles';
 import { serializeFilteredConfig } from './executions/configFieldFilter';
 import {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -292,7 +292,7 @@ const ExecutionsToolInputSchema = z.strictObject({
 
   /** Optional line range [start, end] for large outputs (action="view" only). */
   view_range: ViewRangeSchema.nullish().describe(
-    'Line range [start, end] for paginating large outputs (action="view" only).',
+    'Line range [start, end] for paginating file and background-command output (action="view" only). Conversation pagination uses offset and limit.',
   ),
 
   /** Execution IDs to wait on (action="wait" with /executions only). */
@@ -325,23 +325,23 @@ const ExecutionsToolInputSchema = z.strictObject({
       `Max seconds to wait for a status change (action="wait" only). Default: ${EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS}; finite values are clamped to the ${EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS}-${EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS} range.`,
     ),
 
-  /** Zero-based offset for paginating the /executions listing (action="view" only). */
+  /** Zero-based offset for list or conversation pagination (action="view" only). */
   offset: z
     .int()
     .min(0)
     .nullish()
     .describe(
-      'Zero-based offset into the executions list. Use with limit for pagination on /executions. Default: 0.',
+      'Zero-based offset into the executions list or conversation messages. Use with limit on /executions or /executions/{id}/conversation. Default: 0.',
     ),
 
-  /** Maximum number of entries to return from the /executions listing (action="view" only). */
+  /** Maximum list entries or conversation messages to return (action="view" only). */
   limit: z
     .int()
     .min(1)
     .max(200)
     .nullish()
     .describe(
-      'Max entries to return from /executions listing. Default: 100, max: 200.',
+      'Max entries or conversation messages to return. Use on /executions or /executions/{id}/conversation. Default: 100, max: 200.',
     ),
 });
 
@@ -356,8 +356,8 @@ Paths:
 ${EXECUTION_PATH_LIST}
 
 Use "current" as {id} to access the active execution.
-Use offset/limit to paginate the /executions listing (default: offset 0, limit 100).
-Use view_range: [start, end] to paginate conversation, file, and background-command output content.
+Use offset/limit to paginate the /executions listing or conversation messages (default: offset 0, limit 100).
+Use view_range: [start, end] to paginate file and background-command output content.
 Use action: "wait" on /executions or /executions/{id} to wait for a status change instead of polling.
 Use action: "wait" with ids: ["id1", "id2", ...] on /executions to wait for any of the listed executions to change.
 Use action: "kill" on /executions/{id} to terminate a running execution.
@@ -412,8 +412,18 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
     switch (resource) {
       case 'config':
         return this.showConfig(executionId);
-      case 'conversation':
-        return this.showConversation(executionId, viewRange);
+      case 'conversation': {
+        if (viewRange) {
+          throw new ToolError(
+            'Conversation pagination is message-based. Use offset and limit; view_range applies only to file and background-command output.',
+          );
+        }
+        return this.showConversation(
+          executionId,
+          input.offset ?? 0,
+          input.limit ?? 100,
+        );
+      }
       case 'todos':
         return this.showTodos(executionId);
       case 'report':
@@ -845,10 +855,12 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
 
   private async showConversation(
     executionId: ExecutionId,
-    viewRange?: number[],
+    offset: number,
+    limit: number,
   ): Promise<ToolResult> {
     const store = getExecutionStore(executionId);
-    const { conversation } = await readCompletedRunConversation(executionId);
+    const { conversation, source, streamId } =
+      await readCompletedRunConversation(executionId);
 
     if (!conversation) {
       // Match the top-level execution lookup: a flow-only record is found only
@@ -865,7 +877,19 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
       };
     }
 
-    const output = applyViewRange(formatConversation(conversation), viewRange);
+    const pageStart = Math.min(offset, conversation.length);
+    const page = conversation.slice(pageStart, pageStart + limit);
+    const pageEnd = pageStart + page.length;
+    const output = formatConversation(page, {
+      offset: pageStart,
+      totalMessages: conversation.length,
+      metadata: [
+        `Source: ${source}`,
+        `Stream: ${streamId ?? 'none'}`,
+        `Returned message interval: [${pageStart}, ${pageEnd})`,
+        `Next offset: ${pageEnd < conversation.length ? pageEnd : 'none'}`,
+      ],
+    });
 
     return { status: 'executed', output };
   }

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -870,7 +870,15 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
       }
       return {
         status: 'executed',
-        output: '(No conversation history available)',
+        output: formatConversation([], {
+          totalMessages: 0,
+          metadata: [
+            'Source: none',
+            'Stream: none',
+            'Returned message interval: [0, 0)',
+            'Next offset: none',
+          ],
+        }),
       };
     }
 

--- a/src/tools/executions/conversationFormat.ts
+++ b/src/tools/executions/conversationFormat.ts
@@ -10,8 +10,6 @@ import {
   formatConversationMessage,
   type ConversationFormatOptions,
 } from '@agent/storage/conversationFormat';
-import { sliceLineRange } from '@tools/formatting';
-
 const CONVERSATION_FORMAT_OPTIONS: ConversationFormatOptions = {
   textLimit: 500,
   toolBlockLimit: 100,
@@ -47,11 +45,4 @@ export function formatConversation(
     '',
     messages.join('\n\n'),
   ].join('\n');
-}
-
-/** Slice multi-line output to a 1-based inclusive [start, end] range. */
-export function applyViewRange(output: string, viewRange?: number[]): string {
-  if (!viewRange || viewRange.length < 2) return output;
-  const [start, end] = viewRange;
-  return sliceLineRange(output.split('\n'), start, end).join('\n');
 }

--- a/src/tools/executions/conversationFormat.ts
+++ b/src/tools/executions/conversationFormat.ts
@@ -17,17 +17,36 @@ const CONVERSATION_FORMAT_OPTIONS: ConversationFormatOptions = {
   toolBlockLimit: 100,
 };
 
+export interface ConversationPageFormatOptions {
+  /** Zero-based index of the first message in this page. */
+  readonly offset?: number;
+  /** Total messages in the unsliced archive. */
+  readonly totalMessages?: number;
+  /** Archive-selection facts shown before the message blocks. */
+  readonly metadata?: readonly string[];
+}
+
 /** Render a stored conversation as numbered <message> blocks. */
-export function formatConversation(conversation: readonly unknown[]): string {
+export function formatConversation(
+  conversation: readonly unknown[],
+  options: ConversationPageFormatOptions = {},
+): string {
+  const offset = options.offset ?? 0;
+  const totalMessages = options.totalMessages ?? conversation.length;
   const messages = conversation.map((msg, i) => {
     const { role, content } = formatConversationMessage(
       msg,
       CONVERSATION_FORMAT_OPTIONS,
     );
-    return `<message index="${i + 1}" role="${role}">\n${content}\n</message>`;
+    return `<message index="${offset + i + 1}" role="${role}">\n${content}\n</message>`;
   });
 
-  return `Conversation (${conversation.length} messages):\n\n${messages.join('\n\n')}`;
+  return [
+    `Conversation (${totalMessages} messages):`,
+    ...(options.metadata ?? []),
+    '',
+    messages.join('\n\n'),
+  ].join('\n');
 }
 
 /** Slice multi-line output to a 1-based inclusive [start, end] range. */


### PR DESCRIPTION
## Summary

Resolve the confirmed pagination ambiguity in #9533 and establish the requested disk-backed resumed-turn regression.

- paginate `/executions/{id}/conversation` by message `offset` and `limit`, rather than slicing rendered output lines
- report the total message count, returned zero-based interval, next offset, selected archive source, and selected stream
- retain one-based global message indices inside the rendered message blocks across pages
- reserve `view_range` for file and background-command line output and return a clear error when it is used for a conversation
- verify on disk that turn 1 survives writer closure and eviction, a resumed turn 2 appends after reloading the same stream, and both turns are reconstructed by the archive reader and endpoint

The current same-stream resumed path passes the new regression. Historical archives split across multiple non-empty execution-associated sidecars remain a separate unresolved part of #9533; this change does not merge sidecars speculatively.

## Verification

- focused archive, conversation-format, output, and resumability suites: 41 tests passed
- `npm run typecheck`
- `npm run lint`
- Prettier check on changed files
- `git diff --check`

Refs #9533

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to a documented executions API surface affects agents and integrations that still pass `view_range` for conversations; behavior is well-tested but callers must migrate.
> 
> **Overview**
> **Breaking:** Callers of `/executions/{id}/conversation` must use **`offset` and `limit`** instead of **`view_range`**. Using `view_range` on that path now returns a **`ToolError`** that directs agents to message-based pagination; **`view_range` stays for file and background-command output only**.
> 
> The **executions tool** slices the archived conversation by message index, then formats the page with **total message count**, **source**, **stream id**, **returned interval `[start, end)`**, and **next offset**. Empty conversations get the same header shape instead of a bare “no history” string. **`formatConversation`** accepts pagination options so **`<message index>`** stays **one-based across pages**; line-range slicing was removed from the conversation formatter.
> 
> **Progress view** tool-use UI shows **Offset** and **Limit** when those inputs are numbers. **CHANGELOG** documents the breaking change. **Tests** cover formatter display, full vs paged output, `view_range` rejection, empty runs, and a **disk-backed resume** scenario where two turns survive writer close/eviction and appear via the archive reader and executions endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91aaa2b8f3642b6754109d6dd6e155165638f6d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->