### PR TITLE
refactor(model): share OpenAI client construction across handlers

### DIFF
--- a/src/agent/modelHandlers/openai/OpenAICompatibleModelHandler.ts
+++ b/src/agent/modelHandlers/openai/OpenAICompatibleModelHandler.ts
@@ -1,0 +1,72 @@
+// Third-party imports
+import OpenAI from 'openai';
+
+// Local imports
+import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import type { ProviderMessage } from '@agent/types/ProviderMessage';
+import type {
+  ModelCredentialSelection,
+  SdkToolCall,
+} from '@agent/types/ModelHandlerContracts';
+
+// Local file imports
+import { logOpenAICompatibleClientConfig } from './openAIChatHelpers';
+
+/**
+ * Shared mechanics for handlers that talk to an OpenAI-compatible endpoint
+ * through the `openai` SDK client. The client-construction, `getClient`, and
+ * retry-endpoint contract live here so the Chat Completions
+ * ({@link ModelHandlerOpenAI}) and Responses ({@link ModelHandlerOpenAIResponse})
+ * handlers do not each re-implement byte-identical copies.
+ *
+ * Generic over the same wire types as {@link ModelHandler} (`M`/`U`/`T`/`Resp`/
+ * `Media`), with the client type pinned to {@link OpenAI} — the one axis all
+ * OpenAI-compatible handlers share.
+ */
+export abstract class OpenAICompatibleModelHandler<
+  M extends ProviderMessage = ProviderMessage,
+  U = unknown,
+  T extends SdkToolCall = SdkToolCall,
+  Resp = unknown,
+  Media = unknown,
+> extends ModelHandler<M, U, T, OpenAI, Resp, Media> {
+  /**
+   * Creates a new OpenAI client using the stored credentials.
+   * Handles API key retrieval, base URL resolution, and logging.
+   */
+  protected async createOpenAIClient(
+    selection: ModelCredentialSelection = 'configured',
+  ): Promise<OpenAI> {
+    const credential = await this.resolveClientCredential(selection);
+    // there is a time out parameter that can be set; default is 10 minutes
+    const client = new OpenAI({
+      apiKey: credential.apiKey,
+      baseURL: credential.baseUrl,
+      fetch: this.longRunningModelFetch,
+      maxRetries: 0,
+    });
+    logOpenAICompatibleClientConfig(
+      this.logger,
+      this.config,
+      client.baseURL,
+      credential.route,
+      this.shouldUseServerSideKeys(),
+    );
+    return this.rememberClientCredentialRoute(
+      client,
+      credential.route,
+      credential.apiKey,
+    );
+  }
+
+  /** Returns OpenAI client with configured API key. */
+  async getClient(
+    selection: ModelCredentialSelection = 'configured',
+  ): Promise<OpenAI> {
+    return this.createOpenAIClient(selection);
+  }
+
+  override getRetryEndpoint(client: OpenAI): string {
+    return client.baseURL;
+  }
+}

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -21,7 +21,6 @@ import type {
   CreateResponseResult,
   ExtractResponseResult,
   DeepSeekToolCall,
-  ModelCredentialSelection,
   OpenAIToolCall,
 } from '@agent/types/ModelHandlerContracts';
 import {
@@ -69,11 +68,11 @@ import {
 import {
   extractOpenAIPartialTail,
   extractReasoningDelta as extractReasoningDeltaFromChunk,
-  logOpenAICompatibleClientConfig,
 } from './openAIChatHelpers';
 import { toOpenAITools } from '../toolConversion';
 import { formatToolResultTextWithAttachments } from '../utils/toolAttachmentUtils';
 import { ModelHandler } from '../ModelHandler';
+import { OpenAICompatibleModelHandler } from './OpenAICompatibleModelHandler';
 import {
   BaseReasoningStreamAggregator,
   type StreamingAggregator,
@@ -169,11 +168,10 @@ function classifyOpenAIResponse(responseObject: any): OpenAIClassifiedResponse {
  */
 export class ModelHandlerOpenAI<
   TCall extends OpenAIToolCall | DeepSeekToolCall = OpenAIToolCall,
-> extends ModelHandler<
+> extends OpenAICompatibleModelHandler<
   ChatCompletionMessageParam,
   ExtendedCompletionUsage | null,
   TCall,
-  OpenAI,
   ChatCompletion,
   ChatCompletionContentPart
 > {
@@ -237,46 +235,6 @@ export class ModelHandlerOpenAI<
         content: summary,
       }),
     );
-  }
-
-  /**
-   * Creates a new OpenAI client using the stored credentials.
-   * Handles API key retrieval, base URL resolution, and logging.
-   */
-  protected async createOpenAIClient(
-    selection: ModelCredentialSelection = 'configured',
-  ): Promise<OpenAI> {
-    const credential = await this.resolveClientCredential(selection);
-    // there is a time out parameter that can be set; default is 10 minutes
-    const client = new OpenAI({
-      apiKey: credential.apiKey,
-      baseURL: credential.baseUrl,
-      fetch: this.longRunningModelFetch,
-      maxRetries: 0,
-    });
-    logOpenAICompatibleClientConfig(
-      this.logger,
-      this.config,
-      client.baseURL,
-      credential.route,
-      this.shouldUseServerSideKeys(),
-    );
-    return this.rememberClientCredentialRoute(
-      client,
-      credential.route,
-      credential.apiKey,
-    );
-  }
-
-  /** Returns OpenAI client with configured API key. */
-  async getClient(
-    selection: ModelCredentialSelection = 'configured',
-  ): Promise<OpenAI> {
-    return this.createOpenAIClient(selection);
-  }
-
-  override getRetryEndpoint(client: OpenAI): string {
-    return client.baseURL;
   }
 
   /**

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -24,7 +24,6 @@ import type {
   CreateResponseOptions,
   CreateResponseResult,
   ExtractResponseResult,
-  ModelCredentialSelection,
   OpenAIResponseToolCall,
   TokenCountOptions,
 } from '@agent/types/ModelHandlerContracts';
@@ -72,7 +71,6 @@ import {
   normalizeOpenAIResponseUsage,
 } from './openAIUsage';
 import { tagOpenAISdkError } from './openAISdkError';
-import { logOpenAICompatibleClientConfig } from './openAIChatHelpers';
 import { normalizeOpenAIResponseError } from './openAIResponseErrors';
 import {
   formatAttachmentSummary,
@@ -80,7 +78,7 @@ import {
   uploadAndRecordToolAttachments,
 } from '../utils/toolAttachmentUtils';
 import { toOpenAIResponseTools } from '../toolConversion';
-import { ModelHandler } from '../ModelHandler';
+import { OpenAICompatibleModelHandler } from './OpenAICompatibleModelHandler';
 import {
   CHAINED_RESPONSE_MAX_OUTPUT_FACTOR,
   CHAINED_RESPONSE_SAFETY_MARGIN_PERCENT,
@@ -287,11 +285,10 @@ function mergeMissingStreamedOutputItems(
  * owns) must be used by a single agent execution at a time. Do not share
  * instances across concurrent invocations.
  */
-export class ModelHandlerOpenAIResponse extends ModelHandler<
+export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
   ResponseInputItem,
   ResponseUsage,
   OpenAIResponseToolCall,
-  OpenAI,
   Response,
   ResponseInputContent
 > {
@@ -912,7 +909,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * stored response for the compact endpoint to act on (#7213). Summarizes
    * the conversation locally via a throwaway system-prompt-swap call to the
    * same Responses API, then resends a single summary message instead of the
-   * full history. Reuses the {@link ModelHandler.runClientCompaction} scaffold
+   * full history. Reuses the `ModelHandler.runClientCompaction` scaffold
    * already shared by the Chat Completions, OpenRouter-native, and Google
    * Interactions handlers.
    *
@@ -1112,42 +1109,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // a same-turn retry, resend this turn's stale compactedMessages, and
     // silently drop everything appended since (tool outputs, new user turns).
     this.compactionResult = undefined;
-  }
-
-  /** Creates a configured OpenAI client instance. */
-  protected async createOpenAIClient(
-    selection: ModelCredentialSelection = 'configured',
-  ): Promise<OpenAI> {
-    const credential = await this.resolveClientCredential(selection);
-    const client = new OpenAI({
-      apiKey: credential.apiKey,
-      baseURL: credential.baseUrl,
-      fetch: this.longRunningModelFetch,
-      maxRetries: 0,
-    });
-    logOpenAICompatibleClientConfig(
-      this.logger,
-      this.config,
-      client.baseURL,
-      credential.route,
-      this.shouldUseServerSideKeys(),
-    );
-    return this.rememberClientCredentialRoute(
-      client,
-      credential.route,
-      credential.apiKey,
-    );
-  }
-
-  /** Returns OpenAI client with configured API key. */
-  async getClient(
-    selection: ModelCredentialSelection = 'configured',
-  ): Promise<OpenAI> {
-    return this.createOpenAIClient(selection);
-  }
-
-  override getRetryEndpoint(client: OpenAI): string {
-    return client.baseURL;
   }
 
   /** Reset conversation bookkeeping when starting a new session. */


### PR DESCRIPTION
## Summary

The Chat Completions handler (`ModelHandlerOpenAI`) and the Responses handler (`ModelHandlerOpenAIResponse`) each carried a byte-identical copy of the OpenAI client plumbing — `createOpenAIClient`, `getClient`, and `getRetryEndpoint`. This PR hoists that trio into a new intermediate base class, `OpenAICompatibleModelHandler`, that both handlers now extend. No behavior change.

The new base mirrors the existing `GoogleModelHandlerBase` pattern: it pins the SDK client type to `OpenAI` while staying generic over the message / usage / tool-call / response / media wire types, so each concrete handler keeps its own type parameters. `ModelHandlerCodex` (which extends `ModelHandlerOpenAIResponse`) keeps its `createOpenAIClient` override; its `super.createOpenAIClient(...)` call now resolves up the prototype chain to the shared base — verified by the existing Codex fallback tests.

This is the smallest, fully self-contained slice of a broader model-handler duplication finding from a tech-debt audit; the larger per-provider streaming-envelope and background-lifecycle consolidations are noted below as follow-ups.

## Issue acceptance gates

No tracking issue — surfaced by a tech-debt audit of `src/agent/modelHandlers/`. Gate satisfied: eliminate the duplicated OpenAI client-construction code without changing runtime behavior.

## Single source of truth

`OpenAICompatibleModelHandler` (`src/agent/modelHandlers/openai/OpenAICompatibleModelHandler.ts`) now owns OpenAI-compatible client construction, the `getClient` contract, and the retry-endpoint resolution for every handler that talks to an OpenAI SDK client.

## Duplication and abstraction budget

Removed one full copy (~41 lines) of the `createOpenAIClient` / `getClient` / `getRetryEndpoint` trio that was duplicated between the Chat and Responses handlers. The one new abstraction is an intermediate base class whose invariant is "handlers reaching an OpenAI-compatible endpoint through the `openai` SDK share client construction"; it pins the `ModelHandler` client-type parameter to `OpenAI` and adds no pass-through layer (the methods live on the base and are inherited directly, exactly as `GoogleModelHandlerBase` does for `GoogleGenAI`).

## Net elements (R6)

- Files: +1 (`OpenAICompatibleModelHandler.ts`), 2 modified. Diffstat: `3 files changed, 77 insertions(+), 86 deletions(-)`.
- Exported symbols: +1 (`export abstract class OpenAICompatibleModelHandler`). The `ModelHandlerOpenAIResponse` export is unchanged apart from its base clause.
- Classes: +1 abstract class.
- Net LoC: −9 (one duplicated copy of the ~41-line trio removed; the single retained copy plus doc comments lives in the base).

## Consumer counts (R8)

New export `OpenAICompatibleModelHandler` has 2 direct consumers — `modelHandlerOpenAI.ts` and `modelHandlerOpenAIResponse.ts` (and `ModelHandlerCodex` transitively). No emit path or existing export was deleted or re-routed; the three moved methods keep identical signatures and inherited call sites.

## Host impact

Extension: no change — consumes the shared agent core; model-handler behavior identical.

Desktop: no change — same.

CLI: no change — same.

## Scheduled refactoring

Follow-ups from the same audit, not included here to keep this PR self-contained and behavior-preserving:
- Generalize `BackgroundRunLifecycle` so the Google Interactions handler's ~350-line inline background loop reuses it (comments already say "Mirrors ModelHandlerOpenAIResponse").
- Extract a shared streaming open/consume/finalize-on-error envelope duplicated across the OpenAI, Responses, OpenRouter, and Google handlers.
- Consider folding `ModelHandlerOpenRouterNative` (also OpenAI-SDK based) into the same base.

## Validation

- `npm run typecheck` — passes across all 7 workspaces (workspace, test-kernel, agent, extension, cli, trace-viewer, desktop).
- `npx eslint` on the three changed files — clean (exit 0).
- `npx prettier --check` on the three files — clean.
- `npx vitest run src/test-kernel/agent/modelHandlers/` — 690 passed, 4 skipped (includes `ModelHandlerOpenAIClientDiagnostics`, `ModelClientRouteSnapshot`, `CodexSubscriptionFallback`, `LongRunningModelFetch`, which exercise the refactored client path).
- `npm run check:dead-code-ratchet` — OK, no new unused files/exports/types (new export has its consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbgeYN99u6xX2yJjvsX148

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbgeYN99u6xX2yJjvsX148)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure structural deduplication of identical client plumbing; signatures and logic are moved, not altered. Codex override path remains via super.
> 
> **Overview**
> Introduces **`OpenAICompatibleModelHandler`**, an intermediate base (same idea as `GoogleModelHandlerBase`) that owns OpenAI SDK client setup for handlers that speak OpenAI-compatible APIs.
> 
> **`ModelHandlerOpenAI`** and **`ModelHandlerOpenAIResponse`** now extend this base instead of **`ModelHandler`** directly. The duplicated **`createOpenAIClient`**, **`getClient`**, and **`getRetryEndpoint`** implementations are removed from both concrete handlers and inherited unchanged.
> 
> Wire-type generics stay on each handler; only the client type is pinned to **`OpenAI`**. Subclasses such as Codex that override **`createOpenAIClient`** still call **`super.createOpenAIClient`** up the new hierarchy. No intended runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caab9144dd12d62aa929054bc91a8bdb8cc0fe38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->