### PR TITLE
fix(tools): make lean_inspect failures reachable; drop dead compaction-skip flag

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -439,12 +439,6 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
    *  instead of mutating chain fields directly. */
   private readonly chainState = new ServerChainState();
 
-  /** Whether the OpenRouter compaction-skip debug line has already been logged.
-   *  Route-specific log de-duplication rather than chain state, so it lives on
-   *  the handler; {@link initializeMessages} resets it alongside
-   *  {@link ServerChainState.resetChainForNewSession}. */
-  private openRouterSkipLogged = false;
-
   /** Pending background-response id + poll/resume choreography. See
    *  {@link BackgroundRunLifecycle} for the narrow interface this handler
    *  uses instead of mutating background-response fields directly. */
@@ -681,10 +675,11 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
       return false;
     }
     if (this.isOpenRouterRoutingEnabled()) {
-      if (!this.openRouterSkipLogged) {
-        this.logger.debug('Skipping compaction: OpenRouter routing is enabled');
-        this.openRouterSkipLogged = true;
-      }
+      // Same exclusion as canCompactRoute(): OpenRouter conversations compact
+      // through ModelHandlerOpenRouterNative. Nothing is logged here because
+      // the capability gate above already returns for every OpenRouter-routed
+      // request — no provider profile grants supportsManualCompaction on that
+      // route — so this only pins the invariant.
       return false;
     }
     const threshold = this.getCompactionTokenThreshold();
@@ -1119,7 +1114,6 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
     systemPrompt?: string,
   ): Promise<ResponseInputItem[]> {
     this.chainState.resetChainForNewSession();
-    this.openRouterSkipLogged = false;
     this.backgroundLifecycle.clearPending();
     this.wsTransport?.dispose();
 

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
@@ -55,6 +55,16 @@ function createHandler(): ModelHandlerOpenAIResponse {
   );
 }
 
