### PR TITLE
fix(data-structures): tighten correlated-optional shapes flagged by audit

### DIFF
--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -108,16 +108,16 @@ export function createDesktopProgressIpc(
       const result = ProgressViewInboundMessageSchema.safeParse(message);
       if (!result.success) return false;
 
-      const command = result.data.command;
       // WEBVIEW_READY and pass-through commands return false so sibling
       // handlers in the chain still receive them.
-      if (command === PROGRESS_VIEW_COMMANDS.WEBVIEW_READY) {
-        if (message.view !== 'progress') return false;
+      if (result.data.command === PROGRESS_VIEW_COMMANDS.WEBVIEW_READY) {
+        if (result.data.view !== 'progress') return false;
         withProgress((progress) => {
           void progress.completeWebviewReady().catch(reportAsyncError);
         });
         return false;
       }
+      const command = result.data.command;
       if (passThroughCommands.has(command)) return false;
 
       withProgress((progress) => {

--- a/src/controllers/approval/ToolEditApprovalController.ts
+++ b/src/controllers/approval/ToolEditApprovalController.ts
@@ -190,17 +190,11 @@ export class ToolEditApprovalController {
       if (!entry.isSettled()) {
         void this.runAction(entry, () => this.publishPromptWhenVisible(entry));
       }
-      const result = await settlement;
-
       // `requestToolEditApproval` derives userPatch, lineChanges, and startLine
-      // from the content this returns, so an accepted result only owes it the
-      // content the user actually approved.
-      if (result.accepted && result.appliedContent == null) {
-        throw new Error(
-          'Tool edit approval settled without the current proposed content.',
-        );
-      }
-      return result;
+      // from the content this returns; `ToolEditApprovalResult` requires
+      // `appliedContent` on acceptance, so every settle() call below already
+      // supplies it.
+      return await settlement;
     } finally {
       this.requests.delete(requestId);
       await preview.dispose();

--- a/src/controllers/progressView/ProgressFollowUpPolishController.ts
+++ b/src/controllers/progressView/ProgressFollowUpPolishController.ts
@@ -73,7 +73,7 @@ export class ProgressFollowUpPolishController {
       if (result.success) {
         return {
           kind: 'updated',
-          update: this.createUpdate(input.stream, 'polished', result.text),
+          update: this.createPolishedUpdate(input.stream, result.text),
         };
       }
       if (!result.error) {
@@ -81,9 +81,7 @@ export class ProgressFollowUpPolishController {
       }
       return {
         kind: 'failed',
-        update: this.createUpdate(input.stream, 'polishError', null, {
-          error: result.error,
-        }),
+        update: this.createPolishErrorUpdate(input.stream, result.error),
         userMessage: result.error,
       };
     } catch (error) {
@@ -91,9 +89,7 @@ export class ProgressFollowUpPolishController {
       const logMessage = `Error polishing follow-up: ${errorMsg}`;
       return {
         kind: 'exception',
-        update: this.createUpdate(input.stream, 'polishError', null, {
-          error: errorMsg,
-        }),
+        update: this.createPolishErrorUpdate(input.stream, errorMsg),
         userMessage: logMessage,
         logMessage,
         ...(error instanceof Error && { logData: error }),
@@ -123,18 +119,28 @@ export class ProgressFollowUpPolishController {
     return context;
   }
 
-  private createUpdate(
+  private createPolishedUpdate(
     stream: StreamTabId,
-    kind: 'polished' | 'polishError',
-    text: string | null,
-    options: { readonly error?: string } = {},
+    text: string,
   ): UpdateFollowUpTextMessage {
     return {
       command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
       stream,
-      kind,
+      kind: 'polished',
       text,
-      ...(options.error && { error: options.error }),
+    };
+  }
+
+  private createPolishErrorUpdate(
+    stream: StreamTabId,
+    error: string,
+  ): UpdateFollowUpTextMessage {
+    return {
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
+      stream,
+      kind: 'polishError',
+      text: null,
+      error,
     };
   }
 }

--- a/src/controllers/progressView/ProgressFollowUpPolishController.ts
+++ b/src/controllers/progressView/ProgressFollowUpPolishController.ts
@@ -73,7 +73,12 @@ export class ProgressFollowUpPolishController {
       if (result.success) {
         return {
           kind: 'updated',
-          update: this.createPolishedUpdate(input.stream, result.text),
+          update: {
+            command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
+            stream: input.stream,
+            kind: 'polished',
+            text: result.text,
+          },
         };
       }
       if (!result.error) {
@@ -117,18 +122,6 @@ export class ProgressFollowUpPolishController {
     }
 
     return context;
-  }
-
-  private createPolishedUpdate(
-    stream: StreamTabId,
-    text: string,
-  ): UpdateFollowUpTextMessage {
-    return {
-      command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
-      stream,
-      kind: 'polished',
-      text,
-    };
   }
 
   private createPolishErrorUpdate(

--- a/src/platform/interfaces.ts
+++ b/src/platform/interfaces.ts
@@ -262,15 +262,27 @@ export interface ToolEditApprovalRequest {
   readonly streamId?: string | null;
 }
 
-/** Platform-level contract for a tool-edit approval result. */
-export interface ToolEditApprovalResult {
-  readonly accepted: boolean;
-  readonly userMessage?: string;
-  readonly appliedContent?: string;
-  readonly userPatch?: string;
-  readonly lineChanges?: { readonly added: number; readonly removed: number };
-  readonly startLine?: number;
-}
+/**
+ * Platform-level contract for a tool-edit approval result. `appliedContent`
+ * is required on acceptance — every host implementation always supplies the
+ * content the user actually approved, so this is a type-level guarantee
+ * rather than a convention callers must null-check.
+ */
+export type ToolEditApprovalResult =
+  | {
+      readonly accepted: true;
+      readonly appliedContent: string;
+      readonly userPatch?: string;
+      readonly lineChanges?: {
+        readonly added: number;
+        readonly removed: number;
+      };
+      readonly startLine?: number;
+    }
+  | {
+      readonly accepted: false;
+      readonly userMessage?: string;
+    };
 
 // ---------------------------------------------------------------------------
 // Tool notifications

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -12,7 +12,10 @@ import {
 } from '@shared/utils/dispatcher';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
-import { SwitchViewMessageSchema } from '../commonViewMessages';
+import {
+  SwitchViewMessageSchema,
+  WebviewReadyMessageSchema,
+} from '../commonViewMessages';
 import { commandOnly } from '../messageFactories';
 import {
   ExternalInquiryThreadIdSchema,
@@ -278,7 +281,7 @@ const GettingStartedActionMessageSchema = z.object({
 export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
   'command',
   [
-    commandOnly(PROGRESS_VIEW_COMMANDS.WEBVIEW_READY),
+    WebviewReadyMessageSchema,
     SwitchViewMessageSchema,
     ThemeSetMessageSchema,
     DebugModeSetMessageSchema,

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -240,19 +240,31 @@ const UpdateBypassMessageSchema = StreamScopedBaseSchema.extend({
   bypassActive: z.boolean(),
 });
 
-const FollowUpTextKindSchema = z.enum([
-  'polished',
-  'polishError',
-  'transcribed',
+// `error` is only ever populated (and only ever read) on the `polishError`
+// branch — a discriminated union enforces that at the type level instead of
+// leaving it a flat optional field a `polished`/`transcribed` sender could
+// set by mistake.
+const UpdateFollowUpTextMessageSchema = z.discriminatedUnion('kind', [
+  z.object({
+    command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT),
+    stream: StreamTabIdSchema.nullish(),
+    kind: z.literal('polished'),
+    text: z.string().nullish(),
+  }),
+  z.object({
+    command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT),
+    stream: StreamTabIdSchema.nullish(),
+    kind: z.literal('polishError'),
+    text: z.string().nullish(),
+    error: z.string().optional(),
+  }),
+  z.object({
+    command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT),
+    stream: StreamTabIdSchema.nullish(),
+    kind: z.literal('transcribed'),
+    text: z.string().nullish(),
+  }),
 ]);
-
-const UpdateFollowUpTextMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT),
-  stream: StreamTabIdSchema.nullish(),
-  kind: FollowUpTextKindSchema,
-  text: z.string().nullish(),
-  error: z.string().optional(),
-});
 
 const RecordingStatusSchema = z.enum(['started', 'stopped', 'error']);
 

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -151,7 +151,10 @@ describe('accept_run_files progress events', () => {
     stubWorkspaceFiles(false, '');
     vi.spyOn(AbsoluteFS, 'read').mockResolvedValue('accepted content');
 
-    testApprovalHandler = async () => ({ accepted: true });
+    testApprovalHandler = async (request) => ({
+      accepted: true,
+      appliedContent: request.proposedContent,
+    });
 
     const result = await runAccept(
       tool,
@@ -181,7 +184,10 @@ describe('accept_run_files progress events', () => {
     });
     const write = stubWorkspaceFiles(false, '');
     vi.spyOn(AbsoluteFS, 'read').mockResolvedValue('accepted content');
-    testApprovalHandler = async () => ({ accepted: true });
+    testApprovalHandler = async (request) => ({
+      accepted: true,
+      appliedContent: request.proposedContent,
+    });
 
     const result = await tool.call({
       execution_id: executionId,
@@ -211,7 +217,7 @@ describe('accept_run_files progress events', () => {
     testApprovalHandler = async (request) => {
       approvalOriginal = request.originalContent;
       approvalProposed = request.proposedContent;
-      return { accepted: true };
+      return { accepted: true, appliedContent: request.proposedContent };
     };
 
     const result = await runAccept(tool, [
@@ -237,9 +243,9 @@ describe('accept_run_files progress events', () => {
     const write = stubWorkspaceFiles(true, 'same content');
     vi.spyOn(AbsoluteFS, 'isFile').mockResolvedValue(false);
     vi.spyOn(AbsoluteFS, 'read').mockResolvedValue('same content');
-    testApprovalHandler = async () => {
+    testApprovalHandler = async (request) => {
       approvals++;
-      return { accepted: true };
+      return { accepted: true, appliedContent: request.proposedContent };
     };
 
     const result = await runAccept(tool, [
@@ -264,9 +270,9 @@ describe('accept_run_files progress events', () => {
         FileType.SymbolicLink | FileType.File,
     });
     const write = stubWorkspaceFiles(true, '');
-    testApprovalHandler = async () => {
+    testApprovalHandler = async (request) => {
       approvals++;
-      return { accepted: true };
+      return { accepted: true, appliedContent: request.proposedContent };
     };
 
     const result = await runAccept(tool, [

--- a/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
+++ b/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
@@ -116,6 +116,8 @@ describe('Concurrent session tool edit approval handlers', () => {
     assert.strictEqual(seenByB.length, 1);
     assert.strictEqual(seenByB[0]?.path, 'b.tex');
 
+    assert.ok(resultA.accepted);
+    assert.ok(resultB.accepted);
     assert.strictEqual(resultA.appliedContent, 'from-a');
     assert.strictEqual(resultB.appliedContent, 'from-b');
   });

--- a/src/test-kernel/tools/TextEditorToolHistoryCap.vitest.ts
+++ b/src/test-kernel/tools/TextEditorToolHistoryCap.vitest.ts
@@ -30,7 +30,10 @@ async function installPlatform(
   await installFakePlatform({ workspacePath: '/workspace', files });
   detachHostInteractions();
   detachHostInteractions = defaultSession().useHostInteractions({
-    requestToolEditApproval: async () => ({ accepted: true }),
+    requestToolEditApproval: async (request) => ({
+      accepted: true,
+      appliedContent: request.proposedContent,
+    }),
     cancel: () => undefined,
   });
 }

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -86,7 +86,7 @@ describe('Tool edit approval gating', () => {
 
     testApprovalHandler = async (request) => {
       capturedRequest = request;
-      return { accepted: true };
+      return { accepted: true, appliedContent: request.proposedContent };
     };
 
     const result = await tool.call({ path: 'doc.txt', content: 'new content' });
@@ -149,9 +149,9 @@ describe('Tool edit approval gating', () => {
 
     const write = stubWorkspaceFile({ exists: false, content: '' });
 
-    testApprovalHandler = async () => {
+    testApprovalHandler = async (request) => {
       handlerCalled = true;
-      return { accepted: true };
+      return { accepted: true, appliedContent: request.proposedContent };
     };
 
     const result = await tool.call({ path: 'doc.txt', content: 'new content' });
@@ -167,9 +167,9 @@ describe('Tool edit approval gating', () => {
 
     const write = stubWorkspaceFile({ exists: false, content: '' });
 
-    testApprovalHandler = async () => {
+    testApprovalHandler = async (request) => {
       handlerCalled = true;
-      return { accepted: true };
+      return { accepted: true, appliedContent: request.proposedContent };
     };
 
     setToolEditApprovalSessionBypass(TEST_STREAM_ID, true, { silent: true });
@@ -219,7 +219,7 @@ describe('Tool edit approval gating', () => {
 
     assert.strictEqual(handlerCalls, 1);
     setToolEditApprovalSessionBypass(TEST_STREAM_ID, true, { silent: true });
-    firstApproval.resolve({ accepted: true });
+    firstApproval.resolve({ accepted: true, appliedContent: 'first.txt' });
 
     const results = await Promise.all([firstRequest, secondRequest]);
     assert.deepStrictEqual(

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -792,7 +792,13 @@ describe('StreamLogStore load', () => {
     expect(store.get('alpha')?.size).toBe(2);
   });
 
-  it('salvages valid fields from partially corrupt summaries', async () => {
+  it('rebuilds from the authoritative log when a summary field has the wrong type', async () => {
+    // `hasRunningGroup: 'bad'` is exactly the case a per-field `.catch()`
+    // would silently coerce to `undefined` (not running) instead of failing
+    // the whole parse — masking a crash-recovery flag that should have
+    // triggered the orphan-recovery sweep. The summary schema has no
+    // per-field `.catch()`, so a malformed field invalidates the whole
+    // cached summary and falls back to the log, like malformed JSON does.
     const storage = mockStorage({
       logs: {
         alpha: [logEntry('alpha', 1, 200), logEntry('alpha', 2, 250)],
@@ -808,10 +814,13 @@ describe('StreamLogStore load', () => {
 
     const store = await StreamLogStore.open();
 
-    expect(storage.fullLogReads()).toBe(0);
+    expect(storage.fullLogReads()).toBe(1);
     expect(store.keys()).toEqual(['alpha']);
     expect(store.getFirstTimestamp('alpha')).toBe(200);
-    expect(store.getLastTimestamp('alpha')).toBeUndefined();
+    expect(store.getLastTimestamp('alpha')).toBe(250);
+    expect(writtenSummary(storage.writes, 'alpha')).toEqual(
+      settledSummary(200, 250),
+    );
   });
 
   it('rebuilds malformed summary JSON from the authoritative stream log', async () => {

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -222,7 +222,7 @@ Parameters map directly to subagent-result delivery attributes:
         continue;
       }
 
-      const finalContent = getApprovedContent(approval, entry.proposedContent);
+      const finalContent = getApprovedContent(approval);
       await writeApprovedContent(
         entry.original,
         entry.originalContent,

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -202,8 +202,13 @@ export async function requestToolEditApproval(
   const streamId = preparedRequest.streamId ?? undefined;
   const isStreamBypassed =
     streamId && session.approvals.toolEdit.bypass.isBypassed(streamId);
+  const acceptProposedAsIs = (): ToolEditApprovalResult =>
+    finalizeApprovalResult(
+      { accepted: true, appliedContent: preparedRequest.proposedContent },
+      preparedRequest,
+    );
   if (!approvalsEnabled || isStreamBypassed) {
-    return finalizeApprovalResult({ accepted: true }, preparedRequest);
+    return acceptProposedAsIs();
   }
 
   return session.approvals.toolEdit.enqueue(streamId ?? undefined, {
@@ -217,7 +222,7 @@ export async function requestToolEditApproval(
       }
       return finalizeApprovalResult(await hostInteraction, preparedRequest);
     },
-    bypassed: () => finalizeApprovalResult({ accepted: true }, preparedRequest),
+    bypassed: acceptProposedAsIs,
   });
 }
 
@@ -229,7 +234,7 @@ function finalizeApprovalResult(
     return result;
   }
 
-  const appliedContent = result.appliedContent ?? request.proposedContent;
+  const { appliedContent } = result;
   const userPatch =
     result.userPatch ??
     computeUserPatch(request.proposedContent, appliedContent);
@@ -249,11 +254,16 @@ function finalizeApprovalResult(
   };
 }
 
+/** The `accepted: true` branch of {@link ToolEditApprovalResult}. */
+export type AcceptedToolEditApprovalResult = Extract<
+  ToolEditApprovalResult,
+  { accepted: true }
+>;
+
 export function getApprovedContent(
-  approval: ToolEditApprovalResult,
-  fallback: string,
+  approval: AcceptedToolEditApprovalResult,
 ): string {
-  return approval.appliedContent ?? fallback;
+  return approval.appliedContent;
 }
 
 function formatUnifiedApprovalUserDiff(
@@ -355,7 +365,7 @@ export function buildApprovalRejectedResult(
 }
 
 interface WrittenApprovedEdit extends WriteApprovedContentResult {
-  approval: ToolEditApprovalResult;
+  approval: AcceptedToolEditApprovalResult;
 }
 
 /**
@@ -402,7 +412,7 @@ export async function requestAndWriteApprovedEdit(request: {
   const written = await writeApprovedContent(
     path,
     originalContent,
-    getApprovedContent(approval, proposedContent),
+    getApprovedContent(approval),
   );
   return { approval, ...written };
 }

--- a/src/tools/fileEditFlow.ts
+++ b/src/tools/fileEditFlow.ts
@@ -12,7 +12,7 @@ import { countOccurrences } from '@tools/utils';
 import {
   appendApprovalDiffNote,
   requestAndWriteApprovedEdit,
-  type ToolEditApprovalResult,
+  type AcceptedToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS } from '@utils/files';
 
@@ -197,7 +197,7 @@ export function replaceLiteralMatches({
 }
 
 interface AppliedFileEdit {
-  approval: ToolEditApprovalResult;
+  approval: AcceptedToolEditApprovalResult;
   appliedContent: string;
   baseContent: string;
 }

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -50,13 +50,19 @@ function createSummaryKv(): KVStore {
 
 type StreamLogListener = (streamId: StreamTabId) => void;
 
+// No per-field `.catch()`: this schema covers the crash-recovery flags
+// (`hasRunningGroup`, `hasRunningStreamingText`, `hasNonterminalWorkflowTask`)
+// that `hasSomethingRunning()` gates orphan recovery on. A `.catch()` here
+// would silently turn a malformed field into `undefined` (recovery skipped)
+// instead of failing the whole `safeParse`, which routes through the
+// existing "ignore cache, rebuild from stream log" fallback in `readSummary`.
 const StreamLogSummarySchema = z.object({
-  firstTimestamp: z.number().finite().optional().catch(undefined),
-  lastTimestamp: z.number().finite().optional().catch(undefined),
-  hasRunningGroup: z.boolean().optional().catch(undefined),
-  hasRunningStreamingText: z.boolean().optional().catch(undefined),
+  firstTimestamp: z.number().finite().optional(),
+  lastTimestamp: z.number().finite().optional(),
+  hasRunningGroup: z.boolean().optional(),
+  hasRunningStreamingText: z.boolean().optional(),
   // Legacy persisted key retained for existing summary sidecars.
-  hasNonterminalWorkflowTask: z.boolean().optional().catch(undefined),
+  hasNonterminalWorkflowTask: z.boolean().optional(),
 });
 type StreamLogSummary = z.infer<typeof StreamLogSummarySchema>;
 
@@ -148,16 +154,34 @@ interface StreamState {
   writer?: StreamWriterOwnership;
 }
 
-function summaryOf(logInstance: StreamLog): StreamLogSummary {
+/**
+ * Shared projection into {@link StreamLogSummary}, fed either by a resident
+ * `StreamLog`'s getters (`summaryOf`) or by a raw entries scan
+ * (`summarizeEntries`). Keeping the field list here means a new derived flag
+ * is added once instead of in two hand-synced call sites.
+ */
+interface SummarySource {
+  readonly firstTimestamp: number | undefined;
+  readonly lastTimestamp: number | undefined;
+  readonly hasRunningGroup: boolean;
+  readonly hasRunningStreamingText: boolean;
+  readonly hasNonterminalWorkflowCall: boolean;
+}
+
+function toSummary(source: SummarySource): StreamLogSummary {
   return {
-    firstTimestamp: logInstance.firstTimestamp,
-    lastTimestamp: logInstance.lastTimestamp,
-    hasRunningGroup: logInstance.hasRunningGroup,
-    hasRunningStreamingText: logInstance.hasRunningStreamingText,
-    ...(logInstance.hasNonterminalWorkflowCall
+    firstTimestamp: source.firstTimestamp,
+    lastTimestamp: source.lastTimestamp,
+    hasRunningGroup: source.hasRunningGroup,
+    hasRunningStreamingText: source.hasRunningStreamingText,
+    ...(source.hasNonterminalWorkflowCall
       ? { hasNonterminalWorkflowTask: true }
       : {}),
   };
+}
+
+function summaryOf(logInstance: StreamLog): StreamLogSummary {
+  return toSummary(logInstance);
 }
 
 /**
@@ -1261,15 +1285,15 @@ export class StreamLogStore {
   private summarizeEntries(
     entries: readonly StreamLogEntry[],
   ): StreamLogSummary {
-    return {
+    return toSummary({
       firstTimestamp: entries[0]?.timestamp,
       lastTimestamp: entries.at(-1)?.timestamp,
       hasRunningGroup: entries.some(isRunningGroupEntry),
       hasRunningStreamingText: entries.some(isRunningStreamingTextEntry),
-      ...(entries.some((entry) => nonterminalWorkflowCall(entry) !== undefined)
-        ? { hasNonterminalWorkflowTask: true }
-        : {}),
-    };
+      hasNonterminalWorkflowCall: entries.some(
+        (entry) => nonterminalWorkflowCall(entry) !== undefined,
+      ),
+    });
   }
 
   private parsePersistedSummary(value: unknown): StreamLogSummary | undefined {


### PR DESCRIPTION
## Summary

Follow-up to a scheduled data-structure-complexity audit. Fixes the audit's High-severity finding and the contained Medium findings; two Mediums were investigated and deliberately left unapplied (see below).

- **`StreamLogStore` (High)**: `StreamLogSummarySchema` had `.catch(undefined)` on every field, including the crash-recovery flags (`hasRunningGroup`, `hasRunningStreamingText`, `hasNonterminalWorkflowTask`). A malformed field silently became `undefined` (treated as "not running"), which could skip the orphan-recovery sweep for a stream that actually needed it — exactly the "corruption → silent wrong default" pattern this repo's own review checklist calls a defect. Removed the per-field `.catch()` so a malformed field now fails the whole parse and falls back to the existing "rebuild from the authoritative log" path. Also unified `summaryOf()`/`summarizeEntries()` (previously two independently hand-written projections into the same summary shape) through one `toSummary()` helper.
- **`ToolEditApprovalResult` (Medium)**: was a flat object with 6 fields correlated by `accepted` (content fields only meaningful when `true`), forcing a runtime `appliedContent == null` throw and `??`-defaults at every consumer. Now a discriminated union on `accepted`, so `appliedContent` is a compile-time guarantee on acceptance.
- **`UpdateFollowUpTextMessageSchema` (Medium)**: `kind`/`error` were flat, unrelated fields — `error` was populated by the sender only on `polishError` but the frontend handler never read it, an invariant nothing enforced. Now a discriminated union on `kind`.
- **Desktop `WEBVIEW_READY` (Medium)**: `desktopProgressIpc.ts` validated the message via `ProgressViewInboundMessageSchema` but then read `message.view` off the raw, pre-validation object, because that schema's `WEBVIEW_READY` variant was `commandOnly(...)` (no `view` field) and Zod strips unknown keys on parse. Swapped in the already-existing, properly-typed `WebviewReadyMessageSchema` (used by the settings-view IPC path) so `result.data.view` is validated and typed.

### Investigated, not applied

- **`StreamLogEntry.data: unknown` classification duplicated across ~21 call sites** (the audit's other High finding) — left out of scope; it spans the CLI TUI, extension webview, and transcript recorder, and deserves a dedicated, carefully-tested PR rather than a rider on this cleanup.
- **`tool.end` event `result` typing** — the audit suggested typing it as `Partial<ToolUseLog>`, but `ToolUseLog` is a TeXRA/progress-view-specific shape, and `src/agent/trace/events.ts`/`TraceEmitter.ts` are explicitly documented as "agent-general, no TeXRA-specific sugar." Applying the suggested fix would have violated that boundary, so left as `unknown` (a genuine, already-documented escape hatch).
- **`FormProgress` "discriminated union on `status`"** — on inspection, `message`/`copyableMessage`/`archivedCopyableMessage`/`archiveCopyable` are genuinely independent of `status` in actual usage (`registerBuiltins.tsx`): the record is incrementally mutated via `{...current, field}` as an async action progresses, not reconstructed as one of several correlated variants. A discriminated union here would have broken that update pattern for no type-safety gain.

## Issue acceptance gates

Ad hoc fix from a scheduled audit, not tracked against a filed issue. Acceptance gate: each fix above compiles, is covered by (updated or existing) tests, and preserves current behavior except where the behavior itself was the bug (`StreamLogStore` corruption masking).

## Single source of truth

- `StreamLogStore.toSummary()` is now the one place a `StreamLogSummary` is projected from either a live `StreamLog` or a raw entries scan.
- `WebviewReadyMessageSchema` (`commonViewMessages.ts`) is now the one schema for the `WEBVIEW_READY` message shape reused across progress-view and settings-view IPC, instead of the progress-view path re-deriving `view` from the unvalidated raw message.

## Duplication and abstraction budget

Removed: the hand-duplicated `summaryOf`/`summarizeEntries` object-literal construction (now both go through `toSummary`); the `result.accepted && result.appliedContent == null` runtime guard and the `??`-default fallbacks in `toolEditApproval.ts` (now compile-time guaranteed by the discriminated union). No new abstractions beyond the type-level discriminated unions and the one `toSummary` projection, all single-purpose and directly motivated by the audit findings.

## Net elements (R6)

15 files changed, 168 insertions(+), 94 deletions(-). No new files. New exported symbols: `AcceptedToolEditApprovalResult` (narrowed type alias, consumed by `fileEditFlow.ts`). No new classes/interfaces beyond the type narrowing already described.

## Consumer counts (R8)

n/a — no emit path or export was deleted/re-routed; `ToolEditApprovalResult`'s shape changed but its name/export site is unchanged, and every construction site across `src/`, `packages/cli/`, and tests was updated (grepped and fixed 13 call sites; see commit).

## Host impact

Extension: none functionally — `ToolEditApprovalController` (used by the VS Code webview host) behavior unchanged, only the redundant runtime check removed.

Desktop: `desktopProgressIpc.ts`'s `WEBVIEW_READY` routing now reads a validated `view` field instead of an unvalidated one; same runtime behavior for well-formed messages.

CLI: `toToolEditResult`/`subscribeApprovals.ts` already always supplied `appliedContent`; no behavior change, just now compile-time enforced.

## Scheduled refactoring

None. The `StreamLogEntry.data` 21-site duplication is flagged above as a candidate for a future dedicated PR but no follow-up issue was filed.

## Validation

- `npx tsc --noEmit` across the root workspace, `tsconfig.test-kernel.json`, `packages/extension`, `packages/cli`, `packages/desktop` (main/renderer/preload), and `packages/trace-viewer` — all clean.
- `corepack pnpm --filter @texra-ai/agent build` — clean.
- `npx vitest run` (full suite) — 8442 passed, 9 skipped (pre-existing), 0 failures. One test (`StreamLogStoreLoad.vitest.ts`) was rewritten because it was asserting the exact corruption-masking behavior this PR fixes.
- `npm run lint`, `npm run check:dead-code-ratchet`, `npx prettier --check` on all touched files — all clean.
- `npm run compile:fast` — builds successfully.


---
_Generated by [Claude Code](https://claude.ai/code/session_014PBqyD3eP5WsKvvgMpmFfD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `StreamLogStore` summary parsing change alters crash-recovery behavior (intentional fix); tool-edit and IPC changes are mostly type-level with behavior preserved for well-formed data.
> 
> **Overview**
> Follow-up to a data-structure audit: replaces **flat optional fields** with **discriminated unions** and fixes one **crash-recovery** bug in transcript summary caching.
> 
> **`StreamLogStore`**: Removes per-field `.catch(undefined)` on `StreamLogSummarySchema` so a malformed crash-recovery flag (e.g. `hasRunningGroup`) no longer silently reads as “not running” and skips orphan recovery; invalid summaries now fail parse and **rebuild from the authoritative log**. Adds shared `toSummary()` for live `StreamLog` vs entries scan.
> 
> **`ToolEditApprovalResult`**: Becomes a union on `accepted` with required `appliedContent` when accepted; drops runtime throws and `??` fallbacks in `toolEditApproval.ts` / `ToolEditApprovalController`. Bypass and disabled-approval paths always supply proposed content via `acceptProposedAsIs`.
> 
> **IPC/schemas**: Progress inbound uses `WebviewReadyMessageSchema` so desktop reads `result.data.view` after validation; `UPDATE_FOLLOW_UP_TEXT` is a union on `kind` so `error` only exists on `polishError`.
> 
> Tests updated for the new approval shape and for summary rebuild when summary fields have wrong types (replacing the old “salvage partial fields” expectation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5510fcc9e7f9efe6758ad39bdad7962499f6ed54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
