### PR TITLE
refactor: retire pre-March shared-state formats

### DIFF
--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -17,7 +17,6 @@ import {
 } from '@agent/core/definition/AgentCycleOptions';
 import {
   ProviderMessageArraySchema,
-  normalizeProviderMessages,
   type ProviderMessage,
 } from '@agent/types/ProviderMessage';
 import { ModelHandlerCompatibilityKeySchema } from '@agent/runtime/modelHandlerCompatibilityKey';
@@ -118,14 +117,6 @@ export type SharedStateMigrationResult =
   | { success: true; data: ToolUseRunShared; migrated: boolean }
   | { success: false; error: z.ZodError };
 
-function failedSharedMigration(value: unknown): SharedStateMigrationResult {
-  const result = ToolUseRunSharedSchema.safeParse(value);
-  if (result.success) {
-    throw new Error('Expected invalid tool-use shared state');
-  }
-  return result;
-}
-
 export function findLastAssistantText(
   messages: ProviderMessage[],
   extractAssistantText: (message: ProviderMessage) => string | undefined,
@@ -146,38 +137,13 @@ export function assertPreparedShared(
 }
 
 /**
- * Parse persisted shared state once, normalizing the legacy conversation key,
- * outer state wrapper, workspace snapshot, and pre-`modelId` model identity
- * before live flow code sees it.
+ * Parse persisted shared state once, normalizing the workspace snapshot and
+ * pre-`modelId` model identity before live flow code sees it.
  */
 export function migrateSharedState(
   shared: unknown,
 ): SharedStateMigrationResult {
-  if (!shared || typeof shared !== 'object') {
-    return failedSharedMigration(shared);
-  }
-
-  // Unwrap nested `{ state: {...} }` wrapper if present. The unwrap itself
-  // counts as a migration even if the inner shape is already canonical.
-  const nested = 'state' in shared;
-  const obj = nested ? (shared as Record<string, unknown>).state : shared;
-  if (!obj || typeof obj !== 'object') return failedSharedMigration(obj);
-
-  const record = obj as Record<string, unknown>;
-  // `normalizeProviderMessages` already prefers `record.messages` and falls
-  // back to the legacy `record.conversation` key — shared with the same
-  // messages/conversation normalization used to infer a keyless persisted
-  // run's model-handler compatibility key.
-  const messages = normalizeProviderMessages(record);
-  if (!messages) {
-    return failedSharedMigration(obj);
-  }
-
-  const { conversation: _legacyConversation, ...candidate } = record;
-  candidate.messages = messages;
-  const migrated = nested || Object.hasOwn(record, 'conversation');
-
-  const parsed = ToolUseRunSharedSchema.safeParse(candidate);
+  const parsed = ToolUseRunSharedSchema.safeParse(shared);
   if (!parsed.success) return parsed;
 
   // Records written before `modelId` existed carry the run's model only in the
@@ -197,6 +163,6 @@ export function migrateSharedState(
   return {
     success: true,
     data,
-    migrated: migrated || !isDeepStrictEqual(candidate, data),
+    migrated: !isDeepStrictEqual(shared, data),
   };
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -522,7 +522,7 @@ export async function runToolUseFlow<C = unknown>(
       }
       if (shouldWriteShared) {
         if (migrationResult.migrated) {
-          logger.debug('Migrated legacy shared state to flat format');
+          logger.debug('Normalized persisted tool-use shared state');
         }
         flowRecord.shared = migratedData;
         await kv.write(

--- a/src/agent/runtime/modelHandlerCompatibilityInference.ts
+++ b/src/agent/runtime/modelHandlerCompatibilityInference.ts
@@ -2,7 +2,7 @@ import { ModelProvider } from 'llm-zoo';
 
 import type { AgentTrace } from '@agent/trace';
 import {
-  normalizeProviderMessages,
+  ProviderMessageArraySchema,
   type ProviderMessage,
 } from '@agent/types/ProviderMessage';
 import {
@@ -89,17 +89,11 @@ function currentModelFromRawSharedState(
   );
 }
 
-function unwrapSharedState(shared: unknown): Record<string, unknown> | null {
-  const record = asRecord(shared);
-  if (!record) return null;
-  return asRecord(record.state) ?? record;
-}
-
 export function inferPersistedFlowModelHandlerCompatibilityKey(
   model: string,
   shared: unknown,
 ): ModelHandlerCompatibilityKey | undefined {
-  const record = unwrapSharedState(shared);
+  const record = asRecord(shared);
   if (!record) return undefined;
 
   const parsedKey = ModelHandlerCompatibilityKeySchema.nullish().safeParse(
@@ -107,14 +101,11 @@ export function inferPersistedFlowModelHandlerCompatibilityKey(
   );
   if (parsedKey.success && parsedKey.data) return parsedKey.data;
 
-  // The union in `normalizeProviderMessages` already tries `record` as a bare
-  // messages array, then `record.messages`, then `record.conversation` — one
-  // call covers all three legacy shapes.
-  const messages = normalizeProviderMessages(record);
-  if (!messages) return undefined;
+  const messages = ProviderMessageArraySchema.safeParse(record.messages);
+  if (!messages.success) return undefined;
 
   return inferPersistedModelHandlerCompatibilityKey(
     currentModelFromRawSharedState(record) ?? model,
-    messages,
+    messages.data,
   );
 }

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -526,54 +526,6 @@ describe('retrieveSessionResumeData', () => {
     expect((await readFlowRecord(executionId))?.shared).toEqual(shared);
   });
 
-  it('normalizes legacy nested conversation shared state for tool-use resume', async () => {
-    const executionId = 'abc128' as ExecutionId;
-    const streamId = 'chat@gpt54#abc128' as StreamTabId;
-    await writeFlowRecord(executionId, {
-      state: {
-        conversation: [
-          {
-            role: 'user',
-            content: 'Continue the legacy conversation.',
-          },
-        ],
-        shouldSkipCycle: false,
-        stateSlices: defaultStateSlices(),
-      },
-    });
-
-    const resume = await retrieveToolUseResume(streamId, executionId);
-
-    expect(resume.shared.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Continue the legacy conversation.',
-      },
-    ]);
-  });
-
-  it('falls back to a flat legacy conversation when messages is invalid', async () => {
-    // Distinct from the nested `{ state: { conversation } }` case above: this
-    // is the flat (unwrapped) legacy shape -- `conversation` at the top level
-    // of `shared`, never renamed to `messages`.
-    const executionId = 'abc133' as ExecutionId;
-    const streamId = 'chat@gpt54#abc133' as StreamTabId;
-    await writeFlowRecord(executionId, {
-      messages: null,
-      conversation: [
-        { role: 'user', content: 'Continue the flat legacy conversation.' },
-      ],
-      shouldSkipCycle: false,
-      stateSlices: defaultStateSlices(),
-    });
-
-    const resume = await retrieveToolUseResume(streamId, executionId);
-
-    expect(resume.shared.messages).toEqual([
-      { role: 'user', content: 'Continue the flat legacy conversation.' },
-    ]);
-  });
-
   it('throws when resumable tool-use storage cannot be read', async () => {
     const executionId = 'abc129' as ExecutionId;
     const streamId = 'chat@gpt54#abc129' as StreamTabId;
@@ -1539,39 +1491,6 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       runSpy.mockRestore();
       session.followUps.terminalize(streamId);
     }
-  });
-
-  it('hydrates a legacy-shaped flow record through the single boundary, then self-heals via its canonical fields', async () => {
-    const executionId = 'abc140' as ExecutionId;
-    const streamId = 'chat@gpt54#abc140' as StreamTabId;
-    const legacyShared = {
-      state: {
-        conversation: [
-          { role: 'user', content: 'Continue the legacy conversation.' },
-        ],
-        shouldSkipCycle: false,
-        // Pass-through state must survive the consumer's self-heal write.
-        systemPrompt: 'You are a helpful assistant.',
-        stateSlices: defaultStateSlices(),
-      },
-    };
-    await writeFlowRecord(executionId, legacyShared, WAITING_AT_START);
-
-    const resume = await retrieveToolUseResume(streamId, executionId);
-    expect(resume.shared.modelHandlerCompatibilityKey).toBeUndefined();
-
-    await runResumedFlowToWaiting(executionId, streamId, resume);
-
-    const healedRecord = await readFlowRecord(executionId);
-
-    expect(healedRecord?.shared).toMatchObject({
-      messages: resume.shared.messages,
-      // Derived from the legacy MODEL variable and persisted by the self-heal.
-      modelId: 'gpt54',
-      modelHandlerCompatibilityKey: ACTIVE_COMPATIBILITY_KEY,
-      stateSlices: resume.shared.stateSlices,
-      systemPrompt: 'You are a helpful assistant.',
-    });
   });
 
   it('skips the resume self-heal write when the persisted record is already canonical (issue #8018)', async () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerCompatibilityInference.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerCompatibilityInference.vitest.ts
@@ -88,7 +88,7 @@ describe('model handler compatibility inference', () => {
     expect(
       inferPersistedFlowModelHandlerCompatibilityKey('gemini35f', {
         modelHandlerCompatibilityKey: 'ModelHandlerOpenRouterNative',
-        conversation: [
+        messages: [
           {
             role: 'user',
             parts: [{ text: 'continue' }],


### PR DESCRIPTION
## Summary

Tool-use resume now accepts only the current top-level `messages` shared-state shape. The retired nested `state` wrapper and `conversation` alias, together with their inference paths and compatibility-only fixtures, are removed.

## Issue acceptance gates

Part of #9422.

Satisfied here:
- retire the nested wrapper whose writer was removed on 2026-01-14;
- retire the `conversation` alias replaced by `messages` on 2026-02-08;
- preserve current schema validation, workspace normalization, model recovery, and compatibility-key handling;
- remove tests that existed only for the retired formats.

The younger #9422 arms remain scheduled separately.

## Single source of truth

`ToolUseRunSharedSchema` is the persisted tool-use shared-state authority. Compatibility inference reads the same current top-level `messages` field through `ProviderMessageArraySchema`.

## Duplication and abstraction budget

Removed two parallel legacy normalization paths and three compatibility-only resume tests. No abstraction, facade, alias, or replacement migration was added.

## Net elements (R6)

- files: 5 changed, no files added or removed;
- exported symbols: 0 added, 0 removed;
- private helpers: 2 removed (`failedSharedMigration`, `unwrapSharedState`);
- tests: 3 compatibility-only tests removed;
- lines: +11 / -135, net -124.

## Consumer counts (R8)

No emitted event or exported API is deleted or rerouted. Before deletion, `failedSharedMigration` had three same-module calls and `unwrapSharedState` had one same-module call; neither had an external consumer. `normalizeProviderMessages` remains live in `ExecutionKVStore`.

## Host impact

Extension: current tool-use runs are unchanged; sessions persisted only in the retired January/February shapes no longer resume.

Desktop: current tool-use runs are unchanged; desktop has no released persistence contract.

CLI: current tool-use runs are unchanged; sessions persisted only in the retired January/February shapes no longer resume.

## Scheduled refactoring

Remaining #9422 dates:
- workspace snapshot twin: after 2026-08-14;
- usage accumulator twin: after 2026-09-22;
- persisted task-state fallback: after 2026-10-05;
- pre-`modelId` lift: after 2026-11-01.

## Validation

- 52 focused tests passed;
- root, test-kernel, and agent-package type checks passed;
- agent declaration validation passed;
- ESLint and Prettier passed on changed files;
- pre-push and whitespace checks passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for old persisted sessions that never migrated; current canonical runs are unchanged but extension/CLI users with very old on-disk state lose resume.
> 
> **Overview**
> Tool-use **resume and persistence** now accept only the current top-level shared shape with **`messages`**. Support for the nested **`{ state: … }`** wrapper and the legacy **`conversation`** field is removed from **`migrateSharedState`** and from model-handler compatibility inference.
> 
> **`migrateSharedState`** no longer unwraps or renames fields; it validates with **`ToolUseRunSharedSchema`** and still lifts **`modelId`** from the **`MODEL`** user variable when missing. **`inferPersistedFlowModelHandlerCompatibilityKey`** reads **`record.messages`** via **`ProviderMessageArraySchema`** instead of **`normalizeProviderMessages`**.
> 
> Sessions stored only in the retired January/February shapes **will not resume**. Compatibility-only resume tests for those formats are deleted; **`normalizeProviderMessages`** remains for execution KV **`conversation.json`** reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fb29a7193f00b52343990b3abd9723803365d5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->