### PR TITLE
refactor(desktop): drop unread fragment from DesktopProtocolCallback

### DIFF
--- a/packages/desktop/src/main/desktopProtocolCallbacks.ts
+++ b/packages/desktop/src/main/desktopProtocolCallbacks.ts
@@ -10,7 +10,6 @@ export interface DesktopProtocolCallback {
   rawUrl: string;
   path: string;
   query: string;
-  fragment: string;
 }
 
 interface DesktopProtocolCallbackSubscription {
@@ -82,7 +81,6 @@ export function parseDesktopProtocolCallback(
     rawUrl,
     path,
     query: url.search.length > 0 ? url.search.slice(1) : '',
-    fragment: url.hash.length > 0 ? url.hash.slice(1) : '',
   };
 }
 

--- a/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
@@ -69,7 +69,6 @@ describe('desktop protocol callbacks', () => {
         'texra://texra-ai.texra/auth-callback?state=abc&code=authorization-code',
       path: '/auth-callback',
       query: 'state=abc&code=authorization-code',
-      fragment: '',
     });
   });
 
@@ -78,7 +77,6 @@ describe('desktop protocol callbacks', () => {
       rawUrl: 'texra://auth-callback',
       path: '/auth-callback',
       query: '',
-      fragment: '',
     });
   });
 
@@ -87,7 +85,6 @@ describe('desktop protocol callbacks', () => {
       rawUrl: 'texra://auth-callback/',
       path: '/auth-callback',
       query: '',
-      fragment: '',
     });
   });
 
@@ -100,7 +97,6 @@ describe('desktop protocol callbacks', () => {
       rawUrl: 'texra://texra-ai.texra/auth-callback/?state=abc',
       path: '/auth-callback',
       query: 'state=abc',
-      fragment: '',
     });
   });
 


### PR DESCRIPTION
## Summary

Follow-up from #9639 (implicit OAuth callback fallback removal). `DesktopProtocolCallback.fragment` in `packages/desktop/src/main/desktopProtocolCallbacks.ts` was still declared on the interface and populated from `url.hash` in `parseDesktopProtocolCallback`, but #9639 removed the fragment forwarding in `processProtocolCallback` — the field has zero remaining readers. This PR deletes it.

Closes #9650.

## Issue acceptance gates

- [x] `fragment: string` removed from the `DesktopProtocolCallback` interface.
- [x] `fragment:` property removed from the `parseDesktopProtocolCallback` return value.
- [x] Test fixtures in `DesktopProtocolCallbacks.vitest.mts` updated (4 `fragment: ''` assertions dropped); all 17 tests pass.

## Single source of truth

`DesktopProtocolCallback` (interface + sole parser `parseDesktopProtocolCallback`) owns the callback shape; the auth path consumes `query` only since #9639.

## Duplication and abstraction budget

n/a — dead field deleted; no new abstraction.

## Net elements (R6)

- Files: 2 changed (+0/−6)
- Exported symbols: 0 added/removed (one interface field deleted)
- Classes/interfaces/enums: 0 added/removed; net LoC −6

## Consumer counts (R8)

- `DesktopProtocolCallback.fragment`: 0 readers repo-wide (grepped `.fragment` / `fragment:` across `packages/desktop/src` and `src/`); 1 producer (`parseDesktopProtocolCallback`) and 4 test-fixture assertions, all updated.

## Host impact

Extension: none.
Desktop: protocol callback shape loses an unread field; behavior unchanged.
CLI: none.

## Scheduled refactoring

None.

## Validation

- `npx vitest run src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts` — 17/17 pass
- `npm run typecheck:desktop`, `npm run format` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-field cleanup with no remaining consumers; desktop auth callback behavior unchanged.
> 
> **Overview**
> Removes the unused **`fragment`** field from **`DesktopProtocolCallback`** and stops populating it from **`url.hash`** in **`parseDesktopProtocolCallback`**. Auth/desktop protocol handling already relied on **`query`** only, so runtime behavior is unchanged.
> 
> Vitest expectations in **`DesktopProtocolCallbacks.vitest.mts`** no longer assert **`fragment: ''`** on parsed callback objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a69537aa5b9dfab5862da7f325f778efa4cb868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->