### PR TITLE
refactor(approval): move live policy to session owner

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -34,6 +34,7 @@ import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import {
   formatTexraApprovalPolicy,
   parseTexraApprovalPolicy,
+  TEXRA_APPROVAL_POLICY_DEFAULT,
   type TexraApprovalPolicy,
 } from '@shared/approvalPolicy';
 import {
@@ -317,10 +318,9 @@ const SHOW_COMPLETED_TODOS_ONLY = process.env.HARNESS_TODOS_COMPLETED === '1';
 const FAILED_CHILD_AGENT = process.env.HARNESS_FAILED_CHILD?.trim();
 const TEAM_NAME = process.env.HARNESS_TEAM_NAME?.trim() || undefined;
 let canInterrupt = process.env.HARNESS_CAN_INTERRUPT === '1';
-// Seed only: `sessionMeta.approvalPolicy` is the live value once the harness
-// session state exists, exactly as in the real chat session.
 const HARNESS_INITIAL_APPROVAL_POLICY: TexraApprovalPolicy =
-  parseTexraApprovalPolicy(process.env.HARNESS_APPROVAL_POLICY ?? '') ?? 'ask';
+  parseTexraApprovalPolicy(process.env.HARNESS_APPROVAL_POLICY ?? '') ??
+  TEXRA_APPROVAL_POLICY_DEFAULT;
 const EDIT_APPROVAL_DELAY_MS = Number(
   process.env.HARNESS_EDIT_APPROVAL_DELAY_MS ?? '0',
 );
@@ -333,7 +333,9 @@ const HARNESS_COLOR_ENABLED = process.env.HARNESS_COLOR_ENABLED !== '0';
 const HARNESS_RESOURCES_PATH = resolveCliResourcesPath();
 const HARNESS_CLI_CONTEXT: CliContext = {
   apiMode: HARNESS_API_MODE,
-  approvalPolicy: HARNESS_INITIAL_APPROVAL_POLICY,
+  get approvalPolicy(): TexraApprovalPolicy {
+    return defaultSession().approvalPolicy;
+  },
   cliConfig: {},
   commandName: 'texra',
   configWarnings: [],
@@ -442,10 +444,11 @@ if (HARNESS_MEMORY_FILES.length > 0) {
     utimesSync(filePath, mtime, mtime);
   });
 }
