### PR TITLE
refactor: replace ad-hoc image-dimension probe and debounce timer with npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "delay": "^7.0.0",
     "diff-match-patch": "^1.0.5",
     "dotenv": "^17.4.2",
+    "es-toolkit": "^1.50.0",
     "escape-string-regexp": "^5.0.0",
     "execa": "^10.0.1",
     "fast-json-stable-stringify": "^2.1.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -68,6 +68,7 @@
     "deepmerge": "^4.3.1",
     "delay": "^7.0.0",
     "diff-match-patch": "^1.0.5",
+    "es-toolkit": "^1.50.0",
     "escape-string-regexp": "^5.0.0",
     "execa": "^10.0.1",
     "fast-json-stable-stringify": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  ink@7.1.1:
-    hash: db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6
-    path: patches/ink@7.1.1.patch
-  openai@7.3.0:
-    hash: b93e49cfd275eb480aac067d76a3da100df386766cc32c5e62863ed5ae3b18b9
-    path: patches/openai@7.3.0.patch
+  ink@7.1.1: db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6
+  openai@7.3.0: b93e49cfd275eb480aac067d76a3da100df386766cc32c5e62863ed5ae3b18b9
 
 importers:
 
@@ -109,6 +105,9 @@ importers:
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
+      es-toolkit:
+        specifier: ^1.50.0
+        version: 1.50.0
       escape-string-regexp:
         specifier: ^5.0.0
         version: 5.0.0
@@ -488,6 +487,9 @@ importers:
       diff-match-patch:
         specifier: ^1.0.5
         version: 1.0.5
+      es-toolkit:
+        specifier: ^1.50.0
+        version: 1.50.0
       escape-string-regexp:
         specifier: ^5.0.0
         version: 5.0.0
@@ -3908,6 +3910,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   crypto-random-string@4.0.0:
     resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
@@ -4187,8 +4190,8 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  es-toolkit@1.46.1:
-    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
+  es-toolkit@1.50.0:
+    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
@@ -10051,7 +10054,7 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
-  es-toolkit@1.46.1: {}
+  es-toolkit@1.50.0: {}
 
   es6-error@4.1.1:
     optional: true
@@ -10804,7 +10807,7 @@ snapshots:
       cli-cursor: 4.0.0
       cli-truncate: 6.0.0
       code-excerpt: 4.0.0
-      es-toolkit: 1.46.1
+      es-toolkit: 1.50.0
       indent-string: 5.0.0
       is-in-ci: 2.0.0
       patch-console: 2.0.0

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -15,6 +15,7 @@
  * (the single home for generic string helpers) and are re-exported here for
  * existing @utils/core consumers.
  */
+import { debounce as debounceWithFlush } from 'es-toolkit';
 import { customAlphabet, nanoid } from 'nanoid';
 import { basename as pathBasename, extname as pathExtname } from 'pathe';
 
