### PR TITLE
refactor(lean): remove unused server observers

### DIFF
--- a/src/test-kernel/tools/lean/LeanServerRegistry.vitest.ts
+++ b/src/test-kernel/tools/lean/LeanServerRegistry.vitest.ts
@@ -1,6 +1,5 @@
 /**
- * Vitests for the Lean server registry — covers register/update/list/
- * unregister plus the dashboard-facing `summarizeLeanServers` formatter.
+ * Vitests for the Lean server registry and its dashboard-facing formatter.
  */
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -9,7 +8,6 @@ import {
   isLeanServerActive,
   listLeanServers,
   registerLeanServer,
-  subscribeLeanServers,
   summarizeLeanServers,
   unregisterLeanServer,
   updateLeanServer,
@@ -69,18 +67,6 @@ describe('leanServerRegistry', () => {
     ]);
   });
 
-  it('notifies subscribers and stops once unsubscribed', () => {
-    const seen: number[] = [];
-    const unsubscribe = subscribeLeanServers((view) => seen.push(view.length));
-
-    registerLeanServer({ id: 'a', workspaceRoot: '/a', mode: 'direct-lsp' });
-    registerLeanServer({ id: 'b', workspaceRoot: '/b', mode: 'direct-lsp' });
-    unsubscribe();
-    registerLeanServer({ id: 'c', workspaceRoot: '/c', mode: 'direct-lsp' });
-
-    expect(seen).toEqual([1, 2]);
-  });
-
   it('counts only starting and running servers as active', () => {
     expect(
       [
@@ -98,15 +84,6 @@ describe('leanServerRegistry', () => {
         } as LeanServerInfo),
       ),
     ).toHaveLength(2);
-  });
-
-  it('does not call listeners when nothing matches an update id', () => {
-    let calls = 0;
-    subscribeLeanServers(() => {
-      calls += 1;
-    });
-    updateLeanServer('does-not-exist', { status: 'running' });
-    expect(calls).toBe(0);
   });
 });
 

--- a/src/tools/lean/leanServerRegistry.ts
+++ b/src/tools/lean/leanServerRegistry.ts
@@ -11,7 +11,6 @@
  * surface across all three builds.
  */
 
-import { warn } from '@logger/logUtils';
 import {
   formatCompactDuration,
   formatResultCount,
@@ -34,30 +33,12 @@ export interface LeanServerInfo {
   readonly errorMessage?: string;
 }
 
-type Listener = (snapshot: readonly LeanServerInfo[]) => void;
-
 const servers = new Map<string, LeanServerInfo>();
-const listeners = new Set<Listener>();
 
 function snapshot(): readonly LeanServerInfo[] {
   return [...servers.values()].sort((a, b) =>
     a.workspaceRoot.localeCompare(b.workspaceRoot),
   );
-}
-
-function notify(): void {
-  const view = snapshot();
-  for (const listener of listeners) {
-    try {
-      listener(view);
-    } catch (error) {
-      // Isolate observers so one bad listener can't break the others, but
-      // surface the failure since a throwing listener is unexpected.
-      warn('lean.serverRegistry', 'Lean server listener threw', {
-        data: error,
-      });
-    }
-  }
 }
 
 export function listLeanServers(): readonly LeanServerInfo[] {
@@ -66,11 +47,6 @@ export function listLeanServers(): readonly LeanServerInfo[] {
 
 export function isLeanServerActive(info: LeanServerInfo): boolean {
   return info.status === 'starting' || info.status === 'running';
-}
-
-export function subscribeLeanServers(listener: Listener): () => void {
-  listeners.add(listener);
-  return () => listeners.delete(listener);
 }
 
 export interface RegisterLeanServerInit {
@@ -92,7 +68,6 @@ export function registerLeanServer(init: RegisterLeanServerInit): void {
     toolchain: init.toolchain,
     pid: init.pid,
   });
-  notify();
 }
 
 export interface UpdateLeanServerPatch {
@@ -118,19 +93,15 @@ export function updateLeanServer(
         ? undefined
         : (patch.errorMessage ?? existing.errorMessage),
   });
-  notify();
 }
 
 export function unregisterLeanServer(id: string): void {
-  if (!servers.delete(id)) return;
-  notify();
+  servers.delete(id);
 }
 
-/** Clear all entries — only used by tests and shutdown handlers. */
+/** Clear all entries so registry-dependent tests remain isolated. */
 export function clearLeanServerRegistry(): void {
-  if (servers.size === 0) return;
   servers.clear();
-  notify();
 }
 
 function statusTail(info: LeanServerInfo, now: number): string {


### PR DESCRIPTION
## Summary

Remove the unused observer side of the Lean server registry.

The registry still records, updates, lists, formats, and clears active Lean
servers. No production code subscribed to registry changes, so the listener
set, notification fan-out, error isolation, and four notification calls formed
a second interface with no consumer. The two tests that existed only for that
unused interface are removed with it.

`clearLeanServerRegistry()` remains as the direct test-isolation boundary. No
replacement event abstraction or compatibility path is introduced.

## User impact

None. The Tools dashboard reads the registry on demand through
`listLeanServers()`; its displayed status and availability behavior are
unchanged.

## Single source of truth

`leanServerRegistry.ts` remains the one owner of active Lean server state.
This change removes an unobserved projection of that state.

## Net elements (R6)

- Files: 2 changed, +3 / -55.
- Exported symbols: -1 (`subscribeLeanServers`).
- Internal state: -1 listener set.
- Functions: -1 notification dispatcher.
- Tests: -2 observer-only tests.
- No files, classes, interfaces, enums, or abstractions added.

## Consumer count (R8)

Repository search found zero production consumers of
`subscribeLeanServers`. Its only consumer was its own test file. The retained
registry functions have current production or test consumers.

## Validation

- `npm run format`
- `npm run lint`
- `npm run compile:fast`
- `npm run typecheck:workspace`
- `npm test`: 823 files passed, 1 skipped; 8,457 tests passed, 5 skipped
- Focused Lean registry/tool tests: 22 passed
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal with no production subscribers; dashboard still reads the registry via pull-style listing.
> 
> **Overview**
> Removes the **unused observer API** from the Lean server registry: `subscribeLeanServers`, the internal listener set, `notify()` fan-out (including per-listener error logging), and the `warn` import that only supported that path.
> 
> Registry **mutations no longer broadcast**; `registerLeanServer`, `updateLeanServer`, `unregisterLeanServer`, and `clearLeanServerRegistry` only update the in-memory map. `unregisterLeanServer` and `clearLeanServerRegistry` are simplified (no notify-on-delete or size checks). Comments are tightened to reflect test isolation for `clearLeanServerRegistry`.
> 
> The vitest file drops **two subscriber-only tests** and stops importing `subscribeLeanServers`; remaining tests still cover register/update/list, active detection, and `summarizeLeanServers`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7df6a3e38fc338d2a09340132a5691a77716bbb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->