### PR TITLE
refactor(storage): remove provider message wrappers

### DIFF
--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -13,7 +13,7 @@ import {
   type AgentConfig,
   AgentConfigSchema,
 } from '@agent/core/definition/AgentConfig';
-import { normalizeProviderMessages } from '@agent/types/ProviderMessage';
+import { ProviderMessageArraySchema } from '@agent/types/ProviderMessage';
 import { KVStore } from '@common/storage/KVStore';
 import * as logger from '@logger/logUtils';
 import { resolveRunStoragePath } from '@platform/defaults/workspaceStorage';
@@ -234,15 +234,15 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   async readConversation(): Promise<unknown[] | null> {
     const raw = await this.read(KEYS.CONVERSATION);
     if (raw == null) return null;
-    const messages = normalizeProviderMessages(raw);
-    if (messages === null) {
+    const result = ProviderMessageArraySchema.safeParse(raw);
+    if (!result.success) {
       logger.warn(
         CHANNEL,
         `Failed to parse execution ${this.executionId} ${KEYS.CONVERSATION}.json as provider messages`,
       );
       return null;
     }
-    return messages.length > 0 ? messages : null;
+    return result.data.length > 0 ? result.data : null;
   }
 
   async readWorkspaceFiles(): Promise<string[]> {

--- a/src/agent/types/ProviderMessage.ts
+++ b/src/agent/types/ProviderMessage.ts
@@ -51,20 +51,3 @@ const ProviderMessageSchema = z.custom<ProviderMessage>(
 );
 
 export const ProviderMessageArraySchema = z.array(ProviderMessageSchema);
-
-const ProviderMessageStorageSchema = z.union([
-  ProviderMessageArraySchema,
-  z
-    .looseObject({ messages: ProviderMessageArraySchema })
-    .transform(({ messages }) => messages),
-  z
-    .looseObject({ conversation: ProviderMessageArraySchema })
-    .transform(({ conversation }) => conversation),
-]);
-
-export function normalizeProviderMessages(
-  value: unknown,
-): ProviderMessage[] | null {
-  const result = ProviderMessageStorageSchema.safeParse(value);
-  return result.success ? result.data : null;
-}

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -291,28 +291,11 @@ describe('ExecutionKVStore meta read shims', () => {
     await expect(getExecutionStore(id).readMeta()).resolves.toBeNull();
   });
 
-  it('reads legacy conversation wrappers as provider messages', async () => {
-    const id = 'legacy-conversation-wrapper' as ExecutionId;
-    const message = { role: 'user', content: 'Resume this.' };
-
-    await getExecutionStore(id).write('conversation', { messages: [message] });
-    await expect(getExecutionStore(id).readConversation()).resolves.toEqual([
-      message,
-    ]);
-
-    await getExecutionStore(id).write('conversation', {
-      conversation: [message],
-    });
-    await expect(getExecutionStore(id).readConversation()).resolves.toEqual([
-      message,
-    ]);
-  });
-
   it('warns when conversation storage is malformed instead of silently dropping it', async () => {
-    const id = 'bad-conversation-wrapper' as ExecutionId;
+    const id = 'bad-conversation' as ExecutionId;
     const warnSpy = mockWarn();
 
-    await getExecutionStore(id).write('conversation', { messages: ['text'] });
+    await getExecutionStore(id).write('conversation', ['text']);
 
     await expect(getExecutionStore(id).readConversation()).resolves.toBeNull();
     expect(warnSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

Remove the provider-message object-wrapper normalizer from the legacy `conversation.json` fallback. Every historical writer for that file stored a raw message array; no writer or migration produced `{ messages }` or `{ conversation }` wrappers.

`ExecutionKVStore.readConversation` now validates the raw array directly. The released raw-array fallback, empty-array behavior, and malformed-data warning remain.

Refs #6981.

## Issue acceptance gates

- trace every wrapper parser caller: satisfied; `readConversation` was the sole production caller;
- trace historical and current `conversation.json` writers: satisfied; all wrote raw arrays;
- verify no migration or merge path carries wrapper objects into the file: satisfied;
- remove the unreachable schemas, exported normalizer, and wrapper-only test: satisfied;
- retain malformed raw-array and completed-run fallback coverage: satisfied.

## Single source of truth

`ProviderMessageArraySchema` directly defines the persisted `conversation.json` boundary. `ExecutionKVStore` no longer accepts a second storage container shape.

## Duplication and abstraction budget

Direct deletion. One private union and one exported pass-through normalizer are removed; no replacement wrapper or migration layer is added.

## Net elements (R6)

- files: 0 added, 0 deleted, 3 modified;
- exported symbols: 0 added, 1 deleted (`normalizeProviderMessages`);
- classes/interfaces/enums: none added or deleted;
- lines: +6/-40, net -34.

## Consumer counts (R8)

`normalizeProviderMessages` had one production consumer and zero other consumers. That caller now uses `ProviderMessageArraySchema` directly. No event, subscription, or command key changes.

## Host impact

Extension:

- released raw-array `conversation.json` fallbacks continue to load; never-written object wrappers are rejected.

Desktop:

- unchanged except for the shared strict raw-array boundary.

CLI:

- history and export retain the same raw-array fallback through `ExecutionKVStore`.

## Scheduled refactoring

None for the removed wrapper arms. The separate read-only `conversation.json` fallback remains tracked by its actual persisted-run retention condition in #6981.

## Validation

- `ExecutionKVStore.vitest.ts` and `completedRunArchive.vitest.ts`: 66 passed;
- workspace and test-kernel typechecks;
- targeted ESLint and Prettier;
- dead-code ratchet;
- `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small storage-boundary tightening with no writers producing wrapper shapes; raw-array resume behavior is unchanged.
> 
> **Overview**
> **`conversation.json` is now read as a raw provider message array only** — `ExecutionKVStore.readConversation` validates with `ProviderMessageArraySchema` instead of `normalizeProviderMessages`.
> 
> The PR **removes** the legacy union that accepted `{ messages }` or `{ conversation }` wrappers, the exported **`normalizeProviderMessages`** helper, and tests that asserted those wrapper shapes. **Malformed raw arrays** still log a warning and return `null`; **empty arrays** still map to `null`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 307ffd43831321affa131304f688abf6146e6898. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->