### PR TITLE
fix(google): resume background interactions across retries

### DIFF
--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -413,7 +413,10 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
   }
 
   public override isBackgroundModeActive(): boolean {
-    return this.useBackgroundMode(this.serverStateEnabled());
+    return (
+      this.pendingBackgroundInteraction !== null ||
+      this.useBackgroundMode(this.serverStateEnabled())
+    );
   }
 
   /**
@@ -1250,7 +1253,12 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     // active, getStreamingConfig() already returns false, so useStreaming is
     // false and the streaming/non-streaming branches stay byte-identical when
     // background is off.
-    const useBackground = this.useBackgroundMode(stateful);
+    // A known remote interaction takes precedence over current settings: once
+    // submitted, disabling background or server state must not replace it with a
+    // foreground create. New submissions still obey the normal eligibility gate.
+    const useBackground =
+      this.pendingBackgroundInteraction !== null ||
+      this.useBackgroundMode(stateful);
     // super.getStreamingConfig() (not this.) — the override would recompute
     // background mode (extra config reads) when we already know useBackground.
     const useStreaming = !useBackground && super.getStreamingConfig();
@@ -1416,9 +1424,11 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     requestOptions: InteractionsRequestOptions,
     signal: AbortSignal | undefined,
   ): Promise<CreateResponseResult<GoogleGenAIInteraction, Step>> {
-    // Background REQUIRES server-side state — defense-in-depth assertion of the
-    // gate invariant (the gate already returns false when !stateful).
-    if (!stateful) {
+    const pending = this.pendingBackgroundInteraction;
+    // A NEW background submission requires server-side state. A known pending
+    // interaction was already submitted with store:true and must still be
+    // retrieved if the setting changed while its poll was being retried.
+    if (!stateful && !pending) {
       throw new Error(
         'Background mode requires server-side state (store:true); refusing to ' +
           'submit a background interaction in stateless mode.',
@@ -1426,7 +1436,6 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     }
 
     let initial: GoogleGenAIInteraction;
-    const pending = this.pendingBackgroundInteraction;
     if (pending) {
       if (Date.now() >= pending.deadlineAtMs) {
         this.pendingBackgroundInteraction = null;
@@ -1474,7 +1483,14 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
 
     // Capture the chain anchor from the COMPLETED polled interaction (NOT the
     // submit), so the next turn chains onto a server-retained, completed id.
-    this.finalizeChain(completed, totalStepCount, stateful);
+    // If server state was disabled while this interaction was pending, discard
+    // the old chain instead: a later re-enable must full-resend rather than skip
+    // over intervening stateless turns.
+    if (stateful) {
+      this.finalizeChain(completed, totalStepCount, true);
+    } else {
+      this.invalidateChain();
+    }
     return { response: completed };
   }
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -28,11 +28,14 @@ import type {
   TokenCountOptions,
 } from '@agent/types/ModelHandlerContracts';
 import {
-  detectStatusCode,
+  attachManualRetryOnlyError,
   attachPartialText,
-  takeTail,
+  detectStatusCode,
+  isUserAbort,
   PARTIAL_TEXT_TAIL_MAX,
+  takeTail,
 } from '@common/errors/sdkErrorUtils';
+import { hasManualRetryOnlyErrorMarker } from '@common/errors/sdkError/errorMetadata';
 import type { ToolDefinition } from '@model/ToolDefinition';
 import { composeLongRunningModelDispatcher } from '@platform/defaults/longRunningModelTransport';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
@@ -91,9 +94,9 @@ type CreateModelInteractionParamsNonStreaming =
   Interactions.CreateModelInteractionParamsNonStreaming;
 // `InteractionStatus` is internal (not re-exported under the `Interactions`
 // namespace), so derive it from the public `Interaction.status` field instead of
-// referencing the unexported alias. Union (genai.d.ts): 'in_progress' |
-// 'requires_action' | 'completed' | 'failed' | 'cancelled' | 'incomplete' |
-// 'budget_exceeded' | (string & {}).
+// referencing the unexported alias. Union (genai.d.ts): 'queued' |
+// 'in_progress' | 'requires_action' | 'completed' | 'failed' | 'cancelled' |
+// 'incomplete' | 'budget_exceeded' | (string & {}).
 type InteractionStatus = Interactions.Interaction['status'];
 // The non-streaming get param type is `Omit<GetInteractionByIdRequest,'id'> &
 // { stream?: false }` — the `id` is the positional first arg, so it is NOT
@@ -282,6 +285,11 @@ type InteractionsRequestOptions = {
   fetchOptions: RequestInit;
 };
 
+interface PendingBackgroundInteraction {
+  readonly id: string;
+  readonly deadlineAtMs: number;
+}
+
 export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
   Step,
   Usage | null,
@@ -308,25 +316,19 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
   private static readonly BACKGROUND_GET_PARAMS: InteractionGetParamsNonStreaming =
     { stream: false };
 
-  /**
-   * Non-terminal Interaction statuses — polling continues while the status is in
-   * this set, and every other status is treated as terminal. Interactions has no
-   * `queued` member (unlike OpenAI's `['queued','in_progress']`). `requires_action`
-   * is deliberately EXCLUDED so the loop stops on a tool-call turn; that status
-   * is then returned as a serviceable terminal (not an error) so any function
-   * calls reach the cycle.
-   *
-   * Verified live (gemini-3.5-flash): a `background:true` create returns
-   * `in_progress`, and the first `get()` poll returns `completed` with full
-   * steps + usage — so `['in_progress']` is the correct pending set.
-   */
+  private static readonly BACKGROUND_MAX_DURATION_MS = 3 * 60 * 60 * 1000;
+
+  /** Non-terminal statuses. `requires_action` remains serviceable terminal. */
   private static readonly BACKGROUND_PENDING_STATUSES: readonly InteractionStatus[] =
-    ['in_progress'];
+    ['queued', 'in_progress'];
+
+  private static readonly BACKGROUND_FAILURE_STATUSES: readonly InteractionStatus[] =
+    ['failed', 'cancelled', 'incomplete', 'budget_exceeded'];
 
   private readonly backgroundPoller =
     new BackgroundPoller<GoogleGenAIInteraction>({
       pollIntervalMs: 5000,
-      maxDurationMs: 3 * 60 * 60 * 1000, // 3 hours
+      maxDurationMs: ModelHandlerGoogleInteractions.BACKGROUND_MAX_DURATION_MS,
       isPending: (r) => this.isBackgroundPending(r),
       logger: () => this.logger,
     });
@@ -341,6 +343,10 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
    * this runtime fallback is the model gate.
    */
   private backgroundUnsupported = false;
+
+  /** In-memory identity and original lifetime for the current background turn. */
+  private pendingBackgroundInteraction: PendingBackgroundInteraction | null =
+    null;
 
   // ===========================================================================
   // STATEFUL chaining state (store:true + previous_interaction_id)
@@ -1317,7 +1323,11 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
       // HTTP 400) ⇒ disable background for this instance and retry on the
       // streaming / non-streaming path. Bounded: backgroundUnsupported makes
       // useBackgroundMode() false on the retry, so it cannot re-hit this error.
