### PR TITLE
feat(cli): show session cost + payment route in the TUI exit summary

### DIFF
--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -13,9 +13,8 @@ import {
   sumUsageStats,
   type StreamTabId,
   type TokenUsageStats,
-  type UsageRoute,
 } from '@shared/schemas';
-import { INCLUDED_ACCESS, OWN_API_KEYS } from '@shared/copy/modelAccess';
+import { usageRouteBadge } from '@shared/copy/modelAccess';
 
 import { formatCostUsd } from '@utils/text/stringUtils';
 
@@ -79,42 +78,16 @@ function usageHasTokens(usage: TokenUsageStats): boolean {
   );
 }
 
-/** User-facing label for how a session's model calls were paid for. */
-function usageRouteLabel(route: UsageRoute): string {
-  switch (route) {
-    case 'chatgpt-subscription':
-      return 'ChatGPT';
-    case 'xai-subscription':
-      return 'Grok';
-    case 'kimi-code-subscription':
-      return 'Kimi Code';
-    case 'relay':
-      return INCLUDED_ACCESS.inline;
-    case 'api-key':
-      return OWN_API_KEYS.inline;
-  }
-}
-
-/** Whether a usage route means model calls were covered by a subscription. */
-function isSubscriptionRoute(route: UsageRoute): boolean {
-  return (
-    route === 'chatgpt-subscription' ||
-    route === 'xai-subscription' ||
-    route === 'kimi-code-subscription'
-  );
-}
-
-/** Session-level cost line — mirrors the extension UsagePanel's cost+route
- *  label so the CLI and extension bill the same way. Empty when there is no
+/** Session-level cost line — reuses the shared usage-route badge so the
+ *  CLI and extension attribute payment the same way. Empty when there is no
  *  cost to report and no known route to attribute. */
 function formatSessionCost(usage: TokenUsageStats): string | undefined {
-  const route = usage.usageRoute;
-  if (route != null) {
-    const label = usageRouteLabel(route);
-    if (isSubscriptionRoute(route) && usage.cost === 0) {
-      return `free via ${label}`;
+  const badge = usageRouteBadge(usage.usageRoute);
+  if (badge) {
+    if (badge.subscription && usage.cost === 0) {
+      return `free via ${badge.label}`;
     }
-    return `${formatCostUsd(usage.cost)} via ${label}`;
+    return `${formatCostUsd(usage.cost)} via ${badge.label}`;
   }
   return usage.cost > 0 ? formatCostUsd(usage.cost) : undefined;
 }

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -13,7 +13,11 @@ import {
   sumUsageStats,
   type StreamTabId,
   type TokenUsageStats,
+  type UsageRoute,
 } from '@shared/schemas';
+import { INCLUDED_ACCESS, OWN_API_KEYS } from '@shared/copy/modelAccess';
+
+import { formatCostUsd } from '@utils/text/stringUtils';
 
 import {
   childExecutionLabel,
@@ -75,6 +79,46 @@ function usageHasTokens(usage: TokenUsageStats): boolean {
   );
 }
 
+/** User-facing label for how a session's model calls were paid for. */
+function usageRouteLabel(route: UsageRoute): string {
+  switch (route) {
+    case 'chatgpt-subscription':
+      return 'ChatGPT';
+    case 'xai-subscription':
+      return 'Grok';
+    case 'kimi-code-subscription':
+      return 'Kimi Code';
+    case 'relay':
+      return INCLUDED_ACCESS.inline;
+    case 'api-key':
+      return OWN_API_KEYS.inline;
+  }
+}
+
+/** Whether a usage route means model calls were covered by a subscription. */
+function isSubscriptionRoute(route: UsageRoute): boolean {
+  return (
+    route === 'chatgpt-subscription' ||
+    route === 'xai-subscription' ||
+    route === 'kimi-code-subscription'
+  );
+}
+
+/** Session-level cost line — mirrors the extension UsagePanel's cost+route
+ *  label so the CLI and extension bill the same way. Empty when there is no
+ *  cost to report and no known route to attribute. */
+function formatSessionCost(usage: TokenUsageStats): string | undefined {
+  const route = usage.usageRoute;
+  if (route != null) {
+    const label = usageRouteLabel(route);
+    if (isSubscriptionRoute(route) && usage.cost === 0) {
+      return `free via ${label}`;
+    }
+    return `${formatCostUsd(usage.cost)} via ${label}`;
+  }
+  return usage.cost > 0 ? formatCostUsd(usage.cost) : undefined;
+}
+
 export function collectResumeUsage(
   streams: ReadonlyMap<StreamTabId, StreamSlice>,
 ): TokenUsageStats | undefined {
@@ -105,7 +149,10 @@ export function formatResumeUsage(
   if (cached > 0) lines.push(`(+ ${formatInteger(cached)} cached)`);
   lines.push(`output=${formatInteger(usage.outputTokens)}`);
   if (reasoning > 0) lines.push(`(reasoning ${formatInteger(reasoning)})`);
-  return `Token usage: ${lines.join(' ')}`;
+  const costLine = formatSessionCost(usage);
+  return costLine
+    ? `Token usage: ${lines.join(' ')}\nSession cost: ${costLine}`
+    : `Token usage: ${lines.join(' ')}`;
 }
 
 /** The main session followed by each tool-use subagent (any depth), deduped by

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -13,7 +13,7 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 import type { TokenUsageStats, UsageRoute } from '@shared/schemas';
 import { designTokens } from '@shared/styles';
 import { DEFAULT_COMPACTION_THRESHOLD_PERCENT } from '@shared/constants/contextManagement';
-import { INCLUDED_ACCESS, OWN_API_KEYS } from '@shared/copy/modelAccess';
+import { usageRouteBadge } from '@shared/copy/modelAccess';
 
 // Local imports - shared icons and utils
 import type { TeXRAIconName } from '@shared/wa/iconNames';
@@ -24,11 +24,6 @@ import { formatCostUsd } from '@utils/text/stringUtils';
 // Local imports - progress view
 import { ELEMENT_IDS } from '../constants';
 import type { ContextStateData } from '../store';
-
-type UsageRouteBadge = {
-  label: string;
-  subscription: boolean;
-};
 
 /** One token counter in the usage strip: icon, count, and its tooltip. */
 type TokenStat = {
@@ -50,40 +45,6 @@ function fillColor(percent: number): string {
   if (percent <= 65) return 'var(--color-success)';
   if (percent <= 80) return 'var(--color-warning)';
   return 'var(--color-status-error)';
-}
-
-function usageRouteBadge(
-  route: UsageRoute | undefined,
-): UsageRouteBadge | undefined {
-  switch (route) {
-    case 'chatgpt-subscription':
-      return {
-        label: 'ChatGPT',
-        subscription: true,
-      };
-    case 'xai-subscription':
-      return {
-        label: 'Grok',
-        subscription: true,
-      };
-    case 'kimi-code-subscription':
-      return {
-        label: 'Kimi Code',
-        subscription: true,
-      };
-    case 'relay':
-      return {
-        label: INCLUDED_ACCESS.inline,
-        subscription: false,
-      };
-    case 'api-key':
-      return {
-        label: OWN_API_KEYS.inline,
-        subscription: false,
-      };
-    default:
-      return undefined;
-  }
 }
 
 function usageCostLabel(cost: number, route: UsageRoute | undefined): string {

--- a/src/shared/copy/modelAccess.ts
+++ b/src/shared/copy/modelAccess.ts
@@ -12,6 +12,8 @@
  * included access; that copy lives in `onboarding.ts`.
  */
 
+import type { UsageRoute } from '@shared/schemas';
+
 /** Model calls paid for by your TeXRA plan. */
 export const INCLUDED_ACCESS = {
   /** Standalone display name, e.g. a section heading or a status chip. */
@@ -45,3 +47,35 @@ export const OWN_API_KEYS = {
       'Model calls are billed to your own accounts at OpenAI, Anthropic, and other providers. You get higher limits, plus the models your plan does not cover.',
   },
 } as const;
+
+/** User-facing label and plan status for a {@link UsageRoute}. The label is
+ *  the payment surface's display name — "included access", "your own API
+ *  keys", or the subscription it runs on — and `subscription` marks routes
+ *  covered by a top-up-free subscription plan. Hosts (CLI exit summary,
+ *  extension usage panel) share this so payment attribution can't drift
+ *  between surfaces. */
+export interface UsageRouteBadge {
+  readonly label: string;
+  readonly subscription: boolean;
+}
+
+/** Map a usage route to its display badge, or undefined when the route is
+ *  unknown/unset. */
+export function usageRouteBadge(
+  route: UsageRoute | undefined,
+): UsageRouteBadge | undefined {
+  switch (route) {
+    case 'chatgpt-subscription':
+      return { label: 'ChatGPT', subscription: true };
+    case 'xai-subscription':
+      return { label: 'Grok', subscription: true };
+    case 'kimi-code-subscription':
+      return { label: 'Kimi Code', subscription: true };
+    case 'relay':
+      return { label: INCLUDED_ACCESS.inline, subscription: false };
+    case 'api-key':
+      return { label: OWN_API_KEYS.inline, subscription: false };
+    default:
+      return undefined;
+  }
+}

--- a/src/test-kernel/cli/ResumeHint.vitest.ts
+++ b/src/test-kernel/cli/ResumeHint.vitest.ts
@@ -338,4 +338,61 @@ describe('formatResumeUsage', () => {
       formatResumeUsage({ inputTokens: 0, outputTokens: 0, cost: 0 }),
     ).toBeUndefined();
   });
+
+  it('appends the session cost with the relay route label', () => {
+    expect(
+      formatResumeUsage({
+        inputTokens: 100,
+        outputTokens: 20,
+        cost: 0.012,
+        usageRoute: 'relay',
+      }),
+    ).toBe(
+      'Token usage: total=120 input=100 output=20\n' +
+        'Session cost: $0.012 via included access',
+    );
+  });
+
+  it('shows a covered subscription as free', () => {
+    expect(
+      formatResumeUsage({
+        inputTokens: 100,
+        outputTokens: 20,
+        cost: 0,
+        usageRoute: 'chatgpt-subscription',
+      }),
+    ).toBe(
+      'Token usage: total=120 input=100 output=20\n' +
+        'Session cost: free via ChatGPT',
+    );
+  });
+
+  it('labels your own API keys', () => {
+    expect(
+      formatResumeUsage({
+        inputTokens: 100,
+        outputTokens: 20,
+        cost: 0.5,
+        usageRoute: 'api-key',
+      }),
+    ).toBe(
+      'Token usage: total=120 input=100 output=20\n' +
+        'Session cost: $0.500 via your own API keys',
+    );
+  });
+
+  it('shows the bare cost when no route is stamped', () => {
+    expect(
+      formatResumeUsage({ inputTokens: 100, outputTokens: 20, cost: 0.3 }),
+    ).toBe(
+      'Token usage: total=120 input=100 output=20\n' + 'Session cost: $0.300',
+    );
+  });
+
+  it('omits the cost line when there is no cost and no route', () => {
+    const usage = { inputTokens: 100, outputTokens: 20, cost: 0 };
+    expect(formatResumeUsage(usage)).toBe(
+      'Token usage: total=120 input=100 output=20',
+    );
+  });
 });

--- a/src/test-kernel/cli/ResumeHint.vitest.ts
+++ b/src/test-kernel/cli/ResumeHint.vitest.ts
@@ -263,6 +263,24 @@ describe('formatResumeHint', () => {
     );
   });
 
+  it('flows the session cost line through the full hint', () => {
+    expect(
+      formatResumeHint([{ executionId: 'root', label: 'main', isRoot: true }], {
+        inputTokens: 100,
+        outputTokens: 20,
+        cost: 0.012,
+        usageRoute: 'relay',
+      } satisfies TokenUsageStats),
+    ).toBe(
+      [
+        'Token usage: total=120 input=100 output=20',
+        'Session cost: $0.012 via included access',
+        'Resume this session with:',
+        '  texra resume root  (main)',
+      ].join('\n'),
+    );
+  });
+
   it('is undefined when there is nothing to resume', () => {
     expect(formatResumeHint([])).toBeUndefined();
   });


### PR DESCRIPTION
## What

The CLI TUI now shows the current session's **USD cost and payment route** in the exit/resume summary, mirroring the VS Code extension `UsagePanel` wording so both surfaces bill and label the same way.

On exit, the hint prints a second line whenever there is a cost or a known route to attribute:

```
Token usage: total=120 input=100 output=20
Session cost: $0.012 via included access
Resume this session with:
  texra resume root  (main)
```

## Route wording (mirrors the extension's `usageCostLabel`)

| Route | Output |
|---|---|
| none | `Session cost: $0.300` |
| `relay` | `$0.012 via included access` |
| `api-key` | `$0.500 via your own API keys` |
| `chatgpt-subscription` ($0) | `free via ChatGPT` |
| `xai-subscription` ($0) | `free via Grok` |
| `kimi-code-subscription` ($0) | `free via Kimi Code` |
| no cost + no route | cost line omitted |

Reuses the TUI's existing per-stream `cumulativeUsage` aggregation (`sumUsageStats`, which already propagates a uniform `usageRoute`), so no new data plumbing is needed.

## Files
- `packages/cli/src/chat/tui/state/resumeHint.ts` — add `formatSessionCost` (+ route-label helpers) and append the cost line in `formatResumeUsage`
- `src/test-kernel/cli/ResumeHint.vitest.ts` — 5 new tests

## Verification
- `ResumeHint.vitest.ts`: 25/25 tests pass
- CLI `tsc --noEmit` clean
- prettier, eslint, guidance-refs, dead-code ratchet all clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only copy and a shared formatting helper; no billing, auth, or usage aggregation logic changes beyond what was already summed for token lines.
> 
> **Overview**
> The CLI TUI **exit/resume hint** now prints a **Session cost** line (USD plus how the run was paid) whenever aggregated usage has a cost or a known `usageRoute`, using the same wording as the VS Code usage panel.
> 
> **`usageRouteBadge`** is moved into **`modelAccess.ts`** so relay, API keys, and subscription routes map to one shared label set; the extension **`UsagePanel`** drops its local copy and imports that helper. **`formatResumeUsage`** / **`formatSessionCost`** in **`resumeHint.ts`** append lines like `$0.012 via included access`, `free via ChatGPT`, or bare cost when the route is unknown.
> 
> Tests in **`ResumeHint.vitest.ts`** cover the new cost line across routes and the full hint output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff90dcc17d1a04e3c61cfbb00cc11b4673b692d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Review resolution
- **Dedup** (review): localized `usageRouteLabel`/`isSubscriptionRoute` in the CLI and `usageRouteBadge` in the extension were hand-synced. Hoisted a single `usageRouteBadge(route) => {label, subscription}` into `@shared/copy/modelAccess.ts`; both the CLI exit summary and the extension `UsagePanel` now import it, so route labels can't drift between surfaces again.
- **Capitalization** (review): the CLI keeps lowercase `free via …` as it follows a colon (`Session cost: free via ChatGPT`); the extension badge keeps capitalized `Free · …` (standalone chip). Both now derive the same `label` from the shared badge; only the per-surface sentence framing differs.
- **Coverage** (review): added an integrated test asserting the `Session cost:` line flows through `formatResumeHint` (previously only `formatResumeUsage` was tested).
