### PR TITLE
fix(google): resume background interactions on retry

### DIFF
--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -28,8 +28,10 @@ import type {
   TokenCountOptions,
 } from '@agent/types/ModelHandlerContracts';
 import {
+  attachManualRetryOnlyError,
   detectStatusCode,
   attachPartialText,
+  isUserAbort,
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
@@ -202,6 +204,12 @@ function isStaleInteractionChainError(error: unknown): boolean {
   );
 }
 
+/** Whether a submitted background interaction is definitively unavailable. */
+function isMissingBackgroundInteraction(error: unknown): boolean {
+  const status = detectStatusCode(error);
+  return status === 404 || status === 410;
+}
+
 /**
  * True when the model rejected `background:true` because it does not support
  * background interactions (verified live: gemini-2.5-flash → HTTP 400
@@ -282,6 +290,13 @@ type InteractionsRequestOptions = {
   fetchOptions: RequestInit;
 };
 
+const BACKGROUND_MAX_DURATION_MS = 3 * 60 * 60 * 1000;
+
+interface PendingBackgroundInteraction {
+  readonly id: string;
+  readonly deadlineAtMs: number;
+}
+
 export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
   Step,
   Usage | null,
@@ -326,7 +341,7 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
   private readonly backgroundPoller =
     new BackgroundPoller<GoogleGenAIInteraction>({
       pollIntervalMs: 5000,
-      maxDurationMs: 3 * 60 * 60 * 1000, // 3 hours
+      maxDurationMs: BACKGROUND_MAX_DURATION_MS,
       isPending: (r) => this.isBackgroundPending(r),
       logger: () => this.logger,
     });
@@ -341,6 +356,10 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
    * this runtime fallback is the model gate.
    */
   private backgroundUnsupported = false;
+
+  /** A submitted interaction retained across transient polling failures. */
+  private pendingBackgroundInteraction: PendingBackgroundInteraction | null =
+    null;
 
   // ===========================================================================
   // STATEFUL chaining state (store:true + previous_interaction_id)
