### PR TITLE
refactor(desktop): replace route protocol with direct actions

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -82,6 +82,11 @@
       "name": "packages/trace-viewer/vite.standalone.config.ts"
     },
     {
+      "file": "src/shared/schemas/commonViewMessages.ts",
+      "category": "types",
+      "name": "SwitchViewTarget"
+    },
+    {
       "file": "src/test-kernel/support/setupFakePlatform.ts",
       "category": "files",
       "name": "src/test-kernel/support/setupFakePlatform.ts"

--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -17,8 +17,8 @@ import {
 } from '@shared/commands/registry';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import {
-  buildDesktopSetRouteMessage,
-  type DesktopRoute,
+  DESKTOP_SHELL_COMMANDS,
+  type DesktopWorkbenchKind,
 } from './desktopShellMessages.js';
 import type { MenuItemConstructorOptions } from 'electron';
 
@@ -158,7 +158,8 @@ export interface DesktopMenuTemplateItem extends Omit<
  * main-process action set does not implement it.
  */
 export interface DesktopCommandActions {
-  showRoute(route: DesktopRoute): void;
+  showLauncher(): void;
+  openWorkbench(kind: DesktopWorkbenchKind): void;
   showSettings(tabIndex?: SettingsTab, agentSubTab?: AgentCategory): void;
   showStream?(streamId: StreamTabId): void;
   openDesktopDocs(): void;
@@ -311,8 +312,8 @@ function action(
 }
 
 const DESKTOP_COMMAND_HANDLERS = {
-  'texra.showMainView': action((a) => a.showRoute('main')),
-  [DESKTOP_LOCAL_COMMANDS.SHOW_LOGS]: action((a) => a.showRoute('logs')),
+  'texra.showMainView': action((a) => a.showLauncher()),
+  [DESKTOP_LOCAL_COMMANDS.SHOW_LOGS]: action((a) => a.openWorkbench('logs')),
   [DESKTOP_LOCAL_COMMANDS.TOGGLE_BOTTOM_BAR]: action((a) =>
     a.toggleBottomBar(),
   ),
@@ -387,16 +388,19 @@ export function buildDesktopSettingsTabMessage(
 }
 
 /**
- * Sole owner of the two-message "open the settings surface, then select a tab"
- * sequence the main process posts. Menu/rail navigation and stream-initiated
- * navigation both route here so the two cannot drift apart.
+ * Opens the Settings workbench before selecting an optional settings tab.
+ * Main-process navigation has two consumers, so this helper keeps their
+ * message ordering identical.
  */
-export function postDesktopSettingsRoute(
+export function postDesktopSettingsView(
   postToRenderer: (message: unknown) => void,
   tabIndex?: SettingsTab,
   agentSubTab?: AgentCategory,
 ): void {
-  postToRenderer(buildDesktopSetRouteMessage('settings'));
+  postToRenderer({
+    command: DESKTOP_SHELL_COMMANDS.OPEN_WORKBENCH,
+    kind: 'settings',
+  });
   if (tabIndex == null) return;
   postToRenderer(buildDesktopSettingsTabMessage(tabIndex, agentSubTab));
 }

--- a/packages/desktop/src/desktopShellMessages.ts
+++ b/packages/desktop/src/desktopShellMessages.ts
@@ -1,28 +1,23 @@
 import { z } from 'zod';
 
 export const DESKTOP_SHELL_COMMANDS = {
+  OPEN_WORKBENCH: 'desktop:openWorkbench',
   SAVE_FILE: 'desktop:saveFile',
-  SET_ROUTE: 'desktop:setRoute',
+  SHOW_LAUNCHER: 'desktop:showLauncher',
   TOGGLE_LAYOUT: 'desktop:toggleLayout',
 } as const;
 
-const DesktopRouteSchema = z.enum(['main', 'settings', 'logs']);
-export type DesktopRoute = z.infer<typeof DesktopRouteSchema>;
+const DesktopWorkbenchKindSchema = z.enum(['settings', 'logs']);
+export type DesktopWorkbenchKind = z.infer<typeof DesktopWorkbenchKindSchema>;
 
-export const DesktopSetRouteMessageSchema = z.object({
-  command: z.literal(DESKTOP_SHELL_COMMANDS.SET_ROUTE),
-  route: DesktopRouteSchema,
+export const DesktopOpenWorkbenchMessageSchema = z.object({
+  command: z.literal(DESKTOP_SHELL_COMMANDS.OPEN_WORKBENCH),
+  kind: DesktopWorkbenchKindSchema,
 });
 
-export type DesktopSetRouteMessage = z.infer<
-  typeof DesktopSetRouteMessageSchema
->;
-
-export function buildDesktopSetRouteMessage(
-  route: DesktopRoute,
-): DesktopSetRouteMessage {
-  return { command: DESKTOP_SHELL_COMMANDS.SET_ROUTE, route };
-}
+export const DesktopShowLauncherMessageSchema = z.object({
+  command: z.literal(DESKTOP_SHELL_COMMANDS.SHOW_LAUNCHER),
+});
 
 export const DesktopSaveFileMessageSchema = z.object({
   command: z.literal(DESKTOP_SHELL_COMMANDS.SAVE_FILE),

--- a/packages/desktop/src/desktopTaskShell.ts
+++ b/packages/desktop/src/desktopTaskShell.ts
@@ -11,8 +11,6 @@
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { clamp, getBasename } from '@utils/core';
 
-import type { DesktopRoute } from './desktopShellMessages.js';
-
 export const WORKBENCH_KINDS = [
   'editor',
   'terminal',
@@ -463,14 +461,6 @@ export function setWorkbenchWidth(
       WORKBENCH_MAX_WIDTH,
     ),
   };
-}
-
-export function workbenchKindForRoute(
-  route: DesktopRoute,
-): WorkbenchKind | undefined {
-  if (route === 'settings') return 'settings';
-  if (route === 'logs') return 'logs';
-  return undefined;
 }
 
 export function workspaceInitials(workspacePath: string | undefined): string {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -111,11 +111,11 @@ import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
-  postDesktopSettingsRoute,
+  postDesktopSettingsView,
   vsCodeOnlyGettingStartedMessage,
 } from '../desktopCommandSurface.js';
 import { buildDesktopOnboardingSetStateMessage } from '../desktopOnboardingMessages.js';
-import { buildDesktopSetRouteMessage } from '../desktopShellMessages.js';
+import { DESKTOP_SHELL_COMMANDS } from '../desktopShellMessages.js';
 import { DesktopToolEditApprovalHost } from './desktopToolEditApproval.js';
 import { createDesktopHostInteractions } from './desktopHostInteractions.js';
 import { listDesktopWorkspaceFiles } from './desktopFileSelection.js';
@@ -500,7 +500,7 @@ export class DesktopProgressBridge {
       readKey: (provider) => lookupApiKey(platform().secrets, provider),
       hasUsableKey: (provider) => hasUsableApiKey(platform().secrets, provider),
       promptForApiKey: async () => {
-        this.routeToSettings(SETTINGS_TAB.MODELS);
+        this.showSettings(SETTINGS_TAB.MODELS);
         await this.options.host.showInfoMessage(
           'Add a provider API key in Models, then use "Retry" on the request.',
         );
@@ -1034,10 +1034,10 @@ export class DesktopProgressBridge {
       },
       // Settings navigation
       openMemoryView: () => {
-        this.routeToSettings(SETTINGS_TAB.MEMORY);
+        this.showSettings(SETTINGS_TAB.MEMORY);
       },
       openProfile: () => {
-        this.routeToSettings();
+        this.showSettings();
       },
       // Pop-out-to-editor is a VS Code editor-tab concept; the desktop app is
       // a single window.
@@ -1084,8 +1084,8 @@ export class DesktopProgressBridge {
    * owner the rail and menu commands use, so a stream-initiated navigation
    * lands identically.
    */
-  private routeToSettings(tabIndex?: SettingsTab): void {
-    postDesktopSettingsRoute(
+  private showSettings(tabIndex?: SettingsTab): void {
+    postDesktopSettingsView(
       (message) => this.postToRenderer(message),
       tabIndex,
     );
@@ -1301,7 +1301,7 @@ export class DesktopProgressBridge {
 
   /**
    * Restore a run's setup into the main view: builds the host-neutral
-   * persisted-state snapshot and routes the renderer there. Shared by the
+   * persisted-state snapshot and shows it in the launcher. Shared by the
    * in-session "restore this proposal" flow (`agentProposal.restoreRunConfig`
    * above) and desktop history's "Setup" action (settings IPC), which mirrors
    * the extension's `texra.restoreState` command.
@@ -1316,7 +1316,9 @@ export class DesktopProgressBridge {
       });
       return false;
     }
-    this.postToRenderer(buildDesktopSetRouteMessage('main'));
+    this.postToRenderer({
+      command: DESKTOP_SHELL_COMMANDS.SHOW_LAUNCHER,
+    });
     this.postToRenderer({
       command: COMMON_COMMANDS.STATE_RESTORE,
       state,

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -192,10 +192,20 @@ function dispatchMainViewInboundOnShell(
 ): boolean {
   switch (message.command) {
     case COMMON_COMMANDS.SWITCH_VIEW: {
-      if (message.view === 'main') actions.showLauncher();
-      if (message.view === 'dashboard') actions.showSettings();
-      // The conversation is the permanent desktop canvas, so "progress" is
-      // already visible and intentionally needs no action.
+      switch (message.view) {
+        case 'main':
+          actions.showLauncher();
+          break;
+        case 'dashboard':
+          actions.showSettings();
+          break;
+        case 'progress':
+          // The conversation is the permanent desktop canvas, so progress is
+          // already visible and intentionally needs no action.
+          break;
+        default:
+          message.view satisfies never;
+      }
       return true;
     }
     case MAIN_VIEW_COMMANDS.SETTINGS_OPEN:

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -1,6 +1,5 @@
 import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import { AgentCategory } from '@shared/schemas/agent';
-import { type SwitchViewTarget } from '@shared/schemas/commonViewMessages';
 import {
   MainViewInboundMessageSchema,
   type MainViewInboundMessage,
@@ -10,10 +9,9 @@ import {
   type SettingsTab,
 } from '@shared/schemas/settingsViewMessages';
 import {
-  buildDesktopSetRouteMessage,
   DESKTOP_SHELL_COMMANDS,
   type DesktopLayoutPanel,
-  type DesktopRoute,
+  type DesktopWorkbenchKind,
 } from '../desktopShellMessages.js';
 import { buildDesktopOnboardingSetStateMessage } from '../desktopOnboardingMessages.js';
 import {
@@ -26,7 +24,7 @@ import {
   buildDesktopMainViewResetMessage,
   DESKTOP_DOCS_URL,
   DESKTOP_LOCAL_COMMANDS,
-  postDesktopSettingsRoute,
+  postDesktopSettingsView,
   vsCodeOnlyGettingStartedMessage,
   type DesktopCommandActions,
 } from '../desktopCommandSurface.js';
@@ -62,30 +60,21 @@ export interface DesktopShellActions extends DesktopCommandActions {
   showInfoMessage(message: string): void;
 }
 
-// The desktop task shell has no separate progress surface: the conversation is
-// the permanent canvas, so a 'progress' target is already on screen and maps to
-// no route change.
-const SWITCH_VIEW_ROUTES = {
-  main: 'main',
-  progress: undefined,
-  dashboard: 'settings',
-} satisfies Record<SwitchViewTarget, DesktopRoute | undefined>;
-
 export function createDesktopShellActions(
   renderer: DesktopRenderer,
   options: DesktopShellActionFactoryOptions,
 ): DesktopShellActions {
   const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
 
-  function postRoute(route: DesktopRoute) {
-    renderer.postToRenderer(buildDesktopSetRouteMessage(route));
+  function openWorkbench(kind: DesktopWorkbenchKind) {
+    renderer.postToRenderer({
+      command: DESKTOP_SHELL_COMMANDS.OPEN_WORKBENCH,
+      kind,
+    });
   }
 
-  function postSettingsRoute(
-    tabIndex?: SettingsTab,
-    agentSubTab?: AgentCategory,
-  ) {
-    postDesktopSettingsRoute(
+  function showSettings(tabIndex?: SettingsTab, agentSubTab?: AgentCategory) {
+    postDesktopSettingsView(
       (message) => renderer.postToRenderer(message),
       tabIndex,
       agentSubTab,
@@ -99,7 +88,7 @@ export function createDesktopShellActions(
 
   function openAgentDirectory(customDirSet?: boolean) {
     if (customDirSet !== true) {
-      postSettingsRoute(SETTINGS_TAB.AGENTS);
+      showSettings(SETTINGS_TAB.AGENTS);
       return;
     }
     void openCustomAgentDirectory().catch(reportAsyncError);
@@ -122,7 +111,9 @@ export function createDesktopShellActions(
   }
 
   function resetMainView() {
-    postRoute('main');
+    renderer.postToRenderer({
+      command: DESKTOP_SHELL_COMMANDS.SHOW_LAUNCHER,
+    });
     renderer.postToRenderer(buildDesktopMainViewResetMessage());
   }
 
@@ -164,8 +155,13 @@ export function createDesktopShellActions(
           postReply([], false);
         });
     },
-    showRoute: postRoute,
-    showSettings: postSettingsRoute,
+    showLauncher: () => {
+      renderer.postToRenderer({
+        command: DESKTOP_SHELL_COMMANDS.SHOW_LAUNCHER,
+      });
+    },
+    openWorkbench,
+    showSettings,
     toggleBottomBar: () => toggleLayout('bottomBar'),
     toggleSidePanel: () => toggleLayout('sidePanel'),
     toggleSummaryBar: () => toggleLayout('summaryBar'),
@@ -196,8 +192,10 @@ function dispatchMainViewInboundOnShell(
 ): boolean {
   switch (message.command) {
     case COMMON_COMMANDS.SWITCH_VIEW: {
-      const route = SWITCH_VIEW_ROUTES[message.view];
-      if (route) actions.showRoute(route);
+      if (message.view === 'main') actions.showLauncher();
+      if (message.view === 'dashboard') actions.showSettings();
+      // The conversation is the permanent desktop canvas, so "progress" is
+      // already visible and intentionally needs no action.
       return true;
     }
     case MAIN_VIEW_COMMANDS.SETTINGS_OPEN:

--- a/packages/desktop/src/renderer/desktopOnboarding.ts
+++ b/packages/desktop/src/renderer/desktopOnboarding.ts
@@ -30,8 +30,6 @@ import {
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
-import type { DesktopRoute } from '../desktopShellMessages';
-
 interface StartupPanelController {
   isVisible(): boolean;
   template(): TemplateResult | typeof nothing;
@@ -42,7 +40,7 @@ interface StartupPanelController {
 export interface DesktopStartupTeamPanelOptions {
   dismiss(): void;
   onVisibilityChanged(): void;
-  setRoute(route: DesktopRoute): void;
+  showLauncher(): void;
   /** Opens the Settings tab focused on the team picker, for fine-tuning. */
   openMultiAgent(): void;
 }
@@ -108,7 +106,7 @@ function presetById(presetId: string): AgentModePreset | undefined {
 export function createStartupTeamPanel({
   dismiss: postDismissed,
   onVisibilityChanged,
-  setRoute,
+  showLauncher,
   openMultiAgent,
 }: DesktopStartupTeamPanelOptions): StartupPanelController {
   const titleId = nextPanelTitleId();
@@ -330,7 +328,7 @@ export function createStartupTeamPanel({
           data-walkthrough-primary
           @click=${() => {
             closePanel();
-            setRoute('main');
+            showLauncher();
           }}
         >
           Start working

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -78,11 +78,11 @@ import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import {
+  DesktopOpenWorkbenchMessageSchema,
   DesktopSaveFileMessageSchema,
-  DesktopSetRouteMessageSchema,
+  DesktopShowLauncherMessageSchema,
   DesktopToggleLayoutMessageSchema,
   type DesktopLayoutPanel,
-  type DesktopRoute,
 } from '../desktopShellMessages';
 import { DesktopSetLogMessageSchema } from '../desktopLogMessages';
 import {
@@ -139,7 +139,6 @@ import {
   toggleSummaryBar,
   toggleWorkbench,
   WORKBENCH_PLACEMENTS,
-  workbenchKindForRoute,
   workbenchTabsForPlacement,
   workspaceInitials,
   workspaceName,
@@ -181,7 +180,7 @@ const appRoot = root;
 const startupTeamPanel = createStartupTeamPanel({
   dismiss: () => postMessage(DESKTOP_ONBOARDING_COMMANDS.DISMISS),
   onVisibilityChanged: rerenderShell,
-  setRoute,
+  showLauncher: returnToLauncher,
   openMultiAgent: () => openSettingsTab(SETTINGS_TAB.MULTI_AGENT),
 });
 
@@ -216,11 +215,6 @@ function commandTitle(
     rendererPlatform,
   );
   return shortcut ? `${label} - ${shortcut}` : label;
-}
-
-/** Publishes the current route on `<body>` for styling and end-to-end checks. */
-function setRouteState(route: DesktopRoute): void {
-  document.body.dataset.desktopRoute = route;
 }
 
 // =============================================================================
@@ -1338,7 +1332,8 @@ function openSettingsTab(
 // =============================================================================
 
 const desktopRendererCommandActions: DesktopCommandActions = {
-  showRoute: setRoute,
+  showLauncher: returnToLauncher,
+  openWorkbench: openKind,
   showSettings: openSettingsTab,
   showStream: switchToStream,
   openDesktopDocs: () => {
@@ -1414,23 +1409,6 @@ function returnToLauncher(): void {
       draft.activeStreamId = null;
     }),
   );
-  setRouteState('main');
-}
-
-// Entry point for `desktop:setRoute` IPC (menu items, command palette). Each
-// route resolves to the workbench tab that owns its surface; 'main'
-// additionally clears the active stream so the center pane shows the launcher.
-function setRoute(route: DesktopRoute): void {
-  setRouteState(route);
-  if (bootstrapFailed) return;
-  if (route === 'main') {
-    returnToLauncher();
-    return;
-  }
-  // Opening Logs must also fetch a snapshot; the pane renders whatever it last
-  // received, which on first open is a placeholder.
-  const kind = workbenchKindForRoute(route);
-  if (kind) openKind(kind);
 }
 
 const LAYOUT_PANEL_TOGGLES: Record<DesktopLayoutPanel, () => void> = {
@@ -1460,9 +1438,12 @@ const MESSAGE_ROUTES: ReadonlyArray<(data: unknown) => boolean> = [
   messageRoute(DesktopSaveFileMessageSchema, () => {
     void editorPane.save();
   }),
-  messageRoute(DesktopSetRouteMessageSchema, (message) =>
-    setRoute(message.route),
-  ),
+  messageRoute(DesktopShowLauncherMessageSchema, () => {
+    if (!bootstrapFailed) returnToLauncher();
+  }),
+  messageRoute(DesktopOpenWorkbenchMessageSchema, (message) => {
+    if (!bootstrapFailed) openKind(message.kind);
+  }),
   messageRoute(DesktopToggleLayoutMessageSchema, (message) => {
     LAYOUT_PANEL_TOGGLES[message.panel]();
   }),

--- a/packages/desktop/tests/e2e/electronApp.ts
+++ b/packages/desktop/tests/e2e/electronApp.ts
@@ -209,7 +209,7 @@ export async function dismissOnboarding(page: Page): Promise<void> {
   }
 
   // The launcher can render before main.ts has finished registering its
-  // desktop:setRoute listener. Wait for the renderer's explicit readiness
+  // desktop shell listeners. Wait for the renderer's explicit readiness
   // marker so the first command after onboarding is never dropped.
   await page.waitForFunction(
     () => document.body.dataset.desktopReady === 'true',
@@ -218,65 +218,50 @@ export async function dismissOnboarding(page: Page): Promise<void> {
   );
 }
 
-export type DesktopRoute = 'main' | 'settings' | 'logs';
-
-/**
- * Send a legacy `desktop:setRoute` IPC message through the task-centric shell
- * and wait until the route is fully applied. Main keeps the permanent
- * conversation surface; Settings and Logs activate their corresponding
- * right-workbench tabs. The wait asserts both the route marker and the target
- * surface so callers never race the first frame.
- */
-export async function setRoute(
-  launched: LaunchedApp,
-  route: DesktopRoute,
-): Promise<void> {
-  await launched.page.evaluate((next) => {
-    window.postMessage({ command: 'desktop:setRoute', route: next }, '*');
-  }, route);
+export async function showLauncher(launched: LaunchedApp): Promise<void> {
+  await launched.page.evaluate(() => {
+    window.postMessage({ command: 'desktop:showLauncher' }, '*');
+  });
   await launched.page.waitForFunction(
-    (targetRoute) => {
-      if (document.body.dataset.desktopRoute !== targetRoute) return false;
-      const shell = document.querySelector<HTMLElement>('.task-shell');
-      if (!shell) return false;
-      switch (targetRoute) {
-        case 'main': {
-          const pane = document.querySelector<HTMLElement>(
-            '.task-conversation-pane[data-pane="launcher"]',
-          );
-          return pane != null && pane.hidden === false;
-        }
-        case 'settings': {
-          const tab = document.querySelector<HTMLElement>(
-            '.task-workbench-tab[data-kind="settings"][data-active="true"]',
-          );
-          const settings = document.querySelector<HTMLElement>(
-            '.task-workbench-surface settings-app[data-desktop-view="settings"]',
-          );
-          return (
-            shell.dataset.workbenchOpen === 'true' &&
-            tab != null &&
-            settings != null
-          );
-        }
-        case 'logs': {
-          const tab = document.querySelector<HTMLElement>(
-            '.task-workbench-tab[data-kind="logs"][data-active="true"]',
-          );
-          const logs = document.querySelector<HTMLElement>(
-            '.task-workbench-surface [data-desktop-view="logs"]',
-          );
-          return (
-            shell.dataset.workbenchOpen === 'true' &&
-            tab != null &&
-            logs != null
-          );
-        }
-        default:
-          return true;
-      }
+    () => {
+      const pane = document.querySelector<HTMLElement>(
+        '.task-conversation-pane[data-pane="launcher"]',
+      );
+      return pane != null && pane.hidden === false;
     },
-    route,
+    undefined,
+    { timeout: 5000 },
+  );
+}
+
+export type DesktopWorkbenchKind = 'settings' | 'logs';
+
+export async function openWorkbench(
+  launched: LaunchedApp,
+  kind: DesktopWorkbenchKind,
+): Promise<void> {
+  await launched.page.evaluate((nextKind) => {
+    window.postMessage(
+      { command: 'desktop:openWorkbench', kind: nextKind },
+      '*',
+    );
+  }, kind);
+  await launched.page.waitForFunction(
+    (targetKind) => {
+      const shell = document.querySelector<HTMLElement>('.task-shell');
+      const tab = document.querySelector<HTMLElement>(
+        `.task-workbench-tab[data-kind="${targetKind}"][data-active="true"]`,
+      );
+      const surface = document.querySelector<HTMLElement>(
+        `[data-desktop-view="${targetKind}"]`,
+      );
+      return (
+        shell?.dataset.workbenchOpen === 'true' &&
+        tab != null &&
+        surface != null
+      );
+    },
+    kind,
     { timeout: 5000 },
   );
 }
@@ -293,7 +278,7 @@ export async function setSettingsTab(
   tabIndex: number,
   panel?: string,
 ): Promise<void> {
-  await setRoute(launched, 'settings');
+  await openWorkbench(launched, 'settings');
   await launched.page.evaluate((idx) => {
     window.postMessage({ command: 'setTab', tabIndex: idx }, '*');
   }, tabIndex);

--- a/packages/desktop/tests/e2e/menuLifetime.spec.ts
+++ b/packages/desktop/tests/e2e/menuLifetime.spec.ts
@@ -77,17 +77,20 @@ test('application menu releases a closed window and binds once to its replacemen
   await windowB.waitForSelector('#app', { state: 'attached' });
 
   await windowB.evaluate(() => {
-    document.body.dataset.menuRouteMessageCount = '0';
+    document.body.dataset.menuWorkbenchMessageCount = '0';
     window.addEventListener('message', (event) => {
-      const message = event.data as { command?: unknown; route?: unknown };
-      if (message.command !== 'desktop:setRoute' || message.route !== 'logs') {
+      const message = event.data as { command?: unknown; kind?: unknown };
+      if (
+        message.command !== 'desktop:openWorkbench' ||
+        message.kind !== 'logs'
+      ) {
         return;
       }
       const current = Number.parseInt(
-        document.body.dataset.menuRouteMessageCount ?? '0',
+        document.body.dataset.menuWorkbenchMessageCount ?? '0',
         10,
       );
-      document.body.dataset.menuRouteMessageCount = String(current + 1);
+      document.body.dataset.menuWorkbenchMessageCount = String(current + 1);
     });
   });
 
@@ -113,7 +116,7 @@ test('application menu releases a closed window and binds once to its replacemen
   await expect
     .poll(() =>
       windowB.evaluate(
-        () => document.body.dataset.menuRouteMessageCount ?? '0',
+        () => document.body.dataset.menuWorkbenchMessageCount ?? '0',
       ),
     )
     .toBe('1');

--- a/packages/desktop/tests/e2e/screenshots.spec.ts
+++ b/packages/desktop/tests/e2e/screenshots.spec.ts
@@ -6,7 +6,7 @@ import {
   closeTexraApp,
   dismissOnboarding,
   launchTexraApp,
-  setRoute,
+  showLauncher,
   setSettingsTab,
   type LaunchedApp,
 } from './electronApp.js';
@@ -74,7 +74,7 @@ test('startup team chooser screenshot', async ({}, testInfo) => {
 });
 
 test('launcher screenshot', async ({}, testInfo) => {
-  await setRoute(launched, 'main');
+  await showLauncher(launched);
   await launched.page.screenshot({
     path: getScreenshotPath(testInfo, 'launcher.png'),
     fullPage: false,
@@ -93,7 +93,7 @@ test('settings screenshot', async ({}, testInfo) => {
 });
 
 test('command palette opens and dismisses', async () => {
-  await setRoute(launched, 'main');
+  await showLauncher(launched);
   // A prior screenshot can leave Settings in the workbench. Hide the workbench
   // so this check exercises the conversation-header command affordance.
   const closeWorkbench = launched.page.locator('.task-workbench-close');

--- a/packages/desktop/tests/e2e/trajectories.spec.ts
+++ b/packages/desktop/tests/e2e/trajectories.spec.ts
@@ -4,7 +4,8 @@ import {
   closeTexraApp,
   dismissOnboarding,
   launchTexraApp,
-  setRoute,
+  openWorkbench,
+  showLauncher,
   setSettingsTab,
   type LaunchedApp,
 } from './electronApp.js';
@@ -65,10 +66,10 @@ async function pdfOverlayIsOpen(): Promise<boolean> {
 
 /**
  * Trajectory 1 — first launch on an empty workspace.
- * The launcher (main route) must mount without crashing the renderer.
+ * The launcher must mount without crashing the renderer.
  */
 test('first launch shows a usable launcher chrome', async () => {
-  await setRoute(launched, 'main');
+  await showLauncher(launched);
   // The workspace directory and command palette button must be reachable.
   const workspaceDirectory =
     launched.workspacePath.split(/[\\/]/).at(-1) ?? launched.workspacePath;
@@ -136,12 +137,12 @@ test('settings → memory tab mounts', async () => {
 });
 
 /**
- * Trajectory 4 — Logs view: ensure the Logs route renders the desktop log
+ * Trajectory 4 — Logs view: ensure the Logs workbench renders the desktop log
  * viewer skeleton (header + actions). The actual log content is async and
  * may be empty on a fresh run, so we only assert structural surfaces.
  */
-test('logs route renders the desktop log viewer', async () => {
-  await setRoute(launched, 'logs');
+test('logs workbench renders the desktop log viewer', async () => {
+  await openWorkbench(launched, 'logs');
   const header = launched.page.locator('.desktop-log-viewer-header');
   await expect(header).toBeVisible();
   // Header has Refresh / Copy / Export / Open Folder buttons.

--- a/packages/desktop/tests/e2e/verify-fixes.spec.ts
+++ b/packages/desktop/tests/e2e/verify-fixes.spec.ts
@@ -4,7 +4,8 @@ import {
   closeTexraApp,
   dismissOnboarding,
   launchTexraApp,
-  setRoute,
+  openWorkbench,
+  showLauncher,
   type LaunchedApp,
 } from './electronApp.js';
 
@@ -55,7 +56,7 @@ async function readToolsPanelMetrics(): Promise<{
 }
 
 test('main view no longer renders inner Launcher/Progress toolbar', async ({}, testInfo) => {
-  await setRoute(launched, 'main');
+  await showLauncher(launched);
   await launched.page.screenshot({
     path: testInfo.outputPath('verify-fixes', 'main-view.png'),
     fullPage: false,
@@ -81,7 +82,7 @@ test('main view no longer renders inner Launcher/Progress toolbar', async ({}, t
 });
 
 test('command palette keeps each icon and label in one compact row', async ({}, testInfo) => {
-  await setRoute(launched, 'main');
+  await showLauncher(launched);
   const closeWorkbench = launched.page.locator('.task-workbench-close');
   if (await closeWorkbench.isVisible()) {
     await closeWorkbench.click();
@@ -144,7 +145,7 @@ test('command palette keeps each icon and label in one compact row', async ({}, 
 });
 
 test('settings workbench scrolls (Tools tab top + bottom)', async ({}, testInfo) => {
-  await setRoute(launched, 'settings');
+  await openWorkbench(launched, 'settings');
   await launched.page.evaluate(
     ({ command, tabIndex }) => {
       window.postMessage({ command, tabIndex }, '*');

--- a/packages/desktop/tests/e2e/workspaceTabs.spec.ts
+++ b/packages/desktop/tests/e2e/workspaceTabs.spec.ts
@@ -780,25 +780,3 @@ test('closes a bottom tab and falls back within the same pane', async () => {
   ).toBeVisible();
   await expect(page.locator('.task-conversation')).toBeVisible();
 });
-
-test('routes legacy desktop:setRoute IPC to the owning tab', async () => {
-  const { page } = launched;
-
-  // Menu items and the command palette still speak the four-route vocabulary;
-  // each route must resolve to the tab that now owns that surface.
-  await page.evaluate(() => {
-    window.postMessage({ command: 'desktop:setRoute', route: 'logs' }, '*');
-  });
-  await expect(page.locator(activeWorkbenchTab('logs'))).toBeVisible();
-  await expect(page.locator('.desktop-log-viewer')).toBeVisible();
-  await expect(page.locator('.task-conversation')).toBeVisible();
-
-  await page.evaluate(() => {
-    window.postMessage({ command: 'desktop:setRoute', route: 'main' }, '*');
-  });
-  await expect(
-    page.locator('.task-conversation-pane[data-pane="launcher"]:not([hidden])'),
-  ).toBeVisible();
-  // Returning to the launcher does not discard the inspected workbench.
-  await expect(page.locator(activeWorkbenchTab('logs'))).toBeVisible();
-});

--- a/src/shared/schemas/commonViewMessages.ts
+++ b/src/shared/schemas/commonViewMessages.ts
@@ -42,7 +42,6 @@ export const WebviewReadyMessageSchema = z.object({
 });
 
 const SwitchViewTargetSchema = z.enum(['main', 'progress', 'dashboard']);
-export type SwitchViewTarget = z.infer<typeof SwitchViewTargetSchema>;
 
 export const SwitchViewMessageSchema = z.object({
   command: z.literal(COMMON_COMMANDS.SWITCH_VIEW),

--- a/src/shared/schemas/commonViewMessages.ts
+++ b/src/shared/schemas/commonViewMessages.ts
@@ -42,6 +42,7 @@ export const WebviewReadyMessageSchema = z.object({
 });
 
 const SwitchViewTargetSchema = z.enum(['main', 'progress', 'dashboard']);
+export type SwitchViewTarget = z.infer<typeof SwitchViewTargetSchema>;
 
 export const SwitchViewMessageSchema = z.object({
   command: z.literal(COMMON_COMMANDS.SWITCH_VIEW),

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -2360,7 +2360,7 @@ describe('DesktopProgressBridge', () => {
 
     await expect(result).resolves.toEqual({ action: 'setup' });
     expect(messages).toEqual([
-      { command: DESKTOP_SHELL_COMMANDS.SET_ROUTE, route: 'main' },
+      { command: DESKTOP_SHELL_COMMANDS.SHOW_LAUNCHER },
       expect.objectContaining({
         command: COMMON_COMMANDS.STATE_RESTORE,
         state: expect.objectContaining({
@@ -2402,7 +2402,7 @@ describe('DesktopProgressBridge', () => {
     });
 
     expect(messages).toEqual([
-      { command: DESKTOP_SHELL_COMMANDS.SET_ROUTE, route: 'main' },
+      { command: DESKTOP_SHELL_COMMANDS.SHOW_LAUNCHER },
       expect.objectContaining({ command: COMMON_COMMANDS.STATE_RESTORE }),
     ]);
   });

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -19,7 +19,8 @@ interface DesktopCommandPaletteModule {
   createDesktopCommandPalette(options: {
     document: Document;
     actions: {
-      showRoute(route: string): void;
+      showLauncher(): void;
+      openWorkbench(kind: 'settings' | 'logs'): void;
       showSettings(tabIndex?: number): void;
       showStream?(streamId: string): void;
     };
@@ -151,7 +152,11 @@ describe('desktop command palette', () => {
     const { createDesktopCommandPalette } = await loadDesktopCommandPalette();
     const controller = createDesktopCommandPalette({
       document,
-      actions: { showRoute: vi.fn(), showSettings: vi.fn() },
+      actions: {
+        showLauncher: vi.fn(),
+        openWorkbench: vi.fn(),
+        showSettings: vi.fn(),
+      },
       platform: 'darwin',
       ...options,
     });
@@ -168,7 +173,8 @@ describe('desktop command palette', () => {
 
   it('renders catalog entries and dispatches the active command on Enter', async () => {
     const actions = {
-      showRoute: vi.fn(),
+      showLauncher: vi.fn(),
+      openWorkbench: vi.fn(),
       showSettings: vi.fn(),
     };
     const controller = await mountPalette({ actions });
@@ -199,7 +205,8 @@ describe('desktop command palette', () => {
 
   it('adds current streams as switch commands when opened', async () => {
     const actions = {
-      showRoute: vi.fn(),
+      showLauncher: vi.fn(),
+      openWorkbench: vi.fn(),
       showSettings: vi.fn(),
       showStream: vi.fn(),
     };
@@ -237,7 +244,8 @@ describe('desktop command palette', () => {
 
   it('clicking an item dispatches its command and closes the dialog', async () => {
     const actions = {
-      showRoute: vi.fn(),
+      showLauncher: vi.fn(),
+      openWorkbench: vi.fn(),
       showSettings: vi.fn(),
     };
     const controller = await mountPalette({ actions });
@@ -251,7 +259,7 @@ describe('desktop command palette', () => {
     button!.click();
     await flushDialogTicks();
 
-    expect(actions.showRoute).toHaveBeenCalledWith('main');
+    expect(actions.showLauncher).toHaveBeenCalledOnce();
     expect(controller.element.open).toBe(false);
   });
 

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -28,8 +28,8 @@ const DESKTOP_DISPATCH_CASES: ReadonlyArray<
     args: readonly unknown[],
   ]
 > = [
-  ['texra.showMainView', 'showRoute', ['main']],
-  ['texra.desktop.showLogs', 'showRoute', ['logs']],
+  ['texra.showMainView', 'showLauncher', []],
+  ['texra.desktop.showLogs', 'openWorkbench', ['logs']],
   ['texra.showDashboard', 'showSettings', []],
   ['texra.mainView.reset', 'resetMainView', []],
   ['texra.desktop.toggleBottomBar', 'toggleBottomBar', []],
@@ -53,11 +53,12 @@ function makeDesktopActions(): MockedDesktopActions {
   return {
     openDesktopDocs: vi.fn(),
     openLogFolder: vi.fn(),
+    openWorkbench: vi.fn(),
     openWorkspaceFolder: vi.fn(),
     resetMainView: vi.fn(),
     saveFile: vi.fn(),
     showFirstRunWalkthrough: vi.fn(),
-    showRoute: vi.fn(),
+    showLauncher: vi.fn(),
     showSettings: vi.fn(),
     showStream: vi.fn(),
     toggleBottomBar: vi.fn(),
@@ -256,7 +257,7 @@ describe('desktop command surface', () => {
     const modelsItem = submenu.find((item) => item.label === 'Show Models');
     launcherItem?.click?.();
     modelsItem?.click?.();
-    expect(actions.showRoute).toHaveBeenCalledWith('main');
+    expect(actions.showLauncher).toHaveBeenCalledOnce();
     expect(actions.showSettings).toHaveBeenCalledWith(SETTINGS_TAB.MODELS);
 
     const helpMenu = menu.find((item) => item.label === 'Help');

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -199,20 +199,19 @@ describe('desktop IPC adapters', () => {
     await Promise.resolve();
 
     expect(postToRenderer).toHaveBeenNthCalledWith(1, {
-      command: 'desktop:setRoute',
-      route: 'main',
+      command: 'desktop:showLauncher',
     });
     expect(postToRenderer).toHaveBeenNthCalledWith(2, {
-      command: 'desktop:setRoute',
-      route: 'settings',
+      command: 'desktop:openWorkbench',
+      kind: 'settings',
     });
     expect(postToRenderer).toHaveBeenNthCalledWith(3, {
       command: SETTINGS_VIEW_COMMANDS.SET_TAB,
       tabIndex: SETTINGS_TAB.MODELS,
     });
     expect(postToRenderer).toHaveBeenNthCalledWith(4, {
-      command: 'desktop:setRoute',
-      route: 'settings',
+      command: 'desktop:openWorkbench',
+      kind: 'settings',
     });
     expect(postToRenderer).toHaveBeenNthCalledWith(5, {
       agentSubTab: AgentCategory.ToolUse,
@@ -239,8 +238,8 @@ describe('desktop IPC adapters', () => {
       customDirSet: false,
     });
     expect(postToRenderer).toHaveBeenCalledWith({
-      command: 'desktop:setRoute',
-      route: 'settings',
+      command: 'desktop:openWorkbench',
+      kind: 'settings',
     });
     expect(postToRenderer).toHaveBeenCalledWith({
       command: SETTINGS_VIEW_COMMANDS.SET_TAB,

--- a/src/test-kernel/desktop/DesktopShortcutRegistry.vitest.mts
+++ b/src/test-kernel/desktop/DesktopShortcutRegistry.vitest.mts
@@ -20,7 +20,8 @@ interface ShortcutRegistryModule {
   createDesktopShortcutRegistry(options: {
     document: Document;
     actions: {
-      showRoute(route: string): void;
+      showLauncher(): void;
+      openWorkbench(kind: 'settings' | 'logs'): void;
       showSettings(tabIndex?: number): void;
     };
     openCommands(): void;
@@ -39,7 +40,8 @@ async function createRegistry(
   return createDesktopShortcutRegistry({
     document,
     actions: {
-      showRoute: vi.fn(),
+      showLauncher: vi.fn(),
+      openWorkbench: vi.fn(),
       showSettings: vi.fn(),
     },
     openCommands,

--- a/src/test-kernel/desktop/DesktopTaskShell.vitest.mts
+++ b/src/test-kernel/desktop/DesktopTaskShell.vitest.mts
@@ -31,7 +31,6 @@ import {
   WORKBENCH_KINDS,
   WORKBENCH_MAX_WIDTH,
   WORKBENCH_MIN_WIDTH,
-  workbenchKindForRoute,
   workbenchTab,
   workspaceInitials,
   workspaceName,
@@ -338,12 +337,6 @@ describe('desktop task shell model', () => {
     expect(setWorkbenchWidth(initial, 10_000).workbenchWidth).toBe(
       WORKBENCH_MAX_WIDTH,
     );
-  });
-
-  it('maps only artifact routes into the workbench', () => {
-    expect(workbenchKindForRoute('settings')).toBe('settings');
-    expect(workbenchKindForRoute('logs')).toBe('logs');
-    expect(workbenchKindForRoute('main')).toBeUndefined();
   });
 
   it('derives concise workspace labels from POSIX and Windows paths', () => {

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -25,7 +25,8 @@ import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 const mocks = createModuleMocks();
 
 interface TestDesktopShellActions {
-  showRoute: ReturnType<typeof vi.fn>;
+  showLauncher: ReturnType<typeof vi.fn>;
+  openWorkbench: ReturnType<typeof vi.fn>;
   showSettings: ReturnType<typeof vi.fn>;
   signIn: ReturnType<typeof vi.fn>;
   openAgentDirectory: ReturnType<typeof vi.fn>;
@@ -164,7 +165,8 @@ function createWindowMock(
 
 function createMainViewShellActions(): TestDesktopShellActions {
   return {
-    showRoute: vi.fn(),
+    showLauncher: vi.fn(),
+    openWorkbench: vi.fn(),
     showSettings: vi.fn(),
     signIn: vi.fn(),
     openAgentDirectory: vi.fn(),
@@ -397,7 +399,7 @@ describe('desktop main-view IPC', () => {
       command: COMMON_COMMANDS.SWITCH_VIEW,
       view: 'main',
     });
-    expect(capabilities.shellActions.showRoute).toHaveBeenCalledWith('main');
+    expect(capabilities.shellActions.showLauncher).toHaveBeenCalledOnce();
     expect(sends).toEqual([]);
 
     sends.length = 0;
@@ -412,20 +414,18 @@ describe('desktop main-view IPC', () => {
     });
     sendFromRenderer({ command: MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS });
     sendFromRenderer({ command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY });
-    expect(capabilities.shellActions.showRoute).toHaveBeenCalledWith(
-      'settings',
-    );
+    expect(capabilities.shellActions.showSettings).toHaveBeenNthCalledWith(1);
     expect(capabilities.shellActions.showSettings).toHaveBeenNthCalledWith(
-      1,
+      2,
       SETTINGS_TAB.MODELS,
     );
     expect(capabilities.shellActions.showSettings).toHaveBeenNthCalledWith(
-      2,
+      3,
       SETTINGS_TAB.AGENTS,
       AgentCategory.ToolUse,
     );
     expect(capabilities.shellActions.showSettings).toHaveBeenNthCalledWith(
-      3,
+      4,
       SETTINGS_TAB.MULTI_AGENT,
     );
     expect(capabilities.shellActions.openAgentDirectory).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- replace the generic `desktop:setRoute` command with `desktop:showLauncher` and `desktop:openWorkbench`
- send launcher and settings/logs workbench actions directly from menus, onboarding, restore flows, and shell commands
- delete the route enum, translation helper, renderer route state, route-only tests, and the legacy end-to-end route case

Desktop has not been released, so it does not need a compatibility reader for its former internal route vocabulary.

## Issue acceptance gates

This implements the desktop route-protocol arm of the active compatibility-retirement programme.

- current actions name the two actual state transitions: satisfied
- settings opens before an optional `SET_TAB` message: satisfied
- launcher restore clears the active stream while retaining workbench tabs: satisfied
- logs still request a snapshot when their workbench becomes active: satisfied
- old route schema, helper, translation, renderer state, fixtures, and tests are removed: satisfied

## Single source of truth

`desktopShellMessages.ts` owns the two renderer commands. The renderer's `returnToLauncher` and `openKind` functions own the corresponding state transitions.

## Duplication and abstraction budget

The change removes one three-valued route protocol and its translation into two already distinct operations. It retains `postDesktopSettingsView` because two main-process consumers must preserve the consequential ordering “open Settings, then select a tab.” No compatibility facade or replacement route abstraction is added.

## Net elements (R6)

- files: 0 added, 0 deleted, 20 modified
- exported symbols: 5 added, 7 deleted, net -2
- classes/interfaces/enums: none added or deleted
- lines: +192 / -243, net -51

## Consumer counts (R8)

- `desktop:setRoute`: 3 production emit sites and 1 renderer subscriber removed
- `desktop:showLauncher`: 3 direct production emit sites and 1 renderer subscriber
- `desktop:openWorkbench`: 2 direct production emit sites and 1 renderer subscriber
- `buildDesktopSetRouteMessage`: 3 production consumers plus its definition removed
- `DesktopRoute`: all 16 source/test occurrences removed

## Host impact

Extension:

- none

Desktop:

- launcher, Settings, and Logs navigation now use direct current actions
- no old desktop route message is accepted
- menu, palette, shortcut, onboarding, reset, proposal restore, and history restore paths are updated

CLI:

- none

## Scheduled refactoring

None. PR #9609 touches one desktop shortcut test fixture but no shared production code; any merge-order conflict is mechanical.

## Validation

- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- full Vitest suite: 8,430 passed
- focused desktop tests after current-main rebase: 140 passed
- desktop and test-kernel type checks after rebase
- desktop production build
- 10 exact menu/launcher/settings/logs end-to-end tests
- final search found no old route protocol, type, helper, or renderer-state reference\n- post-review desktop typecheck and 19 focused shell/IPC tests

A broader desktop end-to-end run passed 37 of 40 tests. The three failures reproduce unchanged on current `main` and concern stale onboarding/settings-banner assertions, not this route change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-cutting desktop navigation (menu, palette, IPC, restore, onboarding) but behavior is intentionally preserved; risk is mainly regression in shell routing rather than security or data handling.
> 
> **Overview**
> **Desktop shell navigation** no longer uses a single `desktop:setRoute` message with a `main` | `settings` | `logs` enum. Main and renderer now speak **`desktop:showLauncher`** (clear active stream, show launcher) and **`desktop:openWorkbench`** with `kind: 'settings' | 'logs'`.
> 
> **Main process and commands:** `DesktopCommandActions` exposes `showLauncher()` and `openWorkbench(kind)` instead of `showRoute`. Settings still goes through **`postDesktopSettingsView`** (renamed from `postDesktopSettingsRoute`), which posts open-workbench then optional `SET_TAB`. `SWITCH_VIEW` is handled inline (`main` → launcher, `dashboard` → settings, `progress` → no-op).
> 
> **Renderer:** Drops `document.body.dataset.desktopRoute` and the old `setRoute` IPC handler; launcher and workbench are driven by the new messages and existing `returnToLauncher` / `openKind`. **`workbenchKindForRoute`** is removed from the task shell module.
> 
> **Tests / tooling:** E2E helpers become `showLauncher` and `openWorkbench`; the legacy route IPC e2e case is removed. Knip baseline adds unused **`SwitchViewTarget`** after desktop stops importing it from shared schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a4ba7184ec9c223c5b774852a996850ed1832a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->