### PR TITLE
refactor(tools)!: rename delegate_workflow_script to delegate_multi_agents

### DIFF
--- a/.claude/skills/tech-debt-tournament/SKILL.md
+++ b/.claude/skills/tech-debt-tournament/SKILL.md
@@ -47,7 +47,7 @@ cursor from a previous conversation turn.
    must not edit files or run state-changing commands.
 
    This script targets Claude Code's Workflow runtime and its inline `schema`
-   option. Do not pass it to TeXRA's separate `delegate_workflow_script` tool;
+   option. Do not pass it to TeXRA's separate `delegate_multi_agents` tool;
    that host intentionally uses fixed result envelopes and JSON output files.
 
 4. **Inspect the result.** The workflow returns

--- a/.claude/workflows/tech-debt-tournament.mjs
+++ b/.claude/workflows/tech-debt-tournament.mjs
@@ -3,7 +3,7 @@ export const meta = {
   description:
     'Recurring tech-debt tournament: seam mappers over a ROTATING slice of areas, architect lenses propose deletions, dedupe against known issues + do-not-do ledger, adversarial net-gain verification, output capped to a few issues per cycle.',
   whenToUse:
-    'Claude Code Workflow script invoked by the tech-debt-tournament skill (scheduled campaign); this is not a TeXRA delegate_workflow_script. Args: { campaignDate, cursor?, rotationSize?, knownIssues?, doNotDo?, areas?, maxFile? }. Deliberately scoped small per run (a handful of areas, a few issues filed) — breadth comes from repeated cycles rotating through areas, not from one large sweep.',
+    'Claude Code Workflow script invoked by the tech-debt-tournament skill (scheduled campaign); this is not a TeXRA delegate_multi_agents. Args: { campaignDate, cursor?, rotationSize?, knownIssues?, doNotDo?, areas?, maxFile? }. Deliberately scoped small per run (a handful of areas, a few issues filed) — breadth comes from repeated cycles rotating through areas, not from one large sweep.',
   phases: [
     { title: 'Map', detail: 'one read-only seam mapper per rotated area' },
     { title: 'Propose', detail: 'four architect lenses over all maps' },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+#### Breaking Changes
+
+- **The multi-agent orchestration tool is now `delegate_multi_agents`** —
+  the tool formerly named `delegate_workflow_script` has been renamed with
+  no compatibility alias. Custom agent YAML files that list
+  `delegate_workflow_script` in their tool list must use the new name.
+
 ## [0.40.0] - 2026-08-02
 
 ### CLI

--- a/docs/supabase/SYNC_REMOTE_AGENTS.sql
+++ b/docs/supabase/SYNC_REMOTE_AGENTS.sql
@@ -196,7 +196,7 @@ VALUES (
   'tool-use/orchestrator.yaml',
   ARRAY['public'],
   'toolUse',
-  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'delegate_workflow_script', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'extract_figures', 'extract_bib_entries', 'texcount', 'inquiry', 'codex', 'claude_code', 'github_subscription']
+  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'delegate_multi_agents', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'extract_figures', 'extract_bib_entries', 'texcount', 'inquiry', 'codex', 'claude_code', 'github_subscription']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,
@@ -312,7 +312,7 @@ VALUES (
   'tool-use-lean/leanOrchestrator.yaml',
   ARRAY['researcher', 'lean'],
   'toolUse',
-  ARRAY['delegate_workflow', 'delegate_agent', 'delegate_workflow_script', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'codex', 'claude_code', 'lean_diagnostics', 'lean_inspect', 'lean_loogle', 'lean_file', 'lean_project', 'github_subscription']
+  ARRAY['delegate_workflow', 'delegate_agent', 'delegate_multi_agents', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'codex', 'claude_code', 'lean_diagnostics', 'lean_inspect', 'lean_loogle', 'lean_file', 'lean_project', 'github_subscription']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -1276,7 +1276,7 @@ function seedWorkflowTimeline(): void {
       executionId,
       agentName: 'repositoryAudit',
       childStreamId,
-      toolName: 'delegate_workflow_script',
+      toolName: 'delegate_multi_agents',
     },
   ]);
   emitChildEventOrderEdge(childStreamId, STREAM_ID);
