### PR TITLE
refactor(storage): remove taskRuns legacy run-dir probing

### DIFF
--- a/src/common/storage/storageLayout.ts
+++ b/src/common/storage/storageLayout.ts
@@ -10,7 +10,6 @@ export const WORKSPACE_STORAGE_LAYOUT = Object.freeze({
   runs: 'executions',
   executionLeases: 'executionLeases',
   executionLocks: 'executionLocks',
-  legacyRuns: 'taskRuns',
   streamData: 'streamData',
   streamLogs: 'streamLogs',
   original: 'original',

--- a/src/housekeeping/runDirOps.ts
+++ b/src/housekeeping/runDirOps.ts
@@ -71,8 +71,7 @@ export async function runPackRunDir(
 
 /**
  * Delete a run's runDir. Irreversible. Used when the user discards a run
- * from the progress-view toolbar. Uses `findRunDir` so the
- * legacy `taskRuns/` location is cleaned up too.
+ * from the progress-view toolbar.
  */
 export async function runCleanRunDir(
   executionId: ExecutionId,

--- a/src/platform/defaults/workspaceStorage.ts
+++ b/src/platform/defaults/workspaceStorage.ts
@@ -22,11 +22,9 @@ const STORAGE_LAYOUT = {
 
 export const MEMORY_STORAGE_DIR = WORKSPACE_STORAGE_LAYOUT.memory;
 export const RUNS_STORAGE_DIR = WORKSPACE_STORAGE_LAYOUT.runs;
-export const LEGACY_RUNS_STORAGE_DIR = WORKSPACE_STORAGE_LAYOUT.legacyRuns;
 export const WORKSPACE_STORAGE_COLLECTIONS_MERGED_PER_CHILD = [
   RUNS_STORAGE_DIR,
   WORKSPACE_STORAGE_LAYOUT.executionLeases,
-  LEGACY_RUNS_STORAGE_DIR,
   WORKSPACE_STORAGE_LAYOUT.streamData,
   WORKSPACE_STORAGE_LAYOUT.streamLogs,
   MEMORY_STORAGE_DIR,
@@ -91,10 +89,6 @@ export function resolveRunStoragePath(...segments: string[]): string {
   return join(RUNS_STORAGE_DIR, ...segments);
 }
 
-export function resolveLegacyRunStoragePath(...segments: string[]): string {
-  return join(LEGACY_RUNS_STORAGE_DIR, ...segments);
-}
-
 export function resolveRunOriginalSnapshotPath(
   executionId: string,
   workspaceRelativePath: string,
@@ -121,10 +115,7 @@ export async function resolveExistingRunStoragePath(
   exists: (storagePath: string) => Promise<boolean>,
 ): Promise<string | undefined> {
   const primary = resolveRunStoragePath(...segments);
-  if (await exists(primary)) return primary;
-  const legacy = resolveLegacyRunStoragePath(...segments);
-  if (await exists(legacy)) return legacy;
-  return undefined;
+  return (await exists(primary)) ? primary : undefined;
 }
 
 function resolveLegacyWorkspaceStoragePath(

--- a/src/test-kernel/platform/LegacyDataMigration.vitest.ts
+++ b/src/test-kernel/platform/LegacyDataMigration.vitest.ts
@@ -143,13 +143,7 @@ describe('mergeLegacyWorkspaceStorageBucket', () => {
     const legacy = await makeTempDir('texra-workspace-legacy-', tempDirs);
     const target = await makeTempDir('texra-workspace-target-', tempDirs);
     const logger = fakeLogger();
-    const collections = [
-      'executions',
-      'taskRuns',
-      'streamData',
-      'streamLogs',
-      'memories',
-    ];
+    const collections = ['executions', 'streamData', 'streamLogs', 'memories'];
 
     for (const collection of collections) {
       await mkdir(join(legacy, collection, 'legacy-child'), {

--- a/src/test-kernel/platform/WorkspaceStorage.vitest.ts
+++ b/src/test-kernel/platform/WorkspaceStorage.vitest.ts
@@ -9,12 +9,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { WORKSPACE_SIDECAR_FILE } from '@common/storage/storageLayout';
 import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
 import {
-  LEGACY_RUNS_STORAGE_DIR,
   MEMORY_STORAGE_DIR,
   resolveExistingRunStoragePath,
   WorkspaceStorageProvider,
   resolveGlobalStoragePath,
-  resolveLegacyRunStoragePath,
   resolveMemoryStoragePath,
   resolveRunOriginalSnapshotPath,
   resolveRunStoragePath,
@@ -71,9 +69,9 @@ describe('workspace storage defaults', () => {
       ['run-1', 'result.json'],
       async (storagePath) => storagePath === 'executions/run-1/result.json',
     );
-    const existingLegacy = await resolveExistingRunStoragePath(
-      ['legacy-run'],
-      async (storagePath) => storagePath === 'taskRuns/legacy-run',
+    const missingRun = await resolveExistingRunStoragePath(
+      ['missing-run'],
+      async () => false,
     );
 
     expect([
@@ -84,10 +82,8 @@ describe('workspace storage defaults', () => {
       RUNS_STORAGE_DIR,
       resolveRunStoragePath('run-1', 'result.json'),
       resolveRunOriginalSnapshotPath('run-1', 'Draft/Draft.tex'),
-      LEGACY_RUNS_STORAGE_DIR,
-      resolveLegacyRunStoragePath('legacy-run'),
       existingCurrent,
-      existingLegacy,
+      missingRun,
     ]).toEqual([
       join(root, 'global-storage'),
       join(root, 'workspace-storage', workspaceStorageId(workspacePath)),
@@ -96,10 +92,8 @@ describe('workspace storage defaults', () => {
       'executions',
       'executions/run-1/result.json',
       'executions/run-1/original/Draft/Draft.tex',
-      'taskRuns',
-      'taskRuns/legacy-run',
       'executions/run-1/result.json',
-      'taskRuns/legacy-run',
+      undefined,
     ]);
     expect(() => resolveMemoryStoragePath('not-memories/project.md')).toThrow(
       'Invalid memory path',

--- a/src/test-kernel/utils/files/RunStorageEntryInspection.vitest.ts
+++ b/src/test-kernel/utils/files/RunStorageEntryInspection.vitest.ts
@@ -27,10 +27,6 @@ function primaryEntry(...segments: string[]): string {
   return path.join('executions', executionId, ...segments);
 }
 
-function legacyEntry(...segments: string[]): string {
-  return path.join('taskRuns', executionId, ...segments);
-}
-
 function storagePath(...segments: string[]): string {
   return path.join(storageRoot, ...segments);
 }
@@ -73,27 +69,6 @@ describe('inspectRunStorageEntry', () => {
         absolutePath: storagePath('executions', executionId, 'r1', 'draft.tex'),
         relativePath: 'r1/draft.tex',
         executionId,
-      },
-    });
-  });
-
-  it('falls back to the legacy layout only when the primary entry is absent', async () => {
-    StorageFS.stat = async (target) => {
-      if (target === legacyEntry('result.tex')) {
-        return fileStat(FileType.File);
-      }
-      if (target === legacyEntry()) {
-        return fileStat(FileType.Directory);
-      }
-      throw missing(target);
-    };
-
-    const result = await inspectRunStorageEntry(executionId, 'result.tex');
-
-    expect(result).toMatchObject({
-      kind: 'file',
-      location: {
-        absolutePath: storagePath('taskRuns', executionId, 'result.tex'),
       },
     });
   });
@@ -186,7 +161,7 @@ describe('inspectRunStorageEntry', () => {
     ).rejects.toThrow('Denied');
   });
 
-  it('recovers execution identity from current and legacy absolute paths', () => {
+  it('recovers execution identity from run-storage absolute paths', () => {
     expect(
       runStorageLocationFromAnyAbsolutePath(
         storagePath('executions', executionId, 'r2', 'result.tex'),
@@ -195,15 +170,6 @@ describe('inspectRunStorageEntry', () => {
       kind: 'runStorage',
       executionId,
       relativePath: 'r2/result.tex',
-    });
-    expect(
-      runStorageLocationFromAnyAbsolutePath(
-        storagePath('taskRuns', executionId, 'result.tex'),
-      ),
-    ).toMatchObject({
-      kind: 'runStorage',
-      executionId,
-      relativePath: 'result.tex',
     });
     expect(
       runStorageLocationFromAnyAbsolutePath(
@@ -228,15 +194,6 @@ describe('inspectRunStorageEntry', () => {
       kind: 'runStorage',
       executionId,
       relativePath: 'r1/draft.tex',
-    });
-    expect(
-      fileService.locateSource(
-        storagePath('taskRuns', executionId, 'legacy.tex'),
-      ),
-    ).toMatchObject({
-      kind: 'runStorage',
-      executionId,
-      relativePath: 'legacy.tex',
     });
   });
 });

--- a/src/utils/files/runStorageFs.ts
+++ b/src/utils/files/runStorageFs.ts
@@ -7,7 +7,6 @@ import { isFileNotFoundError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import {
   resolveExistingRunStoragePath,
-  resolveLegacyRunStoragePath,
   resolveRunOriginalSnapshotPath,
   resolveRunStoragePath,
   resolveRunStorageRelativePath,
@@ -75,8 +74,7 @@ async function storageEntryType(target: string): Promise<number | undefined> {
 
 /**
  * Inspect one execution-relative run-storage entry without following a
- * workspace-mirror symlink. Primary storage takes precedence over the legacy
- * layout, matching {@link findExistingRunStoragePath}.
+ * workspace-mirror symlink.
  */
 export async function inspectRunStorageEntry(
   executionId: ExecutionId,
@@ -98,64 +96,47 @@ export async function inspectRunStorageEntry(
   }
   const normalizedPath = path.posix.normalize(posixPath);
 
-  const candidates = [
-    {
-      entry: resolveRunStoragePath(executionId, normalizedPath),
-      root: resolveRunStoragePath(executionId),
-    },
-    {
-      entry: resolveLegacyRunStoragePath(executionId, normalizedPath),
-      root: resolveLegacyRunStoragePath(executionId),
-    },
-  ];
-  for (const candidate of candidates) {
-    const ancestors = [candidate.root];
-    let ancestorPath = candidate.root;
-    for (const segment of pathSegments.slice(0, -1)) {
-      ancestorPath = path.join(ancestorPath, segment);
-      ancestors.push(ancestorPath);
-    }
-    let missingAncestor = false;
-    for (const ancestor of ancestors) {
-      const ancestorType = await storageEntryType(ancestor);
-      if (ancestorType === undefined) {
-        missingAncestor = true;
-        break;
-      }
-      if (isSymlink(ancestorType)) {
-        return {
-          kind: 'symlink',
-          absolutePath: StorageFS.fullPath(ancestor),
-        };
-      }
-      if (!isDirectory(ancestorType)) {
-        return {
-          kind: 'unsupported',
-          absolutePath: StorageFS.fullPath(ancestor),
-        };
-      }
-    }
-    if (missingAncestor) continue;
-
-    const type = await storageEntryType(candidate.entry);
-    if (type === undefined) continue;
-    const absolutePath = StorageFS.fullPath(candidate.entry);
-    if (isSymlink(type)) return { kind: 'symlink', absolutePath };
-    if (isFile(type)) {
+  const root = resolveRunStoragePath(executionId);
+  const ancestors = [root];
+  let ancestorPath = root;
+  for (const segment of pathSegments.slice(0, -1)) {
+    ancestorPath = path.join(ancestorPath, segment);
+    ancestors.push(ancestorPath);
+  }
+  for (const ancestor of ancestors) {
+    const ancestorType = await storageEntryType(ancestor);
+    if (ancestorType === undefined) return { kind: 'missing' };
+    if (isSymlink(ancestorType)) {
       return {
-        kind: 'file',
-        location: createRunStorageLocation(
-          absolutePath,
-          normalizedPath,
-          executionId,
-        ),
+        kind: 'symlink',
+        absolutePath: StorageFS.fullPath(ancestor),
       };
     }
-    if (isDirectory(type)) return { kind: 'directory', absolutePath };
-    return { kind: 'unsupported', absolutePath };
+    if (!isDirectory(ancestorType)) {
+      return {
+        kind: 'unsupported',
+        absolutePath: StorageFS.fullPath(ancestor),
+      };
+    }
   }
 
-  return { kind: 'missing' };
+  const entry = resolveRunStoragePath(executionId, normalizedPath);
+  const type = await storageEntryType(entry);
+  if (type === undefined) return { kind: 'missing' };
+  const absolutePath = StorageFS.fullPath(entry);
+  if (isSymlink(type)) return { kind: 'symlink', absolutePath };
+  if (isFile(type)) {
+    return {
+      kind: 'file',
+      location: createRunStorageLocation(
+        absolutePath,
+        normalizedPath,
+        executionId,
+      ),
+    };
+  }
+  if (isDirectory(type)) return { kind: 'directory', absolutePath };
+  return { kind: 'unsupported', absolutePath };
 }
 
 export async function ensureRunDir(id: ExecutionId): Promise<void> {
@@ -183,33 +164,26 @@ export function runStorageLocationFromAbsolutePath(
   return createRunStorageLocation(absolutePath, relativePath, executionId);
 }
 
-/** Recover execution identity from an absolute path in either run layout. */
+/** Recover execution identity from an absolute path in run storage. */
 export function runStorageLocationFromAnyAbsolutePath(
   absolutePath: string,
 ): RunStorageFileLocation | undefined {
   if (!path.isAbsolute(absolutePath)) return undefined;
 
-  const roots = [
-    StorageFS.fullPath(resolveRunStoragePath()),
-    StorageFS.fullPath(resolveLegacyRunStoragePath()),
-  ];
-  for (const root of roots) {
-    const runRelativePath = resolveRunStorageRelativePath(absolutePath, root);
-    if (!runRelativePath) continue;
+  const root = StorageFS.fullPath(resolveRunStoragePath());
+  const runRelativePath = resolveRunStorageRelativePath(absolutePath, root);
+  if (!runRelativePath) return undefined;
 
-    const [rawExecutionId, ...entrySegments] = getPathSegments(runRelativePath);
-    const executionId = ExecutionIdSchema.safeParse(rawExecutionId);
-    if (!executionId.success || entrySegments.length === 0) return undefined;
+  const [rawExecutionId, ...entrySegments] = getPathSegments(runRelativePath);
+  const executionId = ExecutionIdSchema.safeParse(rawExecutionId);
+  if (!executionId.success || entrySegments.length === 0) return undefined;
 
-    const relativePath = entrySegments.join('/');
-    return createRunStorageLocation(
-      path.resolve(root, runRelativePath),
-      relativePath,
-      executionId.data,
-    );
-  }
-
-  return undefined;
+  const relativePath = entrySegments.join('/');
+  return createRunStorageLocation(
+    path.resolve(root, runRelativePath),
+    relativePath,
+    executionId.data,
+  );
 }
 
 export async function ensureParentDir(filePath: string): Promise<void> {


### PR DESCRIPTION
## Summary

Every run-directory lookup used to probe two on-disk layouts: the current `executions/` directory and the legacy `taskRuns/` directory that predates it. The `taskRuns/` layout was replaced before the 2026-06-30 history squash (pinned in `docs/proposals/2026-07-09-tech-debt-audit-runtime-ui.md`), so no build has written it for over three months — yet the fallback probe still ran an extra filesystem existence check on hot read paths (run-dir resolution, run-storage entry inspection, absolute-path identity recovery). This PR removes the legacy layout entirely: the `legacyRuns: 'taskRuns'` layout key, `LEGACY_RUNS_STORAGE_DIR`, `resolveLegacyRunStoragePath`, the two-candidate loops in `runStorageFs.ts`, and the compat-only test cases.

## Issue acceptance gates

Partially addresses #9430 (perpetual legacy-storage probes on hot paths). Retirement gate: the `runs/` (`executions/`) replacement predates the 2026-06-30 squash point, so the compatibility window has expired. Accepted outcome: a pre-replacement workspace whose runs exist only under `taskRuns/` will no longer be found; no warning path keeps reading it.

## Single source of truth

Run storage now has exactly one layout root: `WORKSPACE_STORAGE_LAYOUT.runs` (`executions/`). `resolveRunStoragePath` is the only path constructor; `resolveExistingRunStoragePath`, `inspectRunStorageEntry`, and `runStorageLocationFromAnyAbsolutePath` all consult it alone.

## Duplication and abstraction budget

Net removal only — no new helpers, layers, or flags. Two 2-candidate loops (`inspectRunStorageEntry`, `runStorageLocationFromAnyAbsolutePath`) collapsed into straight-line single-root code; `resolveExistingRunStoragePath` shrank from a 2-probe cascade to a single existence check.

## Net elements

`git diff --stat`: 7 files changed, 58 insertions(+), 150 deletions(-) — net -92 lines. Deleted symbols: `LEGACY_RUNS_STORAGE_DIR`, `resolveLegacyRunStoragePath`, `WORKSPACE_STORAGE_LAYOUT.legacyRuns`, plus one compat-only merged-collection entry and three compat-only test cases.

## Consumer counts

Grepped the whole repo for `taskRuns`, `legacyRuns`, `LEGACY_RUNS`, and `resolveLegacyRunStoragePath`: 0 remaining production references. Remaining hits are historical records only (`docs/proposals/`, `docs/prds/`) and the unrelated `taskRunStorage` logger channel / module name.

## Host impact

All three hosts (VS Code extension, desktop, CLI) share this storage path code via `src/platform/defaults/workspaceStorage.ts` and `src/utils/files/runStorageFs.ts`; every host's run-dir reads drop the extra probe. The legacy-bucket merge (`WORKSPACE_STORAGE_COLLECTIONS_MERGED_PER_CHILD`) no longer merges `taskRuns/` per child; an old `taskRuns/` directory is left in place untouched.

## Scheduled refactoring

The separate dated legacy arm in the same file — `legacyWorkspaceStorageId`, `resolveLegacyWorkspaceStoragePath`, `migrateLegacyWorkspaceStorage` (hash-only workspace-bucket rename) — is deliberately left in place; it retires 2026-10-16, not now.

## Validation

- `npm run typecheck`: clean.
- `env -u FORCE_COLOR npx vitest run src/test-kernel/platform/WorkspaceStorage.vitest.ts src/test-kernel/utils/files/RunStorageEntryInspection.vitest.ts src/test-kernel/platform/LegacyDataMigration.vitest.ts`: 24/24 passed.
- `npx vitest run src/test-kernel/utils/files`: 32/32 passed.
- `npm run check:dead-code-ratchet`: OK (18 baselined, 18 current — no baseline change needed).
- `npm run format` on touched files: no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change on run lookup paths: unmigrated `taskRuns/`-only data becomes invisible, but the change is scoped storage cleanup with no auth or payment impact.
> 
> **Overview**
> **Removes legacy `taskRuns/` run storage** after the compatibility window; run directories and files are resolved only under **`executions/`** via `WORKSPACE_STORAGE_LAYOUT.runs`.
> 
> Deletes **`legacyRuns`**, **`LEGACY_RUNS_STORAGE_DIR`**, and **`resolveLegacyRunStoragePath`**, drops **`taskRuns`** from workspace merge collections, and simplifies **`resolveExistingRunStoragePath`**, **`inspectRunStorageEntry`**, and **`runStorageLocationFromAnyAbsolutePath`** to single-root logic (no second existence probe on hot paths). Tests and comments that covered legacy fallback are removed or updated.
> 
> **Breaking for unmigrated data:** workspaces that still have runs only under `taskRuns/` will no longer be found; separate hash-based workspace-bucket migration remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca3bbbca07a5a3e1bb1d2ebac925757ffad2200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->