### PR TITLE
ci(review): bump texra-action to pick up response-field fix

### DIFF
--- a/.github/workflows/texra-code-review.yml
+++ b/.github/workflows/texra-code-review.yml
@@ -105,11 +105,11 @@ jobs:
 
       - name: TeXRA review
         if: steps.keys.outputs.present == 'true' && steps.merge-ref.outputs.available == 'true'
-        # texra-ai/texra-action v1.1.0; pin the reviewed release commit so
+        # texra-ai/texra-action v1.1.3; pin the reviewed release commit so
         # PR review behavior only changes through an explicit workflow update.
         # Keep the secret-bearing review job read-only: provider keys and the
         # GitHub token are present, so shell/tool mutations must stay disabled.
-        uses: texra-ai/texra-action/review@7800c7098bcb4d4bf956aa5dc72437eb5d0af6ac
+        uses: texra-ai/texra-action/review@94bd5336d31ac62b1a196c6039a71d69e15ba0c5
         with:
           prompt-file: .trusted-review-prompt/.github/prompts/texra-code-review-prompt.md
           approval-policy: yolo


### PR DESCRIPTION
## Problem

Every TeXRA CI review since ~Aug 3 posted the fallback text instead of the actual review (e.g. #9817):

> TeXRA completed without a final review message.

`@texra-ai/cli` 0.40.0 (published Aug 3) includes #9518, which canonicalized the tool-use result fields (`lastResponse` -> `response`, `touchedFiles` -> `files`). The pinned texra-action still read only `result.lastResponse` from the run's result JSON, so it always saw an empty final message.

## Fix

texra-ai/texra-action#6 makes the action read the canonical `response` field with a legacy `lastResponse` fallback. This PR bumps the pin to that commit (`94bd533`, to be tagged v1.1.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNB2P6rHb16ShoEN3RTKkQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency pin with no application code changes; restores expected review comment behavior with minimal blast radius.
> 
> **Overview**
> Updates the **TeXRA Code Review** workflow pin from **texra-ai/texra-action v1.1.0** to **v1.1.3** (`94bd533`), so CI reviews post the real model output instead of the fallback *"TeXRA completed without a final review message."*
> 
> That regression came from `@texra-ai/cli` 0.40.0 putting the final text in the canonical **`response`** field while the older action only read **`lastResponse`**. The bumped action reads **`response`** with a legacy **`lastResponse`** fallback; no other workflow inputs or steps change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 963c02111c147d2b2dd987aca56f992020e58242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->