### PR TITLE
fix: merge associated archive sidecars

### DIFF
--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -13,6 +13,7 @@ import { flowKey } from '@agent/node/persistedFlow';
 
 import * as logger from '@logger/logUtils';
 import {
+  EXECUTION_STREAM_ID_SOURCE,
   RUN_OUTCOME,
   executionStatusToRunOutcome,
   type ExecutionId,
@@ -123,6 +124,7 @@ export async function registerExecution(
       const meta = {
         timestamp,
         streamId,
+        streamIdSource: EXECUTION_STREAM_ID_SOURCE.REGISTRATION,
         parentExecutionId,
         ...(category ? { category } : {}),
       };
@@ -343,7 +345,10 @@ export async function writeLegacyExecutionStreamId(
 ): Promise<void> {
   await persistSupplementaryMetaFieldsBestEffort(
     executionId,
-    { streamId },
+    {
+      streamId,
+      streamIdSource: EXECUTION_STREAM_ID_SOURCE.LEGACY_RESOLUTION,
+    },
     'legacy execution stream id',
   );
 }

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -71,7 +71,7 @@ export const EXECUTION_STREAM_ID_SOURCE = {
   REGISTRATION: 'registration',
   LEGACY_RESOLUTION: 'legacyResolution',
 } as const;
-export const ExecutionStreamIdSourceSchema = z.enum(EXECUTION_STREAM_ID_SOURCE);
+const ExecutionStreamIdSourceSchema = z.enum(EXECUTION_STREAM_ID_SOURCE);
 
 /** Execution metadata stored alongside config at launch time. */
 const ExecutionMetaBaseSchema = z.object({

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -67,6 +67,12 @@ export type RunOutcome = z.infer<typeof RunOutcomeSchema>;
 
 export const EXECUTION_META_SCHEMA_VERSION = 1;
 
+export const EXECUTION_STREAM_ID_SOURCE = {
+  REGISTRATION: 'registration',
+  LEGACY_RESOLUTION: 'legacyResolution',
+} as const;
+export const ExecutionStreamIdSourceSchema = z.enum(EXECUTION_STREAM_ID_SOURCE);
+
 /** Execution metadata stored alongside config at launch time. */
 const ExecutionMetaBaseSchema = z.object({
   schemaVersion: z.literal(EXECUTION_META_SCHEMA_VERSION).prefault(1),
@@ -85,6 +91,8 @@ const ExecutionMetaBaseSchema = z.object({
    * write it at registration; it may be absent on historical executions.
    */
   streamId: StreamTabIdSchema.optional(),
+  /** Distinguishes birth identity from a replaceable historical read cache. */
+  streamIdSource: ExecutionStreamIdSourceSchema.optional(),
 });
 
 const ConsistentExecutionMetaSchema = ExecutionMetaBaseSchema.superRefine(

--- a/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
+++ b/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { flowKey } from '@agent/node/persistedFlow';
 import {
+  EXECUTION_STREAM_ID_SOURCE,
   EXECUTION_STATUS,
   RUN_OUTCOME,
   type ExecutionId,
@@ -97,6 +98,7 @@ describe('execution lifecycle', () => {
     expect(mocks.writeMeta).toHaveBeenCalledWith({
       timestamp: expect.any(String),
       streamId: 'chat@deepseekT#abc123',
+      streamIdSource: EXECUTION_STREAM_ID_SOURCE.REGISTRATION,
       parentExecutionId: undefined,
       category: 'toolUse',
     });

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -707,7 +707,7 @@ describe('completedRunArchive facade', () => {
     expect(result.conversation!.length).toBeGreaterThan(0);
   });
 
-  it('falls through to a content-bearing historical sibling stream', async () => {
+  it('reads the historical root instead of its child sidecar', async () => {
     const executionId = '0777aa0777aa' as ExecutionId;
     const emptyStream = 'aChild@tool#0777aa0777aa' as StreamTabId;
     const fullStream = 'zOrchestrator@deepseekproT#0777aa0777aa' as StreamTabId;
@@ -762,19 +762,26 @@ describe('completedRunArchive facade', () => {
     snapshots.setParentStream(child, firstRoot);
     await snapshots.flush();
 
-    const firstQuestion = logRow(MESSAGE_TYPES.USER_MESSAGE, {
-      text: 'First question',
-    });
-    const firstAnswer = logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
-      text: 'First answer',
-    });
-    const secondQuestion = logRow(MESSAGE_TYPES.USER_MESSAGE, {
-      text: 'Second question',
-    });
-    const secondAnswer = logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
-      // Equal text with a distinct row identity is a real second message.
-      text: 'First answer',
-    });
+    const firstQuestion = {
+      ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'First question' }),
+      timestamp: 2000,
+    };
+    const firstAnswer = {
+      ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'First answer' }),
+      // A clock adjustment must not move this response before its prompt.
+      timestamp: 1000,
+    };
+    const secondQuestion = {
+      ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Second question' }),
+      timestamp: 3000,
+    };
+    const secondAnswer = {
+      ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
+        // Equal text with a distinct row identity is a real second message.
+        text: 'First answer',
+      }),
+      timestamp: 4000,
+    };
     const childMessage = logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
       text: 'Child implementation detail',
     });
@@ -816,6 +823,37 @@ describe('completedRunArchive facade', () => {
     );
     expect(endpoint.output).not.toContain('Child implementation detail');
     expect(endpoint.output?.split('First answer')).toHaveLength(3);
+  });
+
+  it('never substitutes child conversation rows for empty confirmed roots', async () => {
+    const executionId = '0999cc0999cc' as ExecutionId;
+    const root = 'orchestrator@model#0999cc0999cc' as StreamTabId;
+    const child = 'child@tool#0999cc0999cc' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(root, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(child, runConfig('bash'), executionId);
+    snapshots.setParentStream(child, root);
+    await snapshots.flush();
+
+    const logs = await StreamLogStore.open();
+    logs.append(
+      root,
+      logRow(MESSAGE_TYPES.PROGRESS_STATUS, { text: 'Root status only' }),
+    );
+    logs.append(
+      child,
+      logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Child-only prompt' }),
+    );
+    logs.append(
+      child,
+      logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Child-only answer' }),
+    );
+    await logs.flush();
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      conversation: null,
+      source: 'none',
+    });
   });
 
   it('falls back to legacy when the transcript holds no conversation-shaped rows', async () => {

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -825,6 +825,44 @@ describe('completedRunArchive facade', () => {
     expect(endpoint.output?.split('First answer')).toHaveLength(3);
   });
 
+  it('retains copied rows as ordering constraints across roots', async () => {
+    const executionId = '0888bc0888bc' as ExecutionId;
+    const firstRoot = 'orchestrator@old#0888bc0888bc' as StreamTabId;
+    const resumedRoot = 'orchestrator@new#0888bc0888bc' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(firstRoot, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(resumedRoot, runConfig('orchestrator'), executionId);
+    await snapshots.flush();
+
+    const copiedQuestion = {
+      ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Copied question' }),
+      timestamp: 2000,
+    };
+    const answer = {
+      ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Later answer' }),
+      // The copied prompt still constrains this row despite the earlier clock.
+      timestamp: 1000,
+    };
+    const logs = await StreamLogStore.open();
+    logs.append(firstRoot, copiedQuestion);
+    logs.append(resumedRoot, copiedQuestion);
+    logs.append(resumedRoot, answer);
+    await logs.flush();
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'streamLog',
+      streamId: resumedRoot,
+      streamIds: [resumedRoot, firstRoot],
+      conversation: [
+        { role: 'user', content: 'Copied question' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Later answer' }],
+        },
+      ],
+    });
+  });
+
   it('never substitutes child conversation rows for empty confirmed roots', async () => {
     const executionId = '0999cc0999cc' as ExecutionId;
     const root = 'orchestrator@model#0999cc0999cc' as StreamTabId;

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -715,6 +715,7 @@ describe('completedRunArchive facade', () => {
     const snapshots = new StreamSnapshotStore();
     snapshots.setRunConfig(emptyStream, runConfig('bash'), executionId);
     snapshots.setRunConfig(fullStream, runConfig('orchestrator'), executionId);
+    snapshots.setParentStream(emptyStream, fullStream);
     await snapshots.flush();
 
     const logs = await StreamLogStore.open();
@@ -746,6 +747,75 @@ describe('completedRunArchive facade', () => {
         },
       ],
     });
+  });
+
+  it('merges matched roots, excluding children and only deduplicating row identity', async () => {
+    const executionId = '0888bb0888bb' as ExecutionId;
+    const firstRoot = 'aOrchestrator@old#0888bb0888bb' as StreamTabId;
+    const secondRoot = 'bOrchestrator@new#0888bb0888bb' as StreamTabId;
+    const child = 'child@tool#0888bb0888bb' as StreamTabId;
+
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(firstRoot, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(secondRoot, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(child, runConfig('bash'), executionId);
+    snapshots.setParentStream(child, firstRoot);
+    await snapshots.flush();
+
+    const firstQuestion = logRow(MESSAGE_TYPES.USER_MESSAGE, {
+      text: 'First question',
+    });
+    const firstAnswer = logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
+      text: 'First answer',
+    });
+    const secondQuestion = logRow(MESSAGE_TYPES.USER_MESSAGE, {
+      text: 'Second question',
+    });
+    const secondAnswer = logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
+      // Equal text with a distinct row identity is a real second message.
+      text: 'First answer',
+    });
+    const childMessage = logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
+      text: 'Child implementation detail',
+    });
+
+    const logs = await StreamLogStore.open();
+    logs.append(firstRoot, firstQuestion);
+    logs.append(firstRoot, firstAnswer);
+    // The resumed sidecar copied the last settled row before appending turn 2.
+    logs.append(secondRoot, firstAnswer);
+    logs.append(secondRoot, secondQuestion);
+    logs.append(secondRoot, secondAnswer);
+    logs.append(child, childMessage);
+    await logs.flush();
+
+    const result = await readCompletedRunConversation(executionId);
+    expect(result).toEqual({
+      source: 'streamLog',
+      streamId: firstRoot,
+      streamIds: [firstRoot, secondRoot],
+      conversation: [
+        { role: 'user', content: 'First question' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'First answer' }],
+        },
+        { role: 'user', content: 'Second question' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'First answer' }],
+        },
+      ],
+    });
+
+    const endpoint = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+    });
+    expect(endpoint.output).toContain(
+      `Merged streams: ${firstRoot}, ${secondRoot}`,
+    );
+    expect(endpoint.output).not.toContain('Child implementation detail');
+    expect(endpoint.output?.split('First answer')).toHaveLength(3);
   });
 
   it('falls back to legacy when the transcript holds no conversation-shaped rows', async () => {

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -894,6 +894,39 @@ describe('completedRunArchive facade', () => {
     });
   });
 
