### PR TITLE
test(desktop): lock run-directory file operations

### DIFF
--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -195,6 +195,14 @@ function seedBridgeFollowUp(
   followUps.release(lease, 'recoverable');
 }
 
+type HousekeepingMocks = {
+  runPackRunDir: ReturnType<typeof vi.fn>;
+  runCleanRunDir: ReturnType<typeof vi.fn>;
+  runPack: ReturnType<typeof vi.fn>;
+  runCleanSingle: ReturnType<typeof vi.fn>;
+  runCleanMultiple: ReturnType<typeof vi.fn>;
+};
+
 type CreateBridgeOptions = {
   kvStoreBacking?: Map<string, unknown>;
   kvRead?: (key: string) => Promise<unknown> | unknown;
@@ -220,6 +228,7 @@ type CreateBridgeOptions = {
   observeRendererMessage?: (message: unknown) => void;
   /** Captures `this.logger.error(...)` calls made by the bridge under test. */
   loggerErrorSpy?: ReturnType<typeof vi.fn<AgentTrace['error']>>;
+  housekeeping?: HousekeepingMocks;
 };
 
 type ProgressMessage = {
@@ -358,6 +367,9 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
   mocks.doMock('@controllers/mainView/MainViewExecutionController', () => ({
     prepareMainViewExecutionRequest: vi.fn(),
   }));
+  if (options.housekeeping) {
+    mocks.doMock('@housekeeping', () => options.housekeeping!);
+  }
   const { StreamLogStore, StreamSnapshotStore } = await import('@transcript');
   const createProgressSnapshotStore = (): ProgressSnapshotStore =>
     new StreamSnapshotStore();
@@ -593,6 +605,75 @@ function workflowConfig(): AgentConfig {
     model: 'deepseekproT',
     agentCategory: AgentCategory.Workflow,
     toolConfig: DEFAULT_TOOL_CONFIG,
+  });
+}
+
+function workflowFileOperationConfig(): AgentConfig {
+  return WorkflowAgentConfigSchema.parse({
+    ...workflowConfig(),
+    inputFiles: ['paper.tex'],
+    outputFiles: ['paper_revised.tex'],
+  });
+}
+
+function createHousekeepingMocks(): HousekeepingMocks {
+  const success = async () => ({ status: 'success' as const });
+  return {
+    runPackRunDir: vi.fn(success),
+    runCleanRunDir: vi.fn(success),
+    runPack: vi.fn(success),
+    runCleanSingle: vi.fn(success),
+    runCleanMultiple: vi.fn(success),
+  };
+}
+
+async function createWorkflowFileOperationBridge(
+  streamId: StreamTabId,
+  options: {
+    executionId?: ExecutionId;
+    showErrorMessage?: CreateBridgeOptions['showErrorMessage'];
+  } = {},
+): Promise<{ bridge: TestableBridge; housekeeping: HousekeepingMocks }> {
+  const housekeeping = createHousekeepingMocks();
+  const bridge = await createBridge([], {
+    housekeeping,
+    canonicalStreamIds: [streamId],
+    ...(options.showErrorMessage && {
+      showErrorMessage: options.showErrorMessage,
+    }),
+    configureProgressSnapshotStore: (store) => {
+      store.setRunConfig(
+        streamId,
+        workflowFileOperationConfig(),
+        options.executionId,
+      );
+    },
+  });
+  return { bridge, housekeeping };
+}
+
+async function invokeWorkflowFileOperation(
+  bridge: TestableBridge,
+  streamId: StreamTabId,
+  operation: 'pack' | 'clean',
+): Promise<void> {
+  if (operation === 'pack') {
+    const runOperation = assertSupported(
+      bridge.progressViewInboundHandlers[PROGRESS_VIEW_COMMANDS.PACK_STREAM],
+    );
+    await runOperation({
+      command: PROGRESS_VIEW_COMMANDS.PACK_STREAM,
+      stream: streamId,
+    });
+    return;
+  }
+
+  const runOperation = assertSupported(
+    bridge.progressViewInboundHandlers[PROGRESS_VIEW_COMMANDS.CLEAN_STREAM],
+  );
+  await runOperation({
+    command: PROGRESS_VIEW_COMMANDS.CLEAN_STREAM,
+    stream: streamId,
   });
 }
 
@@ -2105,6 +2186,72 @@ describe('DesktopProgressBridge', () => {
       }),
     );
   });
