### PR TITLE
refactor(storage): initialize workspace roots once

### DIFF
--- a/src/platform/defaults/workspaceStorage.ts
+++ b/src/platform/defaults/workspaceStorage.ts
@@ -184,10 +184,7 @@ function migrateLegacyWorkspaceStorage(
 export class WorkspaceStorageProvider implements StorageProvider {
   private readonly getWorkspacePath: () => string | undefined;
   private activeWorkspacePath: string | undefined;
-  /** Storage paths whose one-off setup (legacy rename, sidecar) already ran in
-   *  this process. `getStoragePath` is on the hot path of every storage read
-   *  and write, and neither step can change its outcome once done. */
-  private readonly preparedStoragePaths = new Set<string>();
+  private readonly initializedStoragePaths = new Set<string>();
   private workspaceChangeRollback:
     { readonly workspacePath: string | undefined } | undefined;
 
@@ -207,21 +204,14 @@ export class WorkspaceStorageProvider implements StorageProvider {
   getStoragePath(): string {
     const workspacePath = this.activeWorkspacePath;
     const storagePath = this.storagePathFor(workspacePath);
-    const firstUse = !this.preparedStoragePaths.has(storagePath);
+    if (this.initializedStoragePaths.has(storagePath)) return storagePath;
 
-    if (firstUse) {
-      // The legacy rename has to run before `mkdirSync`: it bails out once the
-      // current directory exists.
-      migrateLegacyWorkspaceStorage(this.storageRoot, workspacePath);
-    }
-
-    // Unconditional, so a directory removed underneath us comes back. When it
-    // did have to be recreated the sidecar went with it, so write it again.
-    const recreated = mkdirSync(storagePath, { recursive: true }) !== undefined;
-    if (firstUse || recreated) {
-      writeWorkspaceSidecar(storagePath, workspacePath);
-      this.preparedStoragePaths.add(storagePath);
-    }
+    // The legacy rename must precede directory creation because it stops once
+    // the current directory exists.
+    migrateLegacyWorkspaceStorage(this.storageRoot, workspacePath);
+    mkdirSync(storagePath, { recursive: true });
+    writeWorkspaceSidecar(storagePath, workspacePath);
+    this.initializedStoragePaths.add(storagePath);
     return storagePath;
   }
 

--- a/src/test-kernel/platform/WorkspaceStorage.vitest.ts
+++ b/src/test-kernel/platform/WorkspaceStorage.vitest.ts
@@ -177,7 +177,7 @@ describe('workspace storage defaults', () => {
     });
   });
 
-  it('recreates a storage root deleted underneath it, marker included', async () => {
+  it('initializes each workspace storage root only once', async () => {
     const root = await makeTempDir('texra-workspace-storage-', tempDirs);
     const workspacePath = '/workspace/a';
     const provider = new WorkspaceStorageProvider(root, workspacePath);
@@ -186,9 +186,7 @@ describe('workspace storage defaults', () => {
     await rm(storagePath, { recursive: true, force: true });
 
     expect(provider.getStoragePath()).toBe(storagePath);
-    await expect(readWorkspaceMarker(storagePath)).resolves.toMatchObject({
-      path: workspacePath,
-    });
+    await expect(pathExists(storagePath)).resolves.toBe(false);
   });
 
   it('uses the same workspace storage rule for node hosts', async () => {


### PR DESCRIPTION
## Summary

- initialize each workspace storage root once per `WorkspaceStorageProvider` lifetime;
- keep legacy-hash migration, directory creation, and sidecar creation at the same first-use boundary;
- make later `getStoragePath()` calls pure path reads instead of issuing `mkdirSync` on every relative-path storage operation.

## Design

`initializedStoragePaths` is the single record of completed root initialization. The accessor returns immediately for a known root; first use performs the ordered migration/create/sidecar sequence and records completion only after it succeeds.

A root deleted externally is no longer silently recreated by the path accessor. The filesystem operation that follows now reports `ENOENT` through the ordinary error path. Checking for disappearance inside `getStoragePath()` would restore filesystem work to the hot accessor; any richer diagnosis belongs at the filesystem error boundary.

This is the ungated hot-path half of #9430. It does not attempt the separate `taskRuns/* → executions/*` migration, whose awaited initialization boundary remains a design decision.

## Net elements (R6)

- 2 files changed
- production code: 8 insertions, 18 deletions (net -10 lines)
- test code: 2 insertions, 4 deletions (net -2 lines)
- exported symbols: unchanged
- abstractions: unchanged; one conditional repair branch removed

## Consumer counts (R8)

Not applicable: no export, event, command, or compatibility surface is deleted.

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- focused workspace-storage suite: 7 tests passed
- full Vitest suite: 824 files passed, 1 skipped; 8,446 tests passed, 4 skipped

Refs #9430