### PR TITLE
refactor(desktop): remove legacy icon aliases

### DIFF
--- a/packages/desktop/src/renderer/desktopIconLibrary.ts
+++ b/packages/desktop/src/renderer/desktopIconLibrary.ts
@@ -13,10 +13,7 @@ import {
 } from '@awesome.me/webawesome/dist/components/icon/library.js';
 import iconNodes from 'lucide-static/icon-nodes.json';
 
-import {
-  TEXRA_ICON_LIBRARY,
-  LEGACY_ICON_ALIASES,
-} from '@shared/wa/webAwesomeIcons';
+import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 
 /**
  * Our icon name -> Lucide icon name.
@@ -195,13 +192,7 @@ function lucideSvg(name: string): string | undefined {
  * Direct lookup: canonical name → Lucide equivalent → fallback to name.
  */
 function resolveLucideName(name: string): string {
-  const canonical =
-    (LEGACY_ICON_ALIASES as Record<string, string>)[name] ?? name;
-  return (
-    LUCIDE_NAME_BY_TEXRA_NAME[canonical] ??
-    LUCIDE_NAME_BY_TEXRA_NAME[name] ??
-    name
-  );
+  return LUCIDE_NAME_BY_TEXRA_NAME[name] ?? name;
 }
 
 function svgDataUri(svg: string): string {

--- a/packages/desktop/src/renderer/desktopIconLibrary.ts
+++ b/packages/desktop/src/renderer/desktopIconLibrary.ts
@@ -68,7 +68,6 @@ const LUCIDE_NAME_BY_TEXRA_NAME: Readonly<Record<string, string>> = {
   gears: 'settings-2',
   screwdriver: 'wrench',
   'screwdriver-wrench': 'wrench',
-  tools: 'wrench',
   'wand-magic-sparkles': 'wand-sparkles',
   flask: 'flask-conical',
   microphone: 'mic',

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -314,7 +314,7 @@ export class FileSelectGroup extends LitElement {
         <div class="file-select-header">
           <div class="file-select-label-group">
             <span class="file-select-icon" aria-hidden="true">
-              ${waIcon(config.icon as TeXRAIconName)}
+              ${waIcon(config.icon)}
             </span>
             <label>${config.label}</label>
             ${

--- a/packages/extension/src/webview/frontend/store.ts
+++ b/packages/extension/src/webview/frontend/store.ts
@@ -177,7 +177,7 @@ export const FILE_SELECT_CONFIGS: ReadonlyArray<FileSelectConfig> = [
   {
     type: 'media',
     label: 'Media',
-    icon: 'device-camera-video',
+    icon: 'video',
     addOpenedLabel: 'Add opened files as media',
     emptyListLabel: 'Clear all media files',
     selectListLabel: 'Add media files',

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -6,6 +6,7 @@
 import { z } from 'zod';
 
 import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
+import { TEXRA_ICON_CANONICAL_NAMES } from '@shared/wa/iconNames';
 import { UIFileFieldsSchema, requiredFileListFields } from '../fileFields';
 import {
   CurrentFileTypeSchema,
@@ -206,7 +207,7 @@ export type DependencyBannerState = z.infer<typeof DependencyBannerStateSchema>;
 const FileSelectConfigSchema = z.object({
   type: DocumentFileTypeSchema,
   label: z.string(),
-  icon: z.string(),
+  icon: z.enum(TEXRA_ICON_CANONICAL_NAMES),
   addOpenedLabel: z.string(),
   emptyListLabel: z.string(),
   selectListLabel: z.string(),

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -286,7 +286,7 @@ let isRegistered = false;
  * may still reference the old names). The static migration handled the source
  * code; this map handles data that lives outside the repo.
  */
-export const LEGACY_ICON_ALIASES: Readonly<Record<string, keyof typeof icons>> =
+const LEGACY_ICON_ALIASES: Readonly<Record<string, keyof typeof icons>> =
   Object.freeze({
     close: 'xmark',
     diff: 'code-compare',

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -285,6 +285,11 @@ let isRegistered = false;
  * icon names (e.g. in localStorage, settings files, or telemetry events that
  * may still reference the old names). The static migration handled the source
  * code; this map handles data that lives outside the repo.
+ *
+ * Canonical names first shipped in extension v0.39.10 on 2026-07-29. Retain
+ * these aliases through 2026-10-29; remove them only after supported persisted
+ * and external extension icon names can no longer contain the legacy spellings
+ * tracked in #6981.
  */
 const LEGACY_ICON_ALIASES: Readonly<Record<string, keyof typeof icons>> =
   Object.freeze({

--- a/src/test-kernel/desktop/DesktopIconLibrary.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIconLibrary.vitest.mts
@@ -7,7 +7,6 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports - shared icon contract
 import {
-  LEGACY_ICON_ALIASES,
   TEXRA_ICON_LIBRARY,
   TEXRA_ICON_NAMES,
 } from '@shared/wa/webAwesomeIcons';
@@ -76,14 +75,14 @@ describe('desktop icon library', () => {
     expect(svg).not.toContain('<path fill="currentColor"');
   });
 
-  it('keeps aliases and unknown runtime names visible in both libraries', async () => {
-    const aliasSvg = decodeSvg(await resolve(texraResolver, 'send'));
+  it('keeps canonical and unknown runtime names visible in both libraries', async () => {
+    const canonicalSvg = decodeSvg(await resolve(texraResolver, 'send'));
     const unknownSvg = decodeSvg(
       await resolve(defaultResolver, 'unexpected-runtime-icon'),
     );
 
-    expect(aliasSvg).toContain('stroke-width="1.75"');
-    expect(aliasSvg).not.toContain('<path fill="currentColor"');
+    expect(canonicalSvg).toContain('stroke-width="1.75"');
+    expect(canonicalSvg).not.toContain('<path fill="currentColor"');
     expect(unknownSvg).toContain('stroke-width="1.75"');
   });
 
@@ -96,14 +95,6 @@ describe('desktop icon library', () => {
       unmapped: 'circle-question',
       // Guards the parse itself: an empty list would make the walk vacuous.
       minimumSize: 50,
-    },
-    {
-      // Aliases take an extra hop (alias -> canonical -> Lucide). Skipping that
-      // hop previously blanked 22 icons, so the whole table is walked.
-      table: 'codicon alias',
-      readNames: () => Object.keys(LEGACY_ICON_ALIASES),
-      unmapped: 'question',
-      minimumSize: 0,
     },
     {
       table: 'canonical TeXRA name',

--- a/src/test-kernel/desktop/DesktopIconLibrary.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIconLibrary.vitest.mts
@@ -76,7 +76,7 @@ describe('desktop icon library', () => {
   });
 
   it('keeps canonical and unknown runtime names visible in both libraries', async () => {
-    const canonicalSvg = decodeSvg(await resolve(texraResolver, 'send'));
+    const canonicalSvg = decodeSvg(await resolve(texraResolver, 'paper-plane'));
     const unknownSvg = decodeSvg(
       await resolve(defaultResolver, 'unexpected-runtime-icon'),
     );

--- a/src/test-kernel/shared/WebAwesomeIcons.vitest.ts
+++ b/src/test-kernel/shared/WebAwesomeIcons.vitest.ts
@@ -1,0 +1,36 @@
+// Third-party imports
+import { getIconLibrary } from '@awesome.me/webawesome/dist/components/icon/library.js';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// Local imports - shared icon registration
+import {
+  registerTeXRAWebAwesomeIcons,
+  TEXRA_ICON_LIBRARY,
+} from '@shared/wa/webAwesomeIcons';
+
+type IconResolver = NonNullable<ReturnType<typeof getIconLibrary>>['resolver'];
+
+let texraResolver: IconResolver;
+
+beforeAll(() => {
+  registerTeXRAWebAwesomeIcons();
+  const texraLibrary = getIconLibrary(TEXRA_ICON_LIBRARY);
+  if (!texraLibrary) throw new Error('TeXRA icon library was not registered.');
+  texraResolver = texraLibrary.resolver;
+});
+
+async function resolve(name: string): Promise<string> {
+  return texraResolver(name, 'classic', 'solid', false);
+}
+
+describe('extension Web Awesome icon registration', () => {
+  // #6981: retire this compatibility regression with the private alias table
+  // after 2026-10-29, once supported extension data cannot contain old names.
+  it('resolves retained legacy aliases through the public registration surface', async () => {
+    const legacyIcon = await resolve('tools');
+    const canonicalIcon = await resolve('screwdriver-wrench');
+
+    expect(legacyIcon).toBe(canonicalIcon);
+    expect(legacyIcon).toMatch(/^data:image\/svg\+xml,/);
+  });
+});


### PR DESCRIPTION
## Summary

Remove the legacy icon-name alias hop from the unreleased desktop renderer. Desktop producers use canonical `TeXRAIconName` values, so the renderer now resolves those names directly to Lucide geometry.

Keep the released extension's legacy alias table private and covered through its public registration surface. Also close the FileSelect contract gap that allowed a noncanonical media icon: the producer now uses canonical `video`, the schema derives the icon field from the canonical TeXRA vocabulary, and the renderer no longer needs an unsafe cast.

Refs #6981.

## Issue acceptance gates

- verify all current desktop icon producers use canonical names: satisfied;
- remove only the desktop compatibility reader: satisfied;
- preserve and regression-test the released extension alias boundary: satisfied;
- constrain the FileSelect icon producer/consumer contract without a new compatibility layer: satisfied;
- delete the desktop compatibility-only test row while retaining canonical and unknown-icon coverage: satisfied.

## Single source of truth

`TEXRA_ICON_CANONICAL_NAMES` defines the FileSelect icon contract, and `LUCIDE_NAME_BY_TEXRA_NAME` remains the desktop renderer mapping from canonical TeXRA icon names to differently named Lucide glyphs.

## Duplication and abstraction budget

No replacement alias table, resolver layer, migration, schema, or compatibility layer is added. The required released-extension compatibility test exercises `registerTeXRAWebAwesomeIcons()` rather than exporting the private table.

## Net elements (R6)

- files: 1 added, 0 deleted, 6 modified;
- exported symbols: 0 added, 1 deleted;
- classes/interfaces/enums: none added or deleted;
- actual lines: +52/-29, net +23;
- R7 accounting: the 36-line #6981 compatibility suite counts twice, yielding adjusted +88/-29, net +59. The positive delta is the required public-boundary regression plus the dated retirement documentation and schema type-safety fix; no production abstraction was added.

## Consumer counts (R8)

No event emit, subscription, or command-dispatch key changes. The formerly exported alias table had one desktop consumer, which is removed; the table is now private and remains consumed by the extension resolver.

## Host impact

Extension:

- released-extension compatibility is preserved: retained legacy aliases still resolve through the public registration surface;
- the FileSelect media producer now uses canonical `video`, restoring its intended video glyph.

Desktop:

- canonical TeXRA icon names resolve directly;
- retired aliases are no longer translated to their canonical TeXRA meanings. A retired spelling that is also a literal Lucide name, such as `diff`, `save`, or `search`, can still resolve as that Lucide glyph; other unknown runtime names use the existing question-marker fallback.

CLI:

- unchanged.

## Scheduled refactoring

The released-extension alias table remains through 2026-10-29, three months after canonical names first shipped in v0.39.10 on 2026-07-29. Remove it only after supported persisted/localStorage, settings, and external extension icon names can no longer contain the legacy spellings. The code comment, regression-test expiry comment, and #6981 ledger now record this condition.

## Validation

- focused Vitest: 3 files, 36 tests passed (`DesktopIconLibrary`, public Web Awesome registration, and main-view schema/state coverage);
- `typecheck:workspace`, `typecheck:test-kernel`, `typecheck:extension`, and `typecheck:desktop` passed;
- full `npm run lint` passed;
- targeted Prettier check passed;
- extension `compile:fast` and `desktop:build` passed (with existing Vite config/chunk-size warnings only);
- dead-code ratchet: 18 current findings, all baselined;
- pre-push changed-file lint passed;
- `git diff --check` passed.
