### PR TITLE
test(kernel): decouple medium-severity structural findings from test sweep

### DIFF
--- a/src/test-kernel/agent/AgentRegistry.vitest.ts
+++ b/src/test-kernel/agent/AgentRegistry.vitest.ts
@@ -136,13 +136,18 @@ describe('agent registry', () => {
       },
     });
 
-    const pendingRefresh = refresh({ includeRemote: false });
-    await delay(0);
+    try {
+      const pendingRefresh = refresh({ includeRemote: false });
+      await delay(0);
 
-    expect(getAgent('assistant')?.name).toBe('assistant');
+      expect(getAgent('assistant')?.name).toBe('assistant');
 
-    builtInToolUseDir.resolve();
-    await pendingRefresh;
+      builtInToolUseDir.resolve();
+      await pendingRefresh;
+    } finally {
+      builtInToolUseDir.resolve();
+      useAgentDirectories();
+    }
   });
 
   it('forces a new remote fetch after an older initialization settles', async () => {
@@ -160,21 +165,24 @@ describe('agent registry', () => {
       return [remoteAgentFixture('fresh-agent', 'freshAgent', 'Fresh')];
     });
 
-    const staleInitialization = loadAgents({ includeRemote: true });
-    await vi.waitFor(() => expect(listRemoteAgents).toHaveBeenCalledOnce());
-    const forcedRefresh = refresh({ includeRemote: true });
+    try {
+      const staleInitialization = loadAgents({ includeRemote: true });
+      await vi.waitFor(() => expect(listRemoteAgents).toHaveBeenCalledOnce());
+      const forcedRefresh = refresh({ includeRemote: true });
 
-    staleLoadGate.resolve();
-    await staleInitialization;
-    await forcedRefresh;
+      staleLoadGate.resolve();
+      await staleInitialization;
+      await forcedRefresh;
 
-    expect(listRemoteAgents).toHaveBeenCalledTimes(2);
-    expect(getAgent('freshAgent')?.source).toBe('remote');
-    expect(getAgent('staleAgent')).toBeUndefined();
-
-    listRemoteAgents.mockReset();
-    listRemoteAgents.mockResolvedValue([ORCHESTRATOR_AGENT]);
-    await refresh({ includeRemote: false });
+      expect(listRemoteAgents).toHaveBeenCalledTimes(2);
+      expect(getAgent('freshAgent')?.source).toBe('remote');
+      expect(getAgent('staleAgent')).toBeUndefined();
+    } finally {
+      staleLoadGate.resolve();
+      listRemoteAgents.mockReset();
+      listRemoteAgents.mockResolvedValue([ORCHESTRATOR_AGENT]);
+      await refresh({ includeRemote: false });
+    }
   });
 
   it('reloads local-only definitions after sign-out invalidation', async () => {
@@ -200,20 +208,22 @@ describe('agent registry', () => {
       },
     });
 
-    const invalidation = invalidateRemoteAgentsAfterSignOut();
-    expect(getAgentsBySource('remote')).toEqual([]);
-    await expect(invalidation).resolves.toBeUndefined();
-    expect(getAgentsBySource('remote')).toEqual([]);
-    expect(warn).toHaveBeenCalledWith(
-      'agentRegistry',
-      expect.stringContaining(
-        'Local agent catalog rebuild failed after sign-out',
-      ),
-    );
-
-    useAgentDirectories();
-    await refresh({ includeRemote: false });
-    warn.mockRestore();
+    try {
+      const invalidation = invalidateRemoteAgentsAfterSignOut();
+      expect(getAgentsBySource('remote')).toEqual([]);
+      await expect(invalidation).resolves.toBeUndefined();
+      expect(getAgentsBySource('remote')).toEqual([]);
+      expect(warn).toHaveBeenCalledWith(
+        'agentRegistry',
+        expect.stringContaining(
+          'Local agent catalog rebuild failed after sign-out',
+        ),
+      );
+    } finally {
+      useAgentDirectories();
+      await refresh({ includeRemote: false });
+      warn.mockRestore();
+    }
   });
 
   it('fences an in-flight remote load before rebuilding locally', async () => {
@@ -238,15 +248,22 @@ describe('agent registry', () => {
 
     const staleLoad = loadAgents({ includeRemote: true });
     await vi.waitFor(() => expect(listRemoteAgents).toHaveBeenCalled());
-    const invalidation = invalidateRemoteAgentsAfterSignOut();
-    remoteLoad.resolve();
-    await staleLoad;
 
-    expect(getAgent('lateRemote')).toBeUndefined();
-    expect(getAgentsBySource('remote')).toEqual([]);
+    try {
+      const invalidation = invalidateRemoteAgentsAfterSignOut();
+      remoteLoad.resolve();
+      await staleLoad;
 
-    localRebuild.resolve();
-    await invalidation;
+      expect(getAgent('lateRemote')).toBeUndefined();
+      expect(getAgentsBySource('remote')).toEqual([]);
+
+      localRebuild.resolve();
+      await invalidation;
+    } finally {
+      remoteLoad.resolve();
+      localRebuild.resolve();
+      useAgentDirectories();
+    }
   });
 
   it('keeps the registry marked ready when a later refresh fails', async () => {
@@ -259,12 +276,14 @@ describe('agent registry', () => {
       },
     });
 
-    await expect(loadAgents()).rejects.toThrow('refresh failed');
+    try {
+      await expect(loadAgents()).rejects.toThrow('refresh failed');
 
-    expect(isAgentRegistryReady()).toBe(true);
-    expect(getAgent('assistant')?.name).toBe('assistant');
-
-    useAgentDirectories();
+      expect(isAgentRegistryReady()).toBe(true);
+      expect(getAgent('assistant')?.name).toBe('assistant');
+    } finally {
+      useAgentDirectories();
+    }
   });
 
   it('includes remote agents in launcher options after local-only startup load', async () => {

--- a/src/test-kernel/agent/modelHandlers/BackgroundRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/BackgroundRunLifecycle.vitest.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentTrace } from '@agent/trace';
 import { BackgroundRunLifecycle } from '@agent/modelHandlers/openai/BackgroundRunLifecycle';
-import { BackgroundPoller } from '@agent/modelHandlers/support/BackgroundPoller';
 import {
   isProviderErrorAutoRetryable,
   normalizeProviderError,
@@ -104,9 +103,9 @@ describe('BackgroundRunLifecycle.tryResume', () => {
       },
     } as unknown as OpenAI;
 
-    // Simulate a prior poll having remembered a pending id.
-    (lifecycle as unknown as { pendingResponseId: string }).pendingResponseId =
-      'resp-done';
+    // A prior poll remembers the id as pending through the public path.
+    await lifecycle.retrieveAndRemember(client, 'resp-done', undefined, undefined);
+    vi.mocked(client.responses.retrieve).mockClear();
 
     const result = await lifecycle.tryResume(client);
 
@@ -129,8 +128,12 @@ describe('BackgroundRunLifecycle.tryResume', () => {
         })),
       },
     } as unknown as OpenAI;
-    (lifecycle as unknown as { pendingResponseId: string }).pendingResponseId =
-      'resp-failed';
+    await lifecycle.retrieveAndRemember(
+      client,
+      'resp-failed',
+      undefined,
+      undefined,
+    );
 
     const result = await lifecycle.tryResume(client);
 
