### PR TITLE
refactor(modelHandlers): decompose createResponseImpl into BUILD/EXECUTE phases

### DIFF
--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -128,9 +128,11 @@ import type {
   BetaUsage,
   MessageCountTokensParams,
   MessageCreateParams,
+  MessageCreateParamsNonStreaming,
 } from '@anthropic-ai/sdk/resources/beta/messages';
 import type {
   Base64ImageSource,
+  CacheControlEphemeral,
   MessageParam,
   ContentBlockParam,
   ToolUseBlock,
@@ -623,63 +625,44 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
   }
 
-  /** Creates an Anthropic response after SDK-boundary error tagging is installed. */
-  protected override async createResponseImpl(
-    requestOptions: CreateResponseOptions<MessageParam, Anthropic>,
-  ): Promise<CreateResponseResult<BetaMessage, MessageParam>> {
+  /**
+   * Phase 1: BUILD - Construct provider-specific request parameters.
+   * Extracted from {@link createResponseImpl} verbatim; the only inputs it
+   * needs are the already-resolved cache decision and the raw request fields.
+   */
+  private buildAnthropicRequestParams(
+    params: Pick<
+      CreateResponseOptions<MessageParam, Anthropic>,
+      | 'messages'
+      | 'temperature'
+      | 'endTag'
+      | 'systemPrompt'
+      | 'tools'
+      | 'finalTool'
+    > & {
+      supportsCache: boolean;
+      cacheControl: CacheControlEphemeral;
+      useStreaming: boolean;
+    },
+  ): MessageCreateParamsNonStreaming {
     const {
-      client,
       messages,
       temperature,
-      systemPrompt,
       endTag,
-      signal,
+      systemPrompt,
       tools,
       finalTool,
-    } = requestOptions;
-    // Get streaming config
-    const useStreaming = this.getStreamingConfig();
-    // Track input token count for client-side context management triggering
-    let measuredInputTokens: number | undefined;
-    const effectiveContextWindow = this.getEffectiveContextWindow();
-
-    // Count cache slots reserved by top-level automatic caching and system prompt
-    // so enforceCacheControlLimit knows how many remain for message blocks.
-    const supportsCache = this.capabilities.supportsPromptCaching;
-    let reservedCacheSlots = 0;
-    if (supportsCache) {
-      reservedCacheSlots += 1; // top-level automatic caching
-      if (systemPrompt) reservedCacheSlots += 1; // system prompt breakpoint
-    }
-
-    // Use 1-hour cache TTL for tool-use requests (which involve long-running
-    // tool execution cycles where 5-minute caches would frequently expire),
-    // and 5-minute TTL for simple non-tool requests.
-    const cacheControl = tools?.length
-      ? LONG_CACHE_CONTROL
-      : SHORT_CACHE_CONTROL;
-
-    enforceCacheControlLimit(
-      messages,
-      reservedCacheSlots,
+      supportsCache,
       cacheControl,
-      this.capabilities.supportsPromptCaching,
-    );
+      useStreaming,
+    } = params;
 
-    const documentAnalysis = analyzeDocumentSources(messages);
-    let hasFileReference = documentAnalysis.hasFileSource;
-
-    // Prune tracked file metadata for file IDs no longer in messages
-    // (e.g. after server-side compaction drops old messages)
-    if (
-      this.uploadedPdfPageCounts.size > 0 ||
-      this.fileTokenEstimates.size > 0
-    ) {
-      this.pruneTrackedFileMetadata(messages);
-    }
-
-    // Phase 1: BUILD - Construct provider-specific request parameters
-    const options: MessageCreateParams = {
+    // Typed as the non-streaming member: this handler never sets `stream`, and
+    // pinning the member here (rather than the `MessageCreateParams` union)
+    // preserves the narrowed type through `dispatchAnthropicExecution`'s
+    // `client.beta.messages.create()` call — a plain union parameter type
+    // would force TS to pick the ambiguous three-way overload.
+    const options: MessageCreateParamsNonStreaming = {
       model: this.config.fullName,
       max_tokens: this.getEffectiveMaxOutputTokens(),
       messages,
@@ -783,6 +766,177 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
     }
 
+    return options;
+  }
+
+  /**
+   * Phase 4: EXECUTE - Dispatch through the provider's two SDK paths
+   * (streaming vs. non-streaming), including the non-streaming compaction
+   * heuristic and post-response bookkeeping. Extracted from
+   * {@link createResponseImpl} verbatim; it is the tail of that method, so it
+   * returns the final {@link CreateResponseResult} directly.
+   */
+  private async dispatchAnthropicExecution(params: {
+    client: Anthropic;
+    options: MessageCreateParamsNonStreaming;
+    useStreaming: boolean;
+    measuredInputTokens: number | undefined;
+    hasFileReference: boolean;
+    messages: MessageParam[];
+    signal: AbortSignal | undefined;
+    effectiveContextWindow: number;
+    compactionConsumed: boolean;
+    pendingCompactionRequestId: number | undefined;
+  }): Promise<CreateResponseResult<BetaMessage, MessageParam>> {
+    const {
+      client,
+      options,
+      useStreaming,
+      measuredInputTokens,
+      hasFileReference,
+      messages,
+      signal,
+      effectiveContextWindow,
+      compactionConsumed,
+      pendingCompactionRequestId,
+    } = params;
+
+    // Non-streaming responses have no block-start event. Use the native count
+    // when available and otherwise combine the existing text heuristic with
+    // tracked PDF pages. Treating an unavailable count as either zero or
+    // definitely over threshold would miss large requests or label every small
+    // request as compaction.
+    const compactionEdit = options.context_management?.edits?.find(
+      (edit) => edit.type === 'compact_20260112',
+    );
+    const compactionTrigger =
+      !useStreaming && compactionEdit?.trigger?.type === 'input_tokens'
+        ? compactionEdit.trigger.value
+        : undefined;
+    let inputTokensForCompaction = measuredInputTokens;
+    if (inputTokensForCompaction === undefined) {
+      const textTokens = estimateTokensFromText(
+        JSON.stringify({
+          messages: options.messages,
+          system: options.system,
+          tools: options.tools,
+          thinking: options.thinking,
+          outputConfig: options.output_config,
+        }),
+      );
+      const tokensUntilCompaction =
+        compactionTrigger === undefined ? 0 : compactionTrigger - textTokens;
+      const fileReferenceTokens =
+        hasFileReference && tokensUntilCompaction > 0
+          ? await this.estimateFileReferenceTokens(
+              client,
+              messages,
+              signal,
+              tokensUntilCompaction,
+            )
+          : 0;
+      inputTokensForCompaction = textTokens + fileReferenceTokens;
+    }
+    const nonStreamingCompactionExpected =
+      compactionTrigger !== undefined &&
+      inputTokensForCompaction >= compactionTrigger;
+
+    if (nonStreamingCompactionExpected) {
+      logCompactionActivity(this.logger, 'started');
+    }
+
+    let response: BetaMessage;
+    try {
+      response = useStreaming
+        ? await this.executeStreamingResponse(client, options, signal)
+        : await client.beta.messages.create(options, { signal });
+    } finally {
+      if (nonStreamingCompactionExpected) {
+        logCompactionActivity(this.logger, 'finished');
+      }
+    }
+
+    if (compactionConsumed && pendingCompactionRequestId !== undefined) {
+      this.clearCompactionRequest(pendingCompactionRequestId);
+    }
+
+    // Log server-side compaction events when present in response content.
+    logContextManagementFromResponse(
+      response,
+      effectiveContextWindow,
+      this.logger,
+    );
+
+    return { response };
+  }
+
+  /** Creates an Anthropic response after SDK-boundary error tagging is installed. */
+  protected override async createResponseImpl(
+    requestOptions: CreateResponseOptions<MessageParam, Anthropic>,
+  ): Promise<CreateResponseResult<BetaMessage, MessageParam>> {
+    const {
+      client,
+      messages,
+      temperature,
+      systemPrompt,
+      endTag,
+      signal,
+      tools,
+      finalTool,
+    } = requestOptions;
+    // Get streaming config
+    const useStreaming = this.getStreamingConfig();
+    // Track input token count for client-side context management triggering
+    let measuredInputTokens: number | undefined;
+    const effectiveContextWindow = this.getEffectiveContextWindow();
+
+    // Count cache slots reserved by top-level automatic caching and system prompt
+    // so enforceCacheControlLimit knows how many remain for message blocks.
+    const supportsCache = this.capabilities.supportsPromptCaching;
+    let reservedCacheSlots = 0;
+    if (supportsCache) {
+      reservedCacheSlots += 1; // top-level automatic caching
+      if (systemPrompt) reservedCacheSlots += 1; // system prompt breakpoint
+    }
+
+    // Use 1-hour cache TTL for tool-use requests (which involve long-running
+    // tool execution cycles where 5-minute caches would frequently expire),
+    // and 5-minute TTL for simple non-tool requests.
+    const cacheControl = tools?.length
+      ? LONG_CACHE_CONTROL
+      : SHORT_CACHE_CONTROL;
+
+    enforceCacheControlLimit(
+      messages,
+      reservedCacheSlots,
+      cacheControl,
+      this.capabilities.supportsPromptCaching,
+    );
+
+    const documentAnalysis = analyzeDocumentSources(messages);
+    let hasFileReference = documentAnalysis.hasFileSource;
+
+    // Prune tracked file metadata for file IDs no longer in messages
+    // (e.g. after server-side compaction drops old messages)
+    if (
+      this.uploadedPdfPageCounts.size > 0 ||
+      this.fileTokenEstimates.size > 0
+    ) {
+      this.pruneTrackedFileMetadata(messages);
+    }
+
+    const options = this.buildAnthropicRequestParams({
+      messages,
+      temperature,
+      endTag,
+      systemPrompt,
+      tools,
+      finalTool,
+      supportsCache,
+      cacheControl,
+      useStreaming,
+    });
+
     // Set up context management before token counting so estimates use matching options.
     const compactionThresholdPercent = this.getCompactionThresholdPercent();
     const pendingCompactionRequestId = this.getPendingCompactionRequestId();
@@ -867,74 +1021,18 @@ export class ModelHandlerAnthropic extends ModelHandler<
       ensureBeta(options, FILES_API_BETA);
     }
 
-    // Phase 4: EXECUTE - Dispatch through the provider's two SDK paths.
-    // Non-streaming responses have no block-start event. Use the native count
-    // when available and otherwise combine the existing text heuristic with
-    // tracked PDF pages. Treating an unavailable count as either zero or
-    // definitely over threshold would miss large requests or label every small
-    // request as compaction.
-    const compactionEdit = options.context_management?.edits?.find(
-      (edit) => edit.type === 'compact_20260112',
-    );
-    const compactionTrigger =
-      !useStreaming && compactionEdit?.trigger?.type === 'input_tokens'
-        ? compactionEdit.trigger.value
-        : undefined;
-    let inputTokensForCompaction = measuredInputTokens;
-    if (inputTokensForCompaction === undefined) {
-      const textTokens = estimateTokensFromText(
-        JSON.stringify({
-          messages: options.messages,
-          system: options.system,
-          tools: options.tools,
-          thinking: options.thinking,
-          outputConfig: options.output_config,
-        }),
-      );
-      const tokensUntilCompaction =
-        compactionTrigger === undefined ? 0 : compactionTrigger - textTokens;
-      const fileReferenceTokens =
-        hasFileReference && tokensUntilCompaction > 0
-          ? await this.estimateFileReferenceTokens(
-              client,
-              messages,
-              signal,
-              tokensUntilCompaction,
-            )
-          : 0;
-      inputTokensForCompaction = textTokens + fileReferenceTokens;
-    }
-    const nonStreamingCompactionExpected =
-      compactionTrigger !== undefined &&
-      inputTokensForCompaction >= compactionTrigger;
-
-    if (nonStreamingCompactionExpected) {
-      logCompactionActivity(this.logger, 'started');
-    }
-
-    let response: BetaMessage;
-    try {
-      response = useStreaming
-        ? await this.executeStreamingResponse(client, options, signal)
-        : await client.beta.messages.create(options, { signal });
-    } finally {
-      if (nonStreamingCompactionExpected) {
-        logCompactionActivity(this.logger, 'finished');
-      }
-    }
-
-    if (compactionConsumed && pendingCompactionRequestId !== undefined) {
-      this.clearCompactionRequest(pendingCompactionRequestId);
-    }
-
-    // Log server-side compaction events when present in response content.
-    logContextManagementFromResponse(
-      response,
+    return this.dispatchAnthropicExecution({
+      client,
+      options,
+      useStreaming,
+      measuredInputTokens,
+      hasFileReference,
+      messages,
+      signal,
       effectiveContextWindow,
-      this.logger,
-    );
-
-    return { response };
+      compactionConsumed,
+      pendingCompactionRequestId,
+    });
   }
 
   /** Initializes the message array for Anthropic chat models with user prefix, request, and optional media. */

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1276,6 +1276,66 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     // super.getStreamingConfig() (not this.) — the override would recompute
     // background mode (extra config reads) when we already know useBackground.
     const useStreaming = !useBackground && super.getStreamingConfig();
