### PR TITLE
refactor(desktop): remove legacy workspace sweep

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -56,13 +56,7 @@ import {
   type ProgressViewSecondTierActions,
 } from '@controllers/progressView/ProgressViewCommandHandlers';
 import { buildMainViewState } from '@controllers/mainView/MainViewStateRestoreController';
-import {
-  runCleanMultiple,
-  runCleanRunDir,
-  runCleanSingle,
-  runPack,
-  runPackRunDir,
-} from '@housekeeping';
+import { runCleanRunDir, runPackRunDir } from '@housekeeping';
 import {
   API_PROVIDERS,
   hasUsableApiKey,
@@ -100,10 +94,7 @@ import {
 } from '@shared/copy/executionHistory';
 import { SESSION_DISPOSED_CAUSE } from '@shared/copy/interactionCancellation';
 import type { MainViewExecuteMessage } from '@shared/schemas/mainView/executeMessage';
-import {
-  mergeRunDirAndWorkspaceResult,
-  type FileOpResult,
-} from '@shared/schemas/opResults';
+import type { FileOpResult } from '@shared/schemas/opResults';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { cleanupUnscopedApprovals } from '@tools/approval';
 import { startRecording, stopRecordingAndTranscribe } from '@tools/media/audio';
@@ -659,17 +650,13 @@ export class DesktopProgressBridge {
   }
 
   /**
-   * Stream-toolbar pack/clean. Toolbar invocations always carry an
-   * `executionId`, so — exactly as the extension's handlers document — both the
-   * run directory and the workspace are swept: the workspace pass is a no-op for
-   * new runs whose outputs live only inside the run directory, but it catches
-   * legacy runs whose outputs still sit beside the source.
+   * Stream-toolbar pack/clean for artifacts in the current execution directory.
    */
   private async runWorkflowFileOperation(
     operation: WorkflowFileOperation,
     request: WorkflowFileOperationRequest,
   ): Promise<void> {
-    const { agent, model, inputFile, outputFiles, executionId } = request;
+    const { agent, model, inputFile, executionId } = request;
     if (!agent || !model || !inputFile) {
       await this.options.host.showErrorMessage(
         `Missing required parameters for ${operation}.`,
@@ -677,32 +664,24 @@ export class DesktopProgressBridge {
       return;
     }
 
-    const runWorkspaceOperation = (): Promise<FileOpResult> => {
-      if (operation === 'pack') {
-        return runPack(model, inputFile, agent, outputFiles);
-      }
-      return outputFiles.length > 0
-        ? runCleanMultiple(model, inputFile, agent, outputFiles)
-        : runCleanSingle(model, inputFile, agent);
-    };
+    if (!executionId) {
+      await this.options.host.showErrorMessage(
+        `Missing execution identity for ${operation}.`,
+      );
+      return;
+    }
 
     let result: FileOpResult;
     try {
-      if (executionId) {
-        const runDirResult =
-          operation === 'pack'
-            ? await runPackRunDir(
-                executionId as ExecutionId,
-                agent,
-                model,
-                inputFile,
-              )
-            : await runCleanRunDir(executionId as ExecutionId);
-        const workspaceResult = await runWorkspaceOperation();
-        result = mergeRunDirAndWorkspaceResult(runDirResult, workspaceResult);
-      } else {
-        result = await runWorkspaceOperation();
-      }
+      result =
+        operation === 'pack'
+          ? await runPackRunDir(
+              executionId as ExecutionId,
+              agent,
+              model,
+              inputFile,
+            )
+          : await runCleanRunDir(executionId as ExecutionId);
     } catch (error) {
       this.logger.error(`Desktop ${operation} operation failed`, {
         data: toLogData(error),


### PR DESCRIPTION
## Summary

- require a current execution identity for desktop stream Pack and Clean actions
- operate only on artifacts in the execution directory
- remove the desktop-only workspace scan and result merge retained for pre-April output layouts

Workflow outputs have been written under `executions/{id}/r{round}` since 21 April 2026. Desktop was first wired after that change and has never been released, so it has no historical workspace artifacts to preserve.

## Issue acceptance gates

Refs #6981.

- identify the old and current writers: satisfied; pre-#3082 outputs lived beside source files, while #3082 made the execution directory the sole writer
- establish the replacement date: satisfied; commit `e4df4c293c` shipped on 21 April 2026
- preserve released-host compatibility: satisfied; extension workspace cleanup remains unchanged
- remove the complete desktop reader: satisfied; imports, calls, result merge, fallback branch, and legacy comment are gone
- avoid compatibility-only tests: satisfied; no desktop test pinned the retired dual sweep

## Single source of truth

The execution ID and its run directory are now the sole authority for desktop workflow artifacts. `runPackRunDir` and `runCleanRunDir` implement the two operations.

## Duplication and abstraction budget

The change deletes a second workspace operation and its result merge. It adds no helper, facade, schema, or migration layer.

## Net elements (R6)

- files: 0 added, 0 deleted, 1 modified
- exported symbols: none added or deleted
- classes/interfaces/enums: none added or deleted
- lines: +19 / -40, net -21

## Consumer counts (R8)

n/a: no export or event path is removed. Four shared housekeeping imports are removed from the desktop adapter only; their released extension consumers remain.

## Host impact

Extension:

- unchanged; Pack and Clean still sweep historical workspace outputs for released extension data

Desktop:

- Pack and Clean require `executionId` and operate only in that execution directory
- a malformed or historical desktop request without an execution identity reports an error instead of scanning the workspace

CLI:

- unchanged

## Scheduled refactoring

The released extension’s pre-#3082 workspace reader remains governed by #6981 and its longer public-data retention policy.

## Validation

- desktop typecheck
- `DesktopAgentExecution.vitest.mts`: 73 passed
- ESLint on the changed production file
- Prettier check
- `git diff --check`
- consumer search confirming extension housekeeping paths remain

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, unreleased desktop adapter change with no auth or shared API changes; extension behavior is untouched.
> 
> **Overview**
> Desktop stream-toolbar **Pack** and **Clean** no longer run a parallel workspace sweep or merge results with `mergeRunDirAndWorkspaceResult`. They now **require** `executionId` and call only `runPackRunDir` / `runCleanRunDir`, so artifacts are handled solely under that execution’s run directory.
> 
> Requests missing execution identity show an error instead of falling back to workspace-only `runPack` / `runClean*` helpers. Unused housekeeping imports and the legacy dual-sweep comment are removed from `desktopAgentExecution.ts`.
> 
> The **VS Code extension** path is unchanged and still merges run-dir and workspace cleanup for pre–#3082 layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8969003704b5083a10019d3c252bf4ab6ef4c4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->