### PR TITLE
fix: canonicalize custom roster identifiers

### DIFF
--- a/src/agent/roster/AgentRosterController.ts
+++ b/src/agent/roster/AgentRosterController.ts
@@ -197,7 +197,6 @@ export class AgentRosterController<
 
     return unique(
       identifiers.map((identifier) => {
-        if (selection.kind === 'custom') return identifier;
         const entry = this.resolveEntry(category, identifier);
         return entry ? agentKeyOf(entry) : identifier;
       }),

--- a/src/test-kernel/controllers/AgentRosterController.vitest.ts
+++ b/src/test-kernel/controllers/AgentRosterController.vitest.ts
@@ -107,6 +107,20 @@ describe('AgentRosterController', () => {
     });
   });
 
+  it('canonicalizes known custom identifiers and preserves unknown ones', async () => {
+    const roster = controller(new FakeStateStore());
+    await roster.setCustom({
+      workflowAgentKeys: ['write', 'future-writer'],
+      toolUseAgentKeys: ['search'],
+    });
+
+    expect(roster.getEnabledAgentKeys('workflow')).toEqual([
+      'builtInWorkflow:write',
+      'future-writer',
+    ]);
+    expect(roster.getEnabledAgentKeys('toolUse')).toEqual(['custom:search']);
+  });
+
   it('preserves symbolic roster semantics when a toggle changes nothing', async () => {
     const inheritedState = new FakeStateStore();
     const inherited = controller(inheritedState, {


### PR DESCRIPTION
## Summary

- canonicalize resolvable custom-roster identifiers in the shared roster controller
- preserve unknown identifiers unchanged for forward compatibility
- give the CLI, VS Code extension, and desktop settings the same canonical enabled-agent keys

This prevents bare saved names from appearing unselected, disappearing from chat-default choices, or being duplicated by bulk visibility controls.

## Verification

- AgentRosterController, SettingsAgentVisibilityController, and AgentRosterForm suites: 21 passed
- workspace, test-kernel, and CLI type checking
- ESLint on the changed source and test

Follow-up to the final review finding on #9593, which was merged before this correction reached its branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in roster key normalization with targeted tests; no auth or persistence schema changes.
> 
> **Overview**
> **Custom roster selections now return canonical agent keys** from `getEnabledAgentKeys` and related paths that use `selectionKeys`, instead of echoing bare saved names when `selection.kind === 'custom'`.
> 
> The controller **removes the custom-only bypass** so each stored identifier is resolved when possible and mapped to `agentKeyOf(entry)`; **unresolvable identifiers are left unchanged** for forward compatibility (e.g. `future-writer`).
> 
> A test asserts that inputs like `write` / `search` become `builtInWorkflow:write` and `custom:search`, aligning CLI, VS Code, and desktop settings on the same enabled-key shape and avoiding UI mismatches (unselected rows, missing chat defaults, duplicate bulk toggles).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91835f7d634a99969cf48f0b776d804bce227811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->