### PR TITLE
refactor(settings)!: retire Claude model aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
   the tool formerly named `delegate_workflow_script` has been renamed with
   no compatibility alias. Custom agent YAML files that list
   `delegate_workflow_script` in their tool list must use the new name.
+- **Retired Claude model selections now use the current default** — saved
+  Opus 4.7 or 4.8 selections are no longer translated to Opus 5.
 
 ## [0.40.0] - 2026-08-02
 

--- a/src/shared/schemas/agentCliSettings.ts
+++ b/src/shared/schemas/agentCliSettings.ts
@@ -10,13 +10,12 @@ import { z } from 'zod';
 function parseEnumSetting<T extends string>(
   values: readonly T[],
   fallback: T,
-  aliases?: Readonly<Record<string, T>>,
 ): (raw: unknown) => T {
   const known = values as readonly string[];
   return (raw: unknown): T => {
     if (typeof raw !== 'string') return fallback;
     if (known.includes(raw)) return raw as T;
-    return aliases?.[raw] ?? fallback;
+    return fallback;
   };
 }
 
@@ -75,16 +74,9 @@ export type ClaudeAgentModel = z.infer<typeof ClaudeAgentModelSchema>;
 
 export const CLAUDE_AGENT_DEFAULT_MODEL: ClaudeAgentModel = 'claude-sonnet-5';
 
-const RETIRED_CLAUDE_AGENT_MODELS: Readonly<Record<string, ClaudeAgentModel>> =
-  {
-    'claude-opus-4-7': 'claude-opus-5',
-    'claude-opus-4-8': 'claude-opus-5',
-  };
-
 export const parseClaudeAgentModel = parseEnumSetting(
   ClaudeAgentModelSchema.options,
   CLAUDE_AGENT_DEFAULT_MODEL,
-  RETIRED_CLAUDE_AGENT_MODELS,
 );
 
 /** Claude Code CLI permission modes exposed in settings. */

--- a/src/test-kernel/schemas/SharedSchemas.vitest.ts
+++ b/src/test-kernel/schemas/SharedSchemas.vitest.ts
@@ -47,11 +47,6 @@ describe('parseCodexApprovalPolicy', () => {
 });
 
 describe('parseClaudeAgentModel', () => {
-  it('maps retained Opus selections to the current model', () => {
-    expect(parseClaudeAgentModel('claude-opus-4-7')).toBe('claude-opus-5');
-    expect(parseClaudeAgentModel('claude-opus-4-8')).toBe('claude-opus-5');
-  });
-
   it('defaults invalid persisted selections to Sonnet', () => {
     expect(parseClaudeAgentModel('claude-opus-3')).toBe('claude-sonnet-5');
   });

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -530,16 +530,6 @@ describe('settingsAccess', () => {
     );
   });
 
-  it('migrates retired Claude Agent models through the generic catalog read path', () => {
-    const entry = entryByKey(WorkspaceStateKey.CLAUDE_AGENT_MODEL);
-
-    for (const retiredModel of ['claude-opus-4-7', 'claude-opus-4-8']) {
-      const { stores, workspaceState } = makeFakeSettingsStores();
-      void workspaceState.update(entry.key, retiredModel);
-      assert.equal(readSetting(entry, stores, 'cli'), 'claude-opus-5');
-    }
-  });
-
   it('routes extension writes to the canonical store', async () => {
     const { stores, config, workspaceState } = makeFakeSettingsStores();
     const entry = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);


### PR DESCRIPTION
## Summary

Remove the temporary settings translations from `claude-opus-4-7` and `claude-opus-4-8` to Opus 5. Persisted values now have the same direct rule as any other unsupported Claude model: use the current default, Sonnet 5.

The generic enum parser no longer accepts an alias table because these were its final alias consumers. Compatibility-only assertions for the two translations are deleted rather than rewritten around the current behavior.

Refs #9627.

## Retirement evidence

- The settings and model pickers now write only values from `ClaudeAgentModelSchema`.
- Opus 4.7 was replaced in the product model list by Opus 4.8; Opus 5 became the current Opus selection in #9154 on 2026-07-25.
- The remaining production reads were confined to `parseClaudeAgentModel` through shared settings and Claude configuration boundaries.
- The owner explicitly waived the dated rows in #9627 on 2026-08-03 after requiring a live-writer and carrier check.
- There is no open pull request implementing or overlapping this retirement.

## Resulting behavior

Current Claude model selections are unchanged. A stored Opus 4.7 or 4.8 string is no longer translated to Opus 5; it falls back to the current default, Sonnet 5. The changelog records this as a breaking change.

## Maintenance result

- 4 files changed
- 3 insertions, 24 deletions (net -21)
- one compatibility table and one generic parser parameter removed
- two compatibility-only test blocks removed
- no replacement abstraction, migration, alias, fixture, or new test

## Net elements (R6)

- Files: 0 added, 0 deleted, 4 modified.
- Exported symbols: 0 added, 0 removed.
- Constructs: one compatibility table and one optional parser parameter removed; no constructs added.
- Lines: 3 added, 24 deleted, net -21.

## Consumer counts (R8)

n/a: this change removes no export or event-emission path. The file-local alias table had one consumer, `parseClaudeAgentModel`, and no current writer emits either retired value.

## Validation

- 75 focused schema/settings tests
- full `npm run typecheck`
- full `npm run lint`
- dead-code ratchet
- Prettier and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, settings-only change; users with legacy stored Opus 4.7/4.8 strings will silently get Sonnet 5 rather than Opus 5, which is intentional but worth noting on upgrade.
> 
> **Overview**
> **Breaking:** Persisted Claude Code model values `claude-opus-4-7` and `claude-opus-4-8` are no longer rewritten to Opus 5. They now follow the same rule as any other unknown string and fall back to the current default, **Sonnet 5**.
> 
> The shared `parseEnumSetting` helper drops its optional alias map (it was only used for those two models). Compatibility tests that asserted the Opus 4.7/4.8 → Opus 5 migration are removed. The unreleased changelog records the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266cfc5cd01803618a0ffec5168391de689c0b62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
