### PR TITLE
fix(ui): size the composer from content and cut dead progress-view CSS

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -70,10 +70,6 @@ export class BackgroundTasksPanel extends LitElement {
         display: block;
       }
 
-      :host([hidden]) {
-        display: none;
-      }
-
       .task-list {
         display: flex;
         flex-direction: column;

--- a/packages/extension/src/progressView/frontend/components/FileList.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.styles.ts
@@ -7,10 +7,6 @@ export const fileListStyles: CSSResult = css`
     display: block;
   }
 
-  :host([hidden]) {
-    display: none;
-  }
-
   .files-container {
     padding: 0;
     font-size: var(--wa-editor-font-size);
@@ -57,14 +53,6 @@ export const fileListStyles: CSSResult = css`
     white-space: nowrap;
     flex: 1;
     min-width: 200px;
-  }
-
-  .file-path {
-    cursor: pointer;
-  }
-
-  .file-path:hover {
-    text-decoration: underline;
   }
 
   .file-dir {

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -71,10 +71,6 @@ export class FollowUpInput extends LitElement {
         max-width: 100%;
       }
 
-      :host([hidden]) {
-        display: none;
-      }
-
       /* VS Code only (see useCollapsibleShell): match Todos / Plan chrome. */
       wa-details.panel-collapsible {
         min-width: 0;
@@ -123,9 +119,12 @@ export class FollowUpInput extends LitElement {
             color-mix(in srgb, var(--wa-color-surface-shadow) 16%, transparent);
       }
 
-      /* Give substantial instructions six lines by default. Web Awesome's
-         vertical mode puts the resize affordance on the native textarea and
-         mirrors its bounded height onto the wrapper. */
+      /* The composer rests at two lines and grows with what you type, up to
+         the max below, so a substantial instruction still gets room without
+         an empty draft reserving it. Not Web Awesome's resize="auto": that
+         copies the scroll height into an invisible grid item which, inside a
+         constrained composer, keeps an oversized row for an empty draft. Size
+         the native textarea part from its own content instead. */
       #followUpInput {
         display: block;
         min-width: 0;
@@ -134,7 +133,7 @@ export class FollowUpInput extends LitElement {
         line-height: var(--line-height-relaxed);
         height: auto;
         --textarea-min-height: calc(
-          6lh + var(--wa-space-xs) + var(--wa-space-3xs)
+          2lh + var(--wa-space-xs) + var(--wa-space-3xs)
         );
         --textarea-max-height: clamp(var(--textarea-min-height), 32vh, 240px);
       }
@@ -151,7 +150,9 @@ export class FollowUpInput extends LitElement {
       /* The one place a textarea renders sans rather than mono: this is prose a
          user writes to an agent, not code. */
       #followUpInput::part(textarea) {
+        field-sizing: content;
         width: 100%;
+        height: auto;
         min-height: var(--textarea-min-height);
         max-height: var(--textarea-max-height);
         padding: var(--wa-space-xs) var(--wa-space-s) var(--wa-space-3xs);
@@ -447,8 +448,8 @@ export class FollowUpInput extends LitElement {
             id=${ELEMENT_IDS.FOLLOW_UP_INPUT}
             aria-label="Follow-up message"
             placeholder="Message TeXRA…"
-            rows="6"
-            resize="vertical"
+            rows="2"
+            resize="none"
             .value=${live(this.value)}
             @input=${this.handleInput}
             @keydown=${this.handleKeydown}

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -121,10 +121,11 @@ export class FollowUpInput extends LitElement {
 
       /* The composer rests at two lines and grows with what you type, up to
          the max below, so a substantial instruction still gets room without
-         an empty draft reserving it. Not Web Awesome's resize="auto": that
-         copies the scroll height into an invisible grid item which, inside a
-         constrained composer, keeps an oversized row for an empty draft. Size
-         the native textarea part from its own content instead. */
+         an empty draft reserving it. field-sizing does the growing; the drag
+         affordance stays for anyone who wants a taller box than their text.
+         Not Web Awesome's resize="auto": that copies the scroll height into an
+         invisible grid item which, inside a constrained composer, keeps an
+         oversized row for an empty draft. */
       #followUpInput {
         display: block;
         min-width: 0;
@@ -449,7 +450,7 @@ export class FollowUpInput extends LitElement {
             aria-label="Follow-up message"
             placeholder="Message TeXRA…"
             rows="2"
-            resize="none"
+            resize="vertical"
             .value=${live(this.value)}
             @input=${this.handleInput}
             @keydown=${this.handleKeydown}

--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -34,10 +34,6 @@ export class PlanView extends LitElement {
         display: block;
       }
 
-      :host([hidden]) {
-        display: none;
-      }
-
       .plan-body {
         max-height: var(--height-xlarge);
         overflow-y: auto;

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -145,10 +145,6 @@ export class StreamHeader extends LitElement {
         container-type: inline-size;
       }
 
-      :host([hidden]) {
-        display: none;
-      }
-
       .log-header {
         padding: var(--wa-space-2xs)
           max(

--- a/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
@@ -199,12 +199,6 @@ export const streamTabStyles = css`
     background: transparent;
   }
 
-  /* Drop the dim-by-default opacity so the flipped foreground renders
-   * at full contrast on the selection background. */
-  .tab-container.is-active .tab-meta {
-    opacity: var(--opacity-full);
-  }
-
   .tab-container.is-compact .tab {
     padding: var(--wa-space-3xs) var(--wa-space-3xs);
   }

--- a/packages/extension/src/progressView/frontend/components/StreamTabsContainer.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabsContainer.styles.ts
@@ -14,10 +14,6 @@ export const streamTabsContainerStyles = css`
     overflow: hidden;
   }
 
-  :host([hidden]) {
-    display: none;
-  }
-
   /*
    * No own border-left: the single separator between this rail and the
    * conversation is owned by the host layout — the wa-split-panel divider

--- a/packages/extension/src/progressView/frontend/components/TodoList.ts
+++ b/packages/extension/src/progressView/frontend/components/TodoList.ts
@@ -35,10 +35,6 @@ export class TodoList extends LitElement {
         display: block;
       }
 
-      :host([hidden]) {
-        display: none;
-      }
-
       .todo-list {
         display: flex;
         flex-direction: column;

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -107,10 +107,6 @@ export class UsagePanel extends LitElement {
         display: block;
       }
 
-      :host([hidden]) {
-        display: none;
-      }
-
       .usage-summary-footer {
         border-top: var(--border-thin) solid var(--color-border);
         background-color: var(--wa-color-surface-lowered);

--- a/packages/extension/src/progressView/frontend/styles/codeBlockStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/codeBlockStyles.ts
@@ -93,11 +93,6 @@ export const codeBlockStyles = css`
   }
 
   /* Syntax highlighted code blocks */
-  pre.hljs {
-    padding: var(--wa-space-2xs);
-    overflow-x: auto;
-  }
-
   pre.hljs code {
     background: transparent;
     padding: 0;

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -380,19 +380,11 @@ export const logEntryStyles = css`
     contain-intrinsic-size: auto 40px;
   }
 
-  wa-details.banner-details::part(base) {
-    border: 0;
-    border-radius: 0;
-    background: transparent;
-  }
-
+  /* Base/content resets and the header's padding come from
+     commonViewStyles, which every consumer of this sheet loads first. Only
+     the compact header height is specific to log banners. */
   wa-details.banner-details::part(header) {
     min-height: 26px;
-    padding: 0;
-  }
-
-  wa-details.banner-details::part(content) {
-    padding: 0;
   }
 
   .details-summary {

--- a/packages/extension/src/progressView/frontend/styles/logStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logStyles.ts
@@ -34,9 +34,7 @@ export const layoutStyles = css`
     contain: layout style paint;
   }
 
-  task-group-list > .log-container,
-  task-group-list > vscode-scrollable,
-  vscode-scrollable {
+  task-group-list > .log-container {
     flex: 1 1 auto;
     min-height: 0;
     overflow-y: auto;

--- a/scripts/smoke-webviews-electron-runner.cjs
+++ b/scripts/smoke-webviews-electron-runner.cjs
@@ -368,6 +368,12 @@ async function assertProgressComposerLayout(window, view) {
   return window.webContents.executeJavaScript(
     `
       (async () => {
+        // Resting height of the composer, in lines. It sits at two and grows
+        // with content up to --textarea-max-height; the six-line resting box
+        // it replaced reserved that room for an empty draft. Keep in step
+        // with --textarea-min-height in FollowUpInput.ts.
+        const COMPOSER_RESTING_ROWS = 2;
+
         function findDeep(selector, root = document) {
           const direct = root.querySelector?.(selector);
           if (direct) return direct;
@@ -408,7 +414,7 @@ async function assertProgressComposerLayout(window, view) {
           Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingBottom);
         const minHeight = Number.parseFloat(style.minHeight);
         const maxHeight = Number.parseFloat(style.maxHeight);
-        const expectedMinHeight = 6 * lineHeight + paddingBlock;
+        const expectedMinHeight = COMPOSER_RESTING_ROWS * lineHeight + paddingBlock;
         const expectedMaxHeight = Math.max(
           minHeight,
           Math.min(window.innerHeight * 0.32, 240),
@@ -416,9 +422,12 @@ async function assertProgressComposerLayout(window, view) {
         const initialTextareaRect = textarea.getBoundingClientRect();
         const initialWrapperRect = wrapper.getBoundingClientRect();
 
-        if (webAwesomeTextarea.rows !== 6 || textarea.rows !== 6) {
+        if (
+          webAwesomeTextarea.rows !== COMPOSER_RESTING_ROWS ||
+          textarea.rows !== COMPOSER_RESTING_ROWS
+        ) {
           throw new Error(
-            \`${view.name} composer rows did not propagate: host=\${webAwesomeTextarea.rows} native=\${textarea.rows}\`,
+            \`${view.name} composer rows did not propagate: host=\${webAwesomeTextarea.rows} native=\${textarea.rows} expected=\${COMPOSER_RESTING_ROWS}\`,
           );
         }
         if (webAwesomeTextarea.resize !== 'vertical' || style.resize !== 'vertical') {
@@ -428,7 +437,7 @@ async function assertProgressComposerLayout(window, view) {
         }
         if (Math.abs(minHeight - expectedMinHeight) > 3) {
           throw new Error(
-            \`${view.name} composer minimum is not six lines: min=\${minHeight.toFixed(1)}px expected=\${expectedMinHeight.toFixed(1)}px\`,
+            \`${view.name} composer minimum is not \${COMPOSER_RESTING_ROWS} lines: min=\${minHeight.toFixed(1)}px expected=\${expectedMinHeight.toFixed(1)}px\`,
           );
         }
         if (initialTextareaRect.height < minHeight - 1) {

--- a/src/shared/styles/bannerStyles.ts
+++ b/src/shared/styles/bannerStyles.ts
@@ -155,36 +155,6 @@ export const settingsBannerStyles: CSSResult = css`
     max-width: min(42rem, 46%);
   }
 
-  .settings-banner-list {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
-    gap: var(--wa-space-2xs) var(--wa-space-s);
-    margin: var(--wa-space-3xs) 0 0;
-    padding: 0;
-    list-style: none;
-  }
-
-  .settings-banner-list li {
-    display: flex;
-    align-items: flex-start;
-    gap: var(--wa-space-2xs);
-  }
-
-  .settings-banner-step {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 18px;
-    height: 18px;
-    flex: 0 0 18px;
-    border-radius: 50%;
-    background: var(--wa-color-brand-fill-loud);
-    color: var(--wa-color-brand-on-loud);
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-bold);
-    line-height: var(--line-height-tight);
-  }
-
   @container settings (max-width: 720px) {
     .settings-banner-layout {
       grid-template-columns: auto minmax(0, 1fr);

--- a/src/shared/styles/litStyles.ts
+++ b/src/shared/styles/litStyles.ts
@@ -93,9 +93,7 @@ export const designTokens: CSSResult = css`
     --height-xlarge: 400px;
 
     /* Widths */
-    --width-icon: 16px;
     --width-button-min: 80px;
-    --width-content-max: 1000px;
 
     /* Borders */
     --border-thin: 1px;
@@ -137,7 +135,6 @@ export const designTokens: CSSResult = css`
        rows, code blocks, inputs); large regions separate by a background step
        instead. */
     --border-hairline: light-dark(rgb(0 0 0 / 10%), rgb(255 255 255 / 10%));
-    --border-hairline-soft: light-dark(rgb(0 0 0 / 5%), rgb(255 255 255 / 5%));
     --border-hairline-strong: light-dark(
       rgb(0 0 0 / 15%),
       rgb(255 255 255 / 20%)
@@ -167,22 +164,17 @@ export const designTokens: CSSResult = css`
     --focus-ring-offset: 2px;
     --textarea-h-s: 2.75rem;
     --textarea-h-m: 6rem;
-    --textarea-h-l: 6.625rem;
 
     /* Opacity levels */
     --opacity-separator: 0.3;
-    --opacity-faint: 0.35;
     --opacity-disabled: 0.5;
-    --opacity-muted: 0.6;
     --opacity-subtle: 0.7;
-    --opacity-hover: 0.8;
     --opacity-normal: 0.85;
     --opacity-full: 1;
 
     /* Transitions */
     --transition-fast: 0.15s ease;
     --transition-normal: 0.2s ease;
-    --transition-slow: 0.3s ease;
 
     /* Letter spacing. Caps for uppercase labels/badges, tight for display type
        (em scales with font-size). */

--- a/src/shared/styles/requestPanelSharedStyles.ts
+++ b/src/shared/styles/requestPanelSharedStyles.ts
@@ -23,7 +23,6 @@
 import { css, unsafeCSS, type CSSResult } from 'lit';
 
 import { truncateTextRule } from './commonViewStyles';
-import { formControlStyles } from './controlStyles';
 
 /**
  * Shared selector groups for :is() consolidation.
@@ -261,7 +260,6 @@ export const requestPanelSharedStyles: CSSResult = css`
   .approval-request__actions wa-button[data-action]::part(base) {
     justify-content: center;
     width: 100%;
-    inline-size: 100%;
     min-width: 0;
     max-width: 100%;
   }
@@ -300,10 +298,6 @@ export const requestPanelSharedStyles: CSSResult = css`
   :is(${FEEDBACK_INPUTS}) {
     width: 100%;
   }
-
-  /* Canonical form-control skin: without it wa-textarea's stock padding eats
-     most of the feedback box's height. */
-  ${formControlStyles}
 
   /* Carousel navigation for multiple external inquiries (rendered directly by
      RequestPanels.ts, not by ExternalInquiryPanel). */

--- a/src/shared/styles/selectStyles.ts
+++ b/src/shared/styles/selectStyles.ts
@@ -109,10 +109,6 @@ export const selectStyles: CSSResult = css`
     max-height: var(--height-large, 300px);
   }
 
-  /* Compact form controls — stricter IDE-density inputs/selects.
-   * Border uses subtle surface-border, not heavier panel border. */
-  ${compactFormControlStyles}
-
   .model-option-status {
     color: var(--wa-color-danger-on-quiet);
     opacity: var(--opacity-full);

--- a/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
@@ -102,10 +102,10 @@ function image(fileName: string): ExtractedClipboardImage {
 
 describe('follow-up-input layout', () => {
   // The composer sizes from its own content rather than reserving a fixed
-  // block for an empty draft. resize="none" is deliberate: Web Awesome's
-  // "auto" mode keeps an oversized row for an empty draft inside a
-  // constrained composer, which is what the two-line floor exists to avoid.
-  it('rests at two rows and sizes from content', async () => {
+  // block for an empty draft, and keeps the manual drag affordance. Not Web
+  // Awesome's "auto" mode: it holds an oversized row for an empty draft inside
+  // a constrained composer, which is the failure the two-line floor avoids.
+  it('rests at two rows and stays vertically resizable', async () => {
     const element = createFollowUpInput('stream-layout');
     await element.updateComplete;
 
@@ -120,7 +120,7 @@ describe('follow-up-input layout', () => {
     await textarea?.updateComplete;
 
     expect(textarea?.rows).toBe(2);
-    expect(textarea?.resize).toBe('none');
+    expect(textarea?.resize).toBe('vertical');
     expect(textarea?.input.rows).toBe(2);
   });
 });

--- a/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
@@ -101,7 +101,11 @@ function image(fileName: string): ExtractedClipboardImage {
 }
 
 describe('follow-up-input layout', () => {
-  it('renders six rows with Web Awesome vertical resizing', async () => {
+  // The composer sizes from its own content rather than reserving a fixed
+  // block for an empty draft. resize="none" is deliberate: Web Awesome's
+  // "auto" mode keeps an oversized row for an empty draft inside a
+  // constrained composer, which is what the two-line floor exists to avoid.
+  it('rests at two rows and sizes from content', async () => {
     const element = createFollowUpInput('stream-layout');
     await element.updateComplete;
 
@@ -115,9 +119,9 @@ describe('follow-up-input layout', () => {
       | null;
     await textarea?.updateComplete;
 
-    expect(textarea?.rows).toBe(6);
-    expect(textarea?.resize).toBe('vertical');
-    expect(textarea?.input.rows).toBe(6);
+    expect(textarea?.rows).toBe(2);
+    expect(textarea?.resize).toBe('none');
+    expect(textarea?.input.rows).toBe(2);
   });
 });
 


### PR DESCRIPTION
## The composer

It reserved six lines in three places at once — `rows="6"`, `resize="vertical"`, and a `6lh` min-height floor — so it stood six lines tall whether the draft held one word or twenty.

It now rests at two lines and sizes from its own content, keeping the same 240px ceiling a long instruction needs before it scrolls.

**Not `resize="auto"`.** That was tried here before and removed in 4e5c782e; the comment it deleted says why — WA's auto mode copies the scroll height into an invisible grid item which, inside a constrained composer, preserves an oversized row for an empty draft. That is exactly the symptom this change is fixing, so reaching for `auto` would have shipped the bug back. The reason is now recorded in the CSS and in the test that pins the contract, so the next person doesn't reach for it either.

4e5c782e was titled "enlarge progress message composer", so the six-line size was deliberate three days ago. Content sizing preserves that intent for the case it was aimed at (a substantial instruction still gets the full height) and drops it only for the empty case.

## The dead CSS

Found by a six-lane audit of the progress-view stylesheets and the shared sheets. Every claim below was verified by tracing the selector to the templates that could match it, or the token to its consumers — not by eyeballing.

| Cut | Why it is dead |
| --- | --- |
| `.settings-banner-list`, `.settings-banner-list li`, `.settings-banner-step` | The only renderer (`src/shared/wa/settingsBanner.ts`) emits no list or step markup; the style-contract test pins only `-layout` and `-actions` |
| Eight `:host([hidden])` blocks | No caller sets `hidden` on any of those elements anywhere in the repo. Every `?hidden` binding is on a different element |
| `wa-details.banner-details` `::part(base)` and `::part(content)`, plus the header's `padding` | Byte-identical in `commonViewStyles`, which `logStyles` adopts at index 0 before `logEntryStyles`. Only the compact `min-height: 26px` was specific, and it stays |
| Second `${formControlStyles}` and `${compactFormControlStyles}` interpolations | All eight panel consumers and all three select consumers load `commonViewStyles` first, and it already reaches both via `controlStyles` |
| Eight design tokens | `--width-icon`, `--width-content-max`, `--border-hairline-soft`, `--textarea-h-l`, `--opacity-faint`, `--opacity-muted`, `--opacity-hover`, `--transition-slow`: zero `var()` consumers repo-wide, no test pins them |
| `pre.hljs { padding; overflow-x }` | `hljs` is emitted at one site, always inside `.code-block`, and `.code-block pre` already sets both |
| `.file-path` cursor and hover | The element is always `class="file-path clickable-link"`, and `.clickable-link` already provides both |
| `.tab-container.is-active .tab-meta { opacity }` | `.tab-meta` declares no opacity and nothing dims it — this restated the initial value |
| `inline-size: 100%` beside `width: 100%` | Logical alias of the same property in a horizontal writing mode |
| `vscode-scrollable` selectors | The element appears nowhere in the repo; `@vscode-elements` is not a dependency |

No visual change is intended outside the composer.

## Scope

The approval-dock work from the same session is **not** here — it ships separately in `fix/approval-actions-stay-visible`, which owns `ConversationContent.styles.ts`, `ToolUseStreamContent.ts`, `WorkflowStreamContent.ts`, and the `SCROLLABLE_DETAILS` caps. This branch touches `requestPanelSharedStyles.ts` only in three hunks far from those, so the two should merge cleanly in either order.

## Verification

Run in an isolated worktree on this exact diff, not inherited from a larger change:

- `npm run typecheck` — clean across all four projects
- `npx vitest run src/test-kernel/{progressView,webview,settings,desktop}` — 1269 passed, 162 files
- `npm run lint` — clean
- `npm run check:dead-code-ratchet` — 18 current vs 18 baselined, unchanged

**Not verified:** I did not render the webview. Every finding is a static fact about selectors, sheet order, and token consumers; the one runtime-shaped change is the composer, which wants a look in a real panel.

## Two things found that are bugs, not cuts, and are left alone here

1. `UserMessage.ts` sets `border-color` for high-contrast themes on an element that sets `border: 0`, which zeroes `border-style`. The contrast border its comment promises does not render today. Deleting the dead line would lose the intent, so it wants a real fix.
2. `ConfigForm.tsx` has `ENUM_CHROME_ROWS = 4` where the identical chrome shape uses `LIST_CHROME_ROWS = 5`, so the enum picker can size its `Select` one row past its budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