-initializeDefaultSession({
+const harnessRuntimeSession = initializeDefaultSession({
   transcripts: await StreamLogStore.open(),
   responseTextProcessing: texraResponseTextProcessing,
 });
+harnessRuntimeSession.setApprovalPolicy(HARNESS_INITIAL_APPROVAL_POLICY);
 const harnessFollowUpLease = defaultSession().followUps.claimLive(
   STREAM_ID,
   'flow',
@@ -2120,6 +2123,7 @@ function defaultHarnessTranscriptStreamId(): StreamTabId {
 }
 
 function setHarnessApprovalPolicy(policy: TexraApprovalPolicy): void {
+  harnessRuntimeSession.setApprovalPolicy(policy);
   sessionMeta.set({
     ...sessionMeta.get(),
     approvalPolicy: policy,
@@ -2249,7 +2253,7 @@ function appendHarnessStatus(): void {
         subscriptionActive: false,
         usageRoute: slice?.usage?.usageRoute,
       }),
-      approval: formatTexraApprovalPolicy(meta.approvalPolicy),
+      approval: formatTexraApprovalPolicy(harnessRuntimeSession.approvalPolicy),
       approvalBypasses: slice?.bypass,
       status: slice?.status ?? 'not started',
       goal: GoalStore.getForStream(streamId),
@@ -2332,7 +2336,7 @@ registerBuiltinSlashCommands({
   canSelectAgent: () => CAN_SELECT_AGENT,
   canSelectModel: () => CAN_SELECT_MODEL,
   getModelSwitchDisabledReason: getHarnessModelSwitchDisabledReason,
-  getApprovalPolicy: () => sessionMeta.get().approvalPolicy,
+  getApprovalPolicy: () => harnessRuntimeSession.approvalPolicy,
   onApprovalPolicySelect: setHarnessApprovalPolicy,
   onModelSelect: (model) => {
     setCliSessionModelOverride(model);

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1183,8 +1183,14 @@ const SCENARIOS = [
   {
     name: 'approval-policy-status-bar',
     frame: 'scrollback',
-    env: { HARNESS_APPROVAL_POLICY: 'never', HARNESS_ENTRIES: '4' },
-    expect: ['personal', 'deny', '/status details'],
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/approval never', '\r', '/status', '\r'],
+    expect: [
+      'Approval mode: Deny Bash commands and tool edits.',
+      'personal',
+      'deny',
+      '/status details',
+    ],
     unexpect: ['keys deny', 'approval: deny privileged actions'],
   },
   {

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -16,7 +16,7 @@ import { resumeToolUseFromResumeData } from '@agent/runtime/executeAgent';
 import { runAgent } from '@agent/runtime/runAgent';
 import { resolveAndResumeStream } from '@agent/runtime/resolveAndResumeStream';
 import { resumeQueuedToolUseFromResumeData } from '@agent/runtime/resumeQueuedToolUse';
-import { defaultSession } from '@agent/runtime/SessionHandle';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { type CliContext } from '@cli/runtime/cliContext';
 import { approvalPromptsUnavailable } from '@cli/runtime/approval/approvalPolicy';
@@ -161,6 +161,9 @@ export interface ChatSessionControllerInit {
   /** Mutable session state the controller owns. */
   readonly session: TuiSession;
 
+  /** Runtime session that owns executions, storage, and interactions. */
+  readonly runtimeSession: SessionHandle;
+
   /** Build a {@link CliContext} keyed on the current model. */
   readonly getSessionContext: (model: string) => CliContext;
 
@@ -179,15 +182,12 @@ export function createChatSessionController(
 ): ChatSessionController {
   const {
     session,
+    runtimeSession,
     getSessionContext,
     disposers,
     followUpQueue,
     snapshotStore,
   } = init;
-  // The controller owns exactly one runtime session for its whole lifetime;
-  // resolve it once here so every path below propagates that owner instead of
-  // re-resolving the process default.
-  const runtimeSession = defaultSession();
   let interruptedContinuation: InterruptedContinuationBatch | undefined;
   let pendingInterruptedFollowUps: InterruptedFollowUp[] = [];
 

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -13,7 +13,6 @@ import PQueue from 'p-queue';
 import { getVisibleAgents, loadAgents } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
-import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
   presentFollowUpResult,
   submitFollowUp,
@@ -268,6 +267,8 @@ export async function runChat(
           showPersistentWarning: writeTextStderr,
         },
   );
+  const runtimeSession = transcriptLifecycle.session;
+  runtimeSession.setApprovalPolicy(context.approvalPolicy);
   // First-run gate (interactive only; headless already rejected above). A
   // credential-less user signs in or saves a key here; the apiMode + model
   // resolution below then see the freshly-set credentials in the same process.
@@ -333,12 +334,8 @@ export async function runChat(
   const model = modelSelection.model;
   const version = await readCliVersion();
 
-  // `sessionMeta` is the only store for the live approval policy: the status
-  // bar, the runtime context handed to each run, and `/approval` all read the
-  // same signal, so a mid-session change cannot be visible in one surface and
-  // stale in another.
   const getApprovalPolicy = (): TexraApprovalPolicy =>
-    sessionMetaSignal.get().approvalPolicy;
+    runtimeSession.approvalPolicy;
   const currentSessionContext = (helperModel: string): CliContext => ({
     ...context,
     apiMode: sessionMetaSignal.get().apiMode,
@@ -349,6 +346,7 @@ export async function runChat(
     quietLogs: true,
   });
   const setApprovalPolicy = (policy: TexraApprovalPolicy): void => {
+    runtimeSession.setApprovalPolicy(policy);
     patchSessionMeta({ approvalPolicy: policy });
   };
   // The slash-command context is identical at every call site; build it once
@@ -380,7 +378,7 @@ export async function runChat(
     modelSource: defaults.modelSource,
     cwd: context.cwd,
     apiMode,
-    approvalPolicy: context.approvalPolicy,
+    approvalPolicy: runtimeSession.approvalPolicy,
     canDelegate: chatAgentSupportsDelegation(agent),
     transcriptMode: transcriptLifecycle.canResume ? 'persistent' : 'ephemeral',
     teamName: initialResume
@@ -419,14 +417,6 @@ export async function runChat(
     stdin: process.stdin,
     stdout: process.stdout,
   });
-
-  // The TUI owns exactly one runtime session for its whole lifetime; resolve it
-  // once here so every path below propagates that owner instead of re-resolving
-  // the process default. Per-stream sidecar data (todos, plan, usage, output
-  // files) is persisted by the session's own snapshot store, so a `texra resume`
-  // restores the full display — the same streamData/{id}/* files the
-  // extension/desktop read.
-  const runtimeSession = defaultSession();
 
   const disposers: Array<() => void> = [];
   // Crash safety: if the process dies outside the orderly teardown below
@@ -504,6 +494,7 @@ export async function runChat(
   // state transition flows through one of the controller's narrow commands.
   const chatController: ChatSessionController = createChatSessionController({
     session,
+    runtimeSession,
     getSessionContext: currentSessionContext,
     disposers,
     followUpQueue,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -4,7 +4,10 @@
  */
 import { computed, signal, type Signal } from '@lit-labs/signals';
 import type { RunModelDecisionReason } from '@model/runModelDecision';
-import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
+import {
+  TEXRA_APPROVAL_POLICY_DEFAULT,
+  type TexraApprovalPolicy,
+} from '@shared/approvalPolicy';
 import {
   AgentCategory,
   type CompileFailure,
@@ -457,7 +460,7 @@ export function setStreamStatusInCliState({
 // sessionSlice
 // ---------------------------------------------------------------------------
 
-// Session-identity slice: the agent/model/cwd/approval snapshot for the
+// Session-identity slice: the agent/model/cwd/approval display snapshot for the
 // current CLI session. One signal, no cross-stream concerns.
 
 const EMPTY_SESSION_META: SessionMeta = {
@@ -467,13 +470,13 @@ const EMPTY_SESSION_META: SessionMeta = {
   modelSource: 'builtin-default',
   cwd: '',
   apiMode: 'personal',
-  approvalPolicy: 'ask',
+  approvalPolicy: TEXRA_APPROVAL_POLICY_DEFAULT,
   canDelegate: false,
   transcriptMode: 'persistent',
   version: '',
 };
 
-/** Agent/model/cwd/approval snapshot for the current CLI session. */
+/** Reactive display snapshot for the current CLI session. */
 export const sessionMeta = signal<SessionMeta>(EMPTY_SESSION_META);
 
 export function patchSessionMeta(patch: Partial<SessionMeta>): void {

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -183,6 +183,7 @@ export async function executeCliRequest(
   // Transcript persistence is a launch prerequisite for every headless run.
   // This executes before runtime-host construction and before runAgent.
   const { session } = await initializeHeadlessTranscriptSession();
+  session.setApprovalPolicy(runContext.approvalPolicy);
   const presentationHost = createCliRuntimeHost(runContext);
   const renderWorkflowPlainProgress =
     runContext.outputFormat === 'text' && runContext.renderRunProgress === true;

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -38,6 +38,10 @@ import { detectWaitingStreams } from '@agent/storage/detectWaitingStreams';
 import { runWithOwnedExecutionLeaseQuiescence } from '@agent/storage/executionLease';
 import { deriveResumability } from '@agent/storage/resumability';
 import { platform } from '@platform/platform';
+import {
+  TEXRA_APPROVAL_POLICY_DEFAULT,
+  type TexraApprovalPolicy,
+} from '@shared/approvalPolicy';
 import { STREAM_PHASE, type StreamTabId } from '@shared/schemas';
 import {
   isInFlightPhase,
@@ -169,6 +173,7 @@ export class SessionHandle {
   readonly interactions: SessionHostInteractions;
   /** Session-owned approval queues, pending registries, and bypass state. */
   readonly approvals: SessionApprovals;
+  private texraApprovalPolicy = TEXRA_APPROVAL_POLICY_DEFAULT;
   /** Coordinates recovery probes for model routes shared by parallel runs. */
   readonly modelRetries: ModelRetryGate;
   /** Host policy for provider-output cleanup and continuation joining. */
@@ -258,6 +263,15 @@ export class SessionHandle {
       // becoming unhandled before the host reaches that boundary.
       void startupRepair.catch(() => undefined);
     }
+  }
+
+  /** Live host-neutral approval policy for executable requests. */
+  get approvalPolicy(): TexraApprovalPolicy {
+    return this.texraApprovalPolicy;
+  }
+
+  setApprovalPolicy(policy: TexraApprovalPolicy): void {
+    this.texraApprovalPolicy = policy;
   }
 
   /**

--- a/src/shared/approvalPolicy.ts
+++ b/src/shared/approvalPolicy.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const TEXRA_APPROVAL_POLICIES = ['never', 'ask', 'yolo'] as const;
 export const TexraApprovalPolicySchema = z.enum(TEXRA_APPROVAL_POLICIES);
 export type TexraApprovalPolicy = z.infer<typeof TexraApprovalPolicySchema>;
+export const TEXRA_APPROVAL_POLICY_DEFAULT: TexraApprovalPolicy = 'ask';
 
 const TEXRA_APPROVAL_POLICY_COPY = {
   ask: {

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -231,6 +231,9 @@ describe('SessionHandle', () => {
         defaultSession().workflowControls,
       );
       expect(fresh.flushers).not.toBe(defaultSession().flushers);
+      fresh.setApprovalPolicy('yolo');
+      expect(fresh.approvalPolicy).toBe('yolo');
+      expect(defaultSession().approvalPolicy).toBe('ask');
     } finally {
       fresh.dispose();
     }

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -300,10 +300,12 @@ describe('executeCliRequest', () => {
 
   it('keeps yolo runs approval-available for agent execution', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const { defaultSession } = await import('@agent/runtime/SessionHandle');
     const request = baseRequest();
 
     await executeCliRequest(request, cliContext({ approvalPolicy: 'yolo' }));
 
+    expect(defaultSession().approvalPolicy).toBe('yolo');
     expect(mocks.runAgent).toHaveBeenCalledWith(
       request,
       expect.objectContaining({

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -243,6 +243,7 @@ function makeInit(
 ): ChatSessionControllerInit {
   return {
     session: makeSession(),
+    runtimeSession: mocks.defaultSession(),
     getSessionContext: () => makeSessionContext(),
     disposers: [],
     followUpQueue: new PQueue({ concurrency: 1 }),


### PR DESCRIPTION
## Summary

Make the runtime session the single live owner of TeXRA's approval policy. `SessionHandle` now holds the current `never | ask | yolo` value, with the shared policy module owning the default.

Headless CLI runs seed that value before attaching host interactions. The chat TUI reads and updates the same session value, while its reactive session metadata remains a display projection. The chat controller now receives its owning runtime session directly instead of resolving the process default again.

Refs #9597.

## Issue acceptance gates

Completes the first remaining implementation item in #9597: place the live primitive policy value on the session lifetime owner without placing evaluation or UI behavior there.

This PR intentionally does not move Bash/edit enforcement, add desktop or extension settings, or delete the CLI denial bookkeeping. Those are later gates on #9597.

## Single source of truth

- `src/shared/approvalPolicy.ts` owns the vocabulary and default.
- `SessionHandle.approvalPolicy` owns the live per-session value.
- CLI `sessionMeta.approvalPolicy` is only the reactive display projection.

## Duplication and abstraction budget

No resolver, registry, event bus, host facade, constructor option, persistence format, or compatibility path is added. One redundant `defaultSession()` lookup and its explanatory branch are removed from the chat controller.

## Net elements (R6)

- Files: 0 added, 0 deleted, 11 modified.
- Exported symbols: 1 added (`TEXRA_APPROVAL_POLICY_DEFAULT`), 0 removed.
- Existing structures: one primitive field, getter, setter, and one controller input added; one process-default lookup removed.
- Lines: 59 added, 33 deleted, net +26. Most additions align the existing TUI harness and strengthen an existing behavioral scenario; no new test file or abstraction is introduced.

## Consumer counts (R8)

n/a: no export or event-emission path is deleted or rerouted. The new shared default has three direct consumers: `SessionHandle`, CLI display-state initialization, and the TUI harness.

## Host impact

Extension: Uses the session default `ask`; no UI or persistence change in this stage.

Desktop: Uses the session default `ask`; no migration or persistence change.

CLI: Headless runs seed the session policy once. Interactive `/approval` changes the live session value and updates the status projection.

## Scheduled refactoring

#9597 retains shared Bash/edit enforcement, atomic desktop/extension adoption, native controls, deletion of superseded CLI enforcement seams, and the structural check.

## Validation

- Existing TUI `approval-policy-status-bar` scenario now changes policy through `/approval never` and verifies the confirmation and status.
- 87 focused SessionHandle, run-execution, and chat-controller tests.
- Full `npm run typecheck`.
- Full `npm run lint`.
- Dead-code ratchet.
- Prettier and `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where the authoritative approval policy is stored for CLI runs and TUI `/approval`, but enforcement behavior is intentionally unchanged in this step.
> 
> **Overview**
> Moves the **live** TeXRA approval policy (`never` | `ask` | `yolo`) onto **`SessionHandle`**, with **`TEXRA_APPROVAL_POLICY_DEFAULT`** (`ask`) defined in the shared approval module.
> 
> **CLI** headless runs call **`setApprovalPolicy`** on the transcript session before execution. The **interactive TUI** seeds the same session value at startup, reads policy from **`runtimeSession.approvalPolicy`**, and on `/approval` updates the session first while **`sessionMeta.approvalPolicy`** stays a reactive display mirror. **`createChatSessionController`** now receives the owning **`runtimeSession`** instead of resolving **`defaultSession()`** again.
> 
> The TUI harness and **`approval-policy-status-bar`** scenario exercise changing policy via **`/approval never`** rather than env-only seeding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 217136ea8168120fa36b4b8dc5ea5a328fa89b92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->