### PR TITLE
fix(storage): stop repeating legacy history migration

### DIFF
--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -5,19 +5,14 @@
  * and reading per-execution KV data (meta.json, config.json). This replaces
  * the monolithic `index.json` maintained by AgentHistoryManager.
  *
- * On first access, migrates legacy data (index.json and workspace state)
- * into per-execution KV stores, then deletes the legacy sources.
+ * A storage-boundary migration handles legacy history before the scan.
  */
 
 import pMap from 'p-map';
 
-import {
-  type AgentConfig,
-  AgentConfigSchema,
-} from '@agent/core/definition/AgentConfig';
+import { type AgentConfig } from '@agent/core/definition/AgentConfig';
 import { isFileNotFoundError } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { platform, type Platform } from '@platform/platform';
 import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import type { ExecutionId } from '@shared/schemas';
 import { StorageFS, WorkspaceFS } from '@utils/files';
@@ -30,10 +25,9 @@ import {
   inspectExecutionLease,
   runWithInactiveExecutionLease,
 } from './executionLease';
+import { migrateLegacyExecutionHistoryOnce } from './legacyExecutionHistoryMigration';
 
 const CHANNEL = 'ExecutionListing';
-const INDEX_PATH = `${RUNS_STORAGE_DIR}/index.json`;
-const LEGACY_HISTORY_KEY = 'texra.agentHistory';
 const EXECUTION_ID_PATTERN = /^[0-9a-f][-0-9a-f]*$/i;
 const EXECUTION_STORAGE_CONCURRENCY = 32;
 
@@ -89,49 +83,6 @@ export function isUserVisibleExecution(
   return entry.kind === 'agent' && entry.parentExecutionId === undefined;
 }
 
-// ============================================================================
-// Legacy migration state
-// ============================================================================
-
-/**
- * In-flight or completed legacy migration per workspace path. The promise is
- * the memo, so concurrent listings share one migration instead of racing two
- * backfills over the same legacy entries. An incomplete or failed migration is
- * forgotten so the next listing retries it.
- *
- * The memo describes the storage the current platform exposes, so installing a
- * different platform drops it — a host that re-initializes its platform gets a
- * fresh migration decision rather than one made against the previous storage.
- */
-const migrationsByWorkspace = new Map<string | undefined, Promise<boolean>>();
-let migrationPlatform: Platform | undefined;
-
-function migrateOncePerWorkspace(
-  workspacePath: string | undefined,
-): Promise<boolean> {
-  const currentPlatform = platform();
-  if (currentPlatform !== migrationPlatform) {
-    migrationPlatform = currentPlatform;
-    migrationsByWorkspace.clear();
-  }
-
-  const inFlight = migrationsByWorkspace.get(workspacePath);
-  if (inFlight) return inFlight;
-
-  const migration = migrateIfNeeded().then(
-    (complete) => {
-      if (!complete) migrationsByWorkspace.delete(workspacePath);
-      return complete;
-    },
-    (error: unknown) => {
-      migrationsByWorkspace.delete(workspacePath);
-      throw error;
-    },
-  );
-  migrationsByWorkspace.set(workspacePath, migration);
-  return migration;
-}
-
 /**
  * Read a storage directory, returning an empty array if it doesn't exist.
  * Other I/O errors propagate.
@@ -168,7 +119,7 @@ function listExecutionDirs(entries: [string, number][]): ExecutionId[] {
  * cannot observe another host's writes or metadata updates reliably.
  */
 export async function listExecutions(): Promise<ExecutionListingEntry[]> {
-  await migrateOncePerWorkspace(WorkspaceFS.getPath());
+  await migrateLegacyExecutionHistoryOnce(WorkspaceFS.getPath());
 
   const entries = await readDirOrEmpty(RUNS_STORAGE_DIR);
   const executionDirs = listExecutionDirs(entries);
@@ -330,150 +281,4 @@ export async function deleteAllExecutions(): Promise<DeleteAllExecutionsResult> 
         : [],
     ),
   };
