### PR TITLE
fix(progressView): render the high-contrast user-message border, dedupe inquiry CSS

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.styles.ts
@@ -76,7 +76,12 @@ export const externalInquiryPanelStyles: CSSResult = css`
     scrollbar-gutter: stable;
   }
 
-  .external-inquiry-request__transcript-turn {
+  .external-inquiry-request__transcript-turn,
+  .external-inquiry-request__attach-files,
+  .external-inquiry-request__answer-area,
+  .external-inquiry-request__session-links,
+  .external-inquiry-request__session-links-known,
+  .external-inquiry-request__session-links-input-group {
     display: flex;
     flex-direction: column;
     gap: ${sp.small};
@@ -95,7 +100,10 @@ export const externalInquiryPanelStyles: CSSResult = css`
     color: var(--wa-color-text-quiet);
   }
 
-  .external-inquiry-request__transcript-context {
+  .external-inquiry-request__transcript-context,
+  .external-inquiry-request__session-links-hint,
+  .external-inquiry-request__chat-links,
+  .external-inquiry-request__answer-hint {
     font-size: var(--font-size-sm);
     color: var(--wa-color-text-quiet);
   }
@@ -123,12 +131,6 @@ export const externalInquiryPanelStyles: CSSResult = css`
     padding: ${sp.small} 0;
   }
 
-  .external-inquiry-request__attach-files {
-    display: flex;
-    flex-direction: column;
-    gap: ${sp.small};
-  }
-
   .external-inquiry-request__attach-label {
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-semibold);
@@ -138,7 +140,8 @@ export const externalInquiryPanelStyles: CSSResult = css`
     gap: ${sp.small};
   }
 
