### PR TITLE
fix(ui): make Approve the filled primary action, open settings on Account

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
+++ b/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
@@ -46,8 +46,8 @@ const DELEGATED_WORK_VALUE = 'approve-all-delegated-work';
  * the item), so the menu stays keyboard-accessible.
  *
  * The fused-pill layout comes from the shared `splitButtonStyles`; this
- * component contributes only its success tint (`--split-accent`) and the host
- * width cap that matches the `.action-button` rule in
+ * component contributes only its primary skin (`--split-fill`/`--split-accent`)
+ * and the host width cap that matches the `.action-button` rule in
  * `requestPanelSharedStyles` (#6658), so Approve stays button-sized like its
  * siblings. The `.approve-split*` class names are kept alongside the shared
  * ones because the component's tests query them.
@@ -68,13 +68,18 @@ export class ApproveSplitButton extends LitElement {
         flex: 0 1 auto;
         min-width: auto;
         max-width: min(14rem, 100%);
-        /* Tints both halves of the shared split-button skin. The on-quiet
-           token, not fill-loud: the skin applies this as the label color, and
-           a fill token used as a foreground measured 3.90:1 (Light+) and
-           4.07:1 (Light Modern) against the panel surface — under AA for the
-           primary action of the approval flow. The on-quiet token is the
-           role-correct one and measures 5.63 / 5.88 / 7.65:1. */
-        --split-accent: var(--wa-color-success-on-quiet);
+        /* Approve is the panel's one primary action, so it takes the shared
+           .btn-primary fill (see the primary kind passed in render). These
+           carry that skin across the caret half, which the split skin would
+           otherwise leave transparent beside a filled label.
+
+           Both are brand tokens because .btn-primary is the accent fill and
+           the design system allows one per view — a second, green fill would
+           be a competing accent. Tinting the label green instead is what made
+           Approve read as plain text: it is a transparent button whose only
+           weight is its label colour. */
+        --split-fill: var(--wa-color-brand-fill-loud);
+        --split-accent: var(--wa-color-brand-on-loud);
       }
     `,
   ];
@@ -103,6 +108,7 @@ export class ApproveSplitButton extends LitElement {
       text: 'Approve',
       title: this.approveTitle,
       action: 'approve',
+      kind: 'primary',
       className: 'approve-split-main split-button-main',
       disabled: this.disabled,
       onClick: () => this.emit('approve'),

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -72,6 +72,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
               ? 'Submit answers (y)'
               : 'Select or type at least one answer before submitting',
             action: 'submit',
+            kind: 'primary',
             disabled: !canSubmit,
             onClick: () => this.submitAnswers(),
           })}

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -175,13 +175,6 @@ export class SettingsApp extends SettingsAppBase {
     });
   }
 
-  override connectedCallback(): void {
-    super.connectedCallback();
-    if (this.isDesktopHost && selectedTabIndex.get() === 0) {
-      selectedTabIndex.set(SETTINGS_TAB.ACCOUNT);
-    }
-  }
-
   private selectSettingsEntry(entry: SettingsNavEntry): void {
     const selectedIndex = SETTINGS_TAB_PANEL_NAMES.indexOf(entry.panel);
     if (selectedIndex < 0) return;
@@ -493,7 +486,8 @@ export class SettingsApp extends SettingsAppBase {
       SETTINGS_VIEW_COMMANDS.GET_GOAL_LIST,
     );
     const requestedPanel =
-      SETTINGS_TAB_PANEL_NAMES[selectedTabIndex.get()] ?? 'memory';
+      SETTINGS_TAB_PANEL_NAMES[selectedTabIndex.get()] ??
+      SETTINGS_TAB_PANEL_BY_NAME.ACCOUNT;
     const activePanel =
       !desktopHost && requestedPanel === SETTINGS_TAB_PANEL_BY_NAME.SHORTCUTS
         ? SETTINGS_TAB_PANEL_BY_NAME.ACCOUNT

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -33,6 +33,7 @@ import type {
 } from '@shared/schemas';
 import {
   byCategory,
+  SETTINGS_TAB,
   type AgentCategory,
   type ByCategory,
 } from '@shared/schemas';
@@ -101,7 +102,17 @@ const { trackedSignal, resetAll: resetTrackedSignals } =
 // ---------------------------------------------------------------------------
 // Tab state
 // ---------------------------------------------------------------------------
-export const selectedTabIndex = trackedSignal(() => 0);
+/**
+ * Opening panel when the host asks for the settings view without naming a tab.
+ *
+ * Named, not `0`: SETTINGS_TAB_ORDER is an append-only wire format, so index 0
+ * means whichever panel happened to be added first (MEMORY) rather than
+ * anything intended. Account is also the first nav group, so this matches what
+ * the nav already presents as the entry point.
+ */
+export const selectedTabIndex = trackedSignal<number>(
+  () => SETTINGS_TAB.ACCOUNT,
+);
 
 // ---------------------------------------------------------------------------
 // Memory state

--- a/src/shared/styles/controlStyles.ts
+++ b/src/shared/styles/controlStyles.ts
@@ -531,8 +531,14 @@ export const formControlStyles: CSSResult = css`
  * alongside their own prefixed ones, which they keep because their tests and
  * per-panel width rules query them.
  *
- * Consumers set `--split-accent` to tint both halves (approve uses success);
- * it defaults to `currentColor` so an untinted split button just inherits.
+ * Consumers set `--split-accent` to tint both halves; it defaults to
+ * `currentColor` so an untinted split button just inherits. `--split-fill`
+ * backs the caret half and defaults to `transparent`, so a split button whose
+ * label half carries a skin (`.btn-primary`) can extend that fill across the
+ * caret instead of leaving it a floating transparent stub. Hover stays
+ * `--surface-hover`: it is a translucent overlay, so it composites correctly
+ * over both the transparent default and a filled half.
+ *
  * The host is expected to own the width budget — `.split-button` fills its
  * container, so cap it on the container, not here.
  */
@@ -582,7 +588,7 @@ export const splitButtonStyles: CSSResult = css`
     height: auto;
     min-height: var(--height-control-compact);
     padding: 0;
-    background: transparent;
+    background: var(--split-fill, transparent);
     color: var(--split-accent, currentColor);
     border: var(--border-thin) solid transparent;
     border-start-start-radius: 0;

--- a/src/shared/styles/requestPanelSharedStyles.ts
+++ b/src/shared/styles/requestPanelSharedStyles.ts
@@ -272,12 +272,13 @@ export const requestPanelSharedStyles: CSSResult = css`
     ${truncateTextRule}
   }
 
