### PR TITLE
Consolidate duplicate OpenAI client setup and reimplemented error helpers

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -76,6 +76,7 @@ import {
 import { renderEmptyState } from '@shared/wa/emptyState';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { extractErrorMessage } from '@utils/errors/errorMessage';
 
 import {
   DesktopOpenWorkbenchMessageSchema,
@@ -1187,9 +1188,7 @@ function rerenderShell(): void {
 }
 
 function toBootstrapErrorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === 'string') return error;
-  return 'TeXRA could not finish starting up.';
+  return extractErrorMessage(error) ?? 'TeXRA could not finish starting up.';
 }
 
 function renderBootstrapFallback(error: unknown): void {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -100,7 +100,7 @@ import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 import { setInlineCommentProvider } from '@tools/comment/InlineCommentTool';
 import { ephemeralTranscriptWarning, StreamLogStore } from '@transcript';
 import { StorageFS } from '@utils/files';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local file imports
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
@@ -478,9 +478,7 @@ export async function activate(context: vscode.ExtensionContext) {
       }
     }
   } catch (error) {
-    const initError =
-      error instanceof Error ? error : new Error(toErrorMessage(error));
-    SupabaseClient.setInitError(initError);
+    SupabaseClient.setInitError(ensureError(error));
     logger.error(
       'extension',
       `Failed to initialize Supabase authentication: ${toErrorMessage(error)}`,

--- a/packages/extension/src/frontend/lm/createLanguageModelPort.ts
+++ b/packages/extension/src/frontend/lm/createLanguageModelPort.ts
@@ -14,6 +14,8 @@ import {
   type LanguageModelReference,
   type LanguageModelResponsePart,
 } from '@platform/languageModel';
+import { isObject } from '@utils/core';
+import { extractErrorMessage } from '@utils/errors/errorMessage';
 
 function translateLanguageModelError(
   error: unknown,
@@ -31,10 +33,7 @@ function translateLanguageModelError(
     );
   }
 
-  const code =
-    typeof error === 'object' && error !== null && 'code' in error
-      ? (error as { code?: unknown }).code
-      : undefined;
+  const code = isObject(error) && 'code' in error ? error.code : undefined;
   switch (code) {
     case 'NoPermissions':
       return new LanguageModelPortError(
@@ -57,9 +56,7 @@ function translateLanguageModelError(
     default:
       return new LanguageModelPortError(
         LANGUAGE_MODEL_PORT_ERROR_CODE.UNKNOWN,
-        error instanceof Error && error.message
-          ? error.message
-          : `Language model${model} request failed.`,
+        extractErrorMessage(error) ?? `Language model${model} request failed.`,
         { cause: error },
       );
   }

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -12,11 +12,11 @@ import { customElement, property, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { keyed } from 'lit/directives/keyed.js';
 
-// Local imports - shared schemas and types
-import type { LaunchTarget } from '@shared/schemas';
-
-// Local imports - shared styles
+// Local imports - shared schemas, styles, and commands
 import { designTokens } from '@shared/styles';
+import type { LaunchTarget } from '@shared/schemas';
+import { formatDesktopAccelerator } from '@shared/commands/accelerators';
+import { commandCatalogById } from '@shared/commands/catalog';
 import { commonViewStyles } from '@shared/styles/commonViewStyles';
 import { selectStyles } from '@shared/styles/selectStyles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
@@ -350,15 +350,19 @@ export class InstructionPanel extends LitElement {
   }
 
   /**
-   * Keyboard-shortcut label shown in the Execute button. Matches the
-   * `texra.execute` keybinding declared in the extension's package.json
-   * (cmd+option+e on macOS, ctrl+alt+e elsewhere).
+   * Keyboard-shortcut label shown in the Execute button, derived from the
+   * `texra.execute` keybinding registered in the command catalog so the
+   * label can't drift from the actual binding.
    */
   private get executeShortcutLabel(): string {
     const isMac =
       typeof navigator !== 'undefined' &&
       /Mac|iPhone|iPod|iPad/.test(navigator.platform || '');
-    return isMac ? '⌘⌥E' : 'Ctrl+Alt+E';
+    const platform: NodeJS.Platform = isMac ? 'darwin' : 'linux';
+    const keybinding = commandCatalogById.get('texra.execute')?.keybinding;
+    const accelerator =
+      isMac && keybinding?.mac ? keybinding.mac : keybinding?.key;
+    return formatDesktopAccelerator(accelerator, platform) ?? 'Ctrl+Alt+E';
   }
 
   private handleAgentSettings(): void {

--- a/src/agent/modelHandlers/openai/OpenAIClientModelHandler.ts
+++ b/src/agent/modelHandlers/openai/OpenAIClientModelHandler.ts
@@ -1,0 +1,69 @@
+// Third-party imports
+import OpenAI from 'openai';
+
+// Local imports
+import type { ProviderMessage } from '@agent/types/ProviderMessage';
+import type {
+  ModelCredentialSelection,
+  SdkToolCall,
+} from '@agent/types/ModelHandlerContracts';
+import { ModelHandler } from '../ModelHandler';
+
+// Local file imports
+import { logOpenAICompatibleClientConfig } from './openAIChatHelpers';
+
+/**
+ * Shared client-construction surface for the OpenAI-family handlers
+ * (Chat Completions and Responses API). Both bind the base `ModelHandler`'s
+ * client type parameter to the OpenAI SDK client, so credential resolution,
+ * client construction, and logging are identical across them — kept here
+ * rather than on `ModelHandler` so non-OpenAI providers don't carry this
+ * SDK dependency.
+ */
+export abstract class OpenAIClientModelHandler<
+  M extends ProviderMessage = ProviderMessage,
+  U = unknown,
+  T extends SdkToolCall = SdkToolCall,
+  Resp = unknown,
+  Media = unknown,
+> extends ModelHandler<M, U, T, OpenAI, Resp, Media> {
+  /**
+   * Creates a new OpenAI client using the stored credentials.
+   * Handles API key retrieval, base URL resolution, and logging.
+   */
+  protected async createOpenAIClient(
+    selection: ModelCredentialSelection = 'configured',
+  ): Promise<OpenAI> {
+    const credential = await this.resolveClientCredential(selection);
+    // there is a time out parameter that can be set; default is 10 minutes
+    const client = new OpenAI({
+      apiKey: credential.apiKey,
+      baseURL: credential.baseUrl,
+      fetch: this.longRunningModelFetch,
+      maxRetries: 0,
+    });
+    logOpenAICompatibleClientConfig(
+      this.logger,
+      this.config,
+      client.baseURL,
+      credential.route,
+      this.shouldUseServerSideKeys(),
+    );
+    return this.rememberClientCredentialRoute(
+      client,
+      credential.route,
+      credential.apiKey,
+    );
+  }
+
+  /** Returns OpenAI client with configured API key. */
+  async getClient(
+    selection: ModelCredentialSelection = 'configured',
+  ): Promise<OpenAI> {
+    return this.createOpenAIClient(selection);
+  }
+
+  override getRetryEndpoint(client: OpenAI): string {
+    return client.baseURL;
+  }
+}

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -21,7 +21,6 @@ import type {
   CreateResponseResult,
   ExtractResponseResult,
   DeepSeekToolCall,
-  ModelCredentialSelection,
   OpenAIToolCall,
 } from '@agent/types/ModelHandlerContracts';
 import {
@@ -69,11 +68,11 @@ import {
 import {
   extractOpenAIPartialTail,
   extractReasoningDelta as extractReasoningDeltaFromChunk,
-  logOpenAICompatibleClientConfig,
 } from './openAIChatHelpers';
 import { toOpenAITools } from '../toolConversion';
 import { formatToolResultTextWithAttachments } from '../utils/toolAttachmentUtils';
 import { ModelHandler } from '../ModelHandler';
+import { OpenAIClientModelHandler } from './OpenAIClientModelHandler';
 import {
   BaseReasoningStreamAggregator,
   type StreamingAggregator,
@@ -169,11 +168,10 @@ function classifyOpenAIResponse(responseObject: any): OpenAIClassifiedResponse {
  */
 export class ModelHandlerOpenAI<
   TCall extends OpenAIToolCall | DeepSeekToolCall = OpenAIToolCall,
-> extends ModelHandler<
+> extends OpenAIClientModelHandler<
   ChatCompletionMessageParam,
   ExtendedCompletionUsage | null,
   TCall,
-  OpenAI,
   ChatCompletion,
   ChatCompletionContentPart
 > {
@@ -237,46 +235,6 @@ export class ModelHandlerOpenAI<
         content: summary,
       }),
     );
-  }
-
-  /**
-   * Creates a new OpenAI client using the stored credentials.
-   * Handles API key retrieval, base URL resolution, and logging.
-   */
-  protected async createOpenAIClient(
-    selection: ModelCredentialSelection = 'configured',
-  ): Promise<OpenAI> {
-    const credential = await this.resolveClientCredential(selection);
-    // there is a time out parameter that can be set; default is 10 minutes
-    const client = new OpenAI({
-      apiKey: credential.apiKey,
-      baseURL: credential.baseUrl,
-      fetch: this.longRunningModelFetch,
-      maxRetries: 0,
-    });
-    logOpenAICompatibleClientConfig(
-      this.logger,
-      this.config,
-      client.baseURL,
-      credential.route,
-      this.shouldUseServerSideKeys(),
-    );
-    return this.rememberClientCredentialRoute(
-      client,
-      credential.route,
-      credential.apiKey,
-    );
-  }
-
-  /** Returns OpenAI client with configured API key. */
-  async getClient(
-    selection: ModelCredentialSelection = 'configured',
-  ): Promise<OpenAI> {
-    return this.createOpenAIClient(selection);
-  }
-
-  override getRetryEndpoint(client: OpenAI): string {
-    return client.baseURL;
   }
 
   /**

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -24,7 +24,6 @@ import type {
   CreateResponseOptions,
   CreateResponseResult,
   ExtractResponseResult,
-  ModelCredentialSelection,
   OpenAIResponseToolCall,
   TokenCountOptions,
 } from '@agent/types/ModelHandlerContracts';
@@ -72,7 +71,6 @@ import {
   normalizeOpenAIResponseUsage,
 } from './openAIUsage';
 import { tagOpenAISdkError } from './openAISdkError';
-import { logOpenAICompatibleClientConfig } from './openAIChatHelpers';
 import { normalizeOpenAIResponseError } from './openAIResponseErrors';
 import {
   formatAttachmentSummary,
@@ -80,7 +78,7 @@ import {
   uploadAndRecordToolAttachments,
 } from '../utils/toolAttachmentUtils';
 import { toOpenAIResponseTools } from '../toolConversion';
-import { ModelHandler } from '../ModelHandler';
+import { OpenAIClientModelHandler } from './OpenAIClientModelHandler';
 import {
   CHAINED_RESPONSE_MAX_OUTPUT_FACTOR,
   CHAINED_RESPONSE_SAFETY_MARGIN_PERCENT,
@@ -287,11 +285,10 @@ function mergeMissingStreamedOutputItems(
  * owns) must be used by a single agent execution at a time. Do not share
  * instances across concurrent invocations.
  */
-export class ModelHandlerOpenAIResponse extends ModelHandler<
+export class ModelHandlerOpenAIResponse extends OpenAIClientModelHandler<
   ResponseInputItem,
   ResponseUsage,
   OpenAIResponseToolCall,
-  OpenAI,
   Response,
   ResponseInputContent
 > {
@@ -1112,42 +1109,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // a same-turn retry, resend this turn's stale compactedMessages, and
     // silently drop everything appended since (tool outputs, new user turns).
     this.compactionResult = undefined;
-  }
-
-  /** Creates a configured OpenAI client instance. */
-  protected async createOpenAIClient(
-    selection: ModelCredentialSelection = 'configured',
-  ): Promise<OpenAI> {
-    const credential = await this.resolveClientCredential(selection);
-    const client = new OpenAI({
-      apiKey: credential.apiKey,
-      baseURL: credential.baseUrl,
-      fetch: this.longRunningModelFetch,
-      maxRetries: 0,
-    });
-    logOpenAICompatibleClientConfig(
-      this.logger,
-      this.config,
-      client.baseURL,
-      credential.route,
-      this.shouldUseServerSideKeys(),
-    );
-    return this.rememberClientCredentialRoute(
-      client,
-      credential.route,
-      credential.apiKey,
-    );
-  }
-
-  /** Returns OpenAI client with configured API key. */
-  async getClient(
-    selection: ModelCredentialSelection = 'configured',
-  ): Promise<OpenAI> {
-    return this.createOpenAIClient(selection);
-  }
-
-  override getRetryEndpoint(client: OpenAI): string {
-    return client.baseURL;
   }
 
   /** Reset conversation bookkeeping when starting a new session. */


### PR DESCRIPTION
## Summary

Scheduled code-consolidation sweep. Three independent Explore agents scanned `src/utils`/`src/shared`/`src/tools`, `src/agent`/`src/model`, and the three host packages for duplicate logic and hand-rolled reimplementations of native/existing helpers. The codebase turned out to already be heavily consolidated — most categories (debounce, sleep, retry/backoff, dedup, UUID gen, promise-queue serialization) came back clean. This PR lands the handful of genuine, low-risk findings that survived review.

## Issue acceptance gates

No linked issue — this is a scheduled maintenance sweep, not a fix for a filed bug. Acceptance gate: each change is a behavior-preserving consolidation, verified by full typecheck, lint, and the relevant test suites.

## Single source of truth

- `OpenAIClientModelHandler` (new, `src/agent/modelHandlers/openai/OpenAIClientModelHandler.ts`) now owns OpenAI-family client construction (`createOpenAIClient`/`getClient`/`getRetryEndpoint`) for both `ModelHandlerOpenAI` and `ModelHandlerOpenAIResponse`, kept off the generic `ModelHandler` base so non-OpenAI providers don't carry the OpenAI SDK dependency (mirrors the existing rationale on `logOpenAICompatibleClientConfig`).
- `ensureError` / `extractErrorMessage` / `isObject` (all pre-existing in `@utils/errors/errorMessage` and `@utils/core`) are now the single source for error-to-string/Error coercion in `extension.ts`, `createLanguageModelPort.ts`, and the desktop renderer bootstrap path, replacing three independent reimplementations. Note (per review discussion below): this swap is byte-identical for `ensureError`, but `extractErrorMessage` trims and drops empty/whitespace-only messages where the two replaced inline checks did not — a deliberate, safer edge-case behavior (falls back to a meaningful default instead of a blank message), not a strictly zero-diff substitution. Similarly `isObject` excludes arrays where one replaced inline check didn't, on a path (VS Code Language Model errors) that never surfaces arrays.
- The Execute-button shortcut label in `InstructionPanel.ts` is now derived from the `texra.execute` entry in the shared command catalog (`commandCatalogById` + `formatDesktopAccelerator`) instead of a second hardcoded/independent platform-sniffing string.

## Duplication and abstraction budget

Removed: two byte-identical ~30-line method clusters (`createOpenAIClient`/`getClient`/`getRetryEndpoint`) duplicated across `modelHandlerOpenAI.ts` and `modelHandlerOpenAIResponse.ts`; three independent reimplementations of `ensureError`/`extractErrorMessage`-shaped logic; one independently-hardcoded keyboard-shortcut string that could silently drift from the real keybinding.

Added: one new abstract class, `OpenAIClientModelHandler`. It owns exactly one invariant — "OpenAI-family handlers share one client-construction/credential/logging path" — and sits between `ModelHandler` (generic, SDK-agnostic) and the two concrete OpenAI handlers, matching the existing `openAIChatHelpers.ts` pattern of keeping OpenAI SDK specifics off the generic base. `ModelHandlerCodex`'s existing `super.createOpenAIClient()` override chain is unaffected — it now resolves through the new intermediate class instead of `ModelHandlerOpenAIResponse` directly.

No other new abstractions; the error-helper and shortcut-label changes are pure call-site substitutions with no new exports.

## Net elements (R6)

Diffstat: 7 files changed, 93 insertions(+), 107 deletions(-) (net −14 lines).

Exported symbols (`^[+-]export` over the diff):
- `+export abstract class OpenAIClientModelHandler<...>` (new)
- `-export class ModelHandlerOpenAIResponse extends ModelHandler<...>` / `+export class ModelHandlerOpenAIResponse extends OpenAIClientModelHandler<...>` (same export, new base)

Net: +1 class, 0 net new public API surface beyond the new shared base itself.

## Consumer counts (R8)

No emit paths or subscriptions touched. `createOpenAIClient`/`getClient`/`getRetryEndpoint` had exactly 2 duplicate call-site definitions before this change (grepped and confirmed by an independent audit agent); both now delegate to the single base implementation. `ModelHandlerCodex` (1 additional override site) still calls `super.createOpenAIClient()`, which now resolves one level higher in the prototype chain — verified via full typecheck and the Codex-specific test suites (`CodexExperimentalTransports`, `CodexSubscriptionFallback`, `CodexEncryptedReasoning`).

## Host impact

Extension: `extension.ts` (Supabase init error handling), `createLanguageModelPort.ts` (VS Code Language Model API error translation), `InstructionPanel.ts` (Execute-button shortcut label) — all VS Code-allowed zones, no `vscode`-coupling changes.

Desktop: `packages/desktop/src/renderer/main.ts` bootstrap-fallback error message — browser-bundled renderer code, using the already browser-safe `@utils/errors/errorMessage`.

CLI: No changes.

## Scheduled refactoring

None. A larger, higher-risk finding (~18 call sites of `vscode.env.openExternal`/`revealFileInOS` across extension command handlers that could route through the existing `ExternalOpener` port) was identified by the audit but deliberately not implemented here — it needs light dependency-injection wiring into several plain command handlers rather than a pure substitution, so it's left as a follow-up rather than bundled into this low-risk sweep.

## Validation

- `npm run typecheck` — full workspace (root, test-kernel, agent, extension, cli, trace-viewer, desktop) — all pass.
- `npm run lint` — clean on the full touched-file set (two import-order nits were caught and fixed).
- `npx prettier --check` on all touched files — clean.
- `npm run check:dead-code-ratchet` — 18 findings, matches baseline exactly, no new dead code/exports.
- `npx vitest run` on the full `src/test-kernel/agent/modelHandlers/` suite (63 files, 706 tests, 4 pre-existing skips) plus `src/test-kernel/frontend/createLanguageModelPort.vitest.ts` — all pass.
