### PR TITLE
fix(cli): retain credential retry diagnostics

### DIFF
--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -202,14 +202,19 @@ export function immediateDecisionForApproval(
   payload: CliDecisionApprovalPayloads[CliDecisionApprovalEvent],
   context: CliContext,
 ): ApprovalDecision | undefined {
-  if (event === 'showRetryRequest' && context.approvalPolicy === 'yolo') {
-    const credentialRetry = isCredentialRetryRequest(event, payload);
-    if (credentialRetry) markApprovalDenied(context);
+  if (isCredentialRetryRequest(event, payload)) {
+    if (approvalPromptAllowed(context)) return undefined;
+    markApprovalDenied(context);
     return {
       accepted: false,
-      userMessage: credentialRetry
-        ? 'Retry skipped: credential exhausted or unauthorized.'
-        : 'Retry skipped: explicit interactive approval is required after automatic attempts are exhausted.',
+      userMessage: 'Retry skipped: credential exhausted or unauthorized.',
+    };
+  }
+  if (event === 'showRetryRequest' && context.approvalPolicy === 'yolo') {
+    return {
+      accepted: false,
+      userMessage:
+        'Retry skipped: explicit interactive approval is required after automatic attempts are exhausted.',
     };
   }
   return immediateDecision(context);

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -316,6 +316,31 @@ describe('requestRetry classification (#7331)', () => {
     );
   });
 
+  it.each([
+    { approvalPolicy: 'never' as const, mode: 'interactive' as const },
+    { approvalPolicy: 'ask' as const, mode: 'headless' as const },
+  ])(
+    'preserves the credential denial reason in $approvalPolicy/$mode mode',
+    async ({ approvalPolicy, mode }) => {
+      const ctx = context({ approvalPolicy, mode });
+      const result = await createHeadlessCliHostInteractions(
+        ctx,
+      ).requestRetry?.({
+        ...retryRequest,
+        errorDetails: credentialExhaustedRetry.errorDetails,
+      });
+
+      expect(result).toEqual({
+        action: 'deny',
+        reason: 'Retry skipped: credential exhausted or unauthorized.',
+      });
+      expect(hasCliApprovalDenied(ctx)).toBe(true);
+      expect(runOutcomeExitCode(RUN_OUTCOME.FAILED, ctx)).toBe(
+        CliExitCode.ApprovalDenied,
+      );
+    },
+  );
+
   it('denies a yolo retry without changing provider-failure exit classification', async () => {
     const ctx = context({ approvalPolicy: 'yolo' });
     const result =


### PR DESCRIPTION
## Summary

Follow up on #9557 after it merged while its final review fix was being pushed.

- classify credential exhaustion and 401/403 before the yolo-only transient retry branch
- preserve the interactive `ask` retry prompt
- restore `Retry skipped: credential exhausted or unauthorized.` under `never` and headless `ask`
- retain the approval-denied marker and exit classification for credential/auth failures
- keep transient yolo batch exhaustion unmarked as `AgentError`

## Verification

- focused CLI and RetryState suites: 128 tests passed
- `npm run typecheck`
- `npm run lint`
- Prettier check on changed files
- `git diff --check`

Follow-up to #9557 and #9532.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, policy-only change in CLI approval routing with focused regression tests; no auth or data-path logic beyond message and marker ordering.
> 
> **Overview**
> **Reorders CLI retry auto-decisions** so credential exhaustion and 401/403 auth failures are handled in `immediateDecisionForApproval` *before* the yolo “batch exhausted” path, instead of folding them into that branch.
> 
> When prompts aren’t allowed (`never`, headless `ask`, and yolo for these failures), denials again use **`Retry skipped: credential exhausted or unauthorized.`**, call `markApprovalDenied`, and keep **ApprovalDenied** exit classification. Interactive **`ask`** still returns no immediate decision so the retry UI can prompt. Ordinary transient yolo retries keep the separate message about needing explicit interactive approval and stay unmarked as approval-denied.
> 
> Adds headless adapter tests for **`never`** and headless **`ask`** to lock in the credential-specific deny reason and exit code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c69ca2f283a7ea93ea8a0921265d698c5db1aeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->