@@ -1389,7 +1389,7 @@ function seedRunningWorkflow(): void {
       executionId,
       agentName: 'live-workflow-validation',
       childStreamId,
-      toolName: 'delegate_workflow_script',
+      toolName: 'delegate_multi_agents',
     },
   ]);
   emitChildEventOrderEdge(childStreamId, STREAM_ID);

--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -982,7 +982,7 @@ description: Exercise workflow-script dispatch from the headless CLI.
 settings:
   agentCategory: toolUse
   tools:
-    - delegate_workflow_script
+    - delegate_multi_agents
 
 prompts:
   systemPrompt: |

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -12,7 +12,7 @@ import { Box, Static, Text } from 'ink';
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import { COLOR_HINT } from '@cli/tui/ui/colors';
 import type { StreamTabId } from '@shared/schemas';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { groupBy } from '@utils/core';
 import { safeHomedir } from '@utils/system/platformPaths';
@@ -102,7 +102,7 @@ export function sessionHeaderIdentityLine(
       streams: context.streams,
     });
     const streamKind =
-      view.toolName === DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME
+      view.toolName === DELEGATE_MULTI_AGENTS_TOOL_NAME
         ? 'workflow script'
         : 'subagent';
     return `${streamKind}: ${view.label} · parent: ${view.parentLabel} · model: ${model}`;

--- a/packages/extension/resources/docs/agent-creation/tool_catalog.md
+++ b/packages/extension/resources/docs/agent-creation/tool_catalog.md
@@ -58,7 +58,7 @@ recommended groups at the bottom are a good starting point.
 - `delegate_workflow` — delegate to a workflow agent for whole-document
   operations. Pass `agent`, `model`, `instruction`, `inputFiles`. Returns
   asynchronously via the follow-up queue.
-- `delegate_workflow_script` — advanced opt-in tool for a durable sequence of
+- `delegate_multi_agents` — advanced opt-in tool for a durable sequence of
   workflow-agent calls with predetermined branching and fan-out. Pass a default
   `agent` and exactly one of the complete `script` source or an existing
   `scriptPath`. Submitted source is saved as an
