### PR TITLE
fix: enlarge progress message composer

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -106,11 +106,9 @@ export class FollowUpInput extends LitElement {
             color-mix(in srgb, var(--wa-color-surface-shadow) 16%, transparent);
       }
 
-      /* Web Awesome's resize="auto" copies the textarea scroll height into an
-         invisible grid item. Inside a constrained composer that grid item can
-         preserve an oversized row for an empty draft. Size the native
-         textarea part from its content instead: two lines initially, growing
-         to the bounded reading height before it scrolls. */
+      /* Give substantial instructions six lines by default. Web Awesome's
+         vertical mode puts the resize affordance on the native textarea and
+         mirrors its bounded height onto the wrapper. */
       #followUpInput {
         display: block;
         min-width: 0;
@@ -119,9 +117,9 @@ export class FollowUpInput extends LitElement {
         line-height: var(--line-height-relaxed);
         height: auto;
         --textarea-min-height: calc(
-          2lh + var(--wa-space-xs) + var(--wa-space-3xs)
+          6lh + var(--wa-space-xs) + var(--wa-space-3xs)
         );
-        --textarea-max-height: min(32vh, 240px);
+        --textarea-max-height: clamp(var(--textarea-min-height), 32vh, 240px);
       }
 
       #followUpInput::part(base) {
