### PR TITLE
fix(model): complete explicit Copilot route handling

### DIFF
--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -8,6 +8,7 @@ import { ModelHandlerCompatibilityKeySchema } from '@agent/runtime/modelHandlerC
 import { runAgent } from '@agent/runtime/runAgent';
 import { openFinalOutputIfAvailable } from '@frontend/agents/finalOutputOpener';
 import * as logger from '@logger/logUtils';
+import type { CopilotRouteOverride } from '@model/copilotRouting';
 import type { ExecutionId } from '@shared/schemas';
 
 const CHANNEL = 'ExecuteCommand';
@@ -17,6 +18,7 @@ interface WrappedExecuteInput {
   executionId?: ExecutionId;
   preferHelperModel?: boolean;
   modelHandlerCompatibilityKey?: unknown;
+  copilotRouteOverride?: unknown;
   onRun?: () => void;
 }
 
@@ -40,6 +42,10 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
       ModelHandlerCompatibilityKeySchema.nullish().parse(
         wrapped?.modelHandlerCompatibilityKey,
       );
+    const copilotRouteOverride = z
+      .literal('direct')
+      .optional()
+      .parse(wrapped?.copilotRouteOverride) as CopilotRouteOverride | undefined;
 
     await runAgent(
       { config, executionId: wrapped?.executionId },
@@ -50,6 +56,7 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
         // keeps the user's selected model.
         preferHelperModel: wrapped?.preferHelperModel === true,
         modelHandlerCompatibilityKey,
+        copilotRouteOverride,
         onRun: wrapped?.onRun,
       },
     );

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -752,13 +752,14 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           chatGptSubscriptionEligible: fallback.chatGptSubscriptionEligible,
           viaRelay: data.viaRelay,
         },
-        async () => {
+        async (copilotRouteOverride) => {
           if (!this.interactions.isRetryPending(data.stream, data.requestId)) {
             return false;
           }
-          return this.executeValidatedUntilStarted({
-            config: { ...config, model: fallback.model },
-          });
+          return this.executeValidatedUntilStarted(
+            { config: { ...config, model: fallback.model } },
+            { copilotRouteOverride },
+          );
         },
       );
     if (!started) return;
