### PR TITLE
docs: refresh public site pages against current codebase

### DIFF
--- a/docs/.vitepress/components/CliAgentShowHero.vue
+++ b/docs/.vitepress/components/CliAgentShowHero.vue
@@ -49,7 +49,7 @@ const details = [
         section."</span
       >
     </div>
-    <div class="cas-out">.texra/runs/e2c70a94b18f/r0/notes.tex</div>
+    <div class="cas-out">executions/e2c70a94b18f/r0/notes.tex</div>
   </TermWindow>
 </template>
 

--- a/docs/.vitepress/components/CliModelsHero.vue
+++ b/docs/.vitepress/components/CliModelsHero.vue
@@ -16,8 +16,8 @@ const rows = [
   { id: 'fable5', label: 'Claude Fable 5', status: 'included access' },
   { id: 'opus5T', label: 'Opus 5 (Thinking)', status: 'included access' },
   {
-    id: 'sonnet46T',
-    label: 'Sonnet 4.6 (Thinking)',
+    id: 'sonnet5T',
+    label: 'Sonnet 5 (Thinking)',
     status: 'included access',
   },
   {

--- a/docs/.vitepress/components/CliStorageHero.vue
+++ b/docs/.vitepress/components/CliStorageHero.vue
@@ -6,8 +6,9 @@
 // `--output` copies the final artifact out — the CLI's "Accept", (3)
 // `texra history show <id>` lists the run's stored artifacts with the real
 // `Files (N):` `<size>\t<path>` format (packages/cli/src/runtime/history.ts
-// formatCliHistoryDetailsText). The CLI's run store lives under
-// `.texra/runs/<run-id>/` (see First run); ids are 12-char hex.
+// formatCliHistoryDetailsText). The CLI shares the host-neutral run store at
+// `executions/<executionId>/` under TeXRA's workspace storage; ids are
+// 12-char hex.
 //
 // Built on <TermWindow>; .mockup-scoped and token-only. Static strings.
 const files = [
@@ -29,7 +30,7 @@ const files = [
         <span class="mk-term-flag">--input</span> paper.tex</span
       >
     </div>
-    <div class="csh-out">.texra/runs/9f3a6c81d24e/r1/paper.tex</div>
+    <div class="csh-out">…/executions/9f3a6c81d24e/r1/paper.tex</div>
     <div class="csh-note">outputs land in the run's storage folder first</div>
 
     <!-- Beat 2: copy out on request (the CLI's "Accept") -->

--- a/docs/.vitepress/components/CliToolsLifecycleHero.vue
+++ b/docs/.vitepress/components/CliToolsLifecycleHero.vue
@@ -1,8 +1,8 @@
 <script setup>
 // Terminal card for guide/agent-integrations.md "Quick Start" — the
-// IntegrationCard flow (Not Found → Install → Sign in → Recheck → Available)
+// IntegrationCard flow (Not Found → Install → Sign in → Re-check → Available)
 // beat for beat, from a terminal. Output lines reproduce the real shapes:
-// `texra tools show codex` prints `key: value` detail lines including the
+// `texra tools status codex` prints `key: value` detail lines including the
 // registered installCommand / authCommand (packages/cli/src/runtime/tools.ts
 // formatCliToolStatus); `tools install --run` prints the install guide then
 // executes the registered command; `tools auth` runs `codex login`. The codex
@@ -19,7 +19,7 @@
     <!-- Beat 1: detect -->
     <div class="mk-term-prompt">
       <span class="mk-term-sigil">$</span>
-      <span class="mk-term-cmd">texra tools show codex</span>
+      <span class="mk-term-cmd">texra tools status codex</span>
     </div>
     <div class="ctf-block">
       <div><span class="ctf-k">name:</span> OpenAI Codex CLI</div>
@@ -55,10 +55,10 @@
       <div>Command: codex login</div>
     </div>
 
-    <!-- Beat 4: recheck -->
+    <!-- Beat 4: re-check -->
     <div class="mk-term-prompt ctf-beat">
       <span class="mk-term-sigil">$</span>
-      <span class="mk-term-cmd">texra tools show codex</span>
+      <span class="mk-term-cmd">texra tools status codex</span>
     </div>
     <div class="ctf-block">
       <div>

--- a/docs/.vitepress/components/DelegatedStreamHero.vue
+++ b/docs/.vitepress/components/DelegatedStreamHero.vue
@@ -1,6 +1,6 @@
 <script setup>
 // The live side-panel a `codex` / `claude_code` hand-off opens on the
-// ProgressBoard: a stream tab labelled `claude@agent-sdk` that streams the
+// ProgressBoard: a stream tab labelled `claude_code` that streams the
 // delegated agent's reasoning, the commands it runs, file changes, web
 // searches, and todos — then shows WAITING when the turn ends, with a Stop
 // control. The final message + token cost hand back to the calling TeXRA agent.
@@ -21,17 +21,14 @@ import StatusPill from './StatusPill.vue';
   >
     <!-- Stream head: tab name · Stop · turn/tool-call badge -->
     <div class="stream-head">
-      <span class="sh-name">claude@agent-sdk</span>
+      <span class="sh-name">claude_code</span>
       <span class="sh-dot" title="Running"></span>
-      <span class="sh-badge"
-        ><wa-icon class="sh-pulse" library="texra" name="pulse"></wa-icon>1 turn
-        · 6 tool calls</span
-      >
+      <span class="sh-badge">1 turn · 6 tool calls</span>
       <span class="sh-tools">
         <wa-icon
           class="shi"
           library="texra"
-          name="debug-stop"
+          name="circle-stop"
           title="Stop"
         ></wa-icon>
       </span>

--- a/docs/.vitepress/components/DiffArtifactsHero.vue
+++ b/docs/.vitepress/components/DiffArtifactsHero.vue
@@ -1,8 +1,8 @@
 <script setup>
 // Frameless artifact-tree card for guide/latex-diff.md "Manage Diff Outputs":
 // the diff file-naming scheme is scattered across the page in prose — latexdiff
-// emits `_diff.tex`, latexdiff-vc emits `_diff_rev<hash>.tex`, and between-round
-// runs emit `_diff_rN-rM.tex`. This grounds the set: the source pair on top,
+// emits `_diff.tex`, latexdiff-vc emits `-diff<hash>.tex`, and between-round
+// runs emit `_diffr<newer>r<older>.tex`. This grounds the set: the source pair on top,
 // then each generated diff with its .tex source + compiled .pdf, tagged by the
 // tool that made it. The header carries the same Pack / Clean toolbar the
 // LaTeXDiffs section exposes (mirrors LatexDiffHero's .act buttons) so it's
@@ -41,24 +41,24 @@ const groups = [
       },
       { name: 'spectral-gap_diff.pdf', icon: 'file-pdf', kind: 'pdf' },
       {
-        name: 'spectral-gap_diff_reva3f9c1.tex',
+        name: 'spectral-gap-diffa3f9c1.tex',
         icon: 'file-code',
         kind: 'tex',
         tag: 'latexdiff-vc',
         commit: 'a3f9c1',
       },
       {
-        name: 'spectral-gap_diff_reva3f9c1.pdf',
+        name: 'spectral-gap-diffa3f9c1.pdf',
         icon: 'file-pdf',
         kind: 'pdf',
       },
       {
-        name: 'spectral-gap_diff_r1-r0.tex',
+        name: 'spectral-gap_diffr1r0.tex',
         icon: 'file-code',
         kind: 'tex',
         tag: 'between-round',
       },
-      { name: 'spectral-gap_diff_r1-r0.pdf', icon: 'file-pdf', kind: 'pdf' },
+      { name: 'spectral-gap_diffr1r0.pdf', icon: 'file-pdf', kind: 'pdf' },
     ],
   },
 ];

--- a/docs/.vitepress/components/FileSelectHero.vue
+++ b/docs/.vitepress/components/FileSelectHero.vue
@@ -110,11 +110,7 @@ import MockupFrame from './MockupFrame.vue';
         <div class="field">
           <div class="frow">
             <span class="f-label"
-              ><wa-icon
-                class="lbl-ic"
-                library="texra"
-                name="video"
-              ></wa-icon>
+              ><wa-icon class="lbl-ic" library="texra" name="video"></wa-icon>
               Media
               <span class="act" title="Auto-extract options"
                 ><wa-icon library="texra" name="wand-magic-sparkles"></wa-icon

--- a/docs/.vitepress/components/FileSelectHero.vue
+++ b/docs/.vitepress/components/FileSelectHero.vue
@@ -35,18 +35,18 @@ import MockupFrame from './MockupFrame.vue';
               ></wa-icon>
               Input
               <span class="act" title="Tool configuration options"
-                ><wa-icon library="texra" name="tools"></wa-icon
+                ><wa-icon library="texra" name="screwdriver-wrench"></wa-icon
               ></span>
             </span>
             <div class="acts">
               <span class="act" title="Add opened files as input"
-                ><wa-icon library="texra" name="folder-opened"></wa-icon
+                ><wa-icon library="texra" name="folder-open"></wa-icon
               ></span>
               <span class="act" title="Clear all input files"
                 ><wa-icon library="texra" name="trash"></wa-icon
               ></span>
               <span class="act" title="Add input files"
-                ><wa-icon library="texra" name="add"></wa-icon
+                ><wa-icon library="texra" name="plus"></wa-icon
               ></span>
             </div>
           </div>
@@ -74,13 +74,13 @@ import MockupFrame from './MockupFrame.vue';
             >
             <div class="acts">
               <span class="act" title="Add opened files as context"
-                ><wa-icon library="texra" name="folder-opened"></wa-icon
+                ><wa-icon library="texra" name="folder-open"></wa-icon
               ></span>
               <span class="act" title="Clear all context files"
                 ><wa-icon library="texra" name="trash"></wa-icon
               ></span>
               <span class="act" title="Add context files"
-                ><wa-icon library="texra" name="add"></wa-icon
+                ><wa-icon library="texra" name="plus"></wa-icon
               ></span>
             </div>
           </div>
@@ -113,22 +113,22 @@ import MockupFrame from './MockupFrame.vue';
               ><wa-icon
                 class="lbl-ic"
                 library="texra"
-                name="device-camera-video"
+                name="video"
               ></wa-icon>
               Media
               <span class="act" title="Auto-extract options"
-                ><wa-icon library="texra" name="wand"></wa-icon
+                ><wa-icon library="texra" name="wand-magic-sparkles"></wa-icon
               ></span>
             </span>
             <div class="acts">
               <span class="act" title="Add opened files as media"
-                ><wa-icon library="texra" name="folder-opened"></wa-icon
+                ><wa-icon library="texra" name="folder-open"></wa-icon
               ></span>
               <span class="act" title="Clear all media files"
                 ><wa-icon library="texra" name="trash"></wa-icon
               ></span>
               <span class="act" title="Add media files"
-                ><wa-icon library="texra" name="add"></wa-icon
+                ><wa-icon library="texra" name="plus"></wa-icon
               ></span>
             </div>
           </div>

--- a/docs/.vitepress/components/GuideIntroHero.vue
+++ b/docs/.vitepress/components/GuideIntroHero.vue
@@ -34,7 +34,11 @@ const view = ref('search');
         <span class="sh-badge">4 turns, 18 tool calls</span>
         <span class="sh-tools">
           <wa-icon class="shi" library="texra" name="circle-stop"></wa-icon>
-          <wa-icon class="shi" library="texra" name="clock-rotate-left"></wa-icon>
+          <wa-icon
+            class="shi"
+            library="texra"
+            name="clock-rotate-left"
+          ></wa-icon>
         </span>
       </div>
 
@@ -130,7 +134,11 @@ const view = ref('search');
                 library="texra"
                 name="chevron-right"
               ></wa-icon>
-              <wa-icon class="tc-ic" library="texra" name="circle-user"></wa-icon>
+              <wa-icon
+                class="tc-ic"
+                library="texra"
+                name="circle-user"
+              ></wa-icon>
               <span class="tc-label"
                 ><span class="tc-tool">delegate_agent</span> — lean</span
               >

--- a/docs/.vitepress/components/GuideIntroHero.vue
+++ b/docs/.vitepress/components/GuideIntroHero.vue
@@ -31,13 +31,10 @@ const view = ref('search');
           ><wa-icon class="goal-ic" library="texra" name="compass"></wa-icon
           >Goal</span
         >
-        <span class="sh-badge"
-          ><wa-icon class="sh-pulse" library="texra" name="pulse"></wa-icon>4
-          turns, 18 tool calls</span
-        >
+        <span class="sh-badge">4 turns, 18 tool calls</span>
         <span class="sh-tools">
-          <wa-icon class="shi" library="texra" name="debug-stop"></wa-icon>
-          <wa-icon class="shi" library="texra" name="history"></wa-icon>
+          <wa-icon class="shi" library="texra" name="circle-stop"></wa-icon>
+          <wa-icon class="shi" library="texra" name="clock-rotate-left"></wa-icon>
         </span>
       </div>
 
@@ -95,7 +92,7 @@ const view = ref('search');
               library="texra"
               name="chevron-right"
             ></wa-icon>
-            <wa-icon class="tc-ic" library="texra" name="account"></wa-icon>
+            <wa-icon class="tc-ic" library="texra" name="circle-user"></wa-icon>
             <span class="tc-label"
               ><span class="tc-tool">delegate_agent</span> — search · arXiv +
               Crossref</span
@@ -113,7 +110,7 @@ const view = ref('search');
               library="texra"
               name="chevron-right"
             ></wa-icon>
-            <wa-icon class="tc-ic" library="texra" name="account"></wa-icon>
+            <wa-icon class="tc-ic" library="texra" name="circle-user"></wa-icon>
             <span class="tc-label"
               ><span class="tc-tool">delegate_agent</span> — research · derive
               in Wolfram</span
@@ -133,7 +130,7 @@ const view = ref('search');
                 library="texra"
                 name="chevron-right"
               ></wa-icon>
-              <wa-icon class="tc-ic" library="texra" name="account"></wa-icon>
+              <wa-icon class="tc-ic" library="texra" name="circle-user"></wa-icon>
               <span class="tc-label"
                 ><span class="tc-tool">delegate_agent</span> — lean</span
               >

--- a/docs/.vitepress/components/InstructionHeaderCard.vue
+++ b/docs/.vitepress/components/InstructionHeaderCard.vue
@@ -83,7 +83,7 @@ const actions = [
             <wa-icon library="texra" name="robot"></wa-icon>
           </span>
           <div class="select">
-            <span class="s-val">sonnet46</span>
+            <span class="s-val">sonnet5</span>
             <wa-icon
               class="s-caret"
               library="texra"

--- a/docs/.vitepress/components/IntegrationCard.vue
+++ b/docs/.vitepress/components/IntegrationCard.vue
@@ -1,9 +1,9 @@
 <script setup>
 // Dashboard → Integrations cards (mirrors the OpenAI Codex CLI / Claude Code
 // CLI setup cards). Two states stacked: a `Not Found` card whose setup actions
-// are expanded (Install in Terminal · Sign in · Recheck), and an `Available`
+// are expanded (Install in Terminal · Sign in), and an `Available`
 // card with its version + settings summary. The contrast visualizes the
-// Recheck flip the Quick Start prose describes.
+// Re-check flip the Quick Start prose describes.
 //
 // Root carries `.mockup` so the shared `--mk-*` tokens resolve and the card
 // flips with the docs light / dark theme. Static strings only.
@@ -31,17 +31,14 @@ import StatusPill from './StatusPill.vue';
           <wa-icon library="texra" name="terminal"></wa-icon>Install in Terminal
         </button>
         <button type="button" class="r-btn">
-          <wa-icon library="texra" name="sign-in"></wa-icon>Sign in
-        </button>
-        <button type="button" class="r-btn r-btn--accent">
-          <wa-icon library="texra" name="refresh"></wa-icon>Recheck
+          <wa-icon library="texra" name="right-to-bracket"></wa-icon>Sign in
         </button>
       </div>
     </article>
 
     <div class="ic-flip" aria-hidden="true">
       <wa-icon library="texra" name="arrow-down"></wa-icon>
-      <span>Recheck</span>
+      <span>Re-check</span>
     </div>
 
     <!-- Available: version + settings summary -->
@@ -168,7 +165,7 @@ import StatusPill from './StatusPill.vue';
   color: var(--mk-accent);
 }
 
-/* The Recheck flip connector between the two states. */
+/* The Re-check flip connector between the two states. */
 .ic-flip {
   display: flex;
   align-items: center;

--- a/docs/.vitepress/components/LandingCliStrip.vue
+++ b/docs/.vitepress/components/LandingCliStrip.vue
@@ -26,7 +26,7 @@ const lines = [
         >{{ l.rest }}</span
       >
     </div>
-    <div class="lcs-out">.texra/runs/9f3a6c81d24e/r1/paper.tex</div>
+    <div class="lcs-out">executions/9f3a6c81d24e/r1/paper.tex</div>
   </TermWindow>
 </template>
 

--- a/docs/.vitepress/components/MergeFlowHero.vue
+++ b/docs/.vitepress/components/MergeFlowHero.vue
@@ -1,8 +1,9 @@
 <script setup>
 // The mental model behind Intelligent Merge: a PARTIAL agent output
-// (r1/output.tex — only the sections the agent touched) plus the FULL Base File
-// feed the `merge` agent, which synthesizes a COMPLETE document (_full.tex) that
-// is the valid latexdiff input against the original basename.tex.
+// (r1/spectral-gap.tex — only the sections the agent touched) plus the FULL
+// Base File feed the `merge` agent, which synthesizes a COMPLETE document
+// (r0/spectral-gap.tex) that is the valid latexdiff input against the original
+// basename.tex.
 //
 // Root carries `.mockup`, so the shared `--mk-*` tokens and the
 // .surface/.cl/.kw mono-code vocabulary in theme/mockup.css resolve here and
@@ -45,7 +46,7 @@ import StatusPill from './StatusPill.vue';
             library="texra"
             name="file-code"
           ></wa-icon>
-          <span class="mf-name">r1/output.tex</span>
+          <span class="mf-name">r1/spectral-gap.tex</span>
           <StatusPill variant="warning" shape="pill"
             >Edited · partial</StatusPill
           >
@@ -86,7 +87,7 @@ import StatusPill from './StatusPill.vue';
     <article class="mf-doc mf-out">
       <header class="mf-doc-head">
         <wa-icon class="mf-fi t-tex" library="texra" name="file-code"></wa-icon>
-        <span class="mf-name">_full.tex</span>
+        <span class="mf-name">r0/spectral-gap.tex</span>
         <StatusPill variant="success" shape="pill">Complete</StatusPill>
       </header>
       <div class="surface mf-code">

--- a/docs/.vitepress/components/MergePanelHero.vue
+++ b/docs/.vitepress/components/MergePanelHero.vue
@@ -1,9 +1,9 @@
 <script setup>
 // Frameless variant of LatexDiffHero's left sidebar — the LaTeXDiffs section on
 // its own, with the editor / PDF pane dropped so the merge controls read
-// clearly. Mirrors the four-step Merge Workflow: pick a Base File, pick an
-// Edited File, choose the Model below, then click Merge in the Edited row (the
-// merge icon is highlighted here as the act-on control).
+// clearly. Mirrors the Merge Workflow: pick a Base File, pick an Edited File,
+// then click Merge in the Edited row (the merge icon is highlighted here as the
+// act-on control). The merge runs on the configured helper model.
 //
 // Root carries `.mockup`, so the shared `--mk-*` tokens and the .field/.frow/
 // .select/.acts/.act vocabulary in theme/mockup.css resolve here and flip with
@@ -42,7 +42,7 @@
         </div>
       </div>
 
-      <!-- Step 2 · Edited File + Step 4 · Merge action (highlighted) -->
+      <!-- Step 2 · Edited File + Step 3 · Merge action (highlighted) -->
       <div class="field">
         <div class="frow">
           <span class="f-label"
@@ -66,26 +66,7 @@
           <span class="step-n">2</span>
         </div>
         <div class="select">
-          <span class="s-val">r1/output.tex</span>
-          <wa-icon
-            class="s-caret"
-            library="texra"
-            name="chevron-down"
-          ></wa-icon>
-        </div>
-      </div>
-
-      <!-- Step 3 · Merge Model (lives below the instruction box) -->
-      <div class="field model-field">
-        <div class="frow">
-          <span class="f-label"
-            ><wa-icon class="lbl-ic" library="texra" name="robot"></wa-icon>
-            Model</span
-          >
-          <span class="step-n">3</span>
-        </div>
-        <div class="select">
-          <span class="s-val">opus5T</span>
+          <span class="s-val">r1/spectral-gap.tex</span>
           <wa-icon
             class="s-caret"
             library="texra"
@@ -119,12 +100,6 @@
   display: inline-flex;
   color: var(--mk-accent);
   font-size: var(--mk-space-13);
-}
-/* The Model selector is conceptually below the instruction box, not in the
-   LaTeXDiffs section — set it off with a faint rule. */
-.model-field {
-  border-top: 1px solid var(--mk-border);
-  padding-top: var(--mk-space-12);
 }
 /* Small numbered step marker pinned to each row's far right. */
 .step-n {

--- a/docs/.vitepress/components/ModelChoiceMatrix.vue
+++ b/docs/.vitepress/components/ModelChoiceMatrix.vue
@@ -18,25 +18,25 @@ const rows = [
     icon: 'chart-line',
     use: 'Complex tasks',
     note: 'Powerful flagship models',
-    models: ['fable5', 'opus5', 'gpt55', 'gemini31p'],
+    models: ['fable5', 'opus5', 'gpt56', 'gemini31p'],
   },
   {
     icon: 'code',
     use: 'Code-heavy / LaTeX editing',
     note: 'Strong editing models',
-    models: ['opus5T', 'sonnet46T', 'qwenplus'],
+    models: ['opus5T', 'sonnet5T', 'qwenplus'],
   },
   {
     icon: 'sparkle',
     use: 'Reasoning-heavy',
     note: 'Thinking models',
-    models: ['fable5', 'opus5T', 'sonnet46T', 'deepseekT', 'kimi26T'],
+    models: ['fable5', 'opus5T', 'sonnet5T', 'deepseekT', 'kimi26T'],
   },
   {
     icon: 'file-lines',
     use: 'Large documents',
     note: 'High-context models',
-    models: ['gemini31p', 'fable5', 'sonnet46', 'opus5'],
+    models: ['gemini31p', 'fable5', 'sonnet5', 'opus5'],
   },
 ];
 </script>

--- a/docs/.vitepress/components/ModelChoiceMatrix.vue
+++ b/docs/.vitepress/components/ModelChoiceMatrix.vue
@@ -30,7 +30,7 @@ const rows = [
     icon: 'sparkle',
     use: 'Reasoning-heavy',
     note: 'Thinking models',
-    models: ['fable5', 'opus5T', 'sonnet5T', 'deepseekT', 'kimi26T'],
+    models: ['fable5', 'opus5T', 'sonnet5T', 'deepseekT', 'kimi3'],
   },
   {
     icon: 'file-lines',

--- a/docs/.vitepress/components/ModelChoiceMatrix.vue
+++ b/docs/.vitepress/components/ModelChoiceMatrix.vue
@@ -12,7 +12,7 @@ const rows = [
     icon: 'bolt',
     use: 'Simple tasks',
     note: 'Fast, cheap models',
-    models: ['qwenturbo', 'deepseek', 'haiku45'],
+    models: ['gpt56--', 'deepseek', 'haiku45'],
   },
   {
     icon: 'chart-line',
@@ -24,7 +24,7 @@ const rows = [
     icon: 'code',
     use: 'Code-heavy / LaTeX editing',
     note: 'Strong editing models',
-    models: ['opus5T', 'sonnet5T', 'qwenplus'],
+    models: ['opus5T', 'sonnet5T', 'gpt56'],
   },
   {
     icon: 'sparkle',

--- a/docs/.vitepress/components/ModelPickerHero.vue
+++ b/docs/.vitepress/components/ModelPickerHero.vue
@@ -10,12 +10,12 @@ const items = [
   { id: 'opus5T', thinking: true },
   { id: 'opus5', thinking: false },
   {
-    id: 'sonnet46T',
+    id: 'sonnet5T',
     thinking: true,
     hovered: true,
     tip: { context: '1M', input: '$3', output: '$15', mode: 'Thinking' },
   },
-  { id: 'sonnet46', thinking: false },
+  { id: 'sonnet5', thinking: false },
   { id: 'haiku45T', thinking: true },
   { id: 'haiku45', thinking: false },
 ];
@@ -26,7 +26,7 @@ const items = [
     <span class="mp-label">Model</span>
     <div class="mp-control">
       <wa-icon class="mp-cv-ic" library="texra" name="cpu"></wa-icon>
-      <span class="mp-value">sonnet46T</span>
+      <span class="mp-value">sonnet5T</span>
       <wa-icon class="mp-caret" library="texra" name="chevron-down"></wa-icon>
     </div>
     <div class="mp-menu">

--- a/docs/.vitepress/components/ModelTierMatrixCard.vue
+++ b/docs/.vitepress/components/ModelTierMatrixCard.vue
@@ -17,7 +17,7 @@ const tiers = [
     icon: 'bolt',
     kind: 'Simple',
     cue: 'Corrections, quick edits',
-    models: ['qwenturbo', 'deepseek', 'haiku45'],
+    models: ['gpt56--', 'deepseek', 'haiku45'],
   },
   {
     icon: 'sparkle',

--- a/docs/.vitepress/components/ModelTierMatrixCard.vue
+++ b/docs/.vitepress/components/ModelTierMatrixCard.vue
@@ -23,13 +23,13 @@ const tiers = [
     icon: 'sparkle',
     kind: 'Complex',
     cue: 'Transformations, rewrites',
-    models: ['fable5', 'opus5T', 'gpt55', 'gemini31p'],
+    models: ['fable5', 'opus5T', 'gpt56', 'gemini31p'],
   },
   {
     icon: 'lightbulb',
     kind: 'Reasoning-heavy',
     cue: 'Deep, multi-step thinking',
-    models: ['fable5', 'sonnet46T', 'opus5T', 'deepseekT'],
+    models: ['fable5', 'sonnet5T', 'opus5T', 'deepseekT'],
   },
 ];
 </script>

--- a/docs/.vitepress/components/PolishRoundsTree.vue
+++ b/docs/.vitepress/components/PolishRoundsTree.vue
@@ -34,7 +34,7 @@ const rounds = [
     <div class="mk-card-head prt-head">
       <wa-icon class="mk-card-head-ic" library="texra" name="folder"></wa-icon>
       <span class="mk-card-title prt-head-name"
-        >.texra/runs/&lt;run-id&gt;/</span
+        >executions/&lt;run-id&gt;/</span
       >
       <span class="mk-card-sub prt-head-sub">one folder per round</span>
     </div>

--- a/docs/.vitepress/components/PolishRunTree.vue
+++ b/docs/.vitepress/components/PolishRunTree.vue
@@ -1,6 +1,7 @@
 <script setup>
 // Frameless task-storage file tree for guide/first-run.md ("In the terminal").
-// Polish writes one folder per round under .texra/runs/<run-id>/, and KEEPS the
+// Polish writes one folder per round under executions/<run-id>/ in the
+// workspace store, and KEEPS the
 // input filename (draft.tex, not output.tex). r0 is the first revision, r1 the
 // critique pass / final. A side note pins the preserved-filename point, and a
 // dimmed sibling leaf shows the --output draft.polished.tex alternative.
@@ -29,7 +30,7 @@ const rounds = [
 <template>
   <MockCard
     class="prt"
-    title=".texra/runs/"
+    title="executions/"
     icon="folder-opened"
     sub="one folder per round · input filename preserved"
   >

--- a/docs/.vitepress/components/QuickStartHero.vue
+++ b/docs/.vitepress/components/QuickStartHero.vue
@@ -61,7 +61,7 @@ import MockupFrame from './MockupFrame.vue';
               ><wa-icon library="texra" name="robot"></wa-icon
             ></span>
             <div class="select">
-              <span class="s-val">sonnet46</span>
+              <span class="s-val">sonnet5</span>
               <wa-icon
                 class="s-caret"
                 library="texra"

--- a/docs/.vitepress/components/RemoteAgentsProfile.vue
+++ b/docs/.vitepress/components/RemoteAgentsProfile.vue
@@ -16,8 +16,8 @@ const rows = [
     state: 'use',
   },
   {
-    name: 'discuss',
-    desc: 'Academic brainstorming with literature',
+    name: 'orchestrator',
+    desc: 'Multi-agent coordination',
     state: 'in-use',
   },
   {

--- a/docs/.vitepress/components/RunParityHero.vue
+++ b/docs/.vitepress/components/RunParityHero.vue
@@ -40,7 +40,7 @@ const RUN_ID = '9f3a6c81d24e';
           <span>run complete</span>
           <code class="rph-id">{{ RUN_ID }}</code>
         </div>
-        <div class="rph-path">.texra/runs/{{ RUN_ID }}/r1/draft.tex</div>
+        <div class="rph-path">executions/{{ RUN_ID }}/r1/draft.tex</div>
       </div>
     </section>
 

--- a/docs/.vitepress/components/StatusDotLegend.vue
+++ b/docs/.vitepress/components/StatusDotLegend.vue
@@ -1,38 +1,36 @@
 <script setup>
 // Frameless status-indicator legend for the ProgressBoard guide. The prose
-// enumerates four states as colored circles (Green/Grey/Red/Yellow); a swatch
-// legend beats parsing "a colored circle shows the current status" four times.
+// enumerates the live status-dot states as colored circles; a swatch legend
+// beats parsing "a colored circle shows the current status" four times.
 //
-// Reuses the .sh-dot sizing intent from theme/mockup.css and the
-// --color-success / --color-warning / --color-error tokens (plus --mk-text-faint
-// for the grey Stopped dot). Only the Running dot pulses (mk-shpulse keyframe);
-// the others are static, matching how the live header reads. Root carries
-// `.mockup` so every --mk-* token resolves and the figure flips with the theme.
+// Colors mirror src/shared/styles/statusIndicatorStyles.ts: running = green,
+// waiting = link blue, completed/cancelled = grey, failed = red. No state
+// pulses in the live UI. Root carries `.mockup` so every --mk-* token
+// resolves and the figure flips with the theme.
 const states = [
   {
     cls: 'd-run',
     label: 'Running',
     desc: 'Agent is actively processing',
-    pulse: true,
   },
   {
-    cls: 'd-stop',
-    label: 'Stopped',
-    desc: 'Finished successfully or stopped manually',
+    cls: 'd-wait',
+    label: 'Waiting',
+    desc: 'Paused for your input or a follow-up',
   },
-  { cls: 'd-err', label: 'Error', desc: 'The run hit an error' },
   {
-    cls: 'd-ready',
-    label: 'Ready',
-    desc: 'View is idle — no active stream yet',
+    cls: 'd-done',
+    label: 'Completed',
+    desc: 'Finished (or cancelled) — grey',
   },
+  { cls: 'd-err', label: 'Failed', desc: 'The run hit an error' },
 ];
 </script>
 
 <template>
   <div class="mockup sdl" role="group" aria-label="Status indicator legend">
     <div v-for="s in states" :key="s.label" class="sdl-row">
-      <span class="sdl-dot" :class="[s.cls, { 'sdl-pulse': s.pulse }]"></span>
+      <span class="sdl-dot" :class="s.cls"></span>
       <span class="sdl-label">{{ s.label }}</span>
       <span class="sdl-desc">{{ s.desc }}</span>
     </div>
@@ -68,19 +66,14 @@ const states = [
 .sdl-dot.d-run {
   background: var(--color-success);
 }
-.sdl-dot.d-stop {
+.sdl-dot.d-wait {
+  background: var(--wa-color-text-link, var(--mk-accent));
+}
+.sdl-dot.d-done {
   background: var(--mk-text-faint);
 }
 .sdl-dot.d-err {
   background: var(--color-error);
-}
-.sdl-dot.d-ready {
-  background: var(--color-warning);
-}
-/* Only the Running dot animates — same intent as the live .sh-dot. */
-.sdl-dot.sdl-pulse {
-  box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-success) 60%, transparent);
-  animation: mk-shpulse 1.8s infinite;
 }
 .sdl-label {
   font-family: var(--vp-font-family-mono);

--- a/docs/.vitepress/components/StorageLifecycleFlow.vue
+++ b/docs/.vitepress/components/StorageLifecycleFlow.vue
@@ -53,11 +53,7 @@ import StatusPill from './StatusPill.vue';
         </span>
         <wa-icon class="sf-arr" library="texra" name="arrow-right"></wa-icon>
         <span class="sf-dest">
-          <wa-icon
-            class="sf-dest-ic"
-            library="texra"
-            name="folder"
-          ></wa-icon>
+          <wa-icon class="sf-dest-ic" library="texra" name="folder"></wa-icon>
           <span class="sf-dest-txt">
             <span class="sf-dest-name">Workspace</span>
             <span class="sf-dest-sub">copies reviewed outputs back in</span>
@@ -71,7 +67,11 @@ import StatusPill from './StatusPill.vue';
         </span>
         <wa-icon class="sf-arr" library="texra" name="arrow-right"></wa-icon>
         <span class="sf-dest">
-          <wa-icon class="sf-dest-ic" library="texra" name="clock-rotate-left"></wa-icon>
+          <wa-icon
+            class="sf-dest-ic"
+            library="texra"
+            name="clock-rotate-left"
+          ></wa-icon>
           <span class="sf-dest-txt">
             <span class="sf-dest-name">History/</span>
             <span class="sf-dest-sub">archives the whole run, timestamped</span>

--- a/docs/.vitepress/components/StorageLifecycleFlow.vue
+++ b/docs/.vitepress/components/StorageLifecycleFlow.vue
@@ -29,7 +29,7 @@ import StatusPill from './StatusPill.vue';
         <wa-icon
           class="sf-store-ic"
           library="texra"
-          name="folder-opened"
+          name="folder-open"
         ></wa-icon>
         <span class="sf-store-title">Task-run storage</span>
         <StatusPill variant="info" shape="chip">isolated</StatusPill>
@@ -56,7 +56,7 @@ import StatusPill from './StatusPill.vue';
           <wa-icon
             class="sf-dest-ic"
             library="texra"
-            name="repo-clone"
+            name="folder"
           ></wa-icon>
           <span class="sf-dest-txt">
             <span class="sf-dest-name">Workspace</span>
@@ -67,11 +67,11 @@ import StatusPill from './StatusPill.vue';
 
       <div class="sf-branch">
         <span class="sf-cmd">
-          <wa-icon library="texra" name="archive"></wa-icon> Pack
+          <wa-icon library="texra" name="box-archive"></wa-icon> Pack
         </span>
         <wa-icon class="sf-arr" library="texra" name="arrow-right"></wa-icon>
         <span class="sf-dest">
-          <wa-icon class="sf-dest-ic" library="texra" name="history"></wa-icon>
+          <wa-icon class="sf-dest-ic" library="texra" name="clock-rotate-left"></wa-icon>
           <span class="sf-dest-txt">
             <span class="sf-dest-name">History/</span>
             <span class="sf-dest-sub">archives the whole run, timestamped</span>

--- a/docs/.vitepress/components/StreamHeaderActions.vue
+++ b/docs/.vitepress/components/StreamHeaderActions.vue
@@ -11,15 +11,14 @@
 // Root carries `.mockup`, so every --mk-* token + the wa-* bridge resolves
 // and the figure flips with the docs light/dark theme.
 const actions = [
-  { icon: 'debug-stop', label: 'Stop', desc: 'Abort the running task' },
-  { icon: 'debug-rerun', label: 'Run Again', desc: 'Re-run, same config' },
+  { icon: 'circle-stop', label: 'Stop', desc: 'Abort the running task' },
+  { icon: 'play', label: 'Run New', desc: 'Fresh run, same config' },
+  { icon: 'forward-step', label: 'Resume', desc: 'Continue saved outputs' },
   { icon: 'reply', label: 'Restore', desc: 'Load config into Launcher' },
-  { icon: 'diff-multiple', label: 'Diff', desc: 'latexdiff vs. base' },
-  { icon: 'check', label: 'Accept', desc: 'Replace base with edit' },
-  { icon: 'folder-opened', label: 'Open', desc: 'Reveal task storage' },
-  { icon: 'archive', label: 'Pack', desc: 'Archive to History' },
+  { icon: 'folder-open', label: 'Open', desc: 'Reveal task storage' },
+  { icon: 'code-compare', label: 'Diff', desc: 'latexdiff vs. base' },
   { icon: 'trash', label: 'Clean', desc: 'Delete task storage' },
-  { icon: 'clear-all', label: 'Erase', desc: 'Remove stream + log' },
+  { icon: 'box-archive', label: 'Pack', desc: 'Archive to History' },
 ];
 </script>
 
@@ -27,12 +26,9 @@ const actions = [
   <div class="mockup sha" role="group" aria-label="Stream header actions">
     <!-- Identity strip: name + live status dot + token/cost summary -->
     <div class="stream-head">
-      <span class="sh-name">polish@sonnet46: paper.tex</span>
+      <span class="sh-name">polish: paper.tex</span>
       <span class="sh-dot" title="Running"></span>
-      <span class="sh-badge">
-        <wa-icon class="sh-pulse" library="texra" name="pulse"></wa-icon>
-        r0–r2 · 48.2K in / 6.1K out · $0.21
-      </span>
+      <span class="sh-badge">r0–r2 · 48.2K in / 6.1K out · $0.21</span>
     </div>
 
     <!-- Labeled action toolbar — one icon button per header action -->

--- a/docs/.vitepress/components/TaskRecipeCards.vue
+++ b/docs/.vitepress/components/TaskRecipeCards.vue
@@ -14,7 +14,7 @@ const recipes = [
     title: 'Fix grammar & typos',
     agent: 'correct',
     model: 'qwenturbo',
-    alts: 'deepseek, gemini31p, sonnet46',
+    alts: 'deepseek, gemini31p, sonnet5',
     instruction:
       'Fix grammatical errors and typos without changing the content or technical terminology.',
   },
@@ -22,8 +22,8 @@ const recipes = [
     icon: 'file-export',
     title: 'Paper to slides',
     agent: 'paper2slide',
-    model: 'sonnet46T',
-    alts: 'opus5T, gpt55',
+    model: 'sonnet5T',
+    alts: 'opus5T, gpt56',
     instruction:
       'Convert this paper into presentation slides using the beamer template. Create approximately 12–15 slides highlighting the key points, methodology, and results.',
   },
@@ -31,8 +31,8 @@ const recipes = [
     icon: 'sparkle',
     title: 'Polish writing style',
     agent: 'polish',
-    model: 'opus46',
-    alts: 'sonnet46T',
+    model: 'opus5',
+    alts: 'sonnet5T',
     instruction:
       'Improve the writing style to make it more engaging and clear. Enhance the flow between paragraphs while preserving all technical content.',
   },

--- a/docs/.vitepress/components/TaskRecipeCards.vue
+++ b/docs/.vitepress/components/TaskRecipeCards.vue
@@ -13,8 +13,8 @@ const recipes = [
     icon: 'check',
     title: 'Fix grammar & typos',
     agent: 'correct',
-    model: 'qwenturbo',
-    alts: 'deepseek, gemini31p, sonnet5',
+    model: 'gemini36f',
+    alts: 'deepseek, gpt56--, sonnet5',
     instruction:
       'Fix grammatical errors and typos without changing the content or technical terminology.',
   },

--- a/docs/guide/agent-architecture.md
+++ b/docs/guide/agent-architecture.md
@@ -39,7 +39,7 @@ These `.yaml` files have two main parts (and thankfully, YAML is usually less pr
     - `userPrefix`: Provides the main context, including your input file(s) (available via e.g., `{{ INPUT_CONTENT }}`) and the specific instruction you typed in the UI (available via `{{ INSTRUCTION }}`).
     - `userRequest`: Asks the LLM to perform the initial task (Round 0). Often instructs the LLM to think within `<scratchpad>` tags and then output the main content wrapped in the fixed `<documents>` container, with one `<document name="...">...</document>` entry per output file. You can also provide an **array** here: the first entry becomes the round 0 request, and any additional entries drive automatic reflection rounds (Round 1+). When a run consumes more rounds than entries you specify, the first reflection template is reused.
 
-_(Prompts use Jinja2 templating. For a detailed list of available variables like `{{ INPUT_CONTENT }}` and how to use them, see the [Custom Agents](./custom-agents.md) guide.)_
+_(Prompts use Nunjucks templating (Jinja2-style syntax). For a detailed list of available variables like `{{ INPUT_CONTENT }}` and how to use them, see the [Custom Agents](./custom-agents.md) guide.)_
 
 ::: tip Transparency & Customization
 The prompts described above (`systemPrompt`, `userPrefix`, etc.) represent TeXRA's structured approach to guiding the LLM. This structured, template-based system means the agent's behavior is transparent and highly customizable through the `.yaml` file, not a hidden black box.
@@ -98,7 +98,7 @@ Each round lands in its own folder under task storage:
 
 ### What Goes Into the Prompt
 
-TeXRA assembles a conversation from your agent's prompts and the content you selected in the UI. If you enabled **Attach TeX Count** or **Attach Diagnostics**, that information is included too. Figures and audio files are sent alongside the text for models that support them. The AI then reasons through the task and produces its output.
+TeXRA assembles a conversation from your agent's prompts and the content you selected in the UI. If you enabled **Attach TeX Count**, that information is included too. Figures and audio files are sent alongside the text for models that support them. The AI then reasons through the task and produces its output.
 
 **Reflection Rounds (Round 1+):**
 

--- a/docs/guide/agent-integrations.md
+++ b/docs/guide/agent-integrations.md
@@ -24,22 +24,22 @@ does its thing.
 
 Both integrations follow the same setup flow from the TeXRA Dashboard.
 
-1. Open **TeXRA: Show Settings Dashboard** (`Ctrl+Shift+P`) → **Integrations** tab (<wa-icon library="texra" name="robot"></wa-icon>).
+1. Open **TeXRA: Show Settings Dashboard** (`Ctrl+Shift+P`) → **Integrations** tab (<wa-icon library="texra" name="link"></wa-icon>).
 2. Find the **OpenAI Codex CLI** or **Claude Code CLI** card. When it's **Not Found**, the setup actions expand automatically.
-3. Click <wa-icon library="texra" name="terminal"></wa-icon> **Install in Terminal**, then <wa-icon library="texra" name="sign-in"></wa-icon> **Sign in** to OAuth in your browser.
-4. Click **Recheck**. The status flips to <wa-icon library="texra" name="check"></wa-icon> **Available**.
+3. Click <wa-icon library="texra" name="terminal"></wa-icon> **Install in Terminal**, then <wa-icon library="texra" name="right-to-bracket"></wa-icon> **Sign in** to OAuth in your browser.
+4. Reopen the dashboard (or click **Re-check** on the **Tools** tab). The status flips to <wa-icon library="texra" name="check"></wa-icon> **Available** once TeXRA detects the install.
 
 <IntegrationCard />
-<p class="hero-caption">Each integration has its own card: a <strong>Not Found</strong> card expands its setup actions, and <strong>Recheck</strong> flips it to <strong>Available</strong> with a settings summary.</p>
+<p class="hero-caption">Each integration has its own card: a <strong>Not Found</strong> card expands its setup actions, and <strong>Re-check</strong> flips it to <strong>Available</strong> with a settings summary.</p>
 
 The same flow runs beat for beat in a terminal — detect, install, sign in,
 recheck:
 
 <CliToolsLifecycleHero />
 
-<p class="hero-caption"><code>texra tools</code> drives the full lifecycle: <code>show</code> reports the registered install and auth commands, <code>install --run</code> executes the installer after printing it, and <code>auth</code> hands off to the tool's own sign-in.</p>
+<p class="hero-caption"><code>texra tools</code> drives the full lifecycle: <code>status</code> reports the registered install and auth commands, <code>install --run</code> executes the installer after printing it, and <code>auth</code> hands off to the tool's own sign-in.</p>
 
-Each integration's options live on its card and are scoped to the current workspace. Per-call approval prompts are governed by the global **Require approval for shell commands & agent sessions** switch under **Dashboard → Tools → Approval & Safety** (on by default); turn it off to let agents call Codex or Claude Code without confirming each time.
+Each integration's options live on its card and are scoped to the current workspace. Per-call approval prompts are governed by the global **Approve shell commands** switch under **Dashboard → Tools → Approval & safety** (on by default); turn it off to let agents call Codex or Claude Code without confirming each time.
 
 Both CLIs are installed once per machine and shared by every TeXRA surface — the VS Code extension, the desktop app, and the terminal client all detect the same installation. Neither ships inside TeXRA: each one is a 250-410 MB native binary that Anthropic and OpenAI update on their own schedule, so TeXRA looks for whichever version you have rather than freezing a copy into every release.
 
@@ -100,7 +100,7 @@ the session is still working).
 ## Running an Integration
 
 Check which agents have the `codex` or `claude_code` tool enabled on the
-**Agents** tab (<wa-icon library="texra" name="sparkle"></wa-icon>), then prompt
+**Agents** tab (<wa-icon library="texra" name="robot"></wa-icon>), then prompt
 one of them:
 
 > Use codex to sketch a minimal FastAPI server that returns a JSON healthcheck.
@@ -109,9 +109,9 @@ one of them:
 
 When the tool fires:
 
-1. A new stream tab opens on the ProgressBoard (<wa-icon library="texra" name="type-hierarchy"></wa-icon>) labelled `codex@codex-sdk` or `claude@agent-sdk`.
+1. A new stream tab opens on the ProgressBoard labelled `codex` or `claude_code`.
 2. You see the side agent's reasoning, the commands it runs, the file changes it makes, and any web searches (<wa-icon library="texra" name="globe"></wa-icon>) and todos — all live.
-3. When the turn ends, the tab shows **WAITING**. Type into it to send a follow-up, or press <wa-icon library="texra" name="debug-stop"></wa-icon> **Stop** to close the session.
+3. When the turn ends, the tab shows **WAITING**. Type into it to send a follow-up, or press <wa-icon library="texra" name="circle-stop"></wa-icon> **Stop** to close the session.
 4. The result (final message and token cost) is handed back to the TeXRA agent that asked for it, which then continues its own work.
 
 <DelegatedStreamHero />

--- a/docs/guide/built-in-agents.md
+++ b/docs/guide/built-in-agents.md
@@ -333,20 +333,20 @@ current revision (main.tex), highlighting additions and deletions.
 
 ### `ocr`
 
-The `ocr` agent performs Optical Character Recognition (OCR) on image or PDF files.
+The `ocr` agent converts handwritten mathematical content from images into LaTeX.
 
-**Purpose:** Extract text content from images or non-searchable PDFs.
+**Purpose:** Turn handwritten equations and notes into LaTeX code that matches your document's notation and style.
 
 **Best for:**
 
-- Extracting text from scanned documents or figures
-- Making image-based text searchable and editable
-- Processing figures containing text for analysis
+- Converting handwritten derivations or lecture-board photos into LaTeX
+- Digitizing handwritten mathematical notes across multiple images
+- Keeping converted notation consistent with the existing document
 
 **Example instruction:**
 
 ```
-Perform OCR on the provided image file [figure.png] and extract all text content. Format the output as plain text.
+Convert the handwritten derivation in [notes.png] into LaTeX, matching the notation used in the attached document.
 ```
 
 ### `transcribe_audio`
@@ -474,19 +474,6 @@ Find recent papers on transformer architectures for scientific document understa
 Focus on papers from 2023-2024 that address mathematical equation handling.
 ```
 
-### `discuss`
-
-A brainstorming partner that can pull in relevant literature as you talk. Useful for thinking through research directions, poking holes in methodology, or connecting ideas across papers. Read-only.
-
-**Best for:** Brainstorming, methodology critique, research direction guidance
-
-**Example instruction:**
-
-```
-I'm considering attention mechanisms for my theorem prover. What are the
-tradeoffs compared to tree-based approaches? What does the literature say?
-```
-
 ### `simplifier`
 
 Cuts through complexity in your code and writing. Whether it's duplicated logic across files, overly-abstract wrappers, or LLM-generated filler prose, `simplifier` cleans things up while preserving correctness.
@@ -508,7 +495,7 @@ Coordinates multi-agent work on LaTeX research projects. It reads project contex
 
 ### `progressCheck`
 
-An end-of-session reviewer. It looks at what was just done, the project's standing goal, and the git/PR state to decide whether the orchestrator is actually finished or whether meaningful, low-risk progress is still on the table. Read-only — it advises, but does not edit or delegate. Bundled with every [team](#built-in-teams).
+An end-of-session reviewer. It looks at what was just done, the project's standing goal, and the git/PR state to decide whether the orchestrator is actually finished or whether meaningful, low-risk progress is still on the table. Read-only — it advises, but does not edit or delegate. Bundled with every [team](#built-in-teams) except Software Engineer.
 
 **Best for:** Auditing what a team run actually delivered versus the goal
 
@@ -519,7 +506,7 @@ Additional remote agents may be available depending on your access level. In the
 ## Built-in Teams
 
 Teams are predefined collections of agents for a discipline. Pick one from the
-**Multi-Agent** tab in the Dashboard, or run one from the CLI with
+**Teams** tab in the Dashboard, or run one from the CLI with
 `texra multi-agent run <team>`:
 
 | Team               | For                                                                                         | Lead agent         |
@@ -530,9 +517,9 @@ Teams are predefined collections of agents for a discipline. Pick one from the
 | Computer Scientist | CS papers — algorithm design, code-driven experiments and ablations, tests, and review      | `orchestrator`     |
 | Software Engineer  | A project's code — implementation, review, debugging, and testing across specialists        | `engineer`         |
 
-Every team bundles the `progressCheck` audit helper, and the paper-focused
-teams also include `latexFixer`. The Software Engineer lead and its specialists
-run locally; some specialists in other teams are
+Every team except Software Engineer bundles the `progressCheck` audit helper,
+and the paper-focused teams also include `latexFixer`. The Software Engineer
+lead and its specialists run locally; some specialists in other teams are
 [remote agents](./remote-agents.md) that sync after you sign in.
 
 ## Next Steps

--- a/docs/guide/code-review.md
+++ b/docs/guide/code-review.md
@@ -233,9 +233,11 @@ deliberately when adopting a new release.
 :::
 
 This is the same workflow the TeXRA repository runs on its own pull requests,
-with two documented differences: TeXRA pins the action to a release commit (the
-tip above) and adds a custom prompt (see
-[Writing your own review prompt](#writing-your-own-review-prompt)).
+with documented differences: TeXRA pins the action to a release commit (the
+tip above), adds a custom prompt (see
+[Writing your own review prompt](#writing-your-own-review-prompt)), and
+triggers on PR open only — a `re-review` label requests a fresh run instead of
+reviewing every push.
 
 ### 4. Open a pull request and watch it run
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -14,15 +14,15 @@ view; TeXRA does not contribute product settings to VS Code's Settings editor.
 
 The Dashboard groups the current controls by subject:
 
-- **Account & usage** — sign-in status, included usage, telemetry, and
-  subscription access (ChatGPT, Kimi Code, and Copilot).
+- **Account** — sign-in status, included usage, telemetry, and subscription
+  access (ChatGPT, Kimi Code, and Copilot).
 - **Models** — access mode, provider keys, and model visibility.
-- **Agents and teams** — available agents, active teams, orchestration, and
-  session reliability.
-- **Tools and integrations** — tool availability, permissions, skills, and
-  connected coding agents.
-- **Workspace** — Git behavior and LaTeX processing.
-- **Data & activity** — history, memory, and autonomous goals.
+- **Agents** — available agents, active teams, orchestration, and session
+  reliability.
+- **Capabilities** — tool availability, permissions, skills, connected coding
+  agents, and LaTeX processing.
+- **Workspace** — Git behavior and shortcuts.
+- **Data & Activity** — history, memory, and autonomous goals.
 
 Settings that benefit from an ordinary control appear directly in these views.
 File-handling rules and other internal implementation constants are not exposed
@@ -67,11 +67,13 @@ them at the intended project or user scope.
 
 ## Model access and credentials
 
-The **Models** view is the single home for model access, provider API keys,
-provider behavior, model visibility, and retry settings. Account connections
-that stand in for a provider key — Researcher Access and the ChatGPT
-subscription — live in **Account & usage**. Included-usage data remains visible whenever the signed-in account
-has usage data, regardless of the currently selected access mode.
+The **Providers & Models** view is the single home for model access, provider
+API keys, provider behavior, model visibility, and retry settings. Account
+connections that stand in for a provider key live in the **Account** group:
+Researcher Access sign-in under **Account & Usage**, and the ChatGPT, Kimi
+Code, and Copilot subscriptions under **Subscriptions**. Included-usage data
+remains visible whenever the signed-in account has usage data, regardless of
+the currently selected access mode.
 
 Saved provider keys currently use each host's secure credential mechanism. They
 are not copied through the shared JSON configuration. Environment-variable keys
@@ -109,8 +111,7 @@ The **LaTeX** view contains the settings that remain useful to change:
 
 - inline criticism display;
 - compile and diff behavior;
-- formatter selection;
-- TikZ processing; and
+- formatter selection; and
 - direct, regular-expression, and custom replacement rules.
 
 The latexdiff picture-environment pattern is a fixed product rule rather than a
@@ -123,9 +124,8 @@ TeXRA's native configuration.
 ## Agent execution settings (webview interface)
 
 Per-run controls in the task composer affect only the task being launched. They
-include attached files and optional context helpers such as TeX count or editor
-diagnostics. Persistent agent visibility and team selection belong in the
-Dashboard instead.
+include attached files and optional context helpers such as TeX count.
+Persistent agent visibility and team selection belong in the Dashboard instead.
 
 ## Debugging
 

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -36,7 +36,7 @@ Custom agents live in a dedicated directory that TeXRA prepares for you.
 
 ### <wa-icon library="texra" name="wand"></wa-icon> Automatic Creation
 
-If you'd like TeXRA to draft an agent for you, click **New Agent** (<wa-icon library="texra" name="add"></wa-icon>) in the **Agents** tab. The wizard only asks for a short description and the default output filenames. TeXRA sends that info to a Claude model, which returns the YAML enclosed in `<yaml>...</yaml>` tags. The extension extracts the content between those tags and saves it as a basic CoT template (single or multiple files) in your Custom Agents folder.
+If you'd like TeXRA to draft an agent for you, click **New Agent** (<wa-icon library="texra" name="add"></wa-icon>) in the **Agents** tab. The wizard asks for the agent name and a short description (tool-use agents additionally let you pick the tools to grant). TeXRA sends that info to your configured helper model, which returns the YAML enclosed in `<yaml>...</yaml>` tags. The extension extracts the content between those tags and saves it as a template in your Custom Agents folder (falling back to a built-in template if generation fails).
 
 ### <wa-icon library="texra" name="file-add"></wa-icon> Step 2 — Create a New YAML File
 
@@ -58,7 +58,7 @@ Customize it to define your agent's structure. Here are the key fields:
 # --- Agent Inheritance (Optional) ---
 # Specify a built-in or other custom agent to inherit settings and prompts from.
 # See guide/built-in-agents.md for potential parents.
-inherits: base # Or polish, correct, etc.
+inherits: polish # Or correct, merge, etc.
 
 # --- Agent Settings ---
 # Define the agent's core behavior and operational parameters.
@@ -107,9 +107,9 @@ prompts:
 > prompts. If a run requests more reflections than the list provides, the first
 > reflection template is reused.
 
-#### <wa-icon library="texra" name="symbol-variable"></wa-icon> Using Variables in Prompts (Jinja2 Templating)
+#### <wa-icon library="texra" name="symbol-variable"></wa-icon> Using Variables in Prompts (Nunjucks Templating)
 
-Prompts are processed using the Jinja2 templating engine, allowing you to insert dynamic information using `{{ variable_name }}` syntax. TeXRA provides several built-in variables based on the files and instructions you select in the UI:
+Prompts are processed using the Nunjucks templating engine (Jinja2-style syntax), allowing you to insert dynamic information using `{{ variable_name }}` syntax. TeXRA provides several built-in variables based on the files and instructions you select in the UI:
 
 This mechanism is sometimes referred to as **Variable Retrieval (VR)**—the extension loads your chosen inputs, references, figures, and any additional context, then exposes them as template variables. For example, the text content of your main file becomes `{{ INPUT_CONTENT }}` while the full list of selected files can be accessed through `{{ ALL_INPUTS }}`. When you run the agent these placeholders are replaced with real data.
 
@@ -120,9 +120,7 @@ that file's text, `ALL_*` bundles every selected file into one
 `<document name="...">…</document>` XML string, and `LIST_OF_*` gives the same
 set as a comma-separated path list. Media is the exception — `MEDIA_FILE` is a
 path, but the media itself is sent to multimodal models separately rather than
-inlined as text (see [Working with Figures](./working-with-figures.md)). Legacy
-custom agents can still read the `REFERENCE_*` and `AUXILIARY_*` aliases, but new
-agents should use `CONTEXT_*`.
+inlined as text (see [Working with Figures](./working-with-figures.md)).
 
 **Multiple Document Output:**
 
@@ -180,7 +178,7 @@ To create your own tool-use agent, set `agentCategory: toolUse` and list the too
 
 <ToolCategoriesHero />
 
-<p class="hero-caption">The seven tool categories on <strong>Dashboard → Tools</strong>; every chip is a name you can list verbatim in your agent's <code>tools:</code> array.</p>
+<p class="hero-caption">The eight tool categories on <strong>Dashboard → Tools</strong>; every chip is a name you can list verbatim in your agent's <code>tools:</code> array.</p>
 
 For the exact tool names to list in your YAML, browse any of the built-in tool-use agents (like `research`, `review`, `lean`, or `numerics`) in the **Agents** tab — their `tools:` array shows exactly which tools are wired up.
 
@@ -240,11 +238,10 @@ filename from the selected input list or from `settings.defaultOutputFiles`:
 
 See [Handling Multiple Files](./multiple-output.md) for more details.
 
-### <wa-icon library="texra" name="save"></wa-icon> Step 4 — Save and Reload
+### <wa-icon library="texra" name="save"></wa-icon> Step 4 — Save and Run
 
 1. Save your `.yaml` file.
-2. Reload the VS Code window (Command Palette → `Developer: Reload Window`).
-3. Your new custom agent should now appear in the **Agent** dropdown (<wa-icon library="texra" name="sparkle"></wa-icon>) of the TeXRA UI.
+2. TeXRA watches the custom agents directory, so your new agent appears automatically in the **Agent** dropdown (<wa-icon library="texra" name="sparkle"></wa-icon>) of the TeXRA UI — no window reload needed.
 
 From a terminal the iteration loop is faster — no window reload needed.
 Verify the agent registered, then smoke-test it in one go:

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -178,7 +178,7 @@ To create your own tool-use agent, set `agentCategory: toolUse` and list the too
 
 <ToolCategoriesHero />
 
-<p class="hero-caption">The eight tool categories on <strong>Dashboard → Tools</strong>; every chip is a name you can list verbatim in your agent's <code>tools:</code> array.</p>
+<p class="hero-caption">The seven grantable tool categories on <strong>Dashboard → Tools</strong>; every chip is a name you can list verbatim in your agent's <code>tools:</code> array.</p>
 
 For the exact tool names to list in your YAML, browse any of the built-in tool-use agents (like `research`, `review`, `lean`, or `numerics`) in the **Agents** tab — their `tools:` array shows exactly which tools are wired up.
 

--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -41,7 +41,7 @@ TeXRA organizes files into three categories, each with its own accepted file typ
       ],
     },
     {
-      icon: 'device-camera-video',
+      icon: 'video',
       title: 'Media',
       tag: 'Visual / audio',
       tagVariant: 'neutral',
@@ -88,7 +88,7 @@ TeXRA supports directly pasting images from your clipboard into the instruction 
 2. **Click in the instruction text area** where you want to reference the image
 3. **Paste** (Ctrl/Cmd+V) - the image will be automatically:
    - Saved to the workspace storage
-   - Referenced in the text as `[pasted_timestamp_hash.ext]`
+   - Referenced in the text as `[pasted_<timestamp>_<rand>.ext]`
    - Added to the Media Files list
    - Made available to the AI model
 
@@ -100,7 +100,7 @@ Note: Pasted images are stored in workspace storage and automatically cleaned up
 
 ## File Selection Interface
 
-The TeXRA interface provides a streamlined way to select and manage files using distinct sections for each file category (Input <wa-icon library="texra" name="file-code"></wa-icon>, Context <wa-icon library="texra" name="book"></wa-icon>, Media <wa-icon library="texra" name="device-camera-video"></wa-icon>):
+The TeXRA interface provides a streamlined way to select and manage files using distinct sections for each file category (Input <wa-icon library="texra" name="file-code"></wa-icon>, Context <wa-icon library="texra" name="book"></wa-icon>, Media <wa-icon library="texra" name="video"></wa-icon>):
 
 <FileSelectHero />
 
@@ -110,9 +110,9 @@ The TeXRA interface provides a streamlined way to select and manage files using 
 
 Each category — Input, Context, and Media — manages a list of files (a single-file workflow is just a list of length one). The header exposes three buttons:
 
-- **Add opened files** (<wa-icon library="texra" name="folder-opened"></wa-icon>): Append every editor tab whose extension matches the category to the list.
+- **Add opened files** (<wa-icon library="texra" name="folder-open"></wa-icon>): Append every editor tab whose extension matches the category to the list.
 - **Clear all files** (<wa-icon library="texra" name="trash"></wa-icon>): Empty the list.
-- **Add files** (<wa-icon library="texra" name="add"></wa-icon>): Open a file picker to append files.
+- **Add files** (<wa-icon library="texra" name="plus"></wa-icon>): Open a file picker to append files.
 
 You can also **drag-and-drop files** from the OS file manager (or from VS Code's Explorer) onto a category to add them.
 
@@ -166,8 +166,8 @@ For example:
 
 - Input: `paper.tex`
 - Agent: `polish`
-- Model: `sonnet46`
-- Output: `r0/output.tex`
+- Model: `sonnet5`
+- Output: `r0/paper.tex`
 
 When the agent definition includes reflection rounds, you may also see:
 
@@ -179,7 +179,7 @@ TeXRA provides several commands for managing generated files, accessible from th
 
 ### Pack
 
-The "Pack" button (<wa-icon library="texra" name="archive"></wa-icon>) snapshots the run's task storage folder into a structured history folder:
+The "Pack" button (<wa-icon library="texra" name="box-archive"></wa-icon>) snapshots the run's task storage folder into a structured history folder:
 
 1. Creates a timestamped directory in the "History" folder
 2. Copies all relevant output files, logs, and mirrored dependencies
@@ -205,7 +205,7 @@ viewer, so PDFs and images display correctly while `.tex` documents open in the
 editor.
 
 To browse the whole run folder, use the
-<wa-icon library="texra" name="folder-opened"></wa-icon> **Open in task storage** toolbar
+<wa-icon library="texra" name="folder-open"></wa-icon> **Open in task storage** toolbar
 button. This reveals the task-run storage folder with generated files, compile
 logs, mirrored LaTeX dependencies, and intermediate artifacts. (From a
 terminal, `texra history show <id>` lists the same stored artifacts — see the
@@ -227,8 +227,9 @@ files. Three commands then move that run's artifacts to three different places:
 
 <p class="hero-caption">Accept copies reviewed outputs into the workspace, Pack archives the run into History, and Clean deletes the run folder — your input files are never touched.</p>
 
-The CLI follows the same storage-first lifecycle — its run store lives at
-`.texra/runs/<run-id>/`, and `--output` plays the role of **Accept**:
+The CLI follows the same storage-first lifecycle — it reads and writes the
+same `executions/<executionId>/` run store, and `--output` plays the role of
+**Accept**:
 
 <CliStorageHero />
 
@@ -275,17 +276,12 @@ to inspect and apply the available workspace recommendations explicitly.
 
 ## Cross-Computer Syncing
 
-For users working on multiple computers, we recommend using a cloud storage service like Dropbox to sync the following folders:
+For users working on multiple computers, we recommend using a cloud storage service like Dropbox to sync the **History** folder, which keeps track of packed versions of your documents.
 
-- **Log**: Contains thinking logs and other processing information
-- **Diffs**: Stores difference files generated by LaTeX diff functionality
-- **History**: Keeps track of different versions of your documents
-
-To maintain your local directory structure while syncing these folders, we suggest using soft links (symbolic links). This approach allows you to store the actual folders in Dropbox while creating symbolic links in your local project directory. For example:
+To maintain your local directory structure while syncing this folder, we suggest using soft links (symbolic links). This approach allows you to store the actual folder in Dropbox while creating a symbolic link in your local project directory. For example:
 
 ```bash
-ln -s /path/to/Dropbox/texra-papers/ProjectName/Diffs /path/to/local/ProjectName
-ln -s /path/to/Dropbox/texra-papers/ProjectName/History /path/to/local/ProjectName
+ln -s /path/to/Dropbox/texra-papers/ProjectName/History /path/to/local/ProjectName/History
 ```
 
 Replace `/path/to/Dropbox` and `/path/to/local` with your actual Dropbox and local project paths.

--- a/docs/guide/first-run.md
+++ b/docs/guide/first-run.md
@@ -27,10 +27,10 @@ A credential is the one step no agent can do for you. Three ways in:
   needed (recommended). In VS Code, run **TeXRA: Sign In** from the
   command palette; in the terminal, run `texra login`.
 - **Use ChatGPT subscription** — Codex models through your ChatGPT plan.
-  In VS Code, open **Settings → Account** and use the ChatGPT subscription
+  In VS Code, open **Settings → Subscriptions** and use the ChatGPT
   sign-in section; in the terminal, run `texra auth chatgpt login`.
 - **Use GitHub Copilot in VS Code** — compatible models through your Copilot
-  subscription. Open **Settings → Models → Copilot in VS Code** and grant
+  subscription. Open **Settings → Subscriptions → Copilot in VS Code** and grant
   access in the native VS Code prompt. No provider API key is needed. This
   source is unavailable in the terminal and desktop applications.
 - **Use your own provider API key** — Anthropic, OpenAI, Google, and
@@ -76,7 +76,7 @@ EOF
 1. Open `draft.tex`.
 2. Click the TeXRA icon in the activity bar.
 3. In the **Input** section, click <wa-icon library="texra" name="add"></wa-icon> **Add files** and pick `draft.tex` from the file picker.
-4. Pick **polish** under Agent. Pick **sonnet46T** under Model (or any
+4. Pick **polish** under Agent. Pick **sonnet5T** under Model (or any
    available model).
 5. Type an instruction:
    > Tighten the prose. Preserve all math and citations.
@@ -105,17 +105,18 @@ texra run polish \
 <p class="hero-caption">Mid-run: Round 0 has written the first revision, Round 1 is critiquing and revising it — the live status line on stderr tracks the current round. When the run completes, the path to the final document prints on stdout.</p>
 
 The run streams reasoning, tool calls, and the assembled output.
-When it completes, polish has written one folder per round under
-`.texra/runs/<run-id>/`:
+When it completes, polish has written one folder per round in the run's
+storage folder (`executions/<run-id>/` under TeXRA's workspace storage):
 
 <PolishRunTree />
 
 <p class="hero-caption">Each round lands in its own folder and keeps the input filename — <code>r0/draft.tex</code> is the first revision, <code>r1/draft.tex</code> the critique pass and final. Add <code>--output draft.polished.tex</code> to write the result next to your input instead.</p>
 
-To diff against your original:
+To diff against your original, use the final-document path printed on
+stdout:
 
 ```sh
-diff -u draft.tex .texra/runs/<run-id>/r1/draft.tex
+diff -u draft.tex <path-to-r1/draft.tex-from-stdout>
 ```
 
 ## What just happened

--- a/docs/guide/first-run.md
+++ b/docs/guide/first-run.md
@@ -74,7 +74,7 @@ EOF
 ### In VS Code
 
 1. Open `draft.tex`.
-2. Click the TeXRA icon in the activity bar.
+2. Click the TeXRA icon in the Secondary Side Bar.
 3. In the **Input** section, click <wa-icon library="texra" name="add"></wa-icon> **Add files** and pick `draft.tex` from the file picker.
 4. Pick **polish** under Agent. Pick **sonnet5T** under Model (or any
    available model).

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -24,7 +24,7 @@ work — with every change returned as a diff you approve.
 | ------------------------------------------ | ------------------------------------------------------------- |
 | Tighten prose in a draft                   | [Polish a draft](./workflows/polish-a-draft.md)               |
 | Fix LaTeX errors and notation              | `correct` agent — see [Built-in Agents](./built-in-agents.md) |
-| Search literature, no fabricated citations | `search` — see [Research Tools](./research-tools.md)          |
+| Search literature, no fabricated citations | `assistant` — see [Research Tools](./research-tools.md)       |
 | Verify proofs and derivations              | `review` — see [Built-in Agents](./built-in-agents.md)        |
 | Formalize in Lean 4                        | [Lean 4 Proofs](./lean.md)                                    |
 | Build slides from a paper                  | `paper2slide` — see [Built-in Agents](./built-in-agents.md)   |
@@ -141,13 +141,12 @@ never leave your machine except to the provider endpoint.
 hosted models are proxied through TeXRA's service so we can manage
 provider credentials and quota on your behalf. Switch any run back
 to direct mode with `--api-mode personal` (CLI) or by adding your own
-key in the **Dashboard → Models** tab (VS Code extension).
+key in the **Dashboard → Providers & Models** tab (VS Code extension).
 
-API keys, whichever mode you use, are stored in your operating
-system's secure credential store — VS Code's built-in Secret Storage
-in the extension, the OS keychain (or a local config file) for the
-CLI. They can also be supplied via environment variables or a `.env`
-file in your project.
+API keys, whichever mode you use, stay on your machine — VS Code's
+built-in Secret Storage in the extension, an owner-only `secrets.json`
+under `~/.texra` for the CLI. They can also be supplied via environment
+variables or a `.env` file in your project (extension only).
 
 ## Support
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -274,11 +274,11 @@ TeXRA talks to model providers directly with an API key you supply. You need a k
 
 ### In the VS Code Extension
 
-The friendliest path: open the TeXRA Dashboard, go to the **Models** tab, and click the provider you want. Paste the key and it's saved in VS Code's secret storage. You can also run **TeXRA: Set API Key** from the Command Palette, or drop the keys in a `.env` file in your project — the extension reads it on startup.
+The friendliest path: open the TeXRA Dashboard, go to the **Providers & Models** tab, and click the provider you want. Paste the key and it's saved in VS Code's secret storage. You can also run **TeXRA: Set API Key** from the Command Palette, or drop the keys in a `.env` file in your project — the extension reads it on startup.
 
 <ApiKeysHero />
 
-<p class="hero-caption">The Dashboard's Models tab → API Configuration: each provider shows its key status (Set · Env · Not set) with Set, Get, and Remove actions.</p>
+<p class="hero-caption">The Dashboard's Providers & Models tab → API configuration: each provider shows its key status (Set · Env · Not set) with Set, Get, and Remove actions.</p>
 
 ### In the CLI
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -324,7 +324,7 @@ See [TeXRA CLI](./texra-cli.md) for sign-in, workspace defaults, and switching b
 To verify that TeXRA and all dependencies are correctly installed:
 
 1. Open VS Code
-2. Click on the TeXRA icon in the Activity Bar
+2. Click on the TeXRA icon in the Secondary Side Bar
 3. The TeXRA panel should load without errors
 4. Create or open a LaTeX document
 5. Try a simple command like "Indent Current TeX" from the editor title menu

--- a/docs/guide/intelligent-merge.md
+++ b/docs/guide/intelligent-merge.md
@@ -7,7 +7,7 @@ import MergePanelHero from '../.vitepress/components/MergePanelHero.vue';
 
 ## The Problem: Partial Agent Outputs
 
-When you run agents like `correct` or `polish`, the AI might intelligently focus its changes on specific sections, potentially resulting in a round output (`r0/output.tex` or `r1/output.tex`) that only contains the modified parts, not the entire document. While this saves processing time and tokens, comparing this partial output directly against your full original document using `latexdiff` wouldn't produce a meaningful result.
+When you run agents like `correct` or `polish`, the AI might intelligently focus its changes on specific sections, potentially resulting in a round output (e.g. `r0/draft.tex` or `r1/draft.tex` for a `draft.tex` input) that only contains the modified parts, not the entire document. While this saves processing time and tokens, comparing this partial output directly against your full original document using `latexdiff` wouldn't produce a meaningful result.
 
 ## The Solution: Intelligent Merge Button
 
@@ -17,7 +17,7 @@ This generated _full_ document can then be cleanly compared against your origina
 
 <MergeFlowHero />
 
-<p class="hero-caption">The full <strong>Base File</strong> and the agent's partial <strong>Edited File</strong> both feed the <code>merge</code> agent, which emits a complete <code>_full.tex</code> — the valid <code>latexdiff</code> input.</p>
+<p class="hero-caption">The full <strong>Base File</strong> and the agent's partial <strong>Edited File</strong> both feed the <code>merge</code> agent, which emits a complete merged document — the valid <code>latexdiff</code> input.</p>
 
 ## The Merge Workflow
 
@@ -25,12 +25,11 @@ Access the merge functionality via the "LaTeXdiffs" section (<wa-icon library="t
 
 <MergePanelHero />
 
-<p class="hero-caption">The LaTeXDiffs section: pick a <strong>Base File</strong>, pick an <strong>Edited File</strong>, choose a <strong>Model</strong>, then click the highlighted <wa-icon library="texra" name="merge"></wa-icon> <strong>Merge</strong> action in the Edited row.</p>
+<p class="hero-caption">The LaTeXDiffs section: pick a <strong>Base File</strong>, pick an <strong>Edited File</strong>, then click the highlighted <wa-icon library="texra" name="merge"></wa-icon> <strong>Merge</strong> action in the Edited row.</p>
 
 1.  **Select Base File**: Choose the original document you want to merge changes _into_ using the "Base File" dropdown (<wa-icon library="texra" name="file"></wa-icon> Base).
 2.  **Select Edited File**: Choose the document containing the suggested changes using the "Edited File" dropdown (<wa-icon library="texra" name="edit"></wa-icon> Edited).
-3.  **Choose Merge Model**: Select an appropriate language model from the main Model dropdown (<wa-icon library="texra" name="robot"></wa-icon> Model) below the instruction box. Models capable of strong reasoning (like Claude Opus 5, GPT-5.5, or Gemini 3.1 Pro) are recommended for complex merges.
-4.  **Click Merge**: Press the "Merge" button (<wa-icon library="texra" name="merge"></wa-icon>) located in the "Edited File" row.
+3.  **Click Merge**: Press the "Merge" button (<wa-icon library="texra" name="merge"></wa-icon>) located in the "Edited File" row. The merge runs on TeXRA's **helper model** — set it from the Dashboard → Models tab. Models capable of strong reasoning (like Claude Opus 5, GPT-5.5, or Gemini 3.1 Pro) are recommended for complex merges.
 
 ::: info VS Code feature
 The Intelligent Merge button pairs a **Base File** with a separate **Edited
@@ -42,28 +41,28 @@ extension, not the CLI.
 
 TeXRA will then invoke the specialized `merge` agent:
 
-- The agent receives the base file, the edited file, and the selected model.
+- The agent receives the base file, the edited file, and the configured helper model.
 - It analyzes both versions to identify meaningful differences.
-- It generates a new merge output (`_full.tex` inside the run's task storage folder) containing the content of the base file updated with the accepted changes from the edited file.
+- It generates a new merge output (`r0/<base filename>` inside the run's task storage folder) containing the content of the base file updated with the accepted changes from the edited file.
 - The process and results can be monitored in the [ProgressBoard](./progress-board.md).
 
 ## What Happens Behind the Scenes
 
-1. TeXRA sends both files to the selected AI model
+1. TeXRA sends both files to the configured helper model
 2. The model synthesizes a complete document preserving the Base File structure while incorporating Edited File changes
 3. TeXRA saves the result
 
 ## The Output: A Complete, Merged File
 
-The merge process generates a new file in task storage:
+The merge process generates a new file in task storage, named after the base file:
 
-`_full.tex`
+`r0/<base filename>.tex`
 
-This `_full` file contains the complete document content, incorporating the changes from the agent's output.
+This merged file contains the complete document content, incorporating the changes from the agent's output.
 
-**Crucially, this `_full.tex` file is now ready to be compared against your original `basename.tex` using the `latexdiff` command (either via the UI button or automatically if configured) to clearly visualize the changes the agent effectively made.**
+**Crucially, this merged file is now ready to be compared against your original `basename.tex` using the `latexdiff` command (either via the UI button or automatically if configured) to clearly visualize the changes the agent effectively made.**
 
 ## Next Steps
 
-- [LaTeX Diff](./latex-diff.md): Learn how to use `latexdiff` to compare the merged (`_full_`) file with your original.
+- [LaTeX Diff](./latex-diff.md): Learn how to use `latexdiff` to compare the merged file with your original.
 - [Built-in Agents](./built-in-agents.md): Review the agents whose outputs you might want to merge.

--- a/docs/guide/latex-diff.md
+++ b/docs/guide/latex-diff.md
@@ -11,7 +11,7 @@ A core design philosophy of TeXRA is transparency and control over the AI's modi
 
 <p class="hero-caption">Pick a base and an edited file (or a git commit), press latexdiff, and TeXRA compiles and opens the marked-up PDF — additions underlined in blue, deletions struck through in red.</p>
 
-TeXRA automatically generates diff files after agent runs that modify `.tex` files (like `correct` or `polish`), comparing the agent's task-storage output (`r0/output.tex` or `r1/output.tex`) against the original input or the previous round's output. This provides immediate observability into the agent's actions.
+TeXRA automatically generates diff files after agent runs that modify `.tex` files (like `correct` or `polish`), comparing the agent's task-storage output (e.g. `r0/intro.tex` or `r1/intro.tex` for an `intro.tex` input) against the original input or the previous round's output. This provides immediate observability into the agent's actions.
 
 This guide explains how to use TeXRA's dedicated LaTeXdiff features for comparing arbitrary file versions and understanding the results.
 
@@ -24,7 +24,7 @@ LaTeX versions.
 
 ### Controlling Between-Round Diffs
 
-TeXRA compares each round of agent output to your original input and can also create diffs between consecutive rounds (`_diff_rN-rM.tex`). Between-round diffs are disabled by default—enable them from the **Dashboard → LaTeX** tab (the `texra.latexdiff.generateBetweenRoundDiffs` setting in the VS Code extension). When left off, the run command and progress notifications only account for the original-vs-round comparisons, reducing the number of diff files created.
+TeXRA compares each round of agent output to your original input and can also create diffs between consecutive rounds (`_diffr1r0.tex` for the r0→r1 comparison). Between-round diffs are disabled by default—enable them from the **Dashboard → LaTeX** tab (the `texra.latexdiff.generateBetweenRoundDiffs` setting in the VS Code extension). When left off, the run command and progress notifications only account for the original-vs-round comparisons, reducing the number of diff files created.
 
 ### Focusing Diff PDFs on Changed Pages
 
@@ -103,17 +103,17 @@ The commit dropdown shows recent commits. Click the refresh icon (<wa-icon libra
 
 Click the **Diff** button (<wa-icon library="texra" name="diff-single"></wa-icon>) beneath the Commit dropdown to compare your file with its version at the selected commit.
 
-TeXRA runs the same five-stage pipeline shown above — only this route uses the `latexdiff-vc` tool and names its output with the commit hash (e.g., `original_diff_rev[commit_hash].tex`).
+TeXRA runs the same five-stage pipeline shown above — only this route uses the `latexdiff-vc` tool and names its output with the commit hash (e.g., `original-diff<commit_hash>.tex`).
 
 ### Step 3: Manage Diff Outputs
 
 After generating a Git-based diff using the **Diff** button beneath the Commit dropdown, you can manage the resulting files from the Commit section's **Pack** (<wa-icon library="texra" name="archive"></wa-icon>) and **Clean** (<wa-icon library="texra" name="trash"></wa-icon>) buttons. Pack archives the diff files; Clean removes them.
 
-Each diff route writes its own predictably-named artifacts alongside the source pair — `latexdiff` produces `_diff.tex`, `latexdiff-vc` appends the commit hash (`_diff_rev<hash>.tex`), and between-round runs use `_diff_rN-rM.tex` — and every `.tex` compiles to a matching `.pdf`. Pack and Clean act on this whole set:
+Each diff route writes its own predictably-named artifacts — `latexdiff` produces `_diff.tex` and `latexdiff-vc` appends the commit hash (`-diff<hash>.tex`), both alongside the base file, while agent runs write round (`_diff.tex`) and between-round (`_diffr<newer>r<older>.tex`) diffs into the run's task storage — and every `.tex` compiles to a matching `.pdf`. Pack and Clean act on the selected commit's diff files:
 
 <DiffArtifactsHero />
 
-<p class="hero-caption">The diff file-naming scheme grounded as one set — the base/edited source pair, then each generated diff (<code>latexdiff</code>, <code>latexdiff-vc</code> with its commit hash, and between-round) paired with its compiled PDF. The Pack and Clean buttons archive or remove the whole set.</p>
+<p class="hero-caption">The diff file-naming scheme grounded as one set — the base/edited source pair, then each generated diff (<code>latexdiff</code>, <code>latexdiff-vc</code> with its commit hash, and between-round) paired with its compiled PDF. The Pack and Clean buttons archive or remove the selected commit's diff files.</p>
 
 ## Understanding Diff Output
 

--- a/docs/guide/latex-tools.md
+++ b/docs/guide/latex-tools.md
@@ -126,7 +126,7 @@ The Wolfram card sits under **Dashboard → Tools → Computation** (<wa-icon li
 
 Control how TeXRA uses these tools from the UI:
 
-- **Tool Config Dropdown** (<wa-icon library="texra" name="tools"></wa-icon>): enable per-run helpers like **Attach TeX Count** (<wa-icon library="texra" name="symbol-numeric"></wa-icon>) or **Attach Diagnostics** (<wa-icon library="texra" name="tools"></wa-icon>). See [Configuration](./configuration.md#agent-execution-settings-webview-interface).
+- **Tool Config Dropdown** (<wa-icon library="texra" name="tools"></wa-icon>): toggle the **Attach TeX Count** (<wa-icon library="texra" name="symbol-numeric"></wa-icon>) per-run helper. See [Configuration](./configuration.md#agent-execution-settings-webview-interface).
 - **Auto Extract Dropdown** (<wa-icon library="texra" name="wand"></wa-icon>): toggle automatic extraction of Figures or TikZ Figures. See [Working with Figures](./working-with-figures.md).
 - **Dashboard → Tools** (<wa-icon library="texra" name="tools"></wa-icon>): enable/disable whole tool groups, view install guides, and run one-click installers.
 

--- a/docs/guide/lean.md
+++ b/docs/guide/lean.md
@@ -67,7 +67,7 @@ The built-in `lean` agent is always available. The **Lean Project** team adds a 
 | `leanBlueprint`    | Remote / Lean team | Building dependency-tracked LeanBlueprint LaTeX that bridges math ↔ Lean |
 | `leanOrchestrator` | Remote / Lean team | Coordinating a whole formalization project across the agents above       |
 
-To load the full set, open the **Multi-Agent** tab and select the **Lean Project** team. Formalizing a paper that's also part LaTeX? The **Mathematician** team bundles the `lean` agent alongside the LaTeX and research agents.
+To load the full set, open the **Teams** tab and select the **Lean Project** team. Formalizing a paper that's also part LaTeX? The **Mathematician** team bundles the `lean` agent alongside the LaTeX and research agents.
 
 ::: tip
 Pick any agent from the **Agent** dropdown (<wa-icon library="texra" name="sparkle"></wa-icon>). Check **Dashboard → Agents** (<wa-icon library="texra" name="sparkle"></wa-icon>) to see exactly which tools each one has enabled.

--- a/docs/guide/memory.md
+++ b/docs/guide/memory.md
@@ -65,7 +65,8 @@ The pinned indicator in the Dashboard is a blue left border plus a `Pinned` badg
 
 ## Managing memories from the Dashboard
 
-The Memory tab shows every saved note, sorted with the most recently updated first. For each note you get:
+The Memory tab shows every saved note, with pinned notes first and the rest sorted most recently
+updated. For each note you get:
 
 - **Path** — the canonical `/memories/...` location
 - **Metadata strip** — `Pinned · size · line count · updated · by <agent>`

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -21,15 +21,15 @@ TeXRA supports models from multiple providers. Select models from the dropdown i
 
 ## Anthropic Models
 
-| Model ID    | Use Case                                  | Cost | Speed  |
-| :---------- | :---------------------------------------- | :--- | :----- |
-| `fable5`    | Most capable, always-on adaptive thinking | $$$$ | Slow   |
-| `opus5T`    | Top-tier reasoning, long-horizon work     | $$$$ | Slow   |
-| `opus5`     | Most capable for agentic coding           | $$$$ | Slow   |
-| `sonnet5T`  | All-rounder with reasoning                | $$$  | Medium |
-| `sonnet5`   | Strong all-rounder                        | $$$  | Medium |
-| `haiku45T`  | Fast with reasoning                       | $$   | Fast   |
-| `haiku45`   | Fast responses                            | $$   | Fast   |
+| Model ID   | Use Case                                  | Cost | Speed  |
+| :--------- | :---------------------------------------- | :--- | :----- |
+| `fable5`   | Most capable, always-on adaptive thinking | $$$$ | Slow   |
+| `opus5T`   | Top-tier reasoning, long-horizon work     | $$$$ | Slow   |
+| `opus5`    | Most capable for agentic coding           | $$$$ | Slow   |
+| `sonnet5T` | All-rounder with reasoning                | $$$  | Medium |
+| `sonnet5`  | Strong all-rounder                        | $$$  | Medium |
+| `haiku45T` | Fast with reasoning                       | $$   | Fast   |
+| `haiku45`  | Fast responses                            | $$   | Fast   |
 
 Fable 5, Opus 5, and Sonnet 5 include the full 1M context window at standard pricing — no opt-in or
 beta header required. Other Claude models use a 200K context window.
@@ -40,13 +40,13 @@ Claude Opus 5 uses adaptive thinking only (extended thinking with a manual `budg
 
 ## OpenAI Models
 
-| Model ID    | Use Case                          | Cost | Speed  |
-| :---------- | :-------------------------------- | :--- | :----- |
-| `gpt56pro`  | Pro reasoning mode, 1M context    | $$$$ | Slow   |
-| `gpt56`     | Flagship reasoning, 1M context    | $$$$ | Medium |
-| `gpt56fast` | Flagship, fast variant            | $$$$ | Fast   |
-| `gpt56-`    | Lower-cost reasoning              | $$$  | Fast   |
-| `gpt56--`   | Budget reasoning                  | $    | Fast   |
+| Model ID    | Use Case                       | Cost | Speed  |
+| :---------- | :----------------------------- | :--- | :----- |
+| `gpt56pro`  | Pro reasoning mode, 1M context | $$$$ | Slow   |
+| `gpt56`     | Flagship reasoning, 1M context | $$$$ | Medium |
+| `gpt56fast` | Flagship, fast variant         | $$$$ | Fast   |
+| `gpt56-`    | Lower-cost reasoning           | $$$  | Fast   |
+| `gpt56--`   | Budget reasoning               | $    | Fast   |
 
 GPT-5.6 Sol (`gpt56`) is OpenAI's current flagship reasoning model; TeXRA pins the
 [Codex integration](./agent-integrations.md#openai-codex) to `gpt-5.5`. GPT-5.6 Pro (`gpt56pro`)
@@ -91,9 +91,9 @@ GPT-5 reasoning summaries require account verification. Enable with `texra.model
 
 ## MiniMax Models
 
-| Model ID    | Use Case                                        | Cost | Speed  |
-| :---------- | :---------------------------------------------- | :--- | :----- |
-| `minimaxM3` | Flagship with interleaved thinking, 1M context  | $    | Medium |
+| Model ID    | Use Case                                       | Cost | Speed  |
+| :---------- | :--------------------------------------------- | :--- | :----- |
+| `minimaxM3` | Flagship with interleaved thinking, 1M context | $    | Medium |
 
 MiniMax uses interleaved thinking (chain-of-thought woven into responses). API keys are region-specific — international keys (api.minimax.io) and China keys (api.minimaxi.com) are not interchangeable. Toggle the region in the Models tab.
 
@@ -103,11 +103,11 @@ MiniMax uses interleaved thinking (chain-of-thought woven into responses). API k
 
 ## GLM (Zhipu AI / Z.AI) Models
 
-| Model ID      | Use Case                        | Cost | Speed  |
-| :------------ | :------------------------------ | :--- | :----- |
-| `glm52`       | Flagship open-source model      | $$   | Medium |
-| `glm5turbo`   | Fast inference, agent-optimized | $$$  | Medium |
-| `glm5vturbo`  | Multimodal vision model         | $$   | Medium |
+| Model ID     | Use Case                        | Cost | Speed  |
+| :----------- | :------------------------------ | :--- | :----- |
+| `glm52`      | Flagship open-source model      | $$   | Medium |
+| `glm5turbo`  | Fast inference, agent-optimized | $$$  | Medium |
+| `glm5vturbo` | Multimodal vision model         | $$   | Medium |
 
 GLM models support thinking mode (reasoning is shown inline). The API uses a non-standard base path (`/api/paas/v4`), which TeXRA handles automatically.
 

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -26,12 +26,13 @@ TeXRA supports models from multiple providers. Select models from the dropdown i
 | `fable5`    | Most capable, always-on adaptive thinking | $$$$ | Slow   |
 | `opus5T`    | Top-tier reasoning, long-horizon work     | $$$$ | Slow   |
 | `opus5`     | Most capable for agentic coding           | $$$$ | Slow   |
-| `sonnet46T` | All-rounder with reasoning                | $$$  | Medium |
-| `sonnet46`  | Strong all-rounder                        | $$$  | Medium |
+| `sonnet5T`  | All-rounder with reasoning                | $$$  | Medium |
+| `sonnet5`   | Strong all-rounder                        | $$$  | Medium |
 | `haiku45T`  | Fast with reasoning                       | $$   | Fast   |
 | `haiku45`   | Fast responses                            | $$   | Fast   |
 
-Fable 5, Opus 5, and Sonnet 4.6 include the full 1M context window at standard pricing — no opt-in or beta header required. Other Claude models use a 200K context window.
+Fable 5, Opus 5, and Sonnet 5 include the full 1M context window at standard pricing — no opt-in or
+beta header required. Other Claude models use a 200K context window.
 
 Claude Fable 5 (`fable5`) is Anthropic's most capable model. Thinking is always on — adaptive, with summarized reasoning — so there is no separate `T` variant. It supports the full reasoning-effort range up to Extra High and the top Max tier, and is eligible for context compaction in tool-use mode.
 
@@ -39,15 +40,23 @@ Claude Opus 5 uses adaptive thinking only (extended thinking with a manual `budg
 
 ## OpenAI Models
 
-| Model ID   | Use Case                       | Cost  | Speed  |
-| :--------- | :----------------------------- | :---- | :----- |
-| `gpt55pro` | Top-tier reasoning, 1M context | $$$$$ | Slow   |
-| `gpt55`    | Flagship reasoning             | $$$$  | Medium |
-| `gpt54`    | Mid-tier reasoning             | $$$   | Medium |
-| `gpt54-`   | Lower-cost reasoning           | $$    | Fast   |
-| `gpt54--`  | Budget reasoning               | $     | Fast   |
+| Model ID    | Use Case                          | Cost | Speed  |
+| :---------- | :-------------------------------- | :--- | :----- |
+| `gpt56pro`  | Pro reasoning mode, 1M context    | $$$$ | Slow   |
+| `gpt56`     | Flagship reasoning, 1M context    | $$$$ | Medium |
+| `gpt56fast` | Flagship, fast variant            | $$$$ | Fast   |
+| `gpt56-`    | Lower-cost reasoning              | $$$  | Fast   |
+| `gpt56--`   | Budget reasoning                  | $    | Fast   |
 
-GPT-5.5 is OpenAI's latest flagship and the model TeXRA pins the [Codex integration](./agent-integrations.md#openai-codex) to. GPT-5.5 Pro (`gpt55pro`) extends GPT-5.5 with a 1.05M context window and `xhigh` default reasoning for the hardest planning and long-horizon tasks, at premium pricing — it is hidden by default; enable it from Settings → Models when you need it. The GPT Pro variants (`gpt5pro`, `gpt52pro`, `gpt55pro`) charge $15-$30 per 1M input and $120-$180 per 1M output, so for one-off hard questions consider enabling the `inquiry` tool and pasting the answer from your own ChatGPT subscription instead of running a full agent turn against the API. `gpt54` and its mini/nano variants remain the lower-cost option for most workloads. See the [API reference](https://developers.openai.com/api/docs) for full capabilities.
+GPT-5.6 Sol (`gpt56`) is OpenAI's current flagship reasoning model; TeXRA pins the
+[Codex integration](./agent-integrations.md#openai-codex) to `gpt-5.5`. GPT-5.6 Pro (`gpt56pro`)
+runs the same model in the Responses API's pro reasoning mode — billed at standard token rates
+rather than a premium tier — for the hardest planning and long-horizon tasks; it is hidden by
+default, so enable it from Settings → Models when you need it. For one-off hard questions you can
+also enable the `inquiry` tool and paste the answer from your own ChatGPT subscription instead of
+running a full agent turn against the API. `gpt56-` (Terra) and `gpt56--` (Luna) are the lower-cost
+options for most workloads. See the [API reference](https://developers.openai.com/api/docs) for
+full capabilities.
 
 GPT-5 reasoning summaries require account verification. Enable with `texra.model.gpt5ReasoningSummary`.
 
@@ -56,7 +65,7 @@ GPT-5 reasoning summaries require account verification. Enable with `texra.model
 | Model ID    | Use Case                       | Cost | Speed  |
 | :---------- | :----------------------------- | :--- | :----- |
 | `gemini31p` | Pro with reasoning, 1M context | $$$  | Medium |
-| `gemini35f` | Flash model with 1M context    | $$   | Fast   |
+| `gemini36f` | Flash model with 1M context    | $$   | Fast   |
 
 ## DeepSeek Models
 
@@ -66,14 +75,13 @@ GPT-5 reasoning summaries require account verification. Enable with `texra.model
 | `deepseekT`    | V4 Flash with reasoning | $    | Medium |
 | `deepseekpro`  | V4 Pro chat mode        | $    | Medium |
 | `deepseekproT` | V4 Pro with reasoning   | $    | Medium |
-| `dsr1`         | Advanced reasoning      | $$   | Medium |
 
 ## Moonshot Kimi Models
 
-| Model ID  | Use Case                | Cost | Speed  |
-| :-------- | :---------------------- | :--- | :----- |
-| `kimi26T` | K2.6 with thinking mode | $$$  | Medium |
-| `kimi26`  | K2.6, agent tasks       | $$$  | Medium |
+| Model ID  | Use Case                     | Cost | Speed  |
+| :-------- | :--------------------------- | :--- | :----- |
+| `kimi3`   | K3 flagship, 1M context      | $$$  | Medium |
+| `kimi26T` | K2.6 with thinking mode      | $$$  | Medium |
 
 ## DashScope Qwen Models
 
@@ -84,10 +92,9 @@ GPT-5 reasoning summaries require account verification. Enable with `texra.model
 
 ## MiniMax Models
 
-| Model ID     | Use Case                           | Cost | Speed  |
-| :----------- | :--------------------------------- | :--- | :----- |
-| `minimaxM27` | Flagship with interleaved thinking | $$   | Medium |
-| `minimaxM25` | Strong all-rounder                 | $$   | Medium |
+| Model ID    | Use Case                                        | Cost | Speed  |
+| :---------- | :---------------------------------------------- | :--- | :----- |
+| `minimaxM3` | Flagship with interleaved thinking, 1M context  | $    | Medium |
 
 MiniMax uses interleaved thinking (chain-of-thought woven into responses). API keys are region-specific — international keys (api.minimax.io) and China keys (api.minimaxi.com) are not interchangeable. Toggle the region in the Models tab.
 
@@ -97,13 +104,11 @@ MiniMax uses interleaved thinking (chain-of-thought woven into responses). API k
 
 ## GLM (Zhipu AI / Z.AI) Models
 
-| Model ID    | Use Case                             | Cost | Speed  |
-| :---------- | :----------------------------------- | :--- | :----- |
-| `glm5`      | Flagship open-source model           | $$$  | Medium |
-| `glm5turbo` | Fast inference, agent-optimized      | $$$  | Medium |
-| `glm47`     | Programming and multi-step reasoning | $$   | Medium |
-| `glm46v`    | Multimodal vision model              | $$   | Medium |
-| `glm45`     | Hybrid reasoning (MoE)               | $$   | Medium |
+| Model ID      | Use Case                        | Cost | Speed  |
+| :------------ | :------------------------------ | :--- | :----- |
+| `glm52`       | Flagship open-source model      | $$   | Medium |
+| `glm5turbo`   | Fast inference, agent-optimized | $$$  | Medium |
+| `glm5vturbo`  | Multimodal vision model         | $$   | Medium |
 
 GLM models support thinking mode (reasoning is shown inline). The API uses a non-standard base path (`/api/paas/v4`), which TeXRA handles automatically.
 
@@ -126,11 +131,9 @@ developers.
 
 ## Grok / xAI Models
 
-| Model ID | Use Case                        | Cost | Speed  |
-| :------- | :------------------------------ | :--- | :----- |
-| `grok4`  | Large context (256k), reasoning | $$$  | Medium |
-| `grok3`  | Large context (131k)            | $$$  | Medium |
-| `grok2v` | Vision-enabled                  | $$   | Medium |
+| Model ID | Use Case           | Cost | Speed  |
+| :------- | :----------------- | :--- | :----- |
+| `grok45` | Reasoning + vision | $$$  | Medium |
 
 ## Choosing a Model
 
@@ -143,7 +146,7 @@ developers.
 ### Subscription-backed models in VS Code
 
 The VS Code extension can also use compatible models from a GitHub Copilot
-subscription. Open **Settings → Models → Copilot in VS Code**, then choose
+subscription. Open **Settings → Subscriptions → Copilot in VS Code**, then choose
 **Grant access**. VS Code presents its own consent prompt; TeXRA never asks for
 or stores a Copilot API key.
 

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -52,7 +52,7 @@ GPT-5.6 Sol (`gpt56`) is OpenAI's current flagship reasoning model; TeXRA pins t
 [Codex integration](./agent-integrations.md#openai-codex) to `gpt-5.5`. GPT-5.6 Pro (`gpt56pro`)
 runs the same model in the Responses API's pro reasoning mode — billed at standard token rates
 rather than a premium tier — for the hardest planning and long-horizon tasks; it is hidden by
-default, so enable it from Settings → Models when you need it. For one-off hard questions you can
+default, so enable it from Settings → Providers & Models when you need it. For one-off hard questions you can
 also enable the `inquiry` tool and paste the answer from your own ChatGPT subscription instead of
 running a full agent turn against the API. `gpt56-` (Terra) and `gpt56--` (Luna) are the lower-cost
 options for most workloads. See the [API reference](https://developers.openai.com/api/docs) for

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -78,10 +78,9 @@ GPT-5 reasoning summaries require account verification. Enable with `texra.model
 
 ## Moonshot Kimi Models
 
-| Model ID  | Use Case                     | Cost | Speed  |
-| :-------- | :--------------------------- | :--- | :----- |
-| `kimi3`   | K3 flagship, 1M context      | $$$  | Medium |
-| `kimi26T` | K2.6 with thinking mode      | $$$  | Medium |
+| Model ID | Use Case                | Cost | Speed  |
+| :------- | :---------------------- | :--- | :----- |
+| `kimi3`  | K3 flagship, 1M context | $$$  | Medium |
 
 ## DashScope Qwen Models
 

--- a/docs/guide/open-source.md
+++ b/docs/guide/open-source.md
@@ -10,11 +10,11 @@ TeXRA is built on the belief that great research tools benefit from community co
 [![GitHub](https://img.shields.io/github/stars/texra-ai/llm-zoo)](https://github.com/texra-ai/llm-zoo)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/texra-ai/llm-zoo/blob/main/LICENSE)
 
-Keeping track of LLM pricing, context windows, and capabilities across providers is a moving target. **llm-zoo** solves this by providing a single, typed, zero-dependency package covering 70+ models from Claude, GPT, Gemini, DeepSeek, Grok, and more.
+Keeping track of LLM pricing, context windows, and capabilities across providers is a moving target. **llm-zoo** solves this by providing a single, typed, zero-dependency package covering 100+ models from Claude, GPT, Gemini, DeepSeek, Grok, and more.
 
 ### Highlights
 
-- **70+ models** across Anthropic, OpenAI, Google, DeepSeek, xAI, Moonshot, DashScope, Copilot, and OpenRouter
+- **100+ models** across Anthropic, OpenAI, Google, GLM, DeepSeek, MiniMax, xAI, Moonshot, Meta, DashScope, Copilot, and OpenRouter
 - **Zero dependencies** — lightweight with full TypeScript support
 - **Tree-shakeable** for efficient bundling
 - **Zod schemas** for runtime validation (Zod v4)
@@ -30,15 +30,14 @@ npm install llm-zoo
 import { lookup, cost, from, cheapest, ModelProvider } from 'llm-zoo';
 
 // Look up a model
-const claude = lookup('sonnet');
-console.log(claude.contextWindow); // 200000
+const claude = lookup('sonnet5');
+console.log(claude.contextWindow); // 1000000
 
 // Calculate cost
-const usage = { inputTokens: 1000, outputTokens: 500 };
-console.log(cost('sonnet', usage)); // { input: 0.003, output: 0.0075, total: 0.0105 }
+const price = cost('sonnet5', { input: 1000, output: 500 }); // 0.007
 
 // Find the cheapest model with vision support
-const model = cheapest({ capabilities: ['vision'] });
+const model = cheapest({ supportsVision: true });
 
 // Filter by provider
 const anthropicModels = from(ModelProvider.ANTHROPIC);

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -23,7 +23,7 @@ Agent Execution History** in VS Code.
 
 ## Accessing the ProgressBoard
 
-The ProgressBoard shares the **TeXRA view** in the Activity Bar with the launcher — click the TeXRA icon in the Activity Bar, then switch to the Progress view.
+The ProgressBoard shares the **TeXRA view** with the launcher — click the TeXRA icon in the Secondary Side Bar, then switch to the Progress view.
 
 - **Automatic**: It often opens automatically when you execute an agent.
 - **Manual**: Open it from the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`) with **TeXRA: Show Progress**, or press `Ctrl+Alt+P` (`Cmd+Option+P` on macOS).
@@ -44,10 +44,9 @@ The ProgressBoard interface is split into two main sections (usually side-by-sid
 
 This section lists all the agent execution streams from your current VS Code session.
 
-- **Switching Streams**: Click on a stream name (e.g., `polish@sonnet46: paper.tex`) to view its specific logs and status in the Content Area.
-- **Delete All**: The <wa-icon library="texra" name="trash"></wa-icon> **Delete All** button at the bottom permanently removes all streams and their logs from the ProgressBoard view for the current session.
+- **Switching Streams**: Click on a stream name (e.g., `polish: paper.tex`) to view its specific logs and status in the Content Area.
+- **Removing a Stream**: Each tab has an <wa-icon library="texra" name="xmark"></wa-icon> button that removes that stream and its logs from the ProgressBoard view.
 - **Metadata**: Tabs display the model and when the stream was last active on a second line. Icons indicate the agent type and if multiple output files were generated.
-- **Sorting**: Use the buttons below the tab list to order streams by time, input file, or agent name. The chosen order is saved for the workspace.
 
 ## Content Area
 
@@ -58,16 +57,17 @@ This area shows the details for the stream selected in the Stream Tabs section.
 The header provides a summary and actions for the selected stream:
 
 - **Stream Name**: Displays the identifier of the current run.
-  Workflow agents use the familiar `agent@model: inputFile` format.
+  Workflow agents show `agent: inputFile` so parallel runs are easy to tell apart.
   Tool-use sessions show just the agent name so they stand alone even without an associated input file.
+  The model rides on the second line of the tab.
 - **Status Indicator**: A colored circle shows the current status — the four states read at a glance:
 
 <StatusDotLegend />
 
-<p class="hero-caption">The status dot: only the running state pulses; stopped, error, and ready are static.</p>
+<p class="hero-caption">The status dot: green while running, blue while waiting for input, grey once finished, red on error.</p>
 
 - **Token & Cost Summary**: Displays the combined input and output token counts from all completed rounds (e.g., `r0`, `r1`, `r2`, …) along with the estimated cost.
-- **Stream Header Actions**: A toolbar of icon buttons acting on the selected stream, in order — Stop, Run Again, Restore, Diff, Accept, Open in task storage, Pack, Clean, and Erase.
+- **Stream Header Actions**: A toolbar of icon buttons acting on the selected stream. Workflow streams get Stop, Run New, Resume, Restore, Open in task storage, Diff, Clean, and Pack; tool-use streams get Stop, YOLO, agent-work approval, Compact, Restore, and Open in task storage.
 
 <StreamHeaderActions />
 
@@ -75,18 +75,20 @@ The header provides a summary and actions for the selected stream:
 
 Each action in detail:
 
-- <wa-icon library="texra" name="debug-stop"></wa-icon> **Stop**: Attempts to gracefully stop the currently running task for this stream. For providers supporting `AbortController` (like OpenAI or Anthropic) the active request is aborted immediately; otherwise the current API call will finish before stopping.
-- <wa-icon library="texra" name="debug-rerun"></wa-icon> **Run Again**: Re-runs the task associated with this stream using the _exact same configuration_ (agent, model, files, instruction) that was used when it originally ran. Useful for retrying failed tasks or reproducing results.
+- <wa-icon library="texra" name="circle-stop"></wa-icon> **Stop**: Attempts to gracefully stop the currently running task for this stream. For providers supporting `AbortController` (like OpenAI or Anthropic) the active request is aborted immediately; otherwise the current API call will finish before stopping.
+- <wa-icon library="texra" name="play"></wa-icon> **Run New**: Starts a fresh run of the task associated with this stream using the _exact same configuration_ (agent, model, files, instruction), discarding previous outputs. Useful for retrying failed tasks or reproducing results.
+- <wa-icon library="texra" name="forward-step"></wa-icon> **Resume**: Continues the run from its saved outputs, picking up where it left off instead of starting over.
 - <wa-icon library="texra" name="reply"></wa-icon> **Restore**: Loads the configuration (agent, model, files, instruction) from this stream back into the main TeXRA webview interface. This allows you to easily modify and re-run a previous task.
-- <wa-icon library="texra" name="diff-multiple"></wa-icon> **Diff**: Triggers the `latexdiff` process to compare the original input file(s) with the generated output `.tex` file(s) from this stream. If no base file was selected, TeXRA automatically falls back to the original file. Requires `latexdiff` to be installed. See [LaTeX Diff](./latex-diff.md).
-- <wa-icon library="texra" name="check"></wa-icon> **Accept**: After reviewing a diff, replace the base file with the edited version.
-- <wa-icon library="texra" name="folder-opened"></wa-icon> **Open in task storage**:
+- <wa-icon library="texra" name="code-compare"></wa-icon> **Diff**: Triggers the `latexdiff` process to compare the original input file(s) with the generated output `.tex` file(s) from this stream. If no base file was selected, TeXRA automatically falls back to the original file. Requires `latexdiff` to be installed. See [LaTeX Diff](./latex-diff.md).
+- <wa-icon library="texra" name="folder-open"></wa-icon> **Open in task storage**:
   Reveals the run folder under task-run storage so you can browse generated
   files, compile logs, mirrored dependencies, and intermediate artifacts
   manually.
-- <wa-icon library="texra" name="archive"></wa-icon> **Pack**: Archives the output files and log for this stream into the `History` folder. See [File Management](./file-management.md).
+- <wa-icon library="texra" name="box-archive"></wa-icon> **Pack**: Archives the output files and log for this stream into the `History` folder. See [File Management](./file-management.md).
 - <wa-icon library="texra" name="trash"></wa-icon> **Clean**: Deletes the task storage folder associated with this stream.
-- <wa-icon library="texra" name="clear-all"></wa-icon> **Erase**: Removes this stream and its log content entirely from the ProgressBoard.
+
+Reviewed outputs are accepted per file: each row under **Generated Files** has
+an **Accept** action that copies the edited version into your workspace.
 
 ### YOLO Mode
 
@@ -115,7 +117,7 @@ The followup picks up right where the previous run left off - no need to re-sele
 
 ### Memory
 
-Tool-use agents can remember things between sessions. When memory is enabled (toggle in the toolbar), agents save useful notes about your project. You can browse, pin, and delete these notes from the **Memory** tab in the Dashboard, or by running **TeXRA: Show Memory** from the Command Palette. See the [Memory guide](./memory.md) for a full walkthrough.
+Tool-use agents can remember things between sessions. When memory is enabled (toggle in the Dashboard's **Memory** tab), agents save useful notes about your project. You can browse, pin, and delete these notes from the **Memory** tab in the Dashboard, or by running **TeXRA: Show Memory** from the Command Palette. See the [Memory guide](./memory.md) for a full walkthrough.
 
 ### Log Content
 
@@ -131,7 +133,3 @@ This scrollable area displays the detailed, timestamped logs for the selected ag
 <p class="hero-caption">The log: each row is color-keyed by severity — green for info/success, yellow for warnings, red for errors — with expandable nested detail and per-task IDs.</p>
 
 Understanding the log content is key to diagnosing problems and seeing how TeXRA and the AI models process your requests. Refer to the [Troubleshooting](./troubleshooting.md) guide for more tips on using logs.
-
-At the bottom of the tab list, there is a "Delete All" button (<wa-icon library="texra" name="close-all"></wa-icon>) that allows you to clear all streams and their associated logs from the ProgressBoard view.
-Above the sorter, the **All / Workflow / Tool Use** buttons let you focus the tab list on specific agent types.
-Next to "Delete All" are sorting buttons (<wa-icon library="texra" name="clock"></wa-icon>, <wa-icon library="texra" name="file"></wa-icon>, <wa-icon library="texra" name="account"></wa-icon>) for ordering the tabs.

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -45,15 +45,15 @@ TeXRA panel offers the main access choices:
 1. **Sign in — free for academics** — Researcher Access: no API key needed (recommended). Run **TeXRA: Sign In**
    from the Command Palette, or pick the sign-in option on the welcome card. Signing in also unlocks remote
    agents, including the orchestrator.
-2. **Use ChatGPT subscription** — Codex models through your ChatGPT plan. Open the Dashboard's **Models** tab
-   (the <wa-icon library="texra" name="settings-gear"></wa-icon> gear icon at the top of the TeXRA panel) and
+2. **Use ChatGPT subscription** — Codex models through your ChatGPT plan. Open the Dashboard's **Subscriptions**
+   tab (the <wa-icon library="texra" name="settings-gear"></wa-icon> gear icon at the top of the TeXRA panel) and
    use the **ChatGPT subscription** sign-in section.
-3. **Use GitHub Copilot in VS Code** — compatible models through a Copilot subscription. Open **Models →
+3. **Use GitHub Copilot in VS Code** — compatible models through a Copilot subscription. Open **Subscriptions →
    Copilot in VS Code** and grant access through VS Code's native consent prompt. This source does not appear in
    the CLI or desktop applications.
-4. **Use your own provider API key** — Anthropic, OpenAI, Google, and more. In the same **Models** tab, set your
-   provider's key in the **API Configuration** table, or place a `.env` file in your workspace with variables
-   like `OPENAI_API_KEY`.
+4. **Use your own provider API key** — Anthropic, OpenAI, Google, and more. Open the **Providers & Models** tab
+   and set your provider's key in the **API Configuration** table, or place a `.env` file in your workspace with
+   variables like `OPENAI_API_KEY`.
 
 The full per-provider key reference — the API Configuration table, Set / Get / Remove actions, and per-provider toggles — lives in [Models → Setting API Keys](./models.md#setting-api-keys).
 
@@ -94,7 +94,7 @@ Each category holds an ordered list — add as many files as the task needs and 
 ### Choose Agent, Model, and Instruction
 
 The dropdown menus at the bottom of the instruction box pick the agent
-(e.g. `polish` for improving writing) and the model (e.g. `sonnet46`).
+(e.g. `polish` for improving writing) and the model (e.g. `sonnet5`).
 Then write a specific instruction in the text area:
 
 ```
@@ -125,7 +125,7 @@ Reflection rounds are controlled by the selected agent—most writing agents alr
 <p class="hero-caption">The two helper menus in the Input and Media file-group headers. Active helpers tint their buttons; here Attach TeX Count and Figures are on.</p>
 
 ::: tip Save Prompts for Later
-For advanced debugging, enable the `texra.debug.saveModelIO` setting (in `.texra/config.json` or VS Code settings) to store the generated prompt alongside other debug artifacts.
+For advanced debugging, enable the `texra.debug.saveModelIO` setting in `.texra/config.json` to store the generated prompt alongside other debug artifacts.
 :::
 
 ### Execute and Watch the Run
@@ -193,7 +193,7 @@ texra chat
     { label: 'r0 — draft revision', state: 'done' },
     { label: 'r1 — critique and revise', state: 'done' },
   ]"
-  :outputs="['.texra/runs/9f3a6c81d24e/r1/draft.tex']"
+  :outputs="['executions/9f3a6c81d24e/r1/draft.tex']"
 />
 
 <p class="hero-caption">What a one-shot run looks like: rounds stream as progress, then the path to the revised document prints on stdout.</p>
@@ -307,7 +307,8 @@ folder per round. Each round holds three artifacts, and the document keeps your
 
 So if your input file is `paper.tex`, the first round's output lands at
 `r0/paper.tex` — the filename you started with, never `output.tex`. The CLI
-writes the same per-round tree under `.texra/runs/<run-id>/` — see
+writes the same per-round tree under `executions/<run-id>/` in the
+workspace store — see
 [First run](./first-run.md) for the terminal walkthrough.
 
 ## Next Steps

--- a/docs/guide/remote-agents.md
+++ b/docs/guide/remote-agents.md
@@ -47,7 +47,7 @@ The selected agent will appear in your main TeXRA view alongside your built-in a
 
 Remote agents work just like built-in agents:
 
-1. Open the TeXRA view (click the TeXRA icon in the Activity Bar)
+1. Open the TeXRA view (click the TeXRA icon in the Secondary Side Bar)
 2. Select your remote agent from the agent dropdown
 3. Choose your input file and model
 4. Click **Run** to execute the agent

--- a/docs/guide/remote-agents.md
+++ b/docs/guide/remote-agents.md
@@ -22,7 +22,7 @@ To access remote agents, you need a TeXRA account:
 
 1. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
 2. Run the command: **TeXRA: Sign In**
-3. Choose your preferred sign-in method (GitHub, Google, or GitLab)
+3. Choose your preferred sign-in method (GitHub or Google)
 4. Complete the authentication flow in your browser
 5. Return to VS Code once authenticated
 
@@ -39,7 +39,7 @@ Once signed in, you can explore remote agents from the Agents tab:
 3. Select any remote agent in the list to see its details
 4. Click **Show in agent selector** to add it to your agent selector
 
-Your account at a glance — your email and access level — sits on the Account tab (**TeXRA: View Profile**).
+Your account at a glance — your email and access level — sits on the Account & Usage tab (**TeXRA: View Profile**).
 
 The selected agent will appear in your main TeXRA view alongside your built-in agents.
 
@@ -70,13 +70,13 @@ In the agent dropdown, your local agents sit above a **Remote** group whose entr
     ] },
     { label: 'Remote', items: [
       { name: 'search', icon: 'cloud', badge: 'in use', badgeVariant: 'accent', active: true },
-      { name: 'discuss', icon: 'cloud' },
       { name: 'simplifier', icon: 'cloud' },
+      { name: 'orchestrator', icon: 'cloud' },
     ] },
   ]"
 />
 
-<p class="hero-caption">The agent dropdown: remote agents (<code>search</code>, <code>discuss</code>, <code>simplifier</code>) carry a cloud marker that sets them apart from local agents like <code>polish</code> and <code>correct</code>.</p>
+<p class="hero-caption">The agent dropdown: remote agents (<code>search</code>, <code>simplifier</code>, <code>orchestrator</code>) carry a cloud marker that sets them apart from local agents like <code>polish</code> and <code>correct</code>.</p>
 
 None of this is VS Code-only — the whole loop works from a terminal too:
 
@@ -105,7 +105,7 @@ The **Researcher Access Program** provides access to specialized remote agents d
 
 <p class="hero-caption">What Researcher Access Program members get: domain-specific agents, advanced multi-step reasoning, early access to beta agents, and a direct line into how agents evolve.</p>
 
-Current remote agents include `search` (literature discovery), `discuss` (academic brainstorming with literature), and `simplifier` (code and writing simplification). See [Built-in Agents — Remote Agents](./built-in-agents.md#remote-agents) for details on each.
+Current remote agents include `search` (literature discovery), `simplifier` (code and writing simplification), and `orchestrator` (multi-agent coordination). See [Built-in Agents — Remote Agents](./built-in-agents.md#remote-agents) for details on each.
 
 Different agents may be available to different research groups based on their domain and needs.
 
@@ -133,7 +133,7 @@ Check your account status:
 
 1. Open Command Palette
 2. Run: **TeXRA: View Profile**
-3. View your email and access level on the Account tab
+3. View your email and access level on the Account & Usage tab
 
 Run **TeXRA: Show Agents** to browse the remote agents available to you.
 

--- a/docs/guide/research-tools.md
+++ b/docs/guide/research-tools.md
@@ -74,7 +74,7 @@ The `web_search` tool prefers the active provider's native search (Anthropic, Op
 
 ### <wa-icon library="texra" name="book"></wa-icon> Manage References with Zotero
 
-If you use [Zotero](https://www.zotero.org/) with the [Better BibTeX](https://retorque.re/zotero-better-bibtex/) plugin, TeXRA can search, export, and add items to your library directly. Make sure Zotero is running while you use these features — check status on **Dashboard → Integrations** (<wa-icon library="texra" name="robot"></wa-icon>).
+If you use [Zotero](https://www.zotero.org/) with the [Better BibTeX](https://retorque.re/zotero-better-bibtex/) plugin, TeXRA can search, export, and add items to your library directly. Make sure Zotero is running while you use these features — check status on **Dashboard → Integrations** (<wa-icon library="texra" name="link"></wa-icon>).
 
 ```
 Search my Zotero library for papers by Vaswani on attention mechanisms.
@@ -103,7 +103,7 @@ Add this arXiv paper to my Zotero library.
 <p class="hero-caption">How the <code>search</code> agent drives the <code>zotero_*</code> tools across one conversation — search → add → export — as the calls surface in the Progress view.</p>
 
 ::: tip Default Bibliography Path
-Set a default location for Zotero exports so agents always know where to save bibliography entries. The setting key is `texra.bib.defaultPath` — configure it in your `.texra/config.json` (CLI) or VS Code settings.
+Set a default location for Zotero exports so agents always know where to save bibliography entries. The setting key is `texra.bib.defaultPath` — configure it in your `.texra/config.json`.
 :::
 
 ### <wa-icon library="texra" name="symbol-operator"></wa-icon> Verify Math with Wolfram
@@ -120,7 +120,7 @@ The `inquiry` tool lets a TeXRA agent ask one question in an external chat (Chat
 
 ## Which Agent to Use
 
-Three research agents, each tuned for a different stage of the work — pick one from the **Agent** dropdown (<wa-icon library="texra" name="sparkle"></wa-icon>):
+Two research agents, each tuned for a different stage of the work — pick one from the **Agent** dropdown (<wa-icon library="texra" name="sparkle"></wa-icon>):
 
 <DropdownMenu
   label="Agent"
@@ -130,7 +130,6 @@ Three research agents, each tuned for a different stage of the work — pick one
   :groups="[{ label: 'Research', items: [
     { name: 'search', icon: 'mortar-board', badge: 'tool-use', badgeVariant: 'info', active: true },
     { name: 'research', icon: 'symbol-operator', badge: 'tool-use', badgeVariant: 'info' },
-    { name: 'discuss', icon: 'comment-discussion', badge: 'tool-use', badgeVariant: 'info' },
   ] }]"
 />
 
@@ -150,11 +149,6 @@ Three research agents, each tuned for a different stage of the work — pick one
       { text: 'file-edit', variant: 'neutral' },
       { text: 'texcount', variant: 'neutral' },
       { text: 'extract_figures', variant: 'neutral' },
-    ] },
-    { icon: 'comment-discussion', title: 'discuss', desc: 'Brainstorming research directions with literature context.', chips: [
-      { text: 'web_search', variant: 'neutral' },
-      { text: 'arxiv_metadata', variant: 'neutral' },
-      { text: 'inquiry', variant: 'neutral' },
     ] },
   ]"
 />

--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -213,8 +213,8 @@ texra multi-agent run software-engineer --instruction "Profile and speed up scri
 
 `run` starts the team's orchestrator, which plans the work and delegates to its
 specialists. For example, the Software Engineer team's `engineer` lead delegates
-to `coder`, `codeReviewer`, `testEngineer`, `codeSimplifier`, and
-`progressCheck`. Pass `--input` and `--context` files as with `texra run`;
+to `coder`, `codeReviewer`, `testEngineer`, and `codeSimplifier`. Pass `--input`
+and `--context` files as with `texra run`;
 read-only context files are included in the instruction the team receives.
 
 <CliMultiAgentHero />
@@ -374,19 +374,19 @@ defaults.
 
 <ConfigPrecedenceStack />
 
-<p class="hero-caption">Resolution order, highest priority on top: a CLI flag beats its <code>TEXRA_*</code> env var, which beats the <code>.texra/config.json</code> key, which beats the built-in default (<code>deepseekT</code>).</p>
+<p class="hero-caption">Resolution order, highest priority on top: a CLI flag beats its <code>TEXRA_*</code> env var, which beats the <code>.texra/config.json</code> key, which beats the built-in default (<code>deepseekproT</code>).</p>
 
 ```json
 {
-  "texra.model": "deepseekT",
+  "texra.model": "deepseekproT",
   "texra.outputFormat": "text",
   "texra.approvalPolicy": "never",
   "texra.chat": {
     "agent": "assistant",
-    "model": "deepseekT"
+    "model": "deepseekproT"
   },
   "texra.run": {
-    "model": "deepseekT"
+    "model": "deepseekproT"
   }
 }
 ```
@@ -394,7 +394,7 @@ defaults.
 Supported top-level keys are `texra.agent`, `texra.model`,
 `texra.outputFormat`, and `texra.approvalPolicy`; `texra.chat` and `texra.run`
 may set command-specific `agent` and `model` defaults. The built-in CLI model
-default is `deepseekT`.
+default is `deepseekproT`.
 
 The corresponding environment variables are `TEXRA_AGENT`, `TEXRA_MODEL`,
 `TEXRA_OUTPUT_FORMAT`, `TEXRA_APPROVAL_POLICY`, and `TEXRA_API_MODE`. Run
@@ -405,8 +405,8 @@ Use `--api-mode personal` or `TEXRA_API_MODE=personal` to force a `run` or
 `chat` invocation to use provider API keys even when the CLI is signed in for
 included hosted access. `--api-mode included` keeps the default hosted behavior
 when the account is signed in. The accepted aliases match the TUI `/api`
-command: for example, `direct`, `api`, and `byok` select personal API keys,
-while `included` selects hosted access.
+command: `personal` (or its shorthand `byok`) selects your own provider keys,
+while `included` (or `relay`) selects hosted access.
 
 Two switches are environment-only:
 

--- a/docs/guide/tikz-figures.md
+++ b/docs/guide/tikz-figures.md
@@ -66,7 +66,7 @@ Because these are tool-use agents, they can compile the figure and inspect the r
 ### Creating New Figures
 
 1. Select a tool-use agent — `research` or `presenter` (<wa-icon library="texra" name="sparkle"></wa-icon>).
-2. Pick a vision-capable model (<wa-icon library="texra" name="robot"></wa-icon>) — `sonnet46T`, `opus5T`, `gpt55`, or `gemini31p` are good choices for complex drawings.
+2. Pick a vision-capable model (<wa-icon library="texra" name="robot"></wa-icon>) — `sonnet5T`, `opus5T`, `gpt56`, or `gemini31p` are good choices for complex drawings.
 3. Provide a detailed description of the figure you want.
 4. Click Execute (<wa-icon library="texra" name="play"></wa-icon>).
 
@@ -132,8 +132,8 @@ When automatic extraction is enabled, TeXRA will:
 
 1. <wa-icon library="texra" name="search"></wa-icon> Scan your LaTeX documents for `tikzpicture` environments.
 2. <wa-icon library="texra" name="file-add"></wa-icon> Extract each figure as a separate file.
-3. <wa-icon library="texra" name="output"></wa-icon> Compile the figures to generate PNG previews.
-4. <wa-icon library="texra" name="eye"></wa-icon> Make both the TikZ code and previews available to the agent.
+3. <wa-icon library="texra" name="output"></wa-icon> Compile the figures into standalone PDFs.
+4. <wa-icon library="texra" name="eye"></wa-icon> Make both the TikZ code and compiled PDFs available to the agent.
 
 ### Manual Extraction Commands
 
@@ -167,17 +167,17 @@ Once extracted, TikZ figures can be compiled into viewable images.
 
 ### Automatic Compilation
 
-With automatic extraction on, one source file fans out into one standalone document, one PDF, and one PNG preview per figure — handed back to the agent:
+With automatic extraction on, one source file fans out into one standalone document and one compiled PDF per figure — handed back to the agent:
 
 <FlowSteps :steps="[
   { icon: 'file-code', title: 'Source', desc: 'One .tex file with several tikzpicture environments.', chips: [{ text: 'diagrams.tex', variant: 'info', icon: 'file-code' }] },
   { icon: 'file-submodule', title: 'Extract', desc: 'A standalone LaTeX document per figure.', chips: [{ text: 'fig1.tex', variant: 'neutral' }, { text: 'fig2.tex', variant: 'neutral' }, { text: 'fig3.tex', variant: 'neutral' }] },
   { icon: 'play-circle', title: 'Compile', desc: 'latexmk / pdflatex builds each standalone.', chips: [{ text: '3 PDFs', variant: 'warning', icon: 'file-pdf' }] },
-  { icon: 'output', title: 'Preview', desc: 'PDF → PNG via GraphicsMagick / ImageMagick + Ghostscript.', chips: [{ text: '3 PNGs', variant: 'success', icon: 'eye' }] },
-  { icon: 'robot', title: 'Agent', desc: 'Sees both the TikZ code and the rendered previews.', chips: [{ text: 'code + image', variant: 'accent' }] }
+  { icon: 'output', title: 'Attach', desc: 'Models with native PDF support read the PDFs directly; others get rasterised PNGs via GraphicsMagick / ImageMagick + Ghostscript.', chips: [{ text: 'PDF or PNG', variant: 'success', icon: 'eye' }] },
+  { icon: 'robot', title: 'Agent', desc: 'Sees both the TikZ code and the rendered output.', chips: [{ text: 'code + image', variant: 'accent' }] }
 ]" />
 
-<p class="hero-caption">The extract → compile → preview pipeline: each <code>tikzpicture</code> becomes its own standalone document, PDF, and PNG. The last hop needs GraphicsMagick / ImageMagick + Ghostscript.</p>
+<p class="hero-caption">The extract → compile → attach pipeline: each <code>tikzpicture</code> becomes its own standalone document and PDF. Rasterisation to PNG — only for models without native PDF support — needs GraphicsMagick / ImageMagick + Ghostscript.</p>
 
 Missing system dependencies show <wa-icon library="texra" name="warning"></wa-icon> on **Dashboard → LaTeX** (<wa-icon library="texra" name="file-code"></wa-icon>).
 
@@ -186,7 +186,7 @@ Missing system dependencies show <wa-icon library="texra" name="warning"></wa-ic
 1. Open the Command Palette (`Ctrl+Shift+P`).
 2. Run **TeXRA: Compile TikZ Figures from Current File**.
 
-This compiles all extracted figures and generates preview images.
+This compiles all extracted figures into standalone PDFs.
 
 ## <wa-icon library="texra" name="settings-gear"></wa-icon> Customising TikZ Processing
 
@@ -228,7 +228,7 @@ Tool-use agents can reuse existing figures as references when creating new ones.
 
 ### Using Reference Figures
 
-1. Add previous TikZ figures to the **Reference** section (<wa-icon library="texra" name="book"></wa-icon>).
+1. Add previous TikZ figures to the **Context** section (<wa-icon library="texra" name="book"></wa-icon>).
 2. Mention them explicitly in your instructions.
 3. Ask the agent to adopt similar styles or approaches.
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -484,7 +484,7 @@ The ProgressBoard is your main debugging tool. See the [ProgressBoard Guide](./p
 Key points for troubleshooting:
 
 1. **Access ProgressBoard**:
-   - The ProgressBoard shares the TeXRA view in the Activity Bar with the
+   - The ProgressBoard shares the TeXRA view in the Secondary Side Bar with the
      launcher — click the TeXRA icon, then switch to the Progress view
    - If not visible, open it via the Command Palette: "TeXRA: Show Progress"
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -484,8 +484,9 @@ The ProgressBoard is your main debugging tool. See the [ProgressBoard Guide](./p
 Key points for troubleshooting:
 
 1. **Access ProgressBoard**:
-   - Look for "TeXRA ProgressBoard" in the panel at the bottom of VS Code
-   - If not visible, open it via the Command Palette: "TeXRA: Show ProgressBoard"
+   - The ProgressBoard shares the TeXRA view in the Activity Bar with the
+     launcher — click the TeXRA icon, then switch to the Progress view
+   - If not visible, open it via the Command Palette: "TeXRA: Show Progress"
 
 2. **Interpreting logs**: entries are colour-coded by severity, and nested
    entries expand to reveal detail — green for information and successful
@@ -496,7 +497,6 @@ Key points for troubleshooting:
 <p class="hero-caption">ProgressBoard colour-codes every entry by severity — green info/success, yellow warnings, red errors — with task-id chips and expandable nested detail.</p>
 
 3. **Finding specific information**:
-   - Use the search function to find relevant messages
    - Look for task IDs to track specific operations
    - Expand nested entries to see detailed information
 

--- a/docs/guide/workflows/polish-a-draft.md
+++ b/docs/guide/workflows/polish-a-draft.md
@@ -44,17 +44,18 @@ texra run polish \
     { label: 'r0 — first revision', state: 'done' },
     { label: 'r1 — critique-and-revise pass', state: 'done' },
   ]"
-  :outputs="['.texra/runs/c4e19b07a52d/r1/intro.tex']"
+  :outputs="['executions/c4e19b07a52d/r1/intro.tex']"
 />
 
 <p class="hero-caption">Rounds stream as progress, then the path to the final revision prints on stdout — that printed path is the success signal.</p>
 
-Each round writes its output into the run's task storage, using the
-**input filename** as the document name:
+Each round writes its output into the run's task storage — an
+`executions/<run-id>/` folder under TeXRA's workspace storage directory —
+using the **input filename** as the document name:
 
 ```
-.texra/runs/<run-id>/r0/intro.tex   # Round 0 — first revision
-.texra/runs/<run-id>/r1/intro.tex   # Round 1 — critique-and-revise pass
+executions/<run-id>/r0/intro.tex   # Round 0 — first revision
+executions/<run-id>/r1/intro.tex   # Round 1 — critique-and-revise pass
 ```
 
 <PolishRoundsTree />
@@ -83,8 +84,8 @@ Same run, same history, same output files — whichever surface you used.
 CLI — diff the rounds against your input:
 
 ```sh
-diff -u intro.tex .texra/runs/<run-id>/r0/intro.tex
-diff -u .texra/runs/<run-id>/r0/intro.tex .texra/runs/<run-id>/r1/intro.tex
+diff -u intro.tex executions/<run-id>/r0/intro.tex
+diff -u executions/<run-id>/r0/intro.tex executions/<run-id>/r1/intro.tex
 ```
 
 VS Code — the Progress Board shows side-by-side diffs and lets you accept

--- a/docs/guide/workflows/polish-a-draft.md
+++ b/docs/guide/workflows/polish-a-draft.md
@@ -71,7 +71,7 @@ texra run polish --input intro.tex --output intro.polished.tex
 ## Run it in VS Code
 
 1. Open `intro.tex`.
-2. Click the TeXRA icon in the activity bar.
+2. Click the TeXRA icon in the Secondary Side Bar.
 3. In the **Input** section, click <wa-icon library="texra" name="add"></wa-icon> **Add files** and pick `intro.tex` from the file picker.
 4. Pick **polish** as the agent. Pick a model.
 5. Type the instruction. Press **Execute**.

--- a/docs/guide/working-with-figures.md
+++ b/docs/guide/working-with-figures.md
@@ -3,41 +3,25 @@
 <script setup>
 import MediaSectionPanel from '../.vitepress/components/MediaSectionPanel.vue';
 import AutoExtractMenu from '../.vitepress/components/AutoExtractMenu.vue';
-import CliRunHero from '../.vitepress/components/CliRunHero.vue';
 </script>
 
 TeXRA lets AI agents analyse, reference, and generate figures inside your documents — from `.png` screenshots to embedded TikZ diagrams and PDFs.
 
 ::: tip CLI
 This page covers the VS Code **Media** selector. From the [`texra` CLI](./texra-cli.md),
-figures referenced by your input documents are auto-extracted and attached for
-vision-capable models on workflow runs — or work with a figure conversationally
-in `texra chat`. (`--context` files are read as text, so they're for `.tex` and
+work with a figure conversationally in `texra chat`, or let a tool-use agent
+pull figures out of your documents with the built-in extraction tools.
+(`--context` files are read as text, so they're for `.tex` and
 `.bib` sources, not images.)
 :::
 
 ## <wa-icon library="texra" name="rocket"></wa-icon> Quick Task: Add a Figure Caption
 
 1. Select the `polish` agent from the agent dropdown (<wa-icon library="texra" name="sparkle"></wa-icon>).
-2. Pick a vision-capable model (<wa-icon library="texra" name="robot"></wa-icon>) — e.g. `gpt55`, `sonnet46T`, `gemini31p`.
+2. Pick a vision-capable model (<wa-icon library="texra" name="robot"></wa-icon>) — e.g. `gpt56`, `sonnet5T`, `gemini31p`.
 3. Select your figure in the **Media** (<wa-icon library="texra" name="file-media"></wa-icon>) section.
 4. Type the instruction: "Write a detailed caption for this figure."
 5. Click Execute (<wa-icon library="texra" name="play"></wa-icon>).
-
-In the terminal, the same five steps collapse to one command. Pick a
-vision-capable model, and the figures your document references are
-auto-extracted and attached for it:
-
-<CliRunHero
-  command='texra run polish --input draft.tex --model sonnet46T --instruction "Write a detailed caption for the pipeline figure."'
-  :rounds="[
-    { label: 'r0 — draft revision', state: 'done' },
-    { label: 'r1 — critique and revise', state: 'done' },
-  ]"
-  :outputs="['.texra/runs/b81d4f29e6a3/r1/draft.tex']"
-/>
-
-<p class="hero-caption">No media picker needed: on a vision model, round 0 extracts the figures referenced by <code>draft.tex</code> and sends them alongside the text.</p>
 
 ## <wa-icon library="texra" name="file-media"></wa-icon> The Media Section
 


### PR DESCRIPTION
## Summary

Full audit of every page published to the texra.ai VitePress site (`docs/guide/**`, root `index.md`/`launch.md`/`providers.md`, plus the `.vitepress/components/*.vue` hero mocks those pages render) against the current codebase. Each factual claim — agent rosters, settings keys, defaults, command names, file paths, model handles, UI tab labels — was verified against source before editing. 51 files, net -80 lines.

## What was stale and is now fixed

- **Model roster** — replaced deprecated/retired llm-zoo handles: `sonnet46(T)` → `sonnet5(T)`, GPT-5.4/5.5 family → GPT-5.6 family, `gemini35f` → `gemini36f`, `kimi26` → `kimi3`, `minimaxM25/M27` → `minimaxM3`, `glm45–glm5` → `glm52`/`glm5vturbo`, `grok2v–grok4` → `grok45`; dropped retired `dsr1`; llm-zoo is "100+ models", provider list gained GLM/MiniMax/Meta
- **Run storage** — `.texra/runs/<run-id>/` → `executions/<run-id>/` in the workspace store; round outputs keep the input filename (`r0/paper.tex`, not `r0/output.tex`); latexdiff artifact naming (`_diffr1r0`, `-diff<hash>`) and Pack/Clean scope corrected
- **Agents** — removed the retired `discuss` agent everywhere; `ocr` re-described as handwritten-math → LaTeX; `progressCheck` is not in the Software Engineer team; `search` → `assistant` in the intro table
- **Dashboard tabs** — Models → **Providers & Models**, Multi-Agent → **Teams**, ChatGPT/Copilot/Kimi Code subscriptions live under **Subscriptions**; settings groups match `SETTINGS_TAB_GROUPS`
- **UI flows** — Merge uses the configured helper model (no Model dropdown step); removed retired Attach Diagnostics, per-card Recheck, and ProgressBoard Delete All/sort/filter controls; stream tabs are `agent: file` with the model on the second line; status dots are Running/Waiting/Completed/Failed; ProgressBoard lives in the TeXRA view
- **CLI** — built-in default model is `deepseekproT`; `texra tools show` → `texra tools status`; `--api-mode` accepts only `included`/`relay`/`personal`/`byok`; settings are `.texra/config.json`-only
- **Tools** — TikZ extraction produces standalone PDFs (PNG only for models without native PDF support); figures are **not** auto-extracted on CLI runs; prompt templating engine is Nunjucks; removed phantom `inherits: base` and `REFERENCE_*`/`AUXILIARY_*` aliases
- **Mock components** — hero mocks updated to the current UI (toolbars, tab labels, storage trees) and ~15 stale codicon-style icon names replaced with canonical TeXRA icon names that actually resolve

## Verification

- `npm run docs:build` (content gate + sync + `vitepress build`) passes
- Model handle changes verified programmatically against bundled `llm-zoo@1.25.0`
- Edited Vue SFCs parse and template-compile clean
- Pages verified current with no changes needed: `index.md`, `launch.md`, `providers.md`, `multiple-output.md`, `working-with-overleaf.md`, `latex-compilation.md`, `best-practices.md`, `acknowledgments.md`

Out of scope (internal, excluded from the site): `docs/prds/`, `docs/proposals/`, `docs/dev/`, `docs/architecture/`, `docs/design/`, `docs/reference/`, `docs/supabase/`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static mock components only; no runtime, auth, or data-path behavior changes in application code.
> 
> **Overview**
> **Brings the published texra.ai docs in line with the current product** — guide pages, landing copy, and VitePress hero mocks — after verifying claims against source (agents, settings, CLI, paths, model handles).
> 
> **Run storage & diffs:** Replaces `.texra/runs/<id>/` with shared workspace **`executions/<executionId>/`**, documents round outputs that **keep the input filename** (not `output.tex`), and updates latexdiff artifact naming and merge output paths (`r0/<base>.tex` via helper model, not a separate Model step or `_full.tex`).
> 
> **Models & agents:** Refreshes llm-zoo handles (e.g. `sonnet5(T)`, GPT-5.6, `gemini36f`, `kimi3`, `grok45`); removes retired **`discuss`**; rewrites **`ocr`** for handwritten math → LaTeX; adjusts team notes (`progressCheck`, Software Engineer specialists, intro **`assistant`** for literature).
> 
> **UI & CLI copy:** Dashboard tabs → **Providers & Models**, **Teams**, **Subscriptions**; ProgressBoard stream labels (`agent: file`), status legend, and toolbar actions; `texra tools **status**`; default model **`deepseekproT`**; integrations flow drops per-card Recheck; icon names and mock toolbars updated across ~30 Vue heroes.
> 
> **Other factual fixes:** Nunjucks templating, no Attach Diagnostics / `inherits: base`, TikZ pipeline (PDF-first), custom agents hot-reload without window reload, credential storage wording, and trimmed obsolete ProgressBoard controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 415729fbb1275171780b2bba4760eeeb505e70e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->