@@ -126,7 +126,7 @@ zotero_export`
 **Orchestrator agent:**
 `bash, read_file, write_file, glob, grep, delegate_workflow,
 delegate_agent, executions, accept_run_files, todo_write`, optionally
-`delegate_workflow_script` for pipelines with a predetermined fan-out/join
+`delegate_multi_agents` for pipelines with a predetermined fan-out/join
 structure (off by default — see above).
 
 **Computation agent:**

--- a/packages/extension/resources/tool_use_agents/engineer.yaml
+++ b/packages/extension/resources/tool_use_agents/engineer.yaml
@@ -9,7 +9,7 @@ settings:
     - delegate_workflow
     # Advanced deterministic delegation. The global Workflow Script switch is
     # an additional kill switch and is disabled by default.
-    - delegate_workflow_script
+    - delegate_multi_agents
     - executions
     - accept_run_files
     - plan

--- a/packages/extension/src/progressView/frontend/formatters/constants.ts
+++ b/packages/extension/src/progressView/frontend/formatters/constants.ts
@@ -180,7 +180,7 @@ export const TOOL_ICON_MAP: Record<string, TeXRAIconName> = {
 
   // Workflow/delegation
   delegate_workflow: 'list-ul',
-  delegate_workflow_script: 'list-ul',
+  delegate_multi_agents: 'list-ul',
   delegate_agent: 'circle-user',
 
   // Execution history

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -17,7 +17,7 @@ import { html, nothing, type TemplateResult } from 'lit';
 import type { LogMessageData } from '@shared/schemas';
 import { normalizeToolUseData } from '@shared/toolUse';
 import {
-  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  DELEGATE_MULTI_AGENTS_TOOL_NAME,
   DELEGATION_TOOL_CATEGORY,
 } from '@shared/constants/delegationTools';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
@@ -149,7 +149,7 @@ export function formatToolUseTemplate(
   if (
     outputText &&
     !isOutputInTitle &&
-    toolName !== DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME &&
+    toolName !== DELEGATE_MULTI_AGENTS_TOOL_NAME &&
     !isMcpToolName(toolName) &&
     displayKind !== 'read' &&
     !isTrivialWriteOutput

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -37,7 +37,7 @@ import { EXECUTIONS_DEFAULT_ACTION } from '@shared/tools/executionsDisplay';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import {
-  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  DELEGATE_MULTI_AGENTS_TOOL_NAME,
   DELEGATION_TOOLS,
 } from '@shared/constants/delegationTools';
 import {
@@ -642,7 +642,7 @@ const TOOL_SECTION_BUILDERS: Array<{
     build: buildAcceptRunFilesSections,
   },
   {
-    match: (ctx) => ctx.toolName === DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+    match: (ctx) => ctx.toolName === DELEGATE_MULTI_AGENTS_TOOL_NAME,
     build: buildWorkflowScriptSections,
   },
   {

--- a/prompts/agents/remote/Lean4/leanOrchestrator.yaml
+++ b/prompts/agents/remote/Lean4/leanOrchestrator.yaml
@@ -9,7 +9,7 @@ settings:
     - delegate_agent
     # Advanced deterministic delegation. The global Workflow Script switch is
     # an additional kill switch and is disabled by default.
-    - delegate_workflow_script
+    - delegate_multi_agents
     - executions
     - accept_run_files
     # Project management

--- a/prompts/agents/remote/orchestrator.yaml
+++ b/prompts/agents/remote/orchestrator.yaml
@@ -13,7 +13,7 @@ settings:
     # and disabled by default; enable in Dashboard → Tools ("Workflow
     # Script"). When disabled by the user, resolveAgentTools() strips this
     # from the model's tool list, same as github_subscription below.
-    - delegate_workflow_script
+    - delegate_multi_agents
     - todo_write
     - plan
     - read_file

--- a/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
@@ -16,7 +16,7 @@ import {
 import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
 import { buildUserVarPassthrough } from '@agent/utils/userVars';
 import * as logger from '@logger/logUtils';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import { AbsoluteFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { isNonEmptyString } from '@utils/text/stringUtils';
@@ -133,7 +133,7 @@ export const TOOL_GROUPS: Record<string, ToolGroup> = {
     description: 'Delegate tasks to other agents and manage executions',
     tools: [
       'delegate_workflow',
-      DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+      DELEGATE_MULTI_AGENTS_TOOL_NAME,
       'delegate_agent',
       'executions',
       'accept_run_files',

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -163,9 +163,9 @@ export class ModelHandlerValidation extends ModelHandler<
             mathematicalValidationOutput(options.messages),
           ),
         ];
-      } else if (!hasToolResult && toolNames.has('delegate_workflow_script')) {
+      } else if (!hasToolResult && toolNames.has('delegate_multi_agents')) {
         toolCalls = [
-          validationToolCall('delegate_workflow_script', {
+          validationToolCall('delegate_multi_agents', {
             agent: 'correct',
             script: WORKFLOW_SCRIPT_VALIDATION_SOURCE,
           }),

--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -162,7 +162,7 @@ return await parallel(
 
 ## Production integration
 
-The opt-in `delegate_workflow_script` tool composes the production in-band
+The opt-in `delegate_multi_agents` tool composes the production in-band
 subagent runner, durable checkpoint store, task-run file hand-off, progress
 projection, parent cancellation, and completed-journal cost settlement. It
 accepts exactly one of newly submitted `script` source or an existing
@@ -176,7 +176,7 @@ agent's tool list
 agent's configuration is one half of the consent boundary for automated
 workflow fan-out. The other half is global: the "Workflow Script" toggle in
 the Tools dashboard (`src/tools/externalToolDefs.ts`, id `workflow-script`)
-strips `delegate_workflow_script` from every agent's resolved tools when
+strips `delegate_multi_agents` from every agent's resolved tools when
 switched off, regardless of what any individual agent configuration names —
 and new installs start with the switch off.
 

--- a/src/shared/constants/delegationTools.ts
+++ b/src/shared/constants/delegationTools.ts
@@ -1,11 +1,10 @@
 import { AgentCategory } from '../schemas/agent';
 
-export const DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME =
-  'delegate_workflow_script' as const;
+export const DELEGATE_MULTI_AGENTS_TOOL_NAME = 'delegate_multi_agents' as const;
 
 const CANONICAL_DELEGATION_TOOL_NAMES = [
   'delegate_workflow',
-  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  DELEGATE_MULTI_AGENTS_TOOL_NAME,
   'delegate_agent',
 ] as const;
 
@@ -39,7 +38,7 @@ export const DELEGATION_AVAILABILITY_CATEGORY: Readonly<
   Record<string, AgentCategory>
 > = {
   ...DELEGATION_TOOL_CATEGORY,
-  [DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME]: AgentCategory.Workflow,
+  [DELEGATE_MULTI_AGENTS_TOOL_NAME]: AgentCategory.Workflow,
 };
 
 /** True when any of the given tool names is a delegation tool. */

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -238,7 +238,7 @@ export function workflowScriptDeliverySummary(xml: string): string | undefined {
       : []),
     ...fileLines,
     `  script: ${summary.scriptPath}`,
-    `  rerun: edit the script, then call delegate_workflow_script with scriptPath`,
+    `  rerun: edit the script, then call delegate_multi_agents with scriptPath`,
   ].join('\n');
 }
 

--- a/src/shared/tools/toolDisplayName.ts
+++ b/src/shared/tools/toolDisplayName.ts
@@ -19,7 +19,7 @@
 /** Friendly labels for tool names that shouldn't be shown verbatim, keyed by
  *  normalized name. */
 const TOOL_LABEL = new Map<string, string>([
-  ['delegate_workflow_script', 'Workflow script'],
+  ['delegate_multi_agents', 'Multi-agent workflow'],
   ['codex_patch', 'Codex Files'],
   ['codex_thread', 'Codex Thread'],
   ['codex_todo', 'Codex Plan'],

--- a/src/test-kernel/agent/AgentPromptContracts.vitest.mts
+++ b/src/test-kernel/agent/AgentPromptContracts.vitest.mts
@@ -81,8 +81,8 @@ describe('engineer agent prompt', () => {
   });
 
   it('can run deterministic workflow scripts when globally enabled', () => {
-    expect(agent.settings.tools).toContain('delegate_workflow_script');
-    expect(systemPrompt).not.toContain('delegate_workflow_script');
+    expect(agent.settings.tools).toContain('delegate_multi_agents');
+    expect(systemPrompt).not.toContain('delegate_multi_agents');
   });
 
   it('grounds its delegation targets in the live Available agents roster', () => {
@@ -123,10 +123,8 @@ describe('Lean orchestrator agent prompt', () => {
   );
 
   it('can run deterministic workflow scripts when globally enabled', () => {
-    expect(agent.settings.tools).toContain('delegate_workflow_script');
-    expect(agent.prompts.systemPrompt).not.toContain(
-      'delegate_workflow_script',
-    );
+    expect(agent.settings.tools).toContain('delegate_multi_agents');
+    expect(agent.prompts.systemPrompt).not.toContain('delegate_multi_agents');
   });
 });
 

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -15,7 +15,7 @@ import {
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,
@@ -245,7 +245,7 @@ describe('child stream progress events', () => {
         agentName: 'draft-sections',
         description: 'Run a named child task',
         config,
-        toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+        toolName: DELEGATE_MULTI_AGENTS_TOOL_NAME,
       }),
     );
     await withSessionEventRecording(() => firstRun.finalize());
@@ -264,7 +264,7 @@ describe('child stream progress events', () => {
         agentName: 'draft-sections',
         description: 'Resume the named child task',
         config,
-        toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+        toolName: DELEGATE_MULTI_AGENTS_TOOL_NAME,
       },
     );
 
@@ -309,7 +309,7 @@ describe('child stream progress events', () => {
       agentName: 'retry-setup',
       description: 'Retry a failed child stream setup',
       config,
-      toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+      toolName: DELEGATE_MULTI_AGENTS_TOOL_NAME,
     };
 
     try {
@@ -366,7 +366,7 @@ describe('child stream progress events', () => {
           agentName: 'repo-cleanup-readonly-pilot-2026-07-24',
           description: 'Audit the repository without editing',
           config: workerConfig,
-          toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+          toolName: DELEGATE_MULTI_AGENTS_TOOL_NAME,
         },
       );
 

--- a/src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts
@@ -165,7 +165,7 @@ describe('tool-use tool resolution', () => {
       const registry = getDefaultToolRegistry();
 
       const { tools } = await resolveAgentTools({
-        tools: toolDefs(['bash', 'delegate_workflow_script']),
+        tools: toolDefs(['bash', 'delegate_multi_agents']),
         registry,
         logger,
         toolInjections,

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -780,7 +780,7 @@ describe('toGoogleTools', () => {
       'arxiv_metadata',
       'crossref_search',
       'diagnostics',
-      'delegate_workflow_script',
+      'delegate_multi_agents',
     ]);
 
     expect(reviewTools).toHaveLength(17);
@@ -805,7 +805,7 @@ describe('toGoogleTools', () => {
   });
 
   it('converts the registered workflow script JSON args for both Google APIs', () => {
-    const [definition] = resolveToolDefinitions(['delegate_workflow_script']);
+    const [definition] = resolveToolDefinitions(['delegate_multi_agents']);
     const interactionSchema = convertGoogleToolSchema(definition) as {
       properties: Record<string, Record<string, unknown>>;
     };

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -286,7 +286,7 @@ describe('summarizeSubagentFollowup', () => {
         '  paper_A.tex (+120 -80)',
         '  notes.txt',
         '  script: .texra/workflow-scripts/proofread-pipeline.mjs',
-        '  rerun: edit the script, then call delegate_workflow_script with scriptPath',
+        '  rerun: edit the script, then call delegate_multi_agents with scriptPath',
       ].join('\n'),
     );
   });

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
@@ -1,4 +1,4 @@
-// A detached delegate_workflow_script run owns a child stream. Its phases and
+// A detached delegate_multi_agents run owns a child stream. Its phases and
 // typed task records render through the focused-child viewport, while the
 // workflow-specific header identifies the kind of child execution.
 
@@ -40,7 +40,7 @@ import {
   TOOL_USE_STATUS,
   type StreamTabId,
 } from '@shared/schemas';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
 import { clearAllStreamStatusesForTest } from '@test/support/streamStatusTestUtils';
 import { loadInk } from '@test/support/inkTestHarness.mts';
@@ -983,7 +983,7 @@ describe('CLI workflow-script child-stream transcript', () => {
               agentName: 'draft-sections',
               executionId: 'exec-1',
               kind: 'subagent' as const,
-              toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+              toolName: DELEGATE_MULTI_AGENTS_TOOL_NAME,
             },
           },
         ],

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -463,7 +463,7 @@ describe('task-group-list status icon (#7993 step 3)', () => {
   });
 });
 
-// #8722 Phase 2b: a focused delegate_workflow_script run projects its phases
+// #8722 Phase 2b: a focused delegate_multi_agents run projects its phases
 // as `kind: 'phase'` groups with per-agent Running/Finished/Failed lines
 // beneath. The phase header and call cards are both derived from typed state;
 // the renderer does not parse status prefixes from prose.

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -82,7 +82,7 @@ const papers = await parallel(
 );
 return { papers, question: args.question };`;
     const message = toolUseMessage('workflow-script', {
-      toolName: 'delegate_workflow_script',
+      toolName: 'delegate_multi_agents',
       input: {
         agent: 'research',
         script,
@@ -142,7 +142,7 @@ return { papers, question: args.question };`;
 
   it('shows explicit null workflow-script arguments as JSON', () => {
     const message = toolUseMessage('workflow-script-null-args', {
-      toolName: 'delegate_workflow_script',
+      toolName: 'delegate_multi_agents',
       input: {
         agent: 'research',
         script: 'export const meta = { name: "One call" };\nreturn null;',

--- a/src/test-kernel/shared/DelegationTools.vitest.ts
+++ b/src/test-kernel/shared/DelegationTools.vitest.ts
@@ -15,7 +15,7 @@ it('keeps canonical delegation tool names registered', () => {
 it('contains the canonical delegation tool names', () => {
   expect([...DELEGATION_TOOLS]).toEqual([
     'delegate_workflow',
-    'delegate_workflow_script',
+    'delegate_multi_agents',
     'delegate_agent',
   ]);
 });

--- a/src/test-kernel/shared/ToolDisplayName.vitest.ts
+++ b/src/test-kernel/shared/ToolDisplayName.vitest.ts
@@ -27,7 +27,9 @@ describe('displayToolName', () => {
   });
 
   it('applies friendly labels after stripping the namespace', () => {
-    expect(displayToolName('delegate_workflow_script')).toBe('Workflow script');
+    expect(displayToolName('delegate_multi_agents')).toBe(
+      'Multi-agent workflow',
+    );
     expect(displayToolName('codex:codex_turn')).toBe('Codex Turn');
   });
 

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -198,12 +198,12 @@ beforeEach(async () => {
 
 describe('WorkflowScriptTool', () => {
   it('is registered and classified without becoming a proposal tool', () => {
-    expect(getDefaultToolRegistry().has('delegate_workflow_script')).toBe(true);
-    expect(DELEGATION_TOOLS.has('delegate_workflow_script')).toBe(true);
-    expect(DELEGATION_AVAILABILITY_CATEGORY.delegate_workflow_script).toBe(
+    expect(getDefaultToolRegistry().has('delegate_multi_agents')).toBe(true);
+    expect(DELEGATION_TOOLS.has('delegate_multi_agents')).toBe(true);
+    expect(DELEGATION_AVAILABILITY_CATEGORY.delegate_multi_agents).toBe(
       'workflow',
     );
-    expect(DELEGATION_TOOL_CATEGORY.delegate_workflow_script).toBeUndefined();
+    expect(DELEGATION_TOOL_CATEGORY.delegate_multi_agents).toBeUndefined();
   });
 
   it('owns a detached run completion rejection without delivering a second error', async () => {

--- a/src/test-kernel/tools/externalToolDefs.vitest.ts
+++ b/src/test-kernel/tools/externalToolDefs.vitest.ts
@@ -32,7 +32,7 @@ describe('external tool definitions', () => {
 
     assert.ok(workflowScript, 'Workflow script tool definition should exist');
     assert.strictEqual(workflowScript.toggleable, true);
-    assert.deepStrictEqual(workflowScript.tools, ['delegate_workflow_script']);
+    assert.deepStrictEqual(workflowScript.tools, ['delegate_multi_agents']);
     assert.strictEqual(await workflowScript.check(), true);
   });
 

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -26,7 +26,7 @@ import {
 } from '@shared/schemas';
 import { WorkflowScriptFilesSchema } from '@shared/schemas/workflowScriptFiles';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import { configureDelegatedChildApprovals } from '@tools/approval';
 import {
   assertWritable,
@@ -181,9 +181,9 @@ function withScriptReference(
  * new installs start with the switch off.
  */
 export class WorkflowScriptTool extends defineTool({
-  name: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  name: DELEGATE_MULTI_AGENTS_TOOL_NAME,
   slow: true,
-  description: `Run a deterministic JavaScript workflow that coordinates workflow agents. Workflow agents edit or produce FILES: each agent() call resolves to a result envelope { category: 'workflow', outcome, outputs, diffs, compileFailures, cost } listing the files it produced, never prose. Use this only when the complete fan-out, pipeline, and join structure is known before execution and should resume safely after interruption. Keep using delegate_agent one call at a time when a later decision depends on reviewing an earlier result.
+  description: `Run a deterministic JavaScript workflow that coordinates workflow agents. Workflow agents edit or produce FILES: each agent() call resolves to a result envelope { category: 'workflow', outcome, outputs, diffs, compileFailures, cost } listing the files it produced, never prose. Use \`delegate_multi_agents\` only when the complete fan-out, pipeline, and join structure is known before execution and should resume safely after interruption. Keep using \`delegate_agent\` one call at a time when a later decision depends on reviewing an earlier result.
 
 Script input: every source submission is saved immediately as a unique, non-overwriting draft under .texra/workflow-scripts/. Every result returns that editable path; on an error, edit the file and retry with scriptPath instead of rewriting the source.
 
@@ -233,7 +233,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
     const contexts = getCurrentToolContexts();
     if (contexts?.runContext?.kind !== 'launch') {
       throw new Error(
-        'delegate_workflow_script requires an active launched agent session.',
+        'delegate_multi_agents requires an active launched agent session.',
       );
     }
     const { runContext: parent, callContext } = contexts;
@@ -428,7 +428,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
             agentName: meta.name,
             description: meta.description,
             config: runConfig,
-            toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+            toolName: DELEGATE_MULTI_AGENTS_TOOL_NAME,
           },
         );
         runChildStreamId = childStream.childStreamId;

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -30,7 +30,7 @@ import type {
 } from '@agent/runtime/workflowControlRegistry';
 import type { ExecutionId } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import type { WorkflowScriptFiles } from '@shared/schemas/workflowScriptFiles';
 import { truncateSummary } from '@utils/text/stringUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -54,7 +54,7 @@ const RUN_LOG_MAX_LINE_LENGTH = 500;
 export function formatWorkflowScriptReference(scriptPath: string): string {
   return [
     `Script file: ${scriptPath}`,
-    `To revise and rerun it, edit that file and call ${DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME} with scriptPath: '${scriptPath}'.`,
+    `To revise and rerun it, edit that file and call ${DELEGATE_MULTI_AGENTS_TOOL_NAME} with scriptPath: '${scriptPath}'.`,
   ].join('\n');
 }
 

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -17,7 +17,7 @@ import { z } from 'zod';
 // Local imports
 import { apiKeyEnvName, lookupApiKeyOrigin } from '@model/apiProviders';
 import { platform } from '@platform/platform';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
 import type { RegisteredToolName } from '@tools/registry';
 import { importCodexClass, findCodexBinaryPath } from '@tools/codexImport';
@@ -454,13 +454,13 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
   },
   {
     id: 'workflow-script',
-    tools: [DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME],
+    tools: [DELEGATE_MULTI_AGENTS_TOOL_NAME],
     name: 'Workflow Script',
     category: 'workflow',
     description:
       'Run deterministic JavaScript workflow scripts that fan out, pipeline, and join calls to sub-agents, resuming safely after interruption. An agent only gets this tool if its own configuration names it — this switch is an additional kill switch on top of that per-agent opt-in.',
     configNotes:
-      'No local install required. Turning this off removes delegate_workflow_script from every agent tool list, even agents whose configuration names it explicitly.',
+      'No local install required. Turning this off removes delegate_multi_agents from every agent tool list, even agents whose configuration names it explicitly.',
     toggleable: true,
     check: async () => true,
   },

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -4,7 +4,7 @@ import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ToolDefinition } from '@model/ToolDefinition';
 import type { CanonicalToolDisplayName } from '@shared/tools/toolKind';
 import {
-  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  DELEGATE_MULTI_AGENTS_TOOL_NAME,
   type CanonicalDelegationToolName,
 } from '@shared/constants/delegationTools';
 
@@ -125,7 +125,7 @@ function createDefaultTools() {
     codex: new CodexTool(),
     [CLAUDE_AGENT_NAME]: new ClaudeAgentTool(),
     delegate_workflow: new WorkflowAgentTool(),
-    [DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME]: new WorkflowScriptTool(),
+    [DELEGATE_MULTI_AGENTS_TOOL_NAME]: new WorkflowScriptTool(),
     delegate_agent: new DelegateAgentTool(),
     executions: new ExecutionsTool(),
     accept_run_files: new AcceptRunFilesTool(),


### PR DESCRIPTION
## Summary

Atomic breaking rename of the orchestration tool `delegate_workflow_script` → `delegate_multi_agents`, per #9681: the old name described an implementation mechanism; the new name names the product capability (a known multi-agent fan-out, pipeline, and join executed as one resumable operation). **No alias, dual registration, fallback parser, or compatibility mirror** — CLI/TUI workflow tools use only the current protocol; historical traces display the old spelling as inert history.

Closes #9681.

**BREAKING CHANGE for users:** custom agent YAMLs listing `delegate_workflow_script` in their tool list must rename the entry to `delegate_multi_agents`. (Called out in the changelog section below and worth a CHANGELOG entry at release.)

## Issue acceptance gates

- [x] Zero production or current agent-definition hits for `delegate_workflow_script` (48 hits → 0 in `src/`, `packages/`, `prompts/`, `docs/supabase/`, `.claude/`; the 7 remaining hits are dated history under `docs/proposals/`)
- [x] `delegate_multi_agents` available on the intended engineer (`tool_use_agents/engineer.yaml`) and lean-project (`prompts/agents/remote/Lean4/leanOrchestrator.yaml`) surfaces, plus the remote orchestrator
- [x] No alias or dual-registration branch exists
- [x] Workflow checkpoints keep journaling their current inner `agent()` calls; no old checkpoint translator added
- [ ] **Remote definitions redeploy** — `docs/supabase/SYNC_REMOTE_AGENTS.sql` content is updated, but the actual Supabase redeploy + verification must run in the release operation (needs the owner's Supabase session). This gate is intentionally left open and called out here.
- [x] Changelog-identifiable user-facing break (custom-agent YAML tool-name change) — stated above and in the commit trailer
- [x] CLI, extension, desktop build/type checks pass (typecheck:workspace, extension, cli clean; 3101 tests across tools/shared/agent suites green)

## Single source of truth

`DELEGATE_MULTI_AGENTS_TOOL_NAME` in `src/shared/constants/delegationTools.ts` is the one constant every dispatcher, display, approval, and validation path reads. The when-to-use guidance lives only in the tool description (`WorkflowScriptTool.ts`), never in orchestrator prompts (asserted by `AgentPromptContracts`).

## Duplication and abstraction budget

n/a — mechanical rename, no new abstraction. Engine names (`WorkflowScriptTool` class, `src/agent/workflowScript/`, stage labels, the `workflow-script` settings-toggle persistence id) intentionally kept: the issue renames the exposed tool name only.

## Net elements (R6)

- Files: 36 changed (+79/−71, includes the CHANGELOG entry)
- Exported symbols: 1 renamed (`DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME` → `DELEGATE_MULTI_AGENTS_TOOL_NAME`); all ~10 consumers updated
- Classes/interfaces/enums: 0 added/removed

## Consumer counts (R8)

- `DELEGATE_*_TOOL_NAME` constant: ~10 production consumers (dispatcher, registry, externalToolDefs, subagentFollowup, displayName, validation handler, progressView formatters, CLI transcript) — all updated in this PR; test fixtures updated; no compatibility-only fixtures existed to delete.

## Host impact

Extension: tool renamed in registry, settings toggle copy, progress view icons/formatters.
Desktop: shares the same shared/constants path.
CLI: TUI transcript formatter + harness/validate scripts renamed.

## Scheduled refactoring

The Supabase remote-agent redeploy (`docs/supabase/SYNC_REMOTE_AGENTS.sql`) must run in the release operation that ships this rename, with post-deploy verification that remote definitions expose `delegate_multi_agents`.

## Validation

- Grep proof: 48 → 0 old-name hits outside `docs/proposals/` history
- `npx vitest run` on all 12 touched test files (207 tests) + full `src/test-kernel/{tools,shared,agent}` sweep (3101 tests) — green
- `npm run typecheck:workspace`, `typecheck:extension`, `typecheck:cli`, `npm run lint`, `npm run format` — clean
- Trace-viewer standalone bundle rebuilt locally (regenerates in CI; not tracked)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking tool rename with no alias affects custom agent YAML and any external integrations still calling `delegate_workflow_script`; runtime behavior is unchanged but misconfigured agents will lose the tool until updated.
> 
> **Overview**
> **Breaking rename:** the multi-agent orchestration tool is now **`delegate_multi_agents`** (replacing **`delegate_workflow_script`**). There is **no compatibility alias**—registry, dashboard toggle (`workflow-script`), agent YAMLs, Supabase sync SQL, docs, and tests all use the new name only.
> 
> The shared constant becomes **`DELEGATE_MULTI_AGENTS_TOOL_NAME`** in `delegationTools.ts`; **`WorkflowScriptTool`** still implements the capability but registers under the new id and updates user-facing copy (including display label **Multi-agent workflow**). Follow-up/rerun hints and tool descriptions now tell models to call **`delegate_multi_agents`** with `scriptPath`.
> 
> **CHANGELOG [Unreleased]** documents the break for custom agents that still list the old tool name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d4923bb1dfa890c4b149e0892998c5a829d04a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

