### PR TITLE
fix(google): enforce resume boundaries after retrieval

### DIFF
--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1180,11 +1180,12 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     if (!stateful) this.invalidateChain();
 
     const pending = this.pendingBackgroundInteraction;
-    if (pending && signal?.aborted) {
-      if (this.clearPendingBackgroundInteraction(pending.id)) {
-        void this.cancelBackgroundInteraction(client, pending.id);
-      }
-      signal.throwIfAborted();
+    if (pending) {
+      this.throwIfPendingBackgroundInteractionAborted(
+        client,
+        pending.id,
+        signal,
+      );
     }
 
     const generationConfig = this.buildGenerationConfig(endTag);
@@ -1449,16 +1450,29 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
 
     let initial: GoogleGenAIInteraction;
     if (pending) {
-      if (Date.now() >= pending.deadlineAtMs) {
-        this.clearPendingBackgroundInteraction(pending.id);
-        await this.cancelBackgroundInteraction(client, pending.id);
-        throw this.createBackgroundTimeoutError(pending.id);
-      }
-      initial = await this.retrieveBackgroundInteraction(
+      this.throwIfPendingBackgroundInteractionAborted(
         client,
         pending.id,
-        requestOptions,
+        signal,
       );
+      await this.throwIfPendingBackgroundInteractionExpired(client, pending);
+      try {
+        initial = await this.retrieveBackgroundInteraction(
+          client,
+          pending.id,
+          requestOptions,
+        );
+      } finally {
+        // Retrieval happens before BackgroundPoller installs its guards.
+        // Recheck both boundaries after success or failure so neither outcome
+        // can bypass cancellation or extend the original lifetime.
+        this.throwIfPendingBackgroundInteractionAborted(
+          client,
+          pending.id,
+          signal,
+        );
+        await this.throwIfPendingBackgroundInteractionExpired(client, pending);
+      }
     } else {
       // background:true forces store:true (already true under `stateful`).
       const submitParams = {
@@ -1513,6 +1527,28 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     if (this.pendingBackgroundInteraction?.id !== interactionId) return false;
     this.pendingBackgroundInteraction = null;
     return true;
+  }
+
+  private throwIfPendingBackgroundInteractionAborted(
+    client: GoogleGenAI,
+    interactionId: string,
+    signal: AbortSignal | undefined,
+  ): void {
+    if (!signal?.aborted) return;
+    if (this.clearPendingBackgroundInteraction(interactionId)) {
+      void this.cancelBackgroundInteraction(client, interactionId);
+    }
+    signal.throwIfAborted();
+  }
+
+  private async throwIfPendingBackgroundInteractionExpired(
+    client: GoogleGenAI,
+    pending: PendingBackgroundInteraction,
+  ): Promise<void> {
+    if (Date.now() < pending.deadlineAtMs) return;
+    this.clearPendingBackgroundInteraction(pending.id);
+    await this.cancelBackgroundInteraction(client, pending.id);
+    throw this.createBackgroundTimeoutError(pending.id);
   }
 
   private createManualBackgroundError(message: string, cause?: unknown): Error {

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsBackground.vitest.ts
@@ -71,6 +71,7 @@ interface CapturedCalls {
 function bgClient(opts: {
   submit: () => Interaction;
   getSequence: Array<Interaction | Error>;
+  beforeGet?: (index: number) => void | Promise<void>;
   onCancel?: (id: string) => void | Promise<void>;
   generateContent?: () => Promise<unknown>;
   countTokens?: (params: unknown) => Promise<unknown>;
@@ -97,6 +98,7 @@ function bgClient(opts: {
       },
       get: async (id: string) => {
         calls.get.push(id);
+        await opts.beforeGet?.(getIdx);
         const next =
           opts.getSequence[Math.min(getIdx, opts.getSequence.length - 1)];
         getIdx += 1;
@@ -490,6 +492,119 @@ describe('ModelHandlerGoogleInteractions background mode', () => {
     expect(calls.create).toHaveLength(1);
     expect(calls.get).toEqual(['int_expire']);
     expect(calls.cancel).toEqual(['int_expire']);
+  });
+
+  it.each([
+    {
+      outcome: completedInteraction('int_late'),
+      outcomeLabel: 'returns',
+    },
+    { outcome: new TypeError('late failure'), outcomeLabel: 'rejects' },
+  ])(
+    'rejects a resumed retrieval that $outcomeLabel after the original deadline',
+    async ({ outcome }) => {
+      mockConfig();
+      const startedAt = new Date('2026-08-01T00:00:00.000Z');
+      vi.useFakeTimers({ now: startedAt });
+      const handler = createHandler();
+      const { client, calls } = bgClient({
+        submit: () => ({ id: 'int_late', status: 'in_progress' }),
+        getSequence: [new TypeError('fetch failed'), outcome],
+        beforeGet: (index) => {
+          if (index === 1) {
+            vi.setSystemTime(startedAt.getTime() + MAX_DURATION_MS);
+          }
+        },
+      });
+
+      const first = respond(handler, client, [userStep('a')]);
+      const firstError = captureRejection(first);
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      await firstError;
+
+      vi.setSystemTime(startedAt.getTime() + MAX_DURATION_MS - 1);
+      const timeout = await captureRejection(
+        respond(handler, client, [userStep('a')]),
+      );
+
+      expect(timeout.message).toContain(
+        `maximum polling duration of ${MAX_DURATION_MS} ms`,
+      );
+      expect(hasManualRetryOnlyErrorMarker(timeout)).toBe(true);
+      expect(calls.create).toHaveLength(1);
+      expect(calls.get).toEqual(['int_late', 'int_late']);
+      expect(calls.cancel).toEqual(['int_late']);
+    },
+  );
+
+  it.each([
+    {
+      outcome: completedInteraction('int_late_abort'),
+      outcomeLabel: 'returns',
+    },
+    { outcome: new TypeError('late failure'), outcomeLabel: 'rejects' },
+  ])(
+    'cancels when a resumed retrieval $outcomeLabel after user abort',
+    async ({ outcome }) => {
+      mockConfig();
+      vi.useFakeTimers();
+      const handler = createHandler();
+      const controller = new AbortController();
+      const { client, calls } = bgClient({
+        submit: () => ({ id: 'int_late_abort', status: 'in_progress' }),
+        getSequence: [new TypeError('fetch failed'), outcome],
+        beforeGet: (index) => {
+          if (index === 1) controller.abort();
+        },
+      });
+
+      const first = respond(handler, client, [userStep('a')]);
+      const firstError = captureRejection(first);
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      await firstError;
+
+      await expect(
+        respond(handler, client, [userStep('a')], controller.signal),
+      ).rejects.toMatchObject({ name: 'AbortError' });
+      await Promise.resolve();
+
+      expect(calls.create).toHaveLength(1);
+      expect(calls.get).toEqual(['int_late_abort', 'int_late_abort']);
+      expect(calls.cancel).toEqual(['int_late_abort']);
+    },
+  );
+
+  it('cancels before resumed retrieval when token counting observes abort', async () => {
+    mockConfig();
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    let countCalls = 0;
+    const countTokens = vi.fn(async () => {
+      countCalls += 1;
+      if (countCalls === 2) controller.abort();
+      return { totalTokens: 1 };
+    });
+    const handler = createHandler(AgentCategory.Workflow, true);
+    const { client, calls } = bgClient({
+      submit: () => ({ id: 'int_abort_before_resume', status: 'in_progress' }),
+      getSequence: [new TypeError('fetch failed')],
+      countTokens,
+    });
+
+    const first = respond(handler, client, [userStep('a')]);
+    const firstError = captureRejection(first);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    await firstError;
+
+    await expect(
+      respond(handler, client, [userStep('a')], controller.signal),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    await Promise.resolve();
+
+    expect(countTokens).toHaveBeenCalledTimes(2);
+    expect(calls.create).toHaveLength(1);
+    expect(calls.get).toEqual(['int_abort_before_resume']);
+    expect(calls.cancel).toEqual(['int_abort_before_resume']);
   });
 
   it('clears a pre-aborted pending interaction before token counting', async () => {


### PR DESCRIPTION
## Summary

- recheck cancellation and the original absolute deadline after a pending Google interaction is retrieved
- reject a terminal response that began retrieval before the deadline but returned after it
- cancel and clear a pending interaction if its retrieval returns after user cancellation
- keep abort and expiry accounting in two private lifecycle guards shared by all resume boundaries

## Issue acceptance gates

Advances #9532 as a narrow follow-up to #9570. The merged provider-lifecycle implementation correctly guards before resumed retrieval and inside BackgroundPoller; this PR closes the interval between those two guards. Durable lifecycle telemetry remains outside this PR, so #9532 stays open.

## Single source of truth

The handler now owns one abort guard and one expiry guard for pending background interactions. The same transitions are used before token work, immediately before resumed retrieval, and immediately after it.

## Duplication and abstraction budget

Two private guards replace repeated clear/cancel/error sequences. No export, provider abstraction, retry ledger, or host coupling is added.

## Net elements (R6)

- Files: 2 changed; none added or deleted.
- Lines: 163 additions, 12 deletions; net +151, including five deterministic boundary cases.
- Exported symbols: none added or deleted.
- Classes/interfaces/enums: none added or deleted.

## Consumer counts (R8)

n/a: no export, event key, or subscriber path is deleted or rerouted.

## Host impact

Extension: late Google resume results cannot outlive cancellation or the original interaction deadline.

Desktop: Same shared provider behavior.

CLI: Same shared provider behavior.

## Scheduled refactoring

#9532 remains open for compact durable retry/lifecycle diagnostics.

## Validation

- npm run format (target files)
- npm run typecheck:workspace
- npm run typecheck:test-kernel
- npm run lint
- npm run compile:fast
- 37 focused Google background tests
- npm test (824 files passed, 1 skipped; 8,438 tests passed, 4 skipped)

The regressions cover success and rejection after time or cancellation changes during resumed retrieval, plus cancellation during the intervening token-count phase. They assert exact creation, retrieval, cancellation, and terminal-error counts at each boundary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches long-running Google background interaction lifecycle (abort, deadline, cancel) on a shared model handler path; behavior change is narrow but affects when resumed polls are accepted or rejected.
> 
> **Overview**
> Closes a gap in **Google Interactions background resume**: lifecycle checks used to run before resumed `interactions.get` and inside `BackgroundPoller`, but not around the retrieval call itself. A slow or late `get` could still return a terminal result after the user aborted or after the interaction’s original max-polling deadline.
> 
> The handler now centralizes **abort** and **expiry** in `throwIfPendingBackgroundInteractionAborted` and `throwIfPendingBackgroundInteractionExpired`, and runs them whenever a pending interaction is resumed—at the start of `createResponseImpl`, immediately before retrieval, and again in a `finally` after retrieval succeeds or fails. Aborted resumes clear the pending id and trigger best-effort cancel; expired resumes cancel and throw the existing timeout error instead of accepting a late completion.
> 
> Vitest coverage drives fake time or abort during the second `get`, plus abort during token counting before resume, and asserts create/get/cancel counts at each boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fcf56fc78e95d0a42d8d836e01416b0f386769e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


