### PR TITLE
docs: Agent-SDK readiness re-check — confirm alignment, retire TD-2(a)

### DIFF
--- a/docs/dev/audits/2026-08-03-agent-sdk-readiness-checkpoint.md
+++ b/docs/dev/audits/2026-08-03-agent-sdk-readiness-checkpoint.md
@@ -1,12 +1,14 @@
 # Agent-SDK readiness re-check (agent core · model handler · logger · surface)
 
 > **Status:** Audit note. Written 2026-08-03, all figures recomputed at HEAD
-> `434b89d`. This is a _current-state_ re-measurement, not a new plan. It sits
-> under the plan of record
-> [`2026-07-09-agent-sdk-north-star.md`](./2026-07-09-agent-sdk-north-star.md)
+> `434b89d`. This is a _current-state_ re-measurement, not a new plan. It
+> continues the daily checkpoint series — read alongside the immediately prior
+> [`2026-08-02-agent-sdk-readiness-checkpoint.md`](./2026-08-02-agent-sdk-readiness-checkpoint.md) —
+> and sits under the plan of record
+> [`2026-07-09-agent-sdk-north-star.md`](../../proposals/2026-07-09-agent-sdk-north-star.md)
 > and the two measurements it depends on
-> ([`2026-07-26-agent-sdk-foundation-gap.md`](./2026-07-26-agent-sdk-foundation-gap.md),
-> [`2026-07-27-agent-npm-package-step3.md`](./2026-07-27-agent-npm-package-step3.md)).
+> ([`2026-07-26-agent-sdk-foundation-gap.md`](../../proposals/2026-07-26-agent-sdk-foundation-gap.md),
+> [`2026-07-27-agent-npm-package-step3.md`](../../proposals/2026-07-27-agent-npm-package-step3.md)).
 > Its job is to confirm whether those conclusions still hold and flag what has
 > since landed or remains open — nothing here overrides a maintainer ruling.
 >

--- a/docs/proposals/2026-08-03-agent-sdk-readiness-recheck.md
+++ b/docs/proposals/2026-08-03-agent-sdk-readiness-recheck.md
@@ -9,18 +9,25 @@
 > [`2026-07-27-agent-npm-package-step3.md`](./2026-07-27-agent-npm-package-step3.md)).
 > Its job is to confirm whether those conclusions still hold and flag what has
 > since landed or remains open — nothing here overrides a maintainer ruling.
+>
+> **Amended same-day**, after tracing the fourth tracked delta (TD-2a) down to
+> its actual runtime behavior at the maintainer's request for concrete
+> follow-through: executing it would regress the SDK surface it was meant to
+> improve. §7 retires it with the evidence; no code changes were made.
 
 ## Verdict
 
