### PR TITLE
fix(ui): unify composer action button

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -176,24 +176,6 @@ export class FollowUpInput extends LitElement {
         border-radius: var(--wa-border-radius-circle);
       }
 
-      .follow-up-actions .composer-send {
-        margin-left: auto;
-      }
-
-      .follow-up-actions .composer-send::part(base) {
-        color: var(--wa-color-surface-default);
-        background: var(--wa-color-text-normal);
-      }
-
-      .follow-up-actions .composer-send::part(base):hover {
-        color: var(--wa-color-surface-default);
-        background: color-mix(
-          in srgb,
-          var(--wa-color-text-normal) 86%,
-          var(--wa-color-surface-default)
-        );
-      }
-
       .follow-up-actions .recording::part(base) {
         color: var(--wa-color-danger-on-quiet);
         background: var(--wa-color-danger-fill-quiet);
@@ -463,8 +445,9 @@ export class FollowUpInput extends LitElement {
               icon: 'arrow-up',
               label: 'Send',
               tooltip: 'Send follow-up message',
-              className: 'composer-send',
+              className: 'composer-primary-action',
               appearance: 'filled',
+              size: 'l',
               onClick: this.emitSend,
             })}
           </div>

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.styles.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.styles.ts
@@ -286,32 +286,6 @@ export const instructionPanelStyles: CSSResult = css`
     height: var(--height-control);
   }
 
-  /*
-   * Execute is the primary action of the entire UI and the one place in this
-   * view that spends the accent budget. It carries .btn-primary, so the fill,
-   * radius, weight, hover, and focus ring all come from the shared skin; only
-   * the footer placement and the label floor are local.
-   */
-  wa-button.execute-button {
-    min-width: auto;
-    height: auto;
-    flex: 0 0 auto;
-    margin-left: auto;
-  }
-
-  wa-button.execute-button::part(base) {
-    min-width: 64px;
-  }
-
-  wa-button.execute-button wa-icon {
-    font-size: var(--font-size-sm);
-  }
-
-  .execute-button__label {
-    font-size: var(--font-size-sm);
-    line-height: var(--line-height-tight);
-  }
-
   /* Lock both selects to identical fixed width. Without flex: 0 0, the
      agent box would shrink/stretch with its label content (e.g.
      "humanize" vs. "🎯 orchestrator ☁"), shifting the model select to
@@ -344,7 +318,6 @@ export const instructionPanelStyles: CSSResult = css`
     width: 100%;
     container-name: desktop-composer;
     container-type: inline-size;
-    --desktop-send-size: var(--control-size-l);
     --agent-model-listbox-max-width: min(24rem, calc(100vw - 3rem));
   }
 
@@ -439,8 +412,7 @@ export const instructionPanelStyles: CSSResult = css`
     --control-size: var(--control-size-m);
   }
 
-  :host([desktop-host]) .desktop-drop-affordance .icon-surface wa-icon,
-  :host([desktop-host]) wa-button.execute-button wa-icon {
+  :host([desktop-host]) .desktop-drop-affordance .icon-surface wa-icon {
     display: block;
     flex: 0 0 auto;
     width: 1em;
@@ -460,7 +432,7 @@ export const instructionPanelStyles: CSSResult = css`
     grid-template-columns: minmax(0, 1fr) max-content;
     align-items: end;
     gap: var(--wa-space-2xs);
