### PR TITLE
test: prune schema migration boilerplate

### DIFF
--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -18,6 +18,27 @@ const usageFixture = {
 } as const;
 
 describe('RunUsageAccumulatorJSONSchema — legacy normalizedSnapshots migration', () => {
+  it('takes the last element when normalizedSnapshots has multiple entries', () => {
+    const older = { ...usageFixture, inputTokens: 50 };
+    const latest = { ...usageFixture, inputTokens: 200 };
+    const result = RunUsageAccumulatorJSONSchema.parse({
+      normalizedSnapshots: [
+        { round: 0, usage: older },
+        { round: 1, usage: latest },
+      ],
+    });
+
+    expect(result.latestUsage?.inputTokens).toBe(200);
+  });
+
+  it('sets latestUsage to null for an empty normalizedSnapshots array', () => {
+    const result = RunUsageAccumulatorJSONSchema.parse({
+      normalizedSnapshots: [],
+    });
+
+    expect(result.latestUsage).toBeNull();
+  });
+
   it('keeps an explicit null latestUsage over snapshots in a hybrid payload', () => {
     const result = RunUsageAccumulatorJSONSchema.parse({
       latestUsage: null,
@@ -56,6 +77,14 @@ describe('OutputXmlSummarySchema — tagContents legacy string coercion', () => 
     });
 
     expect(result.tagContents['title']).toEqual(['My Paper']);
+  });
+
+  it('passes an existing string[] through unchanged', () => {
+    const result = OutputXmlSummarySchema.parse({
+      tagContents: { authors: ['Alice', 'Bob'] },
+    });
+
+    expect(result.tagContents['authors']).toEqual(['Alice', 'Bob']);
   });
 
   it('degrades a malformed value to [] via .catch', () => {
@@ -108,6 +137,17 @@ describe('ContextManagementDataSchema — legacy missing tokensAfter/utilization
       tokensAfter: 1000,
       utilizationAfter: 5,
     });
+  });
+
+  it('passes an already-populated tokens-freed entry through unchanged', () => {
+    const result = ContextManagementDataSchema.parse({
+      ...legacyBase,
+      action: 'compaction',
+      tokensAfter: 400,
+      utilizationAfter: 2,
+    });
+
+    expect(result).toMatchObject({ tokensAfter: 400, utilizationAfter: 2 });
   });
 
   it('still requires originalMaxTokens/reducedMaxTokens for max_tokens_reduced', () => {

--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -5,7 +5,6 @@ import {
   ActiveChildInfoSchema,
   ContextManagementDataSchema,
   OutputXmlSummarySchema,
-  STREAM_PHASE,
   STREAM_STATUS,
 } from '@shared/schemas';
 
@@ -19,54 +18,6 @@ const usageFixture = {
 } as const;
 
 describe('RunUsageAccumulatorJSONSchema — legacy normalizedSnapshots migration', () => {
-  it('extracts latestUsage from a single-element normalizedSnapshots array', () => {
-    const result = RunUsageAccumulatorJSONSchema.parse({
-      normalizedSnapshots: [{ round: 0, usage: usageFixture }],
-    });
-
-    expect(result.latestUsage).toMatchObject(usageFixture);
-  });
-
-  it('takes the last element when normalizedSnapshots has multiple entries', () => {
-    const older = { ...usageFixture, inputTokens: 50 };
-    const latest = { ...usageFixture, inputTokens: 200 };
-    const result = RunUsageAccumulatorJSONSchema.parse({
-      normalizedSnapshots: [
-        { round: 0, usage: older },
-        { round: 1, usage: latest },
-      ],
-    });
-
-    expect(result.latestUsage?.inputTokens).toBe(200);
-  });
-
-  it('sets latestUsage to null for an empty normalizedSnapshots array', () => {
-    const result = RunUsageAccumulatorJSONSchema.parse({
-      normalizedSnapshots: [],
-    });
-
-    expect(result.latestUsage).toBeNull();
-  });
-
-  it('is idempotent: already-migrated data passes through unchanged', () => {
-    const result = RunUsageAccumulatorJSONSchema.parse({
-      latestUsage: usageFixture,
-    });
-
-    expect(result.latestUsage).toMatchObject(usageFixture);
-  });
-
-  it('keeps canonical latestUsage when a hybrid payload also has snapshots', () => {
-    const stale = { ...usageFixture, inputTokens: 1 };
-    const result = RunUsageAccumulatorJSONSchema.parse({
-      latestUsage: usageFixture,
-      normalizedSnapshots: [{ round: 0, usage: stale }],
-    });
-
-    // The canonical latestUsage must win over the snapshot-derived value.
-    expect(result.latestUsage).toMatchObject(usageFixture);
-  });
-
   it('keeps an explicit null latestUsage over snapshots in a hybrid payload', () => {
     const result = RunUsageAccumulatorJSONSchema.parse({
       latestUsage: null,
@@ -107,14 +58,6 @@ describe('OutputXmlSummarySchema — tagContents legacy string coercion', () => 
     expect(result.tagContents['title']).toEqual(['My Paper']);
   });
 
-  it('passes an existing string[] through unchanged', () => {
-    const result = OutputXmlSummarySchema.parse({
-      tagContents: { authors: ['Alice', 'Bob'] },
-    });
-
-    expect(result.tagContents['authors']).toEqual(['Alice', 'Bob']);
-  });
-
   it('degrades a malformed value to [] via .catch', () => {
     const result = OutputXmlSummarySchema.parse({
       tagContents: { broken: 42 },
@@ -138,12 +81,6 @@ describe('OutputXmlSummarySchema — legacy documents field', () => {
       singleOutputFile: '/tmp/run/main.tex',
       sourceLocation: null,
     });
-  });
-
-  it('still rejects an unrecognized key on a record without documents', () => {
-    expect(() =>
-      OutputXmlSummarySchema.parse({ tagContents: {}, unexpected: 1 }),
-    ).toThrow();
   });
 
   it('rejects an unrecognized key alongside legacy documents', () => {
@@ -171,17 +108,6 @@ describe('ContextManagementDataSchema — legacy missing tokensAfter/utilization
       tokensAfter: 1000,
       utilizationAfter: 5,
     });
-  });
-
-  it('passes an already-populated tokens-freed entry through unchanged', () => {
-    const result = ContextManagementDataSchema.parse({
-      ...legacyBase,
-      action: 'compaction',
-      tokensAfter: 400,
-      utilizationAfter: 2,
-    });
-
-    expect(result).toMatchObject({ tokensAfter: 400, utilizationAfter: 2 });
   });
 
   it('still requires originalMaxTokens/reducedMaxTokens for max_tokens_reduced', () => {
@@ -218,31 +144,11 @@ describe('ActiveChildInfoSchema — legacy missing kind discriminant', () => {
     expect(result).toMatchObject({ kind: 'process' });
   });
 
-  it('passes an already-migrated entry through unchanged', () => {
-    const result = ActiveChildInfoSchema.parse({
-      ...legacyBase,
-      kind: 'process',
-    });
-
-    expect(result).toMatchObject({ kind: 'process' });
-  });
-
   // `status` has no legacy migration on purpose. The child roster is liveness
   // state: `assembleSnapshot` never writes `subagents`, and every hydrate
   // clamps it to `[]`, so no on-disk roster carries the retired 7-value
   // `StreamStatus` vocabulary. The v0.41 cut dropped the speculative union
   // member that mapped it; the field now takes `StreamPhase` only.
-  it('accepts a StreamPhase status', () => {
-    const result = ActiveChildInfoSchema.parse({
-      ...legacyBase,
-      kind: 'subagent',
-      childStreamId: 'stream-1',
-      status: STREAM_PHASE.RUNNING,
-    });
-
-    expect(result).toMatchObject({ status: STREAM_PHASE.RUNNING });
-  });
-
   it('rejects a retired StreamStatus value rather than folding it', () => {
     expect(() =>
       ActiveChildInfoSchema.parse({


### PR DESCRIPTION
## Summary

- remove six tests that enumerate identity paths, canonical passthroughs, or native Zod behavior
- retain sixteen consequential migration-boundary tests for malformed data, explicit-null precedence, reconstruction, strict unknown-key rejection, active-child inference, and rejection of retired status vocabulary

No production code changes.

## Rationale

The deleted cases repeat schema implementation branches without protecting a distinct runtime outcome. Canonical passthrough and last-snapshot edge cases remain covered where a transform could otherwise change valid data. Current live behavior remains covered by usage monitoring, stream persistence, XML output, progress projection, and active-child lifecycle suites.

## Validation

- `SchemaMigrations.vitest.ts`: 16 passed
- test-kernel typecheck
- full repository lint
- Prettier check
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deletion of redundant cases; consequential migration tests remain.
> 
> **Overview**
> **Trims boilerplate in `SchemaMigrations.vitest.ts`** by deleting six cases that only restated identity passthrough, canonical precedence, native Zod strictness, or accepted `StreamPhase` values.
> 
> **What stays covered:** multi-snapshot and empty `normalizedSnapshots` handling, explicit-null `latestUsage` over hybrid payloads, malformed snapshot tolerance, legacy `OutputXmlSummary` coercion and `documents` stripping, `ContextManagementData` defaults, `ActiveChildInfo` `kind` inference, and rejection of retired `StreamStatus` values.
> 
> No production or schema code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95dd0200487beecb8df3f48fc61b11dfee6d5131. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->