### PR TITLE
refactor: Lit stack adopts the canonical single stage slot

### DIFF
--- a/docs/proposals/2026-08-03-run-classification-consolidation.md
+++ b/docs/proposals/2026-08-03-run-classification-consolidation.md
@@ -51,11 +51,23 @@ nothing to unify — the `--output` copy and stdout result line keep their
 explicit-flag/stdout semantics; and the chat-defaults tier already reads
 the shared listing primitives (`listExecutions` + `isUserVisibleExecution`)
 — its extra filters are tier-specific projection, not a duplicated rule.
-Still remaining: the `taskRuns` legacy directory probe (#6981, its own
-dated retention policy), and step 16 / step 18 of Part III (the session
-view-model generalization and the TUI-as-renderer recut — a PR-sized
-change of its own; `ProgressViewState` is already host-neutral and
-`ProgressFactApplier`'s ~25 `WebviewUpdater` call sites are the work).
+After the main PR (#9705) merged, two step-16 slices landed as follow-up
+PRs: **#9710** promoted the CLI's discriminated `StreamStage` to shared and
+gave `stage.start` normalization one home (`src/shared/streams/stage.ts` —
+all four inline guard clones deleted), and **#9712** adopted the single
+`stage` slot across the Lit stack end-to-end (`StreamStageSchema` in
+`src/shared/schemas/streamState.ts` as SSOT; `StreamExecutionState.stage`;
+`UPDATE_ROUND_STAGE` → `UPDATE_STAGE`; `StreamMetadata` and the
+`SYNC_STREAM_CONTENT` active state carry `stage`; frontend readers dispatch
+on `kind` via `formatStageLabel`; delivery policy unchanged — phases ride
+the metadata patch so parent viewports see them, rounds go targeted to the
+active stream; the frozen public NDJSON wire keeps
+`updateRoundStage`/`RoundStage`).
+Still remaining — detailed handoff in the tracking issue for step 16/18
+(see "Remaining work" below and the issue filed from it): the session
+view-model generalization + TUI-as-renderer recut (step 16 remainder), the
+step-18 gate sweep, and the `taskRuns` legacy directory probe (#6981, its
+own dated retention policy).
 Date: 2026-08-03
 Revision: 10 (holistic build order; open-problems register)
 
@@ -1190,6 +1202,82 @@ _Gate:_ `rg -c 'resolveCliResume|resolveCliHistoryStatus|userStartedCliHistoryEn
 
 **Step 18 — Part III gate sweep.** Ratchets shrink; no new `@agent/*`
 specifiers; the NDJSON byte-parity suite passes against the unified stack.
+
+## Remaining work — handoff (2026-08-04, after #9705/#9710/#9712)
+
+What is done, what is left, and the load-bearing facts a fresh session
+needs. Everything below step 16's "canonical field shapes" bullet is
+landed; the rest of step 16 and step 18 are open.
+
+**Landed (do not redo):**
+
+- `StreamStageSchema` / `StreamStage` in `src/shared/schemas/streamState.ts`
+  is the discriminated slot's SSOT; `src/shared/streams/stage.ts` holds the
+  `stage.start` normalizers (`streamStageFromStageStart`,
+  `roundStageFromStageStart`; the phase helper is module-private). All four
+  stage-guard clones are gone.
+- The Lit stack carries `stage` end-to-end (state, wire `UPDATE_STAGE`,
+  `StreamMetadata`, `SYNC_STREAM_CONTENT` active state, frontend). The
+  applier's `handleUpdateStage` keeps the two delivery policies: phase →
+  per-stream metadata patch (parent viewports read a child's phase), round
+  → targeted message to the active stream only.
+- The CLI TUI already holds the canonical slot (`StreamSlice.stage`), and
+  the frozen public NDJSON vocabulary keeps `updateRoundStage` /
+  `UpdateRoundStagePayload` — never migrate that wire.
+
+**Open A — step 16 remainder: one session view-model, hosts as renderers.**
+Generalize `src/controllers/progressView/backend/ProgressViewState.ts`
+(~600 lines; already `vscode`-free, host seam is the injected `StateStore`)
+plus the fact→state half of
+`src/controllers/progressView/backend/events/ProgressFactApplier.ts`
+(~800 lines) into `src/controllers/session/`. The applier interleaves state
+mutation with webview push policy at ~25 `webviewUpdater.*` call sites —
+the split is: shared applier owns fact→state and notifies a host-renderer
+port; the Lit renderer keeps `sendIfActive`, the conversation-progress
+debounce (500 ms), tab-switch suppression under `hasPendingPermissions`,
+and the async log rehydrate/evict ordering in `setStreamStatus`
+(state-mutations-first already holds). Hub wiring today:
+`ProgressBackend.ts` subscribes twice (session + run scopes) and forwards
+to `handleSessionFact`/`handleRunFact`. `WebviewUpdater`'s
+`Pick<ProgressViewState, ...>` types enumerate the read surface the
+renderer needs (`getStreamMetadata`, `getStreamState`, `streamLogs`,
+`selectableStreamNames`, `rotateActiveStream`).
+Then port the TUI onto the shared model (a signals adapter mirrors model
+change notifications into `cliState` slices) and delete the CLI's parallel
+derivations, per the step-16 _Delete_ list: `setStreamStatusInCliState`
+mirror, `applySubagentRoster` + `ParentProvenance` reconciliation +
+`REMOVED_STREAM_TOMBSTONE_CAP` value-copy
+(`packages/cli/src/chat/tui/state/childExecutions.ts` — note the shared
+applier's `RETAINED_FINISHED_CHILDREN_CAP`/roster retention in
+`updateChildRoster` and `recordChildPhase` already implement the same
+semantics once), the full-rebuild task-group driver, the duplicate
+`subagentExecutionLabels` (the Lit twin is `subagentExecutionLabels$` in
+`packages/extension/src/progressView/frontend/progressState.ts`), the
+duplicated phase grouping, and the TUI dispatch table
+(`TUI_RUN_FACT_HANDLERS` in
+`packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts`). The headless
+line renderer (`packages/cli/src/runtime/runProgressRenderer.ts`) and the
+frozen NDJSON projection
+(`packages/cli/src/runtime/sessionProgressSubscription.ts`) stay as
+boundary projections — they are projections, not accumulators, and merging
+them into the store would couple a public wire to a view-model.
+Fact-coverage deltas to reconcile deliberately (one decided behavior per
+fact, same on every host): `followUpSent` (TUI refreshes immediately, Lit
+ignores), `goalPaused` (TUI appends a transcript notice, Lit ignores),
+`goalStateChanged`/`inquiryThreadUpdated` (Lit renders, TUI ignores).
+_Tests:_ TUI snapshots unchanged (`node scripts/validate-tui.mjs` from
+packages/cli); NDJSON byte-parity; the recut Lit suites from #9712 keep
+passing. _Gate:_
+`rg -c 'TUI_RUN_FACT_HANDLERS|applySubagentRoster|mergeArtifactSnapshot' packages/cli/` → 0.
+
+**Open B — step 18 gate sweep.** After A: shrink
+`config/ratchets/host-agent-mock-baseline.json` (deleting
+`chatSessionController`/TUI mocks should drop sites), re-run
+`architecture-edges` and `host-agent-import-baseline` expecting shrink, no
+new `@agent/*` specifiers, dead-code ratchet ≤ 18.
+
+**Open C — `taskRuns` legacy directory probe.** Tracked in #6981 with its
+own dated retention policy; independent of A/B.
 
 ## Build order — holistic
 

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -21,11 +21,11 @@ import {
   spendingQuotaState,
   type SpendingStatus,
   type StreamPhase,
+  type StreamStage,
   type StreamSubstate,
   type StreamTabId,
   type TokenUsageStats,
 } from '@shared/schemas';
-import type { StreamStage } from '@shared/streams/stage';
 import { isActivePhase } from '@shared/streams/streamStatus';
 import { formatStageLabel } from '@shared/streams/streamStatusDisplay';
 import {

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -19,6 +19,7 @@ import {
   type RoundIndexed,
   type RunIdentity,
   type StreamPhase,
+  type StreamStage,
   type StreamSubstate,
   type StreamTabId,
   type TaskGroup,
@@ -28,7 +29,6 @@ import {
 } from '@shared/schemas';
 import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
 import { isActivePhase } from '@shared/streams/streamStatus';
-import type { StreamStage } from '@shared/streams/stage';
 import type { ApiAccessMode } from '@shared/schemas/profileViewMessages';
 import {
   applyChildStreamRemoval,

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -10,14 +10,12 @@ import {
   sumUsageStats,
   type ClearMissingOutputsPayload,
   type SetActiveStreamPayload,
+  type StreamStage,
   type StreamTabId,
   type UpdateQueuedFollowUpsPayload,
   type UpdateStreamUsagePayload,
 } from '@shared/schemas';
-import {
-  streamStageFromStageStart,
-  type StreamStage,
-} from '@shared/streams/stage';
+import { streamStageFromStageStart } from '@shared/streams/stage';
 import { assertNever } from '@utils/core';
 
 import {

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -13,8 +13,7 @@ import {
   STREAM_PHASE,
   STREAM_SUBSTATE,
   type ConversationProgress,
-  type PhaseStage,
-  type RoundStage,
+  type StreamStage,
   type StreamSubstate,
   type StreamTabInfo,
 } from '@shared/schemas';
@@ -319,8 +318,7 @@ export class StreamHeader extends LitElement {
     DEFAULT_STREAM_METADATA_STATUS;
   @property({ attribute: false }) substate: StreamSubstate | undefined;
   @property({ attribute: false }) progress: ConversationProgress | undefined;
-  @property({ attribute: false }) roundStage: RoundStage | undefined;
-  @property({ attribute: false }) phaseStage: PhaseStage | undefined;
+  @property({ attribute: false }) stage: StreamStage | undefined;
   @property({ attribute: false }) yoloActive = false;
   @property({ attribute: false }) superYoloActive = false;
   @property({ attribute: false }) goalActive = false;
@@ -526,14 +524,10 @@ export class StreamHeader extends LitElement {
   }
 
   private renderProgressBadge(): TemplateResult | typeof nothing {
-    if (!this.phaseStage && !this.roundStage && !this.progress?.toolCallCount) {
+    if (!this.stage && !this.progress?.toolCallCount) {
       return nothing;
     }
-    const stage = {
-      phaseStage: this.phaseStage,
-      roundStage: this.roundStage,
-    };
-    const progressTitle = getProgressBadgeTitle(this.progress, stage);
+    const progressTitle = getProgressBadgeTitle(this.progress, this.stage);
     return html`<wa-tag
         id=${ELEMENT_IDS.PROGRESS_BADGE}
         class="progress-badge"
@@ -541,7 +535,7 @@ export class StreamHeader extends LitElement {
         size="s"
       >
         ${waIcon('chart-line')}
-        ${renderProgressBadgeContent(this.progress, stage)}
+        ${renderProgressBadgeContent(this.progress, this.stage)}
       </wa-tag>
       ${
         progressTitle

--- a/packages/extension/src/progressView/frontend/components/streamHeaderView.ts
+++ b/packages/extension/src/progressView/frontend/components/streamHeaderView.ts
@@ -35,8 +35,7 @@ export function renderStreamHeader(
       .status=${state.status}
       .substate=${state.substate}
       .progress=${state.conversationProgress}
-      .roundStage=${state.roundStage}
-      .phaseStage=${state.phaseStage}
+      .stage=${state.stage}
       .yoloActive=${Boolean(toolUse?.toolEditBypass)}
       .superYoloActive=${Boolean(toolUse?.superYoloBypass)}
       .goalActive=${Boolean(toolUse?.goalActive)}

--- a/packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts
@@ -1,24 +1,7 @@
 import { html, nothing, type TemplateResult } from 'lit';
-import type {
-  ConversationProgress,
-  PhaseStage,
-  RoundStage,
-} from '@shared/schemas';
-import {
-  formatPhaseStageLabel,
-  formatRoundStageLabel,
-} from '@shared/streams/streamStatusDisplay';
+import type { ConversationProgress, StreamStage } from '@shared/schemas';
+import { formatStageLabel } from '@shared/streams/streamStatusDisplay';
 import { formatResultCount } from '@utils/text/stringUtils';
-
-/**
- * The stage slot of the progress badge. A workflow-script run advances through
- * named phases, a tool-use run through numbered rounds; one slot carries
- * whichever this stream has, phase first.
- */
-interface ProgressBadgeStage {
-  phaseStage: PhaseStage | undefined;
-  roundStage: RoundStage | undefined;
-}
 
 /**
  * Render progress badge with the stage slot and tool call count.
@@ -26,11 +9,9 @@ interface ProgressBadgeStage {
  */
 export function renderProgressBadgeContent(
   progress: ConversationProgress | undefined,
-  stage: ProgressBadgeStage,
+  stage: StreamStage | undefined,
 ): TemplateResult | typeof nothing {
-  const stageLabel =
-    formatPhaseStageLabel(stage.phaseStage) ??
-    formatRoundStageLabel(stage.roundStage);
+  const stageLabel = formatStageLabel(stage);
   const tools = progress?.toolCallCount ?? 0;
   const parts = [
     stageLabel ?? '',
@@ -42,7 +23,7 @@ export function renderProgressBadgeContent(
 
 export function getProgressBadgeTitle(
   progress: ConversationProgress | undefined,
-  stage: ProgressBadgeStage,
+  stage: StreamStage | undefined,
 ): string | undefined {
   const parts: string[] = [];
   const stageTitle = stageBadgeTitle(stage);
@@ -55,24 +36,17 @@ export function getProgressBadgeTitle(
   return parts.length > 0 ? parts.join(', ') : undefined;
 }
 
-/** Spelled-out counterpart of the compact stage label, phase first. */
-function stageBadgeTitle({
-  phaseStage,
-  roundStage,
-}: ProgressBadgeStage): string | undefined {
-  if (phaseStage) {
-    if (phaseStage.index === undefined) return `Phase: ${phaseStage.label}`;
+/** Spelled-out counterpart of the compact stage label. */
+function stageBadgeTitle(stage: StreamStage | undefined): string | undefined {
+  if (stage === undefined) return undefined;
+  if (stage.kind === 'phase') {
+    if (stage.index === undefined) return `Phase: ${stage.label}`;
     const position =
-      phaseStage.total === undefined
-        ? `Phase ${phaseStage.index + 1}`
-        : `Phase ${phaseStage.index + 1} of ${phaseStage.total}`;
-    return `${position}: ${phaseStage.label}`;
+      stage.total === undefined
+        ? `Phase ${stage.index + 1}`
+        : `Phase ${stage.index + 1} of ${stage.total}`;
+    return `${position}: ${stage.label}`;
   }
-  if (roundStage) {
-    const round = `Round ${roundStage.index + 1}`;
-    return roundStage.total !== undefined
-      ? `${round} of ${roundStage.total}`
-      : round;
-  }
-  return undefined;
+  const round = `Round ${stage.index + 1}`;
+  return stage.total !== undefined ? `${round} of ${stage.total}` : round;
 }

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -277,7 +277,8 @@ let _prevPhaseStages: PhaseStageMap = EMPTY_PHASE_STAGE_MAP;
 export const phaseStages$ = new Signal.Computed((): PhaseStageMap => {
   const stages = new Map<StreamTabId, PhaseStage>();
   for (const [streamId, state] of streamStates$.get()) {
-    if (state.phaseStage) stages.set(streamId, state.phaseStage);
+    const stage = state.stage;
+    if (stage?.kind === 'phase') stages.set(streamId, stage);
   }
   if (samePhaseStages(stages, _prevPhaseStages)) return _prevPhaseStages;
   _prevPhaseStages = stages.size > 0 ? stages : EMPTY_PHASE_STAGE_MAP;

--- a/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -145,10 +145,10 @@ export const streamMetaHandlers = {
     );
   },
 
-  [PROGRESS_VIEW_COMMANDS.UPDATE_ROUND_STAGE]: (data) => {
+  [PROGRESS_VIEW_COMMANDS.UPDATE_STAGE]: (data) => {
     setStreamStateForId(data.stream, (prev) =>
       create(prev, (draft) => {
-        draft.roundStage = data.roundStage;
+        draft.stage = data.stage;
       }),
     );
   },

--- a/packages/extension/src/progressView/frontend/slices/streamStateMerge.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamStateMerge.ts
@@ -14,11 +14,8 @@ function metadataToStreamStatePartial(
   const { category: _category, ...backendFields } = metadata;
   return {
     ...backendFields,
-    ...(Object.hasOwn(metadata, 'roundStage') && {
-      roundStage: metadata.roundStage ?? undefined,
-    }),
-    ...(Object.hasOwn(metadata, 'phaseStage') && {
-      phaseStage: metadata.phaseStage ?? undefined,
+    ...(Object.hasOwn(metadata, 'stage') && {
+      stage: metadata.stage ?? undefined,
     }),
   } as Partial<StreamState>;
 }

--- a/packages/extension/src/progressView/frontend/slices/syncSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/syncSlice.ts
@@ -10,12 +10,10 @@ import { updateToolUseState, updateWorkflowState } from '../stateUtils';
 
 function activeStateFields(data: StreamContentRenderPayload) {
   if (!data.activeState) return {};
-  const { conversationProgress, roundStage, phaseStage, badges } =
-    data.activeState;
+  const { conversationProgress, stage, badges } = data.activeState;
   return {
     conversationProgress,
-    roundStage: roundStage ?? undefined,
-    phaseStage: phaseStage ?? undefined,
+    stage: stage ?? undefined,
     subagents: badges.subagents,
   };
 }

--- a/scripts/capture-walkthrough-media.mjs
+++ b/scripts/capture-walkthrough-media.mjs
@@ -346,7 +346,7 @@ function progressMessages() {
           conversationProgress: {
             toolCallCount: 5,
           },
-          roundStage: { index: 1 },
+          stage: { kind: 'round', index: 1 },
           subagents: [
             {
               executionId: 'exec-polish',

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -113,7 +113,7 @@ const views = [
             conversationProgress: {
               toolCallCount: 1,
             },
-            roundStage: { index: 0 },
+            stage: { kind: 'round', index: 0 },
             subagents: [],
             processes: [],
           },
@@ -186,7 +186,7 @@ const views = [
             conversationProgress: {
               toolCallCount: 12,
             },
-            roundStage: { index: 3 },
+            stage: { kind: 'round', index: 3 },
             subagents: [],
             processes: [],
           },

--- a/src/controllers/progressView/backend/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/ProgressViewState.ts
@@ -19,8 +19,7 @@ import {
   type ActiveChildInfo,
   type ConversationProgress,
   type ExecutionId,
-  type PhaseStage,
-  type RoundStage,
+  type StreamStage,
   type RunIdentity,
   type StreamPhase,
   type StreamTabId,
@@ -97,8 +96,7 @@ type ProgressViewPrefs = z.infer<typeof ProgressViewPrefsSchema>;
 export interface StreamExecutionState {
   category: (typeof AgentCategory)[keyof typeof AgentCategory];
   conversationProgress: ConversationProgress;
-  roundStage?: RoundStage;
-  phaseStage?: PhaseStage;
+  stage?: StreamStage;
   /** Live children plus the finished ones retained for display (`finishedAt`
    *  set). */
   subagents: ActiveChildInfo[];
@@ -425,8 +423,7 @@ export class ProgressViewState {
     const needsReset =
       retainedSubagents.length > 0 ||
       current.conversationProgress.toolCallCount !== 0 ||
-      current.roundStage !== undefined ||
-      current.phaseStage !== undefined;
+      current.stage !== undefined;
 
     if (needsReset) {
       this._streamStates.set(stream, {
@@ -435,8 +432,7 @@ export class ProgressViewState {
           (child) => child.finishedAt === undefined,
         ),
         conversationProgress: { toolCallCount: 0 },
-        roundStage: undefined,
-        phaseStage: undefined,
+        stage: undefined,
       });
     }
   }

--- a/src/controllers/progressView/backend/WebviewUpdater.ts
+++ b/src/controllers/progressView/backend/WebviewUpdater.ts
@@ -22,9 +22,9 @@ import type {
   ProgressViewPlacement,
   ProgressViewOutboundMessage,
   RoundIndexed,
-  RoundStage,
   StreamMetadata,
   StreamPhase,
+  StreamStage,
   StreamSubstate,
   StreamTabId,
   StreamTabInfo,
@@ -277,11 +277,11 @@ export class WebviewUpdater {
     });
   }
 
-  updateRoundStage(stream: StreamTabId, roundStage: RoundStage): void {
+  updateStage(stream: StreamTabId, stage: StreamStage): void {
     this.sendMessage({
-      command: PROGRESS_VIEW_COMMANDS.UPDATE_ROUND_STAGE,
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_STAGE,
       stream,
-      roundStage,
+      stage,
     });
   }
 
@@ -405,8 +405,7 @@ export class WebviewUpdater {
       substate: streamState?.substate,
       lastTimestamp: state.streamLogs.getLastTimestamp(streamInfo.name),
       conversationProgress: current?.conversationProgress,
-      roundStage: current?.roundStage,
-      phaseStage: current?.phaseStage,
+      stage: current?.stage,
       subagents: current?.subagents,
     });
   }

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -24,25 +24,21 @@ import {
   type SetActiveStreamPayload,
   type SetParentStreamPayload,
   type StreamPhase,
+  type StreamStage,
   type StreamSubstate,
   type StreamTabId,
   type UpdateCompileFailuresPayload,
   type UpdateConversationProgressPayload,
   type UpdateMissingOutputsPayload,
-  type UpdatePhaseStagePayload,
   type UpdatePlanPayload,
   type UpdateQueuedFollowUpsPayload,
-  type UpdateRoundStagePayload,
   type UpdateStreamDescriptionPayload,
   type UpdateStreamUsagePayload,
   type UpdateTodosPayload,
 } from '@shared/schemas';
 import { isGoalInFlight } from '@shared/schemas/goal';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
-import {
-  phaseStageFromStageStart,
-  roundStageFromStageStart,
-} from '@shared/streams/stage';
+import { streamStageFromStageStart } from '@shared/streams/stage';
 import { isActivePhase } from '@shared/streams/streamStatus';
 import { GoalStore } from '@tools/goal';
 import {
@@ -156,12 +152,8 @@ export class ProgressFactApplier {
         progress: event.progress,
       }),
     'stage.start': (streamId, event) => {
-      const phaseStage = phaseStageFromStageStart(event);
-      if (phaseStage)
-        return this.handleUpdatePhaseStage({ streamId, phaseStage });
-      const roundStage = roundStageFromStageStart(event);
-      if (roundStage)
-        return this.handleUpdateRoundStage({ streamId, roundStage });
+      const stage = streamStageFromStageStart(event);
+      if (stage) return this.handleUpdateStage(streamId, stage);
     },
     'child.activity': (_streamId, event) =>
       this.updateChildRoster(event.parentStreamId, [...event.items]),
@@ -482,38 +474,26 @@ export class ProgressFactApplier {
     if (!this.progressDebounce.pending) this.progressDebounce.schedule();
   }
 
-  handleUpdateRoundStage(data: UpdateRoundStagePayload): void {
-    const { streamId, roundStage } = data;
-    this.state.updateStreamState(streamId, (prev) => ({
-      ...prev,
-      roundStage,
-    }));
+  handleUpdateStage(streamId: StreamTabId, stage: StreamStage): void {
+    this.state.updateStreamState(streamId, (prev) => ({ ...prev, stage }));
 
+    if (stage.kind === 'phase') {
+      // A workflow-script run's phase is read from its *parent's* viewport
+      // (the Background Tasks row for that run), so unlike round progress it
+      // cannot be pushed only for the active stream. It rides the existing
+      // per-stream metadata patch instead of the targeted message: phases
+      // advance a handful of times per run, so the extra fields on the wire
+      // cost nothing.
+      if (!this.webviewUpdater.isAvailable()) return;
+      this.webviewUpdater.updateStreamMetadata(
+        this.state,
+        streamId,
+        this.state.streamStatus.getAllStreamStates(),
+      );
+      return;
+    }
     this.sendIfActive(streamId, () =>
-      this.webviewUpdater.updateRoundStage(streamId, roundStage),
-    );
-  }
-
-  /**
-   * A workflow-script run's phase is read from its *parent's* viewport (the
-   * Background Tasks row for that run), so unlike `roundStage` this cannot be
-   * pushed only for the active stream. It rides the existing per-stream
-   * metadata patch instead of a new targeted message: phases advance a
-   * handful of times per run, so the extra fields on the wire cost nothing
-   * and no new command has to be added to the outbound union.
-   */
-  private handleUpdatePhaseStage(data: UpdatePhaseStagePayload): void {
-    const { streamId, phaseStage } = data;
-    this.state.updateStreamState(streamId, (prev) => ({
-      ...prev,
-      phaseStage,
-    }));
-
-    if (!this.webviewUpdater.isAvailable()) return;
-    this.webviewUpdater.updateStreamMetadata(
-      this.state,
-      streamId,
-      this.state.streamStatus.getAllStreamStates(),
+      this.webviewUpdater.updateStage(streamId, stage),
     );
   }
 
@@ -697,8 +677,7 @@ export class ProgressFactApplier {
   ) {
     return {
       conversationProgress: state.conversationProgress,
-      roundStage: state.roundStage ?? null,
-      phaseStage: state.phaseStage ?? null,
+      stage: state.stage ?? null,
       badges: { subagents: state.subagents },
     };
   }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -155,7 +155,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   UPDATE_STREAM_STATUS: 'updateStreamStatus',
   SET_ACTIVE_STREAM: 'setActiveStream',
   UPDATE_CONVERSATION_PROGRESS: 'updateConversationProgress',
-  UPDATE_ROUND_STAGE: 'updateRoundStage',
+  UPDATE_STAGE: 'updateStage',
   UPDATE_STREAM_BADGES: 'updateStreamBadges',
   UPDATE_STREAM_DESCRIPTION: 'updateStreamDescription',
   SYNC_INQUIRY_THREADS: 'syncInquiryThreads',

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -103,17 +103,12 @@ export interface UpdateConversationProgressPayload {
   progress: ConversationProgress;
 }
 
-/** Round advance within a run, projected from `stage.start` (kind 'round'). */
+/** Round advance within a run, projected from `stage.start` (kind 'round').
+ *  Kept for the frozen public NDJSON vocabulary (`updateRoundStage`); internal
+ *  state and the webview wire carry the discriminated `StreamStage` slot. */
 export interface UpdateRoundStagePayload {
   streamId: StreamTabId;
   roundStage: RoundStage;
-}
-
-/** Phase advance within a workflow-script run, projected from `stage.start`
- *  (kind 'phase'). */
-export interface UpdatePhaseStagePayload {
-  streamId: StreamTabId;
-  phaseStage: PhaseStage;
 }
 
 /**

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -2,11 +2,7 @@ import type { AgentCategory } from './agent';
 import type { ExecutionId, StorageKey, StreamTabId } from './identifiers';
 import type { CompileFailure, FileLocation, OutputFileInfo } from './output';
 import type { RoundIndexed } from './roundIndexed';
-import type {
-  ConversationProgress,
-  PhaseStage,
-  RoundStage,
-} from './streamState';
+import type { ConversationProgress, RoundStage } from './streamState';
 import type { StreamPhase, StreamSubstate } from './stream';
 import type { ExtendedTokenUsageStats } from './usage';
 

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -41,8 +41,7 @@ import {
 import {
   ActiveChildInfoSchema,
   ConversationProgressSchema,
-  PhaseStageSchema,
-  RoundStageSchema,
+  StreamStageSchema,
   StreamMetadataSchema,
 } from '../streamState';
 import { PlanSchema } from '../plan';
@@ -82,9 +81,9 @@ const UpdateConversationProgressMessageSchema = StreamScopedBaseSchema.extend({
   progress: ConversationProgressSchema,
 });
 
-const UpdateRoundStageMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_ROUND_STAGE),
-  roundStage: RoundStageSchema,
+const UpdateStageMessageSchema = StreamScopedBaseSchema.extend({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STAGE),
+  stage: StreamStageSchema,
 });
 
 const UpdateStreamBadgesMessageSchema = StreamScopedBaseSchema.extend({
@@ -291,8 +290,7 @@ const StreamContentRenderFields = {
   activeState: z
     .strictObject({
       conversationProgress: ConversationProgressSchema,
-      roundStage: RoundStageSchema.nullable(),
-      phaseStage: PhaseStageSchema.nullable(),
+      stage: StreamStageSchema.nullable(),
       badges: z.strictObject({
         subagents: z.array(ActiveChildInfoSchema),
       }),
@@ -391,7 +389,7 @@ export const ProgressViewOutboundMessageSchema = z.discriminatedUnion(
     UpdateStreamMetadataMessageSchema,
     SetActiveStreamMessageSchema,
     UpdateConversationProgressMessageSchema,
-    UpdateRoundStageMessageSchema,
+    UpdateStageMessageSchema,
     UpdateStreamBadgesMessageSchema,
     UpdateStreamDescriptionMessageSchema,
     UpdateStreamStatusMessageSchema,

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -64,7 +64,7 @@ export type ActiveChildInfo = z.infer<typeof ActiveChildInfoSchema>;
 
 // Round Stage (ephemeral round label from typed stage.start metadata)
 
-export const RoundStageSchema = z.object({
+const RoundStageSchema = z.object({
   /** Zero-based round/turn index. */
   index: z.int().nonnegative(),
   /** Planned total, when known. Workflow runs set this; tool-use turns may not. */
@@ -80,7 +80,7 @@ export type RoundStage = z.infer<typeof RoundStageSchema>;
 // are projected from the same `stage.start` fact, discriminated by its `kind`,
 // and a stream that opens phases never opens rounds.
 
-export const PhaseStageSchema = z.object({
+const PhaseStageSchema = z.object({
   /** Phase title, free-form text from the workflow script. */
   label: z.string(),
   /** Zero-based position in the declared phase list. Absent for a phase the
@@ -91,6 +91,20 @@ export const PhaseStageSchema = z.object({
 });
 
 export type PhaseStage = z.infer<typeof PhaseStageSchema>;
+
+/**
+ * The one discriminated run-progress slot: a tool-use run advances through
+ * numbered rounds, a workflow-script run through named phases — never both —
+ * so state and wire carry one `stage` field rather than two
+ * independently-optional ones every reader has to fall back between. The arms
+ * extend the payload schemas above, so projecting to either is a `kind` strip.
+ */
+export const StreamStageSchema = z.discriminatedUnion('kind', [
+  RoundStageSchema.extend({ kind: z.literal('round') }),
+  PhaseStageSchema.extend({ kind: z.literal('phase') }),
+]);
+
+export type StreamStage = z.infer<typeof StreamStageSchema>;
 
 // Conversation Progress (tool-call counters updated during execution)
 
@@ -117,8 +131,7 @@ export const BackendOwnedFieldsSchema = z.object({
   conversationProgress: ConversationProgressSchema.prefault(
     DEFAULT_CONVERSATION_PROGRESS,
   ),
-  roundStage: RoundStageSchema.optional(),
-  phaseStage: PhaseStageSchema.optional(),
+  stage: StreamStageSchema.optional(),
   /** Child roster — live entries plus the finished ones retained for display
    *  (`finishedAt` set). */
   subagents: z.array(ActiveChildInfoSchema).prefault([]),
@@ -127,8 +140,7 @@ export const BackendOwnedFieldsSchema = z.object({
 export const StreamMetadataSchema = BackendOwnedFieldsSchema.extend({
   // Nullable over the wire: an explicit `null` clears a stage the frontend
   // still holds, which a plain omission cannot express.
-  roundStage: RoundStageSchema.nullable().optional(),
-  phaseStage: PhaseStageSchema.nullable().optional(),
+  stage: StreamStageSchema.nullable().optional(),
   /** Absent while the stream's run identity is still pending. */
   category: AgentCategorySchema.optional(),
 });

--- a/src/shared/streams/stage.ts
+++ b/src/shared/streams/stage.ts
@@ -1,16 +1,4 @@
-import type { PhaseStage, RoundStage } from '@shared/schemas';
-
-/**
- * One discriminated run-progress slot. A tool-use run advances through
- * numbered rounds; a workflow-script run advances through named phases —
- * never both — so consumers hold one `stage` field rather than two
- * independently-optional ones (`roundStage` / `phaseStage`) every reader
- * has to fall back between. The arms extend the wire payload shapes, so a
- * projection to either is a `kind` strip, never a field mapping.
- */
-export type StreamStage =
-  | ({ readonly kind: 'round' } & RoundStage)
-  | ({ readonly kind: 'phase' } & PhaseStage);
+import type { PhaseStage, RoundStage, StreamStage } from '@shared/schemas';
 
 /** The `stage.start` fact fields the normalizers below read. */
 interface StageStartLike {
@@ -38,7 +26,7 @@ export function roundStageFromStageStart(
 }
 
 /** The `PhaseStage` payload of a `kind: "phase"` stage fact, or undefined. */
-export function phaseStageFromStageStart(
+function phaseStageFromStageStart(
   event: StageStartLike,
 ): PhaseStage | undefined {
   if (event.kind !== 'phase') return undefined;

--- a/src/shared/streams/streamMetadata.ts
+++ b/src/shared/streams/streamMetadata.ts
@@ -32,8 +32,7 @@ export function buildStreamMetadata(
     conversationProgress: inputs.conversationProgress ?? {
       ...DEFAULT_CONVERSATION_PROGRESS,
     },
-    roundStage: inputs.roundStage ?? null,
-    phaseStage: inputs.phaseStage ?? null,
+    stage: inputs.stage ?? null,
     subagents: inputs.subagents ?? [],
   };
 }

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -6,9 +6,9 @@ import {
   type PhaseStage,
   type RoundStage,
   type StreamPhase,
+  type StreamStage,
   type StreamSubstate,
 } from '@shared/schemas';
-import type { StreamStage } from '@shared/streams/stage';
 
 export type StreamStatusDisplayKey = StreamPhase | StreamSubstate | 'ready';
 

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1041,7 +1041,7 @@ describe('DesktopProgressBridge', () => {
     );
     expect(streamSync?.streamStates?.parent).toMatchObject({
       conversationProgress: { toolCallCount: 5 },
-      roundStage: { index: 2 },
+      stage: { kind: 'round', index: 2 },
       subagents: [{ executionId: 'agent-1', agentName: 'reviewer' }],
     });
   });
@@ -1738,7 +1738,7 @@ describe('DesktopProgressBridge', () => {
       outputs: { files: {}, missing: {}, compileFailures: {} },
       activeState: {
         conversationProgress: { toolCallCount: 0 },
-        roundStage: null,
+        stage: null,
         badges: {
           subagents: [],
         },

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -177,12 +177,11 @@ describe('ProgressBackend', () => {
     expect(backend.state.activeStream).toBe('root');
     await vi.waitFor(() =>
       expect(backend.state.getStreamState(run)).toMatchObject({
-        phaseStage: { label: 'Reduce', index: 1, total: 3 },
+        stage: { kind: 'phase', label: 'Reduce', index: 1, total: 3 },
       }),
     );
     expect(metadataPatchFor(messages, run).streamState).toMatchObject({
-      phaseStage: { label: 'Reduce', index: 1, total: 3 },
-      roundStage: null,
+      stage: { kind: 'phase', label: 'Reduce', index: 1, total: 3 },
     });
   });
 
@@ -864,7 +863,7 @@ describe('ProgressBackend', () => {
 
       expect(target.backend.state.getStreamState(parentStreamId)).toMatchObject(
         {
-          roundStage: { index: 2, total: 4 },
+          stage: { kind: 'round', index: 2, total: 4 },
           subagents: [child],
         },
       );
@@ -931,7 +930,7 @@ describe('ProgressBackend', () => {
     backend.state.updateStreamState(stream, (prev) => ({
       ...prev,
       conversationProgress: { toolCallCount: 7 },
-      roundStage: { index: 2 },
+      stage: { kind: 'round', index: 2 },
       subagents: [
         {
           childStreamId: 'child-stream',
@@ -962,10 +961,10 @@ describe('ProgressBackend', () => {
       category: AgentCategory.ToolUse,
       status: STREAM_PHASE.RUNNING,
       conversationProgress: { toolCallCount: 0 },
-      roundStage: null,
+      stage: null,
       subagents: [],
     });
-    expect(JSON.parse(JSON.stringify(patch)).streamState.roundStage).toBeNull();
+    expect(JSON.parse(JSON.stringify(patch)).streamState.stage).toBeNull();
   });
 
   it('keeps resident background entries during an in-flight status update', async () => {

--- a/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
@@ -82,8 +82,7 @@ describe('SyncStreamContentMessageSchema', () => {
     outputs: { files: {}, missing: {}, compileFailures: {} },
     activeState: {
       conversationProgress: { toolCallCount: 0 },
-      roundStage: null,
-      phaseStage: null,
+      stage: null,
       badges: {
         subagents: [],
       },
@@ -132,7 +131,7 @@ describe('SyncStreamContentMessageSchema', () => {
       ...workflow,
       activeState: {
         conversationProgress: workflow.activeState.conversationProgress,
-        roundStage: null,
+        stage: null,
         badges: workflow.activeState.badges,
         parentStreamId: null,
       },

--- a/src/test-kernel/progressView/RepairRoundBadge.vitest.ts
+++ b/src/test-kernel/progressView/RepairRoundBadge.vitest.ts
@@ -121,10 +121,7 @@ describe('repair-round progress badge (PR #7290 follow-up)', () => {
       // total widened to 3 via Math.max(totalRounds, roundIndex + 1).
       const repairRoundStage: RoundStage = { index: 2, total: 3 };
 
-      const stage = {
-        phaseStage: undefined,
-        roundStage: repairRoundStage,
-      };
+      const stage = { kind: 'round', ...repairRoundStage } as const;
 
       const container = document.createElement('div');
       render(renderProgressBadgeContent(undefined, stage), container);

--- a/src/test-kernel/progressView/StreamContentSync.vitest.ts
+++ b/src/test-kernel/progressView/StreamContentSync.vitest.ts
@@ -133,7 +133,7 @@ describe('progress view stream-content projection', () => {
     state.updateStreamState(stream, (prev) => ({
       ...prev,
       conversationProgress: { toolCallCount: 5 },
-      roundStage: { index: 2 },
+      stage: { kind: 'round', index: 2 },
       subagents: [activeSubagent],
     }));
 
@@ -159,10 +159,7 @@ describe('progress view stream-content projection', () => {
       },
       activeState: {
         conversationProgress: { toolCallCount: 5 },
-        roundStage: { index: 2 },
-        // All-or-nothing: a tool-use run has no phase, and the slot is still
-        // sent so a tab switch clears whatever the frontend had cached.
-        phaseStage: null,
+        stage: { kind: 'round', index: 2 },
         badges: {
           subagents: [activeSubagent],
         },
@@ -184,7 +181,7 @@ describe('progress view stream-content projection', () => {
     state.getOrCreateStreamState(stream, AgentCategory.Workflow);
     state.updateStreamState(stream, (prev) => ({
       ...prev,
-      phaseStage: { label: 'Reduce', index: 1, total: 3 },
+      stage: { kind: 'phase', label: 'Reduce', index: 1, total: 3 },
     }));
 
     handler.syncStreamContent(stream, { includeActiveState: true });
@@ -194,8 +191,7 @@ describe('progress view stream-content projection', () => {
       action: 'render',
       category: AgentCategory.Workflow,
       activeState: {
-        roundStage: null,
-        phaseStage: { label: 'Reduce', index: 1, total: 3 },
+        stage: { kind: 'phase', label: 'Reduce', index: 1, total: 3 },
       },
     });
   });

--- a/src/test-kernel/progressView/StreamHeader.vitest.mts
+++ b/src/test-kernel/progressView/StreamHeader.vitest.mts
@@ -148,7 +148,7 @@ describe('stream-header', () => {
 
     it('anchors the progress badge tooltip via wa-tooltip[for], not a native title', async () => {
       const element = await mount({
-        roundStage: { index: 0, total: 2 },
+        stage: { kind: 'round', index: 0, total: 2 },
       });
 
       const badge = element.shadowRoot?.querySelector('#progressBadge');
@@ -173,10 +173,9 @@ describe('stream-header', () => {
   });
 
   /**
-   * The badge's stage slot follows the CLI's child-row rule: a workflow-script
-   * run advances through named phases, a tool-use run through numbered rounds,
-   * and one slot carries whichever this stream has, phase first. Before this,
-   * a workflow-script stream's own header showed no stage at all.
+   * The badge's stage slot is the canonical discriminated `StreamStage`: a
+   * workflow-script run advances through named phases, a tool-use run through
+   * numbered rounds — one slot carries whichever this stream has.
    */
   describe('phase/round stage slot', () => {
     function badgeText(element: StreamHeader): string | undefined {
@@ -193,7 +192,7 @@ describe('stream-header', () => {
 
     it('renders the phase label when the stream has one', async () => {
       const element = await mount({
-        phaseStage: { label: 'Reduce', index: 1, total: 3 },
+        stage: { kind: 'phase', label: 'Reduce', index: 1, total: 3 },
       });
 
       expect(badgeText(element)).toBe('Reduce 2/3');
@@ -201,25 +200,17 @@ describe('stream-header', () => {
     });
 
     it('renders a dynamically opened phase with no declared position', async () => {
-      const element = await mount({ phaseStage: { label: 'Cleanup' } });
+      const element = await mount({
+        stage: { kind: 'phase', label: 'Cleanup' },
+      });
 
       expect(badgeText(element)).toBe('Cleanup');
       expect(badgeTooltip(element)).toBe('Phase: Cleanup');
     });
 
-    it('prefers the phase over a round when both are somehow present', async () => {
-      const element = await mount({
-        phaseStage: { label: 'Reduce', index: 1, total: 3 },
-        roundStage: { index: 0, total: 2 },
-      });
-
-      expect(badgeText(element)).toBe('Reduce 2/3');
-      expect(badgeTooltip(element)).toBe('Phase 2 of 3: Reduce');
-    });
-
     it('keeps the tool-call count alongside the phase', async () => {
       const element = await mount({
-        phaseStage: { label: 'Reduce', index: 1, total: 3 },
+        stage: { kind: 'phase', label: 'Reduce', index: 1, total: 3 },
         progress: { toolCallCount: 4 },
       });
 

--- a/src/test-kernel/progressView/StreamMetaState.vitest.ts
+++ b/src/test-kernel/progressView/StreamMetaState.vitest.ts
@@ -139,7 +139,7 @@ describe('stream meta frontend state', () => {
         conversationProgress: {
           toolCallCount: 3,
         },
-        roundStage: { index: 1 },
+        stage: { kind: 'round', index: 1 },
         subagents: [],
       },
       activeStream: siblingId,
@@ -156,7 +156,7 @@ describe('stream meta frontend state', () => {
       conversationProgress: {
         toolCallCount: 3,
       },
-      roundStage: { index: 1 },
+      stage: { kind: 'round', index: 1 },
       subagents: [],
     });
     expect(getState().activeStreamId).toBe(siblingId);
@@ -249,7 +249,7 @@ describe('stream meta frontend state', () => {
     state.streamStates.set(
       streamId,
       createStreamState(AgentCategory.Workflow, {
-        roundStage: { index: 2 },
+        stage: { kind: 'round', index: 2 },
       } satisfies Partial<StreamState>),
     );
     const getState = seedState(state);
@@ -268,14 +268,14 @@ describe('stream meta frontend state', () => {
         conversationProgress: {
           toolCallCount: 0,
         },
-        roundStage: null,
+        stage: null,
         subagents: [],
       },
     });
 
     dispatch(streamMetaHandlers, message);
 
-    expect(getState().streamStates.get(streamId)?.roundStage).toBeUndefined();
+    expect(getState().streamStates.get(streamId)?.stage).toBeUndefined();
   });
 
   it('merges and clears a phase stage from a transport-safe metadata patch', () => {
@@ -285,7 +285,12 @@ describe('stream meta frontend state', () => {
     const getState = seedState(state);
 
     const patch = (
-      phaseStage: { label: string; index?: number; total?: number } | null,
+      stage: {
+        kind: 'phase';
+        label: string;
+        index?: number;
+        total?: number;
+      } | null,
     ): ProgressViewOutboundMessage =>
       overWire({
         command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
@@ -301,24 +306,24 @@ describe('stream meta frontend state', () => {
           conversationProgress: {
             toolCallCount: 0,
           },
-          roundStage: null,
-          phaseStage,
+          stage,
           subagents: [],
         },
       });
 
     dispatch(
       streamMetaHandlers,
-      patch({ label: 'Reduce', index: 1, total: 3 }),
+      patch({ kind: 'phase', label: 'Reduce', index: 1, total: 3 }),
     );
-    expect(getState().streamStates.get(streamId)?.phaseStage).toEqual({
+    expect(getState().streamStates.get(streamId)?.stage).toEqual({
+      kind: 'phase',
       label: 'Reduce',
       index: 1,
       total: 3,
     });
 
     dispatch(streamMetaHandlers, patch(null));
-    expect(getState().streamStates.get(streamId)?.phaseStage).toBeUndefined();
+    expect(getState().streamStates.get(streamId)?.stage).toBeUndefined();
   });
 
   it('keeps the phase-stage projection stable across unrelated stream ticks', () => {
@@ -330,13 +335,14 @@ describe('stream meta frontend state', () => {
     state.streamStates.set(
       streamId,
       createStreamState(AgentCategory.Workflow, {
-        phaseStage: { label: 'Reduce', index: 1, total: 3 },
+        stage: { kind: 'phase', label: 'Reduce', index: 1, total: 3 },
       } satisfies Partial<StreamState>),
     );
     seedState(state);
 
     const initial = phaseStages$.get();
     expect(initial.get(streamId)).toEqual({
+      kind: 'phase',
       label: 'Reduce',
       index: 1,
       total: 3,
@@ -354,11 +360,12 @@ describe('stream meta frontend state', () => {
     // A real phase advance does change identity.
     setStreamStateForId(streamId, (prev) => ({
       ...prev,
-      phaseStage: { label: 'Publish', index: 2, total: 3 },
+      stage: { kind: 'phase', label: 'Publish', index: 2, total: 3 },
     }));
     const advanced = phaseStages$.get();
     expect(advanced).not.toBe(initial);
     expect(advanced.get(streamId)).toEqual({
+      kind: 'phase',
       label: 'Publish',
       index: 2,
       total: 3,
@@ -368,20 +375,19 @@ describe('stream meta frontend state', () => {
     // metadata patch that crosses postMessage) must not count as a change.
     setStreamStateForId(streamId, (prev) => ({
       ...prev,
-      phaseStage: { label: 'Publish', index: 2, total: 3 },
+      stage: { kind: 'phase', label: 'Publish', index: 2, total: 3 },
     }));
     expect(phaseStages$.get()).toBe(advanced);
   });
 
-  it('clears round and phase stage when synced content explicitly clears them', () => {
+  it('clears the stage slot when synced content explicitly clears it', () => {
     const streamId = 'stream-a' as StreamTabId;
     const state = createInitialState();
     registerStream(state, streamId);
     state.streamStates.set(
       streamId,
       createStreamState(AgentCategory.Workflow, {
-        roundStage: { index: 2 },
-        phaseStage: { label: 'Reduce', index: 1, total: 3 },
+        stage: { kind: 'phase', label: 'Reduce', index: 1, total: 3 },
       } satisfies Partial<StreamState>),
     );
     const getState = seedState(state);
@@ -395,8 +401,7 @@ describe('stream meta frontend state', () => {
       outputs: { files: {}, missing: {}, compileFailures: {} },
       activeState: {
         conversationProgress: { toolCallCount: 0 },
-        roundStage: null,
-        phaseStage: null,
+        stage: null,
         badges: {
           subagents: [],
         },
@@ -405,8 +410,7 @@ describe('stream meta frontend state', () => {
 
     dispatch(syncHandlers, message);
 
-    expect(getState().streamStates.get(streamId)?.roundStage).toBeUndefined();
-    expect(getState().streamStates.get(streamId)?.phaseStage).toBeUndefined();
+    expect(getState().streamStates.get(streamId)?.stage).toBeUndefined();
   });
 
   it('honors an explicit empty active-stream selection', () => {

--- a/src/test-kernel/shared/SharedStreams.vitest.ts
+++ b/src/test-kernel/shared/SharedStreams.vitest.ts
@@ -86,8 +86,7 @@ describe('buildStreamMetadata', () => {
       category: AgentCategory.Workflow,
       status: STREAM_STATUS.READY,
       conversationProgress: { toolCallCount: 0 },
-      roundStage: null,
-      phaseStage: null,
+      stage: null,
       subagents: [],
     });
     expect(Object.hasOwn(metadata, 'substate')).toBe(true);
@@ -118,7 +117,7 @@ describe('buildStreamMetadata', () => {
         substate: STREAM_SUBSTATE.STARTING,
         lastTimestamp: 123,
         conversationProgress: { toolCallCount: 5 },
-        roundStage: { index: 1, total: 3 },
+        stage: { kind: 'round', index: 1, total: 3 },
         subagents: [child, finishedChild],
       }),
     ).toEqual({
@@ -127,8 +126,7 @@ describe('buildStreamMetadata', () => {
       substate: STREAM_SUBSTATE.STARTING,
       lastTimestamp: 123,
       conversationProgress: { toolCallCount: 5 },
-      roundStage: { index: 1, total: 3 },
-      phaseStage: null,
+      stage: { kind: 'round', index: 1, total: 3 },
       subagents: [child, finishedChild],
     });
   });
@@ -137,9 +135,9 @@ describe('buildStreamMetadata', () => {
     expect(
       buildStreamMetadata({
         category: AgentCategory.Workflow,
-        phaseStage: { label: 'Reduce', index: 1, total: 3 },
-      }).phaseStage,
-    ).toEqual({ label: 'Reduce', index: 1, total: 3 });
+        stage: { kind: 'phase', label: 'Reduce', index: 1, total: 3 },
+      }).stage,
+    ).toEqual({ kind: 'phase', label: 'Reduce', index: 1, total: 3 });
   });
 });
 


### PR DESCRIPTION
## Summary

Second slice of Part III step 16 of the run-classification consolidation proposal, after #9710. The Lit stack (extension + desktop progress view) drops the independently-optional `roundStage`/`phaseStage` pair and carries the one discriminated `stage: StreamStage` slot end-to-end — backend `StreamExecutionState`, the webview wire (`UPDATE_ROUND_STAGE` → `UPDATE_STAGE`; `StreamMetadata` and the `SYNC_STREAM_CONTENT` active state carry `stage`), and every frontend reader. The impossible both-slots-set state is now unrepresentable, and `formatStageLabel` is the one dispatch point for rendering.

Delivery policy is unchanged: phase advances still ride the per-stream metadata patch (a workflow-script run's phase is read from its parent's viewport, so it must reach non-active streams), and round advances still go as a targeted message to the active stream only. The frozen public NDJSON wire is untouched — it keeps `updateRoundStage`/`RoundStage`.

## Issue acceptance gates

Proposal step 16, "adopt the canonical field shapes (single `stage` slot from the CLI)": done for the Lit stack. `rg -n 'roundStage|phaseStage' src/controllers packages/extension/src/progressView` now hits only the frozen-wire arms (`RoundStage`/`PhaseStage` types) where they are genuinely per-arm (`formatRoundStageLabel`/`formatPhaseStageLabel`). The view-model generalization (one applier, TUI port, CLI parallel-derivation deletions) is the next PR.

## Single source of truth

`StreamStageSchema` in `src/shared/schemas/streamState.ts` — the discriminated union whose arms extend `RoundStageSchema`/`PhaseStageSchema`, so a projection to either payload is a `kind` strip. The `StreamStage` type moved from `src/shared/streams/stage.ts` (added in #9710) into the schema per the schemas-are-SSOT rule; the normalizers stay in `stage.ts`.

## Duplication and abstraction budget

Removed: the two-field fallback pattern at every reader (`phaseStage ?? roundStage` in badge formatter, header, sync slices, metadata merge), the applier's separate `handleUpdateRoundStage`/`handleUpdatePhaseStage` (one `handleUpdateStage` keeps both delivery policies), `UpdatePhaseStagePayload`, and one impossible-state test. `RoundStageSchema`/`PhaseStageSchema` and `phaseStageFromStageStart` are un-exported (internal-only now). No new abstractions.

## Net elements (R6)

30 files changed, +156/−245 (net −89 LoC). Exports: +2 (`StreamStageSchema`, `StreamStage` in schemas), −5 (`StreamStage` moved out of `stage.ts`, `UpdatePhaseStagePayload` deleted, `RoundStageSchema`/`PhaseStageSchema`/`phaseStageFromStageStart` un-exported). No new classes.

## Consumer counts (R8)

`UPDATE_ROUND_STAGE` → `UPDATE_STAGE`: 1 sender (`WebviewUpdater.updateStage`), 1 frontend handler (`streamMetaSlice`), both recut. `UpdatePhaseStagePayload` deleted: 0 remaining consumers (grepped). `StreamStage` import re-pointed in 4 files. Frozen NDJSON `updateRoundStage` consumers untouched (`cliNdjsonProgressEvents`, `sessionProgressSubscription`).

## Host impact

Extension: webview wire message renamed and payload shape changed (internal wire, versioned with the bundle — backend and frontend ship together).

Desktop: same progress-view stack; smoke fixtures (`scripts/smoke-webviews-electron.mjs`, `capture-walkthrough-media.mjs`) updated to the new shape.

CLI: no behavior change — only the `StreamStage` import moves to `@shared/schemas`; the TUI slot and frozen NDJSON output are byte-identical.

## Scheduled refactoring

Next PR (step 16 remainder): generalize `ProgressViewState`/`ProgressFactApplier` into the session view-model, port the TUI onto it, delete the CLI's parallel derivations (`applySubagentRoster`, status mirror, task-group rebuild driver, remaining dispatch tables).

## Validation

`npm run typecheck` (all 7 configs), `npx vitest run src/test-kernel/{progressView,shared,desktop,cli}` (292 files, 3379 passed), `npx eslint` on all changed files, `npm run check:dead-code-ratchet` (18 = 18), `prettier` clean. Electron webview smoke runs in CI (`webview smoke (macOS)`) against the updated fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JK8BzoyKHjFg2jEam9KXv

---
_Generated by [Claude Code](https://claude.ai/code/session_013JK8BzoyKHjFg2jEam9KXv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches progress-view backend state, webview IPC schemas, and Lit frontend merge/sync paths; delivery policy is intentionally unchanged but regressions could show wrong badges or stale stage on tab switches. Public CLI NDJSON is explicitly untouched.
> 
> **Overview**
> **Unifies run progress staging** in the extension/desktop Lit progress view on a single discriminated **`stage: StreamStage`** slot (`kind: 'round' | 'phase'`) instead of the old paired optional `roundStage` / `phaseStage` fields, so both-at-once state is unrepresentable.
> 
> **Schema & wire:** `StreamStageSchema` / `StreamStage` become the SSOT in `streamState.ts`; backend `StreamExecutionState`, `StreamMetadata`, and `SYNC_STREAM_CONTENT` active state carry `stage`. The internal webview command is **`UPDATE_ROUND_STAGE` → `UPDATE_STAGE`** with a `stage` payload. `UpdatePhaseStagePayload` is removed; **`UpdateRoundStagePayload` remains** only for the frozen public NDJSON `updateRoundStage` vocabulary.
> 
> **Behavior preserved:** `ProgressFactApplier` collapses to **`handleUpdateStage`** using `streamStageFromStageStart` — **phase** updates still ride the per-stream metadata patch (parent viewports), **round** updates still target the active stream only. Frontend badge/header/sync paths use **`formatStageLabel`** on `stage.kind` instead of phase-first fallbacks.
> 
> **Tests & docs:** Vitest fixtures and smoke scripts switch to `{ kind: 'round', … }` / `{ kind: 'phase', … }`. The run-classification proposal is updated to record #9712 as landed and to spell out remaining step 16/18 handoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6df1772e23f314a59aaf5229b197d0ae9f81f99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->