### PR TITLE
refactor(extension): stop rewriting editor preferences

### DIFF
--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -267,21 +267,11 @@ TeXRA automatically detects appropriate input files based on:
 
 ### LaTeX Workshop Integration
 
-If you use the popular [LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) extension, TeXRA attempts to automatically configure some settings upon its first activation to ensure smoother integration and cleaner project structures.
-If the extension isn't installed, TeXRA will offer to install it for a smoother experience.
-These defaults are applied only if the corresponding settings are not already defined:
-
-- **Output Directory**: Sets `latex-workshop.latex.outDir` to `%DIR%/build/`. This directs LaTeX compilation output (like `.aux`, `.log`, `.pdf` files) into a `build` subdirectory within your project, keeping your main directory tidy.
-
-  ```json
-  "latex-workshop.latex.outDir": "%DIR%/build/"
-  ```
-
-- **Compilation Arguments**: Adds arguments like `-interaction=nonstopmode`, `-pdf`, and `-f` to `latex-workshop.latex.magic.args`. These help LaTeX compile more robustly, especially when run by TeXRA agents.
-
-- **Word Wrap**: Enables word wrap specifically for `.tex` files (`[latex].editor.wordWrap`) for better readability of long lines.
-
-These automatic configurations aim to provide a good default setup. They apply to the VS Code extension only (LaTeX Workshop is itself a VS Code extension); you can review and adjust them in your VS Code `settings.json` if needed.
+If a LaTeX workspace does not have the popular
+[LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop)
+extension installed, TeXRA offers to install it. TeXRA does not rewrite editor
+or LaTeX Workshop preferences during startup. Use TeXRA's LaTeX settings page
+to inspect and apply the available workspace recommendations explicitly.
 
 ## Cross-Computer Syncing
 

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -37,7 +37,7 @@ import { appSignals } from '@eventBus/AppSignals';
 import { SecretManager } from '@frontend/secretManager';
 import {
   copyDefaultAgents,
-  configureLatexSettings,
+  initializeLatexSupport,
   registerAgentDirectoryRoots,
 } from '@frontend/setup';
 import { runTerminalCommand } from '@frontend/setupTerminalRunner';
@@ -506,7 +506,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // synchronous glob probes of TeX install directories, which would
   // otherwise block activation on slow disks. (Never rejects — the body is
   // fully wrapped in try/catch.)
-  setTimeout(() => void configureLatexSettings(), 0);
+  setTimeout(() => void initializeLatexSupport(), 0);
   const mainViewProvider = registerCommands(context);
   // Wire the two sidebar surfaces to each other before anything can invoke a
   // placement command: `texra.showProgressView` is registered above and is

--- a/packages/extension/src/frontend/setup.ts
+++ b/packages/extension/src/frontend/setup.ts
@@ -17,18 +17,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { registerExternalRoot } from '@utils/files/externalRoots';
 import { extendEnvPath } from '@utils/system/platformPaths';
 
-// Local imports - VS Code configuration
-import {
-  isVscodeHostConfigExplicitlySet,
-  updateVscodeHostConfig,
-} from './vscode/vscodeHostConfig';
-
-/**
- * Version number for LaTeX-related VS Code config setup.
- * Increment this when changing which settings are auto-configured.
- */
-const LATEX_CONFIG_VERSION = 2;
-
 /**
  * Reconciles bundled agents in global storage from packaged resources.
  *
@@ -146,10 +134,8 @@ export async function refreshCustomAgentRoot(): Promise<void> {
   }
 }
 
-/**
- * Configure LaTeX-related workspace settings if LaTeX Workshop extension is installed
- */
-export async function configureLatexSettings(): Promise<void> {
+/** Prepare the host environment and recommend LaTeX Workshop when useful. */
+export async function initializeLatexSupport(): Promise<void> {
   // Extend process.env.PATH with common TeX installation directories so that
   // child processes spawned by other extensions (e.g., LaTeX Workshop) can
   // find latexmk, pdflatex, and other TeX binaries.  When VS Code is launched
@@ -179,49 +165,11 @@ export async function configureLatexSettings(): Promise<void> {
       if (await workspaceContainsLatexFiles()) {
         await promptLatexWorkshopInstall();
       }
-      return;
     }
-
-    const storedVersion = globalSM.get<number>(
-      GlobalStateKey.LATEX_CONFIG_VERSION,
-    );
-    if (storedVersion === LATEX_CONFIG_VERSION) {
-      return;
-    }
-
-    logger.info(
-      'extension',
-      'LaTeX Workshop extension detected, configuring settings',
-    );
-
-    if (!isVscodeHostConfigExplicitlySet('[latex]')) {
-      await updateVscodeHostConfig(
-        '[latex]',
-        { 'editor.wordWrap': 'on' },
-        'global',
-      );
-    }
-
-    if (
-      !vscode.env.appName?.toLowerCase().includes('windsurf') &&
-      !isVscodeHostConfigExplicitlySet('workbench.activityBar.location')
-    ) {
-      await updateVscodeHostConfig(
-        'workbench.activityBar.location',
-        'default',
-        'global',
-      );
-      logger.info('extension', 'Activity bar location set to default');
-    }
-
-    await globalSM.update(
-      GlobalStateKey.LATEX_CONFIG_VERSION,
-      LATEX_CONFIG_VERSION,
-    );
   } catch (err) {
     logger.error(
       'extension',
-      `Error configuring LaTeX settings: ${toErrorMessage(err)}`,
+      `Error initializing LaTeX support: ${toErrorMessage(err)}`,
     );
   }
 }

