### PR TITLE
fix(cli): resolve custom roster names

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
@@ -17,7 +17,11 @@ import {
   type SelectWindowSize,
 } from '@cli/tui/selectWindow';
 import { platform } from '@platform/platform';
-import { agentKeyOf, type AgentCategory } from '@shared/schemas/agent';
+import {
+  agentKeyOf,
+  agentMatchesIdentifier,
+  type AgentCategory,
+} from '@shared/schemas/agent';
 import {
   AGENT_MODE_PRESETS,
   STARTER_AGENT_MODE_PRESET,
@@ -82,7 +86,16 @@ export function selectedAgentKeys(
   agents: readonly AgentEntry[],
 ): readonly string[] {
   if (selection === 'all') return agents.map(agentKeyOf);
-  return selection;
+  return [
+    ...new Set(
+      selection.map((identifier) => {
+        const agent = agents.find((candidate) =>
+          agentMatchesIdentifier(candidate, identifier),
+        );
+        return agent ? agentKeyOf(agent) : identifier;
+      }),
+    ),
+  ];
 }
 
 function selectionSizeLabel(

--- a/src/agent/roster/AgentRosterController.ts
+++ b/src/agent/roster/AgentRosterController.ts
@@ -349,15 +349,17 @@ export class AgentRosterController<
         input.category,
       );
       const key = agentKeyOf(input);
-      const index = target.findIndex((candidate) =>
-        agentMatchesIdentifier(input, candidate),
-      );
+      const matchesTarget = (candidate: string): boolean => {
+        const resolved = this.resolveEntry(input.category, candidate);
+        return resolved !== undefined && agentKeyOf(resolved) === key;
+      };
+      const index = target.findIndex(matchesTarget);
       const alreadyEnabled = index >= 0;
       if (input.enabled === alreadyEnabled) return;
       if (input.enabled && index < 0) target.push(key);
       if (!input.enabled && index >= 0) {
         const remaining = target.filter(
-          (candidate) => !agentMatchesIdentifier(input, candidate),
+          (candidate) => !matchesTarget(candidate),
         );
         target.splice(0, target.length, ...remaining);
       }

--- a/src/agent/roster/AgentRosterController.ts
+++ b/src/agent/roster/AgentRosterController.ts
@@ -355,7 +355,12 @@ export class AgentRosterController<
       const alreadyEnabled = index >= 0;
       if (input.enabled === alreadyEnabled) return;
       if (input.enabled && index < 0) target.push(key);
-      if (!input.enabled && index >= 0) target.splice(index, 1);
+      if (!input.enabled && index >= 0) {
+        const remaining = target.filter(
+          (candidate) => !agentMatchesIdentifier(input, candidate),
+        );
+        target.splice(0, target.length, ...remaining);
+      }
       await this.writeSelection({
         kind: 'custom',
         workflowAgentKeys:

--- a/src/test-kernel/cli/AgentRosterForm.vitest.mts
+++ b/src/test-kernel/cli/AgentRosterForm.vitest.mts
@@ -32,6 +32,61 @@ const agents: AgentEntry[] = [
   },
 ];
 
+const agentsWithDuplicateName: AgentEntry[] = [
+  ...agents,
+  {
+    category: 'toolUse',
+    source: 'remote',
+    name: 'review',
+    description: 'Remote review agent',
+    path: '',
+  },
+];
+
+const selectedAgentKeyCases: Array<{
+  name: string;
+  selection: 'all' | string[];
+  catalog: AgentEntry[];
+  expected: string[];
+}> = [
+  {
+    name: 'expands all to the catalog keys',
+    selection: 'all',
+    catalog: agents,
+    expected: ['builtInToolUse:assistant', 'custom:review'],
+  },
+  {
+    name: 'deduplicates bare and source-qualified aliases',
+    selection: ['assistant', 'builtInToolUse:assistant'],
+    catalog: agents,
+    expected: ['builtInToolUse:assistant'],
+  },
+  {
+    name: 'preserves unknown bare and source-qualified identifiers',
+    selection: ['future', 'remote:future'],
+    catalog: agents,
+    expected: ['future', 'remote:future'],
+  },
+  {
+    name: 'resolves an exact remote source key',
+    selection: ['remote:review'],
+    catalog: agentsWithDuplicateName,
+    expected: ['remote:review'],
+  },
+  {
+    name: 'leaves category-like qualified identifiers unresolved',
+    selection: ['toolUse:assistant'],
+    catalog: agents,
+    expected: ['toolUse:assistant'],
+  },
+  {
+    name: 'uses the first same-name agent for bare names and retains exact identities',
+    selection: ['review', 'remote:review', 'custom:review'],
+    catalog: agentsWithDuplicateName,
+    expected: ['custom:review', 'remote:review'],
+  },
+];
+
 describe('AgentRosterForm', () => {
   it('renders loading through the shared Ink indicator', async () => {
     const { ink, React } = await loadInk();
@@ -76,12 +131,12 @@ describe('AgentRosterForm', () => {
     ]);
   });
 
-  it('resolves bare custom-roster names to catalog keys', () => {
-    const selected = selectedAgentKeys(['assistant', 'custom:review'], agents);
-
-    expect(selected).toEqual(['builtInToolUse:assistant', 'custom:review']);
-    expect(buildChatDefaultAgentItems(agents, selected)).toHaveLength(3);
-  });
+  it.each(selectedAgentKeyCases)(
+    '$name',
+    ({ selection, catalog, expected }) => {
+      expect(selectedAgentKeys(selection, catalog)).toEqual(expected);
+    },
+  );
 
   it('windows long roster lists to the available terminal rows', () => {
     expect(

--- a/src/test-kernel/cli/AgentRosterForm.vitest.mts
+++ b/src/test-kernel/cli/AgentRosterForm.vitest.mts
@@ -76,6 +76,13 @@ describe('AgentRosterForm', () => {
     ]);
   });
 
+  it('resolves bare custom-roster names to catalog keys', () => {
+    const selected = selectedAgentKeys(['assistant', 'custom:review'], agents);
+
+    expect(selected).toEqual(['builtInToolUse:assistant', 'custom:review']);
+    expect(buildChatDefaultAgentItems(agents, selected)).toHaveLength(3);
+  });
+
   it('windows long roster lists to the available terminal rows', () => {
     expect(
       agentRosterSelectWindow({ availableRows: 10, itemCount: 20 }),

--- a/src/test-kernel/controllers/AgentRosterController.vitest.ts
+++ b/src/test-kernel/controllers/AgentRosterController.vitest.ts
@@ -131,6 +131,72 @@ describe('AgentRosterController', () => {
     });
   });
 
+  it('preserves a bare same-name agent when disabling another source', async () => {
+    const duplicateAgents: Record<AgentCategory, AgentRosterEntry[]> = {
+      workflow: [],
+      toolUse: [
+        { category: 'toolUse', source: 'custom', name: 'review' },
+        { category: 'toolUse', source: 'remote', name: 'review' },
+      ],
+    };
+    const workspaceState = new FakeStateStore({
+      [WorkspaceStateKey.AGENT_ROSTER_SELECTION]: {
+        kind: 'custom',
+        workflowAgentKeys: [],
+        toolUseAgentKeys: ['review', 'remote:review', 'future-reviewer'],
+      },
+    });
+    const roster = controller(workspaceState, {
+      getAgents: (category) => duplicateAgents[category],
+    });
+
+    await roster.setAgentEnabled({
+      category: 'toolUse',
+      source: 'remote',
+      name: 'review',
+      enabled: false,
+    });
+
+    expect(roster.getSelection()).toEqual({
+      kind: 'custom',
+      workflowAgentKeys: [],
+      toolUseAgentKeys: ['review', 'future-reviewer'],
+    });
+  });
+
+  it('enables an exact source beside a bare same-name agent', async () => {
+    const duplicateAgents: Record<AgentCategory, AgentRosterEntry[]> = {
+      workflow: [],
+      toolUse: [
+        { category: 'toolUse', source: 'custom', name: 'review' },
+        { category: 'toolUse', source: 'remote', name: 'review' },
+      ],
+    };
+    const workspaceState = new FakeStateStore({
+      [WorkspaceStateKey.AGENT_ROSTER_SELECTION]: {
+        kind: 'custom',
+        workflowAgentKeys: [],
+        toolUseAgentKeys: ['review'],
+      },
+    });
+    const roster = controller(workspaceState, {
+      getAgents: (category) => duplicateAgents[category],
+    });
+
+    await roster.setAgentEnabled({
+      category: 'toolUse',
+      source: 'remote',
+      name: 'review',
+      enabled: true,
+    });
+
+    expect(roster.getSelection()).toEqual({
+      kind: 'custom',
+      workflowAgentKeys: [],
+      toolUseAgentKeys: ['review', 'remote:review'],
+    });
+  });
+
   it('preserves symbolic roster semantics when a toggle changes nothing', async () => {
     const inheritedState = new FakeStateStore();
     const inherited = controller(inheritedState, {

--- a/src/test-kernel/controllers/AgentRosterController.vitest.ts
+++ b/src/test-kernel/controllers/AgentRosterController.vitest.ts
@@ -107,6 +107,30 @@ describe('AgentRosterController', () => {
     });
   });
 
+  it('removes every matching alias when disabling an agent', async () => {
+    const workspaceState = new FakeStateStore({
+      [WorkspaceStateKey.AGENT_ROSTER_SELECTION]: {
+        kind: 'custom',
+        workflowAgentKeys: [],
+        toolUseAgentKeys: ['lead', 'builtInToolUse:lead', 'custom:search'],
+      },
+    });
+    const roster = controller(workspaceState);
+
+    await roster.setAgentEnabled({
+      category: 'toolUse',
+      source: 'builtInToolUse',
+      name: 'lead',
+      enabled: false,
+    });
+
+    expect(roster.getSelection()).toEqual({
+      kind: 'custom',
+      workflowAgentKeys: [],
+      toolUseAgentKeys: ['custom:search'],
+    });
+  });
+
   it('preserves symbolic roster semantics when a toggle changes nothing', async () => {
     const inheritedState = new FakeStateStore();
     const inherited = controller(inheritedState, {


### PR DESCRIPTION
## Summary

- resolve persisted bare agent identifiers against the current catalog before building CLI roster selections
- preserve canonical custom identifiers and unknown entries while deduplicating aliases
- keep the  selection path unchanged

## Regression coverage

- a bare built-in name such as  resolves to 
- canonical custom entries remain available in the roster

This follow-up was prepared during the final review of #9593 but was not included in its merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace roster persistence and toggle semantics for mixed bare/qualified identifiers; wrong matching could drop or duplicate agents in custom rosters, but scope is limited to CLI agent configuration.
> 
> **Overview**
> Fixes how **persisted agent roster identifiers** are interpreted in the CLI when building selections and when toggling agents on/off.
> 
> **`selectedAgentKeys`** (used for chat-default and custom roster UI) now maps each stored id through `agentMatchesIdentifier` against the current catalog, emits canonical `source:name` keys, **deduplicates** bare vs qualified aliases, and **keeps unknown** ids unchanged.
> 
> **`setAgentEnabled`** in `AgentRosterController` matches stored entries by resolving candidates to the same canonical key as the toggled agent. Disabling removes **all** aliases for that agent (e.g. both `lead` and `builtInToolUse:lead`), while distinct same-name agents from different sources stay separate when only one source is turned off.
> 
> Regression tests cover alias deduplication, unknown ids, duplicate names across sources, and multi-alias removal on disable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 520adf5497f6a1d0cf66558769678cd7d48c755d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->