### PR TITLE
refactor: rename trace-viewer resource directories

### DIFF
--- a/packages/cli/scripts/copy-resources.mjs
+++ b/packages/cli/scripts/copy-resources.mjs
@@ -30,7 +30,7 @@ const runtimeResourceEntries = [
 // too as a defensive fallback for anyone invoking copy-resources.mjs in
 // isolation, so a missing prerequisite build warns instead of failing the
 // whole resource copy.
-const optionalRuntimeResourceEntries = ['traceViewer', 'traceViewerStandalone'];
+const optionalRuntimeResourceEntries = ['traceViewer', 'traceViewerShared'];
 
 async function copyEntry(entry, { optional = false } = {}) {
   try {

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -262,11 +262,13 @@ export async function readCliHistoryExportInput(
   return { status: 'incomplete' };
 }
 
-const TRACE_VIEWER_STANDALONE_DIR_NAME = 'traceViewerStandalone';
-const TRACE_VIEWER_SHARED_DIR_NAME = 'traceViewer';
+/** Single-file default export template (file://-safe, inlined assets). */
+const TRACE_VIEWER_DIR_NAME = 'traceViewer';
+/** Multi-file shared-assets bundle for CLI `--assets-dir` site hosting. */
+const TRACE_VIEWER_SHARED_DIR_NAME = 'traceViewerShared';
 
 /**
- * Read the trace-viewer's single-file standalone bundle — one self-contained
+ * Read the trace-viewer's single-file default bundle — one self-contained
  * `index.html` with no external `assets/` (JS/CSS/fonts all inlined) so the
  * default export opens correctly via `file://` with no server. Returns `null`
  * (without throwing) when the CLI install doesn't have the bundled template
@@ -278,7 +280,7 @@ export async function readCliHistoryStandaloneTemplate(
 ): Promise<string | null> {
   const templatePath = path.join(
     resourcesPath,
-    TRACE_VIEWER_STANDALONE_DIR_NAME,
+    TRACE_VIEWER_DIR_NAME,
     'index.html',
   );
   return readFile(templatePath, 'utf8').catch(() => null);
@@ -288,11 +290,11 @@ export async function readCliHistoryStandaloneTemplate(
  * Stage the trace-viewer's multi-file bundle (`index.html` + `assets/`) into
  * `destDir` for the shared-assets export mode (`--assets-dir`) — a site
  * hosting many traces points every trace's `?trace=` query param at one
- * shared bundle instead of duplicating it per trace. Unlike the standalone
- * bundle, this one keeps external `assets/` references, which is fine here:
- * shared-assets mode targets pages served over http(s), which never hits the
- * `file://` module-script CORS restriction the standalone bundle exists to
- * avoid (see `packages/trace-viewer/vite.standalone.config.ts`).
+ * shared bundle instead of duplicating it per trace. Unlike the default
+ * single-file bundle, this one keeps external `assets/` references, which is
+ * fine here: shared-assets mode targets pages served over http(s), which
+ * never hits the `file://` module-script CORS restriction the default
+ * bundle exists to avoid (see `packages/trace-viewer/vite.standalone.config.ts`).
  *
  * `fs.cp`'s recursive copy merges into an existing `destDir` rather than
  * nesting under it, so staging is safe to repeat across multiple exports

--- a/packages/desktop/src/main/desktopHistoryHandlers.ts
+++ b/packages/desktop/src/main/desktopHistoryHandlers.ts
@@ -201,11 +201,7 @@ export class DesktopHistoryHandlers implements DesktopHistorySettingsController 
     const controller = await this.getChatExportController();
     const outcome = await controller.exportAsHtml(
       historyId,
-      path.join(
-        this.dependencies.resourcesPath,
-        'traceViewerStandalone',
-        'index.html',
-      ),
+      path.join(this.dependencies.resourcesPath, 'traceViewer', 'index.html'),
     );
     if (outcome.status !== 'ok') {
       await this.dependencies.showInfoMessage(

--- a/packages/extension/.gitignore
+++ b/packages/extension/.gitignore
@@ -11,9 +11,10 @@
 resources/skills/
 
 # Built by packages/trace-viewer's vite configs during `pnpm run package:fast`
-# (prepare:trace-viewer-assets) — the multi-file bundle (shared-assets export
-# mode, served over http/https) and the single-file, fully self-contained
+# (prepare:trace-viewer-assets) — the single-file, fully self-contained
 # bundle (default export mode, opens via file:// with no server) used by the
-# `--export html` CLI export and the Settings view's "Export as HTML" button.
+# `--export html` CLI export and the Settings view's "Export as HTML" button,
+# and the multi-file bundle (shared-assets / --assets-dir export mode, served
+# over http/https).
 resources/traceViewer/
-resources/traceViewerStandalone/
+resources/traceViewerShared/

--- a/packages/extension/.vscodeignore
+++ b/packages/extension/.vscodeignore
@@ -33,20 +33,20 @@ CLAUDE.md
 
 # Multi-file, external-assets trace-viewer build (shared-assets/site-hosting
 # export mode) — CLI-only (packages/cli/src/runtime/history.ts), never
-# referenced by the extension host. resources/traceViewerStandalone (the
-# single-file build historyHandlers.ts actually loads) is unaffected.
+# referenced by the extension host. resources/traceViewer (the single-file
+# build historyHandlers.ts actually loads) is unaffected.
 #
 # No `!resources/**` line exists in this file (deliberately — see below), so
 # this plain ignore line works: vsce applies every `!`-negated line *after*
 # all plain ignore lines regardless of position in this file, so a blanket
 # `!resources/**` anywhere would silently re-include this directory no
-# matter where a plain `resources/traceViewer/**` ignore line was placed.
+# matter where a plain `resources/traceViewerShared/**` ignore line was placed.
 # A prior `!resources/**` line here was dead weight anyway — verified no
 # earlier rule in this file broadly excludes resources/ content (the only
 # earlier match is the specific `resources/.DS_Store` line above), so every
 # other resources/* entry (agents, docs, examples, templates, ...) is already
 # included by default with no unignore needed at all.
-resources/traceViewer/**
+resources/traceViewerShared/**
 
 # Webview HTML entry points (loaded by BaseViewContentProvider)
 !src/webview/*.html

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -59,14 +59,14 @@ export class HistoryHandlers {
     latexPreamble,
   });
 
-  /** Path to the bundled trace-viewer standalone template (under extension resources). */
-  private readonly traceViewerStandaloneTemplate: string;
+  /** Path to the bundled trace-viewer template (under extension resources). */
+  private readonly traceViewerTemplate: string;
 
   constructor(private readonly ctx: SettingsHandlerContext) {
-    this.traceViewerStandaloneTemplate = path.join(
+    this.traceViewerTemplate = path.join(
       ctx.extensionContext.extensionPath,
       'resources',
-      'traceViewerStandalone',
+      'traceViewer',
       'index.html',
     );
   }
@@ -249,7 +249,7 @@ export class HistoryHandlers {
   private async exportAndOpenHtml(historyId: string): Promise<void> {
     const outcome = await this.chatExportController.exportAsHtml(
       historyId,
-      this.traceViewerStandaloneTemplate,
+      this.traceViewerTemplate,
     );
 
     // assembleTrace's failure statuses, surfaced through exportAsHtml.

--- a/packages/trace-viewer/vite.config.ts
+++ b/packages/trace-viewer/vite.config.ts
@@ -9,12 +9,12 @@ import { aliases } from '../../scripts/aliases.mjs';
 // `packages/extension/resources/**` staging step
 // (packages/cli/scripts/copy-resources.mjs) picks it up without a separate
 // build-then-copy script. This is the shared, multi-file bundle (external
-// `assets/`) used by the shared-assets export mode — see
+// `assets/`) used by the shared-assets export mode (`--assets-dir`) — see
 // vite.standalone.config.ts for the single-file, self-contained bundle used
-// by the default export mode.
+// by the default export mode (resources/traceViewer).
 const RESOURCES_OUT_DIR = resolve(
   __dirname,
-  '../extension/resources/traceViewer',
+  '../extension/resources/traceViewerShared',
 );
 
 export default defineConfig({

--- a/packages/trace-viewer/vite.standalone.config.ts
+++ b/packages/trace-viewer/vite.standalone.config.ts
@@ -19,12 +19,13 @@ import { aliases } from '../../scripts/aliases.mjs';
  * leaving no external file for the module to fetch. This build backs the
  * CLI's/extension's default self-contained export, which must open via
  * `file://` with no server running. The regular multi-file build
- * (`vite.config.ts`) stays for the shared-assets, site-hosting case, which
- * is always served over http(s) and never hits this restriction.
+ * (`vite.config.ts` → resources/traceViewerShared) stays for the
+ * shared-assets, site-hosting case, which is always served over http(s)
+ * and never hits this restriction.
  */
 const RESOURCES_OUT_DIR = resolve(
   __dirname,
-  '../extension/resources/traceViewerStandalone',
+  '../extension/resources/traceViewer',
 );
 
 export default defineConfig({

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -704,7 +704,7 @@
   ],
   "requiredVscodeIgnoreLines": [
     "src/**",
-    "resources/traceViewer/**",
+    "resources/traceViewerShared/**",
     "!src/common/styles/*.css",
     "!src/progressView/*.html",
     "!src/settingsView/*.html",

--- a/scripts/extension-package-utils.mjs
+++ b/scripts/extension-package-utils.mjs
@@ -114,11 +114,13 @@ export function withoutCatalogDerivedContributes(packageJson) {
   return { ...packageJson, contributes: trimmedContributes };
 }
 
-// packages/extension/resources/traceViewer is the multi-file, external-assets
-// trace-viewer build (shared-assets/site-hosting export mode) — CLI-only
-// (packages/cli/src/runtime/history.ts), never referenced by the extension
-// host, so packages/extension/.vscodeignore deliberately excludes it from the
-// packaged VSIX. One source of truth for the directory name so
-// verify-extension-package-invariants.mjs's required .vscodeignore line and
-// verify-vsix-contents.mjs's resource-hash exclusion can't drift apart.
-export const EXCLUDED_TRACE_VIEWER_DIR = 'traceViewer';
+// packages/extension/resources/traceViewerShared is the multi-file,
+// external-assets trace-viewer build (shared-assets/site-hosting export
+// mode) — CLI-only (packages/cli/src/runtime/history.ts), never referenced by
+// the extension host, so packages/extension/.vscodeignore deliberately
+// excludes it from the packaged VSIX. resources/traceViewer is the
+// single-file default template and is packaged. One source of truth for the
+// directory name so verify-extension-package-invariants.mjs's required
+// .vscodeignore line and verify-vsix-contents.mjs's resource-hash exclusion
+// can't drift apart.
+export const EXCLUDED_TRACE_VIEWER_DIR = 'traceViewerShared';

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -628,8 +628,8 @@ async function checkBundledResources(app, failures) {
 
   await checkExists(
     app,
-    'resources/traceViewerStandalone/index.html',
-    'trace-viewer standalone HTML template',
+    'resources/traceViewer/index.html',
+    'trace-viewer HTML template',
     failures,
   );
 }
@@ -719,7 +719,7 @@ const summary = [
   '- dist/renderer/assets/*.css',
   '- dist/renderer/assets Monaco worker chunks',
   '- resources/agents, resources/tool_use_agents, and resources/skills',
-  '- resources/traceViewerStandalone/index.html',
+  '- resources/traceViewer/index.html',
   '- package.json runtime dependencies',
   '- node_modules runtime dependency packages',
   '- no bundled Codex or Claude Code CLI payload',

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -67,7 +67,7 @@ const BUILD_TIME_PACKAGED_PATHS = new Set([
   'resources/skills',
 ]);
 
-// See packages/extension/.vscodeignore for why resources/traceViewer is
+// See packages/extension/.vscodeignore for why resources/traceViewerShared is
 // excluded (and why there is deliberately no blanket `!resources/**` line).
 const REQUIRED_VSCODEIGNORE_LINES = [
   'src/**',
@@ -79,7 +79,7 @@ const REQUIRED_VSCODEIGNORE_LINES = [
 ];
 
 // A blanket `!resources/**` (or an equivalent whitespace variant) would
-// silently re-include resources/traceViewer no matter where the required
+// silently re-include resources/traceViewerShared no matter where the required
 // line above sits in .vscodeignore, since vsce applies every `!`-negated
 // line after all plain ignore lines regardless of file position. Guard
 // against a future PR reintroducing it for an unrelated reason.

--- a/scripts/verify-vsix-contents.mjs
+++ b/scripts/verify-vsix-contents.mjs
@@ -116,7 +116,7 @@ function verifyRequiredPaths(entries, snapshot, failures) {
   }
 }
 
-// See packages/extension/.vscodeignore for why resources/traceViewer is
+// See packages/extension/.vscodeignore for why resources/traceViewerShared is
 // excluded from the packaged VSIX (~3.4MB of CLI-only dead weight).
 const RESOURCE_HASH_EXCLUDED_PREFIX = `${EXCLUDED_TRACE_VIEWER_DIR}/`;
 

--- a/src/test-kernel/cli/History.vitest.ts
+++ b/src/test-kernel/cli/History.vitest.ts
@@ -1310,9 +1310,9 @@ describe('CLI history runtime', () => {
         tempDirs,
       );
       const cwd = await makeTempDir('texra-history-export-dest-', tempDirs);
-      const traceViewerDir = path.join(resourcesPath, 'traceViewer');
-      await mkdir(traceViewerDir, { recursive: true });
-      await writeFile(path.join(traceViewerDir, 'index.html'), '<html></html>');
+      const sharedDir = path.join(resourcesPath, 'traceViewerShared');
+      await mkdir(sharedDir, { recursive: true });
+      await writeFile(path.join(sharedDir, 'index.html'), '<html></html>');
 
       const destDir = path.join(cwd, 'shared-assets');
       const result = await stageCliHistoryTraceViewerAssets({
@@ -1343,19 +1343,17 @@ describe('CLI history runtime', () => {
 
     it('merges into a pre-existing destination directory instead of nesting under it', async () => {
       // A repeat export pointed at the same --assets-dir must not turn
-      // `<dir>/assets/index-xxx.js` into `<dir>/traceViewer/assets/index-xxx.js`.
+      // `<dir>/assets/index-xxx.js` into
+      // `<dir>/traceViewerShared/assets/index-xxx.js`.
       const resourcesPath = await makeTempDir(
         'texra-history-export-src-',
         tempDirs,
       );
       const cwd = await makeTempDir('texra-history-export-dest-', tempDirs);
-      const traceViewerDir = path.join(resourcesPath, 'traceViewer');
-      await mkdir(path.join(traceViewerDir, 'assets'), { recursive: true });
-      await writeFile(path.join(traceViewerDir, 'index.html'), '<html></html>');
-      await writeFile(
-        path.join(traceViewerDir, 'assets', 'index.js'),
-        'js-bytes',
-      );
+      const sharedDir = path.join(resourcesPath, 'traceViewerShared');
+      await mkdir(path.join(sharedDir, 'assets'), { recursive: true });
+      await writeFile(path.join(sharedDir, 'index.html'), '<html></html>');
+      await writeFile(path.join(sharedDir, 'assets', 'index.js'), 'js-bytes');
 
       const destDir = path.join(cwd, 'shared-assets');
       await mkdir(destDir, { recursive: true });
@@ -1383,15 +1381,15 @@ describe('CLI history runtime', () => {
       );
     });
 
-    it('reads the bundled trace-viewer standalone template', async () => {
+    it('reads the bundled trace-viewer default template', async () => {
       const resourcesPath = await makeTempDir(
         'texra-history-standalone-',
         tempDirs,
       );
-      const standaloneDir = path.join(resourcesPath, 'traceViewerStandalone');
-      await mkdir(standaloneDir, { recursive: true });
+      const traceViewerDir = path.join(resourcesPath, 'traceViewer');
+      await mkdir(traceViewerDir, { recursive: true });
       await writeFile(
-        path.join(standaloneDir, 'index.html'),
+        path.join(traceViewerDir, 'index.html'),
         '<html>standalone</html>',
       );
 
@@ -1400,7 +1398,7 @@ describe('CLI history runtime', () => {
       ).resolves.toBe('<html>standalone</html>');
     });
 
-    it('returns null instead of throwing when the standalone template is absent', async () => {
+    it('returns null instead of throwing when the default template is absent', async () => {
       const resourcesPath = await makeTempDir(
         'texra-history-standalone-empty-',
         tempDirs,
@@ -1457,15 +1455,12 @@ describe('CLI history runtime', () => {
         stderrSpy.mockRestore();
       });
 
-      /** Temp resources dir holding the bundled trace-viewer assets. */
+      /** Temp resources dir holding the bundled shared trace-viewer assets. */
       async function makeStagedResources(prefix: string): Promise<string> {
         const resourcesPath = await makeTempDir(prefix, tempDirs);
-        const traceViewerDir = path.join(resourcesPath, 'traceViewer');
-        await mkdir(traceViewerDir, { recursive: true });
-        await writeFile(
-          path.join(traceViewerDir, 'index.html'),
-          '<html></html>',
-        );
+        const sharedDir = path.join(resourcesPath, 'traceViewerShared');
+        await mkdir(sharedDir, { recursive: true });
+        await writeFile(path.join(sharedDir, 'index.html'), '<html></html>');
         return resourcesPath;
       }
 

--- a/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.ts
+++ b/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.ts
@@ -503,7 +503,7 @@ describe('DesktopHistoryHandlers', () => {
 
     expect(chatExportMocks.exportAsHtml).toHaveBeenCalledWith(
       'abc',
-      `${RESOURCES_PATH}/traceViewerStandalone/index.html`,
+      `${RESOURCES_PATH}/traceViewer/index.html`,
     );
     expect(openPath).toHaveBeenCalledWith('/tmp/executions/abc/chat.html');
   });

--- a/src/test-kernel/desktop/DesktopPackagePayload.vitest.ts
+++ b/src/test-kernel/desktop/DesktopPackagePayload.vitest.ts
@@ -125,16 +125,14 @@ describe('desktop package native CLI payload', () => {
     }
   });
 
-  it('requires the standalone trace-viewer template in packaged resources', () => {
+  it('requires the trace-viewer template in packaged resources', () => {
     const { packageRoot, resourcesDir } = createFakeDesktopPackage();
-    rmSync(
-      join(resourcesDir, 'resources', 'traceViewerStandalone', 'index.html'),
-    );
+    rmSync(join(resourcesDir, 'resources', 'traceViewer', 'index.html'));
 
     const result = runVerifier(packageRoot);
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
-      'Missing trace-viewer standalone HTML template: resources/traceViewerStandalone/index.html',
+      'Missing trace-viewer HTML template: resources/traceViewer/index.html',
     );
   });
 
@@ -244,7 +242,7 @@ function createFakeDesktopPackage(
     'name: example\n\ndescription: Example bundled skill.\n',
   );
   writeText(
-    join(appRoot, 'resources/traceViewerStandalone/index.html'),
+    join(appRoot, 'resources/traceViewer/index.html'),
     '<!doctype html>\n',
   );
 


### PR DESCRIPTION
## Summary

- Rename the default single-file export template from `resources/traceViewerStandalone` to `resources/traceViewer` (extension, desktop, and CLI default HTML export).
- Rename the multi-file shared-assets bundle from `resources/traceViewer` to `resources/traceViewerShared` (CLI `--assets-dir` only).
- Update Vite outDirs, package/copy/verify scripts, VSIX ignore rules, runtime paths, and tests so packaging still includes the default template and excludes the CLI-only shared build.

## Test plan

- [x] `npx vitest run src/test-kernel/cli/History.vitest.ts src/test-kernel/desktop/DesktopHistoryHandlers.vitest.ts src/test-kernel/desktop/DesktopPackagePayload.vitest.ts`
- [x] `node scripts/verify-extension-package-invariants.mjs`
- [ ] After build: confirm `packages/extension/resources/traceViewer/index.html` is the single-file template and `traceViewerShared/` has the multi-file assets
- [ ] Smoke: extension/desktop HTML history export opens via `file://`
- [ ] Smoke: `texra history show <id> --export html --assets-dir <dir>` stages shared assets from `traceViewerShared`