### PR TITLE
fix(approval): associate feedback label with textarea via for/id (#9777)

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -97,8 +97,9 @@ export abstract class BaseFeedbackPanel<
     // description of the field with it.
     return html`
       <div class=${containerClass}>
-        <label>${placeholder}</label>
+        <label for="feedback-input">${placeholder}</label>
         <wa-textarea
+          id="feedback-input"
           class=${inputClass}
           placeholder="Optional — this is sent back to the agent"
           rows="3"


### PR DESCRIPTION
## What

Fixes #9777: the feedback textarea's visible `<label>` wasn't associated with the `<wa-textarea>`, and the old `aria-label` was deleted by #9766. No click-to-focus for mouse users, no accessible name for assistive technology.

## Change

Add `id='feedback-input'` to the `<wa-textarea>` and `for='feedback-input'` to the `<label>`, matching the pattern already used in `InstructionPanel.ts:695-699` (`wa-textarea` is form-associated, so `for`/`id` names the inner control).

## Verification

- Shadow DOM IDs are scoped per component instance — no collision risk
- Matches existing in-repo convention for `wa-textarea` label association