### PR TITLE
refactor: implement the nineteen accepted wake-sweep decisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -588,6 +588,8 @@ These rules were earned from a 2026-07 whole-repo simplification campaign, not d
 
 - **One fake per port.** Tests use the shared fakes in `src/test-kernel/support/` for platform ports. A local fake for a port that already has a shared fake requires a one-line comment naming the capability the shared fake deliberately lacks.
 
+- **Vitest `expect` is the assertion idiom.** New and edited suites in `src/test-kernel/` assert with `expect`; do not import `node:assert`. The files still on `node:assert` are migration backlog, converted only in dedicated mechanical PRs (one file or one directory per reviewable PR, no behavior changes riding along) using the strict mapping: `assert.equal` becomes `toBe`, `assert.deepEqual` becomes `toStrictEqual` (never `toEqual`, which drops the `{a: undefined}` versus `{}` distinction), `assert.ok` becomes `toBeTruthy()`, or `toBe(true)` when the argument is already a boolean expression. Two carve-outs: `shared/stateSettings.vitest.ts` and `shared/settingsConfiguration.vitest.ts` keep `node:assert` for its per-key message argument, which names the failing settings key inside a catalog loop; and `agent/modelHandlers/ModelHandlerAnthropic.vitest.ts` and `agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts` (about 300 sites between them) are barred from batch conversion inside a polish or refactor pass, where the mechanical diff would bury the change under review.
+
 ## Documentation
 
 - Documentation lives in `docs/` and uses Markdown. Follow existing heading levels and style.

--- a/config/ratchets/shared-schemas-deep-import-baseline.json
+++ b/config/ratchets/shared-schemas-deep-import-baseline.json
@@ -216,7 +216,7 @@
         "UpdateGitAuthorSettingsMessage",
         "UpdateLatexConfigValuesMessage",
         "UpdateModelSelectionMessage",
-        "UpdateSuperYoloEnabledMessage"
+        "UpdateReliabilityAndOrchestrationMessage"
       ],
       "value": [
         "API_ACCESS_MODE_OPTIONS",

--- a/packages/cli/src/chat/tui/modals/RetryRequest.tsx
+++ b/packages/cli/src/chat/tui/modals/RetryRequest.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from 'ink';
 import {
   isCliApiSwitchableRetry,
   isCliChatGptSubscriptionRetry,
-} from '@cli/runtime/approvalAdapter';
+} from '@cli/runtime/approval/approvalPolicy';
 import { COLOR_HINT, COLOR_WARNING } from '@cli/tui/ui/colors';
 import { missingApiKeyRetryMessage } from '@cli/tui/ui/retryCopy';
 import { isApiProvider } from '@model/apiProviders';

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -22,10 +22,7 @@ import {
   workflowPhaseCallProgress,
   type WorkflowPhaseHeading,
 } from '@shared/copy/workflowCall';
-import {
-  formatPhaseStageLabel,
-  formatRoundStageLabel,
-} from '@shared/streams/streamStatusDisplay';
+import { formatStageLabel } from '@shared/streams/streamStatusDisplay';
 import { formatResultCount } from '@utils/text/stringUtils';
 
 // Local imports - TUI rendering
@@ -49,7 +46,6 @@ import {
   pendingApprovalRowSuffix,
 } from './SubagentListDisplay';
 import type { PendingApprovalKind } from '../state/approvalQueue';
