### PR TITLE
refactor(transcript): resolve current records via registered identity

### DIFF
--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -562,21 +562,35 @@ export class SessionHandle {
     }
     const snapshotExecutionIds = this.snapshots.getExecutionIdMap();
     const executionIds = new Map(snapshotExecutionIds);
+    const unresolvedStreams = new Set<StreamTabId>();
     for (const streamId of this.transcripts.keys()) {
       if (executionIds.has(streamId)) continue;
-      const derived = await legacyExecutionIdFromStreamSuffix(streamId, {
-        malformedMeta: 'admit',
-      });
-      if (derived) executionIds.set(streamId, derived);
+      try {
+        const derived = await legacyExecutionIdFromStreamSuffix(streamId, {
+          malformedMeta: 'admit',
+        });
+        if (derived) executionIds.set(streamId, derived);
+      } catch (error) {
+        // A transient storage failure proves nothing about this stream. Leave
+        // it out of this pass — repairing it unmapped would skip its lease
+        // guard — instead of aborting repair for every other stream.
+        unresolvedStreams.add(streamId);
+        logger.warn(
+          `Skipped restart repair for stream ${streamId}: its execution identity could not be read`,
+          { data: error },
+        );
+      }
     }
     let waitingStreams: Set<StreamTabId>;
     let repairStreams: Set<StreamTabId>;
     try {
       waitingStreams = await detectWaitingStreams(executionIds);
-      repairStreams = new Set([
-        ...this.transcripts.getUnfinishedStreamIds(),
-        ...waitingStreams,
-      ]);
+      repairStreams = new Set(
+        [
+          ...this.transcripts.getUnfinishedStreamIds(),
+          ...waitingStreams,
+        ].filter((streamId) => !unresolvedStreams.has(streamId)),
+      );
     } catch (error) {
       logger.warn('Failed to detect resumable streams during restart repair', {
         data: error,
@@ -585,7 +599,11 @@ export class SessionHandle {
       repairStreams = new Set(
         this.transcripts
           .getUnfinishedStreamIds()
-          .filter((streamId) => !snapshotExecutionIds.has(streamId)),
+          .filter(
+            (streamId) =>
+              !snapshotExecutionIds.has(streamId) &&
+              !unresolvedStreams.has(streamId),
+          ),
       );
     }
     if (

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -35,7 +35,7 @@ import type { AgentEvent, AgentTrace, ResultEvent } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { detectWaitingStreams } from '@agent/storage/detectWaitingStreams';
-import { executionIdFromStream } from '@agent/storage/executionIdFromStream';
+import { legacyExecutionIdFromStreamSuffix } from '@agent/storage/executionIdFromStream';
 import { runWithOwnedExecutionLeaseQuiescence } from '@agent/storage/executionLease';
 import { deriveResumability } from '@agent/storage/resumability';
 import { platform } from '@platform/platform';
@@ -564,7 +564,7 @@ export class SessionHandle {
     const executionIds = new Map(snapshotExecutionIds);
     for (const streamId of this.transcripts.keys()) {
       if (executionIds.has(streamId)) continue;
-      const derived = executionIdFromStream(streamId);
+      const derived = await legacyExecutionIdFromStreamSuffix(streamId);
       if (derived) executionIds.set(streamId, derived);
     }
     let waitingStreams: Set<StreamTabId>;

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -564,7 +564,9 @@ export class SessionHandle {
     const executionIds = new Map(snapshotExecutionIds);
     for (const streamId of this.transcripts.keys()) {
       if (executionIds.has(streamId)) continue;
-      const derived = await legacyExecutionIdFromStreamSuffix(streamId);
+      const derived = await legacyExecutionIdFromStreamSuffix(streamId, {
+        malformedMeta: 'admit',
+      });
       if (derived) executionIds.set(streamId, derived);
     }
     let waitingStreams: Set<StreamTabId>;

--- a/src/agent/runtime/restartRepair.ts
+++ b/src/agent/runtime/restartRepair.ts
@@ -7,7 +7,6 @@ import {
   EXECUTION_LEASE_STALE_MS,
   runWithInactiveExecutionLease as defaultRunWithInactiveExecutionLease,
 } from '@agent/storage/executionLease';
-import { executionIdFromStream } from '@agent/storage/executionIdFromStream';
 import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
 import { deriveResumability } from '@agent/storage/resumability';
 import type {
@@ -259,8 +258,10 @@ export async function repairRestartedStreams(
     options.repairStreams,
   )) {
     if (options.signal?.aborted) break;
-    const executionId =
-      options.executionIds.get(streamId) ?? executionIdFromStream(streamId);
+    // `executionIds` is the caller-owned identity channel: SessionHandle
+    // populates it from snapshot sidecars plus the explicit legacy suffix
+    // boundary. No second suffix decode happens here (#9590 A2).
+    const executionId = options.executionIds.get(streamId);
     let repairStarted = false;
     try {
       const repair = async () => {

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -288,7 +288,9 @@ export class SessionStores {
   ): Promise<ExecutionId | undefined> {
     return (
       (await this.snapshots.readPersistedExecutionId(stream)) ??
-      (await legacyExecutionIdFromStreamSuffix(stream))
+      (await legacyExecutionIdFromStreamSuffix(stream, {
+        malformedMeta: 'reject',
+      }))
     );
   }
 
@@ -339,7 +341,9 @@ export class SessionStores {
     }
     for (const stream of streamIds) {
       if (executionIdsByStream.has(stream)) continue;
-      const derived = await legacyExecutionIdFromStreamSuffix(stream);
+      const derived = await legacyExecutionIdFromStreamSuffix(stream, {
+        malformedMeta: 'reject',
+      });
       if (derived) executionIdsByStream.set(stream, derived);
     }
 

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -335,21 +335,41 @@ export class SessionStores {
     const canonicalStreams = new Set(this.streamLogs.keys());
     const streamIds = unique([...snapshotStreams, ...canonicalStreams]);
     const executionIdsByStream = new Map(this.snapshots.getExecutionIdMap());
+    const failed = new Set<StreamTabId>();
+    const retainUnreadable = (stream: StreamTabId, error: unknown): void => {
+      // Per-stream isolation: one unreadable ownership record retains that
+      // stream instead of failing the whole bulk deletion before it starts.
+      logger.warn(
+        CHANNEL,
+        `Stream ${stream} was retained because its execution ownership could not be read: ${toErrorMessage(error)}`,
+        { data: error },
+      );
+      failed.add(stream);
+    };
     for (const stream of snapshotStreams) {
-      const executionId = await this.persistedOrDerivedExecutionId(stream);
-      if (executionId) executionIdsByStream.set(stream, executionId);
+      try {
+        const executionId = await this.persistedOrDerivedExecutionId(stream);
+        if (executionId) executionIdsByStream.set(stream, executionId);
+      } catch (error) {
+        retainUnreadable(stream, error);
+      }
     }
     for (const stream of streamIds) {
-      if (executionIdsByStream.has(stream)) continue;
-      const derived = await legacyExecutionIdFromStreamSuffix(stream, {
-        malformedMeta: 'reject',
-      });
-      if (derived) executionIdsByStream.set(stream, derived);
+      if (failed.has(stream) || executionIdsByStream.has(stream)) continue;
+      try {
+        const derived = await legacyExecutionIdFromStreamSuffix(stream, {
+          malformedMeta: 'reject',
+        });
+        if (derived) executionIdsByStream.set(stream, derived);
+      } catch (error) {
+        retainUnreadable(stream, error);
+      }
     }
 
     const streamsByExecution = new Map<ExecutionId, StreamTabId[]>();
     const streamsWithoutExecution: StreamTabId[] = [];
     for (const stream of streamIds) {
+      if (failed.has(stream)) continue;
       const executionId = executionIdsByStream.get(stream);
       if (!executionId) {
         streamsWithoutExecution.push(stream);
@@ -360,7 +380,6 @@ export class SessionStores {
       streamsByExecution.set(executionId, streams);
     }
     const active = new Set<StreamTabId>();
-    const failed = new Set<StreamTabId>();
     await Promise.all(
       streamsWithoutExecution.map(async (stream) => {
         try {

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -7,7 +7,7 @@ import {
   type DeleteExecutionOptions,
   type DeleteExecutionResult,
 } from '@agent/storage/executionListing';
-import { executionIdFromStream } from '@agent/storage/executionIdFromStream';
+import { legacyExecutionIdFromStreamSuffix } from '@agent/storage/executionIdFromStream';
 import { waitForOwnedExecutionLeaseRelease } from '@agent/storage/executionLease';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
@@ -277,13 +277,18 @@ export class SessionStores {
     );
   }
 
-  /** Persisted run-descriptor id, falling back to the stream-name id. */
+  /**
+   * Persisted run-descriptor id (the stream→execution reverse edge), falling
+   * back to the suffix-derived legacy boundary. Suffix resemblance alone never
+   * admits an execution directory into deletion: the boundary rejects a
+   * derived id whose registered metadata names a different stream (#9590 A2).
+   */
   private async persistedOrDerivedExecutionId(
     stream: StreamTabId,
   ): Promise<ExecutionId | undefined> {
     return (
       (await this.snapshots.readPersistedExecutionId(stream)) ??
-      executionIdFromStream(stream)
+      (await legacyExecutionIdFromStreamSuffix(stream))
     );
   }
 
@@ -334,7 +339,7 @@ export class SessionStores {
     }
     for (const stream of streamIds) {
       if (executionIdsByStream.has(stream)) continue;
-      const derived = executionIdFromStream(stream);
+      const derived = await legacyExecutionIdFromStreamSuffix(stream);
       if (derived) executionIdsByStream.set(stream, derived);
     }
 

--- a/src/agent/storage/executionIdFromStream.ts
+++ b/src/agent/storage/executionIdFromStream.ts
@@ -3,6 +3,7 @@ import {
   ExecutionIdSchema,
   registeredStreamId,
   type ExecutionId,
+  type ExecutionMeta,
   type StreamTabId,
 } from '@shared/schemas';
 
@@ -22,15 +23,31 @@ function executionIdFromStream(stream: StreamTabId): ExecutionId | undefined {
  * directory even when an unrelated stream resembles it by suffix. Records
  * without registration provenance (pre-#9590 history, or a stream whose
  * sidecar was lost) keep the suffix-derived answer.
+ *
+ * `malformedMeta` states the caller's stance on a present-but-unparseable
+ * record, which may well register another owner stream (the parse failure is
+ * logged at warn by the store):
+ * - `'reject'` — deletion admission: corruption blocks the execution
+ *   directory from being admitted, instead of reading as an absent legacy
+ *   record.
+ * - `'admit'` — restart repair: corruption cannot disprove the suffix, and
+ *   the repair path's own strict settlement read fails loudly on the corrupt
+ *   record before any repair mutation, while settled historical corruption
+ *   must not abort the whole pass.
  */
 export async function legacyExecutionIdFromStreamSuffix(
   stream: StreamTabId,
+  options: { readonly malformedMeta: 'reject' | 'admit' },
 ): Promise<ExecutionId | undefined> {
   const derived = executionIdFromStream(stream);
   if (derived === undefined) return undefined;
-  const registered = registeredStreamId(
-    await getExecutionStore(derived).readMeta(),
-  );
+  let meta: ExecutionMeta | null;
+  try {
+    meta = await getExecutionStore(derived).readMetaStrict();
+  } catch {
+    return options.malformedMeta === 'reject' ? undefined : derived;
+  }
+  const registered = registeredStreamId(meta);
   return registered !== undefined && registered !== stream
     ? undefined
     : derived;

--- a/src/agent/storage/executionIdFromStream.ts
+++ b/src/agent/storage/executionIdFromStream.ts
@@ -32,10 +32,17 @@ function executionIdFromStream(stream: StreamTabId): ExecutionId | undefined {
  * - `'reject'` — deletion admission: corruption blocks the execution
  *   directory from being admitted, instead of reading as an absent legacy
  *   record.
- * - `'admit'` — restart repair: corruption cannot disprove the suffix, and
- *   the repair path's own strict settlement read fails loudly on the corrupt
- *   record before any repair mutation, while settled historical corruption
- *   must not abort the whole pass.
+ * - `'admit'` — restart repair: corruption cannot disprove the suffix, so
+ *   mapping here must not throw. A corrupt record surfaces downstream: an
+ *   in-flight repair candidate deliberately aborts the repair pass at its
+ *   own strict settlement read, before any mutation; a settled historical
+ *   stream is never consulted again, so its corruption stays inert.
+ *
+ * Introduced 2026-08-03 (#9590 Stage 2). Retirement: #9590 Stage 3 folds this
+ * boundary into the single discriminated legacy reader; the suffix arm is
+ * deleted at the issue's dated retirement decision (`streamData/` has no
+ * natural expiry, so a date — no earlier than the 2026-11-01 legacy cohort —
+ * is the only available gate).
  */
 export async function legacyExecutionIdFromStreamSuffix(
   stream: StreamTabId,

--- a/src/agent/storage/executionIdFromStream.ts
+++ b/src/agent/storage/executionIdFromStream.ts
@@ -1,15 +1,37 @@
+import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
 import {
   ExecutionIdSchema,
+  registeredStreamId,
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
 
 /** Recover the conventional execution suffix from a persisted stream id. */
-export function executionIdFromStream(
-  stream: StreamTabId,
-): ExecutionId | undefined {
+function executionIdFromStream(stream: StreamTabId): ExecutionId | undefined {
   const separator = stream.lastIndexOf('#');
   const candidate = separator >= 0 ? stream.slice(separator + 1) : stream;
   const parsed = ExecutionIdSchema.safeParse(candidate);
   return parsed.success ? parsed.data : undefined;
+}
+
+/**
+ * Legacy ownership boundary (#9590 A2): a `#executionId` stream-name suffix is
+ * a formatting hint, not authority over an execution directory. The derived id
+ * is admitted only when registered execution metadata does not contradict it —
+ * an execution whose birth registration names a different stream keeps its
+ * directory even when an unrelated stream resembles it by suffix. Records
+ * without registration provenance (pre-#9590 history, or a stream whose
+ * sidecar was lost) keep the suffix-derived answer.
+ */
+export async function legacyExecutionIdFromStreamSuffix(
+  stream: StreamTabId,
+): Promise<ExecutionId | undefined> {
+  const derived = executionIdFromStream(stream);
+  if (derived === undefined) return undefined;
+  const registered = registeredStreamId(
+    await getExecutionStore(derived).readMeta(),
+  );
+  return registered !== undefined && registered !== stream
+    ? undefined
+    : derived;
 }

--- a/src/agent/storage/executionIdFromStream.ts
+++ b/src/agent/storage/executionIdFromStream.ts
@@ -1,3 +1,5 @@
+import { ZodError } from 'zod';
+
 import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
 import {
   ExecutionIdSchema,
@@ -44,7 +46,11 @@ export async function legacyExecutionIdFromStreamSuffix(
   let meta: ExecutionMeta | null;
   try {
     meta = await getExecutionStore(derived).readMetaStrict();
-  } catch {
+  } catch (error) {
+    // Only a validation failure means "malformed record"; a storage read
+    // failure proves nothing about ownership and must propagate rather than
+    // silently admit (or silently withhold) an execution directory.
+    if (!(error instanceof ZodError)) throw error;
     return options.malformedMeta === 'reject' ? undefined : derived;
   }
   const registered = registeredStreamId(meta);

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -8,16 +8,20 @@
 import * as path from 'node:path';
 
 // Local imports
-import { listExecutions, type ExecutionListingEntry } from '@agent/storage';
-import { getStreamTabId } from '@agent/runtime/streamTab';
+import {
+  getExecutionStore,
+  listExecutions,
+  type ExecutionListingEntry,
+} from '@agent/storage';
 import { isFileNotFoundError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { platform } from '@platform/platform';
-import type {
-  ExecutionId,
-  FileLocation,
-  OutputFileInfo,
-  RoundIndexed,
+import {
+  registeredStreamId,
+  type ExecutionId,
+  type FileLocation,
+  type OutputFileInfo,
+  type RoundIndexed,
 } from '@shared/schemas';
 import {
   WORKFLOW_OUTPUT_BASENAME,
@@ -237,14 +241,18 @@ export async function discoverLatestExecutionOutputs(query: {
 
     const snapshots = new StreamSnapshotStore();
     for (const candidate of candidates) {
-      const streamId = getStreamTabId(
-        candidate.agentConfig.agent,
-        candidate.agentConfig.model,
-        { executionId: candidate.id },
+      // The execution's registered stream identity addresses its snapshot
+      // directly; identity is never rebuilt from agent/model configuration
+      // (#9590 A1). Legacy records without registration provenance go
+      // straight to the run-directory scan below.
+      const streamId = registeredStreamId(
+        await getExecutionStore(candidate.id).readMeta(),
       );
-      const rounds = await snapshots.readOutputFiles(streamId);
-      if (rounds && Object.keys(rounds).length > 0) {
-        return { executionId: candidate.id, rounds };
+      if (streamId !== undefined) {
+        const rounds = await snapshots.readOutputFiles(streamId);
+        if (rounds && Object.keys(rounds).length > 0) {
+          return { executionId: candidate.id, rounds };
+        }
       }
       // Stream-tab snapshots are a progress-view artifact that headless
       // `texra run` executions never persist. Fall back to scanning the matched

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -118,6 +118,21 @@ export const ExecutionMetaSchema = ConsistentExecutionMetaSchema.transform(
 );
 export type ExecutionMeta = z.infer<typeof ExecutionMetaSchema>;
 
+/**
+ * The execution's birth-registered stream identity (#9590 A1). Only
+ * registration provenance is authoritative: a `LEGACY_RESOLUTION` value is a
+ * replaceable read cache, and readers holding one must keep using the
+ * compatibility resolver.
+ */
+export function registeredStreamId(
+  meta: Pick<ExecutionMeta, 'streamId' | 'streamIdSource'> | null | undefined,
+): z.infer<typeof StreamTabIdSchema> | undefined {
+  return meta?.streamId !== undefined &&
+    meta.streamIdSource === EXECUTION_STREAM_ID_SOURCE.REGISTRATION
+    ? meta.streamId
+    : undefined;
+}
+
 export const STREAM_PHASE = {
   RUNNING: STREAM_STATUS.RUNNING,
   WAITING: STREAM_STATUS.WAITING,

--- a/src/test-kernel/agent/runtime/RestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/RestartRepair.vitest.ts
@@ -238,33 +238,6 @@ describe('repairRestartedStreams', () => {
     }
   });
 
-  it('derives the lease identity when restart metadata has no execution mapping', async () => {
-    const executionId = 'a8644a' as ExecutionId;
-    const streamId = `tool@model#${executionId}` as StreamTabId;
-    const streamStatus = new StreamStatusMachine(new SessionEventHub());
-    seedRunning(streamStatus, streamId);
-    const runWithInactiveExecutionLease = vi.fn(async () => ({
-      status: 'active' as const,
-      heartbeatAt: 123,
-    }));
-    const closeRunningGroups = vi.fn(async () => [] as StreamTabId[]);
-
-    await repairRestartedStreams({
-      streamStatus,
-      waitingStreams: new Set(),
-      executionIds: new Map(),
-      closeRunningGroups,
-      runWithInactiveExecutionLease,
-    });
-
-    expect(runWithInactiveExecutionLease).toHaveBeenCalledWith(
-      executionId,
-      expect.any(Function),
-    );
-    expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
-    expect(closeRunningGroups).not.toHaveBeenCalled();
-  });
-
   it('repairs resumable running streams to WAITING with neutral group closure', async () => {
     const streamId = 'stream-waiting' as StreamTabId;
     const executionId = 'execution-waiting' as ExecutionId;
@@ -719,32 +692,5 @@ describe('repairRestartedStreams', () => {
       },
     });
     expect(result.terminalStatusUpdated).toEqual([executionId]);
-  });
-
-  it('terminalizes a suffix-derived execution without a snapshot mapping', async () => {
-    const executionId = 'de1a1ed8644' as ExecutionId;
-    const streamId = `assistant#${executionId}` as StreamTabId;
-    const store = getExecutionStore(executionId);
-    await store.writeMeta({ timestamp: '2026-07-16T00:00:00.000Z' });
-    const streamStatus = new StreamStatusMachine(new SessionEventHub());
-    seedRunning(streamStatus, streamId);
-
-    try {
-      const result = await repairRestartedStreams({
-        streamStatus,
-        waitingStreams: new Set(),
-        executionIds: new Map(),
-        repairStreams: [streamId],
-        closeRunningGroups: async () => [],
-      });
-
-      await expect(store.readMeta()).resolves.toMatchObject({
-        terminalStatus: EXECUTION_STATUS.ERROR,
-        outcome: RUN_OUTCOME.FAILED,
-      });
-      expect(result.terminalStatusUpdated).toEqual([executionId]);
-    } finally {
-      await store.clear();
-    }
   });
 });

--- a/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
@@ -42,6 +42,7 @@ vi.mock('@agent/runtime/executeAgent', () => ({
 
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { runAgent } from '@agent/runtime/runAgent';
+import { getStreamTabId } from '@agent/runtime/streamTab';
 import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
 
 const EXECUTION_ID = 'run-agent-owner' as ExecutionId;
@@ -82,7 +83,23 @@ describe('runAgent execution ownership', () => {
     );
 
     expect(mocks.registerExecution).toHaveBeenCalledOnce();
+    // #9590 obligation 1: registration carries the birth stream identity and
+    // completes before the run — so before any transcript/snapshot fact.
+    expect(mocks.registerExecution).toHaveBeenCalledWith(
+      EXECUTION_ID,
+      CONFIG,
+      CONFIG.agent,
+      expect.objectContaining({
+        streamId: getStreamTabId(CONFIG.agent, CONFIG.model, {
+          executionId: EXECUTION_ID,
+        }),
+      }),
+    );
     expect(mocks.executeAgent).toHaveBeenCalledOnce();
+    expect(
+      mocks.registerExecution.mock.invocationCallOrder[0] ??
+        Number.POSITIVE_INFINITY,
+    ).toBeLessThan(mocks.executeAgent.mock.invocationCallOrder[0] ?? 0);
     expect(mocks.completeOwnedExecutionLease).toHaveBeenCalledWith(
       EXECUTION_ID,
     );

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -138,10 +138,12 @@ describe('SessionStores deletion coordination', () => {
 
 describe('SessionStores deletion admission (#9590 A2)', () => {
   function deletionSpy() {
-    return vi.fn(async (executionId: ExecutionId) => ({
-      status: 'deleted' as const,
-      executionId,
-    }));
+    return vi.fn(
+      async (executionId: ExecutionId, options?: DeleteExecutionOptions) => {
+        await options?.beforeDelete?.();
+        return { status: 'deleted' as const, executionId };
+      },
+    );
   }
 
   it('never lets suffix resemblance authorize deleting an execution registered to another stream', async () => {
@@ -224,6 +226,49 @@ describe('SessionStores deletion admission (#9590 A2)', () => {
       expect(session.transcripts.has(stream)).toBe(true);
     } finally {
       readMetaStrict.mockRestore();
+      session.dispose();
+    }
+  });
+
+  it('retains only the unreadable stream during bulk deletion, deleting the rest', async () => {
+    const session = createTestSession();
+    const flakyExecutionId = 'abc222' as ExecutionId;
+    const goodExecutionId = 'abc333' as ExecutionId;
+    const flakyStream = `flaky@model#${flakyExecutionId}` as StreamTabId;
+    const goodStream = `good@model#${goodExecutionId}` as StreamTabId;
+    session.transcripts.ensureStream(flakyStream);
+    session.transcripts.ensureStream(goodStream);
+    await getExecutionStore(goodExecutionId).writeMeta({
+      timestamp: '2026-07-31T00:00:00.000Z',
+    });
+    const readMetaStrict = vi
+      .spyOn(getExecutionStore(flakyExecutionId), 'readMetaStrict')
+      .mockRejectedValue(new Error('storage read failed'));
+    const warn = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
+    const deleteExecution = deletionSpy();
+    const stores = new SessionStores({
+      streamLogs: session.transcripts,
+      snapshots: new StreamSnapshotStore(),
+      deleteExecution,
+    });
+
+    try {
+      const result = await stores.deleteAll();
+
+      expect(result.failed).toEqual(new Set([flakyStream]));
+      expect(deleteExecution).toHaveBeenCalledWith(
+        goodExecutionId,
+        expect.anything(),
+      );
+      expect(deleteExecution).not.toHaveBeenCalledWith(
+        flakyExecutionId,
+        expect.anything(),
+      );
+      expect(session.transcripts.has(flakyStream)).toBe(true);
+      expect(session.transcripts.has(goodStream)).toBe(false);
+    } finally {
+      readMetaStrict.mockRestore();
+      warn.mockRestore();
       session.dispose();
     }
   });

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -5,9 +5,17 @@ import '@test/support/defaultSessionTestSetup';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import { SessionStores, type DeleteExecutionOptions } from '@agent/storage';
+import {
+  getExecutionStore,
+  SessionStores,
+  type DeleteExecutionOptions,
+} from '@agent/storage';
 import * as logUtils from '@logger/logUtils';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  EXECUTION_STREAM_ID_SOURCE,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { createTestSession } from '@test/support/sessionTestUtils';
 import { releaseStreamResources } from '@tools/approval';
 import { StreamLogStore, StreamSnapshotStore } from '@transcript';
@@ -122,6 +130,72 @@ describe('SessionStores deletion coordination', () => {
       expect(result.active).toEqual(new Set([retained]));
       expect(result.failed).toEqual(new Set());
       expect(releases).toEqual([deleted]);
+    } finally {
+      session.dispose();
+    }
+  });
+});
+
+describe('SessionStores deletion admission (#9590 A2)', () => {
+  function deletionSpy() {
+    return vi.fn(async (executionId: ExecutionId) => ({
+      status: 'deleted' as const,
+      executionId,
+    }));
+  }
+
+  it('never lets suffix resemblance authorize deleting an execution registered to another stream', async () => {
+    const session = createTestSession();
+    const executionId = 'abc777' as ExecutionId;
+    const ownerStream = `owner@model#${executionId}` as StreamTabId;
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: '2026-07-31T00:00:00.000Z',
+      streamId: ownerStream,
+      streamIdSource: EXECUTION_STREAM_ID_SOURCE.REGISTRATION,
+    });
+    // Carries the execution's id as a name suffix but has no sidecar
+    // ownership: a formatting hint, not deletion authority.
+    const impostor = `rogue@model#${executionId}` as StreamTabId;
+    session.transcripts.ensureStream(impostor);
+    const deleteExecution = deletionSpy();
+    const stores = new SessionStores({
+      streamLogs: session.transcripts,
+      snapshots: new StreamSnapshotStore(),
+      deleteExecution,
+    });
+
+    try {
+      await expect(stores.deleteStream(impostor)).resolves.toBe('deleted');
+      expect(deleteExecution).not.toHaveBeenCalled();
+      await expect(
+        getExecutionStore(executionId).readMeta(),
+      ).resolves.toMatchObject({ streamId: ownerStream });
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('keeps the suffix boundary for legacy records without registration provenance', async () => {
+    const session = createTestSession();
+    const executionId = 'abc888' as ExecutionId;
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: '2026-07-31T00:00:00.000Z',
+    });
+    const stream = `legacy@model#${executionId}` as StreamTabId;
+    session.transcripts.ensureStream(stream);
+    const deleteExecution = deletionSpy();
+    const stores = new SessionStores({
+      streamLogs: session.transcripts,
+      snapshots: new StreamSnapshotStore(),
+      deleteExecution,
+    });
+
+    try {
+      await expect(stores.deleteStream(stream)).resolves.toBe('deleted');
+      expect(deleteExecution).toHaveBeenCalledWith(
+        executionId,
+        expect.anything(),
+      );
     } finally {
       session.dispose();
     }

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -175,6 +175,32 @@ describe('SessionStores deletion admission (#9590 A2)', () => {
     }
   });
 
+  it('fails closed when the suffix-named execution has malformed metadata', async () => {
+    const session = createTestSession();
+    const executionId = 'abc999' as ExecutionId;
+    // Malformed present metadata may well register another owner stream; it
+    // must not be treated like an absent legacy record.
+    await getExecutionStore(executionId).write('meta', { timestamp: 42 });
+    const stream = `corrupt@model#${executionId}` as StreamTabId;
+    session.transcripts.ensureStream(stream);
+    const warn = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
+    const deleteExecution = deletionSpy();
+    const stores = new SessionStores({
+      streamLogs: session.transcripts,
+      snapshots: new StreamSnapshotStore(),
+      deleteExecution,
+    });
+
+    try {
+      await expect(stores.deleteStream(stream)).resolves.toBe('deleted');
+      expect(deleteExecution).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      session.dispose();
+    }
+  });
+
   it('keeps the suffix boundary for legacy records without registration provenance', async () => {
     const session = createTestSession();
     const executionId = 'abc888' as ExecutionId;

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -201,6 +201,33 @@ describe('SessionStores deletion admission (#9590 A2)', () => {
     }
   });
 
+  it('propagates metadata storage failures instead of deciding ownership', async () => {
+    const session = createTestSession();
+    const executionId = 'abc111' as ExecutionId;
+    const stream = `flaky@model#${executionId}` as StreamTabId;
+    session.transcripts.ensureStream(stream);
+    const readMetaStrict = vi
+      .spyOn(getExecutionStore(executionId), 'readMetaStrict')
+      .mockRejectedValue(new Error('storage read failed'));
+    const deleteExecution = deletionSpy();
+    const stores = new SessionStores({
+      streamLogs: session.transcripts,
+      snapshots: new StreamSnapshotStore(),
+      deleteExecution,
+    });
+
+    try {
+      await expect(stores.deleteStream(stream)).rejects.toThrow(
+        'storage read failed',
+      );
+      expect(deleteExecution).not.toHaveBeenCalled();
+      expect(session.transcripts.has(stream)).toBe(true);
+    } finally {
+      readMetaStrict.mockRestore();
+      session.dispose();
+    }
+  });
+
   it('keeps the suffix boundary for legacy records without registration provenance', async () => {
     const session = createTestSession();
     const executionId = 'abc888' as ExecutionId;

--- a/src/test-kernel/latex/OutputDiscovery.vitest.mts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.mts
@@ -17,6 +17,7 @@ import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 // r0/r1 outputs on disk (the same source the `--run-id` path scans).
 const mocks = vi.hoisted(() => ({
   listExecutions: vi.fn(),
+  getExecutionStore: vi.fn(),
   findRunDir: vi.fn(),
   readOutputFiles: vi.fn(),
 }));
@@ -24,6 +25,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@agent/storage', async (importActual) => ({
   ...(await importActual<typeof import('@agent/storage')>()),
   listExecutions: mocks.listExecutions,
+  getExecutionStore: mocks.getExecutionStore,
 }));
 
 vi.mock('@utils/files', async (importActual) => ({
@@ -64,7 +66,11 @@ describe('discoverLatestExecutionOutputs', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     await installPlatform({}, { fs: nodeFilesystem });
-    // No stream-tab snapshot exists for headless runs.
+    // Headless executions have no registered stream identity and no
+    // stream-tab snapshot.
+    mocks.getExecutionStore.mockReturnValue({
+      readMeta: async () => null,
+    } as never);
     mocks.readOutputFiles.mockResolvedValue(undefined);
   });
 
@@ -100,6 +106,34 @@ describe('discoverLatestExecutionOutputs', () => {
         .sort((a, b) => a - b),
     ).toEqual([0, 1]);
     expect(mocks.findRunDir).toHaveBeenCalledWith('exec-headless');
+  });
+
+  it('reads outputs under the registered stream identity instead of rebuilding it from configuration (#9590 A1)', async () => {
+    mocks.listExecutions.mockResolvedValue([
+      matchingExecution('exec-registered'),
+    ]);
+    // Registered under a stream the agent/model config would NOT derive.
+    mocks.getExecutionStore.mockReturnValue({
+      readMeta: async () => ({
+        timestamp: '2026-01-01T00:00:00.000Z',
+        streamId: 'polish@earlierModel#exec-registered',
+        streamIdSource: 'registration',
+      }),
+    } as never);
+    const rounds = { 0: [] };
+    mocks.readOutputFiles.mockResolvedValue(rounds);
+
+    const result = await discoverLatestExecutionOutputs({
+      agent: 'polish',
+      model: 'deepseek',
+      inputFile: 'paper.tex',
+    });
+
+    expect(mocks.readOutputFiles).toHaveBeenCalledWith(
+      'polish@earlierModel#exec-registered',
+    );
+    expect(result).toEqual({ executionId: 'exec-registered', rounds });
+    expect(mocks.findRunDir).not.toHaveBeenCalled();
   });
 
   it('returns null when neither the snapshot nor the run directory has outputs', async () => {

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -586,6 +586,47 @@ describe('completedRunArchive facade', () => {
     });
   });
 
+  it('reads a registered execution without sidecar or suffix scans, even when its transcript is empty (#9590 A1)', async () => {
+    const executionId = 'abc907abc907' as ExecutionId;
+    const streamId = 'orchestrator@deepseekproT#abc907abc907' as StreamTabId;
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: '2026-07-07T00:00:00.000Z',
+      terminalStatus: 'completed',
+      streamId,
+      streamIdSource: EXECUTION_STREAM_ID_SOURCE.REGISTRATION,
+    });
+    // A decoy stream that a suffix scan would match; registration must make
+    // it unreachable, and an empty registered transcript must not trigger the
+    // alternate-root fallback scan.
+    await persistRows(
+      executionId,
+      new Map([
+        [
+          `other@model#${executionId}` as StreamTabId,
+          [logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'decoy row' })],
+        ],
+      ]),
+    );
+
+    const scan = vi.spyOn(
+      StreamSnapshotStore.prototype,
+      'listPersistedStreams',
+    );
+    const association = vi.spyOn(
+      StreamSnapshotStore.prototype,
+      'readPersistedStreamAssociation',
+    );
+
+    const conversationResult = await readCompletedRunConversation(executionId);
+    expect(conversationResult).toEqual({ conversation: null, source: 'none' });
+
+    const todosResult = await readCompletedRunTodos(executionId);
+    expect(todosResult).toEqual({ todos: [], source: 'none' });
+
+    expect(scan).not.toHaveBeenCalled();
+    expect(association).not.toHaveBeenCalled();
+  });
+
   it('reads a sidecar conversation', async () => {
     const executionId = 'ddd444ddd444' as ExecutionId;
     const streamId = 'orchestrator@deepseekproT#ddd444ddd444' as StreamTabId;

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -1,6 +1,8 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getExecutionStore } from '@agent/storage';
+import { registerExecution } from '@agent/storage/executionLifecycle';
+import { releaseOwnedExecutionLease } from '@agent/storage/executionLease';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   AgentConfigSchema,
@@ -60,7 +62,41 @@ describe('assembleTrace', () => {
   setupPlatform(() => createTempDirPlatform('texra-trace-', tempDirs));
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await cleanupTempDirs(tempDirs);
+  });
+
+  it('resolves a registered execution from its metadata without any sidecar scan (#9590 A1)', async () => {
+    const executionId = 'abc900abc900' as ExecutionId;
+    const executionConfig = config({ agent: 'review', model: 'sonnet46T' });
+    // Registered under a stream the config would NOT derive: proves the read
+    // comes from execution metadata, not from agent/model reconstruction.
+    const registeredId = `chat@earlierModel#${executionId}` as StreamTabId;
+    await registerExecution(executionId, executionConfig, 'review', {
+      streamId: registeredId,
+    });
+    await releaseOwnedExecutionLease(executionId);
+    await appendLogEntry(
+      registeredId as ReturnType<typeof getStreamTabId>,
+      'registered row',
+    );
+
+    const scan = vi.spyOn(
+      StreamSnapshotStore.prototype,
+      'listPersistedStreams',
+    );
+    const association = vi.spyOn(
+      StreamSnapshotStore.prototype,
+      'readPersistedStreamAssociation',
+    );
+
+    const result = await assembleTrace(executionId);
+
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.trace.streamId).toBe(registeredId);
+    expect(scan).not.toHaveBeenCalled();
+    expect(association).not.toHaveBeenCalled();
   });
 
   it('assembles a full trace document, deriving streamId from agent/model/executionId', async () => {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -39,6 +39,7 @@ import {
   ExecutionIdSchema,
   LOG_LEVELS,
   MESSAGE_TYPES,
+  registeredStreamId,
   STREAM_LOG_ENTRY_TYPES,
   type ExecutionId,
   type StreamLogEntry,
@@ -939,14 +940,17 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     }
 
     const transcripts = currentSession().transcripts;
+    // A registration-proven record names its stream directly; only legacy
+    // records enter the compatibility resolver's scans (#9590 A1).
     const streamId =
       handle instanceof AgentExecutionHandle
         ? handle.childStreamId
-        : (
+        : (registeredStreamId(meta) ??
+          (
             await resolvePersistedStreamIdForExecution(executionId, {
               streamLogStore: transcripts,
             })
-          )?.streamId;
+          )?.streamId);
     // Resident while the command runs (an open writer refuses eviction); a
     // released stream rehydrates from disk, and an ephemeral store no-ops.
     if (streamId) await transcripts.ensureLoaded(streamId);

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -6,7 +6,7 @@
  */
 import { isDeepStrictEqual } from 'node:util';
 
-import type { TodoEntry } from '@agent/storage';
+import { getExecutionStore, type TodoEntry } from '@agent/storage';
 import { mediaAttachmentKindToContentBlock } from '@agent/export/attachmentMarkerVocabulary';
 import { formatToolResultAsText } from '@agent/modelHandlers/utils/toolAttachmentUtils';
 import {
@@ -15,6 +15,7 @@ import {
 } from '@agent/storage/conversationFormat';
 import {
   MESSAGE_TYPES,
+  registeredStreamId,
   STREAM_LOG_ENTRY_TYPES,
   ToolUseLogSchema,
   UserMessagePayloadSchema,
@@ -53,6 +54,29 @@ function todoItemToEntry(todo: TodoItem): TodoEntry {
 }
 
 /**
+ * A registration-proven record resolves directly from its execution metadata:
+ * one canonical stream, no historical fallback candidates, and no sidecar or
+ * suffix scan (`fallbackStreamIds` is empty by proof, not omitted as
+ * unknown). Only legacy records — no registration provenance — enter the
+ * compatibility resolver (#9590 A1).
+ */
+async function resolveCompletedRunStream(
+  executionId: ExecutionId,
+  options: {
+    snapshotStore: StreamSnapshotStore;
+    streamLogStore?: StreamLogStore;
+  },
+): Promise<PersistedStreamIdResolution | null> {
+  const registered = registeredStreamId(
+    await getExecutionStore(executionId).readMeta(),
+  );
+  if (registered !== undefined) {
+    return { streamId: registered, fallbackStreamIds: [] };
+  }
+  return resolvePersistedStreamIdForExecution(executionId, options);
+}
+
+/**
  * Read the archived task list for a completed run from the durable stream
  * sidecar (`streamData/{stream}/workPlan.json`).
  */
@@ -60,7 +84,7 @@ export async function readCompletedRunTodos(
   executionId: ExecutionId,
 ): Promise<CompletedRunTodosReadResult> {
   const snapshotStore = new StreamSnapshotStore();
-  const resolved = await resolvePersistedStreamIdForExecution(executionId, {
+  const resolved = await resolveCompletedRunStream(executionId, {
     snapshotStore,
   });
 
@@ -791,7 +815,7 @@ export async function readCompletedRunConversation(
   // nor mutates persistence.
   const streamLogStore = await StreamLogStore.openReadOnly();
 
-  const resolved = await resolvePersistedStreamIdForExecution(executionId, {
+  const resolved = await resolveCompletedRunStream(executionId, {
     snapshotStore,
     streamLogStore,
   });

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -10,13 +10,19 @@
  * a generic failure.
  */
 import { getExecutionStore } from '@agent/storage';
-import { getStreamTabId } from '@agent/runtime/streamTab';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  registeredStreamId,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { runOutcomeToExecutionStatus } from '@shared/streams/streamStatus';
 
 import { StreamLogStore } from './StreamLogStore';
 import { StreamSnapshotStore } from './StreamSnapshotStore';
-import { resolvePersistedStreamIdForExecution } from './executionStreamResolver';
+import {
+  resolvePersistedStreamIdForExecution,
+  type PersistedStreamIdResolution,
+} from './executionStreamResolver';
 import type { TraceDocument } from './traceDocumentSchema';
 
 export type AssembleTraceResult =
@@ -49,10 +55,17 @@ export async function assembleTrace(
   // One call-scoped snapshot store serves both the resolver's sidecar scan and
   // the snapshot read, so the two share its per-stream KV handles.
   const snapshotStore = new StreamSnapshotStore();
-  const resolved = await resolvePersistedStreamIdForExecution(executionId, {
-    snapshotStore,
-    streamLogStore,
-  });
+  // A registration-proven record carries its stream identity directly; only
+  // legacy records (no registration provenance) enter the compatibility
+  // resolver and its sidecar/suffix scans (#9590 A1).
+  const registered = registeredStreamId(meta);
+  const resolved: PersistedStreamIdResolution | null =
+    registered !== undefined
+      ? { streamId: registered }
+      : await resolvePersistedStreamIdForExecution(executionId, {
+          snapshotStore,
+          streamLogStore,
+        });
   if (resolved && !resolved.streamId) {
     const candidateStreamIds = resolved.exactExecutionCandidateStreamIds ?? [];
     return candidateStreamIds.length > 0
@@ -60,10 +73,8 @@ export async function assembleTrace(
       : { status: 'streamLogs_missing' };
   }
   if (!config) return { status: 'config_missing' };
-  const fallbackStreamId = getStreamTabId(config.agent, config.model, {
-    executionId,
-  });
-  const streamId = resolved?.streamId ?? fallbackStreamId;
+  const streamId = resolved?.streamId;
+  if (!streamId) return { status: 'streamLogs_missing' };
 
   const [, snapshot] = await Promise.all([
     streamLogStore.ensureLoaded(streamId),


### PR DESCRIPTION
## Summary

Stage 2 of #9590: current execution records — those whose `ExecutionMeta` carries a `streamId` with `streamIdSource: registration` — resolve execution→stream through that registered value directly. They no longer enter the compatibility resolver's sidecar directory scans, suffix inference, or agent/model-config reconstruction; those mechanisms remain reachable only for legacy records (no registration provenance). Per call site:

| Call site | Before | After |
| --- | --- | --- |
| `src/transcript/traceAssembler.ts` | always called `resolvePersistedStreamIdForExecution`; on `null` reconstructed the stream id from `getStreamTabId(config.agent, config.model, {executionId})` | registered records use `meta.streamId` directly; legacy records use the resolver; the config-derived fallback is deleted (a stream matching it always ends in `#executionId`, so the resolver's suffix scan already finds it — the fallback could only ever "find" a stream that does not exist) |
| `src/transcript/completedRunArchive.ts` (`readCompletedRunConversation`, `readCompletedRunTodos`) | both entry points always called the resolver; a registered record whose primary conversation was empty still fell into `findPersistedStreamFallbacksForExecution`'s alternate-root scan | registered records resolve as `{streamId, fallbackStreamIds: []}` — one canonical stream, provably no fallback candidates, so the alternate-root scan is unreachable; legacy records keep the resolver + scan |
| `src/tools/ExecutionsTool.ts` (`showOutput`) | live-handle miss → resolver | live-handle miss → `registeredStreamId(meta)` (the meta was already in scope) → resolver only for legacy records |
| `src/latex/latexdiff/outputDiscovery.ts` | rebuilt the stream id from `candidate.agentConfig` via `getStreamTabId` for every candidate | reads the candidate's registered `meta.streamId`; only a registered id addresses the snapshot; legacy candidates go straight to the same-execution run-directory scan (the issue's prescribed step 4) |
| `src/agent/runtime/SessionHandle.ts` (restart) | filled sidecar-map gaps with raw `executionIdFromStream` suffix decode | fills gaps with `legacyExecutionIdFromStreamSuffix`, the explicit legacy boundary below |
| `src/agent/runtime/restartRepair.ts` | second, redundant raw suffix decode (`options.executionIds.get(streamId) ?? executionIdFromStream(streamId)`) | removed — `executionIds` is the caller-owned identity channel and `SessionHandle` (the sole production caller) populates it for every repair candidate; no second decode site |
| `src/agent/storage/SessionStores.ts` (`deleteStreamOnce`/`deleteAllOnce`/`sweepOrphanedStreams`) | sidecar `readPersistedExecutionId` → raw suffix decode, which **authorized execution-directory deletion** by name resemblance | sidecar reverse edge unchanged; the suffix arm now goes through `legacyExecutionIdFromStreamSuffix` |

**Deletion-admission decision (the safety-critical site).** A2 says a `StreamTabId` suffix is a formatting hint, not authority to delete an execution directory. But deleting the suffix arm outright would orphan every genuinely legacy stream (pre-registration history has no sidecar `executionId`), which Stage 2 must not do. The conservative rule shipped is a contradiction check, not a new index: decode the suffix, read that execution's registered metadata once, and

- if the execution is **registered to a different stream**, the resemblance is a coincidence — the derived id is rejected and only adjacent stream state is deleted (obligation 6);
- if the execution is **registered to this very stream** (sidecar lost), the registration confirms ownership — deletion proceeds;
- if the record has **no registration provenance** (legacy), the suffix answer stands, exactly as before — this is the explicit, documented legacy boundary (`legacyExecutionIdFromStreamSuffix`), which Stage 3 will fold into the isolated legacy reader;
- if the execution's metadata is **present but malformed** (Codex review finding, fixed in-flight), the boundary reads via `readMetaStrict()` and takes a required per-caller stance: deletion admission passes `malformedMeta: 'reject'` — corruption may hide another registered owner, so it blocks the execution directory instead of reading as absent legacy — while restart repair passes `'admit'`, preserving the pre-existing invariants that a repair candidate's own strict settlement read fails loudly before any mutation and settled historical corruption does not abort the whole pass. Only `ZodError` takes this branch (Codex second finding): storage/read failures propagate, so a transient I/O error can neither admit nor silently withhold ownership. Callers isolate that propagation per stream (Bugbot/texra third-round findings): restart repair warns and excludes only the unresolved stream from the pass, and bulk deletion retains only the unreadable stream in its `failed` set instead of failing the whole clear-all; the single-stream deletion promise rejects loudly. The helper documents its introduction date and the Stage-3/dated-cohort retirement path.

The same boundary serves the restart path, so a suffix coincidence can also no longer route a FAILED terminal-status write to an unrelated execution.

## Issue acceptance gates (#9590 Stage 2; A1/A2)

- **A1** — current runtime/archive paths use `ExecutionMeta.streamId` (registration provenance) directly; no sidecar scan, no suffix inference, no config reconstruction. The resolver itself is untouched and now hosts only legacy resolution plus its own registration fast path.
- **A2** — suffix decode no longer authorizes current execution-directory deletion; ownership comes from the sidecar `RunDescriptor.executionId` reverse edge or registered execution metadata; the surviving suffix arm is legacy-only, explicit, and named as such.
- **Obligation 1** (registration persists immutable `streamId` before transcript/snapshot facts) — already largely pinned by `executionStreamResolver.vitest.ts` "returns the birth-written execution stream without scanning sidecars" (persisted shape + provenance); extended `RunAgentOwnership.vitest.ts` "registers and releases an explicitly identified fresh run" to also assert the registration call carries the birth `streamId` and completes before `executeAgent` (the first possible transcript/snapshot fact).
- **Obligation 2** (no sidecar scan for current records) — three public-boundary tests spy `StreamSnapshotStore.prototype.listPersistedStreams`/`readPersistedStreamAssociation`:
  - `traceAssembler.vitest.ts` — "resolves a registered execution from its metadata without any sidecar scan (#9590 A1)" (registered under a stream the config would *not* derive);
  - `completedRunArchive.vitest.ts` — "reads a registered execution without sidecar or suffix scans, even when its transcript is empty (#9590 A1)" (empty registered transcript + a suffix-matching decoy stream: no scan, no decoy pickup — this path scanned before this PR);
  - `OutputDiscovery.vitest.mts` — "reads outputs under the registered stream identity instead of rebuilding it from configuration (#9590 A1)".
- **Obligation 6** (suffix resemblance never authorizes deletion) — `SessionStores.vitest.ts` "never lets suffix resemblance authorize deleting an execution registered to another stream": a stream named `rogue@model#<executionId>` with no sidecar ownership deletes only its own stream state; `deleteExecution` is never invoked and the execution's metadata survives. Companion tests pin the explicit legacy arm (no registration provenance → suffix boundary still applies) and the malformed-metadata arms ("fails closed when the suffix-named execution has malformed metadata": corrupt `meta.json` never admits the execution directory into deletion; "propagates metadata storage failures instead of deciding ownership": an I/O failure rejects the single-stream deletion instead of deciding either way; "retains only the unreadable stream during bulk deletion, deleting the rest": bulk deletion isolates the failure per stream).

Per the Stage-1 review direction, there are no defensive runtime guards for shapes the type system excludes and no retired-shape rejection tests. Two tests that existed only to pin the removed suffix fallback inside `repairRestartedStreams` were deleted ("derives the lease identity when restart metadata has no execution mapping", "terminalizes a suffix-derived execution without a snapshot mapping"); no test pinned the traceAssembler/outputDiscovery config-derived fallbacks specifically, so none needed deleting there.

## Single source of truth

- **execution → stream (forward):** `ExecutionMeta.streamId` with `streamIdSource: registration`, read via the one predicate `registeredStreamId(meta)` (`src/shared/schemas/stream.ts`, beside the schema it interprets).
- **stream → execution (reverse):** sidecar `RunDescriptor.executionId` — unchanged, per the issue's authority table. `getExecutionId`/`getExecutionIdMap`/`readPersistedExecutionId` reads are untouched.
- **legacy suffix:** exactly one decode site remains in production, `legacyExecutionIdFromStreamSuffix` (`src/agent/storage/executionIdFromStream.ts`); the raw decoder is no longer exported.

## Duplication and abstraction budget

0 new abstractions: no ports, facades, classes, or middle layers. Added elements are two small functions with real multi-caller demand: `registeredStreamId` (6 production callers) and `legacyExecutionIdFromStreamSuffix` (3 production call sites, replacing 4 raw decode sites); plus one module-private `resolveCompletedRunStream` (2 callers inside `completedRunArchive.ts`). Deleted: the config-derived `getStreamTabId` fallback in `traceAssembler`, the config reconstruction in `outputDiscovery`, the duplicate suffix decode in `restartRepair`, and the raw `executionIdFromStream` export.

## Net elements (R6)

```
 src/agent/runtime/SessionHandle.ts                 |  4 +-
 src/agent/runtime/restartRepair.ts                 |  7 +-
 src/agent/storage/SessionStores.ts                 | 13 ++--
 src/agent/storage/executionIdFromStream.ts         | 28 +++++++-
 src/latex/latexdiff/outputDiscovery.ts             | 36 ++++++----
 src/shared/schemas/stream.ts                       | 15 +++++
 src/test-kernel/agent/runtime/RestartRepair.vitest.ts          | 54 ---------
 src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts      | 17 +++++
 src/test-kernel/agent/storage/SessionStores.vitest.ts          | 78 +++++++++-
 src/test-kernel/latex/OutputDiscovery.vitest.mts   | 36 +++++++++-
 src/test-kernel/transcript/completedRunArchive.vitest.ts       | 41 ++++++
 src/test-kernel/transcript/traceAssembler.vitest.ts            | 38 +++++++-
 src/tools/ExecutionsTool.ts                        |  8 ++-
 src/transcript/completedRunArchive.ts              | 30 ++++++++-
 src/transcript/traceAssembler.ts                   | 33 ++++++---
 15 files changed, 520 insertions(+), 111 deletions(-)
```

Production code: 9 files, net +190 lines (mostly comments naming the authority at each converted site); tests: net +158/-54 plus the malformed-metadata admission test. `StreamLogStore`/`StreamSnapshotStore` public surfaces are unchanged (40 + 29); no store method was added or removed in this stage.

## Consumer counts (R8)

Remaining production call sites after this PR (grepped over `src/` and `packages/`, tests excluded) — all legacy-only by construction:

- `resolvePersistedStreamIdForExecution` — 4 callers, each gated behind "no registered streamId": `src/transcript/traceAssembler.ts:65`, `src/transcript/completedRunArchive.ts:76` (via `resolveCompletedRunStream`, both entry points), `src/tools/ExecutionsTool.ts:950`. Its internal registration fast path remains for any residual caller but no converted site reaches the scans with a registered record.
- `findPersistedStreamFallbacksForExecution` — 1 caller: `src/transcript/completedRunArchive.ts:786`, unreachable for registered records (`fallbackStreamIds` is `[]` by proof).
- `legacyExecutionIdFromStreamSuffix` — 3 call sites: `src/agent/storage/SessionStores.ts:291,342`, `src/agent/runtime/SessionHandle.ts:567`.
- raw `executionIdFromStream` — 0 external references (module-private; the export is deleted).

## Host impact

All converted code is host-agnostic core; no extension/desktop/CLI source changed. Extension and desktop share `SessionStores`/`SessionHandle`/`completedRunArchive` and get the admission rule and direct reads for free. CLI: `texra history show/trace` (traceAssembler), `/executions` tool reads, and latexdiff discovery now resolve registered records in constant time; headless latexdiff discovery behavior for meta-less runs is unchanged (run-dir scan). One deliberate legacy-behavior narrowing: a legacy execution with no registered streamId no longer has its latexdiff outputs looked up under a config-derived snapshot id — it goes straight to the run-directory scan, the issue's prescribed retrieval order.

## Scheduled refactoring

Stage 3 isolates the legacy resolver (`executionStreamResolver.ts` scans + `legacyExecutionIdFromStreamSuffix`) into the one discriminated, dated legacy reader with explicit `associated | ambiguous | missing` results and retirement evidence. Stages 4–7 (backfill, store-surface shrink, duplicate-metadata writes, retirement) remain tracked on #9590. This PR does not touch reload/root-replacement/flush machinery (#9603 atomic workspace-transition boundary) and does not change the sidecar reverse edge.

## Validation

- `npm run typecheck` — clean (workspace, test-kernel, CLI, extension, trace-viewer, desktop)
- `env -u FORCE_COLOR npx vitest run src/test-kernel/transcript src/test-kernel/agent/storage src/test-kernel/agent/runtime src/test-kernel/latex src/test-kernel/tools` — 171 files, 1627 tests, all pass
- `env -u FORCE_COLOR npx vitest run src/test-kernel/architecture` — 71 tests pass (no ratchet widened)
- `env -u FORCE_COLOR npx vitest run src/test-kernel/cli/History.vitest.mts src/test-kernel/tools/ExecutionsToolOutput.vitest.ts` — pass
- `npm run check:dead-code-ratchet` — OK, 18 vs 18 baselined
- `npx eslint` on all touched files — clean; `npm run format` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
