### PR TITLE
fix(cli): deduplicate account access status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Account status is concise and unambiguous** — `/auth` and `/api status`
+  now show model preferences, account identities, personal keys, and included
+  usage once each instead of repeating the same access in several forms.
 - **Automatic CLI runs stop after their model retry limit** — automatic
   approval mode no longer restarts another full retry sequence when every
   configured attempt has failed.

--- a/packages/cli/src/chat/tui/commands/handlers/statusAssembly.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/statusAssembly.ts
@@ -1,5 +1,5 @@
 import {
-  loadCliApiStatus,
+  loadCliDetailedAccountStatusLines,
   loadCliModelAccessOverview,
 } from '@cli/runtime/apiStatus';
 import type { ApiAccessMode } from '@shared/schemas/profileViewMessages';
@@ -9,14 +9,10 @@ export async function loadCliAccountStatusLines(options: {
   readonly apiMode: ApiAccessMode;
   readonly includeApiDetails?: boolean;
 }): Promise<string[]> {
-  const [overview, apiStatus] = await Promise.all([
-    loadCliModelAccessOverview({ apiMode: options.apiMode }),
-    options.includeApiDetails
-      ? loadCliApiStatus({ apiMode: options.apiMode })
-      : Promise.resolve(undefined),
-  ]);
-  const detailLines =
-    apiStatus?.detailLines.filter((line) => !overview.lines.includes(line)) ??
-    [];
-  return [...overview.lines, ...detailLines];
+  if (options.includeApiDetails) {
+    return loadCliDetailedAccountStatusLines({ apiMode: options.apiMode });
+  }
+  return [
+    ...(await loadCliModelAccessOverview({ apiMode: options.apiMode })).lines,
+  ];
 }

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -61,28 +61,6 @@ export interface CliModelAccessOverview {
   readonly lines: readonly string[];
 }
 
