### PR TITLE
refactor: retire legacy flow checkpoints

### DIFF
--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -21,7 +21,6 @@ import {
   PersistedFlowStateError,
   flowKey,
   readPersistedFlowRecord,
-  stampFlowRecordSchemaVersion,
 } from '@agent/node/persistedFlow';
 import {
   AgentCategory,
@@ -479,10 +478,7 @@ export async function runToolUseFlow<C = unknown>(
       };
       if (!isDeepStrictEqual(flowRecord.shared, resumedShared)) {
         flowRecord.shared = resumedShared;
-        await kv.write(
-          flowKey(executionId),
-          stampFlowRecordSchemaVersion(flowRecord),
-        );
+        await kv.write(flowKey(executionId), flowRecord);
       }
     } else if (flowRecord) {
       const migrationResult = migrateSharedState(flowRecord.shared);
@@ -525,10 +521,7 @@ export async function runToolUseFlow<C = unknown>(
           logger.debug('Normalized persisted tool-use shared state');
         }
         flowRecord.shared = migratedData;
-        await kv.write(
-          flowKey(executionId),
-          stampFlowRecordSchemaVersion(flowRecord),
-        );
+        await kv.write(flowKey(executionId), flowRecord);
       }
     }
     // Cleanup may delete a terminal flow record only after absence was

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -30,53 +30,45 @@ const START_NODE_ID = 'start';
 
 interface NodeRecord {
   action?: string;
-  nodeId?: string;
+  nodeId: string;
 }
 
 interface FlowCursor {
   /** The next graph-local node path, or null when the flow has reached a terminal edge. */
   nextNodeId: string | null;
-  /** Last action emitted by the previous node, for diagnostics and legacy parity. */
+  /** Last action emitted by the previous node, for diagnostics. */
   lastAction?: string;
 }
 
 export interface FlowRecord {
-  schemaVersion?: number;
-  flowName: string;
-  /**
-   * Legacy per-execution params, always `{}` in practice — the params
-   * channel was removed from the node/flow engine. Kept optional so a
-   * tolerant reader still accepts records written before the removal;
-   * new records omit it entirely.
-   */
-  params?: Record<string, unknown>;
+  schemaVersion: typeof FLOW_RECORD_SCHEMA_VERSION;
+  flowName: 'texra';
   shared: unknown;
   createdAt: string;
   /**
    * Authoritative replay cursor. `nodes[]` is now only an audit log: it can be
    * capped or moved later without changing resume semantics.
    */
-  cursor?: FlowCursor;
+  cursor: FlowCursor;
   nodes: NodeRecord[];
 }
 
