### PR TITLE
refactor(storage): execute #9590 Stage 7 early — delete intermediate-era identity readers

### DIFF
--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -186,9 +186,9 @@ export function replayTrace(trace: TraceDocument): void {
   // The embedded ExecutionMeta carries the run's identity. Pre-migration
   // exports have no identity and are NOT all agent runs (bash process and
   // workflow-script traces exist), so classify from the trace's stream-id
-  // prefix — the same quarantined evidence rule as the storage entrance
-  // stamper (`deriveLegacyIdentity`); an immutable exported file is the one
-  // permanent home for this fallback.
+  // prefix. An exported trace file is immutable, so unlike the storage-side
+  // readers retired in #9590 Stage 7 this fallback is permanent: it is the
+  // only place a stream-id prefix may be read as evidence.
   const identity: RunIdentity =
     trace.meta?.identity ?? legacyTraceIdentity(trace);
   const streamTabInfo: StreamTabInfo =

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -34,7 +34,6 @@ import {
   WORKFLOW_DOCUMENT_OUTPUT_EXT,
   WORKFLOW_RAW_OUTPUT_EXT,
 } from '@shared/constants/workflowOutput';
-import { seedResumedConversationSidecar } from '@transcript/completedRunArchive';
 import { AbsoluteFS, TaskRunFileService } from '@utils/files';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 
@@ -319,12 +318,10 @@ export async function runReflectionFlow<C = unknown>(
 
   if (flowRecord) {
     logger.debug('Resuming reflection flow from persistence');
-    await seedResumedConversationSidecar(
-      runSession.transcripts,
-      streamId,
-      executionId,
-      shared.conversation,
-    );
+    // Resume runs from the flow-record conversation. Pre-sidecar sessions
+    // once had that conversation imported into the transcript sidecar here;
+    // the importer was retired per #9590 Stage 7, so such a session's
+    // pre-resume turns stay out of the durable transcript.
     // Persist the synced totalRounds into the flow record so that
     // stepWithResult() picks up the current config, not the stale one.
     await pf.setShared(shared);

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -121,7 +121,7 @@ function isReplayableTerminalResult(event: ResultEvent): boolean {
 export type SessionHandleInit = Pick<SessionHandle, 'transcripts'> & {
   /**
    * Delay store repair until {@link SessionHandle.waitUntilReady} is called.
-   * Desktop uses this while claiming legacy stream identities.
+   * Desktop uses this so repair runs only after its process stores are wired.
    */
   restartRepair?: 'deferred';
 } & Partial<

--- a/src/agent/runtime/restartRepair.ts
+++ b/src/agent/runtime/restartRepair.ts
@@ -253,8 +253,8 @@ export async function repairRestartedStreams(
   )) {
     if (options.signal?.aborted) break;
     // `executionIds` is the caller-owned identity channel: SessionHandle
-    // populates it from snapshot sidecars plus the explicit legacy suffix
-    // boundary. No second suffix decode happens here (#9590 A2).
+    // populates it from snapshot sidecars. No suffix decode happens here
+    // (#9590 A2).
     const executionId = options.executionIds.get(streamId);
     let repairStarted = false;
     try {

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -15,12 +15,7 @@ import {
 import { isFileNotFoundError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
-import type {
-  ExecutionId,
-  ExecutionMeta,
-  RunIdentity,
-  RunOutcome,
-} from '@shared/schemas';
+import type { ExecutionId, RunIdentity, RunOutcome } from '@shared/schemas';
 import { StorageFS } from '@utils/files';
 import { filterNotNull, toNewestFirstByTimestamp } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -28,7 +23,6 @@ import { isDirectory } from '@utils/files/fsEntryType';
 
 import { getExecutionStore } from './ExecutionKVStore';
 import {
-  EXECUTION_LEASE_STALE_MS,
   inspectExecutionLease,
   runWithInactiveExecutionLease,
 } from './executionLease';
@@ -101,92 +95,6 @@ export function isUserVisibleExecution(
   return isAgentRunEntry(entry) && entry.parentExecutionId === undefined;
 }
 
-// ============================================================================
-// Idempotent entrance stamping — the only legacy-migration artifact.
-//
-// Pre-consolidation rows carry no `identity`. The listing is the store's read
-// entrance that already visits every row, so an unstamped row is healed here:
-// identity derived once from the persisted config and written back under an
-// inactive execution lease. Runs every time with no generation marker —
-// idempotent because stamped rows never reach it, and re-runnable because an
-// old binary's read-modify-write stripping the field, a legacy-bucket merge
-// injecting v1 rows, or a restored backup simply re-heals on the next pass.
-// ============================================================================
-
-/** Rows younger than the lease-stale horizon may be mid-registration by an
- *  old binary — a half-born row must not be classified. */
-const STAMP_MIN_AGE_MS = EXECUTION_LEASE_STALE_MS;
-
-/**
- * Un-stamped legacy row → identity, from the surviving evidence: the
- * persisted config plus the row's stamped `streamId`, whose host prefix
- * encoded the run kind before `identity` existed. This prefix-reading is
- * quarantined HERE (and mirrored only by the trace-viewer's immutable-export
- * fallback) — production classification never inspects stream-id prefixes;
- * it reads the stamped `identity`. Exported for store-read entrances
- * (hydration) so an un-healed row behaves identically before its durable
- * stamp lands; the listing's stamper remains the only WRITER of the derived
- * value. Rows without usable evidence are left unstamped: they keep parsing
- * and keep listing as `incomplete`. No sentinel names are fabricated.
- */
-export function deriveLegacyIdentity(
-  meta: Pick<ExecutionMeta, 'streamId'> | null | undefined,
-  cfg: AgentConfig | null,
-): RunIdentity | undefined {
-  const streamId = meta?.streamId ?? '';
-  if (streamId.startsWith('workflow-script#')) {
-    return {
-      kind: 'multiAgentWorkflow',
-      workflowName: cfg?.agent ?? 'workflow-script',
-    };
-  }
-  if (streamId.startsWith('codex@')) {
-    return cfg ? { kind: 'agent', agent: cfg.agent, tool: 'codex' } : undefined;
-  }
-  if (streamId.startsWith('claude@')) {
-    return cfg
-      ? { kind: 'agent', agent: cfg.agent, tool: 'claude_code' }
-      : undefined;
-  }
-  if (streamId.startsWith('bash@')) {
-    return { kind: 'process', tool: 'bash' };
-  }
-  return cfg ? { kind: 'agent', agent: cfg.agent } : undefined;
-}
-
-/**
- * Durably stamp a derived identity onto an unstamped row. Best-effort: an
- * active lease or a write failure leaves the row to heal on the next pass,
- * and the caller still uses the derived value for this read. The retired
- * `terminalStatus` bytes some legacy rows still carry are deliberately NOT
- * converted: `outcome` starts absent for pre-consolidation rows, which
- * simply have no recorded terminal state.
- */
-async function stampExecutionRow(
-  id: ExecutionId,
-  meta: ExecutionMeta,
-): Promise<void> {
-  if (Date.now() - Date.parse(meta.timestamp) < STAMP_MIN_AGE_MS) return;
-  try {
-    await runWithInactiveExecutionLease(id, async () => {
-      const store = getExecutionStore(id);
-      const [current, cfg] = await Promise.all([
-        store.readMeta(),
-        store.readConfig(),
-      ]);
-      if (!current || current.identity) return;
-      const identity = deriveLegacyIdentity(current, cfg);
-      if (!identity) return;
-      await store.writeMeta({ ...current, identity });
-    });
-  } catch (error) {
-    logger.warn(
-      CHANNEL,
-      `Could not stamp identity onto execution ${id}: ${toErrorMessage(error)}`,
-    );
-  }
-}
-
 /**
  * Read a storage directory, returning an empty array if it doesn't exist.
  * Other I/O errors propagate.
@@ -226,6 +134,11 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
   const entries = await readDirOrEmpty(RUNS_STORAGE_DIR);
   const executionDirs = listExecutionDirs(entries);
 
+  // Rows registered before `identity` stamping existed. Their reader (derive
+  // + write-back healing) was retired per #9590 Stage 7; they now list as
+  // `incomplete`, loudly, and are never reconstructed.
+  const preIdentityIds: ExecutionId[] = [];
+
   // Read meta + config with bounded concurrency. Large histories should not
   // enqueue one storage read pair per execution all at once.
   const results = await pMap(
@@ -248,11 +161,8 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
           description: meta.description,
         };
         const agentRecord = record && isAgentRunRecord(record) ? record : null;
-        const identity =
-          meta.identity ?? deriveLegacyIdentity(meta, agentRecord);
-        // Durable healing is async and best-effort; this read already has
-        // the derived value either way.
-        if (identity !== meta.identity) void stampExecutionRow(id, meta);
+        const identity = meta.identity;
+        if (!identity) preIdentityIds.push(id);
         if (!record || !identity) {
           return { ...base, kind: 'incomplete' };
         }
@@ -273,6 +183,15 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
     },
     { concurrency: EXECUTION_STORAGE_CONCURRENCY },
   );
+
+  // One warning per listing pass, not one per row — a directory full of old
+  // rows must degrade loudly, not spam.
+  if (preIdentityIds.length > 0) {
+    logger.warn(
+      CHANNEL,
+      `${preIdentityIds.length} pre-identity execution row(s) listed as incomplete (e.g. ${preIdentityIds[0]}): reader retired per #9590 Stage 7`,
+    );
+  }
 
   return toNewestFirstByTimestamp(
     results.filter(filterNotNull),

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -45,7 +45,6 @@ export {
   deleteAllExecutions,
   isAgentRunEntry,
   isUserVisibleExecution,
-  deriveLegacyIdentity,
 } from './executionListing';
 export {
   RESUMABILITY_CAUSE,

--- a/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
@@ -11,7 +11,8 @@ import {
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import * as logger from '@logger/logUtils';
+import type { ExecutionId } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 
 function config(agent: string): AgentConfig {
@@ -31,7 +32,15 @@ async function writeExecution(
   parentExecutionId?: ExecutionId,
 ): Promise<void> {
   const store = getExecutionStore(id);
-  await store.writeMeta({ timestamp, parentExecutionId });
+  // Current-era registration always stamps identity into the first meta
+  // write; an identity-less row models the pre-identity (incomplete) case.
+  await store.writeMeta({
+    timestamp,
+    parentExecutionId,
+    ...(agentConfig
+      ? { identity: { kind: 'agent', agent: agentConfig.agent } }
+      : {}),
+  });
   if (agentConfig) await store.writeRunRecord(agentConfig);
 }
 
@@ -168,109 +177,35 @@ describe('execution listing normalization', () => {
     expect(entries.filter(isUserVisibleExecution)).toHaveLength(0);
   });
 
-  it('heals unstamped legacy rows durably on the listing read', async () => {
-    const legacyId = 'abc777' as ExecutionId;
-    const store = getExecutionStore(legacyId);
-    // Legacy row: pre-identity metadata, old enough to be safely classified
-    // and written back. No stream-prefix evidence → native agent.
-    await store.writeMeta({ timestamp: '2026-07-15T06:00:00.000Z' });
-    await store.writeRunRecord(config('assistant'));
+  it('lists a pre-identity row as incomplete, warns once per pass, and never heals it', async () => {
+    // Rows registered before identity stamping lost their reader (#9590
+    // Stage 7): no derivation from config or stream-id prefixes, no
+    // write-back healing. They degrade loudly to `incomplete`.
+    const firstId = 'abc777' as ExecutionId;
+    const secondId = 'abc778' as ExecutionId;
+    for (const id of [firstId, secondId]) {
+      const store = getExecutionStore(id);
+      await store.writeMeta({ timestamp: '2026-07-15T06:00:00.000Z' });
+      await store.writeRunRecord(config('assistant'));
+    }
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
 
     const entries = await listExecutions();
-    expect(entries).toEqual([
-      expect.objectContaining({
-        kind: 'run',
-        identity: { kind: 'agent', agent: 'assistant' },
-      }),
+
+    expect(entries.map(({ kind }) => kind)).toEqual([
+      'incomplete',
+      'incomplete',
     ]);
-
-    // The async best-effort write-back stamps the derived identity durably.
-    await vi.waitFor(async () => {
-      const healed = await store.readMeta();
-      expect(healed?.identity).toEqual({ kind: 'agent', agent: 'assistant' });
-    });
-  });
-
-  it('stamps the four legacy cohorts from quarantined stream-prefix evidence', async () => {
-    // Pre-identity rows carried their run kind only in the stream-id prefix.
-    // One fixture per real cohort, asserting both the stamped identity and
-    // that resume gating (isNativeAgentRun: kind 'agent' with no tool) keeps
-    // excluding the non-native ones after healing.
-    const isNativeAgentRun = (identity: {
-      kind: string;
-      tool?: string;
-    }): boolean => identity.kind === 'agent' && identity.tool === undefined;
-    const cohorts = [
-      {
-        id: 'aaa001' as ExecutionId,
-        streamId: 'bash@tool#aaa001',
-        agent: 'bash',
-        identity: { kind: 'process', tool: 'bash' },
-      },
-      {
-        id: 'aaa002' as ExecutionId,
-        streamId: 'workflow-script#aaa002',
-        agent: 'engineer',
-        identity: { kind: 'multiAgentWorkflow', workflowName: 'engineer' },
-      },
-      {
-        id: 'aaa003' as ExecutionId,
-        streamId: 'codex@codex-sdk#aaa003',
-        agent: 'coder',
-        identity: { kind: 'agent', agent: 'coder', tool: 'codex' },
-      },
-      {
-        id: 'aaa004' as ExecutionId,
-        streamId: 'claude@agent-sdk#aaa004',
-        agent: 'assistant',
-        identity: { kind: 'agent', agent: 'assistant', tool: 'claude_code' },
-      },
-    ] as const;
-
-    for (const cohort of cohorts) {
-      const store = getExecutionStore(cohort.id);
-      await store.writeMeta({
-        timestamp: '2026-07-15T06:00:00.000Z',
-        streamId: cohort.streamId as StreamTabId,
-      });
-      await store.writeRunRecord(config(cohort.agent));
-    }
-
-    const entries = await listExecutions();
-    for (const cohort of cohorts) {
-      const entry = entries.find((candidate) => candidate.id === cohort.id);
-      expect(entry).toMatchObject({ kind: 'run', identity: cohort.identity });
-      expect(isNativeAgentRun(cohort.identity)).toBe(false);
-    }
-
-    // The durable stamp carries the same prefix-derived identity.
-    for (const cohort of cohorts) {
-      await vi.waitFor(async () => {
-        const healed = await getExecutionStore(cohort.id).readMeta();
-        expect(healed?.identity).toEqual(cohort.identity);
-      });
-    }
-  });
-
-  it('lists a legacy terminalStatus-bearing row with no outcome', async () => {
-    // The retired terminalStatus vocabulary is deliberately not converted:
-    // pre-consolidation rows simply have no recorded terminal state. The
-    // stray bytes must not break parsing or identity healing.
-    const id = 'abd001' as ExecutionId;
-    const store = getExecutionStore(id);
-    await store.write('meta', {
-      timestamp: '2026-07-15T06:00:00.000Z',
-      terminalStatus: 'interrupted',
-    });
-    await store.writeRunRecord(config('assistant'));
-
-    const entries = await listExecutions();
-    const entry = entries.find((candidate) => candidate.id === id);
-    expect(entry).toMatchObject({
-      kind: 'run',
-      identity: { kind: 'agent', agent: 'assistant' },
-    });
-    expect(entry?.outcome).toBeUndefined();
+    // One warning per listing pass — a directory of old rows must not spam.
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [, message] = warn.mock.calls[0] as [string, string];
+    expect(message).toContain('2 pre-identity execution row(s)');
+    expect(message).toContain('#9590');
+    // The row stays unstamped on disk: readers never reconstruct identity.
+    expect(
+      (await getExecutionStore(firstId).readMeta())?.identity,
+    ).toBeUndefined();
+    warn.mockRestore();
   });
 
   it('lists a pre-PR team-run config with the legacy delegation-scope pair as kind run', async () => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1276,48 +1276,6 @@ describe('StreamSnapshotStore', () => {
     expect(store.getExecutionId(STREAM)).toBe(executionId);
   });
 
-  it('derives identity in memory for an un-healed legacy row and replaces the pair on handoff', async () => {
-    await installPlatform();
-    // Un-healed legacy row: the execution meta carries no stamped `identity`,
-    // but its config is readable — hydration derives the identity in memory
-    // with the stamper's rule instead of leaving it undefined.
-    const legacyExecutionId = 'abc123' as ExecutionId;
-    const legacyConfig = toolUseConfig('legacy-search');
-    await getExecutionStore(legacyExecutionId).writeRunRecord(legacyConfig);
-    await getExecutionStore(legacyExecutionId).writeMeta({
-      timestamp: new Date(0).toISOString(),
-    });
-    await writeMetaFile(STREAM, { executionId: legacyExecutionId });
-
-    const store = new StreamSnapshotStore();
-    await store.load([STREAM]);
-    expect(store.getRunConfig(STREAM)).toEqual(legacyConfig);
-    expect(store.getRunIdentity(STREAM)).toEqual({
-      kind: 'agent',
-      agent: 'legacy-search',
-    });
-
-    // Once meta names a stamped execution, the identity/config pair moves
-    // together to the new execution's durable record.
-    const executionId = 'def456' as ExecutionId;
-    const handoffConfig = toolUseConfig('handoff-search');
-    await getExecutionStore(executionId).writeRunRecord(handoffConfig);
-    await getExecutionStore(executionId).writeMeta({
-      timestamp: new Date(0).toISOString(),
-      identity: { kind: 'agent', agent: 'handoff-search' },
-    });
-    await writeMetaFile(STREAM, {
-      executionId,
-    });
-    await store.load([STREAM]);
-
-    expect(store.getRunConfig(STREAM)).toEqual(handoffConfig);
-    expect(store.getRunIdentity(STREAM)).toEqual({
-      kind: 'agent',
-      agent: 'handoff-search',
-    });
-  });
-
   it('drops run identity when disk meta no longer names an execution', async () => {
     await installPlatform();
     const executionId = 'abc123' as ExecutionId;

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -91,7 +91,6 @@ import {
   hasCompletedRunConversationEvidence,
   readCompletedRunConversation,
   readCompletedRunTodos,
-  seedResumedConversationSidecar,
   StreamLogStore,
   StreamSnapshotStore,
 } from '@transcript';
@@ -665,50 +664,6 @@ describe('completedRunArchive facade', () => {
     expect(result.source).toBe('streamLog');
     expect(result.streamId).toBe(streamId);
     expect(result.conversation).not.toBeNull();
-  });
-
-  it('seeds a resumed legacy conversation into an empty transcript once', async () => {
-    const executionId = '0dd4440dd444' as ExecutionId;
-    const streamId = 'orchestrator@deepseekproT#0dd4440dd444' as StreamTabId;
-    await seedStreams(executionId, [{ streamId }]);
-    await stampStreamId(executionId, streamId);
-
-    const logs = await StreamLogStore.open();
-    logs.ensureStream(streamId);
-    appendTranscriptEntry(
-      logs,
-      streamId,
-      logRow(MESSAGE_TYPES.PROGRESS_STATUS, { text: 'Resuming...' }),
-    );
-    const messages = [
-      { role: 'system', content: 'Follow the proof protocol.' },
-      { role: 'user', content: 'Prove the legacy lemma.' },
-      { role: 'assistant', content: 'Here is the legacy proof.' },
-    ];
-
-    await expect(
-      seedResumedConversationSidecar(logs, streamId, executionId, messages),
-    ).resolves.toBe(true);
-    await expect(
-      seedResumedConversationSidecar(logs, streamId, executionId, [
-        { role: 'assistant', content: 'Duplicate seed' },
-      ]),
-    ).resolves.toBe(false);
-    await logs.flush();
-
-    const result = await readCompletedRunConversation(executionId);
-    expect(result).toEqual({
-      source: 'streamLog',
-      streamId,
-      conversation: [
-        { role: 'system', content: 'Follow the proof protocol.' },
-        { role: 'user', content: 'Prove the legacy lemma.' },
-        {
-          role: 'assistant',
-          content: [{ type: 'text', text: 'Here is the legacy proof.' }],
-        },
-      ],
-    });
   });
 
   it('reconstructs structured successful and failed tool results as model-facing text', async () => {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -19,7 +19,6 @@ import {
   type TodoEntry,
   listExecutions,
   resolveExecutionWorkspaceFilePath,
-  deriveLegacyIdentity,
 } from '@agent/storage';
 import {
   currentSession,
@@ -36,10 +35,8 @@ import {
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import {
-  isAgentRunRecord,
-  type RunRecord,
-} from '@agent/core/definition/RunRecord';
+import { type RunRecord } from '@agent/core/definition/RunRecord';
+import * as logger from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import {
   ExecutionIdSchema,
@@ -109,6 +106,8 @@ import {
   type ExecutionSummaryOptions,
 } from './executions/summaryFormat';
 import { formatSizedEntryLines } from './executions/fileListingFormat';
+
+const CHANNEL = 'ExecutionsTool';
 
 // ============================================================================
 // Resource path catalog
@@ -646,12 +645,16 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       );
     }
 
-    const identity =
-      meta?.identity ??
-      deriveLegacyIdentity(
-        meta,
-        record && isAgentRunRecord(record) ? record : null,
+    // Identity comes only from the stamped execution row; pre-identity rows
+    // lost their reader per #9590 Stage 7 and degrade to the config-derived
+    // display category, loudly.
+    const identity = meta?.identity;
+    if (meta && !identity) {
+      logger.warn(
+        CHANNEL,
+        `Execution ${executionId} is a pre-identity row; showing config-derived category only (reader retired per #9590 Stage 7)`,
       );
+    }
     const category = executionDisplayCategory(identity, record);
     const info = getExecutionStatusInfo(executionId, meta?.outcome);
     const lines = buildCompletedSummaryLines(
@@ -877,11 +880,17 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       throw new ToolError(`Config not found for execution: ${executionId}.`);
     }
 
-    // Filter out fields irrelevant to this agent's category
+    // Filter out fields irrelevant to this agent's category. Identity comes
+    // only from the stamped execution row; a pre-identity row (reader retired
+    // per #9590 Stage 7) degrades to the config-derived category, loudly.
     const meta = await getExecutionStore(executionId).readMeta();
-    const identity =
-      meta?.identity ??
-      deriveLegacyIdentity(meta, isAgentRunRecord(record) ? record : null);
+    const identity = meta?.identity;
+    if (meta && !identity) {
+      logger.warn(
+        CHANNEL,
+        `Execution ${executionId} is a pre-identity row; filtering config by its config-derived category only (reader retired per #9590 Stage 7)`,
+      );
+    }
     const category = executionDisplayCategory(identity, record);
     return executed(serializeFilteredConfig(record, category));
   }

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -25,7 +25,6 @@ import { getExecutionStore } from '@agent/storage';
 import type { AgentEvent } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
-import { deriveLegacyIdentity } from '@agent/storage/executionListing';
 import { isFileNotFoundError } from '@common/errors';
 import { KVStore } from '@common/storage/KVStore';
 import * as logger from '@logger/logUtils';
@@ -378,6 +377,10 @@ export class StreamSnapshotStore {
   private readonly dirtyWrites = new Map<string, DirtySidecarWrite>();
 
   private hasAuthoritativeStreamSet = false;
+
+  /** Streams already warned about a pre-identity execution row (#9590 Stage
+   *  7), so repeated hydrations of the same old row stay one warning each. */
+  private readonly preIdentityWarned = new Set<StreamTabId>();
 
   private getOrCreateRecord(stream: StreamTabId): StreamRecord {
     return this.records.getOrCreate(stream);
@@ -1591,9 +1594,9 @@ export class StreamSnapshotStore {
   /**
    * Execution id recorded in a stream sidecar's `meta.json`, without seeding
    * memory or reading the stream's other sidecar files. Callers that scan
-   * every persisted stream (the `legacyExecutionIdentity` meta-match, bulk
-   * admin sweeps in `SessionStores`) only ever need this one field, so this
-   * reads just `meta.json` rather than the full 6-file `readStreamData()`.
+   * every persisted stream (bulk admin sweeps in `SessionStores`) only ever
+   * need this one field, so this reads just `meta.json` rather than the full
+   * 6-file `readStreamData()`.
    */
   async readPersistedExecutionId(
     stream: StreamTabId,
@@ -2042,19 +2045,18 @@ export class StreamSnapshotStore {
           store.readMeta(),
           store.readConfig(),
         ]);
-        // Un-healed legacy row: derive in memory with the stamper's rule so
-        // resume/rerun and rendering behave identically before the durable
-        // stamp lands (the listing entrance remains the only writer). When
-        // the execution row predates registration-time streamId stamping,
-        // this sidecar's own id is still valid evidence — its association
-        // with the execution is proven by the registration-written
-        // `meta.executionId` edge, not by name resemblance.
-        identity =
-          execMeta?.identity ??
-          deriveLegacyIdentity(
-            { streamId: execMeta?.streamId ?? stream },
-            execConfig,
+        // Identity comes only from the stamped execution row. Pre-identity
+        // rows (registered before identity stamping) lost their reader per
+        // #9590 Stage 7: hydrate without an identity, loudly — never
+        // reconstruct one from stream-id prefixes or config.
+        identity = execMeta?.identity;
+        if (execMeta && !identity && !this.preIdentityWarned.has(stream)) {
+          this.preIdentityWarned.add(stream);
+          logger.warn(
+            CHANNEL,
+            `Stream ${stream} maps to pre-identity execution row ${executionId}; hydrating without a run identity (reader retired per #9590 Stage 7)`,
           );
+        }
         description = execMeta?.description;
         config = execConfig;
       } catch (error) {

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -7,10 +7,7 @@
 import { getExecutionStore, type TodoEntry } from '@agent/storage';
 import { mediaAttachmentKindToContentBlock } from '@agent/export/attachmentMarkerVocabulary';
 import { formatToolResultAsText } from '@agent/modelHandlers/utils/toolAttachmentUtils';
-import {
-  formatConversationMessage,
-  stringifyConversationValue,
-} from '@agent/storage/conversationFormat';
+import { stringifyConversationValue } from '@agent/storage/conversationFormat';
 import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
@@ -25,7 +22,7 @@ import {
   type ToolUseLog,
 } from '@shared/schemas';
 import { ToolResultSchema } from '@shared/schemas/toolResult';
-import { assertNever, generateShortId, isObject } from '@utils/core';
+import { assertNever, isObject } from '@utils/core';
 
 import { StreamLogStore } from './StreamLogStore';
 import { StreamSnapshotStore } from './StreamSnapshotStore';
@@ -312,56 +309,6 @@ function streamLogEntriesToConversation(
       ? conversationMessagesForEntry(entry)
       : [],
   );
-}
-
-/**
- * Import a pre-sidecar persisted conversation into an otherwise
- * conversation-empty stream before a resumed reflection run appends new
- * turns. This is the one legacy-to-canonical migration boundary: subsequent
- * completed reads remain sidecar-first and never have to splice two histories.
- */
-export async function seedResumedConversationSidecar(
-  streamLogStore: StreamLogStore,
-  streamId: StreamTabId,
-  executionId: ExecutionId,
-  messages: readonly unknown[],
-): Promise<boolean> {
-  if (messages.length === 0) return false;
-  await streamLogStore.ensureLoaded(streamId);
-  const existing = streamLogStore.get(streamId);
-  if (
-    existing &&
-    streamLogEntriesToConversation(existing.toJSON()).length > 0
-  ) {
-    return false;
-  }
-
-  const normalized = messages
-    .map((message) => formatConversationMessage(message))
-    .filter(({ content }) => content.length > 0);
-  if (normalized.length === 0) return false;
-
-  const writer = streamLogStore.acquireWriter(streamId, executionId);
-  try {
-    for (const { role, content } of normalized) {
-      writer.appendSettled({
-        id: generateShortId(),
-        type: STREAM_LOG_ENTRY_TYPES.LOG,
-        level: 'info',
-        timestamp: Date.now(),
-        messageType:
-          role === 'assistant' || role === 'model'
-            ? MESSAGE_TYPES.MODEL_RESPONSE
-            : MESSAGE_TYPES.USER_MESSAGE,
-        text: content,
-        data: { archivedRole: role },
-        verbose: false,
-      });
-    }
-  } finally {
-    writer.close();
-  }
-  return true;
 }
 
 /** Reconstruct one stream's conversation; `[]` when the log is absent/empty. */

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -25,6 +25,5 @@ export {
   hasCompletedRunConversationEvidence,
   readCompletedRunConversation,
   readCompletedRunTodos,
-  seedResumedConversationSidecar,
 } from './completedRunArchive';
 export { injectStandaloneTrace } from './standaloneTraceHtml';


### PR DESCRIPTION
## Summary

- Executes #9590 Stage 7 and closes the tracker. Deletes the intermediate-era identity readers: `deriveLegacyIdentity` (stream-id prefix decode), the self-healing entrance stamper (`stampExecutionRow`, `STAMP_MIN_AGE_MS`), and all five `?? deriveLegacyIdentity` read-entrance fallbacks.
- Deletes `seedResumedConversationSidecar`, the pre-sidecar conversation importer — the self-described "one legacy-to-canonical migration boundary", which had no ledger row of its own.
- Pre-identity rows now degrade **loudly and without inference**: they list as `incomplete` with one warning per listing pass (not per row), hydrate without a run identity, and show their config-derived display category in `ExecutionsTool`. No stream-id prefix is ever read as evidence again outside the trace-viewer.
- Deletes three comments naming machinery that no longer exists, and states the trace-viewer's permanent exemption in place of its cross-reference to the deleted stamper.

**Owner decision (2026-08-05) waives this issue's 2026-11-01 age gate**: "not everything needs to be kept — intermediate fixes are not important." The gate existed to let intermediate-migration-era local run rows age out; those rows are local dev artifacts, and keeping ~300 LoC of readers alive for them is the wrong trade. Recorded at https://github.com/LionSR/TeXRA/issues/9590#issuecomment-5191075561.

## Issue acceptance gates

Closes #9590. All four completion-condition searches from the issue body return empty on current paths at this head:

- sidecar directory scans used to associate a current execution → none (all scans read the registered `meta.executionId` FK).
- suffix-derived execution ownership → none.
- configuration-derived stream identifiers for run-local mutations → none.
- snapshot `description` mirror or fallback → none (retired early with the run-classification consolidation).

Stage 7 bullet 4 recount: `StreamSnapshotStore` 29 public methods, `StreamLogStore` 25 — **0 legacy-only on either**. The area's last legacy-only exported symbol (`deriveLegacyIdentity`, incl. its `@agent/storage` barrel entry) is gone.

## Single source of truth

Run identity comes only from the stamped `meta.identity` on the execution row. Nothing re-derives it from stream-id prefixes, config, or file names.

## Duplication and abstraction budget

Pure deletion — no new module, port, or helper. The only added state is a per-stream `Set` in `StreamSnapshotStore` that keeps the pre-identity warning to once per stream across re-seeds; it only ever admits pre-identity streams, which nothing creates anymore.

## Net elements (R6)

- Diffstat: 13 files, **+106 / −386** (net −280 LoC).
- Exported symbols over the diff (`^[+-]export`): **−2 / +0** (`deriveLegacyIdentity`, `seedResumedConversationSidecar`).
- Files: 0 added, 0 deleted. No new types, classes, or interfaces.
- Tests: ~180 LoC of legacy-pinning cases deleted (`ExecutionListing`, `StreamSnapshotStore`, `completedRunArchive`), replaced by one case asserting the loud path (`incomplete` + exactly one warn per pass + no healing write). Kept: the negative invariant guard "never derives ownership from a name suffix" (`SessionStores.vitest.ts`) and the description-absence guards — those pin current behavior, not legacy.

## Consumer counts (R8)

No emit paths touched. Deleted exports, grepped across `src/`, `packages/*`, `docs/`, `config/`, `.github/` after deletion:

- `deriveLegacyIdentity` — 0 remaining references (was: `StreamSnapshotStore` hydration, `ExecutionsTool` ×2, its own listing, barrel re-export).
- `stampExecutionRow` / `STAMP_MIN_AGE_MS` — 0 (module-private; sole caller deleted in the same hunk).
- `seedResumedConversationSidecar` — 0 (sole production caller was the reflection resume path, deleted here; barrel export removed).

## Host impact

Extension / Desktop / CLI: identical, except that an execution row registered before identity stamping now lists as `incomplete` with a warning instead of being silently classified from its stream-id prefix and healed in place. Nothing fails; no current-format row is affected.

## Scheduled refactoring

None deferred by this PR. The sibling arm `normalizeGroupStatusEntry` (`StreamLogStore.ts`) stays on its own #9627 row (2026-10-31) — a candidate for the same treatment under the same ruling, deliberately out of scope here. The trace-viewer's stream-id prefix fallback (`replayTrace.ts`) is **permanent**: it reads immutable exported trace files, so it never ages out; its comment now says so instead of pointing at the deleted stamper.

## Test plan

- [x] `npm run typecheck` (all packages)
- [x] `npm run check:dead-code-ratchet` (18, unchanged baseline)
- [x] `npx vitest run src/test-kernel/agent/storage/ src/test-kernel/transcript/` — 17 files, 284 tests pass
- [x] Full `npm test`
- [x] Completion-condition greps (above)
