### PR TITLE
fix(approval): re-seed policy on rollback/reset and warn on coerce

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -13,7 +13,7 @@ import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   TEXRA_APPROVAL_POLICY_CONFIG_KEY,
-  TEXRA_APPROVAL_POLICY_DEFAULT,
+  readPersistedTexraApprovalPolicy,
   type TexraApprovalPolicy,
 } from '@shared/approvalPolicy';
 import { resetSetting, writeSetting } from '@shared/config/settingsAccess';
@@ -270,7 +270,9 @@ export function createDesktopSettingsIpc(
       if (write.entry.key === TEXRA_APPROVAL_POLICY_CONFIG_KEY) {
         options.session.setApprovalPolicy(
           write.kind === 'reset'
-            ? TEXRA_APPROVAL_POLICY_DEFAULT
+            ? readPersistedTexraApprovalPolicy((key, fallback) =>
+                options.config.get(key, fallback),
+              )
             : (write.value as TexraApprovalPolicy),
         );
       }

--- a/packages/extension/src/frontend/vscode/texraConfig.ts
+++ b/packages/extension/src/frontend/vscode/texraConfig.ts
@@ -126,11 +126,24 @@ export class ExtensionTexraConfig extends JsonConfigProvider {
 
       let previousStore: JsonStore | undefined;
       let finalized = false;
+      const seedSessionApprovalPolicy = (): void => {
+        // No default session exists yet during activation's own config setup,
+        // and unit tests exercise transitions without one; a live session
+        // always exists by the time a real workspace-folder change can fire.
+        tryDefaultSession()?.setApprovalPolicy(
+          readPersistedTexraApprovalPolicy((key, fallback) =>
+            this.get(key, fallback),
+          ),
+        );
+        refreshApprovalPolicyTooltip();
+      };
       const rollbackConfig = () => {
-        if (previousStore) {
-          this.replaceWorkspaceStore(previousStore);
-          previousStore = undefined;
-        }
+        if (!previousStore) return;
+        this.replaceWorkspaceStore(previousStore);
+        previousStore = undefined;
+        // Commit may have already re-seeded from the new workspace; restore
+        // the session + tooltip to match the rolled-back config store.
+        seedSessionApprovalPolicy();
       };
 
       try {
@@ -142,16 +155,7 @@ export class ExtensionTexraConfig extends JsonConfigProvider {
               path.join(this.storage.getStoragePath(), TEXRA_CONFIG_FILE_NAME),
             );
             previousStore = this.replaceWorkspaceStore(workspaceStore);
-            // No default session exists yet during activation's own config
-            // setup, and unit tests exercise transitions without one; a live
-            // session always exists by the time a real workspace-folder
-            // change can fire.
-            tryDefaultSession()?.setApprovalPolicy(
-              readPersistedTexraApprovalPolicy((key, fallback) =>
-                this.get(key, fallback),
-              ),
-            );
-            refreshApprovalPolicyTooltip();
+            seedSessionApprovalPolicy();
           },
           afterStorageRollback: rollbackConfig,
           afterStorageFinalize: () => {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -66,7 +66,7 @@ import { revealProgressStream } from '@progressView/progressNavigation';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   TEXRA_APPROVAL_POLICY_CONFIG_KEY,
-  TEXRA_APPROVAL_POLICY_DEFAULT,
+  readPersistedTexraApprovalPolicy,
   type TexraApprovalPolicy,
 } from '@shared/approvalPolicy';
 import { resetSetting, writeSetting } from '@shared/config/settingsAccess';
@@ -743,7 +743,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       if (write.entry.key === TEXRA_APPROVAL_POLICY_CONFIG_KEY) {
         defaultSession().setApprovalPolicy(
           write.kind === 'reset'
-            ? TEXRA_APPROVAL_POLICY_DEFAULT
+            ? readPersistedTexraApprovalPolicy((key, fallback) =>
+                platform().config.get(key, fallback),
+              )
             : (write.value as TexraApprovalPolicy),
         );
         refreshApprovalPolicyTooltip();

--- a/src/shared/approvalPolicy.ts
+++ b/src/shared/approvalPolicy.ts
@@ -77,7 +77,8 @@ export function readPersistedTexraApprovalPolicy(
   if (typeof raw !== 'string') {
     if (raw !== undefined && raw !== null) {
       warn(
-        `[approval-policy] Ignoring invalid ${TEXRA_APPROVAL_POLICY_CONFIG_KEY} value ${JSON.stringify(raw)}; using "${TEXRA_APPROVAL_POLICY_DEFAULT}".`,
+        'approval-policy',
+        `Ignoring invalid ${TEXRA_APPROVAL_POLICY_CONFIG_KEY} value ${JSON.stringify(raw)}; using "${TEXRA_APPROVAL_POLICY_DEFAULT}".`,
       );
     }
     return TEXRA_APPROVAL_POLICY_DEFAULT;
@@ -85,7 +86,8 @@ export function readPersistedTexraApprovalPolicy(
   const parsed = parseTexraApprovalPolicy(raw);
   if (parsed) return parsed;
   warn(
-    `[approval-policy] Ignoring invalid ${TEXRA_APPROVAL_POLICY_CONFIG_KEY} "${raw}"; using "${TEXRA_APPROVAL_POLICY_DEFAULT}".`,
+    'approval-policy',
+    `Ignoring invalid ${TEXRA_APPROVAL_POLICY_CONFIG_KEY} "${raw}"; using "${TEXRA_APPROVAL_POLICY_DEFAULT}".`,
   );
   return TEXRA_APPROVAL_POLICY_DEFAULT;
 }

--- a/src/shared/approvalPolicy.ts
+++ b/src/shared/approvalPolicy.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+// Local imports
+import { warn } from '@logger/logUtils';
+
 export const TEXRA_APPROVAL_POLICIES = ['never', 'ask', 'yolo'] as const;
 export const TexraApprovalPolicySchema = z.enum(TEXRA_APPROVAL_POLICIES);
 export type TexraApprovalPolicy = z.infer<typeof TexraApprovalPolicySchema>;
@@ -71,8 +74,20 @@ export function readPersistedTexraApprovalPolicy(
     TEXRA_APPROVAL_POLICY_CONFIG_KEY,
     TEXRA_APPROVAL_POLICY_DEFAULT,
   );
-  if (typeof raw !== 'string') return TEXRA_APPROVAL_POLICY_DEFAULT;
-  return parseTexraApprovalPolicy(raw) ?? TEXRA_APPROVAL_POLICY_DEFAULT;
+  if (typeof raw !== 'string') {
+    if (raw !== undefined && raw !== null) {
+      warn(
+        `[approval-policy] Ignoring invalid ${TEXRA_APPROVAL_POLICY_CONFIG_KEY} value ${JSON.stringify(raw)}; using "${TEXRA_APPROVAL_POLICY_DEFAULT}".`,
+      );
+    }
+    return TEXRA_APPROVAL_POLICY_DEFAULT;
+  }
+  const parsed = parseTexraApprovalPolicy(raw);
+  if (parsed) return parsed;
+  warn(
+    `[approval-policy] Ignoring invalid ${TEXRA_APPROVAL_POLICY_CONFIG_KEY} "${raw}"; using "${TEXRA_APPROVAL_POLICY_DEFAULT}".`,
+  );
+  return TEXRA_APPROVAL_POLICY_DEFAULT;
 }
 
 export type TexraApprovalPolicyDecision =

--- a/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
+++ b/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
@@ -377,6 +377,55 @@ describe.skipIf(process.platform === 'win32')(
       provider.dispose();
     });
 
+    it('re-seeds the default session approval policy after a transition rolls back', async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'texra-workspace-transition-'));
+      const firstWorkspace = join(tempDir, 'first');
+      const secondWorkspace = join(tempDir, 'second');
+      const storageRoot = join(tempDir, 'storage');
+      await Promise.all([
+        createProject(firstWorkspace, 24001),
+        mkdir(join(secondWorkspace, '.texra'), { recursive: true }),
+        mkdir(storageRoot),
+      ]);
+      await writeFile(
+        join(firstWorkspace, '.texra', 'config.json'),
+        '{"texra.bib.zoteroPort": 24001, "texra.approvalPolicy": "ask"}\n',
+      );
+      await writeFile(
+        join(secondWorkspace, '.texra', 'config.json'),
+        '{"texra.approvalPolicy": "yolo"}\n',
+      );
+
+      let workspaceRoot: string | undefined = firstWorkspace;
+      const storage = new WorkspaceStorageProvider(
+        storageRoot,
+        () => workspaceRoot,
+      );
+      const config = await createExtensionTexraConfig(storage, workspaceRoot);
+      driveTransitions(storage, {
+        failWorkspaceRoots: new Set([secondWorkspace]),
+      });
+      const provider = new ProgressViewProvider(
+        {
+          storageUri: { fsPath: join(tempDir, 'extension-storage') },
+        } as unknown as vscode.ExtensionContext,
+        config,
+        { getWorkspacePath: () => workspaceRoot } as never,
+      );
+
+      workspaceRoot = secondWorkspace;
+      mocks.workspaceListeners[0]?.();
+      await vi.waitFor(() =>
+        expect(mocks.showErrorMessage).toHaveBeenCalled(),
+      );
+      // Commit briefly seeds yolo from the failed target, then rollback
+      // restores the prior workspace store and re-seeds ask.
+      expect(mocks.setApprovalPolicy.mock.calls.map((call) => call[0])).toEqual(
+        ['yolo', 'ask'],
+      );
+      provider.dispose();
+    });
+
     it('serializes rapid moves, rolls a failed move back, and preserves watchers for retry', async () => {
       tempDir = await mkdtemp(join(tmpdir(), 'texra-workspace-transition-'));
       const firstWorkspace = join(tempDir, 'first');

--- a/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
+++ b/src/test-kernel/settings/ExtensionWorkspaceTransition.vitest.ts
@@ -415,9 +415,7 @@ describe.skipIf(process.platform === 'win32')(
 
       workspaceRoot = secondWorkspace;
       mocks.workspaceListeners[0]?.();
-      await vi.waitFor(() =>
-        expect(mocks.showErrorMessage).toHaveBeenCalled(),
-      );
+      await vi.waitFor(() => expect(mocks.showErrorMessage).toHaveBeenCalled());
       // Commit briefly seeds yolo from the failed target, then rollback
       // restores the prior workspace store and re-seeds ask.
       expect(mocks.setApprovalPolicy.mock.calls.map((call) => call[0])).toEqual(

--- a/src/test-kernel/shared/ApprovalPolicy.vitest.ts
+++ b/src/test-kernel/shared/ApprovalPolicy.vitest.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
+import { warn } from '@logger/logUtils';
 import {
   TEXRA_APPROVAL_POLICIES,
+  TEXRA_APPROVAL_POLICY_CONFIG_KEY,
+  TEXRA_APPROVAL_POLICY_DEFAULT,
   TEXRA_APPROVAL_POLICY_DENIED_MESSAGE,
   TEXRA_APPROVAL_POLICY_DISPLAY_ORDER,
   TEXRA_APPROVAL_POLICY_OPTIONS,
@@ -12,10 +15,15 @@ import {
   decideRetryApproval,
   decideTexraApproval,
   parseTexraApprovalPolicy,
+  readPersistedTexraApprovalPolicy,
   texraApprovalDenialMessage,
   texraHumanInputDenialMessage,
   texraRetryDenialMessage,
 } from '@shared/approvalPolicy';
+
+vi.mock('@logger/logUtils', () => ({
+  warn: vi.fn(),
+}));
 
 describe('TeXRA approval policy', () => {
   it.each([
@@ -54,6 +62,37 @@ describe('TeXRA approval policy', () => {
     );
     expect(parseTexraApprovalPolicy(' Yolo ')).toBe('yolo');
     expect(parseTexraApprovalPolicy('auto')).toBeUndefined();
+  });
+
+  it('reads a valid persisted policy without warning', () => {
+    vi.mocked(warn).mockClear();
+    expect(
+      readPersistedTexraApprovalPolicy((key, fallback) => {
+        expect(key).toBe(TEXRA_APPROVAL_POLICY_CONFIG_KEY);
+        return 'never' as typeof fallback;
+      }),
+    ).toBe('never');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns and falls back when the persisted policy value is invalid', () => {
+    vi.mocked(warn).mockClear();
+    expect(
+      readPersistedTexraApprovalPolicy(() => 'auto' as never),
+    ).toBe(TEXRA_APPROVAL_POLICY_DEFAULT);
+    expect(warn).toHaveBeenCalledWith(
+      `[approval-policy] Ignoring invalid ${TEXRA_APPROVAL_POLICY_CONFIG_KEY} "auto"; using "${TEXRA_APPROVAL_POLICY_DEFAULT}".`,
+    );
+  });
+
+  it('warns and falls back when the persisted policy value is not a string', () => {
+    vi.mocked(warn).mockClear();
+    expect(
+      readPersistedTexraApprovalPolicy(() => 42 as never),
+    ).toBe(TEXRA_APPROVAL_POLICY_DEFAULT);
+    expect(warn).toHaveBeenCalledWith(
+      `[approval-policy] Ignoring invalid ${TEXRA_APPROVAL_POLICY_CONFIG_KEY} value 42; using "${TEXRA_APPROVAL_POLICY_DEFAULT}".`,
+    );
   });
 
   it('maps deny reasons to distinct user-facing messages', () => {

--- a/src/test-kernel/shared/ApprovalPolicy.vitest.ts
+++ b/src/test-kernel/shared/ApprovalPolicy.vitest.ts
@@ -77,9 +77,9 @@ describe('TeXRA approval policy', () => {
 
   it('warns and falls back when the persisted policy value is invalid', () => {
     vi.mocked(warn).mockClear();
-    expect(
-      readPersistedTexraApprovalPolicy(() => 'auto' as never),
-    ).toBe(TEXRA_APPROVAL_POLICY_DEFAULT);
+    expect(readPersistedTexraApprovalPolicy(() => 'auto' as never)).toBe(
+      TEXRA_APPROVAL_POLICY_DEFAULT,
+    );
     expect(warn).toHaveBeenCalledWith(
       `[approval-policy] Ignoring invalid ${TEXRA_APPROVAL_POLICY_CONFIG_KEY} "auto"; using "${TEXRA_APPROVAL_POLICY_DEFAULT}".`,
     );
@@ -87,9 +87,9 @@ describe('TeXRA approval policy', () => {
 
   it('warns and falls back when the persisted policy value is not a string', () => {
     vi.mocked(warn).mockClear();
-    expect(
-      readPersistedTexraApprovalPolicy(() => 42 as never),
-    ).toBe(TEXRA_APPROVAL_POLICY_DEFAULT);
+    expect(readPersistedTexraApprovalPolicy(() => 42 as never)).toBe(
+      TEXRA_APPROVAL_POLICY_DEFAULT,
+    );
     expect(warn).toHaveBeenCalledWith(
       `[approval-policy] Ignoring invalid ${TEXRA_APPROVAL_POLICY_CONFIG_KEY} value 42; using "${TEXRA_APPROVAL_POLICY_DEFAULT}".`,
     );

--- a/src/test-kernel/shared/ApprovalPolicy.vitest.ts
+++ b/src/test-kernel/shared/ApprovalPolicy.vitest.ts
@@ -81,7 +81,8 @@ describe('TeXRA approval policy', () => {
       TEXRA_APPROVAL_POLICY_DEFAULT,
     );
     expect(warn).toHaveBeenCalledWith(
-      `[approval-policy] Ignoring invalid ${TEXRA_APPROVAL_POLICY_CONFIG_KEY} "auto"; using "${TEXRA_APPROVAL_POLICY_DEFAULT}".`,
+      'approval-policy',
+      `Ignoring invalid ${TEXRA_APPROVAL_POLICY_CONFIG_KEY} "auto"; using "${TEXRA_APPROVAL_POLICY_DEFAULT}".`,
     );
   });
 
@@ -91,7 +92,8 @@ describe('TeXRA approval policy', () => {
       TEXRA_APPROVAL_POLICY_DEFAULT,
     );
     expect(warn).toHaveBeenCalledWith(
-      `[approval-policy] Ignoring invalid ${TEXRA_APPROVAL_POLICY_CONFIG_KEY} value 42; using "${TEXRA_APPROVAL_POLICY_DEFAULT}".`,
+      'approval-policy',
+      `Ignoring invalid ${TEXRA_APPROVAL_POLICY_CONFIG_KEY} value 42; using "${TEXRA_APPROVAL_POLICY_DEFAULT}".`,
     );
   });
 


### PR DESCRIPTION
## Summary
- Re-seed session approval policy (and tooltip) when a workspace transition rolls back, so a failed switch away from `yolo` cannot leave the session auto-approving while config/UI say otherwise (#9748).
- On settings reset, seed from `readPersistedTexraApprovalPolicy` (effective config) instead of hardcoding `ask` (#9749).
- Warn when `readPersistedTexraApprovalPolicy` coerces an invalid persisted value, matching the CLI path (#9750).

## Test plan
- [x] `ApprovalPolicy.vitest.ts` — valid read silent; invalid string/non-string warn + fallback
- [x] `ExtensionWorkspaceTransition.vitest.ts` — rollback path asserts `yolo` then `ask` reseeds
- [ ] CI green

Closes #9748
Closes #9749
Closes #9750

Made with [Cursor](https://cursor.com)