### PR TITLE
fix(latex): share transient-HTTP-status classification with arxivProcessor

### DIFF
--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -11,8 +11,8 @@ import pTimeout from 'p-timeout';
 import * as tar from 'tar';
 
 import * as logger from '@logger/logUtils';
-import { isTransientHttpStatus } from '@tools/timeouts';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
+import { isTransientHttpStatus } from '@utils/core/httpStatus';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { hasExtension } from '@utils/core/pathCore';
 import { normaliseArxivIdentifier } from './arxivIdentifier';

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -11,6 +11,7 @@ import pTimeout from 'p-timeout';
 import * as tar from 'tar';
 
 import * as logger from '@logger/logUtils';
+import { isTransientHttpStatus } from '@tools/timeouts';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { hasExtension } from '@utils/core/pathCore';
@@ -151,9 +152,10 @@ class ArxivSourceProcessor {
   }
 
   /**
-   * Download `url` to disk, retrying transient network / server (5xx)
-   * failures with exponential backoff. Permanent failures — any 4xx status
-   * or a PDF-only submission — abort the retry loop immediately.
+   * Download `url` to disk, retrying transient failures — network errors,
+   * 408/429, or 5xx (see {@link isTransientHttpStatus}) — with exponential
+   * backoff. Permanent failures — other 4xx statuses or a PDF-only
+   * submission — abort the retry loop immediately.
    */
   public async downloadFile(
     url: string,
@@ -193,10 +195,9 @@ class ArxivSourceProcessor {
 
       if (response.status !== StatusCodes.OK) {
         const message = `Failed to download: HTTP ${response.status}`;
-        // 4xx is permanent and won't change on retry; only retry 5xx.
-        throw response.status < StatusCodes.INTERNAL_SERVER_ERROR
-          ? new AbortError(message)
-          : new Error(message);
+        throw isTransientHttpStatus(response.status)
+          ? new Error(message)
+          : new AbortError(message);
       }
 
       // Extract filename from Content-Disposition header if available.

--- a/src/test-kernel/latex/ArxivProcessor.vitest.ts
+++ b/src/test-kernel/latex/ArxivProcessor.vitest.ts
@@ -82,3 +82,55 @@ describe('arXiv source download filenames', () => {
     await expect(fs.access(`${destBasePath}.gz`)).rejects.toThrow();
   });
 });