-**Well-aligned. No structural refactor is warranted, and none is proposed
-here.** The four areas the task names — agent core, model handler, logger, and
-the package surface — are already converged on the Claude-Agent-SDK shape by
-deliberate, documented work, and the guardrails that hold them there (the
+**Well-aligned. No structural refactor is warranted, and none was made.** The
+four areas the task names — agent core, model handler, logger, and the package
+surface — are already converged on the Claude-Agent-SDK shape by deliberate,
+documented work, and the guardrails that hold them there (the
 `config/ratchets/` baselines and the free-zone import fence) are *tightening*,
-not slipping. The one thing this re-check adds over the July docs is evidence:
-two of the four tracked "finish-the-endgame" deltas have since landed, the host
-boundary has measurably shrunk, and exactly one small, already-ruled cleanup
-remains open on the core interaction quartet.
+not slipping. This re-check adds evidence over the July docs: two of the four
+tracked "finish-the-endgame" deltas have since landed cleanly, the host
+boundary has measurably shrunk, and the fourth (TD-2a) turns out to already be
+the correct shipped design rather than residue — retired in §7 rather than
+executed, since executing it would have broken the npm package's tested
+minimal-host contract for zero runtime benefit.
 
 This matches the standing conclusion of the `-05-30 → -07-26` chain: the open
 work is *deciding* the product line and shipping the package, not untangling
@@ -131,29 +138,69 @@ warned the host boundary was eroding. Re-measured:
 | Host `@agent/*` deep-import width (ext/cli/desktop) | 49 / 35 / 27, growing ~2.5/wk | **39 / 32 / 25** — shrunk; ratchet-frozen at current |
 | TD-2(b) phantom `RuntimeInteractionEventPayloads` arms | 6 to relocate | **landed** — symbol absent repo-wide |
 | TD-2(c) `runFact.` string-prefix protocol (dated v0.41) | retire on schedule | **landed** — absent under `src/agent` |
-| TD-2(a) `HostInteractions` request methods optional | 7/7 `?`, 6 runtime-hard-required | **still open** — `HostInteractions.ts:299–325` all `?` |
+| TD-2(a) `HostInteractions` request methods optional | 7/7 `?`, 6 runtime-hard-required | **retired, not executed** — optionality is the tested minimal-host contract the npm package depends on; see §7 |
 | TD-2(d) status dual-rail | complete atomically | trace `status` arm still present (`trace/events.ts:153`); not independently confirmed here |
 
-## 7. The only open cleanup, and why not to do it piecemeal now
+## 7. TD-2(a) re-investigated and retired (not executed — executing it would regress the SDK surface)
 
-**TD-2(a): make the six runtime-hard-required `HostInteractions` request methods
-non-optional.** Today all seven are `?`-optional with `Promise|void` returns
-(`src/agent/runtime/HostInteractions.ts:299–325`) while six are required at
-runtime — the type is looser than the contract. The plan is explicit that this
-conversion **rides A2's −300..−450 legacy-fallback deletion**, i.e. it is
-coupled to a larger deletion and should land with it, not as an isolated
-signature flip. Doing it alone would touch the core interaction contract for
-cosmetic gain and risk widening churn ahead of the deletion it depends on.
+The prior section of this doc (and the north-star plan before it) treated
+TD-2(a) — making the request methods on `HostInteractions` non-optional — as
+blocked only on A2's fallback deletion landing. A2 has since landed in full
+(verified at HEAD: `platform().toolEditApproval`, `RunContext
+.toolEditApprovalHandler`, and every `create{Desktop,Cli}ToolEditApprovalPort`
+factory are gone repo-wide). That unblocks TD-2(a) mechanically — but a deeper
+trace of the runtime shows **executing it now would be a regression, not a
+cleanup**, for reasons the July docs didn't have in front of them:
 
-**Recommendation:** leave TD-2(a) to land with A2 as designed; take no
-autonomous action on the interaction quartet. Everything else in the four
-audited areas is already at target.
+- **All 6 non-`openExternalInquiry` request methods already resolve through
+  `SessionHostInteractions.enqueue()`** (`HostInteractions.ts:594–618`), whose
+  `dispatch()` (`:686–715`) treats a missing method on the attached host
+  exactly like a normal decline: `if (!result) { …; pending.settle(pending
+  .cancellationResult()); return; }` — no crash, no thrown error, a typed
+  cancellation/deny result. `openExternalInquiry` is the deliberate exception,
+  bypassing the queue to throw loud when unattached (comment at
+  `HostInteractions.ts:525–528`).
+- **This is a tested, documented contract, not an accident.** `warnParked`'s
+  own message says it outright: *"A headless embedder must attach at least
+  `{ cancel: () => {} }`, or blocking requests never settle."*
+  `SessionInteractions.vitest.ts:606` (`'settles against the documented
+  minimal `{ cancel }` host'`) asserts exactly this: a bare `{ cancel: vi.fn()
+  }` host makes `requestPlanApproval` resolve `{ action: 'reject' }`, not
+  throw. Every other request method degrades the same way.
+- **The npm package depends on this contract to exist at all.**
+  `packages/agent/src/index.ts:234–238` attaches `{ cancel, requestRetry }` —
+  2 of 7 methods — and works today only because the other 5 gracefully
+  decline. Making them required would force this file to add stub
+  implementations for interactions it structurally can never reach (`runAgent`
+  already throws upfront for any `requiresApproval: true` tool — verified this
+  covers `UserQuestionTool`, `ExternalInquiryTool`, and `PlanTool` too, not
+  only tool-edit/bash/proposal), producing dead ceremony code in exactly the
+  package this whole effort exists to keep minimal.
+- **The blast radius elsewhere is real and value-free.** A parallel sweep
+  found `src/test-kernel/agent/progressTestUtils.ts`'s shared
+  `createRecordingHost()` fixture missing 2 of 7 methods, plus **~25
+  independent `src/test-kernel/**` files** that pass narrow 1–2-method inline
+  `HostInteractions` literals by design (each exercises one interaction route
+  in isolation). Required methods would force stub implementations into all
+  of them for a signature change none of their tests exercise — pure test
+  churn, the "add abstraction for hypothetical future requirements" pattern
+  this codebase's own conventions rule out.
+
+**Verdict: retire TD-2(a).** The "optional-with-graceful-decline" shape is not
+residue from the dead legacy fallback A2 removed — it is the *replacement*
+design, already shipped, tested, and load-bearing for the npm package's
+minimal-host contract. Converting it to required would trade a working
+progressive-capability host model for a rigid one, for no runtime benefit
+`enqueue()` doesn't already provide. No code change made in this area.
 
 ## 8. Bottom line
 
-Agent core, model handler, logger, and the package surface are aligned with the
-Agent-SDK direction and actively converging — the boundary shrank, two tracked
-deltas landed, and the guardrails are holding. There is no unnecessary
-abstraction to remove and no subagent boundary to newly design; the residual
-work is packaging/legal decisions already captured elsewhere, plus one
-deletion-coupled cleanup (TD-2a) best left to its planned landing.
+Agent core, model handler, logger, and the package surface are aligned with
+the Agent-SDK direction and actively converging — the boundary shrank, two
+tracked deltas (b, c) landed cleanly, and the guardrails are holding. The
+fourth tracked delta, TD-2(a), turns out on inspection to already be the
+correct end state as shipped — not a residue to clean up — and this doc
+retires it with evidence so it stops being re-proposed. There is no
+unnecessary abstraction to remove and no subagent boundary to newly design in
+any of the four audited areas; the only work still open belongs to the
+packaging/legal track captured elsewhere.

--- a/docs/proposals/2026-08-03-agent-sdk-readiness-recheck.md
+++ b/docs/proposals/2026-08-03-agent-sdk-readiness-recheck.md
@@ -1,0 +1,159 @@
+# Agent-SDK readiness re-check (agent core · model handler · logger · surface)
+
+> **Status:** Audit note. Written 2026-08-03, all figures recomputed at HEAD
+> `434b89d`. This is a *current-state* re-measurement, not a new plan. It sits
+> under the plan of record
+> [`2026-07-09-agent-sdk-north-star.md`](./2026-07-09-agent-sdk-north-star.md)
+> and the two measurements it depends on
+> ([`2026-07-26-agent-sdk-foundation-gap.md`](./2026-07-26-agent-sdk-foundation-gap.md),
+> [`2026-07-27-agent-npm-package-step3.md`](./2026-07-27-agent-npm-package-step3.md)).
+> Its job is to confirm whether those conclusions still hold and flag what has
+> since landed or remains open — nothing here overrides a maintainer ruling.
+
+## Verdict
+
+**Well-aligned. No structural refactor is warranted, and none is proposed
+here.** The four areas the task names — agent core, model handler, logger, and
+the package surface — are already converged on the Claude-Agent-SDK shape by
+deliberate, documented work, and the guardrails that hold them there (the
+`config/ratchets/` baselines and the free-zone import fence) are *tightening*,
+not slipping. The one thing this re-check adds over the July docs is evidence:
+two of the four tracked "finish-the-endgame" deltas have since landed, the host
+boundary has measurably shrunk, and exactly one small, already-ruled cleanup
+remains open on the core interaction quartet.
+
+This matches the standing conclusion of the `-05-30 → -07-26` chain: the open
+work is *deciding* the product line and shipping the package, not untangling
+abstractions. Re-deriving that here would duplicate ~23 prior docs.
+
+## 1. Surface — `@texra-ai/agent` (`packages/agent/src/index.ts`)
+
+The public run surface already mirrors the Anthropic `Query` pattern one-for-one:
+
+- `runAgent(input: RunAgentInput): AgentRun` — a single entry, one import path.
+- `AgentRun extends AsyncIterable<AgentEvent>` with `result: Promise<AgentFlowResult>`
+  and `interrupt()`. One observation rail (the async iterator over the typed
+  one-way `AgentEvent` fact stream) plus one terminal result — the SDK's
+  "observe on the stream, block on a callback" principle, applied.
+- `RunAgentInput` is five fields (`platform`, `agent`, `instruction`,
+  `interactions`, optional `model`/`tools`). No 13-type config ceremony reaches
+  the caller.
+
+**Deliberate, documented gaps — not debt:**
+
+- **No interactive approvals in the package.** `runAgent` throws for any
+  approval-requiring tool, and `HostInteractions` at the package boundary is
+  `cancel()` only (`packages/agent/src/index.ts`). This is the plan-of-record
+  NS decision — approval methods join the contract when they have a stable
+  package-level shape, not before. Correct as-is.
+- **Definitions load only through the disk registry** (`loadAgents` /
+  `resolveAgent`), not as injectable values. Also a live ruling (NS-4):
+  document port-injection as the embedding path; add definitions-as-options
+  only when a real external consumer asks. No change indicated.
+
+The remaining blocker to publication is packaging/legal (the five §2 blockers of
+the step-3 doc and the open-source-readiness audit's license/history gates), not
+API shape.
+
+## 2. Agent core (`src/agent/core`, `src/agent/runtime`, `src/agent/node`)
+
+- **Launch is single-entry.** `runAgent` (`src/agent/runtime/runAgent.ts`, 212
+  LoC) assigns the `executionId` and registers the run; `executeAgent` is the
+  lower-level path for callers that already own the id (subagent dispatch,
+  resume). The split is intentional and documented in
+  `src/agent/runtime/README.md` — not a pass-through wrapper.
+- **The flow engine is not indirection.** `src/agent/node/index.ts` (~250 LoC)
+  is the sole local definition of `BaseNode`/`Node`/`Flow`; nodes create and run
+  flows directly. There is no upstream-PocketFlow layer to collapse. (It *does*
+  carry an unattended-attribution license obligation — see B2 of the
+  open-source-readiness audit — but that is a NOTICE file, not a refactor.)
+- **The session quartet is the seed surface** — `SessionHandle`,
+  `session.events` (`SessionEventHub`), `session.interactions`
+  (`HostInteractions`), `session.runs`/`status`. Frozen from outside by
+  `host-agent-import-baseline` and the free-zone fence.
+
+No unnecessary abstraction found to remove in core. The two-flow +
+`agentCreator` decomposition and the runtime module set are the shape three
+hosts converged on independently.
+
+## 3. Model handler (`src/agent/modelHandlers`)
+
+`abstract class ModelHandler<…>` (`ModelHandler.ts`, ~2,000 LoC) with one
+concrete implementation per provider (`anthropic/`, `google/`, `openai/`,
+`openrouter/`, `vscodelm/`). This is **genuine provider polymorphism** — real
+shared logic (compaction, token-limit continuation, media/attachment handling,
+usage accounting) behind a stable interface with five live subclasses — not a
+redundant interface over a single implementation. Provider-specific concerns are
+already extracted into cohesive files (`anthropicThinking.ts`,
+`anthropicUsage.ts`, `anthropicContextManagement.ts`, …) rather than branched
+inline. The base class is large but cohesive; splitting it would trade one
+readable file for cross-file indirection with no caller benefit. **Keep as-is.**
+
+## 4. Logger (`src/logger`, `src/agent/trace`)
+
+Two tiers, cleanly separated, joined by thin adapters — no redundant layer:
+
+- **Sink tier** — `src/logger/logUtils.ts`: channel management, redaction
+  (`createRedactingSink`), and the functional `debug/info/warn/error` +
+  `createChannelWriter` API. Host-agnostic.
+- **Run tier** — `src/agent/trace/AgentTrace`: the run-scoped structured event
+  stream (`AgentEvent`), where `log` is one arm among stages/streams/status.
+- **Adapters** — `createChannelTrace` (a ~10-line log-only trace over
+  `noopTrace` for module-level work outside a run) and `attachChannelSubscriber`
+  (routes a trace's `log` events to a channel sink). Both are minimal bridges,
+  not wrappers with their own policy.
+
+Confirming the decoupling holds: `platform().log` has **0** call sites under
+`src/agent` — agent logging flows through trace/channel, the intended
+host-agnostic path. **No cleanup indicated.**
+
+## 5. Subagent boundaries (task step 4) — already designed and shipped
+
+The "logical units that could run as independent agents" already exist as
+first-class runtime concepts; there is nothing to newly carve out:
+
+- `executeAgent` + `childRunLoop` — subagent dispatch under an owned execution.
+- `AgentRosterController` (`src/agent/roster/`) — the multi-agent roster.
+- `detachSubagentsOnStop`, `resumeQueuedToolUse` — subagent lifecycle/resume.
+
+The delegation *tools* are exactly the closure that pulls in the heaviest import
+graph (step-3 doc B1: 19 tools share one ~630-file closure), which is the real
+packaging seam for a multi-agent SDK — a decision about where the product line
+falls, already tracked, not a boundary to invent here.
+
+## 6. What changed since the July plan (measured at `434b89d`)
+
+The plan of record listed a four-item "finish-the-endgame" quartet (TD-2) and
+warned the host boundary was eroding. Re-measured:
+
+| Item | July status | HEAD `434b89d` |
+| --- | --- | --- |
+| Host `@agent/*` deep-import width (ext/cli/desktop) | 49 / 35 / 27, growing ~2.5/wk | **39 / 32 / 25** — shrunk; ratchet-frozen at current |
+| TD-2(b) phantom `RuntimeInteractionEventPayloads` arms | 6 to relocate | **landed** — symbol absent repo-wide |
+| TD-2(c) `runFact.` string-prefix protocol (dated v0.41) | retire on schedule | **landed** — absent under `src/agent` |
+| TD-2(a) `HostInteractions` request methods optional | 7/7 `?`, 6 runtime-hard-required | **still open** — `HostInteractions.ts:299–325` all `?` |
+| TD-2(d) status dual-rail | complete atomically | trace `status` arm still present (`trace/events.ts:153`); not independently confirmed here |
+
+## 7. The only open cleanup, and why not to do it piecemeal now
+
+**TD-2(a): make the six runtime-hard-required `HostInteractions` request methods
+non-optional.** Today all seven are `?`-optional with `Promise|void` returns
+(`src/agent/runtime/HostInteractions.ts:299–325`) while six are required at
+runtime — the type is looser than the contract. The plan is explicit that this
+conversion **rides A2's −300..−450 legacy-fallback deletion**, i.e. it is
+coupled to a larger deletion and should land with it, not as an isolated
+signature flip. Doing it alone would touch the core interaction contract for
+cosmetic gain and risk widening churn ahead of the deletion it depends on.
+
+**Recommendation:** leave TD-2(a) to land with A2 as designed; take no
+autonomous action on the interaction quartet. Everything else in the four
+audited areas is already at target.
+
+## 8. Bottom line
+
+Agent core, model handler, logger, and the package surface are aligned with the
+Agent-SDK direction and actively converging — the boundary shrank, two tracked
+deltas landed, and the guardrails are holding. There is no unnecessary
+abstraction to remove and no subagent boundary to newly design; the residual
+work is packaging/legal decisions already captured elsewhere, plus one
+deletion-coupled cleanup (TD-2a) best left to its planned landing.

--- a/docs/proposals/2026-08-03-agent-sdk-readiness-recheck.md
+++ b/docs/proposals/2026-08-03-agent-sdk-readiness-recheck.md
@@ -1,7 +1,7 @@
 # Agent-SDK readiness re-check (agent core · model handler · logger · surface)
 
 > **Status:** Audit note. Written 2026-08-03, all figures recomputed at HEAD
-> `434b89d`. This is a *current-state* re-measurement, not a new plan. It sits
+> `434b89d`. This is a _current-state_ re-measurement, not a new plan. It sits
 > under the plan of record
 > [`2026-07-09-agent-sdk-north-star.md`](./2026-07-09-agent-sdk-north-star.md)
 > and the two measurements it depends on
@@ -21,7 +21,7 @@
 four areas the task names — agent core, model handler, logger, and the package
 surface — are already converged on the Claude-Agent-SDK shape by deliberate,
 documented work, and the guardrails that hold them there (the
-`config/ratchets/` baselines and the free-zone import fence) are *tightening*,
+`config/ratchets/` baselines and the free-zone import fence) are _tightening_,
 not slipping. This re-check adds evidence over the July docs: two of the four
 tracked "finish-the-endgame" deltas have since landed cleanly, the host
 boundary has measurably shrunk, and the fourth (TD-2a) turns out to already be
@@ -30,7 +30,7 @@ executed, since executing it would have broken the npm package's tested
 minimal-host contract for zero runtime benefit.
 
 This matches the standing conclusion of the `-05-30 → -07-26` chain: the open
-work is *deciding* the product line and shipping the package, not untangling
+work is _deciding_ the product line and shipping the package, not untangling
 abstractions. Re-deriving that here would duplicate ~23 prior docs.
 
 ## 1. Surface — `@texra-ai/agent` (`packages/agent/src/index.ts`)
@@ -71,7 +71,7 @@ API shape.
   `src/agent/runtime/README.md` — not a pass-through wrapper.
 - **The flow engine is not indirection.** `src/agent/node/index.ts` (~250 LoC)
   is the sole local definition of `BaseNode`/`Node`/`Flow`; nodes create and run
-  flows directly. There is no upstream-PocketFlow layer to collapse. (It *does*
+  flows directly. There is no upstream-PocketFlow layer to collapse. (It _does_
   carry an unattended-attribution license obligation — see B2 of the
   open-source-readiness audit — but that is a NOTICE file, not a refactor.)
 - **The session quartet is the seed surface** — `SessionHandle`,
@@ -123,7 +123,7 @@ first-class runtime concepts; there is nothing to newly carve out:
 - `AgentRosterController` (`src/agent/roster/`) — the multi-agent roster.
 - `detachSubagentsOnStop`, `resumeQueuedToolUse` — subagent lifecycle/resume.
 
-The delegation *tools* are exactly the closure that pulls in the heaviest import
+The delegation _tools_ are exactly the closure that pulls in the heaviest import
 graph (step-3 doc B1: 19 tools share one ~630-file closure), which is the real
 packaging seam for a multi-agent SDK — a decision about where the product line
 falls, already tracked, not a boundary to invent here.
@@ -133,13 +133,13 @@ falls, already tracked, not a boundary to invent here.
 The plan of record listed a four-item "finish-the-endgame" quartet (TD-2) and
 warned the host boundary was eroding. Re-measured:
 
-| Item | July status | HEAD `434b89d` |
-| --- | --- | --- |
-| Host `@agent/*` deep-import width (ext/cli/desktop) | 49 / 35 / 27, growing ~2.5/wk | **39 / 32 / 25** — shrunk; ratchet-frozen at current |
-| TD-2(b) phantom `RuntimeInteractionEventPayloads` arms | 6 to relocate | **landed** — symbol absent repo-wide |
-| TD-2(c) `runFact.` string-prefix protocol (dated v0.41) | retire on schedule | **landed** — absent under `src/agent` |
-| TD-2(a) `HostInteractions` request methods optional | 7/7 `?`, 6 runtime-hard-required | **retired, not executed** — optionality is the tested minimal-host contract the npm package depends on; see §7 |
-| TD-2(d) status dual-rail | complete atomically | trace `status` arm still present (`trace/events.ts:153`); not independently confirmed here |
+| Item                                                    | July status                      | HEAD `434b89d`                                                                                                 |
+| ------------------------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Host `@agent/*` deep-import width (ext/cli/desktop)     | 49 / 35 / 27, growing ~2.5/wk    | **39 / 32 / 25** — shrunk; ratchet-frozen at current                                                           |
+| TD-2(b) phantom `RuntimeInteractionEventPayloads` arms  | 6 to relocate                    | **landed** — symbol absent repo-wide                                                                           |
+| TD-2(c) `runFact.` string-prefix protocol (dated v0.41) | retire on schedule               | **landed** — absent under `src/agent`                                                                          |
+| TD-2(a) `HostInteractions` request methods optional     | 7/7 `?`, 6 runtime-hard-required | **retired, not executed** — optionality is the tested minimal-host contract the npm package depends on; see §7 |
+| TD-2(d) status dual-rail                                | complete atomically              | trace `status` arm still present (`trace/events.ts:153`); not independently confirmed here                     |
 
 ## 7. TD-2(a) re-investigated and retired (not executed — executing it would regress the SDK surface)
 
@@ -156,16 +156,16 @@ cleanup**, for reasons the July docs didn't have in front of them:
   `SessionHostInteractions.enqueue()`** (`HostInteractions.ts:594–618`), whose
   `dispatch()` (`:686–715`) treats a missing method on the attached host
   exactly like a normal decline: `if (!result) { …; pending.settle(pending
-  .cancellationResult()); return; }` — no crash, no thrown error, a typed
+.cancellationResult()); return; }` — no crash, no thrown error, a typed
   cancellation/deny result. `openExternalInquiry` is the deliberate exception,
   bypassing the queue to throw loud when unattached (comment at
   `HostInteractions.ts:525–528`).
 - **This is a tested, documented contract, not an accident.** `warnParked`'s
-  own message says it outright: *"A headless embedder must attach at least
-  `{ cancel: () => {} }`, or blocking requests never settle."*
+  own message says it outright: _"A headless embedder must attach at least
+  `{ cancel: () => {} }`, or blocking requests never settle."_
   `SessionInteractions.vitest.ts:606` (`'settles against the documented
-  minimal `{ cancel }` host'`) asserts exactly this: a bare `{ cancel: vi.fn()
-  }` host makes `requestPlanApproval` resolve `{ action: 'reject' }`, not
+minimal `{ cancel }` host'`) asserts exactly this: a bare `{ cancel: vi.fn()
+}` host makes `requestPlanApproval` resolve `{ action: 'reject' }`, not
   throw. Every other request method degrades the same way.
 - **The npm package depends on this contract to exist at all.**
   `packages/agent/src/index.ts:234–238` attaches `{ cancel, requestRetry }` —