--- a/src/shared/state/stateKeys.ts
+++ b/src/shared/state/stateKeys.ts
@@ -92,9 +92,6 @@ export enum GlobalStateKey {
   STREAMING_GLM = 'texra.streaming.glm',
   STREAMING_META = 'texra.streaming.meta',
 
-  // LaTeX settings
-  LATEX_CONFIG_VERSION = 'texra.latexConfigVersion',
-
   // Agent settings (migrated from VS Code config)
   CUSTOM_AGENT_DIR = 'texra.customAgentDir',
   REMOTE_AGENT_META_CACHE = 'texra.remoteAgentMetaCache',


### PR DESCRIPTION
## Summary

- stop changing global LaTeX word wrapping and activity-bar placement during extension startup
- remove the version marker that gated those automatic writes
- retain TeX PATH preparation and the contextual LaTeX Workshop recommendation
- rename the startup routine to describe its remaining responsibility\n- update the public guide to describe opt-in recommendations instead of automatic rewrites

The native opt-in LaTeX settings page replaced automatic editor configuration on 19 February 2026. TeXRA should no longer claim authority over unrelated global editor preferences.

## Issue acceptance gates

This satisfies the editor-settings writer arm of the active settings-retirement programme.

- establish the replacement date: satisfied; opt-in configuration landed in `e1e6adccb0` on 2026-02-19
- remove both automatic global preference writes: satisfied
- remove the reader, writer, declaration, and comment for the version marker: satisfied
- retain current environment setup and installation guidance: satisfied
- avoid a replacement migration or compatibility test: satisfied

## Single source of truth

User and VS Code settings remain the authority for editor appearance. `initializeLatexSupport` now owns only process PATH preparation and the contextual LaTeX Workshop prompt.

## Duplication and abstraction budget

The change deletes a versioned startup-settings writer and its marker. It adds no migration, wrapper, settings alias, or new state owner.

## Net elements (R6)

- files: 0 added, 0 deleted, 4 modified
- exported symbols: 1 renamed, net 0
- classes/interfaces/enums: no declarations added or deleted; 1 enum member deleted
- lines: +10 / -75, net -65

## Consumer counts (R8)

- `configureLatexSettings`: 1 production caller, renamed directly to `initializeLatexSupport`
- `GlobalStateKey.LATEX_CONFIG_VERSION`: 1 reader, 1 writer, and 1 declaration removed; remaining consumers 0
- `[latex].editor.wordWrap` and `workbench.activityBar.location`: each had 1 startup writer; remaining TeXRA writers 0

## Host impact

Extension:

- startup no longer changes global word wrapping or activity-bar placement
- TeX executable discovery and the contextual LaTeX Workshop prompt remain

Desktop:

- none

CLI:

- none

## Scheduled refactoring

Younger settings compatibility paths retain their dated windows: worktree-memento read-through after 2026-10-14, retired model aliases after 2026-10-25, and banner fallbacks after 2026-11-01. The split `inlineCriticism.enabled` ownership should be reconsidered after 2026-08-07.

## Validation

- extension typecheck
- `compile:fast`
- full repository lint
- Prettier check on changed files
- `git diff --check`
- final search found no version marker or automatic preference writer\n- public documentation build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to no longer mutating user VS Code settings; TeX discovery and install guidance remain.
> 
> **Overview**
> TeXRA no longer **auto-writes global editor or LaTeX Workshop settings** during extension activation. Startup LaTeX handling is narrowed to **TeX `PATH` preparation** and an **optional LaTeX Workshop install prompt** when the workspace contains `.tex` files and the extension is missing.
> 
> The version-gated startup writer (`LATEX_CONFIG_VERSION`, `[latex].editor.wordWrap`, `workbench.activityBar.location`, and related `vscodeHostConfig` usage) is removed; `configureLatexSettings` is renamed to **`initializeLatexSupport`**. The file-management guide now describes **opt-in** recommendations via TeXRA’s LaTeX settings page instead of automatic preference rewrites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3318dfbaa333ee5654a02289c2006428dc45d891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->