### PR TITLE
feat(model): allow switching from Kimi Code to the Moonshot API on usage exhaustion

### DIFF
--- a/packages/cli/src/chat/tui/modals/RetryRequest.tsx
+++ b/packages/cli/src/chat/tui/modals/RetryRequest.tsx
@@ -3,6 +3,7 @@ import { Text, useWindowSize } from 'ink';
 import {
   isCliApiSwitchableRetry,
   isCliChatGptSubscriptionRetry,
+  isCliKimiCodeSubscriptionRetry,
 } from '@cli/runtime/approval/approvalPrompts';
 import { wrapAnsiToWidth } from '@cli/tui/ansiWrap';
 import { COLOR_HINT, COLOR_WARNING } from '@cli/tui/ui/colors';
@@ -47,16 +48,19 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
   const { columns } = useWindowSize();
   const errorText = props.payload.errorMessage ?? props.payload.operation;
   const isSubscriptionLimit = isCliChatGptSubscriptionRetry(props.payload);
+  const isKimiCodeLimit = isCliKimiCodeSubscriptionRetry(props.payload);
   const isApiSwitchable = isCliApiSwitchableRetry(props.payload);
   const personalApiKeyAvailable = props.payload.personalApiKeyAvailable;
   const canSwitchToPersonalKey =
     isApiSwitchable && personalApiKeyAvailable === true;
   // Both switches flip the api-mode to personal keys so the retry uses the
-  // user's own key (not the relay JWT); the subscription switch additionally
-  // turns off the "prefer ChatGPT subscription" preference.
+  // user's own key (not the relay JWT); the subscription switches additionally
+  // turn off the "prefer ChatGPT subscription" / "Prefer Kimi Code" preference.
   const switchDecision: ApprovalDecision = isSubscriptionLimit
     ? { accepted: true, disableChatGptSubscription: true, apiMode: 'personal' }
