### PR TITLE
refactor(transcript): backfill identity and description only when uniquely provable

### DIFF
--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -967,6 +967,74 @@ describe('StreamSnapshotStore', () => {
     expect((await store.read(STREAM)).executionId).toBe(executionId);
   });
 
+  it('backfills an absent description mirror from ExecutionMeta and is a no-op once present (#9590 Stage 4)', async () => {
+    await installPlatform();
+    const executionId = 'aa22cc33' as ExecutionId;
+    await getExecutionStore(executionId).writeConfig(toolUseConfig());
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: new Date(0).toISOString(),
+      description: 'Meta authority label',
+    });
+    await writeMetaFile(STREAM, { executionId });
+
+    const store = new StreamSnapshotStore();
+    await store.load([STREAM]);
+    expect(store.getDescription(STREAM)).toBe('Meta authority label');
+    await store.flush();
+
+    // Reconciliation is idempotent: with the mirror present, a second load
+    // runs no projection at all and both sides keep their values.
+    const reloaded = new StreamSnapshotStore();
+    const projected = vi.spyOn(reloaded, 'setDescription');
+    await reloaded.load([STREAM]);
+    expect(reloaded.getDescription(STREAM)).toBe('Meta authority label');
+    expect(projected).not.toHaveBeenCalled();
+    expect((await getExecutionStore(executionId).readMeta())?.description).toBe(
+      'Meta authority label',
+    );
+  });
+
+  it('reconciles description disagreement with one winner and never writes meta from the mirror (#9590 A4)', async () => {
+    await installPlatform();
+    // Both sides present and disagreeing: meta stays the authority, the
+    // mirror stays display data, and neither side is rewritten.
+    const described = 'aa33dd44' as ExecutionId;
+    await getExecutionStore(described).writeConfig(toolUseConfig());
+    await getExecutionStore(described).writeMeta({
+      timestamp: new Date(0).toISOString(),
+      description: 'Meta authority label',
+    });
+    await writeMetaFile(STREAM, {
+      executionId: described,
+      description: 'Stale mirror label',
+    });
+
+    // Mirror-only: the authoritative side is absent and must stay absent —
+    // the display mirror is never a backfill source for ExecutionMeta.
+    const undescribed = 'aa44ee55' as ExecutionId;
+    await getExecutionStore(undescribed).writeConfig(toolUseConfig());
+    await getExecutionStore(undescribed).writeMeta({
+      timestamp: new Date(0).toISOString(),
+    });
+    await writeMetaFile(OTHER_STREAM, {
+      executionId: undescribed,
+      description: 'Mirror-only label',
+    });
+
+    const store = new StreamSnapshotStore();
+    await store.load([STREAM, OTHER_STREAM]);
+    await store.flush();
+
+    expect(store.getDescription(STREAM)).toBe('Stale mirror label');
+    expect((await getExecutionStore(described).readMeta())?.description).toBe(
+      'Meta authority label',
+    );
+    expect(store.getDescription(OTHER_STREAM)).toBe('Mirror-only label');
+    expect(
+      (await getExecutionStore(undescribed).readMeta())?.description,
+    ).toBeUndefined();
+  });
+
   it('keeps a runtime run-config update that arrives during async hydration', async () => {
     await installPlatform();
     const oldExecutionId = 'abc123' as ExecutionId;

--- a/src/test-kernel/transcript/legacyExecutionIdentity.vitest.ts
+++ b/src/test-kernel/transcript/legacyExecutionIdentity.vitest.ts
@@ -222,6 +222,11 @@ describe('resolvePersistedStreamIdForExecution', () => {
       fallbackStreamIds: [],
       exactExecutionCandidateStreamIds: [firstStream, secondStream],
     });
+    // Skip-backfill-on-ambiguity (#9590 Stage 4): a resolution that reports
+    // candidates never stamps a LEGACY_RESOLUTION identity on the record.
+    expect(
+      (await getExecutionStore(executionId).readMeta())?.streamId,
+    ).toBeUndefined();
   });
 
   it('does not treat a stream log as canonical-ownership evidence', async () => {
@@ -311,6 +316,10 @@ describe('resolvePersistedStreamIdForExecution', () => {
       fallbackStreamIds: [],
       suffixCandidateStreamIds: [first, second],
     });
+    // Suffix ambiguity never backfills a persisted identity (#9590 Stage 4).
+    expect(
+      (await getExecutionStore(executionId).readMeta())?.streamId,
+    ).toBeUndefined();
   });
 
   it('reports a sidecar/log suffix disagreement as explicit ambiguity', async () => {
@@ -346,5 +355,27 @@ describe('resolvePersistedStreamIdForExecution', () => {
         streamLogStore: logs,
       }),
     ).resolves.toEqual({ streamId, fallbackStreamIds: [] });
+  });
+
+  it('never persists identity from a display-materialized transcript stream (#8226, #9590 Stage 4)', async () => {
+    const executionId = 'abcccc' as ExecutionId;
+    const orphanStream = 'progress@display#abcccc' as StreamTabId;
+    // The #8226 class: a display event materializes a transcript stream via
+    // `StreamLogStore.ensureStream` with no sidecar and no execution record.
+    const logs = await StreamLogStore.open();
+    logs.ensureStream(orphanStream);
+
+    // The suffix arm may still surface the orphan for compatibility display
+    // reads, but resemblance is not proof: no LEGACY_RESOLUTION identity is
+    // ever backfilled onto the execution record from it.
+    await expect(
+      resolvePersistedStreamIdForExecution(executionId, {
+        snapshotStore: new StreamSnapshotStore(),
+        streamLogStore: logs,
+      }),
+    ).resolves.toEqual({ streamId: orphanStream, fallbackStreamIds: [] });
+    expect(
+      (await getExecutionStore(executionId).readMeta())?.streamId,
+    ).toBeUndefined();
   });
 });

