### PR TITLE
refactor(cli): remove retired idle status

### DIFF
--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -23,20 +23,18 @@ import type { PendingApprovalKind } from '../state/approvalQueue';
  * away and carries no other affordance, so the CLI spends color on "this one
  * finished" (green) and "this one wants you" (yellow), where the webview keeps
  * both quiet and lets its own chrome carry that. A user stop is neither success
- * nor error, so it stays neutral in both. `stopped` and `idle` remain accepted
- * for historical snapshots of the retired live-status vocabulary. */
+ * nor error, so it stays neutral in both. */
 export function childStatusColor(status: string | undefined): string {
-  if (status === STREAM_PHASE.WAITING || status === 'idle') {
+  if (status === STREAM_PHASE.WAITING) {
     return COLOR_WARNING;
   }
   if (isChildExecutionErrorStatus(status)) return COLOR_ERROR;
   if (status === STREAM_PHASE.RUNNING || status === STREAM_PHASE.COMPLETED) {
     return COLOR_SUCCESS;
   }
-  // Everything else is neutral: a user stop (`cancelled`, or `stopped` in a
-  // historical snapshot), a stream that has not reported a phase yet, and any
-  // phase a future build adds. Green would report success for a state nobody
-  // established.
+  // Everything else is neutral: a user stop, a stream that has not reported a
+  // phase yet, and any phase a future build adds. Green would report success
+  // for a state nobody established.
   return COLOR_BORDER;
 }
 

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -437,7 +437,6 @@ describe('CLI child list display model', () => {
     expect(childStatusColor('error')).toBe('red');
     expect(childStatusColor('failed')).toBe('red');
     expect(childStatusColor('exit 2')).toBe('red');
-    expect(childStatusColor('stopped')).toBe('gray');
     expect(childStatusColor(STREAM_PHASE.CANCELLED)).toBe('gray');
     expect(childStatusColor(STREAM_PHASE.COMPLETED)).toBe('green');
   });


### PR DESCRIPTION
## Summary

Remove the CLI child-list color branch for the retired `idle` status. The production ingress carries the current `StreamPhase` vocabulary, and current roster/checkpoint schemas do not translate historical live-status values.

This is an explicitly breakable CLI/TUI protocol residue rather than a persisted-data migration. Current waiting, running, completed, cancelled, error, absent, and unknown-future values retain their existing presentation.

Refs #6981.

## Issue acceptance gates

- trace the renderer's production status ingress: satisfied;
- confirm current roster and checkpoint schemas do not produce `idle`: satisfied;
- remove the obsolete branch and historical-status commentary: satisfied;
- remove only the compatibility-specific test expectation: satisfied.

## Single source of truth

`StreamPhase` is the CLI child execution-status vocabulary. `childStatusColor` maps those current phases and treats unrecognized values neutrally.

## Duplication and abstraction budget

Direct deletion. No alias, normalization layer, schema migration, or replacement helper is added.

## Net elements (R6)

- files: 0 added, 0 deleted, 2 modified;
- exported symbols: none added or deleted;
- classes/interfaces/enums: none added or deleted;
- lines: +5/-8, net -3.

## Consumer counts (R8)

n/a: no event, subscription, command key, or exported API is deleted. The existing renderer remains the sole consumer of its color helper.

## Host impact

Extension:

- unchanged.

Desktop:

- unchanged.

CLI:

- `idle` no longer receives the warning color; as an unknown value it receives the existing neutral fallback.

## Scheduled refactoring

None. Current workflow-script checkpoints and stable roster schemas are already strict; no related translation layer remains.

## Validation

- `SubagentListDisplay.vitest.mts`: 30 passed;
- CLI typecheck;
- test-kernel typecheck;
- targeted ESLint and Prettier;
- dead-code ratchet;
- `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only TUI change with no API or persistence impact; only `idle` dot color changes from yellow to neutral.
> 
> **Overview**
> Drops legacy handling in **`childStatusColor`** for the retired **`idle`** live-status value and trims comments that described **`stopped`** / snapshot compatibility.
> 
> **`idle`** no longer maps to the warning (yellow) dot; it follows the same neutral fallback as other unrecognized phases. **`STREAM_PHASE.WAITING`**, running/completed, errors, and cancelled behavior are unchanged.
> 
> Tests drop the **`stopped`**-specific color assertion tied to that retired vocabulary; neutral/unknown-phase coverage stays in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a01010d8598982dd8885e27362fa8f3ff777e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->