### PR TITLE
test(desktop): lock run-directory file operations

### DIFF
--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -195,6 +195,14 @@ function seedBridgeFollowUp(
   followUps.release(lease, 'recoverable');
 }
 
+type HousekeepingMocks = {
+  runPackRunDir: ReturnType<typeof vi.fn>;
+  runCleanRunDir: ReturnType<typeof vi.fn>;
+  runPack: ReturnType<typeof vi.fn>;
+  runCleanSingle: ReturnType<typeof vi.fn>;
+  runCleanMultiple: ReturnType<typeof vi.fn>;
+};
+
 type CreateBridgeOptions = {
   kvStoreBacking?: Map<string, unknown>;
   kvRead?: (key: string) => Promise<unknown> | unknown;
@@ -220,6 +228,7 @@ type CreateBridgeOptions = {
   observeRendererMessage?: (message: unknown) => void;
   /** Captures `this.logger.error(...)` calls made by the bridge under test. */
   loggerErrorSpy?: ReturnType<typeof vi.fn<AgentTrace['error']>>;
+  housekeeping?: HousekeepingMocks;
 };
 
 type ProgressMessage = {
@@ -358,6 +367,9 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
   mocks.doMock('@controllers/mainView/MainViewExecutionController', () => ({
     prepareMainViewExecutionRequest: vi.fn(),
   }));
+  if (options.housekeeping) {
+    mocks.doMock('@housekeeping', () => options.housekeeping!);
+  }
   const { StreamLogStore, StreamSnapshotStore } = await import('@transcript');
   const createProgressSnapshotStore = (): ProgressSnapshotStore =>
     new StreamSnapshotStore();
@@ -593,6 +605,75 @@ function workflowConfig(): AgentConfig {
     model: 'deepseekproT',
     agentCategory: AgentCategory.Workflow,
     toolConfig: DEFAULT_TOOL_CONFIG,
+  });
+}
+
+function workflowFileOperationConfig(): AgentConfig {
+  return WorkflowAgentConfigSchema.parse({
+    ...workflowConfig(),
+    inputFiles: ['paper.tex'],
+    outputFiles: ['paper_revised.tex'],
+  });
+}
+
+function createHousekeepingMocks(): HousekeepingMocks {
+  const success = async () => ({ status: 'success' as const });
+  return {
+    runPackRunDir: vi.fn(success),
+    runCleanRunDir: vi.fn(success),
+    runPack: vi.fn(success),
+    runCleanSingle: vi.fn(success),
+    runCleanMultiple: vi.fn(success),
+  };
+}
+
+async function createWorkflowFileOperationBridge(
+  streamId: StreamTabId,
+  options: {
+    executionId?: ExecutionId;
+    showErrorMessage?: CreateBridgeOptions['showErrorMessage'];
+  } = {},
+): Promise<{ bridge: TestableBridge; housekeeping: HousekeepingMocks }> {
+  const housekeeping = createHousekeepingMocks();
+  const bridge = await createBridge([], {
+    housekeeping,
+    canonicalStreamIds: [streamId],
+    ...(options.showErrorMessage && {
+      showErrorMessage: options.showErrorMessage,
+    }),
+    configureProgressSnapshotStore: (store) => {
+      store.setRunConfig(
+        streamId,
+        workflowFileOperationConfig(),
+        options.executionId,
+      );
+    },
+  });
+  return { bridge, housekeeping };
+}
+
+async function invokeWorkflowFileOperation(
+  bridge: TestableBridge,
+  streamId: StreamTabId,
+  operation: 'pack' | 'clean',
+): Promise<void> {
+  if (operation === 'pack') {
+    const runOperation = assertSupported(
+      bridge.progressViewInboundHandlers[PROGRESS_VIEW_COMMANDS.PACK_STREAM],
+    );
+    await runOperation({
+      command: PROGRESS_VIEW_COMMANDS.PACK_STREAM,
+      stream: streamId,
+    });
+    return;
+  }
+
+  const runOperation = assertSupported(
+    bridge.progressViewInboundHandlers[PROGRESS_VIEW_COMMANDS.CLEAN_STREAM],
+  );
+  await runOperation({
+    command: PROGRESS_VIEW_COMMANDS.CLEAN_STREAM,
+    stream: streamId,
   });
 }
 
@@ -2105,6 +2186,72 @@ describe('DesktopProgressBridge', () => {
       }),
     );
   });