+
+describe('arXiv source download retry classification', () => {
+  it('retries a 429 rate limit instead of aborting immediately', async () => {
+    const dir = await makeTempDir('texra-arxiv-', tempDirs);
+    const destBasePath = path.join(dir, 'source');
+    let attempt = 0;
+    const fetchMock = vi.fn(
+      async (_url: RequestInfo | URL, _init?: RequestInit) => {
+        attempt += 1;
+        if (attempt === 1) {
+          return new Response(null, { status: 429 });
+        }
+        return new Response('source contents', {
+          status: 200,
+          headers: {
+            'content-disposition': 'attachment; filename="source"',
+            'content-type': 'application/x-gzip',
+          },
+        });
+      },
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const downloadedPath = await ArxivProcessor.downloadFile(
+      'https://arxiv.org/src/2404.12175',
+      destBasePath,
+      5000,
+    );
+
+    expect(attempt).toBe(2);
+    expect(downloadedPath).toBe(destBasePath);
+  });
+
+  it('does not retry a permanent 400 response', async () => {
+    const dir = await makeTempDir('texra-arxiv-', tempDirs);
+    const destBasePath = path.join(dir, 'source');
+    const fetchMock = vi.fn(
+      async (_url: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(null, { status: 400 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      ArxivProcessor.downloadFile(
+        'https://arxiv.org/src/2404.12175',
+        destBasePath,
+        5000,
+      ),
+    ).rejects.toThrow('HTTP 400');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test-kernel/tools/TransientHttpError.vitest.ts
+++ b/src/test-kernel/tools/TransientHttpError.vitest.ts
@@ -3,7 +3,8 @@ import { HTTPError, TimeoutError } from 'ky';
 import { describe, expect, it } from 'vitest';
 
 // Local imports - tools
-import { isTransientHttpError, isTransientHttpStatus } from '@tools/timeouts';
+import { isTransientHttpError } from '@tools/timeouts';
+import { isTransientHttpStatus } from '@utils/core/httpStatus';
 
 function kyErrorWithStatus(status: number): HTTPError {
   return new HTTPError(
@@ -78,20 +79,8 @@ describe('isTransientHttpError', () => {
   );
 });
 
-describe('isTransientHttpStatus', () => {
-  it('treats request timeouts, rate limits, and 5xx as transient', () => {
-    expect(isTransientHttpStatus(408)).toBe(true);
-    expect(isTransientHttpStatus(429)).toBe(true);
-    expect(isTransientHttpStatus(500)).toBe(true);
-    expect(isTransientHttpStatus(503)).toBe(true);
-  });
-
-  it('treats other 4xx statuses as permanent', () => {
-    expect(isTransientHttpStatus(400)).toBe(false);
-    expect(isTransientHttpStatus(404)).toBe(false);
-  });
-
-  it('agrees with isTransientHttpError for ky HTTPError status codes', () => {
+describe('isTransientHttpError / isTransientHttpStatus parity', () => {
+  it('agrees on ky HTTPError status codes', () => {
     for (const status of [400, 404, 408, 429, 500, 503]) {
       expect(isTransientHttpStatus(status)).toBe(
         isTransientHttpError(kyErrorWithStatus(status)),

--- a/src/test-kernel/tools/TransientHttpError.vitest.ts
+++ b/src/test-kernel/tools/TransientHttpError.vitest.ts
@@ -3,7 +3,7 @@ import { HTTPError, TimeoutError } from 'ky';
 import { describe, expect, it } from 'vitest';
 
 // Local imports - tools
-import { isTransientHttpError } from '@tools/timeouts';
+import { isTransientHttpError, isTransientHttpStatus } from '@tools/timeouts';
 
 function kyErrorWithStatus(status: number): HTTPError {
   return new HTTPError(
@@ -76,4 +76,26 @@ describe('isTransientHttpError', () => {
       expect(isTransientHttpError(value)).toBe(false);
     },
   );
+});
+
+describe('isTransientHttpStatus', () => {
+  it('treats request timeouts, rate limits, and 5xx as transient', () => {
+    expect(isTransientHttpStatus(408)).toBe(true);
+    expect(isTransientHttpStatus(429)).toBe(true);
+    expect(isTransientHttpStatus(500)).toBe(true);
+    expect(isTransientHttpStatus(503)).toBe(true);
+  });
+
+  it('treats other 4xx statuses as permanent', () => {
+    expect(isTransientHttpStatus(400)).toBe(false);
+    expect(isTransientHttpStatus(404)).toBe(false);
+  });
+
+  it('agrees with isTransientHttpError for ky HTTPError status codes', () => {
+    for (const status of [400, 404, 408, 429, 500, 503]) {
+      expect(isTransientHttpStatus(status)).toBe(
+        isTransientHttpError(kyErrorWithStatus(status)),
+      );
+    }
+  });
 });

--- a/src/test-kernel/utils/HttpStatus.vitest.ts
+++ b/src/test-kernel/utils/HttpStatus.vitest.ts
@@ -1,0 +1,19 @@
+// Suites for @utils/core/httpStatus (isTransientHttpStatus).
+
+import { describe, expect, it } from 'vitest';
+
+import { isTransientHttpStatus } from '@utils/core/httpStatus';
+
+describe('isTransientHttpStatus', () => {
+  it('treats request timeouts, rate limits, and 5xx as transient', () => {
+    expect(isTransientHttpStatus(408)).toBe(true);
+    expect(isTransientHttpStatus(429)).toBe(true);
+    expect(isTransientHttpStatus(500)).toBe(true);
+    expect(isTransientHttpStatus(503)).toBe(true);
+  });
+
+  it('treats other 4xx statuses as permanent', () => {
+    expect(isTransientHttpStatus(400)).toBe(false);
+    expect(isTransientHttpStatus(404)).toBe(false);
+  });
+});

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -11,6 +11,7 @@ import { HTTPError, TimeoutError } from 'ky';
 import pRetry, { AbortError, type Options as PRetryOptions } from 'p-retry';
 
 import { ToolError } from '@shared/schemas/toolResult';
+import { isTransientHttpStatus } from '@utils/core/httpStatus';
 import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 
 /**
@@ -49,20 +50,6 @@ export function isTimeoutError(error: unknown): boolean {
     return true;
   }
   return false;
-}
-
-/**
- * Whether an HTTP status code is transient (worth retrying): 408 request
- * timeout, 429 rate limit, or 5xx server error. Other 4xx statuses are
- * permanent and won't change on retry.
- *
- * Shared by {@link isTransientHttpError} (ky's `HTTPError`) and by callers
- * built on raw `fetch()` that classify `response.status` directly, so the
- * transient/permanent policy has one source of truth regardless of HTTP
- * client.
- */
-export function isTransientHttpStatus(status: number): boolean {
-  return status === 408 || status === 429 || status >= 500;
 }
 
 /**

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -52,6 +52,20 @@ export function isTimeoutError(error: unknown): boolean {
 }
 
 /**
+ * Whether an HTTP status code is transient (worth retrying): 408 request
+ * timeout, 429 rate limit, or 5xx server error. Other 4xx statuses are
+ * permanent and won't change on retry.
+ *
+ * Shared by {@link isTransientHttpError} (ky's `HTTPError`) and by callers
+ * built on raw `fetch()` that classify `response.status` directly, so the
+ * transient/permanent policy has one source of truth regardless of HTTP
+ * client.
+ */
+export function isTransientHttpStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+/**
  * Whether an HTTP request error is transient (worth retrying).
  *
  * Transient = timeout, network-level failure (no response received), 408
@@ -64,11 +78,7 @@ export function isTimeoutError(error: unknown): boolean {
 export function isTransientHttpError(error: unknown): boolean {
   if (isTimeoutError(error)) return true;
   if (error instanceof HTTPError) {
-    return (
-      error.response.status === 408 ||
-      error.response.status === 429 ||
-      error.response.status >= 500
-    );
+    return isTransientHttpStatus(error.response.status);
   }
   // Network-level failure from the underlying fetch — connection reset, DNS
   // hiccup, socket hang-up. `fetch` surfaces these as a `TypeError`, but a bare

--- a/src/utils/core/httpStatus.ts
+++ b/src/utils/core/httpStatus.ts
@@ -1,0 +1,13 @@
+/**
+ * Whether an HTTP status code is transient (worth retrying): 408 request
+ * timeout, 429 rate limit, or 5xx server error. Other 4xx statuses are
+ * permanent and won't change on retry.
+ *
+ * Lives in `utils` (rather than `tools`, where the only current consumer of
+ * this policy used to live) so both `src/tools` and `src/latex` can share it
+ * without adding a `latex -> tools` subsystem edge on top of the existing
+ * `tools -> latex` edge.
+ */
+export function isTransientHttpStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}


### PR DESCRIPTION
## Summary

Structural audit of the codebase (looking for overlapping/duplicated responsibilities per a scheduled review task) surfaced one concrete case of drifted duplicate logic: `src/latex/arxivProcessor.ts`'s `downloadFile()` hand-rolled its own "is this HTTP status worth retrying" check, independently of `src/tools/timeouts.ts`'s `isTransientHttpError` — the single canonical classifier every other network-boundary tool (`WebFetchTool`, `WebSearchTool`, `LoogleTool`) already shares via `retryTransientFetch`.

The two independently-maintained policies had already diverged: arxivProcessor treated *any* status below 500 as permanent, so a 429 rate-limit or 408 timeout from arXiv's export host aborted the download immediately instead of retrying with backoff, unlike every other network call in the codebase.

This PR extracts the status-code policy (`408`/`429`/`5xx` = transient) into a shared `isTransientHttpStatus(status)` in **`src/utils/core/httpStatus.ts`**, used by both `isTransientHttpError` (`src/tools/timeouts.ts`, for tools built on `ky`) and `arxivProcessor`'s raw-`fetch()` status check (which can't use `isTransientHttpError` directly since it doesn't throw ky's `HTTPError`). One source of truth now; the two call sites can no longer silently diverge again.

*(The predicate initially lived in `src/tools/timeouts.ts`, but review — Cursor Bugbot and `claude[bot]` — caught that importing it from `arxivProcessor.ts` added a `latex -> tools` subsystem edge not present in `config/ratchets/architecture-edges-baseline.json`, on top of the existing `tools -> latex` edge, failing the LAY-1 ratchet. Moved to `src/utils/core/httpStatus.ts`, which both `latex` and `tools` already have permitted edges to — see commit df9f05eb5.)*

## Issue acceptance gates

Ad hoc structural audit (no tracked issue). Acceptance gate: eliminate the duplicated/drifted retry-status policy between `src/tools/timeouts.ts` and `src/latex/arxivProcessor.ts`, cover the previously-untested 429/408-retry behavior with a regression test, and do so without introducing a new architecture-ratchet violation. All three satisfied.

## Single source of truth

`isTransientHttpStatus(status: number)` in `src/utils/core/httpStatus.ts` is now the sole authority for "is this HTTP status code worth retrying," consumed by `isTransientHttpError` (ky-based tools) and `arxivProcessor.downloadFileOnce` (raw-`fetch`-based).

## Duplication and abstraction budget

Removed: a second, independently-drifted copy of the transient-status decision (`status < 500` in `arxivProcessor.ts`) that had fallen out of sync with the canonical policy. Added: one small pure function (`isTransientHttpStatus`), extracted from existing logic already inside `isTransientHttpError` — not a new abstraction layer, just the existing decision made shareable across HTTP clients (ky vs raw `fetch`) and across subsystems (placed in `utils`, which both `latex` and `tools` already depend on). No wrapper/pass-through added.

## Net elements (R6)

Files: 3 production files touched (2 modified, 1 new — `src/utils/core/httpStatus.ts`), 3 test files touched (2 modified, 1 new — `src/test-kernel/utils/HttpStatus.vitest.ts`). Exported symbols: `+1` (`isTransientHttpStatus`), `0` removed. Classes/interfaces/enums: none added or removed. Net LoC: +98/-13 on the original commit, +38/-30 on the follow-up relocation commit (test additions dominate: two new regression tests plus classifier-parity tests).

## Consumer counts (R8)

Not a removal or re-route of an existing emit path or export — n/a.

## Host impact

Extension: none (host-agnostic `src/` change only).

Desktop: none.

CLI: none.

## Scheduled refactoring

None — this was the single significant finding from the audit; no further follow-up identified.

## Validation

- `npx eslint` on all changed files — clean.
- `npm run typecheck` (full workspace: workspace, test-kernel, agent, extension, cli, trace-viewer, desktop) — passes.
- `npm run check:dead-code-ratchet` — passes (new export has 2 in-PR consumers).
- `npx vitest run src/test-kernel/architecture` (full LAY-1 subsystem edge ratchet suite, 12 files / 81 tests) — passes.
- `npx vitest run src/test-kernel/tools/TransientHttpError.vitest.ts src/test-kernel/utils/HttpStatus.vitest.ts src/test-kernel/latex/ArxivProcessor.vitest.ts` — 19/19 passing, including two regression tests: a 429 response now retries and succeeds (previously would have aborted immediately — the bug this PR fixes), and a genuinely permanent 400 response still aborts after a single attempt.