### PR TITLE
refactor(approval): enforce policy at shared tool boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to this project will be documented in this file.
 - **Retired Claude model selections now use the current default** — saved
   Opus 4.7 or 4.8 selections are no longer translated to Opus 5.
 
+#### Bug Fixes
+
+- **CLI approval modes now govern Bash commands and file edits consistently** —
+  `never` denies them even when a prompt setting or stream bypass would allow
+  them, while automatic approval permits them without opening a prompt.
+
 ## [0.40.0] - 2026-08-02
 
 ### CLI

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -19,7 +19,10 @@ import { resumeQueuedToolUseFromResumeData } from '@agent/runtime/resumeQueuedTo
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { type CliContext } from '@cli/runtime/cliContext';
-import { approvalPromptsUnavailable } from '@cli/runtime/approval/approvalPolicy';
+import {
+  approvalPromptsUnavailable,
+  markApprovalDenied,
+} from '@cli/runtime/approval/approvalPolicy';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { readCliMultiAgentPresetName } from '@cli/runtime/multiAgentPresets';
 import { setCliHelperModel } from '@cli/runtime/initPlatform';
@@ -373,6 +376,7 @@ export function createChatSessionController(
             registerExecution: true,
             enforceCategory: true,
             approvalPromptsUnavailable: approvalsUnavailable,
+            onApprovalPolicyDenial: () => markApprovalDenied(sessionContext),
             runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
             onStreamResolved: (resolvedStreamId) => {
               // Each chat round mints a fresh root StreamTabId (new
@@ -507,6 +511,7 @@ export function createChatSessionController(
         .then(() =>
           resumeToolUseFromResumeData(resolution, {
             approvalPromptsUnavailable: approvalsUnavailable,
+            onApprovalPolicyDenial: () => markApprovalDenied(sessionContext),
             runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
             drainedFollowUps: supersededRecovery?.followUps.map((followUp) => ({
               ...followUp,
@@ -629,6 +634,8 @@ export function createChatSessionController(
                   session: runtimeSession,
                   recovery: claimedRecovery,
                   approvalPromptsUnavailable: approvalsUnavailable,
+                  onApprovalPolicyDenial: () =>
+                    markApprovalDenied(sessionContext),
                   runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
                   extraFollowUps: options.extraFollowUps,
                   onFollowUpQueueReady: (lease) => {

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -4,10 +4,9 @@
 // user). When the modal resolves, the interaction promise resolves with the
 // same host-facing result shape.
 //
-// Policy is honored *before* the modal is shown — `immediateDecision` runs
-// first so `--approval-policy yolo` auto-approves without a modal, and
-// `never` auto-rejects with `denyMessage(...)`. Only `ask` (or interactive
-// non-print) reaches the queue.
+// Bash and edit policy is honored at the shared tool boundary before this
+// presentation adapter is called. Plans, proposals, retries, and human-input
+// requests retain their focused CLI decisions here.
 //
 // Tool-edit is part of this port because it returns a typed
 // Promise<ToolEditApprovalResult>, not a fire-and-forget event.
@@ -141,14 +140,11 @@ export function createTuiHostInteractions(
   return {
     emit: (event, payload) => host.emit(event, payload),
     async requestToolEditApproval(request) {
-      let decision: ApprovalDecision | undefined = immediateDecision(context);
-      if (!decision) {
-        decision = await enqueueTuiApproval({
-          kind: 'toolEdit',
-          payload: request,
-        });
-        markIfRejected(context, decision);
-      }
+      const decision = await decidePresentedApproval(
+        context,
+        'toolEdit',
+        request,
+      );
       if (
         decision.accepted &&
         decision.bypass === 'toolEdit' &&
@@ -246,13 +242,10 @@ function prepareRetryClient(
 
 // Retry carries its own policy lookup (`showRetryRequest`) and owns a queue
 // reservation, so it does not enter through this path.
-async function decideWithPolicy<
-  K extends 'bash' | 'planApproval' | 'proposal',
+async function decidePresentedApproval<
+  K extends 'bash' | 'toolEdit' | 'planApproval' | 'proposal',
   P,
 >(context: CliContext, kind: K, payload: P): Promise<ApprovalDecision> {
-  const policy = immediateDecision(context);
-  if (policy) return policy;
-
   try {
     const queuePayload = { kind, payload } as Extract<
       ApprovalPayload,
@@ -271,12 +264,21 @@ async function decideWithPolicy<
   }
 }
 
+async function decideWithPolicy<K extends 'planApproval' | 'proposal', P>(
+  context: CliContext,
+  kind: K,
+  payload: P,
+): Promise<ApprovalDecision> {
+  const policy = immediateDecision(context);
+  return policy ?? decidePresentedApproval(context, kind, payload);
+}
+
 async function requestBashInteraction(
   request: HostBashApprovalRequest,
   context: CliContext,
 ): Promise<BashSettlement> {
   const payload = prepareBashApprovalPrompt(request);
-  const decision = await decideWithPolicy(context, 'bash', payload);
+  const decision = await decidePresentedApproval(context, 'bash', payload);
   if (decision.accepted && decision.bypass === 'bash' && request.streamId) {
     setBashApprovalSessionBypass(request.streamId, true);
   }

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -7,7 +7,6 @@ import {
   isChatGptSubscriptionLimitError,
   isCredentialExhausted,
   type AgentProposalPermission,
-  type BashPermission,
   type ExhaustionReason,
   type PlanApprovalPermission,
   type RetryPermission,
@@ -29,7 +28,6 @@ import { askCliQuestion } from '../logSinks';
  * the live `HostInteractions` requests already carry.
  */
 export interface CliDecisionApprovalPayloads {
-  showBashPermission: BashPermission;
   showPlanApproval: PlanApprovalPermission;
   showAgentProposal: AgentProposalPermission;
   showRetryRequest: RetryPermission;

--- a/packages/cli/src/runtime/approval/approvalSummaries.ts
+++ b/packages/cli/src/runtime/approval/approvalSummaries.ts
@@ -1,6 +1,9 @@
 import { structuredPatch } from 'diff';
 
-import type { HostUserQuestionRequest } from '@agent/runtime/HostInteractions';
+import type {
+  HostBashApprovalRequest,
+  HostUserQuestionRequest,
+} from '@agent/runtime/HostInteractions';
 import {
   agentProposalCategoryLabel,
   getProposalFileGroups,
@@ -148,6 +151,13 @@ export function formatRetryRequestMessage(payload: RetryPermission): string {
     return [message, CLI_PERSONAL_API_RETRY_HINT].join('\n');
   }
   return message;
+}
+
+export function formatBashApprovalSummary(
+  request: HostBashApprovalRequest,
+): string {
+  const cwd = request.cwd ? `Directory: ${request.cwd}\n` : '';
+  return `Command requested:\n${cwd}${request.command}`;
 }
 
 function formatDiffRange(start: number, lineCount: number): string {

--- a/packages/cli/src/runtime/approval/eventDispatch.ts
+++ b/packages/cli/src/runtime/approval/eventDispatch.ts
@@ -1,6 +1,5 @@
 import type {
   AgentProposalPermission,
-  BashPermission,
   PlanApprovalPermission,
   RetryPermission,
 } from '@shared/schemas';
@@ -16,11 +15,6 @@ export function summarizeApprovalEvent<K extends CliDecisionApprovalEvent>(
   payload: CliDecisionApprovalPayloads[K],
 ): string {
   switch (event) {
-    case 'showBashPermission': {
-      const data = payload as BashPermission;
-      const cwd = data.cwd ? `Directory: ${data.cwd}\n` : '';
-      return `Command requested:\n${cwd}${data.command}`;
-    }
     case 'showPlanApproval': {
       const data = payload as PlanApprovalPermission;
       return `Plan approval requested:\n${JSON.stringify(data.plan, null, 2)}`;

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -14,7 +14,6 @@ import type {
 import type { RetryPermission, UserQuestionAnswers } from '@shared/schemas';
 
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
-import { prepareBashApprovalPrompt } from '@tools/approval/bashApproval';
 import {
   type ToolEditApprovalRequest,
   type ToolEditApprovalResult,
@@ -31,15 +30,15 @@ import {
   askApproval,
   askUserQuestionDenial,
   approvalPromptAllowed,
-  immediateDecision,
   immediateDecisionForApproval,
   markApprovalDenied,
   queueCliApprovalQuestion,
 } from './approval/approvalPolicy';
 import {
-  formatUserQuestionPrompt,
+  formatBashApprovalSummary,
   formatRetryRequestMessage,
   formatToolEditApprovalSummary,
+  formatUserQuestionPrompt,
 } from './approval/approvalSummaries';
 import { summarizeApprovalEvent } from './approval/eventDispatch';
 import { parseUserQuestionAnswer } from './userQuestionAnswer';
@@ -65,9 +64,6 @@ async function decideToolEdit(
   context: CliContext,
   hooks: CliApprovalPromptHooks,
 ): Promise<ToolEditApprovalResult> {
-  const immediate = immediateDecision(context);
-  if (immediate) return toToolEditResult(immediate, request.proposedContent);
-
   const decision = await askApproval(
     context,
     formatToolEditApprovalSummary(request),
@@ -187,10 +183,9 @@ export function createHeadlessCliHostInteractions(
       return decideToolEdit(request, context, hooks);
     },
     async requestBashApproval(request) {
-      const decision = await decideApprovalEvent(
-        'showBashPermission',
-        prepareBashApprovalPrompt(request),
+      const decision = await askApproval(
         context,
+        formatBashApprovalSummary(request),
         hooks,
       );
       return toApprovalSettlement(decision);

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -17,7 +17,10 @@ import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-import { approvalPromptsUnavailable } from './approval/approvalPolicy';
+import {
+  approvalPromptsUnavailable,
+  markApprovalDenied,
+} from './approval/approvalPolicy';
 import { createHeadlessCliHostInteractions } from './approvalAdapter';
 import { finalizeCliExecution } from './executionFinalization';
 import { attachCliSessionProgressProjection } from './sessionProgressSubscription';
@@ -278,6 +281,7 @@ export async function executeCliRequest(
         },
         stopAfterCycle: options.stopAfterCycle,
         approvalPromptsUnavailable: approvalPromptsUnavailable(runContext),
+        onApprovalPolicyDenial: () => markApprovalDenied(runContext),
         runtimeUnavailableTools: [
           ...CLI_UNAVAILABLE_TOOLS,
           ...(options.runtimeUnavailableTools ?? []),

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -46,13 +46,12 @@ export function runOutcomeExitCode(
   outcome: RunOutcome | typeof STREAM_PHASE.WAITING,
   context: CliContext,
 ): CliExitCode {
-  if (outcome === RUN_OUTCOME.FAILED) {
-    return hasCliApprovalDenied(context)
-      ? CliExitCode.ApprovalDenied
-      : CliExitCode.AgentError;
-  }
   if (outcome === RUN_OUTCOME.CANCELLED) {
     return CliExitCode.Interrupted;
+  }
+  if (hasCliApprovalDenied(context)) return CliExitCode.ApprovalDenied;
+  if (outcome === RUN_OUTCOME.FAILED) {
+    return CliExitCode.AgentError;
   }
   return CliExitCode.Success;
 }

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -123,7 +123,10 @@ export async function withExecutionRunContext<T>(
   ctx: AgentLaunchContext,
   options: Pick<
     CreateLaunchRunContextOptions,
-    'approvalPromptsUnavailable' | 'runtimeUnavailableTools' | 'stopAfterCycle'
+    | 'approvalPromptsUnavailable'
+    | 'onApprovalPolicyDenial'
+    | 'runtimeUnavailableTools'
+    | 'stopAfterCycle'
   >,
   fn: () => T | Promise<T>,
 ): Promise<T> {

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -14,6 +14,7 @@ interface RunContextCommon {
    */
   readonly model?: string;
   readonly approvalPromptsUnavailable?: boolean;
+  readonly onApprovalPolicyDenial?: () => void;
   readonly runtimeUnavailableTools?: readonly string[];
   readonly stopAfterCycle?: boolean;
 }
@@ -57,6 +58,7 @@ interface CreateRunContextCommon {
    */
   modelCell?: Pick<ModelCell, 'modelId'>;
   approvalPromptsUnavailable?: boolean;
+  onApprovalPolicyDenial?: () => void;
   runtimeUnavailableTools?: readonly string[];
   stopAfterCycle?: boolean;
 }
@@ -84,7 +86,10 @@ const runContextScope = new AsyncLocalStorage<RunContext>();
 // ---------------------------------------------------------------------------
 
 type CommonRunContextFieldNames =
-  'approvalPromptsUnavailable' | 'runtimeUnavailableTools' | 'stopAfterCycle';
+  | 'approvalPromptsUnavailable'
+  | 'onApprovalPolicyDenial'
+  | 'runtimeUnavailableTools'
+  | 'stopAfterCycle';
 
 /**
  * Fields shared by both `RunContext` kinds, forwarded as-is from the input
@@ -95,6 +100,7 @@ function commonRunContextFields<T extends CreateRunContextCommon>(
 ): Pick<T, CommonRunContextFieldNames> {
   return {
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+    onApprovalPolicyDenial: options.onApprovalPolicyDenial,
     runtimeUnavailableTools: options.runtimeUnavailableTools,
     stopAfterCycle: options.stopAfterCycle,
   } satisfies Pick<T, CommonRunContextFieldNames>;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -313,6 +313,8 @@ export interface SubagentRunOptions {
   onProgress?: (update: SubagentProgressUpdate) => void;
   /** Hide tools whose approval prompts cannot be answered in this host mode. */
   approvalPromptsUnavailable?: boolean;
+  /** Record that this run encountered an executable policy denial. */
+  onApprovalPolicyDenial?: () => void;
   /** Hide tools unavailable because the current host/runtime cannot support them. */
   runtimeUnavailableTools?: readonly string[];
   /** Session owning this run's coordination state. Defaults to the process session. */
@@ -412,6 +414,7 @@ export async function executeAgent(
     });
     const runContextOptions = {
       approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+      onApprovalPolicyDenial: options.onApprovalPolicyDenial,
       runtimeUnavailableTools: options.runtimeUnavailableTools,
       stopAfterCycle: options.stopAfterCycle,
     };
@@ -566,6 +569,7 @@ export async function resumeToolUseFromResumeData(
     }
     const runContextOptions = {
       approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+      onApprovalPolicyDenial: options.onApprovalPolicyDenial,
       runtimeUnavailableTools: options.runtimeUnavailableTools,
     };
     const { setting } = ctx;

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -139,6 +139,7 @@ export async function resumeQueuedToolUseFromResumeData(
       session: options.session,
       tools: options.tools,
       approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+      onApprovalPolicyDenial: options.onApprovalPolicyDenial,
       runtimeUnavailableTools: options.runtimeUnavailableTools,
       parentStreamId: options.parentStreamId ?? resume.parentStreamId,
       workflowPhase: options.workflowPhase,

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -31,6 +31,7 @@ export interface RunAgentOptions extends Pick<
   | 'enforceCategory'
   | 'stopAfterCycle'
   | 'approvalPromptsUnavailable'
+  | 'onApprovalPolicyDenial'
   | 'runtimeUnavailableTools'
   | 'tools'
   | 'session'

--- a/src/shared/approvalPolicy.ts
+++ b/src/shared/approvalPolicy.ts
@@ -4,6 +4,8 @@ export const TEXRA_APPROVAL_POLICIES = ['never', 'ask', 'yolo'] as const;
 export const TexraApprovalPolicySchema = z.enum(TEXRA_APPROVAL_POLICIES);
 export type TexraApprovalPolicy = z.infer<typeof TexraApprovalPolicySchema>;
 export const TEXRA_APPROVAL_POLICY_DEFAULT: TexraApprovalPolicy = 'ask';
+export const TEXRA_APPROVAL_POLICY_DENIED_MESSAGE =
+  'Denied by TeXRA approval policy.';
 
 const TEXRA_APPROVAL_POLICY_COPY = {
   ask: {

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -11,6 +11,7 @@ vi.mock('@tools/inquiry/ExternalInquiryTool', () => ({
 }));
 
 import { Node } from '@agent/node';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import type {
   HostInteractions,
   HostRetryRequest,
@@ -27,6 +28,7 @@ import {
   humanInputDenialFeedback,
   immediateDecisionForApproval,
   isCliApiSwitchableRetry,
+  markApprovalDenied,
   type CliApprovalPromptHooks,
 } from '@cli/runtime/approval/approvalPolicy';
 import {
@@ -60,6 +62,7 @@ function useCliHostInteractions(
   hooks: CliApprovalPromptHooks = {},
 ): void {
   detachHostInteractions();
+  defaultSession().setApprovalPolicy(cliContext.approvalPolicy);
   detachHostInteractions = defaultSession().useHostInteractions(
     createHeadlessCliHostInteractions(cliContext, hooks),
   );
@@ -181,6 +184,26 @@ describe('human input approval policy', () => {
       'Denied by CLI approval policy.',
     );
     expect(hasCliApprovalDenied(ctx)).toBe(true);
+  });
+
+  it('classifies a shared edit-policy denial as approval denied', async () => {
+    const ctx = context({ approvalPolicy: 'never', mode: 'headless' });
+    useCliHostInteractions(ctx);
+
+    const result = await withRunContext(
+      createRunContext({
+        onApprovalPolicyDenial: () => markApprovalDenied(ctx),
+      }),
+      requestNewProofEdit,
+    );
+    expect(result).toMatchObject({ accepted: false });
+    expect(hasCliApprovalDenied(ctx)).toBe(true);
+    expect(runOutcomeExitCode(RUN_OUTCOME.COMPLETED, ctx)).toBe(
+      CliExitCode.ApprovalDenied,
+    );
+    expect(runOutcomeExitCode(RUN_OUTCOME.CANCELLED, ctx)).toBe(
+      CliExitCode.Interrupted,
+    );
   });
 });
 

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -663,21 +663,24 @@ describe('executeCliRequest', () => {
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
-  it('maps a classified run failure to ApprovalDenied when the run denied approval', async () => {
+  it('maps a completed run to ApprovalDenied after a shared policy denial', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const { markApprovalDenied } =
-      await import('@cli/runtime/approval/approvalPolicy');
+    const { runOutcomeExitCode } = await import('@cli/runtime/terminalStatus');
     const request = baseRequest();
     const context = cliContext();
-    markApprovalDenied(context);
-    mocks.runAgent.mockRejectedValueOnce(new AgentError('approval denied'));
-
-    const result = await executeCliRequest(request, context);
-
-    expect(result).toEqual({
-      ok: false,
-      exitCode: CliExitCode.ApprovalDenied,
+    mocks.runAgent.mockImplementationOnce(async (_request, options) => {
+      options.onExecutionLeaseAcquired?.((operation: () => unknown) =>
+        operation(),
+      );
+      options.onApprovalPolicyDenial?.();
+      return COMPLETED_RUN;
     });
+
+    await executeCliRequest(request, context);
+
+    expect(runOutcomeExitCode('completed', context)).toBe(
+      CliExitCode.ApprovalDenied,
+    );
   });
 
   it('closes the runtime host when sidecar flush fails', async () => {

--- a/src/test-kernel/tools/BashApprovalPrompt.vitest.ts
+++ b/src/test-kernel/tools/BashApprovalPrompt.vitest.ts
@@ -70,6 +70,44 @@ describe('prepareBashApprovalPrompt', () => {
 });
 
 describe('requestBashApproval queueing', () => {
+  it('lets never override a stream bypass at the shared boundary', async () => {
+    const session = createTestSession();
+    const streamId = sid('s:bash-policy-denial');
+    let policyDenials = 0;
+    let prompts = 0;
+    session.setApprovalPolicy('never');
+    setBashApprovalSessionBypass(streamId, true, { silent: true, session });
+    session.useHostInteractions({
+      requestBashApproval: async () => {
+        prompts += 1;
+        return { action: 'approve' };
+      },
+      cancel: () => undefined,
+    });
+
+    try {
+      const result = await withRunContext(
+        createRunContext({
+          streamId,
+          session,
+          onApprovalPolicyDenial: () => {
+            policyDenials += 1;
+          },
+        }),
+        () => requestBashApproval({ command: 'echo denied' }),
+      );
+
+      expect(result).toEqual({
+        action: 'reject',
+        feedback: 'Denied by TeXRA approval policy.',
+      });
+      expect(policyDenials).toBe(1);
+      expect(prompts).toBe(0);
+    } finally {
+      session.dispose();
+    }
+  });
+
   it('auto-approves a queued request once the stream is bypassed while it waits', async () => {
     const session = createTestSession();
     const streamId = sid('s:bash-queued-bypass');

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -33,6 +33,7 @@ let testApprovalHandler:
   | ((request: ToolEditApprovalRequest) => Promise<ToolEditApprovalResult>)
   | undefined;
 let detachHostInteractions = (): void => {};
+let policyDenials = 0;
 
 async function installPlatform(
   config: Record<string, unknown> = {},
@@ -66,6 +67,8 @@ function stubWorkspaceFile(options: { exists: boolean; content: string }) {
 describe('Tool edit approval gating', () => {
   beforeEach(async () => {
     await installPlatform();
+    defaultSession().setApprovalPolicy('ask');
+    policyDenials = 0;
     cleanupAllApprovals();
   });
 
@@ -158,6 +161,37 @@ describe('Tool edit approval gating', () => {
     assert.strictEqual(handlerCalled, false);
     assert.strictEqual(write.mock.lastCall?.[1], 'new content');
     assert.strictEqual(result.output, 'written');
+  });
+
+  it('lets never override a disabled approval setting', async () => {
+    await installPlatform({ 'texra.toolUse.requireEditApproval': false });
+    defaultSession().setApprovalPolicy('never');
+
+    const tool = new WriteFileTool();
+    let handlerCalled = false;
+    const write = stubWorkspaceFile({ exists: false, content: '' });
+    testApprovalHandler = async (request) => {
+      handlerCalled = true;
+      return { accepted: true, appliedContent: request.proposedContent };
+    };
+
+    const result = await withRunContext(
+      createRunContext({
+        onApprovalPolicyDenial: () => {
+          policyDenials += 1;
+        },
+      }),
+      () => tool.call({ path: 'denied.txt', content: 'blocked' }),
+    );
+
+    assert.strictEqual(handlerCalled, false);
+    assert.strictEqual(write.mock.calls.length, 0);
+    assert.strictEqual(result.status, 'error');
+    assert.strictEqual(
+      result.userInstruction,
+      'Denied by TeXRA approval policy.',
+    );
+    assert.strictEqual(policyDenials, 1);
   });
 
   it('session bypass auto-approves pending requests', async () => {

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -20,6 +20,10 @@ import {
   type BashPermission,
   type StreamTabId,
 } from '@shared/schemas';
+import {
+  decideTexraApproval,
+  TEXRA_APPROVAL_POLICY_DENIED_MESSAGE,
+} from '@shared/approvalPolicy';
 import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { requireInteractions } from '@tools/contextHelpers';
@@ -93,12 +97,23 @@ export async function requestBashApproval(
   const context = tryUseRunContext();
   const session = getRunContextSession(context) ?? defaultSession();
   const streamId = request.streamId ?? getRunContextStreamId(context);
+  const isStreamBypassed = Boolean(
+    streamId && session.approvals.bash.bypass.isBypassed(streamId),
+  );
+  const decision = decideTexraApproval({
+    policy: session.approvalPolicy,
+    promptRequired: approvalsEnabled,
+    scopedBypass: isStreamBypassed,
+    canPresent: context?.approvalPromptsUnavailable !== true,
+  });
 
-  if (
-    !approvalsEnabled ||
-    (streamId && session.approvals.bash.bypass.isBypassed(streamId))
-  ) {
-    return { action: 'approve' };
+  if (decision === 'allow') return { action: 'approve' };
+  if (decision === 'deny') {
+    context?.onApprovalPolicyDenial?.();
+    return {
+      action: 'reject',
+      feedback: TEXRA_APPROVAL_POLICY_DENIED_MESSAGE,
+    };
   }
 
   requireInteractions('bash approval', context);

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -10,6 +10,10 @@ import {
 } from '@agent/runtime/RunContext';
 import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import { isLatexFile } from '@common/files/fileTypeUtils';
+import {
+  decideTexraApproval,
+  TEXRA_APPROVAL_POLICY_DENIED_MESSAGE,
+} from '@shared/approvalPolicy';
 import type { StreamTabId, ToolEditPermission } from '@shared/schemas';
 import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
 import type { LineChanges } from '@shared/schemas/lineChanges';
@@ -242,15 +246,27 @@ export async function requestToolEditApproval(
       : { ...request, streamId: contextStreamId };
 
   const streamId = preparedRequest.streamId ?? undefined;
-  const isStreamBypassed =
-    streamId && session.approvals.toolEdit.bypass.isBypassed(streamId);
+  const isStreamBypassed = Boolean(
+    streamId && session.approvals.toolEdit.bypass.isBypassed(streamId),
+  );
   const acceptProposedAsIs = (): ToolEditApprovalResult =>
     finalizeApprovalResult(
       { accepted: true, appliedContent: preparedRequest.proposedContent },
       preparedRequest,
     );
-  if (!approvalsEnabled || isStreamBypassed) {
-    return acceptProposedAsIs();
+  const decision = decideTexraApproval({
+    policy: session.approvalPolicy,
+    promptRequired: approvalsEnabled,
+    scopedBypass: isStreamBypassed,
+    canPresent: context?.approvalPromptsUnavailable !== true,
+  });
+  if (decision === 'allow') return acceptProposedAsIs();
+  if (decision === 'deny') {
+    context?.onApprovalPolicyDenial?.();
+    return {
+      accepted: false,
+      userMessage: TEXRA_APPROVAL_POLICY_DENIED_MESSAGE,
+    };
   }
 
   return session.approvals.toolEdit.enqueue(streamId ?? undefined, {

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -71,6 +71,7 @@ interface InBandSubagentExecutionBaseOptions {
   readonly parentStreamId: StreamTabId;
   readonly session: SessionHandle;
   readonly approvalPromptsUnavailable?: boolean;
+  readonly onApprovalPolicyDenial?: () => void;
   readonly runtimeUnavailableTools?: readonly string[];
   readonly signal?: AbortSignal;
   readonly onStreamResolved?: (streamId: StreamTabId) => void;
@@ -487,6 +488,7 @@ async function executeInBand(
         startedAt,
         workingDirectory,
         approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+        onApprovalPolicyDenial: options.onApprovalPolicyDenial,
         runtimeUnavailableTools: options.runtimeUnavailableTools,
         workflowPhase: options.workflowPhase,
         executionMode: 'single-cycle',

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -76,6 +76,7 @@ export interface NativeSubagentStrategyParams {
   readonly startedAt: number;
   readonly workingDirectory?: string;
   readonly approvalPromptsUnavailable?: boolean;
+  readonly onApprovalPolicyDenial?: () => void;
   readonly runtimeUnavailableTools?: readonly string[];
   readonly workflowPhase?: string;
   /** Omit for ordinary interactive delegation; durable calls end after one cycle. */
@@ -226,6 +227,7 @@ export function createNativeSubagentStrategy(
           enforceCategory: params.agentCategoryExplicit,
           parentStreamId: params.orchestratorStreamId,
           approvalPromptsUnavailable: params.approvalPromptsUnavailable,
+          onApprovalPolicyDenial: params.onApprovalPolicyDenial,
           runtimeUnavailableTools: params.runtimeUnavailableTools,
           workflowPhase: params.workflowPhase,
           onStreamResolved: params.onStreamResolved,
@@ -286,6 +288,7 @@ export function createNativeSubagentStrategy(
         return await resumeToolUseFromResumeData(resume, {
           session: params.parentSession,
           approvalPromptsUnavailable: params.approvalPromptsUnavailable,
+          onApprovalPolicyDenial: params.onApprovalPolicyDenial,
           runtimeUnavailableTools: params.runtimeUnavailableTools,
           parentStreamId: params.orchestratorStreamId,
           // The loop's queue never admits synthetic goal continuations for

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -131,6 +131,7 @@ export async function executeSubagent(
         parentStreamId: orchestratorStreamId,
         session: parentSession,
         approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
+        onApprovalPolicyDenial: parentContext.onApprovalPolicyDenial,
         runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
         onStreamResolved: inheritChildStreamApprovals,
         onCost: recordCost,
@@ -180,6 +181,7 @@ export async function executeSubagent(
       startedAt,
       workingDirectory,
       approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
+      onApprovalPolicyDenial: parentContext.onApprovalPolicyDenial,
       runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
       onStreamResolved: inheritChildStreamApprovals,
     };

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -345,6 +345,7 @@ export function createWorkflowScriptAgentRunner(
             session: runScope.session,
             signal: invocation.signal,
             approvalPromptsUnavailable: parent.approvalPromptsUnavailable,
+            onApprovalPolicyDenial: parent.onApprovalPolicyDenial,
             runtimeUnavailableTools: parent.runtimeUnavailableTools,
             // The engine settles the owning phase onto the call options before
             // handing them here (declared task phase, else the phase active at


### PR DESCRIPTION
## Summary

Enforce the live TeXRA approval policy at the shared Bash and tool-edit request boundaries instead of deciding it independently in each CLI presenter.

- `never` denies executable requests before prompt transport, even when a prompt setting is disabled or the stream has a scoped bypass.
- `yolo` and prompt-disabled `ask` requests proceed without presentation.
- Headless `ask` denies requests that still require presentation instead of parking them.
- CLI denial classification follows the run through fresh runs, resumes, subagents, and workflow-script children. A denied required gate returns exit code 4 even if the model later completes; explicit interruption remains exit 130.

## Issue acceptance gates

Advances #9597 without closing it.

- Completes shared request-time enforcement for Bash and tool edits.
- Removes the corresponding CLI-only policy branches from the headless and TUI presentation adapters.
- Preserves exact stream/kind bypass isolation and request-time policy capture.
- Leaves desktop/extension policy seeding, native controls, and final structural checks for the remaining stages.

## Single source of truth

`SessionHandle.approvalPolicy` supplies the live value, and `decideTexraApproval()` remains the only evaluator. `requestBashApproval()` and `requestToolEditApproval()` construct the request facts and apply that decision before presentation.

## Duplication and abstraction budget

The CLI no longer evaluates Bash/edit policy in both its headless and TUI adapters. No resolver, registry, service, migration, or persistence layer was added. One optional run-context callback carries denial classification to the CLI boundary without placing policy bookkeeping in `HostInteractions`.

## Net elements (R6)

- Files: 25 changed, 0 added, 0 deleted
- Lines: 233 added, 64 deleted, net +169
- Exported symbols: 2 added (`TEXRA_APPROVAL_POLICY_DENIED_MESSAGE`, `formatBashApprovalSummary`), 0 removed
- Classes, interfaces, and enums: no net change
- Most added lines are focused boundary tests and direct callback forwarding; production logic remains a single evaluator call at each tool boundary.

## Consumer counts (R8)

- CLI `showBashPermission` policy-dispatch arm: 1 producer and 1 formatter branch removed; 0 remain.
- Headless tool-edit immediate-policy branch: 1 removed; 0 remain.
- TUI Bash/edit immediate-policy branches: 2 removed; 0 remain.
- Run denial callback: forwarded by the four CLI root/resume paths and inherited by ordinary, in-band, native, resumed, and workflow-script child runs.

## Host impact

Extension: Existing `ask` behavior is unchanged. A later #9597 stage will seed and expose the native policy value.

Desktop: Existing `ask` behavior is unchanged. A later #9597 stage will seed and expose the native policy value.

CLI: Bash and edit policy is enforced before presentation across headless, TUI, resume, and delegated runs. Required-gate denial maps to exit code 4 unless the run is interrupted.

## Scheduled refactoring

#9597 remains open for desktop/extension policy adoption, native controls and status, deletion of any remaining superseded enforcement branches, and the final structural check.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `npm test` — 8,459 passed, 5 skipped
- Focused approval/runtime/delegation suite — 227 passed
- Two independent architecture reviews; the first rejected host-transport bookkeeping, and the final design uses run-owned propagation instead

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Bash and file edits are allowed or denied across CLI modes, resumes, and delegated runs; incorrect policy or exit-code wiring could block legitimate commands or misreport success.
> 
> **Overview**
> Bash and tool-edit approvals now go through **`decideTexraApproval()`** in `requestBashApproval()` and `requestToolEditApproval()` before any CLI/TUI modal or headless prompt. **`never`** rejects even when edit/bash prompts are disabled or a stream bypass is set; **`yolo`** (and prompt-disabled **`ask`**) auto-allow without presentation.
> 
> CLI headless and TUI adapters no longer run **`immediateDecision`** for bash/edit—only plans, proposals, and retries keep presenter-side policy. Denials invoke **`onApprovalPolicyDenial`** → **`markApprovalDenied`**, threaded through runs, resumes, and subagents. Exit mapping prefers **`ApprovalDenied` (4)** when a policy denial was recorded (including on a later **completed** outcome), while **cancelled** still exits **130**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74a722362e1c71c7432b0bb4e6ce978087c2db85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->