### PR TITLE
fix(cli): update stale Ctrl-T help text and SKILL.md for TranscriptReader

### DIFF
--- a/.claude/skills/texra-cli/SKILL.md
+++ b/.claude/skills/texra-cli/SKILL.md
@@ -38,8 +38,13 @@ search, and mouse-scroll for finalized history, so don't reinvent them.
   streaming tail, spinners, side panels, input bar, and the active approval
   modal. In child focus, the same live region renders only the focused child's
   pending entries through the bounded row-budgeted path; full child history
-  belongs to that child's Static scrollback owner. Ctrl-T appends a full-output
-  snapshot through that same owner rather than opening a second viewport.
+  belongs to that child's Static scrollback owner. Ctrl-T opens the focused
+  stream's full output in a scrollable, closable `TranscriptReader`
+  (`panes/TranscriptReader.tsx`) rendered in the live region — `Esc` closes it
+  and restores the conversation exactly as it was, `p` prints the transcript to
+  native scrollback (for selecting/copying text out of the terminal). The reader
+  never takes over the viewport (the TUI avoids the alternate screen), so it is
+  sized by the same row budget as every other foreground surface.
   Cap root panels (`BOTTOM_PANEL_MAX_ROWS` in `panes/ConversationRegion.tsx`) so
   chrome never pushes the input off-screen. Don't park finalized content in the
   live region "for now."

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -363,7 +363,7 @@ const SCENARIOS = [
     expect: [
       '● bash (python3 enumerate_triples.py)',
       'tool-output-line-01',
-      '… +9 lines (Ctrl-T to print full output)',
+      '… +9 lines (Ctrl-T to view full output)',
       'tool-output-line-18',
     ],
     unexpect: ['tool-output-line-10 hidden-middle'],

--- a/packages/cli/src/chat/tui/commands/helpText.ts
+++ b/packages/cli/src/chat/tui/commands/helpText.ts
@@ -73,7 +73,7 @@ function keyboardSection(options: SlashCommandHelpOptions): string {
     // bindings that actually exist (see textInputBindings.ts).
     `- ${textInputEditingHelp()}`,
     '- `Esc` stops the focused agent · `Ctrl-C` exits idle chats; stops active responses',
-    "- `Ctrl-T` prints the focused stream's full output once into terminal scrollback",
+    "- `Ctrl-T` opens the focused stream's full output in a scrollable reader (`p` prints it to scrollback)",
     `- \`Tab\` ${SESSION_LIST.openHelp} · \`v\` prints the selected stream's full output`,
     `- \`${focusChord}\` focuses a stream directly`,
   ].join('\n');

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -106,7 +106,7 @@ function elideOutputLines(lines: readonly string[]): ElidedOutput {
 }
 
 function elisionMarker(hiddenCount: number): string {
-  return `… +${hiddenCount} lines (Ctrl-T to print full output)`;
+  return `… +${hiddenCount} lines (Ctrl-T to view full output)`;
 }
 
 // Generic fallback for tools without a curated preview field in

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -60,7 +60,7 @@ export const chatCommand = withUsageSections(
         ['/login, /logout', 'sign in or out of ChatGPT or Researcher Access'],
         [
           'Ctrl-T',
-          "print the focused stream's full output once into terminal scrollback",
+          "open the focused stream's full output in a scrollable reader (`p` prints it to scrollback)",
         ],
         ['Tab', 'select a visible child session or process'],
         [

--- a/src/test-kernel/cli/CliRootArgs.vitest.ts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.ts
@@ -1322,7 +1322,7 @@ describe('runCli usage output stream routing', () => {
     expect(stdout).toContain('/login, /logout');
     expect(stdout).toContain('ChatGPT or Researcher Access');
     expect(stdout).toContain(
-      "print the focused stream's full output once into terminal scrollback",
+      "open the focused stream's full output in a scrollable reader (`p` prints it to scrollback)",
     );
     expect(stdout).toContain('Tab');
     expect(stdout).toContain('select a visible child session or process');

--- a/src/test-kernel/cli/SlashHelpText.vitest.ts
+++ b/src/test-kernel/cli/SlashHelpText.vitest.ts
@@ -78,7 +78,7 @@ describe('formatSlashCommandHelp', () => {
     expect(macKittyHelp).toContain('`Esc 1..9`');
     expect(macKittyHelp).toContain('`Shift-Enter` or `Ctrl-J`');
     expect(macKittyHelp).toContain(
-      "`Ctrl-T` prints the focused stream's full output once into terminal scrollback",
+      "`Ctrl-T` opens the focused stream's full output in a scrollable reader (`p` prints it to scrollback)",
     );
     expect(macKittyHelp).toContain(
       "`v` prints the selected stream's full output",

--- a/src/test-kernel/cli/ToolRenderers.vitest.ts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.ts
@@ -288,7 +288,7 @@ describe('CLI tool display lines', () => {
         "  line 4",
         "  line 5",
         "  line 6",
-        "  … +11 lines (Ctrl-T to print full output)",
+        "  … +11 lines (Ctrl-T to view full output)",
         "  line 18",
         "  line 19",
         "  line 20",


### PR DESCRIPTION
## Summary

Follow-ups from #9840 (restore live transcript updates, make Ctrl-T closable). Ctrl-T now opens a scrollable, closable `TranscriptReader` foreground surface instead of printing directly to terminal scrollback; `p` prints to scrollback from within it. Several strings still described the old scrollback-print behavior.

## Changes

- `toolRenderers.tsx` elision marker: `Ctrl-T to print full output` → `Ctrl-T to view full output`
- `helpText.ts` /help keyboard section: describe the reader + `p` print
- `chat.ts` INTERACTIVE CONTROLS row: same update
- `validate-tui.mjs` golden string: match the new elision marker
- `.claude/skills/texra-cli/SKILL.md`: describe the new TranscriptReader design (Esc closes, p prints)

## Testing

- `corepack pnpm --filter @texra-ai/cli typecheck` — clean
- `node scripts/validate-tui.mjs long-tool-output-elided` — passes with new golden string

Closes #9847, #9848

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test expectation updates only; no runtime behavior changes in this diff.
> 
> **Overview**
> Updates user-facing strings and internal docs so **Ctrl-T** is described as opening a scrollable **`TranscriptReader`** (close with **`Esc`**, print to native scrollback with **`p`**) instead of one-shot printing to terminal scrollback.
> 
> The elision hint on truncated tool output changes from “print full output” to **“view full output”** in `toolRenderers.tsx`, with matching golden expectations in `validate-tui.mjs` and `ToolRenderers.vitest.ts`. **`/help`**, **`chat --help`**, and **`INTERACTIVE CONTROLS`** in `helpText.ts` and `chat.ts` use the same wording; **`texra-cli` SKILL.md** documents the reader design for child-focus full output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6310c511e2ca7386c39b85e639c9131439248efb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->