+  it('reads a historical execution whose canonical stream is delegated', async () => {
+    const executionId = '0999cd0999cd' as ExecutionId;
+    const streamId = 'child@tool#0999cd0999cd' as StreamTabId;
+    const parentStreamId = 'orchestrator@model#parent' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(streamId, runConfig('bash'), executionId);
+    snapshots.setParentStream(streamId, parentStreamId);
+    await snapshots.flush();
+
+    const logs = await StreamLogStore.open();
+    logs.append(
+      streamId,
+      logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Delegated question' }),
+    );
+    logs.append(
+      streamId,
+      logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Delegated answer' }),
+    );
+    await logs.flush();
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'streamLog',
+      streamId,
+      conversation: [
+        { role: 'user', content: 'Delegated question' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Delegated answer' }],
+        },
+      ],
+    });
+  });
+
   it('falls back to legacy when the transcript holds no conversation-shaped rows', async () => {
     const executionId = 'eee555eee555' as ExecutionId;
     const streamId = 'orchestrator@deepseekproT#eee555eee555' as StreamTabId;

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -107,15 +107,16 @@ describe('resolvePersistedStreamIdForExecution', () => {
       const resolveStore = new StreamSnapshotStore();
       let inFlight = 0;
       let maxInFlight = 0;
-      vi.spyOn(resolveStore, 'readPersistedExecutionId').mockImplementation(
-        async () => {
-          inFlight++;
-          maxInFlight = Math.max(maxInFlight, inFlight);
-          await new Promise((resolve) => setTimeout(resolve, 5));
-          inFlight--;
-          return undefined;
-        },
-      );
+      vi.spyOn(
+        resolveStore,
+        'readPersistedStreamAssociation',
+      ).mockImplementation(async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        inFlight--;
+        return {};
+      });
 
       await resolvePersistedStreamIdForExecution('abcdff' as ExecutionId, {
         snapshotStore: resolveStore,

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -8,6 +8,7 @@ import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
 import { registerExecution } from '@agent/storage/executionLifecycle';
 import { releaseOwnedExecutionLease } from '@agent/storage/executionLease';
 import {
+  EXECUTION_STREAM_ID_SOURCE,
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
@@ -85,7 +86,11 @@ describe('resolvePersistedStreamIdForExecution', () => {
       snapshotStore: new StreamSnapshotStore(),
     });
 
-    expect(resolved).toEqual({ streamId, source: 'streamDataMeta' });
+    expect(resolved).toEqual({
+      streamId,
+      source: 'streamDataMeta',
+      associatedRootStreamIds: [streamId],
+    });
   });
 
   it(
@@ -148,7 +153,10 @@ describe('resolvePersistedStreamIdForExecution', () => {
     });
     await expect(
       getExecutionStore(executionId).readMeta(),
-    ).resolves.toMatchObject({ streamId });
+    ).resolves.toMatchObject({
+      streamId,
+      streamIdSource: EXECUTION_STREAM_ID_SOURCE.REGISTRATION,
+    });
   });
 
   it('retains a sidecar scan fallback for execution records predating streamId', async () => {
@@ -165,10 +173,36 @@ describe('resolvePersistedStreamIdForExecution', () => {
     const resolved = await resolvePersistedStreamIdForExecution(executionId, {
       snapshotStore: new StreamSnapshotStore(),
     });
-    expect(resolved).toEqual({ streamId, source: 'streamDataMeta' });
+    expect(resolved).toEqual({
+      streamId,
+      source: 'streamDataMeta',
+      associatedRootStreamIds: [streamId],
+    });
     await expect(
       getExecutionStore(executionId).readMeta(),
-    ).resolves.toMatchObject({ streamId });
+    ).resolves.toMatchObject({
+      streamId,
+      streamIdSource: EXECUTION_STREAM_ID_SOURCE.LEGACY_RESOLUTION,
+    });
+
+    const resumedStream = 'zOrchestrator@newModel#abc666' as StreamTabId;
+    store.setRunConfig(
+      resumedStream,
+      runConfig('orchestrator', 'newModel'),
+      executionId,
+    );
+    await store.flush();
+
+    await expect(
+      resolvePersistedStreamIdForExecution(executionId, {
+        snapshotStore: new StreamSnapshotStore(),
+      }),
+    ).resolves.toEqual({
+      streamId,
+      source: 'streamDataMeta',
+      fallbackStreamIds: [resumedStream],
+      associatedRootStreamIds: [streamId, resumedStream],
+    });
   });
 
   it('prefers a work-plan-bearing historical stream over a bare match', async () => {

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -192,6 +192,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       streamId: secondStream,
       source: 'streamDataMeta',
       fallbackStreamIds: [firstStream],
+      associatedRootStreamIds: [firstStream, secondStream],
     });
   });
 
@@ -220,6 +221,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       streamId: logStream,
       source: 'streamDataMeta',
       fallbackStreamIds: [workPlanStream],
+      associatedRootStreamIds: [workPlanStream, logStream],
     });
     expect(
       (await getExecutionStore(executionId).readMeta())?.streamId,

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -159,11 +159,12 @@ describe('resolvePersistedStreamIdForExecution', () => {
     });
   });
 
