### PR TITLE
chore(deps): remove unused es-toolkit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "delay": "^7.0.0",
     "diff-match-patch": "^1.0.5",
     "dotenv": "^17.4.2",
-    "es-toolkit": "^1.50.0",
     "escape-string-regexp": "^5.0.0",
     "execa": "^10.0.1",
     "fast-json-stable-stringify": "^2.1.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -68,7 +68,6 @@
     "deepmerge": "^4.3.1",
     "delay": "^7.0.0",
     "diff-match-patch": "^1.0.5",
-    "es-toolkit": "^1.50.0",
     "escape-string-regexp": "^5.0.0",
     "execa": "^10.0.1",
     "fast-json-stable-stringify": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,9 +105,6 @@ importers:
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
-      es-toolkit:
-        specifier: ^1.50.0
-        version: 1.50.0
       escape-string-regexp:
         specifier: ^5.0.0
         version: 5.0.0
@@ -487,9 +484,6 @@ importers:
       diff-match-patch:
         specifier: ^1.0.5
         version: 1.0.5
-      es-toolkit:
-        specifier: ^1.50.0
-        version: 1.50.0
       escape-string-regexp:
         specifier: ^5.0.0
         version: 5.0.0


### PR DESCRIPTION
## Summary

Follow-up from #9840. The debounce reimplementation in `src/utils/core/index.ts` replaced es-toolkit's `debounce` with a hand-rolled `setTimeout`/`clearTimeout` wrapper, leaving es-toolkit unused as a direct dependency in both the repo root and `packages/agent`.

## Changes

- Remove `es-toolkit` from `dependencies` in `package.json` and `packages/agent/package.json`
- Regenerate the lockfile (`corepack pnpm install --lockfile-only`)

es-toolkit remains in the lockfile only as a transitive dependency of `ink@7.1.1`, which is expected.

## Testing

- `npm run typecheck:workspace` — clean

Closes #9845

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only cleanup with no runtime code changes; typecheck was reported clean.
> 
> **Overview**
> Removes the direct **`es-toolkit`** dependency from the workspace root **`package.json`** and **`packages/agent/package.json`**, and updates **`pnpm-lock.yaml`** so it is no longer listed as a direct workspace dependency.
> 
> This follows replacing es-toolkit’s **`debounce`** with a local implementation in **`src/utils/core/index.ts`** (#9840); there are no remaining imports of **`es-toolkit`** in **`src`** or **`packages/agent`**. **`es-toolkit`** can still appear in the lockfile as a transitive dependency (e.g. via **`ink`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26c85052b31e55ccfc40489c6991f70bd2d4b19e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->