### PR TITLE
fix(storage): evidence-gate historical sidecar merges

### DIFF
--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -156,9 +156,8 @@ export async function runHistoryExport(
         writeTextStderr(
           `Execution ${id} has multiple associated transcript sidecars ` +
             `(${traceResult.candidateStreamIds.join(', ')}), but no canonical ` +
-            'trace timeline can be established. Run `texra history show ' +
-            id +
-            '` to see the merged conversation evidence.',
+            'trace timeline can be established, so HTML trace export was ' +
+            'not written.',
         );
         break;
       default:

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -152,6 +152,13 @@ export async function runHistoryExport(
             '` to see what is available.',
         );
         break;
+      case 'rootStream_missing':
+        writeTextStderr(
+          `Execution ${id} is represented only by delegated child transcript ` +
+            `sidecars (${traceResult.associatedChildStreamIds.join(', ')}); ` +
+            'no root transcript is available, so HTML trace export was not written.',
+        );
+        break;
       case 'streamId_ambiguous':
         writeTextStderr(
           `Execution ${id} has multiple associated transcript sidecars ` +

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -145,18 +145,9 @@ export async function runHistoryExport(
         break;
       case 'streamLogs_missing':
         writeTextStderr(
-          `Execution ${id} exists but has no stored transcript to export (it ` +
-            'may predate transcript persistence, or the run never produced ' +
-            'any output). Run `texra history show ' +
-            id +
-            '` to see what is available.',
-        );
-        break;
-      case 'rootStream_missing':
-        writeTextStderr(
-          `Execution ${id} is represented only by delegated child transcript ` +
-            `sidecars (${traceResult.associatedChildStreamIds.join(', ')}); ` +
-            'no root transcript is available, so HTML trace export was not written.',
+          `Execution ${id} exists but has no replayable execution-root transcript ` +
+            '(it may predate transcript persistence, the run may have produced ' +
+            'no output, or only proven child transcripts may remain).',
         );
         break;
       case 'streamId_ambiguous':

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -140,6 +140,13 @@ export async function runHistoryExport(
   if (traceResult.status !== 'ok') {
     if (traceResult.status === 'config_missing') {
       writeTextStderr(formatCliHistoryNotFoundText(id, context.cwd));
+    } else if (traceResult.status === 'streamId_ambiguous') {
+      writeTextStderr(
+        `Execution ${id} has several historical transcripts, but none is ` +
+          'proven canonical for trace export. Run `texra history show ' +
+          id +
+          '` to inspect the archived conversation and diagnostics.',
+      );
     } else {
       writeTextStderr(
         `Execution ${id} exists but has no stored transcript to export (it ` +

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -6,6 +6,7 @@ import { formatChatAsMarkdown } from '@agent/export/chatExportFormatter';
 import { type ExecutionId } from '@shared/schemas';
 import { formatCliHistoryDeletionSummary } from '@shared/copy/executionHistory';
 import { assembleTrace, injectStandaloneTrace } from '@transcript';
+import { assertNever } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';
 
 import { CliExitCode } from '../runtime/exitCodes';
@@ -138,23 +139,30 @@ export async function runHistoryExport(
 
   const traceResult = await assembleTrace(id);
   if (traceResult.status !== 'ok') {
-    if (traceResult.status === 'config_missing') {
-      writeTextStderr(formatCliHistoryNotFoundText(id, context.cwd));
-    } else if (traceResult.status === 'streamId_ambiguous') {
-      writeTextStderr(
-        `Execution ${id} has several historical transcripts, but none is ` +
-          'proven canonical for trace export. Run `texra history show ' +
-          id +
-          '` to inspect the archived conversation and diagnostics.',
-      );
-    } else {
-      writeTextStderr(
-        `Execution ${id} exists but has no stored transcript to export (it ` +
-          'may predate transcript persistence, or the run never produced ' +
-          'any output). Run `texra history show ' +
-          id +
-          '` to see what is available.',
-      );
+    switch (traceResult.status) {
+      case 'config_missing':
+        writeTextStderr(formatCliHistoryNotFoundText(id, context.cwd));
+        break;
+      case 'streamLogs_missing':
+        writeTextStderr(
+          `Execution ${id} exists but has no stored transcript to export (it ` +
+            'may predate transcript persistence, or the run never produced ' +
+            'any output). Run `texra history show ' +
+            id +
+            '` to see what is available.',
+        );
+        break;
+      case 'streamId_ambiguous':
+        writeTextStderr(
+          `Execution ${id} has multiple associated transcript sidecars ` +
+            `(${traceResult.candidateStreamIds.join(', ')}), but no canonical ` +
+            'trace timeline can be established. Run `texra history show ' +
+            id +
+            '` to see the merged conversation evidence.',
+        );
+        break;
+      default:
+        assertNever(traceResult, 'Unhandled trace assembly result');
     }
     return CliExitCode.Usage;
   }

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -261,7 +261,15 @@ export async function readCliHistoryExportInput(
   const { meta, config, conversation, exportInput } =
     await loadChatExportInput(id);
   if (exportInput) return { status: 'ok', exportInput };
-  if (!meta && !config && !conversation) return { status: 'not_found' };
+  if (!meta && !config && !conversation) {
+    const transcript = await readCompletedRunConversation(id);
+    const hasTranscriptEvidence =
+      transcript.streamId !== undefined ||
+      (transcript.streamIds?.length ?? 0) > 0 ||
+      (transcript.candidateStreamIds?.length ?? 0) > 0 ||
+      (transcript.associatedStreamIds?.length ?? 0) > 0;
+    if (!hasTranscriptEvidence) return { status: 'not_found' };
+  }
   return { status: 'incomplete' };
 }
 

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -21,7 +21,10 @@ import type { ChatExportInput } from '@agent/export/schemas';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import { ExecutionIdSchema, type ExecutionId } from '@shared/schemas';
 import { GoalStore } from '@tools/goal';
-import { readCompletedRunConversation } from '@transcript';
+import {
+  hasCompletedRunConversationEvidence,
+  readCompletedRunConversation,
+} from '@transcript';
 
 import { readCliToolUseResumeDataForListing } from './toolUseResumeData';
 import {
@@ -167,10 +170,7 @@ export async function readCliHistoryDetails(
   ]);
   const conversation = conversationResult.conversation;
   const hasTranscriptEvidence =
-    conversationResult.streamId !== undefined ||
-    (conversationResult.streamIds?.length ?? 0) > 0 ||
-    (conversationResult.candidateStreamIds?.length ?? 0) > 0 ||
-    (conversationResult.associatedStreamIds?.length ?? 0) > 0;
+    hasCompletedRunConversationEvidence(conversationResult);
   const resumeData =
     resumability.resumable && config
       ? await readCliToolUseResumeDataForListing(id, config)
@@ -258,17 +258,11 @@ export type CliHistoryExportInputResult =
 export async function readCliHistoryExportInput(
   id: ExecutionId,
 ): Promise<CliHistoryExportInputResult> {
-  const { meta, config, conversation, exportInput } =
+  const { meta, config, conversation, hasTranscriptEvidence, exportInput } =
     await loadChatExportInput(id);
   if (exportInput) return { status: 'ok', exportInput };
-  if (!meta && !config && !conversation) {
-    const transcript = await readCompletedRunConversation(id);
-    const hasTranscriptEvidence =
-      transcript.streamId !== undefined ||
-      (transcript.streamIds?.length ?? 0) > 0 ||
-      (transcript.candidateStreamIds?.length ?? 0) > 0 ||
-      (transcript.associatedStreamIds?.length ?? 0) > 0;
-    if (!hasTranscriptEvidence) return { status: 'not_found' };
+  if (!meta && !config && !conversation && !hasTranscriptEvidence) {
+    return { status: 'not_found' };
   }
   return { status: 'incomplete' };
 }

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -166,6 +166,11 @@ export async function readCliHistoryDetails(
     deriveResumability(id),
   ]);
   const conversation = conversationResult.conversation;
+  const hasTranscriptEvidence =
+    conversationResult.streamId !== undefined ||
+    (conversationResult.streamIds?.length ?? 0) > 0 ||
+    (conversationResult.candidateStreamIds?.length ?? 0) > 0 ||
+    (conversationResult.associatedStreamIds?.length ?? 0) > 0;
   const resumeData =
     resumability.resumable && config
       ? await readCliToolUseResumeDataForListing(id, config)
@@ -193,7 +198,8 @@ export async function readCliHistoryDetails(
     !config &&
     !conversationPreview &&
     !fullConversation &&
-    !resumeData
+    !resumeData &&
+    !hasTranscriptEvidence
   ) {
     return null;
   }

--- a/src/agent/export/loadChatExportInput.ts
+++ b/src/agent/export/loadChatExportInput.ts
@@ -28,7 +28,10 @@ import { getExecutionStore, type ExecutionMeta } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { ChatExportInput } from '@agent/export/schemas';
 import type { ExecutionId } from '@shared/schemas';
-import { readCompletedRunConversation } from '@transcript';
+import {
+  hasCompletedRunConversationEvidence,
+  readCompletedRunConversation,
+} from '@transcript';
 
 /**
  * Facts read from the execution store, plus the assembled
@@ -43,6 +46,8 @@ export interface ChatExportLoadResult {
   /** Normalized: `null` when absent *or* empty — an empty array never counts
    *  as "a conversation is present" (see module doc). */
   readonly conversation: readonly unknown[] | null;
+  /** Host-neutral storage evidence used to distinguish incomplete from absent. */
+  readonly hasTranscriptEvidence: boolean;
   readonly exportInput: ChatExportInput | null;
 }
 
@@ -77,15 +82,24 @@ export async function loadChatExportInput(
   const conversation = hasConversationMessages(conversationResult.conversation)
     ? conversationResult.conversation
     : null;
+  const hasTranscriptEvidence =
+    hasCompletedRunConversationEvidence(conversationResult);
 
   if (!config || !conversation) {
-    return { meta, config, conversation, exportInput: null };
+    return {
+      meta,
+      config,
+      conversation,
+      hasTranscriptEvidence,
+      exportInput: null,
+    };
   }
 
   return {
     meta,
     config,
     conversation,
+    hasTranscriptEvidence,
     exportInput: {
       timestamp: meta?.timestamp ?? new Date().toISOString(),
       description: meta?.description,

--- a/src/controllers/settingsView/HistoryActionOutcomes.ts
+++ b/src/controllers/settingsView/HistoryActionOutcomes.ts
@@ -58,6 +58,8 @@ export function htmlExportErrorMessage(
   switch (status) {
     case 'config_missing':
       return HISTORY_ITEM_NOT_FOUND_MESSAGE;
+    case 'rootStream_missing':
+      return 'No root transcript is available for trace export; this execution is represented only by delegated child streams.';
     case 'streamId_ambiguous':
       return 'Several historical transcripts match this execution, but none is proven canonical for trace export.';
     case 'streamLogs_missing':

--- a/src/controllers/settingsView/HistoryActionOutcomes.ts
+++ b/src/controllers/settingsView/HistoryActionOutcomes.ts
@@ -58,12 +58,10 @@ export function htmlExportErrorMessage(
   switch (status) {
     case 'config_missing':
       return HISTORY_ITEM_NOT_FOUND_MESSAGE;
-    case 'rootStream_missing':
-      return 'No root transcript is available for trace export; this execution is represented only by delegated child streams.';
     case 'streamId_ambiguous':
       return 'Several historical transcripts match this execution, but none is proven canonical for trace export.';
     case 'streamLogs_missing':
-      return 'No stored transcript available for this execution — it may predate transcript persistence.';
+      return 'No replayable execution-root transcript is available — it may predate transcript persistence or have only child transcripts.';
   }
 }
 

--- a/src/controllers/settingsView/HistoryActionOutcomes.ts
+++ b/src/controllers/settingsView/HistoryActionOutcomes.ts
@@ -58,6 +58,8 @@ export function htmlExportErrorMessage(
   switch (status) {
     case 'config_missing':
       return HISTORY_ITEM_NOT_FOUND_MESSAGE;
+    case 'streamId_ambiguous':
+      return 'Several historical transcripts match this execution, but none is proven canonical for trace export.';
     case 'streamLogs_missing':
       return 'No stored transcript available for this execution — it may predate transcript persistence.';
   }

--- a/src/test-kernel/agent/export/loadChatExportInput.vitest.ts
+++ b/src/test-kernel/agent/export/loadChatExportInput.vitest.ts
@@ -79,6 +79,7 @@ describe('loadChatExportInput (shared CLI/extension chat-export loader)', () => 
       { role: 'user', content: 'Polish the lemma.' },
       { role: 'assistant', content: 'Done.' },
     ]);
+    expect(result.hasTranscriptEvidence).toBe(true);
   });
 
   it('returns a null exportInput when nothing is stored at all', async () => {
@@ -88,6 +89,7 @@ describe('loadChatExportInput (shared CLI/extension chat-export loader)', () => 
       meta: null,
       config: null,
       conversation: null,
+      hasTranscriptEvidence: false,
       exportInput: null,
     });
   });

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -1409,6 +1409,28 @@ describe('CLI history runtime', () => {
         expect(stderr).not.toContain('texra history show');
       });
 
+      it('reports child-only transcript associations without calling them ambiguous', async () => {
+        mocks.assembleTrace.mockResolvedValue({
+          status: 'rootStream_missing',
+          associatedChildStreamIds: ['bash@tool#a1', 'codex@tool#a1'],
+        });
+
+        const exitCode = await runHistoryExport(
+          makeContext('/resources'),
+          'a1' as ExecutionId,
+          'html',
+          {},
+        );
+
+        expect(exitCode).toBe(CliExitCode.Usage);
+        expect(stdout).toBe('');
+        expect(stderr).toContain(
+          'represented only by delegated child transcript sidecars (bash@tool#a1, codex@tool#a1)',
+        );
+        expect(stderr).toContain('HTML trace export was not written');
+        expect(stderr).not.toContain('multiple associated transcript');
+      });
+
       it('returns a non-zero exit code (but still writes the trace JSON) when the bundled assets are missing', async () => {
         const resourcesPath = await makeTempDir(
           'texra-history-export-missing-src-',

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -89,7 +89,7 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
-import type { TraceDocument } from '@transcript';
+import { StreamSnapshotStore, type TraceDocument } from '@transcript';
 import {
   cliHistoryNdjsonRecords,
   deleteCliHistory,
@@ -360,6 +360,31 @@ describe('CLI history runtime', () => {
     await expect(
       readCliHistoryDetails('dead' as ExecutionId),
     ).resolves.toBeNull();
+  });
+
+  it('treats candidate-only sidecar associations as a found execution', async () => {
+    const executionId = 'a11ce5a11ce5' as ExecutionId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(
+      `orchestrator@old#${executionId}` as StreamTabId,
+      config,
+      executionId,
+    );
+    snapshots.setRunConfig(
+      `orchestrator@new#${executionId}` as StreamTabId,
+      config,
+      executionId,
+    );
+    await snapshots.flush();
+    mocks.readConfig.mockResolvedValue(null);
+    mocks.readMeta.mockResolvedValue(null);
+    mocks.exists.mockResolvedValue(false);
+
+    await expect(readCliHistoryDetails(executionId)).resolves.toMatchObject({
+      id: executionId,
+      status: 'unknown',
+      conversationPreview: null,
+    });
   });
 
   it('treats full-only conversation data as a found execution', async () => {

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -1374,6 +1374,26 @@ describe('CLI history runtime', () => {
         stderrSpy.mockRestore();
       });
 
+      it('reports ambiguous historical transcripts without selecting one', async () => {
+        mocks.assembleTrace.mockResolvedValue({
+          status: 'streamId_ambiguous',
+        });
+
+        const exitCode = await runHistoryExport(
+          makeContext('/resources'),
+          'a1' as ExecutionId,
+          'html',
+          {},
+        );
+
+        expect(exitCode).toBe(CliExitCode.Usage);
+        expect(stdout).toBe('');
+        expect(stderr).toContain(
+          'several historical transcripts, but none is proven canonical',
+        );
+        expect(stderr).toContain('texra history show a1');
+      });
+
       /** Temp resources dir holding the bundled trace-viewer assets. */
       async function makeStagedResources(prefix: string): Promise<string> {
         const resourcesPath = await makeTempDir(prefix, tempDirs);

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -1405,6 +1405,8 @@ describe('CLI history runtime', () => {
           'multiple associated transcript sidecars (orchestrator@old#a1, orchestrator@new#a1)',
         );
         expect(stderr).toContain('no canonical trace timeline');
+        expect(stderr).toContain('HTML trace export was not written');
+        expect(stderr).not.toContain('texra history show');
       });
 
       it('returns a non-zero exit code (but still writes the trace JSON) when the bundled assets are missing', async () => {

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -1197,6 +1197,29 @@ describe('CLI history runtime', () => {
       ).resolves.toEqual({ status: 'not_found' });
     });
 
+    it('reports candidate-only sidecars as incomplete rather than not found', async () => {
+      const executionId = 'a11ce6a11ce6' as ExecutionId;
+      const snapshots = new StreamSnapshotStore();
+      snapshots.setRunConfig(
+        `orchestrator@old#${executionId}` as StreamTabId,
+        config,
+        executionId,
+      );
+      snapshots.setRunConfig(
+        `orchestrator@new#${executionId}` as StreamTabId,
+        config,
+        executionId,
+      );
+      await snapshots.flush();
+      mocks.readConfig.mockResolvedValue(null);
+      mocks.readMeta.mockResolvedValue(null);
+      mocks.readConversation.mockResolvedValue(null);
+
+      await expect(readCliHistoryExportInput(executionId)).resolves.toEqual({
+        status: 'incomplete',
+      });
+    });
+
     it('reports "incomplete" (not "not_found") when config exists but conversation does not', async () => {
       // history show would still display this execution (it has a config) —
       // export just has nothing to render, which is a different failure than

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -1374,26 +1374,6 @@ describe('CLI history runtime', () => {
         stderrSpy.mockRestore();
       });
 
-      it('reports ambiguous historical transcripts without selecting one', async () => {
-        mocks.assembleTrace.mockResolvedValue({
-          status: 'streamId_ambiguous',
-        });
-
-        const exitCode = await runHistoryExport(
-          makeContext('/resources'),
-          'a1' as ExecutionId,
-          'html',
-          {},
-        );
-
-        expect(exitCode).toBe(CliExitCode.Usage);
-        expect(stdout).toBe('');
-        expect(stderr).toContain(
-          'several historical transcripts, but none is proven canonical',
-        );
-        expect(stderr).toContain('texra history show a1');
-      });
-
       /** Temp resources dir holding the bundled trace-viewer assets. */
       async function makeStagedResources(prefix: string): Promise<string> {
         const resourcesPath = await makeTempDir(prefix, tempDirs);
@@ -1405,6 +1385,27 @@ describe('CLI history runtime', () => {
         );
         return resourcesPath;
       }
+
+      it('reports ambiguous transcript ownership without exporting an arbitrary trace', async () => {
+        mocks.assembleTrace.mockResolvedValue({
+          status: 'streamId_ambiguous',
+          candidateStreamIds: ['orchestrator@old#a1', 'orchestrator@new#a1'],
+        });
+
+        const exitCode = await runHistoryExport(
+          makeContext('/resources'),
+          'a1' as ExecutionId,
+          'html',
+          { assetsDir: '/assets' },
+        );
+
+        expect(exitCode).toBe(CliExitCode.Usage);
+        expect(stdout).toBe('');
+        expect(stderr).toContain(
+          'multiple associated transcript sidecars (orchestrator@old#a1, orchestrator@new#a1)',
+        );
+        expect(stderr).toContain('no canonical trace timeline');
+      });
 
       it('returns a non-zero exit code (but still writes the trace JSON) when the bundled assets are missing', async () => {
         const resourcesPath = await makeTempDir(

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -14,7 +14,13 @@ import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { GoalStore } from '@tools/goal';
 
 const mocks = vi.hoisted(() => ({
@@ -89,7 +95,11 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
-import { StreamSnapshotStore, type TraceDocument } from '@transcript';
+import {
+  StreamLogStore,
+  StreamSnapshotStore,
+  type TraceDocument,
+} from '@transcript';
 import {
   cliHistoryNdjsonRecords,
   deleteCliHistory,
@@ -376,6 +386,57 @@ describe('CLI history runtime', () => {
       executionId,
     );
     await snapshots.flush();
+    mocks.readConfig.mockResolvedValue(null);
+    mocks.readMeta.mockResolvedValue(null);
+    mocks.exists.mockResolvedValue(false);
+
+    await expect(readCliHistoryDetails(executionId)).resolves.toMatchObject({
+      id: executionId,
+      status: 'unknown',
+      conversationPreview: null,
+    });
+    await expect(readCliHistoryExportInput(executionId)).resolves.toEqual({
+      status: 'incomplete',
+    });
+  });
+
+  it('treats children-only associations as incomplete markdown export evidence', async () => {
+    const executionId = 'a11ce6a11ce6' as ExecutionId;
+    const parent = 'orchestrator@model#parent' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    for (const streamId of [
+      `bash@tool#${executionId}`,
+      `codex@tool#${executionId}`,
+    ] as StreamTabId[]) {
+      snapshots.setRunConfig(streamId, config, executionId);
+      snapshots.setParentStream(streamId, parent);
+    }
+    await snapshots.flush();
+    mocks.readConfig.mockResolvedValue(null);
+    mocks.readMeta.mockResolvedValue(null);
+    mocks.exists.mockResolvedValue(false);
+
+    await expect(readCliHistoryExportInput(executionId)).resolves.toEqual({
+      status: 'incomplete',
+    });
+  });
+
+  it('finds a sole diagnostic-only exact root in CLI history details', async () => {
+    const executionId = 'a11ce7a11ce7' as ExecutionId;
+    const root = `orchestrator@model#${executionId}` as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(root, config, executionId);
+    await snapshots.flush();
+    const logs = await StreamLogStore.open();
+    logs.append(root, {
+      id: 'diagnostic-only-root',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 1000,
+      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+      text: 'Root status only',
+    });
+    await logs.flush();
     mocks.readConfig.mockResolvedValue(null);
     mocks.readMeta.mockResolvedValue(null);
     mocks.exists.mockResolvedValue(false);

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -1386,6 +1386,22 @@ describe('CLI history runtime', () => {
         return resourcesPath;
       }
 
+      it('reports missing replayable roots without an empty sidecar list', async () => {
+        mocks.assembleTrace.mockResolvedValue({ status: 'streamLogs_missing' });
+
+        const exitCode = await runHistoryExport(
+          makeContext('/resources'),
+          'a1' as ExecutionId,
+          'html',
+          {},
+        );
+
+        expect(exitCode).toBe(CliExitCode.Usage);
+        expect(stdout).toBe('');
+        expect(stderr).toContain('no replayable execution-root transcript');
+        expect(stderr).not.toContain('sidecars (');
+      });
+
       it('reports ambiguous transcript ownership without exporting an arbitrary trace', async () => {
         mocks.assembleTrace.mockResolvedValue({
           status: 'streamId_ambiguous',
@@ -1407,28 +1423,6 @@ describe('CLI history runtime', () => {
         expect(stderr).toContain('no canonical trace timeline');
         expect(stderr).toContain('HTML trace export was not written');
         expect(stderr).not.toContain('texra history show');
-      });
-
-      it('reports child-only transcript associations without calling them ambiguous', async () => {
-        mocks.assembleTrace.mockResolvedValue({
-          status: 'rootStream_missing',
-          associatedChildStreamIds: ['bash@tool#a1', 'codex@tool#a1'],
-        });
-
-        const exitCode = await runHistoryExport(
-          makeContext('/resources'),
-          'a1' as ExecutionId,
-          'html',
-          {},
-        );
-
-        expect(exitCode).toBe(CliExitCode.Usage);
-        expect(stdout).toBe('');
-        expect(stderr).toContain(
-          'represented only by delegated child transcript sidecars (bash@tool#a1, codex@tool#a1)',
-        );
-        expect(stderr).toContain('HTML trace export was not written');
-        expect(stderr).not.toContain('multiple associated transcript');
       });
 
       it('returns a non-zero exit code (but still writes the trace JSON) when the bundled assets are missing', async () => {

--- a/src/test-kernel/controllers/ChatExportControllerHtml.vitest.ts
+++ b/src/test-kernel/controllers/ChatExportControllerHtml.vitest.ts
@@ -18,10 +18,11 @@ import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   type ExecutionId,
+  type StreamTabId,
 } from '@shared/schemas';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 import { createFakePlatform } from '@test/support/FakePlatform';
-import { StreamLogStore } from '@transcript';
+import { StreamLogStore, StreamSnapshotStore } from '@transcript';
 import { StorageFS } from '@utils/files';
 
 const TEMPLATE =
@@ -130,6 +131,24 @@ describe('ChatExportController.exportAsHtml', () => {
     );
 
     expect(outcome).toEqual({ status: 'streamLogs_missing' });
+  });
+
+  it('returns streamId_ambiguous when no canonical transcript timeline is proven', async () => {
+    const templatePath = await writeTemplate();
+    const executionId = 'aaa555aaa555' as ExecutionId;
+    const executionConfig = config();
+    await getExecutionStore(executionId).writeConfig(executionConfig);
+
+    const first = `orchestrator@old#${executionId}` as StreamTabId;
+    const second = `orchestrator@new#${executionId}` as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(first, executionConfig, executionId);
+    snapshots.setRunConfig(second, executionConfig, executionId);
+    await snapshots.flush();
+
+    const outcome = await controller.exportAsHtml(executionId, templatePath);
+
+    expect(outcome).toEqual({ status: 'streamId_ambiguous' });
   });
 
   it('writes a self-contained HTML file with the trace embedded, when everything is present', async () => {

--- a/src/test-kernel/controllers/ChatExportControllerHtml.vitest.ts
+++ b/src/test-kernel/controllers/ChatExportControllerHtml.vitest.ts
@@ -151,6 +151,28 @@ describe('ChatExportController.exportAsHtml', () => {
     expect(outcome).toEqual({ status: 'streamId_ambiguous' });
   });
 
+  it('returns rootStream_missing when only delegated child sidecars remain', async () => {
+    const templatePath = await writeTemplate();
+    const executionId = 'aaa556aaa556' as ExecutionId;
+    const executionConfig = config();
+    await getExecutionStore(executionId).writeConfig(executionConfig);
+
+    const parent = 'orchestrator@model#parent' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    for (const streamId of [
+      `bash@tool#${executionId}`,
+      `codex@tool#${executionId}`,
+    ] as StreamTabId[]) {
+      snapshots.setRunConfig(streamId, executionConfig, executionId);
+      snapshots.setParentStream(streamId, parent);
+    }
+    await snapshots.flush();
+
+    const outcome = await controller.exportAsHtml(executionId, templatePath);
+
+    expect(outcome).toEqual({ status: 'rootStream_missing' });
+  });
+
   it('writes a self-contained HTML file with the trace embedded, when everything is present', async () => {
     const templatePath = await writeTemplate();
     const executionId = 'exec-full' as ExecutionId;

--- a/src/test-kernel/controllers/ChatExportControllerHtml.vitest.ts
+++ b/src/test-kernel/controllers/ChatExportControllerHtml.vitest.ts
@@ -151,7 +151,7 @@ describe('ChatExportController.exportAsHtml', () => {
     expect(outcome).toEqual({ status: 'streamId_ambiguous' });
   });
 
-  it('returns rootStream_missing when only delegated child sidecars remain', async () => {
+  it('returns streamLogs_missing when only delegated child sidecars remain', async () => {
     const templatePath = await writeTemplate();
     const executionId = 'aaa556aaa556' as ExecutionId;
     const executionConfig = config();
@@ -170,7 +170,7 @@ describe('ChatExportController.exportAsHtml', () => {
 
     const outcome = await controller.exportAsHtml(executionId, templatePath);
 
-    expect(outcome).toEqual({ status: 'rootStream_missing' });
+    expect(outcome).toEqual({ status: 'streamLogs_missing' });
   });
 
   it('writes a self-contained HTML file with the trace embedded, when everything is present', async () => {

--- a/src/test-kernel/controllers/HistoryActionOutcomes.vitest.ts
+++ b/src/test-kernel/controllers/HistoryActionOutcomes.vitest.ts
@@ -39,6 +39,9 @@ describe('HistoryActionOutcomes', () => {
     expect(htmlExportErrorMessage('config_missing')).toBe(
       'History item not found',
     );
+    expect(htmlExportErrorMessage('streamId_ambiguous')).toBe(
+      'Several historical transcripts match this execution, but none is proven canonical for trace export.',
+    );
     expect(htmlExportErrorMessage('streamLogs_missing')).toBe(
       'No stored transcript available for this execution — it may predate transcript persistence.',
     );

--- a/src/test-kernel/controllers/HistoryActionOutcomes.vitest.ts
+++ b/src/test-kernel/controllers/HistoryActionOutcomes.vitest.ts
@@ -39,14 +39,11 @@ describe('HistoryActionOutcomes', () => {
     expect(htmlExportErrorMessage('config_missing')).toBe(
       'History item not found',
     );
-    expect(htmlExportErrorMessage('rootStream_missing')).toBe(
-      'No root transcript is available for trace export; this execution is represented only by delegated child streams.',
-    );
     expect(htmlExportErrorMessage('streamId_ambiguous')).toBe(
       'Several historical transcripts match this execution, but none is proven canonical for trace export.',
     );
     expect(htmlExportErrorMessage('streamLogs_missing')).toBe(
-      'No stored transcript available for this execution — it may predate transcript persistence.',
+      'No replayable execution-root transcript is available — it may predate transcript persistence or have only child transcripts.',
     );
   });
 

--- a/src/test-kernel/controllers/HistoryActionOutcomes.vitest.ts
+++ b/src/test-kernel/controllers/HistoryActionOutcomes.vitest.ts
@@ -39,6 +39,9 @@ describe('HistoryActionOutcomes', () => {
     expect(htmlExportErrorMessage('config_missing')).toBe(
       'History item not found',
     );
+    expect(htmlExportErrorMessage('rootStream_missing')).toBe(
+      'No root transcript is available for trace export; this execution is represented only by delegated child streams.',
+    );
     expect(htmlExportErrorMessage('streamId_ambiguous')).toBe(
       'Several historical transcripts match this execution, but none is proven canonical for trace export.',
     );

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -864,10 +864,15 @@ describe('completedRunArchive facade', () => {
       }),
       id: 'copied-status',
     };
+    const copiedTimestamp = {
+      ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Timed answer' }),
+      id: 'copied-timestamp',
+      timestamp: 1000,
+    };
     await persistRows(
       executionId,
       new Map([
-        [canonical, [copiedText, copiedRole, copiedStatus]],
+        [canonical, [copiedText, copiedRole, copiedStatus, copiedTimestamp]],
         [
           conflicting,
           [
@@ -882,6 +887,7 @@ describe('completedRunArchive facade', () => {
                 status: 'failed',
               },
             },
+            { ...copiedTimestamp, timestamp: 2000 },
           ],
         ],
       ]),
@@ -896,6 +902,7 @@ describe('completedRunArchive facade', () => {
         { rowId: 'copied-role', streamIds: [canonical, conflicting] },
         { rowId: 'copied-status', streamIds: [canonical, conflicting] },
         { rowId: 'copied-text', streamIds: [canonical, conflicting] },
+        { rowId: 'copied-timestamp', streamIds: [canonical, conflicting] },
       ],
     });
     expect(result.conversation).toContainEqual({
@@ -910,7 +917,7 @@ describe('completedRunArchive facade', () => {
       path: `/executions/${executionId}/conversation`,
     });
     expect(endpoint.output).toContain(
-      'Conflicting row IDs: copied-role, copied-status, copied-text',
+      'Conflicting row IDs: copied-role, copied-status, copied-text, copied-timestamp',
     );
   });
 

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -1640,6 +1640,34 @@ describe('completedRunArchive facade', () => {
     });
   });
 
+  it('retains existence evidence when only several proven child streams remain', async () => {
+    const executionId = '0999ce0999ce' as ExecutionId;
+    const parent = 'orchestrator@model#parent' as StreamTabId;
+    const firstChild = 'bash@tool#0999ce0999ce' as StreamTabId;
+    const secondChild = 'codex@tool#0999ce0999ce' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(firstChild, runConfig('bash'), executionId);
+    snapshots.setParentStream(firstChild, parent);
+    snapshots.setRunConfig(secondChild, runConfig('codex'), executionId);
+    snapshots.setParentStream(secondChild, parent);
+    await snapshots.flush();
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      conversation: null,
+      source: 'none',
+      associatedChildStreamIds: [firstChild, secondChild],
+    });
+
+    const endpoint = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+    });
+    expect(endpoint.status).toBe('executed');
+    expect(endpoint.output).toContain(
+      `Associated child streams: ${firstChild}, ${secondChild}`,
+    );
+    expect(endpoint.output).toContain('Returned message interval: [0, 0)');
+  });
+
   it('reads a historical execution whose canonical stream is delegated', async () => {
     const executionId = '0999cd0999cd' as ExecutionId;
     const streamId = 'child@tool#0999cd0999cd' as StreamTabId;

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -818,19 +818,55 @@ describe('completedRunArchive facade', () => {
     );
 
     await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
-      source: 'streamLog',
-      streamId: canonical,
-      candidateStreamIds: [ambiguousChild],
-      conversation: [{ role: 'user', content: 'Canonical question' }],
+      source: 'none',
+      candidateStreamIds: [canonical, ambiguousChild],
+      conversation: null,
     });
 
     const endpoint = await new ExecutionsTool().call({
       path: `/executions/${executionId}/conversation`,
     });
+    expect(endpoint.output).toContain('Source: none');
+    expect(endpoint.output).toContain('Stream: none');
     expect(endpoint.output).toContain(
-      `Ambiguous candidate streams: ${ambiguousChild}`,
+      `Ambiguous candidate streams: ${canonical}, ${ambiguousChild}`,
     );
+    expect(endpoint.output).not.toContain('Canonical question');
     expect(endpoint.output).not.toContain('Unproven child answer');
+  });
+
+  it('uses legacy KV without hiding ambiguous exact-execution candidates', async () => {
+    const executionId = '0888b50888b5' as ExecutionId;
+    const first = 'aOrchestrator@old#0888b50888b5' as StreamTabId;
+    const second = 'zOrchestrator@new#0888b50888b5' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(first, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(second, runConfig('orchestrator'), executionId);
+    await snapshots.flush();
+    await persistRows(
+      executionId,
+      new Map([
+        [
+          first,
+          [logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'First sidecar' })],
+        ],
+        [
+          second,
+          [logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Second sidecar' })],
+        ],
+      ]),
+    );
+    await getExecutionStore(executionId).write('conversation', [
+      { role: 'user', content: 'Legacy canonical conversation' },
+    ]);
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'legacyKV',
+      candidateStreamIds: [first, second],
+      conversation: [
+        { role: 'user', content: 'Legacy canonical conversation' },
+      ],
+    });
   });
 
   it('reports conflicting copied text, role, and status instead of silently deduplicating', async () => {
@@ -894,10 +930,10 @@ describe('completedRunArchive facade', () => {
     );
 
     const result = await readCompletedRunConversation(executionId);
-    expect(result).toMatchObject({
-      source: 'streamLog',
-      streamId: canonical,
-      candidateStreamIds: [conflicting],
+    expect(result).toEqual({
+      source: 'none',
+      conversation: null,
+      candidateStreamIds: [canonical, conflicting],
       conflicts: [
         { rowId: 'copied-role', streamIds: [canonical, conflicting] },
         { rowId: 'copied-status', streamIds: [canonical, conflicting] },
@@ -905,13 +941,6 @@ describe('completedRunArchive facade', () => {
         { rowId: 'copied-timestamp', streamIds: [canonical, conflicting] },
       ],
     });
-    expect(result.conversation).toContainEqual({
-      role: 'assistant',
-      content: [{ type: 'text', text: 'Canonical answer' }],
-    });
-    expect(JSON.stringify(result.conversation)).not.toContain(
-      'Conflicting answer',
-    );
 
     const endpoint = await new ExecutionsTool().call({
       path: `/executions/${executionId}/conversation`,
@@ -971,7 +1000,6 @@ describe('completedRunArchive facade', () => {
     const result = await readCompletedRunConversation(executionId);
     expect(result).toEqual({
       source: 'streamLog',
-      streamId: firstRoot,
       streamIds: [firstRoot, secondRoot],
       conversation: [
         { role: 'user', content: 'First question' },
@@ -1023,7 +1051,6 @@ describe('completedRunArchive facade', () => {
 
     await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
       source: 'streamLog',
-      streamId: resumedRoot,
       streamIds: [resumedRoot, firstRoot],
       conversation: [
         { role: 'user', content: 'Copied question' },
@@ -1035,7 +1062,7 @@ describe('completedRunArchive facade', () => {
     });
   });
 
-  it('merges transitive overlaps while reporting a disconnected candidate across pages', async () => {
+  it('does not choose an overlap component when another exact candidate is disconnected', async () => {
     const executionId = '0888be0888be' as ExecutionId;
     const streams = ['a', 'b', 'c', 'd', 'z'].map(
       (name) => `orchestrator@${name}#0888be0888be` as StreamTabId,
@@ -1068,42 +1095,25 @@ describe('completedRunArchive facade', () => {
 
     const archived = await readCompletedRunConversation(executionId);
     expect(archived).toEqual({
-      source: 'streamLog',
-      streamId: streamA,
-      streamIds: [streamA, streamB, streamC, streamD],
-      candidateStreamIds: [disconnected],
-      conversation: ['A', 'B', 'C', 'D', 'E'].map((content) => ({
-        role: 'user',
-        content,
-      })),
+      source: 'none',
+      candidateStreamIds: streams,
+      conversation: null,
     });
 
-    const firstPage = await new ExecutionsTool().call({
+    const endpoint = await new ExecutionsTool().call({
       path: `/executions/${executionId}/conversation`,
-      offset: 0,
+      offset: 200,
       limit: 2,
     });
-    const secondPage = await new ExecutionsTool().call({
-      path: `/executions/${executionId}/conversation`,
-      offset: 2,
-      limit: 3,
-    });
-    for (const page of [firstPage, secondPage]) {
-      expect(page.output).toContain(
-        `Merged streams: ${streamA}, ${streamB}, ${streamC}, ${streamD}`,
-      );
-      expect(page.output).toContain(
-        `Ambiguous candidate streams: ${disconnected}`,
-      );
-      expect(page.output).not.toContain('Disconnected');
-    }
-    const pagedOutput = `${firstPage.output}\n${secondPage.output}`;
-    for (const text of ['A', 'B', 'C', 'D', 'E']) {
-      expect(pagedOutput.split(`\n${text}\n</message>`)).toHaveLength(2);
-    }
+    expect(endpoint.output).toContain(
+      `Ambiguous candidate streams: ${streams.join(', ')}`,
+    );
+    expect(endpoint.output).toContain('Returned message interval: [0, 0)');
+    expect(endpoint.output).not.toContain('Merged streams:');
+    expect(endpoint.output).not.toContain('Disconnected');
   });
 
-  it('merges a valid overlap component despite a disconnected conflicting candidate', async () => {
+  it('reports overlap conflicts without selecting an unproven component', async () => {
     const executionId = '0888b60888b6' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888b60888b6' as StreamTabId;
     const continuation = 'bOrchestrator@new#0888b60888b6' as StreamTabId;
@@ -1132,28 +1142,161 @@ describe('completedRunArchive facade', () => {
     );
 
     await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
-      source: 'streamLog',
-      streamId: canonical,
-      streamIds: [canonical, continuation],
-      candidateStreamIds: [conflicting],
+      source: 'none',
+      conversation: null,
+      candidateStreamIds: [canonical, continuation, conflicting],
       conflicts: [
         {
           rowId: 'shared-conflict-row',
           streamIds: [canonical, continuation, conflicting],
         },
       ],
+    });
+  });
+
+  it('ignores divergent diagnostic rows when conversation chronology has one continuation', async () => {
+    const executionId = '0888b80888b8' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888b80888b8' as StreamTabId;
+    const continuation = 'bOrchestrator@new#0888b80888b8' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(
+      continuation,
+      runConfig('orchestrator'),
+      executionId,
+    );
+    await snapshots.flush();
+
+    const shared = {
+      ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Shared prompt' }),
+      id: 'diagnostic-shared-prompt',
+    };
+    const answer = logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
+      text: 'Unique continuation',
+    });
+    await persistRows(
+      executionId,
+      new Map([
+        [
+          canonical,
+          [
+            shared,
+            logRow(MESSAGE_TYPES.STATISTICS, {
+              text: 'Usage - input: 10, output: 5',
+            }),
+          ],
+        ],
+        [
+          continuation,
+          [
+            shared,
+            logRow(MESSAGE_TYPES.PROGRESS_STATUS, { text: 'Resuming...' }),
+            answer,
+          ],
+        ],
+      ]),
+    );
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'streamLog',
+      streamIds: [canonical, continuation],
       conversation: [
-        { role: 'user', content: 'Prefix' },
+        { role: 'user', content: 'Shared prompt' },
         {
           role: 'assistant',
-          content: [{ type: 'text', text: 'Shared answer' }],
+          content: [{ type: 'text', text: 'Unique continuation' }],
         },
-        { role: 'user', content: 'Valid continuation' },
       ],
     });
   });
 
-  it('falls back when acyclic overlap constraints do not establish unique chronology', async () => {
+  it('ignores divergent diagnostics that reconverge around one conversation chronology across pages', async () => {
+    const executionId = '0888b90888b9' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888b90888b9' as StreamTabId;
+    const continuation = 'bOrchestrator@new#0888b90888b9' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(
+      continuation,
+      runConfig('orchestrator'),
+      executionId,
+    );
+    await snapshots.flush();
+
+    const prompt = {
+      ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Reconverged prompt' }),
+      id: 'reconverged-prompt',
+    };
+    const answer = {
+      ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Reconverged answer' }),
+      id: 'reconverged-answer',
+    };
+    const followUp = logRow(MESSAGE_TYPES.USER_MESSAGE, {
+      text: 'Later unique turn',
+    });
+    await persistRows(
+      executionId,
+      new Map([
+        [
+          canonical,
+          [
+            prompt,
+            logRow(MESSAGE_TYPES.STATISTICS, { text: 'Usage branch A' }),
+            answer,
+          ],
+        ],
+        [
+          continuation,
+          [
+            prompt,
+            logRow(MESSAGE_TYPES.PROGRESS_STATUS, { text: 'Branch B' }),
+            answer,
+            followUp,
+          ],
+        ],
+      ]),
+    );
+
+    const archived = await readCompletedRunConversation(executionId);
+    expect(archived).toEqual({
+      source: 'streamLog',
+      streamIds: [canonical, continuation],
+      conversation: [
+        { role: 'user', content: 'Reconverged prompt' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Reconverged answer' }],
+        },
+        { role: 'user', content: 'Later unique turn' },
+      ],
+    });
+
+    const firstPage = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+      offset: 0,
+      limit: 2,
+    });
+    const secondPage = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+      offset: 2,
+      limit: 1,
+    });
+    for (const page of [firstPage, secondPage]) {
+      expect(page.output).toContain(
+        `Merged streams: ${canonical}, ${continuation}`,
+      );
+      expect(page.output).not.toContain('Complete chronology established: no');
+      expect(page.output).not.toContain('Ordering cycle detected: yes');
+      expect(page.output).not.toContain('Usage branch A');
+      expect(page.output).not.toContain('Branch B');
+    }
+    expect(firstPage.output).toContain('Returned message interval: [0, 2)');
+    expect(firstPage.output).toContain('Next offset: 2');
+    expect(secondPage.output).toContain('Returned message interval: [2, 3)');
+    expect(secondPage.output).toContain('Next offset: none');
+  });
+
+  it('reports acyclic ambiguity without selecting an unproven archive', async () => {
     const executionId = '0888b70888b7' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888b70888b7' as StreamTabId;
     const ambiguous = 'bOrchestrator@new#0888b70888b7' as StreamTabId;
@@ -1181,17 +1324,10 @@ describe('completedRunArchive facade', () => {
     );
 
     await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
-      source: 'streamLog',
-      streamId: canonical,
-      candidateStreamIds: [ambiguous],
+      source: 'none',
+      candidateStreamIds: [canonical, ambiguous],
       hasOrderingAmbiguity: true,
-      conversation: [
-        { role: 'user', content: 'Shared prompt' },
-        {
-          role: 'assistant',
-          content: [{ type: 'text', text: 'Canonical branch' }],
-        },
-      ],
+      conversation: null,
     });
 
     const firstPage = await new ExecutionsTool().call({
@@ -1207,123 +1343,15 @@ describe('completedRunArchive facade', () => {
     for (const page of [firstPage, secondPage]) {
       expect(page.output).toContain('Complete chronology established: no');
       expect(page.output).toContain(
-        `Ambiguous candidate streams: ${ambiguous}`,
+        `Ambiguous candidate streams: ${canonical}, ${ambiguous}`,
       );
+      expect(page.output).not.toContain('Canonical branch');
       expect(page.output).not.toContain('Ambiguous branch');
+      expect(page.output).toContain('Returned message interval: [0, 0)');
     }
-    expect(firstPage.output).toContain('Returned message interval: [0, 1)');
-    expect(secondPage.output).toContain('Returned message interval: [1, 2)');
   });
 
-  it('ignores non-conversation branches when the message order is unique', async () => {
-    const executionId = '0888b80888b8' as ExecutionId;
-    const canonical = 'aOrchestrator@old#0888b80888b8' as StreamTabId;
-    const continuation = 'bOrchestrator@new#0888b80888b8' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(
-      continuation,
-      runConfig('orchestrator'),
-      executionId,
-    );
-    await snapshots.flush();
-
-    const shared = {
-      ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Shared prompt' }),
-      id: 'diagnostic-branch-shared',
-    };
-    const answer = {
-      ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Shared answer' }),
-      id: 'diagnostic-branch-answer',
-    };
-    const nextTurn = logRow(MESSAGE_TYPES.USER_MESSAGE, {
-      text: 'Continued question',
-    });
-    await persistRows(
-      executionId,
-      new Map([
-        [
-          canonical,
-          [
-            shared,
-            logRow(MESSAGE_TYPES.PROGRESS_STATUS, {
-              text: 'Canonical status',
-            }),
-            answer,
-          ],
-        ],
-        [
-          continuation,
-          [
-            shared,
-            logRow(MESSAGE_TYPES.STATISTICS, {
-              text: 'Continuation statistics',
-            }),
-            answer,
-            nextTurn,
-          ],
-        ],
-      ]),
-    );
-
-    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
-      source: 'streamLog',
-      streamId: canonical,
-      streamIds: [canonical, continuation],
-      conversation: [
-        { role: 'user', content: 'Shared prompt' },
-        {
-          role: 'assistant',
-          content: [{ type: 'text', text: 'Shared answer' }],
-        },
-        { role: 'user', content: 'Continued question' },
-      ],
-    });
-  });
-
-  it('retains archive diagnostics when an empty sidecar falls back to legacy', async () => {
-    const executionId = '0888b90888b9' as ExecutionId;
-    const selected = 'aOrchestrator@old#0888b90888b9' as StreamTabId;
-    const disconnected = 'bOrchestrator@other#0888b90888b9' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(selected, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(
-      disconnected,
-      runConfig('orchestrator'),
-      executionId,
-    );
-    await snapshots.flush();
-
-    await persistRows(
-      executionId,
-      new Map([
-        [
-          selected,
-          [
-            logRow(MESSAGE_TYPES.PROGRESS_STATUS, {
-              text: 'No conversation',
-            }),
-          ],
-        ],
-        [
-          disconnected,
-          [logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Unrelated prompt' })],
-        ],
-      ]),
-    );
-    await getExecutionStore(executionId).write('conversation', [
-      { role: 'user', content: 'Legacy prompt' },
-    ]);
-
-    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
-      source: 'legacyKV',
-      streamId: selected,
-      candidateStreamIds: [disconnected],
-      conversation: [{ role: 'user', content: 'Legacy prompt' }],
-    });
-  });
-
-  it('keeps the selected archive when copied-row ordering forms a cycle', async () => {
+  it('reports copied-row cycles without selecting an unproven archive', async () => {
     const executionId = '0888bf0888bf' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888bf0888bf' as StreamTabId;
     const contradictory = 'bOrchestrator@new#0888bf0888bf' as StreamTabId;
@@ -1353,17 +1381,10 @@ describe('completedRunArchive facade', () => {
     );
 
     await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
-      source: 'streamLog',
-      streamId: canonical,
-      candidateStreamIds: [contradictory],
+      source: 'none',
+      candidateStreamIds: [canonical, contradictory],
       hasOrderingCycle: true,
-      conversation: [
-        { role: 'user', content: 'First' },
-        {
-          role: 'assistant',
-          content: [{ type: 'text', text: 'Second' }],
-        },
-      ],
+      conversation: null,
     });
 
     const endpoint = await new ExecutionsTool().call({

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -1296,6 +1296,121 @@ describe('completedRunArchive facade', () => {
     expect(secondPage.output).toContain('Next offset: none');
   });
 
+  it('reports divergent diagnostic payloads without vetoing a unique conversation merge', async () => {
+    const executionId = '0888b00888b0' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888b00888b0' as StreamTabId;
+    const continuation = 'bOrchestrator@new#0888b00888b0' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(
+      continuation,
+      runConfig('orchestrator'),
+      executionId,
+    );
+    await snapshots.flush();
+
+    const prompt = {
+      ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Payload prompt' }),
+      id: 'payload-prompt',
+    };
+    const answer = {
+      ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Payload answer' }),
+      id: 'payload-answer',
+    };
+    const statistics = {
+      ...logRow(MESSAGE_TYPES.STATISTICS, {
+        text: 'Usage branch A',
+        data: { inputTokens: 10 },
+      }),
+      id: 'divergent-statistics',
+    };
+    const followUp = logRow(MESSAGE_TYPES.USER_MESSAGE, {
+      text: 'Payload continuation',
+    });
+    await persistRows(
+      executionId,
+      new Map([
+        [canonical, [prompt, statistics, answer]],
+        [
+          continuation,
+          [
+            prompt,
+            {
+              ...statistics,
+              text: 'Usage branch B',
+              data: { inputTokens: 20 },
+            },
+            answer,
+            followUp,
+          ],
+        ],
+      ]),
+    );
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'streamLog',
+      streamIds: [canonical, continuation],
+      conflicts: [
+        {
+          rowId: 'divergent-statistics',
+          streamIds: [canonical, continuation],
+        },
+      ],
+      conversation: [
+        { role: 'user', content: 'Payload prompt' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Payload answer' }],
+        },
+        { role: 'user', content: 'Payload continuation' },
+      ],
+    });
+  });
+
+  it('contracts a copied diagnostic bridge while preserving conversation order', async () => {
+    const executionId = '0888b10888b1' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888b10888b1' as StreamTabId;
+    const continuation = 'bOrchestrator@new#0888b10888b1' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(
+      continuation,
+      runConfig('orchestrator'),
+      executionId,
+    );
+    await snapshots.flush();
+
+    const first = logRow(MESSAGE_TYPES.USER_MESSAGE, {
+      text: 'Before diagnostic bridge',
+    });
+    const bridge = {
+      ...logRow(MESSAGE_TYPES.PROGRESS_STATUS, { text: 'Copied status' }),
+      id: 'copied-diagnostic-bridge',
+    };
+    const second = logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
+      text: 'After diagnostic bridge',
+    });
+    await persistRows(
+      executionId,
+      new Map([
+        [canonical, [first, bridge]],
+        [continuation, [bridge, second]],
+      ]),
+    );
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'streamLog',
+      streamIds: [canonical, continuation],
+      conversation: [
+        { role: 'user', content: 'Before diagnostic bridge' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'After diagnostic bridge' }],
+        },
+      ],
+    });
+  });
+
   it('reports acyclic ambiguity without selecting an unproven archive', async () => {
     const executionId = '0888b70888b7' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888b70888b7' as StreamTabId;

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -1274,6 +1274,48 @@ describe('completedRunArchive facade', () => {
     });
   });
 
+  it('retains archive diagnostics when an empty sidecar falls back to legacy', async () => {
+    const executionId = '0888b90888b9' as ExecutionId;
+    const selected = 'aOrchestrator@old#0888b90888b9' as StreamTabId;
+    const disconnected = 'bOrchestrator@other#0888b90888b9' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(selected, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(
+      disconnected,
+      runConfig('orchestrator'),
+      executionId,
+    );
+    await snapshots.flush();
+
+    await persistRows(
+      executionId,
+      new Map([
+        [
+          selected,
+          [
+            logRow(MESSAGE_TYPES.PROGRESS_STATUS, {
+              text: 'No conversation',
+            }),
+          ],
+        ],
+        [
+          disconnected,
+          [logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Unrelated prompt' })],
+        ],
+      ]),
+    );
+    await getExecutionStore(executionId).write('conversation', [
+      { role: 'user', content: 'Legacy prompt' },
+    ]);
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'legacyKV',
+      streamId: selected,
+      candidateStreamIds: [disconnected],
+      conversation: [{ role: 'user', content: 'Legacy prompt' }],
+    });
+  });
+
   it('keeps the selected archive when copied-row ordering forms a cycle', async () => {
     const executionId = '0888bf0888bf' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888bf0888bf' as StreamTabId;

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -1367,6 +1367,71 @@ describe('completedRunArchive facade', () => {
     });
   });
 
+  it('keeps incompatible copied diagnostics distinct while ordering conversation rows', async () => {
+    const executionId = '0888b20888b2' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888b20888b2' as StreamTabId;
+    const continuation = 'bOrchestrator@new#0888b20888b2' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(
+      continuation,
+      runConfig('orchestrator'),
+      executionId,
+    );
+    await snapshots.flush();
+
+    const first = logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'First turn' });
+    const shared = {
+      ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Shared turn' }),
+      id: 'shared-conversation-row',
+    };
+    const diagnostic = {
+      ...logRow(MESSAGE_TYPES.STATISTICS, {
+        text: 'Usage branch A',
+        data: { inputTokens: 10 },
+      }),
+      id: 'incompatible-diagnostic-row',
+    };
+    const last = logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Last turn' });
+    await persistRows(
+      executionId,
+      new Map([
+        [canonical, [first, diagnostic, shared]],
+        [
+          continuation,
+          [
+            shared,
+            {
+              ...diagnostic,
+              text: 'Usage branch B',
+              data: { inputTokens: 20 },
+            },
+            last,
+          ],
+        ],
+      ]),
+    );
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'streamLog',
+      streamIds: [canonical, continuation],
+      conflicts: [
+        {
+          rowId: 'incompatible-diagnostic-row',
+          streamIds: [canonical, continuation],
+        },
+      ],
+      conversation: [
+        { role: 'user', content: 'First turn' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Shared turn' }],
+        },
+        { role: 'user', content: 'Last turn' },
+      ],
+    });
+  });
+
   it('contracts a copied diagnostic bridge while preserving conversation order', async () => {
     const executionId = '0888b10888b1' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888b10888b1' as StreamTabId;

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -1208,6 +1208,72 @@ describe('completedRunArchive facade', () => {
     expect(secondPage.output).toContain('Returned message interval: [1, 2)');
   });
 
+  it('ignores non-conversation branches when the message order is unique', async () => {
+    const executionId = '0888b80888b8' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888b80888b8' as StreamTabId;
+    const continuation = 'bOrchestrator@new#0888b80888b8' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(
+      continuation,
+      runConfig('orchestrator'),
+      executionId,
+    );
+    await snapshots.flush();
+
+    const shared = {
+      ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Shared prompt' }),
+      id: 'diagnostic-branch-shared',
+    };
+    const answer = {
+      ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Shared answer' }),
+      id: 'diagnostic-branch-answer',
+    };
+    const nextTurn = logRow(MESSAGE_TYPES.USER_MESSAGE, {
+      text: 'Continued question',
+    });
+    await persistRows(
+      executionId,
+      new Map([
+        [
+          canonical,
+          [
+            shared,
+            logRow(MESSAGE_TYPES.PROGRESS_STATUS, {
+              text: 'Canonical status',
+            }),
+            answer,
+          ],
+        ],
+        [
+          continuation,
+          [
+            shared,
+            logRow(MESSAGE_TYPES.STATISTICS, {
+              text: 'Continuation statistics',
+            }),
+            answer,
+            nextTurn,
+          ],
+        ],
+      ]),
+    );
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'streamLog',
+      streamId: canonical,
+      streamIds: [canonical, continuation],
+      conversation: [
+        { role: 'user', content: 'Shared prompt' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Shared answer' }],
+        },
+        { role: 'user', content: 'Continued question' },
+      ],
+    });
+  });
+
   it('keeps the selected archive when copied-row ordering forms a cycle', async () => {
     const executionId = '0888bf0888bf' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888bf0888bf' as StreamTabId;

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -67,6 +67,7 @@ import { resolveAndResumeStream } from '@agent/runtime/resolveAndResumeStream';
 import { getStreamTabId } from '@agent/runtime/streamTab';
 import { flowKey } from '@agent/node/persistedFlow';
 import {
+  EXECUTION_STREAM_ID_SOURCE,
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
@@ -1724,6 +1725,70 @@ describe('completedRunArchive facade', () => {
     });
     expect(endpoint.output).toContain('Ordering cycle detected: yes');
     expect(endpoint.output).not.toContain('Merged streams:');
+  });
+
+  it('never falls back from an empty registered root to an explicit child', async () => {
+    const executionId = '0999ca0999ca' as ExecutionId;
+    const root = 'orchestrator@model#0999ca0999ca' as StreamTabId;
+    const child = 'child@tool#0999ca0999ca' as StreamTabId;
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: new Date().toISOString(),
+      streamId: root,
+      streamIdSource: EXECUTION_STREAM_ID_SOURCE.REGISTRATION,
+    });
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(root, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(child, runConfig('child'), executionId);
+    snapshots.setParentStream(child, root);
+    await snapshots.flush();
+
+    const logs = await StreamLogStore.open();
+    logs.ensureStream(root);
+    logs.append(
+      child,
+      logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Child-only prompt' }),
+    );
+    await logs.flush();
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      conversation: null,
+      source: 'none',
+    });
+
+    const legacy = [{ role: 'user', content: 'Legacy root prompt' }];
+    await getExecutionStore(executionId).write('conversation', legacy);
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      conversation: legacy,
+      source: 'legacyKV',
+    });
+  });
+
+  it('preserves a sole diagnostic-only exact root as execution evidence', async () => {
+    const executionId = '0999cb0999cb' as ExecutionId;
+    const root = 'orchestrator@model#0999cb0999cb' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(root, runConfig('orchestrator'), executionId);
+    await snapshots.flush();
+
+    const logs = await StreamLogStore.open();
+    logs.append(
+      root,
+      logRow(MESSAGE_TYPES.PROGRESS_STATUS, { text: 'Root status only' }),
+    );
+    await logs.flush();
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      conversation: null,
+      source: 'none',
+      streamId: root,
+    });
+
+    const endpoint = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+    });
+    expect(endpoint.status).toBe('executed');
+    expect(endpoint.output).toContain('Conversation (0 messages)');
+    expect(endpoint.output).toContain(`Stream: ${root}`);
   });
 
   it('never substitutes child conversation rows for empty confirmed roots', async () => {

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -1469,6 +1469,44 @@ describe('completedRunArchive facade', () => {
     expect(endpoint.output).toContain('Returned message interval: [0, 0)');
   });
 
+  it('does not attribute a legacy conversation to diagnostic-only merged streams', async () => {
+    const executionId = '0888c10888c1' as ExecutionId;
+    const first = 'aOrchestrator@old#0888c10888c1' as StreamTabId;
+    const second = 'bOrchestrator@new#0888c10888c1' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(first, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(second, runConfig('orchestrator'), executionId);
+    await snapshots.flush();
+
+    const sharedDiagnostic = {
+      ...logRow(MESSAGE_TYPES.STATISTICS, { text: 'Usage recorded' }),
+      id: 'legacy-shared-diagnostic-row',
+    };
+    await persistRows(
+      executionId,
+      new Map([
+        [first, [sharedDiagnostic]],
+        [second, [sharedDiagnostic]],
+      ]),
+    );
+    await getExecutionStore(executionId).write('conversation', [
+      { role: 'user', content: 'Legacy conversation' },
+    ]);
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'legacyKV',
+      conversation: [{ role: 'user', content: 'Legacy conversation' }],
+    });
+
+    const endpoint = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+    });
+    expect(endpoint.output).toContain('Source: legacyKV');
+    expect(endpoint.output).toContain('Legacy conversation');
+    expect(endpoint.output).not.toContain('Merged streams:');
+    expect(endpoint.output).toContain('Stream: none');
+  });
+
   it('uses proven child associations as existence evidence without reading them', async () => {
     const executionId = '0888b40888b4' as ExecutionId;
     const parent = 'orchestrator@model#parent' as StreamTabId;

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -1469,6 +1469,34 @@ describe('completedRunArchive facade', () => {
     expect(endpoint.output).toContain('Returned message interval: [0, 0)');
   });
 
+  it('recognizes a sole diagnostic-only root as an existing execution', async () => {
+    const executionId = '0888c20888c2' as ExecutionId;
+    const streamId = 'orchestrator@model#0888c20888c2' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
+    await snapshots.flush();
+    await persistRows(
+      executionId,
+      new Map([
+        [
+          streamId,
+          [logRow(MESSAGE_TYPES.STATISTICS, { text: 'Usage recorded' })],
+        ],
+      ]),
+    );
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'none',
+      streamId,
+      conversation: null,
+    });
+    const endpoint = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+    });
+    expect(endpoint.status).toBe('executed');
+    expect(endpoint.output).toContain(`Stream: ${streamId}`);
+  });
+
   it('does not attribute a legacy conversation to diagnostic-only merged streams', async () => {
     const executionId = '0888c10888c1' as ExecutionId;
     const first = 'aOrchestrator@old#0888c10888c1' as StreamTabId;

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -765,6 +765,7 @@ describe('completedRunArchive facade', () => {
     expect(result).toEqual({
       source: 'streamLog',
       streamId: fullStream,
+      associatedStreamIds: [emptyStream],
       conversation: [
         { role: 'user', content: 'Real question' },
         {
@@ -1001,6 +1002,7 @@ describe('completedRunArchive facade', () => {
     expect(result).toEqual({
       source: 'streamLog',
       streamIds: [firstRoot, secondRoot],
+      associatedStreamIds: [child],
       conversation: [
         { role: 'user', content: 'First question' },
         {
@@ -1467,6 +1469,55 @@ describe('completedRunArchive facade', () => {
     expect(endpoint.output).toContain('Returned message interval: [0, 0)');
   });
 
+  it('uses proven child associations as existence evidence without reading them', async () => {
+    const executionId = '0888b40888b4' as ExecutionId;
+    const parent = 'orchestrator@model#parent' as StreamTabId;
+    const firstChild = 'bash@tool#0888b40888b4' as StreamTabId;
+    const secondChild = 'codex@tool#0888b40888b4' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(firstChild, runConfig('bash'), executionId);
+    snapshots.setParentStream(firstChild, parent);
+    snapshots.setRunConfig(secondChild, runConfig('codex'), executionId);
+    snapshots.setParentStream(secondChild, parent);
+    await snapshots.flush();
+    await persistRows(
+      executionId,
+      new Map([
+        [
+          firstChild,
+          [logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'First child row' })],
+        ],
+        [
+          secondChild,
+          [
+            logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
+              text: 'Second child row',
+            }),
+          ],
+        ],
+      ]),
+    );
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'none',
+      associatedStreamIds: [firstChild, secondChild],
+      conversation: null,
+    });
+
+    const endpoint = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+    });
+    expect(endpoint.status).toBe('executed');
+    expect(endpoint.output).toContain(
+      `Associated streams: ${firstChild}, ${secondChild}`,
+    );
+    expect(endpoint.output).toContain('Conversation (0 messages)');
+    expect(endpoint.output).not.toContain('First child row');
+    expect(endpoint.output).not.toContain('Second child row');
+    expect(endpoint.output).not.toContain('Ambiguous candidate streams:');
+    expect(endpoint.output).not.toContain('Merged streams:');
+  });
+
   it('contracts a copied diagnostic bridge while preserving conversation order', async () => {
     const executionId = '0888b10888b1' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888b10888b1' as StreamTabId;
@@ -1637,6 +1688,8 @@ describe('completedRunArchive facade', () => {
     await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
       conversation: null,
       source: 'none',
+      streamId: root,
+      associatedStreamIds: [child],
     });
   });
 
@@ -1655,7 +1708,7 @@ describe('completedRunArchive facade', () => {
     await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
       conversation: null,
       source: 'none',
-      associatedChildStreamIds: [firstChild, secondChild],
+      associatedStreamIds: [firstChild, secondChild],
     });
 
     const endpoint = await new ExecutionsTool().call({
@@ -1663,7 +1716,7 @@ describe('completedRunArchive facade', () => {
     });
     expect(endpoint.status).toBe('executed');
     expect(endpoint.output).toContain(
-      `Associated child streams: ${firstChild}, ${secondChild}`,
+      `Associated streams: ${firstChild}, ${secondChild}`,
     );
     expect(endpoint.output).toContain('Returned message interval: [0, 0)');
   });

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -1096,6 +1096,118 @@ describe('completedRunArchive facade', () => {
     }
   });
 
+  it('merges a valid overlap component despite a disconnected conflicting candidate', async () => {
+    const executionId = '0888b60888b6' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888b60888b6' as StreamTabId;
+    const continuation = 'bOrchestrator@new#0888b60888b6' as StreamTabId;
+    const conflicting = 'cOrchestrator@other#0888b60888b6' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    for (const streamId of [canonical, continuation, conflicting]) {
+      snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
+    }
+    await snapshots.flush();
+
+    const prefix = logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Prefix' });
+    const copied = {
+      ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Shared answer' }),
+      id: 'shared-conflict-row',
+    };
+    const continued = logRow(MESSAGE_TYPES.USER_MESSAGE, {
+      text: 'Valid continuation',
+    });
+    await persistRows(
+      executionId,
+      new Map([
+        [canonical, [prefix, copied]],
+        [continuation, [copied, continued]],
+        [conflicting, [{ ...copied, text: 'Incompatible copy' }]],
+      ]),
+    );
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'streamLog',
+      streamId: canonical,
+      streamIds: [canonical, continuation],
+      candidateStreamIds: [conflicting],
+      conflicts: [
+        {
+          rowId: 'shared-conflict-row',
+          streamIds: [canonical, continuation, conflicting],
+        },
+      ],
+      conversation: [
+        { role: 'user', content: 'Prefix' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Shared answer' }],
+        },
+        { role: 'user', content: 'Valid continuation' },
+      ],
+    });
+  });
+
+  it('falls back when acyclic overlap constraints do not establish unique chronology', async () => {
+    const executionId = '0888b70888b7' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888b70888b7' as StreamTabId;
+    const ambiguous = 'bOrchestrator@new#0888b70888b7' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(ambiguous, runConfig('orchestrator'), executionId);
+    await snapshots.flush();
+
+    const shared = {
+      ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Shared prompt' }),
+      id: 'ambiguous-shared',
+    };
+    const canonicalSuccessor = logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
+      text: 'Canonical branch',
+    });
+    const ambiguousSuccessor = logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
+      text: 'Ambiguous branch',
+    });
+    await persistRows(
+      executionId,
+      new Map([
+        [canonical, [shared, canonicalSuccessor]],
+        [ambiguous, [shared, ambiguousSuccessor]],
+      ]),
+    );
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'streamLog',
+      streamId: canonical,
+      candidateStreamIds: [ambiguous],
+      hasOrderingAmbiguity: true,
+      conversation: [
+        { role: 'user', content: 'Shared prompt' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Canonical branch' }],
+        },
+      ],
+    });
+
+    const firstPage = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+      offset: 0,
+      limit: 1,
+    });
+    const secondPage = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+      offset: 1,
+      limit: 1,
+    });
+    for (const page of [firstPage, secondPage]) {
+      expect(page.output).toContain('Complete chronology established: no');
+      expect(page.output).toContain(
+        `Ambiguous candidate streams: ${ambiguous}`,
+      );
+      expect(page.output).not.toContain('Ambiguous branch');
+    }
+    expect(firstPage.output).toContain('Returned message interval: [0, 1)');
+    expect(secondPage.output).toContain('Returned message interval: [1, 2)');
+  });
+
   it('keeps the selected archive when copied-row ordering forms a cycle', async () => {
     const executionId = '0888bf0888bf' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888bf0888bf' as StreamTabId;

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -1432,6 +1432,41 @@ describe('completedRunArchive facade', () => {
     });
   });
 
+  it('recognizes a connected diagnostic-only archive as an existing execution', async () => {
+    const executionId = '0888b30888b3' as ExecutionId;
+    const first = 'aOrchestrator@old#0888b30888b3' as StreamTabId;
+    const second = 'bOrchestrator@new#0888b30888b3' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(first, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(second, runConfig('orchestrator'), executionId);
+    await snapshots.flush();
+
+    const sharedDiagnostic = {
+      ...logRow(MESSAGE_TYPES.STATISTICS, { text: 'Usage recorded' }),
+      id: 'shared-diagnostic-only-row',
+    };
+    await persistRows(
+      executionId,
+      new Map([
+        [first, [sharedDiagnostic]],
+        [second, [sharedDiagnostic]],
+      ]),
+    );
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'none',
+      streamIds: [first, second],
+      conversation: null,
+    });
+
+    const endpoint = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+    });
+    expect(endpoint.status).toBe('executed');
+    expect(endpoint.output).toContain(`Merged streams: ${first}, ${second}`);
+    expect(endpoint.output).toContain('Returned message interval: [0, 0)');
+  });
+
   it('contracts a copied diagnostic bridge while preserving conversation order', async () => {
     const executionId = '0888b10888b1' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888b10888b1' as StreamTabId;

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -117,6 +117,32 @@ function logRow(
   };
 }
 
+async function persistRows(
+  executionId: ExecutionId,
+  rowsByStream: ReadonlyMap<
+    StreamTabId,
+    readonly Parameters<StreamLogStore['append']>[1][]
+  >,
+): Promise<void> {
+  const logs = await StreamLogStore.open();
+  for (const [streamId, rows] of rowsByStream) {
+    const writer = logs.acquireWriter(streamId, executionId);
+    try {
+      for (const row of rows) writer.appendSettled(row);
+    } finally {
+      writer.close();
+    }
+  }
+  await logs.flush();
+  for (const streamId of rowsByStream.keys()) logs.requestEviction(streamId);
+
+  const reopened = await StreamLogStore.openReadOnly();
+  for (const streamId of rowsByStream.keys()) {
+    await reopened.ensureLoaded(streamId);
+    expect(reopened.get(streamId)).toBeDefined();
+  }
+}
+
 /** Write the sidecar fixture: transcript rows + snapshot meta/todos. */
 async function writeSidecarFixture(
   executionId: ExecutionId,
@@ -749,6 +775,145 @@ describe('completedRunArchive facade', () => {
     });
   });
 
+  it('does not merge a disjoint exact-execution sidecar with missing parent metadata', async () => {
+    const executionId = '0888ba0888ba' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888ba0888ba' as StreamTabId;
+    const ambiguousChild = 'zOrchestrator@new#0888ba0888ba' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(
+      ambiguousChild,
+      runConfig('orchestrator'),
+      executionId,
+    );
+    await snapshots.flush();
+
+    await persistRows(
+      executionId,
+      new Map([
+        [
+          canonical,
+          [
+            {
+              ...logRow(MESSAGE_TYPES.USER_MESSAGE, {
+                text: 'Canonical question',
+              }),
+              timestamp: 9000,
+            },
+          ],
+        ],
+        [
+          ambiguousChild,
+          [
+            {
+              ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
+                text: 'Unproven child answer',
+              }),
+              // A reversed clock cannot order a disconnected sidecar.
+              timestamp: 1000,
+            },
+          ],
+        ],
+      ]),
+    );
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'streamLog',
+      streamId: canonical,
+      candidateStreamIds: [ambiguousChild],
+      conversation: [{ role: 'user', content: 'Canonical question' }],
+    });
+
+    const endpoint = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+    });
+    expect(endpoint.output).toContain(
+      `Ambiguous candidate streams: ${ambiguousChild}`,
+    );
+    expect(endpoint.output).not.toContain('Unproven child answer');
+  });
+
+  it('reports conflicting copied text, role, and status instead of silently deduplicating', async () => {
+    const executionId = '0888bd0888bd' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888bd0888bd' as StreamTabId;
+    const conflicting = 'zOrchestrator@new#0888bd0888bd' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(conflicting, runConfig('orchestrator'), executionId);
+    await snapshots.flush();
+
+    const copiedText = {
+      ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Canonical answer' }),
+      id: 'copied-text',
+    };
+    const copiedRole = {
+      ...logRow(MESSAGE_TYPES.USER_MESSAGE, {
+        text: 'Role-sensitive prompt',
+        data: { archivedRole: 'user' },
+      }),
+      id: 'copied-role',
+    };
+    const copiedStatus = {
+      ...logRow(MESSAGE_TYPES.TOOL_USE, {
+        data: {
+          toolName: 'read_file',
+          input: { path: 'proof.tex' },
+          output: 'Proof text',
+          status: 'completed',
+        },
+      }),
+      id: 'copied-status',
+    };
+    await persistRows(
+      executionId,
+      new Map([
+        [canonical, [copiedText, copiedRole, copiedStatus]],
+        [
+          conflicting,
+          [
+            { ...copiedText, text: 'Conflicting answer' },
+            { ...copiedRole, data: { archivedRole: 'system' } },
+            {
+              ...copiedStatus,
+              data: {
+                toolName: 'read_file',
+                input: { path: 'proof.tex' },
+                output: 'Proof text',
+                status: 'failed',
+              },
+            },
+          ],
+        ],
+      ]),
+    );
+
+    const result = await readCompletedRunConversation(executionId);
+    expect(result).toMatchObject({
+      source: 'streamLog',
+      streamId: canonical,
+      candidateStreamIds: [conflicting],
+      conflicts: [
+        { rowId: 'copied-role', streamIds: [canonical, conflicting] },
+        { rowId: 'copied-status', streamIds: [canonical, conflicting] },
+        { rowId: 'copied-text', streamIds: [canonical, conflicting] },
+      ],
+    });
+    expect(result.conversation).toContainEqual({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Canonical answer' }],
+    });
+    expect(JSON.stringify(result.conversation)).not.toContain(
+      'Conflicting answer',
+    );
+
+    const endpoint = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+    });
+    expect(endpoint.output).toContain(
+      'Conflicting row IDs: copied-role, copied-status, copied-text',
+    );
+  });
+
   it('merges matched roots, excluding children and only deduplicating row identity', async () => {
     const executionId = '0888bb0888bb' as ExecutionId;
     const firstRoot = 'aOrchestrator@old#0888bb0888bb' as StreamTabId;
@@ -861,6 +1026,124 @@ describe('completedRunArchive facade', () => {
         },
       ],
     });
+  });
+
+  it('merges transitive overlaps while reporting a disconnected candidate across pages', async () => {
+    const executionId = '0888be0888be' as ExecutionId;
+    const streams = ['a', 'b', 'c', 'd', 'z'].map(
+      (name) => `orchestrator@${name}#0888be0888be` as StreamTabId,
+    );
+    const [streamA, streamB, streamC, streamD, disconnected] = streams;
+    const snapshots = new StreamSnapshotStore();
+    for (const streamId of streams) {
+      snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
+    }
+    await snapshots.flush();
+
+    const rows = ['A', 'B', 'C', 'D', 'E'].map((text) => ({
+      ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text }),
+      id: `transitive-${text.toLowerCase()}`,
+    }));
+    const disconnectedRow = {
+      ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Disconnected' }),
+      timestamp: 1,
+    };
+    await persistRows(
+      executionId,
+      new Map([
+        [streamA, [rows[0], rows[1]]],
+        [streamB, [rows[1], rows[2]]],
+        [streamC, [rows[2], rows[3]]],
+        [streamD, [rows[3], rows[4]]],
+        [disconnected, [disconnectedRow]],
+      ]),
+    );
+
+    const archived = await readCompletedRunConversation(executionId);
+    expect(archived).toEqual({
+      source: 'streamLog',
+      streamId: streamA,
+      streamIds: [streamA, streamB, streamC, streamD],
+      candidateStreamIds: [disconnected],
+      conversation: ['A', 'B', 'C', 'D', 'E'].map((content) => ({
+        role: 'user',
+        content,
+      })),
+    });
+
+    const firstPage = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+      offset: 0,
+      limit: 2,
+    });
+    const secondPage = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+      offset: 2,
+      limit: 3,
+    });
+    for (const page of [firstPage, secondPage]) {
+      expect(page.output).toContain(
+        `Merged streams: ${streamA}, ${streamB}, ${streamC}, ${streamD}`,
+      );
+      expect(page.output).toContain(
+        `Ambiguous candidate streams: ${disconnected}`,
+      );
+      expect(page.output).not.toContain('Disconnected');
+    }
+    const pagedOutput = `${firstPage.output}\n${secondPage.output}`;
+    for (const text of ['A', 'B', 'C', 'D', 'E']) {
+      expect(pagedOutput.split(`\n${text}\n</message>`)).toHaveLength(2);
+    }
+  });
+
+  it('keeps the selected archive when copied-row ordering forms a cycle', async () => {
+    const executionId = '0888bf0888bf' as ExecutionId;
+    const canonical = 'aOrchestrator@old#0888bf0888bf' as StreamTabId;
+    const contradictory = 'bOrchestrator@new#0888bf0888bf' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
+    snapshots.setRunConfig(
+      contradictory,
+      runConfig('orchestrator'),
+      executionId,
+    );
+    await snapshots.flush();
+
+    const first = {
+      ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'First' }),
+      id: 'cycle-first',
+    };
+    const second = {
+      ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Second' }),
+      id: 'cycle-second',
+    };
+    await persistRows(
+      executionId,
+      new Map([
+        [canonical, [first, second]],
+        [contradictory, [second, first]],
+      ]),
+    );
+
+    await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
+      source: 'streamLog',
+      streamId: canonical,
+      candidateStreamIds: [contradictory],
+      hasOrderingCycle: true,
+      conversation: [
+        { role: 'user', content: 'First' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Second' }],
+        },
+      ],
+    });
+
+    const endpoint = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+    });
+    expect(endpoint.output).toContain('Ordering cycle detected: yes');
+    expect(endpoint.output).not.toContain('Merged streams:');
   });
 
   it('never substitutes child conversation rows for empty confirmed roots', async () => {

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -257,6 +257,25 @@ describe('resolvePersistedStreamIdForExecution', () => {
     ).toBeUndefined();
   });
 
+  it('does not treat several proven children as competing archive roots', async () => {
+    const executionId = 'abc889' as ExecutionId;
+    const parent = 'orchestrator@model#parent' as StreamTabId;
+    const firstChild = 'bash@tool#abc889' as StreamTabId;
+    const secondChild = 'codex@tool#abc889' as StreamTabId;
+    const snapshotWriter = new StreamSnapshotStore();
+    snapshotWriter.setRunConfig(firstChild, runConfig('bash'), executionId);
+    snapshotWriter.setParentStream(firstChild, parent);
+    snapshotWriter.setRunConfig(secondChild, runConfig('codex'), executionId);
+    snapshotWriter.setParentStream(secondChild, parent);
+    await snapshotWriter.flush();
+
+    await expect(
+      resolvePersistedStreamIdForExecution(executionId, {
+        snapshotStore: new StreamSnapshotStore(),
+      }),
+    ).resolves.toEqual({ source: 'streamDataMeta' });
+  });
+
   it('preserves the legacy streamData suffix fallback', async () => {
     const executionId = 'abc999' as ExecutionId;
     const first = 'a@model#abc999' as StreamTabId;

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -275,7 +275,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       }),
     ).resolves.toEqual({
       source: 'streamDataMeta',
-      associatedChildStreamIds: [firstChild, secondChild],
+      associatedStreamIds: [firstChild, secondChild],
     });
   });
 

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -199,14 +199,12 @@ describe('resolvePersistedStreamIdForExecution', () => {
         snapshotStore: new StreamSnapshotStore(),
       }),
     ).resolves.toEqual({
-      streamId,
       source: 'streamDataMeta',
-      fallbackStreamIds: [resumedStream],
       exactExecutionCandidateStreamIds: [streamId, resumedStream],
     });
   });
 