@@ -187,7 +187,7 @@ cleanup**, for reasons the July docs didn't have in front of them:
   this codebase's own conventions rule out.
 
 **Verdict: retire TD-2(a).** The "optional-with-graceful-decline" shape is not
-residue from the dead legacy fallback A2 removed — it is the *replacement*
+residue from the dead legacy fallback A2 removed — it is the _replacement_
 design, already shipped, tested, and load-bearing for the npm package's
 minimal-host contract. Converting it to required would trade a working
 progressive-capability host model for a rigid one, for no runtime benefit


### PR DESCRIPTION
## Summary

Scheduled audit of the four areas named in the task — agent core, model handler, logger, and the `@texra-ai/agent` package surface — for Agent-SDK readiness, re-measured at HEAD against the existing plan of record (`docs/proposals/2026-07-09-agent-sdk-north-star.md`).

**Verdict: already well-aligned, no structural refactor needed.** All four areas already match the Claude-Agent-SDK shape by deliberate prior work. This PR is a documentation-only re-check plus a same-day correction after digging into the one item the July docs still listed as open:

- Host `@agent/*` deep-import width shrank to 39/32/25 (from 49/35/27) — the boundary ratchet is tightening, not eroding.
- Two of four tracked "finish-the-endgame" deltas (TD-2b phantom event arms, TD-2c `runFact.` prefix protocol) have landed cleanly and are confirmed gone at HEAD.
- The fourth, TD-2(a) — making `HostInteractions`' optional request methods required — was investigated in depth rather than executed. It turns out doing so would **regress** the SDK surface: all six affected methods already resolve through a tested "minimal host" fallback contract (`SessionHostInteractions.enqueue()`/`dispatch()`) that the npm package's `{ cancel, requestRetry }` implementation depends on to work at all, and ~25 test-kernel fixtures intentionally implement only 1–2 of the 7 methods per test. Converting to required would force dead stub code into the package this effort exists to keep minimal, for zero runtime benefit. Retired with evidence in §7 of the doc so it stops being re-proposed.

