### PR TITLE
refactor(schemas): adopt zod v4 native idioms for int and nullish (#9767)

### DIFF
--- a/packages/desktop/src/shared/desktopWorkspaceMessages.ts
+++ b/packages/desktop/src/shared/desktopWorkspaceMessages.ts
@@ -98,8 +98,8 @@ export const DesktopFileErrorMessageSchema = z.object({
 const DesktopTerminalStartMessageSchema = z.object({
   command: z.literal(DESKTOP_WORKSPACE_COMMANDS.TERMINAL_START),
   sessionId: z.string(),
-  cols: z.number().int().positive(),
-  rows: z.number().int().positive(),
+  cols: z.int().positive(),
+  rows: z.int().positive(),
   initialCommand: z.string().min(1).optional(),
 });
 
@@ -112,8 +112,8 @@ const DesktopTerminalInputMessageSchema = z.object({
 const DesktopTerminalResizeMessageSchema = z.object({
   command: z.literal(DESKTOP_WORKSPACE_COMMANDS.TERMINAL_RESIZE),
   sessionId: z.string(),
-  cols: z.number().int().positive(),
-  rows: z.number().int().positive(),
+  cols: z.int().positive(),
+  rows: z.int().positive(),
 });
 
 const DesktopTerminalCloseMessageSchema = z.object({
@@ -130,7 +130,7 @@ export const DesktopTerminalDataMessageSchema = z.object({
 export const DesktopTerminalExitMessageSchema = z.object({
   command: z.literal(DESKTOP_WORKSPACE_COMMANDS.TERMINAL_EXIT),
   sessionId: z.string(),
-  exitCode: z.number().int(),
+  exitCode: z.int(),
 });
 
 export const DesktopTerminalErrorMessageSchema = z.object({

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -140,7 +140,7 @@ export const BackendOwnedFieldsSchema = z.object({
 export const StreamMetadataSchema = BackendOwnedFieldsSchema.extend({
   // Nullable over the wire: an explicit `null` clears a stage the frontend
   // still holds, which a plain omission cannot express.
-  stage: StreamStageSchema.nullable().optional(),
+  stage: StreamStageSchema.nullish(),
   /** Absent while the stream's run identity is still pending. */
   category: AgentCategorySchema.optional(),
 });


### PR DESCRIPTION
## What

Fixes #9767: replace pre-v4 zod patterns with v4 native forms.

## Changes

- `z.number().int()` → `z.int()` (5 sites in `desktopWorkspaceMessages.ts`)
- `.nullable().optional()` → `.nullish()` (1 site in `streamState.ts`)

**Not changed:** `z.coerce.number().int()` in `roundIndexed.ts` — zod v4.4.3's `z.coerce` wrapper only exposes `.number()`, `.string()`, `.boolean()`, `.bigint()`, `.date()`; there is no `z.coerce.int()`.

## Verification

- `npm run typecheck` — clean
- No functional change — each replacement is byte-identical in runtime behavior