-  it('prefers a work-plan-bearing historical stream over a bare match', async () => {
+  it('does not treat a work plan as canonical-ownership evidence', async () => {
     const executionId = 'abc777' as ExecutionId;
     const firstStream = 'aOrchestrator@deepseekproT#abc777' as StreamTabId;
     const secondStream = 'zBashTool@tool#abc777' as StreamTabId;
@@ -224,14 +222,12 @@ describe('resolvePersistedStreamIdForExecution', () => {
       snapshotStore: new StreamSnapshotStore(),
     });
     expect(resolved).toEqual({
-      streamId: secondStream,
       source: 'streamDataMeta',
-      fallbackStreamIds: [firstStream],
       exactExecutionCandidateStreamIds: [firstStream, secondStream],
     });
   });
 
-  it('prefers a log-backed historical stream over a work-plan-only match', async () => {
+  it('does not treat a stream log as canonical-ownership evidence', async () => {
     const executionId = 'abc888' as ExecutionId;
     const workPlanStream = 'aOrchestrator@deepseekproT#abc888' as StreamTabId;
     const logStream = 'zBashTool@tool#abc888' as StreamTabId;
@@ -253,13 +249,48 @@ describe('resolvePersistedStreamIdForExecution', () => {
       streamLogStore: logStore,
     });
     expect(resolved).toEqual({
-      streamId: logStream,
       source: 'streamDataMeta',
-      fallbackStreamIds: [workPlanStream],
       exactExecutionCandidateStreamIds: [workPlanStream, logStream],
     });
     expect(
       (await getExecutionStore(executionId).readMeta())?.streamId,
     ).toBeUndefined();
+  });
+
+  it('preserves the legacy streamData suffix fallback', async () => {
+    const executionId = 'abc999' as ExecutionId;
+    const first = 'a@model#abc999' as StreamTabId;
+    const second = 'z@model#abc999' as StreamTabId;
+    const writer = new StreamSnapshotStore();
+    writer.setTodos(first, [TODO]);
+    writer.setTodos(second, [TODO]);
+    await writer.flush();
+
+    await expect(
+      resolvePersistedStreamIdForExecution(executionId, {
+        snapshotStore: new StreamSnapshotStore(),
+      }),
+    ).resolves.toEqual({
+      streamId: first,
+      source: 'streamDataSuffix',
+      fallbackStreamIds: [second],
+    });
+  });
+
+  it('preserves the legacy streamLogs suffix fallback', async () => {
+    const executionId = 'abcaaa' as ExecutionId;
+    const streamId = 'agent@model#abcaaa' as StreamTabId;
+    const logs = await StreamLogStore.open();
+    await appendLogEntry(logs, streamId);
+
+    await expect(
+      resolvePersistedStreamIdForExecution(executionId, {
+        snapshotStore: new StreamSnapshotStore(),
+        streamLogStore: logs,
+      }),
+    ).resolves.toEqual({
+      streamId,
+      source: 'streamLogsSuffix',
+    });
   });
 });

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -279,6 +279,24 @@ describe('resolvePersistedStreamIdForExecution', () => {
     });
   });
 