-}
-
-// ============================================================================
-// Legacy migration (runs once on first listExecutions() call)
-// ============================================================================
-
-async function migrateIfNeeded(): Promise<boolean> {
-  const indexMigrated = await migrateIndexJson();
-  const workspaceStateMigrated = await migrateWorkspaceState();
-  return indexMigrated && workspaceStateMigrated;
-}
-
-/** Migrate entries from executions/index.json into per-execution KV. */
-async function migrateIndexJson(): Promise<boolean> {
-  let raw: unknown;
-  try {
-    raw = await StorageFS.readJson<unknown>(INDEX_PATH);
-  } catch (error) {
-    // Nothing to migrate only when the legacy file is genuinely absent. Any
-    // other read failure (unreadable, malformed JSON) leaves history behind,
-    // so report it and let the next listing retry.
-    if (isFileNotFoundError(error)) return true;
-    logger.warn(
-      CHANNEL,
-      `Failed to read legacy ${INDEX_PATH}: ${toErrorMessage(error)}`,
-    );
-    return false;
-  }
-
-  if (!Array.isArray(raw)) {
-    logger.warn(
-      CHANNEL,
-      `Legacy ${INDEX_PATH} is not an array; leaving it untouched.`,
-    );
-    return true;
-  }
-  if (raw.length === 0) return true;
-
-  if (!(await backfillEntries(raw))) return false;
-
-  try {
-    await StorageFS.delete(INDEX_PATH);
-    return true;
-  } catch (error) {
-    logger.warn(
-      CHANNEL,
-      `Failed to delete legacy ${INDEX_PATH}: ${toErrorMessage(error)}`,
-    );
-    return false;
-  }
-}
-
-/** Migrate entries from workspace state into per-execution KV. */
-async function migrateWorkspaceState(): Promise<boolean> {
-  const workspace = platform().workspace;
-  const paths = [
-    workspace.getWorkspacePath(),
-    ...(workspace.getLegacyWorkspacePaths?.() ?? []),
-  ];
-  const storageKeys = [
-    ...new Set(paths.map((path) => getWorkspaceStorageKey(path))),
-  ];
-
-  let migratedAll = true;
-  for (const storageKey of storageKeys) {
-    const legacy = platform().workspaceState.get<unknown[]>(storageKey, []);
-    if (!Array.isArray(legacy) || legacy.length === 0) continue;
-
-    if (!(await backfillEntries(legacy))) {
-      migratedAll = false;
-      continue;
-    }
-
-    try {
-      await platform().workspaceState.update(storageKey, []);
-    } catch (error) {
-      migratedAll = false;
-      logger.warn(
-        CHANNEL,
-        `Failed to clear workspace state key: ${toErrorMessage(error)}`,
-      );
-    }
-  }
-  return migratedAll;
-}
-
-function getWorkspaceStorageKey(workspacePath: string | undefined): string {
-  return workspacePath
-    ? `${LEGACY_HISTORY_KEY}.${workspacePath}`
-    : LEGACY_HISTORY_KEY;
-}
-
-/**
- * Backfill per-execution KV from legacy history entries.
- * Only writes if meta.json doesn't already exist (no overwriting).
- */
-async function backfillEntries(entries: unknown[]): Promise<boolean> {
-  const migrated = await pMap(
-    entries,
-    async (rawEntry) => {
-      if (!rawEntry || typeof rawEntry !== 'object') return true;
-
-      const candidate = rawEntry as {
-        id?: ExecutionId;
-        timestamp?: string;
-        agentConfig?: AgentConfig;
-        config?: AgentConfig; // Legacy field name
-        parentExecutionId?: ExecutionId;
-      };
-
-      const rawConfig = candidate.agentConfig ?? candidate.config;
-      if (!candidate.id || !candidate.timestamp || !rawConfig) return true;
-      const executionId = candidate.id;
-      const timestamp = candidate.timestamp;
-
-      let normalizedConfig: AgentConfig;
-      try {
-        normalizedConfig = AgentConfigSchema.parse(rawConfig);
-      } catch {
-        logger.warn(CHANNEL, `Skipping malformed legacy entry ${candidate.id}`);
-        return true;
-      }
-
-      const result = await runWithInactiveExecutionLease(
-        executionId,
-        async () => {
-          const store = getExecutionStore(executionId);
-          // Don't overwrite existing KV data.
-          if (await store.exists('meta')) return;
-          await Promise.all([
-            store.writeMeta({
-              timestamp,
-              parentExecutionId: candidate.parentExecutionId,
-            }),
-            store.writeConfig(normalizedConfig),
-          ]);
-        },
-      );
-      return result.status === 'performed';
-    },
-    {
-      concurrency: EXECUTION_STORAGE_CONCURRENCY,
-      stopOnError: false,
-    },
-  );
-  return migrated.every(Boolean);
 }

