### PR TITLE
fix(openai): close expired background lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,8 @@ All notable changes to this project will be documented in this file.
 
 - **OpenAI background responses keep one polling deadline across retries** —
   reconnecting to the same response no longer restarts its three-hour polling
-  window.
+  window. Once that window expires, TeXRA stops automatic retries and permits
+  an explicit retry to start a new response.
 - **Automatic model retry settings are bounded** — the retry setting now
   accepts zero to five additional attempts after the initial request. Invalid
   stored values fall back to the documented default instead of creating an

--- a/src/agent/modelHandlers/openai/BackgroundRunLifecycle.ts
+++ b/src/agent/modelHandlers/openai/BackgroundRunLifecycle.ts
@@ -99,7 +99,7 @@ export class BackgroundRunLifecycle {
   private rememberPending(
     responseId: string,
     retrieveParams?: ResponseRetrieveParamsNonStreaming,
-  ): void {
+  ): number {
     if (
       this.pendingResponseId !== responseId ||
       this.pendingDeadlineAtMs === null
@@ -108,14 +108,30 @@ export class BackgroundRunLifecycle {
     }
     this.pendingResponseId = responseId;
     this.pendingRetrieveParams = retrieveParams;
+    return this.pendingDeadlineAtMs;
   }
 
   private pollingTimeoutError(responseId: string): Error {
+    this.clearPending();
     return createOpenAIBackgroundPollingTimeoutError(
       responseId,
       BACKGROUND_MAX_DURATION_MS,
       this.deps.provider,
     );
+  }
+
+  private assertCanPoll(
+    responseId: string,
+    deadlineAtMs: number,
+    signal?: AbortSignal,
+  ): void {
+    if (signal?.aborted) {
+      this.clearPending();
+      signal.throwIfAborted();
+    }
+    if (Date.now() >= deadlineAtMs) {
+      throw this.pollingTimeoutError(responseId);
+    }
   }
 
   /**
@@ -133,12 +149,8 @@ export class BackgroundRunLifecycle {
       return null;
     }
     const retrieveParams = this.pendingRetrieveParams;
-    if (
-      this.pendingDeadlineAtMs !== null &&
-      Date.now() >= this.pendingDeadlineAtMs
-    ) {
-      throw this.pollingTimeoutError(pendingId);
-    }
+    const deadlineAtMs = this.rememberPending(pendingId, retrieveParams);
+    this.assertCanPoll(pendingId, deadlineAtMs, signal);
 
     this.logger.debug(
       `Resuming polling for pending background response ${pendingId}`,
@@ -160,6 +172,7 @@ export class BackgroundRunLifecycle {
         this.clearPending();
         throw err;
       }
+      this.assertCanPoll(pendingId, deadlineAtMs, signal);
       // Transient failures (no status / 5xx / 429 / 408) — the background
       // response is likely still alive server-side, so retain the ID and
       // rethrow so the outer retry resumes the same ID. Definitive failures
@@ -170,9 +183,7 @@ export class BackgroundRunLifecycle {
       // on a relay-wrapped 404 and loop until retries are exhausted.
       const { providerError, shouldRetainPendingResponse } =
         classifyOpenAIBackgroundResumeError(err, this.deps.provider);
-      if (shouldRetainPendingResponse) {
-        throw err;
-      }
+      if (shouldRetainPendingResponse) throw err;
       this.logger.warn(
         "Couldn't resume the pending OpenAI response; will start a new request.",
         {
@@ -186,6 +197,8 @@ export class BackgroundRunLifecycle {
       this.clearPending();
       return null;
     }
+
+    this.assertCanPoll(pendingId, deadlineAtMs, signal);
 
     // Check the status of the retrieved response
     if (this.isPending(pendingResponse)) {
@@ -250,9 +263,11 @@ export class BackgroundRunLifecycle {
     retrieveParams: ResponseRetrieveParamsNonStreaming | undefined,
     signal: AbortSignal | undefined,
   ): Promise<Response> {
-    this.rememberPending(responseId, retrieveParams);
+    const deadlineAtMs = this.rememberPending(responseId, retrieveParams);
+    this.assertCanPoll(responseId, deadlineAtMs, signal);
+    let response: Response;
     try {
-      return await client.responses.retrieve(
+      response = await client.responses.retrieve(
         responseId,
         retrieveParams,
         signal ? { signal } : undefined,
@@ -263,6 +278,7 @@ export class BackgroundRunLifecycle {
         this.clearPending();
         throw err;
       }
+      this.assertCanPoll(responseId, deadlineAtMs, signal);
       const { shouldRetainPendingResponse } =
         classifyOpenAIBackgroundResumeError(err, this.deps.provider);
       if (!shouldRetainPendingResponse) {
@@ -270,6 +286,8 @@ export class BackgroundRunLifecycle {
       }
       throw err;
     }
+    this.assertCanPoll(responseId, deadlineAtMs, signal);
+    return response;
   }
 
   /**
@@ -289,7 +307,11 @@ export class BackgroundRunLifecycle {
 
     // Track which response is being polled so retry logic can resume via
     // tryResume instead of creating a new request.
-    this.rememberPending(initialResponse.id, retrieveParams);
+    const deadlineAtMs = this.rememberPending(
+      initialResponse.id,
+      retrieveParams,
+    );
+    this.assertCanPoll(initialResponse.id, deadlineAtMs, signal);
 
     let pollStats: BackgroundPollStats | undefined;
     const polled = (await this.backgroundPoller.poll({
@@ -334,7 +356,7 @@ export class BackgroundRunLifecycle {
       extractId: (r) => r.id,
       extractStatus: (r) => r.status ?? 'unknown',
       signal,
-      deadlineAtMs: this.pendingDeadlineAtMs ?? undefined,
+      deadlineAtMs,
       resourceLabel: 'response',
       providerLabel: 'OpenAI',
       onAbort: () => this.clearPending(),
@@ -364,6 +386,7 @@ export class BackgroundRunLifecycle {
         incomplete: polled.incomplete_details ?? undefined,
       },
     });
+    this.clearPending();
     throw createOpenAIBackgroundTerminalError(polled, this.deps.provider);
   }
 }

--- a/src/agent/modelHandlers/openai/openAIResponseErrors.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseErrors.ts
@@ -1,6 +1,6 @@
 // Local imports
 import {
-  attachProviderError,
+  attachManualRetryOnlyError,
   isRetryableStatusCode,
   normalizeProviderError,
 } from '@common/errors/sdkErrorUtils';
@@ -86,21 +86,18 @@ export function createOpenAIBackgroundPollingError(
   return pollingError;
 }
 
-/** Create a terminal error for a background response whose polling lifetime ended. */
+/** Create a manual-retry-only error for an exhausted background response lifetime. */
 export function createOpenAIBackgroundPollingTimeoutError(
   responseId: string,
   maxDurationMs: number,
   provider: string,
 ): Error {
-  const error = new Error(
+  const error: RequestIdTaggedError = new Error(
     `OpenAI response ${responseId} exceeded maximum polling duration of ${maxDurationMs} ms. ` +
-      `Inspect or cancel the job with client.responses.cancel("${responseId}").`,
+      `Retry explicitly to start a new response, or cancel the old job with client.responses.cancel("${responseId}").`,
   );
-  attachProviderError(error, {
-    message: error.message,
-    provider,
-    userRetryable: false,
-  });
+  error.provider = provider;
+  attachManualRetryOnlyError(error);
   return error;
 }
 

--- a/src/agent/modelHandlers/support/BackgroundPoller.ts
+++ b/src/agent/modelHandlers/support/BackgroundPoller.ts
@@ -176,9 +176,37 @@ export class BackgroundPoller<TResponse> {
     const logger = () => resolveLogger(this.config.logger);
     const startTime =
       deadlineAtMs === undefined ? Date.now() : deadlineAtMs - maxDurationMs;
-    const deadline = deadlineAtMs ?? startTime + maxDurationMs;
     let current = initialResponse;
     let pollCount = 0;
+
+    const throwIfTimedOut = (response: TResponse): void => {
+      const now = Date.now();
+      const elapsedMs = now - startTime;
+      const timedOut =
+        deadlineAtMs === undefined
+          ? elapsedMs >= maxDurationMs
+          : now >= deadlineAtMs;
+      if (!timedOut) return;
+
+      const stats = {
+        responseId,
+        status: extractStatus(response),
+        pollCount,
+        elapsedMs,
+      };
+      logger().error(
+        `${providerLabel} ${resourceLabel} ${responseId} exceeded maximum polling duration while pending`,
+        { data: { ...stats, maxDurationMs } },
+      );
+      const timeout =
+        options.formatTimeoutError?.({
+          ...stats,
+          maxDurationMs,
+          response,
+        }) ??
+        `${providerLabel} ${resourceLabel} ${responseId} exceeded maximum polling duration of ${maxDurationMs} ms.`;
+      throw timeout instanceof Error ? timeout : new Error(timeout);
+    };
 
     const initialStatus = extractStatus(current);
     logger().debug(
@@ -227,30 +255,24 @@ export class BackgroundPoller<TResponse> {
           throw err;
         }
 
-        const elapsedMs = Date.now() - startTime;
-        const status = extractStatus(current);
-        if (Date.now() >= deadline) {
-          const stats = { responseId, status, pollCount, elapsedMs };
-          logger().error(
-            `${providerLabel} ${resourceLabel} ${responseId} exceeded maximum polling duration while pending`,
-            {
-              data: {
-                ...stats,
-                maxDurationMs,
-              },
-            },
-          );
-          const timeout =
-            options.formatTimeoutError?.({
-              ...stats,
-              maxDurationMs,
-              response: current,
-            }) ??
-            `${providerLabel} ${resourceLabel} ${responseId} exceeded maximum polling duration of ${maxDurationMs} ms.`;
-          throw timeout instanceof Error ? timeout : new Error(timeout);
-        }
+        if (deadlineAtMs !== undefined) signal?.throwIfAborted();
+        throwIfTimedOut(current);
 
-        current = await retrieve(responseId, signal);
+        let retrieved: TResponse;
+        try {
+          retrieved = await retrieve(responseId, signal);
+        } catch (err) {
+          if (deadlineAtMs !== undefined && !isUserAbort(err)) {
+            signal?.throwIfAborted();
+            throwIfTimedOut(current);
+          }
+          throw err;
+        }
+        if (deadlineAtMs !== undefined) {
+          signal?.throwIfAborted();
+          throwIfTimedOut(retrieved);
+        }
+        current = retrieved;
 
         const polledStatus = extractStatus(current);
         logger().debug(

--- a/src/common/errors/sdkError/errorMetadata.ts
+++ b/src/common/errors/sdkError/errorMetadata.ts
@@ -103,6 +103,12 @@ const missingApiKeyErrorMarker = createErrorMarker('missingApiKeyError');
 export const attachMissingApiKeyError = missingApiKeyErrorMarker.attach;
 export const hasMissingApiKeyErrorMarker = missingApiKeyErrorMarker.has;
 
+const manualRetryOnlyErrorMarker = createErrorMarker('manualRetryOnlyError');
+
+/** Marks a user-retryable failure that must not repeat automatically. */
+export const attachManualRetryOnlyError = manualRetryOnlyErrorMarker.attach;
+export const hasManualRetryOnlyErrorMarker = manualRetryOnlyErrorMarker.has;
+
 export const providerErrorMetadata =
   createErrorMetadata<ProviderError>('providerError');
 

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -25,6 +25,7 @@ import {
   detectPartialText,
   detectSdkErrorMetadata,
   detectStreamDiagnostics,
+  hasManualRetryOnlyErrorMarker,
   providerErrorMetadata,
 } from './errorMetadata';
 import {
@@ -625,7 +626,13 @@ export function isUnauthorizedProviderError(formatted: ProviderError): boolean {
 
 /** Whether repeating the same provider request can recover without user action. */
 export function isProviderErrorAutoRetryable(err: unknown): boolean {
-  if (isUserAbort(err) || isContextWindowError(err)) return false;
+  if (
+    isUserAbort(err) ||
+    isContextWindowError(err) ||
+    hasManualRetryOnlyErrorMarker(err)
+  ) {
+    return false;
+  }
 
   const formatted = normalizeProviderError(err);
   return (

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -22,6 +22,7 @@ export {
   hasContextWindowErrorMarker,
   attachMissingApiKeyError,
   hasMissingApiKeyErrorMarker,
+  attachManualRetryOnlyError,
 } from './sdkError/errorMetadata';
 
 export { handleStreamingFailure } from './sdkError/streamFailure';

--- a/src/test-kernel/agent/modelHandlers/BackgroundPoller.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/BackgroundPoller.vitest.ts
@@ -117,6 +117,132 @@ describe('BackgroundPoller', () => {
     expect(retrieve).not.toHaveBeenCalled();
   });
 
+  it('returns the timeout error when retrieval rejects at the deadline', async () => {
+    vi.useFakeTimers({ now: new Date('2026-08-01T00:00:00.000Z') });
+    const deadlineAtMs = Date.now() + 1;
+    const retrieve = vi.fn(async () => {
+      vi.setSystemTime(deadlineAtMs);
+      throw new Error('socket hang up');
+    });
+    const poller = new BackgroundPoller<TestResponse>({
+      pollIntervalMs: 0,
+      maxDurationMs: 1000,
+      isPending: (response) => response.status === 'in_progress',
+      logger: trace(),
+    });
+    const timeout = new Error('canonical polling timeout');
+
+    const polling = poller.poll({
+      initialResponse: { id: 'resp-late', status: 'in_progress' },
+      retrieve,
+      extractId,
+      extractStatus,
+      deadlineAtMs,
+      formatTimeoutError: () => timeout,
+    });
+    const rejection = expect(polling).rejects.toBe(timeout);
+    await vi.advanceTimersByTimeAsync(0);
+
+    await rejection;
+    expect(retrieve).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a retrieval result that arrives at the deadline', async () => {
+    vi.useFakeTimers({ now: new Date('2026-08-01T00:00:00.000Z') });
+    const deadlineAtMs = Date.now() + 1;
+    const retrieve = vi.fn(async () => {
+      vi.setSystemTime(deadlineAtMs);
+      return { id: 'resp-late-result', status: 'completed' };
+    });
+    const poller = new BackgroundPoller<TestResponse>({
+      pollIntervalMs: 0,
+      maxDurationMs: 1000,
+      isPending: (response) => response.status === 'in_progress',
+      logger: trace(),
+    });
+
+    const polling = poller.poll({
+      initialResponse: { id: 'resp-late-result', status: 'in_progress' },
+      retrieve,
+      extractId,
+      extractStatus,
+      deadlineAtMs,
+    });
+    const rejection = expect(polling).rejects.toThrow(
+      'exceeded maximum polling duration',
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    await rejection;
+    expect(retrieve).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['fulfills', false],
+    ['rejects', true],
+  ])(
+    'preserves cancellation when a deadline-bound retrieval %s late',
+    async (_label, rejects) => {
+      vi.useFakeTimers({ now: new Date('2026-08-01T00:00:00.000Z') });
+      const controller = new AbortController();
+      const deadlineAtMs = Date.now() + 1;
+      const poller = new BackgroundPoller<TestResponse>({
+        pollIntervalMs: 0,
+        maxDurationMs: 1000,
+        isPending: (response) => response.status === 'in_progress',
+        logger: trace(),
+      });
+
+      const polling = poller.poll({
+        initialResponse: { id: 'resp-aborted-late', status: 'in_progress' },
+        retrieve: vi.fn(async () => {
+          controller.abort();
+          vi.setSystemTime(deadlineAtMs);
+          if (rejects) throw new Error('socket hang up');
+          return { id: 'resp-aborted-late', status: 'completed' };
+        }),
+        extractId,
+        extractStatus,
+        signal: controller.signal,
+        deadlineAtMs,
+      });
+      const rejection = expect(polling).rejects.toMatchObject({
+        name: 'AbortError',
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      await rejection;
+    },
+  );
+
+  it('times out the default poller exactly at its duration boundary', async () => {
+    vi.useFakeTimers({ now: new Date('2026-08-01T00:00:00.000Z') });
+    const retrieve = vi.fn(async () => ({
+      id: 'resp-boundary',
+      status: 'completed',
+    }));
+    const poller = new BackgroundPoller<TestResponse>({
+      pollIntervalMs: 0,
+      maxDurationMs: 0,
+      isPending: (response) => response.status === 'in_progress',
+      logger: trace(),
+    });
+
+    const polling = poller.poll({
+      initialResponse: { id: 'resp-boundary', status: 'in_progress' },
+      retrieve,
+      extractId,
+      extractStatus,
+    });
+    const rejection = expect(polling).rejects.toThrow(
+      'exceeded maximum polling duration',
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    await rejection;
+    expect(retrieve).not.toHaveBeenCalled();
+  });
+
   it('logs aborts that happen while waiting for the next poll', async () => {
     const logger = trace();
     const controller = new AbortController();

--- a/src/test-kernel/agent/modelHandlers/BackgroundRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/BackgroundRunLifecycle.vitest.ts
@@ -3,7 +3,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AgentTrace } from '@agent/trace';
 import { BackgroundRunLifecycle } from '@agent/modelHandlers/openai/BackgroundRunLifecycle';
 import { BackgroundPoller } from '@agent/modelHandlers/support/BackgroundPoller';
-import { normalizeProviderError } from '@common/errors/sdkErrorUtils';
+import {
+  isProviderErrorAutoRetryable,
+  normalizeProviderError,
+} from '@common/errors/sdkErrorUtils';
 import { spiedTrace } from '@test/support/spiedTrace';
 
 import type OpenAI from 'openai';
@@ -26,6 +29,8 @@ function completedResponse(id: string): Response {
     output_text: 'ok',
   } as unknown as Response;
 }
+
+const MAX_BACKGROUND_DURATION_MS = 3 * 60 * 60 * 1000;
 
 afterEach(() => {
   vi.useRealTimers();
@@ -141,16 +146,17 @@ describe('BackgroundRunLifecycle.tryResume', () => {
       undefined,
     );
     retrieve.mockClear();
-    vi.advanceTimersByTime(3 * 60 * 60 * 1000);
+    vi.advanceTimersByTime(MAX_BACKGROUND_DURATION_MS);
 
     const timeout = await lifecycle.tryResume(client).catch((error) => error);
     expect(timeout).toBeInstanceOf(Error);
     expect((timeout as Error).message).toContain(
       'exceeded maximum polling duration',
     );
-    expect(normalizeProviderError(timeout).userRetryable).toBe(false);
+    expect(normalizeProviderError(timeout).userRetryable).toBe(true);
+    expect(isProviderErrorAutoRetryable(timeout)).toBe(false);
     expect(retrieve).not.toHaveBeenCalled();
-    expect(lifecycle.getPendingId()).toBe('resp-pending');
+    expect(lifecycle.getPendingId()).toBeNull();
   });
 });
 
@@ -194,6 +200,34 @@ describe('BackgroundRunLifecycle.retrieveAndRemember', () => {
     ).rejects.toThrow('not found');
     expect(lifecycle.hasPendingResume()).toBe(false);
   });
+
+  it('replaces a transient failure with the timeout when retrieval settles late', async () => {
+    vi.useFakeTimers({ now: new Date('2026-08-01T00:00:00.000Z') });
+    const lifecycle = createLifecycle();
+    const retrieve = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('socket hang up'))
+      .mockImplementationOnce(async () => {
+        vi.setSystemTime(Date.now() + 2);
+        throw new Error('socket hang up');
+      });
+    const client = { responses: { retrieve } } as unknown as OpenAI;
+
+    await expect(
+      lifecycle.retrieveAndRemember(client, 'resp-late', undefined, undefined),
+    ).rejects.toThrow('socket hang up');
+    vi.advanceTimersByTime(MAX_BACKGROUND_DURATION_MS - 1);
+
+    const timeout = await lifecycle.tryResume(client).catch((error) => error);
+    expect(timeout).toBeInstanceOf(Error);
+    expect((timeout as Error).message).toContain(
+      'exceeded maximum polling duration',
+    );
+    expect(normalizeProviderError(timeout).userRetryable).toBe(true);
+    expect(isProviderErrorAutoRetryable(timeout)).toBe(false);
+    expect(retrieve).toHaveBeenCalledTimes(2);
+    expect(lifecycle.hasPendingResume()).toBe(false);
+  });
 });
 
 describe('BackgroundRunLifecycle.waitForCompletion', () => {
@@ -235,5 +269,6 @@ describe('BackgroundRunLifecycle.waitForCompletion', () => {
         status: 'in_progress',
       } as Response),
     ).rejects.toThrow();
+    expect(lifecycle.hasPendingResume()).toBe(false);
   });
 });

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -33,7 +33,9 @@ import {
   attachContextWindowError,
   hasContextWindowErrorMarker,
   isContextWindowError,
+  isProviderErrorAutoRetryable,
   isUserAbort,
+  normalizeProviderError,
 } from '@common/errors/sdkErrorUtils';
 import type { ToolDefinition } from '@model/ToolDefinition';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
@@ -268,12 +270,13 @@ type BackgroundLifecycleInternals = {
     status?: string | null;
   }>;
   pendingResponseId: string | null;
-  tryResume(client: OpenAI, signal?: AbortSignal): Promise<unknown>;
-  waitForCompletion(
+  retrieveAndRemember(
     client: OpenAI,
-    initialResponse: { id?: string; status?: string | null },
-    signal?: AbortSignal,
+    responseId: string,
+    retrieveParams: undefined,
+    signal: undefined,
   ): Promise<unknown>;
+  tryResume(client: OpenAI, signal?: AbortSignal): Promise<unknown>;
 };
 
 function backgroundLifecycleInternals(
@@ -1611,23 +1614,56 @@ describe('ModelHandlerOpenAIResponse background abort handling', () => {
     assert.equal(target.pendingResponseId, 'resp_pending_transient');
   });
 
-  it('surfaces background polling timeouts', async () => {
-    const handler = createBackgroundAbortHandler();
-    const target = backgroundLifecycleInternals(handler);
-    target.backgroundPoller = new BackgroundPoller({
-      pollIntervalMs: 1,
-      maxDurationMs: 0,
-      isPending: (response) => response.status === 'in_progress',
-      logger: spiedTrace(),
-    });
+  it('starts a replacement only after an explicit retry of an expired response', async () => {
+    vi.useFakeTimers({ now: new Date('2026-08-01T00:00:00.000Z') });
+    try {
+      const handler = createHandler();
+      const lifecycle = backgroundLifecycleInternals(handler);
+      const retrieve = vi.fn(async () => {
+        throw new Error('socket hang up');
+      });
+      const create = vi.fn(async () =>
+        createResponse('resp-replacement', { input_tokens: 12 }),
+      );
+      const client = { responses: { retrieve, create } } as unknown as OpenAI;
 
-    const thrown = await target
-      .waitForCompletion(
-        { responses: { retrieve: vi.fn() } } as unknown as OpenAI,
-        { id: 'resp_timeout', status: 'in_progress' },
-      )
-      .catch((err: unknown) => err);
+      await assert.rejects(
+        lifecycle.retrieveAndRemember(
+          client,
+          'resp-expired',
+          undefined,
+          undefined,
+        ),
+        /socket hang up/,
+      );
+      vi.advanceTimersByTime(3 * 60 * 60 * 1000);
 
-    assert.ok(thrown instanceof Error);
+      const timeout = await handler
+        .createResponse({
+          client,
+          messages: createMessages(1),
+          temperature: 0,
+        })
+        .catch((error: unknown) => error);
+
+      assert.ok(timeout instanceof Error);
+      assert.equal(normalizeProviderError(timeout).userRetryable, true);
+      assert.equal(isProviderErrorAutoRetryable(timeout), false);
+      assert.equal(create.mock.calls.length, 0);
+      assert.equal(retrieve.mock.calls.length, 1);
+      assert.equal(lifecycle.pendingResponseId, null);
+
+      const result = await handler.createResponse({
+        client,
+        messages: createMessages(1),
+        temperature: 0,
+      });
+
+      assert.equal(result.response.id, 'resp-replacement');
+      assert.equal(create.mock.calls.length, 1);
+      assert.equal(retrieve.mock.calls.length, 1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
@@ -13,6 +13,7 @@ import {
 import {
   attachContextWindowError,
   formatProviderHttpError,
+  isProviderErrorAutoRetryable,
   normalizeProviderError,
 } from '@common/errors/sdkErrorUtils';
 
@@ -86,7 +87,7 @@ describe('OpenAI Responses error normalization', () => {
     expect(normalized.userRetryable).toBe(true);
   });
 
-  it('classifies an exhausted polling lifetime as non-retryable', () => {
+  it('requires an explicit retry after the polling lifetime expires', () => {
     const error = createOpenAIBackgroundPollingTimeoutError(
       'resp_expired',
       10_800_000,
@@ -95,10 +96,11 @@ describe('OpenAI Responses error normalization', () => {
 
     const providerError = normalizeProviderError(error);
 
-    expect(providerError.userRetryable).toBe(false);
+    expect(providerError.userRetryable).toBe(true);
+    expect(isProviderErrorAutoRetryable(error)).toBe(false);
     expect(providerError.provider).toBe('openai');
     expect(providerError.message).toContain('resp_expired');
-    expect(providerError.message).not.toContain('Retry later');
+    expect(providerError.message).toContain('Retry explicitly');
   });
 
   it('classifies internally tagged context-window overflows as non-retryable', () => {

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -46,6 +46,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import type { AuthTokenProvider } from '@auth/TokenProvider';
 import {
   attachContextWindowError,
+  attachManualRetryOnlyError,
   attachSdkErrorMetadata,
 } from '@common/errors/sdkErrorUtils';
 import { installTexraModelAccess } from '@controllers/modelAccess/installTexraModelAccess';
@@ -458,6 +459,16 @@ describe('RetryState', () => {
     tagOpenAISdkError(error, 'openai');
 
     expect(node.shouldAutoRetry(error)).toBe(true);
+  });
+
+  it('does not automatically repeat a manual-retry-only failure', () => {
+    const node = new ExposedRetryNode();
+    const error = Object.assign(new Error('retry explicitly'), {
+      provider: 'openai',
+    });
+    attachManualRetryOnlyError(error);
+
+    expect(node.shouldAutoRetry(error)).toBe(false);
   });
 
   it('delays an unclassified retryable failure before the next attempt', async () => {


### PR DESCRIPTION
## Summary

PR #9566 established one polling deadline for an OpenAI background response. This follow-up completes the expiry behavior:

- clear the expired response from resumable state before reporting its timeout
- permit a later explicit retry to create a replacement, while preventing automatic retries from doing so
- enforce the deadline after retrieval settles, including late successes and transient failures
- preserve cancellation when retrieval and the deadline occur together
- clear failed, cancelled, and incomplete terminal response state
- retain the existing `BackgroundPoller` interface and exact relative-duration boundary

The implementation uses one error marker to distinguish errors that a user may retry from errors that the runtime may repeat automatically. This keeps retry policy separate from OpenAI lifecycle ownership and avoids adding another retry loop.

## Verification

- full formatter
- workspace and test-kernel type checks
- extension host, trace viewer, and three webview bundles
- full ESLint run
- full Vitest suite: 8,416 passed, 4 skipped
- focused deadline, late-result, late-failure, cancellation, retry-classification, and explicit-replacement tests
- `git diff --check`

Part of #9532. Google repair, telemetry, and durable lifecycle persistence remain outside this PR.