-      if (useBackground && isBackgroundUnsupportedError(error)) {
+      if (
+        useBackground &&
+        this.pendingBackgroundInteraction === null &&
+        isBackgroundUnsupportedError(error)
+      ) {
         this.logger.warn(
           `Model ${this.config.fullName} does not support background interactions; ` +
             `falling back to foreground for this run.`,
@@ -1332,6 +1342,7 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
       if (
         stateful &&
         this.chainedInteractionId !== null &&
+        !hasManualRetryOnlyErrorMarker(error) &&
         isStaleInteractionChainError(error)
       ) {
         this.logger.debug(
@@ -1414,29 +1425,49 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
       );
     }
 
-    // background:true forces store:true (already true under `stateful`).
-    const submitParams = {
-      ...commonParams,
-      stream: false as const,
-      store: true,
-      background: true,
-    };
-    logProgressStatus(
-      this.logger,
-      'Running Google Interactions in background mode; polling for completion ' +
-        '(this may take longer than usual).',
-    );
-    // SMOKE-TEST: the initial status of a background:true create, and whether
-    // background:true is accepted with store:true (and rejected/ignored with
-    // store:false), are unconfirmed offline; verify on a real-key run.
-    const submitted = await client.interactions.create(
-      submitParams,
-      requestOptions,
-    );
+    let initial: GoogleGenAIInteraction;
+    const pending = this.pendingBackgroundInteraction;
+    if (pending) {
+      if (Date.now() >= pending.deadlineAtMs) {
+        this.pendingBackgroundInteraction = null;
+        await this.cancelBackgroundInteraction(client, pending.id);
+        throw this.createBackgroundTimeoutError(pending.id);
+      }
+      initial = await this.retrieveBackgroundInteraction(
+        client,
+        pending.id,
+        requestOptions,
+      );
+    } else {
+      // background:true forces store:true (already true under `stateful`).
+      const submitParams = {
+        ...commonParams,
+        stream: false as const,
+        store: true,
+        background: true,
+      };
+      logProgressStatus(
+        this.logger,
+        'Running Google Interactions in background mode; polling for completion ' +
+          '(this may take longer than usual).',
+      );
+      // SMOKE-TEST: the initial status of a background:true create, and whether
+      // background:true is accepted with store:true (and rejected/ignored with
+      // store:false), are unconfirmed offline; verify on a real-key run.
+      initial = await client.interactions.create(submitParams, requestOptions);
+      if (typeof initial.id === 'string') {
+        this.pendingBackgroundInteraction = {
+          id: initial.id,
+          deadlineAtMs:
+            Date.now() +
+            ModelHandlerGoogleInteractions.BACKGROUND_MAX_DURATION_MS,
+        };
+      }
+    }
 
     const completed = await this.pollBackgroundInteraction(
       client,
-      submitted,
+      initial,
       requestOptions,
       signal,
     );
@@ -1451,6 +1482,70 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     return ModelHandlerGoogleInteractions.BACKGROUND_PENDING_STATUSES.includes(
       interaction.status as InteractionStatus,
     );
+  }
+
+  private clearPendingBackgroundInteraction(interactionId: string): void {
+    if (this.pendingBackgroundInteraction?.id === interactionId) {
+      this.pendingBackgroundInteraction = null;
+    }
+  }
+
+  private createManualBackgroundError(message: string, cause?: unknown): Error {
+    const error = new Error(
+      message,
+      cause === undefined ? undefined : { cause },
+    );
+    Object.assign(error, { provider: this.config.provider });
+    attachManualRetryOnlyError(error);
+    return error;
+  }
+
+  private createBackgroundTimeoutError(interactionId: string): Error {
+    return this.createManualBackgroundError(
+      `Google Interactions background interaction ${interactionId} exceeded ` +
+        `maximum polling duration of ${ModelHandlerGoogleInteractions.BACKGROUND_MAX_DURATION_MS} ms. ` +
+        'Server-side cancellation was attempted; retry explicitly to start a new interaction.',
+    );
+  }
+
+  private async retrieveBackgroundInteraction(
+    client: GoogleGenAI,
+    interactionId: string,
+    requestOptions: InteractionsRequestOptions,
+  ): Promise<GoogleGenAIInteraction> {
+    try {
+      return await client.interactions.get(
+        interactionId,
+        ModelHandlerGoogleInteractions.BACKGROUND_GET_PARAMS,
+        requestOptions,
+      );
+    } catch (error) {
+      this.sdkErrorTagger(error, this.config.provider);
+      if (isUserAbort(error)) {
+        const shouldCancel =
+          this.pendingBackgroundInteraction?.id === interactionId;
+        this.clearPendingBackgroundInteraction(interactionId);
+        if (shouldCancel) {
+          await this.cancelBackgroundInteraction(client, interactionId);
+        }
+        throw error;
+      }
+
+      const status = detectStatusCode(error);
+      if (status === 404 || status === 410) {
+        this.clearPendingBackgroundInteraction(interactionId);
+        throw this.createManualBackgroundError(
+          `Google Interactions background interaction ${interactionId} is no longer available ` +
+            `(HTTP ${status}). Retry explicitly to start a new interaction.`,
+          error,
+        );
+      }
+
+      // Every other retrieval failure retains the known id. Retryable transport,
+      // 408/409/429, and 5xx failures can resume it automatically; non-missing
+      // 4xx and unknown failures fail closed under the existing retry policy.
+      throw error;
+    }
   }
 
   /**
@@ -1475,48 +1570,47 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     }
 
     let pollStats: BackgroundPollStats | undefined;
+    let timedOut = false;
+    let polled: GoogleGenAIInteraction;
 
-    const polled = await this.backgroundPoller.poll({
-      initialResponse: initial,
-      retrieve: async (id, sig) => {
-        const opts = sig
-          ? this.interactionsRequestOptions(sig)
-          : requestOptions;
-        try {
-          return await client.interactions.get(
+    try {
+      polled = await this.backgroundPoller.poll({
+        initialResponse: initial,
+        retrieve: (id, sig) =>
+          this.retrieveBackgroundInteraction(
+            client,
             id,
-            ModelHandlerGoogleInteractions.BACKGROUND_GET_PARAMS,
-            opts,
-          );
-        } catch (err) {
-          // Tag and rethrow — a user-abort surfaces as-is; a transient poll
-          // error (5xx/429/network) re-enters createResponse via PocketFlow's
-          // retry layer with a fresh submit (orphaned job ages out; no resume
-          // path in v0).
-          this.sdkErrorTagger(err, this.config.provider);
-          throw err;
-        }
-      },
-      extractId: (r) => r.id,
-      extractStatus: (r) => r.status ?? 'unknown',
-      signal,
-      resourceLabel: 'interaction',
-      providerLabel: 'Google Interactions',
-      onAbort: () => {
-        // Fire-and-forget cancel; do NOT await inside the listener.
-        void this.cancelBackgroundInteraction(client, interactionId);
-      },
-      formatTimeoutError: ({ responseId, maxDurationMs }) =>
-        `Google Interactions background interaction ${responseId} exceeded ` +
-        `maximum polling duration of ${maxDurationMs} ms. Cancel it with ` +
-        `client.interactions.cancel("${responseId}").`,
-      extraFinishData: (interaction) => ({
-        usage: interaction.usage ?? undefined,
-      }),
-      onFinished: (_interaction, stats) => {
-        pollStats = stats;
-      },
-    });
+            sig ? this.interactionsRequestOptions(sig) : requestOptions,
+          ),
+        extractId: (r) => r.id,
+        extractStatus: (r) => r.status ?? 'unknown',
+        signal,
+        deadlineAtMs: this.pendingBackgroundInteraction?.deadlineAtMs,
+        resourceLabel: 'interaction',
+        providerLabel: 'Google Interactions',
+        onAbort: () => {
+          this.clearPendingBackgroundInteraction(interactionId);
+          // Fire-and-forget cancel; do NOT await inside the listener.
+          void this.cancelBackgroundInteraction(client, interactionId);
+        },
+        formatTimeoutError: () => {
+          timedOut = true;
+          return this.createBackgroundTimeoutError(interactionId);
+        },
+        extraFinishData: (interaction) => ({
+          usage: interaction.usage ?? undefined,
+        }),
+        onFinished: (_interaction, stats) => {
+          pollStats = stats;
+        },
+      });
+    } catch (error) {
+      if (timedOut) {
+        this.clearPendingBackgroundInteraction(interactionId);
+        await this.cancelBackgroundInteraction(client, interactionId);
+      }
+      throw error;
+    }
 
     // `completed` and `requires_action` are both serviceable terminals: the
     // latter carries function_call steps, so return it (don't throw) and let the
@@ -1525,11 +1619,10 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     // tools, but the gate (isWorkflowMode) is not a hard guarantee, so handle it
     // rather than crash a run that does emit a call.
     if (polled.status === 'completed' || polled.status === 'requires_action') {
+      this.clearPendingBackgroundInteraction(interactionId);
       return polled;
     }
 
-    // Terminal failure: failed / cancelled / incomplete / budget_exceeded —
-    // treated uniformly as a thrown, tagged error.
     const status = polled.status ?? 'unknown';
     this.logger.error(
       'Background interaction ended with a non-completed status.',
@@ -1542,12 +1635,27 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
         },
       },
     );
-    const err = new Error(
-      `Google Interactions background interaction ${interactionId} ended with ` +
-        `status "${status}".`,
+
+    if (
+      ModelHandlerGoogleInteractions.BACKGROUND_FAILURE_STATUSES.includes(
+        status as InteractionStatus,
+      )
+    ) {
+      this.clearPendingBackgroundInteraction(interactionId);
+      throw this.createManualBackgroundError(
+        `Google Interactions background interaction ${interactionId} ended with ` +
+          `status "${status}". Retry explicitly to start a new interaction.`,
+      );
+    }
+
+    // The SDK status union is open. An unrecognized value does not prove the
+    // remote job is terminal, so retain its identity and fail closed.
+    const error = new Error(
+      `Google Interactions background interaction ${interactionId} returned ` +
+        `unknown status "${status}"; refusing to submit a replacement.`,
     );
-    this.sdkErrorTagger(err, this.config.provider);
-    throw err;
+    Object.assign(error, { provider: this.config.provider });
+    throw error;
   }
 
   /** Cancel the in-flight background interaction (best-effort; swallow errors). */

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1179,6 +1179,14 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     // leaves a later re-enable on a safe full-resend boundary.
     if (!stateful) this.invalidateChain();
 
+    const pending = this.pendingBackgroundInteraction;
+    if (pending && signal?.aborted) {
+      if (this.clearPendingBackgroundInteraction(pending.id)) {
+        void this.cancelBackgroundInteraction(client, pending.id);
+      }
+      signal.throwIfAborted();
+    }
+
     const generationConfig = this.buildGenerationConfig(endTag);
     const interactionsTools = tools?.length
       ? this.toInteractionsTools(tools)
@@ -1441,12 +1449,6 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
 
     let initial: GoogleGenAIInteraction;
     if (pending) {
-      if (signal?.aborted) {
-        if (this.clearPendingBackgroundInteraction(pending.id)) {
-          void this.cancelBackgroundInteraction(client, pending.id);
-        }
-        signal.throwIfAborted();
-      }
       if (Date.now() >= pending.deadlineAtMs) {
         this.clearPendingBackgroundInteraction(pending.id);
         await this.cancelBackgroundInteraction(client, pending.id);

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1174,6 +1174,12 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     let updatedMessages: Step[] | undefined;
 
     const stateful = this.serverStateEnabled();
+    // Observing stateless mode invalidates any prior chain immediately. This is
+    // deliberately before token work, pending retrieval, and dispatch so every
+    // exit path (including timeout, abort, terminal status, or retrieval error)
+    // leaves a later re-enable on a safe full-resend boundary.
+    if (!stateful) this.invalidateChain();
+
     const generationConfig = this.buildGenerationConfig(endTag);
     const interactionsTools = tools?.length
       ? this.toInteractionsTools(tools)
@@ -1483,14 +1489,8 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
 
     // Capture the chain anchor from the COMPLETED polled interaction (NOT the
     // submit), so the next turn chains onto a server-retained, completed id.
-    // If server state was disabled while this interaction was pending, discard
-    // the old chain instead: a later re-enable must full-resend rather than skip
-    // over intervening stateless turns.
-    if (stateful) {
-      this.finalizeChain(completed, totalStepCount, true);
-    } else {
-      this.invalidateChain();
-    }
+    // Stateless mode invalidated the chain at entry and must not establish one.
+    if (stateful) this.finalizeChain(completed, totalStepCount, true);
     return { response: completed };
   }
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -35,7 +35,6 @@ import {
   PARTIAL_TEXT_TAIL_MAX,
   takeTail,
 } from '@common/errors/sdkErrorUtils';
-import { hasManualRetryOnlyErrorMarker } from '@common/errors/sdkError/errorMetadata';
 import type { ToolDefinition } from '@model/ToolDefinition';
 import { composeLongRunningModelDispatcher } from '@platform/defaults/longRunningModelTransport';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
@@ -1356,7 +1355,6 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
       if (
         stateful &&
         this.chainedInteractionId !== null &&
-        !hasManualRetryOnlyErrorMarker(error) &&
         isStaleInteractionChainError(error)
       ) {
         this.logger.debug(
@@ -1443,8 +1441,14 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
 
     let initial: GoogleGenAIInteraction;
     if (pending) {
+      if (signal?.aborted) {
+        if (this.clearPendingBackgroundInteraction(pending.id)) {
+          void this.cancelBackgroundInteraction(client, pending.id);
+        }
+        signal.throwIfAborted();
+      }
       if (Date.now() >= pending.deadlineAtMs) {
-        this.pendingBackgroundInteraction = null;
+        this.clearPendingBackgroundInteraction(pending.id);
         await this.cancelBackgroundInteraction(client, pending.id);
         throw this.createBackgroundTimeoutError(pending.id);
       }
@@ -1480,9 +1484,12 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
       }
     }
 
+    const lifecycle = pending ?? this.pendingBackgroundInteraction;
     const completed = await this.pollBackgroundInteraction(
       client,
       initial,
+      lifecycle?.id,
+      lifecycle?.deadlineAtMs,
       requestOptions,
       signal,
     );
@@ -1500,18 +1507,19 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     );
   }
 
-  private clearPendingBackgroundInteraction(interactionId: string): void {
-    if (this.pendingBackgroundInteraction?.id === interactionId) {
-      this.pendingBackgroundInteraction = null;
-    }
+  private clearPendingBackgroundInteraction(interactionId: string): boolean {
+    if (this.pendingBackgroundInteraction?.id !== interactionId) return false;
+    this.pendingBackgroundInteraction = null;
+    return true;
   }
 
   private createManualBackgroundError(message: string, cause?: unknown): Error {
-    const error = new Error(
+    const error: Error & { provider?: string } = new Error(
       message,
       cause === undefined ? undefined : { cause },
     );
-    Object.assign(error, { provider: this.config.provider });
+    // Synthetic lifecycle errors have no SDK instance for sdkErrorTagger to map.
+    error.provider = this.config.provider;
     attachManualRetryOnlyError(error);
     return error;
   }
@@ -1538,21 +1546,23 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     } catch (error) {
       this.sdkErrorTagger(error, this.config.provider);
       if (isUserAbort(error)) {
-        const shouldCancel =
-          this.pendingBackgroundInteraction?.id === interactionId;
-        this.clearPendingBackgroundInteraction(interactionId);
-        if (shouldCancel) {
-          await this.cancelBackgroundInteraction(client, interactionId);
+        if (this.clearPendingBackgroundInteraction(interactionId)) {
+          void this.cancelBackgroundInteraction(client, interactionId);
         }
         throw error;
       }
 
       const status = detectStatusCode(error);
-      if (status === 404 || status === 410) {
+      if (
+        status === 404 ||
+        status === 410 ||
+        isStaleInteractionChainError(error)
+      ) {
         this.clearPendingBackgroundInteraction(interactionId);
         throw this.createManualBackgroundError(
-          `Google Interactions background interaction ${interactionId} is no longer available ` +
-            `(HTTP ${status}). Retry explicitly to start a new interaction.`,
+          `Google Interactions background interaction ${interactionId} is no longer available` +
+            `${status === undefined ? '' : ` (HTTP ${status})`}. ` +
+            'Retry explicitly to start a new interaction.',
           error,
         );
       }
@@ -1572,10 +1582,12 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
   private async pollBackgroundInteraction(
     client: GoogleGenAI,
     initial: GoogleGenAIInteraction,
+    lifecycleInteractionId: string | undefined,
+    deadlineAtMs: number | undefined,
     requestOptions: InteractionsRequestOptions,
     signal: AbortSignal | undefined,
   ): Promise<GoogleGenAIInteraction> {
-    const interactionId = initial.id;
+    const interactionId = lifecycleInteractionId ?? initial.id;
     if (typeof interactionId !== 'string') {
       // No id ⇒ cannot poll. Trust the submit response (its status drives
       // finalizeChain, which invalidates the chain if not 'completed').
@@ -1598,16 +1610,17 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
             id,
             sig ? this.interactionsRequestOptions(sig) : requestOptions,
           ),
-        extractId: (r) => r.id,
+        extractId: () => interactionId,
         extractStatus: (r) => r.status ?? 'unknown',
         signal,
-        deadlineAtMs: this.pendingBackgroundInteraction?.deadlineAtMs,
+        deadlineAtMs,
         resourceLabel: 'interaction',
         providerLabel: 'Google Interactions',
         onAbort: () => {
-          this.clearPendingBackgroundInteraction(interactionId);
-          // Fire-and-forget cancel; do NOT await inside the listener.
-          void this.cancelBackgroundInteraction(client, interactionId);
+          if (this.clearPendingBackgroundInteraction(interactionId)) {
+            // Fire-and-forget cancel; do NOT await inside the listener.
+            void this.cancelBackgroundInteraction(client, interactionId);
+          }
         },
         formatTimeoutError: () => {
           timedOut = true;
@@ -1666,12 +1679,10 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
 
     // The SDK status union is open. An unrecognized value does not prove the
     // remote job is terminal, so retain its identity and fail closed.
-    const error = new Error(
+    throw this.createManualBackgroundError(
       `Google Interactions background interaction ${interactionId} returned ` +
         `unknown status "${status}"; refusing to submit a replacement.`,
     );
-    Object.assign(error, { provider: this.config.provider });
-    throw error;
   }
 
   /** Cancel the in-flight background interaction (best-effort; swallow errors). */

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
@@ -1,10 +1,16 @@
 // Third-party imports
+import { ApiError, type Interactions } from '@google/genai';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { noopTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
+import { hasManualRetryOnlyErrorMarker } from '@common/errors/sdkError/errorMetadata';
+import {
+  isProviderErrorAutoRetryable,
+  normalizeProviderError,
+} from '@common/errors/sdkErrorUtils';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 import * as configModule from '@utils/config/configUtils';
 import * as providerConfigModule from '@utils/config/providerConfig';
@@ -14,9 +20,6 @@ import {
   GOOGLE_INTERACTIONS_TEST_CONFIG,
   userStep,
 } from './googleInteractionsTestUtils';
-
-// Third-party imports
-import type { Interactions } from '@google/genai';
 
 type Step = Interactions.Step;
 
@@ -67,7 +70,7 @@ interface CapturedCalls {
  */
 function bgClient(opts: {
   submit: () => Interaction;
-  getSequence: Interaction[];
+  getSequence: Array<Interaction | Error>;
   onCancel?: (id: string) => void;
   generateContent?: () => Promise<unknown>;
 }): { client: unknown; calls: CapturedCalls } {
@@ -96,6 +99,7 @@ function bgClient(opts: {
         const next =
           opts.getSequence[Math.min(getIdx, opts.getSequence.length - 1)];
         getIdx += 1;
+        if (next instanceof Error) throw next;
         return next;
       },
       cancel: async (id: string) => {
@@ -193,6 +197,16 @@ async function runWithPolls<T>(promise: Promise<T>, ticks: number): Promise<T> {
   return promise;
 }
 
+async function captureRejection(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    if (error instanceof Error) return error;
+    throw error;
+  }
+  throw new Error('Expected promise to reject');
+}
+
 describe('ModelHandlerGoogleInteractions background mode', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -237,6 +251,215 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
     expect(calls.get.every((id) => id === 'int_1')).toBe(true);
     expect(result.response.status).toBe('completed');
   });
+
+  it('resumes the same interaction after a transient get failure', async () => {
+    mockConfig();
+    vi.useFakeTimers();
+    const handler = createHandler();
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_resume', status: 'in_progress' }),
+      getSequence: [
+        new TypeError('fetch failed'),
+        completedInteraction('int_resume'),
+      ],
+    });
+
+    const first = respond(handler, client, [userStep('a')]);
+    const firstRejection = expect(first).rejects.toThrow('fetch failed');
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstRejection;
+
+    await expect(
+      runWithPolls(respond(handler, client, [userStep('a')]), 1),
+    ).resolves.toMatchObject({ response: { status: 'completed' } });
+
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_resume', 'int_resume']);
+    expect(calls.cancel).toHaveLength(0);
+  });
+
+  it('keeps the original id through a transient failure, in_progress, and completion', async () => {
+    mockConfig();
+    vi.useFakeTimers();
+    const handler = createHandler();
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_long_resume', status: 'in_progress' }),
+      getSequence: [
+        Object.assign(new Error('temporarily unavailable'), { status: 503 }),
+        { id: 'int_long_resume', status: 'in_progress' },
+        completedInteraction('int_long_resume'),
+      ],
+    });
+
+    const first = respond(handler, client, [userStep('a')]);
+    const firstRejection = expect(first).rejects.toThrow(
+      'temporarily unavailable',
+    );
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstRejection;
+
+    await runWithPolls(respond(handler, client, [userStep('a')]), 1);
+
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual([
+      'int_long_resume',
+      'int_long_resume',
+      'int_long_resume',
+    ]);
+    expect(calls.cancel).toHaveLength(0);
+  });
+
+  it('does not reset the original deadline when a retry resumes', async () => {
+    mockConfig();
+    vi.useFakeTimers({ now: new Date('2026-08-01T00:00:00.000Z') });
+    const handler = createHandler();
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_expire', status: 'in_progress' }),
+      getSequence: [new TypeError('fetch failed')],
+    });
+
+    const first = respond(handler, client, [userStep('a')]);
+    const firstError = captureRejection(first);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstError;
+
+    await vi.advanceTimersByTimeAsync(MAX_DURATION_MS - POLL_INTERVAL_MS);
+    const timeout = await captureRejection(
+      respond(handler, client, [userStep('a')]),
+    );
+
+    expect(timeout.message).toContain(
+      `maximum polling duration of ${MAX_DURATION_MS} ms`,
+    );
+    expect(hasManualRetryOnlyErrorMarker(timeout)).toBe(true);
+    expect(normalizeProviderError(timeout).userRetryable).toBe(true);
+    expect(isProviderErrorAutoRetryable(timeout)).toBe(false);
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_expire']);
+    expect(calls.cancel).toEqual(['int_expire']);
+  });
+
+  it('treats queued as pending', async () => {
+    mockConfig();
+    vi.useFakeTimers();
+    const handler = createHandler();
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_queued', status: 'queued' }),
+      getSequence: [
+        { id: 'int_queued', status: 'queued' },
+        completedInteraction('int_queued'),
+      ],
+    });
+
+    await runWithPolls(respond(handler, client, [userStep('a')]), 2);
+
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_queued', 'int_queued']);
+  });
+
+  it('retains an unknown status and resumes without replacement', async () => {
+    mockConfig();
+    vi.useFakeTimers();
+    const handler = createHandler();
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_unknown', status: 'in_progress' }),
+      getSequence: [
+        { id: 'int_unknown', status: 'mystery' },
+        completedInteraction('int_unknown'),
+      ],
+    });
+
+    const first = respond(handler, client, [userStep('a')]);
+    const firstRejection = expect(first).rejects.toThrow(
+      /unknown status "mystery"/,
+    );
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstRejection;
+    await respond(handler, client, [userStep('a')]);
+
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_unknown', 'int_unknown']);
+  });
+
+  it('retains a known id after a non-missing 4xx retrieval failure', async () => {
+    mockConfig();
+    vi.useFakeTimers();
+    const handler = createHandler();
+    const forbidden = Object.assign(new Error('request rejected'), {
+      status: 403,
+    });
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_forbidden', status: 'in_progress' }),
+      getSequence: [forbidden, completedInteraction('int_forbidden')],
+    });
+
+    const first = respond(handler, client, [userStep('a')]);
+    const firstRejection = expect(first).rejects.toBe(forbidden);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstRejection;
+    await respond(handler, client, [userStep('a')]);
+
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_forbidden', 'int_forbidden']);
+  });
+
+  it.each([404, 410])(
+    'clears a definitively missing interaction on HTTP %i and requires manual retry',
+    async (status) => {
+      mockConfig();
+      vi.useFakeTimers();
+      const handler = createHandler();
+      let submitCount = 0;
+      const { client, calls } = bgClient({
+        submit: () => ({
+          id: `int_missing_${++submitCount}`,
+          status: submitCount === 1 ? 'in_progress' : 'completed',
+        }),
+        getSequence: [
+          new ApiError({ message: 'gone', status }),
+          completedInteraction('unused'),
+        ],
+      });
+
+      const first = respond(handler, client, [userStep('a')]);
+      const missingPromise = captureRejection(first);
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      const missing = await missingPromise;
+
+      expect(hasManualRetryOnlyErrorMarker(missing)).toBe(true);
+      expect(normalizeProviderError(missing).userRetryable).toBe(true);
+      expect(isProviderErrorAutoRetryable(missing)).toBe(false);
+      expect(calls.create).toHaveLength(1);
+
+      await respond(handler, client, [userStep('a')]);
+      expect(calls.create).toHaveLength(2);
+    },
+  );
+
+  it.each(['failed', 'cancelled', 'incomplete', 'budget_exceeded'])(
+    'clears terminal status %s and prevents automatic replacement',
+    async (status) => {
+      mockConfig();
+      vi.useFakeTimers();
+      const handler = createHandler();
+      const { client, calls } = bgClient({
+        submit: () => ({ id: 'int_terminal', status: 'in_progress' }),
+        getSequence: [{ id: 'int_terminal', status }],
+      });
+
+      const response = respond(handler, client, [userStep('a')]);
+      const terminalPromise = captureRejection(response);
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      const terminal = await terminalPromise;
+
+      expect(terminal.message).toContain(`status "${status}"`);
+      expect(hasManualRetryOnlyErrorMarker(terminal)).toBe(true);
+      expect(normalizeProviderError(terminal).userRetryable).toBe(true);
+      expect(isProviderErrorAutoRetryable(terminal)).toBe(false);
+      expect(calls.create).toHaveLength(1);
+      expect(calls.get).toEqual(['int_terminal']);
+    },
+  );
 
   it('B3: captures the chain id from the polled completion (not the submit)', async () => {
     mockConfig();
@@ -291,13 +514,15 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
     expect(calls.cancel).toEqual(['int_1']);
 
     // No leak: a fresh serial call on the same handler succeeds.
-    const { client: client2 } = bgClient({
+    const { client: client2, calls: calls2 } = bgClient({
       submit: () => completedInteraction('int_2'),
       getSequence: [completedInteraction('int_2')],
     });
     await expect(
       runWithPolls(respond(handler, client2, [userStep('b')]), 1),
     ).resolves.toBeDefined();
+    expect(calls2.create).toHaveLength(1);
+    expect(calls2.get).toHaveLength(0);
 
     // A later abort cancels ITS OWN interaction, never the earlier one: the
     // cancel target is the id captured by that poll invocation, so no handler
@@ -416,17 +641,13 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
     mockConfig();
     vi.useFakeTimers();
     const handler = createHandler();
-    const { client } = bgClient({
+    const { client, calls } = bgClient({
       submit: () => ({ id: 'int_1', status: 'in_progress' }),
       getSequence: [{ id: 'int_1', status: 'in_progress' }], // never completes
     });
 
     const promise = respond(handler, client, [userStep('a')]);
-    // Assert the cap value too, so a regression in BACKGROUND_MAX_DURATION_MS
-    // (3h) is caught, not just the presence of a timeout message.
-    const rejection = expect(promise).rejects.toThrow(
-      new RegExp(`maximum polling duration of ${MAX_DURATION_MS} ms`),
-    );
+    const timeoutPromise = captureRejection(promise);
 
     // Drive well past the 3h cap (one get() recomputes elapsed time).
     const ticks = Math.ceil(MAX_DURATION_MS / POLL_INTERVAL_MS) + 2;
@@ -434,7 +655,13 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
       await Promise.resolve();
       await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
     }
-    await rejection;
+    const timeout = await timeoutPromise;
+    expect(timeout.message).toContain(
+      `maximum polling duration of ${MAX_DURATION_MS} ms`,
+    );
+    expect(hasManualRetryOnlyErrorMarker(timeout)).toBe(true);
+    expect(isProviderErrorAutoRetryable(timeout)).toBe(false);
+    expect(calls.cancel).toEqual(['int_1']);
   });
 
   it('B10: background (workflow) and input-token compaction (tool-use) are mutually exclusive', async () => {

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
@@ -281,58 +281,112 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
     expect(calls.cancel).toHaveLength(0);
   });
 
-  it.each(['background', 'serverState'] as const)(
-    'resumes a pending interaction when %s is disabled between attempts',
-    async (setting) => {
-      let background = true;
+  it('resumes a pending interaction when background is disabled and preserves its chain', async () => {
+    let background = true;
+    mockConfig({ background: () => background });
+    vi.useFakeTimers();
+    const handler = createHandler();
+    const messages = [userStep('a')];
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_background_resume', status: 'in_progress' }),
+      getSequence: [
+        new TypeError('fetch failed'),
+        completedInteraction('int_background_resume'),
+      ],
+    });
+
+    const first = respond(handler, client, messages);
+    const firstRejection = expect(first).rejects.toThrow('fetch failed');
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstRejection;
+
+    background = false;
+    await expect(respond(handler, client, messages)).resolves.toMatchObject({
+      response: { status: 'completed' },
+    });
+
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual([
+      'int_background_resume',
+      'int_background_resume',
+    ]);
+    expect(calls.cancel).toHaveLength(0);
+
+    const { client: nextClient, calls: nextCalls } = bgClient({
+      submit: () => completedInteraction('int_after_background_change'),
+      getSequence: [completedInteraction('int_after_background_change')],
+    });
+    messages.push(userStep('b'));
+    await respond(handler, nextClient, messages);
+    expect(nextCalls.create[0].previousId).toBe('int_background_resume');
+    expect(nextCalls.create[0].input).toEqual([messages[1]]);
+  });
+
+  it.each(['completed', 'missing'] as const)(
+    'invalidates an existing chain before a disabled-server-state resume ends %s',
+    async (outcome) => {
       let serverState = true;
-      mockConfig({
-        background: () => background,
-        serverState: () => serverState,
-      });
+      mockConfig({ serverState: () => serverState });
       vi.useFakeTimers();
       const handler = createHandler();
       const messages = [userStep('a')];
-      const { client, calls } = bgClient({
-        submit: () => ({ id: 'int_setting_resume', status: 'in_progress' }),
-        getSequence: [
-          new TypeError('fetch failed'),
-          completedInteraction('int_setting_resume'),
-        ],
+
+      const { client: chainClient, calls: chainCalls } = bgClient({
+        submit: () => ({ id: 'int_chain', status: 'in_progress' }),
+        getSequence: [completedInteraction('int_chain')],
       });
+      await runWithPolls(respond(handler, chainClient, messages), 1);
+      expect(chainCalls.create).toHaveLength(1);
+      expect(chainCalls.get).toEqual(['int_chain']);
+      expect(chainCalls.cancel).toHaveLength(0);
 
-      const first = respond(handler, client, messages);
-      const firstRejection = expect(first).rejects.toThrow('fetch failed');
-      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
-      await firstRejection;
-
-      if (setting === 'background') background = false;
-      else serverState = false;
-
-      await expect(respond(handler, client, messages)).resolves.toMatchObject({
-        response: { status: 'completed' },
-      });
-
-      expect(calls.create).toHaveLength(1);
-      expect(calls.get).toEqual(['int_setting_resume', 'int_setting_resume']);
-      expect(calls.cancel).toHaveLength(0);
-
-      // Chaining follows the setting that was active at completion: background
-      // off still permits the completed stored interaction as an anchor, while
-      // server state off discards the anchor so a later re-enable full-resends.
-      if (setting === 'serverState') serverState = true;
-      const { client: nextClient, calls: nextCalls } = bgClient({
-        submit: () => completedInteraction('int_after_setting_change'),
-        getSequence: [completedInteraction('int_after_setting_change')],
-      });
       messages.push(userStep('b'));
+      const resumeResult =
+        outcome === 'completed'
+          ? completedInteraction('int_pending_turn')
+          : new ApiError({ message: 'gone', status: 404 });
+      const { client: pendingClient, calls: pendingCalls } = bgClient({
+        submit: () => ({ id: 'int_pending_turn', status: 'in_progress' }),
+        getSequence: [new TypeError('fetch failed'), resumeResult],
+      });
+      const pending = respond(handler, pendingClient, messages);
+      const pendingRejection = expect(pending).rejects.toThrow('fetch failed');
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      await pendingRejection;
+      expect(pendingCalls.create[0].previousId).toBe('int_chain');
+
+      serverState = false;
+      if (outcome === 'completed') {
+        await expect(
+          respond(handler, pendingClient, messages),
+        ).resolves.toMatchObject({ response: { status: 'completed' } });
+        messages.push(userStep('c'));
+      } else {
+        const missing = await captureRejection(
+          respond(handler, pendingClient, messages),
+        );
+        expect(hasManualRetryOnlyErrorMarker(missing)).toBe(true);
+        expect(isProviderErrorAutoRetryable(missing)).toBe(false);
+      }
+
+      expect(pendingCalls.create).toHaveLength(1);
+      expect(pendingCalls.get).toEqual([
+        'int_pending_turn',
+        'int_pending_turn',
+      ]);
+      expect(pendingCalls.cancel).toHaveLength(0);
+
+      serverState = true;
+      const { client: nextClient, calls: nextCalls } = bgClient({
+        submit: () => completedInteraction('int_after_server_state_change'),
+        getSequence: [completedInteraction('int_after_server_state_change')],
+      });
       await respond(handler, nextClient, messages);
-      expect(nextCalls.create[0].previousId).toBe(
-        setting === 'background' ? 'int_setting_resume' : undefined,
-      );
-      expect(nextCalls.create[0].input).toHaveLength(
-        setting === 'background' ? 1 : 2,
-      );
+      expect(nextCalls.create).toHaveLength(1);
+      expect(nextCalls.create[0].previousId).toBeUndefined();
+      expect(nextCalls.create[0].input).toEqual(messages);
+      expect(nextCalls.get).toHaveLength(0);
+      expect(nextCalls.cancel).toHaveLength(0);
     },
   );
 
@@ -497,6 +551,11 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
       expect(calls.create).toHaveLength(1);
       expect(calls.get).toEqual(['int_missing_1']);
       expect(calls.cancel).toHaveLength(0);
+
+      await respond(handler, client, [userStep('a')]);
+      expect(calls.create).toHaveLength(2);
+      expect(calls.get).toEqual(['int_missing_1']);
+      expect(calls.cancel).toHaveLength(0);
     },
   );
 
@@ -506,8 +565,14 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
       mockConfig();
       vi.useFakeTimers();
       const handler = createHandler();
+      let submitCount = 0;
       const { client, calls } = bgClient({
-        submit: () => ({ id: 'int_terminal', status: 'in_progress' }),
+        submit: () => {
+          submitCount += 1;
+          return submitCount === 1
+            ? { id: 'int_terminal', status: 'in_progress' }
+            : completedInteraction('int_after_terminal');
+        },
         getSequence: [{ id: 'int_terminal', status }],
       });
 
@@ -521,6 +586,11 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
       expect(normalizeProviderError(terminal).userRetryable).toBe(true);
       expect(isProviderErrorAutoRetryable(terminal)).toBe(false);
       expect(calls.create).toHaveLength(1);
+      expect(calls.get).toEqual(['int_terminal']);
+      expect(calls.cancel).toHaveLength(0);
+
+      await respond(handler, client, [userStep('a')]);
+      expect(calls.create).toHaveLength(2);
       expect(calls.get).toEqual(['int_terminal']);
       expect(calls.cancel).toHaveLength(0);
     },

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
@@ -73,6 +73,7 @@ function bgClient(opts: {
   getSequence: Array<Interaction | Error>;
   onCancel?: (id: string) => void | Promise<void>;
   generateContent?: () => Promise<unknown>;
+  countTokens?: (params: unknown) => Promise<unknown>;
 }): { client: unknown; calls: CapturedCalls } {
   let getIdx = 0;
   const calls: CapturedCalls = { create: [], get: [], cancel: [] };
@@ -108,9 +109,12 @@ function bgClient(opts: {
         return {};
       },
     },
-    models: opts.generateContent
-      ? { generateContent: opts.generateContent }
-      : {},
+    models: {
+      ...(opts.generateContent
+        ? { generateContent: opts.generateContent }
+        : {}),
+      ...(opts.countTokens ? { countTokens: opts.countTokens } : {}),
+    },
   };
   return { client, calls };
 }
@@ -118,12 +122,13 @@ function bgClient(opts: {
 /** Workflow-mode handler so isBackgroundModeEligible() is true. */
 function createHandler(
   category: AgentCategory = AgentCategory.Workflow,
+  supportsTokenCounting = false,
 ): ModelHandlerGoogleInteractions {
   const handler = new ModelHandlerGoogleInteractions(
     buildTestModelConfig(GOOGLE_INTERACTIONS_TEST_CONFIG, {
       capabilities: {
         supportsReasoning: true,
-        supportsTokenCounting: false,
+        supportsTokenCounting,
       },
     }),
   );
@@ -485,6 +490,60 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
     expect(calls.create).toHaveLength(1);
     expect(calls.get).toEqual(['int_expire']);
     expect(calls.cancel).toEqual(['int_expire']);
+  });
+
+  it('clears a pre-aborted pending interaction before token counting', async () => {
+    mockConfig();
+    vi.useFakeTimers();
+    const handler = createHandler(AgentCategory.Workflow, true);
+    let releaseCancel!: () => void;
+    const cancelPending = new Promise<void>((resolve) => {
+      releaseCancel = resolve;
+    });
+    const countTokens = vi.fn(
+      async (params: { config?: { abortSignal?: AbortSignal } }) => {
+        params.config?.abortSignal?.throwIfAborted();
+        return { totalTokens: 1 };
+      },
+    );
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_abort_before_count', status: 'in_progress' }),
+      getSequence: [new TypeError('fetch failed')],
+      countTokens: countTokens as (params: unknown) => Promise<unknown>,
+      onCancel: () => cancelPending,
+    });
+
+    const first = respond(handler, client, [userStep('a')]);
+    const firstRejection = expect(first).rejects.toThrow('fetch failed');
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstRejection;
+    expect(countTokens).toHaveBeenCalledTimes(1);
+    countTokens.mockClear();
+
+    const controller = new AbortController();
+    controller.abort();
+    let settled = false;
+    let caught: unknown;
+    const retry = respond(
+      handler,
+      client,
+      [userStep('a')],
+      controller.signal,
+    ).catch((error: unknown) => {
+      settled = true;
+      caught = error;
+    });
+    for (let i = 0; i < 50; i += 1) await Promise.resolve();
+    const settledBeforeCancel = settled;
+    releaseCancel();
+    await retry;
+
+    expect(settledBeforeCancel).toBe(true);
+    expect(caught).toMatchObject({ name: 'AbortError' });
+    expect(countTokens).not.toHaveBeenCalled();
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_abort_before_count']);
+    expect(calls.cancel).toEqual(['int_abort_before_count']);
   });
 
   it('lets an already-aborted signal win over pending expiry without awaiting cancel', async () => {

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
@@ -150,8 +150,8 @@ const originalGetConfig = configModule.getConfig;
  */
 function mockConfig(
   opts: {
-    serverState?: boolean;
-    background?: boolean;
+    serverState?: boolean | (() => boolean);
+    background?: boolean | (() => boolean);
   } = {},
 ): void {
   const serverState = opts.serverState ?? true;
@@ -159,10 +159,14 @@ function mockConfig(
   vi.spyOn(configModule, 'getConfig').mockImplementation(
     <T>(key: string, defaultValue?: T): T => {
       if (key === 'texra.model.useGoogleInteractionsServerState') {
-        return serverState as T;
+        return (
+          typeof serverState === 'function' ? serverState() : serverState
+        ) as T;
       }
       if (key === 'texra.model.useBackgroundResponses') {
-        return background as T;
+        return (
+          typeof background === 'function' ? background() : background
+        ) as T;
       }
       return originalGetConfig(key, defaultValue);
     },
@@ -247,8 +251,7 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
     const promise = respond(handler, client, [userStep('a')]);
     const result = await runWithPolls(promise, 4);
 
-    expect(calls.get.length).toBeGreaterThanOrEqual(3);
-    expect(calls.get.every((id) => id === 'int_1')).toBe(true);
+    expect(calls.get).toEqual(['int_1', 'int_1', 'int_1']);
     expect(result.response.status).toBe('completed');
   });
 
@@ -277,6 +280,61 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
     expect(calls.get).toEqual(['int_resume', 'int_resume']);
     expect(calls.cancel).toHaveLength(0);
   });
+
+  it.each(['background', 'serverState'] as const)(
+    'resumes a pending interaction when %s is disabled between attempts',
+    async (setting) => {
+      let background = true;
+      let serverState = true;
+      mockConfig({
+        background: () => background,
+        serverState: () => serverState,
+      });
+      vi.useFakeTimers();
+      const handler = createHandler();
+      const messages = [userStep('a')];
+      const { client, calls } = bgClient({
+        submit: () => ({ id: 'int_setting_resume', status: 'in_progress' }),
+        getSequence: [
+          new TypeError('fetch failed'),
+          completedInteraction('int_setting_resume'),
+        ],
+      });
+
+      const first = respond(handler, client, messages);
+      const firstRejection = expect(first).rejects.toThrow('fetch failed');
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      await firstRejection;
+
+      if (setting === 'background') background = false;
+      else serverState = false;
+
+      await expect(respond(handler, client, messages)).resolves.toMatchObject({
+        response: { status: 'completed' },
+      });
+
+      expect(calls.create).toHaveLength(1);
+      expect(calls.get).toEqual(['int_setting_resume', 'int_setting_resume']);
+      expect(calls.cancel).toHaveLength(0);
+
+      // Chaining follows the setting that was active at completion: background
+      // off still permits the completed stored interaction as an anchor, while
+      // server state off discards the anchor so a later re-enable full-resends.
+      if (setting === 'serverState') serverState = true;
+      const { client: nextClient, calls: nextCalls } = bgClient({
+        submit: () => completedInteraction('int_after_setting_change'),
+        getSequence: [completedInteraction('int_after_setting_change')],
+      });
+      messages.push(userStep('b'));
+      await respond(handler, nextClient, messages);
+      expect(nextCalls.create[0].previousId).toBe(
+        setting === 'background' ? 'int_setting_resume' : undefined,
+      );
+      expect(nextCalls.create[0].input).toHaveLength(
+        setting === 'background' ? 1 : 2,
+      );
+    },
+  );
 
   it('keeps the original id through a transient failure, in_progress, and completion', async () => {
     mockConfig();
@@ -394,13 +452,20 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
     });
 
     const first = respond(handler, client, [userStep('a')]);
-    const firstRejection = expect(first).rejects.toBe(forbidden);
+    const firstErrorPromise = captureRejection(first);
     await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
-    await firstRejection;
-    await respond(handler, client, [userStep('a')]);
+    const firstError = await firstErrorPromise;
 
+    expect(firstError).toBe(forbidden);
+    expect(isProviderErrorAutoRetryable(firstError)).toBe(false);
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_forbidden']);
+    expect(calls.cancel).toHaveLength(0);
+
+    await respond(handler, client, [userStep('a')]);
     expect(calls.create).toHaveLength(1);
     expect(calls.get).toEqual(['int_forbidden', 'int_forbidden']);
+    expect(calls.cancel).toHaveLength(0);
   });
 
   it.each([404, 410])(
@@ -430,9 +495,8 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
       expect(normalizeProviderError(missing).userRetryable).toBe(true);
       expect(isProviderErrorAutoRetryable(missing)).toBe(false);
       expect(calls.create).toHaveLength(1);
-
-      await respond(handler, client, [userStep('a')]);
-      expect(calls.create).toHaveLength(2);
+      expect(calls.get).toEqual(['int_missing_1']);
+      expect(calls.cancel).toHaveLength(0);
     },
   );
 