+
+  it('packs an identified execution only through its run directory', async () => {
+    const streamId = 'stream-pack' as StreamTabId;
+    const executionId = 'ec-a11' as ExecutionId;
+    const { bridge, housekeeping } = await createWorkflowFileOperationBridge(
+      streamId,
+      { executionId },
+    );
+
+    await invokeWorkflowFileOperation(bridge, streamId, 'pack');
+
+    expect(housekeeping.runPackRunDir).toHaveBeenCalledOnce();
+    expect(housekeeping.runPackRunDir).toHaveBeenCalledWith(
+      executionId,
+      'proofreader',
+      'deepseekproT',
+      'paper.tex',
+    );
+    expect(housekeeping.runCleanRunDir).not.toHaveBeenCalled();
+    expect(housekeeping.runPack).not.toHaveBeenCalled();
+    expect(housekeeping.runCleanSingle).not.toHaveBeenCalled();
+    expect(housekeeping.runCleanMultiple).not.toHaveBeenCalled();
+  });
+
+  it('cleans an identified execution only through its run directory', async () => {
+    const streamId = 'stream-clean' as StreamTabId;
+    const executionId = 'ec-c1ea' as ExecutionId;
+    const { bridge, housekeeping } = await createWorkflowFileOperationBridge(
+      streamId,
+      { executionId },
+    );
+
+    await invokeWorkflowFileOperation(bridge, streamId, 'clean');
+
+    expect(housekeeping.runCleanRunDir).toHaveBeenCalledOnce();
+    expect(housekeeping.runCleanRunDir).toHaveBeenCalledWith(executionId);
+    expect(housekeeping.runPackRunDir).not.toHaveBeenCalled();
+    expect(housekeeping.runPack).not.toHaveBeenCalled();
+    expect(housekeeping.runCleanSingle).not.toHaveBeenCalled();
+    expect(housekeeping.runCleanMultiple).not.toHaveBeenCalled();
+  });
+
+  it.each(['pack', 'clean'] as const)(
+    'rejects %s without an execution identity before any file operation',
+    async (operation) => {
+      const streamId = `stream-missing-${operation}` as StreamTabId;
+      const showErrorMessage = vi.fn(async () => undefined);
+      const { bridge, housekeeping } = await createWorkflowFileOperationBridge(
+        streamId,
+        {
+          showErrorMessage,
+        },
+      );
+
+      await invokeWorkflowFileOperation(bridge, streamId, operation);
+
+      expect(showErrorMessage).toHaveBeenCalledExactlyOnceWith(
+        `Missing execution identity for ${operation}.`,
+      );
+      expect(housekeeping.runPackRunDir).not.toHaveBeenCalled();
+      expect(housekeeping.runCleanRunDir).not.toHaveBeenCalled();
+      expect(housekeeping.runPack).not.toHaveBeenCalled();
+      expect(housekeeping.runCleanSingle).not.toHaveBeenCalled();
+      expect(housekeeping.runCleanMultiple).not.toHaveBeenCalled();
+    },
+  );
 
   it('resumes canonical streams using sidecar execution ids', async () => {
     const executionId = 'abc123';


### PR DESCRIPTION
## Summary

- directly cover desktop Pack dispatch to the execution run directory
- directly cover desktop Clean dispatch to the execution run directory
- prove missing execution identity fails visibly without falling back to workspace operations

## Context

Follow-up test-only coverage for merged PR #9612. These tests were requested by independent review before merge, but #9612 merged concurrently without them. Earlier follow-up #9624 was closed while main advanced; this branch is now rebased onto current main.

## Duplicate audit

This does **not** repeat #9612 production work. Current main contains the production patch; this PR modifies exactly one test file. Independent review confirmed the patch is unique (`git cherry`) and no other open PR touches `DesktopAgentExecution.vitest.mts`.

## Validation

- `DesktopAgentExecution.vitest.mts`: 77 passed
- desktop typecheck
- test-kernel typecheck
- targeted ESLint and Prettier
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `DesktopAgentExecution.vitest.mts` changes; no production code or runtime behavior.
> 
> **Overview**
> **Test-only follow-up** for merged run-directory pack/clean behavior in desktop `DesktopProgressBridge` (production already on main).
> 
> The harness can inject mocked `@housekeeping` (`runPackRunDir`, `runCleanRunDir`, and legacy workspace helpers). New helpers drive `PACK_STREAM` / `CLEAN_STREAM` against a workflow stream with `inputFiles` / `outputFiles` and an optional snapshot `executionId`.
> 
> **Pack** with an execution id calls `runPackRunDir` once with that id, agent, model, and input file, and never touches `runPack`, `runCleanRunDir`, or other clean/pack entry points. **Clean** with an id calls only `runCleanRunDir(executionId)`. **Pack and clean** without an execution id show `Missing execution identity for {pack|clean}.` and invoke no housekeeping APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4f4067b15beec9f7e3bd355fc5cb499f1c417a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->