### PR TITLE
fix(ui): name nested runs "background tasks" in user-facing text

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -58,7 +58,7 @@ const PAGE_DOWN = ESC + '[6~';
 const ANSI_SGR_PATTERN = new RegExp(`${ESC}\\[[0-?]*[ -/]*m`, 'g');
 const RUNNING_STATUS_PATTERN = /◆ [-|\/\\] running/;
 const STOPPED_SUBAGENT_INPUT_MESSAGE_START =
-  'Subagent is no longer accepting follow-ups; press Tab to select a session';
+  'This background task is no longer accepting follow-ups; press Tab to select a session';
 const STOPPED_SUBAGENT_INPUT_MESSAGE = `${STOPPED_SUBAGENT_INPUT_MESSAGE_START}.`;
 const LONG_BASH_APPROVAL_COMMAND = [
   "python3 << 'EOF'",
@@ -3148,7 +3148,7 @@ const SCENARIOS = [
     expect: ['◆ stopped', 'root active', STOPPED_SUBAGENT_INPUT_MESSAGE_START],
     expectCollapsed: [STOPPED_SUBAGENT_INPUT_MESSAGE],
     unexpect: [
-      'The selected subagent is no longer accepting follow-ups.',
+      'The selected background task is no longer accepting follow-ups.',
       'Harness received: can you still receive this?',
     ],
     unexpectPatterns: [RUNNING_STATUS_PATTERN],

--- a/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
+++ b/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
@@ -47,7 +47,7 @@ export function focusedChildInputDisabledMessage(init: {
   ) {
     return undefined;
   }
-  return 'Subagent is no longer accepting follow-ups; press Tab to select a session.';
+  return 'This background task is no longer accepting follow-ups; press Tab to select a session.';
 }
 
 export function stoppedFocusedChildFollowUpMessage(init: {
@@ -60,6 +60,6 @@ export function stoppedFocusedChildFollowUpMessage(init: {
       activeStreamId: init.streamId,
       parentStream: init.parentStream,
       status: init.streams.get(init.streamId)?.status,
-    }) ?? 'The selected subagent is no longer accepting follow-ups.'
+    }) ?? 'The selected background task is no longer accepting follow-ups.'
   );
 }

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -182,10 +182,16 @@ export class StreamTab extends LitElement {
     const streamDecorator = this._streamDecorator;
     const hasChildren = this.childCount > 0 && !this.compact;
     const showCompactChildHint = this.childCount > 0 && this.compact;
-    const childStreamLabel = formatResultCount(this.childCount, 'child stream');
+    // "Background task" covers every nested run — delegated agents, agent CLIs
+    // and background commands — matching the Background tasks panel; "child
+    // stream" is the internal stream-tree name and stays out of the UI.
+    const childCountLabel = formatResultCount(
+      this.childCount,
+      'background task',
+    );
     const childToggleLabel = this.expanded
-      ? 'Collapse child streams'
-      : childStreamLabel;
+      ? 'Collapse background tasks'
+      : childCountLabel;
 
     return html`
       <div
@@ -242,7 +248,7 @@ export class StreamTab extends LitElement {
                 ? waIcon('chevron-right', {
                     id: 'stream-tab-compact-children',
                     className: 'compact-subagent-hint',
-                    label: childStreamLabel,
+                    label: childCountLabel,
                   })
                 : nothing
             }
@@ -290,7 +296,7 @@ export class StreamTab extends LitElement {
         ${
           showCompactChildHint
             ? html`<wa-tooltip for="stream-tab-compact-children"
-                >${childStreamLabel}</wa-tooltip
+                >${childCountLabel}</wa-tooltip
               >`
             : nothing
         }

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -1294,7 +1294,7 @@ describe('CLI TUI row allocation', () => {
         status: STREAM_PHASE.COMPLETED,
       }),
     ).toBe(
-      'Subagent is no longer accepting follow-ups; press Tab to select a session.',
+      'This background task is no longer accepting follow-ups; press Tab to select a session.',
     );
   });
 

--- a/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.ts
+++ b/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.ts
@@ -56,8 +56,8 @@ describe('stream-tab expand chevron', () => {
     expect(expandButton?.hasAttribute('aria-expanded')).toBe(true);
     const expectedLabel =
       expandButton?.getAttribute('aria-expanded') === 'true'
-        ? 'Collapse child streams'
-        : '1 child stream';
+        ? 'Collapse background tasks'
+        : '1 background task';
     expect(expandButton?.getAttribute('aria-label')).toBe(expectedLabel);
     expect(
       parentTab?.shadowRoot

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -244,7 +244,7 @@ const BashInputSchema = z.strictObject({
     .boolean()
     .prefault(false)
     .describe(
-      'Run command in background. Returns immediately with execution ID and child stream tab. Result delivered as follow-up when complete.',
+      'Run command in background. Returns immediately with execution ID and a background task tab. Result delivered as follow-up when complete.',
     ),
 });
 


### PR DESCRIPTION
Closes #9798.

The three terms in that issue were not interchangeable, so this splits them by
scope rather than collapsing them into one word.

**Ruling applied**

| Concept | Term |
| --- | --- |
| Anything nested under a run (delegated agent, agent CLI, background command) | background task |
| A delegated TeXRA agent specifically | subagent |
| The internal stream-tree relationship | child stream — code only, never UI |

**Changes**

- Progress-view stream tab: the expand toggle's aria-label and tooltip said
  "2 child streams" / "Collapse child streams". Screen-reader users were being
  read the internal stream-tree name; they now hear "2 background tasks" /
  "Collapse background tasks", matching the Background tasks panel that lists
  the same rows.
- `bash`'s `run_in_background` description said it returns a "child stream tab";
  now "a background task tab".
- CLI stopped-follow-up messages said "Subagent is no longer accepting
  follow-ups", which is the wrong noun whenever the focused child is a
  background command. Both messages now use the umbrella term.

**Deliberately unchanged**

- The extension panel ("Background tasks") and its "Subagents" section header
  were already correct under this ruling.
- The CLI status-bar count keeps "N subagents" / compact "N sub". Renaming it
  would rewrite ~40 golden expectations in the PTY harness
  (`validate-tui.mjs`), and "N bg" is less legible than "N sub" in the compact
  status bar — not worth it for a count whose rows are overwhelmingly delegated
  agents.
- `Tab children` stays as navigation phrasing; "tasks" there would collide with
  the todo pane's vocabulary.

## Test plan

- [x] `npx vitest run src/test-kernel/cli src/test-kernel/progressView src/test-kernel/tools/BashTool.vitest.ts` — 207 files pass
- [x] `npm run typecheck:extension`, `eslint`, `prettier` clean
- [ ] PTY harness (`validate-tui.mjs`) exercised in CI — the stopped-follow-up expectation is a named constant plus one negative assertion, both updated

Made with [Cursor](https://cursor.com)