@@ -846,6 +847,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   /** Validate a request and acknowledge it once the runtime owns a run handle. */
   private async executeValidatedUntilStarted(
     request: ExecutionRequest,
+    options: { copilotRouteOverride?: 'direct' } = {},
   ): Promise<boolean> {
     const validation = validateExecutionRequest(request);
     if (!validation.valid) {
@@ -859,6 +861,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       void this.runViewCommand<boolean>('texra.execute', [
         {
           ...validation.request,
+          ...options,
           onRun: () => resolve(true),
         },
       ]).then(

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -51,6 +51,18 @@ export class ModelsTab extends LitElement {
 
       /* max-width and centering provided by .tab-content-container */
 
+      .copilot-route-controls {
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }
+
+      @container settings (max-width: 520px) {
+        .copilot-route-controls {
+          align-self: stretch;
+          justify-content: flex-start;
+        }
+      }
+
       .keyless-source__limit {
         display: flex;
         align-items: flex-start;
@@ -208,32 +220,19 @@ export class ModelsTab extends LitElement {
     const readyCount = models.filter(
       (model) => model.access === 'allowed',
     ).length;
-    // A chosen route needs an explicit undo (#9659): clearing the
-    // preference returns the canonical model to direct-provider routing.
-    // The undo wins the single action slot even when the route is stuck
-    // (consent-required/unavailable) — it is the only way out of that state.
-    const preferredModel = models.find((model) => model.preferred);
-    const consentModel = models.find(
+    const consentCount = models.filter(
       (model) => model.access === 'consent-required' && !model.preferred,
-    );
-    // An already-authorized route still needs an explicit opt-in: access
-    // alone never routes a canonical model through Copilot (#9635).
-    const optInModel = models.find(
-      (model) => model.access === 'allowed' && !model.preferred,
-    );
+    ).length;
+    const blockedPreferredCount = models.filter(
+      (model) => model.preferred && model.access !== 'allowed',
+    ).length;
     const unavailableCount = models.filter(
       (model) => model.access === 'unavailable',
     ).length;
     let status: string;
-    if (preferredModel) {
-      if (preferredModel.access === 'allowed') {
-        status = `${preferredModel.label} runs through Copilot.`;
-      } else if (preferredModel.access === 'consent-required') {
-        status = `${preferredModel.label} is set to use Copilot but is waiting for consent.`;
-      } else {
-        status = `${preferredModel.label} is set to use Copilot but is currently unavailable.`;
-      }
-    } else if (consentModel) {
+    if (blockedPreferredCount > 0) {
+      status = `${blockedPreferredCount} selected ${pluralize(blockedPreferredCount, 'Copilot route needs', 'Copilot routes need')} attention.`;
+    } else if (consentCount > 0) {
       status = 'VS Code is ready to ask for your consent.';
     } else if (readyCount > 0) {
       status = `${readyCount} ${pluralize(readyCount, 'Copilot model is', 'Copilot models are')} ready.`;
@@ -241,29 +240,83 @@ export class ModelsTab extends LitElement {
       status = `${unavailableCount} ${pluralize(unavailableCount, 'Copilot model is', 'Copilot models are')} unavailable.`;
     }
 
-    // The single route action: undo for a chosen route first, then consent,
-    // then opt-in for an already-authorized route not chosen yet.
-    const actionModel = preferredModel ?? consentModel ?? optInModel;
-    let actionText = '';
-    let actionCommand: string = SETTINGS_VIEW_COMMANDS.REQUEST_MODEL_ACCESS;
-    if (preferredModel) {
-      actionText = `Stop using Copilot for ${preferredModel.label}`;
-      actionCommand = SETTINGS_VIEW_COMMANDS.CLEAR_COPILOT_ROUTE;
-    } else if (consentModel) {
-      actionText = 'Grant access';
-    } else if (optInModel) {
-      actionText = `Use Copilot for ${optInModel.label}`;
-    }
-    const action = actionModel
-      ? renderLabeledActionButton({
-          icon: 'shield',
-          text: actionText,
-          kind: 'primary',
-          appearance: consentModel ? 'filled' : 'outlined',
+    // Each route gets its own responsive settings row. Short action labels
+    // keep controls usable in narrow panels while the adjacent text names the
+    // model and route state.
+    const actionRows = models.flatMap((model) => {
+      let routeStatus: string;
+      let action: TemplateResult;
+      if (model.preferred) {
+        if (model.access === 'allowed') {
+          routeStatus = 'Copilot route selected.';
+        } else if (model.access === 'consent-required') {
+          routeStatus =
+            'Selected Copilot route is waiting for VS Code consent.';
+        } else {
+          routeStatus = 'Selected Copilot route is currently unavailable.';
+        }
+        const stopAction = renderLabeledActionButton({
+          icon: 'xmark',
+          text: 'Stop using Copilot',
+          kind: 'secondary',
+          appearance: 'outlined',
           onClick: () =>
-            postMessage(actionCommand, { modelName: actionModel.name }),
-        })
-      : nothing;
+            postMessage(SETTINGS_VIEW_COMMANDS.CLEAR_COPILOT_ROUTE, {
+              modelName: model.name,
+            }),
+        });
+        action =
+          model.access === 'consent-required'
+            ? html`${renderLabeledActionButton({
+                icon: 'shield',
+                text: 'Grant access',
+                kind: 'primary',
+                appearance: 'filled',
+                onClick: () =>
+                  postMessage(SETTINGS_VIEW_COMMANDS.REQUEST_MODEL_ACCESS, {
+                    modelName: model.name,
+                  }),
+              })}${stopAction}`
+            : stopAction;
+      } else if (model.access === 'consent-required') {
+        routeStatus = 'VS Code consent is required.';
+        action = renderLabeledActionButton({
+          icon: 'shield',
+          text: 'Grant access',
+          kind: 'primary',
+          appearance: 'filled',
+          onClick: () =>
+            postMessage(SETTINGS_VIEW_COMMANDS.REQUEST_MODEL_ACCESS, {
+              modelName: model.name,
+            }),
+        });
+      } else if (model.access === 'allowed') {
+        routeStatus = 'Ready to use through Copilot.';
+        action = renderLabeledActionButton({
+          icon: 'shield',
+          text: 'Use Copilot',
+          kind: 'secondary',
+          appearance: 'outlined',
+          onClick: () =>
+            postMessage(SETTINGS_VIEW_COMMANDS.REQUEST_MODEL_ACCESS, {
+              modelName: model.name,
+            }),
+        });
+      } else {
+        return [];
+      }
+      return [
+        html`<div class="settings-row copilot-route-action">
+          <div class="settings-row-text">
+            <span class="settings-row-label">${model.label}</span>
+            <span class="settings-row-help">${routeStatus}</span>
+          </div>
+          <div class="settings-row-control copilot-route-controls">
+            ${action}
+          </div>
+        </div>`,
+      ];
+    });
 
     return html`
       <section id="copilot-access">
@@ -284,11 +337,11 @@ export class ModelsTab extends LitElement {
                 Access is managed by VS Code and GitHub Copilot.
               </span>
             </div>
-            <div class="settings-row-control">${action}</div>
           </div>
+          ${actionRows}
         </div>
         ${
-          unavailableCount > 0 && !consentModel
+          unavailableCount > 0 && consentCount === 0
             ? html`<p class="keyless-source__limit">
                 ${waIcon('triangle-exclamation')}
                 <span>

--- a/packages/extension/src/webview/MainViewProvider.ts
+++ b/packages/extension/src/webview/MainViewProvider.ts
@@ -30,7 +30,6 @@ import { onTexraAuthSessionsChanged } from '@frontend/events/onTexraAuthSessions
 import { loadMainViewModelOptions } from '@frontend/agents/optionsLoader';
 import { loadMainViewTeamOptions } from '@frontend/agents/teamOptionsLoader';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import { MainViewPersistedStateSchema } from '@shared/schemas';
 import { agentKeyOf } from '@shared/schemas/agent';
 import {
   readOnboardingFlags,
@@ -42,6 +41,7 @@ import { DEBOUNCE_OPTIONS_MS } from '@utils/config/constants';
 
 // Local file imports
 import { MainViewMessageHandler } from './MainViewMessageHandler';
+import { VscodeMainViewPersistedStateSchema } from './vscodeMainViewPersistedState';
 import type { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 
 export class MainViewProvider
@@ -324,7 +324,9 @@ export class MainViewProvider
       pendingData;
       pendingData = consumePendingState()
     ) {
-      const parsed = MainViewPersistedStateSchema.safeParse(pendingData.state);
+      const parsed = VscodeMainViewPersistedStateSchema.safeParse(
+        pendingData.state,
+      );
       if (!parsed.success) {
         console.warn('Invalid pending state restore payload', parsed.error);
         continue;

--- a/packages/extension/src/webview/frontend/persistence.ts
+++ b/packages/extension/src/webview/frontend/persistence.ts
@@ -27,10 +27,7 @@ import { type ZodError } from 'zod';
 
 // Local imports - shared state and schemas
 import { hostBridge } from '@shared/hostBridge';
-import {
-  MainViewPersistedStateSchema,
-  type MainViewPersistedState,
-} from '@shared/schemas';
+import type { MainViewPersistedState } from '@shared/schemas';
 import { Signal } from '@shared/signals';
 import {
   createWebviewStorage,
@@ -40,6 +37,7 @@ import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
 import { createFlushableDebounce } from '@utils/core';
 
 // Local imports - main view
+import { VscodeMainViewPersistedStateSchema } from '../vscodeMainViewPersistedState';
 import { SESSION_TYPES } from './constants';
 import { SESSION_DEFAULTS } from './sessionDefaults';
 import {
@@ -70,7 +68,7 @@ const webviewStorage = createWebviewStorage(hostBridge);
 const stateManager = new PersistedState(
   webviewStorage,
   'mainViewState',
-  MainViewPersistedStateSchema,
+  VscodeMainViewPersistedStateSchema,
 );
 
 /**
@@ -186,8 +184,8 @@ const watcher = new Signal.subtle.Watcher(() => {
 });
 
 export function restorePersistedState(): void {
-  // State is parsed through MainViewPersistedStateSchema which provides all defaults.
-  // No manual fallbacks needed - schema handles missing/invalid values.
+  // The extension-local schema provides defaults and reads the retired VS Code
+  // Copilot picker identity. No manual fallbacks are needed.
   const state = stateManager.getState();
   applyState(state);
   // Arm the writer on what the mount produced, not on what storage held: the
@@ -227,7 +225,7 @@ export function handleRestoreState(
     return false;
   }
 
-  const parsed = MainViewPersistedStateSchema.safeParse(message.state);
+  const parsed = VscodeMainViewPersistedStateSchema.safeParse(message.state);
   if (!parsed.success) {
     onSchemaError('[MainApp] State restore validation failed.', parsed.error);
     return false;

--- a/packages/extension/src/webview/vscodeMainViewPersistedState.ts
+++ b/packages/extension/src/webview/vscodeMainViewPersistedState.ts
@@ -1,5 +1,7 @@
+// Third-party imports
 import { z } from 'zod';
 
+// Local imports - shared schemas
 import {
   MainViewPersistedStateSchema,
   type MainViewPersistedState,

--- a/packages/extension/src/webview/vscodeMainViewPersistedState.ts
+++ b/packages/extension/src/webview/vscodeMainViewPersistedState.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+import {
+  MainViewPersistedStateSchema,
+  type MainViewPersistedState,
+} from '@shared/schemas';
+
+/**
+ * VS Code compatibility reader for main-view snapshots written with synthetic
+ * `copilot:<baseModel>` picker ids before #9635. Introduced 2026-08-03;
+ * retire after 2026-11-03 with the other Copilot identity readers.
+ *
+ * This stays extension-local because Electron never wrote that VS Code picker
+ * format. The shared schema therefore describes only the current state shape.
+ */
+export const VscodeMainViewPersistedStateSchema: z.ZodType<MainViewPersistedState> =
+  z.preprocess((input) => {
+    if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+      return input;
+    }
+    const model = 'model' in input ? input.model : undefined;
+    if (typeof model !== 'string' || !model.startsWith('copilot:'))
+      return input;
+    return { ...input, model: model.slice('copilot:'.length) };
+  }, MainViewPersistedStateSchema);

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -38,6 +38,7 @@ import { buildUserVars } from '@agent/utils/userVars';
 import { UsageMonitor } from '@agent/utils/UsageMonitor';
 import { AgentError, getSdkErrorMessage } from '@common/errors';
 import { normalizeRunId } from '@common/constants/runIds';
+import type { CopilotRouteOverride } from '@model/copilotRouting';
 import { resolveRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import {
   STREAM_PHASE,
@@ -104,6 +105,8 @@ export interface AgentLaunchInput {
   session?: SessionHandle;
   /** Resume using this persisted provider-message format instead of today's default route. */
   modelHandlerCompatibilityKey?: ModelHandlerCompatibilityKey | null;
+  /** Deliberate one-run bypass used only by a Copilot direct-key fallback. */
+  copilotRouteOverride?: CopilotRouteOverride;
 }
 
 const STATUS_MESSAGES: Record<string, string> = {
@@ -305,6 +308,7 @@ async function assembleAgentLaunchContext(
           modelConfig,
           setting.agentCategory,
           session.responseTextProcessing,
+          input.copilotRouteOverride,
         ),
   );
   const modelCell = new ModelCell(modelHandler, config.model);

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -19,6 +19,7 @@ import { apiKeyExists } from '@model/apiProviders';
 import {
   copilotRouteUnavailableReason,
   prefersCopilotRoute,
+  type CopilotRouteOverride,
 } from '@model/copilotRouting';
 import { includedModelAccess } from '@model/includedModelAccess';
 import { resolveCodexSubscriptionCapabilitiesForAgentCategory } from '@model/providerCapabilities';
@@ -35,7 +36,6 @@ import {
   type ResolvedModelConfig,
 } from '@model/openRouterRouting';
 import { copilotRouteForModel } from '@model/runtimeModelRegistry';
-import { zeroCostAccessOverrides } from '@model/subscriptionAccessOverrides';
 import {
   LANGUAGE_MODEL_PORT_ERROR_CODE,
   LanguageModelPortError,
@@ -265,6 +265,7 @@ export function modelHandlerCompatibilityKey(
   originalConfig: ModelConfig,
   useOpenRouter = getUseOpenRouter(),
   preferShortModelNames = getPreferShortModelNames(),
+  copilotRouteOverride?: CopilotRouteOverride,
 ): ModelHandlerCompatibilityKey | undefined {
   if (shouldUseInternalValidationModelHandler()) {
     return 'ModelHandlerValidation';
@@ -276,7 +277,10 @@ export function modelHandlerCompatibilityKey(
   // OpenRouter preference below. A preference is a hard route choice: when
   // the editor cannot serve it right now, report the route state instead of
   // silently consuming a provider key or subscription (#9635).
-  if (prefersCopilotRoute(originalConfig.name)) {
+  if (
+    copilotRouteOverride !== 'direct' &&
+    prefersCopilotRoute(originalConfig.name)
+  ) {
     const unavailableReason = copilotRouteUnavailableReason(
       originalConfig.name,
     );
@@ -421,6 +425,7 @@ export async function createModelHandler(
   originalConfig: ModelConfig,
   agentCategory?: AgentCategory,
   responseTextProcessing?: ResponseTextProcessing,
+  copilotRouteOverride?: CopilotRouteOverride,
 ): Promise<ModelHandler> {
   const config = withShortModelName(originalConfig);
   const useOpenRouter = getUseOpenRouter();
@@ -431,6 +436,7 @@ export async function createModelHandler(
     // pass false so the key predicate routes on the same resolved config
     // instead of re-resolving it.
     false,
+    copilotRouteOverride,
   );
   if (compatibilityKey === 'ModelHandlerOpenRouterNative') {
     assertGoogleInteractionsRoutable(config);
@@ -640,9 +646,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
       // route is zero-cost per call — apply both to the config the handler
       // validates and accounts against.
       const route = copilotRouteForModel(config.name);
-      const routedConfig = route
-        ? { ...config, ...zeroCostAccessOverrides(route.maxInputTokens) }
-        : config;
+      const routedConfig = route?.effectiveConfig ?? config;
       const { ModelHandlerVscodeLm } =
         await import('@agent/modelHandlers/vscodelm/modelHandlerVscodeLm');
       return finalizeModelHandler(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -27,6 +27,7 @@ import {
   releaseOwnedExecutionLeaseAfterFailure,
 } from '@agent/storage/executionLease';
 import { AgentError } from '@common/errors';
+import type { CopilotRouteOverride } from '@model/copilotRouting';
 import {
   type RequestEnsureProgressViewPayload,
   type StreamTabId,
@@ -369,6 +370,8 @@ export interface ExecuteAgentOptions extends SubagentRunOptions {
   allowWaitingResult?: boolean;
   /** Resume using this persisted provider-message format instead of today's default route. */
   modelHandlerCompatibilityKey?: ModelHandlerCompatibilityKey | null;
+  /** Deliberate one-run bypass used only by a Copilot direct-key fallback. */
+  copilotRouteOverride?: CopilotRouteOverride;
 }
 
 export function executeAgent(
@@ -405,6 +408,7 @@ export async function executeAgent(
         options.suppressErrorNotification ?? options.isSubagent,
       session: options.session,
       modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
+      copilotRouteOverride: options.copilotRouteOverride,
     });
     const runContextOptions = {
       approvalPromptsUnavailable: options.approvalPromptsUnavailable,

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -35,6 +35,7 @@ export interface RunAgentOptions extends Pick<
   | 'tools'
   | 'session'
   | 'modelHandlerCompatibilityKey'
+  | 'copilotRouteOverride'
   | 'onRun'
   | 'onStreamResolved'
   | 'onIdle'

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -1,6 +1,6 @@
 // Local imports
 import type { ApiProvider } from '@model/apiProviders';
-import { withCopilotRouteSuppressed } from '@model/copilotRouting';
+import type { CopilotRouteOverride } from '@model/copilotRouting';
 import type { ExhaustionReason, StreamTabId } from '@shared/schemas';
 
 export interface ProgressApiKeyRetryRequest {
@@ -159,22 +159,16 @@ export class ProgressApiKeyRetryController {
   /** Apply Copilot fallback routing only for the duration of a launch attempt. */
   async runCopilotFallbackWithRouting(
     request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
-    start: () => Promise<boolean>,
+    start: (copilotRouteOverride: CopilotRouteOverride) => Promise<boolean>,
   ): Promise<boolean> {
     const before = this.routingSnapshot();
     const prepared = await this.applyOwnApiKeyRouting(request);
-    // The user chose "use own API key" for this retry: suppress the Copilot
-    // route preference for the launch so handler construction cannot route
-    // the same canonical model straight back through Copilot (#9635). The
-    // override is process-local and launch-scoped — the persisted
-    // preference is never written, so a crash mid-launch cannot drop it.
-    const fallbackModel = request.model;
-    const startWithSuppression = fallbackModel
-      ? () => withCopilotRouteSuppressed(fallbackModel, start)
-      : start;
+    // The user chose "use own API key" for this retry. The direct-route
+    // override travels only with the replacement launch; the standing
+    // preference remains visible to concurrent and future runs.
     let started = false;
     try {
-      started = await startWithSuppression();
+      started = await start('direct');
       return started;
     } finally {
       if (!started) await this.restoreOwnApiKeyRouting(before, prepared);

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -6,10 +6,7 @@ import {
   LEVEL_TO_EFFORT,
 } from '@agent/modelHandlers/support/reasoningEffort';
 import { FREE_TIER, MAX_TIER } from '@auth/config';
-import {
-  preferredCopilotRouteModels,
-  prefersCopilotRoute,
-} from '@model/copilotRouting';
+import { preferredCopilotRouteModels } from '@model/copilotRouting';
 import { resolveModelSource } from '@model/openRouterRouting';
 import {
   discoveredCopilotRoutes,
@@ -50,6 +47,7 @@ export interface SettingsModelSelectionControllerDeps {
   useIncludedAccess?: () => boolean;
   getUserTier?: () => string | undefined;
   getCopilotRoutes?: () => Promise<ReadonlyMap<string, CopilotModelRoute>>;
+  getPreferredCopilotRouteModels?: () => readonly string[];
   /**
    * Resolve availability-decorated options for the given models. Injected as a
    * port so the controller stays unit-testable; production wiring uses the
@@ -90,44 +88,41 @@ export class SettingsModelSelectionController {
 
   async buildSelectionData(): Promise<SettingsModelSelectionData> {
     const visibleModels = this.getVisibleModels();
+    const routes = await (
+      this.deps.getCopilotRoutes ?? discoveredCopilotRoutes
+    )();
+    const preferredModels = new Set(
+      (
+        this.deps.getPreferredCopilotRouteModels ?? preferredCopilotRouteModels
+      )(),
+    );
     return {
-      models: await this.buildSelectionItems(),
+      models: await this.buildSelectionItems(routes, preferredModels),
       helperModel: this.getEffectiveHelperModel(visibleModels),
       preferShortModelNames:
         this.deps.state.getPreferShortModelNames() ?? false,
-      copilotModels: await this.buildCopilotRouteInfos(),
+      copilotModels: this.buildCopilotRouteInfos(routes, preferredModels),
     };
   }
 
   /**
-   * Route status for the Models tab Copilot section: every discovered Copilot
-   * route with its editor-reported access state, labelled by the base model it
-   * serves. Routes are not picker rows; they describe transports.
+   * Route status for the Models tab Copilot section: every discovered route
+   * plus every persisted preference, labelled by the base model it serves.
+   * A preferred route absent from discovery remains visible as unavailable so
+   * the user can clear it. Routes are transports, never picker rows.
    */
-  private async buildCopilotRouteInfos(): Promise<CopilotRouteInfo[]> {
-    const routes = await (
-      this.deps.getCopilotRoutes ?? discoveredCopilotRoutes
-    )();
+  private buildCopilotRouteInfos(
+    routes: ReadonlyMap<string, CopilotModelRoute>,
+    preferredModels: ReadonlySet<string>,
+  ): CopilotRouteInfo[] {
     const configs = new Map(staticModelConfigEntries());
-    const infos: CopilotRouteInfo[] = [...routes].map(([name, route]) => ({
+    const names = new Set([...routes.keys(), ...preferredModels]);
+    return [...names].map((name) => ({
       name,
       label: configs.get(name)?.label ?? name,
-      access: route.access,
-      preferred: prefersCopilotRoute(name),
+      access: routes.get(name)?.access ?? 'unavailable',
+      preferred: preferredModels.has(name),
     }));
-    // A preferred model the editor no longer discovers still needs its undo
-    // surface (#9659): the routing layer treats the persisted preference as
-    // a hard route choice, so without a row the user could never clear it.
-    for (const name of preferredCopilotRouteModels()) {
-      if (routes.has(name)) continue;
-      infos.push({
-        name,
-        label: configs.get(name)?.label ?? name,
-        access: 'unavailable',
-        preferred: true,
-      });
-    }
-    return infos;
   }
 
   async setModelEnabled(input: {
@@ -178,7 +173,10 @@ export class SettingsModelSelectionController {
     await this.deps.state.setPreferShortModelNames(enabled);
   }
 
-  private async buildSelectionItems(): Promise<ModelSelectionItem[]> {
+  private async buildSelectionItems(
+    copilotRoutes: ReadonlyMap<string, CopilotModelRoute>,
+    preferredCopilotModels: ReadonlySet<string>,
+  ): Promise<ModelSelectionItem[]> {
     const enabledSet = new Set(this.getVisibleModels());
     const reasoningOverrides =
       this.deps.state.getReasoningLevelOverrides() ?? {};
@@ -224,7 +222,16 @@ export class SettingsModelSelectionController {
         disabled: option.disabled,
       };
 
-      this.addReasoningLevelData(item, config, reasoningOverrides[name]);
+      const copilotRoute = copilotRoutes.get(name);
+      const effectiveConfig =
+        preferredCopilotModels.has(name) && copilotRoute?.access === 'allowed'
+          ? copilotRoute.effectiveConfig
+          : config;
+      this.addReasoningLevelData(
+        item,
+        effectiveConfig,
+        reasoningOverrides[name],
+      );
       items.push(item);
     }
 

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -595,6 +595,10 @@ async function buildModelOptionData(
   const config = effectiveKimiCodeConfig(rawConfig, ctx);
 
   const availability = await resolveModelAvailability(model, config, ctx);
+  const copilotConfig =
+    availability.kind === 'copilot-access'
+      ? copilotRouteForModel(model)?.effectiveConfig
+      : undefined;
   const optionConfig = availability.providerCapabilities
     ? {
         ...config,
@@ -602,7 +606,7 @@ async function buildModelOptionData(
         inputPrice: availability.providerCapabilities.inputPrice,
         outputPrice: availability.providerCapabilities.outputPrice,
       }
-    : config;
+    : (copilotConfig ?? config);
   let routeLabel: string | undefined;
   if (availability.kind === 'copilot-access') {
     // The row's identity stays the base model; the badge names the route.

--- a/src/model/copilotRouting.ts
+++ b/src/model/copilotRouting.ts
@@ -27,7 +27,11 @@ function copilotRouteModels(): readonly string[] {
   );
 }
 
-/** Persisted canonical model ids whose Copilot route the user prefers. */
+/**
+ * Persisted canonical model ids whose Copilot route the user prefers. Settings
+ * needs the raw list so a model the editor no longer discovers still surfaces
+ * its undo (#9659).
+ */
 export function preferredCopilotRouteModels(): readonly string[] {
   return [...copilotRouteModels()];
 }
@@ -35,15 +39,6 @@ export function preferredCopilotRouteModels(): readonly string[] {
 /** Whether the user prefers the Copilot route for this canonical base model. */
 export function prefersCopilotRoute(model: string): boolean {
   return copilotRouteModels().includes(model);
-}
-
-/**
- * The persisted per-model preferences, unfiltered by launch suppression.
- * Settings UI needs the raw list so a preferred model the editor no longer
- * discovers still surfaces its undo (#9659).
- */
-export function preferredCopilotRouteModels(): readonly string[] {
-  return copilotRouteModels();
 }
 
 /** Persist (or clear) the Copilot route preference for one base model. */

--- a/src/model/copilotRouting.ts
+++ b/src/model/copilotRouting.ts
@@ -15,6 +15,9 @@ import { GlobalStateKey } from '@shared/state/stateKeys';
 
 import { copilotRouteForModel } from './runtimeModelRegistry';
 
+/** One-launch override for a deliberate direct-key retry. */
+export type CopilotRouteOverride = 'direct';
+
 function copilotRouteModels(): readonly string[] {
   return (
     platform().globalState.get<readonly string[]>(
@@ -24,36 +27,13 @@ function copilotRouteModels(): readonly string[] {
   );
 }
 
-/**
- * Process-local, launch-scoped routing override (#9635): a direct-key
- * fallback retry must not re-enter Copilot for the same model, but the
- * user's persisted preference must survive a host crash or reload
- * mid-launch — so the override lives in memory only and never writes
- * global state. Mutated exclusively through
- * {@link withCopilotRouteSuppressed}; empty between launches.
- */
-const launchSuppressedModels = new Set<string>();
-
-/**
- * Run `launch` with the Copilot route preference for `model` suppressed.
- * The persisted preference is never touched; a crash mid-launch leaves
- * the user's standing choice intact.
- */
-export async function withCopilotRouteSuppressed<T>(
-  model: string,
-  launch: () => Promise<T>,
-): Promise<T> {
-  launchSuppressedModels.add(model);
-  try {
-    return await launch();
-  } finally {
-    launchSuppressedModels.delete(model);
-  }
+/** Persisted canonical model ids whose Copilot route the user prefers. */
+export function preferredCopilotRouteModels(): readonly string[] {
+  return [...copilotRouteModels()];
 }
 
 /** Whether the user prefers the Copilot route for this canonical base model. */
 export function prefersCopilotRoute(model: string): boolean {
-  if (launchSuppressedModels.has(model)) return false;
   return copilotRouteModels().includes(model);
 }
 

--- a/src/model/runtimeModelRegistry.ts
+++ b/src/model/runtimeModelRegistry.ts
@@ -57,6 +57,8 @@ interface RuntimeModelCatalogue {
   readonly discovered: boolean;
   /** The in-flight discovery, if one is running. */
   readonly pending?: Promise<void>;
+  /** Whether the in-flight discovery explicitly bypasses a fresh cache. */
+  readonly pendingForceDiscovery?: boolean;
 }
 
 let catalogue: RuntimeModelCatalogue = {
@@ -129,26 +131,52 @@ async function discoverCopilotRoutes(): Promise<
   return entries;
 }
 
+export interface RefreshRuntimeModelRegistryOptions {
+  /** Re-query the adapter even when the current catalogue is marked fresh. */
+  forceDiscovery?: boolean;
+}
+
 /** Refresh editor-supplied routes after the native model/access cache changes. */
-export async function refreshRuntimeModelRegistry(): Promise<void> {
+export async function refreshRuntimeModelRegistry(
+  options: RefreshRuntimeModelRegistryOptions = {},
+): Promise<void> {
+  if (options.forceDiscovery) {
+    // Overlapping user actions share one forced probe. A normal probe that
+    // started earlier is superseded because its access snapshot may predate
+    // the action that must authorize persistence.
+    if (catalogue.pendingForceDiscovery && catalogue.pending) {
+      return catalogue.pending;
+    }
+    invalidateRuntimeModelRegistry();
+  }
   if (catalogue.discovered) return;
   if (catalogue.pending) return catalogue.pending;
 
   // Both outcomes below replace the catalogue wholesale, which is also what
   // clears `pending`; a result whose generation has moved on was superseded by
   // an invalidation and is dropped instead of committed.
-  const { generation } = catalogue;
+  const { generation, entries: previousEntries } = catalogue;
   const request = (async () => {
     const entries = await discoverCopilotRoutes();
     if (catalogue.generation !== generation) return;
     catalogue = { generation, entries, discovered: true };
   })();
-  catalogue = { ...catalogue, pending: request };
+  catalogue = {
+    ...catalogue,
+    pending: request,
+    pendingForceDiscovery: options.forceDiscovery === true,
+  };
   try {
     await request;
   } catch (error) {
     if (catalogue.generation === generation) {
-      catalogue = { generation, entries: new Map(), discovered: false };
+      catalogue = {
+        generation,
+        // A user-initiated revalidation must not blank useful last-known
+        // presentation merely because the fresh adapter probe failed.
+        entries: options.forceDiscovery ? previousEntries : new Map(),
+        discovered: false,
+      };
     }
     throw error;
   }
@@ -254,7 +282,7 @@ export type RuntimeModelAccessRequestResult =
 export async function requestRuntimeModelAccess(
   model: string,
 ): Promise<RuntimeModelAccessRequestResult> {
-  await refreshRuntimeModelRegistry();
+  await refreshRuntimeModelRegistry({ forceDiscovery: true });
   const route = catalogue.entries.get(model);
   if (!route) return 'unavailable';
   if (route.access === 'allowed') return 'already-allowed';

--- a/src/model/runtimeModelRegistry.ts
+++ b/src/model/runtimeModelRegistry.ts
@@ -2,6 +2,7 @@ import { MODEL_CONFIGS, type ModelConfig } from 'llm-zoo';
 
 import type { ApiProvider } from '@model/apiProviders';
 import { resolveModelApiKeyProvider } from '@model/openRouterRouting';
+import { zeroCostAccessOverrides } from '@model/subscriptionAccessOverrides';
 import { platform } from '@platform/platform';
 import type {
   LanguageModelAccessState,
@@ -26,12 +27,8 @@ const MODEL_ACCESS_REQUEST_TIMEOUT_MS = 120_000;
 export interface CopilotModelRoute {
   readonly access: LanguageModelAccessState;
   readonly reference: LanguageModelReference;
-  /**
-   * Editor-reported input-token ceiling for the discovered model. Carried so
-   * the routed handler caps context at what the route actually serves, not
-   * the base provider's window.
-   */
-  readonly maxInputTokens: number;
+  /** Base config with the editor's context ceiling and subscription pricing. */
+  readonly effectiveConfig: ModelConfig;
 }
 
 export interface RuntimeModelDirectFallback {
@@ -115,7 +112,18 @@ async function discoverCopilotRoutes(): Promise<
         vendor: info.vendor,
         id: info.id,
       },
-      maxInputTokens: info.maxInputTokens,
+      effectiveConfig: {
+        ...MODEL_CONFIGS[baseModel],
+        ...zeroCostAccessOverrides(info.maxInputTokens),
+        capabilities: {
+          ...MODEL_CONFIGS[baseModel].capabilities,
+          // VS Code's LM route chooses the model's own reasoning behavior and
+          // exposes no per-request effort control.
+          supportsReasoningEffort: false,
+          maxReasoningEffort: undefined,
+          supportedReasoningEfforts: undefined,
+        },
+      },
     });
   }
   return entries;

--- a/src/model/runtimeModelRegistry.ts
+++ b/src/model/runtimeModelRegistry.ts
@@ -17,6 +17,7 @@ import type {
  */
 export const COPILOT_MODEL_PREFIX = 'copilot:';
 const MODEL_ACCESS_REQUEST_TIMEOUT_MS = 120_000;
+const MODEL_ACCESS_DISCOVERY_ATTEMPTS = 2;
 
 /**
  * The Copilot access route for one canonical base model: the exact editor
@@ -56,7 +57,7 @@ interface RuntimeModelCatalogue {
   /** Whether {@link entries} reflect a discovery that is still current. */
   readonly discovered: boolean;
   /** The in-flight discovery, if one is running. */
-  readonly pending?: Promise<void>;
+  readonly pending?: Promise<RefreshRuntimeModelRegistryResult>;
   /** Whether the in-flight discovery explicitly bypasses a fresh cache. */
   readonly pendingForceDiscovery?: boolean;
 }
@@ -136,10 +137,12 @@ export interface RefreshRuntimeModelRegistryOptions {
   forceDiscovery?: boolean;
 }
 
+export type RefreshRuntimeModelRegistryResult = 'current' | 'superseded';
+
 /** Refresh editor-supplied routes after the native model/access cache changes. */
 export async function refreshRuntimeModelRegistry(
   options: RefreshRuntimeModelRegistryOptions = {},
-): Promise<void> {
+): Promise<RefreshRuntimeModelRegistryResult> {
   if (options.forceDiscovery) {
     // Overlapping user actions share one forced probe. A normal probe that
     // started earlier is superseded because its access snapshot may predate
@@ -149,17 +152,18 @@ export async function refreshRuntimeModelRegistry(
     }
     invalidateRuntimeModelRegistry();
   }
-  if (catalogue.discovered) return;
+  if (catalogue.discovered) return 'current';
   if (catalogue.pending) return catalogue.pending;
 
   // Both outcomes below replace the catalogue wholesale, which is also what
   // clears `pending`; a result whose generation has moved on was superseded by
   // an invalidation and is dropped instead of committed.
   const { generation, entries: previousEntries } = catalogue;
-  const request = (async () => {
+  const request = (async (): Promise<RefreshRuntimeModelRegistryResult> => {
     const entries = await discoverCopilotRoutes();
-    if (catalogue.generation !== generation) return;
+    if (catalogue.generation !== generation) return 'superseded';
     catalogue = { generation, entries, discovered: true };
+    return 'current';
   })();
   catalogue = {
     ...catalogue,
@@ -167,7 +171,7 @@ export async function refreshRuntimeModelRegistry(
     pendingForceDiscovery: options.forceDiscovery === true,
   };
   try {
-    await request;
+    return await request;
   } catch (error) {
     if (catalogue.generation === generation) {
       catalogue = {
@@ -285,7 +289,18 @@ export type RuntimeModelAccessRequestResult =
 export async function requestRuntimeModelAccess(
   model: string,
 ): Promise<RuntimeModelAccessRequestResult> {
-  await refreshRuntimeModelRegistry({ forceDiscovery: true });
+  let refreshResult: RefreshRuntimeModelRegistryResult = 'superseded';
+  for (
+    let attempt = 0;
+    attempt < MODEL_ACCESS_DISCOVERY_ATTEMPTS && refreshResult === 'superseded';
+    attempt += 1
+  ) {
+    refreshResult = await refreshRuntimeModelRegistry({ forceDiscovery: true });
+  }
+  // Repeated native invalidations must fail closed rather than authorize from
+  // the retained last-known catalogue.
+  if (refreshResult === 'superseded') return 'unavailable';
+
   const route = catalogue.entries.get(model);
   if (!route) return 'unavailable';
   if (route.access === 'allowed') return 'already-allowed';

--- a/src/model/runtimeModelRegistry.ts
+++ b/src/model/runtimeModelRegistry.ts
@@ -172,9 +172,10 @@ export async function refreshRuntimeModelRegistry(
     if (catalogue.generation === generation) {
       catalogue = {
         generation,
-        // A user-initiated revalidation must not blank useful last-known
-        // presentation merely because the fresh adapter probe failed.
-        entries: options.forceDiscovery ? previousEntries : new Map(),
+        // Discovery failure marks last-known presentation stale but does not
+        // blank it. Authorization callers still receive the thrown error and
+        // therefore cannot act on these retained entries.
+        entries: previousEntries,
         discovered: false,
       };
     }
@@ -240,7 +241,9 @@ export function copilotRouteForModel(
  * Refresh and return the discovered Copilot routes keyed by canonical base
  * model id. Runtime discovery is an optional host capability: the host
  * adapter logs port-level discovery failures (see `createLanguageModelPort`),
- * and consumers receive an empty catalogue instead of stale entries.
+ * and presentation consumers retain the last-known catalogue while it is
+ * stale. Authorization never uses this fallback: access requests force a new
+ * probe and propagate its failure.
  */
 export async function discoveredCopilotRoutes(): Promise<
   ReadonlyMap<string, CopilotModelRoute>
@@ -248,7 +251,7 @@ export async function discoveredCopilotRoutes(): Promise<
   try {
     await refreshRuntimeModelRegistry();
   } catch {
-    return new Map();
+    return catalogue.entries;
   }
   return catalogue.entries;
 }

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -166,19 +166,7 @@ const MainViewPersistedStateBaseSchema = UIFileFieldsSchema.merge(
   openedFiles: z.array(z.string()).nullish(),
 });
 
-/**
- * Compatibility reader for main-view snapshots written with synthetic
- * `copilot:<baseModel>` picker ids before #9635. Introduced 2026-08-03;
- * retire after 2026-11-03 with the other Copilot identity readers.
- */
-export const MainViewPersistedStateSchema = z.preprocess((input) => {
-  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
-    return input;
-  }
-  const model = 'model' in input ? input.model : undefined;
-  if (typeof model !== 'string' || !model.startsWith('copilot:')) return input;
-  return { ...input, model: model.slice('copilot:'.length) };
-}, MainViewPersistedStateBaseSchema);
+export const MainViewPersistedStateSchema = MainViewPersistedStateBaseSchema;
 export type MainViewPersistedState = z.infer<
   typeof MainViewPersistedStateSchema
 >;

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -166,7 +166,19 @@ const MainViewPersistedStateBaseSchema = UIFileFieldsSchema.merge(
   openedFiles: z.array(z.string()).nullish(),
 });
 
-export const MainViewPersistedStateSchema = MainViewPersistedStateBaseSchema;
+/**
+ * Compatibility reader for main-view snapshots written with synthetic
+ * `copilot:<baseModel>` picker ids before #9635. Introduced 2026-08-03;
+ * retire after 2026-11-03 with the other Copilot identity readers.
+ */
+export const MainViewPersistedStateSchema = z.preprocess((input) => {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    return input;
+  }
+  const model = 'model' in input ? input.model : undefined;
+  if (typeof model !== 'string' || !model.startsWith('copilot:')) return input;
+  return { ...input, model: model.slice('copilot:'.length) };
+}, MainViewPersistedStateBaseSchema);
 export type MainViewPersistedState = z.infer<
   typeof MainViewPersistedStateSchema
 >;

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -179,6 +179,35 @@ describe('Copilot route preference on a canonical base model', () => {
     );
   });
 
+  it('scopes a direct retry override without changing concurrent route selection', async () => {
+    await installCopilotRoute({
+      'texra.copilotRouteModels': ['sonnet46'],
+    });
+
+    const config = MODEL_CONFIGS.sonnet46;
+    expect(modelHandlerCompatibilityKey(config, false, false, 'direct')).toBe(
+      'ModelHandlerAnthropic',
+    );
+    expect(modelHandlerCompatibilityKey(config, false, false)).toBe(
+      'ModelHandlerVscodeLm',
+    );
+
+    const directHandler = await createModelHandler(
+      config,
+      undefined,
+      undefined,
+      'direct',
+    );
+    const concurrentHandler = await createModelHandler(config);
+    try {
+      expect(directHandler.constructor.name).toBe('ModelHandlerAnthropic');
+      expect(concurrentHandler.constructor.name).toBe('ModelHandlerVscodeLm');
+    } finally {
+      directHandler.dispose();
+      concurrentHandler.dispose();
+    }
+  });
+
   it('rejects a preferred route the editor cannot serve instead of falling through', async () => {
     invalidateRuntimeModelRegistry();
     await installPlatform(
@@ -217,6 +246,7 @@ describe('Copilot route preference on a canonical base model', () => {
   it('applies the discovered context ceiling and zero-cost subscription overrides', async () => {
     await installCopilotRoute({
       'texra.copilotRouteModels': ['sonnet46'],
+      'texra.reasoningLevels': { sonnet46: 'low' },
     });
 
     const handler = await createModelHandler(MODEL_CONFIGS.sonnet46);
@@ -224,6 +254,13 @@ describe('Copilot route preference on a canonical base model', () => {
       expect(handler.config.contextWindow).toBe(160_000);
       expect(handler.config.inputPrice).toBe(0);
       expect(handler.config.outputPrice).toBe(0);
+      expect(handler.config.capabilities.supportsReasoningEffort).toBe(false);
+      expect(handler.supportsReasoningLevelOverride).toBe(false);
+      // The persisted override is intentionally ignored because VS Code's LM
+      // request surface has no reasoning-effort parameter.
+      expect(handler.config.capabilities.reasoningEffort).toBe(
+        MODEL_CONFIGS.sonnet46.capabilities.reasoningEffort,
+      );
     } finally {
       handler.dispose();
     }

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -422,7 +422,7 @@ describe('ProgressApiKeyRetryController', () => {
     assert.equal(harness.invalidations, 1);
   });
 
-  it('suppresses the Copilot route preference only during the fallback launch', async () => {
+  it('keeps the global Copilot preference while scoping direct routing to the fallback launch', async () => {
     const { FakeStateStore } = await import('@test/support/FakePlatform');
     const store = new FakeStateStore({
       'texra.copilotRouteModels': ['sonnet46'],
@@ -439,10 +439,11 @@ describe('ProgressApiKeyRetryController', () => {
     expect(prefersCopilotRoute('sonnet46')).toBe(true);
     const started = await harness.controller.runCopilotFallbackWithRouting(
       { model: 'sonnet46', exhaustionReason: 'copilot-subscription' },
-      async () => {
-        // Handler construction during launch must not see the preference,
-        // or the retry would dispatch through Copilot again (#9635).
-        expect(prefersCopilotRoute('sonnet46')).toBe(false);
+      async (copilotRouteOverride) => {
+        expect(copilotRouteOverride).toBe('direct');
+        // A concurrent launch still sees the user's standing preference; only
+        // the replacement request receives the direct-route override.
+        expect(prefersCopilotRoute('sonnet46')).toBe(true);
         return true;
       },
     );

--- a/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
@@ -71,6 +71,7 @@ function createController(
     state: createState(),
     resolveModelOptions,
     getCopilotRoutes: NO_COPILOT_ROUTES,
+    getPreferredCopilotRouteModels: () => [],
     ...overrides,
   });
 }
@@ -179,6 +180,58 @@ describe('SettingsModelSelectionController', () => {
     );
   });
 
+  it('keeps a preferred undiscovered Copilot route visible for opt-out', async () => {
+    const controller = createController({
+      getPreferredCopilotRouteModels: () => ['sonnet46'],
+    });
+
+    expect((await controller.buildSelectionData()).copilotModels).toEqual([
+      {
+        name: 'sonnet46',
+        label: MODEL_CONFIGS.sonnet46.label,
+        access: 'unavailable',
+        preferred: true,
+      },
+    ]);
+  });
+
+  it('does not expose reasoning controls for a preferred VS Code route', async () => {
+    const controller = createController({
+      getPreferredCopilotRouteModels: () => ['sonnet46'],
+      getCopilotRoutes: async () =>
+        new Map<string, CopilotModelRoute>([
+          [
+            'sonnet46',
+            {
+              access: 'allowed',
+              reference: { vendor: 'copilot', id: 'claude-sonnet-4.6' },
+              effectiveConfig: {
+                ...MODEL_CONFIGS.sonnet46,
+                capabilities: {
+                  ...MODEL_CONFIGS.sonnet46.capabilities,
+                  supportsReasoningEffort: false,
+                  maxReasoningEffort: undefined,
+                  supportedReasoningEfforts: undefined,
+                },
+                contextWindow: 200_000,
+                inputPrice: 0,
+                outputPrice: 0,
+              },
+            },
+          ],
+        ]),
+    });
+
+    const sonnet = (await controller.buildSelectionData()).models.find(
+      (model) => model.name === 'sonnet46',
+    );
+    expect(MODEL_CONFIGS.sonnet46.capabilities.supportsReasoningEffort).toBe(
+      true,
+    );
+    expect(sonnet).not.toHaveProperty('supportsReasoningLevel');
+    expect(sonnet).not.toHaveProperty('reasoningLevel');
+  });
+
   it('surfaces discovered Copilot routes as route status, never as picker rows', async () => {
     const controller = createController({
       getCopilotRoutes: async () =>
@@ -188,7 +241,12 @@ describe('SettingsModelSelectionController', () => {
             {
               access: 'consent-required',
               reference: { vendor: 'copilot', id: 'claude-sonnet-4.6' },
-              maxInputTokens: 200_000,
+              effectiveConfig: {
+                ...MODEL_CONFIGS.sonnet46,
+                contextWindow: 200_000,
+                inputPrice: 0,
+                outputPrice: 0,
+              },
             },
           ],
         ]),

--- a/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
@@ -11,7 +11,6 @@ import { buildBasicModelOptionsData } from '@model/modelOptionsBasic';
 import type { CopilotModelRoute } from '@model/runtimeModelRegistry';
 import type { ModelOptionData } from '@shared/schemas';
 import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
-import { installPlatform } from '@test/support/setupPlatform';
 
 const NO_COPILOT_ROUTES = async (): Promise<
   ReadonlyMap<string, CopilotModelRoute>
@@ -271,26 +270,5 @@ describe('SettingsModelSelectionController', () => {
       ),
     ).toEqual([]);
     expect(models.filter((model) => model.name === 'sonnet46')).toHaveLength(1);
-  });
-
-  it('surfaces a persisted preference whose route is no longer discovered', async () => {
-    // #9659: the routing layer treats a persisted preference as a hard route
-    // choice, so the settings UI must expose its undo even when VS Code has
-    // stopped offering the model through Copilot.
-    await installPlatform({
-      globalState: { 'texra.copilotRouteModels': ['sonnet46'] },
-    });
-    const controller = createController();
-
-    const { copilotModels } = await controller.buildSelectionData();
-
-    expect(copilotModels).toEqual([
-      {
-        name: 'sonnet46',
-        label: MODEL_CONFIGS.sonnet46.label,
-        access: 'unavailable',
-        preferred: true,
-      },
-    ]);
   });
 });

--- a/src/test-kernel/frontend/createLanguageModelPort.vitest.ts
+++ b/src/test-kernel/frontend/createLanguageModelPort.vitest.ts
@@ -81,7 +81,10 @@ const mocks = vi.hoisted(() => ({
   onDidChangeChatModels: vi.fn(() => ({ dispose: vi.fn() })),
   canSendRequest: vi.fn(),
   onDidChangeAccess: vi.fn(() => ({ dispose: vi.fn() })),
+  warn: vi.fn(),
 }));
+
+vi.mock('@logger/logUtils', () => ({ warn: mocks.warn }));
 
 vi.mock('vscode', () => ({
   lm: {
@@ -331,6 +334,29 @@ describe('createLanguageModelPort', () => {
 
     expect(cancellationSources[0]?.cancel).toHaveBeenCalledOnce();
     if (mode !== 'return') await iterator.return?.();
+  });
+
+  it('logs discovery failures at the VS Code language-model adapter boundary', async () => {
+    const nativeError = new Error('discovery failed');
+    mocks.selectChatModels.mockRejectedValue(nativeError);
+
+    await expect(
+      createPort().selectModels({ vendor: 'copilot' }),
+    ).rejects.toMatchObject({
+      name: 'LanguageModelPortError',
+      code: LANGUAGE_MODEL_PORT_ERROR_CODE.UNKNOWN,
+      cause: nativeError,
+    });
+    expect(mocks.warn).toHaveBeenCalledWith(
+      'LanguageModelPort',
+      'Could not discover editor-supplied language models.',
+      {
+        data: expect.objectContaining({
+          name: 'LanguageModelPortError',
+          code: LANGUAGE_MODEL_PORT_ERROR_CODE.UNKNOWN,
+        }),
+      },
+    );
   });
 
   it.each([

--- a/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
+++ b/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
@@ -119,11 +119,21 @@ describe('runtime model registry', () => {
     await refreshRuntimeModelRegistry();
 
     expect(port.selectModels).toHaveBeenCalledWith({ vendor: 'copilot' });
-    expect(copilotRouteForModel('sonnet46')).toEqual({
-      access: 'allowed',
-      reference: { vendor: 'copilot', id: SONNET.id },
-      maxInputTokens: SONNET.maxInputTokens,
-    });
+    expect(copilotRouteForModel('sonnet46')).toEqual(
+      expect.objectContaining({
+        access: 'allowed',
+        reference: { vendor: 'copilot', id: SONNET.id },
+        effectiveConfig: expect.objectContaining({
+          name: 'sonnet46',
+          contextWindow: SONNET.maxInputTokens,
+          inputPrice: 0,
+          outputPrice: 0,
+          capabilities: expect.objectContaining({
+            supportsReasoningEffort: false,
+          }),
+        }),
+      }),
+    );
     // No synthetic picker identity is materialized for the route.
     expect(copilotRouteForModel('copilot:sonnet46')).toBeUndefined();
     expect(getRuntimeModelConfig('sonnet46')?.label).not.toContain('Copilot');
@@ -350,6 +360,8 @@ describe('Copilot route in model pickers', () => {
         availability: 'copilot-access',
         availabilityLabel: 'Copilot subscription',
         routeLabel: 'Via Copilot',
+        context: '160K',
+        cost: '$0.000/$0.000',
         disabled: false,
         requiresKey: false,
       }),

--- a/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
+++ b/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
@@ -7,6 +7,7 @@ import {
   type ModelOptionsAccess,
 } from '@model/computeModelOptions';
 import {
+  preferredCopilotRouteModels,
   shouldRouteModelThroughCopilot,
   setCopilotRoutePreference,
 } from '@model/copilotRouting';
@@ -242,6 +243,43 @@ describe('runtime model registry', () => {
     expect(port.sendRequest).not.toHaveBeenCalled();
   });
 
+  it('does not let a superseded ordinary discovery overwrite forced access state', async () => {
+    let releaseOrdinary: (models: readonly LanguageModelInfo[]) => void = () =>
+      undefined;
+    let releaseForced: (models: readonly LanguageModelInfo[]) => void = () =>
+      undefined;
+    const ordinary = new Promise<readonly LanguageModelInfo[]>((resolve) => {
+      releaseOrdinary = resolve;
+    });
+    const forced = new Promise<readonly LanguageModelInfo[]>((resolve) => {
+      releaseForced = resolve;
+    });
+    const port = {
+      ...languageModelPort([]),
+      selectModels: vi
+        .fn<() => Promise<readonly LanguageModelInfo[]>>()
+        .mockReturnValueOnce(ordinary)
+        .mockReturnValueOnce(forced),
+    };
+    await installPlatform({}, { languageModel: port });
+
+    const staleOrdinaryRefresh = refreshRuntimeModelRegistry();
+    const forcedRequest = requestRuntimeModelAccess('sonnet46');
+    releaseForced([{ ...SONNET, access: 'unavailable' }]);
+    await expect(forcedRequest).resolves.toBe('unavailable');
+
+    // Resolve stale allowed data last: the superseded generation must not
+    // overwrite the forced result that authorized the opt-in outcome.
+    releaseOrdinary([SONNET]);
+    await staleOrdinaryRefresh;
+
+    expect((await discoveredCopilotRoutes()).get('sonnet46')?.access).toBe(
+      'unavailable',
+    );
+    expect(port.sendRequest).not.toHaveBeenCalled();
+    expect(port.selectModels).toHaveBeenCalledTimes(2);
+  });
+
   it('coalesces overlapping user-initiated fresh discoveries', async () => {
     const port = await installModels(SONNET);
     await refreshRuntimeModelRegistry();
@@ -264,15 +302,28 @@ describe('runtime model registry', () => {
     expect(port.selectModels).toHaveBeenCalledTimes(2);
   });
 
-  it('retains last-known routes when user-initiated discovery fails', async () => {
-    const port = await installModels(SONNET);
-    await refreshRuntimeModelRegistry();
+  it('keeps a visible non-preferred route after failed opt-in revalidation', async () => {
     const error = new Error('fresh discovery failed');
-    vi.mocked(port.selectModels).mockRejectedValueOnce(error);
+    let discoveryFails = false;
+    const port = {
+      ...languageModelPort([]),
+      selectModels: vi.fn(async () => {
+        if (discoveryFails) throw error;
+        return [SONNET];
+      }),
+    };
+    await installPlatform({}, { languageModel: port });
+    await refreshRuntimeModelRegistry();
+    discoveryFails = true;
 
     await expect(requestRuntimeModelAccess('sonnet46')).rejects.toBe(error);
 
-    expect(copilotRouteForModel('sonnet46')?.access).toBe('allowed');
+    // Settings reads through the public asynchronous boundary. Its retry also
+    // fails, but the previously visible route remains available for display.
+    const visibleRoutes = await discoveredCopilotRoutes();
+    expect(visibleRoutes.get('sonnet46')?.access).toBe('allowed');
+    expect(preferredCopilotRouteModels()).toEqual([]);
+    expect(port.selectModels).toHaveBeenCalledTimes(3);
   });
 
   it('reports the direct fallback for a base model and a legacy copilot id', async () => {
@@ -383,14 +434,16 @@ describe('runtime model registry', () => {
     await expect(resolveRuntimeModelConfig('gpt55')).resolves.toBeDefined();
   });
 
-  it('returns an empty route catalogue when native discovery fails', async () => {
+  it('returns the last-known route catalogue when rediscovery fails', async () => {
     await installModels(SONNET);
     await refreshRuntimeModelRegistry();
 
     invalidateRuntimeModelRegistry();
     await installPlatform({}, { languageModel: failingDiscoveryPort() });
 
-    await expect(discoveredCopilotRoutes()).resolves.toEqual(new Map());
+    expect((await discoveredCopilotRoutes()).get('sonnet46')?.access).toBe(
+      'allowed',
+    );
   });
 });
 

--- a/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
+++ b/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
@@ -243,6 +243,67 @@ describe('runtime model registry', () => {
     expect(port.sendRequest).not.toHaveBeenCalled();
   });
 
+  it('retries when access invalidation supersedes a forced allowed probe', async () => {
+    const port = await installModels(SONNET);
+    await refreshRuntimeModelRegistry();
+
+    let releaseForced: (models: readonly LanguageModelInfo[]) => void = () =>
+      undefined;
+    const forced = new Promise<readonly LanguageModelInfo[]>((resolve) => {
+      releaseForced = resolve;
+    });
+    vi.mocked(port.selectModels)
+      .mockReturnValueOnce(forced)
+      .mockResolvedValueOnce([{ ...SONNET, access: 'unavailable' }]);
+
+    const request = requestRuntimeModelAccess('sonnet46');
+    invalidateRuntimeModelRegistry();
+    releaseForced([SONNET]);
+
+    await expect(request).resolves.toBe('unavailable');
+    expect(port.selectModels).toHaveBeenCalledTimes(3);
+    expect(port.sendRequest).not.toHaveBeenCalled();
+    expect(copilotRouteForModel('sonnet46')?.access).toBe('unavailable');
+  });
+
+  it('fails closed when repeated invalidation supersedes the bounded retry', async () => {
+    const port = await installModels(SONNET);
+    await refreshRuntimeModelRegistry();
+
+    let releaseForced: (models: readonly LanguageModelInfo[]) => void = () =>
+      undefined;
+    let releaseRetry: (models: readonly LanguageModelInfo[]) => void = () =>
+      undefined;
+    let markRetryStarted: () => void = () => undefined;
+    const forced = new Promise<readonly LanguageModelInfo[]>((resolve) => {
+      releaseForced = resolve;
+    });
+    const retry = new Promise<readonly LanguageModelInfo[]>((resolve) => {
+      releaseRetry = resolve;
+    });
+    const retryStarted = new Promise<void>((resolve) => {
+      markRetryStarted = resolve;
+    });
+    vi.mocked(port.selectModels)
+      .mockReturnValueOnce(forced)
+      .mockImplementationOnce(() => {
+        markRetryStarted();
+        return retry;
+      });
+
+    const request = requestRuntimeModelAccess('sonnet46');
+    invalidateRuntimeModelRegistry();
+    releaseForced([SONNET]);
+    await retryStarted;
+    invalidateRuntimeModelRegistry();
+    releaseRetry([SONNET]);
+
+    await expect(request).resolves.toBe('unavailable');
+    expect(port.selectModels).toHaveBeenCalledTimes(3);
+    expect(port.sendRequest).not.toHaveBeenCalled();
+    expect(copilotRouteForModel('sonnet46')?.access).toBe('allowed');
+  });
+
   it('does not let a superseded ordinary discovery overwrite forced access state', async () => {
     let releaseOrdinary: (models: readonly LanguageModelInfo[]) => void = () =>
       undefined;

--- a/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
+++ b/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
@@ -204,6 +204,77 @@ describe('runtime model registry', () => {
     expect(unavailablePort.sendRequest).not.toHaveBeenCalled();
   });
 
+  it('re-discovers stale allowed access before entering the native consent flow', async () => {
+    let models: readonly LanguageModelInfo[] = [SONNET];
+    const port = {
+      ...languageModelPort([]),
+      selectModels: vi.fn(async () => models),
+    };
+    await installPlatform({}, { languageModel: port });
+    await refreshRuntimeModelRegistry();
+    expect(copilotRouteForModel('sonnet46')?.access).toBe('allowed');
+
+    models = [{ ...SONNET, access: 'consent-required' }];
+
+    await expect(requestRuntimeModelAccess('sonnet46')).resolves.toBe(
+      'requested',
+    );
+    expect(port.selectModels).toHaveBeenCalledTimes(2);
+    expect(port.sendRequest).toHaveBeenCalledOnce();
+  });
+
+  it('re-discovers stale allowed access before reporting unavailable', async () => {
+    let models: readonly LanguageModelInfo[] = [SONNET];
+    const port = {
+      ...languageModelPort([]),
+      selectModels: vi.fn(async () => models),
+    };
+    await installPlatform({}, { languageModel: port });
+    await refreshRuntimeModelRegistry();
+    expect(copilotRouteForModel('sonnet46')?.access).toBe('allowed');
+
+    models = [{ ...SONNET, access: 'unavailable' }];
+
+    await expect(requestRuntimeModelAccess('sonnet46')).resolves.toBe(
+      'unavailable',
+    );
+    expect(port.selectModels).toHaveBeenCalledTimes(2);
+    expect(port.sendRequest).not.toHaveBeenCalled();
+  });
+
+  it('coalesces overlapping user-initiated fresh discoveries', async () => {
+    const port = await installModels(SONNET);
+    await refreshRuntimeModelRegistry();
+
+    let releaseDiscovery: (models: readonly LanguageModelInfo[]) => void = () =>
+      undefined;
+    const deferred = new Promise<readonly LanguageModelInfo[]>((resolve) => {
+      releaseDiscovery = resolve;
+    });
+    vi.mocked(port.selectModels).mockReturnValueOnce(deferred);
+
+    const first = requestRuntimeModelAccess('sonnet46');
+    const second = requestRuntimeModelAccess('sonnet46');
+    releaseDiscovery([{ ...SONNET, access: 'unavailable' }]);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      'unavailable',
+      'unavailable',
+    ]);
+    expect(port.selectModels).toHaveBeenCalledTimes(2);
+  });
+
+  it('retains last-known routes when user-initiated discovery fails', async () => {
+    const port = await installModels(SONNET);
+    await refreshRuntimeModelRegistry();
+    const error = new Error('fresh discovery failed');
+    vi.mocked(port.selectModels).mockRejectedValueOnce(error);
+
+    await expect(requestRuntimeModelAccess('sonnet46')).rejects.toBe(error);
+
+    expect(copilotRouteForModel('sonnet46')?.access).toBe('allowed');
+  });
+
   it('reports the direct fallback for a base model and a legacy copilot id', async () => {
     await installModels(SONNET, GPT_56);
     await refreshRuntimeModelRegistry();

--- a/src/test-kernel/settings/CopilotModelAccess.vitest.ts
+++ b/src/test-kernel/settings/CopilotModelAccess.vitest.ts
@@ -82,7 +82,7 @@ describe('Copilot model access settings', () => {
     const section = tab.shadowRoot?.querySelector('#copilot-access');
     expect(section?.textContent).toContain('1 Copilot model is ready');
     const button = section?.querySelector<HTMLElement>('wa-button');
-    expect(button?.textContent).toContain('Use Copilot for GPT-5.5');
+    expect(button?.textContent).toContain('Use Copilot');
 
     button?.click();
     expect(mocks.postMessage.mock.calls).toEqual([
@@ -96,7 +96,7 @@ describe('Copilot model access settings', () => {
     const section = tab.shadowRoot?.querySelector('#copilot-access');
     expect(section?.textContent).toContain('GPT-5.5 runs through Copilot.');
     const button = section?.querySelector<HTMLElement>('wa-button');
-    expect(button?.textContent).toContain('Stop using Copilot for GPT-5.5');
+    expect(button?.textContent).toContain('Stop using Copilot');
 
     button?.click();
     expect(mocks.postMessage.mock.calls).toEqual([
@@ -104,21 +104,74 @@ describe('Copilot model access settings', () => {
     ]);
   });
 
-  it('offers the undo, not consent, when a preferred route loses access', async () => {
+  it('keeps other route actions reachable while one route is preferred', async () => {
+    const tab = await renderModelsTab([
+      { ...allowedRoute, preferred: true },
+      consentRoute,
+    ]);
+
+    const buttons = [
+      ...(tab.shadowRoot?.querySelectorAll<HTMLElement>(
+        '#copilot-access wa-button',
+      ) ?? []),
+    ];
+    expect(buttons.map((button) => button.textContent?.trim())).toEqual([
+      'Stop using Copilot',
+      'Grant access',
+    ]);
+    const actionRows = [
+      ...(tab.shadowRoot?.querySelectorAll<HTMLElement>(
+        '#copilot-access .copilot-route-action',
+      ) ?? []),
+    ];
+    expect(actionRows).toHaveLength(2);
+    expect(actionRows[0]?.textContent).toContain('GPT-5.5');
+    expect(actionRows[1]?.textContent).toContain('Claude Sonnet 4.6');
+    expect(buttons[0]?.classList.contains('btn-secondary')).toBe(true);
+    expect(buttons[0]?.getAttribute('appearance')).toBe('outlined');
+    expect(buttons[1]?.classList.contains('btn-primary')).toBe(true);
+    expect(buttons[1]?.getAttribute('appearance')).toBe('filled');
+
+    buttons[0]?.click();
+    buttons[1]?.click();
+    expect(mocks.postMessage.mock.calls).toEqual([
+      [SETTINGS_VIEW_COMMANDS.CLEAR_COPILOT_ROUTE, { modelName: 'gpt55' }],
+      [SETTINGS_VIEW_COMMANDS.REQUEST_MODEL_ACCESS, { modelName: 'sonnet46' }],
+    ]);
+  });
+
+  it('describes a preferred route that is waiting for consent', async () => {
     const tab = await renderModelsTab([{ ...consentRoute, preferred: true }]);
 
     const section = tab.shadowRoot?.querySelector('#copilot-access');
     expect(section?.textContent).toContain(
-      'Claude Sonnet 4.6 is set to use Copilot but is waiting for consent.',
+      'Selected Copilot route is waiting for VS Code consent.',
     );
-    const button = section?.querySelector<HTMLElement>('wa-button');
-    expect(button?.textContent).toContain(
-      'Stop using Copilot for Claude Sonnet 4.6',
-    );
-
-    button?.click();
-    expect(mocks.postMessage.mock.calls).toEqual([
-      [SETTINGS_VIEW_COMMANDS.CLEAR_COPILOT_ROUTE, { modelName: 'sonnet46' }],
+    const buttons = [
+      ...(section?.querySelectorAll<HTMLElement>('wa-button') ?? []),
+    ];
+    expect(buttons.map((button) => button.textContent?.trim())).toEqual([
+      'Grant access',
+      'Stop using Copilot',
     ]);
+    expect(section?.querySelector('.copilot-route-controls')).not.toBeNull();
+    buttons[0]?.click();
+    expect(mocks.postMessage.mock.calls).toEqual([
+      [SETTINGS_VIEW_COMMANDS.REQUEST_MODEL_ACCESS, { modelName: 'sonnet46' }],
+    ]);
+  });
+
+  it('keeps an unavailable preferred route removable', async () => {
+    const tab = await renderModelsTab([
+      { ...allowedRoute, access: 'unavailable', preferred: true },
+    ]);
+
+    const section = tab.shadowRoot?.querySelector('#copilot-access');
+    expect(section?.textContent).toContain(
+      '1 selected Copilot route needs attention.',
+    );
+    expect(section?.querySelector('wa-button')?.textContent).toContain(
+      'Stop using Copilot',
+    );
   });
 });

--- a/src/test-kernel/settings/CopilotModelAccess.vitest.ts
+++ b/src/test-kernel/settings/CopilotModelAccess.vitest.ts
@@ -94,7 +94,7 @@ describe('Copilot model access settings', () => {
     const tab = await renderModelsTab([{ ...allowedRoute, preferred: true }]);
 
     const section = tab.shadowRoot?.querySelector('#copilot-access');
-    expect(section?.textContent).toContain('GPT-5.5 runs through Copilot.');
+    expect(section?.textContent).toContain('Copilot route selected.');
     const button = section?.querySelector<HTMLElement>('wa-button');
     expect(button?.textContent).toContain('Stop using Copilot');
 
@@ -156,8 +156,10 @@ describe('Copilot model access settings', () => {
     ]);
     expect(section?.querySelector('.copilot-route-controls')).not.toBeNull();
     buttons[0]?.click();
+    buttons[1]?.click();
     expect(mocks.postMessage.mock.calls).toEqual([
       [SETTINGS_VIEW_COMMANDS.REQUEST_MODEL_ACCESS, { modelName: 'sonnet46' }],
+      [SETTINGS_VIEW_COMMANDS.CLEAR_COPILOT_ROUTE, { modelName: 'sonnet46' }],
     ]);
   });
 

--- a/src/test-kernel/settings/CopilotRoutePreferenceHandler.vitest.ts
+++ b/src/test-kernel/settings/CopilotRoutePreferenceHandler.vitest.ts
@@ -1,0 +1,136 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  invalidateModelOptionsCache: vi.fn(),
+  invalidateRuntimeModelRegistry: vi.fn(),
+  requestRuntimeModelAccess: vi.fn(),
+  safeExecuteCommand: vi.fn(async () => undefined),
+  sendModelSelectionData: vi.fn(async () => undefined),
+  setCopilotRoutePreference: vi.fn(async () => undefined),
+  showLoggedErrorMessage: vi.fn(async () => undefined),
+  showLoggedInfoMessage: vi.fn(async () => undefined),
+}));
+
+vi.mock('@model/runtimeModelRegistry', async (original) => {
+  const actual = await original<typeof import('@model/runtimeModelRegistry')>();
+  return {
+    ...actual,
+    invalidateRuntimeModelRegistry: mocks.invalidateRuntimeModelRegistry,
+    requestRuntimeModelAccess: mocks.requestRuntimeModelAccess,
+  };
+});
+
+vi.mock('@model/copilotRouting', async (original) => {
+  const actual = await original<typeof import('@model/copilotRouting')>();
+  return {
+    ...actual,
+    setCopilotRoutePreference: mocks.setCopilotRoutePreference,
+  };
+});
+
+vi.mock('@model/computeModelOptions', async (original) => {
+  const actual = await original<typeof import('@model/computeModelOptions')>();
+  return {
+    ...actual,
+    invalidateModelOptionsCache: mocks.invalidateModelOptionsCache,
+  };
+});
+
+vi.mock('@frontend/system/commandUtils', async (original) => {
+  const actual =
+    await original<typeof import('@frontend/system/commandUtils')>();
+  return { ...actual, safeExecuteCommand: mocks.safeExecuteCommand };
+});
+
+vi.mock('@frontend/ui/errorHandlingUtils', async (original) => {
+  const actual =
+    await original<typeof import('@frontend/ui/errorHandlingUtils')>();
+  return {
+    ...actual,
+    showLoggedErrorMessage: mocks.showLoggedErrorMessage,
+    showLoggedInfoMessage: mocks.showLoggedInfoMessage,
+  };
+});
+
+// Local imports
+import { SettingsViewMessageHandler } from '@settingsView/SettingsViewMessageHandler';
+
+type CopilotPreferenceHarness = {
+  handleRequestModelAccess(modelName: string): Promise<void>;
+  handleClearCopilotRoute(modelName: string): Promise<void>;
+};
+
+function createHarness(): CopilotPreferenceHarness {
+  const handler = Object.create(SettingsViewMessageHandler.prototype);
+  Reflect.set(handler, 'channel', 'SettingsViewMessageHandler');
+  Reflect.set(handler, 'viewName', 'SettingsView');
+  Reflect.set(handler, 'sendModelSelectionData', mocks.sendModelSelectionData);
+  Reflect.set(
+    handler,
+    'withActiveWebview',
+    vi.fn(async (fn: (webview: object) => Promise<void>) => fn({})),
+  );
+  return handler as CopilotPreferenceHarness;
+}
+
+describe('Copilot route preference handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('revalidates and persists an allowed opt-in', async () => {
+    mocks.requestRuntimeModelAccess.mockResolvedValueOnce('already-allowed');
+    const handler = createHarness();
+
+    await handler.handleRequestModelAccess('sonnet46');
+
+    expect(mocks.requestRuntimeModelAccess).toHaveBeenCalledWith('sonnet46');
+    expect(mocks.setCopilotRoutePreference).toHaveBeenCalledWith(
+      'sonnet46',
+      true,
+    );
+    expect(mocks.showLoggedInfoMessage).not.toHaveBeenCalled();
+  });
+
+  it('uses the current consent flow before persisting a stale allowed opt-in', async () => {
+    mocks.requestRuntimeModelAccess.mockResolvedValueOnce('requested');
+    const handler = createHarness();
+
+    await handler.handleRequestModelAccess('sonnet46');
+
+    expect(mocks.requestRuntimeModelAccess).toHaveBeenCalledWith('sonnet46');
+    expect(mocks.setCopilotRoutePreference).toHaveBeenCalledWith(
+      'sonnet46',
+      true,
+    );
+  });
+
+  it('rejects an opt-in that has become unavailable with actionable feedback', async () => {
+    mocks.requestRuntimeModelAccess.mockResolvedValueOnce('unavailable');
+    const handler = createHarness();
+
+    await handler.handleRequestModelAccess('sonnet46');
+
+    expect(mocks.setCopilotRoutePreference).not.toHaveBeenCalled();
+    expect(mocks.showLoggedInfoMessage).toHaveBeenCalledWith(
+      'SettingsViewMessageHandler',
+      'This Copilot model is no longer available in VS Code. Refresh the model list and choose another model.',
+    );
+  });
+
+  it('allows opt-out without consulting current Copilot access', async () => {
+    const handler = createHarness();
+
+    await handler.handleClearCopilotRoute('sonnet46');
+
+    expect(mocks.requestRuntimeModelAccess).not.toHaveBeenCalled();
+    expect(mocks.setCopilotRoutePreference).toHaveBeenCalledWith(
+      'sonnet46',
+      false,
+    );
+  });
+});

--- a/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
+++ b/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
@@ -4,10 +4,11 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 // Local imports - shared constants and types
 import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import { HOST_BRIDGE_API_KEY } from '@shared/hostBridgeTypes';
-import type {
-  FileStateContextValue,
-  MainViewPersistedState,
-  SessionContextValue,
+import {
+  MainViewPersistedStateSchema,
+  type FileStateContextValue,
+  type MainViewPersistedState,
+  type SessionContextValue,
 } from '@shared/schemas';
 
 // Local imports - component type (type-only: the module loads inside the DOM harness)
@@ -185,7 +186,16 @@ describe('MainApp persistence and restore characterization', () => {
     });
   });
 
-  it('normalizes a legacy Copilot model id during mount-time restore', async () => {
+  it('keeps the shared persisted-state schema current-only', () => {
+    expect(
+      MainViewPersistedStateSchema.parse({
+        ...PERSISTED_SEED,
+        model: 'copilot:sonnet46',
+      }).model,
+    ).toBe('copilot:sonnet46');
+  });
+
+  it('normalizes a legacy Copilot model id during VS Code mount-time restore', async () => {
     seedWebviewState({ ...PERSISTED_SEED, model: 'copilot:sonnet46' });
 
     const element = await mountMainApp();
@@ -287,7 +297,7 @@ describe('MainApp persistence and restore characterization', () => {
     });
   });
 
-  it('normalizes a legacy Copilot model id during backend restore', async () => {
+  it('normalizes a legacy Copilot model id during VS Code backend restore', async () => {
     const element = await mountMainApp();
     storageWrites.length = 0;
 

--- a/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
+++ b/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
@@ -185,6 +185,15 @@ describe('MainApp persistence and restore characterization', () => {
     });
   });
 
+  it('normalizes a legacy Copilot model id during mount-time restore', async () => {
+    seedWebviewState({ ...PERSISTED_SEED, model: 'copilot:sonnet46' });
+
+    const element = await mountMainApp();
+
+    expect(contextsOf(element).session.model).toBe('sonnet46');
+    expect(storageWrites).toHaveLength(0);
+  });
+
   it('restores persisted state on mount through the canonical state applicator', async () => {
     const element = await mountMainApp();
     const { fileState, session } = contextsOf(element);
@@ -276,6 +285,20 @@ describe('MainApp persistence and restore characterization', () => {
       launchTarget: 'agent',
       selectedTeamId: 'physicist',
     });
+  });
+
+  it('normalizes a legacy Copilot model id during backend restore', async () => {
+    const element = await mountMainApp();
+    storageWrites.length = 0;
+
+    dispatchHostMessage({
+      command: COMMON_COMMANDS.STATE_RESTORE,
+      state: restoreState({ model: 'copilot:sonnet46' }),
+    });
+    await element.updateComplete;
+
+    expect(contextsOf(element).session.model).toBe('sonnet46');
+    expect(lastPersistedBlob().model).toBe('sonnet46');
   });
 
   it('applies a backend-pushed restore with exactly one storage write and forced output reset', async () => {


### PR DESCRIPTION
## Summary

Complete the review follow-ups that landed after #9652 merged. This keeps Copilot a hard, explicit route for the canonical model while closing the remaining correctness and recovery gaps:

- preserve the discovered editor context limit and zero-cost subscription pricing in the routed effective config
- mask reasoning controls the VS Code LM transport does not support
- replace process-global retry suppression with a request-scoped direct-route override
- keep concurrent launches on their standing Copilot preferences during a direct-key retry
- let users opt in or out independently for every discovered model, including unavailable preferred routes
- normalize legacy `copilot:*` main-view selections at the persisted-state boundary
- log discovery failures at the VS Code adapter boundary without adding a forbidden model-layer dependency

This fully supersedes the narrower #9660 opt-out PR. Unlike that branch, it also keeps every model's action reachable, preserves missing preferred routes in settings, and uses responsive per-model settings rows.

## Scope and invariants

- Canonical model IDs remain the only persisted/runtime identity.
- A preferred unavailable Copilot route fails explicitly; it does not silently consume another credential.
- The direct-key fallback override is scoped to the replacement launch only and never mutates global preference state.
- Route-effective presentation/configuration does not change canonical persistence.

## Net elements (R6)

- 24 files changed, 460 insertions, 109 deletions.
- No new classes or generic facades.
- One typed launch override is threaded through existing launch context boundaries.
- One generalized settings preference command handles both opt-in and opt-out.

## Consumer counts (R8)

- The request-scoped route override has one producer (Copilot direct-key retry) and is consumed by the existing launch/handler selection pipeline.
- The settings preference command has one frontend producer path and exhaustive extension/desktop handlers.
- Route-effective config has two consumers: model option construction and `ModelFactory`.

## Duplicate audit

- #9660 overlaps only the opt-out subset and is superseded by this reviewed branch.
- Open PRs #9655 and #9656 have no overlapping files or behavior.
- Merged #9657/#9658 behavior is preserved; focused cross-PR regression coverage passed.

## Verification

- Independent final review: no blocking or should-fix findings.
- Focused Copilot/persistence/architecture suites: 151 tests passed before the final UI expansion; 7 Copilot UI tests pass after it.
- Cross-PR regression review: 199 tests passed.
- Full local suite before the final UI-only adjustment: 822 files / 8,436 tests passed; 1 file / 5 tests skipped.
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- `npm test`
- `git diff --check`

Closes #9659.

Follow-up to #9652 and #9635.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model routing, launch context, and VS Code LM discovery/consent; incorrect override or stale access could mis-route runs or block Copilot retries, but behavior is heavily tested and scoped to explicit user actions.
> 
> **Overview**
> Finishes explicit Copilot routing for canonical model IDs: a preferred route stays a hard choice (fail if VS Code cannot serve it), while **“use own API key”** retries pass a **one-run `direct` override** through `texra.execute` → `runAgent` so only that launch bypasses Copilot without touching persisted preferences or blocking concurrent Copilot runs.
> 
> **Runtime model registry** now builds each route’s **`effectiveConfig`** (editor context limit, zero-cost pricing, no reasoning-effort controls) and uses it in **`ModelFactory`**, model picker rows, and settings reasoning UI. Discovery is **forced and retried** for consent/access actions, **coalesces** overlapping probes, **retains last-known routes** when rediscovery fails for display, and **fails closed** when authorization cannot get a fresh snapshot.
> 
> **Settings → Copilot** moves from one shared action to **per-model rows** (opt in, grant consent, stop). **Main view persistence** on VS Code strips legacy **`copilot:<baseModel>`** ids via an extension-local schema preprocessor.
> 
> Adapter **discovery failures are logged** at the VS Code LM boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e80f695656d673f021c64be58774bcab976b9f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->