### PR TITLE
fix(model): bound automatic retry setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Automatic model retry settings are bounded** — the retry setting now
+  accepts zero to five additional attempts after the initial request. Invalid
+  stored values fall back to the documented default instead of creating an
+  arbitrarily long automatic retry sequence.
 - **Runs that overflow the model context window say so** — instead of a generic
   failure message, the run now reports that the conversation exceeds the
   model's context window and suggests starting a new session or reducing

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -799,11 +799,12 @@
         "title": "Model Retries",
         "properties": {
           "texra.model.retry.maxAttempts": {
-            "type": "number",
+            "type": "integer",
             "default": 2,
             "minimum": 0,
-            "description": "Automatic retry attempts for transient model failures. Parallel runs share one recovery probe per affected model route.",
-            "scope": "resource"
+            "description": "Additional automatic retries after the initial model request (0–5). Long-running background requests retain at least two recovery retries.",
+            "scope": "resource",
+            "maximum": 5
           }
         }
       }

--- a/packages/extension/src/settingsView/frontend/components/profile/ReliabilitySettingsSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ReliabilitySettingsSection.ts
@@ -49,7 +49,13 @@ export class ReliabilitySettingsSection extends LitElement {
       input.value = String(setting.value);
       return;
     }
-    const value = clampOptional(parsed, setting.min, setting.max);
+    const stepOrigin = setting.min ?? 0;
+    const stepped =
+      setting.step === undefined
+        ? parsed
+        : stepOrigin +
+          Math.round((parsed - stepOrigin) / setting.step) * setting.step;
+    const value = clampOptional(stepped, setting.min, setting.max);
     if (value !== parsed) input.value = String(value);
     postMessage(SETTINGS_VIEW_COMMANDS.SET_PROVIDER_VSCODE_SETTING, {
       key: setting.key,
@@ -72,6 +78,7 @@ export class ReliabilitySettingsSection extends LitElement {
             .value=${String(setting.value)}
             min=${setting.min ?? nothing}
             max=${setting.max ?? nothing}
+            step=${setting.step ?? nothing}
             @change=${(event: Event) =>
               this.handleSettingChange(setting, event.target as WaInput)}
           ></wa-input>

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -19,9 +19,12 @@ import {
   toRetryErrorInfo,
   type RetryErrorInfo,
 } from '@shared/schemas';
-import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
+import {
+  DEFAULT_CORE_SETTINGS,
+  ModelRetryMaxAttemptsSchema,
+} from '@shared/schemas/coreSettings';
 import { generateShortId } from '@utils/core';
-import { getConfig } from '@utils/config/configUtils';
+import { getValidatedConfig } from '@utils/config/configUtils';
 import { ensureError } from '@utils/errors/errorMessage';
 
 const BACKGROUND_MODE_MIN_RETRIES = 3;
@@ -35,13 +38,14 @@ const RETRY_BACKOFF_MS = 1000;
 
 /** Returns one initial attempt plus configured retries and their base backoff. */
 function getNodeRetryConfig(): { maxRetries: number; backoffMs: number } {
-  const maxAutoAttempts = getConfig<number>(
+  const maxAutoAttempts = getValidatedConfig(
     'texra.model.retry.maxAttempts',
+    ModelRetryMaxAttemptsSchema,
     DEFAULT_CORE_SETTINGS.model.retry.maxAttempts,
   );
 
   return {
-    maxRetries: 1 + Math.max(0, maxAutoAttempts),
+    maxRetries: 1 + maxAutoAttempts,
     backoffMs: RETRY_BACKOFF_MS,
   };
 }

--- a/src/controllers/settingsView/SettingsProfileController.ts
+++ b/src/controllers/settingsView/SettingsProfileController.ts
@@ -8,11 +8,18 @@ import type {
   UpdateProfileMessage,
 } from '@shared/schemas/profileViewMessages';
 import type { ProviderVscodeSettingDef } from '@shared/constants/providers';
-import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
+import {
+  DEFAULT_CORE_SETTINGS,
+  MODEL_RETRY_MAX_ATTEMPTS_SETTING,
+  ModelRetryMaxAttemptsSchema,
+} from '@shared/schemas/coreSettings';
 import { buildProfileMessage } from './ProfileMessageBuilder';
 
 type SettingsReliabilitySetting = Omit<NumberVscodeSetting, 'value'> & {
   defaultValue: number;
+  schema?: {
+    safeParse(value: unknown): { success: boolean };
+  };
 };
 
 const SETTINGS_RELIABILITY_SETTINGS: readonly SettingsReliabilitySetting[] = [
@@ -28,13 +35,28 @@ const SETTINGS_RELIABILITY_SETTINGS: readonly SettingsReliabilitySetting[] = [
   },
   {
     key: 'texra.model.retry.maxAttempts',
-    label: 'Retry attempts',
-    description:
-      'Automatic retry attempts for transient model failures. Parallel runs share one recovery probe per affected model route.',
-    min: 0,
+    label: 'Automatic retries',
+    description: MODEL_RETRY_MAX_ATTEMPTS_SETTING.description,
+    min: MODEL_RETRY_MAX_ATTEMPTS_SETTING.min,
+    max: MODEL_RETRY_MAX_ATTEMPTS_SETTING.max,
+    step: 1,
     defaultValue: DEFAULT_CORE_SETTINGS.model.retry.maxAttempts,
+    schema: ModelRetryMaxAttemptsSchema,
   },
 ];
+
+function acceptsReliabilityValue(
+  setting: Pick<SettingsReliabilitySetting, 'min' | 'max' | 'step' | 'schema'>,
+  value: SettingsProfileConfigValue,
+): value is number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return false;
+  if (setting.schema) {
+    return setting.schema.safeParse(value).success;
+  }
+  if (setting.min !== undefined && value < setting.min) return false;
+  if (setting.max !== undefined && value > setting.max) return false;
+  return setting.step === undefined || Number.isInteger(value / setting.step);
+}
 
 export type SettingsProfileConfigValue = boolean | number;
 
@@ -72,8 +94,8 @@ export interface SettingsProfileControllerDeps {
 
 export class SettingsProfileController {
   private readonly providerSettingsByKey: Map<string, ProviderVscodeSettingDef>;
-  private readonly reliabilitySettingKeys = new Set(
-    SETTINGS_RELIABILITY_SETTINGS.map((setting) => setting.key),
+  private readonly reliabilitySettingsByKey = new Map(
+    SETTINGS_RELIABILITY_SETTINGS.map((setting) => [setting.key, setting]),
   );
 
   constructor(private readonly deps: SettingsProfileControllerDeps) {
@@ -95,12 +117,21 @@ export class SettingsProfileController {
   }
 
   getReliabilitySettings(): NumberVscodeSetting[] {
-    return SETTINGS_RELIABILITY_SETTINGS.map(
-      ({ defaultValue, ...setting }) => ({
+    return SETTINGS_RELIABILITY_SETTINGS.map((definition) => {
+      const { defaultValue, schema: _schema, ...setting } = definition;
+      const configuredValue = this.deps.getConfig<number>(
+        setting.key,
+        defaultValue,
+      );
+      return {
         ...setting,
-        value: this.deps.getConfig<number>(setting.key, defaultValue),
-      }),
-    );
+        value:
+          definition.schema &&
+          !definition.schema.safeParse(configuredValue).success
+            ? defaultValue
+            : configuredValue,
+      };
+    });
   }
 
   getProviderDisplayName(provider: string): string {
@@ -139,8 +170,12 @@ export class SettingsProfileController {
     value: SettingsProfileConfigValue;
   }): Promise<ProviderVscodeSettingUpdateResult> {
     const providerSetting = this.providerSettingsByKey.get(input.key);
-    const isReliabilitySetting = this.reliabilitySettingKeys.has(input.key);
-    if (!providerSetting && !isReliabilitySetting) {
+    const reliabilitySetting = this.reliabilitySettingsByKey.get(input.key);
+    if (
+      (!providerSetting && !reliabilitySetting) ||
+      (reliabilitySetting &&
+        !acceptsReliabilityValue(reliabilitySetting, input.value))
+    ) {
       return { kind: 'rejected', key: input.key };
     }
 

--- a/src/controllers/settingsView/SettingsProfileController.ts
+++ b/src/controllers/settingsView/SettingsProfileController.ts
@@ -45,19 +45,6 @@ const SETTINGS_RELIABILITY_SETTINGS: readonly SettingsReliabilitySetting[] = [
   },
 ];
 
-function acceptsReliabilityValue(
-  setting: Pick<SettingsReliabilitySetting, 'min' | 'max' | 'step' | 'schema'>,
-  value: SettingsProfileConfigValue,
-): value is number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return false;
-  if (setting.schema) {
-    return setting.schema.safeParse(value).success;
-  }
-  if (setting.min !== undefined && value < setting.min) return false;
-  if (setting.max !== undefined && value > setting.max) return false;
-  return setting.step === undefined || Number.isInteger(value / setting.step);
-}
-
 export type SettingsProfileConfigValue = boolean | number;
 
 export type ProviderVscodeSettingUpdateResult =
@@ -173,8 +160,8 @@ export class SettingsProfileController {
     const reliabilitySetting = this.reliabilitySettingsByKey.get(input.key);
     if (
       (!providerSetting && !reliabilitySetting) ||
-      (reliabilitySetting &&
-        !acceptsReliabilityValue(reliabilitySetting, input.value))
+      (reliabilitySetting?.schema &&
+        !reliabilitySetting.schema.safeParse(input.value).success)
     ) {
       return { kind: 'rejected', key: input.key };
     }

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -64,6 +64,18 @@ export type LatexdiffTempFileLocation =
   (typeof LATEXDIFF_TEMP_FILE_LOCATIONS)[number];
 export type AgentReviewApproach = (typeof AGENT_REVIEW_APPROACHES)[number];
 
+/**
+ * Contract for the historical `model.retry.maxAttempts` setting. The value is
+ * the number of automatic retries after the initial model request.
+ */
+export const MODEL_RETRY_MAX_ATTEMPTS_SETTING = {
+  defaultValue: 2,
+  min: 0,
+  max: 5,
+  description:
+    'Additional automatic retries after the initial model request (0–5). Long-running background requests retain at least two recovery retries.',
+} as const;
+
 export const DEFAULT_CORE_SETTINGS = {
   agentOutputs: {
     autoOpenFinal: true,
@@ -83,7 +95,7 @@ export const DEFAULT_CORE_SETTINGS = {
     compactionThresholdPercent: 75,
     gpt5ReasoningSummary: false,
     retry: {
-      maxAttempts: 2,
+      maxAttempts: MODEL_RETRY_MAX_ATTEMPTS_SETTING.defaultValue,
     },
   },
   chatgptCodex: {
@@ -284,6 +296,13 @@ const numberField = (
   return schema.describe(description).prefault(defaultValue);
 };
 
+export const ModelRetryMaxAttemptsSchema = z
+  .int()
+  .min(MODEL_RETRY_MAX_ATTEMPTS_SETTING.min)
+  .max(MODEL_RETRY_MAX_ATTEMPTS_SETTING.max)
+  .describe(MODEL_RETRY_MAX_ATTEMPTS_SETTING.description)
+  .prefault(MODEL_RETRY_MAX_ATTEMPTS_SETTING.defaultValue);
+
 /**
  * Field shape for {@link CoreSettingsSchema}.
  *
@@ -350,11 +369,7 @@ export const CoreSettingsShape = {
       ),
       retry: z
         .strictObject({
-          maxAttempts: numberField(
-            DEFAULT_CORE_SETTINGS.model.retry.maxAttempts,
-            'Automatic retry attempts for transient model failures. Parallel runs share one recovery probe per affected model route.',
-            { min: 0 },
-          ),
+          maxAttempts: ModelRetryMaxAttemptsSchema,
         })
         .prefault(DEFAULT_CORE_SETTINGS.model.retry),
     })

--- a/src/shared/schemas/profileViewMessages.ts
+++ b/src/shared/schemas/profileViewMessages.ts
@@ -81,6 +81,7 @@ export const NumberVscodeSettingSchema = z.object({
   value: z.number(),
   min: z.number().optional(),
   max: z.number().optional(),
+  step: z.number().positive().optional(),
   unit: z.string().optional(),
 });
 export type NumberVscodeSetting = z.infer<typeof NumberVscodeSettingSchema>;

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -56,7 +56,11 @@ import {
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
-import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
+import {
+  DEFAULT_CORE_SETTINGS,
+  MODEL_RETRY_MAX_ATTEMPTS_SETTING,
+} from '@shared/schemas/coreSettings';
+import { installPlatform } from '@test/support/setupPlatform';
 import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,
@@ -318,11 +322,12 @@ describe('RetryState', () => {
     installTexraModelAccess();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.unstubAllEnvs();
     resetRelayTokenTierCacheForTests();
     setIncludedModelAccess(null);
     SupabaseClient.resetForTests();
+    await installPlatform();
   });
 
   it('records a failed invocation without logging bookkeeping', () => {
@@ -386,6 +391,33 @@ describe('RetryState', () => {
       1 + DEFAULT_CORE_SETTINGS.model.retry.maxAttempts,
     );
     expect(node.wait).toBe(RETRY_BACKOFF_SECONDS);
+  });
+
+  it('accepts the canonical maximum number of automatic retries', async () => {
+    await installPlatform({
+      config: {
+        'texra.model.retry.maxAttempts': MODEL_RETRY_MAX_ATTEMPTS_SETTING.max,
+      },
+    });
+
+    const node = new ExposedRetryNode();
+
+    expect(node.maxRetries).toBe(1 + MODEL_RETRY_MAX_ATTEMPTS_SETTING.max);
+  });
+
+  it('falls back when a stored retry count exceeds the canonical maximum', async () => {
+    await installPlatform({
+      config: {
+        'texra.model.retry.maxAttempts':
+          MODEL_RETRY_MAX_ATTEMPTS_SETTING.max + 1,
+      },
+    });
+
+    const node = new ExposedRetryNode();
+
+    expect(node.maxRetries).toBe(
+      1 + DEFAULT_CORE_SETTINGS.model.retry.maxAttempts,
+    );
   });
 
   it('treats user aborts as cancellations instead of failed invocations', () => {

--- a/src/test-kernel/controllers/SettingsProfileController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsProfileController.vitest.ts
@@ -214,7 +214,52 @@ describe('SettingsProfileController', () => {
     expect(controller.getReliabilitySettings()).toContainEqual(
       expect.objectContaining({
         key: 'texra.model.retry.maxAttempts',
+        label: 'Automatic retries',
+        min: 0,
+        max: 5,
+        step: 1,
         value: 3,
+      }),
+    );
+  });
+
+  it('rejects fractional automatic retry values at the settings boundary', async () => {
+    const { controller, config } = createController();
+
+    const result = await controller.setProviderVscodeSetting({
+      key: 'texra.model.retry.maxAttempts',
+      value: 2.5,
+    });
+
+    expect(result).toEqual({
+      kind: 'rejected',
+      key: 'texra.model.retry.maxAttempts',
+    });
+    expect(config).not.toHaveProperty('texra.model.retry.maxAttempts');
+  });
+
+  it('shows the default when persisted automatic retries are invalid', () => {
+    const { controller } = createController({
+      config: { 'texra.model.retry.maxAttempts': 2.5 },
+    });
+
+    expect(controller.getReliabilitySettings()).toContainEqual(
+      expect.objectContaining({
+        key: 'texra.model.retry.maxAttempts',
+        value: DEFAULT_CORE_SETTINGS.model.retry.maxAttempts,
+      }),
+    );
+  });
+
+  it('does not mask a compaction value that runtime still reads directly', () => {
+    const { controller } = createController({
+      config: { 'texra.model.compactionThresholdPercent': 101 },
+    });
+
+    expect(controller.getReliabilitySettings()).toContainEqual(
+      expect.objectContaining({
+        key: 'texra.model.compactionThresholdPercent',
+        value: 101,
       }),
     );
   });

--- a/src/test-kernel/controllers/SettingsProfileController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsProfileController.vitest.ts
@@ -223,33 +223,39 @@ describe('SettingsProfileController', () => {
     );
   });
 
-  it('rejects fractional automatic retry values at the settings boundary', async () => {
-    const { controller, config } = createController();
+  it.each([2.5, 6])(
+    'rejects invalid automatic retry value %s at the settings boundary',
+    async (value) => {
+      const { controller, config } = createController();
 
-    const result = await controller.setProviderVscodeSetting({
-      key: 'texra.model.retry.maxAttempts',
-      value: 2.5,
-    });
-
-    expect(result).toEqual({
-      kind: 'rejected',
-      key: 'texra.model.retry.maxAttempts',
-    });
-    expect(config).not.toHaveProperty('texra.model.retry.maxAttempts');
-  });
-
-  it('shows the default when persisted automatic retries are invalid', () => {
-    const { controller } = createController({
-      config: { 'texra.model.retry.maxAttempts': 2.5 },
-    });
-
-    expect(controller.getReliabilitySettings()).toContainEqual(
-      expect.objectContaining({
+      const result = await controller.setProviderVscodeSetting({
         key: 'texra.model.retry.maxAttempts',
-        value: DEFAULT_CORE_SETTINGS.model.retry.maxAttempts,
-      }),
-    );
-  });
+        value,
+      });
+
+      expect(result).toEqual({
+        kind: 'rejected',
+        key: 'texra.model.retry.maxAttempts',
+      });
+      expect(config).not.toHaveProperty('texra.model.retry.maxAttempts');
+    },
+  );
+
+  it.each([2.5, 6])(
+    'shows the default when persisted automatic retries are invalid (%s)',
+    (value) => {
+      const { controller } = createController({
+        config: { 'texra.model.retry.maxAttempts': value },
+      });
+
+      expect(controller.getReliabilitySettings()).toContainEqual(
+        expect.objectContaining({
+          key: 'texra.model.retry.maxAttempts',
+          value: DEFAULT_CORE_SETTINGS.model.retry.maxAttempts,
+        }),
+      );
+    },
+  );
 
   it('does not mask a compaction value that runtime still reads directly', () => {
     const { controller } = createController({
@@ -262,6 +268,21 @@ describe('SettingsProfileController', () => {
         value: 101,
       }),
     );
+  });
+
+  it('preserves raw compaction writes without a runtime schema', async () => {
+    const { controller, config } = createController();
+
+    const result = await controller.setProviderVscodeSetting({
+      key: 'texra.model.compactionThresholdPercent',
+      value: 101,
+    });
+
+    expect(result).toEqual({
+      kind: 'updated',
+      affectsModelAvailability: false,
+    });
+    expect(config['texra.model.compactionThresholdPercent']).toBe(101);
   });
 
   it('defaults reliability settings to DEFAULT_CORE_SETTINGS.model.retry (no drift from the catalog)', () => {

--- a/src/test-kernel/settings/ReliabilitySettingsSection.vitest.ts
+++ b/src/test-kernel/settings/ReliabilitySettingsSection.vitest.ts
@@ -1,0 +1,67 @@
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  postMessage: vi.fn(),
+}));
+
+vi.mock('@shared/hostBridge', () => ({
+  postMessage: mocks.postMessage,
+}));
+
+// Local imports - component and schema types
+import type { ReliabilitySettingsSection } from '@settingsView/frontend/components/profile/ReliabilitySettingsSection';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+
+// Local imports - test utilities
+import {
+  mountComponent,
+  useLitComponentTestDom,
+} from './litComponentTestUtils';
+
+useLitComponentTestDom(
+  () =>
+    import('@settingsView/frontend/components/profile/ReliabilitySettingsSection'),
+);
+
+describe('reliability-settings-section', () => {
+  beforeEach(() => {
+    mocks.postMessage.mockClear();
+  });
+
+  it('normalizes fractional retry values to the configured integer step', async () => {
+    const section = await mountComponent<ReliabilitySettingsSection>(
+      'reliability-settings-section',
+      {
+        settings: [
+          {
+            key: 'texra.model.retry.maxAttempts',
+            label: 'Automatic retries',
+            description: 'Additional retries after the initial request.',
+            value: 2,
+            min: 0,
+            max: 5,
+            step: 1,
+          },
+        ],
+      },
+    );
+    const input = section.shadowRoot?.querySelector('wa-input') as
+      (HTMLElement & { value: string }) | null;
+
+    expect(input).not.toBeNull();
+    input!.value = '2.5';
+    input!.dispatchEvent(
+      new Event('change', { bubbles: true, composed: true }),
+    );
+
+    expect(input!.value).toBe('3');
+    expect(mocks.postMessage).toHaveBeenCalledWith(
+      SETTINGS_VIEW_COMMANDS.SET_PROVIDER_VSCODE_SETTING,
+      {
+        key: 'texra.model.retry.maxAttempts',
+        value: 3,
+      },
+    );
+  });
+});

--- a/src/test-kernel/shared/settingsConfiguration.vitest.ts
+++ b/src/test-kernel/shared/settingsConfiguration.vitest.ts
@@ -15,6 +15,7 @@ import {
 } from '@extensionSchemas/texraSettings';
 import { PROVIDER_VSCODE_SETTINGS } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
+import { MODEL_RETRY_MAX_ATTEMPTS_SETTING } from '@shared/schemas/coreSettings';
 import { REPO_ROOT } from '@test/support/repoScan';
 import {
   getGLMUseChina,
@@ -76,6 +77,29 @@ describe('TexraSettingsSchema', () => {
     // T10: Google Interactions server-side state defaults ON.
     assert.equal(parsed.model.useGoogleInteractionsServerState, true);
     assert.deepEqual(parsed, DEFAULT_TEXRA_SETTINGS);
+  });
+
+  it('bounds automatic model retries as additional whole attempts', () => {
+    const atMaximum = TexraSettingsSchema.parse({
+      model: { retry: { maxAttempts: MODEL_RETRY_MAX_ATTEMPTS_SETTING.max } },
+    });
+
+    assert.equal(
+      atMaximum.model.retry.maxAttempts,
+      MODEL_RETRY_MAX_ATTEMPTS_SETTING.max,
+    );
+    assert.throws(() =>
+      TexraSettingsSchema.parse({
+        model: {
+          retry: { maxAttempts: MODEL_RETRY_MAX_ATTEMPTS_SETTING.max + 1 },
+        },
+      }),
+    );
+    assert.throws(() =>
+      TexraSettingsSchema.parse({
+        model: { retry: { maxAttempts: 1.5 } },
+      }),
+    );
   });
 
   it('exposes every TEXRA_SETTING_PATH on the parsed tree', () => {


### PR DESCRIPTION
## Summary

Implement the bounded-configuration stage of #9532.

`texra.model.retry.maxAttempts` now has one shared contract: it counts additional automatic retries after the initial model request, accepts only whole numbers from zero through five, and defaults to two. Runtime reads validate against that contract, so a stale or hand-edited invalid value emits the existing configuration warning and falls back to the documented default.

The extension manifest is generated from the same Zod schema, and the settings view consumes the same description and range. Long-running background requests retain their existing minimum of two recovery retries; provider-specific lifetime repair remains separate.

## Issue acceptance gates

This PR satisfies the bounded-configuration gate of #9532:

- one canonical finite maximum is enforced by the shared schema;
- the generated extension setting is an integer with maximum 5;
- runtime parsing rejects invalid present values and uses the documented default;
- user-facing text states that the value counts retries after the initial request.

The OpenAI polling deadline, Google background resumption/accounting, retry-kind distinctions, and durable retry diagnostics remain open in #9532.

## Single source of truth

`MODEL_RETRY_MAX_ATTEMPTS_SETTING` and `ModelRetryMaxAttemptsSchema` in `coreSettings.ts` own the default, range, meaning, and runtime validation. The extension manifest is generated from the schema; the settings controller imports the shared contract.

## Duplication and abstraction budget

The previous repeated setting description and lower bound were removed. One small setting contract was added because its values feed the shared schema, runtime reader, generated host manifest, and settings view.

## Net elements (R6)

- Files: 10 modified, 1 added, 0 deleted
- Exported symbols: 2 added, 0 deleted
- Classes/interfaces/enums: 0 added, 0 deleted
- Net lines: +243

## Consumer counts (R8)

n/a — no export or event path was deleted or rerouted. The two new exports have one runtime/schema owner and one settings-view consumer.

## Host impact

Extension: The numeric control is limited to whole values from 0 through 5, with precise retry semantics in its description.

Desktop: Shared runtime validation bounds stored configuration before constructing a retry batch.

CLI: Shared runtime validation bounds stored configuration before constructing a retry batch.

## Scheduled refactoring

None. Provider-specific lifetime and telemetry work remains tracked in #9532 rather than being folded into this configuration change.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm test` — 8,395 passed, 4 skipped
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- focused controller/frontend/retry/schema Vitest suites — 85 passed
- `corepack pnpm run typecheck:extension`
- `npm run sync:package-contributes -- --check`
- changed-file ESLint and Prettier checks
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration and validation around model retry count; behavior change is capping invalid/high values to the documented default, with broad test coverage and no auth or data-path changes.
> 
> **Overview**
> **Automatic model retries are now bounded and consistently defined** across the extension manifest, core settings schema, runtime, and reliability settings UI.
> 
> `MODEL_RETRY_MAX_ATTEMPTS_SETTING` and `ModelRetryMaxAttemptsSchema` in `coreSettings.ts` own the default (2), range (0–5), description, and meaning: **additional** automatic retries after the initial model request. The VS Code setting is an integer with `maximum: 5`; `RetryState` reads the value via `getValidatedConfig` instead of unbounded `Math.max(0, …)`.
> 
> The settings profile **rejects invalid writes** (e.g. 2.5 or 6) and **masks invalid persisted values** when displaying reliability settings, while compaction threshold behavior is unchanged. The reliability UI applies optional **integer step** snapping on number inputs.
> 
> Tests cover schema bounds, controller validation, runtime fallback for out-of-range config, and fractional input normalization in the reliability section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd11cd5c0824036d58435c2af70a60aba7742d27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
