### PR TITLE
docs: prepare 0.40.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to this project will be documented in this file.
   been removed with explicit maintainer approval. Streamed NDJSON
   progress records are unchanged.
 
+#### Features
+
+- **Workflow runs have a phase-and-task dashboard** — the terminal shows
+  canonical workflow progress, task status, model, elapsed time, generated
+  tokens, and cost. Wide terminals provide separate navigable phase and task
+  panes, while narrow terminals retain source order in one pane.
+
 #### Bug Fixes
 
 - **Automatic CLI runs stop after their model retry limit** — automatic
@@ -25,7 +32,7 @@ All notable changes to this project will be documented in this file.
 
 ### Extension (VS Code) and Desktop
 
-#### Improvements
+#### Features
 
 - **The follow-up composer is larger and resizable** — it starts at six lines
   and can be resized vertically for longer instructions.
@@ -52,6 +59,8 @@ All notable changes to this project will be documented in this file.
   defaults without importing older host-specific settings. Skills, telemetry,
   tool approvals, and LaTeX replacement rules now have native controls in the
   TeXRA settings view.
+- **OpenAI Fast models use the priority service tier** — their requests now ask
+  OpenAI for priority processing instead of the standard service tier.
 - **Workflow scripts are available to the software-engineering and Lean team
   leads** — after enabling Workflow Script in the Tools panel, these teams can
   run predetermined parallel and sequential agent pipelines that resume safely
@@ -86,11 +95,6 @@ All notable changes to this project will be documented in this file.
   lines** — callers of `/executions/{id}/conversation` should replace
   `view_range` with `offset` and `limit`. Responses report the returned message
   interval and next offset.
-
-#### Improvements
-
-- **OpenAI Fast models use the priority service tier** — their requests now ask
-  OpenAI for priority processing instead of the standard service tier.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.40.0] - 2026-08-02
 
 ### CLI
 
@@ -18,6 +18,17 @@ All notable changes to this project will be documented in this file.
 - **Automatic CLI runs stop after their model retry limit** — automatic
   approval mode no longer restarts another full retry sequence when every
   configured attempt has failed.
+- **Escape backs out of nested agents one level at a time** — leaving a child
+  now returns to its immediate parent before Escape can interrupt the root run.
+- **Background workflow task lists start collapsed** — background plans take up
+  less terminal space until their task details are needed.
+
+### Extension (VS Code) and Desktop
+
+#### Improvements
+
+- **The follow-up composer is larger and resizable** — it starts at six lines
+  and can be resized vertically for longer instructions.
 
 ### Desktop
 
@@ -76,6 +87,11 @@ All notable changes to this project will be documented in this file.
   `view_range` with `offset` and `limit`. Responses report the returned message
   interval and next offset.
 
+#### Improvements
+
+- **OpenAI Fast models use the priority service tier** — their requests now ask
+  OpenAI for priority processing instead of the standard service tier.
+
 #### Bug Fixes
 
 - **Failed latexdiff builds no longer flood the workflow log** — the visible
@@ -84,6 +100,9 @@ All notable changes to this project will be documented in this file.
 - **Google models handle prompts and tool-enabled tasks reliably** — requests
   no longer fail when a prompt has no prefix or when complex tool sets are
   enabled.
+- **Google background interactions resume across transient retries** — TeXRA
+  reconnects to the existing interaction instead of losing its in-progress
+  response.
 - **OpenAI background responses keep one polling deadline across retries** —
   reconnecting to the same response no longer restarts its three-hour polling
   window. Once that window expires, TeXRA stops automatic retries and permits
@@ -92,6 +111,9 @@ All notable changes to this project will be documented in this file.
   accepts zero to five additional attempts after the initial request. Invalid
   stored values fall back to the documented default instead of creating an
   arbitrarily long automatic retry sequence.
+- **Stop requests are not lost between runtime stages** — interrupting as one
+  stage finishes now also cancels the next model or tool operation instead of
+  allowing the run to continue.
 - **Runs that overflow the model context window say so** — instead of a generic
   failure message, the run now reports that the conversation exceeds the
   model's context window and suggests starting a new session or reducing
@@ -111,6 +133,12 @@ All notable changes to this project will be documented in this file.
   transcript history loaded only to repair stale run state is released again
   after the repair is saved, instead of remaining in memory for the rest of
   the session.
+- **Workspace switches apply settings and storage together** — a session can no
+  longer observe the new workspace with stale settings or storage from the
+  previous one during the transition.
+- **Snapshot save failures surface without losing queued updates** — writes stop
+  after bounded retries and report the failure while preserving pending updates
+  and their order for recovery.
 - **Install in Terminal now offers a command your machine can run** — the Codex
   and Claude Code cards offer the Homebrew command where Homebrew is present
   and Claude Code's Windows installer on Windows, instead of a global npm


### PR DESCRIPTION
## Summary

Prepare the release notes for TeXRA 0.40.0 from merged changes since 0.39.11.

- finalize the 0.40.0 heading and release date
- retain the existing breaking and migration guidance
- add missing user-visible CLI navigation and workflow-density fixes
- document the larger resizable follow-up composer
- cover merged provider reliability, interrupt, workspace-transition, and snapshot durability fixes

Open work such as #9616 is intentionally excluded. The merged workflow dashboard from #9615 is included.

## Verification

- every added claim was checked against merged commit/PR history
- `prettier --check CHANGELOG.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to CHANGELOG.md; no runtime or build behavior is modified.
> 
> **Overview**
> **Finalizes user-facing release notes for TeXRA 0.40.0** by replacing the `[Unreleased]` section with a dated **`[0.40.0] - 2026-08-02`** heading and expanding the changelog with items that were missing from the draft.
> 
> New or newly documented highlights include a **CLI workflow phase-and-task dashboard**, **Escape backing out of nested agents one level at a time**, **collapsed background workflow task lists**, a **larger resizable follow-up composer** (extension/desktop), **OpenAI Fast models using the priority service tier**, and shared fixes for **Google background interaction resume**, **stop requests across runtime stages**, **atomic workspace switches**, and **snapshot save failure handling** (queued updates preserved).
> 
> Existing **breaking-change** and migration bullets (CLI JSON `outcome`, desktop Codex/Claude CLI bundling, shared settings, agent schema, and related API shifts) are kept as-is; open work called out in the PR (e.g. #9615, #9616) is intentionally omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0530b582bb973251baba92bc76944a4496365ea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->