### PR TITLE
fix(progressView): keep approval Approve/Reject actions on screen

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ConversationContent.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ConversationContent.styles.ts
@@ -55,10 +55,6 @@ export const conversationContentStyles: CSSResult = css`
     background: var(--wa-color-surface-default);
   }
 
-  .conversation-approval-dock:empty {
-    display: none;
-  }
-
   .conversation-prelude,
   .conversation-epilogue {
     flex: 0 1 auto;

--- a/packages/extension/src/progressView/frontend/components/ConversationContent.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ConversationContent.styles.ts
@@ -38,6 +38,27 @@ export const conversationContentStyles: CSSResult = css`
     box-sizing: border-box;
   }
 
+  /* Pending approvals sit above the transcript and are not height-capped
+     with todos/plans. A shared prelude max-height used to clip the Approve
+     row when command details filled the pane (sticky actions alone could
+     not recover once the whole card sat below the fold). */
+  .conversation-approval-dock {
+    flex: 0 1 auto;
+    min-height: 0;
+    max-height: min(52%, 30rem);
+    padding-top: var(--wa-space-xs);
+    overflow-x: hidden;
+    overflow-y: auto;
+    scrollbar-width: thin;
+    position: relative;
+    z-index: 2;
+    background: var(--wa-color-surface-default);
+  }
+
+  .conversation-approval-dock:empty {
+    display: none;
+  }
+
   .conversation-prelude,
   .conversation-epilogue {
     flex: 0 1 auto;
@@ -95,6 +116,10 @@ export const conversationContentStyles: CSSResult = css`
   @container (max-width: 640px) {
     .conversation-column {
       width: calc(100% - 2 * var(--wa-space-xs));
+    }
+
+    .conversation-approval-dock {
+      max-height: min(48%, 24rem);
     }
 
     .conversation-prelude {

--- a/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -47,11 +47,19 @@ export class ToolUseStreamContent extends BaseStreamContent {
       )}
 
       <div class="conversation-content">
-        <div class="conversation-column conversation-prelude">
-          <request-panels
-            .permissions=${this.filteredPermissions}
-          ></request-panels>
+        ${
+          this.filteredPermissions.length > 0
+            ? html`
+                <div class="conversation-column conversation-approval-dock">
+                  <request-panels
+                    .permissions=${this.filteredPermissions}
+                  ></request-panels>
+                </div>
+              `
+            : nothing
+        }
 
+        <div class="conversation-column conversation-prelude">
           <todo-list
             .todos=${currentState.todos}
             .collapseKey=${streamInfo.name}

--- a/packages/extension/src/progressView/frontend/components/WorkflowStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowStreamContent.ts
@@ -45,11 +45,19 @@ export class WorkflowStreamContent extends BaseStreamContent {
       )}
 
       <div class="conversation-content">
-        <div class="conversation-column conversation-prelude">
-          <request-panels
-            .permissions=${this.filteredPermissions}
-          ></request-panels>
+        ${
+          this.filteredPermissions.length > 0
+            ? html`
+                <div class="conversation-column conversation-approval-dock">
+                  <request-panels
+                    .permissions=${this.filteredPermissions}
+                  ></request-panels>
+                </div>
+              `
+            : nothing
+        }
 
+        <div class="conversation-column conversation-prelude">
           <background-tasks-panel scope="inquiries"></background-tasks-panel>
         </div>
 

--- a/src/shared/styles/requestPanelSharedStyles.ts
+++ b/src/shared/styles/requestPanelSharedStyles.ts
@@ -189,6 +189,11 @@ export const requestPanelSharedStyles: CSSResult = css`
     box-sizing: border-box;
     min-width: 0;
     max-width: 100%;
+    /* Keep the action row in the card even when details scroll; the dock
+       that hosts request-panels is height-capped, so the card must not grow
+       past that budget and hide Approve/Reject below the fold. */
+    max-height: 100%;
+    min-height: 0;
   }
 
   :is(${DETAILS}) {
@@ -199,9 +204,13 @@ export const requestPanelSharedStyles: CSSResult = css`
 
   /* Scroll constraint for panels with potentially long content.
      Excluded: workflow-proposal__details (has an absolutely-positioned
-     dropdown that would be clipped by overflow-y: auto). */
+     dropdown that would be clipped by overflow-y: auto).
+     Cap below the approval dock so header + details + actions fit without
+     forcing the primary buttons off-screen. */
   :is(${SCROLLABLE_DETAILS}) {
-    max-height: min(34vh, 26rem);
+    flex: 1 1 auto;
+    min-height: 0;
+    max-height: min(28vh, 16rem);
     overflow-y: auto;
     scrollbar-gutter: stable;
   }
@@ -223,10 +232,18 @@ export const requestPanelSharedStyles: CSSResult = css`
     gap: ${sp.small};
     min-width: 0;
     max-width: 100%;
+    /* Pin under the details block inside the card (not only sticky within a
+       scroll ancestor). flex-shrink: 0 keeps Approve/Reject visible while
+       long commands scroll in __details. */
+    flex: 0 0 auto;
     position: sticky;
     inset-block-end: 0;
     z-index: 1;
+    margin-block-start: auto;
+    padding-block-start: ${sp.small};
     background: var(--wa-color-surface-raised);
+    box-shadow: 0 -0.5rem 0.75rem -0.5rem
+      color-mix(in srgb, var(--wa-color-surface-raised) 85%, transparent);
   }
 
   :is(${ACTIONS}) > * {
@@ -327,7 +344,7 @@ export const requestPanelSharedStyles: CSSResult = css`
      that used to share this block live in ExternalInquiryPanel.styles.ts. */
   @media (max-height: 900px) {
     :is(${SCROLLABLE_DETAILS}) {
-      max-height: min(28vh, 20rem);
+      max-height: min(22vh, 12rem);
     }
   }
 `;

--- a/src/shared/styles/requestPanelSharedStyles.ts
+++ b/src/shared/styles/requestPanelSharedStyles.ts
@@ -189,11 +189,6 @@ export const requestPanelSharedStyles: CSSResult = css`
     box-sizing: border-box;
     min-width: 0;
     max-width: 100%;
-    /* Keep the action row in the card even when details scroll; the dock
-       that hosts request-panels is height-capped, so the card must not grow
-       past that budget and hide Approve/Reject below the fold. */
-    max-height: 100%;
-    min-height: 0;
   }
 
   :is(${DETAILS}) {


### PR DESCRIPTION
## Summary
- Command (and other) approval panels live in a dedicated **approval dock** above the log, not in the height-capped prelude with todos/plans.
- Panel details scroll inside the card; **Approve / Reject stay visible** under the command (sticky action row + tighter details max-height).

## Test plan
- [ ] Trigger a bash/command approval with a multi-line command in VS Code Progress Board
- [ ] Confirm Approve and Reject are visible without hunting a nested scroll region
- [ ] Confirm todos/plans still appear in the prelude when present
- [ ] Confirm no empty approval dock when there are no pending permissions
- [ ] Spot-check workflow stream approvals (same dock layout)