### PR TITLE
fix(progress): stop gating the Background Tasks roster on the active stream

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -568,10 +568,18 @@ function taskStatusBadge(child: ActiveChildInfo): {
         text: WORKFLOW_TASK_STATUS_LABEL.cancelled,
         variant: 'neutral',
       };
-    default:
+    case STREAM_PHASE.COMPLETED:
       return {
         text: WORKFLOW_TASK_STATUS_LABEL.completed,
         variant: 'success',
+      };
+    default:
+      // Left the roster without a terminal status ever arriving. It did
+      // finish, but claiming success would render a failed command green;
+      // say only what is known.
+      return {
+        text: WORKFLOW_TASK_STATUS_LABEL.completed,
+        variant: 'neutral',
       };
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  ink@7.1.1: db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6
-  openai@7.3.0: b93e49cfd275eb480aac067d76a3da100df386766cc32c5e62863ed5ae3b18b9
+  ink@7.1.1:
+    hash: db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6
+    path: patches/ink@7.1.1.patch
+  openai@7.3.0:
+    hash: b93e49cfd275eb480aac067d76a3da100df386766cc32c5e62863ed5ae3b18b9
+    path: patches/openai@7.3.0.patch
 
 importers:
 

--- a/src/controllers/progressView/backend/LitSessionRenderer.ts
+++ b/src/controllers/progressView/backend/LitSessionRenderer.ts
@@ -174,9 +174,15 @@ export class LitSessionRenderer implements SessionRendererPort {
   }
 
   onBadgesChanged(streamId: StreamTabId, badges: StreamBadgeSnapshot): void {
-    this.sendIfActive(streamId, () =>
-      this.webviewUpdater.updateStreamBadges(streamId, badges),
-    );
+    // Badges are the child roster (`StreamBadgeSnapshot` = `subagents`), read
+    // from the parent's viewport in Background Tasks — so, like a phase and
+    // unlike round progress, they cannot be pushed only for the active
+    // stream. Gating them dropped the roster update that retires a finished
+    // child, leaving its row live ("Running") until the parent happened to be
+    // reactivated. The message is stream-addressed and stored per stream, and
+    // a child's lifecycle emits a handful of them, so sending always is cheap.
+    if (!this.webviewUpdater.isAvailable()) return;
+    this.webviewUpdater.updateStreamBadges(streamId, badges);
   }
 
   onFilesChanged(streamId: StreamTabId): void {

--- a/src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts
+++ b/src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts
@@ -184,6 +184,74 @@ describe('background-tasks-panel', () => {
     element.remove();
   });
 
+  it('does not paint a retained process green when no terminal status arrived', async () => {
+    const element = createPanel();
+    element.subagents = [
+      {
+        executionId: 'bash-1',
+        childStreamId: 'child-bash',
+        agentName: 'bash',
+        identity: { kind: 'process' as const, tool: 'bash' },
+        // A process has no child status source, so its retained row can keep
+        // the last in-flight phase. Claiming success here would render a
+        // failed command green.
+        status: 'running',
+        finishedAt: 1_000,
+      },
+    ];
+    document.body.append(element);
+    await element.updateComplete;
+
+    const badge = element.shadowRoot?.querySelector('wa-badge.task-status');
+    expect(badge?.getAttribute('variant')).toBe('neutral');
+
+    element.remove();
+  });
+
+  it('paints a retained process green only on an explicit completed status', async () => {
+    const element = createPanel();
+    element.subagents = [
+      {
+        executionId: 'bash-2',
+        childStreamId: 'child-bash-2',
+        agentName: 'bash',
+        identity: { kind: 'process' as const, tool: 'bash' },
+        status: 'completed',
+        finishedAt: 1_000,
+      },
+    ];
+    document.body.append(element);
+    await element.updateComplete;
+
+    const badge = element.shadowRoot?.querySelector('wa-badge.task-status');
+    expect(badge?.textContent).toBe('Finished');
+    expect(badge?.getAttribute('variant')).toBe('success');
+
+    element.remove();
+  });
+
+  it('shows a failed retained process as failed', async () => {
+    const element = createPanel();
+    element.subagents = [
+      {
+        executionId: 'bash-3',
+        childStreamId: 'child-bash-3',
+        agentName: 'bash',
+        identity: { kind: 'process' as const, tool: 'bash' },
+        status: 'failed',
+        finishedAt: 1_000,
+      },
+    ];
+    document.body.append(element);
+    await element.updateComplete;
+
+    const badge = element.shadowRoot?.querySelector('wa-badge.task-status');
+    expect(badge?.textContent).toBe('Failed');
+    expect(badge?.getAttribute('variant')).toBe('danger');
+
+    element.remove();
+  });
+
   it('shows inquiries without workflow subagents in inquiry scope', async () => {
     const element = createPanel();
     element.scope = 'inquiries';

--- a/src/test-kernel/progressView/ProgressBackendRetainedChildren.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendRetainedChildren.vitest.ts
@@ -90,6 +90,30 @@ describe('retained finished children', () => {
     ).toBeGreaterThan(0);
   });
 
+  it('pushes a roster drop for a parent that is not the active stream', () => {
+    // The Background Tasks roster is parent-viewport data about children, so
+    // it cannot ride the active-stream gate: a child that finishes while the
+    // user is looking at another tab (clicking its own row is enough to move
+    // the active stream) must still retire its row.
+    const { backend, messages } = createRecordingBackend();
+    seedParent(backend);
+    applyRoster(backend, PARENT, [subagent('bg')]);
+
+    const other = 'other-stream' as StreamTabId;
+    backend.state.streamLogs.ensureStream(other);
+    backend.state.getOrCreateStreamState(other, AgentCategory.ToolUse);
+    backend.state.switchActiveStream(other);
+    messages.length = 0;
+
+    applyRoster(backend, PARENT, []);
+
+    const badgeMessages = messages.filter(
+      (message) => message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES,
+    );
+    expect(badgeMessages).toHaveLength(1);
+    expect(badgeMessages[0]).toMatchObject({ stream: PARENT });
+  });
+
   it('promotes a retained child back to one live row when it reappears', () => {
     const { backend } = createRecordingBackend();
     seedParent(backend);

--- a/src/test-kernel/progressView/ProgressBackendRetainedChildren.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendRetainedChildren.vitest.ts
@@ -108,7 +108,8 @@ describe('retained finished children', () => {
     applyRoster(backend, PARENT, []);
 
     const badgeMessages = messages.filter(
-      (message) => message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES,
+      (message) =>
+        message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES,
     );
     expect(badgeMessages).toHaveLength(1);
     expect(badgeMessages[0]).toMatchObject({ stream: PARENT });


### PR DESCRIPTION
## Summary

A failed background bash session kept its Background Tasks row rendered as **Running**, forever. Reported with screenshot evidence; root-caused in #9761.

`StreamBadgeSnapshot` **is** the child roster (`Pick<StreamExecutionState, 'subagents'>`, `SessionState.ts:109`), but `LitSessionRenderer.onBadgesChanged` pushed it through `sendIfActive`. That gate is wrong for this data for the reason the same file already documents 20 lines above, in `onStageChanged`'s phase branch:

> A workflow-script run's phase is read from its *parent's* viewport (the Background Tasks row for that run), so unlike round progress it cannot be pushed only for the active stream.

Badges carry that row's very membership and were left on the gate. With the parent not active — and clicking the child's own row is enough to move the active stream — the sequence drops everything that would retire the row:

1. bash fails → `untrackHandle` → `updateChildRoster(P, [])` → `onBadgesChanged(P)` **dropped**
2. `transitionToTerminal(C, FAILED)` → `recordChildPhase` → `onBadgesChanged(P)` **dropped**
3. `autoClose` → `removeStream(C)` → the active-stream branch of `deleteStreamNow` posts only `DELETE_STREAM`, then activates `topmostStreamTab()` — not necessarily P

Nothing reconciles afterwards: `getActiveChildren` is never called anywhere under `packages/extension/`. So `finishedAt` never reaches the webview's copy and the row stays in the live half, which `taskStatusBadge` renders as Running.

The emitter and projection layers are correct and unchanged — `bash.ts` success and failure are structurally identical (`executeCommand` never rejects), removal has a single owner (`untrackHandle` ← `finalizeRunTerminal`), and `updateChildRoster` is already a full replace. The bug was purely host delivery, so the fix is at the delivery owner, not the renderer.

**Second defect, same trace:** a retained process row whose terminal status never arrived fell to the `default:` arm and rendered **"Finished" in success green** — a failed command displayed as succeeded. Success now requires an explicit `COMPLETED` phase; otherwise the row says it finished without claiming an outcome.

## Issue acceptance gates

Closes #9761.

## Single source of truth

Unchanged. Roster membership stays owned by `ExecutionRegistry` → `child.activity` → `SessionFactApplier`; this only stops the host from discarding the update in flight. No renderer-side reconstruction was added — CLAUDE.md forbids compensating for data-model gaps at render time, and nothing here does.

## Duplication and abstraction budget

No new module, helper, or wire message. One call site stops using `sendIfActive`; one `switch` gains an explicit `COMPLETED` case.

## Net elements (R6)

- Diffstat: 5 files, **+116 / −6**.
- Exported symbols (`^[+-]export`): **0 / 0**. No new files, types, classes, or interfaces.
- Production change is ~12 lines across 2 files; the rest is test coverage (+88) closing a real gap — no test covered a `kind: 'process'` child that **fails**, in either the delivery or the badge dimension.

Net-positive LoC on a `fix:` PR is expected: correctness plus the missing coverage.

## Consumer counts (R8)

No emit paths, exports, or subscribe surfaces added, removed, or re-routed. `UPDATE_STREAM_BADGES` is stream-addressed and stored per-stream in the frontend (`streamMetaSlice.ts:156-161`), so ungating changes only *whether* an already-addressed message is delivered — a handful per child lifecycle. Deliberately scoped to this one call site: conversation progress and round stages are genuinely active-only and high-volume, and stay gated.

## Host impact

Extension / Desktop: a finished background task now retires its row regardless of which tab is focused, and a failed process no longer renders green. CLI: unaffected (`TuiSessionRenderer` has its own delivery).

## Scheduled refactoring

Two adjacent defects found in the same trace are documented in #9761 and deliberately **not** fixed here, being separate lifecycle concerns:

- `finalizeChildStream` (`src/tools/delegation/childStream.ts:298-326`) does fallible work — `logger.error`, `toErrorMessage`, `classifyAgentError` — only on the `failed` outcome and **before** `finalizeRunTerminal`; with `claimTerminalFinalize()` making a retry a silent no-op, one throw there strands the handle forever.
- `BashBackgroundSession.interrupt()` (`src/tools/bash.ts:270-276`) sends a bare SIGTERM with no SIGKILL escalation and no stream destroy, duplicating `executeCommand`'s own `terminateSubprocess` ladder; the clean fix is deleting the duplicate kill owner by passing an `AbortSignal` instead.

## Validation

- `npm run typecheck` — clean.
- `npm run check:dead-code-ratchet` — 18, baseline unchanged.
- `npx vitest run src/test-kernel/progressView/` — **57 files, 454 passed**.
- **Both new guards verified to fail without the fix** (reverted the two production files to `HEAD`, re-ran: `pushes a roster drop for a parent that is not the active stream` and `does not paint a retained process green when no terminal status arrived` both fail; 19 passed / 2 failed). Checked, not assumed.
