### PR TITLE
refactor(auth): remove implicit callback fallback

### DIFF
--- a/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
+++ b/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
@@ -160,7 +160,6 @@ async function handleCallbackRequest(
     const result = await authCoordinator.createSessionFromCallback({
       path: CALLBACK_PATH,
       query: trimUrlMarker(body.query, '?'),
-      fragment: trimUrlMarker(body.fragment, '#'),
     });
     if (!result.success) throw new Error(result.error);
     if (!attemptState.acceptingCallbacks) {
@@ -220,7 +219,6 @@ function readRequestBody(request: IncomingMessage): Promise<string> {
  */
 const CallbackBodySchema = z.object({
   query: z.string().nullish().catch(undefined),
-  fragment: z.string().nullish().catch(undefined),
   nonce: z.string().nullish().catch(undefined),
 });
 
@@ -263,14 +261,12 @@ function callbackHtml(nonce: string): string {
   <p>Completing TeXRA CLI sign-in...</p>
   <script>
     const callbackQuery = window.location.search;
-    const callbackFragment = window.location.hash;
     window.history.replaceState(null, document.title, window.location.pathname);
     fetch('/auth-callback/complete', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         query: callbackQuery,
-        fragment: callbackFragment,
         nonce: ${JSON.stringify(nonce)}
       })
     })

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -430,14 +430,11 @@ async function processProtocolCallback(
   const result = await coordinator.createSessionFromCallback({
     path: callback.path,
     query: callback.query,
-    fragment: callback.fragment,
   });
 
   if (!result.success) {
     if (result.isAuthError) {
-      const callbackError =
-        new URLSearchParams(callback.query).get('error') ??
-        new URLSearchParams(callback.fragment).get('error');
+      const callbackError = new URLSearchParams(callback.query).get('error');
       if (callbackError === 'access_denied') {
         log.info('Desktop sign-in was cancelled in the system browser');
         return false;

--- a/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
+++ b/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
@@ -50,7 +50,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   private uriHandler: SupabaseUriHandler | null = null;
   private uriHandlerSubscription: vscode.Disposable | null = null;
   private readonly sessionCoordinator: SupabaseSessionCoordinator;
-  /** Flag to prevent race conditions between OAuth and magic link handlers */
+  /** Prevent concurrent callback handlers from storing competing sessions. */
   private isProcessingCallback = false;
 
   private readonly notifier: AuthNotifier;
@@ -99,10 +99,10 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
     this.uriHandler = handler;
 
-    // Set up persistent listener for late URI auth callbacks
-    // This handles cases where user clicks magic link outside of active OAuth flow
+    // Keep listening after an active sign-in wait ends so a late browser
+    // callback can still complete while its PKCE verifier remains in memory.
     this.uriHandlerSubscription = handler.onDidReceiveCallback(async (uri) => {
-      await this.handleMagicLinkCallback(uri);
+      await this.handleLateAuthCallback(uri);
     });
   }
 
@@ -115,11 +115,11 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   }
 
   /**
-   * Handle a late implicit-token auth callback URI.
+   * Handle a late PKCE auth callback URI.
    * This runs for all auth callbacks, but only processes if no session exists
    * and no OAuth flow is currently active.
    */
-  private async handleMagicLinkCallback(uri: vscode.Uri): Promise<void> {
+  private async handleLateAuthCallback(uri: vscode.Uri): Promise<void> {
     // Atomically claim processing - must be first check to prevent race
     if (this.isProcessingCallback) {
       return;
@@ -136,7 +136,6 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       const result = await this.sessionCoordinator.createSessionFromCallback({
         path: uri.path,
         query: uri.query,
-        fragment: uri.fragment,
       });
 
       if (!result.success) {
@@ -144,8 +143,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
           logger.error(CHANNEL, `Sign-in failed: ${result.error}`);
           this.notifier.showError(`Sign-in failed: ${result.error}`);
         } else {
-          // Log non-auth errors for debugging (e.g., missing tokens from non-auth callbacks)
-          logger.debug(CHANNEL, `Magic link callback ignored: ${result.error}`);
+          logger.debug(CHANNEL, `Auth callback ignored: ${result.error}`);
         }
         return;
       }
@@ -154,12 +152,12 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       this.notifier.showInfo(`Signed in as ${result.session.account.label}`);
       logger.info(
         CHANNEL,
-        `Magic link sign-in successful for ${result.session.account.label}`,
+        `Late sign-in successful for ${result.session.account.label}`,
       );
     } catch (error) {
       logger.error(
         CHANNEL,
-        `Error processing magic link callback: ${toErrorMessage(error)}`,
+        `Error processing auth callback: ${toErrorMessage(error)}`,
       );
       this.notifier.showError(`Sign-in failed: ${toErrorMessage(error)}`);
     } finally {
@@ -441,14 +439,13 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
             await this.sessionCoordinator.createSessionFromCallback({
               path: uri.path,
               query: uri.query,
-              fragment: uri.fragment,
             });
 
           if (!result.success) {
-            if (result.error === 'Missing tokens in callback') {
+            if (result.error === 'Missing authorization code in callback') {
               logger.error(
                 CHANNEL,
-                `Missing tokens in OAuth callback. Has fragment: ${!!uri.fragment}, Has query: ${!!uri.query}`,
+                `Missing authorization code in OAuth callback. Has query: ${!!uri.query}`,
               );
             }
             reject(new Error(`OAuth error: ${result.error}. Try again.`));

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -3,12 +3,10 @@ import { Mutex } from 'async-mutex';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   parseAuthCallbackCode,
-  parseAuthCallbackTokens,
   type AuthCallbackUriParts,
 } from './core/authCallback';
 import { fetchWithTimeout } from './fetchWithTimeout';
 import {
-  firstAccountLabel,
   parseStoredSupabaseSession,
   parseTokenExchangeResponse,
   toStorableSupabaseSession,
@@ -213,25 +211,14 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     };
   }
 
-  /**
-   * Convert an OAuth callback into a host-neutral session record. PKCE callbacks
-   * carry a one-time ?code= that is exchanged for a session; a legacy
-   * implicit-flow token callback (tokens in the fragment or query) is kept as a
-   * fallback so an older redirect target still authenticates.
-   */
+  /** Convert a PKCE OAuth callback into a host-neutral session record. */
   async createSessionFromCallback(
     uri: AuthCallbackUriParts,
   ): Promise<SupabaseCallbackResult> {
     const parsedCode = parseAuthCallbackCode(uri);
-    if (parsedCode.success) {
-      return this.createSessionViaCodeExchange(parsedCode.code);
-    }
-    // An explicit error in the callback is terminal for either flow.
-    if (parsedCode.isAuthError) {
-      return parsedCode;
-    }
-    // No code present: fall back to the legacy implicit-flow token callback.
-    return this.createSessionViaTokens(uri);
+    return parsedCode.success
+      ? this.createSessionViaCodeExchange(parsedCode.code)
+      : parsedCode;
   }
 
   private async createSessionViaCodeExchange(
@@ -250,43 +237,6 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     }
 
     return { success: true, session: toStorableSupabaseSession(data.session) };
-  }
-
-  private async createSessionViaTokens(
-    uri: AuthCallbackUriParts,
-  ): Promise<SupabaseCallbackResult> {
-    const parsedCallback = parseAuthCallbackTokens(uri);
-
-    if (!parsedCallback.success) return parsedCallback;
-
-    const { accessToken, refreshToken, expiresIn } = parsedCallback.tokens;
-    const { data, error: userError } = await this.options
-      .getClient()
-      .auth.getUser(accessToken);
-
-    if (userError || !data.user) {
-      return {
-        success: false,
-        error: userError?.message || 'User verification failed',
-        isAuthError: true,
-      };
-    }
-
-    const expiresAt = this.getCallbackExpiry(expiresIn);
-
-    return {
-      success: true,
-      session: {
-        id: data.user.id,
-        accessToken,
-        refreshToken,
-        account: {
-          id: data.user.id,
-          label: firstAccountLabel(data.user.email, data.user.id),
-        },
-        expiresAt,
-      },
-    };
   }
 
   /**
@@ -450,23 +400,6 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
       this.lastStoredSession.refreshToken === session.refreshToken &&
       this.lastStoredSession.id === session.id
     );
-  }
-
-  private getCallbackExpiry(expiresIn: string | null): number {
-    if (!expiresIn) {
-      return Date.now() + this.options.defaultSessionExpiryMs;
-    }
-
-    const expiresInSeconds = Number(expiresIn);
-    if (!Number.isFinite(expiresInSeconds) || expiresInSeconds <= 0) {
-      this.options.log?.warn?.(
-        'SupabaseSession',
-        `Invalid expires_in callback value: ${expiresIn}`,
-      );
-      return Date.now() + this.options.defaultSessionExpiryMs;
-    }
-
-    return Date.now() + expiresInSeconds * 1000;
   }
 
   private async refreshViaCustomEndpoint(

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -197,7 +197,7 @@ export function getExtensionId(): string {
 
 /**
  * Get the OAuth callback URI for redirects.
- * Used by both OAuth and magic link flows.
+ * Used by the OAuth flow.
  *
  * Note: This returns the base URI. Use getExternalAuthCallbackInfo() for
  * the environment-appropriate callback URL (handles Codespaces, Remote SSH, etc.)

--- a/src/auth/core/authCallback.ts
+++ b/src/auth/core/authCallback.ts
@@ -6,28 +6,13 @@ const AUTH_CALLBACK_PATHS = [
 export interface AuthCallbackUriParts {
   path: string;
   query?: string;
-  fragment?: string;
 }
 
-interface AuthCallbackTokens {
-  accessToken: string;
-  refreshToken: string;
-  expiresIn: string | null;
-}
-
-interface AuthCallbackTokenParseSuccess {
-  success: true;
-  tokens: AuthCallbackTokens;
-}
-
-interface AuthCallbackTokenParseError {
+interface AuthCallbackParseError {
   success: false;
   error: string;
   isAuthError?: boolean;
 }
-
-export type AuthCallbackTokenParseResult =
-  AuthCallbackTokenParseSuccess | AuthCallbackTokenParseError;
 
 export function getAuthCallbackBasePath(path: string): string {
   return path.split('?')[0];
@@ -44,74 +29,28 @@ function getQueryFromPath(path: string): string {
   return queryStart === -1 ? '' : path.slice(queryStart + 1);
 }
 
-/**
- * Read a callback URI's params and surface any auth error it carries.
- *
- * `priority` selects which source wins when a name appears in both the fragment
- * and the query: implicit-flow token callbacks prefer the fragment, PKCE code
- * callbacks prefer the query.
- */
-function readCallbackParams(
+/** Extract the PKCE authorization code or auth error from a callback query. */
+export function parseAuthCallbackCode(
   uri: AuthCallbackUriParts,
-  priority: 'fragment' | 'query',
-): {
-  getParam: (name: string) => string | null;
-  authError: AuthCallbackTokenParseError | null;
-} {
-  const fragmentParams = new URLSearchParams(uri.fragment ?? '');
+): AuthCallbackCodeParseResult {
   const queryParams = new URLSearchParams(
     uri.query || getQueryFromPath(uri.path),
   );
-  const sources =
-    priority === 'fragment'
-      ? [fragmentParams, queryParams]
-      : [queryParams, fragmentParams];
-
-  const getParam = (name: string): string | null => {
-    for (const source of sources) {
-      const value = source.get(name);
-      if (value !== null) return value;
-    }
-    return null;
-  };
+  const getParam = (name: string): string | null => queryParams.get(name);
 
   const error = getParam('error');
-  const authError: AuthCallbackTokenParseError | null = error
-    ? {
-        success: false,
-        error: getParam('error_description') || error,
-        isAuthError: true,
-      }
-    : null;
-
-  return { getParam, authError };
-}
-
-/**
- * Extract Supabase callback tokens or auth errors from host-neutral URI parts.
- * Fragment params win over query params, matching the legacy implicit-flow
- * callback. PKCE callbacks use parseAuthCallbackCode instead.
- */
-export function parseAuthCallbackTokens(
-  uri: AuthCallbackUriParts,
-): AuthCallbackTokenParseResult {
-  const { getParam, authError } = readCallbackParams(uri, 'fragment');
-  if (authError) return authError;
-
-  const accessToken = getParam('access_token');
-  const refreshToken = getParam('refresh_token');
-  if (!accessToken || !refreshToken) {
-    return { success: false, error: 'Missing tokens in callback' };
+  if (error) {
+    return {
+      success: false,
+      error: getParam('error_description') || error,
+      isAuthError: true,
+    };
   }
 
-  return {
-    success: true,
-    tokens: {
-      accessToken,
-      refreshToken,
-      expiresIn: getParam('expires_in'),
-    },
-  };
+  const code = getParam('code');
+  return code
+    ? { success: true, code }
+    : { success: false, error: 'Missing authorization code in callback' };
 }
 
 interface AuthCallbackCodeParseSuccess {
@@ -120,23 +59,4 @@ interface AuthCallbackCodeParseSuccess {
 }
 
 export type AuthCallbackCodeParseResult =
-  AuthCallbackCodeParseSuccess | AuthCallbackTokenParseError;
-
-/**
- * Extract the PKCE authorization code (or an auth error) from host-neutral URI
- * parts. The code arrives in the query string for the PKCE flow, so query wins
- * here, with the fragment as a defensive fallback.
- */
-export function parseAuthCallbackCode(
-  uri: AuthCallbackUriParts,
-): AuthCallbackCodeParseResult {
-  const { getParam, authError } = readCallbackParams(uri, 'query');
-  if (authError) return authError;
-
-  const code = getParam('code');
-  if (!code) {
-    return { success: false, error: 'Missing authorization code in callback' };
-  }
-
-  return { success: true, code };
-}
+  AuthCallbackCodeParseSuccess | AuthCallbackParseError;

--- a/src/auth/supabaseSessionTypes.ts
+++ b/src/auth/supabaseSessionTypes.ts
@@ -79,7 +79,7 @@ interface SupabaseCallbackParseError {
 export type SupabaseCallbackResult =
   SupabaseCallbackParseResult | SupabaseCallbackParseError;
 
-export function firstAccountLabel(
+function firstAccountLabel(
   ...candidates: readonly (string | null | undefined)[]
 ): string {
   for (const candidate of candidates) {

--- a/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
+++ b/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
@@ -365,30 +365,6 @@ describe('SupabaseSession', () => {
       assert.equal(getReadCount(), 1);
     });
 
-    it('creates a session from host-neutral callback URI parts', async () => {
-      const { coordinator } = createCoordinator();
-
-      const result = await coordinator.createSessionFromCallback({
-        path: '/auth-callback',
-        fragment: new URLSearchParams({
-          access_token: 'access-token',
-          refresh_token: 'refresh-token',
-          expires_in: '3600',
-        }).toString(),
-      });
-
-      assert.equal(result.success, true);
-      if (!result.success) return;
-      assert.equal(result.session.id, 'user-id');
-      assert.equal(result.session.accessToken, 'access-token');
-      assert.equal(result.session.refreshToken, 'refresh-token');
-      assert.deepEqual(result.session.account, {
-        id: 'user-id',
-        label: 'user@example.com',
-      });
-      assert.ok(result.session.expiresAt > Date.now());
-    });
-
     it('exchanges a PKCE code from the query for a session', async () => {
       const client = {
         auth: {
@@ -445,26 +421,21 @@ describe('SupabaseSession', () => {
       assert.equal(result.isAuthError, true);
     });
 
-    it('falls back to default callback expiry when expires_in is invalid', async () => {
+    it('rejects retired implicit-token callbacks', async () => {
       const { coordinator } = createCoordinator();
-      const earliestExpiry = Date.now() + DEFAULT_SUPABASE_SESSION_EXPIRY_MS;
 
       const result = await coordinator.createSessionFromCallback({
         path: '/auth-callback',
-        fragment: new URLSearchParams({
+        query: new URLSearchParams({
           access_token: 'access-token',
           refresh_token: 'refresh-token',
-          expires_in: 'not-a-number',
         }).toString(),
       });
 
-      assert.equal(result.success, true);
-      if (!result.success) return;
-      assert.ok(result.session.expiresAt >= earliestExpiry);
-      assert.ok(
-        result.session.expiresAt <=
-          Date.now() + DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
-      );
+      assert.deepEqual(result, {
+        success: false,
+        error: 'Missing authorization code in callback',
+      });
     });
 
     it('refreshes custom sessions through the injected fetch boundary', async () => {

--- a/src/test-kernel/auth/authCallback.vitest.ts
+++ b/src/test-kernel/auth/authCallback.vitest.ts
@@ -7,7 +7,6 @@ import {
   getAuthCallbackBasePath,
   isAuthCallbackPath,
   parseAuthCallbackCode,
-  parseAuthCallbackTokens,
 } from '@auth/core/authCallback';
 
 describe('authCallback', () => {
@@ -24,87 +23,6 @@ describe('authCallback', () => {
       '/extension-auth-callback',
     );
   });
-
-  it('extracts tokens from fragment params before query params', () => {
-    const result = parseAuthCallbackTokens({
-      path: '/auth-callback',
-      query: 'access_token=query-access&refresh_token=query-refresh',
-      fragment:
-        'access_token=fragment-access&refresh_token=fragment-refresh&expires_in=3600',
-    });
-
-    assert.deepEqual(result, {
-      success: true,
-      tokens: {
-        accessToken: 'fragment-access',
-        refreshToken: 'fragment-refresh',
-        expiresIn: '3600',
-      },
-    });
-  });
-
-  it('preserves empty fragment params instead of falling back to query', () => {
-    const result = parseAuthCallbackTokens({
-      path: '/auth-callback',
-      query: 'access_token=query-access&refresh_token=query-refresh',
-      fragment: 'access_token=&refresh_token=fragment-refresh',
-    });
-
-    assert.deepEqual(result, {
-      success: false,
-      error: 'Missing tokens in callback',
-    });
-  });
-
-  it('extracts tokens from query params when no fragment tokens exist', () => {
-    const result = parseAuthCallbackTokens({
-      path: '/auth-callback',
-      query: 'access_token=query-access&refresh_token=query-refresh',
-    });
-
-    assert.deepEqual(result, {
-      success: true,
-      tokens: {
-        accessToken: 'query-access',
-        refreshToken: 'query-refresh',
-        expiresIn: null,
-      },
-    });
-  });
-
-  it('extracts query params embedded in the path fallback', () => {
-    const result = parseAuthCallbackTokens({
-      path: '/extension-auth-callback?access_token=access&refresh_token=refresh',
-    });
-
-    assert.deepEqual(result, {
-      success: true,
-      tokens: {
-        accessToken: 'access',
-        refreshToken: 'refresh',
-        expiresIn: null,
-      },
-    });
-  });
-
-  it('reports auth errors and missing tokens', () => {
-    assert.deepEqual(
-      parseAuthCallbackTokens({
-        path: '/auth-callback',
-        fragment: 'error=access_denied&error_description=Nope',
-      }),
-      {
-        success: false,
-        error: 'Nope',
-        isAuthError: true,
-      },
-    );
-
-    assert.deepEqual(parseAuthCallbackTokens({ path: '/auth-callback' }), {
-      success: false,
-      error: 'Missing tokens in callback',
-    });
-  });
 });
 
 describe('parseAuthCallbackCode', () => {
@@ -112,27 +30,6 @@ describe('parseAuthCallbackCode', () => {
     assert.deepEqual(
       parseAuthCallbackCode({ path: '/auth-callback', query: 'code=abc123' }),
       { success: true, code: 'abc123' },
-    );
-  });
-
-  it('falls back to the fragment when the query has no code', () => {
-    assert.deepEqual(
-      parseAuthCallbackCode({
-        path: '/auth-callback',
-        fragment: 'code=frag-code',
-      }),
-      { success: true, code: 'frag-code' },
-    );
-  });
-
-  it('prefers the query code over a fragment code', () => {
-    assert.deepEqual(
-      parseAuthCallbackCode({
-        path: '/auth-callback',
-        query: 'code=query-code',
-        fragment: 'code=fragment-code',
-      }),
-      { success: true, code: 'query-code' },
     );
   });
 

--- a/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
@@ -62,14 +62,14 @@ describe('desktop protocol callbacks', () => {
   it('parses texra auth callback URLs into host-neutral callback parts', () => {
     expect(
       parseDesktopProtocolCallback(
-        'texra://texra-ai.texra/auth-callback?state=abc#access_token=tok&refresh_token=ref',
+        'texra://texra-ai.texra/auth-callback?state=abc&code=authorization-code',
       ),
     ).toEqual({
       rawUrl:
-        'texra://texra-ai.texra/auth-callback?state=abc#access_token=tok&refresh_token=ref',
+        'texra://texra-ai.texra/auth-callback?state=abc&code=authorization-code',
       path: '/auth-callback',
-      query: 'state=abc',
-      fragment: 'access_token=tok&refresh_token=ref',
+      query: 'state=abc&code=authorization-code',
+      fragment: '',
     });
   });
 
@@ -107,12 +107,12 @@ describe('desktop protocol callbacks', () => {
   it('accepts extension-auth-callback URLs for shared auth parsing', () => {
     expect(
       parseDesktopProtocolCallback(
-        'texra://extension-auth-callback?access_token=query&refresh_token=refresh',
+        'texra://extension-auth-callback?code=authorization-code',
       ),
     ).toEqual(
       expect.objectContaining({
         path: '/extension-auth-callback',
-        query: 'access_token=query&refresh_token=refresh',
+        query: 'code=authorization-code',
       }),
     );
   });
@@ -200,12 +200,12 @@ describe('desktop protocol callbacks', () => {
 
     app.listeners.openUrl?.(
       event,
-      'texra://texra-ai.texra/auth-callback#access_token=tok',
+      'texra://texra-ai.texra/auth-callback?code=authorization-code',
     );
 
     expect(event.preventDefault).toHaveBeenCalled();
     expect(listener).toHaveBeenCalledWith(
-      expect.objectContaining({ fragment: 'access_token=tok' }),
+      expect.objectContaining({ query: 'code=authorization-code' }),
     );
     expect(focusMainWindow).toHaveBeenCalled();
   });

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -129,17 +129,12 @@ function createOAuthClient() {
   };
 }
 
-function authCallbackUrl(input: {
-  accessToken: string;
-  refreshToken: string;
-  nonce?: string;
-}): string {
-  const fragment = new URLSearchParams({
-    access_token: input.accessToken,
-    refresh_token: input.refreshToken,
+function authCallbackUrl(input: { code: string; nonce?: string }): string {
+  const query = new URLSearchParams({
+    code: input.code,
   });
-  const query = input.nonce ? `?app_nonce=${input.nonce}` : '';
-  return `texra://texra-ai.texra/auth-callback${query}#${fragment}`;
+  if (input.nonce) query.set('app_nonce', input.nonce);
+  return `texra://texra-ai.texra/auth-callback?${query}`;
 }
 
 /** Extract the app_nonce that signIn placed on its OAuth redirect_to. */
@@ -154,12 +149,9 @@ function nonceFor(oauthClient: ReturnType<typeof createOAuthClient>): string {
 function routeMatchingCallback(
   router: DesktopProtocolCallbackRouter,
   oauthClient: ReturnType<typeof createOAuthClient>,
-  tokens: { accessToken: string; refreshToken: string } = {
-    accessToken: 'access-token',
-    refreshToken: 'refresh-token',
-  },
+  code = 'authorization-code',
 ): void {
-  router.routeUrl(authCallbackUrl({ ...tokens, nonce: nonceFor(oauthClient) }));
+  router.routeUrl(authCallbackUrl({ code, nonce: nonceFor(oauthClient) }));
 }
 
 function installAuthenticatedSupabaseProvider() {
@@ -291,8 +283,9 @@ describe('desktop Supabase auth', () => {
     });
     expect(coordinator.createSessionFromCallback).toHaveBeenCalledWith({
       path: '/auth-callback',
-      query: expect.stringMatching(/^app_nonce=[0-9a-f]{32}$/),
-      fragment: 'access_token=access-token&refresh_token=refresh-token',
+      query: expect.stringMatching(
+        /^code=authorization-code&app_nonce=[0-9a-f]{32}$/,
+      ),
     });
     expect(onSessionChanged).toHaveBeenCalled();
 
@@ -431,12 +424,11 @@ describe('desktop Supabase auth', () => {
     });
 
     await auth.signIn();
-    // Attacker-delivered deeplink carrying valid tokens for another account but
+    // Attacker-delivered deeplink carrying a valid code for another account but
     // NOT the nonce this client minted in its redirect_to.
     router.routeUrl(
       authCallbackUrl({
-        accessToken: 'attacker-access',
-        refreshToken: 'attacker-refresh',
+        code: 'attacker-code',
         nonce: 'deadbeefdeadbeefdeadbeefdeadbeef',
       }),
     );
@@ -461,8 +453,7 @@ describe('desktop Supabase auth', () => {
     await auth.signIn();
     router.routeUrl(
       authCallbackUrl({
-        accessToken: 'access-token',
-        refreshToken: 'refresh-token',
+        code: 'authorization-code',
       }),
     );
     await Promise.resolve();
@@ -483,7 +474,7 @@ describe('desktop Supabase auth', () => {
     });
 
     router.routeUrl(
-      'texra://texra-ai.texra/auth-callback#access_token=access-token&refresh_token=refresh-token',
+      'texra://texra-ai.texra/auth-callback?code=authorization-code',
     );
 
     await Promise.resolve();
@@ -568,8 +559,7 @@ describe('desktop Supabase auth', () => {
 
       router.routeUrl(
         authCallbackUrl({
-          accessToken: 'access-token',
-          refreshToken: 'refresh-token',
+          code: 'authorization-code',
         }),
       );
       await Promise.resolve();
@@ -690,13 +680,8 @@ describe('desktop Supabase auth', () => {
     });
 
     await auth.signIn();
-    routeMatchingCallback(router, oauthClient, {
-      accessToken: 'first',
-      refreshToken: 'first',
-    });
-    router.routeUrl(
-      authCallbackUrl({ accessToken: 'second', refreshToken: 'second' }),
-    );
+    routeMatchingCallback(router, oauthClient, 'first');
+    router.routeUrl(authCallbackUrl({ code: 'second' }));
 
     await vi.waitFor(() => {
       expect(coordinator.createSessionFromCallback).toHaveBeenCalledTimes(1);
@@ -759,10 +744,7 @@ describe('desktop Supabase auth', () => {
     });
 
     await auth.signIn();
-    routeMatchingCallback(router, oauthClient, {
-      accessToken: 'stale-access-token',
-      refreshToken: 'stale-refresh-token',
-    });
+    routeMatchingCallback(router, oauthClient, 'stale-code');
     await vi.waitFor(() => {
       expect(coordinator.storeSession).toHaveBeenCalledOnce();
     });
@@ -799,10 +781,7 @@ describe('desktop Supabase auth', () => {
     });
 
     await auth.signIn();
-    routeMatchingCallback(router, oauthClient, {
-      accessToken: 'stale-access-token',
-      refreshToken: 'stale-refresh-token',
-    });
+    routeMatchingCallback(router, oauthClient, 'stale-code');
     await vi.waitFor(() => {
       expect(coordinator.storeSession).toHaveBeenCalledOnce();
     });
@@ -818,10 +797,7 @@ describe('desktop Supabase auth', () => {
     expect(callbackState.hasPendingSignIn()).toBe(true);
     expect(onSessionChanged).not.toHaveBeenCalled();
 
-    routeMatchingCallback(router, oauthClient, {
-      accessToken: 'new-access-token',
-      refreshToken: 'new-refresh-token',
-    });
+    routeMatchingCallback(router, oauthClient, 'new-code');
     await vi.waitFor(() => {
       expect(coordinator.storeSession).toHaveBeenCalledTimes(2);
       expect(onSessionChanged).toHaveBeenCalledOnce();
@@ -852,10 +828,7 @@ describe('desktop Supabase auth', () => {
       });
 
       await auth.signIn();
-      routeMatchingCallback(router, oauthClient, {
-        accessToken: 'stale-access-token',
-        refreshToken: 'stale-refresh-token',
-      });
+      routeMatchingCallback(router, oauthClient, 'stale-code');
       await vi.waitFor(() => {
         expect(onSessionChanged).toHaveBeenCalledOnce();
       });
@@ -927,10 +900,7 @@ describe('desktop Supabase auth', () => {
     await expect(first).resolves.toBe(false);
     await new Promise((resolve) => setTimeout(resolve, 20));
 
-    routeMatchingCallback(router, oauthClient, {
-      accessToken: 'new-access-token',
-      refreshToken: 'new-refresh-token',
-    });
+    routeMatchingCallback(router, oauthClient, 'new-code');
 
     await expect(second).resolves.toBe(true);
     expect(coordinator.storeSession).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

- accepts only PKCE authorization-code callbacks from current TeXRA sign-in flows
- removes the retired implicit token parser, token-to-session conversion, expiry fallback, and compatibility-only tests
- reads PKCE codes and errors only from the callback query across extension, desktop, and CLI
- removes stale magic-link and fragment forwarding paths
- updates desktop callback fixtures to the authorization-code query shape produced by the current client

The PKCE flow replaced implicit OAuth callbacks on 2026-06-18. The remaining implicit writer, email magic-link sign-in, was removed on 2026-08-01 in #9490.

Closes #9629.

## Issue acceptance gates

- repository-wide search finds no production or test writer of token-bearing auth callback URLs
- extension, desktop, and CLI all pass only a PKCE query to session creation
- old token and fragment callback shapes fail with `Missing authorization code in callback`
- browser cancellation remains recognized from the PKCE query

## Single source of truth

`parseAuthCallbackCode` owns callback parsing, and `SupabaseSessionCoordinator.createSessionFromCallback` owns code exchange. All three hosts pass the same `{ path, query }` input.

## Duplication and abstraction budget

The change deletes the second parser, the second session-construction path, the callback-expiry fallback, fragment forwarding, and stale test formats. It adds no abstraction, schema, configuration key, or migration.

## Net elements (R6)

- 11 files changed
- 70 insertions, 389 deletions
- 2 exported token-parser symbols deleted; 0 exports added
- `firstAccountLabel` made module-private after its last external consumer was deleted

## Consumer counts (R8)

- 0 references remain to `parseAuthCallbackTokens`, `AuthCallbackTokenParseResult`, `createSessionViaTokens`, `getCallbackExpiry`, or `handleMagicLinkCallback`
- 0 token-bearing or fragment-based callback writers remain
- 3 host callback consumers remain: extension, desktop, and CLI; all use the canonical PKCE query

## Host impact

Extension: late browser callbacks continue to complete through the persistent listener, using their PKCE query.

Desktop: callbacks and cancellation errors use the query only; nonce validation is unchanged.

CLI: the loopback completion page posts the query and nonce only; callback storage behavior is unchanged.

## Scheduled refactoring

None. The complete obsolete callback path is removed in this pull request.

## Validation

- 111 focused tests across shared auth, extension auth, CLI callbacks, and desktop callbacks
- `corepack pnpm run check:dead-code-ratchet` (18 current, 18 baselined)
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:extension`
- `corepack pnpm run typecheck:desktop`
- `corepack pnpm run typecheck:cli`
- `corepack pnpm run typecheck:test-kernel`
- ESLint and Prettier checks on all changed files
- pre-push checks