### PR TITLE
fix(agent): share results for duplicate side-effect tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1019,8 +1019,9 @@ All notable changes to this project will be documented in this file.
   lookups stop at their next cancellation point (their client libraries are
   not mid-request abortable).
 - **Duplicate parallel tool calls no longer waste a model turn** — identical
-  read-only calls share one execution's result, and identical side-effect
-  calls are answered with a clear skip message instead of a retry prompt.
+  calls in one batch (including accidental GPT re-emissions of bash/write)
+  execute once and share that result with the duplicates, so the model does
+  not see skip errors or re-run the same side effect.
 - **Faster subagent result delivery** — the orchestrator wakes as soon as a
   subagent finishes instead of waiting for report persistence, and
   consecutive maintenance follow-ups batch into a single turn.

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -25,7 +25,6 @@ import {
   normalizeToolCallError,
   parseToolInput,
   partitionDuplicateCalls,
-  UNSAFE_DUPLICATE_CALL_ERROR,
 } from './toolCallParsing';
 import type { ToolUseRoundServices } from '../CycleServices';
 import type { ToolUseRoundShared } from './roundShared';
@@ -79,10 +78,8 @@ function endsToolUseTurn(result: ToolExecutionResult | null): boolean {
  * under a small semaphore; any other tool acts as a barrier and runs alone,
  * preserving ordering guarantees when tools have dependencies (e.g., read
  * file then edit file). Duplicate parallel calls (identical name+arguments)
- * to parallel-safe tools execute once, with duplicates receiving a copy of
- * the primary's result; duplicates of side-effect tools get a synthetic
- * error instead, since sharing a success would misreport an effect that
- * never ran.
+ * execute once; duplicates receive a side-effect-stripped copy of the
+ * primary's result (including accidental GPT re-emissions of bash/write).
  *
  * Batches follow-up messages for Google/DeepSeek handlers to preserve thought signatures.
  */
@@ -101,19 +98,9 @@ export class ToolUseDispatchNode<C> extends Node<
    */
   private _duplicateToPrimary = new Map<string, number>();
 
-  /**
-   * Duplicates of side-effect tools. Fanning the primary's success out
-   * would report an effect that never ran (two identical appends would
-   * "succeed" twice while running once), so these are answered with a
-   * synthetic error instead — the model can re-issue sequentially if it
-   * truly wants the effect twice.
-   */
-  private _unsafeDuplicateCallIds = new Map<string, number>();
-
   /** Returns tool calls to execute, or empty array if skipped/interrupted. */
   async prep(shared: ToolUseRoundShared): Promise<SdkToolCall[]> {
     this._duplicateToPrimary.clear();
-    this._unsafeDuplicateCallIds.clear();
     this._currentUserInstruction = shared.currentUserInstruction;
     const toolCalls = shared.toolCalls ?? [];
 
@@ -127,22 +114,20 @@ export class ToolUseDispatchNode<C> extends Node<
     }
 
     // Deduplicate parallel calls (same tool name + identical arguments):
-    // parallel-safe duplicates share their primary's result, but only
-    // within a contiguous safe segment — a side-effect call in between may
-    // change what a repeated read returns. Side-effect duplicates are
-    // rejected with a synthetic error (see _unsafeDuplicateCallIds).
+    // execute once and fan the primary's result out to every duplicate.
+    // Parallel-safe sharing is limited to a contiguous safe segment; a
+    // side-effect call in between may change what a repeated read returns.
+    // Side-effect identicals share too (models often re-emit bash by
+    // accident); a different mutation between two identical mutations
+    // re-opens the window so intentional restores still run.
     if (toolCalls.length > 1) {
-      const partition = partitionDuplicateCalls(toolCalls, (call) =>
+      this._duplicateToPrimary = partitionDuplicateCalls(toolCalls, (call) =>
         this.isParallelSafe(call),
       );
-      this._duplicateToPrimary = partition.sharedWithPrimary;
-      this._unsafeDuplicateCallIds = partition.rejected;
 
-      const duplicateCount =
-        this._duplicateToPrimary.size + this._unsafeDuplicateCallIds.size;
-      if (duplicateCount > 0) {
+      if (this._duplicateToPrimary.size > 0) {
         this.services.logger.debug(
-          `Deduplicated ${duplicateCount} parallel tool call(s) with identical name and arguments (${this._unsafeDuplicateCallIds.size} side-effect duplicate(s) rejected)`,
+          `Deduplicated ${this._duplicateToPrimary.size} parallel tool call(s) with identical name and arguments`,
         );
       }
     }
@@ -166,12 +151,9 @@ export class ToolUseDispatchNode<C> extends Node<
       calls.length,
     ).fill(null);
     // Duplicates execute nothing — schedule only the live calls, then copy
-    // the primaries' results (or synthetic errors) onto them afterwards.
+    // the primaries' results onto them afterwards.
     const live = calls.flatMap((call, index) =>
-      this._duplicateToPrimary.has(call.callId) ||
-      this._unsafeDuplicateCallIds.has(call.callId)
-        ? []
-        : [index],
+      this._duplicateToPrimary.has(call.callId) ? [] : [index],
     );
     const { signal } = this.services.runScope;
     const queue = new PQueue({ concurrency: MAX_PARALLEL_TOOL_CALLS });
@@ -207,38 +189,13 @@ export class ToolUseDispatchNode<C> extends Node<
       if (run.some((index) => endsToolUseTurn(results[index]))) break;
     }
     this.fanOutDuplicateResults(calls, results);
-    this.rejectUnsafeDuplicates(calls, results);
     return results;
-  }
-
-  /** Answer side-effect duplicates with a synthetic error (never executed). */
-  private rejectUnsafeDuplicates(
-    calls: SdkToolCall[],
-    results: (ToolExecutionResult | null)[],
-  ): void {
-    for (const [index, call] of calls.entries()) {
-      const primaryIndex = this._unsafeDuplicateCallIds.get(call.callId);
-      if (primaryIndex === undefined) continue;
-      // If the primary never ran (interrupted batch), the duplicate stays
-      // null too — a "side effects" skip message would be misleading when
-      // no effect happened at all.
-      if (!results[primaryIndex]) continue;
-      const duplicateResult: ToolResult = {
-        status: 'error',
-        error: UNSAFE_DUPLICATE_CALL_ERROR,
-      };
-      results[index] = this.makeSyntheticResult(
-        call,
-        duplicateResult,
-        call.input,
-      );
-    }
   }
 
   /**
    * Build a synthetic ToolExecutionResult for a call that never actually
-   * executed a tool (duplicate fan-out, rejected duplicate, or cancelled
-   * call) — always empty edits/attachments, and a fresh logRef.
+   * executed a tool (duplicate fan-out or cancelled call) — always empty
+   * edits/attachments, and a fresh logRef.
    */
   private makeSyntheticResult(
     call: SdkToolCall,
@@ -310,7 +267,6 @@ export class ToolUseDispatchNode<C> extends Node<
   clone(): this {
     const cloned = super.clone();
     cloned._duplicateToPrimary = new Map();
-    cloned._unsafeDuplicateCallIds = new Map();
     cloned._currentUserInstruction = undefined;
     return cloned;
   }

--- a/src/agent/core/flows/toolUseRound/toolCallParsing.ts
+++ b/src/agent/core/flows/toolUseRound/toolCallParsing.ts
@@ -14,44 +14,35 @@ import {
 import { isObject } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-export const UNSAFE_DUPLICATE_CALL_ERROR =
-  'Duplicate parallel call skipped — same tool name and arguments as an earlier call in this batch, ' +
-  'and this tool has side effects, so its result cannot be shared. ' +
-  'If you intend the effect to run twice, invoke it again sequentially in your next response.';
-
-/** Duplicate-call partition for one model response (see partitionDuplicateCalls). */
-export interface DuplicateCallPartition {
-  /** Duplicate callId → index of its primary within the same safe segment. */
-  sharedWithPrimary: Map<string, number>;
-  /**
-   * Duplicates of side-effect tools, mapped to their primary's index —
-   * never executed; answered with an error only when the primary actually
-   * ran (an interrupted primary leaves the duplicate cancelled with it).
-   */
-  rejected: Map<string, number>;
-}
+/**
+ * Map of duplicate callId → index of its primary within this model response
+ * (see {@link partitionDuplicateCalls}).
+ */
+export type DuplicateCallMap = Map<string, number>;
 
 /**
  * Partition duplicate parallel tool calls (same name + identical arguments).
  *
- * Parallel-safe (read-only) duplicates share their primary's result — but
- * only within a contiguous run of parallel-safe calls: any side-effect call
- * in between may change what a repeated read would return, so it acts as a
- * barrier that invalidates earlier shareable signatures.
+ * Every duplicate is answered with a copy of its primary's result and is
+ * never executed — models (especially GPT) routinely emit identical calls in
+ * one batch by accident, and a synthetic error for that noise confuses the
+ * model and the UI more than a shared success does. Execution still happens
+ * only once.
  *
- * Side-effect duplicates are rejected with a synthetic error (sharing a
- * success would misreport an effect that never ran; running it silently
- * twice is equally wrong) — a false positive only costs the model one
- * explicit sequential re-issue. The rejection window resets when a
- * different side-effect call runs in between, since changed state makes an
- * identical repeat plausibly intentional.
+ * Parallel-safe (read-only) sharing is limited to a contiguous run of
+ * parallel-safe calls: any side-effect call in between may change what a
+ * repeated read would return, so it acts as a barrier that invalidates
+ * earlier shareable signatures.
+ *
+ * Side-effect sharing uses a separate window that resets when a different
+ * side-effect call runs in between, since changed state makes an identical
+ * repeat plausibly intentional (e.g. write x; edit x; write x as a restore).
  */
 export function partitionDuplicateCalls(
   toolCalls: SdkToolCall[],
   isParallelSafe: (call: SdkToolCall) => boolean,
-): DuplicateCallPartition {
-  const sharedWithPrimary = new Map<string, number>();
-  const rejected = new Map<string, number>();
+): DuplicateCallMap {
+  const sharedWithPrimary: DuplicateCallMap = new Map();
   const segmentPrimaries = new Map<string, number>();
   const unsafeSeen = new Map<string, number>();
   for (const [index, call] of toolCalls.entries()) {
@@ -68,7 +59,7 @@ export function partitionDuplicateCalls(
       segmentPrimaries.clear();
       const unsafePrimary = unsafeSeen.get(key);
       if (unsafePrimary !== undefined) {
-        rejected.set(call.callId, unsafePrimary);
+        sharedWithPrimary.set(call.callId, unsafePrimary);
       } else {
         // A different mutation changes workspace state, which makes an
         // identical repeat of an earlier mutation plausibly intentional
@@ -80,7 +71,7 @@ export function partitionDuplicateCalls(
       }
     }
   }
-  return { sharedWithPrimary, rejected };
+  return sharedWithPrimary;
 }
 
 /** Parse tool input, handling JSON strings and other formats from model providers. */

--- a/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
+++ b/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
@@ -422,7 +422,7 @@ describe('ToolUseDispatchNode parallel dispatch', () => {
     }
   });
 
-  it('leaves unsafe duplicates cancelled when their primary never ran', async () => {
+  it('leaves side-effect duplicates cancelled when their primary never ran', async () => {
     const probe: DispatchProbe = { events: [], inFlight: 0, maxInFlight: 0 };
     const runController = new AbortController();
     const { node, dispose } = dispatchHarness({
@@ -441,8 +441,8 @@ describe('ToolUseDispatchNode parallel dispatch', () => {
       const results = (await execPrepped(node, prepped)) as ExecResult[];
 
       assert.equal(probe.events.length, 0, 'nothing should execute');
-      // The duplicate must not claim a "side effects" skip when no effect
-      // happened at all — it is cancelled along with its primary.
+      // The duplicate stays cancelled with its primary — no synthetic
+      // success when no effect happened at all.
       assert.deepEqual(results, [null, null]);
     } finally {
       dispose();
@@ -465,7 +465,7 @@ describe('ToolUseDispatchNode parallel dispatch', () => {
       ])) as ExecResult[];
 
       // The edit changed state, so re-issuing the identical write is a
-      // plausible restore — it must execute, not be rejected as a glitch.
+      // plausible restore — it must execute, not be swallowed as a glitch.
       const writeStarts = countStarts(probe, 'write_file');
       assert.equal(writeStarts, 2, 'post-mutation identical write must run');
       assert.equal(results[2]?.result.status, 'executed');
@@ -474,7 +474,7 @@ describe('ToolUseDispatchNode parallel dispatch', () => {
     }
   });
 
-  it('rejects duplicates of side-effect tools instead of sharing the result', async () => {
+  it('shares the primary result for side-effect tool duplicates', async () => {
     const probe: DispatchProbe = { events: [], inFlight: 0, maxInFlight: 0 };
     const { node, dispose } = dispatchHarness({
       tools: { write_file: probeTool(probe, 'write_file', 5) },
@@ -488,12 +488,20 @@ describe('ToolUseDispatchNode parallel dispatch', () => {
       const startCount = countStarts(probe);
       assert.equal(startCount, 1, 'the side effect must run exactly once');
       assert.equal(results[0]?.result.status, 'executed');
-      // The duplicate must NOT claim the effect ran twice.
-      assert.equal(results[1]?.result.status, 'error');
-      assert.ok(
-        results[1]?.result.status === 'error' &&
-          results[1].result.error.includes('side effects'),
-        'duplicate should explain why it was skipped',
+      // Accidental GPT re-emissions get the primary's result, not an error.
+      assert.equal(results[1]?.result.status, 'executed');
+      assert.equal(
+        results[1]?.result.status === 'executed'
+          ? results[1].result.output
+          : undefined,
+        results[0]?.result.status === 'executed'
+          ? results[0].result.output
+          : 'missing',
+      );
+      assert.deepEqual(
+        results[1]?.editedFiles,
+        [],
+        'duplicate must not re-track edits',
       );
     } finally {
       dispose();


### PR DESCRIPTION
## Summary

- Identical side-effect tool calls in one model batch (`bash`, write/edit, etc.) now **execute once** and **share the primary result** with duplicates, matching read-only dedup.
- Removes the synthetic "Duplicate parallel call skipped … side effects" error that GPT and other models hit when they re-emit the same tool with different `call_id`s.
- Keeps barrier semantics: a different mutation between two identical mutations still re-opens the window so intentional restores run.
- Edits/attachments stay stripped on fan-out so nothing double-tracks.

## Why

Models (especially GPT-family hosts) routinely emit multiple identical tool calls in a single parallel response. Public reports:

- [openai/codex#27759](https://github.com/openai/codex/issues/27759) — repeated identical tool calls
- [openai/codex#14485](https://github.com/openai/codex/issues/14485) — aggressive parallel tool calling
- [lmstudio#1756](https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/1756) — 9× identical `bash_exec` in one message
- [OpenAI forum](https://community.openai.com/t/ridiculous-number-of-redundant-tool-calls/1181410) — ~70 identical tool calls in one completion

TeXRA already runs the effect once; the old skip **error** was noisier for model and UI than a shared success. Intentional double-runs with identical args in the same batch are rare; re-issue after another mutation still works.

## Test plan

- [x] `npm test -- src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts` (11 passed)
- [ ] Manual: with a GPT tool-use agent, provoke or observe multi-`bash` identical args in one turn — expect one run, no red skip cards, model continues cleanly
- [ ] Confirm intentional `write A` → `edit` → `write A` still runs both writes