### PR TITLE
fix(progressView): restore the shared focus ring, add non-color status cues, fix measured contrast

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
+++ b/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
@@ -68,8 +68,13 @@ export class ApproveSplitButton extends LitElement {
         flex: 0 1 auto;
         min-width: auto;
         max-width: min(14rem, 100%);
-        /* Tints both halves of the shared split-button skin. */
-        --split-accent: var(--wa-color-success-fill-loud);
+        /* Tints both halves of the shared split-button skin. The on-quiet
+           token, not fill-loud: the skin applies this as the label color, and
+           a fill token used as a foreground measured 3.90:1 (Light+) and
+           4.07:1 (Light Modern) against the panel surface — under AA for the
+           primary action of the approval flow. The on-quiet token is the
+           role-correct one and measures 5.63 / 5.88 / 7.65:1. */
+        --split-accent: var(--wa-color-success-on-quiet);
       }
     `,
   ];

--- a/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -93,6 +93,7 @@ export abstract class BaseFeedbackPanel<
       <div class=${containerClass}>
         <wa-textarea
           class=${inputClass}
+          aria-label=${placeholder}
           placeholder=${placeholder}
           rows="3"
           data-feedback-input

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -400,7 +400,8 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
         </div>
         <wa-textarea
           class="external-inquiry-request__answer-input"
-          placeholder="Paste the answer here..."
+          aria-label="Answer from the external model"
+          placeholder="Paste the answer here…"
           rows="4"
           resize="vertical"
           .value=${live(this.answerText)}
@@ -458,7 +459,8 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
           </div>
           <wa-textarea
             class="external-inquiry-request__session-links-input"
-            placeholder="Paste one external session link per line..."
+            aria-label="External session links, one per line"
+            placeholder="Paste one external session link per line…"
             rows="2"
             resize="vertical"
             .value=${live(this.sessionLinksText)}

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -404,6 +404,7 @@ export class FollowUpInput extends LitElement {
         <div class="composer-surface">
           <wa-textarea
             id=${ELEMENT_IDS.FOLLOW_UP_INPUT}
+            aria-label="Follow-up message"
             placeholder="Message TeXRA…"
             rows="6"
             resize="vertical"

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.styles.ts
@@ -108,9 +108,8 @@ export const proposalRequestPanelStyles: CSSResult = css`
     color: var(--wa-color-text-link-active, var(--wa-color-text-link));
   }
 
+  /* Radius only — the ring comes from focusRingStyles. */
   .workflow-proposal__file-name:focus-visible {
-    outline: var(--border-thin) solid var(--wa-color-focus);
-    outline-offset: var(--border-thin);
     border-radius: var(--border-radius-small);
   }
 

--- a/packages/extension/src/progressView/frontend/components/StreamConversation.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamConversation.ts
@@ -50,7 +50,11 @@ import './LogList';
 export class StreamConversation extends SignalWatcher(LitElement) {
   static override styles = css`
     :host {
-      --conversation-reading-width: 800px;
+      /* Body text renders at --wa-font-size-m (13px from the host), so 800px
+         put the measure near 127 characters per line — roughly double the
+         60-75 that keeps the eye finding the next line. Code blocks and
+         diffs are free to overflow this column. */
+      --conversation-reading-width: 680px;
 
       display: flex;
       flex-direction: column;

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -281,9 +281,8 @@ export class StreamHeader extends LitElement {
         color: var(--color-text-link);
       }
 
+      /* Radius only — the ring comes from focusRingStyles. */
       .parent-link:focus-visible {
-        outline: var(--border-thin) solid var(--wa-color-focus);
-        outline-offset: var(--border-thin);
         border-radius: var(--border-radius-small);
       }
 

--- a/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
@@ -106,6 +106,15 @@ export const streamTabStyles = css`
     text-overflow: ellipsis;
   }
 
+  /* Shape half of the status cue — border-left carries the hue. Renders in
+     the row's own foreground so it stays legible on the selection background
+     and adds no new color pair to verify. No opacity fade: this is the only
+     non-color signal the status has, so it is information, not decoration. */
+  .tab-status-icon {
+    flex-shrink: 0;
+    font-size: var(--font-size-xs);
+  }
+
   .tab-meta {
     display: none;
     align-items: center;
@@ -131,14 +140,21 @@ export const streamTabStyles = css`
     margin-left: var(--wa-space-2xs);
   }
 
+  /* 24px literal, not --control-size-s: that step is bridged to 20px in the
+     extension (common.css) for editor-chrome density, which is under WCAG
+     2.5.8's floor. The row's own select target sits flush against this one, so
+     the spacing exception does not apply and it has to meet 24x24 outright —
+     and growing the hit area with a pseudo-element instead would overlap the
+     select target, making near-misses delete a session. 24px is also exactly
+     --wa-row-height, so the row does not get taller. */
   .tab-delete {
     flex-shrink: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 20px;
-    min-width: 20px;
-    height: 20px;
+    width: 24px;
+    min-width: 24px;
+    height: 24px;
     margin: 0 0 0 var(--wa-space-2xs);
     color: var(--wa-color-text-quiet, var(--wa-color-text-normal));
     opacity: 0;
@@ -215,11 +231,9 @@ export const streamTabStyles = css`
     padding: var(--wa-space-3xs) var(--wa-space-3xs);
   }
 
