### PR TITLE
fix(cli): align ENUM_CHROME_ROWS with LIST_CHROME_ROWS (#9783)

### DIFF
--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -188,7 +188,7 @@ type ConfigFormMode =
     };
 
 const LIST_CHROME_ROWS = 5;
-const ENUM_CHROME_ROWS = 4;
+const ENUM_CHROME_ROWS = 5;
 
 /** Inline text editor for a string/number setting (its own input buffer). */
 function ConfigTextEditor(props: {


### PR DESCRIPTION
## What

Fixes #9783: `ENUM_CHROME_ROWS` was 4 but `LIST_CHROME_ROWS` was 5 — both are used for `Select` components under the same `FormFrame` chrome in the `/config` form. The enum picker's chrome was one row short of budget.

## Change

`ENUM_CHROME_ROWS = 4` → `ENUM_CHROME_ROWS = 5`