--- a/src/agent/storage/legacyExecutionHistoryMigration.ts
+++ b/src/agent/storage/legacyExecutionHistoryMigration.ts
@@ -1,0 +1,220 @@
+/**
+ * One-time migration boundary for execution history written before the
+ * per-execution KV layout.
+ *
+ * A durable marker prevents every new host process from probing the retired
+ * index and workspace-state layouts. The marker is committed only after both
+ * sources have been dealt with successfully, so incomplete work remains
+ * retryable.
+ */
+
+import pMap from 'p-map';
+
+import {
+  type AgentConfig,
+  AgentConfigSchema,
+} from '@agent/core/definition/AgentConfig';
+import { isFileNotFoundError } from '@common/errors';
+import * as logger from '@logger/logUtils';
+import { platform, type Platform } from '@platform/platform';
+import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
+import type { ExecutionId } from '@shared/schemas';
+import { StorageFS } from '@utils/files';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+import { getExecutionStore } from './ExecutionKVStore';
+import { runWithInactiveExecutionLease } from './executionLease';
+
+const CHANNEL = 'LegacyExecutionHistoryMigration';
+const INDEX_PATH = `${RUNS_STORAGE_DIR}/index.json`;
+const MIGRATION_MARKER_PATH = `${RUNS_STORAGE_DIR}/.legacy-history-migration-v1`;
+const LEGACY_HISTORY_KEY = 'texra.agentHistory';
+const LEGACY_BACKFILL_CONCURRENCY = 32;
+
+/**
+ * In-flight or completed migration per workspace path. The promise is the
+ * process-local concurrency guard; the marker is the durable cross-process
+ * completion record. Incomplete or failed work is forgotten so a later
+ * listing retries it.
+ */
+const migrationsByWorkspace = new Map<string | undefined, Promise<void>>();
+let migrationPlatform: Platform | undefined;
+
+export async function migrateLegacyExecutionHistoryOnce(
+  workspacePath: string | undefined,
+): Promise<void> {
+  const currentPlatform = platform();
+  if (currentPlatform !== migrationPlatform) {
+    migrationPlatform = currentPlatform;
+    migrationsByWorkspace.clear();
+  }
+
+  const inFlight = migrationsByWorkspace.get(workspacePath);
+  if (inFlight) return inFlight;
+
+  const migration = migrateIfNeeded().then(
+    (complete) => {
+      if (!complete) migrationsByWorkspace.delete(workspacePath);
+    },
+    (error: unknown) => {
+      migrationsByWorkspace.delete(workspacePath);
+      throw error;
+    },
+  );
+  migrationsByWorkspace.set(workspacePath, migration);
+  await migration;
+}
+
+async function migrateIfNeeded(): Promise<boolean> {
+  if (await StorageFS.exists(MIGRATION_MARKER_PATH)) return true;
+
+  const indexMigrated = await migrateIndexJson();
+  const workspaceStateMigrated = await migrateWorkspaceState();
+  if (!indexMigrated || !workspaceStateMigrated) return false;
+
+  try {
+    await StorageFS.ensureDir(RUNS_STORAGE_DIR);
+    await StorageFS.writeAtomic(MIGRATION_MARKER_PATH, 'completed\n');
+    return true;
+  } catch (error) {
+    logger.warn(
+      CHANNEL,
+      `Failed to record legacy history migration: ${toErrorMessage(error)}`,
+    );
+    return false;
+  }
+}
+
+/** Migrate entries from executions/index.json into per-execution KV. */
+async function migrateIndexJson(): Promise<boolean> {
+  let raw: unknown;
+  try {
+    raw = await StorageFS.readJson<unknown>(INDEX_PATH);
+  } catch (error) {
+    // Nothing to migrate only when the legacy file is genuinely absent. Any
+    // other read failure leaves history behind, so report it and retry later.
+    if (isFileNotFoundError(error)) return true;
+    logger.warn(
+      CHANNEL,
+      `Failed to read legacy ${INDEX_PATH}: ${toErrorMessage(error)}`,
+    );
+    return false;
+  }
+
+  if (!Array.isArray(raw)) {
+    logger.warn(
+      CHANNEL,
+      `Legacy ${INDEX_PATH} is not an array; leaving it untouched.`,
+    );
+    return false;
+  }
+  if (raw.length === 0) return true;
+
+  if (!(await backfillEntries(raw))) return false;
+
+  try {
+    await StorageFS.delete(INDEX_PATH);
+    return true;
+  } catch (error) {
+    logger.warn(
+      CHANNEL,
+      `Failed to delete legacy ${INDEX_PATH}: ${toErrorMessage(error)}`,
+    );
+    return false;
+  }
+}
+
+/** Migrate entries from workspace state into per-execution KV. */
+async function migrateWorkspaceState(): Promise<boolean> {
+  const { workspace, workspaceState } = platform();
+  const paths = [
+    workspace.getWorkspacePath(),
+    ...(workspace.getLegacyWorkspacePaths?.() ?? []),
+  ];
+  const storageKeys = [
+    ...new Set(paths.map((path) => getWorkspaceStorageKey(path))),
+  ];
+
+  let migratedAll = true;
+  for (const storageKey of storageKeys) {
+    const legacy = workspaceState.get<unknown[]>(storageKey, []);
+    if (!Array.isArray(legacy) || legacy.length === 0) continue;
+
+    if (!(await backfillEntries(legacy))) {
+      migratedAll = false;
+      continue;
+    }
+
+    try {
+      await workspaceState.update(storageKey, []);
+    } catch (error) {
+      migratedAll = false;
+      logger.warn(
+        CHANNEL,
+        `Failed to clear workspace state key: ${toErrorMessage(error)}`,
+      );
+    }
+  }
+  return migratedAll;
+}
+
+function getWorkspaceStorageKey(workspacePath: string | undefined): string {
+  return workspacePath
+    ? `${LEGACY_HISTORY_KEY}.${workspacePath}`
+    : LEGACY_HISTORY_KEY;
+}
+
+/**
+ * Backfill per-execution KV from legacy history entries.
+ * Only writes if meta.json does not already exist.
+ */
+async function backfillEntries(entries: unknown[]): Promise<boolean> {
+  const migrated = await pMap(
+    entries,
+    async (rawEntry) => {
+      if (!rawEntry || typeof rawEntry !== 'object') return true;
+
+      const candidate = rawEntry as {
+        id?: ExecutionId;
+        timestamp?: string;
+        agentConfig?: AgentConfig;
+        config?: AgentConfig;
+        parentExecutionId?: ExecutionId;
+      };
+
+      const rawConfig = candidate.agentConfig ?? candidate.config;
+      if (!candidate.id || !candidate.timestamp || !rawConfig) return true;
+      const executionId = candidate.id;
+      const timestamp = candidate.timestamp;
+
+      let normalizedConfig: AgentConfig;
+      try {
+        normalizedConfig = AgentConfigSchema.parse(rawConfig);
+      } catch {
+        logger.warn(CHANNEL, `Skipping malformed legacy entry ${candidate.id}`);
+        return true;
+      }
+
+      const result = await runWithInactiveExecutionLease(
+        executionId,
+        async () => {
+          const store = getExecutionStore(executionId);
+          if (await store.exists('meta')) return;
+          await Promise.all([
+            store.writeMeta({
+              timestamp,
+              parentExecutionId: candidate.parentExecutionId,
+            }),
+            store.writeConfig(normalizedConfig),
+          ]);
+        },
+      );
+      return result.status === 'performed';
+    },
+    {
+      concurrency: LEGACY_BACKFILL_CONCURRENCY,
+      stopOnError: false,
+    },
+  );
+  return migrated.every(Boolean);
+}

