### PR TITLE
fix(transcript): preserve metadata around invalid descriptors

### DIFF
--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -996,6 +996,63 @@ describe('StreamSnapshotStore', () => {
     expect((await store.read(STREAM)).executionId).toBe(executionId);
   });
 
+  it('omits an invalid run descriptor without discarding other stream metadata', async () => {
+    const executionId = 'aa11bb33' as ExecutionId;
+    const validDescriptor = buildRunDescriptor({
+      streamId: STREAM,
+      executionId,
+      agent: 'legacy-search',
+      category: AgentCategory.ToolUse,
+      kind: 'agent',
+    });
+    const invalidDescriptors = [
+      { ...validDescriptor, kind: undefined },
+      { kind: 'agent', executionId: 'not-hex!!' },
+    ];
+    const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
+
+    for (const [index, runDescriptor] of invalidDescriptors.entries()) {
+      const description = `Prior session ${index}`;
+      await writeMetaFile(STREAM, {
+        parentStreamId: OTHER_STREAM,
+        description,
+        runDescriptor,
+      });
+
+      const store = new StreamSnapshotStore();
+      await expect(
+        store.readPersistedStreamAssociation(STREAM),
+      ).resolves.toEqual({ parentStreamId: OTHER_STREAM });
+      await expect(store.read(STREAM)).resolves.toMatchObject({
+        executionId: undefined,
+        parentStreamId: OTHER_STREAM,
+        description,
+      });
+    }
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'StreamSnapshotStore',
+      expect.stringContaining('unreadable run descriptor'),
+      expect.anything(),
+    );
+  });
+
+  it('warns and rejects malformed outer stream metadata', async () => {
+    const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
+    await writeStreamFile(STREAM, 'meta.json', ['not', 'stream', 'metadata']);
+
+    const snapshot = await new StreamSnapshotStore().read(STREAM);
+
+    expect(snapshot.executionId).toBeUndefined();
+    expect(snapshot.parentStreamId).toBeUndefined();
+    expect(snapshot.description).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'StreamSnapshotStore',
+      expect.stringContaining('unreadable persisted stream metadata'),
+      expect.anything(),
+    );
+  });
+
   it('serves a current record description from ExecutionMeta without writing a sidecar mirror (#9590 Stage 6)', async () => {
     await installPlatform();
     const executionId = 'aa22cc33' as ExecutionId;

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -16,6 +16,7 @@ import {
   OutputFileInfoSchema,
   parsePersistedRoundIndexed,
   parseUsageData,
+  PersistedRunDescriptorSchema,
   PersistedWorkPlanSchema,
   STREAM_SNAPSHOT_SCHEMA_VERSION,
   StreamSnapshotSchema,
@@ -35,6 +36,9 @@ import { isObject, mapToRecord } from '@utils/core';
 import { STREAM_DATA_KEYS } from './streamDataPaths';
 
 const CHANNEL = 'StreamSnapshotStore';
+const StreamTabMetaWithoutRunDescriptorSchema = StreamTabMetaSchema.omit({
+  runDescriptor: true,
+});
 
 /** The canonical empty work plan (no todos, no plan). Single source for the
  *  "no durable plan yet" value, reused by the store's in-memory default. */
@@ -87,8 +91,27 @@ export async function readMeta(
 ): Promise<StreamTabMeta | undefined> {
   const raw = await tryRead(kv, STREAM_DATA_KEYS.META);
   if (raw === undefined) return undefined;
-  const parsed = StreamTabMetaSchema.safeParse(raw);
-  return parsed.success ? parsed.data : undefined;
+  const parsed = StreamTabMetaWithoutRunDescriptorSchema.safeParse(raw);
+  if (!parsed.success) {
+    logger.warn(CHANNEL, 'Discarding unreadable persisted stream metadata.', {
+      data: parsed.error,
+    });
+    return undefined;
+  }
+  if (!isObject(raw) || !Object.hasOwn(raw, 'runDescriptor')) {
+    return parsed.data;
+  }
+
+  const descriptor = PersistedRunDescriptorSchema.safeParse(raw.runDescriptor);
+  if (!descriptor.success) {
+    logger.warn(
+      CHANNEL,
+      'Ignoring unreadable run descriptor in persisted stream metadata.',
+      { data: descriptor.error },
+    );
+    return parsed.data;
+  }
+  return { ...parsed.data, runDescriptor: descriptor.data };
 }
 
 /**


### PR DESCRIPTION
## Summary

Validate a persisted `runDescriptor` independently from the surrounding stream metadata. An unreadable descriptor is now warned about and omitted, while a valid parent link, description, task state, and other metadata remain available. Structurally invalid outer metadata is still rejected and now produces a warning.

This does not infer a missing descriptor kind, read a top-level execution identifier, or add a compatibility writer.

Closes #9675.

## Issue acceptance gates

- A current descriptor still parses unchanged through the existing round-trip path.
- Kindless and malformed descriptors warn, provide no execution association, and preserve valid parent and description fields.
- Structurally malformed outer metadata warns and is rejected rather than becoming a silent default.
- The resolver-facing persisted association read retains the parent link while omitting the invalid descriptor execution identifier.

## Single source of truth

`readMeta` in `src/transcript/streamSnapshotRead.ts` remains the durable `meta.json` read boundary. `PersistedRunDescriptorSchema` remains the sole current descriptor schema.

## Duplication and abstraction budget

No new abstraction or compatibility representation was added. The existing metadata schema is reused with `runDescriptor` omitted for the outer parse, then the existing descriptor schema validates that one field.

## Net elements (R6)

- Files: 2 modified
- Lines: +82 / -2
- Exported symbols: 0 added, 0 removed
- Classes/interfaces/enums: 0 added, 0 removed

## Consumer counts (R8)

n/a — no emit path or export is deleted or rerouted.

## Host impact

Extension: Persisted stream hydration keeps valid metadata when only the descriptor is invalid.

Desktop: Same shared durable-read behavior; no migration is added.

CLI: Same shared durable-read behavior; no migration is added.

## Scheduled refactoring

None. Existing descriptor and legacy identity retirement remain tracked by #9590 and #9627.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/transcript/legacyExecutionIdentity.vitest.ts` (102 tests)
- `corepack pnpm exec eslint src/transcript/streamSnapshotRead.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- Pre-commit formatting and pre-push changed-file lint checks

The full repository suite was not run because the change is confined to the shared stream-metadata read boundary and its focused resolver-facing tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to durable meta read behavior with explicit degradation and tests; no new write paths or migrations.
> 
> **Overview**
> **`readMeta`** now validates persisted `meta.json` in two steps: outer stream fields parse without `runDescriptor`, then `PersistedRunDescriptorSchema` validates that field alone. A bad descriptor is **warned and dropped** while parent links, descriptions, and other metadata still hydrate; structurally invalid outer metadata is **warned and rejected** instead of failing silently.
> 
> Snapshot reads and resolver-facing **`readPersistedStreamAssociation`** therefore keep valid association data without surfacing an execution id from a corrupt descriptor. Focused **`StreamSnapshotStore`** tests cover kindless/malformed descriptors and malformed top-level meta.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07daea38f839e45fce2cb3c6f6c8a8e11b66741c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->