### PR TITLE
refactor(shared): dedupe compaction threshold constant into src/shared

### DIFF
--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -11,9 +11,10 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - shared schemas
 import type { TokenUsageStats, UsageRoute } from '@shared/schemas';
+import { designTokens } from '@shared/styles';
+import { DEFAULT_COMPACTION_THRESHOLD_PERCENT } from '@shared/constants/contextManagement';
 
 // Local imports - shared styles
-import { designTokens } from '@shared/styles';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { clamp, formatCompactTokenCount } from '@utils/core';
@@ -22,12 +23,6 @@ import { formatCostUsd } from '@utils/text/stringUtils';
 // Local imports - progress view
 import { ELEMENT_IDS } from '../constants';
 import type { ContextStateData } from '../store';
-
-/**
- * Default compaction threshold (%) — must match
- * DEFAULT_COMPACTION_THRESHOLD_PERCENT in contextManagementConstants.ts.
- */
-const COMPACTION_THRESHOLD = 75;
 
 type UsageRouteBadge = {
   label: string;
@@ -337,10 +332,10 @@ export class UsagePanel extends LitElement {
           <span
             id="usage-compaction-tick"
             class="context-gauge__tick"
-            style=${styleMap({ left: `${COMPACTION_THRESHOLD}%` })}
+            style=${styleMap({ left: `${DEFAULT_COMPACTION_THRESHOLD_PERCENT}%` })}
           ></span>
           <wa-tooltip for="usage-compaction-tick"
-            >Compaction at ${COMPACTION_THRESHOLD}%</wa-tooltip
+            >Compaction at ${DEFAULT_COMPACTION_THRESHOLD_PERCENT}%</wa-tooltip
           >
         </span>
         <span class="context-state__value">

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -9,12 +9,12 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/progress-bar/progress-bar.js';
 import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
-// Local imports - shared schemas
+// Local imports - shared schemas, styles, and constants
 import type { TokenUsageStats, UsageRoute } from '@shared/schemas';
 import { designTokens } from '@shared/styles';
 import { DEFAULT_COMPACTION_THRESHOLD_PERCENT } from '@shared/constants/contextManagement';
 
-// Local imports - shared styles
+// Local imports - shared icons and utils
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { clamp, formatCompactTokenCount } from '@utils/core';

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -85,6 +85,7 @@ import type {
   ToolResult,
 } from '@shared/schemas/toolResult';
 import { OUTPUT_END_TAG } from '@shared/schemas/output';
+import { DEFAULT_COMPACTION_THRESHOLD_PERCENT } from '@shared/constants/contextManagement';
 import { AbsoluteFS } from '@utils/files';
 import { extractScratchpad } from '@utils/text/xmlExtraction';
 import {
@@ -99,7 +100,6 @@ import {
   TOKEN_SAFETY_BUFFER,
   TOOL_USE_SAFETY_BUFFER,
   TOOL_USE_MAX_OUTPUT_FACTOR,
-  DEFAULT_COMPACTION_THRESHOLD_PERCENT,
   COMPACTION_SUMMARY_PREFIX,
   COMPACTION_SYSTEM_PROMPT,
 } from './contextManagementConstants';

--- a/src/agent/modelHandlers/contextManagementConstants.ts
+++ b/src/agent/modelHandlers/contextManagementConstants.ts
@@ -1,6 +1,3 @@
-/** Must match `texra.model.compactionThresholdPercent` default in package.json. Set 0 to disable. */
-export const DEFAULT_COMPACTION_THRESHOLD_PERCENT = 75;
-
 /** Minimum completion tokens when reducing max tokens due to context pressure. */
 const MIN_COMPLETION_TOKENS = 100;
 

--- a/src/shared/constants/contextManagement.ts
+++ b/src/shared/constants/contextManagement.ts
@@ -1,0 +1,7 @@
+/**
+ * Default client-side compaction threshold (%), shared by the backend
+ * default (`ModelHandler.getCompactionThresholdPercent`) and the
+ * progress-view gauge that renders the compaction tick mark. Must match
+ * `texra.model.compactionThresholdPercent` default in package.json.
+ */
+export const DEFAULT_COMPACTION_THRESHOLD_PERCENT = 75;


### PR DESCRIPTION
## Summary

`UsagePanel.ts` (the progress-view compaction gauge, a webview frontend component) hardcoded a copy of the compaction threshold default — `const COMPACTION_THRESHOLD = 75` — with only a code comment ("must match `DEFAULT_COMPACTION_THRESHOLD_PERCENT` in `contextManagementConstants.ts`") keeping it in sync with the real source of truth in `src/agent/modelHandlers/contextManagementConstants.ts`. That module backs `ModelHandler.getCompactionThresholdPercent()`, which reads the user-facing setting `texra.model.compactionThresholdPercent`. Because the module lives under `src/agent/modelHandlers/` — not one of the five browser-safe `@utils/` modules, and with no home in `src/shared/`, it isn't importable from a webview frontend — the constant was copy-pasted instead. A future change to the default (or the two definitions silently drifting) would make the UI tick mark/tooltip wrong while actual compaction behavior stayed correct, or vice versa.

This surfaced from a scheduled architecture audit checking the codebase's documented host/layer boundaries (VS Code coupling, `src/utils/` browser-safety, event-bus scope, `src/shared` import discipline) — the only substantive finding out of that pass.

## Issue acceptance gates

No tracked issue; ad hoc fix from a scheduled audit. Gate: the two definitions of the compaction threshold default collapse to one, importable from both the backend module and the webview frontend, with no behavior change.

## Single source of truth

`src/shared/constants/contextManagement.ts` now owns `DEFAULT_COMPACTION_THRESHOLD_PERCENT`. `src/agent/modelHandlers/ModelHandler.ts` and `packages/extension/src/progressView/frontend/components/UsagePanel.ts` both import it from there instead of each holding their own copy.

## Duplication and abstraction budget

Removed the hardcoded frontend literal that duplicated the backend default. No new abstraction — the constant moved to `src/shared/constants/`, an existing directory already used for cross-boundary constants (`agents.ts`, `providers.ts`, `latex.ts`, etc.), consistent with how `src/shared/schemas/contextManagement.ts` (the sibling wire-schema file) is already imported by this same frontend.

## Net elements (R6)

Diffstat: 4 files changed, 12 insertions(+), 13 deletions(-) (1 file added: `src/shared/constants/contextManagement.ts`).
Exported symbols (`^[+-]export` over the diff): +1 / -1 — `DEFAULT_COMPACTION_THRESHOLD_PERCENT` moved from `contextManagementConstants.ts` to the new shared file; net zero new exports.

## Consumer counts (R8)

`DEFAULT_COMPACTION_THRESHOLD_PERCENT`: 2 consumers before (`ModelHandler.ts` import; `UsagePanel.ts`'s independent hardcoded literal) → 2 consumers after (`ModelHandler.ts`, `UsagePanel.ts`), both now importing the same value. No emit path or event-bus key affected.

## Host impact

Extension: `UsagePanel.ts` (progress-view webview) now renders the compaction tick/tooltip from the shared constant instead of a hardcoded literal — no visible behavior change today since both were `75`.

Desktop: none (shares the same webview component).

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — passes across all packages (workspace, test-kernel, agent, extension, cli, trace-viewer, desktop).
- `npx eslint` on all four touched files — clean (one `import/order` finding auto-fixed).
- `npx vitest run -t "compaction"` — 67 tests passed across 24 test files, 0 failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_018LEn6G9UvifGQc2YxxMENX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constant relocation only with the same numeric default; no logic or config semantics changed.
> 
> **Overview**
> **Single source of truth** for the default compaction threshold (`75%`): it lived in `contextManagementConstants.ts` for `ModelHandler.getCompactionThresholdPercent()` while `UsagePanel` hardcoded `COMPACTION_THRESHOLD = 75` with only a comment to keep them aligned.
> 
> The constant is now in **`src/shared/constants/contextManagement.ts`**, imported by **`ModelHandler.ts`** and **`UsagePanel.ts`** (gauge tick position and “Compaction at …%” tooltip). The export was removed from **`contextManagementConstants.ts`**.
> 
> No runtime behavior change today; the UI tick should stay aligned with the backend default and `texra.model.compactionThresholdPercent` in package.json.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c0547a4c26f3b0baa004fa729828b127f15855a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->