### PR TITLE
refactor(agent): fix core-layer abstraction violations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -112,6 +112,11 @@ const AGENT_CORE_RESTRICTED_IMPORT_PATTERNS = [
     message:
       'Agent core must not import model handler implementations; move provider-neutral contracts to @agent/types or a core helper.',
   },
+  {
+    group: ['@tools', '@tools/**'],
+    message:
+      'Agent core must not depend on tool implementations; src/tools consumes agent/core, not the reverse — move shared logic to agent/core or @shared.',
+  },
   ...HOST_LAYER_RESTRICTED_IMPORT_PATTERNS,
 ];
 

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -15,8 +15,8 @@ import type { ProviderUsage } from '@agent/core/usage/ResponseUsage';
 import type { FinalTool } from '@agent/types/ModelHandlerContracts';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
+import { formatPostCompactionContext } from '@agent/core/flows/postCompactionContext';
 import { RetryErrorInfoSchema } from '@shared/schemas';
-import { formatPostCompactionContext } from '@tools/delegation/subagentResults';
 
 /** Base schema for fields common to all cycle flows. */
 export const BaseCycleFieldsSchema = z.object({

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -1,5 +1,3 @@
-import { dirname } from 'node:path';
-
 import { z } from 'zod';
 
 import { BaseNode, Flow } from '@agent/node';
@@ -26,7 +24,6 @@ import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import type { ToolDefinition } from '@model/ToolDefinition';
 import { MESSAGE_TYPES, AgentFileLocationSchema } from '@shared/schemas';
 import { OUTPUT_END_TAG } from '@shared/schemas/output';
-import { AbsoluteFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { extractScratchpad } from '@utils/text/xmlExtraction';
 
@@ -110,9 +107,11 @@ class ResponsePrepNode<C> extends BaseNode<
   ResponseCycleServices<C>
 > {
   async prep(shared: ResponseCycleShared): Promise<ResponsePrepResult> {
-    const { prompt, userVarChannels, runScope } = this.services;
+    const { prompt, userVarChannels, runScope, fileService } = this.services;
     const interrupted = runScope.signal.aborted;
-    const exists = await AbsoluteFS.exists(shared.outputLocation.absolutePath);
+    const exists = await fileService.pathExists(
+      shared.outputLocation.absolutePath,
+    );
     const systemPrompt = interrupted
       ? undefined
       : await getSystemPromptWithRules(prompt.systemPrompt, {
@@ -337,7 +336,7 @@ class ResponseProcessNode<C> extends BaseNode<
     prepRes: ProcessPrepResult,
     execRes: ProcessNodeResult,
   ): Promise<string | undefined> {
-    const { round, workspace, logger } = this.services;
+    const { round, workspace, logger, fileService } = this.services;
     const modelHandler = this.services.modelCell.handler;
 
     if (execRes.kind === 'skipped') {
@@ -376,11 +375,9 @@ class ResponseProcessNode<C> extends BaseNode<
     const { outputLocation } = shared;
     const connector = result.bestConnector;
 
-    await AbsoluteFS.ensureDir(dirname(outputLocation.absolutePath));
-
     if (!shared.outputExists) {
       logger.debug(`Creating new file: ${outputLocation.absolutePath}`);
-      await AbsoluteFS.write(
+      await fileService.writeFile(
         outputLocation.absolutePath,
         result.processedResponse,
       );
@@ -389,7 +386,7 @@ class ResponseProcessNode<C> extends BaseNode<
       logger.debug(
         `Appending to existing file: ${outputLocation.absolutePath}`,
       );
-      await AbsoluteFS.appendFile(
+      await fileService.appendFile(
         outputLocation.absolutePath,
         connector + result.processedResponse,
       );

--- a/src/agent/core/flows/postCompactionContext.ts
+++ b/src/agent/core/flows/postCompactionContext.ts
@@ -1,0 +1,91 @@
+/**
+ * Post-compaction execution context: formats active subagents, todos, and the
+ * work plan as XML so the agent can pick up its task after context has been
+ * compacted (summarized) mid-run.
+ */
+
+import type {
+  ActiveChildInfo,
+  TodoItem,
+  WorkPlanSnapshot,
+} from '@shared/schemas';
+import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
+
+/**
+ * Format active execution state as context for the agent after compaction.
+ * Returns null if there are no active children to report.
+ *
+ * This helps the agent understand what subagents are still running after
+ * context was compressed, so it can:
+ * - Avoid launching duplicate subagents
+ * - Know which execution IDs to check on
+ * - Understand that pending results may arrive as follow-up messages
+ */
+export function formatPostCompactionContext(
+  subagents: ActiveChildInfo[],
+  workPlan?: WorkPlanSnapshot | null,
+): string | null {
+  const hasChildren = subagents.length > 0;
+  const todos = workPlan?.todos ?? [];
+  const hasTodos = todos.length > 0;
+  const hasPlan = workPlan?.plan != null || workPlan?.planSummary != null;
+
+  if (!hasChildren && !hasTodos && !hasPlan) {
+    return null;
+  }
+
+  let note =
+    'Your conversation context was compacted (summarized) to free up space. The following state was preserved from before compaction.';
+  if (hasChildren) {
+    note +=
+      ' Any active executions listed below may still be running and their results will be delivered as follow-up messages when they complete.';
+  }
+  note +=
+    ' Continue the task from this state — do not stop, re-plan from scratch, or suggest starting a new session.';
+
+  const lines: string[] = ['<post-compaction-context>', `<note>${note}</note>`];
+
+  if (hasChildren) {
+    lines.push(`<active-subagents count="${subagents.length}">`);
+    for (const sa of subagents) {
+      const statusAttr = sa.status ? ` status="${escapeAttr(sa.status)}"` : '';
+      const elapsedAttr = sa.elapsed
+        ? ` elapsed="${escapeAttr(sa.elapsed)}"`
+        : '';
+      lines.push(
+        `  <subagent id="${escapeAttr(sa.executionId)}" agent="${escapeAttr(sa.agentName)}"${statusAttr}${elapsedAttr} />`,
+      );
+    }
+    lines.push('</active-subagents>');
+  }
+
+  if (hasTodos) {
+    lines.push(...formatTodoContext(todos));
+  }
+
+  if (hasPlan) {
+    lines.push(...formatPlanContext(workPlan));
+  }
+
+  lines.push('</post-compaction-context>');
+  return lines.join('\n');
+}
+
+/** Format todo items as XML lines for post-compaction context. */
+function formatTodoContext(todos: TodoItem[]): string[] {
+  const lines: string[] = [`<current-todos count="${todos.length}">`];
+  for (const todo of todos) {
+    lines.push(
+      `  <todo status="${escapeAttr(todo.status)}" activeForm="${escapeAttr(todo.activeForm)}">${escapeText(todo.content)}</todo>`,
+    );
+  }
+  lines.push('</current-todos>');
+  return lines;
+}
+
+/** Format the plan document as XML lines for post-compaction context. */
+function formatPlanContext(workPlan: WorkPlanSnapshot): string[] {
+  const objective = workPlan.plan?.objective ?? workPlan.planSummary;
+  if (!objective) return [];
+  return ['<current-plan>', escapeText(objective), '</current-plan>'];
+}

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -16,7 +16,7 @@ import {
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
 import type { FileLocation } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';
-import { AbsoluteFS, pathToLocation } from '@utils/files';
+import { pathToLocation } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 
 // Local file imports
@@ -487,7 +487,7 @@ export class ToolUseDispatchNode<C> extends Node<
     const { call, result, parsedInput, extracted, editedFiles, logRef } =
       execResult;
     const options = this.services;
-    const { workspace } = options;
+    const { workspace, fileService } = options;
 
     // The status discriminator belongs to model-facing tool results. Progress
     // logs should expose only visible tool content.
@@ -530,7 +530,7 @@ export class ToolUseDispatchNode<C> extends Node<
         }
         const location = pathToLocation(attachment.path);
         try {
-          if (await AbsoluteFS.exists(location.absolutePath)) {
+          if (await fileService.pathExists(location.absolutePath)) {
             validLocations.push(location);
           }
         } catch (err) {

--- a/src/tools/delegation/subagentResults.ts
+++ b/src/tools/delegation/subagentResults.ts
@@ -20,13 +20,7 @@ import {
   type ResultDiffSummary,
 } from '@agent/runtime/AgentFinalResult';
 import { normalizeProviderError } from '@common/errors';
-import type {
-  ActiveChildInfo,
-  ExecutionId,
-  SubagentProgressUpdate,
-  TodoItem,
-  WorkPlanSnapshot,
-} from '@shared/schemas';
+import type { ExecutionId, SubagentProgressUpdate } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
 import type { OutputFileSummary } from '@shared/schemas/output';
 import type { ExecResult } from '@shared/schemas/opResults';
@@ -426,93 +420,6 @@ export function formatBashError(
     },
     { message: toErrorMessage(err) },
   );
-}
-
-// ============================================================================
-// Post-compaction execution context
-// ============================================================================
-
-/**
- * Format active execution state as context for the agent after compaction.
- * Returns null if there are no active children to report.
- *
- * This helps the agent understand what subagents are still running after
- * context was compressed, so it can:
- * - Avoid launching duplicate subagents
- * - Know which execution IDs to check on
- * - Understand that pending results may arrive as follow-up messages
- */
-export function formatPostCompactionContext(
-  subagents: ActiveChildInfo[],
-  workPlan?: WorkPlanSnapshot | null,
-): string | null {
-  const hasChildren = subagents.length > 0;
-  const todos = workPlan?.todos ?? [];
-  const hasTodos = todos.length > 0;
-  const hasPlan = workPlan?.plan != null || workPlan?.planSummary != null;
-
-  if (!hasChildren && !hasTodos && !hasPlan) {
-    return null;
-  }
-
-  let note =
-    'Your conversation context was compacted (summarized) to free up space. The following state was preserved from before compaction.';
-  if (hasChildren) {
-    note +=
-      ' Any active executions listed below may still be running and their results will be delivered as follow-up messages when they complete.';
-  }
-  note +=
-    ' Continue the task from this state — do not stop, re-plan from scratch, or suggest starting a new session.';
-
-  const lines: string[] = ['<post-compaction-context>', `<note>${note}</note>`];
-
-  if (hasChildren) {
-    lines.push(`<active-subagents count="${subagents.length}">`);
-    for (const sa of subagents) {
-      const statusAttr = sa.status ? ` status="${escapeAttr(sa.status)}"` : '';
-      const elapsedAttr = sa.elapsed
-        ? ` elapsed="${escapeAttr(sa.elapsed)}"`
-        : '';
-      lines.push(
-        `  <subagent id="${escapeAttr(sa.executionId)}" agent="${escapeAttr(sa.agentName)}"${statusAttr}${elapsedAttr} />`,
-      );
-    }
-    lines.push('</active-subagents>');
-  }
-
-  if (hasTodos) {
-    lines.push(...formatTodoContext(todos));
-  }
-
-  if (hasPlan) {
-    lines.push(...formatPlanContext(workPlan));
-  }
-
-  lines.push('</post-compaction-context>');
-  return lines.join('\n');
-}
-
-/**
- * Format todo items as XML lines for post-compaction context.
- */
-function formatTodoContext(todos: TodoItem[]): string[] {
-  const lines: string[] = [`<current-todos count="${todos.length}">`];
-  for (const todo of todos) {
-    lines.push(
-      `  <todo status="${escapeAttr(todo.status)}" activeForm="${escapeAttr(todo.activeForm)}">${escapeText(todo.content)}</todo>`,
-    );
-  }
-  lines.push('</current-todos>');
-  return lines;
-}
-
-/**
- * Format the plan document as XML lines for post-compaction context.
- */
-function formatPlanContext(workPlan: WorkPlanSnapshot): string[] {
-  const objective = workPlan.plan?.objective ?? workPlan.planSummary;
-  if (!objective) return [];
-  return ['<current-plan>', escapeText(objective), '</current-plan>'];
 }
 
 function lastNLines(text: string, n: number): string {

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -187,11 +187,12 @@ export class TaskRunFileService {
     await AbsoluteFS.write(absolutePath, content);
   }
 
-  /** Append text to an existing file at an absolute path. */
+  /** Append text to a file at an absolute path, creating parent directories first. */
   public async appendFile(
     absolutePath: string,
     content: string,
   ): Promise<void> {
+    await AbsoluteFS.ensureDir(path.dirname(absolutePath));
     await AbsoluteFS.appendFile(absolutePath, content);
   }
 

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -10,6 +10,7 @@ import {
   workflowOutputRoundDir,
 } from '@shared/constants/workflowOutput';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { AbsoluteFS } from './absoluteFS';
 import {
   createExternalLocation,
   createRunStorageLocation,
@@ -173,6 +174,25 @@ export class TaskRunFileService {
       runStorageLocationFromAnyAbsolutePath(inputPath) ??
       pathToLocation(inputPath)
     );
+  }
+
+  /** Whether a file exists at the given absolute path. */
+  public async pathExists(absolutePath: string): Promise<boolean> {
+    return AbsoluteFS.exists(absolutePath);
+  }
+
+  /** Write text to an absolute path, creating parent directories first. */
+  public async writeFile(absolutePath: string, content: string): Promise<void> {
+    await AbsoluteFS.ensureDir(path.dirname(absolutePath));
+    await AbsoluteFS.write(absolutePath, content);
+  }
+
+  /** Append text to an existing file at an absolute path. */
+  public async appendFile(
+    absolutePath: string,
+    content: string,
+  ): Promise<void> {
+    await AbsoluteFS.appendFile(absolutePath, content);
   }
 
   /**


### PR DESCRIPTION
## Summary

Follows up on a scheduled abstraction-layer audit that found two concrete, previously-unflagged violations in `src/agent/core`, both fixed here:

1. **`agent/core` bypassed its own DI seam for filesystem access.** `ResponseCycleFlow.ts` and `ToolUseDispatchNode.ts` imported the static `AbsoluteFS` class directly for output writes and media-attachment existence checks, instead of going through `services.fileService` (`TaskRunFileService`) — the run-scoped file service every other operation in this module already uses. Added `pathExists`/`writeFile`/`appendFile` to `TaskRunFileService` and routed both nodes through it.
2. **Inverted dependency: `agent/core` importing from `src/tools`.** `CommonCycleTypes.ts` imported `formatPostCompactionContext` from `src/tools/delegation/subagentResults.ts` — backwards, since `src/tools` is meant to consume `agent/core`, not the reverse. The function is pure XML formatting with no `src/tools`-specific dependency and had exactly one caller (this file), so it moved wholesale to a new `src/agent/core/flows/postCompactionContext.ts`.

## Issue acceptance gates

No tracked issue — found and fixed during a scheduled architecture audit. Both violations are resolved: no more direct `AbsoluteFS` imports in `src/agent/core`, and no more `@tools` imports from `src/agent/core`.

## Single source of truth

`TaskRunFileService` (`src/utils/files/taskRunStorage.ts`) is now the single run-scoped file-access surface for `agent/core` flow nodes — the existing "the run-scoped file service ... both inner primitives operate on" role documented in `CycleServices.ts`, extended to cover output writes/existence checks rather than only snapshot/mirror management.

## Duplication and abstraction budget

No new abstraction layer: `pathExists`/`writeFile`/`appendFile` are three lean methods added to an existing, already-injected service class, not a new port/factory. No pass-through wrappers introduced. `formatPostCompactionContext` was relocated, not wrapped — same function body, same single caller, new home.

## Net elements (R6)

- Files: 6 modified, 1 added (`postCompactionContext.ts`), net **+1** file.
- Diff: +128 / -108 lines (net +20), most of it the relocated function plus its docblock.
- Exported symbols: `formatPostCompactionContext` removed from `subagentResults.ts`, re-added in `postCompactionContext.ts` — net **0** new exports. Three new public methods on `TaskRunFileService` (not module-level exports).
- No classes/interfaces/enums added.

## Consumer counts (R8)

- `formatPostCompactionContext`: grepped, exactly 1 caller repo-wide (`CommonCycleTypes.ts`) both before and after the move — import path updated, no other consumer affected.
- `AbsoluteFS` direct calls removed: 2 call sites (`ResponseCycleFlow.ts`, `ToolUseDispatchNode.ts`), both re-routed to `fileService`, no other caller depended on the removed imports.

## Host impact

Extension: none — `agent/core` is host-agnostic; this only changes how it reaches the filesystem internally.

Desktop: none.

CLI: none.

## Scheduled refactoring

None — this closes out both findings from the audit; no further follow-up planned. (Optional, not done here: `AgentWorkspaceState.ts` importing `@utils/files`'s `pathToLocation` is low-severity and arguably fine since it already routes through the platform port — left as-is.)

## Validation

- `npm run typecheck` — full workspace, clean.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — no new unused exports (18 baselined, 18 current).
- `npx vitest run src/test-kernel/agent src/test-kernel/tools src/test-kernel/utils` — 314 files / 3166 tests passed (4 skipped, pre-existing).
- `npx vitest run src/test-kernel/architecture/` — all 11 architecture-ratchet suites pass, including `dependencyDirection`, `subsystemEdgeRatchet`, and `hostAgentDeepImportRatchet`.
- Added `@tools`/`@tools/**` to `agent/core`'s `no-restricted-imports` patterns in `eslint.config.mjs` so this inversion can't silently recur.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FeXts7fXmKjRC5xuF4AbGs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with behavior-preserving moves and DI routing; no auth, security, or API surface changes for hosts.
> 
> **Overview**
> Fixes two **agent/core** architecture violations from a layer audit: filesystem access now goes through the injected run-scoped service, and post-compaction XML formatting no longer lives under `src/tools`.
> 
> **`ResponseCycleFlow`** and **`ToolUseDispatchNode`** previously called static **`AbsoluteFS`** for output existence checks, writes, and appends. Those call sites now use **`services.fileService`** via new **`pathExists`**, **`writeFile`**, and **`appendFile`** on **`TaskRunFileService`**.
> 
> **`formatPostCompactionContext`** moved from **`subagentResults.ts`** into **`src/agent/core/flows/postCompactionContext.ts`** so **`CommonCycleTypes`** no longer imports **`@tools`**. ESLint **`no-restricted-imports`** for **`src/agent/core`** now blocks **`@tools/**`** to prevent recurrence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cda45d418130ee0392b2ce974e196630510b5089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->