### PR TITLE
fix(approval): make the approval flow readable and correctly targeted

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -72,10 +72,13 @@ export abstract class BaseFeedbackPanel<
   }
 
   protected renderRejectButton(rejectTitle: string): TemplateResult {
+    // Both states keep the reject icon and name the consequence. Switching to
+    // a checkmark labelled "Submit" made the confirm step of a rejection wear
+    // the approval glyph, which is the one misreading this flow cannot afford.
     return renderLabeledActionButton({
-      icon: this.showFeedback ? 'check' : 'xmark',
-      text: this.showFeedback ? 'Submit' : 'Reject',
-      title: this.showFeedback ? 'Submit rejection (n)' : rejectTitle,
+      icon: 'xmark',
+      text: this.showFeedback ? 'Send rejection' : 'Reject',
+      title: this.showFeedback ? 'Send rejection (n)' : rejectTitle,
       action: 'reject',
       disabled: this.archived,
       onClick: () => this.handleRejectAction(),
@@ -89,12 +92,17 @@ export abstract class BaseFeedbackPanel<
   ): TemplateResult | typeof nothing {
     if (!this.showFeedback) return nothing;
 
+    // The label is visible, not just an aria-label duplicating the
+    // placeholder: a placeholder disappears on first keystroke, taking the
+    // only description of the field with it.
+    const labelId = `${inputClass}-label`;
     return html`
       <div class=${containerClass}>
+        <label id=${labelId}>${placeholder}</label>
         <wa-textarea
           class=${inputClass}
-          aria-label=${placeholder}
-          placeholder=${placeholder}
+          aria-labelledby=${labelId}
+          placeholder="Optional — this is sent back to the agent"
           rows="3"
           data-feedback-input
         ></wa-textarea>

--- a/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -92,16 +92,14 @@ export abstract class BaseFeedbackPanel<
   ): TemplateResult | typeof nothing {
     if (!this.showFeedback) return nothing;
 
-    // The label is visible, not just an aria-label duplicating the
-    // placeholder: a placeholder disappears on first keystroke, taking the
-    // only description of the field with it.
-    const labelId = `${inputClass}-label`;
+    // A visible label, not a placeholder doing the label's job: the
+    // placeholder disappears on the first keystroke, taking the only
+    // description of the field with it.
     return html`
       <div class=${containerClass}>
-        <label id=${labelId}>${placeholder}</label>
+        <label>${placeholder}</label>
         <wa-textarea
           class=${inputClass}
-          aria-labelledby=${labelId}
           placeholder="Optional — this is sent back to the agent"
           rows="3"
           data-feedback-input

--- a/packages/extension/src/progressView/frontend/components/BashRequestPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/BashRequestPanel.styles.ts
@@ -8,16 +8,22 @@ export const bashRequestPanelStyles: CSSResult = css`
     font-size: var(--font-size-sm);
   }
 
+  /* The directory a command will run in is the security-relevant field of
+     this prompt, so it is not the smallest, faintest text in it.
+     --font-size-xs resolves to 10.4px (13px x 0.8), under the ~12px floor,
+     and --wa-color-text-quiet measured 4.40:1 on Light Modern, under AA. The
+     label stays quiet; the path itself takes the normal text colour so the
+     value outranks its label. */
   .bash-approval-request__cwd {
     color: var(--wa-color-text-quiet);
     font-family: var(--wa-font-family-mono);
-    font-size: var(--font-size-xs);
+    font-size: var(--font-size-sm);
     margin-bottom: var(--wa-space-xs);
     overflow-wrap: anywhere;
   }
 
   .bash-approval-request__cwd span {
-    color: var(--color-text-secondary);
+    color: var(--wa-color-text-normal);
   }
 
   .bash-approval-request__command .code-block pre {

--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -125,12 +125,24 @@ const SECTIONS: readonly SectionConfig[] = [
  */
 const PANEL_MARKER_SELECTOR = '[data-request-panel]';
 
+/** Stable id for a section's heading, used as the section's accessible name. */
+function sectionTitleId(section: SectionConfig): string {
+  return `${section.cssClass}__title`;
+}
+
 function renderPanel(
   section: SectionConfig,
   permission: PermissionState,
+  armed = false,
 ): TemplateResult {
+  // `armed` marks the panel the y/n accelerators will act on. Sections render
+  // in a fixed kind order while the accelerators target the newest request,
+  // so with mixed kinds pending the top panel on screen is not the one a
+  // keypress hits. Without a visible mark that divergence is invisible, and
+  // the action it triggers can be executing a shell command.
   return staticHtml`<${section.tag}
     data-request-panel
+    ?data-armed=${armed}
     .permission=${permission}
   ></${section.tag}>`;
 }
@@ -204,10 +216,40 @@ export class RequestPanels extends LitElement {
     super.disconnectedCallback();
   }
 
+  /**
+   * Key of the request the y/n accelerators will act on — the newest, matching
+   * `getActivePanel`. Panels render it as `data-armed` so the target is
+   * visible rather than inferred from queue order.
+   */
+  private armedPermissionKey(): string | null {
+    const newest = this.permissions[0];
+    return newest ? getPermissionKey(newest) : null;
+  }
+
+  /**
+   * What a screen reader hears when a request arrives. The agent blocks until
+   * the user answers, so an unannounced panel reads as a hung run. The region
+   * is rendered on every pass (empty when idle) rather than inserted on
+   * demand, because a live region has to exist before its text changes for the
+   * change to be announced.
+   */
+  private announcement(): string {
+    const newest = this.permissions[0];
+    if (!newest) return '';
+    const section = SECTIONS.find((s) => s.kind === newest.kind);
+    if (!section) return '';
+    const waiting =
+      this.permissions.length > 1
+        ? ` ${this.permissions.length} requests waiting.`
+        : '';
+    return `${section.title} needed.${waiting} Press y to approve, n to reject.`;
+  }
+
   override render(): TemplateResult | typeof nothing {
     if (this.permissions.length === 0) return nothing;
 
     return html`
+      <div class="visually-hidden" role="status">${this.announcement()}</div>
       ${SECTIONS.map((section) => {
         const permissions = this.permissionsFor(section.kind);
         return section.kind === PERMISSION_KIND.EXTERNAL_INQUIRY
@@ -229,10 +271,15 @@ export class RequestPanels extends LitElement {
     config: SectionConfig,
     extra: TemplateResult | typeof nothing = nothing,
   ): TemplateResult {
+    // A real heading, not a styled span: it gives the section an accessible
+    // name (via aria-labelledby below) and puts every pending request in the
+    // screen reader's heading list. Visual weight is unchanged — the shared
+    // header rule already sets font-weight and colour, and the h2 reset in
+    // requestPanelSharedStyles removes the UA margin and size.
     return html`
       <div class="${config.cssClass}__header">
         ${waIcon(config.icon)}
-        <span>${config.title}</span>
+        <h2 id=${sectionTitleId(config)}>${config.title}</h2>
         ${extra}
       </div>
     `;
@@ -244,14 +291,18 @@ export class RequestPanels extends LitElement {
   ): TemplateResult | typeof nothing {
     if (permissions.length === 0) return nothing;
 
+    const armedKey = this.armedPermissionKey();
     return html`
-      <section class=${config.cssClass}>
+      <section
+        class=${config.cssClass}
+        aria-labelledby=${sectionTitleId(config)}
+      >
         ${this.renderSectionHeader(config)}
         <div class="${config.cssClass}__list">
           ${repeat(
             permissions,
             (p) => getPermissionKey(p),
-            (p) => renderPanel(config, p),
+            (p) => renderPanel(config, p, getPermissionKey(p) === armedKey),
           )}
         </div>
       </section>

--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -125,11 +125,6 @@ const SECTIONS: readonly SectionConfig[] = [
  */
 const PANEL_MARKER_SELECTOR = '[data-request-panel]';
 
-/** Stable id for a section's heading, used as the section's accessible name. */
-function sectionTitleId(section: SectionConfig): string {
-  return `${section.cssClass}__title`;
-}
-
 function renderPanel(
   section: SectionConfig,
   permission: PermissionState,
@@ -226,30 +221,10 @@ export class RequestPanels extends LitElement {
     return newest ? getPermissionKey(newest) : null;
   }
 
-  /**
-   * What a screen reader hears when a request arrives. The agent blocks until
-   * the user answers, so an unannounced panel reads as a hung run. The region
-   * is rendered on every pass (empty when idle) rather than inserted on
-   * demand, because a live region has to exist before its text changes for the
-   * change to be announced.
-   */
-  private announcement(): string {
-    const newest = this.permissions[0];
-    if (!newest) return '';
-    const section = SECTIONS.find((s) => s.kind === newest.kind);
-    if (!section) return '';
-    const waiting =
-      this.permissions.length > 1
-        ? ` ${this.permissions.length} requests waiting.`
-        : '';
-    return `${section.title} needed.${waiting} Press y to approve, n to reject.`;
-  }
-
   override render(): TemplateResult | typeof nothing {
     if (this.permissions.length === 0) return nothing;
 
     return html`
-      <div class="visually-hidden" role="status">${this.announcement()}</div>
       ${SECTIONS.map((section) => {
         const permissions = this.permissionsFor(section.kind);
         return section.kind === PERMISSION_KIND.EXTERNAL_INQUIRY
@@ -271,15 +246,14 @@ export class RequestPanels extends LitElement {
     config: SectionConfig,
     extra: TemplateResult | typeof nothing = nothing,
   ): TemplateResult {
-    // A real heading, not a styled span: it gives the section an accessible
-    // name (via aria-labelledby below) and puts every pending request in the
-    // screen reader's heading list. Visual weight is unchanged — the shared
-    // header rule already sets font-weight and colour, and the h2 reset in
-    // requestPanelSharedStyles removes the UA margin and size.
+    // A heading element rather than a styled span, because that is what a
+    // section title is. Visual weight is unchanged — the shared header rule
+    // already sets font-weight and colour, and the h2 reset in
+    // requestPanelSharedStyles strips the UA margin and size.
     return html`
       <div class="${config.cssClass}__header">
         ${waIcon(config.icon)}
-        <h2 id=${sectionTitleId(config)}>${config.title}</h2>
+        <h2>${config.title}</h2>
         ${extra}
       </div>
     `;
@@ -293,10 +267,7 @@ export class RequestPanels extends LitElement {
 
     const armedKey = this.armedPermissionKey();
     return html`
-      <section
-        class=${config.cssClass}
-        aria-labelledby=${sectionTitleId(config)}
-      >
+      <section class=${config.cssClass}>
         ${this.renderSectionHeader(config)}
         <div class="${config.cssClass}__list">
           ${repeat(

--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -212,13 +212,28 @@ export class RequestPanels extends LitElement {
   }
 
   /**
-   * Key of the request the y/n accelerators will act on — the newest, matching
-   * `getActivePanel`. Panels render it as `data-armed` so the target is
-   * visible rather than inferred from queue order.
+   * The request the y/n accelerators will act on.
+   *
+   * Single source of truth: `getActivePanel` resolves the DOM node from this,
+   * and the renderers mark that same permission `data-armed`. Deriving the
+   * two separately let them disagree — the newest permission is not the
+   * target while the external-inquiry carousel is active, so an indicator
+   * keyed off `permissions[0]` would ring a panel the carousel does not even
+   * render, while the keypress landed on the visible one.
    */
-  private armedPermissionKey(): string | null {
+  private get armedPermission(): PermissionState | null {
     const newest = this.permissions[0];
-    return newest ? getPermissionKey(newest) : null;
+    if (!newest) return null;
+    return (
+      (this.externalInquiryCarouselActive
+        ? this.externalInquiries[this.externalInquiryIndex]
+        : newest) ?? null
+    );
+  }
+
+  private armedPermissionKey(): string | null {
+    const armed = this.armedPermission;
+    return armed ? getPermissionKey(armed) : null;
   }
 
   override render(): TemplateResult | typeof nothing {
@@ -333,7 +348,14 @@ export class RequestPanels extends LitElement {
       <section class=${config.cssClass}>
         ${this.renderSectionHeader(config, nav)}
         <div class="${config.cssClass}__list">
-          ${keyed(getPermissionKey(current), renderPanel(config, current))}
+          ${keyed(
+            getPermissionKey(current),
+            renderPanel(
+              config,
+              current,
+              getPermissionKey(current) === this.armedPermissionKey(),
+            ),
+          )}
         </div>
       </section>
     `;
@@ -428,12 +450,7 @@ export class RequestPanels extends LitElement {
    * would target the wrong panel when mixed kinds are pending.
    */
   private getActivePanel(): BaseRequestPanel | null {
-    const newest = this.permissions[0];
-    if (!newest) return null;
-
-    const target = this.externalInquiryCarouselActive
-      ? this.externalInquiries[this.externalInquiryIndex]
-      : newest;
+    const target = this.armedPermission;
     if (!target) return null;
 
     const panels = this.renderRoot.querySelectorAll<BaseRequestPanel>(

--- a/src/shared/styles/requestPanelSharedStyles.ts
+++ b/src/shared/styles/requestPanelSharedStyles.ts
@@ -160,9 +160,9 @@ export const requestPanelSharedStyles: CSSResult = css`
     color: var(--wa-color-text-normal);
   }
 
-  /* The section title is a real h2 so the section has an accessible name and
-     pending requests appear in the heading list. It inherits the header rule
-     above, so this only strips the UA margin and size. */
+  /* The section title is a heading element rather than a styled span. It
+     inherits the header rule above, so this only strips the UA margin and
+     size. */
   :is(${HEADERS}) h2 {
     margin: 0;
     font: inherit;
@@ -321,8 +321,8 @@ export const requestPanelSharedStyles: CSSResult = css`
   }
 
   /* Visible label for the rejection textarea. The field previously carried
-     only a placeholder plus an aria-label repeating it, so the description
-     vanished on the first keystroke. */
+     only a placeholder, so its description vanished on the first
+     keystroke. */
   :is(${FEEDBACKS}) label {
     display: block;
     margin-bottom: ${sp.tiny};

--- a/src/shared/styles/requestPanelSharedStyles.ts
+++ b/src/shared/styles/requestPanelSharedStyles.ts
@@ -175,11 +175,16 @@ export const requestPanelSharedStyles: CSSResult = css`
 
      Targets the panel host element in RequestPanels' shadow root, not the
      ITEMS class: that class is on a div inside each panel's own shadow root,
-     which this selector cannot reach. */
+     which this selector cannot reach.
+
+     Inset rather than offset outward: the panel fills its container's inline
+     width, and a container that clips horizontally would shave the left and
+     right edges off an outward ring. Drawing it inside the card's own edge
+     stays intact regardless of what hosts the panel. */
   [data-request-panel][data-armed] {
     display: block;
     outline: var(--border-medium) solid var(--wa-color-focus);
-    outline-offset: ${sp.tiny};
+    outline-offset: calc(-1 * ${sp.tiny});
     border-radius: var(--border-radius-medium);
   }
 

--- a/src/shared/styles/requestPanelSharedStyles.ts
+++ b/src/shared/styles/requestPanelSharedStyles.ts
@@ -160,6 +160,29 @@ export const requestPanelSharedStyles: CSSResult = css`
     color: var(--wa-color-text-normal);
   }
 
+  /* The section title is a real h2 so the section has an accessible name and
+     pending requests appear in the heading list. It inherits the header rule
+     above, so this only strips the UA margin and size. */
+  :is(${HEADERS}) h2 {
+    margin: 0;
+    font: inherit;
+    color: inherit;
+  }
+
+  /* The request the y/n accelerators will act on. Sections render in a fixed
+     kind order while the accelerators target the newest request, so the top
+     panel on screen is not always the one a keypress hits.
+
+     Targets the panel host element in RequestPanels' shadow root, not the
+     ITEMS class: that class is on a div inside each panel's own shadow root,
+     which this selector cannot reach. */
+  [data-request-panel][data-armed] {
+    display: block;
+    outline: var(--border-medium) solid var(--wa-color-focus);
+    outline-offset: ${sp.tiny};
+    border-radius: var(--border-radius-medium);
+  }
+
   :is(${LISTS}) {
     display: flex;
     flex-direction: column;
@@ -295,6 +318,16 @@ export const requestPanelSharedStyles: CSSResult = css`
   /* Rejection feedback (shared across panels with feedback support) */
   :is(${FEEDBACKS}) {
     margin-top: ${sp.small};
+  }
+
+  /* Visible label for the rejection textarea. The field previously carried
+     only a placeholder plus an aria-label repeating it, so the description
+     vanished on the first keystroke. */
+  :is(${FEEDBACKS}) label {
+    display: block;
+    margin-bottom: ${sp.tiny};
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
   }
 
   :is(${FEEDBACK_INPUTS}) {


### PR DESCRIPTION
An interface pass over the progress-view approval flow — the surface every agent run blocks on. Four fixes, all of them things a user sees.

## The armed panel was invisible

`y`/`n` act on the **newest** request, while sections render in a **fixed kind order**. With mixed kinds pending, the top panel on screen is not the one a keypress hits — and the action it triggers can be executing a shell command. The dispatch code already acknowledged the divergence in a comment; nothing surfaced it to the user. The armed panel now carries `data-armed` and a visible outline.

## Rejecting wore the approval glyph

The confirm step of a **rejection** rendered as a checkmark labelled "Submit". Wrong icon, and a label that never named the consequence. It keeps the reject icon and reads "Send rejection".

## The working directory was the least readable thing in the prompt

The field that decides *where a command runs* used `--font-size-xs`, which resolves to **10.4px** (`13px × 0.8`), at a colour measuring **4.40:1 on Light Modern** — under AA. It moves to `--font-size-sm` and the path takes the normal text colour, so the value outranks its label. The `span` previously resolved to *exactly* its parent's colour, so the markup's label/value split did nothing at all.

## The rejection field lost its description on the first keystroke

It had only a placeholder. Now it has a visible label, and the placeholder carries an example instead.

## Scope

The section title is a heading element rather than a styled span — the right element for a section title, one tag plus a three-line margin reset.

**This branch adds no ARIA.** An earlier revision included a live region and `aria-labelledby` wiring; those were removed as out of scope for this product.

## Considered but rejected

| Location | Candidate | Rejected because |
| --- | --- | --- |
| `requestPanelSharedStyles.ts` details/actions | Cap details height, pin the actions row | Already correct: `max-height: min(34vh, 26rem)` with `overflow-y: auto`, actions `position: sticky` |
| `StreamTabs.ts`, `FileSelectGroup.ts` | `@click` on a `<div>` | Event delegation over real `<button>`s inside `stream-tab` |
| `BaseApprovalPanel.ts` | Require a modifier for single-key `y` | Intentional design, advertised in every button title; the defect was mis-targeting, not the accelerator |
| Panel motion | Add reduced-motion handling | Already covered in `litStyles`, `controlStyles`, and `common.css` |

## Verification

- `npm run typecheck` and `npm run lint` clean.
- 88 suites / 698 tests pass, re-run after each revision.
- Contrast measured against each stock theme's own `editorWidget.background`.
- The armed-panel selector was corrected during review: `:is(${ITEMS})[data-armed]` would never have matched, because `data-armed` lands on the panel host in `RequestPanels`' shadow root while `ITEMS` is a class inside each panel's own root. It targets `[data-request-panel][data-armed]`.

**Not verified:** not rendered. The armed outline and the new visible label have not been eyeballed. The outline is worth checking with two pending requests of different kinds, since that is the exact case it exists for.