+/** A request routed through OpenRouter (`openRouterOnly` forces the route on
+ *  regardless of the global toggle). */
+function createOpenRouterRoutedHandler(): ModelHandlerOpenAIResponse {
+  return configureHandler(
+    new ModelHandlerOpenAIResponse(
+      buildTestModelConfig(COMPACTION_TEST_CONFIG, { openRouterOnly: true }),
+    ),
+  );
+}
+
 class UnsupportedCompactionHandler extends ModelHandlerOpenAIResponse {
   override get supportsManualCompaction(): boolean {
     return false;
@@ -497,6 +507,39 @@ describe('ModelHandlerOpenAIResponse automatic compaction', () => {
     expect(requests[1].previous_response_id).toBe('resp-before-threshold');
     expect(requests[1].input).toEqual([secondTurnMessages.at(-1)]);
     expect(result.updatedMessages).toBeUndefined();
+  });
+
+  it('leaves an OpenRouter-routed conversation uncompacted past the threshold', async () => {
+    // OpenRouter conversations compact through ModelHandlerOpenRouterNative,
+    // so this handler reports compaction unsupported on that route and must
+    // never reach for /responses/compact — not even when the cumulative token
+    // count is over the threshold. That capability gate fires before any
+    // routing check inside shouldCompact(), which is why the skip needs no
+    // log line (and no once-only flag to de-duplicate one).
+    const handler = createOpenRouterRoutedHandler();
+    const requests: any[] = [];
+    const compactRequests: any[] = [];
+    const client = withSdkOptions({
+      responses: {
+        compact: async (params: any) => {
+          compactRequests.push(params);
+          return { output: createMessages(1), usage: { output_tokens: 100 } };
+        },
+        create: async (params: any) => {
+          requests.push(params);
+          // 800 is over the 750-token threshold of the 1000-token window, so
+          // a compaction-capable route would compact on the second turn.
+          return createResponse(`resp-${requests.length}`, 800);
+        },
+      },
+    });
+
+    await sendTurn(handler, client, createMessages(2));
+    await sendTurn(handler, client, createMessages(3));
+
+    expect(handler.supportsManualCompaction).toBe(false);
+    expect(compactRequests).toHaveLength(0);
+    expect(requests).toHaveLength(2);
   });
 
   it('summarizes locally and resends a single message when the backend has no stateful compact endpoint (#7213)', async () => {

--- a/src/test-kernel/tools/LeanInspectTool.vitest.ts
+++ b/src/test-kernel/tools/LeanInspectTool.vitest.ts
@@ -1,0 +1,74 @@
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - tools
+import {
+  setLeanLanguageServices,
+  type LeanLanguageServices,
+} from '@tools/lean/leanLanguageServices';
+import { LeanInspectTool } from '@tools/lean/LspTools';
+
+function installServices(overrides: Partial<LeanLanguageServices>): void {
+  setLeanLanguageServices({
+    executeFileCommand: vi.fn(),
+    getGoalState: vi.fn(),
+    getTermGoal: vi.fn(),
+    getHoverInfo: vi.fn(),
+    fetchDiagnosticsForFile: vi.fn(),
+    navigateToFirstError: vi.fn(),
+    executeProjectCommand: vi.fn(),
+    ...overrides,
+  } as LeanLanguageServices);
+}
+
+describe('LeanInspectTool', () => {
+  beforeEach(() => {
+    installServices({});
+  });
+
+  it('reports a failing language-server request with a per-type summary', async () => {
+    // The dispatch must be awaited inside execute()'s try block; a bare
+    // `return this.executeGoal(...)` settles the promise after the try has
+    // exited, so the rejection reaches the caller unwrapped and loses the
+    // summary that names which inspection failed.
+    installServices({
+      getGoalState: vi.fn(async () => {
+        throw new Error('Lean server not running');
+      }),
+    });
+
+    const result = await new LeanInspectTool().call({
+      type: 'goal',
+      file: 'Proof.lean',
+      line: 12,
+      column: 3,
+    });
+
+    expect(result).toMatchObject({
+      status: 'error',
+      summary: 'Failed to get goal',
+      diagnostics: { name: 'ToolError' },
+    });
+    expect(result.error).toContain('Lean server not running');
+  });
+
+  it('passes a missing-goal response through as its own error result', async () => {
+    // A resolved "no data" answer is a normal outcome, not a thrown failure:
+    // it must keep its own message instead of being wrapped as a ToolError.
+    installServices({
+      getGoalState: vi.fn(async () => ({ data: null, error: 'no goal here' })),
+    });
+
+    const result = await new LeanInspectTool().call({
+      type: 'goal',
+      file: 'Proof.lean',
+      line: 12,
+      column: 3,
+    });
+
+    expect(result).toMatchObject({ status: 'error', summary: 'No goal state' });
+    expect(result.error).toContain(
+      'Could not get goal state at Proof.lean:12:3',
+    );
+  });
+});

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -286,13 +286,23 @@ Requires: Lean 4 VS Code extension installed and active.`,
     const col0 = column - 1;
     const location = `${file}:${line}:${column}`;
 
-    switch (type) {
-      case 'goal':
-        return this.executeGoal(file, line0, col0, location);
-      case 'term_goal':
-        return this.executeTermGoal(file, line0, col0, location);
-      case 'hover':
-        return this.executeHover(file, line0, col0, location);
+    try {
+      switch (type) {
+        // Each dispatch is awaited inside the try so a rejected language-server
+        // request lands in the catch below and carries a summary, matching the
+        // sibling Lean tools.
+        case 'goal':
+          return await this.executeGoal(file, line0, col0, location);
+        case 'term_goal':
+          return await this.executeTermGoal(file, line0, col0, location);
+        case 'hover':
+          return await this.executeHover(file, line0, col0, location);
+      }
+    } catch (error) {
+      throw new ToolError(`Error: ${toErrorMessage(error)}`, {
+        cause: error,
+        summary: `Failed to get ${type}`,
+      });
     }
   }
 


### PR DESCRIPTION
Closes #9807, closes #9808 — both deferred items from #9803.

## `lean_inspect` error handling (#9807)

`LeanInspectTool.execute` dispatched each inspection with a bare
`return this.executeGoal(...)`, so the returned promise settled after the
enclosing `try` had already exited. `BaseTool.call()` still caught the
rejection, so nothing was swallowed, but the result lost the `ToolError`
wrapper — no `summary` naming which inspection failed, and no `Error:` prefix
that every sibling Lean tool applies.

Each dispatch is now awaited inside the `try`, so the `catch` is reachable and
a failed goal/term-goal/hover request reports `Failed to get <type>`.

## OpenRouter compaction-skip flag (#9808)

#9808 asked for a replacement test for the once-only
`markOpenRouterSkipLogged` path. There is no reachable path to test: in
`shouldCompact()`, the `isOpenRouterRoutingEnabled()` branch sits below the
`supportsManualCompaction` gate, and that getter resolves to
`profile?.supportsManualCompaction ?? !isOpenRouterRoutingEnabled()` — every
profile producer (`resolveProviderCapabilities`,
`resolveXaiSubscriptionCapabilities`) returns `null` when the request is
routed through OpenRouter, and the base handler's profile is always `null`.
So an OpenRouter-routed request exits at the capability gate and the debug
line never fires. It has been dead since before #9803; the old test only
exercised the state-holder's setter, never the logging path.

Rather than fabricate an impossible capability combination to test dead code,
this removes the flag, its reset, and the log, keeps the routing guard as an
explicit invariant, and adds a test for the behavior that is actually live:
an OpenRouter-routed conversation stays uncompacted past the token threshold
and never touches `/responses/compact`, because OpenRouter conversations
compact through `ModelHandlerOpenRouterNative`.

## Test plan

- [x] `npx vitest run src/test-kernel/tools src/test-kernel/agent/modelHandlers` — 159 files, 1399 tests pass
- [x] New Lean test fails on the pre-fix code (missing `summary`) and passes after
- [x] `npm run typecheck:workspace`, `npm run typecheck:test-kernel`
- [x] `eslint` and `prettier` clean on the touched files

Made with [Cursor](https://cursor.com)