### PR TITLE
fix(cli): restore live transcript updates, make Ctrl-T closable

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -470,24 +470,27 @@ export function App(props: AppProps): React.JSX.Element {
         return activeApprovalVisible && pending ? (
           <ApprovalModal pending={pending} availableRows={availableRows} />
         ) : null;
-      case 'transcriptReader':
-        return transcriptReaderStreamId ? (
+      case 'transcriptReader': {
+        if (!transcriptReaderStreamId) return null;
+        const title = transcriptReaderTitle(
+          streamDisplayLabel({
+            childStreamEntries,
+            parentStream,
+            streamId: transcriptReaderStreamId,
+            streams,
+          }),
+        );
+        return (
           <TranscriptReader
             availableRows={availableRows}
             executionLabels={subagentExecutionLabels}
             onClose={closeTranscriptReader}
             onPrintToScrollback={printStreamOutput}
             streamId={transcriptReaderStreamId}
-            title={transcriptReaderTitle(
-              streamDisplayLabel({
-                childStreamEntries,
-                parentStream,
-                streamId: transcriptReaderStreamId,
-                streams,
-              }),
-            )}
+            title={title}
           />
-        ) : null;
+        );
+      }
       case undefined:
         return null;
     }

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -39,6 +39,10 @@ import {
 } from './appInteractionPolicy';
 import { ApprovalModal } from './modals/ApprovalModal';
 import { InfoPane } from './panes/InfoPane';
+import {
+  TranscriptReader,
+  transcriptReaderTitle,
+} from './panes/TranscriptReader';
 import { InputBar, type InputBarHandle } from './panes/InputBar';
 import { ConversationRegion } from './panes/ConversationRegion';
 import { StatusBar } from './panes/StatusBar';
