### PR TITLE
Extract shared agent-CLI loop and media classification logic

### DIFF
--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -68,11 +68,16 @@ import {
 } from '../contextManagementConstants';
 import { AnthropicStreamHandler } from '../support/AnthropicStreamHandler';
 import { AUXILIARY_MAX_RETRIES } from '../support/auxiliaryRetry';
+import {
+  classifyMediaEntry,
+  unknownMediaCategoryWarning,
+} from '../support/mediaClassification';
 import { toAnthropicTools } from '../toolConversion';
 import {
   describeAttachments,
   formatAttachmentSummaryFromNotes,
   formatToolResultAsText,
+  uploadAndRecordToolAttachments,
   wipeBuffer,
 } from '../utils/toolAttachmentUtils';
 import { tagAnthropicSdkError } from './anthropicSdkError';
@@ -1104,81 +1109,83 @@ export class ModelHandlerAnthropic extends ModelHandler<
       `Creating media content for ${mediaMessage.length} items for Anthropic`,
     );
     return mediaMessage.flatMap((media): ContentBlockParam[] => {
-      if (media.media_category === 'image') {
-        // Always ensure media_type exists.
-        const originalMediaType = media.media_type;
-        let resolvedMediaType = originalMediaType;
-        if (!resolvedMediaType) {
-          // Default to image/png since PDFs from TikZ are converted to PNG
-          this.logger.warn(
-            `No media_type found for image ${media.file_name}, defaulting to image/png`,
-          );
-          resolvedMediaType = 'image/png';
-        }
+      const classification = classifyMediaEntry(media);
 
-        // Check for native PDF support
-        const isPdf =
-          this.capabilities.supportsNativePdf &&
-          originalMediaType === 'application/pdf';
-        const descriptionBlock = {
-          type: 'text',
-          text: `${isPdf ? 'Document' : 'Image'}: ${media.file_name}`,
-          citations: null,
-        } satisfies TextBlockParam;
-
-        if (isPdf) {
-          const documentBlock = {
-            type: 'document',
-            source: {
-              type: 'base64',
-              media_type: 'application/pdf',
-              data: media.data,
-            },
-            title: media.file_name,
-          } satisfies BetaRequestDocumentBlock;
-          return [descriptionBlock, documentBlock];
-        }
-
-        let imageMediaType: Base64ImageSource['media_type'];
-        if (isSupportedImageMediaType(resolvedMediaType)) {
-          imageMediaType = resolvedMediaType;
-        } else {
-          if (resolvedMediaType !== 'image/png') {
-            this.logger.warn(
-              'Unsupported image media type, defaulting to image/png',
-              {
-                data: {
-                  mediaType: resolvedMediaType,
-                  fileName: media.file_name,
-                },
-              },
-            );
-          }
-          imageMediaType = 'image/png';
-        }
-
-        const imageBlock = {
-          type: 'image',
-          source: {
-            type: 'base64',
-            media_type: imageMediaType,
-            data: media.data,
-          },
-        } satisfies BetaImageBlockParam;
-
-        return [descriptionBlock, imageBlock];
-      } else if (media.media_category === 'audio') {
+      if (classification === 'audio') {
         // Anthropic doesn't explicitly support native audio input yet
         this.logger.warn(
           `Audio input received (${media.file_name}) but native audio is not currently supported by the Anthropic handler. Skipping.`,
         );
         return []; // Return empty array to skip audio
-      } else {
-        this.logger.warn(
-          `Unknown media category for Anthropic: ${media.media_category}`,
-        );
+      }
+
+      if (classification === 'unsupported') {
+        this.logger.warn(unknownMediaCategoryWarning(media));
         return [];
       }
+
+      // classification is 'image' or 'pdf' - for backward compatibility,
+      // always ensure media_type exists
+      const originalMediaType = media.media_type;
+      let resolvedMediaType = originalMediaType;
+      if (!resolvedMediaType) {
+        // Default to image/png since PDFs from TikZ are converted to PNG
+        this.logger.warn(
+          `No media_type found for image ${media.file_name}, defaulting to image/png`,
+        );
+        resolvedMediaType = 'image/png';
+      }
+
+      // Check for native PDF support
+      const isPdf =
+        classification === 'pdf' && this.capabilities.supportsNativePdf;
+      const descriptionBlock = {
+        type: 'text',
+        text: `${isPdf ? 'Document' : 'Image'}: ${media.file_name}`,
+        citations: null,
+      } satisfies TextBlockParam;
+
+      if (isPdf) {
+        const documentBlock = {
+          type: 'document',
+          source: {
+            type: 'base64',
+            media_type: 'application/pdf',
+            data: media.data,
+          },
+          title: media.file_name,
+        } satisfies BetaRequestDocumentBlock;
+        return [descriptionBlock, documentBlock];
+      }
+
+      let imageMediaType: Base64ImageSource['media_type'];
+      if (isSupportedImageMediaType(resolvedMediaType)) {
+        imageMediaType = resolvedMediaType;
+      } else {
+        if (resolvedMediaType !== 'image/png') {
+          this.logger.warn(
+            'Unsupported image media type, defaulting to image/png',
+            {
+              data: {
+                mediaType: resolvedMediaType,
+                fileName: media.file_name,
+              },
+            },
+          );
+        }
+        imageMediaType = 'image/png';
+      }
+
+      const imageBlock = {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: imageMediaType,
+          data: media.data,
+        },
+      } satisfies BetaImageBlockParam;
+
+      return [descriptionBlock, imageBlock];
     });
   }
 