+  it('resolves a sole delegated stream without treating it as an associated sibling', async () => {
+    const executionId = 'abc88a' as ExecutionId;
+    const streamId = 'bash@tool#abc88a' as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(streamId, runConfig('bash'), executionId);
+    snapshots.setParentStream(
+      streamId,
+      'orchestrator@model#parent' as StreamTabId,
+    );
+    await snapshots.flush();
+
+    await expect(
+      resolvePersistedStreamIdForExecution(executionId, {
+        snapshotStore: new StreamSnapshotStore(),
+      }),
+    ).resolves.toEqual({ streamId, source: 'streamDataMeta' });
+  });
+
   it('preserves the legacy streamData suffix fallback', async () => {
     const executionId = 'abc999' as ExecutionId;
     const first = 'a@model#abc999' as StreamTabId;

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -89,7 +89,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
     expect(resolved).toEqual({
       streamId,
       source: 'streamDataMeta',
-      associatedRootStreamIds: [streamId],
+      exactExecutionCandidateStreamIds: [streamId],
     });
   });
 
@@ -177,7 +177,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
     expect(resolved).toEqual({
       streamId,
       source: 'streamDataMeta',
-      associatedRootStreamIds: [streamId],
+      exactExecutionCandidateStreamIds: [streamId],
     });
     await expect(
       getExecutionStore(executionId).readMeta(),
@@ -202,7 +202,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       streamId,
       source: 'streamDataMeta',
       fallbackStreamIds: [resumedStream],
-      associatedRootStreamIds: [streamId, resumedStream],
+      exactExecutionCandidateStreamIds: [streamId, resumedStream],
     });
   });
 