@@ -458,6 +522,7 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
       expect(isProviderErrorAutoRetryable(terminal)).toBe(false);
       expect(calls.create).toHaveLength(1);
       expect(calls.get).toEqual(['int_terminal']);
+      expect(calls.cancel).toHaveLength(0);
     },
   );
 

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
@@ -71,7 +71,7 @@ interface CapturedCalls {
 function bgClient(opts: {
   submit: () => Interaction;
   getSequence: Array<Interaction | Error>;
-  onCancel?: (id: string) => void;
+  onCancel?: (id: string) => void | Promise<void>;
   generateContent?: () => Promise<unknown>;
 }): { client: unknown; calls: CapturedCalls } {
   let getIdx = 0;
@@ -104,7 +104,7 @@ function bgClient(opts: {
       },
       cancel: async (id: string) => {
         calls.cancel.push(id);
-        opts.onCancel?.(id);
+        await opts.onCancel?.(id);
         return {};
       },
     },
@@ -281,6 +281,42 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
     expect(calls.cancel).toHaveLength(0);
   });
 
+  it('clears the submitted lifecycle id when resumed completion returns a different id', async () => {
+    mockConfig();
+    vi.useFakeTimers();
+    const handler = createHandler();
+    const messages = [userStep('a')];
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_submitted', status: 'in_progress' }),
+      getSequence: [
+        new TypeError('fetch failed'),
+        completedInteraction('int_returned'),
+      ],
+    });
+
+    const first = respond(handler, client, messages);
+    const firstRejection = expect(first).rejects.toThrow('fetch failed');
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstRejection;
+    await respond(handler, client, messages);
+
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_submitted', 'int_submitted']);
+    expect(calls.cancel).toHaveLength(0);
+
+    const { client: nextClient, calls: nextCalls } = bgClient({
+      submit: () => completedInteraction('int_next'),
+      getSequence: [completedInteraction('int_submitted')],
+    });
+    messages.push(userStep('b'));
+    await respond(handler, nextClient, messages);
+
+    expect(nextCalls.create).toHaveLength(1);
+    expect(nextCalls.create[0].previousId).toBe('int_returned');
+    expect(nextCalls.get).toHaveLength(0);
+    expect(nextCalls.cancel).toHaveLength(0);
+  });
+
   it('resumes a pending interaction when background is disabled and preserves its chain', async () => {
     let background = true;
     mockConfig({ background: () => background });
@@ -451,6 +487,91 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
     expect(calls.cancel).toEqual(['int_expire']);
   });
 