@@ -1609,46 +1616,33 @@ export class ModelHandlerAnthropic extends ModelHandler<
     attachments: ToolFileAttachment[],
   ): Promise<ContentBlockParam> {
     // Result is already sanitized by source - use the passed attachments
-    // Create mutable copy with explicit type to avoid type assertions later
-    const sanitizedResult: ToolResult = { ...result };
-    const canUploadFiles = this.supportsToolResultFileUpload;
+    const canUpload =
+      this.supportsToolResultFileUpload && attachments.length > 0;
 
-    let uploadedAttachments: UploadedAnthropicAttachment[] = [];
-    const unsupportedAttachments: ToolFileAttachment[] = [];
-    const pageLimitExceeded: ToolFileAttachment[] = [];
-
-    if (canUploadFiles && attachments.length > 0) {
-      // This upload occurs while assembling the next turn, outside the model
-      // invocation gate. Restore the SDK's ordinary two retries for this
-      // auxiliary request; generation requests keep maxRetries: 0.
-      const uploadResult = await uploadToolAttachments(
-        client.withOptions({ maxRetries: AUXILIARY_MAX_RETRIES }),
-        attachments,
-        this.logger,
-        this.getTrackedPdfPageCount(),
-        (fileId, pageCount) =>
-          this.uploadedPdfPageCounts.set(fileId, pageCount),
-        this.getMaxPdfPages(),
+    // This upload occurs while assembling the next turn, outside the model
+    // invocation gate. Restore the SDK's ordinary two retries for this
+    // auxiliary request; generation requests keep maxRetries: 0.
+    const { finalResult: sanitizedResult, uploadResult } =
+      await uploadAndRecordToolAttachments(result, canUpload, () =>
+        uploadToolAttachments(
+          client.withOptions({ maxRetries: AUXILIARY_MAX_RETRIES }),
+          attachments,
+          this.logger,
+          this.getTrackedPdfPageCount(),
+          (fileId, pageCount) =>
+            this.uploadedPdfPageCounts.set(fileId, pageCount),
+          this.getMaxPdfPages(),
+        ),
       );
-      uploadedAttachments = uploadResult.uploaded;
-      unsupportedAttachments.push(...uploadResult.unsupported);
-      pageLimitExceeded.push(...uploadResult.pageLimitExceeded);
 
-      if (
-        sanitizedResult.status === 'executed' &&
-        uploadedAttachments.length > 0
-      ) {
-        // Store uploaded file info with fileId (Anthropic-specific extension)
-        // Type assertion needed because FileReference doesn't include fileId
-        sanitizedResult.files = uploadedAttachments.map(
-          ({ attachment, fileId }) => ({
-            path: attachment.path,
-            mimeType: attachment.mimeType,
-            description: attachment.description,
-            fileId, // Anthropic-specific: retained for potential future reference
-          }),
-        ) as typeof sanitizedResult.files;
-      }
+    const uploadedAttachments: UploadedAnthropicAttachment[] =
+      uploadResult?.uploaded ?? [];
+    const unsupportedAttachments: ToolFileAttachment[] = [];
+    const pageLimitExceeded: ToolFileAttachment[] =
+      uploadResult?.pageLimitExceeded ?? [];
+
+    if (canUpload) {
+      unsupportedAttachments.push(...(uploadResult?.unsupported ?? []));
     } else if (attachments.length > 0) {
       unsupportedAttachments.push(...attachments);
     }

--- a/src/agent/modelHandlers/openai/BaseReasoningStreamAggregator.ts
+++ b/src/agent/modelHandlers/openai/BaseReasoningStreamAggregator.ts
@@ -1,4 +1,4 @@
-import { ToolCallAccumulator } from '../utils/toolCallAccumulator';
+import { ChannelStreamAggregator } from '../utils/channelStreamAggregator';
 import type {
   ChatCompletion,
   ChatCompletionChunk,
@@ -21,23 +21,19 @@ type ChatCompletionMessageWithReasoning = ChatCompletionMessage & {
  * Base class for streaming aggregators that support reasoning models.
  * Used by DeepSeek, Kimi, and other OpenAI-compatible reasoning models.
  */
-export class BaseReasoningStreamAggregator implements StreamingAggregator {
-  private readonly contentParts: string[] = [];
-  private readonly reasoningParts: string[] = [];
-  private readonly toolCalls = new ToolCallAccumulator();
+export class BaseReasoningStreamAggregator
+  extends ChannelStreamAggregator
+  implements StreamingAggregator
+{
   private lastChunkWithChoices: ChatCompletionChunk | undefined;
   private usageChunk: ChatCompletionChunk | undefined;
 
   appendContent(delta: string): void {
-    if (delta) {
-      this.contentParts.push(delta);
-    }
+    this.pushContent(delta);
   }
 
   appendReasoning(delta: string): void {
-    if (delta) {
-      this.reasoningParts.push(delta);
-    }
+    this.pushReasoning(delta);
   }
 
   consumeChunk(chunk: ChatCompletionChunk): void {
@@ -120,14 +116,6 @@ export class BaseReasoningStreamAggregator implements StreamingAggregator {
       choices: [mergedChoice],
       usage: usage ?? undefined,
     };
-  }
-
-  getFullContent(): string {
-    return this.contentParts.join('');
-  }
-
-  getFullReasoning(): string {
-    return this.reasoningParts.join('');
   }
 
   private buildToolCalls(): ChatCompletionMessageFunctionToolCall[] {

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -47,6 +47,10 @@ import { getConfig } from '@utils/config/configUtils';
 import { AUXILIARY_MAX_RETRIES } from '../support/auxiliaryRetry';
 import { toDataUrl } from '../support/dataUrl';
 import {
+  classifyMediaEntry,
+  unknownMediaCategoryWarning,
+} from '../support/mediaClassification';
+import {
   getDeclaredMaxReasoningEffort,
   toOpenAIReasoningEffort,
 } from '../support/reasoningEffort';
@@ -825,10 +829,15 @@ export class ModelHandlerOpenAI<
   /** Formats image/audio content for OpenAI/Google's vision/audio API. */
   createMediaContent(mediaMessage: MediaEntry[]): ChatCompletionContentPart[] {
     return mediaMessage.flatMap((media): ChatCompletionContentPart[] => {
-      if (media.media_category === 'image') {
+      const classification = classifyMediaEntry(media);
+
+      // This handler has no PDF-specific rendering; treat a classified PDF
+      // the same as any other image, matching the prior media_category-only
+      // check.
+      if (classification === 'image' || classification === 'pdf') {
         return this.buildStandardVisionParts(media);
       } else if (
-        media.media_category === 'audio' &&
+        classification === 'audio' &&
         this.capabilities.supportsNativeAudio
       ) {
         // Currently OpenRouter's OpenAI-compatible audio branch is the only consumer
@@ -847,13 +856,13 @@ export class ModelHandlerOpenAI<
             input_audio: { data: media.data, format: audioFormat },
           },
         ];
-      } else if (media.media_category === 'audio') {
+      } else if (classification === 'audio') {
         this.logger.warn(
           `Audio input received (${media.file_name}) but native audio is not supported by this specific model/provider (${this.config.provider}). Skipping.`,
         );
         return [];
       } else {
-        this.logger.warn(`Unknown media category: ${media.media_category}`);
+        this.logger.warn(unknownMediaCategoryWarning(media));
         return [];
       }
     });

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -58,6 +58,10 @@ import { computeUtilizationPercent } from '../support/contextUtilization';
 import { logCompactionEvent } from '../support/compactionLogging';
 import { AUXILIARY_MAX_RETRIES } from '../support/auxiliaryRetry';
 import { toDataUrl } from '../support/dataUrl';
+import {
+  classifyMediaEntry,
+  unknownMediaCategoryWarning,
+} from '../support/mediaClassification';
 import { shouldUseOpenRouter } from '../support/ProxyConfigResolver';
 import {
   getDeclaredMaxReasoningEffort,
@@ -73,6 +77,7 @@ import { normalizeOpenAIResponseError } from './openAIResponseErrors';
 import {
   formatAttachmentSummary,
   formatToolResultAsText,
+  uploadAndRecordToolAttachments,
 } from '../utils/toolAttachmentUtils';
 import { toOpenAIResponseTools } from '../toolConversion';
 import { ModelHandler } from '../ModelHandler';
@@ -1221,9 +1226,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   createMediaContent(mediaMessage: MediaEntry[]): ResponseInputContent[] {
     return mediaMessage.flatMap((media): ResponseInputContent[] => {
       const mediaType = media.media_type ?? '';
+      const classification = classifyMediaEntry(media);
 
       if (
-        media.media_category === 'image' &&
+        classification === 'image' &&
         typeof mediaType === 'string' &&
         mediaType.startsWith('image/')
       ) {
@@ -1241,14 +1247,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // See: https://community.openai.com/t/audio-input-not-working-when-migrating-from-completions-to-responses/1364108/3
       // See: https://github.com/openai/openai-node/commit/9909fef596280fc16174679d97c3e81543c68646
       // TODO: Re-enable when OpenAI makes audio input functional
-      if (media.media_category === 'audio') {
+      if (classification === 'audio') {
         this.logger.warn(
           `Audio input received (${media.file_name}) but the Responses API does not currently support audio input. Skipping.`,
         );
         return [];
       }
 
-      if (mediaType === 'application/pdf') {
+      if (classification === 'pdf') {
         return [
           createInputText(`Document: ${media.file_name}`),
           {
@@ -1259,14 +1265,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         ];
       }
 
-      if (media.media_category === 'image') {
+      if (classification === 'image') {
         this.logger.warn(
           `Skipping media ${media.file_name} with unsupported image MIME type: ${mediaType}`,
         );
         return [];
       }
 
-      this.logger.warn(`Unknown media category: ${media.media_category}`);
+      this.logger.warn(unknownMediaCategoryWarning(media));
       return [];
     });
   }
@@ -2590,34 +2596,29 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       arguments: call.raw.arguments,
     };
 
-    // Create mutable copy for adding attachmentSummary/files
-    const finalResult: ToolResult = { ...result };
     const canUploadFiles = this.supportsToolResultFileUpload;
+    const canUpload =
+      canUploadFiles && attachments.length > 0 && client !== undefined;
 
-    let uploadedAttachments: UploadedOpenAIResponseAttachment[] = [];
-    if (canUploadFiles && attachments.length > 0 && client) {
-      // This upload occurs while assembling the next turn, outside the model
-      // invocation gate. Restore the SDK's ordinary two retries for this
-      // auxiliary request; generation requests keep maxRetries: 0.
-      uploadedAttachments = await uploadToolAttachments(
-        client.withOptions({ maxRetries: AUXILIARY_MAX_RETRIES }),
-        attachments,
-        {
-          openRouterRouting: this.isOpenRouterRoutingEnabled(),
-          logger: this.logger,
-        },
-      );
-      if (finalResult.status === 'executed' && uploadedAttachments.length > 0) {
-        finalResult.files = uploadedAttachments.map(
-          ({ attachment, fileId }) => ({
-            path: attachment.path,
-            mimeType: attachment.mimeType,
-            description: attachment.description,
-            fileId,
-          }),
-        );
-      }
-    }
+    // This upload occurs while assembling the next turn, outside the model
+    // invocation gate. Restore the SDK's ordinary two retries for this
+    // auxiliary request; generation requests keep maxRetries: 0.
+    const { finalResult, uploadResult } = await uploadAndRecordToolAttachments(
+      result,
+      canUpload,
+      async () => ({
+        uploaded: await uploadToolAttachments(
+          client!.withOptions({ maxRetries: AUXILIARY_MAX_RETRIES }),
+          attachments,
+          {
+            openRouterRouting: this.isOpenRouterRoutingEnabled(),
+            logger: this.logger,
+          },
+        ),
+      }),
+    );
+    const uploadedAttachments: UploadedOpenAIResponseAttachment[] =
+      uploadResult?.uploaded ?? [];
 
     if (
       attachments.length > 0 &&

--- a/src/agent/modelHandlers/openrouter/openRouterStreaming.ts
+++ b/src/agent/modelHandlers/openrouter/openRouterStreaming.ts
@@ -1,6 +1,6 @@
 // Local file imports
+import { ChannelStreamAggregator } from '../utils/channelStreamAggregator';
 import { extractTextFromReasoningDetails } from '../utils/openRouterReasoning';
-import { ToolCallAccumulator } from '../utils/toolCallAccumulator';
 import type {
   ChatAssistantMessage,
   ChatFinishReasonEnum,
@@ -37,11 +37,8 @@ export function toOpenRouterReasoningEffort(
  * Accumulates streaming chunks into a final ChatResult since the OpenRouter SDK
  * does not provide a `finalChatCompletion()` helper.
  */
-export class OpenRouterStreamAggregator {
-  private content = '';
-  private reasoning = '';
+export class OpenRouterStreamAggregator extends ChannelStreamAggregator {
   private reasoningDetails: ReasoningDetailUnion[] = [];
-  private toolCalls = new ToolCallAccumulator();
   private finishReason: ChatFinishReasonEnum | null = null;
   private usage: ChatUsage | null = null;
   private model = '';
@@ -51,7 +48,7 @@ export class OpenRouterStreamAggregator {
   /** Text accumulated so far — read on stream failure so the retry UI can
    *  show the partial tail (parity with the other streaming providers). */
   get partialContent(): string {
-    return this.content;
+    return this.getFullContent();
   }
 
   consumeChunk(chunk: ChatStreamChunk): {
@@ -79,7 +76,7 @@ export class OpenRouterStreamAggregator {
 
     const delta = choice.delta;
     const contentDelta = delta.content ?? '';
-    if (contentDelta) this.content += contentDelta;
+    this.pushContent(contentDelta);
 
     // Reasoning - try reasoningDetails first, then reasoning string
     let reasoningDelta = '';
@@ -89,7 +86,7 @@ export class OpenRouterStreamAggregator {
     } else if (delta.reasoning) {
       reasoningDelta = delta.reasoning;
     }
-    if (reasoningDelta) this.reasoning += reasoningDelta;
+    this.pushReasoning(reasoningDelta);
 
     // Accumulate tool calls by index
     if (delta.toolCalls) {
@@ -120,13 +117,14 @@ export class OpenRouterStreamAggregator {
 
     const message: ChatAssistantMessage & { role: 'assistant' } = {
       role: 'assistant',
-      content: this.content || undefined,
+      content: this.getFullContent() || undefined,
     };
     if (toolCalls.length > 0) {
       message.toolCalls = toolCalls;
     }
-    if (this.reasoning) {
-      message.reasoning = this.reasoning;
+    const reasoning = this.getFullReasoning();
+    if (reasoning) {
+      message.reasoning = reasoning;
     }
     if (this.reasoningDetails.length > 0) {
       message.reasoningDetails = this.reasoningDetails;

--- a/src/agent/modelHandlers/support/mediaClassification.ts
+++ b/src/agent/modelHandlers/support/mediaClassification.ts
@@ -1,0 +1,44 @@
+import type { MediaEntry } from '@agent/utils/mediaTypes';
+
+/**
+ * The fundamental kind of a media entry, derived from its `media_category`
+ * and MIME type. Every chat-style handler's `createMediaContent` (Anthropic,
+ * OpenAI chat completions, OpenAI Responses) repeated the same structural
+ * classification — an `'image'`-category entry whose MIME type is
+ * `application/pdf` is really a PDF, any other `'image'`-category entry is a
+ * plain image, an `'audio'`-category entry is audio, anything else is
+ * unrecognized — before applying its own capability gating (native PDF
+ * support, native audio support, accepted image MIME types) on top. This
+ * function owns only the structural classification; callers still decide
+ * whether they actually support what they got back.
+ *
+ * Google's media pipeline (`buildMedia` in `google/`) is deliberately not
+ * routed through this: it dispatches on MIME-type prefix directly (including
+ * a `video` kind this classification doesn't model) rather than on
+ * `media_category`, and is already shared across both Google handlers via
+ * `uploadGoogleMediaEntries`.
+ */
+export type MediaKind = 'image' | 'audio' | 'pdf' | 'unsupported';
+
+export function classifyMediaEntry(
+  entry: Pick<MediaEntry, 'media_category' | 'media_type'>,
+): MediaKind {
+  if (entry.media_category === 'image') {
+    return entry.media_type === 'application/pdf' ? 'pdf' : 'image';
+  }
+  if (entry.media_category === 'audio') {
+    return 'audio';
+  }
+  return 'unsupported';
+}
+
+/**
+ * Standard warning for a media entry `classifyMediaEntry` could not place in
+ * any known category. Shared so the handlers that route through it log
+ * identical text instead of near-identical hand-written variants.
+ */
+export function unknownMediaCategoryWarning(
+  entry: Pick<MediaEntry, 'media_category'>,
+): string {
+  return `Unknown media category: ${entry.media_category}`;
+}

--- a/src/agent/modelHandlers/utils/channelStreamAggregator.ts
+++ b/src/agent/modelHandlers/utils/channelStreamAggregator.ts
@@ -1,0 +1,42 @@
+import { ToolCallAccumulator } from './toolCallAccumulator';
+
+/**
+ * Shared accumulation core for the two chat-completion-shaped streaming
+ * aggregators (`BaseReasoningStreamAggregator` for OpenAI-compatible
+ * reasoning models, `OpenRouterStreamAggregator` for OpenRouter). Both
+ * accumulate content text, reasoning text, and streamed tool-call fragments
+ * across chunks, then materialize a final response — they differ only in the
+ * shape of the chunk they consume and the shape of the response they emit
+ * (`ChatCompletion` vs OpenRouter's `ChatResult`), so this base owns the
+ * accumulation state and leaves chunk consumption and response construction
+ * to each subclass.
+ */
+export abstract class ChannelStreamAggregator {
+  protected readonly contentParts: string[] = [];
+  protected readonly reasoningParts: string[] = [];
+  protected readonly toolCalls = new ToolCallAccumulator();
+
+  /** Appends a content delta, ignoring empty strings. */
+  protected pushContent(delta: string | undefined | null): void {
+    if (delta) {
+      this.contentParts.push(delta);
+    }
+  }
+
+  /** Appends a reasoning delta, ignoring empty strings. */
+  protected pushReasoning(delta: string | undefined | null): void {
+    if (delta) {
+      this.reasoningParts.push(delta);
+    }
+  }
+
+  /** Full accumulated content text, joined in arrival order. */
+  getFullContent(): string {
+    return this.contentParts.join('');
+  }
+
+  /** Full accumulated reasoning text, joined in arrival order. */
+  getFullReasoning(): string {
+    return this.reasoningParts.join('');
+  }
+}

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -86,6 +86,53 @@ export function wipeBuffer(buffer: Buffer | undefined): undefined {
   return undefined;
 }
 
+/** A single uploaded attachment, in the shape common to every provider's
+ * upload result: the source attachment plus the id it was uploaded under. */
+interface UploadedAttachmentBase {
+  attachment: ToolFileAttachment;
+  fileId: string;
+}
+
+/**
+ * Runs a provider's upload call, then folds the uploaded set into a
+ * `finalResult.files` copy of `result` — the block every handler's
+ * tool-result follow-up path (Anthropic's `buildToolResultBlock`, OpenAI
+ * Responses' `createToolUseFollowUpMessages`) repeated identically. Each
+ * provider's actual upload call has its own signature and return shape
+ * (Anthropic's also reports `unsupported`/`pageLimitExceeded`; OpenAI's does
+ * not), so `upload` is the caller's own closure and its full return value is
+ * handed back untouched for the caller to destructure further.
+ */
+export async function uploadAndRecordToolAttachments<
+  TUploadResult extends { uploaded: UploadedAttachmentBase[] },
+>(
+  result: ToolResult,
+  canUpload: boolean,
+  upload: () => Promise<TUploadResult>,
+): Promise<{
+  finalResult: ToolResult;
+  uploadResult: TUploadResult | undefined;
+}> {
+  const finalResult: ToolResult = { ...result };
+
+  if (!canUpload) {
+    return { finalResult, uploadResult: undefined };
+  }
+
+  const uploadResult = await upload();
+
+  if (result.status === 'executed' && uploadResult.uploaded.length > 0) {
+    finalResult.files = uploadResult.uploaded.map(({ attachment, fileId }) => ({
+      path: attachment.path,
+      mimeType: attachment.mimeType,
+      description: attachment.description,
+      fileId,
+    })) as typeof finalResult.files;
+  }
+
+  return { finalResult, uploadResult };
+}
+
 export async function loadAttachmentBuffer(
   attachment: ToolFileAttachment,
 ): Promise<Buffer> {

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -17,6 +17,7 @@ import type {
   UserQuestionPermission,
 } from '@shared/schemas';
 import { SESSION_DISPOSED_CAUSE } from '@shared/copy/interactionCancellation';
+import { createListenerSet, type ListenerSet } from '@utils/core/listenerSet';
 import type { GenericDiagnostic } from '@utils/diagnostics/diagnosticFormatting';
 import type {
   AgentRuntimeEmitOptions,
@@ -354,7 +355,8 @@ interface PendingSessionInteraction {
 export class SessionHostInteractions implements HostInteractions {
   private readonly attachments: HostInteractionAttachment[] = [];
   private readonly pending = new Set<PendingSessionInteraction>();
-  private readonly pendingCountListeners = new Set<(count: number) => void>();
+  private readonly pendingCountListeners: ListenerSet<(count: number) => void> =
+    createListenerSet();
   private readonly pendingPresentationReplays: Array<
     (interactions: HostInteractions) => Promise<void> | void
   > = [];
@@ -369,8 +371,7 @@ export class SessionHostInteractions implements HostInteractions {
   /** Observe transitions between no pending requests and at least one. */
   onPendingCountChange(listener: (count: number) => void): () => void {
     if (this.disposed) return () => {};
-    this.pendingCountListeners.add(listener);
-    return () => this.pendingCountListeners.delete(listener);
+    return this.pendingCountListeners.add(listener);
   }
 
   use(interactions: HostInteractions): () => void {

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -33,6 +33,7 @@ import {
   isTerminalOutcomePhase,
 } from '@shared/streams/streamStatus';
 import { formatDuration, onAbort } from '@utils/core';
+import { createListenerSet, type ListenerSet } from '@utils/core/listenerSet';
 import {
   type ExecutionHandle,
   type ExecutionStatusInfo,
@@ -152,16 +153,16 @@ export class ExecutionRegistry {
     string,
     Set<(handle: ExecutionHandle | undefined) => void>
   >();
-  private readonly registrationListeners = new Set<
+  private readonly registrationListeners: ListenerSet<
     (executionId: string, handle: ExecutionHandle | undefined) => void
-  >();
+  > = createListenerSet();
   private readonly childActivations = new Map<
     string,
     ChildExecutionActivation
   >();
-  private readonly childActivationListeners = new Set<
+  private readonly childActivationListeners: ListenerSet<
     (activation: ChildExecutionActivation, active: boolean) => void
-  >();
+  > = createListenerSet();
 
   constructor(options: ExecutionRegistryInit = {}) {
     const events = options.events ?? new SessionEventHub();
@@ -650,10 +651,7 @@ export class ExecutionRegistry {
   addRegistrationListener(
     cb: (executionId: string, handle: ExecutionHandle | undefined) => void,
   ): () => void {
-    this.registrationListeners.add(cb);
-    return () => {
-      this.registrationListeners.delete(cb);
-    };
+    return this.registrationListeners.add(cb);
   }
 
   /**
@@ -679,10 +677,7 @@ export class ExecutionRegistry {
   addChildActivationListener(
     cb: (activation: ChildExecutionActivation, active: boolean) => void,
   ): () => void {
-    this.childActivationListeners.add(cb);
-    return () => {
-      this.childActivationListeners.delete(cb);
-    };
+    return this.childActivationListeners.add(cb);
   }
 
   private emitChildActivity(parentStreamId: StreamTabId): void {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -55,6 +55,7 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { requireRunStream, requireStreamId } from '@tools/contextHelpers';
 import { assertNoParentTraversal } from '@tools/pathResolution';
+import { executed } from '@tools/core/result';
 import {
   hasCompletedRunConversationEvidence,
   readCompletedRunConversation,
@@ -533,7 +534,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     const entries = await listExecutions();
 
     if (entries.length === 0) {
-      return { status: 'executed', output: 'No execution history found.' };
+      return executed('No execution history found.');
     }
 
     const { page, start, end, total } = paginateToolListing(
@@ -544,10 +545,9 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     const lines = page.map(formatListingLine);
 
     const header = formatListingHeader(start, end, total);
-    return {
-      status: 'executed',
-      output: `${header}\n\n${lines.join('\n')}${formatPaginationHint(end, total)}`,
-    };
+    return executed(
+      `${header}\n\n${lines.join('\n')}${formatPaginationHint(end, total)}`,
+    );
   }
 
   private async showSummary(
@@ -587,7 +587,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
         },
       );
 
-      return { status: 'executed', output: lines.join('\n') };
+      return executed(lines.join('\n'));
     }
 
     // Completed execution: full KV fetch
@@ -605,10 +605,9 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       if (!resumability.resumable) {
         throw new ToolError(`Execution not found: ${executionId}`);
       }
-      return {
-        status: 'executed',
-        output: `Execution: ${executionId}\nStatus: resumable\n(No metadata available - use /executions/${executionId}/conversation to view messages)`,
-      };
+      return executed(
+        `Execution: ${executionId}\nStatus: resumable\n(No metadata available - use /executions/${executionId}/conversation to view messages)`,
+      );
     }
 
     const category = resolveExecutionDisplayCategory(
@@ -636,7 +635,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       },
     );
 
-    return { status: 'executed', output: lines.join('\n') };
+    return executed(lines.join('\n'));
   }
 
   /**
@@ -716,10 +715,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       detachActiveChildren: detachSubagentsOnStop(),
     });
     if (success) {
-      return {
-        status: 'executed',
-        output: `Execution ${executionId} terminated.`,
-      };
+      return executed(`Execution ${executionId} terminated.`);
     }
     throw new ToolError(`Execution ${executionId} could not be terminated.`);
   }
@@ -739,11 +735,10 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     } catch (err) {
       throw new ToolError(toErrorMessage(err));
     }
-    return {
-      status: 'executed',
-      summary: `Subscribed to ${executionId}`,
-      output: `Subscribed to ${executionId}. Status and termination events will arrive as follow-ups wrapped in <execution-activity>. Auto-disposes when the execution finishes or this stream is released. Call again with action='unsubscribe' to stop sooner.`,
-    };
+    return executed(
+      `Subscribed to ${executionId}. Status and termination events will arrive as follow-ups wrapped in <execution-activity>. Auto-disposes when the execution finishes or this stream is released. Call again with action='unsubscribe' to stop sooner.`,
+      `Subscribed to ${executionId}`,
+    );
   }
 
   private handleUnsubscribe(executionId: ExecutionId): ToolResult {
@@ -752,12 +747,11 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       streamId,
       executionId,
     );
-    return {
-      status: 'executed',
-      output: removed
+    return executed(
+      removed
         ? `Unsubscribed from ${executionId}.`
         : `No active subscription to ${executionId} on this stream.`,
-    };
+    );
   }
 
   /**
@@ -775,27 +769,23 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       : (await readCompletedRunTodos(executionId)).todos;
 
     if (todos.length === 0) {
-      return {
-        status: 'executed',
-        output: `No task list found for execution ${executionId}.`,
-      };
+      return executed(`No task list found for execution ${executionId}.`);
     }
 
     const lines = formatTodoSection(todos);
     const header = formatTodoHeader(executionId, todos);
 
-    return { status: 'executed', output: `${header}\n\n${lines.join('\n')}` };
+    return executed(`${header}\n\n${lines.join('\n')}`);
   }
 
   private async showReport(executionId: ExecutionId): Promise<ToolResult> {
     const report = await getExecutionStore(executionId).readReport();
     if (!report) {
-      return {
-        status: 'executed',
-        output: `No report found for execution ${executionId}. Reports are persisted when subagents or background processes complete.`,
-      };
+      return executed(
+        `No report found for execution ${executionId}. Reports are persisted when subagents or background processes complete.`,
+      );
     }
-    return { status: 'executed', output: report };
+    return executed(report);
   }
 
   /**
@@ -805,31 +795,23 @@ Delegated subagent and workflow results are delivered automatically as follow-up
   private async showResultMeta(executionId: ExecutionId): Promise<ToolResult> {
     const resultMeta = await getExecutionStore(executionId).readResultMeta();
     if (!resultMeta) {
-      return {
-        status: 'executed',
-        output: `No structured result recorded for ${executionId} yet. It is written when the execution completes.`,
-      };
+      return executed(
+        `No structured result recorded for ${executionId} yet. It is written when the execution completes.`,
+      );
     }
-    return {
-      status: 'executed',
-      output: JSON.stringify(unwrapResultMeta(resultMeta), null, 2),
-    };
+    return executed(JSON.stringify(unwrapResultMeta(resultMeta), null, 2));
   }
 
   private async showChildren(executionId: ExecutionId): Promise<ToolResult> {
     const children = await getExecutionStore(executionId).readChildren();
     if (children.length === 0) {
-      return {
-        status: 'executed',
-        output: `No child executions found for ${executionId}.`,
-      };
+      return executed(`No child executions found for ${executionId}.`);
     }
 
     const lines = await this.formatChildren(children);
-    return {
-      status: 'executed',
-      output: `Children of ${executionId} (${children.length}):\n\n${lines.join('\n')}`,
-    };
+    return executed(
+      `Children of ${executionId} (${children.length}):\n\n${lines.join('\n')}`,
+    );
   }
 
   private async showConfig(executionId: ExecutionId): Promise<ToolResult> {
@@ -844,10 +826,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       config.agent,
       config.agentCategory,
     );
-    return {
-      status: 'executed',
-      output: serializeFilteredConfig(config, category),
-    };
+    return executed(serializeFilteredConfig(config, category));
   }
 
   private async showConversation(
@@ -900,9 +879,8 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       if (!exists) {
         throw new ToolError(`Execution not found: ${executionId}`);
       }
-      return {
-        status: 'executed',
-        output: formatConversation([], {
+      return executed(
+        formatConversation([], {
           totalMessages: 0,
           metadata: [
             'Source: none',
@@ -911,7 +889,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
             'Next offset: none',
           ],
         }),
-      };
+      );
     }
 
     const pageStart = Math.min(offset, conversation.length);
@@ -928,7 +906,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       ],
     });
 
-    return { status: 'executed', output };
+    return executed(output);
   }
 
   /**
@@ -954,12 +932,10 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       throw new ToolError(`Execution not found: ${executionId}`);
     }
     if (meta?.category !== 'process') {
-      return {
-        status: 'executed',
-        output:
-          `/executions/${executionId}/output is only available for background commands (bash with run_in_background). ` +
+      return executed(
+        `/executions/${executionId}/output is only available for background commands (bash with run_in_background). ` +
           `Use /executions/${executionId}/conversation for an agent run's message history.`,
-      };
+      );
     }
 
     const transcripts = currentSession().transcripts;
@@ -976,12 +952,10 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     if (streamId) await transcripts.ensureLoaded(streamId);
     const log = streamId ? transcripts.get(streamId) : undefined;
     if (!log) {
-      return {
-        status: 'executed',
-        output:
-          `No retained output for ${executionId} — its stream log is no longer available. ` +
+      return executed(
+        `No retained output for ${executionId} — its stream log is no longer available. ` +
           `Use /executions/${executionId}/report for the result summary.`,
-      };
+      );
     }
 
     const { lines, chars } = projectProcessOutput(log.toJSON());
@@ -995,7 +969,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
 
     if (lines.length === 0) {
       out.push('', footer);
-      return { status: 'executed', output: out.join('\n') };
+      return executed(out.join('\n'));
     }
     out.push('Lines are in arrival order; `err:` marks one written to stderr.');
 
@@ -1016,7 +990,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
         '',
         footer,
       );
-      return { status: 'executed', output: out.join('\n') };
+      return executed(out.join('\n'));
     }
 
     let hint = '';
@@ -1033,37 +1007,29 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       footer,
     );
 
-    return {
-      status: 'executed',
-      summary: `Read lines ${first}-${last} of /executions/${executionId}/output`,
-      output: out.join('\n'),
-    };
+    return executed(
+      out.join('\n'),
+      `Read lines ${first}-${last} of /executions/${executionId}/output`,
+    );
   }
 
   private async listFiles(executionId: ExecutionId): Promise<ToolResult> {
     const runDir = await findExistingRunStoragePath(executionId);
     if (!runDir) {
-      return {
-        status: 'executed',
-        output: 'No files generated for this execution.',
-      };
+      return executed('No files generated for this execution.');
     }
 
     const entries = await listRunDirectoryFiles(runDir);
 
     if (entries.length === 0) {
-      return {
-        status: 'executed',
-        output: 'No files generated for this execution.',
-      };
+      return executed('No files generated for this execution.');
     }
 
     const lines = formatSizedEntryLines(entries);
 
-    return {
-      status: 'executed',
-      output: `Files in /executions/${executionId}/files:\n\n${lines.join('\n')}`,
-    };
+    return executed(
+      `Files in /executions/${executionId}/files:\n\n${lines.join('\n')}`,
+    );
   }
 
   private async readFile(
@@ -1107,10 +1073,9 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     const entries = await listExecutionWorkspaceFiles(config, paths);
 
     if (entries.length === 0) {
-      return {
-        status: 'executed',
-        output: `No workspace files recorded for execution ${executionId}.`,
-      };
+      return executed(
+        `No workspace files recorded for execution ${executionId}.`,
+      );
     }
 
     const lines = formatSizedEntryLines(
@@ -1121,12 +1086,10 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       })),
     );
 
-    return {
-      status: 'executed',
-      output:
-        `Workspace files for /executions/${executionId}/workspace-files:\n\n` +
+    return executed(
+      `Workspace files for /executions/${executionId}/workspace-files:\n\n` +
         lines.join('\n'),
-    };
+    );
   }
 
   private async readWorkspaceFile(

--- a/src/tools/OpenPdfTool.ts
+++ b/src/tools/OpenPdfTool.ts
@@ -42,11 +42,9 @@ export class OpenPdfTool extends defineTool({
   protected async execute(input: OpenPdfInput): Promise<ToolResult> {
     const openPdf = currentSession().interactions.openPdf;
     if (!openPdf) {
-      return {
-        status: 'error',
-        error:
-          'open_pdf is not available in this host. Open the PDF manually, or use a host that registers a PDF opener.',
-      };
+      throw new ToolError(
+        'open_pdf is not available in this host. Open the PDF manually, or use a host that registers a PDF opener.',
+      );
     }
 
     const location = resolvePdfLocation(input.path);

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -9,7 +9,10 @@ import {
 } from '@agent/storage/executionLease';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { currentSession, type SessionHandle } from '@agent/runtime/SessionHandle';
+import {
+  currentSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
 import {
   startChildRunLoop,
   type ChildRunPorts,

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -9,9 +9,15 @@ import {
 } from '@agent/storage/executionLease';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { currentSession } from '@agent/runtime/SessionHandle';
+import { currentSession, type SessionHandle } from '@agent/runtime/SessionHandle';
+import {
+  startChildRunLoop,
+  type ChildRunPorts,
+  type ChildRunStrategy,
+} from '@agent/runtime/childRunLoop';
 import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
 import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
+import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import type { RunContext } from '@agent/runtime/RunContext';
 import type {
   ExecutionId,
@@ -32,6 +38,10 @@ import {
   getChildStreamId,
   type ChildStream,
 } from './childStream';
+import type {
+  AgentCliSessionEntry,
+  AgentCliSessionRegistry,
+} from './agentCliSessionRegistry';
 
 /**
  * Publish a turn's token usage to the progress UI for an agent-CLI child stream.
@@ -263,4 +273,171 @@ export async function withAgentCliApproval(
 
   contexts?.callContext?.hooks?.onExecutionReady?.();
   return run(contexts?.runContext);
+}
+
+// ============================================================================
+// Shared session loop — one turn per enqueued prompt, delivers to parent
+// ============================================================================
+
+/** Minimal token-usage shape the loop's turn summary needs. Structurally
+ * compatible with `ChildRunStrategy`'s own (unexported) turn-usage type. */
+interface AgentCliTurnUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+}
+
+export interface AgentCliLoopParams<
+  TTurn,
+  TEntry extends AgentCliSessionEntry,
+> {
+  childStream: ChildStream;
+  parentStreamId: StreamTabId;
+  executionId: ExecutionId;
+  /** Passed through to `startChildRunLoop` (registry lookups, log labels). */
+  agentName: string;
+  /** Stage label opened on the child trace (e.g. "Codex session"). */
+  stageLabel: string;
+  initialPrompt: string;
+  /** Session/thread registry the loop tracks in-flight and successful turns in. */
+  store: AgentCliSessionRegistry<TEntry>;
+  /**
+   * The disk-based fallback session/thread id claimed synchronously before the
+   * loop starts, if any. Release it if the loop exits before promoting it.
+   */
+  releaseFallbackClaim: (() => void) | undefined;
+  /** Provider-specific single-turn execution, given the joined follow-up prompt. */
+  runProviderTurn: (
+    prompt: string,
+    ports: ChildRunPorts,
+    abortController: AbortController,
+  ) => Promise<TTurn>;
+  /** Build the store entry to register/track for the currently active session. */
+  buildEntry: (session: SessionHandle) => TEntry;
+  /**
+   * Session/thread ids to register as active after a successful turn. Falsy
+   * entries (not-yet-known ids) are skipped.
+   */
+  resolveSessionIds: (turn: TTurn) => readonly (string | null | undefined)[];
+  /** Token usage for the turn summary (null when none). */
+  getUsage: (turn: TTurn) => AgentCliTurnUsage | null;
+  /** Usage-stats payload to publish to the UI, or undefined to skip publishing. */
+  buildUsageStats: (turn: TTurn) => TokenUsageStats | undefined;
+  formatDelivery: (
+    turn: TTurn,
+    wallTimeMs: number,
+    lastPrompt: string,
+  ) => string;
+  formatError: (turn: TTurn | null, err: unknown, lastPrompt: string) => string;
+  /** Omitted by providers (codex) that always throw on failure. */
+  isTurnError?: (turn: TTurn) => boolean;
+  onTurnError?: (turn: TTurn, logger: AgentTrace) => void;
+  /** Logged if the loop's completion promise rejects after launch. */
+  loopFailedMessage: string;
+}
+
+/**
+ * Run the shared agent-CLI session loop. `startChildRunLoop` processes prompts
+ * from the child's follow-up queue one at a time and delivers each turn's
+ * result to the parent's follow-up queue; this wraps that with the scaffolding
+ * common to every agent-CLI provider (codex, claudeAgent): a dedup'd
+ * session/thread registration closure, the `lastPrompt` capture feeding
+ * `formatDelivery`/`formatError`, and the boilerplate-identical
+ * `ChildRunStrategy` fields (`isTerminal`, `getUsage`, `onLoopStart`,
+ * `onTurnSuccess`, `publishUsage`, `releaseSessionOwnership`). Callers supply
+ * only their provider-specific turn execution, usage/delivery formatting, and
+ * registry entry shape.
+ */
+export function startAgentCliLoop<TTurn, TEntry extends AgentCliSessionEntry>(
+  params: AgentCliLoopParams<TTurn, TEntry>,
+): void {
+  const {
+    childStream,
+    parentStreamId,
+    executionId,
+    agentName,
+    stageLabel,
+    initialPrompt,
+    store,
+    releaseFallbackClaim,
+    runProviderTurn,
+    buildEntry,
+    resolveSessionIds,
+    getUsage,
+    buildUsageStats,
+    formatDelivery,
+    formatError,
+    isTurnError,
+    onTurnError,
+    loopFailedMessage,
+  } = params;
+  const { childStreamId, logger } = childStream;
+
+  // Fresh and resumed session/thread ids are registered after the first
+  // successful turn is persisted, immediately before its result reaches the
+  // parent.
+  const registerSessionId = (id: string, session: SessionHandle): void => {
+    if (store.lookup(id)) return;
+    store.register(id, buildEntry(session));
+  };
+
+  // The joined prompt text for whichever turn is currently in flight —
+  // captured here (rather than threaded through the loop contract) since
+  // `formatDelivery`/`formatError` run strictly after the turn that set it.
+  let lastPrompt = initialPrompt;
+  const runTurn = (
+    followUps: readonly FollowUpQueueBatchItem[],
+    ports: ChildRunPorts,
+    abortController: AbortController,
+  ): Promise<TTurn> => {
+    lastPrompt = followUps.map((f) => f.text).join('\n\n');
+    return runProviderTurn(lastPrompt, ports, abortController);
+  };
+
+  const strategy: ChildRunStrategy<TTurn> = {
+    stageLabel,
+    launch: (ports, abortController) =>
+      runTurn(
+        [{ text: initialPrompt, origin: 'user' }],
+        ports,
+        abortController,
+      ),
+    runTurn,
+    isTerminal: () => false,
+    getUsage,
+    isTurnError,
+    onTurnError,
+    onLoopStart: (session) => {
+      store.trackInFlight(buildEntry(session));
+    },
+    onTurnSuccess: (turn, session) => {
+      for (const id of resolveSessionIds(turn)) {
+        if (id) registerSessionId(id, session);
+      }
+    },
+    publishUsage: (turn) => {
+      const usage = buildUsageStats(turn);
+      if (usage) {
+        publishAgentCliStreamUsage(childStreamId, executionId, usage, logger);
+      }
+    },
+    formatDelivery: (turn, wallTimeMs) =>
+      formatDelivery(turn, wallTimeMs, lastPrompt),
+    formatError: (turn, err) => formatError(turn, err, lastPrompt),
+    releaseSessionOwnership: () => {
+      releaseFallbackClaim?.();
+      store.releaseByExecutionId(executionId);
+    },
+  };
+
+  const { completion } = startChildRunLoop({
+    childStream,
+    childStreamId,
+    parentStreamId,
+    executionId,
+    agentName,
+    strategy,
+  });
+  void completion.catch((error: unknown) => {
+    childStream.logger.error(loopFailedMessage, { data: error });
+  });
 }

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -19,6 +19,7 @@ import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { requireInteractions } from '@tools/contextHelpers';
 import { createSessionBypassAccessors } from '@tools/approval/sessionBypassAccessors';
+import { errorResult } from '@tools/core/result';
 import { getConfig } from '@utils/config/configUtils';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
@@ -103,10 +104,8 @@ export function buildBashApprovalRejectedResult(
   const preview = truncateWithEllipsis(command, 60);
   const message = `User rejected command: ${preview}`;
   const feedback = rejectionFeedback?.trim();
-  return {
-    status: 'error',
+  return errorResult(message, {
     summary: message,
-    error: message,
     userInstruction: feedback || DEFAULT_BASH_REJECTION_INSTRUCTION,
-  };
+  });
 }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -19,6 +19,7 @@ import type { LineChanges } from '@shared/schemas/lineChanges';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { recordToolFileRead } from '@tools/fileInteractions';
 import { createSessionBypassAccessors } from '@tools/approval/sessionBypassAccessors';
+import { errorResult } from '@tools/core/result';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import {
@@ -347,15 +348,10 @@ export function buildApprovalRejectedResult(
 ): ToolResult {
   const baseMessage = `User rejected ${sourceTool} for ${path}.`;
   const feedback = userMessage?.trim();
-  const result: ToolResult = {
-    status: 'error',
+  return errorResult(baseMessage, {
     summary: baseMessage,
-    error: baseMessage,
-  };
-  if (feedback) {
-    result.userInstruction = feedback;
-  }
-  return result;
+    ...(feedback && { userInstruction: feedback }),
+  });
 }
 
 interface WrittenApprovedEdit extends WriteApprovedContentResult {

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -32,17 +32,10 @@ import {
   type ToolUseCardRef,
 } from '@agent/trace';
 import {
-  startChildRunLoop,
-  type ChildRunPorts,
-  type ChildRunStrategy,
-} from '@agent/runtime/childRunLoop';
-import {
   getRunContextExecutionId,
   getRunContextStreamId,
   getRunContextWorkingDirectory,
 } from '@agent/runtime/RunContext';
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import {
   ClaudeAgentEffortSchema,
   ClaudeAgentPermissionModeSchema,
@@ -73,9 +66,9 @@ import {
 import { type ChildStream } from './childStream';
 import { ClaudeAgentSessions } from './agentCliSessionStores';
 import {
-  publishAgentCliStreamUsage,
   launchAgentCliSession,
   resumeOrLaunchAgentCliSession,
+  startAgentCliLoop,
   withAgentCliApproval,
 } from './agentCliShared';
 import {
@@ -408,7 +401,7 @@ function startClaudeAgentLoop(params: {
   releaseFallbackClaim: (() => void) | undefined;
 }): void {
   const { childStream, parentStreamId, executionId, initialPrompt } = params;
-  const { childStreamId, logger } = childStream;
+  const { logger } = childStream;
 
   // The SDK needs the prior session id to resume the same conversation across
   // turns; it's threaded forward from each turn's result. Seeded from
@@ -416,10 +409,34 @@ function startClaudeAgentLoop(params: {
   let resumeSessionId: string | undefined = params.resumeSessionId;
   const fallbackSessionId = params.resumeSessionId;
 
-  const registerSession = (sessionId: string, session: SessionHandle): void => {
-    if (ClaudeAgentSessions.lookup(sessionId)) return;
-    ClaudeAgentSessions.register(sessionId, {
-      childStreamId,
+  startAgentCliLoop({
+    childStream,
+    parentStreamId,
+    executionId,
+    agentName: CLAUDE_AGENT_NAME,
+    stageLabel: 'Claude Code session',
+    initialPrompt,
+    store: ClaudeAgentSessions,
+    releaseFallbackClaim: params.releaseFallbackClaim,
+    runProviderTurn: async (prompt, _ports, abortController) => {
+      const turn = await runStreamedTurn({
+        prompt,
+        logger,
+        abortController,
+        model: params.model,
+        permissionMode: params.permissionMode,
+        effort: params.effort,
+        cwd: params.cwd,
+        additionalDirectories: params.additionalDirectories,
+        env: params.env,
+        resumeSessionId,
+        pathToClaudeCodeExecutable: params.pathToClaudeCodeExecutable,
+      });
+      if (turn.sessionId) resumeSessionId = turn.sessionId;
+      return turn;
+    },
+    buildEntry: (session) => ({
+      childStreamId: childStream.childStreamId,
       parentStreamId,
       executionId,
       executions: session.executions,
@@ -428,81 +445,18 @@ function startClaudeAgentLoop(params: {
       effort: params.effort,
       cwd: params.cwd,
       additionalDirectories: params.additionalDirectories,
-    });
-  };
-  // The joined prompt text for whichever turn is currently in flight —
-  // captured here (rather than threaded through the loop contract) since
-  // `formatDelivery`/`formatError` run strictly after the turn that set it.
-  let lastPrompt = initialPrompt;
-
-  const runTurn = async (
-    followUps: readonly FollowUpQueueBatchItem[],
-    _ports: ChildRunPorts,
-    abortController: AbortController,
-  ): Promise<TurnResult> => {
-    lastPrompt = followUps.map((f) => f.text).join('\n\n');
-    const turn = await runStreamedTurn({
-      prompt: lastPrompt,
-      logger,
-      abortController,
-      model: params.model,
-      permissionMode: params.permissionMode,
-      effort: params.effort,
-      cwd: params.cwd,
-      additionalDirectories: params.additionalDirectories,
-      env: params.env,
-      resumeSessionId,
-      pathToClaudeCodeExecutable: params.pathToClaudeCodeExecutable,
-    });
-    if (turn.sessionId) resumeSessionId = turn.sessionId;
-    return turn;
-  };
-
-  const strategy: ChildRunStrategy<TurnResult> = {
-    stageLabel: 'Claude Code session',
-    launch: (ports, abortController) =>
-      runTurn(
-        [{ text: initialPrompt, origin: 'user' }],
-        ports,
-        abortController,
-      ),
-    runTurn,
-    isTerminal: () => false,
+    }),
+    resolveSessionIds: (turn) => [fallbackSessionId, turn.sessionId],
     getUsage: (turn) => turn.usage,
+    buildUsageStats: (turn) =>
+      turn.usage ? buildClaudeUsageStats(turn.usage) : undefined,
     isTurnError: (turn) => turn.isError,
     onTurnError: (turn, log) => {
       if (turn.errorMessage) log.error(turn.errorMessage);
     },
-    onLoopStart: (session) => {
-      ClaudeAgentSessions.trackInFlight({
-        childStreamId,
-        parentStreamId,
-        executionId,
-        executions: session.executions,
-        model: params.model,
-        permissionMode: params.permissionMode,
-        effort: params.effort,
-        cwd: params.cwd,
-        additionalDirectories: params.additionalDirectories,
-      });
-    },
-    onTurnSuccess: (turn, session) => {
-      if (fallbackSessionId) registerSession(fallbackSessionId, session);
-      if (turn.sessionId) registerSession(turn.sessionId, session);
-    },
-    publishUsage: (turn) => {
-      if (turn.usage) {
-        publishAgentCliStreamUsage(
-          childStreamId,
-          executionId,
-          buildClaudeUsageStats(turn.usage),
-          logger,
-        );
-      }
-    },
-    formatDelivery: (turn, wallTimeMs) =>
+    formatDelivery: (turn, wallTimeMs, lastPrompt) =>
       formatClaudeDelivery(executionId, lastPrompt, wallTimeMs, turn),
-    formatError: (turn, err) =>
+    formatError: (turn, err, lastPrompt) =>
       formatChildRunError(
         { tag: DELIVERY_TAG.claudeAgentError, executionId, prompt: lastPrompt },
         {
@@ -511,24 +465,7 @@ function startClaudeAgentLoop(params: {
           ),
         },
       ),
-    releaseSessionOwnership: () => {
-      params.releaseFallbackClaim?.();
-      ClaudeAgentSessions.releaseByExecutionId(executionId);
-    },
-  };
-
-  const { completion } = startChildRunLoop({
-    childStream,
-    childStreamId,
-    parentStreamId,
-    executionId,
-    agentName: CLAUDE_AGENT_NAME,
-    strategy,
-  });
-  void completion.catch((error: unknown) => {
-    childStream.logger.error(`Claude Agent run loop failed after launch`, {
-      data: error,
-    });
+    loopFailedMessage: 'Claude Agent run loop failed after launch',
   });
 }
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -34,13 +34,6 @@ import {
   getRunContextStreamId,
   getRunContextWorkingDirectory,
 } from '@agent/runtime/RunContext';
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import {
-  startChildRunLoop,
-  type ChildRunPorts,
-  type ChildRunStrategy,
-} from '@agent/runtime/childRunLoop';
-import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
 import type {
@@ -64,9 +57,9 @@ import { importCodexClass, findCodexBinaryPath } from './codexImport';
 import { type ChildStream } from './childStream';
 import { CodexThreads } from './agentCliSessionStores';
 import {
-  publishAgentCliStreamUsage,
   launchAgentCliSession,
   resumeOrLaunchAgentCliSession,
+  startAgentCliLoop,
   withAgentCliApproval,
 } from './agentCliShared';
 import {
@@ -405,97 +398,42 @@ function startCodexLoop(params: {
   const { childStreamId, logger } = childStream;
   const fallbackThreadId = params.resumeThreadId;
 
-  // Fresh and resumed thread IDs are registered after the first successful
-  // turn is persisted, immediately before its result reaches the parent.
-  const registerThread = (threadId: string, session: SessionHandle): void => {
-    if (CodexThreads.lookup(threadId)) return;
-    CodexThreads.register(threadId, {
+  startAgentCliLoop({
+    childStream,
+    parentStreamId,
+    executionId,
+    agentName: 'codex',
+    stageLabel: 'Codex session',
+    initialPrompt,
+    store: CodexThreads,
+    releaseFallbackClaim: params.releaseFallbackClaim,
+    runProviderTurn: (prompt, _ports, abortController) =>
+      runStreamedTurn(
+        thread,
+        prompt,
+        childStreamId,
+        logger,
+        abortController.signal,
+      ),
+    buildEntry: (session) => ({
       thread,
       childStreamId,
       parentStreamId,
       executionId,
       executions: session.executions,
-    });
-  };
-
-  // The joined prompt text for whichever turn is currently in flight —
-  // captured here (rather than threaded through the loop contract) since
-  // `formatDelivery`/`formatError` run strictly after the turn that set it.
-  let lastPrompt = initialPrompt;
-  const runTurn = (
-    followUps: readonly FollowUpQueueBatchItem[],
-    _ports: ChildRunPorts,
-    abortController: AbortController,
-  ): Promise<RunResult> => {
-    lastPrompt = followUps.map((f) => f.text).join('\n\n');
-    return runStreamedTurn(
-      thread,
-      lastPrompt,
-      childStreamId,
-      logger,
-      abortController.signal,
-    );
-  };
-
-  const strategy: ChildRunStrategy<RunResult> = {
-    stageLabel: 'Codex session',
-    launch: (ports, abortController) =>
-      runTurn(
-        [{ text: initialPrompt, origin: 'user' }],
-        ports,
-        abortController,
-      ),
-    runTurn,
-    isTerminal: () => false,
+    }),
+    resolveSessionIds: () => [fallbackThreadId, thread.id],
     getUsage: (turn) => turn.usage,
-    onLoopStart: (session) => {
-      CodexThreads.trackInFlight({
-        thread,
-        childStreamId,
-        parentStreamId,
-        executionId,
-        executions: session.executions,
-      });
-    },
-    onTurnSuccess: (_turn, session) => {
-      if (fallbackThreadId) registerThread(fallbackThreadId, session);
-      if (thread.id) registerThread(thread.id, session);
-    },
-    publishUsage: (turn) => {
-      if (turn.usage) {
-        publishAgentCliStreamUsage(
-          childStreamId,
-          executionId,
-          buildCodexUsageStats(turn.usage),
-          logger,
-        );
-      }
-    },
-    formatDelivery: (turn, wallTimeMs) =>
+    buildUsageStats: (turn) =>
+      turn.usage ? buildCodexUsageStats(turn.usage) : undefined,
+    formatDelivery: (turn, wallTimeMs, lastPrompt) =>
       formatCodexDelivery(executionId, lastPrompt, wallTimeMs, turn, thread.id),
-    formatError: (_turn, err) =>
+    formatError: (_turn, err, lastPrompt) =>
       formatChildRunError(
         { tag: DELIVERY_TAG.codexError, executionId, prompt: lastPrompt },
         { message: toErrorMessage(err) },
       ),
-    releaseSessionOwnership: () => {
-      params.releaseFallbackClaim?.();
-      CodexThreads.releaseByExecutionId(executionId);
-    },
-  };
-
-  const { completion } = startChildRunLoop({
-    childStream,
-    childStreamId,
-    parentStreamId,
-    executionId,
-    agentName: 'codex',
-    strategy,
-  });
-  void completion.catch((error: unknown) => {
-    childStream.logger.error(`Codex run loop failed after launch`, {
-      data: error,
-    });
+    loopFailedMessage: 'Codex run loop failed after launch',
   });
 }
 

--- a/src/tools/core/result.ts
+++ b/src/tools/core/result.ts
@@ -21,15 +21,6 @@ export function executed(output: string, summary?: string): ExecutedToolResult {
 }
 
 /**
- * Build a `status: 'executed'` result for an empty-collection short-circuit
- * (e.g. "No files matched"), where one message serves as both the model-facing
- * `output` and the human-facing `summary`.
- */
-export function emptyResult(message: string): ExecutedToolResult {
-  return { status: 'executed', output: message, summary: message };
-}
-
-/**
  * Build a `status: 'error'` result literal. Reserved for call sites that
  * cannot use the dominant `throw new ToolError(...)` convention (caught
  * centrally by `BaseTool.call`) — typically because the caller must keep

--- a/src/tools/core/result.ts
+++ b/src/tools/core/result.ts
@@ -1,0 +1,45 @@
+// Shared ToolResult builders. Most tools hand-build the `status: 'executed'`
+// and `status: 'error'` object literals inline; these cover the dominant
+// shapes so call sites read as intent ("executed with this output", "nothing
+// found") rather than object-literal boilerplate.
+//
+// Host-agnostic, VS Code-free.
+
+import type { ToolResult } from '@shared/schemas/toolResult';
+
+type ExecutedToolResult = Extract<ToolResult, { status: 'executed' }>;
+type ErrorToolResult = Extract<ToolResult, { status: 'error' }>;
+
+/** Build a `status: 'executed'` result. `summary` is omitted when not given,
+ * matching the many call sites that only ever set `output`. */
+export function executed(output: string, summary?: string): ExecutedToolResult {
+  return {
+    status: 'executed',
+    output,
+    ...(summary !== undefined && { summary }),
+  };
+}
+
+/**
+ * Build a `status: 'executed'` result for an empty-collection short-circuit
+ * (e.g. "No files matched"), where one message serves as both the model-facing
+ * `output` and the human-facing `summary`.
+ */
+export function emptyResult(message: string): ExecutedToolResult {
+  return { status: 'executed', output: message, summary: message };
+}
+
+/**
+ * Build a `status: 'error'` result literal. Reserved for call sites that
+ * cannot use the dominant `throw new ToolError(...)` convention (caught
+ * centrally by `BaseTool.call`) — typically because the caller must keep
+ * running after emitting a partial per-item error, or because a nested try/catch
+ * would otherwise reformat the thrown message. Prefer `throw new ToolError(...)`
+ * over this helper whenever the call site can support it.
+ */
+export function errorResult(
+  error: string,
+  extra?: Omit<ErrorToolResult, 'status' | 'error'>,
+): ErrorToolResult {
+  return { status: 'error', error, ...extra };
+}

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -37,6 +37,7 @@ import {
   resolveWorkspaceRelativePath,
 } from '@tools/pathResolution';
 import { defineTool } from '@tools/core/define';
+import { errorResult } from '@tools/core/result';
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { deriveExecutionId } from '@utils/core/idHash';
@@ -495,11 +496,9 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
           );
         }
         if (runMeta?.terminalStatus !== EXECUTION_STATUS.COMPLETED) {
-          return {
-            status: 'error',
+          return errorResult(report, {
             summary: `Workflow script '${meta.name}' failed`,
-            error: report,
-          } satisfies ToolResult;
+          });
         }
         return {
           status: 'executed',

--- a/src/tools/delegation/inputFields.ts
+++ b/src/tools/delegation/inputFields.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import { formatBytes } from '@shared/utils/string';
 import { parseWorkingDirectory } from '@tools/pathResolution';
+import { errorResult } from '@tools/core/result';
 import { displayToStoragePath } from '@tools/memory/memoryUtils';
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { isWorktreeSupportEnabled } from '@utils/config/worktreeConfig';
@@ -192,17 +193,15 @@ export async function rejectOversizedBibAttachments(
     if (stats.size <= LARGE_BIB_LIMIT_BYTES) continue;
 
     const message = `${bibFile} is ${stats.size} bytes (${formatBytes(stats.size)}), over the ${LARGE_BIB_LIMIT_BYTES} byte (${formatBytes(LARGE_BIB_LIMIT_BYTES)}) limit. Call extract_bib_entries first if citations are needed, then re-propose without the full .bib file.`;
-    return {
-      status: 'error',
+    return errorResult(message, {
       summary: `Rejected oversized BibTeX attachment`,
-      error: message,
       diagnostics: {
         type: 'oversized_bib_attachment',
         path: bibFile,
         sizeBytes: stats.size,
         limitBytes: LARGE_BIB_LIMIT_BYTES,
       },
-    };
+    });
   }
 
   return null;

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -32,6 +32,7 @@ import {
   getDelegationAgents,
   getDelegationAgentsForScope,
 } from '@tools/delegationAgentAvailability';
+import { errorResult, executed } from '@tools/core/result';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -115,18 +116,16 @@ function proposalResultToToolResult(
       const feedbackLine = feedback
         ? `\nUser feedback: ${feedback}`
         : `\n${DEFAULT_DELEGATION_REJECTION_FEEDBACK}`;
-      return {
-        status: 'error',
-        summary: `User rejected delegation to '${agentName}'`,
-        error: `Delegation to '${agentName}' was rejected.\nYour delegation was: ${echo}${feedbackLine}`,
-      };
+      return errorResult(
+        `Delegation to '${agentName}' was rejected.\nYour delegation was: ${echo}${feedbackLine}`,
+        { summary: `User rejected delegation to '${agentName}'` },
+      );
     }
     case 'setup':
-      return {
-        status: 'executed',
-        summary: `User opened '${agentName}' for editing`,
-        output: `Delegation opened for editing. The user will run it manually when ready.\nYour delegation was: ${echo}`,
-      };
+      return executed(
+        `Delegation opened for editing. The user will run it manually when ready.\nYour delegation was: ${echo}`,
+        `User opened '${agentName}' for editing`,
+      );
     case 'approve':
       return null;
   }
@@ -185,11 +184,12 @@ export async function proposeAndExecute(
         agentCategory: proposal.agentCategory,
       });
     } catch (err) {
-      return {
-        status: 'error',
-        summary: `Approved model override '${result.model}' is not available`,
-        error: `Cannot launch with model '${result.model}': ${toErrorMessage(err)} Re-propose the delegation.`,
-      };
+      return errorResult(
+        `Cannot launch with model '${result.model}': ${toErrorMessage(err)} Re-propose the delegation.`,
+        {
+          summary: `Approved model override '${result.model}' is not available`,
+        },
+      );
     }
   }
   const agentOverride =
@@ -203,11 +203,12 @@ export async function proposeAndExecute(
   // carry a malformed value. Fail fast so the orchestrator sees the problem
   // synchronously instead of after an async launch.
   if (agentOverride && !resolvedAgentOverride) {
-    return {
-      status: 'error',
-      summary: `Approved agent override '${agentOverride}' is not available`,
-      error: `Cannot launch '${agentOverride}': it is not currently a visible ${proposal.agentCategory} agent (removed, renamed, or disabled since the proposal was shown). Re-propose the delegation.`,
-    };
+    return errorResult(
+      `Cannot launch '${agentOverride}': it is not currently a visible ${proposal.agentCategory} agent (removed, renamed, or disabled since the proposal was shown). Re-propose the delegation.`,
+      {
+        summary: `Approved agent override '${agentOverride}' is not available`,
+      },
+    );
   }
 
   const effective = {

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -33,6 +33,7 @@ import {
 } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import { configureDelegatedChildApprovals } from '@tools/approval';
+import { errorResult, executed } from '@tools/core/result';
 import { generateExecutionId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -76,16 +77,16 @@ export async function executeSubagent(
   const parentContext = tryUseRunContext();
   const parentSession = getRunContextSession(parentContext);
   if (!parentContext || !parentSession) {
-    return {
-      status: 'error',
-      summary: 'Delegation session unavailable',
-      error:
-        'delegate_agent and delegate_workflow require an active agent session. Run delegation from an active agent session, or ensure the tool run context provides its owning session.',
-      diagnostics: {
-        type: 'missing_session',
-        tools: ['delegate_agent', 'delegate_workflow'],
+    return errorResult(
+      'delegate_agent and delegate_workflow require an active agent session. Run delegation from an active agent session, or ensure the tool run context provides its owning session.',
+      {
+        summary: 'Delegation session unavailable',
+        diagnostics: {
+          type: 'missing_session',
+          tools: ['delegate_agent', 'delegate_workflow'],
+        },
       },
-    };
+    );
   }
   const parentExecutionId = getRunContextExecutionId(parentContext);
   // Captured now (while the launching tool call's ALS frame is live) so the
@@ -134,20 +135,16 @@ export async function executeSubagent(
         onStreamResolved: inheritChildStreamApprovals,
         onCost: recordCost,
       });
-      return {
-        status: 'executed',
-        summary:
-          result.outcome === 'cancelled'
-            ? `Cancelled '${agentName}'`
-            : `Completed '${agentName}'`,
-        output: delivery,
-      };
+      return executed(
+        delivery,
+        result.outcome === 'cancelled'
+          ? `Cancelled '${agentName}'`
+          : `Completed '${agentName}'`,
+      );
     } catch (err) {
-      return {
-        status: 'error',
+      return errorResult(toErrorMessage(err), {
         summary: `Subagent '${agentName}' failed`,
-        error: toErrorMessage(err),
-      };
+      });
     }
   }
 

--- a/src/tools/fileInteractions.ts
+++ b/src/tools/fileInteractions.ts
@@ -1,6 +1,7 @@
 // Local imports
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { type ToolResult } from '@shared/schemas/toolResult';
+import { errorResult } from '@tools/core/result';
 
 export function recordToolFileRead(path: string): void {
   const context = getCurrentToolCallContext();
@@ -17,12 +18,12 @@ export function requireFileReadForEdit(
   if (!context || !exists || context.tracker.hasRead(path)) {
     return null;
   }
-  return {
-    status: 'error',
-    summary: `Read ${path} before editing`,
-    error:
-      errorMessage ??
+  return errorResult(
+    errorMessage ??
       'Edits to existing files require a prior read in this session. Please call read_file first.',
-    diagnostics: { reason: 'unread-file', path },
-  };
+    {
+      summary: `Read ${path} before editing`,
+      diagnostics: { reason: 'unread-file', path },
+    },
+  );
 }

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -26,7 +26,7 @@ import {
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
-import { emptyResult, executed } from '@tools/core/result';
+import { executed } from '@tools/core/result';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { executeCommand } from '@utils/system/execUtils';
 
@@ -321,7 +321,10 @@ function execList(): ToolResult {
     .map((b) => b.key);
   const all = [...repoKeys, ...prKeys, ...issueKeys];
   if (all.length === 0) {
-    return emptyResult('No active subscriptions on this stream.');
+    return executed(
+      'No active subscriptions on this stream.',
+      'No active subscriptions on this stream.',
+    );
   }
   return executed(
     all.map((k) => `- ${k}`).join('\n'),

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -26,6 +26,7 @@ import {
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
+import { emptyResult, executed } from '@tools/core/result';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { executeCommand } from '@utils/system/execUtils';
 
@@ -320,17 +321,12 @@ function execList(): ToolResult {
     .map((b) => b.key);
   const all = [...repoKeys, ...prKeys, ...issueKeys];
   if (all.length === 0) {
-    return {
-      status: 'executed',
-      summary: 'No active subscriptions on this stream.',
-      output: 'No active subscriptions on this stream.',
-    };
+    return emptyResult('No active subscriptions on this stream.');
   }
-  return {
-    status: 'executed',
-    summary: `${all.length} active subscription(s).`,
-    output: all.map((k) => `- ${k}`).join('\n'),
-  };
+  return executed(
+    all.map((k) => `- ${k}`).join('\n'),
+    `${all.length} active subscription(s).`,
+  );
 }
 
 // GitHub SSH/HTTPS URL → { owner, repo }. Handles `.git` suffix, and repo

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -38,6 +38,7 @@ import {
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { requireInteractions } from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
+import { executed } from '@tools/core/result';
 import { formatResultCount } from '@utils/text/stringUtils';
 
 import { collectKnownSessionLinks } from './externalInquiryResultFormatter';
@@ -305,11 +306,10 @@ function buildReadOutput(manifest: ExternalInquiryThreadManifest): ToolResult {
     }
   }
 
-  return {
-    status: 'executed',
-    summary: `Inquiry thread ${manifest.threadId} (${manifest.status}, ${formatResultCount(manifest.turns.length, 'turn')})`,
-    output: lines.join('\n'),
-  };
+  return executed(
+    lines.join('\n'),
+    `Inquiry thread ${manifest.threadId} (${manifest.status}, ${formatResultCount(manifest.turns.length, 'turn')})`,
+  );
 }
 
 function buildListOutput(
@@ -318,11 +318,10 @@ function buildListOutput(
   scope: string,
 ): ToolResult {
   if (summaries.length === 0) {
-    return {
-      status: 'executed',
-      summary: `No inquiry threads (${filterStatus}, scope=${scope})`,
-      output: '(no threads)',
-    };
+    return executed(
+      '(no threads)',
+      `No inquiry threads (${filterStatus}, scope=${scope})`,
+    );
   }
   const lines = [
     `${summaries.length} thread(s) (${filterStatus}, scope=${scope}):`,
@@ -333,11 +332,7 @@ function buildListOutput(
     );
     lines.push(`    "${s.lastQuestionPreview}"`);
   }
-  return {
-    status: 'executed',
-    summary: `Inquiry threads: ${summaries.length}`,
-    output: lines.join('\n'),
-  };
+  return executed(lines.join('\n'), `Inquiry threads: ${summaries.length}`);
 }
 
 // ============================================================================

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -18,6 +18,7 @@ import {
   unwrapAbortError,
 } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
+import { errorResult, executed } from '@tools/core/result';
 import { ensureArray } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
@@ -205,11 +206,9 @@ Useful for finding the right lemma when you know roughly what type it should hav
         return {
           query,
           hits: [],
-          result: {
-            status: 'error',
+          result: errorResult(`Error: ${data.error}${suggestionText}`, {
             summary: 'No results',
-            error: `Error: ${data.error}${suggestionText}`,
-          },
+          }),
         };
       }
 
@@ -219,11 +218,10 @@ Useful for finding the right lemma when you know roughly what type it should hav
         return {
           query,
           hits: [],
-          result: {
-            status: 'executed',
-            summary: 'No results',
-            output: `No theorems found matching: ${query}\n\nTry a different type signature or name pattern.`,
-          },
+          result: executed(
+            `No theorems found matching: ${query}\n\nTry a different type signature or name pattern.`,
+            'No results',
+          ),
         };
       }
 
@@ -234,11 +232,7 @@ Useful for finding the right lemma when you know roughly what type it should hav
       return {
         query,
         hits,
-        result: {
-          status: 'executed',
-          summary: formatResultCount(hits.length, 'result'),
-          output: formatted,
-        },
+        result: executed(formatted, formatResultCount(hits.length, 'result')),
       };
     } catch (error) {
       // Defensive: ensure the checks below (and the surfaced message) see the
@@ -249,24 +243,20 @@ Useful for finding the right lemma when you know roughly what type it should hav
         return {
           query,
           hits: [],
-          result: {
-            status: 'error',
-            summary: 'Timeout',
-            error:
-              `Loogle API request timed out after ${LOOGLE_TIMEOUT_MS / 1000}s. ` +
+          result: errorResult(
+            `Loogle API request timed out after ${LOOGLE_TIMEOUT_MS / 1000}s. ` +
               `The Loogle server may be overloaded. Retry the request. ` +
               `If it persists, try a simpler type signature or search by name instead.`,
-          },
+            { summary: 'Timeout' },
+          ),
         };
       }
       return {
         query,
         hits: [],
-        result: {
-          status: 'error',
+        result: errorResult(`Error: ${toErrorMessage(err)}`, {
           summary: 'Loogle search failed',
-          error: `Error: ${toErrorMessage(err)}`,
-        },
+        }),
       };
     }
   }
@@ -305,17 +295,9 @@ Useful for finding the right lemma when you know roughly what type it should hav
 
     const output = sections.join('\n\n---\n\n');
     if (allFailed) {
-      return {
-        status: 'error',
-        summary,
-        error: output,
-      };
+      return errorResult(output, { summary });
     }
 
-    return {
-      status: 'executed',
-      summary,
-      output,
-    };
+    return executed(output, summary);
   }
 }

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { defineTool } from '@tools/core/define';
+import { errorResult, executed } from '@tools/core/result';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { formatResultCount } from '@utils/text/stringUtils';
 import {
@@ -127,11 +128,10 @@ Tips:
       const diagnostics =
         await getLeanLanguageServices().fetchDiagnosticsForFile(file);
       if (!diagnostics) {
-        return {
-          status: 'error',
-          summary: 'Failed to open file',
-          error: `Could not open file: ${file}\n\nMake sure the file exists and is accessible.`,
-        };
+        return errorResult(
+          `Could not open file: ${file}\n\nMake sure the file exists and is accessible.`,
+          { summary: 'Failed to open file' },
+        );
       }
 
       await getLeanLanguageServices().navigateToFirstError(file, diagnostics);
@@ -140,11 +140,7 @@ Tips:
       const countsStr = formatCounts(counts);
 
       if (diagnostics.length === 0) {
-        return {
-          status: 'executed',
-          summary: '✓ No diagnostics',
-          output: NO_DIAGNOSTICS_HELP,
-        };
+        return executed(NO_DIAGNOSTICS_HELP, '✓ No diagnostics');
       }
 
       const baseDiagnostics = { ...counts, total: diagnostics.length };
@@ -194,17 +190,12 @@ Requires: Lean 4 VS Code extension installed and active.`,
         file,
       );
       if (!success) {
-        return {
-          status: 'error',
-          summary: 'Command failed',
-          error: `Could not execute "${command}". Is the file open and the Lean 4 extension active?`,
-        };
+        return errorResult(
+          `Could not execute "${command}". Is the file open and the Lean 4 extension active?`,
+          { summary: 'Command failed' },
+        );
       }
-      return {
-        status: 'executed',
-        summary: description,
-        output: `Executed "${command}" on ${file}`,
-      };
+      return executed(`Executed "${command}" on ${file}`, description);
     } catch (error) {
       throw new ToolError(`Error: ${toErrorMessage(error)}`, {
         cause: error,
@@ -245,18 +236,13 @@ In VS Code, these commands use the Lean 4 extension. CLI and desktop provide the
       await getLeanLanguageServices().executeProjectCommand(command);
 
       if (command === 'build') {
-        return {
-          status: 'executed',
-          summary: description,
-          output: `Build started. Note: this command does not capture build output directly.\n\nTo check for errors and warnings, run lean_diagnostics on the relevant .lean files.`,
-        };
+        return executed(
+          `Build started. Note: this command does not capture build output directly.\n\nTo check for errors and warnings, run lean_diagnostics on the relevant .lean files.`,
+          description,
+        );
       }
 
-      return {
-        status: 'executed',
-        summary: description,
-        output: `Executed "${command}" successfully`,
-      };
+      return executed(`Executed "${command}" successfully`, description);
     } catch (error) {
       throw new ToolError(
         `Error executing "${command}": ${toErrorMessage(error)}`,
@@ -324,27 +310,21 @@ Requires: Lean 4 VS Code extension installed and active.`,
     );
 
     if (!data) {
-      return {
-        status: 'error',
-        summary: 'No goal state',
-        error: `Could not get goal state at ${location}${error ? `\nError: ${error}` : ''}`,
-      };
+      return errorResult(
+        `Could not get goal state at ${location}${error ? `\nError: ${error}` : ''}`,
+        { summary: 'No goal state' },
+      );
     }
 
     if (data.goals.length === 0) {
-      return {
-        status: 'executed',
-        summary: 'No goals',
-        output: 'No goals at this position. The proof may be complete here.',
-      };
+      return executed(
+        'No goals at this position. The proof may be complete here.',
+        'No goals',
+      );
     }
 
     const goalCount = data.goals.length;
-    return {
-      status: 'executed',
-      summary: formatResultCount(goalCount, 'goal'),
-      output: data.rendered,
-    };
+    return executed(data.rendered, formatResultCount(goalCount, 'goal'));
   }
 
   private async executeTermGoal(
@@ -360,14 +340,13 @@ Requires: Lean 4 VS Code extension installed and active.`,
     );
 
     if (!data) {
-      return {
-        status: 'error',
-        summary: 'No term goal',
-        error: `No expected type at ${location}${error ? `\nError: ${error}` : ''}`,
-      };
+      return errorResult(
+        `No expected type at ${location}${error ? `\nError: ${error}` : ''}`,
+        { summary: 'No term goal' },
+      );
     }
 
-    return { status: 'executed', summary: 'Term goal', output: data.goal };
+    return executed(data.goal, 'Term goal');
   }
 
   private async executeHover(
@@ -383,22 +362,19 @@ Requires: Lean 4 VS Code extension installed and active.`,
     );
 
     if (!data) {
-      return {
-        status: 'error',
-        summary: 'No hover info',
-        error: `No information at ${location}${error ? `\nError: ${error}` : ''}`,
-      };
+      return errorResult(
+        `No information at ${location}${error ? `\nError: ${error}` : ''}`,
+        { summary: 'No hover info' },
+      );
     }
 
     const text = extractHoverText(data.contents);
     if (!text) {
-      return {
-        status: 'error',
+      return errorResult(`Empty hover response at ${location}`, {
         summary: 'No hover info',
-        error: `Empty hover response at ${location}`,
-      };
+      });
     }
 
-    return { status: 'executed', summary: 'Hover info', output: text };
+    return executed(text, 'Hover info');
   }
 }

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -46,6 +46,7 @@ import {
 } from '@tools/goal';
 import { requireNonEmptyString } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
+import { errorResult, executed } from '@tools/core/result';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const logger = createChannelTrace('PlanTool');
@@ -167,28 +168,24 @@ pause/complete only affect autonomous goals; with no goal running they return gu
   ): Promise<ToolResult> {
     const goal = GoalStore.getForStream(streamId);
     if (!goal) {
-      return {
-        status: 'executed',
-        summary: 'No autonomous goal to pause.',
-        output:
-          'No autonomous goal is currently running on this stream, so there is nothing to pause. ' +
+      return executed(
+        'No autonomous goal is currently running on this stream, so there is nothing to pause. ' +
           'If you need user input, ask the user directly in your next message; do not call plan(command="pause") again.',
-      };
+        'No autonomous goal to pause.',
+      );
     }
     if (goal.status !== 'active') {
-      return {
-        status: 'executed',
-        summary: `Goal already ${goal.status} — pause is a no-op.`,
-        output: `Goal is ${goal.status}; pause is a no-op.\n\n${formatGoalView(goal)}`,
-      };
+      return executed(
+        `Goal is ${goal.status}; pause is a no-op.\n\n${formatGoalView(goal)}`,
+        `Goal already ${goal.status} — pause is a no-op.`,
+      );
     }
     const updated = (await GoalStore.setStatus(streamId, 'paused')) ?? goal;
     await this.setBashAutoApproval(streamId, false);
-    return {
-      status: 'executed',
-      summary: 'Goal paused.',
-      output: `Goal paused: ${reason}\n\n${formatGoalView(updated)}`,
-    };
+    return executed(
+      `Goal paused: ${reason}\n\n${formatGoalView(updated)}`,
+      'Goal paused.',
+    );
   }
 
   /**
@@ -286,12 +283,13 @@ pause/complete only affect autonomous goals; with no goal running they return gu
       logger.info('Plan rejected by user');
     }
 
-    return {
-      status: 'error',
-      summary: 'Plan rejected — revise approach',
-      error: `The user rejected this plan.${feedbackNote}\nPlease revise your approach based on the feedback and create an updated plan.`,
-      ...(feedback ? { userInstruction: feedback } : {}),
-    };
+    return errorResult(
+      `The user rejected this plan.${feedbackNote}\nPlease revise your approach based on the feedback and create an updated plan.`,
+      {
+        summary: 'Plan rejected — revise approach',
+        ...(feedback ? { userInstruction: feedback } : {}),
+      },
+    );
   }
 
   /**
@@ -309,16 +307,14 @@ pause/complete only affect autonomous goals; with no goal running they return gu
         'Run as Goal requested but goal feature flag is off; ' +
           'continuing without an autonomous goal.',
       );
-      return {
-        status: 'executed',
-        summary: 'Plan approved — autonomous run unavailable',
-        output:
-          `The user selected Run as Goal, but the goal feature flag is ` +
+      return executed(
+        `The user selected Run as Goal, but the goal feature flag is ` +
           `currently disabled. The plan is approved, but no autonomous ` +
           `goal was started.\n\n` +
           `Work toward the objective as a normal turn-by-turn workflow, ` +
           `tracking concrete steps with the todo tool.`,
-      };
+        'Plan approved — autonomous run unavailable',
+      );
     }
 
     const objective = plan.objective;
@@ -335,11 +331,8 @@ pause/complete only affect autonomous goals; with no goal running they return gu
             ? ((await GoalStore.setStatus(streamId, 'active')) ?? retargeted)
             : retargeted;
         await this.setBashAutoApproval(streamId, true);
-        return {
-          status: 'executed',
-          summary: `Plan approved — goal ${active.goalId} retargeted`,
-          output:
-            `The user approved a new plan while goal ${active.goalId} ` +
+        return executed(
+          `The user approved a new plan while goal ${active.goalId} ` +
             `was already in flight. The goal has been retargeted to the ` +
             `new objective.\n\n` +
             `${formatGoalView(active)}\n\n` +
@@ -349,24 +342,25 @@ pause/complete only affect autonomous goals; with no goal running they return gu
             `- Do not call plan(command="complete") until the stopping condition is verifiably true.\n` +
             `- If you genuinely need user input, call plan(command="pause") with a reason.\n\n` +
             `Objective:\n${objective}`,
-        };
+          `Plan approved — goal ${active.goalId} retargeted`,
+        );
       } catch (err) {
         const reason = toErrorMessage(err);
         logger.warn(
           'Failed to retarget in-flight goal for approved plan; returning an explicit error result.',
           { data: err },
         );
-        return {
-          status: 'error',
-          summary:
-            'Plan approved — goal could not be retargeted, proceeding without it',
-          error:
-            `The user approved this plan and requested autonomous execution, ` +
+        return errorResult(
+          `The user approved this plan and requested autonomous execution, ` +
             `but the in-flight goal could not be retargeted: ${reason}\n\n` +
             `Work toward the new objective turn-by-turn. The pre-existing ` +
             `goal is still active and will keep injecting continuations ` +
             `against its previous objective until the user pauses or abandons it.`,
-        };
+          {
+            summary:
+              'Plan approved — goal could not be retargeted, proceeding without it',
+          },
+        );
       }
     }
 

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -49,13 +49,10 @@ export class TexcountTool extends defineTool({
     });
 
     if (!output) {
-      const errorMessage =
+      throw new ToolError(
         errors.join('\n') ||
-        'texcount did not return any output. Ensure the files exist.';
-      return {
-        status: 'error',
-        error: errorMessage,
-      };
+          'texcount did not return any output. Ensure the files exist.',
+      );
     }
 
     return {

--- a/src/transcript/ResidentStreamRegistry.ts
+++ b/src/transcript/ResidentStreamRegistry.ts
@@ -1,0 +1,101 @@
+/**
+ * One resident record per key, held in a single map so dropping a key's
+ * state is one `.delete()` — every field disappears with it BY
+ * CONSTRUCTION. `StreamSnapshotStore` and `StreamLogStore` independently
+ * arrived at this same "one record per stream" shape for their own
+ * per-stream lifecycle bookkeeping (each had previously needed a
+ * hand-maintained list of parallel maps/sets that had already drifted once
+ * before being unified — see each store's own record-type doc comment for
+ * the specifics). This factors out the shared container so a future
+ * accumulator or lifecycle flag doesn't need its own bespoke
+ * get-or-create/prune/evict wiring.
+ *
+ * Every capability here is opt-in per consumer: a store with no "prune once
+ * every field is empty" concept (`StreamSnapshotStore`, whose records
+ * persist until an explicit `evict`) simply never calls {@link pruneIfEmpty},
+ * and a store with no per-key version counter (`StreamLogStore`, which
+ * tracks a single store-wide revision instead) never calls
+ * {@link version}/{@link bumpVersion}/{@link evict}/{@link evictAll}. The
+ * two stores' own persistence-strategy code (per-(key,category) write
+ * mutexes vs debounce+generation) is NOT part of this container and stays
+ * on each store.
+ */
+export class ResidentStreamRegistry<TId, TState> {
+  private readonly records = new Map<TId, TState>();
+  /**
+   * Per-key version counters. Deliberately never deleted — not even by
+   * {@link evict}/{@link evictAll} — so a version captured before a key's
+   * record is dropped still lets an in-flight async operation detect that it
+   * raced against a later change for the same key.
+   */
+  private readonly versions = new Map<TId, number>();
+
+  constructor(private readonly createDefault: () => TState) {}
+
+  getOrCreate(id: TId): TState {
+    let record = this.records.get(id);
+    if (!record) {
+      record = this.createDefault();
+      this.records.set(id, record);
+    }
+    return record;
+  }
+
+  get(id: TId): TState | undefined {
+    return this.records.get(id);
+  }
+
+  /** Matches `Map.set` so a record can be seeded directly (e.g. by tests). */
+  set(id: TId, state: TState): void {
+    this.records.set(id, state);
+  }
+
+  delete(id: TId): boolean {
+    return this.records.delete(id);
+  }
+
+  clear(): void {
+    this.records.clear();
+  }
+
+  keys(): IterableIterator<TId> {
+    return this.records.keys();
+  }
+
+  values(): IterableIterator<TState> {
+    return this.records.values();
+  }
+
+  entries(): IterableIterator<[TId, TState]> {
+    return this.records.entries();
+  }
+
+  [Symbol.iterator](): IterableIterator<[TId, TState]> {
+    return this.records.entries();
+  }
+
+  /** Drop a record once `isEmpty` reports no field on it still holds state. */
+  pruneIfEmpty(id: TId, isEmpty: (state: TState) => boolean): void {
+    const record = this.records.get(id);
+    if (record && isEmpty(record)) this.records.delete(id);
+  }
+
+  version(id: TId): number {
+    return this.versions.get(id) ?? 0;
+  }
+
+  bumpVersion(id: TId): void {
+    this.versions.set(id, this.version(id) + 1);
+  }
+
+  /** Bump a key's version, then drop its record — the two always happen together. */
+  evict(id: TId): void {
+    this.bumpVersion(id);
+    this.records.delete(id);
+  }
+
+  evictAll(): void {
+    for (const id of this.records.keys()) this.bumpVersion(id);
+    this.records.clear();
+  }
+}

--- a/src/transcript/ResidentStreamRegistry.ts
+++ b/src/transcript/ResidentStreamRegistry.ts
@@ -45,7 +45,7 @@ export class ResidentStreamRegistry<TId, TState> {
     return this.records.get(id);
   }
 
-  /** Matches `Map.set` so a record can be seeded directly (e.g. by tests). */
+  /** Matches `Map.set` for tests that seed a stale resident record directly. */
   set(id: TId, state: TState): void {
     this.records.set(id, state);
   }
@@ -64,10 +64,6 @@ export class ResidentStreamRegistry<TId, TState> {
 
   values(): IterableIterator<TState> {
     return this.records.values();
-  }
-
-  entries(): IterableIterator<[TId, TState]> {
-    return this.records.entries();
   }
 
   [Symbol.iterator](): IterableIterator<[TId, TState]> {

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -18,6 +18,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { StorageFS } from '@utils/files/storageFS';
 import { formatResultCount } from '@utils/text/stringUtils';
 
+import { ResidentStreamRegistry } from './ResidentStreamRegistry';
 import {
   isRunningGroupEntry,
   isRunningStreamingTextEntry,
@@ -106,12 +107,14 @@ interface StreamWriterOwnership {
 
 /**
  * Every per-stream field that shares the resident stream lifecycle, keyed by
- * stream id in ONE map (`streams`). Because every field for a stream lives on
- * the same object, dropping a stream's resident state is one
- * `streams.delete(id)` — every field disappears with it BY CONSTRUCTION, which
- * is what lets `forgetStreamState` / `forgetAllStreamState` be a single
- * delete/clear. When an individual field is cleared, `pruneStreamState`
- * removes the record once no field remains, so an idle stream holds no memory.
+ * stream id in ONE map (`streams`, a {@link ResidentStreamRegistry}) instead
+ * of parallel hand-synced maps/sets. Because every field for a stream lives
+ * on the same object, dropping a stream's resident state is one
+ * `streams.delete(id)` — every field disappears with it BY CONSTRUCTION,
+ * which is what lets `forgetStreamState` / `forgetAllStreamState` collapse to
+ * a single delete/clear. When an individual field is cleared,
+ * `pruneStreamState` removes the record once no field remains, preserving
+ * the old "absent from every collection" memory footprint.
  *
  * `summaries` (deliberately OUTLIVES per-stream eviction so sidebar metadata
  * survives when heavy `log` entries are dropped) and `writeTombstones` (a
@@ -246,7 +249,10 @@ export class StreamLogStore {
    * {@link StreamState}. `summaries`, `writeTombstones`, and `dirtyIds` are
    * deliberately kept separate because they do not share this lifecycle.
    */
-  private readonly streams = new Map<StreamTabId, StreamState>();
+  private readonly streams = new ResidentStreamRegistry<
+    StreamTabId,
+    StreamState
+  >(() => ({}));
   /**
    * Streams with unsaved changes awaiting `executeWrite`, kept as a dedicated
    * set (not a `StreamState` field) so the `save()` hot path can test
@@ -302,12 +308,7 @@ export class StreamLogStore {
   // empty-record prune, and the two multi-caller iterations are factored out.
 
   private ensureStreamState(streamId: StreamTabId): StreamState {
-    let state = this.streams.get(streamId);
-    if (!state) {
-      state = {};
-      this.streams.set(streamId, state);
-    }
-    return state;
+    return this.streams.getOrCreate(streamId);
   }
 
   /**
@@ -318,18 +319,16 @@ export class StreamLogStore {
    * below already keep its record alive.
    */
   private pruneStreamState(streamId: StreamTabId): void {
-    const s = this.streams.get(streamId);
-    if (
-      s &&
-      s.log === undefined &&
-      !s.pendingRelease &&
-      !s.flushing &&
-      !s.loadFailed &&
-      s.pendingLoad === undefined &&
-      s.writer === undefined
-    ) {
-      this.streams.delete(streamId);
-    }
+    this.streams.pruneIfEmpty(
+      streamId,
+      (s) =>
+        s.log === undefined &&
+        !s.pendingRelease &&
+        !s.flushing &&
+        !s.loadFailed &&
+        s.pendingLoad === undefined &&
+        s.writer === undefined,
+    );
   }
 
   /** Snapshot of streams with unsaved changes (list form of `dirtyIds`). */

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -65,6 +65,7 @@ import { mapToRecord, normalizeFilePath } from '@utils/core';
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 
+import { ResidentStreamRegistry } from './ResidentStreamRegistry';
 import {
   canUseStreamDataDir,
   decodeStreamId,
@@ -274,9 +275,12 @@ function descriptorFromConfig(
  * `records.delete(stream)` — every field disappears with it BY CONSTRUCTION,
  * so `evict()`/`evictAll()` cannot drift from the field list.
  *
- * `streamVersions` (must survive eviction to keep guarding in-flight seed
- * races) and `writeMutexes` (keyed by the compound `${stream}::${key}`, not
- * a bare stream id) stay as their own maps on the store.
+ * Per-stream version counters (must survive eviction to keep guarding
+ * in-flight seed races) live inside the shared {@link ResidentStreamRegistry}
+ * container that backs `records`, not on the record itself. `writeMutexes`
+ * (keyed by the compound `${stream}::${key}`, not a bare stream id) stays as
+ * its own map on the store — the same exclusion #7892 already carved out of
+ * `perStreamStores()`.
  */
 interface StreamRecord {
   // -- Accumulated durable state (mirrors on-disk StreamData) --------------
@@ -353,7 +357,26 @@ type RollbackState = IdleRollbackState | RecoveringRollbackState;
 type DeletionState = StagedDeletionState | RollbackState;
 
 export class StreamSnapshotStore {
-  private readonly records = new Map<StreamTabId, StreamRecord>();
+  private readonly records = new ResidentStreamRegistry<
+    StreamTabId,
+    StreamRecord
+  >(() => ({
+    outputFiles: {},
+    missingOutputs: {},
+    compileFailures: {},
+    usage: new Map(),
+    usageUnparsed: new Map(),
+    workPlan: EMPTY_WORK_PLAN,
+    meta: undefined,
+    runDescriptor: undefined,
+    runConfig: undefined,
+    seeded: false,
+    seedChain: undefined,
+    metaOverlay: false,
+    overlays: {},
+    kv: undefined,
+    writeKv: undefined,
+  }));
   /**
    * Writes arriving while a stream's live directory is reversibly staged.
    * Keeping the latest value per sidecar makes the staging rename a real
@@ -365,32 +388,10 @@ export class StreamSnapshotStore {
   // -- Per (stream, category) serialized write locks -------------------------
   private readonly writeMutexes = new Map<string, Mutex>();
 
-  private readonly streamVersions = new Map<StreamTabId, number>();
   private hasAuthoritativeStreamSet = false;
 
   private getOrCreateRecord(stream: StreamTabId): StreamRecord {
-    let record = this.records.get(stream);
-    if (!record) {
-      record = {
-        outputFiles: {},
-        missingOutputs: {},
-        compileFailures: {},
-        usage: new Map(),
-        usageUnparsed: new Map(),
-        workPlan: EMPTY_WORK_PLAN,
-        meta: undefined,
-        runDescriptor: undefined,
-        runConfig: undefined,
-        seeded: false,
-        seedChain: undefined,
-        metaOverlay: false,
-        overlays: {},
-        kv: undefined,
-        writeKv: undefined,
-      };
-      this.records.set(stream, record);
-    }
-    return record;
+    return this.records.getOrCreate(stream);
   }
 
   private kv(streamId: StreamTabId): KVStore {
@@ -435,11 +436,11 @@ export class StreamSnapshotStore {
   }
 
   private streamVersion(stream: StreamTabId): number {
-    return this.streamVersions.get(stream) ?? 0;
+    return this.records.version(stream);
   }
 
   private bumpStreamVersion(stream: StreamTabId): void {
-    this.streamVersions.set(stream, this.streamVersion(stream) + 1);
+    this.records.bumpVersion(stream);
   }
 
   private canMutateSynchronously(stream: StreamTabId): boolean {
@@ -977,16 +978,14 @@ export class StreamSnapshotStore {
 
   /** Drop a stream's in-memory state. Disk cleanup is the caller's job. */
   evict(stream: StreamTabId): void {
-    this.bumpStreamVersion(stream);
-    this.records.delete(stream);
+    this.records.evict(stream);
     for (const key of [...this.writeMutexes.keys()]) {
       if (key.startsWith(`${stream}::`)) this.writeMutexes.delete(key);
     }
   }
 
   evictAll(): void {
-    for (const stream of this.records.keys()) this.bumpStreamVersion(stream);
-    this.records.clear();
+    this.records.evictAll();
     this.writeMutexes.clear();
     for (const state of this.deletionStates.values()) {
       if (state.kind === 'staging') state.resolveSettled();

--- a/src/utils/core/listenerSet.ts
+++ b/src/utils/core/listenerSet.ts
@@ -1,0 +1,33 @@
+/**
+ * A minimal listener registry: `add()` subscribes and returns a disposer,
+ * `clear()` drops everyone, and iteration (`for...of`, `[...set]`) reaches the
+ * underlying listeners directly so each call site keeps choosing live vs.
+ * snapshot iteration exactly as a hand-rolled `Set` would. Collapses the
+ * "Set + add-returns-a-disposer-that-deletes" shape repeated across the
+ * runtime and host-interaction layers.
+ */
+export interface ListenerSet<T extends (...args: never[]) => void> {
+  readonly size: number;
+  add(listener: T): () => void;
+  clear(): void;
+  [Symbol.iterator](): IterableIterator<T>;
+}
+
+export function createListenerSet<
+  T extends (...args: never[]) => void,
+>(): ListenerSet<T> {
+  const listeners = new Set<T>();
+  return {
+    get size() {
+      return listeners.size;
+    },
+    add: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    clear: () => listeners.clear(),
+    [Symbol.iterator]: () => listeners.values(),
+  };
+}

--- a/src/utils/core/listenerSet.ts
+++ b/src/utils/core/listenerSet.ts
@@ -7,7 +7,6 @@
  * runtime and host-interaction layers.
  */
 export interface ListenerSet<T extends (...args: never[]) => void> {
-  readonly size: number;
   add(listener: T): () => void;
   clear(): void;
   [Symbol.iterator](): IterableIterator<T>;
@@ -18,9 +17,6 @@ export function createListenerSet<
 >(): ListenerSet<T> {
   const listeners = new Set<T>();
   return {
-    get size() {
-      return listeners.size;
-    },
     add: (listener) => {
       listeners.add(listener);
       return () => {


### PR DESCRIPTION
## Summary

This PR consolidates duplicated scaffolding across agent-CLI providers (codex, claudeAgent) into a shared `startAgentCliLoop` function, and extracts media classification logic used by multiple model handlers into a reusable module. It also introduces helper functions for building common `ToolResult` shapes and a `ResidentStreamRegistry` container to unify per-stream lifecycle bookkeeping.

## Issue acceptance gates

N/A — refactoring/consolidation work.

## Single source of truth

- **Agent-CLI loop orchestration:** `startAgentCliLoop` in `src/tools/agentCliShared.ts` now owns the boilerplate-identical scaffolding (session registration, lastPrompt capture, turn summary formatting, usage publishing) common to every agent-CLI provider.
- **Media classification:** `classifyMediaEntry` in `src/agent/modelHandlers/support/mediaClassification.ts` owns the structural classification of media entries (image vs. PDF vs. audio vs. unsupported) used by Anthropic, OpenAI chat, and OpenAI Responses handlers.
- **Per-stream resident state:** `ResidentStreamRegistry` in `src/transcript/ResidentStreamRegistry.ts` owns the unified container for all per-stream fields that share the resident lifecycle, replacing parallel hand-synced maps.
- **ToolResult builders:** `src/tools/core/result.ts` provides `executed()`, `emptyResult()`, and `errorResult()` for the dominant ToolResult shapes.

## Duplication and abstraction budget

**Removed duplication:**
- Codex and claudeAgent each had ~80 lines of identical loop scaffolding (session registration, lastPrompt threading, turn summary formatting, usage publishing, error handling). Consolidated into `startAgentCliLoop` with provider-specific callbacks.
- Anthropic, OpenAI chat, and OpenAI Responses each repeated the same media classification logic (checking `media_category`, MIME type, PDF support). Extracted into `classifyMediaEntry`.
- `StreamSnapshotStore` and `StreamLogStore` each maintained parallel hand-synced maps/sets for per-stream state. Unified into `ResidentStreamRegistry` so dropping a stream is one `.delete()` — every field disappears by construction.
- Multiple tools hand-built `{ status: 'executed', output: ... }` and `{ status: 'error', error: ... }` literals. Replaced with `executed()` and `errorResult()` helpers.

**New abstractions:**
- `ChannelStreamAggregator`: Base class for streaming aggregators (OpenAI reasoning models, OpenRouter) that accumulate content, reasoning, and tool-call fragments. Owns the shared accumulation state; subclasses differ only in chunk shape and response construction.
- `ListenerSet<T>`: Minimal listener registry collapsing the "Set + add-returns-a-disposer" shape repeated across runtime and host-interaction layers.

## Net elements (R6)

**Files added:** 5
- `src/agent/modelHandlers/support/mediaClassification.ts` (44 lines)
- `src/agent/modelHandlers/utils/channelStreamAggregator.ts` (42 lines)
- `src/transcript/ResidentStreamRegistry.ts` (101 lines)
- `src/tools/core/result.ts` (45 lines)
- `src/utils/core/listenerSet.ts` (33 lines)

**Files modified:** 18
- `src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts`: Refactored media content creation to use `classifyMediaEntry`; extracted ~50 lines of classification logic.
- `src/agent/modelHandlers/openai/modelHandlerOpenAI.ts`: Use `classifyMediaEntry`.
- `src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts`: Use `classifyMediaEntry` and `uploadAndRecordToolAttachments`.
- `src/agent/modelHandlers/openai/BaseReasoningStreamAggregator.ts`: Inherit from `ChannelStreamAggregator`.
- `src/agent/modelHandlers/

https://claude.ai/code/session_01233jpnfVhfkGgvmxw2yj5c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model-handler media and tool-attachment paths, transcript eviction/versioning, and agent-CLI session loops; behavior should be equivalent but regressions could affect multimodal input, file uploads, or stream persistence.
> 
> **Overview**
> **Refactors duplicated agent and tool plumbing** into shared modules and rewires call sites, without changing the outward behavior of model calls or tool contracts.
> 
> **Model handlers** now route user media through `classifyMediaEntry` (image / PDF / audio / unsupported) in Anthropic, OpenAI chat, and Responses paths, with consistent unknown-category warnings. OpenAI-compatible and OpenRouter stream aggregators inherit **`ChannelStreamAggregator`** for content, reasoning, and tool-call accumulation. Anthropic and OpenAI Responses tool-result follow-ups use **`uploadAndRecordToolAttachments`** instead of duplicating upload + `finalResult.files` wiring.
> 
> **Agent-CLI tools** (`codex`, `claudeAgent`) delegate the repeated child-run loop (session registration, `lastPrompt`, usage publish, delivery/error formatting) to **`startAgentCliLoop`** in `agentCliShared.ts`, supplying only provider-specific turn execution and formatting callbacks.
> 
> **Tools and runtime** adopt **`executed()`** / **`errorResult()`** across executions, delegation, Lean, plan, and related tools; **`open_pdf`** and **texcount** throw **`ToolError`** where inline error results used to be returned. **`ListenerSet`** replaces hand-rolled subscribe/dispose sets in **`SessionHostInteractions`** and **`executionRegistry`**.
> 
> **Transcript stores** back per-stream resident state with **`ResidentStreamRegistry`** in **`StreamLogStore`** and **`StreamSnapshotStore`** (get-or-create, prune-if-empty, versioned eviction).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8998f2b910d2e67acf992f583457e51144ab1f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->