### PR TITLE
feat(settings): add UI to clear a Copilot route preference

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -403,6 +403,7 @@ export function createDesktopSettingsIpc(
     setPreferShortModelNames: (message) =>
       settingsHost.setPreferShortModelNames(message.enabled),
     requestModelAccess: unsupported('Copilot models require VS Code.'),
+    clearCopilotRoute: unsupported('Copilot models require VS Code.'),
     ...options.agentSettingsController.handlers,
     // Mirrors the extension's `GitHubSubscriptionHandlers`. The token store and
     // the subscription registry are host-agnostic (`@tools/github`); only the

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -402,6 +402,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         }),
       requestModelAccess: (message) =>
         this.handleRequestModelAccess(message.modelName),
+      clearCopilotRoute: (message) =>
+        this.handleClearCopilotRoute(message.modelName),
       setAgentEnabled: (message) =>
         this.agentHandlers.handleSetAgentEnabled(message),
       setAllAgentsEnabled: (message) =>
@@ -964,6 +966,17 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         ),
       ]);
     }
+  }
+
+  /** Clear the per-model Copilot route preference (#9659), returning the
+   * canonical model to direct-provider routing. */
+  private async handleClearCopilotRoute(modelName: string): Promise<void> {
+    await setCopilotRoutePreference(modelName, false);
+    invalidateModelOptionsCache();
+    await Promise.all([
+      safeExecuteCommand('texra.refreshAllOptions', [], this.viewName),
+      this.withActiveWebview((webview) => this.sendModelSelectionData(webview)),
+    ]);
   }
 
   /** Refresh settings-view agent list and main-view dropdown after agent mutations. */

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -216,33 +216,44 @@ export class ModelsTab extends LitElement {
     const optInModel = models.find(
       (model) => model.access === 'allowed' && !model.preferred,
     );
+    // A chosen route needs an explicit undo (#9659): clearing the
+    // preference returns the canonical model to direct-provider routing.
+    const preferredModel = models.find((model) => model.preferred);
     const unavailableCount = models.filter(
       (model) => model.access === 'unavailable',
     ).length;
     let status: string;
     if (consentModel) {
       status = 'VS Code is ready to ask for your consent.';
+    } else if (preferredModel) {
+      status = `${preferredModel.label} runs through Copilot.`;
     } else if (readyCount > 0) {
       status = `${readyCount} ${pluralize(readyCount, 'Copilot model is', 'Copilot models are')} ready.`;
     } else {
       status = `${unavailableCount} ${pluralize(unavailableCount, 'Copilot model is', 'Copilot models are')} unavailable.`;
     }
 
-    // The single route action: consent first, then opt-in for an
-    // already-authorized route the user has not chosen yet.
-    const actionModel = consentModel ?? optInModel;
+    // The single route action: consent first, then undo for a chosen route,
+    // then opt-in for an already-authorized route not chosen yet.
+    const actionModel = consentModel ?? preferredModel ?? optInModel;
+    let actionText = '';
+    let actionCommand: string = SETTINGS_VIEW_COMMANDS.REQUEST_MODEL_ACCESS;
+    if (consentModel) {
+      actionText = 'Grant access';
+    } else if (preferredModel) {
+      actionText = `Stop using Copilot for ${preferredModel.label}`;
+      actionCommand = SETTINGS_VIEW_COMMANDS.CLEAR_COPILOT_ROUTE;
+    } else if (optInModel) {
+      actionText = `Use Copilot for ${optInModel.label}`;
+    }
     const action = actionModel
       ? renderLabeledActionButton({
           icon: 'shield',
-          text: consentModel
-            ? 'Grant access'
-            : `Use Copilot for ${actionModel.label}`,
+          text: actionText,
           kind: 'primary',
           appearance: consentModel ? 'filled' : 'outlined',
           onClick: () =>
-            postMessage(SETTINGS_VIEW_COMMANDS.REQUEST_MODEL_ACCESS, {
-              modelName: actionModel.name,
-            }),
+            postMessage(actionCommand, { modelName: actionModel.name }),
         })
       : nothing;
 

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -208,41 +208,49 @@ export class ModelsTab extends LitElement {
     const readyCount = models.filter(
       (model) => model.access === 'allowed',
     ).length;
+    // A chosen route needs an explicit undo (#9659): clearing the
+    // preference returns the canonical model to direct-provider routing.
+    // The undo wins the single action slot even when the route is stuck
+    // (consent-required/unavailable) — it is the only way out of that state.
+    const preferredModel = models.find((model) => model.preferred);
     const consentModel = models.find(
-      (model) => model.access === 'consent-required',
+      (model) => model.access === 'consent-required' && !model.preferred,
     );
     // An already-authorized route still needs an explicit opt-in: access
     // alone never routes a canonical model through Copilot (#9635).
     const optInModel = models.find(
       (model) => model.access === 'allowed' && !model.preferred,
     );
-    // A chosen route needs an explicit undo (#9659): clearing the
-    // preference returns the canonical model to direct-provider routing.
-    const preferredModel = models.find((model) => model.preferred);
     const unavailableCount = models.filter(
       (model) => model.access === 'unavailable',
     ).length;
     let status: string;
-    if (consentModel) {
+    if (preferredModel) {
+      if (preferredModel.access === 'allowed') {
+        status = `${preferredModel.label} runs through Copilot.`;
+      } else if (preferredModel.access === 'consent-required') {
+        status = `${preferredModel.label} is set to use Copilot but is waiting for consent.`;
+      } else {
+        status = `${preferredModel.label} is set to use Copilot but is currently unavailable.`;
+      }
+    } else if (consentModel) {
       status = 'VS Code is ready to ask for your consent.';
-    } else if (preferredModel) {
-      status = `${preferredModel.label} runs through Copilot.`;
     } else if (readyCount > 0) {
       status = `${readyCount} ${pluralize(readyCount, 'Copilot model is', 'Copilot models are')} ready.`;
     } else {
       status = `${unavailableCount} ${pluralize(unavailableCount, 'Copilot model is', 'Copilot models are')} unavailable.`;
     }
 
-    // The single route action: consent first, then undo for a chosen route,
+    // The single route action: undo for a chosen route first, then consent,
     // then opt-in for an already-authorized route not chosen yet.
-    const actionModel = consentModel ?? preferredModel ?? optInModel;
+    const actionModel = preferredModel ?? consentModel ?? optInModel;
     let actionText = '';
     let actionCommand: string = SETTINGS_VIEW_COMMANDS.REQUEST_MODEL_ACCESS;
-    if (consentModel) {
-      actionText = 'Grant access';
-    } else if (preferredModel) {
+    if (preferredModel) {
       actionText = `Stop using Copilot for ${preferredModel.label}`;
       actionCommand = SETTINGS_VIEW_COMMANDS.CLEAR_COPILOT_ROUTE;
+    } else if (consentModel) {
+      actionText = 'Grant access';
     } else if (optInModel) {
       actionText = `Use Copilot for ${optInModel.label}`;
     }

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -6,7 +6,10 @@ import {
   LEVEL_TO_EFFORT,
 } from '@agent/modelHandlers/support/reasoningEffort';
 import { FREE_TIER, MAX_TIER } from '@auth/config';
-import { prefersCopilotRoute } from '@model/copilotRouting';
+import {
+  preferredCopilotRouteModels,
+  prefersCopilotRoute,
+} from '@model/copilotRouting';
 import { resolveModelSource } from '@model/openRouterRouting';
 import {
   discoveredCopilotRoutes,
@@ -106,12 +109,25 @@ export class SettingsModelSelectionController {
       this.deps.getCopilotRoutes ?? discoveredCopilotRoutes
     )();
     const configs = new Map(staticModelConfigEntries());
-    return [...routes].map(([name, route]) => ({
+    const infos: CopilotRouteInfo[] = [...routes].map(([name, route]) => ({
       name,
       label: configs.get(name)?.label ?? name,
       access: route.access,
       preferred: prefersCopilotRoute(name),
     }));
+    // A preferred model the editor no longer discovers still needs its undo
+    // surface (#9659): the routing layer treats the persisted preference as
+    // a hard route choice, so without a row the user could never clear it.
+    for (const name of preferredCopilotRouteModels()) {
+      if (routes.has(name)) continue;
+      infos.push({
+        name,
+        label: configs.get(name)?.label ?? name,
+        access: 'unavailable',
+        preferred: true,
+      });
+    }
+    return infos;
   }
 
   async setModelEnabled(input: {

--- a/src/model/copilotRouting.ts
+++ b/src/model/copilotRouting.ts
@@ -57,6 +57,15 @@ export function prefersCopilotRoute(model: string): boolean {
   return copilotRouteModels().includes(model);
 }
 
+/**
+ * The persisted per-model preferences, unfiltered by launch suppression.
+ * Settings UI needs the raw list so a preferred model the editor no longer
+ * discovers still surfaces its undo (#9659).
+ */
+export function preferredCopilotRouteModels(): readonly string[] {
+  return copilotRouteModels();
+}
+
 /** Persist (or clear) the Copilot route preference for one base model. */
 export async function setCopilotRoutePreference(
   model: string,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -308,6 +308,7 @@ export const SETTINGS_VIEW_CMD = {
   SET_MODEL_REASONING_LEVEL: 'setModelReasoningLevel',
   SET_PREFER_SHORT_MODEL_NAMES: 'setPreferShortModelNames',
   REQUEST_MODEL_ACCESS: 'requestModelAccess',
+  CLEAR_COPILOT_ROUTE: 'clearCopilotRoute',
   // Agent selection commands
   OPEN_AGENT_YAML: 'openAgentYaml',
   SET_AGENT_ENABLED: 'setAgentEnabled',

--- a/src/shared/schemas/settingsView/inbound.ts
+++ b/src/shared/schemas/settingsView/inbound.ts
@@ -125,6 +125,11 @@ const RequestModelAccessMessageSchema = z.object({
   modelName: z.string().min(1),
 });
 
+const ClearCopilotRouteMessageSchema = z.object({
+  command: z.literal(CMD.CLEAR_COPILOT_ROUTE),
+  modelName: z.string().min(1),
+});
+
 // Agent selection inbound messages
 const OpenAgentYamlMessageSchema = z.object({
   command: z.literal(CMD.OPEN_AGENT_YAML),
@@ -364,6 +369,7 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     SetModelReasoningLevelMessageSchema,
     SetPreferShortModelNamesMessageSchema,
     RequestModelAccessMessageSchema,
+    ClearCopilotRouteMessageSchema,
     // Agent selection messages
     OpenAgentYamlMessageSchema,
     SetAgentEnabledMessageSchema,

--- a/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
@@ -11,6 +11,7 @@ import { buildBasicModelOptionsData } from '@model/modelOptionsBasic';
 import type { CopilotModelRoute } from '@model/runtimeModelRegistry';
 import type { ModelOptionData } from '@shared/schemas';
 import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
+import { installPlatform } from '@test/support/setupPlatform';
 
 const NO_COPILOT_ROUTES = async (): Promise<
   ReadonlyMap<string, CopilotModelRoute>
@@ -212,5 +213,26 @@ describe('SettingsModelSelectionController', () => {
       ),
     ).toEqual([]);
     expect(models.filter((model) => model.name === 'sonnet46')).toHaveLength(1);
+  });
+
+  it('surfaces a persisted preference whose route is no longer discovered', async () => {
+    // #9659: the routing layer treats a persisted preference as a hard route
+    // choice, so the settings UI must expose its undo even when VS Code has
+    // stopped offering the model through Copilot.
+    await installPlatform({
+      globalState: { 'texra.copilotRouteModels': ['sonnet46'] },
+    });
+    const controller = createController();
+
+    const { copilotModels } = await controller.buildSelectionData();
+
+    expect(copilotModels).toEqual([
+      {
+        name: 'sonnet46',
+        label: MODEL_CONFIGS.sonnet46.label,
+        access: 'unavailable',
+        preferred: true,
+      },
+    ]);
   });
 });

--- a/src/test-kernel/settings/CopilotModelAccess.vitest.ts
+++ b/src/test-kernel/settings/CopilotModelAccess.vitest.ts
@@ -103,4 +103,22 @@ describe('Copilot model access settings', () => {
       [SETTINGS_VIEW_COMMANDS.CLEAR_COPILOT_ROUTE, { modelName: 'gpt55' }],
     ]);
   });
+
+  it('offers the undo, not consent, when a preferred route loses access', async () => {
+    const tab = await renderModelsTab([{ ...consentRoute, preferred: true }]);
+
+    const section = tab.shadowRoot?.querySelector('#copilot-access');
+    expect(section?.textContent).toContain(
+      'Claude Sonnet 4.6 is set to use Copilot but is waiting for consent.',
+    );
+    const button = section?.querySelector<HTMLElement>('wa-button');
+    expect(button?.textContent).toContain(
+      'Stop using Copilot for Claude Sonnet 4.6',
+    );
+
+    button?.click();
+    expect(mocks.postMessage.mock.calls).toEqual([
+      [SETTINGS_VIEW_COMMANDS.CLEAR_COPILOT_ROUTE, { modelName: 'sonnet46' }],
+    ]);
+  });
 });

--- a/src/test-kernel/settings/CopilotModelAccess.vitest.ts
+++ b/src/test-kernel/settings/CopilotModelAccess.vitest.ts
@@ -90,11 +90,17 @@ describe('Copilot model access settings', () => {
     ]);
   });
 
-  it('hides the opt-in once the route is preferred', async () => {
+  it('offers an undo once the route is preferred', async () => {
     const tab = await renderModelsTab([{ ...allowedRoute, preferred: true }]);
 
     const section = tab.shadowRoot?.querySelector('#copilot-access');
-    expect(section?.textContent).toContain('1 Copilot model is ready');
-    expect(section?.querySelector('wa-button')).toBeNull();
+    expect(section?.textContent).toContain('GPT-5.5 runs through Copilot.');
+    const button = section?.querySelector<HTMLElement>('wa-button');
+    expect(button?.textContent).toContain('Stop using Copilot for GPT-5.5');
+
+    button?.click();
+    expect(mocks.postMessage.mock.calls).toEqual([
+      [SETTINGS_VIEW_COMMANDS.CLEAR_COPILOT_ROUTE, { modelName: 'gpt55' }],
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

#9652 added the opt-in side of Copilot routing (Grant access / Use Copilot → `setCopilotRoutePreference`), but once set there was no UI to clear the preference — a user who routed a model through Copilot could not switch back to direct-provider routing from Settings. This PR adds the undo: the Models tab Copilot section now surfaces the active route ("X runs through Copilot.") with a **Stop using Copilot for X** action that posts the new `clearCopilotRoute` settings command, clearing the per-model `texra.copilotRouteModels` preference and refreshing model selection.

Closes #9659.

## Issue acceptance gates

- [x] UI control in the Models tab Copilot section (`ModelsTab.renderCopilotSection`) clears the per-model `COPILOT_ROUTE_MODELS` preference.
- [x] A preferred, allowed route offers the undo (single action slot: consent → undo → opt-in, in priority order); status line names the active route.
- [x] Clearing returns the canonical model to direct-provider routing (`setCopilotRoutePreference(name, false)` + `invalidateModelOptionsCache` + resend model-selection data, mirroring the grant path).

## Single source of truth

The preference remains owned by `copilotRouting.ts` (`setCopilotRoutePreference` is the same writer the grant path uses); the new `CLEAR_COPILOT_ROUTE` command is defined once in `src/shared/ipc.ts` with its inbound schema in `settingsView/inbound.ts`.

## Duplication and abstraction budget

The clear handler mirrors the grant path's refresh tail rather than extracting a shared helper for two call sites; the message schema is a two-field twin of `RequestModelAccessMessageSchema` by design (distinct commands).

## Net elements (R6)

- Files: 6 changed (+50/−12)
- Exported symbols: +1 command constant, +1 schema (no new runtime exports)
- Classes/interfaces/enums: 0 added/removed

## Consumer counts (R8)

- `CLEAR_COPILOT_ROUTE`: 1 producer (ModelsTab), 2 handler registrations (extension: live; desktop: `unsupported('Copilot models require VS Code.')`, matching `requestModelAccess`).

## Host impact

Extension: new undo action in Settings → Models → Copilot section.
Desktop: command registered as unsupported (Copilot requires VS Code), consistent with the grant command.
CLI: none.

## Scheduled refactoring

None.

## Validation

- `npx vitest run src/test-kernel/settings/ src/test-kernel/controllers/ src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts` — 470/470 pass (new tests: undo action renders for a preferred route and posts `clearCopilotRoute`; opt-in/grant paths unchanged)
- `npm run typecheck:workspace`, `typecheck:extension`, `typecheck:desktop`, `npm run lint`, `npm run format` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings-only preference writes using the existing `setCopilotRoutePreference` path; no auth or request-routing logic changes beyond surfacing undo in the UI.
> 
> **Overview**
> Adds a way to **undo** per-model GitHub Copilot routing from Settings → Models after opt-in (#9659).
> 
> The Copilot section now treats a **preferred** route as the primary state: status text names the active route (including consent/unavailable), and the single action slot prefers **Stop using Copilot for X**, which posts the new `clearCopilotRoute` IPC command. That path calls `setCopilotRoutePreference(model, false)`, invalidates model options, and refreshes the picker—mirroring the grant flow. Action priority is **undo → consent → opt-in**; consent is skipped when the stuck route is already preferred so users can always clear the preference.
> 
> `preferredCopilotRouteModels()` exposes persisted preferences without launch suppression so the controller can still list an **undiscovered** preferred model as `unavailable` with undo. Desktop registers `clearCopilotRoute` as unsupported like `requestModelAccess`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f913113ee84a092f25b0d034b68d4f3c1a6daab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->