### PR TITLE
fix(progressView): restore Followup collapsible on VS Code

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -42,7 +42,19 @@ import {
 import './QueuedFollowUps';
 
 // Web Awesome native components
+import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
+
+/** True when any shadow host or light ancestor has `data-desktop-view`. */
+function hostHasDesktopViewAttribute(start: Element): boolean {
+  let el: Element | null = start;
+  while (el) {
+    if (el.hasAttribute('data-desktop-view')) return true;
+    const root = el.getRootNode();
+    el = root instanceof ShadowRoot ? root.host : el.parentElement;
+  }
+  return false;
+}
 
 @customElement('follow-up-input')
 export class FollowUpInput extends LitElement {
@@ -61,6 +73,11 @@ export class FollowUpInput extends LitElement {
 
       :host([hidden]) {
         display: none;
+      }
+
+      /* VS Code only (see useCollapsibleShell): match Todos / Plan chrome. */
+      wa-details.panel-collapsible {
+        min-width: 0;
       }
 
       .follow-up-container {
@@ -238,6 +255,9 @@ export class FollowUpInput extends LitElement {
   @query(`#${ELEMENT_IDS.FOLLOW_UP_INPUT}`)
   declare private textAreaEl: HTMLElement | null;
 
+  @query('wa-details')
+  declare private detailsEl: (HTMLElement & { open: boolean }) | null;
+
   private recordingController = new RecordingButtonController(this, {
     startCommand: PROGRESS_VIEW_COMMANDS.START_RECORDING,
     stopCommand: PROGRESS_VIEW_COMMANDS.STOP_RECORDING,
@@ -385,14 +405,32 @@ export class FollowUpInput extends LitElement {
     this.updateValue(insertText, streamId, 'append', eventSink);
   }
 
+  /**
+   * Desktop mounts `<stream-conversation data-desktop-view="progress">` and
+   * keeps the composer always open. VS Code Progress Board uses the collapsible
+   * shell so the six-line Message box does not permanently own the footer.
+   * Walk shadow hosts because FollowUpInput sits under nested shadow roots.
+   */
+  private get useCollapsibleShell(): boolean {
+    return !hostHasDesktopViewAttribute(this);
+  }
+
   override render(): TemplateResult | typeof nothing {
     if (this.archived) return nothing;
+    const body = this.renderComposerBody();
+    // VS Code only: restore the pre-desktop-modernize wa-details chrome.
+    // Desktop already has a roomy conversation pane — leave the composer open.
+    if (!this.useCollapsibleShell) return body;
     return html`
-      <section
-        id=${ELEMENT_IDS.FOLLOW_UP_CONTAINER}
-        class="follow-up-container"
-        aria-label="Follow-up message"
-      >
+      <wa-details class="panel-collapsible" summary="Followup">
+        ${body}
+      </wa-details>
+    `;
+  }
+
+  private renderComposerBody(): TemplateResult {
+    return html`
+      <div id=${ELEMENT_IDS.FOLLOW_UP_CONTAINER} class="follow-up-container">
         ${
           this.queuedMessages.length > 0
             ? html`<queued-follow-ups
@@ -459,7 +497,7 @@ export class FollowUpInput extends LitElement {
             })}
           </div>
         </div>
-      </section>
+      </div>
     `;
   }
 
@@ -472,7 +510,12 @@ export class FollowUpInput extends LitElement {
     // Don't focus if not visible
     if (!this.visible) return;
 
-    // Wait for Lit to finish rendering (replaces setTimeout debounce)
+    // VS Code collapsible shell: expand so the composer is visible.
+    if (this.detailsEl && !this.detailsEl.open) {
+      this.detailsEl.open = true;
+    }
+
+    // Wait for Lit / wa-details to finish laying out
     await this.updateComplete;
 
     if (!this.textAreaEl || !this.visible) return;

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -419,8 +419,11 @@ export class FollowUpInput extends LitElement {
     if (this.archived) return nothing;
     const body = this.renderComposerBody();
     // VS Code only: restore the pre-desktop-modernize wa-details chrome.
-    // Desktop already has a roomy conversation pane — leave the composer open.
-    if (!this.useCollapsibleShell) return body;
+    // Desktop already has a roomy conversation pane — leave the composer open,
+    // but keep a region landmark so the follow-up area stays named for AT.
+    if (!this.useCollapsibleShell) {
+      return html` <section aria-label="Follow-up message">${body}</section> `;
+    }
     return html`
       <wa-details class="panel-collapsible" summary="Followup">
         ${body}


### PR DESCRIPTION
## Summary
- On **VS Code** Progress Board, the follow-up Message TeXRA box is again a Web Awesome `wa-details` with summary **Followup** (collapsible).
- **Desktop** is unchanged: the composer stays always open (`data-desktop-view` detection walks shadow hosts).

## Test plan
- [ ] VS Code: Progress Board shows a **Followup** disclosure; expand to get Message TeXRA…
- [ ] VS Code: focus / send / polish still open the disclosure and work
- [ ] Desktop: composer remains always visible (no Followup details chrome)
- [ ] Queued follow-ups still render inside the expanded body