+  it('lets an already-aborted signal win over pending expiry without awaiting cancel', async () => {
+    mockConfig();
+    vi.useFakeTimers({ now: new Date('2026-08-01T00:00:00.000Z') });
+    const handler = createHandler();
+    let releaseCancel!: () => void;
+    const cancelPending = new Promise<void>((resolve) => {
+      releaseCancel = resolve;
+    });
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_abort_expired', status: 'in_progress' }),
+      getSequence: [new TypeError('fetch failed')],
+      onCancel: () => cancelPending,
+    });
+
+    const first = respond(handler, client, [userStep('a')]);
+    const firstRejection = expect(first).rejects.toThrow('fetch failed');
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstRejection;
+    await vi.advanceTimersByTimeAsync(MAX_DURATION_MS - POLL_INTERVAL_MS);
+
+    const controller = new AbortController();
+    controller.abort();
+    let settled = false;
+    let caught: unknown;
+    const retry = respond(
+      handler,
+      client,
+      [userStep('a')],
+      controller.signal,
+    ).catch((error: unknown) => {
+      settled = true;
+      caught = error;
+    });
+    for (let i = 0; i < 50; i += 1) await Promise.resolve();
+    const settledBeforeCancel = settled;
+    releaseCancel();
+    await retry;
+
+    expect(settledBeforeCancel).toBe(true);
+    expect(caught).toMatchObject({ name: 'AbortError' });
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_abort_expired']);
+    expect(calls.cancel).toEqual(['int_abort_expired']);
+  });
+
+  it('rethrows a retrieval abort without awaiting best-effort cancel', async () => {
+    mockConfig();
+    vi.useFakeTimers();
+    const handler = createHandler();
+    let releaseCancel!: () => void;
+    const cancelPending = new Promise<void>((resolve) => {
+      releaseCancel = resolve;
+    });
+    const retrievalAbort = new DOMException('stopped', 'AbortError');
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_retrieval_abort', status: 'in_progress' }),
+      getSequence: [new TypeError('fetch failed'), retrievalAbort],
+      onCancel: () => cancelPending,
+    });
+
+    const first = respond(handler, client, [userStep('a')]);
+    const firstRejection = expect(first).rejects.toThrow('fetch failed');
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstRejection;
+
+    let settled = false;
+    let caught: unknown;
+    const retry = respond(handler, client, [userStep('a')]).catch(
+      (error: unknown) => {
+        settled = true;
+        caught = error;
+      },
+    );
+    for (let i = 0; i < 50; i += 1) await Promise.resolve();
+    const settledBeforeCancel = settled;
+    releaseCancel();
+    await retry;
+
+    expect(settledBeforeCancel).toBe(true);
+    expect(caught).toBe(retrievalAbort);
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_retrieval_abort', 'int_retrieval_abort']);
+    expect(calls.cancel).toEqual(['int_retrieval_abort']);
+  });
+
   it('treats queued as pending', async () => {
     mockConfig();
     vi.useFakeTimers();
@@ -469,7 +590,7 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
     expect(calls.get).toEqual(['int_queued', 'int_queued']);
   });
 