-    min-height: var(--desktop-send-size);
+    min-height: var(--control-size-l);
   }
 
   :host([desktop-host]) .model-selection-footer {
@@ -503,38 +475,6 @@ export const instructionPanelStyles: CSSResult = css`
     width: auto;
     min-width: 0;
     max-width: none;
-  }
-
-  :host([desktop-host]) wa-button.execute-button {
-    align-self: end;
-    justify-self: end;
-    margin: 0;
-  }
-
-  :host([desktop-host]) wa-button.execute-button::part(base) {
-    min-height: var(--desktop-send-size);
-    padding-inline: var(--wa-space-s);
-  }
-
-  :host([desktop-host]) wa-button.execute-button::part(label) {
-    display: flex;
-    align-items: center;
-    gap: var(--wa-space-2xs);
-  }
-
-  :host([desktop-host]) .execute-button__key {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 18px;
-    padding: 2px 4px;
-    border: var(--border-thin) solid
-      color-mix(in srgb, currentColor 24%, transparent);
-    border-radius: var(--border-radius);
-    background: color-mix(in srgb, currentColor 10%, transparent);
-    font-family: var(--wa-font-family-code);
-    font-size: var(--font-size-xs);
-    line-height: 1;
   }
 
   .visually-hidden {

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -751,28 +751,17 @@ export class InstructionPanel extends LitElement {
               </wa-select>
             </div>
           </div>
-          <wa-button
-            id="executeButton"
-            class="execute-button btn-primary"
-            appearance="filled"
-            variant="brand"
-            ?disabled=${!this.canExecute(session)}
-            aria-label=${this.desktopHost ? 'Send request' : 'Run agent'}
-            @click=${this.handleExecute}
-          >
-            ${
-              this.desktopHost
-                ? waIcon('paper-plane', { slot: 'start' })
-                : waIcon('play', { slot: 'start' })
-            }
-            <span class="execute-button__label">
-              ${this.desktopHost ? 'Send' : 'Run'}
-            </span>
-            ${this.desktopHost ? html`<kbd class="execute-button__key">↵</kbd>` : nothing}
-          </wa-button>
-          <wa-tooltip for="executeButton">
-            ${this.executeTooltip(session)}
-          </wa-tooltip>
+          ${renderIconActionButton({
+            id: 'executeButton',
+            icon: 'arrow-up',
+            label: this.desktopHost ? 'Send request' : 'Run agent',
+            tooltip: this.executeTooltip(session),
+            className: 'composer-primary-action',
+            appearance: 'filled',
+            size: 'l',
+            disabled: !this.canExecute(session),
+            onClick: this.handleExecute,
+          })}
         </div>
         <div class="visually-hidden" aria-live="polite">
           ${session.statusAnnouncement}

--- a/src/shared/styles/controlStyles.ts
+++ b/src/shared/styles/controlStyles.ts
@@ -369,7 +369,6 @@ export const buttonStyles: CSSResult = css`
      composers. The accessible label carries the host-specific verb; the
      visible affordance is deliberately identical. */
   .action-icon-button.composer-primary-action {
-    --control-size: var(--control-size-l);
     margin-left: auto;
   }
 

--- a/src/shared/styles/controlStyles.ts
+++ b/src/shared/styles/controlStyles.ts
@@ -365,6 +365,37 @@ export const buttonStyles: CSSResult = css`
     color: var(--color-error);
   }
 
+  /* Primary composer action shared by the initial request and follow-up
+     composers. The accessible label carries the host-specific verb; the
+     visible affordance is deliberately identical. */
+  .action-icon-button.composer-primary-action {
+    --control-size: var(--control-size-l);
+    margin-left: auto;
+  }
+
+  .action-icon-button.composer-primary-action::part(base) {
+    border-radius: var(--wa-border-radius-circle);
+    background: var(--wa-color-text-normal);
+    color: var(--wa-color-surface-default);
+  }
+
+  .action-icon-button.composer-primary-action::part(base):hover {
+    background: color-mix(
+      in srgb,
+      var(--wa-color-text-normal) 86%,
+      var(--wa-color-surface-default)
+    );
+    color: var(--wa-color-surface-default);
+  }
+
+  .action-icon-button.composer-primary-action[disabled]::part(base):is(
+      :hover,
+      :active
+    ) {
+    background: var(--wa-color-text-normal);
+    color: var(--wa-color-surface-default);
+  }
+
   @media (prefers-reduced-motion: reduce) {
     :is(
         .btn-primary,

--- a/src/test-kernel/webview/InstructionPanelDesktopComposer.vitest.mts
+++ b/src/test-kernel/webview/InstructionPanelDesktopComposer.vitest.mts
@@ -72,11 +72,8 @@ describe('instruction-panel desktop composer', () => {
     expect(query(desktop, '#executeButton').getAttribute('aria-label')).toBe(
       'Send request',
     );
-    expect(query(desktop, '.execute-button__label').textContent?.trim()).toBe(
-      'Send',
-    );
-    expect(query(desktop, '#executeButton wa-icon').getAttribute('slot')).toBe(
-      'start',
+    expect(query(desktop, '#executeButton wa-icon').getAttribute('name')).toBe(
+      'arrow-up',
     );
     expect(desktop.shadowRoot?.querySelector('#sessionTypeToggle')).toBeNull();
     expect(desktop.shadowRoot?.querySelector('#launchTargetToggle')).toBeNull();
@@ -101,15 +98,15 @@ describe('instruction-panel desktop composer', () => {
     expect(
       query(extension, '.instruction-header #sessionTypeToggle'),
     ).toBeTruthy();
+    expect(query(extension, '#executeButton').getAttribute('aria-label')).toBe(
+      'Run agent',
+    );
     expect(
-      query(extension, '#executeButton wa-icon').getAttribute('slot'),
-    ).toBe('start');
+      query(extension, '#executeButton wa-icon').getAttribute('name'),
+    ).toBe('arrow-up');
     expect(
       query(extension, '#sessionTypeToolUse').getAttribute('appearance'),
     ).toBe('default');
-    expect(query(extension, '.execute-button__label').textContent?.trim()).toBe(
-      'Run',
-    );
   });
 
   it('maps the unified desktop mode picker to the existing session state', async () => {

--- a/src/test-kernel/webview/InstructionPanelLauncher.vitest.mts
+++ b/src/test-kernel/webview/InstructionPanelLauncher.vitest.mts
@@ -285,15 +285,14 @@ describe('instruction-panel launcher', () => {
       expect(events).toEqual([{ type: 'team-settings', detail: null }]);
     });
 
-    it('labels the execute button "Run" and the model picker "Lead model"', async () => {
+    it('labels the execute action and the lead model picker', async () => {
       const element = await mountPanel(TEAM_SESSION);
 
       expect(
-        query<HTMLElement>(
-          element,
-          '.execute-button__label',
-        )?.textContent?.trim(),
-      ).toBe('Run');
+        query<HTMLElement>(element, '#executeButton')?.getAttribute(
+          'aria-label',
+        ),
+      ).toBe('Run agent');
       expect(query(element, '#model')?.getAttribute('aria-label')).toBe(
         'Lead model',
       );
@@ -301,15 +300,14 @@ describe('instruction-panel launcher', () => {
   });
 
   describe('agent launcher labels', () => {
-    it('labels the execute button "Run" and the model picker "Model"', async () => {
+    it('labels the execute action and the model picker', async () => {
       const element = await mountPanel(makeSession());
 
       expect(
-        query<HTMLElement>(
-          element,
-          '.execute-button__label',
-        )?.textContent?.trim(),
-      ).toBe('Run');
+        query<HTMLElement>(element, '#executeButton')?.getAttribute(
+          'aria-label',
+        ),
+      ).toBe('Run agent');
       expect(query(element, '#model')?.getAttribute('aria-label')).toBe(
         'Model',
       );


### PR DESCRIPTION
## Summary

Use one circular upward-arrow action for the initial request composer and the follow-up composer. The visible control is now identical across extension runs, desktop requests, and follow-up messages; host-specific wording remains in its accessible label and tooltip.

Closes #9637.

## Issue acceptance gates

- use the same circular upward-arrow affordance in both composers: satisfied;
- give the visual skin one shared owner: satisfied;
- retain `Run agent`, `Send request`, and `Send follow-up message` semantics for assistive text and tooltips: satisfied;
- preserve disabled behavior: satisfied;
- remove the old labeled Run/Send control and keyboard badge: satisfied.

## Single source of truth

`.composer-primary-action` in the shared button styles owns composer-submit alignment, circular shape, fill, hover, and disabled appearance. The existing large action-button size remains the single source for dimensions. Both components render the control through `renderIconActionButton`.

## Duplication and abstraction budget

The follow-up component's private send skin and the instruction panel's labeled-button CSS are deleted. No new component or wrapper is introduced; an existing shared action helper gains one semantic skin.

## Net elements (R6)

- files: 0 added, 0 deleted, 6 modified;
- exported symbols: none added or deleted;
- classes/interfaces/enums: none added or deleted;
- lines: +62/-125, net -63.

## Consumer counts (R8)

The shared composer-action class has two consumers: the initial request composer and follow-up composer. No event, subscription, command key, or exported API changes.

## Host impact

Extension:

- the Run action now matches the follow-up action visually.

Desktop:

- the initial Send request action uses the same circular upward arrow; its accessible label and tooltip remain desktop-specific.

CLI:

- unchanged.

## Scheduled refactoring

None.

## Validation

- focused instruction-panel and follow-up component suites: 31 passed;
- extension and test-kernel typechecks;
- targeted ESLint and Prettier;
- dead-code ratchet;
- `compile:fast` including all three webview bundles;
- `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and markup consolidation only; no API, IPC, or execute/send logic changes beyond swapping the control implementation.
> 
> **Overview**
> **Unifies the initial instruction composer and follow-up composer** behind the same large circular **arrow-up** submit control, replacing the old labeled Run/Send `wa-button` (and desktop keyboard badge) on the instruction panel.
> 
> Shared styling moves to **`.composer-primary-action`** in `controlStyles.ts` (right alignment, circular fill, hover, disabled). Both surfaces render through **`renderIconActionButton`** with host-specific **`aria-label`** / tooltips (`Run agent`, `Send request`, follow-up send) unchanged; disabled execute behavior is preserved.
> 
> Component-local execute/send CSS is removed from **`InstructionPanel.styles`** and **`FollowUpInput`**; vitests now assert icon and accessible labels instead of visible Run/Send text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edd05d322a8dd5b20ab77cb0b80324577c285659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->