### PR TITLE
fix(ui): repair variant token contrast and light-terminal palette

### DIFF
--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -366,7 +366,14 @@ interface DiffLineStyle {
 }
 
 // Light-background diff band colors: green for additions, rose for removals.
-// Both pairs pass WCAG AA contrast at typical terminal font weights.
+// Both pairs pass WCAG AA contrast at typical terminal font weights (added
+// 11.67:1 / APCA Lc 90.2, removed 11.13:1 / Lc 82.8).
+//
+// On 16-color terminals chalk downsamples both backgrounds to brightWhite and
+// both foregrounds to black, so the two bands become visually identical. The
+// `+`/`-` marker kept in `line.text` still distinguishes them, so this degrades
+// rather than breaks; gating the bands on truecolor support would add a code
+// path for a case that already reads correctly.
 const DIFF_ADDED_BG = '#dff4e8';
 const DIFF_ADDED_FG = '#16351f';
 const DIFF_REMOVED_BG = '#f7d9dc';

--- a/packages/cli/src/commands/loginProviderPicker.tsx
+++ b/packages/cli/src/commands/loginProviderPicker.tsx
@@ -5,6 +5,7 @@ import { DEFAULT_OAUTH_PROVIDER, type OAuthProvider } from '@auth/config';
 import { renderCliPrompt } from '@cli/tui/renderCliPrompt';
 import { KeyHints } from '@cli/tui/ui/KeyHints';
 import { Select, type SelectItem } from '@cli/tui/ui/Select';
+import { COLOR_HINT } from '@cli/tui/ui/colors';
 import { isLikelyRemoteSession } from '../runtime/remoteSession';
 import { CLI_OAUTH_PROVIDER_ITEMS } from '../runtime/oauthProviderDisplay';
 
