### PR TITLE
feat(cli): add workflow phase task dashboard

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -92,6 +92,7 @@ import {
 import {
   childListStreamId,
   childStreamListValue,
+  isWorkflowTaskListValue,
   workflowPhaseListValue,
   workflowTaskListValue,
   INITIAL_CHILD_LIST_SELECTION,
@@ -446,7 +447,7 @@ export function App(props: AppProps): React.JSX.Element {
   }, [childListValues]);
   const focusSession = useCallback(
     (streamId: StreamTabId) => {
-      if (selectedChildValue?.startsWith('workflowTask:')) {
+      if (isWorkflowTaskListValue(selectedChildValue)) {
         dispatchChildListSelection({ kind: 'blur' });
       } else {
         dispatchChildListSelection({ kind: 'focusStream', streamId });

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -15,7 +15,7 @@ import {
 // Local imports - shared runtime
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
-import type { StreamTabId } from '@shared/schemas';
+import { AgentCategory, type StreamTabId } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local imports - TUI surfaces and state
@@ -41,6 +41,7 @@ import { InfoPane } from './panes/InfoPane';
 import { InputBar, type InputBarHandle } from './panes/InputBar';
 import { ConversationRegion } from './panes/ConversationRegion';
 import { StatusBar } from './panes/StatusBar';
+import { WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS } from './panes/SubagentListDisplay';
 import { orderedStaticTranscriptEntries } from './panes/transcriptEntries';
 import {
   currentApproval,
@@ -91,6 +92,8 @@ import {
 import {
   childListStreamId,
   childStreamListValue,
+  workflowPhaseListValue,
+  workflowTaskListValue,
   INITIAL_CHILD_LIST_SELECTION,
   reduceChildListSelection,
   type ChildListValue,
@@ -303,12 +306,76 @@ export function App(props: AppProps): React.JSX.Element {
     }
     return executionIds;
   }, [childStreamEntries, sessionViews, streams]);
-  const childListValues = useMemo<readonly ChildListValue[]>(
-    () => sessionViews.map((session) => childStreamListValue(session.id)),
-    [sessionViews],
+  const workflowDashboardRoot =
+    childListTarget.slice?.category === AgentCategory.Workflow &&
+    childListTarget.slice.entries.some((entry) => entry.role === 'workflowTask')
+      ? childListTarget.slice
+      : undefined;
+  const workflowDashboardTasks = useMemo(
+    () =>
+      workflowDashboardRoot?.entries.filter(
+        (entry) => entry.role === 'workflowTask',
+      ) ?? [],
+    [workflowDashboardRoot],
   );
+  const workflowTasksByValue = useMemo(
+    () =>
+      new Map(
+        workflowDashboardTasks.map((entry) => [
+          workflowTaskListValue(entry.id),
+          entry,
+        ]),
+      ),
+    [workflowDashboardTasks],
+  );
+  const workflowChildTaskIndex = useMemo(() => {
+    const index = new Map<
+      StreamTabId,
+      (typeof workflowDashboardTasks)[number] | null
+    >();
+    for (const entry of workflowDashboardTasks) {
+      const childStreamId = entry.task.childStreamId;
+      if (childStreamId === undefined) continue;
+      index.set(childStreamId, index.has(childStreamId) ? null : entry);
+    }
+    return index;
+  }, [workflowDashboardTasks]);
+  const childListValues = useMemo<readonly ChildListValue[]>(() => {
+    if (!workflowDashboardRoot) {
+      return sessionViews.map((session) => childStreamListValue(session.id));
+    }
+    const groupValues: ChildListValue[] = [];
+    const seenPhases = new Set<string>();
+    for (const entry of workflowDashboardRoot.entries) {
+      if (entry.role !== 'phase' && entry.role !== 'workflowTask') continue;
+      const phase =
+        entry.role === 'phase' ? entry.phaseLabel : entry.task.phase;
+      const key = phase === undefined ? 'unphased' : `phase:${phase}`;
+      if (seenPhases.has(key)) continue;
+      seenPhases.add(key);
+      groupValues.push(workflowPhaseListValue(entry.id));
+    }
+    const taskValues = workflowDashboardTasks.map((entry) =>
+      workflowTaskListValue(entry.id),
+    );
+    return columns >= WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS
+      ? [...groupValues, ...taskValues]
+      : taskValues;
+  }, [columns, sessionViews, workflowDashboardRoot, workflowDashboardTasks]);
   const childListAvailable = childListValues.length > 0;
-  const selectedChildStreamId = childListStreamId(selectedChildValue);
+  const selectedWorkflowTask = selectedChildValue
+    ? workflowTasksByValue.get(selectedChildValue)
+    : undefined;
+  const selectedWorkflowChildStreamId =
+    selectedWorkflowTask?.task.childStreamId;
+  const selectedWorkflowChildUnique =
+    selectedWorkflowChildStreamId !== undefined &&
+    streams.has(selectedWorkflowChildStreamId) &&
+    workflowChildTaskIndex.get(selectedWorkflowChildStreamId) ===
+      selectedWorkflowTask;
+  const selectedChildStreamId =
+    childListStreamId(selectedChildValue) ??
+    (selectedWorkflowChildUnique ? selectedWorkflowChildStreamId : undefined);
   const selectedChildKind =
     selectedChildStreamId !== undefined ? 'stream' : undefined;
   const selectedChildKillable =
@@ -324,24 +391,45 @@ export function App(props: AppProps): React.JSX.Element {
   useEffect(() => {
     dispatchChildListSelection({
       kind: 'reconcile',
-      activeStreamId,
+      activeStreamId: workflowDashboardRoot ? undefined : activeStreamId,
       values: childListValues,
     });
-  }, [activeStreamId, childListValues]);
+  }, [activeStreamId, childListValues, workflowDashboardRoot]);
   // Stream focus can also move through lifecycle completion or a numeric
   // accelerator. Align the selected row before the changed frame is painted;
   // ordinary row reconciliation still preserves manual list selection.
   useLayoutEffect(() => {
     if (childListActiveStreamRef.current === activeStreamId) return;
     childListActiveStreamRef.current = activeStreamId;
-    if (activeStreamId) {
-      dispatchChildListSelection({
-        kind: 'syncActiveStream',
-        streamId: activeStreamId,
-        values: childListValues,
-      });
+    if (!activeStreamId) return;
+    if (workflowDashboardRoot) {
+      if (activeStreamId === workflowDashboardRoot.streamId) return;
+      const matchingTask = workflowChildTaskIndex.get(activeStreamId);
+      if (matchingTask) {
+        dispatchChildListSelection({
+          kind: 'highlight',
+          value: workflowTaskListValue(matchingTask.id),
+        });
+      } else {
+        dispatchChildListSelection({
+          kind: 'syncActiveStream',
+          streamId: activeStreamId,
+          values: childListValues,
+        });
+      }
+      return;
     }
-  }, [activeStreamId, childListValues]);
+    dispatchChildListSelection({
+      kind: 'syncActiveStream',
+      streamId: activeStreamId,
+      values: childListValues,
+    });
+  }, [
+    activeStreamId,
+    childListValues,
+    workflowChildTaskIndex,
+    workflowDashboardRoot,
+  ]);
   useEffect(() => {
     if (!childListAvailable && childListFocused) {
       dispatchChildListSelection({ kind: 'blur' });
@@ -356,10 +444,17 @@ export function App(props: AppProps): React.JSX.Element {
       dispatchChildListSelection({ kind: 'focus', value: firstChildValue });
     }
   }, [childListValues]);
-  const focusSession = useCallback((streamId: StreamTabId) => {
-    dispatchChildListSelection({ kind: 'focusStream', streamId });
-    focusStreamAndPromoteApprovals(streamId);
-  }, []);
+  const focusSession = useCallback(
+    (streamId: StreamTabId) => {
+      if (selectedChildValue?.startsWith('workflowTask:')) {
+        dispatchChildListSelection({ kind: 'blur' });
+      } else {
+        dispatchChildListSelection({ kind: 'focusStream', streamId });
+      }
+      focusStreamAndPromoteApprovals(streamId);
+    },
+    [selectedChildValue],
+  );
   const foregroundKind = foregroundSurfaceKind({
     activeFormOpen: activeForm !== undefined,
     formBusy,
@@ -512,6 +607,13 @@ export function App(props: AppProps): React.JSX.Element {
     const parentId = parentStreamSignal.get().get(streamId);
     if (parentId !== undefined) {
       focusStreamAndPromoteApprovals(parentId);
+      if (
+        selectedWorkflowChildUnique &&
+        selectedWorkflowChildStreamId === streamId &&
+        workflowDashboardRoot?.streamId === parentId
+      ) {
+        dispatchChildListSelection({ kind: 'focus' });
+      }
       return true;
     }
     return triggerEscapeInterrupt(escapeInterruptStateRef.current, streamId);

--- a/packages/cli/src/chat/tui/appLayout.ts
+++ b/packages/cli/src/chat/tui/appLayout.ts
@@ -147,12 +147,14 @@ export function allocateConversationBottomPanelRows({
   maxRows,
   sessionCount,
   childListFocused,
+  minimumSessionPanelRows = 2,
   todosPlanContentRows,
   transcriptRows,
 }: {
   readonly maxRows: number;
   readonly sessionCount: number;
   readonly childListFocused: boolean;
+  readonly minimumSessionPanelRows?: number;
   readonly todosPlanContentRows: number;
   readonly transcriptRows: number;
 }): {
@@ -171,7 +173,8 @@ export function allocateConversationBottomPanelRows({
   // The todos/plan panel likewise owns a separator row above its checklist.
   const todosPanelContentRows =
     todosPlanContentRows > 0 ? todosPlanContentRows + 1 : 0;
-  const minimumSessionRows = childListRowCount > 0 ? 2 : 0;
+  const minimumSessionRows =
+    childListRowCount > 0 ? minimumSessionPanelRows : 0;
   const availableTranscriptRows = Math.max(0, transcriptRows);
   let panelTranscriptLimit: number;
   if (childListFocused) {

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -8,7 +8,7 @@ import { useLayoutEffect, useMemo, type ReactNode } from 'react';
 
 // Local imports - shared constants and schemas
 import { clampModalWidth } from '@cli/tui/ui/theme';
-import { AgentCategory, type StreamTabId } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { clamp } from '@utils/core';
 
@@ -31,8 +31,7 @@ import {
   queuedFollowUpPanelRowCount,
 } from './QueuedFollowUpsPanel';
 import { StaticConversationTranscript } from './StaticConversationTranscript';
-import { SubagentList } from './SubagentList';
-import { WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS } from './SubagentListDisplay';
+import { SubagentList, workflowDashboardPanelItemCount } from './SubagentList';
 import { TodosPlanPanel, todosPlanPanelRowCount } from './TodosPlanPanel';
 import { type ChildListValue } from '../state/childListSelection';
 import type { ForegroundSurfaceKind } from '../appInteractionPolicy';
@@ -174,30 +173,18 @@ export function ConversationRegion({
     hasTodosPlanPanel && activeSlice
       ? todosPlanPanelRowCount(activeSlice.todos, activeSlice.plan)
       : 0;
-  const workflowDashboardEntries =
-    snapshot.childListTarget.slice?.category === AgentCategory.Workflow
-      ? snapshot.childListTarget.slice.entries.filter(
-          (entry) => entry.role === 'phase' || entry.role === 'workflowTask',
-        )
-      : [];
-  const workflowTaskCount = workflowDashboardEntries.filter(
-    (entry) => entry.role === 'workflowTask',
-  ).length;
-  const workflowPhaseKeys = new Set(
-    workflowDashboardEntries.map((entry) => {
-      const phase =
-        entry.role === 'phase' ? entry.phaseLabel : entry.task.phase;
-      return phase === undefined ? 'unphased' : `phase:${phase}`;
-    }),
-  );
-  const workflowPhaseCount = workflowPhaseKeys.size;
+  const workflowDashboardItemCount = snapshot.childListTarget.slice
+    ? workflowDashboardPanelItemCount(
+        snapshot.childListTarget.slice,
+        snapshot.selectedChildValue,
+        columns,
+      )
+    : 0;
   const sessionPanelItemCount =
-    workflowTaskCount > 0
-      ? 1 +
-        (columns >= WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS
-          ? Math.max(workflowPhaseCount, workflowTaskCount)
-          : workflowPhaseCount + workflowTaskCount)
+    workflowDashboardItemCount > 0
+      ? workflowDashboardItemCount
       : snapshot.sessionViews.length;
+  const minimumSessionPanelRows = workflowDashboardItemCount > 0 ? 3 : 2;
   const {
     bottomPanelRows: bottomPanelBudget,
     sessionPanelRows: subagentRows,
@@ -206,12 +193,14 @@ export function ConversationRegion({
     maxRows: BOTTOM_PANEL_MAX_ROWS,
     sessionCount: foregroundOpen ? 0 : sessionPanelItemCount,
     childListFocused: snapshot.childListFocused,
+    minimumSessionPanelRows,
     todosPlanContentRows,
     transcriptRows,
   });
   const conversationRows = transcriptRows - bottomPanelBudget;
   const childListHasRows = sessionPanelItemCount > 0;
-  const childListVisible = childListHasRows && subagentRows > 1;
+  const childListVisible =
+    childListHasRows && subagentRows >= minimumSessionPanelRows;
   useLayoutEffect(() => {
     if (snapshot.childListFocused && !foregroundOpen && !childListVisible) {
       onCancelChildList();

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -8,7 +8,7 @@ import { useLayoutEffect, useMemo, type ReactNode } from 'react';
 
 // Local imports - shared constants and schemas
 import { clampModalWidth } from '@cli/tui/ui/theme';
-import { type StreamTabId } from '@shared/schemas';
+import { AgentCategory, type StreamTabId } from '@shared/schemas';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { clamp } from '@utils/core';
 
@@ -32,6 +32,7 @@ import {
 } from './QueuedFollowUpsPanel';
 import { StaticConversationTranscript } from './StaticConversationTranscript';
 import { SubagentList } from './SubagentList';
+import { WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS } from './SubagentListDisplay';
 import { TodosPlanPanel, todosPlanPanelRowCount } from './TodosPlanPanel';
 import { type ChildListValue } from '../state/childListSelection';
 import type { ForegroundSurfaceKind } from '../appInteractionPolicy';
@@ -173,19 +174,43 @@ export function ConversationRegion({
     hasTodosPlanPanel && activeSlice
       ? todosPlanPanelRowCount(activeSlice.todos, activeSlice.plan)
       : 0;
+  const workflowDashboardEntries =
+    snapshot.childListTarget.slice?.category === AgentCategory.Workflow
+      ? snapshot.childListTarget.slice.entries.filter(
+          (entry) => entry.role === 'phase' || entry.role === 'workflowTask',
+        )
+      : [];
+  const workflowTaskCount = workflowDashboardEntries.filter(
+    (entry) => entry.role === 'workflowTask',
+  ).length;
+  const workflowPhaseKeys = new Set(
+    workflowDashboardEntries.map((entry) => {
+      const phase =
+        entry.role === 'phase' ? entry.phaseLabel : entry.task.phase;
+      return phase === undefined ? 'unphased' : `phase:${phase}`;
+    }),
+  );
+  const workflowPhaseCount = workflowPhaseKeys.size;
+  const sessionPanelItemCount =
+    workflowTaskCount > 0
+      ? 1 +
+        (columns >= WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS
+          ? Math.max(workflowPhaseCount, workflowTaskCount)
+          : workflowPhaseCount + workflowTaskCount)
+      : snapshot.sessionViews.length;
   const {
     bottomPanelRows: bottomPanelBudget,
     sessionPanelRows: subagentRows,
     todosPlanRows,
   } = allocateConversationBottomPanelRows({
     maxRows: BOTTOM_PANEL_MAX_ROWS,
-    sessionCount: foregroundOpen ? 0 : snapshot.sessionViews.length,
+    sessionCount: foregroundOpen ? 0 : sessionPanelItemCount,
     childListFocused: snapshot.childListFocused,
     todosPlanContentRows,
     transcriptRows,
   });
   const conversationRows = transcriptRows - bottomPanelBudget;
-  const childListHasRows = snapshot.sessionViews.length > 0;
+  const childListHasRows = sessionPanelItemCount > 0;
   const childListVisible = childListHasRows && subagentRows > 1;
   useLayoutEffect(() => {
     if (snapshot.childListFocused && !foregroundOpen && !childListVisible) {
@@ -259,8 +284,10 @@ export function ConversationRegion({
               onPrintStream={onPrintStream}
               pendingApprovals={snapshot.pendingApprovals}
               listRootStreamId={snapshot.childListTarget.streamId}
+              listRootSlice={snapshot.childListTarget.slice}
               selectedValue={snapshot.selectedChildValue}
               sessions={snapshot.sessionViews}
+              streams={snapshot.streams}
               activeSubagentExecutionIds={snapshot.activeSubagentExecutionIds}
             />
             <TodosPlanPanel maxRows={todosPlanRows} />

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -273,6 +273,32 @@ function workflowPhaseGroups(root: StreamSlice): WorkflowPhaseGroup[] {
   return groups;
 }
 
+/** Number of content rows the dashboard can display at the current width. */
+export function workflowDashboardPanelItemCount(
+  root: StreamSlice,
+  selectedValue: ChildListValue | undefined,
+  columns: number,
+): number {
+  const groups = workflowPhaseGroups(root);
+  const taskCount = groups.reduce(
+    (total, group) => total + group.tasks.length,
+    0,
+  );
+  if (taskCount === 0) return 0;
+  if (columns < WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS) {
+    return 1 + groups.length + taskCount;
+  }
+  const activeGroup =
+    groups.find(
+      (group) =>
+        group.value === selectedValue ||
+        group.tasks.some(
+          (task) => workflowTaskListValue(task.id) === selectedValue,
+        ),
+    ) ?? groups[0];
+  return 1 + Math.max(groups.length, activeGroup?.tasks.length ?? 0);
+}
+
 type WorkflowChildTaskIndex = ReadonlyMap<
   StreamTabId,
   WorkflowTaskEntry | null

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -6,7 +6,12 @@ import { useMemo } from 'react';
 
 // Local imports - shared stream state
 import { COLOR_HINT } from '@cli/tui/ui/colors';
-import { POINTER, STATUS_DIAMOND, TICK } from '@cli/tui/ui/glyphs';
+import {
+  POINTER,
+  STATUS_DIAMOND,
+  TICK,
+  TOKENS_GENERATED,
+} from '@cli/tui/ui/glyphs';
 import {
   Select,
   visibleSelectRange,
@@ -14,6 +19,8 @@ import {
 } from '@cli/tui/ui/Select';
 import {
   AgentCategory,
+  WORKFLOW_TASK_STATUS_LABEL,
+  isTerminalWorkflowCallProgress,
   type StreamTabId,
   type WorkflowCallProgress,
 } from '@shared/schemas';
@@ -23,11 +30,17 @@ import {
   type WorkflowPhaseHeading,
 } from '@shared/copy/workflowCall';
 import { formatStageLabel } from '@shared/streams/streamStatusDisplay';
-import { formatResultCount } from '@utils/text/stringUtils';
+import { formatCompactTokenCount } from '@utils/core';
+import {
+  formatCompactDuration,
+  formatCostUsd,
+  formatResultCount,
+} from '@utils/text/stringUtils';
 
 // Local imports - TUI rendering
 import { truncateSummaryToWidth } from '../render/terminalText';
 import { formatCliStatusLabel } from '../sessionStatus';
+import { WORKFLOW_TASK_STATUS_STYLE } from './transcriptEntryLayout';
 
 // Local imports - TUI state and controls
 import { childElapsed } from '../state/childControls';
@@ -35,17 +48,21 @@ import {
   childListStreamId,
   childPhaseListValue,
   childStreamListValue,
+  workflowPhaseListValue,
+  workflowTaskListValue,
   type ChildListValue,
 } from '../state/childListSelection';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import {
   CHILD_ROW_METADATA_MIN_COLUMNS,
   CHILD_STATUS_MARKER,
+  WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS,
   childRowMetadataText,
   childStatusColor,
   pendingApprovalRowSuffix,
 } from './SubagentListDisplay';
 import type { PendingApprovalKind } from '../state/approvalQueue';
+import type { StreamSlice } from '../state/cliState';
 import type { StreamView } from '../state/streamViews';
 
 function HiddenRowSummary({
@@ -97,8 +114,10 @@ function PhaseHeader({
   return (
     <Box flexDirection="row" flexGrow={1} minWidth={0}>
       <Box minWidth={0} flexShrink={1}>
+        <Text dimColor>{'    '}</Text>
+        <Text aria-hidden dimColor>{`${STATUS_DIAMOND} `}</Text>
         <Text dimColor wrap="truncate-end">
-          {`    ${STATUS_DIAMOND} ${formatWorkflowPhaseHeading(details)}${inlineProgress}`}
+          {`${formatWorkflowPhaseHeading(details)}${inlineProgress}`}
         </Text>
       </Box>
       {metadataColumn && details.progress ? (
@@ -214,6 +233,360 @@ function SessionRow({
   );
 }
 
+type WorkflowTaskEntry = Extract<
+  StreamSlice['entries'][number],
+  { readonly role: 'workflowTask' }
+>;
+type WorkflowPhaseEntry = Extract<
+  StreamSlice['entries'][number],
+  { readonly role: 'phase' }
+>;
+
+interface WorkflowPhaseGroup {
+  readonly value: ChildListValue;
+  readonly label: string;
+  heading?: WorkflowPhaseEntry;
+  readonly tasks: WorkflowTaskEntry[];
+}
+
+function workflowPhaseGroups(root: StreamSlice): WorkflowPhaseGroup[] {
+  const groups: WorkflowPhaseGroup[] = [];
+  const byPhase = new Map<string | undefined, WorkflowPhaseGroup>();
+  for (const entry of root.entries) {
+    if (entry.role !== 'phase' && entry.role !== 'workflowTask') continue;
+    const phase = entry.role === 'phase' ? entry.phaseLabel : entry.task.phase;
+    let group = byPhase.get(phase);
+    if (!group) {
+      group = {
+        value: workflowPhaseListValue(entry.id),
+        label: phase ?? 'Unphased',
+        ...(entry.role === 'phase' ? { heading: entry } : {}),
+        tasks: [],
+      };
+      byPhase.set(phase, group);
+      groups.push(group);
+    } else if (entry.role === 'phase' && group.heading === undefined) {
+      group.heading = entry;
+    }
+    if (entry.role === 'workflowTask') group.tasks.push(entry);
+  }
+  return groups;
+}
+
+type WorkflowChildTaskIndex = ReadonlyMap<
+  StreamTabId,
+  WorkflowTaskEntry | null
+>;
+
+function workflowChildTaskIndex(
+  tasks: readonly WorkflowTaskEntry[],
+): WorkflowChildTaskIndex {
+  const index = new Map<StreamTabId, WorkflowTaskEntry | null>();
+  for (const entry of tasks) {
+    const childStreamId = entry.task.childStreamId;
+    if (childStreamId === undefined) continue;
+    index.set(childStreamId, index.has(childStreamId) ? null : entry);
+  }
+  return index;
+}
+
+function uniqueWorkflowChildStreamId(
+  entry: WorkflowTaskEntry,
+  childTaskIndex: WorkflowChildTaskIndex,
+  streams: ReadonlyMap<StreamTabId, StreamSlice>,
+): StreamTabId | undefined {
+  const childStreamId = entry.task.childStreamId;
+  return childStreamId !== undefined &&
+    childTaskIndex.get(childStreamId) === entry &&
+    streams.has(childStreamId)
+    ? childStreamId
+    : undefined;
+}
+
+function workflowTaskMetadata(
+  call: WorkflowCallProgress,
+  child: StreamSlice | undefined,
+  nowMs: number,
+): string | undefined {
+  const terminal = isTerminalWorkflowCallProgress(call);
+  const usage = child?.cumulativeUsage ?? child?.usage;
+  let elapsed: string | undefined;
+  let model: string | undefined;
+  let cost: number | undefined;
+  if (terminal) {
+    if ('durationMs' in call && call.durationMs !== undefined) {
+      elapsed = formatCompactDuration(call.durationMs);
+    }
+    model = ('model' in call ? call.model : undefined) ?? child?.model;
+    cost =
+      ('totalCostUsd' in call ? call.totalCostUsd : undefined) ?? usage?.cost;
+  } else {
+    if (child?.runStartedAt !== undefined) {
+      elapsed = formatCompactDuration(nowMs - child.runStartedAt);
+    }
+    model = child?.model;
+    cost = usage?.cost;
+  }
+  const parts = [
+    model,
+    elapsed,
+    usage && usage.outputTokens > 0
+      ? `${TOKENS_GENERATED}${formatCompactTokenCount(usage.outputTokens)}`
+      : undefined,
+    cost !== undefined && cost > 0 ? formatCostUsd(cost) : undefined,
+  ].filter((part): part is string => part !== undefined);
+  return parts.length > 0 ? parts.join(' · ') : undefined;
+}
+
+function WorkflowTaskRow({
+  child,
+  entry,
+  focused,
+  nowMs,
+}: {
+  readonly child: StreamSlice | undefined;
+  readonly entry: WorkflowTaskEntry;
+  readonly focused: boolean;
+  readonly nowMs: number;
+}): React.JSX.Element {
+  const style = WORKFLOW_TASK_STATUS_STYLE[entry.task.status];
+  const metadata = workflowTaskMetadata(entry.task, child, nowMs);
+  return (
+    <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
+      <Text aria-hidden color={focused ? COLOR_HINT : undefined}>
+        {focused ? POINTER : ' '}
+      </Text>
+      <Text aria-hidden color={style.color}>{` ${style.marker} `}</Text>
+      <Box minWidth={0} flexShrink={1}>
+        <Text wrap="truncate-end">
+          {entry.task.label} · {WORKFLOW_TASK_STATUS_LABEL[entry.task.status]}
+        </Text>
+      </Box>
+      {metadata ? (
+        <Box minWidth={0} flexShrink={2}>
+          <Text dimColor wrap="truncate-end">{`  ${metadata}`}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+function WorkflowDashboard({
+  columns,
+  keyboardActive,
+  maxRows,
+  onCancel,
+  onFocusStream,
+  onSelectionChange,
+  root,
+  selectedValue,
+  streams,
+  uniqueChildTaskIndex,
+}: {
+  readonly columns: number;
+  readonly keyboardActive: boolean;
+  readonly maxRows: number | undefined;
+  readonly onCancel: () => void;
+  readonly onFocusStream: ((streamId: StreamTabId) => void) | undefined;
+  readonly onSelectionChange: ((value: ChildListValue) => void) | undefined;
+  readonly root: StreamSlice;
+  readonly selectedValue: ChildListValue | undefined;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+  readonly uniqueChildTaskIndex: WorkflowChildTaskIndex;
+}): React.JSX.Element | null {
+  const groups = workflowPhaseGroups(root);
+  const tasks = groups.flatMap((group) => group.tasks);
+  const taskByValue = new Map(
+    tasks.map((entry) => [workflowTaskListValue(entry.id), entry]),
+  );
+  const groupByValue = new Map(groups.map((group) => [group.value, group]));
+  const selectedGroup = selectedValue
+    ? groupByValue.get(selectedValue)
+    : undefined;
+  const selectedTask = selectedValue
+    ? taskByValue.get(selectedValue)
+    : undefined;
+  const selectedTaskGroup = selectedTask
+    ? groups.find((group) => group.tasks.includes(selectedTask))
+    : undefined;
+  const activeGroup = selectedGroup ?? selectedTaskGroup ?? groups[0];
+  const uniqueChildId = (entry: WorkflowTaskEntry): StreamTabId | undefined =>
+    uniqueWorkflowChildStreamId(entry, uniqueChildTaskIndex, streams);
+  const liveElapsedKey = tasks
+    .map((entry) => {
+      const childStreamId = uniqueChildId(entry);
+      return childStreamId === undefined
+        ? undefined
+        : streams.get(childStreamId)?.runStartedAt;
+    })
+    .filter((startedAt): startedAt is number => startedAt !== undefined)
+    .join(':');
+  const nowMs = useLiveNowMs(liveElapsedKey.length > 0, liveElapsedKey);
+  const wide = columns >= WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS;
+  const phaseItems: SelectItem<ChildListValue>[] = groups.map((group) => ({
+    label: group.label,
+    value: group.value,
+  }));
+  const taskItems: SelectItem<ChildListValue>[] = (
+    activeGroup?.tasks ?? []
+  ).map((entry) => ({
+    label: entry.task.label,
+    value: workflowTaskListValue(entry.id),
+  }));
+  const narrowItems: SelectItem<ChildListValue>[] = groups.flatMap((group) => [
+    { label: group.label, value: group.value, disabled: true },
+    ...group.tasks.map((entry) => ({
+      label: entry.task.label,
+      value: workflowTaskListValue(entry.id),
+    })),
+  ]);
+  const { done, total } = workflowPhaseCallProgress(
+    tasks.map((entry) => entry.task),
+  );
+  const contentRows =
+    maxRows === undefined ? undefined : Math.max(0, maxRows - 2);
+
+  const selectTask = (value: ChildListValue): void => {
+    const entry = taskByValue.get(value);
+    if (!entry) return;
+    const childStreamId = uniqueChildId(entry);
+    if (childStreamId !== undefined) onFocusStream?.(childStreamId);
+  };
+  const enterPhase = (value: ChildListValue): void => {
+    const firstTask = groupByValue.get(value)?.tasks[0];
+    if (firstTask) onSelectionChange?.(workflowTaskListValue(firstTask.id));
+  };
+
+  useInput(
+    (_input, key) => {
+      if (!wide || key.ctrl || key.meta) return;
+      if (key.rightArrow && selectedGroup) {
+        enterPhase(selectedGroup.value);
+      } else if (key.leftArrow && selectedTaskGroup) {
+        onSelectionChange?.(selectedTaskGroup.value);
+      }
+    },
+    { isActive: keyboardActive },
+  );
+
+  if (tasks.length === 0 || (contentRows !== undefined && contentRows <= 0)) {
+    return null;
+  }
+  const heading = `${root.agent ?? 'Workflow'} · ${done}/${total} done`;
+  const renderTask = (
+    item: SelectItem<ChildListValue>,
+    state: { readonly focused: boolean },
+  ): React.JSX.Element | null => {
+    const entry = taskByValue.get(item.value);
+    if (!entry) return null;
+    const childStreamId = uniqueChildId(entry);
+    return (
+      <WorkflowTaskRow
+        child={
+          childStreamId === undefined ? undefined : streams.get(childStreamId)
+        }
+        entry={entry}
+        focused={state.focused}
+        nowMs={nowMs}
+      />
+    );
+  };
+  const groupDetails = (group: WorkflowPhaseGroup): PhaseHeaderDetails => {
+    const progress = workflowPhaseCallProgress(
+      group.tasks.map((entry) => entry.task),
+    );
+    return {
+      phaseLabel: group.label,
+      ...(group.heading?.phaseIndex !== undefined
+        ? { phaseIndex: group.heading.phaseIndex }
+        : {}),
+      ...(group.heading?.phaseTotal !== undefined
+        ? { phaseTotal: group.heading.phaseTotal }
+        : {}),
+      progress: `${progress.done}/${progress.total}`,
+    };
+  };
+  const selectProps = {
+    hotkeys: false,
+    maxVisibleItems: contentRows,
+    onCancel,
+    wrap: false,
+  } as const;
+
+  return (
+    <Box
+      flexDirection="column"
+      height={maxRows === undefined ? undefined : Math.max(0, maxRows - 1)}
+      marginTop={1}
+      paddingX={1}
+      width={columns}
+    >
+      <Text bold wrap="truncate-end">
+        {heading}
+      </Text>
+      {wide ? (
+        <Box flexDirection="row" height={contentRows} minWidth={0}>
+          <Box flexDirection="column" width="32%" paddingRight={1}>
+            <Select
+              {...selectProps}
+              isActive={keyboardActive && selectedTask === undefined}
+              highlightedValue={selectedGroup ? (selectedValue ?? null) : null}
+              items={phaseItems}
+              onHighlightChange={(value) => onSelectionChange?.(value)}
+              onSelect={enterPhase}
+              renderItem={(item, state) => {
+                const group = groupByValue.get(item.value);
+                if (!group) return null;
+                const details = groupDetails(group);
+                return (
+                  <Box minWidth={0}>
+                    <Text aria-hidden>{state.focused ? POINTER : ' '}</Text>
+                    <Text wrap="truncate-end">
+                      {' '}
+                      {formatWorkflowPhaseHeading(details)} · {details.progress}
+                    </Text>
+                  </Box>
+                );
+              }}
+            />
+          </Box>
+          <Box flexDirection="column" minWidth={0} width="68%">
+            <Select
+              {...selectProps}
+              isActive={keyboardActive && selectedTask !== undefined}
+              highlightedValue={selectedTask ? (selectedValue ?? null) : null}
+              items={taskItems}
+              onHighlightChange={(value) => onSelectionChange?.(value)}
+              onSelect={selectTask}
+              renderItem={renderTask}
+            />
+          </Box>
+        </Box>
+      ) : (
+        <Select
+          {...selectProps}
+          isActive={keyboardActive}
+          highlightedValue={selectedValue ?? null}
+          items={narrowItems}
+          onHighlightChange={(value) => onSelectionChange?.(value)}
+          onSelect={selectTask}
+          renderItem={(item, state) => {
+            const group = groupByValue.get(item.value);
+            return group ? (
+              <PhaseHeader
+                details={groupDetails(group)}
+                metadataColumn={false}
+              />
+            ) : (
+              renderTask(item, state)
+            );
+          }}
+        />
+      )}
+    </Box>
+  );
+}
+
 export interface SubagentListProps {
   readonly keyboardActive?: boolean;
   readonly maxRows?: number;
@@ -234,6 +607,8 @@ export interface SubagentListProps {
   >;
   readonly selectedValue?: ChildListValue;
   readonly sessions?: readonly StreamView[];
+  readonly streams?: ReadonlyMap<StreamTabId, StreamSlice>;
+  readonly listRootSlice?: StreamSlice;
   /** Stream the list is rooted on — its row never shows a summary. */
   readonly listRootStreamId?: StreamTabId;
   readonly activeSubagentExecutionIds?: ReadonlyMap<StreamTabId, string>;
@@ -252,12 +627,9 @@ export function SubagentList(
     [sessions],
   );
   const { items, phaseHeadersByValue } = useMemo(() => {
-    const rootSession = sessions.find(
-      (session) => session.id === props.listRootStreamId,
-    );
     const entries =
-      rootSession?.slice?.category === AgentCategory.Workflow
-        ? rootSession.slice.entries
+      props.listRootSlice?.category === AgentCategory.Workflow
+        ? props.listRootSlice.entries
         : [];
     const phaseHeadings = new Map<string, WorkflowPhaseHeading>();
     const callsByPhase = new Map<string, WorkflowCallProgress[]>();
@@ -316,7 +688,7 @@ export function SubagentList(
       previousPhase = phase;
     }
     return { items: nextItems, phaseHeadersByValue: nextHeaders };
-  }, [props.listRootStreamId, sessions]);
+  }, [props.listRootSlice, props.listRootStreamId, sessions]);
   const sessionsByValue = useMemo(
     () =>
       new Map(
@@ -327,6 +699,28 @@ export function SubagentList(
   const nowMs = useLiveNowMs(liveElapsedKey !== undefined, liveElapsedKey);
   const { columns } = useWindowSize();
   const metadataColumn = columns >= CHILD_ROW_METADATA_MIN_COLUMNS;
+  const workflowRoot =
+    props.listRootSlice?.category === AgentCategory.Workflow &&
+    props.listRootSlice.entries.some((entry) => entry.role === 'workflowTask')
+      ? props.listRootSlice
+      : undefined;
+  const workflowTasks = useMemo(
+    () =>
+      workflowRoot?.entries.filter((entry) => entry.role === 'workflowTask') ??
+      [],
+    [workflowRoot],
+  );
+  const workflowTasksByValue = useMemo(
+    () =>
+      new Map(
+        workflowTasks.map((entry) => [workflowTaskListValue(entry.id), entry]),
+      ),
+    [workflowTasks],
+  );
+  const uniqueChildTaskIndex = useMemo(
+    () => workflowChildTaskIndex(workflowTasks),
+    [workflowTasks],
+  );
   const contentRows =
     props.maxRows === undefined ? undefined : Math.max(0, props.maxRows - 1);
   const selectedIndex = Math.max(
@@ -352,7 +746,18 @@ export function SubagentList(
   useInput(
     (input, key) => {
       if (key.ctrl || key.meta) return;
-      const streamId = childListStreamId(props.selectedValue);
+      const selectedWorkflowTask = props.selectedValue
+        ? workflowTasksByValue.get(props.selectedValue)
+        : undefined;
+      const workflowChildStreamId = selectedWorkflowTask
+        ? uniqueWorkflowChildStreamId(
+            selectedWorkflowTask,
+            uniqueChildTaskIndex,
+            props.streams ?? new Map(),
+          )
+        : undefined;
+      const streamId =
+        childListStreamId(props.selectedValue) ?? workflowChildStreamId;
       if (!streamId) return;
       const pressed = input.toLowerCase();
       if (pressed === 'v') {
@@ -372,6 +777,23 @@ export function SubagentList(
     },
     { isActive: props.keyboardActive ?? false },
   );
+
+  if (workflowRoot) {
+    return (
+      <WorkflowDashboard
+        columns={columns}
+        keyboardActive={props.keyboardActive ?? false}
+        maxRows={props.maxRows}
+        onCancel={props.onCancel ?? (() => undefined)}
+        onFocusStream={props.onFocusStream}
+        onSelectionChange={props.onSelectionChange}
+        root={workflowRoot}
+        selectedValue={props.selectedValue}
+        streams={props.streams ?? new Map()}
+        uniqueChildTaskIndex={uniqueChildTaskIndex}
+      />
+    );
+  }
 
   if (items.length === 0) return null;
   // The list is deliberately separated from the input/status chrome by one

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -62,6 +62,10 @@ const PENDING_APPROVAL_ROW_LABELS: Record<PendingApprovalKind, string> = {
  *  and rows keep their inline elapsed, so identity is not crowded out. */
 export const CHILD_ROW_METADATA_MIN_COLUMNS = 60;
 
+/** At this width the workflow dashboard has room for independently navigable
+ * phase and task panes; below it, source-ordered tasks use the full row. */
+export const WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS = 100;
+
 /** Right-aligned metadata column for a child row: elapsed time, the number of
  *  tool calls the child has made, and its generated tokens so far (e.g.
  *  `2m 30s · 5 tool calls · ↓40k`). This is the per-agent stats summary a

--- a/packages/cli/src/chat/tui/state/childListSelection.ts
+++ b/packages/cli/src/chat/tui/state/childListSelection.ts
@@ -25,6 +25,12 @@ export function workflowTaskListValue(entryId: string): ChildListValue {
   return `workflowTask:${entryId}`;
 }
 
+export function isWorkflowTaskListValue(
+  value: ChildListValue | undefined,
+): value is `workflowTask:${string}` {
+  return value?.startsWith('workflowTask:') ?? false;
+}
+
 export function childListStreamId(
   value: ChildListValue | undefined,
 ): StreamTabId | undefined {

--- a/packages/cli/src/chat/tui/state/childListSelection.ts
+++ b/packages/cli/src/chat/tui/state/childListSelection.ts
@@ -1,7 +1,11 @@
 // Local imports - shared stream identity
 import type { StreamTabId } from '@shared/schemas';
 
-export type ChildListValue = `stream:${string}` | `phase:${number}`;
+export type ChildListValue =
+  | `stream:${string}`
+  | `phase:${number}`
+  | `workflowPhase:${string}`
+  | `workflowTask:${string}`;
 
 export function childStreamListValue(streamId: StreamTabId): ChildListValue {
   return `stream:${streamId}`;
@@ -11,6 +15,14 @@ export function childStreamListValue(streamId: StreamTabId): ChildListValue {
  *  avoids encoding a free-form phase label into a delimiter-based key. */
 export function childPhaseListValue(ordinal: number): ChildListValue {
   return `phase:${ordinal}`;
+}
+
+export function workflowPhaseListValue(entryId: string): ChildListValue {
+  return `workflowPhase:${entryId}`;
+}
+
+export function workflowTaskListValue(entryId: string): ChildListValue {
+  return `workflowTask:${entryId}`;
 }
 
 export function childListStreamId(

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -178,6 +178,8 @@ export type StreamStage =
 
 export interface StreamSlice {
   readonly streamId: StreamTabId;
+  /** Canonical agent name captured from this stream's `run.config`. */
+  readonly agent?: string | undefined;
   /** Model identity captured from setTaskState for this specific stream. */
   readonly model?: string | undefined;
   /** Agent category for this stream (`toolUse` / `workflow` / …), captured
@@ -271,6 +273,7 @@ export const NO_BYPASS: BypassState = {
 export function emptySlice(streamId: StreamTabId): StreamSlice {
   return {
     streamId,
+    agent: undefined,
     model: undefined,
     category: undefined,
     status: undefined,

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -93,6 +93,7 @@ function applyRunConfig(streamId: StreamTabId, config: AgentConfig): void {
         sameStringList(s.files?.[key] ?? [], files[key]),
       );
     if (
+      s.agent === config.agent &&
       s.model === config.model &&
       s.category === config.agentCategory &&
       sameFiles
@@ -101,6 +102,7 @@ function applyRunConfig(streamId: StreamTabId, config: AgentConfig): void {
     }
     return {
       ...s,
+      agent: config.agent,
       model: config.model,
       category: config.agentCategory,
       files,

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -109,12 +109,22 @@ const CHILD_STREAM_LOG_MESSAGE_TYPES = new Set<string>([
 
 // Roles a workflow-agent stream keeps when it projects an operational feed
 // instead of a model transcript.
+const WORKFLOW_DASHBOARD_ROLES = new Set<ConversationEntry['role']>([
+  'phase',
+  'workflowTask',
+]);
+
 const WORKFLOW_OPERATIONAL_ROLES = new Set<ConversationEntry['role']>([
   'error',
   'media',
   'phase',
   'tool',
+  'workflowTask',
 ]);
+
+// Compact inactive streams must not retain an unbounded operational transcript,
+// but the dashboard needs canonical phase/call identity while a child is open.
+const MAX_COMPACT_WORKFLOW_DASHBOARD_ENTRIES = 2_000;
 
 const LIVE_ACTIVITY_MESSAGE_TYPES = new Set<string>([
   MESSAGE_TYPES.THINKING,
@@ -744,9 +754,9 @@ export function syncStreamLog(
 
   patchStream(streamId, (slice, lifecycle) => {
     const existing = new Map(slice.entries.map((e) => [e.id, e]));
+    const workflowStream = slice.category === AgentCategory.Workflow;
     const workflowOperationalOnly =
-      slice.category === AgentCategory.Workflow &&
-      !isFullLogChildStream(streamId);
+      workflowStream && !isFullLogChildStream(streamId);
     const syntheticEntries = slice.entries.filter(
       (entry) =>
         entry.synthetic &&
@@ -768,7 +778,14 @@ export function syncStreamLog(
         workflowOperationalOnly &&
         messageType === MESSAGE_TYPES.DEFAULT &&
         phaseGroupData(entry) !== null;
-      if (!transcriptCandidate && !workflowDefaultLog && !workflowPhaseHeader) {
+      const workflowCall =
+        workflowOperationalOnly && messageType === MESSAGE_TYPES.WORKFLOW_TASK;
+      if (
+        !transcriptCandidate &&
+        !workflowDefaultLog &&
+        !workflowPhaseHeader &&
+        !workflowCall
+      ) {
         continue;
       }
       const rendered = renderLogEntry(
@@ -850,10 +867,22 @@ export function syncStreamLog(
       lifecycle.status !== undefined &&
       !isActivePhase(lifecycle.status);
 
-    // A stream projected compactly keeps only its synthetic rows, which are
-    // carried over untouched, so identity settles whether anything moved. The
-    // full projection rebuilds entries, so it compares content field by field.
-    const nextEntries = projectFullTranscript ? next : syntheticEntries;
+    // A compact workflow keeps only its bounded canonical dashboard rows plus
+    // synthetic operational rows. Ordinary inactive streams retain the prior
+    // synthetic-only behavior.
+    const compactWorkflowDashboardIds = new Set(
+      next
+        .filter((entry) => WORKFLOW_DASHBOARD_ROLES.has(entry.role))
+        .slice(-MAX_COMPACT_WORKFLOW_DASHBOARD_ENTRIES)
+        .map((entry) => entry.id),
+    );
+    const compactEntries = workflowStream
+      ? next.filter(
+          (entry) =>
+            entry.synthetic || compactWorkflowDashboardIds.has(entry.id),
+        )
+      : syntheticEntries;
+    const nextEntries = projectFullTranscript ? next : compactEntries;
     const entriesUnchanged =
       slice.entries.length === nextEntries.length &&
       slice.entries.every((entry, index) => {

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -107,13 +107,14 @@ const CHILD_STREAM_LOG_MESSAGE_TYPES = new Set<string>([
   MESSAGE_TYPES.WORKFLOW_TASK,
 ]);
 
-// Roles a workflow-agent stream keeps when it projects an operational feed
-// instead of a model transcript.
+// Canonical dashboard rows retained when a workflow stream is compacted.
 const WORKFLOW_DASHBOARD_ROLES = new Set<ConversationEntry['role']>([
   'phase',
   'workflowTask',
 ]);
 
+// Roles a workflow-agent stream keeps when it projects an operational feed
+// instead of a model transcript.
 const WORKFLOW_OPERATIONAL_ROLES = new Set<ConversationEntry['role']>([
   'error',
   'media',

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.mts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.mts
@@ -4,29 +4,35 @@ import { setTimeout as sleep } from 'node:timers/promises';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { App, type AppProps } from '@cli/chat/tui/App';
+import { POINTER } from '@cli/tui/ui/glyphs';
 import type { InputHistory } from '@cli/chat/tui/history/inputHistory';
 import {
   activeStreamId,
   focusStream,
   infoPane,
   openInfoPane,
+  patchStream,
   resetCliState,
   rootRunStartAvailable,
   rootStreamId,
   setStreamStatusInCliState,
+  streams,
 } from '@cli/chat/tui/state/cliState';
 import {
   applySubagentRoster,
   setParentStream,
 } from '@cli/chat/tui/state/childExecutions';
-import { STREAM_PHASE, type StreamTabId } from '@shared/schemas';
+import { syncStreamLog } from '@cli/chat/tui/state/subscribeStreamLog';
+import { AgentCategory, STREAM_PHASE, type StreamTabId } from '@shared/schemas';
 import {
   loadInk,
   renderInteractive,
   type InkRenderHandles,
 } from '@test/support/inkTestHarness.mts';
 import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
+import { createRunTrace } from '@transcript';
 
 vi.mock('@cli/runtime/shortcutLabels', async (importOriginal) => {
   const actual =
@@ -142,6 +148,162 @@ describe('App foreground Escape ownership', () => {
       expect(onInterruptStream).not.toHaveBeenCalled();
     } finally {
       instance.unmount();
+    }
+  });
+
+  it('renders and operates a canonical workflow dashboard with zero descendants', async () => {
+    seedRootStream();
+    patchStream(ROOT, (slice) => ({
+      ...slice,
+      agent: 'solo-workflow',
+      category: AgentCategory.Workflow,
+      entries: [
+        {
+          id: 'task-planned-only',
+          role: 'workflowTask',
+          text: 'Planned: Draft alone',
+          finalized: false,
+          task: {
+            id: 'draft-alone',
+            label: 'Draft alone',
+            status: 'planned',
+          },
+        },
+      ],
+    }));
+    const onInterruptStream = vi.fn();
+    const { instance, stdin, stdout } = await renderApp(
+      appProps(onInterruptStream),
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('\t');
+      await waitFor(() => stdout.output.includes('solo-workflow · 0/1 done'));
+      expect(stdout.output).toContain('Draft alone · Planned');
+      stdin.write('\r');
+      await sleep(30);
+      expect(activeStreamId.get()).toBe(ROOT);
+      expect(onInterruptStream).not.toHaveBeenCalled();
+    } finally {
+      instance.unmount();
+    }
+  });
+
+  it('retains projected workflow rows while child detail is focused and returns to the same task', async () => {
+    seedRootStream();
+    for (const streamId of [CHILD, GRANDCHILD]) {
+      setStreamStatusInCliState({
+        streamId,
+        status: STREAM_PHASE.RUNNING,
+      });
+    }
+    patchStream(ROOT, (slice) => ({
+      ...slice,
+      agent: 'workflow',
+      category: AgentCategory.Workflow,
+    }));
+    const runTrace = createRunTrace(ROOT, defaultSession().transcripts);
+    const phase = runTrace.trace.openStage('Map', {
+      id: 'phase-map',
+      kind: 'phase',
+      index: 0,
+      total: 1,
+    });
+    for (const [logId, id, label, childStreamId] of [
+      ['task-child', 'inspect', 'Inspect', CHILD],
+      ['task-review', 'review', 'Review', GRANDCHILD],
+    ] as const) {
+      runTrace.trace.emit({
+        type: 'workflow.call',
+        logId,
+        stageId: phase.id,
+        call: {
+          id,
+          label,
+          phase: 'Map',
+          status: 'running',
+          childStreamId,
+        },
+      });
+    }
+    syncStreamLog(ROOT);
+    applySubagentRoster(ROOT, [
+      {
+        kind: 'subagent',
+        executionId: 'workflow-child-execution',
+        agentName: 'duplicate',
+        childStreamId: CHILD,
+        status: STREAM_PHASE.RUNNING,
+      },
+      {
+        kind: 'subagent',
+        executionId: 'workflow-review-execution',
+        agentName: 'duplicate',
+        childStreamId: GRANDCHILD,
+        status: STREAM_PHASE.RUNNING,
+      },
+    ]);
+    setParentStream(CHILD, ROOT);
+    setParentStream(GRANDCHILD, ROOT);
+    const onInterruptStream = vi.fn();
+    const { instance, stdin, stdout } = await renderApp(
+      appProps(onInterruptStream),
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('\t');
+      await waitFor(() => stdout.output.includes('workflow · 0/2 done'));
+      stdin.write('\r');
+      await waitFor(() => stdout.output.includes('Inspect · Running'));
+      stdin.write('\r');
+      await waitFor(() => activeStreamId.get() === CHILD);
+      syncStreamLog(ROOT);
+      expect(
+        streams
+          .get()
+          .get(ROOT)
+          ?.entries.map((entry) => [entry.id, entry.role]),
+      ).toEqual([
+        ['phase-map', 'phase'],
+        ['task-child', 'workflowTask'],
+        ['task-review', 'workflowTask'],
+      ]);
+
+      stdin.write(ESC);
+      await waitFor(() => activeStreamId.get() === ROOT, {
+        timeoutMs: 1_000,
+      });
+      const taskLine = stdout.output
+        .split('\n')
+        .find((line) => line.includes('Inspect · Running'));
+      expect(taskLine).toContain(POINTER);
+      expect(stdout.output).toContain('Esc input');
+
+      stdin.write(ESC);
+      await waitFor(() => stdout.output.includes('Tab children'));
+      expect(activeStreamId.get()).toBe(ROOT);
+
+      focusStream(GRANDCHILD);
+      await waitFor(() => activeStreamId.get() === GRANDCHILD);
+      await sleep(30);
+      stdin.write(ESC);
+      await waitFor(() => activeStreamId.get() === ROOT, {
+        timeoutMs: 1_000,
+      });
+      await waitFor(() =>
+        stdout.output
+          .split('\n')
+          .some(
+            (line) =>
+              line.includes('Review · Running') && line.includes(POINTER),
+          ),
+      );
+      expect(onInterruptStream).not.toHaveBeenCalled();
+    } finally {
+      instance.unmount();
+      runTrace.dispose();
     }
   });
 

--- a/src/test-kernel/cli/ChildListInteraction.vitest.mts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.mts
@@ -6,11 +6,14 @@ import { SubagentList } from '@cli/chat/tui/panes/SubagentList';
 import {
   childPhaseListValue,
   childStreamListValue,
+  workflowPhaseListValue,
+  workflowTaskListValue,
   type ChildListValue,
 } from '@cli/chat/tui/state/childListSelection';
+import { emptySlice, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import type { StreamView } from '@cli/chat/tui/state/streamViews';
 import { POINTER } from '@cli/tui/ui/glyphs';
-import type { StreamTabId } from '@shared/schemas';
+import { AgentCategory, type StreamTabId } from '@shared/schemas';
 import {
   loadInk,
   renderInteractive,
@@ -278,6 +281,226 @@ describe('CLI child list interaction', () => {
       expect(onSelectionChange).not.toHaveBeenCalled();
     } finally {
       instance.unmount();
+    }
+  });
+
+  it('enters and leaves wide workflow tasks and ignores no-child Enter', async () => {
+    const { ink, React } = await loadInk();
+    const onFocusStream = vi.fn();
+    const phaseValue = workflowPhaseListValue('phase-map');
+    const childTaskValue = workflowTaskListValue('task-child');
+    const plannedTaskValue = workflowTaskListValue('task-planned');
+    const rootSlice: StreamSlice = {
+      ...emptySlice(root),
+      agent: 'workflow',
+      category: AgentCategory.Workflow,
+      entries: [
+        {
+          id: 'phase-map',
+          role: 'phase',
+          text: 'Map',
+          finalized: true,
+          phaseLabel: 'Map',
+          phaseIndex: 0,
+          phaseTotal: 1,
+        },
+        {
+          id: 'task-child',
+          role: 'workflowTask',
+          text: 'Running: Inspect',
+          finalized: false,
+          task: {
+            id: 'inspect',
+            label: 'Inspect',
+            phase: 'Map',
+            status: 'running',
+            childStreamId: child,
+          },
+        },
+        {
+          id: 'task-planned',
+          role: 'workflowTask',
+          text: 'Planned: Summarize',
+          finalized: false,
+          task: {
+            id: 'summarize',
+            label: 'Summarize',
+            phase: 'Map',
+            status: 'planned',
+          },
+        },
+      ],
+    };
+    let selected = phaseValue;
+
+    function Harness() {
+      const [value, setValue] = React.useState(selected) as [
+        ChildListValue,
+        (next: ChildListValue) => void,
+      ];
+      return React.createElement(SubagentList, {
+        keyboardActive: true,
+        listRootStreamId: root,
+        listRootSlice: rootSlice,
+        maxRows: 6,
+        onCancel: vi.fn(),
+        onFocusStream,
+        onSelectionChange: (next: ChildListValue) => {
+          selected = next;
+          setValue(next);
+        },
+        selectedValue: value,
+        sessions: [
+          { id: root, label: 'workflow', active: true, slice: rootSlice },
+        ],
+        streams: new Map([
+          [root, rootSlice],
+          [child, emptySlice(child)],
+        ]),
+      });
+    }
+
+    const { instance, stdin } = renderChildList(
+      ink,
+      React.createElement(Harness),
+    );
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('\u001b[C');
+      await waitFor(() => selected === childTaskValue);
+      stdin.write('\u001b[D');
+      await waitFor(() => selected === phaseValue);
+      stdin.write('\r');
+      await waitFor(() => selected === childTaskValue);
+      stdin.write('\r');
+      await waitFor(() => onFocusStream.mock.calls.length === 1);
+      expect(onFocusStream).toHaveBeenCalledWith(child);
+
+      stdin.write('\u001b[B');
+      await waitFor(() => selected === plannedTaskValue);
+      stdin.write('\r');
+      await sleep(30);
+      expect(onFocusStream).toHaveBeenCalledOnce();
+    } finally {
+      instance.unmount();
+    }
+
+    selected = childTaskValue;
+    onFocusStream.mockClear();
+    const narrow = renderInteractive(ink, React.createElement(Harness), {
+      columns: 99,
+    });
+    try {
+      await waitFor(() => narrow.stdin.listenerCount('readable') > 0);
+      narrow.stdin.write('\u001b[B');
+      await waitFor(() => selected === plannedTaskValue);
+      narrow.stdin.write('\r');
+      await sleep(30);
+      expect(onFocusStream).not.toHaveBeenCalled();
+
+      narrow.stdin.write('\u001b[A');
+      await waitFor(() => selected === childTaskValue);
+      narrow.stdin.write('\r');
+      await waitFor(() => onFocusStream.mock.calls.length === 1);
+      expect(onFocusStream).toHaveBeenCalledWith(child);
+    } finally {
+      narrow.instance.unmount();
+    }
+  });
+
+  it('keeps detail and controls inert when workflow tasks reuse a child id', async () => {
+    const { ink, React } = await loadInk();
+    const onFocusStream = vi.fn();
+    const onPrintStream = vi.fn();
+    const onSkipExecution = vi.fn();
+    const rootSlice: StreamSlice = {
+      ...emptySlice(root),
+      agent: 'workflow',
+      category: AgentCategory.Workflow,
+      entries: [
+        ...['first', 'second'].map((id) => ({
+          id: `task-${id}`,
+          role: 'workflowTask' as const,
+          text: `Running: ${id}`,
+          finalized: false,
+          task: {
+            id,
+            label: id,
+            status: 'running' as const,
+            childStreamId: child,
+          },
+        })),
+        {
+          id: 'task-missing',
+          role: 'workflowTask',
+          text: 'Running: missing',
+          finalized: false,
+          task: {
+            id: 'missing',
+            label: 'missing',
+            status: 'running',
+            childStreamId: 'missing-child' as StreamTabId,
+          },
+        },
+      ],
+    };
+    const { instance, stdin } = renderChildList(
+      ink,
+      React.createElement(SubagentList, {
+        activeSubagentExecutionIds: new Map([[child, 'shared-exec']]),
+        keyboardActive: true,
+        listRootStreamId: root,
+        listRootSlice: rootSlice,
+        maxRows: 6,
+        onCancel: vi.fn(),
+        onFocusStream,
+        onPrintStream,
+        onSkipExecution,
+        selectedValue: workflowTaskListValue('task-first'),
+        sessions: [],
+        streams: new Map([
+          [root, rootSlice],
+          [child, emptySlice(child)],
+        ]),
+      }),
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      for (const input of ['\r', 'v', 's']) stdin.write(input);
+      await sleep(30);
+      expect(onFocusStream).not.toHaveBeenCalled();
+      expect(onPrintStream).not.toHaveBeenCalled();
+      expect(onSkipExecution).not.toHaveBeenCalled();
+    } finally {
+      instance.unmount();
+    }
+
+    const missing = renderChildList(
+      ink,
+      React.createElement(SubagentList, {
+        keyboardActive: true,
+        listRootStreamId: root,
+        listRootSlice: rootSlice,
+        maxRows: 6,
+        onCancel: vi.fn(),
+        onFocusStream,
+        onPrintStream,
+        onSkipExecution,
+        selectedValue: workflowTaskListValue('task-missing'),
+        sessions: [],
+        streams: new Map([[root, rootSlice]]),
+      }),
+    );
+    try {
+      await waitFor(() => missing.stdin.listenerCount('readable') > 0);
+      for (const input of ['\r', 'v', 's']) missing.stdin.write(input);
+      await sleep(30);
+      expect(onFocusStream).not.toHaveBeenCalled();
+      expect(onPrintStream).not.toHaveBeenCalled();
+      expect(onSkipExecution).not.toHaveBeenCalled();
+    } finally {
+      missing.instance.unmount();
     }
   });
 

--- a/src/test-kernel/cli/ChildListSelection.vitest.mts
+++ b/src/test-kernel/cli/ChildListSelection.vitest.mts
@@ -4,6 +4,7 @@ import {
   childListStreamId,
   childPhaseListValue,
   childStreamListValue,
+  isWorkflowTaskListValue,
   workflowPhaseListValue,
   workflowTaskListValue,
   INITIAL_CHILD_LIST_SELECTION,
@@ -42,6 +43,13 @@ describe('CLI child list selection', () => {
       'workflowPhase:entry:phase',
     );
     expect(workflowTaskListValue('entry:task')).toBe('workflowTask:entry:task');
+    expect(isWorkflowTaskListValue(workflowTaskListValue('entry:task'))).toBe(
+      true,
+    );
+    expect(isWorkflowTaskListValue(workflowPhaseListValue('entry:phase'))).toBe(
+      false,
+    );
+    expect(isWorkflowTaskListValue(undefined)).toBe(false);
     expect(
       childListStreamId(workflowTaskListValue('entry:task')),
     ).toBeUndefined();

--- a/src/test-kernel/cli/ChildListSelection.vitest.mts
+++ b/src/test-kernel/cli/ChildListSelection.vitest.mts
@@ -4,6 +4,8 @@ import {
   childListStreamId,
   childPhaseListValue,
   childStreamListValue,
+  workflowPhaseListValue,
+  workflowTaskListValue,
   INITIAL_CHILD_LIST_SELECTION,
   reduceChildListSelection,
   type ChildListSelectionState,
@@ -36,6 +38,13 @@ describe('CLI child list selection', () => {
     expect(childListStreamId(mainValue)).toBe(main);
     expect(childPhaseListValue(2)).toBe('phase:2');
     expect(childListStreamId(childPhaseListValue(2))).toBeUndefined();
+    expect(workflowPhaseListValue('entry:phase')).toBe(
+      'workflowPhase:entry:phase',
+    );
+    expect(workflowTaskListValue('entry:task')).toBe('workflowTask:entry:task');
+    expect(
+      childListStreamId(workflowTaskListValue('entry:task')),
+    ).toBeUndefined();
     expect(childListStreamId(undefined)).toBeUndefined();
   });
 

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -15,7 +15,11 @@ import {
   type SubagentListProps,
 } from '@cli/chat/tui/panes/SubagentList';
 import { textDisplayWidth } from '@cli/chat/tui/render/terminalText';
-import { childStreamListValue } from '@cli/chat/tui/state/childListSelection';
+import {
+  childStreamListValue,
+  workflowPhaseListValue,
+  workflowTaskListValue,
+} from '@cli/chat/tui/state/childListSelection';
 import {
   activeStreamId,
   emptySlice,
@@ -867,136 +871,364 @@ describe('CLI child list display model', () => {
     expect(output).not.toContain('map-agent');
   });
 
-  it('switches phase progress layout at the exact width boundary', async () => {
+  it('renders canonical workflow calls and switches panes at the exact boundary', async () => {
     const run = 'run' as StreamTabId;
-    const mapRetry = 'map-retry' as StreamTabId;
-    const mapAttempt = 'map-attempt' as StreamTabId;
-    const loose = 'loose' as StreamTabId;
-    const reduce = 'reduce' as StreamTabId;
-    const freeFormPhase = 'Map:review|draft';
-    const sessions: StreamView[] = [
-      {
-        id: run,
-        label: 'workflow-script',
-        active: true,
-        slice: workflowAgentSlice('run', {
-          status: STREAM_PHASE.RUNNING,
-          entries: [
-            {
-              id: 'phase-map',
-              role: 'phase',
-              text: freeFormPhase,
-              finalized: true,
-              phaseLabel: freeFormPhase,
-              phaseIndex: 0,
-              phaseTotal: 2,
-            },
-            {
-              id: 'task-map',
-              role: 'workflowTask',
-              text: 'Finished: Review map',
-              finalized: true,
-              task: {
-                id: 'review-map',
-                label: 'Review map',
-                phase: freeFormPhase,
-                status: 'completed',
-                durationMs: 1_000,
-              },
-            },
-            {
-              id: 'phase-reduce',
-              role: 'phase',
-              text: 'Reduce',
-              finalized: true,
-              phaseLabel: 'Reduce',
-              phaseIndex: 1,
-              phaseTotal: 2,
-            },
-            {
-              id: 'task-reduce',
-              role: 'workflowTask',
-              text: 'Running: Merge map',
-              finalized: false,
-              task: {
-                id: 'merge-map',
-                label: 'Merge map',
-                phase: 'Reduce',
-                status: 'running',
-              },
-            },
-          ],
+    const exactChild = 'exact-child' as StreamTabId;
+    const wrongChild = 'wrong-child' as StreamTabId;
+    const rootSlice = workflowAgentSlice(run, {
+      agent: 'research-workflow',
+      status: STREAM_PHASE.RUNNING,
+      entries: [
+        {
+          id: 'phase-map',
+          role: 'phase',
+          text: 'Map',
+          finalized: true,
+          phaseLabel: 'Map',
+          phaseIndex: 0,
+          phaseTotal: 2,
+        },
+        {
+          id: 'task-planned',
+          role: 'workflowTask',
+          text: 'Planned: Duplicate',
+          finalized: false,
+          task: {
+            id: 'planned',
+            label: 'Duplicate',
+            phase: 'Map',
+            status: 'planned',
+          },
+        },
+        {
+          id: 'task-running',
+          role: 'workflowTask',
+          text: 'Running: Duplicate',
+          finalized: false,
+          task: {
+            id: 'running',
+            label: 'Duplicate',
+            phase: 'Map',
+            status: 'running',
+            childStreamId: exactChild,
+          },
+        },
+        {
+          id: 'phase-write',
+          role: 'phase',
+          text: 'Write',
+          finalized: true,
+          phaseLabel: 'Write',
+          phaseIndex: 1,
+          phaseTotal: 2,
+        },
+        {
+          id: 'task-finished',
+          role: 'workflowTask',
+          text: 'Finished: Duplicate',
+          finalized: true,
+          task: {
+            id: 'finished',
+            label: 'Duplicate',
+            phase: 'Write',
+            status: 'completed',
+            childStreamId: wrongChild,
+            model: 'terminal-model',
+            durationMs: 2_000,
+            totalCostUsd: 0.125,
+          },
+        },
+        {
+          id: 'task-cached',
+          role: 'workflowTask',
+          text: 'Saved result: Cached without child',
+          finalized: true,
+          task: {
+            id: 'cached',
+            label: 'Cached without child',
+            phase: 'Write',
+            status: 'cached',
+          },
+        },
+      ],
+    });
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [run, rootSlice],
+      [
+        exactChild,
+        workflowAgentSlice(exactChild, {
+          model: 'exact-live-model',
+          runStartedAt: Date.now() - 5_000,
+          cumulativeUsage: {
+            inputTokens: 100,
+            outputTokens: 512,
+            cost: 0.004,
+          },
         }),
-      },
-      // Phase-less rows head the list, as `groupWorkflowPhaseEntries` orders
-      // them — never between or after groups, where the header above would
-      // appear to own them.
-      { ...session(loose), label: 'unphased', parentId: run },
-      {
-        ...session(mapRetry),
-        label: 'writer-retry',
-        // Retained under the run, but promoted out of its current topology,
-        // so the projected view has no current parentId.
-        workflowPhase: freeFormPhase,
-      },
-      {
-        ...session(mapAttempt),
-        label: 'writer-attempt',
-        parentId: run,
-        workflowPhase: freeFormPhase,
-      },
-      {
-        ...session(reduce),
-        label: 'editor',
-        parentId: run,
-        workflowPhase: 'Reduce',
-      },
+      ],
+      [
+        wrongChild,
+        workflowAgentSlice(wrongChild, {
+          model: 'wrong-child-model',
+          cumulativeUsage: {
+            inputTokens: 100,
+            outputTokens: 999,
+            cost: 9,
+          },
+        }),
+      ],
+    ]);
+    const sessions: StreamView[] = [
+      { id: run, label: 'workflow-script', active: true, slice: rootSlice },
+      { ...session(exactChild), label: 'Duplicate', parentId: run },
+      { ...session(wrongChild), label: 'Duplicate', parentId: run },
     ];
 
     async function renderAtColumns(columns: number): Promise<string> {
       return renderSubagentList(
         {
           listRootStreamId: run,
+          listRootSlice: rootSlice,
           maxRows: 10,
+          selectedValue: workflowPhaseListValue('phase-map'),
           sessions,
+          streams,
         },
         columns,
-        { until: (frame) => frame.includes(freeFormPhase) },
+        { until: (frame) => frame.includes('research-workflow') },
       );
     }
 
-    const wideOutput = await renderAtColumns(60);
-    const narrowOutput = await renderAtColumns(59);
-    const wideLines = wideOutput.split('\n');
-    const wideMapHeader = wideLines.find((line) =>
-      line.includes(`${freeFormPhase} (1/2)`),
-    );
-    const wideMapRow = wideLines.find((line) => line.includes('writer-retry'));
+    const wideOutput = await renderAtColumns(100);
+    const narrowOutput = await renderAtColumns(99);
 
-    expect(wideMapHeader).toBeDefined();
-    expect(wideMapRow).toBeDefined();
-    expect(wideMapHeader?.indexOf('◆')).toBe(wideMapRow?.indexOf('●'));
-    expect(wideMapHeader?.trimEnd().endsWith('1/1')).toBe(true);
-    expect(wideMapHeader).not.toContain('(1/2) · 1/1');
-    expect(narrowOutput).toContain(`${freeFormPhase} (1/2) · 1/1`);
-    expect(narrowOutput).toContain('Reduce (2/2) · 0/1');
-    // Two attempt rows remain visible, but progress counts the one logical
-    // workflow call from the transcript rather than the retry rows.
-    expect(wideOutput.split(freeFormPhase)).toHaveLength(2);
-    expect(wideOutput).toContain('writer-retry');
-    expect(wideOutput).toContain('writer-attempt');
-    expect(wideOutput.indexOf('unphased')).toBeLessThan(
-      wideOutput.indexOf(`${freeFormPhase} (1/2)`),
+    expect(wideOutput).toContain('research-workflow · 2/4 done');
+    expect(wideOutput).toContain('Map (1/2) · 0/2');
+    expect(wideOutput).toContain('Duplicate · Planned');
+    expect(wideOutput).toContain('Duplicate · Running');
+    expect(wideOutput).toContain('exact-live-model');
+    expect(wideOutput).toContain('5s');
+    expect(wideOutput).toContain('↓512');
+    expect(wideOutput).toContain('$0.004');
+    expect(wideOutput).not.toContain('terminal-model');
+    expect(wideOutput).not.toContain('wrong-child-model');
+    expect(wideOutput).not.toContain('↓999');
+
+    expect(narrowOutput.indexOf('Map (1/2)')).toBeLessThan(
+      narrowOutput.indexOf('Duplicate · Planned'),
     );
-    expect(wideOutput.indexOf(`${freeFormPhase} (1/2)`)).toBeLessThan(
-      wideOutput.indexOf('writer-retry'),
+    expect(narrowOutput.indexOf('Duplicate · Running')).toBeLessThan(
+      narrowOutput.indexOf('Write (2/2)'),
     );
-    expect(wideOutput.indexOf('writer-retry')).toBeLessThan(
-      wideOutput.indexOf('writer-attempt'),
+    expect(narrowOutput).toContain('terminal-model');
+    expect(narrowOutput).toContain('2s');
+    expect(narrowOutput).toContain('↓999');
+    expect(narrowOutput).toContain('$0.125');
+    expect(narrowOutput).toContain('Cached without child · Saved result');
+    for (const [output, columns] of [
+      [wideOutput, 100],
+      [narrowOutput, 99],
+    ] as const) {
+      expect(output.split('\n')).toHaveLength(10);
+      expect(
+        output.split('\n').every((line) => textDisplayWidth(line) <= columns),
+      ).toBe(true);
+    }
+  });
+
+  it('collapses phase labels, synthesizes missing groups, and rejects ambiguous child facts', async () => {
+    const run = 'grouped-run' as StreamTabId;
+    const shared = 'shared-child' as StreamTabId;
+    const fallback = 'fallback-child' as StreamTabId;
+    const missing = 'missing-child' as StreamTabId;
+    const rootSlice = workflowAgentSlice(run, {
+      agent: 'grouped-workflow',
+      status: STREAM_PHASE.RUNNING,
+      entries: [
+        {
+          id: 'phase-map-a',
+          role: 'phase',
+          text: 'Map',
+          finalized: true,
+          phaseLabel: 'Map',
+          phaseIndex: 0,
+          phaseTotal: 2,
+        },
+        {
+          id: 'phase-map-b',
+          role: 'phase',
+          text: 'Map',
+          finalized: true,
+          phaseLabel: 'Map',
+        },
+        {
+          id: 'task-map',
+          role: 'workflowTask',
+          text: 'Planned: Audit',
+          finalized: false,
+          task: {
+            id: 'audit',
+            label: 'Audit',
+            phase: 'Map',
+            status: 'planned',
+          },
+        },
+        {
+          id: 'task-orphan',
+          role: 'workflowTask',
+          text: 'Planned: Synthesize',
+          finalized: false,
+          task: {
+            id: 'synthesize',
+            label: 'Synthesize',
+            phase: 'Synthesis',
+            status: 'planned',
+          },
+        },
+        {
+          id: 'task-loose',
+          role: 'workflowTask',
+          text: 'Planned: Loose',
+          finalized: false,
+          task: { id: 'loose', label: 'Loose', status: 'planned' },
+        },
+        ...['first', 'second'].map((id) => ({
+          id: `task-reused-${id}`,
+          role: 'workflowTask' as const,
+          text: `Running: Reused ${id}`,
+          finalized: false,
+          task: {
+            id: `reused-${id}`,
+            label: `Reused ${id}`,
+            status: 'running' as const,
+            childStreamId: shared,
+          },
+        })),
+        {
+          id: 'task-reused-terminal',
+          role: 'workflowTask',
+          text: 'Finished: Reused terminal',
+          finalized: true,
+          task: {
+            id: 'reused-terminal',
+            label: 'Reused terminal',
+            status: 'completed',
+            childStreamId: shared,
+            model: 'call-owned-model',
+            durationMs: 1_000,
+            totalCostUsd: 0.5,
+          },
+        },
+        {
+          id: 'task-missing',
+          role: 'workflowTask',
+          text: 'Running: Missing',
+          finalized: false,
+          task: {
+            id: 'missing',
+            label: 'Missing',
+            status: 'running',
+            childStreamId: missing,
+          },
+        },
+        {
+          id: 'task-fallback',
+          role: 'workflowTask',
+          text: 'Finished: Fallback',
+          finalized: true,
+          task: {
+            id: 'fallback',
+            label: 'Fallback',
+            status: 'completed',
+            childStreamId: fallback,
+          },
+        },
+      ],
+    });
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [run, rootSlice],
+      [
+        shared,
+        workflowAgentSlice(shared, {
+          model: 'ambiguous-model',
+          cumulativeUsage: {
+            inputTokens: 100,
+            outputTokens: 999,
+            cost: 9,
+          },
+        }),
+      ],
+      [
+        fallback,
+        workflowAgentSlice(fallback, {
+          model: 'fallback-model',
+          runStartedAt: Date.now() - 5_000,
+          cumulativeUsage: {
+            inputTokens: 100,
+            outputTokens: 321,
+            cost: 0.007,
+          },
+        }),
+      ],
+    ]);
+    const props: SubagentListProps = {
+      listRootStreamId: run,
+      listRootSlice: rootSlice,
+      maxRows: 15,
+      sessions: [],
+      streams,
+    };
+    const wideOutput = await renderSubagentList(
+      {
+        ...props,
+        selectedValue: workflowPhaseListValue('task-orphan'),
+      },
+      100,
+      { until: (frame) => frame.includes('Synthesize · Planned') },
     );
-    expect(wideOutput.indexOf('writer-attempt')).toBeLessThan(
-      wideOutput.indexOf('Reduce (2/2)'),
+    const narrowOutput = await renderSubagentList(
+      {
+        ...props,
+        selectedValue: workflowTaskListValue('task-fallback'),
+      },
+      99,
+      { until: (frame) => frame.includes('Fallback · Finished') },
     );
+
+    expect(wideOutput.match(/Map \(1\/2\) · 0\/1/g)).toHaveLength(1);
+    expect(wideOutput).toContain('Synthesis · 0/1');
+    expect(wideOutput).toContain('Unphased · 2/6');
+    expect(wideOutput).toContain('Synthesize · Planned');
+    expect(narrowOutput.match(/Map \(1\/2\) · 0\/1/g)).toHaveLength(1);
+    expect(narrowOutput).toContain('Synthesis · 0/1');
+    expect(narrowOutput).toContain('Unphased · 2/6');
+    expect(narrowOutput).toContain('Loose · Planned');
+
+    const reusedLine = narrowOutput
+      .split('\n')
+      .find((line) => line.includes('Reused first · Running'));
+    expect(reusedLine).not.toContain('ambiguous-model');
+    expect(reusedLine).not.toContain('↓999');
+    const reusedTerminalLine = narrowOutput
+      .split('\n')
+      .find((line) => line.includes('Reused terminal · Finished'));
+    expect(reusedTerminalLine).toContain('call-owned-model');
+    expect(reusedTerminalLine).toContain('1s');
+    expect(reusedTerminalLine).toContain('$0.500');
+    expect(reusedTerminalLine).not.toContain('ambiguous-model');
+    expect(reusedTerminalLine).not.toContain('↓999');
+    const missingLine = narrowOutput
+      .split('\n')
+      .find((line) => line.includes('Missing · Running'));
+    expect(missingLine).toBeDefined();
+    expect(missingLine).not.toContain('fallback-model');
+    const fallbackLine = narrowOutput
+      .split('\n')
+      .find((line) => line.includes('Fallback · Finished'));
+    expect(fallbackLine).toContain('fallback-model');
+    expect(fallbackLine).toContain('↓321');
+    expect(fallbackLine).toContain('$0.007');
+    expect(fallbackLine).not.toContain('5s');
   });
 
   // The right-aligned metadata column is the one row element `SubagentList`

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -12,6 +12,7 @@ import {
 } from '@cli/chat/tui/panes/ConversationPane';
 import {
   SubagentList,
+  workflowDashboardPanelItemCount,
   type SubagentListProps,
 } from '@cli/chat/tui/panes/SubagentList';
 import { textDisplayWidth } from '@cli/chat/tui/render/terminalText';
@@ -79,6 +80,66 @@ async function renderSubagentList(
 }
 
 describe('CLI child list display model', () => {
+  it('budgets a wide dashboard from the selected phase rather than all tasks', () => {
+    const tasks = [
+      ['a-1', 'A'],
+      ['a-2', 'A'],
+      ['b-1', 'B'],
+      ['b-2', 'B'],
+      ['b-3', 'B'],
+      ['b-4', 'B'],
+      ['b-5', 'B'],
+    ].map(([id, phase]) => ({
+      id: `task-${id}`,
+      role: 'workflowTask' as const,
+      text: `Planned: ${id}`,
+      finalized: false,
+      task: { id, label: id, phase, status: 'planned' as const },
+    }));
+    const root = workflowAgentSlice('budget-root', {
+      entries: [
+        {
+          id: 'phase-a',
+          role: 'phase',
+          text: 'A',
+          finalized: false,
+          phaseLabel: 'A',
+        },
+        ...tasks.slice(0, 2),
+        {
+          id: 'phase-b',
+          role: 'phase',
+          text: 'B',
+          finalized: false,
+          phaseLabel: 'B',
+        },
+        ...tasks.slice(2),
+      ],
+    });
+
+    expect(
+      workflowDashboardPanelItemCount(
+        root,
+        workflowPhaseListValue('phase-a'),
+        100,
+      ),
+    ).toBe(3);
+    expect(
+      workflowDashboardPanelItemCount(
+        root,
+        workflowTaskListValue('task-b-1'),
+        100,
+      ),
+    ).toBe(6);
+    expect(
+      workflowDashboardPanelItemCount(
+        root,
+        workflowPhaseListValue('phase-a'),
+        99,
+      ),
+    ).toBe(10);
+  });
+
   it('omits static input and context counts from the live workflow band', () => {
     const workflow = workflowAgentSlice('devise', {
       files: {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -709,6 +709,21 @@ describe('CLI TUI row allocation', () => {
       sessionPanelRows: 0,
       todosPlanRows: 0,
     });
+
+    expect(
+      allocateConversationBottomPanelRows({
+        maxRows: 10,
+        sessionCount: 3,
+        childListFocused: true,
+        minimumSessionPanelRows: 3,
+        todosPlanContentRows: 0,
+        transcriptRows: 2,
+      }),
+    ).toEqual({
+      bottomPanelRows: 0,
+      sessionPanelRows: 0,
+      todosPlanRows: 0,
+    });
   });
 
   it('keeps the child list collapsed until it receives focus', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2127,7 +2127,7 @@ describe('CLI transcript state', () => {
     expect(JSON.stringify(slice)).not.toContain('raw workflow model response');
   });
 
-  it('updates dormant workflow latest lines while keeping entries compact', () => {
+  it('updates dormant workflow summaries while retaining only dashboard rows', () => {
     activeStreamId.set(root);
     patchStream(child1, (slice) => ({
       ...slice,
@@ -2173,7 +2173,13 @@ describe('CLI transcript state', () => {
 
     expect(streams.get().get(child1)).toMatchObject({
       latestLine: 'Checking dormant lemmas',
-      entries: [],
+      entries: [
+        {
+          id: 'dormant-review-phase',
+          role: 'phase',
+          phaseLabel: 'Checking dormant lemmas',
+        },
+      ],
     });
 
     logger.error('Dormant audit failed', {
@@ -2184,9 +2190,104 @@ describe('CLI transcript state', () => {
     const slice = streams.get().get(child1);
     expect(slice).toMatchObject({
       latestLine: 'Dormant audit failed',
-      entries: [],
+      entries: [
+        {
+          id: 'dormant-review-phase',
+          role: 'phase',
+        },
+      ],
     });
     expect(JSON.stringify(slice)).not.toContain('raw dormant workflow prose');
+  });
+
+  it('bounds dormant workflow dashboard rows while preserving source order', () => {
+    activeStreamId.set(root);
+    patchStream(child1, (slice) => ({
+      ...slice,
+      category: AgentCategory.Workflow,
+      entries: [
+        {
+          id: 'synthetic-compact-workflow-error',
+          role: 'error',
+          text: 'Synthetic compact workflow error',
+          finalized: true,
+          synthetic: true,
+          syntheticKind: 'local',
+          syntheticAfterSeq: 0,
+          syntheticAfterSettlementSeqNo: 0,
+        },
+      ],
+    }));
+    const logger = runTrace(child1);
+    logger.openStage('Old phase', {
+      id: 'compact-old-phase',
+      kind: 'phase',
+    });
+    for (let index = 0; index < 2_002; index += 1) {
+      logger.info(`Task ${index}`, {
+        messageType: MESSAGE_TYPES.WORKFLOW_TASK,
+        data: {
+          id: `task-${index}`,
+          label: `Task ${index}`,
+          phase: 'Old phase',
+          status: 'cached',
+        },
+      });
+      if (index === 1_000) {
+        logger.info('Compact operational prose', {
+          messageType: MESSAGE_TYPES.DEFAULT,
+        });
+        logger.info('Compact tool activity', {
+          messageType: MESSAGE_TYPES.TOOL_USE,
+          data: {
+            toolName: 'grep',
+            input: { pattern: 'boundary' },
+            output: 'done',
+            summary: 'Compact operational tool summary',
+            status: 'completed',
+          },
+        });
+        logger.error('Compact operational failure', {
+          messageType: MESSAGE_TYPES.ERROR,
+        });
+      }
+    }
+    logger.openStage('New phase', {
+      id: 'compact-new-phase',
+      kind: 'phase',
+    });
+
+    syncStreamLog(child1);
+
+    const entries = streamEntries(child1);
+    const dashboardEntries = entries.filter((entry) => !entry.synthetic);
+    expect(dashboardEntries).toHaveLength(2_000);
+    expect(dashboardEntries[0]).toMatchObject({
+      role: 'workflowTask',
+      task: { id: 'task-3' },
+    });
+    expect(dashboardEntries.at(-2)).toMatchObject({
+      role: 'workflowTask',
+      task: { id: 'task-2001' },
+    });
+    expect(dashboardEntries.at(-1)).toMatchObject({
+      id: 'compact-new-phase',
+      role: 'phase',
+      phaseLabel: 'New phase',
+    });
+    expect(
+      dashboardEntries
+        .filter((entry) => entry.role === 'workflowTask')
+        .map((entry) => entry.task.id),
+    ).toEqual(Array.from({ length: 1_999 }, (_, index) => `task-${index + 3}`));
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        id: 'synthetic-compact-workflow-error',
+        synthetic: true,
+      }),
+    );
+    expect(JSON.stringify(entries)).not.toContain('Compact operational');
+    expect(JSON.stringify(entries)).not.toContain('compact-old-phase');
   });
 
   it('keeps the runtime description while the latest line follows the transcript', () => {
@@ -3090,6 +3191,7 @@ describe('subscribeRuntimeHost run facts', () => {
       });
 
       expect(streams.get().get(root)).toMatchObject({
+        agent: 'search',
         model: 'kimi26T',
         category: AgentCategory.ToolUse,
         files: {


### PR DESCRIPTION
## Summary

Add a workflow-native dashboard to the CLI TUI so workflow phase and task status uses the available terminal space instead of being compressed into the existing child list. Narrow terminals render one source-ordered pane; terminals at 100 columns and wider render independently navigable phase and task panes.

The dashboard shows canonical workflow status plus exact-child live model, elapsed time, generated tokens, and cost. Task detail navigation keeps the existing hierarchical Escape behavior from #9595.

Closes #9589.

## Issue acceptance gates

- Derives phase/task rows from canonical root workflow transcript entries rather than persisting a second dashboard store.
- Joins task detail and live metadata only through a unique, existing `childStreamId`; ambiguous or missing child IDs remain inert.
- Retains bounded canonical phase/task rows while the workflow root is inactive, including zero-descendant planned tasks and completed rows.
- Supports synthesized and unphased groups while collapsing duplicate canonical phase headings.
- Renders one-pane narrow and two-pane wide layouts with clamped keyboard navigation and stable screen-reader order.
- Keeps active-stream selection synchronized and preserves hierarchical Escape return semantics.
- Uses terminal workflow-call metadata first, with child metadata fallback only when terminal metadata is absent.

## Single source of truth

`StreamSlice.entries` on the workflow root remains the authority for canonical phase/task lifecycle. Existing child `StreamSlice` facts supply live metadata through exact unique `WorkflowCallProgress.childStreamId` joins. `ChildListSelectionState` remains the only dashboard/list cursor and focus state.

## Duplication and abstraction budget

No persisted dashboard view model or independently mutable dashboard store was added. Rendering derives rows directly from existing stream state. A per-render child/task index centralizes the uniqueness invariant and avoids repeated scans without introducing a new state authority.

## Net elements (R6)

n/a — this is a feature PR, not a refactor/simplify/consolidate/dedupe/extract PR. It modifies 13 existing production/test files and adds no files.

## Consumer counts (R8)

n/a — no emit path or existing export was deleted or rerouted.

## Host impact

Extension: None.

Desktop: None.

CLI: Adds the responsive workflow dashboard, canonical row retention, task-detail selection synchronization, and live/terminal task metadata display.

## Scheduled refactoring

None.

## Validation

- `npm run format` and `npm run format:check`
- 14 focused CLI suites: 330 tests passed
- `npm run lint`
- `npm run typecheck:cli`
- `npm run typecheck:test-kernel`
- `corepack pnpm --filter @texra-ai/cli build`
  - CLI typecheck
  - architecture check
  - React compiler smoke check (`react-compiler smoke: ok`)
  - trace-viewer assets and CLI bundle/resources/docs build
- `git diff --check`
- Pre-push changed-file lint hook
- post-review CLI and test-kernel type checks
- post-review dashboard, layout, and Escape suites: 200 tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TUI focus, Escape routing, and transcript compaction for workflow streams; incorrect unique-child joins could mis-route navigation or show wrong metadata, but ambiguous IDs are explicitly inert.
> 
> **Overview**
> Replaces the child-session list with a **workflow-native dashboard** when the list root is a workflow stream that has canonical `workflowTask` entries. Rows come from root `StreamSlice.entries` (phases and tasks), not a separate store.
> 
> **Layout:** Below **100 columns**, one source-ordered list mixes phase headers and tasks. At **100+ columns**, side-by-side phase and task `Select` panes support left/right navigation between group and tasks.
> 
> **Selection and focus:** New `workflowPhase:` / `workflowTask:` list values drive highlighting; entering a task with a **unique** `childStreamId` focuses that stream. Duplicate or missing child IDs leave Enter and kill/skip/retry inert. **Escape** from a task child returns to the workflow root and re-opens the dashboard focus when appropriate.
> 
> **Compaction:** Inactive workflow streams keep bounded phase/task rows (cap 2000) plus synthetic operational rows instead of dropping all non-synthetic entries when the child detail is focused.
> 
> **Metadata:** Task rows show status, terminal call fields (model, duration, cost) when finished, otherwise live child-stream stats when the join is unambiguous. `StreamSlice.agent` is populated from `run.config` for dashboard headings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6cc4f5dc732094c23003944f5a50b3795dff73a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->