@@ -69,8 +73,11 @@ import {
   rootStreamId as rootStreamIdSignal,
   activeForm as activeFormSignal,
   closeInfoPane,
+  closeTranscriptReader,
   formProgress as formProgressSignal,
   infoPane as infoPaneSignal,
+  openTranscriptReader,
+  transcriptReaderStreamId as transcriptReaderStreamIdSignal,
   reverseSearchOpen as reverseSearchOpenSignal,
   setTransientNotice,
   slashPaletteOpen as slashPaletteOpenSignal,
@@ -172,6 +179,7 @@ export function App(props: AppProps): React.JSX.Element {
   const activeForm = useSignal(activeFormSignal);
   const formProgress = useSignal(formProgressSignal);
   const infoPane = useSignal(infoPaneSignal);
+  const transcriptReaderStreamId = useSignal(transcriptReaderStreamIdSignal);
   const slashPaletteOpen = useSignal(slashPaletteOpenSignal);
   const reverseSearchOpen = useSignal(reverseSearchOpenSignal);
   const rootRunStartAvailable = useSignal(rootRunStartAvailableSignal);
@@ -212,7 +220,10 @@ export function App(props: AppProps): React.JSX.Element {
 
   const stdin = useStdin();
   const foregroundOpen =
-    activeApprovalVisible || activeForm !== undefined || infoPane !== undefined;
+    activeApprovalVisible ||
+    activeForm !== undefined ||
+    infoPane !== undefined ||
+    transcriptReaderStreamId !== undefined;
   const childInputDisabledMessage = focusedChildInputDisabledMessage({
     activeStreamId,
     parentStream,
@@ -424,6 +435,7 @@ export function App(props: AppProps): React.JSX.Element {
     formBusy,
     infoPaneOpen: infoPane !== undefined,
     pendingApproval: activeApprovalVisible,
+    transcriptReaderOpen: transcriptReaderStreamId !== undefined,
   });
   const approvalKind =
     foregroundKind === 'approval' ? pending?.payload.kind : undefined;
@@ -457,6 +469,24 @@ export function App(props: AppProps): React.JSX.Element {
       case 'approval':
         return activeApprovalVisible && pending ? (
           <ApprovalModal pending={pending} availableRows={availableRows} />
+        ) : null;
+      case 'transcriptReader':
+        return transcriptReaderStreamId ? (
+          <TranscriptReader
+            availableRows={availableRows}
+            executionLabels={subagentExecutionLabels}
+            onClose={closeTranscriptReader}
+            onPrintToScrollback={printStreamOutput}
+            streamId={transcriptReaderStreamId}
+            title={transcriptReaderTitle(
+              streamDisplayLabel({
+                childStreamEntries,
+                parentStream,
+                streamId: transcriptReaderStreamId,
+                streams,
+              }),
+            )}
+          />
         ) : null;
       case undefined:
         return null;
@@ -701,7 +731,7 @@ export function App(props: AppProps): React.JSX.Element {
     if (!focusShortcutsActive) return;
 
     if (key.ctrl && input.toLowerCase() === 't') {
-      if (activeStreamId) printStreamOutput(activeStreamId);
+      if (activeStreamId) openTranscriptReader(activeStreamId);
       return;
     }
 

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -144,23 +144,29 @@ export function digitFromMetaShortcut(value: string): number | undefined {
   return /^[1-9]$/.test(value) ? Number.parseInt(value, 10) : undefined;
 }
 
-export type ForegroundSurfaceKind = 'form' | 'infoPane' | 'approval';
+export type ForegroundSurfaceKind =
+  'form' | 'infoPane' | 'approval' | 'transcriptReader';
 
 export function foregroundSurfaceKind({
   activeFormOpen,
   formBusy,
   infoPaneOpen,
   pendingApproval,
+  transcriptReaderOpen,
 }: {
   readonly activeFormOpen: boolean;
   readonly formBusy: boolean;
   readonly infoPaneOpen: boolean;
   readonly pendingApproval: boolean;
+  readonly transcriptReaderOpen: boolean;
 }): ForegroundSurfaceKind | undefined {
   if (pendingApproval && formBusy) return 'approval';
   if (activeFormOpen) return 'form';
   if (pendingApproval) return 'approval';
   if (infoPaneOpen) return 'infoPane';
+  // Lowest precedence: the reader is a passive view, so anything that needs an
+  // answer from the user takes the foreground away from it.
+  if (transcriptReaderOpen) return 'transcriptReader';
   return undefined;
 }
 
@@ -191,6 +197,7 @@ export function foregroundEscapeAction({
     case 'form':
       return activeFormEscapeAction ?? 'close';
     case 'infoPane':
+    case 'transcriptReader':
       return 'close';
     case 'approval':
       // Esc rejects (confirmCardKeyAction); label the consequence, not "cancel".
@@ -234,7 +241,10 @@ export function foregroundMaxRowsForKind({
   switch (kind) {
     case 'form':
       return FORM_FOREGROUND_MAX_ROWS;
+    // The reader is the whole point of the keystroke: like the info pane, it
+    // takes every row the layout can spare rather than a modal-sized window.
     case 'infoPane':
+    case 'transcriptReader':
       return undefined;
     case 'approval':
       return approvalForegroundMaxRows(approvalKind);

--- a/packages/cli/src/chat/tui/modals/ScrollableModalText.tsx
+++ b/packages/cli/src/chat/tui/modals/ScrollableModalText.tsx
@@ -61,12 +61,18 @@ export function scrollableModalTextRowsBudget({
 export function modalTextDisplayLines({
   continuationPrefix = '',
   firstLinePrefix = '',
+  preWrapped = false,
   text,
   trimWrappedLeadingWhitespace = false,
   width,
 }: {
   readonly continuationPrefix?: string;
   readonly firstLinePrefix?: string;
+  /** The caller already wrapped `text` to `width`. Re-running wrap-ansi over
+   *  content that already fits costs a full grapheme-segmentation pass per
+   *  render for identical output — worth skipping for a large body that
+   *  refreshes as a run streams. */
+  readonly preWrapped?: boolean;
   readonly text: string;
   /** Strip leading whitespace on wrap continuations (prose bodies only —
    *  never commands, where quoted whitespace is semantic). */
@@ -76,16 +82,17 @@ export function modalTextDisplayLines({
   const contentWidth = clampModalWidth(width);
   return text.split('\n').flatMap((line, index) => {
     const prefixed = `${index === 0 ? firstLinePrefix : continuationPrefix}${line}`;
-    const wrapped =
-      prefixed.length === 0
-        ? ['']
-        : wrapAnsiToWidth(prefixed, contentWidth)
-            .split('\n')
-            .map((part, partIndex) =>
-              trimWrappedLeadingWhitespace && partIndex !== 0
-                ? part.trimStart()
-                : part,
-            );
+    const wrapped = ((): readonly string[] => {
+      if (prefixed.length === 0) return [''];
+      if (preWrapped) return [prefixed];
+      return wrapAnsiToWidth(prefixed, contentWidth)
+        .split('\n')
+        .map((part, partIndex) =>
+          trimWrappedLeadingWhitespace && partIndex !== 0
+            ? part.trimStart()
+            : part,
+        );
+    })();
     return wrapped.map((part): ModalTextDisplayLine => ({
       kind: 'text',
       text: part,
@@ -142,6 +149,9 @@ interface ScrollableModalTextProps {
   readonly marginWhenSpacious?: boolean;
   /** Release ↑/↓ while another surface owns them (feedback input). */
   readonly scrollActive?: boolean;
+  /** Forwarded to {@link modalTextDisplayLines}: `text` is already wrapped to
+   *  `width`, so skip the internal wrap pass. */
+  readonly preWrapped?: boolean;
   /** Open at the last line instead of the first. A transcript reads newest-last,
    *  so the rows worth seeing on open are at the bottom. */
   readonly startAtEnd?: boolean;
@@ -170,6 +180,7 @@ export function ScrollableModalText(
       modalTextDisplayLines({
         continuationPrefix: props.continuationPrefix,
         firstLinePrefix: props.firstLinePrefix,
+        preWrapped: props.preWrapped,
         text,
         trimWrappedLeadingWhitespace: props.trimWrappedLeadingWhitespace,
         width,
@@ -177,6 +188,7 @@ export function ScrollableModalText(
     [
       props.continuationPrefix,
       props.firstLinePrefix,
+      props.preWrapped,
       props.trimWrappedLeadingWhitespace,
       text,
       width,
@@ -188,7 +200,7 @@ export function ScrollableModalText(
   });
   const { scrollOffset, scrollable } = useScrollableOffset({
     active: props.scrollActive !== false,
-    initialOffset: props.startAtEnd === true ? maxScrollOffset : 0,
+    initialOffset: props.startAtEnd ? maxScrollOffset : 0,
     maxScrollOffset,
     resetKey: props.resetKey ?? text,
     pageRows: scrollPageRows({

--- a/packages/cli/src/chat/tui/modals/ScrollableModalText.tsx
+++ b/packages/cli/src/chat/tui/modals/ScrollableModalText.tsx
@@ -142,6 +142,15 @@ interface ScrollableModalTextProps {
   readonly marginWhenSpacious?: boolean;
   /** Release ↑/↓ while another surface owns them (feedback input). */
   readonly scrollActive?: boolean;
+  /** Open at the last line instead of the first. A transcript reads newest-last,
+   *  so the rows worth seeing on open are at the bottom. */
+  readonly startAtEnd?: boolean;
+  /** What counts as "new content" for the purpose of restoring the initial
+   *  scroll position. Defaults to the text itself, which is right for a modal
+   *  whose body is replaced wholesale. A view over a growing transcript passes
+   *  something stabler (the stream id), so appended rows do not yank the
+   *  reader back from wherever it scrolled to. */
+  readonly resetKey?: unknown;
   /** Suppress the hint row where no row is budgeted for it (compact cards). */
   readonly showScrollHints?: boolean;
   /** ↑/↓ hint verb, e.g. `scroll command`. */
@@ -179,8 +188,9 @@ export function ScrollableModalText(
   });
   const { scrollOffset, scrollable } = useScrollableOffset({
     active: props.scrollActive !== false,
+    initialOffset: props.startAtEnd === true ? maxScrollOffset : 0,
     maxScrollOffset,
-    resetKey: text,
+    resetKey: props.resetKey ?? text,
     pageRows: scrollPageRows({
       compactRows: COMPACT_MODAL_TEXT_ROWS,
       maxDisplayLines: maxRows,

--- a/packages/cli/src/chat/tui/panes/TranscriptReader.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptReader.tsx
@@ -1,0 +1,109 @@
+// Scrollable, closable full-transcript reader. Ctrl-T's predecessor printed the
+// same content straight into terminal scrollback, which the terminal owns and
+// nothing can take back. This renders it in the live region instead, so Esc
+// restores the conversation exactly as it was. `p` still prints, for when the
+// point is to select and copy the text out of the terminal.
+//
+// The TUI never enters the alternate screen (see tui/terminalCleanup.ts), so a
+// full-screen pager is not an option here — this is an ordinary foreground
+// surface, sized by the same row budget every other one uses.
+
+import { useMemo } from 'react';
+import { useInput, useWindowSize } from 'ink';
+
+import { BorderedPanel } from '@cli/tui/ui/BorderedPanel';
+import { COLOR_HINT } from '@cli/tui/ui/colors';
+import { KeyHints } from '@cli/tui/ui/KeyHints';
+import type { StreamTabId } from '@shared/schemas';
+import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
+
+import { formFrameWidth } from '../forms/_shared/FormFrame';
+import { isEscapeInput } from '../input/inputKeys';
+import {
+  ScrollableModalText,
+  scrollableModalTextRowsBudget,
+} from '../modals/ScrollableModalText';
+import { streams as streamsSignal } from '../state/cliState';
+import { transcriptToLines } from '../state/transcriptLines';
+import { useSignal } from '../state/useSignal';
+
+const READER_HORIZONTAL_CHROME_COLUMNS = 4;
+const EMPTY_TRANSCRIPT_TEXT = '(no output yet)';
+
+export function transcriptReaderTitle(label: string | undefined): string {
+  return label ? `Transcript: ${label}` : 'Transcript';
+}
+
+export function TranscriptReader({
+  availableRows,
+  executionLabels,
+  onClose,
+  onPrintToScrollback,
+  streamId,
+  title,
+}: {
+  readonly availableRows: number;
+  readonly executionLabels?: ExecutionLabels;
+  readonly onClose: () => void;
+  readonly onPrintToScrollback: (streamId: StreamTabId) => void;
+  readonly streamId: StreamTabId;
+  readonly title: string;
+}): React.JSX.Element {
+  const { columns } = useWindowSize();
+  const streams = useSignal(streamsSignal);
+  const slice = streams.get(streamId);
+  const width = formFrameWidth(columns) - READER_HORIZONTAL_CHROME_COLUMNS;
+
+  // Recomputed as the run appends rows, so the reader stays live rather than
+  // freezing at the content present when it opened.
+  const text = useMemo(() => {
+    const body = transcriptToLines(slice, width, executionLabels)
+      .join('\n')
+      .trimEnd();
+    return body || EMPTY_TRANSCRIPT_TEXT;
+  }, [executionLabels, slice, width]);
+
+  useInput((input, key) => {
+    if (isEscapeInput(input, key)) {
+      onClose();
+      return;
+    }
+    if (input.toLowerCase() === 'p') {
+      onPrintToScrollback(streamId);
+      onClose();
+    }
+  });
+
+  return (
+    <BorderedPanel
+      color={COLOR_HINT}
+      title={title}
+      width={formFrameWidth(columns)}
+      footer={
+        <KeyHints
+          hints={[
+            { key: '↑/↓', action: 'scroll' },
+            { key: 'p', action: 'print to scrollback' },
+            { key: 'Esc', action: 'close' },
+          ]}
+          confirmCancel={false}
+        />
+      }
+    >
+      <ScrollableModalText
+        hiddenNoun="transcript rows"
+        maxRows={scrollableModalTextRowsBudget({
+          availableRows,
+          columns,
+          title,
+        })}
+        resetKey={streamId}
+        scrollHint="scroll transcript"
+        showScrollHints={false}
+        startAtEnd
+        text={text}
+        width={width}
+      />
+    </BorderedPanel>
+  );
+}

--- a/packages/cli/src/chat/tui/panes/TranscriptReader.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptReader.tsx
@@ -14,6 +14,7 @@ import { useInput, useWindowSize } from 'ink';
 import { BorderedPanel } from '@cli/tui/ui/BorderedPanel';
 import { COLOR_HINT } from '@cli/tui/ui/colors';
 import { KeyHints } from '@cli/tui/ui/KeyHints';
+import { CONFIRM_CARD_HORIZONTAL_DECORATION } from '@cli/tui/ui/theme';
 import type { StreamTabId } from '@shared/schemas';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 
@@ -27,7 +28,6 @@ import { streams as streamsSignal } from '../state/cliState';
 import { transcriptToLines } from '../state/transcriptLines';
 import { useSignal } from '../state/useSignal';
 
-const READER_HORIZONTAL_CHROME_COLUMNS = 4;
 const EMPTY_TRANSCRIPT_TEXT = '(no output yet)';
 
 export function transcriptReaderTitle(label: string | undefined): string {
@@ -52,7 +52,8 @@ export function TranscriptReader({
   const { columns } = useWindowSize();
   const streams = useSignal(streamsSignal);
   const slice = streams.get(streamId);
-  const width = formFrameWidth(columns) - READER_HORIZONTAL_CHROME_COLUMNS;
+  const frameWidth = formFrameWidth(columns);
+  const width = frameWidth - CONFIRM_CARD_HORIZONTAL_DECORATION;
 
   // Recomputed as the run appends rows, so the reader stays live rather than
   // freezing at the content present when it opened.
@@ -78,7 +79,7 @@ export function TranscriptReader({
     <BorderedPanel
       color={COLOR_HINT}
       title={title}
-      width={formFrameWidth(columns)}
+      width={frameWidth}
       footer={
         <KeyHints
           hints={[
@@ -97,6 +98,7 @@ export function TranscriptReader({
           columns,
           title,
         })}
+        preWrapped
         resetKey={streamId}
         scrollHint="scroll transcript"
         showScrollHints={false}

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -626,7 +626,7 @@ function statusBarBindingsText(
       })
     : undefined;
   const fullOutput = transcriptAvailable
-    ? keyHintText({ key: 'Ctrl-T', action: 'full output' })
+    ? keyHintText({ key: 'Ctrl-T', action: 'transcript' })
     : undefined;
   const agent = agentSelectionAvailable
     ? keyHintText({ key: '/agent', action: 'agents' })

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -539,6 +539,25 @@ export function closeInfoPane(): void {
   INFO_PANE_QUEUE.set(INFO_PANE_QUEUE.get().slice(1));
 }
 
+/**
+ * Stream whose full transcript is open in the scrollable foreground reader,
+ * or `undefined` when the reader is closed. Holding the id rather than a text
+ * snapshot keeps the reader live: a run that is still producing rows updates
+ * under the reader instead of freezing at the moment it was opened.
+ */
+const TRANSCRIPT_READER_STREAM = signal<StreamTabId | undefined>(undefined);
+export const transcriptReaderStreamId: Signal.Computed<
+  StreamTabId | undefined
+> = computed(() => TRANSCRIPT_READER_STREAM.get());
+
+export function openTranscriptReader(streamId: StreamTabId): void {
+  TRANSCRIPT_READER_STREAM.set(streamId);
+}
+
+export function closeTranscriptReader(): void {
+  TRANSCRIPT_READER_STREAM.set(undefined);
+}
+
 /** True while the slash-command palette is mounted in the InputBar. App-level
  *  Tab handlers gate on this so palette-Tab (accept selection) doesn't double
  *  with stream-focus Tab. */
@@ -718,6 +737,7 @@ export function resetCliState(
   resetChildStreamEntries();
   activeForm.set(undefined);
   INFO_PANE_QUEUE.set([]);
+  TRANSCRIPT_READER_STREAM.set(undefined);
   slashPaletteOpen.set(false);
   reverseSearchOpen.set(false);
   clearTransientNotice();

--- a/packages/cli/src/chat/tui/state/signalSubscription.ts
+++ b/packages/cli/src/chat/tui/state/signalSubscription.ts
@@ -22,8 +22,16 @@ export function subscribeToSignalChanges(
     queueMicrotask(() => {
       notifyPending = false;
       if (disposed) return;
-      notify();
-      watcher.watch();
+      // Re-arm in `finally`: a Watcher fires once and stays dormant until
+      // `watch()` runs again, so letting a throw from `notify()` skip it
+      // silently kills this subscription for the rest of the process. For a
+      // React subscriber that means a component frozen on stale data with no
+      // error and no recovery.
+      try {
+        notify();
+      } finally {
+        watcher.watch();
+      }
     });
   });
   watcher.watch(...signals);

--- a/src/test-kernel/cli/AppInteractionPolicy.vitest.ts
+++ b/src/test-kernel/cli/AppInteractionPolicy.vitest.ts
@@ -103,6 +103,7 @@ function foregroundInput(
     formBusy: false,
     infoPaneOpen: false,
     pendingApproval: true,
+    transcriptReaderOpen: false,
     ...overrides,
   };
 }
@@ -329,6 +330,29 @@ describe('app interaction policy', () => {
       ],
       [foregroundInput(), 'approval'],
       [foregroundInput({ pendingApproval: false }), undefined],
+      // The transcript reader is passive, so every surface that needs an
+      // answer takes the foreground away from it.
+      [
+        foregroundInput({ pendingApproval: false, transcriptReaderOpen: true }),
+        'transcriptReader',
+      ],
+      [foregroundInput({ transcriptReaderOpen: true }), 'approval'],
+      [
+        foregroundInput({
+          activeFormOpen: true,
+          pendingApproval: false,
+          transcriptReaderOpen: true,
+        }),
+        'form',
+      ],
+      [
+        foregroundInput({
+          infoPaneOpen: true,
+          pendingApproval: false,
+          transcriptReaderOpen: true,
+        }),
+        'infoPane',
+      ],
     ] satisfies readonly (readonly [
       ForegroundSurfaceInput,
       ForegroundSurfaceKind | undefined,

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -246,7 +246,7 @@ describe('CLI StatusBar display model', () => {
     );
 
     expect(display.bindings).toContain('Tab sessions');
-    expect(display.bindings).toContain('Ctrl-T full output');
+    expect(display.bindings).toContain('Ctrl-T transcript');
     expect(display.bindings).not.toContain('Alt-s subagents');
   });
 
@@ -290,7 +290,7 @@ describe('CLI StatusBar display model', () => {
     );
 
     expect(display.bindings).toBe(
-      'Esc back · Ctrl-T full output · Ctrl-C stop root',
+      'Esc back · Ctrl-T transcript · Ctrl-C stop root',
     );
   });
 
@@ -308,7 +308,7 @@ describe('CLI StatusBar display model', () => {
     );
 
     expect(display.bindings).toBe(
-      'Esc back · Tab sessions · Ctrl-T full output · /agent agents · Ctrl-C exit',
+      'Esc back · Tab sessions · Ctrl-T transcript · /agent agents · Ctrl-C exit',
     );
   });
 
@@ -325,9 +325,7 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toBe(
-      'Esc back · Ctrl-T full output · Ctrl-C exit',
-    );
+    expect(display.bindings).toBe('Esc back · Ctrl-T transcript · Ctrl-C exit');
   });
 
   it('omits Esc back at the same bounded width without a parent', () => {
@@ -410,7 +408,7 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toContain('Ctrl-T full output');
+    expect(display.bindings).toContain('Ctrl-T transcript');
     expect(display.bindings).toContain('Ctrl-C exit');
   });
 
@@ -448,7 +446,7 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toContain('Ctrl-T full output');
+    expect(display.bindings).toContain('Ctrl-T transcript');
     expect(display.bindings).toContain('/agent agents');
   });
 
@@ -741,7 +739,7 @@ describe('CLI StatusBar display model', () => {
     );
 
     expect(display.bindings).toBe(
-      'Tab sessions · Ctrl-T full output · Ctrl-C stop',
+      'Tab sessions · Ctrl-T transcript · Ctrl-C stop',
     );
   });
 

--- a/src/test-kernel/utils/UtilsCore.vitest.ts
+++ b/src/test-kernel/utils/UtilsCore.vitest.ts
@@ -15,6 +15,7 @@ import {
   getFileStem,
   KeyedMutex,
   toNewestFirstByTimestamp,
+  type FlushableDebounce,
 } from '@utils/core';
 import { deriveExecutionId } from '@utils/core/idHash';
 
@@ -433,6 +434,30 @@ describe('createFlushableDebounce', () => {
 
     batcher.schedule();
     batcher.cancel();
+    expect(batcher.pending).toBe(false);
+  });
+
+  // The CLI transcript sync re-schedules from inside its own callback (its
+  // trace flush writes to the store, which fires the change subscription
+  // synchronously). An implementation that invokes and then cancels drops that
+  // reschedule and leaves `pending` stuck true, freezing every later sync.
+  it('keeps a reschedule made from inside the callback', () => {
+    const inner = vi.fn();
+    let rescheduleOnce = true;
+    const batcher: FlushableDebounce = createFlushableDebounce(() => {
+      inner();
+      if (!rescheduleOnce) return;
+      rescheduleOnce = false;
+      batcher.schedule();
+    }, 100);
+
+    batcher.schedule();
+    vi.advanceTimersByTime(100);
+    expect(inner).toHaveBeenCalledOnce();
+    expect(batcher.pending).toBe(true);
+
+    vi.advanceTimersByTime(100);
+    expect(inner).toHaveBeenCalledTimes(2);
     expect(batcher.pending).toBe(false);
   });
 

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -246,12 +246,12 @@ export function createFlushableDebounce(
 
   return {
     schedule() {
-      if (timer !== undefined) clearTimeout(timer);
+      cancel();
       timer = setTimeout(invoke, waitMs);
     },
     flush() {
       if (timer === undefined) return;
-      clearTimeout(timer);
+      cancel();
       invoke();
     },
     cancel,

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -15,7 +15,6 @@
  * (the single home for generic string helpers) and are re-exported here for
  * existing @utils/core consumers.
  */
-import { debounce as debounceWithFlush } from 'es-toolkit';
 import { customAlphabet, nanoid } from 'nanoid';
 import { basename as pathBasename, extname as pathExtname } from 'pathe';
 
@@ -194,12 +193,20 @@ export function onAbort(
  * pending call), with no way to force the trailing call to run early.
  * Several call sites need exactly that: run the pending work synchronously
  * right now (typically just before teardown/dispose), instead of either
- * waiting out the timer or dropping the work. Built on es-toolkit's
- * `debounce()`, which already provides `schedule`/`cancel`/`flush`; this
- * only adds the `pending` flag, needed by call sites that want "start once,
- * coalesce further calls until it fires" (a throttle-style batching window)
- * instead of a classic reset-on-every-call debounce: guard with
- * `if (!batcher.pending) batcher.schedule();`.
+ * waiting out the timer or dropping the work.
+ *
+ * `schedule()` always (re)starts the timer, matching a classic trailing
+ * debounce. A call site that instead wants "start once, coalesce further
+ * calls until it fires" (a throttle-style batching window) can guard with
+ * `pending`: `if (!batcher.pending) batcher.schedule();`.
+ *
+ * The timer handle is cleared *before* the callback runs, so a `schedule()`
+ * made from inside the callback opens a fresh window that this invocation's
+ * own cleanup cannot cancel. Re-entrancy is not hypothetical: the CLI's
+ * transcript sync flushes buffered trace chunks into the store from inside
+ * its own callback, which synchronously re-schedules. A library debounce
+ * that invokes and then cancels (es-toolkit's does) silently drops that
+ * reschedule and leaves `pending` stuck true, freezing every later update.
  *
  * The callback is fixed at creation and takes no arguments — call sites that
  * need per-invocation data close over their own mutable state (as the
@@ -224,27 +231,32 @@ export function createFlushableDebounce(
   callback: () => void,
   waitMs: number,
 ): FlushableDebounce {
-  let isPending = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
 
-  const debounced = debounceWithFlush(() => {
-    isPending = false;
+  function cancel(): void {
+    if (timer === undefined) return;
+    clearTimeout(timer);
+    timer = undefined;
+  }
+
+  function invoke(): void {
+    timer = undefined;
     callback();
-  }, waitMs);
+  }
 
   return {
     schedule() {
-      isPending = true;
-      debounced();
+      if (timer !== undefined) clearTimeout(timer);
+      timer = setTimeout(invoke, waitMs);
     },
     flush() {
-      debounced.flush();
+      if (timer === undefined) return;
+      clearTimeout(timer);
+      invoke();
     },
-    cancel() {
-      isPending = false;
-      debounced.cancel();
-    },
+    cancel,
     get pending() {
-      return isPending;
+      return timer !== undefined;
     },
   };
 }


### PR DESCRIPTION
## The bug

While an agent is running, the chat transcript stops updating. Follow-up messages you type, tool rows, and streaming assistant text all stay invisible until the turn ends, at which point they appear at once. `Ctrl-T` still shows everything, which is the tell: the data is there, the incremental render is not running.

Reproduced under tmux against a live `deepseek` session, then instrumented to confirm the mechanism, and verified fixed the same way.

## Root cause

`createFlushableDebounce` was reimplemented on es-toolkit's `debounce` in #9800. That timer handler is `invoke(); cancel();` — it runs the callback and *then* clears the timer handle. The CLI's transcript sync reschedules from inside its own callback: `syncStreamLog` calls `flushPendingTraces()`, which writes buffered model output into the transcript store, which fires the store's change subscription synchronously, which schedules the next window. That fresh timer is then cleared by the outgoing invocation's cleanup, while the wrapper's separate `isPending` boolean stays `true` forever. Every later `if (!pending) schedule()` short-circuits and no sync is ever scheduled again for the life of the process.

The instrumented run shows it exactly: one `debounce-fire`, a re-entrant `onChange` logged at `pending=false` inside it, then an unbroken run of `onChange … pending=true` with no further fires.

The pre-#9800 hand-rolled version cleared the handle *before* invoking, so a re-entrant reschedule survived. This restores that ordering and documents why it is load-bearing.

## Also fixed: the same shape one layer up

`subscribeToSignalChanges` re-armed its watcher on the happy path only:

```js
notify();
watcher.watch();   // skipped if notify() throws
```

A `Signal.subtle.Watcher` fires once and stays dormant until `watch()` runs again, so a throw from a subscriber permanently kills that subscription. `useSignal` backs every Ink component, so the user-visible result is a component frozen on stale data with no error and no recovery — the same failure mode from a different cause. Now re-armed in a `finally`.

Note for a follow-up: `packages/desktop/src/renderer/main.ts:1313` has the identical defect and would freeze the whole desktop shell. Left out of this PR to keep it to one host.

## Ctrl-T is now closable

`Ctrl-T` printed the full transcript into terminal scrollback, which the terminal owns and nothing can take back — there was no way to switch back.

It now opens a scrollable reader in the live region, closed with `Esc`, leaving the conversation exactly as it was. It opens at the newest rows, `↑/↓` and PgUp/PgDn scroll, and the scroll position holds as a running turn appends more content instead of yanking to the bottom. `p` still does the permanent scrollback print, which is what you want when the goal is selecting and copying text out of the terminal.

The TUI deliberately never enters the alternate screen (`tui/terminalCleanup.ts` documents that an unmatched `rmcup` wipes printed output on Ghostty/iTerm2/Terminal.app), so this is an ordinary foreground surface. It reuses the existing scroll-offset hook, scroll-bounds windowing, and `transcriptToLines` — the same content function the print path already used.

## Verification

- New regression test rescheduling from inside the callback: fails on the old implementation, passes on this one.
- New foreground-precedence cases pinning the reader below every surface that needs an answer from the user.
- Full workspace `typecheck` clean; all 149 CLI test files (2318 tests) pass; dead-code ratchet clean.
- Live tmux session: mid-run user messages and tool rows now render immediately; a queued follow-up shows in the queued panel and becomes a transcript row at injection; the reader opens mid-run and follows the running agent; `Esc` leaves no residue; `p` prints and closes.

## Follow-ups (not in this PR)

- `es-toolkit` is now an unused dependency in `package.json` and `packages/agent/package.json`; removing it needs a lockfile regen.
- The desktop watcher re-arm noted above.
- An audit of the surrounding transcript surface turned up several confirmed defects (an entry state that renders in neither channel, two disagreeing finalization authorities, a silently dropped root follow-up, tool rows counted as one row but painted as many). Happy to file these as issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CLI transcript sync and shared debounce/signal subscription utilities; behavior changes are well-scoped with regression tests, but incorrect debounce or watcher logic would silently break live UI updates across the TUI.
> 
> **Overview**
> Fixes a **live transcript freeze** during agent runs by reimplementing `createFlushableDebounce` so the timer is cleared **before** the callback runs. Re-entrant `schedule()` from inside transcript sync (store change → debounce) no longer gets wiped by post-invoke cleanup, so `pending` does not stick true and incremental UI updates resume.
> 
> **Ctrl-T** now opens a **scrollable transcript reader** in the TUI foreground (Esc closes, restores the conversation) instead of dumping into terminal scrollback. The reader stays **live** on the stream id, opens at the **bottom**, scroll position is stable via `resetKey`, and **p** still prints to scrollback. Status hint text changes from “full output” to “transcript”.
> 
> `subscribeToSignalChanges` **re-arms the Signal watcher in `finally`** so a thrown subscriber does not permanently freeze `useSignal` subscribers.
> 
> `ScrollableModalText` adds `preWrapped`, `startAtEnd`, and `resetKey` for streaming transcript bodies. Tests cover debounce re-schedule and transcript-reader foreground precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af6ee00bcff7b9c6132f082a145db65b0fa980e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->