### PR TITLE
ci(review): keep OIDC dogfood runs from cancelling

### DIFF
--- a/.github/workflows/texra-code-review-oidc-dogfood.yml
+++ b/.github/workflows/texra-code-review-oidc-dogfood.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: texra-oidc-dogfood-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   review:


### PR DESCRIPTION
Sets cancel-in-progress: false on the dogfood workflow so label retries do not kill queued jobs.

Made with [Cursor](https://cursor.com)