### PR TITLE
refactor: retire obsolete compatibility shims

### DIFF
--- a/src/shared/schemas/agentCliSettings.ts
+++ b/src/shared/schemas/agentCliSettings.ts
@@ -79,7 +79,6 @@ const RETIRED_CLAUDE_AGENT_MODELS: Readonly<Record<string, ClaudeAgentModel>> =
   {
     'claude-opus-4-7': 'claude-opus-5',
     'claude-opus-4-8': 'claude-opus-5',
-    'claude-sonnet-4-6': 'claude-sonnet-5',
   };
 
 export const parseClaudeAgentModel = parseEnumSetting(

--- a/src/shared/schemas/workflowScriptDelivery.ts
+++ b/src/shared/schemas/workflowScriptDelivery.ts
@@ -17,8 +17,7 @@ export const WorkflowScriptDeliverySummarySchema = z.strictObject({
   durationMs: z.int().nonnegative(),
   files: z.array(WorkflowScriptDeliveryFileSchema),
   scriptPath: z.string(),
-  // Older persisted deliveries predate structured failure causes.
-  errorCause: z.string().nullable().prefault(null),
+  errorCause: z.string().nullable(),
 });
 
 export type WorkflowScriptDeliverySummary = z.infer<

--- a/src/shared/state/stateKeys.ts
+++ b/src/shared/state/stateKeys.ts
@@ -153,7 +153,7 @@ export enum GlobalStateKey {
   INLINE_CRITICISM_ENABLED = 'texra.inlineCriticism.enabled',
 
   // Onboarding funnel (user-scoped; see @shared/state/onboardingState)
-  /** Legacy key string — predates the shared funnel, kept for CLI compat. */
+  /** Canonical shared key; the CLI-originated spelling is intentionally stable. */
   ONBOARDING_DECLINED = 'texra.cli.onboardingDeclined',
   ONBOARDING_FIRST_RUN_DONE = 'texra.onboarding.firstRunDone',
   ONBOARDING_DEFAULT_TEAM_ID = 'texra.onboarding.defaultTeamId',

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -269,6 +269,7 @@ describe('summarizeSubagentFollowup', () => {
         { path: 'notes.txt', added: null, removed: null },
       ],
       scriptPath: '.texra/workflow-scripts/proofread-pipeline.mjs',
+      errorCause: null,
     }).replaceAll('"', '&quot;');
     const xml = [
       '<workflow-script-result id="abc">',

--- a/src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts
+++ b/src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts
@@ -65,6 +65,7 @@ describe('user-message structured delivery', () => {
       durationMs: 724_000,
       files: [{ path: 'paper.tex', added: 12, removed: 8 }],
       scriptPath: '.texra/workflow-scripts/proofread-pipeline.mjs',
+      errorCause: null,
     }).replaceAll('"', '&quot;');
     const text = [
       '<workflow-script-result id="abc">',

--- a/src/test-kernel/schemas/SharedSchemas.vitest.ts
+++ b/src/test-kernel/schemas/SharedSchemas.vitest.ts
@@ -47,10 +47,9 @@ describe('parseCodexApprovalPolicy', () => {
 });
 
 describe('parseClaudeAgentModel', () => {
-  it('maps retired selections to their current model', () => {
+  it('maps retained Opus selections to the current model', () => {
     expect(parseClaudeAgentModel('claude-opus-4-7')).toBe('claude-opus-5');
     expect(parseClaudeAgentModel('claude-opus-4-8')).toBe('claude-opus-5');
-    expect(parseClaudeAgentModel('claude-sonnet-4-6')).toBe('claude-sonnet-5');
   });
 
   it('defaults invalid persisted selections to Sonnet', () => {


### PR DESCRIPTION
## Summary

Retire three compatibility claims that do not protect a current or released format:

- require the structured workflow-delivery `errorCause` field, whose writer has included a nullable value since before the format's first release;
- remove the redundant Claude Sonnet 4.6 alias, which already resolves to the same Sonnet 5 fallback as any unknown selection; and
- document the onboarding-declined key as the intentionally stable shared key instead of describing its CLI-originated spelling as legacy.

Current workflow-summary fixtures now include the nullable field emitted by production. The retained Opus aliases and their tests are unchanged.

## Issue acceptance gates

No issue. The retirement audit established these gates:

- no released TeXRA version wrote a workflow-delivery summary without `errorCause`;
- removing the Sonnet 4.6 map entry does not change parser output; and
- onboarding uses one canonical declined key with no alias, mirror, or migration.

All three gates are satisfied by this diff.

## Single source of truth

`WorkflowScriptDeliverySummarySchema` remains the workflow-summary contract, `parseClaudeAgentModel` remains the Claude setting normalizer, and `GlobalStateKey.ONBOARDING_DECLINED` remains the sole onboarding-declined storage key.

## Duplication and abstraction budget

One speculative schema default and one redundant model alias are removed. No abstraction, pass-through layer, alias, migration, or duplicate state authority is added.

## Net elements (R6)

- Files: 6 modified, 0 added, 0 deleted.
- Exported symbols: 0 added, 0 removed.
- Classes/interfaces/enums: 0 added, 0 removed.
- Net LoC: -1 (5 insertions, 6 deletions).

## Consumer counts (R8)

n/a — no emit path or export is deleted or rerouted. The production workflow-summary writer already emits `errorCause`, and the onboarding key value is unchanged.

## Host impact

Extension: Structured workflow summaries use the already-current required nullable field; onboarding storage is unchanged.

Desktop: No migration is introduced for the unreleased desktop; shared current-format parsing is stricter.

CLI: Structured workflow summaries use the already-current required nullable field; old Sonnet input still resolves to Sonnet 5 through the existing fallback; onboarding storage is unchanged.

## Scheduled refactoring

None for these removals. The retained Opus aliases have separate, later retirement horizons.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/schemas/SharedSchemas.vitest.ts src/test-kernel/cli/SubagentFollowup.vitest.mts src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts` — 100 tests passed.
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `npm run lint`
- Repository pre-commit and pre-push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small schema and alias cleanup with no storage key changes; stricter parsing only affects summaries missing `errorCause`, which the PR asserts never shipped.
> 
> **Overview**
> Removes **compatibility shims** that no longer protect real persisted data: workflow delivery summaries must include **`errorCause`** (nullable, no Zod default), the **`claude-sonnet-4-6`** entry is removed from retired Claude agent model aliases (unknown values still fall back to Sonnet 5), and **`ONBOARDING_DECLINED`** is documented as the canonical stable key rather than “legacy.”
> 
> Tests now embed **`errorCause: null`** in workflow-summary fixtures to match production output, and **`parseClaudeAgentModel`** coverage no longer asserts the Sonnet 4.6 alias mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da35aefc48182579cdb091724a4560115507db31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->