### PR TITLE
refactor(platform): move tool-edit-approval types to their real owner

### DIFF
--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -2,10 +2,6 @@ import { createChannelTrace } from '@agent/trace';
 import type { ReviewIssueReport } from '@agent/review/reviewIssues';
 import type { ModelCredentialSelection } from '@agent/types/ModelHandlerContracts';
 import type {
-  ToolEditApprovalRequest,
-  ToolEditApprovalResult,
-} from '@platform/interfaces';
-import type {
   AgentProposal,
   FileLocation,
   Plan,
@@ -17,6 +13,10 @@ import type {
   UserQuestionPermission,
 } from '@shared/schemas';
 import { SESSION_DISPOSED_CAUSE } from '@shared/copy/interactionCancellation';
+import type {
+  ToolEditApprovalRequest,
+  ToolEditApprovalResult,
+} from '@tools/approval/toolEditApproval';
 import { createListenerSet, type ListenerSet } from '@utils/core/listenerSet';
 import type { GenericDiagnostic } from '@utils/diagnostics/diagnosticFormatting';
 import type {

--- a/src/controllers/progressView/backend/progressHostInteractions.ts
+++ b/src/controllers/progressView/backend/progressHostInteractions.ts
@@ -22,13 +22,13 @@ import {
 } from '@agent/runtime/HostInteractions';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ToolEditApprovalController } from '@controllers/approval/ToolEditApprovalController';
-import type {
-  ToolEditApprovalRequest,
-  ToolEditApprovalResult,
-} from '@platform/interfaces';
 import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
 import { SESSION_DISPOSED_CAUSE } from '@shared/copy/interactionCancellation';
 import { prepareBashApprovalPrompt } from '@tools/approval/bashApproval';
+import type {
+  ToolEditApprovalRequest,
+  ToolEditApprovalResult,
+} from '@tools/approval/toolEditApproval';
 
 import {
   cancelApprovalRequestHandlers,

--- a/src/platform/interfaces.ts
+++ b/src/platform/interfaces.ts
@@ -243,49 +243,6 @@ export const NO_TOOL_AVAILABILITY_HOST: ToolAvailabilityHost = Object.freeze({
 });
 
 // ---------------------------------------------------------------------------
-// Tool-edit approval
-// ---------------------------------------------------------------------------
-
-/**
- * Tool-edit approval request / result shapes.
- *
- * Hosts receive these through `SessionHandle.interactions`, not through the
- * process-wide Platform object. `@tools/approval/toolEditApproval` re-exports
- * these types for existing approval call sites.
- */
-
-/** Platform-level contract for a tool-edit approval request. */
-export interface ToolEditApprovalRequest {
-  readonly path: string;
-  readonly originalContent: string;
-  readonly proposedContent: string;
-  readonly sourceTool: string;
-  readonly streamId?: string | null;
-}
-
-/**
- * Platform-level contract for a tool-edit approval result. `appliedContent`
- * is required on acceptance — every host implementation always supplies the
- * content the user actually approved, so this is a type-level guarantee
- * rather than a convention callers must null-check.
- */
-export type ToolEditApprovalResult =
-  | {
-      readonly accepted: true;
-      readonly appliedContent: string;
-      readonly userPatch?: string;
-      readonly lineChanges?: {
-        readonly added: number;
-        readonly removed: number;
-      };
-      readonly startLine?: number;
-    }
-  | {
-      readonly accepted: false;
-      readonly userMessage?: string;
-    };
-
-// ---------------------------------------------------------------------------
 // Tool notifications
 // ---------------------------------------------------------------------------
 

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -12,15 +12,15 @@ import type { SessionEvent } from '@agent/runtime/SessionEventHub';
 import type { DesktopAgentExecutionHost } from '@desktop/main/desktopAgentExecutionHost';
 import type { DiffOptions, DiffSession, DiffSource } from '@hosts/uiHosts';
 
-import type {
-  ToolEditApprovalRequest,
-  ToolEditApprovalResult,
-} from '@platform/interfaces';
 import type { ToolEditPermission } from '@shared/schemas';
 import { SESSION_DISPOSED_CAUSE } from '@shared/copy/interactionCancellation';
 import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
 import { createModuleMocks } from '@test/support/moduleMocks';
 import { createTestSession } from '@test/support/sessionTestUtils';
+import type {
+  ToolEditApprovalRequest,
+  ToolEditApprovalResult,
+} from '@tools/approval/toolEditApproval';
 import { delay } from '@utils/core';
 import {
   createStubDesktopAgentExecutionHost,

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -10,10 +10,6 @@ import {
 } from '@agent/runtime/RunContext';
 import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import { isLatexFile } from '@common/files/fileTypeUtils';
-import type {
-  ToolEditApprovalRequest,
-  ToolEditApprovalResult,
-} from '@platform/interfaces';
 import type { StreamTabId, ToolEditPermission } from '@shared/schemas';
 import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
 import type { LineChanges } from '@shared/schemas/lineChanges';
@@ -33,7 +29,41 @@ import {
 } from '@utils/text/diff';
 import { countLines } from '@utils/text/stringUtils';
 
-export type { ToolEditApprovalRequest, ToolEditApprovalResult };
+/**
+ * Tool-edit approval request / result shapes.
+ *
+ * Hosts receive these through `SessionHandle.interactions`, not through the
+ * process-wide Platform object — this is a session-scoped host-interaction
+ * contract, not a `Platform` port.
+ */
+export interface ToolEditApprovalRequest {
+  readonly path: string;
+  readonly originalContent: string;
+  readonly proposedContent: string;
+  readonly sourceTool: string;
+  readonly streamId?: string | null;
+}
+
+/**
+ * `appliedContent` is required on acceptance — every host implementation
+ * always supplies the content the user actually approved, so this is a
+ * type-level guarantee rather than a convention callers must null-check.
+ */
+export type ToolEditApprovalResult =
+  | {
+      readonly accepted: true;
+      readonly appliedContent: string;
+      readonly userPatch?: string;
+      readonly lineChanges?: {
+        readonly added: number;
+        readonly removed: number;
+      };
+      readonly startLine?: number;
+    }
+  | {
+      readonly accepted: false;
+      readonly userMessage?: string;
+    };
 
 const TOOL_EDIT_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireEditApproval';
 


### PR DESCRIPTION
## Summary

Found while auditing the codebase for confusing/overlapped responsibilities (scheduled task, not tied to an open issue).

`ToolEditApprovalRequest`/`ToolEditApprovalResult` were defined in `src/platform/interfaces.ts`, whose own module doc says it holds only "the host-neutral interfaces a host wires into `initPlatform()`." The two types directly contradicted that: their own doc comment said "Hosts receive these through `SessionHandle.interactions`, not through the process-wide Platform object" — immediately followed by a JSDoc line calling them a "Platform-level contract." They aren't installed through `initPlatform()` at all.

Meanwhile `src/tools/approval/toolEditApproval.ts` — which owns every function that builds and consumes these types (`prepareToolEditApprovalPrompt`, `requestToolEditApproval`, `finalizeApprovalResult`) — had to import them back from `@platform/interfaces` just to re-export them. Two other production files (`src/agent/runtime/HostInteractions.ts`, `src/controllers/progressView/backend/progressHostInteractions.ts`) and one test file reached past that re-export straight into `@platform/interfaces` for the same two types, so the same pair of types had three different import paths in active use across the repo with no documented rule for which was canonical.

## Issue acceptance gates

No linked issue — this is a scheduled structural-debt audit. Acceptance gate self-imposed: the type definitions live next to the behavior that owns them, and every call site uses one canonical import path.

## Single source of truth

`src/tools/approval/toolEditApproval.ts` is now the sole definition site for `ToolEditApprovalRequest`/`ToolEditApprovalResult`. `src/platform/interfaces.ts` no longer defines or references them — it keeps only genuine `Platform` port members wired through `initPlatform()`.

## Duplication and abstraction budget

Removed the definition/re-export split (one file defined the types, another owned their behavior and re-exported them). No new abstraction added; this only relocates an existing definition to its existing sole behavioral owner. `@tools/approval`'s existing barrel re-export (`./index.ts`) is untouched.

## Net elements (R6)

5 files changed, 47 insertions(+), 60 deletions(-). Exported symbols: net zero — `ToolEditApprovalRequest`/`ToolEditApprovalResult` move from `@platform/interfaces` (defined + re-exported via `export type {...}`) to being defined directly in `toolEditApproval.ts`; no new or removed export.

## Consumer counts (R8)

Not deleting or re-routing a public export, just repointing import specifiers. Grepped all production and test importers of these two types (13 files repo-wide): 2 production files + 1 test file imported directly from `@platform/interfaces` and are updated here to import from `@tools/approval/toolEditApproval`; the remaining 10 already imported via `@tools/approval/toolEditApproval` or the `@tools/approval` barrel and are unaffected.

## Host impact

Extension: none (type-only import change, verified via `ProgressViewMessageHandler`/`VscodeToolEditApprovalHost` chain still typechecks).

Desktop: none (`DesktopToolEditApproval.vitest.mts` updated for the new import path; suite passes).

CLI: none — CLI approval code already imported via `@tools/approval/toolEditApproval`.

## Scheduled refactoring

None needed — this closes the finding.

## Validation

- `npm run typecheck` — all 7 workspace projects pass (workspace, test-kernel, agent, extension, cli, trace-viewer, desktop)
- `npm run lint` — scoped to the 5 changed files, clean (one `import/order` violation fixed by hand)
- `npx vitest run` — 16 targeted suites covering tool-edit approval across every host (extension, desktop, CLI) and the shared `src/tools`/`src/agent`/`src/controllers` layers: 258 tests passed
- `npm run check:dead-code-ratchet` — 18 findings, matches baseline, no new dead code


---
_Generated by [Claude Code](https://claude.ai/code/session_01SNZQNr9NeQTeZ3uMbLrghX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only move with identical shapes and no logic changes; low risk aside from import-path churn for any out-of-tree consumers of @platform/interfaces.
> 
> **Overview**
> **`ToolEditApprovalRequest` and `ToolEditApprovalResult` are no longer defined on `@platform/interfaces`.** They now live in `@tools/approval/toolEditApproval` next to the approval flow (`requestToolEditApproval`, `finalizeApprovalResult`, etc.), with docs framing them as session-scoped `SessionHandle.interactions` contracts rather than `Platform` ports wired through `initPlatform()`.
> 
> Call sites that imported these types from `@platform/interfaces`—`HostInteractions.ts`, `progressHostInteractions.ts`, and `DesktopToolEditApproval.vitest.mts`—now import from `@tools/approval/toolEditApproval`. The behavioral module stops re-exporting from platform and owns the type definitions directly. **No runtime or API shape changes**; export surface is unchanged aside from where the types are defined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da8be7903cd415db451335cae35369c41c7edabb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->