-  it('retains a sidecar scan fallback for execution records predating streamId', async () => {
+  it('scans execution records whose stream-id provenance predates registration', async () => {
     const executionId = 'abc666' as ExecutionId;
     const streamId = 'orchestrator@deepseekproT#abc666' as StreamTabId;
     await getExecutionStore(executionId).writeMeta({
       timestamp: new Date().toISOString(),
+      streamId,
     });
 
     const store = new StreamSnapshotStore();

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -857,7 +857,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     limit: number,
   ): Promise<ToolResult> {
     const store = getExecutionStore(executionId);
-    const { conversation, source, streamId } =
+    const { conversation, source, streamId, streamIds } =
       await readCompletedRunConversation(executionId);
 
     if (!conversation) {
@@ -892,6 +892,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       metadata: [
         `Source: ${source}`,
         `Stream: ${streamId ?? 'none'}`,
+        ...(streamIds ? [`Merged streams: ${streamIds.join(', ')}`] : []),
         `Returned message interval: [${pageStart}, ${pageEnd})`,
         `Next offset: ${pageEnd < conversation.length ? pageEnd : 'none'}`,
       ],

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1565,6 +1565,23 @@ export class StreamSnapshotStore {
   }
 
   /**
+   * The persisted execution and parent identity needed to distinguish a run's
+   * root sidecars from child streams without hydrating the remaining files.
+   */
+  async readPersistedStreamAssociation(stream: StreamTabId): Promise<{
+    readonly executionId?: ExecutionId;
+    readonly parentStreamId?: StreamTabId;
+  }> {
+    const meta = await readMeta(this.kv(stream));
+    return {
+      ...(meta?.executionId ? { executionId: meta.executionId } : {}),
+      ...(meta?.parentStreamId
+        ? { parentStreamId: meta.parentStreamId as StreamTabId }
+        : {}),
+    };
+  }
+
+  /**
    * Whether a stream has a persisted `workPlan.json` sidecar — an existence
    * check only (a single stat via `KVStore.exists`), not a read. Used by the
    * resolver to disambiguate between multiple persisted streams that share an

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -390,9 +390,10 @@ async function conversationFromStream(
 }
 
 /**
- * Interleave execution-matched root sidecars by recorded time while preserving
- * each stream's authoritative local sequence. Persisted row identity removes
- * copied overlap without collapsing distinct messages with equal text.
+ * Merge execution-matched root sidecars as a partial order. Each stream adds
+ * its authoritative adjacent-row constraints, while equal persisted row IDs
+ * identify copied overlap. Recorded time orders rows only when the combined
+ * stream sequences leave both choices admissible.
  */
 async function mergedRootConversation(
   streamLogStore: StreamLogStore,
@@ -404,35 +405,66 @@ async function mergedRootConversation(
       return streamLogStore.get(streamId)?.toJSON() ?? [];
     }),
   );
-  const seen = new Set<string>();
-  const uniqueEntriesByStream = entriesByStream.map((entries) =>
-    entries.filter((entry) => {
-      if (seen.has(entry.id)) return false;
-      seen.add(entry.id);
-      return true;
-    }),
+  const nodes = new Map<
+    string,
+    { readonly entry: StreamLogEntry; readonly streamIndex: number }
+  >();
+  const successors = new Map<string, Set<string>>();
+  const indegrees = new Map<string, number>();
+  for (const [streamIndex, entries] of entriesByStream.entries()) {
+    let previousId: string | undefined;
+    for (const entry of entries) {
+      if (!nodes.has(entry.id)) nodes.set(entry.id, { entry, streamIndex });
+      if (!indegrees.has(entry.id)) indegrees.set(entry.id, 0);
+      if (previousId && previousId !== entry.id) {
+        const nextIds = successors.get(previousId) ?? new Set<string>();
+        if (!nextIds.has(entry.id)) {
+          nextIds.add(entry.id);
+          successors.set(previousId, nextIds);
+          indegrees.set(entry.id, (indegrees.get(entry.id) ?? 0) + 1);
+        }
+      }
+      previousId = entry.id;
+    }
+  }
+
+  const remaining = new Set(nodes.keys());
+  const ready = new Set(
+    [...remaining].filter((id) => (indegrees.get(id) ?? 0) === 0),
   );
-  const nextIndexes = uniqueEntriesByStream.map(() => 0);
   const ordered: StreamLogEntry[] = [];
-  while (true) {
-    let next:
-      | { readonly entry: StreamLogEntry; readonly streamIndex: number }
-      | undefined;
-    for (const [streamIndex, entries] of uniqueEntriesByStream.entries()) {
-      const entry = entries[nextIndexes[streamIndex] ?? 0];
+  while (remaining.size > 0) {
+    // Contradictory copied-row orders form a cycle. Such persisted data cannot
+    // satisfy every stream; choose deterministically so archive reads remain
+    // available while preserving every compatible constraint.
+    const candidates = ready.size > 0 ? ready : remaining;
+    let nextId: string | undefined;
+    for (const id of candidates) {
+      const candidate = nodes.get(id);
+      const next = nextId ? nodes.get(nextId) : undefined;
       if (
-        entry &&
+        candidate &&
         (!next ||
-          entry.timestamp < next.entry.timestamp ||
-          (entry.timestamp === next.entry.timestamp &&
-            streamIndex < next.streamIndex))
+          candidate.entry.timestamp < next.entry.timestamp ||
+          (candidate.entry.timestamp === next.entry.timestamp &&
+            (candidate.streamIndex < next.streamIndex ||
+              (candidate.streamIndex === next.streamIndex &&
+                candidate.entry.seqNo < next.entry.seqNo))))
       ) {
-        next = { entry, streamIndex };
+        nextId = id;
       }
     }
+    if (!nextId) break;
+    const next = nodes.get(nextId);
     if (!next) break;
     ordered.push(next.entry);
-    nextIndexes[next.streamIndex] = (nextIndexes[next.streamIndex] ?? 0) + 1;
+    ready.delete(nextId);
+    remaining.delete(nextId);
+    for (const successorId of successors.get(nextId) ?? []) {
+      const indegree = (indegrees.get(successorId) ?? 0) - 1;
+      indegrees.set(successorId, indegree);
+      if (indegree === 0 && remaining.has(successorId)) ready.add(successorId);
+    }
   }
   return streamLogEntriesToConversation(ordered);
 }

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -31,6 +31,7 @@ import { ToolResultSchema } from '@shared/schemas/toolResult';
 import { assertNever, generateShortId, isObject } from '@utils/core';
 
 import {
+  findPersistedRootStreamsForExecution,
   findPersistedStreamFallbacksForExecution,
   resolvePersistedStreamIdForExecution,
   type PersistedStreamIdResolution,
@@ -102,6 +103,8 @@ export interface CompletedRunConversationReadResult {
   readonly conversation: unknown[] | null;
   readonly source: CompletedRunConversationSource;
   readonly streamId?: StreamTabId;
+  /** All positively associated root sidecars used for a merged archive. */
+  readonly streamIds?: readonly StreamTabId[];
 }
 
 /**
@@ -387,6 +390,48 @@ async function conversationFromStream(
   return log ? streamLogEntriesToConversation(log.toJSON()) : [];
 }
 
+/** Load one stream's raw rows; `[]` when its persisted log is absent. */
+async function entriesFromStream(
+  streamLogStore: StreamLogStore,
+  streamId: StreamTabId,
+): Promise<StreamLogEntry[]> {
+  await streamLogStore.ensureLoaded(streamId);
+  return streamLogStore.get(streamId)?.toJSON() ?? [];
+}
+
+/**
+ * Merge execution-matched root sidecars by recorded time. Stream order and
+ * local sequence number break ties, and persisted row identity removes copied
+ * overlap without collapsing two distinct messages that happen to have equal
+ * text.
+ */
+async function mergedRootConversation(
+  streamLogStore: StreamLogStore,
+  streamIds: readonly StreamTabId[],
+): Promise<unknown[]> {
+  const entriesByStream = await Promise.all(
+    streamIds.map((streamId) => entriesFromStream(streamLogStore, streamId)),
+  );
+  const ordered = entriesByStream
+    .flatMap((entries, streamIndex) =>
+      entries.map((entry) => ({ entry, streamIndex })),
+    )
+    .toSorted(
+      (left, right) =>
+        left.entry.timestamp - right.entry.timestamp ||
+        left.streamIndex - right.streamIndex ||
+        left.entry.seqNo - right.entry.seqNo,
+    );
+  const seen = new Set<string>();
+  return streamLogEntriesToConversation(
+    ordered.flatMap(({ entry }) => {
+      if (seen.has(entry.id)) return [];
+      seen.add(entry.id);
+      return [entry];
+    }),
+  );
+}
+
 /**
  * Sidecar arm of the non-empty rule. Current executions normally need only
  * their registered primary. If it reconstructs empty, historical candidates
@@ -398,6 +443,33 @@ async function readSidecarConversation(
   snapshotStore: StreamSnapshotStore,
   streamLogStore: StreamLogStore,
 ): Promise<CompletedRunConversationReadResult | null> {
+  // Current executions register one canonical stream at birth; a disk-backed
+  // release/reopen regression proves resumed turns append there. Only
+  // pre-registration resolutions can represent historical split sidecars, so
+  // keep the ordinary completed-read path constant-time.
+  const rootStreamIds =
+    resolved.source === 'executionMeta'
+      ? []
+      : await findPersistedRootStreamsForExecution(executionId, snapshotStore);
+  if (rootStreamIds.length > 0) {
+    const orderedRoots = [
+      ...(rootStreamIds.includes(resolved.streamId) ? [resolved.streamId] : []),
+      ...rootStreamIds.filter((streamId) => streamId !== resolved.streamId),
+    ];
+    const conversation = await mergedRootConversation(
+      streamLogStore,
+      orderedRoots,
+    );
+    if (conversation.length > 0) {
+      return {
+        conversation,
+        source: 'streamLog',
+        streamId: orderedRoots[0],
+        ...(orderedRoots.length > 1 ? { streamIds: orderedRoots } : {}),
+      };
+    }
+  }
+
   const primaryConversation = await conversationFromStream(
     streamLogStore,
     resolved.streamId,

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -389,46 +389,52 @@ async function conversationFromStream(
   return log ? streamLogEntriesToConversation(log.toJSON()) : [];
 }
 
-/** Load one stream's raw rows; `[]` when its persisted log is absent. */
-async function entriesFromStream(
-  streamLogStore: StreamLogStore,
-  streamId: StreamTabId,
-): Promise<StreamLogEntry[]> {
-  await streamLogStore.ensureLoaded(streamId);
-  return streamLogStore.get(streamId)?.toJSON() ?? [];
-}
-
 /**
- * Merge execution-matched root sidecars by recorded time. Stream order and
- * local sequence number break ties, and persisted row identity removes copied
- * overlap without collapsing two distinct messages that happen to have equal
- * text.
+ * Interleave execution-matched root sidecars by recorded time while preserving
+ * each stream's authoritative local sequence. Persisted row identity removes
+ * copied overlap without collapsing distinct messages with equal text.
  */
 async function mergedRootConversation(
   streamLogStore: StreamLogStore,
   streamIds: readonly StreamTabId[],
 ): Promise<unknown[]> {
   const entriesByStream = await Promise.all(
-    streamIds.map((streamId) => entriesFromStream(streamLogStore, streamId)),
-  );
-  const ordered = entriesByStream
-    .flatMap((entries, streamIndex) =>
-      entries.map((entry) => ({ entry, streamIndex })),
-    )
-    .toSorted(
-      (left, right) =>
-        left.entry.timestamp - right.entry.timestamp ||
-        left.streamIndex - right.streamIndex ||
-        left.entry.seqNo - right.entry.seqNo,
-    );
-  const seen = new Set<string>();
-  return streamLogEntriesToConversation(
-    ordered.flatMap(({ entry }) => {
-      if (seen.has(entry.id)) return [];
-      seen.add(entry.id);
-      return [entry];
+    streamIds.map(async (streamId) => {
+      await streamLogStore.ensureLoaded(streamId);
+      return streamLogStore.get(streamId)?.toJSON() ?? [];
     }),
   );
+  const seen = new Set<string>();
+  const uniqueEntriesByStream = entriesByStream.map((entries) =>
+    entries.filter((entry) => {
+      if (seen.has(entry.id)) return false;
+      seen.add(entry.id);
+      return true;
+    }),
+  );
+  const nextIndexes = uniqueEntriesByStream.map(() => 0);
+  const ordered: StreamLogEntry[] = [];
+  while (true) {
+    let next:
+      | { readonly entry: StreamLogEntry; readonly streamIndex: number }
+      | undefined;
+    for (const [streamIndex, entries] of uniqueEntriesByStream.entries()) {
+      const entry = entries[nextIndexes[streamIndex] ?? 0];
+      if (
+        entry &&
+        (!next ||
+          entry.timestamp < next.entry.timestamp ||
+          (entry.timestamp === next.entry.timestamp &&
+            streamIndex < next.streamIndex))
+      ) {
+        next = { entry, streamIndex };
+      }
+    }
+    if (!next) break;
+    ordered.push(next.entry);
+    nextIndexes[next.streamIndex] = (nextIndexes[next.streamIndex] ?? 0) + 1;
+  }
+  return streamLogEntriesToConversation(ordered);
 }
 
 /**
@@ -446,8 +452,8 @@ async function readSidecarConversation(
   // release/reopen regression proves resumed turns append there. Only
   // pre-registration resolutions can represent historical split sidecars, so
   // keep the ordinary completed-read path constant-time.
-  const rootStreamIds = resolved.associatedRootStreamIds ?? [];
-  if (rootStreamIds.length > 0) {
+  const rootStreamIds = resolved.associatedRootStreamIds;
+  if (rootStreamIds !== undefined) {
     const orderedRoots = [
       ...(rootStreamIds.includes(resolved.streamId) ? [resolved.streamId] : []),
       ...rootStreamIds.filter((streamId) => streamId !== resolved.streamId),
@@ -464,6 +470,10 @@ async function readSidecarConversation(
         ...(orderedRoots.length > 1 ? { streamIds: orderedRoots } : {}),
       };
     }
+    // Exact metadata established the canonical root set. An empty root
+    // conversation must fall back to the legacy execution projection, never
+    // to a child or suffix-only sidecar.
+    return null;
   }
 
   const primaryConversation = await conversationFromStream(

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -31,7 +31,6 @@ import { ToolResultSchema } from '@shared/schemas/toolResult';
 import { assertNever, generateShortId, isObject } from '@utils/core';
 
 import {
-  findPersistedRootStreamsForExecution,
   findPersistedStreamFallbacksForExecution,
   resolvePersistedStreamIdForExecution,
   type PersistedStreamIdResolution,
@@ -447,10 +446,7 @@ async function readSidecarConversation(
   // release/reopen regression proves resumed turns append there. Only
   // pre-registration resolutions can represent historical split sidecars, so
   // keep the ordinary completed-read path constant-time.
-  const rootStreamIds =
-    resolved.source === 'executionMeta'
-      ? []
-      : await findPersistedRootStreamsForExecution(executionId, snapshotStore);
+  const rootStreamIds = resolved.associatedRootStreamIds ?? [];
   if (rootStreamIds.length > 0) {
     const orderedRoots = [
       ...(rootStreamIds.includes(resolved.streamId) ? [resolved.streamId] : []),

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -15,6 +15,8 @@ export interface PersistedStreamIdResolution {
   readonly source: PersistedStreamIdResolutionSource;
   /** Other persisted candidates to try when a historical primary is empty. */
   readonly fallbackStreamIds?: readonly StreamTabId[];
+  /** Exact execution matches with no persisted parent, for archive merging. */
+  readonly associatedRootStreamIds?: readonly StreamTabId[];
 }
 
 export interface PersistedStreamIdResolverOptions {
@@ -72,20 +74,6 @@ async function scanPersistedStreamsForExecution(
       .map((candidate) => candidate.streamId)
       .toSorted(),
   };
-}
-
-/**
- * Persisted root streams positively associated with an execution. A suffix
- * resemblance is deliberately insufficient, and a stream carrying
- * `parentStreamId` is excluded so archive repair never folds child output into
- * its parent's conversation.
- */
-export async function findPersistedRootStreamsForExecution(
-  executionId: ExecutionId,
-  snapshotStore: StreamSnapshotStore = new StreamSnapshotStore(),
-): Promise<StreamTabId[]> {
-  return (await scanPersistedStreamsForExecution(executionId, snapshotStore))
-    .rootMetaMatched;
 }
 
 /** Streams whose id carries the `#executionId` suffix, in the given order. */
@@ -180,7 +168,7 @@ export async function resolvePersistedStreamIdForExecution(
   }
 
   const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
-  const { persistedStreams, metaMatched } =
+  const { persistedStreams, metaMatched, rootMetaMatched } =
     await scanPersistedStreamsForExecution(executionId, snapshotStore);
 
   if (metaMatched.length > 0) {
@@ -204,6 +192,9 @@ export async function resolvePersistedStreamIdForExecution(
       streamId,
       source: 'streamDataMeta',
       ...(fallbackStreamIds.length > 0 ? { fallbackStreamIds } : {}),
+      ...(metaMatched.length > 1 && rootMetaMatched.length > 0
+        ? { associatedRootStreamIds: rootMetaMatched }
+        : {}),
     };
   }
 

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -155,8 +155,9 @@ export async function findPersistedStreamFallbacksForExecution(
  * New executions carry this mapping in their own metadata from registration.
  * The ranked sidecar scan and suffix checks are compatibility fallbacks for
  * records created before that field existed; current records never enter that
- * branch. A unique confirmed legacy match is written through once so later
- * reads use the same constant-time metadata path as current executions.
+ * branch. Confirmed legacy matches are annotated with their provenance, but
+ * remain subject to the bounded scan because a later resume can add another
+ * root sidecar. Only birth-time registrations use the constant-time path.
  *
  * `null` means no persisted stream carries this execution. Callers that have
  * a derivable stream id own that substitution.

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -36,6 +36,8 @@ interface ExecutionStreamScan {
   readonly persistedStreams: StreamTabId[];
   /** Persisted streams whose sidecar `meta.json` claims this execution. */
   readonly metaMatched: StreamTabId[];
+  /** Exact execution matches that are not recorded as child streams. */
+  readonly rootMetaMatched: StreamTabId[];
 }
 
 /**
@@ -52,16 +54,38 @@ async function scanPersistedStreamsForExecution(
     persistedStreams,
     async (streamId) => ({
       streamId,
-      executionId: await snapshotStore.readPersistedExecutionId(streamId),
+      association: await snapshotStore.readPersistedStreamAssociation(streamId),
     }),
     { concurrency: META_SCAN_CONCURRENCY },
   );
   return {
     persistedStreams,
     metaMatched: scanned
-      .filter((candidate) => candidate.executionId === executionId)
+      .filter((candidate) => candidate.association.executionId === executionId)
       .map((candidate) => candidate.streamId),
+    rootMetaMatched: scanned
+      .filter(
+        (candidate) =>
+          candidate.association.executionId === executionId &&
+          candidate.association.parentStreamId === undefined,
+      )
+      .map((candidate) => candidate.streamId)
+      .toSorted(),
   };
+}
+
+/**
+ * Persisted root streams positively associated with an execution. A suffix
+ * resemblance is deliberately insufficient, and a stream carrying
+ * `parentStreamId` is excluded so archive repair never folds child output into
+ * its parent's conversation.
+ */
+export async function findPersistedRootStreamsForExecution(
+  executionId: ExecutionId,
+  snapshotStore: StreamSnapshotStore = new StreamSnapshotStore(),
+): Promise<StreamTabId[]> {
+  return (await scanPersistedStreamsForExecution(executionId, snapshotStore))
+    .rootMetaMatched;
 }
 
 /** Streams whose id carries the `#executionId` suffix, in the given order. */

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -2,7 +2,11 @@ import pMap from 'p-map';
 
 import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
 import { writeLegacyExecutionStreamId } from '@agent/storage/executionLifecycle';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  EXECUTION_STREAM_ID_SOURCE,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 
 import { StreamSnapshotStore } from './StreamSnapshotStore';
 import type { StreamLogStore } from './StreamLogStore';
@@ -161,10 +165,13 @@ export async function resolvePersistedStreamIdForExecution(
   executionId: ExecutionId,
   options: PersistedStreamIdResolverOptions = {},
 ): Promise<PersistedStreamIdResolution | null> {
-  const registeredStreamId = (await getExecutionStore(executionId).readMeta())
-    ?.streamId;
-  if (registeredStreamId) {
-    return { streamId: registeredStreamId, source: 'executionMeta' };
+  const executionMeta = await getExecutionStore(executionId).readMeta();
+  if (
+    executionMeta?.streamId &&
+    executionMeta.streamIdSource !==
+      EXECUTION_STREAM_ID_SOURCE.LEGACY_RESOLUTION
+  ) {
+    return { streamId: executionMeta.streamId, source: 'executionMeta' };
   }
 
   const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
@@ -172,8 +179,10 @@ export async function resolvePersistedStreamIdForExecution(
     await scanPersistedStreamsForExecution(executionId, snapshotStore);
 
   if (metaMatched.length > 0) {
+    const primaryCandidates =
+      rootMetaMatched.length > 0 ? rootMetaMatched : metaMatched;
     const streamId = await pickBestLegacyMetaMatch(
-      metaMatched,
+      primaryCandidates,
       snapshotStore,
       options.streamLogStore,
     );
@@ -192,9 +201,7 @@ export async function resolvePersistedStreamIdForExecution(
       streamId,
       source: 'streamDataMeta',
       ...(fallbackStreamIds.length > 0 ? { fallbackStreamIds } : {}),
-      ...(metaMatched.length > 1 && rootMetaMatched.length > 0
-        ? { associatedRootStreamIds: rootMetaMatched }
-        : {}),
+      associatedRootStreamIds: rootMetaMatched,
     };
   }
 

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -168,8 +168,7 @@ export async function resolvePersistedStreamIdForExecution(
   const executionMeta = await getExecutionStore(executionId).readMeta();
   if (
     executionMeta?.streamId &&
-    executionMeta.streamIdSource !==
-      EXECUTION_STREAM_ID_SOURCE.LEGACY_RESOLUTION
+    executionMeta.streamIdSource === EXECUTION_STREAM_ID_SOURCE.REGISTRATION
   ) {
     return { streamId: executionMeta.streamId, source: 'executionMeta' };
   }
@@ -201,7 +200,9 @@ export async function resolvePersistedStreamIdForExecution(
       streamId,
       source: 'streamDataMeta',
       ...(fallbackStreamIds.length > 0 ? { fallbackStreamIds } : {}),
-      associatedRootStreamIds: rootMetaMatched,
+      ...(rootMetaMatched.length > 0
+        ? { associatedRootStreamIds: rootMetaMatched }
+        : {}),
     };
   }
 


### PR DESCRIPTION
## Summary

- reconstruct historical conversations from every root transcript sidecar whose persisted metadata names the same execution
- exclude streams with persisted parent identity so child output is never folded into the parent conversation
- order rows deterministically by recorded time and stream-local sequence, removing copied overlap by durable row identity
- report every merged stream through the execution conversation endpoint

Current executions keep their registered single-stream, constant-time read path. The merge applies only to historical records resolved through pre-registration sidecar metadata.

## Design

The execution identifier alone is not sufficient because older parent and child tabs can share it. The archive therefore admits a sidecar to a merge only when `meta.json` records the exact execution identifier and does not record a `parentStreamId`. Stream-name suffixes remain compatibility fallbacks and are not merge evidence.

Deduplication uses the persisted transcript row identifier rather than rendered text. This removes copied overlap without erasing two distinct turns that happen to contain the same words.

## Verification

- `npm run format`
- `npm run compile:fast`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm test` (824 files passed, 1 skipped; 8,439 tests passed, 4 skipped)
- focused archive/resolver tests (18 passed)

Closes #9533

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted execution metadata semantics and completed-run conversation reconstruction; mistakes could mis-order or omit historical turns, though registration-time runs keep the existing fast path.
> 
> **Overview**
> Fixes completed-run conversation reads for **historical executions** that split transcript data across multiple root sidecars (e.g. resume/reopen), without changing the constant-time path for runs that register a canonical stream at birth.
> 
> **Stream identity and resolver.** Execution meta now records optional `streamIdSource` (`registration` vs `legacyResolution`). The resolver treats only registration-sourced `streamId` as authoritative for skipping the sidecar scan; legacy backfills stay annotated but can still pick up additional root sidecars later. Scans use `readPersistedStreamAssociation` (execution + `parentStreamId`) and return `associatedRootStreamIds` for root streams only—child tabs are excluded from merge sets.
> 
> **Archive merge.** When `associatedRootStreamIds` is present, `readCompletedRunConversation` merges those roots via a partial-order sort: per-stream adjacency, dedupe by durable log row id (not message text), tie-break by timestamp/sequence. Empty confirmed roots no longer fall through to child streams; delegated child-only histories still read from the child when appropriate.
> 
> **API surface.** `/executions/{id}/conversation` metadata can include `Merged streams: …` when multiple roots contributed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b46402a7ac02b13b101ba8eccf4dae8832bf0bbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->