-    : { accepted: true, apiMode: 'personal' };
+    : isKimiCodeLimit
+      ? { accepted: true, disableKimiCode: true, apiMode: 'personal' }
+      : { accepted: true, apiMode: 'personal' };
   let guidanceText: string | undefined;
   if (isApiSwitchable && personalApiKeyAvailable !== true) {
     const requestedProvider = props.payload.errorDetails?.provider;

--- a/packages/cli/src/chat/tui/modals/RetryRequest.tsx
+++ b/packages/cli/src/chat/tui/modals/RetryRequest.tsx
@@ -56,11 +56,22 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
   // Both switches flip the api-mode to personal keys so the retry uses the
   // user's own key (not the relay JWT); the subscription switches additionally
   // turn off the "prefer ChatGPT subscription" / "Prefer Kimi Code" preference.
-  const switchDecision: ApprovalDecision = isSubscriptionLimit
-    ? { accepted: true, disableChatGptSubscription: true, apiMode: 'personal' }
-    : isKimiCodeLimit
-      ? { accepted: true, disableKimiCode: true, apiMode: 'personal' }
-      : { accepted: true, apiMode: 'personal' };
+  let switchDecision: ApprovalDecision;
+  if (isSubscriptionLimit) {
+    switchDecision = {
+      accepted: true,
+      disableChatGptSubscription: true,
+      apiMode: 'personal',
+    };
+  } else if (isKimiCodeLimit) {
+    switchDecision = {
+      accepted: true,
+      disableKimiCode: true,
+      apiMode: 'personal',
+    };
+  } else {
+    switchDecision = { accepted: true, apiMode: 'personal' };
+  }
   let guidanceText: string | undefined;
   if (isApiSwitchable && personalApiKeyAvailable !== true) {
     const requestedProvider = props.payload.errorDetails?.provider;

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -66,6 +66,9 @@ export interface ApprovalDecision extends Readonly<SharedApprovalDecision> {
   /** Turn off the "prefer ChatGPT subscription" preference before accepting,
    *  so a Codex usage-limit retry routes through the OpenAI API key. */
   readonly disableChatGptSubscription?: boolean;
+  /** Turn off the "Prefer Kimi Code" preference before accepting, so a Kimi
+   *  Code usage-limit retry routes through the Moonshot open-platform API key. */
+  readonly disableKimiCode?: boolean;
   /** Plan-only approval action when plain approve/reject is not specific enough. */
   readonly planAction?: Extract<PlanApprovalAction, 'approve_and_goal'>;
 }

--- a/packages/cli/src/chat/tui/state/codexSubscription.ts
+++ b/packages/cli/src/chat/tui/state/codexSubscription.ts
@@ -3,6 +3,7 @@ import {
   setPreferCodexSubscription,
   type CodexSubscriptionPreferenceUpdate,
 } from '@model/codex/codexPreference';
+import { setPreferKimiCode } from '@utils/config/providerConfig';
 
 import { bumpCodexPreferenceVersion } from './cliState';
 
@@ -28,4 +29,14 @@ export async function setCliCodexSubscription(
   const update = await setPreferCodexSubscription(enabled);
   refreshSubscriptionPreferenceViews();
   return update;
+}
+
+/**
+ * Flip the "Prefer Kimi Code" preference and refresh the TUI views. Shared by
+ * the retry "switch to your own Moonshot API key" path so the
+ * persist-then-refresh sequence lives in one place.
+ */
+export async function setCliKimiCode(enabled: boolean): Promise<void> {
+  await setPreferKimiCode(enabled);
+  refreshSubscriptionPreferenceViews();
 }

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -55,6 +55,7 @@ import {
   isApiProvider,
 } from '@model/apiProviders';
 import { isPreferCodexSubscription } from '@model/codex/codexPreference';
+import { getPreferKimiCode } from '@utils/config/providerConfig';
 import { platform } from '@platform/platform';
 import type { ApprovalBypassKind } from '@shared/approvalBypassKind';
 import {
@@ -79,7 +80,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { notify } from '../notifications/terminalNotifier';
 import { patchSessionMeta, patchStream } from './cliState';
-import { setCliCodexSubscription } from './codexSubscription';
+import { setCliCodexSubscription, setCliKimiCode } from './codexSubscription';
 import {
   approveQueuedDelegatedWorkForStream,
   approvalPayloadStreamId,
@@ -591,8 +592,10 @@ async function switchRetryToPersonalCredentials(
         const previousApiMode = getCliApiMode();
         const previousOpenRouter = cliOpenRouterEnabled();
         const previousSubscriptionPreference = isPreferCodexSubscription();
+        const previousKimiCodePreference = getPreferKimiCode();
         let apiModeWriteStarted = false;
         let subscriptionWriteStarted = false;
+        let kimiCodeWriteStarted = false;
         try {
           if (decision.apiMode) {
             const apiMode = decision.apiMode;
@@ -611,6 +614,11 @@ async function switchRetryToPersonalCredentials(
                 'ChatGPT subscription remains enabled by a more specific setting.',
               );
             }
+            signal.throwIfAborted();
+          }
+          if (decision.disableKimiCode) {
+            kimiCodeWriteStarted = true;
+            await runRetryTask(() => setCliKimiCode(false), signal);
             signal.throwIfAborted();
           }
           if (decision.apiMode) patchSessionMeta({ apiMode: decision.apiMode });
@@ -641,6 +649,25 @@ async function switchRetryToPersonalCredentials(
                     'The previous ChatGPT subscription preference appears restored in memory, but persistence could not be confirmed',
                   restoreFailedContext:
                     'Could not restore the ChatGPT subscription preference',
+                })
+              : undefined;
+          const kimiCodeFailure =
+            kimiCodeWriteStarted && !getPreferKimiCode()
+              ? await attemptRollback({
+                  restore: async () => {
+                    await setCliKimiCode(previousKimiCodePreference);
+                    if (getPreferKimiCode() !== previousKimiCodePreference) {
+                      throw new Error(
+                        `Kimi Code preference remained ${String(getPreferKimiCode())}.`,
+                      );
+                    }
+                  },
+                  restoredInMemory: () =>
+                    getPreferKimiCode() === previousKimiCodePreference,
+                  memoryRestoredContext:
+                    'The previous Kimi Code preference appears restored in memory, but persistence could not be confirmed',
+                  restoreFailedContext:
+                    'Could not restore the Kimi Code preference',
                 })
               : undefined;
           const apiModeFailure =
@@ -681,6 +708,7 @@ async function switchRetryToPersonalCredentials(
               : undefined;
           const rollbackFailures = [
             subscriptionFailure,
+            kimiCodeFailure,
             apiModeFailure,
             openRouterFailure,
           ].filter(filterNotNullish);

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -55,7 +55,6 @@ import {
   isApiProvider,
 } from '@model/apiProviders';
 import { isPreferCodexSubscription } from '@model/codex/codexPreference';
-import { getPreferKimiCode } from '@utils/config/providerConfig';
 import { platform } from '@platform/platform';
 import type { ApprovalBypassKind } from '@shared/approvalBypassKind';
 import {
@@ -76,6 +75,7 @@ import {
 } from '@tools/approval/bashApproval';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
 import { filterNotNullish } from '@utils/core';
+import { getPreferKimiCode } from '@utils/config/providerConfig';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { notify } from '../notifications/terminalNotifier';

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -36,6 +36,7 @@ import {
 import {
   isCliApiSwitchableRetry,
   isCliChatGptSubscriptionRetry,
+  isCliKimiCodeSubscriptionRetry,
 } from '@cli/runtime/approval/approvalPrompts';
 import {
   denyExternalInquiryIfNoHumanInput,
@@ -111,6 +112,7 @@ function maybeAutoSwitchRetry(
 ): ApprovalDecision | undefined {
   if (!isCliApiSwitchableRetry(payload)) return undefined;
   if (isCliChatGptSubscriptionRetry(payload)) return undefined;
+  if (isCliKimiCodeSubscriptionRetry(payload)) return undefined;
 
   const details = payload.errorDetails;
   // Upstream credit depletion means the stored direct key IS the broken

--- a/packages/cli/src/runtime/approval/approvalPrompts.ts
+++ b/packages/cli/src/runtime/approval/approvalPrompts.ts
@@ -5,6 +5,7 @@ import { isRelayMonthlyLimitMessage } from '@common/errors/sdkErrorUtils';
 import {
   isChatGptSubscriptionLimitError,
   isCredentialExhausted,
+  isKimiCodeSubscriptionLimitError,
   type AgentProposalPermission,
   type ExhaustionReason,
   type PlanApprovalPermission,
@@ -39,6 +40,9 @@ export const CLI_PERSONAL_API_RETRY_HINT =
 
 export const CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT =
   'Use `/api personal` in the chat TUI, or press `k` on the retry prompt, to switch from your ChatGPT subscription to your own API keys.';
+
+export const CLI_KIMI_CODE_SUBSCRIPTION_RETRY_HINT =
+  'Use `/api personal` in the chat TUI, or press `k` on the retry prompt, to switch from your Kimi Code subscription to your own Moonshot API keys.';
 
 export interface CliApprovalPromptHooks {
   readonly beforePrompt?: () => void;
@@ -75,10 +79,19 @@ export function isCliChatGptSubscriptionRetry(
   return isChatGptSubscriptionLimitError(payload.errorDetails);
 }
 
+/** Whether the failed retry was a Kimi Code subscription usage limit, so the
+ *  switch turns off the "Prefer Kimi Code" preference rather than relay access. */
+export function isCliKimiCodeSubscriptionRetry(
+  payload: RetryPermission,
+): boolean {
+  return isKimiCodeSubscriptionLimitError(payload.errorDetails);
+}
+
 export function isCliApiSwitchableRetry(payload: RetryPermission): boolean {
   const details = payload.errorDetails;
   if (!details) return false;
   if (isChatGptSubscriptionLimitError(details)) return true;
+  if (isKimiCodeSubscriptionLimitError(details)) return true;
   return (
     isCredentialExhausted(details) &&
     (details.isRelayError === true ||

--- a/packages/cli/src/runtime/approval/approvalSummaries.ts
+++ b/packages/cli/src/runtime/approval/approvalSummaries.ts
@@ -14,9 +14,11 @@ import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
 import {
   CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT,
+  CLI_KIMI_CODE_SUBSCRIPTION_RETRY_HINT,
   CLI_PERSONAL_API_RETRY_HINT,
   isCliApiSwitchableRetry,
   isCliChatGptSubscriptionRetry,
+  isCliKimiCodeSubscriptionRetry,
 } from './approvalPrompts';
 
 const TRUNCATED_DIFF_LINE_MARKER = ' … [line truncated]';
@@ -130,6 +132,9 @@ export function formatRetryRequestMessage(payload: RetryPermission): string {
   const message = `Retry requested (${payload.operation}): ${payload.errorMessage ?? 'unknown error'}`;
   if (isCliChatGptSubscriptionRetry(payload)) {
     return [message, CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT].join('\n');
+  }
+  if (isCliKimiCodeSubscriptionRetry(payload)) {
+    return [message, CLI_KIMI_CODE_SUBSCRIPTION_RETRY_HINT].join('\n');
   }
   if (isCliApiSwitchableRetry(payload)) {
     return [message, CLI_PERSONAL_API_RETRY_HINT].join('\n');

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -100,6 +100,10 @@ import { cleanupUnscopedApprovals } from '@tools/approval';
 import { startRecording, stopRecordingAndTranscribe } from '@tools/media/audio';
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import {
+  getPreferKimiCode,
+  setPreferKimiCode,
+} from '@utils/config/providerConfig';
 
 import {
   postDesktopSettingsView,
@@ -506,6 +510,10 @@ export class DesktopProgressBridge {
       getPreferChatGptSubscription: isPreferCodexSubscription,
       setPreferChatGptSubscription: async (enabled) => {
         await setPreferCodexSubscription(enabled);
+      },
+      getPreferKimiCode,
+      setPreferKimiCode: async (enabled) => {
+        await setPreferKimiCode(enabled);
       },
       invalidateModelOptionsCache,
       isRetryPending: (stream, requestId) =>

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -51,7 +51,11 @@ import {
   releaseStreamResources,
 } from '@tools/approval';
 import { AbsoluteFS, pathToLocation, WorkspaceFS } from '@utils/files';
-import { getUseOpenRouter } from '@utils/config/providerConfig';
+import {
+  getPreferKimiCode,
+  getUseOpenRouter,
+  setPreferKimiCode,
+} from '@utils/config/providerConfig';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import type { ProgressViewProvider } from './ProgressViewProvider';
@@ -595,6 +599,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       getPreferChatGptSubscription: isPreferCodexSubscription,
       setPreferChatGptSubscription: async (enabled) => {
         await setPreferCodexSubscription(enabled);
+      },
+      getPreferKimiCode,
+      setPreferKimiCode: async (enabled) => {
+        await setPreferKimiCode(enabled);
       },
       invalidateModelOptionsCache,
       isRetryPending: (stream, requestId) =>

--- a/src/common/errors/sdkError/kimiCodeSubscriptionDetection.ts
+++ b/src/common/errors/sdkError/kimiCodeSubscriptionDetection.ts
@@ -1,0 +1,90 @@
+import { KIMI_CODE_BASE_URL } from '@model/kimiCodeSubscriptionRouting';
+
+import { errorBodyCandidates, pickStringField } from './errorInspection';
+
+/**
+ * Detection + formatting for the Kimi Code (Moonshot coding-subscription)
+ * usage limit. When a user drives Kimi-subscription-eligible models through
+ * their Kimi Code membership (the `api.kimi.com/coding/v1` coding endpoint),
+ * the backend rejects requests once the membership's usage quota is exhausted
+ * with a distinctive message:
+ *
+ *   "You've reached your usage limit for this billing cycle. Your quota will
+ *    be refreshed in the next cycle. To continue now, purchase extra usage or
+ *    upgrade your plan: https://www.kimi.com/code/#pricing"
+ *
+ * The "usage limit for this billing cycle" / "quota will be refreshed in the
+ * next cycle" phrasing is unique to the Kimi Code membership backend, so
+ * matching it reliably identifies a subscription request whose quota ran out —
+ * the signal that lets the retry UI offer "switch to your own API key"
+ * (parallel to the Codex `usage_limit_reached` affordance). The endpoint guard
+ * (`api.kimi.com/coding/v1`) keeps the Moonshot open platform from being
+ * misread as a subscription limit.
+ */
+export interface KimiCodeSubscriptionLimit {
+  readonly resetsInSeconds?: number;
+}
+
+/** The distinctive Kimi Code membership-exhaustion phrase. */
+const USAGE_LIMIT_PATTERN =
+  /usage limit for this billing cycle|quota will be refreshed in the next cycle/i;
+
+/** Whether the error's request targeted the Kimi Code coding endpoint. The
+ *  OpenAI SDK exposes the request config (with `baseURL`) directly on the
+ *  error, so this is a single field read — no cause-chain walk. */
+function isKimiCodeEndpointError(err: unknown): boolean {
+  const request = (err as { request?: { baseURL?: unknown } }).request;
+  return (
+    typeof request?.baseURL === 'string' &&
+    request.baseURL.includes(KIMI_CODE_BASE_URL)
+  );
+}
+
+/**
+ * Parse a Kimi Code usage-limit error, returning the reset details or `null`
+ * when the error is not a Kimi Code subscription usage-limit. Mirrors
+ * {@link parseChatGptSubscriptionLimit}: pure body inspection, no clock reads.
+ */
+export function parseKimiCodeSubscriptionLimit(
+  err: unknown,
+  rawErrorBody: unknown,
+): KimiCodeSubscriptionLimit | null {
+  if (!isKimiCodeEndpointError(err)) return null;
+
+  const message =
+    errorBodyCandidates(rawErrorBody)
+      .map((candidate) => pickStringField(candidate, 'message'))
+      .find((candidate) => candidate !== undefined) ??
+    (typeof (err as { message?: unknown }).message === 'string'
+      ? (err as { message: string }).message
+      : undefined);
+  if (!message || !USAGE_LIMIT_PATTERN.test(message)) return null;
+
+  const resetsInSeconds = errorBodyCandidates(rawErrorBody)
+    .map(
+      (candidate) => (candidate as Record<string, unknown>).resets_in_seconds,
+    )
+    .find(
+      (value): value is number =>
+        typeof value === 'number' && Number.isFinite(value),
+    );
+
+  return { resetsInSeconds };
+}
+
+/**
+ * Human-readable message for a Kimi Code usage-limit error: how long until the
+ * quota resets (when reported) and the actionable next step.
+ */
+export function describeKimiCodeSubscriptionLimit(
+  info: KimiCodeSubscriptionLimit,
+): string {
+  const reset =
+    info.resetsInSeconds !== undefined
+      ? ` Resets in ${Math.max(0, Math.floor(info.resetsInSeconds / 60))} minutes.`
+      : '';
+  return (
+    `Kimi Code subscription usage limit reached.${reset}` +
+    ' Switch to your own Moonshot API key to keep working, or wait until the limit resets.'
+  );
+}

--- a/src/common/errors/sdkError/kimiCodeSubscriptionDetection.ts
+++ b/src/common/errors/sdkError/kimiCodeSubscriptionDetection.ts
@@ -1,6 +1,11 @@
-import { KIMI_CODE_BASE_URL } from '@model/kimiCodeSubscriptionRouting';
+import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
+import { isObject } from '@utils/core';
 
-import { errorBodyCandidates, pickStringField } from './errorInspection';
+import {
+  errorBodyCandidates,
+  pickNumberField,
+  pickStringField,
+} from './errorInspection';
 
 /**
  * Detection + formatting for the Kimi Code (Moonshot coding-subscription)
@@ -33,6 +38,7 @@ const USAGE_LIMIT_PATTERN =
  *  OpenAI SDK exposes the request config (with `baseURL`) directly on the
  *  error, so this is a single field read — no cause-chain walk. */
 function isKimiCodeEndpointError(err: unknown): boolean {
+  if (!isObject(err)) return false;
   const request = (err as { request?: { baseURL?: unknown } }).request;
   return (
     typeof request?.baseURL === 'string' &&
@@ -61,13 +67,8 @@ export function parseKimiCodeSubscriptionLimit(
   if (!message || !USAGE_LIMIT_PATTERN.test(message)) return null;
 
   const resetsInSeconds = errorBodyCandidates(rawErrorBody)
-    .map(
-      (candidate) => (candidate as Record<string, unknown>).resets_in_seconds,
-    )
-    .find(
-      (value): value is number =>
-        typeof value === 'number' && Number.isFinite(value),
-    );
+    .map((candidate) => pickNumberField(candidate, 'resets_in_seconds'))
+    .find((value): value is number => value !== undefined);
 
   return { resetsInSeconds };
 }

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -58,6 +58,10 @@ import {
   parseChatGptSubscriptionLimit,
 } from './chatgptSubscriptionDetection';
 import {
+  describeKimiCodeSubscriptionLimit,
+  parseKimiCodeSubscriptionLimit,
+} from './kimiCodeSubscriptionDetection';
+import {
   type SdkErrorEntry,
   SDK_ERRORS,
   SDK_ERRORS_BY_KIND,
@@ -255,6 +259,17 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   const chatgptSubscriptionMessage = chatgptSubscriptionLimit
     ? describeChatGptSubscriptionLimit(chatgptSubscriptionLimit)
     : undefined;
+  // Kimi Code (Moonshot coding-subscription) quota exhaustion — same pattern:
+  // a credential exhaustion that disables the "Prefer Kimi Code" preference on
+  // accept so dual-backend Kimi models re-route through the Moonshot API key.
+  const kimiCodeSubscriptionLimit = parseKimiCodeSubscriptionLimit(
+    err,
+    rawErrorBody,
+  );
+  const isKimiCodeSubscriptionLimited = kimiCodeSubscriptionLimit !== null;
+  const kimiCodeSubscriptionMessage = kimiCodeSubscriptionLimit
+    ? describeKimiCodeSubscriptionLimit(kimiCodeSubscriptionLimit)
+    : undefined;
   // Priority mirrors the pre-refactor OR order: ChatGPT-subscription and
   // upstream-credit are independently detected first; relay monthly limit
   // (by body or message) is the remaining exhaustion condition. Explicit SDK
@@ -263,6 +278,8 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   if (exhaustionReason === undefined) {
     if (isChatGptSubscriptionLimited) {
       exhaustionReason = 'chatgpt-subscription';
+    } else if (isKimiCodeSubscriptionLimited) {
+      exhaustionReason = 'kimi-code-subscription';
     } else if (isUpstreamCreditDepleted) {
       exhaustionReason = 'upstream-credit';
     } else if (
@@ -343,7 +360,10 @@ export function formatProviderHttpError(err: unknown): ProviderError {
       ...classification,
       // Prefer the actionable subscription-limit message over the raw
       // `HTTP 429 – The usage limit has been reached`.
-      message: chatgptSubscriptionMessage ?? sdkMatch.message,
+      message:
+        chatgptSubscriptionMessage ??
+        kimiCodeSubscriptionMessage ??
+        sdkMatch.message,
       // Credential-exhausted errors keep userRetryable=true so the retry
       // panel surfaces with the "Use your own API key" affordance, but
       // shouldAutoRetry separately suppresses auto-retry for them — a
@@ -372,7 +392,8 @@ export function formatProviderHttpError(err: unknown): ProviderError {
 
   return {
     ...classification,
-    message: chatgptSubscriptionMessage ?? message,
+    message:
+      chatgptSubscriptionMessage ?? kimiCodeSubscriptionMessage ?? message,
     statusCode,
     statusText,
     provider,

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -61,3 +61,8 @@ export {
   parseChatGptSubscriptionLimit,
   describeChatGptSubscriptionLimit,
 } from './sdkError/chatgptSubscriptionDetection';
+
+export {
+  parseKimiCodeSubscriptionLimit,
+  describeKimiCodeSubscriptionLimit,
+} from './sdkError/kimiCodeSubscriptionDetection';

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -18,6 +18,7 @@ interface ProgressApiKeyPreparationResult {
   proceeded: boolean;
   disabledIncludedModelAccess: boolean;
   disabledChatGptSubscription: boolean;
+  disabledKimiCodeSubscription: boolean;
 }
 
 export interface ProgressApiKeyRetryResult extends ProgressApiKeyPreparationResult {
@@ -27,6 +28,7 @@ export interface ProgressApiKeyRetryResult extends ProgressApiKeyPreparationResu
 interface ProgressApiRoutingSnapshot {
   readonly useIncludedModelAccess: boolean;
   readonly preferChatGptSubscription: boolean;
+  readonly preferKimiCode: boolean;
 }
 
 function noRetryResult(): ProgressApiKeyRetryResult {
@@ -35,6 +37,7 @@ function noRetryResult(): ProgressApiKeyRetryResult {
     retried: false,
     disabledIncludedModelAccess: false,
     disabledChatGptSubscription: false,
+    disabledKimiCodeSubscription: false,
   };
 }
 
@@ -47,6 +50,8 @@ export interface ProgressApiKeyRetryControllerDeps {
   setUseIncludedModelAccess(enabled: boolean): Promise<void>;
   getPreferChatGptSubscription(): boolean;
   setPreferChatGptSubscription(enabled: boolean): Promise<void>;
+  getPreferKimiCode(): boolean;
+  setPreferKimiCode(enabled: boolean): Promise<void>;
   invalidateModelOptionsCache(): void;
   isRetryPending(stream: StreamTabId, requestId: string): boolean;
   triggerRetry(stream: StreamTabId, requestId: string): boolean;
@@ -122,7 +127,8 @@ export class ProgressApiKeyRetryController {
     return (
       request.viaRelay === true ||
       request.exhaustionReason === 'chatgpt-subscription' ||
-      request.exhaustionReason === 'copilot-subscription'
+      request.exhaustionReason === 'copilot-subscription' ||
+      request.exhaustionReason === 'kimi-code-subscription'
     );
   }
 
@@ -134,6 +140,12 @@ export class ProgressApiKeyRetryController {
       request.exhaustionReason === 'copilot-subscription' &&
       request.chatGptSubscriptionEligible === true
     );
+  }
+
+  private isKimiCodeSubscriptionExhausted(
+    request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
+  ): boolean {
+    return request.exhaustionReason === 'kimi-code-subscription';
   }
 
   private async applyOwnApiKeyRouting(
@@ -165,10 +177,25 @@ export class ProgressApiKeyRetryController {
       disabledChatGptSubscription = true;
     }
 
+    // Kimi Code quota exhausted: turn off "Prefer Kimi Code" so dual-backend
+    // Kimi models (e.g. `kimi3`) re-route through the Moonshot open-platform
+    // API key on retry. Exclusive Kimi Code models have no open-platform route
+    // and cannot fall back this way.
+    let disabledKimiCodeSubscription = false;
+    if (
+      this.deps.getPreferKimiCode() &&
+      this.isKimiCodeSubscriptionExhausted(request)
+    ) {
+      await this.deps.setPreferKimiCode(false);
+      this.deps.invalidateModelOptionsCache();
+      disabledKimiCodeSubscription = true;
+    }
+
     return {
       proceeded: true,
       disabledIncludedModelAccess,
       disabledChatGptSubscription,
+      disabledKimiCodeSubscription,
     };
   }
 
@@ -195,6 +222,7 @@ export class ProgressApiKeyRetryController {
     return {
       useIncludedModelAccess: this.deps.getUseIncludedModelAccess(),
       preferChatGptSubscription: this.deps.getPreferChatGptSubscription(),
+      preferKimiCode: this.deps.getPreferKimiCode(),
     };
   }
 
@@ -214,6 +242,9 @@ export class ProgressApiKeyRetryController {
           before.preferChatGptSubscription,
         ),
       );
+    }
+    if (prepared.disabledKimiCodeSubscription) {
+      restores.push(this.deps.setPreferKimiCode(before.preferKimiCode));
     }
     await Promise.all(restores);
     if (restores.length > 0) this.deps.invalidateModelOptionsCache();

--- a/src/model/kimiCodeSubscriptionRouting.ts
+++ b/src/model/kimiCodeSubscriptionRouting.ts
@@ -20,10 +20,9 @@
 
 import { ModelProvider, type ModelConfig } from 'llm-zoo';
 
-import { zeroCostAccessOverrides } from './subscriptionAccessOverrides';
+import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
 
-/** OpenAI-compatible base URL for the Kimi Code coding endpoint. */
-export const KIMI_CODE_BASE_URL = 'https://api.kimi.com/coding/v1';
+import { zeroCostAccessOverrides } from './subscriptionAccessOverrides';
 
 /**
  * Open-platform `fullName` → coding-endpoint wire ID. Exclusive plan aliases

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -5,6 +5,11 @@ import { ModelProvider } from 'llm-zoo';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { INCLUDED_ACCESS } from '@shared/copy/modelAccess';
 
+/** OpenAI-compatible base URL for the Kimi Code (Moonshot coding-subscription)
+ *  coding endpoint. Lives here (shared) so both the model routing layer and the
+ *  error-detection layer can reference it without a `common → model` edge. */
+export const KIMI_CODE_BASE_URL = 'https://api.kimi.com/coding/v1';
+
 // ============================================================================
 // Provider Registry — single source of truth for all provider metadata
 // ============================================================================

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -43,6 +43,11 @@ export const ExhaustionReasonSchema = z.enum([
   /** A GitHub Copilot request was rejected because the subscription quota is
    *  exhausted. */
   'copilot-subscription',
+  /** A Kimi Code (Moonshot coding-subscription) request was rejected because
+   *  the membership's usage quota is exhausted; accepting the switch disables
+   *  the "Prefer Kimi Code" preference so dual-backend Kimi models re-route
+   *  through the Moonshot open-platform API key. */
+  'kimi-code-subscription',
 ]);
 export type ExhaustionReason = z.infer<typeof ExhaustionReasonSchema>;
 
@@ -190,6 +195,17 @@ export function isChatGptSubscriptionLimitError(
   errorDetails: Pick<ProviderError, 'exhaustionReason'> | undefined | null,
 ): boolean {
   return errorDetails?.exhaustionReason === 'chatgpt-subscription';
+}
+
+/** Single source of truth for "this error is a Kimi Code (Moonshot
+ *  coding-subscription) usage-limit rejection". Both hosts (VS Code progress
+ *  view, CLI approval policy) branch on this to switch the retry from the
+ *  relay/personal-key path to disabling the "Prefer Kimi Code" preference so
+ *  dual-backend Kimi models re-route through the Moonshot open-platform key. */
+export function isKimiCodeSubscriptionLimitError(
+  errorDetails: Pick<ProviderError, 'exhaustionReason'> | undefined | null,
+): boolean {
+  return errorDetails?.exhaustionReason === 'kimi-code-subscription';
 }
 
 /** Single source of truth for "the upstream provider account itself is out of

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIClientDiagnostics.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIClientDiagnostics.vitest.ts
@@ -12,7 +12,7 @@ import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpen
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import * as serverKeysModule from '@auth/serverKeys';
 import { installTexraModelAccess } from '@controllers/modelAccess/installTexraModelAccess';
-import { KIMI_CODE_BASE_URL } from '@model/kimiCodeSubscriptionRouting';
+import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 const MOONSHOT_BASE_URL = 'https://api.moonshot.ai/v1';

--- a/src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts
@@ -11,7 +11,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { ModelHandlerGLM } from '@agent/modelHandlers/openai/modelHandlerGLM';
 import { ModelHandlerKimi } from '@agent/modelHandlers/openai/modelHandlerKimi';
 import { ModelHandlerXAI } from '@agent/modelHandlers/openai/modelHandlerXAI';
-import { KIMI_CODE_BASE_URL } from '@model/kimiCodeSubscriptionRouting';
+import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -667,4 +667,21 @@ describe('formatRetryRequestMessage', () => {
       '/api personal',
     );
   });
+
+  it('shows the Moonshot API-key switch for a Kimi Code subscription limit', () => {
+    const retry: RetryPermission = {
+      ...credentialExhaustedRetry,
+      errorDetails: {
+        exhaustionReason: 'kimi-code-subscription',
+        isRelayError: false,
+        statusCode: 429,
+      },
+    };
+
+    expect(isCliApiSwitchableRetry(retry)).toBe(true);
+    expect(formatRetryRequestMessage(retry)).toContain(
+      'Kimi Code subscription',
+    );
+    expect(formatRetryRequestMessage(retry)).toContain('Moonshot API keys');
+  });
 });

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -17,12 +17,15 @@ const mocks = vi.hoisted(() => ({
   hasUsableApiKey: vi.fn(),
   invalidateApiKeyCache: vi.fn(),
   preferSubscription: true,
+  preferKimiCode: false,
   notify: vi.fn(),
   openRouter: false,
   retryCopyFailure: undefined as Error | undefined,
   secrets: {},
   setCliApiMode: vi.fn(),
   setCliCodexSubscription: vi.fn(),
+  setCliKimiCode: vi.fn(),
+  setPreferKimiCode: vi.fn(),
   updateGlobalState: vi.fn(),
 }));
 
@@ -61,7 +64,18 @@ vi.mock('@cli/runtime/apiAccessMode', async (importActual) => {
 
 vi.mock('@cli/chat/tui/state/codexSubscription', () => ({
   setCliCodexSubscription: mocks.setCliCodexSubscription,
+  setCliKimiCode: mocks.setCliKimiCode,
 }));
+
+vi.mock('@utils/config/providerConfig', async (importActual) => {
+  const actual =
+    await importActual<typeof import('@utils/config/providerConfig')>();
+  return {
+    ...actual,
+    getPreferKimiCode: () => mocks.preferKimiCode,
+    setPreferKimiCode: mocks.setPreferKimiCode,
+  };
+});
 
 vi.mock('@model/apiProviders', async (importActual) => {
   const actual = await importActual<typeof import('@model/apiProviders')>();

--- a/src/test-kernel/common/KimiCodeSubscriptionDetection.vitest.ts
+++ b/src/test-kernel/common/KimiCodeSubscriptionDetection.vitest.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  describeKimiCodeSubscriptionLimit,
+  formatProviderHttpError,
+  parseKimiCodeSubscriptionLimit,
+} from '@common/errors/sdkErrorUtils';
+import { KIMI_CODE_BASE_URL } from '@model/kimiCodeSubscriptionRouting';
+
+const USAGE_LIMIT_MESSAGE =
+  "You've reached your usage limit for this billing cycle. Your quota will be refreshed in the next cycle. To continue now, purchase extra usage or upgrade your plan: https://www.kimi.com/code/#pricing";
+
+const USAGE_LIMIT_BODY = {
+  error: {
+    message: USAGE_LIMIT_MESSAGE,
+    type: 'invalid_request_error',
+    code: 'usage_limit_reached',
+  },
+} as const;
+
+/** Build an OpenAI-SDK-style error carrying the Kimi Code coding endpoint. */
+function kimiCodeError(
+  message: string,
+  body: unknown,
+  status = 403,
+  baseURL = KIMI_CODE_BASE_URL,
+): Error & {
+  status: number;
+  request: { baseURL: string };
+  error: unknown;
+  provider?: string;
+} {
+  const error = new Error(message) as Error & {
+    status: number;
+    request: { baseURL: string };
+    error: unknown;
+    provider?: string;
+  };
+  error.status = status;
+  error.request = { baseURL };
+  error.error = body;
+  return error;
+}
+
+describe('parseKimiCodeSubscriptionLimit', () => {
+  it('parses a Kimi Code usage-limit error on the coding endpoint', () => {
+    const limit = parseKimiCodeSubscriptionLimit(
+      kimiCodeError(USAGE_LIMIT_MESSAGE, USAGE_LIMIT_BODY),
+      USAGE_LIMIT_BODY,
+    );
+    expect(limit).not.toBeNull();
+  });
+
+  it('returns null when the error is not on the Kimi Code coding endpoint', () => {
+    const error = kimiCodeError(
+      USAGE_LIMIT_MESSAGE,
+      USAGE_LIMIT_BODY,
+      403,
+      'https://api.moonshot.cn/v1',
+    );
+    expect(parseKimiCodeSubscriptionLimit(error, USAGE_LIMIT_BODY)).toBeNull();
+  });
+
+  it('returns null when the body does not carry the distinctive usage-limit message', () => {
+    const rateLimitBody = {
+      error: { message: 'Rate limit reached, slow down', type: 'rate_limit' },
+    };
+    expect(
+      parseKimiCodeSubscriptionLimit(
+        kimiCodeError('Rate limit reached, slow down', rateLimitBody),
+        rateLimitBody,
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null for unrelated bodies', () => {
+    expect(
+      parseKimiCodeSubscriptionLimit(
+        kimiCodeError('nope', { message: 'nope' }),
+        { message: 'nope' },
+      ),
+    ).toBeNull();
+  });
+
+  it('formats a human-readable reset hint', () => {
+    const text = describeKimiCodeSubscriptionLimit({ resetsInSeconds: 3600 });
+    expect(text).toContain('Kimi Code subscription usage limit');
+    expect(text).toContain('Moonshot API key');
+  });
+});
+
+describe('formatProviderHttpError for Kimi Code subscription limits', () => {
+  it('classifies a Kimi Code usage-limit error as a switchable credential exhaustion', () => {
+    const error = kimiCodeError(USAGE_LIMIT_MESSAGE, USAGE_LIMIT_BODY);
+    error.provider = 'moonshot';
+
+    const providerError = formatProviderHttpError(error);
+
+    expect(providerError.exhaustionReason).toBe('kimi-code-subscription');
+    // The stored Moonshot key is NOT the broken credential, so no key change
+    // is forced (that reason is reserved for upstream credit depletion).
+    expect(providerError.userRetryable).toBe(true);
+    expect(providerError.message).toContain(
+      'Kimi Code subscription usage limit',
+    );
+  });
+
+  it('does not classify a Moonshot open-platform rate limit as Kimi Code exhaustion', () => {
+    const error = kimiCodeError(
+      'Rate limit reached',
+      { error: { message: 'Rate limit reached', type: 'rate_limit' } },
+      429,
+      'https://api.moonshot.cn/v1',
+    );
+    error.provider = 'moonshot';
+
+    const providerError = formatProviderHttpError(error);
+
+    expect(providerError.exhaustionReason).not.toBe('kimi-code-subscription');
+  });
+});

--- a/src/test-kernel/common/KimiCodeSubscriptionDetection.vitest.ts
+++ b/src/test-kernel/common/KimiCodeSubscriptionDetection.vitest.ts
@@ -5,7 +5,7 @@ import {
   formatProviderHttpError,
   parseKimiCodeSubscriptionLimit,
 } from '@common/errors/sdkErrorUtils';
-import { KIMI_CODE_BASE_URL } from '@model/kimiCodeSubscriptionRouting';
+import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
 
 const USAGE_LIMIT_MESSAGE =
   "You've reached your usage limit for this billing cycle. Your quota will be refreshed in the next cycle. To continue now, purchase extra usage or upgrade your plan: https://www.kimi.com/code/#pricing";

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -22,18 +22,21 @@ const IDLE_RESULT = {
   retried: false,
   disabledIncludedModelAccess: false,
   disabledChatGptSubscription: false,
+  disabledKimiCodeSubscription: false,
 };
 const RETRIED_WITH_OWN_KEY_RESULT = {
   proceeded: true,
   retried: true,
   disabledIncludedModelAccess: true,
   disabledChatGptSubscription: false,
+  disabledKimiCodeSubscription: false,
 };
 
 interface HarnessOptions {
   keys?: Partial<Record<ApiProvider, string | undefined>>;
   prompt?(keys: Map<ApiProvider, string | undefined>): void;
   preferChatGptSubscription?: boolean;
+  preferKimiCode?: boolean;
   retryAvailable?: boolean;
   retryPending?: boolean;
 }
@@ -44,6 +47,7 @@ function createHarness(options: HarnessOptions = {}): {
   prompts: Array<ApiProvider | undefined>;
   includedAccessValues: boolean[];
   chatGptSubscriptionValues: boolean[];
+  kimiCodeSubscriptionValues: boolean[];
   invalidations: number;
   retries: string[];
 } {
@@ -55,7 +59,9 @@ function createHarness(options: HarnessOptions = {}): {
   const prompts: Array<ApiProvider | undefined> = [];
   const includedAccessValues: boolean[] = [];
   const chatGptSubscriptionValues: boolean[] = [];
+  const kimiCodeSubscriptionValues: boolean[] = [];
   let preferChatGptSubscription = options.preferChatGptSubscription ?? true;
+  let preferKimiCode = options.preferKimiCode ?? true;
   let invalidations = 0;
   const retries: string[] = [];
 
@@ -64,6 +70,7 @@ function createHarness(options: HarnessOptions = {}): {
     prompts,
     includedAccessValues,
     chatGptSubscriptionValues,
+    kimiCodeSubscriptionValues,
     get invalidations() {
       return invalidations;
     },
@@ -85,6 +92,11 @@ function createHarness(options: HarnessOptions = {}): {
       setPreferChatGptSubscription: async (enabled) => {
         preferChatGptSubscription = enabled;
         chatGptSubscriptionValues.push(enabled);
+      },
+      getPreferKimiCode: () => preferKimiCode,
+      setPreferKimiCode: async (enabled) => {
+        preferKimiCode = enabled;
+        kimiCodeSubscriptionValues.push(enabled);
       },
       invalidateModelOptionsCache: () => {
         invalidations += 1;
@@ -282,6 +294,7 @@ describe('ProgressApiKeyRetryController', () => {
       retried: true,
       disabledIncludedModelAccess: true,
       disabledChatGptSubscription: true,
+      disabledKimiCodeSubscription: false,
     });
     // The subscription quota failed, not the key — a stored key is already
     // usable, so "Use your own API key" must not jump to the key-input prompt.
@@ -306,6 +319,53 @@ describe('ProgressApiKeyRetryController', () => {
     // No usable key exists, so the prompt is still shown (then declined here).
     assert.deepEqual(harness.prompts, ['openai']);
     assert.deepEqual(harness.chatGptSubscriptionValues, []);
+    assert.deepEqual(harness.retries, []);
+  });
+
+  it('disables the Kimi Code preference and retries with the existing Moonshot key, no prompt', async () => {
+    const harness = createHarness({
+      keys: { moonshot: 'stored-moonshot' },
+    });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-kimi',
+      requestId: 'retry-kimi',
+      provider: 'moonshot',
+      exhaustionReason: 'kimi-code-subscription',
+    });
+
+    // The Kimi Code switch also drops relay so the retry reaches the stored
+    // Moonshot key rather than the relay JWT.
+    assert.deepEqual(result, {
+      proceeded: true,
+      retried: true,
+      disabledIncludedModelAccess: true,
+      disabledChatGptSubscription: false,
+      disabledKimiCodeSubscription: true,
+    });
+    // The subscription quota failed, not the key — a stored key is already
+    // usable, so "Use your own API key" must not jump to the key-input prompt.
+    assert.deepEqual(harness.prompts, []);
+    assert.deepEqual(harness.includedAccessValues, [false]);
+    assert.deepEqual(harness.kimiCodeSubscriptionValues, [false]);
+    assert.equal(harness.invalidations, 2);
+    assert.deepEqual(harness.retries, ['stream-kimi']);
+  });
+
+  it('does not disable the Kimi Code preference when no usable Moonshot key is available', async () => {
+    const harness = createHarness({ keys: {} });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-kimi2',
+      requestId: 'retry-kimi2',
+      provider: 'moonshot',
+      exhaustionReason: 'kimi-code-subscription',
+    });
+
+    assert.deepEqual(result, IDLE_RESULT);
+    // No usable key exists, so the prompt is still shown (then declined here).
+    assert.deepEqual(harness.prompts, ['moonshot']);
+    assert.deepEqual(harness.kimiCodeSubscriptionValues, []);
     assert.deepEqual(harness.retries, []);
   });
 

--- a/src/test-kernel/model/KimiSubscriptionRouting.vitest.ts
+++ b/src/test-kernel/model/KimiSubscriptionRouting.vitest.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import { ModelProvider } from 'llm-zoo';
 
 // Local imports
-import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
 import {
   isKimiCodeExclusiveModel,
   isKimiSubscriptionEligible,
@@ -11,6 +10,7 @@ import {
   kimiCodeWireModelId,
   resolveKimiCodeRoute,
 } from '@model/kimiCodeSubscriptionRouting';
+import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
 import type { ModelConfig } from 'llm-zoo';
 
 const dual = {

--- a/src/test-kernel/model/KimiSubscriptionRouting.vitest.ts
+++ b/src/test-kernel/model/KimiSubscriptionRouting.vitest.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest';
 import { ModelProvider } from 'llm-zoo';
 
 // Local imports
+import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
 import {
-  KIMI_CODE_BASE_URL,
   isKimiCodeExclusiveModel,
   isKimiSubscriptionEligible,
   kimiCodeRuntimeConfig,


### PR DESCRIPTION
## Problem

When a Kimi Code membership's usage quota is exhausted, the coding endpoint (`api.kimi.com/coding/v1`) rejects requests with:

```
HTTP 403 Forbidden – 403 You've reached your usage limit for this billing cycle. Your quota will be refreshed in the next cycle. To continue now, purchase extra usage or upgrade your plan: https://www.kimi.com/code/#pricing
```

There was no way to fall back to the Kimi (Moonshot) open-platform API with your own key — the request just failed.

## Fix

Mirror the existing ChatGPT-subscription (Codex) fallback, which detects a usage-limit rejection and lets the retry UI switch to your own OpenAI API key. For Kimi Code:

- **Detection** (`kimiCodeSubscriptionDetection.ts` + `providerErrorFormat.ts`): a Kimi Code usage-limit error (coding endpoint + the distinctive "usage limit for this billing cycle" message) is classified as `exhaustionReason: 'kimi-code-subscription'` — a switchable credential exhaustion, so auto-retry is suppressed and the retry panel surfaces.
- **Retry controller** (`ProgressApiKeyRetryController.ts`): accepting "use your own API key" turns off **"Prefer Kimi Code"**, so dual-backend Kimi models (e.g. `kimi3`) re-route through the Moonshot open-platform API key. `ModelFactory`'s `resolveKimiCodeRoute` already handles that fallback.
- **CLI retry hints** (`approvalPrompts.ts`, `approvalSummaries.ts`, `subscribeApprovals.ts`): the retry prompt shows "switch to your own Moonshot API keys", and Kimi Code exhaustion (like ChatGPT) requires an explicit decision rather than auto-switching.
- **Wiring** (`ProgressViewMessageHandler.ts`, `desktopAgentExecution.ts`): supply the `getPreferKimiCode`/`setPreferKimiCode` deps.
- **Schema** (`errors.ts`): new `kimi-code-subscription` exhaustion reason + `isKimiCodeSubscriptionLimitError` helper.

## Verification

- New tests cover detection (against the real error message), classification, and the retry routing switch.
- 72 tests pass across the 5 relevant suites; root/extension/desktop/CLI typechecks and lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential routing, persisted preferences, and rollback paths across CLI, desktop, and extension retry controllers—not auth core, but wrong rollback could leave users on the wrong API route.
> 
> **Overview**
> Adds **Kimi Code membership quota exhaustion** handling parallel to ChatGPT/Codex: coding-endpoint errors with the billing-cycle usage message become `exhaustionReason: 'kimi-code-subscription'`, with user-facing copy and retry affordances.
> 
> **CLI & desktop/extension:** Retry flows can turn off **Prefer Kimi Code**, switch to personal API mode, and roll back on failure; auto-switch skips Kimi subscription limits so the user must confirm. `KIMI_CODE_BASE_URL` moves to shared constants for routing and detection.
> 
> **Progress view:** `ProgressApiKeyRetryController` disables Prefer Kimi Code when exhaustion is `kimi-code-subscription`, same pattern as ChatGPT subscription + included access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f93d1578a1f78fe9d5e0be29421cf6c5fa0e8ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->