### PR TITLE
refactor(desktop): drop malformed shortcut backups

### DIFF
--- a/packages/desktop/src/renderer/desktopShortcutRegistry.ts
+++ b/packages/desktop/src/renderer/desktopShortcutRegistry.ts
@@ -236,7 +236,7 @@ function readOverrides(storage: Storage | undefined): DesktopShortcutOverrides {
     const result = DesktopShortcutOverridesSchema.safeParse(parsed);
     if (result.success) return result.data;
   } catch {
-    return {};
+    // Malformed JSON resolves to the same empty defaults as a failed schema parse.
   }
   return {};
 }

--- a/packages/desktop/src/renderer/desktopShortcutRegistry.ts
+++ b/packages/desktop/src/renderer/desktopShortcutRegistry.ts
@@ -4,7 +4,6 @@ import type {
   DesktopShortcutService,
 } from '@shared/commands/shortcutPreferences';
 import {
-  DESKTOP_SHORTCUT_INVALID_BACKUP_KEY,
   DESKTOP_SHORTCUT_STORAGE_KEY,
   DesktopShortcutOverridesSchema,
   installDesktopShortcutService,
@@ -49,20 +48,13 @@ export interface DesktopShortcutRegistry extends DesktopShortcutService {
   dispose(): void;
 }
 
-interface StoredShortcutOverrides {
-  readonly overrides: DesktopShortcutOverrides;
-  readonly invalidRaw?: string;
-}
-
 /** Installs the one desktop shortcut dispatcher and Settings service. */
 export function createDesktopShortcutRegistry(
   options: DesktopShortcutRegistryOptions,
 ): DesktopShortcutRegistry {
   const view = options.document.defaultView;
   const platform = options.platform ?? getRendererPlatform(view);
-  const stored = readOverrides(view?.localStorage);
-  let overrides = stored.overrides;
-  let invalidRaw = stored.invalidRaw;
+  let overrides = readOverrides(view?.localStorage);
   const listeners = new Set<
     (entries: readonly DesktopShortcutEntry[]) => void
   >();
@@ -105,16 +97,16 @@ export function createDesktopShortcutRegistry(
       ...overrides,
       [id]: accelerator ?? null,
     };
-    writeOverrides(view?.localStorage, overrides, invalidRaw);
-    invalidRaw = undefined;
+    view?.localStorage.setItem(
+      DESKTOP_SHORTCUT_STORAGE_KEY,
+      JSON.stringify(overrides),
+    );
     notify();
   }
 
   function reset(): void {
     overrides = {};
-    invalidRaw = undefined;
     view?.localStorage.removeItem(DESKTOP_SHORTCUT_STORAGE_KEY);
-    view?.localStorage.removeItem(DESKTOP_SHORTCUT_INVALID_BACKUP_KEY);
     notify();
   }
 
@@ -235,27 +227,16 @@ function hasPrimaryModifier(event: KeyboardEvent): boolean {
   return event.metaKey || event.ctrlKey || event.altKey;
 }
 
-function readOverrides(storage: Storage | undefined): StoredShortcutOverrides {
-  if (!storage) return { overrides: {} };
+function readOverrides(storage: Storage | undefined): DesktopShortcutOverrides {
+  if (!storage) return {};
   const raw = storage.getItem(DESKTOP_SHORTCUT_STORAGE_KEY);
-  if (!raw) return { overrides: {} };
+  if (!raw) return {};
   try {
     const parsed: unknown = JSON.parse(raw);
     const result = DesktopShortcutOverridesSchema.safeParse(parsed);
-    if (result.success) return { overrides: result.data };
+    if (result.success) return result.data;
   } catch {
-    // The invalid value is retained and backed up on the next explicit write.
+    return {};
   }
-  return { overrides: {}, invalidRaw: raw };
-}
-
-function writeOverrides(
-  storage: Storage | undefined,
-  overrides: DesktopShortcutOverrides,
-  invalidRaw: string | undefined,
-): void {
-  if (invalidRaw) {
-    storage?.setItem(DESKTOP_SHORTCUT_INVALID_BACKUP_KEY, invalidRaw);
-  }
-  storage?.setItem(DESKTOP_SHORTCUT_STORAGE_KEY, JSON.stringify(overrides));
+  return {};
 }

--- a/src/shared/commands/shortcutPreferences.ts
+++ b/src/shared/commands/shortcutPreferences.ts
@@ -28,8 +28,6 @@ export interface DesktopShortcutService {
 
 export const DESKTOP_SHORTCUT_STORAGE_KEY =
   'texra.desktop.shortcutOverrides.v1';
-export const DESKTOP_SHORTCUT_INVALID_BACKUP_KEY =
-  'texra.desktop.shortcutOverrides.invalidBackup.v1';
 
 export const DesktopShortcutOverridesSchema = z.record(
   z.string(),

--- a/src/test-kernel/desktop/DesktopShortcutRegistry.vitest.mts
+++ b/src/test-kernel/desktop/DesktopShortcutRegistry.vitest.mts
@@ -2,11 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - shared shortcut contract
-import {
-  DESKTOP_SHORTCUT_INVALID_BACKUP_KEY,
-  DESKTOP_SHORTCUT_STORAGE_KEY,
-  getDesktopShortcutService,
-} from '@shared/commands/shortcutPreferences';
+import { getDesktopShortcutService } from '@shared/commands/shortcutPreferences';
 
 // Local imports - test DOM
 import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
@@ -77,31 +73,6 @@ describe('desktop shortcut registry', () => {
       }),
     );
     expect(openCommands).toHaveBeenCalledOnce();
-    registry.dispose();
-  });
-
-  it('backs up malformed persisted preferences before an explicit update', async () => {
-    const malformed = '{"texra.desktop.showCommands":42}';
-    const storage = document.defaultView?.localStorage;
-    if (!storage) throw new Error('Test DOM localStorage is unavailable.');
-    storage.setItem(DESKTOP_SHORTCUT_STORAGE_KEY, malformed);
-    const registry = await createRegistry();
-
-    expect(
-      registry
-        .entries()
-        .find((entry) => entry.id === 'texra.desktop.showCommands'),
-    ).toMatchObject({ accelerator: 'Command+K' });
-    registry.update('texra.desktop.showCommands', 'Command+Shift+K');
-
-    expect(storage.getItem(DESKTOP_SHORTCUT_INVALID_BACKUP_KEY)).toBe(
-      malformed,
-    );
-    expect(
-      JSON.parse(storage.getItem(DESKTOP_SHORTCUT_STORAGE_KEY) ?? '{}'),
-    ).toMatchObject({
-      'texra.desktop.showCommands': 'Command+Shift+K',
-    });
     registry.dispose();
   });
 


### PR DESCRIPTION
## Summary

Desktop shortcut preferences still validate persisted JSON and fall back to the current empty override map when data is malformed. The unreleased invalid-state backup key, deferred backup write, and compatibility-only test are removed.

## Issue acceptance gates

No dedicated issue. This satisfies the repository rule that the unreleased desktop application does not preserve or migrate historical desktop-only state.

## Single source of truth

`DesktopShortcutOverridesSchema` validates the sole current `DESKTOP_SHORTCUT_STORAGE_KEY` value. Invalid input resolves directly to current defaults.

## Duplication and abstraction budget

Removed the secondary backup key, wrapper state, deferred backup plumbing, and one compatibility-only test. No replacement helper or migration was added.

## Net elements (R6)

- files: 3 changed, no files added or removed;
- exported symbols: 1 constant removed, 0 added;
- private elements: 1 wrapper interface, 1 helper, and `invalidRaw` state removed;
- tests: 1 compatibility-only test removed;
- lines: +12 / -62, net -50.

## Consumer counts (R8)

No event or host command is changed. The removed backup constant had 1 production consumer and 1 test consumer. The removed write helper had 1 production call site. All obsolete backup references are now zero.

## Host impact

Extension: none.

Desktop: malformed shortcut JSON continues to fall back to current defaults, but is no longer preserved under a second unreleased backup key before the next edit.

CLI: none.

## Scheduled refactoring

The obsolete `desktop:setRoute` vocabulary is a separate follow-up because current menu and renderer producers must move together to direct launcher/workbench actions.

## Validation

- focused shortcut registry tests passed 2/2;
- workspace, test-kernel, and desktop type checks passed;
- full lint passed;
- formatting, commit hooks, and whitespace checks passed;
- repository search confirms no obsolete backup symbol remains.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only preference plumbing with no auth or IPC changes; behavior change is dropping preservation of corrupt unreleased state, which matches the stated no-migration policy.
> 
> **Overview**
> Removes the unreleased **invalid shortcut backup** path for desktop shortcut overrides. Malformed or schema-invalid `localStorage` data under `DESKTOP_SHORTCUT_STORAGE_KEY` still falls back to empty defaults via `DesktopShortcutOverridesSchema`, but is **no longer retained** under a second backup key or copied on the next explicit `update`.
> 
> **`desktopShortcutRegistry`** inlines persistence: `update`/`reset` write or clear only the primary key; `readOverrides` returns `{}` on parse or validation failure without tracking `invalidRaw`. The shared constant `DESKTOP_SHORTCUT_INVALID_BACKUP_KEY` and the compatibility test for deferred backup-on-update are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecb394f882799a9b56d7ed038705118073a8447d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->