### PR TITLE
fix(cli): a denied approval gate is not a failed run

### DIFF
--- a/docs/prds/2026-08-03-prd-approval-policy-unification.md
+++ b/docs/prds/2026-08-03-prd-approval-policy-unification.md
@@ -257,8 +257,12 @@ The CLI then consumes shared decisions directly:
   before consulting `canPresent`, so their policy dependence was dead
   weight).
 - The `WeakSet` denial marker is replaced by an explicit boolean on the
-  context object; exit code 4 (`CliExitCode.ApprovalDenied`) behavior is
-  unchanged and covered by tests on both the headless and TUI paths.
+  context object; exit code 4 (`CliExitCode.ApprovalDenied`) is reserved for a
+  run that FAILED with a denied gate, and is covered by tests on both the
+  headless and TUI paths. A denial the model routed around leaves the run
+  COMPLETED and exits 0 — #9692 briefly hoisted the denial check above the
+  outcome, which made every `--approval-policy never` run exit 4 and silently
+  discarded results in callers that read a nonzero exit as "no result".
 - `CliContext.approvalPolicy` reverts to a plain pre-session seed. The TUI
   live-alias getter (`runChatTui.tsx:342-344`, inside the per-run
   `currentSessionContext` literal at `:339-347`) is deleted; the genuinely

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -41,7 +41,15 @@ export function toolUseResultText(result: CliToolUseRunResult): string {
 
 /** Map a run outcome to the CLI process exit code, treating an
  *  approval-denied error distinctly from a generic agent error. A resumed
- *  subagent that parks back to WAITING is a successfully completed turn. */
+ *  subagent that parks back to WAITING is a successfully completed turn.
+ *
+ *  The denial check is nested inside FAILED on purpose. A denied approval gate
+ *  is not, by itself, a failed run: under `--approval-policy never` the gate
+ *  returns feedback to the model, the model works around it, and the run
+ *  completes normally. Hoisting the check above the outcome made every such run
+ *  exit 4, which silently broke any caller that treats a nonzero exit as "did
+ *  not produce a result" — TeXRA's own PR review workflow among them, where the
+ *  review completed and was then thrown away before it could be posted. */
 export function runOutcomeExitCode(
   outcome: RunOutcome | typeof STREAM_PHASE.WAITING,
   context: CliContext,
@@ -49,9 +57,10 @@ export function runOutcomeExitCode(
   if (outcome === RUN_OUTCOME.CANCELLED) {
     return CliExitCode.Interrupted;
   }
-  if (hasCliApprovalDenied(context)) return CliExitCode.ApprovalDenied;
   if (outcome === RUN_OUTCOME.FAILED) {
-    return CliExitCode.AgentError;
+    return hasCliApprovalDenied(context)
+      ? CliExitCode.ApprovalDenied
+      : CliExitCode.AgentError;
   }
   return CliExitCode.Success;
 }

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -198,8 +198,9 @@ describe('human input approval policy', () => {
     );
     expect(result).toMatchObject({ accepted: false });
     expect(hasCliApprovalDenied(ctx)).toBe(true);
+    // A denied gate the model worked around still completed the run.
     expect(runOutcomeExitCode(RUN_OUTCOME.COMPLETED, ctx)).toBe(
-      CliExitCode.ApprovalDenied,
+      CliExitCode.Success,
     );
     expect(runOutcomeExitCode(RUN_OUTCOME.CANCELLED, ctx)).toBe(
       CliExitCode.Interrupted,

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -663,7 +663,7 @@ describe('executeCliRequest', () => {
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
-  it('maps a completed run to ApprovalDenied after a shared policy denial', async () => {
+  it('maps a completed run to Success even after a shared policy denial', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const { runOutcomeExitCode } = await import('@cli/runtime/terminalStatus');
     const request = baseRequest();
@@ -678,7 +678,11 @@ describe('executeCliRequest', () => {
 
     await executeCliRequest(request, context);
 
-    expect(runOutcomeExitCode('completed', context)).toBe(
+    // Exit 4 is reserved for a run that FAILED because a gate was denied.
+    // A denial the model routed around does not make the run unsuccessful,
+    // and reporting it as one makes every caller discard a good result.
+    expect(runOutcomeExitCode('completed', context)).toBe(CliExitCode.Success);
+    expect(runOutcomeExitCode('failed', context)).toBe(
       CliExitCode.ApprovalDenied,
     );
   });


### PR DESCRIPTION
Fixes the regression that has been **discarding TeXRA's own completed PR reviews** since #9692.

## What was happening

The review job ran the agent to completion —

```
[r1] · review · Reviewing PR 9711 … · tools: 97 · 9m 39s
[r1] · review · completed · tools: 97 · 9m 39s
##[error]Process completed with exit code 4.
```

— then exited 4, which skipped the composite action's `Normalize review` and `Post TeXRA review` steps. The review was computed, then thrown away.

Five runs failed this way on 2026-08-04; four others the same day passed. Nothing about the PR under review predicted which.

## Root cause

Exit 4 is `CliExitCode.ApprovalDenied` (`exitCodes.ts:7`). #9692 hoisted the denial check *above* the outcome check in `runOutcomeExitCode`:

```ts
if (hasCliApprovalDenied(context)) return CliExitCode.ApprovalDenied;   // ← hoisted
if (outcome === RUN_OUTCOME.FAILED) return CliExitCode.AgentError;
```

The denial flag is sticky and set by **any** gate denial anywhere in the run. The review job runs `--approval-policy never`, where a denial is the *designed* behaviour: the gate returns feedback to the model, the model works around it, and the run completes normally. So the only variable was whether the model reached for a gated tool at all — which is why it looked intermittent rather than broken.

It reaches for one because dispatch resolves calls from the full registry rather than the filtered tool list, and `review.yaml` explicitly mentions `bash` / `write_file` / `edit_file`.

## The fix

The denial check moves back inside the `FAILED` branch. Exit 4 keeps its meaning for the case it was written for — a run that *failed* because a gate was denied — and a denial the model routed around exits 0, because the run did in fact succeed.

## Tests and the PRD

Two tests pinned the old behaviour. They're updated rather than deleted:

- `ApprovalAdapter.vitest.mts` — the `COMPLETED` case now expects `Success`.
- `RunExecution.vitest.mts` — asserts *both* halves now, so the distinction can't silently invert again: `COMPLETED` → `Success`, `FAILED` → `ApprovalDenied`.

`docs/prds/2026-08-03-prd-approval-policy-unification.md` asserted exit-4 behaviour was "unchanged". It now states the actual rule and records this regression, so the semantics have an owner.

## Not covered here

- **The denial is invisible.** It writes nothing to stderr, so the nonzero exit arrived with no stated cause — which is most of why this took a while to pin down. A one-line warn on policy denial would have made it obvious.
- **`texra-action` passes the exit code straight through** with no allowlist (`process.exit(result.status ?? 0)`), so any future benign nonzero will drop a review the same way. That's a different repo.

Note this fix only reaches CI once it ships in a release — the action installs `@texra-ai/cli` at `latest`, currently 0.40.1. Setting the repo variable `TEXRA_CLI_VERSION` to a pre-0.40.0 build unblocks reviews in the meantime; the workflow already reads it (`texra-code-review.yml:120`).

## Verification

- `npx vitest run` — **8,440 tests passing**, 5 skipped.
- `npm run typecheck` / `npm run lint` / `prettier --check` — clean.
- Root cause traced end to end: `exitCodes.ts:7` → `terminalStatus.ts:52` → `git show 17beddc078` (the hoist) → `approvalPolicy.ts:68` (sticky marker) → the bash/edit approval call sites, and confirmed against 100 runs of the workflow via `gh run list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ddRTq1PLM3eZR8yf8xjaV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9d7d83ce98dfaeca216562d357ded50cfe40fd4d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->