### PR TITLE
ci: re-enable windows-latest kernel-test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,20 +173,18 @@ jobs:
       - name: Check guidance file references resolve
         run: node scripts/check-guidance-refs.mjs
 
-  # TODO(windows-ci): restore the full windows-latest matrix after its remaining
-  # failures are fixed. The focused job below keeps CLI input path handling
-  # covered on Windows without running unrelated failing suites.
   test:
-    name: kernel tests (linux, shard ${{ matrix.shard }}/2)
+    name: kernel tests (${{ matrix.os }}, shard ${{ matrix.shard }}/2)
     needs: changes
     if: needs.changes.outputs.code == 'true' && github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
-      # Run both shards to completion so a red run reports every failure at
+      # Run all shards/OSes to completion so a red run reports every failure at
       # once instead of hiding the other shard's results.
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         shard: [1, 2]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
         run: node scripts/check-guidance-refs.mjs
 
   test:
-    name: kernel tests (${{ matrix.os }}, shard ${{ matrix.shard }}/2)
+    name: kernel tests (${{ matrix.os-label }}, shard ${{ matrix.shard }}/2)
     needs: changes
     if: needs.changes.outputs.code == 'true' && github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
@@ -184,7 +184,11 @@ jobs:
       # once instead of hiding the other shard's results.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            os-label: linux
+          - os: windows-latest
+            os-label: windows
         shard: [1, 2]
 
     steps:


### PR DESCRIPTION
## Summary

Re-enables the full `windows-latest` kernel-test matrix that was gated behind a `TODO(windows-ci)` comment in #9409.

The three Windows failure buckets from #9409 are addressed:
- **Bucket 1 (duplicated run segment in artifact paths)** — fixed by `9a59011282` (`fix(ci): restore Windows kernel tests`)
- **Bucket 2 (separator expectations)** — addressed by `f6650c2be2` (`test(files): use native path expectations`)
- **Bucket 3 (fake-filesystem gaps)** — `RunStorageEntryInspection.vitest.ts` now has symlink and permission-failure tests

## Changes

- Add `windows-latest` to the kernel-test matrix `os` dimension (alongside `ubuntu-latest`)
- Drop the `TODO(windows-ci)` comment
- The focused `cli-workflow-inputs-windows` job remains for CLI input path coverage

## Risk

This makes Windows a gating CI job. If any pre-existing Windows test still fails, the matrix will go red — which is the point: surface the failures so they can be fixed.

Closes #9409

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Windows kernel tests become merge-blocking alongside Linux; any remaining Windows failures will fail CI, which is intentional but increases CI cost and surface area for flaky platform-specific tests.
> 
> **Overview**
> Restores **Windows** as a full peer in the kernel test CI matrix by running the same sharded `pnpm run test` job on `windows-latest` as on `ubuntu-latest`, instead of Linux-only kernel tests with a deferred `TODO(windows-ci)`.
> 
> The `test` job now uses a matrix `include` for `ubuntu-latest` / `windows-latest` with an `os-label` for job names, `runs-on: ${{ matrix.os }}`, and updated comments describing all shards and OSes finishing under `fail-fast: false`. The separate `cli-workflow-inputs-windows` job is unchanged for CLI input path coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4901cd44eae622133bdf93d6152ac972461fd6d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->