### PR TITLE
docs(agents): restore Cross-host consistency section of our-code-simplifier

### DIFF
--- a/.claude/agents/our-code-simplifier.md
+++ b/.claude/agents/our-code-simplifier.md
@@ -197,6 +197,29 @@ anything big.
   `supabase/functions/**` tree, required-peer exceptions like the MCP SDK —
   record those, don't delete them).
 
+## Cross-host consistency (CLI / extension / desktop share one core)
+
+Three hosts, one host-agnostic core — that is the architecture. When you see
+the same POLICY implemented per host, the simplification is to hoist it:
+
+- **Policy belongs to the core; wiring belongs to the host.** Approval
+  policy, queue semantics, run/session lifecycle, model-access resolution,
+  retry/classification rules: one owner in `src/` (host-agnostic), hosts
+  reach it through typed `Platform` ports. Three host copies of one policy
+  are three future divergences.
+- **Host-prefixed names are a smell detector, not a verdict.**
+  `cliXxx`/`desktopXxx`/`vscodeXxx` on *policy* logic (e.g. a
+  `cliApiFallbackSelection` with no shared counterpart) = hoist candidate.
+  The same prefix on *wiring/presentation* (`cliContext`, `cliState`,
+  terminal rendering, `vscodeSecrets`/`electronSecrets` as thin port
+  adapters) = legitimate host surface — leave it.
+- **The adjudicated KEEP line**: per-host *vocabulary* isolation (#7622) and
+  Platform ports are deliberate — never unify UI strings across hosts and
+  never collapse a port. Share logic, not grammar.
+- The ratchets bound HOW you hoist: no new `@agent/*` deep-import specifier
+  from a host (type-only included) — route through the existing alias
+  surface or extend the port.
+
 ## Concurrency discipline (this repo merges dozens of PRs a day)
 
 - Before starting: check in-flight PRs touching your surface. Duplicate


### PR DESCRIPTION
Recovers the +23-line `Cross-host consistency` section (policy-hoisting rules for the 3-hosts-one-core architecture, host-prefix smell detector, the #7622 vocabulary KEEP line, ratchet bounds on hoisting) that was written against the sweep tree, never committed, and got wiped during the #9827→#9829 merge shuffle. Text recovered verbatim from the authoring session's transcript.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an agent prompt file; no application code, security, or data paths affected.
> 
> **Overview**
> Restores a **Cross-host consistency** section in `.claude/agents/our-code-simplifier.md` that was lost during merge shuffle; it does not change runtime code.
> 
> The section spells out how simplification should treat the three-host / one-core layout: hoist shared **policy** into host-agnostic `src/` behind `Platform` ports, treat host-prefixed names on policy as hoist candidates but wiring/presentation prefixes as legitimate, and keep the adjudicated **KEEP** line for per-host vocabulary (#7622) and ports—share logic, not grammar. Hoisting stays bounded by existing ratchets (no new `@agent/*` deep imports from hosts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5843de27b9f90a17e66ad55a434214c8bb954860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->