### PR TITLE
fix(roster): repair hybrid legacy roster selection with stray kind field

### DIFF
--- a/src/agent/roster/AgentRosterController.ts
+++ b/src/agent/roster/AgentRosterController.ts
@@ -85,9 +85,9 @@ function allPresets(
 /**
  * Read the canonical workspace selection. A value that does not parse is
  * tried against the legacy pair-shaped format (`{workflowAgentKeys,
- * toolUseAgentKeys}`) via the existing AgentDelegationScopeLegacySchema.
- * On a match the stored value is immediately repaired so the warning is a
- * one-time event per workspace.
+ * toolUseAgentKeys}`, with or without a stray `kind` field) via the existing
+ * AgentDelegationScopeLegacySchema. On a match the stored value is
+ * immediately repaired so the warning is a one-time event per workspace.
  */
 function readAgentRosterSelection(
   workspaceState: StateStore,
@@ -114,7 +114,21 @@ function readAgentRosterSelection(
 }
 
 function repairLegacySelection(raw: unknown): AgentRosterSelection | undefined {
-  const legacy = AgentDelegationScopeLegacySchema.safeParse(raw);
+  // The legacy pair-shaped value may carry a stray `kind` field: an
+  // intermediate version wrote `{kind: 'custom', workflowAgentKeys,
+  // toolUseAgentKeys}` under AGENT_ROSTER_SELECTION, which neither the
+  // canonical schema (missing `agentKeys`) nor the strict legacy schema
+  // (rejects `kind`) accepts. Drop the discriminant before parsing so both
+  // the pure and hybrid legacy shapes repair to the same canonical value.
+  const candidate =
+    raw !== null && typeof raw === 'object' && 'kind' in raw
+      ? Object.fromEntries(
+          Object.entries(raw as Record<string, unknown>).filter(
+            ([key]) => key !== 'kind',
+          ),
+        )
+      : raw;
+  const legacy = AgentDelegationScopeLegacySchema.safeParse(candidate);
   if (!legacy.success) return undefined;
   return {
     kind: 'custom',

--- a/src/test-kernel/controllers/AgentRosterController.vitest.ts
+++ b/src/test-kernel/controllers/AgentRosterController.vitest.ts
@@ -103,6 +103,42 @@ describe('AgentRosterController', () => {
     });
   });
 
+  it('repairs the hybrid pair-shaped roster that carries a stray kind field in place', () => {
+    // An intermediate version wrote `{kind: 'custom', workflowAgentKeys,
+    // toolUseAgentKeys}` under AGENT_ROSTER_SELECTION. Neither the canonical
+    // schema (missing `agentKeys`) nor the strict legacy schema (rejects
+    // `kind`) accepts it, so it must be normalized to the canonical custom
+    // selection without warning.
+    const warn = stubWarn();
+    const hybrid = {
+      kind: 'custom',
+      workflowAgentKeys: ['builtInWorkflow:write'],
+      toolUseAgentKeys: ['builtInToolUse:lead'],
+    };
+    const workspaceState = new FakeStateStore({
+      [WorkspaceStateKey.AGENT_ROSTER_SELECTION]: hybrid,
+    });
+    const roster = controller(workspaceState);
+
+    expect(roster.getSelection()).toEqual({
+      kind: 'custom',
+      agentKeys: {
+        workflow: ['builtInWorkflow:write'],
+        toolUse: ['builtInToolUse:lead'],
+      },
+    });
+    expect(warn).not.toHaveBeenCalled();
+    expect(
+      workspaceState.get(WorkspaceStateKey.AGENT_ROSTER_SELECTION),
+    ).toEqual({
+      kind: 'custom',
+      agentKeys: {
+        workflow: ['builtInWorkflow:write'],
+        toolUse: ['builtInToolUse:lead'],
+      },
+    });
+  });
+
   it('uses the user default only for inherited workspaces', () => {
     const workspaceState = new FakeStateStore();
     const roster = controller(workspaceState, {


### PR DESCRIPTION
## Problem

The CLI warns on every startup:

```
[agentRoster] Ignoring malformed roster selection; falling back to the inherited roster:
  { path: ["agentKeys"], expected: "record", received: undefined }
  { keys: ["workflowAgentKeys","toolUseAgentKeys"], code: "unrecognized_keys" }
```

An intermediate version wrote `{kind: "custom", workflowAgentKeys, toolUseAgentKeys}` under `texra.agentRosterSelection`. This hybrid shape is rejected by **both** parsers:

- `AgentRosterSelectionSchema` (discriminated union on `kind`): matches `kind: "custom"` but `agentKeys` is missing, and the strict object rejects the legacy keys.
- `AgentDelegationScopeLegacySchema` (strict object): rejects the stray `kind` key.

So `repairLegacySelection` never fired, the value was never repaired, and the warning repeated on every read.

## Fix

In `repairLegacySelection` (`src/agent/roster/AgentRosterController.ts`), strip the stray `kind` field before parsing against `AgentDelegationScopeLegacySchema`. Both the pure and hybrid legacy shapes now normalize to the canonical `{kind: "custom", agentKeys: {workflow, toolUse}}` and are written back in place — the warning becomes a one-time event and the user's actual agent selection is preserved (not dropped to inherited).

The legacy schema is shared with run-history parsing (where `kind` never appears), so it stays strict; the stripping happens only in the roster repair path.

## Verification

- New vitest case covers the hybrid shape (repairs in place, no warning).
- All 13 `AgentRosterController` tests pass; 346 in the broader controller/CLI suite.
- ESLint and `tsc --noEmit` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized read-path normalization for persisted roster JSON; no auth or runtime delegation changes, and the strict legacy schema used elsewhere is unchanged.
> 
> **Overview**
> Fixes repeated CLI startup warnings and loss of user agent picks when workspace state holds the **hybrid** legacy shape `{kind: 'custom', workflowAgentKeys, toolUseAgentKeys}` written by an intermediate release.
> 
> **`repairLegacySelection`** in `AgentRosterController` now strips a stray `kind` field before validating with the strict `AgentDelegationScopeLegacySchema`, so hybrid values repair to canonical `{kind: 'custom', agentKeys: {workflow, toolUse}}` and are written back on read (one-time migration, no recurring warn). Pure pair-shaped legacy values without `kind` still follow the same path.
> 
> Adds a vitest case asserting in-place repair and no `console.warn` for the hybrid shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7144de21a158915535366fb115d3878652f30bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->