### PR TITLE
fix: generate valid Google request formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Google models accept ordinary prompts and complex tool sets reliably** —
+  the Interactions API no longer receives empty text blocks, and Google tool
+  declarations use its supported schema representation instead of failing
+  during server-side schema processing.
 - **OpenAI background responses keep one polling deadline across retries** —
   reconnecting to the same response no longer restarts its three-hour polling
   window. Once that window expires, TeXRA stops automatic retries and permits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,10 +56,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **Google models accept ordinary prompts and complex tool sets reliably** —
-  the Interactions API no longer receives empty text blocks, and Google tool
-  declarations use its supported schema representation instead of failing
-  during server-side schema processing.
+- **Google models handle prompts and tool-enabled tasks reliably** — requests
+  no longer fail when a prompt has no prefix or when complex tool sets are
+  enabled.
 - **OpenAI background responses keep one polling deadline across retries** —
   reconnecting to the same response no longer restarts its three-hour polling
   window. Once that window expires, TeXRA stops automatic retries and permits

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -134,38 +134,6 @@ function isTextContent(content: Content): content is TextContent {
   return content.type === 'text';
 }
 
-/** Remove text blocks that the Interactions API rejects as missing content. */
-function omitEmptyTextContent<T extends Content>(content: readonly T[]): T[] {
-  return content.filter(
-    (item) => !isTextContent(item) || Boolean(item.text?.trim()),
-  );
-}
-
-/** Also normalize transcripts restored from storage at the API boundary. */
-function omitEmptyTextContentFromSteps(steps: readonly Step[]): Step[] {
-  return steps.map((step) => {
-    if (step.type === 'user_input' || step.type === 'model_output') {
-      return {
-        ...step,
-        content: omitEmptyTextContent(step.content ?? []),
-      } satisfies UserInputStep | ModelOutputStep;
-    }
-    if (step.type === 'thought' && step.summary) {
-      return {
-        ...step,
-        summary: omitEmptyTextContent(step.summary),
-      } satisfies ThoughtStep;
-    }
-    if (step.type === 'function_result' && Array.isArray(step.result)) {
-      return {
-        ...step,
-        result: omitEmptyTextContent(step.result),
-      } satisfies FunctionResultStep;
-    }
-    return step;
-  });
-}
-
 /**
  * Steps the CLIENT contributes and must (re)send: the user's turns and tool
  * results. Under `previous_interaction_id` chaining the model-generated steps
@@ -722,6 +690,12 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
       content.push(this.textMedia(`${separator}${userRequest}`));
     }
 
+    if (content.length === 0) {
+      throw new Error(
+        'Google messages require a non-empty user prefix, request, or attachment.',
+      );
+    }
+
     return [{ type: 'user_input', content } satisfies UserInputStep];
   }
 
@@ -735,6 +709,12 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
       ...(userMessage.trim() ? [this.textMedia(userMessage)] : []),
     ];
 
+    if (content.length === 0) {
+      throw new Error(
+        'Google follow-up messages require non-empty text or an attachment.',
+      );
+    }
+
     messages.push({ type: 'user_input', content } satisfies UserInputStep);
     return messages;
   }
@@ -743,6 +723,7 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     messages: Step[],
     userMessage: string,
   ): Promise<Step[]> {
+    if (!userMessage.trim()) return messages;
     const last = messages.at(-1);
     if (last?.type === 'user_input') {
       (last.content ??= []).push(this.textMedia(userMessage));
@@ -770,6 +751,9 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
   }
 
   protected textMedia(text: string): TextContent {
+    if (!text) {
+      throw new Error('Google text content must not be empty.');
+    }
     return { type: 'text', text };
   }
 
@@ -1290,11 +1274,9 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     // completes. Filtering to client-input steps fixes both the tool-round 400
     // and the text-round assistant-turn re-send.
     const shouldSendAll = !stateful || this.chainedInteractionId === null;
-    const inputSteps = omitEmptyTextContentFromSteps(
-      shouldSendAll
-        ? base
-        : base.slice(this.sentStepCount).filter(isClientInputStep),
-    );
+    const inputSteps = shouldSendAll
+      ? base
+      : base.slice(this.sentStepCount).filter(isClientInputStep);
     const previousId =
       stateful && !shouldSendAll
         ? (this.chainedInteractionId ?? undefined)
@@ -2074,8 +2056,8 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
   /**
    * Convert generic tool definitions to Interactions `FunctionT[]`.
    *
-   * Reuses the Google-specific bounded schema conversion and feeds its output
-   * into `FunctionT.parameters` — the
+   * Generates Google's finite OpenAPI schema and feeds it directly into
+   * `FunctionT.parameters` — the
    * chat `toGoogleTools` wrapper (`[{ functionDeclarations }]`) is NOT reused.
    */
   private toInteractionsTools(defs: ToolDefinition[]): FunctionT[] {

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -716,8 +716,11 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     const content: Content[] = [
       ...(userPrefix.trim() ? [this.textMedia(userPrefix)] : []),
       ...(await this.buildLabelledMedia(mediaFiles, 'initial')),
-      ...(userRequest.trim() ? [this.textMedia(userRequest)] : []),
     ];
+    if (userRequest.trim()) {
+      const separator = content.length > 0 ? '\n' : '';
+      content.push(this.textMedia(`${separator}${userRequest}`));
+    }
 
     return [{ type: 'user_input', content } satisfies UserInputStep];
   }

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1151,12 +1151,14 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     mediaFiles: FileLocation[],
   ): Promise<MediaAttachmentKind[]> {
     if (!mediaFiles.length || !this.supportsFileUploads()) return [];
-    const lastUser = messages.findLast(
-      (s): s is UserInputStep => s.type === 'user_input',
-    );
-    if (!lastUser) return [];
     const media = await this.createMediaForRound(mediaFiles, 'insert');
     if (media.length === 0) return [];
+    const trailing = messages.at(-1);
+    const lastUser =
+      trailing?.type === 'user_input' && messages.length > this.sentStepCount
+        ? trailing
+        : ({ type: 'user_input', content: [] } satisfies UserInputStep);
+    if (lastUser !== trailing) messages.push(lastUser);
     (lastUser.content ??= []).unshift(...media);
     return this.consumeInsertedAttachmentKinds('insert');
   }

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -63,7 +63,7 @@ import {
   formatToolResultAsText,
   loadAttachmentBuffer,
 } from '../utils/toolAttachmentUtils';
-import { convertToolSchema, toGoogleTools } from '../toolConversion';
+import { convertGoogleToolSchema, toGoogleTools } from '../toolConversion';
 import type { GoogleMediaSource } from './googleHandlerShared';
 
 // Interactions SDK aliases (public surface; the SDK re-exports these under the
@@ -132,6 +132,38 @@ const COUNTABLE_MEDIA_RESOLUTION_BY_LEVEL: Partial<
  */
 function isTextContent(content: Content): content is TextContent {
   return content.type === 'text';
+}
+
+/** Remove text blocks that the Interactions API rejects as missing content. */
+function omitEmptyTextContent<T extends Content>(content: readonly T[]): T[] {
+  return content.filter(
+    (item) => !isTextContent(item) || Boolean(item.text?.trim()),
+  );
+}
+
+/** Also normalize transcripts restored from storage at the API boundary. */
+function omitEmptyTextContentFromSteps(steps: readonly Step[]): Step[] {
+  return steps.map((step) => {
+    if (step.type === 'user_input' || step.type === 'model_output') {
+      return {
+        ...step,
+        content: omitEmptyTextContent(step.content ?? []),
+      } satisfies UserInputStep | ModelOutputStep;
+    }
+    if (step.type === 'thought' && step.summary) {
+      return {
+        ...step,
+        summary: omitEmptyTextContent(step.summary),
+      } satisfies ThoughtStep;
+    }
+    if (step.type === 'function_result' && Array.isArray(step.result)) {
+      return {
+        ...step,
+        result: omitEmptyTextContent(step.result),
+      } satisfies FunctionResultStep;
+    }
+    return step;
+  });
 }
 
 /**
@@ -682,9 +714,9 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     // System prompt is NOT a step — it rides on request-level system_instruction
     // (resent on every create, spec §6.2).
     const content: Content[] = [
-      this.textMedia(userPrefix),
+      ...(userPrefix.trim() ? [this.textMedia(userPrefix)] : []),
       ...(await this.buildLabelledMedia(mediaFiles, 'initial')),
-      this.textMedia(`\n${userRequest}`),
+      ...(userRequest.trim() ? [this.textMedia(userRequest)] : []),
     ];
 
     return [{ type: 'user_input', content } satisfies UserInputStep];
@@ -697,7 +729,7 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
   ): Promise<Step[]> {
     const content: Content[] = [
       ...(await this.buildLabelledMedia(mediaFiles, 'followUp')),
-      this.textMedia(userMessage),
+      ...(userMessage.trim() ? [this.textMedia(userMessage)] : []),
     ];
 
     messages.push({ type: 'user_input', content } satisfies UserInputStep);
@@ -1255,9 +1287,11 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     // completes. Filtering to client-input steps fixes both the tool-round 400
     // and the text-round assistant-turn re-send.
     const shouldSendAll = !stateful || this.chainedInteractionId === null;
-    const inputSteps = shouldSendAll
-      ? base
-      : base.slice(this.sentStepCount).filter(isClientInputStep);
+    const inputSteps = omitEmptyTextContentFromSteps(
+      shouldSendAll
+        ? base
+        : base.slice(this.sentStepCount).filter(isClientInputStep),
+    );
     const previousId =
       stateful && !shouldSendAll
         ? (this.chainedInteractionId ?? undefined)
@@ -2037,8 +2071,8 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
   /**
    * Convert generic tool definitions to Interactions `FunctionT[]`.
    *
-   * Reuses the wire-agnostic `convertToolSchema` (JSON-Schema flatten +
-   * `$schema` strip) and feeds its output into `FunctionT.parameters` — the
+   * Reuses the Google-specific bounded schema conversion and feeds its output
+   * into `FunctionT.parameters` — the
    * chat `toGoogleTools` wrapper (`[{ functionDeclarations }]`) is NOT reused.
    */
   private toInteractionsTools(defs: ToolDefinition[]): FunctionT[] {
@@ -2046,7 +2080,7 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
       type: 'function',
       name: d.name,
       description: d.description,
-      parameters: convertToolSchema(d) ?? undefined,
+      parameters: convertGoogleToolSchema(d) ?? undefined,
     }));
   }
 }

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -16,7 +16,11 @@ import type {
   Tool as AnthropicTool,
   ToolUnion,
 } from '@anthropic-ai/sdk/resources/messages';