+
+    return this.dispatchGoogleInteractionsExecution({
+      client,
+      inputSteps,
+      stateful,
+      previousId,
+      systemPrompt,
+      interactionsTools,
+      generationConfig,
+      signal,
+      endTag,
+      baseLength: base.length,
+      useBackground,
+      useStreaming,
+      updatedMessages,
+      options,
+    });
+  }
+
+  /**
+   * Dispatch phase: build the common request shape and route through
+   * background / streaming / non-streaming, including the shared error
+   * recovery (background-unsupported fallback and stale-chain retry, both
+   * self-recursive back into {@link createResponseImpl}). Extracted from
+   * {@link createResponseImpl} verbatim; it is the tail of that method, so it
+   * returns the final {@link CreateResponseResult} directly.
+   */
+  private async dispatchGoogleInteractionsExecution(args: {
+    client: GoogleGenAI;
+    inputSteps: Step[];
+    stateful: boolean;
+    previousId: string | undefined;
+    systemPrompt: string | undefined;
+    interactionsTools: FunctionT[] | undefined;
+    generationConfig: GenerationConfig;
+    signal: AbortSignal | undefined;
+    endTag: string | undefined;
+    baseLength: number;
+    useBackground: boolean;
+    useStreaming: boolean;
+    updatedMessages: Step[] | undefined;
+    options: CreateResponseOptions<Step, GoogleGenAI>;
+  }): Promise<CreateResponseResult<GoogleGenAIInteraction, Step>> {
+    const {
+      client,
+      inputSteps,
+      stateful,
+      previousId,
+      systemPrompt,
+      interactionsTools,
+      generationConfig,
+      signal,
+      endTag,
+      baseLength,
+      useBackground,
+      useStreaming,
+      updatedMessages,
+      options,
+    } = args;
+
     let aggregatedText = '';
 
     const withUpdated = (
@@ -1300,7 +1360,7 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
         const result = await this.executeBackgroundPath(
           client,
           commonParams,
-          base.length,
+          baseLength,
           stateful,
           requestOptions,
           signal,
@@ -1320,7 +1380,7 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
         const result = await this.consumeStream(stream, endTag, (text) => {
           aggregatedText += text;
         });
-        this.finalizeChain(result.response, base.length, stateful);
+        this.finalizeChain(result.response, baseLength, stateful);
         return withUpdated(result);
       }
 
@@ -1338,7 +1398,7 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
         stream: false as const,
       };
       const response = await client.interactions.create(params, requestOptions);
-      this.finalizeChain(response, base.length, stateful);
+      this.finalizeChain(response, baseLength, stateful);
       return withUpdated({ response });
     } catch (error) {
       // Model doesn't support background interactions (e.g. gemini-2.5-flash ⇒

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -145,6 +145,28 @@ interface ResponseFinalizeContext {
   readonly compactedMessages: ResponseInputItem[] | undefined;
 }
 
+/**
+ * Shape returned by {@link ModelHandlerOpenAIResponse.buildResponseBaseParams}
+ * (the BUILD phase): the fields shared by token counting and the final API
+ * call, before the EXECUTE phase layers on `max_output_tokens`, `store`, and
+ * the transport-specific flags. `input` is narrowed to `ResponseInputItem[]`
+ * (rather than `ResponseCreateParamsBase`'s `string | ResponseInput`) because
+ * this handler always builds it from `newMessages`, and token counting reads
+ * it back as an array.
+ */
+type OpenAIResponseBaseParams = Omit<
+  Pick<
+    ResponseCreateParamsBase,
+    | 'model'
+    | 'input'
+    | 'instructions'
+    | 'previous_response_id'
+    | 'tools'
+    | 'reasoning'
+  >,
+  'input'
+> & { input: ResponseInputItem[] };
+
 type ServerToolContentBlock = ResponseFunctionWebSearch | ResponseReasoningItem;
 
 /**
@@ -1455,6 +1477,210 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     return true;
   }
 
+  /**
+   * Phase 1: BUILD - Construct the shared base request parameters (including
+   * the reasoning config) used by both token counting and the API call.
+   * Extracted from {@link createResponseImpl} verbatim.
+   */
+  private buildResponseBaseParams(args: {
+    newMessages: ResponseInputItem[];
+    systemPrompt: string | undefined;
+    convertedTools: ReturnType<typeof toOpenAIResponseTools> | undefined;
+  }): OpenAIResponseBaseParams {
+    const { newMessages, systemPrompt, convertedTools } = args;
+
+    const rawEffort = this.capabilities.supportsReasoning
+      ? this.getEffectiveReasoningEffort()
+      : undefined;
+    const reasoningEffort = rawEffort
+      ? toOpenAIReasoningEffort(
+          rawEffort,
+          getDeclaredMaxReasoningEffort(this.config.capabilities),
+        )
+      : undefined;
+    // Pro-mode registry entries (GPT-5.6 Pro) share the base model's wire id
+    // and select pro execution via `reasoning.mode` on the request.
+    const reasoningMode = this.capabilities.reasoningMode;
+    const reasoning: Reasoning | undefined =
+      reasoningEffort || reasoningMode
+        ? {
+            ...(reasoningEffort && { effort: reasoningEffort }),
+            ...(reasoningMode && { mode: reasoningMode }),
+          }
+        : undefined;
+
+    return {
+      model: this.config.fullName,
+      input: newMessages,
+      ...(systemPrompt && { instructions: systemPrompt }),
+      ...(this.supportsResponseChaining &&
+        this.chainState.getPreviousResponseId() && {
+          previous_response_id: this.chainState.getPreviousResponseId(),
+        }),
+      ...(convertedTools?.length && { tools: convertedTools }),
+      ...(reasoning && { reasoning }),
+    };
+  }
+
+  /**
+   * Phase 4: EXECUTE - Build the final request params and dispatch through
+   * the WebSocket / streaming / non-streaming transport paths, including the
+   * shared error recovery for all three. Extracted from
+   * {@link createResponseImpl} verbatim; it is the tail of that method, so it
+   * returns the final {@link CreateResponseResult} directly.
+   */
+  private async dispatchOpenAIResponseExecution(args: {
+    baseParams: OpenAIResponseBaseParams;
+    maxOutputTokens: number;
+    convertedTools: ReturnType<typeof toOpenAIResponseTools> | undefined;
+    finalTool: CreateResponseOptions<ResponseInputItem, OpenAI>['finalTool'];
+    useBackgroundResponses: boolean;
+    useWebSocket: boolean;
+    useStreaming: boolean;
+    temperature: number;
+    client: OpenAI;
+    signal: AbortSignal | undefined;
+    effectiveMessages: ResponseInputItem[];
+    compactedThisCall: boolean;
+    compactedMessages: ResponseInputItem[] | undefined;
+    requestOptions: CreateResponseOptions<ResponseInputItem, OpenAI>;
+  }): Promise<CreateResponseResult<Response, ResponseInputItem>> {
+    const {
+      baseParams,
+      maxOutputTokens,
+      convertedTools,
+      finalTool,
+      useBackgroundResponses,
+      useWebSocket,
+      useStreaming,
+      temperature,
+      client,
+      signal,
+      effectiveMessages,
+      compactedThisCall,
+      compactedMessages,
+      requestOptions,
+    } = args;
+
+    // Phase 4: EXECUTE - Build final params and make the API call
+    const parallelToolCalls = getConfig<boolean>(
+      'texra.model.openaiParallelToolCalls',
+      DEFAULT_CORE_SETTINGS.model.openaiParallelToolCalls,
+    );
+    const params: ResponseCreateParamsBase = {
+      ...baseParams,
+      max_output_tokens: maxOutputTokens,
+      store: this.storesResponsesServerSide,
+      // llm-zoo's Fast tier maps to the SDK's current priority wire value.
+      ...(this.config.serviceTier === 'fast' && {
+        service_tier: 'priority',
+      }),
+      ...(convertedTools?.length && {
+        tool_choice: finalTool
+          ? ({ type: 'function', name: finalTool.name } as const)
+          : ('auto' as const),
+        parallel_tool_calls: parallelToolCalls,
+      }),
+    };
+
+    if (useBackgroundResponses) {
+      this.logger.debug(
+        'Submitting OpenAI Responses request in background mode.',
+        {
+          data: {
+            model: this.config.fullName,
+            previousResponseId:
+              this.chainState.getPreviousResponseId() ?? undefined,
+          },
+        },
+      );
+      params.background = true;
+    }
+
+    if (!this.isOReasoningModel) {
+      params.temperature = temperature;
+    }
+
+    // Include web search sources in response when native web search is enabled.
+    // This is set outside the tools block because deep research models use
+    // native web search even when no explicit tools are passed.
+    if (this.capabilities.supportsNativeWebSearch) {
+      params.include = ['web_search_call.action.sources'];
+    }
+
+    // Stateless (store:false) backends keep no server-side reasoning, so request
+    // encrypted reasoning blobs to replay in the next turn's input for cross-turn
+    // reasoning continuity (matching the Codex CLI / OpenCode). The store:true
+    // path retains reasoning via previous_response_id and must not replay it.
+    if (
+      !this.storesResponsesServerSide &&
+      this.capabilities.supportsReasoning
+    ) {
+      params.include = [
+        ...(params.include ?? []),
+        'reasoning.encrypted_content',
+      ];
+    }
+
+    // Extend reasoning with summary option for API call (not needed for token counting)
+    if (this.capabilities.supportsReasoning) {
+      const isGpt5 = isGpt5ModelName(this.config.name);
+      const includeSummary =
+        !isGpt5 ||
+        getConfig<boolean>('texra.model.gpt5ReasoningSummary', false);
+      if (includeSummary) {
+        params.reasoning = {
+          ...(params.reasoning as Reasoning),
+          summary: 'auto',
+        };
+      }
+    }
+
+    const finalizeContext: ResponseFinalizeContext = {
+      effectiveMessagesLength: effectiveMessages.length,
+      compactedThisCall,
+      compactedMessages,
+    };
+
+    // Wrap execution in a try/catch so the error handler can recover from an
+    // invalid/expired previous_response_id or a context-window overflow.
+    try {
+      // WebSocket transport: persistent connection for lower-latency tool-use loops
+      if (useWebSocket) {
+        return await this.executeWebSocketPath(
+          params,
+          client,
+          signal,
+          finalizeContext,
+        );
+      }
+
+      if (useStreaming) {
+        return await this.executeStreamingPath(
+          params,
+          client,
+          signal,
+          finalizeContext,
+        );
+      }
+
+      // Non-streaming path
+      return await this.executeNonStreamingPath(
+        params,
+        client,
+        signal,
+        useBackgroundResponses,
+        finalizeContext,
+      );
+    } catch (error) {
+      return await this.handleCreateResponseError(
+        error,
+        requestOptions,
+        compactedThisCall,
+      );
+    }
+  }
+
   protected override async createResponseImpl(
     options: CreateResponseOptions<ResponseInputItem, OpenAI>,
   ): Promise<CreateResponseResult<Response, ResponseInputItem>> {
@@ -1637,39 +1863,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     // Build shared params used by both token counting and API call
-
-    const rawEffort = this.capabilities.supportsReasoning
-      ? this.getEffectiveReasoningEffort()
-      : undefined;
-    const reasoningEffort = rawEffort
-      ? toOpenAIReasoningEffort(
-          rawEffort,
-          getDeclaredMaxReasoningEffort(this.config.capabilities),
-        )
-      : undefined;
-    // Pro-mode registry entries (GPT-5.6 Pro) share the base model's wire id
-    // and select pro execution via `reasoning.mode` on the request.
-    const reasoningMode = this.capabilities.reasoningMode;
-    const reasoning: Reasoning | undefined =
-      reasoningEffort || reasoningMode
-        ? {
-            ...(reasoningEffort && { effort: reasoningEffort }),
-            ...(reasoningMode && { mode: reasoningMode }),
-          }
-        : undefined;
-
-    // Phase 1: BUILD - Construct provider-specific request parameters
-    const baseParams = {
-      model: this.config.fullName,
-      input: newMessages,
-      ...(systemPrompt && { instructions: systemPrompt }),
-      ...(this.supportsResponseChaining &&
-        this.chainState.getPreviousResponseId() && {
-          previous_response_id: this.chainState.getPreviousResponseId(),
-        }),
-      ...(convertedTools?.length && { tools: convertedTools }),
-      ...(reasoning && { reasoning }),
-    };
+    const baseParams = this.buildResponseBaseParams({
+      newMessages,
+      systemPrompt,
+      convertedTools,
+    });
 
     let maxOutputTokens = this.getEffectiveMaxOutputTokens();
     maxOutputTokens = this.applyChainedOutputTokenBudget(maxOutputTokens);
@@ -1750,123 +1948,22 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       return this.createResponseImpl(options);
     }
 
-    // Phase 4: EXECUTE - Build final params and make the API call
-    const parallelToolCalls = getConfig<boolean>(
-      'texra.model.openaiParallelToolCalls',
-      DEFAULT_CORE_SETTINGS.model.openaiParallelToolCalls,
-    );
-    const params: ResponseCreateParamsBase = {
-      ...baseParams,
-      max_output_tokens: maxOutputTokens,
-      store: this.storesResponsesServerSide,
-      // llm-zoo's Fast tier maps to the SDK's current priority wire value.
-      ...(this.config.serviceTier === 'fast' && {
-        service_tier: 'priority',
-      }),
-      ...(convertedTools?.length && {
-        tool_choice: finalTool
-          ? ({ type: 'function', name: finalTool.name } as const)
-          : ('auto' as const),
-        parallel_tool_calls: parallelToolCalls,
-      }),
-    };
-
-    if (useBackgroundResponses) {
-      this.logger.debug(
-        'Submitting OpenAI Responses request in background mode.',
-        {
-          data: {
-            model: this.config.fullName,
-            previousResponseId:
-              this.chainState.getPreviousResponseId() ?? undefined,
-          },
-        },
-      );
-      params.background = true;
-    }
-
-    if (!this.isOReasoningModel) {
-      params.temperature = temperature;
-    }
-
-    // Include web search sources in response when native web search is enabled.
-    // This is set outside the tools block because deep research models use
-    // native web search even when no explicit tools are passed.
-    if (this.capabilities.supportsNativeWebSearch) {
-      params.include = ['web_search_call.action.sources'];
-    }
-
-    // Stateless (store:false) backends keep no server-side reasoning, so request
-    // encrypted reasoning blobs to replay in the next turn's input for cross-turn
-    // reasoning continuity (matching the Codex CLI / OpenCode). The store:true
-    // path retains reasoning via previous_response_id and must not replay it.
-    if (
-      !this.storesResponsesServerSide &&
-      this.capabilities.supportsReasoning
-    ) {
-      params.include = [
-        ...(params.include ?? []),
-        'reasoning.encrypted_content',
-      ];
-    }
-
-    // Extend reasoning with summary option for API call (not needed for token counting)
-    if (this.capabilities.supportsReasoning) {
-      const isGpt5 = isGpt5ModelName(this.config.name);
-      const includeSummary =
-        !isGpt5 ||
-        getConfig<boolean>('texra.model.gpt5ReasoningSummary', false);
-      if (includeSummary) {
-        params.reasoning = {
-          ...(params.reasoning as Reasoning),
-          summary: 'auto',
-        };
-      }
-    }
-
-    const finalizeContext: ResponseFinalizeContext = {
-      effectiveMessagesLength: effectiveMessages.length,
+    return this.dispatchOpenAIResponseExecution({
+      baseParams,
+      maxOutputTokens,
+      convertedTools,
+      finalTool,
+      useBackgroundResponses,
+      useWebSocket,
+      useStreaming,
+      temperature,
+      client,
+      signal,
+      effectiveMessages,
       compactedThisCall,
       compactedMessages,
-    };
-
-    // Wrap execution in a try/catch so the error handler can recover from an
-    // invalid/expired previous_response_id or a context-window overflow.
-    try {
-      // WebSocket transport: persistent connection for lower-latency tool-use loops
-      if (useWebSocket) {
-        return await this.executeWebSocketPath(
-          params,
-          client,
-          signal,
-          finalizeContext,
-        );
-      }
-
-      if (useStreaming) {
-        return await this.executeStreamingPath(
-          params,
-          client,
-          signal,
-          finalizeContext,
-        );
-      }
-
-      // Non-streaming path
-      return await this.executeNonStreamingPath(
-        params,
-        client,
-        signal,
-        useBackgroundResponses,
-        finalizeContext,
-      );
-    } catch (error) {
-      return await this.handleCreateResponseError(
-        error,
-        options,
-        compactedThisCall,
-      );
-    }
+      requestOptions: options,
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #9585 (already merged), which covered 4 of 5 refactor targets from a tech-debt scan of the largest ad-hoc/duplicated areas in the codebase. This PR lands the fifth and riskiest: decomposing each provider's monolithic `createResponseImpl` into named BUILD/EXECUTE phase methods, following the decomposition pattern the base class already established for COUNT+VALIDATE (`ModelHandler.applyTokenCountLimit`).

Each provider's `createResponseImpl` inlined the full LLM request lifecycle in one long method — hand-labeled `Phase 1 BUILD / Phase 2 COUNT / Phase 3 VALIDATE / Phase 4 EXECUTE` in comments, but only COUNT+VALIDATE had actually been extracted. This is pure extract-method refactoring: no branch, retry, or error-handling logic changed, only split into smaller named methods with identical control flow.

- **Anthropic**: 312 → ~163 lines. `buildAnthropicRequestParams` (BUILD), `dispatchAnthropicExecution` (EXECUTE tail).
- **OpenAI Responses**: ~413 → ~288 lines. `buildResponseBaseParams` (BUILD), `dispatchOpenAIResponseExecution` (EXECUTE tail). Both self-recursive `createResponseImpl()` retries (pre-flight compaction, overflow-recovery) stay exactly where they were.
- **Google Interactions**: 225 → ~133 lines. A single conservative tail extraction (`dispatchGoogleInteractionsExecution`) — commonParams construction stayed inline rather than getting its own typed BUILD method, per an existing comment warning that naming the request-params type causes TS to fall through to the SDK's most general `create()` overload and lose response typing.
- **OpenAI chat** (`modelHandlerOpenAI.ts`): left untouched — already ~72 lines, already delegating to `buildChatBaseParams`/`executeStreamingChat`/`executeNonStreamingChat`.

## Issue acceptance gates

No tracked issue; this is a proactive tech-debt refactor from a scheduled codebase scan. Acceptance gate: every provider's `createResponseImpl` decomposition preserves exact behavior (control flow, variable capture, execution order, error handling) — verified by full test suite plus line-by-line diff trace against the original.

## Single source of truth

No new fact ownership — this is a pure structural extraction. Each provider class remains the sole owner of its own request-building/dispatch logic; nothing moved to a shared base-class template, since the four providers' BUILD/EXECUTE bodies are only similarly-shaped, not identical (a prior sibling PR already covered the pieces that genuinely were identical — the streaming aggregator core, tool-attachment upload, and media classification).

## Duplication and abstraction budget

No duplication removed here (the providers' request-building logic is provider-specific, not duplicated across them) — this PR is about complexity/testability, not deduplication. No new cross-file abstraction added: the two new methods per provider are private instance methods on the existing handler class, not exported, not shared.

## Net elements (R6)

No files added or deleted. No new exported symbols (`grep '^[+-]export'` over the diff: 0 matches — all new methods are `private`). 6 new private methods added (2 per touched provider); 0 removed. Net diff: +523/-268 across 3 files (the increase is method-boundary parameter objects and doc comments, not new logic).

## Consumer counts (R8)

N/A — no emit path or export re-routed. All new methods are single-caller private methods called once from their provider's reassembled `createResponseImpl`.

## Host impact

Extension: none (shared `src/agent/modelHandlers/` core, no host-specific code touched).

Desktop: none (same).

CLI: none (same).

## Scheduled refactoring

None. This closes out the 5-item scan that produced #9585 and this PR.

## Validation

- `npm run typecheck` (full workspace, all 7 sub-checks) — clean
- `npx eslint` on all 3 touched files — clean
- `npx prettier --check .` (whole repo) — clean
- `npx vitest run` (full suite) — 8498 passed / 9 skipped (pre-existing), 0 failures
- `npm run check:dead-code-ratchet` — 17 findings, matches baseline, no new dead exports
- Manual line-by-line diff trace confirming every original line executes in the same relative order in the new methods, for all 3 files, with particular attention to the two self-recursive `createResponseImpl()` retries in the OpenAI Responses handler (both preserved verbatim in their original positions) and the two preserved in the Google Interactions handler's error-recovery path.

Flagging for reviewer attention: two spots needed an explicit type pin to keep TypeScript's structural narrowing correct across the new method boundaries (Anthropic's `options` typed as `MessageCreateParamsNonStreaming` rather than the broader `MessageCreateParams` union; OpenAI Responses' `OpenAIResponseBaseParams.input` narrowed back to `ResponseInputItem[]`). Both are backed by the SDK's own overload set, verified against runtime behavior (neither handler ever sets `stream: true` on these objects), and pass full typecheck — but this is billing/retry-critical code, so a second look at those two spots specifically would be welcome.

---
_Generated by [Claude Code](https://claude.ai/code/session_01233jpnfVhfkGgvmxw2yj5c)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core LLM request, compaction, chaining, and error-retry paths across three providers; risk is structural (extract-method) but mistakes at method boundaries could alter billing or retry behavior.
> 
> **Overview**
> This PR **refactors** Anthropic, OpenAI Responses, and Google Interactions so each provider’s monolithic `createResponseImpl` matches the base handler’s phased lifecycle: **BUILD** (request params) and **EXECUTE** (transport dispatch), with COUNT/VALIDATE still inline where they were.
> 
> **Anthropic** moves request construction into `buildAnthropicRequestParams` and the streaming/non-streaming tail (compaction heuristics, API call, post-response logging) into `dispatchAnthropicExecution`. `options` is pinned to `MessageCreateParamsNonStreaming` so TypeScript keeps the correct `beta.messages.create` overload.
> 
> **OpenAI Responses** adds `OpenAIResponseBaseParams` plus `buildResponseBaseParams` for shared model/input/tools/reasoning fields, and `dispatchOpenAIResponseExecution` for final params, background/WebSocket/streaming/non-streaming routing, and `handleCreateResponseError`. Self-recursive compaction retries stay in `createResponseImpl`.
> 
> **Google Interactions** extracts only `dispatchGoogleInteractionsExecution` (background vs streaming vs non-streaming, stale-chain and background-unsupported retries, partial text on failure); `commonParams` stays inline to avoid SDK overload typing issues.
> 
> No new shared abstractions or exported APIs—private methods only, behavior intended unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05fb614be2ba3de74a36d7506e1c548e88747568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->