### PR TITLE
fix(cli): expand Windows workflow globs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,9 +164,9 @@ jobs:
       - name: Check guidance file references resolve
         run: node scripts/check-guidance-refs.mjs
 
-  # TODO(windows-ci): add windows-latest after #9409 is complete. The latest
-  # full-matrix run in #9503 found 70 failures across CLI, desktop, storage,
-  # tools, and path handling, so Windows cannot yet be a gating runner.
+  # TODO(windows-ci): restore the full windows-latest matrix after its remaining
+  # failures are fixed. The focused job below keeps CLI input path handling
+  # covered on Windows without running unrelated failing suites.
   test:
     name: kernel tests (linux, shard ${{ matrix.shard }}/2)
     needs: changes
@@ -203,6 +203,35 @@ jobs:
       # shards exist because a single runner can't go wider than that.
       - name: Kernel tests
         run: pnpm run test --maxWorkers=2 --shard=${{ matrix.shard }}/2
+
+  cli-workflow-inputs-windows:
+    name: CLI workflow input paths (Windows)
+    needs: changes
+    if: needs.changes.outputs.code == 'true' && github.event_name != 'schedule'
+    runs-on: windows-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test CLI workflow input paths
+        run: pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts
 
   build:
     name: build artifacts (linux)
@@ -407,6 +436,7 @@ jobs:
       - checks
       - guidance-refs
       - test
+      - cli-workflow-inputs-windows
       - build
       - webview-smoke
       - runtime-validation
@@ -416,9 +446,10 @@ jobs:
     steps:
       - name: Require validation jobs success
         run: |
-          # On code PRs the checks/test/build/webview-smoke jobs gate; on
-          # docs-only PRs they are skipped and the lightweight docs build gates
-          # instead; on the nightly schedule only runtime-validation runs.
+          # On code PRs the checks/test/build/webview-smoke and focused Windows
+          # jobs gate; on docs-only PRs they are skipped and the lightweight docs
+          # build gates instead; on the nightly schedule only runtime-validation
+          # runs.
           # Require whichever ran.
           #
           # `changes` must itself succeed (never skip): if it fails, every
@@ -438,6 +469,7 @@ jobs:
           for result in \
             'checks:${{ needs.checks.result }}' \
             'test:${{ needs.test.result }}' \
+            'cli-workflow-inputs-windows:${{ needs.cli-workflow-inputs-windows.result }}' \
             'build:${{ needs.build.result }}' \
             'webview-smoke:${{ needs.webview-smoke.result }}' \
             'runtime-validation:${{ needs.runtime-validation.result }}' \

--- a/packages/cli/src/runtime/workflowInputs.ts
+++ b/packages/cli/src/runtime/workflowInputs.ts
@@ -26,6 +26,12 @@ const STDIN_TEMP_PREFIX = 'texra-stdin-';
 const STDIN_TEMP_DIR_PATTERN = /^texra-stdin-\d+-[A-Za-z0-9]{6}$/;
 export const STDIN_WORKFLOW_INPUT_BASENAME = 'stdin.tex';
 