-  it('retains an unknown status and resumes without replacement', async () => {
+  it('retains an unknown status but requires manual retry before another poll', async () => {
     mockConfig();
     vi.useFakeTimers();
     const handler = createHandler();
@@ -482,15 +603,22 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
     });
 
     const first = respond(handler, client, [userStep('a')]);
-    const firstRejection = expect(first).rejects.toThrow(
-      /unknown status "mystery"/,
-    );
+    const unknownPromise = captureRejection(first);
     await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
-    await firstRejection;
-    await respond(handler, client, [userStep('a')]);
+    const unknown = await unknownPromise;
 
+    expect(unknown.message).toMatch(/unknown status "mystery"/);
+    expect(hasManualRetryOnlyErrorMarker(unknown)).toBe(true);
+    expect(normalizeProviderError(unknown).provider).toBe('google');
+    expect(isProviderErrorAutoRetryable(unknown)).toBe(false);
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_unknown']);
+    expect(calls.cancel).toHaveLength(0);
+
+    await respond(handler, client, [userStep('a')]);
     expect(calls.create).toHaveLength(1);
     expect(calls.get).toEqual(['int_unknown', 'int_unknown']);
+    expect(calls.cancel).toHaveLength(0);
   });
 
   it('retains a known id after a non-missing 4xx retrieval failure', async () => {
@@ -558,6 +686,60 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
       expect(calls.cancel).toHaveLength(0);
     },
   );