@@ -136,9 +134,7 @@ export class FollowUpInput extends LitElement {
       /* The one place a textarea renders sans rather than mono: this is prose a
          user writes to an agent, not code. */
       #followUpInput::part(textarea) {
-        field-sizing: content;
         width: 100%;
-        height: auto;
         min-height: var(--textarea-min-height);
         max-height: var(--textarea-max-height);
         padding: var(--wa-space-xs) var(--wa-space-s) var(--wa-space-3xs);
@@ -421,8 +417,8 @@ export class FollowUpInput extends LitElement {
           <wa-textarea
             id=${ELEMENT_IDS.FOLLOW_UP_INPUT}
             placeholder="Message TeXRA…"
-            rows="2"
-            resize="none"
+            rows="6"
+            resize="vertical"
             .value=${live(this.value)}
             @input=${this.handleInput}
             @keydown=${this.handleKeydown}

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -122,7 +122,7 @@ export class FollowUpInput extends LitElement {
         --textarea-max-height: clamp(var(--textarea-min-height), 32vh, 240px);
       }
 
-      #followUpInput::part(base) {
+      #followUpInput::part(textarea-wrapper) {
         align-items: start;
         max-height: var(--textarea-max-height);
         overflow: hidden;

--- a/scripts/smoke-webviews-electron-runner.cjs
+++ b/scripts/smoke-webviews-electron-runner.cjs
@@ -364,6 +364,147 @@ function createSmokeWindow(errors) {
   return window;
 }
 
+async function assertProgressComposerLayout(window, view) {
+  return window.webContents.executeJavaScript(
+    `
+      (async () => {
+        function findDeep(selector, root = document) {
+          const direct = root.querySelector?.(selector);
+          if (direct) return direct;
+          for (const element of root.querySelectorAll?.('*') ?? []) {
+            const found = element.shadowRoot ? findDeep(selector, element.shadowRoot) : null;
+            if (found) return found;
+          }
+          return null;
+        }
+
+        const composer = findDeep('follow-up-input');
+        const dock = findDeep('.conversation-composer-dock');
+        const conversationLog = findDeep('.conversation-log');
+        const webAwesomeTextarea = composer?.shadowRoot?.querySelector('wa-textarea');
+        if (webAwesomeTextarea?.updateComplete) await webAwesomeTextarea.updateComplete;
+        const textarea = webAwesomeTextarea?.shadowRoot?.querySelector('textarea');
+        const wrapper = webAwesomeTextarea?.shadowRoot?.querySelector('.textarea');
+
+        const missing = [
+          ['follow-up-input', composer],
+          ['composer dock', dock],
+          ['conversation log', conversationLog],
+          ['wa-textarea', webAwesomeTextarea],
+          ['native textarea', textarea],
+          ['textarea wrapper', wrapper],
+        ]
+          .filter(([, element]) => !element)
+          .map(([label]) => label);
+        if (missing.length > 0) {
+          throw new Error(\`${view.name} missing composer layout elements: \${missing.join(', ')}\`);
+        }
+
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+        const style = getComputedStyle(textarea);
+        const lineHeight = Number.parseFloat(style.lineHeight);
+        const paddingBlock =
+          Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingBottom);
+        const minHeight = Number.parseFloat(style.minHeight);
+        const maxHeight = Number.parseFloat(style.maxHeight);
+        const expectedMinHeight = 6 * lineHeight + paddingBlock;
+        const expectedMaxHeight = Math.max(
+          minHeight,
+          Math.min(window.innerHeight * 0.32, 240),
+        );
+        const initialTextareaRect = textarea.getBoundingClientRect();
+        const initialWrapperRect = wrapper.getBoundingClientRect();
+
+        if (webAwesomeTextarea.rows !== 6 || textarea.rows !== 6) {
+          throw new Error(
+            \`${view.name} composer rows did not propagate: host=\${webAwesomeTextarea.rows} native=\${textarea.rows}\`,
+          );
+        }
+        if (webAwesomeTextarea.resize !== 'vertical' || style.resize !== 'vertical') {
+          throw new Error(
+            \`${view.name} composer is not vertically resizable: host=\${webAwesomeTextarea.resize} native=\${style.resize}\`,
+          );
+        }
+        if (Math.abs(minHeight - expectedMinHeight) > 3) {
+          throw new Error(
+            \`${view.name} composer minimum is not six lines: min=\${minHeight.toFixed(1)}px expected=\${expectedMinHeight.toFixed(1)}px\`,
+          );
+        }
+        if (initialTextareaRect.height < minHeight - 1) {
+          throw new Error(
+            \`${view.name} native textarea rendered below its minimum: rendered=\${initialTextareaRect.height.toFixed(1)}px min=\${minHeight.toFixed(1)}px\`,
+          );
+        }
+        if (maxHeight > 241 || Math.abs(maxHeight - expectedMaxHeight) > 3) {
+          throw new Error(
+            \`${view.name} composer max-height cap is incorrect: max=\${maxHeight.toFixed(1)}px expected=\${expectedMaxHeight.toFixed(1)}px\`,
+          );
+        }
+        if (Math.abs(initialWrapperRect.height - initialTextareaRect.height) > 2) {
+          throw new Error(
+            \`${view.name} Web Awesome wrapper is not synchronized initially: wrapper=\${initialWrapperRect.height.toFixed(1)}px textarea=\${initialTextareaRect.height.toFixed(1)}px\`,
+          );
+        }
+
+        textarea.style.height = '1000px';
+        await new Promise((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(resolve, 0))),
+        );
+        const cappedTextareaRect = textarea.getBoundingClientRect();
+        const cappedWrapperRect = wrapper.getBoundingClientRect();
+        if (cappedTextareaRect.height > maxHeight + 1) {
+          throw new Error(
+            \`${view.name} native textarea exceeded its cap: rendered=\${cappedTextareaRect.height.toFixed(1)}px max=\${maxHeight.toFixed(1)}px\`,
+          );
+        }
+        if (Math.abs(cappedWrapperRect.height - cappedTextareaRect.height) > 2) {
+          throw new Error(
+            \`${view.name} Web Awesome wrapper lost sync after resize: wrapper=\${cappedWrapperRect.height.toFixed(1)}px textarea=\${cappedTextareaRect.height.toFixed(1)}px\`,
+          );
+        }
+
+        const viewportWidth = document.documentElement.clientWidth;
+        const viewportHeight = document.documentElement.clientHeight;
+        const composerRect = composer.getBoundingClientRect();
+        const dockRect = dock.getBoundingClientRect();
+        const logRect = conversationLog.getBoundingClientRect();
+        if (
+          composerRect.left < -1 ||
+          composerRect.right > viewportWidth + 1 ||
+          composerRect.width < 250
+        ) {
+          throw new Error(
+            \`${view.name} composer is unusable at narrow width: [\${composerRect.left.toFixed(1)}, \${composerRect.right.toFixed(1)}] in \${viewportWidth}px\`,
+          );
+        }
+        if (
+          dockRect.top < -1 ||
+          dockRect.bottom > viewportHeight + 1 ||
+          dockRect.height > viewportHeight * 0.55 ||
+          logRect.height < 100
+        ) {
+          throw new Error(
+            \`${view.name} composer consumed the short viewport: dock=\${dockRect.height.toFixed(1)}px log=\${logRect.height.toFixed(1)}px viewport=\${viewportHeight}px\`,
+          );
+        }
+
+        return {
+          lineHeight,
+          logHeight: logRect.height,
+          maxHeight,
+          minHeight,
+          renderedHeight: cappedTextareaRect.height,
+          viewportHeight,
+          viewportWidth,
+          wrapperHeight: cappedWrapperRect.height,
+        };
+      })();
+    `,
+    true,
+  );
+}
+
 async function assertToolEditApprovalLayout(window, view) {
   return window.webContents.executeJavaScript(
     `
@@ -449,6 +590,15 @@ async function assertViewSpecificLayout(window, view) {
   const assertions = Array.isArray(view.assertions) ? view.assertions : [];
   for (const assertion of assertions) {
     switch (assertion) {
+      case 'progressComposerLayout': {
+        const result = await assertProgressComposerLayout(window, view);
+        console.log(
+          `Verified ${view.name} progress composer layout: ${JSON.stringify(
+            result,
+          )}`,
+        );
+        break;
+      }
       case 'toolEditApprovalLayout': {
         const result = await assertToolEditApprovalLayout(window, view);
         console.log(

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -82,6 +82,11 @@ const views = [
     attributes: {
       'data-desktop-view': 'progress',
     },
+    viewport: {
+      width: 420,
+      height: 600,
+    },
+    assertions: ['progressComposerLayout'],
     seedMessages: [
       {
         command: 'updateStreams',

--- a/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
@@ -115,32 +115,9 @@ describe('follow-up-input layout', () => {
       | null;
     await textarea?.updateComplete;
 
-    expect(textarea?.getAttribute('rows')).toBe('6');
-    expect(textarea?.getAttribute('resize')).toBe('vertical');
     expect(textarea?.rows).toBe(6);
     expect(textarea?.resize).toBe('vertical');
     expect(textarea?.input.rows).toBe(6);
-  });
-
-  it('bounds the internal textarea between six lines and the panel cap', () => {
-    const ctor = customElements.get('follow-up-input') as unknown as {
-      styles: { cssText: string } | Array<{ cssText: string }>;
-    };
-    const cssText = [ctor.styles]
-      .flat()
-      .map((sheet) => sheet.cssText)
-      .join('\n')
-      .replaceAll(/\s+/g, '');
-
-    expect(cssText).toContain(
-      '--textarea-min-height:calc(6lh+var(--wa-space-xs)+var(--wa-space-3xs))',
-    );
-    expect(cssText).toContain(
-      '--textarea-max-height:clamp(var(--textarea-min-height),32vh,240px)',
-    );
-    expect(cssText).toContain(
-      '#followUpInput::part(textarea){width:100%;min-height:var(--textarea-min-height);max-height:var(--textarea-max-height)',
-    );
   });
 });
 

--- a/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
@@ -101,28 +101,46 @@ function image(fileName: string): ExtractedClipboardImage {
 }
 
 describe('follow-up-input layout', () => {
-  it('uses two content-sized rows without Web Awesome auto-resize', async () => {
+  it('renders six rows with Web Awesome vertical resizing', async () => {
     const element = createFollowUpInput('stream-layout');
     await element.updateComplete;
 
-    const textarea = element.shadowRoot?.querySelector('wa-textarea');
-    expect(textarea?.getAttribute('rows')).toBe('2');
-    expect(textarea?.getAttribute('resize')).toBe('none');
+    const textarea = element.shadowRoot?.querySelector('wa-textarea') as
+      | (HTMLElement & {
+          rows: number;
+          resize: string;
+          input: HTMLTextAreaElement;
+          updateComplete: Promise<boolean>;
+        })
+      | null;
+    await textarea?.updateComplete;
+
+    expect(textarea?.getAttribute('rows')).toBe('6');
+    expect(textarea?.getAttribute('resize')).toBe('vertical');
+    expect(textarea?.rows).toBe(6);
+    expect(textarea?.resize).toBe('vertical');
+    expect(textarea?.input.rows).toBe(6);
   });
 
-  it('grows with content through CSS field-sizing, not WA auto-resize', () => {
-    // The auto-grow behavior is pure CSS (jsdom cannot lay it out), so pin the
-    // declarations that carry it: content-driven sizing with a bounded band.
+  it('bounds the internal textarea between six lines and the panel cap', () => {
     const ctor = customElements.get('follow-up-input') as unknown as {
       styles: { cssText: string } | Array<{ cssText: string }>;
     };
     const cssText = [ctor.styles]
       .flat()
       .map((sheet) => sheet.cssText)
-      .join('\n');
-    expect(cssText).toContain('field-sizing: content');
-    expect(cssText).toContain('--textarea-min-height: calc(');
-    expect(cssText).toContain('min-height: var(--textarea-min-height)');
+      .join('\n')
+      .replaceAll(/\s+/g, '');
+
+    expect(cssText).toContain(
+      '--textarea-min-height:calc(6lh+var(--wa-space-xs)+var(--wa-space-3xs))',
+    );
+    expect(cssText).toContain(
+      '--textarea-max-height:clamp(var(--textarea-min-height),32vh,240px)',
+    );
+    expect(cssText).toContain(
+      '#followUpInput::part(textarea){width:100%;min-height:var(--textarea-min-height);max-height:var(--textarea-max-height)',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- show six text rows by default in the progress-view `Message TeXRA…` composer
- enable bounded vertical resizing on the actual Web Awesome textarea and wrapper
- cap growth responsively so narrow/short sidebars retain useful transcript space
- add Chromium layout coverage at a narrow 420×600 window

## Verification

- progress-view tests: 457 passed
- focused composer tests: 5 passed
- Electron webview smoke test, including native computed sizing and resize synchronization
- repository lint
- test-kernel and extension typechecks
- extension/webview production build
- Prettier and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only composer sizing in the progress webview with focused unit and Electron layout tests; no auth, data, or backend behavior changes.
> 
> **Overview**
> **Enlarges the progress-view “Message TeXRA…” composer** so users get more room for longer instructions without fighting a tiny box.
> 
> The follow-up `wa-textarea` now defaults to **six rows** with **`resize="vertical"`**, replacing the previous two-row, non-resizable setup and CSS **`field-sizing: content`** auto-grow. Sizing is driven by **`--textarea-min-height`** (6 line-heights) and a **`clamp`**-based max height (up to 32vh / 240px), with styles applied via **`::part(textarea-wrapper)`** so the Web Awesome wrapper stays aligned with the native textarea.
> 
> **Adds Chromium layout smoke coverage** for the populated progress view at a **420×600** viewport (`progressComposerLayout`): row count, vertical resize, min/max heights, wrapper sync after forced resize, and checks that the composer dock does not swallow the conversation log on a short sidebar.
> 
> Unit tests in **`FollowUpInputStreamSwitch.vitest.ts`** now assert six rows and vertical resize on the host and native textarea instead of pinning old CSS auto-grow declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d451ac9272792d892321b136cec39c541ee88f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->