### PR TITLE
fix(ci): repair CLI architecture check, formatting, and duplicate-click regressions

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -337,7 +337,7 @@ function validateMultiAgentListAvailability() {
     );
     const leanProjectAvailability = leanProjectJson?.availability;
     assert(
-      leanProjectAvailability?.toolUse?.label != null,
+      leanProjectAvailability?.agents?.toolUse?.label != null,
       `multi-agent list JSON should include planned availability\nstdout:\n${json.stdout}`,
     );
     assert(
@@ -346,7 +346,7 @@ function validateMultiAgentListAvailability() {
       `lean-project JSON should report degraded or unavailable status\nrecord:\n${JSON.stringify(leanProjectJson, null, 2)}`,
     );
     assert(
-      leanProjectAvailability?.toolUse?.label !== '7',
+      leanProjectAvailability?.agents?.toolUse?.label !== '7',
       `lean-project JSON should not claim full tool-use availability\nrecord:\n${JSON.stringify(leanProjectJson, null, 2)}`,
     );
 
@@ -357,7 +357,7 @@ function validateMultiAgentListAvailability() {
       'multi-agent list NDJSON',
     ).find((record) => record.preset?.id === 'lean-project');
     assert(
-      leanProjectNdjson?.preset?.availability?.toolUse?.label != null,
+      leanProjectNdjson?.preset?.availability?.agents?.toolUse?.label != null,
       `multi-agent list NDJSON should include planned availability\nstdout:\n${ndjson.stdout}`,
     );
   } finally {
@@ -764,7 +764,7 @@ async function validateOrchestrateOnboardingPickers() {
     expected: [
       'Use ChatGPT subscription',
       'Sign in with Researcher Access',
-      'Use your own provider API key',
+      'Use your own API keys',
       'Skip for now',
     ],
     forbidden: truncatedOnboardingLabels,
@@ -779,7 +779,7 @@ async function validateOrchestrateOnboardingPickers() {
       'Skip for now',
     ],
     forbidden: [
-      'Use your own provider API key',
+      'Use your own API keys',
       'Anthropic, OpenAI, Google, and more',
       ...truncatedOnboardingLabels,
     ],
@@ -790,7 +790,7 @@ async function validateOrchestrateOnboardingPickers() {
     env: {},
     expected: [
       'Use ChatGPT subscription',
-      'Use your own provider API key',
+      'Use your own API keys',
       'Skip for now',
     ],
     forbidden: ['Sign in with Researcher Access', ...truncatedOnboardingLabels],

--- a/packages/cli/src/tui/ui/colors.ts
+++ b/packages/cli/src/tui/ui/colors.ts
@@ -1,3 +1,5 @@
+import { cliEnvValue } from '@cli/runtime/cliContext';
+
 // Semantic color palette for the CLI TUI. Components say WHAT (semantic
 // color); this module says WHICH Ink/chalk color name backs it — so
 // re-theming or contrast-tuning happens in one owned place instead of at
@@ -35,7 +37,7 @@
 // never regress a dark one. Resolved once here so every call site keeps
 // consuming a plain string.
 const LIGHT_TERMINAL_BACKGROUND = ((): boolean => {
-  const background = process.env.COLORFGBG?.split(';').at(-1);
+  const background = cliEnvValue('COLORFGBG')?.split(';').at(-1);
   return background === '7' || background === '15';
 })();
 

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -174,15 +174,17 @@ export class ProgressApp extends ProgressAppBase {
               `
             : this.renderEmptyState()
         }
-        ${/*
+        ${
+          /*
           One stable, visually-hidden polite region for the whole shell:
           new approval requests and terminal run outcomes land here (see
           statusAnnouncement$). Stability matters — a region that is always
           mounted re-announces reliably on every text change, unlike a
           dynamically inserted alert. */
-        html`<div class="visually-hidden" role="status">
-          ${statusAnnouncement$.get()}
-        </div>`}
+          html`<div class="visually-hidden" role="status">
+            ${statusAnnouncement$.get()}
+          </div>`
+        }
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -308,7 +308,10 @@ export class SettingsApp extends SettingsAppBase {
              contract (no arrow keys/roving tabindex), and role="tab" on a
              wa-button nests a native button role. aria-pressed matches the
              actual behavior — same pattern as the category nav above. -->
-        <div class="settings-page-nav" aria-label=${`${activeGroup.label} pages`}>
+        <div
+          class="settings-page-nav"
+          aria-label=${`${activeGroup.label} pages`}
+        >
           ${activeEntries.map((entry) => {
             const active = entry.panel === activePanel;
             return html`

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -105,11 +105,7 @@ export class FileSelectGroup extends LitElement {
     );
   }
 
-  private handleRemoveClick(event: MouseEvent): void {
-    const button = (event.target as HTMLElement).closest<HTMLElement>(
-      '[data-remove-file]',
-    );
-    if (!button) return;
+  private handleRemoveClick(button: HTMLElement): void {
     const file = button.dataset.removeFile;
     if (file) {
       this.dispatchEvent(
@@ -121,11 +117,7 @@ export class FileSelectGroup extends LitElement {
   /** Keyboard/touch counterpart to Sortable drag reordering (order is
    * semantic: the first input file is the primary input). Dispatches the
    * same filesReordered event as a drag. */
-  private handleMoveClick(event: MouseEvent): void {
-    const button = (event.target as HTMLElement).closest<HTMLElement>(
-      '[data-move-index]',
-    );
-    if (!button) return;
+  private handleMoveClick(button: HTMLElement): void {
     const index = Number(button.dataset.moveIndex);
     const direction = Number(button.dataset.moveDirection);
     const files = this.currentFiles;
@@ -139,6 +131,22 @@ export class FileSelectGroup extends LitElement {
     this.dispatchEvent(
       MainViewEvents.filesReordered({ listId: this.listId, files: reordered }),
     );
+  }
+
+  /** Single delegate for the file-list row: lit-html rejects two `@click`
+   * bindings on the same element, so remove and move share one dispatch,
+   * each matching its own `data-*` marker on a distinct button. */
+  private handleFileListClick(event: MouseEvent): void {
+    const target = event.target as HTMLElement;
+    const removeButton = target.closest<HTMLElement>('[data-remove-file]');
+    if (removeButton) {
+      this.handleRemoveClick(removeButton);
+      return;
+    }
+    const moveButton = target.closest<HTMLElement>('[data-move-index]');
+    if (moveButton) {
+      this.handleMoveClick(moveButton);
+    }
   }
 
   private get currentCheckboxValues(): CheckboxValues {
@@ -265,11 +273,7 @@ export class FileSelectGroup extends LitElement {
     }
 
     const movable = this.currentFiles.length > 1;
-    return html`<div
-      role="list"
-      @click=${this.handleRemoveClick}
-      @click=${this.handleMoveClick}
-    >
+    return html`<div role="list" @click=${this.handleFileListClick}>
       ${repeat(
         this.currentFiles,
         (file) => file,

--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -140,10 +140,10 @@ function renderActionButtonParts({
   const tooltipTemplate = useWebAwesomeTooltip
     ? html`<wa-tooltip for=${id}>${tooltip}</wa-tooltip>`
     : nothing;
-  // `title` is the one attribute wa-button forwards into its shadow <button>,
-  // so it doubles as the accessible name of an icon-only button. Set it even
-  // when a wa-tooltip carries the visible hint — suppressing it here left
-  // every id+tooltip icon button unnamed.
+  // `aria-label` (below) already names the button unconditionally, so `title`
+  // is only needed as a fallback hint when there's no `wa-tooltip` sibling to
+  // show one — setting both here would double up the hover hint (native
+  // tooltip + wa-tooltip) for every id+tooltip icon button.
   const nativeTitle = tooltip && !id ? tooltip : (title ?? ariaLabel);
   let content: TemplateResult | typeof nothing = nothing;
   if (text) {
@@ -164,7 +164,7 @@ function renderActionButtonParts({
       aria-pressed=${ifDefined(
         pressed === undefined ? undefined : String(pressed),
       )}
-      title=${ifDefined(nativeTitle)}
+      title=${ifDefined(useWebAwesomeTooltip ? undefined : nativeTitle)}
       data-action=${ifDefined(action)}
       ?disabled=${disabled || busy}
       ?hidden=${hidden}


### PR DESCRIPTION
- packages/cli/src/tui/ui/colors.ts: read COLORFGBG through cliContext's
  cliEnvValue instead of process.env directly, per the CLI architecture gate.
- prettier --write on ProgressApp.ts/SettingsApp.ts to clear format:check.
- FileSelectGroup.ts: lit-html rejects two @click bindings on the same
  element ("duplicate attribute bindings"); merge remove/move into one
  delegated handler. This was crashing FileSelectGroup rendering, which is
  also why the Electron webview smoke test saw 0 file rows.
- actionButtons.ts: revert to suppressing the native `title` attribute when
  a wa-tooltip anchors to the same id (aria-label already names the button
  unconditionally), restoring the pre-regression behavior the
  ProposalRequestPanel/ToolEditRequestPanel tests expect.
- validate-run.mjs: fix two copy/schema drifts left behind by unrelated
  commits — the multi-agent list JSON availability now nests under
  `.agents.toolUse`, and the onboarding picker's API-key choice is now
  labeled "Use your own API keys".