### PR TITLE
refactor(transcript): stop duplicate description projection for current records

### DIFF
--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -112,9 +112,17 @@ export async function registerExecution(
     readonly streamId: StreamTabId;
     readonly parentExecutionId?: ExecutionId;
     readonly category?: string;
+    /**
+     * Display description persisted on `ExecutionMeta.description` — the one
+     * description authority (#9590 A4). Child-stream launchers pass the
+     * delegated task label here so it is durable at birth; the later
+     * `updateStreamDescription` session event is display-only and no longer
+     * writes a sidecar copy (#9590 Stage 6).
+     */
+    readonly description?: string;
   },
 ): Promise<void> {
-  const { streamId, parentExecutionId, category } = options;
+  const { streamId, parentExecutionId, category, description } = options;
   await acquireFreshExecutionLease(executionId);
   const runWithOwnership = captureOwnedExecutionLease(executionId);
   await runWithOwnership(async () => {
@@ -127,6 +135,7 @@ export async function registerExecution(
         streamIdSource: EXECUTION_STREAM_ID_SOURCE.REGISTRATION,
         parentExecutionId,
         ...(category ? { category } : {}),
+        ...(description ? { description } : {}),
       };
       const persistedConfig = normalizeWriterCategory(
         pinExecutionWorkingDirectory(config),

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -42,7 +42,14 @@ export const StreamTabMetaSchema = z.object({
   runDescriptor: PersistedRunDescriptorSchema.optional(),
   /** Legacy field — read-shimmed from pre-RunDescriptor snapshots only. */
   taskState: z.unknown().optional(),
-  /** AI-generated session description, mirrored from ExecutionMeta. */
+  /**
+   * Legacy field — read-only mirror of `ExecutionMeta.description` (#9590 A4).
+   * Current records stopped writing it in #9590 Stage 6; readers use
+   * ExecutionMeta and fall back to this field only for records whose execution
+   * metadata carries no description (pre-registration records, desktop legacy
+   * imports). Scheduled for deletion in #9590 Stage 7 / #9627 with the
+   * ≥ 2026-11-01 legacy-retirement cohort.
+   */
   description: z.string().optional(),
 });
 

--- a/src/shared/schemas/streamSnapshot.ts
+++ b/src/shared/schemas/streamSnapshot.ts
@@ -96,6 +96,12 @@ export const StreamSnapshotSchema = SharedBackendOwnedFieldsSchema.extend({
   // -- Pointers (resume / lookup) -------------------------------------------
   executionId: ExecutionIdSchema.optional(),
   parentStreamId: StreamTabIdSchema.optional(),
+  /**
+   * Legacy sidecar mirror only (#9590 Stage 6): current records carry their
+   * description on `ExecutionMeta.description` (A4), which display readers use
+   * — e.g. the trace viewer reads `trace.meta.description`. Populated here
+   * only from a legacy sidecar that still holds the retired mirror field.
+   */
   description: z.string().optional(),
 
   // -- Log-derived (recomputed from the StreamLog on load) ------------------

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -460,6 +460,12 @@ describe('executeCliRequest', () => {
       const config = AgentConfigSchema.parse(toolUseConfig());
 
       await getExecutionStore(executionId).writeConfig(config);
+      // Emitter contract (#9590 A4/Stage 6): the authority write to
+      // `ExecutionMeta.description` lands before the display event below.
+      await getExecutionStore(executionId).writeMeta({
+        timestamp: new Date(0).toISOString(),
+        description: 'chat / gpt54',
+      });
       defaultSession().events.emit({
         scope: 'run',
         streamId,
@@ -532,7 +538,14 @@ describe('executeCliRequest', () => {
       cost: 0.5,
     });
     expect(snapshot.executionId).toBe(executionId);
-    expect(snapshot.description).toBe('chat / gpt54');
+    // Current records read the description via ExecutionMeta (#9590 Stage 6);
+    // the snapshot field is the legacy sidecar mirror and stays unwritten.
+    expect(reader.getDescription(streamId)).toBe('chat / gpt54');
+    expect(snapshot.description).toBeUndefined();
+    const { getExecutionStore } = await import('@agent/storage');
+    expect((await getExecutionStore(executionId).readMeta())?.description).toBe(
+      'chat / gpt54',
+    );
     expect(snapshot.parentStreamId).toBe(parentStreamId);
     expect(reader.getRunConfig(streamId)).toMatchObject({
       agent: 'chat',

--- a/src/test-kernel/cli/TranscriptSessionPolicy.vitest.mts
+++ b/src/test-kernel/cli/TranscriptSessionPolicy.vitest.mts
@@ -118,7 +118,12 @@ describe('CLI transcript session policy', () => {
     );
     const orphan = 'orphaned-cli-stream' as StreamTabId;
     const writer = new StreamSnapshotStore();
-    snapshotFacts(writer).setDescription(orphan, 'orphaned sidecar');
+    // Materialize a persisted sidecar via a durable current field;
+    // descriptions are memory-only for current records (#9590 Stage 6).
+    snapshotFacts(writer).setParentStream(
+      orphan,
+      'orphan-parent' as StreamTabId,
+    );
     await writer.flush();
     await expect(writer.listPersistedStreams()).resolves.toEqual([orphan]);
 

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -71,6 +71,7 @@ vi.mock('@utils/files/taskRunStorage', () => ({
 
 vi.mock('@tools/delegation/childStream', () => ({
   createChildStream: mocks.createChildStream,
+  childStreamDescription: (raw: string) => raw,
   getChildStreamId: (executionId: string, prefix: string) =>
     `${prefix}#${executionId}`,
 }));

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -66,6 +66,7 @@ vi.mock('@utils/files/taskRunStorage', () => ({
 
 vi.mock('@tools/delegation/childStream', () => ({
   createChildStream: mocks.createChildStream,
+  childStreamDescription: (raw: string) => raw,
   getChildStreamId: (executionId: string, prefix: string) =>
     `${prefix}#${executionId}`,
 }));

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -61,6 +61,7 @@ vi.mock('@agent/runtime/childRunLoop', () => ({
 
 vi.mock('@tools/delegation/childStream', () => ({
   createRehydratedChildStream: mocks.createRehydratedChildStream,
+  childStreamDescription: (raw: string) => raw,
   getChildStreamId: (executionId: string, prefix: string) =>
     `${prefix}#${executionId}`,
 }));
@@ -336,6 +337,7 @@ describe('WorkflowScriptTool', () => {
       {
         streamId: `workflow-script#${runExecutionId}`,
         parentExecutionId: executionId,
+        description: 'tests the workflow script tool',
       },
     );
     expect(mocks.createRehydratedChildStream).toHaveBeenCalledWith(
@@ -434,6 +436,7 @@ describe('WorkflowScriptTool', () => {
       {
         streamId: `workflow-script#${runExecutionIdFor('edited-tool-test')}`,
         parentExecutionId: executionId,
+        description: 'tests the workflow script tool',
       },
     );
   });
@@ -618,6 +621,7 @@ describe('WorkflowScriptTool', () => {
       {
         streamId: `workflow-script#${runExecutionIdFor('tool-test')}`,
         parentExecutionId: executionId,
+        description: 'tests the workflow script tool',
       },
     );
   });
@@ -661,6 +665,7 @@ describe('WorkflowScriptTool', () => {
       {
         streamId: `workflow-script#${runExecutionIdFor('tool-test')}`,
         parentExecutionId: executionId,
+        description: 'tests the workflow script tool',
       },
     );
   });
@@ -722,6 +727,7 @@ describe('WorkflowScriptTool', () => {
       {
         streamId: `workflow-script#${runExecutionIdFor('resume')}`,
         parentExecutionId: executionId,
+        description: 'tests the workflow script tool',
       },
     );
   });

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1028,6 +1028,78 @@ describe('StreamSnapshotStore', () => {
     );
   });
 
+  it('does not resurrect a stream evicted during description hydration', async () => {
+    await installPlatform();
+    const executionId = 'bb33dd44' as ExecutionId;
+    const executionStore = getExecutionStore(executionId);
+    await executionStore.writeConfig(toolUseConfig());
+    await executionStore.writeMeta({
+      timestamp: new Date(0).toISOString(),
+      description: 'Late authority label',
+    });
+    await writeMetaFile(STREAM, { executionId });
+    const persistedMeta = await executionStore.readMeta();
+    const readStarted = pDefer<void>();
+    const deferredRead = pDefer<typeof persistedMeta>();
+    vi.spyOn(executionStore, 'readMeta').mockImplementation(() => {
+      readStarted.resolve();
+      return deferredRead.promise;
+    });
+
+    const store = new StreamSnapshotStore();
+    const loading = store.load([STREAM]);
+    await readStarted.promise;
+    await store.deleteStream(STREAM);
+    deferredRead.resolve(persistedMeta);
+    await loading;
+
+    expect(store.getDescription(STREAM)).toBeUndefined();
+    await expect(store.listPersistedStreams()).resolves.not.toContain(STREAM);
+  });
+
+  it('hydrates independent execution descriptions concurrently', async () => {
+    await installPlatform();
+    const firstExecutionId = 'cc44ee55' as ExecutionId;
+    const secondExecutionId = 'dd55ff66' as ExecutionId;
+    const firstExecutionStore = getExecutionStore(firstExecutionId);
+    const secondExecutionStore = getExecutionStore(secondExecutionId);
+    await firstExecutionStore.writeConfig(toolUseConfig());
+    await secondExecutionStore.writeConfig(toolUseConfig());
+    await firstExecutionStore.writeMeta({
+      timestamp: new Date(0).toISOString(),
+      description: 'First authority label',
+    });
+    await secondExecutionStore.writeMeta({
+      timestamp: new Date(0).toISOString(),
+      description: 'Second authority label',
+    });
+    await writeMetaFile(STREAM, { executionId: firstExecutionId });
+    await writeMetaFile(OTHER_STREAM, { executionId: secondExecutionId });
+    const firstMeta = await firstExecutionStore.readMeta();
+    const secondMeta = await secondExecutionStore.readMeta();
+    const firstRead = pDefer<typeof firstMeta>();
+    const secondRead = pDefer<typeof secondMeta>();
+    const firstReadSpy = vi
+      .spyOn(firstExecutionStore, 'readMeta')
+      .mockReturnValue(firstRead.promise);
+    const secondReadSpy = vi
+      .spyOn(secondExecutionStore, 'readMeta')
+      .mockReturnValue(secondRead.promise);
+
+    const store = new StreamSnapshotStore();
+    const loading = store.load([STREAM, OTHER_STREAM]);
+    await vi.waitFor(() => {
+      expect(firstReadSpy).toHaveBeenCalledOnce();
+      expect(secondReadSpy).toHaveBeenCalledOnce();
+    });
+    firstRead.resolve(firstMeta);
+    secondRead.resolve(secondMeta);
+    await loading;
+
+    expect(store.getDescription(STREAM)).toBe('First authority label');
+    expect(store.getDescription(OTHER_STREAM)).toBe('Second authority label');
+  });
+
   it('resolves description disagreement to ExecutionMeta and never writes either side (#9590 A4)', async () => {
     await installPlatform();
     // Both sides present and disagreeing: the display serves the authority

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1057,6 +1057,130 @@ describe('StreamSnapshotStore', () => {
     await expect(store.listPersistedStreams()).resolves.not.toContain(STREAM);
   });
 
+  it('does not apply an authority read across an execution handoff', async () => {
+    await installPlatform();
+    const oldExecutionId = 'ee66aa77' as ExecutionId;
+    const newExecutionId = 'ff77bb88' as ExecutionId;
+    const oldExecutionStore = getExecutionStore(oldExecutionId);
+    await oldExecutionStore.writeConfig(toolUseConfig('old-search'));
+    await oldExecutionStore.writeMeta({
+      timestamp: new Date(0).toISOString(),
+      description: 'Old authority label',
+    });
+    await writeMetaFile(STREAM, { executionId: oldExecutionId });
+    const oldMeta = await oldExecutionStore.readMeta();
+    const readStarted = pDefer<void>();
+    const deferredRead = pDefer<typeof oldMeta>();
+    vi.spyOn(oldExecutionStore, 'readMeta').mockImplementation(() => {
+      readStarted.resolve();
+      return deferredRead.promise;
+    });
+
+    const store = new StreamSnapshotStore();
+    const facts = snapshotFacts(store);
+    const loading = store.load([STREAM]);
+    await readStarted.promise;
+    const newDescriptor = buildRunDescriptor({
+      streamId: STREAM,
+      executionId: newExecutionId,
+      agent: 'new-search',
+      category: AgentCategory.ToolUse,
+      kind: 'agent',
+    });
+    facts.setRunDescriptor(newDescriptor);
+    deferredRead.resolve(oldMeta);
+    await loading;
+
+    expect(store.getRunDescriptor(STREAM)).toEqual(newDescriptor);
+    expect(store.getDescription(STREAM)).toBeUndefined();
+  });
+
+  it('does not overwrite a live description that lands during hydration', async () => {
+    await installPlatform();
+    const executionId = 'aa77cc88' as ExecutionId;
+    const executionStore = getExecutionStore(executionId);
+    await executionStore.writeConfig(toolUseConfig());
+    await executionStore.writeMeta({
+      timestamp: new Date(0).toISOString(),
+      description: 'Captured authority label',
+    });
+    await writeMetaFile(STREAM, { executionId });
+    const capturedMeta = await executionStore.readMeta();
+    const readStarted = pDefer<void>();
+    const deferredRead = pDefer<typeof capturedMeta>();
+    vi.spyOn(executionStore, 'readMeta').mockImplementation(() => {
+      readStarted.resolve();
+      return deferredRead.promise;
+    });
+
+    const store = new StreamSnapshotStore();
+    const facts = snapshotFacts(store);
+    const loading = store.load([STREAM]);
+    await readStarted.promise;
+    facts.setDescription(STREAM, 'New live label');
+    deferredRead.resolve(capturedMeta);
+    await loading;
+
+    expect(store.getDescription(STREAM)).toBe('New live label');
+  });
+
+  it('hydrates a current no-mirror description during first lazy seed', async () => {
+    await installPlatform();
+    const executionId = 'bb88dd99' as ExecutionId;
+    await getExecutionStore(executionId).writeConfig(toolUseConfig());
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: new Date(0).toISOString(),
+      description: 'Lazy authority label',
+    });
+    await writeMetaFile(STREAM, { executionId });
+
+    const store = new StreamSnapshotStore();
+    snapshotFacts(store).setParentStream(STREAM, OTHER_STREAM);
+    await store.flush();
+
+    expect(store.getDescription(STREAM)).toBe('Lazy authority label');
+    expect(
+      ((await readStreamFile(STREAM, 'meta.json')) as { description?: unknown })
+        .description,
+    ).toBeUndefined();
+  });
+
+  it('does not expose a prior execution mirror after a handoff', async () => {
+    await installPlatform();
+    const oldExecutionId = 'cc99ee00' as ExecutionId;
+    const newExecutionId = 'dd00ff11' as ExecutionId;
+    await getExecutionStore(oldExecutionId).writeConfig(
+      toolUseConfig('old-search'),
+    );
+    await getExecutionStore(newExecutionId).writeConfig(
+      toolUseConfig('new-search'),
+    );
+    await getExecutionStore(newExecutionId).writeMeta({
+      timestamp: new Date(0).toISOString(),
+    });
+    await writeMetaFile(STREAM, {
+      executionId: oldExecutionId,
+      description: 'Old mirror label',
+    });
+
+    const store = new StreamSnapshotStore();
+    await store.load([STREAM]);
+    expect(store.getDescription(STREAM)).toBe('Old mirror label');
+
+    await writeMetaFile(STREAM, {
+      executionId: newExecutionId,
+      description: 'Old mirror label',
+    });
+    await store.load([STREAM]);
+
+    expect(store.getExecutionId(STREAM)).toBe(newExecutionId);
+    expect(store.getDescription(STREAM)).toBeUndefined();
+    expect(
+      ((await readStreamFile(STREAM, 'meta.json')) as { description?: unknown })
+        .description,
+    ).toBe('Old mirror label');
+  });
+
   it('hydrates independent execution descriptions concurrently', async () => {
     await installPlatform();
     const firstExecutionId = 'cc44ee55' as ExecutionId;
@@ -1098,6 +1222,65 @@ describe('StreamSnapshotStore', () => {
 
     expect(store.getDescription(STREAM)).toBe('First authority label');
     expect(store.getDescription(OTHER_STREAM)).toBe('Second authority label');
+  });
+
+  it('bounds concurrent description reads to the seed I/O cap', async () => {
+    await installPlatform();
+    const streamIds = Array.from(
+      { length: 9 },
+      (_, index) => `bounded-stream-${index}` as StreamTabId,
+    );
+    const executionIds = Array.from(
+      { length: 9 },
+      (_, index) => `b0ded00${index}` as ExecutionId,
+    );
+    const executionStores = executionIds.map((executionId) =>
+      getExecutionStore(executionId),
+    );
+    for (const [index, executionStore] of executionStores.entries()) {
+      await executionStore.writeConfig(toolUseConfig());
+      await executionStore.writeMeta({
+        timestamp: new Date(0).toISOString(),
+        description: `Authority label ${index}`,
+      });
+      await writeMetaFile(streamIds[index]!, {
+        executionId: executionIds[index],
+      });
+    }
+    const metas = await Promise.all(
+      executionStores.map((executionStore) => executionStore.readMeta()),
+    );
+    const reads = metas.map((meta) => pDefer<typeof meta>());
+    let activeReads = 0;
+    let maximumActiveReads = 0;
+    let startedReads = 0;
+    for (const [index, executionStore] of executionStores.entries()) {
+      vi.spyOn(executionStore, 'readMeta').mockImplementation(async () => {
+        activeReads++;
+        startedReads++;
+        maximumActiveReads = Math.max(maximumActiveReads, activeReads);
+        const meta = await reads[index]!.promise;
+        activeReads--;
+        return meta;
+      });
+    }
+
+    const store = new StreamSnapshotStore();
+    const loading = store.load(streamIds);
+    await vi.waitFor(() => expect(startedReads).toBe(8));
+    expect(activeReads).toBe(8);
+    expect(maximumActiveReads).toBe(8);
+
+    reads[0]!.resolve(metas[0]);
+    await vi.waitFor(() => expect(startedReads).toBe(9));
+    expect(maximumActiveReads).toBe(8);
+    for (const [index, read] of reads.entries()) {
+      if (index !== 0) read.resolve(metas[index]);
+    }
+    await loading;
+
+    expect(maximumActiveReads).toBe(8);
+    expect(store.getDescription(streamIds[8]!)).toBe('Authority label 8');
   });
 
   it('resolves description disagreement to ExecutionMeta and never writes either side (#9590 A4)', async () => {
@@ -1200,6 +1383,19 @@ describe('StreamSnapshotStore', () => {
     const reloaded = new StreamSnapshotStore();
     await reloaded.load([STREAM]);
     expect(reloaded.getDescription(STREAM)).toBe('Current label');
+
+    // The label is execution-scoped: a live run.start handing the stream to a
+    // new execution synchronously drops the previous run's description.
+    snapshotFacts(reloaded).setRunDescriptor(
+      buildRunDescriptor({
+        streamId: STREAM,
+        executionId: 'bb77bb88' as ExecutionId,
+        agent: 'search',
+        category: AgentCategory.ToolUse,
+        kind: 'agent',
+      }),
+    );
+    expect(reloaded.getDescription(STREAM)).toBeUndefined();
   });
 
   it('keeps a runtime run-config update that arrives during async hydration', async () => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -297,6 +297,12 @@ describe('StreamSnapshotStore', () => {
     };
 
     await getExecutionStore(executionId).writeConfig(runConfig);
+    // Emitter contract for `updateStreamDescription` (#9590 A4/Stage 6): the
+    // authority write to `ExecutionMeta.description` lands before the event.
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: new Date(0).toISOString(),
+      description: 'session-search / kimi26T',
+    });
 
     events.emit({
       scope: 'run',
@@ -429,7 +435,13 @@ describe('StreamSnapshotStore', () => {
     expect(snap.runUsage[RUN]).not.toHaveProperty('reasoningTokens');
     expect(snap.runUsage[RUN]).not.toHaveProperty('toolUseTokens');
     expect(snap.executionId).toBe(executionId);
-    expect(snap.description).toBe('session-search / kimi26T');
+    // The live event updated the writer's display value in memory only.
+    expect(writer.getDescription(STREAM)).toBe('session-search / kimi26T');
+    // A fresh load serves the description from ExecutionMeta (the authority);
+    // the snapshot's `description` is the legacy sidecar mirror, which current
+    // records no longer write (#9590 Stage 6).
+    expect(reader.getDescription(STREAM)).toBe('session-search / kimi26T');
+    expect(snap.description).toBeUndefined();
     expect(snap.parentStreamId).toBe(OTHER_STREAM);
     expect(reader.getRunConfig(STREAM)).toEqual(runConfig);
     expect(reader.getRunDescriptor(STREAM)).toMatchObject({
@@ -895,35 +907,45 @@ describe('StreamSnapshotStore', () => {
     await store.load([STREAM]);
     expect(store.getDescription(STREAM)).toBeUndefined();
 
-    snapshotFacts(store).setDescription(STREAM, 'Updated session');
-    await store.flush();
-
-    const raw = await readStreamFile(STREAM, 'meta.json');
-    expect(raw).toMatchObject({
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
-      description: 'Updated session',
-    });
-  });
-
-  it('preserves legacy meta taskState when unrelated meta patches are written', async () => {
-    await installPlatform();
-    const taskState = toolUseTaskState('legacy-search');
-    await writeMetaFile(STREAM, {
-      taskState,
-    });
-
-    const store = new StreamSnapshotStore();
-    await store.load([STREAM]);
-    snapshotFacts(store).setDescription(STREAM, 'Prior session');
+    snapshotFacts(store).setParentStream(STREAM, OTHER_STREAM);
     await store.flush();
 
     const raw = (await readStreamFile(STREAM, 'meta.json')) as {
       schemaVersion?: unknown;
+      parentStreamId?: unknown;
+      description?: unknown;
+    };
+    expect(raw.schemaVersion).toBe(RUN_DESCRIPTOR_SCHEMA_VERSION);
+    expect(raw.parentStreamId).toBe(OTHER_STREAM);
+    // The rejected file's fields do not leak into the fresh current record.
+    expect(raw.description).toBeUndefined();
+  });
+
+  it('preserves legacy meta taskState and description when unrelated meta patches are written', async () => {
+    await installPlatform();
+    const taskState = toolUseTaskState('legacy-search');
+    await writeMetaFile(STREAM, {
+      taskState,
+      description: 'Prior session',
+    });
+
+    const store = new StreamSnapshotStore();
+    await store.load([STREAM]);
+    snapshotFacts(store).setParentStream(STREAM, OTHER_STREAM);
+    await store.flush();
+
+    // Rewriting an unrelated meta field round-trips the LEGACY description
+    // (#9590 Stage 6: never patched for current records, never destroyed for
+    // legacy sidecars before their Stage 7 retirement).
+    const raw = (await readStreamFile(STREAM, 'meta.json')) as {
+      schemaVersion?: unknown;
       taskState?: unknown;
+      parentStreamId?: unknown;
       description?: unknown;
     };
     expect(raw.schemaVersion).toBe(RUN_DESCRIPTOR_SCHEMA_VERSION);
     expect(raw.taskState).toEqual(taskState);
+    expect(raw.parentStreamId).toBe(OTHER_STREAM);
     expect(raw.description).toBe('Prior session');
   });
 
@@ -974,7 +996,7 @@ describe('StreamSnapshotStore', () => {
     expect((await store.read(STREAM)).executionId).toBe(executionId);
   });
 
-  it('backfills an absent description mirror from ExecutionMeta and is a no-op once present (#9590 Stage 4)', async () => {
+  it('serves a current record description from ExecutionMeta without writing a sidecar mirror (#9590 Stage 6)', async () => {
     await installPlatform();
     const executionId = 'aa22cc33' as ExecutionId;
     await getExecutionStore(executionId).writeConfig(toolUseConfig());
@@ -984,33 +1006,32 @@ describe('StreamSnapshotStore', () => {
     });
     await writeMetaFile(STREAM, { executionId });
 
+    // Every load hydrates the display value from the authority and never
+    // projects a sidecar description copy — pinned at the persistence
+    // boundary: no sidecar meta write may be issued.
     const store = new StreamSnapshotStore();
+    const kvWrites = vi.spyOn(KVStore.prototype, 'write');
     await store.load([STREAM]);
     expect(store.getDescription(STREAM)).toBe('Meta authority label');
     await store.flush();
-
-    // Reconciliation is idempotent: with the mirror present, a second load
-    // runs no projection at all and both sides keep their values. Pinned at
-    // the persistence boundary: no sidecar meta write may be issued.
-    const reloaded = new StreamSnapshotStore();
-    const kvWrites = vi.spyOn(KVStore.prototype, 'write');
-    await reloaded.load([STREAM]);
-    expect(reloaded.getDescription(STREAM)).toBe('Meta authority label');
-    await reloaded.flush();
     expect(kvWrites).not.toHaveBeenCalledWith(
       STREAM_DATA_KEYS.META,
       expect.anything(),
     );
     kvWrites.mockRestore();
+    const raw = (await readStreamFile(STREAM, 'meta.json')) as {
+      description?: unknown;
+    };
+    expect(raw.description).toBeUndefined();
     expect((await getExecutionStore(executionId).readMeta())?.description).toBe(
       'Meta authority label',
     );
   });
 
-  it('reconciles description disagreement with one winner and never writes meta from the mirror (#9590 A4)', async () => {
+  it('resolves description disagreement to ExecutionMeta and never writes either side (#9590 A4)', async () => {
     await installPlatform();
-    // Both sides present and disagreeing: meta stays the authority, the
-    // mirror stays display data, and neither side is rewritten.
+    // Both sides present and disagreeing: the display serves the authority
+    // (ExecutionMeta) and neither persisted side is rewritten.
     const described = 'aa33dd44' as ExecutionId;
     await getExecutionStore(described).writeConfig(toolUseConfig());
     await getExecutionStore(described).writeMeta({
@@ -1023,7 +1044,8 @@ describe('StreamSnapshotStore', () => {
     });
 
     // Mirror-only: the authoritative side is absent and must stay absent —
-    // the display mirror is never a backfill source for ExecutionMeta.
+    // the display mirror is never a backfill source for ExecutionMeta, and it
+    // keeps serving reads as the legacy compatibility fallback.
     const undescribed = 'aa44ee55' as ExecutionId;
     await getExecutionStore(undescribed).writeConfig(toolUseConfig());
     await getExecutionStore(undescribed).writeMeta({
@@ -1038,14 +1060,74 @@ describe('StreamSnapshotStore', () => {
     await store.load([STREAM, OTHER_STREAM]);
     await store.flush();
 
-    expect(store.getDescription(STREAM)).toBe('Stale mirror label');
+    expect(store.getDescription(STREAM)).toBe('Meta authority label');
     expect((await getExecutionStore(described).readMeta())?.description).toBe(
       'Meta authority label',
     );
+    // The stale legacy mirror stays on disk untouched until Stage 7 retires it.
+    expect(
+      ((await readStreamFile(STREAM, 'meta.json')) as { description?: unknown })
+        .description,
+    ).toBe('Stale mirror label');
     expect(store.getDescription(OTHER_STREAM)).toBe('Mirror-only label');
     expect(
       (await getExecutionStore(undescribed).readMeta())?.description,
     ).toBeUndefined();
+  });
+
+  it("round-trips a current record's description through ExecutionMeta only (#9590 Stage 6)", async () => {
+    await installPlatform();
+    const events = new SessionEventHub();
+    const store = new StreamSnapshotStore();
+    const detach = store.attachSessionEvents(events);
+    const executionId = 'aa55ff66' as ExecutionId;
+    const runConfig = toolUseConfig();
+    await getExecutionStore(executionId).writeConfig(runConfig);
+
+    events.emit({
+      scope: 'run',
+      streamId: STREAM,
+      event: {
+        type: 'run.start',
+        descriptor: buildRunDescriptor({
+          streamId: STREAM,
+          executionId,
+          agent: 'search',
+          category: AgentCategory.ToolUse,
+          kind: 'agent',
+        }),
+      },
+    });
+    // Emitter contract (#9590 A4): the authority write to
+    // `ExecutionMeta.description` lands before the display event is emitted.
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: new Date(0).toISOString(),
+      description: 'Current label',
+    });
+    events.emit({
+      scope: 'session',
+      event: {
+        type: 'updateStreamDescription',
+        payload: { streamId: STREAM, description: 'Current label' },
+      },
+    });
+    expect(store.getDescription(STREAM)).toBe('Current label');
+    detach();
+    await store.flush();
+
+    // Persistence boundary: the sidecar meta carries the descriptor reverse
+    // edge but no description copy — the sidecar write stopped in Stage 6.
+    const raw = (await readStreamFile(STREAM, 'meta.json')) as {
+      runDescriptor?: { executionId?: unknown };
+      description?: unknown;
+    };
+    expect(raw.runDescriptor).toMatchObject({ executionId });
+    expect(raw.description).toBeUndefined();
+
+    // A fresh store reads the description back via descriptor → ExecutionMeta.
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getDescription(STREAM)).toBe('Current label');
   });
 
   it('keeps a runtime run-config update that arrives during async hydration', async () => {

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -37,6 +37,7 @@ import { generateExecutionId } from '@utils/core';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 import {
+  childStreamDescription,
   createChildStream,
   getChildStreamId,
   type ChildStream,
@@ -196,6 +197,7 @@ export async function launchAgentCliSession(
     await registerExecution(executionId, params.config, params.agentName, {
       streamId: childStreamId,
       parentExecutionId: params.parentExecutionId,
+      description: childStreamDescription(params.description),
     });
   } catch {
     throw new ToolError(params.registerFailedMessage);

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -54,6 +54,7 @@ import { appendHead, appendTail } from '@utils/text/appendTail';
 // Local file imports
 import { defineTool } from './core/define';
 import {
+  childStreamDescription,
   createChildStream,
   getChildStreamId,
   type ChildStream,
@@ -415,6 +416,7 @@ export class BashTool extends defineTool({
       streamId: getChildStreamId(executionId, BASH_CHILD_STREAM_PREFIX),
       parentExecutionId,
       category: 'process',
+      description: childStreamDescription(command),
     });
     const runWithOwnership = captureOwnedExecutionLease(executionId);
 

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -37,7 +37,11 @@ import { errorResult } from '@tools/core/result';
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { deriveExecutionId } from '@utils/core/idHash';
-import { createRehydratedChildStream, getChildStreamId } from './childStream';
+import {
+  childStreamDescription,
+  createRehydratedChildStream,
+  getChildStreamId,
+} from './childStream';
 
 // Local file imports
 import { createWorkflowScriptAgentRunner } from './workflowScriptAgentRunner';
@@ -367,6 +371,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
       await registerExecution(runExecutionId, runConfig, meta.name, {
         streamId: getChildStreamId(runExecutionId, STREAM_PREFIX),
         parentExecutionId: runScope.executionId,
+        description: childStreamDescription(meta.description),
       });
     } catch (error) {
       // A relaunch whose prior run is still in flight shares this deterministic

--- a/src/tools/delegation/childStream.ts
+++ b/src/tools/delegation/childStream.ts
@@ -87,6 +87,17 @@ export function getChildStreamId(
   return `${streamPrefix}#${executionId}` as StreamTabId;
 }
 
+/**
+ * Normalize a child task's raw label to the ≤80-char display description.
+ * Single owner of that cap for both the durable authority write
+ * (`registerExecution`'s `description` → `ExecutionMeta.description`, #9590
+ * A4) and the display-only `updateStreamDescription` event below, so the
+ * persisted and live values can never drift.
+ */
+export function childStreamDescription(raw: string): string {
+  return truncateWithEllipsis(raw, 80);
+}
+
 /** Create a child stream tab and execution handle for a background child task. */
 export function createChildStream(
   executionId: ExecutionId,
@@ -128,7 +139,9 @@ export function createChildStream(
       executionId,
       config: options.config,
     });
-    const description = truncateWithEllipsis(options.description, 80);
+    // Display-only fan-out: the durable copy is `ExecutionMeta.description`,
+    // written by `registerExecution` before this stream exists (#9590 Stage 6).
+    const description = childStreamDescription(options.description);
     session.events.emit({
       scope: 'session',
       event: {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -285,6 +285,16 @@ interface StreamRecord {
    */
   runDescriptor: RunDescriptor | undefined;
   runConfig: AgentConfig | undefined;
+  /**
+   * Display description projected from the authority,
+   * `ExecutionMeta.description` (#9590 A4): set by the live
+   * `updateStreamDescription` session event (whose emitters persist to
+   * ExecutionMeta first) or by load-time hydration from ExecutionMeta.
+   * In-memory only — never written to the stream sidecar; the persisted
+   * `meta.description` sidecar field is a legacy mirror that current records
+   * no longer write (#9590 Stage 6).
+   */
+  description: string | undefined;
 
   // -- Lazy seeding: a stream's existing disk data is read into memory BEFORE
   // the first mutation so an accumulate/merge can't overwrite unloaded disk
@@ -357,6 +367,7 @@ export class StreamSnapshotStore {
     meta: undefined,
     runDescriptor: undefined,
     runConfig: undefined,
+    description: undefined,
     seeded: false,
     seedChain: undefined,
     seedRefreshGeneration: 0,
@@ -1464,8 +1475,11 @@ export class StreamSnapshotStore {
 
   private writeMeta(stream: StreamTabId, next: StreamTabMeta): void {
     // Persist every explicitly-set field (`!== undefined`, not falsy) so
-    // on-disk and in-memory never diverge
-    // — e.g. clearing a description to "" must round-trip, not silently vanish.
+    // on-disk and in-memory never diverge. `description` is never patched for
+    // current records anymore (#9590 Stage 6: the authority is
+    // `ExecutionMeta.description`); its spread below only round-trips a value
+    // a LEGACY sidecar already carried, so rewriting an unrelated meta field
+    // cannot destroy legacy display data before its Stage 7 retirement.
     const file: StreamTabMeta = {
       schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
       ...(next.runDescriptor !== undefined && {
@@ -1555,8 +1569,14 @@ export class StreamSnapshotStore {
     this.queueMetaPatch(child, { parentStreamId: parent ?? undefined });
   }
 
+  /**
+   * Record the display description in memory only (#9590 Stage 6). The
+   * authority is `ExecutionMeta.description` (A4), which the event's emitters
+   * persist before emitting — this store never writes a sidecar description
+   * copy for current records.
+   */
   private setDescription(stream: StreamTabId, description: string): void {
-    this.queueMetaPatch(stream, { description });
+    this.getOrCreateRecord(stream).description = description;
   }
 
   getRunDescriptor(stream: StreamTabId): RunDescriptor | undefined {
@@ -1629,8 +1649,17 @@ export class StreamSnapshotStore {
     return this.records.get(stream)?.meta?.parentStreamId;
   }
 
+  /**
+   * The stream's display description. Current records serve the value
+   * projected from `ExecutionMeta.description` (the authority, #9590 A4) —
+   * live event or load-time hydration. The persisted sidecar `description`
+   * is read only as the legacy compatibility fallback for records whose
+   * execution metadata carries no description (pre-registration records,
+   * desktop legacy imports; retired with the sidecar field in Stage 7).
+   */
   getDescription(stream: StreamTabId): string | undefined {
-    return this.records.get(stream)?.meta?.description;
+    const record = this.records.get(stream);
+    return record?.description ?? record?.meta?.description;
   }
 
   /** Read-only view of stream→executionId for waiting-stream detection. */
@@ -1966,7 +1995,7 @@ export class StreamSnapshotStore {
     this.evictStreamsExcept(new Set(streamIds));
     await this.seedStreams(streamIds);
     this.hasAuthoritativeStreamSet = true;
-    await this.backfillDescriptionsFromExecutionMeta();
+    await this.hydrateDescriptionsFromExecutionMeta();
   }
 
   /**
@@ -1977,7 +2006,7 @@ export class StreamSnapshotStore {
    */
   async preload(streamIds: readonly StreamTabId[]): Promise<void> {
     await this.seedStreams(streamIds);
-    await this.backfillDescriptionsFromExecutionMeta();
+    await this.hydrateDescriptionsFromExecutionMeta();
   }
 
   private async seedStreams(streamIds: readonly StreamTabId[]): Promise<void> {
@@ -2151,6 +2180,10 @@ export class StreamSnapshotStore {
     if (!meta || record.runDescriptor?.executionId !== executionId) {
       record.runDescriptor = undefined;
       record.runConfig = undefined;
+      // The display description belongs to the execution it was projected
+      // from (#9590 Stage 6); when identity changes hands, drop it with the
+      // pair — hydration re-reads the named execution's ExecutionMeta.
+      record.description = undefined;
     }
     if (meta) {
       const pendingLiveWrite = metaOverlay !== undefined;
@@ -2269,31 +2302,28 @@ export class StreamSnapshotStore {
   }
 
   /**
-   * One-time legacy convergence toward the description authority (#9590 A4):
-   * `ExecutionMeta.description` is authoritative and the sidecar `description`
-   * is a display-only mirror, so projection runs meta → mirror only, and only
-   * when the mirror is absent. A present mirror value is never overwritten —
-   * disagreement is not reconciled by writing either side; meta simply stays
-   * the authority and the mirror stays display data — and nothing anywhere
-   * writes `ExecutionMeta.description` from the mirror. Persisting the filled
-   * mirror lets future loads skip the extra I/O. Stage 6 (#9590) stops this
-   * duplicate projection for current records.
+   * Hydrate in-memory display descriptions from the authority,
+   * `ExecutionMeta.description` (#9590 A4/Stage 6). Read-only projection:
+   * nothing is persisted in either direction — the sidecar `description`
+   * mirror is no longer written for current records, and nothing anywhere
+   * writes `ExecutionMeta.description` from the mirror. A record whose
+   * execution metadata is absent or carries no description keeps serving the
+   * persisted sidecar value through {@link getDescription}'s legacy fallback.
    */
-  private async backfillDescriptionsFromExecutionMeta(): Promise<void> {
+  private async hydrateDescriptionsFromExecutionMeta(): Promise<void> {
     for (const [streamId, record] of [...this.records]) {
-      const meta = record.meta;
-      const executionId = meta?.runDescriptor?.executionId;
-      if (!executionId || meta.description) continue;
+      const executionId = record.meta?.runDescriptor?.executionId;
+      if (!executionId) continue;
       try {
         const execMeta = await getExecutionStore(executionId).readMeta();
         if (execMeta?.description) {
           this.setDescription(streamId, execMeta.description);
         }
       } catch (err) {
-        // Best-effort; a missing/corrupt execution store just skips backfill.
+        // Best-effort; a missing/corrupt execution store just skips hydration.
         logger.debug(
           CHANNEL,
-          `Skipping description backfill for stream ${streamId}`,
+          `Skipping description hydration for stream ${streamId}`,
           { data: err },
         );
       }

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -2311,22 +2311,28 @@ export class StreamSnapshotStore {
    * persisted sidecar value through {@link getDescription}'s legacy fallback.
    */
   private async hydrateDescriptionsFromExecutionMeta(): Promise<void> {
-    for (const [streamId, record] of [...this.records]) {
-      const executionId = record.meta?.runDescriptor?.executionId;
-      if (!executionId) continue;
-      try {
-        const execMeta = await getExecutionStore(executionId).readMeta();
-        if (execMeta?.description) {
-          this.setDescription(streamId, execMeta.description);
+    await Promise.all(
+      [...this.records].map(async ([streamId, record]) => {
+        const executionId = record.meta?.runDescriptor?.executionId;
+        if (!executionId) return;
+        try {
+          const execMeta = await getExecutionStore(executionId).readMeta();
+          // The reads are independent, so run them concurrently. Revalidate
+          // the captured record after the await: re-resolving through
+          // `setDescription` would recreate a stream evicted in flight (#8226).
+          if (this.records.get(streamId) !== record) return;
+          if (execMeta?.description) {
+            record.description = execMeta.description;
+          }
+        } catch (err) {
+          // Best-effort; a missing/corrupt execution store just skips hydration.
+          logger.debug(
+            CHANNEL,
+            `Skipping description hydration for stream ${streamId}`,
+            { data: err },
+          );
         }
-      } catch (err) {
-        // Best-effort; a missing/corrupt execution store just skips hydration.
-        logger.debug(
-          CHANNEL,
-          `Skipping description hydration for stream ${streamId}`,
-          { data: err },
-        );
-      }
-    }
+      }),
+    );
   }
 }

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -295,6 +295,8 @@ interface StreamRecord {
    * no longer write (#9590 Stage 6).
    */
   description: string | undefined;
+  /** Invalidates authority reads captured before a live update or handoff. */
+  descriptionRevision: number;
 
   // -- Lazy seeding: a stream's existing disk data is read into memory BEFORE
   // the first mutation so an accumulate/merge can't overwrite unloaded disk
@@ -368,6 +370,7 @@ export class StreamSnapshotStore {
     runDescriptor: undefined,
     runConfig: undefined,
     description: undefined,
+    descriptionRevision: 0,
     seeded: false,
     seedChain: undefined,
     seedRefreshGeneration: 0,
@@ -1523,6 +1526,14 @@ export class StreamSnapshotStore {
     executionId?: ExecutionId,
   ): void {
     const record = this.getOrCreateRecord(stream);
+    if (
+      executionId &&
+      record.runDescriptor &&
+      record.runDescriptor.executionId !== executionId
+    ) {
+      record.description = undefined;
+      record.descriptionRevision++;
+    }
     record.runConfig = config;
     // Synthesize an identity only for a run that never emitted `run.start`
     // (legacy meta, hosts driving the store by hand). A descriptor left over
@@ -1555,6 +1566,8 @@ export class StreamSnapshotStore {
     const previous = record.runDescriptor;
     if (previous && previous.executionId !== descriptor.executionId) {
       record.runConfig = undefined;
+      record.description = undefined;
+      record.descriptionRevision++;
     }
     record.runDescriptor = descriptor;
     this.queueMetaPatch(stream, {
@@ -1576,7 +1589,9 @@ export class StreamSnapshotStore {
    * copy for current records.
    */
   private setDescription(stream: StreamTabId, description: string): void {
-    this.getOrCreateRecord(stream).description = description;
+    const record = this.getOrCreateRecord(stream);
+    record.description = description;
+    record.descriptionRevision++;
   }
 
   getRunDescriptor(stream: StreamTabId): RunDescriptor | undefined {
@@ -1654,12 +1669,18 @@ export class StreamSnapshotStore {
    * projected from `ExecutionMeta.description` (the authority, #9590 A4) —
    * live event or load-time hydration. The persisted sidecar `description`
    * is read only as the legacy compatibility fallback for records whose
-   * execution metadata carries no description (pre-registration records,
-   * desktop legacy imports; retired with the sidecar field in Stage 7).
+   * execution metadata carries no description, unless this resident record
+   * has observed an execution handoff (the mirror then belongs to the prior
+   * execution). Retired with the sidecar field in Stage 7.
    */
   getDescription(stream: StreamTabId): string | undefined {
     const record = this.records.get(stream);
-    return record?.description ?? record?.meta?.description;
+    return (
+      record?.description ??
+      (!record?.runDescriptor || record.descriptionRevision === 0
+        ? record?.meta?.description
+        : undefined)
+    );
   }
 
   /** Read-only view of stream→executionId for waiting-stream detection. */
@@ -2036,7 +2057,7 @@ export class StreamSnapshotStore {
       this.invalidateKvHandles(stream);
       const data = await readStreamData(this.kv(stream));
       if (this.streamVersion(stream) !== version) return;
-      await this.applyStreamData(stream, data);
+      await this.applyStreamData(stream, data, false);
     });
     const next = work.then(
       () => {
@@ -2138,6 +2159,7 @@ export class StreamSnapshotStore {
   private async applyStreamData(
     stream: StreamTabId,
     data: StreamData,
+    hydrateDescription = true,
   ): Promise<void> {
     const version = this.streamVersion(stream);
     const record = this.getOrCreateRecord(stream);
@@ -2177,13 +2199,15 @@ export class StreamSnapshotStore {
     // deleted stream and defeat `writeMergedSidecars`' eviction check (#8226);
     // an orphaned `record` is mutated harmlessly and never written.
     const executionId = meta?.runDescriptor?.executionId;
-    if (!meta || record.runDescriptor?.executionId !== executionId) {
+    const previousExecutionId = record.runDescriptor?.executionId;
+    if (!meta || previousExecutionId !== executionId) {
       record.runDescriptor = undefined;
       record.runConfig = undefined;
       // The display description belongs to the execution it was projected
       // from (#9590 Stage 6); when identity changes hands, drop it with the
-      // pair — hydration re-reads the named execution's ExecutionMeta.
+      // pair and invalidate any authority read already in flight.
       record.description = undefined;
+      if (previousExecutionId !== undefined) record.descriptionRevision++;
     }
     if (meta) {
       const pendingLiveWrite = metaOverlay !== undefined;
@@ -2235,6 +2259,9 @@ export class StreamSnapshotStore {
       }
       sidecarsToWrite.add(STREAM_DATA_KEYS.USAGE_STATS);
       overlays.usage = undefined;
+    }
+    if (hydrateDescription) {
+      await this.hydrateDescriptionFromExecutionMeta(stream, record);
     }
     record.seeded = true;
     this.writeMergedSidecars(stream, record, sidecarsToWrite);
@@ -2302,37 +2329,58 @@ export class StreamSnapshotStore {
   }
 
   /**
+   * Hydrate one resident record's in-memory display description from the
+   * authority. The captured identity and revision must still be current after
+   * the read: a handoff, live description event, or eviction wins the race.
+   */
+  private async hydrateDescriptionFromExecutionMeta(
+    streamId: StreamTabId,
+    record: StreamRecord,
+  ): Promise<void> {
+    const executionId = record.runDescriptor?.executionId;
+    if (!executionId) return;
+    const revision = record.descriptionRevision;
+    try {
+      const execMeta = await getExecutionStore(executionId).readMeta();
+      if (
+        this.records.get(streamId) !== record ||
+        record.runDescriptor?.executionId !== executionId ||
+        record.descriptionRevision !== revision
+      ) {
+        return;
+      }
+      if (execMeta?.description) record.description = execMeta.description;
+    } catch (err) {
+      // Best-effort; a missing/corrupt execution store just skips hydration.
+      logger.debug(
+        CHANNEL,
+        `Skipping description hydration for stream ${streamId}`,
+        { data: err },
+      );
+    }
+  }
+
+  /**
    * Hydrate in-memory display descriptions from the authority,
    * `ExecutionMeta.description` (#9590 A4/Stage 6). Read-only projection:
    * nothing is persisted in either direction — the sidecar `description`
    * mirror is no longer written for current records, and nothing anywhere
    * writes `ExecutionMeta.description` from the mirror. A record whose
    * execution metadata is absent or carries no description keeps serving the
-   * persisted sidecar value through {@link getDescription}'s legacy fallback.
+   * persisted sidecar value through {@link getDescription}'s legacy fallback,
+   * except after an observed execution handoff where that mirror is stale.
+   *
+   * Deliberate cost: every loaded stream with a registered execution pays one
+   * bounded-concurrency `meta.json` read per `load()`/`preload()` — the
+   * persisted mirror that used to short-circuit this is exactly the duplicate
+   * this stage removes.
    */
   private async hydrateDescriptionsFromExecutionMeta(): Promise<void> {
-    await Promise.all(
-      [...this.records].map(async ([streamId, record]) => {
-        const executionId = record.meta?.runDescriptor?.executionId;
-        if (!executionId) return;
-        try {
-          const execMeta = await getExecutionStore(executionId).readMeta();
-          // The reads are independent, so run them concurrently. Revalidate
-          // the captured record after the await: re-resolving through
-          // `setDescription` would recreate a stream evicted in flight (#8226).
-          if (this.records.get(streamId) !== record) return;
-          if (execMeta?.description) {
-            record.description = execMeta.description;
-          }
-        } catch (err) {
-          // Best-effort; a missing/corrupt execution store just skips hydration.
-          logger.debug(
-            CHANNEL,
-            `Skipping description hydration for stream ${streamId}`,
-            { data: err },
-          );
-        }
-      }),
+    await pMap(
+      [...this.records],
+      ([streamId, record]) =>
+        this.hydrateDescriptionFromExecutionMeta(streamId, record),
+      { concurrency: SEED_IO_CONCURRENCY },
     );
   }
 }


### PR DESCRIPTION
## Summary

Stage 6 of #9590: `ExecutionMeta.description` is now the only written description for current records. Previously every generated or delegated session label was persisted twice — once on the execution record (`executions/{id}/meta.json`) and once as a projected copy in the stream sidecar (`streamData/{id}/meta.json`), kept converged by a load-time backfill. This PR stops the sidecar copy entirely for current records:

- The `updateStreamDescription` session event no longer writes the sidecar: `StreamSnapshotStore.setDescription` updates in-memory display state only. Its emitters persist the authority first — `sessionDescription.ts` already did (`writeSessionDescription` before emit), and child-stream launchers now pass the delegated task label to `registerExecution`, which persists it on `ExecutionMeta` in the same atomic registration write.
- `backfillDescriptionsFromExecutionMeta` (meta → mirror, persisted) is replaced by `hydrateDescriptionsFromExecutionMeta` (meta → memory, read-only): `load()`/`preload()` resolve each stream's description through the accepted reverse edge, sidecar `RunDescriptor.executionId` → `ExecutionMeta.description`, and never write either side.
- The sidecar `description` field is now documented as legacy-read-only in `StreamTabMetaSchema`, read only as the compatibility fallback for records whose execution metadata carries no description (pre-registration records, desktop legacy imports). The field itself stays until Stage 7 (#9627, ≥ 2026-11-01 cohort), and rewriting an unrelated meta field still round-trips a legacy value instead of destroying it.

## Issue acceptance gates (#9590 Stage 6; A4)

Stage 6 spec: "stop snapshot description and association projection for current records; switch display/archive readers to execution metadata; retain legacy read only at the compatibility boundary."

1. **Description projection — done.** No production code path writes the sidecar `description` for a current record: `setDescription` is memory-only, the hydration never persists, and `writeMeta`'s `description` spread only round-trips a value a legacy sidecar already carried (grep: the only `description` entering `queueMetaPatch` payloads is gone; `writeMeta` is the single writer of `streamData/{id}/meta.json`).
2. **Association projection — verified-already-true.** The sidecar meta writer persists exactly four fields: `runDescriptor` (carries `executionId`, the accepted reverse edge — stays per the owner's authority table), `parentStreamId` (current-attachment authority — stays, untouched), `taskState` (legacy read-shim round-trip), and `description` (legacy round-trip, above). The legacy top-level `executionId` dual-write was retired in #9646's wave; grep confirms no other production writer of the sidecar meta file and no remaining executionId-adjacent field mirrored redundantly with the RunDescriptor.
3. **Readers to execution metadata — one read path.** See Consumer counts. `StreamSnapshotStore.getDescription` keeps its production caller (`ProgressViewState.buildSnapshotMetadataPatch`, a synchronous per-event path that cannot await ExecutionMeta I/O), so it is retained as the descriptor→meta read: the store hydrates from `ExecutionMeta` at load and the getter serves that projection, falling back to the persisted sidecar value only for records with no meta description (the documented legacy read). It is not deleted, so the surface ratchet baseline is unchanged.
4. **Schema marked legacy** in `src/shared/schemas/streamData.ts` (retirement note: Stage 7 / #9627, ≥ 2026-11-01 cohort) and `StreamSnapshot.description` documented as the legacy mirror surface in `src/shared/schemas/streamSnapshot.ts`.
5. **Untouched as required:** the #9603 transition set, residency/eviction (`requestEviction`, `evict` semantics), the bridge port, hot slice getters, and `legacyExecutionIdentity.ts` internals (no changes to the boundary; identity backfill and `LegacyIdentity` evidence are exactly as Stage 3/4 left them).

Behavior deltas pinned by tests: (a) when `ExecutionMeta` and a stale legacy mirror disagree, display now serves the authority value (A4) — previously the stale mirror won; neither persisted side is written. (b) `StreamSnapshot.description` (the `read()` wire shape) now carries only the legacy sidecar value; it has zero production consumers — the one wire consumer, the trace viewer, already reads `trace.meta.description`.

## Single source of truth

One description authority: `ExecutionMeta.description`, written by `writeSessionDescription` (generated labels) and now by `registerExecution` (delegated child labels, durable at birth in the same awaited meta write). One read path for current records: sidecar `RunDescriptor.executionId` → `ExecutionMeta.description` → in-memory projection → `getDescription`/live event. The sidecar read survives only as the legacy fallback for records with no meta description, and Obligation 7's direction invariant is preserved: nothing anywhere writes `ExecutionMeta.description` from the mirror.

## Duplication and abstraction budget

No new layers, ports, or facades. One new helper, `childStreamDescription` (the ≤80-char label cap), with four callers (`createChildStream` plus the three registration sites) — extracted so the durable authority write and the display event can never drift; the previous inline truncation moves, it is not wrapped. `registerExecution` grows one optional field on its existing options object. The persisted meta→mirror projection is deleted, not relocated: the replacement hydration is strictly read-only.

## Net elements (R6)

- Diff: 12 files, +213 / −49 (tests +138 of the additions; production +75/−49, most of it documentation of the authority contract).
- Public store methods: **23 + 28 = 51, unchanged**; `config/ratchets/store-public-surface-baseline.json` untouched (no public method added or removed — `setDescription` was already private since Stage 5, and `getDescription` retains a production caller). The path from 51 toward the 40–46 band remains Stage 7's dated retirement plus the external recount, as recorded on the issue.
- Elements: −1 persisted projection (`backfillDescriptionsFromExecutionMeta`'s write side), +1 shared truncation helper, +1 optional registration field, +1 in-memory record field replacing the persisted mirror as the display carrier.

## Consumer counts (R8)

Per description reader, before → after:

| Reader | Before | After |
|---|---|---|
| `src/controllers/progressView/backend/ProgressViewState.ts:358` (`snapshots.getDescription`) | sidecar-mirror memory | ExecutionMeta-hydrated memory (call site unchanged; one read path via descriptor→meta), legacy sidecar fallback only when meta has no description |
| `packages/trace-viewer/src/replayTrace.ts:154` | `trace.meta?.description` (ExecutionMeta) | unchanged — verified-already-true |
| `src/agent/storage/executionListing.ts:140` → `packages/cli/src/runtime/history.ts:464,509` (CLI history list/details) | ExecutionMeta | unchanged — verified-already-true |
| `packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts:254` (CLI TUI live) | live `updateStreamDescription` event | unchanged (live event; emitters now guarantee the authority write landed first) |
| `packages/desktop/src/main/desktopAgentResume.ts` / `src/agent/runtime/resumeFromResumeData.ts` (resume adapters) | read no description | unchanged — verified |
| `src/transcript/completedRunArchive.ts` (archive) | reads no description | unchanged — verified |
| `src/transcript/streamSnapshotRead.ts:178` (`StreamSnapshot.description`) | sidecar value | sidecar value, now documented legacy-only; zero production consumers of the field |

Writers, before → after: sidecar description writers 2 (`setDescription` event projection, `backfillDescriptionsFromExecutionMeta`) → **0**. ExecutionMeta description writers: `writeSessionDescription` (unchanged) + `registerExecution` at `src/tools/bash.ts:414`, `src/tools/agentCliShared.ts:196`, `src/tools/delegation/WorkflowScriptTool.ts:367` (previously these child labels were sidecar-only and not durable on the execution record at all).

## Host impact

- **Extension (progress view):** identical rendering. Live updates flow exactly as before (`ProgressFactApplier.handleUpdateStreamDescription` sets view state directly from the event); on reload, `buildSnapshotMetadataPatch` serves the same string, now sourced from ExecutionMeta. Legacy sidecar-only records keep displaying via the fallback.
- **Desktop:** uses the same shared progress backend and renderer metadata patches (`desktopCommandPalette` reads the same stream metadata), so display is identical; desktop legacy stream imports (streams with no execution record, `desktopProcessStores`) are precisely the legacy-fallback cohort and keep their sidecar descriptions readable. The resume adapter reads no description.
- **CLI:** TUI live descriptions unchanged; `texra history` already read ExecutionMeta. Child executions (bash/agent-CLI/workflow-script) now carry their label in ExecutionMeta from registration, so CLI history entries for child runs gain the description they previously only had in the sidecar mirror.

## Scheduled refactoring

Stage 7 (#9627, ≥ 2026-11-01 cohort, gated on `LegacyIdentity` warn-log evidence): delete the legacy boundary's sidecar-scan and suffix arms, delete the sidecar `description` field from `StreamTabMetaSchema` and its legacy fallback read in `getDescription`/`assembleSnapshot`'s meta pass-through, then recount externally required store operations against the 40–46 band.

## Validation

- `npm run typecheck` — clean.
- `npm run lint` — clean (exit 0).
- `env -u FORCE_COLOR npx vitest run src/test-kernel/transcript src/test-kernel/tools src/test-kernel/progressView src/test-kernel/agent` — all green (including `storePublicSurfaceRatchet.vitest.ts` and the Stage 2–4 pins in `legacyExecutionIdentity.vitest.ts`).
- New/updated pins: a public-boundary round-trip test (current record's description round-trips through ExecutionMeta only; the persisted sidecar meta carries the descriptor but no description — asserted on the raw file and via a `KVStore.write` persistence-boundary spy, no private spies); load-hydration without sidecar write; disagreement resolves to the authority with neither side written and the stale mirror left on disk; legacy description round-trip under unrelated meta patches. Two Stage-4 tests whose subject was the retired persisted projection were rewritten to the new contract rather than kept as retired-shape pins.
- `npm run check:dead-code-ratchet` — OK (18 vs 18 baselined; nothing freed, nothing widened).
- `npm run format` on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence and display contracts for session labels across transcript storage and delegation launchers; behavior is race-sensitive but heavily tested with legacy read fallback retained until Stage 7.
> 
> **Overview**
> **Stage 6 (#9590)** makes **`ExecutionMeta.description`** the only persisted description for current records. The stream sidecar **`meta.description`** mirror is no longer written; schemas mark it legacy-read-only.
> 
> **Writes:** `registerExecution` accepts optional **`description`** so bash, agent-CLI, and workflow-script child runs persist delegated labels at registration. **`childStreamDescription`** centralizes the ≤80-char cap for that write and for the display-only **`updateStreamDescription`** event. **`StreamSnapshotStore.setDescription`** updates in-memory display only.
> 
> **Reads:** Load/preload **`hydrateDescriptionsFromExecutionMeta`** projects authority into memory (replacing the old persisted backfill). **`getDescription`** serves hydrated/live values and falls back to the sidecar only for legacy records; when meta and a stale mirror disagree, **display uses ExecutionMeta**. Execution handoffs and in-flight hydration races are guarded via **`descriptionRevision`** and identity checks.
> 
> Tests and call sites are updated to assert ExecutionMeta authority, no sidecar writes for current records, and the new registration **`description`** contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81c84a5b80b25dd648c76b672d916a6c94558ec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->