@@ -1268,6 +1287,16 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     const requestOptions = this.interactionsRequestOptions(signal);
 
     try {
+      const resumed = await this.tryResumeBackgroundInteraction(
+        client,
+        requestOptions,
+        signal,
+      );
+      if (resumed) {
+        this.finalizeChain(resumed, base.length, stateful);
+        return withUpdated({ response: resumed });
+      }
+
       if (useBackground) {
         const result = await this.executeBackgroundPath(
           client,
@@ -1474,6 +1503,9 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
       return initial;
     }
 
+    const deadlineAtMs =
+      this.rememberPendingBackgroundInteraction(interactionId);
+
     let pollStats: BackgroundPollStats | undefined;
 
     const polled = await this.backgroundPoller.poll({
@@ -1489,27 +1521,39 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
             opts,
           );
         } catch (err) {
-          // Tag and rethrow — a user-abort surfaces as-is; a transient poll
-          // error (5xx/429/network) re-enters createResponse via PocketFlow's
-          // retry layer with a fresh submit (orphaned job ages out; no resume
-          // path in v0).
+          // Tag and rethrow. A user abort clears and cancels through onAbort;
+          // failures other than a definitive 404/410 retain the acknowledged
+          // interaction so the next node attempt resumes it before submitting.
           this.sdkErrorTagger(err, this.config.provider);
+          if (isMissingBackgroundInteraction(err)) {
+            this.clearPendingBackgroundInteraction();
+            throw this.replacementInteractionError(
+              interactionId,
+              'is no longer available',
+              err,
+            );
+          }
           throw err;
         }
       },
       extractId: (r) => r.id,
       extractStatus: (r) => r.status ?? 'unknown',
       signal,
+      deadlineAtMs,
       resourceLabel: 'interaction',
       providerLabel: 'Google Interactions',
       onAbort: () => {
+        this.clearPendingBackgroundInteraction();
         // Fire-and-forget cancel; do NOT await inside the listener.
         void this.cancelBackgroundInteraction(client, interactionId);
       },
-      formatTimeoutError: ({ responseId, maxDurationMs }) =>
-        `Google Interactions background interaction ${responseId} exceeded ` +
-        `maximum polling duration of ${maxDurationMs} ms. Cancel it with ` +
-        `client.interactions.cancel("${responseId}").`,
+      formatTimeoutError: ({ responseId, maxDurationMs }) => {
+        return this.expirePendingBackgroundInteraction(
+          client,
+          responseId,
+          `exceeded maximum polling duration of ${maxDurationMs} ms`,
+        );
+      },
       extraFinishData: (interaction) => ({
         usage: interaction.usage ?? undefined,
       }),
@@ -1525,12 +1569,14 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     // tools, but the gate (isWorkflowMode) is not a hard guarantee, so handle it
     // rather than crash a run that does emit a call.
     if (polled.status === 'completed' || polled.status === 'requires_action') {
+      this.clearPendingBackgroundInteraction();
       return polled;
     }
 
     // Terminal failure: failed / cancelled / incomplete / budget_exceeded —
     // treated uniformly as a thrown, tagged error.
     const status = polled.status ?? 'unknown';
+    this.clearPendingBackgroundInteraction();
     this.logger.error(
       'Background interaction ended with a non-completed status.',
       {
@@ -1548,6 +1594,125 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     );
     this.sdkErrorTagger(err, this.config.provider);
     throw err;
+  }
+
+  private rememberPendingBackgroundInteraction(interactionId: string): number {
+    if (this.pendingBackgroundInteraction?.id !== interactionId) {
+      this.pendingBackgroundInteraction = {
+        id: interactionId,
+        deadlineAtMs: Date.now() + BACKGROUND_MAX_DURATION_MS,
+      };
+    }
+    return this.pendingBackgroundInteraction.deadlineAtMs;
+  }
+
+  private clearPendingBackgroundInteraction(): void {
+    this.pendingBackgroundInteraction = null;
+  }
+
+  private replacementInteractionError(
+    interactionId: string,
+    reason: string,
+    cause?: unknown,
+  ): Error {
+    const error: Error & { provider?: string } = new Error(
+      `Google background interaction ${interactionId} ${reason}. ` +
+        'Retry explicitly to submit a replacement interaction.',
+      cause === undefined ? undefined : { cause },
+    );
+    error.provider = this.config.provider;
+    attachManualRetryOnlyError(error);
+    return error;
+  }
+
+  private expirePendingBackgroundInteraction(
+    client: GoogleGenAI,
+    interactionId: string,
+    reason: string,
+  ): Error {
+    this.clearPendingBackgroundInteraction();
+    void this.cancelBackgroundInteraction(client, interactionId);
+    return this.replacementInteractionError(interactionId, reason);
+  }
+
+  private throwIfPendingBackgroundInteractionExpired(
+    client: GoogleGenAI,
+    pending: PendingBackgroundInteraction,
+  ): void {
+    if (Date.now() < pending.deadlineAtMs) return;
+    throw this.expirePendingBackgroundInteraction(
+      client,
+      pending.id,
+      `exceeded maximum polling duration of ${BACKGROUND_MAX_DURATION_MS} ms`,
+    );
+  }
+
+  /** Resume an acknowledged interaction before considering a new submission. */
+  private async tryResumeBackgroundInteraction(
+    client: GoogleGenAI,
+    requestOptions: InteractionsRequestOptions,
+    signal: AbortSignal | undefined,
+  ): Promise<GoogleGenAIInteraction | null> {
+    const pending = this.pendingBackgroundInteraction;
+    if (!pending) return null;
+
+    if (signal?.aborted) {
+      this.clearPendingBackgroundInteraction();
+      void this.cancelBackgroundInteraction(client, pending.id);
+      signal.throwIfAborted();
+    }
+    this.throwIfPendingBackgroundInteractionExpired(client, pending);
+
+    this.logger.debug(
+      `Resuming polling for pending background interaction ${pending.id}`,
+    );
+    let current: GoogleGenAIInteraction;
+    try {
+      current = await client.interactions.get(
+        pending.id,
+        ModelHandlerGoogleInteractions.BACKGROUND_GET_PARAMS,
+        requestOptions,
+      );
+    } catch (error) {
+      this.sdkErrorTagger(error, this.config.provider);
+      if (isUserAbort(error)) {
+        this.clearPendingBackgroundInteraction();
+        void this.cancelBackgroundInteraction(client, pending.id);
+        throw error;
+      }
+      this.throwIfPendingBackgroundInteractionExpired(client, pending);
+
+      // A definitively missing or expired interaction cannot be resumed. Clear
+      // it, but do not submit a replacement inside an automatic retry:
+      // replacement is a new generation and requires an explicit user decision.
+      if (isMissingBackgroundInteraction(error)) {
+        this.clearPendingBackgroundInteraction();
+        throw this.replacementInteractionError(
+          pending.id,
+          'is no longer available',
+          error,
+        );
+      }
+
+      // Unknown/network, throttling, authentication, and server failures retain
+      // the known job identity. The outer retry will retrieve it again rather
+      // than multiplying generations.
+      throw error;
+    }
+
+    if (signal?.aborted) {
+      this.clearPendingBackgroundInteraction();
+      void this.cancelBackgroundInteraction(client, pending.id);
+      signal.throwIfAborted();
+    }
+    this.throwIfPendingBackgroundInteractionExpired(client, pending);
+
+    return this.pollBackgroundInteraction(
+      client,
+      current,
+      requestOptions,
+      signal,
+    );
   }
 
   /** Cancel the in-flight background interaction (best-effort; swallow errors). */

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
@@ -5,6 +5,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { noopTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
+import {
+  isProviderErrorAutoRetryable,
+  normalizeProviderError,
+} from '@common/errors/sdkErrorUtils';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 import * as configModule from '@utils/config/configUtils';
 import * as providerConfigModule from '@utils/config/providerConfig';
@@ -67,8 +71,9 @@ interface CapturedCalls {
  */
 function bgClient(opts: {
   submit: () => Interaction;
-  getSequence: Interaction[];
+  getSequence: Array<Interaction | Error>;
   onCancel?: (id: string) => void;
+  beforeGet?: (index: number) => void;
   generateContent?: () => Promise<unknown>;
 }): { client: unknown; calls: CapturedCalls } {
   let getIdx = 0;
@@ -93,9 +98,11 @@ function bgClient(opts: {
       },
       get: async (id: string) => {
         calls.get.push(id);
+        opts.beforeGet?.(getIdx);
         const next =
           opts.getSequence[Math.min(getIdx, opts.getSequence.length - 1)];
         getIdx += 1;
+        if (next instanceof Error) throw next;
         return next;
       },
       cancel: async (id: string) => {
@@ -519,5 +526,187 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
     expect(getCalls).toBe(0);
     // Background stays disabled for the rest of the run.
     expect(handler.isBackgroundModeActive()).toBe(false);
+  });
+
+  it('B12: a transient poll failure resumes the same interaction without another submit', async () => {
+    mockConfig();
+    vi.useFakeTimers();
+    const handler = createHandler();
+    const transient = new Error('connection reset');
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_1', status: 'in_progress' }),
+      getSequence: [transient, completedInteraction('int_1', 'resumed')],
+    });
+
+    const first = respond(handler, client, [userStep('a')]);
+    const firstRejection = expect(first).rejects.toThrow('connection reset');
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstRejection;
+
+    const second = respond(handler, client, [userStep('a')]);
+    const result = await runWithPolls(second, 2);
+
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_1', 'int_1']);
+    expect(result.response.id).toBe('int_1');
+    expect(result.response.status).toBe('completed');
+  });
+
+  it.each([404, 410])(
+    'B13: an unavailable acknowledged interaction (%i) requires explicit retry before replacement',
+    async (status) => {
+      mockConfig();
+      vi.useFakeTimers();
+      const handler = createHandler();
+      const missing = Object.assign(new Error('interaction not found'), {
+        status,
+      });
+      const { client, calls } = bgClient({
+        submit: () => ({ id: 'int_1', status: 'in_progress' }),
+        getSequence: [new Error('connection reset'), missing],
+      });
+
+      const first = respond(handler, client, [userStep('a')]);
+      const firstRejection = expect(first).rejects.toThrow('connection reset');
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      await firstRejection;
+
+      const secondError = await respond(handler, client, [userStep('a')]).catch(
+        (error: unknown) => error,
+      );
+
+      expect(calls.create).toHaveLength(1);
+      expect(secondError).toBeInstanceOf(Error);
+      expect((secondError as Error).message).toMatch(/Retry explicitly/);
+      expect(isProviderErrorAutoRetryable(secondError)).toBe(false);
+      expect(normalizeProviderError(secondError).provider).toBe('google');
+
+      // A later explicit invocation may submit a replacement after the missing
+      // interaction has been accounted for and removed from local tracking.
+      const { client: replacementClient, calls: replacementCalls } = bgClient({
+        submit: () => completedInteraction('int_2', 'replacement'),
+        getSequence: [completedInteraction('int_2', 'replacement')],
+      });
+      const result = await respond(handler, replacementClient, [userStep('a')]);
+      expect(replacementCalls.create).toHaveLength(1);
+      expect(result.response.id).toBe('int_2');
+    },
+  );
+
+  it('B14: resumed polling keeps the original lifetime deadline', async () => {
+    mockConfig();
+    vi.useFakeTimers();
+    const startedAt = Date.now();
+    const handler = createHandler();
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_1', status: 'in_progress' }),
+      getSequence: [new Error('connection reset')],
+    });
+
+    const first = respond(handler, client, [userStep('a')]);
+    const firstRejection = expect(first).rejects.toThrow('connection reset');
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstRejection;
+
+    vi.setSystemTime(startedAt + MAX_DURATION_MS);
+    const timeout = await respond(handler, client, [userStep('a')]).catch(
+      (error: unknown) => error,
+    );
+    await Promise.resolve();
+
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_1']);
+    expect(calls.cancel).toEqual(['int_1']);
+    expect(timeout).toBeInstanceOf(Error);
+    expect((timeout as Error).message).toMatch(
+      new RegExp(`maximum polling duration of ${MAX_DURATION_MS} ms`),
+    );
+    expect(isProviderErrorAutoRetryable(timeout)).toBe(false);
+  });
+
+  it('B15: a retrieval that finishes after the original deadline cannot succeed late', async () => {
+    mockConfig();
+    vi.useFakeTimers();
+    const startedAt = Date.now();
+    const handler = createHandler();
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_1', status: 'in_progress' }),
+      getSequence: [
+        new Error('connection reset'),
+        completedInteraction('int_1', 'too late'),
+      ],
+      beforeGet: (index) => {
+        if (index === 1) vi.setSystemTime(startedAt + MAX_DURATION_MS);
+      },
+    });
+
+    const first = respond(handler, client, [userStep('a')]);
+    const firstRejection = expect(first).rejects.toThrow('connection reset');
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstRejection;
+
+    vi.setSystemTime(startedAt + MAX_DURATION_MS - 1);
+    const timeout = await respond(handler, client, [userStep('a')]).catch(
+      (error: unknown) => error,
+    );
+    await Promise.resolve();
+
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_1', 'int_1']);
+    expect(calls.cancel).toEqual(['int_1']);
+    expect(timeout).toBeInstanceOf(Error);
+    expect(isProviderErrorAutoRetryable(timeout)).toBe(false);
+  });
+
+  it.each([404, 410])(
+    'B16: an unavailable response (%i) during the first poll cannot trigger an automatic replacement',
+    async (status) => {
+      mockConfig();
+      vi.useFakeTimers();
+      const handler = createHandler();
+      const missing = Object.assign(new Error('interaction not found'), {
+        status,
+      });
+      const { client, calls } = bgClient({
+        submit: () => ({ id: 'int_1', status: 'in_progress' }),
+        getSequence: [missing],
+      });
+
+      const response = respond(handler, client, [userStep('a')]);
+      const errorPromise = response.catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      const error = await errorPromise;
+
+      expect(calls.create).toHaveLength(1);
+      expect(calls.get).toEqual(['int_1']);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toMatch(/Retry explicitly/);
+      expect(isProviderErrorAutoRetryable(error)).toBe(false);
+    },
+  );
+
+  it('B17: an already-aborted resume cancels the retained interaction', async () => {
+    mockConfig();
+    vi.useFakeTimers();
+    const handler = createHandler();
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_1', status: 'in_progress' }),
+      getSequence: [new Error('connection reset')],
+    });
+
+    const first = respond(handler, client, [userStep('a')]);
+    const firstRejection = expect(first).rejects.toThrow('connection reset');
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstRejection;
+
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      respond(handler, client, [userStep('a')], controller.signal),
+    ).rejects.toThrow();
+    await Promise.resolve();
+
+    expect(calls.create).toHaveLength(1);
+    expect(calls.cancel).toEqual(['int_1']);
   });
 });


