### PR TITLE
refactor(cli): use BorderedPanel in onboarding and login picker

### DIFF
--- a/packages/cli/src/commands/loginProviderPicker.tsx
+++ b/packages/cli/src/commands/loginProviderPicker.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useApp } from 'ink';
 import { DEFAULT_OAUTH_PROVIDER, type OAuthProvider } from '@auth/config';
 
 import { renderCliPrompt } from '@cli/tui/renderCliPrompt';
+import { BorderedPanel } from '@cli/tui/ui/BorderedPanel';
 import { KeyHints } from '@cli/tui/ui/KeyHints';
 import { Select, type SelectItem } from '@cli/tui/ui/Select';
 import { COLOR_HINT } from '@cli/tui/ui/colors';
@@ -32,15 +33,23 @@ function LoginProviderPicker(props: {
   };
 
   return (
-    <Box
-      borderStyle="round"
-      borderColor={COLOR_HINT}
-      flexDirection="column"
-      paddingX={1}
+    <BorderedPanel
+      color={COLOR_HINT}
+      title="TeXRA login"
+      footer={
+        <KeyHints
+          hints={[
+            { key: '↑/↓', action: 'navigate' },
+            {
+              key: `1-${LOGIN_PICKER_ITEMS.length}/Enter`,
+              action: 'select',
+            },
+            { key: 'Esc', action: 'cancel' },
+          ]}
+          confirmCancel={false}
+        />
+      }
     >
-      <Text bold color={COLOR_HINT}>
-        TeXRA login
-      </Text>
       <Text dimColor>Choose how to sign in:</Text>
       {remoteSession ? (
         <Text dimColor>
@@ -56,20 +65,7 @@ function LoginProviderPicker(props: {
           onCancel={() => finish(undefined)}
         />
       </Box>
-      <Box marginTop={1}>
-        <KeyHints
-          hints={[
-            { key: '↑/↓', action: 'navigate' },
-            {
-              key: `1-${LOGIN_PICKER_ITEMS.length}/Enter`,
-              action: 'select',
-            },
-            { key: 'Esc', action: 'cancel' },
-          ]}
-          confirmCancel={false}
-        />
-      </Box>
-    </Box>
+    </BorderedPanel>
   );
 }
 

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -453,15 +453,11 @@ function OnboardingFrame(props: {
   readonly hints: readonly KeyHint[];
 }): React.JSX.Element {
   return (
-    <Box
-      borderStyle="round"
-      borderColor={COLOR_HINT}
-      flexDirection="column"
-      paddingX={1}
+    <BorderedPanel
+      color={COLOR_HINT}
+      title={props.title}
+      footer={<KeyHints hints={props.hints} confirmCancel={false} />}
     >
-      <Text bold color={COLOR_HINT}>
-        {props.title}
-      </Text>
       {props.subtitle ? <Text dimColor>{props.subtitle}</Text> : null}
       {props.error ? (
         <Text color={COLOR_ERROR}>{`${CROSS} ${props.error}`}</Text>
@@ -469,10 +465,7 @@ function OnboardingFrame(props: {
       <Box marginTop={1} flexDirection="column">
         {props.children}
       </Box>
-      <Box marginTop={1}>
-        <KeyHints hints={props.hints} confirmCancel={false} />
-      </Box>
-    </Box>
+    </BorderedPanel>
   );
 }
 


### PR DESCRIPTION
## Summary

Follow-up from a scheduled UI-consistency audit. `OnboardingFrame` (`packages/cli/src/onboarding/runOnboarding.tsx`) and `LoginProviderPicker` (`packages/cli/src/commands/loginProviderPicker.tsx`) each hand-rolled the same bordered-box-with-title/body/footer `<Box>` scaffold that `BorderedPanel` (`packages/cli/src/tui/ui/BorderedPanel.tsx`) already provides — and that a sibling component in the same file, `RelayProgressFrame`, already uses. Both call sites now route through `BorderedPanel`.

## Issue acceptance gates

No linked issue; this is a small consolidation surfaced by a scheduled codebase audit (icon/CSS-token duplication was already fully swept in prior PRs #9713–#9785; this was the one remaining leftover).

## Single source of truth

`BorderedPanel` (`packages/cli/src/tui/ui/BorderedPanel.tsx`) is now the sole owner of the bordered-box-with-title/body/footer layout for onboarding and login prompts, matching its existing use in `RelayProgressFrame`.

## Duplication and abstraction budget

Removed two duplicated copies of the bordered-box scaffold (title `<Text bold>`, `marginTop` body wrapper, `marginTop` footer wrapper). No new abstraction added — both call sites adopt the existing `BorderedPanel`.

## Net elements (R6)

2 files changed, 23 insertions(+), 34 deletions(-), net -11 LoC. No exported symbols added or removed (`git diff --name-only` shows no `^[+-]export` changes).

## Consumer counts (R8)

n/a — no emit path or export was re-routed; this only changes internal JSX composition within two existing components.

## Host impact

Extension: none.

Desktop: none.

CLI: `OnboardingFrame` and `LoginProviderPicker` now render through `BorderedPanel`. Output is structurally identical — same border style/color, title, body spacing, and footer spacing — verified by diff inspection against `BorderedPanel`'s props/markup.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck:cli` — pass
- `npm run typecheck:workspace` — pass
- `npx eslint` on both changed files — pass
- `npx prettier --check` on both changed files — pass
- No existing unit tests reference `OnboardingFrame`/`LoginProviderPicker`; a full `vitest` run was kicked off but not confirmed complete before push (typecheck/lint/prettier plus manual diff review against `BorderedPanel`'s exact layout were used to verify behavior is unchanged).

---
_Generated by [Claude Code](https://claude.ai/code/session_014whxrFKC4qokY5RyDkqPBx)_