+export function workflowInputGlobOptionsForTests(
+  platform: NodeJS.Platform,
+): Readonly<{ windowsPathsNoEscape: boolean }> {
+  return { windowsPathsNoEscape: platform === 'win32' };
+}
+
 function resolveAgainstCwd(candidate: string, cwd: string): string {
   return path.isAbsolute(candidate)
     ? path.resolve(candidate)
@@ -210,15 +216,17 @@ async function expandWorkflowInputSpec(
         normalizeCliInputPathForRun(match, cwd, flagLabel, options),
       );
 
-  if (hasMagic(trimmed)) {
+  const globOptions = workflowInputGlobOptionsForTests(process.platform);
+  if (hasMagic(trimmed, { magicalBraces: true, ...globOptions })) {
     const isAbsolute = path.isAbsolute(trimmed);
-    const matches = await glob(trimmed.replaceAll('\\', '/'), {
+    const matches = await glob(trimmed, {
       cwd: isAbsolute ? undefined : cwd,
       absolute: isAbsolute,
       nodir: true,
+      ...globOptions,
     });
     if (matches.length === 0) {
-      throw new CliUsageError(`No input files matched: ${trimmed}`);
+      throw new CliUsageError(`${flagLabel}: no files matched: ${trimmed}`);
     }
     return normalizeMatches(matches);
   }

--- a/packages/cli/src/runtime/workflowInputs.ts
+++ b/packages/cli/src/runtime/workflowInputs.ts
@@ -26,10 +26,13 @@ const STDIN_TEMP_PREFIX = 'texra-stdin-';
 const STDIN_TEMP_DIR_PATTERN = /^texra-stdin-\d+-[A-Za-z0-9]{6}$/;
 export const STDIN_WORKFLOW_INPUT_BASENAME = 'stdin.tex';
 
-export function workflowInputGlobOptionsForTests(
+export function workflowInputGlobOptions(
   platform: NodeJS.Platform,
-): Readonly<{ windowsPathsNoEscape: boolean }> {
-  return { windowsPathsNoEscape: platform === 'win32' };
+): Readonly<{ magicalBraces: true; windowsPathsNoEscape: boolean }> {
+  return {
+    magicalBraces: true,
+    windowsPathsNoEscape: platform === 'win32',
+  };
 }
 
 function resolveAgainstCwd(candidate: string, cwd: string): string {
@@ -216,8 +219,20 @@ async function expandWorkflowInputSpec(
         normalizeCliInputPathForRun(match, cwd, flagLabel, options),
       );
 
-  const globOptions = workflowInputGlobOptionsForTests(process.platform);
-  if (hasMagic(trimmed, { magicalBraces: true, ...globOptions })) {
+  const absolutePath = resolveAgainstCwd(trimmed, cwd);
+  // Prefer an exact existing path even when its valid filename contains glob
+  // syntax. Windows glob mode deliberately has no backslash escape channel.
+  let stats: Stats | null = null;
+  try {
+    stats = await fs.stat(absolutePath);
+  } catch (error: unknown) {
+    if (!isFileNotFoundError(error) && !isNotADirectoryError(error)) {
+      throw error;
+    }
+  }
+
+  const globOptions = workflowInputGlobOptions(process.platform);
+  if (!stats && hasMagic(trimmed, globOptions)) {
     const isAbsolute = path.isAbsolute(trimmed);
     const matches = await glob(trimmed, {
       cwd: isAbsolute ? undefined : cwd,
@@ -231,18 +246,6 @@ async function expandWorkflowInputSpec(
     return normalizeMatches(matches);
   }
 
-  const absolutePath = resolveAgainstCwd(trimmed, cwd);
-  // Only treat true missing-path errors as "file not found"; other failures
-  // (EACCES, EIO, ...) are environment problems, not Usage errors, and must
-  // propagate so the user sees the real cause.
-  let stats: Stats | null = null;
-  try {
-    stats = await fs.stat(absolutePath);
-  } catch (error: unknown) {
-    if (!isFileNotFoundError(error) && !isNotADirectoryError(error)) {
-      throw error;
-    }
-  }
   if (stats?.isDirectory()) {
     // Validate the directory itself before globbing its contents.
     void normalizeCliInputPathForRun(trimmed, cwd, flagLabel, options);

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -3,6 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { hasMagic } from 'glob';
 import stripAnsi from 'strip-ansi';
 
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
@@ -37,6 +38,7 @@ import {
   expandWorkflowInputSpecs,
   hasMixedStdinWorkflowInputSpecs,
   isMaterializedStdinWorkflowInputPath,
+  workflowInputGlobOptionsForTests,
 } from '@cli/runtime/workflowInputs';
 import {
   resolveWorkflowOutput,
@@ -775,6 +777,74 @@ describe('CLI root argument routing', () => {
       await expect(
         expandWorkflowInputSpecs([path.join(root, '*.bib')], root, '--context'),
       ).resolves.toEqual(['a.bib', 'b.bib']);
+    });
+  });
+
+  it('selects platform-specific backslash glob semantics', () => {
+    const pattern = String.raw`refs\*.bib`;
+
+    expect(hasMagic(pattern, workflowInputGlobOptionsForTests('win32'))).toBe(
+      true,
+    );
+    expect(hasMagic(pattern, workflowInputGlobOptionsForTests('linux'))).toBe(
+      false,
+    );
+  });
+
+  it('expands host-native globs for both --input and --context', async () => {
+    await withTempDir('texra-cli-native-glob-', async (root) => {
+      await fs.mkdir(path.join(root, 'refs'));
+      await fs.writeFile(path.join(root, 'refs', 'zeta.bib'), 'zeta');
+      await fs.writeFile(path.join(root, 'refs', 'alpha.bib'), 'alpha');
+      await fs.writeFile(path.join(root, 'refs', 'notes.md'), 'notes');
+      const pattern = path.join('refs', '*.bib');
+
+      await expect(
+        expandRunInputs([pattern], [pattern], root),
+      ).resolves.toEqual({
+        inputFiles: ['refs/alpha.bib', 'refs/zeta.bib'],
+        contextFiles: ['refs/alpha.bib', 'refs/zeta.bib'],
+      });
+    });
+  });
+
+  (process.platform === 'win32' ? it.skip : it)(
+    'preserves POSIX glob escapes for literal metacharacters',
+    async () => {
+      await withTempDir('texra-cli-escaped-glob-', async (root) => {
+        await fs.mkdir(path.join(root, 'refs'));
+        await fs.writeFile(path.join(root, 'refs', '[ab]-one.bib'), 'literal');
+        await fs.writeFile(path.join(root, 'refs', 'a-one.bib'), 'class match');
+
+        await expect(
+          expandWorkflowInputSpecs([String.raw`refs/\[ab]-*.bib`], root),
+        ).resolves.toEqual(['refs/[ab]-one.bib']);
+      });
+    },
+  );
+
+  it('detects brace-only workflow globs', async () => {
+    await withTempDir('texra-cli-brace-glob-', async (root) => {
+      await fs.mkdir(path.join(root, 'refs'));
+      await fs.writeFile(path.join(root, 'refs', 'beta.bib'), 'beta');
+      await fs.writeFile(path.join(root, 'refs', 'alpha.bib'), 'alpha');
+
+      await expect(
+        expandWorkflowInputSpecs(['refs/{alpha,beta}.bib'], root),
+      ).resolves.toEqual(['refs/alpha.bib', 'refs/beta.bib']);
+    });
+  });
+
+  it('attributes unmatched globs to the original input or context flag', async () => {
+    await withTempDir('texra-cli-unmatched-glob-', async (root) => {
+      const pattern = path.join('missing refs', '*.bib');
+
+      await expect(
+        expandWorkflowInputSpecs([`  ${pattern}  `], root),
+      ).rejects.toThrow(`--input: no files matched: ${pattern}`);
+      await expect(
+        expandWorkflowInputSpecs([`  ${pattern}  `], root, '--context'),
+      ).rejects.toThrow(`--context: no files matched: ${pattern}`);
     });
   });
 

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -816,6 +816,22 @@ describe('CLI root argument routing', () => {
     });
   });
 
+  (process.platform === 'win32' ? it : it.skip)(
+    'expands an absolute drive-letter glob',
+    async () => {
+      await withTempDir('texra-cli-drive-glob-', async (root) => {
+        await fs.mkdir(path.join(root, 'refs'));
+        await fs.writeFile(path.join(root, 'refs', 'paper.bib'), 'paper');
+        const pattern = path.join(root, 'refs', '*.bib');
+
+        expect(pattern).toMatch(/^[A-Za-z]:\\/);
+        await expect(
+          expandWorkflowInputSpecs([pattern], root),
+        ).resolves.toEqual(['refs/paper.bib']);
+      });
+    },
+  );
+
   (process.platform === 'win32' ? it.skip : it)(
     'preserves POSIX glob escapes for literal metacharacters',
     async () => {

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -38,7 +38,7 @@ import {
   expandWorkflowInputSpecs,
   hasMixedStdinWorkflowInputSpecs,
   isMaterializedStdinWorkflowInputPath,
-  workflowInputGlobOptionsForTests,
+  workflowInputGlobOptions,
 } from '@cli/runtime/workflowInputs';
 import {
   resolveWorkflowOutput,
@@ -783,12 +783,20 @@ describe('CLI root argument routing', () => {
   it('selects platform-specific backslash glob semantics', () => {
     const pattern = String.raw`refs\*.bib`;
 
-    expect(hasMagic(pattern, workflowInputGlobOptionsForTests('win32'))).toBe(
-      true,
-    );
-    expect(hasMagic(pattern, workflowInputGlobOptionsForTests('linux'))).toBe(
-      false,
-    );
+    expect(hasMagic(pattern, workflowInputGlobOptions('win32'))).toBe(true);
+    expect(hasMagic(pattern, workflowInputGlobOptions('linux'))).toBe(false);
+  });
+
+  it('prefers an exact filename containing glob syntax', async () => {
+    await withTempDir('texra-cli-literal-magic-', async (root) => {
+      await fs.mkdir(path.join(root, 'refs'));
+      await fs.writeFile(path.join(root, 'refs', '[ab].bib'), 'literal');
+      await fs.writeFile(path.join(root, 'refs', 'a.bib'), 'glob match');
+
+      await expect(
+        expandWorkflowInputSpecs([path.join('refs', '[ab].bib')], root),
+      ).resolves.toEqual(['refs/[ab].bib']);
+    });
   });
 
   it('expands host-native globs for both --input and --context', async () => {


### PR DESCRIPTION
## Summary

Fix workflow `--input` and `--context` glob expansion on Windows. Backslash-separated patterns such as `refs\*.bib` were classified as literal paths because glob parsing treated the backslash as an escape.

- use `windowsPathsNoEscape` consistently for magic detection and expansion on Windows
- preserve POSIX glob escaping on macOS and Linux
- detect brace-only patterns consistently with expansion
- attribute no-match diagnostics to the correct CLI flag
- add portable platform-semantics coverage plus end-to-end input/context tests

## Issue scope

This is one bounded cluster from #9409. It does not claim to re-enable the full Windows matrix; the remaining Windows failures are independent path, fake-filesystem, and environment clusters.

## Verification

- `src/test-kernel/cli/CliRootArgs.vitest.mts`: 109 passed
- `npm run typecheck:cli`
- `npm run typecheck:test-kernel`
- scoped ESLint and Prettier checks
- `git diff --check`
- post-review exact-path, glob-option, CLI, and test-kernel checks

Refs #9409

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to CLI workflow path/glob expansion and CI; no auth, persistence, or security-sensitive paths. Behavior change is intentional for Windows users and tighter error messages on all platforms.
> 
> **Overview**
> Fixes **`--input` / `--context` glob expansion on Windows** so backslash-separated patterns (e.g. `refs\*.bib`) are treated as globs instead of literal paths.
> 
> **`workflowInputs.ts`** adds `workflowInputGlobOptions` (`magicalBraces`, `windowsPathsNoEscape` on win32) and uses it for both `hasMagic` and `glob`. Expansion **stats the path first** and prefers an existing file whose name contains glob metacharacters; unmatched patterns get errors prefixed with **`--input`** or **`--context`**. Backslash-to-slash normalization before globbing is removed so host-native path semantics apply.
> 
> **CI** adds a gated **`cli-workflow-inputs-windows`** job that runs `CliRootArgs.vitest.mts` on `windows-latest`, wired into **`validate-status`**.
> 
> **Tests** cover platform backslash semantics, literal-vs-glob precedence, brace globs, flag attribution, and platform-specific cases (drive-letter globs on Windows, POSIX escapes elsewhere).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f19803f8209c28b543b7af3ef248dc57ccb0a9e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->