### PR TITLE
refactor(schema): require active child kind

### DIFF
--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -23,31 +23,11 @@ import { RunUsageMapSchema } from './usage';
 // appear on either kind — e.g. a subagent launched via a specific CLI tool
 // (`options.toolName` in `createChildStream`), or a background process running
 // a named tool (`bash`, `codex`) — so it stays a shared, optional field.
-//
-// Where a roster comes from, since the legacy arms below are only meaningful
-// against it. The roster is liveness state, and every artifact we have written
-// carries an empty one: `assembleSnapshot` does not set `subagents` (it takes
-// the `[]` prefault) and every hydrate clamps it, `replayTrace()` included.
-// It still crosses two parse boundaries, because `StreamSnapshotSchema` picks
-// `subagents` from `BackendOwnedFieldsSchema`: the progress-view wire
-// (`UPDATE_STREAMS`/`STREAM_STATE`), and an exported `trace.json`, which the
-// standalone viewer re-parses — the same permanent second boundary documented
-// on `GroupLogPayloadSchema` in `./taskGroup`. So the legacy arms guard
-// cross-version input on those two boundaries, not our own on-disk state.
-//
-// Retire the roster's legacy arms — `fillLegacyActiveChildKind` and the "still
-// parse" halves of the optional fields below — on 2026-11-01, with the other
-// roster/task-group compat reads. They were added defensively against
-// persisted rosters that, per the note above, no release ever wrote.
 
 const ActiveChildInfoBaseSchema = z.object({
   executionId: z.string(),
   agentName: z.string(),
-  /**
-   * Current execution phase. Takes `StreamPhase` only: no artifact carries a
-   * roster (see the note above), so no input can hold the retired 7-value
-   * `StreamStatus` vocabulary and there is nothing to normalize here.
-   */
+  /** Current execution phase. */
   status: StreamPhaseSchema.optional(),
   /** Epoch milliseconds when the child execution began. */
   startedAt: z.int().positive().optional(),
@@ -76,42 +56,16 @@ const ActiveChildInfoBaseSchema = z.object({
   workflowPhase: z.string().optional(),
 });
 
-/**
- * Replayed ActiveChildInfo entries written before the `kind` discriminant
- * landed (2026-07-06) inferred subagent vs. process from array membership
- * (`subagents` vs. `processes`) or from whether `childStreamId` happened to be
- * set. `childStreamId` was — and still is — exclusive to subagents, so
- * backfill `kind` from that same signal on read, matching the legacy
- * inference, instead of failing to parse.
- */
-function fillLegacyActiveChildKind(raw: unknown): unknown {
-  if (
-    typeof raw !== 'object' ||
-    raw === null ||
-    (raw as { kind?: unknown }).kind !== undefined
-  ) {
-    return raw;
-  }
-  const data = raw as Record<string, unknown>;
-  return {
-    ...data,
-    kind: typeof data.childStreamId === 'string' ? 'subagent' : 'process',
-  };
-}
-
-export const ActiveChildInfoSchema = z.preprocess(
-  fillLegacyActiveChildKind,
-  z.discriminatedUnion('kind', [
-    ActiveChildInfoBaseSchema.extend({
-      kind: z.literal('subagent'),
-      /** Stream tab ID — subagents own their own tab. */
-      childStreamId: z.string(),
-    }),
-    ActiveChildInfoBaseSchema.extend({
-      kind: z.literal('process'),
-    }),
-  ]),
-);
+export const ActiveChildInfoSchema = z.discriminatedUnion('kind', [
+  ActiveChildInfoBaseSchema.extend({
+    kind: z.literal('subagent'),
+    /** Stream tab ID — subagents own their own tab. */
+    childStreamId: z.string(),
+  }),
+  ActiveChildInfoBaseSchema.extend({
+    kind: z.literal('process'),
+  }),
+]);
 
 export type ActiveChildInfo = z.infer<typeof ActiveChildInfoSchema>;
 export type SubagentChildInfo = Extract<ActiveChildInfo, { kind: 'subagent' }>;

--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -160,29 +160,11 @@ describe('ContextManagementDataSchema — legacy missing tokensAfter/utilization
   });
 });
 
