### PR TITLE
refactor(desktop): require displayPath in Review IPC message

### DIFF
--- a/packages/desktop/src/desktopDiffMessages.ts
+++ b/packages/desktop/src/desktopDiffMessages.ts
@@ -22,7 +22,9 @@ export const DESKTOP_DIFF_COMMANDS = {
 export const DesktopShowDiffMessageSchema = z.object({
   command: z.literal(DESKTOP_DIFF_COMMANDS.SHOW_DIFF),
   title: z.string(),
-  displayPath: z.string().optional(),
+  // The one path the Review workbench displays. Always supplied by the
+  // producer; no fallback reconstruction in the renderer.
+  displayPath: z.string(),
   originalText: z.string(),
   proposedText: z.string(),
   additions: z.int().nonnegative().prefault(0),
@@ -30,10 +32,6 @@ export const DesktopShowDiffMessageSchema = z.object({
   // Monaco language id (e.g. 'plaintext', 'typescript', 'latex'). The
   // renderer falls back to 'plaintext' on unknown values.
   language: z.string().default('plaintext'),
-  // File hints purely for the review header / a11y label. Not used to
-  // re-read content — the text is already in the payload.
-  originalPath: z.string().optional(),
-  proposedPath: z.string().optional(),
 });
 
 export type DesktopShowDiffMessage = z.infer<

--- a/packages/desktop/src/main/desktopDiffHost.ts
+++ b/packages/desktop/src/main/desktopDiffHost.ts
@@ -71,8 +71,6 @@ export function createDesktopDiffHost(
       additions: lineChanges.added,
       deletions: lineChanges.removed,
       language: monacoLanguageForFilePath(proposed.filePath),
-      originalPath: original.filePath,
-      proposedPath: proposed.filePath,
     });
     if (shownInRenderer) return { original, proposed, title };
 

--- a/packages/desktop/src/renderer/reviewPane.ts
+++ b/packages/desktop/src/renderer/reviewPane.ts
@@ -32,15 +32,6 @@ export interface ReviewPaneController {
   setTheme(theme: DesktopThemeKind): void;
 }
 
-function reviewPath(payload: DesktopShowDiffMessage): string {
-  return (
-    payload.displayPath ??
-    payload.proposedPath ??
-    payload.originalPath ??
-    payload.title
-  );
-}
-
 export function createReviewPane(): ReviewPaneController {
   const element = document.createElement('section');
   element.className = 'desktop-review-pane';
@@ -216,7 +207,7 @@ export function createReviewPane(): ReviewPaneController {
       rerender();
     },
     open(payload) {
-      const path = reviewPath(payload);
+      const path = payload.displayPath;
       const entry = { ...payload, key: path, path };
       entries.set(path, entry);
       select(entry);

--- a/packages/desktop/tests/e2e/trajectories.spec.ts
+++ b/packages/desktop/tests/e2e/trajectories.spec.ts
@@ -249,8 +249,6 @@ test('desktop:showDiff opens the in-app Review workbench', async () => {
     additions: 1,
     deletions: 1,
     language: 'latex',
-    originalPath: '/tmp/original/paper.tex',
-    proposedPath: '/tmp/proposed/paper.tex',
   };
 
   await launched.page.evaluate((message) => {

--- a/src/test-kernel/desktop/DesktopDiffHost.vitest.mts
+++ b/src/test-kernel/desktop/DesktopDiffHost.vitest.mts
@@ -111,8 +111,6 @@ describe('createDesktopDiffHost', () => {
       additions: 1,
       deletions: 1,
       language: 'latex',
-      proposedPath,
-      originalPath,
     });
   });
 

--- a/src/test-kernel/desktop/DesktopDiffMessages.vitest.mts
+++ b/src/test-kernel/desktop/DesktopDiffMessages.vitest.mts
@@ -44,12 +44,23 @@ describe('DesktopShowDiffMessageSchema', () => {
       additions: 1,
       deletions: 1,
       language: 'latex',
-      originalPath: '/a',
-      proposedPath: '/b',
     });
     expect(parsed.command).toBe('desktop:showDiff');
     expect(parsed.language).toBe('latex');
     expect(parsed.displayPath).toBe('src/file.ts');
+  });
+
+  it('requires displayPath', async () => {
+    const { DesktopShowDiffMessageSchema } = await loadSourceModule(
+      '@desktop/desktopDiffMessages',
+    );
+    const result = DesktopShowDiffMessageSchema.safeParse({
+      command: 'desktop:showDiff',
+      title: 'Compare',
+      originalText: 'a',
+      proposedText: 'b',
+    });
+    expect(result.success).toBe(false);
   });
 
   it('defaults missing language to plaintext', async () => {
@@ -59,6 +70,7 @@ describe('DesktopShowDiffMessageSchema', () => {
     const parsed = DesktopShowDiffMessageSchema.parse({
       command: 'desktop:showDiff',
       title: 'Compare',
+      displayPath: 'src/file.ts',
       originalText: 'a',
       proposedText: 'b',
     });


### PR DESCRIPTION
## Summary

The unreleased desktop Review workbench accepted the obsolete pre-`displayPath` IPC message shape: the renderer reconstructed a path via `displayPath ?? proposedPath ?? originalPath ?? title`, and the producer sent all three path hints. The sole production producer (`desktopDiffHost`) always sends `displayPath`, and this IPC boundary is ephemeral (not persisted, not exported, desktop unreleased), so the fallback added ambiguity without protecting any released client. This PR makes `displayPath` the single required path field and deletes the fallback chain.

Closes #9645.

## Issue acceptance gates

- [x] The desktop diff IPC schema has one required display path (`displayPath: z.string()` in `packages/desktop/src/desktopDiffMessages.ts`).
- [x] No fallback path reconstruction remains in the Review renderer (`reviewPane.open` uses `payload.displayPath` directly; `reviewPath` deleted).
- [x] No obsolete original/proposed path hints cross this IPC boundary (`desktopDiffHost` stops sending them; schema drops them; e2e payload cleaned).
- [x] Current desktop Review behavior remains covered without compatibility-only tests (schema round-trip/defaults tests updated; new "requires displayPath" test; host/pane tests unchanged in behavior).

## Single source of truth

`DesktopShowDiffMessageSchema` (`packages/desktop/src/desktopDiffMessages.ts`) owns the one display-path field; the renderer consumes it verbatim.

## Duplication and abstraction budget

Removed the four-way path fallback (`displayPath ?? proposedPath ?? originalPath ?? title`) and the duplicate path hints. No new abstraction added.

## Net elements (R6)

- Files: 6 changed (+18/−23, net −5 LoC)
- Exported symbols: none added or removed (`^[+-]export` over the diff: 0)
- Classes/interfaces/enums: 0 added, 1 function deleted (file-local `reviewPath`), 2 schema fields deleted

## Consumer counts (R8)

- `DesktopShowDiffMessage.originalPath`/`proposedPath` (removed): 1 producer (`desktopDiffHost`), 1 consumer (`reviewPane.reviewPath`) — both updated; no other grepped references outside tests/e2e payload, also updated.
- `reviewPath` (removed): file-local, 1 call site, inlined.

## Host impact

Extension: none.
Desktop: Review IPC message shape tightened; Review workbench behavior unchanged for the current producer.
CLI: none.

## Scheduled refactoring

None.

## Validation

- `npx vitest run src/test-kernel/desktop/DesktopDiff{Messages,Host}.vitest.mts src/test-kernel/desktop/DesktopReviewPane.vitest.mts` — 14/14 pass
- `npm run typecheck:desktop` — clean
- `npm run lint` — clean
- `npm run format` — clean
- Full `npm test` running locally; CI is the gate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, unreleased desktop IPC shape change with the sole producer already sending `displayPath`; no auth, persistence, or extension impact.
> 
> **Overview**
> Tightens the unreleased **`desktop:showDiff`** IPC contract so the Review workbench has a single required display path instead of optional hints and renderer-side fallbacks.
> 
> **`DesktopShowDiffMessageSchema`** now requires **`displayPath: z.string()`** and drops **`originalPath`** / **`proposedPath`**. **`desktopDiffHost`** still derives **`displayPath`** from the diff title and no longer sends the extra path fields. **`reviewPane.open`** uses **`payload.displayPath`** directly; the **`reviewPath`** fallback chain (**`displayPath ?? proposedPath ?? originalPath ?? title`**) is removed.
> 
> Tests and the Playwright trajectory payload are updated, including a schema test that **`displayPath`** is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2098def2dab5519dde3aa7ffabdee3c94a1752d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->