### PR TITLE
fix(transcript): evidence-gate archive sidecar merges

### DIFF
--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -863,6 +863,129 @@ describe('completedRunArchive facade', () => {
     });
   });
 
+  it('merges the transitive overlap component and reports disconnected candidates', async () => {
+    const executionId = '0888bd0888bd' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888bd0888bd' as StreamTabId;
+    const transitive = 'bOrchestrator@middle#0888bd0888bd' as StreamTabId;
+    const bridge = 'zOrchestrator@new#0888bd0888bd' as StreamTabId;
+    const disconnected = 'zzOrchestrator@other#0888bd0888bd' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    for (const streamId of [canonical, transitive, bridge, disconnected]) {
+      snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
+    }
+    await snapshots.flush();
+
+    const anchor = logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Anchor' });
+    const bridgeRow = logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
+      text: 'Bridge answer',
+    });
+    const finalRow = logRow(MESSAGE_TYPES.USER_MESSAGE, {
+      text: 'Transitive follow-up',
+    });
+    const logs = await StreamLogStore.open();
+    logs.append(canonical, anchor);
+    logs.append(bridge, anchor);
+    logs.append(bridge, bridgeRow);
+    logs.append(transitive, bridgeRow);
+    logs.append(transitive, finalRow);
+    logs.append(
+      disconnected,
+      logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Unrelated history' }),
+    );
+    await logs.flush();
+
+    const result = await readCompletedRunConversation(executionId);
+    expect(result).toEqual({
+      source: 'streamLog',
+      streamId: canonical,
+      streamIds: [canonical, bridge, transitive],
+      diagnostics: [{ kind: 'disconnectedStream', streamId: disconnected }],
+      conversation: [
+        { role: 'user', content: 'Anchor' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Bridge answer' }],
+        },
+        { role: 'user', content: 'Transitive follow-up' },
+      ],
+    });
+
+    const endpoint = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+    });
+    expect(endpoint.output).toContain(
+      `Archive diagnostic: disconnected candidate ${disconnected}`,
+    );
+    expect(endpoint.output).not.toContain('Unrelated history');
+  });
+
+  it('rejects conflicting copied identities instead of silently deduplicating them', async () => {
+    const executionId = '0888be0888be' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888be0888be' as StreamTabId;
+    const conflicting = 'bOrchestrator@new#0888be0888be' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(conflicting, runConfig('orchestrator'), executionId);
+    await snapshots.flush();
+
+    const anchor = logRow(MESSAGE_TYPES.USER_MESSAGE, {
+      text: 'Canonical prompt',
+    });
+    const logs = await StreamLogStore.open();
+    logs.append(canonical, anchor);
+    logs.append(conflicting, { ...anchor, text: 'Conflicting prompt' });
+    logs.append(
+      conflicting,
+      logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Unsafe answer' }),
+    );
+    await logs.flush();
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'streamLog',
+      streamId: canonical,
+      diagnostics: [
+        {
+          kind: 'conflictingRow',
+          streamId: conflicting,
+          rowId: anchor.id,
+        },
+      ],
+      conversation: [{ role: 'user', content: 'Canonical prompt' }],
+    });
+  });
+
+  it('rejects a candidate whose copied-row order would form a cycle', async () => {
+    const executionId = '0888bf0888bf' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888bf0888bf' as StreamTabId;
+    const cyclic = 'bOrchestrator@new#0888bf0888bf' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(cyclic, runConfig('orchestrator'), executionId);
+    await snapshots.flush();
+
+    const first = logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'First' });
+    const second = logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Second' });
+    const logs = await StreamLogStore.open();
+    logs.append(canonical, first);
+    logs.append(canonical, second);
+    logs.append(cyclic, second);
+    logs.append(cyclic, first);
+    await logs.flush();
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'streamLog',
+      streamId: canonical,
+      diagnostics: [{ kind: 'orderingCycle', streamId: cyclic }],
+      conversation: [
+        { role: 'user', content: 'First' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Second' }],
+        },
+      ],
+    });
+  });
+
   it('never substitutes child conversation rows for empty confirmed roots', async () => {
     const executionId = '0999cc0999cc' as ExecutionId;
     const root = 'orchestrator@model#0999cc0999cc' as StreamTabId;

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -863,7 +863,7 @@ describe('completedRunArchive facade', () => {
     });
   });
 
