### PR TITLE
refactor(agent): close two SDK-readiness guardrail gaps, drop a re-export shim, add the agent package README

### DIFF
--- a/docs/dev/audits/2026-08-02-agent-sdk-readiness-checkpoint.md
+++ b/docs/dev/audits/2026-08-02-agent-sdk-readiness-checkpoint.md
@@ -25,12 +25,18 @@ subagent resume test), `71c326f` (#9575 storage init once), `a87c110` (#9574 per
 retry lifecycle diagnostics), plus the #9576 production-delegation test merge at
 HEAD. None of these are structural.
 
-**Run context (honesty note).** This was an **unattended scheduled run** with **no
-external adversarial review available**. Per the discipline every checkpoint since
-`-07-22` has held — this class of refactor needs a reviewer outside the pass's own
-analysis (the `-07-22` applied-then-reverted `MapToolRegistry` and the `-07-30`
-authorized-but-reverted `polishModel`/`createModelHandler` census are the worked
-examples) — **no code change lands.** Method mirrored `-07-29`/`-07-30`/`-08-01`:
+**Run context (honesty note).** This began as an **unattended scheduled run** with
+no external adversarial review available, and the audit below was produced under
+that constraint — read every finding as the output of a read-only pass. Per the
+discipline every checkpoint since `-07-22` has held (the `-07-22`
+applied-then-reverted `MapToolRegistry` and the `-07-30` authorized-but-reverted
+`polishModel`/`createModelHandler` census are the worked examples), it recorded
+**no code change**. The maintainer then came on-shift and authorized applying what
+was cleanly applicable, which is what the discipline was waiting for — the
+resulting four changes are listed in the
+[Addendum](#addendum--what-landed-under-live-authorization) and are scoped to items
+already on the standing record. Nothing in the "design-judgment" class was touched.
+Method mirrored `-07-29`/`-07-30`/`-08-01`:
 four parallel read-only deep-dives (agent core + flows + subagent boundaries; model
 handlers; logging + trace + telemetry; runtime + public surface), each returning
 file:line-cited findings, reconciled here against the standing record so
@@ -45,7 +51,7 @@ warranted from an unattended pass.** The core-shape conclusion every checkpoint
 since `-06-26` has reconverged on holds unchanged. The distinguishing result of
 this pass is a **negative** one worth recording in its own right: four independent
 deep-dives, run without sight of the standing record, each re-derived a subset of
-the *already-recorded* items (§New-8, §New-9, §New-13, §New-14, §New-15, the §9
+the _already-recorded_ items (§New-8, §New-9, §New-13, §New-14, §New-15, the §9
 ceiling, and the accepted core inward→outward edges) and surfaced **nothing beyond
 them**. In a chain this long, an independent re-audit that finds no new seam is
 evidence the record is complete, not that the pass was shallow — the spine
@@ -80,35 +86,38 @@ retry denies `:239`; the public `HostInteractions` is the minimal `cancel()` sha
 
 Every retained finding maps to an existing entry; none is fresh.
 
-| Deep-dive finding (this pass) | Standing entry | State at HEAD |
-| --- | --- | --- |
-| `ModelHandler` base (~2,000 LoC) conflates provider adaptation with host/subscription/LaTeX policy; provider extension closed over the `PROVIDER_HANDLER_ROUTES` enum with no registration API; `IModelHandler` is a `Pick` of the base | §New-13 + §9 item 3 + §New-8 | present, unchanged |
-| `status` transition fans to three rails (trace `AgentEvent`, `updateStreamStatus` `SessionFact`, direct `statusListeners`) | §New-9 | present; distinct consumers, no redundant sink — recorded, not deduped |
-| Non-terminal `WAITING` result leaks into the public result union; three-tier result stack (`RunToolUseFlowResult` → `AgentFlowResult` → `AgentFinalResult`); pick which is *the* public result | §9 + `-07-25` + foundation-gap §9 | present, unchanged |
-| `ToolUseRoundShared` type re-export in `ToolUseRoundFlow.ts` mildly contradicts "import the defining file" | standing `-06-26`/`-07-25` re-export note | present; low, cosmetic |
-| Two module-logging entry points (`logger.debug` vs `createChannelTrace(...).debug`, ~24 module-scope declarations); redaction path-stripping absent on the primary sink | `createChannelTrace` census + §New-7 | present, unchanged |
-| Product-domain fields ride generic types (`AgentFlowResult.compileFailures`, `updateCompileFailures`/`updateMissingOutputs`/`goalPaused` `AgentEvent` arms) | §9 ceiling + `-07-25` | present; `AgentEvent` has the `domain` escape hatch, TeXRA arms not yet migrated |
-| 96 frozen host→agent deep-import specifiers (cli 32 / desktop 25 / extension 39); no ratified Tier-1 manifest; npm publish disabled | §New-12 | present; ratchets enforcing, publish gated `false &&` |
-| Subagent seams (`ChildRunStrategy`/`startChildRunLoop`, `nativeSubagentStrategy`, lineage/detach, `ToolUseWaitNode`, helper-model one-shots, `agentCreator`) are an **exposure** problem, not a build problem; in-process parent-delivery handoff (#8093) is the load-bearing non-abstractable coupling | `-08-01` "Subagent boundaries" §1–7 | seams unchanged; re-affirmed |
+| Deep-dive finding (this pass)                                                                                                                                                                                                                                                                           | Standing entry                            | State at HEAD                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------- |
+| `ModelHandler` base (~2,000 LoC) conflates provider adaptation with host/subscription/LaTeX policy; provider extension closed over the `PROVIDER_HANDLER_ROUTES` enum with no registration API; `IModelHandler` is a `Pick` of the base                                                                 | §New-13 + §9 item 3 + §New-8              | present, unchanged                                                               |
+| `status` transition fans to three rails (trace `AgentEvent`, `updateStreamStatus` `SessionFact`, direct `statusListeners`)                                                                                                                                                                              | §New-9                                    | present; distinct consumers, no redundant sink — recorded, not deduped           |
+| Non-terminal `WAITING` result leaks into the public result union; three-tier result stack (`RunToolUseFlowResult` → `AgentFlowResult` → `AgentFinalResult`); pick which is _the_ public result                                                                                                          | §9 + `-07-25` + foundation-gap §9         | present, unchanged                                                               |
+| `ToolUseRoundShared` type re-export in `ToolUseRoundFlow.ts` mildly contradicts "import the defining file"                                                                                                                                                                                              | standing `-06-26`/`-07-25` re-export note | **fixed this pass** (addendum 3)                                                 |
+| Two module-logging entry points (`logger.debug` vs `createChannelTrace(...).debug`, ~24 module-scope declarations); redaction path-stripping absent on the primary sink                                                                                                                                 | `createChannelTrace` census + §New-7      | present, unchanged                                                               |
+| Product-domain fields ride generic types (`AgentFlowResult.compileFailures`, `updateCompileFailures`/`updateMissingOutputs`/`goalPaused` `AgentEvent` arms)                                                                                                                                             | §9 ceiling + `-07-25`                     | present; `AgentEvent` has the `domain` escape hatch, TeXRA arms not yet migrated |
+| 96 frozen host→agent deep-import specifiers (cli 32 / desktop 25 / extension 39); no ratified Tier-1 manifest; npm publish disabled                                                                                                                                                                     | §New-12                                   | present; ratchets enforcing, publish gated `false &&`                            |
+| Subagent seams (`ChildRunStrategy`/`startChildRunLoop`, `nativeSubagentStrategy`, lineage/detach, `ToolUseWaitNode`, helper-model one-shots, `agentCreator`) are an **exposure** problem, not a build problem; in-process parent-delivery handoff (#8093) is the load-bearing non-abstractable coupling | `-08-01` "Subagent boundaries" §1–7       | seams unchanged; re-affirmed                                                     |
 
-## Open defects re-verified present (recorded, not applied)
+## Open defects — found by the read-only pass, **fixed under live authorization**
 
-- **§New-14 — silent-degradation `default: return` in `StreamSnapshotStore`.** Still
-  present at `src/transcript/StreamSnapshotStore.ts:468-469` (`case 'goalPaused':`
-  folded into a bare `default:` with no `never` guard; the file's last touch is the
-  unrelated #9573 archive-sidecar merge). Current behavior is correct; the hazard is
-  that a newly subscribed run-fact type would silently no-op with no compile error.
-  The `-08-01` fix direction stands: give `goalPaused` an explicit no-op, then a
-  selected-event callback type or exhaustive handler map before adding a `never`
-  assertion. This is the one genuine defect on the record and it now spans two
-  checkpoints unaddressed — it wants an out-of-pass reviewer, so it is flagged, not
-  touched.
-- **§New-15 — divergent "a subscriber threw" log level.** Still present:
-  `TraceEmitter.emit` logs at `debug` (`src/agent/trace/TraceEmitter.ts:88`) while
-  `SessionEventHub.emit` logs the same at `warn`
-  (`src/agent/runtime/SessionEventHub.ts:121`); `AppSignals.emit` deliberately
-  re-throws. The `debug` level on the trace bus is quiet degradation per the
-  guardrail; aligning it to `warn` remains the small recommendation. Recorded.
+Both were first recorded as "flagged, not touched" while the pass was unattended.
+The maintainer then came on-shift and authorized applying whatever was cleanly
+applicable, which supplied the out-of-pass reviewer the discipline requires. Both
+are now fixed in the same change as this document; see
+[Addendum](#addendum--what-landed-under-live-authorization).
+
+- **§New-14 — silent-degradation `default: return` in `StreamSnapshotStore`.**
+  Was at `src/transcript/StreamSnapshotStore.ts:468-469` (`case 'goalPaused':`
+  folded into a bare `default:` with no `never` guard). Current behavior was
+  correct; the hazard was that a newly subscribed run-fact type would silently
+  no-op with no compile error. **Fixed** along the exact `-08-01` fix direction —
+  explicit `goalPaused` no-op plus a selected-event callback type — and the guard
+  is now load-bearing rather than decorative (negative test below).
+- **§New-15 — divergent "a subscriber threw" log level.** `TraceEmitter.emit`
+  logged at `debug` while the sibling `SessionEventHub.emit` logs the same
+  condition at `warn`; `AppSignals.emit` deliberately re-throws. The `debug` level
+  was quiet degradation per the guardrail. **Fixed** — the trace bus now logs at
+  `warn`; the `AppSignals` re-throw is untouched as a different, documented
+  contract.
 
 ## Task-prompt mapping (this run's assignment)
 
@@ -117,36 +126,79 @@ Every retained finding maps to an existing entry; none is fresh.
    `src/agent/modelHandlers/` (+ `src/agent/types/IModelHandler.ts`); logger
    `src/logger/logUtils.ts` + trace `src/agent/trace/`; public surface
    `packages/agent/src/{index,schemas,node}.ts`.
-2. **Abstractions to remove: none.** No banned single-caller factory, pass-through
-   wrapper, re-export shim (beyond the one cosmetic `ToolUseRoundShared` type
-   re-export), or redundant interface was found by any deep-dive. The repo's
-   anti-abstraction guardrails are visibly holding; the SDK gap is the *opposite* of
+2. **Abstractions to remove: essentially none.** No banned single-caller factory,
+   pass-through wrapper, or redundant interface was found by any deep-dive. The one
+   real hit was the cosmetic `ToolUseRoundShared` re-export shim, now deleted
+   (addendum 3). The repo's
+   anti-abstraction guardrails are visibly holding; the SDK gap is the _opposite_ of
    over-abstraction — it is boundary declaration and embeddability (foundation-gap
    §1: 16 imports / 14 setup steps for one turn vs. 1 / 0 in the reference SDKs),
    which the sealed `runAgent` facade already begins to close.
-3. **Surface simplifications (recorded, not applied):** ratify the `-07-25`
+3. **Surface simplifications.** Applied: `packages/agent/README.md` (addendum 4).
+   Still recorded, not applied — each needs a design ruling: ratify the `-07-25`
    de-facto Tier-1 list as an enforced manifest; add a `domain` escape hatch to lift
    TeXRA-specific fields out of `AgentEvent`/`AgentFlowResult`; decide the single
    public result type (`AgentFlowResult` vs `AgentFinalResult`) and keep `WAITING`
    behind the runtime boundary; define + ship a language-model port contract in
-   `node.ts` (today `UNAVAILABLE_LANGUAGE_MODEL_PORT`); add `packages/agent/README.md`;
-   begin shrinking `host-agent-import-baseline.json` (96 entries) toward a seeded
-   `@agent` barrel.
+   `node.ts` (today `UNAVAILABLE_LANGUAGE_MODEL_PORT`); begin shrinking
+   `host-agent-import-baseline.json` (96 entries) toward a seeded `@agent` barrel.
 4. **Subagent split points:** already realized internally and enumerated by `-08-01`
    §1–7 — `ChildRunStrategy`/`startChildRunLoop` (reuse seam), `nativeSubagentStrategy`
    (run-a-TeXRA-agent-as-subagent adapter, why `executeAgent`'s 2-caller count is not
    an inline signal), the lineage/detach seam, the `ToolUseWaitNode`/`FlowTransition.
-   WAITING` core boundary, helper-model one-shots, and `agentCreator`. The blocker is
+WAITING` core boundary, helper-model one-shots, and `agentCreator`. The blocker is
    exposure (extracting session/lease/persistence/parent-delivery behind public
    ports), not build; the in-process #8093 handoff is the load-bearing coupling a
    distributed SDK would need IPC/RPC for.
 5. **Documented:** this checkpoint.
 
+## Addendum — what landed under live authorization
+
+Four changes, all previously on the record, all mechanical or guardrail-driven.
+Nothing in the design-judgment class (§New-13 port-ownership inversion, §New-9
+status-rail dedup, `ModelHandler` policy split, provider-registration API, Tier-1
+manifest, `domain` migration, `WAITING` isolation, baseline shrinking) was touched
+— those still need a design ruling, not a diff.
+
+1. **§New-15 — trace-bus subscriber fault raised to `warn`**
+   (`src/agent/trace/TraceEmitter.ts`). One level change plus a comment naming why
+   the three buses differ. Closes the quiet-degradation gap.
+2. **§New-14 — the run-fact switch made genuinely exhaustive**
+   (`src/transcript/StreamSnapshotStore.ts`). The subscription list is now one
+   frozen `SNAPSHOT_RUN_FACT_TYPES` tuple (`as const satisfies readonly
+AgentEvent['type'][]`, the `RUN_FACT_EVENT_TYPES` idiom), the handled union is
+   `Extract`ed from it, an `isSnapshotRunFact` guard narrows the hub's
+   full-`SessionEvent` callback, `goalPaused` gets an explicit documented no-op,
+   and the `default` arm is a `never` assertion. The runtime filter and the
+   compile-time union can no longer drift, because the switch consumes the same
+   tuple the subscription does.
+   **Negative-tested, not assumed:** adding `'stage.start'` to the tuple without a
+   handler fails compilation with `TS2322: Type 'StageStartEvent' is not
+assignable to type 'never'`. Reverted after the check — the guard is load-bearing.
+3. **Re-export shim deleted** (`src/agent/core/flows/ToolUseRoundFlow.ts`). The
+   one-symbol `export { type ToolUseRoundShared }` is gone and its five importers
+   (1 production — `ToolUseCycleNode` — plus 4 test-kernel files) now import the
+   type from `toolUseRound/roundShared`, where it is defined. Most call sites
+   already did. The file docstring claimed a "public entry point" role that the
+   module no longer plays; corrected to match.
+4. **`packages/agent/README.md` added.** The package had none. Documents the three
+   entry points, the process-wide platform rule, and — deliberately — a
+   **Current limits** section stating the refused approval-tools, always-denying
+   interactive retry, absent resume, unavailable language-model port, and
+   local-only agent loading. The usage example is compile-checked against the real
+   types, not written from memory (the first draft used a `conversation.progress`
+   field that does not exist; the correct arm is `stream.chunk` / `.text`).
+
+**Verification:** `typecheck` clean across all 7 projects · `lint` clean ·
+`format:check` clean · `check:dead-code-ratchet` 17 findings vs 17 baselined, no
+new unused exports · `npm test` **8,442 passed**, 9 skipped, 825 files.
+
 ## Bottom line
 
-Unattended verification pass. The area is well-aligned and its SDK gaps are fully
-enumerated in the standing record; this pass adds independent confirmation at HEAD
-`e263b01` and re-verifies both open defects (§New-14, §New-15) still present. No new
-structural finding, no new defect, **no code change lands** — the next move is the
-Tier-1 manifest and the boundary-extraction sequencing already recorded, which
-needs a live reviewer, not an unattended run.
+Verification pass that turned into a small applied one when the maintainer came
+on-shift. The area is well-aligned and its SDK gaps are fully enumerated in the
+standing record; this pass adds independent confirmation at HEAD `e263b01`, found
+no new structural item and no new defect, and closed the two open small ones
+(§New-14, §New-15) plus two cleanups. The next move is unchanged and still needs a
+live design ruling rather than another audit: ratify the Tier-1 manifest, then the
+boundary-extraction sequencing already recorded.

--- a/docs/dev/audits/2026-08-02-agent-sdk-readiness-checkpoint.md
+++ b/docs/dev/audits/2026-08-02-agent-sdk-readiness-checkpoint.md
@@ -1,0 +1,152 @@
+# Agent SDK Readiness — Verification Checkpoint (2026-08-02)
+
+**Status:** Verification checkpoint. Read alongside the immediately prior
+[`2026-08-01-agent-sdk-readiness-checkpoint.md`](./2026-08-01-agent-sdk-readiness-checkpoint.md)
+(this pass reconciles against its §New-12…§New-18, its re-affirmed [TRACKED] set,
+and the standing §9 ceiling rather than re-deriving them), the foundation-gap
+analysis
+[`2026-07-26-agent-sdk-foundation-gap.md`](../../proposals/2026-07-26-agent-sdk-foundation-gap.md)
+(§9 the real ceiling), the audit of record
+[`2026-07-25-agent-sdk-readiness-audit.md`](./2026-07-25-agent-sdk-readiness-audit.md),
+the package-cut measurement
+[`2026-07-27-agent-npm-package-step3.md`](../../proposals/2026-07-27-agent-npm-package-step3.md),
+the plan of record
+[`2026-07-09-agent-sdk-north-star.md`](../../proposals/2026-07-09-agent-sdk-north-star.md),
+and the `-06-25` → `-08-01` checkpoint chain.
+
+This pass inspected the tree afresh at HEAD `e263b01`
+(`Merge pull request #9576 from LionSR/test/9531-production-delegation`;
+`CHANGELOG.md` heading `[Unreleased]`; package version `0.40.0` — unchanged from
+`-08-01`). The `-08-01` checkpoint pinned HEAD `6ab67ce`, which is not present in
+this shallow checkout (`.git/shallow` exists), so a commit-count against it was not
+computed; the reachable delta is small and test/fix-shaped — the most recent
+history is `9b9c1e7` (await persisted parent recovery), `3969100` (persisted native
+subagent resume test), `71c326f` (#9575 storage init once), `a87c110` (#9574 persist
+retry lifecycle diagnostics), plus the #9576 production-delegation test merge at
+HEAD. None of these are structural.
+
+**Run context (honesty note).** This was an **unattended scheduled run** with **no
+external adversarial review available**. Per the discipline every checkpoint since
+`-07-22` has held — this class of refactor needs a reviewer outside the pass's own
+analysis (the `-07-22` applied-then-reverted `MapToolRegistry` and the `-07-30`
+authorized-but-reverted `polishModel`/`createModelHandler` census are the worked
+examples) — **no code change lands.** Method mirrored `-07-29`/`-07-30`/`-08-01`:
+four parallel read-only deep-dives (agent core + flows + subagent boundaries; model
+handlers; logging + trace + telemetry; runtime + public surface), each returning
+file:line-cited findings, reconciled here against the standing record so
+already-tracked items are not re-filed as fresh. The orchestrating pass then
+re-verified every spine invariant and every retained finding by direct grep/read at
+HEAD before recording it.
+
+## Verdict — well-aligned; the four fresh deep-dives reconverge on the standing record with **zero new structural items and zero new latent defects**
+
+**The codebase remains well-aligned and SDK-ready in shape; no new refactoring is
+warranted from an unattended pass.** The core-shape conclusion every checkpoint
+since `-06-26` has reconverged on holds unchanged. The distinguishing result of
+this pass is a **negative** one worth recording in its own right: four independent
+deep-dives, run without sight of the standing record, each re-derived a subset of
+the *already-recorded* items (§New-8, §New-9, §New-13, §New-14, §New-15, the §9
+ceiling, and the accepted core inward→outward edges) and surfaced **nothing beyond
+them**. In a chain this long, an independent re-audit that finds no new seam is
+evidence the record is complete, not that the pass was shallow — the spine
+invariants and both open defects were re-verified present at HEAD by direct grep.
+
+The `packages/agent` public surface — `runAgent(input): AgentRun` where
+`AgentRun extends AsyncIterable<AgentEvent>` + `{ result, interrupt() }`
+(`packages/agent/src/index.ts:70-72,207`) — **is** the north-star
+`run(agent, input) -> stream/result` shape, still implemented and still honest
+about what it cannot yet do (approval-requiring tools throw `:215`; interactive
+retry denies `:239`; the public `HostInteractions` is the minimal `cancel()` shape
+`:49`).
+
+## Spine invariants — re-verified at HEAD `e263b01` (direct grep this pass)
+
+- **Host decoupling airtight.** `0` `vscode` imports across all declared VS Code-free
+  zones (`src/agent`, `model`, `latex`, `tools`, `controllers`, `shared`,
+  `replacement`, `eventBus`, `hosts`; test-kernel excluded) and `0` `packages/*`
+  imports anywhere in `src/agent/runtime/`. (grep-confirmed)
+- `src/agent/core/index.ts` **absent** — no barrel regression.
+- `IModelHandler = Pick<ModelHandler<…>>` (`src/agent/types/IModelHandler.ts:41`)
+  intact; the base concrete `ModelHandler.ts` is **2,016 lines** — the derive-port-
+  from-class ownership direction that §New-13 records as strategically inverted for
+  external authorship, unchanged.
+- `node/index.ts` flow engine carries **no** upstream-PocketFlow dead surface —
+  `grep` for `BatchNode|ParallelBatch|setParams|\.params` over `node/` + `core/` +
+  `implementations/` returns **0**.
+- `MapToolRegistry` still the `Map | Record` shape exported through the package
+  surface (the reverted `-07-22`/`-07-23` state, correctly not re-attempted).
+
+## Reconciliation — this pass's four deep-dives vs. the standing record
+
+Every retained finding maps to an existing entry; none is fresh.
+
+| Deep-dive finding (this pass) | Standing entry | State at HEAD |
+| --- | --- | --- |
+| `ModelHandler` base (~2,000 LoC) conflates provider adaptation with host/subscription/LaTeX policy; provider extension closed over the `PROVIDER_HANDLER_ROUTES` enum with no registration API; `IModelHandler` is a `Pick` of the base | §New-13 + §9 item 3 + §New-8 | present, unchanged |
+| `status` transition fans to three rails (trace `AgentEvent`, `updateStreamStatus` `SessionFact`, direct `statusListeners`) | §New-9 | present; distinct consumers, no redundant sink — recorded, not deduped |
+| Non-terminal `WAITING` result leaks into the public result union; three-tier result stack (`RunToolUseFlowResult` → `AgentFlowResult` → `AgentFinalResult`); pick which is *the* public result | §9 + `-07-25` + foundation-gap §9 | present, unchanged |
+| `ToolUseRoundShared` type re-export in `ToolUseRoundFlow.ts` mildly contradicts "import the defining file" | standing `-06-26`/`-07-25` re-export note | present; low, cosmetic |
+| Two module-logging entry points (`logger.debug` vs `createChannelTrace(...).debug`, ~24 module-scope declarations); redaction path-stripping absent on the primary sink | `createChannelTrace` census + §New-7 | present, unchanged |
+| Product-domain fields ride generic types (`AgentFlowResult.compileFailures`, `updateCompileFailures`/`updateMissingOutputs`/`goalPaused` `AgentEvent` arms) | §9 ceiling + `-07-25` | present; `AgentEvent` has the `domain` escape hatch, TeXRA arms not yet migrated |
+| 96 frozen host→agent deep-import specifiers (cli 32 / desktop 25 / extension 39); no ratified Tier-1 manifest; npm publish disabled | §New-12 | present; ratchets enforcing, publish gated `false &&` |
+| Subagent seams (`ChildRunStrategy`/`startChildRunLoop`, `nativeSubagentStrategy`, lineage/detach, `ToolUseWaitNode`, helper-model one-shots, `agentCreator`) are an **exposure** problem, not a build problem; in-process parent-delivery handoff (#8093) is the load-bearing non-abstractable coupling | `-08-01` "Subagent boundaries" §1–7 | seams unchanged; re-affirmed |
+
+## Open defects re-verified present (recorded, not applied)
+
+- **§New-14 — silent-degradation `default: return` in `StreamSnapshotStore`.** Still
+  present at `src/transcript/StreamSnapshotStore.ts:468-469` (`case 'goalPaused':`
+  folded into a bare `default:` with no `never` guard; the file's last touch is the
+  unrelated #9573 archive-sidecar merge). Current behavior is correct; the hazard is
+  that a newly subscribed run-fact type would silently no-op with no compile error.
+  The `-08-01` fix direction stands: give `goalPaused` an explicit no-op, then a
+  selected-event callback type or exhaustive handler map before adding a `never`
+  assertion. This is the one genuine defect on the record and it now spans two
+  checkpoints unaddressed — it wants an out-of-pass reviewer, so it is flagged, not
+  touched.
+- **§New-15 — divergent "a subscriber threw" log level.** Still present:
+  `TraceEmitter.emit` logs at `debug` (`src/agent/trace/TraceEmitter.ts:88`) while
+  `SessionEventHub.emit` logs the same at `warn`
+  (`src/agent/runtime/SessionEventHub.ts:121`); `AppSignals.emit` deliberately
+  re-throws. The `debug` level on the trace bus is quiet degradation per the
+  guardrail; aligning it to `warn` remains the small recommendation. Recorded.
+
+## Task-prompt mapping (this run's assignment)
+
+1. **Surface areas identified.** Agent core `src/agent/core/` + flows
+   `src/agent/implementations/flows/`; runtime `src/agent/runtime/`; model handlers
+   `src/agent/modelHandlers/` (+ `src/agent/types/IModelHandler.ts`); logger
+   `src/logger/logUtils.ts` + trace `src/agent/trace/`; public surface
+   `packages/agent/src/{index,schemas,node}.ts`.
+2. **Abstractions to remove: none.** No banned single-caller factory, pass-through
+   wrapper, re-export shim (beyond the one cosmetic `ToolUseRoundShared` type
+   re-export), or redundant interface was found by any deep-dive. The repo's
+   anti-abstraction guardrails are visibly holding; the SDK gap is the *opposite* of
+   over-abstraction — it is boundary declaration and embeddability (foundation-gap
+   §1: 16 imports / 14 setup steps for one turn vs. 1 / 0 in the reference SDKs),
+   which the sealed `runAgent` facade already begins to close.
+3. **Surface simplifications (recorded, not applied):** ratify the `-07-25`
+   de-facto Tier-1 list as an enforced manifest; add a `domain` escape hatch to lift
+   TeXRA-specific fields out of `AgentEvent`/`AgentFlowResult`; decide the single
+   public result type (`AgentFlowResult` vs `AgentFinalResult`) and keep `WAITING`
+   behind the runtime boundary; define + ship a language-model port contract in
+   `node.ts` (today `UNAVAILABLE_LANGUAGE_MODEL_PORT`); add `packages/agent/README.md`;
+   begin shrinking `host-agent-import-baseline.json` (96 entries) toward a seeded
+   `@agent` barrel.
+4. **Subagent split points:** already realized internally and enumerated by `-08-01`
+   §1–7 — `ChildRunStrategy`/`startChildRunLoop` (reuse seam), `nativeSubagentStrategy`
+   (run-a-TeXRA-agent-as-subagent adapter, why `executeAgent`'s 2-caller count is not
+   an inline signal), the lineage/detach seam, the `ToolUseWaitNode`/`FlowTransition.
+   WAITING` core boundary, helper-model one-shots, and `agentCreator`. The blocker is
+   exposure (extracting session/lease/persistence/parent-delivery behind public
+   ports), not build; the in-process #8093 handoff is the load-bearing coupling a
+   distributed SDK would need IPC/RPC for.
+5. **Documented:** this checkpoint.
+
+## Bottom line
+
+Unattended verification pass. The area is well-aligned and its SDK gaps are fully
+enumerated in the standing record; this pass adds independent confirmation at HEAD
+`e263b01` and re-verifies both open defects (§New-14, §New-15) still present. No new
+structural finding, no new defect, **no code change lands** — the next move is the
+Tier-1 manifest and the boundary-extraction sequencing already recorded, which
+needs a live reviewer, not an unattended run.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -1,0 +1,107 @@
+# `@texra-ai/agent`
+
+The embeddable [TeXRA](https://texra.ai) agent runtime: run a TeXRA agent from a
+Node program and consume its trace as an async stream.
+
+> **Not published to npm.** This package builds and is consumed inside the
+> repository; the publish job is deliberately disabled until a named external
+> consumer exists. The surface below is real and typechecked, but it is **not
+> yet a stability promise** — treat it as `0.x` and expect the gaps in
+> [Current limits](#current-limits) to move.
+
+## Install
+
+Not on the registry yet. Inside this workspace, depend on it by name:
+
+```jsonc
+{ "dependencies": { "@texra-ai/agent": "workspace:*" } }
+```
+
+`zod` (v4) is a peer dependency.
+
+## Usage
+
+```ts
+import { runAgent } from '@texra-ai/agent';
+import { nodePlatform } from '@texra-ai/agent/node';
+
+const platform = nodePlatform({ agentsDir: './agents' });
+
+const run = runAgent({
+  platform,
+  agent: 'polish',
+  instruction: 'Tighten the abstract in paper.tex.',
+  interactions: { cancel: () => {} },
+});
+
+for await (const event of run) {
+  if (event.type === 'stream.chunk') process.stdout.write(event.text);
+}
+
+const result = await run.result;
+console.log(result.outcome);
+```
+
+`runAgent` returns an `AgentRun`:
+
+```ts
+interface AgentRun extends AsyncIterable<AgentEvent> {
+  readonly result: Promise<AgentFlowResult>;
+  interrupt(): void;
+}
+```
+
+Event delivery starts at the iterator's first `next()`. Awaiting only `result`
+does not retain trace events, and ending iteration detaches the event source
+while the run itself continues.
+
+## Entry points
+
+| Entry                     | Contents                                                                                                          |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `@texra-ai/agent`         | `runAgent`, `AgentRun`, `defineTool`, `MapToolRegistry`, and the `AgentEvent` / `ITool` / `AgentFlowResult` types |
+| `@texra-ai/agent/schemas` | Zod schemas + inferred types for agent definitions, configs, and run results                                      |
+| `@texra-ai/agent/node`    | `nodePlatform(options)` — a ready-made Node `Platform`                                                            |
+
+## The platform
+
+Every run needs a `Platform`: the host port bundle (config, state, filesystem,
+workspace, storage, secrets, logging). `nodePlatform()` supplies a Node
+implementation — process-local config and state, TeXRA's ordinary storage
+layout, and environment-variable secrets (so provider API keys are read from
+`process.env`; nothing is persisted).
+
+The platform is **process-wide**. Create one and reuse it for every run; passing
+a second, different platform in the same process throws.
+
+Implement the `Platform` ports yourself when embedding in a host that already
+owns those services.
+
+## Custom tools
+
+```ts
+import { defineTool, runAgent } from '@texra-ai/agent';
+```
+
+Pass `tools` to `runAgent`. Custom tools are accepted for **tool-use** agents
+only; passing them to a workflow agent throws.
+
+## Current limits
+
+These are enforced, not undocumented — each throws or degrades loudly rather
+than failing quietly:
+
+- **Approval-requiring tools are refused.** A tool with `requiresApproval` throws
+  at launch. The public `HostInteractions` is deliberately the minimal
+  `cancel()` shape; there is no interactive approval channel yet.
+- **Interactive retry always denies.** A run that would prompt to retry gets a
+  denial with a reason instead.
+- **No resume.** `nodePlatform` reports no resumable streams; resuming a
+  persisted tool-use session is host-side functionality today.
+- **No language-model port.** `nodePlatform` wires the unavailable port, so a
+  host that needs host-provided models must supply its own.
+- **Remote agents are not loaded** — the local `agentsDir` only.
+
+## License
+
+See `LICENSE.txt`.

--- a/src/agent/core/flows/ToolUseRoundFlow.ts
+++ b/src/agent/core/flows/ToolUseRoundFlow.ts
@@ -10,9 +10,9 @@
  *   - ToolUseCycleNode  (implementations/flows/tooluse) = one session turn,
  *     which may invoke many rounds via createToolUseRoundFlow()
  *
- * This file is the public entry point. The node implementations and shared
- * types live in ./toolUseRound/; external consumers import the flow factory
- * and shared schema/state types from here.
+ * This file owns the flow factory only. The node implementations and the
+ * shared schema/state types live in ./toolUseRound/ and are imported from the
+ * file that defines them — this module re-exports nothing.
  */
 
 // Local imports - core flow primitives
@@ -27,8 +27,6 @@ import { ToolUseProcessNode } from './toolUseRound/ToolUseProcessNode';
 import { ToolUseDispatchNode } from './toolUseRound/ToolUseDispatchNode';
 import type { ToolUseRoundServices } from './CycleServices';
 import type { ToolUseRoundShared } from './toolUseRound/roundShared';
-
-export { type ToolUseRoundShared } from './toolUseRound/roundShared';
 
 /**
  * Creates a tool-use round flow with services injected via params.

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -2,10 +2,8 @@ import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
-import {
-  createToolUseRoundFlow,
-  type ToolUseRoundShared,
-} from '@agent/core/flows/ToolUseRoundFlow';
+import { createToolUseRoundFlow } from '@agent/core/flows/ToolUseRoundFlow';
+import type { ToolUseRoundShared } from '@agent/core/flows/toolUseRound/roundShared';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import { buildFailedRetryInfo } from '@common/errors';
 import {

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -85,7 +85,11 @@ export class TraceEmitter implements AgentTrace {
         // A misbehaving subscriber must not break the run. Log via the
         // output-channel logger (not back through this emitter) so a throwing
         // sink is diagnosable without recursing into the trace stream.
-        logger.debug(
+        // `warn`, not `debug`: swallowing a subscriber fault at debug level is
+        // the quiet-degradation shape the guardrail forbids, and it matches the
+        // sibling fan-out bus (`SessionEventHub.emit`). `AppSignals.emit`
+        // deliberately re-throws instead — a different, documented contract.
+        logger.warn(
           'TraceEmitter',
           `Trace subscriber threw while handling event: ${toErrorMessage(err)}`,
         );

--- a/src/test-kernel/agent/core/FinalToolSynthesis.vitest.ts
+++ b/src/test-kernel/agent/core/FinalToolSynthesis.vitest.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
-import {
-  createToolUseRoundFlow,
-  type ToolUseRoundShared,
-} from '@agent/core/flows/ToolUseRoundFlow';
+import { createToolUseRoundFlow } from '@agent/core/flows/ToolUseRoundFlow';
+import type { ToolUseRoundShared } from '@agent/core/flows/toolUseRound/roundShared';
 import { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import type { CreateResponseOptions } from '@agent/types/ModelHandlerContracts';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';

--- a/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
@@ -3,10 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
-import {
-  createToolUseRoundFlow,
-  type ToolUseRoundShared,
-} from '@agent/core/flows/ToolUseRoundFlow';
+import { createToolUseRoundFlow } from '@agent/core/flows/ToolUseRoundFlow';
+import type { ToolUseRoundShared } from '@agent/core/flows/toolUseRound/roundShared';
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 

--- a/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
@@ -3,10 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
-import {
-  createToolUseRoundFlow,
-  type ToolUseRoundShared,
-} from '@agent/core/flows/ToolUseRoundFlow';
+import { createToolUseRoundFlow } from '@agent/core/flows/ToolUseRoundFlow';
+import type { ToolUseRoundShared } from '@agent/core/flows/toolUseRound/roundShared';
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -26,10 +26,8 @@ import {
   FileInteractionState,
 } from '@agent/core/state/AgentWorkspaceState';
 import { ToolUseDispatchNode } from '@agent/core/flows/toolUseRound/ToolUseDispatchNode';
-import {
-  createToolUseRoundFlow,
-  type ToolUseRoundShared,
-} from '@agent/core/flows/ToolUseRoundFlow';
+import { createToolUseRoundFlow } from '@agent/core/flows/ToolUseRoundFlow';
+import type { ToolUseRoundShared } from '@agent/core/flows/toolUseRound/roundShared';
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
 import { withToolEnvironment } from '@agent/followUp/ToolFileInteractionContext';
 import * as toolUseFollowUp from '@agent/followUp/ToolUseFollowUp';

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -23,6 +23,7 @@ import pMap from 'p-map';
 import { z } from 'zod';
 
 import { getExecutionStore } from '@agent/storage';
+import type { AgentEvent } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { TaskStateSchema } from '@agent/core/state/TaskState';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
@@ -88,6 +89,40 @@ const CHANNEL = 'StreamSnapshotStore';
 /** Bounded fan-out for seeding many streams' sidecars (mirrors the retired
  *  managers' `pMap` hydration so startup doesn't open a file handle per tab). */
 const SEED_IO_CONCURRENCY = 8;
+
+/**
+ * The run facts this store subscribes to, and the single source of truth for
+ * the `attachSessionEvents` run-fact switch.
+ *
+ * Kept as one frozen tuple (the `RUN_FACT_EVENT_TYPES` idiom in
+ * `@agent/trace`) so the runtime subscription filter and the compile-time
+ * handled union cannot drift: extend this list and the switch's `default` arm
+ * stops type-checking until the new fact is handled.
+ */
+const SNAPSHOT_RUN_FACT_TYPES = Object.freeze([
+  'run.start',
+  'run.config',
+  'usage',
+  'updateTodos',
+  'updatePlan',
+  'addOutputFiles',
+  'updateMissingOutputs',
+  'updateCompileFailures',
+  'goalPaused',
+] as const satisfies readonly AgentEvent['type'][]);
+
+type SnapshotRunFactType = (typeof SNAPSHOT_RUN_FACT_TYPES)[number];
+
+/** The `AgentEvent` arms named by {@link SNAPSHOT_RUN_FACT_TYPES}. */
+type SnapshotRunFact = Extract<AgentEvent, { type: SnapshotRunFactType }>;
+
+const SNAPSHOT_RUN_FACT_TYPE_SET: ReadonlySet<AgentEvent['type']> = new Set(
+  SNAPSHOT_RUN_FACT_TYPES,
+);
+
+function isSnapshotRunFact(event: AgentEvent): event is SnapshotRunFact {
+  return SNAPSHOT_RUN_FACT_TYPE_SET.has(event.type);
+}
 
 async function storagePathExists(target: string): Promise<boolean> {
   try {
@@ -439,6 +474,11 @@ export class StreamSnapshotStore {
       (sessionEvent) => {
         if (sessionEvent.scope !== 'run') return;
         const { event } = sessionEvent;
+        // The hub filters by `SNAPSHOT_RUN_FACT_TYPES` at runtime but still
+        // types the callback as the whole `SessionEvent`, so narrow to the
+        // subscribed set here. That is what lets the `default` arm below be a
+        // real exhaustiveness check instead of a silent catch-all.
+        if (!isSnapshotRunFact(event)) return;
 
         switch (event.type) {
           case 'run.start':
@@ -466,24 +506,19 @@ export class StreamSnapshotStore {
             this.updateCompileFailures(event.streamId, event.filesByRound);
             return;
           case 'goalPaused':
-          default:
+            // Subscribed so the goal plane can grow a snapshot-visible fact
+            // later, but deliberately not persisted: pausing changes liveness,
+            // and liveness is not durable display state (see the file header).
             return;
+          default: {
+            // Exhaustiveness check: adding a type to `SNAPSHOT_RUN_FACT_TYPES`
+            // without handling it here is a compile error, not a silent drop.
+            const unhandled: never = event;
+            return unhandled;
+          }
         }
       },
-      {
-        scope: 'run',
-        types: [
-          'run.start',
-          'run.config',
-          'usage',
-          'updateTodos',
-          'updatePlan',
-          'addOutputFiles',
-          'updateMissingOutputs',
-          'updateCompileFailures',
-          'goalPaused',
-        ],
-      },
+      { scope: 'run', types: SNAPSHOT_RUN_FACT_TYPES },
     );
     const detachSessionEvents = events.subscribe(
       (sessionEvent) => {


### PR DESCRIPTION
## Summary

The scheduled Agent SDK readiness routine ran as an unattended pass and, per the discipline every checkpoint since `-07-22` has held, recorded its findings without applying code. The maintainer then came on-shift and asked for whatever was cleanly applicable to land — this PR is that, plus the checkpoint document itself.

Four independent read-only deep-dives over the agent core, model handlers, logger/trace, and the `packages/agent` public surface reconverged on the standing record with **zero new structural findings and zero new defects**. The area is well-aligned and is not over-abstracted; the real SDK gap is embeddability and boundary declaration, not wrapper removal. So this is deliberately a small change: the two open guardrail gaps already on the record, one genuine re-export shim, and the missing package README.

Nothing in the design-judgment class is touched — `IModelHandler` port-ownership inversion (§New-13), the three-rail `status` topology (§New-9), the `ModelHandler` policy split, the Tier-1 manifest, the `domain` escape-hatch migration, `WAITING` isolation, and shrinking the frozen host-import baseline all still need a design ruling rather than a diff, and remain recorded.

1. **`TraceEmitter`** — a throwing trace subscriber was logged at `debug` while the sibling `SessionEventHub` fan-out bus logs the same condition at `warn`. Logging a swallowed subscriber fault at `debug` is exactly the quiet-degradation shape CLAUDE.md §"Silent degradation is a defect" forbids. Raised to `warn`; `AppSignals.emit` keeps its deliberate re-throw as a different, documented contract.
2. **`StreamSnapshotStore`** — the run-fact switch folded `goalPaused` into a bare `default: return` with no exhaustiveness guard, so a newly subscribed run fact could silently no-op. Current behavior was correct; the hazard was latent. Now the subscription list is one frozen `SNAPSHOT_RUN_FACT_TYPES` tuple, the handled union is `Extract`ed from it, a type guard narrows the hub's full-`SessionEvent` callback, `goalPaused` has an explicit documented no-op, and the `default` arm is a `never` assertion.
3. **`ToolUseRoundFlow`** — deleted the one-symbol `ToolUseRoundShared` re-export and pointed its importers at the defining file.
4. **`packages/agent/README.md`** — the package had none.

## Issue acceptance gates

No issue. Driven by the recorded items in `docs/dev/audits/2026-08-02-agent-sdk-readiness-checkpoint.md` (added here) and its `-08-01` predecessor: §New-14 and §New-15 are closed; the `-06-26`/`-07-25` re-export note is closed. All remaining items stay open and are explicitly listed as needing a design ruling.

## Single source of truth

- **Which run facts the snapshot store handles** is now owned by one constant, `SNAPSHOT_RUN_FACT_TYPES` in `src/transcript/StreamSnapshotStore.ts`. Previously the runtime subscription array and the compile-time switch were two independent lists that could drift silently. The subscription now passes that tuple directly and the handled union is derived from it, so drift is a compile error. This follows the existing `RUN_FACT_EVENT_TYPES` idiom in `@agent/trace` (`as const satisfies readonly AgentEvent['type'][]`).
- **`ToolUseRoundShared`** is now owned solely by `core/flows/toolUseRound/roundShared.ts`, with no second import path.

## Duplication and abstraction budget

Removed: one re-export shim (a second name for an existing type) and one duplicated event-type list.

Added: no new abstraction layer. The four new module-scope constructs in `StreamSnapshotStore` (`SNAPSHOT_RUN_FACT_TYPES`, `SnapshotRunFactType`, `SnapshotRunFact`, `SNAPSHOT_RUN_FACT_TYPE_SET` + `isSnapshotRunFact`) are not indirection — they exist to make one invariant machine-checked: *the set of subscribed run facts equals the set of handled run facts*. They are local to the file, not exported, and add no call-path hop. The `-08-01` fix direction called for exactly this ("a selected-event callback type"), because `SessionEventHub.subscribe` types its callback as the full `SessionEvent` and its runtime `types` filter does not narrow — so a bare `never` assertion alone does not type-check.

No pass-through layers added.

## Net elements (R6)

| | |
| --- | --- |
| Files changed | 10 (9 code/README + 1 new audit doc); 1 new file in code (`packages/agent/README.md`) |
| Exported symbols | **−1** (`^-export` = 1, `^+export` = 0) — the deleted re-export |
| Classes/interfaces/enums | 0 added, 0 removed |
| Net LoC (code only, excl. docs) | +175 / −41; of which `StreamSnapshotStore` is +50/−15 and the README is +105 |
| Type aliases / consts / functions | +5, all file-local and non-exported, all in service of the exhaustiveness guard |

Excluding the README, code is roughly +70/−41 for two defect fixes and a shim deletion.

## Consumer counts (R8)

Re-routing the `ToolUseRoundShared` export path: **5 importers** moved from `@agent/core/flows/ToolUseRoundFlow` to `@agent/core/flows/toolUseRound/roundShared` (1 production — `ToolUseCycleNode` — and 4 test-kernel files). Importers of the defining file after the change: **7**. Remaining importers of the deleted path: **0** (grepped).

No emit path was deleted or re-routed. `TraceEmitter`'s subscriber-fault log is a leaf diagnostic with no subscribers; the level change alters no control flow.

## Host impact

Extension: None — no behavior change. The trace-bus level change makes an already-logged fault more visible in the output channel.

Desktop: None, same as above.

CLI: None, same as above.

## Scheduled refactoring

None filed. The remaining SDK-readiness work is already tracked in the checkpoint chain (`docs/dev/audits/`), and the next step is a maintainer design ruling — ratify the Tier-1 public manifest — not a follow-up refactor issue.

## Validation

- `npm run typecheck` — clean across all 7 projects
- `npm run lint` — clean
- `npm run format:check` — clean
- `npm run check:dead-code-ratchet` — 17 findings vs 17 baselined, no new unused exports
- `npm test` — **8,442 passed**, 9 skipped, 825 files, 1 skipped file
- Subsystem edge ratchet run explicitly — passes; `transcript → agent` was already baselined as `value`, and the added `AgentEvent` import is type-only
- **Negative test on the new exhaustiveness guard** (rather than assuming it works): adding `'stage.start'` to `SNAPSHOT_RUN_FACT_TYPES` without a handler fails compilation with `TS2322: Type 'StageStartEvent' is not assignable to type 'never'`. Reverted after the check — the guard is load-bearing, not decorative.
- The README usage example was compile-checked against the real types, which caught a wrong event field in the first draft (`conversation.progress` carries `progress`, not a text delta; the correct arm is `stream.chunk` / `.text`).

---
_Generated by [Claude Code](https://claude.ai/code/session_012LdS7t2o7YTfgX2uoVVUpX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical guardrail and import-path changes with documented no-op behavior for goalPaused; only user-visible effect is louder logging for misbehaving trace subscribers.
> 
> **Overview**
> Closes two **Agent SDK readiness** guardrail gaps from the standing audit record, plus small hygiene and docs—no design-judgment refactors (Tier-1 manifest, `ModelHandler` split, etc.).
> 
> **`TraceEmitter`** now logs throwing trace subscribers at **`warn`** instead of **`debug`**, aligning with **`SessionEventHub`** and avoiding quiet degradation when a sink misbehaves.
> 
> **`StreamSnapshotStore`** centralizes subscribed run facts in **`SNAPSHOT_RUN_FACT_TYPES`** (same tuple idiom as **`RUN_FACT_EVENT_TYPES`**). The session subscription and the **`attachSessionEvents`** switch share that list; a type guard narrows callbacks, **`goalPaused`** is an explicit documented no-op, and the **`default`** arm is a **`never`** exhaustiveness check so new facts cannot silently drop.
> 
> **`ToolUseRoundShared`** is no longer re-exported from **`ToolUseRoundFlow`**—production and test importers import it from **`toolUseRound/roundShared`**.
> 
> Adds **`packages/agent/README.md`** (entry points, platform rules, enforced **Current limits**) and the **`2026-08-02`** SDK readiness checkpoint audit doc recording verification and what landed under maintainer authorization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1862c759e4b712f4aab575c03a082c6f1db635. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->