--- a/src/test-kernel/transcript/legacyExecutionIdentity.vitest.ts
+++ b/src/test-kernel/transcript/legacyExecutionIdentity.vitest.ts
@@ -214,6 +214,11 @@ describe('resolvePersistedStreamIdForExecution', () => {
     snapshotWriter.setRunConfig(secondStream, runConfig('bash'), executionId);
     snapshotWriter.setTodos(secondStream, [TODO]);
     await snapshotWriter.flush();
+    // Seed a stamp-able record: the backfill write no-ops on absent metadata,
+    // so without this a wrongful stamp attempt would be invisible below.
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: new Date(0).toISOString(),
+    });
 
     const resolved = await resolvePersistedStreamIdForExecution(executionId, {
       snapshotStore: new StreamSnapshotStore(),
@@ -242,6 +247,11 @@ describe('resolvePersistedStreamIdForExecution', () => {
     snapshotWriter.setRunConfig(logStream, runConfig('bash'), executionId);
     snapshotWriter.setTodos(workPlanStream, [TODO]);
     await snapshotWriter.flush();
+    // Seed a stamp-able record: the backfill write no-ops on absent metadata,
+    // so without this a wrongful stamp attempt would be invisible below.
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: new Date(0).toISOString(),
+    });
 
     const logStore = await StreamLogStore.open();
     await appendLogEntry(logStore, logStream);
@@ -307,6 +317,11 @@ describe('resolvePersistedStreamIdForExecution', () => {
     writer.setTodos(first, [TODO]);
     writer.setTodos(second, [TODO]);
     await writer.flush();
+    // Seed a stamp-able record: the backfill write no-ops on absent metadata,
+    // so without this a wrongful stamp attempt would be invisible below.
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: new Date(0).toISOString(),
+    });
 
     await expect(
       resolvePersistedStreamIdForExecution(executionId, {
@@ -364,6 +379,11 @@ describe('resolvePersistedStreamIdForExecution', () => {
     // `StreamLogStore.ensureStream` with no sidecar and no execution record.
     const logs = await StreamLogStore.open();
     logs.ensureStream(orphanStream);
+    // Seed a stamp-able record: the backfill write no-ops on absent metadata,
+    // so without this a wrongful stamp attempt would be invisible below.
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: new Date(0).toISOString(),
+    });
 
     // The suffix arm may still surface the orphan for compatibility display
     // reads, but resemblance is not proof: no LEGACY_RESOLUTION identity is

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -2264,9 +2264,15 @@ export class StreamSnapshotStore {
   }
 
   /**
-   * One-time backfill for streams with an executionId but no description in
-   * meta.json: read it from ExecutionMeta and persist so future loads skip the
-   * extra I/O.
+   * One-time legacy convergence toward the description authority (#9590 A4):
+   * `ExecutionMeta.description` is authoritative and the sidecar `description`
+   * is a display-only mirror, so projection runs meta → mirror only, and only
+   * when the mirror is absent. A present mirror value is never overwritten —
+   * disagreement is not reconciled by writing either side; meta simply stays
+   * the authority and the mirror stays display data — and nothing anywhere
+   * writes `ExecutionMeta.description` from the mirror. Persisting the filled
+   * mirror lets future loads skip the extra I/O. Stage 6 (#9590) stops this
+   * duplicate projection for current records.
    */
   private async backfillDescriptionsFromExecutionMeta(): Promise<void> {
     for (const [streamId, record] of [...this.records]) {

--- a/src/transcript/legacyExecutionIdentity.ts
+++ b/src/transcript/legacyExecutionIdentity.ts
@@ -220,6 +220,15 @@ export async function resolvePersistedStreamIdForExecution(
     const associatedStreamIds = childMetaMatched.filter(
       (candidate) => candidate !== streamId,
     );
+    // Persisted identity backfill (#9590 Stage 4): stamp
+    // `streamIdSource: LEGACY_RESOLUTION` only when the mapping is uniquely
+    // provable — exactly one persisted sidecar claims this execution. Any
+    // multi-match resolution stays unstamped even when it still names an
+    // archive root for reading, and the suffix branches below never backfill
+    // at all: name resemblance (including a display-materialized transcript
+    // stream that merely carries the `#executionId` suffix, the #8226 class)
+    // is reported, never persisted as identity. The write itself is
+    // best-effort by contract and never throws.
     if (metaMatched.length === 1 && streamId) {
       await writeLegacyExecutionStreamId(executionId, streamId);
     }


### PR DESCRIPTION
## Summary

Stage 4 of #9590: backfill of legacy execution↔stream identity and of execution descriptions must happen only when uniquely provable, never by choosing among candidates. Investigation against current main (post-#9661) found every behavioral rule already holds; this PR is therefore doctrine-made-explicit plus the missing test pins — production changes are comment-only (+18/−3 lines, zero behavior change), with 3 new public-boundary tests and no-backfill assertions added to 2 existing ambiguity tests (+119 test lines).

Findings per sub-item, verified against the diff of #9661 and current main:

1. **Identity backfill hardening — verified already true, now explicit and pinned.** `writeLegacyExecutionStreamId` (the `streamIdSource: LEGACY_RESOLUTION` stamp) has exactly one production caller, inside `resolvePersistedStreamIdForExecution`, guarded by `metaMatched.length === 1 && streamId`: it fires only when exactly one persisted sidecar claims the execution. Every ambiguous resolution (`exactExecutionCandidateStreamIds`, `suffixCandidateStreamIds`, multi-match with a selectable root) and every suffix-only resolution skips backfill. The skip is now stated in a comment at the write site and pinned by tests. The write is best-effort by contract (`persistSupplementaryMetaFieldsBestEffort` never throws).
2. **Description backfill — verified already true, now explicit and pinned.** The only projection is `StreamSnapshotStore.backfillDescriptionsFromExecutionMeta` (private, 2 call sites: `load`/`preload`), and it already runs meta → mirror only, and only when the mirror is absent (`if (!executionId || meta.description) continue`). Nothing anywhere writes `ExecutionMeta.description` from the sidecar mirror (`writeSessionDescription` is the sole meta-description writer, fed only by AI generation in `sessionDescription.ts`). Per the issue's minimality rule, no new machinery was added — the absent-only/authority-direction rule is now the method's documented contract, with tests.
3. **No heuristic root choice — verified already true, no change.** Grep across production code: the only `listPersistedStreams`/`readPersistedStreamAssociation` callers outside the legacy boundary are `SessionStores`' bulk-deletion/orphan-sweep enumeration (Stage 5's charter, not identity resolution); `chatSessionController` reads a single stream's own sidecar (not a scan); `traceAssembler`/`completedRunArchive` consume only resolution-stated `fallbackStreamIds` (empty by proof for registered records). No alternate-root probe remains in any backfill path.
4. **#8226 hazard — verified safe, now pinned.** A display-materialized stream (`StreamLogStore.ensureStream`, ProgressFactApplier paths) has no sidecar and no `runDescriptor.executionId`, so it can never enter the meta-matched set that authorizes backfill; it can only surface via the suffix arm, which never backfills. New test pins exactly this: an `ensureStream`-materialized orphan carrying the `#executionId` suffix resolves for compatibility display but never stamps `LEGACY_RESOLUTION` onto the execution record.

## Issue acceptance gates (#9590 Stage 4)

- **Obligation (7)** — description reconciliation has one winner and is idempotent: two public-boundary tests in `StreamSnapshotStore.vitest.ts`. An absent mirror is filled from meta and a second `load()` runs zero projections (spy-proven no-op); when both sides exist and disagree, neither side is written — meta keeps its authoritative value, the mirror stays display data — and a mirror-only record never backfills meta.
- **Skip-backfill-on-ambiguity** — assertions added to both ambiguity shapes at the resolver boundary (two unproven sidecar roots; two suffix-only candidates): no `streamId` is ever stamped on the execution record.
- **#8226 hazard check** — result: candidate sets already exclude display-materialized streams from provable (meta-matched) backfill by construction; the new orphan-stream test pins that the suffix arm's compatibility resolution never persists identity.

## Single source of truth

`ExecutionMeta.description` is the description authority (A4); the snapshot sidecar `description` is a display-only mirror. Projection direction is meta → mirror, absent-only; disagreement is not reconciled by writing either side. Identity authority is unchanged from Stages 2–3: `ExecutionMeta.streamId` (registration provenance) forward, sidecar `RunDescriptor.executionId` reverse; `LEGACY_RESOLUTION` stamps are minted only from a uniquely-provable sidecar claim.

## Duplication and abstraction budget

Zero new abstractions, helpers, wrappers, or facades. No new machinery for meta-from-mirror backfill (the codebase never had it and the issue forbids inventing it). The production diff is 2 comment blocks at the 2 backfill sites.

## Net elements (R6)

- Public methods/exports added: 0. Removed: 0.
- Production functions added: 0. Production lines: +18/−3, all documentation at the two backfill sites.
- Tests: +3 new `it` blocks, +2 assertions in existing tests, +4 seeded stamp-able meta records so the no-backfill pins can fail (Bugbot finding, fixed in 9afc375308) — +119 lines across 2 suites.

## Consumer counts (R8)

- `writeLegacyExecutionStreamId`: 1 production caller (the boundary's unique-proof branch) — unchanged.
- `backfillDescriptionsFromExecutionMeta`: private, 2 internal call sites (`load`, `preload`) — unchanged.
- `writeSessionDescription`: 1 production caller (`sessionDescription.ts`) — unchanged.

## Host impact

None. All touched files are host-agnostic `src/transcript/` plus centralized tests; extension, desktop, and CLI behavior is byte-identical (production changes are comments).

## Scheduled refactoring

Stage 6 (#9590) stops the duplicate meta → mirror description projection for current records (the mirror then converges to a pure display cache); this PR's contract comment names that handoff at the projection site. Stage 5 gives `SessionStores`' deletion/sweep enumeration its explicit statement; Stage 7 (#9627) deletes the boundary's scan/suffix arms at the dated retirement (≥ 2026-11-01), gated on `LegacyIdentity` warn-log evidence.

## Validation

- `npm run typecheck` — clean.
- `env -u FORCE_COLOR npx vitest run` on both touched suites — 92/92 passed.
- `npm run check:dead-code-ratchet` — 18 findings vs 18 baselined, no widening.
- `npm run format` (prettier) on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
