### PR TITLE
fix(cli): give TUI error and warning text a non-colour cue

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
@@ -9,7 +9,7 @@ import {
 } from '@cli/runtime/agentRoster';
 import { setWorkspaceCliChatAgent } from '@cli/runtime/cliConfig';
 import { COLOR_ERROR, COLOR_WARNING } from '@cli/tui/ui/colors';
-import { TICK } from '@cli/tui/ui/glyphs';
+import { CROSS, TICK, WARNING } from '@cli/tui/ui/glyphs';
 import { KeyHints } from '@cli/tui/ui/KeyHints';
 import { Select, type SelectItem } from '@cli/tui/ui/Select';
 import {
@@ -171,11 +171,11 @@ export function AgentRosterForm(
     });
     return (
       <FormFrame title="/config · Agents" showCloseHint={false}>
-        {error ? <Text color={COLOR_ERROR}>{error}</Text> : null}
+        {error ? <Text color={COLOR_ERROR}>{`${CROSS} ${error}`}</Text> : null}
         {data.record.missingTeamId ? (
           <Text color={COLOR_WARNING}>
-            Team "{data.record.missingTeamId}" is unavailable; showing all
-            agents.
+            {WARNING} Team "{data.record.missingTeamId}" is unavailable; showing
+            all agents.
           </Text>
         ) : null}
         <Select

--- a/packages/cli/src/chat/tui/forms/ApiKeyEntryForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApiKeyEntryForm.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 
 import { COLOR_ERROR } from '@cli/tui/ui/colors';
 import { KeyHints } from '@cli/tui/ui/KeyHints';
-import { POINTER } from '@cli/tui/ui/glyphs';
+import { CROSS, POINTER } from '@cli/tui/ui/glyphs';
 import { apiKeyEnvName, type ApiProvider } from '@model/apiProviders';
 import {
   PROVIDER_DISPLAY_NAMES,
@@ -62,7 +62,7 @@ export function ApiKeyEntryForm(
       </Box>
       <Box marginTop={1} flexDirection="column">
         {props.error ? (
-          <Text color={COLOR_ERROR}>{props.error}</Text>
+          <Text color={COLOR_ERROR}>{`${CROSS} ${props.error}`}</Text>
         ) : (
           <Text dimColor>
             Stored in TeXRA secrets on Enter — or set{' '}

--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -12,7 +12,7 @@ import { useState } from 'react';
 
 import { COLOR_ERROR } from '@cli/tui/ui/colors';
 import { KeyHints } from '@cli/tui/ui/KeyHints';
-import { POINTER } from '@cli/tui/ui/glyphs';
+import { CROSS, POINTER } from '@cli/tui/ui/glyphs';
 import { Select, type SelectItem } from '@cli/tui/ui/Select';
 import { computeSelectWindowSize } from '@cli/tui/selectWindow';
 import { stripPrefix } from '@shared/config/configKeys';
@@ -229,7 +229,7 @@ function ConfigTextEditor(props: {
       </Box>
       {error ? (
         <Box marginTop={1}>
-          <Text color={COLOR_ERROR}>{error}</Text>
+          <Text color={COLOR_ERROR}>{`${CROSS} ${error}`}</Text>
         </Box>
       ) : null}
       <Box marginTop={1}>

--- a/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
+++ b/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
@@ -80,7 +80,10 @@ export class EntryErrorBoundary extends Component<
     const detail = formatRenderError(this.state.error);
     return (
       <Box paddingX={1}>
-        <Text color={COLOR_ERROR} dimColor>
+        {/* Not dimmed: this is the only signal that an entry failed to
+            render, and dimming the one message reporting a failure is the
+            opposite of what its salience should be. */}
+        <Text color={COLOR_ERROR}>
           {`${WARNING} failed to render ${this.props.label ?? 'entry'}${detail ? `: ${detail}` : ''}`}
         </Text>
       </Box>

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -25,6 +25,7 @@ import { renderCliPrompt } from '@cli/tui/renderCliPrompt';
 import { KeyHints, type KeyHint } from '@cli/tui/ui/KeyHints';
 import { Select, type SelectItem } from '@cli/tui/ui/Select';
 import { COLOR_ERROR, COLOR_HINT } from '@cli/tui/ui/colors';
+import { CROSS } from '@cli/tui/ui/glyphs';
 import { planOnboardingFunnelTransition } from '@controllers/onboarding/onboardingFunnel';
 import { warn as logWarning } from '@logger/logUtils';
 import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
@@ -461,7 +462,9 @@ function OnboardingFrame(props: {
         {props.title}
       </Text>
       {props.subtitle ? <Text dimColor>{props.subtitle}</Text> : null}
-      {props.error ? <Text color={COLOR_ERROR}>{props.error}</Text> : null}
+      {props.error ? (
+        <Text color={COLOR_ERROR}>{`${CROSS} ${props.error}`}</Text>
+      ) : null}
       <Box marginTop={1} flexDirection="column">
         {props.children}
       </Box>


### PR DESCRIPTION
An interfaces pass over the terminal UI (263 files in `packages/cli/src`), applying the same lenses used on the webviews.

## The finding

The TUI strips **every** SGR sequence at the stream when colour is off — `tuiOutputStreamForColor` wraps stdout in `sgrStrippingWriteStream`. That module already states the rule in a comment:

> components whose only styling is SGR — the text-input caret's reverse-video — need a glyph fallback when everything SGR is stripped

The caret got its fallback. Error and warning **message text** did not.

So under `NO_COLOR`, `--no-color`, `TERM=dumb`, or a piped stdout, these five rendered as plain text indistinguishable from the ordinary copy beside them:

| Location | Message |
| --- | --- |
| `onboarding/runOnboarding.tsx:465` | sign-in / device-auth error |
| `chat/tui/forms/ApiKeyEntryForm.tsx:65` | API-key entry error |
| `chat/tui/forms/ConfigForm.tsx:232` | config validation error |
| `chat/tui/forms/AgentRosterForm.tsx:174` | agent roster error |
| `chat/tui/forms/AgentRosterForm.tsx:176` | unavailable-team warning |

The onboarding and API-key cases are the sharpest: the red text *was* the entire signal that the attempt failed, and it sits directly under a `dimColor` hint line, so with SGR stripped the error and the hint are the same.

## The fix

Prefix with the glyphs the codebase already uses for exactly this. `transcriptEntryLayout` maps `failed` to `CROSS`; `WorkflowRunDetails` and `EntryErrorBoundary` already prefix `CROSS` and `WARNING` inline. Errors take `✗`, warnings take `⚠`. No new vocabulary.

Separately, `EntryErrorBoundary` rendered its message as `color={COLOR_ERROR} dimColor` — the one signal that an entry failed to render was also the quietest thing in the transcript. The dim is gone.

## Considered but rejected

| Location | Candidate | Rejected because |
| --- | --- | --- |
| `FormFrame.tsx:84`, `ListForm.tsx:71`, `RetryRequest.tsx:58`, `BashApproval.tsx:60` | Add glyphs to the frame/modal tints | These carry the state in their titles already — `"… - error"`, `"Retry the failed call?"` — so the colour is reinforcement, not the only cue |
| `QueuedFollowUpsPanel.tsx:105` | Add `⚠` to the warning-toned header | It is an informational count of queued follow-ups, not a warning; a glyph would overstate it |
| Numeric columns | `tabular-nums` equivalent for changing values | Terminal cells are monospace by definition, so digits already align. Reporting it would be a web habit misapplied |
| `chat/tui/render/DiffView.tsx` | Restore colour distinction on 16-colour terminals | Bands collapse there, but the `+`/`-` markers keep the diff readable — already documented in that file |

## Verification

- `npm run typecheck` and `npm run lint` clean.
- **147 CLI suites / 2158 tests pass.**
- The stripping path was read end to end (`cliContext` → `tuiOutputStreamForColor` → `sgrStrippingWriteStream`) to confirm colour loss is total rather than degraded, which is what makes a colour-only cue unrecoverable.
- Glyph choice cross-checked against existing conventions rather than invented.

**Not verified:** not run in a live terminal with `NO_COLOR=1`. The glyphs are plain Unicode already used elsewhere in the TUI, so terminal support matches the existing markers, but the visual result of the five changed lines has not been eyeballed.
