### PR TITLE
refactor(transcript): require exact stream addressing for clearMissingOutputs

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -196,9 +196,7 @@ export function createChatSessionController(
   // projecting status, output, and approval-related facts after the root
   // promise settles. Installing this once also avoids duplicate projections
   // when another root starts while an earlier detached child is still alive.
-  disposers.push(
-    attachTuiRunFactSubscription(runtimeSession.events, snapshotStore),
-  );
+  disposers.push(attachTuiRunFactSubscription(runtimeSession.events));
 
   // Shared prelude of the three run-starting paths (start, resume,
   // follow-up-wake resume): resolve the model-keyed session context and

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -118,13 +118,6 @@ function applyStage(streamId: StreamTabId, stage: StreamStage): void {
 function applyClearMissingOutputs({
   streamId,
 }: ClearMissingOutputsPayload): void {
-  // Exact addressing only (#9590 rule A3). A payload without a streamId is a
-  // defect: throw so the hub logs the dropped mutation loudly.
-  if (!streamId) {
-    throw new Error(
-      'clearMissingOutputs requires the exact streamId selected by the initiator; configuration-based addressing is not accepted',
-    );
-  }
   // The empty map is a destructive reset, not a round patch. Record its
   // source revision even when the current map is already empty so a cold
   // read that started before this fact cannot restore older disk warnings.

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -13,7 +13,6 @@ import {
   type UpdateQueuedFollowUpsPayload,
   type UpdateStreamUsagePayload,
 } from '@shared/schemas';
-import type { StreamSnapshotStore } from '@transcript';
 import { assertNever } from '@utils/core';
 
 import {
@@ -116,32 +115,25 @@ function applyStage(streamId: StreamTabId, stage: StreamStage): void {
   );
 }
 
-type MissingOutputTargetResolver = Pick<
-  StreamSnapshotStore,
-  'findWorkflowStreamsMatching'
->;
-
-function applyClearMissingOutputs(
-  payload: ClearMissingOutputsPayload,
-  targetResolver: MissingOutputTargetResolver | undefined,
-): void {
-  let targets: readonly StreamTabId[] = [];
-  if (payload.streamId) {
-    targets = [payload.streamId];
-  } else if (payload.streamConfig && targetResolver) {
-    targets = targetResolver.findWorkflowStreamsMatching(payload.streamConfig);
-  }
-  for (const streamId of targets) {
-    // The empty map is a destructive reset, not a round patch. Record its
-    // source revision even when the current map is already empty so a cold
-    // read that started before this fact cannot restore older disk warnings.
-    recordMissingOutputsReset(streamId);
-    patchStream(streamId, (slice) =>
-      Object.keys(slice.missingOutputsByRound).length === 0
-        ? slice
-        : { ...slice, missingOutputsByRound: {} },
+function applyClearMissingOutputs({
+  streamId,
+}: ClearMissingOutputsPayload): void {
+  // Exact addressing only (#9590 rule A3). A payload without a streamId is a
+  // defect: throw so the hub logs the dropped mutation loudly.
+  if (!streamId) {
+    throw new Error(
+      'clearMissingOutputs requires the exact streamId selected by the initiator; configuration-based addressing is not accepted',
     );
   }
+  // The empty map is a destructive reset, not a round patch. Record its
+  // source revision even when the current map is already empty so a cold
+  // read that started before this fact cannot restore older disk warnings.
+  recordMissingOutputsReset(streamId);
+  patchStream(streamId, (slice) =>
+    Object.keys(slice.missingOutputsByRound).length === 0
+      ? slice
+      : { ...slice, missingOutputsByRound: {} },
+  );
 }
 
 type TuiRunFactHandlers = {
@@ -252,7 +244,6 @@ function refreshQueuedFollowUps(
 
 export function attachTuiRunFactSubscription(
   events: SessionEventHub,
-  missingOutputTargets?: MissingOutputTargetResolver,
 ): () => void {
   let generation = getCliStateGeneration();
   const detachResetHook = registerCliStateResetHook(() => {
@@ -298,7 +289,7 @@ export function attachTuiRunFactSubscription(
         case 'status':
           return;
         case 'clearMissingOutputs':
-          applyClearMissingOutputs(fact.payload, missingOutputTargets);
+          applyClearMissingOutputs(fact.payload);
           return;
       }
       assertNever(fact, 'Unhandled TUI session fact');

--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -57,7 +57,8 @@ async function runCleanCommand(
       ? await runCleanMultiple(model, inputFile, agent, outputFiles)
       : await runCleanSingle(model, inputFile, agent);
   showCleanResult(result, inputFile);
-  emitClearMissingOutputs({ agent, model, inputFile, outputFiles });
+  // No missing-outputs clear: these invocations have no stream context, and
+  // configuration-based fan-out to look-alike tabs was removed (#9590 A3).
 }
 
 export async function handleCleanSingle(
@@ -105,5 +106,9 @@ export async function handleClean(config: CleanConfig): Promise<void> {
     result = await runWorkspaceClean();
   }
   showCleanResult(result, inputFile);
-  emitClearMissingOutputs(config);
+  // Exactly addressed (#9590 A3): clear only the tab the caller selected.
+  // Config-only invocations have no stream context and clear nothing.
+  if (!config.skipProgressViewClear && config.streamId) {
+    emitClearMissingOutputs(config.streamId);
+  }
 }

--- a/packages/extension/src/commands/housekeeping/packCommands.ts
+++ b/packages/extension/src/commands/housekeeping/packCommands.ts
@@ -79,7 +79,11 @@ export async function handlePack(config: PackConfig): Promise<void> {
     result = await runWorkspacePack();
   }
   showPackResult(result, inputFile);
-  emitClearMissingOutputs(config);
+  // Exactly addressed (#9590 A3): clear only the tab the caller selected.
+  // Config-only invocations have no stream context and clear nothing.
+  if (!config.skipProgressViewClear && config.streamId) {
+    emitClearMissingOutputs(config.streamId);
+  }
 }
 
 export async function handlePackSingle(
@@ -89,7 +93,8 @@ export async function handlePackSingle(
 ): Promise<void> {
   const result = await runPackSingle(model, inputFile, agent);
   showPackResult(result, inputFile);
-  emitClearMissingOutputs({ agent, model, inputFile, outputFiles: [] });
+  // No missing-outputs clear: these invocations have no stream context, and
+  // configuration-based fan-out to look-alike tabs was removed (#9590 A3).
 }
 
 export async function handlePackMultiple(
@@ -100,10 +105,4 @@ export async function handlePackMultiple(
 ): Promise<void> {
   const result = await runPackMultiple(model, inputFile, agent, inputFiles);
   showPackResult(result, inputFile);
-  emitClearMissingOutputs({
-    agent,
-    model,
-    inputFile,
-    outputFiles: inputFiles,
-  });
 }

--- a/packages/extension/src/commands/housekeeping/streamEventUtils.ts
+++ b/packages/extension/src/commands/housekeeping/streamEventUtils.ts
@@ -1,35 +1,19 @@
 import { defaultSession } from '@agent/runtime/SessionHandle';
 
 /**
- * Identity of a pack/clean operation, as far as the missing-outputs marker is
- * concerned. Structurally satisfied by both `PackConfig` and `CleanConfig`.
+ * Clear the missing-outputs marker for the single workflow tab a pack/clean
+ * operation addressed. Mutations are exactly addressed (#9590 rule A3): the
+ * caller supplies the `StreamTabId` it acted on. Agent/model/config identity
+ * is display data, not command authorization, so invocations without a stream
+ * context (command palette, main-view file buttons) clear nothing and must
+ * not call this.
  */
-interface FileOpTarget {
-  agent: string;
-  model: string;
-  inputFile: string;
-  outputFiles: readonly string[];
-  /** Toolbar invocations target one tab; palette invocations have none. */
-  streamId?: string;
-  skipProgressViewClear?: boolean;
-}
-
-/**
- * Clear the missing-outputs marker for the workflow tab(s) a pack/clean
- * operation touched. With a `streamId` the marker is cleared on that tab
- * alone; without one it is broadcast to every workflow tab whose taskState
- * matches the agent/model/inputFile identity.
- */
-export function emitClearMissingOutputs(target: FileOpTarget): void {
-  if (target.skipProgressViewClear) return;
-  const { agent, model, inputFile, outputFiles, streamId } = target;
+export function emitClearMissingOutputs(streamId: string): void {
   defaultSession().events.emit({
     scope: 'session',
     event: {
       type: 'clearMissingOutputs',
-      payload: streamId
-        ? { streamId }
-        : { streamConfig: { agent, model, inputFile, outputFiles } },
+      payload: { streamId },
     },
   });
 }

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -319,13 +319,6 @@ export class ProgressFactApplier {
   }
 
   handleClearMissingOutputs({ streamId }: ClearMissingOutputsPayload): void {
-    // Exact addressing only (#9590 rule A3). A payload without a streamId is
-    // a defect: throw so `applyFact` logs the dropped mutation loudly.
-    if (!streamId) {
-      throw new Error(
-        'clearMissingOutputs requires the exact streamId selected by the initiator; configuration-based addressing is not accepted',
-      );
-    }
     this.sendIfActive(streamId, () =>
       this.webviewUpdater.updateMissingOutputs(streamId, {
         reset: true,

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -318,15 +318,19 @@ export class ProgressFactApplier {
     });
   }
 
-  handleClearMissingOutputs(payload: ClearMissingOutputsPayload): void {
-    const targets = this.state.snapshots.resolveMissingOutputTargets(payload);
-    for (const streamId of targets) {
-      this.sendIfActive(streamId, () =>
-        this.webviewUpdater.updateMissingOutputs(streamId, {
-          reset: true,
-        }),
+  handleClearMissingOutputs({ streamId }: ClearMissingOutputsPayload): void {
+    // Exact addressing only (#9590 rule A3). A payload without a streamId is
+    // a defect: throw so `applyFact` logs the dropped mutation loudly.
+    if (!streamId) {
+      throw new Error(
+        'clearMissingOutputs requires the exact streamId selected by the initiator; configuration-based addressing is not accepted',
       );
     }
+    this.sendIfActive(streamId, () =>
+      this.webviewUpdater.updateMissingOutputs(streamId, {
+        reset: true,
+      }),
+    );
   }
 
   handleUpdateStreamUsage({

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -82,22 +82,14 @@ export interface UpdateCompileFailuresPayload extends StreamScopedPayload {
 }
 
 /**
- * Clear the "missing outputs" marker. Either target a specific tab via
- * `streamId`, or clear every workflow tab whose taskState matches the
- * given `streamConfig` (for command-palette pack/clean which has no
- * stream context).
+ * Clear the "missing outputs" marker on exactly one tab. The initiator
+ * selects the `StreamTabId` it acted on; agent/model/config identity is
+ * query/display data, not command authorization, so configuration-based
+ * fan-out addressing does not exist (#9590 rule A3).
  */
-export type ClearMissingOutputsPayload =
-  | { streamId: StreamTabId; streamConfig?: undefined }
-  | {
-      streamId?: undefined;
-      streamConfig: {
-        agent: string;
-        model: string;
-        inputFile: string;
-        outputFiles?: readonly string[];
-      };
-    };
+export interface ClearMissingOutputsPayload {
+  streamId: StreamTabId;
+}
 
 /** Usage is storage-key scoped: tool-use can resume → multiple runs per tab. */
 export interface UpdateStreamUsagePayload {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -145,12 +145,9 @@ function runTrace(
 }
 
 /** Run `body` with a TUI run-fact subscription attached to a fresh hub. */
-function withRunFacts(
-  body: (hub: SessionEventHub) => void,
-  missingOutputTargets?: Parameters<typeof attachTuiRunFactSubscription>[1],
-): void {
+function withRunFacts(body: (hub: SessionEventHub) => void): void {
   const hub = new SessionEventHub();
-  const detach = attachTuiRunFactSubscription(hub, missingOutputTargets);
+  const detach = attachTuiRunFactSubscription(hub);
   try {
     body(hub);
   } finally {
@@ -3296,90 +3293,81 @@ describe('subscribeRuntimeHost run facts', () => {
     });
   });
 
-  it('projects missing-output and compile facts and clears matching warnings', () => {
-    withRunFacts(
-      (hub) => {
-        hub.emit({
-          scope: 'run',
+  it('projects missing-output and compile facts and clears the addressed stream', () => {
+    withRunFacts((hub) => {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'updateMissingOutputs',
           streamId: root,
-          event: {
-            type: 'updateMissingOutputs',
-            streamId: root,
-            filesByRound: { 0: ['missing.tex'] },
-          },
-        });
-        hub.emit({
-          scope: 'run',
+          filesByRound: { 0: ['missing.tex'] },
+        },
+      });
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'updateCompileFailures',
           streamId: root,
-          event: {
-            type: 'updateCompileFailures',
-            streamId: root,
-            filesByRound: {
-              0: [
-                {
-                  round: 0,
-                  displayName: 'paper.pdf',
-                  output: {
-                    kind: 'external',
-                    absolutePath: '/tmp/paper.pdf',
-                  },
-                  log: {
-                    kind: 'external',
-                    absolutePath: '/tmp/paper.log',
-                  },
-                  logRelativePath: 'paper.log',
+          filesByRound: {
+            0: [
+              {
+                round: 0,
+                displayName: 'paper.pdf',
+                output: {
+                  kind: 'external',
+                  absolutePath: '/tmp/paper.pdf',
                 },
-              ],
-            },
-          },
-        });
-
-        expect(streams.get().get(root)).toMatchObject({
-          missingOutputsByRound: { 0: ['missing.tex'] },
-          compileFailuresByRound: {
-            0: [expect.objectContaining({ displayName: 'paper.pdf' })],
-          },
-        });
-
-        hub.emit({
-          scope: 'session',
-          event: {
-            type: 'clearMissingOutputs',
-            payload: { streamId: root },
-          },
-        });
-        expect(streams.get().get(root)?.missingOutputsByRound).toEqual({});
-
-        hub.emit({
-          scope: 'run',
-          streamId: root,
-          event: {
-            type: 'updateMissingOutputs',
-            streamId: root,
-            filesByRound: { 1: ['again.tex'] },
-          },
-        });
-        hub.emit({
-          scope: 'session',
-          event: {
-            type: 'clearMissingOutputs',
-            payload: {
-              streamConfig: {
-                agent: 'correct',
-                model: 'deepseekT',
-                inputFile: 'paper.tex',
+                log: {
+                  kind: 'external',
+                  absolutePath: '/tmp/paper.log',
+                },
+                logRelativePath: 'paper.log',
               },
-            },
+            ],
           },
-        });
+        },
+      });
 
-        expect(streams.get().get(root)?.missingOutputsByRound).toEqual({});
-        expect(streams.get().get(root)?.compileFailuresByRound[0]).toHaveLength(
-          1,
-        );
-      },
-      { findWorkflowStreamsMatching: () => [root] },
-    );
+      expect(streams.get().get(root)).toMatchObject({
+        missingOutputsByRound: { 0: ['missing.tex'] },
+        compileFailuresByRound: {
+          0: [expect.objectContaining({ displayName: 'paper.pdf' })],
+        },
+      });
+
+      hub.emit({
+        scope: 'session',
+        event: {
+          type: 'clearMissingOutputs',
+          payload: { streamId: root },
+        },
+      });
+      expect(streams.get().get(root)?.missingOutputsByRound).toEqual({});
+
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'updateMissingOutputs',
+          streamId: root,
+          filesByRound: { 1: ['again.tex'] },
+        },
+      });
+      hub.emit({
+        scope: 'session',
+        event: {
+          type: 'clearMissingOutputs',
+          payload: { streamId: root },
+        },
+      });
+
+      expect(streams.get().get(root)?.missingOutputsByRound).toEqual({});
+      expect(streams.get().get(root)?.compileFailuresByRound[0]).toHaveLength(
+        1,
+      );
+    });
   });
 
   it('applies direct usage sequences exactly once', () => {

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -15,6 +15,7 @@ import {
   AgentCategory,
   type ActiveChildInfo,
   buildRunDescriptor,
+  type ClearMissingOutputsPayload,
   type CompileFailure,
   type InquiryThreadUpdatedEvent,
   LOG_LEVELS,
@@ -867,6 +868,23 @@ describe('ProgressBackend', () => {
     } finally {
       await target.backend.state.clearAll();
     }
+  });
+
+  it('rejects a clearMissingOutputs fact without an exact streamId (#9590 A3)', () => {
+    const { backend } = createRecordingBackend();
+
+    // Configuration-only addressing (the removed legacy payload shape) is a
+    // defect, not a broadcast: the handler throws loudly instead of clearing
+    // look-alike tabs or silently dropping the mutation.
+    expect(() =>
+      backend.factApplier.handleClearMissingOutputs({
+        streamConfig: {
+          agent: 'correct',
+          model: 'deepseekT',
+          inputFile: 'paper.tex',
+        },
+      } as unknown as ClearMissingOutputsPayload),
+    ).toThrow(/exact streamId/);
   });
 
   it('keeps the selection when an unknown stream reaches running', async () => {

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -15,7 +15,6 @@ import {
   AgentCategory,
   type ActiveChildInfo,
   buildRunDescriptor,
-  type ClearMissingOutputsPayload,
   type CompileFailure,
   type InquiryThreadUpdatedEvent,
   LOG_LEVELS,
@@ -868,23 +867,6 @@ describe('ProgressBackend', () => {
     } finally {
       await target.backend.state.clearAll();
     }
-  });
-
-  it('rejects a clearMissingOutputs fact without an exact streamId (#9590 A3)', () => {
-    const { backend } = createRecordingBackend();
-
-    // Configuration-only addressing (the removed legacy payload shape) is a
-    // defect, not a broadcast: the handler throws loudly instead of clearing
-    // look-alike tabs or silently dropping the mutation.
-    expect(() =>
-      backend.factApplier.handleClearMissingOutputs({
-        streamConfig: {
-          agent: 'correct',
-          model: 'deepseekT',
-          inputFile: 'paper.tex',
-        },
-      } as unknown as ClearMissingOutputsPayload),
-    ).toThrow(/exact streamId/);
   });
 
   it('keeps the selection when an unknown stream reaches running', async () => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -17,7 +17,6 @@ import {
   buildRunDescriptor,
 } from '@shared/schemas';
 import type {
-  ClearMissingOutputsPayload,
   CompileFailure,
   ExecutionId,
   OutputFileInfo,
@@ -752,7 +751,7 @@ describe('StreamSnapshotStore', () => {
     expect(raw).toEqual({});
   });
 
-  it('clears missing outputs only on the exactly addressed stream, even with duplicate run configurations (#9590 A3)', () => {
+  it('clears missing outputs only on the exactly addressed stream, even with duplicate run configurations (#9590 A3)', async () => {
     const events = new SessionEventHub();
     const store = new StreamSnapshotStore();
     const detach = store.attachSessionEvents(events);
@@ -790,26 +789,6 @@ describe('StreamSnapshotStore', () => {
       });
     }
 
-    // Configuration-only addressing (the removed legacy payload shape) is
-    // rejected: the handler throws (the hub logs it) and mutates nothing.
-    events.emit({
-      scope: 'session',
-      event: {
-        type: 'clearMissingOutputs',
-        payload: {
-          streamConfig: {
-            agent: 'correct',
-            model: 'deepseekT',
-            inputFile: 'paper.tex',
-          },
-        } as unknown as ClearMissingOutputsPayload,
-      },
-    });
-    expect(store.getMissingOutputs(STREAM)).toEqual({ 1: ['missing.tex'] });
-    expect(store.getMissingOutputs(OTHER_STREAM)).toEqual({
-      1: ['missing.tex'],
-    });
-
     // Exact addressing clears the selected stream alone; the duplicate
     // configuration on the other tab does not authorize a fan-out.
     events.emit({
@@ -824,6 +803,8 @@ describe('StreamSnapshotStore', () => {
       1: ['missing.tex'],
     });
     detach();
+    // Settle the async sidecar writes before afterEach removes the temp dir.
+    await store.flush();
   });
 
   it('returns compile failures immediately for streams outside a partial preload without erasing disk markers', async () => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -17,6 +17,7 @@ import {
   buildRunDescriptor,
 } from '@shared/schemas';
 import type {
+  ClearMissingOutputsPayload,
   CompileFailure,
   ExecutionId,
   OutputFileInfo,
@@ -749,6 +750,80 @@ describe('StreamSnapshotStore', () => {
 
     const raw = await readStreamFile(OTHER_STREAM, 'missingOutputs.json');
     expect(raw).toEqual({});
+  });
+
+  it('clears missing outputs only on the exactly addressed stream, even with duplicate run configurations (#9590 A3)', () => {
+    const events = new SessionEventHub();
+    const store = new StreamSnapshotStore();
+    const detach = store.attachSessionEvents(events);
+    // Two look-alike tabs: identical agent/model/input configuration. Only
+    // the initiator-selected StreamTabId may be mutated.
+    const duplicateConfig = AgentConfigSchema.parse({
+      agent: 'correct',
+      model: 'deepseekT',
+      agentCategory: AgentCategory.Workflow,
+      inputFiles: ['paper.tex'],
+    });
+    const executions: Record<string, ExecutionId> = {
+      [STREAM]: 'a1b2c3d4' as ExecutionId,
+      [OTHER_STREAM]: 'd4c3b2a1' as ExecutionId,
+    };
+    for (const stream of [STREAM, OTHER_STREAM]) {
+      events.emit({
+        scope: 'run',
+        streamId: stream,
+        event: {
+          type: 'run.config',
+          streamId: stream,
+          executionId: executions[stream],
+          config: duplicateConfig,
+        },
+      });
+      events.emit({
+        scope: 'run',
+        streamId: stream,
+        event: {
+          type: 'updateMissingOutputs',
+          streamId: stream,
+          filesByRound: { 1: ['missing.tex'] },
+        },
+      });
+    }
+
+    // Configuration-only addressing (the removed legacy payload shape) is
+    // rejected: the handler throws (the hub logs it) and mutates nothing.
+    events.emit({
+      scope: 'session',
+      event: {
+        type: 'clearMissingOutputs',
+        payload: {
+          streamConfig: {
+            agent: 'correct',
+            model: 'deepseekT',
+            inputFile: 'paper.tex',
+          },
+        } as unknown as ClearMissingOutputsPayload,
+      },
+    });
+    expect(store.getMissingOutputs(STREAM)).toEqual({ 1: ['missing.tex'] });
+    expect(store.getMissingOutputs(OTHER_STREAM)).toEqual({
+      1: ['missing.tex'],
+    });
+
+    // Exact addressing clears the selected stream alone; the duplicate
+    // configuration on the other tab does not authorize a fan-out.
+    events.emit({
+      scope: 'session',
+      event: {
+        type: 'clearMissingOutputs',
+        payload: { streamId: STREAM },
+      },
+    });
+    expect(store.getMissingOutputs(STREAM)).toEqual({});
+    expect(store.getMissingOutputs(OTHER_STREAM)).toEqual({
+      1: ['missing.tex'],
+    });
+    detach();
   });
 
   it('returns compile failures immediately for streams outside a partial preload without erasing disk markers', async () => {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -505,19 +505,11 @@ export class StreamSnapshotStore {
       (sessionEvent) => {
         if (sessionEvent.scope !== 'session') return;
         switch (sessionEvent.event.type) {
-          case 'clearMissingOutputs': {
-            // Exact addressing only (#9590 rule A3). A payload without a
-            // streamId is a defect: throw so the hub logs the dropped
-            // mutation loudly instead of silently clearing nothing.
-            const { streamId } = sessionEvent.event.payload;
-            if (!streamId) {
-              throw new Error(
-                'clearMissingOutputs requires the exact streamId selected by the initiator; configuration-based addressing is not accepted',
-              );
-            }
-            this.clearMissingOutputs(streamId);
+          case 'clearMissingOutputs':
+            // Exactly addressed (#9590 rule A3): the payload carries the
+            // initiator-selected streamId; there is no config fan-out.
+            this.clearMissingOutputs(sessionEvent.event.payload.streamId);
             return;
-          }
           case 'updateStreamDescription':
             this.setDescription(
               sessionEvent.event.payload.streamId,

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -58,9 +58,8 @@ import {
   type UpdateStreamUsagePayload,
   type WorkPlanSnapshot,
 } from '@shared/schemas';
-import { getCleanAgentName } from '@shared/schemas/agent';
 import { isProcessAgent } from '@shared/streams/agentKind';
-import { mapToRecord, normalizeFilePath } from '@utils/core';
+import { mapToRecord } from '@utils/core';
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 
@@ -147,30 +146,6 @@ type UsageUpdateResult =
 interface HydratedRunState {
   config?: AgentConfig;
   descriptor?: RunDescriptor;
-}
-
-/**
- * Match criteria for {@link StreamSnapshotStore.findWorkflowStreamsMatching}.
- * Mirrors the `streamConfig` payload on the `clearMissingOutputs` progress
- * event.
- */
-interface WorkflowStreamMatch {
-  agent: string;
-  model: string;
-  inputFile: string;
-  outputFiles?: readonly string[];
-}
-
-function normalizeOutputFiles(outputFiles?: readonly string[]): string[] {
-  return (outputFiles ?? [])
-    .map((file) => normalizeFilePath(file))
-    .filter((file) => file.length > 0)
-    .sort();
-}
-
-function sameOutputFiles(left: string[], right: string[]): boolean {
-  if (left.length !== right.length) return false;
-  return left.every((file, index) => file === right[index]);
 }
 
 /**
@@ -531,10 +506,16 @@ export class StreamSnapshotStore {
         if (sessionEvent.scope !== 'session') return;
         switch (sessionEvent.event.type) {
           case 'clearMissingOutputs': {
-            const targets = this.resolveMissingOutputTargets(
-              sessionEvent.event.payload,
-            );
-            for (const target of targets) this.clearMissingOutputs(target);
+            // Exact addressing only (#9590 rule A3). A payload without a
+            // streamId is a defect: throw so the hub logs the dropped
+            // mutation loudly instead of silently clearing nothing.
+            const { streamId } = sessionEvent.event.payload;
+            if (!streamId) {
+              throw new Error(
+                'clearMissingOutputs requires the exact streamId selected by the initiator; configuration-based addressing is not accepted',
+              );
+            }
+            this.clearMissingOutputs(streamId);
             return;
           }
           case 'updateStreamDescription':
@@ -1667,52 +1648,6 @@ export class StreamSnapshotStore {
       if (record.meta?.executionId) map.set(stream, record.meta.executionId);
     }
     return map;
-  }
-
-  /**
-   * Workflow stream IDs whose run config matches `match`. Used by
-   * command-palette pack/clean to clear missing-output markers across every tab
-   * that surfaced markers for the cleaned files. Both sides are canonicalized
-   * (agent source prefixes stripped, paths normalized to forward slashes).
-   */
-  findWorkflowStreamsMatching(match: WorkflowStreamMatch): StreamTabId[] {
-    const wantAgent = getCleanAgentName(match.agent);
-    const wantFile = normalizeFilePath(match.inputFile);
-    const wantOutputFiles = normalizeOutputFiles(match.outputFiles);
-    const result: StreamTabId[] = [];
-    for (const [stream, record] of this.records) {
-      const cfg = record.runConfig;
-      if (!cfg || cfg.agentCategory !== 'workflow') continue;
-      const cfgPrimaryInput = normalizeFilePath(cfg.inputFiles[0] ?? '');
-      if (
-        getCleanAgentName(cfg.agent) !== wantAgent ||
-        cfg.model !== match.model ||
-        cfgPrimaryInput !== wantFile ||
-        !sameOutputFiles(normalizeOutputFiles(cfg.outputFiles), wantOutputFiles)
-      ) {
-        continue;
-      }
-      result.push(stream);
-    }
-    return result;
-  }
-
-  /**
-   * Resolve a `clearMissingOutputs` target descriptor to the stream tabs it
-   * affects: an explicit `streamId`, else every workflow tab matching
-   * `streamConfig`, else none. Shared by this store's own session-event handler
-   * and the progress-view `ProgressFactApplier` so the resolution rule lives in
-   * exactly one place.
-   */
-  resolveMissingOutputTargets(target: {
-    streamId?: StreamTabId;
-    streamConfig?: WorkflowStreamMatch;
-  }): StreamTabId[] {
-    if (target.streamId) return [target.streamId];
-    if (target.streamConfig) {
-      return this.findWorkflowStreamsMatching(target.streamConfig);
-    }
-    return [];
   }
 
   // ==========================================================================


### PR DESCRIPTION
## Summary

Stage 1 of #9590: run-local mutations are now exactly addressed. The `clearMissingOutputs` mutation requires the exact `StreamTabId` selected by the initiator; the configuration-based fan-out that could clear missing-output markers on every look-alike workflow tab (same agent/model/inputFile/outputFiles) is deleted end to end — payload arm, both resolver methods on `StreamSnapshotStore`, and the CLI TUI's resolver port. Producers that have no stream context (command palette / main-view pack and clean buttons) now clear nothing instead of broadcasting by configuration; producers that know their tab address it directly.

## Issue acceptance gates (#9590 Stage 1, rule A3)

Rule A3: "Any mutation of run-local state, including `clearMissingOutputs`, must carry the exact `StreamTabId` selected by the initiator. Agent/model/input/output configuration is query/display data, not command authorization."

Proof obligations satisfied:

- **(3) rejects configuration-only addressing** — the payload type is now `{ streamId: StreamTabId }`, so configuration-only addressing is unconstructible: every in-repo producer fails to compile without an exact streamId, and the `streamConfig` resolution machinery no longer exists to receive one. Per the owner's review, this is enforced at the type contract (all producers are repository-controlled); no runtime rejection guards or removed-shape tests were kept.
- **(4) duplicate configurations affect only the explicitly addressed stream** — `src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`, "clears missing outputs only on the exactly addressed stream, even with duplicate run configurations (#9590 A3)": two streams carry identical workflow configs and missing-output markers; clearing one via the session event leaves the other's markers intact.
- **(11) deleted resolver symbols have zero production references** — grep proof below.

## Single source of truth

The mutation's address is the initiator-selected `StreamTabId`, carried on the payload from emit to every consumer. There is no secondary resolution rule anywhere: no configuration matcher, no target resolver, no per-host reimplementation (the CLI TUI's `MissingOutputTargetResolver` port is gone with the store methods).

Schema/compat note: `ClearMissingOutputsPayload` is a TypeScript type on the in-memory `SessionEventHub` — it is not Zod-validated, not persisted, and never parsed from a wire. The only external surface is CLI `--output-format ndjson`, which is output-only; `{ streamId }` was already a valid arm of the old union, so emitted records only narrow. No legacy-arm union/transform is needed because no old-format events can be queued or replayed.

## Duplication and abstraction budget

2 public methods deleted from `StreamSnapshotStore` (`resolveMissingOutputTargets`, `findWorkflowStreamsMatching`), 0 methods, ports, facades, or helpers added. Also deleted: the private `WorkflowStreamMatch` type and its two matching helpers (`normalizeOutputFiles`, `sameOutputFiles`), the CLI `MissingOutputTargetResolver` port, and the extension's `FileOpTarget` emit-descriptor interface (`emitClearMissingOutputs` now takes the streamId directly).

## Net elements

```
packages/cli/src/chat/chatSessionController.ts     |   4 +-
 .../cli/src/chat/tui/state/subscribeRuntimeHost.ts |  42 ++----
 .../src/commands/housekeeping/cleanCommands.ts     |   9 +-
 .../src/commands/housekeeping/packCommands.ts      |  15 +--
 .../src/commands/housekeeping/streamEventUtils.ts  |  32 ++---
 .../backend/events/ProgressFactApplier.ts          |  15 +--
 src/shared/schemas/progressEvents.ts               |  22 +--
 src/test-kernel/cli/TuiStateAndFocus.vitest.mts    | 148 ++++++++++-----------
 .../transcript/StreamSnapshotStore.vitest.ts       |  56 ++++++++
 src/transcript/StreamSnapshotStore.ts              |  83 +-----------
 10 files changed, 178 insertions(+), 248 deletions(-)
```

Net −70 lines overall, −85 lines in `StreamSnapshotStore.ts` alone. Public method count on `StreamSnapshotStore`: 42 → 40 by declaration count on this diff (the issue's AST baseline counted 43 → this change removes exactly 2, adds 0).

## Consumer counts

Deleted symbols, production references after this PR (grep over `src/` and `packages/`, tests excluded): `resolveMissingOutputTargets` — 0, `findWorkflowStreamsMatching` — 0, `WorkflowStreamMatch` — 0, `streamConfig` payload arm — 0.

Producer migration (every emitter of the `clearMissingOutputs` session event):

| Producer | Before | After |
| --- | --- | --- |
| `packages/extension/src/commands/housekeeping/streamEventUtils.ts:11` (`emitClearMissingOutputs`, sole emitter) | streamId or config fan-out descriptor | exact `streamId` only |
| `packages/extension/src/commands/housekeeping/cleanCommands.ts:109` (`handleClean`) | config broadcast when no streamId | emits only with `config.streamId` |
| `packages/extension/src/commands/housekeeping/packCommands.ts:82` (`handlePack`) | config broadcast when no streamId | emits only with `config.streamId` |
| `cleanCommands.ts:59` (`runCleanCommand`: single/multiple clean) | config broadcast | no emit (no stream context) |
| `packCommands.ts:91,101` (`handlePackSingle`/`handlePackMultiple`) | config broadcast | no emit (no stream context) |

The progress-view toolbar path (`ProgressWorkflowActionsController.runFileOperation`, `src/controllers/progressView/ProgressWorkflowActionsController.ts:85`) already passes its exact `streamId` plus `skipProgressViewClear: true` and is unchanged.

## Host impact

- **Extension**: `ProgressFactApplier.handleClearMissingOutputs` resets the addressed tab directly. Palette/main-view pack and clean no longer clear markers on config-matching tabs (deliberate: those invocations select no stream). Toolbar behavior unchanged.
- **CLI**: TUI subscriber (`subscribeRuntimeHost.ts`) drops the snapshot-store resolver parameter and applies the reset to the addressed stream; `chatSessionController` no longer passes the store into the subscription. Headless NDJSON output emits only the `{ streamId }` shape (already valid before). Renderer (`runProgressRenderer`) ignored this fact and still does.
- **Desktop**: no producers or bespoke consumers; it shares `StreamSnapshotStore.attachSessionEvents` and `ProgressFactApplier`, so it gets exact addressing for free. Verified no desktop-side references to the deleted symbols.

## Scheduled refactoring

Stages 2–7 of #9590 (direct current-record identity, the dated legacy boundary, reverse/deletion semantics, writer-only mutation, description authority, legacy retirement) remain tracked on the issue. This PR deliberately does not touch reload/root-replacement/flush machinery (#9603 atomic workspace-transition boundary) or the executionId dual-write sites.

## Validation

- `npm run typecheck` — clean (workspace, test-kernel, CLI, extension, trace-viewer, desktop)
- `env -u FORCE_COLOR npx vitest run src/test-kernel/transcript src/test-kernel/progressView src/test-kernel/cli` — 214 files, 2790 tests, all pass
- `env -u FORCE_COLOR npx vitest run src/test-kernel/architecture` — 10 files, 71 tests, all pass (no ratchet widened)
- `npm run check:dead-code-ratchet` — OK, 18 vs 18 baselined (no new dead exports; deleted methods were live surface, not baseline entries)
- `npx eslint` on all touched production files — clean; `npm run format` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
