### PR TITLE
refactor!: rename multi-agent delegation tool

### DIFF
--- a/.claude/skills/tech-debt-tournament/SKILL.md
+++ b/.claude/skills/tech-debt-tournament/SKILL.md
@@ -47,7 +47,7 @@ cursor from a previous conversation turn.
    must not edit files or run state-changing commands.
 
    This script targets Claude Code's Workflow runtime and its inline `schema`
-   option. Do not pass it to TeXRA's separate `delegate_workflow_script` tool;
+   option. Do not pass it to TeXRA's separate `delegate_multi_agents` tool;
    that host intentionally uses fixed result envelopes and JSON output files.
 
 4. **Inspect the result.** The workflow returns

--- a/.claude/workflows/tech-debt-tournament.mjs
+++ b/.claude/workflows/tech-debt-tournament.mjs
@@ -3,7 +3,7 @@ export const meta = {
   description:
     'Recurring tech-debt tournament: seam mappers over a ROTATING slice of areas, architect lenses propose deletions, dedupe against known issues + do-not-do ledger, adversarial net-gain verification, output capped to a few issues per cycle.',
   whenToUse:
-    'Claude Code Workflow script invoked by the tech-debt-tournament skill (scheduled campaign); this is not a TeXRA delegate_workflow_script. Args: { campaignDate, cursor?, rotationSize?, knownIssues?, doNotDo?, areas?, maxFile? }. Deliberately scoped small per run (a handful of areas, a few issues filed) — breadth comes from repeated cycles rotating through areas, not from one large sweep.',
+    'Claude Code Workflow script invoked by the tech-debt-tournament skill (scheduled campaign); this is not a TeXRA delegate_multi_agents. Args: { campaignDate, cursor?, rotationSize?, knownIssues?, doNotDo?, areas?, maxFile? }. Deliberately scoped small per run (a handful of areas, a few issues filed) — breadth comes from repeated cycles rotating through areas, not from one large sweep.',
   phases: [
     { title: 'Map', detail: 'one read-only seam mapper per rotated area' },
     { title: 'Propose', detail: 'four architect lenses over all maps' },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.41.0] - Unreleased
+
+### Shared (all surfaces)
+
+#### Features
+
+- **Multi-agent workflows are available to the software-engineering and Lean
+  team leads** — after enabling **Multi-Agent Workflow** in the Tools panel,
+  these teams can run predetermined parallel and sequential agent pipelines
+  that resume safely after interruption.
+
+#### Breaking Changes
+
+- **Custom agent definitions use `delegate_multi_agents` for resumable
+  multi-agent workflows** — replace the former
+  `delegate_workflow_script` tool name in custom YAML files. The renamed tool
+  still runs predetermined fan-out, pipeline, and join structures as one
+  resumable operation.
+
 ## [0.40.0] - 2026-08-02
 
 ### CLI
@@ -64,10 +83,6 @@ All notable changes to this project will be documented in this file.
   TeXRA settings view.
 - **OpenAI Fast models use the priority service tier** — their requests now ask
   OpenAI for priority processing instead of the standard service tier.
-- **Workflow scripts are available to the software-engineering and Lean team
-  leads** — after enabling Workflow Script in the Tools panel, these teams can
-  run predetermined parallel and sequential agent pipelines that resume safely
-  after interruption.
 
 #### Breaking Changes
 

--- a/config/ratchets/shared-schemas-deep-import-baseline.json
+++ b/config/ratchets/shared-schemas-deep-import-baseline.json
@@ -415,11 +415,11 @@
       "src/tools/comment/InlineCommentTool.ts",
       "src/tools/contextHelpers.ts",
       "src/tools/core/base.ts",
+      "src/tools/delegation/DelegateMultiAgentsTool.ts",
       "src/tools/delegation/DelegationTools.ts (type-only)",
       "src/tools/delegation/inputFields.ts (type-only)",
       "src/tools/delegation/proposalFlow.ts (type-only)",
       "src/tools/delegation/subagentExecution.ts (type-only)",
-      "src/tools/delegation/WorkflowScriptTool.ts",
       "src/tools/DiagnosticsTool.ts",
       "src/tools/EditTool.ts",
       "src/tools/ExecutionsTool.ts",
@@ -473,8 +473,8 @@
       "src/agent/workflowScript/persistence.ts",
       "src/agent/workflowScript/runWorkflowScript.ts",
       "src/agent/workflowScript/types.ts (type-only)",
-      "src/tools/delegation/workflowScriptStrategy.ts (type-only)",
-      "src/tools/delegation/WorkflowScriptTool.ts"
+      "src/tools/delegation/DelegateMultiAgentsTool.ts",
+      "src/tools/delegation/workflowScriptStrategy.ts (type-only)"
     ]
   },
   "gratuitous": {

--- a/docs/dev/audits/2026-07-22-agent-sdk-readiness-checkpoint.md
+++ b/docs/dev/audits/2026-07-22-agent-sdk-readiness-checkpoint.md
@@ -48,7 +48,7 @@ src/agent/runtime src/agent/storage` alone shows **11**:
 34 files total, including `src/tools/bash.ts`,
 `src/tools/agentCliShared.ts`, and the delegation tool call sites
 (`subagentExecution.ts`, `inBandSubagentExecution.ts`,
-`WorkflowScriptTool.ts`). This pass's fan-out readers opened only **one** of
+`DelegateMultiAgentsTool.ts`). This pass's fan-out readers opened only **one** of
 those 11 runtime/storage files fresh at `395e229`: `runAgent.ts`.
 `RunContext.ts` and `SessionHandle.ts` were also read fresh this pass, but
 as part of the general runtime review, not because `0dc0f8b` touched them —

--- a/docs/dev/audits/2026-07-26-agent-sdk-readiness-checkpoint.md
+++ b/docs/dev/audits/2026-07-26-agent-sdk-readiness-checkpoint.md
@@ -178,7 +178,7 @@ coupling); neither is actionable in an unattended pass.
     exists" note for the workflow-script runner binding is now stale.**
     `createWorkflowScriptAgentRunner` (`workflowScriptAgentRunner.ts:123`) is the
     **live production** binding of the injected `WorkflowAgentRunner` port to
-    `executeStableSubagentInBand`, wired at `WorkflowScriptTool.ts:247`. This is
+    `executeStableSubagentInBand`, wired at `DelegateMultiAgentsTool.ts:247`. This is
     a factual correction to the earlier record, not new debt: the workflow-script
     engine is the natural first _programmatic_ SDK surface and it already returns
     journaled typed results. No action; recorded so the stale claim isn't carried
@@ -241,7 +241,7 @@ narrowing without a deliberate compatibility boundary for `Map` inputs.**
 - `MapToolRegistry` (`src/agent/core/tools/ToolTypes.ts:50-51`) still
   `Map | Record` with the `instanceof Map` branch.
 - `workflowScriptAgentRunner.ts:123` `createWorkflowScriptAgentRunner` confirmed
-  a **live production** binding (`WorkflowScriptTool.ts:247`), not a test fake.
+  a **live production** binding (`DelegateMultiAgentsTool.ts:247`), not a test fake.
 - Direct `executeAgent` census: three production call sites —
   `src/agent/runtime/runAgent.ts`,
   `src/tools/delegation/nativeSubagentStrategy.ts`, and the lazy import in

--- a/docs/proposals/2026-07-05-workflow-script-engine.md
+++ b/docs/proposals/2026-07-05-workflow-script-engine.md
@@ -276,7 +276,7 @@ consolidated result.
 2. **Canonical `AgentFinalResult` envelope after post-flow artifact work.**
    This is the fixed chaining contract for both workflow and tool-use agents;
    it requires no model-constrained JSON mechanism.
-3. **The engine as a `delegate_workflow_script` tool**: prototype engine
+3. **The engine as a `delegate_multi_agents` tool**: prototype engine
    (`src/agent/workflowScript/`) wired to the in-band execution path,
    ordinary `parentExecutionId` lineage, run-storage file binding, journal persistence,
    progress-event bridging onto the existing stream tree (extension board

--- a/docs/proposals/2026-07-17-workflow-script-async-execution.local-before-pull.md
+++ b/docs/proposals/2026-07-17-workflow-script-async-execution.local-before-pull.md
@@ -12,7 +12,7 @@ Prereqs shipped: durable named checkpoints (#8666/#8651), CLI progress projectio
 ## Framing: this is a convergence, not a new mode
 
 The constraint is to make the system _simpler_. Detaching the run does that
-by **removing a dual system**: `delegate_workflow_script` is today the one
+by **removing a dual system**: `delegate_multi_agents` is today the one
 delegation tool that bypasses `startChildRunLoop` and delivers synchronously.
 Folding it into the existing async path means one delivery mechanism (the
 follow-up queue) for all three delegation tools, and lets us **delete** the
@@ -25,7 +25,7 @@ down.
 
 ## Problem
 
-`delegate_workflow_script` runs **synchronously inside the orchestrator's
+`delegate_multi_agents` runs **synchronously inside the orchestrator's
 tool-call turn**. The parent turn blocks for the whole run — up to the
 10-minute wall clock (`meta.timeoutMs`, capped at 60 min) — and the model
 gets exactly one thing back: the final tool result. While the run is in
@@ -71,12 +71,12 @@ So the async conversion is a **new strategy**, not new runtime:
 - **New** `createWorkflowScriptStrategy(params)` — a `ChildRunStrategy` shaped
   like `createNativeWorkflowStrategy`, whose `launch(ports)` calls
   `runPersistedWorkflowScriptWithProgress` (moved out of
-  `WorkflowScriptTool.execute`), uses `ports.recordCost` for the final total
+  `DelegateMultiAgentsTool.execute`), uses `ports.recordCost` for the final total
   and `ports.notify` for interim phase/log progress, `isTerminal: () => true`,
   no `runTurn`. `formatDelivery` → result + run log; `formatError` → error +
   run log + "resume with same meta.name" hint; `buildResultMeta` → the
   structured result envelope so `/executions/{id}/result` chaining works.
-- **Split** `WorkflowScriptTool.execute` into a launch half (mint/derive the
+- **Split** `DelegateMultiAgentsTool.execute` into a launch half (mint/derive the
   run executionId, capture `recordSubagentCost` +
   `approvalPromptsUnavailable`/`runtimeUnavailableTools` up front, call
   `registerExecution` + `startChildRunLoop`, return "Launched (async)") and
@@ -94,7 +94,7 @@ Resume (#8666) works today _because_ the checkpoint is anchored to the stable
 orchestrator executionId plus `meta.name`:
 `deriveWorkflowScriptCheckpointId({ name, defaultAgent, parentExecutionId })`
 where `parentExecutionId` is the orchestrator's execution
-(`WorkflowScriptTool.ts:127`), and the journal KV lives on
+(`DelegateMultiAgentsTool.ts:127`), and the journal KV lives on
 `getExecutionStore(orchestratorExecutionId)`.
 
 If a detached run minted a fresh random executionId
@@ -160,7 +160,7 @@ live retry can be a fast-follow.
 
 The #8672 CLI projection (`workflowScriptProgress.ts`) is built entirely
 around finding and patching the **owning tool row** (gated on
-`DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME`, keyed to `logId`). A detached run is its
+`DELEGATE_MULTI_AGENTS_TOOL_NAME`, keyed to `logId`). A detached run is its
 own stream, so its phase/log lines must instead route into a `StreamSlice`
 and render through the existing focused-child viewport — a different
 mechanism, not a config flip. The workflow's `agent()` children _already_
@@ -202,7 +202,7 @@ equivalent is a separate, larger UI effort.
    its in-flight child via the run signal — arguably more correct, but a
    capability change to decide deliberately.
 2. **Resume ergonomics.** With the run detached, who relaunches after a crash
-   or lease loss — the orchestrator re-issuing `delegate_workflow_script`, or
+   or lease loss — the orchestrator re-issuing `delegate_multi_agents`, or
    a resume-by-executionId path like `delegate_agent execution_id=`? The
    lease-lost watchdog (`childRunLoop.ts:510`) would now interrupt a detached
    run on ownership loss, a behavior the inline version never had.

--- a/docs/proposals/2026-07-17-workflow-script-async-execution.md
+++ b/docs/proposals/2026-07-17-workflow-script-async-execution.md
@@ -7,7 +7,7 @@ Prereqs shipped: durable named checkpoints (#8666/#8651), CLI progress projectio
 ## Framing: this is a convergence, not a new mode
 
 The constraint is to make the system _simpler_. Detaching the run does that
-by **removing a dual system**: `delegate_workflow_script` is today the one
+by **removing a dual system**: `delegate_multi_agents` is today the one
 delegation tool that bypasses `startChildRunLoop` and delivers synchronously.
 Folding it into the existing async path means one delivery mechanism (the
 follow-up queue) for all three delegation tools, and lets us **delete** the
@@ -20,7 +20,7 @@ down.
 
 ## Problem
 
-`delegate_workflow_script` runs **synchronously inside the orchestrator's
+`delegate_multi_agents` runs **synchronously inside the orchestrator's
 tool-call turn**. The parent turn blocks for the whole run — up to the
 10-minute wall clock (`meta.timeoutMs`, capped at 60 min) — and the model
 gets exactly one thing back: the final tool result. While the run is in
@@ -66,7 +66,7 @@ So the async conversion is a **new strategy**, not new runtime:
 - **New** `createWorkflowScriptStrategy(params)` — a `ChildRunStrategy` shaped
   like `createNativeWorkflowStrategy`, whose `launch(ports)` calls
   `runPersistedWorkflowScriptWithProgress` (moved out of
-  `WorkflowScriptTool.execute`), uses `ports.recordCost` for the final total
+  `DelegateMultiAgentsTool.execute`), uses `ports.recordCost` for the final total
   and `ports.notify` for interim phase/log progress, `isTerminal: () => true`,
   no `runTurn`. `formatDelivery` → result + run log; `formatError` → error +
   run log + "resume with same meta.name" hint, both wrapped in the shared
@@ -76,7 +76,7 @@ So the async conversion is a **new strategy**, not new runtime:
   map onto the `AgentFinalResult`-shaped `ResultMeta`; the prose result is
   delivered and persisted as the report, and each `agent()` grandchild still
   persists its own chainable manifest.
-- **Split** `WorkflowScriptTool.execute` into a launch half (mint/derive the
+- **Split** `DelegateMultiAgentsTool.execute` into a launch half (mint/derive the
   run executionId, capture `recordSubagentCost` +
   `approvalPromptsUnavailable`/`runtimeUnavailableTools` up front, call
   `registerExecution` + `startChildRunLoop`, return "Launched (async)") and
@@ -94,7 +94,7 @@ Resume (#8666) works today _because_ the checkpoint is anchored to the stable
 orchestrator executionId plus `meta.name`:
 `deriveWorkflowScriptCheckpointId({ name, defaultAgent, parentExecutionId })`
 where `parentExecutionId` is the orchestrator's execution
-(`WorkflowScriptTool.ts:127`), and the journal KV lives on
+(`DelegateMultiAgentsTool.ts:127`), and the journal KV lives on
 `getExecutionStore(orchestratorExecutionId)`.
 
 If a detached run minted a fresh random executionId
@@ -160,7 +160,7 @@ live retry can be a fast-follow.
 
 The #8672 CLI projection (`workflowScriptProgress.ts`) is built entirely
 around finding and patching the **owning tool row** (gated on
-`DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME`, keyed to `logId`). A detached run is its
+`DELEGATE_MULTI_AGENTS_TOOL_NAME`, keyed to `logId`). A detached run is its
 own stream, so its phase/log lines must instead route into a `StreamSlice`
 and render through the existing focused-child viewport — a different
 mechanism, not a config flip. The workflow's `agent()` children _already_
@@ -202,7 +202,7 @@ equivalent is a separate, larger UI effort.
    its in-flight child via the run signal — arguably more correct, but a
    capability change to decide deliberately.
 2. **Resume ergonomics.** With the run detached, who relaunches after a crash
-   or lease loss — the orchestrator re-issuing `delegate_workflow_script`, or
+   or lease loss — the orchestrator re-issuing `delegate_multi_agents`, or
    a resume-by-executionId path like `delegate_agent execution_id=`? The
    lease-lost watchdog (`childRunLoop.ts:510`) would now interrupt a detached
    run on ownership loss, a behavior the inline version never had.

--- a/docs/supabase/SYNC_REMOTE_AGENTS.sql
+++ b/docs/supabase/SYNC_REMOTE_AGENTS.sql
@@ -196,7 +196,7 @@ VALUES (
   'tool-use/orchestrator.yaml',
   ARRAY['public'],
   'toolUse',
-  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'delegate_workflow_script', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'extract_figures', 'extract_bib_entries', 'texcount', 'inquiry', 'codex', 'claude_code', 'github_subscription']
+  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'delegate_multi_agents', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'extract_figures', 'extract_bib_entries', 'texcount', 'inquiry', 'codex', 'claude_code', 'github_subscription']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,
@@ -312,7 +312,7 @@ VALUES (
   'tool-use-lean/leanOrchestrator.yaml',
   ARRAY['researcher', 'lean'],
   'toolUse',
-  ARRAY['delegate_workflow', 'delegate_agent', 'delegate_workflow_script', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'codex', 'claude_code', 'lean_diagnostics', 'lean_inspect', 'lean_loogle', 'lean_file', 'lean_project', 'github_subscription']
+  ARRAY['delegate_workflow', 'delegate_agent', 'delegate_multi_agents', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'codex', 'claude_code', 'lean_diagnostics', 'lean_inspect', 'lean_loogle', 'lean_file', 'lean_project', 'github_subscription']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -1276,7 +1276,7 @@ function seedWorkflowTimeline(): void {
       executionId,
       agentName: 'repositoryAudit',
       childStreamId,
-      toolName: 'delegate_workflow_script',
+      toolName: 'delegate_multi_agents',
     },
   ]);
   emitChildEventOrderEdge(childStreamId, STREAM_ID);
@@ -1389,7 +1389,7 @@ function seedRunningWorkflow(): void {
       executionId,
       agentName: 'live-workflow-validation',
       childStreamId,
-      toolName: 'delegate_workflow_script',
+      toolName: 'delegate_multi_agents',
     },
   ]);
   emitChildEventOrderEdge(childStreamId, STREAM_ID);

--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -982,7 +982,7 @@ description: Exercise workflow-script dispatch from the headless CLI.
 settings:
   agentCategory: toolUse
   tools:
-    - delegate_workflow_script
+    - delegate_multi_agents
 
 prompts:
   systemPrompt: |

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -12,7 +12,7 @@ import { Box, Static, Text } from 'ink';
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import { COLOR_HINT } from '@cli/tui/ui/colors';
 import type { StreamTabId } from '@shared/schemas';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { groupBy } from '@utils/core';
 import { safeHomedir } from '@utils/system/platformPaths';
@@ -102,8 +102,8 @@ export function sessionHeaderIdentityLine(
       streams: context.streams,
     });
     const streamKind =
-      view.toolName === DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME
-        ? 'workflow script'
+      view.toolName === DELEGATE_MULTI_AGENTS_TOOL_NAME
+        ? 'multi-agent workflow'
         : 'subagent';
     return `${streamKind}: ${view.label} · parent: ${view.parentLabel} · model: ${model}`;
   }

--- a/packages/extension/resources/docs/agent-creation/tool_catalog.md
+++ b/packages/extension/resources/docs/agent-creation/tool_catalog.md
@@ -58,7 +58,7 @@ recommended groups at the bottom are a good starting point.
 - `delegate_workflow` — delegate to a workflow agent for whole-document
   operations. Pass `agent`, `model`, `instruction`, `inputFiles`. Returns
   asynchronously via the follow-up queue.
-- `delegate_workflow_script` — advanced opt-in tool for a durable sequence of
+- `delegate_multi_agents` — advanced opt-in tool for a durable sequence of
   workflow-agent calls with predetermined branching and fan-out. Pass a default
   `agent` and exactly one of the complete `script` source or an existing
   `scriptPath`. Submitted source is saved as an
@@ -126,7 +126,7 @@ zotero_export`
 **Orchestrator agent:**
 `bash, read_file, write_file, glob, grep, delegate_workflow,
 delegate_agent, executions, accept_run_files, todo_write`, optionally
-`delegate_workflow_script` for pipelines with a predetermined fan-out/join
+`delegate_multi_agents` for pipelines with a predetermined fan-out/join
 structure (off by default — see above).
 
 **Computation agent:**

--- a/packages/extension/resources/tool_use_agents/engineer.yaml
+++ b/packages/extension/resources/tool_use_agents/engineer.yaml
@@ -7,9 +7,9 @@ settings:
   tools:
     - delegate_agent
     - delegate_workflow
-    # Advanced deterministic delegation. The global Workflow Script switch is
-    # an additional kill switch and is disabled by default.
-    - delegate_workflow_script
+    # Advanced deterministic delegation. The global Multi-Agent Workflow
+    # switch is an additional kill switch and is disabled by default.
+    - delegate_multi_agents
     - executions
     - accept_run_files
     - plan

--- a/packages/extension/src/progressView/frontend/formatters/constants.ts
+++ b/packages/extension/src/progressView/frontend/formatters/constants.ts
@@ -180,7 +180,7 @@ export const TOOL_ICON_MAP: Record<string, TeXRAIconName> = {
 
   // Workflow/delegation
   delegate_workflow: 'list-ul',
-  delegate_workflow_script: 'list-ul',
+  delegate_multi_agents: 'list-ul',
   delegate_agent: 'circle-user',
 
   // Execution history

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -17,7 +17,7 @@ import { html, nothing, type TemplateResult } from 'lit';
 import type { LogMessageData } from '@shared/schemas';
 import { normalizeToolUseData } from '@shared/toolUse';
 import {
-  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  DELEGATE_MULTI_AGENTS_TOOL_NAME,
   DELEGATION_TOOL_CATEGORY,
 } from '@shared/constants/delegationTools';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
@@ -149,7 +149,7 @@ export function formatToolUseTemplate(
   if (
     outputText &&
     !isOutputInTitle &&
-    toolName !== DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME &&
+    toolName !== DELEGATE_MULTI_AGENTS_TOOL_NAME &&
     !isMcpToolName(toolName) &&
     displayKind !== 'read' &&
     !isTrivialWriteOutput

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -37,7 +37,7 @@ import { EXECUTIONS_DEFAULT_ACTION } from '@shared/tools/executionsDisplay';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import {
-  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  DELEGATE_MULTI_AGENTS_TOOL_NAME,
   DELEGATION_TOOLS,
 } from '@shared/constants/delegationTools';
 import {
@@ -442,7 +442,7 @@ function buildWorkflowScriptSections(
     return [
       buildToolUseSection(
         'Input:',
-        wrapInPre('Workflow script input is unavailable.'),
+        wrapInPre('Multi-agent workflow input is unavailable.'),
       ),
     ];
   }
@@ -642,7 +642,7 @@ const TOOL_SECTION_BUILDERS: Array<{
     build: buildAcceptRunFilesSections,
   },
   {
-    match: (ctx) => ctx.toolName === DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+    match: (ctx) => ctx.toolName === DELEGATE_MULTI_AGENTS_TOOL_NAME,
     build: buildWorkflowScriptSections,
   },
   {

--- a/prompts/agents/remote/Lean4/leanOrchestrator.yaml
+++ b/prompts/agents/remote/Lean4/leanOrchestrator.yaml
@@ -7,9 +7,9 @@ settings:
     # Delegation
     - delegate_workflow
     - delegate_agent
-    # Advanced deterministic delegation. The global Workflow Script switch is
-    # an additional kill switch and is disabled by default.
-    - delegate_workflow_script
+    # Advanced deterministic delegation. The global Multi-Agent Workflow
+    # switch is an additional kill switch and is disabled by default.
+    - delegate_multi_agents
     - executions
     - accept_run_files
     # Project management

--- a/prompts/agents/remote/orchestrator.yaml
+++ b/prompts/agents/remote/orchestrator.yaml
@@ -8,12 +8,12 @@ settings:
     - delegate_agent
     - executions
     - accept_run_files
-    # Workflow script — advanced delegation for a pipeline whose fan-out and
+    # Multi-agent workflow — advanced delegation for a pipeline whose fan-out and
     # join structure is known in advance (see the tool description). Opt-in
-    # and disabled by default; enable in Dashboard → Tools ("Workflow
-    # Script"). When disabled by the user, resolveAgentTools() strips this
+    # and disabled by default; enable in Dashboard → Tools ("Multi-Agent
+    # Workflow"). When disabled by the user, resolveAgentTools() strips this
     # from the model's tool list, same as github_subscription below.
-    - delegate_workflow_script
+    - delegate_multi_agents
     - todo_write
     - plan
     - read_file

--- a/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
@@ -16,7 +16,7 @@ import {
 import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
 import { buildUserVarPassthrough } from '@agent/utils/userVars';
 import * as logger from '@logger/logUtils';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import { AbsoluteFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { isNonEmptyString } from '@utils/text/stringUtils';
@@ -133,7 +133,7 @@ export const TOOL_GROUPS: Record<string, ToolGroup> = {
     description: 'Delegate tasks to other agents and manage executions',
     tools: [
       'delegate_workflow',
-      DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+      DELEGATE_MULTI_AGENTS_TOOL_NAME,
       'delegate_agent',
       'executions',
       'accept_run_files',

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -163,9 +163,9 @@ export class ModelHandlerValidation extends ModelHandler<
             mathematicalValidationOutput(options.messages),
           ),
         ];
-      } else if (!hasToolResult && toolNames.has('delegate_workflow_script')) {
+      } else if (!hasToolResult && toolNames.has('delegate_multi_agents')) {
         toolCalls = [
-          validationToolCall('delegate_workflow_script', {
+          validationToolCall('delegate_multi_agents', {
             agent: 'correct',
             script: WORKFLOW_SCRIPT_VALIDATION_SOURCE,
           }),

--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -162,7 +162,7 @@ return await parallel(
 
 ## Production integration
 
-The opt-in `delegate_workflow_script` tool composes the production in-band
+The opt-in `delegate_multi_agents` tool composes the production in-band
 subagent runner, durable checkpoint store, task-run file hand-off, progress
 projection, parent cancellation, and completed-journal cost settlement. It
 accepts exactly one of newly submitted `script` source or an existing
@@ -174,9 +174,9 @@ to one internal representation. It ships in the built-in `orchestrator`
 agent's tool list
 (`prompts/agents/remote/orchestrator.yaml`); explicitly naming the tool in an
 agent's configuration is one half of the consent boundary for automated
-workflow fan-out. The other half is global: the "Workflow Script" toggle in
+workflow fan-out. The other half is global: the "Multi-Agent Workflow" toggle in
 the Tools dashboard (`src/tools/externalToolDefs.ts`, id `workflow-script`)
-strips `delegate_workflow_script` from every agent's resolved tools when
+strips `delegate_multi_agents` from every agent's resolved tools when
 switched off, regardless of what any individual agent configuration names —
 and new installs start with the switch off.
 

--- a/src/shared/constants/delegationTools.ts
+++ b/src/shared/constants/delegationTools.ts
@@ -1,11 +1,10 @@
 import { AgentCategory } from '../schemas/agent';
 
-export const DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME =
-  'delegate_workflow_script' as const;
+export const DELEGATE_MULTI_AGENTS_TOOL_NAME = 'delegate_multi_agents' as const;
 
 const CANONICAL_DELEGATION_TOOL_NAMES = [
   'delegate_workflow',
-  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  DELEGATE_MULTI_AGENTS_TOOL_NAME,
   'delegate_agent',
 ] as const;
 
@@ -39,7 +38,7 @@ export const DELEGATION_AVAILABILITY_CATEGORY: Readonly<
   Record<string, AgentCategory>
 > = {
   ...DELEGATION_TOOL_CATEGORY,
-  [DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME]: AgentCategory.Workflow,
+  [DELEGATE_MULTI_AGENTS_TOOL_NAME]: AgentCategory.Workflow,
 };
 
 /** True when any of the given tool names is a delegation tool. */

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -238,7 +238,7 @@ export function workflowScriptDeliverySummary(xml: string): string | undefined {
       : []),
     ...fileLines,
     `  script: ${summary.scriptPath}`,
-    `  rerun: edit the script, then call delegate_workflow_script with scriptPath`,
+    `  rerun: edit the script, then call delegate_multi_agents with scriptPath`,
   ].join('\n');
 }
 

--- a/src/shared/tools/toolDisplayName.ts
+++ b/src/shared/tools/toolDisplayName.ts
@@ -19,7 +19,7 @@
 /** Friendly labels for tool names that shouldn't be shown verbatim, keyed by
  *  normalized name. */
 const TOOL_LABEL = new Map<string, string>([
-  ['delegate_workflow_script', 'Workflow script'],
+  ['delegate_multi_agents', 'Multi-agent workflow'],
   ['codex_patch', 'Codex Files'],
   ['codex_thread', 'Codex Thread'],
   ['codex_todo', 'Codex Plan'],

--- a/src/shared/utils/icons.ts
+++ b/src/shared/utils/icons.ts
@@ -96,7 +96,7 @@ export const AGENT_DECORATORS = {
     toolUse: { icon: 'screwdriver-wrench', label: 'Tool Use' },
   },
   streamKinds: {
-    workflowScript: { icon: 'list-ul', label: 'Workflow Script' },
+    workflowScript: { icon: 'list-ul', label: 'Multi-Agent Workflow' },
   },
 } as const;
 

--- a/src/test-kernel/agent/AgentPromptContracts.vitest.mts
+++ b/src/test-kernel/agent/AgentPromptContracts.vitest.mts
@@ -81,8 +81,8 @@ describe('engineer agent prompt', () => {
   });
 
   it('can run deterministic workflow scripts when globally enabled', () => {
-    expect(agent.settings.tools).toContain('delegate_workflow_script');
-    expect(systemPrompt).not.toContain('delegate_workflow_script');
+    expect(agent.settings.tools).toContain('delegate_multi_agents');
+    expect(systemPrompt).not.toContain('delegate_multi_agents');
   });
 
   it('grounds its delegation targets in the live Available agents roster', () => {
@@ -123,10 +123,8 @@ describe('Lean orchestrator agent prompt', () => {
   );
 
   it('can run deterministic workflow scripts when globally enabled', () => {
-    expect(agent.settings.tools).toContain('delegate_workflow_script');
-    expect(agent.prompts.systemPrompt).not.toContain(
-      'delegate_workflow_script',
-    );
+    expect(agent.settings.tools).toContain('delegate_multi_agents');
+    expect(agent.prompts.systemPrompt).not.toContain('delegate_multi_agents');
   });
 });
 

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -15,7 +15,7 @@ import {
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,
@@ -245,7 +245,7 @@ describe('child stream progress events', () => {
         agentName: 'draft-sections',
         description: 'Run a named child task',
         config,
-        toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+        toolName: DELEGATE_MULTI_AGENTS_TOOL_NAME,
       }),
     );
     await withSessionEventRecording(() => firstRun.finalize());
@@ -264,7 +264,7 @@ describe('child stream progress events', () => {
         agentName: 'draft-sections',
         description: 'Resume the named child task',
         config,
-        toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+        toolName: DELEGATE_MULTI_AGENTS_TOOL_NAME,
       },
     );
 
@@ -309,7 +309,7 @@ describe('child stream progress events', () => {
       agentName: 'retry-setup',
       description: 'Retry a failed child stream setup',
       config,
-      toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+      toolName: DELEGATE_MULTI_AGENTS_TOOL_NAME,
     };
 
     try {
@@ -366,7 +366,7 @@ describe('child stream progress events', () => {
           agentName: 'repo-cleanup-readonly-pilot-2026-07-24',
           description: 'Audit the repository without editing',
           config: workerConfig,
-          toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+          toolName: DELEGATE_MULTI_AGENTS_TOOL_NAME,
         },
       );
 

--- a/src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts
@@ -165,7 +165,7 @@ describe('tool-use tool resolution', () => {
       const registry = getDefaultToolRegistry();
 
       const { tools } = await resolveAgentTools({
-        tools: toolDefs(['bash', 'delegate_workflow_script']),
+        tools: toolDefs(['bash', 'delegate_multi_agents']),
         registry,
         logger,
         toolInjections,

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -780,7 +780,7 @@ describe('toGoogleTools', () => {
       'arxiv_metadata',
       'crossref_search',
       'diagnostics',
-      'delegate_workflow_script',
+      'delegate_multi_agents',
     ]);
 
     expect(reviewTools).toHaveLength(17);
@@ -804,8 +804,8 @@ describe('toGoogleTools', () => {
     }
   });
 
-  it('converts the registered workflow script JSON args for both Google APIs', () => {
-    const [definition] = resolveToolDefinitions(['delegate_workflow_script']);
+  it('converts delegate_multi_agents JSON args for both Google APIs', () => {
+    const [definition] = resolveToolDefinitions(['delegate_multi_agents']);
     const interactionSchema = convertGoogleToolSchema(definition) as {
       properties: Record<string, Record<string, unknown>>;
     };

--- a/src/test-kernel/architecture/toolRegistryCycle.vitest.ts
+++ b/src/test-kernel/architecture/toolRegistryCycle.vitest.ts
@@ -40,7 +40,7 @@ const TOOL_REGISTRY = 'src/tools/registry.ts';
  */
 const AGENT_LAUNCHING_TOOLS = [
   'src/tools/delegation/DelegationTools.ts',
-  'src/tools/delegation/WorkflowScriptTool.ts',
+  'src/tools/delegation/DelegateMultiAgentsTool.ts',
 ] as const;
 
 /** Domain subsystems no generic tool should have to install. */

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -286,7 +286,7 @@ describe('summarizeSubagentFollowup', () => {
         '  paper_A.tex (+120 -80)',
         '  notes.txt',
         '  script: .texra/workflow-scripts/proofread-pipeline.mjs',
-        '  rerun: edit the script, then call delegate_workflow_script with scriptPath',
+        '  rerun: edit the script, then call delegate_multi_agents with scriptPath',
       ].join('\n'),
     );
   });

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
@@ -1,4 +1,4 @@
-// A detached delegate_workflow_script run owns a child stream. Its phases and
+// A detached delegate_multi_agents run owns a child stream. Its phases and
 // typed task records render through the focused-child viewport, while the
 // workflow-specific header identifies the kind of child execution.
 
@@ -40,7 +40,7 @@ import {
   TOOL_USE_STATUS,
   type StreamTabId,
 } from '@shared/schemas';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
 import { clearAllStreamStatusesForTest } from '@test/support/streamStatusTestUtils';
 import { loadInk } from '@test/support/inkTestHarness.mts';
@@ -983,7 +983,7 @@ describe('CLI workflow-script child-stream transcript', () => {
               agentName: 'draft-sections',
               executionId: 'exec-1',
               kind: 'subagent' as const,
-              toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+              toolName: DELEGATE_MULTI_AGENTS_TOOL_NAME,
             },
           },
         ],
@@ -992,7 +992,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     });
     expect(staticItems.at(0)).toMatchObject({
       identityLine:
-        'workflow script: draft-sections · parent: main · model: deepseekT',
+        'multi-agent workflow: draft-sections · parent: main · model: deepseekT',
       kind: 'header',
     });
 

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -1153,7 +1153,8 @@ describe('ProgressBackend', () => {
         agent: 'generic',
         model: 'gpt-5.6-sol',
         agentCategory: AgentCategory.Workflow,
-        instruction: "Workflow script 'repo-cleanup-readonly-pilot-2026-07-24'",
+        instruction:
+          "Multi-agent workflow 'repo-cleanup-readonly-pilot-2026-07-24'",
       }),
     );
 
@@ -1161,7 +1162,8 @@ describe('ProgressBackend', () => {
       expect(backend.state.getStreamMetadata(stream).run).toEqual({
         kind: 'workflowScript',
         workflowName: 'repo-cleanup-readonly-pilot-2026-07-24',
-        instruction: "Workflow script 'repo-cleanup-readonly-pilot-2026-07-24'",
+        instruction:
+          "Multi-agent workflow 'repo-cleanup-readonly-pilot-2026-07-24'",
       }),
     );
     const workflowInfos = buildStreamInfos(backend.state);

--- a/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.mts
+++ b/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.mts
@@ -163,6 +163,6 @@ describe('stream-tab expand chevron', () => {
       tab?.shadowRoot
         ?.querySelector('wa-tooltip[for="stream-tab-kind"]')
         ?.textContent?.trim(),
-    ).toBe('Workflow Script');
+    ).toBe('Multi-Agent Workflow');
   });
 });

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -463,7 +463,7 @@ describe('task-group-list status icon (#7993 step 3)', () => {
   });
 });
 
-// #8722 Phase 2b: a focused delegate_workflow_script run projects its phases
+// #8722 Phase 2b: a focused delegate_multi_agents run projects its phases
 // as `kind: 'phase'` groups with per-agent Running/Finished/Failed lines
 // beneath. The phase header and call cards are both derived from typed state;
 // the renderer does not parse status prefixes from prose.

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -82,7 +82,7 @@ const papers = await parallel(
 );
 return { papers, question: args.question };`;
     const message = toolUseMessage('workflow-script', {
-      toolName: 'delegate_workflow_script',
+      toolName: 'delegate_multi_agents',
       input: {
         agent: 'research',
         script,
@@ -99,7 +99,7 @@ return { papers, question: args.question };`;
       output: {
         status: 'executed',
         summary:
-          "Completed workflow script 'Literature synthesis' (2 agent calls)",
+          "Completed multi-agent workflow 'Literature synthesis' (2 agent calls)",
         output: JSON.stringify({ compared: 2 }),
       },
     });
@@ -142,7 +142,7 @@ return { papers, question: args.question };`;
 
   it('shows explicit null workflow-script arguments as JSON', () => {
     const message = toolUseMessage('workflow-script-null-args', {
-      toolName: 'delegate_workflow_script',
+      toolName: 'delegate_multi_agents',
       input: {
         agent: 'research',
         script: 'export const meta = { name: "One call" };\nreturn null;',

--- a/src/test-kernel/shared/DelegationTools.vitest.ts
+++ b/src/test-kernel/shared/DelegationTools.vitest.ts
@@ -15,7 +15,7 @@ it('keeps canonical delegation tool names registered', () => {
 it('contains the canonical delegation tool names', () => {
   expect([...DELEGATION_TOOLS]).toEqual([
     'delegate_workflow',
-    'delegate_workflow_script',
+    'delegate_multi_agents',
     'delegate_agent',
   ]);
 });

--- a/src/test-kernel/shared/ToolDisplayName.vitest.ts
+++ b/src/test-kernel/shared/ToolDisplayName.vitest.ts
@@ -27,7 +27,9 @@ describe('displayToolName', () => {
   });
 
   it('applies friendly labels after stripping the namespace', () => {
-    expect(displayToolName('delegate_workflow_script')).toBe('Workflow script');
+    expect(displayToolName('delegate_multi_agents')).toBe(
+      'Multi-agent workflow',
+    );
     expect(displayToolName('codex:codex_turn')).toBe('Codex Turn');
   });
 

--- a/src/test-kernel/tools/DelegateMultiAgentsTool.vitest.ts
+++ b/src/test-kernel/tools/DelegateMultiAgentsTool.vitest.ts
@@ -76,7 +76,7 @@ vi.mock('@tools/delegation/proposalFlow', async (importOriginal) => ({
   selectAvailableDelegationModel: mocks.selectAvailableDelegationModel,
 }));
 
-import { WorkflowScriptTool } from '@tools/delegation/WorkflowScriptTool';
+import { DelegateMultiAgentsTool } from '@tools/delegation/DelegateMultiAgentsTool';
 import { getDefaultToolRegistry } from '@tools/registry';
 
 const executionId = '7154scripttool' as ExecutionId;
@@ -151,7 +151,7 @@ async function callToolInput(
         trace: new TraceEmitter(),
         hooks: { recordSubagentCost: vi.fn() },
       },
-      () => new WorkflowScriptTool().call(input),
+      () => new DelegateMultiAgentsTool().call(input),
     ),
   );
 }
@@ -196,14 +196,14 @@ beforeEach(async () => {
   );
 });
 
-describe('WorkflowScriptTool', () => {
+describe('DelegateMultiAgentsTool', () => {
   it('is registered and classified without becoming a proposal tool', () => {
-    expect(getDefaultToolRegistry().has('delegate_workflow_script')).toBe(true);
-    expect(DELEGATION_TOOLS.has('delegate_workflow_script')).toBe(true);
-    expect(DELEGATION_AVAILABILITY_CATEGORY.delegate_workflow_script).toBe(
+    expect(getDefaultToolRegistry().has('delegate_multi_agents')).toBe(true);
+    expect(DELEGATION_TOOLS.has('delegate_multi_agents')).toBe(true);
+    expect(DELEGATION_AVAILABILITY_CATEGORY.delegate_multi_agents).toBe(
       'workflow',
     );
-    expect(DELEGATION_TOOL_CATEGORY.delegate_workflow_script).toBeUndefined();
+    expect(DELEGATION_TOOL_CATEGORY.delegate_multi_agents).toBeUndefined();
   });
 
   it('owns a detached run completion rejection without delivering a second error', async () => {
@@ -216,11 +216,11 @@ describe('WorkflowScriptTool', () => {
 
     expect(result).toMatchObject({
       status: 'executed',
-      summary: "Launched workflow script 'tool-test' (async)",
+      summary: "Launched multi-agent workflow 'tool-test' (async)",
     });
     await vi.waitFor(() => {
       expect(mocks.childLoggerError).toHaveBeenCalledWith(
-        "Workflow script 'tool-test' run loop failed after launch",
+        "Multi-agent workflow 'tool-test' run loop failed after launch",
         { data: lateFailure },
       );
     });
@@ -230,7 +230,7 @@ describe('WorkflowScriptTool', () => {
   });
 
   it('declares the task-plan contract at the model-facing boundary', () => {
-    const definition = new WorkflowScriptTool().definition;
+    const definition = new DelegateMultiAgentsTool().definition;
     const description = definition.description;
     const providerSchema = convertToolSchema(definition);
     const providerProperties = providerSchema?.properties as
@@ -252,6 +252,12 @@ describe('WorkflowScriptTool', () => {
     );
     expect(providerProperties?.scriptPath?.description).toContain(
       'Provide exactly one of script or scriptPath',
+    );
+    expect(description).toContain(
+      'Use `delegate_multi_agents` only when the complete fan-out, pipeline, and join structure is known before execution and should resume safely after interruption.',
+    );
+    expect(description).toContain(
+      'Keep using `delegate_agent` one call at a time when a later decision depends on reviewing an earlier result.',
     );
     expect(description).toContain(
       'declare meta.tasks as { id, label, phase? } records',
@@ -294,7 +300,7 @@ describe('WorkflowScriptTool', () => {
   });
 
   it('rejects invalid JSON arguments at the schema boundary', async () => {
-    const result = await new WorkflowScriptTool().call({
+    const result = await new DelegateMultiAgentsTool().call({
       agent: 'correct',
       script,
       scriptPath: null,
@@ -307,7 +313,7 @@ describe('WorkflowScriptTool', () => {
   });
 
   it('requires a launched tool context', async () => {
-    const outside = await new WorkflowScriptTool().call({
+    const outside = await new DelegateMultiAgentsTool().call({
       agent: 'correct',
       script,
       scriptPath: null,
@@ -365,7 +371,7 @@ describe('WorkflowScriptTool', () => {
       agentName: 'tool-test',
     });
     expect(loopParams.strategy).toMatchObject({
-      stageLabel: "Workflow script 'tool-test'",
+      stageLabel: "Multi-agent workflow 'tool-test'",
       launch: expect.any(Function),
       isTerminal: expect.any(Function),
     });
@@ -377,7 +383,7 @@ describe('WorkflowScriptTool', () => {
 
     expect(result).toMatchObject({
       status: 'executed',
-      summary: "Launched workflow script 'tool-test' (async)",
+      summary: "Launched multi-agent workflow 'tool-test' (async)",
     });
     expect(result.output).toContain(`Execution ID: ${runExecutionId}`);
     expect(result.output).toContain(
@@ -426,7 +432,7 @@ describe('WorkflowScriptTool', () => {
 
     expect(result).toMatchObject({
       status: 'executed',
-      summary: "Launched workflow script 'edited-tool-test' (async)",
+      summary: "Launched multi-agent workflow 'edited-tool-test' (async)",
     });
     expect(result.output).toContain(`Script file: ${scriptPath}`);
     expect(mocks.registerExecution).toHaveBeenCalledWith(
@@ -484,7 +490,7 @@ describe('WorkflowScriptTool', () => {
         scriptPath: '.texra/workflow-scripts/stale.mjs',
       },
     ]) {
-      const result = await new WorkflowScriptTool().call(input);
+      const result = await new DelegateMultiAgentsTool().call(input);
       expect(result).toMatchObject({
         status: 'error',
         diagnostics: { type: 'validation_error' },
@@ -531,7 +537,7 @@ describe('WorkflowScriptTool', () => {
     expect(loopParams.strategy.resolveDeliveryTarget).toBeUndefined();
     expect(result).toMatchObject({
       status: 'executed',
-      summary: "Completed workflow script 'tool-test'",
+      summary: "Completed multi-agent workflow 'tool-test'",
       output: expect.stringContaining(
         '<workflow-script-result>solved</workflow-script-result>',
       ),
@@ -555,7 +561,7 @@ describe('WorkflowScriptTool', () => {
 
     expect(result).toMatchObject({
       status: 'error',
-      summary: "Workflow script 'tool-test' failed",
+      summary: "Multi-agent workflow 'tool-test' failed",
       error: expect.stringContaining(
         '<workflow-script-error>broken</workflow-script-error>',
       ),
@@ -585,7 +591,7 @@ describe('WorkflowScriptTool', () => {
     expect(result).toMatchObject({
       status: 'error',
       error: expect.stringContaining(
-        "Workflow script 'interrupted-resume' completed without a persisted report.",
+        "Multi-agent workflow 'interrupted-resume' completed without a persisted report.",
       ),
     });
     expect(result.error).not.toContain('stale success from the prior attempt');
@@ -755,7 +761,7 @@ describe('WorkflowScriptTool', () => {
 
     expect(result).toMatchObject({
       status: 'executed',
-      summary: "Workflow script 'tool-test' is already running",
+      summary: "Multi-agent workflow 'tool-test' is already running",
     });
     expect(result.output).toContain(`Execution ID: ${runExecutionId}`);
     // A relaunch over a live run never starts a second competing loop.

--- a/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
@@ -104,7 +104,7 @@ describe('createWorkflowScriptStrategy', () => {
     );
     expect(strategy.isTerminal({} as never)).toBe(true);
     expect(strategy.runTurn).toBeUndefined();
-    expect(strategy.stageLabel).toBe("Workflow script 'strategy-test'");
+    expect(strategy.stageLabel).toBe("Multi-agent workflow 'strategy-test'");
   });
 
   it('uses persist-only delivery when the headless caller owns the report', () => {

--- a/src/test-kernel/tools/externalToolDefs.vitest.ts
+++ b/src/test-kernel/tools/externalToolDefs.vitest.ts
@@ -27,13 +27,17 @@ describe('external tool definitions', () => {
     ]);
   });
 
-  it('keeps the workflow script tool as a user-toggleable, always-available group', async () => {
-    const workflowScript = findExternalToolDef('workflow-script');
+  it('keeps multi-agent workflows user-toggleable and always available', async () => {
+    const multiAgentWorkflow = findExternalToolDef('workflow-script');
 
-    assert.ok(workflowScript, 'Workflow script tool definition should exist');
-    assert.strictEqual(workflowScript.toggleable, true);
-    assert.deepStrictEqual(workflowScript.tools, ['delegate_workflow_script']);
-    assert.strictEqual(await workflowScript.check(), true);
+    assert.ok(
+      multiAgentWorkflow,
+      'Multi-agent workflow tool definition should exist',
+    );
+    assert.strictEqual(multiAgentWorkflow.name, 'Multi-Agent Workflow');
+    assert.strictEqual(multiAgentWorkflow.toggleable, true);
+    assert.deepStrictEqual(multiAgentWorkflow.tools, ['delegate_multi_agents']);
+    assert.strictEqual(await multiAgentWorkflow.check(), true);
   });
 
   it('shows TeXRA CLI as a detected but inactive integration', () => {

--- a/src/tools/delegation/DelegateMultiAgentsTool.ts
+++ b/src/tools/delegation/DelegateMultiAgentsTool.ts
@@ -26,7 +26,7 @@ import {
 } from '@shared/schemas';
 import { WorkflowScriptFilesSchema } from '@shared/schemas/workflowScriptFiles';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import { configureDelegatedChildApprovals } from '@tools/approval';
 import {
   assertWritable,
@@ -56,7 +56,7 @@ import {
 } from './proposalFlow';
 import { assertWorkflowFilesExist } from './workflowFileValidation';
 
-const WorkflowScriptToolInputSchema = z
+const DelegateMultiAgentsToolInputSchema = z
   .strictObject({
     agent: z
       .string()
@@ -101,7 +101,9 @@ const WorkflowScriptToolInputSchema = z
     }
   });
 
-type WorkflowScriptToolInput = z.infer<typeof WorkflowScriptToolInputSchema>;
+type DelegateMultiAgentsToolInput = z.infer<
+  typeof DelegateMultiAgentsToolInputSchema
+>;
 
 const STREAM_PREFIX = 'workflow-script';
 const WORKFLOW_SCRIPT_DIRECTORY = '.texra/workflow-scripts';
@@ -175,15 +177,15 @@ function withScriptReference(
 
 /**
  * Execute a durable, deterministic workflow script from an agent whose tool
- * list names it. Gated by the "Workflow Script" dashboard switch (id
+ * list names it. Gated by the "Multi-Agent Workflow" dashboard switch (id
  * `workflow-script` in {@link @tools/externalToolDefs}), which
  * `resolveAgentTools()` enforces regardless of any agent's configured tools —
  * new installs start with the switch off.
  */
-export class WorkflowScriptTool extends defineTool({
-  name: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+export class DelegateMultiAgentsTool extends defineTool({
+  name: DELEGATE_MULTI_AGENTS_TOOL_NAME,
   slow: true,
-  description: `Run a deterministic JavaScript workflow that coordinates workflow agents. Workflow agents edit or produce FILES: each agent() call resolves to a result envelope { category: 'workflow', outcome, outputs, diffs, compileFailures, cost } listing the files it produced, never prose. Use this only when the complete fan-out, pipeline, and join structure is known before execution and should resume safely after interruption. Keep using delegate_agent one call at a time when a later decision depends on reviewing an earlier result.
+  description: `Run a deterministic JavaScript workflow that coordinates workflow agents. Workflow agents edit or produce FILES: each agent() call resolves to a result envelope { category: 'workflow', outcome, outputs, diffs, compileFailures, cost } listing the files it produced, never prose. Use \`delegate_multi_agents\` only when the complete fan-out, pipeline, and join structure is known before execution and should resume safely after interruption. Keep using \`delegate_agent\` one call at a time when a later decision depends on reviewing an earlier result.
 
 Script input: every source submission is saved immediately as a unique, non-overwriting draft under .texra/workflow-scripts/. Every result returns that editable path; on an error, edit the file and retry with scriptPath instead of rewriting the source.
 
@@ -227,13 +229,15 @@ return await agent('Merge the corrected drafts.', {
 })
 
 Durability: the journal is keyed by meta.name within this session. If the run times out or is interrupted, call this tool again with the SAME meta.name: completed agent() calls replay for free (the script may be revised; only changed or unfinished calls execute). Use a new meta.name to start over. The default whole-run wall clock is 10 minutes; set meta.timeoutMs (1s to 60min) for longer runs.`,
-  schema: WorkflowScriptToolInputSchema,
+  schema: DelegateMultiAgentsToolInputSchema,
 }) {
-  protected async execute(input: WorkflowScriptToolInput): Promise<ToolResult> {
+  protected async execute(
+    input: DelegateMultiAgentsToolInput,
+  ): Promise<ToolResult> {
     const contexts = getCurrentToolContexts();
     if (contexts?.runContext?.kind !== 'launch') {
       throw new Error(
-        'delegate_workflow_script requires an active launched agent session.',
+        'delegate_multi_agents requires an active launched agent session.',
       );
     }
     const { runContext: parent, callContext } = contexts;
@@ -355,7 +359,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
       agentSource: defaultAgent.source,
       agentCategory: AgentCategory.Workflow,
       model: runModel,
-      instruction: `Workflow script '${meta.name}'`,
+      instruction: `Multi-agent workflow '${meta.name}'`,
       inputFiles: [...files.inputFiles],
       contextFiles: [...files.contextFiles],
       mediaFiles: [...files.mediaFiles],
@@ -382,9 +386,9 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
         return withScriptReference(
           {
             status: 'executed',
-            summary: `Workflow script '${meta.name}' is already running`,
+            summary: `Multi-agent workflow '${meta.name}' is already running`,
             output: [
-              `A workflow script run for meta.name '${meta.name}' is already in progress (or finishing); its result arrives as a follow-up. Do not launch a competing run — wait for it, then resume with the same meta.name if it did not complete.`,
+              `A multi-agent workflow run for meta.name '${meta.name}' is already in progress (or finishing); its result arrives as a follow-up. Do not launch a competing run — wait for it, then resume with the same meta.name if it did not complete.`,
               `Execution ID: ${runExecutionId}`,
               `To check progress or collect the result: executions tool with path=/executions/${runExecutionId} and action=wait (returns immediately if it already finished).`,
             ].join('\n'),
@@ -394,7 +398,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
       }
       throw workflowScriptToolError(
         new ToolError(
-          `Failed to launch workflow script '${meta.name}': ${toErrorMessage(error)}`,
+          `Failed to launch multi-agent workflow '${meta.name}': ${toErrorMessage(error)}`,
         ),
         scriptPath,
       );
@@ -428,7 +432,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
             agentName: meta.name,
             description: meta.description,
             config: runConfig,
-            toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+            toolName: DELEGATE_MULTI_AGENTS_TOOL_NAME,
           },
         );
         runChildStreamId = childStream.childStreamId;
@@ -479,7 +483,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
           // its one user-facing result/error delivery.
           void runCompletion.catch((error: unknown) => {
             childStream.logger.error(
-              `Workflow script '${meta.name}' run loop failed after launch`,
+              `Multi-agent workflow '${meta.name}' run loop failed after launch`,
               { data: error },
             );
           });
@@ -499,17 +503,17 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
         ]);
         if (!report) {
           throw new Error(
-            `Workflow script '${meta.name}' completed without a persisted report.`,
+            `Multi-agent workflow '${meta.name}' completed without a persisted report.`,
           );
         }
         if (runMeta?.terminalStatus !== EXECUTION_STATUS.COMPLETED) {
           return errorResult(report, {
-            summary: `Workflow script '${meta.name}' failed`,
+            summary: `Multi-agent workflow '${meta.name}' failed`,
           });
         }
         return {
           status: 'executed',
-          summary: `Completed workflow script '${meta.name}'`,
+          summary: `Completed multi-agent workflow '${meta.name}'`,
           output: report,
         } satisfies ToolResult;
       }
@@ -517,9 +521,9 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
       return withScriptReference(
         {
           status: 'executed',
-          summary: `Launched workflow script '${meta.name}' (async)`,
+          summary: `Launched multi-agent workflow '${meta.name}' (async)`,
           output: [
-            `Workflow script '${meta.name}' launched. Its result and run log will be delivered automatically as a follow-up message when the run completes.`,
+            `Multi-agent workflow '${meta.name}' launched. Its result and run log will be delivered automatically as a follow-up message when the run completes.`,
             `Execution ID: ${runExecutionId}`,
             `Stream tab: ${runChildStreamId}`,
             `The result arrives automatically — continue other work meanwhile. To check progress: executions tool with path=/executions/${runExecutionId}; use action=wait only when you cannot proceed without it.`,

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -30,7 +30,7 @@ import type {
 } from '@agent/runtime/workflowControlRegistry';
 import type { ExecutionId } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import type { WorkflowScriptFiles } from '@shared/schemas/workflowScriptFiles';
 import { truncateSummary } from '@utils/text/stringUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -54,7 +54,7 @@ const RUN_LOG_MAX_LINE_LENGTH = 500;
 export function formatWorkflowScriptReference(scriptPath: string): string {
   return [
     `Script file: ${scriptPath}`,
-    `To revise and rerun it, edit that file and call ${DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME} with scriptPath: '${scriptPath}'.`,
+    `To revise and rerun it, edit that file and call ${DELEGATE_MULTI_AGENTS_TOOL_NAME} with scriptPath: '${scriptPath}'.`,
   ].join('\n');
 }
 
@@ -150,7 +150,7 @@ export function createWorkflowScriptStrategy(
   );
 
   return {
-    stageLabel: `Workflow script '${params.name}'`,
+    stageLabel: `Multi-agent workflow '${params.name}'`,
     ...(params.deliveryMode && { deliveryMode: params.deliveryMode }),
 
     launch: async (ports, abortController) => {

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -17,7 +17,7 @@ import { z } from 'zod';
 // Local imports
 import { apiKeyEnvName, lookupApiKeyOrigin } from '@model/apiProviders';
 import { platform } from '@platform/platform';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
 import type { RegisteredToolName } from '@tools/registry';
 import { importCodexClass, findCodexBinaryPath } from '@tools/codexImport';
@@ -454,13 +454,13 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
   },
   {
     id: 'workflow-script',
-    tools: [DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME],
-    name: 'Workflow Script',
+    tools: [DELEGATE_MULTI_AGENTS_TOOL_NAME],
+    name: 'Multi-Agent Workflow',
     category: 'workflow',
     description:
       'Run deterministic JavaScript workflow scripts that fan out, pipeline, and join calls to sub-agents, resuming safely after interruption. An agent only gets this tool if its own configuration names it — this switch is an additional kill switch on top of that per-agent opt-in.',
     configNotes:
-      'No local install required. Turning this off removes delegate_workflow_script from every agent tool list, even agents whose configuration names it explicitly.',
+      'No local install required. Turning this off removes delegate_multi_agents from every agent tool list, even agents whose configuration names it explicitly.',
     toggleable: true,
     check: async () => true,
   },

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -4,7 +4,7 @@ import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ToolDefinition } from '@model/ToolDefinition';
 import type { CanonicalToolDisplayName } from '@shared/tools/toolKind';
 import {
-  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  DELEGATE_MULTI_AGENTS_TOOL_NAME,
   type CanonicalDelegationToolName,
 } from '@shared/constants/delegationTools';
 
@@ -54,7 +54,7 @@ import {
   WorkflowAgentTool,
   DelegateAgentTool,
 } from './delegation/DelegationTools';
-import { WorkflowScriptTool } from './delegation/WorkflowScriptTool';
+import { DelegateMultiAgentsTool } from './delegation/DelegateMultiAgentsTool';
 import { ExecutionsTool } from './ExecutionsTool';
 import { AcceptRunFilesTool } from './AcceptRunFilesTool';
 import { ExternalInquiryTool } from './inquiry';
@@ -125,7 +125,7 @@ function createDefaultTools() {
     codex: new CodexTool(),
     [CLAUDE_AGENT_NAME]: new ClaudeAgentTool(),
     delegate_workflow: new WorkflowAgentTool(),
-    [DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME]: new WorkflowScriptTool(),
+    [DELEGATE_MULTI_AGENTS_TOOL_NAME]: new DelegateMultiAgentsTool(),
     delegate_agent: new DelegateAgentTool(),
     executions: new ExecutionsTool(),
     accept_run_files: new AcceptRunFilesTool(),


### PR DESCRIPTION
## Summary

Rename the resumable multi-agent orchestration tool from `delegate_workflow_script` to `delegate_multi_agents` across the current schema, dispatcher, presentation surfaces, bundled definitions, remote definitions, documentation, and tests.

This is an atomic v0.41 breaking change. It deliberately adds no alias, dual registration, checkpoint translation, or compatibility mirror. The decision rule for choosing this tool instead of one-at-a-time delegation appears only in the tool description.

Closes #9681.

## Issue acceptance gates

- Zero repository hits for the retired name outside the v0.41 changelog migration note.
- `delegate_multi_agents` is exposed by the bundled engineer agent and the remote software-engineering and Lean orchestrators.
- The exact fan-out/pipeline/join guidance occurs once, in `DelegateMultiAgentsTool`'s description, and does not occur in orchestrator prompts.
- The registry accepts only the new name; no compatibility path or old-checkpoint translator was added.
- Extension, desktop, and CLI builds pass, along with full type checking and linting.
- Remote YAML and generated SQL are synchronized. Production deployment is intentionally gated until the matching v0.41 client is published; the exact operation is recorded below.

## Single source of truth

`DELEGATE_MULTI_AGENTS_TOOL_NAME` in `src/shared/constants/delegationTools.ts` owns the external tool name. `DelegateMultiAgentsTool` in `src/tools/delegation/DelegateMultiAgentsTool.ts` owns its input contract and model-facing guidance.

## Duplication and abstraction budget

The previous name was removed rather than mirrored. No new pass-through layer or compatibility abstraction was added. Existing workflow-script internals retain their implementation-oriented names where they do not form part of the external tool protocol.

## Net elements (R6)

- Files: 47 changed, including 2 direct renames.
- Exported symbols: 2 renamed, 0 net new.
- Classes: 1 renamed, 0 net new.
- LoC: 185 insertions, 155 deletions, net +30. The increase is the focused current-contract assertions and the v0.41 changelog section.

## Consumer counts (R8)

The external tool-name consumer set is centralized in `DELEGATION_TOOL_NAMES`. Repository audit after the rename: 0 current consumers of `delegate_workflow_script`; 3 intended bundled/remote definition consumers of `delegate_multi_agents` (engineer, software-engineering orchestrator, Lean orchestrator).

## Host impact

Extension: Uses the new registry key and **Multi-Agent Workflow** presentation copy. Bundled engineer exposure is updated.

Desktop: Uses the same current registry and generated remote metadata; no migration or compatibility behavior is added.

CLI: Uses the new registry key and transcript copy. Current workflow checkpoints continue to journal their inner `agent()` calls without translation.

## Scheduled refactoring

No code follow-up is required.

Post-merge release gate: do not deploy the remote definitions before the matching v0.41 client artifacts are published, because older clients do not know the new tool name. As part of that release operation, from the merged repository root with the Supabase CLI authenticated:

```bash
npm run check:remote-agents
supabase storage cp prompts/agents/remote/orchestrator.yaml "ss:///agent-configs/tool-use/orchestrator.yaml" --project-ref "$SUPABASE_PROJECT_REF"
supabase storage cp prompts/agents/remote/Lean4/leanOrchestrator.yaml "ss:///agent-configs/tool-use-lean/leanOrchestrator.yaml" --project-ref "$SUPABASE_PROJECT_REF"
```

Then execute `docs/supabase/SYNC_REMOTE_AGENTS.sql` against the production project using the documented Supabase Studio SQL editor or `mcp__supabase__execute_sql` procedure. Verify with:

```sql
SELECT name, tools
FROM remote_agents
WHERE name IN ('orchestrator', 'leanOrchestrator')
ORDER BY name;
```

Both rows must contain `delegate_multi_agents` and must not contain `delegate_workflow_script` before the release operation is considered complete.

## Validation

- Focused Vitest current-contract suite: 16 files, 249 tests passed.
- `npm run typecheck`
- `npm run lint`
- `corepack pnpm --filter texra compile:fast`
- `corepack pnpm --filter @texra/desktop build`
- `corepack pnpm --filter @texra-ai/cli build`
- `npm run check:remote-agents`
- Prettier over all changed parseable files
- `git diff --check`
- Zero-name, single-guidance-location, and intended-agent-definition grep audits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking tool-name change for custom agent YAML and any external callers; behavior is largely rename plus copy, but release must stay gated until v0.41 clients and remote metadata are deployed together.
> 
> **Overview**
> **Breaking rename** of the opt-in resumable orchestration tool from `delegate_workflow_script` to **`delegate_multi_agents`**, with no alias, dual registration, or checkpoint translation.
> 
> `DELEGATE_MULTI_AGENTS_TOOL_NAME` and **`DelegateMultiAgentsTool`** (renamed from `WorkflowScriptTool`) remain the contract; user-facing strings shift to **Multi-Agent Workflow** (dashboard toggle id `workflow-script` unchanged). Bundled **engineer**, remote **orchestrator** / **leanOrchestrator**, Supabase sync SQL, docs, and tests follow the new name. **CHANGELOG 0.41.0** documents the break and expanded team-lead access wording.
> 
> When-to-use guidance for **`delegate_multi_agents`** vs one-at-a-time **`delegate_agent`** is consolidated in the tool description; orchestrator prompts no longer repeat it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b6fba05fa3f8460f00c137c05f84aaa2826e731. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->