### PR TITLE
Refactor: simplify data structures flagged by the tech-debt audit

### DIFF
--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -22,18 +22,6 @@ import { KNOWN_TEXRA_KEYS } from '../schemas/knownKeys';
 
 export const CLI_BUILTIN_DEFAULT_MODEL = 'deepseekproT';
 
-interface CliCommandConfig {
-  readonly agent?: string;
-  readonly model?: string;
-}
-
-export interface CliConfigValues extends CliCommandConfig {
-  readonly outputFormat?: CliOutputFormat;
-  readonly approvalPolicy?: CliApprovalPolicy;
-  readonly chat?: CliCommandConfig;
-  readonly run?: CliCommandConfig;
-}
-
 export interface LoadedCliConfig {
   readonly path?: string;
   readonly values: CliConfigValues;
@@ -96,23 +84,53 @@ const ModelSchema = NonEmptyStringSchema.refine(isCliSupportedModelId, {
 const OutputFormatSchema = z.enum(CLI_OUTPUT_FORMATS);
 const ApprovalPolicySchema = z.enum(CLI_APPROVAL_POLICIES);
 
-const TOP_LEVEL_FIELD_SCHEMAS: ReadonlyArray<[string, z.ZodType]> = [
-  ['agent', NonEmptyStringSchema],
-  ['model', ModelSchema],
-  ['outputFormat', OutputFormatSchema],
-  ['approvalPolicy', ApprovalPolicySchema],
-];
+/**
+ * Declarative schema for a per-command (`chat`/`run`) config section. This is
+ * the single source of truth for the set of fields walked for
+ * unknown/invalid-key warnings (via `.shape`, see COMMAND_KEYS below) — there
+ * is no separate hand-maintained field list to drift out of sync with
+ * `CliConfigValues`.
+ */
+const CliCommandConfigSchema = z.strictObject({
+  agent: NonEmptyStringSchema.optional(),
+  model: ModelSchema.optional(),
+});
 
-const COMMAND_FIELD_SCHEMAS: ReadonlyArray<[string, z.ZodType]> = [
-  ['agent', NonEmptyStringSchema],
-  ['model', ModelSchema],
-];
-const COMMAND_SECTIONS = ['chat', 'run'] as const;
+/**
+ * Declarative schema for the CLI's own `.texra/config.json` fields. Same
+ * single-source-of-truth relationship to `CliConfigValues` and to the field
+ * walk below as `CliCommandConfigSchema` above.
+ */
+const CliConfigSchema = z.strictObject({
+  agent: NonEmptyStringSchema.optional(),
+  model: ModelSchema.optional(),
+  outputFormat: OutputFormatSchema.optional(),
+  approvalPolicy: ApprovalPolicySchema.optional(),
+  chat: CliCommandConfigSchema.optional(),
+  run: CliCommandConfigSchema.optional(),
+});
+export type CliConfigValues = z.infer<typeof CliConfigSchema>;
+
+// Scalar top-level fields, i.e. everything except the nested chat/run
+// sections — derived from CliConfigSchema rather than re-declared, so a new
+// scalar field only needs to be added once, above.
+const CLI_SCALAR_FIELD_SHAPE = CliConfigSchema.omit({
+  chat: true,
+  run: true,
+}).shape;
+
+// The two known command sections. Kept as a literal tuple (there is no
+// programmatic way to pull "the nested-object keys" out of a ZodObject
+// shape), but `satisfies` ties it back to CliConfigValues so a rename in the
+// schema above is a compile error here instead of a silent drift.
+const COMMAND_SECTIONS = ['chat', 'run'] as const satisfies ReadonlyArray<
+  keyof CliConfigValues
+>;
 
 const TOP_LEVEL_KEYS = new Set<string>(
   CLI_SETTING_PATHS.map(canonicalConfigKey),
 );
-const COMMAND_KEYS = new Set(COMMAND_FIELD_SCHEMAS.map(([key]) => key));
+const COMMAND_KEYS = new Set(Object.keys(CliCommandConfigSchema.shape));
 
 function isKnownConfigKey(key: string): boolean {
   return TOP_LEVEL_KEYS.has(key) || KNOWN_TEXRA_KEYS.has(key);
@@ -157,7 +175,9 @@ function collectValidationWarnings(
   const warnings: string[] = [];
   warnUnknownKeys(warnings, filePath, record, TOP_LEVEL_KEYS);
 
-  for (const [key, schema] of TOP_LEVEL_FIELD_SCHEMAS) {
+  // Validate top-level scalar fields, driven by CliConfigSchema's own shape —
+  // see CLI_SCALAR_FIELD_SHAPE.
+  for (const [key, schema] of Object.entries(CLI_SCALAR_FIELD_SHAPE)) {
     const storedKey = canonicalConfigKey(key);
     warnInvalidField(warnings, filePath, record, storedKey, schema);
   }
@@ -172,22 +192,36 @@ function collectValidationWarnings(
     }
     const prefix = `${sectionKey}.`;
     warnUnknownKeys(warnings, filePath, sectionValue, COMMAND_KEYS, prefix);
-    for (const [key, schema] of COMMAND_FIELD_SCHEMAS) {
+    for (const [key, schema] of Object.entries(CliCommandConfigSchema.shape)) {
       warnInvalidField(warnings, filePath, sectionValue, key, schema, prefix);
     }
   }
   return warnings;
 }
 
+/**
+ * Validate a single field with its own schema, warning-and-dropping (never
+ * `.catch()`-ing) on failure: an invalid field must not silently fall back to
+ * a default, since the loud warning above is what tells the user their config
+ * value was ignored.
+ */
 function parseOptional<T>(schema: z.ZodType<T>, value: unknown): T | undefined {
-  return schema.optional().catch(undefined).parse(value);
+  const parsed = schema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 
-function pickCommandConfig(record: Record<string, unknown>): CliCommandConfig {
-  return {
-    agent: parseOptional(NonEmptyStringSchema, record.agent),
-    model: parseOptional(ModelSchema, record.model),
-  };
+/** Pick and validate every field of `shape` present (as a bare key) in `record`. */
+function pickShapeValues(
+  record: Record<string, unknown>,
+  shape: Record<string, z.ZodType>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, schema] of Object.entries(shape)) {
+    if (Object.hasOwn(record, key)) {
+      result[key] = parseOptional(schema, record[key]);
+    }
+  }
+  return result;
 }
 
 function pickValue<T>(
@@ -207,16 +241,17 @@ function pickRecord(
 }
 
 function pickConfigValues(record: Record<string, unknown>): CliConfigValues {
-  const chat = pickRecord(record, 'chat');
-  const run = pickRecord(record, 'run');
-  return {
-    agent: pickValue(record, 'agent', NonEmptyStringSchema),
-    model: pickValue(record, 'model', ModelSchema),
-    outputFormat: pickValue(record, 'outputFormat', OutputFormatSchema),
-    approvalPolicy: pickValue(record, 'approvalPolicy', ApprovalPolicySchema),
-    chat: chat ? pickCommandConfig(chat) : undefined,
-    run: run ? pickCommandConfig(run) : undefined,
-  };
+  const values: Record<string, unknown> = {};
+  for (const [key, schema] of Object.entries(CLI_SCALAR_FIELD_SHAPE)) {
+    values[key] = pickValue(record, key, schema);
+  }
+  for (const section of COMMAND_SECTIONS) {
+    const sectionRecord = pickRecord(record, section);
+    values[section] = sectionRecord
+      ? pickShapeValues(sectionRecord, CliCommandConfigSchema.shape)
+      : undefined;
+  }
+  return values as CliConfigValues;
 }
 
 export function parseCliConfigValues(value: unknown): CliConfigValues {

--- a/packages/cli/src/runtime/tools.ts
+++ b/packages/cli/src/runtime/tools.ts
@@ -31,7 +31,7 @@ export interface CliToolGuide {
 
 const cliToolDefs = (): ExternalToolDef[] =>
   EXTERNAL_TOOL_DEFS.filter(
-    (def) => !def.hideFromDashboard && !def.hideFromCli,
+    (def) => !def.visibility?.hideFromDashboard && !def.visibility?.hideFromCli,
   );
 
 function detectedFromStatus(status: string): boolean | null {
@@ -45,9 +45,10 @@ function noteForTool(
   detected: boolean | null,
   statusLabel?: string,
 ): string {
-  if (detected === false && def.installCommand) return def.installCommand;
+  const installCommand = def.install?.command;
+  if (detected === false && installCommand) return installCommand;
   return (
-    statusLabel ?? def.authNote ?? def.configNotes ?? def.installCommand ?? ''
+    statusLabel ?? def.auth?.note ?? def.configNotes ?? installCommand ?? ''
   );
 }
 
@@ -57,7 +58,7 @@ export async function readCliToolStatuses(): Promise<CliToolStatusRecord[]> {
 
   return cliToolDefs().map((def) => {
     const check = checks.get(def.id);
-    const comingSoon = def.comingSoon === true;
+    const comingSoon = def.visibility?.comingSoon === true;
     const toggleable = def.toggleable === true;
     const status = check?.status ?? (comingSoon ? 'coming-soon' : 'unknown');
     const detected = check?.detected ?? detectedFromStatus(status);
@@ -72,8 +73,8 @@ export async function readCliToolStatuses(): Promise<CliToolStatusRecord[]> {
       statusDetail: check?.statusDetail,
       toggleable,
       comingSoon,
-      installCommand: def.installCommand,
-      authCommand: def.authCommand,
+      installCommand: def.install?.command,
+      authCommand: def.auth?.command,
       note: noteForTool(def, detected, check?.statusLabel),
     };
   });
@@ -101,23 +102,25 @@ export function readCliToolGuide(
   if (!def) return undefined;
 
   if (kind === 'install') {
-    const lines = [def.installGuide ?? def.configNotes ?? 'No install guide.'];
-    if (def.installCommand) {
+    const lines = [
+      def.install?.guide ?? def.configNotes ?? 'No install guide.',
+    ];
+    if (def.install?.command) {
       lines.push('');
-      lines.push(`Command: ${def.installCommand}`);
+      lines.push(`Command: ${def.install.command}`);
     }
-    if (def.installUrl) {
-      lines.push(`URL: ${def.installUrl}`);
+    if (def.install?.url) {
+      lines.push(`URL: ${def.install.url}`);
     }
-    return { text: lines.join('\n'), command: def.installCommand };
+    return { text: lines.join('\n'), command: def.install?.command };
   }
 
-  const lines = [def.authNote ?? def.configNotes ?? 'No auth guide.'];
-  if (def.authCommand) {
+  const lines = [def.auth?.note ?? def.configNotes ?? 'No auth guide.'];
+  if (def.auth?.command) {
     lines.push('');
-    lines.push(`Command: ${def.authCommand}`);
+    lines.push(`Command: ${def.auth.command}`);
   }
-  return { text: lines.join('\n'), command: def.authCommand };
+  return { text: lines.join('\n'), command: def.auth?.command };
 }
 
 export async function setCliToolEnabled(

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -1393,7 +1393,7 @@ function openCommandPalette(): void {
 }
 
 function switchToStream(streamId: StreamTabId): void {
-  if (!appState.get().streamById.has(streamId)) return;
+  if (!appState.get().streams.has(streamId)) return;
   appState.set(
     mutate(appState.get(), (draft) => {
       draft.activeStreamId = streamId;

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -112,8 +112,7 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
       preferHelperModel: data.preferHelperModel === true,
       modelHandlerCompatibilityKey: data.modelHandlerCompatibilityKey,
       copilotRouteOverride: data.copilotRouteOverride as
-        | CopilotRouteOverride
-        | undefined,
+        CopilotRouteOverride | undefined,
       onRun: extractOnRun(input),
     },
   );

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import { z, ZodError } from 'zod';
+import { z } from 'zod';
 
 // Local imports
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
@@ -9,17 +9,72 @@ import { runAgent } from '@agent/runtime/runAgent';
 import { openFinalOutputIfAvailable } from '@frontend/agents/finalOutputOpener';
 import * as logger from '@logger/logUtils';
 import type { CopilotRouteOverride } from '@model/copilotRouting';
-import type { ExecutionId } from '@shared/schemas';
+import { ExecutionIdSchema } from '@shared/schemas';
 
 const CHANNEL = 'ExecuteCommand';
 
-interface WrappedExecuteInput {
-  config: unknown;
-  executionId?: ExecutionId;
-  preferHelperModel?: boolean;
-  modelHandlerCompatibilityKey?: unknown;
-  copilotRouteOverride?: unknown;
-  onRun?: () => void;
+/** Fields common to both the fresh and resume execute-input shapes. */
+const ExecuteInputFieldsSchema = z.object({
+  config: AgentConfigSchema,
+  preferHelperModel: z.boolean().optional(),
+  modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullish(),
+  copilotRouteOverride: z.literal('direct').optional(),
+});
+
+const FreshExecuteInputSchema = ExecuteInputFieldsSchema.extend({
+  mode: z.literal('fresh'),
+});
+
+const ResumeExecuteInputSchema = ExecuteInputFieldsSchema.extend({
+  mode: z.literal('resume'),
+  executionId: ExecutionIdSchema,
+});
+
+/**
+ * Normalizes the two accepted call shapes into a `mode`-tagged bag so the
+ * fresh/resume contract can be validated by a real discriminated union
+ * instead of an ad hoc `'config' in input` duck-check + cast:
+ *
+ * - A bare `AgentConfig` (no `config` property of its own — see
+ *   `AgentConfigSharedFieldsSchema`) is always a fresh execution.
+ * - `{ config, executionId?, ... }` is fresh when `executionId` is absent
+ *   and resume when present (`runAgent` uses that same presence check to
+ *   decide whether to mint a new `executionId` or reuse one).
+ */
+function normalizeExecuteInput(input: unknown): unknown {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    return input;
+  }
+  const bag: Record<string, unknown> =
+    'config' in input
+      ? { ...(input as Record<string, unknown>) }
+      : { config: input };
+  return {
+    ...bag,
+    mode: bag.executionId != null ? 'resume' : 'fresh',
+  };
+}
+
+const ExecuteInputSchema = z.preprocess(
+  normalizeExecuteInput,
+  z.discriminatedUnion('mode', [
+    FreshExecuteInputSchema,
+    ResumeExecuteInputSchema,
+  ]),
+);
+
+/**
+ * `onRun` is a same-process callback reference, not serializable data, so it
+ * is carried through structurally rather than Zod-validated like the rest of
+ * the payload — mirroring `RunAgentOptions['onRun']` and friends elsewhere in
+ * `src/agent/runtime`, which are plain TS-typed callback fields too.
+ */
+function extractOnRun(input: unknown): (() => void) | undefined {
+  if (input === null || typeof input !== 'object' || !('onRun' in input)) {
+    return undefined;
+  }
+  const { onRun } = input as { onRun?: unknown };
+  return typeof onRun === 'function' ? (onRun as () => void) : undefined;
 }
 
 /**
@@ -32,44 +87,34 @@ interface WrappedExecuteInput {
  * For tool-use sessions, use texra.resumeAgent with a snapshot instead.
  */
 export async function runExecuteCommand(input: unknown): Promise<void> {
-  try {
-    const wrapped =
-      input !== null && typeof input === 'object' && 'config' in input
-        ? (input as WrappedExecuteInput)
-        : null;
-    const config = AgentConfigSchema.parse(wrapped ? wrapped.config : input);
-    const modelHandlerCompatibilityKey =
-      ModelHandlerCompatibilityKeySchema.nullish().parse(
-        wrapped?.modelHandlerCompatibilityKey,
-      );
-    const copilotRouteOverride = z
-      .literal('direct')
-      .optional()
-      .parse(wrapped?.copilotRouteOverride) as CopilotRouteOverride | undefined;
-
-    await runAgent(
-      { config, executionId: wrapped?.executionId },
-      {
-        openWorkflowOutput: openFinalOutputIfAvailable,
-        // Set only by the "fix LaTeX" actions (see handleFixCompilation and the
-        // progress-view compile fixer); a direct main-view launch omits it and
-        // keeps the user's selected model.
-        preferHelperModel: wrapped?.preferHelperModel === true,
-        modelHandlerCompatibilityKey,
-        copilotRouteOverride,
-        onRun: wrapped?.onRun,
-      },
-    );
-  } catch (error) {
-    if (error instanceof ZodError) {
-      const message = `Invalid agent configuration. ${z.prettifyError(error)}`;
-      logger.warn(CHANNEL, message, { data: error });
-      void vscode.window.showErrorMessage(message);
-      return;
-    }
-
-    // Post-start failures are already logged and surfaced by the run
-    // lifecycle; rethrow without a second (mislabeled) log entry.
-    throw error;
+  const parsed = ExecuteInputSchema.safeParse(input);
+  if (!parsed.success) {
+    const message = `Invalid agent configuration. ${z.prettifyError(parsed.error)}`;
+    logger.warn(CHANNEL, message, { data: parsed.error });
+    void vscode.window.showErrorMessage(message);
+    return;
   }
+  const data = parsed.data;
+
+  // Post-start failures are already logged and surfaced by the run
+  // lifecycle; let them propagate rather than adding a second (mislabeled)
+  // catch-all here.
+  await runAgent(
+    {
+      config: data.config,
+      executionId: data.mode === 'resume' ? data.executionId : undefined,
+    },
+    {
+      openWorkflowOutput: openFinalOutputIfAvailable,
+      // Set only by the "fix LaTeX" actions (see handleFixCompilation and the
+      // progress-view compile fixer); a direct main-view launch omits it and
+      // keeps the user's selected model.
+      preferHelperModel: data.preferHelperModel === true,
+      modelHandlerCompatibilityKey: data.modelHandlerCompatibilityKey,
+      copilotRouteOverride: data.copilotRouteOverride as
+        | CopilotRouteOverride
+        | undefined,
+      onRun: extractOnRun(input),
+    },
+  );
 }

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -11,7 +11,7 @@ import {
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 // Local imports - progress view
-import { deleteStreamState, firstStreamId, isToolUseState } from './store';
+import { firstStreamId, isToolUseState } from './store';
 import { deleteFollowUpInputTransientState } from './followUpInputState';
 import { addResolvedProposalId, removePrompt } from './slices/permissionSlice';
 import { updateToolUseState } from './stateUtils';
@@ -51,10 +51,9 @@ export function handleStreamDelete(
   // Optimistic removal: apply delete locally before notifying backend
   appState.set(
     create(appState.get(), (draft) => {
-      deleteStreamState(draft, streamId);
-      draft.streamById.delete(streamId);
+      draft.streams.delete(streamId);
       if (draft.activeStreamId === streamId) {
-        draft.activeStreamId = firstStreamId(draft.streamById);
+        draft.activeStreamId = firstStreamId(draft.streams);
       }
     }),
   );
@@ -95,7 +94,7 @@ export function handleFollowUpChange(
   event: CustomEvent<FollowUpChangeDetail>,
 ): void {
   const { mode = 'replace', streamId, value } = event.detail;
-  if (!appState.get().streamStates.has(streamId)) return;
+  if (!appState.get().streams.has(streamId)) return;
   updateToolUseState(streamId, (prev) =>
     create(prev, (draft) => {
       if (mode === 'replace') {
@@ -116,7 +115,7 @@ function getFollowUpText(
   streamId: StreamTabId,
 ): { streamId: StreamTabId; text: string } | null {
   const state = appState.get();
-  const streamState = state.streamStates.get(streamId);
+  const streamState = state.streams.get(streamId)?.state;
   if (!streamState || !isToolUseState(streamState)) return null;
 
   const text = streamState.ui.followUpText?.trim() ?? '';

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -29,9 +29,9 @@ import { setsEqual } from './utils';
 import { clearFollowUpInputTransientStateStore } from './followUpInputState';
 import {
   createInitialState,
-  ensureStreamState,
   EMPTY_STREAM_LOGS,
   isToolUseState,
+  type StreamEntry,
   type StreamState,
 } from './store';
 import {
@@ -94,12 +94,62 @@ export const unsupportedProgressCommands$ = signal<ReadonlySet<string> | null>(
 // Selector computeds: extract fields, auto-memoized by Object.is.
 // ---------------------------------------------------------------------------
 
-export const streamById$ = select(appState, (s) => s.streamById);
-export const streamStates$ = select(appState, (s) => s.streamStates);
-const streamLogs$ = select(appState, (s) => s.streamLogs);
+/** Raw per-stream record map. Changes identity on ANY field of ANY stream
+ *  (info, state, logs, or followup options all live on the same entry now)
+ *  — components that need to skip re-rendering on an unrelated facet's
+ *  change must read one of the memoized per-facet views below instead of
+ *  this signal directly. */
+const streamEntries$ = select(appState, (s) => s.streams);
 export const activeStreamId$ = select(appState, (s) => s.activeStreamId);
 const inquiries$ = select(appState, (s) => s.inquiries);
-const followupOptions$ = select(appState, (s) => s.followupOptionsByStream);
+
+/**
+ * Builds a per-facet view Map from `streamEntries$`, reusing the previous
+ * Map instance when every entry's extracted facet is still reference-equal.
+ * `streamEntries$` changes identity on every per-stream write (info, state,
+ * logs, and followup options all live on the same consolidated entry now),
+ * so without this the facet views below would rebuild — and change
+ * identity — on ticks that don't touch them, defeating the render-skip Lit
+ * relies on for content components that only read one facet (mirrors the
+ * manual-cache pattern `phaseStages$` already uses below).
+ */
+function memoizedFacetView<V>(
+  prev: Map<StreamTabId, V>,
+  extract: (entry: StreamEntry) => V,
+): Map<StreamTabId, V> {
+  const entries = streamEntries$.get();
+  let changed = entries.size !== prev.size;
+  if (!changed) {
+    for (const [id, entry] of entries) {
+      if (prev.get(id) !== extract(entry)) {
+        changed = true;
+        break;
+      }
+    }
+  }
+  if (!changed) return prev;
+  const next = new Map<StreamTabId, V>();
+  for (const [id, entry] of entries) next.set(id, extract(entry));
+  return next;
+}
+
+/** Canonical per-stream tab metadata. Only changes identity when a stream is
+ *  added/removed or its `StreamTabInfo` itself changes — not on a log or
+ *  meta-state tick for an existing stream. */
+let _prevStreamById: Map<StreamTabId, StreamTabInfo> = new Map();
+export const streamById$ = new Signal.Computed(() => {
+  _prevStreamById = memoizedFacetView(_prevStreamById, (e) => e.info);
+  return _prevStreamById;
+});
+
+/** Meta state per stream (status, todos, usage, ui, taskGroups, etc). Only
+ *  changes identity when some stream's meta state actually changes — not on
+ *  a log-only tick for an existing stream. */
+let _prevStreamStates: Map<StreamTabId, StreamState> = new Map();
+export const streamStates$ = new Signal.Computed(() => {
+  _prevStreamStates = memoizedFacetView(_prevStreamStates, (e) => e.state);
+  return _prevStreamStates;
+});
 
 // ---------------------------------------------------------------------------
 // Derived computeds: only re-evaluate when selector inputs propagate.
@@ -212,11 +262,17 @@ const activeStreamState$ = new Signal.Computed(() => {
   );
 });
 
-/** Only changes when the ACTIVE stream's logs change, not any stream. */
+/**
+ * Only changes when the ACTIVE stream's logs change, not any stream. Reads
+ * the consolidated `streamEntries$` directly (not a memoized facet view like
+ * `streamStates$`/`streamById$`) — it's a single-key lookup, not a rebuilt
+ * container, so its own return value is already reference-stable without
+ * needing the manual-cache treatment.
+ */
 const activeStreamLogs$ = new Signal.Computed(() => {
   const info = activeStreamInfo$.get();
   if (!info) return EMPTY_STREAM_LOGS;
-  return streamLogs$.get().get(info.name) ?? EMPTY_STREAM_LOGS;
+  return streamEntries$.get().get(info.name)?.logs ?? EMPTY_STREAM_LOGS;
 });
 
 // ---------------------------------------------------------------------------
@@ -317,7 +373,7 @@ export const streamContext$ = new Signal.Computed((): StreamContextValue => {
   }
 
   const followupOptions =
-    followupOptions$.get().get(activeStreamInfo.name) ?? null;
+    streamEntries$.get().get(activeStreamInfo.name)?.followupOptions ?? null;
   return {
     streamInfo: activeStreamInfo,
     streamState: activeStreamState$.get(),
@@ -366,21 +422,14 @@ export function setStreamStateForId(
   updater: (prev: StreamState) => StreamState,
 ): void {
   const state = appState.get();
-  let current = state.streamStates.get(streamId);
-  if (!current) {
-    const streamInfo = state.streamById.get(streamId);
-    if (!streamInfo) return;
-    current = createStreamState(streamInfo.agentCategory);
-  }
-  const updated = updater(current);
-  if (updated === current) return;
+  const entry = state.streams.get(streamId);
+  if (!entry) return;
+  const updated = updater(entry.state);
+  if (updated === entry.state) return;
   appState.set(
     create(state, (draft) => {
-      // Backfills streamLogs/followupOptionsByStream alongside streamStates
-      // when this is the first handler to observe the stream (see
-      // `ensureStreamState`'s doc comment for the owned key list).
-      ensureStreamState(draft, streamId, current.kind);
-      draft.streamStates.set(streamId, updated);
+      const target = draft.streams.get(streamId);
+      if (target) target.state = updated;
     }),
   );
 }

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -31,6 +31,7 @@ import {
   createInitialState,
   EMPTY_STREAM_LOGS,
   isToolUseState,
+  type FollowupOptionsState,
   type StreamEntry,
   type StreamState,
 } from './store';
@@ -151,6 +152,20 @@ export const streamStates$ = new Signal.Computed(() => {
   return _prevStreamStates;
 });
 
+/** Follow-up options per stream. Only changes identity when some stream's
+ *  follow-up options actually change — not on a log-only tick for an
+ *  existing stream. Read by `streamContext$` so its non-log consumers
+ *  (header, todos, usage, follow-up controls) don't re-render on every
+ *  streamed token. */
+let _prevFollowupOptions: Map<StreamTabId, FollowupOptionsState> = new Map();
+const followupOptions$ = new Signal.Computed(() => {
+  _prevFollowupOptions = memoizedFacetView(
+    _prevFollowupOptions,
+    (e) => e.followupOptions,
+  );
+  return _prevFollowupOptions;
+});
+
 // ---------------------------------------------------------------------------
 // Derived computeds: only re-evaluate when selector inputs propagate.
 // ---------------------------------------------------------------------------
@@ -213,12 +228,20 @@ export const pendingApprovalIds$ = new Signal.Computed(() => {
  * `permissions$.set([])` because that setter triggers `pendingApprovalIds$`
  * recomputation, which reads `_prevApprovalIds` for the stable-Set memo —
  * if we clear the cache after, the next read sees a stale prior Set and
- * returns it instead of the empty post-reset value. `_prevPhaseStages` is
- * the same memo over `appState`, so it is cleared before that setter too.
+ * returns it instead of the empty post-reset value. `_prevPhaseStages`,
+ * `_prevStreamById`, `_prevStreamStates`, and `_prevFollowupOptions` are the
+ * same kind of memo over `appState`, so they're all cleared before that
+ * setter too (each would otherwise self-heal on the next read anyway, since
+ * `memoizedFacetView`'s size check forces a rebuild once `streamEntries$`
+ * goes back to empty — clearing them here just keeps every memo cache
+ * consistently reset in one place rather than relying on that).
  */
 export function resetProgressState(): void {
   _prevApprovalIds = new Set();
   _prevPhaseStages = EMPTY_PHASE_STAGE_MAP;
+  _prevStreamById = new Map();
+  _prevStreamStates = new Map();
+  _prevFollowupOptions = new Map();
   clearFollowUpInputTransientStateStore();
   appState.set(createInitialState());
   placement.set('sidebar');
@@ -373,7 +396,7 @@ export const streamContext$ = new Signal.Computed((): StreamContextValue => {
   }
 
   const followupOptions =
-    streamEntries$.get().get(activeStreamInfo.name)?.followupOptions ?? null;
+    followupOptions$.get().get(activeStreamInfo.name) ?? null;
   return {
     streamInfo: activeStreamInfo,
     streamState: activeStreamState$.get(),

--- a/packages/extension/src/progressView/frontend/slices/followUpSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/followUpSlice.ts
@@ -23,7 +23,7 @@ export const followUpHandlers = {
       data.stream ??
       (data.kind === 'transcribed' ? appState.get().activeStreamId : null);
     if (!streamId) return;
-    if (!appState.get().streamStates.has(streamId)) return;
+    if (!appState.get().streams.has(streamId)) return;
 
     updateToolUseState(streamId, (prev) =>
       create(prev, (draft) => {
@@ -69,14 +69,17 @@ export const followUpHandlers = {
   },
 
   [PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS]: (data) => {
-    if (!appState.get().streamStates.has(data.stream)) return;
+    if (!appState.get().streams.has(data.stream)) return;
 
     appState.set(
       create(appState.get(), (draft) => {
-        draft.followupOptionsByStream.set(data.stream, {
-          toolUseAgentsData: data.toolUseAgentsData,
-          modelOptionsData: data.modelOptionsData,
-        });
+        const target = draft.streams.get(data.stream);
+        if (target) {
+          target.followupOptions = {
+            toolUseAgentsData: data.toolUseAgentsData,
+            modelOptionsData: data.modelOptionsData,
+          };
+        }
       }),
     );
   },

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -13,7 +13,7 @@ import {
 import { upsertTaskGroupFromStreamLog } from '@shared/streams/taskGroupProjection';
 
 import { appState } from '../progressState';
-import { ensureStreamState, type StreamLogs, type StreamState } from '../store';
+import type { StreamLogs, StreamState } from '../store';
 
 function toLogMessage(entry: StreamLogEntry): LogMessageData {
   return {
@@ -117,14 +117,17 @@ export const logHandlers = {
 
     appState.set(
       create(appState.get(), (draft) => {
-        const streamState = draft.streamStates.get(streamId);
-        if (!streamState) return;
-
-        // Backfills streamLogs (and followupOptionsByStream) if this is the
-        // first handler to observe the stream — see `ensureStreamState`.
-        ensureStreamState(draft, streamId, streamState.kind);
-        // Non-null: ensureStreamState above guarantees this entry exists.
-        const streamLogs: StreamLogs = draft.streamLogs.get(streamId)!;
+        const streamEntry = draft.streams.get(streamId);
+        if (!streamEntry) return;
+        // `streamState`/`streamLogs` are the same draft proxies as
+        // `streamEntry.state`/`.logs`, so `applyEntry`'s in-place field
+        // mutations (taskGroups, contextState) land on the entry directly —
+        // no separate write-back needed, and when `stateChanged` stays
+        // false, Mutative keeps `streamEntry.state` reference-stable so a
+        // log-only tick doesn't re-render content components that only read
+        // stream state.
+        const streamState = streamEntry.state;
+        const streamLogs: StreamLogs = streamEntry.logs;
 
         let logChanged = false;
         let stateChanged = false;
@@ -154,18 +157,18 @@ export const logHandlers = {
         }
 
         if (logChanged) {
-          draft.streamLogs.set(streamId, {
+          streamEntry.logs = {
             logs: streamLogs.logs,
             logIndex: streamLogs.logIndex,
             taskGroupIndex: streamLogs.taskGroupIndex,
             updatedMessageIndices: [...updatedMessageIndices],
             updatedMessageBaseGeneration,
             generation: streamLogs.generation + 1,
-          });
+          };
         }
 
         if (stateChanged) {
-          draft.streamStates.set(streamId, streamState);
+          streamEntry.state = streamState;
         }
       }),
     );

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -9,6 +9,7 @@ import { create } from 'mutative';
 
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
+  createStreamState,
   type ProgressViewOutboundHandlerRegistry,
   type StreamMetadata,
   type StreamTabId,
@@ -16,11 +17,10 @@ import {
 } from '@shared/schemas';
 
 import {
-  deleteStreamState,
-  ensureStreamState,
+  createEmptyStreamLogs,
   firstStreamId,
   type ProgressState,
-  type StreamState,
+  type StreamEntry,
 } from '../store';
 import {
   appState,
@@ -53,62 +53,49 @@ function updateStreamInfo(
   streams: StreamTabInfo[],
   backendMetadata?: Record<string, StreamMetadata>,
 ): ProgressState {
-  // Pre-compute merged states outside the draft (mergeBackendOwnedState uses
-  // create() internally, which cannot operate on draft proxies). Fold the
-  // pending-description drain into the same pass — no extra iteration.
-  // Explicit description on StreamTabInfo wins over the pending buffer.
-  const mergedStates = new Map<string, StreamState>();
-  const newStreamById = new Map<string, StreamTabInfo>();
-  // Streams with no backend metadata and no prior state yet: routed through
-  // `ensureStreamState` below so their default streamStates entry and its
-  // streamLogs/followupOptionsByStream companions are created together,
-  // instead of synthesizing a bare streamStates default here.
-  const streamsNeedingDefaultState: StreamTabInfo[] = [];
+  // Pre-compute the replacement `streams` map outside the draft
+  // (mergeBackendOwnedState uses create() internally, which cannot operate
+  // on draft proxies). Fold the pending-description drain into the same
+  // pass — no extra iteration. Explicit description on StreamTabInfo wins
+  // over the pending buffer. Built wholesale (not patched in place) so a
+  // stream absent from `streams` is naturally dropped — the single-map
+  // equivalent of the old delete-from-every-map pass.
+  const newStreams = new Map<StreamTabId, StreamEntry>();
   for (const stream of streams) {
-    const existing = state.streamStates.get(stream.name);
+    const existing = state.streams.get(stream.name);
     const metadata = backendMetadata?.[stream.name];
-    if (metadata) {
-      mergedStates.set(stream.name, mergeBackendOwnedState(existing, metadata));
-    } else if (!existing) {
-      streamsNeedingDefaultState.push(stream);
-    }
+    const streamState = metadata
+      ? mergeBackendOwnedState(existing?.state, metadata)
+      : (existing?.state ?? createStreamState(stream.agentCategory));
+
     // Always drain the pending buffer so stale entries don't linger once the
     // stream registers, even if the payload already carries a description.
     // Stream-payload description wins (it's the authoritative value).
     const pending = takePendingDescription(stream.name);
     const description = stream.description ?? pending;
-    newStreamById.set(
-      stream.name,
-      description !== stream.description ? { ...stream, description } : stream,
-    );
+    const info =
+      description !== stream.description ? { ...stream, description } : stream;
+
+    newStreams.set(stream.name, {
+      info,
+      state: streamState,
+      logs: existing?.logs ?? createEmptyStreamLogs(),
+      followupOptions: existing?.followupOptions ?? {},
+    });
   }
 
   // Clean up removed streams' pending-description buffer outside the
   // mutative draft callback so the side effect doesn't run if the draft
   // later throws.
-  for (const key of state.streamStates.keys()) {
-    if (!newStreamById.has(key)) {
+  for (const key of state.streams.keys()) {
+    if (!newStreams.has(key)) {
       pendingDescriptions.delete(key);
       deleteFollowUpInputTransientState(key);
     }
   }
 
   return create(state, (draft) => {
-    for (const key of draft.streamStates.keys()) {
-      if (!newStreamById.has(key)) {
-        deleteStreamState(draft, key);
-      }
-    }
-
-    for (const [name, merged] of mergedStates) {
-      draft.streamStates.set(name, merged);
-    }
-
-    for (const stream of streamsNeedingDefaultState) {
-      ensureStreamState(draft, stream.name, stream.agentCategory);
-    }
-
-    draft.streamById = newStreamById;
+    draft.streams = newStreams;
   });
 }
 
@@ -120,11 +107,11 @@ function updateStreamInfo(
  */
 function resolveActiveStreamId(
   activeStream: StreamTabId | '',
-  streamById: Map<StreamTabId, StreamTabInfo>,
+  streams: Map<StreamTabId, StreamEntry>,
 ): StreamTabId | null {
   if (activeStream === '') return null;
-  if (activeStream && streamById.has(activeStream)) return activeStream;
-  return firstStreamId(streamById);
+  if (activeStream && streams.has(activeStream)) return activeStream;
+  return firstStreamId(streams);
 }
 
 // ============================================================
@@ -153,7 +140,7 @@ export const streamLifecycleHandlers = {
     // re-pick a filtered-out tab and render hidden-category content.
     const nextActiveStreamId = resolveActiveStreamId(
       data.activeStream,
-      updated.streamById,
+      updated.streams,
     );
 
     appState.set(
@@ -167,7 +154,7 @@ export const streamLifecycleHandlers = {
     const prev = appState.get();
     const nextActiveStreamId = resolveActiveStreamId(
       data.activeStream,
-      prev.streamById,
+      prev.streams,
     );
     if (nextActiveStreamId === prev.activeStreamId) return;
     appState.set(
@@ -193,8 +180,7 @@ export const streamLifecycleHandlers = {
     pendingDescriptions.delete(streamId);
     appState.set(
       create(appState.get(), (draft) => {
-        deleteStreamState(draft, streamId);
-        draft.streamById.delete(streamId);
+        draft.streams.delete(streamId);
         if (draft.activeStreamId === streamId) {
           draft.activeStreamId = null;
         }
@@ -213,18 +199,15 @@ export const streamLifecycleHandlers = {
     permissions$.set([]);
 
     // Every remaining stream's persisted toggle state loses its only future
-    // consumer here (the stream itself is about to disappear from
-    // streamById below) — read the ids before the reset wipes them.
-    for (const streamId of appState.get().streamById.keys()) {
+    // consumer here (the stream itself is about to disappear from `streams`
+    // below) — read the ids before the reset wipes them.
+    for (const streamId of appState.get().streams.keys()) {
       webviewStorage.delete(logListStateKey(streamId));
     }
 
     appState.set(
       create(appState.get(), (draft) => {
-        draft.streamById = new Map();
-        draft.streamStates = new Map();
-        draft.streamLogs = new Map();
-        draft.followupOptionsByStream = new Map();
+        draft.streams = new Map();
         draft.activeStreamId = null;
       }),
     );

--- a/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -10,11 +10,14 @@ import {
   STREAM_PHASE,
   type ProgressViewOutboundHandlerRegistry,
   type StreamTabId,
-  type StreamTabInfo,
 } from '@shared/schemas';
 import { compareByNewestCreationTime } from '@shared/streams/streamOrdering';
 
-import { isToolUseState } from '../store';
+import {
+  createEmptyStreamLogs,
+  isToolUseState,
+  type StreamEntry,
+} from '../store';
 import { mergeBackendOwnedState } from './streamStateMerge';
 import { appState, setStreamStateForId } from '../progressState';
 
@@ -33,18 +36,31 @@ export function takePendingDescription(
   return desc;
 }
 
-function upsertSortedStreamInfo(
-  streams: Map<StreamTabId, StreamTabInfo>,
-  streamInfo: StreamTabInfo,
-): Map<StreamTabId, StreamTabInfo> {
-  const streamsWithoutPatch = [...streams.values()].filter(
-    (stream) => stream.name !== streamInfo.name,
-  );
-  const ordered = [...streamsWithoutPatch, streamInfo].toSorted(
+/**
+ * Insert/replace one stream's entry and re-sort the whole map by newest
+ * creation time. Every OTHER stream's entry is reused as-is (same object
+ * reference) — only the patched stream's entry and the map's key order
+ * change.
+ */
+function upsertSortedStreamEntry(
+  streams: Map<StreamTabId, StreamEntry>,
+  entry: StreamEntry,
+): Map<StreamTabId, StreamEntry> {
+  const name = entry.info.name;
+  const infosWithoutPatch = [...streams.values()]
+    .map((existing) => existing.info)
+    .filter((info) => info.name !== name);
+  const ordered = [...infosWithoutPatch, entry.info].toSorted(
     compareByNewestCreationTime,
   );
 
-  return new Map(ordered.map((stream) => [stream.name, stream]));
+  return new Map(
+    ordered.map((info) =>
+      info.name === name
+        ? [info.name, entry]
+        : [info.name, streams.get(info.name)!],
+    ),
+  );
 }
 
 // The composed registry is exhaustive (every ProgressView outbound command
@@ -59,7 +75,8 @@ export const streamMetaHandlers = {
     const pending = takePendingDescription(name);
 
     const prev = appState.get();
-    const existingInfo = prev.streamById.get(name);
+    const existingEntry = prev.streams.get(name);
+    const existingInfo = existingEntry?.info;
     const description =
       data.streamInfo.description ?? pending ?? existingInfo?.description;
     const streamInfo =
@@ -67,7 +84,7 @@ export const streamMetaHandlers = {
         ? { ...data.streamInfo, description }
         : data.streamInfo;
     const mergedState = mergeBackendOwnedState(
-      prev.streamStates.get(name),
+      existingEntry?.state,
       data.streamState,
     );
 
@@ -77,15 +94,19 @@ export const streamMetaHandlers = {
           !existingInfo ||
           existingInfo.creationTimestamp !== streamInfo.creationTimestamp
         ) {
-          draft.streamById = upsertSortedStreamInfo(
-            prev.streamById,
-            streamInfo,
-          );
+          draft.streams = upsertSortedStreamEntry(prev.streams, {
+            info: streamInfo,
+            state: mergedState,
+            logs: existingEntry?.logs ?? createEmptyStreamLogs(),
+            followupOptions: existingEntry?.followupOptions ?? {},
+          });
         } else {
-          draft.streamById.set(name, streamInfo);
+          const target = draft.streams.get(name);
+          if (target) {
+            target.info = streamInfo;
+            target.state = mergedState;
+          }
         }
-
-        draft.streamStates.set(name, mergedState);
 
         if (data.activeStream !== undefined) {
           draft.activeStreamId = data.activeStream || null;
@@ -119,20 +140,21 @@ export const streamMetaHandlers = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_DESCRIPTION]: (data) => {
     const { stream, description } = data;
     // Subagent description can race its own UPDATE_STREAMS registration; if
-    // the stream isn't in streamById yet, buffer out-of-band so
+    // the stream doesn't have an entry yet, buffer out-of-band so
     // streamLifecycleSlice can drain it on arrival.
-    if (!appState.get().streamById.has(stream)) {
+    const entry = appState.get().streams.get(stream);
+    if (!entry) {
       pendingDescriptions.set(stream, description);
       return;
     }
     appState.set(
       create(appState.get(), (draft) => {
-        const existing = draft.streamById.get(stream);
-        // Replace via set() so the Map value identity changes and selectors
+        const target = draft.streams.get(stream);
+        // Replace `.info` wholesale so its identity changes and selectors
         // observing streamById propagate the update (mirrors the pattern in
         // stateUtils.updateParentStreamId).
-        if (existing) {
-          draft.streamById.set(stream, { ...existing, description });
+        if (target) {
+          target.info = { ...entry.info, description };
         }
       }),
     );

--- a/packages/extension/src/progressView/frontend/stateUtils.ts
+++ b/packages/extension/src/progressView/frontend/stateUtils.ts
@@ -96,7 +96,7 @@ export function updateWorkflowState(
 }
 
 /**
- * Update a stream's parentStreamId in the streamById map.
+ * Update a stream's parentStreamId on its `streams` entry.
  * No-op if the stream doesn't exist or the parentStreamId hasn't changed.
  */
 export function updateParentStreamId(
@@ -105,11 +105,12 @@ export function updateParentStreamId(
 ): void {
   const resolved = parentStreamId ?? undefined;
   const prev = appState.get();
-  const target = prev.streamById.get(streamId);
-  if (!target || target.parentStreamId === resolved) return;
+  const entry = prev.streams.get(streamId);
+  if (!entry || entry.info.parentStreamId === resolved) return;
   appState.set(
     create(prev, (draft) => {
-      draft.streamById.set(streamId, { ...target, parentStreamId: resolved });
+      const target = draft.streams.get(streamId);
+      if (target) target.info = { ...entry.info, parentStreamId: resolved };
     }),
   );
 }

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -1,7 +1,5 @@
 // Shared imports
 import {
-  createStreamState,
-  type AgentCategory,
   type ContextStateData,
   type LogMessageData,
   type StreamState,
@@ -11,7 +9,6 @@ import {
   type InquiryThreadUpdatedEvent,
   type ExternalInquiryThreadId,
 } from '@shared/schemas';
-import type { Draft } from 'mutative';
 
 // Re-export schema types for components (single source of truth)
 export {
@@ -31,10 +28,11 @@ export type FollowupOptionsState = Omit<
 >;
 
 /**
- * Log data stored separately from stream meta state.
- * This separation lets Lit skip re-renders of content components
- * (StreamHeader, TodoList, UsagePanel, FollowUpInput) during streaming —
- * only LogList/TaskGroupList re-render when logs change.
+ * Log data stored on a stream's `StreamEntry`, as its own field rather than
+ * folded into `state`. See `StreamEntry`'s doc comment for why, and
+ * `progressState.ts`'s `streamStates$`/`streamById$` memoized facet views
+ * for how the reference stability that separation buys survives now that
+ * both live on the same consolidated map entry.
  */
 export interface StreamLogs {
   logs: LogMessageData[];
@@ -53,7 +51,7 @@ export interface StreamLogs {
 }
 
 /** Fresh, unshared `StreamLogs` value for a stream with no log entries yet. */
-function createEmptyStreamLogs(): StreamLogs {
+export function createEmptyStreamLogs(): StreamLogs {
   return {
     logs: [],
     logIndex: new Map(),
@@ -67,94 +65,65 @@ function createEmptyStreamLogs(): StreamLogs {
 /**
  * Stable empty fallback for read paths (e.g. `activeStreamLogs$`) that need a
  * value before any log has arrived for a stream. Never mutated in place —
- * writers always replace the map entry with a fresh object (see
- * `ensureStreamState` and `logSlice.ts`), so sharing this single reference
- * across reads is safe.
+ * writers always give a new stream's entry its own fresh `StreamLogs` object
+ * (see `createEmptyStreamLogs`), so sharing this single reference across
+ * reads is safe.
  */
 export const EMPTY_STREAM_LOGS: StreamLogs = createEmptyStreamLogs();
+
+/**
+ * One stream's complete frontend record: tab metadata, meta state (status,
+ * todos, usage, ui, taskGroups, ...), log messages, and follow-up option
+ * data. These four facets used to live in four separately-mutated top-level
+ * maps (`streamById`, `streamStates`, `streamLogs`, `followupOptionsByStream`)
+ * all keyed by the same `StreamTabId`, plus a `deleteStreamState` /
+ * `ensureStreamState` pair that existed only to keep them in sync on
+ * removal/creation — any new per-stream facet had to remember to route
+ * through both helpers or silently drift out of sync between them. The
+ * codebase's own `packages/cli/src/chat/tui/state/childExecutions.ts`
+ * documents rejecting this same N-parallel-maps pattern for child-stream
+ * state, for the same reason.
+ *
+ * One map of `StreamEntry` makes that drift structurally impossible: a
+ * stream either has a record with all four facets, or it has no record at
+ * all — a plain `.get()`/`.set()`/`.delete()` on `ProgressState.streams`
+ * replaces every one of the old add/remove helpers.
+ *
+ * `logs` stays a field of its own on the entry (not folded into `state`),
+ * for the same reason the two were separate maps before: log-only ticks
+ * (very frequent — e.g. streaming tokens) should leave `state` referentially
+ * unchanged so Lit can skip re-rendering content components (StreamHeader,
+ * TodoList, UsagePanel, FollowUpInput) that only read state, not logs. See
+ * `progressState.ts`'s `streamStates$`/`streamById$` memoized facet views
+ * for how that per-field reference stability is preserved now that both
+ * live on the same consolidated map entry.
+ */
+export interface StreamEntry {
+  info: StreamTabInfo;
+  state: StreamState;
+  logs: StreamLogs;
+  followupOptions: FollowupOptionsState;
+}
 
 export interface ProgressState {
   activeStreamId: StreamTabId | null;
   /** Canonical stream storage — Map preserves insertion order for iteration. */
-  streamById: Map<StreamTabId, StreamTabInfo>;
-  /** Meta state per stream (status, todos, usage, ui, taskGroups, etc.) */
-  streamStates: Map<StreamTabId, StreamState>;
-  /** Log messages per stream — separated so log appends don't trigger meta context updates */
-  streamLogs: Map<StreamTabId, StreamLogs>;
-  /** Workflow-result follow-up option data, keyed per stream. */
-  followupOptionsByStream: Map<StreamTabId, FollowupOptionsState>;
+  streams: Map<StreamTabId, StreamEntry>;
   /** Durable external inquiry thread summaries, keyed by thread id. */
   inquiries: Map<ExternalInquiryThreadId, InquiryThreadUpdatedEvent>;
 }
 
-/**
- * Delete one stream's entry from every per-stream map it owns
- * (`streamStates`, `streamLogs`, `followupOptionsByStream`).
- * Single owner of that key list so a removed/renamed/added map can't drift
- * out of sync between the lifecycle handlers that garbage-collect streams.
- * Does not touch `streamById` — callers that also drop the stream from the
- * tab list delete that key themselves, since some callers (bulk snapshot
- * sync) replace it wholesale instead.
- */
-export function deleteStreamState(
-  draft: Draft<ProgressState>,
-  streamId: StreamTabId,
-): void {
-  draft.streamStates.delete(streamId);
-  draft.streamLogs.delete(streamId);
-  draft.followupOptionsByStream.delete(streamId);
-}
-
-/**
- * Create default entries — for whichever of the same key list
- * `deleteStreamState` owns (`streamStates`, `streamLogs`,
- * `followupOptionsByStream`) a stream doesn't have one in yet. Single owner
- * of that initialization logic, mirroring `deleteStreamState`, so a stream
- * can't end up registered in some of these maps but not others depending on
- * which handler happened to observe it first. Already-present entries are
- * left untouched.
- *
- * Does not touch `streamById`, for the same reason `deleteStreamState`
- * doesn't: every call site that introduces a brand-new stream already holds
- * its full `StreamTabInfo` and writes it through its own logic (e.g. the
- * newest-first sorted upsert in `streamMetaSlice.ts`) — there is no
- * meaningful placeholder to synthesize here.
- *
- * Returns the stream's (possibly just-created) `StreamState`.
- */
-export function ensureStreamState(
-  draft: Draft<ProgressState>,
-  streamId: StreamTabId,
-  agentCategory: AgentCategory,
-): StreamState {
-  let state = draft.streamStates.get(streamId);
-  if (!state) {
-    state = createStreamState(agentCategory);
-    draft.streamStates.set(streamId, state);
-  }
-  if (!draft.streamLogs.has(streamId)) {
-    draft.streamLogs.set(streamId, createEmptyStreamLogs());
-  }
-  if (!draft.followupOptionsByStream.has(streamId)) {
-    draft.followupOptionsByStream.set(streamId, {});
-  }
-  return state;
-}
-
-/** Return the first stream ID from a streamById Map, or null if empty. */
+/** Return the first stream ID from a `streams` Map, or null if empty. */
 export function firstStreamId(
-  streamById: Map<StreamTabId, StreamTabInfo>,
+  streams: ReadonlyMap<StreamTabId, unknown>,
 ): StreamTabId | null {
-  return streamById.keys().next().value ?? null;
+  return streams.keys().next().value ?? null;
 }
 
 export function createInitialState(): ProgressState {
   return {
     activeStreamId: null,
-    streamById: new Map(),
-    streamStates: new Map(),
-    streamLogs: new Map(),
-    followupOptionsByStream: new Map(),
+    streams: new Map(),
     inquiries: new Map(),
   };
 }

--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -21,6 +21,11 @@ import {
   isFunctionCallOutputItem,
 } from '@agent/modelHandlers/openai/openAIResponseContent';
 import { isResponseFunctionToolCallItem } from '@agent/modelHandlers/openai/responseStreamEvents';
+import {
+  ContentBlockSchema,
+  normalizeVsCodeLmBlock,
+  type ContentBlock,
+} from '@agent/types/ContentBlockSchema';
 import { CONVERSATION_BLOCK_TYPES } from '@agent/types/ConversationBlockTypes';
 import {
   ANTHROPIC_SERVER_TOOL_BLOCK_TYPES,
@@ -39,83 +44,6 @@ import type { ExportNode, UserPart } from './schemas';
 // ============================================================
 // Input schemas (implementation detail — not exported publicly)
 // ============================================================
-
-/** One entry inside a `web_search_tool_result` block's `content` array. */
-const WebSearchResultItemSchema = z.object({
-  type: z.string(),
-  title: z.string().optional(),
-  url: z.string().optional(),
-});
-
-/**
- * Discriminated union of API content blocks across the four provider shapes
- * this module normalizes (Anthropic, OpenAI Chat Completions, OpenAI
- * Response API, Google GenAI — the latter via {@link googlePartToBlocks},
- * which translates Google's field-based `Part` into these type-based
- * blocks). Each variant declares only the fields that provider actually
- * populates for that block kind, so the six consuming functions below can
- * switch/narrow on `type` instead of re-deriving validity with ad hoc
- * optional-field checks.
- */
-const ContentBlockSchema = z.discriminatedUnion('type', [
-  // Plain text. Anthropic and Google GenAI use 'text'; OpenAI Response API
-  // splits it into 'input_text' (user) and 'output_text' (assistant).
-  z.object({ type: z.literal('text'), text: z.string().optional() }),
-  z.object({ type: z.literal('input_text'), text: z.string().optional() }),
-  z.object({ type: z.literal('output_text'), text: z.string().optional() }),
-
-  // Anthropic extended-thinking / Google GenAI thought blocks.
-  z.object({
-    type: z.literal(CONVERSATION_BLOCK_TYPES.thinking),
-    thinking: z.string().optional(),
-  }),
-  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.redactedThinking) }),
-
-  // Tool call / tool result — shared by Anthropic, Google GenAI, and the
-  // VS Code language-model bridge (see normalizeContentBlock).
-  z.object({
-    type: z.literal(CONVERSATION_BLOCK_TYPES.toolUse),
-    name: z.string().optional(),
-    input: z.unknown().optional(),
-  }),
-  z.object({
-    type: z.literal(CONVERSATION_BLOCK_TYPES.toolResult),
-    content: z.unknown().optional(),
-  }),
-
-  // Attachment markers: Anthropic ('image'/'document'), OpenAI Response API
-  // ('input_image'/'input_file'), OpenAI Chat Completions ('image_url'/
-  // 'file'). None of these carry fields this module reads — only `type`
-  // decides which attachment kind to render.
-  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.image) }),
-  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.inputImage) }),
-  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.imageUrl) }),
-  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.document) }),
-  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.inputFile) }),
-  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.file) }),
-
-  // Anthropic server-side tool blocks (the provider executes these, not a
-  // local tool handler).
-  z.object({
-    type: z.literal(ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.serverToolUse),
-    name: z.string().optional(),
-    input: z.unknown().optional(),
-  }),
-  z.object({
-    type: z.literal(ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webSearchToolResult),
-    content: z.array(WebSearchResultItemSchema).optional(),
-  }),
-  // `extractWebFetchResultFields` reads its fields off the raw block itself
-  // (it accepts `unknown`), not off this schema's inferred type, so this
-  // variant only declares the discriminant. `looseObject` (not `object`)
-  // documents that undeclared fields are intentionally read elsewhere —
-  // and keeps that true if runtime `.parse()` is ever added to this schema
-  // (currently it isn't; see the module-level type-derivation-only note).
-  z.looseObject({
-    type: z.literal(ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webFetchToolResult),
-  }),
-]);
-type ContentBlock = z.infer<typeof ContentBlockSchema>;
 
 const ConversationMessageSchema = z.looseObject({
   role: z.string().optional(),
@@ -156,30 +84,16 @@ function extractBlocks(msg: ConversationMessage): ContentBlock[] {
   return [];
 }
 
-/** Convert host-neutral VS Code language-model parts to the shared block form. */
+/**
+ * Convert host-neutral VS Code language-model parts to the shared block
+ * form via {@link normalizeVsCodeLmBlock} (`@agent/types/ContentBlockSchema`
+ * — shared with `formatConversationBlock` in
+ * `@agent/storage/conversationFormat`). Every other provider's blocks
+ * already carry the canonical `type` tag and pass through unchanged.
+ */
 function normalizeContentBlock(block: unknown): ContentBlock[] {
   if (!isObject(block)) return [];
-  switch (block.kind) {
-    case 'text':
-      return [
-        {
-          type: 'text',
-          text: typeof block.text === 'string' ? block.text : undefined,
-        },
-      ];
-    case 'toolCall':
-      return [
-        {
-          type: 'tool_use',
-          name: typeof block.name === 'string' ? block.name : undefined,
-          input: block.input,
-        },
-      ];
-    case 'toolResult':
-      return [{ type: 'tool_result', content: block.text }];
-    default:
-      return [block as ContentBlock];
-  }
+  return [normalizeVsCodeLmBlock(block) ?? (block as ContentBlock)];
 }
 
 /** Convert a Google GenAI Part (field-based discrimination) to type-based ContentBlock(s). */

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -9,7 +9,12 @@
  * `{text}`/`{functionCall}`/`{functionResponse}` parts, VS Code LM's
  * `{kind: 'text'|'toolCall'|'toolResult'}` parts, or OpenAI's top-level
  * `tool_calls`. This module recognizes those shapes once, instead of every
- * caller re-parsing them with its own drifted truncation rules.
+ * caller re-parsing them with its own drifted truncation rules. The VS Code
+ * `kind`-tag and top-level `tool_calls` shapes are recognized via the schema
+ * and normalizers in `@agent/types/ContentBlockSchema`, shared with
+ * `assistantBlockToNode` in `@agent/export/normalizeConversation` so a new
+ * provider block type is added in one place instead of two independently
+ * hand-rolled switches.
  *
  * Used by:
  *  - `ExecutionsTool`'s `/executions/{id}/conversation` endpoint
@@ -22,6 +27,10 @@
  * truncation for the CLI). Provider-native message and content recognition is
  * shared here.
  */
+import {
+  extractFunctionToolCallFields,
+  normalizeVsCodeLmBlock,
+} from '@agent/types/ContentBlockSchema';
 import { CONVERSATION_BLOCK_TYPES } from '@agent/types/ConversationBlockTypes';
 import {
   ANTHROPIC_SERVER_TOOL_BLOCK_TYPES,
@@ -192,8 +201,10 @@ function formatWebFetchResultMarker(
  * Render a single content-block (an element of a message's `content`/`parts`
  * array) to text. Handles Anthropic's `{type: ...}` discriminated blocks,
  * Google's discriminator-less `{text}`/`{functionCall}`/`{functionResponse}`
- * parts, VS Code LM's `kind`-discriminated parts, and falls back to a JSON dump
- * for unrecognized shapes.
+ * parts, VS Code LM's `kind`-discriminated parts (via
+ * {@link normalizeVsCodeLmBlock}, shared with `assistantBlockToNode` in
+ * `@agent/export/normalizeConversation`), and falls back to a JSON dump for
+ * unrecognized shapes.
  */
 function formatConversationBlock(
   block: unknown,
@@ -209,17 +220,24 @@ function formatConversationBlock(
       options,
     );
   }
-  switch (block.kind) {
-    case 'text':
-      return truncate(asText(block.text), options.textLimit, options);
-    case 'toolCall':
-      return formatToolUseMarker(
-        asText(block.name) || 'unknown',
-        block.input,
-        options,
-      );
-    case 'toolResult':
-      return formatToolResultMarker(block.text, options);
+  // VS Code language-model bridge's `kind`-tagged parts normalize into the
+  // canonical `type`-tagged shape rendered below — anything else (including
+  // every other provider's already `type`-tagged blocks, which never carry a
+  // `kind` field) falls through unchanged.
+  const vsCodeBlock = normalizeVsCodeLmBlock(block);
+  if (vsCodeBlock) {
+    switch (vsCodeBlock.type) {
+      case 'text':
+        return truncate(asText(vsCodeBlock.text), options.textLimit, options);
+      case CONVERSATION_BLOCK_TYPES.toolUse:
+        return formatToolUseMarker(
+          asText(vsCodeBlock.name) || 'unknown',
+          vsCodeBlock.input,
+          options,
+        );
+      case CONVERSATION_BLOCK_TYPES.toolResult:
+        return formatToolResultMarker(vsCodeBlock.content, options);
+    }
   }
   // Google's `parts` entries have no `type` discriminator at all — a plain
   // `text` field is the only signal, so check it before the `type` switch.
@@ -261,10 +279,11 @@ function formatConversationBlock(
     );
   }
 
-  // Non-text tags are shared with the `assistantBlockToNode` switch in
-  // `@agent/export/normalizeConversation` via `CONVERSATION_BLOCK_TYPES`
-  // (`@agent/types/ConversationBlockTypes`) and `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES`
-  // (`@agent/types/ServerToolTypes`) — both switches must recognize the same
+  // Non-text tags are the same `ContentBlockSchema` vocabulary consumed by
+  // the `assistantBlockToNode` switch in `@agent/export/normalizeConversation`
+  // (`@agent/types/ContentBlockSchema`, `CONVERSATION_BLOCK_TYPES` from
+  // `@agent/types/ConversationBlockTypes`, and `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES`
+  // from `@agent/types/ServerToolTypes`) — both switches recognize the same
   // tags, just into different output shapes (a truncated marker string here
   // vs. a structured `ExportNode` there). `text`/`input_text`/`output_text`
   // are the exception: they're caught by the duck-typed `block.text` check
@@ -401,12 +420,10 @@ function formatTopLevelToolCall(
       options,
     )}]`;
   }
-  const nestedFunction = isObject(toolCall.function)
-    ? toolCall.function
-    : undefined;
-  const name =
-    asText(nestedFunction?.name) || asText(toolCall.name) || 'unknown';
-  const input =
-    nestedFunction?.arguments ?? toolCall.arguments ?? toolCall.input ?? {};
-  return formatToolUseMarker(name, input, options);
+  // Shared with `getAssistantToolCalls` in `@agent/export/normalizeConversation`
+  // via `extractFunctionToolCallFields` (`@agent/types/ContentBlockSchema`) —
+  // that path additionally SDK-validates each entry as a genuine function
+  // tool call; this one renders whatever shape is present.
+  const { name, input } = extractFunctionToolCallFields(toolCall);
+  return formatToolUseMarker(name || 'unknown', input ?? {}, options);
 }

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -27,10 +27,7 @@
  * truncation for the CLI). Provider-native message and content recognition is
  * shared here.
  */
-import {
-  extractFunctionToolCallFields,
-  normalizeVsCodeLmBlock,
-} from '@agent/types/ContentBlockSchema';
+import { normalizeVsCodeLmBlock } from '@agent/types/ContentBlockSchema';
 import { CONVERSATION_BLOCK_TYPES } from '@agent/types/ConversationBlockTypes';
 import {
   ANTHROPIC_SERVER_TOOL_BLOCK_TYPES,
@@ -409,6 +406,30 @@ function formatTopLevelToolCalls(
     .join('\n');
 }
 
+/**
+ * Extract the `{name, input}` fields off one entry of an OpenAI Chat
+ * Completions assistant message's top-level `tool_calls` array: the
+ * `{function: {name, arguments}}` shape, or a flatter `{name,
+ * arguments|input}` fallback some archived/alternate shapes use. Both
+ * fields are `undefined` when absent — this renders a bare `'unknown'`
+ * marker either way (see the caller below).
+ */
+function extractFunctionToolCallFields(toolCall: Record<string, unknown>): {
+  name?: string;
+  input?: unknown;
+} {
+  const nestedFunction = isObject(toolCall.function)
+    ? toolCall.function
+    : undefined;
+  const nestedName =
+    typeof nestedFunction?.name === 'string' ? nestedFunction.name : '';
+  const topName = typeof toolCall.name === 'string' ? toolCall.name : '';
+  return {
+    name: nestedName || topName || undefined,
+    input: nestedFunction?.arguments ?? toolCall.arguments ?? toolCall.input,
+  };
+}
+
 function formatTopLevelToolCall(
   toolCall: unknown,
   options: ConversationFormatOptions,
@@ -420,10 +441,6 @@ function formatTopLevelToolCall(
       options,
     )}]`;
   }
-  // Shared with `getAssistantToolCalls` in `@agent/export/normalizeConversation`
-  // via `extractFunctionToolCallFields` (`@agent/types/ContentBlockSchema`) —
-  // that path additionally SDK-validates each entry as a genuine function
-  // tool call; this one renders whatever shape is present.
   const { name, input } = extractFunctionToolCallFields(toolCall);
   return formatToolUseMarker(name || 'unknown', input ?? {}, options);
 }

--- a/src/agent/types/ContentBlockSchema.ts
+++ b/src/agent/types/ContentBlockSchema.ts
@@ -5,13 +5,12 @@
  * both `assistantBlockToNode` (`@agent/export/normalizeConversation`) and
  * `formatConversationBlock` (`@agent/storage/conversationFormat`) classify —
  * Anthropic/OpenAI `type`-tagged blocks (including Anthropic's server-side
- * tool blocks), the VS Code language-model bridge's `kind`-tagged blocks, and
- * OpenAI Chat Completions' top-level `tool_calls` array shape. Each consumer
- * still owns its own output shape (a structured `ExportNode` vs. a truncated
- * marker string) and its own further business rules (which block kinds are
- * visible, how they're truncated) — only the wire-shape recognition lives
- * here, so a new provider block type is added once instead of drifting
- * between two independently hand-rolled switches.
+ * tool blocks) and the VS Code language-model bridge's `kind`-tagged blocks.
+ * Each consumer still owns its own output shape (a structured `ExportNode`
+ * vs. a truncated marker string) and its own further business rules (which
+ * block kinds are visible, how they're truncated) — only the wire-shape
+ * recognition lives here, so a new provider block type is added once instead
+ * of drifting between two independently hand-rolled switches.
  *
  * Google GenAI's discriminator-less `{text}`/`{functionCall}`/
  * `{functionResponse}`/`{thought}` parts are deliberately NOT normalized
@@ -24,8 +23,6 @@
  * own Google-part handling.
  */
 import { z } from 'zod';
-
-import { isObject } from '@utils/core';
 
 import { CONVERSATION_BLOCK_TYPES } from './ConversationBlockTypes';
 import { ANTHROPIC_SERVER_TOOL_BLOCK_TYPES } from './ServerToolTypes';
@@ -161,34 +158,4 @@ export function normalizeVsCodeLmBlock(
 ): NormalizedVsCodeLmBlock | undefined {
   const parsed = VsCodeLmBlockSchema.safeParse(raw);
   return parsed.success ? parsed.data : undefined;
-}
-
-// ============================================================
-// OpenAI Chat Completions — top-level `tool_calls` array shape
-// ============================================================
-
-/**
- * Extract the `{name, input}` fields off one entry of an OpenAI Chat
- * Completions assistant message's top-level `tool_calls` array: the
- * `{function: {name, arguments}}` shape, or a flatter `{name,
- * arguments|input}` fallback some archived/alternate shapes use. Both
- * fields are `undefined` when absent — callers decide their own defaults
- * (`conversationFormat` renders a bare `'unknown'` marker either way;
- * `normalizeConversation`'s SDK-validated `getAssistantToolCalls` path keeps
- * its own extraction because it operates on an already-narrowed
- * `ChatCompletionMessageFunctionToolCall`, not this raw shape).
- */
-export function extractFunctionToolCallFields(
-  toolCall: Record<string, unknown>,
-): { name?: string; input?: unknown } {
-  const nestedFunction = isObject(toolCall.function)
-    ? toolCall.function
-    : undefined;
-  const nestedName =
-    typeof nestedFunction?.name === 'string' ? nestedFunction.name : '';
-  const topName = typeof toolCall.name === 'string' ? toolCall.name : '';
-  return {
-    name: nestedName || topName || undefined,
-    input: nestedFunction?.arguments ?? toolCall.arguments ?? toolCall.input,
-  };
 }

--- a/src/agent/types/ContentBlockSchema.ts
+++ b/src/agent/types/ContentBlockSchema.ts
@@ -1,0 +1,194 @@
+/**
+ * Shared provider content-block schema and cross-shape normalizers.
+ *
+ * Single source of truth for the discriminated content-block vocabulary that
+ * both `assistantBlockToNode` (`@agent/export/normalizeConversation`) and
+ * `formatConversationBlock` (`@agent/storage/conversationFormat`) classify —
+ * Anthropic/OpenAI `type`-tagged blocks (including Anthropic's server-side
+ * tool blocks), the VS Code language-model bridge's `kind`-tagged blocks, and
+ * OpenAI Chat Completions' top-level `tool_calls` array shape. Each consumer
+ * still owns its own output shape (a structured `ExportNode` vs. a truncated
+ * marker string) and its own further business rules (which block kinds are
+ * visible, how they're truncated) — only the wire-shape recognition lives
+ * here, so a new provider block type is added once instead of drifting
+ * between two independently hand-rolled switches.
+ *
+ * Google GenAI's discriminator-less `{text}`/`{functionCall}`/
+ * `{functionResponse}`/`{thought}` parts are deliberately NOT normalized
+ * here: Google never sets a `type` or `kind` tag, so there is no shared
+ * literal vocabulary to centralize, and the two consumers already read those
+ * fields under materially different rules (`normalizeConversation`'s
+ * `googlePartToBlocks` suppresses `thought` parts as provider reasoning;
+ * `conversationFormat` has never special-cased `thought` and renders a
+ * thought part's `text` field like any other text). Each module keeps its
+ * own Google-part handling.
+ */
+import { z } from 'zod';
+
+import { isObject } from '@utils/core';
+
+import { CONVERSATION_BLOCK_TYPES } from './ConversationBlockTypes';
+import { ANTHROPIC_SERVER_TOOL_BLOCK_TYPES } from './ServerToolTypes';
+
+/** One entry inside a `web_search_tool_result` block's `content` array. */
+const WebSearchResultItemSchema = z.object({
+  type: z.string(),
+  title: z.string().optional(),
+  url: z.string().optional(),
+});
+
+/**
+ * Discriminated union of API content blocks across the provider shapes that
+ * carry a `type` tag: Anthropic, OpenAI Chat Completions, OpenAI Response
+ * API, and Anthropic's server-side tool blocks. Each variant declares only
+ * the fields that provider actually populates for that block kind, so
+ * consumers can switch/narrow on `type` instead of re-deriving validity with
+ * ad hoc optional-field checks.
+ */
+export const ContentBlockSchema = z.discriminatedUnion('type', [
+  // Plain text. Anthropic and Google GenAI use 'text'; OpenAI Response API
+  // splits it into 'input_text' (user) and 'output_text' (assistant).
+  z.object({ type: z.literal('text'), text: z.string().optional() }),
+  z.object({ type: z.literal('input_text'), text: z.string().optional() }),
+  z.object({ type: z.literal('output_text'), text: z.string().optional() }),
+
+  // Anthropic extended-thinking / Google GenAI thought blocks.
+  z.object({
+    type: z.literal(CONVERSATION_BLOCK_TYPES.thinking),
+    thinking: z.string().optional(),
+  }),
+  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.redactedThinking) }),
+
+  // Tool call / tool result — shared by Anthropic, Google GenAI, and the
+  // VS Code language-model bridge (see {@link normalizeVsCodeLmBlock}).
+  z.object({
+    type: z.literal(CONVERSATION_BLOCK_TYPES.toolUse),
+    name: z.string().optional(),
+    input: z.unknown().optional(),
+  }),
+  z.object({
+    type: z.literal(CONVERSATION_BLOCK_TYPES.toolResult),
+    content: z.unknown().optional(),
+  }),
+
+  // Attachment markers: Anthropic ('image'/'document'), OpenAI Response API
+  // ('input_image'/'input_file'), OpenAI Chat Completions ('image_url'/
+  // 'file'). None of these carry fields this module reads — only `type`
+  // decides which attachment kind to render.
+  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.image) }),
+  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.inputImage) }),
+  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.imageUrl) }),
+  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.document) }),
+  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.inputFile) }),
+  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.file) }),
+
+  // Anthropic server-side tool blocks (the provider executes these, not a
+  // local tool handler).
+  z.object({
+    type: z.literal(ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.serverToolUse),
+    name: z.string().optional(),
+    input: z.unknown().optional(),
+  }),
+  z.object({
+    type: z.literal(ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webSearchToolResult),
+    content: z.array(WebSearchResultItemSchema).optional(),
+  }),
+  // `extractWebFetchResultFields` reads its fields off the raw block itself
+  // (it accepts `unknown`), not off this schema's inferred type, so this
+  // variant only declares the discriminant. `looseObject` (not `object`)
+  // documents that undeclared fields are intentionally read elsewhere —
+  // and keeps that true if runtime `.parse()` is ever added to this schema
+  // (currently it isn't for this variant; see the module-level
+  // type-derivation-only note in the consuming modules).
+  z.looseObject({
+    type: z.literal(ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webFetchToolResult),
+  }),
+]);
+export type ContentBlock = z.infer<typeof ContentBlockSchema>;
+
+// ============================================================
+// VS Code language-model bridge — `kind`-tagged parts
+// ============================================================
+
+const VsCodeLmBlockShapeSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('text'), text: z.unknown().optional() }),
+  z.object({
+    kind: z.literal('toolCall'),
+    name: z.unknown().optional(),
+    input: z.unknown().optional(),
+  }),
+  z.object({ kind: z.literal('toolResult'), text: z.unknown().optional() }),
+]);
+
+/** The subset of {@link ContentBlock} that a VS Code LM part normalizes into. */
+type NormalizedVsCodeLmBlock = Extract<
+  ContentBlock,
+  | { type: 'text' }
+  | { type: typeof CONVERSATION_BLOCK_TYPES.toolUse }
+  | { type: typeof CONVERSATION_BLOCK_TYPES.toolResult }
+>;
+
+const VsCodeLmBlockSchema = VsCodeLmBlockShapeSchema.transform(
+  (b): NormalizedVsCodeLmBlock => {
+    switch (b.kind) {
+      case 'text':
+        return {
+          type: 'text',
+          text: typeof b.text === 'string' ? b.text : undefined,
+        };
+      case 'toolCall':
+        return {
+          type: CONVERSATION_BLOCK_TYPES.toolUse,
+          name: typeof b.name === 'string' ? b.name : undefined,
+          input: b.input,
+        };
+      case 'toolResult':
+        return { type: CONVERSATION_BLOCK_TYPES.toolResult, content: b.text };
+    }
+  },
+);
+
+/**
+ * Normalize one VS Code language-model content part — `{kind: 'text' |
+ * 'toolCall' | 'toolResult', ...}` — into the canonical `type`-tagged
+ * {@link ContentBlock} shape used by every other provider. Returns
+ * `undefined` for anything that isn't a recognized `kind`-tagged block,
+ * including blocks with no `kind` at all (every other provider's blocks) —
+ * callers fall back to their own handling for that case.
+ */
+export function normalizeVsCodeLmBlock(
+  raw: unknown,
+): NormalizedVsCodeLmBlock | undefined {
+  const parsed = VsCodeLmBlockSchema.safeParse(raw);
+  return parsed.success ? parsed.data : undefined;
+}
+
+// ============================================================
+// OpenAI Chat Completions — top-level `tool_calls` array shape
+// ============================================================
+
+/**
+ * Extract the `{name, input}` fields off one entry of an OpenAI Chat
+ * Completions assistant message's top-level `tool_calls` array: the
+ * `{function: {name, arguments}}` shape, or a flatter `{name,
+ * arguments|input}` fallback some archived/alternate shapes use. Both
+ * fields are `undefined` when absent — callers decide their own defaults
+ * (`conversationFormat` renders a bare `'unknown'` marker either way;
+ * `normalizeConversation`'s SDK-validated `getAssistantToolCalls` path keeps
+ * its own extraction because it operates on an already-narrowed
+ * `ChatCompletionMessageFunctionToolCall`, not this raw shape).
+ */
+export function extractFunctionToolCallFields(
+  toolCall: Record<string, unknown>,
+): { name?: string; input?: unknown } {
+  const nestedFunction = isObject(toolCall.function)
+    ? toolCall.function
+    : undefined;
+  const nestedName =
+    typeof nestedFunction?.name === 'string' ? nestedFunction.name : '';
+  const topName = typeof toolCall.name === 'string' ? toolCall.name : '';
+  return {
+    name: nestedName || topName || undefined,
+    input: nestedFunction?.arguments ?? toolCall.arguments ?? toolCall.input,
+  };
+}

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -1,7 +1,12 @@
 import * as path from 'node:path';
 
+import { z } from 'zod';
+
 import { logFileCategory, logFilesLoaded, type AgentTrace } from '@agent/trace';
-import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
+import {
+  AttachedMemoryMissSchema,
+  type AttachedMemoryMiss,
+} from '@agent/types/AttachedMemory';
 import {
   AgentSetting,
   AgentPrompt,
@@ -46,65 +51,87 @@ import { StorageFS } from '@utils/files/storageFS';
 const SHARED_LATEX_RULES_REL = '../shared/latex_style_rules.txt';
 
 /**
- * User variables for prompt rendering
- */
-export type UserVars = Record<string, unknown>;
-
-/**
- * Fixed runtime template variables owned by `buildUserVars`.
+ * Fixed runtime template variables owned by `buildUserVars`, with the exact
+ * type each builder produces. This is the single source of truth: both the
+ * `UserVars` type and `USER_VAR_RUNTIME_TOKENS` are derived from it, so a
+ * builder that drops or misspells a key is a compile error instead of a
+ * silent runtime gap.
  *
  * Agent-creation templates render once when a YAML file is produced, then the
  * generated agent renders again at runtime. These tokens must pass through the
  * creation render literally so the runtime render can substitute them later.
  * User-defined `requiredFilesInternal` variables are intentionally not in this
- * fixed list; they remain caller-supplied names and `throwOnUndefined` stays
- * disabled until there is a separate validation story for them.
+ * fixed schema; they remain caller-supplied names carried as a plain
+ * `Record<string, string>`, and `throwOnUndefined` stays disabled until there
+ * is a separate validation story for them.
  */
-export const USER_VAR_RUNTIME_TOKENS = [
-  'MODEL',
-  'INSTRUCTION',
-  'IS_OPENAI_MODEL',
-  'IS_ANTHROPIC_MODEL',
-  'IS_GOOGLE_MODEL',
-  'WORKFLOW_AGENTS',
-  'TOOL_USE_AGENTS',
-  'CWD',
-  'DEFAULT_BIB_PATH',
-  'BUILTIN_WORKFLOW_DIR',
-  'BUILTIN_TOOLUSE_DIR',
-  'CUSTOM_AGENTS_DIR',
-  'AGENT_DOCS_DIR',
-  'INPUT_FILE',
-  'INPUT_CONTENT',
-  'INPUT_FILES',
-  'ALL_INPUTS',
-  'LIST_OF_ALL_INPUTS',
-  'CONTEXT_FILE',
-  'CONTEXT_CONTENT',
-  'CONTEXT_FILES',
-  'ALL_CONTEXTS',
-  'LIST_OF_ALL_CONTEXTS',
-  'EDITED_FILE',
-  'EDITED_CONTENT',
-  'EDITED_FILES',
-  'ALL_EDITEDS',
-  'LIST_OF_ALL_EDITEDS',
-  'MEDIA_FILE',
-  'MEDIA_CONTENT',
-  'OUTPUT_FILES',
-  'AUTO_EXTRACT_FIGURE',
-  'AUTO_EXTRACT_TIKZ_FIGURE',
-  'INCLUDE_TEX_COUNT',
-  'PRINT_INPUT_PROMPT',
-  'AUTO_COMPILE_INPUT_PDF',
-  'CODEX_GUIDANCE',
-  'CLAUDE_CODE_GUIDANCE',
-  'ROUNDS',
-  'LATEX_STYLE_RULES',
-  'ATTACHED_MEMORIES',
-  'ATTACHED_MEMORY_MISSES',
-  'AVAILABLE_SKILLS',
-] as const;
+const UserVarsSchema = z.object({
+  MODEL: z.string(),
+  INSTRUCTION: z.string(),
+  IS_OPENAI_MODEL: z.boolean(),
+  IS_ANTHROPIC_MODEL: z.boolean(),
+  IS_GOOGLE_MODEL: z.boolean(),
+  WORKFLOW_AGENTS: z.string(),
+  TOOL_USE_AGENTS: z.string(),
+  CWD: z.string(),
+  DEFAULT_BIB_PATH: z.string(),
+  BUILTIN_WORKFLOW_DIR: z.string(),
+  BUILTIN_TOOLUSE_DIR: z.string(),
+  CUSTOM_AGENTS_DIR: z.string(),
+  AGENT_DOCS_DIR: z.string(),
+
+  INPUT_FILE: z.string().nullable(),
+  INPUT_CONTENT: z.string().nullable(),
+  INPUT_FILES: z.array(z.string()),
+  ALL_INPUTS: z.string().nullable(),
+  LIST_OF_ALL_INPUTS: z.string(),
+
+  CONTEXT_FILE: z.string().nullable(),
+  CONTEXT_CONTENT: z.string().nullable(),
+  CONTEXT_FILES: z.array(z.string()),
+  ALL_CONTEXTS: z.string().nullable(),
+  LIST_OF_ALL_CONTEXTS: z.string(),
+
+  EDITED_FILE: z.string().nullable(),
+  EDITED_CONTENT: z.string().nullable(),
+  EDITED_FILES: z.array(z.string()),
+  ALL_EDITEDS: z.string().nullable(),
+  LIST_OF_ALL_EDITEDS: z.string(),
+
+  MEDIA_FILE: z.string().nullable(),
+  MEDIA_CONTENT: z.null(),
+
+  // Only set when there are usable output files at all.
+  OUTPUT_FILES: z.array(z.string()).nullish(),
+
+  AUTO_EXTRACT_FIGURE: z.boolean(),
+  AUTO_EXTRACT_TIKZ_FIGURE: z.boolean(),
+  INCLUDE_TEX_COUNT: z.boolean(),
+  PRINT_INPUT_PROMPT: z.boolean(),
+  AUTO_COMPILE_INPUT_PDF: z.boolean(),
+  CODEX_GUIDANCE: z.string(),
+  CLAUDE_CODE_GUIDANCE: z.string(),
+  // Only computed for workflow agents, not tool-use agents.
+  ROUNDS: z.number().nullish(),
+
+  LATEX_STYLE_RULES: z.string(),
+  ATTACHED_MEMORIES: z.string().nullable(),
+  ATTACHED_MEMORY_MISSES: z.array(AttachedMemoryMissSchema),
+  AVAILABLE_SKILLS: z.string(),
+});
+
+type KnownUserVars = z.infer<typeof UserVarsSchema>;
+
+/**
+ * User variables for prompt rendering: the fixed, known set above plus
+ * caller-supplied `requiredFilesInternal` var names, which aren't part of the
+ * fixed schema (see `UserVarsSchema`'s doc comment).
+ */
+export type UserVars = KnownUserVars & Record<string, unknown>;
+
+export const USER_VAR_RUNTIME_TOKENS = Object.keys(
+  UserVarsSchema.shape,
+) as ReadonlyArray<keyof KnownUserVars>;
 
 export function buildUserVarPassthrough(): Readonly<Record<string, string>> {
   return Object.freeze(
@@ -140,10 +167,11 @@ export interface BuildUserVarsOptions {
 }
 
 /**
- * Result of loading file-based variables
+ * Result of loading the caller-supplied `requiredFilesInternal` file vars.
+ * Keyed by arbitrary YAML `varName`s, not part of the fixed `UserVarsSchema`.
  */
 type FileVarsResult = {
-  vars: UserVars;
+  vars: Record<string, string>;
   files: LoadedFileEntry[];
 };
 
@@ -227,7 +255,22 @@ function getBasicVars(
   agentConfig: AgentConfig,
   providerFlags: ModelProviderFlags,
   options: BuildUserVarsOptions,
-): UserVars {
+): Pick<
+  KnownUserVars,
+  | 'MODEL'
+  | 'INSTRUCTION'
+  | 'IS_OPENAI_MODEL'
+  | 'IS_ANTHROPIC_MODEL'
+  | 'IS_GOOGLE_MODEL'
+  | 'WORKFLOW_AGENTS'
+  | 'TOOL_USE_AGENTS'
+  | 'CWD'
+  | 'DEFAULT_BIB_PATH'
+  | 'BUILTIN_WORKFLOW_DIR'
+  | 'BUILTIN_TOOLUSE_DIR'
+  | 'CUSTOM_AGENTS_DIR'
+  | 'AGENT_DOCS_DIR'
+> {
   // Build agent lists for template use. Tool-use agents append their tools.
   function formatAgentList(
     agents: Pick<AgentEntry, 'name' | 'description' | 'tools'>[],
@@ -288,14 +331,20 @@ function getBasicVars(
  * label cannot break prompt rendering. Absent roots render as empty strings
  * (e.g. in tests that don't run activation).
  */
-function getAgentDirectoryVars(): UserVars {
+function getAgentDirectoryVars(): Pick<
+  KnownUserVars,
+  | 'BUILTIN_WORKFLOW_DIR'
+  | 'BUILTIN_TOOLUSE_DIR'
+  | 'CUSTOM_AGENTS_DIR'
+  | 'AGENT_DOCS_DIR'
+> {
   const KIND_TO_VAR: Record<ExternalRootKind, string> = {
     builtInWorkflow: 'BUILTIN_WORKFLOW_DIR',
     builtInToolUse: 'BUILTIN_TOOLUSE_DIR',
     custom: 'CUSTOM_AGENTS_DIR',
     agentDocs: 'AGENT_DOCS_DIR',
   };
-  const vars: UserVars = {
+  const vars: Record<string, string> = {
     BUILTIN_WORKFLOW_DIR: '',
     BUILTIN_TOOLUSE_DIR: '',
     CUSTOM_AGENTS_DIR: '',
@@ -304,40 +353,76 @@ function getAgentDirectoryVars(): UserVars {
   for (const root of listExternalRoots()) {
     vars[KIND_TO_VAR[root.kind]] = root.absolutePath;
   }
-  return vars;
+  // Loop writes computed keys from KIND_TO_VAR's values, which TS can't
+  // verify incrementally match the four literal keys seeded above.
+  return vars as Pick<
+    KnownUserVars,
+    | 'BUILTIN_WORKFLOW_DIR'
+    | 'BUILTIN_TOOLUSE_DIR'
+    | 'CUSTOM_AGENTS_DIR'
+    | 'AGENT_DOCS_DIR'
+  >;
 }
 
-// Maps a template prefix to its canonical file-list field.
+// Maps a template prefix to its canonical file-list field, via typed
+// accessors rather than a `keyof AgentConfig` lookup table — that would need
+// an `as string[]`/`as string | null` cast at the read site to recover the
+// per-field type a bare key name can't express.
 type FileCategoryConfig = {
-  multiple: keyof AgentConfig;
-  single?: keyof AgentConfig;
+  readonly getMultiple: (config: AgentConfig) => string[];
+  readonly getSingle?: (config: AgentConfig) => string | null;
 };
 
 const FILE_CATEGORIES: Record<string, FileCategoryConfig> = {
-  INPUT: { multiple: 'inputFiles' },
-  CONTEXT: { multiple: 'contextFiles' },
-  MEDIA: { multiple: 'mediaFiles' },
-  EDITED: { multiple: 'editedFiles', single: 'editedFile' },
+  INPUT: { getMultiple: (config) => config.inputFiles },
+  CONTEXT: { getMultiple: (config) => config.contextFiles },
+  MEDIA: { getMultiple: (config) => config.mediaFiles },
+  EDITED: {
+    getMultiple: (config) => config.editedFiles,
+    getSingle: (config) => config.editedFile,
+  },
 };
 
 /** Get the multi-list for a category (filtering empties) */
 function getCategoryFiles(config: AgentConfig, category: string): string[] {
   const cat = FILE_CATEGORIES[category];
   if (!cat) return [];
-  const list = (config[cat.multiple] as string[] | undefined) ?? [];
-  const single = cat.single ? (config[cat.single] as string | null) : null;
+  const list = cat.getMultiple(config);
+  const single = cat.getSingle ? cat.getSingle(config) : null;
   return unique([single, ...list].filter(isNonEmptyString));
 }
 
 /** Categories used for building file vars (excludes MEDIA which is display-only) */
 const FILE_VAR_CATEGORIES = ['INPUT', 'CONTEXT', 'EDITED'];
 
+type FileCategoryVarKeys =
+  | 'INPUT_FILE'
+  | 'INPUT_CONTENT'
+  | 'INPUT_FILES'
+  | 'ALL_INPUTS'
+  | 'LIST_OF_ALL_INPUTS'
+  | 'CONTEXT_FILE'
+  | 'CONTEXT_CONTENT'
+  | 'CONTEXT_FILES'
+  | 'ALL_CONTEXTS'
+  | 'LIST_OF_ALL_CONTEXTS'
+  | 'EDITED_FILE'
+  | 'EDITED_CONTENT'
+  | 'EDITED_FILES'
+  | 'ALL_EDITEDS'
+  | 'LIST_OF_ALL_EDITEDS'
+  | 'MEDIA_FILE'
+  | 'MEDIA_CONTENT';
+
 async function getFileVars(
   agentConfig: AgentConfig,
   agentSetting: AgentSetting,
   logger: AgentTrace,
-): Promise<UserVars> {
-  const userVars: UserVars = {};
+): Promise<Pick<KnownUserVars, FileCategoryVarKeys>> {
+  // Keys are computed per FILE_VAR_CATEGORIES entry (`${prefix}_FILE`, etc.),
+  // which TS can't verify incrementally match FileCategoryVarKeys — see the
+  // single contained cast at the return below.
+  const userVars: Record<string, unknown> = {};
 
   const contextFiles = getCategoryFiles(agentConfig, 'CONTEXT');
 
@@ -379,7 +464,7 @@ async function getFileVars(
   userVars.MEDIA_FILE = mediaFiles[0] ?? null;
   userVars.MEDIA_CONTENT = null;
 
-  return userVars;
+  return userVars as Pick<KnownUserVars, FileCategoryVarKeys>;
 }
 
 /**
@@ -431,7 +516,7 @@ async function getRequiredFileVars(
   agentSetting: AgentSetting,
   agentPath: string,
 ): Promise<FileVarsResult> {
-  const vars: UserVars = {};
+  const vars: Record<string, string> = {};
   const files: LoadedFileEntry[] = [];
 
   for (const [varName, filePath] of Object.entries(
@@ -500,8 +585,8 @@ async function getAttachedMemories(
 export function resolveOutputFiles(
   agentConfig: AgentConfig,
   agentSetting: AgentSetting,
-): UserVars {
-  const userVars: UserVars = {};
+): Pick<KnownUserVars, 'OUTPUT_FILES'> {
+  const userVars: Pick<KnownUserVars, 'OUTPUT_FILES'> = {};
   const explicitOutputFiles = (agentConfig.outputFiles ?? []).filter(Boolean);
   const defaultOutputFiles = (agentSetting.defaultOutputFiles ?? []).filter(
     Boolean,
@@ -523,12 +608,22 @@ export function resolveOutputFiles(
   return userVars;
 }
 
+type ToolFlagsKeys =
+  | 'AUTO_EXTRACT_FIGURE'
+  | 'AUTO_EXTRACT_TIKZ_FIGURE'
+  | 'INCLUDE_TEX_COUNT'
+  | 'PRINT_INPUT_PROMPT'
+  | 'AUTO_COMPILE_INPUT_PDF'
+  | 'CODEX_GUIDANCE'
+  | 'CLAUDE_CODE_GUIDANCE'
+  | 'ROUNDS';
+
 export function getToolFlags(
   agentConfig: AgentConfig,
   agentSetting: AgentSetting,
   agentPrompt: AgentPrompt,
-): UserVars {
-  const flags: UserVars = {
+): Pick<KnownUserVars, ToolFlagsKeys> {
+  const flags: Pick<KnownUserVars, ToolFlagsKeys> = {
     AUTO_EXTRACT_FIGURE: agentConfig.toolConfig.autoExtractFigure,
     AUTO_EXTRACT_TIKZ_FIGURE: agentConfig.toolConfig.autoExtractTikzFigure,
     INCLUDE_TEX_COUNT: agentConfig.toolConfig.attachTeXCount,

--- a/src/controllers/progressView/backend/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/ProgressViewState.ts
@@ -68,16 +68,41 @@ type ProgressStreamRunDetails =
       workingDirectory?: string;
     };
 
+/**
+ * `agentCategory` and `run` are only ever assembled together, atomically, in
+ * `buildSnapshotMetadataPatch` from one `RunConfig` — `run` never appears
+ * without `agentCategory`. `agentCategory` alone (the first variant) is a
+ * live hint `ProgressFactApplier.handleSetActiveStream` can set before that
+ * config resolves, so the pairing is one-directional, not symmetric.
+ */
+type ProgressStreamRunResolution =
+  | { run?: undefined; agentCategory?: AgentCategory }
+  | { run: ProgressStreamRunDetails; agentCategory: AgentCategory };
+
 /** Canonical current metadata used by every progress-view stream consumer. */
 export interface ProgressStreamMetadata {
-  agentCategory?: AgentCategory;
+  resolution: ProgressStreamRunResolution;
   isRemote?: boolean;
   creationTimestamp: number;
   executionId?: ExecutionId;
   parentStreamId?: StreamTabId;
   description?: string;
-  run?: ProgressStreamRunDetails;
 }
+
+/**
+ * External patch input for {@link ProgressViewState.updateStreamMetadata}.
+ * `run` is intentionally absent: it's only ever assembled internally by
+ * `buildSnapshotMetadataPatch` from a resolved `RunConfig`, never patched in
+ * directly by a caller.
+ */
+type ProgressStreamMetadataPatch = Partial<
+  Pick<
+    ProgressStreamMetadata,
+    'isRemote' | 'executionId' | 'parentStreamId' | 'description'
+  >
+> & {
+  agentCategory?: AgentCategory;
+};
 
 /**
  * The stored slice of {@link ProgressStreamMetadata}. `creationTimestamp` is
@@ -270,7 +295,7 @@ export class ProgressViewState {
     let state = this._sessionState.get(stream);
     if (!state) {
       state = {
-        metadata: {},
+        metadata: { resolution: {} },
         provisionalCreationTimestamp:
           this.streamLogs.getFirstTimestamp(stream) ?? Date.now(),
       };
@@ -322,24 +347,24 @@ export class ProgressViewState {
         category: config.agentCategory,
         kind: isProcessAgent(config.agent) ? 'process' : 'agent',
       };
-      patch.agentCategory = identity.category;
       const workingDirectory = config.workingDirectory ?? undefined;
+      let run: ProgressStreamRunDetails;
       if (identity.kind === 'workflowScript') {
-        patch.run = {
+        run = {
           kind: 'workflowScript',
           workflowName: identity.agent,
           instruction: config.instruction,
           workingDirectory,
         };
       } else if (identity.kind === 'process') {
-        patch.run = {
+        run = {
           kind: 'process',
           agent: identity.agent,
           instruction: config.instruction,
           workingDirectory,
         };
       } else {
-        patch.run = {
+        run = {
           kind: 'agent',
           agent: identity.agent,
           inputFile: config.inputFiles?.at(0),
@@ -348,6 +373,8 @@ export class ProgressViewState {
           workingDirectory,
         };
       }
+      // Set together, atomically — see ProgressStreamRunResolution's doc.
+      patch.resolution = { agentCategory: identity.category, run };
     }
 
     patch.executionId =
@@ -377,10 +404,20 @@ export class ProgressViewState {
    */
   updateStreamMetadata(
     stream: StreamTabId,
-    patch: Partial<StoredStreamMetadata>,
+    patch: ProgressStreamMetadataPatch,
   ): void {
     const state = this.getOrCreateSession(stream);
-    const merged = this.applyMetadataPatch(state.metadata, patch);
+    const { agentCategory, ...rest } = patch;
+    const storedPatch: Partial<StoredStreamMetadata> = { ...rest };
+    if (agentCategory !== undefined) {
+      // Preserve `run` if already resolved — only `agentCategory` is being
+      // patched here; `run` is only ever assembled by buildSnapshotMetadataPatch.
+      storedPatch.resolution = {
+        ...state.metadata.resolution,
+        agentCategory,
+      } as ProgressStreamRunResolution;
+    }
+    const merged = this.applyMetadataPatch(state.metadata, storedPatch);
     state.metadata = this.applySnapshotMetadata(stream, merged);
   }
 
@@ -393,7 +430,7 @@ export class ProgressViewState {
   /** Start a run from durable metadata, dropping this session's live-only data. */
   resetStreamMetadataForRun(stream: StreamTabId): void {
     const state = this.getOrCreateSession(stream);
-    state.metadata = this.applySnapshotMetadata(stream, {});
+    state.metadata = this.applySnapshotMetadata(stream, { resolution: {} });
   }
 
   /**

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -791,7 +791,7 @@ export class ProgressFactApplier {
   }
 
   private getStreamCategory(streamId: StreamTabId): AgentCategory | undefined {
-    return this.state.getStreamMetadata(streamId).agentCategory;
+    return this.state.getStreamMetadata(streamId).resolution.agentCategory;
   }
 
   getAllStreamStates(): Map<StreamTabId, StreamPhaseState> {

--- a/src/controllers/progressView/backend/streamInfoUtils.ts
+++ b/src/controllers/progressView/backend/streamInfoUtils.ts
@@ -17,7 +17,7 @@ export function buildStreamInfo(
   id: string,
 ): StreamTabInfo {
   const metadata = state.getStreamMetadata(id);
-  const workingDirectory = metadata.run?.workingDirectory;
+  const workingDirectory = metadata.resolution.run?.workingDirectory;
   let worktreeInfo;
   if (workingDirectory) {
     worktreeInfo = peekWorktreeInfo(workingDirectory);

--- a/src/controllers/progressView/backend/streamTabInfo.ts
+++ b/src/controllers/progressView/backend/streamTabInfo.ts
@@ -27,9 +27,9 @@ export interface StreamTabInfoInputs {
  */
 export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   const { streamId, metadata } = inputs;
-  const { run } = metadata;
+  const { run, agentCategory } = metadata.resolution;
 
-  const category = metadata.agentCategory ?? AgentCategory.Workflow;
+  const category = agentCategory ?? AgentCategory.Workflow;
 
   // `run` is undefined until the stream's RunConfig snapshot resolves (see
   // `applySnapshotMetadata`); fall back to parsing the agent name out of the

--- a/src/controllers/settingsView/ToolDashboardData.ts
+++ b/src/controllers/settingsView/ToolDashboardData.ts
@@ -50,7 +50,9 @@ export function planToolTerminalAction(input: {
   if (!def) return { kind: 'none', reason: 'unknownTool' };
 
   const command =
-    input.commandKind === 'install' ? def.installCommand : def.authCommand;
+    input.commandKind === 'install'
+      ? def.install?.command
+      : def.auth?.command;
   if (!command) return { kind: 'none', reason: 'missingCommand' };
 
   return { kind: 'terminal', name: `TeXRA: ${def.name}`, command };
@@ -177,7 +179,7 @@ export async function buildToolDashboardItems(
   const externalItems: ToolDashboardItem[] = [];
   for (const { id, tools, status, statusLabel, statusDetail } of results) {
     const def = findExternalToolDef(id);
-    if (!def || def.hideFromDashboard) continue;
+    if (!def || def.visibility?.hideFromDashboard) continue;
     externalItems.push({
       id: def.id,
       name: def.name,
@@ -187,14 +189,14 @@ export async function buildToolDashboardItems(
       status,
       statusLabel,
       requiresSetup: true,
-      installGuide: def.installGuide,
-      installUrl: def.installUrl,
-      installExtensionId: def.installExtensionId,
-      installCommand: def.installCommand,
-      authCommand: def.authCommand,
+      installGuide: def.install?.guide,
+      installUrl: def.install?.url,
+      installExtensionId: def.install?.extensionId,
+      installCommand: def.install?.command,
+      authCommand: def.auth?.command,
       configNotes: def.configNotes,
       statusDetail,
-      authNote: def.authNote,
+      authNote: def.auth?.note,
       toggleable: def.toggleable,
       enabled: !disabledIds.has(def.id),
     });

--- a/src/controllers/settingsView/ToolDashboardData.ts
+++ b/src/controllers/settingsView/ToolDashboardData.ts
@@ -50,9 +50,7 @@ export function planToolTerminalAction(input: {
   if (!def) return { kind: 'none', reason: 'unknownTool' };
 
   const command =
-    input.commandKind === 'install'
-      ? def.install?.command
-      : def.auth?.command;
+    input.commandKind === 'install' ? def.install?.command : def.auth?.command;
   if (!command) return { kind: 'none', reason: 'missingCommand' };
 
   return { kind: 'terminal', name: `TeXRA: ${def.name}`, command };

--- a/src/test-kernel/progressView/FollowUpEventHandlers.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpEventHandlers.vitest.ts
@@ -24,6 +24,7 @@ import {
   resetProgressState,
 } from '@progressView/frontend/progressState';
 import {
+  createEmptyStreamLogs,
   createInitialState,
   isToolUseState,
   type ProgressState,
@@ -45,9 +46,9 @@ function createToolUseState(text: string): StreamState {
 }
 
 /**
- * Seed the shared appState singleton with two tool-use streams and return a
- * live reader over it. Streams are registered in `streamById` too, so the
- * real `setStreamStateForId` mutator accepts updates for them.
+ * Seed the shared appState singleton with two tool-use streams (info + state
+ * on one entry each) and return a live reader over it, so the real
+ * `setStreamStateForId` mutator accepts updates for them.
  */
 function seedState(): () => ProgressState {
   const state = createInitialState();
@@ -56,13 +57,17 @@ function seedState(): () => ProgressState {
     ['stream-a', 'draft'],
     ['stream-b', 'other'],
   ] as const) {
-    state.streamStates.set(streamId, createToolUseState(text));
-    state.streamById.set(streamId, {
-      kind: 'agent',
-      name: streamId as StreamTabId,
-      label: streamId,
-      agentCategory: AgentCategory.ToolUse,
-      creationTimestamp: 1,
+    state.streams.set(streamId, {
+      info: {
+        kind: 'agent',
+        name: streamId as StreamTabId,
+        label: streamId,
+        agentCategory: AgentCategory.ToolUse,
+        creationTimestamp: 1,
+      },
+      state: createToolUseState(text),
+      logs: createEmptyStreamLogs(),
+      followupOptions: {},
     });
   }
   appState.set(state);
@@ -70,7 +75,7 @@ function seedState(): () => ProgressState {
 }
 
 function followUpText(state: ProgressState, streamId: string): string {
-  const stream = state.streamStates.get(streamId);
+  const stream = state.streams.get(streamId)?.state;
   if (!stream || !isToolUseState(stream)) {
     throw new Error(`Expected tool-use state for ${streamId}`);
   }

--- a/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
+++ b/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
@@ -7,6 +7,7 @@ import {
   resetProgressState,
 } from '@progressView/frontend/progressState';
 import {
+  createEmptyStreamLogs,
   createInitialState,
   type ProgressState,
 } from '@progressView/frontend/store';
@@ -36,7 +37,18 @@ const STREAM_ID = 'stream-a' as StreamTabId;
 function seedWorkflowStream(): () => ProgressState {
   const state = createInitialState();
   state.activeStreamId = STREAM_ID;
-  state.streamStates.set(STREAM_ID, createStreamState(AgentCategory.Workflow));
+  state.streams.set(STREAM_ID, {
+    info: {
+      kind: 'agent',
+      name: STREAM_ID,
+      label: STREAM_ID,
+      agentCategory: AgentCategory.Workflow,
+      creationTimestamp: 1,
+    },
+    state: createStreamState(AgentCategory.Workflow),
+    logs: createEmptyStreamLogs(),
+    followupOptions: {},
+  });
   appState.set(state);
   return () => appState.get();
 }
@@ -80,7 +92,7 @@ describe('LOG_DELTA text deltas', () => {
       updates: [],
     } as unknown as ProgressViewOutboundMessage);
 
-    expect(getState().streamLogs.get(STREAM_ID)?.logs[0]?.text).toBe('hello');
+    expect(getState().streams.get(STREAM_ID)?.logs.logs[0]?.text).toBe('hello');
   });
 
   it('appends streamed text without whole-entry replacement and finalizes via full update', () => {
@@ -102,7 +114,7 @@ describe('LOG_DELTA text deltas', () => {
       textDeltas: [{ id: 'model-response', appendText: ' world' }],
     });
 
-    const streamedLogs = getState().streamLogs.get(STREAM_ID);
+    const streamedLogs = getState().streams.get(STREAM_ID)?.logs;
     const streamed = streamedLogs?.logs[0];
     expect(streamed?.text).toBe('hello world');
     expect(streamedLogs?.updatedMessageIndices).toEqual([0]);
@@ -116,7 +128,7 @@ describe('LOG_DELTA text deltas', () => {
       textDeltas: [],
     });
 
-    const finalizedLogs = getState().streamLogs.get(STREAM_ID);
+    const finalizedLogs = getState().streams.get(STREAM_ID)?.logs;
     const finalized = finalizedLogs?.logs[0];
     expect(finalized?.text).toBe('hello world');
     expect(finalizedLogs?.updatedMessageIndices).toEqual([0]);
@@ -164,7 +176,7 @@ describe('LOG_DELTA text deltas', () => {
       textDeltas: [],
     });
 
-    const streamLogs = getState().streamLogs.get(STREAM_ID);
+    const streamLogs = getState().streams.get(STREAM_ID)?.logs;
     expect(streamLogs?.logs.map(({ id }) => id)).toEqual(['model-response']);
     expect([...(streamLogs?.logIndex.keys() ?? [])]).toEqual([
       'model-response',
@@ -192,7 +204,7 @@ describe('LOG_DELTA text deltas', () => {
       textDeltas: [],
     });
 
-    const group = getState().streamStates.get(STREAM_ID)?.taskGroups[0];
+    const group = getState().streams.get(STREAM_ID)?.state.taskGroups[0];
     expect(group?.status).toBe(STREAM_PHASE.RUNNING);
     expect(group?.kind).toBe('round');
     expect(group?.index).toBe(1);
@@ -273,7 +285,7 @@ describe('LOG_DELTA GROUP_END task-group status (#7993 step 3)', () => {
         textDeltas: [],
       });
 
-      const taskGroups = getState().streamStates.get(STREAM_ID)?.taskGroups;
+      const taskGroups = getState().streams.get(STREAM_ID)?.state.taskGroups;
       expect(taskGroups?.[0]?.status).toBe(expectedStatus);
     },
   );
@@ -294,7 +306,7 @@ describe('LOG_DELTA GROUP_END task-group status (#7993 step 3)', () => {
     });
 
     const extensionTaskGroups =
-      getState().streamStates.get(STREAM_ID)?.taskGroups;
+      getState().streams.get(STREAM_ID)?.state.taskGroups;
     expect(extensionTaskGroups).toEqual(
       projectTaskGroupsFromStreamLog([legacyRound]),
     );

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -1097,14 +1097,16 @@ describe('ProgressBackend', () => {
     });
 
     expect(backend.state.getStreamMetadata(stream)).toMatchObject({
-      agentCategory: AgentCategory.ToolUse,
       isRemote: true,
       executionId,
-      run: expect.objectContaining({
-        kind: 'agent',
-        agent: 'search',
-        model: 'deepseekproT',
-      }),
+      resolution: {
+        agentCategory: AgentCategory.ToolUse,
+        run: expect.objectContaining({
+          kind: 'agent',
+          agent: 'search',
+          model: 'deepseekproT',
+        }),
+      },
     });
 
     const infos = buildStreamInfos(backend.state);
@@ -1158,7 +1160,7 @@ describe('ProgressBackend', () => {
     );
 
     await vi.waitFor(() =>
-      expect(backend.state.getStreamMetadata(stream).run).toEqual({
+      expect(backend.state.getStreamMetadata(stream).resolution.run).toEqual({
         kind: 'workflowScript',
         workflowName: 'repo-cleanup-readonly-pilot-2026-07-24',
         instruction: "Workflow script 'repo-cleanup-readonly-pilot-2026-07-24'",

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -108,7 +108,9 @@ describe('ProgressBackend', () => {
       toolUseConfig('search', 'deepseekproT'),
     );
 
-    expect(backend.state.getStreamMetadata(streamId).run).toMatchObject({
+    expect(
+      backend.state.getStreamMetadata(streamId).resolution.run,
+    ).toMatchObject({
       kind: 'agent',
       agent: 'search',
       model: 'deepseekproT',

--- a/src/test-kernel/progressView/ProgressExecutionLabels.vitest.ts
+++ b/src/test-kernel/progressView/ProgressExecutionLabels.vitest.ts
@@ -7,9 +7,13 @@ import {
   logContext$,
   resetProgressState,
 } from '@progressView/frontend/progressState';
-import { createInitialState } from '@progressView/frontend/store';
+import {
+  createEmptyStreamLogs,
+  createInitialState,
+} from '@progressView/frontend/store';
 import {
   AgentCategory,
+  createStreamState,
   type StreamTabId,
   type StreamTabInfo,
 } from '@shared/schemas';
@@ -60,8 +64,16 @@ function seedStreams(
   appState.set({
     ...createInitialState(),
     activeStreamId,
-    streamById: new Map(
-      streams.map((stream) => [stream.name as StreamTabId, stream]),
+    streams: new Map(
+      streams.map((stream) => [
+        stream.name as StreamTabId,
+        {
+          info: stream,
+          state: createStreamState(stream.agentCategory),
+          logs: createEmptyStreamLogs(),
+          followupOptions: {},
+        },
+      ]),
     ),
   });
 }

--- a/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
@@ -26,11 +26,16 @@ import {
   resetProgressState,
 } from '@progressView/frontend/progressState';
 import { dispatchMessage } from '@progressView/frontend/messageDispatcher';
+import { createEmptyStreamLogs } from '@progressView/frontend/store';
 import {
   logListStateKey,
   webviewStorage,
 } from '@progressView/frontend/webviewStorage';
-import { AgentCategory, type StreamTabId } from '@shared/schemas';
+import {
+  AgentCategory,
+  createStreamState,
+  type StreamTabId,
+} from '@shared/schemas';
 import { MAIN_VIEW_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   dispatchProgressViewOutbound,
@@ -193,18 +198,23 @@ describe('progressView dispatchMessage (createDispatcher migration)', () => {
 
     expect(handled).toBe(true);
     expect(permissions$.get()).toEqual([]);
-    expect(appState.get().streamById.size).toBe(0);
+    expect(appState.get().streams.size).toBe(0);
     expect(onError).not.toHaveBeenCalled();
   });
 
   it("DELETE_ALL clears every remaining stream's persisted LogList toggle state", () => {
     const streamId = 'stream-delete-all' as StreamTabId;
-    appState.get().streamById.set(streamId, {
-      kind: 'agent',
-      name: streamId,
-      label: 'stream-delete-all',
-      agentCategory: AgentCategory.Workflow,
-      creationTimestamp: 1,
+    appState.get().streams.set(streamId, {
+      info: {
+        kind: 'agent',
+        name: streamId,
+        label: 'stream-delete-all',
+        agentCategory: AgentCategory.Workflow,
+        creationTimestamp: 1,
+      },
+      state: createStreamState(AgentCategory.Workflow),
+      logs: createEmptyStreamLogs(),
+      followupOptions: {},
     });
     webviewStorage.set(logListStateKey(streamId), {
       groupToggleStates: [['group-1', true]],
@@ -222,12 +232,17 @@ describe('progressView dispatchMessage (createDispatcher migration)', () => {
 
   it("DELETE_STREAM clears that stream's persisted LogList toggle state", () => {
     const streamId = 'stream-delete-one' as StreamTabId;
-    appState.get().streamById.set(streamId, {
-      kind: 'agent',
-      name: streamId,
-      label: 'stream-delete-one',
-      agentCategory: AgentCategory.Workflow,
-      creationTimestamp: 1,
+    appState.get().streams.set(streamId, {
+      info: {
+        kind: 'agent',
+        name: streamId,
+        label: 'stream-delete-one',
+        agentCategory: AgentCategory.Workflow,
+        creationTimestamp: 1,
+      },
+      state: createStreamState(AgentCategory.Workflow),
+      logs: createEmptyStreamLogs(),
+      followupOptions: {},
     });
     webviewStorage.set(logListStateKey(streamId), {
       groupToggleStates: [['group-1', true]],

--- a/src/test-kernel/progressView/StreamContentSync.vitest.ts
+++ b/src/test-kernel/progressView/StreamContentSync.vitest.ts
@@ -244,7 +244,9 @@ describe('progress view stream-content projection', () => {
     // state while reset metadata awaits a canonical run config.
     state.resetStreamMetadataForRun(stream);
     state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
-    expect(state.getStreamMetadata(stream).agentCategory).toBeUndefined();
+    expect(
+      state.getStreamMetadata(stream).resolution.agentCategory,
+    ).toBeUndefined();
     state.updateStreamState(stream, (prev) => ({
       ...prev,
       conversationProgress: { toolCallCount: 3 },

--- a/src/test-kernel/progressView/StreamMetaState.vitest.ts
+++ b/src/test-kernel/progressView/StreamMetaState.vitest.ts
@@ -13,9 +13,9 @@ import {
   topLevelStreams$,
 } from '@progressView/frontend/progressState';
 import {
+  createEmptyStreamLogs,
   createInitialState,
   type ProgressState,
-  type StreamState,
 } from '@progressView/frontend/store';
 import {
   AgentCategory,
@@ -57,13 +57,20 @@ function registerStream(
   streamId: StreamTabId,
   overrides: Partial<Extract<StreamTabInfo, { kind: 'agent' }>> = {},
 ): void {
-  state.streamById.set(streamId, {
+  const info: StreamTabInfo = {
     kind: 'agent',
     name: streamId,
     label: streamId,
     agentCategory: AgentCategory.Workflow,
     creationTimestamp: 1,
     ...overrides,
+  };
+  const existing = state.streams.get(streamId);
+  state.streams.set(streamId, {
+    info,
+    state: existing?.state ?? createStreamState(info.agentCategory),
+    logs: existing?.logs ?? createEmptyStreamLogs(),
+    followupOptions: existing?.followupOptions ?? {},
   });
 }
 
@@ -106,10 +113,12 @@ describe('stream meta frontend state', () => {
       creationTimestamp: 2,
     });
     registerStream(state, streamId);
-    state.streamStates.set(streamId, createStreamState(AgentCategory.Workflow));
-    state.streamStates.set(
-      siblingId,
-      createStreamState(AgentCategory.ToolUse, {
+    state.streams.get(streamId)!.state = createStreamState(
+      AgentCategory.Workflow,
+    );
+    state.streams.get(siblingId)!.state = createStreamState(
+      AgentCategory.ToolUse,
+      {
         status: STREAM_PHASE.RUNNING,
         subagents: [
           {
@@ -119,7 +128,7 @@ describe('stream meta frontend state', () => {
             agentName: 'old child',
           },
         ],
-      } satisfies Partial<StreamState>),
+      },
     );
     const getState = seedState(state);
 
@@ -147,12 +156,12 @@ describe('stream meta frontend state', () => {
       activeStream: siblingId,
     });
 
-    expect(getState().streamById.get(streamId)?.label).toBe('stream-a');
-    expect(getState().streamById.get(siblingId)).toMatchObject({
+    expect(getState().streams.get(streamId)?.info.label).toBe('stream-a');
+    expect(getState().streams.get(siblingId)?.info).toMatchObject({
       label: 'search',
       model: 'deepseekproT',
     });
-    expect(getState().streamStates.get(siblingId)).toMatchObject({
+    expect(getState().streams.get(siblingId)?.state).toMatchObject({
       status: STREAM_PHASE.WAITING,
       lastTimestamp: 9,
       conversationProgress: {
@@ -162,18 +171,18 @@ describe('stream meta frontend state', () => {
       subagents: [],
     });
     expect(getState().activeStreamId).toBe(siblingId);
-    expect([...getState().streamById.keys()]).toEqual([siblingId, streamId]);
+    expect([...getState().streams.keys()]).toEqual([siblingId, streamId]);
   });
 
   it('updates and clears stream substate with status changes', () => {
     const streamId = 'stream-a' as StreamTabId;
     const state = createInitialState();
     registerStream(state, streamId);
-    state.streamStates.set(
-      streamId,
-      createStreamState(AgentCategory.Workflow, {
+    state.streams.get(streamId)!.state = createStreamState(
+      AgentCategory.Workflow,
+      {
         status: STREAM_PHASE.RUNNING,
-      } satisfies Partial<StreamState>),
+      },
     );
     const getState = seedState(state);
 
@@ -184,7 +193,7 @@ describe('stream meta frontend state', () => {
       substate: STREAM_SUBSTATE.STARTING,
     });
 
-    expect(getState().streamStates.get(streamId)?.substate).toBe(
+    expect(getState().streams.get(streamId)?.state.substate).toBe(
       STREAM_SUBSTATE.STARTING,
     );
 
@@ -194,10 +203,10 @@ describe('stream meta frontend state', () => {
       status: STREAM_PHASE.COMPLETED,
     });
 
-    expect(getState().streamStates.get(streamId)?.status).toBe(
+    expect(getState().streams.get(streamId)?.state.status).toBe(
       STREAM_PHASE.COMPLETED,
     );
-    expect(getState().streamStates.get(streamId)?.substate).toBeUndefined();
+    expect(getState().streams.get(streamId)?.state.substate).toBeUndefined();
   });
 
   it('clears stream substate when full metadata sync omits it', () => {
@@ -205,12 +214,12 @@ describe('stream meta frontend state', () => {
     const state = createInitialState();
     state.activeStreamId = streamId;
     registerStream(state, streamId);
-    state.streamStates.set(
-      streamId,
-      createStreamState(AgentCategory.Workflow, {
+    state.streams.get(streamId)!.state = createStreamState(
+      AgentCategory.Workflow,
+      {
         status: STREAM_PHASE.RUNNING,
         substate: STREAM_SUBSTATE.STARTING,
-      } satisfies Partial<StreamState>),
+      },
     );
     const getState = seedState(state);
 
@@ -239,21 +248,21 @@ describe('stream meta frontend state', () => {
       },
     });
 
-    expect(getState().streamStates.get(streamId)?.status).toBe(
+    expect(getState().streams.get(streamId)?.state.status).toBe(
       STREAM_PHASE.COMPLETED,
     );
-    expect(getState().streamStates.get(streamId)?.substate).toBeUndefined();
+    expect(getState().streams.get(streamId)?.state.substate).toBeUndefined();
   });
 
   it('clears round stage from a transport-safe metadata patch', () => {
     const streamId = 'stream-a' as StreamTabId;
     const state = createInitialState();
     registerStream(state, streamId);
-    state.streamStates.set(
-      streamId,
-      createStreamState(AgentCategory.Workflow, {
+    state.streams.get(streamId)!.state = createStreamState(
+      AgentCategory.Workflow,
+      {
         roundStage: { index: 2 },
-      } satisfies Partial<StreamState>),
+      },
     );
     const getState = seedState(state);
 
@@ -279,7 +288,7 @@ describe('stream meta frontend state', () => {
 
     dispatch(streamMetaHandlers, message);
 
-    expect(getState().streamStates.get(streamId)?.roundStage).toBeUndefined();
+    expect(getState().streams.get(streamId)?.state.roundStage).toBeUndefined();
   });
 
   it('merges and clears a phase stage from a transport-safe metadata patch', () => {
@@ -316,14 +325,14 @@ describe('stream meta frontend state', () => {
       streamMetaHandlers,
       patch({ label: 'Reduce', index: 1, total: 3 }),
     );
-    expect(getState().streamStates.get(streamId)?.phaseStage).toEqual({
+    expect(getState().streams.get(streamId)?.state.phaseStage).toEqual({
       label: 'Reduce',
       index: 1,
       total: 3,
     });
 
     dispatch(streamMetaHandlers, patch(null));
-    expect(getState().streamStates.get(streamId)?.phaseStage).toBeUndefined();
+    expect(getState().streams.get(streamId)?.state.phaseStage).toBeUndefined();
   });
 
   it('keeps the phase-stage projection stable across unrelated stream ticks', () => {
@@ -332,11 +341,11 @@ describe('stream meta frontend state', () => {
     const state = createInitialState();
     registerStream(state, streamId);
     registerStream(state, otherId);
-    state.streamStates.set(
-      streamId,
-      createStreamState(AgentCategory.Workflow, {
+    state.streams.get(streamId)!.state = createStreamState(
+      AgentCategory.Workflow,
+      {
         phaseStage: { label: 'Reduce', index: 1, total: 3 },
-      } satisfies Partial<StreamState>),
+      },
     );
     seedState(state);
 
@@ -347,9 +356,9 @@ describe('stream meta frontend state', () => {
       total: 3,
     });
 
-    // An unrelated stream's progress tick rebuilds streamStates, so the
-    // projection recomputes — but its identity must not change, or every
-    // consumer re-renders on a tick that touched no phase.
+    // An unrelated stream's progress tick rebuilds the streamStates$ facet
+    // view, so the projection recomputes — but its identity must not
+    // change, or every consumer re-renders on a tick that touched no phase.
     setStreamStateForId(otherId, (prev) => ({
       ...prev,
       conversationProgress: { toolCallCount: 7 },
@@ -382,12 +391,12 @@ describe('stream meta frontend state', () => {
     const streamId = 'stream-a' as StreamTabId;
     const state = createInitialState();
     registerStream(state, streamId);
-    state.streamStates.set(
-      streamId,
-      createStreamState(AgentCategory.Workflow, {
+    state.streams.get(streamId)!.state = createStreamState(
+      AgentCategory.Workflow,
+      {
         roundStage: { index: 2 },
         phaseStage: { label: 'Reduce', index: 1, total: 3 },
-      } satisfies Partial<StreamState>),
+      },
     );
     const getState = seedState(state);
 
@@ -411,8 +420,8 @@ describe('stream meta frontend state', () => {
 
     dispatch(syncHandlers, message);
 
-    expect(getState().streamStates.get(streamId)?.roundStage).toBeUndefined();
-    expect(getState().streamStates.get(streamId)?.phaseStage).toBeUndefined();
+    expect(getState().streams.get(streamId)?.state.roundStage).toBeUndefined();
+    expect(getState().streams.get(streamId)?.state.phaseStage).toBeUndefined();
   });
 
   it('honors an explicit empty active-stream selection', () => {
@@ -448,6 +457,6 @@ describe('stream meta frontend state', () => {
       parentStreamId: null,
     });
 
-    expect(getState().streamById.get(child)?.parentStreamId).toBeUndefined();
+    expect(getState().streams.get(child)?.info.parentStreamId).toBeUndefined();
   });
 });

--- a/src/test-kernel/progressView/streamInfoUtils.vitest.ts
+++ b/src/test-kernel/progressView/streamInfoUtils.vitest.ts
@@ -42,7 +42,7 @@ describe('buildStreamTabInfo', () => {
     const info = buildStreamTabInfo({
       streamId: 'bash@tool#exec:child-stream',
       metadata: {
-        agentCategory: AgentCategory.ToolUse,
+        resolution: { agentCategory: AgentCategory.ToolUse },
         creationTimestamp: 1,
       },
     });
@@ -56,8 +56,10 @@ describe('buildStreamTabInfo', () => {
     const info = buildStreamTabInfo({
       streamId: 'search@deepseek#exec',
       metadata: {
-        run: { kind: 'agent', agent: 'search', model: '', instruction: '' },
-        agentCategory: AgentCategory.ToolUse,
+        resolution: {
+          run: { kind: 'agent', agent: 'search', model: '', instruction: '' },
+          agentCategory: AgentCategory.ToolUse,
+        },
         isRemote: true,
         creationTimestamp: 1,
       },

--- a/src/test-kernel/tools/externalToolDefs.vitest.ts
+++ b/src/test-kernel/tools/externalToolDefs.vitest.ts
@@ -41,12 +41,12 @@ describe('external tool definitions', () => {
 
     assert.ok(texraCli, 'TeXRA CLI tool definition should exist');
     assert.strictEqual(texraCli.category, 'ai-agents');
-    assert.strictEqual(texraCli.comingSoon, true);
-    assert.strictEqual(texraCli.hideFromCli, true);
+    assert.strictEqual(texraCli.visibility?.comingSoon, true);
+    assert.strictEqual(texraCli.visibility?.hideFromCli, true);
     assert.strictEqual(texraCli.toggleable, undefined);
     assert.deepStrictEqual(texraCli.tools, []);
     assert.ok(
-      texraCli.installGuide?.includes('requires Node.js >=22.9.0'),
+      texraCli.install?.guide?.includes('requires Node.js >=22.9.0'),
       'TeXRA CLI install guide should match the published Node engine range',
     );
   });

--- a/src/test-kernel/traceViewer/replayTrace.vitest.ts
+++ b/src/test-kernel/traceViewer/replayTrace.vitest.ts
@@ -80,7 +80,7 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
 
     replayTrace(trace);
 
-    const replayed = appState.get().streamStates.get(trace.streamId);
+    const replayed = appState.get().streams.get(trace.streamId)?.state;
     expect(replayed).toMatchObject({
       kind: AgentCategory.Workflow,
       files: {},
@@ -113,7 +113,7 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
 
     replayTrace(trace);
 
-    const replayed = appState.get().streamStates.get(trace.streamId);
+    const replayed = appState.get().streams.get(trace.streamId)?.state;
     expect(replayed).toMatchObject({
       kind: AgentCategory.ToolUse,
       todos: [{ content: 'Replay the plan' }],
@@ -161,7 +161,7 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
 
     replayTrace(result.trace);
 
-    const replayed = appState.get().streamStates.get(result.trace.streamId);
+    const replayed = appState.get().streams.get(result.trace.streamId)?.state;
     expect(replayed?.status).toBe('failed');
   });
 
@@ -206,7 +206,7 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
 
     replayTrace(trace);
 
-    const replayed = appState.get().streamStates.get(trace.streamId);
+    const replayed = appState.get().streams.get(trace.streamId)?.state;
     expect(replayed?.status).toBe(STREAM_STATUS.READY);
   });
 
@@ -254,7 +254,7 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
 
     replayTrace(trace);
 
-    const replayed = appState.get().streamStates.get(trace.streamId);
+    const replayed = appState.get().streams.get(trace.streamId)?.state;
     expect(replayed?.status).toBe(STREAM_STATUS.READY);
   });
 
@@ -315,7 +315,7 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
 
     replayTrace(trace);
 
-    const replayed = appState.get().streamStates.get(trace.streamId);
+    const replayed = appState.get().streams.get(trace.streamId)?.state;
     expect(replayed?.status).toBe(STREAM_STATUS.READY);
   });
 
@@ -324,7 +324,7 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
 
     replayTrace(trace);
 
-    const replayed = appState.get().streamStates.get(trace.streamId);
+    const replayed = appState.get().streams.get(trace.streamId)?.state;
     expect(replayed?.status).not.toBe(STREAM_STATUS.READY);
     expect(replayed?.status).toBe('failed');
   });
@@ -334,7 +334,7 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
 
     replayTrace(trace);
 
-    const replayed = appState.get().streamStates.get(trace.streamId);
+    const replayed = appState.get().streams.get(trace.streamId)?.state;
     // STOPPED folds into the canonical COMPLETED phase (the same collapse
     // `streamStatusToLifecycleStatus` performs everywhere else in the app) —
     // the point of this regression is that it must not silently become
@@ -348,7 +348,7 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
 
     replayTrace(trace);
 
-    const replayed = appState.get().streamStates.get(trace.streamId);
+    const replayed = appState.get().streams.get(trace.streamId)?.state;
     expect(replayed?.status).toBe(STREAM_STATUS.READY);
   });
 });

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -96,33 +96,42 @@ export interface ExternalToolDef {
   readonly name: string;
   readonly category: ToolCategory;
   readonly description: string;
-  readonly installGuide?: string;
-  readonly installUrl?: string;
-  /** VS Code extension ID — when present, the dashboard offers a direct "Install" button. */
-  readonly installExtensionId?: string;
-  /** Shell command the dashboard can run in an integrated terminal to install the tool. */
-  readonly installCommand?: string;
-  /** Shell command the dashboard can run to sign the user in (e.g. `codex login`). */
-  readonly authCommand?: string;
+  /** Install-time metadata: how the dashboard offers to get the dependency installed. */
+  readonly install?: {
+    readonly guide?: string;
+    readonly url?: string;
+    /** VS Code extension ID — when present, the dashboard offers a direct "Install" button. */
+    readonly extensionId?: string;
+    /** Shell command the dashboard can run in an integrated terminal to install the tool. */
+    readonly command?: string;
+    /**
+     * VS Code command ID invoked by the "fix this" action button in the
+     * "tools were excluded" notification. Overrides the default Tools tab
+     * link — use this when real setup lives elsewhere (e.g. Git tab for a
+     * GitHub token). The label for that button is `actionLabel`.
+     */
+    readonly actionCommand?: string;
+    readonly actionLabel?: string;
+  };
+  /** Auth-time metadata: how the dashboard offers to sign the user in. */
+  readonly auth?: {
+    /** Shell command the dashboard can run to sign the user in (e.g. `codex login`). */
+    readonly command?: string;
+    /** Short auth/billing note shown as a badge (e.g. "Uses ChatGPT subscription"). */
+    readonly note?: string;
+  };
   readonly configNotes?: string;
-  /** When true, the tool is checked for availability but not shown in the Tools tab dashboard. */
-  readonly hideFromDashboard?: boolean;
-  /** When true, the tool is shown in app dashboards but hidden from CLI tools surfaces. */
-  readonly hideFromCli?: boolean;
-  /** Short auth/billing note shown as a badge (e.g. "Uses ChatGPT subscription"). */
-  readonly authNote?: string;
+  /** Dashboard/CLI visibility flags — independent of availability. */
+  readonly visibility?: {
+    /** When true, the tool is checked for availability but not shown in the Tools tab dashboard. */
+    readonly hideFromDashboard?: boolean;
+    /** When true, the tool is shown in app dashboards but hidden from CLI tools surfaces. */
+    readonly hideFromCli?: boolean;
+    /** When true, detect setup but show the integration as not yet enabled. */
+    readonly comingSoon?: boolean;
+  };
   /** When true, the dashboard shows an enable/disable toggle for this tool group. */
   readonly toggleable?: boolean;
-  /** When true, detect setup but show the integration as not yet enabled. */
-  readonly comingSoon?: boolean;
-  /**
-   * VS Code command ID invoked by the "fix this" action button in the
-   * "tools were excluded" notification. Overrides the default Tools tab
-   * link — use this when real setup lives elsewhere (e.g. Git tab for a
-   * GitHub token). The label for that button is `installActionLabel`.
-   */
-  readonly installActionCommand?: string;
-  readonly installActionLabel?: string;
 }
 
 // ============================================================
@@ -308,15 +317,17 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     category: 'latex',
     description:
       'Count words, headers, figures, and other elements in LaTeX documents.',
-    installGuide:
-      'TeXcount is a Perl script for counting words in LaTeX files.\n\n' +
-      'Installation:\n' +
-      '  Mac:     brew install texcount\n' +
-      '  Ubuntu:  sudo apt-get install texlive-extra-utils\n' +
-      '  Windows: Install via MiKTeX or TeX Live package manager',
-    installUrl: 'https://app.uio.no/ifi/texcount/',
+    install: {
+      guide:
+        'TeXcount is a Perl script for counting words in LaTeX files.\n\n' +
+        'Installation:\n' +
+        '  Mac:     brew install texcount\n' +
+        '  Ubuntu:  sudo apt-get install texlive-extra-utils\n' +
+        '  Windows: Install via MiKTeX or TeX Live package manager',
+      url: 'https://app.uio.no/ifi/texcount/',
+    },
     configNotes: 'Part of most TeX Live distributions.',
-    hideFromDashboard: true, // Shown in LaTeX settings tab instead
+    visibility: { hideFromDashboard: true }, // Shown in LaTeX settings tab instead
     check: () => checkToolInstalled('texcount', false),
   },
   {
@@ -326,16 +337,18 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     category: 'computation',
     description:
       'Execute Wolfram Language code for symbolic math, computation, and data analysis.',
-    installGuide:
-      'Requires the "wolframscript" command-line tool.\n\n' +
-      'Install the free Wolfram Engine:\n' +
-      '  Mac:     brew install --cask wolfram-engine\n' +
-      '  Ubuntu:  Download from wolfram.com/engine\n' +
-      '  Windows: Download from wolfram.com/engine\n\n' +
-      'Note: A Mathematica installation alone is not enough — you\n' +
-      'need WolframScript on your PATH. The Wolfram Engine includes\n' +
-      'it automatically. Free licenses are available for development use.',
-    installUrl: 'https://www.wolfram.com/engine/',
+    install: {
+      guide:
+        'Requires the "wolframscript" command-line tool.\n\n' +
+        'Install the free Wolfram Engine:\n' +
+        '  Mac:     brew install --cask wolfram-engine\n' +
+        '  Ubuntu:  Download from wolfram.com/engine\n' +
+        '  Windows: Download from wolfram.com/engine\n\n' +
+        'Note: A Mathematica installation alone is not enough — you\n' +
+        'need WolframScript on your PATH. The Wolfram Engine includes\n' +
+        'it automatically. Free licenses are available for development use.',
+      url: 'https://www.wolfram.com/engine/',
+    },
     configNotes: 'Requires the free Wolfram Engine (provides wolframscript).',
     check: () => checkToolInstalled('wolframscript', false),
   },
@@ -351,17 +364,19 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     category: 'ai-agents',
     description:
       'Search, add items to, and export citations from your Zotero library. Requires Better BibTeX plugin.',
-    installGuide:
-      'Requires Zotero with the Better BibTeX plugin installed.\n\n' +
-      'Setup:\n' +
-      '  1. Install Zotero (zotero.org)\n' +
-      '  2. Install Better BibTeX plugin:\n' +
-      '     - Download from retorque.re/zotero-better-bibtex\n' +
-      '     - In Zotero: Tools > Add-ons > Install from File\n' +
-      '  3. Keep Zotero running while using TeXRA\n\n' +
-      'Better BibTeX exposes a JSON-RPC API on localhost:23119\n' +
-      'that TeXRA uses to communicate with your library.',
-    installUrl: 'https://retorque.re/zotero-better-bibtex/installation/',
+    install: {
+      guide:
+        'Requires Zotero with the Better BibTeX plugin installed.\n\n' +
+        'Setup:\n' +
+        '  1. Install Zotero (zotero.org)\n' +
+        '  2. Install Better BibTeX plugin:\n' +
+        '     - Download from retorque.re/zotero-better-bibtex\n' +
+        '     - In Zotero: Tools > Add-ons > Install from File\n' +
+        '  3. Keep Zotero running while using TeXRA\n\n' +
+        'Better BibTeX exposes a JSON-RPC API on localhost:23119\n' +
+        'that TeXRA uses to communicate with your library.',
+      url: 'https://retorque.re/zotero-better-bibtex/installation/',
+    },
     configNotes:
       'Zotero must be running with Better BibTeX installed. Port configurable via texra.bib.zoteroPort.',
     toggleable: true,
@@ -392,25 +407,26 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     category: 'lean',
     description:
       'Interact with Lean 4 projects: check diagnostics, inspect terms, search Loogle, and manage files. Active language servers (one per project root) are listed below.',
-    installGuide:
-      'TeXRA can drive Lean 4 in two ways:\n\n' +
-      '  • VS Code build — uses the "lean4" extension\n' +
-      '    (leanprover.lean4) and its running language server.\n' +
-      '  • CLI / desktop build — spawns `lake env lean --server`\n' +
-      '    directly, one process per Lake project root. Requires\n' +
-      '    `lake` (from elan/Lean) on PATH; install via\n' +
-      '    https://leanprover-community.github.io/install/.\n\n' +
-      'Setup (VS Code):\n' +
-      '  1. Install the "lean4" extension from VS Code Marketplace\n' +
-      '  2. Open a Lean 4 project (with lakefile.lean or lakefile.toml)\n' +
-      '  3. The extension will auto-install elan and Lean toolchain\n\n' +
-      'Setup (CLI / desktop):\n' +
-      '  1. Install elan: `curl https://elan.lean-lang.org/elan-init.sh -sSf | sh`\n' +
-      '  2. Make sure `lake` is on PATH in a fresh shell\n' +
-      '  3. Open a folder containing a lakefile.lean / lakefile.toml',
-    installUrl:
-      'https://marketplace.visualstudio.com/items?itemName=leanprover.lean4',
-    installExtensionId: LEAN4_EXTENSION_ID,
+    install: {
+      guide:
+        'TeXRA can drive Lean 4 in two ways:\n\n' +
+        '  • VS Code build — uses the "lean4" extension\n' +
+        '    (leanprover.lean4) and its running language server.\n' +
+        '  • CLI / desktop build — spawns `lake env lean --server`\n' +
+        '    directly, one process per Lake project root. Requires\n' +
+        '    `lake` (from elan/Lean) on PATH; install via\n' +
+        '    https://leanprover-community.github.io/install/.\n\n' +
+        'Setup (VS Code):\n' +
+        '  1. Install the "lean4" extension from VS Code Marketplace\n' +
+        '  2. Open a Lean 4 project (with lakefile.lean or lakefile.toml)\n' +
+        '  3. The extension will auto-install elan and Lean toolchain\n\n' +
+        'Setup (CLI / desktop):\n' +
+        '  1. Install elan: `curl https://elan.lean-lang.org/elan-init.sh -sSf | sh`\n' +
+        '  2. Make sure `lake` is on PATH in a fresh shell\n' +
+        '  3. Open a folder containing a lakefile.lean / lakefile.toml',
+      url: 'https://marketplace.visualstudio.com/items?itemName=leanprover.lean4',
+      extensionId: LEAN4_EXTENSION_ID,
+    },
     configNotes:
       'VS Code build: requires the leanprover.lean4 extension. ' +
       'CLI / desktop builds: requires `lake` on PATH; each Lake project root gets its own language server, surfaced below.',
@@ -475,18 +491,20 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     category: 'ai-agents',
     description:
       'Poll GitHub for pull request, issue, and repository activity. Path mirrors GitHub URL shape: "owner/repo" for coarse repo-wide events, "owner/repo/pulls/N" for per-PR comments/reviews/CI, "owner/repo/issues/N" for issue comments and lifecycle.',
-    installGuide:
-      'Requires a git-tracked workspace and a GitHub personal access token:\n\n' +
-      '  1. Open the folder as a git repo (or `git init` + set a github.com remote).\n' +
-      '  2. In VS Code, TeXRA settings → Git tab can open the token page with the right scopes pre-filled.\n' +
-      '  3. Scopes: "repo" for private repositories, "public_repo" for public only.\n' +
-      '  4. Store the token in host secret storage, or export GITHUB_TOKEN/GH_TOKEN for CLI and automation.',
-    installUrl: 'https://github.com/settings/tokens',
+    install: {
+      guide:
+        'Requires a git-tracked workspace and a GitHub personal access token:\n\n' +
+        '  1. Open the folder as a git repo (or `git init` + set a github.com remote).\n' +
+        '  2. In VS Code, TeXRA settings → Git tab can open the token page with the right scopes pre-filled.\n' +
+        '  3. Scopes: "repo" for private repositories, "public_repo" for public only.\n' +
+        '  4. Store the token in host secret storage, or export GITHUB_TOKEN/GH_TOKEN for CLI and automation.',
+      url: 'https://github.com/settings/tokens',
+      actionCommand: 'texra.showGitSettings',
+      actionLabel: 'Open Git settings',
+    },
     configNotes: `Token stored in host secret storage or read from GITHUB_TOKEN/GH_TOKEN. In VS Code, the Git tab manages the stored token. Requires a git repository in the workspace. Polls every ${PR_POLL_INTERVAL_MS / 1000}s; cap: ${MAX_CONCURRENT_PR_SUBSCRIPTIONS} concurrent PRs and 3 concurrent repos. Bot-authored events are dropped end-to-end by policy.`,
-    authNote: 'Uses personal access token',
+    auth: { note: 'Uses personal access token' },
     toggleable: true,
-    installActionCommand: 'texra.showGitSettings',
-    installActionLabel: 'Open Git settings',
     ...prerequisitesChecks({
       probe: getGitHubPRPrerequisites,
       resolve: resolveGitHubPRPrerequisites,
@@ -521,12 +539,12 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'Tap your premium chat subscriptions — ChatGPT Pro, Claude Opus, Gemini Deep Think, Grok, and similar — without an API key. The agent drafts a question, you paste the answer back, and the run continues. Useful for the deep-reasoning tiers that aren’t available through the API.',
     configNotes:
       'No local install required. Uses your own external chat subscription through a human-in-the-loop copy/paste flow.',
-    authNote: 'Uses your premium chat subscription',
+    auth: { note: 'Uses your premium chat subscription' },
     toggleable: true,
     // VS Code / desktop only — the async paste-the-answer-back flow depends on
     // the long-lived progress-view panel. CLI runs hide the `inquiry` tool
     // (see CLI_UNAVAILABLE_TOOLS), so it must not appear on CLI tools surfaces.
-    hideFromCli: true,
+    visibility: { hideFromCli: true },
     check: async () => true,
   },
 
@@ -537,19 +555,20 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     category: 'ai-agents',
     description:
       'Local TeXRA command-line app integration. Detection is shown now; activation is coming soon.',
-    installGuide:
-      'Run the same agents on your .tex projects without an editor — ideal for scripts, CI, and remote machines.\n\n' +
-      `Install globally from npm (requires Node.js ${TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY}):\n` +
-      '  npm install -g @texra-ai/cli\n\n' +
-      'The CLI also ships with the TeXRA package — make sure the `texra` command is on the PATH visible to VS Code or the desktop app.\n\n' +
-      'Check from a terminal:\n' +
-      '  texra --version',
-    installUrl: 'https://www.npmjs.com/package/@texra-ai/cli',
-    installCommand: 'npm install -g @texra-ai/cli',
+    install: {
+      guide:
+        'Run the same agents on your .tex projects without an editor — ideal for scripts, CI, and remote machines.\n\n' +
+        `Install globally from npm (requires Node.js ${TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY}):\n` +
+        '  npm install -g @texra-ai/cli\n\n' +
+        'The CLI also ships with the TeXRA package — make sure the `texra` command is on the PATH visible to VS Code or the desktop app.\n\n' +
+        'Check from a terminal:\n' +
+        '  texra --version',
+      url: 'https://www.npmjs.com/package/@texra-ai/cli',
+      command: 'npm install -g @texra-ai/cli',
+    },
     configNotes:
       'Coming soon. This entry only checks whether the local CLI is visible.',
-    comingSoon: true,
-    hideFromCli: true,
+    visibility: { comingSoon: true, hideFromCli: true },
     ...prerequisitesChecks<boolean | undefined>({
       probe: probeTexraCli,
       resolve: resolveBooleanProbe,
@@ -570,28 +589,32 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     category: 'ai-agents',
     description:
       'OpenAI Codex agent runtime. Required by the Codex SDK for local code generation and analysis.',
-    installGuide:
-      'Install the Codex CLI (choose one):\n\n' +
-      '  npm install -g @openai/codex\n' +
-      '  brew install codex          (macOS)\n\n' +
-      'On Windows, use WSL or the Codex app.\n' +
-      'In WSL, install inside the WSL environment (not on the Windows side).\n' +
-      'See: https://developers.openai.com/codex/cli\n\n' +
-      'Authentication (choose one):\n' +
-      '  • codex login        — sign in with ChatGPT account (recommended)\n' +
-      '  • OPENAI_API_KEY     — environment variable with API key',
-    installUrl: 'https://github.com/openai/codex',
-    get installCommand() {
-      return preferredInstallCommand({
-        brew: 'brew install codex',
-        default: 'npm install -g @openai/codex',
-      });
+    install: {
+      guide:
+        'Install the Codex CLI (choose one):\n\n' +
+        '  npm install -g @openai/codex\n' +
+        '  brew install codex          (macOS)\n\n' +
+        'On Windows, use WSL or the Codex app.\n' +
+        'In WSL, install inside the WSL environment (not on the Windows side).\n' +
+        'See: https://developers.openai.com/codex/cli\n\n' +
+        'Authentication (choose one):\n' +
+        '  • codex login        — sign in with ChatGPT account (recommended)\n' +
+        '  • OPENAI_API_KEY     — environment variable with API key',
+      url: 'https://github.com/openai/codex',
+      get command() {
+        return preferredInstallCommand({
+          brew: 'brew install codex',
+          default: 'npm install -g @openai/codex',
+        });
+      },
     },
-    authCommand: 'codex login',
+    auth: {
+      command: 'codex login',
+      note: 'Uses ChatGPT subscription (free with Plus/Pro)',
+    },
     configNotes:
       'Requires @openai/codex npm package with platform binaries. Used by @openai/codex-sdk. ' +
       'Supports OAuth via `codex login` or OPENAI_API_KEY env var.',
-    authNote: 'Uses ChatGPT subscription (free with Plus/Pro)',
     toggleable: true,
     check: () => probeSdkBinaryAvailable(importCodexClass, findCodexBinaryPath),
     detailCheck: async () => {
@@ -634,30 +657,34 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     category: 'ai-agents',
     description:
       'Spin off a Claude Code CLI agent that works in your workspace. It can read files, run commands, edit code, and search the web on your behalf — great for delegating focused exploration or implementation while another agent stays in charge.',
-    installGuide:
-      'Install the Claude Code CLI (choose one):\n\n' +
-      '  npm install -g @anthropic-ai/claude-code\n' +
-      '  brew install --cask claude-code     (macOS)\n' +
-      '  winget install Anthropic.ClaudeCode (Windows)\n\n' +
-      'Or use the native installer from https://claude.com/code (recommended).\n' +
-      'See: https://code.claude.com/docs/en/setup\n\n' +
-      'Authentication (choose one):\n' +
-      '  • Set ANTHROPIC_API_KEY in TeXRA Settings → API Keys → Anthropic\n' +
-      '  • claude login          — OAuth sign-in (Pro/Max subscription, recommended)\n' +
-      '  • claude setup-token    — long-lived OAuth token (CLAUDE_CODE_OAUTH_TOKEN)\n' +
-      '  • ANTHROPIC_API_KEY     — environment variable with Console API key',
-    installUrl: 'https://code.claude.com/docs/en/setup',
-    get installCommand() {
-      return preferredInstallCommand({
-        brew: 'brew install --cask claude-code',
-        win32: 'winget install Anthropic.ClaudeCode',
-        default: 'npm install -g @anthropic-ai/claude-code',
-      });
+    install: {
+      guide:
+        'Install the Claude Code CLI (choose one):\n\n' +
+        '  npm install -g @anthropic-ai/claude-code\n' +
+        '  brew install --cask claude-code     (macOS)\n' +
+        '  winget install Anthropic.ClaudeCode (Windows)\n\n' +
+        'Or use the native installer from https://claude.com/code (recommended).\n' +
+        'See: https://code.claude.com/docs/en/setup\n\n' +
+        'Authentication (choose one):\n' +
+        '  • Set ANTHROPIC_API_KEY in TeXRA Settings → API Keys → Anthropic\n' +
+        '  • claude login          — OAuth sign-in (Pro/Max subscription, recommended)\n' +
+        '  • claude setup-token    — long-lived OAuth token (CLAUDE_CODE_OAUTH_TOKEN)\n' +
+        '  • ANTHROPIC_API_KEY     — environment variable with Console API key',
+      url: 'https://code.claude.com/docs/en/setup',
+      get command() {
+        return preferredInstallCommand({
+          brew: 'brew install --cask claude-code',
+          win32: 'winget install Anthropic.ClaudeCode',
+          default: 'npm install -g @anthropic-ai/claude-code',
+        });
+      },
     },
-    authCommand: 'claude login',
+    auth: {
+      command: 'claude login',
+      note: 'OAuth, OAuth token, or API key',
+    },
     configNotes:
       'Requires the native `claude` binary. Supports OAuth (`claude login`), long-lived tokens (`claude setup-token` → CLAUDE_CODE_OAUTH_TOKEN), or ANTHROPIC_API_KEY (resolved from TeXRA Settings → API Keys or the environment).',
-    authNote: 'OAuth, OAuth token, or API key',
     toggleable: true,
     check: () =>
       probeSdkBinaryAvailable(importClaudeAgentSdk, findClaudeBinaryPath),

--- a/src/tools/github/IssuePollingSource.ts
+++ b/src/tools/github/IssuePollingSource.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_POLLING_BACKOFF_CONFIG,
   PollingSourceBase,
   type BasePollSubscriptionState,
+  type EtagCache,
 } from './PollingSourceBase';
 import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
 import {
@@ -57,7 +58,7 @@ interface SubscriptionState extends BasePollSubscriptionState {
   initialized: boolean;
   state: 'open' | 'closed' | undefined;
   comments: DedupedResource<GhIssueComment>;
-  etags: { issue?: string; comments?: string };
+  etags: EtagCache<'issue' | 'comments'>;
 }
 
 function createInitialState(issue: IssueKey): SubscriptionState {

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -61,6 +61,7 @@ import {
   DEFAULT_POLLING_BACKOFF_CONFIG,
   PollingSourceBase,
   type BasePollSubscriptionState,
+  type EtagCache,
 } from './PollingSourceBase';
 import {
   MAX_CONCURRENT_PR_SUBSCRIPTIONS,
@@ -172,12 +173,7 @@ export interface PRSubscriptionState extends BasePollSubscriptionState {
   merged: boolean;
   /** Last *definite* `mergeable_state`; see `isDefiniteMergeableState`. */
   mergeableState: string | undefined;
-  etags: {
-    pr?: string;
-    issueComments?: string;
-    reviewComments?: string;
-    reviews?: string;
-  };
+  etags: EtagCache<'pr' | 'issueComments' | 'reviewComments' | 'reviews'>;
 }
 
 /** Per-head-SHA state; reset wholesale whenever the head SHA changes. */

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -40,6 +40,15 @@ export interface BasePollSubscriptionState {
   skipPollUntilMs: number;
 }
 
+/**
+ * Per-endpoint ETag cache: one optional ETag per conditional-GET endpoint a
+ * poller hits, keyed by a poller-supplied literal-string union (e.g.
+ * `'pr' | 'issueComments' | 'reviewComments' | 'reviews'`). A key is absent
+ * until that endpoint's first 200 response. Only the shape is shared — each
+ * source owns its own key set and when its keys are set or cleared.
+ */
+export type EtagCache<K extends string> = Partial<Record<K, string>>;
+
 export interface PollingSourceConfig {
   /** Display name used in the logger and exception messages. */
   name: string;

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -144,7 +144,7 @@ async function runProbes(): Promise<ExternalToolCheckResult[]> {
         check,
         statusLabel: getStatusLabel,
         detailCheck,
-        comingSoon,
+        visibility,
       }): Promise<ExternalToolCheckResult> => {
         // Run check/status/detail from one shared probe result. Some groups
         // (Codex, Zotero, GitHub PR) touch async local state, so running the
@@ -169,7 +169,7 @@ async function runProbes(): Promise<ExternalToolCheckResult[]> {
           id,
           tools,
           name,
-          status: comingSoon ? 'coming-soon' : probedStatus,
+          status: visibility?.comingSoon ? 'coming-soon' : probedStatus,
           detected:
             probedStatus === 'unknown' ? null : probedStatus === 'available',
           statusLabel,

--- a/src/tools/toolUnavailableNotification.ts
+++ b/src/tools/toolUnavailableNotification.ts
@@ -49,9 +49,9 @@ function mapToolNamesToGroups(
       seen.add(def.id);
       groups.push({
         name: def.name,
-        hideFromDashboard: def.hideFromDashboard ?? false,
-        installActionCommand: def.installActionCommand,
-        installActionLabel: def.installActionLabel,
+        hideFromDashboard: def.visibility?.hideFromDashboard ?? false,
+        installActionCommand: def.install?.actionCommand,
+        installActionLabel: def.install?.actionLabel,
       });
     }
   }


### PR DESCRIPTION
## Summary

Follows up on a scheduled data-structure-design audit that flagged unnecessarily complex patterns across the codebase (duplicated parsing logic, `Record<string, unknown>` bags with hand-maintained parallel key lists, flat option types with 10+ independently-optional fields, and parallel maps keyed by the same ID). This PR fixes the 8 highest-value findings, all High/Medium severity plus two Low-severity cleanups:

1. **`src/agent/storage/conversationFormat.ts` / `src/agent/export/normalizeConversation.ts`** (High) — two independently-maintained switch statements hand-parsed the same 5 provider content-block vocabularies. Extracted a shared `ContentBlockSchema` discriminated union (`src/agent/types/ContentBlockSchema.ts`) both formatters now consume, so a new provider block type only needs to be added once.
2. **`src/agent/utils/userVars.ts`** (High) — `UserVars` was `Record<string, unknown>` with ~43 known prompt-var keys hand-enumerated separately in `USER_VAR_RUNTIME_TOKENS`, with no structural link to what the builders actually produce. Modeled the known keys as a Zod schema; both the type and the runtime-token list are now derived from it, and each builder returns a precisely-typed `Pick<...>` slice. `getCategoryFiles` no longer needs `as string[]`/`as string | null` casts.
3. **`src/tools/externalToolDefs.ts`** (Medium) — `ExternalToolDef` had 16 fields, 13 independently optional, mixing install/auth/dashboard-visibility concerns. Regrouped into `install`/`auth`/`visibility` sub-objects; updated all consumers (dashboard, CLI, desktop IPC).
4. **`src/controllers/progressView/backend/ProgressViewState.ts`** (Medium) — `agentCategory` and `run` were two independently-optional fields, but `run` is only ever assembled together with `agentCategory`, atomically, from one `RunConfig`. Replaced both with a `resolution: ProgressStreamRunResolution` discriminated union that encodes the real (one-directional) invariant.
5. **`packages/cli/src/runtime/cliConfig.ts`** (Medium) — config parsing was hand-rolled against `Record<string, unknown>` with parallel `[string, ZodType]` tuple arrays kept in sync by hand. Replaced with a declarative `z.strictObject` schema; `CliConfigValues` is now derived via `z.infer`.
6. **`packages/extension/src/progressView/frontend/store.ts`** (Medium) — one logical "stream" entity was split across four parallel maps (`streamById`, `streamStates`, `streamLogs`, `followupOptionsByStream`) all keyed by the same ID, requiring dedicated sync helpers. Consolidated into one `Map<StreamTabId, StreamEntry>`; preserved the render-skip behavior (log-only ticks don't invalidate unrelated facets) via memoized facet-view selectors.
7. **`src/tools/github/PRPollingSource.ts` / `IssuePollingSource.ts`** (Low) — duplicated inline etag-cache object shapes. Extracted a shared `EtagCache<K>` generic type.
8. **`packages/extension/src/commands/agent/executeCommand.ts`** (Low) — fresh-vs-resume execution was one flat, all-optional input bag validated by a loose `'config' in input` duck-check + cast. Modeled as a Zod discriminated union on a `mode` tag.

**Not included:** the audit's `executeAgent.ts` option-bag finding (13–16 independently-optional fields across `SubagentRunOptions`/`ExecuteAgentOptions`/`ResumeToolUseFromResumeDataOptions`) was deliberately left out — it's used by many call sites and a real fix needs case-by-case judgment about which combinations are meaningful together, which is riskier to get right without deeper investigation than the fixes above.

## Issue acceptance gates

No tracked issue; this PR directly implements the findings from a scheduled data-structure audit (see PR description above for the itemized list and severities).

## Single source of truth

- Content-block vocabulary: `ContentBlockSchema` (`src/agent/types/ContentBlockSchema.ts`)
- Prompt-var keys: `UserVarsSchema` (`src/agent/utils/userVars.ts`)
- CLI config shape: `CliConfigSchema` (`packages/cli/src/runtime/cliConfig.ts`)
- Per-stream progress-view state: `StreamEntry` in the `streams` map (`packages/extension/src/progressView/frontend/store.ts`)
- Run-resolution atomicity: `ProgressStreamRunResolution` (`src/controllers/progressView/backend/ProgressViewState.ts`)

## Duplication and abstraction budget

Removed: the duplicated content-block tag-detection switch, the duplicated etag-cache shape, the four-parallel-map sync helpers (`ensureStreamState`/`deleteStreamState`), and the hand-maintained `USER_VAR_RUNTIME_TOKENS`/CLI config field-tuple lists that had to be kept in sync with their respective types by hand. No new pass-through abstractions were added — each new type (`ContentBlockSchema`, `EtagCache<K>`, `ProgressStreamRunResolution`, `StreamEntry`) owns a real invariant or a previously-duplicated shape.

## Net elements (R6)

- Diffstat: 38 files changed, +1253/-791 (`git diff --stat 434b89d..HEAD`)
- Exported symbols: 12 added, 7 removed (`git diff | grep -c '^[+-]export '`) — net +5, mostly Zod schemas/types replacing what were previously implicit `Record<string, unknown>` shapes
- No new classes; one new discriminated-union type per fix area as listed above

## Consumer counts (R8)

No emit paths or event keys were deleted or re-routed. Field renames (`agentCategory`/`run` → `resolution.*`, `ExternalToolDef`'s flat fields → nested `install`/`auth`/`visibility`) had every consumer updated in the same commit (grepped and verified via typecheck — see Validation).

## Host impact

Extension: `executeCommand.ts` (item 8), `progressView/frontend/store.ts` (item 6), `ExternalToolDef` consumers in `settingsView/`.

Desktop: `desktopSettingsIpcHelpers.ts` and `desktopToolingSettingsController.ts` consumers of `ExternalToolDef`; one `progressView` store read site in `renderer/main.ts`.

CLI: `cliConfig.ts` (item 5); `ExternalToolDef` consumers in `runtime/tools.ts`.

## Scheduled refactoring

None — the one deliberately-deferred finding (`executeAgent.ts` option bag) is noted above as a follow-up candidate, not scheduled.

## Validation

- `npx tsc --noEmit` at the root, `-p tsconfig.test-kernel.json`, and individually for `packages/{extension,desktop,cli,agent,trace-viewer}` — all clean.
- `npx vitest run` (full repo): 8443 passed, 10 skipped, 2 failed — both failures (`ExtensionTexraConfig.vitest.ts`) reproduce identically on the pre-change base commit (confirmed via `git stash`/checkout), unrelated to this PR.
- `npm run lint` (full repo eslint): clean.
- `npm run check:dead-code-ratchet`: 18 findings, matches baseline — no new dead exports.
- `npm run format -- --check` / `prettier --check`: clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01EN1K2Mq8iGNV22UHpzEvNk

---
_Generated by [Claude Code](https://claude.ai/code/session_01EN1K2Mq8iGNV22UHpzEvNk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core progress-view state, stream metadata, and many `ExternalToolDef` consumers across extension, desktop, and CLI; behavior is intended to be equivalent but regressions in render-skip or metadata merging are the main risk areas.
> 
> **Overview**
> Implements the scheduled data-structure audit: **one schema or consolidated map per area** instead of duplicated switches, parallel keyed maps, and loose `Record<string, unknown>` bags.
> 
> **Shared agent types:** New `ContentBlockSchema` (plus VS Code LM normalization) is the single vocabulary for conversation export and storage formatting; `userVars` gains a Zod-derived `UserVars` shape and typed builder slices.
> 
> **CLI & tools:** `.texra/config.json` is driven by `CliConfigSchema` (`CliConfigValues` from `z.infer`); `ExternalToolDef` install/auth/visibility fields move under nested objects (dashboard, CLI, desktop updated).
> 
> **Progress view:** Per-stream tab info, state, logs, and follow-up options live in one `streams: Map<StreamTabId, StreamEntry>` with memoized facet selectors so log-only updates do not re-render state-only UI. Backend stream metadata pairs category and run details under `resolution: ProgressStreamRunResolution`.
> 
> **Smaller fixes:** GitHub pollers share `EtagCache<K>`; `executeCommand` validates fresh vs resume via a Zod discriminated union on `mode`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 909339de0b76cd0240cf54204f9c710a551fae6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->