### PR TITLE
refactor(storage): retire taskRuns read probes

### DIFF
--- a/packages/extension/src/frontend/vscode/sharedStorageRoot.ts
+++ b/packages/extension/src/frontend/vscode/sharedStorageRoot.ts
@@ -9,10 +9,14 @@
  * the storage port moves. VS Code Memento state and SecretStorage remain
  * host-owned; TeXRA configuration uses the shared JSON stores.
  */
+// Node imports
+import { join } from 'node:path';
+
 // Third-party imports
 import * as vscode from 'vscode';
 
 // Local imports
+import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
 import * as logger from '@logger/logUtils';
 import type { StorageProvider } from '@platform/interfaces';
 import {
@@ -39,6 +43,11 @@ const GLOBAL_MERGE_PER_CHILD = [
   CUSTOM_AGENTS_STORAGE_DIR,
   EXTERNAL_INQUIRY_THREADS_DIR,
 ] as const;
+const mergeTaskRuns: BucketMigration = (sourcePath, targetPath, options) =>
+  mergeLegacyStorageBucket(sourcePath, targetPath, {
+    ...options,
+    mergePerChild: 'all',
+  });
 
 /**
  * Best-effort, one-time move of the extension's legacy `context.storageUri` /
@@ -55,13 +64,14 @@ export async function migrateLegacyVscodeStorage(
     warn: (message: string) => logger.warn('extension', message),
   };
   async function migrateBucket(
-    sourcePath: string | undefined,
+    getSourcePath: () => string | undefined,
     getTargetPath: () => string,
     label: string,
     migrate: BucketMigration,
   ): Promise<void> {
-    if (!sourcePath) return;
     try {
+      const sourcePath = getSourcePath();
+      if (!sourcePath) return;
       await migrate(sourcePath, getTargetPath(), {
         label,
         logger: migrationLogger,
@@ -76,13 +86,27 @@ export async function migrateLegacyVscodeStorage(
   // Resolve and migrate each bucket independently: a workspace-root failure
   // must not prevent an otherwise valid global migration, or vice versa.
   await migrateBucket(
-    context.storageUri?.fsPath,
+    () => context.storageUri?.fsPath,
     () => storage.getStoragePath(),
     'vscode-workspace-storage',
     mergeLegacyWorkspaceStorageBucket,
   );
   await migrateBucket(
-    context.globalStorageUri?.fsPath,
+    () =>
+      context.storageUri &&
+      join(context.storageUri.fsPath, WORKSPACE_STORAGE_LAYOUT.legacyRuns),
+    () => join(storage.getStoragePath(), WORKSPACE_STORAGE_LAYOUT.runs),
+    'vscode-workspace-storage/taskRuns',
+    mergeTaskRuns,
+  );
+  await migrateBucket(
+    () => join(storage.getStoragePath(), WORKSPACE_STORAGE_LAYOUT.legacyRuns),
+    () => join(storage.getStoragePath(), WORKSPACE_STORAGE_LAYOUT.runs),
+    'shared-workspace-storage/taskRuns',
+    mergeTaskRuns,
+  );
+  await migrateBucket(
+    () => context.globalStorageUri?.fsPath,
     () => storage.getGlobalStoragePath(),
     'vscode-global-storage',
     (sourcePath, targetPath, options) =>

--- a/src/housekeeping/runDirOps.ts
+++ b/src/housekeeping/runDirOps.ts
@@ -71,8 +71,7 @@ export async function runPackRunDir(
 
 /**
  * Delete a run's runDir. Irreversible. Used when the user discards a run
- * from the progress-view toolbar. Uses `findRunDir` so the
- * legacy `taskRuns/` location is cleaned up too.
+ * from the progress-view toolbar.
  */
 export async function runCleanRunDir(
   executionId: ExecutionId,

--- a/src/platform/defaults/legacyDataMigration.ts
+++ b/src/platform/defaults/legacyDataMigration.ts
@@ -11,7 +11,7 @@
  */
 
 // Node imports
-import { constants, existsSync } from 'node:fs';
+import { constants, existsSync, type Dirent } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import {
   copyFile,
@@ -30,9 +30,6 @@ import { dirname, join } from 'node:path';
 // Local imports
 import { WORKSPACE_STORAGE_COLLECTIONS_MERGED_PER_CHILD } from '@platform/defaults/workspaceStorage';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-
-// Node imports
-import type { Dirent } from 'node:fs';
 
 export interface LegacyDataMigrationLogger {
   info(message: string): void;
@@ -148,11 +145,12 @@ export interface MergeLegacyStorageBucketOptions {
   /**
    * Top-level directory names holding id-keyed children (e.g. `executions/`,
    * `streamData/`, where every child directory is a globally unique run or
-   * stream id). When the target bucket already has one of these — because
+   * stream id), or `all` to apply this rule recursively to every directory. When the
+   * target bucket already has one of these — because
    * another host wrote runs into the shared root first — its children are
    * merged one at a time instead of skipping the whole collection.
    */
-  readonly mergePerChild: readonly string[];
+  readonly mergePerChild: readonly string[] | 'all';
   readonly label: string;
   readonly logger: LegacyDataMigrationLogger;
 }
@@ -182,7 +180,7 @@ export async function mergeLegacyStorageBucket(
 
     const mergeChildren =
       entry.isDirectory() &&
-      mergePerChild.includes(entry.name) &&
+      (mergePerChild === 'all' || mergePerChild.includes(entry.name)) &&
       existsSync(targetPath);
     if (!mergeChildren) {
       await moveEntryIfAbsent(legacyPath, targetPath, entryLabel, logger);
@@ -192,12 +190,27 @@ export async function mergeLegacyStorageBucket(
     const children = await readLegacyDirEntries(legacyPath, logger);
     if (!children) continue;
     for (const child of children) {
-      await moveEntryIfAbsent(
-        join(legacyPath, child.name),
-        join(targetPath, child.name),
-        `${entryLabel}/${child.name}`,
-        logger,
-      );
+      const legacyChildPath = join(legacyPath, child.name);
+      const targetChildPath = join(targetPath, child.name);
+      const childLabel = `${entryLabel}/${child.name}`;
+      if (
+        mergePerChild === 'all' &&
+        child.isDirectory() &&
+        existsSync(targetChildPath)
+      ) {
+        await mergeLegacyStorageBucket(legacyChildPath, targetChildPath, {
+          mergePerChild: 'all',
+          label: childLabel,
+          logger,
+        });
+      } else {
+        await moveEntryIfAbsent(
+          legacyChildPath,
+          targetChildPath,
+          childLabel,
+          logger,
+        );
+      }
     }
   }
 }

--- a/src/platform/defaults/workspaceStorage.ts
+++ b/src/platform/defaults/workspaceStorage.ts
@@ -22,11 +22,10 @@ const STORAGE_LAYOUT = {
 
 export const MEMORY_STORAGE_DIR = WORKSPACE_STORAGE_LAYOUT.memory;
 export const RUNS_STORAGE_DIR = WORKSPACE_STORAGE_LAYOUT.runs;
-export const LEGACY_RUNS_STORAGE_DIR = WORKSPACE_STORAGE_LAYOUT.legacyRuns;
 export const WORKSPACE_STORAGE_COLLECTIONS_MERGED_PER_CHILD = [
   RUNS_STORAGE_DIR,
   WORKSPACE_STORAGE_LAYOUT.executionLeases,
-  LEGACY_RUNS_STORAGE_DIR,
+  WORKSPACE_STORAGE_LAYOUT.legacyRuns,
   WORKSPACE_STORAGE_LAYOUT.streamData,
   WORKSPACE_STORAGE_LAYOUT.streamLogs,
   MEMORY_STORAGE_DIR,
@@ -91,10 +90,6 @@ export function resolveRunStoragePath(...segments: string[]): string {
   return join(RUNS_STORAGE_DIR, ...segments);
 }
 
-export function resolveLegacyRunStoragePath(...segments: string[]): string {
-  return join(LEGACY_RUNS_STORAGE_DIR, ...segments);
-}
-
 export function resolveRunOriginalSnapshotPath(
   executionId: string,
   workspaceRelativePath: string,
@@ -114,17 +109,6 @@ export function resolveRunStorageRelativePath(
   return (
     relative(runDirectory, absolutePath).replaceAll('\\', '/') || undefined
   );
-}
-
-export async function resolveExistingRunStoragePath(
-  segments: readonly string[],
-  exists: (storagePath: string) => Promise<boolean>,
-): Promise<string | undefined> {
-  const primary = resolveRunStoragePath(...segments);
-  if (await exists(primary)) return primary;
-  const legacy = resolveLegacyRunStoragePath(...segments);
-  if (await exists(legacy)) return legacy;
-  return undefined;
 }
 
 function resolveLegacyWorkspaceStoragePath(

--- a/src/test-kernel/frontend/SharedStorageRoot.vitest.ts
+++ b/src/test-kernel/frontend/SharedStorageRoot.vitest.ts
@@ -82,6 +82,24 @@ describe('VS Code shared-storage migration', () => {
         label: 'vscode-workspace-storage',
       }),
     );
+    expect(mocks.mergeLegacyStorageBucket).toHaveBeenNthCalledWith(
+      1,
+      '/legacy/workspace/taskRuns',
+      '/shared/workspace/executions',
+      expect.objectContaining({
+        label: 'vscode-workspace-storage/taskRuns',
+        mergePerChild: 'all',
+      }),
+    );
+    expect(mocks.mergeLegacyStorageBucket).toHaveBeenNthCalledWith(
+      2,
+      '/shared/workspace/taskRuns',
+      '/shared/workspace/executions',
+      expect.objectContaining({
+        label: 'shared-workspace-storage/taskRuns',
+        mergePerChild: 'all',
+      }),
+    );
     expect(mocks.warn).toHaveBeenCalledWith(
       'extension',
       expect.stringContaining('vscode-global-storage migration failed'),

--- a/src/test-kernel/platform/LegacyDataMigration.vitest.ts
+++ b/src/test-kernel/platform/LegacyDataMigration.vitest.ts
@@ -136,6 +136,51 @@ describe('mergeLegacyStorageBucket (#8622 vscode → ~/.texra migration)', () =>
     ).resolves.toBe('legacy');
     expect(logger.warnMessages).toHaveLength(1);
   });
+
+  it('merges colliding taskRuns without overwriting canonical execution files', async () => {
+    const legacy = await makeTempDir('texra-task-runs-', tempDirs);
+    const target = await makeTempDir('texra-executions-', tempDirs);
+    const logger = fakeLogger();
+    const executionId = 'execution-1';
+    const legacyRun = join(legacy, executionId);
+    const canonicalRun = join(target, executionId);
+
+    await mkdir(legacyRun, { recursive: true });
+    await mkdir(canonicalRun, { recursive: true });
+    await writeFile(join(legacyRun, 'result.json'), 'legacy');
+    await writeFile(join(legacyRun, 'artifact.txt'), 'artifact');
+    await writeFile(join(canonicalRun, 'result.json'), 'canonical');
+    await mkdir(join(legacyRun, 'r1'), { recursive: true });
+    await mkdir(join(canonicalRun, 'r1'), { recursive: true });
+    await writeFile(join(legacyRun, 'r1', 'output.tex'), 'legacy output');
+    await writeFile(join(legacyRun, 'r1', 'diff.pdf'), 'legacy diff');
+    await writeFile(join(canonicalRun, 'r1', 'output.tex'), 'canonical output');
+
+    await mergeLegacyStorageBucket(legacy, target, {
+      mergePerChild: 'all',
+      label: 'taskRuns',
+      logger,
+    });
+
+    await expect(
+      readFile(join(canonicalRun, 'result.json'), 'utf8'),
+    ).resolves.toBe('canonical');
+    await expect(
+      readFile(join(canonicalRun, 'artifact.txt'), 'utf8'),
+    ).resolves.toBe('artifact');
+    await expect(
+      readFile(join(canonicalRun, 'r1', 'output.tex'), 'utf8'),
+    ).resolves.toBe('canonical output');
+    await expect(
+      readFile(join(canonicalRun, 'r1', 'diff.pdf'), 'utf8'),
+    ).resolves.toBe('legacy diff');
+    await expect(
+      readFile(join(legacyRun, 'result.json'), 'utf8'),
+    ).resolves.toBe('legacy');
+    await expect(
+      readFile(join(legacyRun, 'r1', 'output.tex'), 'utf8'),
+    ).resolves.toBe('legacy output');
+  });
 });
 
 describe('mergeLegacyWorkspaceStorageBucket', () => {

--- a/src/test-kernel/platform/WorkspaceStorage.vitest.ts
+++ b/src/test-kernel/platform/WorkspaceStorage.vitest.ts
@@ -9,12 +9,9 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { WORKSPACE_SIDECAR_FILE } from '@common/storage/storageLayout';
 import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
 import {
-  LEGACY_RUNS_STORAGE_DIR,
   MEMORY_STORAGE_DIR,
-  resolveExistingRunStoragePath,
   WorkspaceStorageProvider,
   resolveGlobalStoragePath,
-  resolveLegacyRunStoragePath,
   resolveMemoryStoragePath,
   resolveRunOriginalSnapshotPath,
   resolveRunStoragePath,
@@ -67,14 +64,6 @@ describe('workspace storage defaults', () => {
   it('snapshots global, workspace, memory, and run storage layout paths', async () => {
     const root = await makeTempDir('texra-workspace-storage-', tempDirs);
     const workspacePath = '/workspace/a';
-    const existingCurrent = await resolveExistingRunStoragePath(
-      ['run-1', 'result.json'],
-      async (storagePath) => storagePath === 'executions/run-1/result.json',
-    );
-    const existingLegacy = await resolveExistingRunStoragePath(
-      ['legacy-run'],
-      async (storagePath) => storagePath === 'taskRuns/legacy-run',
-    );
 
     expect([
       resolveGlobalStoragePath(root),
@@ -84,10 +73,6 @@ describe('workspace storage defaults', () => {
       RUNS_STORAGE_DIR,
       resolveRunStoragePath('run-1', 'result.json'),
       resolveRunOriginalSnapshotPath('run-1', 'Draft/Draft.tex'),
-      LEGACY_RUNS_STORAGE_DIR,
-      resolveLegacyRunStoragePath('legacy-run'),
-      existingCurrent,
-      existingLegacy,
     ]).toEqual([
       join(root, 'global-storage'),
       join(root, 'workspace-storage', workspaceStorageId(workspacePath)),
@@ -96,10 +81,6 @@ describe('workspace storage defaults', () => {
       'executions',
       'executions/run-1/result.json',
       'executions/run-1/original/Draft/Draft.tex',
-      'taskRuns',
-      'taskRuns/legacy-run',
-      'executions/run-1/result.json',
-      'taskRuns/legacy-run',
     ]);
     expect(() => resolveMemoryStoragePath('not-memories/project.md')).toThrow(
       'Invalid memory path',

--- a/src/test-kernel/utils/files/RunStorageEntryInspection.vitest.ts
+++ b/src/test-kernel/utils/files/RunStorageEntryInspection.vitest.ts
@@ -27,10 +27,6 @@ function primaryEntry(...segments: string[]): string {
   return path.join('executions', executionId, ...segments);
 }
 
-function legacyEntry(...segments: string[]): string {
-  return path.join('taskRuns', executionId, ...segments);
-}
-
 function storagePath(...segments: string[]): string {
   return path.join(storageRoot, ...segments);
 }
@@ -73,27 +69,6 @@ describe('inspectRunStorageEntry', () => {
         absolutePath: storagePath('executions', executionId, 'r1', 'draft.tex'),
         relativePath: 'r1/draft.tex',
         executionId,
-      },
-    });
-  });
-
-  it('falls back to the legacy layout only when the primary entry is absent', async () => {
-    StorageFS.stat = async (target) => {
-      if (target === legacyEntry('result.tex')) {
-        return fileStat(FileType.File);
-      }
-      if (target === legacyEntry()) {
-        return fileStat(FileType.Directory);
-      }
-      throw missing(target);
-    };
-
-    const result = await inspectRunStorageEntry(executionId, 'result.tex');
-
-    expect(result).toMatchObject({
-      kind: 'file',
-      location: {
-        absolutePath: storagePath('taskRuns', executionId, 'result.tex'),
       },
     });
   });

--- a/src/utils/files/runStorageFs.ts
+++ b/src/utils/files/runStorageFs.ts
@@ -4,10 +4,9 @@ import { promises as fs } from 'node:fs';
 
 // Local imports
 import { isFileNotFoundError } from '@common/errors';
+import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
 import * as logger from '@logger/logUtils';
 import {
-  resolveExistingRunStoragePath,
-  resolveLegacyRunStoragePath,
   resolveRunOriginalSnapshotPath,
   resolveRunStoragePath,
   resolveRunStorageRelativePath,
@@ -44,9 +43,9 @@ export function getOriginalSnapshotPath(
 export function findExistingRunStoragePath(
   ...segments: string[]
 ): Promise<string | undefined> {
-  return resolveExistingRunStoragePath(
-    segments,
-    StorageFS.exists.bind(StorageFS),
+  const storagePath = resolveRunStoragePath(...segments);
+  return StorageFS.exists(storagePath).then((exists) =>
+    exists ? storagePath : undefined,
   );
 }
 
@@ -75,8 +74,7 @@ async function storageEntryType(target: string): Promise<number | undefined> {
 
 /**
  * Inspect one execution-relative run-storage entry without following a
- * workspace-mirror symlink. Primary storage takes precedence over the legacy
- * layout, matching {@link findExistingRunStoragePath}.
+ * workspace-mirror symlink.
  */
 export async function inspectRunStorageEntry(
   executionId: ExecutionId,
@@ -98,64 +96,47 @@ export async function inspectRunStorageEntry(
   }
   const normalizedPath = path.posix.normalize(posixPath);
 
-  const candidates = [
-    {
-      entry: resolveRunStoragePath(executionId, normalizedPath),
-      root: resolveRunStoragePath(executionId),
-    },
-    {
-      entry: resolveLegacyRunStoragePath(executionId, normalizedPath),
-      root: resolveLegacyRunStoragePath(executionId),
-    },
-  ];
-  for (const candidate of candidates) {
-    const ancestors = [candidate.root];
-    let ancestorPath = candidate.root;
-    for (const segment of pathSegments.slice(0, -1)) {
-      ancestorPath = path.join(ancestorPath, segment);
-      ancestors.push(ancestorPath);
-    }
-    let missingAncestor = false;
-    for (const ancestor of ancestors) {
-      const ancestorType = await storageEntryType(ancestor);
-      if (ancestorType === undefined) {
-        missingAncestor = true;
-        break;
-      }
-      if (isSymlink(ancestorType)) {
-        return {
-          kind: 'symlink',
-          absolutePath: StorageFS.fullPath(ancestor),
-        };
-      }
-      if (!isDirectory(ancestorType)) {
-        return {
-          kind: 'unsupported',
-          absolutePath: StorageFS.fullPath(ancestor),
-        };
-      }
-    }
-    if (missingAncestor) continue;
-
-    const type = await storageEntryType(candidate.entry);
-    if (type === undefined) continue;
-    const absolutePath = StorageFS.fullPath(candidate.entry);
-    if (isSymlink(type)) return { kind: 'symlink', absolutePath };
-    if (isFile(type)) {
+  const root = resolveRunStoragePath(executionId);
+  const entry = resolveRunStoragePath(executionId, normalizedPath);
+  const ancestors = [root];
+  let ancestorPath = root;
+  for (const segment of pathSegments.slice(0, -1)) {
+    ancestorPath = path.join(ancestorPath, segment);
+    ancestors.push(ancestorPath);
+  }
+  for (const ancestor of ancestors) {
+    const ancestorType = await storageEntryType(ancestor);
+    if (ancestorType === undefined) return { kind: 'missing' };
+    if (isSymlink(ancestorType)) {
       return {
-        kind: 'file',
-        location: createRunStorageLocation(
-          absolutePath,
-          normalizedPath,
-          executionId,
-        ),
+        kind: 'symlink',
+        absolutePath: StorageFS.fullPath(ancestor),
       };
     }
-    if (isDirectory(type)) return { kind: 'directory', absolutePath };
-    return { kind: 'unsupported', absolutePath };
+    if (!isDirectory(ancestorType)) {
+      return {
+        kind: 'unsupported',
+        absolutePath: StorageFS.fullPath(ancestor),
+      };
+    }
   }
 
-  return { kind: 'missing' };
+  const type = await storageEntryType(entry);
+  if (type === undefined) return { kind: 'missing' };
+  const absolutePath = StorageFS.fullPath(entry);
+  if (isSymlink(type)) return { kind: 'symlink', absolutePath };
+  if (isFile(type)) {
+    return {
+      kind: 'file',
+      location: createRunStorageLocation(
+        absolutePath,
+        normalizedPath,
+        executionId,
+      ),
+    };
+  }
+  if (isDirectory(type)) return { kind: 'directory', absolutePath };
+  return { kind: 'unsupported', absolutePath };
 }
 
 export async function ensureRunDir(id: ExecutionId): Promise<void> {
@@ -183,7 +164,13 @@ export function runStorageLocationFromAbsolutePath(
   return createRunStorageLocation(absolutePath, relativePath, executionId);
 }
 
-/** Recover execution identity from an absolute path in either run layout. */
+/**
+ * Recover execution identity from an absolute run-storage path.
+ *
+ * The released extension may retain transcripts and resume records containing
+ * absolute `taskRuns` paths. Keep parsing those paths without probing the
+ * filesystem until that released-data retention policy expires (#6981).
+ */
 export function runStorageLocationFromAnyAbsolutePath(
   absolutePath: string,
 ): RunStorageFileLocation | undefined {
@@ -191,7 +178,7 @@ export function runStorageLocationFromAnyAbsolutePath(
 
   const roots = [
     StorageFS.fullPath(resolveRunStoragePath()),
-    StorageFS.fullPath(resolveLegacyRunStoragePath()),
+    StorageFS.fullPath(WORKSPACE_STORAGE_LAYOUT.legacyRuns),
   ];
   for (const root of roots) {
     const runRelativePath = resolveRunStorageRelativePath(absolutePath, root);


### PR DESCRIPTION
## Summary

Finish the released extension migration from `taskRuns` to `executions`, then remove all runtime filesystem probes of the obsolete directory. The pure absolute-path parser remains for released transcripts and resume records.

The canonical writer changed on 2026-02-12 (`bedbf19e64`). The extension migration introduced on 2026-07-16 (`bf8d152ba6`) was the only remaining code that could preserve the obsolete collection name.

Refs #9430 and #6981.

## Issue acceptance gates

- migrate both VS Code-local and already-shared `taskRuns` collections before platform initialization: satisfied;
- recursively merge colliding execution directories without overwriting canonical files: satisfied;
- preserve distinct legacy files inside colliding `original/` and round directories: satisfied;
- remove runtime dual-layout probes: satisfied;
- retain parsing of persisted absolute legacy paths: satisfied;
- add no desktop or CLI startup migration: satisfied.

## Single source of truth

`migrateLegacyVscodeStorage` owns the extension-only collection move. Runtime storage readers use only `WORKSPACE_STORAGE_LAYOUT.runs` (`executions`).

The broad workspace migration still recognizes `taskRuns`, avoiding a false manual-move warning before the dedicated canonical move.

## Duplication and abstraction budget

No parallel migration helper or framework is added. The existing `mergeLegacyStorageBucket` accepts one discriminated `mergePerChild: all` mode. That mode recursively merges colliding directories while retaining the existing no-overwrite primitive for every file. Compatibility-only runtime branches and branch-enumeration tests are deleted.

## Net elements (R6)

- files: 0 added, 0 deleted, 9 modified;
- exported symbols: 0 added, 3 deleted (`LEGACY_RUNS_STORAGE_DIR`, `resolveLegacyRunStoragePath`, `resolveExistingRunStoragePath`);
- classes/interfaces/enums: none added or deleted;
- lines: +167/-141, net +26; production +104/-97, net +7. The added production lines implement the one-time recursive no-overwrite move required before deleting the runtime readers.

## Consumer counts (R8)

n/a: no event emit, subscription, or command-dispatch key changes. Repository search confirms zero remaining consumers of the three deleted exports.

## Host impact

Extension:

- migrates old `taskRuns` collections once at the existing awaited startup boundary.

Desktop:

- receives no migration machinery; runtime reads use only `executions`.

CLI:

- receives no migration machinery; runtime reads use only `executions`.

## Scheduled refactoring

The pure absolute `taskRuns` path parser remains tracked in #6981 until released transcripts and resume records no longer require it. The released VS Code storage migration remains until at least 2026-10-16.

## Validation

- focused storage/migration suites: 27 passed before review;
- broader affected caller suites: 160 passed;
- workspace, test-kernel, extension, and CLI type checks;
- full lint;
- targeted Prettier and `git diff --check`;
- post-review focused migration suites: 10 passed;
- post-review test-kernel and extension type checks;
- pre-push changed-file lint;
- repository search confirms the retired fallback symbols are gone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extension activation performs filesystem migration on user run data before reads; incorrect merge logic could strand or duplicate runs, though the no-overwrite design limits overwrite risk.
> 
> **Overview**
> **Run storage now uses only `executions/` at runtime.** The dual lookup that probed `taskRuns/` when `executions/` missed is removed, along with `resolveExistingRunStoragePath`, `resolveLegacyRunStoragePath`, and `LEGACY_RUNS_STORAGE_DIR`. `findRunDir`, `inspectRunStorageEntry`, and related helpers resolve paths under the canonical runs layout only.
> 
> **Extension startup owns the one-time `taskRuns` → `executions` move.** `migrateLegacyVscodeStorage` adds two migration buckets (VS Code–local `taskRuns` and any `taskRuns` left under the shared workspace root), both targeting `executions` with a new `mergePerChild: 'all'` mode on `mergeLegacyStorageBucket`. That mode **recursively** merges colliding directories and still never overwrites existing target files, so canonical run data wins while distinct legacy files are preserved.
> 
> **Compatibility for released data:** `runStorageLocationFromAnyAbsolutePath` continues to recognize absolute paths under `taskRuns` (string parsing only, no extra `exists` probes) for transcripts and resume records (#6981).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3353f38cf2e419f5a4a2b3048a15eda077a9690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->