### PR TITLE
test(kernel): fix vacuous review tool roster in ToolConversion vitest

### DIFF
--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -774,10 +774,10 @@ describe('toGoogleTools', () => {
       'packages/extension/resources/tool_use_agents/review.yaml',
     );
     const reviewYaml = parseYaml(readFileSync(reviewYamlPath, 'utf8')) as {
-      tools?: unknown[];
+      settings?: { tools?: unknown[] };
     };
     const reviewToolNames = [
-      ...(extractToolNames(reviewYaml.tools) ?? []),
+      ...(extractToolNames(reviewYaml.settings?.tools) ?? []),
       DELEGATE_MULTI_AGENTS_TOOL_NAME,
     ];
     const reviewTools = resolveToolDefinitions(reviewToolNames);


### PR DESCRIPTION
## Summary

Follow-up from #9834. The YAML-derived roster in the `generates finite schemas for the scientific review tool roster` test read `reviewYaml.tools`, but `review.yaml` nests tools under `settings.tools`. `extractToolNames` received `undefined`, the `?? []` fallback kicked in, and the roster shrank to just the injected delegation tool — so the schema-finiteness test validated 1 tool instead of the full 17-tool roster.

## Changes

Reach the nested `settings` key so the test covers the real roster.

## Testing

- `npx vitest run src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts` — 49/49 passing

Closes #9841

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only path fix with no production or runtime behavior changes.
> 
> **Overview**
> Fixes a **vacuous** Google schema test for the scientific review tool roster: the test now reads tool names from `review.yaml` via **`settings.tools`** instead of a nonexistent top-level `tools` key.
> 
> Before the change, `extractToolNames` got `undefined`, fell back to `[]`, and the roster was only the injected delegation tool—so finiteness checks ran on **one** tool instead of the full YAML roster plus delegation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20b71a087bb8360bd3e1d55b85f08425d0d868e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->