### PR TITLE
docs: drop the Python-era section from the simplifier census

### DIFF
--- a/docs/proposals/2026-08-06-code-simplifier-campaign-stats.md
+++ b/docs/proposals/2026-08-06-code-simplifier-campaign-stats.md
@@ -1,8 +1,11 @@
 # Code-simplifier campaign: full-history stats and rulings
 
-Date: 2026-08-06. Evidence base for `.claude/agents/code-simplifier.md`.
-Compiled from five archival passes over all PRs, issues, git history, and
-deleted workflow scripts (2025-05 → 2026-08-06).
+Date: 2026-08-06. Evidence base for `.claude/agents/our-code-simplifier.md`.
+Compiled from six archival passes over all PRs, issues, git history, and
+deleted workflow scripts. Scope: the TypeScript repo, 2025-05 → 2026-08-06
+(the pre-port Python era, 2024-05 → 2025-02, is excluded as a different
+codebase; its only durable lesson — delete wholesale when there are no
+downstream consumers — appears in the meta-lessons).
 
 ## Headline numbers
 
@@ -121,7 +124,7 @@ extends-collapse + root-typecheck-include (NET_LOSS); CLI scanner fold
 | 2026-07-20    | #8975 adds `tech-debt-tournament.mjs` + skill; ledger #8974; 3 refuters/candidate; NET_LOSS verdicts written back to do-not-do list                                                                |
 | 2026-07-24    | #9114 deletes the 3 detector scripts (OSS streamlining)                                                                                                                                            |
 | 2026-07-30/31 | Big three (#9472/#9473/#9477) — ad-hoc escalating-scope runs, per-area adversarial review pre-merge                                                                                                |
-| 2026-08-06    | #9817 (parallel 3-reviewer pass); repo-local `code-simplifier` agent created from this doc                                                                                                         |
+| 2026-08-06    | #9817 (parallel 3-reviewer pass); repo-local `our-code-simplifier` agent created from this doc                                                                                                     |
 
 **Rotation history**: #8787 debt-audit rotation R1–R7 (~49 verified
 findings, ~−10k LOC, 100% closed) — superseded 2026-08-03 by the #8974


### PR DESCRIPTION
Follow-up to #9825. The pre-port Python era (2024-05 → 2025-02) is a different codebase — including it in the census was noise. Removed the section; kept a one-line scope note. No other content changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to scope and naming; no runtime or behavioral code changes.
> 
> **Overview**
> Updates the **code-simplifier campaign stats** proposal to match follow-up from #9825: the census is explicitly scoped to the **TypeScript repo (2025-05 → 2026-08-06)** and the **pre-port Python era** is excluded, with a one-line note that its durable lesson still appears in meta-lessons.
> 
> Also renames references from `code-simplifier` to **`our-code-simplifier`** (agent path and machinery table) and bumps the evidence base from **five** to **six** archival passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecd6e80e65b18c47292d0d9a0430e76422630ee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->