+
+  it('packs an identified execution only through its run directory', async () => {
+    const streamId = 'stream-pack' as StreamTabId;
+    const executionId = 'ec-a11' as ExecutionId;
+    const { bridge, housekeeping } = await createWorkflowFileOperationBridge(
+      streamId,
+      { executionId },
+    );
+
+    await invokeWorkflowFileOperation(bridge, streamId, 'pack');
+
+    expect(housekeeping.runPackRunDir).toHaveBeenCalledOnce();
+    expect(housekeeping.runPackRunDir).toHaveBeenCalledWith(
+      executionId,
+      'proofreader',
+      'deepseekproT',
+      'paper.tex',
+    );
+    expect(housekeeping.runCleanRunDir).not.toHaveBeenCalled();
+    expect(housekeeping.runPack).not.toHaveBeenCalled();
+    expect(housekeeping.runCleanSingle).not.toHaveBeenCalled();
+    expect(housekeeping.runCleanMultiple).not.toHaveBeenCalled();
+  });
+
+  it('cleans an identified execution only through its run directory', async () => {
+    const streamId = 'stream-clean' as StreamTabId;
+    const executionId = 'ec-c1ea' as ExecutionId;
+    const { bridge, housekeeping } = await createWorkflowFileOperationBridge(
+      streamId,
+      { executionId },
+    );
+
+    await invokeWorkflowFileOperation(bridge, streamId, 'clean');
+
+    expect(housekeeping.runCleanRunDir).toHaveBeenCalledOnce();
+    expect(housekeeping.runCleanRunDir).toHaveBeenCalledWith(executionId);
+    expect(housekeeping.runPackRunDir).not.toHaveBeenCalled();
+    expect(housekeeping.runPack).not.toHaveBeenCalled();
+    expect(housekeeping.runCleanSingle).not.toHaveBeenCalled();
+    expect(housekeeping.runCleanMultiple).not.toHaveBeenCalled();
+  });
+
+  it.each(['pack', 'clean'] as const)(
+    'rejects %s without an execution identity before any file operation',
+    async (operation) => {
+      const streamId = `stream-missing-${operation}` as StreamTabId;
+      const showErrorMessage = vi.fn(async () => undefined);
+      const { bridge, housekeeping } = await createWorkflowFileOperationBridge(
+        streamId,
+        {
+          showErrorMessage,
+        },
+      );
+
+      await invokeWorkflowFileOperation(bridge, streamId, operation);
+
+      expect(showErrorMessage).toHaveBeenCalledExactlyOnceWith(
+        `Missing execution identity for ${operation}.`,
+      );
+      expect(housekeeping.runPackRunDir).not.toHaveBeenCalled();
+      expect(housekeeping.runCleanRunDir).not.toHaveBeenCalled();
+      expect(housekeeping.runPack).not.toHaveBeenCalled();
+      expect(housekeeping.runCleanSingle).not.toHaveBeenCalled();
+      expect(housekeeping.runCleanMultiple).not.toHaveBeenCalled();
+    },
+  );
 
   it('resumes canonical streams using sidecar execution ids', async () => {
     const executionId = 'abc123';


### PR DESCRIPTION
## Summary

- directly cover desktop Pack dispatch to the execution run directory
- directly cover desktop Clean dispatch to the execution run directory
- prove missing execution identity fails visibly without falling back to workspace operations

## Context

Follow-up test-only coverage for merged PR #9612. These tests were reviewed as a pre-merge should-fix, but #9612 merged concurrently before the test commit became part of its PR head. This PR contains only the already-reviewed regression tests; the production change is already on main.

## Duplicate audit

Current main already contains #9612 production behavior. The PR diff is exactly one modified test file and does not duplicate the production patch.

## Validation

- `DesktopAgentExecution.vitest.mts`: 77 passed
- desktop typecheck
- test-kernel typecheck
- targeted ESLint and Prettier
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to one Vitest file; no runtime or security impact.
> 
> **Overview**
> **Regression coverage** for desktop workflow **Pack** and **Clean** (behavior already on main from #9612). No production code changes.
> 
> The test harness can inject a mocked `@housekeeping` module. New helpers build a workflow stream with input/output files and optional `executionId`, then drive `PACK_STREAM` / `CLEAN_STREAM` through the progress view handlers.
> 
> Tests lock in that **pack** calls `runPackRunDir` once with execution id, agent, model, and input file, and that **clean** calls `runCleanRunDir` once with the execution id—without invoking workspace-oriented `runPack`, `runCleanSingle`, or `runCleanMultiple`. When no execution identity is stored, both operations show `Missing execution identity for {pack|clean}.` and do not touch any housekeeping function.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 116b15ab0faf93ba1b0d8b5bc227b7d8f1963ad5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->