### PR TITLE
fix(progressView): unify WorktreeChip .sr-only with .visually-hidden (#9725)

### DIFF
--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -8,7 +8,7 @@ import {
   type WorktreePRState,
   type WorktreeCIState,
 } from '@shared/schemas';
-import { designTokens } from '@shared/styles';
+import { designTokens, commonViewStyles } from '@shared/styles';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { getBasename } from '@utils/core';
@@ -60,6 +60,7 @@ const CI_LABEL: Record<WorktreeCIState, string> = {
 export class WorktreeChip extends LitElement {
   static override styles = [
     designTokens,
+    commonViewStyles,
     css`
       :host {
         display: inline-flex;
@@ -103,18 +104,6 @@ export class WorktreeChip extends LitElement {
         border-radius: 50%;
         background-color: var(--wa-color-chart-orange, #d18616);
         flex-shrink: 0;
-      }
-
-      .sr-only {
-        position: absolute;
-        width: 1px;
-        height: 1px;
-        padding: 0;
-        margin: -1px;
-        overflow: hidden;
-        clip: rect(0, 0, 0, 0);
-        white-space: nowrap;
-        border: 0;
       }
 
       .pr-number {
@@ -208,7 +197,7 @@ export class WorktreeChip extends LitElement {
                   role="img"
                   aria-label="uncommitted changes"
                 ></span>
-                <span class="sr-only">uncommitted changes</span>`
+                <span class="visually-hidden">uncommitted changes</span>`
             : nothing
         }
       </span>

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -285,8 +285,8 @@ export const commonViewStyles: CSSResult = css`
   ${focusRingStyles}
 
   /* Available to the accessibility tree, absent from the layout. The canonical
-     copy: InstructionPanel carried its own and WorktreeChip a differently-named
-     .sr-only, which is how two names for one utility start. */
+     copy across every view surface (InstructionPanel and WorktreeChip both
+     used to carry their own). */
   .visually-hidden {
     position: absolute;
     width: 1px;


### PR DESCRIPTION
## Summary
- Replace WorktreeChip's local `.sr-only` with the shared `.visually-hidden` from `commonViewStyles`
- Compose `commonViewStyles` into the chip so the utility is available in its shadow root
- Closes #9725

## Test plan
- [ ] Progress view worktree chip still shows the dirty indicator with screen-reader text
- [ ] No remaining `.sr-only` definitions under progressView / webview / settingsView


Made with [Cursor](https://cursor.com)