-const PersistedFlowNodeRecordSchema = z.looseObject({
+const PersistedFlowNodeRecordSchema = z.strictObject({
   action: z.string().optional(),
-  nodeId: z.string().optional(),
+  nodeId: z.string(),
 });
 
-const PersistedFlowCursorSchema = z.looseObject({
+const PersistedFlowCursorSchema = z.strictObject({
   nextNodeId: z.string().nullable(),
   lastAction: z.string().optional(),
 });
 
-const PersistedFlowRecordObjectSchema = z.looseObject({
-  schemaVersion: z.int().min(1).max(FLOW_RECORD_SCHEMA_VERSION).optional(),
-  flowName: z.string(),
-  params: z.record(z.string(), z.unknown()).optional(),
+const PersistedFlowRecordObjectSchema = z.strictObject({
+  schemaVersion: z.literal(FLOW_RECORD_SCHEMA_VERSION),
+  flowName: z.literal('texra'),
   shared: z.unknown(),
   createdAt: z.string(),
-  cursor: PersistedFlowCursorSchema.optional(),
+  cursor: PersistedFlowCursorSchema,
   nodes: z.array(PersistedFlowNodeRecordSchema),
 });
 
@@ -156,11 +148,6 @@ export async function readPersistedFlowRecord(
   }
 
   return parsed.data;
-}
-
-export function stampFlowRecordSchemaVersion<T extends FlowRecord>(flow: T): T {
-  flow.schemaVersion = FLOW_RECORD_SCHEMA_VERSION;
-  return flow;
 }
 
 /**
@@ -323,7 +310,7 @@ export class PersistedFlow<
       this.cachedRecord = flow;
       return {
         hasMore: false,
-        action: flow.cursor?.lastAction ?? flow.nodes.at(-1)?.action,
+        action: flow.cursor.lastAction ?? flow.nodes.at(-1)?.action,
         shared: this.readShared(flow.shared),
       };
     }
@@ -350,7 +337,7 @@ export class PersistedFlow<
       ...(action !== undefined ? { lastAction: action } : {}),
     };
     flow.shared = this.serializeShared(shared);
-    await this.kv.write(key, stampFlowRecordSchemaVersion(flow));
+    await this.kv.write(key, flow);
     this.cachedRecord = flow;
     await this.fireProjection(shared);
 
@@ -388,27 +375,13 @@ export class PersistedFlow<
   }
 
   private resolveCursor(flow: FlowRecord): BaseNode | undefined {
-    if (flow.cursor) {
-      if (flow.cursor.nextNodeId === null) return undefined;
-      const byId = this.nodeIndex().byId;
-      const cursor = byId.get(flow.cursor.nextNodeId);
-      if (!cursor) {
-        throw new Error(
-          `Invalid persisted flow cursor: ${flow.cursor.nextNodeId}`,
-        );
-      }
-      return cursor;
-    }
-
-    return this.replayLegacyNodePath(flow.nodes);
-  }
-
-  private replayLegacyNodePath(
-    nodes: readonly NodeRecord[],
-  ): BaseNode | undefined {
-    let cursor: BaseNode | undefined = this.start;
-    for (const n of nodes) {
-      cursor = cursor?.getNextNode(n.action as Action);
+    if (flow.cursor.nextNodeId === null) return undefined;
+    const byId = this.nodeIndex().byId;
+    const cursor = byId.get(flow.cursor.nextNodeId);
+    if (!cursor) {
+      throw new Error(
+        `Invalid persisted flow cursor: ${flow.cursor.nextNodeId}`,
+      );
     }
     return cursor;
   }
@@ -477,14 +450,14 @@ export class PersistedFlow<
     this.cachedRecord = null;
     mutate?.(flow);
     flow.shared = this.serializeShared(shared);
-    await this.kv.write(key, stampFlowRecordSchemaVersion(flow));
+    await this.kv.write(key, flow);
     this.cachedRecord = flow;
     await this.fireProjection(shared);
   }
 
   protected async ensureRecord(shared: S): Promise<void> {
     const key = flowKey(this.runId);
-    const existing = await this.kv.read<FlowRecord>(key);
+    const existing = await readPersistedFlowRecord(this.kv, this.runId);
     if (existing) {
       this.cachedRecord = existing;
       return;

--- a/src/test-kernel/agent/PersistedFlow.vitest.ts
+++ b/src/test-kernel/agent/PersistedFlow.vitest.ts
@@ -72,7 +72,6 @@ describe('PersistedFlow', () => {
     await store.write(flowKey(executionId), {
       schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
       flowName: 'texra',
-      params: {},
       shared: { count: 0, continue: false },
       createdAt: new Date().toISOString(),
       cursor: { nextNodeId: 'start/again', lastAction: 'again' },
@@ -87,37 +86,6 @@ describe('PersistedFlow', () => {
       shared: { count: 1, continue: false },
       cursor: { nextNodeId: null, lastAction: 'complete' },
       nodes: [{ action: 'complete', nodeId: 'start/again' }],
-    });
-  });
-
-  it('migrates legacy node-path records to cursor replay on the next step', async () => {
-    const executionId = 'abc128' as ExecutionId;
-    const store = getExecutionStore(executionId);
-    const first = new ContinueOnceNode();
-    const second = new CompleteNode();
-    first.on('again', second);
-    const flow = new PersistedFlow(first, store, executionId);
-
-    await store.write(flowKey(executionId), {
-      schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
-      flowName: 'texra',
-      params: {},
-      shared: { count: 1, continue: false },
-      createdAt: new Date().toISOString(),
-      nodes: [{ action: 'again' }],
-    } satisfies FlowRecord);
-
-    await flow.run({ count: 999, continue: true });
-
-    await expect(
-      store.read<FlowRecord>(flowKey(executionId)),
-    ).resolves.toMatchObject({
-      shared: { count: 2, continue: false },
-      cursor: { nextNodeId: null, lastAction: 'complete' },
-      nodes: [
-        { action: 'again' },
-        { action: 'complete', nodeId: 'start/again' },
-      ],
     });
   });
 

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -108,6 +108,7 @@ function recoveryCase(name: string) {
 
 function flowRecord(shared: unknown): FlowRecord {
   return {
+    schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
     flowName: 'texra',
     shared,
     createdAt: '2026-01-01T00:00:00.000Z',
@@ -161,8 +162,10 @@ describe('runReflectionFlow persisted-state recovery', () => {
       name: 'missing shared state',
       reason: 'missing-shared',
       stored: {
+        schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
         flowName: 'texra',
         createdAt: '2026-01-01T00:00:00.000Z',
+        cursor: { nextNodeId: 'start' },
         nodes: [],
       },
     },
@@ -175,9 +178,11 @@ describe('runReflectionFlow persisted-state recovery', () => {
       name: 'valid shared state without nodes',
       reason: 'unsupported-record',
       stored: {
+        schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
         flowName: 'texra',
         shared: reflectionFlowShared({ totalRounds: 1, context: null }),
         createdAt: '2026-01-01T00:00:00.000Z',
+        cursor: { nextNodeId: 'start' },
       },
     },
     {

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -95,10 +95,11 @@ async function writeFlowRecord(
   overrides: Record<string, unknown> = {},
 ): Promise<void> {
   await getExecutionStore(executionId).write(flowKey(executionId), {
+    schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
     flowName: 'texra',
-    params: {},
     shared,
     createdAt: new Date().toISOString(),
+    cursor: { nextNodeId: 'start' },
     nodes: [],
     ...overrides,
   });
@@ -1100,6 +1101,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       name: 'invalid shared state',
       reason: 'invalid-shared',
       stored: {
+        schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
         flowName: 'texra',
         shared: {
           messages: [],
@@ -1107,6 +1109,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
           stateSlices: null,
         },
         createdAt: '2026-01-01T00:00:00.000Z',
+        cursor: { nextNodeId: 'start' },
         nodes: [],
       },
     },
@@ -1114,8 +1117,10 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       name: 'missing shared state',
       reason: 'missing-shared',
       stored: {
+        schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
         flowName: 'texra',
         createdAt: '2026-01-01T00:00:00.000Z',
+        cursor: { nextNodeId: 'start' },
         nodes: [],
       },
     },
@@ -1128,9 +1133,11 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       name: 'valid shared state without nodes',
       reason: 'unsupported-record',
       stored: {
+        schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
         flowName: 'texra',
         shared: VALID_TOOL_USE_SHARED,
         createdAt: '2026-01-01T00:00:00.000Z',
+        cursor: { nextNodeId: 'start' },
       },
     },
     {
@@ -1141,6 +1148,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
         flowName: 'texra',
         shared: VALID_TOOL_USE_SHARED,
         createdAt: '2026-01-01T00:00:00.000Z',
+        cursor: { nextNodeId: 'start' },
         nodes: [],
       },
     },
@@ -1239,14 +1247,15 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const readSpy = vi.spyOn(store, 'read').mockImplementationOnce(async () => {
       flowContext?.interrupt();
       return {
+        schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
         flowName: 'texra',
-        params: {},
         shared: {
           messages: [],
           shouldSkipCycle: true,
           stateSlices: snapshot.shared.stateSlices,
         },
         createdAt: new Date().toISOString(),
+        cursor: { nextNodeId: 'start' },
         nodes: [],
       };
     });

--- a/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { clearStoreCache, getExecutionStore } from '@agent/storage';
-import { flowKey } from '@agent/node/persistedFlow';
+import { FLOW_RECORD_SCHEMA_VERSION, flowKey } from '@agent/node/persistedFlow';
 import {
   acquireFreshExecutionLease,
   completeOwnedExecutionLease,
@@ -32,9 +32,11 @@ setupPlatform({ workspacePath: '/workspace/session-restart-repair' });
 const executionId = 'abc123' as ExecutionId;
 const streamId = `crashed#${executionId}` as StreamTabId;
 const validFlowRecord = {
+  schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
   flowName: 'texra',
   shared: { messages: [] },
   createdAt: '2026-07-26T00:00:00.000Z',
+  cursor: { nextNodeId: 'start' },
   nodes: [],
 };
 

--- a/src/test-kernel/agent/storage/Resumability.vitest.ts
+++ b/src/test-kernel/agent/storage/Resumability.vitest.ts
@@ -24,10 +24,11 @@ import {
 import { setupPlatform } from '@test/support/setupPlatform';
 
 const BASE_FLOW_RECORD: FlowRecord = {
+  schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
   flowName: 'texra',
-  params: {},
   shared: { messages: [] },
   createdAt: '2026-07-05T00:00:00.000Z',
+  cursor: { nextNodeId: 'start' },
   nodes: [],
 };
 
@@ -198,28 +199,6 @@ describe('deriveResumability', () => {
       cause: RESUMABILITY_CAUSE.MISSING_TERMINAL_WITH_FLOW,
       flowRecord: BASE_FLOW_RECORD,
     });
-  });
-
-  it('accepts an unstamped legacy envelope and preserves extra fields', async () => {
-    const executionId = 'legacy-extra-flow-envelope' as ExecutionId;
-    const legacyRecord = {
-      ...BASE_FLOW_RECORD,
-      legacyOwner: { host: 'extension' },
-    };
-    await getExecutionStore(executionId).write(
-      flowKey(executionId),
-      legacyRecord,
-    );
-
-    const decision = await deriveResumability(executionId);
-
-    expect(decision).toMatchObject({
-      resumable: true,
-      cause: RESUMABILITY_CAUSE.MISSING_TERMINAL_WITH_FLOW,
-    });
-    if (!decision.resumable) return;
-    expect(decision.flowRecord).toEqual(legacyRecord);
-    expect(Object.hasOwn(decision.flowRecord, 'schemaVersion')).toBe(false);
   });
 
   it('reports missing flow records as not resumable', async () => {

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -11,7 +11,7 @@ import {
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { flowKey } from '@agent/node/persistedFlow';
+import { FLOW_RECORD_SCHEMA_VERSION, flowKey } from '@agent/node/persistedFlow';
 import {
   CLI_HISTORY_RESUMABLE_STATUS,
   formatCliHistoryDetailsText,
@@ -145,10 +145,10 @@ describe('CLI history status formatting', () => {
     });
     await releaseOwnedExecutionLease(id);
     await getExecutionStore(id).write(flowKey(id), {
-      flowName: 'test',
-      params: {},
-      shared: null,
+      schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
+      flowName: 'texra',
       createdAt: new Date().toISOString(),
+      cursor: { nextNodeId: 'start' },
       nodes: [],
     });
 
@@ -170,14 +170,15 @@ describe('CLI history status formatting', () => {
     });
     await releaseOwnedExecutionLease(id);
     await getExecutionStore(id).write(flowKey(id), {
-      flowName: 'test',
-      params: {},
+      schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
+      flowName: 'texra',
       shared: {
         currentRound: 1,
         totalRounds: 2,
         conversation: [],
       },
       createdAt: new Date().toISOString(),
+      cursor: { nextNodeId: 'start' },
       nodes: [],
     });
 

--- a/src/test-kernel/settings/HistoryHandlers.vitest.ts
+++ b/src/test-kernel/settings/HistoryHandlers.vitest.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { RESUMABILITY_CAUSE } from '@agent/storage';
+import { FLOW_RECORD_SCHEMA_VERSION } from '@agent/node/persistedFlow';
 import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
 import { AgentCategory } from '@shared/schemas/agent';
 import { HISTORY_RUN_STATUS } from '@shared/schemas/historyViewMessages';
@@ -118,7 +119,14 @@ describe('settings history handlers', () => {
     mocks.deriveResumability.mockResolvedValue({
       resumable: true,
       cause: RESUMABILITY_CAUSE.INTERRUPTED_WITH_FLOW,
-      flowRecord: { flowName: 'tooluse', params: {}, shared: {}, nodes: [] },
+      flowRecord: {
+        schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
+        flowName: 'texra',
+        shared: {},
+        createdAt: '2026-08-03T00:00:00.000Z',
+        cursor: { nextNodeId: 'start' },
+        nodes: [],
+      },
       outcome: RUN_OUTCOME.CANCELLED,
     });
 

--- a/src/test-kernel/tools/ExecutionsToolResumability.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolResumability.vitest.ts
@@ -4,16 +4,21 @@ import '@test/support/defaultSessionTestSetup';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { clearStoreCache, getExecutionStore } from '@agent/storage';
-import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
+import {
+  FLOW_RECORD_SCHEMA_VERSION,
+  flowKey,
+  type FlowRecord,
+} from '@agent/node/persistedFlow';
 import type { ExecutionId } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { ExecutionsTool } from '@tools/ExecutionsTool';
 
 const BASE_FLOW_RECORD: FlowRecord = {
+  schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
   flowName: 'texra',
-  params: {},
   shared: { messages: [] },
   createdAt: '2026-07-05T00:00:00.000Z',
+  cursor: { nextNodeId: 'start' },
   nodes: [],
 };
 

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -62,7 +62,7 @@ import { loadChatExportInput } from '@agent/export/loadChatExportInput';
 import { resumeToolUseFromResumeData } from '@agent/runtime/executeAgent';
 import { resolveAndResumeStream } from '@agent/runtime/resolveAndResumeStream';
 import { getStreamTabId } from '@agent/runtime/streamTab';
-import { flowKey } from '@agent/node/persistedFlow';
+import { FLOW_RECORD_SCHEMA_VERSION, flowKey } from '@agent/node/persistedFlow';
 import {
   EXECUTION_STREAM_ID_SOURCE,
   LOG_LEVELS,
@@ -431,10 +431,11 @@ describe('completedRunArchive facade', () => {
       },
     });
     await getExecutionStore(executionId).write(flowKey(executionId), {
+      schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
       flowName: 'texra',
-      params: {},
       shared: persistedResumeState.shared,
       createdAt: new Date().toISOString(),
+      cursor: { nextNodeId: 'start' },
       nodes: [],
     });
 


### PR DESCRIPTION
## Summary

TeXRA now reads and writes one current persisted-flow checkpoint envelope. This removes support for version-1 or unstamped records, absent replay cursors, node histories without node identifiers, the removed per-flow params channel, and unknown envelope fields.

The current writer has emitted schema version 2 with an explicit graph cursor since July 2026. CLI and TUI workflow checkpoints are intentionally current-format-only, so retaining a second replay algorithm and silently restamping old records only increases maintenance cost.

## What changed

- require schema version 2, the `texra` flow name, an explicit cursor, and node identifiers
- reject unknown envelope, cursor, and node fields at the persistence boundary
- remove node-history replay and schema-restamping paths
- validate an existing record before `PersistedFlow` caches it
- delete compatibility-only tests and convert current-contract fixtures to the current envelope

## Scope and compatibility

This is an intentional breaking change for historical internal CLI/TUI flow checkpoints. It does not change the current writer or any public wire protocol. Old checkpoints fail as unsupported instead of being inferred or rewritten.

## Validation

- `corepack pnpm run typecheck` (all workspace targets)
- `corepack pnpm run lint`
- focused Vitest run: 9 files, 145 tests passed
- `git diff --check`

## Maintenance effect

11 files, 72 insertions, 128 deletions. The deletion removes one compatibility parser branch, one replay implementation, one mutation helper, and two compatibility-specific tests.

Related to #6981.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Intentionally breaks resume for historical checkpoints and changes persistence validation at the resumability boundary; current writers are unchanged but any stored legacy record will no longer resume.
> 
> **Overview**
> **Retires legacy persisted-flow checkpoint compatibility** so CLI/TUI resume only accepts the current envelope instead of inferring or rewriting older shapes.
> 
> The **`FlowRecord` contract is tightened**: `schemaVersion` must be `2`, `flowName` must be `texra`, `cursor` is required, and node audit entries must include `nodeId`. Zod validation switches to **`strictObject`**, so unknown fields (including removed `params`) fail at read time. **`stampFlowRecordSchemaVersion` is removed**—writes persist the record as-is without bumping/restamping on every KV write.
> 
> **Resume semantics drop the legacy path**: `replayLegacyNodePath` and cursor-less replay from `nodes[]` are gone; **`resolveCursor` only follows `cursor.nextNodeId`**. `PersistedFlow.ensureRecord` loads existing records via **`readPersistedFlowRecord`** so invalid envelopes are rejected before caching.
> 
> **Tool-use recovery** still self-heals **shared** state but no longer restamps the envelope when patching `flowRecord.shared`.
> 
> Tests drop legacy migration cases and update fixtures to the current envelope; old internal checkpoints surface as **unsupported** rather than being migrated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 550e8003f3cb25e18341ad88b8d9f5fabc1dcf38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->