-  /* Shared action button colors */
-  :is(${ACTIONS}) wa-button[data-action='approve']::part(base),
-  :is(${ACTIONS}) wa-button[data-action='submit']::part(base) {
-    color: var(--wa-color-success-fill-loud);
-  }
+  /* Approve and Submit carry the shared .btn-primary skin (each panel's one
+     primary action), so they take their colours from that skin rather than a
+     rule here. They previously used --wa-color-success-fill-loud as a
+     foreground: a fill token read as text, measuring 4.07:1 (Light Modern)
+     and 3.90:1 (Light+) against the panel surface, under AA. */
 
+  /* Shared action button colors */
   :is(${ACTIONS}) wa-button[data-action='setup']::part(base) {
     color: var(--wa-color-text-link);
   }


### PR DESCRIPTION
Two UI fixes that missed #9756 — that PR was squash-merged while these were still being written, so they never made it into a review. No overlap with the merged colour work.

## Approve was too easy to miss

Approve is a `background: transparent` button whose only weight is a green label, sitting beside an identically-styled Reject. On a bash approval the command preview fills the panel, so the primary action of the flow reads as plain text.

`controlStyles.ts` already documents the right skin for this — `.btn-primary`, *"the one accent fill; at most one per view"* — so this uses the system rather than adding styling. Approve and the user-question Submit pass `kind: 'primary'`; Reject stays a neutral ghost, so the pair reads as primary plus secondary.

The split button needed one addition to carry that skin across its caret half, which the shared skin left transparent beside a filled label: `--split-fill`, defaulting to `transparent` alongside the existing `--split-accent`, so the other consumer (the tool-edit diff dropdown) is unchanged. Hover stays `--surface-hover` — a translucent overlay, so it composites correctly over both the transparent default and a fill.

**This also deletes a live AA failure.** Approve and Submit took their colour from a rule applying `--wa-color-success-fill-loud` as a *foreground* — a fill token read as text:

| Theme | fill-as-foreground (before) | `.btn-primary` pair (after) |
| --- | --- | --- |
| Dark Modern | 8.94 | 4.53 |
| Light Modern | **4.07** | 6.31 |
| Dark+ | 8.40 | 6.40 |
| Light+ | **3.90** | 4.51 |

The two bolded cells were under AA. The after column is VS Code's own button background and foreground, so it matches the host's native button by construction.

`ApproveSplitButton` carried a comment warning against exactly this mistake while the other approve path was still making it. That comment also claimed the old token measured "5.63 / 5.88 / 7.65:1"; only the dark figure held, the real light-theme values were 1.80:1 and 1.88:1. It is gone.

## Settings opened on Memory

`selectedTabIndex` defaulted to a bare `0`. `SETTINGS_TAB_ORDER` is an append-only wire format, so index 0 means whichever panel was added first — `MEMORY` — not a chosen landing page. The desktop host had already patched around it on mount by resetting 0 to `ACCOUNT`, so the two hosts disagreed and only the VS Code extension opened on Memory.

Naming the default `SETTINGS_TAB.ACCOUNT` fixes the extension, makes both hosts agree, and **deletes** the desktop-only mount-time patch rather than adding a second one. Account is also the first nav group, so this matches what the nav already presents as the entry point. The out-of-range fallback in `render()` moves off the literal `'memory'` to the same named panel.

## Verification

- `npm run typecheck` and `npm run lint` clean.
- 90 suites / 719 tests pass across `progressView`, `shared`, `DesktopControlSystem` and `SettingsStyleContracts`; 35 settings suites / 139 tests for the tab change.
- Contrast measured against each stock theme's own `editorWidget.background`.
- **Not verified by rendering.** The Approve change is a deliberate visual change to the approval panel and is worth eyeballing in both a light and a dark theme. If the blue accent reads as too strong next to Reject, `.btn-secondary` is the quieter filled alternative.
- The details block is already capped at `max-height: min(34vh, 26rem)` with the actions row `position: sticky; inset-block-end: 0`, so scrolling looked correct in code and the weightless button was treated as the cause. If Approve still sits off-screen after this, that sticky rule is the next thing to check.