-import type { Tool as GeminiTool, FunctionDeclaration } from '@google/genai';
+import type {
+  Tool as GeminiTool,
+  FunctionDeclaration,
+  Schema as GeminiSchema,
+} from '@google/genai';
 import type { ChatCompletionFunctionTool } from 'openai/resources/chat/completions';
 import type {
   FunctionTool,
@@ -162,6 +166,160 @@ export function convertToolSchema(
   }
   if (!schema) return null;
   return stripDollarSchema(flattenTopLevelUnion(schema));
+}
+
+function isSchemaObject(value: unknown): value is JSONSchemaObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Resolve a local JSON Pointer against a schema root. */
+function resolveLocalSchemaRef(root: JSONSchemaObject, ref: string): unknown {
+  if (!ref.startsWith('#/')) return undefined;
+  return ref
+    .slice(2)
+    .split('/')
+    .map((part) => part.replaceAll('~1', '/').replaceAll('~0', '~'))
+    .reduce<unknown>((value, part) => {
+      if (!isSchemaObject(value) && !Array.isArray(value)) return undefined;
+      return value[part as keyof typeof value];
+    }, root);
+}
+
+/**
+ * Reduce a general JSON Schema to the simpler form accepted reliably by
+ * Google's function-calling endpoints.
+ *
+ * Optional properties do not need a separate null branch in the model-facing
+ * schema: omission expresses absence, while runtime Zod validation continues
+ * to accept explicit null. Local references are expanded once; a recursive
+ * edge becomes an unconstrained value so Google's server does not attempt to
+ * flatten an unbounded schema such as `z.json()`.
+ */
+function simplifyGoogleSchemaNode(
+  value: unknown,
+  root: JSONSchemaObject,
+  resolvingRefs: ReadonlySet<string>,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      simplifyGoogleSchemaNode(item, root, resolvingRefs),
+    );
+  }
+  if (!isSchemaObject(value)) return value;
+
+  const ref = typeof value.$ref === 'string' ? value.$ref : undefined;
+  if (ref) {
+    if (resolvingRefs.has(ref)) return {};
+    const target = resolveLocalSchemaRef(root, ref);
+    if (target !== undefined) {
+      return simplifyGoogleSchemaNode(
+        target,
+        root,
+        new Set([...resolvingRefs, ref]),
+      );
+    }
+  }
+
+  const anyOf = Array.isArray(value.anyOf) ? value.anyOf : undefined;
+  if (anyOf) {
+    const nonNull = anyOf.filter(
+      (branch) => !isSchemaObject(branch) || branch.type !== 'null',
+    );
+    if (nonNull.length === 1 && nonNull.length !== anyOf.length) {
+      const simplified = simplifyGoogleSchemaNode(
+        nonNull[0],
+        root,
+        resolvingRefs,
+      );
+      if (isSchemaObject(simplified)) {
+        const { anyOf: _anyOf, ...siblings } = value;
+        return { ...simplified, ...siblings };
+      }
+      return simplified;
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => key !== '$defs' && key !== '$schema')
+      .map(([key, child]) => [
+        key,
+        simplifyGoogleSchemaNode(child, root, resolvingRefs),
+      ]),
+  );
+}
+
+/** Convert a tool schema to Google's bounded function-declaration subset. */
+export function convertGoogleToolSchema(
+  def: ToolDefinition,
+): JSONSchemaObject | null {
+  const schema = convertToolSchema(def);
+  if (!schema) return null;
+  return simplifyGoogleSchemaNode(
+    schema,
+    schema,
+    new Set(),
+  ) as JSONSchemaObject;
+}
+
+const GOOGLE_OPENAPI_SCHEMA_KEYS = new Set([
+  'anyOf',
+  'default',
+  'description',
+  'enum',
+  'example',
+  'format',
+  'items',
+  'maxItems',
+  'maxLength',
+  'maxProperties',
+  'maximum',
+  'minItems',
+  'minLength',
+  'minProperties',
+  'minimum',
+  'nullable',
+  'pattern',
+  'properties',
+  'propertyOrdering',
+  'required',
+  'title',
+  'type',
+]);
+
+/** Keep only the OpenAPI subset represented by the Google SDK's Schema type. */
+function toGoogleOpenApiSchemaNode(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(toGoogleOpenApiSchemaNode);
+  if (!isSchemaObject(value)) return value;
+
+  const converted: JSONSchemaObject = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (!GOOGLE_OPENAPI_SCHEMA_KEYS.has(key)) continue;
+    if (key === 'properties' && isSchemaObject(child)) {
+      converted.properties = Object.fromEntries(
+        Object.entries(child).map(([name, schema]) => [
+          name,
+          toGoogleOpenApiSchemaNode(schema),
+        ]),
+      );
+      continue;
+    }
+    converted[key] = toGoogleOpenApiSchemaNode(child);
+  }
+  return converted;
+}
+
+/**
+ * Build the SDK-native function schema used by Generate Content. Unlike
+ * `parametersJsonSchema`, `parameters` is normalized locally by @google/genai
+ * and does not invoke Google's server-side JSON-Schema flattening path.
+ */
+function convertGoogleFunctionParameters(
+  def: ToolDefinition,
+): GeminiSchema | null {
+  const schema = convertGoogleToolSchema(def);
+  if (!schema) return null;
+  return toGoogleOpenApiSchemaNode(schema) as GeminiSchema;
 }
 
 /**
@@ -374,7 +532,7 @@ export function toGoogleTools(defs: ToolDefinition[]): GeminiTool[] {
   const declarations: FunctionDeclaration[] = defs.map((d) => ({
     name: d.name,
     description: d.description,
-    parametersJsonSchema: convertToolSchema(d) ?? undefined,
+    parameters: convertGoogleFunctionParameters(d) ?? undefined,
   }));
 
   return [{ functionDeclarations: declarations }];

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -36,6 +36,14 @@ const CHANNEL = 'toolConversion';
 
 type JSONSchemaObject = Record<string, unknown>;
 
+function schemaLiteralValue(schema: JSONSchemaObject): unknown {
+  if (schema.const !== undefined) return schema.const;
+  if (Array.isArray(schema.enum) && schema.enum.length === 1) {
+    return schema.enum[0];
+  }
+  return undefined;
+}
+
 /**
  * OpenAI, Gemini, and Anthropic all require function parameter schemas whose
  * top-level node is an object. OpenAI and Gemini also reject schemas whose
@@ -91,8 +99,8 @@ function flattenTopLevelUnion(schema: JSONSchemaObject): JSONSchemaObject {
     }
     // Discriminator: every branch pins this prop to a literal value.
     const constValues = branchSchemas
-      .map((s) => s.const)
-      .filter((c) => c !== undefined);
+      .map(schemaLiteralValue)
+      .filter((value) => value !== undefined);
     if (constValues.length === branchSchemas.length) {
       const descriptions = branchSchemas
         .map((s) => s.description)
@@ -172,107 +180,54 @@ function isSchemaObject(value: unknown): value is JSONSchemaObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-/** Resolve a local JSON Pointer against a schema root. */
-function resolveLocalSchemaRef(root: JSONSchemaObject, ref: string): unknown {
-  if (!ref.startsWith('#/')) return undefined;
-  return ref
-    .slice(2)
-    .split('/')
-    .map((part) => part.replaceAll('~1', '/').replaceAll('~0', '~'))
-    .reduce<unknown>((value, part) => {
-      if (!isSchemaObject(value) && !Array.isArray(value)) return undefined;
-      return value[part as keyof typeof value];
-    }, root);
-}
+const GOOGLE_TOOL_JSON_SCHEMA_OPTIONS = Object.freeze({
+  ...TOOL_JSON_SCHEMA_OPTIONS,
+  target: 'openapi-3.0',
+  cycles: 'throw',
+} as const);
 