-  it('merges the transitive overlap component and reports disconnected candidates', async () => {
+  it('merges a transitive continuation and reports disconnected candidates', async () => {
     const executionId = '0888bd0888bd' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888bd0888bd' as StreamTabId;
     const transitive = 'bOrchestrator@middle#0888bd0888bd' as StreamTabId;
@@ -983,6 +983,106 @@ describe('completedRunArchive facade', () => {
           content: [{ type: 'text', text: 'Second' }],
         },
       ],
+    });
+  });
+
+  it('rejects a sibling continuation that forks after a copied row', async () => {
+    const executionId = '0888c00888c0' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888c00888c0' as StreamTabId;
+    const continued = 'bOrchestrator@new#0888c00888c0' as StreamTabId;
+    const forked = 'cOrchestrator@fork#0888c00888c0' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    for (const streamId of [canonical, continued, forked]) {
+      snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
+    }
+    await snapshots.flush();
+
+    const anchor = logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Anchor' });
+    const logs = await StreamLogStore.open();
+    logs.append(canonical, anchor);
+    logs.append(continued, anchor);
+    logs.append(
+      continued,
+      logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Chosen continuation' }),
+    );
+    logs.append(forked, anchor);
+    logs.append(
+      forked,
+      logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Forked continuation' }),
+    );
+    await logs.flush();
+
+    const result = await readCompletedRunConversation(executionId);
+    expect(result).toEqual({
+      source: 'streamLog',
+      streamId: canonical,
+      streamIds: [canonical, continued],
+      diagnostics: [{ kind: 'branchingHistory', streamId: forked }],
+      conversation: [
+        { role: 'user', content: 'Anchor' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Chosen continuation' }],
+        },
+      ],
+    });
+  });
+
+  it('reports a cycle in the selected canonical stream', async () => {
+    const executionId = '0888c10888c1' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888c10888c1' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
+    await snapshots.flush();
+
+    const first = logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'First' });
+    const second = logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Second' });
+    const logs = await StreamLogStore.open();
+    logs.append(canonical, first);
+    logs.append(canonical, second);
+    logs.append(canonical, first);
+    await logs.flush();
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'none',
+      streamId: canonical,
+      diagnostics: [{ kind: 'orderingCycle', streamId: canonical }],
+      conversation: null,
+    });
+  });
+
+  it('retains selected stream context when diagnostics accompany legacy fallback', async () => {
+    const executionId = '0888c20888c2' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888c20888c2' as StreamTabId;
+    const disconnected = 'bOrchestrator@other#0888c20888c2' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(
+      disconnected,
+      runConfig('orchestrator'),
+      executionId,
+    );
+    await snapshots.flush();
+
+    const logs = await StreamLogStore.open();
+    logs.append(
+      canonical,
+      logRow(MESSAGE_TYPES.PROGRESS_STATUS, { text: 'No conversation' }),
+    );
+    logs.append(
+      disconnected,
+      logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Unrelated prompt' }),
+    );
+    await logs.flush();
+    await getExecutionStore(executionId).write('conversation', [
+      { role: 'user', content: 'Legacy prompt' },
+    ]);
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'legacyKV',
+      streamId: canonical,
+      diagnostics: [{ kind: 'disconnectedStream', streamId: disconnected }],
+      conversation: [{ role: 'user', content: 'Legacy prompt' }],
     });
   });
 

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -1016,15 +1016,11 @@ describe('completedRunArchive facade', () => {
     expect(result).toEqual({
       source: 'streamLog',
       streamId: canonical,
-      streamIds: [canonical, continued],
-      diagnostics: [{ kind: 'branchingHistory', streamId: forked }],
-      conversation: [
-        { role: 'user', content: 'Anchor' },
-        {
-          role: 'assistant',
-          content: [{ type: 'text', text: 'Chosen continuation' }],
-        },
+      diagnostics: [
+        { kind: 'branchingHistory', streamId: continued },
+        { kind: 'branchingHistory', streamId: forked },
       ],
+      conversation: [{ role: 'user', content: 'Anchor' }],
     });
   });
 

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -89,7 +89,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
     expect(resolved).toEqual({
       streamId,
       source: 'streamDataMeta',
-      associatedRootStreamIds: [streamId],
+      mergeCandidateStreamIds: [streamId],
     });
   });
 
@@ -177,7 +177,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
     expect(resolved).toEqual({
       streamId,
       source: 'streamDataMeta',
-      associatedRootStreamIds: [streamId],
+      mergeCandidateStreamIds: [streamId],
     });
     await expect(
       getExecutionStore(executionId).readMeta(),
@@ -202,7 +202,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       streamId,
       source: 'streamDataMeta',
       fallbackStreamIds: [resumedStream],
-      associatedRootStreamIds: [streamId, resumedStream],
+      mergeCandidateStreamIds: [streamId, resumedStream],
     });
   });
 
@@ -227,7 +227,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       streamId: secondStream,
       source: 'streamDataMeta',
       fallbackStreamIds: [firstStream],
-      associatedRootStreamIds: [firstStream, secondStream],
+      mergeCandidateStreamIds: [firstStream, secondStream],
     });
   });
 
@@ -256,7 +256,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       streamId: logStream,
       source: 'streamDataMeta',
       fallbackStreamIds: [workPlanStream],