-describe('ActiveChildInfoSchema — legacy missing kind discriminant', () => {
-  const legacyBase = {
+describe('ActiveChildInfoSchema — current status vocabulary', () => {
+  const base = {
     executionId: 'exec-1',
     agentName: 'review',
   };
-
-  it('infers kind: subagent from a legacy entry that has childStreamId', () => {
-    const result = ActiveChildInfoSchema.parse({
-      ...legacyBase,
-      childStreamId: 'stream-1',
-    });
-
-    expect(result).toMatchObject({
-      kind: 'subagent',
-      childStreamId: 'stream-1',
-    });
-  });
-
-  it('infers kind: process from a legacy entry without childStreamId', () => {
-    const result = ActiveChildInfoSchema.parse({ ...legacyBase });
-
-    expect(result).toMatchObject({ kind: 'process' });
-  });
 
   // `status` has no legacy migration on purpose. The child roster is liveness
   // state: `assembleSnapshot` never writes `subagents`, and every hydrate
@@ -192,7 +174,7 @@ describe('ActiveChildInfoSchema — legacy missing kind discriminant', () => {
   it('rejects a retired StreamStatus value rather than folding it', () => {
     expect(() =>
       ActiveChildInfoSchema.parse({
-        ...legacyBase,
+        ...base,
         kind: 'process',
         status: STREAM_STATUS.INITIALIZING,
       }),


### PR DESCRIPTION
## Summary

Remove the `ActiveChildInfoSchema` transform that inferred a missing `kind` from `childStreamId`. Kind-less child rows existed only in retired same-build live progress traffic; no released durable snapshot or exported trace can contain a nonempty kind-less roster.

The schema now directly requires the current `subagent` or `process` discriminant.

Refs #6981.

## Issue acceptance gates

- trace the pre-kind producer and current producer: satisfied;
- inspect every persistence, hydration, replay, and export boundary: satisfied;
- verify no released durable artifact wrote a nonempty kind-less roster: satisfied;
- delete the transform, speculative retirement prose, and its two inference tests: satisfied;
- retain current phase-vocabulary rejection: satisfied.

## Single source of truth

`ActiveChildInfoSchema` is a direct discriminated union on `kind`. Current producers set the discriminant at construction.

## Duplication and abstraction budget

Direct deletion. The preprocess layer and its historical inference rule are removed; no version union or replacement normalizer is added.

## Net elements (R6)

- files: 0 added, 0 deleted, 2 modified;
- exported symbols: none added or deleted;
- classes/interfaces/enums: none added or deleted;
- lines: +14/-78, net -64.

## Consumer counts (R8)

The deleted inference function was private to the schema. All current producers already supply `kind`; no event, subscription, command key, or exported API changes.

## Host impact

Extension:

- current child rows parse unchanged; speculative kind-less rows are rejected.

Desktop:

- current child rows parse unchanged; no desktop migration is added.

CLI:

- current roster and checkpoint vocabulary remains strict.

## Scheduled refactoring

None. The corresponding speculative row in #6981 can be marked executed after merge.

## Validation

- `SchemaMigrations.vitest.ts`: 14 passed;
- workspace and test-kernel typechecks;
- targeted ESLint and Prettier;
- dead-code ratchet;
- `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Stricter Zod parsing only affects kind-less rows that current producers do not emit and durable artifacts reportedly never stored; no API or producer changes.
> 
> **Overview**
> **`ActiveChildInfoSchema` no longer backfills a missing `kind` on parse.** The `z.preprocess` + `fillLegacyActiveChildKind` path is removed; rows must be a discriminated union with explicit `kind: 'subagent'` (and required `childStreamId`) or `kind: 'process'`.
> 
> Long comments about speculative legacy rosters, parse boundaries, and scheduled retirement are trimmed; **`status` stays `StreamPhase` only** with no migration.
> 
> **Tests:** the two cases that inferred `kind` from `childStreamId` are deleted; the suite still asserts retired `StreamStatus` values are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56aef8cc577b17b69671b25622369b474cfcb05a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->