### PR TITLE
refactor(housekeeping): retire old workspace patterns

### DIFF
--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -5,13 +5,8 @@ import * as path from 'node:path';
 import { globIterate } from 'glob';
 
 // Local imports
-import { buildBetweenRoundDiffSuffix } from '@latex/latexdiff/diffFileNameManager';
 import * as logger from '@logger/logUtils';
-import {
-  legacyWorkflowOutputStem,
-  midEraWorkflowOutputStem,
-  normalizeLegacyModel,
-} from '@shared/constants/workflowOutput';
+import { legacyWorkflowOutputStem } from '@shared/constants/workflowOutput';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 
@@ -26,14 +21,9 @@ export function generateTimestamp(): string {
 }
 
 /**
- * Build glob patterns that match pre-refactor workflow output filenames
- * left over in the user's workspace. Current-layout outputs live inside
- * task-run storage (`executions/{id}/…`) and are managed per-execution, so
- * they are not scanned for here.
- *
- * Pass the raw agent identifier (with any source prefix) — the SSOT
- * helpers derive the legacy chunk form internally so the result matches
- * what pre-refactor runs wrote to disk.
+ * Build glob patterns for flat copies saved beside the source document.
+ * Current workflow outputs live in execution storage; the extension's
+ * "Save as copy" action is the sole writer of this workspace filename.
  */
 function getFilePatterns(
   base: string,
@@ -42,62 +32,9 @@ function getFilePatterns(
   numRounds: number,
 ): string[] {
   const patterns: string[] = [];
-  const legacyModel = normalizeLegacyModel(model);
-
-  // Mid-era layout: files live under `r{round}/<base>_<cleanAgent>_<model>.*`.
-  // These files can still be present in workspaces for users who upgraded
-  // from the mid-era PR; without matching patterns here, clean/pack would
-  // leave them orphaned.
-  const midEraStem = midEraWorkflowOutputStem({ base, agent, model });
-  for (let round = 0; round < numRounds; round++) {
-    patterns.push(
-      `r${round}/${midEraStem}`,
-      `r${round}/${midEraStem}_diff`,
-      `r${round}/${midEraStem}_thinking`,
-    );
-    if (round > 0) {
-      patterns.push(
-        `r${round}/${midEraStem}${buildBetweenRoundDiffSuffix(round, round - 1)}`,
-      );
-    }
-  }
 
   for (let round = 0; round < numRounds; round++) {
-    // Legacy flat layout: `<base>_<chunk>_r{round}_<normalizedModel>.*`
-    const legacyStem = legacyWorkflowOutputStem({ base, agent, model, round });
-    // Legacy stem already includes `_<normalizedModel>`; for suffix variants
-    // we reconstruct the prefix (everything up to the model token).
-    const legacyPrefix = legacyStem.slice(0, -(legacyModel.length + 1));
-    patterns.push(
-      legacyStem,
-      `${legacyStem}_diff`,
-      `${legacyPrefix}_full_${legacyModel}`,
-      `${legacyPrefix}_full_${legacyModel}_diff`,
-      `${legacyStem}_thinking`,
-    );
-    if (round > 0) {
-      const diffSuffix = buildBetweenRoundDiffSuffix(round, round - 1);
-      patterns.push(
-        `${legacyStem}${diffSuffix}`,
-        `${legacyPrefix}_full_${legacyModel}${diffSuffix}`,
-      );
-    }
-  }
-  // Legacy merge output lived next to the input and was named after the
-  // edited file (`<editedBase>_full_<model>.tex`). Requiring the `_` after
-  // `<base>` keeps siblings like `paper2_…` from matching when the target
-  // is `paper.tex`. Emit both raw and normalized-model variants so legacy
-  // merge files written with the dot-stripped model token
-  // (`paper_full_gpt45`) are discovered alongside current-legacy files
-  // (`paper_full_gpt-4.5`).
-  const mergeModels = legacyModel === model ? [model] : [model, legacyModel];
-  for (const m of mergeModels) {
-    patterns.push(
-      `${base}_full_${m}`,
-      `${base}_full_${m}_diff`,
-      `${base}_*_full_${m}`,
-      `${base}_*_full_${m}_diff`,
-    );
+    patterns.push(legacyWorkflowOutputStem({ base, agent, model, round }));
   }
   return patterns;
 }
@@ -134,8 +71,6 @@ export function resolveHousekeepingTargets(
   );
 
   const maxRounds = getConfig<number>('texra.agent.rounds', DEFAULT_MAX_ROUNDS);
-  // Pass the raw agent; getFilePatterns derives both the legacy chunk and
-  // the new clean-agent forms internally so both disk layouts are matched.
   const filePatterns = getFilePatterns(baseName, model, agent, maxRounds);
   logger.debug(CHANNEL, `Generated patterns: ${filePatterns}`);
 

--- a/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
+++ b/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
@@ -1,5 +1,5 @@
 // Node imports
-import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
@@ -7,7 +7,6 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports
-import { runCleanSingle } from '@housekeeping/clean';
 import {
   findFilesFromPatterns,
   resolveHousekeepingTargets,
@@ -90,18 +89,10 @@ describe('filename-era workflow output grammar', () => {
     expect(pattern.test('paper1_polish_r12_gpt-45')).toBe(false);
   });
 
-  it('matches flat and mid-era housekeeping files without matching siblings', async () => {
+  it('matches flat Save as copy files without matching siblings', async () => {
     await mkdir(path.join(workspacePath, 'r1'));
-    const matching = [
-      'paper_polish_r0_gpt-45.tex',
-      'paper_polish_r0_gpt-45_diff.tex',
-      'paper_polish_r0_full_gpt-45.tex',
-      'r1/paper_polish_long_gpt-4.5.tex',
-    ];
-    const nonMatching = [
-      'paper2_polish_r0_gpt-45.tex',
-      'r1/paper2_polish_long_gpt-4.5.tex',
-    ];
+    const matching = ['paper_polish_r0_gpt-45.tex'];
+    const nonMatching = ['paper2_polish_r0_gpt-45.tex'];
     for (const relativePath of [...matching, ...nonMatching]) {
       await writeFile(path.join(workspacePath, relativePath), 'fixture');
     }
@@ -129,21 +120,5 @@ describe('filename-era workflow output grammar', () => {
     for (const relativePath of nonMatching) {
       expect(found).not.toContain(relativePath);
     }
-  });
-
-  it('deletes a file matched by overlapping legacy patterns only once', async () => {
-    const inputPath = path.join(workspacePath, 'paper.tex');
-    const relativePath = 'paper_polish_r0_full_gpt-45.tex';
-    const absolutePath = path.join(workspacePath, relativePath);
-    await writeFile(inputPath, 'source');
-    await writeFile(absolutePath, 'fixture');
-
-    await expect(
-      runCleanSingle('gpt-4.5', 'paper.tex', 'custom:polish_long'),
-    ).resolves.toEqual({ status: 'success' });
-    await expect(access(absolutePath)).rejects.toMatchObject({
-      code: 'ENOENT',
-    });
-    await expect(access(inputPath)).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Remove workspace housekeeping globs for obsolete mid-era round directories, generated diff/thinking files, between-round files, and legacy merge outputs. Current workflow artifacts have lived under per-execution storage since 2026-04-21 (`e4df4c293c`), so these readers passed the three-month retirement date on 2026-07-21.

The one exact flat filename still written by the extension's current **Save as copy** action remains supported.

Refs #6981.

## Issue acceptance gates

- identify the old workspace writers and the exclusive per-execution replacement date: satisfied;
- audit current workspace writers before deleting patterns: satisfied;
- retain the exact flat filename still written by **Save as copy**: satisfied;
- remove obsolete globs, comments, imports, fixtures, and compatibility-only coverage together: satisfied.

## Single source of truth

`legacyWorkflowOutputStem` remains the shared grammar for the current **Save as copy** writer and the matching housekeeping reader. Current workflow-generated artifacts are owned by execution storage.

## Duplication and abstraction budget

Direct deletion. `getFilePatterns` now has one loop and one current workspace pattern. No replacement matcher, migration layer, or compatibility abstraction is added.

## Net elements (R6)

- files: 0 added, 0 deleted, 2 modified;
- exported symbols: none added or deleted;
- classes/interfaces/enums: none added or deleted;
- lines: +9/-99, net -90.

## Consumer counts (R8)

n/a: no event, subscription, command key, or exported API changes. The removed helper imports remain available to their current latexdiff consumers; housekeeping no longer consumes them.

## Host impact

Extension:

- Clean and pack continue to find copies created by **Save as copy** but no longer scan for workflow layouts retired in April.

Desktop:

- unchanged.

CLI:

- unchanged.

## Scheduled refactoring

No follow-up is required for the deleted patterns. The retained flat copy grammar is current behavior, not a dated compatibility reader; broader retirement evidence remains recorded in #6981.

## Validation

- `LegacyWorkflowOutput.vitest.ts`: 9 passed;
- test-kernel typecheck;
- extension typecheck;
- targeted ESLint and Prettier;
- dead-code ratchet;
- `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to no longer deleting/packing obsolete on-disk layouts users were expected to have migrated past; current Save-as-copy paths are unchanged.
> 
> **Overview**
> **Clean/pack** no longer scan the workspace for retired workflow layouts—mid-era `r{round}/` stems, `_diff` / `_thinking` / between-round variants, and legacy `_full_*` merge filenames. Workflow artifacts now live under per-execution storage; housekeeping only targets **flat “Save as copy”** names from `legacyWorkflowOutputStem` (one stem per configured round).
> 
> `getFilePatterns` is reduced to a single loop and drops latexdiff / mid-era SSOT imports. Tests are narrowed to that flat-copy match behavior and the overlapping-pattern clean integration test is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 743be6489fca777f15ae152aeb85cea7cdd5e152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->