-      associatedRootStreamIds: [workPlanStream, logStream],
+      mergeCandidateStreamIds: [workPlanStream, logStream],
     });
     expect(
       (await getExecutionStore(executionId).readMeta())?.streamId,

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -69,21 +69,6 @@ import { findExistingRunStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
 import { splitContentLines } from '@utils/text/stringUtils';
 
-function formatArchiveDiagnostic(
-  diagnostic: CompletedRunArchiveDiagnostic,
-): string {
-  switch (diagnostic.kind) {
-    case 'disconnectedStream':
-      return `Archive diagnostic: disconnected candidate ${diagnostic.streamId}`;
-    case 'conflictingRow':
-      return `Archive diagnostic: conflicting row ${diagnostic.rowId} in ${diagnostic.streamId}`;
-    case 'orderingCycle':
-      return `Archive diagnostic: ordering cycle in ${diagnostic.streamId}`;
-    default:
-      return assertNever(diagnostic, 'Unhandled archive diagnostic');
-  }
-}
-
 // Local file imports
 import {
   formatListingLine,
@@ -117,6 +102,23 @@ import {
   type ExecutionSummaryOptions,
 } from './executions/summaryFormat';
 import { formatSizedEntryLines } from './executions/fileListingFormat';
+
+function formatArchiveDiagnostic(
+  diagnostic: CompletedRunArchiveDiagnostic,
+): string {
+  switch (diagnostic.kind) {
+    case 'disconnectedStream':
+      return `Archive diagnostic: disconnected candidate ${diagnostic.streamId}`;
+    case 'conflictingRow':
+      return `Archive diagnostic: conflicting row ${diagnostic.rowId} in ${diagnostic.streamId}`;
+    case 'orderingCycle':
+      return `Archive diagnostic: ordering cycle in ${diagnostic.streamId}`;
+    case 'branchingHistory':
+      return `Archive diagnostic: branching history in ${diagnostic.streamId}`;
+    default:
+      return assertNever(diagnostic, 'Unhandled archive diagnostic');
+  }
+}
 
 // ============================================================================
 // Resource path catalog

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -62,7 +62,7 @@ import {
   resolvePersistedStreamIdForExecution,
 } from '@transcript';
 import { AbsoluteFS, StorageFS } from '@utils/files';
-import { clamp, unique } from '@utils/core';
+import { assertNever, clamp, unique } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { isDirectory } from '@utils/files/fsEntryType';
 import { findExistingRunStoragePath } from '@utils/files/taskRunStorage';
@@ -79,6 +79,8 @@ function formatArchiveDiagnostic(
       return `Archive diagnostic: conflicting row ${diagnostic.rowId} in ${diagnostic.streamId}`;
     case 'orderingCycle':
       return `Archive diagnostic: ordering cycle in ${diagnostic.streamId}`;
+    default:
+      return assertNever(diagnostic, 'Unhandled archive diagnostic');
   }
 }
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -56,6 +56,7 @@ import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { requireRunStream, requireStreamId } from '@tools/contextHelpers';
 import { assertNoParentTraversal } from '@tools/pathResolution';
 import {
+  type CompletedRunArchiveDiagnostic,
   readCompletedRunConversation,
   readCompletedRunTodos,
   resolvePersistedStreamIdForExecution,
@@ -67,6 +68,19 @@ import { isDirectory } from '@utils/files/fsEntryType';
 import { findExistingRunStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
 import { splitContentLines } from '@utils/text/stringUtils';
+
+function formatArchiveDiagnostic(
+  diagnostic: CompletedRunArchiveDiagnostic,
+): string {
+  switch (diagnostic.kind) {
+    case 'disconnectedStream':
+      return `Archive diagnostic: disconnected candidate ${diagnostic.streamId}`;
+    case 'conflictingRow':
+      return `Archive diagnostic: conflicting row ${diagnostic.rowId} in ${diagnostic.streamId}`;
+    case 'orderingCycle':
+      return `Archive diagnostic: ordering cycle in ${diagnostic.streamId}`;
+  }
+}
 
 // Local file imports
 import {
@@ -857,7 +871,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     limit: number,
   ): Promise<ToolResult> {
     const store = getExecutionStore(executionId);
-    const { conversation, source, streamId, streamIds } =
+    const { conversation, source, streamId, streamIds, diagnostics } =
       await readCompletedRunConversation(executionId);
 
     if (!conversation) {
@@ -875,7 +889,8 @@ Delegated subagent and workflow results are delivered automatically as follow-up
           totalMessages: 0,
           metadata: [
             'Source: none',
-            'Stream: none',
+            `Stream: ${streamId ?? 'none'}`,
+            ...(diagnostics ?? []).map(formatArchiveDiagnostic),
             'Returned message interval: [0, 0)',
             'Next offset: none',
           ],
@@ -893,6 +908,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
         `Source: ${source}`,
         `Stream: ${streamId ?? 'none'}`,
         ...(streamIds ? [`Merged streams: ${streamIds.join(', ')}`] : []),
+        ...(diagnostics ?? []).map(formatArchiveDiagnostic),
         `Returned message interval: [${pageStart}, ${pageEnd})`,
         `Next offset: ${pageEnd < conversation.length ? pageEnd : 'none'}`,
       ],

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -573,10 +573,10 @@ async function mergeConnectedConversation(
     return streamId ? [{ streamId, entries }] : [];
   });
   while (pending.length > 0) {
-    const candidateIndex = pending.findIndex(({ entries }) =>
-      entries.some((entry) => admittedRows.has(entry.id)),
+    const overlappingIndexes = pending.flatMap(({ entries }, index) =>
+      entries.some((entry) => admittedRows.has(entry.id)) ? [index] : [],
     );
-    if (candidateIndex === -1) {
+    if (overlappingIndexes.length === 0) {
       diagnostics.push(
         ...pending.map(({ streamId }) => ({
           kind: 'disconnectedStream' as const,
@@ -585,27 +585,85 @@ async function mergeConnectedConversation(
       );
       break;
     }
-    const candidate = pending.splice(candidateIndex, 1)[0];
+
+    const rejected = new Map<number, CompletedRunArchiveDiagnostic>();
+    for (const index of overlappingIndexes) {
+      const candidate = pending[index]!;
+      const conflict = candidate.entries.find(
+        (entry) =>
+          admittedRows.has(entry.id) &&
+          !entriesAgree(admittedRows.get(entry.id)!, entry),
+      );
+      if (conflict) {
+        rejected.set(index, {
+          kind: 'conflictingRow',
+          streamId: candidate.streamId,
+          rowId: conflict.id,
+        });
+      } else if (!isSingleContinuation(ordered, candidate.entries)) {
+        rejected.set(index, {
+          kind: 'branchingHistory',
+          streamId: candidate.streamId,
+        });
+      }
+    }
+
+    const compatibleIndexes = overlappingIndexes.filter(
+      (index) => !rejected.has(index),
+    );
+    for (const [position, leftIndex] of compatibleIndexes.entries()) {
+      const left = pending[leftIndex]!;
+      for (const rightIndex of compatibleIndexes.slice(position + 1)) {
+        const right = pending[rightIndex]!;
+        const conflictingRow = left.entries.find((leftEntry) => {
+          const rightEntry = right.entries.find(
+            (entry) => entry.id === leftEntry.id,
+          );
+          return rightEntry && !entriesAgree(leftEntry, rightEntry);
+        });
+        if (conflictingRow) {
+          rejected.set(leftIndex, {
+            kind: 'conflictingRow',
+            streamId: left.streamId,
+            rowId: conflictingRow.id,
+          });
+          rejected.set(rightIndex, {
+            kind: 'conflictingRow',
+            streamId: right.streamId,
+            rowId: conflictingRow.id,
+          });
+        } else if (!isSingleContinuation(left.entries, right.entries)) {
+          rejected.set(leftIndex, {
+            kind: 'branchingHistory',
+            streamId: left.streamId,
+          });
+          rejected.set(rightIndex, {
+            kind: 'branchingHistory',
+            streamId: right.streamId,
+          });
+        }
+      }
+    }
+
+    if (rejected.size > 0) {
+      for (const index of [...rejected.keys()].toSorted((a, b) => b - a)) {
+        pending.splice(index, 1);
+      }
+      diagnostics.push(
+        ...[...rejected.entries()]
+          .toSorted(([left], [right]) => left - right)
+          .map(([, diagnostic]) => diagnostic),
+      );
+      continue;
+    }
+
+    const candidateIndex = compatibleIndexes[0];
+    const candidate =
+      candidateIndex === undefined
+        ? undefined
+        : pending.splice(candidateIndex, 1)[0];
     if (!candidate) continue;
     const { entries: candidateEntries, streamId } = candidate;
-    const overlaps = candidateEntries.filter((entry) =>
-      admittedRows.has(entry.id),
-    );
-    const conflict = overlaps.find(
-      (entry) => !entriesAgree(admittedRows.get(entry.id)!, entry),
-    );
-    if (conflict) {
-      diagnostics.push({
-        kind: 'conflictingRow',
-        streamId,
-        rowId: conflict.id,
-      });
-      continue;
-    }
-    if (!isSingleContinuation(ordered, candidateEntries)) {
-      diagnostics.push({ kind: 'branchingHistory', streamId });
-      continue;
-    }
     const nextEntries = [...admittedEntries, candidateEntries];
     const nextOrder = orderMergedEntries(nextEntries);
     if (nextOrder === null) {

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -7,6 +7,8 @@
  * before the sidecars existed. Each fact keeps exactly one legacy read arm,
  * here, tracked for D3 retirement in the #6981 ledger.
  */
+import { isDeepStrictEqual } from 'node:util';
+
 import { getExecutionStore, type TodoEntry } from '@agent/storage';
 import { mediaAttachmentKindToContentBlock } from '@agent/export/attachmentMarkerVocabulary';
 import { formatToolResultAsText } from '@agent/modelHandlers/utils/toolAttachmentUtils';
@@ -102,9 +104,27 @@ export interface CompletedRunConversationReadResult {
   readonly conversation: unknown[] | null;
   readonly source: CompletedRunConversationSource;
   readonly streamId?: StreamTabId;
-  /** All positively associated root sidecars used for a merged archive. */
+  /** Sidecars admitted to the selected stream's overlap-connected component. */
   readonly streamIds?: readonly StreamTabId[];
+  /** Historical candidates rejected because their persisted rows do not
+   *  establish one consistent continuation of the selected stream. */
+  readonly diagnostics?: readonly CompletedRunArchiveDiagnostic[];
 }
+
+export type CompletedRunArchiveDiagnostic =
+  | {
+      readonly kind: 'disconnectedStream';
+      readonly streamId: StreamTabId;
+    }
+  | {
+      readonly kind: 'conflictingRow';
+      readonly streamId: StreamTabId;
+      readonly rowId: string;
+    }
+  | {
+      readonly kind: 'orderingCycle';
+      readonly streamId: StreamTabId;
+    };
 
 /**
  * Deliberate non-goal (#7508): image blocks inside a tool result are not
@@ -389,22 +409,29 @@ async function conversationFromStream(
   return log ? streamLogEntriesToConversation(log.toJSON()) : [];
 }
 
-/**
- * Merge execution-matched root sidecars as a partial order. Each stream adds
- * its authoritative adjacent-row constraints, while equal persisted row IDs
- * identify copied overlap. Recorded time orders rows only when the combined
- * stream sequences leave both choices admissible.
- */
-async function mergedRootConversation(
-  streamLogStore: StreamLogStore,
-  streamIds: readonly StreamTabId[],
-): Promise<unknown[]> {
-  const entriesByStream = await Promise.all(
-    streamIds.map(async (streamId) => {
-      await streamLogStore.ensureLoaded(streamId);
-      return streamLogStore.get(streamId)?.toJSON() ?? [];
-    }),
+interface ArchiveMergeResult {
+  readonly conversation: unknown[];
+  readonly streamIds: readonly StreamTabId[];
+  readonly diagnostics: readonly CompletedRunArchiveDiagnostic[];
+}
+
+function entriesAgree(left: StreamLogEntry, right: StreamLogEntry): boolean {
+  return (
+    left.id === right.id &&
+    left.type === right.type &&
+    left.level === right.level &&
+    left.timestamp === right.timestamp &&
+    left.groupId === right.groupId &&
+    left.messageType === right.messageType &&
+    left.text === right.text &&
+    left.verbose === right.verbose &&
+    isDeepStrictEqual(left.data, right.data)
   );
+}
+
+function orderMergedEntries(
+  entriesByStream: readonly (readonly StreamLogEntry[])[],
+): StreamLogEntry[] | null {
   const nodes = new Map<
     string,
     { readonly entry: StreamLogEntry; readonly streamIndex: number }
@@ -433,13 +460,9 @@ async function mergedRootConversation(
     [...remaining].filter((id) => (indegrees.get(id) ?? 0) === 0),
   );
   const ordered: StreamLogEntry[] = [];
-  while (remaining.size > 0) {
-    // Contradictory copied-row orders form a cycle. Such persisted data cannot
-    // satisfy every stream; choose deterministically so archive reads remain
-    // available while preserving every compatible constraint.
-    const candidates = ready.size > 0 ? ready : remaining;
+  while (ready.size > 0) {
     let nextId: string | undefined;
-    for (const id of candidates) {
+    for (const id of ready) {
       const candidate = nodes.get(id);
       const next = nextId ? nodes.get(nextId) : undefined;
       if (
@@ -466,7 +489,86 @@ async function mergedRootConversation(
       if (indegree === 0 && remaining.has(successorId)) ready.add(successorId);
     }
   }
-  return streamLogEntriesToConversation(ordered);
+  return remaining.size === 0 ? ordered : null;
+}
+
+/**
+ * Merge only the overlap-connected component rooted at the selected stream.
+ * A candidate must share an agreeing persisted row identity with the admitted
+ * component. Conflicting identities and contradictory ordering constraints
+ * reject that candidate instead of being presented as complete chronology.
+ */
+async function mergeConnectedConversation(
+  streamLogStore: StreamLogStore,
+  streamIds: readonly StreamTabId[],
+): Promise<ArchiveMergeResult> {
+  const entriesByStream = await Promise.all(
+    streamIds.map(async (streamId) => {
+      await streamLogStore.ensureLoaded(streamId);
+      return streamLogStore.get(streamId)?.toJSON() ?? [];
+    }),
+  );
+  const admittedIds: StreamTabId[] = [streamIds[0]];
+  const admittedEntries: (readonly StreamLogEntry[])[] = [
+    entriesByStream[0] ?? [],
+  ];
+  const admittedRows = new Map(
+    admittedEntries[0]?.map((entry) => [entry.id, entry]) ?? [],
+  );
+  const diagnostics: CompletedRunArchiveDiagnostic[] = [];
+  let ordered = orderMergedEntries(admittedEntries) ?? admittedEntries[0] ?? [];
+
+  const pending = entriesByStream.slice(1).flatMap((entries, index) => {
+    const streamId = streamIds[index + 1];
+    return streamId ? [{ streamId, entries }] : [];
+  });
+  while (pending.length > 0) {
+    const candidateIndex = pending.findIndex(({ entries }) =>
+      entries.some((entry) => admittedRows.has(entry.id)),
+    );
+    if (candidateIndex === -1) {
+      diagnostics.push(
+        ...pending.map(({ streamId }) => ({
+          kind: 'disconnectedStream' as const,
+          streamId,
+        })),
+      );
+      break;
+    }
+    const candidate = pending.splice(candidateIndex, 1)[0];
+    if (!candidate) continue;
+    const { entries: candidateEntries, streamId } = candidate;
+    const overlaps = candidateEntries.filter((entry) =>
+      admittedRows.has(entry.id),
+    );
+    const conflict = overlaps.find(
+      (entry) => !entriesAgree(admittedRows.get(entry.id)!, entry),
+    );
+    if (conflict) {
+      diagnostics.push({
+        kind: 'conflictingRow',
+        streamId,
+        rowId: conflict.id,
+      });
+      continue;
+    }
+    const nextEntries = [...admittedEntries, candidateEntries];
+    const nextOrder = orderMergedEntries(nextEntries);
+    if (nextOrder === null) {
+      diagnostics.push({ kind: 'orderingCycle', streamId });
+      continue;
+    }
+    admittedIds.push(streamId);
+    admittedEntries.push(candidateEntries);
+    ordered = nextOrder;
+    for (const entry of candidateEntries) admittedRows.set(entry.id, entry);
+  }
+
+  return {
+    conversation: streamLogEntriesToConversation(ordered),
+    streamIds: admittedIds,
+    diagnostics,
+  };
 }
 
 /**
@@ -484,28 +586,43 @@ async function readSidecarConversation(
   // release/reopen regression proves resumed turns append there. Only
   // pre-registration resolutions can represent historical split sidecars, so
   // keep the ordinary completed-read path constant-time.
-  const rootStreamIds = resolved.associatedRootStreamIds;
-  if (rootStreamIds !== undefined) {
+  const mergeCandidateStreamIds = resolved.mergeCandidateStreamIds;
+  if (mergeCandidateStreamIds !== undefined) {
     const orderedRoots = [
-      ...(rootStreamIds.includes(resolved.streamId) ? [resolved.streamId] : []),
-      ...rootStreamIds.filter((streamId) => streamId !== resolved.streamId),
+      ...(mergeCandidateStreamIds.includes(resolved.streamId)
+        ? [resolved.streamId]
+        : []),
+      ...mergeCandidateStreamIds.filter(
+        (streamId) => streamId !== resolved.streamId,
+      ),
     ];
-    const conversation = await mergedRootConversation(
+    const merged = await mergeConnectedConversation(
       streamLogStore,
       orderedRoots,
     );
-    if (conversation.length > 0) {
+    if (merged.conversation.length > 0) {
       return {
-        conversation,
+        conversation: merged.conversation,
         source: 'streamLog',
         streamId: orderedRoots[0],
-        ...(orderedRoots.length > 1 ? { streamIds: orderedRoots } : {}),
+        ...(merged.streamIds.length > 1 ? { streamIds: merged.streamIds } : {}),
+        ...(merged.diagnostics.length > 0
+          ? { diagnostics: merged.diagnostics }
+          : {}),
       };
     }
-    // Exact metadata established the canonical root set. An empty root
-    // conversation must fall back to the legacy execution projection, never
-    // to a child or suffix-only sidecar.
-    return null;
+    // An empty selected stream must fall back to the legacy execution
+    // projection, never to a disconnected or conflicting candidate. Preserve
+    // diagnostics so the caller does not mistake that exclusion for proof
+    // that no other historical sidecar exists.
+    return merged.diagnostics.length > 0
+      ? {
+          conversation: null,
+          source: 'none',
+          streamId: orderedRoots[0],
+          diagnostics: merged.diagnostics,
+        }
+      : null;
   }
 
   const primaryConversation = await conversationFromStream(
@@ -559,27 +676,24 @@ export async function readCompletedRunConversation(
     streamLogStore,
   });
 
-  // Legacy `conversation.json`; `null` when missing or empty.
-  const tryLegacy =
-    async (): Promise<CompletedRunConversationReadResult | null> => {
-      const conversation =
-        await getExecutionStore(executionId).readConversation();
-      return conversation ? { conversation, source: 'legacyKV' } : null;
-    };
-  const trySidecar =
-    async (): Promise<CompletedRunConversationReadResult | null> =>
-      resolved
-        ? readSidecarConversation(
-            executionId,
-            resolved,
-            snapshotStore,
-            streamLogStore,
-          )
-        : null;
+  const sidecar = resolved
+    ? await readSidecarConversation(
+        executionId,
+        resolved,
+        snapshotStore,
+        streamLogStore,
+      )
+    : null;
+  if (sidecar?.conversation) return sidecar;
 
-  for (const arm of [trySidecar, tryLegacy]) {
-    const result = await arm();
-    if (result) return result;
+  // Legacy `conversation.json`; `null` when missing or empty.
+  const legacy = await getExecutionStore(executionId).readConversation();
+  if (legacy) {
+    return {
+      conversation: legacy,
+      source: 'legacyKV',
+      ...(sidecar?.diagnostics ? { diagnostics: sidecar.diagnostics } : {}),
+    };
   }
-  return { conversation: null, source: 'none' };
+  return sidecar ?? { conversation: null, source: 'none' };
 }

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -104,7 +104,7 @@ export interface CompletedRunConversationReadResult {
   readonly conversation: unknown[] | null;
   readonly source: CompletedRunConversationSource;
   readonly streamId?: StreamTabId;
-  /** Sidecars admitted to the selected stream's overlap-connected component. */
+  /** Sidecars admitted to the selected stream's consistent linear history. */
   readonly streamIds?: readonly StreamTabId[];
   /** Historical candidates rejected because their persisted rows do not
    *  establish one consistent continuation of the selected stream. */
@@ -123,6 +123,10 @@ export type CompletedRunArchiveDiagnostic =
     }
   | {
       readonly kind: 'orderingCycle';
+      readonly streamId: StreamTabId;
+    }
+  | {
+      readonly kind: 'branchingHistory';
       readonly streamId: StreamTabId;
     };
 
@@ -429,6 +433,38 @@ function entriesAgree(left: StreamLogEntry, right: StreamLogEntry): boolean {
   );
 }
 
+/**
+ * Decide whether a candidate and the currently admitted chronology describe
+ * one linear history. Their common rows must occupy the same contiguous
+ * interval after alignment. Thus a suffix may continue into a prefix (in
+ * either direction), and a contained historical prefix is harmless, while
+ * two continuations that fork after a copied row are rejected.
+ */
+function isSingleContinuation(
+  admitted: readonly StreamLogEntry[],
+  candidate: readonly StreamLogEntry[],
+): boolean {
+  const admittedIndexById = new Map(
+    admitted.map((entry, index) => [entry.id, index]),
+  );
+  const firstCandidateOverlap = candidate.findIndex((entry) =>
+    admittedIndexById.has(entry.id),
+  );
+  if (firstCandidateOverlap === -1) return false;
+  const firstAdmittedOverlap = admittedIndexById.get(
+    candidate[firstCandidateOverlap]!.id,
+  )!;
+  const offset = firstAdmittedOverlap - firstCandidateOverlap;
+  return candidate.every((entry, candidateIndex) => {
+    const admittedIndex = candidateIndex + offset;
+    return (
+      admittedIndex < 0 ||
+      admittedIndex >= admitted.length ||
+      admitted[admittedIndex]?.id === entry.id
+    );
+  });
+}
+
 function orderMergedEntries(
   entriesByStream: readonly (readonly StreamLogEntry[])[],
 ): StreamLogEntry[] | null {
@@ -493,10 +529,10 @@ function orderMergedEntries(
 }
 
 /**
- * Merge only the overlap-connected component rooted at the selected stream.
- * A candidate must share an agreeing persisted row identity with the admitted
- * component. Conflicting identities and contradictory ordering constraints
- * reject that candidate instead of being presented as complete chronology.
+ * Merge only the consistent linear history rooted at the selected stream. A
+ * candidate must align an agreeing contiguous interval with the admitted
+ * chronology. Disconnected, forked, conflicting, and cyclic candidates are
+ * rejected instead of being presented as one complete chronology.
  */
 async function mergeConnectedConversation(
   streamLogStore: StreamLogStore,
@@ -516,7 +552,21 @@ async function mergeConnectedConversation(
     admittedEntries[0]?.map((entry) => [entry.id, entry]) ?? [],
   );
   const diagnostics: CompletedRunArchiveDiagnostic[] = [];
-  let ordered = orderMergedEntries(admittedEntries) ?? admittedEntries[0] ?? [];
+  const canonicalOrder = orderMergedEntries(admittedEntries);
+  if (canonicalOrder === null) {
+    return {
+      conversation: [],
+      streamIds: admittedIds,
+      diagnostics: [
+        { kind: 'orderingCycle', streamId: streamIds[0] },
+        ...streamIds.slice(1).map((streamId) => ({
+          kind: 'disconnectedStream' as const,
+          streamId,
+        })),
+      ],
+    };
+  }
+  let ordered = canonicalOrder;
 
   const pending = entriesByStream.slice(1).flatMap((entries, index) => {
     const streamId = streamIds[index + 1];
@@ -550,6 +600,10 @@ async function mergeConnectedConversation(
         streamId,
         rowId: conflict.id,
       });
+      continue;
+    }
+    if (!isSingleContinuation(ordered, candidateEntries)) {
+      diagnostics.push({ kind: 'branchingHistory', streamId });
       continue;
     }
     const nextEntries = [...admittedEntries, candidateEntries];
@@ -692,6 +746,8 @@ export async function readCompletedRunConversation(
     return {
       conversation: legacy,
       source: 'legacyKV',
+      ...(sidecar?.streamId ? { streamId: sidecar.streamId } : {}),
+      ...(sidecar?.streamIds ? { streamIds: sidecar.streamIds } : {}),
       ...(sidecar?.diagnostics ? { diagnostics: sidecar.diagnostics } : {}),
     };
   }

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -19,8 +19,11 @@ export interface PersistedStreamIdResolution {
   readonly source: PersistedStreamIdResolutionSource;
   /** Other persisted candidates to try when a historical primary is empty. */
   readonly fallbackStreamIds?: readonly StreamTabId[];
-  /** Exact execution matches with no persisted parent, for archive merging. */
-  readonly associatedRootStreamIds?: readonly StreamTabId[];
+  /** Exact execution matches without an explicit persisted parent. These are
+   *  merge candidates, not proven roots: old/partial metadata may omit the
+   *  parent field. The archive reader admits only candidates connected to the
+   *  selected stream by agreeing copied-row identities. */
+  readonly mergeCandidateStreamIds?: readonly StreamTabId[];
 }
 
 export interface PersistedStreamIdResolverOptions {
@@ -42,8 +45,8 @@ interface ExecutionStreamScan {
   readonly persistedStreams: StreamTabId[];
   /** Persisted streams whose sidecar `meta.json` claims this execution. */
   readonly metaMatched: StreamTabId[];
-  /** Exact execution matches that are not recorded as child streams. */
-  readonly rootMetaMatched: StreamTabId[];
+  /** Exact execution matches without an explicit persisted parent. */
+  readonly unparentedMetaMatched: StreamTabId[];
 }
 
 /**
@@ -69,7 +72,7 @@ async function scanPersistedStreamsForExecution(
     metaMatched: scanned
       .filter((candidate) => candidate.association.executionId === executionId)
       .map((candidate) => candidate.streamId),
-    rootMetaMatched: scanned
+    unparentedMetaMatched: scanned
       .filter(
         (candidate) =>
           candidate.association.executionId === executionId &&
@@ -175,12 +178,12 @@ export async function resolvePersistedStreamIdForExecution(
   }
 
   const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
-  const { persistedStreams, metaMatched, rootMetaMatched } =
+  const { persistedStreams, metaMatched, unparentedMetaMatched } =
     await scanPersistedStreamsForExecution(executionId, snapshotStore);
 
   if (metaMatched.length > 0) {
     const primaryCandidates =
-      rootMetaMatched.length > 0 ? rootMetaMatched : metaMatched;
+      unparentedMetaMatched.length > 0 ? unparentedMetaMatched : metaMatched;
     const streamId = await pickBestLegacyMetaMatch(
       primaryCandidates,
       snapshotStore,
@@ -201,8 +204,8 @@ export async function resolvePersistedStreamIdForExecution(
       streamId,
       source: 'streamDataMeta',
       ...(fallbackStreamIds.length > 0 ? { fallbackStreamIds } : {}),
-      ...(rootMetaMatched.length > 0
-        ? { associatedRootStreamIds: rootMetaMatched }
+      ...(unparentedMetaMatched.length > 0
+        ? { mergeCandidateStreamIds: unparentedMetaMatched }
         : {}),
     };
   }

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -22,6 +22,7 @@ export { StreamSnapshotStore } from './StreamSnapshotStore';
 export { assembleTrace, type AssembleTraceResult } from './traceAssembler';
 export type { TraceDocument } from './traceDocumentSchema';
 export {
+  type CompletedRunArchiveDiagnostic,
   readCompletedRunConversation,
   readCompletedRunTodos,
   seedResumedConversationSidecar,


### PR DESCRIPTION
## Summary

Historical execution metadata can identify several sidecars with the same execution ID, but an absent optional parent field does not prove that every candidate belongs to one chronology. The archive reader previously merged all such candidates, silently kept the first payload for duplicate row IDs, and imposed a deterministic order on histories that could be contradictory or forked.

This change makes the merge evidential:

- the selected canonical sidecar roots the proposed chronology;
- another candidate is admitted only when agreeing copied-row identities align it with the current linear history;
- competing continuations are compared before admission, so filename order cannot select one branch;
- duplicate row IDs must agree in persisted content;
- disconnected, conflicting, cyclic, and branching candidates are excluded and reported by the conversation endpoint.

Current executions with a registration-time canonical stream retain their constant-time single-sidecar path. Explicitly recorded child streams remain excluded. Message and file pagination are unchanged.

Closes #9533.

## Design

`PersistedStreamIdResolution.mergeCandidateStreamIds` describes candidates only. `completedRunArchive.ts` is the single place that decides whether their persisted rows establish one consistent continuation. It retains the existing partial-order merge, but refuses to infer chronology from timestamps or stream-name ordering when histories fork.

No new storage layer or per-turn archive is introduced. A local discriminated union carries the four rejection diagnostics to `/executions/{id}/conversation`, including empty-sidecar and legacy-fallback cases.

## Host impact

Extension, desktop, and CLI history readers receive the same result for ordinary registered executions. Ambiguous historical archives now return only the supported linear history, together with diagnostics, instead of an unsupported combined chronology.

## Validation

- `npm run compile:fast`
- `npm run lint`
- `npm run typecheck`
- full Vitest suite before review amendments: 824 files passed, 1 skipped; 8,443 tests passed, 4 skipped
- focused archive and resolver suites after review amendments: 27 tests passed
- workspace and test-kernel type checks after review amendments