### PR TITLE
test: remove result schema boilerplate

### DIFF
--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -291,66 +291,6 @@ describe('ExecutionKVStore meta read shims', () => {
     await expect(getExecutionStore(id).readMeta()).resolves.toBeNull();
   });
 
-  it('rejects empty result metadata instead of inventing a workflow result', async () => {
-    const id = 'bad-result-empty' as ExecutionId;
-    const warnSpy = mockWarn();
-
-    await getExecutionStore(id).write('result-meta', {});
-
-    await expect(getExecutionStore(id).readResultMeta()).resolves.toBeNull();
-    expectParseWarning(warnSpy, id, 'result-meta.json');
-  });
-
-  it('rejects unknown result metadata producers', async () => {
-    const id = 'bad-result-producer' as ExecutionId;
-    const warnSpy = mockWarn();
-
-    await getExecutionStore(id).write('result-meta', {
-      producer: 'unknown',
-      outputs: [],
-      compileFailures: [],
-    });
-
-    await expect(getExecutionStore(id).readResultMeta()).resolves.toBeNull();
-    expectParseWarning(warnSpy, id, 'result-meta.json');
-  });
-
-  it('rejects unknown fields in canonical result metadata', async () => {
-    const id = 'bad-result-canonical-field' as ExecutionId;
-    const warnSpy = mockWarn();
-
-    await getExecutionStore(id).write('result-meta', {
-      producer: 'subagent',
-      agentName: 'reviewer',
-      wallTimeMs: 12,
-      result: {
-        category: 'toolUse',
-        outcome: RUN_OUTCOME.COMPLETED,
-        response: 'done',
-        files: [],
-        cost: 0,
-      },
-      unexpected: true,
-    });
-
-    await expect(getExecutionStore(id).readResultMeta()).resolves.toBeNull();
-    expectParseWarning(warnSpy, id, 'result-meta.json');
-  });
-
-  it('rejects a CLI workflow record with an explicit tool-use category', async () => {
-    const id = 'bad-result-cli-category' as ExecutionId;
-    const warnSpy = mockWarn();
-    await getExecutionStore(id).write('result-meta', {
-      producer: 'cliWorkflow',
-      category: 'toolUse',
-      outcome: RUN_OUTCOME.COMPLETED,
-      result: { response: 'not a workflow result' },
-    });
-
-    await expect(getExecutionStore(id).readResultMeta()).resolves.toBeNull();
-    expectParseWarning(warnSpy, id, 'result-meta.json');
-  });
-
   it('reads legacy conversation wrappers as provider messages', async () => {
     const id = 'legacy-conversation-wrapper' as ExecutionId;
     const message = { role: 'user', content: 'Resume this.' };

--- a/src/test-kernel/tools/SubagentResultMeta.vitest.ts
+++ b/src/test-kernel/tools/SubagentResultMeta.vitest.ts
@@ -1,144 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { ResultMetaSchema } from '@agent/storage';
-import { buildAgentFinalResult } from '@agent/runtime/AgentFinalResult';
 import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
-import type { OutputFileSummary } from '@shared/schemas/output';
-import {
-  buildSubagentFailureResultMeta,
-  buildSubagentResultMeta,
-} from '@tools/subagentResults';
+import { buildSubagentFailureResultMeta } from '@tools/subagentResults';
 
-const OUTPUT: OutputFileSummary = {
-  absolutePath: '/ws/executions/abc/r0/output.tex',
-  relativePath: 'r0/output.tex',
-  originalPath: '/ws/chapter1.tex',
-  location: 'runStorage',
-  round: 0,
-  added: 12,
-  removed: 3,
-};
-
-describe('buildSubagentResultMeta', () => {
-  it('keeps legacy aliases out of the canonical write schema', () => {
-    expect(
-      ResultMetaSchema.safeParse({
-        producer: 'subagent',
-        agentName: 'reviewer',
-        outcome: 'completed',
-        success: true,
-        wallTimeMs: 20,
-        result: {
-          category: 'toolUse',
-          lastResponse: 'legacy response',
-        },
-      }).success,
-    ).toBe(false);
-  });
-
-  it('builds a schema-valid manifest for workflow results with diffs', () => {
-    const result: AgentFlowResult = {
-      category: 'workflow',
-      outcome: 'completed',
-      outputs: [OUTPUT],
-      compileFailures: [],
-      executionId: 'abcdefabcdef' as ExecutionId,
-      streamId: 'stream:wf' as StreamTabId,
-      totalCostUsd: 0.42,
-    };
-    const finalResult = buildAgentFinalResult({
-      flowResult: result,
-      diffs: [
-        {
-          path: OUTPUT.absolutePath,
-          diffRelPath: 'diffs/r0_output.tex.diff',
-          largeChange: false,
-        },
-      ],
-    });
-    const meta = buildSubagentResultMeta('merge', finalResult, 1234);
-
-    expect(ResultMetaSchema.parse(meta)).toEqual(meta);
-    expect(meta.result).toBe(finalResult);
-    expect(meta).toEqual({
-      producer: 'subagent',
-      agentName: 'merge',
-      wallTimeMs: 1234,
-      result: {
-        category: 'workflow',
-        outcome: 'completed',
-        outputs: [OUTPUT],
-        compileFailures: [],
-        diffs: [
-          {
-            path: OUTPUT.absolutePath,
-            diffRelPath: 'diffs/r0_output.tex.diff',
-            largeChange: false,
-          },
-        ],
-        cost: 0.42,
-      },
-    });
-  });
-
-  it('records diffsUnavailable in the manifest when diff generation failed', () => {
-    const result: AgentFlowResult = {
-      category: 'workflow',
-      outcome: 'completed',
-      outputs: [OUTPUT],
-      compileFailures: [],
-      executionId: 'abcdefabcdef' as ExecutionId,
-      streamId: 'stream:wf' as StreamTabId,
-    };
-    const finalResult = buildAgentFinalResult({
-      flowResult: result,
-      diffsUnavailable: 'latexdiff crashed',
-    });
-    const meta = buildSubagentResultMeta('merge', finalResult, 500);
-
-    expect(ResultMetaSchema.parse(meta)).toEqual(meta);
-    expect(meta.result.category).toBe('workflow');
-    expect(
-      meta.result.category === 'workflow' ? meta.result.diffs : [],
-    ).toEqual([]);
-    expect(
-      meta.result.category === 'workflow'
-        ? meta.result.diffsUnavailable
-        : undefined,
-    ).toBe('latexdiff crashed');
-  });
-
-  it('builds a schema-valid manifest for tool-use results', () => {
-    const result: AgentFlowResult = {
-      category: 'toolUse',
-      outcome: 'completed',
-      response: 'All findings verified.',
-      files: ['notes.md'],
-      executionId: 'abcdefabcdef' as ExecutionId,
-      streamId: 'stream:tu' as StreamTabId,
-    };
-    const meta = buildSubagentResultMeta(
-      'reviewer',
-      buildAgentFinalResult({ flowResult: result }),
-      99,
-    );
-
-    expect(ResultMetaSchema.parse(meta)).toEqual(meta);
-    expect(meta).toEqual({
-      producer: 'subagent',
-      agentName: 'reviewer',
-      wallTimeMs: 99,
-      result: {
-        category: 'toolUse',
-        outcome: 'completed',
-        response: 'All findings verified.',
-        files: ['notes.md'],
-        cost: 0,
-      },
-    });
-  });
-
+describe('buildSubagentFailureResultMeta', () => {
   it('failure manifest overwrites interim success and never claims success', () => {
     const interim: AgentFlowResult = {
       category: 'toolUse',
@@ -153,7 +19,6 @@ describe('buildSubagentResultMeta', () => {
       interim,
       50,
     );
-    expect(ResultMetaSchema.parse(meta)).toEqual(meta);
     expect(meta.result.outcome).toBe('failed');
     // Cancelled runs keep their real outcome.
     const cancelled = buildSubagentFailureResultMeta(
@@ -163,43 +28,5 @@ describe('buildSubagentResultMeta', () => {
       50,
     );
     expect(cancelled.result.outcome).toBe('cancelled');
-  });
-
-  it('failure manifest without a flow result uses the known category', () => {
-    const meta = buildSubagentFailureResultMeta(
-      'merge',
-      'workflow',
-      undefined,
-      10,
-    );
-    expect(ResultMetaSchema.parse(meta)).toEqual(meta);
-    expect(meta).toEqual({
-      producer: 'subagent',
-      agentName: 'merge',
-      wallTimeMs: 10,
-      result: {
-        category: 'workflow',
-        outcome: 'failed',
-        outputs: [],
-        compileFailures: [],
-        diffs: [],
-        cost: 0,
-      },
-    });
-  });
-
-  it('preserves a cancelled outcome in the envelope', () => {
-    const result: AgentFlowResult = {
-      category: 'toolUse',
-      outcome: 'cancelled',
-      executionId: 'abcdefabcdef' as ExecutionId,
-      streamId: 'stream:tu' as StreamTabId,
-    };
-    const meta = buildSubagentResultMeta(
-      'reviewer',
-      buildAgentFinalResult({ flowResult: result }),
-      5,
-    );
-    expect(meta.result.outcome).toBe('cancelled');
   });
 });

--- a/src/test-kernel/tools/SubagentResultMeta.vitest.ts
+++ b/src/test-kernel/tools/SubagentResultMeta.vitest.ts
@@ -1,10 +1,33 @@
 import { describe, expect, it } from 'vitest';
 
+import { ResultMetaSchema } from '@agent/storage';
+import { buildAgentFinalResult } from '@agent/runtime/AgentFinalResult';
 import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
-import { buildSubagentFailureResultMeta } from '@tools/subagentResults';
+import {
+  buildSubagentFailureResultMeta,
+  buildSubagentResultMeta,
+} from '@tools/subagentResults';
 
-describe('buildSubagentFailureResultMeta', () => {
+describe('subagent result metadata', () => {
+  it('builds a schema-valid manifest from the canonical final result', () => {
+    const result: AgentFlowResult = {
+      category: 'toolUse',
+      outcome: 'completed',
+      response: 'All findings verified.',
+      files: ['notes.md'],
+      executionId: 'abcdefabcdef' as ExecutionId,
+      streamId: 'stream:tu' as StreamTabId,
+    };
+    const meta = buildSubagentResultMeta(
+      'reviewer',
+      buildAgentFinalResult({ flowResult: result }),
+      99,
+    );
+
+    expect(ResultMetaSchema.parse(meta)).toEqual(meta);
+  });
+
   it('failure manifest overwrites interim success and never claims success', () => {
     const interim: AgentFlowResult = {
       category: 'toolUse',


### PR DESCRIPTION
## Summary

- keep the consequential subagent failure/cancellation invariant
- remove repeated result-envelope construction checks already covered by the final-result boundary
- remove four storage tests that only enumerate schema rejection branches already covered by the shared validated-read boundary

## Rationale

These tests duplicated current schema implementation details or asserted retired result formats. They increased maintenance cost without protecting distinct behavior. Durable terminal-outcome projection, resume behavior, malformed-storage handling, and the public result boundary remain covered.

No production code changes.

## Validation

- 35 focused tests passed
- test-kernel type checking passed
- ESLint and Prettier passed
- pre-push and whitespace checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only removes tests; behavior and production paths are unchanged, with durable resume, malformed-storage, and subagent failure coverage still asserted elsewhere.
> 
> **Overview**
> **Test-only cleanup** — no production code changes.
> 
> Removes four `ExecutionKVStore` cases that walked `result-meta.json` through invalid payloads (empty object, unknown producer, extra fields, CLI/workflow category mismatch) and asserted warn + `null` on read. Those branches duplicate the shared validated-read / `ResultMetaSchema` boundary already exercised elsewhere in the suite.
> 
> In `SubagentResultMeta.vitest.ts`, drops repeated full-envelope equality checks, legacy-alias rejection, workflow/diff manifest construction, and several failure/cancel permutations. **Keeps** a single schema-valid build from the canonical final result and the **failure manifest** invariant (failed overwrites interim success; cancelled stays cancelled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2a2bbc008eb016b67a0cb73e7454364019bfe88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->