### PR TITLE
fix(model): preserve OpenAI background deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **OpenAI background responses keep one polling deadline across retries** —
+  reconnecting to the same response no longer restarts its three-hour polling
+  window.
 - **Automatic model retry settings are bounded** — the retry setting now
   accepts zero to five additional attempts after the initial request. Invalid
   stored values fall back to the documented default instead of creating an

--- a/src/agent/modelHandlers/openai/BackgroundRunLifecycle.ts
+++ b/src/agent/modelHandlers/openai/BackgroundRunLifecycle.ts
@@ -23,6 +23,7 @@ import { tagOpenAISdkError } from './openAISdkError';
 import {
   classifyOpenAIBackgroundResumeError,
   createOpenAIBackgroundPollingError,
+  createOpenAIBackgroundPollingTimeoutError,
   createOpenAIBackgroundTerminalError,
 } from './openAIResponseErrors';
 import type OpenAI from 'openai';
@@ -37,6 +38,7 @@ const BACKGROUND_PENDING_STATUSES: readonly ResponseStatus[] = [
   'queued',
   'in_progress',
 ];
+const BACKGROUND_MAX_DURATION_MS = 3 * 60 * 60 * 1000;
 
 /** Collaborators the lifecycle borrows from the owning handler. */
 interface BackgroundRunLifecycleDeps {
@@ -50,7 +52,7 @@ interface BackgroundRunLifecycleDeps {
 export class BackgroundRunLifecycle {
   private readonly backgroundPoller = new BackgroundPoller<Response>({
     pollIntervalMs: 15000,
-    maxDurationMs: 3 * 60 * 60 * 1000, // 3 hours
+    maxDurationMs: BACKGROUND_MAX_DURATION_MS,
     isPending: (r) => this.isPending(r),
     logger: this.deps.logger,
   });
@@ -62,6 +64,7 @@ export class BackgroundRunLifecycle {
    */
   private pendingResponseId: string | null = null;
   private pendingRetrieveParams: ResponseRetrieveParamsNonStreaming | undefined;
+  private pendingDeadlineAtMs: number | null = null;
 
   constructor(private readonly deps: BackgroundRunLifecycleDeps) {}
 
@@ -90,14 +93,29 @@ export class BackgroundRunLifecycle {
   clearPending(): void {
     this.pendingResponseId = null;
     this.pendingRetrieveParams = undefined;
+    this.pendingDeadlineAtMs = null;
   }
 
   private rememberPending(
     responseId: string,
     retrieveParams?: ResponseRetrieveParamsNonStreaming,
   ): void {
+    if (
+      this.pendingResponseId !== responseId ||
+      this.pendingDeadlineAtMs === null
+    ) {
+      this.pendingDeadlineAtMs = Date.now() + BACKGROUND_MAX_DURATION_MS;
+    }
     this.pendingResponseId = responseId;
     this.pendingRetrieveParams = retrieveParams;
+  }
+
+  private pollingTimeoutError(responseId: string): Error {
+    return createOpenAIBackgroundPollingTimeoutError(
+      responseId,
+      BACKGROUND_MAX_DURATION_MS,
+      this.deps.provider,
+    );
   }
 
   /**
@@ -115,6 +133,12 @@ export class BackgroundRunLifecycle {
       return null;
     }
     const retrieveParams = this.pendingRetrieveParams;
+    if (
+      this.pendingDeadlineAtMs !== null &&
+      Date.now() >= this.pendingDeadlineAtMs
+    ) {
+      throw this.pollingTimeoutError(pendingId);
+    }
 
     this.logger.debug(
       `Resuming polling for pending background response ${pendingId}`,
@@ -310,12 +334,12 @@ export class BackgroundRunLifecycle {
       extractId: (r) => r.id,
       extractStatus: (r) => r.status ?? 'unknown',
       signal,
+      deadlineAtMs: this.pendingDeadlineAtMs ?? undefined,
       resourceLabel: 'response',
       providerLabel: 'OpenAI',
       onAbort: () => this.clearPending(),
-      formatTimeoutError: ({ responseId, maxDurationMs }) =>
-        `OpenAI response ${responseId} exceeded maximum polling duration of ${maxDurationMs} ms. ` +
-        `Retry later or cancel the job with client.responses.cancel("${responseId}").`,
+      formatTimeoutError: ({ responseId }) =>
+        this.pollingTimeoutError(responseId),
       extraFinishData: (response) => ({
         usage: response.usage ?? undefined,
       }),

--- a/src/agent/modelHandlers/openai/openAIResponseErrors.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseErrors.ts
@@ -1,5 +1,6 @@
 // Local imports
 import {
+  attachProviderError,
   isRetryableStatusCode,
   normalizeProviderError,
 } from '@common/errors/sdkErrorUtils';
@@ -83,6 +84,24 @@ export function createOpenAIBackgroundPollingError(
     pollingError.request_id = causeError.requestId;
   }
   return pollingError;
+}
+
+/** Create a terminal error for a background response whose polling lifetime ended. */
+export function createOpenAIBackgroundPollingTimeoutError(
+  responseId: string,
+  maxDurationMs: number,
+  provider: string,
+): Error {
+  const error = new Error(
+    `OpenAI response ${responseId} exceeded maximum polling duration of ${maxDurationMs} ms. ` +
+      `Inspect or cancel the job with client.responses.cancel("${responseId}").`,
+  );
+  attachProviderError(error, {
+    message: error.message,
+    provider,
+    userRetryable: false,
+  });
+  return error;
 }
 
 export function createOpenAIBackgroundTerminalError(

--- a/src/agent/modelHandlers/support/BackgroundPoller.ts
+++ b/src/agent/modelHandlers/support/BackgroundPoller.ts
@@ -56,6 +56,12 @@ interface BackgroundPollOptions<TResponse> {
   /** Optional abort signal propagated to `delay` and `retrieve`. */
   readonly signal?: AbortSignal;
   /**
+   * Absolute wall-clock deadline for a polling lifetime that began before
+   * this invocation. When absent, this invocation receives the configured
+   * maximum duration.
+   */
+  readonly deadlineAtMs?: number;
+  /**
    * Optional callback invoked on abort (best-effort). Handlers use this to
    * cancel the in-flight job server-side or clear local tracking state.
    */
@@ -67,10 +73,10 @@ interface BackgroundPollOptions<TResponse> {
    * `'Google Interactions'`). Defaults to `'Background'`.
    */
   readonly providerLabel?: string;
-  /** Provider-specific timeout error text with cancellation guidance. */
+  /** Provider-specific timeout error or text with cancellation guidance. */
   readonly formatTimeoutError?: (
     context: BackgroundPollTimeoutContext<TResponse>,
-  ) => string;
+  ) => Error | string;
   /** Provider-specific fields to append to the final polling-finished log. */
   readonly extraFinishData?: (
     response: TResponse,
@@ -155,6 +161,7 @@ export class BackgroundPoller<TResponse> {
       extractId,
       extractStatus,
       signal,
+      deadlineAtMs,
       onAbort,
       resourceLabel = 'response',
       providerLabel = 'Background',
@@ -167,7 +174,9 @@ export class BackgroundPoller<TResponse> {
 
     const { pollIntervalMs, maxDurationMs, isPending } = this.config;
     const logger = () => resolveLogger(this.config.logger);
-    const startTime = Date.now();
+    const startTime =
+      deadlineAtMs === undefined ? Date.now() : deadlineAtMs - maxDurationMs;
+    const deadline = deadlineAtMs ?? startTime + maxDurationMs;
     let current = initialResponse;
     let pollCount = 0;
 
@@ -220,7 +229,7 @@ export class BackgroundPoller<TResponse> {
 
         const elapsedMs = Date.now() - startTime;
         const status = extractStatus(current);
-        if (elapsedMs > maxDurationMs) {
+        if (Date.now() >= deadline) {
           const stats = { responseId, status, pollCount, elapsedMs };
           logger().error(
             `${providerLabel} ${resourceLabel} ${responseId} exceeded maximum polling duration while pending`,
@@ -231,14 +240,14 @@ export class BackgroundPoller<TResponse> {
               },
             },
           );
-          throw new Error(
+          const timeout =
             options.formatTimeoutError?.({
               ...stats,
               maxDurationMs,
               response: current,
             }) ??
-              `${providerLabel} ${resourceLabel} ${responseId} exceeded maximum polling duration of ${maxDurationMs} ms.`,
-          );
+            `${providerLabel} ${resourceLabel} ${responseId} exceeded maximum polling duration of ${maxDurationMs} ms.`;
+          throw timeout instanceof Error ? timeout : new Error(timeout);
         }
 
         current = await retrieve(responseId, signal);

--- a/src/test-kernel/agent/modelHandlers/BackgroundPoller.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/BackgroundPoller.vitest.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentTrace } from '@agent/trace';
 import {
@@ -24,6 +24,10 @@ function trace() {
 
 const extractId = (response: TestResponse) => response.id;
 const extractStatus = (response: TestResponse) => response.status;
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('BackgroundPoller', () => {
   it('resolves the logger supplier at poll time', async () => {
@@ -84,6 +88,33 @@ describe('BackgroundPoller', () => {
         }),
       }),
     );
+  });
+
+  it('honors a polling deadline established by an earlier invocation', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-01T03:00:00Z'));
+    const logger = trace();
+    const retrieve = vi.fn();
+    const poller = new BackgroundPoller<TestResponse>({
+      pollIntervalMs: 0,
+      maxDurationMs: 3 * 60 * 60 * 1000,
+      isPending: (response) => response.status === 'in_progress',
+      logger,
+    });
+    const timeout = new Error('terminal polling timeout');
+
+    const polling = poller.poll({
+      initialResponse: { id: 'resp-expired', status: 'in_progress' },
+      retrieve,
+      extractId,
+      extractStatus,
+      deadlineAtMs: new Date('2026-08-01T03:00:00Z').getTime(),
+      formatTimeoutError: () => timeout,
+    });
+    const rejection = expect(polling).rejects.toBe(timeout);
+    await vi.runAllTimersAsync();
+    await rejection;
+    expect(retrieve).not.toHaveBeenCalled();
   });
 
   it('logs aborts that happen while waiting for the next poll', async () => {

--- a/src/test-kernel/agent/modelHandlers/BackgroundRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/BackgroundRunLifecycle.vitest.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentTrace } from '@agent/trace';
 import { BackgroundRunLifecycle } from '@agent/modelHandlers/openai/BackgroundRunLifecycle';
 import { BackgroundPoller } from '@agent/modelHandlers/support/BackgroundPoller';
+import { normalizeProviderError } from '@common/errors/sdkErrorUtils';
 import { spiedTrace } from '@test/support/spiedTrace';
 
 import type OpenAI from 'openai';
@@ -25,6 +26,10 @@ function completedResponse(id: string): Response {
     output_text: 'ok',
   } as unknown as Response;
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('BackgroundRunLifecycle.isPending / pending-id bookkeeping', () => {
   it('treats queued and in_progress as pending, everything else as terminal', () => {
@@ -117,6 +122,35 @@ describe('BackgroundRunLifecycle.tryResume', () => {
 
     expect(result).toBeNull();
     expect(lifecycle.hasPendingResume()).toBe(false);
+  });
+
+  it('does not restart the polling lifetime when the same response resumes', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-01T00:00:00Z'));
+    const lifecycle = createLifecycle();
+    const retrieve = vi.fn(async () => ({
+      id: 'resp-pending',
+      status: 'in_progress',
+    }));
+    const client = { responses: { retrieve } } as unknown as OpenAI;
+
+    await lifecycle.retrieveAndRemember(
+      client,
+      'resp-pending',
+      undefined,
+      undefined,
+    );
+    retrieve.mockClear();
+    vi.advanceTimersByTime(3 * 60 * 60 * 1000);
+
+    const timeout = await lifecycle.tryResume(client).catch((error) => error);
+    expect(timeout).toBeInstanceOf(Error);
+    expect((timeout as Error).message).toContain(
+      'exceeded maximum polling duration',
+    );
+    expect(normalizeProviderError(timeout).userRetryable).toBe(false);
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(lifecycle.getPendingId()).toBe('resp-pending');
   });
 });
 

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import {
   classifyOpenAIBackgroundResumeError,
   createOpenAIBackgroundPollingError,
+  createOpenAIBackgroundPollingTimeoutError,
   createOpenAIBackgroundTerminalError,
   normalizeOpenAIResponseError,
 } from '@agent/modelHandlers/openai/openAIResponseErrors';
@@ -83,6 +84,21 @@ describe('OpenAI Responses error normalization', () => {
     expect(normalized.statusCode).toBeUndefined();
     expect(normalized.requestId).toBe('req_poll');
     expect(normalized.userRetryable).toBe(true);
+  });
+
+  it('classifies an exhausted polling lifetime as non-retryable', () => {
+    const error = createOpenAIBackgroundPollingTimeoutError(
+      'resp_expired',
+      10_800_000,
+      'openai',
+    );
+
+    const providerError = normalizeProviderError(error);
+
+    expect(providerError.userRetryable).toBe(false);
+    expect(providerError.provider).toBe('openai');
+    expect(providerError.message).toContain('resp_expired');
+    expect(providerError.message).not.toContain('Retry later');
   });
 
   it('classifies internally tagged context-window overflows as non-retryable', () => {


### PR DESCRIPTION
## Summary

- preserve the original three-hour polling deadline when an OpenAI background response is resumed after a transient failure
- stop automatic and manual retry batches once that deadline has expired, before making another provider request
- let the shared background poller preserve provider-specific terminal timeout errors from an earlier polling lifetime

This is a bounded part of #9532. It prevents an approved retry from restarting the lifetime of the same OpenAI background response. Provider-lifetime handling for other background APIs and broader retry telemetry remain separate work.

## User-visible changes

An OpenAI background response now has one finite polling window. Reconnecting to the same response after a temporary failure no longer grants it another three hours, and an expired response is reported as terminal rather than being offered another ineffective retry.

## Design

`BackgroundRunLifecycle` owns the response identity and its absolute deadline together. The shared `BackgroundPoller` accepts that deadline without acquiring responsibility for persistence or provider-specific policy, and preserves a provider-specific error when the deadline expires. This keeps the provider lifecycle as the source of truth while allowing polling to continue across separate invocations.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm test` (8,405 passed, 4 skipped; 8,409 total)
- `npm run typecheck`
