### PR TITLE
fix: keep latexdiff compiler logs concise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Failed latexdiff builds no longer flood the workflow log** — the visible
+  warning identifies the affected diff file without dumping the LaTeX compiler
+  transcript; the full diagnostic remains available in debug data.
 - **OpenAI background responses keep one polling deadline across retries** —
   reconnecting to the same response no longer restarts its three-hour polling
   window. Once that window expires, TeXRA stops automatic retries and permits

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -408,12 +408,11 @@ export class LatexDiffManager {
     });
 
     if (!compiled.ok) {
-      // No MESSAGE_TYPES.INTERNAL here (unlike the diagnostic logs above) —
-      // this is a real failure (the diff PDF silently doesn't appear), so it
-      // must reach the standard channel subscriber, and the tail belongs in
-      // the visible message itself since `data` is only shown in debug mode.
+      // Keep the missing auxiliary PDF visible, but leave the compiler tail in
+      // structured diagnostic data. Dumping that tail into the message makes a
+      // recoverable latexdiff failure dominate the workflow transcript.
       this.logger.warn(
-        `Failed to compile latexdiff PDF:\n${compiled.logTail}`,
+        `Failed to compile latexdiff PDF: ${path.basename(diffLocation.absolutePath)}`,
         {
           data: {
             diffFile: diffLocation.absolutePath,

--- a/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
+++ b/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
@@ -38,7 +38,9 @@ import {
 } from './compileCheckTestUtils';
 
 const mocks = vi.hoisted(() => ({
-  compileLatex2Pdf: vi.fn(async () => ({ ok: true })),
+  compileLatex2Pdf: vi.fn(
+    async (): Promise<{ ok: boolean; logTail?: string }> => ({ ok: true }),
+  ),
   hasLatexCompiler: vi.fn(async () => true),
   publishCompiledPdfArtifact: vi.fn(async () => null),
 }));
@@ -306,6 +308,38 @@ describe('workflow LaTeX compile input directories', () => {
       expect.objectContaining({
         data: expect.objectContaining({ error: publishError }),
       }),
+    );
+  });
+
+  it('keeps a failed latexdiff compiler transcript out of the warning message', async () => {
+    const executionId = 'latexdiff-compile-failure';
+    await initLatexPlatform({});
+    const trace = spiedTrace();
+    const logTail = 'LaTeX compiler transcript that should remain diagnostic';
+    mocks.compileLatex2Pdf.mockResolvedValueOnce({ ok: false, logTail });
+
+    await createDiffCompiler(executionId, trace).compileDiffIfSuccessful(
+      { success: true, diffFileName: 'main-diff.tex' },
+      runStorageFile(executionId, path.join('r1', 'main.tex')),
+      {
+        absolutePath: path.join(runDir(executionId), 'diff', 'r2'),
+        relativePath: path.join('diff', 'r2'),
+        executionId,
+      },
+      2,
+      runStorageFile(executionId, path.join('r2', 'main.tex')),
+      '-diff',
+    );
+
+    expect(trace.warn).toHaveBeenCalledWith(
+      'Failed to compile latexdiff PDF: main-diff.tex',
+      expect.objectContaining({
+        data: expect.objectContaining({ logTail }),
+      }),
+    );
+    expect(trace.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining(logTail),
+      expect.anything(),
     );
   });
 });


### PR DESCRIPTION
## Summary

- keep failed latexdiff PDF compilation visible as a concise warning naming the affected diff file
- retain the full compiler transcript in structured diagnostic data instead of placing it in the workflow message
- add regression coverage and an Unreleased changelog entry

## Validation

- `corepack pnpm run typecheck`
- `corepack pnpm run compile:fast`
- `corepack pnpm run lint`
- `corepack pnpm test` (8,500 passed; 4 skipped)
- focused latexdiff and repair-round tests (20 passed)
- Prettier and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow logging change in latexdiff PDF compile failure handling; no auth, data, or workflow control-flow changes beyond message formatting.
> 
> **Overview**
> When **latexdiff** auxiliary PDF compilation fails, the workflow warning now names only the affected diff file (for example `main-diff.tex`) instead of appending the full LaTeX compiler transcript to the visible message.
> 
> The **full `logTail` stays in structured `data`** (`diffFile`, `logTail`) for debug inspection, so recoverable diff-build failures no longer dominate the progress transcript. An **Unreleased changelog** entry documents the behavior, and a **regression test** asserts the warning text excludes the transcript while `data.logTail` still carries it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ac2c6697a224ce324420e49904d557dee5334cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->