--- a/src/agent/storage/legacyExecutionHistoryMigration.ts
+++ b/src/agent/storage/legacyExecutionHistoryMigration.ts
@@ -104,7 +104,7 @@ async function migrateIndexJson(): Promise<boolean> {
   if (!Array.isArray(raw)) {
     logger.warn(
       CHANNEL,
-      `Legacy ${INDEX_PATH} is not an array; leaving it untouched.`,
+      `Legacy ${INDEX_PATH} is not an array; leaving it untouched and retrying later.`,
     );
     return false;
   }

--- a/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
@@ -176,6 +176,46 @@ describe('execution listing normalization', () => {
     );
   });
 
+  it('uses the durable marker after a host restart', async () => {
+    const firstPlatform = platform();
+    const workspaceStateGet = vi.spyOn(firstPlatform.workspaceState, 'get');
+
+    expect(await listExecutions()).toEqual([]);
+    expect(workspaceStateGet).toHaveBeenCalled();
+    workspaceStateGet.mockClear();
+
+    // Reinitialize the host while preserving its durable filesystem and state.
+    // The process-local memo is discarded with the Platform instance, so only
+    // the on-disk marker can prevent another legacy workspace-state probe.
+    await installPlatform(
+      {},
+      {
+        fs: firstPlatform.fs,
+        storage: firstPlatform.storage,
+        workspace: firstPlatform.workspace,
+        workspaceState: firstPlatform.workspaceState,
+      },
+    );
+    clearStoreCache();
+
+    expect(await listExecutions()).toEqual([]);
+    expect(workspaceStateGet).not.toHaveBeenCalled();
+  });
+
+  it('retries migration after the durable marker cannot be written', async () => {
+    const workspaceStateGet = vi.spyOn(platform().workspaceState, 'get');
+    const writeAtomic = vi
+      .spyOn(StorageFS, 'writeAtomic')
+      .mockRejectedValueOnce(new Error('marker unavailable'));
+
+    expect(await listExecutions()).toEqual([]);
+    expect(workspaceStateGet).toHaveBeenCalledTimes(1);
+
+    expect(await listExecutions()).toEqual([]);
+    expect(workspaceStateGet).toHaveBeenCalledTimes(2);
+    expect(writeAtomic).toHaveBeenCalledTimes(2);
+  });
+
   it('retries the legacy index migration after an unreadable index.json', async () => {
     const indexPath = `${RUNS_STORAGE_DIR}/index.json`;
     await StorageFS.ensureDir(RUNS_STORAGE_DIR);
@@ -189,6 +229,30 @@ describe('execution listing normalization', () => {
         {
           id,
           timestamp: '2026-07-15T13:03:00.000Z',
+          agentConfig: config('assistant'),
+        },
+      ]),
+    );
+
+    expect(await listExecutions()).toEqual([
+      expect.objectContaining({ id, kind: 'agent' }),
+    ]);
+    expect(await StorageFS.exists(indexPath)).toBe(false);
+  });
+
+  it('retries the legacy index migration after an invalid legacy shape', async () => {
+    const indexPath = `${RUNS_STORAGE_DIR}/index.json`;
+    await StorageFS.ensureDir(RUNS_STORAGE_DIR);
+    await StorageFS.write(indexPath, JSON.stringify({ entries: [] }));
+    expect(await listExecutions()).toEqual([]);
+
+    const id = 'abc781' as ExecutionId;
+    await StorageFS.write(
+      indexPath,
+      JSON.stringify([
+        {
+          id,
+          timestamp: '2026-07-15T13:04:00.000Z',
           agentConfig: config('assistant'),
         },
       ]),


### PR DESCRIPTION
## Summary

- record successful legacy execution-history migration with an atomic durable marker
- keep incomplete migrations retryable when source reads, leases, cleanup, or marker writes fail
- isolate retired-format migration from ordinary execution-directory listing
- treat malformed legacy index shapes as incomplete rather than permanently suppressing repair

## Design

The ancient migration remains supported. The marker is written only after both legacy sources have been handled successfully, so it changes repeated detection into a one-time storage-boundary operation without weakening recovery. A process-local promise still prevents concurrent callers from duplicating work.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run typecheck`
- `npm run lint`
- `npm test` (8,368 passed, 4 skipped)
- focused execution-listing suite (12 passed)

Fixes #9424

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches execution history migration and persistence boundaries shared across CLI/desktop/extension hosts; incorrect marker or retry logic could skip migration or repeat destructive cleanup, though changes are narrowly scoped with focused tests.
> 
> **Overview**
> Legacy execution-history migration moves out of `executionListing.ts` into **`legacyExecutionHistoryMigration.ts`**, so directory listing stays separate from one-time backfill from `index.json` and workspace state.
> 
> After both sources succeed, the migration writes a **durable marker** (`executions/.legacy-history-migration-v1`) so new host processes skip legacy probes; a process-local promise still dedupes concurrent work in one process. Failed or partial runs stay **retryable** (no marker until completion), and a **non-array** legacy `index.json` is treated as incomplete migration rather than permanently ignored.
> 
> Tests cover marker behavior across simulated host restart, marker write failure, and invalid legacy index shape retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa5640cbce37038f832c8c7c4ec20ea6f9a5293e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->