### PR TITLE
fix(agent): structured turn diagnostics + concurrent-follow-up regression for #9531

### DIFF
--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -396,6 +396,40 @@ function mintChildTurnRef(
 }
 
 /**
+ * Structured turn-lifecycle diagnostic (#9531): ties the execution, the turn's
+ * logical identity, the follow-up queue owner/generation, and the interruption
+ * cause into one event so a resumed/interrupted child's state is auditable.
+ * Emitted at turn acceptance, delivery, and loop termination.
+ */
+function emitTurnDiagnostic(
+  logger: AgentTrace,
+  event: 'turn.accepted' | 'turn.delivered' | 'loop.terminated',
+  params: {
+    executionId: ExecutionId;
+    turnRef?: ChildTurnRef;
+    queueOwner?: FollowUpConsumerLease;
+    interruptionCause?: string;
+  },
+): void {
+  const { executionId, turnRef, queueOwner, interruptionCause } = params;
+  logger.info(`childRunLoop ${event}`, {
+    data: {
+      executionId,
+      ...(turnRef
+        ? { turnToken: turnRef.token, deliveryId: turnRef.deliveryId }
+        : {}),
+      ...(queueOwner
+        ? {
+            queueGeneration: queueOwner.generation,
+            queueOwner: queueOwner.kind,
+          }
+        : {}),
+      ...(interruptionCause ? { interruptionCause } : {}),
+    },
+  });
+}
+
+/**
  * Persist turn attribution for the report/result slots, swallowing storage
  * errors. Best-effort: a failure degrades /report//result turn labeling, not
  * the delivered result.
@@ -713,6 +747,11 @@ export function startChildRunLoop<TTurn>(
       while (!loop.isInterrupted()) {
         turnIndex += 1;
         const turnRef = mintChildTurnRef(executionId, turnIndex);
+        emitTurnDiagnostic(logger, 'turn.accepted', {
+          executionId,
+          turnRef,
+          queueOwner: queueLease,
+        });
         // Acceptance creates the pending-turn record: until this turn's
         // result is persisted, /report and /result keep attributing the
         // latest-value slots to the last completed turn. Fire-and-forget —
@@ -775,6 +814,11 @@ export function startChildRunLoop<TTurn>(
           },
         });
         lastCompletedTurn = turnRef;
+        emitTurnDiagnostic(logger, 'turn.delivered', {
+          executionId,
+          turnRef,
+          queueOwner: queueLease,
+        });
 
         if (turnFailed) {
           sawTurnFailure = true;
@@ -816,6 +860,15 @@ export function startChildRunLoop<TTurn>(
       }
     } finally {
       detachLoopInterrupt?.();
+      emitTurnDiagnostic(logger, 'loop.terminated', {
+        executionId,
+        queueOwner: queueLease,
+        interruptionCause: loop.isInterrupted()
+          ? 'interrupted'
+          : sawTurnFailure
+            ? 'turn_failed'
+            : 'terminal',
+      });
       if (queueLease) runSession.followUps.release(queueLease, 'terminal');
       releaseSessionOwnershipOnce();
       try {

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -396,6 +396,23 @@ function mintChildTurnRef(
 }
 
 /**
+ * Why the child-run loop stopped, for the structured termination diagnostic.
+ */
+type ChildLoopTerminationCause = 'interrupted' | 'turn_failed' | 'terminal';
+
+/**
+ * Resolve the loop's termination cause without a nested ternary.
+ */
+function resolveLoopTerminationCause(
+  interrupted: boolean,
+  turnFailed: boolean,
+): ChildLoopTerminationCause {
+  if (interrupted) return 'interrupted';
+  if (turnFailed) return 'turn_failed';
+  return 'terminal';
+}
+
+/**
  * Structured turn-lifecycle diagnostic (#9531): ties the execution, the turn's
  * logical identity, the follow-up queue owner/generation, and the interruption
  * cause into one event so a resumed/interrupted child's state is auditable.
@@ -408,7 +425,7 @@ function emitTurnDiagnostic(
     executionId: ExecutionId;
     turnRef?: ChildTurnRef;
     queueOwner?: FollowUpConsumerLease;
-    interruptionCause?: string;
+    interruptionCause?: ChildLoopTerminationCause;
   },
 ): void {
   const { executionId, turnRef, queueOwner, interruptionCause } = params;
@@ -863,11 +880,10 @@ export function startChildRunLoop<TTurn>(
       emitTurnDiagnostic(logger, 'loop.terminated', {
         executionId,
         queueOwner: queueLease,
-        interruptionCause: loop.isInterrupted()
-          ? 'interrupted'
-          : sawTurnFailure
-            ? 'turn_failed'
-            : 'terminal',
+        interruptionCause: resolveLoopTerminationCause(
+          loop.isInterrupted(),
+          sawTurnFailure,
+        ),
       });
       if (queueLease) runSession.followUps.release(queueLease, 'terminal');
       releaseSessionOwnershipOnce();

--- a/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
@@ -222,13 +222,14 @@ async function queueSecondAssertionFollowUp(
   parentContext: ReturnType<typeof createRunContext>,
   runAsParentOwner: ReturnType<typeof captureOwnedExecutionLease>,
   executionId: ExecutionId,
+  instruction = 'Now prove the second assertion.',
 ) {
   const resumed = await runAsParentOwner(() =>
     withRunContext(parentContext, () =>
       new DelegateAgentTool().call({
         agent: null,
         model: null,
-        instruction: 'Now prove the second assertion.',
+        instruction,
         memories: [],
         working_directory: null,
         execution_id: executionId,
@@ -510,22 +511,19 @@ describe('native subagent production delivery path', () => {
     // The loop drains the follow-up batch (waitAndDrainAll) and runs one turn
     // with the combined batch, so both instructions reach the child in one
     // ordered turn rather than sharing/overwriting one turn result.
-    const submitFollowUp = (instruction: string) =>
-      runAsParentOwner(() =>
-        withRunContext(parentContext, () =>
-          new DelegateAgentTool().call({
-            agent: null,
-            model: null,
-            instruction,
-            memories: [],
-            working_directory: null,
-            execution_id: executionId,
-          }),
-        ),
-      );
     const [first, second] = await Promise.all([
-      submitFollowUp('Now prove the second assertion.'),
-      submitFollowUp('Now prove the third assertion.'),
+      queueSecondAssertionFollowUp(
+        parentContext,
+        runAsParentOwner,
+        executionId,
+        'Now prove the second assertion.',
+      ),
+      queueSecondAssertionFollowUp(
+        parentContext,
+        runAsParentOwner,
+        executionId,
+        'Now prove the third assertion.',
+      ),
     ]);
     expect(first.status).toBe('executed');
     expect(second.status).toBe('executed');
@@ -533,12 +531,15 @@ describe('native subagent production delivery path', () => {
     await waitForPersistedResult(executionId, 'Result B.');
     await waitForCompletedResumes(2);
 
-    // The child transcript has turn 1 (Result A) and the batch turn (Result B).
+    // The child transcript has turn 1 (Result A) and the batch turn (Result B),
+    // with BOTH follow-up instructions recorded as user messages in the batch.
     await session.transcripts.flush();
     const archivedChild = await readCompletedRunConversation(executionId);
     const childText = JSON.stringify(archivedChild.conversation);
     expect(childText.match(/Result A\./g)).toHaveLength(1);
     expect(childText.match(/Result B\./g)).toHaveLength(1);
+    expect(childText).toContain('second assertion');
+    expect(childText).toContain('third assertion');
 
     // The parent received each distinct result exactly once.
     const archivedParent =

--- a/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
@@ -491,6 +491,66 @@ describe('native subagent production delivery path', () => {
     expect(parentTurns).toHaveLength(0);
   }, 30_000);
 
+  it('combines concurrent distinct follow-ups into one ordered batch turn, not an overwritten result', async () => {
+    // Two child turns: the initial launch plus one batch turn that drains both
+    // concurrent follow-ups together.
+    const parentTurns = [
+      { text: 'Parent ready.' },
+      { text: 'Parent received result A.' },
+      { text: 'Parent received result B.' },
+    ];
+    const childTurns = [{ text: 'Result A.' }, { text: 'Result B.' }];
+    const { executionId, parentContext, runAsParentOwner } =
+      await launchWaitingChild({ parentTurns, childTurns });
+
+    await waitForPersistedResult(executionId, 'Result A.');
+    await waitForCompletedResumes(1);
+
+    // Submit two follow-ups concurrently, before the child drains the queue.
+    // The loop drains the follow-up batch (waitAndDrainAll) and runs one turn
+    // with the combined batch, so both instructions reach the child in one
+    // ordered turn rather than sharing/overwriting one turn result.
+    const submitFollowUp = (instruction: string) =>
+      runAsParentOwner(() =>
+        withRunContext(parentContext, () =>
+          new DelegateAgentTool().call({
+            agent: null,
+            model: null,
+            instruction,
+            memories: [],
+            working_directory: null,
+            execution_id: executionId,
+          }),
+        ),
+      );
+    const [first, second] = await Promise.all([
+      submitFollowUp('Now prove the second assertion.'),
+      submitFollowUp('Now prove the third assertion.'),
+    ]);
+    expect(first.status).toBe('executed');
+    expect(second.status).toBe('executed');
+
+    await waitForPersistedResult(executionId, 'Result B.');
+    await waitForCompletedResumes(2);
+
+    // The child transcript has turn 1 (Result A) and the batch turn (Result B).
+    await session.transcripts.flush();
+    const archivedChild = await readCompletedRunConversation(executionId);
+    const childText = JSON.stringify(archivedChild.conversation);
+    expect(childText.match(/Result A\./g)).toHaveLength(1);
+    expect(childText.match(/Result B\./g)).toHaveLength(1);
+
+    // The parent received each distinct result exactly once.
+    const archivedParent =
+      await readCompletedRunConversation(PARENT_EXECUTION_ID);
+    const parentText = JSON.stringify(archivedParent.conversation);
+    expect(parentText.match(/Result A\./g)).toHaveLength(1);
+    expect(parentText.match(/Result B\./g)).toHaveLength(1);
+    expect(resumedStreams).toEqual([PARENT_STREAM_ID, PARENT_STREAM_ID]);
+    expect(completedResumes).toEqual([PARENT_STREAM_ID, PARENT_STREAM_ID]);
+    expect(parentTurns).toHaveLength(0);
+  }, 30_000);
+
   it('suppresses replays of one logical child delivery at the real admission boundary', async () => {
     const { executionId } = await launchWaitingChild({
       parentTurns: [


### PR DESCRIPTION
## Summary

Completes the two remaining acceptance criteria from #9531 (resumed native subagent turns reuse stale results):

### 1. Structured diagnostics (AC: `Structured diagnostics identify execution, turn, delivery, queue generation/owner, and interruption cause`)

Adds a `childRunLoop` turn-lifecycle diagnostic emitted at `turn.accepted`, `turn.delivered`, and `loop.terminated`. Each event ties together:
- `executionId`
- the turn's logical `turnToken` + `deliveryId`
- the follow-up queue `queueGeneration` + `queueOwner` (kind)
- the `interruptionCause` (interrupted / turn_failed / terminal)

### 2. Concurrent follow-ups (AC: `Concurrent follow-ups are either distinct ordered turns or one is explicitly rejected`)

Adds a production-shaped regression to `NativeSubagentProductionPath.vitest.ts` asserting that two concurrent distinct follow-ups are drained as one ordered batch turn (both instructions reach the child) rather than sharing/overwriting one turn result, and that each distinct result is delivered to the parent exactly once.

## Testing

- `corepack pnpm --filter @texra-ai/agent build` — clean
- `npx vitest run src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts src/test-kernel/agent/followUp/FollowUpQueue.vitest.ts` — 33/33 passing

Addresses #9531

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive logging and integration tests on the child run loop; no changes to delivery or persistence logic beyond diagnostic emissions.
> 
> **Overview**
> Adds **structured turn-lifecycle logging** in `childRunLoop` for #9531: `emitTurnDiagnostic` fires at **turn acceptance**, **delivery**, and **loop termination**, bundling `executionId`, turn `turnToken` / `deliveryId`, follow-up queue `queueGeneration` and `queueOwner`, and on shutdown an `interruptionCause` (`interrupted`, `turn_failed`, or `terminal`).
> 
> Extends the native subagent production-path tests with a **concurrent follow-up** scenario: two distinct follow-ups queued in parallel are drained as **one batch turn** (both user instructions appear in the child transcript) with a single **Result B** delivery to the parent, not a shared/overwritten turn result. `queueSecondAssertionFollowUp` now accepts a custom instruction string for that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e27237f67dd0ae124b805245a47defc2771118ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->