### PR TITLE
chore(ratchet): drop stale CLI helperModelName deep-import baseline

### DIFF
--- a/config/ratchets/host-agent-import-baseline.json
+++ b/config/ratchets/host-agent-import-baseline.json
@@ -18,7 +18,6 @@
       "@agent/runtime/detachSubagentsOnStop",
       "@agent/runtime/executeAgent",
       "@agent/runtime/executionRegistry",
-      "@agent/runtime/helperModelName",
       "@agent/runtime/HostInteractions",
       "@agent/runtime/resolveAndResumeStream",
       "@agent/runtime/resumeQueuedToolUse",


### PR DESCRIPTION
## Summary
- Remove `@agent/runtime/helperModelName` from the CLI host-agent-import baseline
- Live CLI deep-import count is 31; the entry was leftover after #9717 moved the helper to `@model`
- Closes leftover intent from #9741 (closed as superseded)

## Test plan
- [ ] `npx vitest run src/test-kernel/architecture/hostAgentDeepImportRatchet.vitest.ts` passes
- [ ] CLI baseline length matches live distinct `@agent/*` deep imports


Made with [Cursor](https://cursor.com)