### PR TITLE
fix(settingsView): reuse canonical Zod schema for custom LaTeX replacements

### DIFF
--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -38,6 +38,7 @@ import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared schemas
+import { CoreSettingsShape } from '@shared/schemas/coreSettings';
 import {
   DEFAULT_LATEX_SETTINGS_STATUS,
   type LatexConfigValues,
@@ -771,19 +772,15 @@ export class LaTeXTab extends LitElement {
   ): void {
     try {
       const parsed: unknown = JSON.parse(source);
-      if (
-        !parsed ||
-        Array.isArray(parsed) ||
-        typeof parsed !== 'object' ||
-        Object.values(parsed).some((value) => typeof value !== 'string')
-      ) {
+      const result = CoreSettingsShape.latex.unwrap().shape[field].safeParse(parsed);
+      if (!result.success) {
         throw new Error('Enter a JSON object with string values.');
       }
       this.replacementJsonErrors = {
         ...this.replacementJsonErrors,
         [field]: undefined,
       };
-      this.dispatchSetConfigValue(field, parsed as Record<string, string>);
+      this.dispatchSetConfigValue(field, result.data);
     } catch (error) {
       this.replacementJsonErrors = {
         ...this.replacementJsonErrors,

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -772,7 +772,9 @@ export class LaTeXTab extends LitElement {
   ): void {
     try {
       const parsed: unknown = JSON.parse(source);
-      const result = CoreSettingsShape.latex.unwrap().shape[field].safeParse(parsed);
+      const result = CoreSettingsShape.latex
+        .unwrap()
+        .shape[field].safeParse(parsed);
       if (!result.success) {
         throw new Error('Enter a JSON object with string values.');
       }


### PR DESCRIPTION
## Summary

Follows up on a scheduled abstraction-layer audit that flagged two findings. Only one is addressed here — see below for why the other was intentionally skipped.

- `LaTeXTab.ts`'s `handleCustomReplacementChange` hand-rolled a JSON-shape check (`typeof !== 'object'`, `Array.isArray`, `Object.values(...).some(...)`) for the `customReplacements` / `customReplacementsRegex` textareas instead of reusing the `stringRecord` schema already defined once in `CoreSettingsShape.latex` (`src/shared/schemas/coreSettings.ts`). Client-side validation could silently drift from what the backend actually enforces (e.g. if the schema later tightens with a max-entries cap or key format rule).
- Replaced the manual check with `CoreSettingsShape.latex.unwrap().shape[field].safeParse(parsed)` — the same accessor pattern already used in `src/shared/schemas/stateSettings.ts:811,821` for the same two fields. Error-handling control flow and the user-facing error message are unchanged.

## Skipped finding (intentionally)

The audit also flagged `src/shared/settingsView/handlers/*` (8 files) as duplicating `src/controllers/settingsView/`'s orchestration role and suggested folding them together. Before implementing that, I found `docs/proposals/2026-08-01-directory-organization.md` (item 103) already evaluated and **rejected** this exact move: the `shared/` placement is deliberate, enforced by `SharedSettingsViewBoundary.vitest.ts`, and exists specifically because these handlers must stay free of `@controllers/@agent/@model/@tools/@auth` imports — a strictly tighter constraint than `src/controllers/` allows. Moving them would delete that guard and reverse a documented decision, so I left it alone.

## Test plan

- [x] `npm run typecheck` — clean across the full workspace
- [x] `npm run lint` — clean
- [x] `npm test` — 8480 passed, 2 pre-existing failures in `ExtensionTexraConfig.vitest.ts` (unrelated ENOENT temp-file flake, reproduces identically on `main` before this change)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013YCpFCnDNptP6Edqm6vjWU

---
_Generated by [Claude Code](https://claude.ai/code/session_013YCpFCnDNptP6Edqm6vjWU)_