### PR TITLE
fix(ui): add kind: 'primary' to ExternalInquiryPanel Submit button (#9764)

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -501,6 +501,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
           text: 'Submit answer',
           title: 'Submit the answer from the external model',
           action: INQUIRY_SUBMIT_ACTION,
+          kind: 'primary',
           disabled: !this.hasAnswer,
           onClick: this.handleSubmit,
         })}


### PR DESCRIPTION
## What

Fixes #9764: the ExternalInquiryPanel's 'Submit answer' button lost its accent color when PR #9762 deleted a shared CSS rule. Two of three call sites were updated in that PR (ApproveSplitButton, UserQuestionPanel); this catches the third.

## Change

Add `kind: 'primary'` to the `renderLabeledActionButton` call in `ExternalInquiryPanel.ts:499-506`.

## Verification

- `kind` is an accepted optional parameter on `renderLabeledActionButton` (`ActionButtonKind`)
- Matches the exact pattern already used by `UserQuestionPanel.ts` and `ApproveSplitButton.ts`