### PR TITLE
fix: validate progress view command arguments

### DIFF
--- a/packages/extension/src/commands/extensionCommandHandlers.ts
+++ b/packages/extension/src/commands/extensionCommandHandlers.ts
@@ -61,15 +61,10 @@ const CreateAgentWithAIArgsSchema = z.tuple([AgentCategorySchema.optional()]);
  */
 const ShowAgentsArgsSchema = z.tuple([AgentCategorySchema.optional()]);
 
-/**
- * Optional `{ inPlace }` argument for `texra.showProgressView`. The
- * legacy registration accepted any argument shape and only honoured the
- * `inPlace` boolean — `z.unknown()` here preserves that best-effort
- * semantics so callers passing `null`, booleans, or stringified flags
- * still open the progress view (just without the in-place flag) instead
- * of being rejected by the dispatcher as unhandled.
- */
-const ShowProgressViewArgsSchema = z.tuple([z.unknown().optional()]);
+/** Optional placement argument for `texra.showProgressView`. */
+const ShowProgressViewArgsSchema = z.tuple([
+  z.strictObject({ inPlace: z.boolean().optional() }).optional(),
+]);
 
 /** Positional arguments for opening a comparison between two files. */
 const CompareCommandArgsSchema = z
@@ -343,13 +338,8 @@ export const EXTENSION_COMMAND_HANDLERS = {
   'texra.toggleView': (actions) => awaitTrue(actions.toggleView()),
   'texra.showProgressView': definedHandler(
     ShowProgressViewArgsSchema,
-    (actions: ExtensionCommandActions, parsed?: unknown) => {
-      const inPlace =
-        typeof parsed === 'object' &&
-        parsed !== null &&
-        (parsed as { inPlace?: unknown }).inPlace === true;
-      return awaitTrue(actions.showProgressView(inPlace));
-    },
+    (actions: ExtensionCommandActions, options?: { inPlace?: boolean }) =>
+      awaitTrue(actions.showProgressView(options?.inPlace ?? false)),
   ),
   'texra.setApiKey': definedHandler(
     SetApiKeyArgsSchema,

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -151,7 +151,7 @@ export function createExtensionCommandActions(
  * Duplicate-registration audit (#3787 follow-up):
  * Every command id in `EXTENSION_COMMAND_HANDLERS` has been verified to
  * have no stale `vscode.commands.registerCommand(...)` call elsewhere.
- * The remaining legacy `registerCommand` call sites all register ids NOT
+ * The remaining direct `registerCommand` call sites all register ids NOT
  * tagged `extensionRegistry` in `commandCatalog` — they're legitimate VS
  * Code-only handlers (git, file selection/opening, merge, and LaTeX tools).
  */

--- a/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
@@ -466,6 +466,15 @@ describe('extension command surface — catalog-tagged command dispatch', () => 
     expect(actions.showProgressView).toHaveBeenCalledExactlyOnceWith(true);
   });
 
+  it.each([null, true, 'true', { inPlace: 'true' }, { extra: true }])(
+    'texra.showProgressView rejects malformed argument %j',
+    (argument) => {
+      const actions = makeActions();
+      expect(dispatch(actions, 'texra.showProgressView', argument)).toBe(false);
+      expect(actions.showProgressView).not.toHaveBeenCalled();
+    },
+  );
+
   it('texra.setApiKey forwards parsed provider', async () => {
     const actions = makeActions();
     await expect(


### PR DESCRIPTION
## Summary

- accepts only the two supported `texra.showProgressView` invocation forms: no argument or `{ inPlace?: boolean }`
- rejects wrong value types and unknown fields through the command registry’s existing invalid-argument path
- removes the obsolete comment that described direct command registrations as legacy

All current callers were audited: palette, keybinding, status bar, task setup, approval, and progress routing pass no argument; the main view passes `{ inPlace: true }`.

Closes #9630.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts` (66 tests)
- `corepack pnpm run typecheck:extension`
- ESLint and Prettier checks on the changed files
- pre-push checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow command-boundary validation for a single UI navigation command; known callers already use supported shapes, with no auth or data-handling impact.
> 
> **Overview**
> **Tightens `texra.showProgressView` argument handling** in the extension command registry. The command now accepts only **no argument** or an optional **`{ inPlace?: boolean }`** object validated with `z.strictObject`, replacing permissive `z.unknown()` parsing and manual `inPlace === true` checks.
> 
> **Malformed or extra-field payloads** (e.g. `null`, bare booleans, stringified flags, wrong `inPlace` types, unknown keys) **fail dispatch** with the registry’s existing invalid-argument path (`false`, no `showProgressView` call) instead of silently opening the progress view. Valid callers are unchanged: no-arg invocations still default `inPlace` to `false`; `{ inPlace: true }` still opens in place.
> 
> Tests add parameterized coverage for rejected shapes. A comment in `extensionCommandSurface.ts` wording tweak only (“legacy” → “direct” `registerCommand` sites).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc63d9eb4f1abb2628cbaaf025059cec498b7a95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->