-import type { StreamStage } from '../state/cliState';
 import type { StreamView } from '../state/streamViews';
 
 function HiddenRowSummary({
@@ -115,14 +111,6 @@ function PhaseHeader({
       ) : null}
     </Box>
   );
-}
-
-// A workflow-script run advances through phases, a tool-use run through
-// rounds; one slot carries whichever this stream has.
-function formatStageLabel(stage: StreamStage | undefined): string | undefined {
-  if (stage === undefined) return undefined;
-  if (stage.kind === 'round') return formatRoundStageLabel(stage);
-  return formatPhaseStageLabel(stage);
 }
 
 function SessionRow({

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -26,10 +26,7 @@ import {
   type TokenUsageStats,
 } from '@shared/schemas';
 import { isActivePhase } from '@shared/streams/streamStatus';
-import {
-  formatPhaseStageLabel,
-  formatRoundStageLabel,
-} from '@shared/streams/streamStatusDisplay';
+import { formatStageLabel } from '@shared/streams/streamStatusDisplay';
 import {
   filterNotNullish,
   formatCompactDuration,
@@ -266,33 +263,20 @@ function formatUsage(
   };
 }
 
-// A workflow-script run advances through phases, a tool-use run through
-// rounds; one status-bar slot carries whichever this stream has (mirrors the
+// One status-bar slot carries whichever stage this stream has (mirrors the
 // SubagentList row's `stageLabel`).
 function stageSegment(
   stage: StreamStage | undefined,
 ): StatusBarSegment | undefined {
   if (stage === undefined) return undefined;
-  if (stage.kind === 'round') {
-    return {
-      text: formatRoundStageLabel(stage),
-      // Keep round visibility on narrow terminals: degrade to the bare
-      // current-round label instead of dropping the planned total's context.
-      compactText: formatRoundStageLabel({ index: stage.index }),
-      color: 'dim',
-      compactPriority: STATUS_BAR_COMPACT_PRIORITY.stage,
-    };
-  }
-  const text = formatPhaseStageLabel(stage);
+  const text = formatStageLabel(stage);
   if (text === undefined) return undefined;
   return {
     text,
-    // Keep phase visibility on narrow terminals: degrade to the bare
-    // current-phase label instead of dropping the planned total's context.
-    compactText: formatPhaseStageLabel({
-      label: stage.label,
-      ...(stage.index !== undefined ? { index: stage.index } : {}),
-    }),
+    // Keep stage visibility on narrow terminals: degrade to the bare
+    // current round/phase label instead of dropping the planned total's
+    // context.
+    compactText: formatStageLabel({ ...stage, total: undefined }),
     color: 'dim',
     compactPriority: STATUS_BAR_COMPACT_PRIORITY.stage,
   };

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -418,10 +418,13 @@ export async function runChat(
     stdout: process.stdout,
   });
 
-  // Per-stream sidecar data (todos, plan, usage, output files) is persisted by
-  // the session's own snapshot store, so a `texra resume` restores the full
-  // display — the same streamData/{id}/* files the extension/desktop read.
-  const artifactSession = defaultSession();
+  // The TUI owns exactly one runtime session for its whole lifetime; resolve it
+  // once here so every path below propagates that owner instead of re-resolving
+  // the process default. Per-stream sidecar data (todos, plan, usage, output
+  // files) is persisted by the session's own snapshot store, so a `texra resume`
+  // restores the full display — the same streamData/{id}/* files the
+  // extension/desktop read.
+  const runtimeSession = defaultSession();
 
   const disposers: Array<() => void> = [];
   // Crash safety: if the process dies outside the orderly teardown below
@@ -434,7 +437,7 @@ export async function runChat(
   const terminalTitleUpdates = installTerminalTitleUpdates(context.cwd);
   disposers.push(terminalTitleUpdates.dispose);
   disposers.push(subscribeStreamLog());
-  disposers.push(subscribeStreamArtifacts(artifactSession.snapshots));
+  disposers.push(subscribeStreamArtifacts(runtimeSession.snapshots));
   disposers.push(subscribeStreamStatus());
 
   const session = new TuiSession();
@@ -449,7 +452,7 @@ export async function runChat(
   const hasActiveToolUseFlow = (): boolean =>
     Boolean(
       session.streamId &&
-      defaultSession().executions.getToolUseFlowContext(session.streamId),
+      runtimeSession.executions.getToolUseFlowContext(session.streamId),
     );
   const canSelectCurrentModel = (): boolean =>
     chatTuiCanSelectModel({
@@ -465,7 +468,7 @@ export async function runChat(
       return undefined;
     }
     const activeFlow = session.streamId
-      ? defaultSession().executions.getToolUseFlowContext(session.streamId)
+      ? runtimeSession.executions.getToolUseFlowContext(session.streamId)
       : undefined;
     return activeFlow?.modelSwitchDisabledReason(candidateModel);
   };
@@ -502,7 +505,7 @@ export async function runChat(
     getSessionContext: currentSessionContext,
     disposers,
     followUpQueue,
-    snapshotStore: artifactSession.snapshots,
+    snapshotStore: runtimeSession.snapshots,
   });
   disposers.push(
     setCliAgentResumeHandler({
@@ -542,7 +545,7 @@ export async function runChat(
     // StreamLogStore entries outlive resetCliState (which only clears the
     // React/signal view). Drop them so transcript projection can't replay
     // the cleared conversation into the fresh `<Static>` scrollback.
-    const store = defaultSession().transcripts;
+    const store = runtimeSession.transcripts;
     for (const streamId of streamsSignal.get().keys()) {
       store.delete(streamId).catch(() => {
         // Best-effort: a KV failure leaves the log on disk, but the run
@@ -719,7 +722,7 @@ export async function runChat(
       let delivered = false;
       let followUpTarget = childFollowUpTarget;
       const emitQueuedFollowUpsChanged = (streamId: StreamTabId): void => {
-        defaultSession().events.emit({
+        runtimeSession.events.emit({
           scope: 'session',
           event: {
             type: 'updateQueuedFollowUps',
@@ -789,7 +792,7 @@ export async function runChat(
       canInterruptActiveRun={canInterruptActiveRun}
       canInterruptStream={(streamId) =>
         (streamId === session.streamId && canInterruptActiveRun()) ||
-        defaultSession().status.isInFlight(streamId)
+        runtimeSession.status.isInFlight(streamId)
       }
       canStopActiveRun={canStopActiveRun}
       colorEnabled={stdoutColorEnabled}
@@ -801,15 +804,15 @@ export async function runChat(
       onSuspend={() => exitController.handleSigtstp()}
       onKillExecution={(executionId) => {
         clearApprovals();
-        defaultSession().executions.kill(executionId, {
+        runtimeSession.executions.kill(executionId, {
           detachActiveChildren: detachSubagentsOnStop(),
         });
       }}
       onSkipExecution={(executionId) => {
-        defaultSession().workflowControls.skip(executionId as ExecutionId);
+        runtimeSession.workflowControls.skip(executionId as ExecutionId);
       }}
       onRetryExecution={(executionId) => {
-        defaultSession().workflowControls.retry(executionId as ExecutionId);
+        runtimeSession.workflowControls.retry(executionId as ExecutionId);
       }}
       history={inputHistory}
     />,
@@ -851,7 +854,7 @@ export async function runChat(
     disposers,
     followUpQueue,
     getApprovalPolicy,
-    flushArtifacts: () => artifactSession.flushArtifacts(),
+    flushArtifacts: () => runtimeSession.flushArtifacts(),
     repaintAfterTerminalResume: () =>
       viewportController.repaintAfterTerminalResume(),
     suspendTerminalTitle: terminalTitleUpdates.suspend,
@@ -878,7 +881,7 @@ export async function runChat(
   // Auto-prompt when the active stream goes WAITING so the UI clearly
   // signals "your turn," alongside the StatusBar pill.
   disposers.push(
-    defaultSession().events.subscribeStatus((change) => {
+    runtimeSession.events.subscribeStatus((change) => {
       if (
         change.streamId === session.streamId &&
         change.phase === STREAM_PHASE.WAITING &&

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -31,15 +31,17 @@ import {
 } from '@agent/runtime/HostInteractions';
 import { getCliApiMode, setCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
+  toApprovalSettlement,
+  toToolEditResult,
+} from '@cli/runtime/approvalAdapter';
+import {
   askUserQuestionDenial,
   immediateDecision,
   immediateDecisionForApproval,
   isCliApiSwitchableRetry,
   isCliChatGptSubscriptionRetry,
   markApprovalDenied,
-  toApprovalSettlement,
-  toToolEditResult,
-} from '@cli/runtime/approvalAdapter';
+} from '@cli/runtime/approval/approvalPolicy';
 import { denyExternalInquiryIfNoHumanInput } from '@cli/runtime/approval/humanInputHandlers';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/cliPresentationHost';

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -142,93 +142,96 @@ function applyClearMissingOutputs(
   }
 }
 
-function applyDirectTuiRunEvent(
-  event: AgentEvent,
-  fallbackStreamId: StreamTabId,
-): void {
-  switch (event.type) {
-    case 'run.config':
-      applyRunConfig(event.streamId, event.config);
-      return;
-    case 'usage':
-      applyUsageUpdate(event.payload);
-      return;
-    case 'conversation.progress':
-      patchStream(fallbackStreamId, (s) => ({
-        ...s,
-        conversation: event.progress,
-      }));
-      return;
-    case 'updateTodos':
-      patchStream(event.streamId, (s) => ({
-        ...s,
-        todos: event.todos,
-      }));
-      return;
-    case 'updatePlan':
-      patchStream(event.streamId, (s) => ({
-        ...s,
-        plan: event.plan,
-      }));
-      return;
-    case 'goalPaused':
-      // Without a transcript line, an auto-paused goal is indistinguishable
-      // from a hang: the agent simply stops mid-objective.
-      appendLocalAssistantTranscript(
-        GOAL_PAUSED_TRANSCRIPT_NOTICE,
-        event.streamId,
-      );
-      return;
-    case 'addOutputFiles':
-      patchStream(event.streamId, (s) => ({
-        ...s,
-        outputFilesByRound: { ...s.outputFilesByRound, ...event.filesByRound },
-      }));
-      return;
-    case 'updateMissingOutputs':
-      patchStream(event.streamId, (s) => ({
-        ...s,
-        missingOutputsByRound: {
-          ...s.missingOutputsByRound,
-          ...event.filesByRound,
-        },
-      }));
-      return;
-    case 'updateCompileFailures':
-      patchStream(event.streamId, (s) => ({
-        ...s,
-        compileFailuresByRound: {
-          ...s.compileFailuresByRound,
-          ...event.filesByRound,
-        },
-      }));
-      return;
-    case 'stage.start':
-      if (event.kind === 'phase') {
-        applyStage(fallbackStreamId, {
-          kind: 'phase',
-          label: event.label,
-          ...(event.index !== undefined ? { index: event.index } : {}),
-          ...(event.total !== undefined && event.total > 0
-            ? { total: event.total }
-            : {}),
-        });
-        return;
-      }
-      if (event.kind !== 'round') return;
+type TuiRunFactHandlers = {
+  readonly [K in AgentEvent['type']]?: (
+    event: Extract<AgentEvent, { type: K }>,
+    fallbackStreamId: StreamTabId,
+  ) => void;
+};
+
+/**
+ * Run facts this TUI projects. The subscription filter below is derived from
+ * these keys, so the handled set and the delivered set cannot drift apart and
+ * a fact reaching the dispatch always has a handler.
+ */
+const TUI_RUN_FACT_HANDLERS = {
+  'run.config': (event) => applyRunConfig(event.streamId, event.config),
+  usage: (event) => applyUsageUpdate(event.payload),
+  'conversation.progress': (event, fallbackStreamId) =>
+    patchStream(fallbackStreamId, (s) => ({
+      ...s,
+      conversation: event.progress,
+    })),
+  updateTodos: (event) =>
+    patchStream(event.streamId, (s) => ({
+      ...s,
+      todos: event.todos,
+    })),
+  updatePlan: (event) =>
+    patchStream(event.streamId, (s) => ({
+      ...s,
+      plan: event.plan,
+    })),
+  // Without a transcript line, an auto-paused goal is indistinguishable from a
+  // hang: the agent simply stops mid-objective.
+  goalPaused: (event) =>
+    appendLocalAssistantTranscript(
+      GOAL_PAUSED_TRANSCRIPT_NOTICE,
+      event.streamId,
+    ),
+  addOutputFiles: (event) =>
+    patchStream(event.streamId, (s) => ({
+      ...s,
+      outputFilesByRound: { ...s.outputFilesByRound, ...event.filesByRound },
+    })),
+  updateMissingOutputs: (event) =>
+    patchStream(event.streamId, (s) => ({
+      ...s,
+      missingOutputsByRound: {
+        ...s.missingOutputsByRound,
+        ...event.filesByRound,
+      },
+    })),
+  updateCompileFailures: (event) =>
+    patchStream(event.streamId, (s) => ({
+      ...s,
+      compileFailuresByRound: {
+        ...s.compileFailuresByRound,
+        ...event.filesByRound,
+      },
+    })),
+  'stage.start': (event, fallbackStreamId) => {
+    if (event.kind === 'phase') {
       applyStage(fallbackStreamId, {
-        kind: 'round',
-        index: event.index ?? 0,
+        kind: 'phase',
+        label: event.label,
+        ...(event.index !== undefined ? { index: event.index } : {}),
         ...(event.total !== undefined && event.total > 0
           ? { total: event.total }
           : {}),
       });
       return;
-    case 'child.activity':
-      applySubagentRoster(event.parentStreamId, event.items);
-      return;
-  }
-}
+    }
+    if (event.kind !== 'round') return;
+    applyStage(fallbackStreamId, {
+      kind: 'round',
+      index: event.index ?? 0,
+      ...(event.total !== undefined && event.total > 0
+        ? { total: event.total }
+        : {}),
+    });
+  },
+  'child.activity': (event) =>
+    applySubagentRoster(event.parentStreamId, event.items),
+} satisfies TuiRunFactHandlers;
+
+type TuiRunFactType = keyof typeof TUI_RUN_FACT_HANDLERS;
+
+type TuiRunFactEvent = Extract<AgentEvent, { type: TuiRunFactType }>;
+
+const TUI_RUN_FACT_TYPES = Object.keys(
+  TUI_RUN_FACT_HANDLERS,
+) as TuiRunFactType[];
 
 function refreshQueuedFollowUps(
   streamId: UpdateQueuedFollowUpsPayload['streamId'],
@@ -305,24 +308,16 @@ export function attachTuiRunFactSubscription(
       if (generation !== getCliStateGeneration()) return;
       if (sessionEvent.scope !== 'run') return;
       if (isChildStreamRemoved(sessionEvent.streamId)) return;
-      applyDirectTuiRunEvent(sessionEvent.event, sessionEvent.streamId);
+      // Narrowed by the filter below; TypeScript cannot correlate a union
+      // event with its own handler slot, so the lookup is asserted once.
+      const event = sessionEvent.event as TuiRunFactEvent;
+      const handle = TUI_RUN_FACT_HANDLERS[event.type] as (
+        event: TuiRunFactEvent,
+        fallbackStreamId: StreamTabId,
+      ) => void;
+      handle(event, sessionEvent.streamId);
     },
-    {
-      scope: 'run',
-      types: [
-        'conversation.progress',
-        'updateTodos',
-        'updatePlan',
-        'addOutputFiles',
-        'updateMissingOutputs',
-        'updateCompileFailures',
-        'goalPaused',
-        'run.config',
-        'usage',
-        'stage.start',
-        'child.activity',
-      ],
-    },
+    { scope: 'run', types: TUI_RUN_FACT_TYPES },
   );
   return () => {
     detachResetHook();

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -11,7 +11,7 @@
 import { isDeepStrictEqual } from 'node:util';
 
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { appendCliApiSwitchHint } from '@cli/runtime/approvalAdapter';
+import { appendCliApiSwitchHint } from '@cli/runtime/approval/approvalPolicy';
 import { TOOL_OUTPUT_CORNER } from '@cli/tui/ui/glyphs';
 import { redactSecrets } from '@logger/redaction';
 import {

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -1,6 +1,6 @@
-// The headless CLI's `HostInteractions` implementation, plus the approval
-// surface the chat TUI and the tests import. Internal CLI callers may import
-// the focused modules under ./approval/ directly.
+// The headless CLI's `HostInteractions` implementation. Approval policy and
+// summary formatting live in the focused modules under ./approval/; import
+// those directly.
 
 import type {
   HostAgentProposalRequest,
@@ -43,24 +43,6 @@ import {
 } from './approval/approvalSummaries';
 import { summarizeApprovalEvent } from './approval/eventDispatch';
 import { parseUserQuestionAnswer } from './userQuestionAnswer';
-
-export {
-  appendCliApiSwitchHint,
-  approvalPromptAllowed,
-  askUserQuestionDenial,
-  hasCliApprovalDenied,
-  humanInputDenialFeedback,
-  immediateDecision,
-  immediateDecisionForApproval,
-  isCliApiSwitchableRetry,
-  isCliChatGptSubscriptionRetry,
-  markApprovalDenied,
-} from './approval/approvalPolicy';
-export {
-  formatAgentProposalApprovalSummary,
-  formatRetryRequestMessage,
-  formatToolEditApprovalSummary,
-} from './approval/approvalSummaries';
 
 interface HeadlessCliHostInteractionHooks extends CliApprovalPromptHooks {
   readonly emit?: HostInteractions['emit'];

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -37,6 +37,12 @@ const RUN_PROGRESS_RUN_FACT_TYPES = [
   'child.activity',
 ] as const satisfies readonly AgentEvent['type'][];
 
+/** The run-fact vocabulary this renderer's subscription filter admits. */
+type RunProgressRunFactEvent = Extract<
+  AgentEvent,
+  { type: (typeof RUN_PROGRESS_RUN_FACT_TYPES)[number] }
+>;
+
 // Carriage return + erase-line (CSI 2K): rewind to column 0 and clear the row
 // so the single live status line can be repainted in place.
 const CLEAR_LINE = '\r\x1b[2K';
@@ -52,6 +58,11 @@ interface RenderState {
 }
 
 export interface RunProgressRenderer {
+  /**
+   * Takes session facts and the run facts named by
+   * `RUN_PROGRESS_RUN_FACT_TYPES` only; any other run fact is out of contract
+   * and throws rather than being dropped.
+   */
   handleSessionEvent(event: SessionEvent): void;
   clear(): void;
   preserve(): void;
@@ -143,7 +154,9 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
       this.handleSessionFact(event.event);
       return;
     }
-    this.handleRunFact(event.streamId, event.event);
+    // Narrowed by `attachRunProgressRenderer`'s filter, which admits only
+    // `RUN_PROGRESS_RUN_FACT_TYPES`.
+    this.handleRunFact(event.streamId, event.event as RunProgressRunFactEvent);
   }
 
   clear(): void {
@@ -188,7 +201,10 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     assertNever(event, 'Unhandled run-progress renderer session fact');
   }
 
-  private handleRunFact(streamId: StreamTabId, event: AgentEvent): void {
+  private handleRunFact(
+    streamId: StreamTabId,
+    event: RunProgressRunFactEvent,
+  ): void {
     switch (event.type) {
       case 'run.config':
         if (this.applyRunConfig(event.streamId, event.config)) {
@@ -223,9 +239,8 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         this.updateHeartbeat();
         this.render(true);
         return;
-      default:
-        return;
     }
+    assertNever(event, 'Unhandled run-progress renderer run fact');
   }
 
   private applyRunConfig(streamId: StreamTabId, config: AgentConfig): boolean {

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -4,7 +4,7 @@ import { RUN_OUTCOME, type RunOutcome, STREAM_PHASE } from '@shared/schemas';
 import { runOutcomeToExecutionStatus } from '@shared/streams/streamStatus';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-import { hasCliApprovalDenied } from './approvalAdapter';
+import { hasCliApprovalDenied } from './approval/approvalPolicy';
 import { CliExitCode } from './exitCodes';
 import type { CliContext } from './cliContext';
 

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -298,7 +298,14 @@ export async function checkCliUpdateAvailable({
   });
 }
 
-let notified = false;
+/** Once-per-process latch for {@link notifyCliUpdate}. */
+let updateNotifyStarted = false;
+
+/** Clear the once-per-process {@link notifyCliUpdate} latch. Tests only:
+ *  a process never re-runs the check. */
+export function resetCliUpdateNotifyLatchForTests(): void {
+  updateNotifyStarted = false;
+}
 
 /**
  * Once per process: check the package source for a newer release (at most
@@ -311,8 +318,8 @@ let notified = false;
  * Disable entirely with `TEXRA_NO_UPDATE_CHECK=1`.
  */
 export async function notifyCliUpdate(context: CliContext): Promise<void> {
-  if (notified) return;
-  notified = true;
+  if (updateNotifyStarted) return;
+  updateNotifyStarted = true;
 
   const ambient = readCliAmbientState();
   if (isEnvFlagEnabled(UPDATE_CHECK_SKIP_ENV)) return;

--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -268,10 +268,9 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
 ]);
 
 export function getDesktopCommandMenuEntries(
-  ids: readonly DesktopCommandId[] = DESKTOP_COMMAND_IDS,
   platform: NodeJS.Platform = process.platform,
 ): DesktopCommandMenuEntry[] {
-  return ids.map((id) => {
+  return DESKTOP_COMMAND_IDS.map((id) => {
     if (isDesktopLocalCommandId(id)) {
       const localEntry = DESKTOP_LOCAL_COMMAND_ENTRIES.get(id);
       if (!localEntry) throw new Error(`Missing desktop command entry: ${id}`);
@@ -415,10 +414,7 @@ export function buildDesktopMenuTemplate(
   platform: NodeJS.Platform = process.platform,
 ): DesktopMenuTemplateItem[] {
   const entriesById = new Map(
-    getDesktopCommandMenuEntries(DESKTOP_COMMAND_IDS, platform).map((entry) => [
-      entry.id,
-      entry,
-    ]),
+    getDesktopCommandMenuEntries(platform).map((entry) => [entry.id, entry]),
   );
   const commandItem = (id: DesktopCommandId): DesktopMenuTemplateItem => {
     const entry = entriesById.get(id);

--- a/packages/desktop/src/main/desktopAgentLaunch.ts
+++ b/packages/desktop/src/main/desktopAgentLaunch.ts
@@ -1,11 +1,8 @@
-// Agent imports
 import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
 import type { AgentRunHandle } from '@agent/runtime/ExecutionHandle';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityKey';
 import { selectAutoOpenFinalOutput } from '@agent/runtime/selectAutoOpenFinalOutput';
-
-// Shared and tool imports
 import type { RequestOpenFilePayload } from '@shared/schemas';
 import { DIAGNOSTICS_READ_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
 import type { RegisteredToolName } from '@tools/registry';

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -1,4 +1,3 @@
-// Agent imports
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
@@ -6,13 +5,9 @@ import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { resolveAndResumeStream } from '@agent/runtime/resolveAndResumeStream';
 import { resumeQueuedToolUseFromResumeData } from '@agent/runtime/resumeQueuedToolUse';
 import { trackTerminalResultPresentation } from '@agent/runtime/terminalResultToast';
-
-// Shared imports
 import type { RecoveryContinuation } from '@platform/interfaces';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-
-// Local imports
 import {
   DESKTOP_UNAVAILABLE_TOOLS,
   launchDesktopAgent,

--- a/packages/desktop/src/main/desktopCredentialSettingsController.ts
+++ b/packages/desktop/src/main/desktopCredentialSettingsController.ts
@@ -1,4 +1,3 @@
-// Local imports
 import { codexCoordinator, loginWithLoopback } from '@auth/codex';
 import { relayTokenSignOutNotice } from '@auth/relayToken';
 import { codexAccountLabel } from '@auth/codex/codexSessionTypes';

--- a/packages/desktop/src/main/desktopLegacyStreamImporter.ts
+++ b/packages/desktop/src/main/desktopLegacyStreamImporter.ts
@@ -1,11 +1,6 @@
-// Node imports
 import { readFile, unlink } from 'node:fs/promises';
-
-// Third-party imports
 import writeFileAtomic from 'write-file-atomic';
 import { z } from 'zod';
-
-// Common imports
 import { isFileNotFoundError } from '@common/errors';
 
 const LEGACY_STREAMS_KEY = 'restoredStreams';

--- a/packages/desktop/src/main/desktopProcessStores.ts
+++ b/packages/desktop/src/main/desktopProcessStores.ts
@@ -1,13 +1,8 @@
-// Agent imports
 import { createChannelTrace } from '@agent/trace';
 import { SessionStores } from '@agent/storage';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-
-// Tool imports
 import { releaseStreamResources } from '@tools/approval';
 import { GoalStore } from '@tools/goal';
-
-// Local imports
 import { prepareDesktopLegacyStreamImport } from './desktopLegacyStreamImporter.js';
 import { toLogData } from './desktopLogUtils.js';
 

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -106,6 +106,7 @@ export interface DesktopAuthCoordinator {
 }
 
 export function createDesktopAuthCallbackState(
+  log: DesktopAuthLog,
   store?: Pick<StateStore, 'get' | 'update'>,
 ): DesktopAuthCallbackState {
   let pendingState = readPendingOAuthState(store);
@@ -120,9 +121,20 @@ export function createDesktopAuthCallbackState(
     );
   };
 
-  if (pendingState && isPendingOAuthStateExpired(pendingState)) {
+  // A dropped persist leaves the expired nonce on disk; in-memory state is
+  // already cleared, so the next launch re-expires it. Logged so the stale
+  // record has a trace rather than appearing out of nowhere.
+  const forgetExpiredPendingState = (): void => {
     pendingState = null;
-    void persistPendingState(null).catch(() => {});
+    void persistPendingState(null).catch((error: unknown) => {
+      log.debug(
+        `Desktop pending OAuth state cleanup failed: ${toErrorMessage(error)}`,
+      );
+    });
+  };
+
+  if (pendingState && isPendingOAuthStateExpired(pendingState)) {
+    forgetExpiredPendingState();
   }
 
   // True only while a non-expired sign-in attempt is pending; clears and
@@ -130,8 +142,7 @@ export function createDesktopAuthCallbackState(
   const hasValidPendingState = (): boolean => {
     if (!pendingState) return false;
     if (isPendingOAuthStateExpired(pendingState)) {
-      pendingState = null;
-      void persistPendingState(null).catch(() => {});
+      forgetExpiredPendingState();
       return false;
     }
     return true;
@@ -214,7 +225,11 @@ export function createDesktopSupabaseAuth(
           activeAttempt = undefined;
           void callbackState
             .clearAwaitingCallback(attempt.nonce)
-            .catch(() => {});
+            .catch((error: unknown) => {
+              log.debug(
+                `Desktop sign-in timeout cleanup failed: ${toErrorMessage(error)}`,
+              );
+            });
         }
       }, timeoutMs);
       let settled = false;

--- a/packages/desktop/src/main/desktopWindowTitle.ts
+++ b/packages/desktop/src/main/desktopWindowTitle.ts
@@ -1,10 +1,5 @@
-// Node imports
 import { basename } from 'node:path';
-
-// Third-party imports
 import { type BrowserWindow } from 'electron';
-
-// Local imports
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { STREAM_PHASE } from '@shared/schemas';
 import {

--- a/packages/desktop/src/main/desktopWorkspaceIpc.ts
+++ b/packages/desktop/src/main/desktopWorkspaceIpc.ts
@@ -7,10 +7,7 @@
 // disk: a path from the renderer is untrusted input, and `../` traversal would
 // otherwise read or overwrite anything the user can reach.
 
-// Node imports
 import { basename, dirname, join } from 'node:path';
-
-// Local imports - file listing
 import { isFileNotFoundError } from '@common/errors';
 import {
   loadFileListSettings,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -990,8 +990,10 @@ function createWindow(options: {
         hasPriorInstall,
         hasRunHistory,
       });
-    } catch {
-      // Swallow — backfill failure must not block window creation.
+    } catch (error) {
+      // Never block window creation, but a swallowed failure here leaves the
+      // flag unwritten, so an existing user is re-shown the welcome card.
+      reportAsyncError(error);
     } finally {
       // Open the gate (whether we backfilled or early-returned) so the
       // onboarding IPC's gated first refresh — driven by WEBVIEW_READY — derives
@@ -1315,6 +1317,7 @@ if (protocolLifecycle.shouldContinue) {
           log: console,
         });
         const authCallbackState = createDesktopAuthCallbackState(
+          console,
           platform().globalState,
         );
         installContentSecurityPolicy();

--- a/packages/desktop/src/main/platform/dataRootMigration.ts
+++ b/packages/desktop/src/main/platform/dataRootMigration.ts
@@ -1,8 +1,5 @@
-// Node imports
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-
-// Local imports - platform
 import {
   mergeLegacyWorkspaceStorageBucket,
   moveEntryIfAbsent,
@@ -11,8 +8,6 @@ import {
 import { resolveWorkspaceStoragePath } from '@platform/defaults/workspaceStorage';
 import type { LegacyDataMigrationLogger } from '@platform/defaults/legacyDataMigration';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-
-// Type imports - platform
 
 export type DesktopDataRootMigrationLogger = LegacyDataMigrationLogger;
 

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -1,11 +1,6 @@
-// Node imports
 import { access, constants } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-
-// Third-party imports
 import { app } from 'electron';
-
-// Local imports
 import { createPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
 import { isFileNotFoundError } from '@common/errors';
 import { installTexraModelAccess } from '@controllers/modelAccess/installTexraModelAccess';
@@ -29,8 +24,6 @@ import { GlobalStateKey } from '@shared/state/stateKeys';
 import { configKeyVariants } from '@shared/config/configKeys';
 import { seedDisabledToolDefaults } from '@tools/toolAvailability';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-
-// Local file imports
 import {
   migrateLegacyDesktopDataRoot,
   migrateLegacyDesktopWorkspaceBucket,

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -137,7 +137,7 @@ export function createDesktopCommandPalette({
       (getShortcuts?.() ?? []).map((entry) => [entry.id, entry]),
     );
     return [
-      ...getDesktopCommandMenuEntries(undefined, platform).map((entry) =>
+      ...getDesktopCommandMenuEntries(platform).map((entry) =>
         toPaletteEntry(entry, shortcutsById.get(entry.id), platform),
       ),
       ...streams.map(toStreamPaletteEntry),

--- a/packages/desktop/src/renderer/desktopShortcutRegistry.ts
+++ b/packages/desktop/src/renderer/desktopShortcutRegistry.ts
@@ -66,7 +66,7 @@ export function createDesktopShortcutRegistry(
   const listeners = new Set<
     (entries: readonly DesktopShortcutEntry[]) => void
   >();
-  const menuEntries = getDesktopCommandMenuEntries(undefined, platform);
+  const menuEntries = getDesktopCommandMenuEntries(platform);
 
   function entries(): DesktopShortcutEntry[] {
     return [desktopCommandPaletteShortcut(platform), ...menuEntries].map(

--- a/packages/desktop/src/renderer/logsPane.ts
+++ b/packages/desktop/src/renderer/logsPane.ts
@@ -1,16 +1,11 @@
-// Third-party imports
 import '@awesome.me/webawesome/dist/components/details/details.js';
 import { html, render, type TemplateResult } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
-
-// Shared imports
 import { postMessage } from '@shared/hostBridge';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { formatTimestamp, truncateSummary } from '@utils/text/stringUtils';
-
-// Local imports
 import { DESKTOP_LOCAL_COMMANDS } from '../desktopCommandSurface';
 import {
   DESKTOP_LOG_COMMANDS,

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -196,7 +196,7 @@ const hasWorkspace = window.texraDesktop?.hasWorkspace ?? true;
 const rendererPlatform = getRendererPlatform(document.defaultView);
 document.body.dataset.desktopPlatform = rendererPlatform;
 const shortcutAcceleratorsById = new Map<string, string | undefined>(
-  getDesktopCommandMenuEntries(undefined, rendererPlatform).map((entry) => [
+  getDesktopCommandMenuEntries(rendererPlatform).map((entry) => [
     entry.id,
     entry.accelerator,
   ]),

--- a/packages/desktop/src/renderer/promptOverlay.ts
+++ b/packages/desktop/src/renderer/promptOverlay.ts
@@ -1,18 +1,12 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
-
-// Local imports - prompt protocol
 import {
   DESKTOP_PROMPT_COMMANDS,
   type DesktopSettlePromptMessage,
   type DesktopShowPromptMessage,
 } from '../desktopPromptMessages';
-
-// Local imports - shared overlay chrome
 import { createOverlayDialog } from './overlayDialog';
-
-// Third-party imports - component types
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 export interface DesktopPromptOverlay {

--- a/packages/desktop/src/workspacePath.ts
+++ b/packages/desktop/src/workspacePath.ts
@@ -27,10 +27,6 @@ export function getWorkspacePathInput(
   return options.storedWorkspacePath?.trim() || undefined;
 }
 
-export function hasWorkspacePath(options: WorkspacePathOptions = {}): boolean {
-  return getWorkspacePathInput(options) != null;
-}
-
 export function serializeWorkspacePresenceArg(hasWorkspace: boolean): string {
   return `${WORKSPACE_PRESENT_ARG}${hasWorkspace ? '1' : '0'}`;
 }

--- a/packages/extension/src/commands/latex/figCommands.ts
+++ b/packages/extension/src/commands/latex/figCommands.ts
@@ -12,7 +12,7 @@ import * as logger from '@logger/logUtils';
 import { pathToLocation } from '@utils/files';
 import { pluralize, truncateWithEllipsis } from '@utils/text/stringUtils';
 
-const CHANNEL = 'TestCommands';
+const CHANNEL = 'FigCommands';
 
 export async function handleExtractTikzFigures(): Promise<void> {
   await runGuardedLatexCommand(

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -124,8 +124,13 @@ async function refreshApiKeyStatus() {
   // funnel. This keeps ChatGPT subscription, Researcher Access, and direct API
   // keys in agreement about whether the first-run CTA should remain visible.
   const exists = await hasAnyUsableSetupCredential();
-  // A pre-retirement `ui.showApiKeyReminders` of false is a deliberate
-  // opt-out; keep honoring it rather than making the CTA unsuppressible.
+  // `ui.showApiKeyReminders` is no longer declared in
+  // `contributes.configuration` and nothing writes it, so this is a read-only
+  // compat arm: a settings.json that predates the key's removal can still
+  // carry `false`, which is a deliberate opt-out worth honoring rather than
+  // making the CTA unsuppressible.
+  // Retire on 2026-11-01: drop this read and let the credential predicate
+  // alone decide whether the CTA shows.
   const remindersOptOut =
     getConfig<boolean>('ui.showApiKeyReminders', true) === false;
   if (!exists && !remindersOptOut) {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -258,7 +258,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.DEBUG_MODE_SET]: forwardToActiveView,
       [COMMON_COMMANDS.SWITCH_VIEW]: (data) => this.switchView(data),
       [PROGRESS_VIEW_COMMANDS.POP_OUT]: () => this.provider.popOutToEditor(),
-      [PROGRESS_VIEW_COMMANDS.POP_BACK]: () => this.provider.popBackToSidebar(),
+      [PROGRESS_VIEW_COMMANDS.POP_BACK]: () => this.provider.showInSidebar(),
 
       // First-tier shared progress command groups
       ...this.progressHost.commandHandlers,

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -498,10 +498,6 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     this._mainViewProvider?.switchMode(SIDEBAR_VIEWS.MAIN);
   }
 
-  public async popBackToSidebar(): Promise<void> {
-    await this.showInSidebar();
-  }
-
   public override dispose(): void {
     this.releaseEditorTarget({ disposePanel: true });
     this.backend.dispose();

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -106,8 +106,11 @@ export class FollowUpInput extends LitElement {
             color-mix(in srgb, var(--wa-color-surface-shadow) 16%, transparent);
       }
 
-      /* Height comes off the shared textarea scale; the composer sits inside
-         its own bordered card, so it drops the field's own box. */
+      /* Web Awesome's resize="auto" copies the textarea scroll height into an
+         invisible grid item. Inside a constrained composer that grid item can
+         preserve an oversized row for an empty draft. Size the native
+         textarea part from its content instead: two lines initially, growing
+         to the bounded reading height before it scrolls. */
       #followUpInput {
         display: block;
         min-width: 0;
@@ -115,11 +118,16 @@ export class FollowUpInput extends LitElement {
         box-sizing: border-box;
         line-height: var(--line-height-relaxed);
         height: auto;
-        --textarea-min-height: var(--textarea-h-m);
+        --textarea-min-height: calc(
+          2lh + var(--wa-space-xs) + var(--wa-space-3xs)
+        );
         --textarea-max-height: min(32vh, 240px);
       }
 
       #followUpInput::part(base) {
+        align-items: start;
+        max-height: var(--textarea-max-height);
+        overflow: hidden;
         border: 0;
         background: transparent;
         box-shadow: none;
@@ -128,8 +136,12 @@ export class FollowUpInput extends LitElement {
       /* The one place a textarea renders sans rather than mono: this is prose a
          user writes to an agent, not code. */
       #followUpInput::part(textarea) {
+        field-sizing: content;
         width: 100%;
-        padding: var(--wa-space-s) var(--wa-space-s) var(--wa-space-xs);
+        height: auto;
+        min-height: var(--textarea-min-height);
+        max-height: var(--textarea-max-height);
+        padding: var(--wa-space-xs) var(--wa-space-s) var(--wa-space-3xs);
         box-sizing: border-box;
         overflow-x: hidden;
         overflow-y: auto;

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -264,6 +264,11 @@ export class TaskGroupList extends LitElement {
     const nextStatuses = new Map<string, string>();
     for (const group of this.groups) {
       const prev = this.previousStatuses.get(group.id);
+      // Every live producer sets `kind`, so only replayed rows written before
+      // it landed (2026-07-11) reach the name-parse arm, which reproduces the
+      // round-directory inference the old code used.
+      // Retire on 2026-11-01 with the other roster/task-group compat reads:
+      // `group.kind === 'round'` then stands alone.
       const isRunGroup =
         !this.isToolUse &&
         (group.kind === 'round' ||

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -11,12 +11,12 @@ export const logEntryStyles = css`
   .log-container {
     flex: 1 1 auto;
     width: 100%;
-    padding: var(--wa-space-m)
+    padding: var(--wa-space-xs)
       max(
         var(--wa-space-m),
         calc((100% - var(--conversation-reading-width, 800px)) / 2)
       )
-      var(--wa-space-2xl);
+      var(--wa-space-s);
     box-sizing: border-box;
     min-width: 0;
     min-height: 0;
@@ -455,7 +455,7 @@ export const logEntryStyles = css`
       var(--wa-color-surface-default, transparent)
     );
     color: var(--wa-color-terminal-foreground, var(--wa-color-text-normal));
-    padding-block: var(--wa-space-m);
+    padding-block: var(--wa-space-xs);
   }
 
   :host([terminal]) .log-line {

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -146,9 +146,6 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         );
       },
 
-      // The webview applies the model selection itself and the host keeps no
-      // model state; MODEL_SELECTED has no outbound counterpart to echo to.
-      [MAIN_VIEW_COMMANDS.MODEL_SELECTED]: () => {},
       [MAIN_VIEW_COMMANDS.SETTINGS_OPEN]: () =>
         safeExecuteCommand(
           'workbench.action.openSettings',
@@ -195,12 +192,6 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.fileManager.handleEditedFileSelection(),
       [MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES]: (m) =>
         this.fileManager.handleSelectMultipleFiles(m),
-
-      [MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED]: (m) =>
-        this.fileManager.handleEditedFileSelected({
-          command: m.command,
-          filePath: m.filePath ?? '',
-        }),
 
       [MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE]: (m) =>
         this.fileManager.handleRequestEditedFile(m),

--- a/packages/extension/src/webview/frontend/mainViewActions.ts
+++ b/packages/extension/src/webview/frontend/mainViewActions.ts
@@ -361,7 +361,6 @@ export function changeAgent(sessionType: SessionType, value: string): void {
 
 export function changeModel(value: string): void {
   model$.set(value);
-  postMessage(MAIN_VIEW_COMMANDS.MODEL_SELECTED, { model: value });
 }
 
 export function changeWorkingDirectory(value: string): void {

--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -20,7 +20,6 @@ import {
   FILE_SELECTION_COMMAND_IDS,
   MULTIPLE_FILE_COMMANDS,
 } from '@frontend/files/fileSelectionRegistry';
-import { selectFiles } from '@frontend/ui/dialogs';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { parseVersionControlDiffFilename } from '@latex/latexdiff/diffFileNameManager';
 import * as logger from '@logger/logUtils';
@@ -42,10 +41,6 @@ import { BaseWebviewManager } from './BaseWebviewManager';
 type MessageFor<C extends MainViewInboundMessage['command']> = Extract<
   MainViewInboundMessage,
   { command: C }
->;
-
-type EditedFileSelectedMessage = MessageFor<
-  typeof MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED
 >;
 
 type RequestEditedFileMessage = MessageFor<
@@ -112,10 +107,6 @@ export class FileManager extends BaseWebviewManager {
     }
   }
 
-  handleEditedFileSelected(message: EditedFileSelectedMessage): void {
-    logger.debug(CHANNEL, `${message.command}: ${message.filePath}`);
-  }
-
   async handleRequestEditedFile(
     message: RequestEditedFileMessage,
   ): Promise<void> {
@@ -150,13 +141,10 @@ export class FileManager extends BaseWebviewManager {
       return;
     }
     try {
-      const selectedFiles =
-        fileType === 'output'
-          ? await this.selectOutputFiles(currentFile)
-          : await vscode.commands.executeCommand<string[]>(
-              commands.selectCommand,
-              currentFile,
-            );
+      const selectedFiles = await vscode.commands.executeCommand<string[]>(
+        commands.selectCommand,
+        currentFile,
+      );
 
       if (selectedFiles) {
         this.postMessage({
@@ -347,37 +335,6 @@ export class FileManager extends BaseWebviewManager {
     this.postMessage({ command: setCommand, files: message.files ?? [] });
   }
 
-  private async selectOutputFiles(
-    currentInputFile?: string,
-  ): Promise<string[] | null> {
-    try {
-      const relativePaths = await selectFiles({
-        allowMany: true,
-        openLabel: 'Select Output Files',
-        filters: { 'Text files': ['tex', 'txt', 'md'] },
-        currentFile: currentInputFile,
-      });
-
-      if (relativePaths) {
-        logger.info(
-          CHANNEL,
-          `Selected output files: ${relativePaths.join(', ')}`,
-        );
-        vscode.window.showInformationMessage(
-          `Selected output files: ${relativePaths.join(', ')}`,
-        );
-      }
-      return relativePaths;
-    } catch (err) {
-      await showLoggedErrorMessage(
-        CHANNEL,
-        'Error selecting output files',
-        err,
-      );
-      return null;
-    }
-  }
-
   private postEditedFiles(files: string[], notifyWhenEmpty: boolean): void {
     if (notifyWhenEmpty && files.length === 0) {
       logger.debug(CHANNEL, 'No edited files were found during refresh.');
@@ -400,9 +357,13 @@ export class FileManager extends BaseWebviewManager {
   }
 
   /** Post show/hide getting started banner. The banner's own close button
-   * dismisses it for the session; a pre-move `ui.showGettingStartedBanner`
-   * of false still counts as a permanent opt-out (nothing writes the legacy
-   * key back), matching the login/orchestrator banners. */
+   * dismisses it for the session; a `ui.showGettingStartedBanner` of false
+   * still counts as a permanent opt-out, matching the login/orchestrator
+   * banners. The key is no longer declared in `contributes.configuration` and
+   * nothing writes it back, so this is a read-only compat arm for a
+   * settings.json that predates its removal.
+   * Retire on 2026-11-01: drop this read and let the close button be the only
+   * dismissal. */
   private postGettingStartedBanner(show: boolean): void {
     const legacyOptOut =
       getConfig<boolean>('ui.showGettingStartedBanner', true) === false;

--- a/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
@@ -63,7 +63,6 @@ export class MediaExtractionNode<C = unknown> extends Node<
         prepRes.files,
         prepRes.workspaceState,
         config.toolConfig,
-        true,
         prepRes.extraMediaFiles,
       );
     } else {
@@ -75,7 +74,6 @@ export class MediaExtractionNode<C = unknown> extends Node<
         prepRes.files,
         prepRes.workspaceState,
         config.toolConfig,
-        true,
       );
     }
 

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -231,7 +231,6 @@ export class OutputNode<C = unknown> extends Node<
       compileFailures: [],
       xmlSummary: {
         tagContents: {},
-        documents: [],
         singleOutputFile: null,
         sourceLocation: null,
       },

--- a/src/agent/implementations/flows/tooluse/modelSwitchState.ts
+++ b/src/agent/implementations/flows/tooluse/modelSwitchState.ts
@@ -16,8 +16,10 @@ export function currentModelFromUserChannels(
 
 /**
  * Record a model switch in persisted shared state: `modelId` is the resume
- * SSOT, and the `MODEL` user variable is re-projected from it so prompts keep
- * seeing the model the run is actually on.
+ * SSOT. The `MODEL` user variable is re-projected alongside it so the
+ * pre-`modelId` reader in {@link currentModelFromUserChannels} agrees with it
+ * on records this run rewrites; prompts read the live model off the run's
+ * `ModelCell`, not from here.
  */
 export function setToolUseSharedModel(
   shared: ToolUseRunShared,

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -38,6 +38,13 @@ export class ToolUsePrepareNode<C> extends Node<
       hasDelegationTools,
       isSubagent: this.services.isSubagent,
     };
+    // `MODEL` comes from the run's ModelCell rather than the launch snapshot
+    // baked into the channel, so a resume that rebuilds this prompt states the
+    // model the run is actually on.
+    const promptVars = {
+      ...userVarChannels.transient,
+      MODEL: this.services.modelCell.modelId,
+    };
 
     if (resumeShared) {
       logger.debug('Resuming tool-use session from saved state.');
@@ -57,7 +64,7 @@ export class ToolUsePrepareNode<C> extends Node<
       // it here is orthogonal to the caching concern above.
       const rebuiltPrompts = await buildInitialToolUsePrompts(
         this.services.prompt,
-        userVarChannels.transient,
+        promptVars,
         logger,
         promptOptions,
       );
@@ -90,7 +97,7 @@ export class ToolUsePrepareNode<C> extends Node<
     const { systemPrompt, userPrefix, userRequest, instructionSuffix } =
       await buildInitialToolUsePrompts(
         this.services.prompt,
-        userVarChannels.transient,
+        promptVars,
         logger,
         promptOptions,
       );

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -48,10 +48,9 @@ export class ToolUseWaitNode<C> extends Node<
   }
 
   async exec(prepRes: WaitPrepResult): Promise<WaitExecResult> {
-    const { session, isSubagent } = this.services;
-    const { runScope, stopAfterCycle } = useLaunchRunContext();
-    const { streamId, session: ownerSession } = runScope;
-    const { signal } = this.services.runScope;
+    const { session, isSubagent, runScope } = this.services;
+    const { streamId, session: ownerSession, signal } = runScope;
+    const { stopAfterCycle } = useLaunchRunContext();
     const hasDrainedFollowUps = Boolean(this.drainedFollowUps?.length);
 
     if (signal.aborted) {

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -43,8 +43,8 @@ const ToolUseRunSharedSchema = z.looseObject({
   messages: ProviderMessageArraySchema,
   /**
    * The model the run is on, mirroring the live `ModelCell`. This is the
-   * resume SSOT for model identity; the `MODEL` user variable is a prompt-side
-   * projection of it.
+   * resume SSOT for model identity; the `MODEL` user variable is the legacy
+   * record of it, read only when this field is absent.
    */
   modelId: z.string().optional(),
   modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullable()

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -90,12 +90,13 @@ export interface RunToolUseFlowInput<
   /** Root-run-only: fires with the latest response at every cycle boundary — see `ToolUseServices.onIdle`. */
   onIdle?: (lastResponse: string | undefined) => void;
   /**
-   * Fires after a running tool-use chat changes its model. The launch context
-   * owns every mirror of the live model (`AgentConfig.model`, the `MODEL` user
-   * variable, usage accounting), so this is required: without it those
-   * mirrors would silently keep reporting the model the run started with.
+   * Fires after a running tool-use chat changes its model, once the shared
+   * `ModelCell` already holds the new pair. The handler is deliberately not
+   * passed: readers take it from the cell. Required because the launch
+   * context still owns the persisted `AgentConfig.model` field, which would
+   * otherwise keep naming the model the run started with.
    */
-  onModelChanged: (modelHandler: RunModelHandler<C>, model: string) => void;
+  onModelChanged: (model: string) => void;
   /** Runtime feature registry for auto-injected tools. */
   toolInjections?: ToolInjectionRegistry;
   /** Caller-supplied tools available only to this run. */
@@ -336,7 +337,7 @@ export async function runToolUseFlow<C = unknown>(
     nextHandler.setLogger(logger);
 
     services.modelCell.swap(nextHandler, model);
-    input.onModelChanged(nextHandler, model);
+    input.onModelChanged(model);
     logger.emit({
       type: 'run.config',
       streamId,

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -20,7 +20,6 @@ import { LEGACY_AGENT_ALIASES } from './agentRegistryConstants';
 import type { AgentEntry } from './agentEntry';
 
 const CHANNEL = 'agentRegistry';
-const INVALID_WORKFLOW_ROUNDS = Number.NaN;
 
 interface ParsedAgentYaml {
   readonly name: string;
@@ -220,13 +219,18 @@ function scanYaml(
       settingsBlock.complete &&
       promptsBlock.complete
     ) {
-      const parsedRounds = AgentWorkflowSettingSchema.shape.rounds
-        .catch(INVALID_WORKFLOW_ROUNDS)
-        .parse(rawSettings.rounds);
-      if (!Number.isNaN(parsedRounds)) {
+      const parsedRounds = AgentWorkflowSettingSchema.shape.rounds.safeParse(
+        rawSettings.rounds,
+      );
+      if (parsedRounds.success) {
         rounds = Math.max(
-          parsedRounds,
+          parsedRounds.data,
           userRequestTemplateCount(rawPrompts.userRequest),
+        );
+      } else {
+        logger.warn(
+          CHANNEL,
+          `Ignoring malformed rounds in ${entry.path}: ${toErrorMessage(parsedRounds.error)}`,
         );
       }
     }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -709,19 +709,12 @@ export abstract class ModelHandler<
     return this.getBaseUrl() ?? `${this.config.provider}:default`;
   }
 
-  // Provider-identity getters (isAnthropic/isOpenai/isGoogle/isDeepSeek/
-  // isKimi/isMiniMax) were removed (#7101): each had exactly one or two call
-  // sites, all of which already had `this.config` (or, for the
-  // `ModelHandlerOpenRouterNative` combinators below, `this.config.provider`)
-  // in scope. `config.provider` — already part of the `IModelHandler` port —
-  // *is* the canonical profile read; a same-shaped getter wrapping it added
-  // no capability-profile value, just base-class surface. Callers now compare
-  // `config.provider` against `ModelProvider` directly. The remaining base
-  // predicates below fall into the other two buckets from the #7101 triage:
-  // runtime combinators over profile data (`shouldUseServerSideKeys`,
-  // `getEffectiveReasoningEffort`) and genuinely per-provider behavior that
-  // stays an overridable method/getter (`supportsManualCompaction`,
-  // `isBackgroundModeActive`, etc.).
+  // Provider-identity getters (isAnthropic/isOpenai/isGoogle/…) were removed
+  // (#7101): `config.provider` is already part of the `IModelHandler` port, so
+  // callers compare it against `ModelProvider` directly. The #7101 triage of
+  // every remaining predicate is complete: each carries its own note on why it
+  // stays (runtime combinator, or genuinely per-provider behavior), so there is
+  // nothing left to fold here.
 
   /**
    * Whether parallel tool calls in a single turn must be batched into one

--- a/src/agent/modelHandlers/anthropic/anthropicDocumentHandling.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicDocumentHandling.ts
@@ -3,10 +3,12 @@ import { basename } from 'node:path';
 
 // Third-party imports
 import { Buffer } from 'node:buffer';
-import { PDFDocument } from '@cantoo/pdf-lib';
 import { toFile } from '@anthropic-ai/sdk';
 
 // Local imports
+import * as logger from '@logger/logUtils';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+import { countPdfPagesInBuffer } from '@utils/media/pdfPageCount';
 import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
 
 import { FILES_API_BETA } from './anthropicContextManagement';
@@ -20,6 +22,8 @@ import type {
   MessageParam,
 } from '@anthropic-ai/sdk/resources/messages';
 import type { BetaRequestDocumentBlock } from '@anthropic-ai/sdk/resources/beta/messages';
+
+const CHANNEL = 'AnthropicDocuments';
 
 /**
  * Extracts all document blocks from a content block array, including those
@@ -101,22 +105,6 @@ export function analyzeDocumentSources(
 }
 
 /**
- * Count pages in a PDF buffer without writing to disk.
- * Returns 0 on parse failure so the API can enforce the limit as fallback.
- */
-export async function countPdfPagesFromBuffer(buffer: Buffer): Promise<number> {
-  try {
-    const pdfDoc = await PDFDocument.load(buffer, {
-      updateMetadata: false,
-      ignoreEncryption: true,
-    });
-    return pdfDoc.getPageCount();
-  } catch {
-    return 0;
-  }
-}
-
-/**
  * Sanitizes a filename for Anthropic's Files API.
  */
 export function sanitizeAnthropicFilename(filename: string): string {
@@ -180,7 +168,18 @@ export async function replaceDocumentDataWithUploads(
     try {
       buffer = Buffer.from(base64Data, 'base64');
 
-      const pageCount = await countPdfPagesFromBuffer(buffer);
+      // An unreadable PDF still uploads; Anthropic enforces its own page
+      // limit server-side, so a missing local count only costs the token
+      // estimate. Logged so the degraded estimate is attributable.
+      let pageCount = 0;
+      try {
+        pageCount = await countPdfPagesInBuffer(buffer);
+      } catch (err) {
+        logger.warn(
+          CHANNEL,
+          `Unable to count pages in ${sanitizedFilename}; uploading without a page count: ${toErrorMessage(err)}`,
+        );
+      }
 
       const uploadedFile = await client.beta.files.upload({
         file: await toFile(buffer, sanitizedFilename, {

--- a/src/agent/modelHandlers/anthropic/anthropicTools.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicTools.ts
@@ -7,14 +7,13 @@ import { toFile } from '@anthropic-ai/sdk';
 // Local imports
 import type { AgentTrace } from '@agent/trace';
 import type { ToolFileAttachment } from '@shared/schemas/toolResult';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+import { countPdfPagesInBuffer } from '@utils/media/pdfPageCount';
 import { extractMimeSubtype } from '@utils/text/stringUtils';
 
 // Local file imports
 import { FILES_API_BETA } from './anthropicContextManagement';
-import {
-  countPdfPagesFromBuffer,
-  sanitizeAnthropicFilename,
-} from './anthropicDocumentHandling';
+import { sanitizeAnthropicFilename } from './anthropicDocumentHandling';
 import { loadAttachmentBuffer, wipeBuffer } from '../utils/toolAttachmentUtils';
 import { reportMediaAttachmentFailure } from '../support/mediaAttachmentPolicy';
 
@@ -97,7 +96,16 @@ export async function uploadToolAttachments(
     // Check PDF page limit before uploading
     let pdfPageCount = 0;
     if (isPdf) {
-      pdfPageCount = await countPdfPagesFromBuffer(buffer);
+      try {
+        pdfPageCount = await countPdfPagesInBuffer(buffer);
+      } catch (err) {
+        // An unreadable PDF still uploads and Anthropic enforces the limit
+        // server-side, so the local budget check is skipped rather than the
+        // attachment dropped. Logged because the budget then undercounts.
+        logger.warn(
+          `Unable to count pages in ${attachment.path ?? 'attachment'}; uploading without a local page-limit check: ${toErrorMessage(err)}`,
+        );
+      }
       if (trackedPages + pdfPageCount > maxPdfPages) {
         pageLimitExceeded.push(attachment);
         buffer = wipeBuffer(buffer);

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -54,6 +54,7 @@ import type {
 } from '@shared/schemas/toolResult';
 import { joinNonEmpty } from '@utils/text/stringUtils';
 import { getAnthropicDynamicFiltering } from '@utils/config/providerConfig';
+import { countPdfPagesInBuffer } from '@utils/media/pdfPageCount';
 
 // Local file imports
 import {
@@ -90,7 +91,6 @@ import {
   enforceCacheControlLimit,
 } from './anthropicContextManagement';
 import {
-  countPdfPagesFromBuffer,
   extractDocumentBlocks,
   analyzeDocumentSources,
   replaceDocumentDataWithUploads,
@@ -307,7 +307,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
             const buffer = Buffer.from(await response.arrayBuffer());
             try {
               signal?.throwIfAborted();
-              const pageCount = await countPdfPagesFromBuffer(buffer);
+              // A parse failure falls to the catch below, which applies the
+              // metadata fallback the comment there describes.
+              const pageCount = await countPdfPagesInBuffer(buffer);
               if (pageCount > 0) {
                 this.uploadedPdfPageCounts.set(fileId, pageCount);
                 sizeEstimate =
@@ -1526,7 +1528,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   }
 
   async createToolUseFollowUpMessages(
-    client: Anthropic | undefined,
+    client: Anthropic,
     call: AnthropicToolCall,
     result: ToolResult,
     attachments: ToolFileAttachment[],
@@ -1567,9 +1569,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
       result: ToolResult;
       attachments: ToolFileAttachment[];
     }>,
-    workspaceState?: AgentWorkspaceState,
-    text?: string,
-    client?: Anthropic,
+    workspaceState: AgentWorkspaceState | undefined,
+    text: string | undefined,
+    client: Anthropic,
   ): Promise<MessageParam[]> {
     if (entries.length === 0) return [];
 
@@ -1583,22 +1585,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
       });
     }
 
-    const uploadClient =
-      this.supportsToolResultFileUpload &&
-      entries.some((entry) => entry.attachments.length > 0)
-        ? (client ?? (await this.getClient()))
-        : undefined;
-
     // Sequential on purpose: uploads share the PDF-page tracking state.
     const resultBlocks: ContentBlockParam[] = [];
     for (const { call, result, attachments } of entries) {
       resultBlocks.push(
-        await this.buildToolResultBlock(
-          uploadClient,
-          call,
-          result,
-          attachments,
-        ),
+        await this.buildToolResultBlock(client, call, result, attachments),
       );
     }
 
@@ -1612,7 +1603,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
    * Build one tool_result block, uploading attachments when supported.
    */
   private async buildToolResultBlock(
-    client: Anthropic | undefined,
+    client: Anthropic,
     call: AnthropicToolCall,
     result: ToolResult,
     attachments: ToolFileAttachment[],
@@ -1626,7 +1617,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const unsupportedAttachments: ToolFileAttachment[] = [];
     const pageLimitExceeded: ToolFileAttachment[] = [];
 
-    if (canUploadFiles && attachments.length > 0 && client) {
+    if (canUploadFiles && attachments.length > 0) {
       // This upload occurs while assembling the next turn, outside the model
       // invocation gate. Restore the SDK's ordinary two retries for this
       // auxiliary request; generation requests keep maxRetries: 0.

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -112,11 +112,11 @@ export function shouldUseOpenRouter(config: ModelRoutingConfig): boolean {
  *
  * Centralized here (#7101 triage — "runtime combinator over profile data")
  * so callers that only have a plain `ModelConfig`-shaped value, not a full
- * `ModelHandler` instance — e.g. `UsageMonitor`, which deliberately avoids
- * holding an `IModelHandler` reference (see `UsageMonitorModelInfo`'s doc
- * comment) — read the same combinator `ModelHandler.shouldUseServerSideKeys()`
- * delegates to, instead of re-deriving the `!openRouter && relaySync` formula
- * independently and risking drift.
+ * `ModelHandler` instance — e.g. `UsageMonitor`, which reads the run's live
+ * handler through its `IModelHandler` surface — read the same combinator
+ * `ModelHandler.shouldUseServerSideKeys()` delegates to, instead of
+ * re-deriving the `!openRouter && relaySync` formula independently and
+ * risking drift.
  */
 export function usesServerSideKeysRoute(
   config: ModelRoutingConfig & {

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -181,15 +181,10 @@ export class OutputFileProcessor {
     const singleFile =
       processed.length === 1 ? processed[0].location.absolutePath : null;
 
-    // `documents` stays empty: the extracted text lives once in
-    // `tagContents[OUTPUT_DOCUMENTS_TAG]`, and nothing downstream reads a
-    // second, tag-wrapped copy. Round summaries are cloned per node step (see
-    // persistedFlow.ts), so a duplicate full text would cost per round per run.
     const buildSummary = (
       tagContents: Record<string, string[]> = {},
     ): OutputXmlSummary => ({
       tagContents,
-      documents: [],
       singleOutputFile: singleFile,
       sourceLocation: rawOutput,
     });

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -425,7 +425,7 @@ async function assembleAgentLaunchContext(
   );
 
   const usageMonitor = new UsageMonitor(
-    { capabilities: modelHandler.capabilities, config: modelHandler.config },
+    modelCell,
     { logger: agentLogger, storageKey, streamId },
     {
       agentName: config.agent,

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -348,11 +348,16 @@ export type AgentRunHandle = Pick<
   | 'interrupt'
 >;
 
-/** True when the handle is a child of parentStreamId (not the parent itself). */
+/**
+ * True when the handle is a child of parentStreamId (not the parent itself).
+ * Only an `AgentExecutionHandle` can be one, so callers that need the child's
+ * agent-run members narrow through this predicate rather than re-testing
+ * `instanceof` alongside it.
+ */
 export function isChildExecution(
   handle: ExecutionHandle,
   parentStreamId: StreamTabId,
-): boolean {
+): handle is AgentExecutionHandle {
   if (handle.parentStreamId !== parentStreamId) return false;
   return handle instanceof AgentExecutionHandle && handle.isChildExecution;
 }

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -170,21 +170,6 @@ function withReasoningOverride<T extends ModelHandler>(handler: T): T {
 }
 
 /**
- * Whether a model is pinned to the Interactions API. `requiresInteractionsAPI`
- * is a future per-model opt-in (parallel to `requiresResponsesAPI`); it is not
- * yet on the external llm-zoo ModelConfig, so read it defensively. v0 registers
- * no model with it set.
- */
-function modelRequiresInteractionsAPI(config: ModelConfig): boolean {
-  return (
-    config.provider === ModelProvider.GOOGLE &&
-    !config.openRouterOnly &&
-    (config as { requiresInteractionsAPI?: boolean })
-      .requiresInteractionsAPI === true
-  );
-}
-
-/**
  * Check if the Google Interactions API should be used for this config.
  *
  * Routes to the default, actively-developed Interactions handler unless
@@ -192,9 +177,7 @@ function modelRequiresInteractionsAPI(config: ModelConfig): boolean {
  * `generateContent` GenAI handler is the feature-frozen fallback (#7097).
  * OpenRouter can NOT proxy Interactions, so an active OpenRouter proxy always
  * returns false — the GenAI handler (or OpenRouter) remains the fallback in
- * that case too. This is a PURE predicate (never throws): the unsupported
- * Interactions-only + OpenRouter combination is failed loudly at handler
- * creation (`assertGoogleInteractionsRoutable`), not here, so key-derivation
+ * that case too. This is a PURE predicate (never throws), so key-derivation
  * callers (history restore, `modelSwitchDisabledReason`) stay exception-free —
  * matching `requiresOpenAIResponsesAPI`'s contract.
  */
@@ -206,26 +189,7 @@ export function shouldUseGoogleInteractionsAPI(
     return false;
   }
   if (useOpenRouter) return false;
-  if (modelRequiresInteractionsAPI(config)) return true;
   return getConfig<boolean>('texra.model.useGoogleInteractionsAPI', true);
-}
-
-/**
- * Fail loudly when an Interactions-only model is selected while OpenRouter is
- * active — OpenRouter cannot proxy Interactions, so silently routing it through
- * the OpenRouter handler would be wrong (spec §6.3). Called from
- * `createModelHandler` only (the live-routing path that actually instantiates a
- * handler), keeping the routing predicate pure.
- */
-function assertGoogleInteractionsRoutable(
-  config: ModelConfig,
-  useOpenRouter: boolean,
-): void {
-  if (modelRequiresInteractionsAPI(config) && useOpenRouter) {
-    throw new Error(
-      `Model ${config.name} requires the Google Interactions API, which cannot be used through OpenRouter. Disable OpenRouter or select a different model.`,
-    );
-  }
 }
 
 /** Check if OpenAI Responses API should be used for this config. */
@@ -637,9 +601,6 @@ async function createModelHandlerForResolvedCompatibilityKey(
     }
 
     case 'ModelHandlerOpenRouterNative': {
-      // An Interactions-only model cannot be served through OpenRouter — fail
-      // loudly rather than silently routing it to the OpenRouter handler.
-      assertGoogleInteractionsRoutable(config, useOpenRouter);
       const openrouterFullName =
         config.openrouterFullName ?? `${config.provider}/${config.fullName}`;
       const { ModelHandlerOpenRouterNative } =
@@ -655,7 +616,6 @@ async function createModelHandlerForResolvedCompatibilityKey(
 
     default: {
       // Direct provider handler. The key is the provider's registered route key.
-      assertGoogleInteractionsRoutable(config, useOpenRouter);
       const route = providerHandlerRoute(config.provider);
       if (!route) {
         throw new Error(`Unsupported model provider: ${config.provider}`);

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -1,5 +1,5 @@
 import type { AgentTrace, StatusEvent } from '@agent/trace';
-import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import {
   STREAM_PHASE,
   STREAM_SUBSTATE,
@@ -57,27 +57,17 @@ function effectiveState(entry: StreamEntry): StreamPhaseState {
 
 export class StreamStatusMachine {
   private readonly streams = new Map<StreamTabId, StreamEntry>();
-  private eventHub: SessionEventHub;
 
   /**
-   * @param events Session hub this machine publishes canonical `status` facts
+   * @param eventHub Session hub this machine publishes canonical `status` facts
    *   on. The session constructs both and hands the hub over once, so a
    *   transition reaches every consumer on the session-fact rail no matter
-   *   which caller triggered it. Callers pass a trace only for the transcript
+   *   which caller triggered it. It is required and never rebound: a machine
+   *   publishing where nobody listens is a status plane that silently loses
+   *   every transition. Callers pass a trace only for the transcript
    *   compatibility bridge.
    */
-  constructor(events: SessionEventHub = new SessionEventHub()) {
-    this.eventHub = events;
-  }
-
-  /** Bind status publication to the owning session's fact rail. */
-  attachSessionEvents(events: SessionEventHub): void {
-    this.eventHub = events;
-  }
-
-  get sessionEvents(): SessionEventHub {
-    return this.eventHub;
-  }
+  constructor(private readonly eventHub: SessionEventHub) {}
 
   get(stream: StreamTabId): StreamPhase | undefined {
     return this.stateFor(stream)?.phase;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -184,16 +184,12 @@ async function launchToolUseRun(
       ),
       onFlowRecordDisposition: (disposition) =>
         lifecycle.setFlowRecordDisposition(disposition),
-      onModelChanged: (modelHandler, model) => {
-        // The flow swapped its ModelCell, which is the live model. Every
-        // launch-context view of it is mirrored here, in one place, so none of
-        // them keeps reporting the model the run started with.
+      onModelChanged: (model) => {
+        // The cell is the live model; usage accounting and the prompt-side
+        // MODEL variable read it directly. This one mirror remains because
+        // config.model is a persisted AgentConfig schema field, not a view
+        // of the cell.
         ctx.config.model = model;
-        ctx.userVarChannels.transient.MODEL = model;
-        ctx.usageMonitor.setModelInfo({
-          capabilities: modelHandler.capabilities,
-          config: modelHandler.config,
-        });
       },
       ...(variant.kind === 'fresh'
         ? { onIdle: variant.onIdle }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -101,6 +101,21 @@ export type ManualCompactionRequestResult =
     };
 
 /**
+ * A caller bringing its own status machine must bring the hub that machine
+ * publishes on: the registry subscribes to status facts there, and a second hub
+ * would leave that subscription listening where nothing is ever published.
+ */
+type ExecutionRegistryInit =
+  | {
+      readonly streamStatus: StreamStatusMachine;
+      readonly events: SessionEventHub;
+    }
+  | {
+      readonly streamStatus?: undefined;
+      readonly events?: SessionEventHub;
+    };
+
+/**
  * Session-owned registry of active executions and their change listeners.
  *
  * One instance belongs to each {@link SessionHandle}, which binds it to that
@@ -148,24 +163,10 @@ export class ExecutionRegistry {
     (activation: ChildExecutionActivation, active: boolean) => void
   >();
 
-  constructor(
-    options: {
-      readonly streamStatus?: StreamStatusMachine;
-      readonly events?: SessionEventHub;
-      readonly publishResult?: (
-        event: ResultEvent,
-        streamId: StreamTabId,
-      ) => void;
-    } = {},
-  ) {
-    const events =
-      options.events ??
-      options.streamStatus?.sessionEvents ??
-      new SessionEventHub();
-    const streamStatus =
-      options.streamStatus ?? new StreamStatusMachine(events);
-    this.streamStatus = streamStatus;
-    this.attachSessionEvents(events, options.publishResult);
+  constructor(options: ExecutionRegistryInit = {}) {
+    const events = options.events ?? new SessionEventHub();
+    this.streamStatus = options.streamStatus ?? new StreamStatusMachine(events);
+    this.attachSessionEvents(events);
   }
 
   attachSessionEvents(
@@ -174,7 +175,6 @@ export class ExecutionRegistry {
   ): void {
     this.disposeStatusSubscription();
     this.events = events;
-    this.streamStatus.attachSessionEvents(events);
     if (publishResult) this.publishResult = publishResult;
     // Notify waiters and refresh UI badges when stream status changes
     // (e.g. RUNNING → WAITING). SessionEventHub dispatch is synchronous, so
@@ -575,14 +575,12 @@ export class ExecutionRegistry {
   detachActiveChildren(parentStreamId: StreamTabId): void {
     for (const handle of this.handles.values()) {
       if (!isChildExecution(handle, parentStreamId)) continue;
-      if (handle instanceof AgentExecutionHandle) {
-        this.approvals?.detachStreamFromParent(handle.childStreamId);
-        handle.detach();
-        this.emitParentStreamUpdate({
-          childStreamId: handle.childStreamId,
-          parentStreamId: null,
-        });
-      }
+      this.approvals?.detachStreamFromParent(handle.childStreamId);
+      handle.detach();
+      this.emitParentStreamUpdate({
+        childStreamId: handle.childStreamId,
+        parentStreamId: null,
+      });
     }
     this.emitChildActivity(parentStreamId);
   }
@@ -728,12 +726,7 @@ export class ExecutionRegistry {
   getActiveChildren(parentStreamId: StreamTabId): ActiveChildInfo[] {
     const result: ActiveChildInfo[] = [];
     for (const handle of this.handles.values()) {
-      if (
-        !(handle instanceof AgentExecutionHandle) ||
-        !isChildExecution(handle, parentStreamId)
-      ) {
-        continue;
-      }
+      if (!isChildExecution(handle, parentStreamId)) continue;
       const { status, elapsed } = this.getStatus(handle);
       result.push({
         kind: 'subagent',

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -220,12 +220,8 @@ export async function clearTerminalExecutionState(
   }));
 }
 
-/**
- * Persist a terminal status and its canonical outcome projection.
- * @deprecated Use {@link finalizeExecution} so flow-record disposition and
- * durability failures are handled together.
- */
-export async function writeTerminalStatus(
+/** Persist a terminal status and its canonical outcome projection. */
+async function writeTerminalStatus(
   executionId: ExecutionId,
   status: ExecutionStatus,
 ): Promise<void> {

--- a/src/agent/types/IModelHandler.ts
+++ b/src/agent/types/IModelHandler.ts
@@ -97,9 +97,12 @@ export type IModelHandler<
    * @param entries - One entry per tool call, in original model-response order.
    *   Each entry bundles the call with its own result and attachments, so
    *   alignment is structural rather than three positionally-zipped arrays.
-   * @param workspaceState - Optional workspace state for reasoning blocks
-   * @param text - Optional text to include before function calls
-   * @param client - Client bound to the current run and credential route
+   * @param workspaceState - Workspace state for reasoning blocks, if any
+   * @param text - Text to include before the function calls, if any
+   * @param client - Client bound to the current run and credential route.
+   *   Required: the caller already holds the run's client, so a handler that
+   *   uploads tool-result attachments uses that one rather than resolving a
+   *   second credential route of its own.
    */
   createBatchedToolUseFollowUpMessages?(
     entries: Array<{
@@ -107,8 +110,8 @@ export type IModelHandler<
       result: ToolResult;
       attachments: ToolFileAttachment[];
     }>,
-    workspaceState?: AgentWorkspaceState,
-    text?: string,
-    client?: C,
+    workspaceState: AgentWorkspaceState | undefined,
+    text: string | undefined,
+    client: C,
   ): Promise<M[]>;
 };

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -3,6 +3,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRunStateSnapshot } from '@agent/core/state/AgentState';
 import type { RunUsageTotals } from '@agent/core/usage/RunUsageAccumulator';
 import { usesServerSideKeysRoute } from '@agent/modelHandlers/support/ProxyConfigResolver';
+import type { ModelCell } from '@agent/runtime/ModelCell';
 import type {
   ExtendedTokenUsageStats,
   StorageKey,
@@ -52,8 +53,8 @@ export interface UsageMonitorMetadata {
 /**
  * Minimal model info needed for usage tracking.
  *
- * This interface captures only the fields UsageMonitor actually uses,
- * eliminating the need to store a full IModelHandler reference.
+ * This interface names the fields UsageMonitor reads off the run's live model
+ * handler, so widening what usage accounting depends on is a visible edit here.
  * Fields are directly from ModelCapabilities and ModelConfig.
  */
 export interface UsageMonitorModelInfo {
@@ -106,13 +107,18 @@ export class UsageMonitor {
   private lastSeenTotals: RunUsageTotals | undefined;
 
   constructor(
-    private modelInfo: UsageMonitorModelInfo,
+    private readonly modelCell: ModelCell,
     private readonly context: UsageMonitorContext,
     private readonly metadata: UsageMonitorMetadata,
   ) {}
 
-  setModelInfo(modelInfo: UsageMonitorModelInfo): void {
-    this.modelInfo = modelInfo;
+  /**
+   * The model this run is live on. Read from the cell on every use, so a
+   * mid-run model switch is priced and reported against the model that
+   * actually served the round without anyone mirroring it back in.
+   */
+  private get modelInfo(): UsageMonitorModelInfo {
+    return this.modelCell.handler;
   }
 
   /** The last run totals recorded this run, or undefined before any round. */
@@ -247,9 +253,8 @@ export class UsageMonitor {
   private usesRelayRoute(): boolean {
     // Shares ModelHandler's runtime combinator (#7101 triage) rather than
     // re-deriving the same `!openRouter && relaySync` formula independently
-    // — this class deliberately holds only `modelInfo.config`
-    // (`ModelConfig`-shaped), not a full `IModelHandler` reference, so it
-    // can't call `ModelHandler.shouldUseServerSideKeys()` directly.
+    // — `IModelHandler` does not expose `shouldUseServerSideKeys()`, so the
+    // config-shaped combinator is what this class can call.
     return usesServerSideKeysRoute(this.modelInfo.config);
   }
 

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -107,7 +107,7 @@ export class SupabaseClient {
   static initialize(url: string, publicKey: string): void {
     if (!url || !publicKey) {
       throw new Error(
-        'Supabase credentials missing. Check extension configuration.',
+        'Supabase credentials missing. Check the TeXRA configuration.',
       );
     }
     // Idempotent re-init: returning the existing client preserves the in-memory
@@ -141,9 +141,7 @@ export class SupabaseClient {
    */
   static getClient(): Client {
     if (!this.instance) {
-      throw new Error(
-        'Supabase client not initialized. Restart the extension.',
-      );
+      throw new Error('Supabase client not initialized. Restart TeXRA.');
     }
     return this.instance;
   }

--- a/src/common/storage/KVStore.ts
+++ b/src/common/storage/KVStore.ts
@@ -37,8 +37,6 @@ async function withMissingFallback<T>(
 }
 
 function createStorageStore(dir: string): KeyvStoreAdapter {
-  let dirEnsured = false;
-
   return {
     opts: {},
     namespace: undefined,
@@ -60,10 +58,11 @@ function createStorageStore(dir: string): KeyvStoreAdapter {
     },
 
     async set(key: string, value: unknown): Promise<void> {
-      if (!dirEnsured) {
-        await StorageFS.ensureDir(dir);
-        dirEnsured = true;
-      }
+      // Ensured on every write, not latched once: `dir` is storage-root
+      // relative, so a cached store outlives the root it first saw (workspace
+      // switch, test temp platform) and a latch would write into a directory
+      // that no longer exists. mkdir on an existing directory is cheap.
+      await StorageFS.ensureDir(dir);
       // Keyv has already run the serializer, so StorageFS receives raw JSON.
       // Atomic: a torn flow_{id}.json on an unclean exit makes the run fail to
       // parse on resume and silently restart from scratch (losing applied edits).
@@ -82,7 +81,6 @@ function createStorageStore(dir: string): KeyvStoreAdapter {
         () => StorageFS.delete(dir, { recursive: true }),
         undefined,
       );
-      dirEnsured = false;
     },
 
     async has(key: string): Promise<boolean> {

--- a/src/controllers/progressView/ProgressFollowUpPolishController.ts
+++ b/src/controllers/progressView/ProgressFollowUpPolishController.ts
@@ -16,7 +16,9 @@ type UpdateFollowUpTextMessage = Extract<
 export interface ProgressFollowUpPolishInput {
   readonly stream: StreamTabId;
   readonly text: string;
-  readonly runConfig: AgentConfig | undefined;
+  /** The run's config, which the command handler resolves before dispatching:
+   *  a stream with no config never reaches the controller. */
+  readonly runConfig: AgentConfig;
 }
 
 interface ProgressFollowUpPolishTextResult {
@@ -63,10 +65,6 @@ export class ProgressFollowUpPolishController {
   async polishFollowUp(
     input: ProgressFollowUpPolishInput,
   ): Promise<ProgressFollowUpPolishResult> {
-    if (!input.runConfig) {
-      return { kind: 'skipped' };
-    }
-
     try {
       const fileContext = this.buildFileContext(input.runConfig);
       const result = await this.deps.polishText(input.text, fileContext);

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -15,6 +15,7 @@ import { WebviewUpdater } from '@controllers/progressView/backend/WebviewUpdater
 import {
   ProgressFactApplier,
   type GetProgressStreamControls,
+  type ProgressRunFactEvent,
 } from '@controllers/progressView/backend/events/ProgressFactApplier';
 import { ProgressViewState } from '@controllers/progressView/backend/state/ProgressViewState';
 import {
@@ -422,7 +423,9 @@ export class ProgressBackend {
           if (sessionEvent.scope !== 'run') return;
           this.factApplier.handleRunFact(
             sessionEvent.streamId,
-            sessionEvent.event,
+            // Narrowed by the subscription filter below, which admits only
+            // `RUN_FACT_EVENT_TYPES`.
+            sessionEvent.event as ProgressRunFactEvent,
           );
         },
         { scope: 'run', types: RUN_FACT_EVENT_TYPES },

--- a/src/controllers/progressView/backend/WebviewUpdater.ts
+++ b/src/controllers/progressView/backend/WebviewUpdater.ts
@@ -78,7 +78,7 @@ export class WebviewUpdater {
    * Update stream tabs in the webview.
    * Optionally includes lightweight stream metadata (backend-owned fields only).
    */
-  updateStreams(
+  private updateStreams(
     streams: StreamTabInfo[],
     activeStream: ActiveStreamId,
     streamStates?: Record<StreamTabId, StreamMetadata>,

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -82,6 +82,9 @@ export type GetProgressStreamControls = (
 
 type RunFactType = (typeof RUN_FACT_EVENT_TYPES)[number];
 
+/** The run-fact vocabulary `RUN_FACT_EVENT_TYPES` subscriptions deliver. */
+export type ProgressRunFactEvent = Extract<AgentEvent, { type: RunFactType }>;
+
 type RunFactHandlers = {
   [K in RunFactType]: (
     streamId: StreamTabId,
@@ -246,20 +249,15 @@ export class ProgressFactApplier {
     });
   }
 
-  handleRunFact(streamId: StreamTabId, event: AgentEvent): void {
-    // Widen the exhaustive table to the full event union so an unlisted type
-    // (not in the subscription filter, but defensively tolerated) is a no-op
-    // rather than a lookup on a missing key.
-    const handlers = this.runFactHandlers as Partial<
-      Record<
-        AgentEvent['type'],
-        (streamId: StreamTabId, event: AgentEvent) => void | Promise<void>
-      >
-    >;
-    const handler = handlers[event.type];
-    if (!handler) return;
+  handleRunFact(streamId: StreamTabId, event: ProgressRunFactEvent): void {
+    // The table is exhaustive over `RunFactType`, so a slot always exists;
+    // TypeScript just cannot correlate a union event with its own slot.
+    const handle = this.runFactHandlers[event.type] as (
+      streamId: StreamTabId,
+      event: ProgressRunFactEvent,
+    ) => void | Promise<void>;
     this.applyFact(`failed to handle ${event.type} fact`, () =>
-      handler(streamId, event),
+      handle(streamId, event),
     );
   }
 

--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -57,14 +57,6 @@ export interface SettingsAgentCatalogControllerDeps {
   now?: () => number;
 }
 
-export type SettingsAgentPresetApplyResult =
-  | {
-      ok: true;
-      preset: AgentModePreset;
-      unresolvedNames: string[];
-    }
-  | { ok: false; reason: 'unknownPreset' };
-
 export class SettingsAgentCatalogController implements TeamRosterCatalog {
   constructor(private readonly deps: SettingsAgentCatalogControllerDeps) {}
 
@@ -148,16 +140,6 @@ export class SettingsAgentCatalogController implements TeamRosterCatalog {
         ),
       ],
     }).rootAgent?.name;
-  }
-
-  async applyPreset(presetId: string): Promise<SettingsAgentPresetApplyResult> {
-    const resolved = this.resolvePreset(presetId);
-    if (!resolved.ok) return resolved;
-
-    const { preset, resolution } = resolved;
-    await this.commitPresetResolution(preset, resolution);
-
-    return { ok: true, preset, unresolvedNames: resolution.unresolvedNames };
   }
 
   resolvePreset(presetId: string): TeamRosterPresetResolution {

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -499,7 +499,6 @@ export class LatexMediaManager {
     files: FileLocation[],
     workspaceState: MediaWorkspaceState,
     cfg: ToolConfig,
-    supportsVision: boolean,
     {
       figureMode,
       extraMediaFiles = [],
@@ -516,7 +515,7 @@ export class LatexMediaManager {
       logTikzSummary?: boolean;
     },
   ): Promise<void> {
-    if (files.length === 0 || !supportsVision) {
+    if (files.length === 0) {
       return;
     }
 
@@ -574,10 +573,9 @@ export class LatexMediaManager {
     inputFiles: FileLocation[],
     workspaceState: MediaWorkspaceState,
     cfg: ToolConfig,
-    supportsVision: boolean,
     extraMediaFiles: readonly FileLocation[] = [],
   ): Promise<void> {
-    await this.processFiles(inputFiles, workspaceState, cfg, supportsVision, {
+    await this.processFiles(inputFiles, workspaceState, cfg, {
       figureMode: 'extract',
       extraMediaFiles,
       logTikzSummary: true,
@@ -595,9 +593,8 @@ export class LatexMediaManager {
     outputFiles: FileLocation[],
     workspaceState: MediaWorkspaceState,
     cfg: ToolConfig,
-    supportsVision: boolean,
   ): Promise<void> {
-    await this.processFiles(outputFiles, workspaceState, cfg, supportsVision, {
+    await this.processFiles(outputFiles, workspaceState, cfg, {
       figureMode: 'mirror',
     });
   }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -18,7 +18,6 @@ export const MAIN_VIEW_COMMANDS = {
   COMPARE: 'compare',
 
   // Settings
-  MODEL_SELECTED: 'modelSelected',
   SETTINGS_OPEN: 'openSettings',
 
   // File selection cases (single-file pickers; multi pickers go through SELECT_MULTIPLE_FILES)

--- a/src/shared/schemas/mainView/inbound.ts
+++ b/src/shared/schemas/mainView/inbound.ts
@@ -14,7 +14,7 @@ import {
   type HandlerRegistry,
 } from '@shared/utils/dispatcher';
 
-import { SwitchViewMessageSchema } from '../commonViewMessages';
+import { SwitchViewMessageSchema, ThemeSchema } from '../commonViewMessages';
 import { commandOnly, withFilesArray } from '../messageFactories';
 import {
   CurrentFileTypeSchema,
@@ -34,7 +34,7 @@ const CommonMessages = [
   SwitchViewMessageSchema,
   z.object({
     command: z.literal(MAIN_VIEW_COMMANDS.THEME_SET),
-    theme: z.enum(['dark', 'light']),
+    theme: ThemeSchema,
   }),
   z.object({
     command: z.literal(MAIN_VIEW_COMMANDS.DEBUG_MODE_SET),
@@ -69,10 +69,6 @@ const SettingsMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.OPEN_INSTALLATION_DOCS),
   OpenAgentSettingsMessageSchema,
   OpenAgentDirectoryMessageSchema,
-  z.object({
-    command: z.literal(MAIN_VIEW_COMMANDS.MODEL_SELECTED),
-    model: z.string().min(1),
-  }),
 ] as const;
 
 // MERGE sends the primary input plus the edited file; COMPARE and
@@ -122,13 +118,6 @@ const FileSelectionMessages = [
     command: z.literal(MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES),
     fileType: ExtendedDocumentFileTypeSchema,
     currentFile: z.string().optional(),
-  }),
-] as const;
-
-const FileSelectedMessages = [
-  z.object({
-    command: z.literal(MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED),
-    filePath: z.string().optional(),
   }),
 ] as const;
 
@@ -377,7 +366,6 @@ export const MainViewInboundMessageSchema = z.discriminatedUnion('command', [
   ...SettingsMessages,
   ...ExecutionMessages,
   ...FileSelectionMessages,
-  ...FileSelectedMessages,
   ...RequestFileMessages,
   ...SetFilesMessages,
   ...FileOperationMessages,

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -155,7 +155,7 @@ export const CompileResultSchema = z.discriminatedUnion('status', [
 ]);
 export type CompileResult = z.infer<typeof CompileResultSchema>;
 
-export const OutputXmlSummarySchema = z.strictObject({
+const CanonicalOutputXmlSummarySchema = z.strictObject({
   tagContents: z
     .record(
       z.string(),
@@ -164,10 +164,22 @@ export const OutputXmlSummarySchema = z.strictObject({
         .catch([]),
     )
     .prefault(() => ({})),
-  documents: z.array(z.string()).prefault(() => []),
   singleOutputFile: z.string().nullable().prefault(null),
   sourceLocation: FileLocationSchema.nullable().prefault(null),
 });
+
+/**
+ * Records written before the `documents` field was dropped carry a second copy
+ * of the text already in `tagContents`. Nothing ever read it, so the legacy arm
+ * strips the key and every other unrecognized key still fails the strict shape.
+ */
+export const OutputXmlSummarySchema = z.union([
+  CanonicalOutputXmlSummarySchema,
+  z
+    .looseObject({ documents: z.array(z.string()) })
+    .transform(({ documents: _legacyDocuments, ...rest }) => rest)
+    .pipe(CanonicalOutputXmlSummarySchema),
+]);
 export type OutputXmlSummary = z.infer<typeof OutputXmlSummarySchema>;
 
 export const RoundOutputSchema = z.strictObject({

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -14,6 +14,7 @@ import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 import {
   SwitchViewMessageSchema,
+  ThemeSchema,
   WebviewReadyMessageSchema,
 } from '../commonViewMessages';
 import { commandOnly } from '../messageFactories';
@@ -49,7 +50,7 @@ function fileWithBaseCommand<T extends string>(command: T) {
 
 const ThemeSetMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.THEME_SET),
-  theme: z.enum(['dark', 'light']),
+  theme: ThemeSchema,
 });
 
 const DebugModeSetMessageSchema = z.object({

--- a/src/shared/schemas/settingsView/data.ts
+++ b/src/shared/schemas/settingsView/data.ts
@@ -258,15 +258,19 @@ export type UpdateCustomAgentDirMessage = z.infer<
 // Multi-agent coordination data schema
 // ============================================================
 
-/** Outbound: backend → frontend reliability + orchestration settings */
-const UpdateSuperYoloEnabledMessageSchema = z.object({
+/**
+ * Outbound: backend → frontend reliability + orchestration settings. The wire
+ * literal stays `updateSuperYoloEnabled` for compatibility with shipped
+ * webviews, so only the schema and type carry the payload's real name.
+ */
+const UpdateReliabilityAndOrchestrationMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_SUPER_YOLO_ENABLED),
   reliabilitySettings: z.array(NumberVscodeSettingSchema).prefault([]),
   allowOrchestratorKill: z.boolean().prefault(true),
   detachSubagentsOnStop: z.boolean().prefault(false),
 });
-export type UpdateSuperYoloEnabledMessage = z.infer<
-  typeof UpdateSuperYoloEnabledMessageSchema
+export type UpdateReliabilityAndOrchestrationMessage = z.infer<
+  typeof UpdateReliabilityAndOrchestrationMessageSchema
 >;
 
 // ============================================================
@@ -577,7 +581,7 @@ const SettingsViewOutboundMessageSchema = z.discriminatedUnion('command', [
   UpdateModelSelectionMessageSchema,
   UpdateAgentSelectionMessageSchema,
   UpdateCustomAgentDirMessageSchema,
-  UpdateSuperYoloEnabledMessageSchema,
+  UpdateReliabilityAndOrchestrationMessageSchema,
   UpdateAgentModePresetsMessageSchema,
   UpdateApprovalAndSafetySettingsMessageSchema,
   UpdateAgentSkillsSettingsMessageSchema,

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -176,7 +176,7 @@ export function executionStatusToRunOutcome(
   }
 }
 
-export function streamStatusToPhase(status: StreamStatus): StreamPhase {
+function streamStatusToPhase(status: StreamStatus): StreamPhase {
   switch (status) {
     case STREAM_STATUS.RUNNING:
     case STREAM_STATUS.RESUMING:
@@ -189,19 +189,6 @@ export function streamStatusToPhase(status: StreamStatus): StreamPhase {
     case STREAM_STATUS.STOPPED:
     case STREAM_STATUS.READY:
       return STREAM_PHASE.COMPLETED;
-  }
-}
-
-export function streamStatusToSubstate(
-  status: StreamStatus,
-): StreamSubstate | undefined {
-  switch (status) {
-    case STREAM_STATUS.INITIALIZING:
-      return STREAM_SUBSTATE.STARTING;
-    case STREAM_STATUS.RESUMING:
-      return STREAM_SUBSTATE.RESUMING;
-    default:
-      return undefined;
   }
 }
 

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -75,9 +75,12 @@ export type LegacyInstructionEntry = z.infer<
   typeof LegacyInstructionEntrySchema
 >;
 
-export const LegacyInstructionsDataSchema = z
-  .record(z.string(), LegacyInstructionEntrySchema)
-  .catch({});
+// No whole-record `.catch`: an unreadable file degrades to "no legacy
+// instruction" at `readLegacyInstruction`, which warns first.
+export const LegacyInstructionsDataSchema = z.record(
+  z.string(),
+  LegacyInstructionEntrySchema,
+);
 
 /**
  * Pick the legacy instruction that best matches the workflow run users most

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -23,15 +23,30 @@ import { RunUsageMapSchema } from './usage';
 // appear on either kind — e.g. a subagent launched via a specific CLI tool
 // (`options.toolName` in `createChildStream`), or a background process running
 // a named tool (`bash`, `codex`) — so it stays a shared, optional field.
+//
+// Where a roster comes from, since the legacy arms below are only meaningful
+// against it. The roster is liveness state, and every artifact we have written
+// carries an empty one: `assembleSnapshot` does not set `subagents` (it takes
+// the `[]` prefault) and every hydrate clamps it, `replayTrace()` included.
+// It still crosses two parse boundaries, because `StreamSnapshotSchema` picks
+// `subagents` from `BackendOwnedFieldsSchema`: the progress-view wire
+// (`UPDATE_STREAMS`/`STREAM_STATE`), and an exported `trace.json`, which the
+// standalone viewer re-parses — the same permanent second boundary documented
+// on `GroupLogPayloadSchema` in `./taskGroup`. So the legacy arms guard
+// cross-version input on those two boundaries, not our own on-disk state.
+//
+// Retire the roster's legacy arms — `fillLegacyActiveChildKind` and the "still
+// parse" halves of the optional fields below — on 2026-11-01, with the other
+// roster/task-group compat reads. They were added defensively against
+// persisted rosters that, per the note above, no release ever wrote.
 
 const ActiveChildInfoBaseSchema = z.object({
   executionId: z.string(),
   agentName: z.string(),
   /**
-   * Current execution phase. The roster is liveness state: it is rebuilt from
-   * live handles on every load and never persisted (`StreamSnapshot` clamps
-   * `subagents` to `[]` on hydrate, and `assembleSnapshot` never writes it),
-   * so there is no legacy on-disk vocabulary to normalize here.
+   * Current execution phase. Takes `StreamPhase` only: no artifact carries a
+   * roster (see the note above), so no input can hold the retired 7-value
+   * `StreamStatus` vocabulary and there is nothing to normalize here.
    */
   status: StreamPhaseSchema.optional(),
   /** Epoch milliseconds when the child execution began. */
@@ -55,18 +70,19 @@ const ActiveChildInfoBaseSchema = z.object({
    * know `phase`) — `WorkflowCallIdentity` carries no execution or stream id.
    * Immutable per attempt: it is stamped on the handle before the first
    * `child.activity` emission, so retained (finished) rows keep it. Optional
-   * so persisted rosters written before this field still parse.
+   * because only a workflow-script run's children have an owning phase, and
+   * so replayed rows written before this field still parse.
    */
   workflowPhase: z.string().optional(),
 });
 
 /**
- * Persisted/replayed ActiveChildInfo entries predate the `kind` discriminant,
- * when subagent vs. process was inferred from array membership
- * (`subagents` vs. `processes`) or from whether `childStreamId`
- * happened to be set. `childStreamId` was — and still is — exclusive to
- * subagents, so backfill `kind` from that same signal on read, matching the
- * legacy inference, instead of failing to parse.
+ * Replayed ActiveChildInfo entries written before the `kind` discriminant
+ * landed (2026-07-06) inferred subagent vs. process from array membership
+ * (`subagents` vs. `processes`) or from whether `childStreamId` happened to be
+ * set. `childStreamId` was — and still is — exclusive to subagents, so
+ * backfill `kind` from that same signal on read, matching the legacy
+ * inference, instead of failing to parse.
  */
 function fillLegacyActiveChildKind(raw: unknown): unknown {
   if (

--- a/src/shared/settingsView/handlers/superYoloHandlers.ts
+++ b/src/shared/settingsView/handlers/superYoloHandlers.ts
@@ -9,7 +9,7 @@
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import type { NumberVscodeSetting } from '@shared/schemas/profileViewMessages';
-import type { UpdateSuperYoloEnabledMessage } from '@shared/schemas/settingsViewMessages';
+import type { UpdateReliabilityAndOrchestrationMessage } from '@shared/schemas/settingsViewMessages';
 
 import type { SettingsStatePorts } from '@shared/settingsView/types';
 
@@ -20,7 +20,7 @@ export interface SuperYoloHandlerPorts extends SettingsStatePorts {
 
 export function buildSuperYoloMessage(
   ports: SuperYoloHandlerPorts,
-): UpdateSuperYoloEnabledMessage {
+): UpdateReliabilityAndOrchestrationMessage {
   const { workspaceState } = ports;
   return {
     command: SETTINGS_VIEW_COMMANDS.UPDATE_SUPER_YOLO_ENABLED,

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -149,3 +149,17 @@ export function formatPhaseStageLabel(
   const current = `${stage.label} ${stage.index + 1}`;
   return stage.total !== undefined ? `${current}/${stage.total}` : current;
 }
+
+/** Label for the one stage slot a stream fills: a workflow-script run advances
+ *  through named phases, a tool-use run through numbered rounds, never both,
+ *  so every surface that shows the slot dispatches on the same discriminant. */
+export function formatStageLabel(
+  stage:
+    | ({ readonly kind: 'round' } & Readonly<RoundStage>)
+    | ({ readonly kind: 'phase' } & Readonly<PhaseStage>)
+    | undefined,
+): string | undefined {
+  if (stage === undefined) return undefined;
+  if (stage.kind === 'round') return formatRoundStageLabel(stage);
+  return formatPhaseStageLabel(stage);
+}

--- a/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
+++ b/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
@@ -28,7 +28,6 @@ vi.mock('@agent/storage/ExecutionKVStore', () => ({
 import {
   finalizeExecution,
   registerExecution,
-  writeTerminalStatus,
 } from '@agent/storage/executionLifecycle';
 import { inspectExecutionLease } from '@agent/storage/executionLease';
 import { setupPlatform } from '@test/support/setupPlatform';
@@ -152,7 +151,11 @@ describe('execution lifecycle', () => {
       resultMeta('completed', 'Interim result.'),
     );
 
-    await writeTerminalStatus(executionId, EXECUTION_STATUS.INTERRUPTED);
+    await finalizeExecution({
+      executionId,
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      flowRecord: 'preserve',
+    });
 
     expect(mocks.writeMeta).toHaveBeenCalledWith({
       schemaVersion: 1,
@@ -164,7 +167,7 @@ describe('execution lifecycle', () => {
     expect(mocks.writeResultMeta).not.toHaveBeenCalled();
   });
 
-  it('rejects when terminal metadata cannot be written', async () => {
+  it('reports a failure when terminal metadata cannot be written', async () => {
     mocks.readMeta.mockResolvedValue(
       executionMeta({
         terminalStatus: EXECUTION_STATUS.COMPLETED,
@@ -174,13 +177,22 @@ describe('execution lifecycle', () => {
     mocks.readResultMeta.mockResolvedValue(
       resultMeta('completed', 'Finished.'),
     );
-    mocks.writeMeta.mockRejectedValueOnce(new Error('disk full'));
+    const error = new Error('disk full');
+    mocks.writeMeta.mockRejectedValueOnce(error);
 
     const executionId = 'failed-terminal-write' as ExecutionId;
-    await expect(
-      writeTerminalStatus(executionId, EXECUTION_STATUS.INTERRUPTED),
-    ).rejects.toThrow('disk full');
+    const result = await finalizeExecution({
+      executionId,
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      flowRecord: 'preserve',
+    });
 
+    expect(result).toEqual({
+      status: 'failed',
+      error,
+      stage: 'terminal-status',
+      terminalStatusPersisted: false,
+    });
     expect(mocks.readResultMeta).not.toHaveBeenCalled();
     expect(mocks.writeResultMeta).not.toHaveBeenCalled();
   });

--- a/src/test-kernel/agent/ResponseCycleTools.vitest.mts
+++ b/src/test-kernel/agent/ResponseCycleTools.vitest.mts
@@ -63,8 +63,7 @@ describe('response cycle tool visibility', () => {
     },
   ])('$name', async ({ services, expected }) => {
     const tools = await withTestRunContext(
-      { emit: vi.fn() },
-      'response-cycle-stream',
+      testRunScope('response-cycle-stream'),
       async () => responseCycleToolsForModel(responseServices({})),
       services,
     );
@@ -74,8 +73,7 @@ describe('response cycle tool visibility', () => {
 
   it('omits workflow tools when the model handler cannot call functions', async () => {
     const tools = await withTestRunContext(
-      { emit: vi.fn() },
-      'response-cycle-stream',
+      testRunScope('response-cycle-stream'),
       async () =>
         responseCycleToolsForModel(
           responseServices({ supportsFunctionCalling: false }),
@@ -118,14 +116,11 @@ describe('response cycle tool visibility', () => {
       },
     } as unknown as AgentCore);
 
-    await withTestRunContext(
-      { emit: vi.fn() },
-      'response-cycle-invocation',
-      () =>
-        node.run({
-          messages: [],
-          shouldStop: false,
-        } as unknown as BaseCycleFields),
+    await withTestRunContext(node.services.runScope, () =>
+      node.run({
+        messages: [],
+        shouldStop: false,
+      } as unknown as BaseCycleFields),
     );
 
     expect(createResponse).toHaveBeenCalledWith(

--- a/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
+++ b/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
@@ -15,7 +15,6 @@ import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionCo
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ITool } from '@agent/core/tools/ToolTypes';
 import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
-import { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import type { StreamTabId } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import { installPlatform } from '@test/support/setupPlatform';
@@ -128,10 +127,8 @@ function execPrepped(
   node: ToolUseDispatchNode<unknown>,
   prepped: SdkToolCall[],
 ): Promise<unknown[]> {
-  return withTestRunContext(
-    new SessionHostInteractions(),
-    'dispatch-test',
-    () => internals(node)._exec(prepped),
+  return withTestRunContext(node.services.runScope, () =>
+    internals(node)._exec(prepped),
   );
 }
 

--- a/src/test-kernel/agent/core/FinalToolSynthesis.vitest.ts
+++ b/src/test-kernel/agent/core/FinalToolSynthesis.vitest.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from 'vitest';
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
 import { createToolUseRoundFlow } from '@agent/core/flows/ToolUseRoundFlow';
 import type { ToolUseRoundShared } from '@agent/core/flows/toolUseRound/roundShared';
-import { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import type { CreateResponseOptions } from '@agent/types/ModelHandlerContracts';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import { withTestRunContext } from '../progressTestUtils';
@@ -62,10 +61,8 @@ describe('final-tool synthesis turn', () => {
   it('keeps exploration unforced, then forces exactly one final turn', async () => {
     const { requests, services, shared } = buildRound(true);
 
-    await withTestRunContext(
-      new SessionHostInteractions(),
-      'final-tool-synthesis',
-      () => createToolUseRoundFlow().setServices(services).run(shared),
+    await withTestRunContext(services.runScope, () =>
+      createToolUseRoundFlow().setServices(services).run(shared),
     );
 
     expect(requests.map((request) => request.finalTool)).toEqual([
@@ -84,10 +81,8 @@ describe('final-tool synthesis turn', () => {
   it('asks once without forcing when the provider cannot force tools', async () => {
     const { requests, services, shared } = buildRound(false);
 
-    await withTestRunContext(
-      new SessionHostInteractions(),
-      'final-tool-floor',
-      () => createToolUseRoundFlow().setServices(services).run(shared),
+    await withTestRunContext(services.runScope, () =>
+      createToolUseRoundFlow().setServices(services).run(shared),
     );
 
     expect(requests.map((request) => request.finalTool)).toEqual([

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -589,11 +589,9 @@ describe('child stream progress events', () => {
     const handle =
       defaultSession().executions.getAgentHandleByStream(stoppedChildStreamId);
     expect(handle).toBeDefined();
-    seedStreamStatusForTest(
-      defaultSession().status,
-      stoppedChildStreamId,
-      STREAM_PHASE.CANCELLED,
-    );
+    seedStreamStatusForTest(defaultSession().status, stoppedChildStreamId, {
+      phase: STREAM_PHASE.CANCELLED,
+    });
     recorded.events.splice(0);
 
     try {

--- a/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
@@ -148,12 +148,8 @@ function runRound(
   services: ToolUseRoundServices,
   shared: ToolUseRoundShared,
 ): Promise<string | undefined> {
-  const { session } = services.runScope;
-  return withTestRunContext(
-    session.interactions,
-    'test-stream',
-    () => createToolUseRoundFlow().setServices(services).run(shared),
-    { session },
+  return withTestRunContext(services.runScope, () =>
+    createToolUseRoundFlow().setServices(services).run(shared),
   );
 }
 

--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -13,7 +13,11 @@ import {
   onFollowUpSent,
   submitFollowUp,
 } from '@agent/followUp/ToolUseFollowUp';
-import { STREAM_PHASE, STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import {
+  STREAM_PHASE,
+  STREAM_SUBSTATE,
+  type StreamTabId,
+} from '@shared/schemas';
 import {
   clearAllStreamStatusesForTest,
   seedStreamStatusForTest,
@@ -255,11 +259,9 @@ describe('tool-use follow-up progress events', () => {
   it('does not append through stale active contexts after final status', async () => {
     const appendFollowUp = vi.fn();
 
-    seedStreamStatusForTest(
-      defaultSession().status,
-      streamId,
-      STREAM_PHASE.COMPLETED,
-    );
+    seedStreamStatusForTest(defaultSession().status, streamId, {
+      phase: STREAM_PHASE.COMPLETED,
+    });
     trackToolUseFlow({ appendFollowUp });
 
     const result = await submitFollowUp(streamId, 'late follow-up');
@@ -296,11 +298,10 @@ describe('tool-use follow-up progress events', () => {
   it('queues follow-ups for resuming streams through registry admission', async () => {
     const resumingStreamId = 'stream:resuming-follow-up' as StreamTabId;
 
-    seedStreamStatusForTest(
-      defaultSession().status,
-      resumingStreamId,
-      STREAM_STATUS.RESUMING,
-    );
+    seedStreamStatusForTest(defaultSession().status, resumingStreamId, {
+      phase: STREAM_PHASE.RUNNING,
+      substate: STREAM_SUBSTATE.RESUMING,
+    });
 
     try {
       const result = await submitFollowUp(
@@ -332,11 +333,9 @@ describe('tool-use follow-up progress events', () => {
       agent: 'critic',
     });
 
-    seedStreamStatusForTest(
-      defaultSession().status,
-      parentStreamId,
-      STREAM_STATUS.STOPPED,
-    );
+    seedStreamStatusForTest(defaultSession().status, parentStreamId, {
+      phase: STREAM_PHASE.COMPLETED,
+    });
     defaultSession().executions.track(handle);
 
     try {

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -133,7 +133,7 @@ describe('tool-use progress events', () => {
       forcedToolOverrides([{ name: 'submit_output' }]),
     );
 
-    await withTestRunContext(host, streamId, () =>
+    await withTestRunContext(node.services.runScope, () =>
       node.exec(createPrepResult(AgentWorkspaceState.create(), false)),
     );
 
@@ -152,8 +152,7 @@ describe('tool-use progress events', () => {
     );
 
     await withTestRunContext(
-      host,
-      streamId,
+      node.services.runScope,
       () => node.exec(createPrepResult(AgentWorkspaceState.create(), false)),
       { stopAfterCycle: true },
     );
@@ -177,7 +176,7 @@ describe('tool-use progress events', () => {
     const node = createCycleNode(streamId, host, logger);
 
     try {
-      const result = await withTestRunContext(host, streamId, () =>
+      const result = await withTestRunContext(node.services.runScope, () =>
         node.exec(createPrepResult(workspaceState)),
       );
 
@@ -344,7 +343,7 @@ describe('tool-use round outcome persistence (#8023)', () => {
       const node = createCycleNode(streamId, host, logger);
 
       try {
-        const result = await withTestRunContext(host, streamId, () =>
+        const result = await withTestRunContext(node.services.runScope, () =>
           node.exec(createPrepResult(AgentWorkspaceState.create(), false)),
         );
 

--- a/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
@@ -116,12 +116,8 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
     services: ToolUseRoundServices,
     shared: ToolUseRoundShared,
   ): Promise<string | undefined> {
-    const { session } = services.runScope;
-    return withTestRunContext(
-      session.interactions,
-      'test-stream',
-      () => createToolUseRoundFlow().setServices(services).run(shared),
-      { session },
+    return withTestRunContext(services.runScope, () =>
+      createToolUseRoundFlow().setServices(services).run(shared),
     );
   }
 

--- a/src/test-kernel/agent/followUp/ToolUseRoundPrepNodeFollowUpTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundPrepNodeFollowUpTranscriptLog.vitest.ts
@@ -48,10 +48,9 @@ describe('ToolUseRoundPrepNode follow-up transcript logging (regression: #7508 p
     ).mockRejectedValue(new Error('follow-up append failed'));
     const node = new ToolUseRoundPrepNode().setServices(services);
     const shared = buildShared();
-    const interactions = { emit: vi.fn() };
 
     await expect(
-      withTestRunContext(interactions, 'test-stream', () =>
+      withTestRunContext(services.runScope, () =>
         node.post(shared, {
           interrupted: false,
           queuedFollowUps: [{ text: 'Do the thing.', origin: 'user' }],
@@ -73,23 +72,18 @@ describe('ToolUseRoundPrepNode follow-up transcript logging (regression: #7508 p
       ...buildShared(),
       currentUserInstruction: 'initial request',
     };
-    const interactions = { emit: vi.fn() };
-
-    const transition = await withTestRunContext(
-      interactions,
-      'test-stream',
-      () =>
-        node.post(shared, {
-          interrupted: false,
-          queuedFollowUps: [
-            { text: 'Do the thing.', origin: 'user' },
-            {
-              text: '<subagent-result>done</subagent-result>',
-              origin: 'subagent_result',
-            },
-          ],
-          synthetic: false,
-        }),
+    const transition = await withTestRunContext(services.runScope, () =>
+      node.post(shared, {
+        interrupted: false,
+        queuedFollowUps: [
+          { text: 'Do the thing.', origin: 'user' },
+          {
+            text: '<subagent-result>done</subagent-result>',
+            origin: 'subagent_result',
+          },
+        ],
+        synthetic: false,
+      }),
     );
 
     expect(transition).toBeDefined();
@@ -106,10 +100,9 @@ describe('ToolUseRoundPrepNode follow-up transcript logging (regression: #7508 p
     ).mockRejectedValue(new Error('boom'));
     const node = new ToolUseRoundPrepNode().setServices(services);
     const shared = buildShared();
-    const interactions = { emit: vi.fn() };
 
     await expect(
-      withTestRunContext(interactions, 'test-stream', () =>
+      withTestRunContext(services.runScope, () =>
         node.post(shared, {
           interrupted: false,
           queuedFollowUps: [{ text: 'synthesized', origin: 'user' }],

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -19,6 +19,7 @@ import {
 } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
 import type { RunModelHandler } from '@agent/runtime/ModelCell';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
   SessionEventHub,
@@ -58,24 +59,34 @@ type WaitNodeModelHandlerOverrides = Omit<
 };
 
 type WaitNodeServiceOverrides = Partial<
-  Pick<
-    ToolUseServices,
-    'isSubagent' | 'onFollowUpConsumed' | 'onIdle' | 'runScope'
-  >
+  Pick<ToolUseServices, 'isSubagent' | 'onFollowUpConsumed' | 'onIdle'>
 > & {
   fileService?: Partial<ToolUseServices['fileService']>;
   logger?: AgentTrace;
   modelHandler?: WaitNodeModelHandlerOverrides;
   session?: Partial<ToolUseServices['session']>;
+  /** Run identity the node reads off `services.runScope`. */
+  streamId?: string;
+  /** Session owning this run's status machine and approvals. */
+  ownerSession?: SessionHandle;
+  signal?: AbortSignal;
 };
 
 function createWaitNodeServices(
   overrides: WaitNodeServiceOverrides = {},
 ): ToolUseServices {
-  const { fileService, modelHandler, session, ...topLevel } = overrides;
+  const {
+    fileService,
+    modelHandler,
+    ownerSession,
+    session,
+    signal,
+    streamId = 'test-stream',
+    ...topLevel
+  } = overrides;
   const { capabilities, ...modelHandlerOverrides } = modelHandler ?? {};
   return {
-    runScope: testRunScope('test-stream'),
+    runScope: testRunScope(streamId, { session: ownerSession, signal }),
     fileService: {
       createLocation: (filePath: string) => ({ absolutePath: filePath }),
       ...fileService,
@@ -131,7 +142,6 @@ function recordRunEvents(
 describe('ToolUseWaitNode', () => {
   it('always suspends a subagent cycle at WAITING, carrying its turn facts', async () => {
     const shared: ToolUseRunShared = toolUseRunShared();
-    const interactions = { emit: vi.fn() };
     const waitForFollowUp = vi.fn();
 
     const services = createWaitNodeServices({
@@ -148,14 +158,10 @@ describe('ToolUseWaitNode', () => {
     // them after suspension (see childRunLoop.ts), so the node carries none.
     expect(prep.lastResponse).toBeUndefined();
 
-    const transition = await withTestRunContext(
-      interactions,
-      'test-stream',
-      async () => {
-        const exec = await node.exec(prep);
-        return node.post(shared, prep, exec);
-      },
-    );
+    const transition = await withTestRunContext(services.runScope, async () => {
+      const exec = await node.exec(prep);
+      return node.post(shared, prep, exec);
+    });
 
     expect(transition).toBe(FlowTransition.WAITING);
     // The flow never blocks on session.waitForFollowUp in subagent mode —
@@ -168,7 +174,6 @@ describe('ToolUseWaitNode', () => {
     // already queued is the child-run loop's concern (it resumes immediately
     // instead of genuinely waiting), not something the flow special-cases.
     const shared: ToolUseRunShared = toolUseRunShared();
-    const interactions = { emit: vi.fn() };
     const waitForFollowUp = vi.fn();
 
     const services = createWaitNodeServices({
@@ -181,7 +186,7 @@ describe('ToolUseWaitNode', () => {
 
     const node = new ToolUseWaitNode().setServices(services);
     const prep = await node.prep(shared);
-    const exec = await withTestRunContext(interactions, 'test-stream', () =>
+    const exec = await withTestRunContext(services.runScope, () =>
       node.exec(prep),
     );
 
@@ -191,7 +196,6 @@ describe('ToolUseWaitNode', () => {
 
   it('advances a drained child-loop batch once without reading the session queue', async () => {
     const shared: ToolUseRunShared = toolUseRunShared();
-    const interactions = { emit: vi.fn() };
     const waitForFollowUp = vi.fn();
     const createUserFollowUpMessages = vi.fn(
       async (
@@ -220,16 +224,12 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode(batch).setServices(services);
     const prep = await node.prep(shared);
 
-    const first = await withTestRunContext(
-      interactions,
-      'test-stream',
-      async () => {
-        const exec = await node.exec(prep);
-        const transition = await node.post(shared, prep, exec);
-        return { exec, transition };
-      },
-    );
-    const second = await withTestRunContext(interactions, 'test-stream', () =>
+    const first = await withTestRunContext(services.runScope, async () => {
+      const exec = await node.exec(prep);
+      const transition = await node.post(shared, prep, exec);
+      return { exec, transition };
+    });
+    const second = await withTestRunContext(services.runScope, () =>
       node.exec(prep),
     );
 
@@ -256,7 +256,6 @@ describe('ToolUseWaitNode', () => {
 
   it('stops instead of suspending when stopAfterCycle is set (headless in-band subagent)', async () => {
     const shared: ToolUseRunShared = toolUseRunShared();
-    const interactions = { emit: vi.fn() };
 
     const services = createWaitNodeServices({
       isSubagent: true,
@@ -265,8 +264,7 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
     const prep = await node.prep(shared);
     const transition = await withTestRunContext(
-      interactions,
-      'test-stream',
+      services.runScope,
       async () => {
         const exec = await node.exec(prep);
         expect(exec.kind).toBe('stop');
@@ -280,26 +278,19 @@ describe('ToolUseWaitNode', () => {
 
   it('stops immediately on interruption instead of suspending a subagent', async () => {
     const shared: ToolUseRunShared = toolUseRunShared();
-    const interactions = { emit: vi.fn() };
 
     const services = createWaitNodeServices({
-      runScope: testRunScope('test-stream', {
-        signal: AbortSignal.abort(),
-      }),
+      signal: AbortSignal.abort(),
       isSubagent: true,
     });
 
     const node = new ToolUseWaitNode().setServices(services);
 
     const prep = await node.prep(shared);
-    const transition = await withTestRunContext(
-      interactions,
-      'test-stream',
-      async () => {
-        const exec = await node.exec(prep);
-        return node.post(shared, prep, exec);
-      },
-    );
+    const transition = await withTestRunContext(services.runScope, async () => {
+      const exec = await node.exec(prep);
+      return node.post(shared, prep, exec);
+    });
 
     expect(transition).toBe(FlowTransition.COMPLETE);
   });
@@ -309,7 +300,6 @@ describe('ToolUseWaitNode', () => {
       messages: [{ role: 'assistant', content: 'partial response' } as never],
     });
     const onIdle = vi.fn();
-    const interactions = { emit: vi.fn() };
     let waitCalls = 0;
 
     const services = createWaitNodeServices({
@@ -326,9 +316,7 @@ describe('ToolUseWaitNode', () => {
 
     const node = new ToolUseWaitNode().setServices(services);
     const prep = await node.prep(shared);
-    await withTestRunContext(interactions, 'test-stream', () =>
-      node.exec(prep),
-    );
+    await withTestRunContext(services.runScope, () => node.exec(prep));
 
     expect(onIdle).toHaveBeenCalledOnce();
     expect(onIdle).toHaveBeenCalledWith('partial response');
@@ -340,7 +328,6 @@ describe('ToolUseWaitNode', () => {
     const info = vi.fn();
     const warn = vi.fn();
     const addMediaToUserMessage = vi.fn(async () => []);
-    const interactions = { emit: vi.fn() };
     const logger = Object.assign(new TraceEmitter(), { info, warn });
 
     const services = createWaitNodeServices({
@@ -356,20 +343,17 @@ describe('ToolUseWaitNode', () => {
     });
 
     const node = new ToolUseWaitNode().setServices(services);
-    const transition = await withTestRunContext(
-      interactions,
-      'test-stream',
-      () =>
-        node.post(shared, waitPrep(), {
-          followUps: [
-            {
-              text: 'please inspect this figure',
-              mediaFiles: ['/tmp/figure.png'],
-              origin: 'user',
-            },
-          ],
-          kind: 'continue',
-        }),
+    const transition = await withTestRunContext(services.runScope, () =>
+      node.post(shared, waitPrep(), {
+        followUps: [
+          {
+            text: 'please inspect this figure',
+            mediaFiles: ['/tmp/figure.png'],
+            origin: 'user',
+          },
+        ],
+        kind: 'continue',
+      }),
     );
 
     expect(transition).toBe(FlowTransition.CONTINUE);
@@ -388,7 +372,6 @@ describe('ToolUseWaitNode', () => {
   it('logs follow-up markers reported by provider insertion', async () => {
     const shared: ToolUseRunShared = toolUseRunShared();
     const info = vi.fn();
-    const interactions = { emit: vi.fn() };
     const logger = Object.assign(new TraceEmitter(), {
       info,
       warn: vi.fn(),
@@ -407,7 +390,7 @@ describe('ToolUseWaitNode', () => {
     });
 
     const node = new ToolUseWaitNode().setServices(services);
-    await withTestRunContext(interactions, 'test-stream', () =>
+    await withTestRunContext(services.runScope, () =>
       node.post(shared, waitPrep(), {
         followUps: [
           {
@@ -435,9 +418,8 @@ describe('ToolUseWaitNode', () => {
     const shared: ToolUseRunShared = toolUseRunShared({
       lastError: { message: 'cycle failed', userRetryable: false },
     });
-    const interactions = { emit: vi.fn() };
     const setApprovalBypassState = vi.fn();
-    const session = sessionWithInteractions({
+    const ownerSession = sessionWithInteractions({
       setApprovalBypassState,
       cancel: vi.fn(),
     });
@@ -447,6 +429,8 @@ describe('ToolUseWaitNode', () => {
     const services = createWaitNodeServices({
       isSubagent: false,
       logger,
+      ownerSession,
+      streamId,
       session: {
         waitForFollowUp,
       },
@@ -455,10 +439,9 @@ describe('ToolUseWaitNode', () => {
 
     try {
       const exec = await withTestRunContext(
-        interactions,
-        streamId,
+        services.runScope,
         () => node.exec(waitPrep(true)),
-        { session, stopAfterCycle: true },
+        { stopAfterCycle: true },
       );
 
       const goal = GoalStore.getForStream(streamId);
@@ -505,15 +488,16 @@ describe('ToolUseWaitNode', () => {
     );
     const onFollowUpConsumed = vi.fn();
     const waitForFollowUp = vi.fn();
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     const ownerSession = sessionWithInteractions(undefined, streamStatus);
-    const interactions = { emit: vi.fn() };
     const services = createWaitNodeServices({
       isSubagent: false,
       modelHandler: {
         createUserFollowUpMessages,
       },
       onFollowUpConsumed,
+      ownerSession,
+      streamId,
       session: {
         waitForFollowUp,
       },
@@ -521,13 +505,12 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.RUNNING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
       const prep = await node.prep(shared);
-      const exec = await withTestRunContext(
-        interactions,
-        streamId,
-        () => node.exec(prep),
-        { session: ownerSession },
+      const exec = await withTestRunContext(services.runScope, () =>
+        node.exec(prep),
       );
 
       expect(exec.kind).toBe('continue');
@@ -542,11 +525,8 @@ describe('ToolUseWaitNode', () => {
       expect(waitForFollowUp).not.toHaveBeenCalled();
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
 
-      const transition = await withTestRunContext(
-        interactions,
-        streamId,
-        () => node.post(shared, prep, exec),
-        { session: ownerSession },
+      const transition = await withTestRunContext(services.runScope, () =>
+        node.post(shared, prep, exec),
       );
 
       expect(transition).toBe(FlowTransition.CONTINUE);
@@ -590,12 +570,12 @@ describe('ToolUseWaitNode', () => {
       ],
     );
     const waitForFollowUp = vi.fn(async () => null);
-    const interactions = { emit: vi.fn() };
     const services = createWaitNodeServices({
       isSubagent: false,
       modelHandler: {
         createUserFollowUpMessages,
       },
+      streamId,
       session: {
         waitForFollowUp,
       },
@@ -606,7 +586,7 @@ describe('ToolUseWaitNode', () => {
       const continuationCycles = 25;
       for (let cycle = 0; cycle < continuationCycles; cycle += 1) {
         const prep = await node.prep(shared);
-        const exec = await withTestRunContext(interactions, streamId, () =>
+        const exec = await withTestRunContext(services.runScope, () =>
           node.exec(prep),
         );
 
@@ -617,10 +597,8 @@ describe('ToolUseWaitNode', () => {
           'Keep solving the hard problem until verification is complete.',
         );
 
-        const transition = await withTestRunContext(
-          interactions,
-          streamId,
-          () => node.post(shared, prep, exec),
+        const transition = await withTestRunContext(services.runScope, () =>
+          node.post(shared, prep, exec),
         );
         expect(transition).toBe(FlowTransition.CONTINUE);
         expect(createUserFollowUpMessages).toHaveBeenCalledTimes(cycle + 1);
@@ -635,7 +613,7 @@ describe('ToolUseWaitNode', () => {
       await GoalStore.setStatus(streamId, 'paused');
 
       const prep = await node.prep(shared);
-      const exec = await withTestRunContext(interactions, streamId, () =>
+      const exec = await withTestRunContext(services.runScope, () =>
         node.exec(prep),
       );
 
@@ -656,8 +634,8 @@ describe('ToolUseWaitNode', () => {
       items: [{ text: 'user correction', origin: 'user' as const }],
       synthetic: false,
     }));
-    const interactions = { emit: vi.fn() };
     const services = createWaitNodeServices({
+      streamId,
       session: {
         hasQueuedFollowUp: () => true,
         waitForFollowUp,
@@ -666,7 +644,7 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      const exec = await withTestRunContext(interactions, streamId, () =>
+      const exec = await withTestRunContext(services.runScope, () =>
         node.exec(waitPrep()),
       );
 
@@ -692,9 +670,9 @@ describe('ToolUseWaitNode', () => {
     await GoalStore.start(streamId, 'Parent-owned objective.');
 
     const waitForFollowUp = vi.fn(async () => null);
-    const interactions = { emit: vi.fn() };
     const services = createWaitNodeServices({
       isSubagent: true,
+      streamId,
       session: {
         waitForFollowUp,
       },
@@ -702,7 +680,7 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      const exec = await withTestRunContext(interactions, streamId, () =>
+      const exec = await withTestRunContext(services.runScope, () =>
         node.exec(waitPrep()),
       );
 
@@ -716,13 +694,13 @@ describe('ToolUseWaitNode', () => {
 
   it('updates the run session status while waiting and resuming', async () => {
     const streamId = 'wait-node-owner' as StreamTabId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     const ownerSession = sessionWithInteractions(undefined, streamStatus);
     const shared: ToolUseRunShared = toolUseRunShared();
     const createUserFollowUpMessages = vi.fn(async () => []);
-    const interactions = { emit: vi.fn() };
     const services = createWaitNodeServices({
-      runScope: testRunScope(streamId, { session: ownerSession }),
+      ownerSession,
+      streamId,
       modelHandler: {
         createUserFollowUpMessages,
       },
@@ -736,22 +714,18 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
 
       const prep = await node.prep(shared);
-      const exec = await withTestRunContext(
-        interactions,
-        streamId,
-        () => node.exec(prep),
-        { session: ownerSession },
+      const exec = await withTestRunContext(services.runScope, () =>
+        node.exec(prep),
       );
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.WAITING);
 
-      await withTestRunContext(
-        interactions,
-        streamId,
-        () => node.post(shared, prep, exec),
-        { session: ownerSession },
+      await withTestRunContext(services.runScope, () =>
+        node.post(shared, prep, exec),
       );
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
       expect(createUserFollowUpMessages).toHaveBeenCalledOnce();
@@ -762,9 +736,8 @@ describe('ToolUseWaitNode', () => {
 
   it('repairs retry-cancelled parent cycles to waiting before blocking', async () => {
     const streamId = 'wait-node-retry-cancelled-wait' as StreamTabId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     const ownerSession = sessionWithInteractions(undefined, streamStatus);
-    const interactions = { emit: vi.fn() };
     const logger = Object.assign(new TraceEmitter(), {
       error: vi.fn(),
       info: vi.fn(),
@@ -774,6 +747,8 @@ describe('ToolUseWaitNode', () => {
     const services = createWaitNodeServices({
       isSubagent: false,
       logger,
+      ownerSession,
+      streamId,
       session: {
         waitForFollowUp,
       },
@@ -781,13 +756,12 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.CANCELLED);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.CANCELLED,
+      });
 
-      const exec = await withTestRunContext(
-        interactions,
-        streamId,
-        () => node.exec(waitPrep(true)),
-        { session: ownerSession },
+      const exec = await withTestRunContext(services.runScope, () =>
+        node.exec(waitPrep(true)),
       );
 
       expect(exec.kind).toBe('stop');
@@ -833,7 +807,6 @@ describe('ToolUseWaitNode', () => {
     );
     const sequence: string[] = [];
     const info = vi.fn(() => sequence.push('info'));
-    const interactions = { emit: vi.fn() };
     const streamId = 'test-stream' as StreamTabId;
     const logger = Object.assign(new TraceEmitter(), {
       error: vi.fn(),
@@ -842,7 +815,7 @@ describe('ToolUseWaitNode', () => {
     const recorded = recordRunEvents(logger, streamId, (event) => {
       if (event.type === 'status') sequence.push('status');
     });
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     const ownerSession = sessionWithInteractions(undefined, streamStatus);
     const services = createWaitNodeServices({
       logger,
@@ -850,6 +823,8 @@ describe('ToolUseWaitNode', () => {
         capabilities: { supportsVision: true },
         createUserFollowUpMessages,
       },
+      ownerSession,
+      streamId,
       session: {
         hasQueuedFollowUp: () => true,
         waitForFollowUp: async () => ({
@@ -868,18 +843,18 @@ describe('ToolUseWaitNode', () => {
       },
     });
     const node = new ToolUseWaitNode().setServices(services);
-    seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.WAITING);
+    seedStreamStatusForTest(streamStatus, streamId, {
+      phase: STREAM_PHASE.WAITING,
+    });
 
     const prep = await node.prep(shared);
     try {
       const transition = await withTestRunContext(
-        interactions,
-        streamId,
+        services.runScope,
         async () => {
           const exec = await node.exec(prep);
           return node.post(shared, prep, exec);
         },
-        { session: ownerSession },
       );
 
       expect(transition).toBe(FlowTransition.CONTINUE);
@@ -930,7 +905,6 @@ describe('ToolUseWaitNode', () => {
       message: 'stale failure from the previous cycle',
       userRetryable: false,
     };
-    const interactions = { emit: vi.fn() };
     const setApprovalBypassState = vi.fn();
     const ownerSession = sessionWithInteractions({
       setApprovalBypassState,
@@ -939,7 +913,8 @@ describe('ToolUseWaitNode', () => {
     const batch = [{ text: 'try the other lemma', origin: 'user' as const }];
     const services = createWaitNodeServices({
       isSubagent: true,
-      runScope: testRunScope(streamId),
+      ownerSession,
+      streamId,
       modelHandler: {
         createUserFollowUpMessages: vi.fn(
           async (
@@ -956,13 +931,11 @@ describe('ToolUseWaitNode', () => {
       expect(prep.afterError).toBe(true);
 
       const { exec, transition } = await withTestRunContext(
-        interactions,
-        streamId,
+        services.runScope,
         async () => {
           const exec = await node.exec(prep);
           return { exec, transition: await node.post(shared, prep, exec) };
         },
-        { session: ownerSession },
       );
 
       expect(exec).toEqual({
@@ -991,7 +964,6 @@ describe('ToolUseWaitNode', () => {
       message: 'stale failure from the previous cycle',
       userRetryable: false,
     };
-    const interactions = { emit: vi.fn() };
     const setApprovalBypassState = vi.fn();
     const ownerSession = sessionWithInteractions({
       setApprovalBypassState,
@@ -1001,7 +973,8 @@ describe('ToolUseWaitNode', () => {
     const batch = [{ text: 'use this diagram', origin: 'user' as const }];
     const services = createWaitNodeServices({
       isSubagent: true,
-      runScope: testRunScope(streamId),
+      ownerSession,
+      streamId,
       modelHandler: {
         createUserFollowUpMessages: vi.fn(async () => {
           throw applicationError;
@@ -1012,19 +985,13 @@ describe('ToolUseWaitNode', () => {
 
     try {
       const prep = await node.prep(shared);
-      const exec = await withTestRunContext(
-        interactions,
-        streamId,
-        () => node.exec(prep),
-        { session: ownerSession },
+      const exec = await withTestRunContext(services.runScope, () =>
+        node.exec(prep),
       );
 
       await expect(
-        withTestRunContext(
-          interactions,
-          streamId,
-          () => node.post(shared, prep, exec),
-          { session: ownerSession },
+        withTestRunContext(services.runScope, () =>
+          node.post(shared, prep, exec),
         ),
       ).rejects.toBe(applicationError);
 
@@ -1050,7 +1017,6 @@ describe('ToolUseWaitNode', () => {
   it('still stops a subagent after an error when no batch was drained', async () => {
     const shared: ToolUseRunShared = toolUseRunShared();
     shared.lastError = { message: 'boom', userRetryable: false };
-    const interactions = { emit: vi.fn() };
     const waitForFollowUp = vi.fn();
     const services = createWaitNodeServices({
       isSubagent: true,
@@ -1059,7 +1025,7 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     const prep = await node.prep(shared);
-    const exec = await withTestRunContext(interactions, 'test-stream', () =>
+    const exec = await withTestRunContext(services.runScope, () =>
       node.exec(prep),
     );
 

--- a/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
@@ -66,8 +66,7 @@ function runPost(
 ): Promise<unknown> {
   const node = new ToolUseWaitNode().setServices(services);
   const shared: ToolUseRunShared = toolUseRunShared();
-  const interactions = { emit: vi.fn() };
-  return withTestRunContext(interactions, 'test-stream', () =>
+  return withTestRunContext(services.runScope, () =>
     node.post(shared, PREP_RES, execRes),
   );
 }

--- a/src/test-kernel/agent/modelHandlers/AnthropicToolAttachmentUploadPolicy.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicToolAttachmentUploadPolicy.vitest.ts
@@ -88,4 +88,50 @@ describe('anthropicTools.uploadToolAttachments attachment failure policy (#7465)
       'the failure should be reported through the shared policy owner',
     );
   });
+
+  it('uploads an unreadable PDF without a page count and warns about the skipped budget check', async () => {
+    const { logger, warnMessages } = createWarningRecorder();
+
+    const attachments: ToolFileAttachment[] = [
+      {
+        path: 'corrupt.pdf',
+        mimeType: 'application/pdf',
+        bytes: new Uint8Array([1, 2, 3]),
+      },
+    ];
+
+    const client = {
+      beta: {
+        files: {
+          upload: async () => ({ id: 'file_pdf' }),
+        },
+      },
+    } as any;
+
+    const pageCounts: Array<[string, number]> = [];
+    const result = await uploadToolAttachments(
+      client,
+      attachments,
+      logger,
+      0,
+      (fileId, pageCount) => pageCounts.push([fileId, pageCount]),
+      100,
+    );
+
+    assert.equal(
+      result.uploaded.length,
+      1,
+      'an unparseable PDF still uploads so the API can enforce its own limit',
+    );
+    assert.equal(result.pageLimitExceeded.length, 0);
+    assert.equal(
+      pageCounts.length,
+      0,
+      'no page count is reported when the PDF cannot be parsed',
+    );
+    assert.ok(
+      warnMessages.some((m) => m.includes('corrupt.pdf')),
+      'the skipped local page-limit check must be logged, not silent',
+    );
+  });
 });

--- a/src/test-kernel/agent/modelHandlers/AnthropicToolAttachmentUploadPolicy.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicToolAttachmentUploadPolicy.vitest.ts
@@ -1,6 +1,6 @@
 // Standard library imports
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 // Local imports - agent
 import { noopTrace, type AgentTrace } from '@agent/trace';
@@ -118,20 +118,18 @@ describe('anthropicTools.uploadToolAttachments attachment failure policy (#7465)
       100,
     );
 
-    assert.equal(
+    expect(
       result.uploaded.length,
-      1,
       'an unparseable PDF still uploads so the API can enforce its own limit',
-    );
-    assert.equal(result.pageLimitExceeded.length, 0);
-    assert.equal(
+    ).toBe(1);
+    expect(result.pageLimitExceeded.length).toBe(0);
+    expect(
       pageCounts.length,
-      0,
       'no page count is reported when the PDF cannot be parsed',
-    );
-    assert.ok(
+    ).toBe(0);
+    expect(
       warnMessages.some((m) => m.includes('corrupt.pdf')),
       'the skipped local page-limit check must be logged, not silent',
-    );
+    ).toBe(true);
   });
 });

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -606,47 +606,14 @@ describe('Google Interactions API routing', () => {
     );
   });
 
-  it('forces the Interactions handler for requiresInteractionsAPI models even with the flag off', async () => {
-    const factory = await initWithFlag(false);
-    const forced = {
-      ...googleConfig(),
-      requiresInteractionsAPI: true,
-    } as ModelConfig;
-    expect(factory.shouldUseGoogleInteractionsAPI(forced, false)).toBe(true);
-  });
-
-  it('never routes a flag-enabled (non-required) Google model to Interactions via OpenRouter', async () => {
+  it('never routes a Google model to Interactions via OpenRouter', async () => {
     const factory = await initWithFlag(true);
     expect(factory.shouldUseGoogleInteractionsAPI(googleConfig(), true)).toBe(
       false,
     );
-  });
-
-  it('keeps the routing predicate + key derivation pure (no throw) for Interactions-only under OpenRouter', async () => {
-    const factory = await initWithFlag(true);
-    const forced = {
-      ...googleConfig(),
-      requiresInteractionsAPI: true,
-    } as ModelConfig;
-    // The predicate must not throw — key-derivation callers (history restore,
-    // modelSwitchDisabledReason) rely on string|undefined, never an exception.
-    expect(factory.shouldUseGoogleInteractionsAPI(forced, true)).toBe(false);
-    expect(factory.modelHandlerCompatibilityKey(forced, true, false)).toBe(
-      'ModelHandlerOpenRouterNative',
-    );
-  });
-
-  it('createModelHandler fails loudly for an Interactions-only model under active OpenRouter', async () => {
-    // OpenRouter cannot proxy Interactions — the live-routing path must error
-    // rather than silently route to OpenRouter (spec §6.3).
-    const factory = await initWithFlag(true, /* useOpenRouter */ true);
-    const forced = {
-      ...googleConfig(),
-      requiresInteractionsAPI: true,
-    } as ModelConfig;
-    await expect(factory.createModelHandler(forced)).rejects.toThrow(
-      /OpenRouter/,
-    );
+    expect(
+      factory.modelHandlerCompatibilityKey(googleConfig(), true, false),
+    ).toBe('ModelHandlerOpenRouterNative');
   });
 
   it('exposes the Interactions compatibility key for history-restore parity', async () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -89,6 +89,12 @@ function createAnthropicHandler(
   );
 }
 
+/**
+ * Client stand-in for follow-up tests whose calls carry no attachments, so no
+ * SDK member is ever reached.
+ */
+const NO_UPLOAD_CLIENT = {} as never;
+
 /** A minimal single-turn "hello" user message, the shape most tests need. */
 function helloMessages(): MessageParam[] {
   return [
@@ -592,7 +598,7 @@ describe('ModelHandlerAnthropic message guards', () => {
     } as const;
 
     const [, resultMsg] = await handler.createToolUseFollowUpMessages(
-      undefined,
+      NO_UPLOAD_CLIENT,
       providerCall,
       { status: 'executed', output: 'ok' },
       [],
@@ -634,6 +640,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       ],
       undefined,
       'analysis',
+      NO_UPLOAD_CLIENT,
     );
 
     assert.equal(messages.length, 2);

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -1,5 +1,3 @@
-import { strict as assert } from 'node:assert';
-
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
@@ -448,10 +446,10 @@ describe('toOpenAITools additional coverage', () => {
     ];
 
     const tools = toOpenAITools(defs);
-    assert.equal(tools.length, 1);
-    assert.equal(tools[0].type, 'function');
-    assert.equal(tools[0].function.name, 'delegate_workflow');
-    assert.equal(tools[0].function.strict, undefined);
+    expect(tools.length).toBe(1);
+    expect(tools[0].type).toBe('function');
+    expect(tools[0].function.name).toBe('delegate_workflow');
+    expect(tools[0].function.strict).toBe(undefined);
   });
 });
 
@@ -471,11 +469,11 @@ describe('toOpenAIResponseTools', () => {
     ];
 
     const tools = toOpenAIResponseTools(defs);
-    assert.equal(tools.length, 1);
+    expect(tools.length).toBe(1);
     const tool = tools[0] as FunctionTool;
-    assert.equal(tool.type, 'function');
-    assert.equal(tool.name, 'echo');
-    assert.deepEqual(tool.parameters, defs[0].parameters);
+    expect(tool.type).toBe('function');
+    expect(tool.name).toBe('echo');
+    expect(tool.parameters).toStrictEqual(defs[0].parameters);
   });
 
   // web_search collapses to the native WebSearchTool when (and only when) the
@@ -501,8 +499,8 @@ describe('toOpenAIResponseTools', () => {
     },
   ])('$label', ({ defs, options }) => {
     const tools = toOpenAIResponseTools(defs as ToolDefinition[], options);
-    assert.equal(tools.length, 1);
-    assert.equal(tools[0].type, 'web_search');
+    expect(tools.length).toBe(1);
+    expect(tools[0].type).toBe('web_search');
   });
 
   // Any tool stays a plain function tool when native web search is off, which is
@@ -530,10 +528,10 @@ describe('toOpenAIResponseTools', () => {
     const tools = options
       ? toOpenAIResponseTools(defs, options)
       : toOpenAIResponseTools(defs);
-    assert.equal(tools.length, 1);
+    expect(tools.length).toBe(1);
     const tool = tools[0] as FunctionTool;
-    assert.equal(tool.type, 'function');
-    assert.equal(tool.name, def.name);
+    expect(tool.type).toBe('function');
+    expect(tool.name).toBe(def.name);
   });
 
   it('keeps a shadowing web_search definition as a function tool', () => {
@@ -548,9 +546,9 @@ describe('toOpenAIResponseTools', () => {
       { supportsNativeWebSearch: true },
     );
 
-    assert.equal(tools.length, 1);
-    assert.equal(tools[0].type, 'function');
-    assert.equal((tools[0] as FunctionTool).name, 'web_search');
+    expect(tools.length).toBe(1);
+    expect(tools[0].type).toBe('function');
+    expect((tools[0] as FunctionTool).name).toBe('web_search');
   });
 
   it('filters out function tools when supportsFunctionCalling is false', () => {
@@ -566,7 +564,7 @@ describe('toOpenAIResponseTools', () => {
     const tools = toOpenAIResponseTools(defs, {
       supportsFunctionCalling: false,
     });
-    assert.equal(tools.length, 0);
+    expect(tools.length).toBe(0);
   });
 });
 
@@ -577,7 +575,7 @@ describe('toGoogleTools', () => {
 
   it('returns empty array for empty input', () => {
     const tools = toGoogleTools([]);
-    assert.deepEqual(tools, []);
+    expect(tools).toStrictEqual([]);
   });
 
   // Every tool (including web_search) becomes a function declaration wrapped in a
@@ -616,12 +614,11 @@ describe('toGoogleTools', () => {
     },
   ])('$label', ({ defs, names }) => {
     const tools = toGoogleTools(defs as ToolDefinition[]);
-    assert.equal(tools.length, 1);
+    expect(tools.length).toBe(1);
     const tool = tools[0] as GeminiTool;
-    assert.equal(tool.googleSearch, undefined);
-    assert.ok(tool.functionDeclarations);
-    assert.deepEqual(
-      tool.functionDeclarations?.map((fd) => fd.name),
+    expect(tool.googleSearch).toBe(undefined);
+    expect(tool.functionDeclarations).toBeTruthy();
+    expect(tool.functionDeclarations?.map((fd) => fd.name)).toStrictEqual(
       names,
     );
   });
@@ -657,23 +654,23 @@ describe('toGoogleTools', () => {
     const params = tool.functionDeclarations?.[0]
       .parametersJsonSchema as Record<string, unknown>;
 
-    assert.equal(params.type, 'object');
-    assert.equal(params.oneOf, undefined);
-    assert.equal(params.anyOf, undefined);
-    assert.equal(params.allOf, undefined);
+    expect(params.type).toBe('object');
+    expect(params.oneOf).toBe(undefined);
+    expect(params.anyOf).toBe(undefined);
+    expect(params.allOf).toBe(undefined);
 
     const properties = params.properties as Record<
       string,
       Record<string, unknown>
     >;
     // Discriminator collapses literal branches into an enum.
-    assert.deepEqual(properties.command.enum, ['ask', 'read', 'list']);
-    assert.equal(properties.command.type, 'string');
+    expect(properties.command.enum).toStrictEqual(['ask', 'read', 'list']);
+    expect(properties.command.type).toBe('string');
     // Branch-specific props are merged in.
-    assert.ok(properties.question);
-    assert.ok(properties.thread_id);
-    assert.ok(properties.status);
+    expect(properties.question).toBeTruthy();
+    expect(properties.thread_id).toBeTruthy();
+    expect(properties.status).toBeTruthy();
     // Only command is required by every branch.
-    assert.deepEqual(params.required, ['command']);
+    expect(params.required).toStrictEqual(['command']);
   });
 });

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -47,7 +47,6 @@ function createAgentLocation(path: string): AgentFileLocation {
 
 const emptyXmlSummary: OutputXmlSummary = {
   tagContents: {},
-  documents: [],
   singleOutputFile: null,
   sourceLocation: null,
 };
@@ -192,8 +191,7 @@ describe('output progress events', () => {
     const shared = { roundOutputs: [] } as unknown as ReflectionFlowShared;
     try {
       const transition = await withTestRunContext(
-        host,
-        'stream:output-node',
+        outputNode.services.runScope,
         () =>
           outputNode.post(
             shared,
@@ -247,7 +245,7 @@ describe('output progress events', () => {
       createCompileFailureFixture();
     const shared = { roundOutputs: [] } as unknown as ReflectionFlowShared;
 
-    await withTestRunContext(host, 'stream:compile-context', () =>
+    await withTestRunContext(outputNode.services.runScope, () =>
       outputNode.post(
         shared,
         {
@@ -286,7 +284,7 @@ describe('output progress events', () => {
       createCompileFailureFixture();
     const shared = { roundOutputs: [] } as unknown as ReflectionFlowShared;
 
-    await withTestRunContext(host, 'stream:compile-context-disabled', () =>
+    await withTestRunContext(outputNode.services.runScope, () =>
       outputNode.post(
         shared,
         {
@@ -324,7 +322,7 @@ describe('output progress events', () => {
       },
     } as unknown as ReflectionFlowShared;
 
-    await withTestRunContext(host, 'stream:compile-context-ok', () =>
+    await withTestRunContext(outputNode.services.runScope, () =>
       outputNode.post(
         shared,
         {

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -37,7 +37,6 @@ function createRoundData(round: number): RoundOutput {
     compileFailures: [],
     xmlSummary: {
       tagContents: {},
-      documents: [],
       singleOutputFile: null,
       sourceLocation: null,
     },

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -23,11 +23,11 @@ import {
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { createRunScope, type RunScope } from '@agent/runtime/RunScope';
 import { ModelRetryGate } from '@agent/runtime/ModelRetryGate';
-import type {
-  SessionEvent,
+import {
   SessionEventHub,
-  SessionEventSubscriptionFilter,
-  SessionFact,
+  type SessionEvent,
+  type SessionEventSubscriptionFilter,
+  type SessionFact,
 } from '@agent/runtime/SessionEventHub';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
@@ -405,7 +405,7 @@ export function sessionWithInteractions(
     | SessionHostInteractions
     | Pick<SessionHostInteractions, 'emit'>
     | undefined,
-  status = new StreamStatusMachine(),
+  status = new StreamStatusMachine(new SessionEventHub()),
 ): SessionHandle {
   const owner =
     interactions instanceof SessionHostInteractions
@@ -429,8 +429,9 @@ export function sessionWithInteractions(
 
 /**
  * The `RunScope` a flow-services fixture must carry, since nodes read run
- * identity from `services.runScope`. Same shape {@link withTestRunContext}
- * installs ambiently — pass one `session` to both so they agree.
+ * identity from `services.runScope`. Pass the same object to
+ * {@link withTestRunContext} so the ambient context and the services bag name
+ * one scope, as production does.
  */
 export function testRunScope(
   streamId: string,
@@ -452,31 +453,24 @@ export function testRunScope(
 }
 
 /**
- * Run `fn` inside a launch `RunContext` carrying `interactions`/`streamId`.
+ * Run `fn` inside a launch `RunContext` built on `runScope`.
  *
- * Most flow nodes now read run identity from `services.runScope`; the reads
- * still on the ambient context need the launch scope installed — production
- * always runs them inside `withExecutionRunContext`, which always projects a
- * `launch` context. Tests calling a node's `exec`/`post` directly need the
- * same scope. Pass `session` so it matches the one on the services bag.
+ * Flow nodes read run identity from `services.runScope` and read the remaining
+ * ambient-only fields (`stopAfterCycle`, tool availability) off this context.
+ * Production installs the run's one scope on both, so a test that also builds
+ * services must pass `services.runScope` here rather than a second scope.
  */
 export function withTestRunContext<T>(
-  interactions: SessionHostInteractions | Pick<SessionHostInteractions, 'emit'>,
-  streamId: string,
+  runScope: RunScope,
   fn: () => Promise<T>,
   options: {
     approvalPromptsUnavailable?: boolean;
     runtimeUnavailableTools?: readonly string[];
-    session?: SessionHandle;
     stopAfterCycle?: boolean;
   } = {},
 ): Promise<T> {
-  const { session, ...contextOptions } = options;
   return withRunContext(
-    createRunContext({
-      runScope: testRunScope(streamId, { interactions, session }),
-      ...contextOptions,
-    }),
+    createRunContext({ runScope, ...options }),
     fn,
   ) as Promise<T>;
 }

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -12,6 +12,7 @@ import {
   inspectExecutionLease,
   releaseOwnedExecutionLease,
 } from '@agent/storage/executionLease';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
   AgentExecutionHandle,
@@ -36,7 +37,7 @@ import {
   RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_PHASE,
-  STREAM_STATUS,
+  STREAM_SUBSTATE,
   type ExecutionId,
   type RunOutcome,
   type StreamTabId,
@@ -379,7 +380,9 @@ describe('runFlowWithLifecycle', () => {
     );
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.FAILED);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.FAILED,
+      });
 
       await runFlowWithLifecycle(ctx, async () => {
         expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
@@ -398,7 +401,10 @@ describe('runFlowWithLifecycle', () => {
     );
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RESUMING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+        substate: STREAM_SUBSTATE.RESUMING,
+      });
 
       await runFlowWithLifecycle(ctx, async () => {
         expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
@@ -421,7 +427,9 @@ describe('runFlowWithLifecycle', () => {
       scope: 'session',
     });
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.RUNNING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
 
       await runFlowWithLifecycle(ctx, async () => {
         expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
@@ -671,7 +679,9 @@ describe('runFlowWithLifecycle', () => {
     let terminalResult: AgentRunHandle['result'] | undefined;
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.COMPLETED);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.COMPLETED,
+      });
 
       const result = await runFlowWithLifecycle(
         ctx,
@@ -1082,7 +1092,9 @@ describe('runFlowWithLifecycle', () => {
     const onError = vi.fn();
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
 
       const result = await runFlowWithLifecycle(
         ctx,
@@ -1207,7 +1219,7 @@ function finalizeFixture(slug: string): {
   return {
     executionId,
     streamId,
-    streamStatus: new StreamStatusMachine(),
+    streamStatus: new StreamStatusMachine(new SessionEventHub()),
     handle: testExecutionHandle({
       executionId,
       parentStreamId: streamId,
@@ -1245,7 +1257,9 @@ describe('finalizeRunTerminal', () => {
     );
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.RUNNING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
       const params = {
         handle,
         executions: { untrack },
@@ -1307,7 +1321,9 @@ describe('finalizeRunTerminal', () => {
     });
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.RUNNING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
       const finalization = finalizeRunTerminal({
         handle,
         executions: { untrack },
@@ -1347,7 +1363,9 @@ describe('finalizeRunTerminal', () => {
     channelTraceMocks.warn.mockClear();
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.RUNNING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
 
       const event = await finalizeRunTerminal({
         handle,
@@ -1399,7 +1417,9 @@ describe('finalizeRunTerminal', () => {
     channelTraceMocks.warn.mockClear();
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.CANCELLED);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.CANCELLED,
+      });
 
       const finalized = await finalizeRunTerminal({
         handle,
@@ -1447,7 +1467,9 @@ describe('finalizeRunTerminal', () => {
     channelTraceMocks.warn.mockClear();
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.FAILED);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.FAILED,
+      });
 
       const finalized = await finalizeRunTerminal({
         handle,

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -26,6 +26,7 @@ import {
   RUN_OUTCOME,
   STREAM_PHASE,
   STREAM_STATUS,
+  STREAM_SUBSTATE,
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
@@ -162,7 +163,7 @@ describe('executionRegistry', () => {
   it('settles without persisting a stopped waiting handle after lease loss', async () => {
     const events = new SessionEventHub();
     const streamStatus = new StreamStatusMachine(events);
-    const registry = new ExecutionRegistry({ streamStatus });
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const executionId = 'exec-waiting-lease-lost' as ExecutionId;
     const streamId = 'stream-waiting-lease-lost' as StreamTabId;
     const handle = createHandle(executionId, streamId, streamId);
@@ -172,7 +173,9 @@ describe('executionRegistry', () => {
       registry.track(handle);
       handle.suspend(() => {});
       handle.markExecutionLeaseLost();
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.WAITING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
 
       expect(registry.kill(executionId)).toBe(true);
       await expect(handle.result).resolves.toMatchObject({
@@ -230,8 +233,9 @@ describe('executionRegistry', () => {
     // ordinary resumable agent execution (e.g. a native subagent loop, whose
     // own loop-level interrupt handler must stay untouched so restart recovery
     // can resume it). Drain must reach only the former.
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const bashExecutionId = 'exec-background-bash-drain-test';
     const bashParentStreamId =
       'parent-background-bash-drain-test' as StreamTabId;
@@ -292,8 +296,9 @@ describe('executionRegistry', () => {
   });
 
   it('uses the handle interrupt target when terminating agent handles', () => {
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const executionId = 'exec-injected-interrupt-test';
     const parentStreamId = 'parent-injected-interrupt-test' as StreamTabId;
     const childStreamId = 'child-injected-interrupt-test' as StreamTabId;
@@ -319,8 +324,9 @@ describe('executionRegistry', () => {
     // stays tracked for resume. With no interrupt target left, terminate()
     // must fall back to the parked teardown rather than no-op and strand the
     // handle registered forever.
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const executionId = 'exec-waiting-cleanup-kill-test';
     const parentStreamId = 'parent-waiting-cleanup-kill-test' as StreamTabId;
     const childStreamId = 'child-waiting-cleanup-kill-test' as StreamTabId;
@@ -333,11 +339,9 @@ describe('executionRegistry', () => {
       // No handle interrupt target: mirrors a suspended subagent whose live
       // tool-use session has already been disposed. The stream phase follows
       // the same suspension, as it does in production.
-      seedStreamStatusForTest(
-        streamStatus,
-        childStreamId,
-        STREAM_STATUS.WAITING,
-      );
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
 
       expect(registry.kill(executionId)).toBe(true);
       await handle.result;
@@ -363,11 +367,8 @@ describe('executionRegistry', () => {
     const events = new SessionEventHub();
     const streamStatus = new StreamStatusMachine(events);
     const publishResult = vi.fn();
-    const registry = new ExecutionRegistry({
-      streamStatus,
-      events,
-      publishResult,
-    });
+    const registry = new ExecutionRegistry({ streamStatus, events });
+    registry.attachSessionEvents(events, publishResult);
     const executionId = 'exec-waiting-kill-publish-result-test';
     const parentStreamId =
       'parent-waiting-kill-publish-result-test' as StreamTabId;
@@ -388,11 +389,9 @@ describe('executionRegistry', () => {
       registry.track(handle);
       handle.suspend(() => {});
       // Genuinely suspended: only `transitionToWaiting` reaches this status.
-      seedStreamStatusForTest(
-        streamStatus,
-        childStreamId,
-        STREAM_STATUS.WAITING,
-      );
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
 
       expect(registry.kill(executionId)).toBe(true);
       await handle.result;
@@ -428,10 +427,12 @@ describe('executionRegistry', () => {
   });
 
   it('publishes a waiting cancellation after its transcript cleanup settles', async () => {
-    const streamStatus = new StreamStatusMachine();
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
     const order: string[] = [];
     const publishResult = vi.fn(() => order.push('publish'));
-    const registry = new ExecutionRegistry({ streamStatus, publishResult });
+    const registry = new ExecutionRegistry({ streamStatus, events });
+    registry.attachSessionEvents(events, publishResult);
     const executionId = 'exec-waiting-cleanup-order' as ExecutionId;
     const childStreamId = 'child-waiting-cleanup-order' as StreamTabId;
     let finishCleanup = (): void => undefined;
@@ -450,11 +451,9 @@ describe('executionRegistry', () => {
         await cleanupGate;
         order.push('cleanup');
       });
-      seedStreamStatusForTest(
-        streamStatus,
-        childStreamId,
-        STREAM_STATUS.WAITING,
-      );
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
 
       expect(registry.kill(executionId)).toBe(true);
       await Promise.resolve();
@@ -477,9 +476,11 @@ describe('executionRegistry', () => {
 
   it('hands a waiting stop to a successor tracked during cleanup', async () => {
     storageMocks.finalizeExecution.mockClear();
-    const streamStatus = new StreamStatusMachine();
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
     const publishResult = vi.fn();
-    const registry = new ExecutionRegistry({ streamStatus, publishResult });
+    const registry = new ExecutionRegistry({ streamStatus, events });
+    registry.attachSessionEvents(events, publishResult);
     const executionId = 'exec-waiting-stop-handoff' as ExecutionId;
     const childStreamId = 'child-waiting-stop-handoff' as StreamTabId;
     let finishCleanup = (): void => undefined;
@@ -495,11 +496,9 @@ describe('executionRegistry', () => {
       );
       registry.track(previous);
       previous.suspend(() => cleanupGate);
-      seedStreamStatusForTest(
-        streamStatus,
-        childStreamId,
-        STREAM_STATUS.WAITING,
-      );
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
 
       expect(registry.kill(executionId)).toBe(true);
 
@@ -529,8 +528,9 @@ describe('executionRegistry', () => {
   });
 
   it('does not let lost-generation recovery mutate a successor handle or lease', async () => {
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const releaseLease = vi.fn(async () => undefined);
     registry.attachRootExecutionLeaseRelease(releaseLease);
     const executionId = 'exec-waiting-lost-generation' as ExecutionId;
@@ -545,7 +545,9 @@ describe('executionRegistry', () => {
       });
       registry.track(previous);
       previous.suspend(() => undefined);
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.WAITING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
 
       expect(registry.kill(executionId)).toBe(true);
       const successor = createHandle(executionId, streamId, streamId);
@@ -561,13 +563,12 @@ describe('executionRegistry', () => {
   });
 
   it('settles waiting termination when detached publication throws', async () => {
-    const streamStatus = new StreamStatusMachine();
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
     const publishFailure = new Error('terminal subscriber failed');
-    const registry = new ExecutionRegistry({
-      streamStatus,
-      publishResult: () => {
-        throw publishFailure;
-      },
+    const registry = new ExecutionRegistry({ streamStatus, events });
+    registry.attachSessionEvents(events, () => {
+      throw publishFailure;
     });
     const executionId = 'exec-waiting-publication-failure' as ExecutionId;
     const childStreamId = 'child-waiting-publication-failure' as StreamTabId;
@@ -580,11 +581,9 @@ describe('executionRegistry', () => {
       );
       registry.track(handle);
       handle.suspend(() => {});
-      seedStreamStatusForTest(
-        streamStatus,
-        childStreamId,
-        STREAM_STATUS.WAITING,
-      );
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
 
       expect(registry.kill(executionId)).toBe(true);
       await expect(handle.result).resolves.toMatchObject({
@@ -599,8 +598,9 @@ describe('executionRegistry', () => {
   });
 
   it('settles and untracks a waiting handle when terminal metadata persistence fails', async () => {
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const executionId = 'exec-waiting-kill-metadata-failure' as ExecutionId;
     const parentStreamId =
       'parent-waiting-kill-metadata-failure' as StreamTabId;
@@ -618,11 +618,9 @@ describe('executionRegistry', () => {
       const handle = createHandle(executionId, parentStreamId, childStreamId);
       registry.track(handle);
       handle.suspend(() => {});
-      seedStreamStatusForTest(
-        streamStatus,
-        childStreamId,
-        STREAM_STATUS.WAITING,
-      );
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
 
       expect(registry.kill(executionId)).toBe(true);
 
@@ -652,8 +650,9 @@ describe('executionRegistry', () => {
   });
 
   it('persists a waiting stop after transcript cleanup fails', async () => {
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const executionId = 'exec-waiting-cleanup-failure' as ExecutionId;
     const parentStreamId = 'parent-waiting-cleanup-failure' as StreamTabId;
     const childStreamId = 'child-waiting-cleanup-failure' as StreamTabId;
@@ -669,11 +668,9 @@ describe('executionRegistry', () => {
       const handle = createHandle(executionId, parentStreamId, childStreamId);
       registry.track(handle);
       handle.suspend(() => Promise.reject(cleanupError));
-      seedStreamStatusForTest(
-        streamStatus,
-        childStreamId,
-        STREAM_STATUS.WAITING,
-      );
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
 
       expect(registry.kill(executionId)).toBe(true);
 
@@ -695,8 +692,9 @@ describe('executionRegistry', () => {
   });
 
   it('persists a waiting stop when only flow-record deletion fails', async () => {
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const executionId = 'exec-waiting-kill-flow-delete-failure' as ExecutionId;
     const parentStreamId =
       'parent-waiting-kill-flow-delete-failure' as StreamTabId;
@@ -715,11 +713,9 @@ describe('executionRegistry', () => {
       const handle = createHandle(executionId, parentStreamId, childStreamId);
       registry.track(handle);
       handle.suspend(() => {});
-      seedStreamStatusForTest(
-        streamStatus,
-        childStreamId,
-        STREAM_STATUS.WAITING,
-      );
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
 
       expect(registry.kill(executionId)).toBe(true);
 
@@ -752,8 +748,9 @@ describe('executionRegistry', () => {
     // or the fallback could spuriously tear down a handle mid-completion, in
     // the narrow window between its own interrupt unregister and its own
     // untrack.
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const executionId = 'exec-no-cleanup-kill-test';
     const parentStreamId = 'parent-no-cleanup-kill-test' as StreamTabId;
     const childStreamId = 'child-no-cleanup-kill-test' as StreamTabId;
@@ -776,8 +773,9 @@ describe('executionRegistry', () => {
     // projection of it. A stop landing in the narrow window between a live
     // turn's interrupt-handler detach and its own untrack must not abandon a
     // run that never parked, no matter what phase the stream currently shows.
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const executionId = 'exec-never-suspended-phase-only-test';
     const parentStreamId =
       'parent-never-suspended-phase-only-test' as StreamTabId;
@@ -787,11 +785,9 @@ describe('executionRegistry', () => {
     try {
       const handle = createHandle(executionId, parentStreamId, childStreamId);
       registry.track(handle);
-      seedStreamStatusForTest(
-        streamStatus,
-        childStreamId,
-        STREAM_STATUS.WAITING,
-      );
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
 
       expect(registry.kill(executionId)).toBe(false);
 
@@ -807,8 +803,9 @@ describe('executionRegistry', () => {
     // `finalizeRunTerminal` is parked at its persist await cannot run the
     // suspended teardown, publish a second `result`, or persist a second
     // terminal status over the finalizer's outcome.
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const executionId = 'exec-waiting-stop-after-claim' as ExecutionId;
     const childStreamId = 'child-waiting-stop-after-claim' as StreamTabId;
     const teardown = vi.fn();
@@ -834,11 +831,9 @@ describe('executionRegistry', () => {
       );
       registry.track(handle);
       handle.suspend(teardown);
-      seedStreamStatusForTest(
-        streamStatus,
-        childStreamId,
-        STREAM_STATUS.WAITING,
-      );
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
 
       const finalized = finalizeRunTerminal({
         handle,
@@ -877,8 +872,9 @@ describe('executionRegistry', () => {
     // own interrupt context. The handle it is resuming is still parked from
     // the earlier genuine WAITING suspension, so a kill landing in that window
     // tears it down off that fact alone — no phase or substate is consulted.
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const executionId = 'exec-resuming-window-kill-test' as ExecutionId;
     const parentStreamId = 'parent-resuming-window-kill-test' as StreamTabId;
     const childStreamId = 'child-resuming-window-kill-test' as StreamTabId;
@@ -907,11 +903,10 @@ describe('executionRegistry', () => {
       handle.suspend(cleanup);
       // Mirrors resumeQueuedToolUseFromResumeData's status flip that runs ahead of
       // the resumed run's own context — RUNNING phase, RESUMING substate.
-      seedStreamStatusForTest(
-        streamStatus,
-        childStreamId,
-        STREAM_STATUS.RESUMING,
-      );
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.RUNNING,
+        substate: STREAM_SUBSTATE.RESUMING,
+      });
 
       expect(registry.kill(executionId)).toBe(true);
       await handle.result;
@@ -984,8 +979,9 @@ describe('executionRegistry', () => {
   });
 
   it('interrupts grandchildren when killing a subagent chain', () => {
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const rootStreamId = 'root-cascade-test' as StreamTabId;
     const childStreamId = 'child-cascade-test' as StreamTabId;
     const grandchildStreamId = 'grandchild-cascade-test' as StreamTabId;
@@ -1156,8 +1152,9 @@ describe('executionRegistry', () => {
   });
 
   it('stops one child while preserving its owner, sibling, and agent descendants', () => {
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const rootStreamId = 'root-focused-stop-test' as StreamTabId;
     const childStreamId = 'child-focused-stop-test' as StreamTabId;
     const siblingStreamId = 'sibling-focused-stop-test' as StreamTabId;
@@ -1247,12 +1244,15 @@ describe('executionRegistry', () => {
   });
 
   it('leaves an already-terminal stream phase untouched', () => {
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const streamId = 'terminal-stop-policy-test' as StreamTabId;
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.COMPLETED);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.COMPLETED,
+      });
 
       registry.stopAgentStream(streamId);
 
@@ -1263,18 +1263,17 @@ describe('executionRegistry', () => {
   });
 
   it('reports agent status from its stream-status owner', () => {
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const parentStreamId = 'parent-owned-status-test' as StreamTabId;
     const childStreamId = 'child-owned-status-test' as StreamTabId;
     const executionId = 'exec-owned-status-test';
 
     try {
-      seedStreamStatusForTest(
-        streamStatus,
-        childStreamId,
-        STREAM_STATUS.WAITING,
-      );
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
       registry.track(createHandle(executionId, parentStreamId, childStreamId));
 
       expect(registry.getActiveChildren(parentStreamId)).toEqual([
@@ -1289,8 +1288,9 @@ describe('executionRegistry', () => {
   });
 
   it('publishes initial status when tracking an agent execution', () => {
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const parentStreamId = 'parent-track-agent-status-test' as StreamTabId;
     const childStreamId = 'child-track-agent-status-test' as StreamTabId;
     const executionId = 'exec-track-agent-status-test';
@@ -1314,8 +1314,9 @@ describe('executionRegistry', () => {
   });
 
   it('updates live agent status without reviving stopped or stale handles', () => {
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const parentStreamId = 'parent-update-agent-status-test' as StreamTabId;
     const childStreamId = 'child-update-agent-status-test' as StreamTabId;
     const executionId = 'exec-update-agent-status-test';
@@ -1329,11 +1330,9 @@ describe('executionRegistry', () => {
       ).toBe(true);
       expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.WAITING);
 
-      seedStreamStatusForTest(
-        streamStatus,
-        childStreamId,
-        STREAM_PHASE.CANCELLED,
-      );
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.CANCELLED,
+      });
       expect(registry.getActiveChildren(parentStreamId)).toEqual([
         expect.objectContaining({
           executionId,
@@ -1346,11 +1345,9 @@ describe('executionRegistry', () => {
       expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
 
       registry.untrack(executionId);
-      seedStreamStatusForTest(
-        streamStatus,
-        childStreamId,
-        STREAM_STATUS.WAITING,
-      );
+      seedStreamStatusForTest(streamStatus, childStreamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
       expect(
         registry.updateAgentExecutionStatus(handle, STREAM_STATUS.RUNNING),
       ).toBe(false);
@@ -1583,8 +1580,9 @@ describe('executionRegistry', () => {
   });
 
   it('owns tool-use follow-up admission from status, context, and children', () => {
-    const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const activeStreamId = 'stream-follow-up-active-test' as StreamTabId;
     const resumingStreamId = 'stream-follow-up-resuming-test' as StreamTabId;
     const waitingStreamId = 'stream-follow-up-waiting-test' as StreamTabId;
@@ -1613,52 +1611,43 @@ describe('executionRegistry', () => {
       );
       activeHandle.attachToolUseFlow(context);
       registry.track(activeHandle);
-      seedStreamStatusForTest(
-        streamStatus,
-        activeStreamId,
-        STREAM_STATUS.RUNNING,
-      );
+      seedStreamStatusForTest(streamStatus, activeStreamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
 
       expect(registry.getToolUseFollowUpTarget(activeStreamId)).toEqual({
         kind: 'active',
         context,
       });
 
-      seedStreamStatusForTest(
-        streamStatus,
-        resumingStreamId,
-        STREAM_STATUS.RESUMING,
-      );
+      seedStreamStatusForTest(streamStatus, resumingStreamId, {
+        phase: STREAM_PHASE.RUNNING,
+        substate: STREAM_SUBSTATE.RESUMING,
+      });
       expect(registry.getToolUseFollowUpTarget(resumingStreamId)).toEqual({
         kind: 'queue',
         reason: 'resuming',
       });
 
-      seedStreamStatusForTest(
-        streamStatus,
-        waitingStreamId,
-        STREAM_STATUS.WAITING,
-      );
+      seedStreamStatusForTest(streamStatus, waitingStreamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
       expect(registry.getToolUseFollowUpTarget(waitingStreamId)).toEqual({
         kind: 'queue',
         reason: 'waiting',
       });
 
-      seedStreamStatusForTest(
-        streamStatus,
-        stoppedStreamId,
-        STREAM_PHASE.CANCELLED,
-      );
+      seedStreamStatusForTest(streamStatus, stoppedStreamId, {
+        phase: STREAM_PHASE.CANCELLED,
+      });
       expect(registry.getToolUseFollowUpTarget(stoppedStreamId)).toEqual({
         kind: 'no_session',
         streamStatus: STREAM_PHASE.CANCELLED,
       });
 
-      seedStreamStatusForTest(
-        streamStatus,
-        parentStreamId,
-        STREAM_PHASE.CANCELLED,
-      );
+      seedStreamStatusForTest(streamStatus, parentStreamId, {
+        phase: STREAM_PHASE.CANCELLED,
+      });
       registry.track(
         createHandle(
           'exec-follow-up-child-test',

--- a/src/test-kernel/agent/runtime/RestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/RestartRepair.vitest.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { getExecutionStore } from '@agent/storage';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
   repairRestartedStreams,
@@ -101,7 +102,7 @@ describe('repairRestartedStreams', () => {
   it('skips every repair mutation for a fresh foreign lease', async () => {
     const streamId = 'stream-foreign-active' as StreamTabId;
     const executionId = 'execution-foreign-active' as ExecutionId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
     const closeRunningGroups = vi.fn(async () => [] as StreamTabId[]);
     const finalizeExecution = createDurableFinalizer();
@@ -140,7 +141,7 @@ describe('repairRestartedStreams', () => {
       terminalStatus: EXECUTION_STATUS.COMPLETED,
       outcome: RUN_OUTCOME.COMPLETED,
     });
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
     const closeRunningGroups = vi.fn(async () => [] as StreamTabId[]);
     const finalizeExecution = createDurableFinalizer();
@@ -176,7 +177,7 @@ describe('repairRestartedStreams', () => {
     const streamId = 'stream-unreadable-settlement' as StreamTabId;
     const executionId = 'execution-unreadable-settlement' as ExecutionId;
     const store = getExecutionStore(executionId);
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
     const readMetaStrict = vi
       .spyOn(store, 'readMetaStrict')
@@ -208,7 +209,7 @@ describe('repairRestartedStreams', () => {
       timestamp: '2026-07-26T00:00:00.000Z',
       terminalStatus: 'legacy-terminal',
     });
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
     const closeRunningGroups = vi.fn(async () => [streamId]);
     const finalizeExecution = createDurableFinalizer();
@@ -240,7 +241,7 @@ describe('repairRestartedStreams', () => {
   it('derives the lease identity when restart metadata has no execution mapping', async () => {
     const executionId = 'a8644a' as ExecutionId;
     const streamId = `tool@model#${executionId}` as StreamTabId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
     const runWithInactiveExecutionLease = vi.fn(async () => ({
       status: 'active' as const,
@@ -267,7 +268,7 @@ describe('repairRestartedStreams', () => {
   it('repairs resumable running streams to WAITING with neutral group closure', async () => {
     const streamId = 'stream-waiting' as StreamTabId;
     const executionId = 'execution-waiting' as ExecutionId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
     const closeRunningGroups = closeGroupsOn(RUN_OUTCOME.CANCELLED);
     const finalizeExecution = createDurableFinalizer();
@@ -300,7 +301,7 @@ describe('repairRestartedStreams', () => {
   it('repairs resumable streams without an in-memory phase and closes their groups', async () => {
     const streamId = 'stream-waiting-without-phase' as StreamTabId;
     const executionId = 'execution-waiting-without-phase' as ExecutionId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     const closeRunningGroups = closeGroupsOn(RUN_OUTCOME.CANCELLED);
     const finalizeExecution = createDurableFinalizer();
 
@@ -327,7 +328,7 @@ describe('repairRestartedStreams', () => {
   it('closes non-waiting candidates without an in-memory phase without terminalizing them', async () => {
     const streamId = 'stream-without-phase' as StreamTabId;
     const executionId = 'execution-without-phase' as ExecutionId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     const closeRunningGroups = closeGroupsOn(RUN_OUTCOME.FAILED);
     const finalizeExecution = createDurableFinalizer();
 
@@ -360,7 +361,7 @@ describe('repairRestartedStreams', () => {
   it('closes waiting groups even when the current phase is not repairable', async () => {
     const streamId = 'stream-terminal-waiting' as StreamTabId;
     const executionId = 'execution-terminal-waiting' as ExecutionId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
     streamStatus.transition(
       streamId,
@@ -399,7 +400,7 @@ describe('repairRestartedStreams', () => {
   it('repairs non-resumable running streams to FAILED and writes terminal meta', async () => {
     const streamId = 'stream-failed' as StreamTabId;
     const executionId = 'execution-failed' as ExecutionId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
     const closeRunningGroups = closeGroupsOn(RUN_OUTCOME.FAILED);
     const finalizeExecution = createDurableFinalizer();
@@ -436,7 +437,7 @@ describe('repairRestartedStreams', () => {
   it('does not write failed terminal meta before failed groups close', async () => {
     const streamId = 'stream-failed-close-error' as StreamTabId;
     const executionId = 'execution-failed-close-error' as ExecutionId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
     const finalizeExecution = createDurableFinalizer();
 
@@ -461,7 +462,7 @@ describe('repairRestartedStreams', () => {
     const secondStream = 'stream-abort-second' as StreamTabId;
     const firstExecution = 'execution-abort-first' as ExecutionId;
     const secondExecution = 'execution-abort-second' as ExecutionId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, firstStream);
     seedRunning(streamStatus, secondStream);
     const abort = new AbortController();
@@ -499,7 +500,7 @@ describe('repairRestartedStreams', () => {
   it('writes failed terminal meta when retrying an already failed repair', async () => {
     const streamId = 'stream-failed-retry' as StreamTabId;
     const executionId = 'execution-failed-retry' as ExecutionId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
     const finalizeExecution = createDurableFinalizer();
 
@@ -550,7 +551,7 @@ describe('repairRestartedStreams', () => {
   it('does not retry historical failed streams unless retry is requested', async () => {
     const streamId = 'stream-historical-failed' as StreamTabId;
     const executionId = 'execution-historical-failed' as ExecutionId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
     streamStatus.transition(
       streamId,
@@ -584,7 +585,7 @@ describe('repairRestartedStreams', () => {
   it('does not report terminal status when metadata persistence fails', async () => {
     const streamId = 'stream-metadata-failure' as StreamTabId;
     const executionId = 'execution-metadata-failure' as ExecutionId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
     const durabilityError = new Error('metadata disk write failed');
     const finalizeExecution = vi.fn(async () => ({
@@ -623,7 +624,7 @@ describe('repairRestartedStreams', () => {
   it('reports flow cleanup failure but keeps durable terminal metadata', async () => {
     const streamId = 'stream-flow-delete-failure' as StreamTabId;
     const executionId = 'execution-flow-delete-failure' as ExecutionId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
     const cleanupError = new Error('flow delete failed');
     const finalizeExecution = vi.fn(async () => ({
@@ -661,7 +662,7 @@ describe('repairRestartedStreams', () => {
   it('can terminalize stale WAITING streams through the resume choreography', async () => {
     const streamId = 'stream-stale-waiting' as StreamTabId;
     const executionId = 'execution-stale-waiting' as ExecutionId;
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedWaiting(streamStatus, streamId);
 
     await repairRestartedStreams({
@@ -696,7 +697,7 @@ describe('repairRestartedStreams', () => {
         cost: 0,
       },
     });
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
 
     const result = await repairRestartedStreams({
@@ -725,7 +726,7 @@ describe('repairRestartedStreams', () => {
     const streamId = `assistant#${executionId}` as StreamTabId;
     const store = getExecutionStore(executionId);
     await store.writeMeta({ timestamp: '2026-07-16T00:00:00.000Z' });
-    const streamStatus = new StreamStatusMachine();
+    const streamStatus = new StreamStatusMachine(new SessionEventHub());
     seedRunning(streamStatus, streamId);
 
     try {

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -95,7 +95,6 @@ interface ModelSwitchingFlowInput {
 function buildResumeContext(
   executionId: ExecutionId,
   streamId: StreamTabId,
-  usageMonitor: { setModelInfo: ReturnType<typeof vi.fn> },
 ): AgentLaunchContext {
   const abortController = new AbortController();
   return {
@@ -116,7 +115,7 @@ function buildResumeContext(
       transient: { MODEL: 'test-model' },
     },
     attachedMemoryMisses: [],
-    usageMonitor: { recordUsage: vi.fn(), ...usageMonitor },
+    usageMonitor: { recordUsage: vi.fn() },
     interrupt: () => abortController.abort(),
   } as unknown as AgentLaunchContext;
 }
@@ -152,9 +151,7 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
     });
     mocks.buildAgentLaunchContext.mockImplementationOnce(async () => {
       order.push('launch');
-      return buildResumeContext(executionId, streamId, {
-        setModelInfo: vi.fn(),
-      });
+      return buildResumeContext(executionId, streamId);
     });
     mocks.hasPersistedParent.mockResolvedValueOnce(true);
     mocks.runFlowWithLifecycle.mockImplementationOnce(
@@ -363,9 +360,7 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
   it('mirrors a mid-run model switch onto the persisted config only', async () => {
     const executionId = 'e9421-model' as ExecutionId;
     const streamId = 'stream-9421-model' as StreamTabId;
-    const ctx = buildResumeContext(executionId, streamId, {
-      setModelInfo: vi.fn(),
-    });
+    const ctx = buildResumeContext(executionId, streamId);
     mocks.buildAgentLaunchContext.mockResolvedValueOnce(ctx);
     mocks.hasPersistedParent.mockResolvedValueOnce(false);
     mocks.runFlowWithLifecycle.mockImplementationOnce(
@@ -400,7 +395,7 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
       userRetryable: true,
     };
     mocks.buildAgentLaunchContext.mockResolvedValueOnce(
-      buildResumeContext(executionId, streamId, { setModelInfo: vi.fn() }),
+      buildResumeContext(executionId, streamId),
     );
     mocks.hasPersistedParent.mockResolvedValueOnce(true);
     mocks.runFlowWithLifecycle.mockImplementationOnce(

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -88,13 +88,7 @@ interface TestFlowContext {
 }
 
 interface ModelSwitchingFlowInput {
-  onModelChanged: (
-    modelHandler: {
-      capabilities: Record<string, unknown>;
-      config: Record<string, unknown>;
-    },
-    model: string,
-  ) => void;
+  onModelChanged: (model: string) => void;
 }
 
 /** Minimal launch context for a resumed tool-use run that reaches the flow. */
@@ -366,11 +360,12 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
     ]);
   });
 
-  it('mirrors a mid-run model switch onto every launch-context view', async () => {
+  it('mirrors a mid-run model switch onto the persisted config only', async () => {
     const executionId = 'e9421-model' as ExecutionId;
     const streamId = 'stream-9421-model' as StreamTabId;
-    const setModelInfo = vi.fn();
-    const ctx = buildResumeContext(executionId, streamId, { setModelInfo });
+    const ctx = buildResumeContext(executionId, streamId, {
+      setModelInfo: vi.fn(),
+    });
     mocks.buildAgentLaunchContext.mockResolvedValueOnce(ctx);
     mocks.hasPersistedParent.mockResolvedValueOnce(false);
     mocks.runFlowWithLifecycle.mockImplementationOnce(
@@ -381,13 +376,7 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
     );
     mocks.runToolUseFlow.mockImplementationOnce(
       async (input: ModelSwitchingFlowInput) => {
-        input.onModelChanged(
-          {
-            capabilities: { supportsVision: true },
-            config: { provider: 'anthropic' },
-          },
-          'next-model',
-        );
+        input.onModelChanged('next-model');
         return { outcome: RUN_OUTCOME.COMPLETED };
       },
     );
@@ -396,14 +385,11 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
       createToolUseResumeData({ executionId, streamId }),
     );
 
-    expect(setModelInfo).toHaveBeenCalledWith({
-      capabilities: { supportsVision: true },
-      config: { provider: 'anthropic' },
-    });
-    // The flow's ModelCell is the live model; these mirrors would otherwise
-    // keep reporting the model the run started with.
+    // The cell is the live model: usage accounting and the prompt-side MODEL
+    // variable read it directly, so the only remaining mirror is the
+    // persisted AgentConfig schema field; the seeded transient stays as-is.
     expect(ctx.config.model).toBe('next-model');
-    expect(ctx.userVarChannels.transient.MODEL).toBe('next-model');
+    expect(ctx.userVarChannels.transient.MODEL).toBe('test-model');
   });
 
   it('carries a failed resumed flow result, error included, to the lifecycle', async () => {

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -32,6 +32,7 @@ import type { ModelCell } from '@agent/runtime/ModelCell';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { createRunScope, type RunScope } from '@agent/runtime/RunScope';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import type {
   ModelCredentialRoute,
@@ -190,7 +191,7 @@ function createRetryNode(
     sessionOverride ??
     sessionWithInteractions(
       { requestRetry, cancel: () => {} },
-      new StreamStatusMachine(),
+      new StreamStatusMachine(new SessionEventHub()),
     );
   const streamStatus = session.status;
   const node = new ExposedRetryNode().setServices(
@@ -460,7 +461,7 @@ describe('RetryState', () => {
     const requestRetry = vi.fn(async () => ({ action: 'retry' as const }));
     const session = sessionWithInteractions(
       { requestRetry, cancel: () => {} },
-      new StreamStatusMachine(),
+      new StreamStatusMachine(new SessionEventHub()),
     );
 
     class DiagnosticRetryNode extends ExposedRetryNode {
@@ -486,7 +487,9 @@ describe('RetryState', () => {
     );
 
     try {
-      seedStreamStatusForTest(session.status, streamId, STREAM_STATUS.RUNNING);
+      seedStreamStatusForTest(session.status, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
 
       await expect(node._exec(undefined)).resolves.toBe('recovered');
 
@@ -605,7 +608,7 @@ describe('RetryState', () => {
         }),
         cancel: () => {},
       },
-      new StreamStatusMachine(),
+      new StreamStatusMachine(new SessionEventHub()),
     );
 
     class ClientPreparationRetryNode extends ExposedRetryNode {
@@ -627,7 +630,9 @@ describe('RetryState', () => {
     );
 
     try {
-      seedStreamStatusForTest(session.status, streamId, STREAM_STATUS.RUNNING);
+      seedStreamStatusForTest(session.status, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
 
       await expect(node._exec(undefined)).resolves.toBe('recovered');
 
@@ -1433,7 +1438,9 @@ describe('RetryState', () => {
     requestRetry.mockResolvedValueOnce({ action: 'retry' });
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
 
       await withRetryRunContext(streamId, session, () =>
         node.promptFor(new Error('temporary provider failure')),
@@ -1469,7 +1476,9 @@ describe('RetryState', () => {
     node.seedPersistent401Guards();
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
 
       await expect(
         withRetryRunContext(streamId, session, () =>
@@ -1496,7 +1505,9 @@ describe('RetryState', () => {
     const streamStatus = session.status;
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
 
       const prompt = withRetryRunContext(streamId, session, () =>
         node.promptFor(new Error('temporary provider failure')),
@@ -1528,7 +1539,9 @@ describe('RetryState', () => {
     requestRetry.mockResolvedValueOnce({ action: 'cancel' });
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
 
       await withRetryRunContext(streamId, session, () =>
         node.promptFor(new Error('temporary provider failure')),
@@ -1552,7 +1565,9 @@ describe('RetryState', () => {
     const error = new Error('stream dropped before first token');
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
 
       const shouldRetry = await withRetryRunContext(streamId, session, () =>
         node.retryPrompt(undefined, error),

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -7,7 +7,6 @@ import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
   STREAM_PHASE,
-  STREAM_STATUS,
   STREAM_SUBSTATE,
   type StreamPhase,
   type StreamTabId,
@@ -48,11 +47,11 @@ describe('StreamStatusMachine', () => {
   ) as StreamTransitionCause[];
 
   it('keeps stream status state per instance', () => {
-    const first = new StreamStatusMachine();
-    const second = new StreamStatusMachine();
+    const first = new StreamStatusMachine(new SessionEventHub());
+    const second = new StreamStatusMachine(new SessionEventHub());
     const streamId = 'stream-status-instance-test' as StreamTabId;
 
-    seedStreamStatusForTest(first, streamId, STREAM_PHASE.WAITING);
+    seedStreamStatusForTest(first, streamId, { phase: STREAM_PHASE.WAITING });
 
     expect(first.get(streamId)).toBe(STREAM_PHASE.WAITING);
     expect(second.get(streamId)).toBeUndefined();
@@ -83,10 +82,10 @@ describe('StreamStatusMachine', () => {
     for (const from of [undefined, ...phases]) {
       for (const to of phases) {
         for (const cause of causes) {
-          const machine = new StreamStatusMachine();
+          const machine = new StreamStatusMachine(new SessionEventHub());
           const streamId =
             `stream-status-table:${from ?? 'none'}:${to}:${cause}` as StreamTabId;
-          if (from) seedStreamStatusForTest(machine, streamId, from);
+          if (from) seedStreamStatusForTest(machine, streamId, { phase: from });
 
           const accepted = machine.transition(streamId, to, cause);
 
@@ -100,7 +99,7 @@ describe('StreamStatusMachine', () => {
   });
 
   it('keeps reservations outside the transition table', () => {
-    const machine = new StreamStatusMachine();
+    const machine = new StreamStatusMachine(new SessionEventHub());
     const streamId = 'stream-status-reservation-test' as StreamTabId;
 
     expect(machine.tryAcquire(streamId)).toBe(true);
@@ -128,7 +127,9 @@ describe('StreamStatusMachine', () => {
       'stream-status-terminal-waiting-repair',
     );
 
-    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.CANCELLED);
+    seedStreamStatusForTest(machine, streamId, {
+      phase: STREAM_PHASE.CANCELLED,
+    });
 
     expect(machine.transitionToWaiting(streamId, 'restart-repair')).toBe(true);
 
@@ -159,7 +160,7 @@ describe('StreamStatusMachine', () => {
       `stream-status-waiting-terminal-${cause}`,
     );
 
-    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.WAITING);
+    seedStreamStatusForTest(machine, streamId, { phase: STREAM_PHASE.WAITING });
 
     expect(
       machine.transitionToTerminal(streamId, STREAM_PHASE.FAILED, cause),
@@ -220,7 +221,9 @@ describe('StreamStatusMachine', () => {
       'stream-status-matching-terminal',
     );
 
-    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.CANCELLED);
+    seedStreamStatusForTest(machine, streamId, {
+      phase: STREAM_PHASE.CANCELLED,
+    });
 
     expect(
       machine.transitionToTerminal(
@@ -239,7 +242,10 @@ describe('StreamStatusMachine', () => {
       'stream-status-clear-running-substate',
     );
 
-    seedStreamStatusForTest(machine, streamId, STREAM_STATUS.RESUMING);
+    seedStreamStatusForTest(machine, streamId, {
+      phase: STREAM_PHASE.RUNNING,
+      substate: STREAM_SUBSTATE.RESUMING,
+    });
 
     expect(machine.transition(streamId, STREAM_PHASE.RUNNING, 'resume')).toBe(
       true,
@@ -263,7 +269,7 @@ describe('StreamStatusMachine', () => {
       'stream-status-noop-running-resume',
     );
 
-    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.RUNNING);
+    seedStreamStatusForTest(machine, streamId, { phase: STREAM_PHASE.RUNNING });
 
     expect(machine.transition(streamId, STREAM_PHASE.RUNNING, 'resume')).toBe(
       true,
@@ -274,8 +280,8 @@ describe('StreamStatusMachine', () => {
     expect(statusEvents()).toEqual([]);
   });
 
-  it('rolls back reservation state identically with and without a hub', () => {
-    const hidden = new StreamStatusMachine();
+  it('rolls back reservation state identically with and without a subscriber', () => {
+    const hidden = new StreamStatusMachine(new SessionEventHub());
     const events = new SessionEventHub();
     const observed = new StreamStatusMachine(events);
     const published = recordSessionEvents(events, { scope: 'session' });
@@ -329,7 +335,9 @@ describe('StreamStatusMachine', () => {
       'stream-status-reservation-overlay',
     );
 
-    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.COMPLETED);
+    seedStreamStatusForTest(machine, streamId, {
+      phase: STREAM_PHASE.COMPLETED,
+    });
 
     expect(machine.tryAcquire(streamId)).toBe(true);
     expect(machine.get(streamId)).toBe(STREAM_PHASE.RUNNING);
@@ -337,7 +345,9 @@ describe('StreamStatusMachine', () => {
       machine.transition(streamId, STREAM_PHASE.RUNNING, 'lifecycle'),
     ).toBe(true);
 
-    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.COMPLETED);
+    seedStreamStatusForTest(machine, streamId, {
+      phase: STREAM_PHASE.COMPLETED,
+    });
     expect(machine.tryAcquire(streamId)).toBe(true);
     machine.releaseIfReserved(streamId);
 
@@ -414,7 +424,7 @@ describe('StreamStatusMachine', () => {
     );
     const trace = new TraceEmitter();
 
-    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.WAITING);
+    seedStreamStatusForTest(machine, streamId, { phase: STREAM_PHASE.WAITING });
 
     expect(
       machine.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {

--- a/src/test-kernel/agent/runtime/launchContextTestUtils.ts
+++ b/src/test-kernel/agent/runtime/launchContextTestUtils.ts
@@ -71,6 +71,10 @@ export function createTestLaunchContext({
   });
   const setting = AgentSettingSchema.parse({ agentCategory: category });
   const storageKey = executionId as StorageKey;
+  const modelCell = testModelCell(
+    { ...testModelInfo, dispose: vi.fn() },
+    config.model,
+  );
 
   return {
     config,
@@ -89,11 +93,11 @@ export function createTestLaunchContext({
     userVarChannels: { input: Object.freeze({}), transient: {} },
     attachedMemoryMisses: [],
     usageMonitor: new UsageMonitor(
-      testModelInfo,
+      modelCell,
       { logger, storageKey, streamId },
       { agentName: config.agent, agentCategory: setting.agentCategory },
     ),
-    modelCell: testModelCell({ dispose: vi.fn() }, config.model),
+    modelCell,
     interrupt: () => abortController.abort(),
     disposeTrace: vi.fn(),
   };

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -13,9 +13,10 @@ import {
   resolveAndResumeStream,
   type ResumeStreamPorts,
 } from '@agent/runtime/resolveAndResumeStream';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import { STREAM_PHASE, type StreamTabId } from '@shared/schemas';
 import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,
@@ -116,11 +117,9 @@ describe('resolveAndResumeStream', () => {
     // `resumeInFlight` (held here) cannot catch that, so the post-retrieval
     // re-check must bail before touching the resume ports.
     retrieveSessionResumeDataMock.mockImplementation(async () => {
-      seedStreamStatusForTest(
-        defaultSession().status,
-        STREAM,
-        STREAM_STATUS.RUNNING,
-      );
+      seedStreamStatusForTest(defaultSession().status, STREAM, {
+        phase: STREAM_PHASE.RUNNING,
+      });
       return createToolUseResumeData({ streamId: STREAM });
     });
     const ports = basePorts();
@@ -131,11 +130,9 @@ describe('resolveAndResumeStream', () => {
   });
 
   it('skips resume without resolving when the stream is already active', async () => {
-    seedStreamStatusForTest(
-      defaultSession().status,
-      STREAM,
-      STREAM_STATUS.RUNNING,
-    );
+    seedStreamStatusForTest(defaultSession().status, STREAM, {
+      phase: STREAM_PHASE.RUNNING,
+    });
     const ports = basePorts();
 
     await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
@@ -189,8 +186,10 @@ describe('resolveAndResumeStream', () => {
     // Desktop scenario: the window's own session machine has the stream
     // active while the process-global default is empty. The guard must read
     // the injected machine — before #7640 it read the global and never fired.
-    const windowStatus = new StreamStatusMachine();
-    seedStreamStatusForTest(windowStatus, STREAM, STREAM_STATUS.RUNNING);
+    const windowStatus = new StreamStatusMachine(new SessionEventHub());
+    seedStreamStatusForTest(windowStatus, STREAM, {
+      phase: STREAM_PHASE.RUNNING,
+    });
     const ports = basePorts({ streamStatus: windowStatus });
 
     await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
@@ -202,15 +201,15 @@ describe('resolveAndResumeStream', () => {
   it('ignores activity recorded only on a different session machine', async () => {
     // The inverse: activity on the process default must not block a resume in
     // a session whose own machine says the stream is idle.
-    seedStreamStatusForTest(
-      defaultSession().status,
-      STREAM,
-      STREAM_STATUS.RUNNING,
-    );
+    seedStreamStatusForTest(defaultSession().status, STREAM, {
+      phase: STREAM_PHASE.RUNNING,
+    });
     retrieveSessionResumeDataMock.mockResolvedValue(
       createToolUseResumeData({ streamId: STREAM }),
     );
-    const ports = basePorts({ streamStatus: new StreamStatusMachine() });
+    const ports = basePorts({
+      streamStatus: new StreamStatusMachine(new SessionEventHub()),
+    });
 
     await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(true);
     expect(ports.resumeToolUse).toHaveBeenCalled();

--- a/src/test-kernel/agent/utils/UsageMonitorLastTotals.vitest.ts
+++ b/src/test-kernel/agent/utils/UsageMonitorLastTotals.vitest.ts
@@ -9,6 +9,7 @@ import {
 } from '@agent/core/state/AgentState';
 import { recordNormalizedUsage } from '@agent/core/usage/RunUsageAccumulator';
 import { UsageMonitor } from '@agent/utils/UsageMonitor';
+import type { RunModelHandler } from '@agent/runtime/ModelCell';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import {
   AgentCategory,
@@ -21,6 +22,7 @@ import {
 } from '@telemetry/UsageLogService';
 
 // Local file imports
+import { testModelCell } from '../modelCellTestUtils';
 import { recordSessionEvents, runEventsOfType } from '../progressTestUtils';
 import { testModelInfo } from '../runtime/launchContextTestUtils';
 
@@ -33,13 +35,15 @@ function createMonitorWithEvents() {
   const detachTrace = logger.subscribe((event) =>
     hub.emit({ scope: 'run', streamId, event }),
   );
+  const modelCell = testModelCell({ ...testModelInfo, dispose: vi.fn() });
   const monitor = new UsageMonitor(
-    testModelInfo,
+    modelCell,
     { logger, storageKey, streamId },
     { agentName: 'assistant', agentCategory: AgentCategory.ToolUse },
   );
   return {
     monitor,
+    modelCell,
     logger,
     events: recorded.events,
     dispose: () => {
@@ -121,6 +125,40 @@ describe('UsageMonitor', () => {
         totalInputTokens: 10,
         totalOutputTokens: 2,
       });
+    } finally {
+      log.mockRestore();
+      dispose();
+    }
+  });
+
+  it('bills a round against the model the run switched to', async () => {
+    const { dispose, modelCell, monitor } = createMonitorWithEvents();
+    const log = vi.spyOn(UsageLogService, 'log').mockImplementation(() => {});
+    try {
+      modelCell.swap(
+        {
+          ...testModelInfo,
+          config: { ...testModelInfo.config, fullName: 'Switched Model' },
+          dispose: vi.fn(),
+        } as unknown as RunModelHandler,
+        'switched-model',
+      );
+
+      const state = AgentRunStateSnapshotSchema.parse({});
+      recordCycleMetrics(state, 50, {
+        inputTokens: 10,
+        outputTokens: 2,
+        cost: 0.01,
+        responseTimeMs: 50,
+        provider: 'openai' as const,
+      });
+      await monitor.recordUsage(state);
+
+      // Nothing pushes the new model in: the monitor reads the live handler
+      // out of the run's ModelCell on every round.
+      expect(log).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'Switched Model' }),
+      );
     } finally {
       log.mockRestore();
       dispose();

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -16,22 +16,24 @@ import type {
   HostRetryRequest,
 } from '@agent/runtime/HostInteractions';
 import { defaultSession } from '@agent/runtime/SessionHandle';
+import { createHeadlessCliHostInteractions } from '@cli/runtime/approvalAdapter';
+import type { CliContext } from '@cli/runtime/cliContext';
+import { CliExitCode } from '@cli/runtime/exitCodes';
+import { runOutcomeExitCode } from '@cli/runtime/terminalStatus';
 import {
   appendCliApiSwitchHint,
   approvalPromptAllowed,
-  createHeadlessCliHostInteractions,
-  formatAgentProposalApprovalSummary,
-  formatRetryRequestMessage,
-  formatToolEditApprovalSummary,
   hasCliApprovalDenied,
   humanInputDenialFeedback,
   immediateDecisionForApproval,
   isCliApiSwitchableRetry,
-} from '@cli/runtime/approvalAdapter';
-import type { CliContext } from '@cli/runtime/cliContext';
-import { CliExitCode } from '@cli/runtime/exitCodes';
-import { runOutcomeExitCode } from '@cli/runtime/terminalStatus';
-import type { CliApprovalPromptHooks } from '@cli/runtime/approval/approvalPolicy';
+  type CliApprovalPromptHooks,
+} from '@cli/runtime/approval/approvalPolicy';
+import {
+  formatAgentProposalApprovalSummary,
+  formatRetryRequestMessage,
+  formatToolEditApprovalSummary,
+} from '@cli/runtime/approval/approvalSummaries';
 import {
   AgentCategory,
   DEFAULT_TOOL_CONFIG,

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -746,6 +746,8 @@ describe('CLI run progress renderer', () => {
       const detach = host.attachRunProgressRenderer(events);
 
       events.emit(runConfigEvent());
+      // Out of the renderer's run-fact contract: the subscription filter keeps
+      // it away from the renderer, so only the session fact renders a line.
       events.emit({
         scope: 'run',
         streamId: 'stream-1' as StreamTabId,

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -493,6 +493,20 @@ describe('CLI StatusBar display model', () => {
     expect(segment?.compactText).toBe('r2');
   });
 
+  it('carries a workflow-script phase in the same stage slot', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        status: STREAM_PHASE.RUNNING,
+        stage: { kind: 'phase', label: 'Reduce', index: 1, total: 3 },
+      }),
+    );
+
+    const segment = display.left.find((item) => item.text === 'Reduce 2/3');
+    expect(segment).toBeDefined();
+    // Narrow terminals degrade to the bare current phase, not to nothing.
+    expect(segment?.compactText).toBe('Reduce 2');
+  });
+
   it('prefixes the running label with the current spin frame', () => {
     const display = buildStatusBarDisplay(
       statusInput({ status: STREAM_PHASE.RUNNING, runningFrame: '/' }),
@@ -874,294 +888,272 @@ describe('CLI StatusBar display model', () => {
     },
   );
 
-  it('derives isChildStream for statusBarStreamTarget from whichever stream is actually displayed', () => {
-    const root = 'root';
-    const child = 'child';
-    const waitingChildSlice = {
-      streamId: child,
-      status: STREAM_PHASE.WAITING,
-    } as StreamSlice;
-    const streams = new Map<StreamSlice['streamId'], StreamSlice>([
-      [child, waitingChildSlice],
+  // `statusBarStreamTarget` resolves three coupled outputs from one input: the
+  // Ctrl-C action, which slice the footer renders, and whether that displayed
+  // slice belongs to a child stream. Every case asserts all three, and asserts
+  // `displaySlice` by identity so the live-ancestor fallback stays
+  // distinguishable from a structurally equal slice.
+  describe('statusBarStreamTarget', () => {
+    function streamSlice(
+      streamId: string,
+      status: StreamSlice['status'],
+    ): StreamSlice {
+      return { streamId, status } as StreamSlice;
+    }
+
+    function streamMap(
+      entries: ReadonlyArray<readonly [string, StreamSlice]>,
+    ): ReadonlyMap<StreamSlice['streamId'], StreamSlice> {
+      return new Map<StreamSlice['streamId'], StreamSlice>(entries);
+    }
+
+    const parentOfChild = new Map([['child', 'root']]);
+    const parentOfGrandchild = new Map([
+      ['child', 'root'],
+      ['grandchild', 'child'],
     ]);
 
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: child,
-        canStopActiveRun: true,
-        parentStream: new Map([[child, root]]),
-        streams,
-      }),
-    ).toMatchObject({
-      displaySlice: waitingChildSlice,
-      isChildStream: true,
-    });
+    const rootRunning = streamSlice('root', STREAM_PHASE.RUNNING);
+    const rootPending = streamSlice('root', undefined);
+    const rootWaiting = streamSlice('root', STREAM_PHASE.WAITING);
+    const rootCancelled = streamSlice('root', STREAM_PHASE.CANCELLED);
+    const childWaiting = streamSlice('child', STREAM_PHASE.WAITING);
+    const childCancelled = streamSlice('child', STREAM_PHASE.CANCELLED);
+    const grandchildCancelled = streamSlice(
+      'grandchild',
+      STREAM_PHASE.CANCELLED,
+    );
 
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: root,
-        canStopActiveRun: true,
-        parentStream: new Map([[child, root]]),
-        streams,
-      }),
-    ).toMatchObject({
-      displaySlice: undefined,
-      isChildStream: false,
-    });
-  });
-
-  it('projects focused status while keeping stop capability host-owned', () => {
-    const root = 'root';
-    const child = 'child';
-    const grandchild = 'grandchild';
-    const rootSlice = {
-      streamId: root,
-      status: STREAM_PHASE.RUNNING,
-    } as StreamSlice;
-    const childSlice = {
-      streamId: child,
-      status: STREAM_PHASE.CANCELLED,
-    } as StreamSlice;
-    const grandchildSlice = {
-      streamId: grandchild,
-      status: STREAM_PHASE.CANCELLED,
-    } as StreamSlice;
-    const streams = new Map<StreamSlice['streamId'], StreamSlice>([
-      [root, rootSlice],
-      [child, childSlice],
-      [grandchild, grandchildSlice],
+    const liveRootTree = streamMap([
+      ['root', rootRunning],
+      ['child', childCancelled],
+      ['grandchild', grandchildCancelled],
+    ]);
+    const liveRootWaitingChild = streamMap([
+      ['root', rootRunning],
+      ['child', childWaiting],
+    ]);
+    const waitingChildOnly = streamMap([['child', childWaiting]]);
+    const stoppedTree = streamMap([
+      ['root', rootCancelled],
+      ['child', childCancelled],
     ]);
 
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: root,
-        canStopActiveRun: false,
-        parentStream: new Map([[child, root]]),
-        streams,
-      }),
-    ).toMatchObject({
-      ctrlCAction: 'exit',
-      displaySlice: rootSlice,
-    });
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: root,
-        canStopActiveRun: true,
-        parentStream: new Map([[child, root]]),
-        streams,
-      }),
-    ).toMatchObject({
-      ctrlCAction: 'stop',
-      displaySlice: rootSlice,
-    });
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: child,
-        canStopActiveRun: false,
-        parentStream: new Map([[child, root]]),
-        streams,
-      }),
-    ).toMatchObject({
-      ctrlCAction: 'exit',
-      displaySlice: childSlice,
-    });
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: child,
-        canStopActiveRun: true,
-        parentStream: new Map([[child, root]]),
-        streams,
-      }),
-    ).toMatchObject({
-      ctrlCAction: 'stop root',
-      displaySlice: childSlice,
-    });
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: grandchild,
-        canStopActiveRun: false,
-        parentStream: new Map([
-          [child, root],
-          [grandchild, child],
-        ]),
-        streams,
-      }),
-    ).toMatchObject({
-      ctrlCAction: 'exit',
-      displaySlice: grandchildSlice,
-    });
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: grandchild,
-        canStopActiveRun: true,
-        parentStream: new Map([
-          [child, root],
-          [grandchild, child],
-        ]),
-        streams,
-      }),
-    ).toMatchObject({
-      ctrlCAction: 'stop root',
-      displaySlice: grandchildSlice,
-    });
-
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: undefined,
-        canStopActiveRun: true,
-        canStopPendingRunWithoutStream: false,
-        parentStream: new Map([[child, root]]),
-        streams: new Map(),
-      }),
-    ).toMatchObject({
-      ctrlCAction: 'exit',
-      displaySlice: undefined,
-    });
-
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: undefined,
-        canStopActiveRun: true,
-        canStopPendingRunWithoutStream: true,
-        parentStream: new Map([[child, root]]),
-        streams: new Map(),
-      }),
-    ).toMatchObject({
-      ctrlCAction: 'stop',
-      displaySlice: undefined,
-    });
-
-    const pendingRootSlice = {
-      streamId: root,
-      status: undefined,
-    } as StreamSlice;
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: root,
-        canStopActiveRun: true,
-        parentStream: new Map([[child, root]]),
-        streams: new Map<StreamSlice['streamId'], StreamSlice>([
-          [root, pendingRootSlice],
-        ]),
-      }),
-    ).toMatchObject({
-      ctrlCAction: 'stop',
-      displaySlice: pendingRootSlice,
-    });
-
-    const waitingRootSlice = {
-      streamId: root,
-      status: STREAM_PHASE.WAITING,
-    } as StreamSlice;
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: root,
-        canStopActiveRun: true,
-        canStopPendingRunWithoutStream: true,
-        parentStream: new Map([[child, root]]),
-        streams: new Map<StreamSlice['streamId'], StreamSlice>([
-          [root, waitingRootSlice],
-        ]),
-      }),
-    ).toMatchObject({
-      ctrlCAction: 'stop',
-      displaySlice: waitingRootSlice,
-    });
-
-    const stoppedRootSlice = {
-      streamId: root,
-      status: STREAM_PHASE.CANCELLED,
-    } as StreamSlice;
-    const stoppedChildSlice = {
-      streamId: child,
-      status: STREAM_PHASE.CANCELLED,
-    } as StreamSlice;
-    const stoppedStreams = new Map<StreamSlice['streamId'], StreamSlice>([
-      [root, stoppedRootSlice],
-      [child, stoppedChildSlice],
-    ]);
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: root,
+    const cases: ReadonlyArray<{
+      readonly name: string;
+      readonly input: Parameters<typeof statusBarStreamTarget>[0];
+      readonly ctrlCAction: ReturnType<
+        typeof statusBarStreamTarget
+      >['ctrlCAction'];
+      readonly displaySlice: StreamSlice | undefined;
+      readonly isChildStream: boolean;
+    }> = [
+      {
+        name: 'focused waiting child with nothing pending or live to stop',
+        input: {
+          activeStreamId: 'child',
+          canStopActiveRun: true,
+          parentStream: parentOfChild,
+          streams: waitingChildOnly,
+        },
+        ctrlCAction: 'exit',
+        displaySlice: childWaiting,
+        isChildStream: true,
+      },
+      {
+        name: 'focused root that has no slice and no live ancestor',
+        input: {
+          activeStreamId: 'root',
+          canStopActiveRun: true,
+          parentStream: parentOfChild,
+          streams: waitingChildOnly,
+        },
+        ctrlCAction: 'exit',
+        displaySlice: undefined,
+        isChildStream: false,
+      },
+      {
+        name: 'focused live root without stop capability',
+        input: {
+          activeStreamId: 'root',
+          canStopActiveRun: false,
+          parentStream: parentOfChild,
+          streams: liveRootTree,
+        },
+        ctrlCAction: 'exit',
+        displaySlice: rootRunning,
+        isChildStream: false,
+      },
+      {
+        name: 'focused live root with stop capability',
+        input: {
+          activeStreamId: 'root',
+          canStopActiveRun: true,
+          parentStream: parentOfChild,
+          streams: liveRootTree,
+        },
+        ctrlCAction: 'stop',
+        displaySlice: rootRunning,
+        isChildStream: false,
+      },
+      {
+        name: 'focused stopped child without stop capability',
+        input: {
+          activeStreamId: 'child',
+          canStopActiveRun: false,
+          parentStream: parentOfChild,
+          streams: liveRootTree,
+        },
+        ctrlCAction: 'exit',
+        displaySlice: childCancelled,
+        isChildStream: true,
+      },
+      {
+        name: 'focused stopped child with stop capability',
+        input: {
+          activeStreamId: 'child',
+          canStopActiveRun: true,
+          parentStream: parentOfChild,
+          streams: liveRootTree,
+        },
+        ctrlCAction: 'stop root',
+        displaySlice: childCancelled,
+        isChildStream: true,
+      },
+      {
+        name: 'focused waiting child while the root is still live',
+        input: {
+          activeStreamId: 'child',
+          canStopActiveRun: false,
+          parentStream: parentOfChild,
+          streams: liveRootWaitingChild,
+        },
+        ctrlCAction: 'exit',
+        displaySlice: childWaiting,
+        isChildStream: true,
+      },
+      {
+        name: 'focused stopped grandchild without stop capability',
+        input: {
+          activeStreamId: 'grandchild',
+          canStopActiveRun: false,
+          parentStream: parentOfGrandchild,
+          streams: liveRootTree,
+        },
+        ctrlCAction: 'exit',
+        displaySlice: grandchildCancelled,
+        isChildStream: true,
+      },
+      {
+        name: 'focused stopped grandchild with stop capability',
+        input: {
+          activeStreamId: 'grandchild',
+          canStopActiveRun: true,
+          parentStream: parentOfGrandchild,
+          streams: liveRootTree,
+        },
+        ctrlCAction: 'stop root',
+        displaySlice: grandchildCancelled,
+        isChildStream: true,
+      },
+      {
+        name: 'no focused stream and no pending run to stop',
+        input: {
+          activeStreamId: undefined,
+          canStopActiveRun: true,
+          canStopPendingRunWithoutStream: false,
+          parentStream: parentOfChild,
+          streams: streamMap([]),
+        },
+        ctrlCAction: 'exit',
+        displaySlice: undefined,
+        isChildStream: false,
+      },
+      {
+        name: 'no focused stream but a pending run that has no stream yet',
+        input: {
+          activeStreamId: undefined,
+          canStopActiveRun: true,
+          canStopPendingRunWithoutStream: true,
+          parentStream: parentOfChild,
+          streams: streamMap([]),
+        },
+        ctrlCAction: 'stop',
+        displaySlice: undefined,
+        isChildStream: false,
+      },
+      {
+        name: 'focused root whose stream has not reported a phase yet',
+        input: {
+          activeStreamId: 'root',
+          canStopActiveRun: true,
+          parentStream: parentOfChild,
+          streams: streamMap([['root', rootPending]]),
+        },
+        ctrlCAction: 'stop',
+        displaySlice: rootPending,
+        isChildStream: false,
+      },
+      {
+        name: 'focused waiting root while a pending run is stoppable',
+        input: {
+          activeStreamId: 'root',
+          canStopActiveRun: true,
+          canStopPendingRunWithoutStream: true,
+          parentStream: parentOfChild,
+          streams: streamMap([['root', rootWaiting]]),
+        },
+        ctrlCAction: 'stop',
+        displaySlice: rootWaiting,
+        isChildStream: false,
+      },
+      {
+        name: 'focused waiting root without stop capability',
+        input: {
+          activeStreamId: 'root',
+          canStopActiveRun: false,
+          parentStream: parentOfChild,
+          streams: streamMap([['root', rootWaiting]]),
+        },
+        ctrlCAction: 'exit',
+        displaySlice: rootWaiting,
+        isChildStream: false,
+      },
+      {
         // A stale host callback must not leave the footer advertising stop
         // after the visible stream tree has already become terminal.
-        canStopActiveRun: true,
-        parentStream: new Map([[child, root]]),
-        streams: stoppedStreams,
-      }),
-    ).toMatchObject({
-      ctrlCAction: 'exit',
-      displaySlice: stoppedRootSlice,
-    });
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: child,
-        canStopActiveRun: true,
-        parentStream: new Map([[child, root]]),
-        streams: stoppedStreams,
-      }),
-    ).toMatchObject({
-      ctrlCAction: 'exit',
-      displaySlice: stoppedChildSlice,
-    });
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: root,
-        canStopActiveRun: false,
-        parentStream: new Map([[child, root]]),
-        streams: new Map<StreamSlice['streamId'], StreamSlice>([
-          [
-            root,
-            { streamId: root, status: STREAM_PHASE.WAITING } as StreamSlice,
-          ],
-        ]),
-      }),
-    ).toMatchObject({
-      ctrlCAction: 'exit',
-      displaySlice: { streamId: root, status: STREAM_PHASE.WAITING },
-    });
-  });
+        name: 'stale stop capability over a fully terminal root',
+        input: {
+          activeStreamId: 'root',
+          canStopActiveRun: true,
+          parentStream: parentOfChild,
+          streams: stoppedTree,
+        },
+        ctrlCAction: 'exit',
+        displaySlice: rootCancelled,
+        isChildStream: false,
+      },
+      {
+        name: 'stale stop capability over a fully terminal child',
+        input: {
+          activeStreamId: 'child',
+          canStopActiveRun: true,
+          parentStream: parentOfChild,
+          streams: stoppedTree,
+        },
+        ctrlCAction: 'exit',
+        displaySlice: childCancelled,
+        isChildStream: true,
+      },
+    ];
 
-  it('uses focused stream status when a stopped child stream is focused', () => {
-    const rootSlice = {
-      status: STREAM_PHASE.RUNNING,
-    } as StreamSlice;
-    const childSlice = {
-      status: STREAM_PHASE.CANCELLED,
-    } as StreamSlice;
-    const waitingChildSlice = {
-      status: STREAM_PHASE.WAITING,
-    } as StreamSlice;
-    const streams = new Map<StreamSlice['streamId'], StreamSlice>([
-      ['root', rootSlice],
-      ['child', childSlice],
-      ['waiting-child', waitingChildSlice],
-    ]);
+    it.each(cases)('$name', ({ input, ...expected }) => {
+      const target = statusBarStreamTarget(input);
 
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: 'child',
-        canStopActiveRun: false,
-        parentStream: new Map([['child', 'root']]),
-        streams,
-      }).displaySlice,
-    ).toBe(childSlice);
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: 'waiting-child',
-        canStopActiveRun: false,
-        parentStream: new Map([['waiting-child', 'root']]),
-        streams,
-      }).displaySlice,
-    ).toBe(waitingChildSlice);
-    expect(
-      statusBarStreamTarget({
-        activeStreamId: 'root',
-        canStopActiveRun: false,
-        parentStream: new Map([['child', 'root']]),
-        streams,
-      }).displaySlice,
-    ).toBe(rootSlice);
+      expect(target.ctrlCAction).toBe(expected.ctrlCAction);
+      expect(target.displaySlice).toBe(expected.displaySlice);
+      expect(target.isChildStream).toBe(expected.isChildStream);
+    });
   });
 
   it('keeps status discoverable in narrow single-stream sessions', () => {

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -112,7 +112,7 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { runOutcomeExitCode } from '@cli/runtime/terminalStatus';
 import type { CliRuntimeHost } from '@cli/runtime/cliPresentationHost';
-import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
+import { hasCliApprovalDenied } from '@cli/runtime/approval/approvalPolicy';
 import type { ApiProvider } from '@model/apiProviders';
 import {
   AgentCategory,
@@ -1210,53 +1210,41 @@ describe('TUI retry approvals', () => {
     expect(ordinaryPrepare.mock.calls[0]?.[1]?.aborted).toBe(true);
   });
 
-  it('invalidates pre-queue retry lookups when approvals are cleared', async () => {
-    let resolveLookup: ((value: boolean) => void) | undefined;
-    mocks.hasUsableApiKey.mockImplementation(
-      () =>
-        new Promise<boolean>((resolve) => {
-          resolveLookup = resolve;
-        }),
-    );
+  // Both invalidation triggers must reject a retry whose API-key lookup is
+  // still in flight, and must stay rejected once that lookup finally resolves.
+  it.each([
+    ['cleared', 'interrupted', () => clearApprovals()],
+    [
+      'unbound',
+      'unbound',
+      (handle: ReturnType<typeof tui>) => handle.dispose(),
+    ],
+  ] as const)(
+    'invalidates pre-queue retry lookups when approvals are %s',
+    async (_trigger, streamId, invalidate) => {
+      let resolveLookup: ((value: boolean) => void) | undefined;
+      mocks.hasUsableApiKey.mockImplementation(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveLookup = resolve;
+          }),
+      );
 
-    const { interactions } = tui();
-    const result = interactions.requestRetry?.(
-      relayRetry({ streamId: 'interrupted', provider: 'openai' }),
-    );
-    clearApprovals();
-    await expect(result).resolves.toEqual({ action: 'cancel' });
+      const handle = tui();
+      const result = handle.interactions.requestRetry?.(
+        relayRetry({ streamId, provider: 'openai' }),
+      );
+      invalidate(handle);
+      await expect(result).resolves.toEqual({ action: 'cancel' });
 
-    resolveLookup?.(true);
-    await Promise.resolve();
-    await Promise.resolve();
+      resolveLookup?.(true);
+      await Promise.resolve();
+      await Promise.resolve();
 
-    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
-    expect(currentApproval.get()).toBeUndefined();
-  });
-
-  it('invalidates pre-queue retry lookups when approvals are unbound', async () => {
-    let resolveLookup: ((value: boolean) => void) | undefined;
-    mocks.hasUsableApiKey.mockImplementation(
-      () =>
-        new Promise<boolean>((resolve) => {
-          resolveLookup = resolve;
-        }),
-    );
-
-    const { interactions, dispose } = tui();
-    const result = interactions.requestRetry?.(
-      relayRetry({ streamId: 'unbound', provider: 'openai' }),
-    );
-    dispose();
-    await expect(result).resolves.toEqual({ action: 'cancel' });
-
-    resolveLookup?.(true);
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
-    expect(currentApproval.get()).toBeUndefined();
-  });
+      expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+      expect(currentApproval.get()).toBeUndefined();
+    },
+  );
 
   it('cancels an active retry modal when approvals are cleared', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(false);

--- a/src/test-kernel/cli/UpdateChecker.vitest.mts
+++ b/src/test-kernel/cli/UpdateChecker.vitest.mts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildUpdateCommand,
@@ -8,9 +8,19 @@ import {
   fetchLatestHomebrewFormulaVersion,
   formatUpdateCommand,
   isPackageManagerInstall,
+  notifyCliUpdate,
+  resetCliUpdateNotifyLatchForTests,
 } from '@cli/runtime/updateChecker';
 import { GlobalStateKey } from '@shared/state/stateKeys';
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { FakeStateStore } from '@test/support/FakePlatform';
+
+const mocks = vi.hoisted(() => ({ readCliAmbientState: vi.fn() }));
+
+vi.mock('@cli/runtime/cliContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@cli/runtime/cliContext')>()),
+  readCliAmbientState: mocks.readCliAmbientState,
+}));
 
 describe('detectInstallMethod', () => {
   it('recognizes pnpm, yarn, and bun global layouts', () => {
@@ -258,6 +268,40 @@ describe('fetchLatestHomebrewFormulaVersion', () => {
         cwd: '/workspace',
       },
     ]);
+  });
+});
+
+describe('notifyCliUpdate', () => {
+  // A CI run returns right after the ambient read, so the number of ambient
+  // reads is exactly the number of times the latch let the check start.
+  const context = createTestCliContext({ version: '0.39.3' });
+
+  beforeEach(() => {
+    resetCliUpdateNotifyLatchForTests();
+    mocks.readCliAmbientState.mockReset().mockReturnValue({
+      isCi: true,
+      stdinIsTty: true,
+      stdoutIsTty: true,
+      stderrIsTty: true,
+      termIsDumb: false,
+      stdoutColorEnabled: false,
+      stderrColorEnabled: false,
+    });
+  });
+
+  it('runs the check at most once per process', async () => {
+    await notifyCliUpdate(context);
+    await notifyCliUpdate(context);
+
+    expect(mocks.readCliAmbientState).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts a fresh check once the latch is cleared', async () => {
+    await notifyCliUpdate(context);
+    resetCliUpdateNotifyLatchForTests();
+    await notifyCliUpdate(context);
+
+    expect(mocks.readCliAmbientState).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/test-kernel/controllers/ProgressFollowUpPolishController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressFollowUpPolishController.vitest.ts
@@ -139,23 +139,4 @@ describe('ProgressFollowUpPolishController', () => {
       logData: error,
     });
   });
-
-  it('skips polishing when no task state is available', async () => {
-    let calls = 0;
-    const controller = new ProgressFollowUpPolishController({
-      polishText: async () => {
-        calls += 1;
-        return { success: true, text: 'unused' };
-      },
-    });
-
-    const result = await controller.polishFollowUp({
-      stream: 'stream-a',
-      text: 'draft text',
-      runConfig: undefined,
-    });
-
-    assert.deepEqual(result, { kind: 'skipped' });
-    assert.equal(calls, 0);
-  });
 });

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -985,6 +985,22 @@ describe('createProgressViewSecondTierHandlers', () => {
     );
   });
 
+  it('skips polishing when the stream has no run config', async () => {
+    const actions = createSecondTierActions({
+      getRunConfig: vi.fn().mockReturnValue(undefined),
+    });
+    const handlers = createProgressViewSecondTierHandlers(actions);
+
+    await assertSupported(handlers[PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP])({
+      command: PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP,
+      stream: 'stream-1',
+      text: 'Improve this',
+    });
+
+    expect(actions.followUpPolish.polishFollowUp).not.toHaveBeenCalled();
+    expect(actions.applyPolishResult).not.toHaveBeenCalled();
+  });
+
   it('awaits polish error reporting', async () => {
     const polishFailure = new Error('polish failed');
     const reportingFailure = new Error('reporting failed');

--- a/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
@@ -166,24 +166,28 @@ describe('SettingsAgentCatalogController', () => {
       customPresets: [persistedPreset],
     });
 
-    assert.deepEqual(await controller.applyPreset('custom-team'), {
-      ok: true,
-      preset: {
-        ...persistedPreset,
-        icon: 'bookmark',
-      },
-      unresolvedNames: ['missing'],
+    const resolved = controller.resolvePreset('custom-team');
+    assert.ok(resolved.ok);
+    assert.deepEqual(resolved.preset, {
+      ...persistedPreset,
+      icon: 'bookmark',
     });
+    assert.deepEqual(resolved.resolution.unresolvedNames, ['missing']);
+    await controller.commitPresetResolution(
+      resolved.preset,
+      resolved.resolution,
+    );
+
     assert.deepEqual(enabled.workflow, ['remote:writer']);
     // Unresolved names are kept bare so the agent joins the roster the
     // moment it appears (sign-in, install) — never silently dropped.
     assert.deepEqual(enabled.toolUse, ['builtInToolUse:review', 'missing']);
   });
 
-  it('reports unknown presets without writing enabled agent state', async () => {
+  it('reports unknown presets without writing enabled agent state', () => {
     const { controller, enabled } = createController();
 
-    assert.deepEqual(await controller.applyPreset('missing'), {
+    assert.deepEqual(controller.resolvePreset('missing'), {
       ok: false,
       reason: 'unknownPreset',
     });

--- a/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
@@ -2,7 +2,7 @@
 import { strict as assert } from 'node:assert';
 
 // Third-party imports
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 // Local imports - shared
 import {
@@ -167,12 +167,13 @@ describe('SettingsAgentCatalogController', () => {
     });
 
     const resolved = controller.resolvePreset('custom-team');
-    assert.ok(resolved.ok);
-    assert.deepEqual(resolved.preset, {
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) throw new Error('expected the preset to resolve');
+    expect(resolved.preset).toStrictEqual({
       ...persistedPreset,
       icon: 'bookmark',
     });
-    assert.deepEqual(resolved.resolution.unresolvedNames, ['missing']);
+    expect(resolved.resolution.unresolvedNames).toStrictEqual(['missing']);
     await controller.commitPresetResolution(
       resolved.preset,
       resolved.resolution,
@@ -187,7 +188,7 @@ describe('SettingsAgentCatalogController', () => {
   it('reports unknown presets without writing enabled agent state', () => {
     const { controller, enabled } = createController();
 
-    assert.deepEqual(controller.resolvePreset('missing'), {
+    expect(controller.resolvePreset('missing')).toStrictEqual({
       ok: false,
       reason: 'unknownPreset',
     });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -556,11 +556,9 @@ describe('desktop follow-up submission', () => {
     const bridge = await createBridge([], {
       retrieveSessionResumeData: vi.fn(() => resumeLookup),
       configureSession: (session) => {
-        seedStreamStatusForTest(
-          session.status,
-          streamId,
-          STREAM_STATUS.WAITING,
-        );
+        seedStreamStatusForTest(session.status, streamId, {
+          phase: STREAM_PHASE.WAITING,
+        });
       },
     });
 
@@ -2277,11 +2275,9 @@ describe('DesktopProgressBridge', () => {
     });
 
     try {
-      seedStreamStatusForTest(
-        bridgeStatus(bridge),
-        'stream-1',
-        STREAM_STATUS.RUNNING,
-      );
+      seedStreamStatusForTest(bridgeStatus(bridge), 'stream-1', {
+        phase: STREAM_PHASE.RUNNING,
+      });
 
       await expect(tryResumeStream('stream-1')).resolves.toBe(false);
       expect(retrieveSessionResumeData).not.toHaveBeenCalled();
@@ -3355,11 +3351,9 @@ describe('DesktopProgressBridge', () => {
         childStreamId,
         'Transient bash child',
       );
-      seedStreamStatusForTest(
-        owner.processSession.status,
-        childStreamId,
-        STREAM_PHASE.RUNNING,
-      );
+      seedStreamStatusForTest(owner.processSession.status, childStreamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
       const followUpLease = owner.processSession.followUps.claimLive(
         childStreamId,
         'flow',

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -73,7 +73,7 @@ describe('desktop command surface', () => {
       DESKTOP_LOCAL_COMMANDS,
       getDesktopCommandMenuEntries,
     } = await loadSourceModule('@desktop/desktopCommandSurface');
-    const entries = getDesktopCommandMenuEntries(undefined, 'darwin');
+    const entries = getDesktopCommandMenuEntries('darwin');
 
     expect(entries.map((entry) => entry.id)).toEqual(DESKTOP_COMMAND_IDS);
     for (const entry of entries) {

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -76,7 +76,7 @@ function createTestAuth(options: DesktopAuthTestOptions) {
     router,
     coordinator,
     oauthClient,
-    callbackState = createDesktopAuthCallbackState(),
+    callbackState = createDesktopAuthCallbackState(createLog()),
     log = createLog(),
     openExternalUrl = vi.fn(async () => {}),
     showInfoMessage = vi.fn(),
@@ -499,7 +499,10 @@ describe('desktop Supabase auth', () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
     const stateStore = new FakeStateStore();
-    const callbackState = createDesktopAuthCallbackState(stateStore);
+    const callbackState = createDesktopAuthCallbackState(
+      createLog(),
+      stateStore,
+    );
     const oauthClient = createOAuthClient();
     const auth = createTestAuth({
       router,
@@ -510,7 +513,10 @@ describe('desktop Supabase auth', () => {
 
     await auth.signIn();
     auth.dispose();
-    const persistedCallbackState = createDesktopAuthCallbackState(stateStore);
+    const persistedCallbackState = createDesktopAuthCallbackState(
+      createLog(),
+      stateStore,
+    );
     routeMatchingCallback(router, oauthClient);
 
     createTestAuth({
@@ -542,14 +548,17 @@ describe('desktop Supabase auth', () => {
         router,
         coordinator,
         oauthClient,
-        callbackState: createDesktopAuthCallbackState(stateStore),
+        callbackState: createDesktopAuthCallbackState(createLog(), stateStore),
       });
 
       await auth.signIn();
       auth.dispose();
 
       vi.setSystemTime(Date.now() + 11 * 60 * 1000);
-      const expiredCallbackState = createDesktopAuthCallbackState(stateStore);
+      const expiredCallbackState = createDesktopAuthCallbackState(
+        createLog(),
+        stateStore,
+      );
       createTestAuth({
         router,
         coordinator,
@@ -577,7 +586,10 @@ describe('desktop Supabase auth', () => {
     try {
       vi.setSystemTime(new Date('2026-05-06T00:00:00Z'));
       const stateStore = new FakeStateStore();
-      const callbackState = createDesktopAuthCallbackState(stateStore);
+      const callbackState = createDesktopAuthCallbackState(
+        createLog(),
+        stateStore,
+      );
 
       await callbackState.beginAuthAttempt('attempt-nonce');
       vi.setSystemTime(Date.now() + 11 * 60 * 1000);
@@ -585,7 +597,10 @@ describe('desktop Supabase auth', () => {
       expect(callbackState.matchesPendingNonce('attempt-nonce')).toBe(false);
       expect(callbackState.hasPendingSignIn()).toBe(false);
       expect(
-        createDesktopAuthCallbackState(stateStore).hasPendingSignIn(),
+        createDesktopAuthCallbackState(
+          createLog(),
+          stateStore,
+        ).hasPendingSignIn(),
       ).toBe(false);
     } finally {
       vi.useRealTimers();
@@ -597,7 +612,10 @@ describe('desktop Supabase auth', () => {
     try {
       vi.setSystemTime(new Date('2026-05-06T00:00:00Z'));
       const stateStore = new FakeStateStore();
-      const initialState = createDesktopAuthCallbackState(stateStore);
+      const initialState = createDesktopAuthCallbackState(
+        createLog(),
+        stateStore,
+      );
       await initialState.beginAuthAttempt('expired-nonce');
       vi.setSystemTime(Date.now() + 11 * 60 * 1000);
 
@@ -610,7 +628,10 @@ describe('desktop Supabase auth', () => {
         },
       );
 
-      const recreatedState = createDesktopAuthCallbackState(stateStore);
+      const recreatedState = createDesktopAuthCallbackState(
+        createLog(),
+        stateStore,
+      );
       const beginNewAttempt = recreatedState.beginAuthAttempt('new-nonce');
       await vi.waitFor(() => {
         expect(stateStore.update).toHaveBeenCalledOnce();
@@ -619,7 +640,10 @@ describe('desktop Supabase auth', () => {
       cleanup.resolve();
       await beginNewAttempt;
 
-      const persistedState = createDesktopAuthCallbackState(stateStore);
+      const persistedState = createDesktopAuthCallbackState(
+        createLog(),
+        stateStore,
+      );
       expect(persistedState.matchesPendingNonce('new-nonce')).toBe(true);
     } finally {
       vi.useRealTimers();
@@ -629,7 +653,7 @@ describe('desktop Supabase auth', () => {
   it('cancels pending callback state on sign-out', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
-    const callbackState = createDesktopAuthCallbackState();
+    const callbackState = createDesktopAuthCallbackState(createLog());
     const oauthClient = createOAuthClient();
     const log = createLog();
     const auth = createTestAuth({
@@ -686,7 +710,7 @@ describe('desktop Supabase auth', () => {
   it('does not store a superseded callback or clear the newer sign-in', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
-    const callbackState = createDesktopAuthCallbackState();
+    const callbackState = createDesktopAuthCallbackState(createLog());
     const oauthClient = createOAuthClient();
     const callbackProcessing = createDeferred<void>();
     coordinator.createSessionFromCallback.mockImplementationOnce(async () => {
@@ -757,7 +781,7 @@ describe('desktop Supabase auth', () => {
   it('removes a stored callback before starting a newer sign-in', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
-    const callbackState = createDesktopAuthCallbackState();
+    const callbackState = createDesktopAuthCallbackState(createLog());
     const oauthClient = createOAuthClient();
     const sessionStorage = createDeferred<void>();
     const storeSession = coordinator.storeSession.getMockImplementation();

--- a/src/test-kernel/desktop/DesktopWindowTitle.vitest.mts
+++ b/src/test-kernel/desktop/DesktopWindowTitle.vitest.mts
@@ -77,11 +77,9 @@ describe('desktop process-session window title', () => {
     const waitingStream = 'stream:waiting' as StreamTabId;
     const waitingHandle = createAgentHandle('execution:waiting', waitingStream);
     try {
-      seedStreamStatusForTest(
-        session.status,
-        orphanStream,
-        STREAM_PHASE.RUNNING,
-      );
+      seedStreamStatusForTest(session.status, orphanStream, {
+        phase: STREAM_PHASE.RUNNING,
+      });
       expect(getDesktopSessionActivity(session)).toBe('idle');
 
       session.executions.trackAgentExecution(waitingHandle, {
@@ -177,7 +175,7 @@ describe('desktop process-session window title', () => {
       seedStreamStatusForTest(
         session.status,
         'stream:orphan-update' as StreamTabId,
-        STREAM_PHASE.RUNNING,
+        { phase: STREAM_PHASE.RUNNING },
       );
       expect(view.setTitle).not.toHaveBeenCalled();
 

--- a/src/test-kernel/desktop/desktopWorkspacePath.vitest.ts
+++ b/src/test-kernel/desktop/desktopWorkspacePath.vitest.ts
@@ -4,8 +4,8 @@ import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  getWorkspacePathInput,
   hasResolvedWorkspacePath,
-  hasWorkspacePath,
   serializeWorkspacePresenceArg,
   withWorkspacePathArg,
 } from '@desktop/workspacePath';
@@ -48,17 +48,21 @@ describe('desktop workspace path', () => {
   });
 
   it('does not treat empty workspace flags as an opened workspace', () => {
-    expect(hasWorkspacePath({ argv: ['--texra-workspace'] })).toBe(false);
-    expect(hasWorkspacePath({ argv: ['--texra-workspace='] })).toBe(false);
-    expect(hasWorkspacePath({ argv: ['--texra-workspace', 'paper'] })).toBe(
-      true,
-    );
+    expect(
+      getWorkspacePathInput({ argv: ['--texra-workspace'] }),
+    ).toBeUndefined();
+    expect(
+      getWorkspacePathInput({ argv: ['--texra-workspace='] }),
+    ).toBeUndefined();
+    expect(
+      getWorkspacePathInput({ argv: ['--texra-workspace', 'paper'] }),
+    ).toBe('paper');
   });
 
   it('does not treat option-like positional workspace values as paths', () => {
-    expect(hasWorkspacePath({ argv: ['--texra-workspace', '--inspect'] })).toBe(
-      false,
-    );
+    expect(
+      getWorkspacePathInput({ argv: ['--texra-workspace', '--inspect'] }),
+    ).toBeUndefined();
     expect(
       resolveWorkspacePath({ argv: ['--texra-workspace', '--inspect'] }),
     ).toBeUndefined();
@@ -66,20 +70,20 @@ describe('desktop workspace path', () => {
 
   it('does not treat desktop protocol callback URLs as workspace paths', () => {
     expect(
-      hasWorkspacePath({
+      getWorkspacePathInput({
         argv: ['--texra-workspace', 'texra://auth-callback?code=1'],
       }),
-    ).toBe(false);
+    ).toBeUndefined();
     expect(
       resolveWorkspacePath({
         argv: ['--texra-workspace', 'texra://auth-callback?code=1'],
       }),
     ).toBeUndefined();
     expect(
-      hasWorkspacePath({
+      getWorkspacePathInput({
         argv: ['--texra-workspace=texra://auth-callback?code=1'],
       }),
-    ).toBe(false);
+    ).toBeUndefined();
     expect(
       resolveWorkspacePath({
         argv: ['--texra-workspace=texra://auth-callback?code=1'],

--- a/src/test-kernel/frontend/StatusBarUsageTracker.vitest.ts
+++ b/src/test-kernel/frontend/StatusBarUsageTracker.vitest.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports - stream state
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { StatusBarUsageTracker } from '@frontend/statusBar/StatusBarUsageTracker';
 import { STREAM_PHASE } from '@shared/schemas/stream';
@@ -12,7 +13,7 @@ function trackerOverStatusPlane(): {
   status: StreamStatusMachine;
   tracker: StatusBarUsageTracker;
 } {
-  const status = new StreamStatusMachine();
+  const status = new StreamStatusMachine(new SessionEventHub());
   return { status, tracker: new StatusBarUsageTracker(status) };
 }
 

--- a/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
+++ b/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
@@ -153,7 +153,6 @@ describe('LatexMediaManager PDF compilation', () => {
       inputPaths.map(createExternalLocation),
       workspaceState,
       compilePdfConfig,
-      true,
     );
 
     expect(mocks.compileLatex2Pdf).toHaveBeenCalledTimes(2);

--- a/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
@@ -109,6 +109,21 @@ describe('follow-up-input layout', () => {
     expect(textarea?.getAttribute('rows')).toBe('2');
     expect(textarea?.getAttribute('resize')).toBe('none');
   });
+
+  it('grows with content through CSS field-sizing, not WA auto-resize', () => {
+    // The auto-grow behavior is pure CSS (jsdom cannot lay it out), so pin the
+    // declarations that carry it: content-driven sizing with a bounded band.
+    const ctor = customElements.get('follow-up-input') as unknown as {
+      styles: { cssText: string } | Array<{ cssText: string }>;
+    };
+    const cssText = [ctor.styles]
+      .flat()
+      .map((sheet) => sheet.cssText)
+      .join('\n');
+    expect(cssText).toContain('field-sizing: content');
+    expect(cssText).toContain('--textarea-min-height: calc(');
+    expect(cssText).toContain('min-height: var(--textarea-min-height)');
+  });
 });
 
 describe('follow-up-input pasted-image state across stream switches', () => {

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -521,16 +521,15 @@ describe('ProgressBackend', () => {
       }),
     );
 
-    backend.webviewUpdater.updateStreams([], '');
+    backend.webviewUpdater.updateTodos('alpha' as StreamTabId, []);
     expect(sent).not.toHaveBeenCalled();
 
     hasTarget = true;
-    backend.webviewUpdater.updateStreams([], '');
+    backend.webviewUpdater.updateTodos('alpha' as StreamTabId, []);
     expect(sent).toHaveBeenCalledWith({
-      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-      streams: [],
-      activeStream: '',
-      streamStates: undefined,
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_TODOS,
+      stream: 'alpha',
+      todos: [],
     });
   });
 
@@ -553,8 +552,10 @@ describe('ProgressBackend', () => {
       }),
     );
 
-    expect(() => backend.webviewUpdater.updateStreams([], '')).not.toThrow();
-    backend.webviewUpdater.updateStreams([], '');
+    expect(() =>
+      backend.webviewUpdater.updateTodos('alpha' as StreamTabId, []),
+    ).not.toThrow();
+    backend.webviewUpdater.updateTodos('alpha' as StreamTabId, []);
 
     expect(sent).toHaveBeenCalledTimes(2);
     await vi.waitFor(() => expect(debug).toHaveBeenCalledTimes(2));
@@ -563,7 +564,7 @@ describe('ProgressBackend', () => {
       'Failed to deliver message to webview',
       expect.objectContaining({
         data: expect.objectContaining({
-          command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_TODOS,
         }),
       }),
     );

--- a/src/test-kernel/progressView/ProgressTargetOwnership.vitest.mts
+++ b/src/test-kernel/progressView/ProgressTargetOwnership.vitest.mts
@@ -183,7 +183,7 @@ describe('progress target ownership', () => {
     >;
     expect(getActiveSidebarView()).toBe(SIDEBAR_VIEWS.MAIN);
 
-    await provider.popBackToSidebar();
+    await provider.showInSidebar();
 
     expect(panel.dispose).toHaveBeenCalledTimes(1);
     expect(mainViewProvider.switchMode).toHaveBeenLastCalledWith(

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -113,7 +113,6 @@ function createProgressViewProvider(): ProgressViewProviderFake {
     getPendingAgentProposal: vi.fn(),
     markWebviewReady: vi.fn(),
     popOutToEditor: vi.fn(),
-    popBackToSidebar: vi.fn(),
     refreshOnboardingFunnel: vi.fn(),
     setActiveStream: vi.fn(),
     syncFullView: vi.fn(),

--- a/src/test-kernel/schemas/OutputSummaryTransforms.vitest.ts
+++ b/src/test-kernel/schemas/OutputSummaryTransforms.vitest.ts
@@ -57,7 +57,6 @@ function roundOutput(overrides: Partial<RoundOutput> = {}): RoundOutput {
     compileFailures: [],
     xmlSummary: {
       tagContents: {},
-      documents: [],
       singleOutputFile: null,
       sourceLocation: null,
     },

--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -124,6 +124,35 @@ describe('OutputXmlSummarySchema — tagContents legacy string coercion', () => 
   });
 });
 
+describe('OutputXmlSummarySchema — legacy documents field', () => {
+  it('drops the documents copy a pre-removal record still carries', () => {
+    const result = OutputXmlSummarySchema.parse({
+      tagContents: { documents: ['Body A'] },
+      documents: ['Body A'],
+      singleOutputFile: '/tmp/run/main.tex',
+      sourceLocation: null,
+    });
+
+    expect(result).toStrictEqual({
+      tagContents: { documents: ['Body A'] },
+      singleOutputFile: '/tmp/run/main.tex',
+      sourceLocation: null,
+    });
+  });
+
+  it('still rejects an unrecognized key on a record without documents', () => {
+    expect(() =>
+      OutputXmlSummarySchema.parse({ tagContents: {}, unexpected: 1 }),
+    ).toThrow();
+  });
+
+  it('rejects an unrecognized key alongside legacy documents', () => {
+    expect(() =>
+      OutputXmlSummarySchema.parse({ documents: [], unexpected: 1 }),
+    ).toThrow();
+  });
+});
+
 describe('ContextManagementDataSchema — legacy missing tokensAfter/utilizationAfter', () => {
   const legacyBase = {
     tokensBefore: 1000,

--- a/src/test-kernel/shared/SharedStreams.vitest.ts
+++ b/src/test-kernel/shared/SharedStreams.vitest.ts
@@ -14,6 +14,7 @@ import { buildStreamMetadata } from '@shared/streams/streamMetadata';
 import {
   formatPhaseStageLabel,
   formatRoundStageLabel,
+  formatStageLabel,
   formatStreamStatusLabel,
   streamStatusDisplayKey,
   streamStatusIndicatorClass,
@@ -179,6 +180,24 @@ describe('formatPhaseStageLabel', () => {
 
   it('passes undefined through for streams without a phase', () => {
     expect(formatPhaseStageLabel(undefined)).toBeUndefined();
+  });
+});
+
+describe('formatStageLabel', () => {
+  it('labels a round stage through the round formatter', () => {
+    expect(formatStageLabel({ kind: 'round', index: 1, total: 3 })).toBe(
+      'r2/3',
+    );
+  });
+
+  it('labels a phase stage through the phase formatter', () => {
+    expect(
+      formatStageLabel({ kind: 'phase', label: 'Reduce', index: 1, total: 3 }),
+    ).toBe('Reduce 2/3');
+  });
+
+  it('passes undefined through for a stream with no stage open', () => {
+    expect(formatStageLabel(undefined)).toBeUndefined();
   });
 });
 

--- a/src/test-kernel/support/prPollingSourceState.ts
+++ b/src/test-kernel/support/prPollingSourceState.ts
@@ -1,0 +1,70 @@
+// Local imports - tools
+import { DedupedResource } from '@tools/github/PollingSourceBase';
+import type {
+  PRCurrentShaState,
+  PRSubscriptionState,
+} from '@tools/github/PRPollingSource';
+import type {
+  GhIssueComment,
+  GhReview,
+  GhReviewComment,
+} from '@tools/github/prTypes';
+
+/**
+ * Builders for the real `PRPollingSource` subscription state. Suites drive the
+ * source's protected `pollOne` / `drainAnnotationQueues` with a hand-built
+ * state, so building it through the production types is what makes a new
+ * state field a compile error here instead of a silently-stale test double.
+ */
+
+const MAX_SEEN_IDS = 1000;
+
+export function createPRCurrentShaState(
+  sha: string,
+  overrides: Partial<Omit<PRCurrentShaState, 'sha'>> = {},
+): PRCurrentShaState {
+  return {
+    sha,
+    ciStarted: false,
+    ciComplete: false,
+    ciPassed: false,
+    checkRunsCache: undefined,
+    pendingAnnotationRuns: [],
+    ...overrides,
+  };
+}
+
+export function createPRSubscriptionState(
+  overrides: Partial<PRSubscriptionState> = {},
+): PRSubscriptionState {
+  return {
+    pr: { owner: 'owner', repo: 'repo', pullNumber: 7 },
+    slug: 'owner/repo',
+    listeners: new Set(),
+    initialized: true,
+    issueComments: new DedupedResource<GhIssueComment>({
+      getId: (comment) => comment.id,
+      maxSeenIds: MAX_SEEN_IDS,
+    }),
+    reviewComments: new DedupedResource<GhReviewComment>({
+      getId: (comment) => comment.id,
+      maxSeenIds: MAX_SEEN_IDS,
+    }),
+    reviews: new DedupedResource<GhReview>({
+      getId: (review) => review.id,
+      maxSeenIds: MAX_SEEN_IDS,
+    }),
+    lastFailedCheckKeys: new Set(),
+    lastAnnotationKeys: new Set(),
+    annotationLevelByListener: new Map(),
+    currentShaState: undefined,
+    state: undefined,
+    merged: false,
+    mergeableState: undefined,
+    etags: {},
+    lastSuccessAt: Date.now(),
+    consecutiveFailures: 0,
+    skipPollUntilMs: 0,
+    ...overrides,
+  };
+}

--- a/src/test-kernel/support/streamStatusTestUtils.ts
+++ b/src/test-kernel/support/streamStatusTestUtils.ts
@@ -1,14 +1,8 @@
-import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
-import {
-  STREAM_STATUS,
-  StreamPhaseSchema,
-  type StreamPhase,
-  type StreamStatus,
-  type StreamSubstate,
-  type StreamTabId,
-  streamStatusToPhase,
-  streamStatusToSubstate,
-} from '@shared/schemas';
+import type {
+  StreamPhaseState,
+  StreamStatusMachine,
+} from '@agent/runtime/StreamStatusService';
+import type { StreamTabId } from '@shared/schemas';
 
 /**
  * The machine's single per-stream entry map. Seeding writes the settled
@@ -17,13 +11,7 @@ import {
 interface StreamStatusMachineInternals {
   readonly streams: Map<
     StreamTabId,
-    {
-      readonly kind: 'phase';
-      readonly state: {
-        readonly phase: StreamPhase;
-        readonly substate?: StreamSubstate;
-      };
-    }
+    { readonly kind: 'phase'; readonly state: StreamPhaseState }
   >;
 }
 
@@ -47,25 +35,7 @@ export function clearAllStreamStatusesForTest(
 export function seedStreamStatusForTest(
   machine: StreamStatusMachine,
   streamId: StreamTabId,
-  status: StreamPhase | StreamStatus,
+  state: StreamPhaseState,
 ): void {
-  const { streams } = internals(machine);
-  if (status === STREAM_STATUS.READY) {
-    streams.delete(streamId);
-    return;
-  }
-
-  const phase = StreamPhaseSchema.safeParse(status);
-  const substate = phase.success
-    ? undefined
-    : streamStatusToSubstate(status as StreamStatus);
-  streams.set(streamId, {
-    kind: 'phase',
-    state: {
-      phase: phase.success
-        ? phase.data
-        : streamStatusToPhase(status as StreamStatus),
-      ...(substate ? { substate } : {}),
-    },
-  });
+  internals(machine).streams.set(streamId, { kind: 'phase', state });
 }

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -41,7 +41,6 @@ import { formatToolResultAsText } from '@agent/modelHandlers/utils/toolAttachmen
 import {
   EXECUTION_STATUS,
   STREAM_PHASE,
-  STREAM_STATUS,
   type StreamTabId,
 } from '@shared/schemas';
 import type { ExecResult } from '@shared/schemas/opResults';
@@ -317,12 +316,7 @@ describe('BashTool', () => {
     // Create and run the flow directly
     const flow = createToolUseRoundFlow();
     flow.setServices(options);
-    await withTestRunContext(
-      defaultSession().interactions,
-      'bash-tool',
-      () => flow.run(shared),
-      { session: options.runScope.session },
-    );
+    await withTestRunContext(options.runScope, () => flow.run(shared));
 
     const toolOutputMessage = messages.find(
       (msg) => (msg as any).type === 'function_call_output',
@@ -514,31 +508,27 @@ describe('BashTool', () => {
 
       const node = new ToolUseDispatchNode<OpenAI>();
       node.setServices(options);
-      await withTestRunContext(
-        defaultSession().interactions,
-        'tool-status-log',
-        () =>
-          node.post(
-            shared,
-            [call],
-            [
-              {
-                call,
-                result: {},
-                parsedInput: {},
-                extracted: {
-                  attachments: [],
-                  sanitizedResult: { status: 'executed' },
-                },
-                editedFiles: [],
-                logRef: {
-                  logId: undefined,
-                  groupId: runTrace.trace.activeStageId(),
-                },
-              } as any,
-            ],
-          ),
-        { session: options.runScope.session },
+      await withTestRunContext(options.runScope, () =>
+        node.post(
+          shared,
+          [call],
+          [
+            {
+              call,
+              result: {},
+              parsedInput: {},
+              extracted: {
+                attachments: [],
+                sanitizedResult: { status: 'executed' },
+              },
+              editedFiles: [],
+              logRef: {
+                logId: undefined,
+                groupId: runTrace.trace.activeStageId(),
+              },
+            } as any,
+          ],
+        ),
       );
 
       const completedEvent = events.findLast(
@@ -674,11 +664,9 @@ describe('BashTool', () => {
     await installPlatform(BASH_PLATFORM_OPTIONS, {
       agentResume: { tryResumeStream },
     });
-    seedStreamStatusForTest(
-      defaultSession().status,
-      parentStreamId,
-      STREAM_STATUS.WAITING,
-    );
+    seedStreamStatusForTest(defaultSession().status, parentStreamId, {
+      phase: STREAM_PHASE.WAITING,
+    });
 
     const recorded = recordSessionEvents(defaultSession().events);
 
@@ -735,11 +723,9 @@ describe('BashTool', () => {
     await installPlatform(BASH_PLATFORM_OPTIONS, {
       agentResume: { tryResumeStream },
     });
-    seedStreamStatusForTest(
-      defaultSession().status,
-      parentStreamId,
-      STREAM_STATUS.WAITING,
-    );
+    seedStreamStatusForTest(defaultSession().status, parentStreamId, {
+      phase: STREAM_PHASE.WAITING,
+    });
 
     const recorded = recordSessionEvents(defaultSession().events);
 
@@ -995,11 +981,8 @@ describe('BashTool', () => {
 
     try {
       node.setServices(options);
-      const result = await withTestRunContext(
-        defaultSession().interactions,
-        'bash-tool',
-        () => node.exec(call),
-        { session: options.runScope.session },
+      const result = await withTestRunContext(options.runScope, () =>
+        node.exec(call),
       );
 
       assert.equal(result, null);

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -197,11 +197,9 @@ describe('ExecutionsTool', () => {
 
     try {
       session.executions.track(handle);
-      seedStreamStatusForTest(
-        session.status,
-        childStreamId,
-        STREAM_PHASE.WAITING,
-      );
+      seedStreamStatusForTest(session.status, childStreamId, {
+        phase: STREAM_PHASE.WAITING,
+      });
       mocks.readMeta.mockResolvedValue({
         timestamp: '2026-06-15T09:36:02.345Z',
         category: 'toolUse',
@@ -266,11 +264,9 @@ describe('ExecutionsTool', () => {
 
     try {
       session.executions.track(handle);
-      seedStreamStatusForTest(
-        session.status,
-        childStreamId,
-        STREAM_PHASE.RUNNING,
-      );
+      seedStreamStatusForTest(session.status, childStreamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
       session.snapshots.setTodos(childStreamId, [
         {
           content: 'Read live snapshot state',

--- a/src/test-kernel/tools/PRPollingSource.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSource.vitest.ts
@@ -2,39 +2,25 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - tools
-import {
-  DEFAULT_CHECK_ANNOTATION_LEVEL,
-  type GitHubCheckAnnotationLevel,
-} from '@tools/github/checkAnnotationLevels';
+import { DEFAULT_CHECK_ANNOTATION_LEVEL } from '@tools/github/checkAnnotationLevels';
 import { GitHubRateLimitError } from '@tools/github/githubClient';
 import {
   PRPollingSource,
   prKeyToString,
   type PRSubscribeInput,
+  type PRSubscriptionState,
 } from '@tools/github/PRPollingSource';
 import type { GhCheckAnnotation, GhCheckRun } from '@tools/github/prTypes';
 
-interface CurrentShaState {
-  pendingAnnotationRuns: GhCheckRun[];
-}
-
-interface AnnotationDrainState {
-  pr: { owner: string; repo: string; pullNumber: number };
-  slug: string;
-  listeners: Set<(text: string) => void>;
-  annotationLevelByListener: Map<
-    (text: string) => void,
-    GitHubCheckAnnotationLevel
-  >;
-  currentShaState: CurrentShaState | undefined;
-  lastSuccessAt: number;
-  consecutiveFailures: number;
-  skipPollUntilMs: number;
-}
+// Local imports - test support
+import {
+  createPRCurrentShaState,
+  createPRSubscriptionState,
+} from '../support/prPollingSourceState';
 
 interface AnnotationDrainSource {
   drainAnnotationQueues(
-    entries: ReadonlyArray<readonly [string, AnnotationDrainState]>,
+    entries: ReadonlyArray<readonly [string, PRSubscriptionState]>,
     now?: number,
   ): Promise<void>;
   fetchAnnotations(
@@ -51,7 +37,7 @@ interface AnnotationDrainSource {
     input: PRSubscribeInput,
     onEvent: (text: string) => void,
   ): void;
-  getSubscriptionState(key: string): AnnotationDrainState | undefined;
+  getSubscriptionState(key: string): PRSubscriptionState | undefined;
   has(key: string): boolean;
 }
 
@@ -80,17 +66,12 @@ function annotation(
   };
 }
 
-function createDrainState(runs: GhCheckRun[]): AnnotationDrainState {
-  return {
-    pr: { owner: 'owner', repo: 'repo', pullNumber: 7 },
-    slug: 'owner/repo',
-    listeners: new Set(),
-    annotationLevelByListener: new Map(),
-    currentShaState: { pendingAnnotationRuns: runs },
-    lastSuccessAt: Date.now(),
-    consecutiveFailures: 0,
-    skipPollUntilMs: 0,
-  };
+function createDrainState(runs: GhCheckRun[]): PRSubscriptionState {
+  return createPRSubscriptionState({
+    currentShaState: createPRCurrentShaState('abcdef1234567890', {
+      pendingAnnotationRuns: runs,
+    }),
+  });
 }
 
 /** A source whose subscription states stay active for the whole drain. */
@@ -221,7 +202,9 @@ describe('PRPollingSource annotation drain', () => {
       .fn()
       .mockResolvedValue([annotation('warning', 'format warning')]);
 
-    state.currentShaState = { pendingAnnotationRuns: [createCheckRun(13)] };
+    state.currentShaState = createPRCurrentShaState('abcdef1234567890', {
+      pendingAnnotationRuns: [createCheckRun(13)],
+    });
     await source.drainAnnotationQueues([[key, state]]);
 
     expect(listener).not.toHaveBeenCalled();
@@ -230,7 +213,9 @@ describe('PRPollingSource annotation drain', () => {
       { ...pr, minAnnotationLevel: 'warning' },
       listener,
     );
-    state.currentShaState = { pendingAnnotationRuns: [createCheckRun(14)] };
+    state.currentShaState = createPRCurrentShaState('abcdef1234567890', {
+      pendingAnnotationRuns: [createCheckRun(14)],
+    });
 
     await source.drainAnnotationQueues([[key, state]]);
 

--- a/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
@@ -3,8 +3,13 @@
 
 import { afterEach, describe, expect, it, type Mock, vi } from 'vitest';
 import type { GhCheckAnnotation, GhCheckRun } from '@tools/github/prTypes';
+import type { PRSubscriptionState } from '@tools/github/PRPollingSource';
 import { AnnotationFetchBudget } from '@tools/github/annotationFetchBudget';
 import { mockGitHubClient } from '../support/githubClientMock';
+import {
+  createPRCurrentShaState,
+  createPRSubscriptionState,
+} from '../support/prPollingSourceState';
 
 // ---------------------------------------------------------------------------
 // PRPollingSourceAnnotationPages
@@ -19,24 +24,9 @@ interface AnnotationFetchSource {
   ): Promise<GhCheckAnnotation[]>;
 }
 
-interface CurrentShaState {
-  pendingAnnotationRuns: GhCheckRun[];
-}
-
-interface AnnotationDrainState {
-  pr: { owner: string; repo: string; pullNumber: number };
-  slug: string;
-  listeners: Set<(text: string) => void>;
-  annotationLevelByListener: Map<(text: string) => void, 'failure'>;
-  currentShaState: CurrentShaState | undefined;
-  lastSuccessAt: number;
-  consecutiveFailures: number;
-  skipPollUntilMs: number;
-}
-
 interface AnnotationDrainSource extends AnnotationFetchSource {
   drainAnnotationQueues(
-    entries: ReadonlyArray<readonly [string, AnnotationDrainState]>,
+    entries: ReadonlyArray<readonly [string, PRSubscriptionState]>,
     now?: number,
   ): Promise<void>;
   has(key: string): boolean;
@@ -91,17 +81,12 @@ function checkRun(id: number): GhCheckRun {
   };
 }
 
-function drainState(runs: GhCheckRun[]): AnnotationDrainState {
-  return {
-    pr: { owner: 'owner', repo: 'repo', pullNumber: 7 },
-    slug: 'owner/repo',
-    listeners: new Set(),
-    annotationLevelByListener: new Map(),
-    currentShaState: { pendingAnnotationRuns: runs },
-    lastSuccessAt: Date.now(),
-    consecutiveFailures: 0,
-    skipPollUntilMs: 0,
-  };
+function drainState(runs: GhCheckRun[]): PRSubscriptionState {
+  return createPRSubscriptionState({
+    currentShaState: createPRCurrentShaState('abcdef1234567890', {
+      pendingAnnotationRuns: runs,
+    }),
+  });
 }
 
 describe('PRPollingSource annotation pagination', () => {

--- a/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
@@ -2,115 +2,35 @@
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
 
 // Local imports - tools
-import type {
-  GhCheckRun,
-  GhIssueComment,
-  GhPullRequest,
-  GhReview,
-  GhReviewComment,
-} from '@tools/github/prTypes';
+import type { PRSubscriptionState } from '@tools/github/PRPollingSource';
+import type { GhCheckRun, GhPullRequest } from '@tools/github/prTypes';
 
 // Local imports - test support
 import { mockGitHubClient } from '../support/githubClientMock';
-
-interface CurrentShaState {
-  sha: string;
-  ciStarted: boolean;
-  ciComplete: boolean;
-  ciPassed: boolean;
-  checkRunsCache?: {
-    pages: Map<number, { etag?: string; runs: GhCheckRun[] }>;
-    lastTotalCount: number;
-  };
-  pendingAnnotationRuns: GhCheckRun[];
-}
-
-interface CiStartedState {
-  pr: { owner: string; repo: string; pullNumber: number };
-  slug: string;
-  listeners: Set<(text: string) => void>;
-  initialized: boolean;
-  issueComments: TestDedupedResource<GhIssueComment>;
-  reviewComments: TestDedupedResource<GhReviewComment>;
-  reviews: TestDedupedResource<GhReview>;
-  lastFailedCheckKeys: Set<string>;
-  lastAnnotationKeys: Set<string>;
-  currentShaState: CurrentShaState | undefined;
-  state: 'open' | 'closed' | undefined;
-  merged: boolean;
-  mergeableState: string | undefined;
-  etags: {
-    pr?: string;
-    issueComments?: string;
-    reviewComments?: string;
-    reviews?: string;
-  };
-  lastSuccessAt: number;
-  consecutiveFailures: number;
-  skipPollUntilMs: number;
-}
+import {
+  createPRCurrentShaState,
+  createPRSubscriptionState,
+} from '../support/prPollingSourceState';
 
 interface CiStartedSource {
-  pollOne(key: string, state: CiStartedState): Promise<void>;
-}
-
-interface TestDedupedResource<T> {
-  sinceCursor: string | undefined;
-  seed(items: readonly T[]): void;
-  diff(items: readonly T[], emit: (item: T) => void): void;
+  pollOne(key: string, state: PRSubscriptionState): Promise<void>;
 }
 
 const SHA = 'abcdef1234567890';
 const OLD_SHA = '1234567890abcdef';
 
-function testDedupedResource<T>(): TestDedupedResource<T> {
-  return {
-    sinceCursor: undefined,
-    seed: vi.fn(),
-    diff: vi.fn(),
-  };
-}
-
-function makeCurrentShaState(
-  sha: string,
-  overrides: Partial<Omit<CurrentShaState, 'sha'>> = {},
-): CurrentShaState {
-  return {
-    sha,
-    ciStarted: false,
-    ciComplete: false,
-    ciPassed: false,
-    checkRunsCache: undefined,
-    pendingAnnotationRuns: [],
-    ...overrides,
-  };
-}
-
 function createState(
   events: string[],
-  overrides: Partial<CiStartedState> = {},
-): CiStartedState {
+  overrides: Partial<PRSubscriptionState> = {},
+): PRSubscriptionState {
   const listener = (text: string) => events.push(text);
-  return {
-    pr: { owner: 'owner', repo: 'repo', pullNumber: 7 },
-    slug: 'owner/repo',
+  return createPRSubscriptionState({
     listeners: new Set([listener]),
-    initialized: true,
-    issueComments: testDedupedResource(),
-    reviewComments: testDedupedResource(),
-    reviews: testDedupedResource(),
-    lastFailedCheckKeys: new Set(),
-    lastAnnotationKeys: new Set(),
-    currentShaState: makeCurrentShaState(SHA),
+    currentShaState: createPRCurrentShaState(SHA),
     state: 'open',
-    merged: false,
     mergeableState: 'clean',
-    etags: {},
-    lastSuccessAt: Date.now(),
-    consecutiveFailures: 0,
-    skipPollUntilMs: 0,
     ...overrides,
-  };
+  });
 }
 
 function prResponse(sha: string): {
@@ -233,7 +153,7 @@ describe('PRPollingSource CI-started events', () => {
     const { ghGet, source } = await createHarness();
     const events: string[] = [];
     const state = createState(events, {
-      currentShaState: makeCurrentShaState(OLD_SHA, { ciStarted: true }),
+      currentShaState: createPRCurrentShaState(OLD_SHA, { ciStarted: true }),
     });
 
     queuePollResponses(ghGet, SHA, [checkRun(1, 'lint')]);

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -902,7 +902,7 @@ describe('StreamLogStore load', () => {
 
     expect(storage.fullLogReads()).toBe(0);
 
-    const affected = await store.endRunningGroups(300);
+    const affected = await store.endRunningGroupsForStreams(['alpha'], 300);
     await store.flush();
     expect(store.get('alpha')).toBeUndefined();
     expect(storage.fullLogReads()).toBe(1);
@@ -910,8 +910,8 @@ describe('StreamLogStore load', () => {
 
     expect(affected).toEqual(['alpha']);
     expect(entry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_END);
-    // endRunningGroups() defaults to RUN_OUTCOME.FAILED, the orphan sweep's
-    // caller-classified default.
+    // endRunningGroupsForStreams() defaults to RUN_OUTCOME.FAILED, the orphan
+    // sweep's caller-classified default.
     expect(entry?.data).toEqual({ status: RUN_OUTCOME.FAILED, endTime: 300 });
     expect(writtenSummary(storage.writes, 'alpha')).toEqual(
       settledSummary(100, 100),
@@ -1231,7 +1231,7 @@ describe('StreamLogStore load', () => {
 
     const store = await StreamLogStore.open();
 
-    const endRunningGroups = store.endRunningGroups(300);
+    const endRunningGroups = store.endRunningGroupsForStreams(streamIds, 300);
     await waitForCondition(() => storage.fullLogReads() === 8, {
       timeoutMessage:
         'Expected stale stream rehydrate reads to reach the concurrency cap',

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -914,12 +914,8 @@ describe('StreamSnapshotStore', () => {
 
   it('resolves the descriptor execution id everywhere when the legacy mirror is malformed', async () => {
     await installPlatform();
-    // A per-test execution id: `getExecutionStore` caches one store per id
-    // across tests, and a reused id would inherit a handle whose directory
-    // this test's temp platform no longer has.
     const executionId = 'aa11bb22' as ExecutionId;
     const runConfig = toolUseConfig('legacy-search');
-    await StorageFS.ensureDir(resolveRunStoragePath(executionId));
     await getExecutionStore(executionId).writeConfig(runConfig);
     await writeMetaFile(STREAM, {
       // A legacy sidecar whose top-level mirror never held a real execution id.
@@ -952,7 +948,6 @@ describe('StreamSnapshotStore', () => {
       executionId: ExecutionId,
       agent: string,
     ): Promise<void> => {
-      await StorageFS.ensureDir(resolveRunStoragePath(executionId));
       await getExecutionStore(executionId).writeConfig(toolUseConfig(agent));
       await writeMetaFile(stream, {
         executionId,
@@ -1024,7 +1019,6 @@ describe('StreamSnapshotStore', () => {
     await writeMetaFile(STREAM, {
       executionId,
     });
-    await StorageFS.ensureDir(resolveRunStoragePath(executionId));
     await getExecutionStore(executionId).writeConfig(persisted);
 
     const store = new StreamSnapshotStore();
@@ -1054,7 +1048,6 @@ describe('StreamSnapshotStore', () => {
       category: AgentCategory.Workflow,
       kind: 'workflowScript',
     });
-    await StorageFS.ensureDir(resolveRunStoragePath(executionId));
     await getExecutionStore(executionId).writeConfig(runConfig);
 
     const store = new StreamSnapshotStore();
@@ -1084,7 +1077,6 @@ describe('StreamSnapshotStore', () => {
     store.setRunConfig(STREAM, toolUseConfig('live-search'), liveExecutionId);
     await store.flush();
 
-    await StorageFS.ensureDir(resolveRunStoragePath(foreignExecutionId));
     await getExecutionStore(foreignExecutionId).writeConfig(foreignConfig);
     await writeMetaFile(STREAM, {
       executionId: foreignExecutionId,
@@ -1105,7 +1097,6 @@ describe('StreamSnapshotStore', () => {
     await writeMetaFile(STREAM, {
       executionId,
     });
-    await StorageFS.ensureDir(resolveRunStoragePath(executionId));
     await getExecutionStore(executionId).writeConfig(
       toolUseConfig('search', 'deepseekproT'),
     );
@@ -1141,7 +1132,6 @@ describe('StreamSnapshotStore', () => {
     // from the descriptor half alone: the pair still has to move together.
     const executionId = 'def456' as ExecutionId;
     const handoffConfig = toolUseConfig('handoff-search');
-    await StorageFS.ensureDir(resolveRunStoragePath(executionId));
     await getExecutionStore(executionId).writeConfig(handoffConfig);
     await writeMetaFile(STREAM, {
       executionId,
@@ -1161,7 +1151,6 @@ describe('StreamSnapshotStore', () => {
     await writeMetaFile(STREAM, {
       executionId,
     });
-    await StorageFS.ensureDir(resolveRunStoragePath(executionId));
     await getExecutionStore(executionId).writeConfig(toolUseConfig());
 
     const store = new StreamSnapshotStore();
@@ -1187,7 +1176,6 @@ describe('StreamSnapshotStore', () => {
     await writeMetaFile(STREAM, {
       executionId: oldExecutionId,
     });
-    await StorageFS.ensureDir(resolveRunStoragePath(oldExecutionId));
     await getExecutionStore(oldExecutionId).writeConfig(oldConfig);
 
     const store = new StreamSnapshotStore();

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -88,7 +88,6 @@ describe('resolvePersistedStreamIdForExecution', () => {
 
     expect(resolved).toEqual({
       streamId,
-      source: 'streamDataMeta',
       exactExecutionCandidateStreamIds: [streamId],
     });
   });
@@ -147,10 +146,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       snapshotStore: new StreamSnapshotStore(),
     });
 
-    expect(resolved).toEqual({
-      streamId,
-      source: 'executionMeta',
-    });
+    expect(resolved).toEqual({ streamId });
     await expect(
       getExecutionStore(executionId).readMeta(),
     ).resolves.toMatchObject({
@@ -176,7 +172,6 @@ describe('resolvePersistedStreamIdForExecution', () => {
     });
     expect(resolved).toEqual({
       streamId,
-      source: 'streamDataMeta',
       exactExecutionCandidateStreamIds: [streamId],
     });
     await expect(
@@ -199,7 +194,6 @@ describe('resolvePersistedStreamIdForExecution', () => {
         snapshotStore: new StreamSnapshotStore(),
       }),
     ).resolves.toEqual({
-      source: 'streamDataMeta',
       exactExecutionCandidateStreamIds: [streamId, resumedStream],
     });
   });
@@ -222,7 +216,6 @@ describe('resolvePersistedStreamIdForExecution', () => {
       snapshotStore: new StreamSnapshotStore(),
     });
     expect(resolved).toEqual({
-      source: 'streamDataMeta',
       exactExecutionCandidateStreamIds: [firstStream, secondStream],
     });
   });
@@ -249,7 +242,6 @@ describe('resolvePersistedStreamIdForExecution', () => {
       streamLogStore: logStore,
     });
     expect(resolved).toEqual({
-      source: 'streamDataMeta',
       exactExecutionCandidateStreamIds: [workPlanStream, logStream],
     });
     expect(
@@ -274,7 +266,6 @@ describe('resolvePersistedStreamIdForExecution', () => {
         snapshotStore: new StreamSnapshotStore(),
       }),
     ).resolves.toEqual({
-      source: 'streamDataMeta',
       associatedStreamIds: [firstChild, secondChild],
     });
   });
@@ -294,7 +285,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       resolvePersistedStreamIdForExecution(executionId, {
         snapshotStore: new StreamSnapshotStore(),
       }),
-    ).resolves.toEqual({ streamId, source: 'streamDataMeta' });
+    ).resolves.toEqual({ streamId });
   });
 
   it('preserves the legacy streamData suffix fallback', async () => {
@@ -312,7 +303,6 @@ describe('resolvePersistedStreamIdForExecution', () => {
       }),
     ).resolves.toEqual({
       streamId: first,
-      source: 'streamDataSuffix',
       fallbackStreamIds: [second],
     });
   });
@@ -328,9 +318,6 @@ describe('resolvePersistedStreamIdForExecution', () => {
         snapshotStore: new StreamSnapshotStore(),
         streamLogStore: logs,
       }),
-    ).resolves.toEqual({
-      streamId,
-      source: 'streamLogsSuffix',
-    });
+    ).resolves.toEqual({ streamId });
   });
 });

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -78,7 +78,7 @@ import {
 } from './prTypes';
 import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
 
-function createInitialState(pr: PRKey): SubscriptionState {
+function createInitialState(pr: PRKey): PRSubscriptionState {
   return {
     pr,
     slug: `${pr.owner}/${pr.repo}`,
@@ -140,7 +140,7 @@ export function prKeyToString(k: PRKey): string {
   return prRef(`${k.owner}/${k.repo}`, k.pullNumber);
 }
 
-interface SubscriptionState extends BasePollSubscriptionState {
+export interface PRSubscriptionState extends BasePollSubscriptionState {
   pr: PRKey;
   slug: string;
   /** Initialized on first tick so we don't replay historical events. */
@@ -167,7 +167,7 @@ interface SubscriptionState extends BasePollSubscriptionState {
    * `pollOne`), so a future per-SHA field added here can't leak stale state
    * across a push — there's no separate list of fields to remember to clear.
    */
-  currentShaState: CurrentShaState | undefined;
+  currentShaState: PRCurrentShaState | undefined;
   state: 'open' | 'closed' | undefined;
   merged: boolean;
   /** Last *definite* `mergeable_state`; see `isDefiniteMergeableState`. */
@@ -181,7 +181,7 @@ interface SubscriptionState extends BasePollSubscriptionState {
 }
 
 /** Per-head-SHA state; reset wholesale whenever the head SHA changes. */
-interface CurrentShaState {
+export interface PRCurrentShaState {
   sha: string;
   /** Whether the one-shot "CI triggered" event has been emitted for `sha`. */
   ciStarted: boolean;
@@ -210,7 +210,7 @@ interface CurrentShaState {
 
 export class PRPollingSource extends PollingSourceBase<
   string,
-  SubscriptionState
+  PRSubscriptionState
 > {
   private nextAnnotationDrainKey: string | undefined;
 
@@ -280,14 +280,14 @@ export class PRPollingSource extends PollingSourceBase<
 
   protected formatErrorEvent(
     _key: string,
-    state: SubscriptionState,
+    state: PRSubscriptionState,
     detail: string,
   ): string {
     return formatSubscriptionError(state.slug, state.pr.pullNumber, detail);
   }
 
   protected override async afterTick(
-    entries: ReadonlyArray<readonly [string, SubscriptionState]>,
+    entries: ReadonlyArray<readonly [string, PRSubscriptionState]>,
     now: number,
   ): Promise<void> {
     await this.drainAnnotationQueues(entries, now);
@@ -295,7 +295,7 @@ export class PRPollingSource extends PollingSourceBase<
 
   protected async pollOne(
     key: string,
-    state: SubscriptionState,
+    state: PRSubscriptionState,
   ): Promise<void> {
     const { pr } = state;
     const prPath = `/repos/${pr.owner}/${pr.repo}/pulls/${pr.pullNumber}`;
@@ -636,7 +636,7 @@ export class PRPollingSource extends PollingSourceBase<
    * re-emitting duplicates against an unchanged check-runs response.
    */
   private enqueueAnnotationCandidates(
-    state: SubscriptionState,
+    state: PRSubscriptionState,
     runs: ReadonlyArray<GhCheckRun>,
   ): void {
     const currentShaState = state.currentShaState;
@@ -655,7 +655,7 @@ export class PRPollingSource extends PollingSourceBase<
   }
 
   private async drainAnnotationQueues(
-    entries: ReadonlyArray<readonly [string, SubscriptionState]>,
+    entries: ReadonlyArray<readonly [string, PRSubscriptionState]>,
     now = Date.now(),
   ): Promise<void> {
     const pendingEntries = this.orderAnnotationDrainEntries(entries, now);
@@ -693,9 +693,9 @@ export class PRPollingSource extends PollingSourceBase<
   }
 
   private orderAnnotationDrainEntries(
-    entries: ReadonlyArray<readonly [string, SubscriptionState]>,
+    entries: ReadonlyArray<readonly [string, PRSubscriptionState]>,
     now: number,
-  ): Array<readonly [string, SubscriptionState]> {
+  ): Array<readonly [string, PRSubscriptionState]> {
     const pendingEntries = entries.filter(
       ([key, state]) =>
         this.has(key) &&
@@ -714,7 +714,7 @@ export class PRPollingSource extends PollingSourceBase<
   }
 
   private advanceAnnotationDrainStart(
-    entries: ReadonlyArray<readonly [string, SubscriptionState]>,
+    entries: ReadonlyArray<readonly [string, PRSubscriptionState]>,
   ): void {
     if (entries.length === 0) {
       this.nextAnnotationDrainKey = undefined;
@@ -737,7 +737,7 @@ export class PRPollingSource extends PollingSourceBase<
    * - Anything else (network, timeout): rotate to the back of the queue.
    */
   private async drainNextAnnotationRun(
-    state: SubscriptionState,
+    state: PRSubscriptionState,
     now: number,
   ): Promise<boolean> {
     const run = state.currentShaState?.pendingAnnotationRuns[0];
@@ -782,7 +782,7 @@ export class PRPollingSource extends PollingSourceBase<
   }
 
   private removePendingAnnotationRun(
-    state: SubscriptionState,
+    state: PRSubscriptionState,
     runId: number,
   ): void {
     if (!state.currentShaState) return;
@@ -791,7 +791,7 @@ export class PRPollingSource extends PollingSourceBase<
   }
 
   private emitCheckAnnotations(
-    state: SubscriptionState,
+    state: PRSubscriptionState,
     run: GhCheckRun,
     annotations: readonly GhCheckAnnotation[],
   ): void {

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -22,10 +22,12 @@ import { z } from 'zod';
 import pTimeout from 'p-timeout';
 
 // Local imports
+import * as logger from '@logger/logUtils';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { waitForRateLimit } from '@tools/citation/rateLimiter';
 import { CROSSREF_CONSTANTS, CrossrefClient } from '@tools/citation/constants';
 import { defineTool } from '@tools/core/define';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { pluralize } from '@utils/text/stringUtils';
 
 // Local file imports
@@ -37,6 +39,7 @@ import {
   type CslCreator,
 } from './bbtClient';
 
+const CHANNEL = 'ZoteroAddTool';
 const CROSSREF_RESOLVE_TIMEOUT_MS = 15_000; // 15 s
 
 /**
@@ -239,7 +242,13 @@ async function resolveDOI(doi: string): Promise<ZoteroConnectorItem | null> {
     if (work.abstract) item.abstractNote = work.abstract;
     if (work.resource?.primary?.URL) item.url = work.resource.primary.URL;
     return item;
-  } catch {
+  } catch (err) {
+    // The caller still falls back to the user's own metadata; log so a
+    // silently degraded entry is traceable to the Crossref failure.
+    logger.warn(
+      CHANNEL,
+      `Crossref lookup failed for DOI ${doi}: ${toErrorMessage(err)}`,
+    );
     return null;
   }
 }

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -868,41 +868,6 @@ export class StreamLogStore {
     }
   }
 
-  async endRunningGroups(
-    now: number = Date.now(),
-    streamIds: readonly StreamTabId[] = [],
-    status: RunOutcome = RUN_OUTCOME.FAILED,
-  ): Promise<StreamTabId[]> {
-    this.assertWritableStore('finalize running transcript groups');
-    const streamsToLoad = new Set<StreamTabId>();
-    for (const streamId of streamIds) {
-      if (this.needsReload(streamId)) streamsToLoad.add(streamId);
-    }
-    for (const [streamId, summary] of this.summaries) {
-      if (hasSomethingRunning(summary) && this.needsReload(streamId)) {
-        streamsToLoad.add(streamId);
-      }
-    }
-
-    if (streamsToLoad.size > 0) {
-      await pMap([...streamsToLoad], (id) => this.ensureLoaded(id), {
-        concurrency: STREAM_LOG_LOAD_CONCURRENCY,
-      });
-    }
-
-    const affected = this.endRunningEntriesInLoadedLogs(now, undefined, status);
-    if (affected.length > 0) {
-      void this.save();
-    }
-    // Recovery borrowed these logs only to repair stale entries. Return them
-    // to cold storage; requestEviction waits for any repair write to finish.
-    for (const streamId of streamsToLoad) {
-      this.requestEviction(streamId);
-    }
-
-    return affected;
-  }
-
   async endRunningGroupsForStreams(
     streamIds: readonly StreamTabId[],
     now: number = Date.now(),
@@ -939,14 +904,14 @@ export class StreamLogStore {
 
   private endRunningEntriesInLoadedLogs(
     now: number,
-    streamIds?: ReadonlySet<StreamTabId>,
-    status: RunOutcome = RUN_OUTCOME.FAILED,
+    streamIds: ReadonlySet<StreamTabId>,
+    status: RunOutcome,
   ): StreamTabId[] {
     const affected: StreamTabId[] = [];
     for (const [streamId, state] of this.streams) {
       const logInstance = state.log;
       if (!logInstance) continue;
-      if (streamIds && !streamIds.has(streamId)) continue;
+      if (!streamIds.has(streamId)) continue;
       let updatedAny = false;
       for (const entry of logInstance.getRange(0, logInstance.head)) {
         if (isRunningGroupEntry(entry)) {
@@ -1117,7 +1082,7 @@ export class StreamLogStore {
     );
   }
 
-  /** Shared post-mutation bookkeeping for append/update/appendText/endRunningGroups. */
+  /** Shared post-mutation bookkeeping for append/update/appendText/group-end. */
   private commitChange(streamId: StreamTabId, logInstance: StreamLog): void {
     this.assertWritableStore('commit transcript changes');
     this.refreshSummary(streamId, logInstance);

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -11,13 +11,9 @@ import {
 import { StreamSnapshotStore } from './StreamSnapshotStore';
 import type { StreamLogStore } from './StreamLogStore';
 
-type PersistedStreamIdResolutionSource =
-  'executionMeta' | 'streamDataMeta' | 'streamDataSuffix' | 'streamLogsSuffix';
-
 export interface PersistedStreamIdResolution {
   /** Canonical stream when registration or persisted evidence proves one. */
   readonly streamId?: StreamTabId;
-  readonly source: PersistedStreamIdResolutionSource;
   /** Other persisted candidates to try when a historical primary is empty. */
   readonly fallbackStreamIds?: readonly StreamTabId[];
   /** Exact-execution sidecars eligible for overlap-gated archive merging. */
@@ -164,7 +160,7 @@ export async function resolvePersistedStreamIdForExecution(
     executionMeta?.streamId &&
     executionMeta.streamIdSource === EXECUTION_STREAM_ID_SOURCE.REGISTRATION
   ) {
-    return { streamId: executionMeta.streamId, source: 'executionMeta' };
+    return { streamId: executionMeta.streamId };
   }
 
   const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
@@ -199,7 +195,6 @@ export async function resolvePersistedStreamIdForExecution(
       // archive. Data presence and lexical order are not canonical-ownership
       // evidence. When every match is a proven child there are no candidates.
       return {
-        source: 'streamDataMeta',
         ...(mergeCandidateMetaMatched.length > 0
           ? {
               exactExecutionCandidateStreamIds: mergeCandidateMetaMatched,
@@ -219,7 +214,6 @@ export async function resolvePersistedStreamIdForExecution(
     ]);
     return {
       streamId,
-      source: 'streamDataMeta',
       ...(fallbackStreamIds.length > 0 ? { fallbackStreamIds } : {}),
       ...(mergeCandidateMetaMatched.length > 0
         ? {
@@ -239,7 +233,6 @@ export async function resolvePersistedStreamIdForExecution(
     const fallbackStreamIds = orderedFallbacks(matchedSidecar, matchedSidecars);
     return {
       streamId: matchedSidecar,
-      source: 'streamDataSuffix',
       ...(fallbackStreamIds.length > 0 ? { fallbackStreamIds } : {}),
     };
   }
@@ -252,7 +245,6 @@ export async function resolvePersistedStreamIdForExecution(
     const fallbackStreamIds = orderedFallbacks(matchedLog, matchedLogs);
     return {
       streamId: matchedLog,
-      source: 'streamLogsSuffix',
       ...(fallbackStreamIds.length > 0 ? { fallbackStreamIds } : {}),
     };
   }

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -134,7 +134,13 @@ export async function readLegacyInstruction(
   if (raw === undefined) return null;
 
   const result = LegacyInstructionsDataSchema.safeParse(raw);
-  if (!result.success || Object.keys(result.data).length === 0) return null;
+  if (!result.success) {
+    logger.warn(CHANNEL, 'Discarding unreadable legacy instructions.', {
+      data: result.error,
+    });
+    return null;
+  }
+  if (Object.keys(result.data).length === 0) return null;
 
   return selectPreferredLegacyInstruction(result.data, meta?.activeRunId);
 }

--- a/src/utils/media/img.ts
+++ b/src/utils/media/img.ts
@@ -3,7 +3,6 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 // Third-party imports
-import { PDFDocument } from '@cantoo/pdf-lib';
 import { fromPath } from 'pdf2pic';
 
 // Local imports - log
@@ -16,29 +15,21 @@ import { detectImageTool } from '@utils/system/toolUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { executeCommand } from '@utils/system/execUtils';
 
+import { countPdfPagesInBuffer } from './pdfPageCount';
+
 const CHANNEL = 'ImgUtils';
 
-/** Default DPI/density used when rasterizing a PDF page to PNG. */
-const DEFAULT_PDF_QUALITY = 300;
+/** DPI/density used when rasterizing a PDF page to PNG. */
+const PDF_RASTER_DENSITY = 300;
 
-/** Default maximum [width, height] in px for a rasterized PDF page. */
-const DEFAULT_PDF_MAX_SIZE: [number, number] = [1024, 1024];
+/** Maximum [width, height] in px for a rasterized PDF page. */
+const PDF_RASTER_MAX_SIZE: [number, number] = [1024, 1024];
 
 /** Resolve a file path and return the absolute path, or null if not found. */
 async function resolveFile(filePath: string): Promise<string | null> {
   const absolutePath = WorkspaceFS.toAbsolute(filePath);
   const exists = await AbsoluteFS.exists(absolutePath);
   return exists ? absolutePath : null;
-}
-
-/** Load a PDF and return its page count. Expects an absolute path. */
-async function loadPdfPageCount(absolutePath: string): Promise<number> {
-  const pdfBytes = AbsoluteFS.readBytesSync(absolutePath);
-  const pdfDoc = await PDFDocument.load(pdfBytes, {
-    updateMetadata: false,
-    ignoreEncryption: true,
-  });
-  return pdfDoc.getPageCount();
 }
 
 /** Remove a conversion's private temp directory and every page it holds. */
@@ -173,7 +164,7 @@ export async function countPdfPages(pdfPath: string): Promise<number> {
       logger.debug(CHANNEL, `PDF file not found: ${pdfPath}`);
       return 0;
     }
-    return await loadPdfPageCount(absolutePath);
+    return await countPdfPagesInBuffer(AbsoluteFS.readBytesSync(absolutePath));
   } catch (err) {
     logger.error(CHANNEL, `Error counting PDF pages: ${toErrorMessage(err)}`);
     return 0;
@@ -188,14 +179,12 @@ export async function countPdfPages(pdfPath: string): Promise<number> {
 async function singlePagePdf2Png(
   absolutePath: string,
   pageNum: number,
-  quality: number,
-  maxSize: [number, number],
   tempDir: string,
 ): Promise<string> {
   const convert = fromPath(absolutePath, {
-    density: quality,
-    width: maxSize[0],
-    height: maxSize[1],
+    density: PDF_RASTER_DENSITY,
+    width: PDF_RASTER_MAX_SIZE[0],
+    height: PDF_RASTER_MAX_SIZE[1],
     preserveAspectRatio: true,
     format: 'png',
     saveFilename: `page-${pageNum}`,
@@ -219,16 +208,13 @@ async function singlePagePdf2Png(
   return imageBuffer.toString('base64');
 }
 
-/** Pages converted when the caller does not cap the count. */
-const DEFAULT_PDF_MAX_PAGES = 100;
+/** Upper bound on the pages rasterized from one PDF. */
+const PDF_MAX_PAGES = 100;
 
-/** Process a PDF file and return base64 encoded PNG image(s). Returns null on error. */
+/** Process a PDF file and return one base64 encoded PNG per page. Returns null on error. */
 export async function processPdf2Png(
   pdfPath: string,
-  maxPages?: number,
-  quality: number = DEFAULT_PDF_QUALITY,
-  maxSize: [number, number] = DEFAULT_PDF_MAX_SIZE,
-): Promise<string | string[] | null> {
+): Promise<string[] | null> {
   try {
     const absolutePath = await resolveFile(pdfPath);
     if (!absolutePath) {
@@ -236,7 +222,9 @@ export async function processPdf2Png(
       return null;
     }
 
-    const pageCount = await loadPdfPageCount(absolutePath);
+    const pageCount = await countPdfPagesInBuffer(
+      AbsoluteFS.readBytesSync(absolutePath),
+    );
     if (pageCount === 0) {
       return null;
     }
@@ -249,32 +237,11 @@ export async function processPdf2Png(
     // page it holds without touching pages a concurrent conversion is reading.
     const tempDir = await createTexraTempDir('texra-pdf-conversion-');
     try {
-      if (pageCount === 1) {
-        return await singlePagePdf2Png(
-          absolutePath,
-          1,
-          quality,
-          maxSize,
-          tempDir,
-        );
-      }
-
-      // `??` on purpose: a null maxPages (e.g. from a .nullish() tool field)
-      // means "no limit requested" and gets the default cap, same as undefined.
-      const pagesToConvert = Math.min(
-        pageCount,
-        maxPages ?? DEFAULT_PDF_MAX_PAGES,
-      );
+      const pagesToConvert = Math.min(pageCount, PDF_MAX_PAGES);
       const base64Images: string[] = [];
       for (let pageNum = 1; pageNum <= pagesToConvert; pageNum++) {
         base64Images.push(
-          await singlePagePdf2Png(
-            absolutePath,
-            pageNum,
-            quality,
-            maxSize,
-            tempDir,
-          ),
+          await singlePagePdf2Png(absolutePath, pageNum, tempDir),
         );
       }
       logger.debug(

--- a/src/utils/media/pdfPageCount.ts
+++ b/src/utils/media/pdfPageCount.ts
@@ -1,0 +1,18 @@
+// Third-party imports
+import { PDFDocument } from '@cantoo/pdf-lib';
+
+/**
+ * Count the pages of an in-memory PDF.
+ *
+ * Throws when the bytes cannot be parsed as a PDF, so each caller states its
+ * own failure policy instead of inheriting a silent zero.
+ */
+export async function countPdfPagesInBuffer(
+  bytes: Uint8Array,
+): Promise<number> {
+  const pdfDoc = await PDFDocument.load(bytes, {
+    updateMetadata: false,
+    ignoreEncryption: true,
+  });
+  return pdfDoc.getPageCount();
+}


### PR DESCRIPTION
## Summary

Implements the owner-accepted decision menu harvested by the wake sweep (#9586): 19 rulings, 18 lanes, each recommendation executed as stated. Outcomes: **16 implemented, 3 first-slice (series items with the remainder recorded), 2 skipped as superseded with proof.**

## Issue acceptance gates

The menu on #9586 is the ruling record; every lane carried its decision's question and accepted recommendation verbatim.

## Single source of truth

- **Run-fact dispatch (D1)**: three surfaces narrowed so an unknown event cannot be silently dropped — handler-object literals with `types` derived from their own keys, `assertNever` closures, and each unavoidable cast relocated beside the filter that justifies it.
- **ModelCell readers (D3)**: `UsageMonitor` takes the cell and reads capabilities/config off `modelCell.handler` per use; the prompt-side `MODEL` variable reads `modelCell.modelId`; `onModelChanged` narrows to `(model) => void` with exactly one remaining mirror — the persisted `AgentConfig.model` schema field, commented as such.
- **StreamStatusMachine (D8)**: the session event hub is a required constructor argument; the default-hub escape hatch and its setter are gone.
- **ExecutionKVStore (D12)**: the stale-capable `dirEnsured` latch dropped at the source; the nine compensating test workarounds deleted with it.

## Duplication and abstraction budget

Subtraction throughout: eight test-only exports deleted with their tests retargeted in the same change (D4), dead wire-contract members removed end to end (D5), the approval re-export barrel unwound (D13), the speculative `requiresInteractionsAPI` pin deleted (D14), two PDF page-count implementations folded with the error-policy divergence made a visible per-call choice (D17).

## Net elements (R6)

| | |
| --- | --- |
| Files changed | 149 |
| Net LoC | −182 (1,884 insertions, 2,066 deletions) |
| Tests | 8,503 passing (+22 over base) |

## Consumer counts (R8)

Every deleted export grep-verified to zero remaining consumers before removal; dead-code ratchet 17 vs 17, baseline untouched.

## Host impact

**The one sanctioned user-visible change (D18+D19)**: the compact follow-up composer ships deliberately — and better than the original smuggle: auto-grow via CSS `field-sizing: content` with `rows="2" resize="none"` intact, dodging the Web Awesome `resize="auto"` scroll-height bug (documented inline), pinned by a layout test plus a CSS-declaration pin. All other host-visible behavior is unchanged; D2's five formerly-silent failure paths now log (fallbacks preserved byte-for-byte), and D7 stamps explicit retirement dates on four legacy compat reads so future sweeps neither delete them wrongly nor keep them forever.

## Review

Nine-area adversarial review against the exact 19-recommendation sanction list with a dedicated `beyond-ruling` category: **10 findings, 0 high, 4 medium — all four real, all fixed before this PR**:

1. An agent "fixed" an externally-monitored diagnostic string whose deleted comment documented a byte-for-byte contract; restored exactly, with its guard comment and test.
2. D18's paired test hadn't been restored with the CSS; the auto-grow declarations are now pinned.
3. A deleted `hideWhenUnsupported` guard would have hidden the history Delete button until the host's unsupported-commands broadcast arrived; restored.
4. A test still pinning the pre-D3 triple-mirror choreography rewritten to the ruled single-mirror behavior.

## Operational note

A concurrent session committed work on its own branch in the shared checkout mid-round; one file overlapped (the D6 conversion target). This branch was cut fresh from main with the conversion re-applied as a clean patch — the concurrent branch and its commits are untouched, and nothing from it rides here.

## Validation

| check | result |
| --- | --- |
| `npm run typecheck` | pass |
| `env -u FORCE_COLOR npm test` | 825 files, 8,503 tests, 0 failures |
| lint / prettier | pass |
| dead-code + architecture ratchets | pass (71 architecture tests) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qs4Vgf3VxahEjs5maQF5Ds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide touch across agent runtime, model handlers, execution finalization, and host IPC, but behavior is mostly structural with tests retargeted; the main product risk is the extension follow-up composer layout change and subtle model-switch/accounting paths now tied to ModelCell.
> 
> **Overview**
> Implements the accepted wake-sweep rulings as a broad refactor with a small net deletion of lines, tightening single sources of truth and removing duplicate paths rather than adding features.
> 
> **Run facts and status** — CLI TUI, headless run-progress renderer, and progress-view backend now dispatch run events through exhaustive handler tables whose subscription `types` lists are derived from the same keys, with `assertNever` instead of silent drops. `StreamStatusMachine` requires the session `SessionEventHub` at construction (no default hub or late `attach`). `ExecutionRegistry` documents that a custom status machine must share that hub.
> 
> **Live model identity** — `UsageMonitor` holds a `ModelCell` and reads handler config per round; tool-use `onModelChanged` only mirrors into persisted `AgentConfig.model`, while prompts and usage read the cell (`MODEL` in prepare comes from `modelCell.modelId`). Anthropic batched tool follow-ups require the run’s client (no optional lazy client).
> 
> **CLI / approval** — Approval policy imports move from the `approvalAdapter` barrel to `@cli/runtime/approval/approvalPolicy`; settlement helpers stay on the adapter. Chat TUI resolves `defaultSession()` once as `runtimeSession` for its lifetime. Shared `formatStageLabel` replaces duplicated phase/round formatting in status bar and subagent list.
> 
> **Wire and API cleanup** — Main view drops unused `MODEL_SELECTED` and inbound `EDITED_FILE_SELECTED`; file pickers no longer special-case output files in `FileManager`. Desktop `getDesktopCommandMenuEntries` always uses the full command ID list. Settings types rename super-yolo payload to `UpdateReliabilityAndOrchestrationMessage` while keeping the legacy command literal. `writeTerminalStatus` is internal; callers/tests use `finalizeExecution`.
> 
> **Agent / storage / media** — Removes speculative Google `requiresInteractionsAPI` pinning and related routing asserts. Consolidates PDF page counting into `@utils/media/pdfPageCount` with explicit warn-and-continue on parse failure. `LatexMediaManager` drops the `supportsVision` gate on `processInputFiles` / `processOutputFiles`. `OutputXmlSummary` drops the unused `documents` field with a legacy read transform.
> 
> **Hosts and polish** — Extension follow-up composer uses CSS `field-sizing: content` instead of Web Awesome `resize="auto"`; log container padding tightens. Progress view `POP_BACK` calls `showInSidebar` directly. Several desktop OAuth/update/onboarding failure paths log instead of empty `catch`. `AGENTS.md` documents Vitest `expect` as the test assertion standard.
> 
> **Tests** — Suites use `withTestRunContext(services.runScope, …)` and `seedStreamStatusForTest` phase objects; execution terminal writes go through `finalizeExecution`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a2a3fdb7d8c51dd3d6fc0b5ddef6b7390aa7968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->