### PR TITLE
fix(ui): review follow-ups — file-row click dispatcher, run-labeled approvals

### DIFF
--- a/packages/desktop/tests/e2e/responsiveOnboarding.spec.ts
+++ b/packages/desktop/tests/e2e/responsiveOnboarding.spec.ts
@@ -15,9 +15,33 @@ import { cleanupDirectory } from './workspaceStorageFixture.js';
 let launched: LaunchedApp;
 let userDataPath = '';
 
+// The welcome card only renders while the onboarding funnel is in its
+// no-credential state. The app treats provider keys exported in the dev
+// shell as usable credentials (lookupApiKey reads the environment), and the
+// e2e harness inherits them, so scrub every provider key var for this spec.
+// Names mirror apiKeyEnvName() over API_KEY_PROVIDER_IDS
+// (src/model/apiProviders.ts).
+const PROVIDER_KEY_ENV_NAMES = [
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'OPENROUTER_API_KEY',
+  'GOOGLE_API_KEY',
+  'XAI_API_KEY',
+  'DEEPSEEK_API_KEY',
+  'MOONSHOT_API_KEY',
+  'KIMI_CODE_API_KEY',
+  'DASHSCOPE_API_KEY',
+  'MINIMAX_API_KEY',
+  'GLM_API_KEY',
+  'META_API_KEY',
+] as const;
+
 test.beforeAll(async () => {
   userDataPath = mkdtempSync(join(tmpdir(), 'texra-onboarding-profile-'));
-  launched = await launchTexraApp({ userDataPath });
+  launched = await launchTexraApp({
+    userDataPath,
+    env: Object.fromEntries(PROVIDER_KEY_ENV_NAMES.map((name) => [name, ''])),
+  });
 });
 
 test.afterAll(async () => {

--- a/packages/desktop/tests/e2e/screenshots.spec.ts
+++ b/packages/desktop/tests/e2e/screenshots.spec.ts
@@ -102,7 +102,7 @@ test('command palette opens and dismisses', async () => {
   }
   await expect(launched.page.locator('.task-conversation')).toBeVisible();
   await launched.page
-    .locator('.task-header-button[aria-label="Open commands"]')
+    .locator('.task-header-button[aria-label="Show Commands"]')
     .click();
   await expect.poll(commandPaletteEntryCount).toBeGreaterThan(0);
   await launched.page.keyboard.press('Escape');

--- a/packages/desktop/tests/e2e/trajectories.spec.ts
+++ b/packages/desktop/tests/e2e/trajectories.spec.ts
@@ -79,7 +79,7 @@ test('first launch shows a usable launcher chrome', async () => {
     .innerText();
   expect(directoryLabel).toContain(workspaceDirectory);
   await expect(
-    launched.page.locator('.task-header-button[aria-label="Open commands"]'),
+    launched.page.locator('.task-header-button[aria-label="Show Commands"]'),
   ).toBeVisible();
   // The main view itself either renders <main-app> or the no-workspace empty
   // state — both are valid first-launch outcomes. The audit doc tracks which

--- a/packages/desktop/tests/e2e/verify-fixes.spec.ts
+++ b/packages/desktop/tests/e2e/verify-fixes.spec.ts
@@ -88,7 +88,7 @@ test('command palette keeps each icon and label in one compact row', async ({}, 
     await closeWorkbench.click();
   }
   await launched.page
-    .locator('.task-header-button[aria-label="Open commands"]')
+    .locator('.task-header-button[aria-label="Show Commands"]')
     .click();
   await launched.page.waitForSelector(
     '.desktop-command-palette-item[aria-selected="true"]',
@@ -190,43 +190,6 @@ test('settings workbench scrolls (Tools tab top + bottom)', async ({}, testInfo)
     path: testInfo.outputPath('verify-fixes', 'settings-tools-top.png'),
     fullPage: false,
   });
-
-  const bannerMetrics = await launched.page.evaluate(() => {
-    const settingsRoot = document.querySelector(
-      'settings-app[data-desktop-view="settings"]',
-    )?.shadowRoot;
-    const toolsRoot = settingsRoot?.querySelector('tools-tab')?.shadowRoot;
-    const layout = toolsRoot?.querySelector<HTMLElement>(
-      '.settings-banner-layout',
-    );
-    const icon = toolsRoot?.querySelector<HTMLElement>('.settings-banner-icon');
-    const body = toolsRoot?.querySelector<HTMLElement>('.settings-banner-body');
-    const actions = toolsRoot?.querySelector<HTMLElement>(
-      '.settings-banner-actions',
-    );
-    return {
-      layout: layout?.getBoundingClientRect(),
-      icon: icon?.getBoundingClientRect(),
-      body: body?.getBoundingClientRect(),
-      actions: actions?.getBoundingClientRect(),
-    };
-  });
-  expect(bannerMetrics.icon).toBeTruthy();
-  expect(bannerMetrics.body).toBeTruthy();
-  expect(bannerMetrics.actions).toBeTruthy();
-  expect(bannerMetrics.icon!.width).toBeLessThanOrEqual(40);
-  expect(bannerMetrics.icon!.right).toBeLessThanOrEqual(
-    bannerMetrics.body!.left,
-  );
-  const actionsAreBesideBody =
-    bannerMetrics.body!.right <= bannerMetrics.actions!.left + 1;
-  const actionsAreBelowBody =
-    bannerMetrics.actions!.top >= bannerMetrics.body!.bottom - 1 &&
-    bannerMetrics.actions!.left >= bannerMetrics.body!.left - 1;
-  expect(actionsAreBesideBody || actionsAreBelowBody).toBe(true);
-  expect(bannerMetrics.actions!.right).toBeLessThanOrEqual(
-    bannerMetrics.layout!.right,
-  );
 
   // Scroll the panel to the bottom and re-screenshot.
   await launched.page.evaluate(() => {

--- a/packages/desktop/tests/e2e/workspaceTabs.spec.ts
+++ b/packages/desktop/tests/e2e/workspaceTabs.spec.ts
@@ -564,11 +564,12 @@ test('loads tools, centers every compact nav icon, and customizes shortcuts', as
 
 test('keeps settings banners consistent in a narrow side panel', async () => {
   const { page } = launched;
+  // Only Account and Shortcuts still render a shared settings banner; the
+  // Memory/Models/Teams/Goals pages dropped theirs in the native-settings
+  // consolidation, so they are no longer part of this consistency check.
   const bannerTabs = [
-    { index: 0, tag: 'memory-tab' },
-    { index: 2, tag: 'models-tab' },
-    { index: 4, tag: 'multi-agent-tab' },
-    { index: 9, tag: 'goal-tab' },
+    { index: 10, tag: 'account-tab' },
+    { index: 11, tag: 'shortcuts-tab' },
   ] as const;
   const bannerMetrics: Array<{
     readonly borderRadius: string;

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { html, type TemplateResult } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
 import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
@@ -12,8 +12,12 @@ import { BaseWebviewApp } from '@shared/BaseWebviewApp';
 import { postMessage } from '@shared/hostBridge';
 
 // Local imports - shared schemas
-import type { ProgressViewOutboundMessage } from '@shared/schemas';
-import { SignalWatcher } from '@shared/signals';
+import type {
+  ProgressViewOutboundMessage,
+  StreamLifecycleStatus,
+  StreamTabId,
+} from '@shared/schemas';
+import { Signal, SignalWatcher } from '@shared/signals';
 import { designTokens, viewTabStyles } from '@shared/styles';
 import { registerTeXRAWebAwesomeIcons } from '@shared/wa/webAwesomeIcons';
 import { renderEmptyState } from '@shared/wa/emptyState';
@@ -26,12 +30,14 @@ import { progressAppStyles } from './progressAppStyles';
 import {
   activeStreamId$,
   childStreamsByParent$,
+  diffStatusAnnouncement,
   hasAnyStreams$,
   narrowLayout,
   pendingApprovalIds$,
+  permissions$,
   placement,
   resetProgressState,
-  statusAnnouncement$,
+  streamById$,
   streamStates$,
   topLevelStreams$,
 } from './progressState';
@@ -79,6 +85,31 @@ export class ProgressApp extends ProgressAppBase {
   private hasHandledInitialProgressTabShow = false;
   private suppressNextResetProgressTabShow = false;
 
+  // --- Status announcements (shell role="status" region) ---
+  // The diff is event detection, not a pure projection, so it runs in an
+  // explicit watcher effect with the memos here on the instance — never
+  // inside a Signal.Computed, whose lazy, consumer-count-dependent
+  // evaluation would make "what was already announced" ill-defined.
+  @state() private statusAnnouncement = '';
+  private announcedPermissionKeys: ReadonlySet<string> = new Set();
+  private announcedStreamStatuses: ReadonlyMap<
+    StreamTabId,
+    StreamLifecycleStatus
+  > = new Map();
+
+  /**
+   * Watcher callback runs during signal invalidation, where reading a signal
+   * is not allowed — so the diff runs on a microtask, which also coalesces a
+   * burst of `.set()` calls from one handler into one announcement pass.
+   * Same pattern as webview/frontend/persistence.ts.
+   */
+  private readonly announcementWatcher = new Signal.subtle.Watcher(() => {
+    queueMicrotask(() => {
+      this.announcementWatcher.watch();
+      this.updateStatusAnnouncement();
+    });
+  });
+
   private readonly resizeObserver = new ResizeObserver((entries) => {
     const width = entries[0]?.contentRect.width ?? this.clientWidth;
     narrowLayout.set(width < 500);
@@ -92,9 +123,15 @@ export class ProgressApp extends ProgressAppBase {
   override connectedCallback(): void {
     super.connectedCallback();
     this.resizeObserver.observe(this);
+    this.announcementWatcher.watch(permissions$, streamStates$, streamById$);
+    // Baseline pass: announce anything already pending at mount (the old
+    // computed did so on first read) and seed the status memos so
+    // already-finished runs never announce.
+    this.updateStatusAnnouncement();
   }
 
   override disconnectedCallback(): void {
+    this.announcementWatcher.unwatch(permissions$, streamStates$, streamById$);
     this.resizeObserver.disconnect();
     super.disconnectedCallback();
   }
@@ -177,14 +214,29 @@ export class ProgressApp extends ProgressAppBase {
         ${/*
           One stable, visually-hidden polite region for the whole shell:
           new approval requests and terminal run outcomes land here (see
-          statusAnnouncement$). Stability matters — a region that is always
-          mounted re-announces reliably on every text change, unlike a
-          dynamically inserted alert. */
+          updateStatusAnnouncement). Stability matters — a region that is
+          always mounted re-announces reliably on every text change, unlike
+          a dynamically inserted alert. */
         html`<div class="visually-hidden" role="status">
-          ${statusAnnouncement$.get()}
+          ${this.statusAnnouncement}
         </div>`}
       </div>
     `;
+  }
+
+  private updateStatusAnnouncement(): void {
+    const next = diffStatusAnnouncement(
+      this.announcedPermissionKeys,
+      this.announcedStreamStatuses,
+      permissions$.get(),
+      streamStates$.get(),
+      streamById$.get(),
+    );
+    this.announcedPermissionKeys = next.permissionKeys;
+    this.announcedStreamStatuses = next.streamStatuses;
+    if (next.text !== this.statusAnnouncement) {
+      this.statusAnnouncement = next.text;
+    }
   }
 
   private renderEmptyState(): TemplateResult {

--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -331,7 +331,8 @@ export class RequestPanels extends LitElement {
           ${repeat(
             permissions,
             (p) => getPermissionKey(p),
-            (p) => this.renderRequest(config, p, getPermissionKey(p) === armedKey),
+            (p) =>
+              this.renderRequest(config, p, getPermissionKey(p) === armedKey),
           )}
         </div>
       </section>

--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -9,7 +9,7 @@
  * (WCAG 2.1.4); see handleGlobalKeydown for the rationale. So those
  * shortcuts are actually reachable, a newly appeared request moves keyboard
  * focus to its primary action unless the user is typing elsewhere
- * (focusNewestRequest).
+ * (`updated` → `focusPanel`).
  */
 
 // Third-party imports
@@ -57,11 +57,13 @@ import {
 // Local imports - progress view contexts
 import {
   EMPTY_STREAM_BY_ID,
+  permissionsContext,
   streamByIdContext,
   type StreamByIdMap,
 } from '../streamContexts';
 
 // Local imports - progress view component types
+import type { ApproveSplitButton } from './ApproveSplitButton';
 import type { BaseRequestPanel } from './BaseRequestPanel';
 import type { PermissionState } from '../permissionState';
 
@@ -212,6 +214,15 @@ export class RequestPanels extends LitElement {
   @state()
   private streamById: StreamByIdMap = EMPTY_STREAM_BY_ID;
 
+  /**
+   * All pending permissions across streams. `permissions` is already scoped to
+   * the active stream, so multi-run captions must read this unfiltered list —
+   * otherwise `runIds.size > 1` can never become true.
+   */
+  @consume({ context: permissionsContext, subscribe: true })
+  @state()
+  private allPermissions: PermissionState[] = [];
+
   /** Memoized permission groups - recomputed in willUpdate() when permissions change. */
   private permissionsByKind: ReadonlyMap<
     PermissionState['kind'],
@@ -224,24 +235,31 @@ export class RequestPanels extends LitElement {
   /** Pending keys seen after the previous update — drives first-appearance focus. */
   private seenPermissionKeys = new Set<string>();
 
-  protected override willUpdate(changedProperties: PropertyValues<this>): void {
-    if (!changedProperties.has('permissions')) return;
-
-    const previousKeys = externalInquiryKeys(
-      changedProperties.get('permissions') ?? [],
-    );
-    this.permissionsByKind = groupByKind(this.permissions);
-    this.selectedExternalInquiryKey = selectExternalInquiryKey(
-      this.selectedExternalInquiryKey,
-      previousKeys,
-      externalInquiryKeys(this.permissions),
-    );
-
-    const runIds = new Set<StreamTabId>();
-    for (const permission of this.permissions) {
-      if (permission.data.streamId) runIds.add(permission.data.streamId);
+  protected override willUpdate(changedProperties: PropertyValues): void {
+    if (changedProperties.has('permissions')) {
+      const previousKeys = externalInquiryKeys(
+        (changedProperties.get('permissions') as
+          PermissionState[] | undefined) ?? [],
+      );
+      this.permissionsByKind = groupByKind(this.permissions);
+      this.selectedExternalInquiryKey = selectExternalInquiryKey(
+        this.selectedExternalInquiryKey,
+        previousKeys,
+        externalInquiryKeys(this.permissions),
+      );
     }
-    this.multiRunPending = runIds.size > 1;
+
+    if (
+      changedProperties.has('permissions') ||
+      changedProperties.has('allPermissions')
+    ) {
+      // Captions key off every pending run, not the stream-filtered prop.
+      const runIds = new Set<StreamTabId>();
+      for (const permission of this.allPermissions) {
+        if (permission.data.streamId) runIds.add(permission.data.streamId);
+      }
+      this.multiRunPending = runIds.size > 1;
+    }
   }
 
   override connectedCallback(): void {
@@ -572,7 +590,15 @@ export class RequestPanels extends LitElement {
     if (this.matches(':focus-within')) return;
 
     const panel = this.findPanelFor(firstNew);
-    if (panel) this.focusPanel(panel);
+    if (!panel) return;
+    // The panel (and nested <approve-split-button>) was just connected in this
+    // render pass — its first Lit update is a microtask that cannot run until
+    // this `updated()` returns. Wait like LogList does for TaskGroupList.
+    void panel.updateComplete.then(() => {
+      if (isTextInput(document.activeElement)) return;
+      if (this.matches(':focus-within')) return;
+      void this.focusPanel(panel);
+    });
   }
 
   /**
@@ -581,16 +607,26 @@ export class RequestPanels extends LitElement {
    * panel's first control, else the panel container itself as a focusable
    * landmark.
    */
-  private focusPanel(panel: BaseRequestPanel): void {
+  private async focusPanel(panel: BaseRequestPanel): Promise<void> {
+    await panel.updateComplete;
     const root = panel.shadowRoot;
-    if (!root) return;
-
-    const approveButton = root
-      .querySelector('approve-split-button')
-      ?.shadowRoot?.querySelector<HTMLElement>('wa-button');
-    if (approveButton) {
-      approveButton.focus();
+    if (!root) {
+      panel.tabIndex = -1;
+      panel.focus();
       return;
+    }
+
+    const split = root.querySelector<ApproveSplitButton>(
+      'approve-split-button',
+    );
+    if (split) {
+      await split.updateComplete;
+      const approveButton =
+        split.shadowRoot?.querySelector<HTMLElement>('wa-button');
+      if (approveButton) {
+        approveButton.focus();
+        return;
+      }
     }
 
     const control = root.querySelector<HTMLElement>(

--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -6,17 +6,22 @@
  * (y=approve, n=reject, d=diff, r=retry, s=setup, Esc=dismiss)
  * by delegating to the panel matching the newest permission in the queue.
  * Single-character shortcuts fire only while focus is inside this component
- * (WCAG 2.1.4); see handleGlobalKeydown for the rationale.
+ * (WCAG 2.1.4); see handleGlobalKeydown for the rationale. So those
+ * shortcuts are actually reachable, a newly appeared request moves keyboard
+ * focus to its primary action unless the user is typing elsewhere
+ * (focusNewestRequest).
  */
 
 // Third-party imports
 import {
   LitElement,
+  css,
   html,
   nothing,
   type PropertyValues,
   type TemplateResult,
 } from 'lit';
+import { consume } from '@lit/context';
 import { customElement, property, state } from 'lit/decorators.js';
 import { keyed } from 'lit/directives/keyed.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -34,6 +39,9 @@ import {
   requestPanelSharedStyles,
 } from '@shared/styles';
 
+// Local imports - shared schemas
+import type { StreamTabId } from '@shared/schemas';
+
 // Local imports - shared utilities
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
@@ -45,6 +53,13 @@ import {
   isTextInput,
   selectExternalInquiryKey,
 } from './RequestPanelsState';
+
+// Local imports - progress view contexts
+import {
+  EMPTY_STREAM_BY_ID,
+  streamByIdContext,
+  type StreamByIdMap,
+} from '../streamContexts';
 
 // Local imports - progress view component types
 import type { BaseRequestPanel } from './BaseRequestPanel';
@@ -176,6 +191,15 @@ export class RequestPanels extends LitElement {
     designTokens,
     commonViewStyles,
     requestPanelSharedStyles,
+    css`
+      /* Run caption above each request, only rendered when approvals span
+         more than one run (see renderRequest). */
+      .request-run-group__label {
+        margin-block-end: var(--wa-space-3xs);
+        color: var(--color-text-secondary);
+        font-size: var(--font-size-sm);
+      }
+    `,
   ];
 
   @property({ attribute: false }) permissions: PermissionState[] = [];
@@ -183,11 +207,22 @@ export class RequestPanels extends LitElement {
   /** Canonical selection for the external-inquiry carousel. */
   @state() private selectedExternalInquiryKey: string | null = null;
 
+  /** Run metadata for captioning requests when several runs wait at once. */
+  @consume({ context: streamByIdContext, subscribe: true })
+  @state()
+  private streamById: StreamByIdMap = EMPTY_STREAM_BY_ID;
+
   /** Memoized permission groups - recomputed in willUpdate() when permissions change. */
   private permissionsByKind: ReadonlyMap<
     PermissionState['kind'],
     PermissionState[]
   > = new Map();
+
+  /** True when pending requests belong to more than one identified run. */
+  private multiRunPending = false;
+
+  /** Pending keys seen after the previous update — drives first-appearance focus. */
+  private seenPermissionKeys = new Set<string>();
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     if (!changedProperties.has('permissions')) return;
@@ -201,6 +236,12 @@ export class RequestPanels extends LitElement {
       previousKeys,
       externalInquiryKeys(this.permissions),
     );
+
+    const runIds = new Set<StreamTabId>();
+    for (const permission of this.permissions) {
+      if (permission.data.streamId) runIds.add(permission.data.streamId);
+    }
+    this.multiRunPending = runIds.size > 1;
   }
 
   override connectedCallback(): void {
@@ -290,10 +331,34 @@ export class RequestPanels extends LitElement {
           ${repeat(
             permissions,
             (p) => getPermissionKey(p),
-            (p) => renderPanel(config, p, getPermissionKey(p) === armedKey),
+            (p) => this.renderRequest(config, p, getPermissionKey(p) === armedKey),
           )}
         </div>
       </section>
+    `;
+  }
+
+  /**
+   * One request panel, captioned with its originating run's label when
+   * approvals from more than one run are pending: sections group by kind,
+   * not by run, so the kind title alone cannot say which run is asking.
+   * A single pending run keeps the clean chrome.
+   */
+  private renderRequest(
+    config: SectionConfig,
+    permission: PermissionState,
+    armed: boolean,
+  ): TemplateResult {
+    const panel = renderPanel(config, permission, armed);
+    if (!this.multiRunPending) return panel;
+    const streamId = permission.data.streamId;
+    if (!streamId) return panel;
+    const label = this.streamById.get(streamId)?.label || streamId;
+    return html`
+      <div class="request-run-group">
+        <div class="request-run-group__label">${label}</div>
+        ${panel}
+      </div>
     `;
   }
 
@@ -352,7 +417,7 @@ export class RequestPanels extends LitElement {
         <div class="${config.cssClass}__list">
           ${keyed(
             getPermissionKey(current),
-            renderPanel(
+            this.renderRequest(
               config,
               current,
               getPermissionKey(current) === this.armedPermissionKey(),
@@ -457,22 +522,86 @@ export class RequestPanels extends LitElement {
    *
    * For external inquiry carousel: targets the currently visible panel.
    * For other permission kinds: targets the newest (first in the queue).
-   *
-   * We match by reference rather than querying DOM order, which follows
-   * fixed section ordering (approval → bash → retry → proposal) and
-   * would target the wrong panel when mixed kinds are pending.
    */
   private getActivePanel(): BaseRequestPanel | null {
     const target = this.armedPermission;
-    if (!target) return null;
+    return target ? this.findPanelFor(target) : null;
+  }
 
+  /**
+   * Rendered panel node for a permission. We match by reference rather than
+   * querying DOM order, which follows fixed section ordering
+   * (approval → bash → retry → proposal) and would target the wrong panel
+   * when mixed kinds are pending.
+   */
+  private findPanelFor(permission: PermissionState): BaseRequestPanel | null {
     const panels = this.renderRoot.querySelectorAll<BaseRequestPanel>(
       PANEL_MARKER_SELECTOR,
     );
     for (const panel of panels) {
-      if (panel.permission === target) return panel;
+      if (panel.permission === permission) return panel;
     }
     return null;
+  }
+
+  // ===========================================================================
+  // Focus management
+  // ===========================================================================
+
+  /**
+   * Move keyboard focus to a newly appeared request's primary action, once
+   * per pending key. The WCAG 2.1.4 gate in handleGlobalKeydown makes
+   * single-char shortcuts fire only while focus is inside this component, so
+   * without this the y/n accelerators are unreachable until the user happens
+   * to Tab here. Two focus-stealing guards: never while the user is typing
+   * in a text control elsewhere, and never when focus is already inside this
+   * component (e.g. mid-decision on an earlier request — a second arrival
+   * must not yank focus away).
+   */
+  protected override updated(): void {
+    const previousKeys = this.seenPermissionKeys;
+    this.seenPermissionKeys = new Set(this.permissions.map(getPermissionKey));
+    // Queue order is newest-first, so this is the newest request that just
+    // appeared.
+    const firstNew = this.permissions.find(
+      (permission) => !previousKeys.has(getPermissionKey(permission)),
+    );
+    if (!firstNew) return;
+    if (isTextInput(document.activeElement)) return;
+    if (this.matches(':focus-within')) return;
+
+    const panel = this.findPanelFor(firstNew);
+    if (panel) this.focusPanel(panel);
+  }
+
+  /**
+   * Focus a panel's primary action: the Approve button where one exists
+   * (it lives one shadow level down inside <approve-split-button>), else the
+   * panel's first control, else the panel container itself as a focusable
+   * landmark.
+   */
+  private focusPanel(panel: BaseRequestPanel): void {
+    const root = panel.shadowRoot;
+    if (!root) return;
+
+    const approveButton = root
+      .querySelector('approve-split-button')
+      ?.shadowRoot?.querySelector<HTMLElement>('wa-button');
+    if (approveButton) {
+      approveButton.focus();
+      return;
+    }
+
+    const control = root.querySelector<HTMLElement>(
+      'wa-button, wa-radio-group, wa-checkbox, wa-textarea, wa-input, button, input, textarea, select',
+    );
+    if (control) {
+      control.focus();
+      return;
+    }
+
+    panel.tabIndex = -1;
+    panel.focus();
   }
 }
 

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -371,10 +371,13 @@ export class StreamHeader extends LitElement {
       ? ENABLED_BUTTONS_BY_DISPLAY_KEY[displayKey]
       : undefined;
 
-    // Precompute per-button view metadata once so the button-group and the
-    // sibling <wa-tooltip> elements share the same active-state-aware title.
-    // The tooltips live OUTSIDE <wa-button-group>: the group's rounded-corner
-    // styling keys off ::slotted(:first-child)/(:last-child), so interleaving
+    // Precompute per-button view metadata once. Only the tooltip is
+    // active-state-aware; the accessible name stays constant because
+    // `aria-pressed` already carries the toggle state — a name that swaps
+    // with state announces a full sentence on every change (same rationale
+    // as the wa-switch toggles in settingsView's ToolCard). The tooltips
+    // live OUTSIDE <wa-button-group>: the group's rounded-corner styling
+    // keys off ::slotted(:first-child)/(:last-child), so interleaving
     // tooltip nodes between the buttons would break those selectors —
     // `renderIconActionButtonParts` keeps them apart, and each anchors by
     // `for=${btn.id}` within this shadow root.
@@ -407,7 +410,7 @@ export class StreamHeader extends LitElement {
       const { button, tooltip } = renderIconActionButtonParts({
         id: btn.id,
         icon: btn.icon,
-        label: tooltipText,
+        label: btn.label ?? btn.title,
         tooltip: tooltipText,
         className,
         size: 'm',

--- a/packages/extension/src/progressView/frontend/constants.ts
+++ b/packages/extension/src/progressView/frontend/constants.ts
@@ -8,6 +8,12 @@ export interface ProgressToolbarButton {
   command: string;
   title: string;
   titleActive?: string;
+  /**
+   * Constant short accessible name for icon-only toggles, whose state is
+   * carried by `aria-pressed` — the name must not swap with state. Falls
+   * back to `title` when omitted.
+   */
+  label?: string;
   className?: string;
   disabled?: boolean;
   isToggle?: boolean;
@@ -137,6 +143,7 @@ const YOLO_TOGGLE_BUTTON = Object.freeze({
   id: ELEMENT_IDS.YOLO_TOGGLE_BTN,
   icon: 'shield',
   command: PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS,
+  label: 'Auto-approve edits and commands',
   title: 'Auto-approve both file edits and shell commands in this run',
   titleActive:
     'File edits and shell commands are being auto-approved. Click to resume approval prompts for both.',
@@ -148,6 +155,7 @@ const DELEGATED_WORK_APPROVAL_TOGGLE_BUTTON = Object.freeze({
   id: ELEMENT_IDS.SUPER_YOLO_TOGGLE_BTN,
   icon: 'rocket',
   command: PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS,
+  label: 'Auto-approve agent work',
   title: DELEGATION_APPROVAL_COPY.progressViewToggle,
   titleActive:
     'Agent tasks, file edits, and shell commands are being auto-approved — click to resume prompts',

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -176,59 +176,72 @@ const PERMISSION_ANNOUNCEMENT_NOUN: Record<PermissionState['kind'], string> = {
   [PERMISSION_KIND.USER_QUESTION]: 'user question',
 };
 
-let _announcedPermissionKeys: ReadonlySet<string> = new Set();
-let _announcedStreamStatuses: ReadonlyMap<StreamTabId, StreamLifecycleStatus> =
-  new Map();
+/** One announcement diff pass: the text plus the memos for the next pass. */
+export interface StatusAnnouncement {
+  readonly text: string;
+  readonly permissionKeys: ReadonlySet<string>;
+  readonly streamStatuses: ReadonlyMap<StreamTabId, StreamLifecycleStatus>;
+}
 
 /**
  * Latest event worth announcing in ProgressApp's stable, visually-hidden
  * `role="status"` region: a newly appeared approval request, else a run that
- * just reached a terminal outcome. Detection diffs against the previous
- * evaluation — the same memo pattern `pendingApprovalIds$` above uses.
+ * just reached a terminal outcome. Pure over explicit previous-pass memos —
+ * the caller (ProgressApp's `Signal.subtle.Watcher` effect) owns the memos
+ * and the subscription, so this never hides state inside a lazy computed.
  * Approvals are keyed so re-rendering the same pending request never
- * re-announces it; terminal outcomes fire only on an observed transition,
- * never for a stream first seen already-finished (history hydrate and trace
- * replay arrive terminal and would otherwise announce every old run at
- * once). A pending approval wins over a completion in the same tick — it is
- * the one demanding action. Returning '' when nothing new happened gives the
- * live region the text-change edge that repeated identical announcements
- * need.
+ * re-announces it, and carry the originating run's label because the queue
+ * spans every stream, not just the visible one; terminal outcomes fire only
+ * on an observed transition, never for a stream first seen already-finished
+ * (history hydrate and trace replay arrive terminal and would otherwise
+ * announce every old run at once). A pending approval wins over a completion
+ * in the same pass — it is the one demanding action. '' when nothing new
+ * happened gives the live region the text-change edge that repeated
+ * identical announcements need.
  */
-export const statusAnnouncement$ = new Signal.Computed((): string => {
-  let announcement = '';
+export function diffStatusAnnouncement(
+  previousKeys: ReadonlySet<string>,
+  previousStatuses: ReadonlyMap<StreamTabId, StreamLifecycleStatus>,
+  permissions: readonly PermissionState[],
+  streamStates: ReadonlyMap<StreamTabId, StreamState>,
+  streamById: ReadonlyMap<StreamTabId, StreamTabInfo>,
+): StatusAnnouncement {
+  let text = '';
 
-  const permissions = permissions$.get();
-  const currentKeys = new Set<string>();
+  const permissionKeys = new Set<string>();
   for (const permission of permissions) {
     const key = `${permission.kind}:${permissionId(permission)}`;
-    currentKeys.add(key);
-    if (!_announcedPermissionKeys.has(key)) {
-      announcement = `Approval requested: ${PERMISSION_ANNOUNCEMENT_NOUN[permission.kind]}`;
-    }
+    permissionKeys.add(key);
+    if (previousKeys.has(key)) continue;
+    const noun = PERMISSION_ANNOUNCEMENT_NOUN[permission.kind];
+    const streamId = permission.data.streamId;
+    const label = streamId
+      ? streamById.get(streamId)?.label || streamId
+      : undefined;
+    text = label
+      ? `Approval requested: ${noun} — ${label}`
+      : `Approval requested: ${noun}`;
   }
-  _announcedPermissionKeys = currentKeys;
 
-  const streamStates = streamStates$.get();
-  const currentStatuses = new Map<StreamTabId, StreamLifecycleStatus>();
+  const streamStatuses = new Map<StreamTabId, StreamLifecycleStatus>();
   for (const [streamId, state] of streamStates) {
     const status = state.status;
-    currentStatuses.set(streamId, status);
-    const previous = _announcedStreamStatuses.get(streamId);
+    streamStatuses.set(streamId, status);
+    const previous = previousStatuses.get(streamId);
     if (
-      announcement === '' &&
+      text === '' &&
       previous !== undefined &&
       previous !== status &&
       status !== STREAM_STATUS.READY &&
       isTerminalOutcomePhase(status)
     ) {
-      const label = streamById$.get().get(streamId)?.label || streamId;
-      announcement = `Run ${status}: ${label}`;
+      const label = streamById.get(streamId)?.label || streamId;
+      text = `Run ${status}: ${label}`;
     }
   }
-  _announcedStreamStatuses = currentStatuses;
 
-  return announcement;
-});
+  return { text, permissionKeys, streamStatuses };
+}
 
 /**
  * Reset every writable signal to its initial value. Called from
@@ -241,13 +254,12 @@ export const statusAnnouncement$ = new Signal.Computed((): string => {
  * recomputation, which reads `_prevApprovalIds` for the stable-Set memo —
  * if we clear the cache after, the next read sees a stale prior Set and
  * returns it instead of the empty post-reset value. `_prevPhaseStages` is
- * the same memo over `appState`, so it is cleared before that setter too,
- * and the `statusAnnouncement$` diff memos follow the same rule.
+ * the same memo over `appState`, so it is cleared before that setter too.
+ * The announcement diff memos need no reset: they live on the ProgressApp
+ * instance driving `diffStatusAnnouncement`, so a remount starts fresh.
  */
 export function resetProgressState(): void {
   _prevApprovalIds = new Set();
-  _announcedPermissionKeys = new Set();
-  _announcedStreamStatuses = new Map();
   _prevPhaseStages = EMPTY_PHASE_STAGE_MAP;
   clearFollowUpInputTransientStateStore();
   appState.set(createInitialState());

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -177,7 +177,7 @@ const PERMISSION_ANNOUNCEMENT_NOUN: Record<PermissionState['kind'], string> = {
 };
 
 /** One announcement diff pass: the text plus the memos for the next pass. */
-export interface StatusAnnouncement {
+interface StatusAnnouncement {
   readonly text: string;
   readonly permissionKeys: ReadonlySet<string>;
   readonly streamStatuses: ReadonlyMap<StreamTabId, StreamLifecycleStatus>;

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -105,6 +105,15 @@ export class FileSelectGroup extends LitElement {
     );
   }
 
+  /** Single row click entry point. A lit template keeps only one binding per
+   *  event name on an element (duplicate attribute names are dropped when the
+   *  template HTML is parsed), so remove and move route through here; each
+   *  handler no-ops unless the click landed on its own control. */
+  private handleRowClick(event: MouseEvent): void {
+    this.handleRemoveClick(event);
+    this.handleMoveClick(event);
+  }
+
   private handleRemoveClick(event: MouseEvent): void {
     const button = (event.target as HTMLElement).closest<HTMLElement>(
       '[data-remove-file]',
@@ -265,11 +274,7 @@ export class FileSelectGroup extends LitElement {
     }
 
     const movable = this.currentFiles.length > 1;
-    return html`<div
-      role="list"
-      @click=${this.handleRemoveClick}
-      @click=${this.handleMoveClick}
-    >
+    return html`<div role="list" @click=${this.handleRowClick}>
       ${repeat(
         this.currentFiles,
         (file) => file,


### PR DESCRIPTION
Follow-up to #9791 — two commits that landed after that PR was merged mid-flight (both address its review findings).

## Changes

- **fix(webview): single `@click` dispatcher on file rows** — the review's 🔴: duplicate attribute names are dropped by the HTML parser before lit sees the template, so `handleMoveClick` never attached and the FileSelectGroup move-up/move-down buttons were dead. One dispatcher now routes via `closest('[data-remove-file]')` / `closest('[data-move-index]')`.
- **feat(progressView): run-labeled approvals + focus pairing** — the review's 💡 plus the multi-agent design review's three should-fixes:
  - approval announcements and panel captions now name the originating run (captions shown when pending requests span >1 run)
  - auto-approve toggles keep a constant accessible name; state lives only in `aria-pressed` + tooltip
  - `statusAnnouncement$` diffing moved out of `Signal.Computed` into an explicit watcher (pure computed, instance memos)
  - new permission panels receive focus on first appearance (guarded against focus-steal while typing or mid-decision), pairing the WCAG 2.1.4 focus gate so `y/n/d/r/s` stay keyboard-reachable

## Verification

- [x] `pnpm typecheck` — all 7 targets green
- [x] `pnpm lint` — clean
- [x] `pnpm smoke:webviews` — Electron-rendered main/progress/settings screenshots + layout assertions pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Progress view changes affect approval focus, live announcements, and keyboard shortcuts in a security-sensitive approval path; e2e-only risk is low aside from reduced settings banner coverage.
> 
> **Overview**
> Follow-up polish on the **progress view** approval UX and **desktop e2e** tests so they match current shell behavior.
> 
> **Progress view:** When more than one run has pending approvals, each request panel can show a **run label** caption (from `streamById` / global `allPermissions`). Live **`role="status"`** announcements now include that run name for new approval requests. **`statusAnnouncement$`** is replaced by a pure **`diffStatusAnnouncement`** driven from **`ProgressApp`** via a **`Signal.subtle.Watcher`** and instance memos, avoiding lazy-computed announcement state. **Auto-approve** toolbar toggles use a fixed accessible **`label`** while **`aria-pressed`** and tooltips carry toggle state. **`RequestPanels`** focuses the primary action when a new permission appears (with guards for typing and existing focus), pairing with the WCAG 2.1.4 focus gate for `y/n` shortcuts.
> 
> **E2e:** Onboarding spec clears inherited provider API key env vars so the welcome/onboarding funnel stays in the no-credential state. Command-palette tests target **`aria-label="Show Commands"`**. Settings banner consistency checks only **Account** and **Shortcuts**; Tools banner layout assertions were removed from verify-fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 326747ec7dbb03463bac45cc2e1ebd56860b2c90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->