### PR TITLE
fix(desktop): re-arm shell signal watcher in finally so a throw cannot freeze the shell

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -1310,8 +1310,15 @@ function installShellSignalWatcher(): void {
       shellRerenderQueued = false;
       // Read the pending computed so the watcher re-tracks its dependencies.
       for (const pending of shellWatcher.getPending()) pending.get();
-      rerenderShell();
-      shellWatcher.watch();
+      // Re-arm in `finally`: a Watcher fires once and stays dormant until
+      // `watch()` runs again, so letting a throw from `rerenderShell()` skip
+      // it would freeze the whole shell on stale data with no error and no
+      // recovery (same defect fixed in the CLI's `subscribeToSignalChanges`).
+      try {
+        rerenderShell();
+      } finally {
+        shellWatcher.watch();
+      }
     });
   });
   shellWatcher.watch(shellDeps);


### PR DESCRIPTION
## Summary

Follow-up from #9840. The desktop renderer's shell signal watcher called `rerenderShell()` and then re-armed with `shellWatcher.watch()`. A throw from `rerenderShell()` would skip the re-arm, leaving the `Signal.subtle.Watcher` dormant forever and freezing the whole shell on stale data with no error and no recovery.

## Changes

Wrap the re-arm in `finally` at `packages/desktop/src/renderer/main.ts`, the same fix applied to the CLI's `subscribeToSignalChanges` in #9840.

## Testing

- `corepack pnpm --filter @texra/desktop typecheck` — clean

Closes #9846

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive control-flow change around existing shell rerender logic; no auth, data, or API surface changes.
> 
> **Overview**
> The desktop renderer’s shell **signal watcher** now **re-arms** with `shellWatcher.watch()` in a **`finally` block** after `rerenderShell()`, instead of only on the success path.
> 
> `Signal.subtle.Watcher` fires once and stays dormant until `watch()` runs again. If `rerenderShell()` threw, the previous code skipped re-arming and the shell could **freeze on stale UI** with no error and no recovery. This matches the **CLI** fix in `subscribeToSignalChanges` (#9840).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d008d0a3d090b5ffe22edd02a83ec1eff0d6274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->