+
+  it.each([
+    {
+      label: 'SDK INVALID_ARGUMENT previous_interaction_id error',
+      error: Object.assign(
+        new ApiError({
+          message: 'Invalid previous_interaction_id int_stale',
+          status: 400,
+        }),
+        { code: 'INVALID_ARGUMENT' },
+      ),
+    },
+    {
+      label: 'SDK FAILED_PRECONDITION expired interaction error',
+      error: Object.assign(
+        new ApiError({
+          message: 'Interaction int_stale is expired',
+          status: 400,
+        }),
+        { code: 'FAILED_PRECONDITION' },
+      ),
+    },
+  ])('clears pending identity for a $label', async ({ error }) => {
+    mockConfig();
+    vi.useFakeTimers();
+    const handler = createHandler();
+    let submitCount = 0;
+    const { client, calls } = bgClient({
+      submit: () => {
+        submitCount += 1;
+        return submitCount === 1
+          ? { id: 'int_stale', status: 'in_progress' }
+          : completedInteraction('int_after_stale');
+      },
+      getSequence: [error],
+    });
+
+    const first = respond(handler, client, [userStep('a')]);
+    const stalePromise = captureRejection(first);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    const stale = await stalePromise;
+
+    expect(hasManualRetryOnlyErrorMarker(stale)).toBe(true);
+    expect(normalizeProviderError(stale).provider).toBe('google');
+    expect(isProviderErrorAutoRetryable(stale)).toBe(false);
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_stale']);
+    expect(calls.cancel).toHaveLength(0);
+
+    await respond(handler, client, [userStep('a')]);
+    expect(calls.create).toHaveLength(2);
+    expect(calls.get).toEqual(['int_stale']);
+    expect(calls.cancel).toHaveLength(0);
+  });
 
   it.each(['failed', 'cancelled', 'incomplete', 'budget_exceeded'])(
     'clears terminal status %s and prevents automatic replacement',


### PR DESCRIPTION
## Summary

- retain the acknowledged Google background interaction ID and one original three-hour deadline across handler retries
- resume the known interaction before any replacement create, even if background/server-state settings change between attempts
- treat `queued` as pending and fail closed on unknown or non-missing retrieval errors
- clear accounted terminal/missing/expired state and allow only an explicit human retry to create a replacement
- preserve abort precedence and best-effort server cancellation
- invalidate stored chaining immediately when server state is disabled, including unsuccessful resume paths

This is the bounded Google provider-lifecycle slice of #9532. State is intentionally handler-instance-local; durable restart persistence and telemetry remain separate work.

## Retry policy

Transient retrieval failures retain the interaction ID so automatic retry retrieves the same job. Missing (structured HTTP 404/410), expired, and known terminal interactions clear local state and use the existing manual-retry-only marker: no automatic replacement generation, while one explicit approval may start one fresh interaction under the existing one-attempt-per-approval rule.

## Tests

- focused Google/OpenAI background and retry suites after rebase: **155 passed across 6 files**
- implementation review suites: **121 passed across 6 files**
- workspace and test-kernel typechecks
- changed-file ESLint and Prettier
- dead-code ratchet: **17 current / 17 baselined**
- `git diff --check`

Deterministic regressions assert exact create/get/cancel counts for transient resumption, pending polling, original-deadline expiry, queued status, abort, 403 fail-closed behavior, structured 404/410, known terminal statuses, explicit replacement, setting changes, and chain invalidation/full resend.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes long-running workflow model I/O and retry semantics (what auto-retries vs requires explicit user retry), but state is handler-instance-local and coverage is extensive in `GoogleInteractionsBackground.vitest.ts`.
> 
> **Overview**
> Google Interactions **background mode** now keeps an in-flight job on the handler instance (`pendingBackgroundInteraction`: id + original 3h deadline) so automatic retries **poll the same interaction** via `interactions.get` instead of submitting a replacement `create`.
> 
> **Resume vs replace:** A pending id wins over toggling background or server-state mid-retry; disabling server state still invalidates `previous_interaction_id` chaining before resume completes. `queued` is treated as non-terminal alongside `in_progress`.
> 
> **Lifecycle errors:** Timeouts, HTTP 404/410, stale/expired ids, known terminal statuses (`failed`, `cancelled`, etc.), and unknown statuses clear pending state and surface **manual-retry-only** errors (no automatic replacement create). Transient retrieval failures (e.g. 503, network) keep the id for the next automatic retry. Abort paths clear pending state and fire best-effort `cancel` without blocking on it.
> 
> Polling is refactored through shared `retrieveBackgroundInteraction` and `BackgroundPoller` with a fixed `deadlineAtMs` so resumed attempts do not extend the cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f9d86653fe37812f2af56f1a10bc71359d921de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->