### PR TITLE
fix(agent): persist retry lifecycle diagnostics

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -334,6 +334,9 @@ async function requestRetryInteraction(
   // Written before any path that can produce a credential-changing decision:
   // only the modal and the auto-switch produce one, and both run after this.
   let promptRequest: TuiRetryRequest = request;
+  const retryDecision: { source: 'human' | 'automatic' } = {
+    source: 'human',
+  };
 
   const immediate = immediateDecisionForApproval(
     'showRetryRequest',
@@ -387,6 +390,7 @@ async function requestRetryInteraction(
         );
       }
       if (autoSwitch) {
+        retryDecision.source = 'automatic';
         reservation.settle(autoSwitch);
         return;
       }
@@ -435,7 +439,13 @@ async function requestRetryInteraction(
     // A cancel landing while the last preparation step was already resolving
     // has no await left to reject, so the entry's own state decides.
     if (reservation.signal.aborted) return { action: 'cancel' };
-    return { action: 'retry', feedback: decision.userMessage };
+    return {
+      action: 'retry',
+      feedback: decision.userMessage,
+      ...(retryDecision.source === 'automatic'
+        ? { decisionSource: retryDecision.source }
+        : {}),
+    };
   } catch (error) {
     if (reservation.signal.aborted) return { action: 'cancel' };
     return { action: 'deny', reason: toErrorMessage(error) };

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -40,9 +40,13 @@ function applyEntry(
   streamLogs: StreamLogs,
   streamState: StreamState,
 ): EntryResult {
-  // This is a live CLI/TUI signal, not progress history. Drop it before
-  // indexing so invisible lifecycle markers cannot consume timeline windows.
-  if (entry.messageType === MESSAGE_TYPES.CONTEXT_COMPACTION_ACTIVITY) {
+  // These records are persisted for diagnostics or live CLI/TUI state, not
+  // progress presentation. Drop them before invisible rows consume timeline
+  // windows or fall through to the default log formatter.
+  if (
+    entry.messageType === MESSAGE_TYPES.CONTEXT_COMPACTION_ACTIVITY ||
+    entry.messageType === MESSAGE_TYPES.INTERNAL
+  ) {
     return { logChanged: false, stateChanged: false };
   }
 

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -85,6 +85,14 @@ export class ModelInvocationNode<
     return this._config.operationName;
   }
 
+  protected override isSuccessfulInvocationResult(result: unknown): boolean {
+    const invocationResult =
+      result as InvocationResult<BaseInvocationSuccessData>;
+    return (
+      invocationResult.kind === 'success' && Boolean(invocationResult.response)
+    );
+  }
+
   protected override isBackgroundModeActive(): boolean {
     return (
       this._config.backgroundModeAware === true &&

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -56,6 +56,24 @@ interface ManualRetryPromptResult {
   clientPrepared?: boolean;
 }
 
+type RetryAttemptSource = 'automatic' | 'human';
+
+interface RetryLifecycleState {
+  readonly operationId: string;
+  readonly startedAt: number;
+  readonly automaticAttemptLimit: number;
+  attemptOrdinal: number;
+  lastAttemptSource?: RetryAttemptSource;
+  nextAttemptSource: RetryAttemptSource;
+}
+
+type RetryLifecycleEvent =
+  | 'attempt_started'
+  | 'attempt_succeeded'
+  | 'attempt_failed'
+  | 'retry_decision_requested'
+  | 'retry_decided';
+
 /**
  * Invocation result after retry handling. A `failed` result has already
  * emitted its canonical error at this boundary; outer cycles only propagate
@@ -104,6 +122,7 @@ export abstract class RetryableInvocationNode<
   protected _hasAttemptedTokenRefresh = false;
   protected _persistent401Error: Error | null = null;
   protected _retryBackoffMs: number;
+  private _retryLifecycle: RetryLifecycleState | undefined;
 
   constructor() {
     const config = getNodeRetryConfig();
@@ -118,7 +137,36 @@ export abstract class RetryableInvocationNode<
     cloned._userCancelled = false;
     cloned._hasAttemptedTokenRefresh = false;
     cloned._persistent401Error = null;
+    cloned._retryLifecycle = undefined;
     return cloned;
+  }
+
+  /** Persist a compact, normally hidden diagnostic row on the run trace. */
+  private logRetryLifecycle(
+    event: RetryLifecycleEvent,
+    details: Record<string, unknown> = {},
+  ): void {
+    const lifecycle = this._retryLifecycle;
+    if (!lifecycle) return;
+    const { runScope, modelCell } = this.services;
+    this.services.logger.info('Model retry lifecycle', {
+      verbose: true,
+      data: {
+        kind: 'model_retry_lifecycle',
+        event,
+        operationId: lifecycle.operationId,
+        operation: this.getOperationName(),
+        executionId: runScope.executionId,
+        streamId: runScope.streamId,
+        agentName: runScope.agentName,
+        model: this.services.config.model,
+        credentialRoute: modelCell.route,
+        attemptOrdinal: lifecycle.attemptOrdinal,
+        automaticAttemptLimit: lifecycle.automaticAttemptLimit,
+        elapsedMs: Date.now() - lifecycle.startedAt,
+        ...details,
+      },
+    });
   }
 
   /**
@@ -211,21 +259,65 @@ export abstract class RetryableInvocationNode<
       }
     }
 
+    const lifecycle = this._retryLifecycle;
+    if (lifecycle) lifecycle.attemptOrdinal += 1;
+    const attemptSource = lifecycle?.nextAttemptSource ?? 'automatic';
+    if (lifecycle) {
+      lifecycle.lastAttemptSource = attemptSource;
+      lifecycle.nextAttemptSource = 'automatic';
+    }
+    this.logRetryLifecycle('attempt_started', {
+      decisionSource: attemptSource,
+    });
+
     try {
-      return await operation(signal);
+      const result = await operation(signal);
+      this.logRetryLifecycle('attempt_succeeded', {
+        decisionSource: attemptSource,
+      });
+      return result;
     } catch (err) {
+      const formatted = normalizeProviderError(err);
       // Reactive 401 recovery: refresh token (single-flighted at the auth
       // boundary) and retry once within this same node attempt. 401 is not
       // auto-retryable, so without this the run would halt at the manual
       // retry prompt on every token rotation.
-      const formatted = normalizeProviderError(err);
       if (
         (formatted.isRelayError || services.modelCell.route === 'relay') &&
         isUnauthorizedProviderError(formatted) &&
         !this._hasAttemptedTokenRefresh
       ) {
-        return this.attemptRelay401Recovery(err, operation, signal);
+        try {
+          const result = await this.attemptRelay401Recovery(
+            err,
+            operation,
+            signal,
+          );
+          this.logRetryLifecycle('attempt_succeeded', {
+            decisionSource: attemptSource,
+            credentialRefresh: true,
+          });
+          return result;
+        } catch (retryErr) {
+          const retryFormatted = normalizeProviderError(retryErr);
+          this.logRetryLifecycle('attempt_failed', {
+            decisionSource: attemptSource,
+            credentialRefresh: true,
+            userRetryable: retryFormatted.userRetryable,
+            statusCode: retryFormatted.statusCode,
+            provider: retryFormatted.provider,
+            isRelayError: retryFormatted.isRelayError,
+          });
+          throw retryErr;
+        }
       }
+      this.logRetryLifecycle('attempt_failed', {
+        decisionSource: attemptSource,
+        userRetryable: formatted.userRetryable,
+        statusCode: formatted.statusCode,
+        provider: formatted.provider,
+        isRelayError: formatted.isRelayError,
+      });
       throw err;
     }
   }
@@ -258,6 +350,13 @@ export abstract class RetryableInvocationNode<
 
     this.maxRetries = maxRetries;
     this._retryBackoffMs = config.backoffMs;
+    this._retryLifecycle = {
+      operationId: `model-operation-${generateShortId()}`,
+      startedAt: Date.now(),
+      automaticAttemptLimit: maxRetries,
+      attemptOrdinal: 0,
+      nextAttemptSource: 'automatic',
+    };
     // This local delay is the fallback for retryable failures that do not
     // implicate a shared route. For classified route failures it overlaps the
     // gate's cooling interval, so the gate waits only for any remaining time.
@@ -282,6 +381,9 @@ export abstract class RetryableInvocationNode<
     }
 
     if (result.shouldRetry) {
+      if (this._retryLifecycle) {
+        this._retryLifecycle.nextAttemptSource = 'human';
+      }
       this._persistent401Error = null;
       this._hasAttemptedTokenRefresh = false;
       // Always refresh the client on manual retry. The user may have
@@ -315,6 +417,13 @@ export abstract class RetryableInvocationNode<
       return { shouldRetry: false, userCancelled: false };
     }
 
+    this.logRetryLifecycle('retry_decision_requested', {
+      afterAttemptSource: this._retryLifecycle?.lastAttemptSource,
+      userRetryable: formatted.userRetryable,
+      statusCode: formatted.statusCode,
+      provider: formatted.provider,
+    });
+
     logErrorData(logger, `${operationName} failed`, formatted);
 
     streamStatus.transition(streamId, STREAM_PHASE.WAITING, 'wait', {
@@ -346,6 +455,14 @@ export abstract class RetryableInvocationNode<
       throw new Error('HostInteractions.requestRetry is required');
     }
     const result = await interaction;
+    let decisionSource: 'human' | 'denied' | 'cancelled';
+    if (result.action === 'retry') decisionSource = 'human';
+    else if (result.action === 'deny') decisionSource = 'denied';
+    else decisionSource = 'cancelled';
+    this.logRetryLifecycle('retry_decided', {
+      action: result.action,
+      decisionSource,
+    });
 
     if (result.action === 'retry') {
       logger.debug('Manual retry triggered');

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -309,6 +309,15 @@ export abstract class RetryableInvocationNode<
         isUnauthorizedProviderError(formatted) &&
         !this._hasAttemptedTokenRefresh
       ) {
+        this.logRetryLifecycle('attempt_failed', {
+          decisionSource: attemptSource,
+          credentialRefresh: true,
+          recoveryPending: true,
+          userRetryable: formatted.userRetryable,
+          statusCode: formatted.statusCode,
+          provider: formatted.provider,
+          isRelayError: formatted.isRelayError,
+        });
         try {
           const result = await this.attemptRelay401Recovery(
             err,

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -54,6 +54,7 @@ interface ManualRetryPromptResult {
   shouldRetry: boolean;
   userCancelled: boolean;
   clientPrepared?: boolean;
+  retrySource?: RetryAttemptSource;
 }
 
 type RetryAttemptSource = 'automatic' | 'human';
@@ -411,7 +412,7 @@ export abstract class RetryableInvocationNode<
 
     if (result.shouldRetry) {
       if (this._retryLifecycle) {
-        this._retryLifecycle.nextAttemptSource = 'human';
+        this._retryLifecycle.nextAttemptSource = result.retrySource ?? 'human';
       }
       this._persistent401Error = null;
       this._hasAttemptedTokenRefresh = false;
@@ -484,10 +485,12 @@ export abstract class RetryableInvocationNode<
       throw new Error('HostInteractions.requestRetry is required');
     }
     const result = await interaction;
-    let decisionSource: 'human' | 'denied' | 'cancelled';
-    if (result.action === 'retry') decisionSource = 'human';
-    else if (result.action === 'deny') decisionSource = 'denied';
-    else decisionSource = 'cancelled';
+    const retrySource =
+      result.action === 'retry'
+        ? (result.decisionSource ?? 'human')
+        : undefined;
+    const decisionSource =
+      retrySource ?? (result.action === 'deny' ? 'denied' : 'cancelled');
     this.logRetryLifecycle('retry_decided', {
       action: result.action,
       decisionSource,
@@ -498,7 +501,12 @@ export abstract class RetryableInvocationNode<
       streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
         trace: logger,
       });
-      return { shouldRetry: true, userCancelled: false, clientPrepared };
+      return {
+        shouldRetry: true,
+        userCancelled: false,
+        clientPrepared,
+        retrySource,
+      };
     }
 
     if (result.action === 'deny') {

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -132,6 +132,11 @@ export abstract class RetryableInvocationNode<
 
   protected abstract getOperationName(): string;
 
+  /** Whether a resolved provider result is valid at the concrete boundary. */
+  protected isSuccessfulInvocationResult(_result: unknown): boolean {
+    return true;
+  }
+
   clone(): this {
     const cloned = super.clone();
     cloned._userCancelled = false;
@@ -141,7 +146,7 @@ export abstract class RetryableInvocationNode<
     return cloned;
   }
 
-  /** Persist a compact, normally hidden diagnostic row on the run trace. */
+  /** Emit compact diagnostic data for durable, non-presentational recording. */
   private logRetryLifecycle(
     event: RetryLifecycleEvent,
     details: Record<string, unknown> = {},
@@ -149,8 +154,8 @@ export abstract class RetryableInvocationNode<
     const lifecycle = this._retryLifecycle;
     if (!lifecycle) return;
     const { runScope, modelCell } = this.services;
-    this.services.logger.info('Model retry lifecycle', {
-      verbose: true,
+    this.services.logger.domain({
+      key: 'modelRetryLifecycle',
       data: {
         kind: 'model_retry_lifecycle',
         event,
@@ -167,6 +172,27 @@ export abstract class RetryableInvocationNode<
         ...details,
       },
     });
+  }
+
+  /** Record the concrete boundary's classification without changing its result. */
+  private recordResolvedAttempt<T>(
+    result: T,
+    attemptSource: RetryAttemptSource,
+    details: Record<string, unknown> = {},
+  ): T {
+    if (this.isSuccessfulInvocationResult(result)) {
+      this.logRetryLifecycle('attempt_succeeded', {
+        decisionSource: attemptSource,
+        ...details,
+      });
+    } else {
+      this.logRetryLifecycle('attempt_failed', {
+        decisionSource: attemptSource,
+        failureKind: 'invalid_result',
+        ...details,
+      });
+    }
+    return result;
   }
 
   /**
@@ -222,43 +248,8 @@ export abstract class RetryableInvocationNode<
   protected async invokeWithRelayRecovery<T>(
     operation: (signal: AbortSignal) => Promise<T>,
   ): Promise<T> {
-    if (this._persistent401Error) {
-      throw this._persistent401Error;
-    }
-
     const services = this.services;
     const signal = services.runScope.signal;
-
-    // Build (or reuse) the client this attempt will run on before reading the
-    // credential route it captured: a run that has just switched models holds
-    // no client yet, and an absent route would skip the relay refresh below.
-    await services.modelCell.getClient();
-
-    // Proactive relay token refresh before the request. Only relay-route
-    // clients present a relay session token, so only they consult the expiry
-    // clock — personal-key / openrouter / subscription clients must never
-    // rebuild for a credential the call doesn't use.
-    const includedAccess = includedModelAccess();
-    if (
-      services.modelCell.route === 'relay' &&
-      includedAccess.isAccessTokenExpiringSoon()
-    ) {
-      // Threshold-gated and mutex-deduped: refreshes the session (updating
-      // tokenExpiresAt) only when actually near expiry. For a configured CI
-      // relay token this is a cache-only read with no side effects.
-      await includedAccess.getAccessToken();
-      // Rebuild only when the token actually rotated — rebuilding with the
-      // same JWT changes nothing, and is exactly the loop this branch caused.
-      if (!includedAccess.isAccessTokenExpiringSoon()) {
-        await rebindClient(
-          services.modelCell,
-          services.logger,
-          'proactive pre-invocation',
-          signal,
-        );
-      }
-    }
-
     const lifecycle = this._retryLifecycle;
     if (lifecycle) lifecycle.attemptOrdinal += 1;
     const attemptSource = lifecycle?.nextAttemptSource ?? 'automatic';
@@ -271,11 +262,42 @@ export abstract class RetryableInvocationNode<
     });
 
     try {
+      if (this._persistent401Error) {
+        throw this._persistent401Error;
+      }
+
+      // Build (or reuse) the client this attempt will run on before reading
+      // the credential route it captured. Client preparation is part of the
+      // retry attempt and must therefore remain inside this lifecycle guard.
+      await services.modelCell.getClient();
+
+      // Proactive relay token refresh before the request. Only relay-route
+      // clients present a relay session token, so only they consult the expiry
+      // clock — personal-key / openrouter / subscription clients must never
+      // rebuild for a credential the call doesn't use.
+      const includedAccess = includedModelAccess();
+      if (
+        services.modelCell.route === 'relay' &&
+        includedAccess.isAccessTokenExpiringSoon()
+      ) {
+        // Threshold-gated and mutex-deduped: refreshes the session (updating
+        // tokenExpiresAt) only when actually near expiry. For a configured CI
+        // relay token this is a cache-only read with no side effects.
+        await includedAccess.getAccessToken();
+        // Rebuild only when the token actually rotated — rebuilding with the
+        // same JWT changes nothing, and is exactly the loop this branch caused.
+        if (!includedAccess.isAccessTokenExpiringSoon()) {
+          await rebindClient(
+            services.modelCell,
+            services.logger,
+            'proactive pre-invocation',
+            signal,
+          );
+        }
+      }
+
       const result = await operation(signal);
-      this.logRetryLifecycle('attempt_succeeded', {
-        decisionSource: attemptSource,
-      });
-      return result;
+      return this.recordResolvedAttempt(result, attemptSource);
     } catch (err) {
       const formatted = normalizeProviderError(err);
       // Reactive 401 recovery: refresh token (single-flighted at the auth
@@ -293,11 +315,9 @@ export abstract class RetryableInvocationNode<
             operation,
             signal,
           );
-          this.logRetryLifecycle('attempt_succeeded', {
-            decisionSource: attemptSource,
+          return this.recordResolvedAttempt(result, attemptSource, {
             credentialRefresh: true,
           });
-          return result;
         } catch (retryErr) {
           const retryFormatted = normalizeProviderError(retryErr);
           this.logRetryLifecycle('attempt_failed', {

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -122,7 +122,13 @@ export type ProposalResult =
     };
 
 export type RetrySettlement =
-  | { action: 'retry'; feedback?: string; reason?: never }
+  | {
+      action: 'retry';
+      feedback?: string;
+      reason?: never;
+      /** Omitted by interactive hosts, which default to a human decision. */
+      decisionSource?: 'human' | 'automatic';
+    }
   | { action: 'cancel'; feedback?: never; reason?: never };
 
 export type RetryResult =

--- a/src/test-kernel/agent/ResponseCycleTools.vitest.mts
+++ b/src/test-kernel/agent/ResponseCycleTools.vitest.mts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { noopTrace } from '@agent/trace';
 import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
 import { responseCycleToolsForModel } from '@agent/core/flows/ResponseCycleFlow';
 import { getDefaultToolRegistry } from '@tools/registry';
@@ -98,7 +99,7 @@ describe('response cycle tool visibility', () => {
     });
     node.setServices({
       config: {},
-      logger: { debug: vi.fn(), warn: vi.fn() },
+      logger: noopTrace,
       modelCell: testModelCell({
         config: { provider: 'openai', fullName: 'test-model' },
         createResponse,

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -52,6 +52,7 @@ import {
 import { installTexraModelAccess } from '@controllers/modelAccess/installTexraModelAccess';
 import { setIncludedModelAccess } from '@model/includedModelAccess';
 import {
+  MESSAGE_TYPES,
   STREAM_PHASE,
   STREAM_STATUS,
   type ExecutionId,
@@ -533,7 +534,11 @@ describe('RetryState', () => {
             (row) =>
               isObject(row.data) && row.data.kind === 'model_retry_lifecycle',
           )
-          .every((row) => row.verbose === true),
+          .every(
+            (row) =>
+              row.verbose === false &&
+              row.messageType === MESSAGE_TYPES.INTERNAL,
+          ),
       ).toBe(true);
       expect(new Set(diagnostics.map((data) => data.operationId)).size).toBe(1);
       expect(
@@ -548,6 +553,125 @@ describe('RetryState', () => {
     } finally {
       recorder.unsubscribe();
       clearStreamStatusForTest(session.status, streamId);
+    }
+  });
+
+  it('counts client preparation failures as retry attempts', async () => {
+    await installPlatform({
+      config: { 'texra.model.retry.maxAttempts': 0 },
+    });
+    const streamId = 'retry-client-preparation' as StreamTabId;
+    const logger = new TraceEmitter();
+    const events: Record<string, unknown>[] = [];
+    logger.subscribe((event) => {
+      if (
+        event.type === 'domain' &&
+        event.key === 'modelRetryLifecycle' &&
+        isObject(event.data)
+      ) {
+        events.push(event.data);
+      }
+    });
+    const getClient = vi
+      .fn<() => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error('client preparation failed'))
+      .mockResolvedValue({});
+    const session = sessionWithInteractions(
+      {
+        requestRetry: async () => ({ action: 'retry' as const }),
+        cancel: () => {},
+      },
+      new StreamStatusMachine(),
+    );
+
+    class ClientPreparationRetryNode extends ExposedRetryNode {
+      override async exec(): Promise<string> {
+        return this.runWithRelayRecovery(async () => 'recovered');
+      }
+    }
+
+    const node = new ClientPreparationRetryNode().setServices({
+      config: { model: 'openai:test' },
+      runScope: testRunScope(streamId, { session }),
+      streamId,
+      interactions: new SessionHostInteractions(),
+      logger,
+      modelCell: {
+        getClient,
+        rebind: async () => undefined,
+        route: 'api-key',
+      },
+    });
+
+    try {
+      seedStreamStatusForTest(session.status, streamId, STREAM_STATUS.RUNNING);
+
+      await expect(node._exec(undefined)).resolves.toBe('recovered');
+
+      expect(
+        events.map((event) => [event.event, event.attemptOrdinal]),
+      ).toEqual([
+        ['attempt_started', 1],
+        ['attempt_failed', 1],
+        ['retry_decision_requested', 1],
+        ['retry_decided', 1],
+        ['attempt_started', 2],
+        ['attempt_succeeded', 2],
+      ]);
+      expect(getClient).toHaveBeenCalledTimes(2);
+    } finally {
+      clearStreamStatusForTest(session.status, streamId);
+    }
+  });
+
+  it('records a resolved result rejected by the concrete boundary as failed', async () => {
+    const streamId = 'retry-invalid-result' as StreamTabId;
+    const logger = new TraceEmitter();
+    const events: Record<string, unknown>[] = [];
+    logger.subscribe((event) => {
+      if (
+        event.type === 'domain' &&
+        event.key === 'modelRetryLifecycle' &&
+        isObject(event.data)
+      ) {
+        events.push(event.data);
+      }
+    });
+    const session = createTestSession();
+
+    class InvalidResultNode extends ExposedRetryNode {
+      protected override isSuccessfulInvocationResult(
+        result: unknown,
+      ): boolean {
+        return Boolean(result);
+      }
+
+      override async exec(): Promise<string> {
+        return this.runWithRelayRecovery(async () => '');
+      }
+    }
+
+    const node = new InvalidResultNode().setServices({
+      config: { model: 'openai:test' },
+      runScope: testRunScope(streamId, { session }),
+      streamId,
+      interactions: new SessionHostInteractions(),
+      logger,
+      modelCell: testRetryModelCell(undefined, 'api-key'),
+    });
+
+    try {
+      await expect(node._exec(undefined)).resolves.toBe('');
+      expect(events.map((event) => event.event)).toEqual([
+        'attempt_started',
+        'attempt_failed',
+      ]);
+      expect(events.at(-1)).toMatchObject({
+        attemptOrdinal: 1,
+        failureKind: 'invalid_result',
+      });
+    } finally {
+      session.dispose();
     }
   });
 

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -866,6 +866,84 @@ describe('RetryState', () => {
     expect(refreshSignal?.aborted).toBe(false);
   });
 
+  it('records the relay 401 before a successful reactive recovery', async () => {
+    const streamId = 'retry-relay-refresh-diagnostics' as StreamTabId;
+    const logger = new TraceEmitter();
+    const events: Record<string, unknown>[] = [];
+    logger.subscribe((event) => {
+      if (
+        event.type === 'domain' &&
+        event.key === 'modelRetryLifecycle' &&
+        isObject(event.data)
+      ) {
+        events.push(event.data);
+      }
+    });
+    const session = createTestSession();
+    const rebind = vi.fn(async () => undefined);
+    SupabaseClient.setAuthProvider(createAuthTokenProvider());
+    const unauthorized = Object.assign(new Error('relay token expired'), {
+      status: 401,
+    });
+    const operation = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(unauthorized)
+      .mockResolvedValueOnce('recovered');
+
+    class ReactiveRecoveryNode extends ExposedRetryNode {
+      override async exec(): Promise<string> {
+        return this.runWithRelayRecovery(operation);
+      }
+    }
+
+    const node = new ReactiveRecoveryNode().setServices({
+      config: { model: 'openai:test' },
+      runScope: testRunScope(streamId, { session }),
+      streamId,
+      interactions: new SessionHostInteractions(),
+      logger,
+      modelCell: testRetryModelCell(rebind, 'relay'),
+    });
+
+    try {
+      await expect(node._exec(undefined)).resolves.toBe('recovered');
+      expect(
+        events.map((event) => ({
+          event: event.event,
+          attemptOrdinal: event.attemptOrdinal,
+          statusCode: event.statusCode,
+          recoveryPending: event.recoveryPending,
+          credentialRefresh: event.credentialRefresh,
+        })),
+      ).toEqual([
+        {
+          event: 'attempt_started',
+          attemptOrdinal: 1,
+          statusCode: undefined,
+          recoveryPending: undefined,
+          credentialRefresh: undefined,
+        },
+        {
+          event: 'attempt_failed',
+          attemptOrdinal: 1,
+          statusCode: 401,
+          recoveryPending: true,
+          credentialRefresh: true,
+        },
+        {
+          event: 'attempt_succeeded',
+          attemptOrdinal: 1,
+          statusCode: undefined,
+          recoveryPending: undefined,
+          credentialRefresh: true,
+        },
+      ]);
+      expect(operation).toHaveBeenCalledTimes(2);
+    } finally {
+      session.dispose();
+    }
+  });
+
   it('keeps node-level auto-retry for transient stream failures', () => {
     const node = createModelInvocationNode();
     const streamError = new Error('stream closed after response started');

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -14,7 +14,7 @@ import {
 } from 'vitest';
 
 // Local imports
-import { noopTrace, type AgentTrace } from '@agent/trace';
+import { noopTrace, TraceEmitter, type AgentTrace } from '@agent/trace';
 import type { BaseCycleFields } from '@agent/core/flows/CommonCycleTypes';
 import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
 import {
@@ -67,6 +67,9 @@ import {
   seedStreamStatusForTest,
 } from '@test/support/streamStatusTestUtils';
 import { createTestSession } from '@test/support/sessionTestUtils';
+import { attachTranscriptRecorder } from '@transcript/TexraTranscriptRecorder';
+import { StreamLogStore } from '@transcript/StreamLogStore';
+import { isObject } from '@utils/core';
 
 // Local file imports
 import {
@@ -417,6 +420,135 @@ describe('RetryState', () => {
     expect(node.maxRetries).toBe(
       1 + DEFAULT_CORE_SETTINGS.model.retry.maxAttempts,
     );
+  });
+
+  it('records cumulative attempt and manual-decision diagnostics', async () => {
+    await installPlatform({
+      config: { 'texra.model.retry.maxAttempts': 0 },
+    });
+    const streamId = 'retry-diagnostics' as StreamTabId;
+    const logger = new TraceEmitter();
+    const transcript = StreamLogStore.ephemeral('retry diagnostics test');
+    transcript.ensureStream(streamId);
+    const recorder = attachTranscriptRecorder(
+      logger,
+      transcript.acquireWriter(streamId, streamId),
+    );
+    const requestRetry = vi.fn(async () => ({ action: 'retry' as const }));
+    const session = sessionWithInteractions(
+      { requestRetry, cancel: () => {} },
+      new StreamStatusMachine(),
+    );
+
+    class DiagnosticRetryNode extends ExposedRetryNode {
+      attempts = 0;
+
+      override async exec(): Promise<string> {
+        return this.runWithRelayRecovery(async () => {
+          this.attempts += 1;
+          if (this.attempts === 1) {
+            throw new Error('temporary provider failure');
+          }
+          return 'recovered';
+        });
+      }
+    }
+
+    const node = new DiagnosticRetryNode().setServices({
+      config: { model: 'openai:test' },
+      runScope: testRunScope(streamId, { session }),
+      streamId,
+      interactions: new SessionHostInteractions(),
+      logger,
+      modelCell: testRetryModelCell(undefined, 'api-key'),
+    });
+
+    try {
+      seedStreamStatusForTest(session.status, streamId, STREAM_STATUS.RUNNING);
+
+      await expect(node._exec(undefined)).resolves.toBe('recovered');
+
+      const rows = transcript.get(streamId)?.getRange(0) ?? [];
+      const diagnostics = rows
+        .map((row) => row.data)
+        .filter(
+          (data): data is Record<string, unknown> =>
+            isObject(data) && data.kind === 'model_retry_lifecycle',
+        );
+      expect(
+        diagnostics.map((data) => ({
+          event: data.event,
+          attemptOrdinal: data.attemptOrdinal,
+          decisionSource: data.decisionSource,
+        })),
+      ).toEqual([
+        {
+          event: 'attempt_started',
+          attemptOrdinal: 1,
+          decisionSource: 'automatic',
+        },
+        {
+          event: 'attempt_failed',
+          attemptOrdinal: 1,
+          decisionSource: 'automatic',
+        },
+        {
+          event: 'retry_decision_requested',
+          attemptOrdinal: 1,
+          decisionSource: undefined,
+        },
+        {
+          event: 'retry_decided',
+          attemptOrdinal: 1,
+          decisionSource: 'human',
+        },
+        {
+          event: 'attempt_started',
+          attemptOrdinal: 2,
+          decisionSource: 'human',
+        },
+        {
+          event: 'attempt_succeeded',
+          attemptOrdinal: 2,
+          decisionSource: 'human',
+        },
+      ]);
+      expect(diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            executionId: 'deadbeef',
+            streamId,
+            automaticAttemptLimit: 1,
+            credentialRoute: 'api-key',
+          }),
+          expect.objectContaining({
+            event: 'retry_decision_requested',
+            afterAttemptSource: 'automatic',
+          }),
+        ]),
+      );
+      expect(
+        rows
+          .filter(
+            (row) =>
+              isObject(row.data) && row.data.kind === 'model_retry_lifecycle',
+          )
+          .every((row) => row.verbose === true),
+      ).toBe(true);
+      expect(new Set(diagnostics.map((data) => data.operationId)).size).toBe(1);
+      expect(
+        diagnostics
+          .map((data) => data.elapsedMs as number)
+          .every((elapsed, index, values) =>
+            index === 0
+              ? elapsed >= 0
+              : elapsed >= (values.at(index - 1) ?? elapsed),
+          ),
+      ).toBe(true);
+    } finally {
+      recorder.unsubscribe();
+      clearStreamStatusForTest(session.status, streamId);
+    }
   });
 
   it('treats user aborts as cancellations instead of failed invocations', () => {

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -556,7 +556,7 @@ describe('RetryState', () => {
     }
   });
 
-  it('counts client preparation failures as retry attempts', async () => {
+  it('counts client preparation failures and preserves automatic retry provenance', async () => {
     await installPlatform({
       config: { 'texra.model.retry.maxAttempts': 0 },
     });
@@ -578,7 +578,10 @@ describe('RetryState', () => {
       .mockResolvedValue({});
     const session = sessionWithInteractions(
       {
-        requestRetry: async () => ({ action: 'retry' as const }),
+        requestRetry: async () => ({
+          action: 'retry' as const,
+          decisionSource: 'automatic' as const,
+        }),
         cancel: () => {},
       },
       new StreamStatusMachine(),
@@ -618,6 +621,15 @@ describe('RetryState', () => {
         ['attempt_started', 2],
         ['attempt_succeeded', 2],
       ]);
+      expect(
+        events.find((event) => event.event === 'retry_decided'),
+      ).toMatchObject({ decisionSource: 'automatic' });
+      expect(
+        events.find(
+          (event) =>
+            event.event === 'attempt_started' && event.attemptOrdinal === 2,
+        ),
+      ).toMatchObject({ decisionSource: 'automatic' });
       expect(getClient).toHaveBeenCalledTimes(2);
     } finally {
       clearStreamStatusForTest(session.status, streamId);

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -649,6 +649,7 @@ describe('TUI retry approvals', () => {
     });
     await expect(result).resolves.toEqual({
       action: 'retry',
+      decisionSource: 'automatic',
       feedback: undefined,
     });
     expect(currentApproval.get()).toBeUndefined();
@@ -875,6 +876,7 @@ describe('TUI retry approvals', () => {
     );
     await expect(later).resolves.toEqual({
       action: 'retry',
+      decisionSource: 'automatic',
       feedback: undefined,
     });
     expect(laterPrepare).toHaveBeenCalledOnce();
@@ -1326,6 +1328,7 @@ describe('TUI retry approvals', () => {
     });
     await expect(second).resolves.toEqual({
       action: 'retry',
+      decisionSource: 'automatic',
       feedback: undefined,
     });
   });
@@ -1503,6 +1506,7 @@ describe('TUI retry approvals', () => {
     blockingWrite.resolve(undefined);
     await expect(blocking).resolves.toEqual({
       action: 'retry',
+      decisionSource: 'automatic',
       feedback: undefined,
     });
     expect(mocks.setCliApiMode).toHaveBeenCalledOnce();
@@ -1536,6 +1540,7 @@ describe('TUI retry approvals', () => {
     firstModeSwitch.reject(new Error('stale mode switch failed'));
     await expect(second).resolves.toEqual({
       action: 'retry',
+      decisionSource: 'automatic',
       feedback: undefined,
     });
     expect(mocks.setCliApiMode.mock.calls.map(([mode]) => mode)).toEqual([

--- a/src/test-kernel/cli/TuiRetryApiKeyCache.vitest.mts
+++ b/src/test-kernel/cli/TuiRetryApiKeyCache.vitest.mts
@@ -106,6 +106,7 @@ describe('TUI retry API-key cache boundary', () => {
 
     await expect(result).resolves.toEqual({
       action: 'retry',
+      decisionSource: 'automatic',
       feedback: undefined,
     });
     expect(preparedKeys).toEqual(['sk-rotated-current-key']);

--- a/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
+++ b/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
@@ -123,7 +123,7 @@ describe('LOG_DELTA text deltas', () => {
     expect(finalized && isStreamingTextLogMessage(finalized)).toBe(false);
   });
 
-  it('drops compaction activity before progress-log indexing', () => {
+  it('drops non-presentational records before progress-log indexing', () => {
     const getState = seedWorkflowStream();
     const activityEntry = (
       id: string,
@@ -147,6 +147,16 @@ describe('LOG_DELTA text deltas', () => {
       streamId: STREAM_ID,
       entries: [
         activityEntry('compaction-start', 'started'),
+        {
+          seqNo: 2,
+          id: 'internal-diagnostic',
+          type: STREAM_LOG_ENTRY_TYPES.LOG,
+          level: LOG_LEVELS.INFO,
+          timestamp: 100,
+          messageType: MESSAGE_TYPES.INTERNAL,
+          text: 'hidden diagnostic',
+          verbose: false,
+        },
         modelResponseEntry('visible', 'completed'),
         activityEntry('compaction-finish', 'finished'),
       ],

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -590,6 +590,16 @@ export function attachTranscriptRecorder(
 
         case 'domain': {
           // Subscribers that care about specific keys can switch on event.key.
+          if (event.key === 'modelRetryLifecycle') {
+            appendLog({
+              groupId: event.stageId,
+              messageType: MESSAGE_TYPES.INTERNAL,
+              text: 'Model retry lifecycle',
+              data: event.data,
+              verbose: false,
+            });
+            return;
+          }
           // filesLoaded has a richer payload shape; format the text accordingly.
           if (event.key === 'filesLoaded') {
             const payload = event.data as


### PR DESCRIPTION
## Summary

Persist compact retry-lifecycle diagnostics at the existing model-invocation boundary.

Each model operation now records hidden, durable transcript records for attempt start, success, failure, retry-decision request, and retry decision. The records share one operation identity and include the execution, stream, agent, model, credential route, cumulative attempt ordinal, automatic-attempt limit, elapsed lifetime, normalized failure classification, and whether an attempt was automatic or explicitly approved.

The implementation keeps retry ownership in `RetryableInvocationNode`; it does not introduce another retry manager or alter the host-interaction settlement protocol. Error text and remote job identifiers are not copied into this generic record.

## Design

The run trace remains the single persistence boundary. Retry lifecycle data travels as a non-presentational domain event; the transcript recorder stores it as an internal, `verbose: false` record. Thus the data remains available for diagnosis without appearing in the output channel, CLI plain output, or ordinary progress views.

Attempt tracking encloses client construction and proactive credential refresh as well as the provider call. A concrete invocation node also classifies its resolved result before the lifecycle record is settled, so an empty model response is recorded as a failed attempt consistently with the canonical invocation boundary. Root and delegated executions use the same node boundary and therefore receive the same record shape.

This is a bounded diagnostics stage for #9532. Provider-specific generation-versus-retrieval counters and safely represented remote-job correlation, effective host-policy identity, cross-process lifecycle state, and visible progress distinctions remain separate work because their authoritative owners are outside the generic node retry loop.

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- `npm test` — 824 files passed, 1 skipped; 8,446 tests passed, 4 skipped

The regressions cover automatic failure followed by human-approved recovery through the real transcript recorder, client-preparation failure accounting, concrete-boundary rejection of an empty result, stable operation identity, cumulative ordinals, automatic limits, credential route, monotonic elapsed time, and hidden durable records.

Refs #9532.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the hot model-invocation and retry path (including client prep and relay 401 recovery), but behavior is mostly additive logging and provenance unless lifecycle hooks misclassify outcomes.
> 
> **Overview**
> Adds **durable, hidden retry lifecycle diagnostics** for model invocations: each operation gets a stable `operationId` and emits compact domain events for attempt start/success/failure, manual retry prompts, and retry decisions (with execution/stream/model/credential route, ordinals, and normalized failure metadata).
> 
> **`RetryableInvocationNode`** owns the lifecycle: attempt counting now includes client preparation and proactive relay refresh; the next attempt records whether the user or an auto path approved retry. **`ModelInvocationNode`** classifies empty successful responses as failed attempts for these records.
> 
> **TUI auto-switch retries** set optional `decisionSource: 'automatic'` on `RetryResult`; interactive retries default to human. Events are written to the transcript as **`INTERNAL` / `verbose: false`** and are **filtered from the progress view** (alongside compaction activity) so diagnostics stay off the timeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc6b893709824cfce4bb9ff101d5cdc838210ce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->