### PR TITLE
refactor(cli): move Agent skills into Settings

### DIFF
--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -6,11 +6,8 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import { canLaunchTeam } from '@common/teams/TeamPlan';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { platform } from '@platform/platform';
-import { AGENT_SKILLS_CONFIG_KEY } from '@shared/schemas/agentSkills';
-import { readAgentSkillsEnabled } from '@shared/settingsView/handlers/agentSkillsHandlers';
 import { getFirstRunDone } from '@shared/state/onboardingState';
 import type { ApiAccessMode } from '@shared/schemas/profileViewMessages';
-import { updateConfig } from '@utils/config/configUtils';
 
 import {
   firstRunSetupAgentOverride,
@@ -196,7 +193,6 @@ async function runOrchestration(context: CliContext): Promise<number> {
       includeMultiAgentLoginHint: !presetPlanSet.remoteAgentLoadAttempted,
       modelAccess: launcherModelAccess,
       account: accountStatus,
-      agentSkillsEnabled: readAgentSkillsEnabled(platform().config),
       presetLaunchBlockReason,
     });
     // Load the model registry up front so the launcher can offer a model pick
@@ -338,13 +334,6 @@ async function runOrchestration(context: CliContext): Promise<number> {
           colorEnabled: context.stdoutColorEnabled,
           onError: writeErrorStderr,
         });
