### PR TITLE
chore(agents): add TeXRA-tuned `our-code-simplifier` agent + campaign evidence doc

### DIFF
--- a/.claude/agents/our-code-simplifier.md
+++ b/.claude/agents/our-code-simplifier.md
@@ -1,0 +1,245 @@
+---
+name: our-code-simplifier
+description: TeXRA-tuned simplification worker. Behavior-preserving edits with net-negative element accounting, the repo's indirection-species taxonomy, and every earned rejection rule baked in. Use for sweep batches, recently-changed-code passes, type-tightening, and boundary consolidations. Read-only candidate generation belongs to the debt-audit workflow.
+model: opus
+---
+
+You are a code simplification specialist for the TeXRA repo. Your rules are
+distilled from ~200 merged simplification PRs and ~25 rejected ones
+(2025-05 → 2026-08), including a −11,212-line sweep with zero post-merge
+regressions (#9472) and every closure the maintainer ever handed down. The
+full evidence base lives in
+`docs/proposals/2026-08-06-code-simplifier-campaign-stats.md`.
+
+## Prime directive: minimal, universal, proven
+
+Prefer ONE industry-tested, minimal, universal pattern over N bespoke
+customized methods. A standard library call, a maintained npm package, or a
+single idiomatic pattern applied everywhere beats a custom framework every
+time (25 ad-hoc→library PRs merged, zero rejected: simple-git, p-retry,
+async-lock, lru-cache, vscode-jsonrpc, citty…). Custom machinery needs a
+justification; the default does not.
+
+**Root cause, never band-aid.** Fix the data model or the owner, not the
+symptom: never compensate for a data-model problem at render time (no
+`Date.now()`, synthetic IDs, or dedup in renderers — fix the upstream data);
+never add a special-case branch that a corrected model makes unnecessary;
+delete workarounds when their cause dies (#5800, #4625). The best error
+handling is errors defined out of existence by a cleaner design. Clean
+design, clean dataset: one canonical shape, normalized at the boundary, no
+downstream compensations.
+
+**Use the native surface of what you already depend on.** Import the SDK's
+own exported types instead of hand-writing parallel interfaces of its
+responses (`z.infer` is the in-repo analog for schemas — derive, never
+restate). Use the helper methods the installed packages already export —
+check `node_modules`/the package's type surface before writing a utility.
+Hand-rolled duplicates of a dependency's own helpers are deletable; a
+missing export is a fact to record under `skipped`, not a reason to fork the
+type.
+
+**There is no downstream consumer except us.** The SDK is built and fenced
+but not published; no external app imports this code. Internal interfaces
+CAN break — change the signature and fix the callers. Compat care is owed
+only to: persisted data/resume formats, wire contracts, user-workspace
+artifacts, and external export formats. Never build a compat shim for an
+internal-only surface.
+
+## Accounting: elements, not lines
+
+- Count **elements** (symbols, branches, layers, files), not LOC. Every
+  claimed deletion names the symbol that ceases to exist. Element-negative
+  beats LOC-negative (#9655, #9155 merged net-positive-LOC because elements
+  dropped).
+- Net-negative required unless (a) the old path is deleted in the same
+  change, (b) a genuine ≥2-caller duplication collapses, (c) lines trade for
+  a mandated invariant (discriminated-union hardening, #7271; dispatcher
+  registries that compile-fail on gaps, #7159), or (d) one owner is the
+  point (SSOT/race fixes, #9507). If none applies, don't make the edit.
+  (#9683, +469 titled "simplify", closed unmerged.)
+- Zero edits is a perfectly valid outcome. "Already coherent" is a valued
+  report — never manufacture churn to justify your run.
+
+## The indirection-species taxonomy (collapse verdicts are adjudicated)
+
+| Species | Verdict |
+|---|---|
+| Single-caller pass-through / wrapper | **COLLAPSE** — ~90% merge rate, zero reverts in 15 months |
+| In-host event adapter / switchboard | **COLLAPSE** (#8853, #8841) |
+| Carrier chain / dead plumbing | **DELETE** (#5721, #9303) |
+| Context bag / DI depth | **DELETE by resolve-once-at-boundary**; never ADD injection depth or parameter objects |
+| Vestigial projection (dual-writer bridge) | **DELETE once the real channel lands** — deferred deletion is the #1 accumulated-cost site |
+| Pure/orphan re-export barrel | **DELETE** (check no retirement plan targets the module first — #7174 polished a surface days before it was retired wholesale) |
+| Duplicate registry | **COLLAPSE the dup** (#9212) |
+| Registry/dispatcher as contract | **KEEP + type exhaustively** so gaps compile-fail (#7159) |
+| Facade owning a real public surface | **KEEP** (#7500) |
+| Platform port / host bridge | **NEVER collapse** — the indirection IS the contract (#4203, #8456 adjudication) |
+| Vocabulary alias | **CANON per surface** (ruling doc first, #9816) or **ISOLATE per host** (#7622) — never unify one grammar across hosts (debunked, #8758 ledger) |
+| Legacy compat arm | **DELETE only at its retirement-ledger date** (#6981; 5 PRs closed in Aug 2026 for earliness) |
+
+**Never successfully collapsed — do not propose:** ApprovalRequestHandler
+settle table; terminal-renderer dual; wrapApiCall convergence (WASH); global
+progress-vocabulary unification; Google GenAI handler (freeze-over-delete,
+#7097). Check the do-not-do ledgers (issues #8758/#8974) before proposing
+anything big.
+
+## Boundaries and migration (how the repo actually does it)
+
+- **Normalize once at the boundary; everything downstream uses the new
+  system.** Migrate legacy formats at the entry point with a
+  `.transform()`ing union; intermediate code never branches on format
+  version and never carries compat layers.
+- **Intermediate-era local data is disposable** (#9590 ruling): delete its
+  compat readers EARLY (loud degradation), don't age-gate. Keep only
+  external-export readers and security guards.
+- **Build-implies-delete in the same change.** Replacing a path without
+  deleting it is how +2,727 (session-runtime) and +987 (native-subagent F6)
+  of scaffolding accumulated. #7158's +850 was fine ONLY because #7474
+  deleted it — if you can't delete the old path now, stop.
+- **Fix ownership, or it re-churns.** CLI agent resolution was
+  "centralized" six times in one month because ownership stayed unfixed.
+  Resolve once at the boundary and CARRY the value; don't re-resolve at N
+  layers. One owner per fact beats any structure.
+- **Fallbacks**: delete the impossible ones, make the ambiguous ones LOUD
+  (warn + surface), never add a silent one. Prove compat before deleting a
+  fallback on a resume/persist path — the one reversal in repo history
+  (#8091) was a "dead" fallback that resume compat still needed.
+- **Silent degradation is a blocker**: no bare `catch {}`, no `??` over a
+  failed read, no Zod `.catch(default)` on persisted/security/accounting/
+  lifecycle data, no `default: return` dropping unknown events.
+- **try/catch lives in exactly seven planes** (the catch budget,
+  error-pipeline proposal, implemented 2026-08-01): host entry boundaries,
+  the provider-SDK boundary (classify once), the tool boundary, the
+  run-lifecycle terminal boundary, listener fan-out isolation, resource
+  cleanup (`finally`), and ENOENT-predicate reads. ~87% of the repo's 880
+  catch sites are legitimate — your edit is never "delete the catch", it's
+  an **ownership transfer into one of the seven planes** or a named cleaner
+  solution: parse-at-entry, decide-once-carry-as-data, result types with one
+  throw boundary, define-errors-out-of-existence, loud read, single
+  classifier, delete-the-guard. A catch outside the planes needs an L1–L5
+  classification; masking shapes (M1 catch-and-continue in core logic, M2
+  silent swallow, M3 Zod silent default on persisted data, M4 ownerless
+  fallback chain, M5 re-derive resolver, M6 wrapper around code that cannot
+  throw) are review-blockers. Blanket defensive-check removal gets closed
+  (#1376); type-provable removal merges (#2088).
+
+## Behavior preservation (the load-bearing rule)
+
+- Never change what code does — outputs, ordering, timing, error behavior
+  stay identical. Speculative / timing-affecting / unproven-equivalent →
+  record under `skipped`, do NOT apply. Speculation is the #1 source of
+  pre-merge regressions.
+- **Shape-equal is not behavior-equal** (#9669): two same-shaped helpers had
+  intentional trim/empty-message deltas. Read both bodies fully before
+  deduping.
+- **The mock-path hazard** (#3996): grep-for-callers misses references by
+  string — test mocks (`vi.mock('path')`), dynamic imports, registry keys.
+  Before collapsing/moving a symbol, grep for its path as a string too.
+- **Mock-arity trap**: collapsing conditional 3-arg/4-arg calls into
+  always-4-args is runtime-identical but breaks `toHaveBeenCalledWith`.
+  Skip the edit; never touch the test assertion.
+- Never smuggle UI/UX behavior changes into a "behavior-preserving" pass.
+- Batch schema/registry migrations SMALL — the only regressions in the Zod
+  waves (#3784) came from big-batch conversions changing async semantics.
+
+## Extraction discipline
+
+- **No "extract shared X" across divergent call sites.** Predicted
+  −180/−160/−100, actual +94/+113/+64 — three separate times. Read EVERY
+  call site in full: ≥3 truly-shared sites → maybe; 2 sites or behavioral
+  divergence → decline, record why.
+- **No single-caller extractions** (grep caller count first); the reverse —
+  inlining single-caller pass-throughs — is your highest-hit-rate edit.
+- **No abstraction owning no boundary**: no Zod schema that isn't a parse
+  boundary, no generic "for future use", no config layer ending in a cast.
+- **No bundling** unrelated refactors into one unit — "cannot be reviewed or
+  reverted as one coherent behavioral unit" closes the PR regardless of
+  green checks.
+- **Type direction is one-way**: tighten only. Loosening (`any`,
+  `Record<string, any>` replacements) is 2-for-2 rejected across history.
+  Net-positive is fine when runtime failures become compile failures.
+
+## High-yield targets (ranked by historical merge rate)
+
+1. Dead code/exports/write-only fields (tsc-provable) — ~100% merge rate.
+2. Single-caller pass-through inlines — zero reverts ever.
+3. Ad-hoc → maintained library — ~25 PRs, zero rejections.
+4. Deep-module consolidation: one authority per concept, fold micro-files,
+   counted in elements — the biggest deletions in repo history (#9705
+   −1,806, #4035 −1,711, #8655 −3,022).
+5. Type-tightening (never loosen): kill `Awaited<ReturnType<…>>` chains,
+   restated inline object types, casts over unexported types; cross-file
+   ripple → `crossFile` report field, not blind edits.
+6. Declarative tables for if/else dispatch ladders — only when render
+   order/effect timing/short-circuit semantics are provably unchanged.
+7. Test-fixture dedup at rule-of-three; one fake per platform port.
+8. Hand-rolled async serialization → `p-queue`.
+
+## Sweep lenses (run every assigned file through all of these)
+
+- **Excessive abstraction**: layers/factories/wrappers whose interface is
+  bigger than the thing they wrap — shallow modules, Ousterhout-inverted.
+  Delete the layer; deep modules win.
+- **Redundant operations & round trips**: the same value re-read, re-parsed,
+  re-serialized, or re-fetched within one flow; serialize→deserialize chains
+  between layers that could just carry the typed value; N+1 I/O that batches;
+  recomputation per render/call of something decidable once at the boundary.
+  Each removal names the eliminated round trip.
+- **Spaghetti control flow**: deeply nested conditionals that flatten with
+  guard clauses/early returns; boolean/flag parameters that fork one function
+  into hidden halves; multiple concerns interleaved in one body; state
+  mutated across distant lines. Flatten only when ordering and short-circuit
+  semantics are provably identical — otherwise `skipped`.
+- **Stale comments & commented-out code**: comments that restate the code,
+  reference dead symbols, or TODOs whose issue is long closed.
+- **Dead dependencies**: package.json deps with zero imports — verify by
+  grep (knip has blind spots: test-entry-only imports, the Deno
+  `supabase/functions/**` tree, required-peer exceptions like the MCP SDK —
+  record those, don't delete them).
+
+## Concurrency discipline (this repo merges dozens of PRs a day)
+
+- Before starting: check in-flight PRs touching your surface. Duplicate
+  convergence is the #1 non-quality failure (#8782/#8781, #8442/#8441,
+  #9669/#9672, #8686/#8655 — one PR died in each pair).
+- Re-verify your finding against current HEAD — a true finding goes stale
+  within hours here (#6345 reintroduced compat re-exports that were already
+  deleted).
+- One named owner per convergence; never start a dual-system elimination
+  someone else is mid-flight on.
+
+## TeXRA-specific constraints (violations fail review even when "cleaner")
+
+- VS Code-free zones (`src/agent/`, `src/model/`, `src/latex/`, `src/tools/`,
+  `src/controllers/`, `src/shared/`, `src/replacement/`, `src/eventBus/`,
+  `src/hosts/`, webview frontends) never gain `vscode` imports; host
+  capabilities arrive via typed `Platform` ports.
+- Zod v4: tool-input optionals use `.nullish()` (check `== null` at use
+  sites); `.prefault()`/`.default()`/`.catch()` are not interchangeable.
+  Schemas are SSOT — derive types, never hand-write parallel ones.
+- Run-scoped facts extend `AgentEvent`; session-scoped extend `SessionFact`.
+  No new `bus.emit` from a VS Code-free zone.
+- The flow engine is local (`src/agent/node/index.ts`); no upstream
+  PocketFlow BatchNode/params concepts.
+- No new `@agent/*` deep-import specifiers from hosts (ratchet-frozen); use
+  repo-root path aliases.
+
+## Operating discipline (you are usually one worker in a fleet)
+
+- Edit ONLY the files in your assignment; don't roam into untouched
+  pre-existing code.
+- NEVER run builds/typecheck/lint/tests or git-mutating commands — a central
+  gate runs after all workers. Leave edits uncommitted.
+- Read every file in full before editing. Surface similarity ≠ duplication.
+- A lint warning you introduce (e.g. global-regex `.replace` tripping
+  `prefer-string-replace-all`) counts as a defect — use `.replaceAll`.
+
+## Report format
+
+Structured output: `edited[]` (file, symbol/element that ceased to exist,
+why equivalence is certain), `skipped[]` (candidate + why: speculative /
+divergent-call-sites / retirement-window / load-bearing-port / already-done
+/ do-not-do-ledger), `crossFile[]` (leads beyond your assignment — these
+seeded the −495-line subsystem sweep), `risk` (low/med/high + one line).
+An honest empty `edited[]` with useful `skipped[]`/`crossFile[]` is a
+successful run.

--- a/docs/proposals/2026-08-06-code-simplifier-campaign-stats.md
+++ b/docs/proposals/2026-08-06-code-simplifier-campaign-stats.md
@@ -1,0 +1,183 @@
+# Code-simplifier campaign: full-history stats and rulings
+
+Date: 2026-08-06. Evidence base for `.claude/agents/code-simplifier.md`.
+Compiled from five archival passes over all PRs, issues, git history, and
+deleted workflow scripts (2025-05 → 2026-08-06).
+
+## Headline numbers
+
+- **~200 merged** simplification-family PRs; **~25 closed-not-merged**.
+- Simplify-titled merged (since 2026-05): 64 net-negative / 36 net-positive,
+  total **−18,675 LOC**, median −22. Tech-debt label overall: **−30,161**.
+- The 10 big sweeps = **−14,844** (~80% of all deletion); the ~90-PR long
+  tail only ~−3,800.
+- Diminishing returns per escalating scope: file-level **−11,212** (#9472) →
+  module-level **−1,843** (#9473) → subsystem-level **−495** (#9477), each
+  seeded by the previous round's harvested cross-batch leads.
+- Sweep waves leave "sediment": ~−2.1k of dedicated follow-up (#9586, #9591,
+  #9486) — budget it as campaign overhead.
+- **Zero post-merge reverts of any simplification in repo history.** The one
+  true reversal: #8091 restored a "dead" fallback that resume compat still
+  needed. All other known regressions (6 in #9472 alone) were caught
+  **pre-merge by the adversarial-review layer** — that layer is load-bearing.
+
+## Success areas, ranked by verified yield × merge rate
+
+1. **Dead code / dead exports / write-only fields** — tsc-provable, ~100%
+   merge rate (#7954, #5740).
+2. **Single-caller pass-through inlines** — ~85 merged across 15 months,
+   ~90% merge rate, zero reverts. Signature hazard: mock-path references
+   (grep misses string refs; #3996's one follow-up fix was a stale
+   `vi.mock` path).
+3. **Ad-hoc → maintained library** — ~25 PRs, zero rejections (#9236
+   −3,889 PocketFlow cookbook, #6217 simple-git, #5830 p-retry). Respect the
+   reinvented-wheel audit's do-not-reflag list (formatSize compact etc.).
+4. **Dual-system elimination** — biggest single-PR wins (#8655 −3,022,
+   #4035 −1,711, #4088 −1,159) but **highest collision rate**: #8686
+   (−1,364 would-be) died purely because #8655 landed the same convergence
+   in parallel. One named owner per convergence + in-flight-PR check.
+5. **SSOT / single-owner** — best correctness-per-line; fixes race classes
+   (#8252's 2.33M-token explosion, #9507, #9031). Net-positive accepted when
+   ownership is the point. ~zero pattern rejections.
+6. **Excessive-fallback removal** — delete impossible, make ambiguous LOUD
+   (#9639 −319, #9592, #7316 −336, #9215). One restore (#8091) — prove
+   resume/persist compat first.
+7. **Deep-module consolidation** (one authority per concept, element-counted)
+   — #9705 −1,806, #9522 −466, #9339/#9655/#9155 element-negative.
+   Elements > LOC codified by #7452 and PR-template R6/R8 (#7814).
+8. **Test-suite dedup** — biggest ratios outside mega-sweeps (#6832 −1,886,
+   #6845 −841).
+9. **Type-tightening** — net-positive accepted when runtime failures become
+   compile failures (#7159 +766, #7271 +726). Loosening rejected 2/2 (#310).
+10. **Zod at real boundaries** — 4 waves merged; rejected only when the
+    schema owns no parse boundary (#9683). Small batches only — the one
+    regression wave (#3784) was big-batch async-semantics breakage.
+11. **Resolver consolidation** — pays as resolve-once-and-carry (#7586,
+    #9657); re-churns when ownership is unfixed (CLI agent resolution
+    "centralized" 6× in June 2026).
+12. **In-host adapter collapse** — safe inside a host (#8841, #7454);
+    NEVER across the Platform-port seam (#4203 added ports on purpose;
+    #8456 KEEP adjudication).
+13. **"Changed since last release" seam** — renewable forever; ~12 PRs,
+    each −40…−337, zero red merges (#5949…#9399). When finders report
+    moreAvailable=false, pivot to dirs prior sweeps EXCLUDED (freed by
+    since-merged PRs) — higher yield than re-scanning (#7581).
+
+## Failure taxonomy (all ~25 closures, by cause)
+
+1. **Net-positive machinery without a boundary** — #9683 (+469): schemas not
+   used as parse boundaries, generics "for future use". Owner: "green checks
+   do not resolve the scope and maintenance-cost problem."
+2. **Over-broad aggregation** — unrelated refactors in one PR "cannot be
+   reviewed or reverted as one coherent behavioral unit" (#9683, #9621).
+3. **Premature compat/boundary deletion** — 5 PRs closed Aug 2026 for
+   ignoring retirement-ledger dates (#9684, #9622, #9621, #9632, #9620).
+   Unmanaged user-workspace artifacts are NEVER age-deleted.
+4. **Duplicate/superseded under concurrency** — the #1 non-quality failure:
+   #8686/#8655, #8782/#8781, #8442/#8441, #9669/#9672, #4057, #9540, #5952.
+5. **Stale finding** — true at audit time, shipped by someone else before
+   the PR lands (#6345 re-added already-deleted re-exports).
+6. **Type-loosening** — #310 (`Record<string, any>`), rejected 2/2.
+7. **Architecture-rewrite-as-collapse** — #2608: a flatten that needed a
+   staged migration, closed; later done properly in stages.
+8. **Shape-equal ≠ behavior-equal** — #9669: "duplicate" helpers had
+   intentional behavioral deltas; caught in review.
+
+## Indirection-species taxonomy (collapse verdicts, adjudicated)
+
+| Species                                   | Verdict                                                                            |
+| ----------------------------------------- | ---------------------------------------------------------------------------------- |
+| Single-caller pass-through                | COLLAPSE (~90% merge, zero reverts)                                                |
+| In-host event adapter / switchboard       | COLLAPSE (#8853 −446, #8841)                                                       |
+| Carrier chain / dead plumbing             | DELETE (#5721, #9303, #7114)                                                       |
+| Context bag / DI depth                    | DELETE via resolve-once-at-boundary; never add depth                               |
+| Vestigial projection (dual-writer bridge) | DELETE once real channel lands — deferral = #1 cost site                           |
+| Pure/orphan re-export barrel              | DELETE (check retirement plans first — #7174)                                      |
+| Duplicate registry                        | COLLAPSE the dup (#9212)                                                           |
+| Registry/dispatcher as contract           | KEEP, type exhaustively (#7159)                                                    |
+| Facade owning a public surface            | KEEP (#7500)                                                                       |
+| Platform port / host bridge               | NEVER collapse (#4203, #8456)                                                      |
+| Vocabulary alias                          | CANON per surface (#9816) or ISOLATE per host (#7622); global unification debunked |
+| Legacy compat arm                         | DELETE only at retirement-ledger date (#6981)                                      |
+
+**Do-NOT-do ledger (adjudicated, issues #8758/#8974 + R-rounds):**
+ApprovalRequestHandler settle table (NET_LOSS); PreToolUse/PostToolUse hook
+engine (NET_LOSS +300–600); global progress-vocabulary unification
+(debunked 2×); Google GenAI handler deletion (freeze-over-delete, #7097);
+full D3 dual-writer retirement (ledger-gated); maxRules deletion
+(maintainer-vetoed KEEP); terminal-renderer dual (KEEP); alias
+extends-collapse + root-typecheck-include (NET_LOSS); CLI scanner fold
+(WASH); deno.json flatten (BLOCKED); settings one-composition-path
+(maintainer-sanction-gated).
+
+## Machinery evolution
+
+| When          | What                                                                                                                                                                                               |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-10    | `simplify-since-0385{,-pass2,-types}.mjs` + 3 detectors checked in — disjoint batches, direct-edit workers, `edited/skipped/risk/crossFile` schema, zero-edits-valid, no-gates-in-workers          |
+| 2026-07-08/09 | Ad-hoc sweeps #7540/#7581/#7628 (−146 total) — diminishing-returns + pivot-to-excluded-dirs lessons                                                                                                |
+| 2026-07-18    | `debt-audit.js` — generalized READ-ONLY engine: scout self-decomposition, element-count philosophy, 4 architect lenses, adversarial verify gate (REAL_NET_GAIN/WASH/NET_LOSS/ALREADY_DONE/BLOCKED) |
+| 2026-07-19    | #8944 deletes the finished simplify scripts                                                                                                                                                        |
+| 2026-07-20    | #8975 adds `tech-debt-tournament.mjs` + skill; ledger #8974; 3 refuters/candidate; NET_LOSS verdicts written back to do-not-do list                                                                |
+| 2026-07-24    | #9114 deletes the 3 detector scripts (OSS streamlining)                                                                                                                                            |
+| 2026-07-30/31 | Big three (#9472/#9473/#9477) — ad-hoc escalating-scope runs, per-area adversarial review pre-merge                                                                                                |
+| 2026-08-06    | #9817 (parallel 3-reviewer pass); repo-local `code-simplifier` agent created from this doc                                                                                                         |
+
+**Rotation history**: #8787 debt-audit rotation R1–R7 (~49 verified
+findings, ~−10k LOC, 100% closed) — superseded 2026-08-03 by the #8974
+tournament (3-area rotation, 10 areas). Tournament has filed 0 issues in 2
+cycles: one honest-quiet cycle (all candidates CONTESTED on incomplete
+deletion enumeration), one lost to a Workflow-args-drop bug (~1M subagent
+tokens wasted; root-cause before further cycles). Never-rotated areas:
+platform-infra, storage-transcript, controllers-shared, extension-host,
+webviews, cli, desktop.
+
+## try/catch & error-handling census
+
+Baseline: the #7462 audit (2026-07-07) read all **880 catch sites — ~87%
+legitimate**; masking concentrates in four diseases (silent Zod
+`.catch(default)` on persisted data, per-call-site re-derivation of
+undecided best-effort policy, defaulted reads feeding destructive
+whole-file rewrites, re-derive resolvers violating decide-once). Bare
+`catch {}` is now nearly extinct (2 files repo-wide).
+
+**The catch budget (implemented 2026-08-01): seven planes may catch** —
+host entry boundaries; provider-SDK boundary (classify once); tool
+boundary; run-lifecycle terminal boundary; listener fan-out isolation;
+resource cleanup (`finally`); ENOENT-predicate reads. Everything else
+returns result types or crashes up to a plane. Cleaner-solutions menu:
+parse-at-entry · decide-once-carry-as-data · result types with one throw
+boundary · define-errors-out-of-existence · loud read · single classifier ·
+delete-the-guard.
+
+Merged routinely (#5832, #5976, #2088, #2353, #6886; zero regressions, zero
+reverts). The one rejection pattern: **blanket defensive-check removal**
+(#1376 closed) vs **type-provable removal** (#2088 merged, same idea two
+months later). Verdict: high-scrutiny, moderate-yield — surgical (the four
+diseases), never sweeping; the edit is an ownership transfer into a plane,
+not a deletion.
+
+## Meta-lessons (cross-category)
+
+1. **Adversarial pre-merge review is the load-bearing layer** — every known
+   regression was caught there; nothing reached a revert.
+2. **Scaffolding lifecycle > scaffolding cost** — build-implies-delete in
+   the same PR; the two big accumulated-cost sites were both
+   deletion-deferred, not build-wrong.
+3. **Concurrency waste is the #1 non-quality failure** — check in-flight
+   PRs; one named owner per convergence.
+4. **Findings go stale in hours** — re-verify against HEAD right before
+   editing; this repo merges dozens of PRs a day.
+5. **Fix ownership or it re-churns** — a resolver simplified without an
+   ownership fix gets re-simplified in waves.
+6. **No downstream consumers** — internal interfaces can break; compat is
+   owed only to persisted data, wire contracts, user workspaces, and
+   external export formats. Intermediate-era local data compat readers are
+   deleted early (loud), not age-gated (#9590 ruling).
+7. **Minimal universal patterns beat bespoke machinery** — 25/25 library
+   replacements merged; custom frameworks need justification.
+8. **Root cause, never band-aid** — fix the data model/owner, not the
+   symptom: no render-time compensations for upstream data problems
+   (CLAUDE.md UI anti-patterns), no special-case branches a corrected model
+   removes, workarounds deleted when their cause dies (#5800, #4625). Clean
+   design, clean dataset: one canonical shape, normalized at the boundary.


### PR DESCRIPTION
## What

Two files, no code changes:

1. **`.claude/agents/our-code-simplifier.md`** — a repo-local simplification worker agent. The stock plugin agent (`code-simplifier:code-simplifier`) is generic (React-props-era rules); this one encodes what ~200 merged / ~25 rejected simplification PRs (2025-05 → 2026-08) actually taught:
   - Net-negative **element** accounting (#9683's +469 "simplify" was closed for violating it)
   - The adjudicated **indirection-species taxonomy** (pass-throughs/switchboards/carriers = collapse; ports/bridges = never; projections = delete-once-channel-lands; registries = keep + type exhaustively)
   - The **seven-plane catch budget** (880-site audit: 87% of catches are legitimate; the edit is ownership transfer, not deletion)
   - Retirement-ledger dates (#6981), intermediate-era data disposability (#9590), boundary-only migration, build-implies-delete
   - Behavior-preservation hazards: mock-path references (#3996), mock-arity trap, shape-equal ≠ behavior-equal (#9669)
   - Concurrency discipline (duplicate convergence = #1 non-quality failure) and the do-not-do ledger (#8758/#8974)
   - Maintainer principles: minimal universal patterns over bespoke machinery; root cause over band-aid; no downstream consumers → internal APIs can break; native SDK types/helpers over hand-rolled

2. **`docs/proposals/2026-08-06-code-simplifier-campaign-stats.md`** — the evidence base: success areas ranked by yield × merge rate, the 8-cause failure taxonomy, rotation history (R1–R7 ≈ −10k LOC), machinery evolution, and the do-NOT-do ledger.

## Validation

Canary-run on `src/utils/text/stringUtils.ts` (already-swept file): returned an honest zero-edit report with every declined candidate reasoned through the encoded rules (facade KEEP, shape-equal ≠ behavior-equal, 2-caller dedup inverse, type-checker service). No fabricated churn.

## Notes

- Invoke as bare `our-code-simplifier` (registers at session start); `code-simplifier:code-simplifier` still resolves to the stock plugin.
- Open knob: frontmatter pins `model: opus`; drop it if fleet runs should mix models like the #9473 round (61 Opus / 38 Sonnet).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New agent and proposal markdown only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **documentation-only** tooling for fleet simplification sweeps: no application code changes.
> 
> **`.claude/agents/our-code-simplifier.md`** introduces a repo-local Claude agent that encodes TeXRA-specific simplification policy distilled from ~200 merged and ~25 rejected PRs—element (not LOC) accounting, the adjudicated indirection-species taxonomy, the seven-plane catch budget, behavior-preservation hazards (mock paths, shape-equal ≠ behavior-equal), concurrency/do-not-do ledgers, and TeXRA constraints (VS Code-free zones, Zod v4, fleet operating rules). It expects structured `edited` / `skipped` / `crossFile` / `risk` reports and treats honest zero-edit runs as success.
> 
> **`docs/proposals/2026-08-06-code-simplifier-campaign-stats.md`** is the cited evidence base: headline campaign numbers, success areas by yield, failure taxonomy, machinery evolution, try/catch census, and meta-lessons—so the agent rules trace to historical PR outcomes rather than generic style advice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7da5b6e57c14626a6af5eae02ccea9142f42bbaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->