-interface CliAccessSnapshot {
-  readonly access: CliModelAccessStatus;
-  readonly profile: CliAuthProfile;
-  readonly personalKeyProviders: readonly string[];
-}
-
-/** Read the route-owned facts used by the detailed account renderer once. */
-async function loadCliAccessSnapshot(
-  apiMode: ApiAccessMode,
-): Promise<CliAccessSnapshot> {
-  const [access, profile, configuredPersonalKeyProviders] = await Promise.all([
-    readCliModelAccessStatus(apiMode),
-    getCliAuthProfile(),
-    personalKeyProviders(),
-  ]);
-  return {
-    access: { ...access, texraSignedIn: profile.authenticated },
-    profile,
-    personalKeyProviders: configuredPersonalKeyProviders,
-  };
-}
-
 /** Read both account sessions and the effective model-access route. */
 export async function loadCliModelAccessOverview(
   options: { readonly apiMode?: ApiAccessMode } = {},
@@ -236,11 +214,11 @@ export async function loadCliApiStatus(
 export async function loadCliDetailedAccountStatusLines(options: {
   readonly apiMode: ApiAccessMode;
 }): Promise<string[]> {
-  const {
-    access,
-    personalKeyProviders: providers,
-    profile,
-  } = await loadCliAccessSnapshot(options.apiMode);
+  const [access, profile, providers] = await Promise.all([
+    readCliModelAccessStatus(options.apiMode),
+    getCliAuthProfile(),
+    personalKeyProviders(),
+  ]);
   const includedUsage =
     access.apiFallback === 'included'
       ? await loadIncludedUsageLine(profile)

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -57,15 +57,35 @@ export interface CliModelAccessOverview {
   readonly lines: readonly string[];
 }
 
+interface CliAccessSnapshot {
+  readonly access: CliModelAccessStatus;
+  readonly profile: CliAuthProfile;
+  readonly personalKeyProviders: readonly string[];
+}
+
+/** Read the account, route, and credential facts once for every renderer. */
+async function loadCliAccessSnapshot(
+  apiMode: ApiAccessMode,
+  options: { readonly includePersonalKeys?: boolean } = {},
+): Promise<CliAccessSnapshot> {
+  const [access, profile, configuredPersonalKeyProviders] = await Promise.all([
+    readCliModelAccessStatus(apiMode),
+    getCliAuthProfile(),
+    options.includePersonalKeys ? personalKeyProviders() : Promise.resolve([]),
+  ]);
+  return {
+    access: { ...access, texraSignedIn: profile.authenticated },
+    profile,
+    personalKeyProviders: configuredPersonalKeyProviders,
+  };
+}
+
 /** Read both account sessions and the effective model-access route. */
 export async function loadCliModelAccessOverview(
   options: { readonly apiMode?: ApiAccessMode } = {},
 ): Promise<CliModelAccessOverview> {
   const apiMode = options.apiMode ?? getCliApiMode();
-  const [access, profile] = await Promise.all([
-    readCliModelAccessStatus(apiMode),
-    getCliAuthProfile(),
-  ]);
+  const { access, profile } = await loadCliAccessSnapshot(apiMode);
   const lines = [
     `ChatGPT preference: ${formatCliChatGptPreference(access)}`,
     `Kimi Code preference: ${formatCliKimiCodePreference(access)}`,
@@ -78,26 +98,22 @@ export async function loadCliModelAccessOverview(
   ];
   if (profile.note) lines.push(profile.note);
   return {
-    access: { ...access, texraSignedIn: profile.authenticated },
+    access,
     lines,
   };
 }
 
 /**
- * Warn when a provider key is present at the same time as a relay sign-in: the
- * active `--api-mode` / `/api` setting decides which is actually used, so a
- * stale env key can silently shadow a fresh login (a documented footgun in
- * comparable CLIs). Returns `undefined` unless both credential paths exist.
+ * Format the neutral personal-key inventory from the canonical access facts.
  */
-export function formatApiKeyShadowWarning(
-  authenticated: boolean,
+export function formatPersonalApiKeysLine(
   personalKeyProviders: readonly string[],
 ): string | undefined {
-  if (!authenticated || personalKeyProviders.length === 0) return undefined;
+  if (personalKeyProviders.length === 0) return undefined;
   const providers = personalKeyProviders
     .map((provider) => PROVIDER_DISPLAY_NAMES[provider] ?? provider)
     .join(', ');
-  return `available: included TeXRA access; personal API keys: ${providers}`;
+  return `personal API keys: ${providers}`;
 }
 
 const CLI_API_STATUS_ACTION_HINTS: Record<
@@ -144,8 +160,6 @@ async function personalKeyProviders(): Promise<string[]> {
 export interface CliApiStatus {
   /** Compact lines used by the launcher. */
   readonly lines: readonly string[];
-  /** API account facts appended to the detailed account overview. */
-  readonly detailLines: readonly string[];
 }
 
 export interface LoadCliApiStatusOptions {
@@ -153,55 +167,55 @@ export interface LoadCliApiStatusOptions {
   readonly includeActionHint?: boolean;
 }
 
+async function loadIncludedUsageLine(
+  profile: CliAuthProfile,
+): Promise<string | undefined> {
+  if (!profile.authenticated || !profile.tier) return undefined;
+  // Usage reads usage_logs via PostgREST with a session token; a relay-scoped
+  // CI token cannot read it, while a session alongside that token can.
+  const canReadUsage =
+    profile.credentialSource !== 'relayToken' ||
+    (await getCliSessionAccessToken()) !== null;
+  if (!canReadUsage) {
+    return 'included usage: not available with a CI relay token (run `texra login` to view usage)';
+  }
+  try {
+    const usageTier = (await resolveCliUsageTier(profile)) ?? 'free';
+    return formatRelayUsageStatus(
+      await fetchRelayUsageSummary({ tier: usageTier }),
+    );
+  } catch (error: unknown) {
+    return `included usage: unavailable (${toErrorMessage(error)})`;
+  }
+}
+
 export async function loadCliApiStatus(
   options: LoadCliApiStatusOptions = {},
 ): Promise<CliApiStatus> {
   const mode = options.apiMode ?? getCliApiMode();
-  const profile = await getCliAuthProfile();
+  const snapshot = await loadCliAccessSnapshot(mode, {
+    includePersonalKeys: true,
+  });
+  const { personalKeyProviders: configuredPersonalKeyProviders, profile } =
+    snapshot;
   let authLine = formatCliAuthStatusLine(profile);
-  const configuredPersonalKeyProviders =
-    options.includeActionHint === true || profile.authenticated
-      ? await personalKeyProviders()
-      : [];
   const hasPersonalKey = configuredPersonalKeyProviders.length > 0;
   const actionHint = options.includeActionHint
     ? formatCliApiStatusActionHint(mode, profile, { hasPersonalKey })
     : undefined;
 
-  const shadowWarning = formatApiKeyShadowWarning(
-    profile.authenticated,
+  const personalKeysLine = formatPersonalApiKeysLine(
     configuredPersonalKeyProviders,
   );
   const supplementalLines = [
-    ...(shadowWarning ? [shadowWarning] : []),
+    ...(personalKeysLine ? [personalKeysLine] : []),
     ...(profile.note ? [profile.note] : []),
   ];
-  const detailLines = [...supplementalLines];
   if (profile.authenticated && profile.tier) {
-    detailLines.push(`tier: ${profile.tier}`);
-    // Usage reads usage_logs via PostgREST with a session token; a
-    // relay-scoped CI token cannot read it. Explain the limitation (same as
-    // `texra auth usage`) instead of surfacing a generic fetch error — but a
-    // session alongside the env token can still read its own usage.
-    const canReadUsage =
-      profile.credentialSource !== 'relayToken' ||
-      (await getCliSessionAccessToken()) !== null;
-    let usage: string;
-    if (!canReadUsage) {
-      usage =
-        'included usage: not available with a CI relay token (run `texra login` to view usage)';
-    } else {
-      try {
-        const usageTier = (await resolveCliUsageTier(profile)) ?? 'free';
-        usage = formatRelayUsageStatus(
-          await fetchRelayUsageSummary({ tier: usageTier }),
-        );
-      } catch (error: unknown) {
-        usage = `included usage: unavailable (${toErrorMessage(error)})`;
-      }
+    const usage = await loadIncludedUsageLine(profile);
+    if (usage) {
+      authLine = `${authLine} · ${usage}`;
     }
-    detailLines.push(usage);
-    authLine = `${authLine} · ${usage}`;
   }
 
   return {
@@ -211,8 +225,48 @@ export async function loadCliApiStatus(
       ...supplementalLines,
       ...(actionHint ? [actionHint] : []),
     ],
-    detailLines,
   };
+}
+
+function formatPreferenceState(
+  state: 'off' | 'on',
+  missingCredential: 'key' | 'sign-in' | undefined,
+): string {
+  const label = state === 'on' ? 'On' : 'Off';
+  if (state === 'off' || missingCredential === undefined) return label;
+  return `${label} (${missingCredential === 'key' ? 'key' : 'sign in'} required)`;
+}
+
+/** Render the detailed account view once from the canonical access facts. */
+export async function loadCliDetailedAccountStatusLines(options: {
+  readonly apiMode: ApiAccessMode;
+}): Promise<string[]> {
+  const {
+    access,
+    personalKeyProviders: providers,
+    profile,
+  } = await loadCliAccessSnapshot(options.apiMode, {
+    includePersonalKeys: true,
+  });
+  const chatGpt = formatPreferenceState(
+    access.preferences.chatGpt,
+    access.chatGptSignedIn ? undefined : 'sign-in',
+  );
+  const kimiCode = formatPreferenceState(
+    access.preferences.kimiCode,
+    access.kimiCodeKeySet === true ? undefined : 'key',
+  );
+  const lines = [
+    `Model access: ChatGPT ${chatGpt} · Kimi Code ${kimiCode} · fallback ${formatCliModelAccessRoute(access.apiFallback)}`,
+    `Accounts: ChatGPT ${access.chatGptSignedIn ? (access.chatGptAccountLabel ?? 'signed in') : 'signed out'} · TeXRA ${profile.authenticated ? (profile.accountLabel ?? 'signed in') : 'signed out'}`,
+    formatPersonalApiKeysLine(providers) ?? 'personal API keys: none',
+  ];
+  if (profile.note) lines.push(profile.note);
+  if (profile.authenticated && profile.tier) {
+    const usage = await loadIncludedUsageLine(profile);
+    lines.push(`tier: ${profile.tier}${usage ? ` · ${usage}` : ''}`);
+  }
+  return lines;
 }
 
 export async function loadCliApiStatusLines(

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -251,10 +251,25 @@ export async function loadCliDetailedAccountStatusLines(options: {
           }
         : { kind: 'personal' as const },
   };
-  const lines = [
-    `ChatGPT: ${routes.chatGpt.preferred ? 'preferred' : 'not preferred'} · ${routes.chatGpt.account}`,
-    `Kimi Code: ${routes.kimiCode.preferred ? 'preferred' : 'not preferred'} · ${routes.kimiCode.credential}`,
-  ];
+  const lines: string[] = [];
+  if (routes.chatGpt.preferred || access.chatGptSignedIn) {
+    const account =
+      routes.chatGpt.preferred && !access.chatGptSignedIn
+        ? 'sign in required'
+        : routes.chatGpt.account;
+    lines.push(
+      `ChatGPT: ${routes.chatGpt.preferred ? 'preferred' : 'not preferred'} · ${account}`,
+    );
+  }
+  if (routes.kimiCode.preferred || access.kimiCodeKeySet === true) {
+    const credential =
+      routes.kimiCode.preferred && access.kimiCodeKeySet !== true
+        ? 'key required'
+        : routes.kimiCode.credential;
+    lines.push(
+      `Kimi Code: ${routes.kimiCode.preferred ? 'preferred' : 'not preferred'} · ${credential}`,
+    );
+  }
   if (routes.fallback.kind === 'included') {
     lines.push(
       [

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -43,13 +43,17 @@ export function formatCliAuthStatusLine(
     : account;
 }
 
+function formatAccountStatus(signedIn: boolean, accountLabel?: string): string {
+  if (!signedIn) return 'signed out';
+  return `signed in${accountLabel ? ` as ${accountLabel}` : ''}`;
+}
+
 function formatAccountStatusLine(
   label: string,
   signedIn: boolean,
   accountLabel?: string,
 ): string {
-  if (!signedIn) return `${label}: signed out`;
-  return `${label}: signed in${accountLabel ? ` as ${accountLabel}` : ''}`;
+  return `${label}: ${formatAccountStatus(signedIn, accountLabel)}`;
 }
 
 export interface CliModelAccessOverview {
@@ -63,15 +67,14 @@ interface CliAccessSnapshot {
   readonly personalKeyProviders: readonly string[];
 }
 
-/** Read the account, route, and credential facts once for every renderer. */
+/** Read the route-owned facts used by the detailed account renderer once. */
 async function loadCliAccessSnapshot(
   apiMode: ApiAccessMode,
-  options: { readonly includePersonalKeys?: boolean } = {},
 ): Promise<CliAccessSnapshot> {
   const [access, profile, configuredPersonalKeyProviders] = await Promise.all([
     readCliModelAccessStatus(apiMode),
     getCliAuthProfile(),
-    options.includePersonalKeys ? personalKeyProviders() : Promise.resolve([]),
+    personalKeyProviders(),
   ]);
   return {
     access: { ...access, texraSignedIn: profile.authenticated },
@@ -85,7 +88,10 @@ export async function loadCliModelAccessOverview(
   options: { readonly apiMode?: ApiAccessMode } = {},
 ): Promise<CliModelAccessOverview> {
   const apiMode = options.apiMode ?? getCliApiMode();
-  const { access, profile } = await loadCliAccessSnapshot(apiMode);
+  const [access, profile] = await Promise.all([
+    readCliModelAccessStatus(apiMode),
+    getCliAuthProfile(),
+  ]);
   const lines = [
     `ChatGPT preference: ${formatCliChatGptPreference(access)}`,
     `Kimi Code preference: ${formatCliKimiCodePreference(access)}`,
@@ -98,22 +104,21 @@ export async function loadCliModelAccessOverview(
   ];
   if (profile.note) lines.push(profile.note);
   return {
-    access,
+    access: { ...access, texraSignedIn: profile.authenticated },
     lines,
   };
 }
 
-/**
- * Format the neutral personal-key inventory from the canonical access facts.
- */
+/** Format a neutral personal-key inventory. */
 export function formatPersonalApiKeysLine(
   personalKeyProviders: readonly string[],
+  label = 'personal API keys',
 ): string | undefined {
   if (personalKeyProviders.length === 0) return undefined;
   const providers = personalKeyProviders
     .map((provider) => PROVIDER_DISPLAY_NAMES[provider] ?? provider)
     .join(', ');
-  return `personal API keys: ${providers}`;
+  return `${label}: ${providers}`;
 }
 
 const CLI_API_STATUS_ACTION_HINTS: Record<
@@ -193,11 +198,10 @@ export async function loadCliApiStatus(
   options: LoadCliApiStatusOptions = {},
 ): Promise<CliApiStatus> {
   const mode = options.apiMode ?? getCliApiMode();
-  const snapshot = await loadCliAccessSnapshot(mode, {
-    includePersonalKeys: true,
-  });
-  const { personalKeyProviders: configuredPersonalKeyProviders, profile } =
-    snapshot;
+  const [profile, configuredPersonalKeyProviders] = await Promise.all([
+    getCliAuthProfile(),
+    personalKeyProviders(),
+  ]);
   let authLine = formatCliAuthStatusLine(profile);
   const hasPersonalKey = configuredPersonalKeyProviders.length > 0;
   const actionHint = options.includeActionHint
@@ -228,16 +232,7 @@ export async function loadCliApiStatus(
   };
 }
 
-function formatPreferenceState(
-  state: 'off' | 'on',
-  missingCredential: 'key' | 'sign-in' | undefined,
-): string {
-  const label = state === 'on' ? 'On' : 'Off';
-  if (state === 'off' || missingCredential === undefined) return label;
-  return `${label} (${missingCredential === 'key' ? 'key' : 'sign in'} required)`;
-}
-
-/** Render the detailed account view once from the canonical access facts. */
+/** Render each detailed account/access fact on its owning route. */
 export async function loadCliDetailedAccountStatusLines(options: {
   readonly apiMode: ApiAccessMode;
 }): Promise<string[]> {
@@ -245,27 +240,64 @@ export async function loadCliDetailedAccountStatusLines(options: {
     access,
     personalKeyProviders: providers,
     profile,
-  } = await loadCliAccessSnapshot(options.apiMode, {
-    includePersonalKeys: true,
-  });
-  const chatGpt = formatPreferenceState(
-    access.preferences.chatGpt,
-    access.chatGptSignedIn ? undefined : 'sign-in',
-  );
-  const kimiCode = formatPreferenceState(
-    access.preferences.kimiCode,
-    access.kimiCodeKeySet === true ? undefined : 'key',
-  );
+  } = await loadCliAccessSnapshot(options.apiMode);
+  const includedUsage =
+    access.apiFallback === 'included'
+      ? await loadIncludedUsageLine(profile)
+      : undefined;
+  const routes = {
+    chatGpt: {
+      preferred: access.preferences.chatGpt === 'on',
+      account: formatAccountStatus(
+        access.chatGptSignedIn,
+        access.chatGptAccountLabel,
+      ),
+    },
+    kimiCode: {
+      preferred: access.preferences.kimiCode === 'on',
+      credential:
+        access.kimiCodeKeySet === true
+          ? 'key configured'
+          : 'key not configured',
+    },
+    fallback:
+      access.apiFallback === 'included'
+        ? {
+            kind: 'included' as const,
+            account: formatAccountStatus(
+              profile.authenticated,
+              profile.accountLabel,
+            ),
+            tier: profile.authenticated ? profile.tier : undefined,
+            usage: includedUsage,
+          }
+        : { kind: 'personal' as const },
+  };
   const lines = [
-    `Model access: ChatGPT ${chatGpt} · Kimi Code ${kimiCode} · fallback ${formatCliModelAccessRoute(access.apiFallback)}`,
-    `Accounts: ChatGPT ${access.chatGptSignedIn ? (access.chatGptAccountLabel ?? 'signed in') : 'signed out'} · TeXRA ${profile.authenticated ? (profile.accountLabel ?? 'signed in') : 'signed out'}`,
-    formatPersonalApiKeysLine(providers) ?? 'personal API keys: none',
+    `ChatGPT: ${routes.chatGpt.preferred ? 'preferred' : 'not preferred'} · ${routes.chatGpt.account}`,
+    `Kimi Code: ${routes.kimiCode.preferred ? 'preferred' : 'not preferred'} · ${routes.kimiCode.credential}`,
   ];
-  if (profile.note) lines.push(profile.note);
-  if (profile.authenticated && profile.tier) {
-    const usage = await loadIncludedUsageLine(profile);
-    lines.push(`tier: ${profile.tier}${usage ? ` · ${usage}` : ''}`);
+  if (routes.fallback.kind === 'included') {
+    lines.push(
+      [
+        'Fallback: Included TeXRA access',
+        routes.fallback.account,
+        routes.fallback.tier,
+        routes.fallback.usage,
+      ]
+        .filter((part): part is string => part !== undefined)
+        .join(' · '),
+    );
+  } else {
+    lines.push('Fallback: Personal API keys');
   }
+
+  const otherPersonalKeys = formatPersonalApiKeysLine(
+    providers.filter((provider) => provider !== 'kimiCode'),
+    'Other personal keys',
+  );
+  if (otherPersonalKeys) lines.push(otherPersonalKeys);
+  if (profile.note) lines.push(profile.note);
   return lines;
 }
 

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.mts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.mts
@@ -72,7 +72,6 @@ describe('loadCliApiStatusLines', () => {
       name: 'without a profile note',
       profile: { authenticated: false },
       lines: ['api: personal API keys', 'auth: signed out'],
-      detailLines: [],
     },
     {
       name: 'with a profile note',
@@ -85,19 +84,14 @@ describe('loadCliApiStatusLines', () => {
         'auth: signed out',
         'The configured relay token was rejected.',
       ],
-      detailLines: ['The configured relay token was rejected.'],
     },
-  ])(
-    'preserves signed-out details $name',
-    async ({ profile, lines, detailLines }) => {
-      mocks.getCliAuthProfile.mockResolvedValue(profile);
+  ])('preserves signed-out details $name', async ({ profile, lines }) => {
+    mocks.getCliAuthProfile.mockResolvedValue(profile);
 
-      await expect(loadCliApiStatus()).resolves.toEqual({
-        lines,
-        detailLines,
-      });
-    },
-  );
+    await expect(loadCliApiStatus()).resolves.toEqual({
+      lines,
+    });
+  });
 
   it('uses an invocation API mode override for launcher status text', async () => {
     await expect(
@@ -113,7 +107,7 @@ describe('loadCliApiStatusLines', () => {
     expect(mocks.getCliApiMode).not.toHaveBeenCalled();
   });
 
-  it('keeps action hints out of detailed account facts', async () => {
+  it('includes action hints only when requested', async () => {
     const actionHint =
       'actions: choose Model access below; `texra login` signs in to Researcher Access';
 
@@ -123,8 +117,6 @@ describe('loadCliApiStatusLines', () => {
     });
 
     expect(status.lines).toContain(actionHint);
-    expect(status.detailLines).not.toContain(actionHint);
-    expect(status.detailLines).toEqual([]);
   });
 
   it('keeps launcher usage compact while exposing detailed account facts', async () => {
@@ -142,10 +134,6 @@ describe('loadCliApiStatusLines', () => {
         'api: personal API keys',
         'auth: signed in as researcher@example.com · tier: Ultra · included usage this month: 100.3% used, 0% remaining',
       ],
-      detailLines: [
-        'tier: Ultra',
-        'included usage this month: 100.3% used, 0% remaining',
-      ],
     });
     await expect(loadCliApiStatusLines()).resolves.toEqual([
       'api: personal API keys',
@@ -153,7 +141,7 @@ describe('loadCliApiStatusLines', () => {
     ]);
   });
 
-  it('preserves profile notes and personal-key warnings in detailed facts', async () => {
+  it('preserves profile notes and the personal-key inventory', async () => {
     mocks.getCliAuthProfile.mockResolvedValue({
       authenticated: true,
       accountLabel: 'researcher@example.com',
@@ -169,14 +157,8 @@ describe('loadCliApiStatusLines', () => {
       lines: [
         'api: personal API keys',
         'auth: signed in as researcher@example.com · tier: Researcher · included usage this month: 25.0% used, 75.0% remaining',
-        'available: included TeXRA access; personal API keys: DeepSeek',
+        'personal API keys: DeepSeek',
         'Account metadata may be stale.',
-      ],
-      detailLines: [
-        'available: included TeXRA access; personal API keys: DeepSeek',
-        'Account metadata may be stale.',
-        'tier: Researcher',
-        'included usage this month: 25.0% used, 75.0% remaining',
       ],
     });
   });
@@ -197,7 +179,6 @@ describe('loadCliApiStatusLines', () => {
         'api: personal API keys',
         `auth: signed in as CI relay token (TEXRA_RELAY_TOKEN) · tier: Researcher · ${unavailable}`,
       ],
-      detailLines: ['tier: Researcher', unavailable],
     });
     expect(mocks.fetchRelayUsageSummary).not.toHaveBeenCalled();
   });
@@ -217,10 +198,6 @@ describe('loadCliApiStatusLines', () => {
         'api: personal API keys',
         'auth: signed in as researcher@example.com · tier: Ultra · included usage: unavailable (quota offline)',
       ],
-      detailLines: [
-        'tier: Ultra',
-        'included usage: unavailable (quota offline)',
-      ],
     });
   });
 
@@ -237,6 +214,37 @@ describe('loadCliApiStatusLines', () => {
     });
 
     expect(lines.filter((line) => line === profileNote)).toHaveLength(1);
+  });
+
+  it('renders one detailed snapshot for preferences, accounts, keys, and usage', async () => {
+    mocks.readCliModelAccessStatus.mockResolvedValue({
+      apiFallback: 'included',
+      preferences: { chatGpt: 'on', kimiCode: 'on' },
+      chatGptSignedIn: true,
+      chatGptAccountLabel: 'chatgpt@example.com',
+      kimiCodeKeySet: true,
+    });
+    mocks.getCliAuthProfile.mockResolvedValue({
+      authenticated: true,
+      accountLabel: 'texra@example.com',
+      tier: 'Ultra',
+      credentialSource: 'session',
+    });
+    mocks.lookupApiKeyOrigin.mockResolvedValue('env');
+    mocks.resolveCliUsageTier.mockResolvedValue('Ultra');
+    mocks.fetchRelayUsageSummary.mockResolvedValue({ usagePercent: 24.5 });
+
+    await expect(
+      loadCliAccountStatusLines({
+        apiMode: 'included',
+        includeApiDetails: true,
+      }),
+    ).resolves.toEqual([
+      'Model access: ChatGPT On · Kimi Code On · fallback Included TeXRA access',
+      'Accounts: ChatGPT chatgpt@example.com · TeXRA texra@example.com',
+      'personal API keys: DeepSeek',
+      'tier: Ultra · included usage this month: 24.5% used, 75.5% remaining',
+    ]);
   });
 
   it('reports both preferences and the API fallback without collapsing them', async () => {
@@ -272,6 +280,17 @@ describe('loadCliApiStatusLines', () => {
     });
   });
 
+  it('loads the model-access form without reading personal-key storage', async () => {
+    mocks.lookupApiKeyOrigin.mockRejectedValue(new Error('keychain offline'));
+
+    await expect(
+      loadCliModelAccessOverview({ apiMode: 'personal' }),
+    ).resolves.toMatchObject({
+      access: { apiFallback: 'personal' },
+    });
+    expect(mocks.lookupApiKeyOrigin).not.toHaveBeenCalled();
+  });
+
   it('reports Kimi and ChatGPT preference states separately', async () => {
     mocks.readCliModelAccessStatus.mockResolvedValue({
       apiFallback: 'personal',
@@ -300,6 +319,7 @@ describe('loadCliApiStatusLines', () => {
     ).resolves.toEqual([
       'api: personal API keys',
       'auth: signed out',
+      'personal API keys: DeepSeek',
       'actions: choose Model access below; provider keys are configured',
     ]);
   });

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.mts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.mts
@@ -218,6 +218,113 @@ describe('loadCliApiStatusLines', () => {
     expect(mocks.lookupApiKeyOrigin).toHaveBeenCalledTimes(2);
   });
 
+  it.each([
+    {
+      name: 'off and signed out',
+      preference: 'off',
+      signedIn: false,
+      expected: ['Fallback: Personal API keys'],
+    },
+    {
+      name: 'off and signed in',
+      preference: 'off',
+      signedIn: true,
+      expected: [
+        'ChatGPT: not preferred · signed in as chatgpt@example.com',
+        'Fallback: Personal API keys',
+      ],
+    },
+    {
+      name: 'on and signed out',
+      preference: 'on',
+      signedIn: false,
+      expected: [
+        'ChatGPT: preferred · sign in required',
+        'Fallback: Personal API keys',
+      ],
+    },
+    {
+      name: 'on and signed in',
+      preference: 'on',
+      signedIn: true,
+      expected: [
+        'ChatGPT: preferred · signed in as chatgpt@example.com',
+        'Fallback: Personal API keys',
+      ],
+    },
+  ] as const)(
+    'renders the ChatGPT route when available: $name',
+    async ({ expected, preference, signedIn }) => {
+      mocks.readCliModelAccessStatus.mockResolvedValue({
+        apiFallback: 'personal',
+        preferences: { chatGpt: preference, kimiCode: 'off' },
+        chatGptSignedIn: signedIn,
+        chatGptAccountLabel: signedIn ? 'chatgpt@example.com' : undefined,
+        kimiCodeKeySet: false,
+      });
+
+      await expect(
+        loadCliAccountStatusLines({
+          apiMode: 'personal',
+          includeApiDetails: true,
+        }),
+      ).resolves.toEqual(expected);
+    },
+  );
+
+  it.each([
+    {
+      name: 'off without a key',
+      preference: 'off',
+      keySet: false,
+      expected: ['Fallback: Personal API keys'],
+    },
+    {
+      name: 'off with a key',
+      preference: 'off',
+      keySet: true,
+      expected: [
+        'Kimi Code: not preferred · key configured',
+        'Fallback: Personal API keys',
+      ],
+    },
+    {
+      name: 'on without a key',
+      preference: 'on',
+      keySet: false,
+      expected: [
+        'Kimi Code: preferred · key required',
+        'Fallback: Personal API keys',
+      ],
+    },
+    {
+      name: 'on with a key',
+      preference: 'on',
+      keySet: true,
+      expected: [
+        'Kimi Code: preferred · key configured',
+        'Fallback: Personal API keys',
+      ],
+    },
+  ] as const)(
+    'renders the Kimi Code route when available: $name',
+    async ({ expected, keySet, preference }) => {
+      mocks.readCliModelAccessStatus.mockResolvedValue({
+        apiFallback: 'personal',
+        preferences: { chatGpt: 'off', kimiCode: preference },
+        chatGptSignedIn: false,
+        kimiCodeKeySet: keySet,
+      });
+
+      await expect(
+        loadCliAccountStatusLines({
+          apiMode: 'personal',
+          includeApiDetails: true,
+        }),
+      ).resolves.toEqual(expected);
+    },
+  );
+
   it('keeps signed-out personal-only status truthful', async () => {
     setPersonalKeys('deepseek');
 
@@ -226,14 +333,10 @@ describe('loadCliApiStatusLines', () => {
       includeApiDetails: true,
     });
 
-    expect(lineFor(lines, 'ChatGPT')).toContain('not preferred · signed out');
-    expect(lineFor(lines, 'Kimi Code')).toContain(
-      'not preferred · key not configured',
-    );
-    expect(lineFor(lines, 'Fallback')).toBe('Fallback: Personal API keys');
-    expect(lineFor(lines, 'Other personal keys')).toBe(
+    expect(lines).toEqual([
+      'Fallback: Personal API keys',
       'Other personal keys: DeepSeek',
-    );
+    ]);
     expect(lines.join('\n')).not.toContain('TeXRA');
   });
 
@@ -250,12 +353,7 @@ describe('loadCliApiStatusLines', () => {
       includeApiDetails: true,
     });
 
-    expect(lineFor(lines, 'Fallback')).toBe(
-      'Fallback: Included TeXRA access · signed out',
-    );
-    expect(lines.some((line) => line.startsWith('Other personal keys:'))).toBe(
-      false,
-    );
+    expect(lines).toEqual(['Fallback: Included TeXRA access · signed out']);
     expect(mocks.fetchRelayUsageSummary).not.toHaveBeenCalled();
   });
 
@@ -280,15 +378,9 @@ describe('loadCliApiStatusLines', () => {
       includeApiDetails: true,
     });
 
-    expect(lineFor(lines, 'Fallback')).toBe(
+    expect(lines).toEqual([
       'Fallback: Included TeXRA access · signed in as included@example.com · Researcher · included usage this month: 10.0% used, 90.0% remaining',
-    );
-    expect(
-      lines.filter((line) => line.includes('included@example.com')),
-    ).toHaveLength(1);
-    expect(lines.some((line) => line.startsWith('Other personal keys:'))).toBe(
-      false,
-    );
+    ]);
   });
 
   it('owns the CI relay-token limitation on the included fallback', async () => {
@@ -356,9 +448,7 @@ describe('loadCliApiStatusLines', () => {
       includeApiDetails: true,
     });
 
-    expect(lines.some((line) => /personal keys: (none)?$/i.test(line))).toBe(
-      false,
-    );
+    expect(lines).toEqual(['Fallback: Personal API keys']);
   });
 
   it('preserves a profile note exactly once', async () => {

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.mts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.mts
@@ -35,7 +35,7 @@ vi.mock('@cli/runtime/modelAccessSelection', () => ({
 }));
 
 vi.mock('@model/apiProviders', () => ({
-  API_PROVIDERS: ['deepseek'],
+  API_PROVIDERS: ['deepseek', 'kimiCode'],
   lookupApiKeyOrigin: mocks.lookupApiKeyOrigin,
 }));
 
@@ -47,6 +47,19 @@ const { loadCliApiStatus, loadCliApiStatusLines, loadCliModelAccessOverview } =
   await import('@cli/runtime/apiStatus');
 const { loadCliAccountStatusLines } =
   await import('@cli/chat/tui/commands/handlers/statusAssembly');
+
+function lineFor(lines: readonly string[], route: string): string {
+  const matches = lines.filter((line) => line.startsWith(`${route}:`));
+  expect(matches).toHaveLength(1);
+  return matches[0] ?? '';
+}
+
+function setPersonalKeys(...providers: string[]): void {
+  mocks.lookupApiKeyOrigin.mockImplementation(
+    (_secrets: unknown, provider: string) =>
+      Promise.resolve(providers.includes(provider) ? 'env' : 'none'),
+  );
+}
 
 describe('loadCliApiStatusLines', () => {
   beforeEach(() => {
@@ -63,6 +76,7 @@ describe('loadCliApiStatusLines', () => {
       apiFallback: 'personal',
       preferences: { chatGpt: 'off', kimiCode: 'off' },
       chatGptSignedIn: false,
+      kimiCodeKeySet: false,
     });
     mocks.lookupApiKeyOrigin.mockReset().mockResolvedValue('none');
   });
@@ -85,13 +99,14 @@ describe('loadCliApiStatusLines', () => {
         'The configured relay token was rejected.',
       ],
     },
-  ])('preserves signed-out details $name', async ({ profile, lines }) => {
-    mocks.getCliAuthProfile.mockResolvedValue(profile);
+  ])(
+    'preserves signed-out launcher details $name',
+    async ({ profile, lines }) => {
+      mocks.getCliAuthProfile.mockResolvedValue(profile);
 
-    await expect(loadCliApiStatus()).resolves.toEqual({
-      lines,
-    });
-  });
+      await expect(loadCliApiStatus()).resolves.toEqual({ lines });
+    },
+  );
 
   it('uses an invocation API mode override for launcher status text', async () => {
     await expect(
@@ -107,19 +122,7 @@ describe('loadCliApiStatusLines', () => {
     expect(mocks.getCliApiMode).not.toHaveBeenCalled();
   });
 
-  it('includes action hints only when requested', async () => {
-    const actionHint =
-      'actions: choose Model access below; `texra login` signs in to Researcher Access';
-
-    const status = await loadCliApiStatus({
-      apiMode: 'included',
-      includeActionHint: true,
-    });
-
-    expect(status.lines).toContain(actionHint);
-  });
-
-  it('keeps launcher usage compact while exposing detailed account facts', async () => {
+  it('keeps launcher usage compact', async () => {
     mocks.getCliAuthProfile.mockResolvedValue({
       authenticated: true,
       accountLabel: 'researcher@example.com',
@@ -135,13 +138,9 @@ describe('loadCliApiStatusLines', () => {
         'auth: signed in as researcher@example.com · tier: Ultra · included usage this month: 100.3% used, 0% remaining',
       ],
     });
-    await expect(loadCliApiStatusLines()).resolves.toEqual([
-      'api: personal API keys',
-      'auth: signed in as researcher@example.com · tier: Ultra · included usage this month: 100.3% used, 0% remaining',
-    ]);
   });
 
-  it('preserves profile notes and the personal-key inventory', async () => {
+  it('preserves launcher profile notes and personal-key inventory', async () => {
     mocks.getCliAuthProfile.mockResolvedValue({
       authenticated: true,
       accountLabel: 'researcher@example.com',
@@ -149,7 +148,7 @@ describe('loadCliApiStatusLines', () => {
       credentialSource: 'session',
       note: 'Account metadata may be stale.',
     });
-    mocks.lookupApiKeyOrigin.mockResolvedValue('env');
+    setPersonalKeys('deepseek');
     mocks.resolveCliUsageTier.mockResolvedValue('Researcher');
     mocks.fetchRelayUsageSummary.mockResolvedValue({ usagePercent: 25 });
 
@@ -163,9 +162,142 @@ describe('loadCliApiStatusLines', () => {
     });
   });
 
-  it('explains unavailable usage for relay-token auth without a session', async () => {
-    const unavailable =
-      'included usage: not available with a CI relay token (run `texra login` to view usage)';
+  it('does not couple compact launcher status to model-access reads', async () => {
+    mocks.readCliModelAccessStatus.mockRejectedValue(
+      new Error('preference store offline'),
+    );
+
+    await expect(loadCliApiStatus()).resolves.toEqual({
+      lines: ['api: personal API keys', 'auth: signed out'],
+    });
+    expect(mocks.readCliModelAccessStatus).not.toHaveBeenCalled();
+    expect(mocks.getCliAuthProfile).toHaveBeenCalledOnce();
+    expect(mocks.lookupApiKeyOrigin).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders preferred Kimi and ChatGPT routes with their owned credentials', async () => {
+    mocks.readCliModelAccessStatus.mockResolvedValue({
+      apiFallback: 'included',
+      preferences: { chatGpt: 'on', kimiCode: 'on' },
+      chatGptSignedIn: true,
+      chatGptAccountLabel: 'chatgpt@example.com',
+      kimiCodeKeySet: true,
+    });
+    mocks.getCliAuthProfile.mockResolvedValue({
+      authenticated: true,
+      accountLabel: 'texra@example.com',
+      tier: 'Ultra',
+      credentialSource: 'session',
+    });
+    setPersonalKeys('deepseek', 'kimiCode');
+    mocks.resolveCliUsageTier.mockResolvedValue('Ultra');
+    mocks.fetchRelayUsageSummary.mockResolvedValue({ usagePercent: 24.5 });
+
+    const lines = await loadCliAccountStatusLines({
+      apiMode: 'included',
+      includeApiDetails: true,
+    });
+
+    expect(lineFor(lines, 'ChatGPT')).toBe(
+      'ChatGPT: preferred · signed in as chatgpt@example.com',
+    );
+    expect(lineFor(lines, 'Kimi Code')).toBe(
+      'Kimi Code: preferred · key configured',
+    );
+    expect(lineFor(lines, 'Fallback')).toBe(
+      'Fallback: Included TeXRA access · signed in as texra@example.com · Ultra · included usage this month: 24.5% used, 75.5% remaining',
+    );
+    expect(lineFor(lines, 'Other personal keys')).toBe(
+      'Other personal keys: DeepSeek',
+    );
+    expect(lines.join('\n').match(/Kimi Code/g)).toHaveLength(1);
+    expect(lines.join('\n').match(/chatgpt@example\.com/g)).toHaveLength(1);
+    expect(lines.join('\n').match(/texra@example\.com/g)).toHaveLength(1);
+    expect(mocks.readCliModelAccessStatus).toHaveBeenCalledOnce();
+    expect(mocks.getCliAuthProfile).toHaveBeenCalledOnce();
+    expect(mocks.lookupApiKeyOrigin).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps signed-out personal-only status truthful', async () => {
+    setPersonalKeys('deepseek');
+
+    const lines = await loadCliAccountStatusLines({
+      apiMode: 'personal',
+      includeApiDetails: true,
+    });
+
+    expect(lineFor(lines, 'ChatGPT')).toContain('not preferred · signed out');
+    expect(lineFor(lines, 'Kimi Code')).toContain(
+      'not preferred · key not configured',
+    );
+    expect(lineFor(lines, 'Fallback')).toBe('Fallback: Personal API keys');
+    expect(lineFor(lines, 'Other personal keys')).toBe(
+      'Other personal keys: DeepSeek',
+    );
+    expect(lines.join('\n')).not.toContain('TeXRA');
+  });
+
+  it('keeps signed-out included-only status truthful and omits empty keys', async () => {
+    mocks.readCliModelAccessStatus.mockResolvedValue({
+      apiFallback: 'included',
+      preferences: { chatGpt: 'off', kimiCode: 'off' },
+      chatGptSignedIn: false,
+      kimiCodeKeySet: false,
+    });
+
+    const lines = await loadCliAccountStatusLines({
+      apiMode: 'included',
+      includeApiDetails: true,
+    });
+
+    expect(lineFor(lines, 'Fallback')).toBe(
+      'Fallback: Included TeXRA access · signed out',
+    );
+    expect(lines.some((line) => line.startsWith('Other personal keys:'))).toBe(
+      false,
+    );
+    expect(mocks.fetchRelayUsageSummary).not.toHaveBeenCalled();
+  });
+
+  it('keeps included-only account, tier, and usage on the fallback route', async () => {
+    mocks.readCliModelAccessStatus.mockResolvedValue({
+      apiFallback: 'included',
+      preferences: { chatGpt: 'off', kimiCode: 'off' },
+      chatGptSignedIn: false,
+      kimiCodeKeySet: false,
+    });
+    mocks.getCliAuthProfile.mockResolvedValue({
+      authenticated: true,
+      accountLabel: 'included@example.com',
+      tier: 'Researcher',
+      credentialSource: 'session',
+    });
+    mocks.resolveCliUsageTier.mockResolvedValue('Researcher');
+    mocks.fetchRelayUsageSummary.mockResolvedValue({ usagePercent: 10 });
+
+    const lines = await loadCliAccountStatusLines({
+      apiMode: 'included',
+      includeApiDetails: true,
+    });
+
+    expect(lineFor(lines, 'Fallback')).toBe(
+      'Fallback: Included TeXRA access · signed in as included@example.com · Researcher · included usage this month: 10.0% used, 90.0% remaining',
+    );
+    expect(
+      lines.filter((line) => line.includes('included@example.com')),
+    ).toHaveLength(1);
+    expect(lines.some((line) => line.startsWith('Other personal keys:'))).toBe(
+      false,
+    );
+  });
+
+  it('owns the CI relay-token limitation on the included fallback', async () => {
+    mocks.readCliModelAccessStatus.mockResolvedValue({
+      apiFallback: 'included',
+      preferences: { chatGpt: 'off', kimiCode: 'off' },
+      chatGptSignedIn: false,
+      kimiCodeKeySet: false,
+    });
     mocks.getCliAuthProfile.mockResolvedValue({
       authenticated: true,
       accountLabel: 'CI relay token (TEXRA_RELAY_TOKEN)',
@@ -174,34 +306,62 @@ describe('loadCliApiStatusLines', () => {
     });
     mocks.getCliSessionAccessToken.mockResolvedValue(null);
 
-    await expect(loadCliApiStatus()).resolves.toEqual({
-      lines: [
-        'api: personal API keys',
-        `auth: signed in as CI relay token (TEXRA_RELAY_TOKEN) · tier: Researcher · ${unavailable}`,
-      ],
+    const lines = await loadCliAccountStatusLines({
+      apiMode: 'included',
+      includeApiDetails: true,
     });
+    const fallback = lineFor(lines, 'Fallback');
+
+    expect(fallback).toContain('CI relay token (TEXRA_RELAY_TOKEN)');
+    expect(fallback).toContain('Researcher');
+    expect(fallback).toContain('not available with a CI relay token');
+    expect(
+      lines.filter((line) => line.includes('CI relay token')),
+    ).toHaveLength(1);
     expect(mocks.fetchRelayUsageSummary).not.toHaveBeenCalled();
   });
 
-  it('preserves usage-fetch failures in detailed account facts', async () => {
+  it('owns usage-fetch failures on the included fallback', async () => {
+    mocks.readCliModelAccessStatus.mockResolvedValue({
+      apiFallback: 'included',
+      preferences: { chatGpt: 'off', kimiCode: 'off' },
+      chatGptSignedIn: false,
+      kimiCodeKeySet: false,
+    });
     mocks.getCliAuthProfile.mockResolvedValue({
       authenticated: true,
-      accountLabel: 'researcher@example.com',
+      accountLabel: 'texra@example.com',
       tier: 'Ultra',
       credentialSource: 'session',
     });
     mocks.resolveCliUsageTier.mockResolvedValue('Ultra');
     mocks.fetchRelayUsageSummary.mockRejectedValue(new Error('quota offline'));
 
-    await expect(loadCliApiStatus()).resolves.toEqual({
-      lines: [
-        'api: personal API keys',
-        'auth: signed in as researcher@example.com · tier: Ultra · included usage: unavailable (quota offline)',
-      ],
+    const lines = await loadCliAccountStatusLines({
+      apiMode: 'included',
+      includeApiDetails: true,
     });
+
+    expect(lineFor(lines, 'Fallback')).toContain(
+      'Ultra · included usage: unavailable (quota offline)',
+    );
+    expect(lines.filter((line) => line.includes('quota offline'))).toHaveLength(
+      1,
+    );
   });
 
-  it('deduplicates profile notes already present in the account overview', async () => {
+  it('omits unavailable key categories instead of printing none', async () => {
+    const lines = await loadCliAccountStatusLines({
+      apiMode: 'personal',
+      includeApiDetails: true,
+    });
+
+    expect(lines.some((line) => /personal keys: (none)?$/i.test(line))).toBe(
+      false,
+    );
+  });
+
+  it('preserves a profile note exactly once', async () => {
     const profileNote = 'Account metadata may be stale.';
     mocks.getCliAuthProfile.mockResolvedValue({
       authenticated: false,
@@ -216,38 +376,7 @@ describe('loadCliApiStatusLines', () => {
     expect(lines.filter((line) => line === profileNote)).toHaveLength(1);
   });
 
-  it('renders one detailed snapshot for preferences, accounts, keys, and usage', async () => {
-    mocks.readCliModelAccessStatus.mockResolvedValue({
-      apiFallback: 'included',
-      preferences: { chatGpt: 'on', kimiCode: 'on' },
-      chatGptSignedIn: true,
-      chatGptAccountLabel: 'chatgpt@example.com',
-      kimiCodeKeySet: true,
-    });
-    mocks.getCliAuthProfile.mockResolvedValue({
-      authenticated: true,
-      accountLabel: 'texra@example.com',
-      tier: 'Ultra',
-      credentialSource: 'session',
-    });
-    mocks.lookupApiKeyOrigin.mockResolvedValue('env');
-    mocks.resolveCliUsageTier.mockResolvedValue('Ultra');
-    mocks.fetchRelayUsageSummary.mockResolvedValue({ usagePercent: 24.5 });
-
-    await expect(
-      loadCliAccountStatusLines({
-        apiMode: 'included',
-        includeApiDetails: true,
-      }),
-    ).resolves.toEqual([
-      'Model access: ChatGPT On · Kimi Code On · fallback Included TeXRA access',
-      'Accounts: ChatGPT chatgpt@example.com · TeXRA texra@example.com',
-      'personal API keys: DeepSeek',
-      'tier: Ultra · included usage this month: 24.5% used, 75.5% remaining',
-    ]);
-  });
-
-  it('reports both preferences and the API fallback without collapsing them', async () => {
+  it('reports the legacy model-access overview without reading key storage', async () => {
     mocks.readCliModelAccessStatus.mockResolvedValue({
       apiFallback: 'personal',
       preferences: { chatGpt: 'on', kimiCode: 'off' },
@@ -259,6 +388,7 @@ describe('loadCliApiStatusLines', () => {
       authenticated: true,
       accountLabel: 'texra@example.com',
     });
+    mocks.lookupApiKeyOrigin.mockRejectedValue(new Error('keychain offline'));
 
     await expect(
       loadCliModelAccessOverview({ apiMode: 'personal' }),
@@ -278,41 +408,13 @@ describe('loadCliApiStatusLines', () => {
         'TeXRA: signed in as texra@example.com',
       ],
     });
-  });
-
-  it('loads the model-access form without reading personal-key storage', async () => {
-    mocks.lookupApiKeyOrigin.mockRejectedValue(new Error('keychain offline'));
-
-    await expect(
-      loadCliModelAccessOverview({ apiMode: 'personal' }),
-    ).resolves.toMatchObject({
-      access: { apiFallback: 'personal' },
-    });
     expect(mocks.lookupApiKeyOrigin).not.toHaveBeenCalled();
-  });
-
-  it('reports Kimi and ChatGPT preference states separately', async () => {
-    mocks.readCliModelAccessStatus.mockResolvedValue({
-      apiFallback: 'personal',
-      preferences: { chatGpt: 'off', kimiCode: 'on' },
-      chatGptSignedIn: false,
-      kimiCodeKeySet: true,
-    });
-
-    await expect(
-      loadCliModelAccessOverview({ apiMode: 'personal' }),
-    ).resolves.toMatchObject({
-      lines: [
-        'ChatGPT preference: Off · sign in required to enable',
-        'Kimi Code preference: On · key configured',
-        'API fallback: Personal API keys',
-        'TeXRA: signed out',
-      ],
-    });
+    expect(mocks.readCliModelAccessStatus).toHaveBeenCalledOnce();
+    expect(mocks.getCliAuthProfile).toHaveBeenCalledOnce();
   });
 
   it('does not ask signed-out personal-key users to add another key', async () => {
-    mocks.lookupApiKeyOrigin.mockResolvedValue('env');
+    setPersonalKeys('deepseek');
 
     await expect(
       loadCliApiStatusLines({ includeActionHint: true }),

--- a/src/test-kernel/cli/OnboardingState.vitest.mts
+++ b/src/test-kernel/cli/OnboardingState.vitest.mts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { maskDisplayValue } from '@cli/chat/tui/input/textInputEditing';
-import { formatApiKeyShadowWarning } from '@cli/runtime/apiStatus';
+import { formatPersonalApiKeysLine } from '@cli/runtime/apiStatus';
 import { maybeRunCliOnboarding } from '@cli/onboarding/runOnboarding';
 import {
   describeSavedKeyLocation,
@@ -82,14 +82,12 @@ describe('maskDisplayValue', () => {
   });
 });
 
-describe('formatApiKeyShadowWarning', () => {
-  it('warns only when signed in AND a personal key is present', () => {
-    expect(formatApiKeyShadowWarning(true, ['deepseek'])).toBe(
-      'available: included TeXRA access; personal API keys: DeepSeek',
+describe('formatPersonalApiKeysLine', () => {
+  it('formats the configured provider inventory without access claims', () => {
+    expect(formatPersonalApiKeysLine(['deepseek'])).toBe(
+      'personal API keys: DeepSeek',
     );
-    expect(formatApiKeyShadowWarning(true, [])).toBeUndefined();
-    expect(formatApiKeyShadowWarning(false, ['deepseek'])).toBeUndefined();
-    expect(formatApiKeyShadowWarning(false, [])).toBeUndefined();
+    expect(formatPersonalApiKeysLine([])).toBeUndefined();
   });
 });
 

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -408,29 +408,29 @@ describe('handleTuiSlashCommand', () => {
     const overview = vi
       .spyOn(apiStatus, 'loadCliDetailedAccountStatusLines')
       .mockResolvedValue([
-        'Model access: ChatGPT On · Kimi Code Off · fallback Personal API keys',
-        'Accounts: ChatGPT chatgpt@example.com · TeXRA texra@example.com',
-        'personal API keys: DeepSeek',
-        'tier: researcher · included usage this month: 25% used, 75% remaining',
+        'ChatGPT: preferred · signed in as chatgpt@example.com',
+        'Kimi Code: not preferred · key not configured',
+        'Fallback: Included TeXRA access · signed in as texra@example.com · Researcher · included usage this month: 25% used, 75% remaining',
+        'Other personal keys: DeepSeek',
       ]);
     const context = createContext();
 
     await handleTuiSlashCommand('/auth', context);
     const authStatusText = lastEntryText();
-    expect(authStatusText).toContain('ChatGPT On');
-    expect(authStatusText).toContain('Kimi Code Off');
-    expect(authStatusText).toContain('fallback Personal API keys');
-    expect(authStatusText).toContain('tier: researcher');
+    expect(authStatusText).toContain('ChatGPT: preferred');
+    expect(authStatusText).toContain('Kimi Code: not preferred');
+    expect(authStatusText).toContain('Fallback: Included TeXRA access');
+    expect(authStatusText).toContain('Researcher');
     expect(authStatusText).toContain(
       'included usage this month: 25% used, 75% remaining',
     );
 
     await handleTuiSlashCommand('/api status', context);
     const apiStatusText = lastEntryText();
-    expect(apiStatusText).toContain('ChatGPT On');
-    expect(apiStatusText).toContain('Kimi Code Off');
-    expect(apiStatusText).toContain('fallback Personal API keys');
-    expect(apiStatusText).toContain('tier: researcher');
+    expect(apiStatusText).toContain('ChatGPT: preferred');
+    expect(apiStatusText).toContain('Kimi Code: not preferred');
+    expect(apiStatusText).toContain('Fallback: Included TeXRA access');
+    expect(apiStatusText).toContain('Researcher');
     expect(apiStatusText).toContain(
       'included usage this month: 25% used, 75% remaining',
     );

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -406,38 +406,20 @@ describe('handleTuiSlashCommand', () => {
   it('derives /auth and /api status from the same access overview', async () => {
     registerBuiltinSlashCommands();
     const overview = vi
-      .spyOn(apiStatus, 'loadCliModelAccessOverview')
-      .mockResolvedValue({
-        access: {
-          apiFallback: 'personal',
-          preferences: { chatGpt: 'on', kimiCode: 'off' },
-          chatGptSignedIn: true,
-          texraSignedIn: true,
-        },
-        lines: [
-          'ChatGPT preference: On · your account',
-          'Kimi Code preference: Off · key required to enable',
-          'API fallback: Personal API keys',
-          'TeXRA: signed in',
-        ],
-      });
-    vi.spyOn(apiStatus, 'loadCliApiStatus').mockResolvedValue({
-      lines: [
-        'api: included TeXRA access',
-        'auth: signed in · tier: researcher · included usage this month: 25% used, 75% remaining',
-      ],
-      detailLines: [
-        'tier: researcher',
-        'included usage this month: 25% used, 75% remaining',
-      ],
-    });
+      .spyOn(apiStatus, 'loadCliDetailedAccountStatusLines')
+      .mockResolvedValue([
+        'Model access: ChatGPT On · Kimi Code Off · fallback Personal API keys',
+        'Accounts: ChatGPT chatgpt@example.com · TeXRA texra@example.com',
+        'personal API keys: DeepSeek',
+        'tier: researcher · included usage this month: 25% used, 75% remaining',
+      ]);
     const context = createContext();
 
     await handleTuiSlashCommand('/auth', context);
     const authStatusText = lastEntryText();
-    expect(authStatusText).toContain('ChatGPT preference: On');
-    expect(authStatusText).toContain('Kimi Code preference: Off');
-    expect(authStatusText).toContain('API fallback: Personal API keys');
+    expect(authStatusText).toContain('ChatGPT On');
+    expect(authStatusText).toContain('Kimi Code Off');
+    expect(authStatusText).toContain('fallback Personal API keys');
     expect(authStatusText).toContain('tier: researcher');
     expect(authStatusText).toContain(
       'included usage this month: 25% used, 75% remaining',
@@ -445,9 +427,9 @@ describe('handleTuiSlashCommand', () => {
 
     await handleTuiSlashCommand('/api status', context);
     const apiStatusText = lastEntryText();
-    expect(apiStatusText).toContain('ChatGPT preference: On');
-    expect(apiStatusText).toContain('Kimi Code preference: Off');
-    expect(apiStatusText).toContain('API fallback: Personal API keys');
+    expect(apiStatusText).toContain('ChatGPT On');
+    expect(apiStatusText).toContain('Kimi Code Off');
+    expect(apiStatusText).toContain('fallback Personal API keys');
     expect(apiStatusText).toContain('tier: researcher');
     expect(apiStatusText).toContain(
       'included usage this month: 25% used, 75% remaining',


### PR DESCRIPTION
## Summary

- projects model-access facts into route-owned status lines: ChatGPT owns preference/account, Kimi Code owns preference/key state, and the selected fallback owns its route details
- keeps TeXRA account, tier, usage, CI-token limitations, and usage failures on the Included fallback line, with unrelated configured providers shown only under `Other personal keys`
- keeps compact launcher status on the same profile/key/usage facts without reading model-access preferences, while the model-access form remains isolated from personal-key storage failures
- removes the retired `CliApiStatus.detailLines` path and string-level semantic deduplication

Closes #9641.

## Issue acceptance gates

- Kimi preferred + key: one Kimi Code route line owns both facts; Kimi Code is excluded from `Other personal keys`.
- ChatGPT preferred + account: one ChatGPT route line owns both facts and the full account label.
- Included fallback: one Fallback line owns Included TeXRA access, TeXRA account, tier, usage, CI relay-token limitations, and usage-fetch failures.
- Subscription routes are omitted when both unpreferred and unavailable; preferred-but-missing routes remain actionable. Signed-out, personal-only, included-only, no-key, profile-note, and launcher action-hint cases are covered by tests.
- `/auth` and `/api status` dispatch through the same detailed renderer; launcher and model-access form use only the facts they need.

## Single source of truth

`packages/cli/src/runtime/apiStatus.ts` owns fact loading and route projection. `loadCliDetailedAccountStatusLines` reads each source once, projects those facts into `chatGpt`, `kimiCode`, and `fallback` route entries, and renders each route once. The compact launcher reuses the same profile/key/usage helpers but deliberately does not read `readCliModelAccessStatus`.

## Duplication and abstraction budget

The old grouped preference/account/key/tier arrays, exact-string deduplication, unconditional included-access shadow warning, and dead `detailLines` output are removed. No new facade or pass-through layer was added: the route projection is local to the detailed renderer, while the usage helper has both compact and detailed consumers.

## Net elements (R6)

- Files: 0 added, 0 deleted; 6 modified.
- Exported symbols: 2 added (`formatPersonalApiKeysLine`, `loadCliDetailedAccountStatusLines`), 1 deleted (`formatApiKeyShadowWarning`); net +1. The formatter replacement is the neutral inventory API, and the detailed renderer is consumed by account status assembly.
- Declarations: 4 added helpers/renderers, 1 deleted formatter; no classes or enums added. `CliApiStatus.detailLines` was deleted.
- LoC: +452 / -182, net +270 overall; production + changelog is +136 / -58, net +78. The positive delta is primarily the issue-requested proof matrix (+316 / -124 test LoC) covering route ownership, all four preference/credential combinations per subscription route, non-duplication, omission, failure isolation, and call counts rather than adding production abstraction layers.

## Consumer counts (R8)

- `CliApiStatus.detailLines`: 1 production reader before rerouting (`statusAssembly.ts`), 0 after; the field and writes were deleted together.
- `loadCliDetailedAccountStatusLines`: 1 production consumer (`statusAssembly.ts`).
- `loadCliModelAccessOverview`: 2 production consumers (`statusAssembly.ts` compact path and `ModelAccessForm.tsx`).
- `loadCliApiStatusLines`: 1 production consumer (`commands/orchestrate.ts`).
- No event/subscriber keys changed.

## Host impact

Extension: None.

Desktop: None.

CLI: `/auth` and `/api status` now render one line per owned route; launcher status avoids preference reads and model-access form avoids key-storage reads.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ApiStatusLoad.vitest.mts src/test-kernel/cli/OnboardingState.vitest.mts src/test-kernel/cli/SlashCommandDispatch.vitest.mts src/test-kernel/cli/ModelAccessForm.vitest.mts src/test-kernel/cli/ApiStatus.vitest.mts` — 69 passed
- `corepack pnpm run typecheck:cli`
- `corepack pnpm run typecheck:test-kernel`
- `corepack pnpm run lint`
- targeted ESLint and Prettier checks on all PR-touched TypeScript/Markdown files
- `corepack pnpm run compile:fast` — passed (only existing Vite config/chunk-size warnings)
- `corepack pnpm run check:dead-code-ratchet` — 18 current findings match 18 baselined; no new dead code
- `git diff --check $(git merge-base origin/main HEAD)`
- pre-push checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI status display and formatting only; no auth, billing, or routing behavior changes beyond what text is shown and which helpers are called.
> 
> **Overview**
> **Account status is reorganized so each fact appears once on the route that owns it.** `/auth` and `/api status` both use `loadCliDetailedAccountStatusLines`, which emits separate lines for ChatGPT (preference + account), Kimi Code (preference + key state), Included fallback (TeXRA account, tier, usage, CI-token limits), and other personal keys—instead of overlapping overview plus `detailLines` with string deduplication.
> 
> **Launcher and API status output is simplified.** `CliApiStatus.detailLines` is removed; compact `loadCliApiStatus` keeps usage on the auth line and lists personal keys via neutral `formatPersonalApiKeysLine` (replacing the signed-in-only “shadow” warning). Compact launcher status does not call `readCliModelAccessStatus`, so it stays independent of the model-access preference store.
> 
> **Assembly routing:** `loadCliAccountStatusLines` with `includeApiDetails: true` delegates entirely to the detailed renderer; without it, only the legacy model-access overview lines are returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9a7ae0423272c16b3e593ba849c78c02f5a0bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
