### PR TITLE
fix(model): use deepseekT (thinking) instead of deepseek in default model list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Shared (all surfaces)
+
+#### Bug Fixes
+
+- **DeepSeek V4 Flash (Thinking) is the default DeepSeek model** — the model
+  picker now lists the thinking variant (`deepseekT`) instead of the
+  non-thinking `deepseek`, so DeepSeek V4 Flash users get reasoning support.
+
 #### Breaking Changes
 
 - **The multi-agent orchestration tool is now `delegate_multi_agents`** —

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -51,7 +51,7 @@ export const PREFERRED_DEFAULT_MODELS: readonly string[] = [
   'gpt56',
   'gpt56-',
   'gpt56--',
-  'deepseek',
+  'deepseekT',
   'deepseekproT',
   'kimi26T',
   'kimi3',


### PR DESCRIPTION
## Summary

Commit `a5dd20815b` titled "Add DeepSeek V4 Flash (Thinking) to default model list" intended to add `deepseekT` (the thinking variant) to `PREFERRED_DEFAULT_MODELS`, but accidentally added `deepseek` (the non-thinking V4 Flash) instead. The commit message explicitly says "Adds the thinking variant rather than the non-thinking deepseek" — yet the diff added the wrong one.

## Impact

The model picker was showing **DeepSeek V4 Flash** (non-thinking) instead of **DeepSeek V4 Flash (Thinking)**. Users who picked `deepseek` would never see the TUI's "thinking..." indicator because the model doesn't support reasoning.

## Change

`src/model/modelOptionsBasic.ts`: swap `deepseek` → `deepseekT` in `PREFERRED_DEFAULT_MODELS`.

## Verification

- `deepseekT` is valid in llm-zoo: DeepSeek V4 Flash (Thinking), `supportsReasoning: true`, not retired/deprecated
- `MODEL_LIST_VERSION` auto-recomputes from the preferred list, so existing users' model lists reconcile automatically
- All 137 model-related tests pass (14 test files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single curated default-model id swap with registry-driven list reconciliation; no auth, persistence schema, or runtime routing logic changes beyond which DeepSeek id is preferred in the default set.
> 
> **Overview**
> Corrects a regression where **`PREFERRED_DEFAULT_MODELS`** listed **`deepseek`** (non-thinking V4 Flash) instead of **`deepseekT`** (V4 Flash Thinking), so the model picker and default enabled-model reconciliation now surface the thinking variant with reasoning support and the TUI “thinking…” indicator.
> 
> **`CHANGELOG.md`** documents the fix under Unreleased shared bug fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad2466bff66717287c29f09be5b9d3db888c5462. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->