### PR TITLE
fix(storage): retry malformed legacy workspace state

### DIFF
--- a/src/agent/storage/legacyExecutionHistoryMigration.ts
+++ b/src/agent/storage/legacyExecutionHistoryMigration.ts
@@ -138,7 +138,15 @@ async function migrateWorkspaceState(): Promise<boolean> {
   let migratedAll = true;
   for (const storageKey of storageKeys) {
     const legacy = workspaceState.get<unknown[]>(storageKey, []);
-    if (!Array.isArray(legacy) || legacy.length === 0) continue;
+    if (!Array.isArray(legacy)) {
+      migratedAll = false;
+      logger.warn(
+        CHANNEL,
+        `Legacy workspace state key ${storageKey} is not an array; leaving it untouched and retrying later.`,
+      );
+      continue;
+    }
+    if (legacy.length === 0) continue;
 
     if (!(await backfillEntries(legacy))) {
       migratedAll = false;

--- a/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
@@ -264,6 +264,36 @@ describe('execution listing normalization', () => {
     expect(await StorageFS.exists(indexPath)).toBe(false);
   });
 
+  it('retries workspace-state migration after an invalid legacy shape', async () => {
+    const id = 'abc782' as ExecutionId;
+    const legacyKey = 'texra.agentHistory./workspace';
+    await installPlatform({
+      workspacePath: '/workspace',
+      workspaceState: { [legacyKey]: { entries: [] } },
+    });
+    clearStoreCache();
+
+    expect(await listExecutions()).toEqual([]);
+    expect(
+      await StorageFS.exists(
+        `${RUNS_STORAGE_DIR}/.legacy-history-migration-v1`,
+      ),
+    ).toBe(false);
+
+    await platform().workspaceState.update(legacyKey, [
+      {
+        id,
+        timestamp: '2026-07-15T13:05:00.000Z',
+        agentConfig: config('assistant'),
+      },
+    ]);
+
+    expect(await listExecutions()).toEqual([
+      expect.objectContaining({ id, kind: 'agent' }),
+    ]);
+    expect(platform().workspaceState.get(legacyKey, [])).toEqual([]);
+  });
+
   it('uses the config as the canonical source for visible agent fields', async () => {
     const id = 'aaa111' as ExecutionId;
     const agentConfig = config('assistant');


### PR DESCRIPTION
## Summary

Treat a present, non-array legacy workspace-state history value as an incomplete migration. The migration now leaves the value untouched, emits a diagnostic warning, and retries on a later execution listing instead of writing the durable completion marker.

A regression repairs the malformed value between two listings and verifies that the repaired history is subsequently migrated and cleared.

Closes #9562.

## Issue acceptance gates

- A malformed legacy workspace-state value prevents the migration marker from being written.
- The malformed source remains untouched for later repair.
- A subsequent listing retries the migration and imports a repaired array value.

## Single source of truth

`legacyExecutionHistoryMigration.ts` remains the sole owner of legacy execution-history migration completion. Both legacy sources now use the same rule: a source that exists but cannot be interpreted does not permit the durable completion marker.

## Duplication and abstraction budget

No abstraction or duplicate migration path was added. The existing workspace-state boundary now distinguishes an empty array from a malformed present value.

## Net elements (R6)

- Files: 2 modified, 0 added, 0 deleted
- Exported symbols: 0 added, 0 deleted
- Classes/interfaces/enums: 0 added, 0 deleted
- Net lines: +38

## Consumer counts (R8)

n/a — no export or event path changed.

## Host impact

Extension: Repaired legacy workspace history remains recoverable after a malformed stored value is encountered.

Desktop: Same shared execution-listing behavior as the extension.

CLI: Same shared execution-listing behavior as the extension.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm test` — 8,383 passed, 4 skipped
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- `corepack pnpm exec vitest run src/test-kernel/agent/storage/ExecutionListing.vitest.ts` — 13 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in one-time migration logic with a regression test; no API or export changes.
> 
> **Overview**
> **Workspace-state legacy history** now follows the same rule as `index.json`: if a stored value exists but is **not an array**, migration treats it as incomplete—logs a warning, **does not clear** the key, and **does not** write `.legacy-history-migration-v1` until a later listing can migrate a repaired array.
> 
> A new **ExecutionListing** test seeds a malformed `{ entries: [] }` value, asserts no migration marker on the first list, repairs workspace state to a valid array, then asserts the execution appears and the legacy key is cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba5d13e716804c7691438bf1d48fd0e7ba495aa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->