### PR DESCRIPTION
## Summary

- retain an acknowledged Google background interaction across transient polling failures
- retrieve the same interaction before any later submission and preserve its original three-hour deadline
- require an explicit retry before replacing a definitively missing or expired interaction
- cancel expired interactions best-effort and clear retained state on completion, terminal status, timeout, or user cancellation

## Issue acceptance gates

Advances #9532. This PR completes the bounded Google provider-lifetime slice: retries resume a known interaction where supported, while missing or expired jobs are accounted for before a replacement generation can be submitted. Compact durable retry telemetry remains outside this PR, so #9532 stays open.

## Single source of truth

The Google Interactions handler owns one pending background identity and one absolute deadline. The existing `BackgroundPoller` remains the sole polling-clock mechanism; node retry policy only decides whether another authorized attempt occurs.

## Duplication and abstraction budget

No cross-provider retry ledger or host abstraction is added. The new state and transitions live inside the existing Google background-mode section and reuse the established poller and manual-retry-only error marker.

## Net elements (R6)

- Files: 2 changed; none added or deleted.
- Lines: 364 additions, 10 deletions; net +354, including six provider-lifecycle regressions.
- Exported symbols: none added or deleted.
- Classes/interfaces/enums: one private pending-state interface added.

## Consumer counts (R8)

