### PR TITLE
refactor: sweep the sediment twelve refactor waves left behind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ references/openrouter-skills/
 
 # Generated TypeScript compiler output
 out/
+
+
+errorLogs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ All notable changes to this project will be documented in this file.
 
 ### Shared (all surfaces)
 
+#### Features
+
+- **Workflow scripts are available to the software-engineering and Lean team
+  leads** — after enabling Workflow Script in the Tools panel, these teams can
+  run predetermined parallel and sequential agent pipelines that resume safely
+  after interruption.
+
 #### Breaking Changes
 
 - **Tool-use flow results use `response` and `files` consistently** — consumers

--- a/docs/supabase/SYNC_REMOTE_AGENTS.sql
+++ b/docs/supabase/SYNC_REMOTE_AGENTS.sql
@@ -312,7 +312,7 @@ VALUES (
   'tool-use-lean/leanOrchestrator.yaml',
   ARRAY['researcher', 'lean'],
   'toolUse',
-  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'codex', 'claude_code', 'lean_diagnostics', 'lean_inspect', 'lean_loogle', 'lean_file', 'lean_project', 'github_subscription']
+  ARRAY['delegate_workflow', 'delegate_agent', 'delegate_workflow_script', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'codex', 'claude_code', 'lean_diagnostics', 'lean_inspect', 'lean_loogle', 'lean_file', 'lean_project', 'github_subscription']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3,7 +3,6 @@ import { createChannelTrace, type AgentEvent } from '@agent/trace';
 import type { AgentRunHandle as RuntimeAgentRunHandle } from '@agent/runtime/ExecutionHandle';
 import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 import type { HostInteractions as RuntimeHostInteractions } from '@agent/runtime/HostInteractions';
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ITool } from '@agent/core/tools/ToolTypes';
 
 // Local imports - runtime
@@ -112,7 +111,7 @@ class AgentRunStream implements AgentRun {
     if (this.interruptPending) handle.interrupt();
   }
 
-  attachEvents(session: SessionHandle): void {
+  attachEvents(session: RuntimeSessionHandle): void {
     this.detachEvents = session.events.subscribe(
       (event) => {
         if (

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -1,9 +1,6 @@
 // Chat-session controller: owns run start/resume/stop state-transition
 // orchestration for the CLI chat session. Host-neutral (no Ink/TUI rendering
 // dependencies) — the Ink component consumes narrow commands exposed here.
-//
-// Extracted from runChatTui.tsx per #6328 so that UI rendering, command
-// parsing, runtime orchestration, and persistence rules evolve independently.
 
 import PQueue from 'p-queue';
 
@@ -203,26 +200,6 @@ export function createChatSessionController(
     attachTuiRunFactSubscription(runtimeSession.events, snapshotStore),
   );
 
-  const activateAgentConfig = (
-    config: Pick<
-      AgentConfig,
-      'agent' | 'model' | 'cliMultiAgentPresetId' | 'delegationAgentScope'
-    >,
-    modelSource?: 'history',
-  ): void => {
-    patchSessionMeta({
-      agent: config.agent,
-      model: config.model,
-      ...(modelSource ? { modelSource } : {}),
-      canDelegate: chatAgentSupportsDelegation(config.agent),
-      teamName: readCliMultiAgentPresetName(
-        config.cliMultiAgentPresetId ?? undefined,
-      ),
-      cliMultiAgentPresetId: config.cliMultiAgentPresetId ?? undefined,
-      delegationAgentScope: config.delegationAgentScope ?? undefined,
-    });
-  };
-
   // Shared prelude of the three run-starting paths (start, resume,
   // follow-up-wake resume): resolve the model-keyed session context and
   // activate the config into the session meta signals in one step.
@@ -235,7 +212,17 @@ export function createChatSessionController(
   ): { readonly currentModel: string; readonly sessionContext: CliContext } => {
     const currentModel = config.model;
     const sessionContext = getSessionContext(currentModel);
-    activateAgentConfig(config, modelSource);
+    patchSessionMeta({
+      agent: config.agent,
+      model: config.model,
+      ...(modelSource ? { modelSource } : {}),
+      canDelegate: chatAgentSupportsDelegation(config.agent),
+      teamName: readCliMultiAgentPresetName(
+        config.cliMultiAgentPresetId ?? undefined,
+      ),
+      cliMultiAgentPresetId: config.cliMultiAgentPresetId ?? undefined,
+      delegationAgentScope: config.delegationAgentScope ?? undefined,
+    });
     return { currentModel, sessionContext };
   };
 
@@ -570,12 +557,8 @@ export function createChatSessionController(
 
   const tryResumeStream = (
     streamId: StreamTabId,
-    recoveryOrOptions: RecoveryContinuation | AutoResumeOptions = {},
+    options: AutoResumeOptions = {},
   ): Promise<boolean> => {
-    const options: AutoResumeOptions =
-      'kind' in recoveryOrOptions
-        ? { recovery: recoveryOrOptions }
-        : recoveryOrOptions;
     let resolveRun: (resumed: boolean) => void = () => {};
     let rejectRun: (error: unknown) => void = () => {};
     const runPromise = new Promise<boolean>((resolve, reject) => {
@@ -789,7 +772,8 @@ export function createChatSessionController(
     clearInterruptedRecovery: () => {
       void supersedeInterruptedRecovery();
     },
-    tryResumeStream,
+    tryResumeStream: (streamId, recovery) =>
+      tryResumeStream(streamId, recovery ? { recovery } : {}),
     canStartRootRun: () => chatTuiCanStartRootRun(session),
   };
 }

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -184,7 +184,6 @@ export function App(props: AppProps): React.JSX.Element {
   const activeDraftRegistry = useMemo(() => createActiveDraftRegistry(), []);
   const canStopActiveRun =
     props.canStopActiveRun ?? props.canInterruptActiveRun;
-  const agentSelectionAvailable = rootRunStartAvailable;
   const activeApprovalVisible = approvalVisibleForActiveStream({
     activeStreamId,
     pending,
@@ -624,7 +623,7 @@ export function App(props: AppProps): React.JSX.Element {
               }
             />
             <StatusBar
-              agentSelectionAvailable={agentSelectionAvailable}
+              agentSelectionAvailable={rootRunStartAvailable}
               commandName={props.commandName}
               foregroundEscapeAction={foregroundEscapeAction({
                 activeFormEscapeAction: formBusy

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -103,9 +103,9 @@ export function agentSelectWindow({
     };
   }
 
-  const chromeRows = 8 + Math.max(0, extraRows);
   // Border, title, description, tool-use heading, and key hints are the fixed
   // chrome for the primary selectable list.
+  const chromeRows = 8 + Math.max(0, extraRows);
   const selectRows = Math.max(1, availableRows - chromeRows);
   if (itemCount > selectRows) {
     return {

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -413,25 +413,32 @@ function fitTransientNoticeStatusBarLeftSegments(
     }
   }
 
+  // Shrink `segment` (always the untruncated original, so repeated fits never
+  // compound) into whatever room the rest of the row leaves at `index`.
+  const truncatedIntoRemainingWidth = (
+    index: number,
+    segment: StatusBarSegment,
+  ): StatusBarSegment => {
+    const fixedWidth = fitted.reduce(
+      (total, other, otherIndex) =>
+        otherIndex === index ? total : total + statusBarSegmentWidth(other),
+      fitted.length - 1,
+    );
+    return {
+      ...segment,
+      text: truncateSummaryToWidth(
+        segment.text,
+        Math.max(0, innerWidth - fixedWidth),
+      ),
+    };
+  };
+
   const fitNotice = (): void => {
     const fittedNoticeIndex = fittedNotice ? fitted.indexOf(fittedNotice) : -1;
     if (fittedNoticeIndex < 0 || statusBarSegmentsWidth(fitted) <= innerWidth) {
       return;
     }
-    const fixedWidth = fitted.reduce(
-      (total, segment, index) =>
-        index === fittedNoticeIndex
-          ? total
-          : total + statusBarSegmentWidth(segment),
-      fitted.length - 1,
-    );
-    fittedNotice = {
-      ...notice,
-      text: truncateSummaryToWidth(
-        notice.text,
-        Math.max(0, innerWidth - fixedWidth),
-      ),
-    };
+    fittedNotice = truncatedIntoRemainingWidth(fittedNoticeIndex, notice);
     fitted[fittedNoticeIndex] = fittedNotice;
   };
 
@@ -456,20 +463,10 @@ function fitTransientNoticeStatusBarLeftSegments(
     const fittedNoticeIndex = fittedNotice ? fitted.indexOf(fittedNotice) : -1;
     if (fittedNoticeIndex >= 0) fitted.splice(fittedNoticeIndex, 1);
     const fittedWarningIndex = fitted.indexOf(discardWarning);
-    const fixedWidth = fitted.reduce(
-      (total, segment, index) =>
-        index === fittedWarningIndex
-          ? total
-          : total + statusBarSegmentWidth(segment),
-      fitted.length - 1,
+    fitted[fittedWarningIndex] = truncatedIntoRemainingWidth(
+      fittedWarningIndex,
+      discardWarning,
     );
-    fitted[fittedWarningIndex] = {
-      ...discardWarning,
-      text: truncateSummaryToWidth(
-        discardWarning.text,
-        Math.max(0, innerWidth - fixedWidth),
-      ),
-    };
   }
 
   return fitted;
@@ -634,7 +631,10 @@ function statusBarBindingsText(
   return text;
 }
 
-function fitsStatusBindings(text: string, maxColumns: number | undefined) {
+function fitsStatusBindings(
+  text: string,
+  maxColumns: number | undefined,
+): boolean {
   return maxColumns === undefined || textDisplayWidth(text) <= maxColumns;
 }
 

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -1,9 +1,6 @@
-// `texra chat` entry point — single Ink-based session.
-//
-// The legacy line-based renderer was retired in favour of one canonical
-// path: the Ink TUI runs for every interactive `texra chat` invocation, and
-// non-TTY callers are pointed at `texra run` (which is what they actually
-// want for piping/scripting).
+// `texra chat` entry point — single Ink-based session. The Ink TUI runs for
+// every interactive `texra chat` invocation, and non-TTY callers are pointed
+// at `texra run` (which is what they actually want for piping/scripting).
 //
 // Run start/resume/stop orchestration lives in ../chatSessionController;
 // this module keeps only composition, rendering glue, and the Ink lifecycle.
@@ -208,9 +205,7 @@ export function restorePendingSkillActivations(
   }
 }
 
-export type ChatTuiFocusedChildFollowUpRoute = FocusedChildFollowUpRoute;
-
-export function chatTuiFocusedChildFollowUpRoute(): ChatTuiFocusedChildFollowUpRoute {
+export function chatTuiFocusedChildFollowUpRoute(): FocusedChildFollowUpRoute {
   return focusedChildFollowUpRoute({
     activeStreamId: activeStreamIdSignal.get(),
     parentStream: parentStreamSignal.get(),
@@ -881,8 +876,7 @@ export async function runChat(
   }
 
   // Auto-prompt when the active stream goes WAITING so the UI clearly
-  // signals "your turn." Combined with the StatusBar pill, this replaces
-  // the legacy reader.prompt() ergonomics.
+  // signals "your turn," alongside the StatusBar pill.
   disposers.push(
     defaultSession().events.subscribeStatus((change) => {
       if (

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -108,11 +108,11 @@ export interface PendingApprovalSummary {
   readonly kind: PendingApprovalKind;
 }
 
-const CURRENT = signal<PendingApproval | undefined>(undefined);
-
-export const currentApproval = CURRENT as Signal.State<
+const CURRENT: Signal.State<PendingApproval | undefined> = signal<
   PendingApproval | undefined
->;
+>(undefined);
+
+export const currentApproval = CURRENT;
 
 /**
  * `preparing` holds a slot for a request that cannot be shown yet: invisible

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -1,7 +1,6 @@
 /**
  * CLI TUI shared signal store. All view-level state (streams, session,
- * focus, overlays, exit hints) lives here as signals; formerly one file per
- * slice under `cliState/`.
+ * focus, overlays, exit hints) lives here as signals.
  */
 import { computed, signal, type Signal } from '@lit-labs/signals';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
@@ -39,8 +38,7 @@ import {
 // Data model for the CLI TUI's signal-backed state. Mirrors the webview's
 // `progressState` shape — same primitives (`@lit-labs/signals`), same shape
 // (one record per stream + an `activeStreamId`) so future feature parity is a
-// port, not a rewrite. Phase 4 extends with per-stream subagent/todos/plan
-// fields plus the per-stream bypass-state badges the StatusBar consumes.
+// port, not a rewrite.
 
 interface ConversationEntryBase {
   /** Same id as the upstream `StreamLogEntry.id` — stable across deltas. */

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -1,8 +1,8 @@
 // TUI implementation of the session-owned HostInteractions approval port.
 //
 // Approval requests are routed through the typed queue (-> ApprovalModal ->
-// user) instead of the legacy stderr prompt. When the modal resolves, the
-// interaction promise resolves with the same host-facing result shape.
+// user). When the modal resolves, the interaction promise resolves with the
+// same host-facing result shape.
 //
 // Policy is honored *before* the modal is shown — `immediateDecision` runs
 // first so `--approval-policy yolo` auto-approves without a modal, and
@@ -102,9 +102,9 @@ import {
  * Returns the auto-switch decision, or `undefined` when the modal is needed
  * (no usable key stored, direct-key failure, or unknown provider).
  */
-async function maybeAutoSwitchRetry(
+function maybeAutoSwitchRetry(
   payload: TuiRetryRequest,
-): Promise<ApprovalDecision | undefined> {
+): ApprovalDecision | undefined {
   if (!isCliApiSwitchableRetry(payload)) return undefined;
   if (isCliChatGptSubscriptionRetry(payload)) return undefined;
 
@@ -379,7 +379,7 @@ async function requestRetryInteraction(
             missingPersonalApiKeyMessage,
           };
         }
-        autoSwitch = await maybeAutoSwitchRetry(promptRequest);
+        autoSwitch = maybeAutoSwitchRetry(promptRequest);
       } catch (error) {
         // Preparation only decides whether the modal can be skipped, so a
         // failed lookup falls through to the modal instead of denying a retry

--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -1,7 +1,7 @@
 /**
  * Dispatch-time CLI helpers: argv token classification, command-tree
  * walking, flag reordering, unknown-command/-flag suggestions, and usage
- * rendering. Formerly one file per concern under `dispatch/`.
+ * rendering.
  */
 import {
   type ArgDef,

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -102,8 +102,8 @@ async function runHistoryShow(
  * extension's "Export as HTML" button) and embeds it into the trace-viewer —
  * the same faithful Progress View replay, not a separate hand-written
  * exporter. Default mode writes one self-contained page to stdout (JS/CSS/
- * fonts all inlined, so it opens correctly via `file://` with no server —
- * `> out.html` works exactly like before). `--assets-dir <dir>` switches to
+ * fonts all inlined, so `> out.html` opens correctly via `file://` with no
+ * server). `--assets-dir <dir>` switches to
  * the shared-assets mode for a site publishing many traces: stages the
  * trace-viewer's multi-file bundle into `<dir>` (safe to repeat across many
  * exports pointed at the same directory) and writes just the trace data to

--- a/packages/cli/src/init/runInitWizard.tsx
+++ b/packages/cli/src/init/runInitWizard.tsx
@@ -194,75 +194,81 @@ function WizardApp(props: WizardAppProps): React.JSX.Element {
   };
 
   let picker: React.JSX.Element;
-  if (step === 'agent') {
-    picker = (
-      <Select
-        key={step}
-        initialIndex={initWizardDefaultAgentIndex(props.options.agents)}
-        items={props.options.agents.map((agent) => ({
-          value: agent.name,
-          label: agent.name,
-        }))}
-        onSelect={(agent) => commit({ agent })}
-        onCancel={cancel}
-      />
-    );
-  } else if (step === 'model') {
-    picker = (
-      <Select
-        key={step}
-        initialIndex={firstAvailableIndex(props.options.models)}
-        items={initWizardModelSelectItems(props.options.models)}
-        onSelect={(model) => commit({ model })}
-        onCancel={cancel}
-      />
-    );
-  } else if (step === 'approval') {
-    picker = (
-      <Select
-        key={step}
-        items={APPROVAL_POLICY_ORDER.map((policy) => ({
-          value: policy,
-          label: policy,
-          description: APPROVAL_DESCRIPTIONS[policy],
-        }))}
-        onSelect={(approvalPolicy) => commit({ approvalPolicy })}
-        onCancel={cancel}
-      />
-    );
-  } else if (step === 'output') {
-    picker = (
-      <Select
-        key={step}
-        items={CLI_OUTPUT_FORMATS.map((format) => ({
-          value: format,
-          label: format,
-          description: OUTPUT_DESCRIPTIONS[format],
-        }))}
-        onSelect={(outputFormat) => commit({ outputFormat })}
-        onCancel={cancel}
-      />
-    );
-  } else {
-    picker = (
-      <Select
-        key={step}
-        items={[
-          {
-            value: true,
-            label: 'Yes',
-            description: 'keep local config out of git',
-          },
-          {
-            value: false,
-            label: 'No',
-            description: 'leave .gitignore unchanged',
-          },
-        ]}
-        onSelect={(gitignore) => commit({ gitignore })}
-        onCancel={cancel}
-      />
-    );
+  switch (step) {
+    case 'agent':
+      picker = (
+        <Select
+          key={step}
+          initialIndex={initWizardDefaultAgentIndex(props.options.agents)}
+          items={props.options.agents.map((agent) => ({
+            value: agent.name,
+            label: agent.name,
+          }))}
+          onSelect={(agent) => commit({ agent })}
+          onCancel={cancel}
+        />
+      );
+      break;
+    case 'model':
+      picker = (
+        <Select
+          key={step}
+          initialIndex={firstAvailableIndex(props.options.models)}
+          items={initWizardModelSelectItems(props.options.models)}
+          onSelect={(model) => commit({ model })}
+          onCancel={cancel}
+        />
+      );
+      break;
+    case 'approval':
+      picker = (
+        <Select
+          key={step}
+          items={APPROVAL_POLICY_ORDER.map((policy) => ({
+            value: policy,
+            label: policy,
+            description: APPROVAL_DESCRIPTIONS[policy],
+          }))}
+          onSelect={(approvalPolicy) => commit({ approvalPolicy })}
+          onCancel={cancel}
+        />
+      );
+      break;
+    case 'output':
+      picker = (
+        <Select
+          key={step}
+          items={CLI_OUTPUT_FORMATS.map((format) => ({
+            value: format,
+            label: format,
+            description: OUTPUT_DESCRIPTIONS[format],
+          }))}
+          onSelect={(outputFormat) => commit({ outputFormat })}
+          onCancel={cancel}
+        />
+      );
+      break;
+    case 'gitignore':
+      picker = (
+        <Select
+          key={step}
+          items={[
+            {
+              value: true,
+              label: 'Yes',
+              description: 'keep local config out of git',
+            },
+            {
+              value: false,
+              label: 'No',
+              description: 'leave .gitignore unchanged',
+            },
+          ]}
+          onSelect={(gitignore) => commit({ gitignore })}
+          onCancel={cancel}
+        />
+      );
+      break;
   }
 
   return (

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -1,12 +1,10 @@
 // First-run authentication onboarding for the interactive `texra` CLI.
 //
-// Replaces today's dead-end (a launcher full of "login required" models that
-// errors out when the user picks chat) with a credential picker, modeled on
-// Claude Code / Gemini CLI / aider: ChatGPT subscription, Researcher Access,
-// and bring-your-own provider key are first-class credential paths, and skip is
-// explicit. After credentials are set the caller re-reads availability in the
-// SAME process (the included/ChatGPT/personal paths invalidate the relevant
-// caches), so the launcher/chat continues with real models — no restart.
+// A credential picker with three first-class paths (ChatGPT subscription,
+// Researcher Access, bring-your-own provider key) plus an explicit skip. After
+// credentials are set the caller re-reads availability in the SAME process
+// (the included/ChatGPT/personal paths invalidate the relevant caches), so the
+// launcher/chat continues with real models, with no restart.
 //
 // TTY-only: the gate returns immediately in headless / non-TTY / dumb-terminal
 // runs, and both entry points already reject those before calling it, so
@@ -16,9 +14,9 @@ import { Box, Text, useApp, useInput } from 'ink';
 import { useState } from 'react';
 
 import { listExecutions } from '@agent/storage';
-import { type SupabaseSession } from '@auth/SupabaseSession';
+import type { SupabaseSession } from '@auth/SupabaseSession';
 import { DEFAULT_OAUTH_PROVIDER, type OAuthProvider } from '@auth/config';
-import { type CodexSession } from '@auth/codex';
+import type { CodexSession } from '@auth/codex';
 import { codexAccountLabel } from '@auth/codex/codexSessionTypes';
 import { BorderedPanel } from '@cli/tui/ui/BorderedPanel';
 import { LoadingIndicator } from '@cli/tui/ui/LoadingIndicator';
@@ -121,9 +119,8 @@ const NO_ONBOARDING_RESULT: CliOnboardingResult = {
   declined: false,
 };
 
-interface OnboardingResolution {
-  readonly configured: boolean;
-  readonly declined: boolean;
+interface OnboardingResolution extends CliOnboardingResult {
+  /** Line printed to stdout once the picker settles, when there is one. */
   readonly summary?: string;
 }
 

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -270,11 +270,6 @@ export function OrchestrationApp(
     kind: 'launcher',
   });
   const pending = step.kind === 'model' ? step.action : undefined;
-  const modelAccessOpen = step.kind === 'model-access';
-  const resumeOpen = step.kind === 'resume';
-  const agentOpen = step.kind === 'agent';
-  const teamOpen = step.kind === 'team';
-  const accountOpen = step.kind === 'account';
   const modelAccessItems = props.modelAccess
     ? buildCliModelAccessItems({
         kind: 'loaded',
@@ -331,7 +326,7 @@ export function OrchestrationApp(
   const headerLines: readonly string[] = [title, subtitle];
 
   let footerHints: readonly string[];
-  if (teamOpen) {
+  if (step.kind === 'team') {
     footerHints = orchestrationFooterHints(teamItems);
   } else if (step.kind === 'launcher') {
     footerHints = listFooterHints;
@@ -402,7 +397,7 @@ export function OrchestrationApp(
     goBack();
   });
 
-  if (modelAccessOpen) {
+  if (step.kind === 'model-access') {
     return (
       <Box flexDirection="column" paddingX={1}>
         <Text bold color="cyan">
@@ -427,7 +422,7 @@ export function OrchestrationApp(
     );
   }
 
-  if (resumeOpen) {
+  if (step.kind === 'resume') {
     return (
       <Box flexDirection="column" paddingX={1}>
         <Text bold color="cyan">
@@ -451,11 +446,15 @@ export function OrchestrationApp(
     );
   }
 
-  if (agentOpen || teamOpen || accountOpen) {
+  if (
+    step.kind === 'agent' ||
+    step.kind === 'team' ||
+    step.kind === 'account'
+  ) {
     let pickerItems: readonly CliOrchestrationItem[];
-    if (agentOpen) {
+    if (step.kind === 'agent') {
       pickerItems = agentItems;
-    } else if (teamOpen) {
+    } else if (step.kind === 'team') {
       pickerItems = teamItems;
     } else {
       pickerItems = props.accountItems ?? [];

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -163,8 +163,8 @@ function parseApprovalAnswer(answer: string): ParsedApprovalAnswer {
 
 /**
  * Queue a CLI prompt against the context's serial prompt queue. Exposed so the
- * inquiry/user-question handlers can interleave their own multi-step prompts
- * with approval prompts without overlapping reads from a single stdin.
+ * user-question handler can interleave its own per-question prompts with
+ * approval prompts without overlapping reads from a single stdin.
  */
 export function queueCliApprovalQuestion(
   context: CliContext,
@@ -184,8 +184,10 @@ export function immediateDecision(
   return { accepted: false, userMessage: denyMessage(context.approvalPolicy) };
 }
 
-/** Retry requests caused by exhausted credentials or auth failures retain
- *  their approval-denied classification even when yolo denies another batch. */
+/** Retry requests caused by exhausted credentials or auth failures. They are
+ *  denied under every policy that cannot prompt, and keep the approval-denied
+ *  classification so the run reports the credential failure rather than a
+ *  generic policy denial. */
 function isCredentialRetryRequest(
   event: CliDecisionApprovalEvent,
   payload: CliDecisionApprovalPayloads[CliDecisionApprovalEvent],

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -1,6 +1,6 @@
-// Public entry point for the CLI approval adapter. Internal CLI callers may
-// import the focused modules under ./approval/ directly; this barrel keeps the
-// stable surface for command modules, the TUI, and tests.
+// The headless CLI's `HostInteractions` implementation, plus the approval
+// surface the chat TUI and the tests import. Internal CLI callers may import
+// the focused modules under ./approval/ directly.
 
 import type {
   HostAgentProposalRequest,

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -428,11 +428,9 @@ export function resolveCliHistoryStatus(input: {
   readonly terminalStatus?: string;
   readonly resumable: boolean;
 }): string {
+  if (input.resumable) return CLI_HISTORY_RESUMABLE_STATUS;
   // An absent terminal status means the run never reached its terminal write
   // (crash, kill, old build) — never report that as 'completed'.
-  if (input.resumable) {
-    return CLI_HISTORY_RESUMABLE_STATUS;
-  }
   return input.terminalStatus ?? 'unknown';
 }
 

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -164,10 +164,9 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
 
   private handleSessionFact(event: SessionFact): void {
     switch (event.type) {
-      case 'status': {
+      case 'status':
         this.applyStatus(event.streamId, event.phase);
         return;
-      }
       case 'updateStreamDescription':
         if (!this.rootStreamTerminal) {
           this.applyStreamDescription(

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -26,7 +26,7 @@ import {
 } from './cliContext';
 import { CliExitCode } from './exitCodes';
 import { askCliQuestion, writeTextStderr } from './logSinks';
-import { createCliStyle, type CliStyle } from './style';
+import { createCliStyle } from './style';
 
 /** Published package name on npm; the `texra` bin lives here. */
 const CLI_PACKAGE_NAME = '@texra-ai/cli';
@@ -173,7 +173,7 @@ async function readCommandStdout(
 /**
  * Shape of `brew info --json=v2` that we read. Tolerant by design: a single
  * malformed formula entry degrades to `null` (skipped) rather than failing the
- * whole parse, matching the previous per-entry type guards.
+ * whole parse, so one odd entry cannot hide an available upgrade.
  */
 const HomebrewInfoSchema = z.object({
   formulae: z
@@ -200,14 +200,6 @@ function parseHomebrewFormulaVersion(
 }
 
 /**
- * Result of one fetch attempt against the package source. For Homebrew,
- * `refreshed: false` means a failed tap refresh yielded only stale local
- * metadata: the version may still be offered, but the daily check is not
- * stamped as complete.
- */
-export type CliUpdateFetchResult = UpdateCheckFetchResult;
-
-/**
  * Attempt to refresh Homebrew tap metadata and fetch the latest formula
  * version. Without the explicit update, `brew info` can report stale local
  * metadata and hide an available upgrade until the user runs `brew update`
@@ -220,7 +212,7 @@ export async function fetchLatestHomebrewFormulaVersion(options?: {
   timeoutMs?: number;
   cwd?: string;
   runCommand?: CommandRunner;
-}): Promise<CliUpdateFetchResult> {
+}): Promise<UpdateCheckFetchResult> {
   const formula = options?.formula ?? CLI_HOMEBREW_FORMULA;
   const runCommand = options?.runCommand ?? readCommandStdout;
   const timeoutMs = options?.timeoutMs ?? HOMEBREW_COMMAND_TIMEOUT_MS;
@@ -260,30 +252,11 @@ function affirmative(answer: string): boolean {
   return normalized === '' || normalized === 'y' || normalized === 'yes';
 }
 
-/**
- * Announce that the new version installed, then exit. We intentionally do NOT
- * re-exec the freshly installed binary under the user: this process is still
- * the old code, and silently swapping the running program mid-session is more
- * surprising than a one-line hand-off. Asking the user to run `texra` again is
- * the clean boundary — the next invocation runs `latest` from a fresh process.
- *
- * Never returns — it calls `process.exit`.
- */
-function announceUpdateInstalled(latest: string, style: CliStyle): never {
-  writeTextStderr(
-    style.success(`Updated to ${latest}.`) +
-      style.muted(' Run ') +
-      style.command('texra') +
-      style.muted(' again to use it.'),
-  );
-  process.exit(CliExitCode.Success);
-}
-
 export interface CheckCliUpdateAvailableOptions {
   currentVersion: string;
   globalState: StateStore;
   /** Fetch the latest published version plus whether the source was live. */
-  fetchLatest: () => Promise<CliUpdateFetchResult>;
+  fetchLatest: () => Promise<UpdateCheckFetchResult>;
   /**
    * Present a newer version to the user (notice + prompt). Called only when a
    * strictly newer version was fetched, and always before the daily stamp is
@@ -413,8 +386,16 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
     return;
   }
 
-  // The new version is on disk, but THIS process is still the old code. Don't
-  // re-exec it under the user — announce success and let them run `texra` again
-  // so the next session starts clean on the new version.
-  announceUpdateInstalled(latest, style);
+  // The new version is on disk, but THIS process is still the old code. We
+  // intentionally do NOT re-exec the freshly installed binary: silently
+  // swapping the running program mid-session is more surprising than a
+  // one-line hand-off, and the next `texra` invocation runs `latest` from a
+  // fresh process.
+  writeTextStderr(
+    style.success(`Updated to ${latest}.`) +
+      style.muted(' Run ') +
+      style.command('texra') +
+      style.muted(' again to use it.'),
+  );
+  process.exit(CliExitCode.Success);
 }

--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -1,4 +1,4 @@
-import type { StreamTabId } from '@shared/schemas';
+import type { GettingStartedAction, StreamTabId } from '@shared/schemas';
 import { MAIN_VIEW_COMMANDS, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { type AgentCategory } from '@shared/schemas/agent';
 import {
@@ -35,6 +35,29 @@ export const DESKTOP_LOCAL_COMMANDS = {
 } as const;
 
 export const DESKTOP_DOCS_URL = 'https://texra.ai/guide/desktop';
+
+type VsCodeOnlyGettingStartedAction = Exclude<
+  GettingStartedAction,
+  'openWalkthrough'
+>;
+
+const VS_CODE_ONLY_GETTING_STARTED_LABELS = {
+  runSetup: 'Run setup assistant',
+  createSampleProject: 'Create sample project',
+  cloneOverleaf: 'Import from Overleaf',
+  downloadArxiv: 'Import from arXiv',
+} as const satisfies Record<VsCodeOnlyGettingStartedAction, string>;
+
+/**
+ * Sole owner of the desktop reply for a getting-started action only the VS Code
+ * extension can carry out. Both entry points (the main-view banner and the
+ * progress empty state) route here so the two cannot drift in wording.
+ */
+export function vsCodeOnlyGettingStartedMessage(
+  action: VsCodeOnlyGettingStartedAction,
+): string {
+  return `"${VS_CODE_ONLY_GETTING_STARTED_LABELS[action]}" requires the VS Code extension.`;
+}
 
 type DesktopLocalCommandId =
   (typeof DESKTOP_LOCAL_COMMANDS)[keyof typeof DESKTOP_LOCAL_COMMANDS];

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -110,7 +110,10 @@ import { startRecording, stopRecordingAndTranscribe } from '@tools/media/audio';
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-import { postDesktopSettingsRoute } from '../desktopCommandSurface.js';
+import {
+  postDesktopSettingsRoute,
+  vsCodeOnlyGettingStartedMessage,
+} from '../desktopCommandSurface.js';
 import { buildDesktopOnboardingSetStateMessage } from '../desktopOnboardingMessages.js';
 import { buildDesktopSetRouteMessage } from '../desktopShellMessages.js';
 import { DesktopToolEditApprovalHost } from './desktopToolEditApproval.js';
@@ -186,12 +189,7 @@ export class DesktopProgressBridge {
   private readonly followUpPolishController: ProgressFollowUpPolishController;
   /** Switches a credit/limit-exhausted run onto the user's own API key. */
   private apiKeyRetryController!: ProgressApiKeyRetryController;
-  /**
-   * Pending approval prompts, one {@link ApprovalRequestHandler}
-   * per kind. These back the shared pending-permissions guard against view
-   * switches and the pending-proposal lookup — the same host-agnostic
-   * bookkeeping the extension uses, rather than a hand-rolled registry.
-   */
+  /** Detaches the run-completion subscription that refreshes onboarding. */
   private detachCompletedResult: () => void = () => undefined;
   private toolEditApprovals: ToolEditApprovalController | undefined;
   private hostInteractions!: ProgressHostInteractions;
@@ -249,10 +247,8 @@ export class DesktopProgressBridge {
         });
       },
       requestOpenFile: (data: RequestOpenFilePayload) => {
-        // The extension previews via its LaTeX-Workshop build+view flow
-        // (openBuildDisplayIfTex); desktop has no such editor integration, so
-        // open the resolved path through the same preview-with-fallback host
-        // `openWorkflowOutput` already uses (see runExecution above).
+        // Desktop has no editor integration to preview through, so the
+        // resolved path goes to the preview-with-fallback host directly.
         this.options.host
           .openPath(data.location.absolutePath)
           .catch((error) => {
@@ -266,9 +262,6 @@ export class DesktopProgressBridge {
       emit: (event, payload) => this.handlePresentationEvent(event, payload),
     };
     this.session = options.session;
-    const syncRenderedStreams = (): void =>
-      this.syncStreamContent(this.updateStreamMetadata());
-
     this.backend = new ProgressBackend({
       session: this.session,
       stateOwnership: 'session',
@@ -287,11 +280,10 @@ export class DesktopProgressBridge {
         canSend: () => true,
         logger: this.logger,
         overrides: {
-          // Route retry requests to the renderer's RetryRequestPanel, as the
-          // extension does. These were no-ops while `requestRetry` auto-cancelled;
-          // now that it parks the request for the user, the card has to be shown
-          // or the run would block forever. Both are arrow functions, so
-          // `this.backend` is already assigned by the time either runs.
+          // Route retry requests to the renderer's RetryRequestPanel: a parked
+          // request blocks the run until the user answers it, so the card has
+          // to be shown. Both are arrow functions, so `this.backend` is already
+          // assigned by the time either runs.
           retry: {
             show: (permission) =>
               this.backend.webviewUpdater.showPermission({
@@ -340,7 +332,7 @@ export class DesktopProgressBridge {
           const activeStream = this.updateStreamMetadata();
           if (syncActiveStream) this.syncStreamContent(activeStream);
         },
-        activateStream: (_stream) => syncRenderedStreams(),
+        activateStream: () => this.syncFullView(),
         notifyDeletionRetained: (activeCount, failedCount) =>
           this.options.host.showInfoMessage(
             failedCount === 0
@@ -1003,14 +995,8 @@ export class DesktopProgressBridge {
           this.postToRenderer(buildDesktopOnboardingSetStateMessage(true));
           return;
         }
-        const labels: Record<typeof data.action, string> = {
-          runSetup: 'Run setup assistant',
-          createSampleProject: 'Create sample project',
-          cloneOverleaf: 'Import from Overleaf',
-          downloadArxiv: 'Import from arXiv',
-        };
         await this.options.host.showInfoMessage(
-          `"${labels[data.action]}" requires the VS Code extension.`,
+          vsCodeOnlyGettingStartedMessage(data.action),
         );
       },
       // Recording: the desktop calls standalone functions and posts status
@@ -1151,9 +1137,8 @@ export class DesktopProgressBridge {
 
   /**
    * Select the given stream as this window's active stream.
-   * Mirrors the extension's `revealProgressStream` for the desktop Settings
-   * Goals panel (issue #7751 FS6) so jumping from a goal entry to its owning
-   * run works the same way on both hosts.
+   * Mirrors the extension's `revealProgressStream`, so jumping from a settings
+   * entry to its owning run works the same way on both hosts.
    */
   async revealStream(
     streamId: StreamTabId,

--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 
-// Local imports
 import { getAgent } from '@agent/index';
 import { fetchRemoteAgentConfigYaml } from '@agent/remote/remoteAgentConfigClient';
 import type {

--- a/packages/desktop/src/main/desktopHistoryHandlers.ts
+++ b/packages/desktop/src/main/desktopHistoryHandlers.ts
@@ -1,8 +1,6 @@
-// Node imports
 import { readFileSync } from 'node:fs';
 import * as path from 'node:path';
 
-// Local imports
 import {
   deleteAllExecutions,
   deleteExecution,

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -27,6 +27,7 @@ import {
   DESKTOP_DOCS_URL,
   DESKTOP_LOCAL_COMMANDS,
   postDesktopSettingsRoute,
+  vsCodeOnlyGettingStartedMessage,
   type DesktopCommandActions,
 } from '../desktopCommandSurface.js';
 
@@ -38,11 +39,9 @@ export interface DesktopShellActionFactoryOptions {
   openWorkspaceFolder(): Promise<void>;
   signIn(): Promise<void>;
   /**
-   * Async git log host — closes audit item A from
-   * `docs/dev/audits/2026-05-08-standalone-trajectory-audit.md` (trajectory #16). The shell
-   * forwards its recent-commit result to the renderer. The host converts
-   * expected git failures into an empty result with its best-effort
-   * `isGitRepo` value.
+   * Async git log host. The shell forwards its recent-commit result to the
+   * renderer. The host converts expected git failures into an empty result
+   * with its best-effort `isGitRepo` value.
    */
   getRecentCommits(): Promise<{
     commits: string[];
@@ -235,14 +234,8 @@ function dispatchMainViewInboundOnShell(
       if (message.action === 'openWalkthrough') {
         actions.showFirstRunWalkthrough();
       } else {
-        const labels: Record<typeof message.action, string> = {
-          runSetup: 'Run setup assistant',
-          createSampleProject: 'Create sample project',
-          cloneOverleaf: 'Import from Overleaf',
-          downloadArxiv: 'Import from arXiv',
-        };
         actions.showInfoMessage(
-          `"${labels[message.action]}" requires the VS Code extension.`,
+          vsCodeOnlyGettingStartedMessage(message.action),
         );
       }
       return true;

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -303,6 +303,8 @@ export function createDesktopSupabaseAuth(
     activeAttempt = attempt;
     onAttempt?.(attempt);
     try {
+      // Drain the commit queue before claiming the attempt, so a callback still
+      // storing or clearing a session finishes against the attempt it owns.
       await runAuthCommit(async () => {});
       if (!ownsAttempt(attempt)) return;
 

--- a/packages/desktop/src/main/desktopToolingSettingsController.ts
+++ b/packages/desktop/src/main/desktopToolingSettingsController.ts
@@ -1,4 +1,3 @@
-// Local imports
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
 import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
 import type { ToolTerminalAction } from '@controllers/settingsView/ToolDashboardData';

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -307,11 +307,10 @@ function createWindow(options: {
   } = {};
   // `installDesktopHostBridge.postToRenderer` is itself a no-op when
   // `webContents.isDestroyed()`. Without checking that here too, callers would
-  // falsely report success and skip their external-viewer fallback. Bot
-  // review (#3816) caught it. Shared by the prompt controller, preview host,
-  // agent-execution wiring, and the pty/browser-view workspace IPC below; the
-  // diff host keeps its own narrower check (no `webContents.isDestroyed()`)
-  // per bot review #3815, so it is not folded in.
+  // falsely report success and skip their external-viewer fallback. Shared by
+  // the prompt controller, preview host, agent-execution wiring, and the
+  // pty/browser-view workspace IPC below; the diff host keeps its own narrower
+  // check (no `webContents.isDestroyed()`), so it is not folded in.
   const postToRendererIfAlive = (message: unknown): boolean => {
     const ipc = ipcRef.current;
     if (!ipc || window.isDestroyed() || window.webContents.isDestroyed()) {
@@ -391,10 +390,10 @@ function createWindow(options: {
     if (response === 1) return 'continue';
     return 'cancel';
   };
-  // Lightweight update check (issue #7682, arm b): at most once/day, notifies
-  // at most once per release via a native dialog linking to the GitHub
-  // release page. Not a full updater — no download, no install, no feed
-  // files. Disable with TEXRA_NO_UPDATE_CHECK=1. Gated on owning the
+  // Lightweight update check: at most once/day, notifies at most once per
+  // release via a native dialog linking to the GitHub release page. Not a full
+  // updater: no download, no install, no feed files. Disable with
+  // TEXRA_NO_UPDATE_CHECK=1. Gated on owning the
   // single-instance lock so an "open folder in new window" launch (which
   // deliberately runs as its own process) never duplicates the check or
   // dialog alongside the primary process.
@@ -438,17 +437,11 @@ function createWindow(options: {
   const previewHost = createDesktopPreviewHost({
     shell,
     showErrorMessage,
-    // Audit item B / trajectory #17: prefer the in-app PDF overlay
-    // (<iframe> mounted inside a wa-dialog so Electron's bundled
-    // Chromium PDF viewer renders the build output). The external
-    // viewer (`shell.openPath`) is preserved as a fallback when
-    // `postToRenderer` is unavailable or the renderer rejects the
-    // post — mirrors the diff-host wiring just above.
-    //
-    // Return `false` when the IPC bridge is not yet wired (startup
-    // race) or the BrowserWindow has been destroyed; the host then
-    // falls back to the external viewer so previews never silently
-    // disappear.
+    // Prefer the in-app PDF overlay (an <iframe> inside a wa-dialog, so
+    // Electron's bundled Chromium PDF viewer renders the build output).
+    // Returning `false` when the IPC bridge is not yet wired (startup race)
+    // or the BrowserWindow has been destroyed falls the host back to the
+    // external viewer (`shell.openPath`) so previews never silently disappear.
     postToRenderer: postToRendererIfAlive,
   });
   let teamSignInPending = false;
@@ -559,16 +552,10 @@ function createWindow(options: {
     openBuildDisplay: previewHost.openBuildDisplay,
     openDiff: createDesktopDiffHost({
       openPath: previewHost.openPath,
-      // Audit item C / trajectory #18: prefer the in-app overlay
-      // (<texra-diff-view> inside a wa-dialog). The external-editor
-      // path is preserved as a fallback when `postToRenderer` is
-      // unavailable or `forceExternal` is set.
-      //
-      // Return `false` when the IPC bridge is not yet wired (startup
-      // race) or the BrowserWindow has been destroyed — the host then
-      // falls back to the external-editor flow so diffs never silently
-      // disappear. Bot review (#3815): the previous arrow form
-      // silently no-op'd on `ipcRef.current === undefined`.
+      // Prefer the in-app overlay (<texra-diff-view> inside a wa-dialog).
+      // Returning `false` when the IPC bridge is not yet wired (startup race)
+      // or the BrowserWindow has been destroyed falls the host back to the
+      // external-editor flow, so diffs never silently disappear.
       postToRenderer: (message) => {
         const ipc = ipcRef.current;
         if (!ipc) return false;
@@ -648,9 +635,6 @@ function createWindow(options: {
     },
     onError: reportAsyncError,
   });
-  // Workspace-explorer sidebar removed in PR 3 (PRD § 7.D + § 8). File staging
-  // happens entirely inside <main-app>'s built-in panel; the duplicate tree
-  // sidebar and its IPC are gone.
   const agentSettingsController = new DefaultDesktopAgentSettingsController({
     workspaceState: platform().workspaceState,
     globalState: platform().globalState,
@@ -843,7 +827,7 @@ function createWindow(options: {
     showErrorMessage: settingsUi.showErrorMessage,
     onError: settingsUi.onError,
   });
-  // Cross-host history refresh (#8625): the shared ~/.texra executions dir
+  // Cross-host history refresh: the shared ~/.texra executions dir
   // is written by the CLI and extension too, so the settings history list
   // re-posts when any host adds, finishes, or deletes a run. Best-effort: a
   // watch failure only disables live refresh; manual refresh still works.
@@ -973,9 +957,7 @@ function createWindow(options: {
   onboardingIpcRef.current = onboardingIpc;
   // One-shot migration: existing desktop users with a credential or run
   // history never see the welcome card (State 0) or setup auto-start (State
-  // 1). Mirrors the extension (`extension.ts:282`) and CLI
-  // (`runOnboarding.tsx:154`) backfill, which desktop formerly skipped by
-  // hardcoding `'done'`.
+  // 1). Mirrors the extension and CLI backfill.
   void (async () => {
     try {
       const globalState = platform().globalState;
@@ -1021,11 +1003,9 @@ function createWindow(options: {
       openOnboardingReadyGate();
     }
   })();
-  // Real desktop git host — closes audit item A from
-  // `docs/dev/audits/2026-05-08-standalone-trajectory-audit.md` (trajectory #16). Spawns
-  // `git log` under the active workspace to populate the launcher banner's
-  // recent-commits picker. The host is stateless and re-probes per request,
-  // so workspace switches don't need cache invalidation.
+  // Spawns `git log` under the active workspace to populate the launcher
+  // banner's recent-commits picker. The host is stateless and re-probes per
+  // request, so workspace switches don't need cache invalidation.
   const gitHost = createDesktopGitHost({
     getWorkspacePath: () => options.workspacePath,
     onError: reportAsyncError,

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -1,7 +1,6 @@
-// Desktop command palette — owns the wa-dialog shell, filter/keyboard wiring,
-// and Lit render loop, plus the desktop command surface and accelerator
-// formatting. Repatriated from src/shared/wa/commandPalette.ts (#8825): the
-// desktop renderer is its only consumer.
+// Desktop command palette: owns the wa-dialog shell, filter/keyboard wiring,
+// and Lit render loop over the desktop command surface and its accelerator
+// formatting.
 
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
@@ -109,14 +108,11 @@ export function executeCommandPaletteEntry(
   onExecute: (id: string) => boolean | Promise<boolean>,
 ): boolean {
   if (!entry) return false;
-  // Sync handlers report their actual result; async handlers (typed-args
-  // registry, #3784) return a Promise — treat that as "handled" so the
-  // palette closes immediately and the work runs in the background.
-  //
-  // Bot review (#3818): an async handler that rejects would otherwise
-  // surface as an unhandled rejection at the host. Attach a catch that
-  // logs but doesn't propagate — sync handler errors still throw
-  // synchronously and bubble to the caller.
+  // Sync handlers report their actual result; an async handler returns a
+  // Promise, which counts as "handled" so the palette closes immediately and
+  // the work runs in the background. That background rejection would surface
+  // as an unhandled rejection at the host, so log it here without
+  // propagating; sync handler errors still throw and bubble to the caller.
   const result = onExecute(entry.id);
   if (isThenable(result)) {
     (result as Promise<boolean>).catch((error) => {
@@ -151,9 +147,9 @@ export function createDesktopCommandPalette({
   const onExecute = (id: string): boolean | Promise<boolean> =>
     dispatchDesktopPaletteCommand(id, actions);
 
-  // Reactive state — every mutation calls renderTemplate() to keep the DOM
-  // in sync. wa-dialog handles modal backdrop, focus trap, escape key, and
-  // focus restoration natively, so we no longer manage those by hand.
+  // Reactive state: every mutation calls renderTemplate() to keep the DOM in
+  // sync. wa-dialog handles modal backdrop, focus trap, escape key, and focus
+  // restoration natively, so none of those are managed here.
   let allEntries: CommandPaletteEntry[] = [];
   let visibleEntries: CommandPaletteEntry[] = [];
   let activeIndex = -1;

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -191,10 +191,6 @@ const startupTeamPanel = createStartupTeamPanel({
 //
 // The conversation is the permanent task canvas. Project navigation stays in
 // the left sidebar, while files and tools share one optional right workbench.
-//
-// `setRouteState` survives only as a backwards-compat hook so existing IPC
-// (`desktop:setRoute` from menu/command-palette) still reaches the right
-// surface; sectionForRoute maps each legacy route onto its owning section.
 
 const hasWorkspace = window.texraDesktop?.hasWorkspace ?? true;
 const rendererPlatform = getRendererPlatform(document.defaultView);
@@ -222,6 +218,7 @@ function commandTitle(
   return shortcut ? `${label} - ${shortcut}` : label;
 }
 
+/** Publishes the current route on `<body>` for styling and end-to-end checks. */
 function setRouteState(route: DesktopRoute): void {
   document.body.dataset.desktopRoute = route;
 }
@@ -334,15 +331,14 @@ const conversationView: HTMLElement = document.createElement(
 );
 conversationView.setAttribute('data-desktop-view', 'progress');
 
-// Left rail: a fresh <stream-tabs> mount wired to module-level progressState.
-// PRD § 7.D requires mounting <stream-tabs> directly (not inside <progress-app>).
+// Left rail: a <stream-tabs> mount wired directly to module-level
+// progressState rather than nested inside <progress-app>.
 const railTabs = document.createElement('stream-tabs') as StreamTabs;
 
 const settingsView: HTMLElement = document.createElement('settings-app');
 settingsView.setAttribute('data-desktop-view', 'settings');
 
-// The logs viewer now lives in a tab instead of a drawer, so its element is
-// hosted directly in the tab body rather than inside a wa-drawer.
+// The logs viewer is hosted directly in its workbench tab body.
 const logsController = createLogsPane();
 const logsPane = logsController.element;
 
@@ -467,8 +463,8 @@ function requestFileWrite(path: string, contents: string): Promise<void> {
 
 /**
  * Progress-view messages are dispatched straight into the shared
- * messageDispatcher; `<progress-app>` is never mounted on desktop, its children
- * mount directly (PRD § 7.C).
+ * messageDispatcher: `<progress-app>` is never mounted on desktop, its children
+ * mount directly.
  */
 function isProgressOutboundMessage(
   raw: unknown,
@@ -545,8 +541,7 @@ function layoutVisibleSurfaces(): void {
 
 /**
  * Browser tabs whose URL has already been handed to the main process. Without
- * this the page would reload on every re-render; without posting at all (the
- * original bug) the view stayed blank because nothing ever called loadURL.
+ * this the page would reload on every re-render.
  */
 const loadedBrowserTabs = new Set<string>();
 
@@ -1322,7 +1317,7 @@ if (bootstrapFailed) {
 // =============================================================================
 //
 // Settings is a tab, not a modal dialog: configuring a run while watching it is
-// the common case, and an overlay made those mutually exclusive.
+// the common case, which an overlay would make mutually exclusive.
 
 type ShowSettingsArgs = Parameters<DesktopCommandActions['showSettings']>;
 
@@ -1412,9 +1407,7 @@ function switchToStream(streamId: StreamTabId): void {
   postMessage(PROGRESS_VIEW_COMMANDS.SWITCH_STREAM, { stream: streamId });
 }
 
-// Clear the active stream so the center swaps back to <main-app>. PRD § 6:
-// "Composer pinned at the bottom of <main-app>; follow-up at the bottom of
-// <stream-conversation>" — returning to launcher is just nulling the active id.
+// Clear the active stream so the center pane swaps back to <main-app>.
 function returnToLauncher(): void {
   appState.set(
     mutate(appState.get(), (draft) => {
@@ -1424,9 +1417,9 @@ function returnToLauncher(): void {
   setRouteState('main');
 }
 
-// Bridge for legacy `desktop:setRoute` IPC (menu items, command palette).
-// Each route resolves to the tab that now owns its surface; 'main' additionally
-// clears the active stream so the workspace tab shows the launcher.
+// Entry point for `desktop:setRoute` IPC (menu items, command palette). Each
+// route resolves to the workbench tab that owns its surface; 'main'
+// additionally clears the active stream so the center pane shows the launcher.
 function setRoute(route: DesktopRoute): void {
   setRouteState(route);
   if (bootstrapFailed) return;
@@ -1558,8 +1551,8 @@ window.addEventListener('message', (event) => {
   for (const route of MESSAGE_ROUTES) {
     if (route(event.data)) return;
   }
-  // Progress view messages: dispatch directly into the shared messageDispatcher
-  // — no need to mount <progress-app> for plumbing. PRD § 7.C.
+  // Progress view messages dispatch directly into the shared
+  // messageDispatcher, with no <progress-app> mounted for plumbing.
   if (isProgressOutboundMessage(event.data)) {
     dispatchMessage(event.data);
   }
@@ -1683,9 +1676,9 @@ window.addEventListener(
 );
 
 function postWebviewReady(): void {
-  // The desktop main process expects `WEBVIEW_READY` from both 'main' and
-  // 'progress' views to drive startup messages + a full progress sync. The
-  // single renderer now plays both roles.
+  // The desktop main process expects `WEBVIEW_READY` from both the 'main' and
+  // 'progress' views to drive startup messages and a full progress sync; this
+  // single renderer plays both roles.
   postMessage(COMMON_COMMANDS.WEBVIEW_READY, { view: 'main' });
   postMessage(COMMON_COMMANDS.WEBVIEW_READY, { view: 'progress' });
 }

--- a/packages/desktop/src/workspacePath.ts
+++ b/packages/desktop/src/workspacePath.ts
@@ -76,18 +76,16 @@ export function parseWorkspacePathFromArgv(
 ): string | undefined {
   for (const [index, arg] of argv.entries()) {
     if (isWorkspacePathFlag(arg)) {
-      return getPositionalWorkspacePathArg(argv[index + 1]);
+      return readWorkspacePathValue(argv[index + 1]);
     }
     if (isWorkspacePathAssignment(arg)) {
-      return getPositionalWorkspacePathArg(arg.slice(arg.indexOf('=') + 1));
+      return readWorkspacePathValue(arg.slice(arg.indexOf('=') + 1));
     }
   }
   return undefined;
 }
 
-function getPositionalWorkspacePathArg(
-  arg: string | undefined,
-): string | undefined {
+function readWorkspacePathValue(arg: string | undefined): string | undefined {
   const trimmed = arg?.trim();
   if (!trimmed || trimmed.startsWith('--') || isDesktopProtocolUrl(trimmed)) {
     return undefined;

--- a/packages/extension/resources/tool_use_agents/engineer.yaml
+++ b/packages/extension/resources/tool_use_agents/engineer.yaml
@@ -7,6 +7,9 @@ settings:
   tools:
     - delegate_agent
     - delegate_workflow
+    # Advanced deterministic delegation. The global Workflow Script switch is
+    # an additional kill switch and is disabled by default.
+    - delegate_workflow_script
     - executions
     - accept_run_files
     - plan

--- a/packages/extension/src/MainViewProvider.ts
+++ b/packages/extension/src/MainViewProvider.ts
@@ -51,9 +51,6 @@ export class MainViewProvider
   public static readonly viewType = 'texra.mainView';
   protected messageHandler: MainViewMessageHandler;
   protected contentProvider: BundledViewContentProvider;
-  private fileWatcher: vscode.FileSystemWatcher | undefined;
-  private agentWatcher: vscode.Disposable | undefined;
-
   private _messageDisposable?: vscode.Disposable;
   private _progressViewProvider?: ProgressViewProvider;
 
@@ -254,19 +251,19 @@ export class MainViewProvider
     );
     const filePattern =
       extensions.size === 0 ? '**/*' : `**/*.{${[...extensions].join(',')}}`;
-    this.fileWatcher = vscode.workspace.createFileSystemWatcher(filePattern);
-    this.fileWatcher.onDidCreate(this.refreshFiles.bind(this));
-    this.fileWatcher.onDidDelete(this.refreshFiles.bind(this));
-    this.context.subscriptions.push(this.fileWatcher);
+    const fileWatcher = vscode.workspace.createFileSystemWatcher(filePattern);
+    fileWatcher.onDidCreate(this.refreshFiles.bind(this));
+    fileWatcher.onDidDelete(this.refreshFiles.bind(this));
+    this.context.subscriptions.push(fileWatcher);
   }
 
   private setupAgentWatcher() {
-    this.agentWatcher = agentDirectories.watchAgentDirectories({
-      pattern: '**/*.yaml',
-      onEvent: () => this.debouncedRefreshAgentOptions(),
-    });
-
-    this.context.subscriptions.push(this.agentWatcher);
+    this.context.subscriptions.push(
+      agentDirectories.watchAgentDirectories({
+        pattern: '**/*.yaml',
+        onEvent: () => this.debouncedRefreshAgentOptions(),
+      }),
+    );
   }
 
   private async refreshFiles() {

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -45,23 +45,19 @@ import {
 
 type LatexdiffTool = 'latexdiff' | 'latexdiff-vc';
 
-async function ensureLatexdiffToolInstalled(
-  tool: LatexdiffTool,
-): Promise<boolean> {
-  const installed = await checkToolInstalled(tool);
-  if (!installed) {
-    logger.warn(CHANNEL, `${tool} is not installed; command will not run.`);
-  }
-  return installed;
-}
-
+/**
+ * Run a latexdiff command body, skipping it when the tool is missing and
+ * reporting any failure under `errorMessage`. Every command in this file goes
+ * through here.
+ */
 async function withLatexdiffTool<T>(
   tool: LatexdiffTool,
   errorMessage: string,
   action: () => Promise<T>,
 ): Promise<T | undefined> {
   try {
-    if (!(await ensureLatexdiffToolInstalled(tool))) {
+    if (!(await checkToolInstalled(tool))) {
+      logger.warn(CHANNEL, `${tool} is not installed; command will not run.`);
       return undefined;
     }
     return await action();
@@ -316,119 +312,120 @@ async function handleCleanLatexdiffvcMultiple(
 async function handleRunLatexdiff(
   config: RunLatexdiffCommandConfig,
 ): Promise<void> {
-  try {
-    logger.debug(
-      CHANNEL,
-      `Command called with config: ${JSON.stringify(config)}`,
-    );
-
-    if (!(await ensureLatexdiffToolInstalled('latexdiff'))) {
-      return;
-    }
-
-    const { agent, model, inputFile, outputFiles } = config;
-
-    if (!agent || !model || !inputFile) {
-      await showLoggedMessage(
+  await withLatexdiffTool(
+    'latexdiff',
+    'Error running LaTeX diffs',
+    async () => {
+      logger.debug(
         CHANNEL,
-        'Missing required configuration parameters',
+        `Command called with config: ${JSON.stringify(config)}`,
       );
-      return;
-    }
 
-    const mathMarkup = await promptForLatexdiffMathMarkup();
-    if (!mathMarkup) return;
+      const { agent, model, inputFile, outputFiles } = config;
 
-    logger.info(
-      CHANNEL,
-      `Running latexdiff with math markup mode: ${mathMarkup}`,
-    );
-
-    const generateBetweenRoundDiffs = workspaceSM.get<boolean>(
-      WorkspaceStateKey.LATEXDIFF_BETWEEN_ROUNDS,
-      LATEX_CONFIG_DEFAULTS.latexdiffBetweenRounds,
-    );
-    logger.debug(
-      CHANNEL,
-      `Between-round diffs enabled: ${generateBetweenRoundDiffs}`,
-    );
-
-    const runId = config.runId ?? undefined;
-
-    const outputsByRound = normalizeRunLatexdiffOutputsByRound(
-      config.outputsByRound,
-    );
-
-    const { outcome } = await vscode.window.withProgress(
-      {
-        location: vscode.ProgressLocation.Notification,
-        title: 'Running LaTeX diffs',
-        cancellable: false,
-      },
-      (progress) => {
-        progress.report({ increment: 0, message: 'Preparing LaTeX diffs...' });
-        return runLatexdiffForExecution({
-          agent,
-          model,
-          inputFile,
-          outputFiles,
-          runId,
-          outputsByRound,
-          mathMarkup,
-          generateBetweenRoundDiffs,
-          progress,
-        });
-      },
-    );
-
-    const { results } = outcome;
-
-    if (results.length === 0) {
-      vscode.window.showInformationMessage(
-        'No LaTeX diff operations available for this run.',
-      );
-      return;
-    }
-
-    const successCount = results.filter((r) => r.success).length;
-
-    if (successCount === 0) {
-      await showLoggedMessage(
-        CHANNEL,
-        `All LaTeX diff operations failed (math markup: "${mathMarkup}")`,
-      );
-    } else if (successCount < results.length) {
-      vscode.window.showWarningMessage(
-        `${successCount} of ${results.length} LaTeX diff operations completed successfully (math markup: "${mathMarkup}")`,
-      );
-    } else {
-      vscode.window.showInformationMessage(
-        `All LaTeX diffs completed successfully (math markup: "${mathMarkup}")`,
-      );
-    }
-
-    for (const result of results) {
-      const suffix = result.description ? ` (${result.description})` : '';
-
-      if (result.success && result.basePath && result.diffFileName) {
-        const diffFilePath = await openLatexdiffResult(
-          pathToLocation(result.basePath),
-          result.diffFileName,
-        );
-        if (diffFilePath) {
-          logger.debug(
-            CHANNEL,
-            `Successfully generated diff: ${diffFilePath}${suffix}`,
-          );
-        }
-      } else if (!result.success) {
-        logger.warn(
+      if (!agent || !model || !inputFile) {
+        await showLoggedMessage(
           CHANNEL,
-          `Failed to generate diff${suffix}: ${result.message ?? 'Unknown error'}`,
+          'Missing required configuration parameters',
+        );
+        return;
+      }
+
+      const mathMarkup = await promptForLatexdiffMathMarkup();
+      if (!mathMarkup) return;
+
+      logger.info(
+        CHANNEL,
+        `Running latexdiff with math markup mode: ${mathMarkup}`,
+      );
+
+      const generateBetweenRoundDiffs = workspaceSM.get<boolean>(
+        WorkspaceStateKey.LATEXDIFF_BETWEEN_ROUNDS,
+        LATEX_CONFIG_DEFAULTS.latexdiffBetweenRounds,
+      );
+      logger.debug(
+        CHANNEL,
+        `Between-round diffs enabled: ${generateBetweenRoundDiffs}`,
+      );
+
+      const runId = config.runId ?? undefined;
+
+      const outputsByRound = normalizeRunLatexdiffOutputsByRound(
+        config.outputsByRound,
+      );
+
+      const { outcome } = await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'Running LaTeX diffs',
+          cancellable: false,
+        },
+        (progress) => {
+          progress.report({
+            increment: 0,
+            message: 'Preparing LaTeX diffs...',
+          });
+          return runLatexdiffForExecution({
+            agent,
+            model,
+            inputFile,
+            outputFiles,
+            runId,
+            outputsByRound,
+            mathMarkup,
+            generateBetweenRoundDiffs,
+            progress,
+          });
+        },
+      );
+
+      const { results } = outcome;
+
+      if (results.length === 0) {
+        vscode.window.showInformationMessage(
+          'No LaTeX diff operations available for this run.',
+        );
+        return;
+      }
+
+      const successCount = results.filter((r) => r.success).length;
+
+      if (successCount === 0) {
+        await showLoggedMessage(
+          CHANNEL,
+          `All LaTeX diff operations failed (math markup: "${mathMarkup}")`,
+        );
+      } else if (successCount < results.length) {
+        vscode.window.showWarningMessage(
+          `${successCount} of ${results.length} LaTeX diff operations completed successfully (math markup: "${mathMarkup}")`,
+        );
+      } else {
+        vscode.window.showInformationMessage(
+          `All LaTeX diffs completed successfully (math markup: "${mathMarkup}")`,
         );
       }
-    }
-  } catch (err) {
-    await showLoggedErrorMessage(CHANNEL, 'Error running LaTeX diffs', err);
-  }
+
+      for (const result of results) {
+        const suffix = result.description ? ` (${result.description})` : '';
+
+        if (result.success && result.basePath && result.diffFileName) {
+          const diffFilePath = await openLatexdiffResult(
+            pathToLocation(result.basePath),
+            result.diffFileName,
+          );
+          if (diffFilePath) {
+            logger.debug(
+              CHANNEL,
+              `Successfully generated diff: ${diffFilePath}${suffix}`,
+            );
+          }
+        } else if (!result.success) {
+          logger.warn(
+            CHANNEL,
+            `Failed to generate diff${suffix}: ${result.message ?? 'Unknown error'}`,
+          );
+        }
+      }
+    },
+  );
 }

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -431,7 +431,7 @@ export async function activate(context: vscode.ExtensionContext) {
         'Supabase authentication is enabled but credentials are not configured. Please configure credentials in src/auth/config.ts before building.',
       );
     } else {
-      const authProvider = new SupabaseAuthProvider(context, {
+      const authProvider = new SupabaseAuthProvider({
         showError: (msg) => void vscode.window.showErrorMessage(msg),
         showInfo: (msg) => void vscode.window.showInformationMessage(msg),
         showSignInPrompt: async (reason) => {

--- a/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
+++ b/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
@@ -55,7 +55,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
   private readonly notifier: AuthNotifier;
 
-  constructor(_context: vscode.ExtensionContext, notifier: AuthNotifier) {
+  constructor(notifier: AuthNotifier) {
     this.notifier = notifier;
     this.sessionCoordinator = createHostAuthCoordinator({
       secrets: platform().secrets,
@@ -266,21 +266,20 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     const requestedProvider = scopes
       .find((s) => s.startsWith('provider:'))
       ?.split(':')[1];
-
-    if (requestedProvider === 'github-browser') {
-      return this.createSessionViaSupabaseOAuth('github');
-    }
+    // 'github-browser' is the sign-in menu's name for GitHub OAuth handed off
+    // to the system browser; it resolves to the same Supabase provider.
+    const provider =
+      requestedProvider === 'github-browser' ? 'github' : requestedProvider;
 
     return this.createSessionViaSupabaseOAuth(
-      isOAuthProvider(requestedProvider)
-        ? requestedProvider
-        : DEFAULT_OAUTH_PROVIDER,
+      isOAuthProvider(provider) ? provider : DEFAULT_OAUTH_PROVIDER,
     );
   }
 
   /**
-   * Create session using traditional Supabase OAuth flow.
-   * Used in desktop VS Code where OAuth callbacks work reliably.
+   * Open the provider's Supabase OAuth page in the browser and wait for the
+   * callback. `buildOAuthOptions` picks the callback URI that works for the
+   * current UI kind (desktop bridge page vs. web tunnel).
    */
   private async createSessionViaSupabaseOAuth(
     provider: OAuthProvider,
@@ -319,7 +318,6 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
             );
           }
           await this.storeSession(session);
-          return this.toVSCodeSession(session);
         },
       );
 

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -94,6 +94,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private readonly getOutputFiles = (stream: StreamTabId) =>
     this.provider.state.snapshots.getOutputFiles(stream);
 
+  /** The one info-notification adapter the controller ports are wired to. */
+  private readonly showInfo = async (message: string): Promise<void> => {
+    await this.host.info(message);
+  };
+
   constructor(
     private readonly provider: ProgressViewProvider,
     private readonly host: PromptHost,
@@ -183,11 +188,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       apiKeyRetry: this.apiKeyRetryController,
       followUp: this.followUpController,
       followUpPolish: this.followUpPolishController,
-      host: {
-        showInfo: async (message) => {
-          await this.host.info(message);
-        },
-      },
+      host: { showInfo: this.showInfo },
       session: defaultSession(),
       getRunConfig: this.getRunConfig,
       restoreRunConfig: async (config) => {
@@ -202,9 +203,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       onPolishProgress: (message) => {
         polishProgress?.report({ message });
       },
-      onPolishError: (stream, error) => {
-        void this.reportPolishError(stream, error);
-      },
+      onPolishError: (stream, error) => this.reportPolishError(stream, error),
       loadFollowUpOptions: async () => {
         const { agentOptions, modelOptions } = await loadOptions();
         return {
@@ -380,12 +379,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           getRunConfig: this.getRunConfig,
           getExecutionId: this.getExecutionId,
         },
-        executeAgent: async (request) => {
-          // Workflow actions intentionally wait for the run to finish; the
-          // command owns user-facing failure reporting, so this caller does
-          // not need the boolean launch result.
-          await this.executeValidated(request);
-        },
+        // Workflow actions intentionally wait for the run to finish.
+        executeAgent: (request) => this.executeValidated(request),
       },
       workflowFileActions: {
         state: {
@@ -443,9 +438,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             );
           },
           readFile: (file) => AbsoluteFS.read(file),
-          showInfo: async (message) => {
-            await this.host.info(message);
-          },
+          showInfo: this.showInfo,
           showError: async (message) => {
             await this.host.error(message);
           },
@@ -529,7 +522,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           },
         },
         bypass: {
-          showInfo: (message) => this.host.info(message),
+          showInfo: this.showInfo,
         },
         file: {
           openFile: async (file, line) => {
@@ -774,15 +767,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     });
   }
 
-  /**
-   * Post the polish failure to the renderer, surface it, and log it. Returns
-   * the notification promise so callers can either await the dialog or let it
-   * run in the background.
-   */
-  private reportPolishError(
-    stream: StreamTabId,
-    error: unknown,
-  ): Promise<unknown> {
+  /** Post the polish failure to the renderer, surface it, and log it. */
+  private reportPolishError(stream: StreamTabId, error: unknown): void {
     const errorMsg = toErrorMessage(error);
     this.postToActiveView({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
@@ -791,11 +777,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       text: null,
       error: errorMsg,
     });
-    const shown = this.host.error(`Error polishing follow-up: ${errorMsg}`);
+    void this.host.error(`Error polishing follow-up: ${errorMsg}`);
     this.logger.error(this.channel, `Error polishing follow-up: ${errorMsg}`, {
       data: error instanceof Error ? error : undefined,
     });
-    return shown;
   }
 
   private async applyFollowUpPolishResult(
@@ -838,24 +823,23 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   // ============================================================
 
   /**
-   * Validate and execute an agent request.
-   * Returns true if execution started, false if validation failed.
+   * Validate an agent request and run it. Both callers own their own
+   * user-facing failure reporting, so a rejected request is only logged.
    */
   private async executeValidated(
     request: ExecutionRequest,
     options: { preferHelperModel?: boolean } = {},
-  ): Promise<boolean> {
+  ): Promise<void> {
     const validation = validateExecutionRequest(request);
     if (!validation.valid) {
       this.logger.error(this.channel, validation.message);
-      return false;
+      return;
     }
-    const started = await this.runViewCommand<boolean>('texra.execute', [
+    await this.runViewCommand('texra.execute', [
       options.preferHelperModel
         ? { ...validation.request, preferHelperModel: true }
         : validation.request,
     ]);
-    return started === true;
   }
 
   /** Validate a request and acknowledge it once the runtime owns a run handle. */

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -311,7 +311,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     if (!syncActiveStream) return;
 
     // Skip content sync when streams exist but filter excludes all of them
-    const hasStreams = this.state.streamLogs.keys().length > 0;
+    const hasStreams = this.state.selectableStreamNames().length > 0;
     if (activeStream || !hasStreams) {
       // If the active stream's entries were released (e.g. filter change
       // moved active to a previously-evicted stream), rehydrate before

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -311,7 +311,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     if (!syncActiveStream) return;
 
     // Skip content sync when streams exist but filter excludes all of them
-    const hasStreams = this.state.selectableStreamNames().length > 0;
+    const hasStreams = this.state.streamLogs.keys().length > 0;
     if (activeStream || !hasStreams) {
       // If the active stream's entries were released (e.g. filter change
       // moved active to a previously-evicted stream), rehydrate before

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -106,11 +106,8 @@ export class FollowUpInput extends LitElement {
             color-mix(in srgb, var(--wa-color-surface-shadow) 16%, transparent);
       }
 
-      /* Web Awesome's resize="auto" copies the textarea scroll height into an
-         invisible grid item. Inside a constrained composer that grid item can
-         preserve an oversized row for an empty draft. Size the native
-         textarea part from its content instead: two lines initially, growing
-         to the bounded reading height before it scrolls. */
+      /* Height comes off the shared textarea scale; the composer sits inside
+         its own bordered card, so it drops the field's own box. */
       #followUpInput {
         display: block;
         min-width: 0;
@@ -118,16 +115,11 @@ export class FollowUpInput extends LitElement {
         box-sizing: border-box;
         line-height: var(--line-height-relaxed);
         height: auto;
-        --textarea-min-height: calc(
-          2lh + var(--wa-space-xs) + var(--wa-space-3xs)
-        );
+        --textarea-min-height: var(--textarea-h-m);
         --textarea-max-height: min(32vh, 240px);
       }
 
       #followUpInput::part(base) {
-        align-items: start;
-        max-height: var(--textarea-max-height);
-        overflow: hidden;
         border: 0;
         background: transparent;
         box-shadow: none;
@@ -136,12 +128,8 @@ export class FollowUpInput extends LitElement {
       /* The one place a textarea renders sans rather than mono: this is prose a
          user writes to an agent, not code. */
       #followUpInput::part(textarea) {
-        field-sizing: content;
         width: 100%;
-        height: auto;
-        min-height: var(--textarea-min-height);
-        max-height: var(--textarea-max-height);
-        padding: var(--wa-space-xs) var(--wa-space-s) var(--wa-space-3xs);
+        padding: var(--wa-space-s) var(--wa-space-s) var(--wa-space-xs);
         box-sizing: border-box;
         overflow-x: hidden;
         overflow-y: auto;

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -106,8 +106,11 @@ export class FollowUpInput extends LitElement {
             color-mix(in srgb, var(--wa-color-surface-shadow) 16%, transparent);
       }
 
-      /* Height comes off the shared textarea scale; the composer sits inside
-         its own bordered card, so it drops the field's own box. */
+      /* Web Awesome's resize="auto" copies the textarea scroll height into an
+         invisible grid item. Inside a constrained composer that grid item can
+         preserve an oversized row for an empty draft. Size the native
+         textarea part from its content instead: two lines initially, growing
+         to the bounded reading height before it scrolls. */
       #followUpInput {
         display: block;
         min-width: 0;
@@ -115,11 +118,16 @@ export class FollowUpInput extends LitElement {
         box-sizing: border-box;
         line-height: var(--line-height-relaxed);
         height: auto;
-        --textarea-min-height: var(--textarea-h-m);
+        --textarea-min-height: calc(
+          2lh + var(--wa-space-xs) + var(--wa-space-3xs)
+        );
         --textarea-max-height: min(32vh, 240px);
       }
 
       #followUpInput::part(base) {
+        align-items: start;
+        max-height: var(--textarea-max-height);
+        overflow: hidden;
         border: 0;
         background: transparent;
         box-shadow: none;
@@ -128,8 +136,12 @@ export class FollowUpInput extends LitElement {
       /* The one place a textarea renders sans rather than mono: this is prose a
          user writes to an agent, not code. */
       #followUpInput::part(textarea) {
+        field-sizing: content;
         width: 100%;
-        padding: var(--wa-space-s) var(--wa-space-s) var(--wa-space-xs);
+        height: auto;
+        min-height: var(--textarea-min-height);
+        max-height: var(--textarea-max-height);
+        padding: var(--wa-space-xs) var(--wa-space-s) var(--wa-space-3xs);
         box-sizing: border-box;
         overflow-x: hidden;
         overflow-y: auto;

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -32,7 +32,6 @@ import {
 import { statusIndicatorStyles } from '@shared/styles/statusIndicatorStyles';
 import { isKnownUnsupported } from '@shared/utils/dispatcher';
 import { renderIconActionButtonParts } from '@shared/wa/actionButtons';
-import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Side-effect imports - register WA icon component
@@ -42,7 +41,11 @@ import '@awesome.me/webawesome/dist/components/button-group/button-group.js';
 import '@awesome.me/webawesome/dist/components/badge/badge.js';
 
 // Local imports - progress view constants
-import { ELEMENT_IDS, TOOLBAR_BUTTONS } from '../constants';
+import {
+  ELEMENT_IDS,
+  TOOLBAR_BUTTONS,
+  type ProgressToolbarButton,
+} from '../constants';
 import { archivedContext } from '../contexts/streamContexts';
 import { ProgressEvents } from '../events';
 import { toolbarToggleStyles } from '../styles/toolbarToggleStyles';
@@ -50,17 +53,6 @@ import {
   renderProgressBadgeContent,
   getProgressBadgeTitle,
 } from '../formatters/progressBadgeFormatter';
-
-interface ToolbarButton {
-  id: string;
-  icon: string;
-  command: string;
-  title: string;
-  titleActive?: string;
-  className?: string;
-  disabled?: boolean;
-  isToggle?: boolean;
-}
 
 /**
  * Buttons enabled while a run is active (running / waiting / resuming): stop
@@ -362,51 +354,49 @@ export class StreamHeader extends LitElement {
     // tooltip nodes between the buttons would break those selectors —
     // `renderIconActionButtonParts` keeps them apart, and each anchors by
     // `for=${btn.id}` within this shadow root.
-    const toolbarButtonViews = (toolbarButtons as ToolbarButton[]).map(
-      (btn) => {
-        const { disabled: computedDisabled, hidden } = this.getButtonState(
-          btn,
-          enabledButtons,
-          hasExecutionId,
-        );
-        // Read-only trace-viewer export: no toolbar action reaches a live
-        // backend — the onClick below re-checks `disabled` before
-        // dispatching, so this one flag both looks and behaves inert.
-        const disabled = this.archived || computedDisabled;
-        const isActive = Boolean(
-          btn.isToggle &&
-          (btn.id === ELEMENT_IDS.SUPER_YOLO_TOGGLE_BTN
-            ? this.superYoloActive
-            : this.yoloActive),
-        );
-        const tooltipText =
-          isActive && btn.titleActive ? btn.titleActive : btn.title;
-        const className = [
-          btn.className,
-          hidden ? 'toolbar-button--hidden' : undefined,
-          isActive ? 'is-active' : undefined,
-        ]
-          .filter(Boolean)
-          .join(' ');
-        const { button, tooltip } = renderIconActionButtonParts({
-          id: btn.id,
-          icon: btn.icon as TeXRAIconName,
-          label: tooltipText,
-          tooltip: tooltipText,
-          className,
-          size: 'm',
-          disabled,
-          ariaHidden: hidden,
-          onClick: () => {
-            if (disabled) return;
-            this.dispatchEvent(
-              ProgressEvents.toolbarCommand({ command: btn.command }),
-            );
-          },
-        });
-        return { id: btn.id, hidden, button, tooltip };
-      },
-    );
+    const toolbarButtonViews = toolbarButtons.map((btn) => {
+      const { disabled: computedDisabled, hidden } = this.getButtonState(
+        btn,
+        enabledButtons,
+        hasExecutionId,
+      );
+      // Read-only trace-viewer export: no toolbar action reaches a live
+      // backend — the onClick below re-checks `disabled` before
+      // dispatching, so this one flag both looks and behaves inert.
+      const disabled = this.archived || computedDisabled;
+      const isActive = Boolean(
+        btn.isToggle &&
+        (btn.id === ELEMENT_IDS.SUPER_YOLO_TOGGLE_BTN
+          ? this.superYoloActive
+          : this.yoloActive),
+      );
+      const tooltipText =
+        isActive && btn.titleActive ? btn.titleActive : btn.title;
+      const className = [
+        btn.className,
+        hidden ? 'toolbar-button--hidden' : undefined,
+        isActive ? 'is-active' : undefined,
+      ]
+        .filter(Boolean)
+        .join(' ');
+      const { button, tooltip } = renderIconActionButtonParts({
+        id: btn.id,
+        icon: btn.icon,
+        label: tooltipText,
+        tooltip: tooltipText,
+        className,
+        size: 'm',
+        disabled,
+        ariaHidden: hidden,
+        onClick: () => {
+          if (disabled) return;
+          this.dispatchEvent(
+            ProgressEvents.toolbarCommand({ command: btn.command }),
+          );
+        },
+      });
+      return { id: btn.id, hidden, button, tooltip };
+    });
 
     return html`
       <div class="log-header">
@@ -460,7 +450,7 @@ export class StreamHeader extends LitElement {
   }
 
   private getButtonState(
-    button: ToolbarButton,
+    button: ProgressToolbarButton,
     enabledButtons: ReadonlySet<string> | undefined,
     hasExecutionId: boolean,
   ): { disabled: boolean; hidden: boolean } {

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -67,10 +67,9 @@ const DEFAULT_GROUP_MESSAGE_WINDOW = 400;
 const GROUP_MESSAGE_WINDOW_STEP = 400;
 
 /**
- * Maps group status to a steady wa-icon name.
- * `TaskGroup.status` is the native `StreamPhase`/`RunOutcome` vocabulary
- * (#7993 step 3) — `CANCELLED` now renders distinctly from `COMPLETED`
- * instead of folding into one neutral "stopped" icon.
+ * Maps a group's `StreamPhase`/`RunOutcome` status to a steady wa-icon name.
+ * Each terminal phase gets its own icon; an unrecognized status renders as
+ * running.
  */
 function getStatusIcon(status: string): TeXRAIconName {
   switch (status) {
@@ -257,11 +256,9 @@ export class TaskGroupList extends LitElement {
   }
 
   /**
-   * Play sound when a run group completes. The former stopped status folded
-   * `completed`/`cancelled` into one neutral bucket; the native
-   * `TaskGroup.status` (#7993 step 3) keeps them apart, so this checks both
-   * terminal-but-not-failed phases to preserve the prior "stopped" trigger
-   * byte-for-byte — a failed round still does not play the sound.
+   * Play the completion sound when a workflow round group leaves `running` for
+   * a terminal phase other than `failed`: a finished or cancelled round chimes,
+   * a failed one does not.
    */
   private checkForCompletedRuns(): void {
     const nextStatuses = new Map<string, string>();
@@ -566,6 +563,8 @@ export class TaskGroupList extends LitElement {
 
   private renderTerminalOutput(): TemplateResult {
     const tailText = processTerminalText(this.terminalBuffer.tail);
+    // Single-line templates: a wrapped `<pre>` would put the reflowed
+    // whitespace inside the preformatted block.
     const committedClass = 'terminal-pre terminal-pre--committed';
     const tailClass = 'terminal-pre terminal-pre--tail';
     const committed = html`<pre class=${committedClass}></pre>`;

--- a/packages/extension/src/progressView/frontend/constants.ts
+++ b/packages/extension/src/progressView/frontend/constants.ts
@@ -1,5 +1,17 @@
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { DELEGATION_APPROVAL_COPY } from '@shared/copy/delegationApproval';
+import type { TeXRAIconName } from '@shared/wa/iconNames';
+
+export interface ProgressToolbarButton {
+  id: string;
+  icon: TeXRAIconName;
+  command: string;
+  title: string;
+  titleActive?: string;
+  className?: string;
+  disabled?: boolean;
+  isToggle?: boolean;
+}
 
 /**
  * DOM element IDs used across the progress view.
@@ -49,7 +61,7 @@ export const GROUP_DOM_IDS = Object.freeze({
 
 const STOP_STREAM_BUTTON = Object.freeze({
   id: ELEMENT_IDS.STOP_STREAM_BTN,
-  icon: 'debug-stop',
+  icon: 'circle-stop',
   command: PROGRESS_VIEW_COMMANDS.STOP_STREAM,
   title:
     'Request task interruption (current API call will be aborted if supported)',
@@ -68,18 +80,18 @@ const RESTORE_STATE_BUTTON = Object.freeze({
 
 const OPEN_TASK_STORAGE_BUTTON = Object.freeze({
   id: ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
-  icon: 'folder-opened',
+  icon: 'folder-open',
   command: PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE,
   title: 'Open in task storage: reveal this run folder and generated files',
   className: 'storage-button',
   disabled: true,
 });
 
-const WORKFLOW_TOOLBAR = [
+const WORKFLOW_TOOLBAR: readonly ProgressToolbarButton[] = [
   STOP_STREAM_BUTTON,
   {
     id: ELEMENT_IDS.RUN_NEW_BTN,
-    icon: 'debug-start',
+    icon: 'play',
     command: PROGRESS_VIEW_COMMANDS.RUN_NEW,
     title: 'Start a fresh run (discards previous outputs)',
     className: 'run-button run-new-button',
@@ -87,7 +99,7 @@ const WORKFLOW_TOOLBAR = [
   },
   {
     id: ELEMENT_IDS.RESUME_BTN,
-    icon: 'debug-continue',
+    icon: 'forward-step',
     command: PROGRESS_VIEW_COMMANDS.RESUME,
     title: 'Resume from saved outputs (continues where it left off)',
     className: 'run-button resume-button',
@@ -97,7 +109,7 @@ const WORKFLOW_TOOLBAR = [
   OPEN_TASK_STORAGE_BUTTON,
   {
     id: ELEMENT_IDS.DIFF_STREAM_BTN,
-    icon: 'diff-multiple',
+    icon: 'code-compare',
     command: PROGRESS_VIEW_COMMANDS.DIFF_STREAM,
     title: 'Run latexdiff on existing tex files',
     className: 'diff-button',
@@ -113,7 +125,7 @@ const WORKFLOW_TOOLBAR = [
   },
   {
     id: ELEMENT_IDS.PACK_STREAM_BTN,
-    icon: 'archive',
+    icon: 'box-archive',
     command: PROGRESS_VIEW_COMMANDS.PACK_STREAM,
     title: 'Pack: Archive output files into a timestamped History folder',
     className: 'pack-button',
@@ -153,7 +165,7 @@ const COMPACT_RESPONSE_BUTTON = Object.freeze({
   disabled: true,
 });
 
-const TOOL_USE_TOOLBAR = [
+const TOOL_USE_TOOLBAR: readonly ProgressToolbarButton[] = [
   STOP_STREAM_BUTTON,
   YOLO_TOGGLE_BUTTON,
   DELEGATED_WORK_APPROVAL_TOGGLE_BUTTON,

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
@@ -18,7 +18,7 @@ import '@progressView/frontend/components/ContextManagement';
 import '@progressView/frontend/components/LatexdiffResults';
 
 // Third-party imports - Lit template utilities
-import { html } from 'lit';
+import { html, type TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 // Local imports - shared schemas and utilities
@@ -44,6 +44,27 @@ import {
 } from '../htmlBuilders';
 import type { FormatResult } from '../baseLogFormatter';
 
+/**
+ * The collapsible file-list banner shared by the file-list and missing-outputs
+ * entries: an icon/label summary over a `<ul>` of file rows, with optional
+ * trailing content inside the same details element.
+ */
+function buildFileListDetails(options: {
+  logId: string | undefined;
+  open: boolean;
+  iconName: TeXRAIconName;
+  label: string;
+  items: unknown;
+  trailing?: unknown;
+}): TemplateResult {
+  // prettier-ignore
+  return html`<wa-details appearance="plain" icon-placement="start" class="banner-details file-list-details" ?open=${options.open}>${buildDetailsSummary({
+    iconName: options.iconName,
+    label: options.label,
+    labelClass: 'summary-text',
+  })}<ul class="file-list-content" data-log-id=${ifDefined(options.logId)}>${options.items}</ul>${options.trailing ?? ''}</wa-details>`;
+}
+
 /** Format file list entry as TemplateResult. */
 export function formatFileListTemplate(
   message: LogMessageData,
@@ -52,25 +73,22 @@ export function formatFileListTemplate(
   const { id, data, text } = message;
   // Validate with Zod schema - renderer handles display field computation
   const parseResult = z.array(FileListEntrySchema).safeParse(data);
-  const shouldOpen = options?.defaultOpen ?? false;
 
   // Raw fallback when parsing fails
   const renderData = parseResult.success
     ? buildFileListRender(parseResult.data)
     : undefined;
-  const label = parseResult.success
-    ? (renderData?.summary ?? 'Files')
-    : 'Files (raw)';
-  const listContent = parseResult.success
-    ? (renderData?.items ?? '')
-    : html`<pre>${text ?? ''}</pre>`;
-
-  // prettier-ignore
-  return html`<wa-details appearance="plain" icon-placement="start" class="banner-details file-list-details" ?open=${shouldOpen}>${buildDetailsSummary({
+  return buildFileListDetails({
+    logId: id,
+    open: options?.defaultOpen ?? false,
     iconName: 'file',
-    label,
-    labelClass: 'summary-text',
-  })}<ul class="file-list-content" data-log-id=${ifDefined(id)}>${listContent}</ul></wa-details>`;
+    label: parseResult.success
+      ? (renderData?.summary ?? 'Files')
+      : 'Files (raw)',
+    items: parseResult.success
+      ? (renderData?.items ?? '')
+      : html`<pre>${text ?? ''}</pre>`,
+  });
 }
 
 /** Render XML link template. */
@@ -93,7 +111,6 @@ export function formatMissingOutputsTemplate(
   }
 
   const { missing, xmlFile } = parseResult.data;
-  const shouldOpen = options?.defaultOpen ?? false;
 
   // Special case: only XML link, no missing files
   if (missing.length === 0 && xmlFile) {
@@ -106,12 +123,14 @@ export function formatMissingOutputsTemplate(
     const basename = getBasename(filePath);
     return html`<li class="detail-item" title=${filePath}>${waIcon('triangle-exclamation')} ${buildFileLinkSpan(filePath, basename)}</li>`;
   });
-  // prettier-ignore
-  return html`<wa-details appearance="plain" icon-placement="start" class="banner-details file-list-details" ?open=${shouldOpen}>${buildDetailsSummary({
+  return buildFileListDetails({
+    logId: id,
+    open: options?.defaultOpen ?? false,
     iconName: 'triangle-exclamation',
     label: `Missing outputs (${missing.length})`,
-    labelClass: 'summary-text',
-  })}<ul class="file-list-content" data-log-id=${ifDefined(id)}>${listItems}</ul>${xmlFile ? renderXmlLink(xmlFile) : ''}</wa-details>`;
+    items: listItems,
+    trailing: xmlFile ? renderXmlLink(xmlFile) : '',
+  });
 }
 
 // =============================================================================

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -135,9 +135,9 @@ export function formatToolUseTemplate(
   });
 
   // Show output if present
-  const isWriteTool = toolDisplayKind(toolName) === 'write';
+  const displayKind = toolDisplayKind(toolName);
   const isTrivialWriteOutput =
-    isWriteTool && outputText.trim() === TRIVIAL_WRITE_OUTPUT;
+    displayKind === 'write' && outputText.trim() === TRIVIAL_WRITE_OUTPUT;
   // Skip the output section when its text is already fully shown in the
   // collapsed summary title (e.g. "Replaced 1 occurrence."). Exact match
   // against the summary only — a substring test would also suppress short
@@ -151,11 +151,11 @@ export function formatToolUseTemplate(
     !isOutputInTitle &&
     toolName !== DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME &&
     !isMcpToolName(toolName) &&
-    toolDisplayKind(toolName) !== 'read' &&
+    displayKind !== 'read' &&
     !isTrivialWriteOutput
   ) {
     sections.push(
-      toolDisplayKind(toolName) === 'bash' || normalizedToolName === 'codex'
+      displayKind === 'bash' || normalizedToolName === 'codex'
         ? buildTerminalSection('', outputText)
         : buildToolSection('', outputText, {
             toolName,

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -1,13 +1,10 @@
 /**
  * Module-level reactive state for the Progress view.
  *
- * Hoisted from `ProgressApp` private fields (PRD: docs/prds/2026-05-08-electron-shell-layout.md § 7.A).
- * Both the rail (`<stream-tabs>`) and the conversation body need to observe the
- * same signals from independent DOM trees once PR 2 extracts `<stream-conversation>`.
- *
- * No behavior change: every signal here was previously a private field on the
- * `ProgressApp` class. Identity and reactivity are preserved — selectors are
- * still `select()` / `Signal.Computed`, so consumers do not need to re-subscribe.
+ * The signals live here rather than on `ProgressApp` because independent DOM
+ * trees observe them: the rail (`<stream-tabs>`), the conversation body
+ * (`<stream-conversation>`), and the desktop renderer, which drives the same
+ * `appState` without mounting `<progress-app>` at all.
  *
  * Singleton scope: only one Progress view per webview/page. If we ever need
  * multiple independent progress instances on the same page, this file must be
@@ -360,12 +357,8 @@ export const logContext$ = new Signal.Computed((): StreamLogContextValue => {
 });
 
 // ---------------------------------------------------------------------------
-// Mutators — module-level helpers for stream-scoped updates.
-//
-// Hoisted from `ProgressApp` private methods (PRD: docs/prds/2026-05-08-electron-shell-layout.md
-// § 7.A) so the desktop renderer can drive the same `appState` updates without
-// mounting `<progress-app>`. Behavior preserved exactly: same fast-path,
-// same skip-no-op short-circuit, same Mutative structural sharing.
+// Mutators — module-level helpers for stream-scoped updates, shared by the
+// webview and the desktop renderer.
 // ---------------------------------------------------------------------------
 
 export function setStreamStateForId(

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -11,12 +11,12 @@ export const logEntryStyles = css`
   .log-container {
     flex: 1 1 auto;
     width: 100%;
-    padding: var(--wa-space-xs)
+    padding: var(--wa-space-m)
       max(
         var(--wa-space-m),
         calc((100% - var(--conversation-reading-width, 800px)) / 2)
       )
-      var(--wa-space-s);
+      var(--wa-space-2xl);
     box-sizing: border-box;
     min-width: 0;
     min-height: 0;
@@ -455,7 +455,7 @@ export const logEntryStyles = css`
       var(--wa-color-surface-default, transparent)
     );
     color: var(--wa-color-terminal-foreground, var(--wa-color-text-normal));
-    padding-block: var(--wa-space-xs);
+    padding-block: var(--wa-space-m);
   }
 
   :host([terminal]) .log-line {

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -11,12 +11,12 @@ export const logEntryStyles = css`
   .log-container {
     flex: 1 1 auto;
     width: 100%;
-    padding: var(--wa-space-m)
+    padding: var(--wa-space-xs)
       max(
         var(--wa-space-m),
         calc((100% - var(--conversation-reading-width, 800px)) / 2)
       )
-      var(--wa-space-2xl);
+      var(--wa-space-s);
     box-sizing: border-box;
     min-width: 0;
     min-height: 0;
@@ -455,7 +455,7 @@ export const logEntryStyles = css`
       var(--wa-color-surface-default, transparent)
     );
     color: var(--wa-color-terminal-foreground, var(--wa-color-text-normal));
-    padding-block: var(--wa-space-m);
+    padding-block: var(--wa-space-xs);
   }
 
   :host([terminal]) .log-line {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -1,12 +1,11 @@
 /**
- * Schema-driven message handler for SettingsView.
+ * Schema-driven message handler for every SettingsView tab.
  *
- * Combines handlers from MemoryView, HistoryView, and ProfileView
- * into a single unified message handler.
- *
- * Domain-specific handlers are delegated to focused handler classes:
- * - AgentHandlers: agent selection, directories, and teams
- * - LatexSettingsHandlers: LaTeX tool detection and recommended settings
+ * This class owns the inbound registry, the memory/profile/model/tool commands,
+ * and the refresh fan-out after a mutation. Tab-shaped groups are delegated to
+ * focused handler classes in `./handlers/`: `AgentHandlers`,
+ * `LatexSettingsHandlers`, `HistoryHandlers`, `GitHubSubscriptionHandlers`, and
+ * `ChatGptSubscriptionHandlers`.
  */
 import * as path from 'node:path';
 
@@ -1030,9 +1029,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     await vscode.env.openExternal(vscode.Uri.parse(url));
   }
 
-  private async postMessageToActiveWebview(
-    message: unknown | null | undefined,
-  ): Promise<void> {
+  private async postMessageToActiveWebview(message: unknown): Promise<void> {
     if (message == null) return;
     await this.withActiveWebview(async (webview) => {
       await webview.postMessage(message);

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -133,11 +133,9 @@ export class SettingsApp extends SettingsAppBase {
 
   constructor() {
     super();
-    // State lives at module scope in `settingsState.ts` (mirrors
-    // progressView/frontend/progressState.ts). That state is shared across
-    // remounts in the same JS context (tests, hot reload), so reset it here
-    // to match the pre-migration per-instance-field behavior, where every
-    // signal started fresh on construction.
+    // State lives at module scope in `settingsState.ts` and is shared across
+    // remounts in the same JS context (tests, hot reload), so every signal
+    // starts fresh on construction.
     resetSettingsState();
   }
 
@@ -146,11 +144,9 @@ export class SettingsApp extends SettingsAppBase {
   // HISTORY_CLEARED is overridden here to additionally clear the
   // `<history-tab>` search box — a DOM ref this component owns via `@query`,
   // not signal state, so it can't live in the slice itself. `assertSupported`
-  // narrows the known-real `historySlice` handler out of the `Handler |
-  // Unsupported` union `SettingsViewOutboundHandlerRegistry` now requires
-  // (see `@shared/utils/dispatcher`) — this call site invokes a specific
-  // entry directly rather than going through the dispatcher, so it needs the
-  // narrowing dispatch itself would otherwise provide.
+  // narrows the `historySlice` entry out of the registry's
+  // `Handler | Unsupported` union (see `@shared/utils/dispatcher`), which is
+  // the narrowing the dispatcher would do were this not a direct call.
   private readonly messageHandlers: SettingsViewOutboundHandlerRegistry = {
     ...settingsViewHandlers,
     [SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED]: (data) => {

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -41,25 +41,17 @@ import {
 
 const LONG_INSTRUCTION_CHARS = 400;
 
-/** Per-item action → settings-view command carrying this item's historyId. */
-const HISTORY_ACTION_COMMANDS: Record<string, string> = {
-  delete: SETTINGS_VIEW_COMMANDS.DELETE_AGENT,
-  restore: SETTINGS_VIEW_COMMANDS.RESTORE_AGENT,
-  rerun: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
-  'export-md': SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_MD,
-  'export-tex': SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_TEX,
-  'export-html': SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_HTML,
-};
-
 /** Per-item action buttons, in render order. */
-const HISTORY_ACTION_BUTTONS: ReadonlyArray<{
-  readonly button: IconActionButtonOptions;
+const HISTORY_ACTIONS: ReadonlyArray<{
+  readonly button: IconActionButtonOptions & { readonly action: string };
+  /** Settings-view command this action posts, carrying this item's historyId. */
+  readonly command: string;
   /**
-   * Hidden when the host's registry declares this settings-view command
-   * unsupported, instead of leaving a control visible that can only produce
-   * an unavailable-command toast.
+   * Hidden when the host's registry declares `command` unsupported, instead of
+   * leaving a control visible that can only produce an unavailable-command
+   * toast. Delete renders on every host.
    */
-  readonly requiresCommand?: string;
+  readonly hideWhenUnsupported?: boolean;
   /** Rendered only for tool-use runs. */
   readonly toolUseOnly?: boolean;
 }> = [
@@ -71,6 +63,7 @@ const HISTORY_ACTION_BUTTONS: ReadonlyArray<{
       tooltip: 'Delete this history item',
       action: 'delete',
     },
+    command: SETTINGS_VIEW_COMMANDS.DELETE_AGENT,
   },
   {
     button: {
@@ -80,7 +73,8 @@ const HISTORY_ACTION_BUTTONS: ReadonlyArray<{
       tooltip: "Restore this run's setup",
       action: 'restore',
     },
-    requiresCommand: SETTINGS_VIEW_COMMANDS.RESTORE_AGENT,
+    command: SETTINGS_VIEW_COMMANDS.RESTORE_AGENT,
+    hideWhenUnsupported: true,
   },
   {
     button: {
@@ -90,7 +84,8 @@ const HISTORY_ACTION_BUTTONS: ReadonlyArray<{
       tooltip: 'Rerun this task',
       action: 'rerun',
     },
-    requiresCommand: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
+    command: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
+    hideWhenUnsupported: true,
   },
   {
     button: {
@@ -100,7 +95,8 @@ const HISTORY_ACTION_BUTTONS: ReadonlyArray<{
       tooltip: 'Export as Markdown',
       action: 'export-md',
     },
-    requiresCommand: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_MD,
+    command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_MD,
+    hideWhenUnsupported: true,
     toolUseOnly: true,
   },
   {
@@ -111,7 +107,8 @@ const HISTORY_ACTION_BUTTONS: ReadonlyArray<{
       tooltip: 'Export as LaTeX/PDF',
       action: 'export-tex',
     },
-    requiresCommand: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_TEX,
+    command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_TEX,
+    hideWhenUnsupported: true,
     toolUseOnly: true,
   },
   {
@@ -122,10 +119,16 @@ const HISTORY_ACTION_BUTTONS: ReadonlyArray<{
       tooltip: 'Export as shareable HTML webpage',
       action: 'export-html',
     },
-    requiresCommand: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_HTML,
+    command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_HTML,
+    hideWhenUnsupported: true,
     toolUseOnly: true,
   },
 ];
+
+/** Clicked `data-action` → the command it posts. */
+const HISTORY_ACTION_COMMANDS: ReadonlyMap<string, string> = new Map(
+  HISTORY_ACTIONS.map((entry) => [entry.button.action, entry.command]),
+);
 
 @customElement('history-item')
 export class HistoryItemElement extends LitElement {
@@ -206,7 +209,7 @@ export class HistoryItemElement extends LitElement {
 
   private handleAction(action: string): void {
     if (!this.item) return;
-    const command = HISTORY_ACTION_COMMANDS[action];
+    const command = HISTORY_ACTION_COMMANDS.get(action);
     if (!command) return;
     postMessage(command, { historyId: this.item.id });
   }
@@ -412,14 +415,11 @@ export class HistoryItemElement extends LitElement {
             class="history-actions action-button-group"
             @click=${this.handleActionClick}
           >
-            ${HISTORY_ACTION_BUTTONS.filter(
+            ${HISTORY_ACTIONS.filter(
               (entry) =>
                 (!entry.toolUseOnly || presentation.isToolUse) &&
-                (entry.requiresCommand === undefined ||
-                  !isKnownUnsupported(
-                    this.unsupportedCommands,
-                    entry.requiresCommand,
-                  )),
+                (!entry.hideWhenUnsupported ||
+                  !isKnownUnsupported(this.unsupportedCommands, entry.command)),
             ).map((entry) => renderIconActionButton(entry.button))}
           </div>
         </div>

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -1,12 +1,8 @@
 /**
  * Module-level reactive state for the Settings view.
  *
- * Hoisted from `SettingsApp` private instance fields onto module scope,
- * mirroring the Progress view's `progressState.ts` (audit item A3). Unlike
- * `progressState.ts`, there is no monolithic nested state object here — each
- * signal below was already an independent, flat piece of state (no shared
- * per-stream Map indirection), so slices import and set the specific signals
- * they need directly instead of going through a generic get/set context.
+ * Each signal is an independent, flat piece of state, so slices import and set
+ * the ones they need directly rather than going through a get/set context.
  *
  * SettingsApp has no persistence/restore path: every signal here is written
  * only by the composed `messageHandlers` registry (see `messageDispatcher.ts`
@@ -18,15 +14,10 @@
  * multiple independent settings instances on the same page, this file must be
  * promoted to a per-instance store.
  *
- * Reset mechanism: every writable signal below is declared through
- * `trackedSignal()` instead of the bare `signal()` import. `trackedSignal`
- * records the signal's own default-value factory in `resetCallbacks` at the
- * point of declaration, so `resetSettingsState()` can replay that single list
- * instead of a hand-written, independently-ordered sequence of `.set()`
- * calls. There is only one place that knows each signal's default — the
- * `trackedSignal(() => ...)` call site — so a new signal can't be added
- * without also being wired into the reset; forgetting the wrapper here would
- * mean the signal isn't exported as reactive state at all.
+ * Declare writable signals with `trackedSignal()` rather than the bare
+ * `signal()`: the registry records each default-value factory at its
+ * declaration site, and that single list is what `resetSettingsState()`
+ * replays. A signal declared any other way is silently left out of the reset.
  */
 
 import { createTrackedSignalRegistry } from '@shared/signals';
@@ -86,7 +77,7 @@ const DEFAULT_CHATGPT_AUTH: ChatGptAuthStatus = {
 
 // ---------------------------------------------------------------------------
 // Reset registry — populated by `trackedSignal` as each signal below is
-// declared. See the file-header note on the reset mechanism.
+// declared.
 // ---------------------------------------------------------------------------
 
 const { trackedSignal, resetAll: resetTrackedSignals } =
@@ -254,10 +245,7 @@ export const unsupportedCommands = trackedSignal<ReadonlySet<string> | null>(
 
 // ---------------------------------------------------------------------------
 // Reset — module-level state is shared across remounts in the same JS context
-// (tests, hot reload). Mirrors `resetProgressState()` in progressState.ts in
-// intent (replay the one source of truth on remount); the mechanism differs
-// because these signals stay individually exported rather than living behind
-// one monolithic object signal — see the file-header note.
+// (tests, hot reload), so a fresh mount replays every registered default.
 // ---------------------------------------------------------------------------
 export function resetSettingsState(): void {
   resetTrackedSignals();

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -90,8 +90,6 @@ export class ToolsTab extends LitElement {
         display: block;
       }
 
-      /* max-width and centering provided by .tab-content-container */
-
       .tools-summary {
         display: flex;
         align-items: center;
@@ -181,11 +179,7 @@ export class ToolsTab extends LitElement {
   };
 
   private handleToolPathProtectionToggle = (e: Event): void => {
-    const target = e.target as WaSwitch | null;
-    postMessage(SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING, {
-      key: WorkspaceStateKey.TOOL_PATH_PROTECTION_ENABLED,
-      value: Boolean(target?.checked),
-    });
+    this.postStateToggle(WorkspaceStateKey.TOOL_PATH_PROTECTION_ENABLED, e);
   };
 
   private handleAgentSkillsToggle = (e: Event): void => {

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -1,11 +1,9 @@
 /**
  * Agent selection, directory, and team handlers.
  *
- * Extracted from SettingsViewMessageHandler to improve cohesion.
  * Handles agent enable/disable, create/customize/delete, YAML editing,
  * custom agent directories, and agent teams.
  */
-import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 import { getAgent, loadAgents, refresh as refreshAgents } from '@agent/index';
@@ -44,9 +42,7 @@ import {
   type SettingsHandlerContext,
 } from './SettingsHandlerContext';
 
-/**
- * Agent selection, directory, and team handler delegate.
- */
+/** Agent selection, directory, and team handler delegate. */
 export class AgentHandlers {
   private readonly catalogController: SettingsAgentCatalogController;
   private readonly directoryController: SettingsAgentDirectoryController;

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -7,10 +7,6 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
-// The `.tex` template is bundled in the extension's resources/ tree and loaded
-// as raw text by the esbuild `.tex: text` loader; it is injected into the
-// host-neutral ChatExportController so core stays free of `@resources`.
-
 import {
   getExecutionStore,
   deleteExecution,
@@ -35,6 +31,9 @@ import {
   htmlExportErrorMessage,
 } from '@controllers/settingsView/HistoryActionOutcomes';
 import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
+// Bundled in the extension's resources/ tree and loaded as raw text by the
+// esbuild `.tex: text` loader, then injected into the host-neutral
+// ChatExportController so core stays free of `@resources`.
 import latexPreamble from '@resources/templates/chatExport.tex';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ExecutionId } from '@shared/schemas';
@@ -159,9 +158,9 @@ export class HistoryHandlers {
       this.ctx,
       'Failed to export chat',
       async () => {
-        // HTML no longer goes through buildExportInput/ChatExportInput — it
-        // reads the execution's trace directly via assembleTrace, which has
-        // its own independent (and differently-shaped) missing-data statuses.
+        // HTML reads the execution's trace directly via assembleTrace, whose
+        // missing-data statuses are shaped differently from
+        // buildExportInput's, so it takes its own path.
         if (format === 'html') {
           await this.exportAndOpenHtml(data.historyId);
           return;

--- a/packages/extension/src/settingsView/handlers/latexSettingsHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/latexSettingsHandlers.ts
@@ -1,7 +1,6 @@
 /**
  * LaTeX settings domain handlers.
  *
- * Extracted from SettingsViewMessageHandler to improve cohesion.
  * Handles LaTeX tool detection, recommended VS Code settings,
  * LaTeX Workshop installation, and install commands.
  */
@@ -38,10 +37,7 @@ import {
   type SettingsHandlerContext,
 } from './SettingsHandlerContext';
 
-/**
- * LaTeX settings handler delegate.
- * Manages LaTeX tool detection, recommended settings, and installation.
- */
+/** LaTeX settings handler delegate. */
 export class LatexSettingsHandlers {
   private readonly recommendedSettingsController =
     new LatexRecommendedSettingsController({
@@ -131,10 +127,6 @@ export class LatexSettingsHandlers {
    * Push current LaTeX/compile/diff config values to the webview. Each field
    * is left undefined when no value is set in workspace storage so the UI
    * can render the documented default rather than overwriting it on save.
-   *
-   * Iterates LATEX_FIELD_TO_KEY (the shared single-source-of-truth field/key
-   * map) so the read path stays automatically aligned with the write path
-   * and the migration helper.
    */
   async sendLatexConfigValues(webview: vscode.Webview): Promise<void> {
     await webview.postMessage(

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -148,9 +148,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
 
       // The webview applies the model selection itself and the host keeps no
       // model state; MODEL_SELECTED has no outbound counterpart to echo to.
-      [MAIN_VIEW_COMMANDS.MODEL_SELECTED]: () => {
-        /* State saved client-side */
-      },
+      [MAIN_VIEW_COMMANDS.MODEL_SELECTED]: () => {},
       [MAIN_VIEW_COMMANDS.SETTINGS_OPEN]: () =>
         safeExecuteCommand(
           'workbench.action.openSettings',
@@ -199,7 +197,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.fileManager.handleSelectMultipleFiles(m),
 
       [MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED]: (m) =>
-        this.fileManager.handleGenericFileSelected({
+        this.fileManager.handleEditedFileSelected({
           command: m.command,
           filePath: m.filePath ?? '',
         }),

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -142,9 +142,9 @@ export class MainApp extends MainAppBase {
 
   constructor() {
     super();
-    // Per-mount slate: state and persistence runtime live at module scope
-    // (see mainViewState.ts), so a remount in the same JS context (tests,
-    // hot reload) must reset them like fresh instance fields used to.
+    // Per-mount slate: state and the persistence runtime live at module scope
+    // (see mainViewState.ts) and outlive the element, so a remount in the same
+    // JS context (tests, hot reload) starts by clearing them.
     resetMainViewState();
     resetPersistenceRuntime();
     this.fileStateContextValue = fileStateContext$.get();
@@ -256,7 +256,7 @@ export class MainApp extends MainAppBase {
     }
   }
 
-  private onViewTabShow = (event: WaTabShowEvent): void => {
+  private readonly onViewTabShow = (event: WaTabShowEvent): void => {
     if (event.detail.name !== 'progress') return;
     postMessage(COMMON_COMMANDS.SWITCH_VIEW, { view: 'progress' });
     const tabs = event.currentTarget as MutableWaTabGroup;
@@ -265,11 +265,11 @@ export class MainApp extends MainAppBase {
     });
   };
 
-  private onOpenDashboard = (): void => {
+  private readonly onOpenDashboard = (): void => {
     postMessage(COMMON_COMMANDS.SWITCH_VIEW, { view: 'dashboard' });
   };
 
-  private onPopOutProgress = (): void => {
+  private readonly onPopOutProgress = (): void => {
     postMessage(COMMON_COMMANDS.SWITCH_VIEW, {
       view: 'progress',
       openInEditor: true,
@@ -366,9 +366,6 @@ export class MainApp extends MainAppBase {
       ? FILE_SELECT_CONFIGS.filter((config) => config.type === 'media')
       : FILE_SELECT_CONFIGS;
 
-    const akb = apiKeyBanner$.get();
-    const acb = agentConfigBanner$.get();
-    const db = dependencyBanner$.get();
     const sf = singleFiles$.get();
     const fo = fileOptions$.get();
     const files = multiFiles$.get();
@@ -436,9 +433,9 @@ export class MainApp extends MainAppBase {
 
     const banners = html`
       <banner-group
-        .apiKeyBanner=${akb}
-        .agentConfigBanner=${acb}
-        .dependencyBanner=${db}
+        .apiKeyBanner=${apiKeyBanner$.get()}
+        .agentConfigBanner=${agentConfigBanner$.get()}
+        .dependencyBanner=${dependencyBanner$.get()}
         .gettingStartedVisible=${
           gettingStartedVisible$.get() && !gettingStartedDismissed$.get()
         }

--- a/packages/extension/src/webview/frontend/mainViewActions.ts
+++ b/packages/extension/src/webview/frontend/mainViewActions.ts
@@ -118,37 +118,29 @@ export function announce(message: string): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Validates that a selection exists in options.
- * Returns current value if found, otherwise falls back to first available option.
+ * Resolve the model selection against the current options: keep the current
+ * value when it is present and enabled, otherwise prefer the first enabled
+ * option (models with a missing API key are disabled), then the current
+ * value even though it is disabled, then the first option.
  */
 function validateSelection<T extends { value: string; disabled?: boolean }>(
   options: T[],
   currentValue: string,
-  preferEnabled: boolean,
 ): string {
   const current = options.find((opt) => opt.value === currentValue);
-  if (current && (!preferEnabled || !current.disabled)) {
+  if (current && !current.disabled) {
     return currentValue;
   }
 
-  // Fallback: prefer enabled options (for models with missing API keys)
-  if (preferEnabled) {
-    const firstEnabled = options.find((opt) => !opt.disabled);
-    if (firstEnabled) return firstEnabled.value;
-  }
+  const firstEnabled = options.find((opt) => !opt.disabled);
+  if (firstEnabled) return firstEnabled.value;
   if (current) return currentValue;
   return options[0]?.value ?? '';
 }
 
 export function refreshModelSelectionForActiveSession(): void {
   const options = getModelOptionsForSession(sessionType$.get());
-  model$.set(
-    validateSelection(
-      options,
-      model$.get(),
-      true, // preferEnabled: skip disabled models
-    ),
-  );
+  model$.set(validateSelection(options, model$.get()));
 }
 
 export function enterToolUseSession(): void {

--- a/packages/extension/src/webview/frontend/slices/documentSlice.ts
+++ b/packages/extension/src/webview/frontend/slices/documentSlice.ts
@@ -150,7 +150,7 @@ export const documentHandlers = {
       return;
     }
 
-    // Base/edited single-slot fields go through fileOptions like before.
+    // Base/edited are single-slot fields: they select out of fileOptions.
     const key = SINGLE_FILE_TYPE_TO_KEY[fileType];
     if (!key) return;
     const sf = singleFiles$.get();

--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -112,7 +112,7 @@ export class FileManager extends BaseWebviewManager {
     }
   }
 
-  handleGenericFileSelected(message: EditedFileSelectedMessage): void {
+  handleEditedFileSelected(message: EditedFileSelectedMessage): void {
     logger.debug(CHANNEL, `${message.command}: ${message.filePath}`);
   }
 
@@ -347,7 +347,9 @@ export class FileManager extends BaseWebviewManager {
     this.postMessage({ command: setCommand, files: message.files ?? [] });
   }
 
-  async selectOutputFiles(currentInputFile?: string): Promise<string[] | null> {
+  private async selectOutputFiles(
+    currentInputFile?: string,
+  ): Promise<string[] | null> {
     try {
       const relativePaths = await selectFiles({
         allowMany: true,

--- a/prompts/agents/remote/Lean4/leanOrchestrator.yaml
+++ b/prompts/agents/remote/Lean4/leanOrchestrator.yaml
@@ -7,6 +7,9 @@ settings:
     # Delegation
     - delegate_workflow
     - delegate_agent
+    # Advanced deterministic delegation. The global Workflow Script switch is
+    # an additional kill switch and is disabled by default.
+    - delegate_workflow_script
     - executions
     - accept_run_files
     # Project management

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -83,11 +83,7 @@ export function replaceMessagesInPlace<T>(target: T[], newContents: T[]): void {
   target.push(...newContents);
 }
 
-/**
- * Core services scoped with the run's workspace state. Named distinctly from
- * the exported service interfaces in the sibling `CycleServices.ts` (which
- * model the live model client) to avoid a same-folder name collision.
- */
+/** Core services scoped with the run's workspace state. */
 type WorkspaceScopedCore = AgentCore & { workspace: AgentWorkspaceState };
 
 export type CycleDebugFileOptions = {

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -23,6 +23,7 @@ import { FlowTransition } from './FlowTransitions';
 import {
   type InvocationResult,
   RetryableInvocationNode,
+  RETRY_BACKOFF_MS,
   handleInvocationResult,
 } from './RetryState';
 
@@ -59,10 +60,7 @@ export interface ModelInvocationConfig<TShared, TServices> {
  * Only the services this node and its `RetryableInvocationNode` base class
  * actually read: the model cell (handler and live provider client), logger,
  * setting (temperature/tools), config (for `saveCycleDebug`'s log context),
- * the run scope (retry gate and debug-log identity), and the run's abort
- * signal. Picking from `AgentCore`/`BaseFlowContextInit` instead of requiring
- * the literal type keeps every existing caller, which passes the full services
- * bag, satisfying this narrower shape structurally.
+ * and the run scope (retry gate, abort signal, and debug-log identity).
  */
 type InvocationServices = Pick<
   AgentCore,
@@ -155,7 +153,7 @@ export class ModelInvocationNode<
         wireRoute,
         {
           signal,
-          baseBackoffMs: this._retryBackoffMs,
+          baseBackoffMs: RETRY_BACKOFF_MS,
           // One wire route owns transport and server-failure cooling. A second
           // ordered scope keeps model-specific limits from blocking healthy
           // sibling models on the same credential and endpoint. Relay calls

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -13,6 +13,7 @@ import {
   resetCycleState,
   saveCycleDebug,
   SkippableNodeResult,
+  type CycleDebugFileOptions,
 } from '@agent/core/flows/CommonCycleTypes';
 import {
   isContextWindowExceededStopReason,
@@ -38,22 +39,9 @@ import type { ResponseCycleServices } from './CycleServices';
 // ============================================================================
 
 /**
- * Schema for serializable response cycle fields.
- *
- * Extends BaseCycleFieldsSchema with response-specific fields for output tracking.
- *
- * ## Field Categories
- *
- * From BaseCycleFieldsSchema (shared with ToolUseRoundFlow):
- * - messages, shouldStop, endTurn, responseTimeMs, stopReason, lastError
- *
- * Response-specific fields:
- * - outputExists, outputLocation, processedResponse
- *
- * ## Serialization
- *
- * All fields here are natively serializable (structuredClone compatible).
- * Non-serializable fields (debug, responseObject) are in CycleTransientFields.
+ * Serializable response cycle fields: the base cycle fields plus this flow's
+ * output tracking. Everything here is structuredClone compatible; the
+ * non-serializable rest lives in {@link CycleTransientFields}.
  */
 const CycleFieldsSchema = BaseCycleFieldsSchema.extend({
   /** Whether output file exists */
@@ -68,14 +56,8 @@ const CycleFieldsSchema = BaseCycleFieldsSchema.extend({
 type CycleFields = z.infer<typeof CycleFieldsSchema>;
 
 /**
- * Transient cycle fields that are NOT serialized.
- *
- * These contain non-serializable data (unknown response objects)
- * and are regenerated each cycle execution.
- *
- * NOTE: All debug options (context and file options) are derived from
- * services/shared at each `maybeSaveDebugObject` call site. Nothing is
- * stored in shared state.
+ * Transient cycle fields that are NOT serialized. These hold non-serializable
+ * data (unknown response objects) and are regenerated each cycle execution.
  */
 interface CycleTransientFields {
   /** System prompt for model (regenerated from agent prompt each cycle) */
@@ -102,6 +84,21 @@ interface ResponsePrepResult {
   interrupted: boolean;
   exists: boolean;
   systemPrompt?: string;
+}
+
+/**
+ * Debug-file identity for one cycle. The request messages and the response are
+ * saved from different nodes and must land on the same base name and round.
+ */
+function responseDebugFileOptions(
+  shared: ResponseCycleShared,
+  continuationCount: number,
+): CycleDebugFileOptions {
+  return {
+    continuationCount,
+    baseName: 'response',
+    outputFile: shared.outputLocation.relativePath,
+  };
 }
 
 /**
@@ -141,11 +138,12 @@ class ResponsePrepNode<C> extends BaseNode<
     shared.outputExists = prepRes.exists;
     shared.systemPrompt = prepRes.systemPrompt;
 
-    await saveCycleDebug(shared.messages, 'messages', this.services, {
-      continuationCount: round.continuationCount,
-      baseName: 'response',
-      outputFile: shared.outputLocation.relativePath,
-    });
+    await saveCycleDebug(
+      shared.messages,
+      'messages',
+      this.services,
+      responseDebugFileOptions(shared, round.continuationCount),
+    );
 
     return FlowTransition.DEFAULT;
   }
@@ -172,21 +170,17 @@ interface ProcessResultCommon {
 }
 
 /**
- * Discriminated on `hasResponse`: `newResponse`/`processedResponse`/
- * `bestConnector`/`updatedLastResponse`/`updatedAccumulatedOutput` are only
- * ever set together (see the `if (newResponse)` block below), so modeling
- * them as one correlated variant instead of five independently-optional
- * fields removes the need to re-derive that correlation with separate null
- * checks in `post()`.
+ * Discriminated on `hasResponse`: `processedResponse`/`bestConnector`/
+ * `updatedAccumulatedOutput` are only ever set together, so modeling them as
+ * one correlated variant instead of independently-optional fields removes the
+ * need to re-derive that correlation with separate null checks in `post()`.
  */
 type ProcessResult =
   | (ProcessResultCommon & { hasResponse: false })
   | (ProcessResultCommon & {
       hasResponse: true;
-      newResponse: string;
       processedResponse: string;
       bestConnector: string;
-      updatedLastResponse: string;
       updatedAccumulatedOutput: string;
     });
 
@@ -233,11 +227,6 @@ export function responseCycleToolsForModel<C>(
 /**
  * Transforms the raw model response into output-ready text, updates usage metrics,
  * and persists incremental tool-state derived from the result.
- *
- * PocketFlow compliance:
- * - prep() extracts only the data needed by exec()
- * - exec() performs pure computation, no side effects
- * - post() applies all side effects (store updates)
  */
 class ResponseProcessNode<C> extends BaseNode<
   ResponseCycleShared,
@@ -266,8 +255,11 @@ class ResponseProcessNode<C> extends BaseNode<
     });
 
     return stage.run(async () => {
+      // A host-supplied processor is applied once inside each handler's
+      // extractResponse, so this text is already in its final form.
+      // Re-applying would run non-idempotent custom replacements twice.
       const {
-        text: newResponse,
+        text: processedResponse,
         usage: responseUsage,
         stopReason,
         thinking: thinkingContent,
@@ -281,8 +273,8 @@ class ResponseProcessNode<C> extends BaseNode<
         { normalizeNullUsage: true },
       );
 
-      if (newResponse) {
-        logger.debug(`Model response: ${newResponse.slice(0, 100)}`);
+      if (processedResponse) {
+        logger.debug(`Model response: ${processedResponse.slice(0, 100)}`);
       }
       if (prepRes.responseTimeMs != null) {
         logger.debug(
@@ -298,7 +290,10 @@ class ResponseProcessNode<C> extends BaseNode<
         });
       }
 
-      const scratchpad = await extractScratchpad(newResponse, 'scratchpad');
+      const scratchpad = await extractScratchpad(
+        processedResponse,
+        'scratchpad',
+      );
       if (scratchpad) {
         logger.info(scratchpad, {
           messageType: MESSAGE_TYPES.SCRATCHPAD,
@@ -312,14 +307,9 @@ class ResponseProcessNode<C> extends BaseNode<
         normalizedUsage,
       };
 
-      if (!newResponse) {
+      if (!processedResponse) {
         return { kind: 'success', value: { ...common, hasResponse: false } };
       }
-
-      // A host-supplied processor is applied once inside each handler's
-      // extractResponse, so newResponse is already in its final form here.
-      // Re-applying would run non-idempotent custom replacements twice.
-      const processedResponse = newResponse;
 
       const bestConnector =
         await this.services.runScope.session.responseTextProcessing.connectResponseText(
@@ -334,10 +324,8 @@ class ResponseProcessNode<C> extends BaseNode<
         value: {
           ...common,
           hasResponse: true,
-          newResponse,
           processedResponse,
           bestConnector,
-          updatedLastResponse: processedResponse,
           updatedAccumulatedOutput,
         },
       };
@@ -381,7 +369,7 @@ class ResponseProcessNode<C> extends BaseNode<
       return FlowTransition.COMPLETE;
     }
 
-    workspace.assembly.lastResponse = result.updatedLastResponse;
+    workspace.assembly.lastResponse = result.processedResponse;
     workspace.assembly.accumulatedOutput = result.updatedAccumulatedOutput;
     shared.processedResponse = result.processedResponse;
 
@@ -442,11 +430,9 @@ class ResponseProcessNode<C> extends BaseNode<
 }
 
 /**
- * Finalizes the response cycle by recording round statistics.
- * All flow exit paths route through this node to ensure proper cleanup.
- *
- * PocketFlow pattern: Single finalization point in the flow graph.
- * No guard flags needed (graph ensures single execution).
+ * Finalizes the response cycle by recording round statistics. Every flow exit
+ * path routes through this single finalization node, so no guard flag is
+ * needed: the graph guarantees one execution.
  */
 class ResponseCycleFinalizeNode<C> extends BaseNode<
   ResponseCycleShared,
@@ -475,11 +461,6 @@ class ResponseCycleFinalizeNode<C> extends BaseNode<
 /**
  * Evaluates the processed response to decide whether the agent should end the turn,
  * stop entirely, or enqueue a continuation request.
- *
- * PocketFlow compliance:
- * - prep() extracts only the data needed by exec()
- * - exec() performs pure computation using prepRes
- * - post() applies all side effects
  */
 class ResponseContinuationNode<C> extends BaseNode<
   ResponseCycleShared,
@@ -627,18 +608,8 @@ class ResponseContinuationNode<C> extends BaseNode<
 }
 
 /**
- * Creates a response cycle flow with services injected directly.
- *
- * The returned flow uses the services pattern:
- * - Services are passed via `setServices()` (options flattened)
- * - Only mutable state flows through the shared context
- *
- * @example
- * ```typescript
- * const flow = createResponseCycleFlow<MyContext>();
- * flow.setServices({ ...options, store });
- * await flow.run(sharedState);
- * ```
+ * Creates a response cycle flow. The caller injects {@link ResponseCycleServices}
+ * through `setServices()`; only mutable state travels in the shared context.
  */
 export function createResponseCycleFlow<C>(): Flow<
   ResponseCycleShared,
@@ -659,11 +630,8 @@ export function createResponseCycleFlow<C>(): Flow<
       shared.responseObject = response;
     },
     getPostCompactionContext: defaultPostCompactionContext,
-    getDebugFileOptions: (shared, services) => ({
-      continuationCount: services.round.continuationCount,
-      baseName: 'response',
-      outputFile: shared.outputLocation.relativePath,
-    }),
+    getDebugFileOptions: (shared, services) =>
+      responseDebugFileOptions(shared, services.round.continuationCount),
   });
   const processNode = new ResponseProcessNode<C>();
   const continuationNode = new ResponseContinuationNode<C>();

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -34,20 +34,18 @@ const BACKGROUND_MODE_MIN_RETRIES = 3;
  * own failure-scaled backoff on top, so this is an implementation constant
  * rather than something a user tunes separately from the attempt count.
  */
-const RETRY_BACKOFF_MS = 1000;
+export const RETRY_BACKOFF_MS = 1000;
 
-/** Returns one initial attempt plus configured retries and their base backoff. */
-function getNodeRetryConfig(): { maxRetries: number; backoffMs: number } {
-  const maxAutoAttempts = getValidatedConfig(
-    'texra.model.retry.maxAttempts',
-    ModelRetryMaxAttemptsSchema,
-    DEFAULT_CORE_SETTINGS.model.retry.maxAttempts,
+/** One initial attempt plus the configured number of automatic retries. */
+function getNodeMaxRetries(): number {
+  return (
+    1 +
+    getValidatedConfig(
+      'texra.model.retry.maxAttempts',
+      ModelRetryMaxAttemptsSchema,
+      DEFAULT_CORE_SETTINGS.model.retry.maxAttempts,
+    )
   );
-
-  return {
-    maxRetries: 1 + maxAutoAttempts,
-    backoffMs: RETRY_BACKOFF_MS,
-  };
 }
 
 interface ManualRetryPromptResult {
@@ -122,13 +120,10 @@ export abstract class RetryableInvocationNode<
   protected _userCancelled = false;
   protected _hasAttemptedTokenRefresh = false;
   protected _persistent401Error: Error | null = null;
-  protected _retryBackoffMs: number;
   private _retryLifecycle: RetryLifecycleState | undefined;
 
   constructor() {
-    const config = getNodeRetryConfig();
-    super(config.maxRetries, config.backoffMs / 1000);
-    this._retryBackoffMs = config.backoffMs;
+    super(getNodeMaxRetries(), RETRY_BACKOFF_MS / 1000);
   }
 
   protected abstract getOperationName(): string;
@@ -371,15 +366,13 @@ export abstract class RetryableInvocationNode<
 
   async _exec(prepRes: unknown): Promise<unknown> {
     this._userCancelled = false;
-    const config = getNodeRetryConfig();
-    let maxRetries = config.maxRetries;
+    let maxRetries = getNodeMaxRetries();
 
     if (this.isBackgroundModeActive()) {
       maxRetries = Math.max(maxRetries, BACKGROUND_MODE_MIN_RETRIES);
     }
 
     this.maxRetries = maxRetries;
-    this._retryBackoffMs = config.backoffMs;
     this._retryLifecycle = {
       operationId: `model-operation-${generateShortId()}`,
       startedAt: Date.now(),
@@ -390,7 +383,7 @@ export abstract class RetryableInvocationNode<
     // This local delay is the fallback for retryable failures that do not
     // implicate a shared route. For classified route failures it overlaps the
     // gate's cooling interval, so the gate waits only for any remaining time.
-    this.wait = config.backoffMs / 1000;
+    this.wait = RETRY_BACKOFF_MS / 1000;
     // The run's one interrupt controller drives the retry loop's abort
     // handling; an interrupt is read back off the same signal in
     // `getFallbackResult`, so there is nothing to register or clear here.
@@ -400,8 +393,7 @@ export abstract class RetryableInvocationNode<
 
   async retryPrompt(_prepRes: unknown, error: Error): Promise<boolean> {
     if (isUserAbort(error)) return false;
-    // A missing credential cannot be fixed by retrying; fail immediately as
-    // the pre-cell eager client build did.
+    // A missing credential cannot be fixed by retrying; fail immediately.
     if (hasMissingApiKeyErrorMarker(error)) return false;
 
     const result = await this.handleManualRetryPrompt(error);

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -609,17 +609,17 @@ export class ToolUseDispatchNode<C> extends Node<
     // For handlers that carry provider-side reasoning across multiple parallel
     // calls, batch all tool calls into a single message to preserve thought
     // signatures / reasoning_content.
-    const modelHandler = this.services.modelCell.handler;
-    const shouldBatch =
-      allResults.length > 1 &&
-      modelHandler.requiresBatchedParallelToolResults &&
-      modelHandler.createBatchedToolUseFollowUpMessages !== undefined;
-
+    //
     // Called through `modelHandler.` (not an extracted local reference) so
     // provider implementations that read `this` internally (e.g. Google,
     // OpenAI) keep their receiver bound.
-    if (shouldBatch && modelHandler.createBatchedToolUseFollowUpMessages) {
-      const client = await this.services.modelCell.getClient();
+    const modelHandler = this.services.modelCell.handler;
+    const client = await this.services.modelCell.getClient();
+    if (
+      allResults.length > 1 &&
+      modelHandler.requiresBatchedParallelToolResults &&
+      modelHandler.createBatchedToolUseFollowUpMessages
+    ) {
       const followUpMsgs =
         await modelHandler.createBatchedToolUseFollowUpMessages(
           allResults.map((execResult) => ({
@@ -633,7 +633,6 @@ export class ToolUseDispatchNode<C> extends Node<
         );
       shared.messages.push(...followUpMsgs);
     } else {
-      const client = await this.services.modelCell.getClient();
       for (const [index, execResult] of allResults.entries()) {
         const { sanitizedResult, attachments } = execResult.extracted;
         const followUpMsgs = await modelHandler.createToolUseFollowUpMessages(

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -241,14 +241,12 @@ export class ToolUseProcessNode<C> extends BaseNode<
           ),
         );
         workspace.assembly.lastResponse = execRes.text;
-        // The round's own MODEL_RESPONSE stream (below, in `exec()`) writes
-        // raw provider chunks in real time, before replacement rules run —
-        // so its persisted transcript text can trivially differ from this
-        // authoritative post-replacement value (#7086). Reconcile the two
-        // here, once, at the turn boundary that both a mid-run WAITING pause
-        // and the terminal round go through. Non-streaming responses already
-        // log their own (formatted) MODEL_RESPONSE line directly in `exec()`,
-        // so this only fires for the streamed case it now finalizes.
+        // A streamed MODEL_RESPONSE writes raw provider chunks in real time,
+        // before replacement rules run, so its persisted transcript text can
+        // differ from this authoritative post-replacement value (#7086).
+        // Reconcile the two once, at the turn boundary both a mid-run WAITING
+        // pause and the terminal round pass through. Non-streaming responses
+        // log their own formatted MODEL_RESPONSE line in `exec()`.
         if (execRes.useStreaming) {
           logger.responseFinalized(execRes.text);
         }

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -113,18 +113,15 @@ export class ResponseCycleNode<C = unknown> extends Node<
           lastError: cycleShared.lastError,
         };
       }
-      // A round is `cancelled` only when the run was genuinely interrupted —
-      // sourced from the authoritative interrupt signal, the same one
-      // `RoundPersistedFlow` already uses for its run-outcome, round-loop, and
+      // A round is `cancelled` only when the run was genuinely interrupted,
+      // read from the authoritative interrupt signal — the same one
+      // `RoundPersistedFlow` uses for its run-outcome, round-loop, and
       // step-loop decisions (resolveOutcome / shouldContinueNextRound /
-      // executeRoundSteps). The previous `shouldStop && !endTurn` proxy
-      // conflated three distinct cases — genuine interrupt, empty response, and
-      // a completed response whose stop reason wasn't recognized as end-of-turn
-      // — so any non-interrupt stop without `endTurn` discarded an
-      // already-written round (e.g. a token/continuation-limit stop carrying
-      // real output, or any provider whose terminal reason isn't yet mapped to
-      // the canonical end-turn vocabulary). The `!endTurn` guard preserves a
-      // cleanly-finished round even if an interrupt races in at completion.
+      // executeRoundSteps). Any other stop (empty response, a stop reason not
+      // recognized as end-of-turn, a token/continuation limit carrying real
+      // output) keeps the round it already wrote. The `!endTurn` guard
+      // preserves a cleanly-finished round even if an interrupt races in at
+      // completion.
       if (this.services.runScope.signal.aborted && !cycleShared.endTurn) {
         return { outcome: 'cancelled' };
       }

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -187,16 +187,15 @@ export async function runReflectionFlow<C = unknown>(
   const kv = getExecutionStore(executionId);
 
   const flowRecord = await readPersistedFlowRecord(kv, executionId);
-  // Boundary hydration: the one place a freshly-read persisted record
-  // (possibly written by an older build, hence the legacy todos/plan
-  // fallback in AgentWorkspaceStateSnapshotSchema) is parsed. Downstream,
-  // `RoundPersistedFlow`'s own per-step revalidation uses
-  // ReflectionFlowStateCanonicalSchema instead — see its constructor call
-  // below — since by then `shared` is always this run's own canonical
-  // toSnapshot() output, never a legacy shape.
-  const isResume = flowRecord !== null;
 
   if (flowRecord) {
+    // Boundary hydration: the one place a freshly-read persisted record
+    // (possibly written by an older build, hence the legacy todos/plan
+    // fallback in AgentWorkspaceStateSnapshotSchema) is parsed. Downstream,
+    // `RoundPersistedFlow`'s own per-step revalidation uses
+    // ReflectionFlowStateCanonicalSchema instead — see its constructor call
+    // below — since by then `shared` is always this run's own canonical
+    // toSnapshot() output, never a legacy shape.
     const validated = ReflectionFlowStateSchema.safeParse(flowRecord.shared);
     if (!validated.success) {
       throw new PersistedFlowStateError(executionId, 'invalid-shared', {
@@ -313,7 +312,7 @@ export async function runReflectionFlow<C = unknown>(
   };
   pf.setServices(services);
 
-  if (isResume) {
+  if (flowRecord) {
     logger.debug('Resuming reflection flow from persistence');
     await seedResumedConversationSidecar(
       runSession.transcripts,

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -460,8 +460,8 @@ export async function runToolUseFlow<C = unknown>(
     // queue clear instead of the resume-startup rescue above.
     inResumeStartupWindow = false;
 
+    if (flowRecord) logger.debug('Resuming tool-use flow from persistence');
     if (flowRecord && input.resume) {
-      logger.debug('Resuming tool-use flow from persistence');
       // Retrieval owns the single migration/validation boundary. The second
       // read may be self-healed only when it still matches the exact value
       // retrieval observed; any intervening drift must fail loudly instead of
@@ -484,7 +484,6 @@ export async function runToolUseFlow<C = unknown>(
         );
       }
     } else if (flowRecord) {
-      logger.debug('Resuming tool-use flow from persistence');
       const migrationResult = migrateSharedState(flowRecord.shared);
       if (!migrationResult.success) {
         throw new PersistedFlowStateError(executionId, 'invalid-shared', {

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -502,8 +502,7 @@ function toResolvedAgent(entry: AgentEntry): ResolvedAgent {
   };
   // Carry the inline definition in the resolution so the load path doesn't
   // re-lookup mutable global state — a re-registration between resolution
-  // and load could otherwise pair a stale entry with a replaced definition
-  // (Fix #9).
+  // and load could otherwise pair a stale entry with a replaced definition.
   if (entry.source === 'inline') {
     resolved.inlineDefinition = inlineAgentDefinition(entry.name);
   }

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -191,9 +191,6 @@ function scanYaml(
   definitions: Map<string, ParsedAgentYaml>,
 ): AgentEntry | null {
   try {
-    const validated = entry.definition;
-
-    // Extract lightweight metadata
     const settingsBlock = inheritedDefinitionBlock(
       entry,
       definitions,
@@ -211,7 +208,6 @@ function scanYaml(
 
     const tools = extractToolNames(rawSettings.tools as unknown[] | undefined);
 
-    // Determine category from source or explicit setting
     const rawCategory = rawSettings.agentCategory as string | undefined;
     const category =
       source === 'builtInToolUse' || rawCategory === AgentCategory.ToolUse
@@ -240,7 +236,7 @@ function scanYaml(
       source,
       path: entry.path,
       category,
-      description: validated.description,
+      description: entry.definition.description,
       tools: tools?.length ? tools : undefined,
       defaultOutputFiles: defaultOutputFiles?.length
         ? defaultOutputFiles

--- a/src/agent/index/inlineAgents.ts
+++ b/src/agent/index/inlineAgents.ts
@@ -60,7 +60,7 @@ export function defineInlineAgents(
   definitions: readonly unknown[],
 ): AgentEntry[] {
   // Validate every definition first — the module-level map must never contain
-  // orphaned entries from a partially-failed batch (Fix #2/#4).
+  // orphaned entries from a partially-failed batch.
   const validated = definitions.map((definition) =>
     normalizeInlineAgent(definition),
   );
@@ -75,7 +75,7 @@ export function defineInlineAgents(
  *
  * Each is a fresh copy: a published entry is reachable through `getAgent`, and
  * a consumer that mutates its `tools`/`defaultOutputFiles` array must not
- * corrupt the stored definition those arrays came from (Fix #1/#8).
+ * corrupt the stored definition those arrays came from.
  */
 export function inlineAgentEntries(): AgentEntry[] {
   return [...inlineAgents.values()].map((inline) =>
@@ -85,7 +85,7 @@ export function inlineAgentEntries(): AgentEntry[] {
 
 /**
  * Remove every registered inline definition so a host or test lifecycle can
- * start from a clean slate (Fix #5).
+ * start from a clean slate.
  */
 export function clearInlineAgentDefinitions(): void {
   inlineAgents.clear();
@@ -149,7 +149,7 @@ function normalizeInlineAgent(definition: unknown): InlineAgent {
   const defaultOutputFiles = settings.defaultOutputFiles;
 
   // Validate prompts against their finalized schema at registration time
-  // so an embedder discovers invalid prompts immediately (Fix #6).
+  // so an embedder discovers invalid prompts immediately.
   try {
     AgentPromptSchema.parse(parsed.prompts);
   } catch (error) {

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -947,10 +947,9 @@ export abstract class ModelHandler<
       return null;
     }
 
-    // NONE is a deliberate user choice ("minimize reasoning"), not "no preference".
-    // Providers map it to their minimum effort level (e.g. Anthropic → 'low').
-    // Returning null here would silently fall back to high/default effort.
-
+    // NONE stays a value, not a null: it is a deliberate user choice
+    // ("minimize reasoning") that providers map to their minimum effort level
+    // (e.g. Anthropic → 'low'), while null would fall back to default effort.
     return this.shouldUseServerSideKeys()
       ? includedModelAccess().capReasoningEffort(
           this.config.name,

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -215,13 +215,8 @@ function collectFileReferenceCounts(
 }
 
 /**
- * Build a text content block.
- *
- * Nine sites used to hand-roll this literal with an `as ContentBlockParam`
- * cast. The cast was never needed — `citations` and `cache_control` are both
- * optional on `TextBlockParam` — it only suppressed the union inference that
- * an explicit return type resolves. Naming the constructor keeps the shape in
- * one place and keeps the unchecked cast out of the file.
+ * Build a text content block. The explicit return type resolves the union
+ * inference, so no call site needs an `as ContentBlockParam` cast.
  */
 function textBlock(text: string): ContentBlockParam {
   return { type: 'text', text };
@@ -1108,8 +1103,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     );
     return mediaMessage.flatMap((media): ContentBlockParam[] => {
       if (media.media_category === 'image') {
-        // for backward compatibility
-        // Always ensure media_type exists
+        // Always ensure media_type exists.
         const originalMediaType = media.media_type;
         let resolvedMediaType = originalMediaType;
         if (!resolvedMediaType) {
@@ -1524,7 +1518,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         workspaceState.resetServerToolContent();
       }
       if (text) {
-        content.push({ type: 'text', text });
+        content.push(textBlock(text));
       }
     }
 

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -46,10 +46,10 @@ interface ResolveGoogleClientParams {
  * Resolve a `GoogleGenAI` client, refreshing on every call for server-side relay
  * keys (auth tokens expire ~30 mins) and caching for non-expiring personal keys.
  *
- * SDK-level retries are disabled (`retryOptions: { attempts: 1 }`) so that only
- * the flow-level retry loop (`RetryState.getNodeRetryConfig`) governs the user's
- * retry budget — otherwise transient errors would be retried by both the SDK and
- * the flow, multiplying the configured attempt count.
+ * The client is built without `retryOptions` so that only the flow-level retry
+ * loop (`RetryState.getNodeRetryConfig`) governs the user's retry budget; see
+ * the note in `createClient` for why passing any value there is worse than
+ * passing none.
  */
 export async function resolveGoogleClient(
   params: ResolveGoogleClientParams,

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -47,7 +47,8 @@ interface ResolveGoogleClientParams {
  * keys (auth tokens expire ~30 mins) and caching for non-expiring personal keys.
  *
  * The client is built without `retryOptions` so that only the flow-level retry
- * loop (`RetryState.getNodeRetryConfig`) governs the user's retry budget; see
+ * loop (`RetryState`'s `getNodeMaxRetries`/`RETRY_BACKOFF_MS`) governs the
+ * user's retry budget; see
  * the note in `createClient` for why passing any value there is worse than
  * passing none.
  */

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1512,8 +1512,9 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
 
     // Capture the chain anchor from the COMPLETED polled interaction (NOT the
     // submit), so the next turn chains onto a server-retained, completed id.
-    // Stateless mode invalidated the chain at entry and must not establish one.
-    if (stateful) this.finalizeChain(completed, totalStepCount, true);
+    // Stateless mode invalidated the chain at entry and must not establish one,
+    // which `finalizeChain` enforces from its own `stateful` guard.
+    this.finalizeChain(completed, totalStepCount, stateful);
     return { response: completed };
   }
 

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -1,5 +1,3 @@
-// Third-party imports
-
 // Local imports - agent
 import type { AgentSetting } from '@agent/core/definition/AgentDataclass';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
@@ -23,6 +21,8 @@ import type {
 
 // Local imports - model handlers
 import { ModelHandler } from './ModelHandler';
+
+// Third-party imports
 import type { ModelConfig } from 'llm-zoo';
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import type { CompletionUsage } from 'openai/resources/completions';

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -181,11 +181,10 @@ export class OutputFileProcessor {
     const singleFile =
       processed.length === 1 ? processed[0].location.absolutePath : null;
 
-    // `documents` used to hold the same text again, re-wrapped in its XML
-    // tags — pure duplication of `tagContents[OUTPUT_DOCUMENTS_TAG]` with
-    // nothing reading either the tag-wrapped or bare form downstream. Every
-    // full-text round summary was cloned per node step (see persistedFlow.ts),
-    // so the duplicate copy cost grew with every round of every run.
+    // `documents` stays empty: the extracted text lives once in
+    // `tagContents[OUTPUT_DOCUMENTS_TAG]`, and nothing downstream reads a
+    // second, tag-wrapped copy. Round summaries are cloned per node step (see
+    // persistedFlow.ts), so a duplicate full text would cost per round per run.
     const buildSummary = (
       tagContents: Record<string, string[]> = {},
     ): OutputXmlSummary => ({

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -224,11 +224,11 @@ async function inferLaunchModelHandlerCompatibilityKey(
  * what keeps a subagent's "Run:"/Init/r0/r1 subtree from orphaning in its own
  * transcript. See docs/proposals/2026-05-30-progress-grouping-refactor.md (R1).
  */
-async function beginRunStage(
+function beginRunStage(
   agentLogger: AgentTrace,
   label: string,
   instruction: string | undefined,
-): Promise<StageHandle> {
+): StageHandle {
   if (instruction) {
     logUserMessage(agentLogger, instruction);
   }
@@ -359,7 +359,7 @@ async function assembleAgentLaunchContext(
       : modelHandler.capabilities.supportsVision);
 
   const parentStage = resources.ownParentStage(
-    await beginRunStage(
+    beginRunStage(
       agentLogger,
       `Run: ${config.agent}`,
       initialMediaMayBeInserted ? undefined : initialInstruction,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -280,6 +280,10 @@ export async function finalizeRunTerminal(
   return { event, terminalStatusPersisted };
 }
 
+/** Failures finalizeFailedRun already logged, published, and wrapped; the
+ *  outer catch rethrows these untouched instead of finalizing them again. */
+const finalizedRunFailures = new WeakSet<Error>();
+
 /**
  * Recover a run's carried failure as an `Error`, so the one failure path below
  * classifies and logs a reported failure exactly as it does an exception that
@@ -290,10 +294,6 @@ export async function finalizeRunTerminal(
  * `undefined` when it was, keeping `normalizeProviderError` from reading a
  * wrong relay verdict off the retry-state shape.
  */
-/** Failures finalizeFailedRun already logged, published, and wrapped; the
- *  outer catch rethrows these untouched instead of finalizing them again. */
-const finalizedRunFailures = new WeakSet<Error>();
-
 function toFlowFailureError(error: RetryErrorInfo): Error {
   const failure = new Error(error.message);
   attachProviderError(failure, error);
@@ -314,10 +314,15 @@ function transitionRunStart(ctx: AgentLaunchContext): void {
     streamStatus.transition(
       streamId,
       STREAM_PHASE.RUNNING,
-      'lifecycle',
+      STREAM_TRANSITION_CAUSE.LIFECYCLE,
       options,
     ) ||
-    streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', options);
+    streamStatus.transition(
+      streamId,
+      STREAM_PHASE.RUNNING,
+      STREAM_TRANSITION_CAUSE.RESUME,
+      options,
+    );
   if (transitioned || streamStatus.get(streamId) === STREAM_PHASE.RUNNING) {
     return;
   }
@@ -375,13 +380,13 @@ function transitionStopBeforeRunStart(ctx: AgentLaunchContext): void {
     streamStatus.transition(
       streamId,
       STREAM_PHASE.RUNNING,
-      'resume',
+      STREAM_TRANSITION_CAUSE.RESUME,
       options,
     ) &&
     streamStatus.transition(
       streamId,
       STREAM_PHASE.CANCELLED,
-      'user-stop',
+      STREAM_TRANSITION_CAUSE.USER_STOP,
       options,
     );
   if (recorded) return;

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -1,8 +1,9 @@
 /**
  * Polymorphic execution handles.
  *
- * Replaces data-oriented maps with handles that know how to report status and
- * describe themselves. Termination policy lives with the owning registry.
+ * A handle owns one run's identity, its live control surfaces (interrupt,
+ * tool-use flow, execution lease), and its exactly-once terminal settlement.
+ * Termination policy lives with the owning registry.
  */
 
 import pDefer from 'p-defer';

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -1,14 +1,13 @@
 /**
  * `SessionHandle` — one owner per session for the runtime's coordination state.
  *
- * SDK Step 7d composition root. It is a **composition record**, not a facade:
- * it re-exposes no per-concern methods, so callers keep the existing instance
- * vocabulary they already use after 7a–c landed (`session.interactions.x(...)`,
- * `session.executions.y(...)`). Its sole lifecycle gate,
- * {@link SessionHandle.waitUntilReady}, ensures persistent restart repair has
- * settled before a host exposes the session. It composes the landed runtime owners —
+ * It is a **composition record**, not a facade: it re-exposes no per-concern
+ * methods, so callers address each owner directly
+ * (`session.interactions.x(...)`, `session.executions.y(...)`). Its sole
+ * lifecycle gate, {@link SessionHandle.waitUntilReady}, ensures persistent
+ * restart repair has settled before a host exposes the session. It composes
  * {@link ExecutionRegistry}, {@link ExecutionSubscriptionBinder},
- * {@link SessionHostInteractions} — plus the other session-scoped owners.
+ * {@link SessionHostInteractions}, and the other session-scoped owners.
  *
  * A session is one per host context: extension activation (per VS Code window),
  * CLI process, or desktop Electron process. The default instance is installed
@@ -882,8 +881,8 @@ export function teardownDefaultSession(): void {
  * The process-default session — the sole owner of the process-wide runtime
  * singletons (#7694). Every member the constructor doesn't receive is
  * fresh-built in the same FORCED dependency order any other `SessionHandle`
- * uses; there is no separate `Shared*`/`*Service` module export to alias
- * anymore, so this construction *is* where those singletons now live.
+ * uses, and this construction is the only place those singletons live: no
+ * module-level `Shared*`/`*Service` export aliases them.
  *
  * Hosts must initialize it explicitly after opening transcript persistence.
  * Access before that composition step is a lifecycle error rather than an

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -1,11 +1,11 @@
 // One driver for every child-run type (agent-CLI codex/claude sessions, native
 // subagents of either category, workflow-script runs). Each turn source
-// supplies an AgentCliSessionStrategy-shaped ChildRunStrategy; this loop owns
-// the parts
-// that were previously duplicated per driver: follow-up queue acquire/drain,
-// one run-handle interrupt target for the child's whole lifetime, per-turn
-// delivery choreography (format → persist report → optional manifest → deliver
-// with wake), and the terminal call into the shared finalizer.
+// supplies an AgentCliSessionStrategy-shaped ChildRunStrategy; this loop is the
+// single owner of everything a driver does NOT vary: follow-up queue
+// acquire/drain, one run-handle interrupt target for the child's whole
+// lifetime, per-turn delivery choreography (format → persist report → optional
+// manifest → deliver with wake), and the terminal call into the shared
+// finalizer.
 //
 // Host-agnostic, VS Code-free.
 

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -101,11 +101,10 @@ export type ManualCompactionRequestResult =
     };
 
 /**
- * Process-wide owner for active executions and their change listeners.
+ * Session-owned registry of active executions and their change listeners.
  *
- * This is still a singleton while AgentRun ownership is being introduced, but
- * the mutable maps and status subscription now live behind one explicit owner
- * instead of free module state.
+ * One instance belongs to each {@link SessionHandle}, which binds it to that
+ * session's event hub, approvals, and lease-release boundary.
  */
 export class ExecutionRegistry {
   /**

--- a/src/agent/runtime/restartRepair.ts
+++ b/src/agent/runtime/restartRepair.ts
@@ -202,56 +202,43 @@ function repairToWaiting(
   return false;
 }
 
-async function writeFailedTerminalStatuses(
-  streamIds: readonly StreamTabId[],
-  executionIds: ReadonlyMap<StreamTabId, ExecutionId>,
+/**
+ * Persist the FAILED terminal status for a repaired stream's execution,
+ * reporting whether that status reached disk. Finalization problems are logged
+ * rather than thrown: the in-memory repair has already committed.
+ */
+async function writeFailedTerminalStatus(
+  streamId: StreamTabId,
+  executionId: ExecutionId,
   finalizeExecution: (
     input: FinalizeExecutionInput,
   ) => Promise<FinalizeExecutionResult>,
   logger: RestartRepairLogger | undefined,
-): Promise<ExecutionId[]> {
-  const status = projectRunOutcome(RUN_OUTCOME.FAILED).executionStatus;
-  const writes = streamIds.flatMap((streamId) => {
-    const executionId = executionIds.get(streamId);
-    return executionId ? [{ streamId, executionId }] : [];
-  });
-  const results = await Promise.allSettled(
-    writes.map(({ executionId }) =>
-      finalizeExecution({
-        executionId,
-        terminalStatus: status,
-        flowRecord: 'delete',
-      }),
-    ),
-  );
-
-  const updated: ExecutionId[] = [];
-  for (const [index, result] of results.entries()) {
-    const { streamId, executionId } = writes[index];
-    if (result.status === 'fulfilled') {
-      const finalization = result.value;
-      if (finalization.status === 'failed') {
-        logger?.warn('Failed to finalize restart-repair execution', {
-          data: {
-            streamId,
-            executionId,
-            stage: finalization.stage,
-            terminalStatusPersisted: finalization.terminalStatusPersisted,
-            error: finalization.error,
-          },
-        });
-      }
-      if (finalization.terminalStatusPersisted) {
-        updated.push(executionId);
-      }
-      continue;
-    }
-    logger?.warn('Restart-repair finalization rejected unexpectedly', {
-      data: { streamId, executionId, error: result.reason },
+): Promise<boolean> {
+  try {
+    const finalization = await finalizeExecution({
+      executionId,
+      terminalStatus: projectRunOutcome(RUN_OUTCOME.FAILED).executionStatus,
+      flowRecord: 'delete',
     });
+    if (finalization.status === 'failed') {
+      logger?.warn('Failed to finalize restart-repair execution', {
+        data: {
+          streamId,
+          executionId,
+          stage: finalization.stage,
+          terminalStatusPersisted: finalization.terminalStatusPersisted,
+          error: finalization.error,
+        },
+      });
+    }
+    return finalization.terminalStatusPersisted;
+  } catch (error) {
+    logger?.warn('Restart-repair finalization rejected unexpectedly', {
+      data: { streamId, executionId, error },
+    });
+    return false;
   }
-
-  return updated;
 }
 
 /**
@@ -444,14 +431,16 @@ async function repairRestartedStream(
         now,
       )
     : [];
-  const terminalStatusUpdated = await writeFailedTerminalStatuses(
-    failedStreams,
-    executionId
-      ? new Map<StreamTabId, ExecutionId>([[streamId, executionId]])
-      : options.executionIds,
-    options.finalizeExecution ?? defaultFinalizeExecution,
-    options.logger,
-  );
+  const terminalStatusUpdated: ExecutionId[] = [];
+  if (failedStreams.length > 0 && executionId) {
+    const persisted = await writeFailedTerminalStatus(
+      streamId,
+      executionId,
+      options.finalizeExecution ?? defaultFinalizeExecution,
+      options.logger,
+    );
+    if (persisted) terminalStatusUpdated.push(executionId);
+  }
   return {
     waitingStreams,
     failedStreams,

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -90,10 +90,8 @@ export async function runAgent(
     registerExecutionOption ?? request.executionId === undefined;
   const runSession = executeAgentOptions.session ?? defaultSession();
 
-  // Only the "fix LaTeX" VS Code actions opt in (preferHelperModel); the agent
-  // then runs on the configured helper model. A direct main-view launch keeps the
-  // model the user picked. Resolved before registerExecution so the stored record
-  // and the run agree.
+  // Resolved before registerExecution so the stored record and the run agree
+  // on the model.
   const config = preferHelperModel
     ? await applyHelperModelPreference(request.config)
     : request.config;

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -2,8 +2,7 @@
  * Directory-scanning execution listing.
  *
  * Derives the list of executions by scanning the `executions/` directory
- * and reading per-execution KV data (meta.json, config.json). This replaces
- * the monolithic `index.json` maintained by AgentHistoryManager.
+ * and reading per-execution KV data (meta.json, config.json).
  *
  * A storage-boundary migration handles legacy history before the scan.
  */
@@ -15,7 +14,7 @@ import { isFileNotFoundError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import type { ExecutionId } from '@shared/schemas';
-import { StorageFS, WorkspaceFS } from '@utils/files';
+import { StorageFS } from '@utils/files';
 import { filterNotNull, toNewestFirstByTimestamp } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { isDirectory } from '@utils/files/fsEntryType';
@@ -119,7 +118,7 @@ function listExecutionDirs(entries: [string, number][]): ExecutionId[] {
  * cannot observe another host's writes or metadata updates reliably.
  */
 export async function listExecutions(): Promise<ExecutionListingEntry[]> {
-  await migrateLegacyExecutionHistoryOnce(WorkspaceFS.getPath());
+  await migrateLegacyExecutionHistoryOnce();
 
   const entries = await readDirOrEmpty(RUNS_STORAGE_DIR);
   const executionDirs = listExecutionDirs(entries);

--- a/src/agent/storage/legacyExecutionHistoryMigration.ts
+++ b/src/agent/storage/legacyExecutionHistoryMigration.ts
@@ -41,15 +41,14 @@ const LEGACY_BACKFILL_CONCURRENCY = 32;
 const migrationsByWorkspace = new Map<string | undefined, Promise<void>>();
 let migrationPlatform: Platform | undefined;
 
-export async function migrateLegacyExecutionHistoryOnce(
-  workspacePath: string | undefined,
-): Promise<void> {
+export async function migrateLegacyExecutionHistoryOnce(): Promise<void> {
   const currentPlatform = platform();
   if (currentPlatform !== migrationPlatform) {
     migrationPlatform = currentPlatform;
     migrationsByWorkspace.clear();
   }
 
+  const workspacePath = currentPlatform.workspace.getWorkspacePath();
   const inFlight = migrationsByWorkspace.get(workspacePath);
   if (inFlight) return inFlight;
 

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -123,7 +123,7 @@ export class SupabaseClient {
     this.config = { url, publicKey };
     this.instance = createClient(url, publicKey, {
       auth: {
-        persistSession: false, // VS Code manages session storage
+        persistSession: false, // The host's secret storage owns the session
         autoRefreshToken: false, // Manual refresh via auth provider
         // PKCE: browser OAuth returns a one-time ?code= (not tokens) to the
         // callback. The code_verifier stays in this client and is consumed by

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -269,5 +269,5 @@ export const AUTH_CALLBACK_TIMEOUT_MS = 10 * 60 * 1000;
 /** Refresh token proactively if it expires within this threshold (30 minutes). */
 export const TOKEN_REFRESH_THRESHOLD_MS = 30 * 60 * 1000;
 
-/** Storage key for Supabase session in VS Code SecretStorage. */
+/** Key the stored Supabase session takes in the host's secret storage. */
 export const SUPABASE_SESSION_KEY = 'texra.supabase.session';

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -47,7 +47,7 @@ type SendFollowUpMessage = ProgressViewMessage<
   typeof PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP
 >;
 
-export type ProgressViewFollowUpImage = NonNullable<
+type ProgressViewFollowUpImage = NonNullable<
   SendFollowUpMessage['images']
 >[number];
 
@@ -521,9 +521,9 @@ export function createProgressViewSecondTierHandlers(
       deps.postToRenderer({
         command: CMD.SET_FOLLOWUP_OPTIONS,
         stream: data.stream,
-        ...(toolUseAgentsData && { toolUseAgentsData }),
-        ...(modelOptionsData && { modelOptionsData }),
-      } as ProgressViewOutboundMessage);
+        ...(toolUseAgentsData && { toolUseAgentsData: [...toolUseAgentsData] }),
+        ...(modelOptionsData && { modelOptionsData: [...modelOptionsData] }),
+      });
     },
     [CMD.RUN_COMPILE_FIXER]: async (data) => {
       await deps.applyFollowUpPlan(

--- a/src/controllers/progressView/backend/WebviewUpdater.ts
+++ b/src/controllers/progressView/backend/WebviewUpdater.ts
@@ -217,7 +217,7 @@ export class WebviewUpdater {
     });
   }
 
-  updateTheme(theme: 'dark' | 'light'): void {
+  private updateTheme(theme: 'dark' | 'light'): void {
     this.sendMessage({
       command: PROGRESS_VIEW_COMMANDS.THEME_SET,
       theme,

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -213,11 +213,7 @@ export class ProgressFactApplier {
   handleSessionFact(fact: SessionFact): void {
     // Wrap once, and RETURN each case so async handlers' promises reach
     // `applyFact` (a discarded promise would let a post-await rejection escape
-    // `withEventErrorHandling`'s thenable check as an unhandled rejection). The
-    // switch is inlined here rather than in a single-caller helper, mirroring
-    // `handleRunFact`'s inline table lookup. `assertNever` stays inside the
-    // wrapper — an unreachable exhaustiveness guard that would only ever be
-    // logged, never thrown, and the union is closed so it never fires.
+    // `withEventErrorHandling`'s thenable check as an unhandled rejection).
     this.applyFact(`failed to handle ${fact.type} fact`, () => {
       switch (fact.type) {
         case 'goalStateChanged':
@@ -271,11 +267,11 @@ export class ProgressFactApplier {
     withEventErrorHandling('ProgressFacts', context, handle);
   }
 
-  public handleInquiryThreadUpdated(thread: InquiryThreadUpdatedEvent): void {
+  handleInquiryThreadUpdated(thread: InquiryThreadUpdatedEvent): void {
     this.webviewUpdater.updateInquiryThread(thread);
   }
 
-  public handleUpdateStreamDescription({
+  handleUpdateStreamDescription({
     streamId,
     description,
   }: UpdateStreamDescriptionPayload): void {
@@ -283,7 +279,7 @@ export class ProgressFactApplier {
     this.webviewUpdater.updateStreamDescription(streamId, description);
   }
 
-  public handleSetParentStream({
+  handleSetParentStream({
     childStreamId,
     parentStreamId,
   }: SetParentStreamPayload): void {
@@ -294,7 +290,7 @@ export class ProgressFactApplier {
     );
   }
 
-  public handleAddOutputFiles({ streamId }: AddOutputFilesPayload): void {
+  handleAddOutputFiles({ streamId }: AddOutputFilesPayload): void {
     this.sendIfActive(streamId, () => {
       const rounds = this.state.snapshots.getOutputFiles(streamId);
       this.webviewUpdater.updateFiles(streamId, {
@@ -303,9 +299,7 @@ export class ProgressFactApplier {
     });
   }
 
-  public handleUpdateMissingOutputs({
-    streamId,
-  }: UpdateMissingOutputsPayload): void {
+  handleUpdateMissingOutputs({ streamId }: UpdateMissingOutputsPayload): void {
     this.sendIfActive(streamId, () => {
       const rounds = this.state.snapshots.getMissingOutputs(streamId);
       this.webviewUpdater.updateMissingOutputs(streamId, {
@@ -314,7 +308,7 @@ export class ProgressFactApplier {
     });
   }
 
-  public handleUpdateCompileFailures({
+  handleUpdateCompileFailures({
     streamId,
   }: UpdateCompileFailuresPayload): void {
     this.sendIfActive(streamId, () => {
@@ -326,7 +320,7 @@ export class ProgressFactApplier {
     });
   }
 
-  public handleClearMissingOutputs(payload: ClearMissingOutputsPayload): void {
+  handleClearMissingOutputs(payload: ClearMissingOutputsPayload): void {
     const targets = this.state.snapshots.resolveMissingOutputTargets(payload);
     for (const streamId of targets) {
       this.sendIfActive(streamId, () =>
@@ -337,7 +331,7 @@ export class ProgressFactApplier {
     }
   }
 
-  public handleUpdateStreamUsage({
+  handleUpdateStreamUsage({
     streamId,
     storageKey,
   }: UpdateStreamUsagePayload): void {
@@ -350,17 +344,17 @@ export class ProgressFactApplier {
     );
   }
 
-  public handleUpdateTodos({ streamId, todos }: UpdateTodosPayload): void {
+  handleUpdateTodos({ streamId, todos }: UpdateTodosPayload): void {
     this.sendIfActive(streamId, () =>
       this.webviewUpdater.updateTodos(streamId, todos),
     );
   }
 
-  public handleUpdatePlan({ streamId, plan }: UpdatePlanPayload): void {
+  handleUpdatePlan({ streamId, plan }: UpdatePlanPayload): void {
     this.webviewUpdater.updatePlan(streamId, plan);
   }
 
-  public handleUpdateQueuedFollowUps({
+  handleUpdateQueuedFollowUps({
     streamId,
   }: UpdateQueuedFollowUpsPayload): void {
     this.sendIfActive(streamId, () => {
@@ -379,9 +373,7 @@ export class ProgressFactApplier {
     }
   }
 
-  public async handleSetActiveStream(
-    payload: SetActiveStreamPayload,
-  ): Promise<void> {
+  async handleSetActiveStream(payload: SetActiveStreamPayload): Promise<void> {
     const { streamId, isRemote } = payload;
     if (!streamId) {
       this.state.switchActiveStream('');
@@ -480,7 +472,7 @@ export class ProgressFactApplier {
     }
   }
 
-  public handleUpdateConversationProgress(
+  handleUpdateConversationProgress(
     data: UpdateConversationProgressPayload,
   ): void {
     const { streamId, progress } = data;
@@ -497,7 +489,7 @@ export class ProgressFactApplier {
     if (!this.progressDebounce.pending) this.progressDebounce.schedule();
   }
 
-  public handleUpdateRoundStage(data: UpdateRoundStagePayload): void {
+  handleUpdateRoundStage(data: UpdateRoundStagePayload): void {
     const { streamId, roundStage } = data;
     this.state.updateStreamState(streamId, (prev) => ({
       ...prev,
@@ -558,7 +550,7 @@ export class ProgressFactApplier {
    * or a retained child going live again) has no recorded phase to keep, so it
    * takes the one stamped at emission.
    */
-  public updateChildRoster(
+  updateChildRoster(
     parentStreamId: StreamTabId,
     next: StreamExecutionState['subagents'],
   ): void {
@@ -596,31 +588,27 @@ export class ProgressFactApplier {
     });
 
     const updated = this.state.getStreamState(parentStreamId);
-    if (
-      this.webviewUpdater.isAvailable() &&
-      parentStreamId === this.state.activeStream &&
-      updated
-    ) {
+    if (!updated) return;
+    this.sendIfActive(parentStreamId, () =>
       this.webviewUpdater.updateStreamBadges(parentStreamId, {
         subagents: updated.subagents,
-      });
-    }
+      }),
+    );
   }
 
   /**
    * Cancel every still-running stream because the app itself is going away.
    *
-   * Ruled a KEPT app-lifecycle fact, not a run-lifecycle write: the only
-   * caller is the extension's `extensionDeactivating` signal
+   * An app-lifecycle fact, not a run-lifecycle write: the only caller is the
+   * extension's `extensionDeactivating` signal
    * (`attachProgressBackendAppSignals`), which fires when no run can report its
-   * own outcome any more. It is not an owner of any run's terminal fact —
-   * `runFlowWithLifecycle` and `repairRestartedStreams` remain the only writers
-   * for runs that end on their own or are found stale after a restart. Because
-   * it goes through the same `StreamStatusMachine`, the transition table
-   * refuses anything a run already terminalized, so relocating it into the
-   * runtime buys nothing.
+   * own outcome any more. Runs that end on their own or are found stale after a
+   * restart are still terminalized by `runFlowWithLifecycle` and
+   * `repairRestartedStreams`, and this goes through the same
+   * `StreamStatusMachine`, whose transition table refuses anything a run
+   * already terminalized.
    */
-  public markAllRunningTasksAsCancelled(): void {
+  markAllRunningTasksAsCancelled(): void {
     for (const [stream, status] of this.state.streamStatus.entries()) {
       if (status === STREAM_PHASE.RUNNING) {
         this.state.streamStatus.transition(
@@ -633,7 +621,7 @@ export class ProgressFactApplier {
     }
   }
 
-  public syncStreamContent(
+  syncStreamContent(
     stream: ActiveStreamId,
     options: {
       /** Include conversation progress, badges, and parent stream in the batch. */
@@ -736,11 +724,11 @@ export class ProgressFactApplier {
 
     // Active phases keep the full log resident for runtime writes. Inactive,
     // unfocused streams release heavy entries and rehydrate on demand.
-    const requiresPersistentRehydrate =
-      this.state.streamLogs.mode.kind === 'persistent' &&
-      this.state.streamLogs.has(streamId) &&
-      !this.state.streamLogs.get(streamId);
     if (isActivePhase(status)) {
+      const requiresPersistentRehydrate =
+        this.state.streamLogs.mode.kind === 'persistent' &&
+        this.state.streamLogs.has(streamId) &&
+        !this.state.streamLogs.get(streamId);
       if (requiresPersistentRehydrate) {
         await this.state.streamLogs.ensureLoaded(streamId);
       }

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -35,7 +35,7 @@ import {
 } from '@shared/state/PersistedState';
 import { isProcessAgent } from '@shared/streams/agentKind';
 import { compareByNewestCreationTime } from '@shared/streams/streamOrdering';
-import { isActivePhase } from '@shared/streams/streamStatus';
+import { isActivePhase, isInFlightPhase } from '@shared/streams/streamStatus';
 import { releaseStreamResources } from '@tools/approval';
 import { GoalStore } from '@tools/goal';
 import type { StreamLogStore, StreamSnapshotStore } from '@transcript';
@@ -210,7 +210,7 @@ export class ProgressViewState {
   /**
    * Compute which stream should be active given available streams (pure query).
    */
-  pickValidActiveStream(availableStreams: StreamTabId[]): StreamTabId {
+  private pickValidActiveStream(availableStreams: StreamTabId[]): StreamTabId {
     const current = this._prefs.get('activeStream');
     if (availableStreams.includes(current)) {
       return current;
@@ -244,13 +244,21 @@ export class ProgressViewState {
 
   /**
    * Stream tabs offered for selection, newest first — the order
-   * `buildStreamInfos` renders. Membership and rotation only depend on
-   * creation time, so this answers them without building tab infos or
-   * touching the worktree resolver.
+   * `buildStreamInfos` renders. Process streams are transient views of live
+   * commands, so terminal and restored process transcripts are not sessions
+   * in the navigation list. Their execution artifacts remain available
+   * through the parent run.
    */
   selectableStreamNames(): StreamTabId[] {
     return this.streamLogs
       .keys()
+      .filter((name) => {
+        const metadata = this.getStreamMetadata(name);
+        return (
+          metadata.run?.kind !== 'process' ||
+          isInFlightPhase(this.streamStatus.get(name))
+        );
+      })
       .map((name) => ({
         name,
         creationTimestamp: this.getStreamMetadata(name).creationTimestamp,
@@ -295,8 +303,7 @@ export class ProgressViewState {
    * through here rather than assigning fields by hand. A field the patch
    * doesn't mention is preserved verbatim from `current` — callers that want
    * to clear a field (e.g. detaching a parent) do so by including that key
-   * in the patch with an explicit `undefined`, same as before this was
-   * centralized.
+   * in the patch with an explicit `undefined`.
    */
   private applyMetadataPatch(
     current: StoredStreamMetadata,
@@ -721,22 +728,16 @@ export class ProgressViewState {
     return restoredCount;
   }
 
-  /**
-   * The topmost (newest) visible stream tab, or '' when none exist.
-   *
-   * `streamLogs.keys()` is ascending by creation time (load() sorts by
-   * `firstTimestamp` ASC, session additions are appended), but the sidebar
-   * renders newest-first, so `.at(-1)` matches the topmost visible tab rather
-   * than the oldest one at the bottom.
-   */
+  /** The topmost (newest) selectable stream tab, or '' when none exist. */
   private topmostStreamTab(): ActiveStreamId {
-    return this.streamLogs.keys().at(-1) ?? '';
+    return this.selectableStreamNames().at(0) ?? '';
   }
 
   /** Validate activeStream against available streams after load */
   private validateActiveStream(): void {
     const savedActiveStream = this._prefs.get('activeStream');
-    if (!savedActiveStream || !this.streamLogs.has(savedActiveStream)) {
+    const selectableStreams = this.selectableStreamNames();
+    if (!savedActiveStream || !selectableStreams.includes(savedActiveStream)) {
       const fallback = this.topmostStreamTab();
       if (fallback !== savedActiveStream) {
         this._prefs.update({ activeStream: fallback });

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -35,7 +35,7 @@ import {
 } from '@shared/state/PersistedState';
 import { isProcessAgent } from '@shared/streams/agentKind';
 import { compareByNewestCreationTime } from '@shared/streams/streamOrdering';
-import { isActivePhase, isInFlightPhase } from '@shared/streams/streamStatus';
+import { isActivePhase } from '@shared/streams/streamStatus';
 import { releaseStreamResources } from '@tools/approval';
 import { GoalStore } from '@tools/goal';
 import type { StreamLogStore, StreamSnapshotStore } from '@transcript';
@@ -244,21 +244,13 @@ export class ProgressViewState {
 
   /**
    * Stream tabs offered for selection, newest first — the order
-   * `buildStreamInfos` renders. Process streams are transient views of live
-   * commands, so terminal and restored process transcripts are not sessions
-   * in the navigation list. Their execution artifacts remain available
-   * through the parent run.
+   * `buildStreamInfos` renders. Membership and rotation only depend on
+   * creation time, so this answers them without building tab infos or
+   * touching the worktree resolver.
    */
   selectableStreamNames(): StreamTabId[] {
     return this.streamLogs
       .keys()
-      .filter((name) => {
-        const metadata = this.getStreamMetadata(name);
-        return (
-          metadata.run?.kind !== 'process' ||
-          isInFlightPhase(this.streamStatus.get(name))
-        );
-      })
       .map((name) => ({
         name,
         creationTimestamp: this.getStreamMetadata(name).creationTimestamp,
@@ -728,16 +720,22 @@ export class ProgressViewState {
     return restoredCount;
   }
 
-  /** The topmost (newest) selectable stream tab, or '' when none exist. */
+  /**
+   * The topmost (newest) visible stream tab, or '' when none exist.
+   *
+   * `streamLogs.keys()` is ascending by creation time (load() sorts by
+   * `firstTimestamp` ASC, session additions are appended), but the sidebar
+   * renders newest-first, so `.at(-1)` matches the topmost visible tab rather
+   * than the oldest one at the bottom.
+   */
   private topmostStreamTab(): ActiveStreamId {
-    return this.selectableStreamNames().at(0) ?? '';
+    return this.streamLogs.keys().at(-1) ?? '';
   }
 
   /** Validate activeStream against available streams after load */
   private validateActiveStream(): void {
     const savedActiveStream = this._prefs.get('activeStream');
-    const selectableStreams = this.selectableStreamNames();
-    if (!savedActiveStream || !selectableStreams.includes(savedActiveStream)) {
+    if (!savedActiveStream || !this.streamLogs.has(savedActiveStream)) {
       const fallback = this.topmostStreamTab();
       if (fallback !== savedActiveStream) {
         this._prefs.update({ activeStream: fallback });

--- a/src/controllers/progressView/backend/streamInfoUtils.ts
+++ b/src/controllers/progressView/backend/streamInfoUtils.ts
@@ -9,7 +9,7 @@ export type StreamInfoSource = Pick<ProgressViewState, 'getStreamMetadata'>;
 
 /** The state the full tab list is built from. */
 export type StreamInfoListSource = StreamInfoSource &
-  Pick<ProgressViewState, 'streamLogs'>;
+  Pick<ProgressViewState, 'selectableStreamNames'>;
 
 /** Build a StreamTabInfo object for a single stream ID. */
 export function buildStreamInfo(
@@ -37,8 +37,8 @@ export function buildStreamInfo(
 
 /** Build metadata objects for all streams in the given state, newest first. */
 export function buildStreamInfos(state: StreamInfoListSource): StreamTabInfo[] {
-  return state.streamLogs
-    .keys()
+  return state
+    .selectableStreamNames()
     .map((id) => buildStreamInfo(state, id))
     .sort(compareByNewestCreationTime);
 }

--- a/src/controllers/settingsView/SettingsProfileController.ts
+++ b/src/controllers/settingsView/SettingsProfileController.ts
@@ -105,7 +105,7 @@ export class SettingsProfileController {
 
   getReliabilitySettings(): NumberVscodeSetting[] {
     return SETTINGS_RELIABILITY_SETTINGS.map((definition) => {
-      const { defaultValue, schema: _schema, ...setting } = definition;
+      const { defaultValue, schema, ...setting } = definition;
       const configuredValue = this.deps.getConfig<number>(
         setting.key,
         defaultValue,
@@ -113,8 +113,7 @@ export class SettingsProfileController {
       return {
         ...setting,
         value:
-          definition.schema &&
-          !definition.schema.safeParse(configuredValue).success
+          schema && !schema.safeParse(configuredValue).success
             ? defaultValue
             : configuredValue,
       };

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -41,12 +41,6 @@ const USEPACKAGE_PATTERN =
 const LATEX_CONCURRENCY = 4;
 
 /**
- * Flexible input type that accepts either a string path or FileLocation.
- * Provides API consistency while maintaining caller convenience.
- */
-type PathInput = string | FileLocation;
-
-/**
  * The slice of agent workspace state this manager writes media results into.
  * Structurally satisfied by `AgentWorkspaceState`; declared here so LaTeX
  * processing stays independent of agent execution internals.
@@ -518,7 +512,7 @@ export class LatexMediaManager {
        * Both modes are additionally gated by `cfg.autoExtractFigure`.
        */
       figureMode: 'extract' | 'mirror';
-      extraMediaFiles?: PathInput[];
+      extraMediaFiles?: readonly FileLocation[];
       logTikzSummary?: boolean;
     },
   ): Promise<void> {
@@ -543,10 +537,7 @@ export class LatexMediaManager {
     }
 
     if (extraMediaFiles.length > 0) {
-      const fileLocations = extraMediaFiles.map((input) =>
-        typeof input === 'string' ? pathToLocation(input) : input,
-      );
-      workspaceState.media.addMediaFiles(fileLocations);
+      workspaceState.media.addMediaFiles(extraMediaFiles);
     }
 
     if (cfg.autoExtractFigure) {
@@ -576,16 +567,15 @@ export class LatexMediaManager {
    * Process input files to extract figures, compile TikZ pictures and PDFs.
    * Adds resulting media paths through the provided media workspace state.
    *
-   * @param extraMediaFiles - Additional media files to include.
-   *   Accepts both string paths and FileLocation objects for API flexibility.
-   *   Typically user-provided paths from agent config (mediaFile, mediaFiles).
+   * @param extraMediaFiles - Additional media files to include, typically the
+   *   user-provided `mediaFiles` from the agent config.
    */
   async processInputFiles(
     inputFiles: FileLocation[],
     workspaceState: MediaWorkspaceState,
     cfg: ToolConfig,
     supportsVision: boolean,
-    extraMediaFiles: PathInput[] = [],
+    extraMediaFiles: readonly FileLocation[] = [],
   ): Promise<void> {
     await this.processFiles(inputFiles, workspaceState, cfg, supportsVision, {
       figureMode: 'extract',

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -209,12 +209,10 @@ type UnavailableAvailabilityKind = {
     : K;
 }[ModelAvailabilityKind];
 
-/** Everything an unavailable-reason builder needs to reconstruct the exact
- *  wording `getModelUnavailableReason` used to hand-roll per branch. */
+/** Everything an unavailable-reason builder needs to word its message. */
 interface UnavailableReasonContext {
   readonly model: string;
   readonly config: ModelConfig;
-  readonly ctx: ModelAvailabilityContext;
   readonly reason: UnavailableReason | undefined;
 }
 
@@ -232,7 +230,7 @@ const UNAVAILABLE_REASON_BUILDERS: Record<
     `Model "${model}" is retired and no longer available from its provider. Choose an active model.`,
   'provider-unavailable': ({ model }) =>
     `Model "${model}" requires a provider request mode that OpenRouter does not support. Disable OpenRouter and use the provider API directly.`,
-  'missing-key': ({ model, config, ctx, reason }) => {
+  'missing-key': ({ model, config, reason }) => {
     if (reason === 'openrouter-missing-key') {
       return `Model "${model}" requires an OpenRouter API key.`;
     }
@@ -575,7 +573,6 @@ export async function getModelUnavailableReason(
   return UNAVAILABLE_REASON_BUILDERS[kind]({
     model,
     config,
-    ctx,
     reason: availability.reason,
   });
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1,7 +1,4 @@
-/**
- * Webview IPC command-name constants, grouped per view.
- * Formerly one file per view under `ipc/`.
- */
+/** Webview IPC command-name constants, grouped per view. */
 
 export const COMMON_COMMANDS = {
   THEME_SET: 'setTheme',
@@ -135,7 +132,6 @@ export const MAIN_VIEW_COMMANDS = {
   PACK_MULTIPLE: 'packMultiple',
   CLEAN_MULTIPLE: 'cleanMultiple',
 
-  // Other operations
   ACCEPT_EDITED: 'acceptEdited',
 } as const;
 
@@ -268,8 +264,8 @@ export const MEMORY_VIEW_COMMANDS = {
 
 /**
  * Command string literals for settings view schema definitions.
- * Defined here (not in settingsViewMessages.ts) to avoid circular dependency:
- * commands.ts → settingsViewMessages.ts → memoryViewMessages.ts → commands.ts
+ * Defined here (not in settingsViewMessages.ts) to avoid the cycle
+ * `ipc.ts → settingsViewMessages.ts → memoryViewMessages.ts → ipc.ts`.
  *
  * Memory/History/Profile inbound commands reference their own view's
  * command map (the single source of truth for those literals) instead of

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -65,8 +65,10 @@ export type LatexdiffTempFileLocation =
 export type AgentReviewApproach = (typeof AGENT_REVIEW_APPROACHES)[number];
 
 /**
- * Contract for the historical `model.retry.maxAttempts` setting. The value is
- * the number of automatic retries after the initial model request.
+ * Bounds, default, and copy for `model.retry.maxAttempts`. The value is the
+ * number of automatic retries after the initial model request. Shared by
+ * {@link ModelRetryMaxAttemptsSchema} and the settings-view reliability row so
+ * the schema and the UI cannot disagree about the range.
  */
 export const MODEL_RETRY_MAX_ATTEMPTS_SETTING = {
   defaultValue: 2,
@@ -610,22 +612,21 @@ const CoreSettingsSchema = z
 
 export type CoreSettings = z.infer<typeof CoreSettingsSchema>;
 
+/** True for an index-signature record, false for a fixed-key settings group. */
+type IsRecord<T> = string extends keyof T ? true : false;
+
 /**
  * Dotted leaf paths of the settings tree, enumerated at the type level.
  *
  * Drives the compile-time guards below so {@link CORE_SETTING_PATHS} stays in
  * lockstep with {@link CoreSettingsShape}: a record/array/primitive field is a
  * leaf, a nested settings group is recursed into.
- */
-type IsRecord<T> = string extends keyof T ? true : false;
-
-/**
+ *
  * `NonNullable` is applied before the `extends object` test so that an optional
  * group added without a default (`Group | undefined`) still recurses into its
  * leaves instead of silently collapsing to a single key. The guard therefore
  * stays sound whether a nested group is declared with `.prefault()` (every group
- * today) or `.optional()`. Arrays and records resolve to leaves; nested settings
- * groups recurse.
+ * today) or `.optional()`.
  */
 type LeafPaths<T> = {
   [K in keyof T & string]: NonNullable<T[K]> extends readonly unknown[]
@@ -647,10 +648,9 @@ type AssertNever<T extends never> = T;
  * lists for typo detection without hand-maintaining the list in each host.
  *
  * Kept in sync with the schema by the two compile-time guards just below: the
- * `satisfies` clause rejects a typo'd or renamed path, and `_AssertCorePathsExhaustive`
- * fails the build if a setting is added to the schema without a matching entry
- * here. Previously both failure modes were silent (the list compiled fine while
- * host typo-detection quietly broke).
+ * `satisfies` clause rejects a typo'd or renamed path, and
+ * `_AssertCorePathsExhaustive` fails the build if a setting is added to the
+ * schema without a matching entry here.
  */
 export const CORE_SETTING_PATHS = [
   'agentOutputs.autoOpenFinal',

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -24,10 +24,10 @@ const StreamDiagnosticsSchema = z.object({
 export type StreamDiagnostics = z.infer<typeof StreamDiagnosticsSchema>;
 
 /** Reason a credential/quota is exhausted, requiring user action before an
- *  identical retry can succeed. The reasons are mutually
- *  exclusive — a single error is classified as exactly one — which is why
- *  this is a discriminant rather than independent booleans (see
- *  `isCredentialExhausted` below for the pre-refactor combined check). */
+ *  identical retry can succeed. The reasons are mutually exclusive — a single
+ *  error is classified as exactly one — which is why this is a discriminant
+ *  rather than independent booleans. `isCredentialExhausted` below answers the
+ *  combined "exhausted for any reason" question. */
 export const ExhaustionReasonSchema = z.enum([
   /** Relay monthly spending limit reached; the stored personal key is fine. */
   'relay-limit',
@@ -125,7 +125,7 @@ const ProviderErrorObjectSchema = z.object({
    *  provider credit depletion, or a subscription usage limit). Auto-
    *  retry is skipped and the retry panel offers a "Use your own API key"
    *  button for any of these. Use the `isCredentialExhausted` helper below
-   *  for the pre-refactor combined boolean check. */
+   *  for the combined check. */
   exhaustionReason: ExhaustionReasonSchema.optional(),
   requestId: z.string().optional(),
   /** True when the underlying failure was "no usable credential", detected via
@@ -200,10 +200,8 @@ export function isUpstreamCreditDepletedError(
 }
 
 /** Single source of truth for "auto-retry should be skipped because the
- *  credential/quota is exhausted" — the combined check the pre-refactor
- *  `isCredentialExhausted` boolean used to store directly. Kept as a derived
- *  predicate (not a stored field) so the exhaustion reasons cannot drift
- *  out of sync with it. */
+ *  credential/quota is exhausted". Derived from `exhaustionReason` rather than
+ *  stored as its own field, so the two cannot drift out of sync. */
 export function isCredentialExhausted(
   errorDetails: Pick<ProviderError, 'exhaustionReason'> | undefined | null,
 ): boolean {
@@ -216,10 +214,9 @@ export function isCredentialExhausted(
  * Structurally this is exactly a {@link ProviderError} without `rawErrorBody`
  * (large, not worth persisting in retry state) — that optional field is the
  * sole difference between the two shapes, so they round-trip by narrowing
- * (drop `rawErrorBody`) and widening (it stays absent) rather than by
- * re-listing the field set in three places. Deriving the schema with `.omit()`
- * keeps it from drifting out of sync with `ProviderErrorObjectSchema` as new
- * error fields are added.
+ * (drop `rawErrorBody`) and widening (it stays absent). Deriving the schema
+ * with `.omit()` keeps it from drifting out of sync with
+ * `ProviderErrorObjectSchema` as new error fields are added.
  */
 export const RetryErrorInfoSchema = z.preprocess(
   normalizeLegacyProviderErrorFields,

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -84,12 +84,21 @@ const UseOwnApiKeyMessageSchema = StreamScopedBaseSchema.extend({
   viaRelay: z.boolean().optional(),
 });
 
+/** Set-on (idempotent) delegated-work approval. */
 const EnableDelegatedWorkApprovalMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS),
-  /** The proposal whose ordinary approval message follows this command. */
+  /**
+   * The proposal whose ordinary approval message follows this command. It is
+   * excluded from the pending-request sweep because that message may carry
+   * model or agent overrides.
+   */
   initiatingProposalId: z.string().min(1),
 });
 
+/**
+ * Set-on (idempotent) bypass enable, distinct from the shield's toggle: the
+ * inline "approve always" prompt button means "enable", never "flip".
+ */
 const EnableApprovalBypassMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS),
   /**
@@ -312,13 +321,7 @@ export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
       PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS,
     ),
     streamScopedCommand(PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS),
-    // Set-on (idempotent) delegated-work approval. The initiating proposal is
-    // excluded from the pending-request sweep because its ordinary approval
-    // message follows and may carry model or agent overrides.
     EnableDelegatedWorkApprovalMessageSchema,
-    // Set-on (idempotent) bypass enable, distinct from the shield's toggle: the
-    // inline "approve always" prompt button means "enable", never "flip", and
-    // grants only the kind of the prompt it came from.
     EnableApprovalBypassMessageSchema,
     BashApprovalActionMessageSchema,
     AgentProposalActionMessageSchema,

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -337,12 +337,13 @@ const ToolUseStreamContentMessageSchema = z.strictObject({
   }),
 });
 
-/** Full tab snapshots, expressed as the only three valid transport states. */
+/** Full tab snapshots, one branch per stream kind. */
 const RenderStreamContentMessageSchema = z.discriminatedUnion('kind', [
   WorkflowStreamContentMessageSchema,
   ToolUseStreamContentMessageSchema,
 ]);
 
+/** The only valid tab-content transport states: clear, or a full render. */
 export const SyncStreamContentMessageSchema = z.discriminatedUnion('action', [
   ClearStreamContentMessageSchema,
   RenderStreamContentMessageSchema,
@@ -367,11 +368,10 @@ const GoalActiveUpdatedMessageSchema = StreamScopedBaseSchema.extend({
 });
 
 // `theme` reuses the canonical `ThemeSchema` (`commonViewMessages.ts`) rather
-// than a locally re-declared enum — the actual desktop theme kind includes
+// than a locally re-declared enum: the desktop theme kind includes
 // `'high-contrast'` (see `DESKTOP_THEME_KIND`), which
 // `COMMON_COMMANDS.THEME_SET` messages already carry for both mainView and
-// progressView; a narrower local enum here previously just hadn't been
-// exercised against real payloads before outbound send validation (#8123).
+// progressView, and outbound sends are validated against this schema.
 const ProgressSetThemeMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.THEME_SET),
   theme: ThemeSchema,

--- a/src/shared/schemas/settingsView/data.ts
+++ b/src/shared/schemas/settingsView/data.ts
@@ -355,9 +355,9 @@ const UpdateToolDashboardMessageSchema = z.object({
 // Approval settings data schema
 // ============================================================
 
-/** Outbound: backend → frontend approval settings */
 /**
- * Outbound snapshot for workspace execution permissions and safety.
+ * Outbound: backend → frontend snapshot of workspace execution permissions
+ * and safety.
  *
  * The command string predates the Codex, Claude, and tool-path controls it now
  * carries. Keep that stable wire discriminator while naming the schema by its
@@ -498,20 +498,20 @@ const UpdateLatexSettingsStatusMessageSchema = z.object({
   settings: LatexSettingsStatusSchema,
 });
 
+const LatexFormatterSchema = z.enum(LATEX_FORMATTER_VALUES);
+
+const LatexdiffMathMarkupSchema = z.enum(LATEXDIFF_MATH_MARKUP_VALUES);
+
 /**
- * LaTeX/compile/diff configuration values, persisted in workspace storage.
- * Migrated from VS Code `texra.*` configuration. The frontend tab edits these
- * directly; the backend persists them via `workspaceSM`.
+ * LaTeX/compile/diff configuration values, persisted in workspace storage. The
+ * frontend tab edits these directly; the backend persists them via
+ * `workspaceSM`.
  *
  * Each property is optional so the UI can render either the user-set value
  * (when defined) or the documented default (when undefined). Numeric ranges
  * and enum values come from `@shared/constants/latex` so this schema, the UI,
  * and the runtime readers all stay in lockstep.
  */
-const LatexFormatterSchema = z.enum(LATEX_FORMATTER_VALUES);
-
-const LatexdiffMathMarkupSchema = z.enum(LATEXDIFF_MATH_MARKUP_VALUES);
-
 export const LatexConfigValuesSchema = z.object({
   workflowAutoCompile: z.boolean().optional(),
   workflowAutoCompileTimeoutMs: z

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -12,9 +12,9 @@ import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
  * 1. The standalone trace-viewer's file import (`replayTrace.ts`) parses
  *    externally-authored `trace.json` exports through
  *    `StreamLifecycleStatusSchema` and `StreamSnapshot.status` (§8.3's
- *    second permanent boundary — a static exported file stays legacy-shaped
+ *    permanent boundary — a static exported file stays legacy-shaped
  *    forever).
- * 3. Display tolerance for those two inputs
+ * 2. Display tolerance for that input
  *    (`@shared/streams/streamStatusDisplay`).
  *
  * The trait table that used to hang off this enum is gone: membership
@@ -54,7 +54,7 @@ export type ExecutionStatus = z.infer<typeof ExecutionStatusSchema>;
  * parse-side compatibility readers and normalized to current values.
  *
  * `cancelled` is a sibling of `failed`, never folded into it — a user stop is
- * not an error. Matches the planned `ResultEvent.outcome` triad (SDK 7d/T3-2).
+ * not an error. This is the triad `ResultEvent.outcome` carries.
  */
 export const RUN_OUTCOME = {
   COMPLETED: 'completed',
@@ -134,11 +134,9 @@ export type StreamPhase = z.infer<typeof StreamPhaseSchema>;
  * populated from `GROUP_START`/`GROUP_END` transcript rows — #7993 step 3).
  * No `WAITING`: task groups have no waiting concept, only running and the
  * three terminal `RunOutcome` values (§8.2's group-end mapping table,
- * docs/proposals/2026-07-03-session-scoped-runtime-architecture.md). Previously a
- * 4-value subset of the legacy `StreamStatus` (`running`/`error`/`stopped`/
- * `ready`); retyped to the native vocabulary in lockstep with its readers
- * (`logSlice.ts`, `TaskGroupList.ts`) so the completed/cancelled distinction
- * §8.2 already writes to the transcript row reaches the rendered value too.
+ * docs/proposals/2026-07-03-session-scoped-runtime-architecture.md). Using the
+ * native vocabulary keeps the completed/cancelled distinction §8.2 writes to
+ * the transcript row visible in the rendered value.
  */
 export const TaskGroupStatusSchema = z.enum([
   STREAM_PHASE.RUNNING,

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -2,11 +2,10 @@
  * Host-agnostic parsing schemas for per-stream sidecar data on disk
  * (`streamData/{id}/{outputFiles,missingOutputs,compileFailures,usageStats}.json`).
  *
- * Relocated out of the extension's `streamTabSchemas.ts` so the shared
- * `StreamSnapshotStore` (core) and the extension managers parse identical
- * on-disk shapes — the CLI, extension, and desktop all read/write the same
- * files. Only `@agent`-free schemas live here; `StreamTabMetaSchema` keeps its
- * `TaskState` dependency in the extension layer.
+ * The CLI, extension, and desktop all read and write these files, so the
+ * shared `StreamSnapshotStore` and the extension managers parse identical
+ * on-disk shapes from this one definition. Only `@agent`-free schemas live
+ * here.
  *
  * Legacy data (from before the one-run-per-tab refactor) was keyed by runId:
  *   - outputFiles.json / missingOutputs.json used `{ runId: { round: … } }`
@@ -36,8 +35,7 @@ import {
  * On-disk shape of `meta.json`. `taskState` is kept as `unknown` here so this
  * schema stays `@agent`-free and can live in `@shared/schemas`; consumers that
  * need the typed value parse it with `TaskStateSchema` (which depends on
- * `@agent`). This is THE definition — the core `StreamSnapshotStore` /
- * `streamSnapshotRead` import it directly, never their own copy.
+ * `@agent`).
  */
 export const StreamTabMetaSchema = z.object({
   schemaVersion: z
@@ -133,8 +131,15 @@ const numericUsageParsingShape = Object.fromEntries(
     ]),
 );
 
-/** Parsing schema with safe number coercion. */
-const TokenUsageStatsParsingBaseSchema = z
+/**
+ * Parsing schema with safe number coercion.
+ *
+ * Exported so callers that need to validate a single usage delta (e.g.
+ * {@link StreamSnapshotStore.addUsage}) can `safeParse` it themselves and log
+ * loudly on failure, instead of defaulting to zero. Never wrap this in
+ * `.catch()` for persisted/cost data — see `parseUsageData`'s docs and #7464.
+ */
+export const TokenUsageStatsParsingBaseSchema = z
   .object({
     ...numericUsageParsingShape,
     viaChatGptSubscription: z.boolean().prefault(false),
@@ -149,14 +154,6 @@ const TokenUsageStatsParsingBaseSchema = z
       (viaChatGptSubscription === true ? 'chatgpt-subscription' : undefined);
     return usageRoute == null ? stats : { ...stats, usageRoute };
   }) as z.ZodType<TokenUsageStats>;
-
-/**
- * Exported so callers that need to validate a single usage delta (e.g.
- * {@link StreamSnapshotStore.addUsage}) can `safeParse` it themselves and log
- * loudly on failure, instead of defaulting to zero. Never wrap this in
- * `.catch()` for persisted/cost data — see `parseUsageData`'s docs and #7464.
- */
-export { TokenUsageStatsParsingBaseSchema };
 
 export interface ParsedUsageData {
   /** Successfully parsed, non-empty per-run usage. */
@@ -178,21 +175,17 @@ export interface ParsedUsageData {
  * and tool-use streams. Workflow has one entry per run (= one entry per
  * tab); tool-use can accumulate multiple via resume.
  *
- * Failures are isolated PER RUN — via `safeParse` rather than the previous
- * `.catch(emptyUsageStats())` — so one malformed entry can't silently zero
+ * Failures are isolated PER RUN, so one malformed entry can't silently zero
  * every other run's cost data. A run whose value isn't a well-formed usage
  * object is logged loudly (not swallowed) and its raw value is returned in
  * `unparsedRuns` for the caller to preserve, rather than defaulted to zero
  * and dropped. Individual numeric fields inside an otherwise object-shaped
  * entry still coerce/zero via `TokenUsageStatsParsingBaseSchema`'s own
- * per-field handling — that salvage behavior is unrelated to this fix and
- * intentionally unchanged.
+ * per-field handling.
  *
  * A top-level value that isn't a record at all (e.g. corrupted to an array
  * or a scalar) has no runId to key a preserved raw entry against, so it is
- * only logged loudly; recovering it would require guessing intent. This is
- * an extreme, likely-tampered edge case — the realistic failure mode this
- * fixes is a single corrupted run entry within an otherwise valid record.
+ * only logged loudly; recovering it would require guessing intent. See #7464.
  */
 export function parseUsageData(raw: unknown): ParsedUsageData {
   const usage = new Map<string, TokenUsageStats>();

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -162,12 +162,11 @@ export const BackendOwnedFieldsSchema = z.object({
   subagents: z.array(ActiveChildInfoSchema).prefault([]),
 });
 
-const BackendOwnedMetadataFieldsSchema = BackendOwnedFieldsSchema.extend({
+export const StreamMetadataSchema = BackendOwnedFieldsSchema.extend({
+  // Nullable over the wire: an explicit `null` clears a stage the frontend
+  // still holds, which a plain omission cannot express.
   roundStage: RoundStageSchema.nullable().optional(),
   phaseStage: PhaseStageSchema.nullable().optional(),
-});
-
-export const StreamMetadataSchema = BackendOwnedMetadataFieldsSchema.extend({
   kind: AgentCategorySchema,
 });
 

--- a/src/shared/settingsView/handlers/approvalHandlers.ts
+++ b/src/shared/settingsView/handlers/approvalHandlers.ts
@@ -1,10 +1,8 @@
 /**
- * Approval settings handlers shared between desktop and extension hosts.
- *
- * Builds the approval-and-safety outbound message from workspace state and
- * applies updates from inbound messages. Both hosts hold the same workspace
- * state shape — the only host-specific dependency is the bash-approval flag,
- * which lives in `ConfigProvider` rather than workspace state.
+ * Builds the approval-and-safety outbound message shared by the desktop and
+ * extension hosts. Both hold the same workspace state shape — the only
+ * host-specific dependency is the bash-approval flag, which lives in
+ * `ConfigProvider` rather than workspace state.
  */
 import type { ConfigProvider } from '@platform/interfaces';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';

--- a/src/shared/state/stateKeys.ts
+++ b/src/shared/state/stateKeys.ts
@@ -15,7 +15,7 @@
 
 export enum WorkspaceStateKey {
   AGENT_HISTORY = 'texra.agentHistory',
-  /** Consolidated progress view preferences (replaces individual keys) */
+  /** Consolidated progress-view preferences. */
   PROGRESS_VIEW_PREFS = 'texra.progressViewPrefs',
 
   // Agent visibility (migrated from VS Code config)

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -117,7 +117,7 @@ export function formatStreamStatusLabel(
   ) {
     return CLI_CHILD_WAITING_LABEL;
   }
-  return STREAM_STATUS_LABELS[style][key] ?? status;
+  return STREAM_STATUS_LABELS[style][key];
 }
 
 /** Compact round/turn progress label: `r2/3` when the planned total is known

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -1,12 +1,7 @@
 // Host-neutral parsing/formatting for the child-run delivery-envelope XML
-// blocks produced by src/tools/subagentResults.ts, codex.ts, claudeAgent.ts,
-// github/formatUtils.ts, and ExecutionSubscriptionBinder.ts (the tags owned
-// by @shared/deliveryTags: `<subagent-progress>`, `<subagent-result>`,
-// `<subagent-error>`, `<background-result>`, `<background-error>`,
-// `<codex-result>`, `<codex-error>`, `<claude-agent-result>`,
-// `<claude-agent-error>`, `<github-webhook-activity>`,
-// `<execution-activity>`). These blocks are FollowUpQueue messages addressed
-// to the orchestrator *model*, injected into the conversation as user turns.
+// blocks whose tag vocabulary @shared/deliveryTags owns (`DELIVERY_TAGS`).
+// These blocks are FollowUpQueue messages addressed to the orchestrator
+// *model*, injected into the conversation as user turns.
 //
 // Both hosts render them: the CLI transcript collapses each block to a terse
 // status line (summarizeSubagentFollowup), and the extension ProgressView
@@ -32,10 +27,8 @@ import {
 } from '@utils/text/stringUtils';
 
 // Derived from the single owned DELIVERY_TAGS list (@shared/deliveryTags), so
-// a future child-run kind only needs one entry there. Before this, a bare
-// `subagent-(?:progress|result|error)` recognizer let
-// `claude-agent-result`/`claude-agent-error`/`codex-result`/`codex-error`
-// leak as raw XML into the CLI transcript and queued follow-ups panel.
+// a future child-run kind only needs one entry there and can never leak as raw
+// XML into the CLI transcript or the queued follow-ups panel.
 const DELIVERY_TAG_NAMES = DELIVERY_TAGS.map((entry) => entry.tag);
 const DELIVERY_TAG_ALTERNATION = DELIVERY_TAG_NAMES.join('|');
 // `\b` after the alternation is NOT a safe tag-name terminator here: `-` is a
@@ -48,16 +41,13 @@ const DELIVERY_TAG_ALTERNATION = DELIVERY_TAG_NAMES.join('|');
 // `<execution-activity>`), or the exact `/>` self-closing delimiter, so anchor
 // on those delimiters instead of accepting any slash continuation.
 const TAG_NAME_END = '(?=[\\s>]|/>)';
-const SUBAGENT_TAG_RE = new RegExp(
+const DELIVERY_TAG_RE = new RegExp(
   `^<(${DELIVERY_TAG_ALTERNATION})${TAG_NAME_END}`,
 );
 // Embedded-block variants of the same recognizer, for delivery-envelope
 // blocks that appear mid-stream inside assistant-role text rather than as a
 // standalone follow-up message (see findIncompleteEmbeddedSubagentFollowup /
-// summarizeEmbeddedSubagentFollowups below). Previously hard-coded to
-// `subagent-(?:progress|result|error)`, which let `codex-result`,
-// `claude-agent-error`, and the rest of the non-`subagent-*` families leak as
-// raw XML when embedded (issue #7846, follow-up to #7679/#7788).
+// summarizeEmbeddedSubagentFollowups below).
 const EMBEDDED_DELIVERY_BLOCK_RE = new RegExp(
   `<(?:${DELIVERY_TAG_ALTERNATION})${TAG_NAME_END}[^>]*/>|<(${DELIVERY_TAG_ALTERNATION})${TAG_NAME_END}[^>]*>[\\s\\S]*?</\\1>`,
   'g',
@@ -80,7 +70,7 @@ const RESULT_RESPONSE_PREVIEW_CHARS = 1400;
 export function deliveryTagOf(text: string): DeliveryTagName | undefined {
   // Safe cast: the pattern's only alternation group is the DELIVERY_TAGS tag
   // names, so a match can only capture one of those values.
-  return SUBAGENT_TAG_RE.exec(text.trim())?.[1] as DeliveryTagName | undefined;
+  return DELIVERY_TAG_RE.exec(text.trim())?.[1] as DeliveryTagName | undefined;
 }
 
 function followupText(text: unknown): string | undefined {

--- a/src/test-kernel/agent/AgentCategoryResolution.vitest.mts
+++ b/src/test-kernel/agent/AgentCategoryResolution.vitest.mts
@@ -32,13 +32,13 @@ function launchAs(category: AgentCategory, entry: AgentEntry | undefined) {
 }
 
 /**
- * Regression: a custom *workflow* agent named `assistant` collides with the
- * bundled *tool-use* `assistant`. Validation resolves through the category-aware
- * `getVisibleAgent`, but the launch historically re-resolved via the
- * category-blind `getAgent` (source priority: custom > … > builtInToolUse), so
- * it picked the wrong (workflow) entry and the run failed with a category
- * mismatch. The fix carries the validated entry's *source* to launch, which
- * resolves the exact `(source, name)` key — so launch can never diverge.
+ * A custom *workflow* agent named `assistant` collides with the bundled
+ * *tool-use* `assistant`. Validation resolves through the category-aware
+ * `getVisibleAgent`; a category-blind resolver would answer the same name with
+ * the custom workflow entry (source priority: custom > … > builtInToolUse) and
+ * the run would fail with a category mismatch. Launch therefore carries the
+ * validated entry's *source* and resolves the exact `(source, name)` key, so
+ * it cannot diverge from what validation accepted.
  */
 describe('cross-category agent resolution', () => {
   beforeAll(async () => {
@@ -83,8 +83,8 @@ describe('cross-category agent resolution', () => {
   });
 
   it('demonstrates the divergence the category-scoped resolver closes', () => {
-    // Category-blind resolution (the old launch path) picks the custom workflow
-    // entry by source priority…
+    // Category-blind resolution picks the custom workflow entry by source
+    // priority…
     expect(resolveAgent('assistant')?.entry.source).toBe('custom');
     expect(resolveAgent('assistant')?.entry.category).toBe('workflow');
 

--- a/src/test-kernel/agent/AgentPromptContracts.vitest.mts
+++ b/src/test-kernel/agent/AgentPromptContracts.vitest.mts
@@ -9,7 +9,7 @@ import * as yaml from 'yaml';
 // Local imports
 import { REPO_ROOT } from '@test/support/repoScan';
 
-/** A bundled tool-use agent: declares the tool roster its prompt refers to. */
+/** A tool-use agent: declares the tool roster its prompt refers to. */
 interface ToolUseAgentYaml {
   readonly name: string;
   readonly description: string;
@@ -80,6 +80,11 @@ describe('engineer agent prompt', () => {
     expect(agent.settings.tools).toContain('delegate_agent');
   });
 
+  it('can run deterministic workflow scripts when globally enabled', () => {
+    expect(agent.settings.tools).toContain('delegate_workflow_script');
+    expect(systemPrompt).not.toContain('delegate_workflow_script');
+  });
+
   it('grounds its delegation targets in the live Available agents roster', () => {
     // The fix for #6655: the engineer must defer to the agents the delegate_agent
     // tool currently lists, not assume its hardcoded specialists are reachable.
@@ -109,6 +114,19 @@ describe('engineer agent prompt', () => {
     ]) {
       expect(systemPrompt).toContain(role);
     }
+  });
+});
+
+describe('Lean orchestrator agent prompt', () => {
+  const agent = loadAgentYaml<ToolUseAgentYaml>(
+    'prompts/agents/remote/Lean4/leanOrchestrator.yaml',
+  );
+
+  it('can run deterministic workflow scripts when globally enabled', () => {
+    expect(agent.settings.tools).toContain('delegate_workflow_script');
+    expect(agent.prompts.systemPrompt).not.toContain(
+      'delegate_workflow_script',
+    );
   });
 });
 

--- a/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
+++ b/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
@@ -28,6 +28,7 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { createDeferred } from '@test/support/asyncTestUtils';
 import { REPO_ROOT } from '@test/support/repoScan';
 import { installPlatform } from '@test/support/setupPlatform';
+import { delay } from '@utils/core';
 
 const { listRemoteAgents, ORCHESTRATOR_AGENT } = vi.hoisted(() => {
   const ORCHESTRATOR_AGENT = {
@@ -172,7 +173,7 @@ describe('agent registry legacy aliases', () => {
     });
 
     const pendingRefresh = refresh({ includeRemote: false });
-    await new Promise((resolveNextTick) => setTimeout(resolveNextTick, 0));
+    await delay(0);
 
     expect(getAgent('assistant')?.name).toBe('assistant');
 
@@ -373,7 +374,7 @@ describe('agent registry legacy aliases', () => {
       });
 
       const pendingRefresh = refresh({ includeRemote: false });
-      await new Promise((resolveNextTick) => setTimeout(resolveNextTick, 0));
+      await delay(0);
       const optionsPromise = computeAgentOptionsData();
 
       builtInToolUseDir.resolve();

--- a/src/test-kernel/agent/AgentSettingSchema.vitest.ts
+++ b/src/test-kernel/agent/AgentSettingSchema.vitest.ts
@@ -13,6 +13,21 @@ import {
 import { mergeInheritedAgentObject } from '@agent/core/definition/agentDefinitionInheritance';
 import { REPO_ROOT } from '@test/support/repoScan';
 
+/**
+ * Run `parse` with `console.warn` silenced and report how many deprecation
+ * warnings it fired. The count is read before `mockRestore()`, which implies
+ * `mockReset()` and would clear `mock.calls` first.
+ */
+function withWarningCount<T>(parse: () => T): { result: T; warnings: number } {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    const result = parse();
+    return { result, warnings: warnSpy.mock.calls.length };
+  } finally {
+    warnSpy.mockRestore();
+  }
+}
+
 describe('AgentSettingSchema', () => {
   it('strips legacy workflow outputExt without exposing it in settings', () => {
     const setting = AgentSettingSchema.parse({
@@ -38,24 +53,18 @@ describe('AgentSettingSchema', () => {
       expectedWarnings: 1,
     },
   ])('$scenario', ({ documentTag, endTag, expectedWarnings }) => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    let setting!: ReturnType<typeof AgentSettingSchema.parse>;
-    let warningCount = 0;
-    try {
-      setting = AgentSettingSchema.parse({
+    const { result: setting, warnings } = withWarningCount(() =>
+      AgentSettingSchema.parse({
         agentCategory: AgentCategory.Workflow,
         documentTag,
         endTag,
-      });
-      warningCount = warnSpy.mock.calls.length;
-    } finally {
-      warnSpy.mockRestore();
-    }
+      }),
+    );
 
     expect(setting.agentCategory).toBe(AgentCategory.Workflow);
     expect(Object.hasOwn(setting, 'documentTag')).toBe(false);
     expect(Object.hasOwn(setting, 'endTag')).toBe(false);
-    expect(warningCount).toBe(expectedWarnings);
+    expect(warnings).toBe(expectedWarnings);
   });
 
   it.each([
@@ -74,23 +83,17 @@ describe('AgentSettingSchema', () => {
       expectedWarnings: 0,
     },
   ])('$scenario', ({ legacy, expectedWarnings }) => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    let setting!: ReturnType<typeof AgentSettingSchema.parse>;
-    let warningCount = 0;
-    try {
-      setting = AgentSettingSchema.parse({
+    const { result: setting, warnings } = withWarningCount(() =>
+      AgentSettingSchema.parse({
         agentCategory: AgentCategory.Workflow,
         ...legacy,
-      });
-      warningCount = warnSpy.mock.calls.length;
-    } finally {
-      warnSpy.mockRestore();
-    }
+      }),
+    );
 
     for (const key of Object.keys(legacy)) {
       expect(Object.hasOwn(setting, key)).toBe(false);
     }
-    expect(warningCount).toBe(expectedWarnings);
+    expect(warnings).toBe(expectedWarnings);
   });
 
   it('regression #7497: public remote agent YAML no longer carries documentTag/endTag', () => {
@@ -102,20 +105,13 @@ describe('AgentSettingSchema', () => {
     const files = readdirSync(dir).filter((name) => name.endsWith('.yaml'));
     expect(files.length).toBeGreaterThan(0);
 
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    let callCountAfterParsing: number;
-    try {
+    const { warnings } = withWarningCount(() => {
       for (const file of files) {
         const raw = yaml.parse(readFileSync(resolve(dir, file), 'utf8'));
         AgentDefinitionSchema.parse(raw);
       }
-    } finally {
-      // Read the call count before mockRestore(), which clears .mock.calls
-      // (it implies mockReset()) — asserting after restore would always pass.
-      callCountAfterParsing = warnSpy.mock.calls.length;
-      warnSpy.mockRestore();
-    }
-    expect(callCountAfterParsing).toBe(0);
+    });
+    expect(warnings).toBe(0);
   });
 });
 

--- a/src/test-kernel/agent/ResponseCycleContinuation.vitest.ts
+++ b/src/test-kernel/agent/ResponseCycleContinuation.vitest.ts
@@ -66,9 +66,12 @@ async function runContinuationNode(
   return { prepResult, execResult, action };
 }
 
-async function processEmptyResponse(stopReason: ProviderStopReason) {
-  const shared = createShared({ responseObject: {} });
-  const services = {
+/** Services for the process node, which reads only the extracted response. */
+function createProcessServices(
+  response: { text: string; stopReason: ProviderStopReason },
+  overrides: Record<string, unknown> = {},
+): ResponseCycleServices<unknown> {
+  return {
     round: { responseTimeMs: 0 },
     workspace: AgentWorkspaceState.create(),
     logger: {
@@ -79,11 +82,18 @@ async function processEmptyResponse(stopReason: ProviderStopReason) {
     modelCell: testModelCell({
       processThinkingBlock: vi.fn(() => null),
       getStreamingConfig: vi.fn(() => false),
-      extractResponse: vi.fn(() => ({ text: '', usage: {}, stopReason })),
+      extractResponse: vi.fn(() => ({ ...response, usage: {} })),
       normalizeUsage: vi.fn(() => undefined),
     }),
+    ...overrides,
   } as unknown as ResponseCycleServices<unknown>;
-  const node = getProcessNode().setServices(services);
+}
+
+async function processEmptyResponse(stopReason: ProviderStopReason) {
+  const shared = createShared({ responseObject: {} });
+  const node = getProcessNode().setServices(
+    createProcessServices({ text: '', stopReason }),
+  );
   const prepResult = await node.prep(shared);
   const execResult = await node.exec(prepResult);
   const action = await node.post(shared, prepResult, execResult);
@@ -221,30 +231,15 @@ describe('response cycle continuation phases', () => {
     workspace.assembly.accumulatedOutput = 'left';
     workspace.assembly.lastResponse = 'left';
     const shared = createShared({ responseObject: {} });
-    const services = {
-      runScope: {
-        session: {
-          responseTextProcessing: { connectResponseText },
+    const services = createProcessServices(
+      { text: 'right', stopReason: ANTHROPIC_STOP.END_TURN },
+      {
+        runScope: {
+          session: { responseTextProcessing: { connectResponseText } },
         },
+        workspace,
       },
-      round: { responseTimeMs: 0 },
-      workspace,
-      logger: {
-        openStage: () => ({ run: (run: () => unknown) => run() }),
-        debug: vi.fn(),
-        info: vi.fn(),
-      },
-      modelCell: testModelCell({
-        processThinkingBlock: vi.fn(() => null),
-        getStreamingConfig: vi.fn(() => false),
-        extractResponse: vi.fn(() => ({
-          text: 'right',
-          usage: {},
-          stopReason: ANTHROPIC_STOP.END_TURN,
-        })),
-        normalizeUsage: vi.fn(() => undefined),
-      }),
-    } as unknown as ResponseCycleServices<unknown>;
+    );
     const node = getProcessNode().setServices(services);
 
     const prepResult = await node.prep(shared);

--- a/src/test-kernel/agent/ResponseCycleTools.vitest.mts
+++ b/src/test-kernel/agent/ResponseCycleTools.vitest.mts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { noopTrace } from '@agent/trace';
+import type { AgentCore } from '@agent/core/flows/BaseFlowServices';
+import type { BaseCycleFields } from '@agent/core/flows/CommonCycleTypes';
+import type { ResponseCycleServices } from '@agent/core/flows/CycleServices';
 import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
 import { responseCycleToolsForModel } from '@agent/core/flows/ResponseCycleFlow';
 import { getDefaultToolRegistry } from '@tools/registry';
@@ -15,7 +18,7 @@ function responseServices({
   supportsFunctionCalling = true,
 }: {
   supportsFunctionCalling?: boolean;
-}) {
+}): Parameters<typeof responseCycleToolsForModel>[0] {
   return {
     toolRegistry: getDefaultToolRegistry(),
     modelCell: testModelCell({
@@ -35,7 +38,7 @@ function responseServices({
         { name: 'wolfram' },
       ],
     },
-  };
+  } as unknown as ResponseCycleServices;
 }
 
 describe('response cycle tool visibility', () => {
@@ -62,7 +65,7 @@ describe('response cycle tool visibility', () => {
     const tools = await withTestRunContext(
       { emit: vi.fn() },
       'response-cycle-stream',
-      async () => responseCycleToolsForModel(responseServices({}) as any),
+      async () => responseCycleToolsForModel(responseServices({})),
       services,
     );
 
@@ -75,9 +78,7 @@ describe('response cycle tool visibility', () => {
       'response-cycle-stream',
       async () =>
         responseCycleToolsForModel(
-          responseServices({
-            supportsFunctionCalling: false,
-          }) as any,
+          responseServices({ supportsFunctionCalling: false }),
         ),
     );
 
@@ -111,14 +112,11 @@ describe('response cycle tool visibility', () => {
         setOutputStreaming: vi.fn(),
       }),
       runScope: testRunScope('response-cycle-invocation'),
-      interactions: { emit: vi.fn() },
-      abortSignal: new AbortController().signal,
       setting: {
         temperature: 0,
         tools: [{ name: 'bash' }],
       },
-      streamId: 'stream-1',
-    } as any);
+    } as unknown as AgentCore);
 
     await withTestRunContext(
       { emit: vi.fn() },
@@ -127,7 +125,7 @@ describe('response cycle tool visibility', () => {
         node.run({
           messages: [],
           shouldStop: false,
-        } as any),
+        } as unknown as BaseCycleFields),
     );
 
     expect(createResponse).toHaveBeenCalledWith(

--- a/src/test-kernel/agent/RunScopedToolOverlay.vitest.ts
+++ b/src/test-kernel/agent/RunScopedToolOverlay.vitest.ts
@@ -10,10 +10,7 @@ import {
 } from '@agent/core/definition/AgentDataclass';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { MapToolRegistry, type ITool } from '@agent/core/tools/ToolTypes';
-import {
-  runToolUseFlow,
-  type RunToolUseFlowInput,
-} from '@agent/implementations/flows/tooluse/runToolUseFlow';
+import { runToolUseFlow } from '@agent/implementations/flows/tooluse/runToolUseFlow';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { createRunScope } from '@agent/runtime/RunScope';
 

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -280,26 +280,30 @@ function buildResponseResumeData(
   };
 }
 
+interface PersistedFlowRunOptions {
+  readonly attachment?: Partial<ToolUseFlowAttachment>;
+  readonly session?: SessionHandle;
+  readonly isSubagent?: boolean;
+  readonly stopAfterCycle?: boolean;
+  readonly config?: AgentConfig;
+  readonly modelHandler?: Record<string, unknown>;
+  readonly tools?: readonly ITool[];
+  readonly drainedFollowUps?: RunToolUseFlowInput['drainedFollowUps'];
+  readonly onIdle?: () => void;
+  readonly takePendingFollowUps?: RunToolUseFlowInput['takePendingFollowUps'];
+  readonly onFlowRecordDisposition?: (
+    disposition: 'preserve' | 'delete',
+  ) => void;
+}
+
 async function runPersistedFlow(
   executionId: ExecutionId,
   streamId: StreamTabId,
   resume: ToolUseResumeData | undefined,
-  attachment?: Partial<ToolUseFlowAttachment>,
-  session: SessionHandle = createTestSession(),
-  options: {
-    readonly isSubagent?: boolean;
-    readonly stopAfterCycle?: boolean;
-    readonly config?: AgentConfig;
-    readonly modelHandler?: Record<string, unknown>;
-    readonly tools?: readonly ITool[];
-    readonly drainedFollowUps?: RunToolUseFlowInput['drainedFollowUps'];
-    readonly onIdle?: () => void;
-    readonly takePendingFollowUps?: RunToolUseFlowInput['takePendingFollowUps'];
-    readonly onFlowRecordDisposition?: (
-      disposition: 'preserve' | 'delete',
-    ) => void;
-  } = {},
+  options: PersistedFlowRunOptions = {},
 ): Promise<RunToolUseFlowResult> {
+  const { attachment } = options;
+  const session = options.session ?? createTestSession();
   const config = options.config ?? resume?.agentConfig ?? CONFIG;
   const userVarChannels = resume?.shared.stateSlices.userChannels ?? {
     input: Object.freeze({ MODEL: config.model }),
@@ -736,17 +740,10 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       const resume = buildResponseResumeData(executionId, streamId, prior);
       await writeFlowRecord(executionId, resume.sourceShared, WAITING_AT_START);
 
-      const result = await runPersistedFlow(
-        executionId,
-        streamId,
-        resume,
-        undefined,
-        undefined,
-        {
-          modelHandler: responseModelHandler([{ text: fresh }]),
-          drainedFollowUps: [{ text: 'Continue.', origin: 'user' }],
-        },
-      );
+      const result = await runPersistedFlow(executionId, streamId, resume, {
+        modelHandler: responseModelHandler([{ text: fresh }]),
+        drainedFollowUps: [{ text: 'Continue.', origin: 'user' }],
+      });
 
       expect(result.response).toBe(fresh);
     },
@@ -759,17 +756,10 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const resume = buildResponseResumeData(executionId, streamId, 'A');
     await writeFlowRecord(executionId, resume.sourceShared, WAITING_AT_START);
 
-    const result = await runPersistedFlow(
-      executionId,
-      streamId,
-      resume,
-      undefined,
-      undefined,
-      {
-        modelHandler: partialFailureModelHandler('A'),
-        drainedFollowUps: [{ text: 'Continue.', origin: 'user' }],
-      },
-    );
+    const result = await runPersistedFlow(executionId, streamId, resume, {
+      modelHandler: partialFailureModelHandler('A'),
+      drainedFollowUps: [{ text: 'Continue.', origin: 'user' }],
+    });
 
     expect(result).toMatchObject({
       outcome: RUN_OUTCOME.FAILED,
@@ -810,17 +800,10 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       },
     );
 
-    const result = await runPersistedFlow(
-      executionId,
-      streamId,
-      resume,
-      undefined,
-      undefined,
-      {
-        modelHandler: responseModelHandler([{ error: providerError }]),
-        drainedFollowUps: [{ text: 'Continue.', origin: 'user' }],
-      },
-    );
+    const result = await runPersistedFlow(executionId, streamId, resume, {
+      modelHandler: responseModelHandler([{ error: providerError }]),
+      drainedFollowUps: [{ text: 'Continue.', origin: 'user' }],
+    });
 
     expect(result.outcome).toBe(RUN_OUTCOME.FAILED);
     expect(result.response).toBeUndefined();
@@ -839,24 +822,17 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       },
     });
 
-    const result = await runPersistedFlow(
-      executionId,
-      streamId,
-      undefined,
-      undefined,
-      undefined,
-      {
-        config,
-        isSubagent: false,
-        stopAfterCycle: true,
-        modelHandler: responseModelHandler([
-          {
-            text: 'Here is the structured result.',
-            toolCalls: [testToolCall('submit_output', { answer: 'done' })],
-          },
-        ]),
-      },
-    );
+    const result = await runPersistedFlow(executionId, streamId, undefined, {
+      config,
+      isSubagent: false,
+      stopAfterCycle: true,
+      modelHandler: responseModelHandler([
+        {
+          text: 'Here is the structured result.',
+          toolCalls: [testToolCall('submit_output', { answer: 'done' })],
+        },
+      ]),
+    });
 
     expect(result).toMatchObject({
       outcome: RUN_OUTCOME.COMPLETED,
@@ -881,23 +857,16 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       call: vi.fn(async () => ({ status: 'executed' as const, output: 'ok' })),
     };
 
-    const result = await runPersistedFlow(
-      executionId,
-      streamId,
-      undefined,
-      undefined,
-      undefined,
-      {
-        modelHandler: responseModelHandler([
-          {
-            text: 'I checked the tool.',
-            toolCalls: [testToolCall('probe', {})],
-          },
-          { error: providerError },
-        ]),
-        tools: [probeTool],
-      },
-    );
+    const result = await runPersistedFlow(executionId, streamId, undefined, {
+      modelHandler: responseModelHandler([
+        {
+          text: 'I checked the tool.',
+          toolCalls: [testToolCall('probe', {})],
+        },
+        { error: providerError },
+      ]),
+      tools: [probeTool],
+    });
 
     expect(result).toMatchObject({
       outcome: RUN_OUTCOME.FAILED,
@@ -912,22 +881,15 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const resume = buildResponseResumeData(executionId, streamId, 'A');
     await writeFlowRecord(executionId, resume.sourceShared, WAITING_AT_START);
 
-    const result = await runPersistedFlow(
-      executionId,
-      streamId,
-      resume,
-      undefined,
-      undefined,
-      {
-        modelHandler: responseModelHandler([
-          {
-            text: 'B',
-            updatedMessages: [{ role: 'user', content: 'Compacted context.' }],
-          },
-        ]),
-        drainedFollowUps: [{ text: 'Continue.', origin: 'user' }],
-      },
-    );
+    const result = await runPersistedFlow(executionId, streamId, resume, {
+      modelHandler: responseModelHandler([
+        {
+          text: 'B',
+          updatedMessages: [{ role: 'user', content: 'Compacted context.' }],
+        },
+      ]),
+      drainedFollowUps: [{ text: 'Continue.', origin: 'user' }],
+    });
 
     expect(result.response).toBe('B');
     expect(await readFlowRecord(executionId)).toMatchObject({
@@ -944,18 +906,11 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const executionId = 'abc-flow-fresh-root-response' as ExecutionId;
     const streamId = 'chat@gpt54#abc-flow-fresh-root-response' as StreamTabId;
 
-    const result = await runPersistedFlow(
-      executionId,
-      streamId,
-      undefined,
-      undefined,
-      undefined,
-      {
-        isSubagent: false,
-        stopAfterCycle: true,
-        modelHandler: responseModelHandler([{ text: 'fresh answer' }]),
-      },
-    );
+    const result = await runPersistedFlow(executionId, streamId, undefined, {
+      isSubagent: false,
+      stopAfterCycle: true,
+      modelHandler: responseModelHandler([{ text: 'fresh answer' }]),
+    });
 
     expect(result).toMatchObject({
       outcome: RUN_OUTCOME.COMPLETED,
@@ -973,20 +928,13 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       .mockReturnValueOnce([{ text: 'Continue.', origin: 'user' }])
       .mockReturnValue([]);
 
-    const result = await runPersistedFlow(
-      executionId,
-      streamId,
-      undefined,
-      undefined,
-      undefined,
-      {
-        modelHandler: responseModelHandler([
-          { text: 'first answer' },
-          { text: 'latest answer' },
-        ]),
-        takePendingFollowUps,
-      },
-    );
+    const result = await runPersistedFlow(executionId, streamId, undefined, {
+      modelHandler: responseModelHandler([
+        { text: 'first answer' },
+        { text: 'latest answer' },
+      ]),
+      takePendingFollowUps,
+    });
 
     expect(result).toMatchObject({
       outcome: STREAM_PHASE.WAITING,
@@ -1005,11 +953,8 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       return [];
     });
 
-    const result = await runPersistedFlow(
-      executionId,
-      streamId,
-      snapshot,
-      {
+    const result = await runPersistedFlow(executionId, streamId, snapshot, {
+      attachment: {
         attach: () => {
           boundaryEvents.push('attach');
         },
@@ -1017,9 +962,8 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
           boundaryEvents.push('detach');
         },
       },
-      undefined,
-      { takePendingFollowUps },
-    );
+      takePendingFollowUps,
+    });
 
     expect(result.outcome).toBe(STREAM_PHASE.WAITING);
     expect(takePendingFollowUps).toHaveBeenCalledTimes(2);
@@ -1039,11 +983,13 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
 
     await expect(
       runPersistedFlow(executionId, streamId, snapshot, {
-        attach: () => {
-          throw attachFailure;
-        },
-        detach: (context) => {
-          detached.push(context);
+        attachment: {
+          attach: () => {
+            throw attachFailure;
+          },
+          detach: (context) => {
+            detached.push(context);
+          },
         },
       }),
     ).rejects.toBe(attachFailure);
@@ -1069,11 +1015,8 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
 
       try {
         await expect(
-          runPersistedFlow(
-            executionId,
-            streamId,
-            snapshot,
-            {
+          runPersistedFlow(executionId, streamId, snapshot, {
+            attachment: {
               attach: (context) => {
                 context.session.appendFollowUp({
                   text: 'queued before recovery',
@@ -1081,7 +1024,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
               },
             },
             session,
-          ),
+          }),
         ).rejects.toMatchObject({
           name: PersistedFlowStateError.name,
           reason: 'read-failed',
@@ -1126,17 +1069,14 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     try {
       // The run's own failure outranks the teardown failure: it is carried
       // out on the result rather than replaced by the thrown teardown error.
-      const result = await runPersistedFlow(
-        executionId,
-        streamId,
-        snapshot,
-        {
+      const result = await runPersistedFlow(executionId, streamId, snapshot, {
+        attachment: {
           detach: () => {
             throw teardownFailure;
           },
         },
         session,
-      );
+      });
 
       expect(result).toMatchObject({
         outcome: RUN_OUTCOME.FAILED,
@@ -1165,18 +1105,15 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
 
     try {
       await expect(
-        runPersistedFlow(
-          executionId,
-          streamId,
-          snapshot,
-          {
+        runPersistedFlow(executionId, streamId, snapshot, {
+          attachment: {
             attach: (context) => context.interrupt(),
             detach: () => {
               throw teardownFailure;
             },
           },
           session,
-        ),
+        }),
       ).rejects.toBe(teardownFailure);
       expect(releaseSpy).toHaveBeenCalled();
     } finally {
@@ -1211,17 +1148,14 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
 
     try {
       await expect(
-        runPersistedFlow(
-          executionId,
-          streamId,
-          snapshot,
-          {
+        runPersistedFlow(executionId, streamId, snapshot, {
+          attachment: {
             detach: () => {
               throw teardownFailure;
             },
           },
           session,
-        ),
+        }),
       ).rejects.toThrow(
         'Structured-output run completed without calling submit_output.',
       );
@@ -1318,7 +1252,9 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
 
     try {
       const result = await runPersistedFlow(executionId, streamId, snapshot, {
-        attach: (flowContext) => flowContext.interrupt(),
+        attachment: {
+          attach: (flowContext) => flowContext.interrupt(),
+        },
       });
 
       expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
@@ -1343,14 +1279,11 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const dispositions: Array<'preserve' | 'delete'> = [];
 
     try {
-      const result = await runPersistedFlow(
-        executionId,
-        streamId,
-        undefined,
-        { attach: (flowContext) => flowContext.interrupt() },
+      const result = await runPersistedFlow(executionId, streamId, undefined, {
+        attachment: { attach: (flowContext) => flowContext.interrupt() },
         session,
-        { onFlowRecordDisposition: (value) => dispositions.push(value) },
-      );
+        onFlowRecordDisposition: (value) => dispositions.push(value),
+      });
 
       expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
       expect(readSpy).not.toHaveBeenCalled();
@@ -1392,8 +1325,10 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
 
     try {
       const result = await runPersistedFlow(executionId, streamId, snapshot, {
-        attach: (context) => {
-          flowContext = context;
+        attachment: {
+          attach: (context) => {
+            flowContext = context;
+          },
         },
       });
 
@@ -1415,21 +1350,16 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const store = getExecutionStore(executionId);
     let flowContext: ToolUseSetupContext | undefined;
 
-    const result = await runPersistedFlow(
-      executionId,
-      streamId,
-      snapshot,
-      {
+    const result = await runPersistedFlow(executionId, streamId, snapshot, {
+      attachment: {
         attach: (context) => {
           flowContext = context;
         },
       },
-      createTestSession(),
-      {
-        isSubagent: false,
-        onIdle: () => flowContext?.interrupt(),
-      },
-    );
+      session: createTestSession(),
+      isSubagent: false,
+      onIdle: () => flowContext?.interrupt(),
+    });
 
     expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
     expect(await readFlowRecord(executionId)).toMatchObject({
@@ -1497,18 +1427,14 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
 
     try {
       await expect(
-        runPersistedFlow(
-          executionId,
-          streamId,
-          snapshot,
-          {
+        runPersistedFlow(executionId, streamId, snapshot, {
+          attachment: {
             attach: (context) => {
               flowContext = context;
             },
           },
-          undefined,
-          { onFlowRecordDisposition: (value) => dispositions.push(value) },
-        ),
+          onFlowRecordDisposition: (value) => dispositions.push(value),
+        }),
       ).rejects.toBe(abortError);
       expect(deleteSpy).not.toHaveBeenCalledWith(flowKey(executionId));
       expect(dispositions).toEqual(['preserve']);
@@ -1523,21 +1449,13 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
   });
 
   it('preserves a follow-up appended during setup when cancellation arrives during the recovery read (issue #8049 P2)', async () => {
-    // Regression: once setup attaches the live flow context, a new follow-up
-    // can enter its session queue before the flow is interruptible. If an
-    // external cancellation then lands while the recovery read is pending --
-    // this same "cancellation during read" window as the sibling test above --
-    // the early return here reports CANCELLED with the resume record preserved,
-    // but previously
-    // `ToolUseSessionLifecycle.interrupt()` unconditionally disposed the
-    // queue (dropping the just-appended follow-up) and the finally below
-    // unconditionally released it again, so neither the caller
-    // (`resumeQueuedToolUseFromResumeData`, which never restores follow-ups on
-    // this success path) nor a later resume could ever recover the user's
-    // queued input. Fixed by asking `ToolUseSessionLifecycle.interrupt()` to
-    // preserve the queue for this window (cancelling the pending wait without
-    // dropping queued items) and by skipping the queue release in
-    // `runToolUseFlow`'s finally whenever the flow record itself is preserved.
+    // Once setup attaches the live flow context, a new follow-up can enter its
+    // session queue before the flow is interruptible. When an external
+    // cancellation then lands while the recovery read is pending -- the same
+    // window as the sibling test above -- the run reports CANCELLED with the
+    // resume record preserved, and the queued input must survive with it:
+    // `resumeQueuedToolUseFromResumeData` never restores follow-ups on this
+    // success path, so dropping the item here would lose it for good.
     const executionId = 'abc-cancel-followup' as ExecutionId;
     const streamId = 'chat@gpt54#abc-cancel-followup' as StreamTabId;
     const snapshot = buildToolUseResumeData(executionId, streamId);
@@ -1552,18 +1470,15 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     });
 
     try {
-      const result = await runPersistedFlow(
-        executionId,
-        streamId,
-        snapshot,
-        {
+      const result = await runPersistedFlow(executionId, streamId, snapshot, {
+        attachment: {
           attach: (context) => {
             flowContext = context;
             context.session.appendFollowUp({ text: 'queued during resume' });
           },
         },
         session,
-      );
+      });
 
       expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
       expect(session.followUps.getAll(streamId)).toEqual([
@@ -1610,18 +1525,15 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
 
     try {
       await expect(
-        runPersistedFlow(
-          executionId,
-          streamId,
-          snapshot,
-          {
+        runPersistedFlow(executionId, streamId, snapshot, {
+          attachment: {
             attach: (context) => {
               flowContext = context;
             },
           },
           session,
-          { takePendingFollowUps: () => [] },
-        ),
+          takePendingFollowUps: () => [],
+        }),
       ).rejects.toBe(abortError);
       expect(session.followUps.getAll(streamId)).toEqual([
         'late active-turn input',
@@ -1667,17 +1579,14 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
 
     try {
       await expect(
-        runPersistedFlow(
-          executionId,
-          streamId,
-          snapshot,
-          {
+        runPersistedFlow(executionId, streamId, snapshot, {
+          attachment: {
             attach: (context) => {
               flowContext = context;
             },
           },
           session,
-        ),
+        }),
       ).rejects.toBe(abortError);
       expect(session.followUps.getAll(streamId)).toEqual([
         'queued for next turn',

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -84,6 +84,12 @@ function startCodexChild(executionId: ExecutionId, description: string) {
   });
 }
 
+/**
+ * Run `run` with a run-scope subscriber attached to the default session hub.
+ * Creating or finalizing a child stream activates it, and the hub asserts a
+ * run-scope subscriber is already attached at that point; the recorded events
+ * themselves are not asserted here.
+ */
 function withSessionEventRecording<T>(run: () => T): T {
   const recorded = recordSessionEvents(defaultSession().events);
   try {

--- a/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
@@ -169,16 +169,14 @@ function messagesOfType(
 /**
  * Regression test for https://github.com/LionSR/TeXRA/issues/7163.
  *
- * When a tool-use round is interrupted mid-flight, `ToolUseDispatchNode` used
- * to silently drop the tool_use blocks for calls that never executed —
- * persisting an assistant turn with N tool_use blocks but fewer than N
- * tool_result entries. Providers with strict tool-call pairing requirements
- * (e.g. Anthropic, and OpenAI's response-chaining mode) reject a follow-up
- * request whose history has an unpaired tool_use on resume.
+ * An assistant turn persisted with N tool_use blocks but fewer than N
+ * tool_result entries is unresumable: providers with strict tool-call pairing
+ * requirements (e.g. Anthropic, and OpenAI's response-chaining mode) reject a
+ * follow-up request whose history has an unpaired tool_use.
  *
- * Each test dispatches two tool calls in one round, interrupts the run at a
+ * Each test dispatches three tool calls in one round, interrupts the run at a
  * different point, and asserts the persisted messages contain a matching
- * tool_use/tool_result pair for *both* calls — the pairs for the calls that
+ * tool_use/tool_result pair for *every* call — the pairs for the calls that
  * never ran being synthesized "cancelled" results.
  */
 describe('ToolUseDispatchNode interruption', () => {

--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -22,14 +22,13 @@ import { testExecutionHandle } from '@test/support/executionHandleFixtures';
 import { createTestSession } from '@test/support/sessionTestUtils';
 
 // Local file imports
-import { createRecordingHost } from '../progressTestUtils';
+import { createRecordingHost, recordSessionEvents } from '../progressTestUtils';
 
 const streamId = 'stream:follow-up' as StreamTabId;
 
 describe('tool-use follow-up progress events', () => {
   const unsubscribeFollowUpObservers: Array<() => void> = [];
-  const trackedExecutionIds = new Set<string>();
-  const sessionTrackedExecutions: Array<{
+  const trackedExecutions: Array<{
     readonly session: SessionHandle;
     readonly executionId: string;
   }> = [];
@@ -39,11 +38,7 @@ describe('tool-use follow-up progress events', () => {
     for (const unsubscribe of unsubscribeFollowUpObservers.splice(0)) {
       unsubscribe();
     }
-    for (const executionId of trackedExecutionIds) {
-      defaultSession().executions.untrack(executionId);
-    }
-    trackedExecutionIds.clear();
-    for (const { session, executionId } of sessionTrackedExecutions.splice(0)) {
+    for (const { session, executionId } of trackedExecutions.splice(0)) {
       session.executions.untrack(executionId);
     }
     for (const session of sessions) {
@@ -78,23 +73,16 @@ describe('tool-use follow-up progress events', () => {
       switchModel: async () => {},
       interrupt: () => {},
     });
-    if (session) {
-      session.executions.track(handle);
-      sessionTrackedExecutions.push({ session, executionId });
-    } else {
-      defaultSession().executions.track(handle);
-      trackedExecutionIds.add(executionId);
-    }
+    const owner = session ?? defaultSession();
+    owner.executions.track(handle);
+    trackedExecutions.push({ session: owner, executionId });
   }
 
   it('publishes sent follow-up events through the owning session fact hub', async () => {
     const { events } = createRecordingHost();
     const session = createTestSession();
     sessions.add(session);
-    const facts: unknown[] = [];
-    const detachFacts = session.events.subscribe((event) => {
-      facts.push(event);
-    });
+    const recorded = recordSessionEvents(session.events);
     const appendFollowUp = vi.fn();
 
     trackToolUseFlow({ appendFollowUp, session });
@@ -102,7 +90,7 @@ describe('tool-use follow-up progress events', () => {
     const result = await submitFollowUp(streamId, 'please continue', {
       session,
     });
-    detachFacts();
+    recorded.detach();
 
     expect(result).toEqual({ status: 'sent' });
     expect(appendFollowUp).toHaveBeenCalledWith({
@@ -110,7 +98,7 @@ describe('tool-use follow-up progress events', () => {
       mediaFiles: undefined,
       displayText: undefined,
     });
-    expect(facts).toEqual([
+    expect(recorded.events).toEqual([
       {
         scope: 'session',
         event: {
@@ -128,14 +116,8 @@ describe('tool-use follow-up progress events', () => {
     const activeSession = createTestSession();
     sessions.add(explicitSession);
     sessions.add(activeSession);
-    const explicitFacts: unknown[] = [];
-    const activeFacts: unknown[] = [];
-    const detachExplicitFacts = explicitSession.events.subscribe((event) => {
-      explicitFacts.push(event);
-    });
-    const detachActiveFacts = activeSession.events.subscribe((event) => {
-      activeFacts.push(event);
-    });
+    const explicit = recordSessionEvents(explicitSession.events);
+    const active = recordSessionEvents(activeSession.events);
 
     try {
       withRunContext(
@@ -145,7 +127,7 @@ describe('tool-use follow-up progress events', () => {
         () => notifyFollowUpSent(streamId, explicitSession),
       );
 
-      expect(explicitFacts).toEqual([
+      expect(explicit.events).toEqual([
         {
           scope: 'session',
           event: {
@@ -154,11 +136,11 @@ describe('tool-use follow-up progress events', () => {
           },
         },
       ]);
-      expect(activeFacts).toEqual([]);
+      expect(active.events).toEqual([]);
       expect(run.events).toEqual([]);
     } finally {
-      detachExplicitFacts();
-      detachActiveFacts();
+      explicit.detach();
+      active.detach();
     }
   });
 
@@ -166,20 +148,14 @@ describe('tool-use follow-up progress events', () => {
     const run = createRecordingHost();
     const session = createTestSession();
     sessions.add(session);
-    const facts: unknown[] = [];
-    const detachFacts = session.events.subscribe((event) => {
-      facts.push(event);
-    });
+    const recorded = recordSessionEvents(session.events);
 
     try {
-      withRunContext(
-        createRunContext({
-          session,
-        }),
-        () => notifyFollowUpSent(streamId),
+      withRunContext(createRunContext({ session }), () =>
+        notifyFollowUpSent(streamId),
       );
 
-      expect(facts).toEqual([
+      expect(recorded.events).toEqual([
         {
           scope: 'session',
           event: {
@@ -190,16 +166,13 @@ describe('tool-use follow-up progress events', () => {
       ]);
       expect(run.events).toEqual([]);
     } finally {
-      detachFacts();
+      recorded.detach();
     }
   });
 
   it('falls back to the default session when the active run has no event hub', () => {
     const run = createRecordingHost();
-    const defaultFacts: unknown[] = [];
-    const detachDefaultFacts = defaultSession().events.subscribe((event) => {
-      defaultFacts.push(event);
-    });
+    const recorded = recordSessionEvents(defaultSession().events);
 
     try {
       withRunContext(
@@ -209,7 +182,7 @@ describe('tool-use follow-up progress events', () => {
         () => notifyFollowUpSent(streamId),
       );
 
-      expect(defaultFacts).toEqual([
+      expect(recorded.events).toEqual([
         {
           scope: 'session',
           event: {
@@ -220,7 +193,7 @@ describe('tool-use follow-up progress events', () => {
       ]);
       expect(run.events).toEqual([]);
     } finally {
-      detachDefaultFacts();
+      recorded.detach();
     }
   });
 
@@ -301,10 +274,7 @@ describe('tool-use follow-up progress events', () => {
   it('does not emit a follow-up sent fact when no follow-up reaches a live session', async () => {
     const session = createTestSession();
     sessions.add(session);
-    const facts: unknown[] = [];
-    const detachFacts = session.events.subscribe((event) => {
-      facts.push(event);
-    });
+    const recorded = recordSessionEvents(session.events);
 
     try {
       const result = await submitFollowUp(
@@ -317,9 +287,9 @@ describe('tool-use follow-up progress events', () => {
         status: 'no_session',
         streamStatus: undefined,
       });
-      expect(facts).toEqual([]);
+      expect(recorded.events).toEqual([]);
     } finally {
-      detachFacts();
+      recorded.detach();
     }
   });
 

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -102,7 +102,6 @@ function createCycleNode(
   overrides: Record<string, unknown> = {},
 ): ToolUseCycleNode<unknown> {
   return new ToolUseCycleNode<unknown>().setServices({
-    streamId,
     runScope: testRunScope(streamId, { interactions: host }),
     logger,
     modelCell: testModelCell({ getClient: vi.fn() }),

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -144,9 +144,8 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     const prep = await node.prep(shared);
-    // No in-flow delivery site anymore — the child-run loop reads the turn
-    // facts off the flow result and delivers after suspension (see
-    // childRunLoop.ts), so the node itself carries none.
+    // The child-run loop reads the turn facts off the flow result and delivers
+    // them after suspension (see childRunLoop.ts), so the node carries none.
     expect(prep.lastResponse).toBeUndefined();
 
     const transition = await withTestRunContext(
@@ -165,11 +164,9 @@ describe('ToolUseWaitNode', () => {
   });
 
   it('always suspends a subagent cycle even when a follow-up is already queued', async () => {
-    // The key behavior change from the old "skip suspension if a follow-up
-    // already raced in" fast path: subagent mode now suspends unconditionally
-    // and symmetrically. A follow-up already queued is the child-run loop's
-    // concern (it resumes immediately instead of genuinely waiting) — not
-    // something the flow itself should special-case.
+    // Subagent mode suspends unconditionally and symmetrically. A follow-up
+    // already queued is the child-run loop's concern (it resumes immediately
+    // instead of genuinely waiting), not something the flow special-cases.
     const shared: ToolUseRunShared = toolUseRunShared();
     const interactions = { emit: vi.fn() };
     const waitForFollowUp = vi.fn();
@@ -685,12 +682,10 @@ describe('ToolUseWaitNode', () => {
   });
 
   it('does not let a subagent drive the parent goal continuation loop', async () => {
-    // A subagent cycle always exits WAITING (never reaches the goal-
-    // continuation code path, which is gated `!isSubagent` and only
-    // reachable after the subagent-suspend branch) — the invariant this test
-    // protects (a subagent must never synthesize a continuation against the
-    // PARENT's goal) is now structural, not conditional on waitForFollowUp
-    // ever being called.
+    // A subagent cycle always exits WAITING before the goal-continuation path,
+    // which is gated `!isSubagent` and sits after the subagent-suspend branch.
+    // So a subagent can never synthesize a continuation against the PARENT's
+    // goal, structurally rather than by any check on waitForFollowUp.
     const streamId = 'wait-node-goal-subagent' as StreamTabId;
     await installPlatform();
 
@@ -920,11 +915,11 @@ describe('ToolUseWaitNode', () => {
     );
   });
 
-  // Regression: #9443. The subagent after-error stop fired before the drained
-  // batch was consumed, dropping user input the child-run loop had already
-  // taken off the queue — and skipping `post`'s error clear with it. Since
-  // consuming the batch continues immediately, an active goal must not be
-  // paused or lose its unattended bash approval first.
+  // Regression #9443: a drained batch is consumed before the subagent
+  // after-error stop, so user input the child-run loop already took off the
+  // queue reaches the model and `post` clears the error. Since consuming the
+  // batch continues immediately, an active goal must not be paused or lose its
+  // unattended bash approval first.
   it('recovers an errored goal from a drained batch without pausing it', async () => {
     const streamId = 'wait-node-error-drained-goal' as StreamTabId;
     await installPlatform();

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -41,9 +41,11 @@ import {
 import { installPlatform } from '@test/support/setupPlatform';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
-// installPlatform dynamically imports @platform/platform at call time, so
-// every call below also re-resolves it after this file's vi.resetModules()
-// calls, keeping it on the instance the factory reads.
+// This file calls vi.resetModules(), which desyncs the statically-imported
+// factory from a freshly-imported @platform copy. Blocks that must agree with
+// the platform therefore re-import '@agent/runtime/ModelFactory' right after
+// installPlatform, which itself dynamically imports @platform/platform at call
+// time and so always lands on the instance the re-imported factory reads.
 
 function modelConfig(
   provider: ModelProvider,
@@ -568,9 +570,8 @@ describe('Google Interactions API routing', () => {
 
   const googleConfig = (): ModelConfig => modelConfig(ModelProvider.GOOGLE);
 
-  // Re-import the factory alongside the platform it reads from. An earlier test
-  // in this file calls vi.resetModules(), which would otherwise desync the
-  // statically-imported factory from a freshly-imported @platform copy.
+  // Re-imports the factory alongside the platform it reads from (see the
+  // module-header note on this file's vi.resetModules() calls).
   async function initWithFlag(
     useInteractions?: boolean,
     useOpenRouter = false,
@@ -856,11 +857,10 @@ describe('routing precedence: compat-key ↔ createModelHandler invariant', () =
   // the class differs, not the key), so this signed-out sweep guards the key
   // invariant for both states.
   it('tags every registered model with its predicted compatibility key', async () => {
-    // Re-import the factory alongside a freshly-initialized platform. An
-    // earlier test in this file calls vi.resetModules(), which would otherwise
-    // desync the statically-imported factory from the platform it reads; this
-    // also makes the block robust to isolated `--grep` runs rather than
-    // free-riding on a prior test's initPlatform.
+    // Re-import the factory alongside a freshly-initialized platform (see the
+    // module-header note). Initializing here also keeps the block correct
+    // under an isolated `--grep` run rather than free-riding on a prior
+    // test's initPlatform.
     await installPlatform({}, { languageModel: AVAILABLE_LANGUAGE_MODEL_PORT });
     const {
       modelHandlerCompatibilityKey: compatKey,
@@ -868,7 +868,7 @@ describe('routing precedence: compat-key ↔ createModelHandler invariant', () =
       activeModelHandlerCompatibilityKey: activeKey,
     } = await import('@agent/runtime/ModelFactory');
     // Stub the relay service on the same fresh module instance the re-imported
-    // factory reads (static imports are desynced by this file's resetModules).
+    // factory reads.
     const { setServerSideKeyService: setService } =
       await import('@auth/serverKeys');
     setService({
@@ -912,8 +912,8 @@ describe('Kimi Code reroute under included access', () => {
   async function createKimiHandler(options: {
     readonly includedAccess: boolean;
   }): Promise<ModelConfig> {
-    // Re-import alongside a freshly-initialized platform — see the invariant
-    // test above for why this file cannot rely on the static factory import.
+    // Re-import alongside a freshly-initialized platform (see the
+    // module-header note).
     await installPlatform({
       globalState: { 'texra.kimiCode.prefer': true },
       secrets: { 'apiKey.kimiCode': 'test-kimi-code-key' },

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -50,8 +50,8 @@ import type {
   ToolUseBlock,
 } from '@anthropic-ai/sdk/resources/messages';
 
-// Real node fs is required because the prefill tests write and read files in
-// os.tmpdir().
+// Real node fs is required because the output-initialization tests write and
+// read files in os.tmpdir().
 setupPlatform({}, { fs: nodeFilesystem });
 
 afterEach(() => {
@@ -423,18 +423,6 @@ interface AnthropicFileEstimateTarget {
   ): Promise<number>;
 }
 
-function fileReferenceMessages(...fileIds: string[]): MessageParam[] {
-  return [
-    {
-      role: 'user',
-      content: fileIds.map((fileId) => ({
-        type: 'document',
-        source: { type: 'file', file_id: fileId },
-      })) as unknown as ContentBlockParam[],
-    },
-  ];
-}
-
 function createFileEstimateHarness(...fileIds: string[]): {
   target: AnthropicFileEstimateTarget;
   messages: MessageParam[];
@@ -442,7 +430,15 @@ function createFileEstimateHarness(...fileIds: string[]): {
   const handler = createAnthropicHandler({ supportsNativePdf: true });
   return {
     target: handler as unknown as AnthropicFileEstimateTarget,
-    messages: fileReferenceMessages(...fileIds),
+    messages: [
+      {
+        role: 'user',
+        content: fileIds.map((fileId) => ({
+          type: 'document',
+          source: { type: 'file', file_id: fileId },
+        })) as unknown as ContentBlockParam[],
+      },
+    ],
   };
 }
 
@@ -2515,11 +2511,9 @@ describe('ModelHandlerAnthropic pre-message_start error handling', () => {
       handler.createResponse({ client, messages, temperature: 0 }),
       (err: unknown) => {
         assert.ok(err instanceof Error, 'expected an Error to be thrown');
-        // The fix under test: once message_start was actually received, the
-        // pre-message_start wrap guard must not fire and clobber a more
-        // specific, more accurate error (previously this mislabeled the
-        // message_stop-guard error as "closed before message_start", even
-        // though message_start diagnostics showed it had, in fact, started).
+        // Once message_start was actually received, the pre-message_start
+        // wrap guard must not fire and clobber the more specific
+        // message_stop-guard error with "closed before message_start".
         assert.ok(
           !/Stream closed before message_start/.test((err as Error).message),
           `expected the original message_stop-guard error to survive unwrapped, got: ${(err as Error).message}`,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -1170,9 +1170,8 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     const compactCalls = stubCompactionToLastMessage(handler, {
       tokensAfter: 1000,
     });
-    // Turn 2's live count lands between the 75% threshold (150k) and the 200k
-    // window: the stale cumulative from turn 1 (100k) would never have
-    // triggered, but the live count must.
+    // Turn 2's live pre-flight count lands between the 75% threshold (150k)
+    // and the 200k window, so compaction runs before the request goes out.
     const { client, requests, tokenCounts } = createPreflightCountingClient(
       (call) => (call === 2 ? 180000 : 1000),
     );
@@ -1235,10 +1234,9 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
   });
 
   it('recovers an unchained pre-flight overflow by compacting (no previous_response_id to drop)', async () => {
-    // cursor[bot]/claude[bot] review finding on this PR: recovery used to
-    // require hasPreviousResponseId(), so after invalidateChain() or on a
-    // non-chaining route an overflow failed hard without ever attempting
-    // compaction — a regression vs the old cumulative-threshold trigger.
+    // A non-chaining route (or one whose chain was invalidated) has no
+    // previous_response_id to drop, so overflow recovery has to reach
+    // compaction on its own rather than failing hard.
     const handler = createNonChainingHandler({
       openRouterOnly: false,
       contextWindow: 200_000,

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -348,7 +348,7 @@ describe('output progress events', () => {
 
   it.each([
     {
-      name: 'publishes missing-output processing events through the runtime host',
+      name: 'publishes missing-output processing events on the run trace',
       split: async () => {
         throw new Error('invalid xml');
       },
@@ -391,10 +391,10 @@ describe('output progress events', () => {
   });
 
   it('warns when a non-empty response yields zero extracted files', async () => {
-    // Regression: a run where the model returned content but nothing could be
-    // extracted (e.g. it did not wrap files in <documents>) used to "complete"
-    // silently with only the raw output. It must now surface a warning. Stub
-    // the read so the model output is treated as non-empty.
+    // A run where the model returned content but nothing could be extracted
+    // (e.g. it did not wrap files in <documents>) must surface a warning
+    // rather than completing silently with only the raw output. Stub the read
+    // so the model output is treated as non-empty.
     const readSpy = vi
       .spyOn(AbsoluteFS, 'read')
       .mockResolvedValue('% chunk.tex\n\\section{Untagged content}\n');

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -35,9 +35,10 @@ import { createSessionApprovals } from '@agent/runtime/streamApprovalQueue';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 /**
- * Loosely-typed recording of host emissions. The recording host also encodes
- * typed `HostInteractions` requests and test-owned decisions as legacy-style
- * show/resolve entries, so the vocabulary is a plain string.
+ * Loosely-typed recording of host emissions. The recording host flattens typed
+ * `HostInteractions` requests and test-owned decisions into the same stream as
+ * plain `emit` calls, using its own `show*`/`resolve*` names, so the event
+ * vocabulary is a plain string.
  */
 export type RecordedProgressEvent = {
   event: string;

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -65,7 +65,7 @@ describe('AgentLaunchContext', () => {
     }
   });
 
-  it('publishes missing-agent banners through the explicit runtime host', async () => {
+  it('publishes missing-agent banners through the supplied host interactions', async () => {
     const explicit = createRecordingHost();
 
     await expect(

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -2,7 +2,7 @@
 import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, type Mock } from 'vitest';
 
 // Local imports
 import type { FinalizeExecutionResult } from '@agent/storage';
@@ -835,14 +835,12 @@ describe('runFlowWithLifecycle', () => {
       const waitingHandle = takeWaitingHandle(executionId);
 
       // runToolUseFlow's finally detaches this stream's interrupt handler but
-      // (post #7286) preserves the follow-up queue for WAITING — it does not
-      // dispose the session — by the time a native subagent suspends at
-      // WAITING (not reproduced by this fake runner, but true in production —
-      // see runToolUseFlow.ts). Before the fix, `executions.kill()`
-      // found no interrupt target for a suspended handle and silently
-      // no-opped, leaving the handle stuck registered forever. It must now
-      // fall back to the teardown the WAITING branch parked and actually tear
-      // the execution down.
+      // preserves the follow-up queue for WAITING — it does not dispose the
+      // session — by the time a native subagent suspends at WAITING (not
+      // reproduced by this fake runner, but true in production — see
+      // runToolUseFlow.ts). With no interrupt target left, `executions.kill()`
+      // falls back to the teardown the WAITING branch parked and tears the
+      // execution down.
       expect(defaultSession().executions.kill(executionId)).toBe(true);
       await waitingHandle.result;
 
@@ -875,11 +873,9 @@ describe('runFlowWithLifecycle', () => {
       // The kill path never resumes, so the per-suspension parent stage must
       // be closed here rather than dangling open forever. `ctx.parentStage`
       // is already desubscribed by this point (disposeTrace ran in the
-      // WAITING branch's own finally), so the fix writes the stage's
-      // GROUP_END entry directly to the transcript store instead of calling
-      // the now-inert `ctx.parentStage.end()`. The written status is the
-      // literal `RunOutcome.CANCELLED` (#7993 step 2), not a legacy
-      // 2-value fold.
+      // WAITING branch's own finally), so the stage's GROUP_END entry is
+      // written directly to the transcript store instead of through the
+      // now-inert `ctx.parentStage.end()`.
       expect(transcriptsUpdate).toHaveBeenCalledWith(
         streamId,
         expect.any(String),
@@ -951,9 +947,8 @@ describe('runFlowWithLifecycle', () => {
   // matrix pins the projections for every terminal path — in particular that
   // a user stop (the no-throw `cancelled` exit, the dominant stop path)
   // persists `interrupted` and ends the stage with the literal `cancelled`
-  // outcome, distinct from `completed` (#7993 step 2: `stage.end()` writes
-  // the native `RunOutcome`, not the folded 2-value `EndGroupStatus` string —
-  // completed/cancelled/failed all end up distinct on the transcript row).
+  // outcome. `stage.end()` writes the native `RunOutcome`, so
+  // completed/cancelled/failed stay distinct on the transcript row.
   it('projects returned outcomes to terminal status, stage end, and stream status', async () => {
     const cases = [
       {
@@ -992,8 +987,6 @@ describe('runFlowWithLifecycle', () => {
           flowRecord:
             expected.outcome === RUN_OUTCOME.COMPLETED ? 'delete' : 'preserve',
         });
-        // The stage closes with the literal outcome, not a legacy 2-value
-        // fold.
         expect(stageEnd).toHaveBeenCalledWith(expected.outcome);
         expect(streamStatus.get(streamId)).toBe(expected.stream);
       } finally {
@@ -1002,7 +995,7 @@ describe('runFlowWithLifecycle', () => {
     }
   });
 
-  it('projects a thrown abort as cancelled (distinct stage outcome, not folded to stopped)', async () => {
+  it('projects a thrown abort as cancelled on its own stage outcome', async () => {
     const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
       'outcome-thrown-abort',
     );
@@ -1201,6 +1194,30 @@ describe('runFlowWithLifecycle', () => {
   });
 });
 
+/** The handle, status machine, and untrack spy every finalize test drives. */
+function finalizeFixture(slug: string): {
+  executionId: string;
+  streamId: StreamTabId;
+  streamStatus: StreamStatusMachine;
+  handle: ReturnType<typeof testExecutionHandle>;
+  untrack: Mock<(executionId: string) => void>;
+} {
+  const executionId = `exec-${slug}`;
+  const streamId = `stream-${slug}` as StreamTabId;
+  return {
+    executionId,
+    streamId,
+    streamStatus: new StreamStatusMachine(),
+    handle: testExecutionHandle({
+      executionId,
+      parentStreamId: streamId,
+      agent: 'test-agent',
+      trace: noopTrace,
+    }),
+    untrack: vi.fn<(executionId: string) => void>(),
+  };
+}
+
 describe('finalizeRunTerminal', () => {
   // The exactly-once guard must be an atomic, synchronous claim — not a
   // check-then-await on the settled flag. Two finalizers racing across the
@@ -1208,16 +1225,8 @@ describe('finalizeRunTerminal', () => {
   // handle) would otherwise both pass the check before the first settles and
   // double-publish persist/emit/settle/untrack.
   it('finalizes exactly once when two callers race across the persist await', async () => {
-    const executionId = 'exec-finalize-race';
-    const streamId = 'stream-finalize-race' as StreamTabId;
-    const streamStatus = new StreamStatusMachine();
-    const handle = testExecutionHandle({
-      executionId,
-      parentStreamId: streamId,
-      agent: 'test-agent',
-      trace: noopTrace,
-    });
-    const untrack = vi.fn();
+    const { executionId, streamId, streamStatus, handle, untrack } =
+      finalizeFixture('finalize-race');
     const traceEmit = vi.spyOn(noopTrace, 'emit');
     storageMocks.finalizeExecution.mockClear();
     // Park the first caller at its persist await so the second caller arrives
@@ -1283,16 +1292,8 @@ describe('finalizeRunTerminal', () => {
   });
 
   it('flushes display artifacts before publishing and untracking', async () => {
-    const executionId = 'exec-finalize-artifact-order';
-    const streamId = 'stream-finalize-artifact-order' as StreamTabId;
-    const streamStatus = new StreamStatusMachine();
-    const handle = testExecutionHandle({
-      executionId,
-      parentStreamId: streamId,
-      agent: 'test-agent',
-      trace: noopTrace,
-    });
-    const untrack = vi.fn();
+    const { executionId, streamId, streamStatus, handle, untrack } =
+      finalizeFixture('finalize-artifact-order');
     let releaseFlush: (() => void) | undefined;
     const flushArtifacts = vi.fn(
       () =>
@@ -1334,16 +1335,8 @@ describe('finalizeRunTerminal', () => {
   });
 
   it('settles and untracks once while reporting terminal metadata failure', async () => {
-    const executionId = 'exec-finalize-metadata-failure';
-    const streamId = 'stream-finalize-metadata-failure' as StreamTabId;
-    const streamStatus = new StreamStatusMachine();
-    const handle = testExecutionHandle({
-      executionId,
-      parentStreamId: streamId,
-      agent: 'test-agent',
-      trace: noopTrace,
-    });
-    const untrack = vi.fn();
+    const { executionId, streamId, streamStatus, handle, untrack } =
+      finalizeFixture('finalize-metadata-failure');
     const durabilityError = new Error('metadata disk write failed');
     storageMocks.finalizeExecution.mockResolvedValueOnce({
       status: 'failed',
@@ -1399,16 +1392,8 @@ describe('finalizeRunTerminal', () => {
   // killed then reports its own non-zero exit as a failure — so the phase, not
   // the report, has to decide, and no caller may cross-check it for itself.
   it('resolves the terminal outcome from an already-cancelled stream phase', async () => {
-    const executionId = 'exec-finalize-stopped';
-    const streamId = 'stream-finalize-stopped' as StreamTabId;
-    const streamStatus = new StreamStatusMachine();
-    const handle = testExecutionHandle({
-      executionId,
-      parentStreamId: streamId,
-      agent: 'test-agent',
-      trace: noopTrace,
-    });
-    const untrack = vi.fn();
+    const { executionId, streamId, streamStatus, handle, untrack } =
+      finalizeFixture('finalize-stopped');
     const stage = { end: vi.fn() };
     storageMocks.finalizeExecution.mockClear();
     channelTraceMocks.warn.mockClear();
@@ -1457,16 +1442,8 @@ describe('finalizeRunTerminal', () => {
   // published FAILED is a terminal fact a later stop cannot rewrite, so a
   // caller reporting `cancelled` does not get to relabel it.
   it('keeps an already-failed stream phase over a later cancelled report', async () => {
-    const executionId = 'exec-finalize-failed-then-stopped';
-    const streamId = 'stream-finalize-failed-then-stopped' as StreamTabId;
-    const streamStatus = new StreamStatusMachine();
-    const handle = testExecutionHandle({
-      executionId,
-      parentStreamId: streamId,
-      agent: 'test-agent',
-      trace: noopTrace,
-    });
-    const untrack = vi.fn();
+    const { executionId, streamId, streamStatus, handle, untrack } =
+      finalizeFixture('finalize-failed-then-stopped');
     channelTraceMocks.warn.mockClear();
 
     try {

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -560,9 +560,6 @@ describe('childRunLoop E2E fixtures', () => {
     // The loop starts delivery for turn N before reading the queue for turn
     // N+1. Even input already queued during delivery must not begin another
     // model turn until the parent has received this result.
-    await vi.waitFor(() =>
-      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalled(),
-    );
     expect(onTurnSuccess).toHaveBeenCalledOnce();
     expect(onTurnSuccess.mock.invocationCallOrder[0]).toBeLessThan(
       parentWake.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
@@ -727,12 +724,11 @@ describe('childRunLoop E2E fixtures', () => {
     });
   });
 
-  it('reattaches the loop interrupt handler immediately when a turn settles, before delivery (Copilot review: no interrupt gap during delivery)', async () => {
-    // Regression: if the loop attached its own interrupt handler only AFTER
-    // awaiting deliverTurn (persist report / persist manifest / deliver
-    // follow-up), a stop/kill landing during that delivery window would find
-    // only the now-detached per-turn flow context. The test inspects the run
-    // handle while delivery is deliberately held open.
+  it('leaves no interruptible child continuation while terminal delivery is in flight', async () => {
+    // Terminal delivery (persist report / persist manifest / deliver
+    // follow-up) runs after child finalization and lease release, so a
+    // stop/kill landing in that window finds nothing left to interrupt. The
+    // test inspects the run handle while delivery is deliberately held open.
     const childStreamId = uniqueStreamId('reregister-before-delivery');
     const parentStreamId = 'parent' as StreamTabId;
     const executionId = 'exec-reregister-before-delivery' as ExecutionId;
@@ -754,12 +750,9 @@ describe('childRunLoop E2E fixtures', () => {
       strategy,
     });
 
-    // Poll until delivery is mid-flight (blocked on our gate) — the exact
-    // window the review flagged as unprotected.
+    // Poll until delivery is mid-flight (blocked on our gate).
     await vi.waitFor(() => expect(deliveryGate).toBeDefined());
 
-    // Terminal delivery starts only after child finalization and lease release,
-    // so there is no longer a live child continuation to interrupt here.
     expect(handle.interrupt()).toBe(false);
 
     deliveryGate?.resolve();
@@ -1081,57 +1074,42 @@ describe('childRunLoop E2E fixtures', () => {
     expect(recordCost.mock.calls[0]?.[0]).toBeCloseTo(0.95);
   });
 
-  it('finalizes and wakes when the parent cost observer throws', async () => {
-    const strategy = createTerminalStrategy(
-      'Throwing cost observer',
-      async (ports) => {
-        ports.recordCost(0.4);
-        return { kind: 'terminal', value: 'done' };
+  it.each([
+    {
+      failure: 'throws',
+      recordCost: () => {
+        throw new Error('observer failed');
       },
-      () => 'delivered',
-    );
-    const recordCost = vi.fn(() => {
-      throw new Error('observer failed');
-    });
+    },
+    {
+      failure: 'rejects',
+      recordCost: () => Promise.reject(new Error('observer failed')),
+    },
+  ])(
+    'finalizes and wakes when the parent cost observer $failure',
+    async ({ failure, recordCost: observe }) => {
+      const strategy = createTerminalStrategy(
+        `${failure} cost observer`,
+        async (ports) => {
+          ports.recordCost(0.4);
+          return { kind: 'terminal', value: 'done' };
+        },
+        () => 'delivered',
+      );
+      const recordCost = vi.fn(observe);
 
-    const { completion } = startChildRunLoop({
-      childStreamId: uniqueStreamId('throwing-cost-observer'),
-      parentStreamId: 'parent' as StreamTabId,
-      executionId: 'exec-throwing-cost-observer' as ExecutionId,
-      agentName: 'fake',
-      strategy,
-      recordCost,
-    });
+      const { completion } = startChildRunLoop({
+        childStreamId: uniqueStreamId(`${failure}-cost-observer`),
+        parentStreamId: 'parent' as StreamTabId,
+        executionId: `exec-${failure}-cost-observer` as ExecutionId,
+        agentName: 'fake',
+        strategy,
+        recordCost,
+      });
 
-    await expect(completion).resolves.toBeUndefined();
-    expect(recordCost).toHaveBeenCalledOnce();
-    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledOnce();
-  });
-
-  it('finalizes and wakes when the parent cost observer rejects', async () => {
-    const strategy = createTerminalStrategy(
-      'Rejecting cost observer',
-      async (ports) => {
-        ports.recordCost(0.4);
-        return { kind: 'terminal', value: 'done' };
-      },
-      () => 'delivered',
-    );
-    const recordCost = vi.fn(() =>
-      Promise.reject(new Error('observer failed')),
-    );
-
-    const { completion } = startChildRunLoop({
-      childStreamId: uniqueStreamId('rejecting-cost-observer'),
-      parentStreamId: 'parent' as StreamTabId,
-      executionId: 'exec-rejecting-cost-observer' as ExecutionId,
-      agentName: 'fake',
-      strategy,
-      recordCost,
-    });
-
-    await expect(completion).resolves.toBeUndefined();
-    await vi.waitFor(() => expect(recordCost).toHaveBeenCalledOnce());
-    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledOnce();
-  });
+      await expect(completion).resolves.toBeUndefined();
+      await vi.waitFor(() => expect(recordCost).toHaveBeenCalledOnce());
+      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledOnce();
+    },
+  );
 });

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -37,7 +37,6 @@ import { seedStreamStatusForTest } from '@test/support/streamStatusTestUtils';
 
 // Local file imports
 import {
-  createRecordingHost,
   recordSessionEvents,
   runEventsOfType,
   sessionFactPayloads,
@@ -223,9 +222,7 @@ describe('executionRegistry', () => {
   });
 
   it('drains a background-bash AgentExecutionHandle on shutdown without disturbing a resumable agent execution (issue #8155)', () => {
-    // Regression for #8155: killBackgroundProcesses() previously only walked
-    // a since-deleted background-process handle class, missing a background
-    // `bash` run — which is registered as an AgentExecutionHandle (see
+    // A background `bash` run is registered as an AgentExecutionHandle (see
     // createChildStream in tools/bash.ts) with its OS-process kill reachable
     // only via the interrupt handler BashBackgroundSession attaches. The two
     // AgentExecutionHandles below are tracked concurrently, mirroring the real
@@ -317,11 +314,11 @@ describe('executionRegistry', () => {
   });
 
   it('falls back to the parked teardown when a suspended handle has no live interrupt (issue #7287)', async () => {
-    // Regression: a native subagent suspended at WAITING has already had its
-    // live interrupt context detached (runToolUseFlow's finally), while the
-    // handle stays tracked for resume. Before the fix, terminate() found no
-    // interrupt target and silently no-opped, leaving the handle stuck
-    // registered forever with no way to tear it down from a stop/kill.
+    // A native subagent suspended at WAITING has already had its live
+    // interrupt context detached (runToolUseFlow's finally), while the handle
+    // stays tracked for resume. With no interrupt target left, terminate()
+    // must fall back to the parked teardown rather than no-op and strand the
+    // handle registered forever.
     const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const executionId = 'exec-waiting-cleanup-kill-test';
@@ -353,16 +350,16 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('publishes the cancelled terminal result when killing a suspended WAITING handle (Bugbot: waiting kill omits trace result)', async () => {
-    // Regression: terminateWaitingHandle settles handle.result and the run's
-    // own (already-disposed, per runFlowWithLifecycle's finally) trace, but
-    // previously never told the owning session about the terminal event —
-    // trace/session-result-stream subscribers (session.onResult et al.) would
-    // silently miss a user-initiated stop of a suspended native subagent even
-    // though handle.result itself resolved correctly. `publishResult` is the
-    // callback SessionHandle injects (see SessionHandle.publishRunEvent) so
-    // this path can reach those subscribers directly, since the turn's own
-    // trace subscriptions are already torn down by the time a kill runs.
+  it('publishes the cancelled terminal result when killing a suspended WAITING handle', async () => {
+    // terminateWaitingHandle settles handle.result and the run's own
+    // (already-disposed, per runFlowWithLifecycle's finally) trace, and must
+    // also tell the owning session about the terminal event — otherwise
+    // session-result subscribers (session.onResult et al.) silently miss a
+    // user-initiated stop of a suspended native subagent even though
+    // handle.result itself resolved. `publishResult` is the callback
+    // SessionHandle injects (see SessionHandle.publishRunEvent) so this path
+    // reaches those subscribers directly, since the turn's own trace
+    // subscriptions are already torn down by the time a kill runs.
     const events = new SessionEventHub();
     const streamStatus = new StreamStatusMachine(events);
     const publishResult = vi.fn();
@@ -751,10 +748,10 @@ describe('executionRegistry', () => {
   });
 
   it('reports a failed kill for a tracked handle with neither an interrupt nor a suspension', () => {
-    // Guards the fallback above: a handle that never parked must still no-op
-    // exactly like before the fix — otherwise the fallback could spuriously
-    // tear down a handle mid-completion, in the narrow window between its own
-    // interrupt unregister and its own untrack.
+    // Guards the fallback above: a handle that never parked must still no-op,
+    // or the fallback could spuriously tear down a handle mid-completion, in
+    // the narrow window between its own interrupt unregister and its own
+    // untrack.
     const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const executionId = 'exec-no-cleanup-kill-test';
@@ -1446,7 +1443,6 @@ describe('executionRegistry', () => {
   });
 
   it('publishes parent links through the attached session event hub', () => {
-    const explicit = createRecordingHost();
     const events = new SessionEventHub();
     const seen: SessionEvent[] = [];
     const detach = events.subscribe((event) => seen.push(event));
@@ -1460,7 +1456,6 @@ describe('executionRegistry', () => {
 
       registry.track(handle);
 
-      expect(explicit.events).toEqual([]);
       expect(seen).toContainEqual({
         scope: 'session',
         event: {
@@ -1744,7 +1739,6 @@ describe('executionRegistry', () => {
   });
 
   it('publishes detach parent links through the attached session event hub', () => {
-    const explicit = createRecordingHost();
     const events = new SessionEventHub();
     const seen: SessionEvent[] = [];
     const detach = events.subscribe((event) => seen.push(event));
@@ -1761,7 +1755,6 @@ describe('executionRegistry', () => {
       registry.track(handle);
       registry.detachActiveChildren(parentStreamId);
 
-      expect(explicit.events).toEqual([]);
       expect(seen).toContainEqual({
         scope: 'session',
         event: {
@@ -1779,27 +1772,30 @@ describe('executionRegistry', () => {
   });
 
   it('detaches its stream-status subscription when disposed', () => {
-    const explicit = createRecordingHost();
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
-    const executionId = 'exec-dispose-runtime-host-test';
-    const parentStreamId = 'parent-dispose-runtime-host-test' as StreamTabId;
-    const childStreamId = 'child-dispose-runtime-host-test' as StreamTabId;
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
+    const executionId = 'exec-dispose-status-subscription';
+    const parentStreamId = 'parent-dispose-status-subscription' as StreamTabId;
+    const childStreamId = 'child-dispose-status-subscription' as StreamTabId;
 
-    const handle = createHandle(executionId, parentStreamId, childStreamId);
-
-    registry.track(handle);
+    registry.track(createHandle(executionId, parentStreamId, childStreamId));
     registry.dispose();
-    explicit.events.length = 0;
+    const recorded = recordSessionEvents(events);
 
-    streamStatus.transition(
-      childStreamId,
-      STREAM_PHASE.WAITING,
-      'restart-repair',
-    );
+    try {
+      streamStatus.transition(
+        childStreamId,
+        STREAM_PHASE.WAITING,
+        'restart-repair',
+      );
 
-    expect(
-      explicit.events.some((entry) => entry.event === 'updateActiveSubagents'),
-    ).toBe(false);
+      // Only the status machine's own fact remains; the registry contributes
+      // no roster emission once its subscription is gone.
+      expect(runEventsOfType(recorded.events, 'child.activity')).toEqual([]);
+      expect(sessionFactsOfType(recorded.events, 'status')).toHaveLength(1);
+    } finally {
+      recorded.detach();
+    }
   });
 });

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -66,7 +66,6 @@ vi.mock('@agent/implementations/flows/tooluse/runToolUseFlow', () => ({
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { ITool } from '@agent/core/tools/ToolTypes';
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
-import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import { resumeToolUseFromResumeData } from '@agent/runtime/executeAgent';
 import { ResumeAdmissionCancelledError } from '@agent/runtime/resumeAdmission';
 import {
@@ -205,9 +204,6 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
 
   it('resolves execution lineage before activating the resume stream', async () => {
     const storageError = new Error('execution metadata unavailable');
-    const interactions = {
-      emit: vi.fn(),
-    } as unknown as SessionHostInteractions;
     const snapshot = createToolUseResumeData({
       executionId: 'e8048' as ExecutionId,
       streamId: 'stream-8048' as StreamTabId,
@@ -244,7 +240,7 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
     expect(mocks.buildAgentLaunchContext).not.toHaveBeenCalled();
   });
 
-  it('preserves the historical diagnostic for a non-tool-use launch', async () => {
+  it('rejects a resumed launch that is not a tool-use agent', async () => {
     const resume = createToolUseResumeData();
     mocks.hasPersistedParent.mockResolvedValueOnce(false);
     mocks.buildAgentLaunchContext.mockResolvedValueOnce({
@@ -264,9 +260,6 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
   it('interrupts at flow attachment before substantive work starts', async () => {
     const executionId = 'e8049' as ExecutionId;
     const streamId = 'stream-8049' as StreamTabId;
-    const interactions = {
-      emit: vi.fn(),
-    } as unknown as SessionHostInteractions;
     const abortController = new AbortController();
     const context = {
       setting: { agentCategory: AgentCategory.ToolUse },

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -106,6 +106,29 @@ function testRetryModelCell(
   return { getClient: async () => ({}), rebind, route };
 }
 
+/** Every retry-node scenario's services; cases override what they drive. */
+function retryServices(
+  streamId: StreamTabId,
+  {
+    session,
+    signal,
+    ...overrides
+  }: Partial<TestRetryServices> & {
+    session?: SessionHandle;
+    signal?: AbortSignal;
+  } = {},
+): TestRetryServices {
+  return {
+    config: { model: 'openai:test' },
+    runScope: testRunScope(streamId, { session, signal }),
+    streamId,
+    interactions: new SessionHostInteractions(),
+    logger: noopTrace,
+    modelCell: testRetryModelCell(),
+    ...overrides,
+  };
+}
+
 class ExposedRetryNode extends RetryableInvocationNode<
   unknown,
   TestRetryServices
@@ -170,14 +193,13 @@ function createRetryNode(
       new StreamStatusMachine(),
     );
   const streamStatus = session.status;
-  const node = new ExposedRetryNode().setServices({
-    config: { model: 'copilot:sonnet46' },
-    runScope: testRunScope(streamId, { session }),
-    streamId,
-    interactions: new SessionHostInteractions(),
-    logger: noopTrace,
-    modelCell: testRetryModelCell(rebind, route),
-  });
+  const node = new ExposedRetryNode().setServices(
+    retryServices(streamId, {
+      config: { model: 'copilot:sonnet46' },
+      session,
+      modelCell: testRetryModelCell(rebind, route),
+    }),
+  );
   return { node, session, streamStatus, requestRetry };
 }
 
@@ -455,14 +477,13 @@ describe('RetryState', () => {
       }
     }
 
-    const node = new DiagnosticRetryNode().setServices({
-      config: { model: 'openai:test' },
-      runScope: testRunScope(streamId, { session }),
-      streamId,
-      interactions: new SessionHostInteractions(),
-      logger,
-      modelCell: testRetryModelCell(undefined, 'api-key'),
-    });
+    const node = new DiagnosticRetryNode().setServices(
+      retryServices(streamId, {
+        session,
+        logger,
+        modelCell: testRetryModelCell(undefined, 'api-key'),
+      }),
+    );
 
     try {
       seedStreamStatusForTest(session.status, streamId, STREAM_STATUS.RUNNING);
@@ -593,18 +614,17 @@ describe('RetryState', () => {
       }
     }
 
-    const node = new ClientPreparationRetryNode().setServices({
-      config: { model: 'openai:test' },
-      runScope: testRunScope(streamId, { session }),
-      streamId,
-      interactions: new SessionHostInteractions(),
-      logger,
-      modelCell: {
-        getClient,
-        rebind: async () => undefined,
-        route: 'api-key',
-      },
-    });
+    const node = new ClientPreparationRetryNode().setServices(
+      retryServices(streamId, {
+        session,
+        logger,
+        modelCell: {
+          getClient,
+          rebind: async () => undefined,
+          route: 'api-key',
+        },
+      }),
+    );
 
     try {
       seedStreamStatusForTest(session.status, streamId, STREAM_STATUS.RUNNING);
@@ -663,14 +683,13 @@ describe('RetryState', () => {
       }
     }
 
-    const node = new InvalidResultNode().setServices({
-      config: { model: 'openai:test' },
-      runScope: testRunScope(streamId, { session }),
-      streamId,
-      interactions: new SessionHostInteractions(),
-      logger,
-      modelCell: testRetryModelCell(undefined, 'api-key'),
-    });
+    const node = new InvalidResultNode().setServices(
+      retryServices(streamId, {
+        session,
+        logger,
+        modelCell: testRetryModelCell(undefined, 'api-key'),
+      }),
+    );
 
     try {
       await expect(node._exec(undefined)).resolves.toBe('');
@@ -763,14 +782,9 @@ describe('RetryState', () => {
 
     vi.useFakeTimers();
     try {
-      const node = new StatuslessServerErrorNode().setServices({
-        config: { model: 'openai:test' },
-        runScope: testRunScope('retry-delay' as StreamTabId),
-        streamId: 'retry-delay' as StreamTabId,
-        interactions: new SessionHostInteractions(),
-        logger: noopTrace,
-        modelCell: testRetryModelCell(),
-      });
+      const node = new StatuslessServerErrorNode().setServices(
+        retryServices('retry-delay' as StreamTabId),
+      );
       const retry = node._exec(undefined);
       const delayMs = RETRY_BACKOFF_SECONDS * 1000;
 
@@ -810,16 +824,11 @@ describe('RetryState', () => {
       // mid-backoff must abandon the pending retry instead of waking up to
       // another attempt.
       const runController = new AbortController();
-      const node = new InterruptibleBackoffNode().setServices({
-        config: { model: 'openai:test' },
-        runScope: testRunScope('retry-interrupt' as StreamTabId, {
+      const node = new InterruptibleBackoffNode().setServices(
+        retryServices('retry-interrupt' as StreamTabId, {
           signal: runController.signal,
         }),
-        streamId: 'retry-interrupt' as StreamTabId,
-        interactions: new SessionHostInteractions(),
-        logger: noopTrace,
-        modelCell: testRetryModelCell(),
-      });
+      );
       const retry = node._exec(undefined);
       await vi.advanceTimersByTimeAsync(0);
       expect(node.attempts).toBe(1);
@@ -908,14 +917,13 @@ describe('RetryState', () => {
       }
     }
 
-    const node = new ReactiveRecoveryNode().setServices({
-      config: { model: 'openai:test' },
-      runScope: testRunScope(streamId, { session }),
-      streamId,
-      interactions: new SessionHostInteractions(),
-      logger,
-      modelCell: testRetryModelCell(rebind, 'relay'),
-    });
+    const node = new ReactiveRecoveryNode().setServices(
+      retryServices(streamId, {
+        session,
+        logger,
+        modelCell: testRetryModelCell(rebind, 'relay'),
+      }),
+    );
 
     try {
       await expect(node._exec(undefined)).resolves.toBe('recovered');

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -198,12 +198,7 @@ describe('SessionHandle', () => {
     );
   });
 
-  it('defaultSession is a stable process-wide singleton (#7694: no separate module export to alias)', () => {
-    // No `Shared*`/`*Service` module export exists anymore — the process
-    // default's owners are installed together by the test composition root.
-    // What's left to verify is that repeated calls return the identical
-    // session (and therefore identical members), including its one owned
-    // trace-flusher set.
+  it('defaultSession is a stable process-wide singleton', () => {
     const first = defaultSession();
     const second = defaultSession();
     expect(second).toBe(first);

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -38,16 +38,15 @@ import { createTestSession } from '@test/support/sessionTestUtils';
 import type { GenericDiagnostic } from '@utils/diagnostics/diagnosticFormatting';
 
 /**
- * Parity pins for the coordinator fold (#7487): plan approval, proposal, and
- * retry requests now travel `session.interactions` directly. The behaviors the
- * deleted coordinator layer guaranteed — first-wins resolution, replacement
- * cancellation for duplicate request ids, and per-stream cleanup — are pinned
- * here against a real production port implementation (the desktop one; it has
- * no VS Code import graph) installed into a real `SessionHandle` slot.
+ * Plan approval, proposal, and retry requests travel `session.interactions`
+ * directly. First-wins resolution, replacement cancellation for duplicate
+ * request ids, and per-stream cleanup are pinned here against a real production
+ * port implementation (the desktop one; it has no VS Code import graph)
+ * installed into a real `SessionHandle` slot.
  */
 
 const streamId = 'stream:interactions-test' as StreamTabId;
-const plan: Plan = { objective: 'Fold the coordinator layer into the port.' };
+const plan: Plan = { objective: 'Route approvals through the session port.' };
 const proposal: AgentProposal = {
   agentCategory: AgentCategory.ToolUse,
   agent: 'reviewer',
@@ -482,7 +481,7 @@ describe('session.interactions immediate capabilities', () => {
   });
 });
 
-describe('session.interactions request bookkeeping (coordinator fold)', () => {
+describe('session.interactions request bookkeeping', () => {
   it('disposes an adapter offered after terminal slot disposal', () => {
     const session = createTestSession();
     const adapter = createControllablePlanAdapter();
@@ -927,8 +926,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
         goalEnabled: false,
       });
       expect(pending).toBeDefined();
-      // The port owns display and the activation emissions the coordinator
-      // layer used to duplicate.
+      // The port owns both the display and the activation emissions.
       expect(emitted).toContain('requestEnsureProgressView');
       expect(uiEvents).toContainEqual({
         event: 'show:planApproval',

--- a/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
@@ -34,7 +34,7 @@ vi.mock('@agent/storage', () => ({
   finalizeExecution: storageMocks.finalizeExecution,
 }));
 
-describe('session isolation (SDK Step 7d PR 2)', () => {
+describe('session isolation', () => {
   it('currentSession() resolves the active run context session, default otherwise', () => {
     const sessionB = createTestSession();
     try {

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -61,7 +61,17 @@ function setupResultCase(): {
   return { logger, results, ctx, streamStatus: ctx.runScope.session.status };
 }
 
-describe('terminal result event (SDK Step 7d PR 6)', () => {
+/** The completed tool-use result a flow returns for the given run. */
+function completedRun(ctx: AgentLaunchContext) {
+  return {
+    category: 'toolUse',
+    outcome: RUN_OUTCOME.COMPLETED,
+    executionId: ctx.runScope.executionId,
+    streamId: ctx.runScope.streamId,
+  } as const;
+}
+
+describe('terminal result event', () => {
   setupPlatform({
     globalState: { [GlobalStateKey.ONBOARDING_FIRST_RUN_DONE]: true },
   });
@@ -69,12 +79,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   it('emits exactly one completed result on a successful run', async () => {
     const { ctx, streamStatus, results } = setupResultCase();
     try {
-      await runFlowWithLifecycle(ctx, async () => ({
-        category: 'toolUse',
-        outcome: RUN_OUTCOME.COMPLETED,
-        executionId: ctx.runScope.executionId,
-        streamId: ctx.runScope.streamId,
-      }));
+      await runFlowWithLifecycle(ctx, async () => completedRun(ctx));
       expect(results).toHaveLength(1);
       expect(results[0]).toMatchObject({
         type: 'result',
@@ -104,12 +109,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
     });
     try {
       await expect(
-        runFlowWithLifecycle(ctx, async () => ({
-          category: 'toolUse',
-          outcome: RUN_OUTCOME.COMPLETED,
-          executionId: ctx.runScope.executionId,
-          streamId: ctx.runScope.streamId,
-        })),
+        runFlowWithLifecycle(ctx, async () => completedRun(ctx)),
       ).resolves.toMatchObject({ outcome: RUN_OUTCOME.COMPLETED });
       expect(results).toHaveLength(1);
       expect(results[0].outcome).toBe('completed');
@@ -127,12 +127,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
 
     try {
       await expect(
-        runFlowWithLifecycle(ctx, async () => ({
-          category: 'toolUse',
-          outcome: RUN_OUTCOME.COMPLETED,
-          executionId: ctx.runScope.executionId,
-          streamId: ctx.runScope.streamId,
-        })),
+        runFlowWithLifecycle(ctx, async () => completedRun(ctx)),
       ).resolves.toMatchObject({ outcome: RUN_OUTCOME.COMPLETED });
 
       expect(results).toHaveLength(1);
@@ -145,24 +140,15 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
     }
   });
 
-  it('exposes the per-run handle via onRun and settles handle.result (F-2)', async () => {
+  it('exposes the per-run handle via onRun and settles handle.result', async () => {
     const { logger, ctx, streamStatus } = setupResultCase();
     let handle: AgentRunHandle | undefined;
     try {
-      await runFlowWithLifecycle(
-        ctx,
-        async () => ({
-          category: 'toolUse',
-          outcome: RUN_OUTCOME.COMPLETED,
-          executionId: ctx.runScope.executionId,
-          streamId: ctx.runScope.streamId,
-        }),
-        {
-          onRun: (h) => {
-            handle = h;
-          },
+      await runFlowWithLifecycle(ctx, async () => completedRun(ctx), {
+        onRun: (h) => {
+          handle = h;
         },
-      );
+      });
       expect(handle).toBeDefined();
       // The handle carries the run's trace channel for run-scoped subscribers.
       expect(handle?.trace).toBe(logger);
@@ -181,20 +167,11 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
     const { ctx, streamStatus, results } = setupResultCase();
     try {
       await expect(
-        runFlowWithLifecycle(
-          ctx,
-          async () => ({
-            category: 'toolUse',
-            outcome: RUN_OUTCOME.COMPLETED,
-            executionId: ctx.runScope.executionId,
-            streamId: ctx.runScope.streamId,
-          }),
-          {
-            onRun: () => {
-              throw new Error('onRun boom');
-            },
+        runFlowWithLifecycle(ctx, async () => completedRun(ctx), {
+          onRun: () => {
+            throw new Error('onRun boom');
           },
-        ),
+        }),
       ).resolves.toMatchObject({ outcome: RUN_OUTCOME.COMPLETED });
 
       expect(results).toHaveLength(1);
@@ -212,20 +189,11 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
     const { ctx, streamStatus, results } = setupResultCase();
     try {
       await expect(
-        runFlowWithLifecycle(
-          ctx,
-          async () => ({
-            category: 'toolUse',
-            outcome: RUN_OUTCOME.COMPLETED,
-            executionId: ctx.runScope.executionId,
-            streamId: ctx.runScope.streamId,
-          }),
-          {
-            onRun: async () => {
-              throw new Error('onRun async boom');
-            },
+        runFlowWithLifecycle(ctx, async () => completedRun(ctx), {
+          onRun: async () => {
+            throw new Error('onRun async boom');
           },
-        ),
+        }),
       ).resolves.toMatchObject({ outcome: RUN_OUTCOME.COMPLETED });
       await Promise.resolve();
 
@@ -398,16 +366,9 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
     const detach = session.attachRunTrace(logger, ctx.runScope.streamId);
     session.onResult(onResult);
     try {
-      await runFlowWithLifecycle(
-        ctx,
-        async () => ({
-          category: 'toolUse',
-          outcome: RUN_OUTCOME.COMPLETED,
-          executionId: ctx.runScope.executionId,
-          streamId: ctx.runScope.streamId,
-        }),
-        { isSubagent: true },
-      );
+      await runFlowWithLifecycle(ctx, async () => completedRun(ctx), {
+        isSubagent: true,
+      });
       expect(onResult).toHaveBeenCalledOnce();
       expect(onResult.mock.calls[0][0]).toMatchObject({
         type: 'result',

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -5,7 +5,7 @@ import '@test/support/defaultSessionTestSetup';
 import { describe, expect, it } from 'vitest';
 
 // Local imports
-import { SessionHandle, defaultSession } from '@agent/runtime/SessionHandle';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { MESSAGE_TYPES, type Plan, type StreamTabId } from '@shared/schemas';
 import { testExecutionHandle } from '@test/support/executionHandleFixtures';
@@ -18,7 +18,7 @@ import { createRecordingHost } from '../progressTestUtils';
 
 const plan: Plan = { objective: 'Scope session-owned state.' };
 
-describe('session-scoped trace flushers (SDK Step 7d PR 3)', () => {
+describe('session-scoped trace flushers', () => {
   it('registers the flush in the run session set, not the default set', () => {
     const store = StreamLogStore.ephemeral('test');
     const sessionB = createTestSession();
@@ -69,7 +69,7 @@ describe('session-scoped trace flushers (SDK Step 7d PR 3)', () => {
   });
 });
 
-describe('session-owned transcripts and follow-up queues (Stage 3a)', () => {
+describe('session-owned transcripts and follow-up queues', () => {
   it("writes run trace entries to the launching session's transcript store only", () => {
     const launching = createTestSession();
     const sibling = createTestSession();
@@ -122,7 +122,7 @@ describe('session-owned transcripts and follow-up queues (Stage 3a)', () => {
   });
 });
 
-describe('cleanupAllApprovals scope (SDK Step 7d PR 3)', () => {
+describe('cleanupAllApprovals scope', () => {
   it("clears only the given session's pending interactions", async () => {
     const a = createTestSession();
     const b = createTestSession();
@@ -161,7 +161,7 @@ describe('cleanupAllApprovals scope (SDK Step 7d PR 3)', () => {
   });
 });
 
-describe('sendFollowUp host-path session routing (SDK Step 7d PR 4)', () => {
+describe('sendFollowUp host-path session routing', () => {
   it('resolves the follow-up target against the passed session, not the process default', async () => {
     const processSession = createTestSession();
     const parentStream = 'stream:fu-parent' as StreamTabId;

--- a/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
@@ -44,10 +44,9 @@ function createDeferredResumability(): DeferredResumability {
 }
 
 /**
- * `SessionHandle.repairWaitingIfResumable` is the re-homed lazy WAITING repair
- * that used to be a private helper in the VS Code `texra.sendFollowUp` command
- * (stage 7 item 1). It probes the same `deriveResumability` the startup pass
- * uses, so a follow-up for a resumable execution reaches the resume queue
+ * `SessionHandle.repairWaitingIfResumable` is the lazy WAITING repair every
+ * host follow-up path runs. It probes the same `deriveResumability` the startup
+ * pass uses, so a follow-up for a resumable execution reaches the resume queue
  * rather than `no_session`.
  */
 describe('SessionHandle.repairWaitingIfResumable', () => {
@@ -58,21 +57,25 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
   let streamId: StreamTabId;
   let executionId: ExecutionId;
 
+  function ownStream(owner: ExecutionId): void {
+    session.snapshots.setRunDescriptor(
+      buildRunDescriptor({
+        streamId,
+        executionId: owner,
+        agent: 'assistant',
+        category: AgentCategory.ToolUse,
+        kind: 'agent',
+      }),
+    );
+  }
+
   beforeEach(() => {
     const n = caseCounter++;
     resumabilityMocks.deriveResumability.mockReset();
     session = createTestSession();
     streamId = `stream:waiting-repair-${n}` as StreamTabId;
     executionId = `b${n.toString(16).padStart(5, '0')}` as ExecutionId;
-    session.snapshots.setRunDescriptor(
-      buildRunDescriptor({
-        streamId,
-        executionId,
-        agent: 'assistant',
-        category: AgentCategory.ToolUse,
-        kind: 'agent',
-      }),
-    );
+    ownStream(executionId);
   });
 
   function seedCancelled(): void {
@@ -268,15 +271,7 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
 
     const repair = session.repairWaitingIfResumable(streamId);
     const replacementExecutionId = `c${executionId.slice(1)}` as ExecutionId;
-    session.snapshots.setRunDescriptor(
-      buildRunDescriptor({
-        streamId,
-        executionId: replacementExecutionId,
-        agent: 'assistant',
-        category: AgentCategory.ToolUse,
-        kind: 'agent',
-      }),
-    );
+    ownStream(replacementExecutionId);
     deferred.resolve();
 
     await expect(repair).resolves.toBe(false);
@@ -299,15 +294,7 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
 
     const original = session.repairWaitingIfResumable(streamId);
     const replacementExecutionId = `d${executionId.slice(1)}` as ExecutionId;
-    session.snapshots.setRunDescriptor(
-      buildRunDescriptor({
-        streamId,
-        executionId: replacementExecutionId,
-        agent: 'assistant',
-        category: AgentCategory.ToolUse,
-        kind: 'agent',
-      }),
-    );
+    ownStream(replacementExecutionId);
     const replacement = session.repairWaitingIfResumable(streamId);
 
     expect(resumabilityMocks.deriveResumability).toHaveBeenNthCalledWith(

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -151,19 +151,18 @@ describe('StreamStatusMachine', () => {
     ]);
   });
 
-  it('terminalizes waiting streams through resume then lifecycle', () => {
+  it.each([
+    STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    STREAM_TRANSITION_CAUSE.RESTART_REPAIR,
+  ])('terminalizes waiting streams through resume then %s', (cause) => {
     const { machine, statusEvents, streamId } = setupMachine(
-      'stream-status-waiting-terminal-repair',
+      `stream-status-waiting-terminal-${cause}`,
     );
 
     seedStreamStatusForTest(machine, streamId, STREAM_PHASE.WAITING);
 
     expect(
-      machine.transitionToTerminal(
-        streamId,
-        STREAM_PHASE.FAILED,
-        STREAM_TRANSITION_CAUSE.LIFECYCLE,
-      ),
+      machine.transitionToTerminal(streamId, STREAM_PHASE.FAILED, cause),
     ).toBe(true);
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.FAILED);
@@ -180,41 +179,7 @@ describe('StreamStatusMachine', () => {
         type: 'status',
         phase: STREAM_PHASE.FAILED,
         previousPhase: STREAM_PHASE.RUNNING,
-        cause: 'lifecycle',
-      },
-    ]);
-  });
-
-  it('terminalizes waiting streams with the restart-repair cause', () => {
-    const { machine, statusEvents, streamId } = setupMachine(
-      'stream-status-waiting-terminal-restart-repair',
-    );
-
-    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.WAITING);
-
-    expect(
-      machine.transitionToTerminal(
-        streamId,
-        STREAM_PHASE.FAILED,
-        STREAM_TRANSITION_CAUSE.RESTART_REPAIR,
-      ),
-    ).toBe(true);
-
-    expect(machine.get(streamId)).toBe(STREAM_PHASE.FAILED);
-    expect(statusEvents()).toEqual([
-      {
-        streamId,
-        type: 'status',
-        phase: STREAM_PHASE.RUNNING,
-        previousPhase: STREAM_PHASE.WAITING,
-        cause: 'resume',
-      },
-      {
-        streamId,
-        type: 'status',
-        phase: STREAM_PHASE.FAILED,
-        previousPhase: STREAM_PHASE.RUNNING,
-        cause: 'restart-repair',
+        cause,
       },
     ]);
   });
@@ -442,10 +407,7 @@ describe('StreamStatusMachine', () => {
 
   // One rail: the session fact is published by the machine itself, so a
   // trace-owned transition (run start, terminal, manual-retry wait, restart
-  // repair) reaches every projector without the caller passing a hub. Before
-  // this became unconditional, those transitions were visible only as
-  // run-scope `status` trace events, which is why each projector carried its
-  // own duplicate trace arm.
+  // repair) reaches every projector without the caller passing a hub.
   it('publishes the session fact when a trace bridge is present', () => {
     const { machine, statusEvents, streamId } = setupMachine(
       'stream-status-single-rail',

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -51,10 +51,9 @@ function expectParseWarning(
   );
 }
 
-// Regression for the executionKvFiles leak fix: isReservedKvKeyName is now
-// the single owner of the reserved single-value-key + `child-` prefix
-// vocabulary, exported so callers walking a run directory (e.g.
-// `src/tools/executions/executionKvFiles.ts`) recognize it without
+// `isReservedKvKeyName` is the single owner of the reserved single-value-key
+// and `child-` prefix vocabulary, exported so callers walking a run directory
+// (e.g. `src/tools/executions/executionKvFiles.ts`) recognize it without
 // re-deriving their own copy.
 describe('isReservedKvKeyName', () => {
   it.each([
@@ -317,11 +316,10 @@ describe('ExecutionKVStore meta read shims', () => {
     });
   });
 
-  // `meta.outcome` is the only writer of "how did this run end". These pin the
-  // case a repair pass used to fix up with a second write after the fact: a run
-  // that ends after its last turn wrote an interim envelope (interrupted
-  // between turns, stopped while suspended, failed by restart repair) now reads
-  // back through the owning fact instead.
+  // `meta.outcome` is the only writer of "how did this run end". A run that
+  // ends after its last turn wrote an interim envelope (interrupted between
+  // turns, stopped while suspended, failed by restart repair) reads back
+  // through that owning fact.
   it('supersedes an interim result outcome with the durable cancelled outcome', async () => {
     const id = 'terminal-outcome-supersedes-interim' as ExecutionId;
     const interim = {
@@ -700,7 +698,7 @@ describe('ExecutionKVStore meta read shims', () => {
   });
 });
 
-describe('ExecutionKVStore loud typed reads (#6966 bullet 5)', () => {
+describe('ExecutionKVStore loud typed reads', () => {
   it('warns when config is malformed instead of silently returning null', async () => {
     const id = 'bad-config' as ExecutionId;
     const warnSpy = mockWarn();

--- a/src/test-kernel/agent/toolUseRoundTestUtils.ts
+++ b/src/test-kernel/agent/toolUseRoundTestUtils.ts
@@ -10,9 +10,9 @@ import { createRunTrace, StreamLogStore } from '@transcript';
 import { testRunScope } from './progressTestUtils';
 
 /**
- * Fields identical across every `ToolUseRoundServices` fixture -- only
- * `modelHandler`, `session`, `setting`, and `toolRegistry` vary per scenario,
- * so those stay inline at each call site.
+ * Fields identical across every `ToolUseRoundServices` fixture. `modelCell`,
+ * `session`, `setting`, and `toolRegistry` vary per scenario, so those stay
+ * inline at each call site.
  */
 export function baseRoundServices(
   traceLabel: string,
@@ -35,7 +35,7 @@ export function baseRoundServices(
 }
 
 /**
- * The model-handler surface a full round drives -- response extraction,
+ * The model-handler surface a full round drives: response extraction,
  * server-tool data, routing, streaming. Scenarios override only the members
  * whose behavior they exercise.
  */

--- a/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
+++ b/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
@@ -116,6 +116,10 @@ function createExpiredProvider(
   });
 }
 
+function createUnexpiredProvider(): ReturnType<typeof createProvider> {
+  return createProvider({ expiresAt: Date.now() + 60_000 });
+}
+
 describe('SupabaseAuthProvider expired-session refresh', () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -148,9 +152,7 @@ describe('SupabaseAuthProvider expired-session refresh', () => {
       error: { status: 503 },
     });
     const { provider, clearSessionIfCurrent, showSignInPrompt } =
-      createProvider({
-        expiresAt: Date.now() + 60_000,
-      });
+      createUnexpiredProvider();
 
     await expect(provider.getSessions()).resolves.toEqual([]);
 
@@ -164,9 +166,7 @@ describe('SupabaseAuthProvider expired-session refresh', () => {
       error: null,
     });
     const { provider, clearSessionIfCurrent, showSignInPrompt } =
-      createProvider({
-        expiresAt: Date.now() + 60_000,
-      });
+      createUnexpiredProvider();
 
     await expect(provider.getSessions()).resolves.toEqual([]);
 
@@ -180,9 +180,7 @@ describe('SupabaseAuthProvider expired-session refresh', () => {
       error: { status: 401 },
     });
     const { provider, clearSessionIfCurrent, showSignInPrompt } =
-      createProvider({
-        expiresAt: Date.now() + 60_000,
-      });
+      createUnexpiredProvider();
 
     await expect(provider.getSessions()).resolves.toEqual([]);
 
@@ -196,9 +194,7 @@ describe('SupabaseAuthProvider expired-session refresh', () => {
       error: { status: 401 },
     });
     const { provider, clearSessionIfCurrent, showSignInPrompt } =
-      createProvider({
-        expiresAt: Date.now() + 60_000,
-      });
+      createUnexpiredProvider();
     clearSessionIfCurrent.mockResolvedValueOnce(false);
 
     await expect(provider.getSessions()).resolves.toEqual([]);
@@ -211,9 +207,7 @@ describe('SupabaseAuthProvider expired-session refresh', () => {
 
   it('does not clear a session that revalidates as authenticated', async () => {
     const { provider, clearSessionIfCurrent, getStoredSessionState } =
-      createProvider({
-        expiresAt: Date.now() + 60_000,
-      });
+      createUnexpiredProvider();
     getStoredSessionState.mockResolvedValueOnce('authenticated');
 
     await expect(provider.clearStoredSession()).resolves.toBe(false);
@@ -230,9 +224,7 @@ describe('SupabaseAuthProvider model availability', () => {
   // Listeners recompute model options from the session-change event, so an
   // event published ahead of the invalidation serves the stale option list.
   it('invalidates model availability before publishing a new session', async () => {
-    const { provider, session, fire } = createProvider({
-      expiresAt: Date.now() + 60_000,
-    });
+    const { provider, session, fire } = createUnexpiredProvider();
 
     // The login path stores through a private method; no public entry point
     // reaches it without a live OAuth round trip.
@@ -249,9 +241,7 @@ describe('SupabaseAuthProvider model availability', () => {
   });
 
   it('invalidates model availability before publishing a sign-out', async () => {
-    const { provider, session, fire } = createProvider({
-      expiresAt: Date.now() + 60_000,
-    });
+    const { provider, session, fire } = createUnexpiredProvider();
 
     await provider.removeSession(session.id);
 
@@ -266,9 +256,7 @@ describe('SupabaseAuthProvider model availability', () => {
   // scope, on every device. Sign-out clears local storage only, as on desktop
   // and the CLI.
   it('clears the stored session without a remote revocation', async () => {
-    const { provider, session } = createProvider({
-      expiresAt: Date.now() + 60_000,
-    });
+    const { provider, session } = createUnexpiredProvider();
     const coordinator = (
       provider as unknown as {
         sessionCoordinator: { clearSession: ReturnType<typeof vi.fn> };

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -166,8 +166,7 @@ describe('CLI agents run command', () => {
       response: 'Correct.',
       workingDirectory: '/tmp/project',
     });
-    // The v0.41 cut removed the three deprecated status projections; `outcome`
-    // is the only terminal fact the headless JSON publishes.
+    // `outcome` is the only terminal fact the headless JSON publishes.
     expect(Object.keys(emission?.json ?? {})).toEqual([
       'category',
       'executionId',

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -542,8 +542,8 @@ describe('CLI root argument routing', () => {
   it('rejects a literal --input file that does not exist', async () => {
     await withTempDir('texra-cli-inputs-', async (root) => {
       const missing = path.join(root, 'no-such.tex');
-      // Pure path (no glob magic, not a directory) — previously this was
-      // returned as-is and the workflow ran until the agent ENOENT'd.
+      // A pure path (no glob magic, not a directory) is validated here rather
+      // than handed to the workflow to fail on later with a raw ENOENT.
       await expect(expandWorkflowInputSpecs([missing], root)).rejects.toThrow(
         /--input: file not found/,
       );
@@ -766,10 +766,9 @@ describe('CLI root argument routing', () => {
   });
 
   it('expands a glob --context spec the same way --input does', async () => {
-    // `texra run -c '<glob>'` previously stuffed the literal glob string into
-    // the AgentConfig and failed late with raw ENOENT (exit 1). Routing
-    // through expandWorkflowInputSpecs gives it the same expansion semantics
-    // as `--input` (and surfaces missing-path errors as Usage / exit 2).
+    // `texra run -c '<glob>'` routes through expandWorkflowInputSpecs, so it
+    // has the same expansion semantics as `--input` and surfaces missing-path
+    // errors as Usage (exit 2) instead of a late raw ENOENT.
     await withTempDir('texra-cli-ctx-', async (root) => {
       await fs.writeFile(path.join(root, 'a.bib'), 'a');
       await fs.writeFile(path.join(root, 'b.bib'), 'b');

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -369,13 +369,6 @@ const resumingStatusPayload: RunStatusProjectionPayload = {
   substate: STREAM_SUBSTATE.RESUMING,
 };
 
-function emitSessionStatus(
-  events: SessionEventHub,
-  payload: RunStatusProjectionPayload,
-): void {
-  events.emit(statusFact(payload));
-}
-
 describe('attachCliSessionProgressProjection', () => {
   it('projects every public NDJSON progress event with its typed payload', () => {
     const cases = Object.entries(PROGRESS_PROJECTION_CASES);
@@ -397,26 +390,18 @@ describe('attachCliSessionProgressProjection', () => {
 
   it('writes retained session facts as public NDJSON progress records', () => {
     withProjection(({ events, writeRecord, detach }) => {
-      events.emit({
-        scope: 'session',
-        event: {
-          type: 'setActiveStream',
-          payload: { streamId },
-        },
-      });
+      events.emit(sessionFact('setActiveStream', { streamId }));
 
       expect(writeRecord).toHaveBeenCalledWith(
         progressRecord('setActiveStream', { streamId }),
       );
 
       detach();
-      events.emit({
-        scope: 'session',
-        event: {
-          type: 'setActiveStream',
-          payload: { streamId: 'stream:after-detach' as StreamTabId },
-        },
-      });
+      events.emit(
+        sessionFact('setActiveStream', {
+          streamId: 'stream:after-detach' as StreamTabId,
+        }),
+      );
 
       expect(writeRecord).toHaveBeenCalledTimes(1);
     });
@@ -424,13 +409,7 @@ describe('attachCliSessionProgressProjection', () => {
 
   it('keeps followUpSent session-local', () => {
     withProjection(({ events, writeRecord }) => {
-      events.emit({
-        scope: 'session',
-        event: {
-          type: 'followUpSent',
-          payload: { streamId },
-        },
-      });
+      events.emit(sessionFact('followUpSent', { streamId }));
 
       expect(writeRecord).not.toHaveBeenCalled();
     });
@@ -438,7 +417,7 @@ describe('attachCliSessionProgressProjection', () => {
 
   it('projects status facts to the public stream-status event', () => {
     withProjection(({ events, writeRecord }) => {
-      emitSessionStatus(events, resumingStatusPayload);
+      events.emit(statusFact(resumingStatusPayload));
 
       expect(writeRecord).toHaveBeenCalledTimes(1);
       expect(writeRecord).toHaveBeenCalledWith(
@@ -449,9 +428,9 @@ describe('attachCliSessionProgressProjection', () => {
 
   it('ignores run-scope status trace events', () => {
     withProjection(({ events, writeRecord }) => {
-      // `status` is no longer a projected run fact: `StreamStatusMachine` owns
-      // the canonical session-fact rail, so a stray run-scope status event
-      // must never reach the public NDJSON stream.
+      // `StreamStatusMachine` owns the canonical session-fact rail, so a
+      // stray run-scope status event must never reach the public NDJSON
+      // stream.
       events.emit({
         scope: 'run',
         streamId,
@@ -476,8 +455,8 @@ describe('attachCliSessionProgressProjection', () => {
     };
 
     withProjection(({ events, writeRecord }) => {
-      emitSessionStatus(events, resumingStatusPayload);
-      emitSessionStatus(events, startingPayload);
+      events.emit(statusFact(resumingStatusPayload));
+      events.emit(statusFact(startingPayload));
 
       expect(writeRecord).toHaveBeenCalledTimes(2);
       expect(writeRecord).toHaveBeenNthCalledWith(

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -242,11 +242,8 @@ describe('CLI conversation transcript splitting', () => {
     }
   });
 
-  // Regression: pending tool rows must render after preceding live
-  // assistant text, not before. The previous renderer used a separate
-  // `pendingTools` bucket that always sat above the live region, so a
-  // model emitting prose before a tool call appeared as
-  // user → tool → assistant text on screen.
+  // One pending bucket in stream order: a model that emits prose before a
+  // tool call must render as assistant text then tool row, not the reverse.
   it('keeps pending entries in stream order so tool rows trail prior text', () => {
     const user = entry('u1', 'user', 'do a thing', true);
     const assistant = entry('a1', 'assistant', 'sure, running…', false);
@@ -1352,13 +1349,6 @@ function sliceWithEntries(
   return { ...emptySlice(streamId), entries, ...init };
 }
 
-function streamsFromEntries(
-  streamId: StreamTabId,
-  entries: readonly ConversationEntry[],
-): ReadonlyMap<StreamTabId, StreamSlice> {
-  return new Map([[streamId, sliceWithEntries(streamId, entries)]]);
-}
-
 /** Static scrollback for a single-stream transcript of `entries`. */
 function staticItems(
   entries: readonly ConversationEntry[],
@@ -1375,7 +1365,7 @@ function staticItems(
     meta: SESSION_META,
     printRequests: options.printRequests,
     scrollbackStreamId: STREAM_ID,
-    streams: streamsFromEntries(STREAM_ID, entries),
+    streams: new Map([[STREAM_ID, sliceWithEntries(STREAM_ID, entries)]]),
     width: options.width,
   });
 }

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -1576,8 +1576,8 @@ describe('CLI history runtime', () => {
 
         expect(exitCode).toBe(CliExitCode.Success);
         expect(stdout).toBe(JSON.stringify(trace));
-        // Must not contain the old literal placeholder tokens, which read like
-        // an unresolved template rather than instructions.
+        // The instruction names concrete paths; literal placeholder tokens
+        // would read as an unresolved template.
         expect(stderr).not.toContain('<redirected-path>');
         expect(stderr).not.toContain('<relative-path-to-the-redirected-file>');
         expect(stderr).toContain(

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -284,7 +284,7 @@ describe('CLI multi-agent presets', () => {
     );
   });
 
-  it('formats explicit non-delegating team roots without old fallback wording', () => {
+  it('names an explicit non-delegating team root instead of saying it cannot delegate', () => {
     const preset = findPreset('mathematician');
     const plan = planRun(preset, {
       toolUseAgents: [agent('lean', AgentCategory.ToolUse)],

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -279,8 +279,7 @@ describe('CLI multi-agent run command', () => {
       response: 'The proof is correct.',
       workingDirectory: '/tmp/project',
     });
-    // The v0.41 cut removed the three deprecated status projections; `outcome`
-    // is the only terminal fact the headless JSON publishes.
+    // `outcome` is the only terminal fact the headless JSON publishes.
     expect(Object.keys(emission?.json.result ?? {})).toEqual([
       'category',
       'executionId',
@@ -309,7 +308,8 @@ describe('CLI multi-agent run command', () => {
     expect(mocks.loadAgents).toHaveBeenNthCalledWith(1, {
       includeRemote: false,
     });
-    // The second call is the remote-inclusive reload: `loadAgents()`.
+    // The remote-inclusive reload goes through `refresh()`, not a second
+    // `loadAgents()`.
     expect(mocks.refreshAgents).toHaveBeenCalledWith({ includeRemote: true });
     expect(mocks.planCliMultiAgentPresetRun).toHaveBeenCalledTimes(2);
   });

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -605,25 +605,6 @@ describe('executeCliRequest', () => {
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
-  it('does not finalize a classified run failure a second time', async () => {
-    const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const request = baseRequest();
-    mocks.runAgent.mockImplementationOnce(
-      async (_request: unknown, options: { readonly onRun?: () => void }) => {
-        options.onRun?.();
-        throw new AgentError('provider boom');
-      },
-    );
-
-    await expect(executeCliRequest(request, cliContext())).resolves.toEqual({
-      ok: false,
-      exitCode: CliExitCode.AgentError,
-    });
-
-    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
-    expect(mocks.close).toHaveBeenCalledTimes(1);
-  });
-
   it('keeps a completed run terminal status when wrap cleanup fails after invoke succeeded (#7863)', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = baseRequest();
@@ -650,7 +631,7 @@ describe('executeCliRequest', () => {
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
-  it('resolves a classified run failure to a non-zero exit code without rethrowing', async () => {
+  it('resolves a classified run failure to a non-zero exit code without rethrowing or finalizing again', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = baseRequest();
     mocks.runAgent.mockImplementationOnce(

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -224,8 +224,7 @@ function handleStreamStatus(
   streamId: string,
   status: StreamPhase,
 ): void {
-  // Status reaches the renderer on the session-fact rail only; the renderer
-  // no longer reads run-scope `status` trace events.
+  // Status reaches the renderer on the session-fact rail only.
   renderer?.handleSessionEvent({
     scope: 'session',
     event: {
@@ -734,7 +733,7 @@ describe('CLI run progress renderer', () => {
     expect(output).not.toContain('\r\x1b[2K');
   });
 
-  it('deduplicates matching run and session stream-status facts', async () => {
+  it('writes one status line when a run-scope status fact accompanies the session fact', async () => {
     const output = await captureStreamWrites(process.stderr, async () => {
       const events = new SessionEventHub();
       const host = createCliRuntimeHost(

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -165,8 +165,8 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('/api api');
     expect(display.bindings).toContain('/model models');
     expect(display.bindings).not.toContain('/agent agents');
-    // Ctrl-J newline must be visible — the binding exists in BaseTextInput
-    // (see #4399) but used to be discoverable only via source diving.
+    // Ctrl-J newline must stay advertised: the binding lives in BaseTextInput
+    // and the status row is its only discoverable surface.
     expect(display.bindings).toContain('Ctrl-J newline');
     expect(display.bindings).not.toContain('Shift-Enter newline');
     expect(display.bindings).toContain('Ctrl-C exit');

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -713,8 +713,8 @@ describe('CLI child list display model', () => {
 
   // A `◆ {phase}` header opens a group and nothing closes one, so a row that
   // carries no phase must never be painted after one — an `agent()` call issued
-  // outside any `phase()`, or a roster row from before the field existed, would
-  // otherwise read as belonging to the phase above it. Driven through
+  // outside any `phase()` would otherwise read as belonging to the phase above
+  // it. Driven through
   // `streamTreeViews`, the one owner of row order, rather than a hand-ordered
   // `sessions` array, so it guards the production path.
   it('never renders a phase-less row beneath a phase header', async () => {

--- a/src/test-kernel/cli/TerminalCleanup.vitest.mts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.mts
@@ -51,8 +51,7 @@ afterEach(() => {
 });
 
 /** Put one real approval in the queue: the title reads the queue's own
- *  projection, so the test drives it through the queue rather than writing a
- *  status value the queue no longer stores. */
+ *  projection, so the test has to drive it through the queue. */
 function queueTitleApproval(streamId: string): void {
   void enqueueApproval({
     kind: 'bash',

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -35,11 +35,6 @@ function toolUse(
   };
 }
 
-function patchRows(entry: NormalizedToolUse): readonly string[] {
-  // The patch block follows the single header row in the display lines.
-  return toolUseDisplayLines(entry).slice(1);
-}
-
 async function renderBoundedTool(
   entry: NormalizedToolUse,
   maxRows: number,
@@ -421,27 +416,9 @@ describe('CLI tool display lines', () => {
 });
 
 describe('ToolUseRow edit patch rendering', () => {
-  it('renders an Edit input as an inline patch preview', () => {
-    const rows = patchRows(
-      toolUse('Edit', {
-        path: 'paper.tex',
-        old_string: 'We use a CNN.\n',
-        new_string: 'We use a transformer.\n',
-      }),
-    );
-
-    expect(rows).toMatchInlineSnapshot(`
-      [
-        "⎿ paper.tex",
-        "  @@ -1,1 +1,1 @@",
-        "  -We use a CNN.",
-        "  +We use a transformer.",
-      ]
-    `);
-  });
-
   it('renders MultiEdit edits as patch previews for the target file', () => {
-    const rows = patchRows(
+    // The patch block follows the single header row in the display lines.
+    const rows = toolUseDisplayLines(
       toolUse('MultiEdit', {
         file_path: 'paper.tex',
         edits: [
@@ -455,7 +432,7 @@ describe('ToolUseRow edit patch rendering', () => {
           },
         ],
       }),
-    );
+    ).slice(1);
 
     expect(rows).toMatchInlineSnapshot(`
       [

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -213,6 +213,19 @@ function requestSameStreamRetry(
   );
 }
 
+/** Transient retry with no relay or subscription exhaustion behind it. */
+function ordinaryRetry(
+  streamId: string,
+  requestId: string = streamId,
+): RetryPermission {
+  return {
+    requestId,
+    streamId,
+    operation: 'model request',
+    errorMessage: 'Temporary connection error.',
+  };
+}
+
 function chatGptSubscriptionRetry(streamId: string): RetryPermission {
   return {
     streamId,
@@ -317,12 +330,9 @@ describe('TUI retry approvals', () => {
       approvalPolicy: 'yolo',
     });
 
-    const result = interactions.requestRetry?.({
-      requestId: 'yolo-transient-retry',
-      streamId: 'yolo-transient-stream',
-      operation: 'model request',
-      errorMessage: 'Temporary connection error.',
-    });
+    const result = interactions.requestRetry?.(
+      ordinaryRetry('yolo-transient-stream', 'yolo-transient-retry'),
+    );
 
     await expect(result).resolves.toEqual({
       action: 'deny',
@@ -824,12 +834,7 @@ describe('TUI retry approvals', () => {
       expect(selection).toBe('configured');
     });
     const later = interactions.requestRetry?.(
-      {
-        requestId: 'retry-after-stall',
-        streamId: 'retry-after-stall',
-        operation: 'model request',
-        errorMessage: 'Temporary connection error.',
-      },
+      ordinaryRetry('retry-after-stall'),
       { prepareRetry: laterPrepare },
     );
     await waitForApproval('retry', { streamId: 'retry-after-stall' });
@@ -1031,12 +1036,7 @@ describe('TUI retry approvals', () => {
       expect(mocks.preferSubscription).toBe(true);
     });
     const ordinary = interactions.requestRetry?.(
-      {
-        requestId: 'ordinary-retry',
-        streamId: 'ordinary-stream',
-        operation: 'model request',
-        errorMessage: 'Temporary connection error.',
-      },
+      ordinaryRetry('ordinary-stream', 'ordinary-retry'),
       { prepareRetry: ordinaryPrepare },
     );
     await waitForApproval('retry', { streamId: 'ordinary-stream' });
@@ -1077,12 +1077,7 @@ describe('TUI retry approvals', () => {
       expect(mocks.preferSubscription).toBe(true);
     });
     const ordinary = interactions.requestRetry?.(
-      {
-        requestId: 'ordinary-after-rollback',
-        streamId: 'ordinary-after-rollback',
-        operation: 'model request',
-        errorMessage: 'Temporary connection error.',
-      },
+      ordinaryRetry('ordinary-after-rollback'),
       { prepareRetry: ordinaryPrepare },
     );
     await waitForApproval('retry', { streamId: 'ordinary-after-rollback' });
@@ -1106,12 +1101,7 @@ describe('TUI retry approvals', () => {
       throw new Error('ordinary client refresh failed');
     });
     const ordinary = interactions.requestRetry?.(
-      {
-        requestId: 'ordinary-refresh-failure',
-        streamId: 'ordinary-refresh-failure',
-        operation: 'model request',
-        errorMessage: 'Temporary connection error.',
-      },
+      ordinaryRetry('ordinary-refresh-failure'),
       { prepareRetry },
     );
     await waitForApproval('retry', { streamId: 'ordinary-refresh-failure' });
@@ -1201,12 +1191,7 @@ describe('TUI retry approvals', () => {
     );
     const { interactions } = tui();
     const ordinary = interactions.requestRetry?.(
-      {
-        requestId: 'cancelled-ordinary',
-        streamId: 'cancelled-ordinary',
-        operation: 'model request',
-        errorMessage: 'Temporary connection error.',
-      },
+      ordinaryRetry('cancelled-ordinary'),
       { prepareRetry: ordinaryPrepare },
     );
     await waitForApproval('retry', { streamId: 'cancelled-ordinary' });
@@ -1424,12 +1409,7 @@ describe('TUI retry approvals', () => {
 
     const { interactions } = tui();
     const result = interactions.requestRetry?.(
-      {
-        requestId: 'abort-at-resolution',
-        streamId: 'abort-at-resolution',
-        operation: 'model request',
-        errorMessage: 'Temporary connection error.',
-      },
+      ordinaryRetry('abort-at-resolution'),
       { prepareRetry },
     );
     await waitForApproval('retry', { streamId: 'abort-at-resolution' });

--- a/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts
+++ b/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts
@@ -1,8 +1,7 @@
-// Regression coverage for #7306 (per-stream cancel only cancelled retry
-// routes), flagged by bot review against PR #7303 and left unaddressed at
-// merge.
+// Regression coverage for #7306: a per-stream cancel must settle every
+// approval kind on that stream, not only its retry routes.
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, onTestFinished, vi } from 'vitest';
 
 vi.mock('@cli/chat/tui/notifications/terminalNotifier', () => ({
   notify: vi.fn(),
@@ -26,6 +25,7 @@ vi.mock('@agent/runtime/SessionHandle', async (importOriginal) => {
   };
 });
 
+import type { HostInteractions } from '@agent/runtime/HostInteractions';
 import {
   clearApprovals,
   currentApproval,
@@ -48,6 +48,13 @@ function context(): CliContext {
 
 function host(): CliRuntimeHost {
   return { emit: vi.fn() } as unknown as CliRuntimeHost;
+}
+
+/** Interactions bound to a fresh host, disposed when the test finishes. */
+function tuiInteractions(): HostInteractions {
+  const interactions = createTuiHostInteractions(host(), context());
+  onTestFinished(() => interactions.dispose?.());
+  return interactions;
 }
 
 async function waitForApproval(
@@ -75,189 +82,163 @@ describe('createTuiHostInteractions', () => {
   it('forwards presentation events to the attached CLI presenter', () => {
     const presentationHost = host();
     const interactions = createTuiHostInteractions(presentationHost, context());
-    try {
-      interactions.emit?.('requestShowError', { message: 'Run failed.' });
+    onTestFinished(() => interactions.dispose?.());
 
-      expect(presentationHost.emit).toHaveBeenCalledWith('requestShowError', {
-        message: 'Run failed.',
-      });
-    } finally {
-      interactions.dispose?.();
-    }
+    interactions.emit?.('requestShowError', { message: 'Run failed.' });
+
+    expect(presentationHost.emit).toHaveBeenCalledWith('requestShowError', {
+      message: 'Run failed.',
+    });
   });
 
   it('cancels a queued plan approval for the target stream, leaving other streams untouched', async () => {
-    const interactions = createTuiHostInteractions(host(), context());
-    try {
-      const planResult = interactions.requestPlanApproval?.({
-        approvalId: 'approval-a',
-        streamId: 'stream-a',
-        plan,
-        goalEnabled: false,
-      });
-      const otherStreamResult = interactions.requestPlanApproval?.({
-        approvalId: 'approval-b',
-        streamId: 'stream-b',
-        plan,
-        goalEnabled: false,
-      });
+    const interactions = tuiInteractions();
+    const planResult = interactions.requestPlanApproval?.({
+      approvalId: 'approval-a',
+      streamId: 'stream-a',
+      plan,
+      goalEnabled: false,
+    });
+    const otherStreamResult = interactions.requestPlanApproval?.({
+      approvalId: 'approval-b',
+      streamId: 'stream-b',
+      plan,
+      goalEnabled: false,
+    });
 
-      await waitForApproval('planApproval', { streamId: 'stream-a' });
+    await waitForApproval('planApproval', { streamId: 'stream-a' });
 
-      interactions.cancel({ streamId: 'stream-a' });
+    interactions.cancel({ streamId: 'stream-a' });
 
-      await expect(planResult).resolves.toEqual({
-        action: 'reject',
-        feedback: 'Session interrupted.',
-      });
+    await expect(planResult).resolves.toEqual({
+      action: 'reject',
+      feedback: 'Session interrupted.',
+    });
 
-      // stream-b's request was never touched and now becomes the foreground
-      // modal instead of being left permanently pending.
-      await waitForApproval('planApproval', { streamId: 'stream-b' });
-      currentApproval.get()?.decide({ accepted: true });
-      await expect(otherStreamResult).resolves.toEqual({ action: 'approve' });
-    } finally {
-      interactions.dispose?.();
-    }
+    // stream-b's request was never touched and now becomes the foreground
+    // modal instead of being left permanently pending.
+    await waitForApproval('planApproval', { streamId: 'stream-b' });
+    currentApproval.get()?.decide({ accepted: true });
+    await expect(otherStreamResult).resolves.toEqual({ action: 'approve' });
   });
 
   it('settles plan decisions through the shared mapper: goal action kept, silent rejection omits feedback', async () => {
-    const interactions = createTuiHostInteractions(host(), context());
-    try {
-      const goalResult = interactions.requestPlanApproval?.({
-        approvalId: 'approval-goal',
-        streamId: 'stream-a',
-        plan,
-        goalEnabled: true,
-      });
-      await waitForApproval('planApproval', { streamId: 'stream-a' });
-      currentApproval.get()?.decide({
-        accepted: true,
-        planAction: 'approve_and_goal',
-      });
-      await expect(goalResult).resolves.toEqual({
-        action: 'approve_and_goal',
-      });
+    const interactions = tuiInteractions();
+    const goalResult = interactions.requestPlanApproval?.({
+      approvalId: 'approval-goal',
+      streamId: 'stream-a',
+      plan,
+      goalEnabled: true,
+    });
+    await waitForApproval('planApproval', { streamId: 'stream-a' });
+    currentApproval.get()?.decide({
+      accepted: true,
+      planAction: 'approve_and_goal',
+    });
+    await expect(goalResult).resolves.toEqual({
+      action: 'approve_and_goal',
+    });
 
-      const rejected = interactions.requestPlanApproval?.({
-        approvalId: 'approval-reject',
-        streamId: 'stream-a',
-        plan,
-        goalEnabled: false,
-      });
-      await waitForApproval('planApproval', { streamId: 'stream-a' });
-      currentApproval.get()?.decide({ accepted: false });
+    const rejected = interactions.requestPlanApproval?.({
+      approvalId: 'approval-reject',
+      streamId: 'stream-a',
+      plan,
+      goalEnabled: false,
+    });
+    await waitForApproval('planApproval', { streamId: 'stream-a' });
+    currentApproval.get()?.decide({ accepted: false });
 
-      // A rejection without a user message omits `feedback` rather than
-      // sending an explicit `undefined`.
-      await expect(rejected).resolves.toStrictEqual({ action: 'reject' });
-    } finally {
-      interactions.dispose?.();
-    }
+    // A rejection without a user message omits `feedback` rather than
+    // sending an explicit `undefined`.
+    await expect(rejected).resolves.toStrictEqual({ action: 'reject' });
   });
 
   it('cancels a queued agent proposal for the target stream', async () => {
-    const interactions = createTuiHostInteractions(host(), context());
-    try {
-      const proposalResult = interactions.requestAgentProposal?.({
-        proposalId: 'proposal-a',
-        streamId: 'stream-a',
-        ...proposal,
-      });
+    const interactions = tuiInteractions();
+    const proposalResult = interactions.requestAgentProposal?.({
+      proposalId: 'proposal-a',
+      streamId: 'stream-a',
+      ...proposal,
+    });
 
-      await waitForApproval('proposal', { streamId: 'stream-a' });
+    await waitForApproval('proposal', { streamId: 'stream-a' });
 
-      interactions.cancel({ streamId: 'stream-a' });
+    interactions.cancel({ streamId: 'stream-a' });
 
-      await expect(proposalResult).resolves.toEqual({
-        action: 'reject',
-        feedback: 'Session interrupted.',
-      });
-      expect(currentApproval.get()).toBeUndefined();
-    } finally {
-      interactions.dispose?.();
-    }
+    await expect(proposalResult).resolves.toEqual({
+      action: 'reject',
+      feedback: 'Session interrupted.',
+    });
+    expect(currentApproval.get()).toBeUndefined();
   });
 
   it('cancels a queued bash approval for the target stream (not just retry)', async () => {
-    const interactions = createTuiHostInteractions(host(), context());
-    try {
-      const bashResult = interactions.requestBashApproval?.({
-        command: 'echo hi',
-        streamId: 'stream-a',
-      });
+    const interactions = tuiInteractions();
+    const bashResult = interactions.requestBashApproval?.({
+      command: 'echo hi',
+      streamId: 'stream-a',
+    });
 
-      await waitForApproval('bash', { streamId: 'stream-a' });
+    await waitForApproval('bash', { streamId: 'stream-a' });
 
-      interactions.cancel({ streamId: 'stream-a' });
+    interactions.cancel({ streamId: 'stream-a' });
 
-      await expect(bashResult).resolves.toEqual({
-        action: 'reject',
-        feedback: 'Session interrupted.',
-      });
-      expect(currentApproval.get()).toBeUndefined();
-    } finally {
-      interactions.dispose?.();
-    }
+    await expect(bashResult).resolves.toEqual({
+      action: 'reject',
+      feedback: 'Session interrupted.',
+    });
+    expect(currentApproval.get()).toBeUndefined();
   });
 
-  it('an unfiltered cancel settles a live retry (pre-fold cleanupAllRequests parity)', async () => {
-    const interactions = createTuiHostInteractions(host(), context());
-    try {
-      // requestRetry holds a queue reservation from before the modal appears
-      // until its decision has been acted on; cancel({}) must settle that
-      // entry, resolving the pending retry with 'cancel'.
-      const retryResult = interactions.requestRetry?.({
-        requestId: 'retry:first',
-        streamId: 'stream-a',
-        operation: 'Model invocation',
-      });
+  it('an unfiltered cancel settles a live retry', async () => {
+    const interactions = tuiInteractions();
+    // requestRetry holds a queue reservation from before the modal appears
+    // until its decision has been acted on; cancel({}) must settle that
+    // entry, resolving the pending retry with 'cancel'.
+    const retryResult = interactions.requestRetry?.({
+      requestId: 'retry:first',
+      streamId: 'stream-a',
+      operation: 'Model invocation',
+    });
 
-      await waitForApproval('retry', { streamId: 'stream-a' });
+    await waitForApproval('retry', { streamId: 'stream-a' });
 
-      interactions.cancel({ cause: 'All approvals cleared.' });
+    interactions.cancel({ cause: 'All approvals cleared.' });
 
-      await expect(retryResult).resolves.toEqual({ action: 'cancel' });
-      expect(currentApproval.get()).toBeUndefined();
+    await expect(retryResult).resolves.toEqual({ action: 'cancel' });
+    expect(currentApproval.get()).toBeUndefined();
 
-      // The settled entry is gone from the queue: a stale decision cannot
-      // resurrect it, and a fresh request reserves a fresh entry.
-      const second = interactions.requestRetry?.({
-        requestId: 'retry:second',
-        streamId: 'stream-a',
-        operation: 'Model invocation',
-      });
-      await waitForApproval('retry', {});
-      interactions.cancel({ streamId: 'stream-a', kind: 'retry' });
-      await expect(second).resolves.toEqual({ action: 'cancel' });
-    } finally {
-      interactions.dispose?.();
-    }
+    // The settled entry is gone from the queue: a stale decision cannot
+    // resurrect it, and a fresh request reserves a fresh entry.
+    const second = interactions.requestRetry?.({
+      requestId: 'retry:second',
+      streamId: 'stream-a',
+      operation: 'Model invocation',
+    });
+    await waitForApproval('retry', {});
+    interactions.cancel({ streamId: 'stream-a', kind: 'retry' });
+    await expect(second).resolves.toEqual({ action: 'cancel' });
   });
 
   it('a retry-kind cancel leaves a queued plan approval on the same stream pending', async () => {
-    const interactions = createTuiHostInteractions(host(), context());
-    try {
-      const planResult = interactions.requestPlanApproval?.({
-        approvalId: 'approval-kind',
-        streamId: 'stream-a',
-        plan,
-        goalEnabled: false,
-      });
+    const interactions = tuiInteractions();
+    const planResult = interactions.requestPlanApproval?.({
+      approvalId: 'approval-kind',
+      streamId: 'stream-a',
+      plan,
+      goalEnabled: false,
+    });
 
-      await waitForApproval('planApproval', { streamId: 'stream-a' });
+    await waitForApproval('planApproval', { streamId: 'stream-a' });
 
-      interactions.cancel({ streamId: 'stream-a', kind: 'retry' });
+    interactions.cancel({ streamId: 'stream-a', kind: 'retry' });
 
-      // The plan approval is still the foreground modal and still decidable.
-      expect(currentApproval.get()?.payload).toMatchObject({
-        kind: 'planApproval',
-        payload: { streamId: 'stream-a' },
-      });
-      currentApproval.get()?.decide({ accepted: true });
-      await expect(planResult).resolves.toEqual({ action: 'approve' });
-    } finally {
-      interactions.dispose?.();
-    }
+    // The plan approval is still the foreground modal and still decidable.
+    expect(currentApproval.get()?.payload).toMatchObject({
+      kind: 'planApproval',
+      payload: { streamId: 'stream-a' },
+    });
+    currentApproval.get()?.decide({ accepted: true });
+    await expect(planResult).resolves.toEqual({ action: 'approve' });
   });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1,8 +1,6 @@
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
-// Phase 4 state + focus-cycle smoke.
-
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { logCompactionActivity } from '@agent/trace';
@@ -179,7 +177,7 @@ afterEach(() => {
   resetCliState();
 });
 
-describe('cliState Phase 4 fields', () => {
+describe('cliState stream, focus, and child-edge fields', () => {
   it('clears foreground reference text with the session state', () => {
     openInfoPane('/help', 'reference text');
     expect(infoPane.get()).toBeDefined();
@@ -757,9 +755,9 @@ describe('CLI TUI row allocation', () => {
   });
 
   it('borrows a focused child-list row so an active todo stays visible', () => {
-    // Codex review case: many children + one todo under the 10-row cap. The
-    // proportional split grants todos one row — too small for separator +
-    // content — so one row shifts from the ample child list instead.
+    // Many children plus one todo under the 10-row cap: the proportional
+    // split grants todos a single row, too small for separator plus content,
+    // so one row shifts from the ample child list instead.
     const allocation = allocateConversationBottomPanelRows({
       maxRows: 10,
       sessionCount: 11,
@@ -1472,8 +1470,8 @@ describe('CLI TUI row allocation', () => {
 });
 
 describe('finalizeSettledPrefix', () => {
-  const tool = (id: string, status: 'in_progress' | 'completed') =>
-    ({
+  function tool(id: string, status: 'in_progress' | 'completed') {
+    return {
       id,
       role: 'tool',
       text: '',
@@ -1489,9 +1487,11 @@ describe('finalizeSettledPrefix', () => {
         headerSummary: '',
         status,
       },
-    }) as const;
-  const assistant = (id: string, pendingEmbeddedSubagentFollowup = false) =>
-    ({
+    } as const;
+  }
+
+  function assistant(id: string, pendingEmbeddedSubagentFollowup = false) {
+    return {
       id,
       role: 'assistant',
       text: id,
@@ -1499,10 +1499,14 @@ describe('finalizeSettledPrefix', () => {
         ? { pendingEmbeddedSubagentFollowup }
         : {}),
       finalized: false,
-    }) as const;
-  const finalizedIds = (
+    } as const;
+  }
+
+  function finalizedIds(
     entries: readonly { id: string; finalized: boolean }[],
-  ) => entries.filter((entry) => entry.finalized).map((entry) => entry.id);
+  ): string[] {
+    return entries.filter((entry) => entry.finalized).map((entry) => entry.id);
+  }
 
   it('finalizes an assistant block once the model moves on to a tool call', () => {
     const out = finalizeSettledPrefix(
@@ -1554,10 +1558,8 @@ describe('finalizeSettledPrefix', () => {
 
 describe('CLI transcript state', () => {
   // Several tests below log through `createRunTrace`/`syncStreamLog`, which
-  // read and write the default session's `transcripts` store. No separate
-  // default-store export to swap in anymore (#7694) — clear it in place
-  // before every test instead, so store-backed tests don't need to repeat
-  // that reset individually.
+  // read and write the default session's `transcripts` store (#7694). Clear
+  // it in place here so store-backed tests need no reset of their own.
   beforeEach(async () => {
     await defaultSession().transcripts.clear();
   });
@@ -2288,11 +2290,10 @@ describe('CLI transcript state', () => {
   });
 
   // Regression: a sync tick that fires after `finalizeAssistantTranscriptEntries`
-  // must not roll the entry back to `finalized: false`. Cursor Bugbot flagged
-  // this when `entriesEqual` started comparing `finalized` — without this
-  // guard, the de-finalized entry would land in neither bucket of
-  // `splitTranscriptEntries` once status flipped to WAITING and silently
-  // disappear from the transcript.
+  // must not roll the entry back to `finalized: false`. Without this guard,
+  // the de-finalized entry lands in neither bucket of
+  // `splitTranscriptEntries` once status flips to WAITING, and silently
+  // disappears from the transcript.
   it('preserves the finalized flag through a post-finalize sync tick', () => {
     const logger = runTrace(root);
     logger.info('streaming assistant chunk', {

--- a/src/test-kernel/cli/WorkflowRunDetails.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunDetails.vitest.mts
@@ -36,7 +36,7 @@ const COMPILE_FAILURE: CompileFailure = {
   logRelativePath: 'paper.log',
 };
 
-function workflowRunDetailLines(
+function detailLines(
   facts: Parameters<typeof selectWorkflowRunDetailLines>[0],
   maxRows = Number.MAX_SAFE_INTEGER,
 ) {
@@ -47,9 +47,9 @@ afterEach(() => {
   resetCliState();
 });
 
-describe('workflowRunDetailLines', () => {
+describe('selectWorkflowRunDetailLines', () => {
   it('joins lifecycle, planned rounds, generated files, and warnings', () => {
-    const lines = workflowRunDetailLines({
+    const lines = detailLines({
       taskGroups: [
         {
           id: 'run',
@@ -112,7 +112,7 @@ describe('workflowRunDetailLines', () => {
   });
 
   it('renders a normalized rN round and sanitizes terminal controls', () => {
-    const lines = workflowRunDetailLines({
+    const lines = detailLines({
       taskGroups: projectTaskGroupsFromStreamLog([
         {
           seqNo: 1,
@@ -136,7 +136,7 @@ describe('workflowRunDetailLines', () => {
   });
 
   it('shows a round-qualified alert when only one detail row fits', () => {
-    const [line] = workflowRunDetailLines(
+    const [line] = detailLines(
       {
         taskGroups: [
           {
@@ -169,7 +169,7 @@ describe('workflowRunDetailLines', () => {
     ['round without an index', 'round'],
     ['session stage', 'session'],
   ] as const)('keeps a %s lifecycle group visible', (_case, kind) => {
-    const lines = workflowRunDetailLines({
+    const lines = detailLines({
       taskGroups: projectTaskGroupsFromStreamLog([
         {
           seqNo: 1,
@@ -240,7 +240,7 @@ describe('workflowRunDetailLines', () => {
   });
 
   it('keeps warning context ahead of generated files and future plans', () => {
-    const lines = workflowRunDetailLines(
+    const lines = detailLines(
       {
         taskGroups: [
           {

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -1,8 +1,8 @@
-// Unit tests for the chat-session controller's state transitions.
-// Does not require actual agent execution — the controller's orchestration
-// methods (startRootRun, resume) touch real agent runtime infrastructure,
-// so these tests focus on the factory contract and the stop/idle state
-// mutations that are safe to verify without a full agent harness.
+// Unit tests for the chat-session controller's run-slot ownership, stop and
+// resume paths, and presentation-host lifecycle. Agent execution itself is
+// mocked; the session surfaces the controller reasons about (execution
+// registry, event hub, stream status, host interactions) are the real
+// runtime objects wherever a test asserts through them.
 
 import PQueue from 'p-queue';
 import pDefer from 'p-defer';
@@ -177,10 +177,6 @@ import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
 import { createFakeKv } from '@test/support/FakeExecutionKVStore';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { StreamSnapshotStore } from '@transcript';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 /**
  * Session fixture in the states the controller is exercised from. The
@@ -494,10 +490,6 @@ describe('CLI terminal outcome resolution', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Predicate: chatTuiCanStartRootRun
-// ---------------------------------------------------------------------------
-
 describe('chatTuiCanStartRootRun', () => {
   it('allows a new root run when no run has ever been started', () => {
     expect(chatTuiCanStartRootRun(makeSession())).toBe(true);
@@ -525,10 +517,6 @@ describe('chatTuiCanStartRootRun', () => {
     ).toBe(false);
   });
 });
-
-// ---------------------------------------------------------------------------
-// Factory: createChatSessionController
-// ---------------------------------------------------------------------------
 
 describe('createChatSessionController', () => {
   beforeEach(() => {
@@ -1272,15 +1260,11 @@ describe('createChatSessionController', () => {
   });
 
   it('resume() suspended on the resolution keeps a concurrent follow-up wake from also claiming the root-run slot', async () => {
-    // Reproduces the finding's interleaving: resume(A) suspends on
-    // resolveCliResume (an await-suspension point) with the slot
-    // already claimed; a follow-up wake (tryResumeStream for a different
-    // stream) fires while A is still suspended. Pre-fix, resume(A) checked
-    // availability but claimed the slot only after this (and three more)
-    // awaits, so B's tryResumeStream would see the slot as free, claim it,
-    // and start doing real work — which resume(A) would then clobber when
-    // it woke back up and unconditionally overwrote session.runPromise.
-    // Post-fix, exactly one caller (A) ever holds the slot.
+    // resume(A) suspends on resolveCliResume (an await-suspension point)
+    // with the slot already claimed; a follow-up wake (tryResumeStream for a
+    // different stream) fires while A is still suspended. Exactly one caller
+    // (A) holds the slot end to end, so B must bail out rather than claim it
+    // and start work that A would clobber on waking.
     const resolution = pDefer<{ readonly type: 'not-found' }>();
     mocks.resolveCliResume.mockReturnValueOnce(resolution.promise);
     const session = makeSession({ runCompleted: true });

--- a/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
@@ -16,11 +16,10 @@ import {
 import { dispatchCommandFromRegistry } from '@shared/commands/registry';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
-// `extensionCommandHandlers.ts` is deliberately free of `vscode` imports,
-// so — unlike `extensionCommandSurface.ts`, which wires the real actions
-// against VS Code APIs — the real handler map can be exercised here
-// directly. There is no hand-copied re-implementation to drift out of
-// sync with the production map.
+// `extensionCommandHandlers.ts` is deliberately free of `vscode` imports, so
+// the production handler map is exercised directly here. Only
+// `extensionCommandSurface.ts`, which wires the real actions against VS Code
+// APIs, needs the extension host.
 
 function makeActions(): ExtensionCommandActions {
   return {
@@ -517,12 +516,10 @@ describe('extension command surface — catalog-tagged command dispatch', () => 
     expect(actions.execute).toHaveBeenCalledExactlyOnceWith(payload);
   });
 
-  // Regression guard for #3782: the migrated handlers must propagate
-  // async rejections instead of swallowing them through `void
-  // actions.X(); return true;`. Each asserted handler returns a
-  // promise that rejects — the dispatcher should surface the same
-  // rejection so VS Code's `executeCommand` callers (and the bot
-  // reviewer that filed #3782) actually see the failure.
+  // Regression guard for #3782: handlers must propagate async rejections
+  // instead of swallowing them through `void actions.X(); return true;`.
+  // Each asserted handler returns a rejecting promise, and the dispatcher
+  // must surface that same rejection to VS Code's `executeCommand` callers.
   describe('async rejection propagation (regression guard for #3782)', () => {
     it.each([
       ['texra.cleanOutput', 'cleanOutput'],

--- a/src/test-kernel/controllers/MainViewStateRestoreController.vitest.ts
+++ b/src/test-kernel/controllers/MainViewStateRestoreController.vitest.ts
@@ -42,35 +42,17 @@ describe('RestoreRunConfigInputSchema', () => {
     expect(parsed.inputFiles).toEqual(['main.tex']);
   });
 
-  it('rejects a payload that is neither a run config nor the legacy wrapper', () => {
-    expect(RestoreRunConfigInputSchema.safeParse('nope').success).toBe(false);
-  });
-
-  it('reports a malformed wrapper instead of restoring a blank config', () => {
-    expect(
-      RestoreRunConfigInputSchema.safeParse({ agentConfig: 42 }).success,
-    ).toBe(false);
-    expect(
-      RestoreRunConfigInputSchema.safeParse({
-        agentConfig: { agentCategory: 'not-a-category' },
-      }).success,
-    ).toBe(false);
-  });
-
-  it('rejects blank and unrelated objects before applying config defaults', () => {
-    expect(RestoreRunConfigInputSchema.safeParse({}).success).toBe(false);
-    expect(
-      RestoreRunConfigInputSchema.safeParse({ agentConfig: {} }).success,
-    ).toBe(false);
-    expect(
-      RestoreRunConfigInputSchema.safeParse({ unrelated: true }).success,
-    ).toBe(false);
-    expect(
-      RestoreRunConfigInputSchema.safeParse({ agent: undefined }).success,
-    ).toBe(false);
-  });
-
   it.each([
+    ['a payload that is neither a run config nor the legacy wrapper', 'nope'],
+    ['a wrapper whose config is not an object', { agentConfig: 42 }],
+    [
+      'a wrapper with a malformed config',
+      { agentConfig: { agentCategory: 'not-a-category' } },
+    ],
+    ['a blank object', {}],
+    ['a wrapper around a blank config', { agentConfig: {} }],
+    ['an unrelated object', { unrelated: true }],
+    ['an object whose only identity is undefined', { agent: undefined }],
     ['direct blank identities', { agent: '', model: '' }],
     ['direct whitespace identities', { agent: '  ', model: '\t' }],
     ['direct blank identity', { agent: '', model: 'sonnet46T' }],
@@ -82,7 +64,7 @@ describe('RestoreRunConfigInputSchema', () => {
       'legacy-wrapped whitespace identities',
       { agentConfig: { agent: '  ', model: '\t' } },
     ],
-  ])('rejects %s', (_name, input) => {
+  ])('rejects %s instead of applying config defaults', (_name, input) => {
     expect(RestoreRunConfigInputSchema.safeParse(input).success).toBe(false);
   });
 

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -1,6 +1,4 @@
 // Test composition imports
-
-// Local imports
 import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
@@ -805,18 +803,28 @@ describe('external inquiry action schema', () => {
     externalInquiryMocks.persistExternalInquiryAction.mockReset();
   });
 
-  it("requires each action variant's own fields", () => {
-    const results = [
+  it.each([
+    [
+      'submit with an answer',
       { command, action: 'submit', threadId, answer: 'Confirmed' },
-      { command, action: 'drop', threadId },
+      true,
+    ],
+    ['drop', { command, action: 'drop', threadId }, true],
+    [
+      'draft with a null draft',
       { command, action: 'draft', threadId, draft: null },
+      true,
+    ],
+    [
+      'submit without an answer',
       { command, action: 'submit', threadId },
-      { command, action: 'draft', threadId },
-    ].map(
-      (message) => ProgressViewInboundMessageSchema.safeParse(message).success,
+      false,
+    ],
+    ['draft without a draft', { command, action: 'draft', threadId }, false],
+  ])('%s parses as %s', (_name, message, valid) => {
+    expect(ProgressViewInboundMessageSchema.safeParse(message).success).toBe(
+      valid,
     );
-
-    expect(results).toEqual([true, true, true, false, false]);
   });
 
   it.each([

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -970,9 +970,8 @@ describe('DesktopProgressBridge', () => {
 
     messages.length = 0;
     // The request must stay pending until the renderer settles it, so don't
-    // await the promise here — awaiting the old auto-cancel was exactly the
-    // behavior that terminated runs with "Retry cancelled by user" without ever
-    // asking.
+    // await the promise here: an auto-cancel would terminate the run with
+    // "Retry cancelled by user" without ever asking.
     const pending = bridgeInteractions(bridge).requestRetry?.({
       requestId: 'retry-host-interaction',
       streamId: 'stream-retry' as StreamTabId,
@@ -2346,8 +2345,8 @@ describe('DesktopProgressBridge', () => {
       useMultipleOutputs: false,
       toolConfig: DEFAULT_TOOL_CONFIG,
     });
-    // The port now emits the ensure-view/activation events the coordinator
-    // layer used to duplicate; settle them before snapshotting messages.
+    // The port emits its own ensure-view/activation events; settle them
+    // before snapshotting messages.
     await settleProgressEvents();
     messages.length = 0;
 

--- a/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.mts
@@ -147,9 +147,9 @@ describe('DefaultDesktopAgentSettingsController', () => {
   it('implements the custom-agent management commands', () => {
     const { handlers } = createControllerFixture().controller;
 
-    // These were `unsupported(...)` placeholders until the custom-agent
-    // create/copy/delete flows and the remote prompt viewer were ported from
-    // the extension, so assert they are real handlers now.
+    // The desktop owns the custom-agent create/copy/delete flows and the
+    // remote prompt viewer, so none of them may be an `unsupported(...)`
+    // placeholder.
     expect(
       [
         handlers.createAgent,

--- a/src/test-kernel/desktop/DesktopCredentialSettingsController.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCredentialSettingsController.vitest.mts
@@ -68,7 +68,17 @@ type ControllerOptions = ConstructorParameters<
 >[0];
 type Fixture = Awaited<ReturnType<typeof createFixture>>;
 
-async function createFixture(overrides: Partial<ControllerOptions> = {}) {
+/** Prompt answers the fixture's recording `prompt` port replies with. */
+type FixtureOverrides = Partial<ControllerOptions> & {
+  promptInput?: string;
+  confirmResult?: boolean;
+};
+
+async function createFixture({
+  promptInput,
+  confirmResult = true,
+  ...overrides
+}: FixtureOverrides = {}) {
   const globalState =
     (overrides.globalState as FakeStateStore | undefined) ??
     new FakeStateStore();
@@ -117,10 +127,10 @@ async function createFixture(overrides: Partial<ControllerOptions> = {}) {
       },
     },
     prompt: {
-      input: async () => undefined,
+      input: async () => promptInput,
       confirm: async (message) => {
         confirms.push(message);
-        return true;
+        return confirmResult;
       },
     },
     externalOpener: {
@@ -193,17 +203,7 @@ describe('DefaultDesktopCredentialSettingsController', () => {
     const secretName = apiKeySecretName('openai');
     const secrets = new FakeSecrets({ [secretName]: 'sk-test' });
     const deleteSpy = vi.spyOn(secrets, 'delete');
-    const confirms: string[] = [];
-    const fixture = await createFixture({
-      secrets,
-      prompt: {
-        input: async () => undefined,
-        confirm: async (message) => {
-          confirms.push(message);
-          return false;
-        },
-      },
-    });
+    const fixture = await createFixture({ secrets, confirmResult: false });
 
     await assertSupported(fixture.controller.profileHandlers.removeProviderKey)(
       {
@@ -212,7 +212,7 @@ describe('DefaultDesktopCredentialSettingsController', () => {
       },
     );
 
-    expect(confirms).toEqual([
+    expect(fixture.confirms).toEqual([
       'Remove the OpenAI API key? This cannot be undone.',
     ]);
     expect(deleteSpy).not.toHaveBeenCalled();
@@ -253,16 +253,9 @@ describe('DefaultDesktopCredentialSettingsController', () => {
     const secretName = apiKeySecretName('openai');
     const secrets = new FakeSecrets({ [secretName]: 'old-key' });
     const deleteSpy = vi.spyOn(secrets, 'delete');
-    const confirms: string[] = [];
     const fixture = await createFixture({
       secrets,
-      prompt: {
-        input: async () => '  replacement  ',
-        confirm: async (message) => {
-          confirms.push(message);
-          return true;
-        },
-      },
+      promptInput: '  replacement  ',
     });
 
     await assertSupported(fixture.controller.profileHandlers.setProviderKey)({
@@ -280,7 +273,7 @@ describe('DefaultDesktopCredentialSettingsController', () => {
     );
     expect(deleteSpy).toHaveBeenCalledExactlyOnceWith(secretName);
     expect(await secrets.get(secretName)).toBeUndefined();
-    expect(confirms).toEqual([
+    expect(fixture.confirms).toEqual([
       'Remove the OpenAI API key? This cannot be undone.',
     ]);
   });

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -11,6 +11,7 @@ import { AgentCategory } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { createDeferred } from '@test/support/asyncTestUtils';
+import { FakeStateStore } from '@test/support/FakePlatform';
 import { createModuleMocks } from '@test/support/moduleMocks';
 
 // Local imports - test support
@@ -73,24 +74,9 @@ async function createShellHarness(
   };
 }
 
-// Backing store the onboarding adapter reads and writes; `update` is a spy so
-// tests can assert persisted keys, `values` exposes the raw map for seeding.
-function createMemoryState() {
-  const values = new Map<string, unknown>();
-  const update = vi.fn(async (key: string, value: unknown) => {
-    values.set(key, value);
-  });
-  const state = {
-    get<T>(key: string, defaultValue?: T): T {
-      return (values.has(key) ? values.get(key) : defaultValue) as T;
-    },
-    update,
-  };
-  return { values, update, state };
-}
-
 // Own the repeated onboarding boundary setup so each test declares only its
-// initial state and host callbacks.
+// initial state and host callbacks. `update` is spied so tests can assert
+// persisted keys; `state` is the store the adapter reads and writes.
 async function createOnboardingHarness({
   seed = {},
   ...options
@@ -102,10 +88,8 @@ async function createOnboardingHarness({
     loadSourceModule('@desktop/main/desktopOnboardingIpc'),
     loadSourceModule('@desktop/desktopOnboardingMessages'),
   ]);
-  const memory = createMemoryState();
-  for (const [key, value] of Object.entries(seed)) {
-    memory.values.set(key, value);
-  }
+  const state = new FakeStateStore({ ...seed });
+  const update = vi.spyOn(state, 'update');
   const postToRenderer = vi.fn();
   const onboarding = createDesktopOnboardingIpc(
     { postToRenderer },
@@ -116,11 +100,12 @@ async function createOnboardingHarness({
       signInWithChatGpt: async () => {},
       openGettingStarted: async () => {},
       ...options,
-      state: memory.state,
+      state,
     },
   );
   return {
-    ...memory,
+    state,
+    update,
     onboarding,
     postToRenderer,
     dismissedStateKey: DESKTOP_ONBOARDING_DISMISSED_STATE_KEY,
@@ -279,9 +264,8 @@ describe('desktop IPC adapters', () => {
   });
 
   it('forwards real recent commits when a git host is wired', async () => {
-    // Closes audit item A: `getRecentCommits` is now a first-class shell
-    // option, so the launcher banner sees the actual `git log` output
-    // instead of the legacy empty stub.
+    // `getRecentCommits` is a first-class shell option, so the launcher
+    // banner shows the host's actual `git log` output.
     const getRecentCommits = vi.fn(async () => ({
       commits: ['abc1234: Add feature (2 days ago)'],
       isGitRepo: true,
@@ -629,12 +613,13 @@ describe('desktop IPC adapters', () => {
     // Before the backfill settles this derives 'setup'; the gate must hold the
     // first derivation so the renderer never sees the transient State 1.
     const selectSetupAgent = vi.fn(async () => {});
-    const { onboarding, postToRenderer, values } =
-      await createOnboardingHarness({
+    const { onboarding, postToRenderer, state } = await createOnboardingHarness(
+      {
         readyGate: readyGate.promise,
         hasCredential: () => true,
         selectSetupAgent,
-      });
+      },
+    );
 
     expect(
       onboarding.handleMessage({
@@ -648,7 +633,7 @@ describe('desktop IPC adapters', () => {
     expect(selectSetupAgent).not.toHaveBeenCalled();
 
     // Backfill marks the veteran done, then opens the gate.
-    values.set(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE, true);
+    void state.update(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE, true);
     readyGate.resolve();
     await flushAsync();
 

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -353,8 +353,8 @@ describe('desktop settings IPC', () => {
   it('serves the goal list instead of the desktop "not available" stub (issue #7751 FS6)', async () => {
     const { settings, posted } = createCapturedSettingsFixture();
 
-    // Was previously declared unsupported and appeared in the derived
-    // capability broadcast (SET_UNSUPPORTED_COMMANDS); the fix removes it.
+    // The desktop serves this command, so it must stay out of the derived
+    // capability broadcast (SET_UNSUPPORTED_COMMANDS).
     settings.handleMessage({
       command: SETTINGS_VIEW_COMMANDS.WEBVIEW_READY,
       view: 'settings',

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -19,8 +19,8 @@ import {
   type DesktopOAuthClient,
   type DesktopSupabaseAuthHost,
 } from '@desktop/main/desktopSupabaseAuth';
-import type { StateStore } from '@platform/interfaces';
 import { createDeferred } from '@test/support/asyncTestUtils';
+import { FakeStateStore } from '@test/support/FakePlatform';
 
 function createCoordinator() {
   const storedSession: { current: SupabaseSession | null } = { current: null };
@@ -109,22 +109,6 @@ function callbackSessionResult() {
       refreshToken: 'refresh-token',
       account: { id: 'user-1', label: 'user@example.com' },
       expiresAt: Date.now() + 60_000,
-    },
-  };
-}
-
-function createStateStore(): Pick<StateStore, 'get' | 'update'> {
-  const state = new Map<string, unknown>();
-  return {
-    get<T>(key: string, defaultValue?: T): T {
-      return state.has(key) ? (state.get(key) as T) : (defaultValue as T);
-    },
-    async update(key: string, value: unknown): Promise<void> {
-      if (value == null) {
-        state.delete(key);
-      } else {
-        state.set(key, value);
-      }
     },
   };
 }
@@ -514,7 +498,7 @@ describe('desktop Supabase auth', () => {
   it('preserves pending sign-in across desktop auth recreation', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
-    const stateStore = createStateStore();
+    const stateStore = new FakeStateStore();
     const callbackState = createDesktopAuthCallbackState(stateStore);
     const oauthClient = createOAuthClient();
     const auth = createTestAuth({
@@ -552,7 +536,7 @@ describe('desktop Supabase auth', () => {
       vi.setSystemTime(new Date('2026-05-06T00:00:00Z'));
       const router = createDesktopProtocolCallbackRouter();
       const coordinator = createCoordinator();
-      const stateStore = createStateStore();
+      const stateStore = new FakeStateStore();
       const oauthClient = createOAuthClient();
       const auth = createTestAuth({
         router,
@@ -592,7 +576,7 @@ describe('desktop Supabase auth', () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(new Date('2026-05-06T00:00:00Z'));
-      const stateStore = createStateStore();
+      const stateStore = new FakeStateStore();
       const callbackState = createDesktopAuthCallbackState(stateStore);
 
       await callbackState.beginAuthAttempt('attempt-nonce');
@@ -612,7 +596,7 @@ describe('desktop Supabase auth', () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(new Date('2026-05-06T00:00:00Z'));
-      const stateStore = createStateStore();
+      const stateStore = new FakeStateStore();
       const initialState = createDesktopAuthCallbackState(stateStore);
       await initialState.beginAuthAttempt('expired-nonce');
       vi.setSystemTime(Date.now() + 11 * 60 * 1000);

--- a/src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts
+++ b/src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts
@@ -31,6 +31,8 @@ describe('desktop update checker', () => {
     const release: DesktopLatestRelease = {
       version: '0.40.0',
     };
+    const CURRENT_VERSION = '0.39.3';
+    const DAY_MS = 24 * 60 * 60 * 1000;
     let checkForDesktopUpdate: DesktopUpdateCheckerModule['checkForDesktopUpdate'];
     let globalState: FakeStateStore;
 
@@ -41,60 +43,51 @@ describe('desktop update checker', () => {
       globalState = new FakeStateStore();
     });
 
-    it('skips entirely for unpackaged (dev) runs', async () => {
-      let fetchCalls = 0;
-      let notifyCalls = 0;
-
-      await checkForDesktopUpdate({
-        currentVersion: '0.39.3',
-        globalState,
-        isPackaged: false,
-        notify: () => {
-          notifyCalls += 1;
-        },
-        fetchRelease: async () => {
-          fetchCalls += 1;
-          return release;
-        },
-      });
-
-      expect(fetchCalls).toBe(0);
-      expect(notifyCalls).toBe(0);
-    });
-
-    it('skips entirely when TEXRA_NO_UPDATE_CHECK is set', async () => {
-      let fetchCalls = 0;
-
-      await checkForDesktopUpdate({
-        currentVersion: '0.39.3',
-        globalState,
-        isPackaged: true,
-        env: { TEXRA_NO_UPDATE_CHECK: '1' },
-        notify: () => {},
-        fetchRelease: async () => {
-          fetchCalls += 1;
-          return release;
-        },
-      });
-
-      expect(fetchCalls).toBe(0);
-    });
-
-    it('notifies once when a newer release is found, and persists the notified version', async () => {
-      const notified: DesktopLatestRelease[] = [];
-
-      await checkForDesktopUpdate({
-        currentVersion: '0.39.3',
+    /** One check with the packaged, update-enabled defaults these cases share. */
+    function runCheck(
+      overrides: Partial<CheckForDesktopUpdateOptions> = {},
+    ): Promise<void> {
+      return checkForDesktopUpdate({
+        currentVersion: CURRENT_VERSION,
         globalState,
         isPackaged: true,
         env: {},
-        notify: (r) => {
-          notified.push(r);
-        },
+        notify: () => {},
         fetchRelease: async () => release,
+        ...overrides,
       });
+    }
 
-      expect(notified).toEqual([release]);
+    function lastCheckedAt(): number | undefined {
+      return globalState.get(
+        GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
+      );
+    }
+
+    it('skips entirely for unpackaged (dev) runs', async () => {
+      const notify = vi.fn();
+      const fetchRelease = vi.fn(async () => release);
+
+      await runCheck({ isPackaged: false, notify, fetchRelease });
+
+      expect(fetchRelease).not.toHaveBeenCalled();
+      expect(notify).not.toHaveBeenCalled();
+    });
+
+    it('skips entirely when TEXRA_NO_UPDATE_CHECK is set', async () => {
+      const fetchRelease = vi.fn(async () => release);
+
+      await runCheck({ env: { TEXRA_NO_UPDATE_CHECK: '1' }, fetchRelease });
+
+      expect(fetchRelease).not.toHaveBeenCalled();
+    });
+
+    it('notifies once when a newer release is found, and persists the notified version', async () => {
+      const notify = vi.fn();
+
+      await runCheck({ notify });
+
+      expect(notify).toHaveBeenCalledExactlyOnceWith(release);
       expect(
         globalState.get(
           GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
@@ -103,125 +96,68 @@ describe('desktop update checker', () => {
     });
 
     it('does not notify when the latest release is not newer', async () => {
-      let notifyCalls = 0;
+      const notify = vi.fn();
 
-      await checkForDesktopUpdate({
-        currentVersion: '0.40.0',
-        globalState,
-        isPackaged: true,
-        env: {},
-        notify: () => {
-          notifyCalls += 1;
-        },
-        fetchRelease: async () => release,
-      });
+      await runCheck({ currentVersion: release.version, notify });
 
-      expect(notifyCalls).toBe(0);
+      expect(notify).not.toHaveBeenCalled();
     });
 
     it('throttles repeated checks within the same day', async () => {
-      let fetchCalls = 0;
+      const fetchRelease = vi.fn(async () => release);
       // A realistic epoch timestamp: on the very first check ever,
       // `lastCheckedAt` defaults to 0, and this must be far enough past that
       // default to *not* be throttled (matching a real first launch).
       let nowMs = Date.UTC(2026, 0, 1);
-
-      const run = () =>
-        checkForDesktopUpdate({
-          currentVersion: '0.39.3',
-          globalState,
-          isPackaged: true,
-          env: {},
-          notify: () => {},
-          now: () => nowMs,
-          fetchRelease: async () => {
-            fetchCalls += 1;
-            return release;
-          },
-        });
+      const run = () => runCheck({ now: () => nowMs, fetchRelease });
 
       await run();
-      expect(fetchCalls).toBe(1);
+      expect(fetchRelease).toHaveBeenCalledTimes(1);
 
       // Same process, ten minutes later: still throttled.
       nowMs += 10 * 60 * 1000;
       await run();
-      expect(fetchCalls).toBe(1);
+      expect(fetchRelease).toHaveBeenCalledTimes(1);
 
       // A full day later: throttle window has elapsed.
-      nowMs += 24 * 60 * 60 * 1000;
+      nowMs += DAY_MS;
       await run();
-      expect(fetchCalls).toBe(2);
+      expect(fetchRelease).toHaveBeenCalledTimes(2);
     });
 
     it('does not re-notify for a release version already notified', async () => {
-      let notifyCalls = 0;
+      const notify = vi.fn();
       let nowMs = Date.UTC(2026, 0, 1);
-
-      const run = () =>
-        checkForDesktopUpdate({
-          currentVersion: '0.39.3',
-          globalState,
-          isPackaged: true,
-          env: {},
-          notify: () => {
-            notifyCalls += 1;
-          },
-          now: () => nowMs,
-          fetchRelease: async () => release,
-        });
+      const run = () => runCheck({ now: () => nowMs, notify });
 
       await run();
-      expect(notifyCalls).toBe(1);
+      expect(notify).toHaveBeenCalledTimes(1);
 
       // Next day, same latest release: throttle window elapsed so it fetches
       // again, but must not re-notify for a version already announced.
-      nowMs += 24 * 60 * 60 * 1000;
+      nowMs += DAY_MS;
       await run();
-      expect(notifyCalls).toBe(1);
+      expect(notify).toHaveBeenCalledTimes(1);
     });
 
     it('does not persist the throttle stamp on a failed fetch, so the next launch retries', async () => {
-      let fetchCalls = 0;
       const nowMs = Date.UTC(2026, 0, 1);
+      // `undefined` is how a network or API failure reaches the checker.
+      const failingFetch = vi.fn(async () => undefined);
 
-      await checkForDesktopUpdate({
-        currentVersion: '0.39.3',
-        globalState,
-        isPackaged: true,
-        env: {},
-        notify: () => {},
-        now: () => nowMs,
-        fetchRelease: async () => {
-          fetchCalls += 1;
-          return undefined; // simulates a network/API failure
-        },
-      });
+      await runCheck({ now: () => nowMs, fetchRelease: failingFetch });
 
-      expect(fetchCalls).toBe(1);
-      expect(
-        globalState.get(GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT),
-      ).toBeUndefined();
+      expect(failingFetch).toHaveBeenCalledOnce();
+      expect(lastCheckedAt()).toBeUndefined();
 
       // Immediately "relaunching" (same day) must retry rather than being
       // throttled for a full 24h off the back of the earlier failure.
-      await checkForDesktopUpdate({
-        currentVersion: '0.39.3',
-        globalState,
-        isPackaged: true,
-        env: {},
-        notify: () => {},
-        now: () => nowMs + 1000,
-        fetchRelease: async () => {
-          fetchCalls += 1;
-          return release;
-        },
-      });
+      const retriedFetch = vi.fn(async () => release);
 
-      expect(fetchCalls).toBe(2);
-      expect(
-        globalState.get(GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT),
-      ).toBe(nowMs + 1000);
+      await runCheck({ now: () => nowMs + 1000, fetchRelease: retriedFetch });
+
+      expect(retriedFetch).toHaveBeenCalledOnce();
+      expect(lastCheckedAt()).toBe(nowMs + 1000);
     });
 
     it('treats an empty release tag as a failed fetch', async () => {
@@ -233,89 +169,50 @@ describe('desktop update checker', () => {
         })) as unknown as typeof fetch,
       );
 
-      await checkForDesktopUpdate({
-        currentVersion: '0.39.3',
-        globalState,
-        isPackaged: true,
-        env: {},
-        notify: () => {},
-      });
+      // No `fetchRelease`: this drives the real GitHub fetch path.
+      await runCheck({ fetchRelease: undefined });
 
-      expect(
-        globalState.get(GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT),
-      ).toBeUndefined();
+      expect(lastCheckedAt()).toBeUndefined();
     });
 
     it('does not persist the throttle stamp when notification fails', async () => {
       const nowMs = Date.UTC(2026, 0, 1);
-      let notifyCalls = 0;
-
-      const run = (notify: () => void | Promise<void>) =>
-        checkForDesktopUpdate({
-          currentVersion: '0.39.3',
-          globalState,
-          isPackaged: true,
-          env: {},
-          notify,
-          now: () => nowMs,
-          fetchRelease: async () => release,
-        });
-
-      await expect(
-        run(() => {
-          notifyCalls += 1;
-          throw new Error('dialog failed');
-        }),
-      ).rejects.toThrow('dialog failed');
-      expect(
-        globalState.get(GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT),
-      ).toBeUndefined();
-
-      await run(() => {
-        notifyCalls += 1;
+      let dialogFails = true;
+      const notify = vi.fn(() => {
+        if (dialogFails) throw new Error('dialog failed');
       });
-      expect(notifyCalls).toBe(2);
-      expect(
-        globalState.get(GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT),
-      ).toBe(nowMs);
+
+      await expect(runCheck({ now: () => nowMs, notify })).rejects.toThrow(
+        'dialog failed',
+      );
+      expect(lastCheckedAt()).toBeUndefined();
+
+      dialogFails = false;
+      await runCheck({ now: () => nowMs, notify });
+
+      expect(notify).toHaveBeenCalledTimes(2);
+      expect(lastCheckedAt()).toBe(nowMs);
     });
 
     it('coalesces concurrent checks into one fetch and notification', async () => {
-      let fetchCalls = 0;
-      let firstNotifyCalls = 0;
-      let secondNotifyCalls = 0;
       let resolveFetch: ((value: DesktopLatestRelease) => void) | undefined;
       const pendingRelease = new Promise<DesktopLatestRelease>((resolve) => {
         resolveFetch = resolve;
       });
-      const options = {
-        currentVersion: '0.39.3',
-        globalState,
-        isPackaged: true,
-        env: {},
-        notify: () => {
-          firstNotifyCalls += 1;
-        },
-        fetchRelease: async () => {
-          fetchCalls += 1;
-          return pendingRelease;
-        },
-      };
+      const fetchRelease = vi.fn(() => pendingRelease);
+      const firstNotify = vi.fn();
+      const secondNotify = vi.fn();
 
-      const first = checkForDesktopUpdate(options);
-      const second = checkForDesktopUpdate({
-        ...options,
-        notify: () => {
-          secondNotifyCalls += 1;
-        },
-      });
-      expect(fetchCalls).toBe(1);
+      const first = runCheck({ notify: firstNotify, fetchRelease });
+      const second = runCheck({ notify: secondNotify, fetchRelease });
+      expect(fetchRelease).toHaveBeenCalledOnce();
 
       resolveFetch?.(release);
       await Promise.all([first, second]);
-      expect(fetchCalls).toBe(1);
-      expect(firstNotifyCalls).toBe(0);
-      expect(secondNotifyCalls).toBe(1);
+
+      expect(fetchRelease).toHaveBeenCalledOnce();
+      expect(firstNotify).not.toHaveBeenCalled();
+      expect(secondNotify).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts
+++ b/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts
@@ -129,7 +129,6 @@ describe('desktop renderer bootstrap fallback', () => {
     const source = loadRendererMain();
     expect(source).toContain('renderBootstrapFallback');
     expect(source).toContain('try {');
-    // `logsController` since the logs viewer moved from a wa-drawer to a tab.
     expect(source).toContain('logsController.rerenderViewer();');
     expect(source).toContain('rerenderShell();');
     expect(source).toContain('catch (error)');
@@ -149,9 +148,7 @@ describe('desktop renderer bootstrap fallback', () => {
     const source = loadRendererMain();
     // The DOM-dependent setup (event wiring + onboarding REQUEST_STATE +
     // WEBVIEW_READY emission) must be gated behind !bootstrapFailed so it
-    // cannot throw on top of the already-rendered fallback UI. (The
-    // workspace-explorer sidebar — and its REQUEST_TREE call — was removed
-    // in PRD PR 3; only the onboarding state + ready emission remain.)
+    // cannot throw on top of the already-rendered fallback UI.
     expect(source).toContain('if (!bootstrapFailed) {');
     expect(source).toContain('DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE');
     expect(source).toContain('postWebviewReady');

--- a/src/test-kernel/progressView/AgentPresentationHostReplayGate.vitest.mts
+++ b/src/test-kernel/progressView/AgentPresentationHostReplayGate.vitest.mts
@@ -15,21 +15,17 @@ import { createTestSession } from '@test/support/sessionTestUtils';
 import { createRecordingApprovalHandlers } from './approvalHandlerSetHarness';
 
 /**
- * #9251 behavioral gate: the extension's `HostInteractions.emit` now routes
- * presentation and progress-view interaction events the way desktop's does
- * (a thin pass-through to a caller-supplied presentation host), replacing a
- * deleted per-host presentation-event bus and its 1000-event replay buffer.
- * These tests pin the two things that buffer used to guarantee and that must
- * still hold true with it gone:
+ * The extension's `HostInteractions.emit` is a thin pass-through to a
+ * caller-supplied presentation host, so redelivery is owned elsewhere. These
+ * tests pin the two guarantees that ownership has to keep:
  *
  *  1. A pending tool-edit approval redisplays exactly once per webview
- *     reload, and never redisplays once resolved — owned entirely by
- *     `ApprovalRequestHandler`'s pending/delivered bookkeeping, untouched by
- *     this refactor.
+ *     reload, and never redisplays once resolved, from
+ *     `ApprovalRequestHandler`'s pending/delivered bookkeeping.
  *  2. A presentation event emitted before any host attaches (the launch
  *     path, before `ProgressViewProvider` is constructed) is not lost: the
- *     runtime's `replayWhenAttached` queue — not the deleted buffer —
- *     replays it exactly once when the presentation host attaches.
+ *     runtime's `replayWhenAttached` queue replays it exactly once when the
+ *     presentation host attaches.
  */
 
 const mocks = vi.hoisted(() => ({
@@ -65,12 +61,6 @@ afterEach(() => {
   for (const session of testSessions.splice(0)) session.dispose();
 });
 
-function attachedSession(): SessionHandle {
-  const session = createTestSession();
-  testSessions.push(session);
-  return session;
-}
-
 describe('extension presentation-event emit port (#9251 replay gate)', () => {
   it('redisplays a pending tool-edit approval exactly once per webview reload', () => {
     let canSend = false;
@@ -102,16 +92,17 @@ describe('extension presentation-event emit port (#9251 replay gate)', () => {
   });
 
   it('replays a launch-path presentation event exactly once once the presentation host attaches', async () => {
-    const session = attachedSession();
+    const session = createTestSession();
+    testSessions.push(session);
     const showErrorMessage = vi
       .spyOn(vscode.window, 'showErrorMessage')
       .mockResolvedValue(undefined);
 
     try {
-      // Emitted before any host has attached — mirrors a launch failure
+      // Emitted before any host has attached, mirroring a launch failure
       // (`AgentLaunchContext.ts`) firing before `ProgressViewProvider` is
-      // constructed. Only the runtime's `replayWhenAttached` queue — not the
-      // deleted buffer — can save this event.
+      // constructed. Only the runtime's `replayWhenAttached` queue can save
+      // this event.
       session.interactions.emit(
         'requestShowError',
         { message: 'Launch failed before the view attached.' },

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
 
-import { SessionHandle } from '@agent/runtime/SessionHandle';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionEvent } from '@agent/runtime/SessionEventHub';
 import type { HostApprovalBypassStateUpdate } from '@agent/runtime/HostInteractions';
 import type { ProgressHostInteractionsOptions } from '@controllers/progressView/backend/progressHostInteractions';
@@ -26,7 +26,8 @@ vi.mock('@frontend/latex/inlineCriticism', () => ({
   pushManualCriticism: mocks.pushManualCriticism,
 }));
 
-function createRuntimeHost() {
+/** The caller-supplied presentation host `emit` routes interaction events to. */
+function createPresentationSink() {
   return { emit: vi.fn() };
 }
 
@@ -66,7 +67,7 @@ function firstShowRequestId(show: ReturnType<typeof vi.fn>): string {
  * has to find the requests `show()` recorded.
  */
 function createInteractions(options: {
-  presentationSink?: ReturnType<typeof createRuntimeHost>;
+  presentationSink?: ReturnType<typeof createPresentationSink>;
   setApprovalBypassState?: (update: HostApprovalBypassStateUpdate) => void;
   session: SessionHandle;
 }) {
@@ -76,7 +77,7 @@ function createInteractions(options: {
     handlers,
     toolEditApprovals,
     interactions: createExtensionHostInteractions({
-      interactions: options.presentationSink ?? createRuntimeHost(),
+      interactions: options.presentationSink ?? createPresentationSink(),
       session: options.session,
       getApprovalHandlers: () => handlers,
       getToolEditApprovals: () =>
@@ -97,8 +98,8 @@ function recordSessionEvents(session: SessionHandle): SessionEvent[] {
 }
 
 describe('createExtensionHostInteractions', () => {
-  it('forwards emit to the caller-supplied runtime host (#9251)', () => {
-    const presentationSink = createRuntimeHost();
+  it('forwards emit to the caller-supplied presentation host (#9251)', () => {
+    const presentationSink = createPresentationSink();
     const session = createTestSession();
     const { interactions } = createInteractions({ presentationSink, session });
 
@@ -277,7 +278,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('shows and resolves plan approvals through existing handlers', async () => {
-    const presentationSink = createRuntimeHost();
+    const presentationSink = createPresentationSink();
     const session = createTestSession();
     const sessionEvents = recordSessionEvents(session);
     const { handlers, interactions } = createInteractions({
@@ -440,7 +441,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('cancels pending retry requests for a removed stream', async () => {
-    const presentationSink = createRuntimeHost();
+    const presentationSink = createPresentationSink();
     const { handlers, interactions } = createInteractions({
       presentationSink,
       session: createTestSession(),
@@ -557,7 +558,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('shows external inquiries without waiting for a user decision', async () => {
-    const presentationSink = createRuntimeHost();
+    const presentationSink = createPresentationSink();
     const { handlers, interactions } = createInteractions({
       presentationSink,
       session: createTestSession(),

--- a/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
@@ -100,6 +100,17 @@ function image(fileName: string): ExtractedClipboardImage {
   };
 }
 
+describe('follow-up-input layout', () => {
+  it('uses two content-sized rows without Web Awesome auto-resize', async () => {
+    const element = createFollowUpInput('stream-layout');
+    await element.updateComplete;
+
+    const textarea = element.shadowRoot?.querySelector('wa-textarea');
+    expect(textarea?.getAttribute('rows')).toBe('2');
+    expect(textarea?.getAttribute('resize')).toBe('none');
+  });
+});
+
 describe('follow-up-input pasted-image state across stream switches', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/test-kernel/progressView/ProgressBackendAppSignals.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendAppSignals.vitest.ts
@@ -1,9 +1,9 @@
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { ProgressBackend } from '@controllers/progressView/backend/ProgressBackend';
+import type { ProgressBackend } from '@controllers/progressView/backend/ProgressBackend';
 import type {
   AppSignal,
   AppSignalPayloads,
@@ -16,7 +16,8 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
-import { FakeStateStore } from '@test/support/FakePlatform';
+
+import { createRecordingBackend, track } from './progressBackendHarness';
 
 class MemoryAppSignals implements AppSignalsLike {
   private readonly listeners = new Map<
@@ -52,45 +53,6 @@ class MemoryAppSignals implements AppSignalsLike {
   }
 }
 
-/** Everything a test attaches, released in reverse order by one owner. */
-const testDisposables: { dispose(): void }[] = [];
-
-afterEach(() => {
-  for (const disposable of testDisposables.splice(0).reverse()) {
-    disposable.dispose();
-  }
-});
-
-function track<T extends { dispose(): void }>(disposable: T): T {
-  testDisposables.push(disposable);
-  return disposable;
-}
-
-function createBackend(): ProgressBackend {
-  return track(
-    new ProgressBackend({
-      storage: new FakeStateStore(),
-      sendMessage: () => true,
-      hasTarget: () => true,
-      approvals: {
-        canSend: () => true,
-        overrides: {
-          retry: { show: vi.fn(), dismiss: vi.fn() },
-          proposal: { show: vi.fn(), dismiss: vi.fn() },
-        },
-      },
-      lifecycle: {
-        stopStream: vi.fn(),
-        cleanupDeletedStream: vi.fn(),
-        cleanupDeletedStreams: vi.fn(),
-        rebuildRenderedStreams: vi.fn(),
-        activateStream: vi.fn(),
-        notifyDeletionRetained: vi.fn(),
-      },
-    }),
-  );
-}
-
 function setStatus(
   backend: ProgressBackend,
   streamId: StreamTabId,
@@ -112,7 +74,7 @@ function setStatus(
 
 describe('attachProgressBackendAppSignals', () => {
   it('marks running progress tasks cancelled on extension deactivation', () => {
-    const backend = createBackend();
+    const { backend } = createRecordingBackend();
     const signals = new MemoryAppSignals();
     backend.setupEventListeners();
     track(attachProgressBackendAppSignals(backend, signals));
@@ -133,7 +95,7 @@ describe('attachProgressBackendAppSignals', () => {
   });
 
   it('detaches the app-signal listener cleanly', () => {
-    const backend = createBackend();
+    const { backend } = createRecordingBackend();
     const signals = new MemoryAppSignals();
     backend.setupEventListeners();
     const appSignalSubscription = track(

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -25,6 +25,7 @@ import {
   type FileLocation,
   type OutputFileInfo,
   type Plan,
+  type ProgressViewOutboundMessage,
   type StorageKey,
   type StreamTabId,
   type TodoItem,
@@ -40,10 +41,84 @@ import {
   emitRunEvent,
   emitStreamDescription,
   toolUseConfig,
-  track,
 } from './progressBackendHarness';
 
+/** The metadata patch a stream received, narrowed to its message arm. */
+function metadataPatchFor(
+  messages: ProgressViewOutboundMessage[],
+  streamName: string,
+): Extract<
+  ProgressViewOutboundMessage,
+  { command: typeof PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA }
+> {
+  const patch = messages.find(
+    (message) =>
+      message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
+      message.streamInfo.name === streamName,
+  );
+  if (patch?.command !== PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA) {
+    throw new Error(`Expected a metadata patch for ${streamName}`);
+  }
+  return patch;
+}
+
+/** The full-view sync message, narrowed to its message arm. */
+function fullSyncFrom(
+  messages: ProgressViewOutboundMessage[],
+): Extract<
+  ProgressViewOutboundMessage,
+  { command: typeof PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS }
+> {
+  const fullSync = messages.find(
+    (message) => message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+  );
+  if (fullSync?.command !== PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS) {
+    throw new Error('Expected a full stream metadata sync');
+  }
+  return fullSync;
+}
+
 describe('ProgressBackend', () => {
+  it('shows process streams only while they are in flight', () => {
+    const { backend } = createIsolatedRecordingBackend();
+    const root = 'root-session' as StreamTabId;
+    const processStream = 'bash#background-process' as StreamTabId;
+
+    backend.state.streamLogs.ensureStream(root);
+    backend.state.streamLogs.ensureStream(processStream);
+    backend.state.updateStreamMetadata(processStream, {
+      agentCategory: AgentCategory.ToolUse,
+      run: {
+        kind: 'process',
+        agent: 'bash',
+        instruction: 'corepack pnpm run desktop:package:dist',
+      },
+    });
+
+    // Restored process transcripts have no live phase and must not reappear.
+    expect(buildStreamInfos(backend.state).map((info) => info.name)).toEqual([
+      root,
+    ]);
+
+    backend.state.streamStatus.transition(
+      processStream,
+      STREAM_PHASE.RUNNING,
+      STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    );
+    expect(buildStreamInfos(backend.state).map((info) => info.name)).toContain(
+      processStream,
+    );
+
+    backend.state.streamStatus.transitionToTerminal(
+      processStream,
+      STREAM_PHASE.COMPLETED,
+      STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    );
+    expect(buildStreamInfos(backend.state).map((info) => info.name)).toEqual([
+      root,
+    ]);
+  });
+
   it('sends the full metadata set once for full-view sync', () => {
     const { backend, messages } = createRecordingBackend();
 
@@ -68,14 +143,7 @@ describe('ProgressBackend', () => {
       ),
     ).toHaveLength(0);
 
-    const fullSync = messages.find(
-      (message) => message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-    );
-    if (fullSync?.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS) {
-      expect(fullSync.streams).toHaveLength(20);
-    } else {
-      throw new Error('Expected full stream metadata sync');
-    }
+    expect(fullSyncFrom(messages).streams).toHaveLength(20);
   });
 
   it('registers a suppressed interaction stream without switching to it', async () => {
@@ -149,15 +217,7 @@ describe('ProgressBackend', () => {
         phaseStage: { label: 'Reduce', index: 1, total: 3 },
       }),
     );
-    const patch = messages.find(
-      (message) =>
-        message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
-        message.streamInfo.name === run,
-    );
-    if (patch?.command !== PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA) {
-      throw new Error('Expected a metadata patch for the run stream');
-    }
-    expect(patch.streamState).toMatchObject({
+    expect(metadataPatchFor(messages, run).streamState).toMatchObject({
       phaseStage: { label: 'Reduce', index: 1, total: 3 },
       roundStage: null,
     });
@@ -236,31 +296,19 @@ describe('ProgressBackend', () => {
       ),
     ).toBe(false);
 
-    const patch = messages.find(
-      (message) =>
-        message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
-    );
+    const patch = metadataPatchFor(messages, 'child');
     messages.length = 0;
 
     backend.webviewUpdater.sendStreamMetadata(
       backend.state,
       backend.factApplier.getAllStreamStates(),
     );
-    const fullSync = messages.find(
-      (message) => message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-    );
+    const fullSync = fullSyncFrom(messages);
 
-    if (
-      patch?.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
-      fullSync?.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS
-    ) {
-      expect(
-        fullSync.streams.find((stream) => stream.name === 'child'),
-      ).toEqual(patch.streamInfo);
-      expect(fullSync.streamStates?.child).toEqual(patch.streamState);
-    } else {
-      throw new Error('Expected patch and full sync messages');
-    }
+    expect(fullSync.streams.find((stream) => stream.name === 'child')).toEqual(
+      patch.streamInfo,
+    );
+    expect(fullSync.streamStates?.child).toEqual(patch.streamState);
   });
 
   it('scopes direct session events to each backend session', async () => {
@@ -484,7 +532,8 @@ describe('ProgressBackend', () => {
   });
 
   it('applies session run facts through the fact-native handler', async () => {
-    const { backend, session } = createIsolatedRecordingBackend();
+    const target = createIsolatedRecordingBackend();
+    const { backend } = target;
     backend.setupEventListeners();
     const handleRunFact = vi.spyOn(backend.factApplier, 'handleRunFact');
     const updateFiles = vi.spyOn(backend.webviewUpdater, 'updateFiles');
@@ -541,13 +590,10 @@ describe('ProgressBackend', () => {
 
     try {
       await backend.state.snapshots.load([]);
-      emitActiveStream(
-        { session },
-        {
-          streamId,
-          agentCategory: AgentCategory.Workflow,
-        },
-      );
+      emitActiveStream(target, {
+        streamId,
+        agentCategory: AgentCategory.Workflow,
+      });
       handleRunFact.mockClear();
       updateFiles.mockClear();
       updateMissingOutputs.mockClear();
@@ -556,32 +602,32 @@ describe('ProgressBackend', () => {
       updateTodos.mockClear();
       updatePlan.mockClear();
 
-      emitRunEvent({ session }, streamId, {
+      emitRunEvent(target, streamId, {
         type: 'addOutputFiles',
         streamId,
         filesByRound: { 1: [outputFile] },
       });
-      emitRunEvent({ session }, streamId, {
+      emitRunEvent(target, streamId, {
         type: 'updateMissingOutputs',
         streamId,
         filesByRound: { 1: ['paper.pdf'] },
       });
-      emitRunEvent({ session }, streamId, {
+      emitRunEvent(target, streamId, {
         type: 'updateCompileFailures',
         streamId,
         filesByRound: { 1: [compileFailure] },
       });
-      emitRunEvent({ session }, streamId, {
+      emitRunEvent(target, streamId, {
         type: 'updateTodos',
         streamId,
         todos,
       });
-      emitRunEvent({ session }, streamId, {
+      emitRunEvent(target, streamId, {
         type: 'updatePlan',
         streamId,
         plan,
       });
-      emitRunEvent({ session }, streamId, {
+      emitRunEvent(target, streamId, {
         type: 'usage',
         payload: {
           streamId,
@@ -590,7 +636,7 @@ describe('ProgressBackend', () => {
         },
         recordTranscript: false,
       });
-      emitRunEvent({ session }, streamId, {
+      emitRunEvent(target, streamId, {
         type: 'goalPaused',
         streamId,
       });
@@ -653,7 +699,8 @@ describe('ProgressBackend', () => {
   });
 
   it('drops malformed updateTodos/updatePlan run facts instead of forwarding them unchecked (#7562)', async () => {
-    const { backend, session } = createIsolatedRecordingBackend();
+    const target = createIsolatedRecordingBackend();
+    const { backend } = target;
     backend.setupEventListeners();
     const updateTodos = vi.spyOn(backend.webviewUpdater, 'updateTodos');
     const updatePlan = vi.spyOn(backend.webviewUpdater, 'updatePlan');
@@ -661,22 +708,19 @@ describe('ProgressBackend', () => {
 
     try {
       await backend.state.snapshots.load([]);
-      emitActiveStream(
-        { session },
-        {
-          streamId,
-          agentCategory: AgentCategory.Workflow,
-        },
-      );
+      emitActiveStream(target, {
+        streamId,
+        agentCategory: AgentCategory.Workflow,
+      });
       updateTodos.mockClear();
       updatePlan.mockClear();
 
-      emitRunEvent({ session }, streamId, {
+      emitRunEvent(target, streamId, {
         type: 'domain',
         key: 'runFact.updateTodos',
         data: { streamId, todos: 'not-an-array' },
       });
-      emitRunEvent({ session }, streamId, {
+      emitRunEvent(target, streamId, {
         type: 'domain',
         key: 'runFact.updatePlan',
         data: { streamId, plan: { steps: ['legacy shape'] } },
@@ -690,7 +734,8 @@ describe('ProgressBackend', () => {
   });
 
   it('no-ops session output-file run facts after dispose', async () => {
-    const { backend, session } = createIsolatedRecordingBackend();
+    const target = createIsolatedRecordingBackend();
+    const { backend } = target;
     backend.setupEventListeners();
     const handleRunFact = vi.spyOn(backend.factApplier, 'handleRunFact');
     const updateFiles = vi.spyOn(backend.webviewUpdater, 'updateFiles');
@@ -710,18 +755,15 @@ describe('ProgressBackend', () => {
 
     try {
       await backend.state.snapshots.load([]);
-      emitActiveStream(
-        { session },
-        {
-          streamId,
-          agentCategory: AgentCategory.Workflow,
-        },
-      );
+      emitActiveStream(target, {
+        streamId,
+        agentCategory: AgentCategory.Workflow,
+      });
       handleRunFact.mockClear();
       updateFiles.mockClear();
       backend.dispose();
 
-      emitRunEvent({ session }, streamId, {
+      emitRunEvent(target, streamId, {
         type: 'addOutputFiles',
         streamId,
         filesByRound: { 1: [outputFile] },
@@ -940,14 +982,7 @@ describe('ProgressBackend', () => {
       ),
     ).toBe(false);
 
-    const patch = messages.find(
-      (message) =>
-        message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
-        message.streamInfo.name === stream,
-    );
-    if (patch?.command !== PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA) {
-      throw new Error('Expected existing stream metadata patch');
-    }
+    const patch = metadataPatchFor(messages, stream);
 
     expect(patch.streamState).toMatchObject({
       kind: AgentCategory.ToolUse,
@@ -1048,9 +1083,6 @@ describe('ProgressBackend', () => {
     // block-bodied handler that discarded the promise would hand
     // `withEventErrorHandling` `undefined`, leaving this untouched — and a
     // post-await rejection would then escape logging as an unhandled rejection.
-    // `setStreamStatus` now has exactly one caller — the session-fact
-    // canonical `status` path — since `StreamStatusMachine` publishes every
-    // transition on that rail and the run-fact arm is gone.
     let adopted = 0;
     const tracking: PromiseLike<void> = {
       then(onFulfilled, onRejected) {
@@ -1075,7 +1107,7 @@ describe('ProgressBackend', () => {
     expect(adopted).toBe(1);
   });
 
-  it('keeps task-state metadata canonical across rendering and sync content', () => {
+  it('keeps snapshot metadata canonical across rendering and sync content', () => {
     const { backend, messages } = createRecordingBackend();
     const stream = 'search@deepseek#de5711c' as StreamTabId;
     const executionId = 'de5711c' as ExecutionId;
@@ -1095,7 +1127,7 @@ describe('ProgressBackend', () => {
       executionId,
     );
     backend.state.refreshStreamMetadataFromSnapshot(stream);
-    // A late provisional event cannot replace task-state authority.
+    // A late provisional event cannot replace snapshot authority.
     backend.state.updateStreamMetadata(stream, {
       agentCategory: AgentCategory.Workflow,
     });

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -79,46 +79,6 @@ function fullSyncFrom(
 }
 
 describe('ProgressBackend', () => {
-  it('shows process streams only while they are in flight', () => {
-    const { backend } = createIsolatedRecordingBackend();
-    const root = 'root-session' as StreamTabId;
-    const processStream = 'bash#background-process' as StreamTabId;
-
-    backend.state.streamLogs.ensureStream(root);
-    backend.state.streamLogs.ensureStream(processStream);
-    backend.state.updateStreamMetadata(processStream, {
-      agentCategory: AgentCategory.ToolUse,
-      run: {
-        kind: 'process',
-        agent: 'bash',
-        instruction: 'corepack pnpm run desktop:package:dist',
-      },
-    });
-
-    // Restored process transcripts have no live phase and must not reappear.
-    expect(buildStreamInfos(backend.state).map((info) => info.name)).toEqual([
-      root,
-    ]);
-
-    backend.state.streamStatus.transition(
-      processStream,
-      STREAM_PHASE.RUNNING,
-      STREAM_TRANSITION_CAUSE.LIFECYCLE,
-    );
-    expect(buildStreamInfos(backend.state).map((info) => info.name)).toContain(
-      processStream,
-    );
-
-    backend.state.streamStatus.transitionToTerminal(
-      processStream,
-      STREAM_PHASE.COMPLETED,
-      STREAM_TRANSITION_CAUSE.LIFECYCLE,
-    );
-    expect(buildStreamInfos(backend.state).map((info) => info.name)).toEqual([
-      root,
-    ]);
-  });
-
   it('sends the full metadata set once for full-view sync', () => {
     const { backend, messages } = createRecordingBackend();
 

--- a/src/test-kernel/progressView/ProgressTargetOwnership.vitest.mts
+++ b/src/test-kernel/progressView/ProgressTargetOwnership.vitest.mts
@@ -111,6 +111,7 @@ function createProvider() {
   injected.state = {
     activeStream: undefined,
     streamLogs: { keys: () => [], get: () => undefined },
+    selectableStreamNames: () => [],
   };
   injected.backend = {
     approvalHandlers: {},

--- a/src/test-kernel/progressView/ProgressTargetOwnership.vitest.mts
+++ b/src/test-kernel/progressView/ProgressTargetOwnership.vitest.mts
@@ -111,7 +111,6 @@ function createProvider() {
   injected.state = {
     activeStream: undefined,
     streamLogs: { keys: () => [], get: () => undefined },
-    selectableStreamNames: () => [],
   };
   injected.backend = {
     approvalHandlers: {},

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -1,6 +1,4 @@
 // Test composition imports
-
-// Local imports
 import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
@@ -20,7 +18,6 @@ import {
   createWorkflowConfig,
 } from '../support/ProgressControllerHarnesses';
 
-// Third-party imports
 import type * as vscode from 'vscode';
 
 const mocks = vi.hoisted(() => ({

--- a/src/test-kernel/progressView/StreamHeader.vitest.mts
+++ b/src/test-kernel/progressView/StreamHeader.vitest.mts
@@ -250,6 +250,9 @@ describe('stream-header', () => {
       expect(stopButton).toBeTruthy();
       expect(stopButton?.tagName).toBe('WA-BUTTON');
       expect(stopButton?.hasAttribute('data-command')).toBe(false);
+      expect(stopButton?.querySelector('wa-icon')?.getAttribute('name')).toBe(
+        'circle-stop',
+      );
 
       const stopTooltip = element.shadowRoot?.querySelector(
         `wa-tooltip[for="${ELEMENT_IDS.STOP_STREAM_BTN}"]`,

--- a/src/test-kernel/progressView/StreamMetaState.vitest.ts
+++ b/src/test-kernel/progressView/StreamMetaState.vitest.ts
@@ -45,6 +45,13 @@ function dispatch(
   assertSupported(handler!)(message as never);
 }
 
+/** A message as the webview receives it, after the postMessage JSON round-trip. */
+function overWire(
+  message: ProgressViewOutboundMessage,
+): ProgressViewOutboundMessage {
+  return JSON.parse(JSON.stringify(message)) as ProgressViewOutboundMessage;
+}
+
 function registerStream(
   state: ProgressState,
   streamId: StreamTabId,
@@ -250,27 +257,25 @@ describe('stream meta frontend state', () => {
     );
     const getState = seedState(state);
 
-    const message = JSON.parse(
-      JSON.stringify({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
-        streamInfo: {
-          name: streamId,
-          label: 'stream-a',
-          kind: 'agent',
-          agentCategory: AgentCategory.Workflow,
-          creationTimestamp: 1,
+    const message = overWire({
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
+      streamInfo: {
+        name: streamId,
+        label: 'stream-a',
+        kind: 'agent',
+        agentCategory: AgentCategory.Workflow,
+        creationTimestamp: 1,
+      },
+      streamState: {
+        kind: AgentCategory.Workflow,
+        status: STREAM_PHASE.RUNNING,
+        conversationProgress: {
+          toolCallCount: 0,
         },
-        streamState: {
-          kind: AgentCategory.Workflow,
-          status: STREAM_PHASE.RUNNING,
-          conversationProgress: {
-            toolCallCount: 0,
-          },
-          roundStage: null,
-          subagents: [],
-        },
-      } satisfies ProgressViewOutboundMessage),
-    ) as ProgressViewOutboundMessage;
+        roundStage: null,
+        subagents: [],
+      },
+    });
 
     dispatch(streamMetaHandlers, message);
 
@@ -286,28 +291,26 @@ describe('stream meta frontend state', () => {
     const patch = (
       phaseStage: { label: string; index?: number; total?: number } | null,
     ): ProgressViewOutboundMessage =>
-      JSON.parse(
-        JSON.stringify({
-          command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
-          streamInfo: {
-            name: streamId,
-            label: 'stream-a',
-            kind: 'agent',
-            agentCategory: AgentCategory.Workflow,
-            creationTimestamp: 1,
+      overWire({
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
+        streamInfo: {
+          name: streamId,
+          label: 'stream-a',
+          kind: 'agent',
+          agentCategory: AgentCategory.Workflow,
+          creationTimestamp: 1,
+        },
+        streamState: {
+          kind: AgentCategory.Workflow,
+          status: STREAM_PHASE.RUNNING,
+          conversationProgress: {
+            toolCallCount: 0,
           },
-          streamState: {
-            kind: AgentCategory.Workflow,
-            status: STREAM_PHASE.RUNNING,
-            conversationProgress: {
-              toolCallCount: 0,
-            },
-            roundStage: null,
-            phaseStage,
-            subagents: [],
-          },
-        } satisfies ProgressViewOutboundMessage),
-      ) as ProgressViewOutboundMessage;
+          roundStage: null,
+          phaseStage,
+          subagents: [],
+        },
+      });
 
     dispatch(
       streamMetaHandlers,
@@ -388,25 +391,23 @@ describe('stream meta frontend state', () => {
     );
     const getState = seedState(state);
 
-    const message = JSON.parse(
-      JSON.stringify({
-        command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
-        stream: streamId,
-        action: 'render',
-        kind: AgentCategory.Workflow,
-        runUsage: {},
-        outputs: { files: {}, missing: {}, compileFailures: {} },
-        activeState: {
-          conversationProgress: { toolCallCount: 0 },
-          roundStage: null,
-          phaseStage: null,
-          badges: {
-            subagents: [],
-          },
-          parentStreamId: null,
+    const message = overWire({
+      command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+      stream: streamId,
+      action: 'render',
+      kind: AgentCategory.Workflow,
+      runUsage: {},
+      outputs: { files: {}, missing: {}, compileFailures: {} },
+      activeState: {
+        conversationProgress: { toolCallCount: 0 },
+        roundStage: null,
+        phaseStage: null,
+        badges: {
+          subagents: [],
         },
-      } satisfies ProgressViewOutboundMessage),
-    ) as ProgressViewOutboundMessage;
+        parentStreamId: null,
+      },
+    });
 
     dispatch(syncHandlers, message);
 

--- a/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.mts
+++ b/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.mts
@@ -32,19 +32,14 @@ async function mountTabs(props: Partial<StreamTabs>): Promise<StreamTabs> {
   return element;
 }
 
-/**
- * Regression coverage: the child-stream expand/collapse chevron renders as
- * the shared `wa-button` action-icon pattern (matching the sibling delete
- * button two elements over), not a hand-rolled native `<button>` reset. The
- * delegated click handler in StreamTabs.handleTabClick keys off
- * `[data-stream][data-action]`, so the element must keep carrying both
- * attributes regardless of tag name.
- */
 describe('stream-tab expand chevron', () => {
   useLitComponentTestDom(
     () => import('@progressView/frontend/components/StreamTabs'),
   );
 
+  // The child-stream expand/collapse chevron uses the shared `wa-button`
+  // action-icon pattern, and StreamTabs.handleTabClick delegates off
+  // `[data-stream][data-action]`, so the element must carry both attributes.
   it('renders the expand toggle as a wa-button carrying the delegated-click contract', async () => {
     const tabs = await mountTabs({
       streams: [makeStream('parent')],

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -10,16 +10,10 @@ import {
   useLitComponentTestDom,
 } from '../settings/litComponentTestUtils';
 
-useLitComponentTestDom(() =>
-  Promise.all([
-    import('@progressView/frontend/formatters/logFormatters/toolFormatters'),
-    import('@progressView/frontend/formatters/logFormatters/bannerFormatters'),
-    import('@progressView/frontend/formatters/logFormatters/messageFormatters'),
-  ]),
-);
+useLitComponentTestDom();
 
-// Loaded after useLitComponentTestDom's beforeAll installs the jsdom globals
-// these modules touch at import time.
+// Imported in a `beforeAll` registered after useLitComponentTestDom's, so the
+// jsdom globals these modules touch at import time are already installed.
 let formatToolUseTemplate: typeof import('@progressView/frontend/formatters/logFormatters/toolFormatters').formatToolUseTemplate;
 let formatLogEntry: typeof import('@progressView/frontend/formatters').formatLogEntry;
 let getToolTimeoutMs: typeof import('@progressView/frontend/formatters/logFormatters/toolFormatters/helpers').getToolTimeoutMs;

--- a/src/test-kernel/shared/settingsConfiguration.vitest.ts
+++ b/src/test-kernel/shared/settingsConfiguration.vitest.ts
@@ -74,7 +74,6 @@ describe('TexraSettingsSchema', () => {
     assert.equal(parsed.apiKeys.set, null);
     assert.equal(parsed.apiKeys.remove, null);
     assert.deepEqual(parsed.files.included.editedExtensions, ['.txt', '.tex']);
-    // T10: Google Interactions server-side state defaults ON.
     assert.equal(parsed.model.useGoogleInteractionsServerState, true);
     assert.deepEqual(parsed, DEFAULT_TEXRA_SETTINGS);
   });

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -122,7 +122,7 @@ const EXPECTED_DEFAULTS: Record<string, unknown> = {
   [GlobalStateKey.USE_OPENROUTER]: false,
   [GlobalStateKey.KIMI_CODE_PREFER]: false,
   // Region defaults mirror the PROVIDER_REGISTRY `region.default` facts the
-  // `regionSet()` getter reads (now via `readPlatformSetting`).
+  // `regionSet()` getter reads through `readPlatformSetting`.
   [GlobalStateKey.MOONSHOT_USE_CHINA]: true,
   [GlobalStateKey.DASHSCOPE_USE_CHINA]: false,
   [GlobalStateKey.MINIMAX_USE_CHINA]: false,
@@ -256,9 +256,8 @@ describe('state settings catalog', () => {
   });
 
   it('drives the LaTeX tab enum option labels from catalog metadata', () => {
-    // Locks the catalog wording the extension's LaTeXTab now composes its
-    // <wa-select> labels from, so the displayed options stay byte-identical to
-    // the previously hand-listed arrays.
+    // Locks the catalog wording the extension's LaTeXTab composes its
+    // <wa-select> labels from.
     const mathMarkup = entryByKey(WorkspaceStateKey.LATEXDIFF_MATH_MARKUP);
     const mathMarkupLabels = (settingEnumOptions(mathMarkup) ?? []).map(
       (value, index) => {
@@ -519,8 +518,6 @@ describe('core settings host split', () => {
     }
   });
 });
-
-// --- accessor round-trip ----------------------------------------------------
 
 describe('settingsAccess', () => {
   it('reads the default when the key is absent', () => {

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -18,7 +18,7 @@ import {
 
 const sid = (s: string): StreamTabId => s as StreamTabId;
 
-describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
+describe('approval cleanup scope', () => {
   it("per-stream cleanup leaves another stream's approval state intact", () => {
     const a = sid('s:appr-scope-a');
     const b = sid('s:appr-scope-b');

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -58,14 +58,14 @@ import { TaskRunFileService } from '@utils/files';
 import * as execUtils from '@utils/system/execUtils';
 
 // Local file imports
+import { testModelCell } from '../agent/modelCellTestUtils';
 import {
   recordSessionEvents,
   testRunScope,
   withTestRunContext,
 } from '../agent/progressTestUtils';
 
-// Third-party imports
-import { testModelCell } from '../agent/modelCellTestUtils';
+// Third-party type-only import (import/order places it last)
 import type OpenAI from 'openai';
 
 const testModelConfig: ModelConfig = {
@@ -233,6 +233,27 @@ function mockStreamingCommand(
   );
 }
 
+// Unit tests exercise the tool directly — no approval host is wired.
+const BASH_PLATFORM_OPTIONS = {
+  workspacePath: '/workspace',
+  config: { 'texra.toolUse.requireBashApproval': false },
+} as const;
+
+/** The execution and child-stream ids a background launch reports in its output. */
+function launchedIds(result: ToolResult): {
+  output: string;
+  executionId: string | undefined;
+  childStreamId: StreamTabId | undefined;
+} {
+  const output = String(result.output ?? '');
+  return {
+    output,
+    executionId: /Execution ID: (\S+)/.exec(output)?.[1],
+    childStreamId: /Stream tab: (\S+)/.exec(output)?.[1] as
+      StreamTabId | undefined,
+  };
+}
+
 function launchBackgroundBash(
   parentStreamId: StreamTabId,
 ): Promise<ToolResult> {
@@ -250,11 +271,7 @@ function launchBackgroundBash(
 }
 
 describe('BashTool', () => {
-  setupPlatform({
-    workspacePath: '/workspace',
-    // Unit tests exercise the tool directly — no approval host is wired.
-    config: { 'texra.toolUse.requireBashApproval': false },
-  });
+  setupPlatform(BASH_PLATFORM_OPTIONS);
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -620,12 +637,9 @@ describe('BashTool', () => {
       recorded.detach();
     }
 
-    // sendFollowUp is overloaded (string | FollowUpQueueInput); bash.ts always
-    // calls the object form, but Parameters<> on an overloaded function type
-    // resolves to the last signature, so assert the concrete shape here.
-    const followUpArg = submitFollowUpSpy.mock.calls[0]?.[1] as unknown as
-      { text: string } | undefined;
-    const deliveredText = followUpArg?.text;
+    const followUpArg = submitFollowUpSpy.mock.calls[0]?.[1];
+    const deliveredText =
+      typeof followUpArg === 'string' ? followUpArg : followUpArg?.text;
     assert.ok(
       typeof deliveredText === 'string' && deliveredText.includes(headMarker),
       'Delivered follow-up should retain the first fatal error (head)',
@@ -657,13 +671,9 @@ describe('BashTool', () => {
 
     const parentStreamId = 'bash-tool-bg-wake-parent' as StreamTabId;
     const tryResumeStream = vi.fn().mockResolvedValue(true);
-    await installPlatform(
-      {
-        workspacePath: '/workspace',
-        config: { 'texra.toolUse.requireBashApproval': false },
-      },
-      { agentResume: { tryResumeStream } },
-    );
+    await installPlatform(BASH_PLATFORM_OPTIONS, {
+      agentResume: { tryResumeStream },
+    });
     seedStreamStatusForTest(
       defaultSession().status,
       parentStreamId,
@@ -722,13 +732,9 @@ describe('BashTool', () => {
       });
       return true;
     });
-    await installPlatform(
-      {
-        workspacePath: '/workspace',
-        config: { 'texra.toolUse.requireBashApproval': false },
-      },
-      { agentResume: { tryResumeStream } },
-    );
+    await installPlatform(BASH_PLATFORM_OPTIONS, {
+      agentResume: { tryResumeStream },
+    });
     seedStreamStatusForTest(
       defaultSession().status,
       parentStreamId,
@@ -740,14 +746,12 @@ describe('BashTool', () => {
     try {
       const launchResult = await launchBackgroundBash(parentStreamId);
       assert.equal(launchResult.status, 'executed');
-      const executionIdMatch = /Execution ID: (\S+)/.exec(
-        String(launchResult.output ?? ''),
-      );
+      const launched = launchedIds(launchResult);
       assert.ok(
-        executionIdMatch,
+        launched.executionId,
         'Launch output should report an execution id',
       );
-      executionId = executionIdMatch![1]!;
+      executionId = launched.executionId;
 
       await vi.waitFor(() => {
         assert.ok(
@@ -779,17 +783,12 @@ describe('BashTool', () => {
           resolveCommand = resolve;
         }),
     );
-    await installPlatform({
-      workspacePath: '/workspace',
-      config: { 'texra.toolUse.requireBashApproval': false },
-    });
+    await installPlatform(BASH_PLATFORM_OPTIONS);
     const parentStreamId = 'bash-result-meta-failure' as StreamTabId;
     const recorded = recordSessionEvents(defaultSession().events);
 
     const launchResult = await launchBackgroundBash(parentStreamId);
-    const executionId = /Execution ID: (\S+)/.exec(
-      String(launchResult.output ?? ''),
-    )?.[1];
+    const { executionId } = launchedIds(launchResult);
     assert.ok(executionId, JSON.stringify(launchResult));
     const store = getExecutionStore(executionId);
     vi.spyOn(store, 'writeResultMeta').mockRejectedValueOnce(
@@ -828,20 +827,14 @@ describe('BashTool', () => {
     vi.spyOn(subagentResults, 'formatBashDelivery').mockImplementation(() => {
       throw new Error('delivery formatting blew up');
     });
-    await installPlatform({
-      workspacePath: '/workspace',
-      config: { 'texra.toolUse.requireBashApproval': false },
-    });
+    await installPlatform(BASH_PLATFORM_OPTIONS);
     const parentStreamId = 'bash-completion-path-throw' as StreamTabId;
     const recorded = recordSessionEvents(defaultSession().events);
 
     const launchResult = await launchBackgroundBash(parentStreamId);
-    const launchOutput = String(launchResult.output ?? '');
-    const executionId = /Execution ID: (\S+)/.exec(launchOutput)?.[1];
-    const childStreamId = /Stream tab: (\S+)/.exec(launchOutput)?.[1] as
-      StreamTabId | undefined;
-    assert.ok(executionId, launchOutput);
-    assert.ok(childStreamId, launchOutput);
+    const { output, executionId, childStreamId } = launchedIds(launchResult);
+    assert.ok(executionId, output);
+    assert.ok(childStreamId, output);
 
     resolveCommand?.({
       success: true,
@@ -872,20 +865,14 @@ describe('BashTool', () => {
           resolveCommand = resolve;
         }),
     );
-    await installPlatform({
-      workspacePath: '/workspace',
-      config: { 'texra.toolUse.requireBashApproval': false },
-    });
+    await installPlatform(BASH_PLATFORM_OPTIONS);
     const parentStreamId = 'bash-killed-background' as StreamTabId;
     const recorded = recordSessionEvents(defaultSession().events);
 
     const launchResult = await launchBackgroundBash(parentStreamId);
-    const launchOutput = String(launchResult.output ?? '');
-    const executionId = /Execution ID: (\S+)/.exec(launchOutput)?.[1];
-    const childStreamId = /Stream tab: (\S+)/.exec(launchOutput)?.[1] as
-      StreamTabId | undefined;
-    assert.ok(executionId, launchOutput);
-    assert.ok(childStreamId, launchOutput);
+    const { output, executionId, childStreamId } = launchedIds(launchResult);
+    assert.ok(executionId, output);
+    assert.ok(childStreamId, output);
 
     // The user stop lands CANCELLED on the stream phase; only afterwards does
     // the killed process report its non-zero exit.

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -1,9 +1,9 @@
-// Regression coverage for the claude_agent tool's resume fallback: when a
-// caller passes a session_id whose in-memory ClaudeAgentSessions registry
-// entry is gone (extension reload, host crash, or a stale id from an older
-// run). The first fallback must claim the id before asynchronous setup, while
-// concurrent calls wait for that loop and then enqueue through the ordinary
-// follow-up path.
+// Launch and resume coverage for the claude_agent tool. The resume fallback
+// applies when a caller passes a session_id whose in-memory
+// ClaudeAgentSessions registry entry is gone (extension reload, host crash, or
+// a stale id from an older run): the first fallback claims the id before
+// asynchronous setup, while concurrent calls wait for that loop and then
+// enqueue through the ordinary follow-up path.
 
 import pDefer from 'p-defer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -114,7 +114,7 @@ async function* streamMessages(messages: unknown[]): AsyncGenerator<unknown> {
   }
 }
 
-describe('claude_agent tool — resume fallback for a torn-down registry', () => {
+describe('claude_agent tool launch and resume fallback', () => {
   beforeEach(() => {
     mocks.startChildRunLoop.mockReset();
     mocks.startChildRunLoop.mockReturnValue(completedChildRunLoop());

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -93,7 +93,7 @@ vi.mock('@tools/approval', () => ({
 const PARENT_STREAM_ID = 'parent-stream' as StreamTabId;
 const CHILD_STREAM_ID = 'child-stream' as StreamTabId;
 
-/** The run context shared by nearly every case (host/stopAfterCycle/session vary). */
+/** The run context shared by nearly every case (stream/stopAfterCycle/session vary). */
 function parentRunContext(
   overrides: Partial<{
     streamId: StreamTabId;
@@ -410,11 +410,11 @@ describe('headless delegation', () => {
       () => callDelegateReview(),
     );
 
-    // The delivery XML still returns synchronously — a persistence hiccup on
+    // The delivery XML still returns synchronously: a persistence hiccup on
     // the best-effort path never fails a call whose result already returned
-    // inline (see PersistenceMode's `best-effort-delivery`, unchanged by this
-    // fix). What is lost is the durable report copy, which is why the lease
-    // must be marked undurable — mirroring `childRunLoop.ts`'s twin marks.
+    // inline (PersistenceMode's `best-effort-delivery`). What is lost is the
+    // durable report copy, so the lease must be marked undurable — mirroring
+    // `childRunLoop.ts`'s twin marks.
     expect(result.status).toBe('executed');
     expect(result.summary).toBe("Completed 'review'");
     const executionId = mocks.registerExecution.mock.calls[0]?.[0];
@@ -1086,17 +1086,9 @@ describe('headless delegation', () => {
   });
 
   it('rejects an approved model override unavailable in the active API mode', async () => {
-    // Only deepseekT is available; gpt5 is not — the override must be rejected
-    // synchronously, mirroring the initial delegate path's availability gate.
-    mocks.computeModelOptionsData.mockResolvedValue([
-      {
-        value: 'deepseekT',
-        label: 'DeepSeek',
-        disabled: false,
-        requiresKey: false,
-      },
-    ]);
-
+    // Only deepseekT is available (see beforeEach); gpt5 is not, so the
+    // override must be rejected synchronously, mirroring the initial delegate
+    // path's availability gate.
     const result = await delegateWithProposalDecision({
       action: 'approve',
       model: 'gpt5',
@@ -1165,10 +1157,8 @@ describe('headless delegation', () => {
   });
 
   it('includes memory misses in interactive early-delivered reports', async () => {
-    // Async delegation is now driven by the child-run loop over
-    // nativeSubagentStrategy: `executeAgent` (mocked here) is the loop's
-    // `launch` turn, and a returned WAITING result is the loop's one
-    // delivery site's input — there is no more onBeforeWaiting callback.
+    // The mocked `executeAgent` is the child-run loop's `launch` turn, and the
+    // WAITING result it returns is what the loop's single delivery site sees.
     mockWaitingChildOnce({
       memoryMisses: [
         { path: '/memories/missing.md', reason: 'not found & unreadable' },

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -439,9 +439,8 @@ describe('ExecutionsTool', () => {
     });
   });
 
-  // Regression for #7300: the advertised /executions/{id}/todos endpoint used
-  // to read legacy KV directly, so it could disagree with the completed
-  // summary above once a run's task list only lived in the sidecar.
+  // The advertised /executions/{id}/todos endpoint must resolve a task list
+  // exactly as the completed summary above does, sidecar first (#7300).
   it('agrees with the completed summary when reading /executions/{id}/todos', async () => {
     await withTempStorage(async () => {
       const executionId = 'abc123' as ExecutionId;
@@ -462,31 +461,6 @@ describe('ExecutionsTool', () => {
 
       expect(result.output).toContain('Read the sidecar work plan');
       expect(result.output).not.toContain('Read the old KV todo');
-      expect(mocks.readTodos).not.toHaveBeenCalled();
-    });
-  });
-
-  it('uses sidecar todos for a completed summary without consulting legacy KV', async () => {
-    await withTempStorage(async () => {
-      const executionId = 'abc123' as ExecutionId;
-      await writeSidecarTodos(executionId, [
-        {
-          content: 'Authoritative sidecar todo',
-          status: 'pending',
-          activeForm: 'Reading the authoritative sidecar todo',
-        },
-      ]);
-      mockCompletedExecution();
-      mocks.readTodos.mockResolvedValue([
-        { content: 'Legacy KV todo', status: 'completed' },
-      ]);
-
-      const result = await new ExecutionsTool().call({
-        path: `/executions/${executionId}`,
-      });
-
-      expect(result.output).toContain('Authoritative sidecar todo');
-      expect(result.output).not.toContain('Legacy KV todo');
       expect(mocks.readTodos).not.toHaveBeenCalled();
     });
   });
@@ -534,11 +508,8 @@ describe('ExecutionsTool', () => {
     });
   });
 
-  // Regression for the executionKvFiles leak fix: isKVFile now derives its
-  // vocabulary from ExecutionKVStore's reserved keys and persistedFlow's
-  // FLOW_KEY_PREFIX instead of a hand-copied literal set, so exercise the
-  // real /executions/{id}/files listing to prove every reserved KV filename
-  // (including the child- and flow_ prefixes) is still filtered out.
+  // Exercises the real listing so every reserved KV filename — including the
+  // child- and flow_ prefixed ones — stays out of the model-facing view.
   it('filters internal KV metadata files out of /executions/{id}/files', async () => {
     await withTempStorage(async () => {
       const executionId = 'abc123' as ExecutionId;
@@ -574,11 +545,9 @@ describe('ExecutionsTool', () => {
     });
   });
 
-  // Regression for a bug caught in review of the leak fix above: every real
-  // KV entry is written as `{key}.json` (KVStore.keyToPath always appends
-  // the suffix), so a generated file whose *basename* happens to collide
-  // with a reserved key name — but has no `.json` extension — must not be
-  // swept up by isKVFile.
+  // Every real KV entry is written as `{key}.json` (KVStore.keyToPath always
+  // appends the suffix), so a generated file whose basename collides with a
+  // reserved key name but carries no `.json` extension stays visible.
   it('keeps extensionless generated files named like reserved KV keys', async () => {
     await withTempStorage(async () => {
       const executionId = 'abc123' as ExecutionId;

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -24,12 +24,11 @@ import {
 import { requestToolEditApproval } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS } from '@utils/files';
 
-// Test stream ID for per-stream YOLO mode tests
+// Test stream ID for the per-stream approval-bypass cases
 const TEST_STREAM_ID = 'TestAgent@model: test.tex' as StreamTabId;
 
-// Mutable test handler reference — the Platform is frozen at init time, so
-// tests inject a delegating handler that reads this reference, mirroring the
-// pattern used by the CLI and desktop hosts.
+// Host interactions are attached once per platform install, so each case swaps
+// this reference and the attached port delegates to whatever it holds.
 let testApprovalHandler:
   | ((request: ToolEditApprovalRequest) => Promise<ToolEditApprovalResult>)
   | undefined;

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -32,7 +32,7 @@ setupPlatform({ storagePath: '/storage', workspacePath: '/workspace' });
 const mocks = vi.hoisted(() => ({
   registerExecution: vi.fn(),
   startChildRunLoop: vi.fn(),
-  createChildStream: vi.fn(),
+  createRehydratedChildStream: vi.fn(),
   configureDelegatedChildApprovals: vi.fn(),
   requireVisibleAgent: vi.fn(),
   selectAvailableDelegationModel: vi.fn(),
@@ -60,7 +60,7 @@ vi.mock('@agent/runtime/childRunLoop', () => ({
 }));
 
 vi.mock('@tools/childStream', () => ({
-  createRehydratedChildStream: mocks.createChildStream,
+  createRehydratedChildStream: mocks.createRehydratedChildStream,
   getChildStreamId: (executionId: string, prefix: string) =>
     `${prefix}#${executionId}`,
 }));
@@ -179,7 +179,7 @@ beforeEach(async () => {
       path: `/agents/${name}.yaml`,
     };
   });
-  mocks.createChildStream.mockImplementation(
+  mocks.createRehydratedChildStream.mockImplementation(
     async (runId: ExecutionId): Promise<unknown> => {
       const logger = new TraceEmitter();
       vi.spyOn(logger, 'error').mockImplementation(mocks.childLoggerError);
@@ -203,17 +203,6 @@ describe('WorkflowScriptTool', () => {
       'workflow',
     );
     expect(DELEGATION_TOOL_CATEGORY.delegate_workflow_script).toBeUndefined();
-  });
-
-  it('launches its deterministic stream through transcript rehydration', async () => {
-    await callTool();
-
-    const runExecutionId = runExecutionIdFor('tool-test');
-    expect(mocks.createChildStream).toHaveBeenCalledWith(
-      runExecutionId,
-      streamId,
-      expect.objectContaining({ streamPrefix: 'workflow-script' }),
-    );
   });
 
   it('owns a detached run completion rejection without delivering a second error', async () => {
@@ -334,7 +323,7 @@ describe('WorkflowScriptTool', () => {
         parentExecutionId: executionId,
       },
     );
-    expect(mocks.createChildStream).toHaveBeenCalledWith(
+    expect(mocks.createRehydratedChildStream).toHaveBeenCalledWith(
       runExecutionId,
       streamId,
       expect.objectContaining({
@@ -594,7 +583,7 @@ describe('WorkflowScriptTool', () => {
     });
     expect(result.error).toContain('Script file: .texra/workflow-scripts/');
     expect(mocks.registerExecution).not.toHaveBeenCalled();
-    expect(mocks.createChildStream).not.toHaveBeenCalled();
+    expect(mocks.createRehydratedChildStream).not.toHaveBeenCalled();
     expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
   });
 
@@ -633,7 +622,7 @@ describe('WorkflowScriptTool', () => {
     });
     expect(result.error).toContain('Script file: .texra/workflow-scripts/');
     expect(mocks.registerExecution).not.toHaveBeenCalled();
-    expect(mocks.createChildStream).not.toHaveBeenCalled();
+    expect(mocks.createRehydratedChildStream).not.toHaveBeenCalled();
     expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
   });
 
@@ -749,7 +738,7 @@ describe('WorkflowScriptTool', () => {
     });
     expect(result.output).toContain(`Execution ID: ${runExecutionId}`);
     // A relaunch over a live run never starts a second competing loop.
-    expect(mocks.createChildStream).not.toHaveBeenCalled();
+    expect(mocks.createRehydratedChildStream).not.toHaveBeenCalled();
     expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
   });
 

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -237,8 +237,8 @@ function mockStorage({
     ]);
   });
 
-  // KVStore now calls StorageFS.read (raw string) via the Keyv adapter;
-  // return JSON strings so the custom deserializer can parse them.
+  // KVStore reads raw strings through the Keyv adapter, so hand back JSON
+  // text for its deserializer to parse.
   vi.spyOn(StorageFS, 'read').mockImplementation(async (target) => {
     const key = streamKeyFromFile(target);
 
@@ -910,9 +910,8 @@ describe('StreamLogStore load', () => {
 
     expect(affected).toEqual(['alpha']);
     expect(entry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_END);
-    // endRunningGroups() defaults to RUN_OUTCOME.FAILED (#7993 step 2) — the
-    // orphan sweep's caller-classified default, not the folded 'error'
-    // EndGroupStatus string.
+    // endRunningGroups() defaults to RUN_OUTCOME.FAILED, the orphan sweep's
+    // caller-classified default.
     expect(entry?.data).toEqual({ status: RUN_OUTCOME.FAILED, endTime: 300 });
     expect(writtenSummary(storage.writes, 'alpha')).toEqual(
       settledSummary(100, 100),
@@ -1088,8 +1087,8 @@ describe('StreamLogStore load', () => {
     const store = await StreamLogStore.open();
 
     // A caller-supplied RunOutcome (e.g. restart repair's graceful-interrupt
-    // classification, #7993 step 2) reaches the row directly — no fold to
-    // the legacy 2-value EndGroupStatus.
+    // classification) reaches the row directly, with no fold to the legacy
+    // two-value EndGroupStatus.
     const affected = await store.endRunningGroupsForStreams(
       ['alpha'],
       300,
@@ -1107,12 +1106,11 @@ describe('StreamLogStore load', () => {
     });
   });
 
-  // §8.3 boundary normalization: the ONE app-side read boundary for legacy
-  // GROUP_START/GROUP_END `data.status` wire values a pre-cutover writer left
-  // on disk. Every live producer now writes canonical StreamPhase/RunOutcome
-  // values directly (#7993 step 2), so this is the backfill path for rows
-  // that were already persisted before the cutover.
-  it('normalizes legacy persisted GROUP_END status at the read boundary (#7993 step 2)', async () => {
+  // The one app-side read boundary for legacy GROUP_START/GROUP_END
+  // `data.status` wire values left on disk by a pre-cutover writer. Live
+  // producers write canonical StreamPhase/RunOutcome values directly, so this
+  // path only backfills rows persisted before the cutover.
+  it('normalizes legacy persisted GROUP_END status at the read boundary', async () => {
     const legacyStoppedEntry: StreamLogEntry = {
       seqNo: 1,
       id: 'delta-legacy-stopped',
@@ -1161,8 +1159,8 @@ describe('StreamLogStore load', () => {
       status: RUN_OUTCOME.FAILED,
       endTime: 250,
     });
-    // 'running' is string-identical to StreamPhase.RUNNING (row 1, §8.2) —
-    // passes through unnormalized, retype-only.
+    // 'running' is string-identical to StreamPhase.RUNNING, so it passes
+    // through unnormalized.
     expect(entries.find((e) => e.id === 'delta-legacy-running')?.data).toEqual({
       status: STREAM_PHASE.RUNNING,
     });

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -127,6 +127,17 @@ async function writeStreamFile(
   await StorageFS.write(path.join(dir, name), JSON.stringify(contents));
 }
 
+/** Persist a stream's meta sidecar stamped with the current schema version. */
+function writeMetaFile(
+  stream: StreamTabId,
+  meta: Record<string, unknown>,
+): Promise<void> {
+  return writeStreamFile(stream, 'meta.json', {
+    schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+    ...meta,
+  });
+}
+
 function readStreamFile(stream: StreamTabId, name: string): Promise<unknown> {
   return StorageFS.readJson(path.join(streamDataDir(stream), name));
 }
@@ -475,8 +486,7 @@ describe('StreamSnapshotStore', () => {
   it('degrades a structurally unreadable work plan to empty LOUDLY (not via a silent .catch)', async () => {
     const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
     // A non-object top-level shape survives the `!raw` guard but fails the
-    // object parse — the exact corruption the old whole-object `.catch`
-    // swallowed without a trace.
+    // object parse, so the read must warn rather than swallow it.
     await writeStreamFile(STREAM, 'workPlan.json', ['not', 'a', 'work plan']);
 
     const snap = await new StreamSnapshotStore().read(STREAM);
@@ -691,9 +701,7 @@ describe('StreamSnapshotStore', () => {
     // Same race as the output-files case above, replayed for
     // updateMissingOutputs: a stream outside the preloaded set is still
     // unseeded when the mutation lands, so the seed's disk read is racing
-    // the caller's read of its own write. Regression for the "half-fixed"
-    // eager-apply overlay gap (missingOutputs/compileFailures lacked the
-    // guarantee addOutputFiles/addUsage already had).
+    // the caller's read of its own write.
     await writeStreamFile(OTHER_STREAM, 'missingOutputs.json', {
       '0': ['prior.tex'],
     });
@@ -702,8 +710,8 @@ describe('StreamSnapshotStore', () => {
     await store.preload([STREAM]);
 
     store.updateMissingOutputs(OTHER_STREAM, { 1: ['next.tex'] });
-    // Fails pre-fix: the plain mutate() path defers the whole apply behind
-    // the in-flight seed, so this synchronous read-back still sees nothing.
+    // The overlay applies eagerly, so this synchronous read-back sees the
+    // mutation while the seed is still in flight.
     expect(store.getMissingOutputs(OTHER_STREAM)[1]).toEqual(['next.tex']);
     await store.flush();
 
@@ -796,7 +804,7 @@ describe('StreamSnapshotStore', () => {
     await store.preload([STREAM]);
 
     store.updateCompileFailures(OTHER_STREAM, { 1: [next] });
-    // Fails pre-fix for the same reason as the missing-outputs case above.
+    // Eagerly applied for the same reason as the missing-outputs case above.
     expect(store.getCompileFailures(OTHER_STREAM)[1]).toEqual([next]);
     await store.flush();
 
@@ -842,9 +850,8 @@ describe('StreamSnapshotStore', () => {
     const store = new StreamSnapshotStore();
     await store.load([]);
 
-    // Consolidated per-stream state (#8124): every field lives on one record
-    // keyed by stream id, so priming a stale in-memory meta means seeding
-    // just the `meta` field of that record rather than a standalone map.
+    // Every field lives on one record keyed by stream id, so priming a stale
+    // in-memory meta means seeding just the `meta` field of that record.
     const internals = store as unknown as {
       records: Map<
         StreamTabId,
@@ -865,8 +872,7 @@ describe('StreamSnapshotStore', () => {
   it('preserves legacy meta taskState when unrelated meta patches are written', async () => {
     await installPlatform();
     const taskState = toolUseTaskState('legacy-search');
-    await writeStreamFile(STREAM, 'meta.json', {
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+    await writeMetaFile(STREAM, {
       taskState,
     });
 
@@ -889,8 +895,7 @@ describe('StreamSnapshotStore', () => {
     await installPlatform();
     const executionId = 'abc123' as ExecutionId;
     const taskState = toolUseTaskState('legacy-search');
-    await writeStreamFile(STREAM, 'meta.json', {
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+    await writeMetaFile(STREAM, {
       executionId,
       taskState,
     });
@@ -916,8 +921,7 @@ describe('StreamSnapshotStore', () => {
     const runConfig = toolUseConfig('legacy-search');
     await StorageFS.ensureDir(resolveRunStoragePath(executionId));
     await getExecutionStore(executionId).writeConfig(runConfig);
-    await writeStreamFile(STREAM, 'meta.json', {
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+    await writeMetaFile(STREAM, {
       // A legacy sidecar whose top-level mirror never held a real execution id.
       executionId: 'not-an-execution-id!',
       runDescriptor: buildRunDescriptor({
@@ -950,8 +954,7 @@ describe('StreamSnapshotStore', () => {
     ): Promise<void> => {
       await StorageFS.ensureDir(resolveRunStoragePath(executionId));
       await getExecutionStore(executionId).writeConfig(toolUseConfig(agent));
-      await writeStreamFile(stream, 'meta.json', {
-        schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      await writeMetaFile(stream, {
         executionId,
         // A descriptor persisted before #9119 added `kind`.
         runDescriptor: {
@@ -985,8 +988,7 @@ describe('StreamSnapshotStore', () => {
     const newExecutionId = 'def456' as ExecutionId;
     const oldConfig = toolUseConfig('old-search');
     const newConfig = toolUseConfig('new-search');
-    await writeStreamFile(STREAM, 'meta.json', {
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+    await writeMetaFile(STREAM, {
       executionId: oldExecutionId,
     });
     await getExecutionStore(oldExecutionId).writeConfig(oldConfig);
@@ -1019,8 +1021,7 @@ describe('StreamSnapshotStore', () => {
     const executionId = 'abc123' as ExecutionId;
     const persisted = toolUseConfig('search', 'deepseekproT');
     const switched = toolUseConfig('search', 'kimi26T');
-    await writeStreamFile(STREAM, 'meta.json', {
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+    await writeMetaFile(STREAM, {
       executionId,
     });
     await StorageFS.ensureDir(resolveRunStoragePath(executionId));
@@ -1064,8 +1065,7 @@ describe('StreamSnapshotStore', () => {
     // Disk meta drops back to the pre-descriptor shape for the same execution.
     // Re-seeding may read it, but may not synthesize a competing identity from
     // the execution config over the one run.start emitted.
-    await writeStreamFile(STREAM, 'meta.json', {
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+    await writeMetaFile(STREAM, {
       executionId,
     });
     await store.load([STREAM]);
@@ -1086,8 +1086,7 @@ describe('StreamSnapshotStore', () => {
 
     await StorageFS.ensureDir(resolveRunStoragePath(foreignExecutionId));
     await getExecutionStore(foreignExecutionId).writeConfig(foreignConfig);
-    await writeStreamFile(STREAM, 'meta.json', {
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+    await writeMetaFile(STREAM, {
       executionId: foreignExecutionId,
     });
     await store.load([STREAM]);
@@ -1103,8 +1102,7 @@ describe('StreamSnapshotStore', () => {
   it('refreshes the run config from disk when another host switched the model', async () => {
     await installPlatform();
     const executionId = 'abc123' as ExecutionId;
-    await writeStreamFile(STREAM, 'meta.json', {
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+    await writeMetaFile(STREAM, {
       executionId,
     });
     await StorageFS.ensureDir(resolveRunStoragePath(executionId));
@@ -1130,8 +1128,7 @@ describe('StreamSnapshotStore', () => {
   it('replaces a legacy run config once meta names a real execution', async () => {
     await installPlatform();
     const legacyTaskState = toolUseTaskState('legacy-search');
-    await writeStreamFile(STREAM, 'meta.json', {
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+    await writeMetaFile(STREAM, {
       taskState: legacyTaskState,
     });
 
@@ -1146,8 +1143,7 @@ describe('StreamSnapshotStore', () => {
     const handoffConfig = toolUseConfig('handoff-search');
     await StorageFS.ensureDir(resolveRunStoragePath(executionId));
     await getExecutionStore(executionId).writeConfig(handoffConfig);
-    await writeStreamFile(STREAM, 'meta.json', {
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+    await writeMetaFile(STREAM, {
       executionId,
     });
     await store.load([STREAM]);
@@ -1162,8 +1158,7 @@ describe('StreamSnapshotStore', () => {
   it('drops run identity when disk meta no longer names an execution', async () => {
     await installPlatform();
     const executionId = 'abc123' as ExecutionId;
-    await writeStreamFile(STREAM, 'meta.json', {
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+    await writeMetaFile(STREAM, {
       executionId,
     });
     await StorageFS.ensureDir(resolveRunStoragePath(executionId));
@@ -1173,8 +1168,7 @@ describe('StreamSnapshotStore', () => {
     await store.load([STREAM]);
     expect(store.getRunDescriptor(STREAM)).toMatchObject({ executionId });
 
-    await writeStreamFile(STREAM, 'meta.json', {
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+    await writeMetaFile(STREAM, {
       description: 'Detached tab',
     });
     await store.load([STREAM]);
@@ -1190,8 +1184,7 @@ describe('StreamSnapshotStore', () => {
     const oldExecutionId = 'abc123' as ExecutionId;
     const newExecutionId = 'def456' as ExecutionId;
     const oldConfig = toolUseConfig('old-search');
-    await writeStreamFile(STREAM, 'meta.json', {
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+    await writeMetaFile(STREAM, {
       executionId: oldExecutionId,
     });
     await StorageFS.ensureDir(resolveRunStoragePath(oldExecutionId));
@@ -1220,17 +1213,13 @@ describe('StreamSnapshotStore', () => {
     expect(wasRunStartInjected).toHaveBeenCalledOnce();
     expect(store.getRunDescriptor(STREAM)).toEqual(newDescriptor);
     expect(store.getRunConfig(STREAM)).toBeUndefined();
-    expect(store.getRunConfig(STREAM)).toBeUndefined();
   });
 
   it('persists a late reset and round patch that arrive during async hydration', async () => {
     await installPlatform();
-    const dir = streamDataDir(STREAM);
     const executionId = 'c0ffee' as ExecutionId;
-    await StorageFS.ensureDir(dir);
     await Promise.all([
-      writeStreamFile(STREAM, 'meta.json', {
-        schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      writeMetaFile(STREAM, {
         executionId,
       }),
       writeStreamFile(STREAM, 'missingOutputs.json', { '0': ['stale.tex'] }),
@@ -1265,10 +1254,8 @@ describe('StreamSnapshotStore', () => {
     await installPlatform();
     const dir = streamDataDir(STREAM);
     const executionId = 'deadbeef' as ExecutionId;
-    await StorageFS.ensureDir(dir);
     await Promise.all([
-      writeStreamFile(STREAM, 'meta.json', {
-        schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      writeMetaFile(STREAM, {
         executionId,
         activeRunId: RUN,
       }),
@@ -2091,18 +2078,15 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('does not resurrect a deleted sidecar dir when deleteStream lands during hydration', async () => {
-    // Regression for #8226: applyStreamData awaits execution-config hydration
-    // mid-seed. If the stream is deleted during that await, the continuation
-    // must not re-resolve a record for the evicted stream and flush merged
-    // sidecars — pre-fix, the legacy-shaped file below queued an unconditional
-    // rewrite that recreated `streamData/{id}/` after deleteDir() removed it.
+    // applyStreamData awaits execution-config hydration mid-seed. If the
+    // stream is deleted during that await, the continuation must not
+    // re-resolve a record for the evicted stream and flush merged sidecars,
+    // which would recreate `streamData/{id}/` after deleteDir() removed it.
     await installPlatform();
     const dir = streamDataDir(STREAM);
     const executionId = 'dead01' as ExecutionId;
-    await StorageFS.ensureDir(dir);
     await Promise.all([
-      writeStreamFile(STREAM, 'meta.json', {
-        schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      writeMetaFile(STREAM, {
         executionId,
       }),
       // Legacy nested shape → `missingOutputs` lands in `data.legacyKeys`,

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -29,7 +29,7 @@ function attachRecorder(streamId: StreamTabId): {
   return { trace, rows, row: (id) => rows().find((entry) => entry.id === id) };
 }
 
-describe('attachTranscriptRecorder StreamPhase-native group rows (#7993 step 2)', () => {
+describe('attachTranscriptRecorder StreamPhase-native group rows (issue #7993)', () => {
   it("writes GROUP_START's data.status as StreamPhase.RUNNING", () => {
     const { trace, row } = attachRecorder(
       'stream:group-start-native' as StreamTabId,

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -1,14 +1,11 @@
 /**
- * Completed-run archive facade (#7246 Decision 1): the transcript sidecars
- * own completed-run display/export, with `executions/{id}/conversation.json`
- * / `todos.json` as read-only legacy fallbacks.
+ * Completed-run archive facade: the transcript sidecars own completed-run
+ * display/export, with `executions/{id}/conversation.json` / `todos.json` as
+ * read-only legacy fallbacks.
  *
- * Cross-module scenario (stated in the PR body): the fixture below builds a
- * real completed execution on disk with ONLY sidecar data — no
- * `conversation.json` / `todos.json` projections, matching what tool-use
- * runs persist now that the per-step projection writes are deleted — and
- * proves conversation display, chat export, and todos all read through the
- * facade.
+ * The fixtures build real completed executions on disk from sidecar data
+ * alone, which is what a tool-use run persists, and prove that conversation
+ * display, chat export, and todos all read through the facade.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -73,6 +70,7 @@ import {
   STREAM_LOG_ENTRY_TYPES,
   type ExecutionId,
   type StreamTabId,
+  type TodoItem,
 } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas/agent';
 import {
@@ -99,6 +97,31 @@ function runConfig(agent: string, model = 'deepseekproT'): AgentConfig {
     model,
     agentCategory: AgentCategory.ToolUse,
   });
+}
+
+interface StreamSeed {
+  streamId: StreamTabId;
+  /** Agent that ran the stream; roots run the orchestrator by default. */
+  agent?: string;
+  /** Set when the stream is a delegated child of another stream. */
+  parent?: StreamTabId;
+  /** Work-plan todos persisted alongside the run config. */
+  todos?: TodoItem[];
+}
+
+/** Persist the snapshot sidecars that tie streams to an execution. */
+async function seedStreams(
+  executionId: ExecutionId,
+  seeds: readonly StreamSeed[],
+): Promise<StreamSnapshotStore> {
+  const snapshots = new StreamSnapshotStore();
+  for (const { streamId, agent = 'orchestrator', parent, todos } of seeds) {
+    snapshots.setRunConfig(streamId, runConfig(agent), executionId);
+    if (parent) snapshots.setParentStream(streamId, parent);
+    if (todos) snapshots.setTodos(streamId, todos);
+  }
+  await snapshots.flush();
+  return snapshots;
 }
 
 let entryCounter = 0;
@@ -149,12 +172,14 @@ async function writeSidecarFixture(
   executionId: ExecutionId,
   streamId: StreamTabId,
 ): Promise<void> {
-  const snapshots = new StreamSnapshotStore();
-  snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
-  snapshots.setTodos(streamId, [
-    { content: 'Fix the bug', status: 'completed', activeForm: 'Fixing' },
+  await seedStreams(executionId, [
+    {
+      streamId,
+      todos: [
+        { content: 'Fix the bug', status: 'completed', activeForm: 'Fixing' },
+      ],
+    },
   ]);
-  await snapshots.flush();
 
   const logs = await StreamLogStore.open();
   logs.ensureStream(streamId);
@@ -343,9 +368,7 @@ describe('completedRunArchive facade', () => {
       getStreamTabId(config.agent, config.model, { executionId }),
     ).not.toBe(streamId);
 
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(streamId, config, executionId);
-    await snapshots.flush();
+    const snapshots = await seedStreams(executionId, [{ streamId }]);
 
     const logs = await StreamLogStore.open();
     logs.ensureStream(streamId);
@@ -550,10 +573,7 @@ describe('completedRunArchive facade', () => {
   it('treats a present empty work plan as authoritative over stale legacy todos', async () => {
     const executionId = '0aa2220aa222' as ExecutionId;
     const streamId = 'orchestrator@deepseekproT#0aa2220aa222' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
-    snapshots.setTodos(streamId, []);
-    await snapshots.flush();
+    await seedStreams(executionId, [{ streamId, todos: [] }]);
     await getExecutionStore(executionId).write('todos', [
       { content: 'Stale legacy todo', status: 'pending' },
     ]);
@@ -613,9 +633,7 @@ describe('completedRunArchive facade', () => {
   it('seeds a resumed legacy conversation into an empty transcript once', async () => {
     const executionId = '0dd4440dd444' as ExecutionId;
     const streamId = 'orchestrator@deepseekproT#0dd4440dd444' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
-    await snapshots.flush();
+    await seedStreams(executionId, [{ streamId }]);
 
     const logs = await StreamLogStore.open();
     logs.ensureStream(streamId);
@@ -657,9 +675,7 @@ describe('completedRunArchive facade', () => {
   it('reconstructs structured successful and failed tool results as model-facing text', async () => {
     const executionId = '0ee5550ee555' as ExecutionId;
     const streamId = 'orchestrator@deepseekproT#0ee5550ee555' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
-    await snapshots.flush();
+    await seedStreams(executionId, [{ streamId }]);
 
     const logs = await StreamLogStore.open();
     logs.ensureStream(streamId);
@@ -739,11 +755,10 @@ describe('completedRunArchive facade', () => {
     const emptyStream = 'aChild@tool#0777aa0777aa' as StreamTabId;
     const fullStream = 'zOrchestrator@deepseekproT#0777aa0777aa' as StreamTabId;
 
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(emptyStream, runConfig('bash'), executionId);
-    snapshots.setRunConfig(fullStream, runConfig('orchestrator'), executionId);
-    snapshots.setParentStream(emptyStream, fullStream);
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: emptyStream, agent: 'bash', parent: fullStream },
+      { streamId: fullStream },
+    ]);
 
     const logs = await StreamLogStore.open();
     logs.ensureStream(emptyStream);
@@ -781,14 +796,10 @@ describe('completedRunArchive facade', () => {
     const executionId = '0888ba0888ba' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888ba0888ba' as StreamTabId;
     const ambiguousChild = 'zOrchestrator@new#0888ba0888ba' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(
-      ambiguousChild,
-      runConfig('orchestrator'),
-      executionId,
-    );
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: canonical },
+      { streamId: ambiguousChild },
+    ]);
 
     await persistRows(
       executionId,
@@ -841,10 +852,7 @@ describe('completedRunArchive facade', () => {
     const executionId = '0888b50888b5' as ExecutionId;
     const first = 'aOrchestrator@old#0888b50888b5' as StreamTabId;
     const second = 'zOrchestrator@new#0888b50888b5' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(first, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(second, runConfig('orchestrator'), executionId);
-    await snapshots.flush();
+    await seedStreams(executionId, [{ streamId: first }, { streamId: second }]);
     await persistRows(
       executionId,
       new Map([
@@ -875,10 +883,10 @@ describe('completedRunArchive facade', () => {
     const executionId = '0888bd0888bd' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888bd0888bd' as StreamTabId;
     const conflicting = 'zOrchestrator@new#0888bd0888bd' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(conflicting, runConfig('orchestrator'), executionId);
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: canonical },
+      { streamId: conflicting },
+    ]);
 
     const copiedText = {
       ...logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Canonical answer' }),
@@ -958,12 +966,11 @@ describe('completedRunArchive facade', () => {
     const secondRoot = 'bOrchestrator@new#0888bb0888bb' as StreamTabId;
     const child = 'child@tool#0888bb0888bb' as StreamTabId;
 
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(firstRoot, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(secondRoot, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(child, runConfig('bash'), executionId);
-    snapshots.setParentStream(child, firstRoot);
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: firstRoot },
+      { streamId: secondRoot },
+      { streamId: child, agent: 'bash', parent: firstRoot },
+    ]);
 
     const firstQuestion = {
       ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'First question' }),
@@ -1032,10 +1039,10 @@ describe('completedRunArchive facade', () => {
     const executionId = '0888bc0888bc' as ExecutionId;
     const firstRoot = 'orchestrator@old#0888bc0888bc' as StreamTabId;
     const resumedRoot = 'orchestrator@new#0888bc0888bc' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(firstRoot, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(resumedRoot, runConfig('orchestrator'), executionId);
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: firstRoot },
+      { streamId: resumedRoot },
+    ]);
 
     const copiedQuestion = {
       ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Copied question' }),
@@ -1071,11 +1078,10 @@ describe('completedRunArchive facade', () => {
       (name) => `orchestrator@${name}#0888be0888be` as StreamTabId,
     );
     const [streamA, streamB, streamC, streamD, disconnected] = streams;
-    const snapshots = new StreamSnapshotStore();
-    for (const streamId of streams) {
-      snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
-    }
-    await snapshots.flush();
+    await seedStreams(
+      executionId,
+      streams.map((streamId) => ({ streamId })),
+    );
 
     const rows = ['A', 'B', 'C', 'D', 'E'].map((text) => ({
       ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text }),
@@ -1121,11 +1127,10 @@ describe('completedRunArchive facade', () => {
     const canonical = 'aOrchestrator@old#0888b60888b6' as StreamTabId;
     const continuation = 'bOrchestrator@new#0888b60888b6' as StreamTabId;
     const conflicting = 'cOrchestrator@other#0888b60888b6' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    for (const streamId of [canonical, continuation, conflicting]) {
-      snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
-    }
-    await snapshots.flush();
+    await seedStreams(
+      executionId,
+      [canonical, continuation, conflicting].map((streamId) => ({ streamId })),
+    );
 
     const prefix = logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Prefix' });
     const copied = {
@@ -1161,14 +1166,10 @@ describe('completedRunArchive facade', () => {
     const executionId = '0888b80888b8' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888b80888b8' as StreamTabId;
     const continuation = 'bOrchestrator@new#0888b80888b8' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(
-      continuation,
-      runConfig('orchestrator'),
-      executionId,
-    );
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: canonical },
+      { streamId: continuation },
+    ]);
 
     const shared = {
       ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Shared prompt' }),
@@ -1217,14 +1218,10 @@ describe('completedRunArchive facade', () => {
     const executionId = '0888b90888b9' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888b90888b9' as StreamTabId;
     const continuation = 'bOrchestrator@new#0888b90888b9' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(
-      continuation,
-      runConfig('orchestrator'),
-      executionId,
-    );
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: canonical },
+      { streamId: continuation },
+    ]);
 
     const prompt = {
       ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Reconverged prompt' }),
@@ -1303,14 +1300,10 @@ describe('completedRunArchive facade', () => {
     const executionId = '0888b00888b0' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888b00888b0' as StreamTabId;
     const continuation = 'bOrchestrator@new#0888b00888b0' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(
-      continuation,
-      runConfig('orchestrator'),
-      executionId,
-    );
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: canonical },
+      { streamId: continuation },
+    ]);
 
     const prompt = {
       ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Payload prompt' }),
@@ -1374,14 +1367,10 @@ describe('completedRunArchive facade', () => {
     const executionId = '0888b20888b2' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888b20888b2' as StreamTabId;
     const continuation = 'bOrchestrator@new#0888b20888b2' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(
-      continuation,
-      runConfig('orchestrator'),
-      executionId,
-    );
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: canonical },
+      { streamId: continuation },
+    ]);
 
     const first = logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'First turn' });
     const shared = {
@@ -1439,10 +1428,7 @@ describe('completedRunArchive facade', () => {
     const executionId = '0888b30888b3' as ExecutionId;
     const first = 'aOrchestrator@old#0888b30888b3' as StreamTabId;
     const second = 'bOrchestrator@new#0888b30888b3' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(first, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(second, runConfig('orchestrator'), executionId);
-    await snapshots.flush();
+    await seedStreams(executionId, [{ streamId: first }, { streamId: second }]);
 
     const sharedDiagnostic = {
       ...logRow(MESSAGE_TYPES.STATISTICS, { text: 'Usage recorded' }),
@@ -1473,9 +1459,7 @@ describe('completedRunArchive facade', () => {
   it('recognizes a sole diagnostic-only root as an existing execution', async () => {
     const executionId = '0888c20888c2' as ExecutionId;
     const streamId = 'orchestrator@model#0888c20888c2' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
-    await snapshots.flush();
+    await seedStreams(executionId, [{ streamId }]);
     await persistRows(
       executionId,
       new Map([
@@ -1502,10 +1486,7 @@ describe('completedRunArchive facade', () => {
     const executionId = '0888c10888c1' as ExecutionId;
     const first = 'aOrchestrator@old#0888c10888c1' as StreamTabId;
     const second = 'bOrchestrator@new#0888c10888c1' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(first, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(second, runConfig('orchestrator'), executionId);
-    await snapshots.flush();
+    await seedStreams(executionId, [{ streamId: first }, { streamId: second }]);
 
     const sharedDiagnostic = {
       ...logRow(MESSAGE_TYPES.STATISTICS, { text: 'Usage recorded' }),
@@ -1541,12 +1522,10 @@ describe('completedRunArchive facade', () => {
     const parent = 'orchestrator@model#parent' as StreamTabId;
     const firstChild = 'bash@tool#0888b40888b4' as StreamTabId;
     const secondChild = 'codex@tool#0888b40888b4' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(firstChild, runConfig('bash'), executionId);
-    snapshots.setParentStream(firstChild, parent);
-    snapshots.setRunConfig(secondChild, runConfig('codex'), executionId);
-    snapshots.setParentStream(secondChild, parent);
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: firstChild, agent: 'bash', parent },
+      { streamId: secondChild, agent: 'codex', parent },
+    ]);
     await persistRows(
       executionId,
       new Map([
@@ -1589,14 +1568,10 @@ describe('completedRunArchive facade', () => {
     const executionId = '0888b10888b1' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888b10888b1' as StreamTabId;
     const continuation = 'bOrchestrator@new#0888b10888b1' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(
-      continuation,
-      runConfig('orchestrator'),
-      executionId,
-    );
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: canonical },
+      { streamId: continuation },
+    ]);
 
     const first = logRow(MESSAGE_TYPES.USER_MESSAGE, {
       text: 'Before diagnostic bridge',
@@ -1633,10 +1608,10 @@ describe('completedRunArchive facade', () => {
     const executionId = '0888b70888b7' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888b70888b7' as StreamTabId;
     const ambiguous = 'bOrchestrator@new#0888b70888b7' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(ambiguous, runConfig('orchestrator'), executionId);
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: canonical },
+      { streamId: ambiguous },
+    ]);
 
     const shared = {
       ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Shared prompt' }),
@@ -1688,14 +1663,10 @@ describe('completedRunArchive facade', () => {
     const executionId = '0888bf0888bf' as ExecutionId;
     const canonical = 'aOrchestrator@old#0888bf0888bf' as StreamTabId;
     const contradictory = 'bOrchestrator@new#0888bf0888bf' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(canonical, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(
-      contradictory,
-      runConfig('orchestrator'),
-      executionId,
-    );
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: canonical },
+      { streamId: contradictory },
+    ]);
 
     const first = {
       ...logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'First' }),
@@ -1736,11 +1707,10 @@ describe('completedRunArchive facade', () => {
       streamId: root,
       streamIdSource: EXECUTION_STREAM_ID_SOURCE.REGISTRATION,
     });
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(root, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(child, runConfig('child'), executionId);
-    snapshots.setParentStream(child, root);
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: root },
+      { streamId: child, agent: 'child', parent: root },
+    ]);
 
     const logs = await StreamLogStore.open();
     logs.ensureStream(root);
@@ -1766,9 +1736,7 @@ describe('completedRunArchive facade', () => {
   it('preserves a sole diagnostic-only exact root as execution evidence', async () => {
     const executionId = '0999cb0999cb' as ExecutionId;
     const root = 'orchestrator@model#0999cb0999cb' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(root, runConfig('orchestrator'), executionId);
-    await snapshots.flush();
+    await seedStreams(executionId, [{ streamId: root }]);
 
     const logs = await StreamLogStore.open();
     logs.append(
@@ -1795,11 +1763,10 @@ describe('completedRunArchive facade', () => {
     const executionId = '0999cc0999cc' as ExecutionId;
     const root = 'orchestrator@model#0999cc0999cc' as StreamTabId;
     const child = 'child@tool#0999cc0999cc' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(root, runConfig('orchestrator'), executionId);
-    snapshots.setRunConfig(child, runConfig('bash'), executionId);
-    snapshots.setParentStream(child, root);
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: root },
+      { streamId: child, agent: 'bash', parent: root },
+    ]);
 
     const logs = await StreamLogStore.open();
     logs.append(
@@ -1829,12 +1796,10 @@ describe('completedRunArchive facade', () => {
     const parent = 'orchestrator@model#parent' as StreamTabId;
     const firstChild = 'bash@tool#0999ce0999ce' as StreamTabId;
     const secondChild = 'codex@tool#0999ce0999ce' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(firstChild, runConfig('bash'), executionId);
-    snapshots.setParentStream(firstChild, parent);
-    snapshots.setRunConfig(secondChild, runConfig('codex'), executionId);
-    snapshots.setParentStream(secondChild, parent);
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId: firstChild, agent: 'bash', parent },
+      { streamId: secondChild, agent: 'codex', parent },
+    ]);
 
     await expect(readCompletedRunConversation(executionId)).resolves.toEqual({
       conversation: null,
@@ -1856,10 +1821,9 @@ describe('completedRunArchive facade', () => {
     const executionId = '0999cd0999cd' as ExecutionId;
     const streamId = 'child@tool#0999cd0999cd' as StreamTabId;
     const parentStreamId = 'orchestrator@model#parent' as StreamTabId;
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(streamId, runConfig('bash'), executionId);
-    snapshots.setParentStream(streamId, parentStreamId);
-    await snapshots.flush();
+    await seedStreams(executionId, [
+      { streamId, agent: 'bash', parent: parentStreamId },
+    ]);
 
     const logs = await StreamLogStore.open();
     logs.append(
@@ -1889,9 +1853,7 @@ describe('completedRunArchive facade', () => {
     const executionId = 'eee555eee555' as ExecutionId;
     const streamId = 'orchestrator@deepseekproT#eee555eee555' as StreamTabId;
 
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setRunConfig(streamId, runConfig('orchestrator'), executionId);
-    await snapshots.flush();
+    await seedStreams(executionId, [{ streamId }]);
 
     const logs = await StreamLogStore.open();
     logs.ensureStream(streamId);

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -97,7 +97,7 @@ describe('assembleTrace', () => {
     expect(result).toEqual({ status: 'config_missing' });
   });
 
-  it('returns streamLogs_missing for a pre-#7057 execution (config exists, streamLogs never persisted)', async () => {
+  it('returns streamLogs_missing when a config exists but stream logs were never persisted', async () => {
     const executionId = 'exec-no-logs' as ExecutionId;
     await getExecutionStore(executionId).writeConfig(config());
 

--- a/src/test-kernel/utils/files/FilesUtils.vitest.ts
+++ b/src/test-kernel/utils/files/FilesUtils.vitest.ts
@@ -1,5 +1,5 @@
-// Suites for src/utils/files (workspaceFS, mime, paths, absoluteFS,
-// relativeFS JSON, pasted images).
+// Suites for src/utils/files (baseFS predicates, workspaceFS, mime,
+// absoluteFS, relativeFS JSON, pasted images).
 
 import * as assert from 'node:assert';
 import * as path from 'node:path';
@@ -83,14 +83,11 @@ describe('BaseFS stat predicates', () => {
 // WorkspaceFS
 // ---------------------------------------------------------------------------
 
-describe('WorkspaceFS Test Suite', () => {
-  it('delete should be idempotent - not throw when file does not exist', async () => {
-    // Test that deleting a non-existent file doesn't throw
-    const nonExistentPath = 'this-file-definitely-does-not-exist-12345.txt';
-
-    // This should not throw an error
+describe('WorkspaceFS.delete', () => {
+  it('is idempotent when the file does not exist', async () => {
     await assert.doesNotReject(
-      async () => await WorkspaceFS.delete(nonExistentPath),
+      async () =>
+        await WorkspaceFS.delete('this-file-does-not-exist-12345.txt'),
       'delete() should not throw when file does not exist',
     );
   });
@@ -100,7 +97,7 @@ describe('WorkspaceFS Test Suite', () => {
 // mimeUtils
 // ---------------------------------------------------------------------------
 
-describe('mimeUtils Test Suite', () => {
+describe('getMimeType', () => {
   it('applies audio override for known extensions from file paths', () => {
     assert.strictEqual(getMimeType('/tmp/clip.opus'), 'audio/opus');
     assert.strictEqual(getMimeType('C:\\tmp\\clip.l16'), 'audio/l16');
@@ -118,51 +115,48 @@ describe('mimeUtils Test Suite', () => {
 });
 
 // ---------------------------------------------------------------------------
-// pathUtils
+// fileTypeUtils and workspace path resolution
 // ---------------------------------------------------------------------------
 
-describe('pathUtils Test Suite', () => {
-  describe('isTexFile', () => {
-    it('should identify TeX files correctly', () => {
-      assert.strictEqual(isTexFile('document.tex'), true);
-      assert.strictEqual(isTexFile('DOCUMENT.TEX'), true);
-      assert.strictEqual(isTexFile('path/to/file.tex'), true);
-      assert.strictEqual(isTexFile('file.TeX'), true);
-    });
-
-    it('should reject non-TeX files', () => {
-      assert.strictEqual(isTexFile('document.txt'), false);
-      assert.strictEqual(isTexFile('file.pdf'), false);
-      assert.strictEqual(isTexFile('image.png'), false);
-      assert.strictEqual(isTexFile('script.js'), false);
-      assert.strictEqual(isTexFile('noextension'), false);
-    });
-
-    it('should handle edge cases', () => {
-      assert.strictEqual(isTexFile(''), false);
-      // '.tex' alone is a dotfile: path.extname('.tex') === '', so it has no
-      // .tex extension under the current hasExtension-based implementation.
-      assert.strictEqual(isTexFile('.tex'), false);
-      assert.strictEqual(isTexFile('tex'), false);
-      assert.strictEqual(isTexFile('file.texture'), false);
-    });
+describe('isTexFile', () => {
+  it('identifies TeX files regardless of extension case', () => {
+    assert.strictEqual(isTexFile('document.tex'), true);
+    assert.strictEqual(isTexFile('DOCUMENT.TEX'), true);
+    assert.strictEqual(isTexFile('path/to/file.tex'), true);
+    assert.strictEqual(isTexFile('file.TeX'), true);
   });
 
-  describe('WorkspaceFS.toAbsolute', () => {
-    it('should return absolute paths unchanged', () => {
-      const absolutePath = path.resolve('/absolute/path/file.txt');
-      assert.strictEqual(WorkspaceFS.toAbsolute(absolutePath), absolutePath);
-    });
+  it('rejects non-TeX files', () => {
+    assert.strictEqual(isTexFile('document.txt'), false);
+    assert.strictEqual(isTexFile('file.pdf'), false);
+    assert.strictEqual(isTexFile('image.png'), false);
+    assert.strictEqual(isTexFile('script.js'), false);
+    assert.strictEqual(isTexFile('noextension'), false);
+  });
 
-    it('should resolve relative paths to workspace', () => {
-      const relativePath = 'relative/path/file.txt';
-      const resolved = WorkspaceFS.toAbsolute(relativePath);
-      assert.strictEqual(path.isAbsolute(resolved), true);
-      assert.strictEqual(
-        resolved.endsWith(path.join('relative', 'path', 'file.txt')),
-        true,
-      );
-    });
+  it('rejects names without a .tex extension of their own', () => {
+    assert.strictEqual(isTexFile(''), false);
+    // '.tex' alone is a dotfile: path.extname('.tex') === '', so it has no
+    // .tex extension under the hasExtension-based implementation.
+    assert.strictEqual(isTexFile('.tex'), false);
+    assert.strictEqual(isTexFile('tex'), false);
+    assert.strictEqual(isTexFile('file.texture'), false);
+  });
+});
+
+describe('WorkspaceFS.toAbsolute', () => {
+  it('returns absolute paths unchanged', () => {
+    const absolutePath = path.resolve('/absolute/path/file.txt');
+    assert.strictEqual(WorkspaceFS.toAbsolute(absolutePath), absolutePath);
+  });
+
+  it('resolves relative paths against the workspace', () => {
+    const resolved = WorkspaceFS.toAbsolute('relative/path/file.txt');
+    assert.strictEqual(path.isAbsolute(resolved), true);
+    assert.strictEqual(
+      resolved.endsWith(path.join('relative', 'path', 'file.txt')),
+      true,
+    );
   });
 });
 
@@ -229,7 +223,6 @@ describe('RelativeFS JSON helpers', () => {
   setupPlatform({}, { fs: nodeFilesystem });
 
   beforeEach(async () => {
-    // Ensure each test starts with a clean directory
     await fs
       .rm(BASE_DIR, { recursive: true, force: true })
       .catch(() => undefined);

--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -62,6 +62,14 @@ const SLEEPER_SCRIPT = 'sleep 60 & echo $! > "$PID_FILE"; wait';
 describe('executeCommand', () => {
   const tempDirs: string[] = [];
 
+  // executeCommand resolves its cwd from the workspace; point the fake
+  // platform at a directory that exists on disk so spawning succeeds.
+  setupPlatform({ workspacePath: process.cwd() });
+
+  afterEach(async () => {
+    await cleanupTempDirs(tempDirs);
+  });
+
   it('exposes only text encodings and non-transform output modes', () => {
     expectTypeOf<ExecuteCommandOptions['encoding']>().toEqualTypeOf<
       'utf8' | 'utf-8' | 'utf16le' | undefined
@@ -75,14 +83,6 @@ describe('executeCommand', () => {
     expectTypeOf<ExecuteCommandOptions['stderr']>().toEqualTypeOf<
       'pipe' | 'ignore' | 'inherit' | 'overlapped' | undefined
     >();
-  });
-
-  // executeCommand resolves its cwd from the workspace; point the fake
-  // platform at a directory that exists on disk so spawning succeeds.
-  setupPlatform({ workspacePath: process.cwd() });
-
-  afterEach(async () => {
-    await cleanupTempDirs(tempDirs);
   });
 
   // Runs SLEEPER_SCRIPT in a scratch directory and resolves once the
@@ -115,8 +115,8 @@ describe('executeCommand', () => {
     );
 
     assert.ok(result.success);
-    assert.strictEqual(result.stdout, 'onetwo');
-    assert.strictEqual(result.stderr, null);
+    assert.equal(result.stdout, 'onetwo');
+    assert.equal(result.stderr, null);
   });
 
   it('preserves fallback execution with logical OR', async () => {
@@ -125,8 +125,8 @@ describe('executeCommand', () => {
     );
 
     assert.ok(result.success);
-    assert.strictEqual(result.stdout, 'fallback');
-    assert.strictEqual(result.stderr, null);
+    assert.equal(result.stdout, 'fallback');
+    assert.equal(result.stderr, null);
   });
 
   it('keeps stderr empty for ordinary nonzero exits with stdout only', async () => {

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -29,7 +29,6 @@ import { defineTool } from '@tools/core/define';
 import {
   buildApprovalRejectedResult,
   requestToolEditApproval,
-  getApprovedContent,
   writeApprovedContent,
 } from '@tools/approval/toolEditApproval';
 import { AbsoluteFS, WorkspaceFS, createWorkspaceLocation } from '@utils/files';
@@ -111,9 +110,7 @@ Parameters map directly to subagent-result delivery attributes:
 
     // Verify execution exists — run dir may not exist in workspace storage mode
     if ((await findExistingRunStoragePath(executionId)) === undefined) {
-      const exists = await getExecutionStore(executionId as ExecutionId).exists(
-        'meta',
-      );
+      const exists = await getExecutionStore(executionId).exists('meta');
       if (!exists) {
         throw new ToolError(
           `Run not found: ${executionId}. Use /executions to list available executions.`,
@@ -222,11 +219,10 @@ Parameters map directly to subagent-result delivery attributes:
         continue;
       }
 
-      const finalContent = getApprovedContent(approval);
       await writeApprovedContent(
         entry.original,
         entry.originalContent,
-        finalContent,
+        approval.appliedContent,
       );
 
       const action = entry.destExists ? 'replaced' : 'created';

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -110,9 +110,7 @@ import { formatSizedEntryLines } from './executions/fileListingFormat';
 /**
  * Single source of truth for the virtual resource paths this tool serves.
  * Both the tool `description` and the "Unknown path" error render from this
- * list, so the two can no longer drift — previously the error omitted the
- * `/{path}` sub-reads and the `subscribe`/`unsubscribe` actions the
- * description documented.
+ * list, so the two cannot drift.
  */
 const EXECUTION_PATH_CATALOG: ReadonlyArray<{ path: string; summary: string }> =
   [
@@ -167,6 +165,11 @@ const EXECUTION_PATH_CATALOG: ReadonlyArray<{ path: string; summary: string }> =
     },
   ];
 
+/** Renders the catalog as a bulleted `- <path> - <summary>` list. */
+const EXECUTION_PATH_LIST = EXECUTION_PATH_CATALOG.map(
+  ({ path: resourcePath, summary }) => `- ${resourcePath} - ${summary}`,
+).join('\n');
+
 function getRunningTodos(
   session: SessionHandle,
   handle: ExecutionHandle,
@@ -175,11 +178,6 @@ function getRunningTodos(
     ? session.snapshots.getWorkPlan(handle.childStreamId).todos
     : [];
 }
-
-/** Renders the catalog as a bulleted `- <path> - <summary>` list. */
-const EXECUTION_PATH_LIST = EXECUTION_PATH_CATALOG.map(
-  ({ path: resourcePath, summary }) => `- ${resourcePath} - ${summary}`,
-).join('\n');
 
 // ============================================================================
 // Background command output
@@ -992,9 +990,6 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       ? `[still running — re-read for more output, or use action='wait' on /executions/${executionId} to block until it finishes]`
       : `[finished — this is the retained log; /executions/${executionId}/report has the result summary]`;
     const out: string[] = [
-      // `process` rather than a hardcoded `bash`: the category is what the
-      // guard above actually verified, and it stays true if another tool ever
-      // registers a process-kind execution.
       `Output for ${executionId} (process, ${formatStatusInfo(info)}) — ${chars.toLocaleString()} retained transcript chars; command-output cap ${BASH_BACKGROUND_LOG_CAP_CHARS.toLocaleString()} chars, ${lines.length.toLocaleString()} lines.`,
     ];
 

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -67,6 +67,54 @@ export type ReadInput = z.infer<typeof ReadInputSchema>;
 
 type AttachmentKind = 'pdf' | 'image' | 'document';
 
+/** Guard against very large EML files exhausting memory during parsing. */
+const MAX_EML_BYTES = 15 * 1024 * 1024; // 15 MiB — matches ATTACHMENT_MAX_BYTES
+
+const IMAGE_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.bmp',
+  '.webp',
+  '.tif',
+  '.tiff',
+  '.svg',
+]);
+
+const ATTACHMENT_COPY: Record<
+  AttachmentKind,
+  {
+    label: string;
+    rangeSummary: string;
+    rangeOutput: string;
+    coreOutput: string;
+  }
+> = {
+  pdf: {
+    label: 'PDF',
+    rangeSummary: 'Ignored requested line range because PDFs are binary.',
+    rangeOutput: 'Line ranges are not supported when reading PDFs.',
+    coreOutput:
+      'Returned the PDF as a file attachment. Vision-capable models can analyze each page with text and visual context.',
+  },
+  image: {
+    label: 'Image',
+    rangeSummary: 'Ignored requested line range because images are binary.',
+    rangeOutput: 'Line ranges are not supported when reading images.',
+    coreOutput:
+      'Returned the image as a file attachment. Vision-capable models can analyze the visual content directly.',
+  },
+  document: {
+    label: 'Document',
+    rangeSummary:
+      'Ignored requested line range because office documents are binary.',
+    rangeOutput: 'Line ranges are not supported when reading office documents.',
+    coreOutput:
+      'Returned the document as a file attachment. Models with file input support can extract and analyze the document content.',
+  },
+};
+
 export class ReadFileTool extends defineTool({
   name: 'read_file',
   parallelSafe: true,
@@ -206,51 +254,3 @@ export class ReadFileTool extends defineTool({
     return { status: 'executed', summary, output, files: [attachment] };
   }
 }
-
-/** Guard against very large EML files exhausting memory during parsing. */
-const MAX_EML_BYTES = 15 * 1024 * 1024; // 15 MiB — matches ATTACHMENT_MAX_BYTES
-
-const IMAGE_EXTENSIONS = new Set([
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.gif',
-  '.bmp',
-  '.webp',
-  '.tif',
-  '.tiff',
-  '.svg',
-]);
-
-const ATTACHMENT_COPY: Record<
-  AttachmentKind,
-  {
-    label: string;
-    rangeSummary: string;
-    rangeOutput: string;
-    coreOutput: string;
-  }
-> = {
-  pdf: {
-    label: 'PDF',
-    rangeSummary: 'Ignored requested line range because PDFs are binary.',
-    rangeOutput: 'Line ranges are not supported when reading PDFs.',
-    coreOutput:
-      'Returned the PDF as a file attachment. Vision-capable models can analyze each page with text and visual context.',
-  },
-  image: {
-    label: 'Image',
-    rangeSummary: 'Ignored requested line range because images are binary.',
-    rangeOutput: 'Line ranges are not supported when reading images.',
-    coreOutput:
-      'Returned the image as a file attachment. Vision-capable models can analyze the visual content directly.',
-  },
-  document: {
-    label: 'Document',
-    rangeSummary:
-      'Ignored requested line range because office documents are binary.',
-    rangeOutput: 'Line ranges are not supported when reading office documents.',
-    coreOutput:
-      'Returned the document as a file attachment. Models with file input support can extract and analyze the document content.',
-  },
-};

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -600,11 +600,11 @@ export class TextEditorTool extends defineTool({
   }
 
   /**
-   * Resolve the history owned by the active execution. With no run context,
-   * tests and one-shot manual calls share the legacy empty execution scope.
+   * Resolve the history owned by the active execution. Calls made with no run
+   * context share one unnamed execution scope.
    */
-  private currentExecutionId(): string {
-    return getRunContextExecutionId(tryUseRunContext()) ?? '';
+  private currentExecutionId(context = tryUseRunContext()): string {
+    return getRunContextExecutionId(context) ?? '';
   }
 
   /** `afterWrite` callback recording pre-edit content for undo, only when the write actually changed the file. */
@@ -620,7 +620,7 @@ export class TextEditorTool extends defineTool({
 
   private addToHistory(filePath: string, content: string): void {
     const context = tryUseRunContext();
-    const executionId = getRunContextExecutionId(context) ?? '';
+    const executionId = this.currentExecutionId(context);
     const isNewExecution = !this.fileHistory.hasExecution(executionId);
     this.fileHistory.push(
       executionId,

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -44,10 +44,10 @@ export { setBashApprovalSessionBypass, isBashApprovalBypassedForStream };
  * surface, the bash counterpart of `prepareToolEditApprovalPrompt`.
  *
  * Owning it here keeps one request-id scheme, derives the bypass affordance
- * from the stream's current bypass state instead of asserting it, and drops a
- * blank working directory so no renderer has to decide what an empty `cwd`
- * means. Pass `session` when the host owns one (extension, desktop); the CLI
- * hosts run on the default session.
+ * from the stream's current bypass state, and drops a blank working directory
+ * so no renderer has to decide what an empty `cwd` means. Pass `session` when
+ * the host owns one (extension, desktop); the CLI hosts run on the default
+ * session.
  */
 export function prepareBashApprovalPrompt(
   request: HostBashApprovalRequest,

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -104,7 +104,7 @@ export function prepareToolEditApprovalPrompt(
 }
 
 // ============================================================================
-// Pure diff helpers (exported for use by native handler in @frontend/)
+// Pure diff helpers, shared with the hosts' native approval/diff surfaces
 // ============================================================================
 
 function createSemanticDiffs(original: string, proposed: string): TextDiff[] {
@@ -260,12 +260,6 @@ export type AcceptedToolEditApprovalResult = Extract<
   { accepted: true }
 >;
 
-export function getApprovedContent(
-  approval: AcceptedToolEditApprovalResult,
-): string {
-  return approval.appliedContent;
-}
-
 function formatUnifiedApprovalUserDiff(
   path: string,
   suggestedContent: string,
@@ -371,9 +365,8 @@ interface WrittenApprovedEdit extends WriteApprovedContentResult {
 /**
  * Full approve-then-write handshake for a proposed edit: request approval,
  * then write the resolved content (the user's adjustments if any, else the
- * proposal). Combines the exact pairing every straight-through edit call site
- * previously hand-rolled, so `sourceTool` is named once and the rejection
- * message stays uniform.
+ * proposal). `sourceTool` is named once and the rejection message is uniform
+ * across every straight-through edit call site.
  *
  * Returns `{ rejected }` (a {@link ToolResult} to return directly) when the
  * user declines. `beforeWrite` covers work that must happen only after
@@ -412,7 +405,7 @@ export async function requestAndWriteApprovedEdit(request: {
   const written = await writeApprovedContent(
     path,
     originalContent,
-    getApprovedContent(approval),
+    approval.appliedContent,
   );
   return { approval, ...written };
 }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -53,19 +53,20 @@ import { appendHead, appendTail } from '@utils/text/appendTail';
 
 // Local file imports
 import { defineTool } from './core/define';
-import { createChildStream, getChildStreamId } from './childStream';
+import {
+  createChildStream,
+  getChildStreamId,
+  type ChildStream,
+} from './childStream';
 import { parseWorkingDirectory } from './pathResolution';
 
 const BACKGROUND_OUTPUT_TAIL_CHARS = 12_000;
 /**
- * Small head budget retained alongside the tail (approximates the foreground
- * checkToolResultTextLimit head:tail ratio of TOOL_RESULT_TRUNCATION_HEAD_CHARS
- * /_TAIL_CHARS, 4,000/50,000 = 8.0% — this is 1,000/12,000 ≈ 8.3%, close but
- * not identical, since the two paths have independently-sized tail budgets).
- * A long background build's first fatal error tends to sit near the top of
- * the log, well before the tail budget's trailing window; without this,
- * output that outgrows the tail silently drops that error with no way to
- * recover it from the follow-up.
+ * Small head budget retained alongside the tail, at roughly the foreground
+ * head:tail ratio. A long background build's first fatal error tends to sit
+ * near the top of the log, well before the tail budget's trailing window;
+ * without this, output that outgrows the tail silently drops that error with
+ * no way to recover it from the follow-up.
  */
 const BACKGROUND_OUTPUT_HEAD_CHARS = 1_000;
 const BASH_CHILD_STREAM_PREFIX = 'bash@tool';
@@ -104,8 +105,7 @@ interface BoundedOutputCapture {
  * @param options.normalizeWhitespace When true (the default, used by the
  *   foreground path) leading whitespace is dropped and trailing whitespace is
  *   deferred so a stream that ends in blank lines is not counted or shown. The
- *   background path passes false to keep its historical raw byte-for-byte
- *   head/tail/total tracking exactly.
+ *   background path passes false and tracks head/tail/total byte-for-byte.
  */
 function createBoundedOutputCapture(
   headChars: number,
@@ -418,7 +418,7 @@ export class BashTool extends defineTool({
     });
     const runWithOwnership = captureOwnedExecutionLease(executionId);
 
-    let childStream!: ReturnType<typeof createChildStream>;
+    let childStream!: ChildStream;
     try {
       runWithOwnership(() => {
         childStream = createChildStream(executionId, parentStreamId, {
@@ -435,10 +435,9 @@ export class BashTool extends defineTool({
       throw await releaseOwnedExecutionLeaseAfterFailure(executionId, error);
     }
     const { childStreamId, logger } = childStream;
-    // Reuse the foreground bounded capture, but with whitespace normalization
-    // disabled so the background head/tail/total tracking stays byte-for-byte
-    // identical to its historical inline math (the two paths keep their own
-    // near-but-not-quite head/tail budgets — see the constants above).
+    // Whitespace normalization is off here: a background log is delivered
+    // verbatim, and its head/tail budgets are its own (see the constants
+    // above) rather than the foreground tool-result ones.
     const stdout = createBoundedOutputCapture(
       BACKGROUND_OUTPUT_HEAD_CHARS,
       BACKGROUND_OUTPUT_TAIL_CHARS,

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -91,7 +91,7 @@ import {
   type ClaudeTurnUsage,
 } from './claudeAgentShared';
 
-// Third-party imports
+// Third-party type imports (import/order places these after local imports)
 import type { Options as ClaudeAgentSdkOptions } from '@anthropic-ai/claude-agent-sdk';
 
 let _configModule: typeof import('./claudeAgentConfig.js') | null = null;

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -97,9 +97,7 @@ export function buildClaudeUsageStats(usage: ClaudeTurnUsage): TokenUsageStats {
 
 /** Narrow an SDK-sourced value to a plain record, the way every built-in
  *  tool's `input` arrives per the tool-use protocol (a no-argument call still
- *  sends `{}`, never a bare primitive or `null`). Shared so the guard is
- *  written once and `buildClaudeToolUseLog` and `describeToolInput` can't
- *  drift apart on what counts as "object-shaped". */
+ *  sends `{}`, never a bare primitive or `null`). */
 function isToolRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object';
 }

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -232,11 +232,6 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
     const { runContext: parent, callContext } = contexts;
     const { runScope } = parent;
 
-    // Named checkpoint, not content- or toolCallId-keyed: a retrying model
-    // rewrites its script, so any key derived from call identity or source
-    // text orphans the journal exactly when resume matters (#8666). meta.name
-    // is the durable identity; per-entry prompt/options hashes in the journal
-    // keep replays honest when the script evolves.
     let scriptPath: string;
     let script: string;
     if (input.scriptPath != null) {
@@ -289,6 +284,11 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
       );
       return { meta, defaultAgent };
     });
+    // Named checkpoint, not content- or toolCallId-keyed: a retrying model
+    // rewrites its script, so any key derived from call identity or source
+    // text orphans the journal exactly when resume matters (#8666). meta.name
+    // is the durable identity; per-entry prompt/options hashes in the journal
+    // keep replays honest when the script evolves.
     const checkpointId = deriveWorkflowScriptCheckpointId({
       name: meta.name,
       defaultAgent: defaultAgent.name,

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -106,7 +106,10 @@ export interface StableInBandSubagentExecutionOptions {
   readonly onActiveExecutionId?: (executionId: ExecutionId) => void;
 }
 
-/** Legacy delivery callers may still provide a bare one-shot run context. */
+/**
+ * Options for the XML-delivery API. A one-shot run context need not have a
+ * persisted parent execution, so parentage is optional here.
+ */
 export interface InBandSubagentDeliveryOptions extends InBandSubagentExecutionBaseOptions {
   readonly parentExecutionId?: ExecutionId;
 }
@@ -747,11 +750,11 @@ export async function executeStableSubagentInBand(
   });
 }
 
-/** Preserve the existing headless delegation tool's XML/report behavior. */
+/** Run one child and return its XML delivery alongside the typed result. */
 export async function executeSubagentForDeliveryInBand(
   options: InBandSubagentDeliveryOptions,
 ): Promise<InBandSubagentDeliveryResult> {
-  const executionId = generateExecutionId() as ExecutionId;
+  const executionId = generateExecutionId();
   const completed = await executeInBand(
     options,
     'best-effort-delivery',

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -16,8 +16,8 @@
  * consumed by `childRunLoop`. `runTurn` is unreachable for a workflow child —
  * a workflow flow never produces a WAITING result, so `isTerminal` is always
  * true on its first (and only) turn, and `childRunLoop.ts`'s loop breaks on a
- * terminal turn before ever consulting `runTurn` (see `childRunLoop.ts:642-
- * 650`). `allowWaitingResult: true` is likewise inert for workflow —
+ * terminal turn before ever consulting `runTurn`.
+ * `allowWaitingResult: true` is likewise inert for workflow —
  * `isWaitingFlowResult` requires `category === 'toolUse'`, so a workflow
  * result can never satisfy it. Delivery choreography (format/persist/
  * manifest/deliver), duplicate-delivery prevention (there is exactly one
@@ -207,12 +207,12 @@ export function createNativeSubagentStrategy(
   };
 
   return {
-    // Not used as a trace stage for native delegation (childRunLoop.ts:535-
-    // 537 gates `logger.openStage` on `childStream`, which native delegation
-    // never passes) — its only reader is the loop's non-throwing-failure
-    // message, which becomes the persisted terminal `error.message` for the
-    // execution record. Keep it category-derived so a failed workflow
-    // subagent's record never reads "tool-use".
+    // Not used as a trace stage for native delegation (the loop gates
+    // `logger.openStage` on `childStream`, which native delegation never
+    // passes) — its only reader is the loop's non-throwing-failure message,
+    // which becomes the persisted terminal `error.message` for the execution
+    // record. Keep it category-derived so a failed workflow subagent's record
+    // never reads "tool-use".
     stageLabel:
       params.config.agentCategory === AgentCategory.ToolUse
         ? 'Native tool-use subagent'

--- a/src/tools/executions/conversationFormat.ts
+++ b/src/tools/executions/conversationFormat.ts
@@ -3,8 +3,7 @@
  * text, built on the shared per-content-block formatter in
  * `@agent/storage/conversationFormat` (the same block recognition and
  * truncation the CLI's `texra history` conversation previews use).
- * Used by ExecutionsTool's /conversation endpoint; kept free of I/O so the
- * tool class stays focused on path routing and storage access.
+ * Pure: the caller owns storage access and paging.
  */
 import {
   formatConversationMessage,

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -106,13 +106,12 @@ interface StreamWriterOwnership {
 
 /**
  * Every per-stream field that shares the resident stream lifecycle, keyed by
- * stream id in ONE map (`streams`) instead of parallel hand-synced maps/sets.
- * Because every field for a stream lives on the same object, dropping a
- * stream's resident state is one `streams.delete(id)` — every field disappears
- * with it BY CONSTRUCTION, which is what lets `forgetStreamState` /
- * `forgetAllStreamState` collapse to a single delete/clear. When an individual
- * field is cleared, `pruneStreamState` removes the record once no field
- * remains, preserving the old "absent from every collection" memory footprint.
+ * stream id in ONE map (`streams`). Because every field for a stream lives on
+ * the same object, dropping a stream's resident state is one
+ * `streams.delete(id)` — every field disappears with it BY CONSTRUCTION, which
+ * is what lets `forgetStreamState` / `forgetAllStreamState` be a single
+ * delete/clear. When an individual field is cleared, `pruneStreamState`
+ * removes the record once no field remains, so an idle stream holds no memory.
  *
  * `summaries` (deliberately OUTLIVES per-stream eviction so sidebar metadata
  * survives when heavy `log` entries are dropped) and `writeTombstones` (a
@@ -156,7 +155,7 @@ interface StreamState {
 
 /**
  * Shared projection into {@link StreamLogSummary}, fed either by a resident
- * `StreamLog`'s getters (`summaryOf`) or by a raw entries scan
+ * `StreamLog` (whose getters satisfy this shape) or by a raw entries scan
  * (`summarizeEntries`). Keeping the field list here means a new derived flag
  * is added once instead of in two hand-synced call sites.
  */
@@ -178,10 +177,6 @@ function toSummary(source: SummarySource): StreamLogSummary {
       ? { hasNonterminalWorkflowTask: true }
       : {}),
   };
-}
-
-function summaryOf(logInstance: StreamLog): StreamLogSummary {
-  return toSummary(logInstance);
 }
 
 /**
@@ -316,11 +311,11 @@ export class StreamLogStore {
   }
 
   /**
-   * Drop a record once none of its fields hold state, matching the old
-   * "absent from every per-stream collection" footprint. Dirtiness lives in
-   * the separate `dirtyIds` set and is intentionally NOT consulted here: a
-   * dirty stream always retains a `log` (or a `loadFailed`/`pendingLoad`
-   * deferral record), so the field checks below already keep its record alive.
+   * Drop a record once none of its fields hold state, so an idle stream costs
+   * no memory. Dirtiness lives in the separate `dirtyIds` set and is
+   * intentionally NOT consulted here: a dirty stream always retains a `log`
+   * (or a `loadFailed`/`pendingLoad` deferral record), so the field checks
+   * below already keep its record alive.
    */
   private pruneStreamState(streamId: StreamTabId): void {
     const s = this.streams.get(streamId);
@@ -1147,7 +1142,7 @@ export class StreamLogStore {
         delete existing.hasNonterminalWorkflowTask;
       }
     } else {
-      this.summaries.set(streamId, summaryOf(logInstance));
+      this.summaries.set(streamId, toSummary(logInstance));
     }
   }
 
@@ -1321,7 +1316,7 @@ export class StreamLogStore {
       return;
     }
 
-    await this.maintainSummaryCache(streamId, summaryOf(logInstance));
+    await this.maintainSummaryCache(streamId, toSummary(logInstance));
     if (this.shouldSkipWrite(streamId, expectedGeneration)) {
       await this.kv.delete(streamId);
       await this.deleteSummaryCache(streamId);

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -8,8 +8,7 @@
  * mutators below. Both paths persist the same field-scoped files, including the
  * `workPlan.json` giving todos/plan a durable home.
  *
- * It consolidates the accumulation logic previously split across the extension's
- * `OutputFilesManager` / `UsageStatsManager` / `StreamMetaManager`, talking to
+ * It owns the accumulation of output files, usage, and stream meta, talking to
  * `KVStore` directly via the shared `streamDataDir()` layout. Writes are
  * serialized per (stream, category) so concurrent deltas never interleave.
  *
@@ -86,8 +85,8 @@ import {
 
 const CHANNEL = 'StreamSnapshotStore';
 
-/** Bounded fan-out for seeding many streams' sidecars (mirrors the retired
- *  managers' `pMap` hydration so startup doesn't open a file handle per tab). */
+/** Bounded fan-out for seeding many streams' sidecars, so startup does not
+ *  open a file handle per tab. */
 const SEED_IO_CONCURRENCY = 8;
 
 /**
@@ -220,10 +219,7 @@ interface OverlayPatches {
  * supersedes everything recorded before it — it drops the earlier round
  * patch outright, matching a disk write of `{}` — while a later update
  * layers its round patch on top and preserves whichever reset flag is
- * already recorded. Without this, `clearMissingOutputs` staying on the
- * plain deferred `mutate()` path let it replay out of order relative to an
- * eagerly-overlaid `updateMissingOutputs`, silently dropping the newer
- * update or resurrecting rounds a clear was supposed to erase.
+ * already recorded.
  */
 function mergeMissingOutputsOverlay(
   existing: RoundOverlay<string> | undefined,
@@ -272,22 +268,15 @@ function descriptorFromConfig(
 
 /**
  * Every per-stream field this store tracks, keyed by stream id in ONE map
- * (`records`) instead of 17 independently hand-synced parallel maps/sets (9
- * accumulator fields, `seeded`/`seedChain` seeding bookkeeping, 5 overlay
- * fields, and the cached `KVStore` handle). Because every field for a stream
- * lives on the same object, dropping a stream's memory is one
- * `records.delete(stream)` — every field disappears with it BY CONSTRUCTION.
- * The old design needed a hand-maintained `perStreamStores()` list (#7892)
- * to keep `evict()`/`evictAll()`/`allKnownStreams()` from drifting apart —
- * and that list had already drifted once (`allKnownStreams()` omitted
- * `metaOverlays`) before #7892 unified it. A single record makes that whole
- * drift class structurally impossible: there is no second list to omit a
- * field from.
+ * (`records`): the accumulators, the `seeded`/`seedChain` seeding bookkeeping,
+ * the overlay patches, and the cached `KVStore` handles. Because every field
+ * for a stream lives on the same object, dropping a stream's memory is one
+ * `records.delete(stream)` — every field disappears with it BY CONSTRUCTION,
+ * so `evict()`/`evictAll()` cannot drift from the field list.
  *
  * `streamVersions` (must survive eviction to keep guarding in-flight seed
  * races) and `writeMutexes` (keyed by the compound `${stream}::${key}`, not
- * a bare stream id) stay as their own maps on the store — the same two
- * exclusions #7892 already carved out of `perStreamStores()`.
+ * a bare stream id) stay as their own maps on the store.
  */
 interface StreamRecord {
   // -- Accumulated durable state (mirrors on-disk StreamData) --------------
@@ -640,7 +629,7 @@ export class StreamSnapshotStore {
   }
 
   // ==========================================================================
-  // Mutators (mirror the consolidated managers)
+  // Mutators
   // ==========================================================================
 
   /**
@@ -730,10 +719,9 @@ export class StreamSnapshotStore {
    * (used for effectively-empty patches). `applyStreamData`'s post-seed
    * reconciliation then replays the overlay on top of the freshly-read disk
    * state and persists it there, so an eager write racing ahead of its own
-   * seed is never clobbered by that seed's raw disk read. This is the
-   * guarantee `addOutputFiles`/`addUsage` used to hand-roll individually;
-   * every round/usage mutator now shares it here, so a future one inherits
-   * it by construction instead of needing its own bespoke overlay block.
+   * seed is never clobbered by that seed's raw disk read. Every round/usage
+   * mutator goes through here, so a new one inherits that guarantee instead
+   * of needing its own overlay block.
    */
   private mutateWithOverlay<T, K extends keyof OverlayPatches>(
     stream: StreamTabId,
@@ -849,8 +837,8 @@ export class StreamSnapshotStore {
   }
 
   /**
-   * Accumulate usage per run (mirrors UsageStatsManager.setRunUsage). Returns
-   * the accumulated value for the run so callers can forward it to the UI.
+   * Accumulate usage per run. Returns the accumulated value for the run so
+   * callers can forward it to the UI.
    */
   addUsage(
     stream: StreamTabId,
@@ -905,7 +893,7 @@ export class StreamSnapshotStore {
   }
 
   // ==========================================================================
-  // Read accessors over in-memory accumulated state (replace manager getters)
+  // Read accessors over in-memory accumulated state
   // ==========================================================================
 
   // Deep-enough copies (fresh record, fresh per-round array): a caller that
@@ -950,9 +938,9 @@ export class StreamSnapshotStore {
   /**
    * Clear the missing-outputs marker for a stream (memory + disk). Goes
    * through the same `mutateWithOverlay` shape as `updateMissingOutputs` (via
-   * the shared `reset`-aware overlay) rather than the plain deferred
-   * `mutate()` path, so a clear and an update racing on the same unseeded
-   * stream replay in call order instead of the clear always landing last.
+   * the shared `reset`-aware overlay), so a clear and an update racing on the
+   * same unseeded stream replay in call order instead of the clear always
+   * landing last.
    *
    * `existed` checks `missingOutputs` content specifically, not merely
    * whether the stream has a record: every record defaults `missingOutputs`
@@ -984,7 +972,7 @@ export class StreamSnapshotStore {
   }
 
   // ==========================================================================
-  // Lifecycle (replace manager evict/evictAll)
+  // Lifecycle
   // ==========================================================================
 
   /** Drop a stream's in-memory state. Disk cleanup is the caller's job. */
@@ -1494,7 +1482,7 @@ export class StreamSnapshotStore {
   }
 
   // ==========================================================================
-  // Meta accessors, setters, and queries (replace StreamMetaManager)
+  // Meta accessors, setters, and queries
   // ==========================================================================
 
   /**
@@ -2040,10 +2028,9 @@ export class StreamSnapshotStore {
     // Seeded with `data.legacyKeys` unconditionally (unlike the overlay
     // additions below, which are gated on that overlay actually being
     // present): a legacy key with no corresponding overlay data still gets
-    // an empty-object write in `writeMergedSidecars`. That's a broader net
-    // than the old per-field `has()` guards, but harmless — disk readers
-    // (`parsePersistedRoundIndexed` and friends) treat an absent sidecar and
-    // an empty-object one identically.
+    // an empty-object write in `writeMergedSidecars`, which is harmless —
+    // disk readers (`parsePersistedRoundIndexed` and friends) treat an absent
+    // sidecar and an empty-object one identically.
     const sidecarsToWrite = new Set<string>(data.legacyKeys);
 
     record.outputFiles = data.outputFiles;
@@ -2170,7 +2157,7 @@ export class StreamSnapshotStore {
   /**
    * One-time backfill for streams with an executionId but no description in
    * meta.json: read it from ExecutionMeta and persist so future loads skip the
-   * extra I/O. (Ported from StreamMetaManager.)
+   * extra I/O.
    */
   private async backfillDescriptionsFromExecutionMeta(): Promise<void> {
     for (const [streamId, record] of [...this.records]) {

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -589,7 +589,6 @@ export function attachTranscriptRecorder(
         }
 
         case 'domain': {
-          // Subscribers that care about specific keys can switch on event.key.
           if (event.key === 'modelRetryLifecycle') {
             appendLog({
               groupId: event.stageId,
@@ -635,9 +634,8 @@ export function attachTranscriptRecorder(
           return;
 
         case 'result':
-          // The terminal outcome is consumed by hosts via `session.onResult`.
-          // The transcript already reflects completion through `stage.end`, so it
-          // adds no row here (keeps transcript output unchanged).
+          // The terminal outcome is consumed by hosts via `session.onResult`,
+          // and the transcript already reflects completion through `stage.end`.
           return;
 
         case 'run.start':
@@ -647,8 +645,8 @@ export function attachTranscriptRecorder(
           return;
 
         case 'child.activity':
-          // Stage 3a child facts replace legacy progress events for UI badges;
-          // they were not transcript rows before.
+          // Child facts drive host UI badges through the session plane, not
+          // transcript rows.
           return;
 
         default: {

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -815,45 +815,34 @@ export async function readCompletedRunConversation(
     streamLogStore,
   });
 
-  // Legacy `conversation.json`; `null` when missing or empty.
-  const tryLegacy =
-    async (): Promise<CompletedRunConversationReadResult | null> => {
-      const conversation =
-        await getExecutionStore(executionId).readConversation();
-      return conversation ? { conversation, source: 'legacyKV' } : null;
-    };
-  const trySidecar =
-    async (): Promise<CompletedRunConversationReadResult | null> =>
-      resolved
-        ? readSidecarConversation(
-            executionId,
-            resolved,
-            snapshotStore,
-            streamLogStore,
-          )
-        : null;
-
-  const sidecar = await trySidecar();
+  const sidecar = resolved
+    ? await readSidecarConversation(
+        executionId,
+        resolved,
+        snapshotStore,
+        streamLogStore,
+      )
+    : null;
   if (sidecar?.conversation) return sidecar;
-  const legacy = await tryLegacy();
-  if (legacy) {
-    return sidecar
-      ? {
-          conversation: legacy.conversation,
-          source: 'legacyKV',
-          ...(sidecar.candidateStreamIds
-            ? { candidateStreamIds: sidecar.candidateStreamIds }
-            : {}),
-          ...(sidecar.associatedStreamIds
-            ? { associatedStreamIds: sidecar.associatedStreamIds }
-            : {}),
-          ...(sidecar.conflicts ? { conflicts: sidecar.conflicts } : {}),
-          ...(sidecar.hasOrderingCycle ? { hasOrderingCycle: true } : {}),
-          ...(sidecar.hasOrderingAmbiguity
-            ? { hasOrderingAmbiguity: true }
-            : {}),
-        }
-      : legacy;
+
+  // Legacy `conversation.json`; absent or empty leaves the sidecar diagnostics
+  // as the only answer.
+  const legacyConversation =
+    await getExecutionStore(executionId).readConversation();
+  if (!legacyConversation) {
+    return sidecar ?? { conversation: null, source: 'none' };
   }
-  return sidecar ?? { conversation: null, source: 'none' };
+  return {
+    conversation: legacyConversation,
+    source: 'legacyKV',
+    ...(sidecar?.candidateStreamIds
+      ? { candidateStreamIds: sidecar.candidateStreamIds }
+      : {}),
+    ...(sidecar?.associatedStreamIds
+      ? { associatedStreamIds: sidecar.associatedStreamIds }
+      : {}),
+    ...(sidecar?.conflicts ? { conflicts: sidecar.conflicts } : {}),
+    ...(sidecar?.hasOrderingCycle ? { hasOrderingCycle: true } : {}),
+    ...(sidecar?.hasOrderingAmbiguity ? { hasOrderingAmbiguity: true } : {}),
+  };
 }

--- a/src/utils/diagnostics/diagnosticFormatting.ts
+++ b/src/utils/diagnostics/diagnosticFormatting.ts
@@ -40,21 +40,34 @@ const SEVERITY_HINT = 3;
  * Unified severity metadata for labels, counting, and formatting. The
  * `countKey` doubles as the plural label ('info' stays 'info'), and numeric
  * keys iterate in ascending order so `Object.values` gives formatting order.
+ * `sectionTitle` is the markdown section a severity belongs to; info and hint
+ * deliberately share one.
  */
 const SEVERITY_CONFIG: Record<
   number,
-  { label: string; countKey: keyof SeverityCounts }
+  { label: string; countKey: keyof SeverityCounts; sectionTitle: string }
 > = {
-  [SEVERITY_ERROR]: { label: 'error', countKey: 'errors' },
-  [SEVERITY_WARNING]: { label: 'warning', countKey: 'warnings' },
-  [SEVERITY_INFO]: { label: 'info', countKey: 'info' },
-  [SEVERITY_HINT]: { label: 'hint', countKey: 'hints' },
+  [SEVERITY_ERROR]: {
+    label: 'error',
+    countKey: 'errors',
+    sectionTitle: 'Errors',
+  },
+  [SEVERITY_WARNING]: {
+    label: 'warning',
+    countKey: 'warnings',
+    sectionTitle: 'Warnings',
+  },
+  [SEVERITY_INFO]: {
+    label: 'info',
+    countKey: 'info',
+    sectionTitle: 'Info/Hints',
+  },
+  [SEVERITY_HINT]: {
+    label: 'hint',
+    countKey: 'hints',
+    sectionTitle: 'Info/Hints',
+  },
 };
-
-/** Get the string label for a severity level. */
-function getSeverityLabel(severity: number): string {
-  return SEVERITY_CONFIG[severity]?.label ?? 'unknown';
-}
 
 /** Count diagnostics by severity level. */
 export function countBySeverity(
@@ -91,7 +104,7 @@ export function formatMessageList(diagnostics: GenericDiagnostic[]): string {
   return diagnostics
     .map((d) => {
       const line = d.range.start.line + 1;
-      const label = getSeverityLabel(d.severity);
+      const label = SEVERITY_CONFIG[d.severity]?.label ?? 'unknown';
       return `  ${line}: [${label}] ${d.message}`;
     })
     .join('\n');
@@ -105,22 +118,14 @@ export function formatMessageList(diagnostics: GenericDiagnostic[]): string {
  * **Line 10:** Unexpected token
  * **Line 20:** Missing semicolon
  */
-const SECTION_TITLE_BY_SEVERITY: Partial<Record<number, string>> = {
-  [SEVERITY_ERROR]: 'Errors',
-  [SEVERITY_WARNING]: 'Warnings',
-  [SEVERITY_INFO]: 'Info/Hints',
-  [SEVERITY_HINT]: 'Info/Hints',
-};
-
 export function formatGroupedSections(
   diagnostics: GenericDiagnostic[],
 ): string {
-  // Diagnostics with an unrecognized severity key to `undefined` and are
-  // dropped by the `.get(title) ?? []` lookups below — same silent omission
-  // as the three `.filter()` calls this replaced.
+  // A diagnostic with an unrecognized severity groups under `undefined` and is
+  // deliberately dropped: only the three known section titles are rendered.
   const bySectionTitle = groupBy(
     diagnostics,
-    (d) => SECTION_TITLE_BY_SEVERITY[d.severity],
+    (d) => SEVERITY_CONFIG[d.severity]?.sectionTitle,
   );
   const sections: Array<[title: string, items: GenericDiagnostic[]]> = [
     'Errors',

--- a/src/utils/media/img.ts
+++ b/src/utils/media/img.ts
@@ -24,8 +24,6 @@ const DEFAULT_PDF_QUALITY = 300;
 /** Default maximum [width, height] in px for a rasterized PDF page. */
 const DEFAULT_PDF_MAX_SIZE: [number, number] = [1024, 1024];
 
-// ImageMagick configuration is now in toolUtils.ts
-
 /** Resolve a file path and return the absolute path, or null if not found. */
 async function resolveFile(filePath: string): Promise<string | null> {
   const absolutePath = WorkspaceFS.toAbsolute(filePath);
@@ -247,9 +245,8 @@ export async function processPdf2Png(
       throw new Error('GraphicsMagick/ImageMagick is not installed.');
     }
 
-    // Private per-conversion directory: concurrent conversions used to share
-    // one directory and each wiped every `temp_*` file on the way out, so one
-    // conversion could delete the pages another was still reading.
+    // Private per-conversion directory so the cleanup below can delete every
+    // page it holds without touching pages a concurrent conversion is reading.
     const tempDir = await createTexraTempDir('texra-pdf-conversion-');
     try {
       if (pageCount === 1) {

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -33,7 +33,6 @@ import { executeCommand, executeCommandSync } from './execUtils';
 
 const CHANNEL = 'toolUtils';
 
-// Interface for tool configuration (internal to this module)
 interface ToolConfig {
   command?: string | string[]; // Optional - defaults to "${toolName} --version"
   errorMessage: string;
@@ -56,42 +55,48 @@ async function reportMissingTool(
 
 // Platform-specific install instructions resolved at module load.
 // All guides are defined in @shared/constants/latex (single source of truth).
-const p = process.platform;
+function installGuide(guide: Parameters<typeof getInstallGuide>[0]): string {
+  return getInstallGuide(guide, process.platform);
+}
 
-const LATEXDIFF_INSTRUCTIONS = getInstallGuide(LATEXDIFF_INSTALL_GUIDE, p);
-const LATEXINDENT_INSTRUCTIONS = getInstallGuide(LATEXINDENT_INSTALL_GUIDE, p);
-const TEXFMT_INSTRUCTIONS = getInstallGuide(TEXFMT_INSTALL_GUIDE, p);
-const TEXCOUNT_INSTRUCTIONS = getInstallGuide(TEXCOUNT_INSTALL_GUIDE, p);
-const PERL_INSTRUCTIONS = getInstallGuide(PERL_INSTALL_GUIDE, p);
-const GHOSTSCRIPT_INSTRUCTIONS = getInstallGuide(GHOSTSCRIPT_INSTALL_GUIDE, p);
-const GM_INSTRUCTIONS = getInstallGuide(GRAPHICSMAGICK_INSTALL_GUIDE, p);
-const MAGICK_INSTRUCTIONS = getInstallGuide(IMAGEMAGICK_INSTALL_GUIDE, p);
-const WOLFRAM_INSTRUCTIONS = getInstallGuide(WOLFRAM_INSTALL_GUIDE, p);
-const PANDOC_INSTRUCTIONS = getInstallGuide(PANDOC_INSTALL_GUIDE, p);
-const PDFLATEX_INSTRUCTIONS = getInstallGuide(PDFLATEX_INSTALL_GUIDE, p);
-const LATEXMK_INSTRUCTIONS = getInstallGuide(LATEXMK_INSTALL_GUIDE, p);
+const LATEXDIFF_INSTRUCTIONS = installGuide(LATEXDIFF_INSTALL_GUIDE);
+const LATEXINDENT_INSTRUCTIONS = installGuide(LATEXINDENT_INSTALL_GUIDE);
+const TEXFMT_INSTRUCTIONS = installGuide(TEXFMT_INSTALL_GUIDE);
+const TEXCOUNT_INSTRUCTIONS = installGuide(TEXCOUNT_INSTALL_GUIDE);
+const PERL_INSTRUCTIONS = installGuide(PERL_INSTALL_GUIDE);
+const GHOSTSCRIPT_INSTRUCTIONS = installGuide(GHOSTSCRIPT_INSTALL_GUIDE);
+const GM_INSTRUCTIONS = installGuide(GRAPHICSMAGICK_INSTALL_GUIDE);
+const MAGICK_INSTRUCTIONS = installGuide(IMAGEMAGICK_INSTALL_GUIDE);
+const WOLFRAM_INSTRUCTIONS = installGuide(WOLFRAM_INSTALL_GUIDE);
+const PANDOC_INSTRUCTIONS = installGuide(PANDOC_INSTALL_GUIDE);
+const PDFLATEX_INSTRUCTIONS = installGuide(PDFLATEX_INSTALL_GUIDE);
+const LATEXMK_INSTRUCTIONS = installGuide(LATEXMK_INSTALL_GUIDE);
 
 // Most tool entries share the same "open installation docs" link and the same
 // "<tool> is not installed…" phrasing; only the label, install guide, and the
 // occasional reason/command differ. These builders capture just that variance.
 const INSTALL_DOCS = 'texra.openDoc,installation';
 
-const featureTool = (name: string, guide: string): string =>
-  `${name} is not installed. Please install it to use this feature.\n${guide}`;
-const texTool = (name: string, guide: string): string =>
-  `${name} is not installed. Please install a TeX distribution to use this feature.\n${guide}`;
+function featureTool(name: string, guide: string): string {
+  return `${name} is not installed. Please install it to use this feature.\n${guide}`;
+}
+
+function texTool(name: string, guide: string): string {
+  return `${name} is not installed. Please install a TeX distribution to use this feature.\n${guide}`;
+}
 
 /** Build a ToolConfig with the default install-docs link unless `docs: false`. */
-const withDocs = (
+function withDocs(
   errorMessage: string,
   extra: { command?: string | string[]; docs?: false } = {},
-): ToolConfig => ({
-  errorMessage,
-  ...(extra.command ? { command: extra.command } : {}),
-  ...(extra.docs === false ? {} : { openDocsCommand: INSTALL_DOCS }),
-});
+): ToolConfig {
+  return {
+    errorMessage,
+    ...(extra.command ? { command: extra.command } : {}),
+    ...(extra.docs === false ? {} : { openDocsCommand: INSTALL_DOCS }),
+  };
+}
 
-// All tool configurations in one place
 const TOOL_CONFIGS: Record<string, ToolConfig> = {
   // ImageMagick / GraphicsMagick / system dependencies
   magick: withDocs(
@@ -264,7 +269,6 @@ export async function checkToolInstalled(
   toolOrConfig: string | ToolConfig,
   showError: boolean = true,
 ): Promise<boolean> {
-  // Get the config object - either passed directly or looked up by string key
   const toolName = typeof toolOrConfig === 'string' ? toolOrConfig : null;
   const config: ToolConfig | undefined =
     typeof toolOrConfig === 'string'


### PR DESCRIPTION
## Summary

The campaign's closing coherence pass. Twelve refactor waves landed in three days (#9472..#9547 plus siblings); each file in this diff was churned **3 to 11 times** by agents with different immediate goals. Sequential editing leaves sediment no single wave can see — this sweep hunts exactly that, under one governing test: *would someone writing this file fresh today, with the final architecture in hand, write it this way?*

22 batches over the 351 churn-zone files (selected mechanically: every file the campaign touched 3+ times), each agent reading the file's own wave history (`git log --since=2026-07-30`) to spot the sediment in the diff sequence.

## Issue acceptance gates

No issue; campaign closing round. Behavior-preserving by charter — everything needing a decision was harvested into a 17-entry owner menu (posted separately) rather than decided by the sweep.

## Single source of truth

No ownership moved; this round polishes the wake without reopening the water (ModelCell, the carrier, single-owner facts, the frozen CLI NDJSON wire, and the two TaskState legacy boundaries are all settled and untouched as contracts).

## Duplication and abstraction budget

Pure sediment removal: transitional shims whose transitions completed, "this used to X" comments where X is gone, tests pinning one behavior twice through different eras' vocabulary, half-moved seams finished (stragglers repointed at homes earlier waves established), mixed idioms unified onto each file's dominant one. One deliberate +6: an if/else chain became a switch so a future sixth wizard step fails to compile instead of silently rendering the wrong picker.

## Net elements (R6)

| | |
| --- | --- |
| Files changed | 221 |
| Net LoC | **−1,021** (2,817 insertions, 3,838 deletions) |
| Exported symbols | −1 (8 added, 9 removed) |

## Consumer counts (R8)

All removed exports grep-verified to zero remaining consumers (`ChatTuiFocusedChildFollowUpRoute`, `CliUpdateFetchResult`, and peers); dead-code ratchet 17 vs 17, baseline untouched.

## Host impact

None intended. The one user-visible change a batch smuggled in — a follow-up-input resize (min-height 6rem→2.75rem, auto-grow) — was **reverted with its paired test** and moved to the decision menu; if wanted, it ships as its own reviewed change.

## Review

Adversarial review across 9 areas with the campaign's proven category order: **4 findings, 0 high, 1 medium** (the smuggled resize, reverted). Post-review fixes: a test-state stub updated for the `selectableStreamNames` migration; a transient stale-tsbuildinfo typecheck ghost cleared by a direct tsc run.

## The decision menu

The harvest produced 17 owner decisions (posted as a comment): loud-fallback sweeps, ModelCell mirror retirement, test-only surface deletions, dead wire-contract removals, the assertion-idiom ruling, legacy-read retirement dates, and the follow-up-input resize question. Each has a firm recommendation and is approvable at a glance.

## Validation

| check | result |
| --- | --- |
| `npm run typecheck` | pass |
| `env -u FORCE_COLOR npm test` | 825 files, 8,481 tests, 0 failures |
| lint / prettier | pass (4 gitignored build outputs excluded) |
| dead-code + architecture ratchets | pass |

Note: three agents flagged mid-run cross-batch compile wobble in the shared checkout; all resolved by the time the final gates ran, and the numbers above are from the settled tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qs4Vgf3VxahEjs5maQF5Ds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The reflection round **cancelled** vs **completed** change alters when persisted rounds are discarded on non-interrupt stops; most other edits are comments and refactors, but that path deserves a quick regression check on interrupted vs limit-hit runs.
> 
> **Overview**
> Closing **coherence pass** after many rapid refactors: mostly comment removal, dead export cleanup, and small structural tidy-ups with **~1,021 net lines removed** and no intentional product redesign.
> 
> **Workflow scripts (user-facing):** **CHANGELOG** documents workflow scripts for software-engineering and Lean team leads (behind the Workflow Script tools toggle). **`engineer`** and **`leanOrchestrator`** agent YAML plus **`SYNC_REMOTE_AGENTS.sql`** add **`delegate_workflow_script`** alongside existing delegation tools.
> 
> **Desktop:** VS Code–only getting-started actions now share **`vsCodeOnlyGettingStartedMessage`** in **`desktopCommandSurface`**, so the main-view banner and progress empty state cannot drift. Comments drop stale audit/PRD references; stream activation uses **`syncFullView`** instead of a local closure.
> 
> **CLI / TUI:** **`chatSessionController`** inlines session meta activation into **`beginRunContext`** and narrows **`tryResumeStream`** to an options object (with a thin public wrapper). Status bar fitting gets a shared **`truncatedIntoRemainingWidth`** helper; init wizard steps use a **`switch`**. Approval retry auto-switch is synchronous again; a few unused type aliases and legacy comment blocks are removed.
> 
> **Extension / webview:** Progress toolbar buttons are typed (**`ProgressToolbarButton`**) with updated icon names; history item actions merge command metadata into one array; file-list log formatting shares **`buildFileListDetails`**. **`SupabaseAuthProvider`** drops an unused context param; latexdiff commands route through **`withLatexdiffTool`**.
> 
> **Agent runtime (subtle behavior):** Reflection **response rounds** are **`cancelled` only on a real interrupt signal**, not on every **`shouldStop`** without **`endTurn`**—so token-limit or unrecognized stop reasons keep a round that already produced output. **`RETRY_BACKOFF_MS`** is exported from **`RetryState`** for **`ModelInvocationNode`**; response-cycle debug file naming is centralized in **`responseDebugFileOptions`**.
> 
> Also: **`.gitignore`** adds **`errorLogs/`**; **`packages/agent`** uses the concrete **`RuntimeSessionHandle`** type on **`attachEvents`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35eb0e4ef64814dc094536af91f44d66586d10b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->