### PR TITLE
refactor(agent): require remote agent categories

### DIFF
--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -234,7 +234,7 @@ CREATE TABLE remote_agents (
   description TEXT,
   storage_path TEXT NOT NULL,
   visibility TEXT[] DEFAULT ARRAY['public'],
-  agent_category TEXT DEFAULT 'workflow' CHECK (agent_category IN ('workflow', 'toolUse')),
+  agent_category TEXT NOT NULL DEFAULT 'workflow' CHECK (agent_category IN ('workflow', 'toolUse')),
   tools TEXT[] DEFAULT NULL,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()

--- a/src/agent/remote/remoteAgentList.ts
+++ b/src/agent/remote/remoteAgentList.ts
@@ -37,7 +37,7 @@ interface RemoteAgentListRow {
   description?: string | null;
   visibility?: string[] | null;
   tools?: string[] | null;
-  agent_category?: string | null;
+  agent_category: string;
 }
 
 const RemoteAgentListQueryErrorSchema = z.object({

--- a/src/agent/remote/types.ts
+++ b/src/agent/remote/types.ts
@@ -11,8 +11,8 @@ import { AgentNameSchema } from '@shared/schemas/agent';
  * Remote agent list item from DB. Description is cached; YAML is source of truth.
  *
  * Note: Uses `agentCategory` (DB column name) instead of canonical `category`
- * from AgentMetadataBaseSchema. The transform normalizes nullish → Workflow.
- * See also: AgentMetadataBaseSchema in @shared/schemas/agent for the canonical fields.
+ * from AgentMetadataBaseSchema. See also: AgentMetadataBaseSchema in
+ * @shared/schemas/agent for the canonical fields.
  */
 export const RemoteAgentListItemSchema = z.object({
   id: z.string(),
@@ -21,11 +21,7 @@ export const RemoteAgentListItemSchema = z.object({
   visibility: z.array(z.string()).nullish(),
   /** Cached tool names from YAML. Available when DB column is populated. */
   tools: z.array(z.string()).nullish(),
-  /** Defaults to Workflow for backward compatibility with existing DB rows. */
-  agentCategory: z
-    .enum(AgentCategory)
-    .nullish()
-    .transform((val) => val ?? AgentCategory.Workflow),
+  agentCategory: z.enum(AgentCategory),
 });
 
 export type RemoteAgentListItem = z.infer<typeof RemoteAgentListItemSchema>;

--- a/src/test-kernel/agent/remote/RemoteAgentLoader.vitest.ts
+++ b/src/test-kernel/agent/remote/RemoteAgentLoader.vitest.ts
@@ -71,6 +71,34 @@ describe('remote agent listing', () => {
     expect(agents.map((agent) => agent.name)).toEqual(['review']);
   });
 
+  it('drops remote rows without an agent category', async () => {
+    installRemoteAgentListClient({
+      data: [
+        {
+          id: 'agent-1',
+          name: 'uncategorized',
+          description: 'Invalid row',
+          visibility: ['public'],
+          tools: [],
+          agent_category: null,
+        },
+        {
+          id: 'agent-2',
+          name: 'review',
+          description: 'Canonical row',
+          visibility: ['public'],
+          tools: [],
+          agent_category: 'toolUse',
+        },
+      ],
+      error: null,
+    });
+
+    const agents = await listRemoteAgents();
+
+    expect(agents.map((agent) => agent.name)).toEqual(['review']);
+  });
+
   it('returns no agents when the list query fails', async () => {
     const selectedColumns = installRemoteAgentListClient({
       data: null,

--- a/supabase/migrations/20260802160000_require_remote_agent_category.sql
+++ b/supabase/migrations/20260802160000_require_remote_agent_category.sql
@@ -1,0 +1,10 @@
+-- Make the remote-agent category a database invariant rather than a client
+-- compatibility default. Existing null rows retain the former client-side
+-- interpretation before the column becomes non-null.
+UPDATE public.remote_agents
+SET agent_category = 'workflow'
+WHERE agent_category IS NULL;
+
+ALTER TABLE public.remote_agents
+  ALTER COLUMN agent_category SET DEFAULT 'workflow',
+  ALTER COLUMN agent_category SET NOT NULL;


### PR DESCRIPTION
## Summary

Make every remote agent carry an explicit `workflow` or `toolUse` category. The production database already contains only explicit valid categories, so the client no longer needs to turn a missing value into `workflow`.

The database migration backfills any null value in another deployed environment before making the column non-null. The shared remote-agent parser then validates the database value directly.

Closes #9643.

## Issue acceptance gates

- production data audited: 23 rows, 0 null categories, only `workflow` and `toolUse`;
- existing allowed-value check retained;
- default retained for newly inserted workflow agents;
- null rows in other environments backfilled before `NOT NULL` is applied;
- query row and runtime schema now require the category;
- client-side null-to-workflow compatibility transform removed.

## Single source of truth

`public.remote_agents.agent_category` owns the invariant through its default, allowed-value check, and new `NOT NULL` constraint. `RemoteAgentListItemSchema` validates that database contract without supplying a second default.

## Duplication and abstraction budget

The client-side compatibility default is deleted. No new runtime abstraction, migration framework, or parallel authority is introduced.

## Net elements (R6)

- files: 1 added, 0 deleted, 4 modified;
- exported symbols: none added or deleted;
- classes/interfaces/enums: none added or deleted;
- lines: +43/-9, net +34, of which 10 lines are the database migration and 28 lines are one external-boundary test.

## Consumer counts (R8)

n/a. No event, subscription, command key, or exported API is rerouted. The existing remote-agent list mapping remains the sole production consumer of `RemoteAgentListItemSchema`.

## Host impact

Extension:

- remote-agent lists use only explicit database categories.

Desktop:

- unchanged beyond the shared remote-agent contract.

CLI:

- remote-agent lists use only explicit database categories.

## Scheduled refactoring

None.

## Validation

- production Supabase read audit: 23 rows, 0 null categories, valid category set only;
- `RemoteAgentLoader.vitest.ts`: 4 passed;
- `typecheck:workspace`;
- `typecheck:test-kernel`;
- targeted ESLint and Prettier;
- dead-code ratchet: 18 current, 18 baseline;
- `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small contract tightening with a safe backfill; invalid/null rows are filtered at the list boundary rather than silently defaulted.
> 
> **Overview**
> **Remote agent category is now enforced in the database and validated on the client without a fallback default.**
> 
> A migration backfills any `NULL` `agent_category` values to `workflow`, then sets the column to `NOT NULL` while keeping the existing default and allowed-value check. Setup docs match that schema.
> 
> `RemoteAgentListItemSchema` no longer maps missing categories to `workflow`; it requires `workflow` or `toolUse`. List parsing still drops invalid rows, and a test covers `null` categories being excluded from remote agent lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6e24ce0bc96d0e8d88ef40d02a506e536f68b2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->