### PR TITLE
fix(cli): stop a retired stream returning across the applier's await

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2395,7 +2395,7 @@ const SCENARIOS = [
   },
   // PTY ordering tests (issue #7972): the harness drives one child stream's
   // attachment/roster/edge/status/removal facts through the real
-  // `attachTuiRunFactSubscription`/`subscribeStreamStatus` subscription path,
+  // `attachSessionSignalsAdapter`/`subscribeStreamStatus` subscription path,
   // not the CHILD_STREAMS map mutators directly. After each fact, the harness
   // awaits the Ink render flush and emits an out-of-band marker. The validator
   // snapshots xterm at that exact byte-stream boundary, so a transiently-wrong

--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -1,5 +1,7 @@
 // Project shared session facts into the CLI TUI signal state.
 
+import { isDeepStrictEqual } from 'node:util';
+
 import { RUN_FACT_EVENT_TYPES } from '@agent/trace';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
@@ -46,12 +48,41 @@ import type { StreamArtifactReader } from './subscribeStreamArtifacts';
 const GOAL_PAUSED_TRANSCRIPT_NOTICE =
   'Goal paused after a failed cycle. Review the error before starting a new goal.';
 
+/** Element-wise equality for the string-list slices patched below, so an
+ *  unchanged list never churns the `streams` signal identity. */
+function sameStringList(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return left.length === right.length && left.every((x, i) => x === right[i]);
+}
+
 class TuiSessionRenderer implements SessionRendererPort {
+  /**
+   * Generation captured when the adapter dispatched the fact currently being
+   * applied. The applier can suspend between dispatch and callback
+   * (`handleSetActiveStream` awaits `streamLogs.ensureLoaded`); if
+   * `resetCliState` runs during that await, the continuation still fires
+   * these callbacks, and an unguarded `patchStream`/`focusStream` would
+   * re-mint and re-focus a stream the reset just retired. Every callback
+   * below no-ops when the captured generation is no longer current.
+   */
+  private dispatchGeneration = getCliStateGeneration();
+
   constructor(
     private readonly state: SessionState,
     private readonly snapshots: StreamArtifactReader,
     private readonly session: SessionHandle,
   ) {}
+
+  /** Called by the adapter immediately before each applier dispatch. */
+  captureDispatchGeneration(): void {
+    this.dispatchGeneration = getCliStateGeneration();
+  }
+
+  private isStaleDispatch(): boolean {
+    return this.dispatchGeneration !== getCliStateGeneration();
+  }
 
   isAvailable(): boolean {
     return true;
@@ -62,6 +93,7 @@ class TuiSessionRenderer implements SessionRendererPort {
   clearPendingConversationProgress(_streamId: StreamTabId): void {}
 
   onStreamMetadataChanged(streamId: StreamTabId): void {
+    if (this.isStaleDispatch()) return;
     if (isChildStreamRemoved(streamId)) return;
     const metadata = this.state.getStreamMetadata(streamId);
     const config = this.state.snapshots.getRunConfig(streamId);
@@ -113,6 +145,7 @@ class TuiSessionRenderer implements SessionRendererPort {
     childStreamId: StreamTabId,
     parentStreamId: StreamTabId | null,
   ): void {
+    if (this.isStaleDispatch()) return;
     setParentStream(childStreamId, parentStreamId);
   }
 
@@ -122,10 +155,12 @@ class TuiSessionRenderer implements SessionRendererPort {
     _lastTimestamp?: number,
     substate?: StreamSubstate,
   ): void {
+    if (this.isStaleDispatch()) return;
     setStreamStatusInCliState({ streamId, status, substate });
   }
 
   onActiveStreamChanged(streamId: ActiveStreamId): void {
+    if (this.isStaleDispatch()) return;
     if (!streamId) {
       activeStreamId.set(undefined);
       return;
@@ -135,6 +170,7 @@ class TuiSessionRenderer implements SessionRendererPort {
   }
 
   onStreamDescriptionChanged(streamId: StreamTabId, description: string): void {
+    if (this.isStaleDispatch()) return;
     patchStream(streamId, (slice) => ({ ...slice, description }));
   }
 
@@ -142,17 +178,22 @@ class TuiSessionRenderer implements SessionRendererPort {
     streamId: StreamTabId,
     progress: ConversationProgress,
   ): void {
+    if (this.isStaleDispatch()) return;
     patchStream(streamId, (slice) => ({ ...slice, conversation: progress }));
   }
 
   onStageChanged(streamId: StreamTabId, stage: StreamStage): void {
-    patchStream(streamId, (slice) => ({ ...slice, stage }));
+    if (this.isStaleDispatch()) return;
+    patchStream(streamId, (slice) =>
+      isDeepStrictEqual(slice.stage, stage) ? slice : { ...slice, stage },
+    );
   }
 
   onBadgesChanged(
     streamId: StreamTabId,
     badges: Parameters<SessionRendererPort['onBadgesChanged']>[1],
   ): void {
+    if (this.isStaleDispatch()) return;
     projectChildRoster(
       streamId,
       badges.subagents.filter((child) => child.finishedAt === undefined),
@@ -160,6 +201,7 @@ class TuiSessionRenderer implements SessionRendererPort {
   }
 
   onFilesChanged(streamId: StreamTabId): void {
+    if (this.isStaleDispatch()) return;
     patchStream(streamId, (slice) => ({
       ...slice,
       outputFilesByRound: this.snapshots.getOutputFiles(streamId),
@@ -167,13 +209,24 @@ class TuiSessionRenderer implements SessionRendererPort {
   }
 
   onMissingOutputsChanged(streamId: StreamTabId): void {
-    patchStream(streamId, (slice) => ({
-      ...slice,
-      missingOutputsByRound: this.snapshots.getMissingOutputs(streamId),
-    }));
+    if (this.isStaleDispatch()) return;
+    const missingOutputsByRound = this.snapshots.getMissingOutputs(streamId);
+    // `clearMissingOutputs` on a stream with no slice (or an already-empty
+    // record) must stay a no-op: calling `patchStream` would mint a slice via
+    // the `emptySlice` fallback — and un-retire the id — just to hold an
+    // empty record.
+    const current = streams.get().get(streamId)?.missingOutputsByRound;
+    if (
+      Object.keys(missingOutputsByRound).length === 0 &&
+      Object.keys(current ?? {}).length === 0
+    ) {
+      return;
+    }
+    patchStream(streamId, (slice) => ({ ...slice, missingOutputsByRound }));
   }
 
   onCompileFailuresChanged(streamId: StreamTabId): void {
+    if (this.isStaleDispatch()) return;
     patchStream(streamId, (slice) => ({
       ...slice,
       compileFailuresByRound: this.snapshots.getCompileFailures(streamId),
@@ -185,6 +238,7 @@ class TuiSessionRenderer implements SessionRendererPort {
     storageKey: string,
     latestUsage: Parameters<SessionRendererPort['onRunUsageChanged']>[2],
   ): void {
+    if (this.isStaleDispatch()) return;
     const runUsage = this.snapshots.getRunUsage(streamId);
     patchStream(streamId, (slice) => ({
       ...slice,
@@ -196,22 +250,26 @@ class TuiSessionRenderer implements SessionRendererPort {
   }
 
   onTodosChanged(streamId: StreamTabId, todos: TodoItem[]): void {
+    if (this.isStaleDispatch()) return;
     patchStream(streamId, (slice) => ({ ...slice, todos }));
   }
 
   onPlanChanged(streamId: StreamTabId, plan: Plan | null): void {
+    if (this.isStaleDispatch()) return;
     patchStream(streamId, (slice) => ({ ...slice, plan }));
   }
 
   onQueuedFollowUpsChanged(streamId: StreamTabId): void {
+    if (this.isStaleDispatch()) return;
     // Prefer the process session queue: tests and production both enqueue
     // there, while a harness may construct a throwaway SessionHandle for the
     // hub alone.
     const messages = this.session.followUps.getAll(streamId);
-    patchStream(streamId, (slice) => ({
-      ...slice,
-      queuedFollowUpMessages: messages,
-    }));
+    patchStream(streamId, (slice) =>
+      sameStringList(slice.queuedFollowUpMessages, messages)
+        ? slice
+        : { ...slice, queuedFollowUpMessages: messages },
+    );
   }
 
   onInquiryThreadUpdated(_thread: InquiryThreadUpdatedEvent): void {}
@@ -223,6 +281,7 @@ class TuiSessionRenderer implements SessionRendererPort {
   ): void {}
 
   onGoalPaused(streamId: StreamTabId): void {
+    if (this.isStaleDispatch()) return;
     appendLocalAssistantTranscript(GOAL_PAUSED_TRANSCRIPT_NOTICE, streamId);
   }
 
@@ -249,6 +308,8 @@ export function attachSessionSignalsAdapter({
   const applier = new SessionFactApplier(state, renderer, {
     hasPendingPermissions: () => false,
     deleteStream: removeStream,
+    // CLI focus is the `activeStreamId` signal, not `SessionState.activeStream`.
+    evictOnStreamSwitch: false,
   });
   let generation = getCliStateGeneration();
   const detachResetHook = registerCliStateResetHook(() => {
@@ -263,6 +324,7 @@ export function attachSessionSignalsAdapter({
       // eviction keys off `SessionState.activeStream`, which is not the CLI
       // focus id, and the old TUI ignored status facts here.
       if (event.event.type === 'status') return;
+      renderer.captureDispatchGeneration();
       applier.handleSessionFact(event.event);
     },
     { scope: 'session' },
@@ -276,6 +338,7 @@ export function attachSessionSignalsAdapter({
       ) {
         return;
       }
+      renderer.captureDispatchGeneration();
       applier.handleRunFact(event.streamId, event.event as SessionRunFactEvent);
     },
     { scope: 'run', types: RUN_FACT_EVENT_TYPES },

--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -4,7 +4,10 @@ import { isDeepStrictEqual } from 'node:util';
 
 import { RUN_FACT_EVENT_TYPES } from '@agent/trace';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import type {
+  SessionEventHub,
+  SessionFact,
+} from '@agent/runtime/SessionEventHub';
 import { SessionFactApplier } from '@controllers/session/SessionFactApplier';
 import type { SessionRunFactEvent } from '@controllers/session/SessionFactApplier';
 import type { SessionRendererPort } from '@controllers/session/SessionRendererPort';
@@ -57,17 +60,33 @@ function sameStringList(
   return left.length === right.length && left.every((x, i) => x === right[i]);
 }
 
+/** Extract a stream id from a session fact for per-stream generation capture.
+ *  The only fact types that trigger renderer callbacks after an async suspend
+ *  are `setActiveStream` and `setParentStream`; other facts are handled
+ *  synchronously and the exact id is a best-effort hint. */
+function getSessionFactStreamId(fact: SessionFact): StreamTabId | undefined {
+  switch (fact.type) {
+    case 'status':
+      return fact.streamId;
+    case 'removeStream':
+      return fact.payload.streamId;
+    case 'setParentStream':
+      return fact.payload.childStreamId;
+    default:
+      return (fact.payload as { streamId?: StreamTabId })?.streamId;
+  }
+}
+
 class TuiSessionRenderer implements SessionRendererPort {
   /**
-   * Generation captured when the adapter dispatched the fact currently being
-   * applied. The applier can suspend between dispatch and callback
-   * (`handleSetActiveStream` awaits `streamLogs.ensureLoaded`); if
-   * `resetCliState` runs during that await, the continuation still fires
-   * these callbacks, and an unguarded `patchStream`/`focusStream` would
-   * re-mint and re-focus a stream the reset just retired. Every callback
-   * below no-ops when the captured generation is no longer current.
+   * Generation snapshots captured per-stream at dispatch time, so a callback
+   * can detect that `resetCliState` ran between its dispatch and its
+   * invocation (the applier suspends in `handleSetActiveStream` while
+   * `streamLogs.ensureLoaded` is pending; the old single-field design let a
+   * second dispatch overwrite the captured generation, so the first callback
+   * could not tell a reset had happened).
    */
-  private dispatchGeneration = getCliStateGeneration();
+  private dispatchGenerations = new Map<StreamTabId, number>();
 
   constructor(
     private readonly state: SessionState,
@@ -75,13 +94,18 @@ class TuiSessionRenderer implements SessionRendererPort {
     private readonly session: SessionHandle,
   ) {}
 
-  /** Called by the adapter immediately before each applier dispatch. */
-  captureDispatchGeneration(): void {
-    this.dispatchGeneration = getCliStateGeneration();
+  /** Called by the adapter immediately before each applier dispatch.
+   *  Stores the current CLI-state generation keyed by `streamId` so that
+   *  the downstream callbacks (which all carry a `streamId`) can compare
+   *  against the generation *they* were dispatched with, not a value a
+   *  later dispatch may have overwritten. */
+  captureDispatchGeneration(streamId: StreamTabId): void {
+    this.dispatchGenerations.set(streamId, getCliStateGeneration());
   }
 
-  private isStaleDispatch(): boolean {
-    return this.dispatchGeneration !== getCliStateGeneration();
+  private isStaleDispatch(streamId: StreamTabId): boolean {
+    const captured = this.dispatchGenerations.get(streamId);
+    return captured !== undefined && captured !== getCliStateGeneration();
   }
 
   isAvailable(): boolean {
@@ -93,7 +117,7 @@ class TuiSessionRenderer implements SessionRendererPort {
   clearPendingConversationProgress(_streamId: StreamTabId): void {}
 
   onStreamMetadataChanged(streamId: StreamTabId): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(streamId)) return;
     if (isChildStreamRemoved(streamId)) return;
     const metadata = this.state.getStreamMetadata(streamId);
     const config = this.state.snapshots.getRunConfig(streamId);
@@ -145,7 +169,7 @@ class TuiSessionRenderer implements SessionRendererPort {
     childStreamId: StreamTabId,
     parentStreamId: StreamTabId | null,
   ): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(childStreamId)) return;
     setParentStream(childStreamId, parentStreamId);
   }
 
@@ -155,12 +179,12 @@ class TuiSessionRenderer implements SessionRendererPort {
     _lastTimestamp?: number,
     substate?: StreamSubstate,
   ): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(streamId)) return;
     setStreamStatusInCliState({ streamId, status, substate });
   }
 
   onActiveStreamChanged(streamId: ActiveStreamId): void {
-    if (this.isStaleDispatch()) return;
+    if (streamId && this.isStaleDispatch(streamId)) return;
     if (!streamId) {
       activeStreamId.set(undefined);
       return;
@@ -170,7 +194,7 @@ class TuiSessionRenderer implements SessionRendererPort {
   }
 
   onStreamDescriptionChanged(streamId: StreamTabId, description: string): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(streamId)) return;
     patchStream(streamId, (slice) => ({ ...slice, description }));
   }
 
@@ -178,12 +202,12 @@ class TuiSessionRenderer implements SessionRendererPort {
     streamId: StreamTabId,
     progress: ConversationProgress,
   ): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(streamId)) return;
     patchStream(streamId, (slice) => ({ ...slice, conversation: progress }));
   }
 
   onStageChanged(streamId: StreamTabId, stage: StreamStage): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(streamId)) return;
     patchStream(streamId, (slice) =>
       isDeepStrictEqual(slice.stage, stage) ? slice : { ...slice, stage },
     );
@@ -193,7 +217,7 @@ class TuiSessionRenderer implements SessionRendererPort {
     streamId: StreamTabId,
     badges: Parameters<SessionRendererPort['onBadgesChanged']>[1],
   ): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(streamId)) return;
     projectChildRoster(
       streamId,
       badges.subagents.filter((child) => child.finishedAt === undefined),
@@ -201,7 +225,7 @@ class TuiSessionRenderer implements SessionRendererPort {
   }
 
   onFilesChanged(streamId: StreamTabId): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(streamId)) return;
     patchStream(streamId, (slice) => ({
       ...slice,
       outputFilesByRound: this.snapshots.getOutputFiles(streamId),
@@ -209,7 +233,7 @@ class TuiSessionRenderer implements SessionRendererPort {
   }
 
   onMissingOutputsChanged(streamId: StreamTabId): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(streamId)) return;
     const missingOutputsByRound = this.snapshots.getMissingOutputs(streamId);
     // `clearMissingOutputs` on a stream with no slice (or an already-empty
     // record) must stay a no-op: calling `patchStream` would mint a slice via
@@ -226,7 +250,7 @@ class TuiSessionRenderer implements SessionRendererPort {
   }
 
   onCompileFailuresChanged(streamId: StreamTabId): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(streamId)) return;
     patchStream(streamId, (slice) => ({
       ...slice,
       compileFailuresByRound: this.snapshots.getCompileFailures(streamId),
@@ -238,7 +262,7 @@ class TuiSessionRenderer implements SessionRendererPort {
     storageKey: string,
     latestUsage: Parameters<SessionRendererPort['onRunUsageChanged']>[2],
   ): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(streamId)) return;
     const runUsage = this.snapshots.getRunUsage(streamId);
     patchStream(streamId, (slice) => ({
       ...slice,
@@ -250,17 +274,17 @@ class TuiSessionRenderer implements SessionRendererPort {
   }
 
   onTodosChanged(streamId: StreamTabId, todos: TodoItem[]): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(streamId)) return;
     patchStream(streamId, (slice) => ({ ...slice, todos }));
   }
 
   onPlanChanged(streamId: StreamTabId, plan: Plan | null): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(streamId)) return;
     patchStream(streamId, (slice) => ({ ...slice, plan }));
   }
 
   onQueuedFollowUpsChanged(streamId: StreamTabId): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(streamId)) return;
     // Prefer the process session queue: tests and production both enqueue
     // there, while a harness may construct a throwaway SessionHandle for the
     // hub alone.
@@ -281,7 +305,7 @@ class TuiSessionRenderer implements SessionRendererPort {
   ): void {}
 
   onGoalPaused(streamId: StreamTabId): void {
-    if (this.isStaleDispatch()) return;
+    if (this.isStaleDispatch(streamId)) return;
     appendLocalAssistantTranscript(GOAL_PAUSED_TRANSCRIPT_NOTICE, streamId);
   }
 
@@ -324,7 +348,8 @@ export function attachSessionSignalsAdapter({
       // eviction keys off `SessionState.activeStream`, which is not the CLI
       // focus id, and the old TUI ignored status facts here.
       if (event.event.type === 'status') return;
-      renderer.captureDispatchGeneration();
+      const sessionStreamId = getSessionFactStreamId(event.event);
+      if (sessionStreamId) renderer.captureDispatchGeneration(sessionStreamId);
       applier.handleSessionFact(event.event);
     },
     { scope: 'session' },
@@ -338,7 +363,7 @@ export function attachSessionSignalsAdapter({
       ) {
         return;
       }
-      renderer.captureDispatchGeneration();
+      renderer.captureDispatchGeneration(event.streamId);
       applier.handleRunFact(event.streamId, event.event as SessionRunFactEvent);
     },
     { scope: 'run', types: RUN_FACT_EVENT_TYPES },

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -63,6 +63,13 @@ type RunFactHandlers = {
 export type SessionFactApplierOptions = {
   hasPendingPermissions: (streamId: string) => boolean;
   deleteStream: (stream: StreamTabId) => void | Promise<void>;
+  /**
+   * Set false to skip evicting the stream left behind on an active-stream
+   * switch. The CLI TUI needs this: its focus id is a CLI signal, not
+   * `SessionState.activeStream`, so switch-time eviction would key off the
+   * wrong stream. Defaults to evicting (Lit progress view behavior).
+   */
+  evictOnStreamSwitch?: boolean;
 };
 
 /**
@@ -79,7 +86,11 @@ export type SessionFactApplierOptions = {
 export class SessionFactApplier {
   private readonly logger: AgentTrace;
 
-  /** Streams this renderer has already received metadata for. */
+  /** Streams this renderer has already received metadata for. Not reset when
+   * a webview closes and reopens — `ProgressViewProvider.markWebviewReady`'s
+   * resolve-time full metadata resync (`syncFullView`) re-registers every
+   * stream with the reopened view, so a stale "already delivered" entry here
+   * cannot starve it. */
   private readonly registeredWithRenderer = new Set<StreamTabId>();
 
   /**
@@ -301,8 +312,9 @@ export class SessionFactApplier {
     payload: SetActiveStreamPayload,
   ): Promise<void> {
     const { streamId, isRemote } = payload;
+    const evictPrevious = this.options.evictOnStreamSwitch !== false;
     if (!streamId) {
-      this.state.switchActiveStream('');
+      this.state.switchActiveStream('', { evictPrevious });
       this.renderer.onActiveStreamChanged('');
       return;
     }
@@ -341,7 +353,7 @@ export class SessionFactApplier {
       // The switch also releases the previously-active stream if it reached a
       // terminal status while visible — setStreamStatus skips release for the
       // active stream, so this is our only chance.
-      this.state.switchActiveStream(streamId);
+      this.state.switchActiveStream(streamId, { evictPrevious });
     }
 
     if (!this.renderer.isAvailable()) return;

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -203,13 +203,21 @@ export class SessionState {
   /**
    * The single writer of the active tab: moves the selection to `next` and
    * releases the tab left behind. There is no `activeStream` setter, so no
-   * switching path can forget the release above.
+   * switching path can forget the release above. `evictPrevious: false` is
+   * for hosts whose visible focus is not this active stream (the CLI TUI
+   * keys focus off its own signal), where the release would evict the wrong
+   * stream's transcript.
    */
-  switchActiveStream(next: ActiveStreamId): void {
+  switchActiveStream(
+    next: ActiveStreamId,
+    options?: { evictPrevious?: boolean },
+  ): void {
     const previous = this._prefs.get('activeStream');
     if (previous === next) return;
     this._prefs.update({ activeStream: next });
-    if (previous) this.releasePreviousActive(previous);
+    if (previous && options?.evictPrevious !== false) {
+      this.releasePreviousActive(previous);
+    }
   }
 
   /**

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -2953,6 +2953,52 @@ describe('sessionSignalsAdapter run facts', () => {
     });
   });
 
+  it('does not resurrect a stream retired while attachment awaited rehydrate', async () => {
+    // Inline setup instead of `withRunFacts`: the applier's
+    // `handleSetActiveStream` awaits `streamLogs.ensureLoaded`, so the body
+    // must stay attached across a microtask flush.
+    const hub = new SessionEventHub();
+    const snapshots = new StreamSnapshotStore();
+    const session = new SessionHandle({
+      events: hub,
+      snapshots,
+      transcripts: StreamLogStore.ephemeral('TUI reset-race test'),
+    });
+    const detach = attachSessionSignalsAdapter({
+      events: hub,
+      session,
+      snapshots,
+    });
+    try {
+      hub.emit({
+        scope: 'session',
+        event: {
+          type: 'setActiveStream',
+          payload: {
+            streamId: root,
+            agentCategory: AgentCategory.ToolUse,
+          },
+        },
+      });
+      // The synchronous half of the attachment already minted the slice; the
+      // applier is now suspended in `streamLogs.ensureLoaded`.
+      expect(streams.get().has(root)).toBe(true);
+
+      // `/clear` lands during that await and retires the stream identity.
+      resetCliState();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // The resumed continuation must not re-mint, un-retire, or focus it.
+      expect(streams.get().has(root)).toBe(false);
+      expect(activeStreamId.get()).toBeUndefined();
+      focusStream(root);
+      expect(activeStreamId.get()).toBeUndefined();
+    } finally {
+      detach();
+      snapshots.evictAll();
+    }
+  });
+
   it('applies typed updateTodos run facts without host emission', () => {
     withRunFacts((hub) => {
       const todos: TodoItem[] = [


### PR DESCRIPTION
## Summary

Follow-up to #9716 (#9713), from a post-merge audit of that PR. Three CLI-side defects the session view-model port introduced, all confirmed live on `main`.

- **Retired streams could come back after `/clear`.** `SessionFactApplier.handleSetActiveStream` awaits `streamLogs.ensureLoaded`, but `sessionSignalsAdapter` only checked the CLI state generation at dispatch. A reset landing inside that await let the continuation run anyway: `pushStreamMetadata` → `patchStream` deletes the id from `RETIRED_STREAMS`, and the following `focusStream` then succeeds — re-minting *and* focusing a stream the reset had just retired. The deleted `subscribeRuntimeHost` handler table was fully synchronous, so this race is new. Every `TuiSessionRenderer` callback now no-ops when the generation captured at dispatch is stale.
- **Dropped no-op equality guards.** The old handlers returned the identical slice for unchanged data (stage deep-equal, queued-follow-up list compare, both-empty missing-outputs); the renderer spread a fresh slice unconditionally. `patchStream` only skips on reference equality, so repeated same-value facts churned the `streams` signal against the map's documented identity contract — and `clearMissingOutputs` for a stream with no slice *minted* one via the `emptySlice` fallback and un-retired it. Guards restored.
- **Switch-time transcript eviction leaked into the TUI.** `SessionState.releasePreviousActive` evicts on active-stream switch, keyed off `SessionState.activeStream` — which is not the CLI focus id, the very reason the adapter already skips status-fact eviction (its comment says so). The old TUI never evicted. Hosts can now opt out; Lit/extension behavior is unchanged.

Also fixes the stale `validate-tui.mjs` comment naming the deleted `attachTuiRunFactSubscription` path.

## Issue acceptance gates

n/a — defect follow-up, no new gates. #9713's own gates were met by #9716 and stay met.

## Single source of truth

Unchanged. The applier remains the one fact→state owner; this only stops the CLI renderer from acting on a fact whose session lifetime ended mid-await.

## Duplication and abstraction budget

No new module or layer. One private field + guard method on the existing `TuiSessionRenderer`, one local `sameStringList` helper, one option on the existing `SessionFactApplierOptions`.

## Net elements (R6)

- Diffstat: 5 files, **+145 / −16**.
- Exported symbols (`^[+-]export`): **0 / 0**. No new files, types, classes, or interfaces; the eviction opt-out extends an existing options type.
- Test LoC: +46 (one case in the existing suite — extended, not a new file, per R7).

Net-positive LoC on a `fix:` PR is expected: this is a correctness fix, not a reduction.

## Consumer counts (R8)

No emit paths, exports, or subscribe surfaces added, removed, or re-routed.

## Host impact

CLI: the three fixes above. Extension / Desktop: unchanged — Lit delivery policy and eviction behavior are byte-for-byte the same; the opt-out defaults to today's behavior.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean.
- `npm run check:dead-code-ratchet` — 18, baseline unchanged.
- `npx vitest run src/test-kernel/progressView/ src/test-kernel/cli/` — **204 files, 2,609 passed**, 1 skipped.
- **Regression guard verified honestly**: the new case fails on unfixed `main` (`AssertionError: expected true to be false` — the retired stream returns) and passes with the fix. Checked by reverting the production files to `HEAD` and re-running, not by assuming.
