### PR TITLE
fix(agent): scope resumed-cycle results to text produced in that cycle

### DIFF
--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -38,17 +38,19 @@ export class ToolUseCycleNode<C> extends Node<
   async prep(shared: ToolUseRunShared): Promise<CyclePrepResult> {
     assertPreparedShared(shared);
 
+    // stateSlices.workspaceSnapshot was produced by this same node's own
+    // toSnapshot() last round (or by ToolUsePrepareNode's one-time
+    // hydration) — never raw persisted/legacy data — so re-deriving it
+    // here uses the canonical-only path (see AgentWorkspaceState.fromCanonicalSnapshot).
+    const workspaceState = AgentWorkspaceState.fromCanonicalSnapshot(
+      shared.stateSlices.workspaceSnapshot,
+    );
     return {
       shouldSkipCycle: shared.shouldSkipCycle,
       messages: shared.messages,
       runState: shared.stateSlices.runStateSnapshot,
-      // stateSlices.workspaceSnapshot was produced by this same node's own
-      // toSnapshot() last round (or by ToolUsePrepareNode's one-time
-      // hydration) — never raw persisted/legacy data — so re-deriving it
-      // here uses the canonical-only path (see AgentWorkspaceState.fromCanonicalSnapshot).
-      workspaceState: AgentWorkspaceState.fromCanonicalSnapshot(
-        shared.stateSlices.workspaceSnapshot,
-      ),
+      workspaceState,
+      cycleStartLastResponse: workspaceState.assembly.lastResponse,
       userChannels: shared.stateSlices.userChannels,
       systemPrompt: shared.systemPrompt,
     };
@@ -208,10 +210,18 @@ export class ToolUseCycleNode<C> extends Node<
       workspaceSnapshot,
       userChannels: prepRes.userChannels,
     };
+    const assemblyResponse = prepRes.workspaceState.assembly.lastResponse;
     const cycleResponse =
       execRes.outcome === 'skipped'
         ? undefined
-        : (execRes.response ?? prepRes.workspaceState.assembly.lastResponse);
+        : (execRes.response ??
+          // The assembly fallback exists for text written during THIS cycle
+          // (the failure-path copy in exec). A value unchanged since prep is
+          // a previous turn's response — an answerless cycle must not return
+          // it as its result (#9531).
+          (assemblyResponse !== prepRes.cycleStartLastResponse
+            ? assemblyResponse
+            : undefined));
     shared.lastResponse = cycleResponse || shared.lastResponse;
     if (cycleResponse) {
       this.services.onCycleResponse?.(cycleResponse);

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -72,12 +72,14 @@ export class ToolUsePrepareNode<C> extends Node<
         rebuiltPrompts.systemPrompt,
         rebuiltPrompts.instructionSuffix,
       );
