### PR TITLE
fix(ui): stop stacking element opacity on tokens that already carry alpha

### DIFF
--- a/packages/desktop/src/renderer/taskShell.css
+++ b/packages/desktop/src/renderer/taskShell.css
@@ -99,7 +99,6 @@
   color: var(--wa-color-text-quiet);
   font-size: var(--font-size-xs);
   line-height: 1;
-  opacity: 0.45;
   pointer-events: none;
   transform: rotate(90deg);
 }
@@ -112,7 +111,6 @@
   color: var(--wa-color-text-quiet);
   font-size: var(--font-size-xs);
   line-height: 1;
-  opacity: 0.45;
   pointer-events: none;
 }
 
@@ -282,7 +280,6 @@ body[data-desktop-platform='darwin'] .task-sidebar-brand {
   color: var(--wa-color-text-quiet);
   font-size: var(--font-size-xs);
   line-height: 1;
-  opacity: 0.45;
   pointer-events: none;
 }
 

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
@@ -151,9 +151,12 @@ export const modelSelectionListStyles: CSSResult = css`
   }
 
   /* Unavailable model rows (not in relay allowlist) */
-  .model-row--unavailable {
-    opacity: var(--opacity-disabled);
-  }
+  /* No row-level dim. At 0.5 on top of an already-translucent secondary text
+     token this composited to 1.91:1, and it also dimmed .model-metadata and
+     .reasoning-level-select, which render OUTSIDE the wa-switch and so never
+     qualified for the disabled-control contrast exemption in the first place.
+     Unavailability is already carried by the key / warning icon and its title
+     on the row, which is the cue that survives a contrast check. */
 
   /**
    * Inline icon following a model row's name. Variants set --_icon-color;

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -212,10 +212,9 @@ export class ModelSelectionList extends LitElement {
 
   private renderModelRow(model: ModelSelectionItem): TemplateResult {
     const available = !model.disabled;
-    const unavailableClass = !available ? ' model-row--unavailable' : '';
 
     return html`
