### PR TITLE
fix(agent): grant one attempt per manual retry

### DIFF
--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -120,8 +120,9 @@ class Node<S = unknown, Svc = unknown> extends BaseNode<S, Svc> {
     throw error;
   }
   /**
-   * Hook called when all auto-retries are exhausted.
-   * Return true to restart the auto-retry loop, false to proceed to execFallback.
+   * Hook called when the automatic retry batch is exhausted or declined.
+   * Return true to grant one additional attempt, false to proceed to execFallback.
+   * A failed additional attempt calls this hook again.
    *
    * Default implementation returns false (no manual retry).
    * Override this for manual retry prompts (e.g., showing UI to user).
@@ -177,49 +178,72 @@ class Node<S = unknown, Svc = unknown> extends BaseNode<S, Svc> {
     }
     const effectiveMaxRetries = Math.max(1, this.maxRetries);
 
+    // Track the last exec error so we can forward it to execFallback when
+    // the abort signal fires during the inter-retry delay (p-retry would
+    // otherwise rethrow signal.reason, discarding the original failure).
+    let lastExecError: Error | undefined;
+    let attemptThrew = false;
+    const runAttempts = async (retries: number): Promise<unknown> => {
+      attemptThrew = false;
+      return await pRetry(
+        async () => {
+          // Throw AbortError at each attempt start so p-retry surfaces it
+          // immediately (before any delay) and skips onFailedAttempt.
+          if (this.signal?.aborted)
+            throw new AbortError('Operation cancelled by user');
+          try {
+            return await this.exec(prepRes);
+          } catch (error) {
+            attemptThrew = true;
+            throw error;
+          }
+        },
+        {
+          retries,
+          minTimeout: this.wait * 1000,
+          factor: 1, // linear (fixed) delay to preserve existing behaviour
+          randomize: false, // explicit: default is false; no jitter on fixed delays
+          signal: this.signal, // aborts an attempt or inter-retry delay early
+          shouldRetry: ({ error }) => {
+            lastExecError = error;
+            if (this.signal?.aborted) return false;
+            return this.shouldAutoRetry(error);
+          },
+        },
+      );
+    };
+
+    let retryError: Error;
+    try {
+      return await runAttempts(effectiveMaxRetries - 1);
+    } catch (e) {
+      // User cancellation surfaces here as p-retry's aborted-delay rejection
+      // (signal.reason) or as the unwrapped error from our pre-attempt check
+      // (p-retry rethrows an AbortError's originalError, not the AbortError).
+      // Forward the recorded exec failure when one exists.
+      if (this.signal?.aborted) {
+        return await this.execFallback(prepRes, lastExecError ?? (e as Error));
+      }
+      retryError = e as Error;
+    }
+
     for (;;) {
-      // Track the last exec error so we can forward it to execFallback when
-      // the abort signal fires during the inter-retry delay (p-retry would
-      // otherwise rethrow signal.reason, discarding the original failure).
-      let lastExecError: Error | undefined;
+      const shouldRetry = await this.retryPrompt(prepRes, retryError);
+      if (!shouldRetry || this.signal?.aborted) {
+        return await this.execFallback(prepRes, retryError);
+      }
+
       try {
-        return await pRetry(
-          () => {
-            // Throw AbortError at each attempt start so p-retry surfaces it
-            // immediately (before any delay) and skips onFailedAttempt.
-            if (this.signal?.aborted)
-              throw new AbortError('Operation cancelled by user');
-            return this.exec(prepRes);
-          },
-          {
-            retries: effectiveMaxRetries - 1,
-            minTimeout: this.wait * 1000,
-            factor: 1, // linear (fixed) delay to preserve existing behaviour
-            randomize: false, // explicit: default is false; no jitter on fixed delays
-            signal: this.signal, // aborts the inter-retry delay early
-            shouldRetry: ({ error }) => {
-              lastExecError = error;
-              if (this.signal?.aborted) return false;
-              return this.shouldAutoRetry(error);
-            },
-          },
-        );
+        return await runAttempts(0);
       } catch (e) {
-        // User cancellation surfaces here as p-retry's aborted-delay rejection
-        // (signal.reason) or as the unwrapped error from our pre-attempt check
-        // (p-retry rethrows an AbortError's originalError, not the AbortError).
-        // Forward the recorded exec failure when one exists.
+        const approvedError = e as Error;
         if (this.signal?.aborted) {
           return await this.execFallback(
             prepRes,
-            lastExecError ?? (e as Error),
+            attemptThrew ? approvedError : retryError,
           );
         }
-        // No abort: auto-retries are exhausted or shouldAutoRetry declined.
-        // Offer the manual retry prompt before falling back.
-        const shouldRetry = await this.retryPrompt(prepRes, e as Error);
-        if (shouldRetry) continue;
-        return await this.execFallback(prepRes, e as Error);
+        retryError = approvedError;
       }
     }
   }

--- a/src/test-kernel/agent/PocketFlowNode.vitest.ts
+++ b/src/test-kernel/agent/PocketFlowNode.vitest.ts
@@ -1,3 +1,4 @@
+import { AbortError } from 'p-retry';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BaseNode, Node } from '@agent/node';
@@ -50,25 +51,249 @@ describe('BaseNode.getNextNode', () => {
   });
 });
 
-class ApprovedRetryNode extends Node {
+type ScriptedOutcome =
+  Error | string | (() => Promise<string>) | { thrown: unknown };
+
+class ScriptedRetryNode extends Node {
   calls = 0;
+  prompts = 0;
+  fallbackError?: Error;
+  readonly events: string[] = [];
+  readonly promptErrors: Error[] = [];
+
+  constructor(
+    maxRetries: number,
+    private readonly outcomes: ScriptedOutcome[],
+    private readonly approvals: boolean[],
+    private readonly autoRetry = true,
+    private readonly onPrompt?: () => void,
+    private readonly onExec?: (call: number) => void,
+  ) {
+    super(maxRetries, 0);
+  }
 
   override async exec(): Promise<string> {
     this.calls += 1;
-    if (this.calls <= 101) throw new Error('temporary failure');
-    return 'completed';
+    this.events.push(`exec:${this.calls}`);
+    this.onExec?.(this.calls);
+    const outcome = this.outcomes[this.calls - 1];
+    if (outcome instanceof Error) throw outcome;
+    if (typeof outcome === 'function') return await outcome();
+    if (typeof outcome === 'object') throw outcome.thrown;
+    return outcome;
   }
 
-  override async retryPrompt(): Promise<boolean> {
-    return true;
+  override shouldAutoRetry(): boolean {
+    return this.autoRetry;
+  }
+
+  override async retryPrompt(
+    _prepRes: unknown,
+    error: Error,
+  ): Promise<boolean> {
+    this.prompts += 1;
+    this.promptErrors.push(error);
+    this.events.push(`prompt:${error.message}`);
+    this.onPrompt?.();
+    return this.approvals[this.prompts - 1] ?? false;
+  }
+
+  override async execFallback(
+    _prepRes: unknown,
+    error: Error,
+  ): Promise<string> {
+    this.fallbackError = error;
+    this.events.push(`fallback:${error.message}`);
+    return 'fallback';
   }
 }
 
 describe('Node manual retry', () => {
-  it('continues beyond the former 100-approval ceiling', async () => {
-    const node = new ApprovedRetryNode(1, 0);
+  it('grants one attempt after an exhausted automatic retry batch', async () => {
+    const node = new ScriptedRetryNode(
+      3,
+      [1, 2, 3, 4].map((attempt) => new Error(`failure ${attempt}`)),
+      [true, false],
+    );
+
+    await expect(node._exec(undefined)).resolves.toBe('fallback');
+    expect(node.calls).toBe(4);
+    expect(node.events).toEqual([
+      'exec:1',
+      'exec:2',
+      'exec:3',
+      'prompt:failure 3',
+      'exec:4',
+      'prompt:failure 4',
+      'fallback:failure 4',
+    ]);
+    expect(node.fallbackError?.message).toBe('failure 4');
+  });
+
+  it('grants one attempt for each repeated approval', async () => {
+    const node = new ScriptedRetryNode(
+      2,
+      [1, 2, 3, 4].map((attempt) => new Error(`failure ${attempt}`)),
+      [true, true, false],
+    );
+
+    await expect(node._exec(undefined)).resolves.toBe('fallback');
+    expect(node.calls).toBe(4);
+    expect(node.prompts).toBe(3);
+    expect(node.events).toEqual([
+      'exec:1',
+      'exec:2',
+      'prompt:failure 2',
+      'exec:3',
+      'prompt:failure 3',
+      'exec:4',
+      'prompt:failure 4',
+      'fallback:failure 4',
+    ]);
+  });
+
+  it('skips the remaining automatic batch when shouldAutoRetry is false', async () => {
+    const node = new ScriptedRetryNode(
+      3,
+      [new Error('not automatic'), 'completed'],
+      [true],
+      false,
+    );
+
+    await expect(node._exec(undefined)).resolves.toBe('completed');
+    expect(node.events).toEqual(['exec:1', 'prompt:not automatic', 'exec:2']);
+  });
+
+  it('returns success from the single approved attempt', async () => {
+    const node = new ScriptedRetryNode(
+      3,
+      [
+        new Error('failure 1'),
+        new Error('failure 2'),
+        new Error('failure 3'),
+        'completed',
+      ],
+      [true],
+    );
+
+    await expect(node._exec(undefined)).resolves.toBe('completed');
+    expect(node.calls).toBe(4);
+    expect(node.prompts).toBe(1);
+  });
+
+  it('does not execute or prompt again when cancelled while awaiting approval', async () => {
+    const controller = new AbortController();
+    const node = new ScriptedRetryNode(
+      1,
+      [new Error('original failure')],
+      [true],
+      true,
+      () => controller.abort(),
+    );
+    node.signal = controller.signal;
+
+    await expect(node._exec(undefined)).resolves.toBe('fallback');
+    expect(node.events).toEqual([
+      'exec:1',
+      'prompt:original failure',
+      'fallback:original failure',
+    ]);
+    expect(node.fallbackError?.message).toBe('original failure');
+  });
+
+  it('does not prompt again when cancelled during an approved attempt', async () => {
+    const controller = new AbortController();
+    const node = new ScriptedRetryNode(
+      1,
+      [new Error('original failure'), new Error('approved failure')],
+      [true],
+      true,
+      undefined,
+      (call) => {
+        if (call === 2) controller.abort();
+      },
+    );
+    node.signal = controller.signal;
+
+    await expect(node._exec(undefined)).resolves.toBe('fallback');
+    expect(node.events).toEqual([
+      'exec:1',
+      'prompt:original failure',
+      'exec:2',
+      'fallback:approved failure',
+    ]);
+    expect(node.fallbackError?.message).toBe('approved failure');
+  });
+
+  it('falls back when cancellation wins after an approved attempt resolves', async () => {
+    const controller = new AbortController();
+    let resolveApprovedAttempt!: (value: string) => void;
+    const approvedAttempt = new Promise<string>((resolve) => {
+      resolveApprovedAttempt = resolve;
+    });
+    const originalError = new Error('original failure');
+    const node = new ScriptedRetryNode(
+      1,
+      [originalError, () => approvedAttempt],
+      [true],
+    );
+    node.signal = controller.signal;
+
+    const result = node._exec(undefined);
+    await vi.waitFor(() => expect(node.calls).toBe(2));
+    controller.abort();
+    resolveApprovedAttempt('late success');
+
+    await expect(result).resolves.toBe('fallback');
+    expect(node.events).toEqual([
+      'exec:1',
+      'prompt:original failure',
+      'exec:2',
+      'fallback:original failure',
+    ]);
+    expect(node.fallbackError).toBe(originalError);
+  });
+
+  it('unwraps AbortError from an approved attempt before prompting again', async () => {
+    const originalError = new Error('stop retrying');
+    const node = new ScriptedRetryNode(
+      1,
+      [new Error('initial failure'), new AbortError(originalError)],
+      [true, false],
+    );
+
+    await expect(node._exec(undefined)).resolves.toBe('fallback');
+    expect(node.promptErrors[1]).toBe(originalError);
+    expect(node.fallbackError).toBe(originalError);
+  });
+
+  it('normalizes a non-Error thrown by an approved attempt', async () => {
+    const node = new ScriptedRetryNode(
+      1,
+      [new Error('initial failure'), { thrown: 'raw failure' }],
+      [true, false],
+    );
+
+    await expect(node._exec(undefined)).resolves.toBe('fallback');
+    expect(node.promptErrors[1]).toBeInstanceOf(TypeError);
+    expect(node.promptErrors[1]?.message).toBe(
+      'Non-error was thrown: "raw failure". You should only throw errors.',
+    );
+    expect(node.fallbackError).toBe(node.promptErrors[1]);
+  });
+
+  it('continues beyond the former 100-approval ceiling one attempt at a time', async () => {
+    const node = new ScriptedRetryNode(
+      1,
+      [
+        ...Array.from({ length: 101 }, () => new Error('temporary failure')),
+        'completed',
+      ],
+      Array.from({ length: 101 }, () => true),
+    );
 
     await expect(node._exec(undefined)).resolves.toBe('completed');
     expect(node.calls).toBe(102);
+    expect(node.prompts).toBe(101);
   });
 });


### PR DESCRIPTION
## Summary

Implement step 2 only of #9532 at the shared node retry boundary.

- keep the initial automatic `pRetry` batch at exactly the configured effective attempt count
- make each explicit manual retry approval grant exactly one additional attempt instead of replenishing another automatic batch
- run that approved attempt through the same `pRetry` boundary with `retries: 0`, preserving signal checks, `AbortError` unwrapping, and non-Error normalization
- prompt again after a failed approved attempt, while preserving arbitrarily many explicit approvals
- fall back with the most relevant execution error on decline or cancellation

This intentionally does **not** add or move host policy, a durable retry ledger, retry configuration limits, provider-specific background lifetime handling, or retry telemetry. Those bounded config/provider lifetime/telemetry parts remain deferred follow-up work for #9532.

## Verification

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/PocketFlowNode.vitest.ts src/test-kernel/agent/runtime/RetryState.vitest.ts` — 65 tests passed
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- `corepack pnpm eslint src/agent/node/index.ts src/test-kernel/agent/PocketFlowNode.vitest.ts`
- `corepack pnpm prettier --check src/agent/node/index.ts src/test-kernel/agent/PocketFlowNode.vitest.ts`
- `git diff --check`

Refs #9532
