### PR TITLE
fix(cli): reject blocked Windows output paths

### DIFF
--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -31,23 +31,26 @@ function joinCwdRelative(target: string, cwd: string): string {
 
 type OutputPathStats = Pick<Awaited<ReturnType<typeof fs.stat>>, 'isDirectory'>;
 
+type OutputFlag = '--output' | '--output-dir';
+
 interface OutputPathProbeDependencies {
   readonly stat: (target: string) => Promise<OutputPathStats>;
-  readonly lstat: (
+  readonly mkdir: (
     target: string,
-  ) => Promise<OutputPathStats & { isSymbolicLink(): boolean }>;
+    options: { readonly recursive: true },
+  ) => Promise<string | undefined>;
   readonly dirname: (target: string) => string;
 }
 
 const outputPathProbeDefaults: OutputPathProbeDependencies = {
   stat: fs.stat,
-  lstat: fs.lstat,
+  mkdir: fs.mkdir,
   dirname: path.dirname,
 };
 
 function parentFileUsageError(
   target: string,
-  flagLabel: '--output' | '--output-dir',
+  flagLabel: OutputFlag,
 ): CliUsageError {
   return new CliUsageError(
     flagLabel === '--output-dir'
@@ -56,89 +59,48 @@ function parentFileUsageError(
   );
 }
 
-function danglingSymlinkUsageError(
-  target: string,
-  candidate: string,
-  flagLabel: '--output' | '--output-dir',
-): CliUsageError {
-  if (candidate === target) {
-    return new CliUsageError(
-      `${flagLabel} is a dangling symbolic link: ${target}`,
-    );
-  }
-  return new CliUsageError(
-    flagLabel === '--output-dir'
-      ? `--output-dir cannot be created (a parent path component is a dangling symbolic link): ${target}`
-      : `--output: a parent path component is a dangling symbolic link: ${target}`,
-  );
-}
-
 /**
- * Stat `target` for the output-path guards. Returns `null` when the path
- * doesn't exist yet and its nearest existing ancestor is a directory. Some
- * platforms report a file ancestor as ENOENT rather than ENOTDIR, so missing
- * paths are checked upward. Other stat errors propagate with their real cause.
+ * Probe `target` and materialize the directory that the eventual output write
+ * requires. Using the same recursive mkdir operation as the writer avoids
+ * platform-specific ancestor traversal: it handles missing depth, Windows
+ * ENOENT-through-file behavior, and symlink resolution natively.
  */
 async function probeOutputPath(
   target: string,
-  flagLabel: '--output' | '--output-dir',
+  flagLabel: OutputFlag,
   dependencies: OutputPathProbeDependencies = outputPathProbeDefaults,
 ): Promise<OutputPathStats | null> {
-  const { stat, lstat, dirname } = dependencies;
-  let candidate = target;
-  while (true) {
-    let stats: OutputPathStats;
-    try {
-      stats = await stat(candidate);
-    } catch (error: unknown) {
-      if (isNotADirectoryError(error)) {
-        throw parentFileUsageError(target, flagLabel);
-      }
-      if (!isFileNotFoundError(error)) throw error;
-
-      try {
-        const linkStats = await lstat(candidate);
-        if (!linkStats.isSymbolicLink()) {
-          stats = linkStats;
-        } else {
-          try {
-            stats = await stat(candidate);
-          } catch (retryError: unknown) {
-            if (isFileNotFoundError(retryError)) {
-              throw danglingSymlinkUsageError(target, candidate, flagLabel);
-            }
-            throw retryError;
-          }
-        }
-      } catch (lstatError: unknown) {
-        if (lstatError instanceof CliUsageError) throw lstatError;
-        if (isNotADirectoryError(lstatError)) {
-          throw parentFileUsageError(target, flagLabel);
-        }
-        if (!isFileNotFoundError(lstatError)) throw lstatError;
-
-        const parent = dirname(candidate);
-        if (parent === candidate) throw lstatError;
-        candidate = parent;
-        continue;
-      }
-    }
-
-    if (candidate === target) return stats;
-    if (!stats.isDirectory()) {
+  const { stat, mkdir, dirname } = dependencies;
+  try {
+    return await stat(target);
+  } catch (error: unknown) {
+    if (isNotADirectoryError(error)) {
       throw parentFileUsageError(target, flagLabel);
     }
-    return null;
+    if (!isFileNotFoundError(error)) throw error;
   }
+
+  const requiredDirectory =
+    flagLabel === '--output-dir' ? target : dirname(target);
+  try {
+    await mkdir(requiredDirectory, { recursive: true });
+  } catch (error: unknown) {
+    if (isNotADirectoryError(error)) {
+      throw parentFileUsageError(target, flagLabel);
+    }
+    if (isFileNotFoundError(error)) {
+      throw new CliUsageError(
+        flagLabel === '--output-dir'
+          ? `--output-dir cannot be created: ${target}`
+          : `--output parent directory cannot be created: ${target}`,
+      );
+    }
+    throw error;
+  }
+  return null;
 }
 
-export async function probeOutputPathForTests(
-  target: string,
-  flagLabel: '--output' | '--output-dir',
-  dependencies: OutputPathProbeDependencies,
-): Promise<void> {
-  await probeOutputPath(target, flagLabel, dependencies);
-}
+export { probeOutputPath as probeOutputPathForTests };
 
 /** `--output-dir <path>` must point at a directory (or not exist yet). */
 export async function assertOutputDirAvailable(

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -48,6 +48,10 @@ const outputPathProbeDefaults: OutputPathProbeDependencies = {
   dirname: path.dirname,
 };
 
+function isAlreadyExistsError(error: unknown): boolean {
+  return (error as { readonly code?: string })?.code === 'EEXIST';
+}
+
 function parentFileUsageError(
   target: string,
   flagLabel: OutputFlag,
@@ -85,7 +89,7 @@ async function probeOutputPath(
   try {
     await mkdir(requiredDirectory, { recursive: true });
   } catch (error: unknown) {
-    if (isNotADirectoryError(error)) {
+    if (isNotADirectoryError(error) || isAlreadyExistsError(error)) {
       throw parentFileUsageError(target, flagLabel);
     }
     if (isFileNotFoundError(error)) {

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -29,29 +29,115 @@ function joinCwdRelative(target: string, cwd: string): string {
   return path.isAbsolute(target) ? target : path.join(cwd, target);
 }
 
+type OutputPathStats = Pick<Awaited<ReturnType<typeof fs.stat>>, 'isDirectory'>;
+
+interface OutputPathProbeDependencies {
+  readonly stat: (target: string) => Promise<OutputPathStats>;
+  readonly lstat: (
+    target: string,
+  ) => Promise<OutputPathStats & { isSymbolicLink(): boolean }>;
+  readonly dirname: (target: string) => string;
+}
+
+const outputPathProbeDefaults: OutputPathProbeDependencies = {
+  stat: fs.stat,
+  lstat: fs.lstat,
+  dirname: path.dirname,
+};
+
+function parentFileUsageError(
+  target: string,
+  flagLabel: '--output' | '--output-dir',
+): CliUsageError {
+  return new CliUsageError(
+    flagLabel === '--output-dir'
+      ? `--output-dir is not a directory (a parent path component is a file): ${target}`
+      : `--output: a parent path component is a file: ${target}`,
+  );
+}
+
+function danglingSymlinkUsageError(
+  target: string,
+  candidate: string,
+  flagLabel: '--output' | '--output-dir',
+): CliUsageError {
+  if (candidate === target) {
+    return new CliUsageError(
+      `${flagLabel} is a dangling symbolic link: ${target}`,
+    );
+  }
+  return new CliUsageError(
+    flagLabel === '--output-dir'
+      ? `--output-dir cannot be created (a parent path component is a dangling symbolic link): ${target}`
+      : `--output: a parent path component is a dangling symbolic link: ${target}`,
+  );
+}
+
 /**
  * Stat `target` for the output-path guards. Returns `null` when the path
- * doesn't exist yet (the workflow will create it). `ENOTDIR` (a parent path
- * component is a file) is surfaced as a Usage error here so callers don't
- * have to repeat it. Other stat errors propagate with their real cause.
+ * doesn't exist yet and its nearest existing ancestor is a directory. Some
+ * platforms report a file ancestor as ENOENT rather than ENOTDIR, so missing
+ * paths are checked upward. Other stat errors propagate with their real cause.
  */
 async function probeOutputPath(
   target: string,
   flagLabel: '--output' | '--output-dir',
-): Promise<Awaited<ReturnType<typeof fs.stat>> | null> {
-  try {
-    return await fs.stat(target);
-  } catch (error: unknown) {
-    if (isFileNotFoundError(error)) return null;
-    if (isNotADirectoryError(error)) {
-      throw new CliUsageError(
-        flagLabel === '--output-dir'
-          ? `--output-dir is not a directory (a parent path component is a file): ${target}`
-          : `--output: a parent path component is a file: ${target}`,
-      );
+  dependencies: OutputPathProbeDependencies = outputPathProbeDefaults,
+): Promise<OutputPathStats | null> {
+  const { stat, lstat, dirname } = dependencies;
+  let candidate = target;
+  while (true) {
+    let stats: OutputPathStats;
+    try {
+      stats = await stat(candidate);
+    } catch (error: unknown) {
+      if (isNotADirectoryError(error)) {
+        throw parentFileUsageError(target, flagLabel);
+      }
+      if (!isFileNotFoundError(error)) throw error;
+
+      try {
+        const linkStats = await lstat(candidate);
+        if (!linkStats.isSymbolicLink()) {
+          stats = linkStats;
+        } else {
+          try {
+            stats = await stat(candidate);
+          } catch (retryError: unknown) {
+            if (isFileNotFoundError(retryError)) {
+              throw danglingSymlinkUsageError(target, candidate, flagLabel);
+            }
+            throw retryError;
+          }
+        }
+      } catch (lstatError: unknown) {
+        if (lstatError instanceof CliUsageError) throw lstatError;
+        if (isNotADirectoryError(lstatError)) {
+          throw parentFileUsageError(target, flagLabel);
+        }
+        if (!isFileNotFoundError(lstatError)) throw lstatError;
+
+        const parent = dirname(candidate);
+        if (parent === candidate) throw lstatError;
+        candidate = parent;
+        continue;
+      }
     }
-    throw error;
+
+    if (candidate === target) return stats;
+    if (!stats.isDirectory()) {
+      throw parentFileUsageError(target, flagLabel);
+    }
+    return null;
   }
+}
+
+export async function probeOutputPathForTests(
+  target: string,
+  flagLabel: '--output' | '--output-dir',
+  dependencies: OutputPathProbeDependencies,
+): Promise<void> {
+  await probeOutputPath(target, flagLabel, dependencies);
 }
 
 /** `--output-dir <path>` must point at a directory (or not exist yet). */

--- a/src/test-kernel/cli/OutputGuards.vitest.mts
+++ b/src/test-kernel/cli/OutputGuards.vitest.mts
@@ -36,9 +36,13 @@ describe('probeOutputPath', () => {
     },
   ];
 
-  it.each(windowsCases)(
-    'uses native mkdir after Windows-shaped ENOENT for a $label output path',
-    async ({ target, outputParent }) => {
+  const windowsBlockedCases = windowsCases.flatMap((testCase) =>
+    ['ENOTDIR', 'EEXIST'].map((mkdirCode) => ({ ...testCase, mkdirCode })),
+  );
+
+  it.each(windowsBlockedCases)(
+    'maps native $mkdirCode after Windows-shaped ENOENT for a $label output path',
+    async ({ target, outputParent, mkdirCode }) => {
       const mkdirVisited: string[] = [];
       await expect(
         probeOutputPathForTests(target, '--output', {
@@ -48,7 +52,7 @@ describe('probeOutputPath', () => {
           },
           mkdir: async (candidate) => {
             mkdirVisited.push(candidate);
-            throw errno('ENOTDIR');
+            throw errno(mkdirCode);
           },
         }),
       ).rejects.toThrow(

--- a/src/test-kernel/cli/OutputGuards.vitest.mts
+++ b/src/test-kernel/cli/OutputGuards.vitest.mts
@@ -1,6 +1,6 @@
-import { chmod, mkdir, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, posix, win32 } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -8,6 +8,7 @@ import { CliUsageError } from '@cli/runtime/cliContext';
 import {
   assertOutputDirAvailable,
   assertOutputFileAvailable,
+  probeOutputPathForTests,
 } from '@cli/runtime/workflowOutput';
 import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 
@@ -15,6 +16,278 @@ const tempDirs: string[] = [];
 
 afterEach(async () => {
   await cleanupTempDirs(tempDirs);
+});
+
+function missingError(message = 'missing'): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code: 'ENOENT' });
+}
+
+const outputFlagCases = [
+  {
+    flagLabel: '--output-dir' as const,
+    fileMessage:
+      '--output-dir is not a directory (a parent path component is a file)',
+    danglingMessage: '--output-dir is a dangling symbolic link',
+  },
+  {
+    flagLabel: '--output' as const,
+    fileMessage: '--output: a parent path component is a file',
+    danglingMessage: '--output is a dangling symbolic link',
+  },
+];
+
+const windowsAncestorCases = [
+  {
+    label: 'drive',
+    fileAncestor: String.raw`C:\workspace\blocked`,
+    target: String.raw`C:\workspace\blocked\missing-one\missing-two\output.tex`,
+  },
+  {
+    label: 'UNC',
+    fileAncestor: String.raw`\\server\share\workspace\blocked`,
+    target: String.raw`\\server\share\workspace\blocked\missing-one\missing-two\output.tex`,
+  },
+];
+
+const rootCases = [
+  {
+    label: 'POSIX',
+    dirname: posix.dirname,
+    target: '/missing/output.tex',
+    candidates: ['/missing/output.tex', '/missing', '/'],
+  },
+  {
+    label: 'Windows drive',
+    dirname: win32.dirname,
+    target: String.raw`C:\missing\output.tex`,
+    candidates: [
+      String.raw`C:\missing\output.tex`,
+      String.raw`C:\missing`,
+      'C:\\',
+    ],
+  },
+  {
+    label: 'Windows UNC',
+    dirname: win32.dirname,
+    target: String.raw`\\server\share\missing\output.tex`,
+    candidates: [
+      String.raw`\\server\share\missing\output.tex`,
+      String.raw`\\server\share\missing`,
+      '\\\\server\\share\\',
+    ],
+  },
+];
+
+describe('probeOutputPath', () => {
+  describe.each(windowsAncestorCases)(
+    '$label paths',
+    ({ fileAncestor, target }) => {
+      it.each(outputFlagCases)(
+        'walks past Windows-shaped ENOENT and reports a file ancestor for $flagLabel',
+        async ({ flagLabel, fileMessage }) => {
+          const missingCandidates = [
+            target,
+            win32.dirname(target),
+            win32.dirname(win32.dirname(target)),
+          ];
+          const statVisited: string[] = [];
+          const lstatVisited: string[] = [];
+
+          await expect(
+            probeOutputPathForTests(target, flagLabel, {
+              dirname: win32.dirname,
+              stat: async (candidate) => {
+                statVisited.push(candidate);
+                if (candidate === fileAncestor) {
+                  return { isDirectory: () => false };
+                }
+                throw missingError();
+              },
+              lstat: async (candidate) => {
+                lstatVisited.push(candidate);
+                throw missingError();
+              },
+            }),
+          ).rejects.toThrow(`${fileMessage}: ${target}`);
+          expect(statVisited).toEqual([...missingCandidates, fileAncestor]);
+          expect(lstatVisited).toEqual(missingCandidates);
+        },
+      );
+    },
+  );
+
+  it('stops at the nearest existing directory for a creatable target', async () => {
+    const ancestor = String.raw`C:\workspace`;
+    const target = String.raw`C:\workspace\missing\output.tex`;
+    const statVisited: string[] = [];
+    const lstatVisited: string[] = [];
+
+    await expect(
+      probeOutputPathForTests(target, '--output', {
+        dirname: win32.dirname,
+        stat: async (candidate) => {
+          statVisited.push(candidate);
+          if (candidate === ancestor) return { isDirectory: () => true };
+          throw missingError();
+        },
+        lstat: async (candidate) => {
+          lstatVisited.push(candidate);
+          throw missingError();
+        },
+      }),
+    ).resolves.toBeUndefined();
+    expect(statVisited).toEqual([
+      target,
+      String.raw`C:\workspace\missing`,
+      ancestor,
+    ]);
+    expect(lstatVisited).toEqual([target, String.raw`C:\workspace\missing`]);
+  });
+
+  it.each(rootCases)(
+    'propagates ENOENT after exhausting a $label root',
+    async ({ dirname, target, candidates }) => {
+      const rootError = missingError('missing root');
+      const statVisited: string[] = [];
+      const lstatVisited: string[] = [];
+
+      await expect(
+        probeOutputPathForTests(target, '--output', {
+          dirname,
+          stat: async (candidate) => {
+            statVisited.push(candidate);
+            throw missingError();
+          },
+          lstat: async (candidate) => {
+            lstatVisited.push(candidate);
+            if (candidate === candidates.at(-1)) throw rootError;
+            throw missingError();
+          },
+        }),
+      ).rejects.toBe(rootError);
+      expect(statVisited).toEqual(candidates);
+      expect(lstatVisited).toEqual(candidates);
+    },
+  );
+
+  it.each(outputFlagCases)(
+    'rejects a dangling target symlink for $flagLabel',
+    async ({ flagLabel, danglingMessage }) => {
+      const target = String.raw`C:\workspace\dangling`;
+      const statVisited: string[] = [];
+      const lstatVisited: string[] = [];
+
+      await expect(
+        probeOutputPathForTests(target, flagLabel, {
+          dirname: win32.dirname,
+          stat: async (candidate) => {
+            statVisited.push(candidate);
+            throw missingError();
+          },
+          lstat: async (candidate) => {
+            lstatVisited.push(candidate);
+            return {
+              isDirectory: () => false,
+              isSymbolicLink: () => true,
+            };
+          },
+        }),
+      ).rejects.toThrow(`${danglingMessage}: ${target}`);
+      expect(statVisited).toEqual([target, target]);
+      expect(lstatVisited).toEqual([target]);
+    },
+  );
+
+  it('rejects a dangling symlink ancestor without walking past it', async () => {
+    const dangling = String.raw`C:\workspace\dangling`;
+    const target = String.raw`C:\workspace\dangling\missing\output.tex`;
+    const statVisited: string[] = [];
+    const lstatVisited: string[] = [];
+
+    await expect(
+      probeOutputPathForTests(target, '--output', {
+        dirname: win32.dirname,
+        stat: async (candidate) => {
+          statVisited.push(candidate);
+          throw missingError();
+        },
+        lstat: async (candidate) => {
+          lstatVisited.push(candidate);
+          if (candidate === dangling) {
+            return {
+              isDirectory: () => false,
+              isSymbolicLink: () => true,
+            };
+          }
+          throw missingError();
+        },
+      }),
+    ).rejects.toThrow(
+      `--output: a parent path component is a dangling symbolic link: ${target}`,
+    );
+    expect(statVisited).toEqual([
+      target,
+      win32.dirname(target),
+      dangling,
+      dangling,
+    ]);
+    expect(lstatVisited).toEqual([target, win32.dirname(target), dangling]);
+  });
+
+  it('propagates unexpected lstat errors', async () => {
+    const denied = Object.assign(new Error('denied'), { code: 'EACCES' });
+    await expect(
+      probeOutputPathForTests('/missing/output.tex', '--output', {
+        dirname: win32.dirname,
+        stat: async () => {
+          throw missingError();
+        },
+        lstat: async () => {
+          throw denied;
+        },
+      }),
+    ).rejects.toBe(denied);
+  });
+});
+
+describe('dangling output symlinks', () => {
+  it('rejects a real dangling symlink for both output modes', async (context) => {
+    const root = await makeTempDir('texra-cli-dangling-output-', tempDirs);
+    const dangling = join(root, 'dangling');
+    try {
+      await symlink(
+        join(root, 'absent'),
+        dangling,
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
+    } catch (error: unknown) {
+      const code =
+        typeof error === 'object' && error !== null && 'code' in error
+          ? error.code
+          : undefined;
+      if (
+        typeof code === 'string' &&
+        ['EACCES', 'EINVAL', 'ENOSYS', 'ENOTSUP', 'EPERM'].includes(code)
+      ) {
+        context.skip();
+        return;
+      }
+      throw error;
+    }
+
+    await expect(
+      assertOutputDirAvailable(dangling, root),
+    ).rejects.toBeInstanceOf(CliUsageError);
+    await expect(assertOutputDirAvailable(dangling, root)).rejects.toThrow(
+      `--output-dir is a dangling symbolic link: ${dangling}`,
+    );
+    await expect(
+      assertOutputFileAvailable(dangling, root),
+    ).rejects.toBeInstanceOf(CliUsageError);
+    await expect(assertOutputFileAvailable(dangling, root)).rejects.toThrow(
+      `--output is a dangling symbolic link: ${dangling}`,
+    );
+  });
 });
 
 describe('assertOutputDirAvailable', () => {

--- a/src/test-kernel/cli/OutputGuards.vitest.mts
+++ b/src/test-kernel/cli/OutputGuards.vitest.mts
@@ -1,6 +1,6 @@
-import { chmod, mkdir, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join, posix, win32 } from 'node:path';
+import { join, win32 } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -18,231 +18,105 @@ afterEach(async () => {
   await cleanupTempDirs(tempDirs);
 });
 
-function missingError(message = 'missing'): NodeJS.ErrnoException {
-  return Object.assign(new Error(message), { code: 'ENOENT' });
+function errno(code: string, message = code): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code });
 }
 
-const outputFlagCases = [
-  {
-    flagLabel: '--output-dir' as const,
-    fileMessage:
-      '--output-dir is not a directory (a parent path component is a file)',
-    danglingMessage: '--output-dir is a dangling symbolic link',
-  },
-  {
-    flagLabel: '--output' as const,
-    fileMessage: '--output: a parent path component is a file',
-    danglingMessage: '--output is a dangling symbolic link',
-  },
-];
-
-const windowsAncestorCases = [
-  {
-    label: 'drive',
-    fileAncestor: String.raw`C:\workspace\blocked`,
-    target: String.raw`C:\workspace\blocked\missing-one\missing-two\output.tex`,
-  },
-  {
-    label: 'UNC',
-    fileAncestor: String.raw`\\server\share\workspace\blocked`,
-    target: String.raw`\\server\share\workspace\blocked\missing-one\missing-two\output.tex`,
-  },
-];
-
-const rootCases = [
-  {
-    label: 'POSIX',
-    dirname: posix.dirname,
-    target: '/missing/output.tex',
-    candidates: ['/missing/output.tex', '/missing', '/'],
-  },
-  {
-    label: 'Windows drive',
-    dirname: win32.dirname,
-    target: String.raw`C:\missing\output.tex`,
-    candidates: [
-      String.raw`C:\missing\output.tex`,
-      String.raw`C:\missing`,
-      'C:\\',
-    ],
-  },
-  {
-    label: 'Windows UNC',
-    dirname: win32.dirname,
-    target: String.raw`\\server\share\missing\output.tex`,
-    candidates: [
-      String.raw`\\server\share\missing\output.tex`,
-      String.raw`\\server\share\missing`,
-      '\\\\server\\share\\',
-    ],
-  },
-];
-
 describe('probeOutputPath', () => {
-  describe.each(windowsAncestorCases)(
-    '$label paths',
-    ({ fileAncestor, target }) => {
-      it.each(outputFlagCases)(
-        'walks past Windows-shaped ENOENT and reports a file ancestor for $flagLabel',
-        async ({ flagLabel, fileMessage }) => {
-          const missingCandidates = [
-            target,
-            win32.dirname(target),
-            win32.dirname(win32.dirname(target)),
-          ];
-          const statVisited: string[] = [];
-          const lstatVisited: string[] = [];
-
-          await expect(
-            probeOutputPathForTests(target, flagLabel, {
-              dirname: win32.dirname,
-              stat: async (candidate) => {
-                statVisited.push(candidate);
-                if (candidate === fileAncestor) {
-                  return { isDirectory: () => false };
-                }
-                throw missingError();
-              },
-              lstat: async (candidate) => {
-                lstatVisited.push(candidate);
-                throw missingError();
-              },
-            }),
-          ).rejects.toThrow(`${fileMessage}: ${target}`);
-          expect(statVisited).toEqual([...missingCandidates, fileAncestor]);
-          expect(lstatVisited).toEqual(missingCandidates);
-        },
-      );
+  const windowsCases = [
+    {
+      label: 'drive',
+      target: String.raw`C:\workspace\blocked\missing\output.tex`,
+      outputParent: String.raw`C:\workspace\blocked\missing`,
     },
-  );
+    {
+      label: 'UNC',
+      target: String.raw`\\server\share\blocked\missing\output.tex`,
+      outputParent: String.raw`\\server\share\blocked\missing`,
+    },
+  ];
 
-  it('stops at the nearest existing directory for a creatable target', async () => {
-    const ancestor = String.raw`C:\workspace`;
-    const target = String.raw`C:\workspace\missing\output.tex`;
-    const statVisited: string[] = [];
-    const lstatVisited: string[] = [];
-
-    await expect(
-      probeOutputPathForTests(target, '--output', {
-        dirname: win32.dirname,
-        stat: async (candidate) => {
-          statVisited.push(candidate);
-          if (candidate === ancestor) return { isDirectory: () => true };
-          throw missingError();
-        },
-        lstat: async (candidate) => {
-          lstatVisited.push(candidate);
-          throw missingError();
-        },
-      }),
-    ).resolves.toBeUndefined();
-    expect(statVisited).toEqual([
-      target,
-      String.raw`C:\workspace\missing`,
-      ancestor,
-    ]);
-    expect(lstatVisited).toEqual([target, String.raw`C:\workspace\missing`]);
-  });
-
-  it.each(rootCases)(
-    'propagates ENOENT after exhausting a $label root',
-    async ({ dirname, target, candidates }) => {
-      const rootError = missingError('missing root');
-      const statVisited: string[] = [];
-      const lstatVisited: string[] = [];
-
+  it.each(windowsCases)(
+    'uses native mkdir after Windows-shaped ENOENT for a $label output path',
+    async ({ target, outputParent }) => {
+      const mkdirVisited: string[] = [];
       await expect(
         probeOutputPathForTests(target, '--output', {
-          dirname,
-          stat: async (candidate) => {
-            statVisited.push(candidate);
-            throw missingError();
-          },
-          lstat: async (candidate) => {
-            lstatVisited.push(candidate);
-            if (candidate === candidates.at(-1)) throw rootError;
-            throw missingError();
-          },
-        }),
-      ).rejects.toBe(rootError);
-      expect(statVisited).toEqual(candidates);
-      expect(lstatVisited).toEqual(candidates);
-    },
-  );
-
-  it.each(outputFlagCases)(
-    'rejects a dangling target symlink for $flagLabel',
-    async ({ flagLabel, danglingMessage }) => {
-      const target = String.raw`C:\workspace\dangling`;
-      const statVisited: string[] = [];
-      const lstatVisited: string[] = [];
-
-      await expect(
-        probeOutputPathForTests(target, flagLabel, {
           dirname: win32.dirname,
-          stat: async (candidate) => {
-            statVisited.push(candidate);
-            throw missingError();
+          stat: async () => {
+            throw errno('ENOENT');
           },
-          lstat: async (candidate) => {
-            lstatVisited.push(candidate);
-            return {
-              isDirectory: () => false,
-              isSymbolicLink: () => true,
-            };
+          mkdir: async (candidate) => {
+            mkdirVisited.push(candidate);
+            throw errno('ENOTDIR');
           },
         }),
-      ).rejects.toThrow(`${danglingMessage}: ${target}`);
-      expect(statVisited).toEqual([target, target]);
-      expect(lstatVisited).toEqual([target]);
+      ).rejects.toThrow(
+        `--output: a parent path component is a file: ${target}`,
+      );
+      expect(mkdirVisited).toEqual([outputParent]);
     },
   );
 
-  it('rejects a dangling symlink ancestor without walking past it', async () => {
-    const dangling = String.raw`C:\workspace\dangling`;
-    const target = String.raw`C:\workspace\dangling\missing\output.tex`;
-    const statVisited: string[] = [];
-    const lstatVisited: string[] = [];
-
+  it('materializes the complete --output-dir path after ENOENT', async () => {
+    const target = String.raw`C:\workspace\missing\output`;
+    const mkdirVisited: string[] = [];
     await expect(
-      probeOutputPathForTests(target, '--output', {
+      probeOutputPathForTests(target, '--output-dir', {
         dirname: win32.dirname,
-        stat: async (candidate) => {
-          statVisited.push(candidate);
-          throw missingError();
+        stat: async () => {
+          throw errno('ENOENT');
         },
-        lstat: async (candidate) => {
-          lstatVisited.push(candidate);
-          if (candidate === dangling) {
-            return {
-              isDirectory: () => false,
-              isSymbolicLink: () => true,
-            };
-          }
-          throw missingError();
+        mkdir: async (candidate) => {
+          mkdirVisited.push(candidate);
+          return candidate;
         },
       }),
-    ).rejects.toThrow(
-      `--output: a parent path component is a dangling symbolic link: ${target}`,
-    );
-    expect(statVisited).toEqual([
-      target,
-      win32.dirname(target),
-      dangling,
-      dangling,
-    ]);
-    expect(lstatVisited).toEqual([target, win32.dirname(target), dangling]);
+    ).resolves.toBeNull();
+    expect(mkdirVisited).toEqual([target]);
   });
 
-  it('propagates unexpected lstat errors', async () => {
-    const denied = Object.assign(new Error('denied'), { code: 'EACCES' });
+  it.each([
+    {
+      flagLabel: '--output' as const,
+      expectedDirectory: '/missing',
+      expectedMessage:
+        '--output parent directory cannot be created: /missing/output.tex',
+    },
+    {
+      flagLabel: '--output-dir' as const,
+      expectedDirectory: '/missing/output.tex',
+      expectedMessage: '--output-dir cannot be created: /missing/output.tex',
+    },
+  ])(
+    'reports mkdir ENOENT before execution for $flagLabel',
+    async ({ flagLabel, expectedDirectory, expectedMessage }) => {
+      const mkdirVisited: string[] = [];
+      await expect(
+        probeOutputPathForTests('/missing/output.tex', flagLabel, {
+          dirname: win32.dirname,
+          stat: async () => {
+            throw errno('ENOENT');
+          },
+          mkdir: async (candidate) => {
+            mkdirVisited.push(candidate);
+            throw errno('ENOENT');
+          },
+        }),
+      ).rejects.toThrow(expectedMessage);
+      expect(mkdirVisited).toEqual([expectedDirectory]);
+    },
+  );
+
+  it('preserves unexpected mkdir failures', async () => {
+    const denied = errno('EACCES', 'denied');
     await expect(
       probeOutputPathForTests('/missing/output.tex', '--output', {
         dirname: win32.dirname,
         stat: async () => {
-          throw missingError();
+          throw errno('ENOENT');
         },
-        lstat: async () => {
+        mkdir: async () => {
           throw denied;
         },
       }),
@@ -251,13 +125,17 @@ describe('probeOutputPath', () => {
 });
 
 describe('dangling output symlinks', () => {
-  it('rejects a real dangling symlink for both output modes', async (context) => {
+  it('keeps a dangling --output symlink writable and rejects a dangling --output-dir before execution', async (context) => {
     const root = await makeTempDir('texra-cli-dangling-output-', tempDirs);
-    const dangling = join(root, 'dangling');
+    const fileReferent = join(root, 'absent.tex');
+    const fileLink = join(root, 'file-link.tex');
+    const directoryReferent = join(root, 'absent-directory');
+    const directoryLink = join(root, 'directory-link');
     try {
+      await symlink(fileReferent, fileLink, 'file');
       await symlink(
-        join(root, 'absent'),
-        dangling,
+        directoryReferent,
+        directoryLink,
         process.platform === 'win32' ? 'junction' : 'dir',
       );
     } catch (error: unknown) {
@@ -276,17 +154,14 @@ describe('dangling output symlinks', () => {
     }
 
     await expect(
-      assertOutputDirAvailable(dangling, root),
-    ).rejects.toBeInstanceOf(CliUsageError);
-    await expect(assertOutputDirAvailable(dangling, root)).rejects.toThrow(
-      `--output-dir is a dangling symbolic link: ${dangling}`,
-    );
+      assertOutputFileAvailable(fileLink, root),
+    ).resolves.toBeUndefined();
     await expect(
-      assertOutputFileAvailable(dangling, root),
+      assertOutputDirAvailable(directoryLink, root),
     ).rejects.toBeInstanceOf(CliUsageError);
-    await expect(assertOutputFileAvailable(dangling, root)).rejects.toThrow(
-      `--output is a dangling symbolic link: ${dangling}`,
-    );
+    await expect(stat(directoryReferent)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
   });
 });
 
@@ -306,12 +181,13 @@ describe('assertOutputDirAvailable', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('accepts a path that does not exist yet (mkdir -p happens later)', async () => {
+  it('creates and accepts a path that does not exist yet', async () => {
     const root = await makeTempDir('texra-cli-outdir-', tempDirs);
     const target = join(root, 'no-such-yet');
     await expect(
       assertOutputDirAvailable(target, root),
     ).resolves.toBeUndefined();
+    expect((await stat(target)).isDirectory()).toBe(true);
   });
 
   it('rejects a --output-dir that points at a file', async () => {


### PR DESCRIPTION
## Summary

Fix another bounded Windows compatibility cluster from #9409. Windows may report `ENOENT` rather than `ENOTDIR` when an output path descends through a file, causing TeXRA to accept an impossible destination and run the full workflow before writing fails.

- preflight with the same native recursive `mkdir` operation the output writer uses
- create `--output-dir` itself, or only the parent directory for `--output`
- reject blocked file ancestors before execution without custom path traversal
- preserve valid exact dangling `--output` symlinks that `copyFile` can follow
- report missing roots and dangling ancestors before the workflow starts
- cover Windows drive/UNC behavior through injected native-operation seams

## Contract decision

Preflight may create output directories before the workflow starts. This is intentional: exercising the real operation is simpler and more portable than reproducing filesystem traversal semantics, and the paths are destinations the successful workflow would create anyway. It does not create or overwrite the `--output` file.

## Scope

This does not claim to re-enable the full Windows matrix. Other path, environment, and fake-filesystem clusters remain independent.

## Verification

- Full local suite: 823 files, 8,400 tests passed; 1 file / 5 tests skipped
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- `npm test`

Refs #9409

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI filesystem preflight and eagerly creates output directories before runs; behavior shifts on Windows and symlink edge cases, though scope is limited to `--output` / `--output-dir` validation.
> 
> **Overview**
> Fixes a Windows case where output paths descending through a **file** could look missing (`ENOENT`) during `stat`, so TeXRA ran the full workflow and only failed at write time.
> 
> **`probeOutputPath`** no longer relies on stat-only ancestor checks. After `ENOENT` on the target, it runs the same **recursive `mkdir`** the output writer uses: for `--output-dir` it creates the full directory; for `--output` only the parent. **`ENOTDIR` / `EEXIST`** from that mkdir are mapped to the existing “parent path component is a file” usage errors; persistent **`ENOENT`** gets clearer “cannot be created” messages. Dependencies are injectable for tests (`probeOutputPathForTests`).
> 
> Preflight **may create output directories** before the workflow starts (intentional—same destinations a successful run would create); it does **not** create the `--output` file. **Dangling `--output` symlinks** to absent files remain allowed; **dangling `--output-dir`** symlinks are rejected before execution.
> 
> Tests cover Windows drive/UNC paths with mocked native ops, mkdir failure modes, and integration updates (e.g. missing `--output-dir` is now created during assert).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5333e127e58d70ac48e591edf6a80ac1e7bcc6e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->