@@ -190,15 +191,15 @@ export function onAbort(
 /**
  * A trailing-edge timer batcher with a synchronous flush escape hatch —
  * perfect-debounce's `debounce()` only exposes `cancel()` (discard the
- * pending call), with no way to force the trailing call to run early. Several
- * hand-rolled `setTimeout`/`clearTimeout` sites need exactly that: run the
- * pending work synchronously right now (typically just before teardown/
- * dispose), instead of either waiting out the timer or dropping the work.
- *
- * `schedule()` always (re)starts the timer, matching a classic trailing
- * debounce. A call site that instead wants "start once, coalesce further
- * calls until it fires" (a throttle-style batching window) can guard with
- * `pending`: `if (!batcher.pending) batcher.schedule();`.
+ * pending call), with no way to force the trailing call to run early.
+ * Several call sites need exactly that: run the pending work synchronously
+ * right now (typically just before teardown/dispose), instead of either
+ * waiting out the timer or dropping the work. Built on es-toolkit's
+ * `debounce()`, which already provides `schedule`/`cancel`/`flush`; this
+ * only adds the `pending` flag, needed by call sites that want "start once,
+ * coalesce further calls until it fires" (a throttle-style batching window)
+ * instead of a classic reset-on-every-call debounce: guard with
+ * `if (!batcher.pending) batcher.schedule();`.
  *
  * The callback is fixed at creation and takes no arguments — call sites that
  * need per-invocation data close over their own mutable state (as the
@@ -223,34 +224,27 @@ export function createFlushableDebounce(
   callback: () => void,
   waitMs: number,
 ): FlushableDebounce {
-  let timer: ReturnType<typeof setTimeout> | undefined;
+  let isPending = false;
 
-  function cancel(): void {
-    if (timer === undefined) return;
-    clearTimeout(timer);
-    timer = undefined;
-  }
-
-  function schedule(): void {
-    if (timer !== undefined) clearTimeout(timer);
-    timer = setTimeout(() => {
-      timer = undefined;
-      callback();
-    }, waitMs);
-  }
-
-  function flush(): void {
-    if (timer === undefined) return;
-    cancel();
+  const debounced = debounceWithFlush(() => {
+    isPending = false;
     callback();
-  }
+  }, waitMs);
 
   return {
-    schedule,
-    flush,
-    cancel,
+    schedule() {
+      isPending = true;
+      debounced();
+    },
+    flush() {
+      debounced.flush();
+    },
+    cancel() {
+      isPending = false;
+      debounced.cancel();
+    },
     get pending() {
-      return timer !== undefined;
+      return isPending;
     },
   };
 }

--- a/src/utils/media/img.ts
+++ b/src/utils/media/img.ts
@@ -3,6 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 // Third-party imports
+import { imageSize } from 'image-size';
 import { fromPath } from 'pdf2pic';
 
 // Local imports - log
@@ -44,26 +45,16 @@ async function removeConversionTempDir(tempDir: string): Promise<void> {
   }
 }
 
-/** Get the dimensions of an image file using ImageMagick or GraphicsMagick. */
-async function getImageDimensions(
-  imagePath: string,
-  tool: 'magick' | 'gm',
-): Promise<{ width: number; height: number }> {
-  const identifyArgs = [tool, 'identify', '-format', '%w %h', imagePath];
-  const result = await executeCommand(identifyArgs, { channel: CHANNEL });
-  if (!result.success || !result.stdout) {
-    throw new Error(result.stderr || 'Failed to get image dimensions');
+/** Get the dimensions of an image file. Pure JS — no external binary required. */
+function getImageDimensions(imagePath: string): {
+  width: number;
+  height: number;
+} {
+  try {
+    return imageSize(AbsoluteFS.readBytesSync(imagePath));
+  } catch (err) {
+    throw new Error(`Failed to get image dimensions: ${toErrorMessage(err)}`);
   }
-  const [widthStr, heightStr] = result.stdout.trim().split(/\s+/);
-  const width = Number.parseInt(widthStr, 10);
-  const height = Number.parseInt(heightStr, 10);
-
-  if (Number.isNaN(width) || Number.isNaN(height)) {
-    throw new Error(
-      `Invalid dimensions parsed: width=${widthStr}, height=${heightStr}`,
-    );
-  }
-  return { width, height };
 }
 
 /** Maximum image dimension (pixels) accepted by provider APIs. */
@@ -71,18 +62,21 @@ const API_MAX_IMAGE_DIMENSION = 8000;
 
 /** Resize an image if it exceeds the maximum dimensions. Returns the original path if no resize needed. */
 async function resizeImageIfNeeded(imagePath: string): Promise<string> {
-  const tool = await detectImageTool();
-  if (!tool) {
-    throw new Error('Neither ImageMagick nor GraphicsMagick is installed');
-  }
   const maxDimension = Math.min(
     getConfig<number>('texra.maxImageDimension', 2000),
     API_MAX_IMAGE_DIMENSION,
   );
-  const { width, height } = await getImageDimensions(imagePath, tool);
+  const { width, height } = getImageDimensions(imagePath);
 
   if (width <= maxDimension && height <= maxDimension) {
     return imagePath;
+  }
+
+  // Resizing (unlike measuring) still needs an external tool — only
+  // required once we know the image actually exceeds the limit.
+  const tool = await detectImageTool();
+  if (!tool) {
+    throw new Error('Neither ImageMagick nor GraphicsMagick is installed');
   }
 
   const ext = path.extname(imagePath);


### PR DESCRIPTION
## Summary

Follow-up to a scheduled npm-replacement audit. Two of the three flagged candidates get a clean library swap; the third was investigated and kept as-is because the library doesn't preserve a correctness guarantee the call sites rely on.

- `src/utils/media/img.ts`: `getImageDimensions` shelled out to `magick identify`/`gm identify` and hand-parsed stdout to read an image's width/height, requiring ImageMagick or GraphicsMagick on the host just to measure a file. `image-size` (already a dependency, already used the same way in `src/tools/imageUtils.ts`) reads dimensions in pure JS with no subprocess. As a direct consequence, `resizeImageIfNeeded` no longer requires the external tool at all unless the image actually needs resizing — previously it required ImageMagick/GraphicsMagick even for images already under the size limit.
- `src/utils/core/index.ts`: `createFlushableDebounce` hand-rolled a `setTimeout`/`clearTimeout` state machine (schedule/flush/cancel/pending) because `perfect-debounce` (already used elsewhere in the file) has no `flush()`. Swapped the internals to wrap `es-toolkit`'s `debounce()`, which already provides `schedule`/`cancel`/`flush` — the wrapper now only adds the `pending` flag that one call-site pattern needs. The public `FlushableDebounce` interface and all 12 call sites are unchanged.
- `coalesceAsync` (also in `src/utils/core/index.ts`) was investigated against `promise-coalesce` but **not** changed: that package keeps its in-flight promises in a single module-global, string-keyed `Map` with no way to inject an external store or observe the in-flight entry. Two of the three `coalesceAsync` call sites (`src/model/apiProviders.ts`, `src/model/computeModelOptions.ts`) call `.clear()` on their `pending`/`resolved` maps to invalidate a cached API-key lookup, and `coalesceAsync`'s existing race-guard (only cache the result if `pending.get(key) === request` still holds once it settles) exists specifically to stop a stale in-flight computation from re-poisoning the cache after that invalidation. `promise-coalesce` has no hook to reproduce that guard, so replacing it would silently drop a real correctness property on a secrets-adjacent path. Left the hand-rolled version in place rather than force a worse fit.

## Issue acceptance gates

No linked issue — self-initiated follow-up to a scheduled audit that identified these three candidates. Gate: each of the three candidates either gets a verified, behavior-preserving swap, or an explicit, checked reason it doesn't.

## Single source of truth

`image-size` is now the single way this codebase reads raster image dimensions (previously two ways: `src/tools/imageUtils.ts` via `image-size`, `src/utils/media/img.ts` via subprocess). `es-toolkit`'s `debounce()` now owns the timer/flush/cancel mechanics for `createFlushableDebounce`; `FlushableDebounce` still owns the `pending` flag as the one bit of behavior no library exposes.

## Duplication and abstraction budget

Removed duplication: two different techniques for the same "read image dimensions" problem collapsed into one. No new abstraction added — `createFlushableDebounce`'s public shape is unchanged, only its internals now delegate to a library instead of hand-rolling timer state.

## Net elements (R6)

Diffstat: `package.json` +1, `packages/agent/package.json` +1, `pnpm-lock.yaml` +12/-11, `src/utils/core/index.ts` +26/-32 (net -6 lines), `src/utils/media/img.ts` +19/-23 (net -4 lines). No exported symbols added or removed (`git diff -- src/utils/core/index.ts src/utils/media/img.ts | grep -E '^[+-]export'` is empty — both changed functions are module-private). One new dependency (`es-toolkit`, zero transitive deps); `image-size` was already a dependency.

## Consumer counts (R8)

Not applicable — no emit path, export, or public API surface was removed or re-routed. `getImageDimensions` and `createFlushableDebounce`'s implementation are both internal; the `FlushableDebounce` public interface and its 12 call sites are unchanged (verified via `git diff` showing zero call-site edits, plus a full typecheck and the existing `UtilsCore.vitest.ts` suite passing unmodified).

## Host impact

Extension: uses both changed modules (webview persistence debounce, progress-view render debounce, tooltip/copy-button controllers, image attachment resizing) — covered by the full workspace build below.

Desktop: shares the same host-agnostic `src/` core: `es-toolkit`'s build now needs to be declared per-host or resolved from the root workspace, verified via `npm run compile:fast` building every host bundle without missing-package errors.

CLI: `createFlushableDebounce` is used by `packages/cli/src/chat/tui/state/subscribeStreamLog.ts` — covered by the workspace-wide typecheck/test run.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm install` — `es-toolkit` resolves cleanly at the workspace root and in `packages/agent` (its `validate-artifacts.mjs` check initially failed until `es-toolkit` was declared in `packages/agent/package.json` too; fixed and re-verified).
- `npm run typecheck` — full workspace, all six sub-project typechecks (workspace, test-kernel, agent, extension, cli, trace-viewer, desktop) pass.
- `npx vitest run src/test-kernel/utils/UtilsCore.vitest.ts` — 69/69 pass, unmodified, including the schedule/flush/cancel/pending behavior tests for `createFlushableDebounce`.
- `npx vitest run src/test-kernel/utils/` — 289/289 pass across all 19 utils test files.
- `npm run check:dead-code-ratchet` — 18 findings, matches baseline, no new dead code.
- `npx eslint` on both changed source files — 0 errors.
- `npm run compile:fast` — full build (extension host + progressView/settingsView/webview Vite bundles + trace-viewer) succeeds, confirming `es-toolkit` is browser-safe.
- Manual sanity check: `imageSize()` against an inline 1×1 PNG returns `{ width: 1, height: 1 }`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCRAiqDzwBKKYafAvR7R3b)_