@@ -240,16 +243,10 @@ describe('BackgroundRunLifecycle.waitForCompletion', () => {
   });
 
   it('throws a terminal error when polling ends in a non-completed status', async () => {
+    // Fake timers carry the test past the real poll interval deterministically
+    // instead of swapping in a fast poller through the private field.
+    vi.useFakeTimers();
     const lifecycle = createLifecycle();
-    // Swap in a fast poller so the test doesn't wait on the real 15s interval.
-    (
-      lifecycle as unknown as { backgroundPoller: BackgroundPoller<Response> }
-    ).backgroundPoller = new BackgroundPoller({
-      pollIntervalMs: 0,
-      maxDurationMs: 1000,
-      isPending: (r) => lifecycle.isPending(r),
-      logger: spiedTrace(),
-    });
     const client = {
       responses: {
         retrieve: vi.fn(async () => ({
@@ -260,12 +257,14 @@ describe('BackgroundRunLifecycle.waitForCompletion', () => {
       },
     } as unknown as OpenAI;
 
-    await expect(
-      lifecycle.waitForCompletion(client, {
-        id: 'resp-terminal',
-        status: 'in_progress',
-      } as Response),
-    ).rejects.toThrow();
+    const completion = lifecycle.waitForCompletion(client, {
+      id: 'resp-terminal',
+      status: 'in_progress',
+    } as Response);
+    const rejection = expect(completion).rejects.toThrow();
+    // One step well past the first poll interval, far short of the deadline.
+    await vi.advanceTimersByTimeAsync(60_000);
+    await rejection;
     expect(lifecycle.hasPendingResume()).toBe(false);
   });
 });

--- a/src/test-kernel/agent/modelHandlers/BackgroundRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/BackgroundRunLifecycle.vitest.ts
@@ -104,7 +104,12 @@ describe('BackgroundRunLifecycle.tryResume', () => {
     } as unknown as OpenAI;
 
     // A prior poll remembers the id as pending through the public path.
-    await lifecycle.retrieveAndRemember(client, 'resp-done', undefined, undefined);
+    await lifecycle.retrieveAndRemember(
+      client,
+      'resp-done',
+      undefined,
+      undefined,
+    );
     vi.mocked(client.responses.retrieve).mockClear();
 
     const result = await lifecycle.tryResume(client);

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
@@ -5,13 +5,14 @@ import { describe, expect, it } from 'vitest';
 import { noopTrace } from '@agent/trace';
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
 import { GOOGLE_FINISH } from '@agent/types/StopReasonTypes';
+import type { MediaEntry } from '@agent/utils/mediaTypes';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 // Local file imports
 import { GOOGLE_INTERACTIONS_TEST_CONFIG } from './googleInteractionsTestUtils';
 
 // Third-party imports
-import type { Interactions } from '@google/genai';
+import type { GoogleGenAI, Interactions } from '@google/genai';
 
 type Step = Interactions.Step;
 
@@ -43,38 +44,44 @@ function userStep(text: string): Step {
   return { type: 'user_input', content: [{ type: 'text', text }] };
 }
 
-/** Stub the media loader so no platform / filesystem is touched. */
-function stubImageMediaLoader(handler: ModelHandlerGoogleInteractions): void {
-  (
-    handler as unknown as {
-      createMediaMessage: (files: unknown[]) => Promise<Interactions.Content[]>;
-    }
-  ).createMediaMessage = async () => [
-    { type: 'image', data: 'aGVsbG8=', mime_type: 'image/png' },
-  ];
+/**
+ * A handler test double that stubs the media pipeline through typed seams:
+ * canned media replaces the filesystem-backed loader, a canned client
+ * replaces the credential-resolving factory, and the protected upload
+ * pipeline is exposed directly. A private-member rename now fails
+ * compilation instead of silently breaking the suite.
+ */
+class MediaProbeHandler extends ModelHandlerGoogleInteractions {
+  private stubbedMedia: Interactions.Content[] = [];
+
+  /** Canned media the loader override returns, so no platform/fs is touched. */
+  setMediaContent(content: Interactions.Content[]): void {
+    this.stubbedMedia = content;
+  }
+
+  /** Replace the client factory with a canned client (e.g. files.upload stub). */
+  setClient(client: GoogleGenAI): void {
+    this.getClient = () => Promise.resolve(client);
+  }
+
+  /** Invoke the media-upload pipeline directly. */
+  uploadEntries(entries: MediaEntry[]): Promise<Interactions.Content[]> {
+    return this.uploadMediaEntries(entries);
+  }
+
+  protected override async createMediaMessage(): Promise<
+    Interactions.Content[]
+  > {
+    return this.stubbedMedia;
+  }
 }
 
-/** Replace the client factory with a canned client (e.g. a files.upload stub). */
-function stubGetClient(
-  handler: ModelHandlerGoogleInteractions,
-  client: unknown,
-): void {
-  (handler as unknown as { getClient: () => Promise<unknown> }).getClient =
-    async () => client;
-}
-
-/** Reach the private media-upload pipeline directly. */
-function uploadMediaEntries(
-  handler: ModelHandlerGoogleInteractions,
-  entries: unknown[],
-): Promise<Interactions.Content[]> {
-  return (
-    handler as unknown as {
-      uploadMediaEntries: (
-        entries: unknown[],
-      ) => Promise<Interactions.Content[]>;
-    }
-  ).uploadMediaEntries(entries);
+function createMediaProbe(): MediaProbeHandler {
+  const handler = new MediaProbeHandler(
+    buildTestModelConfig(MESSAGES_TEST_CONFIG),
+  );
+  handler.setLogger({ ...noopTrace });
+  return handler;
 }
 
 describe('ModelHandlerGoogleInteractions message construction', () => {
@@ -140,10 +147,12 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
   });
 
   it('addMediaToUserMessage unshifts inline image content into the trailing user_input step', async () => {
-    const handler = createHandler();
+    const handler = createMediaProbe();
     const steps: Step[] = [userStep('caption')];
 
-    stubImageMediaLoader(handler);
+    handler.setMediaContent([
+      { type: 'image', data: 'aGVsbG8=', mime_type: 'image/png' },
+    ]);
 
     await handler.addMediaToUserMessage(steps, [
       { absolutePath: '/x/fig.png' } as never,
@@ -155,12 +164,14 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
   });
 
   it('creates a new user turn for an image-only follow-up', async () => {
-    const handler = createHandler();
+    const handler = createMediaProbe();
     const steps: Step[] = [
       userStep('question'),
       { type: 'model_output', content: [{ type: 'text', text: 'answer' }] },
     ];
-    stubImageMediaLoader(handler);
+    handler.setMediaContent([
+      { type: 'image', data: 'aGVsbG8=', mime_type: 'image/png' },
+    ]);
 
     await handler.createUserFollowUpMessages(steps, '');
     await handler.addMediaToUserMessage(steps, [
@@ -175,8 +186,10 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
   });
 
   it('initializeMessages includes typed media content when mediaFiles are provided', async () => {
-    const handler = createHandler();
-    stubImageMediaLoader(handler);
+    const handler = createMediaProbe();
+    handler.setMediaContent([
+      { type: 'image', data: 'aGVsbG8=', mime_type: 'image/png' },
+    ]);
 
     const steps = await handler.initializeMessages('PREFIX', 'REQUEST', [
       { absolutePath: '/x/fig.png' } as never,
@@ -200,44 +213,46 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
   it('uploadMediaEntries inlines data under the limit and uploads (uri) over it', async () => {
     // A handler whose inline limit is 4 bytes so the boundary is exercised
     // without allocating a 20 MB payload.
-    class TinyInlineLimitHandler extends ModelHandlerGoogleInteractions {
+    class TinyInlineLimitProbe extends MediaProbeHandler {
       protected override getInlineUploadLimitBytes(): number {
         return 4;
       }
     }
-    const handler = new TinyInlineLimitHandler(
+    const handler = new TinyInlineLimitProbe(
       buildTestModelConfig(MESSAGES_TEST_CONFIG),
     );
     handler.setLogger({ ...noopTrace });
 
     let uploadCalls = 0;
-    stubGetClient(handler, {
+    handler.setClient({
       files: {
         upload: async () => {
           uploadCalls += 1;
           return { uri: 'files/abc', mimeType: 'image/png' };
         },
       },
-    });
+    } as unknown as GoogleGenAI);
 
-    const entries = [
+    const entries: MediaEntry[] = [
       // 2 bytes decoded (<= 4) → inline data.
       {
         file_name: 'small.png',
         media_type: 'image/png',
+        media_category: 'image',
         data: Buffer.from('hi').toString('base64'),
       },
       // 11 bytes decoded (> 4) → falls back to upload → uri.
       {
         file_name: 'big.png',
         media_type: 'image/png',
+        media_category: 'image',
         data: Buffer.from('hello world').toString('base64'),
         source_path: '/x/big.png',
         bytes_match_source: true,
       },
     ];
 
-    const content = await uploadMediaEntries(handler, entries);
+    const content = await handler.uploadEntries(entries);
 
     expect(content).toHaveLength(2);
     const inline = content[0] as Interactions.ImageContent;
@@ -255,34 +270,37 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
   });
 
   it('builds typed Interactions media content for audio, video, and documents', async () => {
-    const handler = createHandler();
-    stubGetClient(handler, {
+    const handler = createMediaProbe();
+    handler.setClient({
       files: {
         upload: async () => {
           throw new Error('expected inline media');
         },
       },
-    });
+    } as unknown as GoogleGenAI);
 
-    const entries = [
+    const entries: MediaEntry[] = [
       {
         file_name: 'sound.mp3',
         media_type: 'audio/mp3',
+        media_category: 'audio',
         data: Buffer.from('audio').toString('base64'),
       },
       {
         file_name: 'clip.mp4',
         media_type: 'video/mp4',
+        media_category: 'video',
         data: Buffer.from('video').toString('base64'),
       },
       {
         file_name: 'paper.pdf',
         media_type: 'application/pdf',
+        media_category: 'document',
         data: Buffer.from('pdf').toString('base64'),
       },
     ];
 
-    const content = await uploadMediaEntries(handler, entries);
+    const content = await handler.uploadEntries(entries);
 
     expect(content).toEqual([
       {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -354,7 +354,8 @@ function stubHandlerForTest(
   loggerOverrides?: Partial<Record<string, unknown>>,
 ): void {
   handler.setLogger({ ...noopTrace, ...loggerOverrides } as AgentTrace);
-  (handler as any).getStreamingConfig = () => false;
+  // getStreamingConfig is public, so this stub stays compile-checked.
+  handler.getStreamingConfig = () => false;
 }
 
 /** A minimal successful Anthropic message response. */
@@ -2461,7 +2462,7 @@ describe('ModelHandlerAnthropic pre-message_start error handling', () => {
       supportsReasoning: false,
     });
     handler.setLogger(logger ?? { ...noopTrace });
-    (handler as any).getStreamingConfig = () => true;
+    handler.getStreamingConfig = () => true;
     return handler;
   }
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIClientDiagnostics.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIClientDiagnostics.vitest.ts
@@ -119,11 +119,28 @@ async function clientDiagnostics(
   return messages;
 }
 
-function expectBothHandlers(messages: string[], expected: string): void {
+interface ExpectedDiagnostics {
+  /** Credential owner label, e.g. "moonshot API key". */
+  owner: string;
+  model: string;
+  baseUrl: string;
+}
+
+function expectBothHandlers(
+  messages: string[],
+  expected: ExpectedDiagnostics,
+): void {
   const clientConfigMessages = messages.filter((message) =>
-    message.includes('. Model:'),
+    message.includes('Base URL:'),
   );
-  expect(clientConfigMessages).toEqual([expected, expected]);
+  // One client-config diagnostic per handler (chat + responses), each
+  // reporting the credential owner, the wire model, and the endpoint.
+  expect(clientConfigMessages).toHaveLength(2);
+  for (const message of clientConfigMessages) {
+    expect(message).toContain(expected.owner);
+    expect(message).toContain(`Model: ${expected.model}`);
+    expect(message).toContain(`Base URL: ${expected.baseUrl}`);
+  }
   expect(messages.join('\n')).not.toContain(TEST_API_KEY);
 }
 
@@ -150,10 +167,11 @@ describe('OpenAI-compatible client diagnostics', () => {
       buildTestModelConfig(KIMI_DIAGNOSTICS_CONFIG),
     );
 
-    expectBothHandlers(
-      messages,
-      `Using moonshot API key. Model: kimi-k2.5. Base URL: ${MOONSHOT_BASE_URL}`,
-    );
+    expectBothHandlers(messages, {
+      owner: 'moonshot API key',
+      model: 'kimi-k2.5',
+      baseUrl: MOONSHOT_BASE_URL,
+    });
   });
 
   it('reports the Kimi Code credential owner and final k3 wire model', async () => {
@@ -166,10 +184,11 @@ describe('OpenAI-compatible client diagnostics', () => {
       }),
     );
 
-    expectBothHandlers(
-      messages,
-      `Using kimiCode API key. Model: k3. Base URL: ${KIMI_CODE_BASE_URL}`,
-    );
+    expectBothHandlers(messages, {
+      owner: 'kimiCode API key',
+      model: 'k3',
+      baseUrl: KIMI_CODE_BASE_URL,
+    });
   });
 
   it('reports the exclusive Kimi Code alias without rewriting its wire model', async () => {
@@ -183,10 +202,11 @@ describe('OpenAI-compatible client diagnostics', () => {
       }),
     );
 
-    expectBothHandlers(
-      messages,
-      `Using kimiCode API key. Model: kimi-for-coding. Base URL: ${KIMI_CODE_BASE_URL}`,
-    );
+    expectBothHandlers(messages, {
+      owner: 'kimiCode API key',
+      model: 'kimi-for-coding',
+      baseUrl: KIMI_CODE_BASE_URL,
+    });
   });
 
   it('reports OpenRouter credentials and endpoint for OpenRouter-only models', async () => {
@@ -199,10 +219,11 @@ describe('OpenAI-compatible client diagnostics', () => {
       }),
     );
 
-    expectBothHandlers(
-      messages,
-      `Using OpenRouter API key. Model: moonshotai/kimi-k2.5. Base URL: ${OPENROUTER_BASE_URL}`,
-    );
+    expectBothHandlers(messages, {
+      owner: 'OpenRouter API key',
+      model: 'moonshotai/kimi-k2.5',
+      baseUrl: OPENROUTER_BASE_URL,
+    });
   });
 
   it('reports the relay access token and relay endpoint', async () => {
@@ -223,10 +244,11 @@ describe('OpenAI-compatible client diagnostics', () => {
       { useRelay: true },
     );
 
-    expectBothHandlers(
-      messages,
-      `Using TeXRA relay access token. Model: gpt-test. Base URL: ${RELAY_BASE_URL}`,
-    );
+    expectBothHandlers(messages, {
+      owner: 'TeXRA relay access token',
+      model: 'gpt-test',
+      baseUrl: RELAY_BASE_URL,
+    });
   });
 
   it('reports the OpenAI client default when no base URL is configured', async () => {
@@ -240,10 +262,11 @@ describe('OpenAI-compatible client diagnostics', () => {
       }),
     );
 
-    expectBothHandlers(
-      messages,
-      `Using openai API key. Model: gpt-test. Base URL: ${OPENAI_DEFAULT_BASE_URL}`,
-    );
+    expectBothHandlers(messages, {
+      owner: 'openai API key',
+      model: 'gpt-test',
+      baseUrl: OPENAI_DEFAULT_BASE_URL,
+    });
     expect(messages.join('\n')).not.toContain('Base URL: null');
   });
 });

--- a/src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts
@@ -91,7 +91,9 @@ function configureHandler<Handler extends CompatibleHandler>(
   handler: Handler,
 ): Handler {
   handler.setLogger({ ...noopTrace });
-  (handler as any).getStreamingConfig = () => false;
+  // Both members are public, so the stubs stay compile-checked: a rename or
+  // signature change fails typecheck instead of silently breaking the suite.
+  handler.getStreamingConfig = () => false;
   return handler;
 }
 
@@ -99,7 +101,7 @@ function configureHandler<Handler extends CompatibleHandler>(
 function configureKimiHandler<Handler extends ModelHandlerKimi>(
   handler: Handler,
 ): Handler {
-  (handler as any).estimateTokenCount = async () => 100;
+  handler.estimateTokenCount = async () => 100;
   return configureHandler(handler);
 }
 

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
@@ -40,8 +40,9 @@ function configureHandler(
     error: vi.fn(),
     domain: vi.fn(),
   });
-  (handler as { getStreamingConfig: () => boolean }).getStreamingConfig = () =>
-    false;
+  // getStreamingConfig is public on ModelHandlerOpenAIResponse; stub it
+  // rather than poking a private-typed cast.
+  vi.spyOn(handler, 'getStreamingConfig').mockReturnValue(false);
   return handler;
 }
 

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -1,6 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';
 
+import { extractToolNames } from '@agent/index/agentYamlScanner';
 import {
   convertGoogleToolSchema,
   toAnthropicTools,
@@ -9,6 +14,8 @@ import {
   toOpenAIResponseTools,
 } from '@agent/modelHandlers/toolConversion';
 import type { ToolDefinition } from '@model/ToolDefinition';
+import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
+import { REPO_ROOT } from '@test/support/repoScan';
 import { resolveToolDefinitions } from '@tools/registry';
 import { DiagnosticsTool } from '@tools/DiagnosticsTool';
 import { BashTool } from '@tools/bash';
@@ -759,27 +766,25 @@ describe('toGoogleTools', () => {
   });
 
   it('generates finite schemas for the scientific review tool roster', () => {
-    const reviewTools = resolveToolDefinitions([
-      'wolfram',
-      'todo_write',
-      'bash',
-      'read_file',
-      'write_file',
-      'edit_file',
-      'glob',
-      'grep',
-      'extract_figures',
-      'extract_bib_entries',
-      'extract_tikz_figures',
-      'texcount',
-      'arxiv_search',
-      'arxiv_metadata',
-      'crossref_search',
-      'diagnostics',
-      'delegate_multi_agents',
-    ]);
+    // The roster lives in the review agent YAML (plus the delegation tool the
+    // runtime injects) — derive it from there so a roster change doesn't
+    // break this conversion test.
+    const reviewYamlPath = resolve(
+      REPO_ROOT,
+      'packages/extension/resources/tool_use_agents/review.yaml',
+    );
+    const reviewYaml = parseYaml(readFileSync(reviewYamlPath, 'utf8')) as {
+      tools?: unknown[];
+    };
+    const reviewToolNames = [
+      ...(extractToolNames(reviewYaml.tools) ?? []),
+      DELEGATE_MULTI_AGENTS_TOOL_NAME,
+    ];
+    const reviewTools = resolveToolDefinitions(reviewToolNames);
 
-    expect(reviewTools).toHaveLength(17);
+    expect(reviewTools.map((definition) => definition.name)).toEqual(
+      reviewToolNames,
+    );
     for (const definition of reviewTools) {
       for (const schema of Object.values(googleSchemasFor(definition))) {
         const serialized = JSON.stringify(schema);

--- a/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
+++ b/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
@@ -9,12 +9,31 @@ const providerMocks = vi.hoisted(() => ({
   signOut: vi.fn(async () => {}),
 }));
 
+// Test doubles installed through the module seams the provider's constructor
+// already depends on, so tests build a real provider instead of fabricating
+// one from its prototype and private fields.
+const testDoubles = vi.hoisted(() => ({
+  coordinator: null as Record<string, ReturnType<typeof vi.fn>> | null,
+  emitters: [] as Array<{ fire: ReturnType<typeof vi.fn> }>,
+}));
+
 vi.mock('vscode', () => ({
   EventEmitter: class {
     readonly event = vi.fn();
     dispose = vi.fn();
     fire = vi.fn();
+    constructor() {
+      testDoubles.emitters.push(this);
+    }
   },
+}));
+
+vi.mock('@platform/platform', () => ({
+  platform: () => ({ secrets: {} }),
+}));
+
+vi.mock('@auth/SupabaseAuthCoordinator', () => ({
+  createHostAuthCoordinator: () => testDoubles.coordinator,
 }));
 
 vi.mock('@auth/SupabaseClient', () => ({
@@ -44,12 +63,10 @@ vi.mock('@model/computeModelOptions', () => ({
 }));
 
 // Local imports
-import type {
-  SupabaseSession,
-  SupabaseSessionCoordinator,
-} from '@auth/SupabaseSession';
+import type { SupabaseSession } from '@auth/SupabaseSession';
 import type { StoredSessionState } from '@auth/TokenProvider';
 import { SupabaseAuthProvider } from '@frontend/auth/SupabaseAuthProvider';
+import type { SupabaseUriHandler } from '@frontend/auth/UriHandler';
 
 function createProvider(options: {
   expiresAt: number;
@@ -57,6 +74,7 @@ function createProvider(options: {
 }): {
   provider: SupabaseAuthProvider;
   session: SupabaseSession;
+  coordinator: Record<string, ReturnType<typeof vi.fn>>;
   fire: ReturnType<typeof vi.fn>;
   clearSessionIfCurrent: ReturnType<typeof vi.fn>;
   getStoredSessionState: ReturnType<typeof vi.fn>;
@@ -67,7 +85,6 @@ function createProvider(options: {
     async () => 'invalid',
   );
   const showSignInPrompt = vi.fn();
-  const fire = vi.fn();
   const session: SupabaseSession = {
     id: 'user-id',
     accessToken: 'expired-access',
@@ -83,24 +100,23 @@ function createProvider(options: {
     getStoredSessionState,
     getLastRefreshFailure: vi.fn(() => options.failure ?? null),
     clearSessionIfCurrent,
+    createSessionFromCallback: vi.fn(),
   };
-  const provider = Object.create(
-    SupabaseAuthProvider.prototype,
-  ) as SupabaseAuthProvider;
-  Object.assign(provider, {
-    _onDidChangeSessions: { fire },
-    sessionCoordinator: coordinator as unknown as SupabaseSessionCoordinator,
-    notifier: {
-      showError: vi.fn(),
-      showInfo: vi.fn(),
-      showSignInPrompt,
-    },
+  testDoubles.coordinator = coordinator;
+  testDoubles.emitters.length = 0;
+  const provider = new SupabaseAuthProvider({
+    showError: vi.fn(),
+    showInfo: vi.fn(),
+    showSignInPrompt,
   });
+  const emitter = testDoubles.emitters[0];
+  if (!emitter) throw new Error('provider did not create a session emitter');
 
   return {
     provider,
     session,
-    fire,
+    coordinator,
+    fire: emitter.fire,
     clearSessionIfCurrent,
     getStoredSessionState,
     showSignInPrompt,
@@ -216,15 +232,30 @@ describe('SupabaseAuthProvider model availability', () => {
   // Listeners recompute model options from the session-change event, so an
   // event published ahead of the invalidation serves the stale option list.
   it('invalidates model availability before publishing a new session', async () => {
-    const { provider, session, fire } = createUnexpiredProvider();
+    const { provider, session, coordinator, fire } = createUnexpiredProvider();
 
-    // The login path stores through a private method; no public entry point
-    // reaches it without a live OAuth round trip.
-    await (
-      provider as unknown as {
-        storeSession(session: SupabaseSession): Promise<void>;
-      }
-    ).storeSession(session);
+    // Drive the login path through its public seams: a late OAuth callback
+    // delivered to the registered URI handler stores the session.
+    coordinator.loadSession.mockResolvedValueOnce(null);
+    coordinator.createSessionFromCallback.mockResolvedValue({
+      success: true,
+      session,
+    });
+    let authCallback:
+      | ((uri: { path: string; query: string }) => unknown)
+      | undefined;
+    const handler = {
+      onDidReceiveCallback: (
+        listener: (uri: { path: string; query: string }) => unknown,
+      ) => {
+        authCallback = listener;
+        return { dispose: vi.fn() };
+      },
+      handleUri: vi.fn(),
+    } as unknown as SupabaseUriHandler;
+    provider.setUriHandler(handler);
+
+    await authCallback?.({ path: '/auth-callback', query: 'code=test' });
 
     expect(providerMocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
     expect(
@@ -248,12 +279,7 @@ describe('SupabaseAuthProvider model availability', () => {
   // scope, on every device. Sign-out clears local storage only, as on desktop
   // and the CLI.
   it('clears the stored session without a remote revocation', async () => {
-    const { provider, session } = createUnexpiredProvider();
-    const coordinator = (
-      provider as unknown as {
-        sessionCoordinator: { clearSession: ReturnType<typeof vi.fn> };
-      }
-    ).sessionCoordinator;
+    const { provider, session, coordinator } = createUnexpiredProvider();
 
     await provider.removeSession(session.id);
 

--- a/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
+++ b/src/test-kernel/auth/SupabaseAuthProvider.vitest.ts
@@ -242,8 +242,7 @@ describe('SupabaseAuthProvider model availability', () => {
       session,
     });
     let authCallback:
-      | ((uri: { path: string; query: string }) => unknown)
-      | undefined;
+      ((uri: { path: string; query: string }) => unknown) | undefined;
     const handler = {
       onDidReceiveCallback: (
         listener: (uri: { path: string; query: string }) => unknown,

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts
@@ -19,7 +19,6 @@ import type {
   ToolEditApprovalRequest,
   ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
-import { delay } from '@utils/core';
 import {
   createStubDesktopAgentExecutionHost,
   disposeAfterTest,
@@ -124,11 +123,11 @@ async function pathExists(filePath: string): Promise<boolean> {
   }
 }
 
+/** Polls until `dir` is empty; fails the test if cleanup never completes. */
 async function waitForEmptyDir(dir: string): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt++) {
-    if ((await readdir(dir)).length === 0) return;
-    await delay(10);
-  }
+  await vi.waitFor(async () => {
+    expect(await readdir(dir)).toEqual([]);
+  });
 }
 
 async function loadApprovalModules(workspacePath = '/workspace') {

--- a/src/test-kernel/desktop/ElectronFileSelection.vitest.ts
+++ b/src/test-kernel/desktop/ElectronFileSelection.vitest.ts
@@ -29,6 +29,13 @@ const BASE_FILE_OPTIONS = [
   'templates/main.tex',
 ];
 
+/** Lets microtasks and a macrotask queued via `runAsync` settle. */
+function flushAsyncWork(): Promise<void> {
+  return new Promise((resolve) =>
+    setImmediate(() => setImmediate(() => resolve())),
+  );
+}
+
 /**
  * Post W4-collapse the desktop file selection module routes only single-slot
  * base/edited dropdowns + the disk-listing refresh; input/context/media are
@@ -201,7 +208,11 @@ describe('desktop file selection', () => {
         }),
       ).toBe(true);
 
-      await vi.waitFor(() => expect(showOpenFileDialog).not.toHaveBeenCalled());
+      // The picker path is async (dispatched via runAsync), so let queued
+      // work settle before asserting the picker stayed closed — a negative
+      // vi.waitFor would pass on its first poll without observing anything.
+      await flushAsyncWork();
+      expect(showOpenFileDialog).not.toHaveBeenCalled();
     },
   );
 

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
@@ -262,61 +262,52 @@ async function createMainViewHarness(
   };
 }
 
+type MainViewIpcOptions = Parameters<
+  MainViewIpcModule['installDesktopMainViewIpc']
+>[1];
+
+type MainViewHarness = Awaited<ReturnType<typeof createMainViewHarness>>;
+
+/**
+ * Installs the IPC router over a fresh harness with the default (all
+ * unhandled) capabilities plus the given overrides. The startup catalog
+ * loader is stubbed empty so only the behavior under test posts to the
+ * renderer.
+ */
+function installMainView(
+  harness: MainViewHarness,
+  overrides: Partial<MainViewIpcOptions> = {},
+): {
+  capabilities: ReturnType<typeof createMainViewCommandCapabilities>;
+  ipc: ReturnType<MainViewIpcModule['installDesktopMainViewIpc']>;
+} {
+  const capabilities = createMainViewCommandCapabilities();
+  const ipc = harness.installDesktopMainViewIpc(harness.window, {
+    ...capabilities,
+    loadStartupOptions: emptyStartupOptionsLoader([]),
+    ...overrides,
+  });
+  return { capabilities, ipc };
+}
+
 describe('desktop main-view IPC', () => {
-  it('pushes theme and debug state over the fixed host bridge channel', async () => {
-    let themeListener: (() => void) | undefined;
-    const {
-      installDesktopMainViewIpc,
-      ipcMain,
-      nativeTheme,
-      sends,
-      window,
-      closedListeners,
-      getRendererListener,
-      sendFromRenderer,
-    } = await createMainViewHarness({
-      shouldUseDarkColors: true,
-      onUpdated: (listener) => {
-        themeListener = listener;
-      },
-    });
-    const fileSelection = {
-      handleMessage: vi.fn(
-        (message: { command: string }) =>
-          message.command === MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE,
-      ),
-    };
-    const settings = {
-      handleMessage: vi.fn(
-        (message: { command: string }) =>
-          message.command === SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING,
-      ),
-    };
-    const progress = {
-      handleMessage: vi.fn(
-        (message: { command: string }) =>
-          message.command === PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
-      ),
-    };
-    const executeAgent = vi.fn(async (_message: unknown) => {});
+  it('registers one listener on the fixed host bridge channel', async () => {
+    const harness = await createMainViewHarness();
+    installMainView(harness);
 
-    const capabilities = createMainViewCommandCapabilities();
-    const ipc = installDesktopMainViewIpc(window, {
-      ...capabilities,
-      debugMode: true,
-      fileSelection,
-      settings,
-      progress,
-      executeAgent,
-      // This test only cares about theme/debug pushes; keep the startup
-      // catalog loader (which reads platform workspace state) out of scope.
-      loadStartupOptions: emptyStartupOptionsLoader([]),
-    });
-
-    expect(ipcMain.on).toHaveBeenCalledWith(
+    expect(harness.ipcMain.on).toHaveBeenCalledWith(
       ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
-      getRendererListener(),
+      harness.getRendererListener(),
     );
+  });
+
+  it('defers theme and debug pushes until the main view signals ready', async () => {
+    const harness = await createMainViewHarness({
+      shouldUseDarkColors: true,
+    });
+    installMainView(harness, { debugMode: true });
+    const { sends, sendFromRenderer } = harness;
+
     sendFromRenderer({ command: MAIN_VIEW_COMMANDS.GET_THEME }, {});
     expect(sends).toEqual([]);
 
@@ -348,6 +339,30 @@ describe('desktop main-view IPC', () => {
         message: { command: COMMON_COMMANDS.DEBUG_MODE_SET, debugMode: true },
       },
     ]);
+  });
+
+  it('routes file-selection, settings, and progress messages to their handlers', async () => {
+    const harness = await createMainViewHarness();
+    const fileSelection = {
+      handleMessage: vi.fn(
+        (message: { command: string }) =>
+          message.command === MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE,
+      ),
+    };
+    const settings = {
+      handleMessage: vi.fn(
+        (message: { command: string }) =>
+          message.command === SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING,
+      ),
+    };
+    const progress = {
+      handleMessage: vi.fn(
+        (message: { command: string }) =>
+          message.command === PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
+      ),
+    };
+    installMainView(harness, { fileSelection, settings, progress });
+    const { sendFromRenderer } = harness;
 
     sendFromRenderer({ command: MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE });
     expect(fileSelection.handleMessage).toHaveBeenCalledWith({
@@ -373,13 +388,31 @@ describe('desktop main-view IPC', () => {
       command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
       stream: 'run-1',
     });
+  });
 
-    sends.length = 0;
+  it('routes recent-commit requests to the shell without renderer pushes', async () => {
+    const harness = await createMainViewHarness();
+    const { capabilities } = installMainView(harness);
+    const { sends, sendFromRenderer } = harness;
+
     sendFromRenderer({ command: MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS });
     expect(capabilities.shellActions.sendRecentCommits).toHaveBeenCalledOnce();
     expect(sends).toEqual([]);
+  });
 
+  it('answers GET_THEME with the current native theme', async () => {
+    const harness = await createMainViewHarness({
+      shouldUseDarkColors: true,
+    });
+    installMainView(harness);
+    const { nativeTheme, sends, sendFromRenderer } = harness;
+
+    sendFromRenderer({
+      command: MAIN_VIEW_COMMANDS.WEBVIEW_READY,
+      view: 'main',
+    });
     sends.length = 0;
+
     nativeTheme.shouldUseDarkColors = false;
     sendFromRenderer({ command: MAIN_VIEW_COMMANDS.GET_THEME });
     expect(sends).toEqual([
@@ -388,8 +421,19 @@ describe('desktop main-view IPC', () => {
         message: { command: COMMON_COMMANDS.THEME_SET, theme: 'light' },
       },
     ]);
+  });
 
+  it('answers GET_DEBUG_MODE with the configured flag', async () => {
+    const harness = await createMainViewHarness();
+    installMainView(harness, { debugMode: true });
+    const { sends, sendFromRenderer } = harness;
+
+    sendFromRenderer({
+      command: MAIN_VIEW_COMMANDS.WEBVIEW_READY,
+      view: 'main',
+    });
     sends.length = 0;
+
     sendFromRenderer({ command: MAIN_VIEW_COMMANDS.GET_DEBUG_MODE });
     expect(sends).toEqual([
       {
@@ -397,16 +441,26 @@ describe('desktop main-view IPC', () => {
         message: { command: COMMON_COMMANDS.DEBUG_MODE_SET, debugMode: true },
       },
     ]);
+  });
 
-    sends.length = 0;
+  it('routes SWITCH_VIEW to the launcher without renderer pushes', async () => {
+    const harness = await createMainViewHarness();
+    const { capabilities } = installMainView(harness);
+    const { sends, sendFromRenderer } = harness;
+
     sendFromRenderer({
       command: COMMON_COMMANDS.SWITCH_VIEW,
       view: 'main',
     });
     expect(capabilities.shellActions.showLauncher).toHaveBeenCalledOnce();
     expect(sends).toEqual([]);
+  });
 
-    sends.length = 0;
+  it('routes settings and agent-directory commands to shell actions', async () => {
+    const harness = await createMainViewHarness();
+    const { capabilities } = installMainView(harness);
+    const { sends, sendFromRenderer } = harness;
+
     sendFromRenderer({
       command: COMMON_COMMANDS.SWITCH_VIEW,
       view: 'dashboard',
@@ -437,7 +491,6 @@ describe('desktop main-view IPC', () => {
     );
     expect(sends).toEqual([]);
 
-    sends.length = 0;
     sendFromRenderer({
       command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY,
       customDirSet: true,
@@ -446,6 +499,13 @@ describe('desktop main-view IPC', () => {
       true,
     );
     expect(sends).toEqual([]);
+  });
+
+  it('forwards EXECUTE messages to the injected executor', async () => {
+    const harness = await createMainViewHarness();
+    const executeAgent = vi.fn(async (_message: unknown) => {});
+    installMainView(harness, { executeAgent });
+    const { sendFromRenderer } = harness;
 
     const executeMessage = {
       command: MAIN_VIEW_COMMANDS.EXECUTE,
@@ -455,6 +515,23 @@ describe('desktop main-view IPC', () => {
     sendFromRenderer(executeMessage);
     await Promise.resolve();
     expect(executeAgent).toHaveBeenCalledWith(executeMessage);
+  });
+
+  it('pushes the new theme when the native theme changes', async () => {
+    let themeListener: (() => void) | undefined;
+    const harness = await createMainViewHarness({
+      shouldUseDarkColors: true,
+      onUpdated: (listener) => {
+        themeListener = listener;
+      },
+    });
+    installMainView(harness);
+    const { nativeTheme, sends, sendFromRenderer } = harness;
+
+    sendFromRenderer({
+      command: MAIN_VIEW_COMMANDS.WEBVIEW_READY,
+      view: 'main',
+    });
 
     nativeTheme.shouldUseHighContrastColors = true;
     themeListener?.();
@@ -465,17 +542,35 @@ describe('desktop main-view IPC', () => {
         theme: 'high-contrast',
       },
     });
+  });
+
+  it('relays postToRenderer over the push channel', async () => {
+    const harness = await createMainViewHarness();
+    const { ipc } = installMainView(harness);
+    const { sends } = harness;
 
     ipc.postToRenderer({ command: 'customPush' });
     expect(sends.at(-1)).toEqual({
       channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
       message: { command: 'customPush' },
     });
+  });
+
+  it('disposes listeners idempotently', async () => {
+    let themeListener: (() => void) | undefined;
+    const harness = await createMainViewHarness({
+      onUpdated: (listener) => {
+        themeListener = listener;
+      },
+    });
+    const { capabilities, ipc } = installMainView(harness);
+    const { closedListeners, ipcMain, nativeTheme } = harness;
 
     ipc.dispose();
     expect(nativeTheme.off).toHaveBeenCalledWith('updated', themeListener);
     expect(ipcMain.off).toHaveBeenCalledTimes(1);
     expect(capabilities.prompt.dispose).toHaveBeenCalledOnce();
+
     closedListeners.forEach((listener) => listener());
     expect(ipcMain.off).toHaveBeenCalledTimes(1);
     expect(capabilities.prompt.dispose).toHaveBeenCalledOnce();

--- a/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.ts
+++ b/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.ts
@@ -137,11 +137,13 @@ describe('desktop renderer bootstrap fallback', () => {
   it('wraps the initial render in a try/catch with a fallback UI', () => {
     const source = loadRendererMain();
     expect(source).toContain('renderBootstrapFallback');
-    expect(source).toContain('try {');
-    expect(source).toContain('logsController.rerenderViewer();');
-    expect(source).toContain('rerenderShell();');
-    expect(source).toContain('catch (error)');
-    expect(source).toContain('bootstrapFailed');
+    // The initial render (rerender + shell) must sit inside the bootstrap
+    // try/catch whose handler flags the failure and renders the fallback —
+    // a bare `try {`/`catch (error)` containment check would match almost
+    // any source, so pin the whole guard structurally.
+    expect(source).toMatch(
+      /try \{\s*logsController\.rerenderViewer\(\);\s*rerenderShell\(\);[\s\S]*?\} catch \(error\) \{\s*bootstrapFailed = true;[\s\S]*?renderBootstrapFallback\(error\);/,
+    );
   });
 
   it('renders a Reload control and a "continue without saved secrets" affordance', () => {

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -12,6 +12,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { buildStreamInfos } from '@controllers/session/streamInfoUtils';
 import { SessionFactApplier } from '@controllers/session/SessionFactApplier';
+import { setOutputChannelFactory } from '@logger/logUtils';
 import {
   AgentCategory,
   type ActiveChildInfo,
@@ -524,10 +525,6 @@ describe('ProgressBackend', () => {
   it('applies session run facts through the fact-native handler', async () => {
     const target = createListeningBackend();
     const { backend } = target;
-    const handleRunFact = vi.spyOn(
-      SessionFactApplier.prototype,
-      'handleRunFact',
-    );
     const updateFiles = vi.spyOn(backend.webviewUpdater, 'updateFiles');
     const updateMissingOutputs = vi.spyOn(
       backend.webviewUpdater,
@@ -584,7 +581,6 @@ describe('ProgressBackend', () => {
       agentCategory: AgentCategory.Workflow,
     });
     for (const spy of [
-      handleRunFact,
       updateFiles,
       updateMissingOutputs,
       updateCompileFailures,
@@ -634,7 +630,6 @@ describe('ProgressBackend', () => {
       streamId,
     });
 
-    expect(handleRunFact).toHaveBeenCalledTimes(7);
     expect(updateFiles).toHaveBeenCalledTimes(1);
     expect(updateFiles).toHaveBeenCalledWith(streamId, {
       rounds: { 1: [outputFile] },
@@ -706,10 +701,6 @@ describe('ProgressBackend', () => {
   it('no-ops session output-file run facts after dispose', async () => {
     const target = createListeningBackend();
     const { backend } = target;
-    const handleRunFact = vi.spyOn(
-      SessionFactApplier.prototype,
-      'handleRunFact',
-    );
     const updateFiles = vi.spyOn(backend.webviewUpdater, 'updateFiles');
     const streamId = 'session:output-files-after-dispose' as StreamTabId;
     const outputFile = paperOutputFile();
@@ -719,7 +710,6 @@ describe('ProgressBackend', () => {
       streamId,
       agentCategory: AgentCategory.Workflow,
     });
-    handleRunFact.mockClear();
     updateFiles.mockClear();
     backend.dispose();
 
@@ -729,7 +719,6 @@ describe('ProgressBackend', () => {
       filesByRound: { 1: [outputFile] },
     });
 
-    expect(handleRunFact).not.toHaveBeenCalled();
     expect(updateFiles).not.toHaveBeenCalled();
     // The presentation no-ops, but the sidecar store is session-owned, so it
     // keeps recording: disposing one window/webview must not stop the runtime
@@ -1021,38 +1010,46 @@ describe('ProgressBackend', () => {
     }
   });
 
-  it('propagates async fact-handler promises to the error wrapper', async () => {
-    const { backend } = createRecordingBackend();
-    const stream = 'tool-stream' as StreamTabId;
-
-    // A tracking thenable: `withEventErrorHandling` does
-    // `Promise.resolve(result).catch(...)`, which adopts (calls `.then` on) the
-    // handler's result only when the dispatch wrapper actually RETURNED it. A
-    // block-bodied handler that discarded the promise would hand
-    // `withEventErrorHandling` `undefined`, leaving this untouched — and a
-    // post-await rejection would then escape logging as an unhandled rejection.
-    let adopted = 0;
-    const tracking: PromiseLike<void> = {
-      then(onFulfilled, onRejected) {
-        adopted += 1;
-        return Promise.resolve().then(onFulfilled, onRejected);
+  it('logs a rejecting async fact handler through the SessionFacts channel', async () => {
+    // The observable contract of the dispatch wrapper returning handler
+    // promises to `withEventErrorHandling`: a post-await rejection reaches the
+    // SessionFacts error log instead of escaping as an unhandled rejection. A
+    // block-bodied handler that discarded its promise would leave this line
+    // unwritten (and the run would flag an unhandled rejection instead).
+    const lines: string[] = [];
+    setOutputChannelFactory(() => ({
+      appendLine: (line: string) => {
+        lines.push(line);
       },
-    };
-    vi.spyOn(SessionFactApplier.prototype, 'setStreamStatus').mockReturnValue(
-      tracking as Promise<void>,
-    );
+    }));
+    try {
+      const { backend } = createRecordingBackend();
+      const stream = 'tool-stream' as StreamTabId;
+      const failure = new Error('status application exploded');
+      vi.spyOn(
+        SessionFactApplier.prototype,
+        'setStreamStatus',
+      ).mockRejectedValue(failure);
 
-    backend.applySessionFact({
-      type: 'status',
-      streamId: stream,
-      phase: STREAM_PHASE.RUNNING,
-      cause: 'lifecycle',
-    });
+      backend.applySessionFact({
+        type: 'status',
+        streamId: stream,
+        phase: STREAM_PHASE.RUNNING,
+        cause: 'lifecycle',
+      });
 
-    // Thenable adoption runs on a microtask; flush before asserting.
-    await new Promise((resolve) => setImmediate(resolve));
-
-    expect(adopted).toBe(1);
+      await vi.waitFor(() => {
+        expect(
+          lines.some(
+            (line) =>
+              line.startsWith('ERROR') &&
+              line.includes('[SessionFacts] failed to handle status fact'),
+          ),
+        ).toBe(true);
+      });
+    } finally {
+      setOutputChannelFactory(null);
+    }
   });
 
   it('keeps snapshot metadata canonical across rendering and sync content', () => {

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import type { ProgressHostInteractions } from '@controllers/progressView/backend/progressHostInteractions';
+import * as logger from '@logger/logUtils';
 import { ProgressViewMessageHandler } from '@progressView/ProgressViewMessageHandler';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import type { StreamTabId } from '@shared/schemas';
@@ -90,16 +91,11 @@ function createProgressViewProvider(): ProgressViewProviderFake {
     snapshots,
     pickValidActiveStream: vi.fn(() => ''),
     waitForOwnedExecutionRelease: vi.fn(async () => undefined),
-    clearStream: vi.fn(async (_stream: StreamTabId) => 'deleted' as const),
-    clearAll: vi.fn(async () => ({
-      active: new Set<StreamTabId>(),
-      failed: new Set<StreamTabId>(),
-    })),
   };
   return {
     state,
     backend: {
-      deleteStream: (stream: StreamTabId) => state.clearStream(stream),
+      deleteStream: vi.fn(),
       deleteAllStreams: vi.fn(),
       stopStream: vi.fn(),
     },
@@ -477,16 +473,30 @@ describe('progress-view onboarding refresh wiring', () => {
     await expect(provider.refreshOnboardingFunnel()).resolves.toBeUndefined();
   });
 
-  it('returns deletion failures from host removeStream handling', async () => {
+  it('logs deletion failures from stream removal instead of a raw rejection', async () => {
     const provider = createProgressViewProvider();
     const deletionError = new Error('delete failed');
-    const clearStream = provider.state.clearStream as ReturnType<typeof vi.fn>;
-    clearStream.mockRejectedValue(deletionError);
+    const deleteStream = provider.backend
+      .deleteStream as unknown as ReturnType<typeof vi.fn>;
+    deleteStream.mockRejectedValue(deletionError);
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const handler = createMessageHandler(provider);
 
-    const result = provider.backend.deleteStream('missing' as StreamTabId);
+    await handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
+        stream: 'missing' as StreamTabId,
+      },
+      createWebviewView(),
+    );
 
-    expect(result).toBeInstanceOf(Promise);
-    await expect(result).rejects.toBe(deletionError);
-    expect(clearStream).toHaveBeenCalledWith('missing');
+    expect(deleteStream).toHaveBeenCalledWith('missing');
+    await vi.waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        'ProgressViewMessageHandler',
+        'Error handling message',
+        expect.objectContaining({ data: deletionError }),
+      );
+    });
   });
 });

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
@@ -476,8 +476,9 @@ describe('progress-view onboarding refresh wiring', () => {
   it('logs deletion failures from stream removal instead of a raw rejection', async () => {
     const provider = createProgressViewProvider();
     const deletionError = new Error('delete failed');
-    const deleteStream = provider.backend
-      .deleteStream as unknown as ReturnType<typeof vi.fn>;
+    const deleteStream = provider.backend.deleteStream as unknown as ReturnType<
+      typeof vi.fn
+    >;
     deleteStream.mockRejectedValue(deletionError);
     const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const handler = createMessageHandler(provider);

--- a/src/test-kernel/settings/CopilotRoutePreferenceHandler.vitest.ts
+++ b/src/test-kernel/settings/CopilotRoutePreferenceHandler.vitest.ts
@@ -9,7 +9,6 @@ const mocks = vi.hoisted(() => ({
   invalidateRuntimeModelRegistry: vi.fn(),
   requestRuntimeModelAccess: vi.fn(),
   safeExecuteCommand: vi.fn(async () => undefined),
-  sendModelSelectionData: vi.fn(async () => undefined),
   setCopilotRoutePreference: vi.fn(async () => undefined),
   showLoggedErrorMessage: vi.fn(async () => undefined),
   showLoggedInfoMessage: vi.fn(async () => undefined),
@@ -56,81 +55,136 @@ vi.mock('@frontend/ui/errorHandlingUtils', async (original) => {
   };
 });
 
+// The shared vscode stub predates workspace-folder listeners; the handler's
+// constructor subscribes to folder changes to re-register its history watcher.
+vi.mock('vscode', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vscode')>();
+  return {
+    ...actual,
+    workspace: {
+      ...actual.workspace,
+      onDidChangeWorkspaceFolders: () => ({ dispose: () => {} }),
+    },
+  };
+});
+
 // Local imports
 import { SettingsViewMessageHandler } from '@settingsView/SettingsViewMessageHandler';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type * as vscode from 'vscode';
 
-type CopilotPreferenceHarness = {
-  handleRequestModelAccess(modelName: string): Promise<void>;
-  handleClearCopilotRoute(modelName: string): Promise<void>;
+/** Private method type surface used only to stub the post-action refresh. */
+type RefreshSurface = {
+  sendModelSelectionData(webview: vscode.Webview): Promise<void>;
 };
 
-function createHarness(): CopilotPreferenceHarness {
-  const handler = Object.create(SettingsViewMessageHandler.prototype);
-  Reflect.set(handler, 'channel', 'SettingsViewMessageHandler');
-  Reflect.set(handler, 'viewName', 'SettingsView');
-  Reflect.set(handler, 'sendModelSelectionData', mocks.sendModelSelectionData);
-  Reflect.set(
-    handler,
-    'withActiveWebview',
-    vi.fn(async (fn: (webview: object) => Promise<void>) => fn({})),
+/**
+ * The real constructor wires channel/viewName, the command registry, and the
+ * history watcher from the extension context; the fake context only needs the
+ * subscriptions sink and an extension path for handler delegates.
+ */
+function createHandler(): SettingsViewMessageHandler {
+  return new SettingsViewMessageHandler({
+    subscriptions: [],
+    extensionPath: '/ext',
+  } as unknown as vscode.ExtensionContext);
+}
+
+function createWebviewView(): vscode.WebviewView {
+  return {
+    webview: { postMessage: vi.fn(async () => true) },
+  } as unknown as vscode.WebviewView;
+}
+
+function requestModelAccess(
+  handler: SettingsViewMessageHandler,
+  modelName: string,
+): Promise<void> {
+  return handler.handleMessage(
+    { command: SETTINGS_VIEW_COMMANDS.REQUEST_MODEL_ACCESS, modelName },
+    createWebviewView(),
   );
-  return handler as CopilotPreferenceHarness;
+}
+
+function clearCopilotRoute(
+  handler: SettingsViewMessageHandler,
+  modelName: string,
+): Promise<void> {
+  return handler.handleMessage(
+    { command: SETTINGS_VIEW_COMMANDS.CLEAR_COPILOT_ROUTE, modelName },
+    createWebviewView(),
+  );
 }
 
 describe('Copilot route preference handler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The refresh fan-out after a route change re-sends the full model
+    // selection payload; it is orthogonal to the routing decision under test.
+    // A prototype spy fails loudly on rename, unlike an injected field.
+    vi.spyOn(
+      SettingsViewMessageHandler.prototype as unknown as RefreshSurface,
+      'sendModelSelectionData',
+    ).mockResolvedValue(undefined);
   });
 
   it('revalidates and persists an allowed opt-in', async () => {
     mocks.requestRuntimeModelAccess.mockResolvedValueOnce('already-allowed');
-    const handler = createHarness();
+    const handler = createHandler();
 
-    await handler.handleRequestModelAccess('sonnet46');
+    await requestModelAccess(handler, 'sonnet46');
 
+    await vi.waitFor(() => {
+      expect(mocks.setCopilotRoutePreference).toHaveBeenCalledWith(
+        'sonnet46',
+        true,
+      );
+    });
     expect(mocks.requestRuntimeModelAccess).toHaveBeenCalledWith('sonnet46');
-    expect(mocks.setCopilotRoutePreference).toHaveBeenCalledWith(
-      'sonnet46',
-      true,
-    );
     expect(mocks.showLoggedInfoMessage).not.toHaveBeenCalled();
   });
 
   it('uses the current consent flow before persisting a stale allowed opt-in', async () => {
     mocks.requestRuntimeModelAccess.mockResolvedValueOnce('requested');
-    const handler = createHarness();
+    const handler = createHandler();
 
-    await handler.handleRequestModelAccess('sonnet46');
+    await requestModelAccess(handler, 'sonnet46');
 
+    await vi.waitFor(() => {
+      expect(mocks.setCopilotRoutePreference).toHaveBeenCalledWith(
+        'sonnet46',
+        true,
+      );
+    });
     expect(mocks.requestRuntimeModelAccess).toHaveBeenCalledWith('sonnet46');
-    expect(mocks.setCopilotRoutePreference).toHaveBeenCalledWith(
-      'sonnet46',
-      true,
-    );
   });
 
   it('rejects an opt-in that has become unavailable with actionable feedback', async () => {
     mocks.requestRuntimeModelAccess.mockResolvedValueOnce('unavailable');
-    const handler = createHarness();
+    const handler = createHandler();
 
-    await handler.handleRequestModelAccess('sonnet46');
+    await requestModelAccess(handler, 'sonnet46');
 
+    await vi.waitFor(() => {
+      expect(mocks.showLoggedInfoMessage).toHaveBeenCalledWith(
+        'SettingsViewMessageHandler',
+        'This Copilot model is no longer available in VS Code. Refresh the model list and choose another model.',
+      );
+    });
     expect(mocks.setCopilotRoutePreference).not.toHaveBeenCalled();
-    expect(mocks.showLoggedInfoMessage).toHaveBeenCalledWith(
-      'SettingsViewMessageHandler',
-      'This Copilot model is no longer available in VS Code. Refresh the model list and choose another model.',
-    );
   });
 
   it('allows opt-out without consulting current Copilot access', async () => {
-    const handler = createHarness();
+    const handler = createHandler();
 
-    await handler.handleClearCopilotRoute('sonnet46');
+    await clearCopilotRoute(handler, 'sonnet46');
 
+    await vi.waitFor(() => {
+      expect(mocks.setCopilotRoutePreference).toHaveBeenCalledWith(
+        'sonnet46',
+        false,
+      );
+    });
     expect(mocks.requestRuntimeModelAccess).not.toHaveBeenCalled();
-    expect(mocks.setCopilotRoutePreference).toHaveBeenCalledWith(
-      'sonnet46',
-      false,
-    );
   });
 });

--- a/src/test-kernel/settings/ExecutionHistoryWatcher.vitest.ts
+++ b/src/test-kernel/settings/ExecutionHistoryWatcher.vitest.ts
@@ -1,7 +1,7 @@
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
 
 import * as logger from '@logger/logUtils';
@@ -9,20 +9,59 @@ import { SettingsViewMessageHandler } from '@settingsView/SettingsViewMessageHan
 import { createDeferred } from '@test/support/asyncTestUtils';
 import { StorageFS } from '@utils/files';
 
-type WatcherHarness = {
-  executionsWatcher?: vscode.FileSystemWatcher;
-  executionsWatcherGeneration: number;
-  invalidateExecutionsWatcher: () => number;
-  registerExecutionsWatcher: () => Promise<void>;
+const mocks = vi.hoisted(() => ({
+  workspaceFoldersListeners: [] as Array<() => void>,
+}));
+
+// The shared vscode stub predates workspace-folder listeners; capture them so
+// tests drive re-registration through the same event the extension host fires.
+vi.mock('vscode', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vscode')>();
+  return {
+    ...actual,
+    workspace: {
+      ...actual.workspace,
+      onDidChangeWorkspaceFolders: (listener: () => void) => {
+        mocks.workspaceFoldersListeners.push(listener);
+        return { dispose: vi.fn() };
+      },
+    },
+  };
+});
+
+type HandlerFixture = {
+  /** Fires the workspace-folders-changed event the handler subscribes to. */
+  fireWorkspaceFoldersChanged(): void;
+  /** Disposes every subscription the constructor registered (view teardown). */
+  disposeSubscriptions(): void;
 };
 
-function createHandlerHarness(): WatcherHarness {
-  // The full constructor requires a live ExtensionContext; these methods reach
-  // only the explicitly initialized watcher, generation, and logging fields.
-  const handler = Object.create(SettingsViewMessageHandler.prototype);
-  Reflect.set(handler, 'channel', 'SettingsViewMessageHandler');
-  Reflect.set(handler, 'executionsWatcherGeneration', 0);
-  return handler as WatcherHarness;
+/**
+ * The real constructor kicks off the initial watcher registration and wires
+ * re-registration to folder changes and teardown to context subscriptions, so
+ * every scenario below is driven through those public triggers.
+ */
+function createHandler(): HandlerFixture {
+  const subscriptions: Array<{ dispose(): void }> = [];
+  new SettingsViewMessageHandler({
+    subscriptions,
+    extensionPath: '/ext',
+  } as unknown as vscode.ExtensionContext);
+  return {
+    fireWorkspaceFoldersChanged: () => {
+      for (const listener of mocks.workspaceFoldersListeners) listener();
+    },
+    disposeSubscriptions: () => {
+      for (const subscription of subscriptions.splice(0)) {
+        subscription.dispose();
+      }
+    },
+  };
+}
+
+/** Let queued registration continuations (microtasks) run to completion. */
+function flushRegistrations(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
 }
 
 function watcher(): vscode.FileSystemWatcher {
@@ -38,19 +77,25 @@ function watcher(): vscode.FileSystemWatcher {
 }
 
 describe('settings execution history watcher', () => {
+  beforeEach(() => {
+    mocks.workspaceFoldersListeners.length = 0;
+  });
+
   afterEach(() => vi.restoreAllMocks());
 
   it('logs and absorbs directory setup failures', async () => {
     const failure = new Error('permission denied');
     vi.spyOn(StorageFS, 'ensureDir').mockRejectedValue(failure);
     const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
-    const handler = createHandlerHarness();
 
-    await expect(handler.registerExecutionsWatcher()).resolves.toBeUndefined();
-    expect(errorSpy).toHaveBeenCalledWith(
-      'SettingsViewMessageHandler',
-      'Failed to register execution history watcher: permission denied',
-    );
+    createHandler();
+
+    await vi.waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        'SettingsViewMessageHandler',
+        'Failed to register execution history watcher: permission denied',
+      );
+    });
   });
 
   it('keeps the newest watcher when setup completes out of order', async () => {
@@ -58,59 +103,66 @@ describe('settings execution history watcher', () => {
     const secondSetup = createDeferred();
     vi.spyOn(StorageFS, 'ensureDir')
       .mockImplementationOnce(() => firstSetup.promise)
-      .mockImplementationOnce(() => secondSetup.promise);
+      .mockImplementationOnce(() => secondSetup.promise)
+      .mockResolvedValue(undefined);
     const currentWatcher = watcher();
     const createWatcher = vi
       .spyOn(vscode.workspace, 'createFileSystemWatcher')
       .mockReturnValue(currentWatcher);
-    const handler = createHandlerHarness();
 
-    const first = handler.registerExecutionsWatcher();
-    const second = handler.registerExecutionsWatcher();
+    // The constructor's registration pends on firstSetup; the folder-change
+    // re-registration pends on secondSetup and wins the generation race.
+    const fixture = createHandler();
+    fixture.fireWorkspaceFoldersChanged();
     secondSetup.resolve();
-    await second;
+    await vi.waitFor(() => expect(createWatcher).toHaveBeenCalledOnce());
     firstSetup.resolve();
-    await first;
+    await flushRegistrations();
 
     expect(createWatcher).toHaveBeenCalledTimes(1);
-    expect(handler.executionsWatcher).toBe(currentWatcher);
     expect(currentWatcher.dispose).not.toHaveBeenCalled();
+
+    // The next re-registration invalidates (disposes) whichever watcher is
+    // live — proving the out-of-order loser never got published.
+    fixture.fireWorkspaceFoldersChanged();
+    expect(currentWatcher.dispose).toHaveBeenCalledOnce();
   });
 
   it('disposes a candidate made stale by synchronous reentrancy', async () => {
     vi.spyOn(StorageFS, 'ensureDir').mockResolvedValue(undefined);
     const staleWatcher = watcher();
     const currentWatcher = watcher();
-    const handler = createHandlerHarness();
-    let second: Promise<void> | undefined;
-    vi.spyOn(vscode.workspace, 'createFileSystemWatcher')
+    const createWatcher = vi
+      .spyOn(vscode.workspace, 'createFileSystemWatcher')
       .mockImplementationOnce(() => {
-        second = handler.registerExecutionsWatcher();
+        // A folder change lands while the constructor's registration is
+        // mid-setup: its candidate is stale the moment it returns.
+        fixture.fireWorkspaceFoldersChanged();
         return staleWatcher;
       })
-      .mockReturnValueOnce(currentWatcher);
+      .mockReturnValue(currentWatcher);
+    const fixture = createHandler();
 
-    await handler.registerExecutionsWatcher();
-    if (!second) throw new Error('reentrant registration did not start');
-    await second;
+    await vi.waitFor(() => expect(createWatcher).toHaveBeenCalledTimes(2));
+    await flushRegistrations();
 
     expect(staleWatcher.dispose).toHaveBeenCalledOnce();
     expect(currentWatcher.dispose).not.toHaveBeenCalled();
-    expect(handler.executionsWatcher).toBe(currentWatcher);
+
+    fixture.fireWorkspaceFoldersChanged();
+    expect(currentWatcher.dispose).toHaveBeenCalledOnce();
   });
 
   it('invalidates setup still pending during teardown', async () => {
     const setup = createDeferred();
     vi.spyOn(StorageFS, 'ensureDir').mockReturnValue(setup.promise);
     const createWatcher = vi.spyOn(vscode.workspace, 'createFileSystemWatcher');
-    const handler = createHandlerHarness();
+    const fixture = createHandler();
 
-    const registration = handler.registerExecutionsWatcher();
-    handler.invalidateExecutionsWatcher();
+    fixture.disposeSubscriptions();
     setup.resolve();
-    await registration;
+    await flushRegistrations();
 
     expect(createWatcher).not.toHaveBeenCalled();
-    expect(handler.executionsWatcher).toBeUndefined();
   });
 });

--- a/src/test-kernel/settings/SettingsGoalList.vitest.ts
+++ b/src/test-kernel/settings/SettingsGoalList.vitest.ts
@@ -10,15 +10,31 @@ import type { StreamTabId } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { GoalStore } from '@tools/goal';
 
+// The shared vscode stub predates workspace-folder listeners; the handler's
+// constructor subscribes to folder changes to re-register its history watcher.
+vi.mock('vscode', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vscode')>();
+  return {
+    ...actual,
+    workspace: {
+      ...actual.workspace,
+      onDidChangeWorkspaceFolders: () => ({ dispose: () => {} }),
+    },
+  };
+});
+
 const STREAM_ID = 'stream:settings-goal-list' as StreamTabId;
 const GOAL_KEY = `goals:byStream:${STREAM_ID}`;
 
-type GoalListHarness = Pick<SettingsViewMessageHandler, 'sendGoalList'>;
-
-function createHandlerHarness(): GoalListHarness {
-  const handler = Object.create(SettingsViewMessageHandler.prototype);
-  Reflect.set(handler, 'channel', 'SettingsViewMessageHandler');
-  return handler as GoalListHarness;
+/**
+ * The real constructor wires channel/viewName and the history watcher from
+ * the extension context; the fake context only needs the subscriptions sink.
+ */
+function createHandler(): SettingsViewMessageHandler {
+  return new SettingsViewMessageHandler({
+    subscriptions: [],
+    extensionPath: '/ext',
+  } as unknown as vscode.ExtensionContext);
 }
 
 function createWebview(): vscode.Webview {
@@ -38,7 +54,7 @@ async function expectSendGoalListFailure(
   const showErrorMessage = vi.spyOn(vscode.window, 'showErrorMessage');
 
   await expect(
-    createHandlerHarness().sendGoalList(webview),
+    createHandler().sendGoalList(webview),
   ).resolves.toBeUndefined();
 
   expect(showErrorMessage).toHaveBeenCalledWith(expectedError);
@@ -53,7 +69,7 @@ describe('settings goal list', () => {
     const goal = await GoalStore.start(STREAM_ID, 'Finish the settings fix.');
     const webview = createWebview();
 
-    await createHandlerHarness().sendGoalList(webview);
+    await createHandler().sendGoalList(webview);
 
     expect(webview.postMessage).toHaveBeenCalledWith({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_GOAL_LIST,

--- a/src/test-kernel/settings/SettingsGoalList.vitest.ts
+++ b/src/test-kernel/settings/SettingsGoalList.vitest.ts
@@ -53,9 +53,7 @@ async function expectSendGoalListFailure(
 ): Promise<void> {
   const showErrorMessage = vi.spyOn(vscode.window, 'showErrorMessage');
 
-  await expect(
-    createHandler().sendGoalList(webview),
-  ).resolves.toBeUndefined();
+  await expect(createHandler().sendGoalList(webview)).resolves.toBeUndefined();
 
   expect(showErrorMessage).toHaveBeenCalledWith(expectedError);
 }

--- a/src/test-kernel/supabase/RelayModelAccess.vitest.ts
+++ b/src/test-kernel/supabase/RelayModelAccess.vitest.ts
@@ -33,6 +33,7 @@ vi.mock('llm-zoo', async (importOriginal) => {
 // Local imports - Supabase relay
 import {
   FREE_TIER,
+  FREE_TIER_SUGGESTED_MODEL,
   MAX_TIER,
   PROVIDER_CONFIGS,
   TIER_CONFIG,
@@ -57,22 +58,63 @@ describe('relay tier model access', () => {
   it('limits Max to non-Ultra providers and keeps Ultra passthrough', () => {
     const maxModels = TIER_CONFIG.tiers.Max?.models;
     assert.ok(Array.isArray(maxModels));
-    assert.deepEqual(
-      maxModels,
-      Object.values(MODEL_CONFIGS)
-        .filter(
-          (model) =>
-            TIER_CONFIG.providers.includes(model.provider) &&
-            !model.openRouterOnly &&
-            !model.retired &&
-            !ULTRA_ONLY_PROVIDER_SET.has(model.provider.toLowerCase()) &&
-            // Kimi Code membership models are pinned to the coding endpoint and
-            // are not relay-servable (see RELAY_MODELS in models.ts).
-            (model as { baseUrl?: string }).baseUrl !==
-              'https://api.kimi.com/coding/v1',
-        )
-        .map((model) => model.name),
-    );
+    assert.ok(maxModels.length > 0);
+
+    // Assert the contract on each advertised member with independent
+    // per-property checks instead of re-deriving the list with a mirrored
+    // filter chain: a predicate mistake copied into both sides of the
+    // assertion would pass silently, while these checks fail if production
+    // drops any one of its filters (see RELAY_MODELS in models.ts).
+    const configsByName = new Map<
+      string,
+      (typeof MODEL_CONFIGS)[string][]
+    >();
+    for (const config of Object.values(MODEL_CONFIGS)) {
+      const list = configsByName.get(config.name) ?? [];
+      list.push(config);
+      configsByName.set(config.name, list);
+    }
+    for (const name of maxModels) {
+      const candidates = configsByName.get(name) ?? [];
+      assert.ok(
+        candidates.length > 0,
+        `Max-advertised model '${name}' must exist in llm-zoo`,
+      );
+      // Model names are unique among relay-servable entries (the only
+      // duplicate name in the pinned registry is an Ultra-only Google
+      // model), so every entry behind an advertised name must qualify.
+      for (const model of candidates) {
+        assert.equal(model.retired ?? false, false, `'${name}' is retired`);
+        assert.equal(
+          model.openRouterOnly ?? false,
+          false,
+          `'${name}' is openRouterOnly`,
+        );
+        assert.equal(
+          TIER_CONFIG.providers.includes(model.provider),
+          true,
+          `'${name}' provider '${model.provider}' is not relay-routable`,
+        );
+        assert.equal(
+          ULTRA_ONLY_PROVIDER_SET.has(model.provider.toLowerCase()),
+          false,
+          `'${name}' belongs to an Ultra-only provider`,
+        );
+        // Kimi Code membership models are pinned to the coding endpoint and
+        // are not relay-servable.
+        assert.notEqual(
+          (model as { baseUrl?: string }).baseUrl,
+          'https://api.kimi.com/coding/v1',
+          `'${name}' is pinned to the Kimi coding endpoint`,
+        );
+      }
+      // The advertised list and the request gate must agree.
+      assert.equal(isModelAllowedForTier(MAX_TIER, name), true);
+    }
+    // The free-tier suggestion is what over-tier 403 denials point users at,
+    // so it must stay reachable on Max.
+    assert.ok(maxModels.includes(FREE_TIER_SUGGESTED_MODEL));
+
     assert.equal(TIER_CONFIG.tiers.Ultra?.models, '*');
 
     assert.equal(isModelAllowedForTier(MAX_TIER, 'unknown-model'), true);

--- a/src/test-kernel/supabase/RelayModelAccess.vitest.ts
+++ b/src/test-kernel/supabase/RelayModelAccess.vitest.ts
@@ -65,10 +65,7 @@ describe('relay tier model access', () => {
     // filter chain: a predicate mistake copied into both sides of the
     // assertion would pass silently, while these checks fail if production
     // drops any one of its filters (see RELAY_MODELS in models.ts).
-    const configsByName = new Map<
-      string,
-      (typeof MODEL_CONFIGS)[string][]
-    >();
+    const configsByName = new Map<string, (typeof MODEL_CONFIGS)[string][]>();
     for (const config of Object.values(MODEL_CONFIGS)) {
       const list = configsByName.get(config.name) ?? [];
       list.push(config);

--- a/src/test-kernel/tools/ArxivDownloadTool.vitest.ts
+++ b/src/test-kernel/tools/ArxivDownloadTool.vitest.ts
@@ -27,54 +27,39 @@ declare module '@latex/arxivProcessor' {
   }
 }
 
-// Mutable references for stubbing
-const processor = arxivModule.ArxivProcessor as {
-  validateId: typeof arxivModule.ArxivProcessor.validateId;
-  downloadSource: typeof arxivModule.ArxivProcessor.downloadSource;
-};
-const wsFS = WorkspaceFS as unknown as {
-  relativePath: typeof WorkspaceFS.relativePath;
-  readDir: typeof WorkspaceFS.readDir;
-};
-
 describe('ArxivDownloadTool', () => {
-  const originalValidateId = processor.validateId;
-  const originalDownloadSource = processor.downloadSource;
-  const originalRelativePath = wsFS.relativePath;
-  const originalReadDir = wsFS.readDir;
-
   afterEach(() => {
-    processor.validateId = originalValidateId;
-    processor.downloadSource = originalDownloadSource;
-    wsFS.relativePath = originalRelativePath;
-    wsFS.readDir = originalReadDir;
+    // spyOn-registered stubs restore here even when a test body throws.
+    vi.restoreAllMocks();
     gitignoreMock.ignoredPaths.clear();
   });
 
   it('returns download summary and a listing of the extracted files', async () => {
     let receivedId: string | undefined;
     let receivedAutoIndent: boolean | undefined;
-    const validateId = vi.fn(() => null);
+    const validateId = vi
+      .spyOn(arxivModule.ArxivProcessor, 'validateId')
+      .mockReturnValue(null);
 
-    processor.validateId = validateId;
+    vi.spyOn(arxivModule.ArxivProcessor, 'downloadSource').mockImplementation(
+      async (id, options) => {
+        receivedId = id;
+        receivedAutoIndent = options?.autoIndent;
+        return { path: '/workspace/project/sample', alreadyExisted: false };
+      },
+    );
 
-    processor.downloadSource = async (id, options) => {
-      receivedId = id;
-      receivedAutoIndent = options?.autoIndent;
-      return { path: '/workspace/project/sample', alreadyExisted: false };
-    };
-
-    wsFS.relativePath = () => 'sample';
+    vi.spyOn(WorkspaceFS, 'relativePath').mockReturnValue('sample');
 
     gitignoreMock.ignoredPaths.add('sample/node_modules');
 
-    wsFS.readDir = async () => [
+    vi.spyOn(WorkspaceFS, 'readDir').mockResolvedValue([
       ['.git', FileType.Directory],
       ['.gitignore', FileType.File],
       ['main.tex', FileType.File],
       ['node_modules', FileType.Directory],
       ['src', FileType.Directory],
-    ];
+    ]);
 
     const tool = new ArxivDownloadTool();
     const result = await tool.call({ id: '2401.12345v2', autoIndent: false });

--- a/src/test-kernel/tools/lean/LeanTools.vitest.ts
+++ b/src/test-kernel/tools/lean/LeanTools.vitest.ts
@@ -2,12 +2,11 @@
 // resolution, external-tool status, lake command mutex). The LSP adapter,
 // server registry, and JSON-RPC connection keep their own suites.
 
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { performance } from 'node:perf_hooks';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { findExternalToolDef } from '@tools/externalToolDefs';
 import { defaultResolveWorkspaceRoot } from '@tools/lean/direct/directLspAdapter';
 import {
@@ -158,17 +157,38 @@ describe('Lean external tool status', () => {
  */
 
 const NODE = process.execPath;
-const PARALLEL_BUDGET_MS = 600;
-const SLEEP_PER_CALL_MS = 120;
 
-function nodeSleep(ms: number, marker: string): readonly string[] {
-  // Emits `marker:start`, sleeps, then `marker:end` on stdout so we can
-  // reconstruct the interleaving from captured output.
+/**
+ * A child process that announces its startup by writing `readyPath` and then
+ * blocks until `gatePath` exists, so tests can observe process startup and
+ * control process completion deterministically — no wall-clock budgets. The
+ * child self-terminates (exit 1) if the gate never lands, so a failing test
+ * cannot leak a hung process.
+ */
+function nodeGateCommand(
+  readyPath: string,
+  gatePath: string,
+): readonly string[] {
   return [
     '-e',
-    `process.stdout.write('${marker}:start\\n'); ` +
-      `setTimeout(() => { process.stdout.write('${marker}:end\\n'); }, ${ms});`,
+    `const fs = require('node:fs');` +
+      `fs.writeFileSync(${JSON.stringify(readyPath)}, 'ready');` +
+      `const poll = setInterval(() => {` +
+      ` if (fs.existsSync(${JSON.stringify(gatePath)})) {` +
+      ` clearInterval(poll); process.exit(0);` +
+      ` }` +
+      `}, 5);` +
+      `setTimeout(() => process.exit(1), 30_000).unref();`,
   ];
+}
+
+async function waitForFile(filePath: string): Promise<void> {
+  await vi.waitFor(
+    () => {
+      expect(existsSync(filePath)).toBe(true);
+    },
+    { timeout: 10_000, interval: 10 },
+  );
 }
 
 describe('runLakeCommand mutex', () => {
@@ -234,27 +254,38 @@ describe('runLakeCommand mutex', () => {
   });
 
   it('serializes calls against the same workspace when `serialize: true`', async () => {
-    const [first, second] = await Promise.all([
-      runLakeCommand({
-        workspaceRoot: workspaceA,
-        lakeCommand: NODE,
-        args: nodeSleep(60, 'a'),
-        serialize: true,
-      }).then((result) => ({ result, finishedAt: performance.now() })),
-      runLakeCommand({
-        workspaceRoot: workspaceA,
-        lakeCommand: NODE,
-        args: nodeSleep(10, 'b'),
-        serialize: true,
-      }).then((result) => ({ result, finishedAt: performance.now() })),
-    ]);
-    expect(first.result.exitCode).toBe(0);
-    expect(second.result.exitCode).toBe(0);
-    expect(first.result.stdout).toContain('a:start');
-    expect(first.result.stdout).toContain('a:end');
-    expect(second.result.stdout).toContain('b:start');
-    expect(second.result.stdout).toContain('b:end');
-    expect(second.finishedAt).toBeGreaterThanOrEqual(first.finishedAt);
+    const gateA = path.join(workspaceA, 'gate-a');
+    const readyA = path.join(workspaceA, 'ready-a');
+    const gateB = path.join(workspaceA, 'gate-b');
+    const readyB = path.join(workspaceA, 'ready-b');
+
+    const first = runLakeCommand({
+      workspaceRoot: workspaceA,
+      lakeCommand: NODE,
+      args: nodeGateCommand(readyA, gateA),
+      serialize: true,
+    });
+    const second = runLakeCommand({
+      workspaceRoot: workspaceA,
+      lakeCommand: NODE,
+      args: nodeGateCommand(readyB, gateB),
+      serialize: true,
+    });
+
+    // The first child holds the workspace mutex: it starts and blocks on its
+    // gate. While that gate holds, the second call's child cannot have
+    // spawned — if the mutex were broken, the second child would announce
+    // itself during the first waitFor poll window.
+    await waitForFile(readyA);
+    expect(existsSync(readyB)).toBe(false);
+
+    // Only releasing the first call lets the second child start.
+    writeFileSync(gateA, 'go');
+    await waitForFile(readyB);
+    writeFileSync(gateB, 'go');
+
+    await expect(first).resolves.toMatchObject({ exitCode: 0 });
+    await expect(second).resolves.toMatchObject({ exitCode: 0 });
   });
 
   it.each<{
@@ -273,24 +304,38 @@ describe('runLakeCommand mutex', () => {
       serialize: false,
     },
   ])('runs calls in parallel $name', async ({ secondWorkspace, serialize }) => {
-    const start = Date.now();
-    await Promise.all([
+    const gateA = path.join(workspaceA, 'gate-a');
+    const readyA = path.join(workspaceA, 'ready-a');
+    const gateB = path.join(secondWorkspace(), 'gate-b');
+    const readyB = path.join(secondWorkspace(), 'ready-b');
+
+    const calls = Promise.all([
       runLakeCommand({
         workspaceRoot: workspaceA,
         lakeCommand: NODE,
-        args: nodeSleep(SLEEP_PER_CALL_MS, 'a'),
+        args: nodeGateCommand(readyA, gateA),
         serialize,
       }),
       runLakeCommand({
         workspaceRoot: secondWorkspace(),
         lakeCommand: NODE,
-        args: nodeSleep(SLEEP_PER_CALL_MS, 'b'),
+        args: nodeGateCommand(readyB, gateB),
         serialize,
       }),
     ]);
-    // Serialized, the two sleeps would take >= 2*SLEEP_PER_CALL_MS. In
-    // parallel they finish in roughly SLEEP_PER_CALL_MS plus startup. The
-    // budget allows comfortable headroom while still distinguishing the two.
-    expect(Date.now() - start).toBeLessThan(PARALLEL_BUDGET_MS);
+
+    // Both children announce themselves while each is still blocked on its
+    // own gate — only possible when the calls run concurrently. If they were
+    // serialized, the second child would never spawn (its gate could never
+    // be released first) and this poll would time out and fail the test.
+    await waitForFile(readyA);
+    await waitForFile(readyB);
+
+    writeFileSync(gateA, 'go');
+    writeFileSync(gateB, 'go');
+    const results = await calls;
+    for (const result of results) {
+      expect(result.exitCode).toBe(0);
+    }
   });
 });

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1477,27 +1477,27 @@ describe('StreamSnapshotStore', () => {
 
   it('drains writes that arrive as rollback replay returns', async () => {
     const { store, deletion } = await stageDeletionWithBufferedClear();
-    type ReplayHarness = {
-      replayStagedWrites: (
-        stream: StreamTabId,
-        state: unknown,
-      ) => Promise<void>;
-    };
-    // The replay/drain loop lives on the store's StagedDeletionCoordinator.
-    const replayHarness = (store as unknown as { deletions: ReplayHarness })
-      .deletions;
-    const replay = replayHarness.replayStagedWrites.bind(replayHarness);
-    const replaySpy = vi
-      .spyOn(replayHarness, 'replayStagedWrites')
-      .mockImplementationOnce(async (stream, state) => {
-        await replay(stream, state);
-        snapshotFacts(store).setTodos(STREAM, [TODO]);
-      })
-      .mockImplementation(replay);
+    // A write landing while rollback replays the buffered clear must be
+    // drained by the same rollback instead of leaking past it. Inject through
+    // the write seam the replay drains into: when the replayed workPlan write
+    // reaches disk, a newer todo arrives and is diverted into the staged
+    // deletion's buffer, forcing a second replay pass.
+    const writeAtomic = StorageFS.writeAtomic.bind(StorageFS);
+    const streamPlanPath = path.join(streamDataDir(STREAM), 'workPlan.json');
+    let injected = false;
+    const writeSpy = vi
+      .spyOn(StorageFS, 'writeAtomic')
+      .mockImplementation(async (target, data) => {
+        await writeAtomic(target, data);
+        if (!injected && target === streamPlanPath) {
+          injected = true;
+          snapshotFacts(store).setTodos(STREAM, [TODO]);
+        }
+      });
 
     await deletion.rollback();
 
-    replaySpy.mockRestore();
+    writeSpy.mockRestore();
     expect(await reloadWorkPlan()).toMatchObject({
       plan: null,
       todos: [TODO],

--- a/src/test-kernel/utils/text/xmlUtils.vitest.ts
+++ b/src/test-kernel/utils/text/xmlUtils.vitest.ts
@@ -44,18 +44,17 @@ describe('xmlUtils.formatContent', () => {
 
   it('processes mixed HTML and LaTeX content sequentially', async () => {
     const mixedInput =
-      '<div><strong>Plan</strong></div>\\begin{itemize}\\item Step 1\\item Step 2\\end{itemize>';
+      '<div><strong>Plan</strong></div>\\begin{itemize}\\item Step 1\\item Step 2\\end{itemize}';
 
     const result = await formatContent(mixedInput);
 
-    // The HTML pass runs first and Turndown escapes the LaTeX backslashes
-    // (\begin -> \\begin), so the subsequent LaTeX regex pass only strips the
-    // single-backslash forms it recognizes inside the escaped text. This
-    // documents the sequential HTML -> LaTeX fallback pipeline as-is.
-    assert.equal(
-      result,
-      '**Plan**\n\n\\\\\n- Step 1\\\n- Step 2\\\\end{itemize>',
-    );
+    // Contract for mixed content: both fallback passes apply — the HTML half
+    // becomes markdown emphasis and the LaTeX items become bullets. The exact
+    // escaping of the LaTeX tail is an artifact of running the HTML pass
+    // first and is deliberately not pinned.
+    assert.ok(result.startsWith('**Plan**'));
+    assert.ok(result.includes('- Step 1'));
+    assert.ok(result.includes('- Step 2'));
   });
 
   it('passes through existing markdown content after trimming', async () => {


### PR DESCRIPTION
## Summary

Follow-up to the test-simplification campaign: the scout report's 45 verified **medium** test-structure findings (`src/test-kernel/` only — no production code touched), worked by `our-code-simplifier` agents under a fix-the-coupling-never-the-coverage charter.

**24 fixed**, e.g.:
- exact log-sentence equality → component assertions (wording refactors no longer break the suite)
- private-field pokes → public seams (`retrieveAndRemember`, fake timers past the real poll interval, typed probe subclasses replacing `as unknown as` casts — renames now fail compilation instead of silently breaking)
- hardcoded 17-name tool roster → derived from canonical `review.yaml`
- mutating tests now restore shared registry state via `try/finally`

**19 skipped with reasons** — the report's false-positive tail: white-box coupling that *is* the coverage (retry-gate classification contract), fixes requiring production seams (recorded as prod-side leads, e.g. extracting the `grantExtraRound` gating closure in `runReflectionFlow.ts` for import instead of reimplementation).

## Verification

Every edited file passed targeted `vitest run` at the worker; central gates on the final tree: `typecheck` / `lint` / `check:dead-code-ratchet` green, full suite **8,782 passed / 0 failed** (+11 tests net vs main — vacuous-test fixes added real assertions).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactors in `src/test-kernel/` with no production surface area; risk is limited to possible test gaps if a stubbed public seam no longer reflects real behavior.
> 
> **Overview**
> Refactors **`src/test-kernel/`** tests so coverage stays the same but coupling to internals, brittle strings, and shared mutable state is reduced—**no production code changes**.
> 
> **Seams instead of private access:** model-handler and Google Interactions tests stub **`getStreamingConfig`**, **`estimateTokenCount`**, and media upload through **public methods** or small typed probe subclasses; OpenAI background lifecycle tests use **`retrieveAndRemember`** and **fake timers** instead of assigning **`pendingResponseId`** or swapping a private poller.
> 
> **Stable assertions:** OpenAI client diagnostics check **owner / model / base URL** fragments instead of one exact log line; relay Max-tier tests validate **each advertised model** against relay rules rather than **`deepEqual`** on a mirrored filter; mixed HTML/LaTeX **`formatContent`** tests pin behavior with partial checks instead of a fragile escaped tail.
> 
> **Canonical fixtures & cleanup:** the scientific-review tool conversion roster is **read from `review.yaml`** (plus the injected delegation tool); agent-registry and similar suites wrap mutations in **`try/finally`** to reset directories, deferred gates, and mocks.
> 
> **Real handlers where it matters:** Supabase auth, settings (Copilot route, execution-history watcher, goal list), and related suites construct **`SettingsViewMessageHandler`** / **`SupabaseAuthProvider`** through constructors and **IPC/message paths** instead of **`Object.create(prototype)`** and private **`storeSession`**.
> 
> **Async / failure behavior:** desktop IPC tests are split into focused cases; file-selection uses an explicit async flush; lean lake mutex tests use **ready/gate files** instead of wall-clock budgets; progress/settings tests expect **logged handler errors** rather than raw rejections or spy counts on private fact appliers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbbcc03fb379244e6b56ab27ddafa528992b4deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->