### PR TITLE
refactor(ui): consolidate ad-hoc panel chrome and extract inline styles

### DIFF
--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -680,7 +680,9 @@ function RelayProgressFrame(props: {
       title={props.title ?? 'Sign in · Researcher Access'}
       footer={<LoadingIndicator label={props.spinnerLabel} />}
     >
-      <Box flexDirection="column">{props.children}</Box>
+      <Box marginTop={1} flexDirection="column">
+        {props.children}
+      </Box>
     </BorderedPanel>
   );
 }

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -20,6 +20,7 @@ import { type SupabaseSession } from '@auth/SupabaseSession';
 import { DEFAULT_OAUTH_PROVIDER, type OAuthProvider } from '@auth/config';
 import { type CodexSession } from '@auth/codex';
 import { codexAccountLabel } from '@auth/codex/codexSessionTypes';
+import { BorderedPanel } from '@cli/tui/ui/BorderedPanel';
 import { LoadingIndicator } from '@cli/tui/ui/LoadingIndicator';
 import { useCancellableEffect } from '@cli/tui/useCancellableEffect';
 import { renderCliPrompt } from '@cli/tui/renderCliPrompt';
@@ -674,22 +675,13 @@ function RelayProgressFrame(props: {
   readonly children: React.ReactNode;
 }): React.JSX.Element {
   return (
-    <Box
-      borderStyle="round"
-      borderColor="cyan"
-      flexDirection="column"
-      paddingX={1}
+    <BorderedPanel
+      color="cyan"
+      title={props.title ?? 'Sign in · Researcher Access'}
+      footer={<LoadingIndicator label={props.spinnerLabel} />}
     >
-      <Text bold color="cyan">
-        {props.title ?? 'Sign in · Researcher Access'}
-      </Text>
-      <Box marginTop={1} flexDirection="column">
-        {props.children}
-      </Box>
-      <Box marginTop={1}>
-        <LoadingIndicator label={props.spinnerLabel} />
-      </Box>
-    </Box>
+      <Box flexDirection="column">{props.children}</Box>
+    </BorderedPanel>
   );
 }
 

--- a/packages/extension/src/progressView/frontend/components/ContextManagement.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ContextManagement.styles.ts
@@ -1,0 +1,69 @@
+/** Component-scoped styles for {@link ContextManagement} (context event banners). */
+
+import { css, type CSSResult } from 'lit';
+
+export const contextManagementStyles: CSSResult = css`
+  :host {
+    display: block;
+    margin: var(--wa-space-2xs) 0;
+  }
+
+  wa-details {
+    margin: 0;
+    content-visibility: auto;
+    contain-intrinsic-size: auto 40px;
+  }
+
+  /* Extend .details-summary from commonViewStyles with accent color */
+  .details-summary,
+  .details-summary .icon,
+  .context-title {
+    color: var(--accent-color, var(--wa-color-text-normal));
+  }
+
+  .context-title {
+    font-weight: var(--font-weight-medium);
+  }
+
+  .context-content {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--wa-space-s);
+  }
+
+  .stat-item {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--wa-space-3xs);
+    font-size: var(--font-size-sm);
+  }
+
+  .stat-item wa-icon {
+    opacity: var(--opacity-subtle);
+  }
+
+  .summary-block {
+    margin-top: var(--wa-space-2xs);
+    display: block;
+    width: 100%;
+  }
+
+  .summary-title {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--wa-space-3xs);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    margin-bottom: var(--wa-space-3xs);
+  }
+
+  .summary-text {
+    margin: 0;
+    padding: var(--wa-space-2xs);
+    white-space: pre-wrap;
+    word-break: break-word;
+    border: var(--border-thin) solid var(--wa-color-surface-border);
+    border-radius: var(--border-radius-small);
+    background: var(--wa-color-surface-raised);
+  }
+`;