n/a: no export, event key, or subscriber path is deleted or rerouted.

## Host impact

Extension: Google workflow retries no longer multiply acknowledged background generations.

Desktop: Same shared provider behavior.

CLI: Same shared provider behavior; retry policy remains unchanged.

## Scheduled refactoring

#9532 remains open for compact durable retry/lifecycle diagnostics.

## Validation

- `npm run format`
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `npm run lint`
- `npm run compile:fast`
- 33 focused Google background/chaining/streaming tests
- `npm test` (824 files passed, 1 skipped; 8,420 tests passed, 4 skipped)

The new regressions assert same-ID resumption after transient failures, explicit replacement after a definitive miss, preservation of the original deadline (including late completion), safe accounting for a 404 during active polling, and cancellation when resume begins after user abort.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes long-running Google workflow retry semantics (duplicate generations vs resume) and error auto-retry classification for 404/410 and timeouts; scope is limited to the Google Interactions background path with regression tests.
> 
> **Overview**
> **Google Interactions background polling** no longer treats every node retry as a fresh `interactions.create`. After a successful submit, the handler keeps a **pending interaction id** and its **original three-hour deadline**, and on the next `createResponse` it **resumes polling** via `tryResumeBackgroundInteraction` before submitting again.
> 
> **Transient poll/`get` failures** (network, 5xx, etc.) leave that pending state in place so automatic retries **poll the same id** instead of spawning duplicate background generations. **HTTP 404/410** (and equivalent “gone” cases) clear pending state and surface **manual-retry-only** errors (`attachManualRetryOnlyError`) so replacements are not auto-submitted. **Timeouts, terminal failure, completion, abort, and expired deadlines** clear pending state and **best-effort cancel** the server job where appropriate.
> 
> Vitest cases **B12–B17** cover resume-after-transient-error, explicit replacement after miss, deadline preservation (including late completion), first-poll 404 behavior, and abort-on-resume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fc45f15d1cb16189f7fabd48f68682634f041ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