@@ -227,7 +227,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       streamId: secondStream,
       source: 'streamDataMeta',
       fallbackStreamIds: [firstStream],
-      associatedRootStreamIds: [firstStream, secondStream],
+      exactExecutionCandidateStreamIds: [firstStream, secondStream],
     });
   });
 
@@ -256,7 +256,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       streamId: logStream,
       source: 'streamDataMeta',
       fallbackStreamIds: [workPlanStream],
-      associatedRootStreamIds: [workPlanStream, logStream],
+      exactExecutionCandidateStreamIds: [workPlanStream, logStream],
     });
     expect(
       (await getExecutionStore(executionId).readMeta())?.streamId,

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -273,7 +273,10 @@ describe('resolvePersistedStreamIdForExecution', () => {
       resolvePersistedStreamIdForExecution(executionId, {
         snapshotStore: new StreamSnapshotStore(),
       }),
-    ).resolves.toEqual({ source: 'streamDataMeta' });
+    ).resolves.toEqual({
+      source: 'streamDataMeta',
+      associatedChildStreamIds: [firstChild, secondChild],
+    });
   });
 
   it('preserves the legacy streamData suffix fallback', async () => {

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -106,22 +106,34 @@ describe('assembleTrace', () => {
     expect(result).toEqual({ status: 'streamLogs_missing' });
   });
 
-  it('reports ambiguous historical sidecars instead of selecting one for trace export', async () => {
-    const executionId = 'abcde1abcde1' as ExecutionId;
+  it('reports candidate-only sidecars as ambiguous without choosing the derived fallback', async () => {
+    const executionId = 'aaa444aaa444' as ExecutionId;
     const executionConfig = config();
+    await getExecutionStore(executionId).writeConfig(executionConfig);
+
     const first = `orchestrator@old#${executionId}` as StreamTabId;
     const second = `orchestrator@new#${executionId}` as StreamTabId;
-    await getExecutionStore(executionId).writeConfig(executionConfig);
+    const derived = getStreamTabId(
+      executionConfig.agent,
+      executionConfig.model,
+      { executionId },
+    );
+    expect(derived).not.toBe(first);
+    expect(derived).not.toBe(second);
 
     const snapshots = new StreamSnapshotStore();
     snapshots.setRunConfig(first, executionConfig, executionId);
     snapshots.setRunConfig(second, executionConfig, executionId);
     await snapshots.flush();
-    await appendLogEntry(first, 'First historical transcript');
-    await appendLogEntry(second, 'Second historical transcript');
+    await appendLogEntry(first, 'first candidate');
+    await appendLogEntry(second, 'second candidate');
+    await appendLogEntry(derived, 'derived fallback must not be selected');
 
-    await expect(assembleTrace(executionId)).resolves.toEqual({
+    const result = await assembleTrace(executionId);
+
+    expect(result).toEqual({
       status: 'streamId_ambiguous',
+      candidateStreamIds: [second, first],
     });
   });
 

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -137,6 +137,27 @@ describe('assembleTrace', () => {
     });
   });
 
+  it('reports child-only associations separately from ambiguous archive roots', async () => {
+    const executionId = 'abcde2abcde2' as ExecutionId;
+    const executionConfig = config();
+    const parent = 'orchestrator@model#parent' as StreamTabId;
+    const firstChild = `bash@tool#${executionId}` as StreamTabId;
+    const secondChild = `codex@tool#${executionId}` as StreamTabId;
+    await getExecutionStore(executionId).writeConfig(executionConfig);
+
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(firstChild, executionConfig, executionId);
+    snapshots.setParentStream(firstChild, parent);
+    snapshots.setRunConfig(secondChild, executionConfig, executionId);
+    snapshots.setParentStream(secondChild, parent);
+    await snapshots.flush();
+
+    await expect(assembleTrace(executionId)).resolves.toEqual({
+      status: 'rootStream_missing',
+      associatedChildStreamIds: [firstChild, secondChild],
+    });
+  });
+
   it('resolves a child stream by executionId suffix when its id does not match the derived agent@model#executionId format', async () => {
     // Background child streams (bash/codex/claude subagents, see
     // @tools/childStream.createChildStream) use a tool-specific

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -137,6 +137,21 @@ describe('assembleTrace', () => {
     });
   });
 
+  it('reports candidate-only sidecars as ambiguous even when execution config is absent', async () => {
+    const executionId = 'aaa446aaa446' as ExecutionId;
+    const first = `orchestrator@old#${executionId}` as StreamTabId;
+    const second = `orchestrator@new#${executionId}` as StreamTabId;
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(first, config(), executionId);
+    snapshots.setRunConfig(second, config(), executionId);
+    await snapshots.flush();
+
+    await expect(assembleTrace(executionId)).resolves.toEqual({
+      status: 'streamId_ambiguous',
+      candidateStreamIds: [second, first],
+    });
+  });
+
   it('does not classify children-only associations as ambiguous or choose a fallback', async () => {
     const executionId = 'aaa445aaa445' as ExecutionId;
     const executionConfig = config();

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -137,24 +137,35 @@ describe('assembleTrace', () => {
     });
   });
 
-  it('reports child-only associations separately from ambiguous archive roots', async () => {
-    const executionId = 'abcde2abcde2' as ExecutionId;
+  it('does not classify children-only associations as ambiguous or choose a fallback', async () => {
+    const executionId = 'aaa445aaa445' as ExecutionId;
     const executionConfig = config();
+    await getExecutionStore(executionId).writeConfig(executionConfig);
+
     const parent = 'orchestrator@model#parent' as StreamTabId;
     const firstChild = `bash@tool#${executionId}` as StreamTabId;
     const secondChild = `codex@tool#${executionId}` as StreamTabId;
-    await getExecutionStore(executionId).writeConfig(executionConfig);
-
+    const derived = getStreamTabId(
+      executionConfig.agent,
+      executionConfig.model,
+      { executionId },
+    );
     const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(firstChild, executionConfig, executionId);
+    snapshots.setRunConfig(firstChild, config({ agent: 'bash' }), executionId);
     snapshots.setParentStream(firstChild, parent);
-    snapshots.setRunConfig(secondChild, executionConfig, executionId);
+    snapshots.setRunConfig(
+      secondChild,
+      config({ agent: 'codex' }),
+      executionId,
+    );
     snapshots.setParentStream(secondChild, parent);
     await snapshots.flush();
+    await appendLogEntry(firstChild, 'first child must not be selected');
+    await appendLogEntry(secondChild, 'second child must not be selected');
+    await appendLogEntry(derived, 'derived fallback must not be selected');
 
     await expect(assembleTrace(executionId)).resolves.toEqual({
-      status: 'rootStream_missing',
-      associatedChildStreamIds: [firstChild, secondChild],
+      status: 'streamLogs_missing',
     });
   });
 

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -13,13 +13,18 @@ import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   type ExecutionId,
+  type StreamTabId,
 } from '@shared/schemas';
 import {
   cleanupTempDirs,
   createTempDirPlatform,
 } from '@test/support/tempDirPlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
-import { assembleTrace, StreamLogStore } from '@transcript';
+import {
+  assembleTrace,
+  StreamLogStore,
+  StreamSnapshotStore,
+} from '@transcript';
 
 const tempDirs: string[] = [];
 
@@ -99,6 +104,25 @@ describe('assembleTrace', () => {
     const result = await assembleTrace(executionId);
 
     expect(result).toEqual({ status: 'streamLogs_missing' });
+  });
+
+  it('reports ambiguous historical sidecars instead of selecting one for trace export', async () => {
+    const executionId = 'abcde1abcde1' as ExecutionId;
+    const executionConfig = config();
+    const first = `orchestrator@old#${executionId}` as StreamTabId;
+    const second = `orchestrator@new#${executionId}` as StreamTabId;
+    await getExecutionStore(executionId).writeConfig(executionConfig);
+
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setRunConfig(first, executionConfig, executionId);
+    snapshots.setRunConfig(second, executionConfig, executionId);
+    await snapshots.flush();
+    await appendLogEntry(first, 'First historical transcript');
+    await appendLogEntry(second, 'Second historical transcript');
+
+    await expect(assembleTrace(executionId)).resolves.toEqual({
+      status: 'streamId_ambiguous',
+    });
   });
 
   it('resolves a child stream by executionId suffix when its id does not match the derived agent@model#executionId format', async () => {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -863,7 +863,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       streamId,
       streamIds,
       candidateStreamIds,
-      associatedChildStreamIds,
+      associatedStreamIds,
       conflicts,
       hasOrderingCycle,
       hasOrderingAmbiguity,
@@ -879,7 +879,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
         resumability.resumable ||
         (streamIds?.length ?? 0) > 0 ||
         (candidateStreamIds?.length ?? 0) > 0 ||
-        (associatedChildStreamIds?.length ?? 0) > 0;
+        (associatedStreamIds?.length ?? 0) > 0;
       if (!exists) {
         throw new ToolError(`Execution not found: ${executionId}`);
       }
@@ -891,14 +891,12 @@ Delegated subagent and workflow results are delivered automatically as follow-up
             'Source: none',
             'Stream: none',
             ...(streamIds ? [`Merged streams: ${streamIds.join(', ')}`] : []),
+            ...(associatedStreamIds
+              ? [`Associated streams: ${associatedStreamIds.join(', ')}`]
+              : []),
             ...(candidateStreamIds
               ? [
                   `Ambiguous candidate streams: ${candidateStreamIds.join(', ')}`,
-                ]
-              : []),
-            ...(associatedChildStreamIds
-              ? [
-                  `Associated child streams: ${associatedChildStreamIds.join(', ')}`,
                 ]
               : []),
             ...(conflicts
@@ -929,11 +927,11 @@ Delegated subagent and workflow results are delivered automatically as follow-up
         `Source: ${source}`,
         `Stream: ${streamId ?? 'none'}`,
         ...(streamIds ? [`Merged streams: ${streamIds.join(', ')}`] : []),
+        ...(associatedStreamIds
+          ? [`Associated streams: ${associatedStreamIds.join(', ')}`]
+          : []),
         ...(candidateStreamIds
           ? [`Ambiguous candidate streams: ${candidateStreamIds.join(', ')}`]
-          : []),
-        ...(associatedChildStreamIds
-          ? [`Associated child streams: ${associatedChildStreamIds.join(', ')}`]
           : []),
         ...(conflicts
           ? [

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -870,6 +870,25 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       hasOrderingCycle,
       hasOrderingAmbiguity,
     } = conversationResult;
+    const streamDiagnostics = [
+      `Stream: ${streamId ?? 'none'}`,
+      ...(streamIds ? [`Merged streams: ${streamIds.join(', ')}`] : []),
+      ...(associatedStreamIds
+        ? [`Associated streams: ${associatedStreamIds.join(', ')}`]
+        : []),
+      ...(candidateStreamIds
+        ? [`Ambiguous candidate streams: ${candidateStreamIds.join(', ')}`]
+        : []),
+      ...(conflicts
+        ? [
+            `Conflicting row IDs: ${conflicts
+              .map(({ rowId }) => rowId)
+              .join(', ')}`,
+          ]
+        : []),
+      ...(hasOrderingCycle ? ['Ordering cycle detected: yes'] : []),
+      ...(hasOrderingAmbiguity ? ['Complete chronology established: no'] : []),
+    ];
 
     if (!conversation) {
       // Match the top-level execution lookup: a flow-only record is found only
@@ -889,27 +908,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
           totalMessages: 0,
           metadata: [
             'Source: none',
-            `Stream: ${streamId ?? 'none'}`,
-            ...(streamIds ? [`Merged streams: ${streamIds.join(', ')}`] : []),
-            ...(associatedStreamIds
-              ? [`Associated streams: ${associatedStreamIds.join(', ')}`]
-              : []),
-            ...(candidateStreamIds
-              ? [
-                  `Ambiguous candidate streams: ${candidateStreamIds.join(', ')}`,
-                ]
-              : []),
-            ...(conflicts
-              ? [
-                  `Conflicting row IDs: ${conflicts
-                    .map(({ rowId }) => rowId)
-                    .join(', ')}`,
-                ]
-              : []),
-            ...(hasOrderingCycle ? ['Ordering cycle detected: yes'] : []),
-            ...(hasOrderingAmbiguity
-              ? ['Complete chronology established: no']
-              : []),
+            ...streamDiagnostics,
             'Returned message interval: [0, 0)',
             'Next offset: none',
           ],
@@ -925,25 +924,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       totalMessages: conversation.length,
       metadata: [
         `Source: ${source}`,
-        `Stream: ${streamId ?? 'none'}`,
-        ...(streamIds ? [`Merged streams: ${streamIds.join(', ')}`] : []),
-        ...(associatedStreamIds
-          ? [`Associated streams: ${associatedStreamIds.join(', ')}`]
-          : []),
-        ...(candidateStreamIds
-          ? [`Ambiguous candidate streams: ${candidateStreamIds.join(', ')}`]
-          : []),
-        ...(conflicts
-          ? [
-              `Conflicting row IDs: ${conflicts
-                .map(({ rowId }) => rowId)
-                .join(', ')}`,
-            ]
-          : []),
-        ...(hasOrderingCycle ? ['Ordering cycle detected: yes'] : []),
-        ...(hasOrderingAmbiguity
-          ? ['Complete chronology established: no']
-          : []),
+        ...streamDiagnostics,
         `Returned message interval: [${pageStart}, ${pageEnd})`,
         `Next offset: ${pageEnd < conversation.length ? pageEnd : 'none'}`,
       ],

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -56,6 +56,7 @@ import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { requireRunStream, requireStreamId } from '@tools/contextHelpers';
 import { assertNoParentTraversal } from '@tools/pathResolution';
 import {
+  hasCompletedRunConversationEvidence,
   readCompletedRunConversation,
   readCompletedRunTodos,
   resolvePersistedStreamIdForExecution,
@@ -857,6 +858,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     limit: number,
   ): Promise<ToolResult> {
     const store = getExecutionStore(executionId);
+    const conversationResult = await readCompletedRunConversation(executionId);
     const {
       conversation,
       source,
@@ -867,7 +869,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       conflicts,
       hasOrderingCycle,
       hasOrderingAmbiguity,
-    } = await readCompletedRunConversation(executionId);
+    } = conversationResult;
 
     if (!conversation) {
       // Match the top-level execution lookup: a flow-only record is found only
@@ -877,10 +879,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       const exists =
         meta !== null ||
         resumability.resumable ||
-        streamId !== undefined ||
-        (streamIds?.length ?? 0) > 0 ||
-        (candidateStreamIds?.length ?? 0) > 0 ||
-        (associatedStreamIds?.length ?? 0) > 0;
+        hasCompletedRunConversationEvidence(conversationResult);
       if (!exists) {
         throw new ToolError(`Execution not found: ${executionId}`);
       }

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -873,7 +873,10 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       // when the shared storage decision says it is resumable.
       const meta = await store.readMeta();
       const resumability = await deriveResumability(executionId);
-      const exists = meta !== null || resumability.resumable;
+      const exists =
+        meta !== null ||
+        resumability.resumable ||
+        (candidateStreamIds?.length ?? 0) > 0;
       if (!exists) {
         throw new ToolError(`Execution not found: ${executionId}`);
       }
@@ -884,6 +887,22 @@ Delegated subagent and workflow results are delivered automatically as follow-up
           metadata: [
             'Source: none',
             'Stream: none',
+            ...(candidateStreamIds
+              ? [
+                  `Ambiguous candidate streams: ${candidateStreamIds.join(', ')}`,
+                ]
+              : []),
+            ...(conflicts
+              ? [
+                  `Conflicting row IDs: ${conflicts
+                    .map(({ rowId }) => rowId)
+                    .join(', ')}`,
+                ]
+              : []),
+            ...(hasOrderingCycle ? ['Ordering cycle detected: yes'] : []),
+            ...(hasOrderingAmbiguity
+              ? ['Complete chronology established: no']
+              : []),
             'Returned message interval: [0, 0)',
             'Next offset: none',
           ],

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -857,8 +857,16 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     limit: number,
   ): Promise<ToolResult> {
     const store = getExecutionStore(executionId);
-    const { conversation, source, streamId, streamIds } =
-      await readCompletedRunConversation(executionId);
+    const {
+      conversation,
+      source,
+      streamId,
+      streamIds,
+      candidateStreamIds,
+      conflicts,
+      hasOrderingCycle,
+      hasOrderingAmbiguity,
+    } = await readCompletedRunConversation(executionId);
 
     if (!conversation) {
       // Match the top-level execution lookup: a flow-only record is found only
@@ -893,6 +901,20 @@ Delegated subagent and workflow results are delivered automatically as follow-up
         `Source: ${source}`,
         `Stream: ${streamId ?? 'none'}`,
         ...(streamIds ? [`Merged streams: ${streamIds.join(', ')}`] : []),
+        ...(candidateStreamIds
+          ? [`Ambiguous candidate streams: ${candidateStreamIds.join(', ')}`]
+          : []),
+        ...(conflicts
+          ? [
+              `Conflicting row IDs: ${conflicts
+                .map(({ rowId }) => rowId)
+                .join(', ')}`,
+            ]
+          : []),
+        ...(hasOrderingCycle ? ['Ordering cycle detected: yes'] : []),
+        ...(hasOrderingAmbiguity
+          ? ['Complete chronology established: no']
+          : []),
         `Returned message interval: [${pageStart}, ${pageEnd})`,
         `Next offset: ${pageEnd < conversation.length ? pageEnd : 'none'}`,
       ],

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -877,6 +877,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       const exists =
         meta !== null ||
         resumability.resumable ||
+        streamId !== undefined ||
         (streamIds?.length ?? 0) > 0 ||
         (candidateStreamIds?.length ?? 0) > 0 ||
         (associatedStreamIds?.length ?? 0) > 0;
@@ -889,7 +890,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
           totalMessages: 0,
           metadata: [
             'Source: none',
-            'Stream: none',
+            `Stream: ${streamId ?? 'none'}`,
             ...(streamIds ? [`Merged streams: ${streamIds.join(', ')}`] : []),
             ...(associatedStreamIds
               ? [`Associated streams: ${associatedStreamIds.join(', ')}`]

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -876,6 +876,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       const exists =
         meta !== null ||
         resumability.resumable ||
+        (streamIds?.length ?? 0) > 0 ||
         (candidateStreamIds?.length ?? 0) > 0;
       if (!exists) {
         throw new ToolError(`Execution not found: ${executionId}`);
@@ -887,6 +888,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
           metadata: [
             'Source: none',
             'Stream: none',
+            ...(streamIds ? [`Merged streams: ${streamIds.join(', ')}`] : []),
             ...(candidateStreamIds
               ? [
                   `Ambiguous candidate streams: ${candidateStreamIds.join(', ')}`,

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -863,6 +863,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       streamId,
       streamIds,
       candidateStreamIds,
+      associatedChildStreamIds,
       conflicts,
       hasOrderingCycle,
       hasOrderingAmbiguity,
@@ -877,7 +878,8 @@ Delegated subagent and workflow results are delivered automatically as follow-up
         meta !== null ||
         resumability.resumable ||
         (streamIds?.length ?? 0) > 0 ||
-        (candidateStreamIds?.length ?? 0) > 0;
+        (candidateStreamIds?.length ?? 0) > 0 ||
+        (associatedChildStreamIds?.length ?? 0) > 0;
       if (!exists) {
         throw new ToolError(`Execution not found: ${executionId}`);
       }
@@ -892,6 +894,11 @@ Delegated subagent and workflow results are delivered automatically as follow-up
             ...(candidateStreamIds
               ? [
                   `Ambiguous candidate streams: ${candidateStreamIds.join(', ')}`,
+                ]
+              : []),
+            ...(associatedChildStreamIds
+              ? [
+                  `Associated child streams: ${associatedChildStreamIds.join(', ')}`,
                 ]
               : []),
             ...(conflicts
@@ -924,6 +931,9 @@ Delegated subagent and workflow results are delivered automatically as follow-up
         ...(streamIds ? [`Merged streams: ${streamIds.join(', ')}`] : []),
         ...(candidateStreamIds
           ? [`Ambiguous candidate streams: ${candidateStreamIds.join(', ')}`]
+          : []),
+        ...(associatedChildStreamIds
+          ? [`Associated child streams: ${associatedChildStreamIds.join(', ')}`]
           : []),
         ...(conflicts
           ? [

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -453,16 +453,30 @@ async function loadConversationStreams(
 function sharedRows(
   left: LoadedConversationStream,
   right: LoadedConversationStream,
-): { readonly overlaps: number; readonly conflictingIds: string[] } {
+): {
+  readonly overlaps: number;
+  readonly conflictingIds: string[];
+  readonly conversationConflictingIds: string[];
+} {
   let overlaps = 0;
   const conflictingIds: string[] = [];
+  const conversationConflictingIds: string[] = [];
   for (const [id, leftEntry] of left.entriesById) {
     const rightEntry = right.entriesById.get(id);
     if (!rightEntry) continue;
-    if (rowsAgree(leftEntry, rightEntry)) overlaps++;
-    else conflictingIds.push(id);
+    if (rowsAgree(leftEntry, rightEntry)) {
+      overlaps++;
+      continue;
+    }
+    conflictingIds.push(id);
+    if (
+      conversationMessagesForEntry(leftEntry).length > 0 ||
+      conversationMessagesForEntry(rightEntry).length > 0
+    ) {
+      conversationConflictingIds.push(id);
+    }
   }
-  return { overlaps, conflictingIds };
+  return { overlaps, conflictingIds, conversationConflictingIds };
 }
 
 /**
@@ -482,17 +496,18 @@ async function mergedCandidateConversation(
   const conflictStreamsById = new Map<string, Set<StreamTabId>>();
   for (const [index, left] of streams.entries()) {
     for (const right of streams.slice(index + 1)) {
-      const { overlaps, conflictingIds } = sharedRows(left, right);
-      if (conflictingIds.length > 0) {
+      const { overlaps, conflictingIds, conversationConflictingIds } =
+        sharedRows(left, right);
+      if (conversationConflictingIds.length > 0) {
         conflictingPairs.push([left.streamId, right.streamId]);
-        for (const id of conflictingIds) {
-          const conflictStreams = conflictStreamsById.get(id) ?? new Set();
-          conflictStreams.add(left.streamId);
-          conflictStreams.add(right.streamId);
-          conflictStreamsById.set(id, conflictStreams);
-        }
       }
-      if (overlaps === 0 || conflictingIds.length > 0) continue;
+      for (const id of conflictingIds) {
+        const conflictStreams = conflictStreamsById.get(id) ?? new Set();
+        conflictStreams.add(left.streamId);
+        conflictStreams.add(right.streamId);
+        conflictStreamsById.set(id, conflictStreams);
+      }
+      if (overlaps === 0 || conversationConflictingIds.length > 0) continue;
       const leftNeighbors = neighbors.get(left.streamId) ?? new Set();
       leftNeighbors.add(right.streamId);
       neighbors.set(left.streamId, leftNeighbors);

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -108,8 +108,8 @@ export interface CompletedRunConversationReadResult {
   readonly streamIds?: readonly StreamTabId[];
   /** Exact-execution sidecars excluded because persisted evidence is insufficient. */
   readonly candidateStreamIds?: readonly StreamTabId[];
-  /** Proven child sidecars associated with the run when no archive root exists. */
-  readonly associatedChildStreamIds?: readonly StreamTabId[];
+  /** Proven child associations retained as evidence but never read as archive rows. */
+  readonly associatedStreamIds?: readonly StreamTabId[];
   /** Same row ID persisted with incompatible conversation payload or state. */
   readonly conflicts?: readonly CompletedRunConversationConflict[];
   /** Overlap constraints contradicted one another. */
@@ -696,6 +696,10 @@ async function readSidecarConversation(
   // release/reopen regression proves resumed turns append there. Only
   // pre-registration resolutions scan historical candidates, so keep the
   // ordinary completed-read path constant-time.
+  const associationDiagnostics =
+    resolved.associatedStreamIds && resolved.associatedStreamIds.length > 0
+      ? { associatedStreamIds: resolved.associatedStreamIds }
+      : {};
   const exactCandidates = resolved.exactExecutionCandidateStreamIds;
   if (exactCandidates !== undefined) {
     const orderedCandidates = resolved.streamId
@@ -712,6 +716,7 @@ async function readSidecarConversation(
       resolved.streamId,
     );
     const diagnostics = {
+      ...associationDiagnostics,
       ...(resolved.streamId ? { streamId: resolved.streamId } : {}),
       ...(merged.streamIds.length > 1 ? { streamIds: merged.streamIds } : {}),
       ...(merged.candidateStreamIds.length > 0
@@ -733,17 +738,16 @@ async function readSidecarConversation(
     }
     // Exact metadata established the selected stream and candidate set. An
     // empty selected conversation falls back to the legacy projection, never
-    // to a child, disconnected candidate, or suffix-only sidecar.
-    return null;
+    // to a child, disconnected candidate, or suffix-only sidecar. Preserve
+    // child association evidence so an empty legacy fallback remains findable.
+    return resolved.associatedStreamIds?.length
+      ? { conversation: null, source: 'none', ...diagnostics }
+      : null;
   }
 
   if (!resolved.streamId) {
-    return resolved.associatedChildStreamIds
-      ? {
-          conversation: null,
-          source: 'none',
-          associatedChildStreamIds: resolved.associatedChildStreamIds,
-        }
+    return resolved.associatedStreamIds?.length
+      ? { conversation: null, source: 'none', ...associationDiagnostics }
       : null;
   }
   const primaryConversation = await conversationFromStream(
@@ -755,6 +759,7 @@ async function readSidecarConversation(
       conversation: primaryConversation,
       source: 'streamLog',
       streamId: resolved.streamId,
+      ...associationDiagnostics,
     };
   }
 
@@ -768,7 +773,12 @@ async function readSidecarConversation(
   for (const streamId of fallbackStreamIds) {
     const conversation = await conversationFromStream(streamLogStore, streamId);
     if (conversation.length > 0) {
-      return { conversation, source: 'streamLog', streamId };
+      return {
+        conversation,
+        source: 'streamLog',
+        streamId,
+        ...associationDiagnostics,
+      };
     }
   }
   return null;

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -7,6 +7,8 @@
  * before the sidecars existed. Each fact keeps exactly one legacy read arm,
  * here, tracked for D3 retirement in the #6981 ledger.
  */
+import { isDeepStrictEqual } from 'node:util';
+
 import { getExecutionStore, type TodoEntry } from '@agent/storage';
 import { mediaAttachmentKindToContentBlock } from '@agent/export/attachmentMarkerVocabulary';
 import { formatToolResultAsText } from '@agent/modelHandlers/utils/toolAttachmentUtils';
@@ -102,8 +104,21 @@ export interface CompletedRunConversationReadResult {
   readonly conversation: unknown[] | null;
   readonly source: CompletedRunConversationSource;
   readonly streamId?: StreamTabId;
-  /** All positively associated root sidecars used for a merged archive. */
+  /** All overlap-connected sidecars used for a merged archive. */
   readonly streamIds?: readonly StreamTabId[];
+  /** Exact-execution sidecars excluded because persisted evidence is insufficient. */
+  readonly candidateStreamIds?: readonly StreamTabId[];
+  /** Same row ID persisted with incompatible conversation payload or state. */
+  readonly conflicts?: readonly CompletedRunConversationConflict[];
+  /** Overlap constraints contradicted one another. */
+  readonly hasOrderingCycle?: boolean;
+  /** Overlap constraints did not establish one complete chronology. */
+  readonly hasOrderingAmbiguity?: boolean;
+}
+
+interface CompletedRunConversationConflict {
+  readonly rowId: string;
+  readonly streamIds: readonly StreamTabId[];
 }
 
 /**
@@ -389,32 +404,138 @@ async function conversationFromStream(
   return log ? streamLogEntriesToConversation(log.toJSON()) : [];
 }
 
-/**
- * Merge execution-matched root sidecars as a partial order. Each stream adds
- * its authoritative adjacent-row constraints, while equal persisted row IDs
- * identify copied overlap. Recorded time orders rows only when the combined
- * stream sequences leave both choices admissible.
- */
-async function mergedRootConversation(
+interface LoadedConversationStream {
+  readonly streamId: StreamTabId;
+  readonly entries: readonly StreamLogEntry[];
+  readonly entriesById: ReadonlyMap<string, StreamLogEntry>;
+}
+
+interface MergedConversationResult {
+  readonly conversation: unknown[];
+  readonly streamIds: readonly StreamTabId[];
+  readonly candidateStreamIds: readonly StreamTabId[];
+  readonly conflicts: readonly CompletedRunConversationConflict[];
+  readonly hasOrderingCycle: boolean;
+  readonly hasOrderingAmbiguity: boolean;
+}
+
+function conversationRowIdentity(entry: StreamLogEntry): unknown {
+  const data = isObject(entry.data) ? entry.data : undefined;
+  return {
+    type: entry.type,
+    messageType: entry.messageType,
+    text: entry.text,
+    messages: conversationMessagesForEntry(entry),
+    status: data?.status,
+    isError: data?.isError,
+  };
+}
+
+function rowsAgree(left: StreamLogEntry, right: StreamLogEntry): boolean {
+  return isDeepStrictEqual(
+    conversationRowIdentity(left),
+    conversationRowIdentity(right),
+  );
+}
+
+async function loadConversationStreams(
   streamLogStore: StreamLogStore,
   streamIds: readonly StreamTabId[],
-): Promise<unknown[]> {
-  const entriesByStream = await Promise.all(
+): Promise<LoadedConversationStream[]> {
+  return Promise.all(
     streamIds.map(async (streamId) => {
       await streamLogStore.ensureLoaded(streamId);
-      return streamLogStore.get(streamId)?.toJSON() ?? [];
+      const entries = streamLogStore.get(streamId)?.toJSON() ?? [];
+      return {
+        streamId,
+        entries,
+        entriesById: new Map(entries.map((entry) => [entry.id, entry])),
+      };
     }),
   );
-  const nodes = new Map<
-    string,
-    { readonly entry: StreamLogEntry; readonly streamIndex: number }
-  >();
+}
+
+function sharedRows(
+  left: LoadedConversationStream,
+  right: LoadedConversationStream,
+): { readonly overlaps: number; readonly conflictingIds: string[] } {
+  let overlaps = 0;
+  const conflictingIds: string[] = [];
+  for (const [id, leftEntry] of left.entriesById) {
+    const rightEntry = right.entriesById.get(id);
+    if (!rightEntry) continue;
+    if (rowsAgree(leftEntry, rightEntry)) overlaps++;
+    else conflictingIds.push(id);
+  }
+  return { overlaps, conflictingIds };
+}
+
+/**
+ * Merge only the exact-execution sidecars connected to the selected stream by
+ * validated copied row IDs. Stream-local adjacency supplies every ordering
+ * edge; neither clocks nor per-stream sequence numbers order disjoint rows.
+ */
+async function mergedCandidateConversation(
+  streamLogStore: StreamLogStore,
+  streamIds: readonly StreamTabId[],
+): Promise<MergedConversationResult> {
+  const streams = await loadConversationStreams(streamLogStore, streamIds);
+  const neighbors = new Map<StreamTabId, Set<StreamTabId>>();
+  const conflictStreamsById = new Map<string, Set<StreamTabId>>();
+  for (const [index, left] of streams.entries()) {
+    for (const right of streams.slice(index + 1)) {
+      const { overlaps, conflictingIds } = sharedRows(left, right);
+      for (const id of conflictingIds) {
+        const conflictStreams = conflictStreamsById.get(id) ?? new Set();
+        conflictStreams.add(left.streamId);
+        conflictStreams.add(right.streamId);
+        conflictStreamsById.set(id, conflictStreams);
+      }
+      if (overlaps === 0 || conflictingIds.length > 0) continue;
+      const leftNeighbors = neighbors.get(left.streamId) ?? new Set();
+      leftNeighbors.add(right.streamId);
+      neighbors.set(left.streamId, leftNeighbors);
+      const rightNeighbors = neighbors.get(right.streamId) ?? new Set();
+      rightNeighbors.add(left.streamId);
+      neighbors.set(right.streamId, rightNeighbors);
+    }
+  }
+
+  const selected = streams[0];
+  if (!selected) {
+    return {
+      conversation: [],
+      streamIds: [],
+      candidateStreamIds: [],
+      conflicts: [],
+      hasOrderingCycle: false,
+      hasOrderingAmbiguity: false,
+    };
+  }
+  const connectedIds = new Set<StreamTabId>([selected.streamId]);
+  const queue = [selected.streamId];
+  for (const streamId of queue) {
+    for (const neighbor of neighbors.get(streamId) ?? []) {
+      if (connectedIds.has(neighbor)) continue;
+      connectedIds.add(neighbor);
+      queue.push(neighbor);
+    }
+  }
+  const connected = streams.filter(({ streamId }) =>
+    connectedIds.has(streamId),
+  );
+  const connectedConflict = [...conflictStreamsById.values()].some(
+    (conflictStreams) =>
+      [...conflictStreams].filter((id) => connectedIds.has(id)).length > 1,
+  );
+  const mergeStreams = connectedConflict ? [selected] : connected;
+  const nodes = new Map<string, StreamLogEntry>();
   const successors = new Map<string, Set<string>>();
   const indegrees = new Map<string, number>();
-  for (const [streamIndex, entries] of entriesByStream.entries()) {
+  for (const { entries } of mergeStreams) {
     let previousId: string | undefined;
     for (const entry of entries) {
-      if (!nodes.has(entry.id)) nodes.set(entry.id, { entry, streamIndex });
+      if (!nodes.has(entry.id)) nodes.set(entry.id, entry);
       if (!indegrees.has(entry.id)) indegrees.set(entry.id, 0);
       if (previousId && previousId !== entry.id) {
         const nextIds = successors.get(previousId) ?? new Set<string>();
@@ -433,31 +554,18 @@ async function mergedRootConversation(
     [...remaining].filter((id) => (indegrees.get(id) ?? 0) === 0),
   );
   const ordered: StreamLogEntry[] = [];
+  let hasOrderingCycle = false;
+  let hasOrderingAmbiguity = false;
   while (remaining.size > 0) {
-    // Contradictory copied-row orders form a cycle. Such persisted data cannot
-    // satisfy every stream; choose deterministically so archive reads remain
-    // available while preserving every compatible constraint.
-    const candidates = ready.size > 0 ? ready : remaining;
-    let nextId: string | undefined;
-    for (const id of candidates) {
-      const candidate = nodes.get(id);
-      const next = nextId ? nodes.get(nextId) : undefined;
-      if (
-        candidate &&
-        (!next ||
-          candidate.entry.timestamp < next.entry.timestamp ||
-          (candidate.entry.timestamp === next.entry.timestamp &&
-            (candidate.streamIndex < next.streamIndex ||
-              (candidate.streamIndex === next.streamIndex &&
-                candidate.entry.seqNo < next.entry.seqNo))))
-      ) {
-        nextId = id;
-      }
+    if (ready.size === 0) {
+      hasOrderingCycle = true;
+      break;
     }
-    if (!nextId) break;
+    if (ready.size > 1) hasOrderingAmbiguity = true;
+    const nextId = ready.values().next().value as string;
     const next = nodes.get(nextId);
     if (!next) break;
-    ordered.push(next.entry);
+    ordered.push(next);
     ready.delete(nextId);
     remaining.delete(nextId);
     for (const successorId of successors.get(nextId) ?? []) {
@@ -466,7 +574,26 @@ async function mergedRootConversation(
       if (indegree === 0 && remaining.has(successorId)) ready.add(successorId);
     }
   }
-  return streamLogEntriesToConversation(ordered);
+
+  const mergeTrusted =
+    !connectedConflict && !hasOrderingCycle && !hasOrderingAmbiguity;
+  const usedStreams = mergeTrusted ? mergeStreams : [selected];
+  const conversation = mergeTrusted
+    ? streamLogEntriesToConversation(ordered)
+    : streamLogEntriesToConversation(selected.entries);
+  const usedIds = new Set(usedStreams.map(({ streamId }) => streamId));
+  return {
+    conversation,
+    streamIds: usedStreams.map(({ streamId }) => streamId),
+    candidateStreamIds: streams
+      .map(({ streamId }) => streamId)
+      .filter((streamId) => !usedIds.has(streamId)),
+    conflicts: [...conflictStreamsById]
+      .map(([rowId, ids]) => ({ rowId, streamIds: [...ids] }))
+      .toSorted((left, right) => left.rowId.localeCompare(right.rowId)),
+    hasOrderingCycle,
+    hasOrderingAmbiguity,
+  };
 }
 
 /**
@@ -482,29 +609,35 @@ async function readSidecarConversation(
 ): Promise<CompletedRunConversationReadResult | null> {
   // Current executions register one canonical stream at birth; a disk-backed
   // release/reopen regression proves resumed turns append there. Only
-  // pre-registration resolutions can represent historical split sidecars, so
-  // keep the ordinary completed-read path constant-time.
-  const rootStreamIds = resolved.associatedRootStreamIds;
-  if (rootStreamIds !== undefined) {
-    const orderedRoots = [
-      ...(rootStreamIds.includes(resolved.streamId) ? [resolved.streamId] : []),
-      ...rootStreamIds.filter((streamId) => streamId !== resolved.streamId),
+  // pre-registration resolutions scan historical candidates, so keep the
+  // ordinary completed-read path constant-time.
+  const exactCandidates = resolved.exactExecutionCandidateStreamIds;
+  if (exactCandidates !== undefined) {
+    const orderedCandidates = [
+      resolved.streamId,
+      ...exactCandidates.filter((streamId) => streamId !== resolved.streamId),
     ];
-    const conversation = await mergedRootConversation(
+    const merged = await mergedCandidateConversation(
       streamLogStore,
-      orderedRoots,
+      orderedCandidates,
     );
-    if (conversation.length > 0) {
+    if (merged.conversation.length > 0) {
       return {
-        conversation,
+        conversation: merged.conversation,
         source: 'streamLog',
-        streamId: orderedRoots[0],
-        ...(orderedRoots.length > 1 ? { streamIds: orderedRoots } : {}),
+        streamId: resolved.streamId,
+        ...(merged.streamIds.length > 1 ? { streamIds: merged.streamIds } : {}),
+        ...(merged.candidateStreamIds.length > 0
+          ? { candidateStreamIds: merged.candidateStreamIds }
+          : {}),
+        ...(merged.conflicts.length > 0 ? { conflicts: merged.conflicts } : {}),
+        ...(merged.hasOrderingCycle ? { hasOrderingCycle: true } : {}),
+        ...(merged.hasOrderingAmbiguity ? { hasOrderingAmbiguity: true } : {}),
       };
     }
-    // Exact metadata established the canonical root set. An empty root
-    // conversation must fall back to the legacy execution projection, never
-    // to a child or suffix-only sidecar.
+    // Exact metadata established the selected stream and candidate set. An
+    // empty selected conversation falls back to the legacy projection, never
+    // to a child, disconnected candidate, or suffix-only sidecar.
     return null;
   }
 

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -550,16 +550,35 @@ async function mergedCandidateConversation(
   if (connectedConflict) mergeStreams = selected ? [selected] : [];
   const allNodes = new Map<string, StreamLogEntry>();
   const rowSuccessors = new Map<string, Set<string>>();
-  for (const { entries } of mergeStreams) {
-    let previousId: string | undefined;
+  // Persisted IDs identify conflict diagnostics, but only complete agreeing rows
+  // represent the same ordering node. Keep incompatible copies stream-qualified.
+  const rowVariantsById = new Map<
+    string,
+    { readonly graphId: string; readonly entry: StreamLogEntry }[]
+  >();
+  for (const { streamId, entries } of mergeStreams) {
+    let previousGraphId: string | undefined;
     for (const entry of entries) {
-      if (!allNodes.has(entry.id)) allNodes.set(entry.id, entry);
-      if (previousId && previousId !== entry.id) {
-        const nextIds = rowSuccessors.get(previousId) ?? new Set<string>();
-        nextIds.add(entry.id);
-        rowSuccessors.set(previousId, nextIds);
+      const variants = rowVariantsById.get(entry.id) ?? [];
+      const matchingVariant = variants.find((variant) =>
+        rowsAgree(variant.entry, entry),
+      );
+      const graphId =
+        matchingVariant?.graphId ??
+        (variants.length === 0
+          ? entry.id
+          : `${entry.id}\0${streamId}\0${variants.length}`);
+      if (!matchingVariant) {
+        variants.push({ graphId, entry });
+        rowVariantsById.set(entry.id, variants);
+        allNodes.set(graphId, entry);
       }
-      previousId = entry.id;
+      if (previousGraphId && previousGraphId !== graphId) {
+        const nextIds = rowSuccessors.get(previousGraphId) ?? new Set<string>();
+        nextIds.add(graphId);
+        rowSuccessors.set(previousGraphId, nextIds);
+      }
+      previousGraphId = graphId;
     }
   }
 

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -419,22 +419,17 @@ interface MergedConversationResult {
   readonly hasOrderingAmbiguity: boolean;
 }
 
-function conversationRowIdentity(entry: StreamLogEntry): unknown {
-  const data = isObject(entry.data) ? entry.data : undefined;
-  return {
-    type: entry.type,
-    messageType: entry.messageType,
-    text: entry.text,
-    messages: conversationMessagesForEntry(entry),
-    status: data?.status,
-    isError: data?.isError,
-  };
-}
-
 function rowsAgree(left: StreamLogEntry, right: StreamLogEntry): boolean {
-  return isDeepStrictEqual(
-    conversationRowIdentity(left),
-    conversationRowIdentity(right),
+  return (
+    left.id === right.id &&
+    left.type === right.type &&
+    left.level === right.level &&
+    left.timestamp === right.timestamp &&
+    left.groupId === right.groupId &&
+    left.messageType === right.messageType &&
+    left.text === right.text &&
+    left.verbose === right.verbose &&
+    isDeepStrictEqual(left.data, right.data)
   );
 }
 

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -79,7 +79,7 @@ export async function readCompletedRunTodos(
   });
 
   if (
-    resolved &&
+    resolved?.streamId &&
     (await snapshotStore.hasPersistedWorkPlan(resolved.streamId))
   ) {
     const snapshot = await snapshotStore.read(resolved.streamId);
@@ -466,13 +466,15 @@ function sharedRows(
 }
 
 /**
- * Merge only the exact-execution sidecars connected to the selected stream by
- * validated copied row IDs. Stream-local adjacency supplies every ordering
- * edge; neither clocks nor per-stream sequence numbers order disjoint rows.
+ * Merge exact-execution sidecars connected by validated copied row IDs. When
+ * no canonical stream is proven, every candidate must join the same component.
+ * Stream-local adjacency supplies ordering; neither clocks nor per-stream
+ * sequence numbers order disjoint rows.
  */
 async function mergedCandidateConversation(
   streamLogStore: StreamLogStore,
   streamIds: readonly StreamTabId[],
+  selectedStreamId?: StreamTabId,
 ): Promise<MergedConversationResult> {
   const streams = await loadConversationStreams(streamLogStore, streamIds);
   const neighbors = new Map<StreamTabId, Set<StreamTabId>>();
@@ -500,8 +502,11 @@ async function mergedCandidateConversation(
     }
   }
 
-  const selected = streams[0];
-  if (!selected) {
+  const selected = selectedStreamId
+    ? streams.find(({ streamId }) => streamId === selectedStreamId)
+    : undefined;
+  const overlapAnchor = selected ?? streams[0];
+  if (!overlapAnchor) {
     return {
       conversation: [],
       streamIds: [],
@@ -511,8 +516,8 @@ async function mergedCandidateConversation(
       hasOrderingAmbiguity: false,
     };
   }
-  const connectedIds = new Set<StreamTabId>([selected.streamId]);
-  const queue = [selected.streamId];
+  const connectedIds = new Set<StreamTabId>([overlapAnchor.streamId]);
+  const queue = [overlapAnchor.streamId];
   for (const streamId of queue) {
     for (const neighbor of neighbors.get(streamId) ?? []) {
       if (connectedIds.has(neighbor)) continue;
@@ -526,30 +531,53 @@ async function mergedCandidateConversation(
   const connectedConflict = conflictingPairs.some(
     ([left, right]) => connectedIds.has(left) && connectedIds.has(right),
   );
-  const mergeStreams = connectedConflict ? [selected] : connected;
-  const nodes = new Map<string, StreamLogEntry>();
-  const successors = new Map<string, Set<string>>();
-  const indegrees = new Map<string, number>();
+  let mergeStreams = connected;
+  if (connectedConflict) mergeStreams = selected ? [selected] : [];
+  const allNodes = new Map<string, StreamLogEntry>();
+  const rowSuccessors = new Map<string, Set<string>>();
   for (const { entries } of mergeStreams) {
-    // The endpoint promises conversation chronology. Status, statistics, and
-    // other display-only rows are projected away, so independent placement of
-    // those rows cannot make the resulting message order ambiguous.
-    const conversationEntries = entries.filter(
-      (entry) => conversationMessagesForEntry(entry).length > 0,
-    );
     let previousId: string | undefined;
-    for (const entry of conversationEntries) {
-      if (!nodes.has(entry.id)) nodes.set(entry.id, entry);
-      if (!indegrees.has(entry.id)) indegrees.set(entry.id, 0);
+    for (const entry of entries) {
+      if (!allNodes.has(entry.id)) allNodes.set(entry.id, entry);
       if (previousId && previousId !== entry.id) {
-        const nextIds = successors.get(previousId) ?? new Set<string>();
-        if (!nextIds.has(entry.id)) {
-          nextIds.add(entry.id);
-          successors.set(previousId, nextIds);
-          indegrees.set(entry.id, (indegrees.get(entry.id) ?? 0) + 1);
-        }
+        const nextIds = rowSuccessors.get(previousId) ?? new Set<string>();
+        nextIds.add(entry.id);
+        rowSuccessors.set(previousId, nextIds);
       }
       previousId = entry.id;
+    }
+  }
+
+  // Diagnostic rows still prove copied-row overlap and carry payload conflicts,
+  // but they do not produce archived messages. Contract paths through them so
+  // they can preserve A < diagnostic < B without creating false branch choices
+  // when two sidecars persisted different STATISTICS/PROGRESS rows between the
+  // same conversation turns.
+  const nodes = new Map(
+    [...allNodes].filter(
+      ([, entry]) =>
+        entry.type === STREAM_LOG_ENTRY_TYPES.LOG &&
+        conversationMessagesForEntry(entry).length > 0,
+    ),
+  );
+  const successors = new Map<string, Set<string>>();
+  const indegrees = new Map([...nodes.keys()].map((id) => [id, 0]));
+  for (const sourceId of nodes.keys()) {
+    const pending = [...(rowSuccessors.get(sourceId) ?? [])];
+    const visitedDiagnostics = new Set<string>();
+    for (const successorId of pending) {
+      if (nodes.has(successorId)) {
+        const nextIds = successors.get(sourceId) ?? new Set<string>();
+        if (!nextIds.has(successorId)) {
+          nextIds.add(successorId);
+          successors.set(sourceId, nextIds);
+          indegrees.set(successorId, (indegrees.get(successorId) ?? 0) + 1);
+        }
+        continue;
+      }
+      if (visitedDiagnostics.has(successorId)) continue;
+      visitedDiagnostics.add(successorId);
+      pending.push(...(rowSuccessors.get(successorId) ?? []));
     }
   }
 
@@ -580,11 +608,19 @@ async function mergedCandidateConversation(
   }
 
   const mergeTrusted =
-    !connectedConflict && !hasOrderingCycle && !hasOrderingAmbiguity;
-  const usedStreams = mergeTrusted ? mergeStreams : [selected];
-  const conversation = mergeTrusted
-    ? streamLogEntriesToConversation(ordered)
-    : streamLogEntriesToConversation(selected.entries);
+    !connectedConflict &&
+    !hasOrderingCycle &&
+    !hasOrderingAmbiguity &&
+    (selected !== undefined || connected.length === streams.length);
+  let usedStreams: LoadedConversationStream[] = [];
+  let conversation: unknown[] = [];
+  if (mergeTrusted) {
+    usedStreams = mergeStreams;
+    conversation = streamLogEntriesToConversation(ordered);
+  } else if (selected) {
+    usedStreams = [selected];
+    conversation = streamLogEntriesToConversation(selected.entries);
+  }
   const usedIds = new Set(usedStreams.map(({ streamId }) => streamId));
   const streamOrder = new Map(
     streams.map(({ streamId }, index) => [streamId, index]),
@@ -626,43 +662,22 @@ async function readSidecarConversation(
   // ordinary completed-read path constant-time.
   const exactCandidates = resolved.exactExecutionCandidateStreamIds;
   if (exactCandidates !== undefined) {
-    const orderedCandidates = [
-      resolved.streamId,
-      ...exactCandidates.filter((streamId) => streamId !== resolved.streamId),
-    ];
+    const orderedCandidates = resolved.streamId
+      ? [
+          resolved.streamId,
+          ...exactCandidates.filter(
+            (streamId) => streamId !== resolved.streamId,
+          ),
+        ]
+      : exactCandidates;
     const merged = await mergedCandidateConversation(
       streamLogStore,
       orderedCandidates,
+      resolved.streamId,
     );
-    if (merged.conversation.length > 0) {
-      return {
-        conversation: merged.conversation,
-        source: 'streamLog',
-        streamId: resolved.streamId,
-        ...(merged.streamIds.length > 1 ? { streamIds: merged.streamIds } : {}),
-        ...(merged.candidateStreamIds.length > 0
-          ? { candidateStreamIds: merged.candidateStreamIds }
-          : {}),
-        ...(merged.conflicts.length > 0 ? { conflicts: merged.conflicts } : {}),
-        ...(merged.hasOrderingCycle ? { hasOrderingCycle: true } : {}),
-        ...(merged.hasOrderingAmbiguity ? { hasOrderingAmbiguity: true } : {}),
-      };
-    }
-    // Exact metadata established the selected stream and candidate set. An
-    // empty selected conversation falls back to the legacy projection, never
-    // to a child, disconnected candidate, or suffix-only sidecar. Retain the
-    // archive diagnostics so the fallback is not mistaken for a complete
-    // sidecar chronology.
-    const hasDiagnostics =
-      merged.candidateStreamIds.length > 0 ||
-      merged.conflicts.length > 0 ||
-      merged.hasOrderingCycle ||
-      merged.hasOrderingAmbiguity;
-    if (!hasDiagnostics) return null;
-    return {
-      conversation: null,
-      source: 'none',
-      streamId: resolved.streamId,
+    const diagnostics = {
+      ...(resolved.streamId ? { streamId: resolved.streamId } : {}),
+      ...(merged.streamIds.length > 1 ? { streamIds: merged.streamIds } : {}),
       ...(merged.candidateStreamIds.length > 0
         ? { candidateStreamIds: merged.candidateStreamIds }
         : {}),
@@ -670,8 +685,23 @@ async function readSidecarConversation(
       ...(merged.hasOrderingCycle ? { hasOrderingCycle: true } : {}),
       ...(merged.hasOrderingAmbiguity ? { hasOrderingAmbiguity: true } : {}),
     };
+    if (merged.conversation.length > 0) {
+      return {
+        conversation: merged.conversation,
+        source: 'streamLog',
+        ...diagnostics,
+      };
+    }
+    if (!resolved.streamId && exactCandidates.length > 1) {
+      return { conversation: null, source: 'none', ...diagnostics };
+    }
+    // Exact metadata established the selected stream and candidate set. An
+    // empty selected conversation falls back to the legacy projection, never
+    // to a child, disconnected candidate, or suffix-only sidecar.
+    return null;
   }
 
+  if (!resolved.streamId) return null;
   const primaryConversation = await conversationFromStream(
     streamLogStore,
     resolved.streamId,
@@ -723,22 +753,31 @@ export async function readCompletedRunConversation(
     streamLogStore,
   });
 
-  const sidecar = resolved
-    ? await readSidecarConversation(
-        executionId,
-        resolved,
-        snapshotStore,
-        streamLogStore,
-      )
-    : null;
-  if (sidecar?.conversation) return sidecar;
-
   // Legacy `conversation.json`; `null` when missing or empty.
-  const legacy = await getExecutionStore(executionId).readConversation();
+  const tryLegacy =
+    async (): Promise<CompletedRunConversationReadResult | null> => {
+      const conversation =
+        await getExecutionStore(executionId).readConversation();
+      return conversation ? { conversation, source: 'legacyKV' } : null;
+    };
+  const trySidecar =
+    async (): Promise<CompletedRunConversationReadResult | null> =>
+      resolved
+        ? readSidecarConversation(
+            executionId,
+            resolved,
+            snapshotStore,
+            streamLogStore,
+          )
+        : null;
+
+  const sidecar = await trySidecar();
+  if (sidecar?.conversation) return sidecar;
+  const legacy = await tryLegacy();
   if (legacy) {
     return sidecar
-      ? { ...sidecar, conversation: legacy, source: 'legacyKV' }
-      : { conversation: legacy, source: 'legacyKV' };
+      ? { ...sidecar, conversation: legacy.conversation, source: 'legacyKV' }
+      : legacy;
   }
   return sidecar ?? { conversation: null, source: 'none' };
 }

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -655,8 +655,26 @@ async function readSidecarConversation(
     }
     // Exact metadata established the selected stream and candidate set. An
     // empty selected conversation falls back to the legacy projection, never
-    // to a child, disconnected candidate, or suffix-only sidecar.
-    return null;
+    // to a child, disconnected candidate, or suffix-only sidecar. Retain the
+    // archive diagnostics so the fallback is not mistaken for a complete
+    // sidecar chronology.
+    const hasDiagnostics =
+      merged.candidateStreamIds.length > 0 ||
+      merged.conflicts.length > 0 ||
+      merged.hasOrderingCycle ||
+      merged.hasOrderingAmbiguity;
+    if (!hasDiagnostics) return null;
+    return {
+      conversation: null,
+      source: 'none',
+      streamId: resolved.streamId,
+      ...(merged.candidateStreamIds.length > 0
+        ? { candidateStreamIds: merged.candidateStreamIds }
+        : {}),
+      ...(merged.conflicts.length > 0 ? { conflicts: merged.conflicts } : {}),
+      ...(merged.hasOrderingCycle ? { hasOrderingCycle: true } : {}),
+      ...(merged.hasOrderingAmbiguity ? { hasOrderingAmbiguity: true } : {}),
+    };
   }
 
   const primaryConversation = await conversationFromStream(
@@ -710,27 +728,22 @@ export async function readCompletedRunConversation(
     streamLogStore,
   });
 
-  // Legacy `conversation.json`; `null` when missing or empty.
-  const tryLegacy =
-    async (): Promise<CompletedRunConversationReadResult | null> => {
-      const conversation =
-        await getExecutionStore(executionId).readConversation();
-      return conversation ? { conversation, source: 'legacyKV' } : null;
-    };
-  const trySidecar =
-    async (): Promise<CompletedRunConversationReadResult | null> =>
-      resolved
-        ? readSidecarConversation(
-            executionId,
-            resolved,
-            snapshotStore,
-            streamLogStore,
-          )
-        : null;
+  const sidecar = resolved
+    ? await readSidecarConversation(
+        executionId,
+        resolved,
+        snapshotStore,
+        streamLogStore,
+      )
+    : null;
+  if (sidecar?.conversation) return sidecar;
 
-  for (const arm of [trySidecar, tryLegacy]) {
-    const result = await arm();
-    if (result) return result;
+  // Legacy `conversation.json`; `null` when missing or empty.
+  const legacy = await getExecutionStore(executionId).readConversation();
+  if (legacy) {
+    return sidecar
+      ? { ...sidecar, conversation: legacy, source: 'legacyKV' }
+      : { conversation: legacy, source: 'legacyKV' };
   }
-  return { conversation: null, source: 'none' };
+  return sidecar ?? { conversation: null, source: 'none' };
 }

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -536,8 +536,14 @@ async function mergedCandidateConversation(
   const successors = new Map<string, Set<string>>();
   const indegrees = new Map<string, number>();
   for (const { entries } of mergeStreams) {
+    // The endpoint promises conversation chronology. Status, statistics, and
+    // other display-only rows are projected away, so independent placement of
+    // those rows cannot make the resulting message order ambiguous.
+    const conversationEntries = entries.filter(
+      (entry) => conversationMessagesForEntry(entry).length > 0,
+    );
     let previousId: string | undefined;
-    for (const entry of entries) {
+    for (const entry of conversationEntries) {
       if (!nodes.has(entry.id)) nodes.set(entry.id, entry);
       if (!indegrees.has(entry.id)) indegrees.set(entry.id, 0);
       if (previousId && previousId !== entry.id) {

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -830,7 +830,21 @@ export async function readCompletedRunConversation(
   const legacy = await tryLegacy();
   if (legacy) {
     return sidecar
-      ? { ...sidecar, conversation: legacy.conversation, source: 'legacyKV' }
+      ? {
+          conversation: legacy.conversation,
+          source: 'legacyKV',
+          ...(sidecar.candidateStreamIds
+            ? { candidateStreamIds: sidecar.candidateStreamIds }
+            : {}),
+          ...(sidecar.associatedStreamIds
+            ? { associatedStreamIds: sidecar.associatedStreamIds }
+            : {}),
+          ...(sidecar.conflicts ? { conflicts: sidecar.conflicts } : {}),
+          ...(sidecar.hasOrderingCycle ? { hasOrderingCycle: true } : {}),
+          ...(sidecar.hasOrderingAmbiguity
+            ? { hasOrderingAmbiguity: true }
+            : {}),
+        }
       : legacy;
   }
   return sidecar ?? { conversation: null, source: 'none' };

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -733,16 +733,11 @@ async function readSidecarConversation(
         ...diagnostics,
       };
     }
-    if (!resolved.streamId && exactCandidates.length > 1) {
-      return { conversation: null, source: 'none', ...diagnostics };
-    }
     // Exact metadata established the selected stream and candidate set. An
     // empty selected conversation falls back to the legacy projection, never
     // to a child, disconnected candidate, or suffix-only sidecar. Preserve
-    // child association evidence so an empty legacy fallback remains findable.
-    return resolved.associatedStreamIds?.length
-      ? { conversation: null, source: 'none', ...diagnostics }
-      : null;
+    // the association diagnostics so every persisted root remains findable.
+    return { conversation: null, source: 'none', ...diagnostics };
   }
 
   if (!resolved.streamId) {

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -118,6 +118,19 @@ export interface CompletedRunConversationReadResult {
   readonly hasOrderingAmbiguity?: boolean;
 }
 
+/** Whether completed-run storage proves a conversation or transcript association exists. */
+export function hasCompletedRunConversationEvidence(
+  result: CompletedRunConversationReadResult,
+): boolean {
+  return (
+    (result.conversation?.length ?? 0) > 0 ||
+    result.streamId !== undefined ||
+    (result.streamIds?.length ?? 0) > 0 ||
+    (result.candidateStreamIds?.length ?? 0) > 0 ||
+    (result.associatedStreamIds?.length ?? 0) > 0
+  );
+}
+
 interface CompletedRunConversationConflict {
   readonly rowId: string;
   readonly streamIds: readonly StreamTabId[];

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -108,6 +108,8 @@ export interface CompletedRunConversationReadResult {
   readonly streamIds?: readonly StreamTabId[];
   /** Exact-execution sidecars excluded because persisted evidence is insufficient. */
   readonly candidateStreamIds?: readonly StreamTabId[];
+  /** Proven child sidecars associated with the run when no archive root exists. */
+  readonly associatedChildStreamIds?: readonly StreamTabId[];
   /** Same row ID persisted with incompatible conversation payload or state. */
   readonly conflicts?: readonly CompletedRunConversationConflict[];
   /** Overlap constraints contradicted one another. */
@@ -735,7 +737,15 @@ async function readSidecarConversation(
     return null;
   }
 
-  if (!resolved.streamId) return null;
+  if (!resolved.streamId) {
+    return resolved.associatedChildStreamIds
+      ? {
+          conversation: null,
+          source: 'none',
+          associatedChildStreamIds: resolved.associatedChildStreamIds,
+        }
+      : null;
+  }
   const primaryConversation = await conversationFromStream(
     streamLogStore,
     resolved.streamId,

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -481,15 +481,19 @@ async function mergedCandidateConversation(
 ): Promise<MergedConversationResult> {
   const streams = await loadConversationStreams(streamLogStore, streamIds);
   const neighbors = new Map<StreamTabId, Set<StreamTabId>>();
+  const conflictingPairs: [StreamTabId, StreamTabId][] = [];
   const conflictStreamsById = new Map<string, Set<StreamTabId>>();
   for (const [index, left] of streams.entries()) {
     for (const right of streams.slice(index + 1)) {
       const { overlaps, conflictingIds } = sharedRows(left, right);
-      for (const id of conflictingIds) {
-        const conflictStreams = conflictStreamsById.get(id) ?? new Set();
-        conflictStreams.add(left.streamId);
-        conflictStreams.add(right.streamId);
-        conflictStreamsById.set(id, conflictStreams);
+      if (conflictingIds.length > 0) {
+        conflictingPairs.push([left.streamId, right.streamId]);
+        for (const id of conflictingIds) {
+          const conflictStreams = conflictStreamsById.get(id) ?? new Set();
+          conflictStreams.add(left.streamId);
+          conflictStreams.add(right.streamId);
+          conflictStreamsById.set(id, conflictStreams);
+        }
       }
       if (overlaps === 0 || conflictingIds.length > 0) continue;
       const leftNeighbors = neighbors.get(left.streamId) ?? new Set();
@@ -524,9 +528,8 @@ async function mergedCandidateConversation(
   const connected = streams.filter(({ streamId }) =>
     connectedIds.has(streamId),
   );
-  const connectedConflict = [...conflictStreamsById.values()].some(
-    (conflictStreams) =>
-      [...conflictStreams].filter((id) => connectedIds.has(id)).length > 1,
+  const connectedConflict = conflictingPairs.some(
+    ([left, right]) => connectedIds.has(left) && connectedIds.has(right),
   );
   const mergeStreams = connectedConflict ? [selected] : connected;
   const nodes = new Map<string, StreamLogEntry>();
@@ -582,6 +585,9 @@ async function mergedCandidateConversation(
     ? streamLogEntriesToConversation(ordered)
     : streamLogEntriesToConversation(selected.entries);
   const usedIds = new Set(usedStreams.map(({ streamId }) => streamId));
+  const streamOrder = new Map(
+    streams.map(({ streamId }, index) => [streamId, index]),
+  );
   return {
     conversation,
     streamIds: usedStreams.map(({ streamId }) => streamId),
@@ -589,7 +595,13 @@ async function mergedCandidateConversation(
       .map(({ streamId }) => streamId)
       .filter((streamId) => !usedIds.has(streamId)),
     conflicts: [...conflictStreamsById]
-      .map(([rowId, ids]) => ({ rowId, streamIds: [...ids] }))
+      .map(([rowId, ids]) => ({
+        rowId,
+        streamIds: [...ids].toSorted(
+          (left, right) =>
+            (streamOrder.get(left) ?? 0) - (streamOrder.get(right) ?? 0),
+        ),
+      }))
       .toSorted((left, right) => left.rowId.localeCompare(right.rowId)),
     hasOrderingCycle,
     hasOrderingAmbiguity,

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -22,6 +22,8 @@ export interface PersistedStreamIdResolution {
   readonly fallbackStreamIds?: readonly StreamTabId[];
   /** Exact-execution sidecars eligible for overlap-gated archive merging. */
   readonly exactExecutionCandidateStreamIds?: readonly StreamTabId[];
+  /** Proven child sidecars associated with the run when no archive root exists. */
+  readonly associatedChildStreamIds?: readonly StreamTabId[];
 }
 
 export interface PersistedStreamIdResolverOptions {
@@ -181,7 +183,7 @@ export async function resolvePersistedStreamIdForExecution(
           ? {
               exactExecutionCandidateStreamIds: mergeCandidateMetaMatched,
             }
-          : {}),
+          : { associatedChildStreamIds: metaMatched }),
       };
     }
     const suffixMatched = findExecutionSuffixMatches(

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -125,13 +125,17 @@ export async function findPersistedStreamFallbacksForExecution(
   options: PersistedStreamIdResolverOptions = {},
 ): Promise<StreamTabId[]> {
   const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
-  const { persistedStreams, metaMatched } =
+  const { persistedStreams, mergeCandidateMetaMatched, childMetaMatched } =
     await scanPersistedStreamsForExecution(executionId, snapshotStore);
+  const excludedChildren = new Set(childMetaMatched);
   const suffixMatched = findExecutionSuffixMatches(
     [...persistedStreams, ...(options.streamLogStore?.keys() ?? [])],
     executionId,
-  );
-  return orderedFallbacks(primary, [...metaMatched, ...suffixMatched]);
+  ).filter((candidate) => !excludedChildren.has(candidate));
+  return orderedFallbacks(primary, [
+    ...mergeCandidateMetaMatched,
+    ...suffixMatched,
+  ]);
 }
 
 /**

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -19,8 +19,8 @@ export interface PersistedStreamIdResolution {
   readonly source: PersistedStreamIdResolutionSource;
   /** Other persisted candidates to try when a historical primary is empty. */
   readonly fallbackStreamIds?: readonly StreamTabId[];
-  /** Exact execution matches with no persisted parent, for archive merging. */
-  readonly associatedRootStreamIds?: readonly StreamTabId[];
+  /** Exact-execution sidecars eligible for overlap-gated archive merging. */
+  readonly exactExecutionCandidateStreamIds?: readonly StreamTabId[];
 }
 
 export interface PersistedStreamIdResolverOptions {
@@ -42,8 +42,8 @@ interface ExecutionStreamScan {
   readonly persistedStreams: StreamTabId[];
   /** Persisted streams whose sidecar `meta.json` claims this execution. */
   readonly metaMatched: StreamTabId[];
-  /** Exact execution matches that are not recorded as child streams. */
-  readonly rootMetaMatched: StreamTabId[];
+  /** Exact execution matches not positively identified as child streams. */
+  readonly mergeCandidateMetaMatched: StreamTabId[];
 }
 
 /**
@@ -69,7 +69,7 @@ async function scanPersistedStreamsForExecution(
     metaMatched: scanned
       .filter((candidate) => candidate.association.executionId === executionId)
       .map((candidate) => candidate.streamId),
-    rootMetaMatched: scanned
+    mergeCandidateMetaMatched: scanned
       .filter(
         (candidate) =>
           candidate.association.executionId === executionId &&
@@ -175,12 +175,14 @@ export async function resolvePersistedStreamIdForExecution(
   }
 
   const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
-  const { persistedStreams, metaMatched, rootMetaMatched } =
+  const { persistedStreams, metaMatched, mergeCandidateMetaMatched } =
     await scanPersistedStreamsForExecution(executionId, snapshotStore);
 
   if (metaMatched.length > 0) {
     const primaryCandidates =
-      rootMetaMatched.length > 0 ? rootMetaMatched : metaMatched;
+      mergeCandidateMetaMatched.length > 0
+        ? mergeCandidateMetaMatched
+        : metaMatched;
     const streamId = await pickBestLegacyMetaMatch(
       primaryCandidates,
       snapshotStore,
@@ -201,8 +203,10 @@ export async function resolvePersistedStreamIdForExecution(
       streamId,
       source: 'streamDataMeta',
       ...(fallbackStreamIds.length > 0 ? { fallbackStreamIds } : {}),
-      ...(rootMetaMatched.length > 0
-        ? { associatedRootStreamIds: rootMetaMatched }
+      ...(mergeCandidateMetaMatched.length > 0
+        ? {
+            exactExecutionCandidateStreamIds: mergeCandidateMetaMatched,
+          }
         : {}),
     };
   }

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -22,8 +22,8 @@ export interface PersistedStreamIdResolution {
   readonly fallbackStreamIds?: readonly StreamTabId[];
   /** Exact-execution sidecars eligible for overlap-gated archive merging. */
   readonly exactExecutionCandidateStreamIds?: readonly StreamTabId[];
-  /** Proven child sidecars associated with the run when no archive root exists. */
-  readonly associatedChildStreamIds?: readonly StreamTabId[];
+  /** Proven child associations excluded from archive ownership and row reads. */
+  readonly associatedStreamIds?: readonly StreamTabId[];
 }
 
 export interface PersistedStreamIdResolverOptions {
@@ -47,6 +47,8 @@ interface ExecutionStreamScan {
   readonly metaMatched: StreamTabId[];
   /** Exact execution matches not positively identified as child streams. */
   readonly mergeCandidateMetaMatched: StreamTabId[];
+  /** Exact execution matches positively identified as child streams. */
+  readonly childMetaMatched: StreamTabId[];
 }
 
 /**
@@ -77,6 +79,14 @@ async function scanPersistedStreamsForExecution(
         (candidate) =>
           candidate.association.executionId === executionId &&
           candidate.association.parentStreamId === undefined,
+      )
+      .map((candidate) => candidate.streamId)
+      .toSorted(),
+    childMetaMatched: scanned
+      .filter(
+        (candidate) =>
+          candidate.association.executionId === executionId &&
+          candidate.association.parentStreamId !== undefined,
       )
       .map((candidate) => candidate.streamId)
       .toSorted(),
@@ -154,8 +164,12 @@ export async function resolvePersistedStreamIdForExecution(
   }
 
   const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
-  const { persistedStreams, metaMatched, mergeCandidateMetaMatched } =
-    await scanPersistedStreamsForExecution(executionId, snapshotStore);
+  const {
+    persistedStreams,
+    metaMatched,
+    mergeCandidateMetaMatched,
+    childMetaMatched,
+  } = await scanPersistedStreamsForExecution(executionId, snapshotStore);
 
   if (metaMatched.length > 0) {
     // A sole delegated stream can itself be the historical execution being
@@ -169,6 +183,9 @@ export async function resolvePersistedStreamIdForExecution(
       mergeCandidateMetaMatched.length === 1
         ? mergeCandidateMetaMatched[0]
         : soleDelegatedStream;
+    const associatedStreamIds = childMetaMatched.filter(
+      (candidate) => candidate !== streamId,
+    );
     if (metaMatched.length === 1 && streamId) {
       await writeLegacyExecutionStreamId(executionId, streamId);
     }
@@ -183,15 +200,17 @@ export async function resolvePersistedStreamIdForExecution(
           ? {
               exactExecutionCandidateStreamIds: mergeCandidateMetaMatched,
             }
-          : { associatedChildStreamIds: metaMatched }),
+          : {}),
+        ...(associatedStreamIds.length > 0 ? { associatedStreamIds } : {}),
       };
     }
+    const excludedChildren = new Set(associatedStreamIds);
     const suffixMatched = findExecutionSuffixMatches(
       [...persistedStreams, ...(options.streamLogStore?.keys() ?? [])],
       executionId,
-    );
+    ).filter((candidate) => !excludedChildren.has(candidate));
     const fallbackStreamIds = orderedFallbacks(streamId, [
-      ...metaMatched,
+      ...mergeCandidateMetaMatched,
       ...suffixMatched,
     ]);
     return {
@@ -203,6 +222,7 @@ export async function resolvePersistedStreamIdForExecution(
             exactExecutionCandidateStreamIds: mergeCandidateMetaMatched,
           }
         : {}),
+      ...(associatedStreamIds.length > 0 ? { associatedStreamIds } : {}),
     };
   }
 

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -15,7 +15,8 @@ type PersistedStreamIdResolutionSource =
   'executionMeta' | 'streamDataMeta' | 'streamDataSuffix' | 'streamLogsSuffix';
 
 export interface PersistedStreamIdResolution {
-  readonly streamId: StreamTabId;
+  /** Canonical stream when registration or persisted evidence proves one. */
+  readonly streamId?: StreamTabId;
   readonly source: PersistedStreamIdResolutionSource;
   /** Other persisted candidates to try when a historical primary is empty. */
   readonly fallbackStreamIds?: readonly StreamTabId[];
@@ -89,34 +90,6 @@ function findExecutionSuffixMatches(
   return streams.filter((id) => id.endsWith(suffix));
 }
 
-/** Choose the data-bearing primary for an ambiguous historical record. */
-async function pickBestLegacyMetaMatch(
-  candidates: readonly StreamTabId[],
-  snapshotStore: StreamSnapshotStore,
-  streamLogStore: Pick<StreamLogStore, 'has'> | undefined,
-): Promise<StreamTabId> {
-  if (candidates.length === 1) return candidates[0];
-
-  const withData = await pMap(
-    candidates,
-    async (streamId) => {
-      const hasLog = streamLogStore?.has(streamId) ?? false;
-      return {
-        streamId,
-        hasLog,
-        hasWorkPlan:
-          hasLog || (await snapshotStore.hasPersistedWorkPlan(streamId)),
-      };
-    },
-    { concurrency: META_SCAN_CONCURRENCY },
-  );
-  return (
-    withData.find((entry) => entry.hasLog)?.streamId ??
-    withData.find((entry) => entry.hasWorkPlan)?.streamId ??
-    candidates[0]
-  );
-}
-
 function orderedFallbacks(
   primary: StreamTabId,
   candidates: readonly StreamTabId[],
@@ -159,8 +132,10 @@ export async function findPersistedStreamFallbacksForExecution(
  * remain subject to the bounded scan because a later resume can add another
  * root sidecar. Only birth-time registrations use the constant-time path.
  *
- * `null` means no persisted stream carries this execution. Callers that have
- * a derivable stream id own that substitution.
+ * `null` means no persisted stream carries this execution. A resolution with
+ * no `streamId` exposes exact-execution candidates whose canonical owner is
+ * unproven; callers must not substitute one of them. Callers that receive
+ * `null` and have a derivable stream id own that compatibility substitution.
  */
 export async function resolvePersistedStreamIdForExecution(
   executionId: ExecutionId,
@@ -183,13 +158,19 @@ export async function resolvePersistedStreamIdForExecution(
       mergeCandidateMetaMatched.length > 0
         ? mergeCandidateMetaMatched
         : metaMatched;
-    const streamId = await pickBestLegacyMetaMatch(
-      primaryCandidates,
-      snapshotStore,
-      options.streamLogStore,
-    );
-    if (metaMatched.length === 1) {
+    const streamId =
+      primaryCandidates.length === 1 ? primaryCandidates[0] : undefined;
+    if (metaMatched.length === 1 && streamId) {
       await writeLegacyExecutionStreamId(executionId, streamId);
+    }
+    if (!streamId) {
+      // Exact execution metadata associates every candidate with this run, but
+      // missing parent metadata does not prove which one owns the archive.
+      // Data presence and lexical order are not canonical-ownership evidence.
+      return {
+        source: 'streamDataMeta',
+        exactExecutionCandidateStreamIds: primaryCandidates,
+      };
     }
     const suffixMatched = findExecutionSuffixMatches(
       [...persistedStreams, ...(options.streamLogStore?.keys() ?? [])],

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -133,9 +133,11 @@ export async function findPersistedStreamFallbacksForExecution(
  * root sidecar. Only birth-time registrations use the constant-time path.
  *
  * `null` means no persisted stream carries this execution. A resolution with
- * no `streamId` exposes exact-execution candidates whose canonical owner is
- * unproven; callers must not substitute one of them. Callers that receive
- * `null` and have a derivable stream id own that compatibility substitution.
+ * no `streamId` means persisted associations exist but prove no canonical
+ * archive root; when unproven roots exist, they are exposed as exact-execution
+ * candidates. Callers must not substitute a candidate or proven child.
+ * Callers that receive `null` and have a derivable stream id own that
+ * compatibility substitution.
  */
 export async function resolvePersistedStreamIdForExecution(
   executionId: ExecutionId,
@@ -154,22 +156,32 @@ export async function resolvePersistedStreamIdForExecution(
     await scanPersistedStreamsForExecution(executionId, snapshotStore);
 
   if (metaMatched.length > 0) {
-    const primaryCandidates =
-      mergeCandidateMetaMatched.length > 0
-        ? mergeCandidateMetaMatched
-        : metaMatched;
+    // A sole delegated stream can itself be the historical execution being
+    // resolved. Several proven children, however, are not competing archive
+    // roots and must never enter overlap-gated merging.
+    const soleDelegatedStream =
+      mergeCandidateMetaMatched.length === 0 && metaMatched.length === 1
+        ? metaMatched[0]
+        : undefined;
     const streamId =
-      primaryCandidates.length === 1 ? primaryCandidates[0] : undefined;
+      mergeCandidateMetaMatched.length === 1
+        ? mergeCandidateMetaMatched[0]
+        : soleDelegatedStream;
     if (metaMatched.length === 1 && streamId) {
       await writeLegacyExecutionStreamId(executionId, streamId);
     }
     if (!streamId) {
-      // Exact execution metadata associates every candidate with this run, but
-      // missing parent metadata does not prove which one owns the archive.
-      // Data presence and lexical order are not canonical-ownership evidence.
+      // Exact execution metadata associates every root candidate with this
+      // run, but missing parent metadata does not prove which root owns the
+      // archive. Data presence and lexical order are not canonical-ownership
+      // evidence. When every match is a proven child there are no candidates.
       return {
         source: 'streamDataMeta',
-        exactExecutionCandidateStreamIds: primaryCandidates,
+        ...(mergeCandidateMetaMatched.length > 0
+          ? {
+              exactExecutionCandidateStreamIds: mergeCandidateMetaMatched,
+            }
+          : {}),
       };
     }
     const suffixMatched = findExecutionSuffixMatches(

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -22,6 +22,7 @@ export { StreamSnapshotStore } from './StreamSnapshotStore';
 export { assembleTrace, type AssembleTraceResult } from './traceAssembler';
 export type { TraceDocument } from './traceDocumentSchema';
 export {
+  hasCompletedRunConversationEvidence,
   readCompletedRunConversation,
   readCompletedRunTodos,
   seedResumedConversationSidecar,

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -11,7 +11,7 @@
  */
 import { getExecutionStore } from '@agent/storage';
 import { getStreamTabId } from '@agent/runtime/streamTab';
-import type { ExecutionId } from '@shared/schemas';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { runOutcomeToExecutionStatus } from '@shared/streams/streamStatus';
 
 import { StreamLogStore } from './StreamLogStore';
@@ -21,9 +21,10 @@ import type { TraceDocument } from './traceDocumentSchema';
 
 export type AssembleTraceResult =
   | { readonly status: 'ok'; readonly trace: TraceDocument }
+  | { readonly status: 'config_missing' | 'streamLogs_missing' }
   | {
-      readonly status:
-        'config_missing' | 'streamId_ambiguous' | 'streamLogs_missing';
+      readonly status: 'streamId_ambiguous';
+      readonly candidateStreamIds: readonly StreamTabId[];
     };
 
 /**
@@ -58,10 +59,12 @@ export async function assembleTrace(
     streamLogStore,
   });
   if (resolved && !resolved.streamId) {
-    return { status: 'streamId_ambiguous' };
+    return {
+      status: 'streamId_ambiguous',
+      candidateStreamIds: resolved.exactExecutionCandidateStreamIds ?? [],
+    };
   }
   const streamId = resolved?.streamId ?? fallbackStreamId;
-  if (!streamId) return { status: 'streamLogs_missing' };
 
   const [, snapshot] = await Promise.all([
     streamLogStore.ensureLoaded(streamId),

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -49,13 +49,12 @@ export async function assembleTrace(
   // One call-scoped snapshot store serves both the resolver's sidecar scan and
   // the snapshot read, so the two share its per-stream KV handles.
   const snapshotStore = new StreamSnapshotStore();
-  const streamId =
-    (
-      await resolvePersistedStreamIdForExecution(executionId, {
-        snapshotStore,
-        streamLogStore,
-      })
-    )?.streamId ?? fallbackStreamId;
+  const resolved = await resolvePersistedStreamIdForExecution(executionId, {
+    snapshotStore,
+    streamLogStore,
+  });
+  const streamId = resolved ? resolved.streamId : fallbackStreamId;
+  if (!streamId) return { status: 'streamLogs_missing' };
 
   const [, snapshot] = await Promise.all([
     streamLogStore.ensureLoaded(streamId),

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -46,11 +46,6 @@ export async function assembleTrace(
     executionStore.readConfig(),
     executionStore.readMeta(),
   ]);
-  if (!config) return { status: 'config_missing' };
-
-  const fallbackStreamId = getStreamTabId(config.agent, config.model, {
-    executionId,
-  });
   // One call-scoped snapshot store serves both the resolver's sidecar scan and
   // the snapshot read, so the two share its per-stream KV handles.
   const snapshotStore = new StreamSnapshotStore();
@@ -64,6 +59,10 @@ export async function assembleTrace(
       ? { status: 'streamId_ambiguous', candidateStreamIds }
       : { status: 'streamLogs_missing' };
   }
+  if (!config) return { status: 'config_missing' };
+  const fallbackStreamId = getStreamTabId(config.agent, config.model, {
+    executionId,
+  });
   const streamId = resolved?.streamId ?? fallbackStreamId;
 
   const [, snapshot] = await Promise.all([

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -25,20 +25,15 @@ export type AssembleTraceResult =
   | {
       readonly status: 'streamId_ambiguous';
       readonly candidateStreamIds: readonly StreamTabId[];
-    }
-  | {
-      readonly status: 'rootStream_missing';
-      readonly associatedChildStreamIds: readonly StreamTabId[];
     };
 
 /**
- * `streamId_ambiguous` means several historical root sidecars claim the
- * execution, but persisted evidence does not identify one as canonical.
- * `rootStream_missing` means only proven child sidecars remain. By contrast,
- * `streamLogs_missing` is the expected outcome for executions recorded before
- * the headless-persistence fix (TeXRA#7057), when no replayable transcript was
- * written. Callers should surface both distinctions rather than reporting a
- * generic "not found".
+ * `streamId_ambiguous` means several unproven archive roots claim the
+ * execution, but persisted evidence does not identify one as canonical. By
+ * contrast, `streamLogs_missing` means no replayable execution-root timeline
+ * is available, either because the run predates transcript persistence or
+ * because its only exact associations are proven children. Callers should
+ * surface both distinctions rather than reporting a generic "not found".
  */
 export async function assembleTrace(
   executionId: ExecutionId,
@@ -64,16 +59,10 @@ export async function assembleTrace(
     streamLogStore,
   });
   if (resolved && !resolved.streamId) {
-    if (resolved.associatedChildStreamIds) {
-      return {
-        status: 'rootStream_missing',
-        associatedChildStreamIds: resolved.associatedChildStreamIds,
-      };
-    }
-    return {
-      status: 'streamId_ambiguous',
-      candidateStreamIds: resolved.exactExecutionCandidateStreamIds ?? [],
-    };
+    const candidateStreamIds = resolved.exactExecutionCandidateStreamIds ?? [];
+    return candidateStreamIds.length > 0
+      ? { status: 'streamId_ambiguous', candidateStreamIds }
+      : { status: 'streamLogs_missing' };
   }
   const streamId = resolved?.streamId ?? fallbackStreamId;
 

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -25,11 +25,16 @@ export type AssembleTraceResult =
   | {
       readonly status: 'streamId_ambiguous';
       readonly candidateStreamIds: readonly StreamTabId[];
+    }
+  | {
+      readonly status: 'rootStream_missing';
+      readonly associatedChildStreamIds: readonly StreamTabId[];
     };
 
 /**
- * `streamId_ambiguous` means several historical sidecars claim the execution,
- * but persisted evidence does not identify one as canonical. By contrast,
+ * `streamId_ambiguous` means several historical root sidecars claim the
+ * execution, but persisted evidence does not identify one as canonical.
+ * `rootStream_missing` means only proven child sidecars remain. By contrast,
  * `streamLogs_missing` is the expected outcome for executions recorded before
  * the headless-persistence fix (TeXRA#7057), when no replayable transcript was
  * written. Callers should surface both distinctions rather than reporting a
@@ -59,6 +64,12 @@ export async function assembleTrace(
     streamLogStore,
   });
   if (resolved && !resolved.streamId) {
+    if (resolved.associatedChildStreamIds) {
+      return {
+        status: 'rootStream_missing',
+        associatedChildStreamIds: resolved.associatedChildStreamIds,
+      };
+    }
     return {
       status: 'streamId_ambiguous',
       candidateStreamIds: resolved.exactExecutionCandidateStreamIds ?? [],

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -21,14 +21,18 @@ import type { TraceDocument } from './traceDocumentSchema';
 
 export type AssembleTraceResult =
   | { readonly status: 'ok'; readonly trace: TraceDocument }
-  | { readonly status: 'config_missing' | 'streamLogs_missing' };
+  | {
+      readonly status:
+        'config_missing' | 'streamId_ambiguous' | 'streamLogs_missing';
+    };
 
 /**
- * `streamLogs_missing` is the expected outcome for any execution recorded
- * before the headless-persistence fix (TeXRA#7057) — headless runs before
- * that fix never wrote a `streamLogs` file at all, so there is nothing here
- * to replay faithfully. Callers should surface that distinction rather than
- * a generic "not found".
+ * `streamId_ambiguous` means several historical sidecars claim the execution,
+ * but persisted evidence does not identify one as canonical. By contrast,
+ * `streamLogs_missing` is the expected outcome for executions recorded before
+ * the headless-persistence fix (TeXRA#7057), when no replayable transcript was
+ * written. Callers should surface both distinctions rather than reporting a
+ * generic "not found".
  */
 export async function assembleTrace(
   executionId: ExecutionId,
@@ -53,7 +57,10 @@ export async function assembleTrace(
     snapshotStore,
     streamLogStore,
   });
-  const streamId = resolved ? resolved.streamId : fallbackStreamId;
+  if (resolved && !resolved.streamId) {
+    return { status: 'streamId_ambiguous' };
+  }
+  const streamId = resolved?.streamId ?? fallbackStreamId;
   if (!streamId) return { status: 'streamLogs_missing' };
 
   const [, snapshot] = await Promise.all([


### PR DESCRIPTION
## Summary

Corrective follow-up to #9573 for reopened #9533.

- merge historical conversation sidecars only when exact-execution candidates are connected by validated copied row IDs
- determine chronology on conversation-producing rows, contracting diagnostic-only paths so divergent STATISTICS/PROGRESS rows cannot suppress a uniquely ordered continuation
- compare complete persisted row semantics before treating copied IDs as overlap evidence
- expose multiple unproven historical candidates without inventing a canonical owner from lexical order, log presence, or work-plan presence
- return a merged archive only when all unproven candidates form one conflict-free, uniquely ordered component; otherwise preserve candidate/conflict/order diagnostics and use legacy KV when available
- preserve registration-proven and sole-candidate resolution, legacy streamData/streamLogs suffix fallbacks, explicit-child exclusion, current same-stream resume behavior, and message pagination
- report candidate-only trace ownership as `streamId_ambiguous` (with candidate IDs) rather than `streamLogs_missing`, and never substitute a derived raw timeline when exact sidecar ownership is unresolved
- treat overlap-connected diagnostic-only sidecars as execution evidence even when the reconstructed conversation is empty
- retain proven child associations separately as `associatedStreamIds`: they establish execution existence but are never exposed as archive roots, candidates, merged streams, or canonical owners, and their rows are never read into the parent conversation
- classify children-only trace archives as `streamLogs_missing` (no replayable execution-root transcript), without selecting either a child or the derived fallback and without emitting empty-candidate ambiguity
- count root, merged, candidate, and child-association transcript diagnostics as existence evidence in `texra history show`, so candidate-only archives are not reported as missing
- exclude proven children from registration-root fallback scans, so an empty canonical root can use legacy KV but can never expose a child conversation
- centralize host-neutral completed-run evidence detection across chat-export loading, `ExecutionsTool`, and CLI history; candidate-only and children-only markdown exports are incomplete rather than not found
- preserve the selected `streamId` for sole diagnostic-only roots so archive reads, execution tooling, and CLI details retain exact ownership evidence

## Evidence boundary

Exact `executionId` metadata proves execution association, and a present `parentStreamId` proves a child. Proven children remain association/existence evidence only: they are excluded from root selection, candidate lists, merging, and row reads. Historical artifacts do not provide a cross-stream turn ordinal or reliable chronology for disjoint sidecars; wall clocks, stream-local sequence numbers, lexical IDs, and data presence therefore do not authorize canonical ownership. Copied rows with complete persisted semantic equality are the overlap evidence used for merging.

Diagnostic rows still participate in overlap and conflict checks, but chronology trust is projected onto conversation-producing rows. This preserves ordering constraints through copied diagnostics without treating independently persisted status/usage rows as conversation branches.

## Validation

At pushed head `0f4957f0d7ab9867e173bd183f3cc0398c885a17`:

- affected archive/resolver/trace/export/ExecutionsTool/CLI suites: **206 passed across 16 files**
- workspace typecheck: passed
- test-kernel typecheck: passed
- CLI typecheck: passed
- extension typecheck: passed
- changed-file ESLint: passed
- changed-file Prettier check: passed
- `git diff --check`: passed

Disk-backed coverage includes divergent diagnostic branches with and without reconvergence, incompatible diagnostic copies around a shared conversation row, diagnostic-only connected archives, candidate-only trace resolution with a populated derived fallback that must not be selected, stable pagination diagnostics, disjoint unproven candidates, legacy-KV fallback with retained candidates, complete copied-row conflicts, cycles, acyclic ambiguity, transitive overlap, current registration, sole candidates, child exclusion, children-only existence diagnostics, children-only trace refusal without derived fallback or empty-candidate CLI text, registration-root fallback refusal when only a child has conversation rows, candidate-only and children-only markdown export evidence, sole diagnostic-only exact-root ownership in archive/tool/CLI details, and legacy suffix fallbacks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core historical transcript resolution, merge logic, and export/history “found vs missing” behavior across CLI, extension, and execution APIs; incorrect merging or evidence rules could mis-attribute conversations or block valid exports.
> 
> **Overview**
> Tightens how completed runs resolve **multiple historical transcript sidecars** so the system no longer picks a “best” root from log presence, work plans, or lexical order.
> 
> **Transcript archive (`completedRunArchive`, `executionStreamResolver`)** merges exact-execution candidates only when they connect via **fully agreeing copied row IDs**; conflicts, ordering cycles, or disconnected candidates yield **no merged conversation** while still exposing `candidateStreamIds`, `associatedStreamIds` (proven children), and conflict/order diagnostics. Legacy KV conversation can still win when sidecars are empty or unproven. **`hasCompletedRunConversationEvidence`** centralizes “this execution id has transcript-related storage” for export and history.
> 
> **Trace export (`assembleTrace`)** adds **`streamId_ambiguous`** when several unproven roots exist and refuses a derived fallback timeline; **children-only** associations map to **`streamLogs_missing`** instead of ambiguity.
> 
> **CLI, extension, and `ExecutionsTool`** align on the new outcomes: richer HTML export errors, markdown export **incomplete vs not found** when only sidecar evidence exists, and conversation tooling that surfaces merge/ambiguity metadata without reading child rows into the parent archive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f4957f0d7ab9867e173bd183f3cc0398c885a17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


















