### PR TITLE
fix(cli): resolve custom roster names

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
@@ -17,7 +17,11 @@ import {
   type SelectWindowSize,
 } from '@cli/tui/selectWindow';
 import { platform } from '@platform/platform';
-import { agentKeyOf, type AgentCategory } from '@shared/schemas/agent';
+import {
+  agentKeyOf,
+  agentMatchesIdentifier,
+  type AgentCategory,
+} from '@shared/schemas/agent';
 import {
   AGENT_MODE_PRESETS,
   STARTER_AGENT_MODE_PRESET,
@@ -82,7 +86,16 @@ export function selectedAgentKeys(
   agents: readonly AgentEntry[],
 ): readonly string[] {
   if (selection === 'all') return agents.map(agentKeyOf);
-  return selection;
+  return [
+    ...new Set(
+      selection.map((identifier) => {
+        const agent = agents.find((candidate) =>
+          agentMatchesIdentifier(candidate, identifier),
+        );
+        return agent ? agentKeyOf(agent) : identifier;
+      }),
+    ),
+  ];
 }
 
 function selectionSizeLabel(

--- a/src/test-kernel/cli/AgentRosterForm.vitest.mts
+++ b/src/test-kernel/cli/AgentRosterForm.vitest.mts
@@ -76,6 +76,13 @@ describe('AgentRosterForm', () => {
     ]);
   });
 
+  it('resolves bare custom-roster names to catalog keys', () => {
+    const selected = selectedAgentKeys(['assistant', 'custom:review'], agents);
+
+    expect(selected).toEqual(['builtInToolUse:assistant', 'custom:review']);
+    expect(buildChatDefaultAgentItems(agents, selected)).toHaveLength(3);
+  });
+
   it('windows long roster lists to the available terminal rows', () => {
     expect(
       agentRosterSelectWindow({ availableRows: 10, itemCount: 20 }),


### PR DESCRIPTION
## Summary

- resolve saved bare agent names against the current catalog before constructing CLI roster selections
- preserve already-qualified custom identities and remove duplicate resolved keys
- keep the chat-default picker aligned with the effective roster

## Testing

- `npm run typecheck`
- `npm run lint`
- `corepack pnpm vitest run src/test-kernel/cli/AgentRosterForm.vitest.mts --maxWorkers=1` (6 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI roster selection normalization with a small helper from shared schemas; no auth, persistence format, or network changes.
> 
> **Overview**
> Fixes CLI agent roster handling when persisted selections store **bare agent names** (e.g. `assistant`) instead of fully qualified catalog keys.
> 
> **`selectedAgentKeys`** now resolves each stored identifier against the current agent catalog via **`agentMatchesIdentifier`**, normalizes matches to **`agentKeyOf`**, leaves unknown identifiers unchanged, and **deduplicates** the result. That keeps the **default chat agent** picker and custom roster checkmarks aligned with the effective tool-use/workflow roster when config mixes short names and keys like `custom:review`.
> 
> Adds a unit test covering resolution of `assistant` → `builtInToolUse:assistant` while preserving already-qualified custom keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 340ae1e20e16c9a2ce345eecd0678edb60643ea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->