### PR TITLE
fix(ui): name every control, expose its state, and restore the shared focus ring

### DIFF
--- a/packages/desktop/src/renderer/promptOverlay.ts
+++ b/packages/desktop/src/renderer/promptOverlay.ts
@@ -96,7 +96,12 @@ export function createDesktopPromptOverlay(
     // label. As a subtitle it named nothing — wa-input puts its control inside
     // a shadow root, so only WebAwesome's `label` produces a real <label for>.
     // Kept in one place rather than two so the text is not read out twice.
-    if (shell.subtitleEl) shell.subtitleEl.textContent = '';
+    // Hide the empty subtitle so its always-on top margin does not leave a gap
+    // between the title and the input.
+    if (shell.subtitleEl) {
+      shell.subtitleEl.textContent = '';
+      shell.subtitleEl.hidden = true;
+    }
     input.type = message.password ? 'password' : 'text';
     input.label = message.prompt;
     input.value = '';

--- a/packages/desktop/src/renderer/promptOverlay.ts
+++ b/packages/desktop/src/renderer/promptOverlay.ts
@@ -92,8 +92,13 @@ export function createDesktopPromptOverlay(
     if (current) sendSettlement(current, null);
     current = message;
     if (shell.titleEl) shell.titleEl.textContent = message.title;
-    if (shell.subtitleEl) shell.subtitleEl.textContent = message.prompt;
+    // The prompt text moves from the sibling subtitle into the field's own
+    // label. As a subtitle it named nothing — wa-input puts its control inside
+    // a shadow root, so only WebAwesome's `label` produces a real <label for>.
+    // Kept in one place rather than two so the text is not read out twice.
+    if (shell.subtitleEl) shell.subtitleEl.textContent = '';
     input.type = message.password ? 'password' : 'text';
+    input.label = message.prompt;
     input.value = '';
     dialog.setAttribute('aria-label', message.title);
     dialog.open = true;

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -420,7 +420,12 @@ export class HistoryItemElement extends LitElement {
                 (!entry.toolUseOnly || presentation.isToolUse) &&
                 (!entry.hideWhenUnsupported ||
                   !isKnownUnsupported(this.unsupportedCommands, entry.command)),
-            ).map((entry) => renderIconActionButton(entry.button))}
+            ).map((entry) =>
+              renderIconActionButton({
+                ...entry.button,
+                label: `${entry.button.label}: ${presentation.title}`,
+              }),
+            )}
           </div>
         </div>
         ${this.renderInstructionBlock(

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -30,6 +30,7 @@ import {
   historyStyles,
   searchHighlightStyles,
 } from '@shared/styles/historyStyles';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local imports - history view events
 import { HistoryViewEvents } from './events';
@@ -423,7 +424,7 @@ export class HistoryItemElement extends LitElement {
             ).map((entry) =>
               renderIconActionButton({
                 ...entry.button,
-                label: `${entry.button.label}: ${presentation.title}`,
+                label: `${entry.button.label}: ${truncateWithEllipsis(presentation.title, LONG_INSTRUCTION_CHARS)}`,
               }),
             )}
           </div>

--- a/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
@@ -68,16 +68,18 @@ export class SearchBar extends LitElement {
   override render(): TemplateResult {
     return html`
       <div class="search-container">
+        <label class="visually-hidden" for="history-search">
+          Search history
+        </label>
         <wa-input
+          id="history-search"
           class="search-input"
           type="search"
           placeholder="Search history…"
           .value=${this.searchTerm}
           @input=${this.handleInput}
           @keydown=${this.handleKeydown}
-        >
-          <span slot="label" class="visually-hidden">Search history</span>
-        </wa-input>
+        ></wa-input>
         <div class="search-controls action-button-group">
           ${renderIconActionButton({
             id: 'history-search-prev-button',

--- a/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
@@ -71,11 +71,13 @@ export class SearchBar extends LitElement {
         <wa-input
           class="search-input"
           type="search"
-          placeholder="Search history items..."
+          placeholder="Search history…"
           .value=${this.searchTerm}
           @input=${this.handleInput}
           @keydown=${this.handleKeydown}
-        ></wa-input>
+        >
+          <span slot="label" class="visually-hidden">Search history</span>
+        </wa-input>
         <div class="search-controls action-button-group">
           ${renderIconActionButton({
             id: 'history-search-prev-button',

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -198,6 +198,7 @@ export class MemoryItem extends LitElement {
    */
   private renderActionGroup(): TemplateResult {
     const pinned = this.item?.pinned === true;
+    const memoryName = this.item?.storagePath?.split('/').pop() ?? '';
     const actions = [
       {
         id: 'memory-pin-button',
@@ -222,7 +223,12 @@ export class MemoryItem extends LitElement {
       },
     ].map((action) => ({
       id: action.id,
-      ...renderIconActionButtonParts(action),
+      // Name each control by the memory it acts on: three identical "Delete"s
+      // down a list tell a screen-reader user nothing about which one they hit.
+      ...renderIconActionButtonParts({
+        ...action,
+        label: memoryName ? `${action.label}: ${memoryName}` : action.label,
+      }),
     }));
     return html`
       <wa-button-group label="Memory actions">

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -198,7 +198,7 @@ export class MemoryItem extends LitElement {
    */
   private renderActionGroup(): TemplateResult {
     const pinned = this.item?.pinned === true;
-    const memoryName = this.item?.storagePath?.split('/').pop() ?? '';
+    const memoryName = this.item?.displayPath?.split('/').pop() ?? '';
     const actions = [
       {
         id: 'memory-pin-button',

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.styles.ts
@@ -66,7 +66,6 @@ export const agentSelectionPanelStyles: CSSResult = css`
     font-size: var(--font-size-sm);
     color: var(--wa-color-text-normal);
     border-left: var(--border-medium) solid transparent;
-    outline: none;
   }
 
   /*
@@ -92,11 +91,6 @@ export const agentSelectionPanelStyles: CSSResult = css`
 
   .agent-list-item:hover {
     background: var(--wa-color-neutral-fill-quiet);
-  }
-
-  .agent-list-item:focus-visible {
-    outline: var(--border-thin) solid var(--wa-color-focus);
-    outline-offset: -1px;
   }
 
   .agent-list-item.selected {

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -242,7 +242,11 @@ export class AgentSelectionPanel extends LitElement {
 
     return html`
       <div
-        class=${classMap({ 'agent-list-item': true, selected: isSelected })}
+        class=${classMap({
+          'agent-list-item': true,
+          'focus-ring-inset': true,
+          selected: isSelected,
+        })}
         data-source=${tone}
         role="option"
         aria-selected=${isSelected}

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -62,7 +62,7 @@ export class ProviderKeyList extends LitElement {
         ? renderIconActionButton({
             id: `provider-key-remove-${provider}`,
             icon: 'trash',
-            label: 'Remove',
+            label: `Remove ${provider} key`,
             tooltip: 'Remove key',
             onClick: () =>
               postMessage(SETTINGS_VIEW_COMMANDS.REMOVE_PROVIDER_KEY, {
@@ -76,7 +76,7 @@ export class ProviderKeyList extends LitElement {
         ${renderIconActionButton({
           id: `provider-key-set-${provider}`,
           icon: 'key',
-          label: 'Set',
+          label: `Set ${provider} API key`,
           tooltip: 'Set API key',
           // Bubbles to SettingsApp, which owns the desktop-vs-VS Code
           // provider-key entry flow (modal on desktop, host prompt otherwise).
@@ -86,7 +86,7 @@ export class ProviderKeyList extends LitElement {
         ${renderIconActionButton({
           id: `provider-key-get-${provider}`,
           icon: 'arrow-up-right-from-square',
-          label: 'Get',
+          label: `Get ${provider} API key`,
           tooltip: 'Get API key from provider',
           onClick: () =>
             postMessage(SETTINGS_VIEW_COMMANDS.OPEN_PROVIDER_KEY_URL, {
@@ -119,8 +119,9 @@ export class ProviderKeyList extends LitElement {
     const endpointInput = entry.supportsCustomEndpoint
       ? html`
           <div class="provider-setting">
-            <label>Custom endpoint</label>
+            <label for=${`endpoint-${entry.provider}`}>Custom endpoint</label>
             <wa-input
+              id=${`endpoint-${entry.provider}`}
               class="endpoint-input"
               .value=${entry.customEndpoint}
               placeholder="Leave blank for default"

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -420,16 +420,18 @@ export class GitTab extends LitElement {
               ? html`
                   <div class="identity-fields">
                     <div class="input-row">
-                      <label>Name</label>
+                      <label for="git-author-name">Name</label>
                       <wa-input
+                        id="git-author-name"
                         .value=${this.authorName}
                         placeholder=${DEFAULT_GIT_AUTHOR_NAME}
                         @change=${this.handleAuthorNameChange}
                       ></wa-input>
                     </div>
                     <div class="input-row">
-                      <label>Email</label>
+                      <label for="git-author-email">Email</label>
                       <wa-input
+                        id="git-author-email"
                         .value=${this.authorEmail}
                         placeholder=${DEFAULT_GIT_AUTHOR_EMAIL}
                         @change=${this.handleAuthorEmailChange}

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -68,11 +68,6 @@ export class MultiAgentTab extends LitElement {
         border-color: var(--wa-color-focus);
       }
 
-      .preset-card:focus-visible {
-        outline: var(--border-thin) solid var(--wa-color-focus);
-        outline-offset: var(--border-thin);
-      }
-
       .preset-card.active {
         background-color: var(--wa-color-brand-fill-quiet);
         color: var(
@@ -166,9 +161,11 @@ export class MultiAgentTab extends LitElement {
         color: var(--wa-color-danger-on-quiet);
       }
 
+      /* Part-piercing: a shadow-scoped :focus-visible cannot reach wa-button's
+         inner control, so this rule is the only ring it gets. */
       .preset-delete-btn:focus-visible::part(base) {
-        outline: var(--border-thin) solid var(--wa-color-focus);
-        outline-offset: var(--border-thin);
+        outline: var(--focus-ring-width) solid var(--wa-color-focus);
+        outline-offset: var(--focus-ring-offset);
         border-radius: var(--border-radius-small);
       }
 

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.styles.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.styles.ts
@@ -478,18 +478,6 @@ export const instructionPanelStyles: CSSResult = css`
     max-width: none;
   }
 
-  .visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-
   @media (max-width: 420px) {
     .model-selection-footer .launch-target-group {
       flex-basis: 100%;

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -679,7 +679,10 @@ export class InstructionPanel extends LitElement {
             ${renderIconActionButton({
               id: 'recordInstructionButton',
               icon: session.isRecording ? 'circle-stop' : 'microphone',
-              label: 'Record instruction',
+              label: session.isRecording
+                ? 'Stop recording'
+                : 'Record instruction',
+              pressed: session.isRecording,
               tooltip: session.isRecording
                 ? 'Stop recording'
                 : 'Record instruction with microphone',
@@ -691,6 +694,7 @@ export class InstructionPanel extends LitElement {
         ${this.renderSessionHint(session)}
         <wa-textarea
           id="instruction"
+          aria-label="Instruction"
           rows=${this.desktopHost ? '4' : '10'}
           resize="none"
           enterkeyhint=${this.desktopHost ? 'send' : nothing}

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -692,9 +692,13 @@ export class InstructionPanel extends LitElement {
           </div>
         </div>
         ${this.renderSessionHint(session)}
+        <!-- A light-DOM <label for>, not a host aria-label and not WebAwesome's
+             label slot: wa-textarea is form-associated, so this names the inner
+             control for real while adding no shadow-DOM label chrome that could
+             shift the composer's layout. -->
+        <label class="visually-hidden" for="instruction">Instruction</label>
         <wa-textarea
           id="instruction"
-          aria-label="Instruction"
           rows=${this.desktopHost ? '4' : '10'}
           resize="none"
           enterkeyhint=${this.desktopHost ? 'send' : nothing}

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -102,10 +102,6 @@ export const commonViewStyles: CSSResult = css`
     );
   }
 
-  .list-item:focus-within {
-    outline: var(--border-thin) solid var(--wa-color-focus);
-  }
-
   .settings-disclosure-list {
     display: grid;
     gap: var(--wa-space-2xs);
@@ -287,6 +283,21 @@ export const commonViewStyles: CSSResult = css`
   ${busyIconButtonStyles}
   ${formControlStyles}
   ${focusRingStyles}
+
+  /* Available to the accessibility tree, absent from the layout. The canonical
+     copy: InstructionPanel carried its own and WorktreeChip a differently-named
+     .sr-only, which is how two names for one utility start. */
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
   ${settingsRowStyles}
 
   /* Stricter compactness for wa-checkbox / wa-radio — smaller label,

--- a/src/shared/wa/settingsSection.ts
+++ b/src/shared/wa/settingsSection.ts
@@ -60,23 +60,46 @@ export interface SettingsToggleRowOptions {
   readonly onChange: (event: Event) => void;
 }
 
+/** Stable per-row id derived from the label, so the `for`/`id` pair does not
+ *  churn across re-renders the way a counter would. Labels are unique within a
+ *  settings page. */
+function toggleRowId(label: string): string {
+  return `settings-toggle-${label
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-|-$/g, '')}`;
+}
+
 /**
  * The one switch row shared by every Settings page: label/help on the left,
  * the switch in the control slot. A switch is its own state indicator — do
  * not add status icons beside it.
+ *
+ * The visible label is a real `<label for>`, not a `<span>` plus an
+ * `aria-label` on the host. WebAwesome renders
+ * `<label part="base"><input role="switch"> … </label>` inside its shadow root,
+ * so a host `aria-label` names the custom element rather than the control that
+ * carries the role — all 21 rows built by this helper were reaching the
+ * accessibility tree unnamed. `wa-switch` is a form-associated custom element
+ * (`WebAwesomeFormAssociatedElement.formAssociated = true`), which makes it
+ * labelable, so a light-DOM `for` associates properly.
+ *
+ * It also means the label text is now part of the switch's hit target, which
+ * is what removes the dead zone between a toggle and the words describing it.
  */
 export function renderSettingsToggleRow(
   options: SettingsToggleRowOptions,
 ): TemplateResult {
+  const id = toggleRowId(options.label);
   return html`
     <div class="settings-row">
       <div class="settings-row-text">
-        <span class="settings-row-label">${options.label}</span>
+        <label class="settings-row-label" for=${id}>${options.label}</label>
         <span class="settings-row-help">${options.description}</span>
       </div>
       <div class="settings-row-control">
         <wa-switch
-          aria-label=${options.label}
+          id=${id}
           ?checked=${options.checked}
           ?disabled=${options.disabled ?? false}
           @change=${options.onChange}

--- a/src/test-kernel/settings/MemoryItemActionGroup.vitest.mts
+++ b/src/test-kernel/settings/MemoryItemActionGroup.vitest.mts
@@ -57,7 +57,7 @@ describe('memory-item action group', () => {
     );
     expect(deleteButton).toBeTruthy();
     expect(deleteButton?.tagName).toBe('WA-BUTTON');
-    expect(deleteButton?.getAttribute('aria-label')).toBe('Delete');
+    expect(deleteButton?.getAttribute('aria-label')).toBe('Delete: notes.md');
 
     const deleteTooltip = element.shadowRoot?.querySelector(
       'wa-tooltip[for="memory-delete-button"]',
@@ -70,7 +70,7 @@ describe('memory-item action group', () => {
 
     const pinButton =
       element.shadowRoot?.querySelector<HTMLElement>('#memory-pin-button');
-    expect(pinButton?.getAttribute('aria-label')).toBe('Unpin');
+    expect(pinButton?.getAttribute('aria-label')).toBe('Unpin: notes.md');
     const pinTooltip = element.shadowRoot?.querySelector(
       'wa-tooltip[for="memory-pin-button"]',
     );

--- a/src/test-kernel/settings/ToolsTab.vitest.ts
+++ b/src/test-kernel/settings/ToolsTab.vitest.ts
@@ -76,9 +76,16 @@ describe('tools-tab availability summary', () => {
     const element = await mount([]);
     const skillSwitch = element.shadowRoot?.querySelector<
       HTMLElement & { checked?: boolean }
-    >('wa-switch[aria-label="Make skills available to tool-use agents"]');
+    >('wa-switch#settings-toggle-make-skills-available-to-tool-use-agents');
 
     expect(skillSwitch).not.toBeNull();
+    // The <label for> is what names the control; a host aria-label never
+    // reached the role-bearing input inside wa-switch's shadow root.
+    expect(
+      element.shadowRoot?.querySelector(
+        'label[for="settings-toggle-make-skills-available-to-tool-use-agents"]',
+      )?.textContent,
+    ).toBe('Make skills available to tool-use agents');
     expect(skillSwitch?.checked).toBe(true);
 
     if (!skillSwitch) return;
@@ -99,9 +106,16 @@ describe('tools-tab availability summary', () => {
     });
     const protectionSwitch = element.shadowRoot?.querySelector<
       HTMLElement & { checked?: boolean }
-    >('wa-switch[aria-label="Restrict tool paths to the working directory"]');
+    >('wa-switch#settings-toggle-restrict-tool-paths-to-the-working-directory');
 
-    expect(protectionSwitch).toBeDefined();
+    expect(protectionSwitch).not.toBeNull();
+    // The <label for> is what names the control; a host aria-label never
+    // reached the role-bearing input inside wa-switch's shadow root.
+    expect(
+      element.shadowRoot?.querySelector(
+        'label[for="settings-toggle-restrict-tool-paths-to-the-working-directory"]',
+      )?.textContent,
+    ).toBe('Restrict tool paths to the working directory');
     expect(protectionSwitch?.checked).toBe(false);
 
     if (!protectionSwitch) return;


### PR DESCRIPTION
Final PR of the cross-surface interface review. Stacked on #9715 → #9714 → #9711; retarget as they merge.

## Names that never reached the control

WebAwesome puts the role-bearing element **inside its shadow root**:

```
wa-switch → <label part="base"><input role="switch"> … </label>
wa-input  → <label for="input">…</label>  +  <input id="input">
```

So an `aria-label` on the host names the *custom element*, not the control that carries the role — and a sibling `<label>` with no `for` names nothing at all.

The fix hinges on a fact worth checking rather than assuming: **`WebAwesomeFormAssociatedElement.formAssociated = true`**, so these elements are labelable and a plain light-DOM `for`/`id` pair associates properly — with zero layout change.

- **`renderSettingsToggleRow`** builds **21 toggle rows across 8 settings files**. Its `<span class="settings-row-label">` is now a real `<label for>`. Those switches were reaching the accessibility tree **unnamed**. The label text also becomes part of the switch's hit target, which removes the dead zone between a toggle and the words describing it.
- Git author name/email and the provider custom-endpoint field get `for`/`id` pairs against their existing visible labels.
- The history search field and the desktop credential prompt were named only by a placeholder or a sibling subtitle. Both now use WebAwesome's own `label` API. In the desktop prompt the text **moves** into the label rather than being duplicated, so it isn't announced twice.
- The launcher composer, named only by a rotating placeholder, gets a stable name.

## State that existed only visually

The record toggle flipped its icon, tooltip and colour but not its name or pressed state — nothing about the change reached a screen reader. It now reports `aria-pressed` and renames to "Stop recording".

## One static name per list

"Delete" repeated down a list says nothing about which row it destroys. History, memory and provider-key actions now carry their row's subject, appended at the map site so the shared descriptor tables stay untouched.

## Focus rings, continuing #9711

`commonViewStyles` composes `focusRingStyles` — and then overrode it on `.list-item`, using `:focus-within`, which also fires on a **mouse click**. `AgentSelectionPanel` killed the ring outright with `outline: none` and substituted a 1px one; it now uses the shared `.focus-ring-inset` class built for exactly that case (a ring inside an `overflow: hidden` scroller). `MultiAgentTab`'s preset card defers to the shared ring; its delete button keeps a part-piercing rule at the shared token width.

**Two sites that looked like the same defect are deliberately untouched** — `mark[data-current]` in `historyStyles` and `wa-button.has-options` in `fileSelectStyles` are *state cues*, not focus indicators. Changing them would have been a false positive.

## Also

One canonical `.visually-hidden` in `commonViewStyles`, replacing a local copy in `InstructionPanel`. A differently-named `.sr-only` remains in `WorktreeChip`; it's in progressView, so it's left for that surface's follow-up rather than widened here.

## Tests

Two files pinned the old behaviour and are updated rather than worked around. `ToolsTab` selected switches by `wa-switch[aria-label="…"]` — the very attribute that never named anything — and now asserts the `<label for>` association that does. `MemoryItemActionGroup` expects the per-row subject.

## Verification

- `npm run typecheck` — clean across all seven projects.
- `npm run lint` — clean. `prettier --check` on every changed file — clean.
- `npm run check:dead-code-ratchet` — 18 vs 18 baselined.
- `npx vitest run` — **820 files / 8,421 tests passing**.
- WebAwesome internals read from `dist/chunks/` to confirm where the role and the `for` actually live, and that `formAssociated` is set.

**Not verified:** nothing rendered. The settings toggle rows and the desktop credential prompt are the two places where the DOM changed shape, so they're worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ddRTq1PLM3eZR8yf8xjaV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only accessibility and focus-style changes with no auth, data, or backend logic; tests lock in the new labeling behavior.
> 
> **Overview**
> Improves **accessibility naming and keyboard focus** across settings, history, memory, provider keys, Git, the launcher composer, and the desktop credential prompt.
> 
> **Controls that were unnamed or misnamed** now use real `label`/`for` (or WebAwesome `label`) so screen readers hit the actual input inside shadow DOM—not a host `aria-label`. Shared **`renderSettingsToggleRow`** switches from span + `aria-label` to `<label for>` + stable ids for all settings toggles. History search, Git author fields, provider custom endpoint, instruction textarea, and the desktop prompt get proper labels; the prompt moves prompt text into `wa-input.label` and hides the empty subtitle to avoid double announcement.
> 
> **List actions** append row context to `aria-label` (history item title, memory filename, provider name) so repeated “Delete”/“Set” buttons are distinguishable. The **record** button toggles label (“Record” / “Stop recording”) and **`aria-pressed`** while recording.
> 
> **Focus styling** drops ad-hoc outlines and a `.list-item:focus-within` ring that fired on click; agent list rows use shared **`.focus-ring-inset`**, and multi-agent preset delete uses shared focus tokens. **`.visually-hidden`** is centralized in `commonViewStyles` (removed duplicate from InstructionPanel).
> 
> Tests updated to assert label association and per-row action labels instead of `wa-switch[aria-label]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ae2cb531cee5962d43eb5883c080261ffde75ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->