No production code was changed — every candidate refactor identified was either already done upstream or, on inspection, not a real improvement.

## Issue acceptance gates

No linked issue; this is a scheduled readiness audit. Acceptance gate: produce a grounded, evidence-backed current-state assessment of the four named areas, and either identify concrete refactors or confirm alignment. Both tracked candidate refactors (host boundary shrink, TD-2 quartet) were re-verified against source rather than restated from the prior docs.

## Single source of truth

N/A — no code changes. The doc itself becomes the source of truth for TD-2(a)'s status, superseding the "still open" framing in the 2026-07-09 north-star doc.

## Duplication and abstraction budget

N/A — docs-only change, no abstractions added or removed.

## Net elements (R6)

1 new file (`docs/proposals/2026-08-03-agent-sdk-readiness-recheck.md`), 0 exported symbols, 0 code files touched.

## Consumer counts (R8)

N/A — no emit paths, exports, or routes changed.

## Host impact

Extension: none (docs only).
Desktop: none (docs only).
CLI: none (docs only).

## Scheduled refactoring

None. TD-2(a) is retired, not deferred — see §7 of the doc for why executing it would be a regression rather than a cleanup.

## Validation

Every claim in the doc is grounded in a direct source read or grep at HEAD `434b89d` (host import-baseline JSON, `HostInteractions.ts` dispatch/enqueue logic, `SessionInteractions.vitest.ts:606`, `packages/agent/src/index.ts`, and a dedicated sweep of `src/test-kernel/**` for `HostInteractions` implementers). No build/test/lint run since no code changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0149bDnHb8Gervj1rgNcGvHw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single new markdown audit file; no runtime, API, or test behavior changes.
> 
> **Overview**
> Adds **`docs/dev/audits/2026-08-03-agent-sdk-readiness-checkpoint.md`**, a documentation-only re-measurement at HEAD against the Agent-SDK north-star plan. **No production or test code changes.**
> 
> The audit records that agent core, model handler, logger, and `@texra-ai/agent` are already aligned with the target SDK shape, with host `@agent/*` deep-import counts down (39/32/25 vs July’s 49/35/27) and TD-2(b)/(c) confirmed landed.
> 
> **TD-2(a)** — making optional `HostInteractions` request methods required — is **retired in §7** instead of executed: runtime `enqueue()`/`dispatch()` already treat missing methods as graceful declines, tests and `packages/agent` rely on a minimal `{ cancel, requestRetry }` host, and requiring all seven methods would add dead stubs without runtime gain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e01998dcbc6034df6f52478b288648f1ba28e27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->