### PR TITLE
fix(retry): stop clipping the error message with no way to read it

### DIFF
--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.styles.ts
@@ -12,13 +12,21 @@ export const retryRequestPanelStyles: CSSResult = css`
     font-weight: var(--font-weight-medium);
   }
 
+  /* No local clip. A max-height of 4em with overflow hidden cut the message
+     with no way to read the rest: the adjacent "Error details" disclosure
+     holds errorDetails, a different value, not the truncated remainder. The
+     text-overflow: ellipsis beside it never applied either — that needs
+     white-space: nowrap or a line clamp, so the text was hard-cut without
+     even an ellipsis to show it. Length is already handled one level up,
+     where retry-request__details scrolls at min(34vh, 26rem).
+
+     Sized with its sibling __operation rather than a step below it: this is
+     the text explaining why the call failed, and it was the smallest text in
+     the panel at 10.4px. */
   .retry-request__error {
-    font-size: var(--font-size-xs);
+    font-size: var(--font-size-sm);
     color: var(--color-error);
     word-break: break-word;
-    max-height: 4em;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .retry-request__error-details {


### PR DESCRIPTION
Follow-up to the `--font-size-xs` question left open on #9766. I audited all 51 usages rather than changing the token. **One real defect came out of it; the rest are fine.** This PR is that one defect.

## The bug

`RetryRequestPanel` capped its error message at `max-height: 4em; overflow: hidden`, so a long provider error is cut mid-sentence — and the remainder is unreachable. The "Error details" disclosure next to it renders `errorDetails`, a separately formatted value, **not** the truncated rest of `errorMessage`.

The `text-overflow: ellipsis` sitting beside the clip never did anything either: that property needs `white-space: nowrap` or a line clamp, and this is a wrapping block. So the message was hard-cut with no ellipsis to even signal that text was missing.

The clip is deleted rather than repaired — length is already handled one level up, where `retry-request__details` scrolls at `min(34vh, 26rem)` like every other panel's details block.

The error is also sized with its sibling `__operation` (`--font-size-sm`) instead of a step below it. At `--font-size-xs` (**10.4px**) the text explaining why the call failed was the smallest thing in the panel.

## Correcting the earlier claim

On #9766 I described `--font-size-xs` as "53 usages" of sub-legible text and implied a systemic scale problem. Auditing it:

- **51 usages, not 53.**
- **14 of those size icon glyphs**, not text — no legibility question at all.
- Of the ~37 text usages, nearly all are badges, chips, hints, and secondary metadata in a dense IDE sidebar, where 10.4px scaled off `--vscode-font-size` is a reasonable and *user-controlled* size.

So **no token change and no mass migration.** The rule worth holding is narrower: `--font-size-xs` is for secondary metadata, not for content the user must read to make a decision. The retry error and the bash working directory (fixed in #9766) were the two places that broke it.

## Considered but rejected

| Location | Candidate | Rejected because |
| --- | --- | --- |
| `litStyles.ts` | Raise `--font-size-xs` from `0.8` toward a 12px floor | It scales off `--vscode-font-size`, so it already tracks the user's own choice; raising it would resize ~37 correct call sites to fix two wrong ones |
| `InstructionPanel.styles.ts:378`, `desktop/styles.css:675` | `outline: 0` removes the focus ring | Both wrappers carry a `:focus-within` replacement (border + box-shadow), so focus stays visible |
| `AgentSelectionPanel.ts:479` | Path truncated with `nowrap` + ellipsis | The full path is reachable — the element carries `title=${agent.filePath}` |
| `taskShell.css:614` | Inert `text-overflow: ellipsis` on an `inline-flex` chip | Same inert-property shape, but it is a fixed-width status chip, not content with a lost remainder |
| `codeBlockStyles.ts:25` | Code-block header at `--font-size-xs` | Chrome label (language name + copy control), not content |

## Verification

- `npm run typecheck` and `npm run lint` clean.
- 88 suites / 698 tests pass.
- Confirmed the disclosure holds a different value by reading `RetryRequestPanel.ts:95-111` — `errorMessage` in the clipped block, `formatRetryDetails(errorDetails)` in the disclosure.
- Confirmed `retry-request__details` is in `SCROLLABLE_DETAILS` (only `workflow-proposal` is excluded), so removing the inner clip cannot make the panel grow unbounded.

**Not verified:** not rendered. Worth checking with a genuinely long provider error to confirm the panel scrolls rather than stretches.
