### PR TITLE
refactor: one canonical stage slot — shared StreamStage + stage.start normalization

### DIFF
--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -25,6 +25,7 @@ import {
   type StreamTabId,
   type TokenUsageStats,
 } from '@shared/schemas';
+import type { StreamStage } from '@shared/streams/stage';
 import { isActivePhase } from '@shared/streams/streamStatus';
 import { formatStageLabel } from '@shared/streams/streamStatusDisplay';
 import {
@@ -44,7 +45,6 @@ import { formatResumeCommand } from '../state/resumeHint';
 import {
   type BypassState,
   type StreamSlice,
-  type StreamStage,
   type TransientNotice,
 } from '../state/cliState';
 import {

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -28,6 +28,7 @@ import {
 } from '@shared/schemas';
 import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
 import { isActivePhase } from '@shared/streams/streamStatus';
+import type { StreamStage } from '@shared/streams/stage';
 import type { ApiAccessMode } from '@shared/schemas/profileViewMessages';
 import {
   applyChildStreamRemoval,
@@ -152,33 +153,6 @@ interface StreamFileMetadata {
   readonly media: readonly string[];
   readonly output: readonly string[];
 }
-
-/**
- * Current run/round/phase progress for one stream. A tool-use run advances
- * through numbered rounds; a workflow-script run advances through named
- * phases instead — never both — so this is one discriminated field rather
- * than two independently-optional ones (`roundStage` / `phaseStage`) that
- * every reader had to fall back between.
- */
-export type StreamStage =
-  | {
-      readonly kind: 'round';
-      /** Zero-based round/turn index. */
-      readonly index: number;
-      /** Planned total, when known. Workflow runs set this; tool-use turns
-       *  may not. */
-      readonly total?: number;
-    }
-  | {
-      readonly kind: 'phase';
-      /** Phase title, free-form text from the workflow script. */
-      readonly label: string;
-      /** Zero-based position in the declared phase list. Absent for a phase
-       *  the script opened dynamically, which has no declared position. */
-      readonly index?: number;
-      /** Number of declared phases, when known. */
-      readonly total?: number;
-    };
 
 export interface StreamSlice {
   readonly streamId: StreamTabId;

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -14,6 +14,10 @@ import {
   type UpdateQueuedFollowUpsPayload,
   type UpdateStreamUsagePayload,
 } from '@shared/schemas';
+import {
+  streamStageFromStageStart,
+  type StreamStage,
+} from '@shared/streams/stage';
 import { assertNever } from '@utils/core';
 
 import {
@@ -23,7 +27,6 @@ import {
   patchStream,
   removeStream,
   registerCliStateResetHook,
-  type StreamStage,
 } from './cliState';
 import {
   applySubagentRoster,
@@ -199,25 +202,8 @@ const TUI_RUN_FACT_HANDLERS = {
       compileFailuresByRound: snapshots.getCompileFailures(event.streamId),
     })),
   'stage.start': (event, fallbackStreamId) => {
-    if (event.kind === 'phase') {
-      applyStage(fallbackStreamId, {
-        kind: 'phase',
-        label: event.label,
-        ...(event.index !== undefined ? { index: event.index } : {}),
-        ...(event.total !== undefined && event.total > 0
-          ? { total: event.total }
-          : {}),
-      });
-      return;
-    }
-    if (event.kind !== 'round') return;
-    applyStage(fallbackStreamId, {
-      kind: 'round',
-      index: event.index ?? 0,
-      ...(event.total !== undefined && event.total > 0
-        ? { total: event.total }
-        : {}),
-    });
+    const stage = streamStageFromStageStart(event);
+    if (stage) applyStage(fallbackStreamId, stage);
   },
   'child.activity': (event) =>
     applySubagentRoster(event.parentStreamId, event.items),

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -18,6 +18,7 @@ import type {
   StreamPhase,
   StreamTabId,
 } from '@shared/schemas';
+import { roundStageFromStageStart } from '@shared/streams/stage';
 import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
 import {
   formatRoundStageLabel,
@@ -219,20 +220,15 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
           this.render();
         }
         return;
-      case 'stage.start':
-        if (this.rootStreamTerminal || event.kind !== 'round') return;
-        if (
-          this.applyRoundStage(streamId, {
-            index: event.index ?? 0,
-            ...(event.total !== undefined && event.total > 0
-              ? { total: event.total }
-              : {}),
-          })
-        ) {
+      case 'stage.start': {
+        if (this.rootStreamTerminal) return;
+        const roundStage = roundStageFromStageStart(event);
+        if (roundStage && this.applyRoundStage(streamId, roundStage)) {
           this.updateHeartbeat();
           this.render();
         }
         return;
+      }
       case 'child.activity':
         if (this.rootStreamTerminal) return;
         this.applyActiveSubagents(event.parentStreamId, event.items);

--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -6,6 +6,7 @@ import type {
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
+import { roundStageFromStageStart } from '@shared/streams/stage';
 import { assertNever } from '@utils/core';
 import { writeNdjsonStdout } from './logSinks';
 import type {
@@ -159,20 +160,13 @@ function projectCliRunFact(
       };
     case 'goalPaused':
       return { event: 'goalPaused', payload: { streamId: event.streamId } };
-    case 'stage.start':
-      if (event.kind !== 'round') return undefined;
-      return {
-        event: 'updateRoundStage',
-        payload: {
-          streamId,
-          roundStage: {
-            index: event.index ?? 0,
-            ...(event.total !== undefined && event.total > 0
-              ? { total: event.total }
-              : {}),
-          },
-        },
-      };
+    case 'stage.start': {
+      // The frozen public wire carries round progress only; phase progress
+      // stays internal.
+      const roundStage = roundStageFromStageStart(event);
+      if (!roundStage) return undefined;
+      return { event: 'updateRoundStage', payload: { streamId, roundStage } };
+    }
     case 'child.activity':
       return {
         event: 'updateActiveSubagents',

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -39,6 +39,10 @@ import {
 } from '@shared/schemas';
 import { isGoalInFlight } from '@shared/schemas/goal';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
+import {
+  phaseStageFromStageStart,
+  roundStageFromStageStart,
+} from '@shared/streams/stage';
 import { isActivePhase } from '@shared/streams/streamStatus';
 import { GoalStore } from '@tools/goal';
 import {
@@ -152,28 +156,12 @@ export class ProgressFactApplier {
         progress: event.progress,
       }),
     'stage.start': (streamId, event) => {
-      if (event.kind === 'phase') {
-        return this.handleUpdatePhaseStage({
-          streamId,
-          phaseStage: {
-            label: event.label,
-            ...(event.index !== undefined ? { index: event.index } : {}),
-            ...(event.total !== undefined && event.total > 0
-              ? { total: event.total }
-              : {}),
-          },
-        });
-      }
-      if (event.kind !== 'round') return;
-      return this.handleUpdateRoundStage({
-        streamId,
-        roundStage: {
-          index: event.index ?? 0,
-          ...(event.total !== undefined && event.total > 0
-            ? { total: event.total }
-            : {}),
-        },
-      });
+      const phaseStage = phaseStageFromStageStart(event);
+      if (phaseStage)
+        return this.handleUpdatePhaseStage({ streamId, phaseStage });
+      const roundStage = roundStageFromStageStart(event);
+      if (roundStage)
+        return this.handleUpdateRoundStage({ streamId, roundStage });
     },
     'child.activity': (_streamId, event) =>
       this.updateChildRoster(event.parentStreamId, [...event.items]),

--- a/src/shared/streams/stage.ts
+++ b/src/shared/streams/stage.ts
@@ -1,0 +1,64 @@
+import type { PhaseStage, RoundStage } from '@shared/schemas';
+
+/**
+ * One discriminated run-progress slot. A tool-use run advances through
+ * numbered rounds; a workflow-script run advances through named phases —
+ * never both — so consumers hold one `stage` field rather than two
+ * independently-optional ones (`roundStage` / `phaseStage`) every reader
+ * has to fall back between. The arms extend the wire payload shapes, so a
+ * projection to either is a `kind` strip, never a field mapping.
+ */
+export type StreamStage =
+  | ({ readonly kind: 'round' } & RoundStage)
+  | ({ readonly kind: 'phase' } & PhaseStage);
+
+/** The `stage.start` fact fields the normalizers below read. */
+interface StageStartLike {
+  readonly kind?: 'run' | 'round' | 'phase' | 'session';
+  readonly label: string;
+  readonly index?: number;
+  readonly total?: number;
+}
+
+function boundedTotal(total: number | undefined): { total?: number } {
+  return total !== undefined && total > 0 ? { total } : {};
+}
+
+/**
+ * The `RoundStage` payload of a `kind: "round"` stage fact, or undefined for
+ * any other kind. Single home for the index/total normalization (`index`
+ * defaults to 0; a non-positive `total` is treated as unknown) that every
+ * stage consumer previously cloned inline.
+ */
+export function roundStageFromStageStart(
+  event: StageStartLike,
+): RoundStage | undefined {
+  if (event.kind !== 'round') return undefined;
+  return { index: event.index ?? 0, ...boundedTotal(event.total) };
+}
+
+/** The `PhaseStage` payload of a `kind: "phase"` stage fact, or undefined. */
+export function phaseStageFromStageStart(
+  event: StageStartLike,
+): PhaseStage | undefined {
+  if (event.kind !== 'phase') return undefined;
+  return {
+    label: event.label,
+    ...(event.index !== undefined ? { index: event.index } : {}),
+    ...boundedTotal(event.total),
+  };
+}
+
+/**
+ * Normalize a `stage.start` fact into the discriminated slot. `run` and
+ * `session` stages structure the trace, not run progress, so they yield
+ * undefined.
+ */
+export function streamStageFromStageStart(
+  event: StageStartLike,
+): StreamStage | undefined {
+  const phase = phaseStageFromStageStart(event);
+  if (phase) return { kind: 'phase', ...phase };
+  const round = roundStageFromStageStart(event);
+  return round && { kind: 'round', ...round };
+}

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -8,6 +8,7 @@ import {
   type StreamPhase,
   type StreamSubstate,
 } from '@shared/schemas';
+import type { StreamStage } from '@shared/streams/stage';
 
 export type StreamStatusDisplayKey = StreamPhase | StreamSubstate | 'ready';
 
@@ -153,10 +154,7 @@ export function formatPhaseStageLabel(
  *  through named phases, a tool-use run through numbered rounds, never both,
  *  so every surface that shows the slot dispatches on the same discriminant. */
 export function formatStageLabel(
-  stage:
-    | ({ readonly kind: 'round' } & Readonly<RoundStage>)
-    | ({ readonly kind: 'phase' } & Readonly<PhaseStage>)
-    | undefined,
+  stage: Readonly<StreamStage> | undefined,
 ): string | undefined {
   if (stage === undefined) return undefined;
   if (stage.kind === 'round') return formatRoundStageLabel(stage);


### PR DESCRIPTION
## Summary

First follow-up slice of Part III step 16 of the run-classification consolidation proposal (`docs/proposals/2026-08-03-run-classification-consolidation.md`), after #9705 merged. The CLI's discriminated `StreamStage` (`{kind:'round'}` / `{kind:'phase'}`) is promoted to `src/shared/streams/stage.ts` as the canonical run-progress slot, together with one home for `stage.start` normalization: `index ?? 0` for rounds, positive-`total` filter, and `run`/`session` stage kinds yielding no progress. The four sites that each cloned that guard inline — the TUI fact handlers, the frozen NDJSON projection, the headless line renderer, and the Lit `ProgressFactApplier` — now call the shared helpers. `formatStageLabel`'s inline structural union becomes the named `StreamStage`.

Behavior is unchanged everywhere: the frozen public NDJSON wire still carries `roundStage` only, the Lit stack still splits into `RoundStage`/`PhaseStage` payloads (the arms extend those shapes, so projection is a `kind` strip), and the TUI slot is byte-identical.

## Issue acceptance gates

Proposal step 16, partial: "all four stage-guard clones" deleted — `rg -n 'total > 0' packages/cli/src src/controllers` now hits only the shared helper. The view-model generalization itself (the rest of step 16) is the next PR.

## Single source of truth

`src/shared/streams/stage.ts` owns the `StreamStage` type and all `stage.start` → progress-slot normalization (`streamStageFromStageStart`, `roundStageFromStageStart`, `phaseStageFromStageStart`).

## Duplication and abstraction budget

Removed: four inline normalization clones (index default + positive-total guard + kind dispatch) and one inline structural type on `formatStageLabel`. Added: one module whose invariant is "one reading of a `stage.start` fact"; no pass-through layers. Caller counts: `roundStageFromStageStart` ×3 external consumers, `phaseStageFromStageStart` ×1 external (Lit applier) + the composition; `streamStageFromStageStart` has **one** external caller today (TUI `subscribeRuntimeHost`) — acknowledged single-caller state; the Lit stack's single-slot adoption in the next PR (step 16 remainder) supplies its second consumer. It does real dispatch + `kind` tagging, not forwarding.

## Net elements (R6)

8 files changed, +98/−98 (net 0 LoC). Exports: +4 (`StreamStage`, 3 normalizers) in the new module, −1 (`StreamStage` moved out of `cliState.ts`); no classes/interfaces/enums added.

## Consumer counts (R8)

`StreamStage` re-routed from `@cli .../cliState` to `@shared/streams/stage`: 3 importers updated (`subscribeRuntimeHost`, `statusBarDisplay`, `cliState` itself). No emit paths changed.

## Host impact

Extension: `ProgressFactApplier`'s `stage.start` handler now calls the shared normalizers; identical payloads on the webview wire.

Desktop: same applier path as the extension; no desktop-specific change.

CLI: TUI handler, NDJSON projection, and headless renderer call the shared normalizers; identical output.

## Scheduled refactoring

Next PR (same proposal, step 16 remainder): generalize `ProgressViewState`/`ProgressFactApplier` into the session view-model, adopt this slot in the Lit stack (`StreamExecutionState.stage`), port the TUI onto it, delete the CLI's parallel derivations.

## Validation

`npm run typecheck` (all 7 configs), `npx vitest run src/test-kernel/cli src/test-kernel/progressView src/test-kernel/shared` (233 files, 2814 passed), `npm run lint` on changed files, `npm run check:dead-code-ratchet` (18 = 18 baseline), `npm run format` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JK8BzoyKHjFg2jEam9KXv