### PR TITLE
fix: make workspace settings transitions atomic

### DIFF
--- a/packages/extension/src/frontend/vscode/texraConfig.ts
+++ b/packages/extension/src/frontend/vscode/texraConfig.ts
@@ -5,6 +5,9 @@ import * as path from 'node:path';
 // Third-party imports
 import PQueue from 'p-queue';
 
+// Local imports - agent
+import type { WorkspaceStorageTransitionHooks } from '@agent/runtime/SessionHandle';
+
 // Local imports - common
 import { isFileNotFoundError } from '@common/errors';
 
@@ -62,13 +65,6 @@ async function openWorkspaceConfigStore(
   return JsonStore.open(internalConfigPath);
 }
 
-export interface ExtensionConfigWorkspaceTransitionHooks {
-  readonly workspacePath: string | undefined;
-  afterStorageCommit(): Promise<void>;
-  afterStorageRollback(): void;
-  afterStorageFinalize(): void;
-}
-
 export interface ExtensionConfigWorkspaceTransition {
   readonly generation: number;
   readonly completion: Promise<void>;
@@ -111,9 +107,7 @@ export class ExtensionTexraConfig extends JsonConfigProvider {
   /** Capture and serialize a complete storage/config workspace transition. */
   enqueueWorkspaceTransition(
     workspaceRoot: string | undefined,
-    reloadStorage: (
-      hooks: ExtensionConfigWorkspaceTransitionHooks,
-    ) => Promise<void>,
+    reloadStorage: (hooks: WorkspaceStorageTransitionHooks) => Promise<void>,
   ): ExtensionConfigWorkspaceTransition {
     const generation = ++this.transitionGeneration;
     const completion = this.workspaceQueue.add(async () => {

--- a/packages/extension/src/frontend/vscode/texraConfig.ts
+++ b/packages/extension/src/frontend/vscode/texraConfig.ts
@@ -117,6 +117,14 @@ export class ExtensionTexraConfig extends JsonConfigProvider {
   ): ExtensionConfigWorkspaceTransition {
     const generation = ++this.transitionGeneration;
     const completion = this.workspaceQueue.add(async () => {
+      if (
+        this.storage.hasPendingWorkspaceStorageChange?.({
+          workspacePath: workspaceRoot,
+        }) === false
+      ) {
+        return;
+      }
+
       let previousStore: JsonStore | undefined;
       let finalized = false;
       const rollbackConfig = () => {

--- a/packages/extension/src/frontend/vscode/texraConfig.ts
+++ b/packages/extension/src/frontend/vscode/texraConfig.ts
@@ -12,7 +12,7 @@ import { isFileNotFoundError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 
 // Local imports - platform
-import type { StorageProvider } from '@platform/interfaces';
+import type { ConfigTarget, StorageProvider } from '@platform/interfaces';
 import { JsonConfigProvider } from '@platform/defaults/jsonConfigProvider';
 import { JsonStore } from '@platform/defaults/jsonStore';
 import {
@@ -62,8 +62,22 @@ async function openWorkspaceConfigStore(
   return JsonStore.open(internalConfigPath);
 }
 
+export interface ExtensionConfigWorkspaceTransitionHooks {
+  readonly workspacePath: string | undefined;
+  afterStorageCommit(): Promise<void>;
+  afterStorageRollback(): void;
+  afterStorageFinalize(): void;
+}
+
+export interface ExtensionConfigWorkspaceTransition {
+  readonly generation: number;
+  readonly completion: Promise<void>;
+}
+
 export class ExtensionTexraConfig extends JsonConfigProvider {
-  private readonly rebindQueue = new PQueue({ concurrency: 1 });
+  private transitionGeneration = 0;
+  private failedTransitionGeneration: number | undefined;
+  private readonly workspaceQueue = new PQueue({ concurrency: 1 });
 
   constructor(
     private readonly storage: StorageProvider,
@@ -73,20 +87,76 @@ export class ExtensionTexraConfig extends JsonConfigProvider {
     super({ workspace: workspaceStore, global: globalStore });
   }
 
-  /** Follow VS Code after its workspace-storage replacement has committed. */
-  rebindWorkspace(workspaceRoot: string | undefined): Promise<void> {
-    return this.rebindQueue.add(async () => {
-      if (this.storage.hasPendingWorkspaceStorageChange?.()) {
+  override async update<T>(
+    key: string,
+    value: T,
+    target: ConfigTarget = 'workspace',
+  ): Promise<void> {
+    if (target === 'global') {
+      await super.update(key, value, target);
+      return;
+    }
+
+    const generation = this.transitionGeneration;
+    await this.workspaceQueue.add(async () => {
+      if (this.failedTransitionGeneration === generation) {
         throw new Error(
-          'Cannot rebind TeXRA settings before the workspace storage change commits.',
+          `Cannot update workspace settings because workspace transition ${generation} failed. Retry the workspace change or restart TeXRA.`,
         );
       }
-      const workspaceStore = await openWorkspaceConfigStore(
-        workspaceRoot,
-        path.join(this.storage.getStoragePath(), TEXRA_CONFIG_FILE_NAME),
-      );
-      this.replaceWorkspaceStore(workspaceStore);
+      await super.update(key, value, target);
+    });
+  }
+
+  /** Capture and serialize a complete storage/config workspace transition. */
+  enqueueWorkspaceTransition(
+    workspaceRoot: string | undefined,
+    reloadStorage: (
+      hooks: ExtensionConfigWorkspaceTransitionHooks,
+    ) => Promise<void>,
+  ): ExtensionConfigWorkspaceTransition {
+    const generation = ++this.transitionGeneration;
+    const completion = this.workspaceQueue.add(async () => {
+      let previousStore: JsonStore | undefined;
+      let finalized = false;
+      const rollbackConfig = () => {
+        if (previousStore) {
+          this.replaceWorkspaceStore(previousStore);
+          previousStore = undefined;
+        }
+      };
+
+      try {
+        await reloadStorage({
+          workspacePath: workspaceRoot,
+          afterStorageCommit: async () => {
+            const workspaceStore = await openWorkspaceConfigStore(
+              workspaceRoot,
+              path.join(this.storage.getStoragePath(), TEXRA_CONFIG_FILE_NAME),
+            );
+            previousStore = this.replaceWorkspaceStore(workspaceStore);
+          },
+          afterStorageRollback: rollbackConfig,
+          afterStorageFinalize: () => {
+            previousStore = undefined;
+            finalized = true;
+          },
+        });
+        if (!finalized) {
+          throw new Error(
+            `Workspace transition ${generation} completed without finalizing storage and configuration.`,
+          );
+        }
+      } catch (error) {
+        if (!finalized) {
+          rollbackConfig();
+          this.failedTransitionGeneration = generation;
+        }
+        throw error;
+      }
     }) as Promise<void>;
+
+    return { generation, completion };
   }
 }
 

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -211,37 +211,22 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     ProgressViewProvider._instance = this;
 
     this._disposables.push(
-      vscode.workspace.onDidChangeWorkspaceFolders(async () => {
-        let storageReloadError: unknown;
-        try {
-          await this.backend.reloadAfterStorageRootChange();
-        } catch (error) {
-          storageReloadError = error;
-        }
-
-        let configReloadError: unknown;
-        try {
-          await this.config.rebindWorkspace(this.workspace.getWorkspacePath());
-        } catch (error) {
-          configReloadError = error;
-        }
-
-        if (!storageReloadError && !configReloadError) {
-          this.syncFullView();
-          return;
-        }
-        const error =
-          storageReloadError && configReloadError
-            ? new AggregateError(
-                [storageReloadError, configReloadError],
-                'Failed to reload workspace storage and configuration',
-              )
-            : (storageReloadError ?? configReloadError);
-        this.logger.error('Failed to reload after workspace change', {
-          data: error,
-        });
-        void vscode.window.showErrorMessage(
-          'TeXRA could not reload settings and transcripts after the workspace changed. Retry the workspace change or restart TeXRA.',
+      vscode.workspace.onDidChangeWorkspaceFolders(() => {
+        const transition = this.config.enqueueWorkspaceTransition(
+          this.workspace.getWorkspacePath(),
+          (hooks) => this.backend.reloadAfterStorageRootChange(hooks),
+        );
+        void transition.completion.then(
+          () => this.syncFullView(),
+          (error: unknown) => {
+            this.logger.error(
+              `Failed workspace transition ${transition.generation}`,
+              { data: error },
+            );
+            void vscode.window.showErrorMessage(
+              'TeXRA could not reload settings and transcripts after the workspace changed. Retry the workspace change or restart TeXRA.',
+            );
+          },
         );
       }),
       vscode.window.onDidChangeActiveColorTheme(() => {

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -137,6 +137,13 @@ export type SessionHandleInit = Pick<SessionHandle, 'transcripts'> & {
     >
   >;
 
+export interface WorkspaceStorageTransitionHooks {
+  readonly workspacePath: string | undefined;
+  afterStorageCommit(): Promise<void>;
+  afterStorageRollback(): void;
+  afterStorageFinalize(): void;
+}
+
 export class SessionHandle {
   /** Per-run execution handles; owns the process-output poller + status sub. */
   readonly executions: ExecutionRegistry;
@@ -278,21 +285,27 @@ export class SessionHandle {
    * Ordinary view loads must not reopen these live stores. The host calls this
    * explicit lifecycle boundary only after a workspace-root change.
    */
-  reloadAfterStorageRootChange(): Promise<boolean> {
+  reloadAfterStorageRootChange(
+    hooks?: WorkspaceStorageTransitionHooks,
+  ): Promise<boolean> {
     if (
       this.transcripts.mode.kind !== 'persistent' ||
       this.restartRepairAbort.signal.aborted
     ) {
       return Promise.resolve(false);
     }
-    if (platform().storage.hasPendingWorkspaceStorageChange?.() === false) {
-      return Promise.resolve(false);
-    }
+    const hasPendingStorageChange =
+      hooks === undefined
+        ? platform().storage.hasPendingWorkspaceStorageChange?.()
+        : platform().storage.hasPendingWorkspaceStorageChange?.({
+            workspacePath: hooks.workspacePath,
+          });
+    if (hasPendingStorageChange === false) return Promise.resolve(false);
     this.storageGeneration += 1;
     const generation = this.storageGeneration;
     this.restartRepairRetry.cancel();
     const repair = this.enqueueRestartRepair(() =>
-      this.repairStoresAfterRestart(generation, true),
+      this.repairStoresAfterRestart(generation, true, hooks),
     );
     this.restartRepairPromise = repair;
     return repair;
@@ -382,13 +395,17 @@ export class SessionHandle {
   private async repairStoresAfterRestart(
     generation: number,
     reloadTranscripts = false,
+    transitionHooks?: WorkspaceStorageTransitionHooks,
   ): Promise<boolean> {
     try {
       if (this.restartRepairAbort.signal.aborted) return false;
       if (reloadTranscripts) {
         return await runWithOwnedExecutionLeaseQuiescence(async () => {
           if (this.restartRepairAbort.signal.aborted) return false;
-          return this.replaceStoresAfterStorageRootChange(generation);
+          return this.replaceStoresAfterStorageRootChange(
+            generation,
+            transitionHooks,
+          );
         });
       }
       if (generation !== this.storageGeneration) return false;
@@ -412,6 +429,7 @@ export class SessionHandle {
 
   private async replaceStoresAfterStorageRootChange(
     generation: number,
+    transitionHooks?: WorkspaceStorageTransitionHooks,
   ): Promise<boolean> {
     if (generation !== this.storageGeneration) return false;
     try {
@@ -429,12 +447,26 @@ export class SessionHandle {
       return false;
     }
     const storage = platform().storage;
-    if (storage.commitWorkspaceStorageChange?.() === false) {
-      await this.runRestartRepair(generation);
-      return false;
+    const storageRootChanged =
+      transitionHooks === undefined
+        ? storage.commitWorkspaceStorageChange?.()
+        : storage.commitWorkspaceStorageChange?.({
+            workspacePath: transitionHooks.workspacePath,
+          });
+    if (storageRootChanged === false) {
+      try {
+        await transitionHooks?.afterStorageCommit();
+        await this.runRestartRepair(generation);
+        transitionHooks?.afterStorageFinalize();
+        return false;
+      } catch (replacementError) {
+        transitionHooks?.afterStorageRollback();
+        throw replacementError;
+      }
     }
     const previousStatus = this.status.getAllStreamStates();
     try {
+      await transitionHooks?.afterStorageCommit();
       await this.transcripts.reload();
       this.status.clearAll();
       const streamIds = this.transcripts.keys();
@@ -442,11 +474,14 @@ export class SessionHandle {
       this.markUnfinishedStreamsRunning();
       await this.runRestartRepair(generation);
       storage.finalizeWorkspaceStorageChange?.();
+      transitionHooks?.afterStorageFinalize();
       return true;
     } catch (replacementError) {
       if (storage.rollbackWorkspaceStorageChange?.() !== true) {
+        transitionHooks?.afterStorageRollback();
         throw replacementError;
       }
+      transitionHooks?.afterStorageRollback();
       try {
         await this.transcripts.reload({ discardPendingWrites: true });
         this.snapshots.evictAll();

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -6,6 +6,7 @@ import type { HostApprovalBypassStateUpdate } from '@agent/runtime/HostInteracti
 import {
   defaultSession,
   type SessionHandle,
+  type WorkspaceStorageTransitionHooks,
 } from '@agent/runtime/SessionHandle';
 import {
   WebviewBridge,
@@ -330,12 +331,16 @@ export class ProgressBackend {
   }
 
   /** Replace session stores and presentation caches after a workspace move. */
-  reloadAfterStorageRootChange(): Promise<void> {
+  reloadAfterStorageRootChange(
+    transitionHooks?: WorkspaceStorageTransitionHooks,
+  ): Promise<void> {
     const reload = async () => {
       let sessionReloadError: unknown;
       let storageRootReplaced = false;
       try {
-        storageRootReplaced = await this.session.reloadAfterStorageRootChange();
+        storageRootReplaced = transitionHooks
+          ? await this.session.reloadAfterStorageRootChange(transitionHooks)
+          : await this.session.reloadAfterStorageRootChange();
       } catch (error) {
         sessionReloadError = error;
       }

--- a/src/platform/defaults/jsonConfigProvider.ts
+++ b/src/platform/defaults/jsonConfigProvider.ts
@@ -43,13 +43,15 @@ export class JsonConfigProvider implements ConfigProvider {
   }
 
   /** Switch workspace scope while retaining global values and subscriptions. */
-  replaceWorkspaceStore(workspaceStore: JsonStore): void {
+  replaceWorkspaceStore(workspaceStore: JsonStore): JsonStore {
+    const previousStore = this.workspaceStore;
     const affectedKeys = new Set([
-      ...Object.keys(this.workspaceStore.snapshot()),
+      ...Object.keys(previousStore.snapshot()),
       ...Object.keys(workspaceStore.snapshot()),
     ]);
     this.workspaceStore = workspaceStore;
     for (const key of affectedKeys) this.watchers.notify(key);
+    return previousStore;
   }
 
   async update<T>(

--- a/src/platform/defaults/workspaceStorage.ts
+++ b/src/platform/defaults/workspaceStorage.ts
@@ -215,17 +215,26 @@ export class WorkspaceStorageProvider implements StorageProvider {
     return storagePath;
   }
 
-  hasPendingWorkspaceStorageChange(): boolean {
+  hasPendingWorkspaceStorageChange(target?: {
+    workspacePath: string | undefined;
+  }): boolean {
+    const targetWorkspacePath = target
+      ? target.workspacePath
+      : this.getWorkspacePath();
     return (
       this.storagePathFor(this.activeWorkspacePath) !==
-      this.storagePathFor(this.getWorkspacePath())
+      this.storagePathFor(targetWorkspacePath)
     );
   }
 
-  commitWorkspaceStorageChange(): boolean {
-    const workspacePath = this.getWorkspacePath();
+  commitWorkspaceStorageChange(target?: {
+    workspacePath: string | undefined;
+  }): boolean {
+    const targetWorkspacePath = target
+      ? target.workspacePath
+      : this.getWorkspacePath();
     if (
-      this.storagePathFor(workspacePath) ===
+      this.storagePathFor(targetWorkspacePath) ===
       this.storagePathFor(this.activeWorkspacePath)
     ) {
       return false;
@@ -236,7 +245,7 @@ export class WorkspaceStorageProvider implements StorageProvider {
     this.workspaceChangeRollback = {
       workspacePath: this.activeWorkspacePath,
     };
-    this.activeWorkspacePath = workspacePath;
+    this.activeWorkspacePath = targetWorkspacePath;
     return true;
   }
 

--- a/src/platform/interfaces.ts
+++ b/src/platform/interfaces.ts
@@ -172,14 +172,18 @@ export interface StorageProvider {
    * currently exposed to callers. Providers with a dynamic workspace source
    * keep the old root pinned until the change is committed.
    */
-  hasPendingWorkspaceStorageChange?(): boolean;
+  hasPendingWorkspaceStorageChange?(target?: {
+    workspacePath: string | undefined;
+  }): boolean;
 
   /**
-   * Expose the current workspace source as the new storage root. The runtime
+   * Expose a captured workspace source as the new storage root. The runtime
    * calls this only after execution ownership at the old root is quiescent.
    * Returns whether the exposed root changed.
    */
-  commitWorkspaceStorageChange?(): boolean;
+  commitWorkspaceStorageChange?(target?: {
+    workspacePath: string | undefined;
+  }): boolean;
 
   /** Finalize a successfully loaded workspace-storage replacement. */
   finalizeWorkspaceStorageChange?(): void;

--- a/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
@@ -541,14 +541,23 @@ describe('SessionHandle restart repair', () => {
       STREAM_PHASE.RUNNING,
       'lifecycle',
     );
+    const transitionHooks = {
+      workspacePath: '/workspace/new',
+      afterStorageCommit: vi.fn(async () => {}),
+      afterStorageRollback: vi.fn(),
+      afterStorageFinalize: vi.fn(),
+    };
 
     try {
-      await expect(session.reloadAfterStorageRootChange()).rejects.toBe(
-        reloadError,
-      );
+      await expect(
+        session.reloadAfterStorageRootChange(transitionHooks),
+      ).rejects.toBe(reloadError);
 
       expect(activeRoot).toBe('/workspace/old-storage');
       expect(rollbackWorkspaceStorageChange).toHaveBeenCalledOnce();
+      expect(transitionHooks.afterStorageCommit).toHaveBeenCalledOnce();
+      expect(transitionHooks.afterStorageRollback).toHaveBeenCalledOnce();
+      expect(transitionHooks.afterStorageFinalize).not.toHaveBeenCalled();
       expect(reload).toHaveBeenCalledTimes(2);
       expect(evictSnapshots).toHaveBeenCalledOnce();
       expect(reload).toHaveBeenNthCalledWith(2, {
@@ -558,9 +567,14 @@ describe('SessionHandle restart repair', () => {
         STREAM_PHASE.RUNNING,
       );
 
-      await expect(session.reloadAfterStorageRootChange()).resolves.toBe(true);
+      await expect(
+        session.reloadAfterStorageRootChange(transitionHooks),
+      ).resolves.toBe(true);
       expect(activeRoot).toBe('/workspace/new-storage');
       expect(finalizeWorkspaceStorageChange).toHaveBeenCalledOnce();
+      expect(transitionHooks.afterStorageCommit).toHaveBeenCalledTimes(2);
+      expect(transitionHooks.afterStorageRollback).toHaveBeenCalledOnce();
+      expect(transitionHooks.afterStorageFinalize).toHaveBeenCalledOnce();
     } finally {
       session.dispose();
     }

--- a/src/test-kernel/settings/ExtensionTexraConfig.vitest.ts
+++ b/src/test-kernel/settings/ExtensionTexraConfig.vitest.ts
@@ -1,5 +1,6 @@
 // Node imports
 import {
+  access,
   chmod,
   mkdtemp,
   mkdir,
@@ -11,6 +12,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 // Third-party imports
+import pDefer from 'p-defer';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - extension
@@ -76,6 +78,11 @@ describe.skipIf(process.platform === 'win32')('extension TeXRA config', () => {
       mkdir(globalStorage),
     ]);
 
+    const projectConfig = join(workspace, '.texra', 'config.json');
+    const globalConfig = join(globalStorage, 'config.json');
+    await expect(access(projectConfig)).rejects.toThrow();
+    await expect(access(globalConfig)).rejects.toThrow();
+
     const config = await createExtensionTexraConfig(
       createStorage(internalStorage, globalStorage),
       workspace,
@@ -88,6 +95,8 @@ describe.skipIf(process.platform === 'win32')('extension TeXRA config', () => {
       workspaceValue: undefined,
       effectiveValue: 23119,
     });
+    await expect(access(projectConfig)).rejects.toThrow();
+    await expect(access(globalConfig)).rejects.toThrow();
   });
 
   it('waits for workspace storage to commit before rebinding fallback config', async () => {
@@ -114,16 +123,33 @@ describe.skipIf(process.platform === 'win32')('extension TeXRA config', () => {
     const config = await createExtensionTexraConfig(storage, workspaceRoot);
 
     workspaceRoot = readOnlyWorkspace;
-    await expect(config.rebindWorkspace(workspaceRoot)).rejects.toThrow(
-      'before the workspace storage change commits',
+    const continueTransition = pDefer<void>();
+    const transition = config.enqueueWorkspaceTransition(
+      workspaceRoot,
+      async (hooks) => {
+        await continueTransition.promise;
+        expect(
+          storage.commitWorkspaceStorageChange({
+            workspacePath: workspaceRoot,
+          }),
+        ).toBe(true);
+        await hooks.afterStorageCommit();
+        storage.finalizeWorkspaceStorageChange();
+        hooks.afterStorageFinalize();
+      },
     );
+    let updateCompleted = false;
+    const update = config.update('texra.bib.zoteroPort', 25000).then(() => {
+      updateCompleted = true;
+    });
+    await Promise.resolve();
+    expect(updateCompleted).toBe(false);
     expect(config.get('texra.bib.zoteroPort')).toBe(24001);
 
-    expect(storage.commitWorkspaceStorageChange()).toBe(true);
+    continueTransition.resolve();
+    await transition.completion;
     const secondInternalConfig = join(storage.getStoragePath(), 'config.json');
-    await config.rebindWorkspace(workspaceRoot);
-    storage.finalizeWorkspaceStorageChange();
-    await config.update('texra.bib.zoteroPort', 25000);
+    await update;
 
     await expect(readFile(secondInternalConfig, 'utf8')).resolves.toContain(
       '25000',
@@ -186,7 +212,14 @@ describe.skipIf(process.platform === 'win32')('extension TeXRA config', () => {
     config.watch('texra.bib.zoteroPort', listener);
 
     expect(config.get('texra.bib.zoteroPort')).toBe(24001);
-    await config.rebindWorkspace(secondWorkspace);
+    const transition = config.enqueueWorkspaceTransition(
+      secondWorkspace,
+      async (hooks) => {
+        await hooks.afterStorageCommit();
+        hooks.afterStorageFinalize();
+      },
+    );
+    await transition.completion;
     expect(config.get('texra.bib.zoteroPort')).toBe(24002);
     expect(listener).toHaveBeenCalledOnce();
 

--- a/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
+++ b/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
@@ -190,6 +190,43 @@ describe.skipIf(process.platform === 'win32')(
       tempDir = undefined;
     });
 
+    it('ignores folder changes that keep the active workspace root unchanged', async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'texra-workspace-transition-'));
+      const workspace = join(tempDir, 'project');
+      const storageRoot = join(tempDir, 'storage');
+      await Promise.all([createProject(workspace, 24001), mkdir(storageRoot)]);
+
+      const storage = new WorkspaceStorageProvider(
+        storageRoot,
+        () => workspace,
+      );
+      const config = await createExtensionTexraConfig(storage, workspace);
+      const storageCommit = vi.spyOn(storage, 'commitWorkspaceStorageChange');
+      const configReplacement = vi.spyOn(config, 'replaceWorkspaceStore');
+      const listener = vi.fn();
+      config.watch('texra.bib.zoteroPort', listener);
+      const provider = new ProgressViewProvider(
+        {
+          storageUri: { fsPath: join(tempDir, 'extension-storage') },
+        } as unknown as vscode.ExtensionContext,
+        config,
+        { getWorkspacePath: () => workspace } as never,
+      );
+
+      mocks.workspaceListeners[0]?.();
+      await config.update('texra.bib.zoteroPort', 25000);
+
+      expect(mocks.backend.reloadAfterStorageRootChange).not.toHaveBeenCalled();
+      expect(storageCommit).not.toHaveBeenCalled();
+      expect(configReplacement).not.toHaveBeenCalled();
+      expect(mocks.showErrorMessage).not.toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledOnce();
+      await expect(
+        readFile(join(workspace, '.texra', 'config.json'), 'utf8'),
+      ).resolves.toContain('25000');
+      provider.dispose();
+    });
+
     it('blocks workspace writes across storage and config commit windows while allowing global writes', async () => {
       tempDir = await mkdtemp(join(tmpdir(), 'texra-workspace-transition-'));
       const firstWorkspace = join(tempDir, 'first');
@@ -223,6 +260,7 @@ describe.skipIf(process.platform === 'win32')(
 
       workspaceRoot = secondWorkspace;
       mocks.workspaceListeners[0]?.();
+      mocks.workspaceListeners[0]?.();
       let workspaceWriteFinished = false;
       const workspaceWrite = config
         .update('texra.bib.zoteroPort', 25000)
@@ -247,6 +285,7 @@ describe.skipIf(process.platform === 'win32')(
 
       configCommit.resolve();
       await workspaceWrite;
+      expect(mocks.backend.reloadAfterStorageRootChange).toHaveBeenCalledOnce();
       await expect(
         readFile(join(secondWorkspace, '.texra', 'config.json'), 'utf8'),
       ).resolves.toContain('25000');

--- a/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
+++ b/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
@@ -1,0 +1,366 @@
+// Node imports
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Third-party imports
+import pDefer from 'p-defer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Type imports
+import type { WorkspaceStorageTransitionHooks } from '@agent/runtime/SessionHandle';
+import type * as vscode from 'vscode';
+
+const mocks = vi.hoisted(() => ({
+  backend: {
+    approvalHandlers: { toolEdit: { show: vi.fn(), dismiss: vi.fn() } },
+    factApplier: { getAllStreamStates: vi.fn(() => new Map()) },
+    reloadAfterStorageRootChange:
+      vi.fn<(hooks: WorkspaceStorageTransitionHooks) => Promise<void>>(),
+    dispose: vi.fn(),
+    setupEventListeners: vi.fn(),
+    state: {},
+    webviewBridge: {},
+    webviewUpdater: {},
+    setApprovalBypassState: vi.fn(),
+  },
+  showErrorMessage: vi.fn(),
+  workspaceListeners: [] as Array<() => void>,
+}));
+
+vi.mock('vscode', () => ({
+  ColorThemeKind: { Dark: 2 },
+  Uri: { file: (fsPath: string) => ({ fsPath }) },
+  window: {
+    activeColorTheme: { kind: 1 },
+    onDidChangeActiveColorTheme: () => ({ dispose: vi.fn() }),
+    showErrorMessage: mocks.showErrorMessage,
+    showInformationMessage: vi.fn(),
+  },
+  workspace: {
+    onDidChangeWorkspaceFolders: (listener: () => void) => {
+      mocks.workspaceListeners.push(listener);
+      return { dispose: vi.fn() };
+    },
+  },
+}));
+
+vi.mock('@common/webview', () => ({
+  BaseWebviewProvider: class {
+    protected readonly _disposables: Array<{ dispose(): void }> = [];
+
+    getActiveWebview(): undefined {
+      return undefined;
+    }
+
+    isViewVisible(): boolean {
+      return false;
+    }
+
+    dispose(): void {
+      for (const disposable of this._disposables) disposable.dispose();
+    }
+  },
+  BundledViewContentProvider: class {},
+  getActiveSidebarView: () => 'main',
+  getSharedLocalResourceRoots: () => [],
+  SIDEBAR_VIEWS: { MAIN: 'main', PROGRESS: 'progress' },
+}));
+vi.mock('@common/state', () => ({ workspaceSM: {} }));
+vi.mock('@agent/trace', () => ({
+  createChannelTrace: () => ({ debug: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('@agent/runtime/SessionHandle', () => ({
+  defaultSession: () => ({
+    interactions: {},
+    useHostInteractions: () => () => {},
+  }),
+}));
+vi.mock('@agent/runtime/terminalResultToast', () => ({
+  attachTerminalResultToast: () => () => {},
+}));
+vi.mock('@controllers/progressView/backend/ProgressBackend', () => ({
+  ProgressBackend: class {
+    constructor() {
+      return mocks.backend;
+    }
+  },
+}));
+vi.mock('@controllers/approval/ToolEditApprovalController', () => ({
+  ToolEditApprovalController: class {
+    dispose(): void {}
+  },
+}));
+vi.mock('@controllers/progressView/backend/agentProposalTransport', () => ({
+  createAgentProposalTransport: () => ({}),
+}));
+vi.mock('@controllers/progressView/backend/progressBackendUiConfig', () => ({
+  replayApprovalRequestHandlers: vi.fn(),
+}));
+vi.mock('@frontend/approval/VscodeToolEditApprovalHost', () => ({
+  VscodeToolEditApprovalHost: class {},
+}));
+vi.mock('@frontend/hosts/VscodePromptHost', () => ({
+  VscodePromptHost: class {},
+}));
+vi.mock('@frontend/events/agentEventListeners', () => ({
+  createAgentPresentationHost: () => ({}),
+}));
+vi.mock('@progressView/extensionHostInteractions', () => ({
+  createExtensionHostInteractions: () => ({}),
+}));
+vi.mock('@progressView/ProgressViewMessageHandler', () => ({
+  ProgressViewMessageHandler: class {},
+}));
+vi.mock('@progressView/progressBackendAppSignals', () => ({
+  attachProgressBackendAppSignals: () => ({ dispose: vi.fn() }),
+}));
+vi.mock('@eventBus/AppSignals', () => ({ appSignals: {} }));
+
+const { WorkspaceStorageProvider } =
+  await import('@platform/defaults/workspaceStorage');
+const { createExtensionTexraConfig } =
+  await import('@frontend/vscode/texraConfig');
+const { ProgressViewProvider } =
+  await import('@progressView/ProgressViewProvider');
+
+interface TransitionDriverOptions {
+  beforeStorageCommit?: Promise<unknown>;
+  beforeConfigCommit?: Promise<unknown>;
+  failWorkspaceRoots?: Set<string | undefined>;
+  operations?: string[];
+  storagePaths?: Map<string | undefined, string>;
+}
+
+function driveTransitions(
+  storage: InstanceType<typeof WorkspaceStorageProvider>,
+  options: TransitionDriverOptions = {},
+): void {
+  mocks.backend.reloadAfterStorageRootChange.mockImplementation(
+    async (hooks) => {
+      const root = hooks.workspacePath;
+      options.operations?.push(`start:${root ?? 'none'}`);
+      await options.beforeStorageCommit;
+      const storageChanged = storage.commitWorkspaceStorageChange({
+        workspacePath: root,
+      });
+      options.operations?.push(`storage:${root ?? 'none'}`);
+      await options.beforeConfigCommit;
+      try {
+        await hooks.afterStorageCommit();
+        options.operations?.push(`config:${root ?? 'none'}`);
+        if (options.failWorkspaceRoots?.has(root)) {
+          throw new Error(`cannot load ${root ?? 'no folder'}`);
+        }
+        if (storageChanged) storage.finalizeWorkspaceStorageChange();
+        hooks.afterStorageFinalize();
+        options.storagePaths?.set(root, storage.getStoragePath());
+        options.operations?.push(`done:${root ?? 'none'}`);
+      } catch (error) {
+        if (storageChanged) storage.rollbackWorkspaceStorageChange();
+        hooks.afterStorageRollback();
+        options.operations?.push(`failed:${root ?? 'none'}`);
+        throw error;
+      }
+    },
+  );
+}
+
+async function createProject(root: string, port: number): Promise<void> {
+  await mkdir(join(root, '.texra'), { recursive: true });
+  await writeFile(
+    join(root, '.texra', 'config.json'),
+    `{"texra.bib.zoteroPort": ${port}}\n`,
+  );
+}
+
+describe.skipIf(process.platform === 'win32')(
+  'extension workspace transition integration',
+  () => {
+    let tempDir: string | undefined;
+
+    beforeEach(() => {
+      mocks.backend.reloadAfterStorageRootChange.mockReset();
+      mocks.showErrorMessage.mockReset();
+      mocks.workspaceListeners.length = 0;
+    });
+
+    afterEach(async () => {
+      if (tempDir) await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    });
+
+    it('blocks workspace writes across storage and config commit windows while allowing global writes', async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'texra-workspace-transition-'));
+      const firstWorkspace = join(tempDir, 'first');
+      const secondWorkspace = join(tempDir, 'second');
+      const storageRoot = join(tempDir, 'storage');
+      await Promise.all([
+        createProject(firstWorkspace, 24001),
+        createProject(secondWorkspace, 24002),
+        mkdir(storageRoot),
+      ]);
+
+      let workspaceRoot: string | undefined = firstWorkspace;
+      const storage = new WorkspaceStorageProvider(
+        storageRoot,
+        () => workspaceRoot,
+      );
+      const config = await createExtensionTexraConfig(storage, workspaceRoot);
+      const storageCommit = pDefer<void>();
+      const configCommit = pDefer<void>();
+      driveTransitions(storage, {
+        beforeStorageCommit: storageCommit.promise,
+        beforeConfigCommit: configCommit.promise,
+      });
+      const provider = new ProgressViewProvider(
+        {
+          storageUri: { fsPath: join(tempDir, 'extension-storage') },
+        } as unknown as vscode.ExtensionContext,
+        config,
+        { getWorkspacePath: () => workspaceRoot } as never,
+      );
+
+      workspaceRoot = secondWorkspace;
+      mocks.workspaceListeners[0]?.();
+      let workspaceWriteFinished = false;
+      const workspaceWrite = config
+        .update('texra.bib.zoteroPort', 25000)
+        .then(() => {
+          workspaceWriteFinished = true;
+        });
+      await config.update('texra.telemetry.enabled', false, 'global');
+
+      expect(workspaceWriteFinished).toBe(false);
+      await expect(
+        readFile(join(firstWorkspace, '.texra', 'config.json'), 'utf8'),
+      ).resolves.toContain('24001');
+      await expect(
+        readFile(join(storage.getGlobalStoragePath(), 'config.json'), 'utf8'),
+      ).resolves.toContain('false');
+
+      storageCommit.resolve();
+      await vi.waitFor(() =>
+        expect(storage.getStoragePath()).not.toContain(firstWorkspace),
+      );
+      expect(workspaceWriteFinished).toBe(false);
+
+      configCommit.resolve();
+      await workspaceWrite;
+      await expect(
+        readFile(join(secondWorkspace, '.texra', 'config.json'), 'utf8'),
+      ).resolves.toContain('25000');
+      await expect(
+        readFile(join(firstWorkspace, '.texra', 'config.json'), 'utf8'),
+      ).resolves.toContain('24001');
+      provider.dispose();
+    });
+
+    it('moves writable project config to the no-folder internal store', async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'texra-workspace-transition-'));
+      const workspace = join(tempDir, 'project');
+      const storageRoot = join(tempDir, 'storage');
+      await Promise.all([createProject(workspace, 24001), mkdir(storageRoot)]);
+
+      let workspaceRoot: string | undefined = workspace;
+      const storage = new WorkspaceStorageProvider(
+        storageRoot,
+        () => workspaceRoot,
+      );
+      const config = await createExtensionTexraConfig(storage, workspaceRoot);
+      driveTransitions(storage);
+      const provider = new ProgressViewProvider(
+        {
+          storageUri: { fsPath: join(tempDir, 'extension-storage') },
+        } as unknown as vscode.ExtensionContext,
+        config,
+        { getWorkspacePath: () => workspaceRoot } as never,
+      );
+
+      workspaceRoot = undefined;
+      mocks.workspaceListeners[0]?.();
+      await config.update('texra.bib.zoteroPort', 25000);
+
+      await expect(
+        readFile(join(storage.getStoragePath(), 'config.json'), 'utf8'),
+      ).resolves.toContain('25000');
+      await expect(
+        readFile(join(workspace, '.texra', 'config.json'), 'utf8'),
+      ).resolves.toContain('24001');
+      provider.dispose();
+    });
+
+    it('serializes rapid moves, rolls a failed move back, and preserves watchers for retry', async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'texra-workspace-transition-'));
+      const firstWorkspace = join(tempDir, 'first');
+      const secondWorkspace = join(tempDir, 'second');
+      const thirdWorkspace = join(tempDir, 'third');
+      const storageRoot = join(tempDir, 'storage');
+      await Promise.all([
+        createProject(firstWorkspace, 24001),
+        createProject(secondWorkspace, 24002),
+        createProject(thirdWorkspace, 24003),
+        mkdir(storageRoot),
+      ]);
+
+      let workspaceRoot: string | undefined = firstWorkspace;
+      const storage = new WorkspaceStorageProvider(
+        storageRoot,
+        () => workspaceRoot,
+      );
+      const config = await createExtensionTexraConfig(storage, workspaceRoot);
+      const failedRoots = new Set<string | undefined>([thirdWorkspace]);
+      const operations: string[] = [];
+      const storagePaths = new Map<string | undefined, string>();
+      driveTransitions(storage, {
+        failWorkspaceRoots: failedRoots,
+        operations,
+        storagePaths,
+      });
+      const provider = new ProgressViewProvider(
+        {
+          storageUri: { fsPath: join(tempDir, 'extension-storage') },
+        } as unknown as vscode.ExtensionContext,
+        config,
+        { getWorkspacePath: () => workspaceRoot } as never,
+      );
+      const listener = vi.fn();
+      config.watch('texra.bib.zoteroPort', listener);
+
+      workspaceRoot = secondWorkspace;
+      mocks.workspaceListeners[0]?.();
+      workspaceRoot = thirdWorkspace;
+      mocks.workspaceListeners[0]?.();
+      const failedWorkspaceWrite = expect(
+        config.update('texra.bib.zoteroPort', 26000),
+      ).rejects.toThrow('workspace transition 2 failed');
+
+      await vi.waitFor(() => expect(mocks.showErrorMessage).toHaveBeenCalled());
+      await failedWorkspaceWrite;
+      expect(operations).toEqual([
+        `start:${secondWorkspace}`,
+        `storage:${secondWorkspace}`,
+        `config:${secondWorkspace}`,
+        `done:${secondWorkspace}`,
+        `start:${thirdWorkspace}`,
+        `storage:${thirdWorkspace}`,
+        `config:${thirdWorkspace}`,
+        `failed:${thirdWorkspace}`,
+      ]);
+      expect(config.get('texra.bib.zoteroPort')).toBe(24002);
+      expect(storage.getStoragePath()).toBe(storagePaths.get(secondWorkspace));
+
+      const callsAfterRollback = listener.mock.calls.length;
+      failedRoots.clear();
+      mocks.workspaceListeners[0]?.();
+      await config.update('texra.bib.zoteroPort', 25003);
+
+      expect(config.get('texra.bib.zoteroPort')).toBe(25003);
+      expect(listener.mock.calls.length).toBeGreaterThan(callsAfterRollback);
+      await expect(
+        readFile(join(thirdWorkspace, '.texra', 'config.json'), 'utf8'),
+      ).resolves.toContain('25003');
+      provider.dispose();
+    });
+  },
+);


### PR DESCRIPTION
## Summary

- serialize each extension workspace storage replacement and native-config rebind as one generation-aware transaction
- queue workspace-scoped setting writes behind transitions while allowing global writes to continue
- capture explicit workspace targets, including no-folder, and keep configuration aligned with storage across rapid transitions and rollback
- preserve watcher continuity and keep effective schema-default reads non-persisting

## Regression coverage

- blocked storage reload and writes during transition
- post-storage/pre-config window
- global writes during transitions
- writable to no-folder
- rapid A to B to C transitions
- failed C rollback to B, explicit workspace-write failure, retry, and watcher continuity
- mutable defaults and absent config files after effective reads

## Validation

- 37 relevant test files / 194 tests passed
- focused lifecycle/config/telemetry suite: 6 files / 80 tests passed
- formatting and changed-file lint
- npm run lint
- npm run typecheck
- npm run compile:fast
- git diff --check

Follow-up to #9593, which was merged before this final lifecycle fix landed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace storage commit/rollback timing and session store replacement during folder switches; regression tests cover transitions, but mistakes could misroute transcripts or settings across roots.
> 
> **Overview**
> **Makes VS Code workspace-folder changes one serialized transaction** across persisted storage, session transcripts/snapshots, and TeXRA workspace config—replacing separate `reloadAfterStorageRootChange` + `rebindWorkspace` calls.
> 
> `ExtensionTexraConfig` adds **`enqueueWorkspaceTransition`** (generation-aware, single `PQueue`): session storage reload runs with **`WorkspaceStorageTransitionHooks`** so config rebind happens at **`afterStorageCommit`**, rolls back via **`replaceWorkspaceStore`**, and finalizes only when storage does. **Workspace-scoped `update()` waits on that queue**; **global settings still write immediately**. A failed transition blocks further workspace writes until retry/restart.
> 
> **`WorkspaceStorageProvider`** / **`StorageProvider`** now take an explicit **`workspacePath`** when detecting or committing pending root changes (including **no-folder**), so rapid A→B→C moves and captured targets stay aligned.
> 
> **`ProgressViewProvider`** wires `onDidChangeWorkspaceFolders` to the new transition API and refreshes the progress view on success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44a0097d8bc205f8e3aa0cc1f86cbd6252d6924f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->