-/**
- * Reduce a general JSON Schema to the simpler form accepted reliably by
- * Google's function-calling endpoints.
- *
- * Optional properties do not need a separate null branch in the model-facing
- * schema: omission expresses absence, while runtime Zod validation continues
- * to accept explicit null. Local references are expanded once; a recursive
- * edge becomes an unconstrained value so Google's server does not attempt to
- * flatten an unbounded schema such as `z.json()`.
- */
-function simplifyGoogleSchemaNode(
-  value: unknown,
-  root: JSONSchemaObject,
-  resolvingRefs: ReadonlySet<string>,
-): unknown {
-  if (Array.isArray(value)) {
-    return value.map((item) =>
-      simplifyGoogleSchemaNode(item, root, resolvingRefs),
-    );
-  }
-  if (!isSchemaObject(value)) return value;
-
-  const ref = typeof value.$ref === 'string' ? value.$ref : undefined;
-  if (ref) {
-    const { $ref: _ref, ...siblings } = value;
-    const simplifiedSiblings = simplifyGoogleSchemaNode(
-      siblings,
-      root,
-      resolvingRefs,
-    );
-    if (resolvingRefs.has(ref)) return simplifiedSiblings;
-    const target = resolveLocalSchemaRef(root, ref);
-    if (target !== undefined) {
-      const simplifiedTarget = simplifyGoogleSchemaNode(
-        target,
-        root,
-        new Set([...resolvingRefs, ref]),
-      );
-      if (
-        isSchemaObject(simplifiedTarget) &&
-        isSchemaObject(simplifiedSiblings)
-      ) {
-        return { ...simplifiedTarget, ...simplifiedSiblings };
-      }
-      return simplifiedTarget;
-    }
-  }
-
-  const anyOf = Array.isArray(value.anyOf) ? value.anyOf : undefined;
-  if (anyOf) {
-    const nonNull = anyOf.filter(
-      (branch) => !isSchemaObject(branch) || branch.type !== 'null',
-    );
-    if (nonNull.length === 1 && nonNull.length !== anyOf.length) {
-      const simplified = simplifyGoogleSchemaNode(
-        nonNull[0],
-        root,
-        resolvingRefs,
-      );
-      if (isSchemaObject(simplified)) {
-        const { anyOf: _anyOf, ...siblings } = value;
-        return { ...simplified, ...siblings };
-      }
-      return simplified;
-    }
-  }
-
-  return Object.fromEntries(
-    Object.entries(value)
-      .filter(([key]) => key !== '$defs' && key !== '$schema')
-      .map(([key, child]) => [
-        key,
-        simplifyGoogleSchemaNode(child, root, resolvingRefs),
-      ]),
+function containsSchemaReference(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsSchemaReference);
+  if (!isSchemaObject(value)) return false;
+  return (
+    typeof value.$ref === 'string' ||
+    Object.values(value).some(containsSchemaReference)
   );
 }
 
-/** Convert a tool schema to Google's bounded function-declaration subset. */
+/**
+ * Convert a tool directly from its canonical Zod schema to Google's finite
+ * OpenAPI representation. Recursive references are rejected locally rather
+ * than weakened on the wire.
+ */
 export function convertGoogleToolSchema(
   def: ToolDefinition,
 ): JSONSchemaObject | null {
-  const schema = convertToolSchema(def);
+  let schema: JSONSchemaObject | null;
+  if (def.zodSchema) {
+    try {
+      schema = toJSONSchema(
+        def.zodSchema,
+        GOOGLE_TOOL_JSON_SCHEMA_OPTIONS,
+      ) as JSONSchemaObject;
+    } catch (error) {
+      throw new Error(
+        `Google tool "${def.name}" must use a finite parameter schema without recursive references.`,
+        { cause: error },
+      );
+    }
+  } else {
+    schema = (def.parameters ?? null) as JSONSchemaObject | null;
+  }
   if (!schema) return null;
-  return simplifyGoogleSchemaNode(
-    schema,
-    schema,
-    new Set(),
-  ) as JSONSchemaObject;
+  const normalized = stripDollarSchema(flattenTopLevelUnion(schema));
+  if (containsSchemaReference(normalized)) {
+    throw new Error(
+      `Google tool "${def.name}" must use a finite parameter schema without references.`,
+    );
+  }
+  const { $defs: _defs, definitions: _definitions, ...finite } = normalized;
+  return finite;
 }
 
 // This mirrors @google/genai's Schema interface. Validation-only JSON Schema

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -191,7 +191,12 @@ function containsSchemaReference(value: unknown): boolean {
   if (!isSchemaObject(value)) return false;
   return (
     typeof value.$ref === 'string' ||
-    Object.values(value).some(containsSchemaReference)
+    Object.entries(value).some(
+      ([key, child]) =>
+        key !== 'default' &&
+        key !== 'example' &&
+        containsSchemaReference(child),
+    )
   );
 }
 

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -235,7 +235,7 @@ export function convertGoogleToolSchema(
 // exclusiveMaximum, and multipleOf are deliberately absent: the SDK does not
 // represent them (and independently drops additionalProperties). The original
 // Zod schema remains authoritative when TeXRA validates a returned tool call.
-const GOOGLE_OPENAPI_SCHEMA_KEYS = new Set([
+const GOOGLE_OPENAPI_SCHEMA_KEYS = new Set<string>([
   'anyOf',
   'default',
   'description',
@@ -258,7 +258,7 @@ const GOOGLE_OPENAPI_SCHEMA_KEYS = new Set([
   'required',
   'title',
   'type',
-]);
+] as const satisfies readonly (keyof GeminiSchema)[]);
 
 /** Keep only the OpenAPI subset represented by the Google SDK's Schema type. */
 function toGoogleOpenApiSchemaNode(value: unknown): unknown {
@@ -281,6 +281,17 @@ function toGoogleOpenApiSchemaNode(value: unknown): unknown {
       continue;
     }
     converted[key] = toGoogleOpenApiSchemaNode(child);
+  }
+
+  // Google has no exclusive-bound fields, but integer exclusivity can be
+  // represented exactly with the adjacent inclusive integer.
+  if (value.type === 'integer') {
+    if (value.exclusiveMinimum === true && typeof value.minimum === 'number') {
+      converted.minimum = Math.floor(value.minimum) + 1;
+    }
+    if (value.exclusiveMaximum === true && typeof value.maximum === 'number') {
+      converted.maximum = Math.ceil(value.maximum) - 1;
+    }
   }
   return converted;
 }

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -183,91 +183,8 @@ function isSchemaObject(value: unknown): value is JSONSchemaObject {
 const GOOGLE_TOOL_JSON_SCHEMA_OPTIONS = Object.freeze({
   ...TOOL_JSON_SCHEMA_OPTIONS,
   target: 'openapi-3.0',
-  cycles: 'ref',
+  cycles: 'throw',
 } as const);
-
-function isReferenceTo(value: unknown, reference: string): boolean {
-  return isSchemaObject(value) && value.$ref === reference;
-}
-
-/** Match the finite JSON Schema expansion emitted specifically for z.json(). */
-function isArbitraryJsonDefinition(value: unknown, reference: string): boolean {
-  if (!isSchemaObject(value) || !Array.isArray(value.anyOf)) return false;
-  const [string, number, boolean, nullable, array, record] = value.anyOf;
-  return (
-    value.anyOf.length === 6 &&
-    isSchemaObject(string) &&
-    string.type === 'string' &&
-    isSchemaObject(number) &&
-    number.type === 'number' &&
-    isSchemaObject(boolean) &&
-    boolean.type === 'boolean' &&
-    isSchemaObject(nullable) &&
-    nullable.type === 'string' &&
-    nullable.nullable === true &&
-    Array.isArray(nullable.enum) &&
-    nullable.enum.length === 1 &&
-    nullable.enum[0] === null &&
-    isSchemaObject(array) &&
-    array.type === 'array' &&
-    isReferenceTo(array.items, reference) &&
-    isSchemaObject(record) &&
-    record.type === 'object' &&
-    isReferenceTo(record.additionalProperties, reference)
-  );
-}
-
-function arbitraryJsonDefinitionReferences(
-  schema: JSONSchemaObject,
-): Set<string> {
-  const references = new Set<string>();
-  for (const definitionsKey of ['$defs', 'definitions'] as const) {
-    const definitions = schema[definitionsKey];
-    if (!isSchemaObject(definitions)) continue;
-    for (const [name, definition] of Object.entries(definitions)) {
-      const reference = `#/${definitionsKey}/${name.replaceAll('~', '~0').replaceAll('/', '~1')}`;
-      if (isArbitraryJsonDefinition(definition, reference)) {
-        references.add(reference);
-      }
-    }
-  }
-  return references;
-}
-
-/** Replace only references emitted for z.json(); leave every other ref intact. */
-function rewriteArbitraryJsonNodes(
-  value: unknown,
-  references: ReadonlySet<string>,
-): unknown {
-  if (Array.isArray(value)) {
-    return value.map((child) => rewriteArbitraryJsonNodes(child, references));
-  }
-  if (!isSchemaObject(value)) return value;
-
-  const rewritten = Object.fromEntries(
-    Object.entries(value)
-      .map(([key, child]) => [
-        key,
-        key === '$ref' && typeof child === 'string' && references.has(child)
-          ? undefined
-          : rewriteArbitraryJsonNodes(child, references),
-      ])
-      .filter(([, child]) => child !== undefined),
-  );
-
-  if (
-    Array.isArray(rewritten.allOf) &&
-    rewritten.allOf.length > 0 &&
-    rewritten.allOf.every(
-      (branch: unknown) =>
-        isSchemaObject(branch) && Object.keys(branch).length === 0,
-    )
-  ) {
-    delete rewritten.allOf;
-    delete rewritten.nullable;
-  }
-  return rewritten;
-}
 
 function containsSchemaReference(value: unknown): boolean {
   if (Array.isArray(value)) return value.some(containsSchemaReference);
@@ -289,13 +206,9 @@ export function convertGoogleToolSchema(
   let schema: JSONSchemaObject | null;
   if (def.zodSchema) {
     try {
-      const converted = toJSONSchema(
+      schema = toJSONSchema(
         def.zodSchema,
         GOOGLE_TOOL_JSON_SCHEMA_OPTIONS,
-      ) as JSONSchemaObject;
-      schema = rewriteArbitraryJsonNodes(
-        converted,
-        arbitraryJsonDefinitionReferences(converted),
       ) as JSONSchemaObject;
     } catch (error) {
       throw new Error(
@@ -310,9 +223,7 @@ export function convertGoogleToolSchema(
   const normalized = stripDollarSchema(flattenTopLevelUnion(schema));
   if (containsSchemaReference(normalized)) {
     throw new Error(
-      def.zodSchema
-        ? `Google tool "${def.name}" must use a finite parameter schema without recursive references.`
-        : `Google tool "${def.name}" must use a finite parameter schema without references.`,
+      `Google tool "${def.name}" must use a finite parameter schema without references.`,
     );
   }
   const { $defs: _defs, definitions: _definitions, ...finite } = normalized;

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -209,14 +209,27 @@ function simplifyGoogleSchemaNode(
 
   const ref = typeof value.$ref === 'string' ? value.$ref : undefined;
   if (ref) {
-    if (resolvingRefs.has(ref)) return {};
+    const { $ref: _ref, ...siblings } = value;
+    const simplifiedSiblings = simplifyGoogleSchemaNode(
+      siblings,
+      root,
+      resolvingRefs,
+    );
+    if (resolvingRefs.has(ref)) return simplifiedSiblings;
     const target = resolveLocalSchemaRef(root, ref);
     if (target !== undefined) {
-      return simplifyGoogleSchemaNode(
+      const simplifiedTarget = simplifyGoogleSchemaNode(
         target,
         root,
         new Set([...resolvingRefs, ref]),
       );
+      if (
+        isSchemaObject(simplifiedTarget) &&
+        isSchemaObject(simplifiedSiblings)
+      ) {
+        return { ...simplifiedTarget, ...simplifiedSiblings };
+      }
+      return simplifiedTarget;
     }
   }
 
@@ -298,6 +311,9 @@ function toGoogleOpenApiSchemaNode(value: unknown): unknown {
   if (!isSchemaObject(value)) return value;
 
   const converted: JSONSchemaObject = {};
+  if (typeof value.const === 'string' && !Array.isArray(value.enum)) {
+    converted.enum = [value.const];
+  }
   for (const [key, child] of Object.entries(value)) {
     if (!GOOGLE_OPENAPI_SCHEMA_KEYS.has(key)) continue;
     if (key === 'properties' && isSchemaObject(child)) {

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -262,6 +262,11 @@ export function convertGoogleToolSchema(
   ) as JSONSchemaObject;
 }
 
+// This mirrors @google/genai's Schema interface. Validation-only JSON Schema
+// keywords such as additionalProperties, exclusiveMinimum,
+// exclusiveMaximum, and multipleOf are deliberately absent: the SDK does not
+// represent them (and independently drops additionalProperties). The original
+// Zod schema remains authoritative when TeXRA validates a returned tool call.
 const GOOGLE_OPENAPI_SCHEMA_KEYS = new Set([
   'anyOf',
   'default',

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -235,7 +235,7 @@ export function convertGoogleToolSchema(
 // exclusiveMaximum, and multipleOf are deliberately absent: the SDK does not
 // represent them (and independently drops additionalProperties). The original
 // Zod schema remains authoritative when TeXRA validates a returned tool call.
-const GOOGLE_OPENAPI_SCHEMA_KEYS = new Set<string>([
+const GOOGLE_OPENAPI_SCHEMA_KEY_LIST = [
   'anyOf',
   'default',
   'description',
@@ -258,7 +258,16 @@ const GOOGLE_OPENAPI_SCHEMA_KEYS = new Set<string>([
   'required',
   'title',
   'type',
-] as const satisfies readonly (keyof GeminiSchema)[]);
+] as const satisfies readonly (keyof GeminiSchema)[];
+
+type AssertNever<T extends never> = T;
+type _GoogleSchemaKeysAreExhaustive = AssertNever<
+  Exclude<keyof GeminiSchema, (typeof GOOGLE_OPENAPI_SCHEMA_KEY_LIST)[number]>
+>;
+
+const GOOGLE_OPENAPI_SCHEMA_KEYS = new Set<string>(
+  GOOGLE_OPENAPI_SCHEMA_KEY_LIST,
+);
 
 /** Keep only the OpenAPI subset represented by the Google SDK's Schema type. */
 function toGoogleOpenApiSchemaNode(value: unknown): unknown {

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -282,9 +282,13 @@ const GOOGLE_OPENAPI_SCHEMA_KEYS = new Set<string>(
 function toGoogleOpenApiSchemaNode(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(toGoogleOpenApiSchemaNode);
   if (!isSchemaObject(value)) return value;
-  if (Object.hasOwn(value, 'oneOf') || Object.hasOwn(value, 'allOf')) {
+  if (
+    Object.hasOwn(value, 'oneOf') ||
+    Object.hasOwn(value, 'allOf') ||
+    Object.hasOwn(value, 'not')
+  ) {
     throw new Error(
-      'Google tool schemas do not support nested oneOf or allOf combinators.',
+      'Google tool schemas do not support nested oneOf, allOf, or not constraints.',
     );
   }
   if (
@@ -322,10 +326,20 @@ function toGoogleOpenApiSchemaNode(value: unknown): unknown {
   // Google has no exclusive-bound fields, but integer exclusivity can be
   // represented exactly with the adjacent inclusive integer.
   if (value.type === 'integer') {
-    if (value.exclusiveMinimum === true && typeof value.minimum === 'number') {
+    if (typeof value.exclusiveMinimum === 'number') {
+      converted.minimum = Math.floor(value.exclusiveMinimum) + 1;
+    } else if (
+      value.exclusiveMinimum === true &&
+      typeof value.minimum === 'number'
+    ) {
       converted.minimum = Math.floor(value.minimum) + 1;
     }
-    if (value.exclusiveMaximum === true && typeof value.maximum === 'number') {
+    if (typeof value.exclusiveMaximum === 'number') {
+      converted.maximum = Math.ceil(value.exclusiveMaximum) - 1;
+    } else if (
+      value.exclusiveMaximum === true &&
+      typeof value.maximum === 'number'
+    ) {
       converted.maximum = Math.ceil(value.maximum) - 1;
     }
   }

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -273,6 +273,11 @@ const GOOGLE_OPENAPI_SCHEMA_KEYS = new Set<string>(
 function toGoogleOpenApiSchemaNode(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(toGoogleOpenApiSchemaNode);
   if (!isSchemaObject(value)) return value;
+  if (Object.hasOwn(value, 'oneOf') || Object.hasOwn(value, 'allOf')) {
+    throw new Error(
+      'Google tool schemas do not support nested oneOf or allOf combinators.',
+    );
+  }
 
   const converted: JSONSchemaObject = {};
   if (typeof value.const === 'string' && !Array.isArray(value.enum)) {
@@ -280,6 +285,10 @@ function toGoogleOpenApiSchemaNode(value: unknown): unknown {
   }
   for (const [key, child] of Object.entries(value)) {
     if (!GOOGLE_OPENAPI_SCHEMA_KEYS.has(key)) continue;
+    if (key === 'default' || key === 'example') {
+      converted[key] = child;
+      continue;
+    }
     if (key === 'properties' && isSchemaObject(child)) {
       converted.properties = Object.fromEntries(
         Object.entries(child).map(([name, schema]) => [

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -191,12 +191,16 @@ function containsSchemaReference(value: unknown): boolean {
   if (!isSchemaObject(value)) return false;
   return (
     typeof value.$ref === 'string' ||
-    Object.entries(value).some(
-      ([key, child]) =>
-        key !== 'default' &&
-        key !== 'example' &&
-        containsSchemaReference(child),
-    )
+    Object.entries(value).some(([key, child]) => {
+      if (key === 'default' || key === 'example') return false;
+      if (
+        (key === 'properties' || key === '$defs' || key === 'definitions') &&
+        isSchemaObject(child)
+      ) {
+        return Object.values(child).some(containsSchemaReference);
+      }
+      return containsSchemaReference(child);
+    })
   );
 }
 

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -277,19 +277,32 @@ type _GoogleSchemaKeysAreExhaustive = AssertNever<
 const GOOGLE_OPENAPI_SCHEMA_KEYS = new Set<string>(
   GOOGLE_OPENAPI_SCHEMA_KEY_LIST,
 );
+const GOOGLE_SCHEMA_CONVERSION_KEYS = new Set([
+  'additionalProperties',
+  'const',
+  'deprecated',
+  'exclusiveMaximum',
+  'exclusiveMinimum',
+  'readOnly',
+  'writeOnly',
+]);
 
 /** Keep only the OpenAPI subset represented by the Google SDK's Schema type. */
 function toGoogleOpenApiSchemaNode(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(toGoogleOpenApiSchemaNode);
   if (!isSchemaObject(value)) return value;
-  if (
-    Object.hasOwn(value, 'oneOf') ||
-    Object.hasOwn(value, 'allOf') ||
-    Object.hasOwn(value, 'not')
-  ) {
+  const unsupportedKey = Object.keys(value).find(
+    (key) =>
+      !GOOGLE_OPENAPI_SCHEMA_KEYS.has(key) &&
+      !GOOGLE_SCHEMA_CONVERSION_KEYS.has(key),
+  );
+  if (unsupportedKey) {
     throw new Error(
-      'Google tool schemas do not support nested oneOf, allOf, or not constraints.',
+      `Google tool schemas do not support the "${unsupportedKey}" keyword.`,
     );
+  }
+  if (Array.isArray(value.type)) {
+    throw new Error('Google tool schemas require a single scalar type.');
   }
   if (
     (value.const !== undefined && typeof value.const !== 'string') ||

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -183,8 +183,91 @@ function isSchemaObject(value: unknown): value is JSONSchemaObject {
 const GOOGLE_TOOL_JSON_SCHEMA_OPTIONS = Object.freeze({
   ...TOOL_JSON_SCHEMA_OPTIONS,
   target: 'openapi-3.0',
-  cycles: 'throw',
+  cycles: 'ref',
 } as const);
+
+function isReferenceTo(value: unknown, reference: string): boolean {
+  return isSchemaObject(value) && value.$ref === reference;
+}
+
+/** Match the finite JSON Schema expansion emitted specifically for z.json(). */
+function isArbitraryJsonDefinition(value: unknown, reference: string): boolean {
+  if (!isSchemaObject(value) || !Array.isArray(value.anyOf)) return false;
+  const [string, number, boolean, nullable, array, record] = value.anyOf;
+  return (
+    value.anyOf.length === 6 &&
+    isSchemaObject(string) &&
+    string.type === 'string' &&
+    isSchemaObject(number) &&
+    number.type === 'number' &&
+    isSchemaObject(boolean) &&
+    boolean.type === 'boolean' &&
+    isSchemaObject(nullable) &&
+    nullable.type === 'string' &&
+    nullable.nullable === true &&
+    Array.isArray(nullable.enum) &&
+    nullable.enum.length === 1 &&
+    nullable.enum[0] === null &&
+    isSchemaObject(array) &&
+    array.type === 'array' &&
+    isReferenceTo(array.items, reference) &&
+    isSchemaObject(record) &&
+    record.type === 'object' &&
+    isReferenceTo(record.additionalProperties, reference)
+  );
+}
+
+function arbitraryJsonDefinitionReferences(
+  schema: JSONSchemaObject,
+): Set<string> {
+  const references = new Set<string>();
+  for (const definitionsKey of ['$defs', 'definitions'] as const) {
+    const definitions = schema[definitionsKey];
+    if (!isSchemaObject(definitions)) continue;
+    for (const [name, definition] of Object.entries(definitions)) {
+      const reference = `#/${definitionsKey}/${name.replaceAll('~', '~0').replaceAll('/', '~1')}`;
+      if (isArbitraryJsonDefinition(definition, reference)) {
+        references.add(reference);
+      }
+    }
+  }
+  return references;
+}
+
+/** Replace only references emitted for z.json(); leave every other ref intact. */
+function rewriteArbitraryJsonNodes(
+  value: unknown,
+  references: ReadonlySet<string>,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((child) => rewriteArbitraryJsonNodes(child, references));
+  }
+  if (!isSchemaObject(value)) return value;
+
+  const rewritten = Object.fromEntries(
+    Object.entries(value)
+      .map(([key, child]) => [
+        key,
+        key === '$ref' && typeof child === 'string' && references.has(child)
+          ? undefined
+          : rewriteArbitraryJsonNodes(child, references),
+      ])
+      .filter(([, child]) => child !== undefined),
+  );
+
+  if (
+    Array.isArray(rewritten.allOf) &&
+    rewritten.allOf.length > 0 &&
+    rewritten.allOf.every(
+      (branch: unknown) =>
+        isSchemaObject(branch) && Object.keys(branch).length === 0,
+    )
+  ) {
+    delete rewritten.allOf;
+    delete rewritten.nullable;
+  }
+  return rewritten;
+}
 
 function containsSchemaReference(value: unknown): boolean {
   if (Array.isArray(value)) return value.some(containsSchemaReference);
@@ -206,9 +289,13 @@ export function convertGoogleToolSchema(
   let schema: JSONSchemaObject | null;
   if (def.zodSchema) {
     try {
-      schema = toJSONSchema(
+      const converted = toJSONSchema(
         def.zodSchema,
         GOOGLE_TOOL_JSON_SCHEMA_OPTIONS,
+      ) as JSONSchemaObject;
+      schema = rewriteArbitraryJsonNodes(
+        converted,
+        arbitraryJsonDefinitionReferences(converted),
       ) as JSONSchemaObject;
     } catch (error) {
       throw new Error(
@@ -223,7 +310,9 @@ export function convertGoogleToolSchema(
   const normalized = stripDollarSchema(flattenTopLevelUnion(schema));
   if (containsSchemaReference(normalized)) {
     throw new Error(
-      `Google tool "${def.name}" must use a finite parameter schema without references.`,
+      def.zodSchema
+        ? `Google tool "${def.name}" must use a finite parameter schema without recursive references.`
+        : `Google tool "${def.name}" must use a finite parameter schema without references.`,
     );
   }
   const { $defs: _defs, definitions: _definitions, ...finite } = normalized;

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -301,10 +301,17 @@ function toGoogleOpenApiSchemaNode(value: unknown): unknown {
     );
   }
 
-  const converted: JSONSchemaObject = {};
-  if (typeof value.const === 'string' && !Array.isArray(value.enum)) {
-    converted.enum = [value.const];
+  if (
+    typeof value.const === 'string' &&
+    Array.isArray(value.enum) &&
+    !value.enum.includes(value.const)
+  ) {
+    throw new Error(
+      'Google tool schemas cannot represent contradictory const and enum constraints.',
+    );
   }
+
+  const converted: JSONSchemaObject = {};
   for (const [key, child] of Object.entries(value)) {
     if (!GOOGLE_OPENAPI_SCHEMA_KEYS.has(key)) continue;
     if (key === 'default' || key === 'example') {
@@ -323,24 +330,43 @@ function toGoogleOpenApiSchemaNode(value: unknown): unknown {
     converted[key] = toGoogleOpenApiSchemaNode(child);
   }
 
+  if (typeof value.const === 'string') {
+    converted.enum = [value.const];
+  }
+
   // Google has no exclusive-bound fields, but integer exclusivity can be
   // represented exactly with the adjacent inclusive integer.
   if (value.type === 'integer') {
+    let exclusiveMinimum: number | undefined;
     if (typeof value.exclusiveMinimum === 'number') {
-      converted.minimum = Math.floor(value.exclusiveMinimum) + 1;
+      exclusiveMinimum = Math.floor(value.exclusiveMinimum) + 1;
     } else if (
       value.exclusiveMinimum === true &&
       typeof value.minimum === 'number'
     ) {
-      converted.minimum = Math.floor(value.minimum) + 1;
+      exclusiveMinimum = Math.floor(value.minimum) + 1;
     }
+    if (exclusiveMinimum !== undefined) {
+      converted.minimum =
+        typeof converted.minimum === 'number'
+          ? Math.max(converted.minimum, exclusiveMinimum)
+          : exclusiveMinimum;
+    }
+
+    let exclusiveMaximum: number | undefined;
     if (typeof value.exclusiveMaximum === 'number') {
-      converted.maximum = Math.ceil(value.exclusiveMaximum) - 1;
+      exclusiveMaximum = Math.ceil(value.exclusiveMaximum) - 1;
     } else if (
       value.exclusiveMaximum === true &&
       typeof value.maximum === 'number'
     ) {
-      converted.maximum = Math.ceil(value.maximum) - 1;
+      exclusiveMaximum = Math.ceil(value.maximum) - 1;
+    }
+    if (exclusiveMaximum !== undefined) {
+      converted.maximum =
+        typeof converted.maximum === 'number'
+          ? Math.min(converted.maximum, exclusiveMaximum)
+          : exclusiveMaximum;
     }
   }
   return converted;

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -196,9 +196,9 @@ function containsSchemaReference(value: unknown): boolean {
 }
 
 /**
- * Convert a tool directly from its canonical Zod schema to Google's finite
- * OpenAPI representation. Recursive references are rejected locally rather
- * than weakened on the wire.
+ * Convert a tool directly from its canonical Zod schema to the finite OpenAPI
+ * subset accepted by Google's model APIs. Recursive references are rejected
+ * locally rather than weakened on the wire.
  */
 export function convertGoogleToolSchema(
   def: ToolDefinition,
@@ -227,7 +227,7 @@ export function convertGoogleToolSchema(
     );
   }
   const { $defs: _defs, definitions: _definitions, ...finite } = normalized;
-  return finite;
+  return toGoogleOpenApiSchemaNode(finite) as JSONSchemaObject;
 }
 
 // This mirrors @google/genai's Schema interface. Validation-only JSON Schema
@@ -293,9 +293,7 @@ function toGoogleOpenApiSchemaNode(value: unknown): unknown {
 function convertGoogleFunctionParameters(
   def: ToolDefinition,
 ): GeminiSchema | null {
-  const schema = convertGoogleToolSchema(def);
-  if (!schema) return null;
-  return toGoogleOpenApiSchemaNode(schema) as GeminiSchema;
+  return convertGoogleToolSchema(def) as GeminiSchema | null;
 }
 
 /**

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -287,6 +287,15 @@ function toGoogleOpenApiSchemaNode(value: unknown): unknown {
       'Google tool schemas do not support nested oneOf or allOf combinators.',
     );
   }
+  if (
+    (value.const !== undefined && typeof value.const !== 'string') ||
+    (Array.isArray(value.enum) &&
+      value.enum.some((entry) => typeof entry !== 'string'))
+  ) {
+    throw new Error(
+      'Google tool schemas support only string literal constraints.',
+    );
+  }
 
   const converted: JSONSchemaObject = {};
   if (typeof value.const === 'string' && !Array.isArray(value.enum)) {

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
@@ -56,8 +56,7 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
     const steps = await handler.initializeMessages('PREFIX', 'REQUEST');
     expect(steps).toHaveLength(1);
     expect(steps[0].type).toBe('user_input');
-    expect(textOf(steps[0])).toContain('PREFIX');
-    expect(textOf(steps[0])).toContain('REQUEST');
+    expect(textOf(steps[0])).toBe('PREFIX\nREQUEST');
   });
 
   it('omits an empty prefix instead of sending an invalid text block', async () => {

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
@@ -67,12 +67,44 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
     expect(content).toEqual([{ type: 'text', text: 'What are we lacking?' }]);
   });
 
+  it('rejects an initial message with no content', async () => {
+    const handler = createHandler();
+    await expect(handler.initializeMessages(' ', '\n')).rejects.toThrow(
+      'Google messages require a non-empty user prefix, request, or attachment.',
+    );
+  });
+
+  it('rejects a follow-up round with no content', async () => {
+    const handler = createHandler();
+    await expect(handler.createRoundMessages([], ' ')).rejects.toThrow(
+      'Google follow-up messages require non-empty text or an attachment.',
+    );
+  });
+
   it('createAssistantMessage builds a model_output step', () => {
     const handler = createHandler();
     const step = handler.createAssistantMessage('hi');
     expect(step.type).toBe('model_output');
     expect(textOf(step)).toBe('hi');
     expect(handler.extractAssistantText(step)).toBe('hi');
+  });
+
+  it('rejects empty text when constructing a content block', () => {
+    const handler = createHandler();
+    expect(() => handler.createAssistantMessage('')).toThrow(
+      'Google text content must not be empty.',
+    );
+  });
+
+  it('does not append an empty follow-up text block', async () => {
+    const handler = createHandler();
+    const steps: Step[] = [
+      { type: 'user_input', content: [{ type: 'text', text: 'body' }] },
+    ];
+    await handler.createUserFollowUpMessages(steps, '');
+    expect(steps).toEqual([
+      { type: 'user_input', content: [{ type: 'text', text: 'body' }] },
+    ]);
   });
 
   it('prependTextToUserMessage prepends into the trailing user_input step', () => {

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
@@ -135,6 +135,26 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
     expect((content[1] as Interactions.TextContent).text).toBe('caption');
   });
 
+  it('creates a new user turn for an image-only follow-up', async () => {
+    const handler = createHandler();
+    const steps: Step[] = [
+      { type: 'user_input', content: [{ type: 'text', text: 'question' }] },
+      { type: 'model_output', content: [{ type: 'text', text: 'answer' }] },
+    ];
+    stubImageMediaLoader(handler);
+
+    await handler.createUserFollowUpMessages(steps, '');
+    await handler.addMediaToUserMessage(steps, [
+      { absolutePath: '/x/follow-up.png' } as never,
+    ]);
+
+    expect(steps).toHaveLength(3);
+    expect(steps[2]).toEqual({
+      type: 'user_input',
+      content: [{ type: 'image', data: 'aGVsbG8=', mime_type: 'image/png' }],
+    });
+  });
+
   it('initializeMessages includes typed media content when mediaFiles are provided', async () => {
     const handler = createHandler();
     stubImageMediaLoader(handler);

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
@@ -60,6 +60,14 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
     expect(textOf(steps[0])).toContain('REQUEST');
   });
 
+  it('omits an empty prefix instead of sending an invalid text block', async () => {
+    const handler = createHandler();
+    const steps = await handler.initializeMessages('', 'What are we lacking?');
+
+    const content = (steps[0] as Interactions.UserInputStep).content ?? [];
+    expect(content).toEqual([{ type: 'text', text: 'What are we lacking?' }]);
+  });
+
   it('createAssistantMessage builds a model_output step', () => {
     const handler = createHandler();
     const step = handler.createAssistantMessage('hi');

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 
 // Local imports
 import { noopTrace } from '@agent/trace';
@@ -158,6 +159,40 @@ describe('ModelHandlerGoogleInteractions tool use', () => {
 
     expect(calls[0]?.generation_config?.tool_choice).toBe('submit_output');
     expect(handler.supportsForcedToolChoice).toBe(true);
+  });
+
+  it('sends only Google-supported numeric constraints', async () => {
+    const handler = createHandler();
+    const calls: CreateParams[] = [];
+    const client = fakeClient(
+      [completedEvent('int_schema', 'completed', [])],
+      calls,
+    );
+
+    await handler.createResponse({
+      client: client as never,
+      messages: [
+        { type: 'user_input', content: [{ type: 'text', text: 'count' }] },
+      ],
+      temperature: 0,
+      tools: [
+        {
+          name: 'positive_count',
+          zodSchema: z.strictObject({ count: z.number().positive() }),
+        },
+      ],
+    });
+
+    const interactionTool = calls[0]?.tools?.[0] as
+      { parameters?: unknown } | undefined;
+    const parameters = interactionTool?.parameters as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+    expect(parameters.properties.count).toStrictEqual({
+      type: 'number',
+      minimum: 0,
+    });
+    expect(JSON.stringify(parameters)).not.toContain('exclusiveMinimum');
   });
 
   it('accumulates parallel arguments_delta chunks and extracts tool calls', async () => {

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
@@ -177,8 +177,11 @@ describe('ModelHandlerGoogleInteractions tool use', () => {
       temperature: 0,
       tools: [
         {
-          name: 'positive_count',
-          zodSchema: z.strictObject({ count: z.number().positive() }),
+          name: 'bounded_counts',
+          zodSchema: z.strictObject({
+            integer: z.int().positive().lt(10),
+            number: z.number().positive().lt(10),
+          }),
         },
       ],
     });
@@ -188,11 +191,17 @@ describe('ModelHandlerGoogleInteractions tool use', () => {
     const parameters = interactionTool?.parameters as {
       properties: Record<string, Record<string, unknown>>;
     };
-    expect(parameters.properties.count).toStrictEqual({
+    expect(parameters.properties.integer).toStrictEqual({
+      type: 'integer',
+      minimum: 1,
+      maximum: 9,
+    });
+    expect(parameters.properties.number).toStrictEqual({
       type: 'number',
       minimum: 0,
+      maximum: 10,
     });
-    expect(JSON.stringify(parameters)).not.toContain('exclusiveMinimum');
+    expect(JSON.stringify(parameters)).not.toContain('exclusive');
   });
 
   it('accumulates parallel arguments_delta chunks and extracts tool calls', async () => {

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -832,36 +832,53 @@ describe('toGoogleTools', () => {
         properties: {
           options: {
             type: 'object',
-            default: { mode: 'fast' },
-            example: { mode: 'careful' },
+            default: {
+              $ref: 'literal default data',
+              oneOf: ['fast'],
+              allOf: [{ mode: 'fast' }],
+            },
+            example: {
+              $ref: 'literal example data',
+              oneOf: ['careful'],
+              allOf: [{ mode: 'careful' }],
+            },
           },
         },
       },
     }) as { properties: Record<string, Record<string, unknown>> };
 
-    expect(schema.properties.options.default).toStrictEqual({ mode: 'fast' });
+    expect(schema.properties.options.default).toStrictEqual({
+      $ref: 'literal default data',
+      oneOf: ['fast'],
+      allOf: [{ mode: 'fast' }],
+    });
     expect(schema.properties.options.example).toStrictEqual({
-      mode: 'careful',
+      $ref: 'literal example data',
+      oneOf: ['careful'],
+      allOf: [{ mode: 'careful' }],
     });
   });
 
-  it('rejects unsupported nested Google combinators', () => {
-    expect(() =>
-      convertGoogleToolSchema({
-        name: 'combined_input',
-        parameters: {
-          type: 'object',
-          properties: {
-            value: {
-              oneOf: [{ type: 'string' }, { type: 'number' }],
+  it.each(['oneOf', 'allOf'] as const)(
+    'rejects unsupported nested Google %s combinators',
+    (combinator) => {
+      expect(() =>
+        convertGoogleToolSchema({
+          name: 'combined_input',
+          parameters: {
+            type: 'object',
+            properties: {
+              value: {
+                [combinator]: [{ type: 'string' }, { type: 'number' }],
+              },
             },
           },
-        },
-      }),
-    ).toThrow(
-      'Google tool schemas do not support nested oneOf or allOf combinators.',
-    );
-  });
+        }),
+      ).toThrow(
+        'Google tool schemas do not support nested oneOf or allOf combinators.',
+      );
+    },
+  );
 
   it('preserves constraints attached to nested Google parameters', () => {
     const tools = toGoogleTools([

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -884,25 +884,48 @@ describe('toGoogleTools', () => {
   );
 
   it('preserves raw numeric exclusive integer bounds exactly', () => {
-    const schema = convertGoogleToolSchema({
+    const definition = {
       name: 'bounded_integer',
       parameters: {
         type: 'object',
         properties: {
-          value: {
+          lowerInclusiveStricter: {
             type: 'integer',
+            minimum: 7,
             exclusiveMinimum: 3,
+          },
+          lowerExclusiveStricter: {
+            type: 'integer',
+            minimum: 3,
+            exclusiveMinimum: 7,
+          },
+          upperInclusiveStricter: {
+            type: 'integer',
+            maximum: 4,
             exclusiveMaximum: 10,
+          },
+          upperExclusiveStricter: {
+            type: 'integer',
+            maximum: 10,
+            exclusiveMaximum: 4,
           },
         },
       },
-    }) as { properties: Record<string, Record<string, unknown>> };
+    };
+    const interactionSchema = convertGoogleToolSchema(definition) as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+    const generateContentSchema = (toGoogleTools([definition])[0] as GeminiTool)
+      .functionDeclarations?.[0].parameters as {
+      properties: Record<string, Record<string, unknown>>;
+    };
 
-    expect(schema.properties.value).toMatchObject({
-      type: 'integer',
-      minimum: 4,
-      maximum: 9,
-    });
+    for (const schema of [interactionSchema, generateContentSchema]) {
+      expect(schema.properties.lowerInclusiveStricter.minimum).toBe(7);
+      expect(schema.properties.lowerExclusiveStricter.minimum).toBe(8);
+      expect(schema.properties.upperInclusiveStricter.maximum).toBe(4);
+      expect(schema.properties.upperExclusiveStricter.maximum).toBe(3);
+    }
   });
 
   it('rejects Google literal constraints that cannot be represented', () => {
@@ -915,6 +938,54 @@ describe('toGoogleTools', () => {
         },
       }),
     ).toThrow('Google tool schemas support only string literal constraints.');
+  });
+
+  it('intersects compatible Google string const and enum constraints', () => {
+    const definition = {
+      name: 'literal_intersection',
+      parameters: {
+        type: 'object',
+        properties: {
+          value: {
+            type: 'string',
+            const: 'review',
+            enum: ['draft', 'review'],
+          },
+        },
+      },
+    };
+    const interactionSchema = convertGoogleToolSchema(definition) as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+    const generateContentSchema = (toGoogleTools([definition])[0] as GeminiTool)
+      .functionDeclarations?.[0].parameters as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+
+    for (const schema of [interactionSchema, generateContentSchema]) {
+      expect(schema.properties.value.enum).toStrictEqual(['review']);
+    }
+  });
+
+  it('rejects contradictory Google string const and enum constraints', () => {
+    const definition = {
+      name: 'literal_contradiction',
+      parameters: {
+        type: 'object',
+        properties: {
+          value: {
+            type: 'string',
+            const: 'review',
+            enum: ['draft', 'final'],
+          },
+        },
+      },
+    };
+    const message =
+      'Google tool schemas cannot represent contradictory const and enum constraints.';
+
+    expect(() => convertGoogleToolSchema(definition)).toThrow(message);
+    expect(() => toGoogleTools([definition])).toThrow(message);
   });
 
   it('preserves constraints attached to nested Google parameters', () => {

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -878,10 +878,43 @@ describe('toGoogleTools', () => {
           },
         }),
       ).toThrow(
-        'Google tool schemas do not support nested oneOf, allOf, or not constraints.',
+        `Google tool schemas do not support the "${constraint}" keyword.`,
       );
     },
   );
+
+  it.each([
+    'contains',
+    'if',
+    'then',
+    'else',
+    'dependentSchemas',
+    'prefixItems',
+  ])('rejects the unsupported Google %s keyword', (keyword) => {
+    expect(() =>
+      convertGoogleToolSchema({
+        name: 'unsupported_input',
+        parameters: {
+          type: 'object',
+          properties: {
+            value: { type: 'array', [keyword]: { type: 'string' } },
+          },
+        },
+      }),
+    ).toThrow(`Google tool schemas do not support the "${keyword}" keyword.`);
+  });
+
+  it('rejects array-valued Google schema types', () => {
+    expect(() =>
+      convertGoogleToolSchema({
+        name: 'union_type',
+        parameters: {
+          type: 'object',
+          properties: { value: { type: ['string', 'null'] } },
+        },
+      }),
+    ).toThrow('Google tool schemas require a single scalar type.');
+  });
 
   it('preserves raw numeric exclusive integer bounds exactly', () => {
     const definition = {

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -859,9 +859,9 @@ describe('toGoogleTools', () => {
     });
   });
 
-  it.each(['oneOf', 'allOf'] as const)(
-    'rejects unsupported nested Google %s combinators',
-    (combinator) => {
+  it.each(['oneOf', 'allOf', 'not'] as const)(
+    'rejects unsupported nested Google %s constraints',
+    (constraint) => {
       expect(() =>
         convertGoogleToolSchema({
           name: 'combined_input',
@@ -869,16 +869,41 @@ describe('toGoogleTools', () => {
             type: 'object',
             properties: {
               value: {
-                [combinator]: [{ type: 'string' }, { type: 'number' }],
+                [constraint]:
+                  constraint === 'not'
+                    ? { const: 'reserved' }
+                    : [{ type: 'string' }, { type: 'number' }],
               },
             },
           },
         }),
       ).toThrow(
-        'Google tool schemas do not support nested oneOf or allOf combinators.',
+        'Google tool schemas do not support nested oneOf, allOf, or not constraints.',
       );
     },
   );
+
+  it('preserves raw numeric exclusive integer bounds exactly', () => {
+    const schema = convertGoogleToolSchema({
+      name: 'bounded_integer',
+      parameters: {
+        type: 'object',
+        properties: {
+          value: {
+            type: 'integer',
+            exclusiveMinimum: 3,
+            exclusiveMaximum: 10,
+          },
+        },
+      },
+    }) as { properties: Record<string, Record<string, unknown>> };
+
+    expect(schema.properties.value).toMatchObject({
+      type: 'integer',
+      minimum: 4,
+      maximum: 9,
+    });
+  });
 
   it('rejects Google literal constraints that cannot be represented', () => {
     expect(() =>

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -4,12 +4,14 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
 import {
+  convertGoogleToolSchema,
   toAnthropicTools,
   toGoogleTools,
   toOpenAITools,
   toOpenAIResponseTools,
 } from '@agent/modelHandlers/toolConversion';
 import type { ToolDefinition } from '@model/ToolDefinition';
+import { resolveToolDefinitions } from '@tools/registry';
 import { DiagnosticsTool } from '@tools/DiagnosticsTool';
 import { BashTool } from '@tools/bash';
 import { EditFileTool } from '@tools/EditTool';
@@ -679,24 +681,74 @@ describe('toGoogleTools', () => {
     assert.deepEqual(params.required, ['command']);
   });
 
-  it('removes null-only union branches from optional Google parameters', () => {
-    const tools = toGoogleTools([
-      {
-        name: 'optional_input',
-        zodSchema: z.strictObject({
-          query: z.string().nullish(),
-          count: z.number().positive().nullish(),
-        }),
-      },
-    ]);
+  it('generates optional Google parameters directly in OpenAPI form', () => {
+    const definition = {
+      name: 'optional_input',
+      zodSchema: z.strictObject({
+        query: z.string().nullish(),
+        count: z.number().positive().nullish(),
+      }),
+    };
+    const interactionParams = convertGoogleToolSchema(definition) as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+    expect(interactionParams.properties.query).toStrictEqual({
+      nullable: true,
+      type: 'string',
+    });
+    expect(interactionParams.properties.count).toStrictEqual({
+      nullable: true,
+      type: 'number',
+      minimum: 0,
+      exclusiveMinimum: true,
+    });
+    expect(JSON.stringify(interactionParams)).not.toContain('anyOf');
+
+    const tools = toGoogleTools([definition]);
     const params = (tools[0] as GeminiTool).functionDeclarations?.[0]
       .parameters as {
       properties: Record<string, Record<string, unknown>>;
     };
 
-    expect(params.properties.query).toStrictEqual({ type: 'string' });
-    expect(params.properties.count).toStrictEqual({ type: 'number' });
+    expect(params.properties.query).toStrictEqual({
+      nullable: true,
+      type: 'string',
+    });
+    expect(params.properties.count).toStrictEqual({
+      nullable: true,
+      type: 'number',
+      minimum: 0,
+    });
     expect(params).not.toHaveProperty('additionalProperties');
+  });
+
+  it('generates finite schemas for the scientific review tool roster', () => {
+    const reviewTools = resolveToolDefinitions([
+      'wolfram',
+      'todo_write',
+      'bash',
+      'read_file',
+      'write_file',
+      'edit_file',
+      'glob',
+      'grep',
+      'extract_figures',
+      'extract_bib_entries',
+      'extract_tikz_figures',
+      'texcount',
+      'arxiv_search',
+      'arxiv_metadata',
+      'crossref_search',
+      'diagnostics',
+    ]);
+
+    expect(reviewTools).toHaveLength(16);
+    for (const definition of reviewTools) {
+      const serialized = JSON.stringify(convertGoogleToolSchema(definition));
+      expect(serialized, definition.name).not.toContain('"type":"null"');
+      expect(serialized, definition.name).not.toContain('$ref');
+      expect(serialized, definition.name).not.toContain('$defs');
+    }
   });
 
   it('preserves constraints attached to nested Google parameters', () => {
@@ -707,13 +759,13 @@ describe('toGoogleTools', () => {
           type: 'object',
           properties: {
             mode: {
-              $ref: '#/$defs/mode',
+              type: 'string',
+              enum: ['brief', 'full'],
               description: 'Mode selected for this call',
             },
             action: { type: 'string', const: 'review' },
           },
           required: ['mode', 'action'],
-          $defs: { mode: { type: 'string', enum: ['brief', 'full'] } },
         },
       },
     ]);
@@ -733,20 +785,31 @@ describe('toGoogleTools', () => {
     });
   });
 
-  it('bounds recursive JSON values before Google flattens the schema', () => {
-    const tools = toGoogleTools([
-      {
-        name: 'json_input',
-        zodSchema: z.strictObject({ value: z.json().nullish() }),
-      },
-    ]);
-    const declaration = (tools[0] as GeminiTool).functionDeclarations?.[0];
-    const params = declaration?.parameters as Record<string, unknown>;
-    const serialized = JSON.stringify(params);
+  it('rejects recursive Google schemas instead of weakening them', () => {
+    expect(() =>
+      toGoogleTools([
+        {
+          name: 'json_input',
+          zodSchema: z.strictObject({ value: z.json().nullish() }),
+        },
+      ]),
+    ).toThrow(
+      'Google tool "json_input" must use a finite parameter schema without recursive references.',
+    );
+  });
 
-    expect(serialized.includes('$ref')).toBe(false);
-    expect(serialized.includes('$defs')).toBe(false);
-    expect(serialized.length < 1_000).toBe(true);
-    expect(declaration?.parametersJsonSchema).toBe(undefined);
+  it('rejects referenced external Google schemas instead of flattening them', () => {
+    expect(() =>
+      convertGoogleToolSchema({
+        name: 'referenced_input',
+        parameters: {
+          type: 'object',
+          properties: { mode: { $ref: '#/$defs/mode' } },
+          $defs: { mode: { type: 'string' } },
+        },
+      }),
+    ).toThrow(
+      'Google tool "referenced_input" must use a finite parameter schema without references.',
+    );
   });
 });

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -700,7 +700,6 @@ describe('toGoogleTools', () => {
       nullable: true,
       type: 'number',
       minimum: 0,
-      exclusiveMinimum: true,
     });
     expect(JSON.stringify(interactionParams)).not.toContain('anyOf');
 

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -880,6 +880,18 @@ describe('toGoogleTools', () => {
     },
   );
 
+  it('rejects Google literal constraints that cannot be represented', () => {
+    expect(() =>
+      convertGoogleToolSchema({
+        name: 'numeric_literal',
+        parameters: {
+          type: 'object',
+          properties: { value: { type: 'integer', const: 1 } },
+        },
+      }),
+    ).toThrow('Google tool schemas support only string literal constraints.');
+  });
+
   it('preserves constraints attached to nested Google parameters', () => {
     const tools = toGoogleTools([
       {

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -721,6 +721,38 @@ describe('toGoogleTools', () => {
     expect(params).not.toHaveProperty('additionalProperties');
   });
 
+  it('preserves exclusive integer bounds on both Google surfaces', () => {
+    const definition = {
+      name: 'bounded_values',
+      zodSchema: z.strictObject({
+        integer: z.int().positive().lt(10),
+        number: z.number().positive().lt(10),
+      }),
+    };
+    const interactionParams = convertGoogleToolSchema(definition) as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+    const generateContentParams = (toGoogleTools([definition])[0] as GeminiTool)
+      .functionDeclarations?.[0].parameters as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+
+    for (const parameters of [interactionParams, generateContentParams]) {
+      expect(parameters.properties.integer).toStrictEqual({
+        type: 'integer',
+        minimum: 1,
+        maximum: 9,
+      });
+      // Number bounds have no adjacent representable value in Google's
+      // supported subset, so retain their inclusive bounds without shifting.
+      expect(parameters.properties.number).toStrictEqual({
+        type: 'number',
+        minimum: 0,
+        maximum: 10,
+      });
+    }
+  });
+
   it('generates finite schemas for the scientific review tool roster', () => {
     const reviewTools = resolveToolDefinitions([
       'wolfram',
@@ -753,6 +785,12 @@ describe('toGoogleTools', () => {
         expect(serialized, definition.name).not.toContain('"type":"null"');
         expect(serialized, definition.name).not.toContain('$ref');
         expect(serialized, definition.name).not.toContain('$defs');
+        if (definition.name === 'arxiv_search') {
+          const parameters = schema as {
+            properties: Record<string, Record<string, unknown>>;
+          };
+          expect(parameters.properties.maxResults.minimum).toBe(1);
+        }
       }
     }
   });

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -740,14 +740,39 @@ describe('toGoogleTools', () => {
       'arxiv_metadata',
       'crossref_search',
       'diagnostics',
+      'delegate_workflow_script',
     ]);
 
-    expect(reviewTools).toHaveLength(16);
+    expect(reviewTools).toHaveLength(17);
     for (const definition of reviewTools) {
-      const serialized = JSON.stringify(convertGoogleToolSchema(definition));
-      expect(serialized, definition.name).not.toContain('"type":"null"');
-      expect(serialized, definition.name).not.toContain('$ref');
-      expect(serialized, definition.name).not.toContain('$defs');
+      const interactionSchema = convertGoogleToolSchema(definition);
+      const generateContentSchema = (
+        toGoogleTools([definition])[0] as GeminiTool
+      ).functionDeclarations?.[0].parameters;
+      for (const schema of [interactionSchema, generateContentSchema]) {
+        const serialized = JSON.stringify(schema);
+        expect(serialized, definition.name).not.toContain('"type":"null"');
+        expect(serialized, definition.name).not.toContain('$ref');
+        expect(serialized, definition.name).not.toContain('$defs');
+      }
+    }
+  });
+
+  it('converts the registered workflow script JSON args for both Google APIs', () => {
+    const [definition] = resolveToolDefinitions(['delegate_workflow_script']);
+    const interactionSchema = convertGoogleToolSchema(definition) as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+    const generateContentSchema = (toGoogleTools([definition])[0] as GeminiTool)
+      .functionDeclarations?.[0].parameters as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+
+    for (const schema of [interactionSchema, generateContentSchema]) {
+      const { description, ...argsConstraints } = schema.properties.args;
+      expect(description).toEqual(expect.any(String));
+      expect(argsConstraints).toStrictEqual({});
+      expect(JSON.stringify(schema)).not.toContain('$ref');
     }
   });
 
@@ -785,16 +810,20 @@ describe('toGoogleTools', () => {
     });
   });
 
-  it('rejects recursive Google schemas instead of weakening them', () => {
+  it('rejects recursive structural Google schemas instead of weakening them', () => {
+    const recursiveNode: z.ZodType = z.lazy(() =>
+      z.strictObject({ children: z.array(recursiveNode) }),
+    );
+
     expect(() =>
       toGoogleTools([
         {
-          name: 'json_input',
-          zodSchema: z.strictObject({ value: z.json().nullish() }),
+          name: 'recursive_input',
+          zodSchema: z.strictObject({ value: recursiveNode }),
         },
       ]),
     ).toThrow(
-      'Google tool "json_input" must use a finite parameter schema without recursive references.',
+      'Google tool "recursive_input" must use a finite parameter schema without recursive references.',
     );
   });
 
@@ -810,6 +839,20 @@ describe('toGoogleTools', () => {
       }),
     ).toThrow(
       'Google tool "referenced_input" must use a finite parameter schema without references.',
+    );
+  });
+
+  it('rejects dangling caller-supplied Google references', () => {
+    expect(() =>
+      convertGoogleToolSchema({
+        name: 'dangling_reference',
+        parameters: {
+          type: 'object',
+          properties: { mode: { $ref: '#/$defs/missing' } },
+        },
+      }),
+    ).toThrow(
+      'Google tool "dangling_reference" must use a finite parameter schema without references.',
     );
   });
 });

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -726,6 +726,8 @@ describe('toGoogleTools', () => {
       name: 'bounded_values',
       zodSchema: z.strictObject({
         integer: z.int().positive().lt(10),
+        aboveFraction: z.int().gt(1.2).max(10),
+        belowNegativeFraction: z.int().min(-10).lt(-1.2),
         number: z.number().positive().lt(10),
       }),
     };
@@ -742,6 +744,16 @@ describe('toGoogleTools', () => {
         type: 'integer',
         minimum: 1,
         maximum: 9,
+      });
+      expect(parameters.properties.aboveFraction).toStrictEqual({
+        type: 'integer',
+        minimum: 2,
+        maximum: 10,
+      });
+      expect(parameters.properties.belowNegativeFraction).toStrictEqual({
+        type: 'integer',
+        minimum: -10,
+        maximum: -2,
       });
       // Number bounds have no adjacent representable value in Google's
       // supported subset, so retain their inclusive bounds without shifting.

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -769,9 +769,8 @@ describe('toGoogleTools', () => {
     };
 
     for (const schema of [interactionSchema, generateContentSchema]) {
-      const { description, ...argsConstraints } = schema.properties.args;
-      expect(description).toEqual(expect.any(String));
-      expect(argsConstraints).toStrictEqual({});
+      expect(schema.properties.args.description).toEqual(expect.any(String));
+      expect(schema.properties.args.type).toBe('object');
       expect(JSON.stringify(schema)).not.toContain('$ref');
     }
   });

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -699,6 +699,40 @@ describe('toGoogleTools', () => {
     expect(params).not.toHaveProperty('additionalProperties');
   });
 
+  it('preserves constraints attached to nested Google parameters', () => {
+    const tools = toGoogleTools([
+      {
+        name: 'referenced_input',
+        parameters: {
+          type: 'object',
+          properties: {
+            mode: {
+              $ref: '#/$defs/mode',
+              description: 'Mode selected for this call',
+            },
+            action: { type: 'string', const: 'review' },
+          },
+          required: ['mode', 'action'],
+          $defs: { mode: { type: 'string', enum: ['brief', 'full'] } },
+        },
+      },
+    ]);
+    const params = (tools[0] as GeminiTool).functionDeclarations?.[0]
+      .parameters as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+
+    expect(params.properties.mode).toStrictEqual({
+      type: 'string',
+      enum: ['brief', 'full'],
+      description: 'Mode selected for this call',
+    });
+    expect(params.properties.action).toStrictEqual({
+      type: 'string',
+      enum: ['review'],
+    });
+  });
+
   it('bounds recursive JSON values before Google flattens the schema', () => {
     const tools = toGoogleTools([
       {

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -819,9 +819,48 @@ describe('toGoogleTools', () => {
 
     for (const schema of [interactionSchema, generateContentSchema]) {
       expect(schema.properties.args.description).toEqual(expect.any(String));
-      expect(schema.properties.args.type).toBe('object');
+      expect(schema.properties.args.type).toBeUndefined();
       expect(JSON.stringify(schema)).not.toContain('$ref');
     }
+  });
+
+  it('preserves opaque Google schema annotations', () => {
+    const schema = convertGoogleToolSchema({
+      name: 'annotated_input',
+      parameters: {
+        type: 'object',
+        properties: {
+          options: {
+            type: 'object',
+            default: { mode: 'fast' },
+            example: { mode: 'careful' },
+          },
+        },
+      },
+    }) as { properties: Record<string, Record<string, unknown>> };
+
+    expect(schema.properties.options.default).toStrictEqual({ mode: 'fast' });
+    expect(schema.properties.options.example).toStrictEqual({
+      mode: 'careful',
+    });
+  });
+
+  it('rejects unsupported nested Google combinators', () => {
+    expect(() =>
+      convertGoogleToolSchema({
+        name: 'combined_input',
+        parameters: {
+          type: 'object',
+          properties: {
+            value: {
+              oneOf: [{ type: 'string' }, { type: 'number' }],
+            },
+          },
+        },
+      }),
+    ).toThrow(
+      'Google tool schemas do not support nested oneOf or allOf combinators.',
+    );
   });
 
   it('preserves constraints attached to nested Google parameters', () => {

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -931,6 +931,26 @@ describe('toGoogleTools', () => {
     );
   });
 
+  it.each(['default', 'example'] as const)(
+    'rejects refs in Google properties named %s',
+    (propertyName) => {
+      expect(() =>
+        convertGoogleToolSchema({
+          name: 'named_property_reference',
+          parameters: {
+            type: 'object',
+            properties: {
+              [propertyName]: { $ref: '#/$defs/value' },
+            },
+            $defs: { value: { type: 'string' } },
+          },
+        }),
+      ).toThrow(
+        'Google tool "named_property_reference" must use a finite parameter schema without references.',
+      );
+    },
+  );
+
   it('rejects referenced external Google schemas instead of flattening them', () => {
     expect(() =>
       convertGoogleToolSchema({

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -654,8 +654,10 @@ describe('toGoogleTools', () => {
 
     const tools = toGoogleTools(defs);
     const tool = tools[0] as GeminiTool;
-    const params = tool.functionDeclarations?.[0]
-      .parametersJsonSchema as Record<string, unknown>;
+    const params = tool.functionDeclarations?.[0].parameters as Record<
+      string,
+      unknown
+    >;
 
     assert.equal(params.type, 'object');
     assert.equal(params.oneOf, undefined);
@@ -675,5 +677,42 @@ describe('toGoogleTools', () => {
     assert.ok(properties.status);
     // Only command is required by every branch.
     assert.deepEqual(params.required, ['command']);
+  });
+
+  it('removes null-only union branches from optional Google parameters', () => {
+    const tools = toGoogleTools([
+      {
+        name: 'optional_input',
+        zodSchema: z.strictObject({
+          query: z.string().nullish(),
+          count: z.number().positive().nullish(),
+        }),
+      },
+    ]);
+    const params = (tools[0] as GeminiTool).functionDeclarations?.[0]
+      .parameters as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+
+    expect(params.properties.query).toStrictEqual({ type: 'string' });
+    expect(params.properties.count).toStrictEqual({ type: 'number' });
+    expect(params).not.toHaveProperty('additionalProperties');
+  });
+
+  it('bounds recursive JSON values before Google flattens the schema', () => {
+    const tools = toGoogleTools([
+      {
+        name: 'json_input',
+        zodSchema: z.strictObject({ value: z.json().nullish() }),
+      },
+    ]);
+    const declaration = (tools[0] as GeminiTool).functionDeclarations?.[0];
+    const params = declaration?.parameters as Record<string, unknown>;
+    const serialized = JSON.stringify(params);
+
+    expect(serialized.includes('$ref')).toBe(false);
+    expect(serialized.includes('$defs')).toBe(false);
+    expect(serialized.length < 1_000).toBe(true);
+    expect(declaration?.parametersJsonSchema).toBe(undefined);
   });
 });

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -242,6 +242,9 @@ describe('WorkflowScriptTool', () => {
         scriptPath: expect.any(Object),
       },
     });
+    expect(JSON.stringify(providerProperties?.args)).toContain(
+      '"type":"object"',
+    );
     expect(providerProperties).not.toHaveProperty('scriptInput');
     expect(providerSchema?.required).not.toContain('script');
     expect(providerSchema?.required).not.toContain('scriptPath');
@@ -275,6 +278,20 @@ describe('WorkflowScriptTool', () => {
     expect(description).toContain(
       'Omit meta.tasks when the call set is data-dependent',
     );
+    expect(
+      definition.zodSchema?.safeParse({
+        agent: 'review',
+        script,
+        args: { nested: ['text', 1, true, null] },
+      }).success,
+    ).toBe(true);
+    expect(
+      definition.zodSchema?.safeParse({
+        agent: 'review',
+        script,
+        args: ['not', 'an', 'argument', 'object'],
+      }).success,
+    ).toBe(false);
   });
 
   it('rejects invalid JSON arguments at the schema boundary', async () => {

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -242,9 +242,7 @@ describe('WorkflowScriptTool', () => {
         scriptPath: expect.any(Object),
       },
     });
-    expect(JSON.stringify(providerProperties?.args)).toContain(
-      '"type":"object"',
-    );
+    expect(providerProperties?.args?.description).toContain('JSON value');
     expect(providerProperties).not.toHaveProperty('scriptInput');
     expect(providerSchema?.required).not.toContain('script');
     expect(providerSchema?.required).not.toContain('scriptPath');
@@ -291,7 +289,7 @@ describe('WorkflowScriptTool', () => {
         script,
         args: ['not', 'an', 'argument', 'object'],
       }).success,
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('rejects invalid JSON arguments at the schema boundary', async () => {

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -61,11 +61,9 @@ const WorkflowScriptToolInputSchema = z
       .min(1)
       .describe('Default workflow agent used when agent() omits agentName.'),
     args: z
-      .looseObject({})
+      .unknown()
       .nullish()
-      .describe(
-        'JSON argument object exposed to the script as the global args value.',
-      ),
+      .describe('JSON value exposed to the script as the global args value.'),
     files: WorkflowScriptFilesSchema.nullish().describe(
       'Workspace files bound to the workflow run by role and exposed to the script as the immutable global files object.',
     ),

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -61,10 +61,10 @@ const WorkflowScriptToolInputSchema = z
       .min(1)
       .describe('Default workflow agent used when agent() omits agentName.'),
     args: z
-      .json()
+      .looseObject({})
       .nullish()
       .describe(
-        'JSON arguments exposed to the script as the global args value.',
+        'JSON argument object exposed to the script as the global args value.',
       ),
     files: WorkflowScriptFilesSchema.nullish().describe(
       'Workspace files bound to the workflow run by role and exposed to the script as the immutable global files object.',
@@ -85,6 +85,13 @@ const WorkflowScriptToolInputSchema = z
       ),
   })
   .superRefine((input, ctx) => {
+    if (input.args != null && !z.json().safeParse(input.args).success) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Workflow arguments must contain valid JSON values.',
+        path: ['args'],
+      });
+    }
     if ((input.script == null) === (input.scriptPath == null)) {
       ctx.addIssue({
         code: 'custom',


### PR DESCRIPTION
## Summary

- construct Google Interactions messages without empty text blocks or empty user steps
- generate Google tool declarations directly in the finite OpenAPI schema dialect
- reject recursive or referenced tool schemas locally instead of weakening their meaning
- send Generate Content declarations through the SDK-native `parameters` field

## Problem

An ordinary Interactions request could contain an empty prefix text block followed by the actual user request. Google rejected the entire request with `400 Missing text in content of type text.`

The shared draft JSON Schema representation also rendered every optional-nullable tool field as an `anyOf` with a null branch. The scientific review agent consequently sent 45 artificial branches across 16 tools, and Google failed while flattening the schema. The prior implementation attempted to repair arbitrary generated schemas recursively at dispatch time, including weakening recursive schemas. That obscured the actual request format and could change tool meaning.

## Solution

Message constructors now omit absent text and reject a user step that would have no content. No transcript cleanup occurs at the request boundary.

Google tool schemas are generated directly from their Zod source with the OpenAPI 3.0 target used by Google's native function declarations. Optional-nullable properties therefore use `nullable: true` rather than redundant union branches. Genuine unions remain genuine unions. Recursive or referenced schemas are rejected with a descriptive local error because Google's function-schema processing cannot flatten them safely.

Runtime tool-call validation continues to use the original Zod schemas.

## Verification

- `corepack pnpm vitest run src/test-kernel/agent/modelHandlers/GoogleInteractions*.vitest.ts src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts` (106 passed, 4 live tests skipped)
- `corepack pnpm run typecheck:agent`
- `corepack pnpm run lint`
- `corepack pnpm run compile:fast`
- pre-commit and pre-push checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Google request shaping and tool declaration conversion used on every Google agent run; behavior is heavily tested but mis-converted schemas could still break tool calling until caught.
> 
> **Overview**
> Fixes Google model failures from **invalid Interactions payloads** and **tool schemas** that Google could not flatten.
> 
> **Messages:** Initial and follow-up user steps no longer emit empty text blocks (e.g. when the prefix is blank). Empty user turns are rejected; empty follow-up text is skipped; `textMedia` rejects empty strings. Media attachment logic can open a **new** `user_input` step for image-only follow-ups after model output instead of only mutating an already-sent user step.
> 
> **Tools:** Google Interactions and Generate Content now use a dedicated **`convertGoogleToolSchema`** path: OpenAPI 3.0 emission with `nullable: true` for optional fields (avoiding large `anyOf`/`null` unions), mapping to the SDK **`parameters`** field instead of **`parametersJsonSchema`**, and **local rejection** of recursive or `$ref`-based schemas rather than weakening them on the wire. Union flattening also treats single-value **`enum`** as discriminators. **`delegate_workflow_script`** `args` is typed as `unknown` with a JSON check in `superRefine` so provider schemas stay finite while runtime validation is unchanged.
> 
> CHANGELOG and broad vitest coverage document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d99c0cc61a7a2039621ac1d422a9d68f2e48cf1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->