-        continue launcher;
-      }
-      case 'set-agent-skills': {
-        await updateConfig(AGENT_SKILLS_CONFIG_KEY, action.enabled);
-        writeTextStdout(
-          action.enabled ? 'Agent skills enabled.' : 'Agent skills disabled.',
-        );
         continue launcher;
       }
       case 'account': {

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -50,7 +50,6 @@ export type CliOrchestrationAction =
   | { readonly kind: 'browse-teams' }
   | { readonly kind: 'browse-accounts' }
   | { readonly kind: 'configure-settings' }
-  | { readonly kind: 'set-agent-skills'; readonly enabled: boolean }
   | {
       readonly kind: 'account';
       readonly provider: CliAccountProvider;
@@ -87,7 +86,6 @@ export interface BuildCliOrchestrationItemsInput {
   readonly includeMultiAgentLoginHint?: boolean;
   readonly modelAccess?: CliModelAccessStatus;
   readonly account?: CliAccountStatus;
-  readonly agentSkillsEnabled?: boolean;
   readonly presetLaunchBlockReason?: CliPresetLaunchBlockReason;
 }
 
@@ -191,18 +189,6 @@ export function buildCliOrchestrationItems(
       value: { kind: 'browse-accounts' },
       label: 'Account',
       description: accountSummary(input.account),
-    });
-  }
-  if (input.agentSkillsEnabled !== undefined) {
-    items.push({
-      value: {
-        kind: 'set-agent-skills',
-        enabled: !input.agentSkillsEnabled,
-      },
-      label: 'Agent skills',
-      description: input.agentSkillsEnabled
-        ? 'On · TeXRA and imported skills available to tool-use agents'
-        : 'Off · tool-use agents receive no skills',
     });
   }
   items.push({

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -264,6 +264,12 @@ const TOOL_PATH_PROTECTION_RUNTIME_REACHABILITY = {
   through:
     'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/tools/pathResolution.ts',
 } satisfies CliRuntimeReachability;
+const AGENT_SKILLS_RUNTIME_REACHABILITY = {
+  command:
+    'texra agents run <tool-use-agent> --instruction "answer a short question"',
+  through:
+    'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/agent/runtime/runAgent.ts -> src/agent/runtime/executeAgent.ts -> src/agent/runtime/AgentLaunchContext.ts -> src/agent/utils/userVars.ts',
+} satisfies CliRuntimeReachability;
 
 const PROXY_CONFIG_CONSUMER =
   'src/agent/modelHandlers/support/ProxyConfigResolver.ts';
@@ -750,10 +756,14 @@ const STATE_SETTINGS_BY_KEY: ReadonlyMap<string, StateSettingEntry> = new Map(
   STATE_SETTINGS.map((entry) => [entry.key, entry]),
 );
 
-// These two rows already belong to CoreSettingsShape, so they must not enter
-// the state-backed catalog above. They carry only the storage and rebroadcast
+// These rows already belong to CoreSettingsShape, so they must not enter the
+// state-backed catalog above. They carry only the storage and rebroadcast
 // metadata needed by the settings view's unified scalar-write boundary.
-const SETTINGS_VIEW_CORE_SETTINGS = [
+// Exported so host rosters and the guardrail suite can iterate the full
+// catalog (state-backed plus settings-view rows) in one place. Typed at the
+// catalog-entry level (not `as const`) so `hosts.includes('cli')` checks
+// compile against the widened `SettingHost` union.
+export const SETTINGS_VIEW_CORE_SETTINGS: readonly StateSettingEntry[] = [
   {
     key: 'texra.latex.wrapCritiqueInAlign',
     schema: CoreSettingsShape.latex.unwrap().shape.wrapCritiqueInAlign,
@@ -835,7 +845,9 @@ const SETTINGS_VIEW_CORE_SETTINGS = [
       'Discover TeXRA and imported skills and expose them to tool-use agent prompts.',
     category: 'tools',
     store: 'config',
-    hosts: ['vscode', 'desktop'],
+    hosts: ['vscode', 'desktop', 'cli'],
+    cliConsumer: 'src/agent/utils/userVars.ts',
+    cliRuntimeReachability: AGENT_SKILLS_RUNTIME_REACHABILITY,
     settingsViewSnapshot: 'agent-skills',
   },
   {
@@ -850,7 +862,7 @@ const SETTINGS_VIEW_CORE_SETTINGS = [
     hosts: ['vscode', 'desktop'],
     settingsViewSnapshot: 'telemetry',
   },
-] as const satisfies readonly StateSettingEntry[];
+];
 
 const SETTINGS_VIEW_SETTINGS_BY_KEY: ReadonlyMap<
   string,
@@ -877,12 +889,17 @@ export function settingsViewSettingByKey(
 }
 
 /**
- * The single canonical "CLI roster" — catalog entries the CLI consumes. Both
- * the `/config` panel and any key-list derivation come from this one filter so
- * the `hosts.includes('cli')` predicate lives in exactly one place.
+ * The single canonical "CLI roster" — catalog entries the CLI consumes,
+ * spanning both the state-backed catalog and the settings-view core rows
+ * (e.g. Agent skills, which the CLI reads from `texra.skills.enabled` in
+ * config). Both the `/config` panel and any key-list derivation come from
+ * this one filter so the `hosts.includes('cli')` predicate lives in exactly
+ * one place.
  */
-export const CLI_STATE_SETTINGS: readonly StateSettingEntry[] =
-  STATE_SETTINGS.filter((entry) => entry.hosts.includes('cli'));
+export const CLI_STATE_SETTINGS: readonly StateSettingEntry[] = [
+  ...STATE_SETTINGS,
+  ...SETTINGS_VIEW_CORE_SETTINGS,
+].filter((entry) => entry.hosts.includes('cli'));
 
 /** The entry's schema with the outer `.prefault()` wrapper peeled off. */
 function innerSchema(entry: StateSettingEntry): unknown {

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -51,6 +51,7 @@ import { AgentCategory } from '@shared/schemas/agent';
 import {
   CLI_STATE_SETTINGS,
   DEFAULT_GIT_AUTHOR_NAME,
+  SETTINGS_VIEW_CORE_SETTINGS,
   STATE_SETTINGS,
   type StateSettingEntry,
 } from '@shared/schemas/stateSettings';
@@ -212,9 +213,9 @@ function openConfigFormProps(
 describe('ConfigForm helpers', () => {
   it('rosters exactly the CLI-consumed catalog entries', () => {
     expect([...CLI_STATE_SETTINGS].map((entry) => entry.key)).toEqual(
-      STATE_SETTINGS.filter((entry) => entry.hosts.includes('cli')).map(
-        (entry) => entry.key,
-      ),
+      [...STATE_SETTINGS, ...SETTINGS_VIEW_CORE_SETTINGS]
+        .filter((entry) => entry.hosts.includes('cli'))
+        .map((entry) => entry.key),
     );
     expect(CLI_STATE_SETTINGS.length).toBeGreaterThan(0);
     // Every rostered entry must be reachable from the CLI's store set.

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -389,17 +389,6 @@ describe('CLI orchestration items', () => {
     ]);
   });
 
-  it('presents agent skills as an independent launcher switch', () => {
-    const items = orchestrationItems({ agentSkillsEnabled: true });
-
-    expect(items.find((item) => item.label === 'Agent skills')).toEqual({
-      label: 'Agent skills',
-      description:
-        'On · TeXRA and imported skills available to tool-use agents',
-      value: { kind: 'set-agent-skills', enabled: false },
-    });
-  });
-
   it('describes the Kimi Code route by key state and activity', () => {
     expect(
       buildCliModelAccessItems({

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -14,6 +14,7 @@ import {
   CORE_SETTING_PATHS,
   EXTENSION_ONLY_CORE_SETTING_CONSUMERS,
 } from '@shared/schemas/coreSettings';
+import { AGENT_SKILLS_CONFIG_KEY } from '@shared/schemas/agentSkills';
 import {
   CLI_STATE_SETTINGS,
   DEFAULT_GIT_AUTHOR_EMAIL,
@@ -21,6 +22,7 @@ import {
   DEFAULT_GIT_MARK_COMMITS,
   DEFAULT_GIT_WORKTREE_SUPPORT,
   DEFAULT_TOOL_PATH_PROTECTION_ENABLED,
+  SETTINGS_VIEW_CORE_SETTINGS,
   STATE_SETTINGS,
   STATE_SETTING_KEYS,
   settingEnumChoices,
@@ -62,6 +64,12 @@ const VALID_STORES: ReadonlySet<SettingStore> = new Set<SettingStore>([
   'workspaceState',
   'globalState',
 ]);
+
+/** Every catalog row across both tiers: state-backed plus settings-view core. */
+const ALL_CATALOG_ENTRIES: readonly StateSettingEntry[] = [
+  ...STATE_SETTINGS,
+  ...SETTINGS_VIEW_CORE_SETTINGS,
+];
 
 const CLI_RUNTIME_COMMAND_PATTERN =
   /^texra\s+(?:chat|run|agents run|multi-agent run|orchestrate)\b/;
@@ -138,7 +146,7 @@ describe('state settings catalog', () => {
   });
 
   it('every CLI-host entry names an existing consumer file', () => {
-    for (const entry of STATE_SETTINGS) {
+    for (const entry of ALL_CATALOG_ENTRIES) {
       if (!entry.hosts.includes('cli')) {
         continue;
       }
@@ -154,7 +162,7 @@ describe('state settings catalog', () => {
   });
 
   it('every CLI-host entry documents a runtime-reachability path', () => {
-    for (const entry of STATE_SETTINGS) {
+    for (const entry of ALL_CATALOG_ENTRIES) {
       if (!entry.hosts.includes('cli')) {
         assert.equal(
           entry.cliRuntimeReachability,
@@ -379,6 +387,8 @@ describe('state settings catalog', () => {
     //    providerConfig/ProxyConfigResolver during CLI model dispatch.
     //  - the Kimi Code prefer switch is read by ModelFactory when dispatching
     //    dual-backend Kimi models in CLI runs.
+    //  - agent skills is read by buildUserVars (userVars) when assembling
+    //    tool-use agent prompts, skipping skill discovery when disabled.
     // auto-open-pdf (no CLI opener), latexdiff, and the formatter are
     // intentionally excluded. Changing the CLI roster must be a deliberate edit
     // here, not an accident of flipping `hosts`.
@@ -411,6 +421,7 @@ describe('state settings catalog', () => {
         GlobalStateKey.GLM_USE_CHINA,
         GlobalStateKey.GLM_CODING_PLAN,
         GlobalStateKey.DISABLED_TOOLS,
+        AGENT_SKILLS_CONFIG_KEY,
       ].sort(),
     );
   });


### PR DESCRIPTION
## Summary

- remove the separate Agent skills switch from the TUI start menu
- expose the existing native `texra.skills.enabled` setting through the canonical CLI Settings catalog
- delete the obsolete launcher action and its dedicated presentation test

This keeps skill configuration in one place and makes the TUI consistent with the extension and desktop settings surfaces.

## Issue acceptance gates

No issue is linked. This implements the requested removal of the duplicate TUI launcher toggle while preserving the existing native skill setting.

## Single source of truth

`CLI_STATE_SETTINGS` is the CLI settings roster. It now combines eligible state-backed entries with eligible settings-view core entries before applying the single CLI-host filter.

## Duplication and abstraction budget

The independent launcher read, action, write handler, menu item, and presentation test are removed. No new service, adapter, migration, or compatibility path is added. The existing catalog entry gains CLI host and reachability metadata.

## Net elements (R6)

- files: 6 modified; none added or deleted
- lines: 44 added, 51 deleted; net -7
- exported symbols: 1 added (`SETTINGS_VIEW_CORE_SETTINGS`), with two test consumers; none removed
- removed constructs: one action-union arm, one launcher input field, one dispatch case, one launcher item, and one presentation test
- added constructs: one runtime-reachability metadata constant

## Consumer counts (R8)

- removed `set-agent-skills` action: one producer and one consumer, both deleted
- removed `agentSkillsEnabled` launcher input: one producer and one consumer, both deleted
- existing `texra.skills.enabled` runtime consumer remains `src/agent/utils/userVars.ts`

## Host impact

Extension: no behavior change.

Desktop: no behavior change.

CLI: Agent skills moves from the start menu to Settings; persisted behavior and runtime consumption are unchanged.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- focused Vitest suites: 3 files, 101 tests