--- a/packages/extension/src/progressView/frontend/components/ContextManagement.ts
+++ b/packages/extension/src/progressView/frontend/components/ContextManagement.ts
@@ -1,7 +1,7 @@
 /** Displays compaction / clearing / max_tokens reduction events as collapsible details. */
 
 // Third-party imports
-import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
@@ -17,6 +17,9 @@ import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - progress view helpers
 import { buildDetailsSummary } from '../formatters/htmlBuilders';
+
+// Local imports - styles
+import { contextManagementStyles } from './ContextManagement.styles';
 
 /** Stat item to display */
 export interface StatItem {
@@ -37,71 +40,7 @@ export class ContextManagement extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    css`
-      :host {
-        display: block;
-        margin: var(--wa-space-2xs) 0;
-      }
-
-      wa-details {
-        margin: 0;
-        content-visibility: auto;
-        contain-intrinsic-size: auto 40px;
-      }
-
-      /* Extend .details-summary from commonViewStyles with accent color */
-      .details-summary,
-      .details-summary .icon,
-      .context-title {
-        color: var(--accent-color, var(--wa-color-text-normal));
-      }
-
-      .context-title {
-        font-weight: var(--font-weight-medium);
-      }
-
-      .context-content {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--wa-space-s);
-      }
-
-      .stat-item {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--wa-space-3xs);
-        font-size: var(--font-size-sm);
-      }
-
-      .stat-item wa-icon {
-        opacity: var(--opacity-subtle);
-      }
-
-      .summary-block {
-        margin-top: var(--wa-space-2xs);
-        display: block;
-        width: 100%;
-      }
-
-      .summary-title {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--wa-space-3xs);
-        font-size: var(--font-size-sm);
-        font-weight: var(--font-weight-medium);
-        margin-bottom: var(--wa-space-3xs);
-      }
-
-      .summary-text {
-        margin: 0;
-        padding: var(--wa-space-2xs);
-        white-space: pre-wrap;
-        word-break: break-word;
-        border: var(--border-thin) solid var(--wa-color-surface-border);
-        border-radius: var(--border-radius-small);
-        background: var(--wa-color-surface-raised);
-      }
-    `,
+    contextManagementStyles,
   ];
 
   /** Log ID for tracking */