-      <div class="model-row${unavailableClass}">
+      <div class="model-row">
         <wa-switch
           ?checked=${model.enabled}
           ?disabled=${!available && !model.enabled}

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.styles.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.styles.ts
@@ -136,9 +136,10 @@ export const instructionPanelStyles: CSSResult = css`
     flex: 1 1 auto;
   }
 
+  /* No element opacity: --wa-color-text-quiet is already 70% alpha, and the
+     extra 0.85 composited to 3.18:1 on the brand callout. */
   .session-hint-time {
     color: var(--wa-color-text-quiet);
-    opacity: var(--opacity-normal);
   }
 
   .session-hint-dismiss {

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -34,15 +34,16 @@ export class LoginBanner extends LitElement {
         display: block;
         margin-top: var(--wa-space-3xs);
         font-size: var(--font-size-sm);
-        opacity: var(--opacity-normal);
         line-height: var(--line-height-normal, 1.4);
       }
 
+      /* Terms the user is agreeing to. Was --font-size-xs (10.4px) at 0.6
+         opacity on an already-translucent callout: 3.22:1. It now inherits the
+         13px body size and takes its de-emphasis from the callout treatment,
+         not from a second size step plus an alpha. */
       .banner-fineprint {
         display: block;
         margin-top: var(--wa-space-3xs);
-        font-size: var(--font-size-xs);
-        opacity: var(--opacity-muted);
         line-height: var(--line-height-normal, 1.4);
       }
 

--- a/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
@@ -166,7 +166,6 @@ export class OnboardingWelcomeCard extends LitElement {
 
       .skip-row wa-button::part(base) {
         font-size: var(--font-size-sm);
-        color: var(--color-text-muted);
       }
 
       @container onboarding-card (max-width: 420px) {

--- a/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
@@ -151,7 +151,6 @@ export class OnboardingWelcomeCard extends LitElement {
         margin-top: var(--wa-space-3xs);
         text-align: center;
         font-size: var(--font-size-sm);
-        opacity: var(--opacity-subtle);
         line-height: var(--line-height-normal, 1.4);
         overflow-wrap: anywhere;
       }
@@ -167,7 +166,7 @@ export class OnboardingWelcomeCard extends LitElement {
 
       .skip-row wa-button::part(base) {
         font-size: var(--font-size-sm);
-        opacity: var(--opacity-subtle);
+        color: var(--color-text-muted);
       }
 
       @container onboarding-card (max-width: 420px) {

--- a/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
@@ -152,6 +152,7 @@ export class OnboardingWelcomeCard extends LitElement {
         text-align: center;
         font-size: var(--font-size-sm);
         line-height: var(--line-height-normal, 1.4);
+        color: var(--wa-color-text-quiet);
         overflow-wrap: anywhere;
       }
 

--- a/packages/extension/src/webview/frontend/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/fileSelectStyles.ts
@@ -49,7 +49,7 @@ export const fileSelectLayoutStyles = css`
   .file-select-label-group {
     display: flex;
     align-items: center;
-    gap: var(--wa-space-3xs);
+    gap: var(--wa-space-2xs);
     flex-wrap: nowrap;
     flex: 1;
     min-width: 0;
@@ -86,7 +86,7 @@ export const fileSelectLayoutStyles = css`
     align-items: center;
     flex-wrap: nowrap;
     margin-left: auto;
-    gap: var(--wa-space-3xs);
+    gap: var(--wa-space-2xs);
   }
 
   .file-select-actions wa-button {
@@ -163,7 +163,7 @@ const multiFilesStyles = css`
 
   .file-folder {
     color: var(--color-text-secondary);
-    font-size: var(--font-size-xs);
+    font-size: var(--font-size-sm);
   }
 
   .file-folder wa-icon {

--- a/src/shared/styles/selectStyles.ts
+++ b/src/shared/styles/selectStyles.ts
@@ -84,8 +84,7 @@ export const selectStyles: CSSResult = css`
 
   wa-option[disabled],
   wa-option[data-requires-key='true'] {
-    color: var(--color-text-secondary, var(--wa-color-text-quiet));
-    opacity: var(--opacity-subtle, 0.7);
+    color: var(--color-text-muted);
     font-style: italic;
   }
 

--- a/src/shared/styles/statusIndicatorStyles.ts
+++ b/src/shared/styles/statusIndicatorStyles.ts
@@ -1,5 +1,18 @@
 import { css, type CSSResult } from 'lit';
 
+/**
+ * The 8px status dot.
+ *
+ * Every state expresses its step in colour alone. The previous version layered
+ * an element `opacity` on top of `--wa-color-text-quiet`, which is itself
+ * `color-mix(… 70%, transparent)` — so the quiet states composited to 0.49 and
+ * the `is-ready` state to 0.35 effective alpha, measuring 2.65:1 and 1.94:1
+ * against the 3:1 minimum for a non-text indicator. `--color-text-muted`
+ * carries that de-emphasis once, at a value that holds in every theme.
+ *
+ * The saturated states never needed `opacity: 1` — that was only undoing the
+ * base rule's fade.
+ */
 export const statusIndicatorStyles: CSSResult = css`
   .status-indicator {
     width: 8px;
@@ -7,39 +20,34 @@ export const statusIndicatorStyles: CSSResult = css`
     border-radius: 50%;
     display: inline-block;
     flex-shrink: 0;
-    background-color: var(--wa-color-text-quiet);
-    opacity: var(--opacity-subtle, 0.7);
+    background-color: var(--color-text-muted);
   }
 
   .status-indicator.is-running {
     background-color: var(--color-success);
-    opacity: var(--opacity-full);
   }
 
   .status-indicator.is-completed,
   .status-indicator.is-cancelled {
-    background-color: var(--wa-color-text-quiet);
-    opacity: var(--opacity-subtle, 0.7);
+    background-color: var(--color-text-muted);
   }
 
   .status-indicator.is-failed {
     background-color: var(--color-error);
-    opacity: var(--opacity-full);
   }
 
   .status-indicator.is-waiting,
   .status-indicator.is-resuming {
     background-color: var(--wa-color-text-link);
-    opacity: var(--opacity-full);
   }
 
   .status-indicator.is-starting {
-    background-color: var(--wa-color-text-quiet);
-    opacity: var(--opacity-full);
+    background-color: var(--color-text-muted);
   }
 
+  /* Same fill as the other quiet states: "ready" is told apart by its position
+     and its label, not by an alpha step nobody can see. */
   .status-indicator.is-ready {
-    background-color: var(--wa-color-text-quiet);
-    opacity: var(--opacity-disabled, 0.5);
+    background-color: var(--color-text-muted);
   }
 `;

--- a/src/shared/styles/statusIndicatorStyles.ts
+++ b/src/shared/styles/statusIndicatorStyles.ts
@@ -41,8 +41,11 @@ export const statusIndicatorStyles: CSSResult = css`
     background-color: var(--wa-color-text-link);
   }
 
+  /* Not the muted fill: "starting" is in progress, and folding it in with
+     completed/cancelled/ready made five different states render as one dot.
+     --color-pending is the accent already used for in-progress timers. */
   .status-indicator.is-starting {
-    background-color: var(--color-text-muted);
+    background-color: var(--color-pending);
   }
 
   /* Same fill as the other quiet states: "ready" is told apart by its position


### PR DESCRIPTION
Stacked on #9714 (which is stacked on #9711). Retarget as those merge.

PR 2 of the cross-surface interface review. **One root cause, fourteen rules.** `--wa-color-text-quiet` is `color-mix(… 70%, transparent)`, so an element `opacity` on top multiplies into an effective alpha nobody wrote down — and every measured composite landed under its threshold.

| Site | effective α | measured | needs |
| --- | --- | --- | --- |
| Status dots, quiet states | 0.49 | 2.65:1 | 3:1 |
| Status dot, `is-ready` | 0.35 | **1.94:1** | 3:1 |
| Disabled `wa-option` | 0.49 | 2.65:1 | 3:1 |
| Unavailable model row | 0.35 | **1.91:1** | 3:1 |
| Session hint time | 0.595 | 3.18:1 | 4.5:1 |
| Login banner fineprint | 0.60 | 3.22:1 | 4.5:1 |
| Onboarding choice copy | 0.70 | 4.11:1 | 4.5:1 |
| Desktop split-panel grips | 0.45 | **1.99:1** | 3:1 |

The fix is the same everywhere: delete the `opacity`, express the step once in colour via `--color-text-muted` from #9714.

## Three sites needed judgement, not a mechanical swap

**Login banner fineprint** is the programme terms a user is agreeing to. It was `--font-size-xs` (10.4px) *and* faded. `--font-size-sm` would still be 11.7px, so it now inherits the 13px body size and takes its de-emphasis from the callout treatment rather than a second size step plus an alpha.

**The unavailable model row's dim** also covered `.model-metadata` and `.reasoning-level-select` — both rendered *outside* the `<wa-switch>`, so they never qualified for the disabled-control contrast exemption in the first place. I checked before removing it: the row already renders a `key` or `triangle-exclamation` icon with a title (`ModelSelectionList.ts:196-210`), so unavailability keeps a cue that survives a contrast check. This was flagged as a possible design decision during review; that cue is what resolves it.

**The saturated status dots** carried `opacity: 1` only to undo the base rule's fade. With the fade gone, they don't need it.

## Also here

- `.file-folder` moves off the 10.4px step to 11.7px.
- The two 2px gutters between adjacent icon-only buttons widen to 4px so their hit areas stop touching.

The buttons themselves stay 20px. Reaching 24×24 means raising `--wa-control-size-s`, which carries an explicit "reads as editor chrome" rationale and resizes every compact toolbar in the extension — left as a design decision, not shipped silently.

## Verification

- `npm run typecheck` — clean across all seven projects.
- `npm run lint` — clean. `prettier --check` on every changed file — clean.
- `npx vitest run` — **820 files / 8,421 tests passing**.
- Every ratio above computed in Node against the surface each element actually sits on, compositing `color-mix` alpha and element `opacity` before measuring.

**Not verified:** nothing rendered. These are contrast and token changes derived from the cascade; the status dots and the model list are the most visible and worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ddRTq1PLM3eZR8yf8xjaV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only visual and contrast adjustments with no logic, auth, or data-path changes; main risk is subtle appearance shifts worth a quick visual pass on status dots and the model list.
> 
> **Overview**
> Fixes **accessibility contrast failures** caused by layering element `opacity` on top of tokens like `--wa-color-text-quiet` that already use `color-mix` alpha. The effective contrast dropped below 3:1 (non-text) or 4.5:1 (small text) across ~14 rules.
> 
> **Core pattern:** remove redundant `opacity`, and express de-emphasis once via **`--color-text-muted`** (from the stacked token PR) or existing quiet text colors. **Status dots** no longer fade the base dot; quiet states use `--color-text-muted`, **`is-starting`** uses **`--color-pending`**, and redundant `opacity: 1` on saturated states is gone. **Disabled / requires-key `wa-option`** rows drop stacked opacity for `--color-text-muted` + italic.
> 
> **Targeted UX tweaks:** unavailable **model rows** lose row-level dim (it also washed metadata/reasoning controls outside the switch); key/warning icons still signal unavailability. **Login banner** fineprint drops xs size + fade and inherits body size. **Onboarding** choice copy and skip button use quiet color instead of opacity fade. **Desktop split handles** lose extra opacity. **File select** bumps folder label to `font-size-sm` and widens icon-button gaps from 3xs to 2xs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b780d1c80d3be3cead485e8f2a5856b0f0948db0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->