-  .tab-container.is-compact .tab-delete {
-    width: 20px;
-    min-width: 20px;
-    height: 20px;
-  }
+  /* No compact override for .tab-delete: the narrow rail is 48px wide, which
+     still fits the 24px target, and shrinking it there would put the same
+     sub-minimum hit area back on the layout that most needs a reliable one. */
 
   .tab-container.is-compact .tab-header {
     gap: var(--wa-space-3xs);
@@ -256,8 +270,8 @@ export const streamTabStyles = css`
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 20px;
-    min-width: 20px;
+    width: 24px;
+    min-width: 24px;
     height: 100%;
     color: var(--wa-color-text-quiet, var(--wa-color-text-normal));
     opacity: var(--opacity-muted);

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -14,6 +14,8 @@ import { when } from 'lit/directives/when.js';
 // Local imports
 import {
   DEFAULT_STREAM_METADATA_STATUS,
+  STREAM_PHASE,
+  STREAM_SUBSTATE,
   type StreamSubstate,
   type StreamTabId,
   type StreamTabInfo,
@@ -22,6 +24,7 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 import {
   formatStreamStatusLabel,
   streamStatusDisplayKey,
+  type StreamStatusDisplayKey,
 } from '@shared/streams/streamStatusDisplay';
 import {
   AGENT_DECORATORS,
@@ -53,6 +56,25 @@ import type { StreamState } from '../store';
 
 // Web Awesome native components
 import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
+
+/**
+ * Non-color cue for the states that light the row's status rail. The rail's
+ * `border-left-color` alone put running/failed/waiting/starting apart by hue
+ * only, which is no distinction at all for a red-green colorblind reader and
+ * left "blocked on your approval" — the one state that wants you now —
+ * carrying no shape. Finished states (completed/cancelled/ready) leave the
+ * rail transparent and get no glyph, so a settled rail stays quiet.
+ *
+ * Rendered in `currentColor`: the border carries hue for fast scanning, the
+ * glyph carries shape, and neither introduces a new foreground to contrast-check.
+ */
+const STATUS_ICONS: Partial<Record<StreamStatusDisplayKey, TeXRAIconName>> = {
+  [STREAM_SUBSTATE.STARTING]: 'spinner',
+  [STREAM_SUBSTATE.RESUMING]: 'spinner',
+  [STREAM_PHASE.RUNNING]: 'play',
+  [STREAM_PHASE.WAITING]: 'clock',
+  [STREAM_PHASE.FAILED]: 'circle-exclamation',
+};
 
 function buildTooltip(
   info: StreamTabInfo,
@@ -145,8 +167,19 @@ export class StreamTab extends LitElement {
   override render(): TemplateResult {
     const stream = this.info;
     const status = this.status || DEFAULT_STREAM_METADATA_STATUS;
-    const statusKey = streamStatusDisplayKey(status, this.substate) ?? status;
+    const displayKey = streamStatusDisplayKey(status, this.substate);
+    const statusKey = displayKey ?? status;
+    // Pending approval outranks the lifecycle phase: a run held at the
+    // approval gate is still "running", and the gate is what you act on.
+    const phaseGlyph =
+      displayKey === undefined ? undefined : STATUS_ICONS[displayKey];
+    const statusGlyph: TeXRAIconName | undefined = this.hasPendingApproval
+      ? 'triangle-exclamation'
+      : phaseGlyph;
     const tooltip = this._tooltip;
+    // Also names the delete button: one "Delete" repeated down the rail tells
+    // a screen-reader user nothing about which session it destroys.
+    const streamTitle = stream.description || stream.label || stream.name;
     const streamDecorator = this._streamDecorator;
     const hasChildren = this.childCount > 0 && !this.compact;
     const showCompactChildHint = this.childCount > 0 && this.compact;
@@ -193,12 +226,17 @@ export class StreamTab extends LitElement {
           aria-label=${tooltip}
         >
           <div class="tab-header">
+            ${
+              statusGlyph
+                ? waIcon(statusGlyph, { className: 'tab-status-icon' })
+                : nothing
+            }
             <span id="stream-tab-title" class="tab-title"
               >${
                 stream.parentStreamId
                   ? waIcon('chevron-right', { className: 'nested-stream-icon' })
                   : nothing
-              }${stream.description || stream.label || stream.name}</span
+              }${streamTitle}</span
             >
             ${
               showCompactChildHint
@@ -285,7 +323,7 @@ export class StreamTab extends LitElement {
           variant="neutral"
           size="s"
           type="button"
-          aria-label="Delete"
+          aria-label=${`Delete ${streamTitle}`}
           data-stream=${stream.name}
           data-action="delete"
         >

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -117,18 +117,22 @@ export class UsagePanel extends LitElement {
         color: var(--color-text-secondary);
       }
 
+      /* No opacity here or on the icons below. --color-text-secondary is
+         already color-mix(… 70%, transparent), so the extra 0.85 (and a
+         further 0.7 on icons) compounded to 0.595 / 0.4165 effective alpha:
+         text measured 4.32:1 (Dark+) and 3.34:1 (Light Modern) against AA's
+         4.5:1, and the icons missed the 3:1 non-text minimum in all four
+         default themes. The token carries the de-emphasis on its own. */
       :is(.run-summary, .context-state) {
         display: inline-flex;
         align-items: center;
         gap: var(--wa-space-3xs);
         color: var(--color-text-secondary);
         font-size: var(--font-size-sm);
-        opacity: var(--opacity-normal);
       }
 
       :is(.run-summary, .context-state) wa-icon {
         font-size: var(--font-size-icon-sm);
-        opacity: var(--opacity-subtle);
       }
 
       .run-summary__route {
@@ -175,8 +179,12 @@ export class UsagePanel extends LitElement {
         margin-left: auto;
       }
 
+      /* Token counts and cost tick on every stream event inside a
+         right-aligned strip, so proportional digits shifted the whole footer
+         on each update. Same treatment ToolTimer and WorktreeChip already use. */
       :is(.run-summary__value, .context-state__value) {
         color: var(--wa-color-text-normal);
+        font-variant-numeric: tabular-nums;
       }
     `,
   ];

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -24,6 +24,7 @@ import {
 import type { WorkflowScriptDeliverySummary } from '@shared/schemas';
 import { DELIVERY_TAGS } from '@shared/deliveryTags';
 import { CopyButtonController } from '@shared/litControllers/CopyButtonController';
+import { focusRingStyles } from '@shared/styles/controlStyles';
 import { designTokens } from '@shared/styles/litStyles';
 import { markdownStyles } from '@shared/styles/markdownStyles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
@@ -55,6 +56,11 @@ export class UserMessage extends LitElement {
   static override styles = [
     designTokens,
     compactIconActionButtonStyles,
+    // The only markdownStyles consumer that does not compose commonViewStyles,
+    // so it is also the only one that would not inherit the shared focus ring.
+    // A user message can contain \ref{}/\cref{}, which render as focusable
+    // .latex-ref spans (role=button, tabindex=0) — they need the ring too.
+    focusRingStyles,
     markdownStyles,
     css`
       :host {

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -142,6 +142,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
           question.allowFreeText
             ? html`<wa-textarea
                 class="user-question-request__free-text"
+                aria-label=${`Another answer for: ${question.question}`}
                 placeholder="Type another answer"
                 rows="2"
                 .value=${this.freeText[question.question] ?? ''}

--- a/packages/extension/src/progressView/frontend/styles/codeBlockStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/codeBlockStyles.ts
@@ -83,9 +83,13 @@ export const codeBlockStyles = css`
     color: var(--wa-color-git-added, #3fb950);
   }
 
+  /* Kept rather than deleted like the others: the focus-visible rule in
+     focusRingStyles cannot reach inside wa-button's shadow root, so this
+     part-piercing rule is the only ring this control gets. Widened to the
+     shared tokens. */
   .code-block-copy:focus-visible::part(base) {
-    outline: var(--border-thin) solid var(--wa-color-focus);
-    outline-offset: var(--border-thin);
+    outline: var(--focus-ring-width) solid var(--wa-color-focus);
+    outline-offset: var(--focus-ring-offset);
   }
 
   /* Syntax highlighted code blocks */

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -304,6 +304,15 @@ export const logEntryStyles = css`
     opacity: var(--opacity-full);
   }
 
+  /* Same shadow-piercing exception as .code-block-copy: this is a wa-button,
+     and WebAwesome ships no focus styling of its own for it, so without this
+     the control falls back to the UA default ring while every sibling control
+     shows the branded one. */
+  .banner-content-copy:focus-visible::part(base) {
+    outline: var(--focus-ring-width) solid var(--wa-color-focus);
+    outline-offset: var(--focus-ring-offset);
+  }
+
   .banner-content-copy.copy-success {
     opacity: var(--opacity-full);
     color: var(--color-success);

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -33,8 +33,10 @@ export const logEntryStyles = css`
     padding: var(--wa-space-3xs) 0;
     display: block;
     white-space: pre-wrap;
-    word-wrap: break-word;
-    word-break: break-all;
+    /* anywhere breaks only what cannot fit (long paths, ids, URLs); break-all
+       split ordinary prose mid-word on every wrap. The terminal variant below
+       already made this trade for the same reason. */
+    overflow-wrap: anywhere;
     content-visibility: auto;
     contain-intrinsic-size: auto 24px;
   }
@@ -80,10 +82,11 @@ export const logEntryStyles = css`
     cursor: pointer;
   }
 
-  .workflow-task--linked:hover,
-  .workflow-task--linked:focus-visible {
+  /* Hover only. Focus keeps the shared 2px ring from focusRingStyles: the
+     border-color flip alone was identical to hover, so a keyboard user had no
+     way to tell "focused" from "pointed at". */
+  .workflow-task--linked:hover {
     border-color: var(--wa-color-focus);
-    outline: none;
   }
 
   .workflow-task--completed,
@@ -234,9 +237,9 @@ export const logEntryStyles = css`
     text-decoration: underline;
   }
 
+  /* Radius only — the ring itself comes from focusRingStyles, which an
+     outline here would narrow to 1px. */
   :is(.file-link, .web-search-link):focus-visible {
-    outline: var(--border-thin) solid var(--wa-color-focus);
-    outline-offset: var(--border-thin);
     border-radius: var(--border-radius-small);
   }
 
@@ -299,11 +302,6 @@ export const logEntryStyles = css`
   .banner-details:focus-within .banner-content-copy,
   .banner-content-copy:focus-visible {
     opacity: var(--opacity-full);
-  }
-
-  .banner-content-copy:focus-visible {
-    outline: var(--border-thin) solid var(--wa-color-focus);
-    outline-offset: var(--border-thin);
   }
 
   .banner-content-copy.copy-success {

--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -162,9 +162,8 @@ export const toolUseStyles = css`
     gap: var(--wa-space-3xs);
   }
 
+  /* Radius only — the ring comes from focusRingStyles. */
   .proposal-restore-link:focus-visible {
-    outline: var(--border-thin) solid var(--wa-color-focus);
-    outline-offset: var(--border-thin);
     border-radius: var(--border-radius-small);
   }
 

--- a/src/shared/styles/markdownStyles.ts
+++ b/src/shared/styles/markdownStyles.ts
@@ -112,9 +112,8 @@ export const markdownStyles: CSSResult = css`
     color: var(--wa-color-symbol-keyword);
   }
 
+  /* Radius only — the ring comes from focusRingStyles. */
   .markdown-content .latex-ref:focus-visible {
-    outline: var(--border-thin) solid var(--wa-color-focus);
-    outline-offset: var(--border-thin);
     border-radius: var(--border-radius-small);
   }
 


### PR DESCRIPTION
An interface review of the session view (`packages/extension/src/progressView/frontend/`) turned up eleven issues across accessibility, color, typography, and layout. This fixes ten. Every color claim below is a measured ratio, not an impression.

## Focus rings — the repo already made this call

`focusRingStyles` (`src/shared/styles/controlStyles.ts:34`) is documented as "one focus ring for every interactive element in the shadow root", set to `--focus-ring-width: 2px` with the rationale written next to it:

> A 1px ring is the kind of thing that reads as tidy and fails a low-vision user.

It reaches every affected shadow root already, via `commonViewStyles` / `logStyles`. Eight selectors were beating it on specificity with a 1px outline, and `.workflow-task--linked` replaced it with `outline: none` plus a border-color flip **identical to its hover state** — so a keyboard user had no way to tell focused from pointed-at.

All eight now defer to the shared ring, keeping only the `border-radius` the outline needs to follow the shape. One exception: `.code-block-copy` keeps a local rule, because a `:focus-visible` in the adopting sheet cannot reach inside `wa-button`'s shadow root — it is that control's only ring, so it was widened to the shared tokens rather than removed.

The eighth site (`src/shared/styles/markdownStyles.ts`) was found while implementing and is shared with the desktop host; the change there moves it in the same direction.

## Status was carried by hue alone

A run's state — running, failed, waiting, starting, and **blocked on your approval** — was encoded only in the `border-left-color` of a 2px edge. A red-green colorblind reader could not distinguish a failed run from a running one, and the one state that actively wants you had no shape at all. The label was already in the `aria-label` and the tooltip, so pointer-free visual scanning was the only path with nothing.

Rows now carry a glyph too, rendered in `currentColor` so it adds no new foreground to verify. It appears only for states that light the rail — completed, cancelled, and ready leave it transparent and get no glyph, so a settled rail stays as quiet as it is today.

## Contrast, measured

Against the four default VS Code themes:

| Fix | Before | After |
| --- | --- | --- |
| Approve label (`ApproveSplitButton`) | **3.90:1** Light+, **4.07:1** Light Modern | 5.63 / 5.88 / 7.65:1 |
| Usage strip text (`UsagePanel`) | **4.32:1** Dark+, **3.34:1** Light Modern | token value, no stacked alpha |
| Usage strip icons | **2.87 / 2.96 / 2.95 / 2.21:1** — under 3:1 in *all four* | as above |

The Approve button was using a `-fill-` token as a foreground; `controlStyles.ts:558` applies `--split-accent` as `color`. `--wa-color-success-on-quiet` is the role-correct token.

The usage strip stacked element `opacity` on top of `--color-text-secondary`, which is itself `color-mix(… 70%, transparent)` — compounding to 0.595 effective alpha on text and 0.4165 on icons. The token already carries the de-emphasis.

## Also

- **Five unlabeled textareas** — including the main follow-up composer — had only a placeholder for a name. `WorkflowToolUseFollowupSection` already showed the intended pattern.
- **`aria-label="Delete"`** repeated identically down the rail; now names its stream.
- **20px hit targets** in the rail raised to 24px (WCAG 2.5.8). Deliberately a literal, not `--control-size-s`: that step is bridged to 20px in the extension for editor-chrome density. A pseudo-element hit area was rejected — it would overlap the select target, so near-misses would *delete* a session.
- **`tabular-nums`** on the live token/cost counters, which shifted the right-aligned footer on every tick.
- **Conversation measure** 800px → 680px (~127 characters at the 13px body size, against a 60–75 target). Code blocks and diffs still overflow the column.
- **`word-break: break-all`** → `overflow-wrap: anywhere` on log lines; the file's own comment already made this trade for terminal streams.
- Two `...` → proper ellipses.

## Deliberately not fixed

The rail's `.tab-meta` is hidden until hover and revealed with `display: flex`, which grows the hovered row and pushes every row below it. That is a real reflow, but the fix is a design call about the recent declutter work (#9702) rather than a defect fix, so it is left for a decision.

## Verification

- `npm run typecheck` — clean across all seven projects.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — 18 findings vs 18 baselined, no new exports.
- `npx vitest run` — **820 files / 8,421 tests passing**, 1 file and 5 tests skipped.
- Contrast computed in Node from the stock theme values (WCAG 2.x relative luminance), compositing `color-mix` alpha and element `opacity` before measuring.

**Not verified:** no rendered inspection — these webviews only mount inside a VS Code extension host — and no screen-reader pass. The status glyph, the 680px measure, and the 24px rail targets are the three changes most worth a look on screen before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ddRTq1PLM3eZR8yf8xjaV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Progress-view UI, styling, and ARIA only—no auth, data, or API changes; risk is mainly visual regression in the extension webview.
> 
> **Overview**
> Addresses accessibility and readability issues in the progress view session UI: focus visibility, stream status scanning, measured contrast, labels, and a few layout tweaks.
> 
> **Focus** — Removes local 1px `:focus-visible` outlines that overrode the shared **2px** `focusRingStyles` ring; linked workflow tasks no longer use hover-identical border styling on focus. `UserMessage` composes `focusRingStyles` for focusable LaTeX refs. `wa-button` copy controls keep `::part(base)` rings aligned to shared focus tokens.
> 
> **Stream tabs** — Adds `currentColor` status glyphs (including pending approval) beside hue-only rail colors; enlarges delete/expand controls to **24×24**; delete `aria-label` includes the stream title.
> 
> **Contrast & typography** — Approve split button uses `--wa-color-success-on-quiet`; usage footer drops stacked opacity on secondary text/icons; token/cost values use `tabular-nums`; conversation column **680px**; log lines use `overflow-wrap: anywhere` instead of `break-all`.
> 
> **Forms** — Adds `aria-label`s on several textareas (follow-up composer, rejection, external inquiry, user questions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2f886f60869af3bf004a1761abff1cba6f79f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->