### PR TITLE
fix(cli): preserve ambiguous workflow selection

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -406,6 +406,7 @@ export function App(props: AppProps): React.JSX.Element {
     if (workflowDashboardRoot) {
       if (activeStreamId === workflowDashboardRoot.streamId) return;
       const matchingTask = workflowChildTaskIndex.get(activeStreamId);
+      if (matchingTask === null) return;
       if (matchingTask) {
         dispatchChildListSelection({
           kind: 'highlight',

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.mts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.mts
@@ -2,6 +2,7 @@ import '@test/support/defaultSessionTestSetup';
 
 import { setTimeout as sleep } from 'node:timers/promises';
 
+import stripAnsi from 'strip-ansi';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { defaultSession } from '@agent/runtime/SessionHandle';
@@ -304,6 +305,93 @@ describe('App foreground Escape ownership', () => {
     } finally {
       instance.unmount();
       runTrace.dispose();
+    }
+  });
+
+  it('preserves workflow selection when tasks share a child stream', async () => {
+    seedRootStream();
+    setStreamStatusInCliState({
+      streamId: CHILD,
+      status: STREAM_PHASE.RUNNING,
+    });
+    applySubagentRoster(ROOT, [
+      {
+        kind: 'subagent',
+        executionId: 'shared-child-execution',
+        agentName: 'shared-child',
+        childStreamId: CHILD,
+        status: STREAM_PHASE.RUNNING,
+      },
+    ]);
+    setParentStream(CHILD, ROOT);
+    patchStream(ROOT, (slice) => ({
+      ...slice,
+      agent: 'ambiguous-workflow',
+      category: AgentCategory.Workflow,
+      entries: ['first', 'second'].map((id) => ({
+        id: `task-${id}`,
+        role: 'workflowTask' as const,
+        text: `Running: ${id}`,
+        finalized: false,
+        task: {
+          id,
+          label: id,
+          status: 'running' as const,
+          childStreamId: CHILD,
+        },
+      })),
+    }));
+    const onInterruptStream = vi.fn();
+    const { ink, React } = await loadInk();
+    const { instance, stdin, stdout } = renderInteractive(
+      ink,
+      React.createElement(App, appProps(onInterruptStream)),
+      { columns: 100, debug: true, rows: 30 },
+    );
+    const currentFrame = (): string =>
+      stripAnsi(stdout.writes.findLast((write) => write.length > 0) ?? '');
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('\t');
+      await waitFor(() =>
+        currentFrame().includes('ambiguous-workflow · 0/2 done'),
+      );
+      stdin.write('\r');
+      await waitFor(() =>
+        currentFrame()
+          .split('\n')
+          .some(
+            (line) =>
+              line.includes('first · Running') && line.includes(POINTER),
+          ),
+      );
+      stdin.write('\u001b[B');
+      await waitFor(() =>
+        currentFrame()
+          .split('\n')
+          .some(
+            (line) =>
+              line.includes('second · Running') && line.includes(POINTER),
+          ),
+      );
+
+      focusStream(CHILD);
+      await waitFor(() => activeStreamId.get() === CHILD);
+      focusStream(ROOT);
+      await waitFor(() => activeStreamId.get() === ROOT);
+      await waitFor(() =>
+        currentFrame()
+          .split('\n')
+          .some(
+            (line) =>
+              line.includes('second · Running') && line.includes(POINTER),
+          ),
+      );
+
+      expect(onInterruptStream).not.toHaveBeenCalled();
+    } finally {
+      instance.unmount();
     }
   });
 


### PR DESCRIPTION
## Summary

When two workflow tasks refer to the same child stream, returning from that child now leaves the current workflow-task selection unchanged. The ambiguous join is inert instead of being treated as a missing join that clears the dashboard cursor.

This is a follow-up to #9615, which was merged while its final review was still reporting this defect.

## Single source of truth

`workflowChildTaskIndex` already represents three states: a unique task, no task, or `null` for an ambiguous child. The App synchronization effect now respects that existing distinction; no second index or selection authority is added.

## Scope and abstraction budget

- production change: one guard in the existing synchronization effect;
- no helper, protocol, schema, or persisted state;
- one rendered behavioral regression at the App boundary because the defect depends on the interaction among child focus, Escape routing, and dashboard selection.

## Host impact

- CLI/TUI: ambiguous shared-child joins preserve the selected workflow task;
- extension and desktop: unchanged.

## Validation

- `AppEscapeRouting.vitest.mts`: 27 passed;
- CLI typecheck;
- test-kernel typecheck;
- targeted ESLint;
- post-review rendered regression confirms the ambiguous index branch;
- Prettier and `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single early-return guard in TUI selection sync; behavior change is limited to ambiguous shared-child workflow joins.
> 
> **Overview**
> When multiple workflow tasks point at the **same child stream**, returning focus to the workflow dashboard no longer resets the highlighted task row.
> 
> The stream-focus `useLayoutEffect` in `App` now treats an **ambiguous** `workflowChildTaskIndex` lookup (`null`) as a no-op instead of running `syncActiveStream`, which had been clearing manual selection. Unique and missing mappings behave as before.
> 
> A rendered **App** regression covers Tab into the dashboard, arrow to the second task, drill into the shared child, and focus back to root—the pointer stays on **second**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0366561651107b8219fe9b5dec1a99e80d75634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->