-  .external-inquiry-request__file-list {
+  .external-inquiry-request__file-list,
+  .external-inquiry-request__session-links-list {
     display: flex;
     flex-direction: column;
     gap: ${sp.tiny};
@@ -156,38 +159,11 @@ export const externalInquiryPanelStyles: CSSResult = css`
     color: var(--wa-color-text-link);
   }
 
-  .external-inquiry-request__answer-area {
-    display: flex;
-    flex-direction: column;
-    gap: ${sp.small};
-  }
-
-  .external-inquiry-request__session-links {
-    display: flex;
-    flex-direction: column;
-    gap: ${sp.small};
-  }
-
-  .external-inquiry-request__session-links-known,
-  .external-inquiry-request__session-links-input-group {
-    display: flex;
-    flex-direction: column;
-    gap: ${sp.small};
-  }
-
-  .external-inquiry-request__session-links-label {
+  .external-inquiry-request__session-links-label,
+  .external-inquiry-request__answer-label {
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-semibold);
     color: var(--wa-color-text-normal);
-  }
-
-  .external-inquiry-request__session-links-list {
-    display: flex;
-    flex-direction: column;
-    gap: ${sp.tiny};
-    padding: ${sp.small};
-    background: var(--wa-color-surface-lowered);
-    border-radius: var(--border-radius-small);
   }
 
   .external-inquiry-request__session-link-item {
@@ -203,22 +179,11 @@ export const externalInquiryPanelStyles: CSSResult = css`
     text-decoration: underline;
   }
 
-  /* Sizing via the canonical skin's tokens (formControlStyles, now in
-     requestPanelSharedStyles); font/line rules come from the skin itself. */
+  /* Sizing via the canonical skin's tokens (formControlStyles, reached
+     through commonViewStyles); font/line rules come from the skin itself. */
   .external-inquiry-request__session-links-input {
-    width: 100%;
     --textarea-min-height: 2.75rem;
     --textarea-max-height: min(12vh, 5rem);
-  }
-
-  .external-inquiry-request__session-links-hint {
-    font-size: var(--font-size-sm);
-    color: var(--wa-color-text-quiet);
-  }
-
-  .external-inquiry-request__chat-links {
-    font-size: var(--font-size-sm);
-    color: var(--wa-color-text-quiet);
   }
 
   .external-inquiry-request__chat-links a {
@@ -230,14 +195,7 @@ export const externalInquiryPanelStyles: CSSResult = css`
     text-decoration: underline;
   }
 
-  .external-inquiry-request__answer-label {
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-semibold);
-    color: var(--wa-color-text-normal);
-  }
-
   .external-inquiry-request__answer-input {
-    width: 100%;
     --textarea-min-height: 96px;
     --textarea-max-height: min(24vh, 12rem);
   }
@@ -245,11 +203,6 @@ export const externalInquiryPanelStyles: CSSResult = css`
   /* Answer text stays at body size, larger than the skin's sm default. */
   .external-inquiry-request__answer-input::part(textarea) {
     font-size: var(--font-size);
-  }
-
-  .external-inquiry-request__answer-hint {
-    font-size: var(--font-size-sm);
-    color: var(--wa-color-text-quiet);
   }
 
   /* The SCROLLABLE_DETAILS short-viewport override that used to share this

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -162,14 +162,16 @@ export class UserMessage extends LitElement {
        * editor-foreground text (rendering the bubble unreadable) and the panel
        * border resolves to transparent. Fall back to the editor background plus
        * a solid contrast border so the message stays visible and delineated.
+       * The bubble's outline is the inset box-shadow above, not a border, so
+       * the contrast color has to replace that shadow: the base rule sets
+       * border: 0, which zeroes border-style, so overriding border-color alone
+       * painted nothing and this fallback never rendered.
        */
       :host-context(.vscode-high-contrast) .user-message,
       :host-context(.vscode-high-contrast-light) .user-message {
         background-color: var(--wa-color-surface-default);
-        border-color: var(
-          --vscode-contrastBorder,
-          var(--wa-color-surface-border)
-        );
+        box-shadow: inset 0 0 0 1px
+          var(--vscode-contrastBorder, var(--wa-color-surface-border));
       }
     `,
   ];

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.styles.ts
@@ -69,8 +69,4 @@ export const userQuestionPanelStyles: CSSResult = css`
     color: var(--wa-color-text-quiet);
     font-size: var(--font-size-xs);
   }
-
-  .user-question-request__free-text {
-    width: 100%;
-  }
 `;


### PR DESCRIPTION
## A high-contrast border that never rendered

`UserMessage.ts` has a fallback for high-contrast themes: the selection-background fill clashes with editor-foreground text, so the bubble switches to the editor background plus "a solid contrast border so the message stays visible and delineated."

That border does not exist. The rule overrides `border-color`, but the base rule sets `border: 0`, which zeroes `border-style` — a `border-color` alone paints nothing. The bubble's visible outline is an inset `box-shadow`, so the contrast color has to replace that shadow instead.

```css
/* before: no border-style to color */
box-shadow: inset 0 0 0 1px color-mix(...);   /* base rule draws the outline */
border: 0;
...
border-color: var(--vscode-contrastBorder, ...);   /* paints nothing */

/* after */
box-shadow: inset 0 0 0 1px var(--vscode-contrastBorder, var(--wa-color-surface-border));
```

High-contrast users now get the delineated bubble the rule always intended. Found while auditing for dead CSS: the declaration reads as dead, but deleting it would have quietly discarded the intent, so it is a bug rather than a cut.

## 47 lines of duplicate rule bodies

`ExternalInquiryPanel.styles.ts` kept five sets of byte-identical declaration blocks as separate rules:

| Merged into one selector list | Members |
| --- | --- |
| `display: flex; flex-direction: column; gap: 2xs` | `__transcript-turn`, `__attach-files`, `__answer-area`, `__session-links`, `__session-links-known`, `__session-links-input-group` |
| `font-size: sm; color: quiet` | `__transcript-context`, `__session-links-hint`, `__chat-links`, `__answer-hint` |
| `font-size: sm; font-weight: semibold; color: normal` | `__session-links-label`, `__answer-label` |
| the lowered, rounded list box | `__file-list`, `__session-links-list` |

No cascade change: no selector in any set is overridden by anything between its members, and each merged block stays at its first member's position, so nothing moves later than it was.

Also drops three `width: 100%` declarations on `wa-textarea`s whose column-flex parents already stretch them (`__session-links-input`, `__answer-input`, `.user-question-request__free-text`), and corrects a comment that pointed at `requestPanelSharedStyles` for the form-control skin when it actually arrives via `commonViewStyles`.

## Relationship to the other open branches

Independent of #9773 (composer sizing and dead CSS) and of `fix/approval-actions-stay-visible` — no shared files with either, so it merges in any order.

## Verification

- `npm run typecheck` — clean across all four projects
- `npx vitest run src/test-kernel/{progressView,webview}` — 568 passed, 69 files
- `npm run lint` — clean

**Not verified:** the high-contrast bubble is a visual change I have not rendered. It wants a look under Light High Contrast and Dark High Contrast, which is exactly the state that was broken before this. The CSS dedup is textual and carries no intended visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
