### PR TITLE
fix(ui): consume --color-text-muted and --border-control tokens

### DIFF
--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -1578,7 +1578,7 @@ wa-card.desktop-onboarding::part(footer) {
   height: 1em;
   flex: 0 0 1em;
   place-items: center;
-  opacity: 0.7;
+  color: var(--color-text-muted);
 }
 
 .desktop-editor-tree-icon wa-icon {

--- a/packages/extension/src/progressView/frontend/components/ContextManagement.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ContextManagement.styles.ts
@@ -39,7 +39,7 @@ export const contextManagementStyles: CSSResult = css`
   }
 
   .stat-item wa-icon {
-    opacity: var(--opacity-subtle);
+    color: var(--color-text-muted);
   }
 
   .summary-block {

--- a/packages/extension/src/progressView/frontend/components/FileList.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.styles.ts
@@ -68,7 +68,7 @@ export const fileListStyles: CSSResult = css`
   }
 
   .file-dir {
-    opacity: var(--opacity-subtle);
+    color: var(--color-text-muted);
     font-size: var(--font-size-sm);
   }
 

--- a/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
@@ -99,8 +99,7 @@ export const streamTabStyles = css`
     align-items: center;
     gap: var(--wa-space-3xs);
     font-size: var(--font-size-xs);
-    color: var(--wa-color-text-normal);
-    opacity: var(--opacity-subtle);
+    color: var(--color-text-muted);
     width: 100%;
     min-width: 0;
     overflow: hidden;
@@ -220,13 +219,13 @@ export const streamTabStyles = css`
 
   .compact-subagent-hint {
     font-size: var(--font-size-xs);
-    opacity: var(--opacity-faint);
+    color: var(--color-text-muted);
     flex-shrink: 0;
   }
 
   .nested-stream-icon {
     font-size: var(--font-size-xs);
-    opacity: var(--opacity-faint);
+    color: var(--color-text-muted);
     flex-shrink: 0;
     margin-inline-end: var(--wa-space-3xs);
   }
@@ -252,8 +251,7 @@ export const streamTabStyles = css`
     width: 24px;
     min-width: 24px;
     height: 100%;
-    color: var(--wa-color-text-quiet, var(--wa-color-text-normal));
-    opacity: var(--opacity-muted);
+    color: var(--color-text-muted);
   }
 
   .tab-expand::part(base) {

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.styles.ts
@@ -35,9 +35,8 @@ export const toolEditRequestPanelStyles: CSSResult = css`
   }
 
   .approval-request__diff-label {
-    color: var(--color-text-secondary);
+    color: var(--color-text-muted);
     font-size: var(--font-size-xs);
-    opacity: var(--opacity-normal);
   }
 
   /*

--- a/packages/extension/src/progressView/frontend/styles/groupStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/groupStyles.ts
@@ -34,7 +34,7 @@ export const groupStyles = css`
     /* A user stop is neither success nor error, so the rail reads neutral,
        matching the shared status dot and the CLI row marker. */
     &.is-cancelled {
-      border-left-color: var(--wa-color-text-quiet);
+      border-left-color: var(--border-control);
     }
   }
 
@@ -67,13 +67,13 @@ export const groupStyles = css`
   .group-progress {
     font-size: var(--font-size-sm);
     font-variant-numeric: tabular-nums;
-    opacity: var(--opacity-subtle);
+    color: var(--color-text-muted);
     margin-inline-start: var(--wa-space-2xs);
   }
 
   .group-time {
     font-size: var(--font-size-sm);
-    opacity: var(--opacity-subtle);
+    color: var(--color-text-muted);
     margin-inline-start: var(--wa-space-2xs);
   }
 

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -62,7 +62,7 @@ export const logEntryStyles = css`
     margin: var(--wa-space-2xs) 0;
     padding: var(--wa-space-xs);
     border: var(--border-thin) solid var(--wa-color-surface-border);
-    border-left: 2px solid var(--color-text-secondary);
+    border-left: 2px solid var(--border-control);
     border-radius: var(--wa-border-radius-m, var(--border-radius));
     background: color-mix(
       in srgb,
@@ -191,17 +191,15 @@ export const logEntryStyles = css`
 
   .file-list-content .file-var,
   .file-list-content .file-source {
-    color: var(--color-text-secondary);
+    color: var(--color-text-muted);
   }
 
   .file-list-content .file-var {
-    opacity: var(--opacity-normal);
     font-size: var(--font-size-sm);
     margin-inline-start: var(--wa-space-3xs);
   }
 
   .file-list-content .file-source {
-    opacity: var(--opacity-subtle);
     font-size: 0.85em;
     font-style: italic;
   }
@@ -217,12 +215,11 @@ export const logEntryStyles = css`
   }
 
   .xml-link-container wa-icon {
-    opacity: var(--opacity-subtle);
+    color: var(--color-text-muted);
   }
 
   .xml-link-container .document-tag {
-    color: var(--color-text-secondary);
-    opacity: var(--opacity-normal);
+    color: var(--color-text-muted);
     font-style: italic;
   }
 
@@ -406,7 +403,7 @@ export const logEntryStyles = css`
   }
 
   .details-summary > .icon {
-    opacity: var(--opacity-muted);
+    color: var(--color-text-muted);
   }
 
   .banner-content {

--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -27,8 +27,7 @@ export const toolUseStyles = css`
 
   .tool-use-sublabel {
     font-weight: var(--font-weight-medium);
-    color: var(--wa-color-text-normal);
-    opacity: var(--opacity-normal);
+    color: var(--color-text-muted);
     font-size: var(--font-size-sm);
   }
 

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.styles.ts
@@ -86,7 +86,7 @@ export const agentSelectionPanelStyles: CSSResult = css`
 
   .agent-list-item[data-source='remote']:hover,
   .agent-list-item[data-source='remote'].selected {
-    border-inline-start-color: var(--wa-color-text-quiet);
+    border-inline-start-color: var(--border-control);
   }
 
   .agent-list-item:hover {

--- a/src/shared/styles/bannerStyles.ts
+++ b/src/shared/styles/bannerStyles.ts
@@ -39,7 +39,7 @@ const bannerFrameStyles: CSSResult = css`
   .banner-row .hint {
     width: 100%;
     font-size: var(--font-size-sm);
-    opacity: var(--opacity-subtle);
+    color: var(--color-text-muted);
     line-height: var(--line-height-relaxed, 1.5);
   }
 

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -395,7 +395,7 @@ export const commonViewStyles: CSSResult = css`
 
   .empty-state wa-icon {
     font-size: calc(var(--font-size) * 2.5);
-    opacity: var(--opacity-disabled);
+    color: var(--color-text-muted);
   }
 
   /* Class hooks consumed by the shared renderEmptyState() helper


### PR DESCRIPTION
## Summary
- Replace `--color-text-secondary` (or normal/quiet) + element `opacity` de-emphasis with `var(--color-text-muted)` so contrast stays a single known step (#9722).
- Point control/status rails that used secondary/quiet text colour at `var(--border-control)`.
- Touches progress-view styles, shared banner/empty-state chrome, settings agent list, and the desktop editor tree icon.

Left alone: whole-row pending/disabled fades, interactive hover-reveal opacity (tab close), and secondary text that already stands alone without opacity (per UsagePanel).

## Test plan
- [ ] Spot-check progress tabs, workflow task rails, file list dirs, empty states, and desktop editor tree icons in light + dark
- [ ] Confirm muted text/icons meet ~3:1 non-text contrast on VS Code Light+/Dark+ and desktop appearances
- [ ] CI green

Closes #9722

Made with [Cursor](https://cursor.com)