--- a/packages/extension/src/progressView/frontend/components/FileList.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.styles.ts
@@ -1,0 +1,157 @@
+/** Component-scoped styles for {@link FileList} (generated-files listing). */
+
+import { css, type CSSResult } from 'lit';
+
+export const fileListStyles: CSSResult = css`
+  :host {
+    display: block;
+  }
+
+  :host([hidden]) {
+    display: none;
+  }
+
+  .files-container {
+    padding: 0;
+    font-size: var(--wa-editor-font-size);
+    overflow-y: auto;
+    max-height: var(--height-large);
+    flex-shrink: 0;
+  }
+
+  .storage-hint {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--wa-space-2xs);
+    padding: var(--wa-space-3xs) 0 var(--wa-space-2xs);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.4;
+  }
+
+  .storage-hint wa-icon {
+    flex-shrink: 0;
+  }
+
+  .storage-hint__text {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .storage-hint__dismiss {
+    flex-shrink: 0;
+    color: var(--color-text-secondary);
+  }
+
+  .file-item {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-3xs);
+    padding: var(--wa-space-3xs) 0;
+    margin-bottom: 0;
+  }
+
+  .file-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 200px;
+  }
+
+  .file-path {
+    cursor: pointer;
+  }
+
+  .file-path:hover {
+    text-decoration: underline;
+  }
+
+  .file-dir {
+    opacity: var(--opacity-subtle);
+    font-size: var(--font-size-sm);
+  }
+
+  .file-basename {
+    font-weight: var(--font-weight-medium);
+  }
+
+  .file-stats {
+    white-space: nowrap;
+    text-decoration: none;
+    flex-shrink: 0;
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .file-stats span:first-child {
+    margin-left: 0;
+  }
+
+  .added {
+    color: var(--wa-color-chart-green, green);
+    margin-left: var(--wa-space-2xs);
+    font-size: var(--font-size-sm);
+  }
+
+  .removed {
+    color: var(--wa-color-chart-red, red);
+    margin-left: var(--wa-space-2xs);
+    font-size: var(--font-size-sm);
+  }
+
+  .file-actions {
+    display: flex;
+    gap: var(--wa-space-3xs);
+    flex-shrink: 0;
+    flex-wrap: nowrap;
+    align-items: center;
+  }
+
+  .file-actions wa-button {
+    margin-right: 0;
+    margin-left: var(--wa-space-3xs);
+  }
+
+  /* Nested round collapsibles inherit the shared .panel-collapsible
+     chrome; they only drop the top rule on the first round (the parent
+     panel already rules above it) and shrink the header text so the
+     nested rounds read as subordinate. */
+  .round-collapsible:first-child {
+    border-top: none;
+  }
+
+  .round-collapsible::part(header) {
+    font-size: var(--font-size-sm);
+  }
+
+  .compile-warning {
+    flex-shrink: 0;
+    color: var(--color-warning);
+  }
+
+  .compile-actions {
+    display: flex;
+    justify-content: flex-end;
+    padding: var(--wa-space-2xs) 0;
+    border-top: var(--border-thin) solid var(--color-border);
+    margin-top: var(--wa-space-3xs);
+  }
+
+  @media (max-width: 500px) {
+    .file-item {
+      flex-wrap: wrap;
+      gap: var(--wa-space-2xs);
+      align-items: center;
+    }
+
+    .file-name {
+      width: 100%;
+      flex-basis: 100%;
+    }
+
+    .file-actions {
+      margin-left: auto;
+    }
+  }
+`;

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -2,7 +2,6 @@
 import {
   LitElement,
   html,
-  css,
   nothing,
   type PropertyValues,
   type TemplateResult,
@@ -31,6 +30,9 @@ import { ELEMENT_IDS } from '../constants';
 import { ProgressEvents } from '../events';
 import { getComposedPathElement } from '../utils';
 import { webviewStorage } from '../webviewStorage';
+
+// Local imports - styles
+import { fileListStyles } from './FileList.styles';
 
 // Web Awesome native components
 import '@awesome.me/webawesome/dist/components/details/details.js';
@@ -99,163 +101,7 @@ function parsePath(path: string): ParsedPath {
 
 @customElement('file-list')
 export class FileList extends LitElement {
-  static override styles = [
-    designTokens,
-    commonViewStyles,
-    css`
-      :host {
-        display: block;
-      }
-
-      :host([hidden]) {
-        display: none;
-      }
-
-      .files-container {
-        padding: 0;
-        font-size: var(--wa-editor-font-size);
-        overflow-y: auto;
-        max-height: var(--height-large);
-        flex-shrink: 0;
-      }
-
-      .storage-hint {
-        display: flex;
-        align-items: flex-start;
-        gap: var(--wa-space-2xs);
-        padding: var(--wa-space-3xs) 0 var(--wa-space-2xs);
-        color: var(--color-text-secondary);
-        font-size: var(--font-size-sm);
-        line-height: 1.4;
-      }
-
-      .storage-hint wa-icon {
-        flex-shrink: 0;
-      }
-
-      .storage-hint__text {
-        flex: 1;
-        min-width: 0;
-      }
-
-      .storage-hint__dismiss {
-        flex-shrink: 0;
-        color: var(--color-text-secondary);
-      }
-
-      .file-item {
-        display: flex;
-        align-items: center;
-        gap: var(--wa-space-3xs);
-        padding: var(--wa-space-3xs) 0;
-        margin-bottom: 0;
-      }
-
-      .file-name {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        flex: 1;
-        min-width: 200px;
-      }
-
-      .file-path {
-        cursor: pointer;
-      }
-
-      .file-path:hover {
-        text-decoration: underline;
-      }
-
-      .file-dir {
-        opacity: var(--opacity-subtle);
-        font-size: var(--font-size-sm);
-      }
-
-      .file-basename {
-        font-weight: var(--font-weight-medium);
-      }
-
-      .file-stats {
-        white-space: nowrap;
-        text-decoration: none;
-        flex-shrink: 0;
-        font-size: var(--font-size-sm);
-        color: var(--color-text-secondary);
-      }
-
-      .file-stats span:first-child {
-        margin-left: 0;
-      }
-
-      .added {
-        color: var(--wa-color-chart-green, green);
-        margin-left: var(--wa-space-2xs);
-        font-size: var(--font-size-sm);
-      }
-
-      .removed {
-        color: var(--wa-color-chart-red, red);
-        margin-left: var(--wa-space-2xs);
-        font-size: var(--font-size-sm);
-      }
-
-      .file-actions {
-        display: flex;
-        gap: var(--wa-space-3xs);
-        flex-shrink: 0;
-        flex-wrap: nowrap;
-        align-items: center;
-      }
-
-      .file-actions wa-button {
-        margin-right: 0;
-        margin-left: var(--wa-space-3xs);
-      }
-
-      /* Nested round collapsibles inherit the shared .panel-collapsible
-         chrome; they only drop the top rule on the first round (the parent
-         panel already rules above it) and shrink the header text so the
-         nested rounds read as subordinate. */
-      .round-collapsible:first-child {
-        border-top: none;
-      }
-
-      .round-collapsible::part(header) {
-        font-size: var(--font-size-sm);
-      }
-
-      .compile-warning {
-        flex-shrink: 0;
-        color: var(--color-warning);
-      }
-
-      .compile-actions {
-        display: flex;
-        justify-content: flex-end;
-        padding: var(--wa-space-2xs) 0;
-        border-top: var(--border-thin) solid var(--color-border);
-        margin-top: var(--wa-space-3xs);
-      }
-
-      @media (max-width: 500px) {
-        .file-item {
-          flex-wrap: wrap;
-          gap: var(--wa-space-2xs);
-          align-items: center;
-        }
-
-        .file-name {
-          width: 100%;
-          flex-basis: 100%;
-        }
-
-        .file-actions {
-          margin-left: auto;
-        }
-      }
-    `,
-  ];
+  static override styles = [designTokens, commonViewStyles, fileListStyles];
 
   @property({ attribute: false }) filesByRound: Record<
     string,


### PR DESCRIPTION
## Summary

A scheduled UI-consistency audit checked the extension webviews, the CLI's Ink TUI, and the trace-viewer for ad-hoc UI implementations that should standardize on the existing Font Awesome icon system (`waIcon`/`wa-icon`) or shared Ink components. The codebase turned out to already be disciplined about both — no raw inline SVGs, no live `codicon` usage, no duplicated spinner/select/truncation logic anywhere. Two small, real inconsistencies survived the audit and are fixed here:

1. **CLI onboarding hand-rolled panel chrome.** `packages/cli/src/onboarding/runOnboarding.tsx`'s `RelayProgressFrame` reimplemented the exact `title` / `children` / `footer` bordered-box layout that `packages/cli/src/tui/ui/BorderedPanel.tsx` already provides, even though the same file already imports `BorderedPanel`'s sibling primitives (`LoadingIndicator`, `KeyHints`, `Select`). It now composes `BorderedPanel` directly.
2. **Two Lit components skipped the `Foo.ts` + `Foo.styles.ts` split.** `FileList.ts` and `ContextManagement.ts` embedded their `static override styles` CSS blocks inline, unlike comparable `progressView/frontend/components/` siblings (`BashRequestPanel`, `ExternalInquiryPanel`, `ProposalRequestPanel`, `StreamTab`, `ToolEditRequestPanel`, `UserQuestionPanel`), which all extract styles to a sibling `.styles.ts` file. Extracted both into `FileList.styles.ts` / `ContextManagement.styles.ts` to match. (A third candidate, `LogList.ts`, was checked and found to already delegate to `../styles/logStyles` — no change needed there.)

No behavior changes — CSS rules and rendered markup are unchanged; this is pure reorganization onto the existing conventions.

## Issue acceptance gates

No tracked issue — this was produced by a scheduled UI-consistency audit routine, not a filed issue. Acceptance gate: replace the two identified ad-hoc UI patterns with the project's existing standard components/file layout, with no behavior change.

## Single source of truth

`BorderedPanel` (`packages/cli/src/tui/ui/BorderedPanel.tsx`) is now the single owner of bordered-panel chrome (title/body/footer) for the CLI onboarding relay screens, matching every other modal/form in `packages/cli/src/chat/tui/`. `FileList.styles.ts` and `ContextManagement.styles.ts` are now the single owners of their components' CSS, matching the `.ts`/`.styles.ts` split already established by sibling components in the same directory.

## Duplication and abstraction budget

Removed duplication: one hand-rolled `Box`/`Text` panel layout in the CLI (now delegates to `BorderedPanel`). No new abstractions were introduced — `BorderedPanel` already existed with multiple callers, and the `.styles.ts` split is an established, pre-existing pattern in this directory, not a new one.

## Net elements (R6)

- Files: 3 modified, 2 created (diffstat: `5 files changed, 242 insertions(+), 239 deletions(-)`)
- Exported symbols: `+2` (`fileListStyles`, `contextManagementStyles` — both are the extracted CSS constants, no other export surface changed)
- Classes/interfaces/enums: none added or removed
- Net LoC: +3 (242 insertions / 239 deletions) — CSS moved verbatim into new files plus small import/wiring changes

## Consumer counts (R8)

n/a — no emit path, exported event, or public API was deleted or re-routed. `fileListStyles`/`contextManagementStyles` each have exactly one consumer (their own component), matching the existing pattern for every other `*.styles.ts` file in the directory.

## Host impact

Extension: `FileList` and `ContextManagement` (progress view webview) — no visual or behavioral change, styles extracted verbatim.

Desktop: none (shares the extension's webview components).

CLI: onboarding "Sign in" progress screens (browser relay, device code, ChatGPT sign-in) now render through `BorderedPanel` — same visual layout, no behavior change.

## Scheduled refactoring

None — both findings are now resolved.

## Validation

- `npm run typecheck` — full workspace (workspace, test-kernel, agent, extension, cli, trace-viewer, desktop) — pass
- `npx eslint` on all changed/added files — pass, no warnings
- `npx prettier --check` on all changed/added files — pass
- `npm run check:dead-code-ratchet` — pass, no new unused exports beyond baseline
- `npx vitest run src/test-kernel/cli` — 148 files / 2057 tests passed
- `npx vitest run src/test-kernel/progressView` — 57 files / 455 tests passed, including `FileList.vitest.mts`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01S5UmrXDskU2iU91jWv8QVw

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5UmrXDskU2iU91jWv8QVw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and markup are moved verbatim; changes are structural refactors in presentation layers with no auth, data, or API surface impact.
> 
> **Overview**
> Aligns CLI onboarding and progress-view Lit components with existing UI conventions, with **no intended visual or behavioral change**.
> 
> **CLI:** `RelayProgressFrame` in onboarding now composes shared `BorderedPanel` (title, body, footer with `LoadingIndicator`) instead of duplicating the same rounded cyan `Box`/`Text` layout used elsewhere in the Ink TUI.
> 
> **Extension progress view:** `FileList` and `ContextManagement` move their large inline `static override styles` blocks into new `FileList.styles.ts` and `ContextManagement.styles.ts`, matching sibling components in the same directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c966b95b56044425408a4068063fe3a5ebcc8c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->