@@ -33,11 +34,11 @@ function LoginProviderPicker(props: {
   return (
     <Box
       borderStyle="round"
-      borderColor="cyan"
+      borderColor={COLOR_HINT}
       flexDirection="column"
       paddingX={1}
     >
-      <Text bold color="cyan">
+      <Text bold color={COLOR_HINT}>
         TeXRA login
       </Text>
       <Text dimColor>Choose how to sign in:</Text>

--- a/packages/cli/src/init/runInitWizard.tsx
+++ b/packages/cli/src/init/runInitWizard.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 
 import { KeyHints } from '@cli/tui/ui/KeyHints';
 import { Select, type SelectItem } from '@cli/tui/ui/Select';
+import { COLOR_HINT } from '@cli/tui/ui/colors';
 import { renderCliPrompt } from '@cli/tui/renderCliPrompt';
 import {
   TEXRA_APPROVAL_POLICY_OPTIONS,
@@ -76,7 +77,7 @@ function StepFrame(props: {
 }): React.JSX.Element {
   return (
     <Box flexDirection="column" paddingX={1}>
-      <Text bold color="cyan">
+      <Text bold color={COLOR_HINT}>
         texra init
       </Text>
       <Text dimColor>

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -24,6 +24,7 @@ import { useCancellableEffect } from '@cli/tui/useCancellableEffect';
 import { renderCliPrompt } from '@cli/tui/renderCliPrompt';
 import { KeyHints, type KeyHint } from '@cli/tui/ui/KeyHints';
 import { Select, type SelectItem } from '@cli/tui/ui/Select';
+import { COLOR_ERROR, COLOR_HINT } from '@cli/tui/ui/colors';
 import { planOnboardingFunnelTransition } from '@controllers/onboarding/onboardingFunnel';
 import { warn as logWarning } from '@logger/logUtils';
 import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
@@ -452,15 +453,15 @@ function OnboardingFrame(props: {
   return (
     <Box
       borderStyle="round"
-      borderColor="cyan"
+      borderColor={COLOR_HINT}
       flexDirection="column"
       paddingX={1}
     >
-      <Text bold color="cyan">
+      <Text bold color={COLOR_HINT}>
         {props.title}
       </Text>
       {props.subtitle ? <Text dimColor>{props.subtitle}</Text> : null}
-      {props.error ? <Text color="red">{props.error}</Text> : null}
+      {props.error ? <Text color={COLOR_ERROR}>{props.error}</Text> : null}
       <Box marginTop={1} flexDirection="column">
         {props.children}
       </Box>
@@ -673,7 +674,7 @@ function RelayProgressFrame(props: {
 }): React.JSX.Element {
   return (
     <BorderedPanel
-      color="cyan"
+      color={COLOR_HINT}
       title={props.title ?? 'Sign in · Researcher Access'}
       footer={<LoadingIndicator label={props.spinnerLabel} />}
     >
@@ -714,7 +715,7 @@ function RelayProgressStep(
           : `Opening your browser to sign in with ${provider}…`}
       </Text>
       {url ? (
-        <Text color="cyan">{url}</Text>
+        <Text color={COLOR_HINT}>{url}</Text>
       ) : (
         <Text dimColor>
           {noBrowser
@@ -749,10 +750,10 @@ function RelayDeviceProgressStep(
       <Text>{CLI_DEVICE_AUTH_URL_PROMPT}</Text>
       {deviceAuth ? (
         <>
-          <Text color="cyan">{deviceAuth.verification_uri}</Text>
+          <Text color={COLOR_HINT}>{deviceAuth.verification_uri}</Text>
           <Text>
             and enter this code:{' '}
-            <Text bold color="cyan">
+            <Text bold color={COLOR_HINT}>
               {deviceAuth.user_code}
             </Text>
           </Text>

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -6,6 +6,7 @@ import { KeyHints, type KeyHint } from '@cli/tui/ui/KeyHints';
 import { renderCliPrompt } from '@cli/tui/renderCliPrompt';
 import { wrapAnsiToWidth } from '@cli/tui/ansiWrap';
 import { computeSelectWindowSize } from '@cli/tui/selectWindow';
+import { COLOR_HINT } from '@cli/tui/ui/colors';
 import type { ApiAccessMode } from '@shared/schemas/profileViewMessages';
 import {
   isCliOrchestrationModelPickAction,
@@ -400,7 +401,7 @@ export function OrchestrationApp(
   if (step.kind === 'model-access') {
     return (
       <Box flexDirection="column" paddingX={1}>
-        <Text bold color="cyan">
+        <Text bold color={COLOR_HINT}>
           {title}
         </Text>
         <Text dimColor>{subtitle}</Text>
@@ -425,7 +426,7 @@ export function OrchestrationApp(
   if (step.kind === 'resume') {
     return (
       <Box flexDirection="column" paddingX={1}>
-        <Text bold color="cyan">
+        <Text bold color={COLOR_HINT}>
           {title}
         </Text>
         <Text dimColor>{subtitle}</Text>
@@ -461,7 +462,7 @@ export function OrchestrationApp(
     }
     return (
       <Box flexDirection="column" paddingX={1}>
-        <Text bold color="cyan">
+        <Text bold color={COLOR_HINT}>
           {title}
         </Text>
         <Text dimColor>{subtitle}</Text>
@@ -494,7 +495,7 @@ export function OrchestrationApp(
   if (pending) {
     return (
       <Box flexDirection="column" paddingX={1}>
-        <Text bold color="cyan">
+        <Text bold color={COLOR_HINT}>
           {title}
         </Text>
         <Text dimColor>{subtitle}</Text>
@@ -518,7 +519,7 @@ export function OrchestrationApp(
   return (
     <Box flexDirection="column" paddingX={1}>
       <Box gap={1}>
-        <Text bold color="cyan">
+        <Text bold color={COLOR_HINT}>
           {'{ T } TeXRA'}
         </Text>
         <Text dimColor>v{props.version}</Text>

--- a/packages/cli/src/tui/ui/colors.ts
+++ b/packages/cli/src/tui/ui/colors.ts
@@ -11,14 +11,21 @@
 // chalk is only a transitive dependency of `ink` here, not one the CLI
 // declares directly.
 
-// ANSI green, yellow and cyan are tuned for dark terminals and carry no
-// lightness guarantee — the terminal owns the value. Against a white
-// background they measure APCA Lc 30-47 (WCAG 1.70-2.56:1) on the xterm and
-// macOS Basic palettes, under the Lc 60 floor for non-body text. Red, blue,
-// magenta and gray are fine in both directions (Lc 66-91), so only these three
-// roles take a light-background substitute: oklch(0.48) at each role's hue,
-// clamped to sRGB, measuring Lc 80.1/82.5/80.8 on white and 74.2/76.5/74.9 on
-// #f5f5f5.
+// A named ANSI colour carries no lightness guarantee — the terminal owns the
+// value, and the sixteen are tuned for dark backgrounds. Which roles need a
+// light-background substitute is measured, not assumed: against white, red,
+// blue, magenta and gray hold Lc 66-91 on the xterm, macOS Basic and VS Code
+// Light+ palettes and are left alone, while green, yellow and cyan collapse to
+// Lc 30-47 (WCAG 1.70-2.56:1), under the Lc 60 floor for non-body text.
+//
+// The three substitutes are one derivation rather than three picks: oklch
+// lightness 0.48 at each role's own hue, chroma at the sRGB gamut boundary.
+// Shared lightness is what makes them a scale; only the hue differs.
+//
+//   role       hue    value      Lc on #ffffff / #f5f5f5
+//   success    150    #007132    80.1 / 74.2
+//   warning     75    #7f5400    82.5 / 76.5
+//   hint       220    #006980    80.8 / 74.9
 //
 // COLORFGBG is "<fg>;<bg>"; some terminals insert extra fields, so the
 // background is always the last one, and 7 (light gray) and 15 (white) are the

--- a/packages/cli/src/tui/ui/colors.ts
+++ b/packages/cli/src/tui/ui/colors.ts
@@ -11,17 +11,38 @@
 // chalk is only a transitive dependency of `ink` here, not one the CLI
 // declares directly.
 
+// ANSI green, yellow and cyan are tuned for dark terminals and carry no
+// lightness guarantee — the terminal owns the value. Against a white
+// background they measure APCA Lc 30-47 (WCAG 1.70-2.56:1) on the xterm and
+// macOS Basic palettes, under the Lc 60 floor for non-body text. Red, blue,
+// magenta and gray are fine in both directions (Lc 66-91), so only these three
+// roles take a light-background substitute: oklch(0.48) at each role's hue,
+// clamped to sRGB, measuring Lc 80.1/82.5/80.8 on white and 74.2/76.5/74.9 on
+// #f5f5f5.
+//
+// COLORFGBG is "<fg>;<bg>"; some terminals insert extra fields, so the
+// background is always the last one, and 7 (light gray) and 15 (white) are the
+// only light backgrounds terminals report. Terminals that never set it
+// (Terminal.app, iTerm2, Alacritty) fall through to the dark assumption the
+// ANSI names are already tuned for, so this can only improve a light terminal,
+// never regress a dark one. Resolved once here so every call site keeps
+// consuming a plain string.
+const LIGHT_TERMINAL_BACKGROUND = ((): boolean => {
+  const background = process.env.COLORFGBG?.split(';').at(-1);
+  return background === '7' || background === '15';
+})();
+
 /** Positive/affirmative state: completed tool runs, "agent asks" prompts. */
-export const COLOR_SUCCESS = 'green';
+export const COLOR_SUCCESS = LIGHT_TERMINAL_BACKGROUND ? '#007132' : 'green';
 
 /** Caution: retryable failures, bash/edit auto-approval, queued/empty states. */
-export const COLOR_WARNING = 'yellow';
+export const COLOR_WARNING = LIGHT_TERMINAL_BACKGROUND ? '#7f5400' : 'yellow';
 
 /** Failure/destructive state: errors, non-zero exit codes, the yolo policy. */
 export const COLOR_ERROR = 'red';
 
 /** Default informational emphasis: form/panel borders, headings, previews. */
-export const COLOR_HINT = 'cyan';
+export const COLOR_HINT = LIGHT_TERMINAL_BACKGROUND ? '#006980' : 'cyan';
 
 /** Distinctive one-off highlight: reverse-search mode, agent-proposal review. */
 export const COLOR_ACCENT = 'magenta';

--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -21,8 +21,8 @@
     var(--vscode-foreground)
   );
   /* Some VS Code themes (notably dark) set descriptionForeground too dim to
-     read against tinted surface cards. Mix at least 65% of the normal text
-     color in to guarantee a readable contrast in every theme. */
+     read against tinted surface cards. Mix 70% of the normal text color in
+     to guarantee a readable contrast in every theme. */
   --wa-color-text-quiet: color-mix(
     in srgb,
     var(--vscode-editor-foreground, var(--vscode-foreground)) 70%,
@@ -56,7 +56,12 @@
   --wa-color-brand-border-loud: var(--vscode-button-border, transparent);
   --wa-color-brand-fill-quiet: var(--vscode-inputValidation-infoBackground);
   --wa-color-brand-border-quiet: var(--vscode-inputValidation-infoBorder);
-  --wa-color-brand-on-quiet: var(--vscode-inputValidation-infoForeground);
+  /* infoForeground is null in every stock theme, so this token would otherwise
+     be invalid and brand callouts would inherit body text by accident. */
+  --wa-color-brand-on-quiet: var(
+    --vscode-inputValidation-infoForeground,
+    var(--wa-color-text-normal)
+  );
 
   /* Neutral variant — outlined wa-button / wa-callout, hovers. */
   --wa-color-neutral-fill-quiet: var(--vscode-button-secondaryBackground);
@@ -72,46 +77,87 @@
   );
   --wa-color-neutral-on-loud: var(--vscode-button-secondaryForeground);
 
-  /* Warning variant. */
+  /* ── Warning / danger / success variants ────────────────────────────────
+     One shape for all three, driven by a single theme-aware role colour:
+
+       fill-quiet   8% role over the raised surface
+       border-quiet 45% role
+       on-quiet     55% role mixed toward the normal text colour
+       fill-loud    the role colour itself
+       on-loud      the editor background
+
+     The on-quiet mix is what lets one expression work in both appearances:
+     it darkens the role colour on light themes and lightens it on dark ones
+     while holding hue. Binding a quiet fill and its on-colour to two members
+     of the same palette (as success did with charts.green + testing.iconPassed)
+     renders the variant on itself — 1.10:1 on dark themes.
+
+     Worst case across Dark Modern / Light Modern / Dark+ / Light+: quiet
+     4.54:1, loud 4.33:1. Danger-on-quiet is the floor at 5.33:1 (APCA Lc 46.5)
+     in dark themes, bounded by VS Code's own mid-lightness editorError colour;
+     going lighter to clear APCA's Lc 60 stops reading as an error. */
+
+  /* Warning variant. Loud keeps VS Code's own status-bar pairing: that fill is
+     darken(editorWarning.foreground, 0.4) in BOTH appearances, so an on-colour
+     that follows the theme's text lightness gives dark-on-dark in light
+     themes (1.57:1). */
   --wa-color-warning-fill-loud: var(--vscode-statusBarItem-warningBackground);
-  --wa-color-warning-on-loud: var(--vscode-editor-foreground);
-  --wa-color-warning-border-loud: var(--vscode-inputValidation-warningBorder);
-  --wa-color-warning-fill-quiet: var(
-    --vscode-editorWarning-background,
-    var(--vscode-inputValidation-warningBackground)
+  --wa-color-warning-on-loud: var(--vscode-statusBarItem-warningForeground);
+  --wa-color-warning-border-loud: transparent;
+  --wa-color-warning-fill-quiet: color-mix(
+    in srgb,
+    var(--vscode-editorWarning-foreground) 8%,
+    var(--wa-color-surface-raised)
   );
-  --wa-color-warning-border-quiet: var(--vscode-inputValidation-warningBorder);
-  --wa-color-warning-on-quiet: var(
-    --vscode-editorWarning-foreground,
-    var(--vscode-inputValidation-warningForeground)
+  --wa-color-warning-border-quiet: color-mix(
+    in srgb,
+    var(--vscode-editorWarning-foreground) 45%,
+    transparent
+  );
+  --wa-color-warning-on-quiet: color-mix(
+    in srgb,
+    var(--vscode-editorWarning-foreground) 55%,
+    var(--wa-color-text-normal)
   );
 
   /* Danger variant. */
   --wa-color-danger-fill-loud: var(--vscode-editorError-foreground);
-  --wa-color-danger-on-loud: #ffffff;
+  --wa-color-danger-on-loud: var(--vscode-editor-background);
   --wa-color-danger-border-loud: transparent;
-  --wa-color-danger-fill-quiet: var(--vscode-inputValidation-errorBackground);
-  --wa-color-danger-border-quiet: var(--vscode-inputValidation-errorBorder);
-  --wa-color-danger-on-quiet: var(
-    --vscode-editorError-foreground,
-    var(--vscode-errorForeground)
+  --wa-color-danger-fill-quiet: color-mix(
+    in srgb,
+    var(--vscode-editorError-foreground) 8%,
+    var(--wa-color-surface-raised)
+  );
+  --wa-color-danger-border-quiet: color-mix(
+    in srgb,
+    var(--vscode-editorError-foreground) 45%,
+    transparent
+  );
+  --wa-color-danger-on-quiet: color-mix(
+    in srgb,
+    var(--vscode-editorError-foreground) 55%,
+    var(--wa-color-text-normal)
   );
 
   /* Success variant. */
-  --wa-color-success-fill-loud: var(
-    --vscode-charts-green,
-    var(--vscode-testing-iconPassed)
-  );
-  --wa-color-success-on-loud: #ffffff;
+  --wa-color-success-fill-loud: var(--vscode-charts-green);
+  --wa-color-success-on-loud: var(--vscode-editor-background);
   --wa-color-success-border-loud: transparent;
-  --wa-color-success-fill-quiet: var(
-    --vscode-charts-green,
-    var(--vscode-inputValidation-infoBackground)
+  --wa-color-success-fill-quiet: color-mix(
+    in srgb,
+    var(--vscode-charts-green) 8%,
+    var(--wa-color-surface-raised)
   );
-  --wa-color-success-border-quiet: var(--vscode-inputValidation-infoBorder);
-  --wa-color-success-on-quiet: var(
-    --vscode-testing-iconPassed,
-    var(--vscode-charts-green)
+  --wa-color-success-border-quiet: color-mix(
+    in srgb,
+    var(--vscode-charts-green) 45%,
+    transparent
+  );
+  --wa-color-success-on-quiet: color-mix(
+    in srgb,
+    var(--vscode-charts-green) 55%,
+    var(--wa-color-text-normal)
   );
 
   /* Buttons — niche tokens consumers still need. */
@@ -143,8 +189,7 @@
   --wa-color-chart-orange: var(--vscode-charts-orange);
   --wa-color-chart-red: var(--vscode-charts-red);
   --wa-color-chart-yellow: var(--vscode-charts-yellow);
-  /* VS Code does not ship a charts.purple — fall back to keyword colour. */
-  --wa-color-chart-purple: light-dark(#8250df, #c586c0);
+  --wa-color-chart-purple: var(--vscode-charts-purple);
 
   /* Diff editor. */
   --wa-color-diff-inserted: var(--vscode-diffEditor-insertedTextBackground);

--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -50,20 +50,55 @@
   --wa-form-control-text-color: var(--vscode-input-foreground);
   --wa-form-control-border-color: var(--vscode-input-border);
 
-  /* Brand variant — primary buttons, links, focus accents. */
+  /* ── Semantic variants ──────────────────────────────────────────────────
+     One rule, no per-variant judgement: derive only what VS Code does not
+     ship, and derive it from what VS Code does ship.
+
+       ships background AND foreground → pass both through
+       ships one side                  → derive the other
+       ships only a role colour        → derive both sides from it
+
+     Each variant below names which case it is, so no line is a decision on
+     its own. Neutral and brand-loud are host pairs; warning-loud is a host
+     pair too (statusBarItem ships a background and a foreground); the status
+     roles ship a colour but no surface, so their quiet tiers derive.
+
+     A derived on-colour mixes toward --wa-color-text-normal rather than
+     toward black or white. That is what makes a single expression correct in
+     both appearances: it darkens the role colour on light themes and lightens
+     it on dark ones, holding hue either way.
+
+     Measured worst case over Dark Modern / Light Modern / Dark+ / Light+,
+     against each theme's own editorWidget.background: 4.74:1 quiet (warning
+     on Light Modern), 4.33:1 loud (success on light). Danger-on-quiet is the
+     APCA floor on dark themes at Lc 47.2 (5.6:1), which is VS Code's own
+     mid-lightness editorError colour — a lighter red stops reading as an
+     error.
+
+     The three steps are inputs to this sheet, not consumer tokens. */
+  --wa-variant-fill: 8%; /* role over the raised surface */
+  --wa-variant-border: 45%; /* role over transparent */
+  --wa-variant-ink: 55%; /* role toward the normal text colour */
+
+  /* Brand — primary buttons, links, focus accents.
+     loud: host pair. quiet: host ships the background only, and
+     inputValidation.infoForeground is null in every stock theme, so the
+     foreground derives to the colour that by definition reads on host
+     surfaces. Deriving it from the brand hue instead measures worse
+     (Lc 39.2 versus 68.7 on Dark+), because callout prose is body text
+     rather than a status label. */
   --wa-color-brand-fill-loud: var(--vscode-button-background);
   --wa-color-brand-on-loud: var(--vscode-button-foreground);
   --wa-color-brand-border-loud: var(--vscode-button-border, transparent);
   --wa-color-brand-fill-quiet: var(--vscode-inputValidation-infoBackground);
   --wa-color-brand-border-quiet: var(--vscode-inputValidation-infoBorder);
-  /* infoForeground is null in every stock theme, so this token would otherwise
-     be invalid and brand callouts would inherit body text by accident. */
   --wa-color-brand-on-quiet: var(
     --vscode-inputValidation-infoForeground,
     var(--wa-color-text-normal)
   );
 
-  /* Neutral variant — outlined wa-button / wa-callout, hovers. */
+  /* Neutral — outlined wa-button / wa-callout, hovers. Host pair throughout
+     (button.secondary*), so nothing derives. */
   --wa-color-neutral-fill-quiet: var(--vscode-button-secondaryBackground);
   --wa-color-neutral-border-quiet: var(
     --vscode-button-border,
@@ -77,86 +112,69 @@
   );
   --wa-color-neutral-on-loud: var(--vscode-button-secondaryForeground);
 
-  /* ── Warning / danger / success variants ────────────────────────────────
-     One shape for all three, driven by a single theme-aware role colour:
-
-       fill-quiet   8% role over the raised surface
-       border-quiet 45% role
-       on-quiet     55% role mixed toward the normal text colour
-       fill-loud    the role colour itself
-       on-loud      the editor background
-
-     The on-quiet mix is what lets one expression work in both appearances:
-     it darkens the role colour on light themes and lightens it on dark ones
-     while holding hue. Binding a quiet fill and its on-colour to two members
-     of the same palette (as success did with charts.green + testing.iconPassed)
-     renders the variant on itself — 1.10:1 on dark themes.
-
-     Worst case across Dark Modern / Light Modern / Dark+ / Light+: quiet
-     4.54:1, loud 4.33:1. Danger-on-quiet is the floor at 5.33:1 (APCA Lc 46.5)
-     in dark themes, bounded by VS Code's own mid-lightness editorError colour;
-     going lighter to clear APCA's Lc 60 stops reading as an error. */
-
-  /* Warning variant. Loud keeps VS Code's own status-bar pairing: that fill is
-     darken(editorWarning.foreground, 0.4) in BOTH appearances, so an on-colour
-     that follows the theme's text lightness gives dark-on-dark in light
-     themes (1.57:1). */
+  /* Warning — role colour editorWarning.foreground.
+     loud: host pair (statusBarItem.warningBackground is
+     darken(editorWarning.foreground, 0.4) in BOTH appearances, and the host
+     ships the matching foreground for it). quiet: host ships neither side for
+     this role, so both derive. */
   --wa-color-warning-fill-loud: var(--vscode-statusBarItem-warningBackground);
   --wa-color-warning-on-loud: var(--vscode-statusBarItem-warningForeground);
   --wa-color-warning-border-loud: transparent;
   --wa-color-warning-fill-quiet: color-mix(
     in srgb,
-    var(--vscode-editorWarning-foreground) 8%,
+    var(--vscode-editorWarning-foreground) var(--wa-variant-fill),
     var(--wa-color-surface-raised)
   );
   --wa-color-warning-border-quiet: color-mix(
     in srgb,
-    var(--vscode-editorWarning-foreground) 45%,
+    var(--vscode-editorWarning-foreground) var(--wa-variant-border),
     transparent
   );
   --wa-color-warning-on-quiet: color-mix(
     in srgb,
-    var(--vscode-editorWarning-foreground) 55%,
+    var(--vscode-editorWarning-foreground) var(--wa-variant-ink),
     var(--wa-color-text-normal)
   );
 
-  /* Danger variant. */
+  /* Danger — role colour editorError.foreground.
+     loud: host ships the role colour but no on-colour, so that side derives.
+     quiet: both sides derive. */
   --wa-color-danger-fill-loud: var(--vscode-editorError-foreground);
   --wa-color-danger-on-loud: var(--vscode-editor-background);
   --wa-color-danger-border-loud: transparent;
   --wa-color-danger-fill-quiet: color-mix(
     in srgb,
-    var(--vscode-editorError-foreground) 8%,
+    var(--vscode-editorError-foreground) var(--wa-variant-fill),
     var(--wa-color-surface-raised)
   );
   --wa-color-danger-border-quiet: color-mix(
     in srgb,
-    var(--vscode-editorError-foreground) 45%,
+    var(--vscode-editorError-foreground) var(--wa-variant-border),
     transparent
   );
   --wa-color-danger-on-quiet: color-mix(
     in srgb,
-    var(--vscode-editorError-foreground) 55%,
+    var(--vscode-editorError-foreground) var(--wa-variant-ink),
     var(--wa-color-text-normal)
   );
 
-  /* Success variant. */
+  /* Success — role colour charts.green. Same two cases as danger. */
   --wa-color-success-fill-loud: var(--vscode-charts-green);
   --wa-color-success-on-loud: var(--vscode-editor-background);
   --wa-color-success-border-loud: transparent;
   --wa-color-success-fill-quiet: color-mix(
     in srgb,
-    var(--vscode-charts-green) 8%,
+    var(--vscode-charts-green) var(--wa-variant-fill),
     var(--wa-color-surface-raised)
   );
   --wa-color-success-border-quiet: color-mix(
     in srgb,
-    var(--vscode-charts-green) 45%,
+    var(--vscode-charts-green) var(--wa-variant-border),
     transparent
   );
   --wa-color-success-on-quiet: color-mix(
     in srgb,
-    var(--vscode-charts-green) 55%,
+    var(--vscode-charts-green) var(--wa-variant-ink),
     var(--wa-color-text-normal)
   );
 


### PR DESCRIPTION
Fixes the colour findings from a review of the extension token bridge and the CLI TUI palette. Numbers are measured against VS Code's registered defaults and each stock theme's own overrides (extracted from the installed `workbench.desktop.main.js` and the bundled theme JSONs) across Dark Modern, Light Modern, Dark+ and Light+.

## The visible bug

`<wa-tag variant="success">Connected</wa-tag>` in the settings Account tab renders green text on a green background: **1.10:1 / APCA Lc 2.5** on dark themes, **2.16:1** on light. `--wa-color-success-fill-quiet` was bound to the full-strength `charts.green` while `--wa-color-success-on-quiet` was bound to `testing.iconPassed`, and Web Awesome pairs exactly those two tokens on `wa-tag`.

## The rule

Rather than fix each variant on its own judgement, the block now states one rule that every line is an instance of:

> **Derive only what VS Code does not ship, and derive it from what VS Code does ship.**

| Case | Tokens | Behaviour |
| --- | --- | --- |
| Host ships background **and** foreground | neutral, brand-loud, warning-loud | pass both through |
| Host ships one side | brand-quiet | derive the other |
| Host ships only a role colour | success/warning/danger quiet, success/danger loud | derive both |

This turns warning-loud from a carve-out into an instance: `statusBarItem` ships a warning background *and* a warning foreground, so it passes through. Previously `--wa-color-warning-on-loud` was the editor text colour over a fill that is `darken(editorWarning.foreground, 0.4)` in *both* appearances, giving dark-on-dark at **1.57:1** in light themes.

It also settles brand by measurement rather than preference. Deriving brand-quiet's foreground from the brand hue measures **Lc 39.2 versus 68.7** for the current value on Dark+, because callout prose is body text rather than a status label. So brand keeps the host's info surface and derives only the missing foreground — `inputValidation.infoForeground` is `null` in every stock theme, so that token was invalid and brand callouts inherited body text by accident.

The three derivation steps are declared once instead of repeated across nine declarations:

```css
--wa-variant-fill: 8%;    /* role over the raised surface */
--wa-variant-border: 45%; /* role over transparent */
--wa-variant-ink: 55%;    /* role toward the normal text colour */
```

A derived on-colour mixes toward `--wa-color-text-normal` rather than toward black or white. That is what makes a single expression correct in both appearances: it darkens the role colour on light themes and lightens it on dark ones, holding hue either way.

## Results

| Tier | Worst WCAG | Min \|Lc\| |
| --- | --- | --- |
| quiet (tag, callout) | 4.74 (warning, Light Modern) | 47.2 (danger, Dark Modern) |
| loud (filled) | 4.33 (success, light) | 39.4 (danger, dark) |

The success tag goes from **1.10:1 to 8.01:1** on Dark Modern and **2.16:1 to 5.74:1** on Light Modern. Because `litStyles.ts` derives `--color-success` / `--color-error` / `--color-warning` from the `*-on-quiet` tokens, status text in the progress and settings views improves with it (`--color-success` was `#73c991`, 2.0:1 on a white editor background).

Also gone: both hardcoded `#ffffff` on-colours, which were the only raw hex in extension source and measured 1.82:1 for success on dark themes. And `--wa-color-chart-purple` now points at the `charts.purple` VS Code does ship (`#652D90` / `#B180D7`); the removed hand-picked pair drifted 34.4 degrees in hue between appearances versus 2.3 for the host's own.

## CLI palette

Which roles need a light-background substitute is measured, not assumed. Red, blue, magenta and gray hold Lc 66-91 against white on the xterm, macOS Basic and VS Code Light+ palettes and are untouched. Green, yellow and cyan collapse to Lc 30-47 (1.70-2.56:1), under the Lc 60 floor for non-body text.

The three substitutes are one derivation rather than three picks — oklch lightness 0.48 at each role's own hue, chroma at the sRGB gamut boundary, so lightness is shared and only hue differs:

| role | hue | value | Lc on `#ffffff` / `#f5f5f5` |
| --- | --- | --- | --- |
| success | 150 | `#007132` | 80.1 / 74.2 |
| warning | 75 | `#7f5400` | 82.5 / 76.5 |
| hint | 220 | `#006980` | 80.8 / 74.9 |

They apply when `COLORFGBG` reports a light background. Terminals that never set it (Terminal.app, iTerm2, Alacritty) keep the ANSI names, so this can only improve a light terminal and never regresses a dark one. Resolved once at module load, so all ~136 call sites keep consuming plain strings.

The last 15 raw Ink literals move onto the palette (`runOnboarding`, `runOrchestrationTui`, `loginProviderPicker`, `runInitWizard`). All were exact semantic equivalents of `COLOR_HINT` / `COLOR_ERROR`; this is what makes the light-terminal fix reach those screens.

## Known limits

- Danger-on-quiet is the APCA floor at Lc 47.2 (5.6:1) on dark themes, above AA but under APCA's Lc 60 ideal for non-body text. That ceiling is VS Code's own mid-lightness `editorError.foreground`; a lighter red stops reading as an error.
- The CLI fix only reaches terminals that report `COLORFGBG`.
- `DiffView`'s bands still collapse to identical brightWhite-on-black on 16-colour terminals. The `+`/`-` markers keep the diff readable, so this degrades safely; recorded in a comment rather than gated on truecolor support.

## Verification

- `npm run typecheck` and `npm run lint` clean.
- 9 affected vitest suites pass (107 tests). No snapshot movement, as expected: the default environment sets no `COLORFGBG`.
- Nested `var()` inside `color-mix()` verified in headless Chrome rather than assumed, since a failure there would be silent. Computed values match the arithmetic exactly (`color(srgb 0.158431 0.18102 0.157176)` for the Dark Modern success fill).
- Palette resolution checked directly: unset and `15;0` give the ANSI names, `0;15` and `0;default;7` give the tuned hex.
- Contrast re-measured against each theme's own `editorWidget.background`, which Dark Modern (`#202020`) and Light Modern (`#F8F8F8`) both override away from the registry default.
- Not verified: neither UI was rendered live. A user theme can move any of these numbers in either direction.
