### PR TITLE
fix(ui): declare session labels from RunIdentity; drop finished bash

### DIFF
--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -11,12 +11,11 @@
 
 import { computed, signal, type Signal } from '@lit-labs/signals';
 import {
-  runIdentityName,
+  runIdentityDisplayName,
   type ActiveChildInfo,
   type RunIdentity,
   type StreamTabId,
 } from '@shared/schemas';
-import { getCleanAgentName } from '@shared/schemas/agent';
 
 import type { StreamSlice } from './cliState';
 
@@ -582,7 +581,7 @@ export function childExecutionLabel(
   // RunIdentity is the declared authority for the row label; agentName and
   // executionId are only fallbacks for a malformed roster entry.
   if (child.identity) {
-    return getCleanAgentName(runIdentityName(child.identity));
+    return runIdentityDisplayName(child.identity);
   }
   return child.agentName || child.executionId;
 }

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -10,11 +10,13 @@
 // transition/selector semantics this module implements.
 
 import { computed, signal, type Signal } from '@lit-labs/signals';
-import type {
-  ActiveChildInfo,
-  RunIdentity,
-  StreamTabId,
+import {
+  runIdentityName,
+  type ActiveChildInfo,
+  type RunIdentity,
+  type StreamTabId,
 } from '@shared/schemas';
+import { getCleanAgentName } from '@shared/schemas/agent';
 
 import type { StreamSlice } from './cliState';
 
@@ -575,9 +577,12 @@ export function childExecutionKey(child: ActiveChildInfo): string {
 }
 
 export function childExecutionLabel(
-  child: Pick<ActiveChildInfo, 'agentName' | 'executionId'>,
+  child: Pick<ActiveChildInfo, 'identity' | 'agentName' | 'executionId'>,
 ): string {
-  // The agent name is always set by the runtime, so it's the label;
-  // executionId is just a defensive fallback for a malformed entry.
+  // RunIdentity is the declared authority for the row label; agentName and
+  // executionId are only fallbacks for a malformed roster entry.
+  if (child.identity) {
+    return getCleanAgentName(runIdentityName(child.identity));
+  }
   return child.agentName || child.executionId;
 }

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -41,8 +41,8 @@ import {
   type ActiveChildInfo,
   type InquiryThreadUpdatedEvent,
 } from '@shared/schemas';
-import { getCleanAgentName } from '@shared/schemas/agent';
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { getCleanAgentName } from '@shared/schemas/agent';
 import { formatPhaseStageLabel } from '@shared/streams/streamStatusDisplay';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -9,7 +9,8 @@
  * don't have their own tab so they are not clickable.
  *
  * Rows are live children followed by the finished children the backend retains
- * (`ActiveChildInfo.finishedAt`); this panel never counts what it cannot list.
+ * (`ActiveChildInfo.finishedAt`); finished process (background bash) rows are
+ * ephemeral and filtered out here. This panel never counts what it cannot list.
  */
 
 // Third-party imports
@@ -36,9 +37,11 @@ import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import {
   STREAM_PHASE,
   WORKFLOW_TASK_STATUS_LABEL,
+  runIdentityName,
   type ActiveChildInfo,
   type InquiryThreadUpdatedEvent,
 } from '@shared/schemas';
+import { getCleanAgentName } from '@shared/schemas/agent';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { formatPhaseStageLabel } from '@shared/streams/streamStatusDisplay';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
@@ -263,7 +266,18 @@ export class BackgroundTasksPanel extends LitElement {
   }
 
   override render(): TemplateResult | typeof nothing {
-    const visibleSubagents = this.scope === 'all' ? this.subagents : [];
+    // Finished process children (background bash) are ephemeral — hide them
+    // even if a retained roster row still arrives from an older snapshot.
+    const visibleSubagents =
+      this.scope === 'all'
+        ? this.subagents.filter(
+            (child) =>
+              !(
+                child.identity?.kind === 'process' &&
+                child.finishedAt !== undefined
+              ),
+          )
+        : [];
     if (visibleSubagents.length + this.inquiries.length === 0) {
       return nothing;
     }
@@ -405,9 +419,11 @@ export class BackgroundTasksPanel extends LitElement {
       : undefined;
     const badge = taskStatusBadge(child);
     const idPrefix = `background-subagent-${index}`;
-    const nameTooltip = isClickable
-      ? `Go to ${child.agentName}`
+    // RunIdentity is the declared authority; agentName is only a fallback.
+    const displayName = child.identity
+      ? getCleanAgentName(runIdentityName(child.identity))
       : child.agentName;
+    const nameTooltip = isClickable ? `Go to ${displayName}` : displayName;
 
     return html`
       <div class="task-header">
@@ -437,7 +453,7 @@ export class BackgroundTasksPanel extends LitElement {
                 }
               : nothing
           }
-          >${child.agentName}</span
+          >${displayName}</span
         >
         <wa-tooltip for="${idPrefix}-name">${nameTooltip}</wa-tooltip>
         ${

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -37,12 +37,11 @@ import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import {
   STREAM_PHASE,
   WORKFLOW_TASK_STATUS_LABEL,
-  runIdentityName,
+  runIdentityDisplayName,
   type ActiveChildInfo,
   type InquiryThreadUpdatedEvent,
 } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { getCleanAgentName } from '@shared/schemas/agent';
 import { formatPhaseStageLabel } from '@shared/streams/streamStatusDisplay';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
@@ -421,7 +420,7 @@ export class BackgroundTasksPanel extends LitElement {
     const idPrefix = `background-subagent-${index}`;
     // RunIdentity is the declared authority; agentName is only a fallback.
     const displayName = child.identity
-      ? getCleanAgentName(runIdentityName(child.identity))
+      ? runIdentityDisplayName(child.identity)
       : child.agentName;
     const nameTooltip = isClickable ? `Go to ${displayName}` : displayName;
 

--- a/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
@@ -105,8 +105,9 @@ export const streamTabStyles = css`
     overflow: hidden;
   }
 
-  /* The metadata line stays out of the way until the row is focused or
-     selected — the full details also live in the tooltip. */
+  /* Reveal the metadata line on hover, focus, or selection. The agent name
+     rides a tooltip on this line when the title is the AI session one-liner. */
+  .tab-container:hover .tab-meta,
   .tab-container:focus-within .tab-meta,
   .tab-container.is-active .tab-meta {
     display: flex;

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -21,8 +21,8 @@ import {
   type StreamTabId,
   type StreamTabInfo,
 } from '@shared/schemas';
-import { getCleanAgentName } from '@shared/schemas/agent';
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { getCleanAgentName } from '@shared/schemas/agent';
 import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
 import {
   formatStreamStatusLabel,

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -16,11 +16,14 @@ import {
   DEFAULT_STREAM_METADATA_STATUS,
   STREAM_PHASE,
   STREAM_SUBSTATE,
+  runIdentityName,
   type StreamSubstate,
   type StreamTabId,
   type StreamTabInfo,
 } from '@shared/schemas';
+import { getCleanAgentName } from '@shared/schemas/agent';
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
 import {
   formatStreamStatusLabel,
   streamStatusDisplayKey,
@@ -88,8 +91,12 @@ function buildTooltip(
   const worktreeDisplay = info.worktree
     ? `Worktree: ${info.worktree.branch}${info.worktree.pr ? ` (#${info.worktree.pr.number})` : ''}`
     : undefined;
+  // Prefer the declared RunIdentity over the derived tab label.
+  const identityDisplay = info.identity
+    ? getCleanAgentName(runIdentityName(info.identity))
+    : undefined;
   const mainLine = [
-    info.label || info.name,
+    identityDisplay || info.label || info.name,
     `Status: ${statusLabel}`,
     modelDisplay && `Model: ${modelDisplay}`,
     worktreeDisplay,
@@ -192,6 +199,12 @@ export class StreamTab extends LitElement {
     const childToggleLabel = this.expanded
       ? 'Collapse background tasks'
       : childCountLabel;
+    // RunIdentity is the declared authority for what owns the stream. When the
+    // title is the AI one-liner, keep that explicit identity on metadata hover.
+    const metaAgentName =
+      stream.identity?.kind === 'agent'
+        ? getCleanAgentName(stream.identity.agent)
+        : undefined;
 
     return html`
       <div
@@ -257,7 +270,7 @@ export class StreamTab extends LitElement {
             this.compact
               ? nothing
               : html`
-                  <div class="tab-meta">
+                  <div id="stream-tab-meta" class="tab-meta">
                     ${
                       stream.worktree
                         ? html`<worktree-chip
@@ -303,7 +316,13 @@ export class StreamTab extends LitElement {
         ${
           this.compact
             ? nothing
-            : html`<wa-tooltip for="stream-tab-kind"
+            : html`${
+                  metaAgentName
+                    ? html`<wa-tooltip for="stream-tab-meta"
+                        >Agent: ${metaAgentName}</wa-tooltip
+                      >`
+                    : nothing
+                }<wa-tooltip for="stream-tab-kind"
                   >${
                     // Only agent runs have an execution-mode category; other
                     // stream kinds (and pending streams) show their label bare.
@@ -436,7 +455,22 @@ export class StreamTabs extends LitElement {
     nextVisited.add(stream.name);
 
     const children = (this.childStreamsByParent.get(stream.name) ?? []).filter(
-      (child) => !nextVisited.has(child.name),
+      (child) => {
+        if (nextVisited.has(child.name)) return false;
+        // Background bash/process tabs are ephemeral: once terminal, drop
+        // them from the Sessions tree even if autoClose has not removed the
+        // stream record yet.
+        if (child.identity?.kind === 'process') {
+          const childStatus = this.streamStates.get(child.name)?.status;
+          const phase =
+            childStatus === undefined ||
+            childStatus === DEFAULT_STREAM_METADATA_STATUS
+              ? undefined
+              : childStatus;
+          if (isTerminalOutcomePhase(phase)) return false;
+        }
+        return true;
+      },
     );
     const childCount = children.length;
     const expanded =

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -16,13 +16,12 @@ import {
   DEFAULT_STREAM_METADATA_STATUS,
   STREAM_PHASE,
   STREAM_SUBSTATE,
-  runIdentityName,
+  runIdentityDisplayName,
   type StreamSubstate,
   type StreamTabId,
   type StreamTabInfo,
 } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { getCleanAgentName } from '@shared/schemas/agent';
 import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
 import {
   formatStreamStatusLabel,
@@ -93,7 +92,7 @@ function buildTooltip(
     : undefined;
   // Prefer the declared RunIdentity over the derived tab label.
   const identityDisplay = info.identity
-    ? getCleanAgentName(runIdentityName(info.identity))
+    ? runIdentityDisplayName(info.identity)
     : undefined;
   const mainLine = [
     identityDisplay || info.label || info.name,
@@ -203,7 +202,7 @@ export class StreamTab extends LitElement {
     // title is the AI one-liner, keep that explicit identity on metadata hover.
     const metaAgentName =
       stream.identity?.kind === 'agent'
-        ? getCleanAgentName(stream.identity.agent)
+        ? runIdentityDisplayName(stream.identity)
         : undefined;
 
     return html`

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -443,12 +443,13 @@ export class SessionFactApplier {
   }
 
   /**
-   * Replace a parent stream's live child roster, retaining every child that
-   * just left it instead of folding it into a counter — a finished subagent
-   * keeps its executionId, agentName, status, startedAt, elapsed and toolName
-   * so hosts can list it. A retained row is only ever created from an entry
-   * that was already in OUR roster and is absent from `next`, so a first
-   * roster can never mark anything finished.
+   * Replace a parent stream's live child roster, retaining every non-process
+   * child that just left it instead of folding it into a counter — a finished
+   * subagent keeps its executionId, agentName, status, startedAt, elapsed and
+   * toolName so hosts can list it. Process children (background bash) are
+   * ephemeral and are never retained. A retained row is only ever created from
+   * an entry that was already in OUR roster and is absent from `next`, so a
+   * first roster can never mark anything finished.
    *
    * `next` decides roster membership and identity only. A row we already track
    * keeps the phase `recordChildPhase` wrote, so the status-machine fact stays
@@ -489,13 +490,21 @@ export class SessionFactApplier {
       // order), then the newly-vanished ones — so the list stays chronological
       // by construction and the cap evicts the oldest without a sort. A child
       // that reappears in `next` is live again, so drop its retained copy.
+      // Process children (background bash) are ephemeral: autoClose removes
+      // their stream tab, and retaining them only clutters Background Tasks.
+      const retainable = (child: (typeof previous)[number]): boolean =>
+        child.identity?.kind !== 'process';
       const retained = [
         ...previous.filter(
           (child) =>
-            child.finishedAt !== undefined && !nextIds.has(child.executionId),
+            child.finishedAt !== undefined &&
+            !nextIds.has(child.executionId) &&
+            retainable(child),
         ),
         ...previous
-          .filter((child) => vanishedIds.has(child.executionId))
+          .filter(
+            (child) => vanishedIds.has(child.executionId) && retainable(child),
+          )
           .map((child) => ({ ...child, finishedAt })),
       ].slice(-RETAINED_FINISHED_CHILDREN_CAP);
       return { ...prev, subagents: [...live, ...retained] };

--- a/src/shared/schemas/runIdentity.ts
+++ b/src/shared/schemas/runIdentity.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+// Local imports
+import { getCleanAgentName } from './agent';
+
 /**
  * What kind of thing owns a stream, declared once at the launch site and
  * persisted once by `registerExecution` (`ExecutionMeta.identity`). The struct
@@ -38,4 +41,9 @@ export function runIdentityName(id: RunIdentity): string {
     case 'multiAgentWorkflow':
       return id.workflowName;
   }
+}
+
+/** UI label for a run identity — strips a known source prefix from agent ids. */
+export function runIdentityDisplayName(id: RunIdentity): string {
+  return getCleanAgentName(runIdentityName(id));
 }

--- a/src/test-kernel/cli/ResumeHint.vitest.ts
+++ b/src/test-kernel/cli/ResumeHint.vitest.ts
@@ -78,11 +78,13 @@ describe('collectResumeTargets', () => {
         child({
           executionId: 'rev',
           agentName: 'reviewer',
+          identity: { kind: 'agent', agent: 'reviewer' },
           childStreamId: 'reviewer@m#rev' as StreamTabId,
         }),
         child({
           executionId: 'flow',
           agentName: 'builder',
+          identity: { kind: 'agent', agent: 'builder' },
           childStreamId: 'builder@m#flow' as StreamTabId,
         }),
       ],

--- a/src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts
+++ b/src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts
@@ -184,7 +184,7 @@ describe('background-tasks-panel', () => {
     element.remove();
   });
 
-  it('does not paint a retained process green when no terminal status arrived', async () => {
+  it('does not render finished process children — they are ephemeral', async () => {
     const element = createPanel();
     element.subagents = [
       {
@@ -192,30 +192,14 @@ describe('background-tasks-panel', () => {
         childStreamId: 'child-bash',
         agentName: 'bash',
         identity: { kind: 'process' as const, tool: 'bash' },
-        // A process has no child status source, so its retained row can keep
-        // the last in-flight phase. Claiming success here would render a
-        // failed command green.
-        status: 'running',
+        status: 'completed',
         finishedAt: 1_000,
       },
-    ];
-    document.body.append(element);
-    await element.updateComplete;
-
-    const badge = element.shadowRoot?.querySelector('wa-badge.task-status');
-    expect(badge?.getAttribute('variant')).toBe('neutral');
-
-    element.remove();
-  });
-
-  it('paints a retained process green only on an explicit completed status', async () => {
-    const element = createPanel();
-    element.subagents = [
       {
-        executionId: 'bash-2',
-        childStreamId: 'child-bash-2',
-        agentName: 'bash',
-        identity: { kind: 'process' as const, tool: 'bash' },
+        executionId: 'agent-1',
+        childStreamId: 'child-agent',
+        agentName: 'reviewer',
+        identity: { kind: 'agent' as const, agent: 'reviewer' },
         status: 'completed',
         finishedAt: 1_000,
       },
@@ -223,31 +207,37 @@ describe('background-tasks-panel', () => {
     document.body.append(element);
     await element.updateComplete;
 
-    const badge = element.shadowRoot?.querySelector('wa-badge.task-status');
-    expect(badge?.textContent).toBe('Finished');
-    expect(badge?.getAttribute('variant')).toBe('success');
+    const names = [
+      ...(element.shadowRoot?.querySelectorAll('.task-name') ?? []),
+    ].map((node) => node.textContent?.trim());
+    expect(names).toEqual(['reviewer']);
+    expect(
+      element.shadowRoot?.querySelector('wa-badge.task-status'),
+    ).toBeTruthy();
 
     element.remove();
   });
 
-  it('shows a failed retained process as failed', async () => {
+  it('still lists a live process child', async () => {
     const element = createPanel();
     element.subagents = [
       {
-        executionId: 'bash-3',
-        childStreamId: 'child-bash-3',
+        executionId: 'bash-live',
+        childStreamId: 'child-bash-live',
         agentName: 'bash',
         identity: { kind: 'process' as const, tool: 'bash' },
-        status: 'failed',
-        finishedAt: 1_000,
+        status: 'running',
       },
     ];
     document.body.append(element);
     await element.updateComplete;
 
-    const badge = element.shadowRoot?.querySelector('wa-badge.task-status');
-    expect(badge?.textContent).toBe('Failed');
-    expect(badge?.getAttribute('variant')).toBe('danger');
+    expect(
+      element.shadowRoot?.querySelector('.task-name')?.textContent?.trim(),
+    ).toBe('bash');
+    expect(
+      element.shadowRoot?.querySelector('wa-badge.task-status')?.textContent,
+    ).toBe('Running');
 
     element.remove();
   });

--- a/src/test-kernel/progressView/ProgressBackendRetainedChildren.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendRetainedChildren.vitest.ts
@@ -458,4 +458,24 @@ describe('retained finished children', () => {
 
     expect(backend.state.getStreamState(PARENT)?.subagents).toEqual([live]);
   });
+
+  it('does not retain vanished process children — they are ephemeral', () => {
+    const { backend } = createRecordingBackend();
+    seedParent(backend);
+    const agent = subagent('reviewer', {
+      identity: { kind: 'agent', agent: 'reviewer' },
+    });
+    const bash = subagent('bash', {
+      agentName: 'bash',
+      identity: { kind: 'process', tool: 'bash' },
+    });
+
+    applyRoster(backend, PARENT, [agent, bash]);
+    applyRoster(backend, PARENT, []);
+
+    const roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
+    expect(roster).toHaveLength(1);
+    expect(roster[0]?.executionId).toBe('reviewer');
+    expect(roster[0]?.finishedAt).toBeGreaterThan(0);
+  });
 });

--- a/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.ts
+++ b/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.ts
@@ -166,5 +166,98 @@ describe('stream-tab expand chevron', () => {
         ?.querySelector('wa-tooltip[for="stream-tab-kind"]')
         ?.textContent?.trim(),
     ).toBe('Multi-Agent Workflow');
+    expect(
+      tab?.shadowRoot?.querySelector('wa-tooltip[for="stream-tab-meta"]'),
+    ).toBeNull();
+  });
+
+  it('surfaces the agent name on the metadata hover when the title is a summary', async () => {
+    const tabs = await mountTabs({
+      streams: [
+        {
+          ...makeStream('engineer'),
+          agentCategory: AgentCategory.ToolUse,
+          description: 'Removing Supabase migrations from remote...',
+          model: 'grok45',
+          modelLabel: 'Grok 4.5',
+        },
+      ],
+    });
+
+    const shadow = tabs.shadowRoot?.querySelector('stream-tab')?.shadowRoot;
+    expect(shadow?.querySelector('#stream-tab-title')?.textContent).toContain(
+      'Removing Supabase migrations from remote...',
+    );
+    expect(shadow?.querySelector('.model')?.textContent?.trim()).toBe(
+      'Grok 4.5',
+    );
+    expect(
+      shadow
+        ?.querySelector('wa-tooltip[for="stream-tab-meta"]')
+        ?.textContent?.trim(),
+    ).toBe('Agent: engineer');
+  });
+
+  it('reads the agent tooltip from RunIdentity, not the derived tab label', async () => {
+    const tabs = await mountTabs({
+      streams: [
+        {
+          identity: { kind: 'agent', agent: 'custom:engineer' },
+          name: 'custom:engineer#abc',
+          // Deliberately stale/wrong derived label — identity is authoritative.
+          label: 'stale-label',
+          agentCategory: AgentCategory.ToolUse,
+          description: 'Removing Supabase migrations from remote...',
+          creationTimestamp: 1,
+        },
+      ],
+    });
+
+    expect(
+      tabs.shadowRoot
+        ?.querySelector('stream-tab')
+        ?.shadowRoot?.querySelector('wa-tooltip[for="stream-tab-meta"]')
+        ?.textContent?.trim(),
+    ).toBe('Agent: engineer');
+  });
+
+  it('hides finished process children from the Sessions tree', async () => {
+    const parent = {
+      ...makeStream('engineer'),
+      agentCategory: AgentCategory.ToolUse,
+    };
+    const liveBash: StreamTabInfo = {
+      identity: { kind: 'process', tool: 'bash' },
+      name: 'bash@tool#live',
+      label: 'bash',
+      parentStreamId: 'engineer',
+      creationTimestamp: 2,
+    };
+    const doneBash: StreamTabInfo = {
+      identity: { kind: 'process', tool: 'bash' },
+      name: 'bash@tool#done',
+      label: 'bash',
+      parentStreamId: 'engineer',
+      creationTimestamp: 3,
+    };
+    const tabs = await mountTabs({
+      streams: [parent],
+      childStreamsByParent: new Map([['engineer', [liveBash, doneBash]]]),
+      streamStates: new Map([
+        ['engineer', { status: 'running', lastTimestamp: 1 } as never],
+        ['bash@tool#live', { status: 'running', lastTimestamp: 2 } as never],
+        ['bash@tool#done', { status: 'completed', lastTimestamp: 3 } as never],
+      ]),
+    });
+
+    const childTabs = [
+      ...(tabs.shadowRoot?.querySelectorAll('.child-streams stream-tab') ?? []),
+    ];
+    expect(childTabs).toHaveLength(1);
+    expect(
+      childTabs[0]?.shadowRoot
+        ?.querySelector('#stream-tab-title')
+        ?.textContent?.trim(),
+    ).toBe('bash');
   });
 });


### PR DESCRIPTION
## Summary
- Sessions meta hover and tooltips (GUI + TUI) read display names from declared `RunIdentity` instead of derived labels / `agentName`
- Finished background bash/process children are ephemeral: not retained in the roster, and hidden from the Sessions tree and Background tasks panel
- Meta row reveals on hover so the `Agent: …` tooltip is reachable without selecting the session first

## Test plan
- [ ] Hover a Sessions row whose title is an AI one-liner — meta line shows worktree/time/model and tooltip reads `Agent: <name>` from identity (not a stale label)
- [ ] Run a background bash command; confirm it appears while live and disappears from Sessions + Background tasks when finished
- [ ] Confirm finished subagent rows are still retained/listed as before
- [ ] `npm test -- src/test-kernel/progressView/StreamTabsExpandChevron.vitest.ts src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts src/test-kernel/progressView/ProgressBackendRetainedChildren.vitest.ts src/test-kernel/cli/SubagentListDisplay.vitest.ts`


Made with [Cursor](https://cursor.com)