### PR TITLE
fix(cli): warn once when an approval gate is denied

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -373,7 +373,8 @@ export function createChatSessionController(
             registerExecution: true,
             enforceCategory: true,
             approvalPromptsUnavailable: approvalsUnavailable,
-            onApprovalPolicyDenial: () => markApprovalDenied(sessionContext),
+            onApprovalPolicyDenial: () =>
+              markApprovalDenied(sessionContext, 'Tool or edit approval'),
             runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
             onStreamResolved: (resolvedStreamId) => {
               // Each chat round mints a fresh root StreamTabId (new
@@ -535,7 +536,8 @@ export function createChatSessionController(
         .then(() =>
           resumeToolUseFromResumeData(resolution, {
             approvalPromptsUnavailable: approvalsUnavailable,
-            onApprovalPolicyDenial: () => markApprovalDenied(sessionContext),
+            onApprovalPolicyDenial: () =>
+              markApprovalDenied(sessionContext, 'Tool or edit approval'),
             runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
             drainedFollowUps: supersededRecovery?.followUps.map((followUp) => ({
               ...followUp,
@@ -664,7 +666,7 @@ export function createChatSessionController(
                   recovery: claimedRecovery,
                   approvalPromptsUnavailable: approvalsUnavailable,
                   onApprovalPolicyDenial: () =>
-                    markApprovalDenied(sessionContext),
+                    markApprovalDenied(sessionContext, 'Tool or edit approval'),
                   runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
                   extraFollowUps: options.extraFollowUps,
                   onFollowUpQueueReady: (lease) => {

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -421,7 +421,8 @@ async function requestRetryInteraction(
       }
       // A cleared or replaced entry was never denied by a user, so it must not
       // mark the run as approval-denied.
-      if (!reservation.signal.aborted) markApprovalDenied(context);
+      if (!reservation.signal.aborted)
+        markApprovalDenied(context, 'Interactive approval');
       return { action: 'cancel' };
     }
     if (
@@ -497,7 +498,7 @@ function announceApproval(payload: ApprovalPayload): void {
 }
 
 function markIfRejected(context: CliContext, decision: ApprovalDecision): void {
-  if (!decision.accepted) markApprovalDenied(context);
+  if (!decision.accepted) markApprovalDenied(context, 'Interactive approval');
 }
 
 function setTuiApprovalBypassState({

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -2,6 +2,7 @@ import PQueue from 'p-queue';
 
 import type { UserQuestionSettlement } from '@agent/runtime/HostInteractions';
 import { isRelayMonthlyLimitMessage } from '@common/errors/sdkErrorUtils';
+import { warn } from '@logger/logUtils';
 import { decideTexraApproval } from '@shared/approvalPolicy';
 import {
   isChatGptSubscriptionLimitError,
@@ -65,8 +66,16 @@ function denyMessage(policy: CliContext['approvalPolicy']): string {
     : 'Denied by CLI approval policy.';
 }
 
-export function markApprovalDenied(context: CliContext): void {
+export function markApprovalDenied(context: CliContext, gate?: string): void {
+  if (deniedApprovalContexts.has(context)) {
+    return;
+  }
   deniedApprovalContexts.add(context);
+  // One warn on first denial so exit code 4 has a visible cause on stderr.
+  warn(
+    'cli-approval',
+    `${gate?.trim() || 'Approval gate'} denied under policy "${context.approvalPolicy}".`,
+  );
 }
 
 export function hasCliApprovalDenied(context: CliContext): boolean {
@@ -202,7 +211,7 @@ export function immediateDecision(
   const decision = cliExecutableApprovalDecision(context);
   if (decision === 'allow') return { accepted: true };
   if (decision === 'present') return undefined;
-  markApprovalDenied(context);
+  markApprovalDenied(context, 'Approval policy');
   return { accepted: false, userMessage: denyMessage(context.approvalPolicy) };
 }
 
@@ -228,7 +237,7 @@ export function immediateDecisionForApproval(
 ): ApprovalDecision | undefined {
   if (isCredentialRetryRequest(event, payload)) {
     if (approvalPromptAllowed(context)) return undefined;
-    markApprovalDenied(context);
+    markApprovalDenied(context, 'Credential-exhausted retry');
     return {
       accepted: false,
       userMessage: 'Retry skipped: credential exhausted or unauthorized.',
@@ -258,7 +267,7 @@ export async function askApproval(
       prompt: 'Approve? [y/N, or n <feedback>] ',
     });
   } catch {
-    markApprovalDenied(context);
+    markApprovalDenied(context, 'Approval prompt');
     return { accepted: false, userMessage: 'CLI approval prompt failed.' };
   }
 
@@ -278,7 +287,7 @@ export async function askApproval(
     }
   }
 
-  if (!parsed.accepted) markApprovalDenied(context);
+  if (!parsed.accepted) markApprovalDenied(context, 'Interactive approval');
   return {
     accepted: parsed.accepted,
     userMessage: parsed.accepted
@@ -292,7 +301,7 @@ export function humanInputDenialFeedback(
   yoloMessage: string,
 ): string {
   if (context.approvalPolicy === 'yolo') return yoloMessage;
-  markApprovalDenied(context);
+  markApprovalDenied(context, 'Human-input request');
   return denyMessage(context.approvalPolicy);
 }
 

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -2,7 +2,6 @@ import PQueue from 'p-queue';
 
 import type { UserQuestionSettlement } from '@agent/runtime/HostInteractions';
 import { isRelayMonthlyLimitMessage } from '@common/errors/sdkErrorUtils';
-import { warn } from '@logger/logUtils';
 import { decideTexraApproval } from '@shared/approvalPolicy';
 import {
   isChatGptSubscriptionLimitError,
@@ -15,7 +14,7 @@ import {
 } from '@shared/schemas';
 
 import { type CliContext, type CliPromptRequest } from '../cliContext';
-import { askCliQuestion } from '../logSinks';
+import { askCliQuestion, writeTextStderr } from '../logSinks';
 
 /**
  * Approval requests the CLI can settle by policy (auto-approve / auto-deny)
@@ -71,10 +70,10 @@ export function markApprovalDenied(context: CliContext, gate?: string): void {
     return;
   }
   deniedApprovalContexts.add(context);
-  // One warn on first denial so exit code 4 has a visible cause on stderr.
-  warn(
-    'cli-approval',
-    `${gate?.trim() || 'Approval gate'} denied under policy "${context.approvalPolicy}".`,
+  // Operator-facing CLI warnings go to stderr (not @logger/logUtils, which can
+  // fall through to stdout/console before the CLI log backend is wired).
+  writeTextStderr(
+    `[warn] [cli-approval] ${gate?.trim() || 'Approval gate'} denied under policy "${context.approvalPolicy}".`,
   );
 }
 

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -159,7 +159,7 @@ async function askHeadlessUserQuestion(
       if (parsed != null) answers[question.question] = parsed;
     }
   } catch {
-    markApprovalDenied(context);
+    markApprovalDenied(context, 'User-question prompt');
     return {
       action: 'reject',
       feedback: 'CLI user question prompt failed.',

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -294,7 +294,8 @@ export async function executeCliRequest(
         },
         stopAfterCycle: options.stopAfterCycle,
         approvalPromptsUnavailable: approvalPromptsUnavailable(runContext),
-        onApprovalPolicyDenial: () => markApprovalDenied(runContext),
+        onApprovalPolicyDenial: () =>
+          markApprovalDenied(runContext, 'Tool or edit approval'),
         runtimeUnavailableTools: [
           ...CLI_UNAVAILABLE_TOOLS,
           ...(options.runtimeUnavailableTools ?? []),

--- a/src/test-kernel/cli/ApprovalDeniedWarn.vitest.mts
+++ b/src/test-kernel/cli/ApprovalDeniedWarn.vitest.mts
@@ -3,13 +3,13 @@ import '@test/support/defaultSessionTestSetup';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const warnMock = vi.hoisted(() => vi.fn());
+const writeTextStderrMock = vi.hoisted(() => vi.fn());
 
-vi.mock('@logger/logUtils', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@logger/logUtils')>();
+vi.mock('@cli/runtime/logSinks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@cli/runtime/logSinks')>();
   return {
     ...actual,
-    warn: warnMock,
+    writeTextStderr: writeTextStderrMock,
   };
 });
 
@@ -21,7 +21,7 @@ import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 
 describe('markApprovalDenied', () => {
   beforeEach(() => {
-    warnMock.mockClear();
+    writeTextStderrMock.mockClear();
   });
 
   it('warns once with the gate and policy on first denial', () => {
@@ -31,10 +31,9 @@ describe('markApprovalDenied', () => {
     markApprovalDenied(context, 'Tool or edit approval');
 
     expect(hasCliApprovalDenied(context)).toBe(true);
-    expect(warnMock).toHaveBeenCalledTimes(1);
-    expect(warnMock).toHaveBeenCalledWith(
-      'cli-approval',
-      'Tool or edit approval denied under policy "never".',
+    expect(writeTextStderrMock).toHaveBeenCalledTimes(1);
+    expect(writeTextStderrMock).toHaveBeenCalledWith(
+      '[warn] [cli-approval] Tool or edit approval denied under policy "never".',
     );
   });
 
@@ -43,9 +42,8 @@ describe('markApprovalDenied', () => {
 
     markApprovalDenied(context);
 
-    expect(warnMock).toHaveBeenCalledWith(
-      'cli-approval',
-      'Approval gate denied under policy "ask".',
+    expect(writeTextStderrMock).toHaveBeenCalledWith(
+      '[warn] [cli-approval] Approval gate denied under policy "ask".',
     );
   });
 });

--- a/src/test-kernel/cli/ApprovalDeniedWarn.vitest.mts
+++ b/src/test-kernel/cli/ApprovalDeniedWarn.vitest.mts
@@ -1,0 +1,51 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const warnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@logger/logUtils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@logger/logUtils')>();
+  return {
+    ...actual,
+    warn: warnMock,
+  };
+});
+
+import {
+  hasCliApprovalDenied,
+  markApprovalDenied,
+} from '@cli/runtime/approval/approvalPolicy';
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
+
+describe('markApprovalDenied', () => {
+  beforeEach(() => {
+    warnMock.mockClear();
+  });
+
+  it('warns once with the gate and policy on first denial', () => {
+    const context = createTestCliContext({ approvalPolicy: 'never' });
+
+    markApprovalDenied(context, 'Tool or edit approval');
+    markApprovalDenied(context, 'Tool or edit approval');
+
+    expect(hasCliApprovalDenied(context)).toBe(true);
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock).toHaveBeenCalledWith(
+      'cli-approval',
+      'Tool or edit approval denied under policy "never".',
+    );
+  });
+
+  it('falls back to a generic gate label when none is given', () => {
+    const context = createTestCliContext({ approvalPolicy: 'ask' });
+
+    markApprovalDenied(context);
+
+    expect(warnMock).toHaveBeenCalledWith(
+      'cli-approval',
+      'Approval gate denied under policy "ask".',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #9721 (follow-up from #9720): first `markApprovalDenied` now emits a `warn` on the `cli-approval` channel naming the gate and policy.
- Repeat marks on the same context stay silent.
- Focused unit coverage in `ApprovalDeniedWarn.vitest.mts`.

## Test plan
- [x] `vitest` `ApprovalDeniedWarn.vitest.mts`
- [ ] Manual: `texra run … --approval-policy never` against a tool that needs approval and fails the run → stderr shows `[warn] [cli-approval] … denied under policy "never".`


Made with [Cursor](https://cursor.com)