### PR TITLE
refactor(cli): drop unreachable transcript render paths, fix /config enum budget

### DIFF
--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -187,9 +187,9 @@ type ConfigFormMode =
       readonly category: string;
     };
 
-	/* Every /config layout wraps one Select in the same chrome: two FormFrame
+/* Every /config layout wraps one Select in the same chrome: two FormFrame
 	   border rows, the title, the KeyHints margin, and the hints row. */
-	const SELECT_CHROME_ROWS = 5;
+const SELECT_CHROME_ROWS = 5;
 
 /** Inline text editor for a string/number setting (its own input buffer). */
 function ConfigTextEditor(props: {

--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -187,8 +187,9 @@ type ConfigFormMode =
       readonly category: string;
     };
 
-const LIST_CHROME_ROWS = 5;
-const ENUM_CHROME_ROWS = 5;
+	/* Every /config layout wraps one Select in the same chrome: two FormFrame
+	   border rows, the title, the KeyHints margin, and the hints row. */
+	const SELECT_CHROME_ROWS = 5;
 
 /** Inline text editor for a string/number setting (its own input buffer). */
 function ConfigTextEditor(props: {
@@ -327,7 +328,7 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
     const window = computeSelectWindowSize({
       availableRows: props.availableRows,
       itemCount: items.length,
-      chromeRows: ENUM_CHROME_ROWS,
+      chromeRows: SELECT_CHROME_ROWS,
     });
     return (
       <FormFrame
@@ -410,7 +411,7 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
     const window = computeSelectWindowSize({
       availableRows: props.availableRows,
       itemCount: categories.length,
-      chromeRows: LIST_CHROME_ROWS,
+      chromeRows: SELECT_CHROME_ROWS,
     });
     return (
       <FormFrame title="/config" showCloseHint={false}>
@@ -453,7 +454,7 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
   const window = computeSelectWindowSize({
     availableRows: props.availableRows,
     itemCount: items.length,
-    chromeRows: LIST_CHROME_ROWS,
+    chromeRows: SELECT_CHROME_ROWS,
   });
 
   const handleSelect = (key: string): void => {

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -30,28 +30,18 @@ const TODO_STATUS_DISPLAY: Partial<
   [TODO_STATUS.IN_PROGRESS]: { marker: TODO_ACTIVE, color: COLOR_HINT },
 };
 
-function TodoRow({
-  compact = false,
-  todo,
-}: {
-  readonly compact?: boolean;
-  readonly todo: TodoItem;
-}): React.JSX.Element {
+function TodoRow({ todo }: { readonly todo: TodoItem }): React.JSX.Element {
   const label =
     todo.status === TODO_STATUS.IN_PROGRESS ? todo.activeForm : todo.content;
   const display = TODO_STATUS_DISPLAY[todo.status];
   return (
-    <Box
-      height={compact ? 1 : undefined}
-      minWidth={0}
-      overflowY={compact ? 'hidden' : undefined}
-    >
+    <Box height={1} minWidth={0} overflowY="hidden">
       <Box flexShrink={0}>
         <Text color={display?.color}>{display?.marker ?? TODO_PENDING} </Text>
       </Box>
       <Text
         dimColor={todo.status === TODO_STATUS.COMPLETED}
-        wrap={compact ? 'truncate-end' : undefined}
+        wrap="truncate-end"
       >
         {label}
       </Text>
@@ -152,7 +142,7 @@ export function todosPlanPanelRowCount(
 function CompactRow({ row }: { row: CompactTodosPlanRow }): React.JSX.Element {
   switch (row.kind) {
     case 'todo':
-      return <TodoRow compact todo={row.todo} />;
+      return <TodoRow todo={row.todo} />;
     case 'planSummary':
       return (
         <Box height={1} minWidth={0} overflowY="hidden">
@@ -165,11 +155,11 @@ function CompactRow({ row }: { row: CompactTodosPlanRow }): React.JSX.Element {
 }
 
 export interface TodosPlanPanelProps {
-  readonly maxRows?: number;
+  readonly maxRows: number;
 }
 
 export function TodosPlanPanel(
-  props: TodosPlanPanelProps = {},
+  props: TodosPlanPanelProps,
 ): React.JSX.Element | null {
   const activeStreamId = useSignal(activeStreamIdSignal);
   const streams = useSignal(streamsSignal);
@@ -180,63 +170,33 @@ export function TodosPlanPanel(
   // Like the child list above it, the panel owns one blank separator row so
   // the todo checklist never sits flush against its neighbor. If the gap and
   // one content row do not both fit, render nothing.
-  const rowBudget =
-    props.maxRows === undefined
-      ? undefined
-      : Math.max(0, Math.floor(props.maxRows)) - 1;
-  if (rowBudget !== undefined && rowBudget <= 0) return null;
+  const rowBudget = Math.max(0, Math.floor(props.maxRows)) - 1;
+  if (rowBudget <= 0) return null;
 
-  if (rowBudget !== undefined) {
-    const { hiddenCount, rows } = compactTodosPlanRows({
-      maxRows: rowBudget,
-      plan,
-      todos,
-    });
-    return (
-      <Box
-        flexDirection="column"
-        height={rowBudget}
-        marginTop={1}
-        overflowY="hidden"
-        paddingX={1}
-      >
-        {rows.map((row) => (
-          <CompactRow key={`${row.kind}:${row.sourceIndex}`} row={row} />
-        ))}
-        {hiddenCount > 0 && rows.length < rowBudget ? (
-          <Box height={1} minWidth={0} overflowY="hidden">
-            <Text dimColor wrap="truncate-end">
-              {hiddenRowsText(
-                hiddenCount,
-                pluralize(hiddenCount, 'todo/plan item', 'todo/plan items'),
-              )}
-            </Text>
-          </Box>
-        ) : null}
-      </Box>
-    );
-  }
-
-  // Reached only when maxRows is undefined (the compact branch above owns every
-  // bounded case), so the panel renders uncapped with a trailing margin.
+  const { hiddenCount, rows } = compactTodosPlanRows({
+    maxRows: rowBudget,
+    plan,
+    todos,
+  });
   return (
-    <Box flexDirection="column" paddingX={1} marginBottom={1}>
-      {todos.length > 0 ? (
-        <Box flexDirection="column">
-          <Text bold dimColor>
-            Todos
+    <Box
+      flexDirection="column"
+      height={rowBudget}
+      marginTop={1}
+      overflowY="hidden"
+      paddingX={1}
+    >
+      {rows.map((row) => (
+        <CompactRow key={`${row.kind}:${row.sourceIndex}`} row={row} />
+      ))}
+      {hiddenCount > 0 && rows.length < rowBudget ? (
+        <Box height={1} minWidth={0} overflowY="hidden">
+          <Text dimColor wrap="truncate-end">
+            {hiddenRowsText(
+              hiddenCount,
+              pluralize(hiddenCount, 'todo/plan item', 'todo/plan items'),
+            )}
           </Text>
-          {todos.map((todo, i) => (
-            <TodoRow key={i} todo={todo} />
-          ))}
-        </Box>
-      ) : null}
-      {plan ? (
-        <Box flexDirection="column" marginTop={todos.length > 0 ? 1 : 0}>
-          <Text bold dimColor>
-            Plan
-          </Text>
-          <Text dimColor>{planSummaryLine(plan.objective)}</Text>
         </Box>
       ) : null}
     </Box>

--- a/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
+++ b/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
@@ -121,28 +121,19 @@ function toolDisplayViewport(
 // re-rendering every settled tool row in the live region.
 export const ToolUseRow = memo(function ToolUseRow({
   maxRows,
-  neutralStatus,
-  omitHeader,
-  showOutput,
   subagentExecutionLabels,
   toolUse,
   width,
 }: {
   readonly maxRows?: number;
-  readonly neutralStatus?: boolean;
-  readonly omitHeader?: boolean;
-  readonly showOutput?: boolean;
   readonly subagentExecutionLabels?: ExecutionLabels;
   readonly toolUse: NormalizedToolUse;
   readonly width?: number;
 }): React.JSX.Element {
-  const allLines = toolUseStyledLines(toolUse, {
+  const lines = toolUseStyledLines(toolUse, {
     executionLabels: subagentExecutionLabels,
-    neutralStatus,
-    showOutput,
     width,
   });
-  const lines = omitHeader === true ? allLines.slice(1) : allLines;
   const viewport = toolDisplayViewport(lines, maxRows);
   return (
     <Box
@@ -164,7 +155,7 @@ export const ToolUseRow = memo(function ToolUseRow({
             key={index}
             flexDirection="row"
             flexWrap="nowrap"
-            paddingLeft={omitHeader === true || index !== 0 ? 2 : 0}
+            paddingLeft={index === 0 ? 0 : 2}
           >
             {line.spans.map((span, spanIndex) => (
               <Text key={spanIndex} {...toolDisplaySpanTextProps(span)}>

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -125,10 +125,6 @@ export interface DisplayLineOptions {
   /** When false, emit the full output instead of the head+tail slice.
    *  The ctrl+t print path sets this to include everything. */
   readonly elide?: boolean;
-  /** Include raw output for a caller with an explicit result surface. */
-  readonly showOutput?: boolean;
-  /** Render the status marker without active or terminal state color. */
-  readonly neutralStatus?: boolean;
   /** Terminal columns when the projection must match rich rendered rows. */
   readonly width?: number;
   /** Retained subagent identities used by executions wait/view headers. */
@@ -378,8 +374,7 @@ function buildStyledLines(
   const elide = options.elide !== false;
   const patchGroups = toolUsePatchGroups(toolUse);
   const opts = toolRowOptions(toolUse, patchGroups !== undefined);
-  const color =
-    options.neutralStatus === true ? undefined : statusColor(toolUse);
+  const color = statusColor(toolUse);
   const preview = toolHeaderPreview(
     toolUse,
     options.width === undefined
@@ -389,7 +384,7 @@ function buildStyledLines(
     executionSummary,
   );
 
-  const showOutput = options.showOutput === true || opts.showOutput;
+  const showOutput = opts.showOutput;
   const output = showOutput ? outputRows(toolUse, elide) : [];
   const exitCode =
     opts.showExitCode && toolUse.isError ? extractExitCode(toolUse) : undefined;
@@ -472,7 +467,7 @@ export function toolUseStyledLines(
     toolUse.toolName === 'executions' && options.executionLabels
       ? executionsSubagentSummary(toolUse.input, options.executionLabels)
       : undefined;
-  const key = `${options.elide === false ? 'f' : 'e'}|${options.showOutput === true ? 'o' : 'h'}|${options.neutralStatus === true ? 'n' : 's'}|${options.width ?? 'd'}|${executionSummary ?? ''}`;
+  const key = `${options.elide === false ? 'f' : 'e'}|${options.width ?? 'd'}|${executionSummary ?? ''}`;
   let cached = styledLinesCache.get(toolUse);
   const hit = cached?.get(key);
   if (hit) return hit;


### PR DESCRIPTION
Three unreachable paths in the CLI transcript, plus one budget constant that was wrong because it was written twice.

## `ToolUseRow`: three props no caller passes

`omitHeader`, `neutralStatus`, and `showOutput` are declared, threaded into `toolUseStyledLines`, and branched on — by nobody. All three `<ToolUseRow>` call sites (`ConversationPane.tsx`, `TranscriptEntry.tsx` ×2) pass only `maxRows`/`toolUse`/`width`/`subagentExecutionLabels`, no test constructs the component, and no caller of `toolUseStyledLines` or `toolUseDisplayLines` sets `showOutput` or `neutralStatus`. So `allLines.slice(1)`, the neutral status color, the `showOutput` override, and two constant segments of the memo cache key were all dead.

Removing them also narrows that cache key from five segments to three, so entries no longer vary on values that never differ.

One subtlety worth flagging for review: `toolRenderers.tsx` has **two** `showOutput`s. `options.showOutput` is the dead prop; `opts.showOutput` is live per-tool config from `toolRowOptions` that decides whether e.g. a bash row shows output at all. Only the former is gone — `const showOutput = options.showOutput === true || opts.showOutput` becomes `const showOutput = opts.showOutput`.

## `TodosPlanPanel`: an unreachable branch that said so

The panel had a bounded branch and an uncapped one. The uncapped branch's own comment read *"Reached only when maxRows is undefined (the compact branch above owns every bounded case)"* — and the only production caller is `ConversationRegion.tsx:289`, `<TodosPlanPanel maxRows={todosPlanRows} />`, where `allocateConversationBottomPanelRows` declares `todosPlanRows: number`. It was never undefined. Tests import only `compactTodosPlanRows` and `todosPlanPanelRowCount`, never the component.

`maxRows` is now required and the branch is gone, which takes the `Todos`/`Plan` heading rows and their margins with it. `TodoRow`'s `compact` prop follows: the one surviving caller always passed `compact`, so its three conditionals collapse to their compact values.

## `/config`: 4 where the identical shape says 5

`ENUM_CHROME_ROWS = 4` sat beside `LIST_CHROME_ROWS = 5`, but both layouts wrap one `Select` in the same chrome — two `FormFrame` border rows, the title, the `KeyHints` margin, and the hints row. Both even pass `showCloseHint={false}`. The enum picker could therefore size its `Select` one row past its budget.

## Net elements (R6)

- Files: 4 changed (+42 / −95 LoC)
- Exports: 0 exported symbols added or removed
- Constructs removed: `omitHeader`, `neutralStatus`, `showOutput` (ToolUseRow props); uncapped `TodosPlanPanel` branch; `TodoRow.compact` prop; `LIST_CHROME_ROWS`, `ENUM_CHROME_ROWS` constants
- Constructs added: `SELECT_CHROME_ROWS` (unifies the two removed)

## Consumer counts (R8)

n/a — no emit paths or external-consumed exports changed; all removed symbols were internal to their modules.