### PR TITLE
refactor(tools): consolidate ad-hoc nanoid calls to generateShortId

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,10 @@ Things the tree won't tell you:
 
 Two wiring points fail silently if you forget them: a new VS Code command must
 be registered through `packages/extension/src/commands.ts`, and a new setting
-must have its key declared in `package.json` under `contributes.configuration`.
+must be declared in the Zod schemas (`src/shared/schemas/coreSettings.ts` or
+`stateSettings.ts`) and the native TeXRA settings view —
+`packages/extension/package.json` must NOT contribute `configuration`;
+`scripts/sync-package-contributes.mjs` throws if it does.
 
 ## Separation of concerns: VS Code coupling
 

--- a/src/controllers/approval/ToolEditApprovalController.ts
+++ b/src/controllers/approval/ToolEditApprovalController.ts
@@ -7,8 +7,6 @@
  * what the user edited — lives behind {@link ToolEditApprovalHost}.
  */
 
-import { nanoid } from 'nanoid';
-
 import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import {
   matchesCancelSelector,
@@ -31,6 +29,7 @@ import {
   type ToolEditApprovalRequest,
   type ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
+import { generateShortId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { normalizeLineEndings } from '@utils/text/stringUtils';
 
@@ -135,7 +134,7 @@ export class ToolEditApprovalController {
       throw new Error('Tool edit approval controller is disposed.');
     }
 
-    const requestId = `approval-${nanoid()}`;
+    const requestId = `approval-${generateShortId()}`;
     const relativePath = this.options.host.relativeDisplayPath(request.path);
     const initialization: InitializingToolEditApproval = {
       phase: 'initializing',

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -1,4 +1,3 @@
-import { nanoid } from 'nanoid';
 import { z } from 'zod';
 
 import type {
@@ -28,6 +27,7 @@ import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { requireInteractions } from '@tools/contextHelpers';
 import { errorResult } from '@tools/core/result';
+import { generateShortId } from '@utils/core';
 import { getConfig } from '@utils/config/configUtils';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
@@ -81,7 +81,7 @@ export function prepareBashApprovalPrompt(
     : false;
   const cwd = request.cwd?.trim();
   return {
-    requestId: `bash-${nanoid()}`,
+    requestId: `bash-${generateShortId()}`,
     command: request.command,
     ...(cwd ? { cwd } : {}),
     allowBypass: !isBypassed,

--- a/src/tools/approval/latexPreview.ts
+++ b/src/tools/approval/latexPreview.ts
@@ -6,7 +6,6 @@
 import path from 'node:path';
 
 import { sync as globSync } from 'glob';
-import { nanoid } from 'nanoid';
 import { z } from 'zod';
 
 import { TEMP_EXTENSIONS } from '@housekeeping/constants';
@@ -20,6 +19,7 @@ import {
   createWorkspaceLocation,
   WorkspaceFS,
 } from '@utils/files';
+import { generateShortId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getValidatedConfig } from '@utils/config/configUtils';
 import { isStrictlyWithin } from '@utils/core/pathCore';
@@ -148,7 +148,7 @@ async function createTempFileWithCleanup(
   const originalPath = entry.request.path;
   const ext = path.extname(originalPath);
   const basename = path.basename(originalPath, ext);
-  const tempFileName = `${basename}${suffix}-${nanoid(TEMP_ID_LENGTH)}${ext}`;
+  const tempFileName = `${basename}${suffix}-${generateShortId(TEMP_ID_LENGTH)}${ext}`;
 
   let tempDir: string;
   if (location === 'workspaceTemp') {

--- a/src/tools/approval/tempFileManager.ts
+++ b/src/tools/approval/tempFileManager.ts
@@ -23,9 +23,8 @@
 import { unlink, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { nanoid } from 'nanoid';
-
 import { debug } from '@logger/logUtils';
+import { generateShortId } from '@utils/core';
 
 export interface ApprovalTempFiles {
   readonly originalPath: string;
@@ -55,8 +54,8 @@ export async function writeApprovalTempFiles(
 ): Promise<ApprovalTempFiles> {
   const { directory, targetPath, originalContent, proposedContent } = input;
   const ext = path.extname(targetPath) || '.txt';
-  const originalPath = path.join(directory, `${nanoid()}-original${ext}`);
-  const proposedPath = path.join(directory, `${nanoid()}-proposed${ext}`);
+  const originalPath = path.join(directory, `${generateShortId()}-original${ext}`);
+  const proposedPath = path.join(directory, `${generateShortId()}-proposed${ext}`);
 
   await Promise.all([
     writeFile(originalPath, originalContent, 'utf8'),

--- a/src/tools/approval/tempFileManager.ts
+++ b/src/tools/approval/tempFileManager.ts
@@ -54,8 +54,14 @@ export async function writeApprovalTempFiles(
 ): Promise<ApprovalTempFiles> {
   const { directory, targetPath, originalContent, proposedContent } = input;
   const ext = path.extname(targetPath) || '.txt';
-  const originalPath = path.join(directory, `${generateShortId()}-original${ext}`);
-  const proposedPath = path.join(directory, `${generateShortId()}-proposed${ext}`);
+  const originalPath = path.join(
+    directory,
+    `${generateShortId()}-original${ext}`,
+  );
+  const proposedPath = path.join(
+    directory,
+    `${generateShortId()}-proposed${ext}`,
+  );
 
   await Promise.all([
     writeFile(originalPath, originalContent, 'utf8'),

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -5,9 +5,6 @@
  * waits for user approval via `session.interactions` before executing.
  */
 
-// Third-party imports
-import { nanoid } from 'nanoid';
-
 // Local imports
 import type { AgentEntry } from '@agent/index/agentRegistry';
 import { currentSession } from '@agent/runtime/SessionHandle';
@@ -23,6 +20,7 @@ import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import { proposalApprovals } from '@tools/approval';
 import { errorResult, executed } from '@tools/core/result';
+import { generateShortId } from '@utils/core';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
@@ -150,7 +148,7 @@ export async function proposeAndExecute(
     });
   }
 
-  const proposalId = nanoid();
+  const proposalId = generateShortId();
 
   const interaction = currentSession().interactions.requestAgentProposal({
     proposalId,

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -14,7 +14,6 @@
  */
 
 // Third-party imports
-import { nanoid } from 'nanoid';
 import { z } from 'zod';
 
 // Local imports
@@ -47,6 +46,7 @@ import {
 import { requireNonEmptyString } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 import { errorResult, executed } from '@tools/core/result';
+import { generateShortId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const logger = createChannelTrace('PlanTool');
@@ -243,7 +243,7 @@ pause/complete only affect autonomous goals; with no goal running they return gu
     streamId: string,
     workPlanState: WorkPlanState,
   ): Promise<ToolResult> {
-    const approvalId = `plan-${nanoid()}`;
+    const approvalId = `plan-${generateShortId()}`;
     const goalEnabled = isGoalEnabled();
 
     logger.info('Requesting approval for plan objective');

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -1,4 +1,3 @@
-import { nanoid } from 'nanoid';
 import { z } from 'zod';
 
 import { createChannelTrace } from '@agent/trace';
@@ -15,6 +14,7 @@ import {
 import type { ToolResult } from '@shared/schemas/toolResult';
 import { requireInteractions } from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
+import { generateShortId } from '@utils/core';
 
 const logger = createChannelTrace('UserQuestionTool');
 
@@ -48,7 +48,7 @@ The tool returns a JSON object whose keys are the original question texts and wh
     const context = tryUseRunContext();
     requireInteractions('ask_user_question', context);
     const streamId = getRunContextStreamId(context);
-    const requestId = `user-question-${nanoid()}`;
+    const requestId = `user-question-${generateShortId()}`;
 
     logger.info('User question requested', {
       data: input.questions[0]?.question.slice(0, 100) ?? '',


### PR DESCRIPTION
## Summary

Scheduled structural-debt audit of the whole workspace (`src/`, `packages/extension`, `packages/desktop`, `packages/cli`, `packages/agent`, `packages/trace-viewer`) for confusing or overlapped responsibilities. Most hypothesized overlaps (flow-engine boundaries, controller/shared/eventBus split, tool event emission, command registration, `packages/agent` vs `src/agent`) turned out to be intentional, already-documented design from the 2026-07 simplification campaign — those are not reported here since they'd just restate existing architecture. Two concrete, verified issues survived scrutiny, both fixed in this PR:

1. **Duplicate ID-generation logic.** Seven call sites across the approval and delegation tools imported `nanoid` directly and called it for request/temp-file IDs, instead of going through `generateShortId` (`src/utils/core/index.ts`), the wrapper the rest of the codebase already uses for this exact purpose (see `src/tools/delegation/workflowScriptRun.ts`, `src/agent/trace/TraceEmitter.ts`). Two ways to do the same thing means a future ID-policy change (alphabet, entropy) has to be applied in two places, and a reviewer can't grep one call site to audit all ID generation.
2. **Stale CLAUDE.md instruction.** It told contributors a new setting "must have its key declared in `package.json` under `contributes.configuration`" — but `scripts/sync-package-contributes.mjs` actively **throws** if that key is present (`packages/extension/package.json must not contribute TeXRA settings; use the native TeXRA settings view`). Settings now live entirely in the Zod schemas (`src/shared/schemas/coreSettings.ts`, `stateSettings.ts`) plus the native settings view. Following the stale instruction as written would break the `sync:package-contributes --check` CI gate — this is exactly the kind of doc a contributor (or agent) follows literally, and CLAUDE.md flags it as one of only two "wiring points [that] fail silently if you forget them."

## Issue acceptance gates

No tracked issue — this PR is the direct output of a scheduled codebase-responsibility audit. Gate: identify overlap/confusion, document it, and fix the most significant instance found. Both items above are fixed.

## Single source of truth

`generateShortId` in `src/utils/core/index.ts` is now the sole call path for short non-schema-constrained IDs across the seven touched sites (request IDs in `ToolEditApprovalController`, `UserQuestionTool`, `PlanTool`, `bashApproval`; the delegation `proposalId`; the two `tempFileManager` temp-file names; the `latexPreview` temp-file suffix). `nanoid` itself is untouched as a dependency and still used directly elsewhere for CSP nonce generation (`welcomeView.ts`, `common/webview/html.ts`) and a desktop diff temp path — those are a distinct security/host concern and out of scope for this consolidation.

## Duplication and abstraction budget

Removed: 7 duplicate `import { nanoid } from 'nanoid'` call sites doing the same thing `generateShortId` already does. No new abstraction added — this routes existing call sites through the existing wrapper.

## Net elements (R6)

8 files changed, 19 insertions(+), 20 deletions(-). No new/removed exports, files, classes, or interfaces — pure call-site substitution plus one CLAUDE.md doc correction.

## Consumer counts (R8)

n/a — no emit path, export, or public API changed. `generateShortId`'s existing consumers are unaffected; the change only adds 7 more.

## Host impact

Extension: no behavior change (`ToolEditApprovalController`, `bashApproval`, `latexPreview`, `tempFileManager`, `PlanTool`, `UserQuestionTool`, `proposalFlow` are host-agnostic; same underlying nanoid call, same ID shape/length).

Desktop: no behavior change (same host-agnostic modules).

CLI: no behavior change (same host-agnostic modules).

## Scheduled refactoring

None — this fully resolves the two findings from this audit pass.

## Validation

- `npm run typecheck` — full workspace (workspace, test-kernel, agent, extension, cli, trace-viewer, desktop) passes clean.
- `npx eslint <changed files>` — clean (one `import/order` violation was `--fix`ed automatically).
- Targeted Vitest suites covering the touched modules (`ToolEditApprovalController`, `SessionInteractions`, `PlanToolWorkPlanState`, `BashApprovalPrompt`) — 47/47 pass.
- Full `npm test` — 822/824 files pass; the 2 failures (`ExtensionTexraConfig.vitest.ts`, ENOENT on a workspace-storage temp config file) are pre-existing and unrelated: they reproduce identically on `main` with this diff stashed out, in a directory this PR never touches.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SsTud4u3qzg9GdEaXX9QVC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical import/call-site swap with no API or ID-format change; doc-only fix elsewhere.
> 
> **Overview**
> **Routes short ID creation through one helper** instead of scattered `nanoid` imports in approval, delegation, plan, and user-question flows (request IDs, proposal IDs, and approval temp filenames). Behavior stays the same because `generateShortId` still wraps `nanoid`.
> 
> **Fixes contributor docs for settings wiring** in `CLAUDE.md`: new keys belong in Zod schemas and the native TeXRA settings UI, and `packages/extension/package.json` must not add `contributes.configuration` (the sync script fails CI if it does).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7adcab0eda4e0a097a5cb0fe869d43bc9d095d83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->