+      const workspaceState = AgentWorkspaceState.fromSnapshot(
+        resumeShared.stateSlices.workspaceSnapshot,
+      );
       return {
         messages: resumeShared.messages,
         runState: resumeShared.stateSlices.runStateSnapshot,
-        workspaceState: AgentWorkspaceState.fromSnapshot(
-          resumeShared.stateSlices.workspaceSnapshot,
-        ),
+        workspaceState,
+        cycleStartLastResponse: workspaceState.assembly.lastResponse,
         userChannels: {
           input: Object.freeze({
             ...resumeShared.stateSlices.userChannels.input,
@@ -139,6 +141,7 @@ export class ToolUsePrepareNode<C> extends Node<
       messages,
       runState,
       workspaceState,
+      cycleStartLastResponse: workspaceState.assembly.lastResponse,
       userChannels: userVarChannels,
       shouldSkipCycle: false,
       systemPrompt: systemMessage,

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -106,6 +106,15 @@ export interface CyclePrepResult {
   userChannels: UserVariableChannels;
   messages: ProviderMessage[];
   shouldSkipCycle: boolean;
+  /**
+   * `assembly.lastResponse` as captured when this cycle prepared — the
+   * historical baseline. `ToolUseCycleNode.post()` may fall back to assembly
+   * text only when it differs from this value, i.e. when the text was written
+   * during this cycle (e.g. the failure-path copy in `exec`). An unchanged
+   * value is a previous turn's response, and an answerless cycle must not
+   * return it as its result (#9531).
+   */
+  cycleStartLastResponse: string;
   systemPrompt?: string;
 }
 

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -75,12 +75,14 @@ const plan: Plan = {
 function createPrepResult(
   workspaceState: AgentWorkspaceState,
   shouldSkipCycle = true,
+  cycleStartLastResponse = '',
 ): CyclePrepResult {
   return {
     shouldSkipCycle,
     messages: [],
     runState: AgentRunStateSnapshotSchema.parse({}),
     workspaceState,
+    cycleStartLastResponse,
     userChannels: { input: {}, transient: {} },
   };
 }
@@ -274,6 +276,78 @@ describe('tool-use progress events', () => {
     await node.post(shared, prepRes, { outcome: 'skipped' });
 
     expect(onCycleResponse).not.toHaveBeenCalled();
+  });
+
+  it('does not return the previous cycle response for an answerless completed cycle', async () => {
+    // Assembly text unchanged since prep is historical: the cycle produced no
+    // new assistant response, so it must not become this cycle's result (#9531).
+    const workspaceState = AgentWorkspaceState.create();
+    workspaceState.assembly.lastResponse = 'previous turn response';
+    const prepRes = createPrepResult(
+      workspaceState,
+      false,
+      'previous turn response',
+    );
+    const shared = {
+      lastResponse: 'previous turn response',
+    } as ToolUseRunShared;
+    const onCycleResponse = vi.fn();
+    const node = new ToolUseCycleNode().setServices({
+      onCycleResponse,
+    } as unknown as ToolUseServices);
+
+    await node.post(shared, prepRes, { outcome: 'completed', messages: [] });
+
+    expect(onCycleResponse).not.toHaveBeenCalled();
+    expect(shared.lastResponse).toBe('previous turn response');
+  });
+
+  it('does not return the previous cycle response for an answerless failed cycle', async () => {
+    const workspaceState = AgentWorkspaceState.create();
+    workspaceState.assembly.lastResponse = 'previous turn response';
+    const prepRes = createPrepResult(
+      workspaceState,
+      false,
+      'previous turn response',
+    );
+    const shared = {} as ToolUseRunShared;
+    const onCycleResponse = vi.fn();
+    const node = new ToolUseCycleNode().setServices({
+      onCycleResponse,
+    } as unknown as ToolUseServices);
+
+    await node.post(shared, prepRes, {
+      outcome: 'failed',
+      lastError: { message: 'stream failed', userRetryable: true },
+    });
+
+    expect(onCycleResponse).not.toHaveBeenCalled();
+    expect(shared.lastResponse).toBeUndefined();
+  });
+
+  it('reports assembly text written during the cycle over the prep baseline', async () => {
+    // The failure path in exec copies this cycle's partial text into assembly;
+    // differing from the prep-time baseline is what makes it reportable.
+    const workspaceState = AgentWorkspaceState.create();
+    workspaceState.assembly.lastResponse = 'partial cycle text';
+    const prepRes = createPrepResult(
+      workspaceState,
+      false,
+      'previous turn response',
+    );
+    const shared = {} as ToolUseRunShared;
+    const onCycleResponse = vi.fn();
+    const node = new ToolUseCycleNode().setServices({
+      onCycleResponse,
+    } as unknown as ToolUseServices);
+
+    await node.post(shared, prepRes, {
+      outcome: 'failed',
+      lastError: { message: 'stream failed', userRetryable: true },
+    });
+
+    expect(onCycleResponse).toHaveBeenCalledWith('partial cycle text');
+    expect(shared.lastResponse).toBe('partial cycle text');
   });
 
   it('persists a completed cycle structured result in shared state', async () => {

--- a/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
@@ -372,4 +372,143 @@ describe('native subagent production delivery path', () => {
     expect(completedResumes).toEqual([PARENT_STREAM_ID, PARENT_STREAM_ID]);
     expect(parentTurns).toHaveLength(0);
   }, 30_000);
+
+  it('does not redeliver turn 1 when the resumed turn produces no new assistant message', async () => {
+    const parentTurns = [
+      { text: 'Parent ready.' },
+      { text: 'Parent received result A.' },
+      { text: 'Parent closed out an empty second turn.' },
+    ];
+    // Turn 2 is answerless: the scripted transport ends the turn with no text,
+    // so the resumed cycle completes without adding an assistant message.
+    const childTurns = [{ text: 'Result A.' }, { text: '' }];
+    const observedFollowUps: Array<{
+      readonly model: string;
+      readonly messages: readonly unknown[];
+      readonly text: string;
+    }> = [];
+    modelFactoryMocks.createModelHandler.mockImplementation(
+      async (modelConfig: { name: string }) =>
+        taggedScriptedHandler(
+          modelConfig.name,
+          modelConfig.name === CHILD_MODEL ? childTurns : parentTurns,
+          observedFollowUps,
+        ),
+    );
+
+    const parentConfig = AgentConfigSchema.parse({
+      agent: PARENT_AGENT,
+      agentSource: 'inline',
+      agentCategory: AgentCategory.ToolUse,
+      model: PARENT_MODEL,
+      instruction: 'Coordinate the child proof review.',
+      workingDirectory: process.cwd(),
+    });
+    await registerExecution(PARENT_EXECUTION_ID, parentConfig, PARENT_AGENT, {
+      streamId: PARENT_STREAM_ID,
+      parentExecutionId: OUTER_EXECUTION_ID,
+    });
+    await expect(
+      executeAgent(parentConfig, PARENT_EXECUTION_ID, {
+        session,
+        allowWaitingResult: true,
+        isSubagent: true,
+        parentStreamId: OUTER_STREAM_ID,
+      }),
+    ).resolves.toMatchObject({
+      outcome: STREAM_PHASE.WAITING,
+      response: 'Parent ready.',
+    });
+
+    const parentContext = createRunContext({
+      streamId: PARENT_STREAM_ID,
+      executionId: PARENT_EXECUTION_ID,
+      modelCell: new ModelCell({} as never, PARENT_MODEL),
+      session,
+    });
+    const runAsParentOwner = captureOwnedExecutionLease(PARENT_EXECUTION_ID);
+    const launch = await runAsParentOwner(() =>
+      withRunContext(parentContext, () =>
+        executeSubagent(
+          {
+            agent: CHILD_AGENT,
+            agentSource: 'inline',
+            agentCategory: AgentCategory.ToolUse,
+            model: CHILD_MODEL,
+            instruction: 'Prove the first assertion.',
+            memories: [],
+            workingDirectory: process.cwd(),
+          },
+          CHILD_AGENT,
+          PARENT_STREAM_ID,
+        ),
+      ),
+    );
+    expect(launch.status).toBe('executed');
+    const executionId = childExecutionId(launch.output);
+    childId = executionId;
+
+    await waitForPersistedResult(executionId, 'Result A.');
+    await vi.waitFor(() => expect(completedResumes).toHaveLength(1), {
+      timeout: 10_000,
+    });
+
+    const resumed = await runAsParentOwner(() =>
+      withRunContext(parentContext, () =>
+        new DelegateAgentTool().call({
+          agent: null,
+          model: null,
+          instruction: 'Now prove the second assertion.',
+          memories: [],
+          working_directory: null,
+          execution_id: executionId,
+        }),
+      ),
+    );
+    expect(resumed.status).toBe('executed');
+    expect(resumed.summary).toContain('Follow-up queued');
+
+    // The answerless turn still delivers: its report/result overwrite turn 1's
+    // with an explicitly empty response rather than replaying 'Result A.' — and
+    // the parent is resumed a second time to consume that empty delivery.
+    await vi.waitFor(
+      async () => {
+        await expect(
+          getExecutionStore(executionId).readResultMeta(),
+        ).resolves.toMatchObject({
+          result: { response: '' },
+        });
+        const report = await getExecutionStore(executionId).readReport();
+        expect(report).not.toContain('Result A.');
+        expect(report).not.toContain('<response>');
+      },
+      { timeout: 10_000 },
+    );
+    await vi.waitFor(() => expect(completedResumes).toHaveLength(2), {
+      timeout: 10_000,
+    });
+
+    await session.transcripts.flush();
+    const archivedChild = await readCompletedRunConversation(executionId);
+    // Turn 2 added the user instruction but no new assistant row.
+    expect(archivedChild.conversation).toEqual([
+      expect.objectContaining({ role: 'user' }),
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Result A.' }],
+      },
+      expect.objectContaining({
+        role: 'user',
+        content: expect.stringContaining('second assertion'),
+      }),
+    ]);
+
+    const archivedParent =
+      await readCompletedRunConversation(PARENT_EXECUTION_ID);
+    const parentText = JSON.stringify(archivedParent.conversation);
+    expect(parentText.match(/Result A\./g)).toHaveLength(1);
+    expect(resumedStreams).toEqual([PARENT_STREAM_ID, PARENT_STREAM_ID]);
+    expect(completedResumes).toEqual([PARENT_STREAM_ID, PARENT_STREAM_ID]);
+    expect(parentTurns).toHaveLength(0);
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

One acceptance criterion of #9531: **a resumed cycle that produces no new assistant response cannot return the previous cycle's response.**

`ToolUseCycleNode.post()` computed the cycle result as `execRes.response ?? prepRes.workspaceState.assembly.lastResponse`. The fallback value is captured at `prep()` from persisted state — i.e. historical — so a resumed turn (e.g. `delegate_agent(execution_id)` follow-up) that completed without a new assistant message returned the *previous* turn's response as its own result. This is the mechanism behind the 2026-07-31 incident in which a resumed child re-emitted its prior result repeatedly.

`prep()` now captures the cycle-start baseline (`CyclePrepResult.cycleStartLastResponse`), and `post()` honors the assembly fallback only when the value changed during the cycle (the failure-path refresh in `exec`'s catch). An answerless cycle fires no `onCycleResponse`; `RunToolUseFlowResult.response` stays `undefined`, which the delivery path already handles explicitly (an empty-response delivery overwrites the prior report/result slots rather than replaying them — see notes below).

Refs #9531 (one AC; the turn-identity and idempotent-delivery ACs are later-stage work, deliberately out of scope here).

## Issue acceptance gates

- [x] A resumed cycle that produces no new assistant response cannot return the previous cycle's response (new production-shaped regression + `post()`-level unit tests).
- [x] The regression traverses real resume, child queue, report/result persistence, parent admission, and reopened archive; only the external model transport is scripted (extends the #9576 suite).
- [x] Existing #9347 ownership/race tests and the #9560 partial-text-retention tests continue to pass (failure-path refresh semantics preserved).
- [ ] Remaining ACs (stable turn identity, idempotent delivery, interrupted-turn exposure, concurrent-turn ordering, structured diagnostics) — not in this PR's scope; they are the issue's later stages.

## Single source of truth

The cycle result boundary is `ToolUseCycleNode.post()` alone: the baseline lives on `CyclePrepResult` and the "was it written during this cycle?" judgment happens in exactly one place.

## Duplication and abstraction budget

n/a — one prep field + one comparison. No new abstraction; the #9560 scrub/snapshot machinery is untouched and the fix no longer depends on its placement.

## Net elements (R6)

- Files: 5 changed (+246/−11, mostly tests)
- Exported symbols: 0 added/removed (one field added to the internal `CyclePrepResult` interface)
- Classes/interfaces/enums: 0 added/removed

## Consumer counts (R8)

- `CyclePrepResult` producers: 2 (`ToolUseCycleNode.prep`, `ToolUsePrepareNode` literals) — both populate the new required field; `ToolUsePrepareNode`'s result never reaches `CycleNode.post`.
- `onCycleResponse`: 1 consumer (`runToolUseFlow` result closure) — verified an unfired callback leaves `response: undefined`, mapped through `executeAgent.buildToolUseFlowResult` → `nativeSubagentStrategy.toDeliveryResult` → `AgentFinalResult` (prefaults `''`) → `formatSubagentDelivery` (omits the `<response>` block) → `childRunLoop.deliverTurn` overwrites the prior report/result slots and enqueues one parent wake. No crash, no secondary replay of the prior response.

## Host impact

Extension: resumed subagent turns can no longer replay the prior turn's result.
Desktop: same shared flow.
CLI: same shared flow.

## Scheduled refactoring

The issue's later stages (stable turn identity, idempotent parent admission) remain tracked on #9531. Known residual gaps documented by this PR's investigation: an interrupted turn 2 still leaves turn 1 in the report/result slots (the issue's "one mutable latest-value slot" gap), and the value-compare guard cannot distinguish byte-identical partial text across turns (needs turn identity).

## Validation

- `npx vitest run src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts` — 16/16 pass
- `npx vitest run src/test-kernel/tools/ src/test-kernel/agent/` — 295 files / 2864 tests pass
- Mutation check: reverting only the `post()` guard makes exactly the new answerless tests fail
- `npm run typecheck:workspace`, `npm run lint`, `npm run format` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the tool-use cycle result boundary used by subagent resume and parent delivery; behavior is intentional but affects production orchestration paths.
> 
> **Overview**
> Fixes **#9531**: resumed tool-use cycles that finish without new assistant text no longer treat the prior turn’s `assembly.lastResponse` as this cycle’s result.
> 
> `CyclePrepResult` now records **`cycleStartLastResponse`** at prepare time (`ToolUsePrepareNode` and `ToolUseCycleNode.prep`). In **`ToolUseCycleNode.post()`**, the assembly fallback applies only when that value **changed during the cycle** (e.g. partial text copied on failure); otherwise the cycle yields no response, **`onCycleResponse` is not fired**, and delivery can persist an empty result instead of replaying the last answer.
> 
> Unit tests cover answerless completed/failed cycles and unchanged-vs-updated assembly text; a production-shaped subagent test asserts an answerless resumed child turn does not redeliver turn 1’s result to the parent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e043ab0fbdbcbbcf0bbccb7a1e6ca66243fd0d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->