### PR TITLE
feat(model): support GLM Coding Plan quota-exhaustion fallback

### DIFF
--- a/packages/cli/src/chat/tui/modals/RetryRequest.tsx
+++ b/packages/cli/src/chat/tui/modals/RetryRequest.tsx
@@ -3,7 +3,7 @@ import { Text, useWindowSize } from 'ink';
 import {
   isCliApiSwitchableRetry,
   isCliChatGptSubscriptionRetry,
-  isCliKimiCodeSubscriptionRetry,
+  isCliCodingPlanRetry,
 } from '@cli/runtime/approval/approvalPrompts';
 import { wrapAnsiToWidth } from '@cli/tui/ansiWrap';
 import { COLOR_HINT, COLOR_WARNING } from '@cli/tui/ui/colors';
@@ -48,14 +48,15 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
   const { columns } = useWindowSize();
   const errorText = props.payload.errorMessage ?? props.payload.operation;
   const isSubscriptionLimit = isCliChatGptSubscriptionRetry(props.payload);
-  const isKimiCodeLimit = isCliKimiCodeSubscriptionRetry(props.payload);
+  const isGlmCodingPlanLimit = isCliCodingPlanRetry(props.payload);
   const isApiSwitchable = isCliApiSwitchableRetry(props.payload);
   const personalApiKeyAvailable = props.payload.personalApiKeyAvailable;
   const canSwitchToPersonalKey =
     isApiSwitchable && personalApiKeyAvailable === true;
   // Both switches flip the api-mode to personal keys so the retry uses the
   // user's own key (not the relay JWT); the subscription switches additionally
-  // turn off the "prefer ChatGPT subscription" / "Prefer Kimi Code" preference.
+  // turn off the "prefer ChatGPT subscription" / coding-plan preference.
+  const exhaustionReason = props.payload.errorDetails?.exhaustionReason;
   let switchDecision: ApprovalDecision;
   if (isSubscriptionLimit) {
     switchDecision = {
@@ -63,7 +64,13 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
       disableChatGptSubscription: true,
       apiMode: 'personal',
     };
-  } else if (isKimiCodeLimit) {
+  } else if (exhaustionReason === 'glm-coding-plan') {
+    switchDecision = {
+      accepted: true,
+      disableGlmCodingPlan: true,
+      apiMode: 'personal',
+    };
+  } else if (isGlmCodingPlanLimit) {
     switchDecision = {
       accepted: true,
       disableKimiCode: true,

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -69,6 +69,9 @@ export interface ApprovalDecision extends Readonly<SharedApprovalDecision> {
   /** Turn off the "Prefer Kimi Code" preference before accepting, so a Kimi
    *  Code usage-limit retry routes through the Moonshot open-platform API key. */
   readonly disableKimiCode?: boolean;
+  /** Turn off the GLM Coding Plan toggle before accepting, so a GLM Coding
+   *  Plan usage-limit retry routes through the regular GLM endpoint. */
+  readonly disableGlmCodingPlan?: boolean;
   /** Plan-only approval action when plain approve/reject is not specific enough. */
   readonly planAction?: Extract<PlanApprovalAction, 'approve_and_goal'>;
 }

--- a/packages/cli/src/chat/tui/state/codexSubscription.ts
+++ b/packages/cli/src/chat/tui/state/codexSubscription.ts
@@ -3,7 +3,10 @@ import {
   setPreferCodexSubscription,
   type CodexSubscriptionPreferenceUpdate,
 } from '@model/codex/codexPreference';
-import { setGLMCodingPlan, setPreferKimiCode } from '@utils/config/providerConfig';
+import {
+  setGLMCodingPlan,
+  setPreferKimiCode,
+} from '@utils/config/providerConfig';
 
 import { bumpCodexPreferenceVersion } from './cliState';
 

--- a/packages/cli/src/chat/tui/state/codexSubscription.ts
+++ b/packages/cli/src/chat/tui/state/codexSubscription.ts
@@ -3,7 +3,7 @@ import {
   setPreferCodexSubscription,
   type CodexSubscriptionPreferenceUpdate,
 } from '@model/codex/codexPreference';
-import { setPreferKimiCode } from '@utils/config/providerConfig';
+import { setGLMCodingPlan, setPreferKimiCode } from '@utils/config/providerConfig';
 
 import { bumpCodexPreferenceVersion } from './cliState';
 
@@ -38,5 +38,15 @@ export async function setCliCodexSubscription(
  */
 export async function setCliKimiCode(enabled: boolean): Promise<void> {
   await setPreferKimiCode(enabled);
+  refreshSubscriptionPreferenceViews();
+}
+
+/**
+ * Flip the GLM Coding Plan toggle and refresh the TUI views. Shared by the
+ * retry "switch to the regular GLM endpoint" path so the persist-then-refresh
+ * sequence lives in one place.
+ */
+export async function setCliGlmCodingPlan(enabled: boolean): Promise<void> {
+  await setGLMCodingPlan(enabled);
   refreshSubscriptionPreferenceViews();
 }

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -75,7 +75,10 @@ import {
 } from '@tools/approval/bashApproval';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
 import { filterNotNullish } from '@utils/core';
-import { getGLMCodingPlan, getPreferKimiCode } from '@utils/config/providerConfig';
+import {
+  getGLMCodingPlan,
+  getPreferKimiCode,
+} from '@utils/config/providerConfig';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { notify } from '../notifications/terminalNotifier';

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -36,7 +36,7 @@ import {
 import {
   isCliApiSwitchableRetry,
   isCliChatGptSubscriptionRetry,
-  isCliKimiCodeSubscriptionRetry,
+  isCliCodingPlanRetry,
 } from '@cli/runtime/approval/approvalPrompts';
 import {
   denyExternalInquiryIfNoHumanInput,
@@ -75,12 +75,16 @@ import {
 } from '@tools/approval/bashApproval';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
 import { filterNotNullish } from '@utils/core';
-import { getPreferKimiCode } from '@utils/config/providerConfig';
+import { getGLMCodingPlan, getPreferKimiCode } from '@utils/config/providerConfig';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { notify } from '../notifications/terminalNotifier';
 import { patchSessionMeta, patchStream } from './cliState';
-import { setCliCodexSubscription, setCliKimiCode } from './codexSubscription';
+import {
+  setCliCodexSubscription,
+  setCliGlmCodingPlan,
+  setCliKimiCode,
+} from './codexSubscription';
 import {
   approveQueuedDelegatedWorkForStream,
   approvalPayloadStreamId,
@@ -113,7 +117,7 @@ function maybeAutoSwitchRetry(
 ): ApprovalDecision | undefined {
   if (!isCliApiSwitchableRetry(payload)) return undefined;
   if (isCliChatGptSubscriptionRetry(payload)) return undefined;
-  if (isCliKimiCodeSubscriptionRetry(payload)) return undefined;
+  if (isCliCodingPlanRetry(payload)) return undefined;
 
   const details = payload.errorDetails;
   // Upstream credit depletion means the stored direct key IS the broken
@@ -592,9 +596,11 @@ async function switchRetryToPersonalCredentials(
         const previousApiMode = getCliApiMode();
         const previousOpenRouter = cliOpenRouterEnabled();
         const previousSubscriptionPreference = isPreferCodexSubscription();
+        const previousGlmCodingPlan = getGLMCodingPlan();
         const previousKimiCodePreference = getPreferKimiCode();
         let apiModeWriteStarted = false;
         let subscriptionWriteStarted = false;
+        let glmCodingPlanWriteStarted = false;
         let kimiCodeWriteStarted = false;
         try {
           if (decision.apiMode) {
@@ -614,6 +620,11 @@ async function switchRetryToPersonalCredentials(
                 'ChatGPT subscription remains enabled by a more specific setting.',
               );
             }
+            signal.throwIfAborted();
+          }
+          if (decision.disableGlmCodingPlan) {
+            glmCodingPlanWriteStarted = true;
+            await runRetryTask(() => setCliGlmCodingPlan(false), signal);
             signal.throwIfAborted();
           }
           if (decision.disableKimiCode) {
@@ -649,6 +660,25 @@ async function switchRetryToPersonalCredentials(
                     'The previous ChatGPT subscription preference appears restored in memory, but persistence could not be confirmed',
                   restoreFailedContext:
                     'Could not restore the ChatGPT subscription preference',
+                })
+              : undefined;
+          const glmCodingPlanFailure =
+            glmCodingPlanWriteStarted && !getGLMCodingPlan()
+              ? await attemptRollback({
+                  restore: async () => {
+                    await setCliGlmCodingPlan(previousGlmCodingPlan);
+                    if (getGLMCodingPlan() !== previousGlmCodingPlan) {
+                      throw new Error(
+                        `GLM Coding Plan remained ${String(getGLMCodingPlan())}.`,
+                      );
+                    }
+                  },
+                  restoredInMemory: () =>
+                    getGLMCodingPlan() === previousGlmCodingPlan,
+                  memoryRestoredContext:
+                    'The previous GLM Coding Plan setting appears restored in memory, but persistence could not be confirmed',
+                  restoreFailedContext:
+                    'Could not restore the GLM Coding Plan setting',
                 })
               : undefined;
           const kimiCodeFailure =
@@ -708,6 +738,7 @@ async function switchRetryToPersonalCredentials(
               : undefined;
           const rollbackFailures = [
             subscriptionFailure,
+            glmCodingPlanFailure,
             kimiCodeFailure,
             apiModeFailure,
             openRouterFailure,

--- a/packages/cli/src/runtime/approval/approvalPrompts.ts
+++ b/packages/cli/src/runtime/approval/approvalPrompts.ts
@@ -5,7 +5,6 @@ import { isRelayMonthlyLimitMessage } from '@common/errors/sdkErrorUtils';
 import {
   isChatGptSubscriptionLimitError,
   isCredentialExhausted,
-  isKimiCodeSubscriptionLimitError,
   type AgentProposalPermission,
   type ExhaustionReason,
   type PlanApprovalPermission,
@@ -41,8 +40,22 @@ export const CLI_PERSONAL_API_RETRY_HINT =
 export const CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT =
   'Use `/api personal` in the chat TUI, or press `k` on the retry prompt, to switch from your ChatGPT subscription to your own API keys.';
 
-export const CLI_KIMI_CODE_SUBSCRIPTION_RETRY_HINT =
-  'Use `/api personal` in the chat TUI, or press `k` on the retry prompt, to switch from your Kimi Code subscription to your own Moonshot API keys.';
+/** Coding-plan exhaustion reasons whose retry hint names the regular endpoint. */
+const CODING_PLAN_RETRY_HINTS: Readonly<Record<string, string>> = {
+  'glm-coding-plan':
+    'Use `/api personal` in the chat TUI, or press `k` on the retry prompt, to switch from your GLM Coding Plan to the regular GLM endpoint.',
+  'kimi-code-subscription':
+    'Use `/api personal` in the chat TUI, or press `k` on the retry prompt, to switch from your Kimi Code subscription to your own Moonshot API keys.',
+};
+
+/** Retry hint for an API-key-based coding-plan exhaustion, or undefined. */
+export function codingPlanRetryHint(
+  exhaustionReason: ExhaustionReason | undefined,
+): string | undefined {
+  return exhaustionReason
+    ? CODING_PLAN_RETRY_HINTS[exhaustionReason]
+    : undefined;
+}
 
 export interface CliApprovalPromptHooks {
   readonly beforePrompt?: () => void;
@@ -79,19 +92,19 @@ export function isCliChatGptSubscriptionRetry(
   return isChatGptSubscriptionLimitError(payload.errorDetails);
 }
 
-/** Whether the failed retry was a Kimi Code subscription usage limit, so the
- *  switch turns off the "Prefer Kimi Code" preference rather than relay access. */
-export function isCliKimiCodeSubscriptionRetry(
-  payload: RetryPermission,
-): boolean {
-  return isKimiCodeSubscriptionLimitError(payload.errorDetails);
+/** Whether the failed retry was an API-key-based coding-plan usage limit (GLM
+ *  Coding Plan, Kimi Code), so the switch turns off the plan's toggle. */
+export function isCliCodingPlanRetry(payload: RetryPermission): boolean {
+  return (
+    codingPlanRetryHint(payload.errorDetails?.exhaustionReason) !== undefined
+  );
 }
 
 export function isCliApiSwitchableRetry(payload: RetryPermission): boolean {
   const details = payload.errorDetails;
   if (!details) return false;
   if (isChatGptSubscriptionLimitError(details)) return true;
-  if (isKimiCodeSubscriptionLimitError(details)) return true;
+  if (isCliCodingPlanRetry(payload)) return true;
   return (
     isCredentialExhausted(details) &&
     (details.isRelayError === true ||

--- a/packages/cli/src/runtime/approval/approvalSummaries.ts
+++ b/packages/cli/src/runtime/approval/approvalSummaries.ts
@@ -14,11 +14,11 @@ import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
 import {
   CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT,
-  CLI_KIMI_CODE_SUBSCRIPTION_RETRY_HINT,
   CLI_PERSONAL_API_RETRY_HINT,
+  codingPlanRetryHint,
   isCliApiSwitchableRetry,
   isCliChatGptSubscriptionRetry,
-  isCliKimiCodeSubscriptionRetry,
+  isCliCodingPlanRetry,
 } from './approvalPrompts';
 
 const TRUNCATED_DIFF_LINE_MARKER = ' … [line truncated]';
@@ -133,8 +133,11 @@ export function formatRetryRequestMessage(payload: RetryPermission): string {
   if (isCliChatGptSubscriptionRetry(payload)) {
     return [message, CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT].join('\n');
   }
-  if (isCliKimiCodeSubscriptionRetry(payload)) {
-    return [message, CLI_KIMI_CODE_SUBSCRIPTION_RETRY_HINT].join('\n');
+  const codingPlanHint = codingPlanRetryHint(
+    payload.errorDetails?.exhaustionReason,
+  );
+  if (codingPlanHint) {
+    return [message, codingPlanHint].join('\n');
   }
   if (isCliApiSwitchableRetry(payload)) {
     return [message, CLI_PERSONAL_API_RETRY_HINT].join('\n');

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -101,7 +101,9 @@ import { startRecording, stopRecordingAndTranscribe } from '@tools/media/audio';
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
+  getGLMCodingPlan,
   getPreferKimiCode,
+  setGLMCodingPlan,
   setPreferKimiCode,
 } from '@utils/config/providerConfig';
 
@@ -511,10 +513,22 @@ export class DesktopProgressBridge {
       setPreferChatGptSubscription: async (enabled) => {
         await setPreferCodexSubscription(enabled);
       },
-      getPreferKimiCode,
-      setPreferKimiCode: async (enabled) => {
-        await setPreferKimiCode(enabled);
-      },
+      codingPlanToggles: [
+        {
+          exhaustionReason: 'glm-coding-plan',
+          getEnabled: getGLMCodingPlan,
+          setEnabled: async (enabled) => {
+            await setGLMCodingPlan(enabled);
+          },
+        },
+        {
+          exhaustionReason: 'kimi-code-subscription',
+          getEnabled: getPreferKimiCode,
+          setEnabled: async (enabled) => {
+            await setPreferKimiCode(enabled);
+          },
+        },
+      ],
       invalidateModelOptionsCache,
       isRetryPending: (stream, requestId) =>
         this.hostInteractions.isRetryPending(stream, requestId),

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -52,8 +52,10 @@ import {
 } from '@tools/approval';
 import { AbsoluteFS, pathToLocation, WorkspaceFS } from '@utils/files';
 import {
+  getGLMCodingPlan,
   getPreferKimiCode,
   getUseOpenRouter,
+  setGLMCodingPlan,
   setPreferKimiCode,
 } from '@utils/config/providerConfig';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -600,10 +602,22 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       setPreferChatGptSubscription: async (enabled) => {
         await setPreferCodexSubscription(enabled);
       },
-      getPreferKimiCode,
-      setPreferKimiCode: async (enabled) => {
-        await setPreferKimiCode(enabled);
-      },
+      codingPlanToggles: [
+        {
+          exhaustionReason: 'glm-coding-plan',
+          getEnabled: getGLMCodingPlan,
+          setEnabled: async (enabled) => {
+            await setGLMCodingPlan(enabled);
+          },
+        },
+        {
+          exhaustionReason: 'kimi-code-subscription',
+          getEnabled: getPreferKimiCode,
+          setEnabled: async (enabled) => {
+            await setPreferKimiCode(enabled);
+          },
+        },
+      ],
       invalidateModelOptionsCache,
       isRetryPending: (stream, requestId) =>
         this.interactions.isRetryPending(stream, requestId),

--- a/packages/extension/src/settingsView/frontend/tabs/SubscriptionsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/SubscriptionsTab.ts
@@ -34,6 +34,47 @@ import {
 } from '../components/profile/SubscriptionSection';
 
 const KIMI_CODE_CONSOLE_URL = 'https://www.kimi.com/code/console';
+const GLM_CODING_PLAN_CONSOLE_URL = 'https://z.ai/subscribe';
+
+/** One API-key-based coding-plan subscription section (GLM Coding Plan, Kimi
+ *  Code). Both share the same three-step setup: get a key, add it, enable the
+ *  plan toggle. */
+interface CodingPlanSection {
+  readonly sectionId: string;
+  readonly title: string;
+  readonly description: string;
+  readonly consoleUrl: string;
+  readonly keyLabel: string;
+  readonly keyHelp: string;
+  readonly toggleLabel: string;
+  readonly toggleHelp: string;
+}
+
+const CODING_PLAN_SECTIONS: readonly CodingPlanSection[] = [
+  {
+    sectionId: 'glm-coding-plan-subscription',
+    title: 'GLM Coding Plan',
+    description:
+      'Use a GLM Coding Plan subscription for GLM models via the coding endpoint.',
+    consoleUrl: GLM_CODING_PLAN_CONSOLE_URL,
+    keyLabel: '1. Get a subscription key',
+    keyHelp: 'Subscribe and create an API key in the Z.AI console.',
+    toggleLabel: '3. Enable the Coding Plan',
+    toggleHelp:
+      'Turn on "GLM Coding Plan" on the GLM row so requests route through the coding endpoint with your plan\u2019s monthly quota.',
+  },
+  {
+    sectionId: 'kimi-code-subscription',
+    title: 'Kimi Code',
+    description: 'Use a Kimi Code membership for the kimi-for-coding models.',
+    consoleUrl: KIMI_CODE_CONSOLE_URL,
+    keyLabel: '1. Get a membership key',
+    keyHelp: 'Create an API key in the Kimi Code console.',
+    toggleLabel: '3. Optional: prefer Kimi Code',
+    toggleHelp:
+      'Enable "Prefer Kimi Code" on the same row so K3 also uses your Kimi Code subscription; the kimi-for-coding models always do.',
+  },
+];
 
 @customElement('subscriptions-tab')
 export class SubscriptionsTab extends LitElement {
@@ -76,27 +117,27 @@ export class SubscriptionsTab extends LitElement {
           .provider=${GROK_SUBSCRIPTION_SECTION}
           .auth=${this.grokAuth}
         ></subscription-section>
-        ${this.renderKimiCodeSection()} ${this.renderCopilotSection()}
+        ${CODING_PLAN_SECTIONS.map((section) =>
+          this.renderCodingPlanSection(section),
+        )}
+        ${this.renderCopilotSection()}
       </div>
     `;
   }
 
-  private renderKimiCodeSection(): TemplateResult {
+  private renderCodingPlanSection(section: CodingPlanSection): TemplateResult {
     return html`
-      <section id="kimi-code-subscription">
+      <section id=${section.sectionId}>
         ${renderSettingsSectionHeading({
-          title: 'Kimi Code',
-          description:
-            'Use a Kimi Code membership for the kimi-for-coding models.',
+          title: section.title,
+          description: section.description,
           icon: 'gem',
         })}
         <div class="settings-section">
           <div class="settings-row">
             <div class="settings-row-text">
-              <span class="settings-row-label">1. Get a membership key</span>
-              <span class="settings-row-help">
-                Create an API key in the Kimi Code console.
-              </span>
+              <span class="settings-row-label">${section.keyLabel}</span>
+              <span class="settings-row-help">${section.keyHelp}</span>
             </div>
             <div class="settings-row-control">
               ${renderLabeledActionButton({
@@ -106,7 +147,7 @@ export class SubscriptionsTab extends LitElement {
                 appearance: 'outlined',
                 onClick: () =>
                   postMessage(SETTINGS_VIEW_COMMANDS.OPEN_EXTERNAL_URL, {
-                    url: KIMI_CODE_CONSOLE_URL,
+                    url: section.consoleUrl,
                   }),
               })}
             </div>
@@ -115,8 +156,8 @@ export class SubscriptionsTab extends LitElement {
             <div class="settings-row-text">
               <span class="settings-row-label">2. Add the key</span>
               <span class="settings-row-help">
-                Paste it on the Kimi Code row in Providers &amp; Models, or set
-                the KIMI_CODE_API_KEY environment variable.
+                Paste it on the ${section.title} row in Providers &amp; Models,
+                or set the provider API key environment variable.
               </span>
             </div>
             <div class="settings-row-control">
@@ -134,13 +175,8 @@ export class SubscriptionsTab extends LitElement {
           </div>
           <div class="settings-row">
             <div class="settings-row-text">
-              <span class="settings-row-label"
-                >3. Optional: prefer Kimi Code</span
-              >
-              <span class="settings-row-help">
-                Enable "Prefer Kimi Code" on the same row so K3 also uses your
-                Kimi Code subscription; the kimi-for-coding models always do.
-              </span>
+              <span class="settings-row-label">${section.toggleLabel}</span>
+              <span class="settings-row-help">${section.toggleHelp}</span>
             </div>
           </div>
         </div>

--- a/src/common/errors/sdkError/glmCodingPlanDetection.ts
+++ b/src/common/errors/sdkError/glmCodingPlanDetection.ts
@@ -1,0 +1,113 @@
+import prettyMilliseconds from 'pretty-ms';
+
+import {
+  errorBodyCandidates,
+  pickNumberField,
+  pickStringField,
+} from './errorInspection';
+
+/**
+ * Detection + formatting for the GLM Coding Plan usage limit.
+ *
+ * When a user routes GLM models through their GLM Coding Plan (the
+ * `api.z.ai/api/coding/paas/v4` coding endpoint), the backend rejects requests
+ * once the plan's usage quota is exhausted with a distinctive business error
+ * code in the OpenAI-compatible envelope:
+ *
+ *   { "error": { "code": "1310", "message": "Weekly/Monthly Limit Exhausted..." } }
+ *
+ * The quota-exhaustion codes (1308–1321) are unique to the GLM
+ * Coding Plan backend — a regular GLM pay-as-you-go request reports rate limits
+ * as 1302/1305 instead — so matching the `code` field reliably identifies a
+ * coding-plan request whose quota ran out. That is the signal that lets the
+ * retry UI offer "switch to the regular GLM endpoint" (turn off the Coding Plan
+ * toggle so requests route through `/api/paas/v4` instead).
+ *
+ * The reset hint is derived from either a `resets_in_seconds` field or the
+ * absolute reset timestamp embedded in the message (e.g. "您的限额将在
+ * 2026-08-08 11:32:36 重置" — a UTC+8 China-time timestamp). The timestamp is
+ * parsed as UTC+8 and converted to seconds-until-reset.
+ */
+export interface GlmCodingPlanLimit {
+  /** Reset hint when the backend reports one (seconds until quota resets). */
+  readonly resetsInSeconds?: number;
+}
+
+/** GLM Coding Plan quota-exhaustion business error codes (all HTTP 429). */
+const GLM_CODING_PLAN_EXHAUSTION_CODES: ReadonlySet<string> = new Set([
+  '1308', // Usage limit reached for {number} {unit}
+  '1309', // GLM Coding Plan package expired
+  '1310', // Weekly/Monthly Limit Exhausted
+  '1316', // Usage limit reached for the past 5 hours
+  '1317', // Usage limit reached for the past 7 days
+  '1318', // Usage limit reached for the past 5 hours (monthly spend limit)
+  '1319', // Usage limit reached for the past 7 days (monthly spend limit)
+  '1320', // Usage limit reached for the past 5 hours (monthly spend limit)
+  '1321', // Usage limit reached for the past 7 days (monthly spend limit)
+]);
+
+/** UTC+8 (China Standard Time) offset in milliseconds. */
+const CST_OFFSET_MS = 8 * 60 * 60 * 1000;
+
+/** Match a `YYYY-MM-DD HH:MM:SS` reset timestamp in the error message. */
+const RESET_TIMESTAMP_PATTERN = /(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2})/;
+
+/** Seconds until the quota resets, from a UTC+8 `YYYY-MM-DD HH:MM:SS` timestamp. */
+function secondsUntilReset(timestamp: string): number | undefined {
+  const match = RESET_TIMESTAMP_PATTERN.exec(timestamp);
+  if (!match) return undefined;
+  const [date, time] = [match[1], match[2]];
+  // Parse as UTC+8: treat the wall-clock as UTC, then subtract the CST offset
+  // to get the true UTC instant.
+  const utcMs = Date.parse(`${date}T${time}Z`);
+  if (Number.isNaN(utcMs)) return undefined;
+  const resetMs = utcMs - CST_OFFSET_MS;
+  return Math.max(0, Math.floor((resetMs - Date.now()) / 1000));
+}
+
+/**
+ * Parse a GLM Coding Plan usage-limit error, returning the reset details or
+ * `null` when the error is not a GLM Coding Plan quota exhaustion. Mirrors
+ * {@link parseChatGptSubscriptionLimit}: pure body inspection, no clock reads.
+ */
+export function parseGlmCodingPlanLimit(
+  rawErrorBody: unknown,
+): GlmCodingPlanLimit | null {
+  for (const candidate of errorBodyCandidates(rawErrorBody)) {
+    const code = pickStringField(candidate, 'code');
+    if (!code || !GLM_CODING_PLAN_EXHAUSTION_CODES.has(code)) continue;
+    const resetsInSeconds =
+      pickNumberField(candidate, 'resets_in_seconds') ??
+      secondsUntilReset(pickStringField(candidate, 'message') ?? '');
+    return { resetsInSeconds };
+  }
+  return null;
+}
+
+/**
+ * Format a coarse "1d 20h" / "20h 22m" / "5m" duration from a second count,
+ * matching {@link describeChatGptSubscriptionLimit}. Pure (no clock read), so
+ * it stays usable from the synchronous error formatter.
+ */
+function formatResetDuration(totalSeconds: number): string {
+  const wholeMinutes = Math.floor(Math.max(0, totalSeconds) / 60);
+  if (wholeMinutes === 0) return 'less than a minute';
+  const flooredMinutes =
+    wholeMinutes >= 1440 ? wholeMinutes - (wholeMinutes % 60) : wholeMinutes;
+  return prettyMilliseconds(flooredMinutes * 60_000, { unitCount: 2 });
+}
+
+/**
+ * Human-readable message for a GLM Coding Plan usage-limit error: how long
+ * until the quota resets (when reported) and the actionable next step.
+ */
+export function describeGlmCodingPlanLimit(info: GlmCodingPlanLimit): string {
+  const reset =
+    info.resetsInSeconds !== undefined
+      ? ` Resets in ${formatResetDuration(info.resetsInSeconds)}.`
+      : '';
+  return (
+    `GLM Coding Plan usage limit reached.${reset}` +
+    ' Switch to the regular GLM endpoint to keep working, or wait until the limit resets.'
+  );
+}

--- a/src/common/errors/sdkError/glmCodingPlanDetection.ts
+++ b/src/common/errors/sdkError/glmCodingPlanDetection.ts
@@ -46,6 +46,13 @@ const GLM_CODING_PLAN_EXHAUSTION_CODES: ReadonlySet<string> = new Set([
   '1321', // Usage limit reached for the past 7 days (monthly spend limit)
 ]);
 
+/** GLM Coding Plan transient rate-limit / overload codes (all HTTP 429). These
+ *  are retryable, not quota exhaustion — a moment's pause clears them. */
+const GLM_CODING_PLAN_RATE_LIMIT_CODES: ReadonlySet<string> = new Set([
+  '1302', // Rate limit reached for requests
+  '1305', // The service may be temporarily overloaded
+]);
+
 /** UTC+8 (China Standard Time) offset in milliseconds. */
 const CST_OFFSET_MS = 8 * 60 * 60 * 1000;
 
@@ -82,6 +89,31 @@ export function parseGlmCodingPlanLimit(
     return { resetsInSeconds };
   }
   return null;
+}
+
+/**
+ * Whether a GLM Coding Plan error is a transient rate limit / overload (codes
+ * 1302/1305) rather than quota exhaustion. These are retryable after a pause —
+ * they are deliberately NOT classified as a coding-plan exhaustion, so the
+ * retry UI keeps the ordinary retry affordance instead of the switch-to-regular
+ * endpoint one.
+ */
+export function isGlmCodingPlanRateLimit(rawErrorBody: unknown): boolean {
+  return errorBodyCandidates(rawErrorBody).some((candidate) => {
+    const code = pickStringField(candidate, 'code');
+    return code !== undefined && GLM_CODING_PLAN_RATE_LIMIT_CODES.has(code);
+  });
+}
+
+/**
+ * Human-readable message for a GLM Coding Plan rate-limit / overload error:
+ * a clear "retry in a moment" hint distinct from quota exhaustion.
+ */
+export function describeGlmCodingPlanRateLimit(): string {
+  return (
+    'GLM Coding Plan rate limit reached. Wait a moment and retry; the plan is ' +
+    'still active.'
+  );
 }
 
 /**

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -62,6 +62,10 @@ import {
   parseKimiCodeSubscriptionLimit,
 } from './kimiCodeSubscriptionDetection';
 import {
+  describeGlmCodingPlanLimit,
+  parseGlmCodingPlanLimit,
+} from './glmCodingPlanDetection';
+import {
   type SdkErrorEntry,
   SDK_ERRORS,
   SDK_ERRORS_BY_KIND,
@@ -270,6 +274,14 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   const kimiCodeSubscriptionMessage = kimiCodeSubscriptionLimit
     ? describeKimiCodeSubscriptionLimit(kimiCodeSubscriptionLimit)
     : undefined;
+  // GLM Coding Plan quota exhaustion — same pattern: a credential exhaustion
+  // that turns off the Coding Plan toggle on accept so GLM requests re-route
+  // through the regular pay-as-you-go endpoint.
+  const glmCodingPlanLimit = parseGlmCodingPlanLimit(rawErrorBody);
+  const isGlmCodingPlanLimited = glmCodingPlanLimit !== null;
+  const glmCodingPlanMessage = glmCodingPlanLimit
+    ? describeGlmCodingPlanLimit(glmCodingPlanLimit)
+    : undefined;
   // Priority mirrors the pre-refactor OR order: ChatGPT-subscription and
   // upstream-credit are independently detected first; relay monthly limit
   // (by body or message) is the remaining exhaustion condition. Explicit SDK
@@ -280,6 +292,8 @@ export function formatProviderHttpError(err: unknown): ProviderError {
       exhaustionReason = 'chatgpt-subscription';
     } else if (isKimiCodeSubscriptionLimited) {
       exhaustionReason = 'kimi-code-subscription';
+    } else if (isGlmCodingPlanLimited) {
+      exhaustionReason = 'glm-coding-plan';
     } else if (isUpstreamCreditDepleted) {
       exhaustionReason = 'upstream-credit';
     } else if (
@@ -363,6 +377,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
       message:
         chatgptSubscriptionMessage ??
         kimiCodeSubscriptionMessage ??
+        glmCodingPlanMessage ??
         sdkMatch.message,
       // Credential-exhausted errors keep userRetryable=true so the retry
       // panel surfaces with the "Use your own API key" affordance, but
@@ -393,7 +408,10 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   return {
     ...classification,
     message:
-      chatgptSubscriptionMessage ?? kimiCodeSubscriptionMessage ?? message,
+      chatgptSubscriptionMessage ??
+      kimiCodeSubscriptionMessage ??
+      glmCodingPlanMessage ??
+      message,
     statusCode,
     statusText,
     provider,

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -63,6 +63,8 @@ import {
 } from './kimiCodeSubscriptionDetection';
 import {
   describeGlmCodingPlanLimit,
+  describeGlmCodingPlanRateLimit,
+  isGlmCodingPlanRateLimit,
   parseGlmCodingPlanLimit,
 } from './glmCodingPlanDetection';
 import {
@@ -282,6 +284,12 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   const glmCodingPlanMessage = glmCodingPlanLimit
     ? describeGlmCodingPlanLimit(glmCodingPlanLimit)
     : undefined;
+  // GLM Coding Plan transient rate limit / overload (codes 1302/1305): surface
+  // a clear "retry in a moment" message, but keep it retryable — it is NOT a
+  // quota exhaustion, so no switch-to-regular-endpoint affordance.
+  const glmCodingPlanRateLimitMessage = isGlmCodingPlanRateLimit(rawErrorBody)
+    ? describeGlmCodingPlanRateLimit()
+    : undefined;
   // Priority mirrors the pre-refactor OR order: ChatGPT-subscription and
   // upstream-credit are independently detected first; relay monthly limit
   // (by body or message) is the remaining exhaustion condition. Explicit SDK
@@ -378,6 +386,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
         chatgptSubscriptionMessage ??
         kimiCodeSubscriptionMessage ??
         glmCodingPlanMessage ??
+        glmCodingPlanRateLimitMessage ??
         sdkMatch.message,
       // Credential-exhausted errors keep userRetryable=true so the retry
       // panel surfaces with the "Use your own API key" affordance, but
@@ -411,6 +420,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
       chatgptSubscriptionMessage ??
       kimiCodeSubscriptionMessage ??
       glmCodingPlanMessage ??
+      glmCodingPlanRateLimitMessage ??
       message,
     statusCode,
     statusText,

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -66,3 +66,8 @@ export {
   parseKimiCodeSubscriptionLimit,
   describeKimiCodeSubscriptionLimit,
 } from './sdkError/kimiCodeSubscriptionDetection';
+
+export {
+  parseGlmCodingPlanLimit,
+  describeGlmCodingPlanLimit,
+} from './sdkError/glmCodingPlanDetection';

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -70,4 +70,6 @@ export {
 export {
   parseGlmCodingPlanLimit,
   describeGlmCodingPlanLimit,
+  isGlmCodingPlanRateLimit,
+  describeGlmCodingPlanRateLimit,
 } from './sdkError/glmCodingPlanDetection';

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -21,7 +21,7 @@ export interface ProgressApiKeyRetryRequest {
  * quota-exhaustion reason that signals the toggle should be disabled so requests
  * re-route through the regular pay-as-you-go endpoint.
  */
-export interface CodingPlanToggle {
+interface CodingPlanToggle {
   /** The exhaustion reason that signals this plan's quota ran out. */
   readonly exhaustionReason: ExhaustionReason;
   readonly getEnabled: () => boolean;

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -14,11 +14,26 @@ export interface ProgressApiKeyRetryRequest {
   viaRelay?: boolean;
 }
 
+/**
+ * One API-key-based coding-plan subscription (GLM Coding Plan, Kimi Code) that
+ * the retry controller can turn off when its quota is exhausted. Both share the
+ * same shape: a toggle that routes requests through a coding endpoint, and a
+ * quota-exhaustion reason that signals the toggle should be disabled so requests
+ * re-route through the regular pay-as-you-go endpoint.
+ */
+export interface CodingPlanToggle {
+  /** The exhaustion reason that signals this plan's quota ran out. */
+  readonly exhaustionReason: ExhaustionReason;
+  readonly getEnabled: () => boolean;
+  readonly setEnabled: (enabled: boolean) => Promise<void>;
+}
+
 interface ProgressApiKeyPreparationResult {
   proceeded: boolean;
   disabledIncludedModelAccess: boolean;
   disabledChatGptSubscription: boolean;
-  disabledKimiCodeSubscription: boolean;
+  /** Exhaustion reasons whose coding-plan toggle was turned off. */
+  disabledCodingPlans: readonly ExhaustionReason[];
 }
 
 export interface ProgressApiKeyRetryResult extends ProgressApiKeyPreparationResult {
@@ -28,7 +43,7 @@ export interface ProgressApiKeyRetryResult extends ProgressApiKeyPreparationResu
 interface ProgressApiRoutingSnapshot {
   readonly useIncludedModelAccess: boolean;
   readonly preferChatGptSubscription: boolean;
-  readonly preferKimiCode: boolean;
+  readonly codingPlans: ReadonlyMap<ExhaustionReason, boolean>;
 }
 
 function noRetryResult(): ProgressApiKeyRetryResult {
@@ -37,7 +52,7 @@ function noRetryResult(): ProgressApiKeyRetryResult {
     retried: false,
     disabledIncludedModelAccess: false,
     disabledChatGptSubscription: false,
-    disabledKimiCodeSubscription: false,
+    disabledCodingPlans: [],
   };
 }
 
@@ -50,8 +65,8 @@ export interface ProgressApiKeyRetryControllerDeps {
   setUseIncludedModelAccess(enabled: boolean): Promise<void>;
   getPreferChatGptSubscription(): boolean;
   setPreferChatGptSubscription(enabled: boolean): Promise<void>;
-  getPreferKimiCode(): boolean;
-  setPreferKimiCode(enabled: boolean): Promise<void>;
+  /** API-key-based coding-plan subscriptions (GLM Coding Plan, Kimi Code). */
+  codingPlanToggles: readonly CodingPlanToggle[];
   invalidateModelOptionsCache(): void;
   isRetryPending(stream: StreamTabId, requestId: string): boolean;
   triggerRetry(stream: StreamTabId, requestId: string): boolean;
@@ -127,8 +142,7 @@ export class ProgressApiKeyRetryController {
     return (
       request.viaRelay === true ||
       request.exhaustionReason === 'chatgpt-subscription' ||
-      request.exhaustionReason === 'copilot-subscription' ||
-      request.exhaustionReason === 'kimi-code-subscription'
+      request.exhaustionReason === 'copilot-subscription'
     );
   }
 
@@ -140,12 +154,6 @@ export class ProgressApiKeyRetryController {
       request.exhaustionReason === 'copilot-subscription' &&
       request.chatGptSubscriptionEligible === true
     );
-  }
-
-  private isKimiCodeSubscriptionExhausted(
-    request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
-  ): boolean {
-    return request.exhaustionReason === 'kimi-code-subscription';
   }
 
   private async applyOwnApiKeyRouting(
@@ -177,25 +185,26 @@ export class ProgressApiKeyRetryController {
       disabledChatGptSubscription = true;
     }
 
-    // Kimi Code quota exhausted: turn off "Prefer Kimi Code" so dual-backend
-    // Kimi models (e.g. `kimi3`) re-route through the Moonshot open-platform
-    // API key on retry. Exclusive Kimi Code models have no open-platform route
-    // and cannot fall back this way.
-    let disabledKimiCodeSubscription = false;
-    if (
-      this.deps.getPreferKimiCode() &&
-      this.isKimiCodeSubscriptionExhausted(request)
-    ) {
-      await this.deps.setPreferKimiCode(false);
-      this.deps.invalidateModelOptionsCache();
-      disabledKimiCodeSubscription = true;
+    // Any API-key-based coding-plan subscription (GLM Coding Plan, Kimi Code)
+    // whose quota is exhausted: turn off its toggle so requests re-route through
+    // the regular pay-as-you-go endpoint on retry.
+    const disabledCodingPlans: ExhaustionReason[] = [];
+    for (const toggle of this.deps.codingPlanToggles) {
+      if (
+        toggle.getEnabled() &&
+        request.exhaustionReason === toggle.exhaustionReason
+      ) {
+        await toggle.setEnabled(false);
+        this.deps.invalidateModelOptionsCache();
+        disabledCodingPlans.push(toggle.exhaustionReason);
+      }
     }
 
     return {
       proceeded: true,
       disabledIncludedModelAccess,
       disabledChatGptSubscription,
-      disabledKimiCodeSubscription,
+      disabledCodingPlans,
     };
   }
 
@@ -222,7 +231,12 @@ export class ProgressApiKeyRetryController {
     return {
       useIncludedModelAccess: this.deps.getUseIncludedModelAccess(),
       preferChatGptSubscription: this.deps.getPreferChatGptSubscription(),
-      preferKimiCode: this.deps.getPreferKimiCode(),
+      codingPlans: new Map(
+        this.deps.codingPlanToggles.map((toggle) => [
+          toggle.exhaustionReason,
+          toggle.getEnabled(),
+        ]),
+      ),
     };
   }
 
@@ -243,8 +257,14 @@ export class ProgressApiKeyRetryController {
         ),
       );
     }
-    if (prepared.disabledKimiCodeSubscription) {
-      restores.push(this.deps.setPreferKimiCode(before.preferKimiCode));
+    for (const reason of prepared.disabledCodingPlans) {
+      const toggle = this.deps.codingPlanToggles.find(
+        (candidate) => candidate.exhaustionReason === reason,
+      );
+      if (toggle)
+        restores.push(
+          toggle.setEnabled(before.codingPlans.get(reason) ?? false),
+        );
     }
     await Promise.all(restores);
     if (restores.length > 0) this.deps.invalidateModelOptionsCache();

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -48,6 +48,10 @@ export const ExhaustionReasonSchema = z.enum([
    *  the "Prefer Kimi Code" preference so dual-backend Kimi models re-route
    *  through the Moonshot open-platform API key. */
   'kimi-code-subscription',
+  /** A GLM Coding Plan request was rejected because the plan's usage quota is
+   *  exhausted; accepting the switch turns off the Coding Plan toggle so GLM
+   *  requests route through the regular pay-as-you-go endpoint. */
+  'glm-coding-plan',
 ]);
 export type ExhaustionReason = z.infer<typeof ExhaustionReasonSchema>;
 
@@ -206,6 +210,16 @@ export function isKimiCodeSubscriptionLimitError(
   errorDetails: Pick<ProviderError, 'exhaustionReason'> | undefined | null,
 ): boolean {
   return errorDetails?.exhaustionReason === 'kimi-code-subscription';
+}
+
+/** Single source of truth for "this error is a GLM Coding Plan usage-limit
+ *  rejection". Hosts branch on this to switch the retry from the coding-plan
+ *  path to the regular GLM pay-as-you-go endpoint by turning off the Coding
+ *  Plan toggle. */
+export function isGlmCodingPlanLimitError(
+  errorDetails: Pick<ProviderError, 'exhaustionReason'> | undefined | null,
+): boolean {
+  return errorDetails?.exhaustionReason === 'glm-coding-plan';
 }
 
 /** Single source of truth for "the upstream provider account itself is out of

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -201,27 +201,6 @@ export function isChatGptSubscriptionLimitError(
   return errorDetails?.exhaustionReason === 'chatgpt-subscription';
 }
 
-/** Single source of truth for "this error is a Kimi Code (Moonshot
- *  coding-subscription) usage-limit rejection". Both hosts (VS Code progress
- *  view, CLI approval policy) branch on this to switch the retry from the
- *  relay/personal-key path to disabling the "Prefer Kimi Code" preference so
- *  dual-backend Kimi models re-route through the Moonshot open-platform key. */
-export function isKimiCodeSubscriptionLimitError(
-  errorDetails: Pick<ProviderError, 'exhaustionReason'> | undefined | null,
-): boolean {
-  return errorDetails?.exhaustionReason === 'kimi-code-subscription';
-}
-
-/** Single source of truth for "this error is a GLM Coding Plan usage-limit
- *  rejection". Hosts branch on this to switch the retry from the coding-plan
- *  path to the regular GLM pay-as-you-go endpoint by turning off the Coding
- *  Plan toggle. */
-export function isGlmCodingPlanLimitError(
-  errorDetails: Pick<ProviderError, 'exhaustionReason'> | undefined | null,
-): boolean {
-  return errorDetails?.exhaustionReason === 'glm-coding-plan';
-}
-
 /** Single source of truth for "the upstream provider account itself is out of
  *  credit/quota" — the key the user has IS the broken one, so the auto-resume
  *  handler must require a new key rather than reusing the depleted stored

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   invalidateApiKeyCache: vi.fn(),
   preferSubscription: true,
   preferKimiCode: false,
+  glmCodingPlan: false,
   notify: vi.fn(),
   openRouter: false,
   retryCopyFailure: undefined as Error | undefined,
@@ -25,7 +26,9 @@ const mocks = vi.hoisted(() => ({
   setCliApiMode: vi.fn(),
   setCliCodexSubscription: vi.fn(),
   setCliKimiCode: vi.fn(),
+  setCliGlmCodingPlan: vi.fn(),
   setPreferKimiCode: vi.fn(),
+  setGLMCodingPlan: vi.fn(),
   updateGlobalState: vi.fn(),
 }));
 
@@ -65,6 +68,7 @@ vi.mock('@cli/runtime/apiAccessMode', async (importActual) => {
 vi.mock('@cli/chat/tui/state/codexSubscription', () => ({
   setCliCodexSubscription: mocks.setCliCodexSubscription,
   setCliKimiCode: mocks.setCliKimiCode,
+  setCliGlmCodingPlan: mocks.setCliGlmCodingPlan,
 }));
 
 vi.mock('@utils/config/providerConfig', async (importActual) => {
@@ -74,6 +78,8 @@ vi.mock('@utils/config/providerConfig', async (importActual) => {
     ...actual,
     getPreferKimiCode: () => mocks.preferKimiCode,
     setPreferKimiCode: mocks.setPreferKimiCode,
+    getGLMCodingPlan: () => mocks.glmCodingPlan,
+    setGLMCodingPlan: mocks.setGLMCodingPlan,
   };
 });
 

--- a/src/test-kernel/common/GlmCodingPlanDetection.vitest.ts
+++ b/src/test-kernel/common/GlmCodingPlanDetection.vitest.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
   describeGlmCodingPlanLimit,
+  describeGlmCodingPlanRateLimit,
   formatProviderHttpError,
+  isGlmCodingPlanRateLimit,
   parseGlmCodingPlanLimit,
 } from '@common/errors/sdkErrorUtils';
 
@@ -92,6 +94,33 @@ describe('parseGlmCodingPlanLimit', () => {
   it('ignores unrelated bodies', () => {
     expect(parseGlmCodingPlanLimit({ message: 'nope' })).toBeNull();
     expect(parseGlmCodingPlanLimit(undefined)).toBeNull();
+  });
+
+  it('recognizes a GLM Coding Plan rate limit (1302) as retryable, not exhaustion', () => {
+    const rateLimitBody = {
+      error: {
+        code: '1302',
+        message: '您的账户已达到速率限制，请您控制请求频率',
+      },
+    } as const;
+
+    // Not a quota exhaustion — no switch-to-regular-endpoint affordance.
+    expect(parseGlmCodingPlanLimit(rateLimitBody)).toBeNull();
+    // But it IS recognized as a rate limit with a clear retry hint.
+    expect(isGlmCodingPlanRateLimit(rateLimitBody)).toBe(true);
+    expect(describeGlmCodingPlanRateLimit()).toContain('rate limit');
+    expect(describeGlmCodingPlanRateLimit()).toContain('retry');
+  });
+
+  it('recognizes a GLM Coding Plan overload (1305) as a rate limit', () => {
+    const overloadBody = {
+      error: { code: '1305', message: 'temporarily overloaded' },
+    } as const;
+    expect(isGlmCodingPlanRateLimit(overloadBody)).toBe(true);
+  });
+
+  it('does not treat quota exhaustion as a rate limit', () => {
+    expect(isGlmCodingPlanRateLimit(WEEKLY_LIMIT_BODY)).toBe(false);
   });
 
   it('formats a human-readable reset hint', () => {

--- a/src/test-kernel/common/GlmCodingPlanDetection.vitest.ts
+++ b/src/test-kernel/common/GlmCodingPlanDetection.vitest.ts
@@ -26,10 +26,26 @@ const FIVE_HOUR_LIMIT_BODY = {
 const CST_TIMESTAMP_BODY = {
   error: {
     code: '1308',
-    message:
-      '已达到 5 小时的使用上限。您的限额将在 2026-08-08 11:32:36 重置。',
+    message: '已达到 5 小时的使用上限。您的限额将在 2026-08-08 11:32:36 重置。',
   },
 } as const;
+
+/** Build a UTC+8 reset timestamp a fixed window in the future. */
+function futureCstTimestampBody(minutesFromNow: number): {
+  error: { code: string; message: string };
+} {
+  const resetMs = Date.now() + minutesFromNow * 60 * 1000;
+  // Convert to UTC+8 wall-clock, then format as YYYY-MM-DD HH:MM:SS.
+  const cst = new Date(resetMs + 8 * 60 * 60 * 1000);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const timestamp = `${cst.getUTCFullYear()}-${pad(cst.getUTCMonth() + 1)}-${pad(cst.getUTCDate())} ${pad(cst.getUTCHours())}:${pad(cst.getUTCMinutes())}:${pad(cst.getUTCSeconds())}`;
+  return {
+    error: {
+      code: '1308',
+      message: `已达到 5 小时的使用上限。您的限额将在 ${timestamp} 重置。`,
+    },
+  };
+}
 
 describe('parseGlmCodingPlanLimit', () => {
   it('parses a GLM Coding Plan weekly-limit error', () => {
@@ -47,9 +63,10 @@ describe('parseGlmCodingPlanLimit', () => {
   });
 
   it('derives the reset window from a UTC+8 China-time timestamp in the message', () => {
-    const limit = parseGlmCodingPlanLimit(CST_TIMESTAMP_BODY);
+    const limit = parseGlmCodingPlanLimit(futureCstTimestampBody(30));
     expect(limit).not.toBeNull();
-    // The reset timestamp is in the future, so a finite seconds count is set.
+    // The reset timestamp is ~30 minutes in the future, so a finite seconds
+    // count is set.
     expect(limit?.resetsInSeconds).toBeTypeOf('number');
     expect(limit?.resetsInSeconds).toBeGreaterThan(0);
   });

--- a/src/test-kernel/common/GlmCodingPlanDetection.vitest.ts
+++ b/src/test-kernel/common/GlmCodingPlanDetection.vitest.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  describeGlmCodingPlanLimit,
+  formatProviderHttpError,
+  parseGlmCodingPlanLimit,
+} from '@common/errors/sdkErrorUtils';
+
+const WEEKLY_LIMIT_BODY = {
+  error: {
+    code: '1310',
+    message:
+      'Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-08-14T00:00:00Z',
+  },
+} as const;
+
+const FIVE_HOUR_LIMIT_BODY = {
+  error: {
+    code: '1316',
+    message:
+      'Usage limit reached for the past 5 hours. Insufficient balance for extra usage. Resets at 2026-08-07T05:00:00Z',
+  },
+} as const;
+
+/** The real GLM Coding Plan error: a UTC+8 China-time reset timestamp. */
+const CST_TIMESTAMP_BODY = {
+  error: {
+    code: '1308',
+    message:
+      '已达到 5 小时的使用上限。您的限额将在 2026-08-08 11:32:36 重置。',
+  },
+} as const;
+
+describe('parseGlmCodingPlanLimit', () => {
+  it('parses a GLM Coding Plan weekly-limit error', () => {
+    expect(parseGlmCodingPlanLimit(WEEKLY_LIMIT_BODY)).not.toBeNull();
+  });
+
+  it('parses a GLM Coding Plan 5-hour-limit error', () => {
+    expect(parseGlmCodingPlanLimit(FIVE_HOUR_LIMIT_BODY)).not.toBeNull();
+  });
+
+  it('parses the SDK-enveloped { error } form', () => {
+    expect(
+      parseGlmCodingPlanLimit({ error: WEEKLY_LIMIT_BODY.error }),
+    ).not.toBeNull();
+  });
+
+  it('derives the reset window from a UTC+8 China-time timestamp in the message', () => {
+    const limit = parseGlmCodingPlanLimit(CST_TIMESTAMP_BODY);
+    expect(limit).not.toBeNull();
+    // The reset timestamp is in the future, so a finite seconds count is set.
+    expect(limit?.resetsInSeconds).toBeTypeOf('number');
+    expect(limit?.resetsInSeconds).toBeGreaterThan(0);
+  });
+
+  it('ignores non-quota error codes', () => {
+    expect(
+      parseGlmCodingPlanLimit({
+        error: { code: '1302', message: 'Rate limit reached' },
+      }),
+    ).toBeNull();
+    expect(
+      parseGlmCodingPlanLimit({
+        error: { code: '1305', message: 'temporarily overloaded' },
+      }),
+    ).toBeNull();
+    expect(
+      parseGlmCodingPlanLimit({
+        error: { code: '1113', message: 'Insufficient balance' },
+      }),
+    ).toBeNull();
+  });
+
+  it('ignores unrelated bodies', () => {
+    expect(parseGlmCodingPlanLimit({ message: 'nope' })).toBeNull();
+    expect(parseGlmCodingPlanLimit(undefined)).toBeNull();
+  });
+
+  it('formats a human-readable reset hint', () => {
+    const text = describeGlmCodingPlanLimit({ resetsInSeconds: 3600 });
+    expect(text).toContain('GLM Coding Plan usage limit');
+    expect(text).toContain('regular GLM endpoint');
+  });
+});
+
+describe('formatProviderHttpError for GLM Coding Plan limits', () => {
+  it('classifies a GLM Coding Plan usage-limit error as a switchable credential exhaustion', () => {
+    const error = new Error('Weekly/Monthly Limit Exhausted') as Error & {
+      error: unknown;
+      provider?: string;
+    };
+    error.error = WEEKLY_LIMIT_BODY;
+    error.provider = 'glm';
+
+    const providerError = formatProviderHttpError(error);
+
+    expect(providerError.exhaustionReason).toBe('glm-coding-plan');
+    expect(providerError.userRetryable).toBe(true);
+    expect(providerError.message).toContain('GLM Coding Plan usage limit');
+  });
+
+  it('does not classify a GLM rate limit as a coding-plan exhaustion', () => {
+    const error = new Error('Rate limit reached') as Error & {
+      error: unknown;
+      provider?: string;
+    };
+    error.error = { error: { code: '1302', message: 'Rate limit reached' } };
+    error.provider = 'glm';
+
+    const providerError = formatProviderHttpError(error);
+
+    expect(providerError.exhaustionReason).not.toBe('glm-coding-plan');
+  });
+});

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -22,21 +22,21 @@ const IDLE_RESULT = {
   retried: false,
   disabledIncludedModelAccess: false,
   disabledChatGptSubscription: false,
-  disabledKimiCodeSubscription: false,
+  disabledCodingPlans: [],
 };
 const RETRIED_WITH_OWN_KEY_RESULT = {
   proceeded: true,
   retried: true,
   disabledIncludedModelAccess: true,
   disabledChatGptSubscription: false,
-  disabledKimiCodeSubscription: false,
+  disabledCodingPlans: [],
 };
 
 interface HarnessOptions {
   keys?: Partial<Record<ApiProvider, string | undefined>>;
   prompt?(keys: Map<ApiProvider, string | undefined>): void;
   preferChatGptSubscription?: boolean;
-  preferKimiCode?: boolean;
+  glmCodingPlan?: boolean;
   retryAvailable?: boolean;
   retryPending?: boolean;
 }
@@ -47,7 +47,7 @@ function createHarness(options: HarnessOptions = {}): {
   prompts: Array<ApiProvider | undefined>;
   includedAccessValues: boolean[];
   chatGptSubscriptionValues: boolean[];
-  kimiCodeSubscriptionValues: boolean[];
+  glmCodingPlanValues: boolean[];
   invalidations: number;
   retries: string[];
 } {
@@ -59,9 +59,9 @@ function createHarness(options: HarnessOptions = {}): {
   const prompts: Array<ApiProvider | undefined> = [];
   const includedAccessValues: boolean[] = [];
   const chatGptSubscriptionValues: boolean[] = [];
-  const kimiCodeSubscriptionValues: boolean[] = [];
+  const glmCodingPlanValues: boolean[] = [];
   let preferChatGptSubscription = options.preferChatGptSubscription ?? true;
-  let preferKimiCode = options.preferKimiCode ?? true;
+  let glmCodingPlan = options.glmCodingPlan ?? true;
   let invalidations = 0;
   const retries: string[] = [];
 
@@ -70,7 +70,7 @@ function createHarness(options: HarnessOptions = {}): {
     prompts,
     includedAccessValues,
     chatGptSubscriptionValues,
-    kimiCodeSubscriptionValues,
+    glmCodingPlanValues,
     get invalidations() {
       return invalidations;
     },
@@ -93,11 +93,16 @@ function createHarness(options: HarnessOptions = {}): {
         preferChatGptSubscription = enabled;
         chatGptSubscriptionValues.push(enabled);
       },
-      getPreferKimiCode: () => preferKimiCode,
-      setPreferKimiCode: async (enabled) => {
-        preferKimiCode = enabled;
-        kimiCodeSubscriptionValues.push(enabled);
-      },
+      codingPlanToggles: [
+        {
+          exhaustionReason: 'glm-coding-plan',
+          getEnabled: () => glmCodingPlan,
+          setEnabled: async (enabled) => {
+            glmCodingPlan = enabled;
+            glmCodingPlanValues.push(enabled);
+          },
+        },
+      ],
       invalidateModelOptionsCache: () => {
         invalidations += 1;
       },
@@ -294,7 +299,7 @@ describe('ProgressApiKeyRetryController', () => {
       retried: true,
       disabledIncludedModelAccess: true,
       disabledChatGptSubscription: true,
-      disabledKimiCodeSubscription: false,
+      disabledCodingPlans: [],
     });
     // The subscription quota failed, not the key — a stored key is already
     // usable, so "Use your own API key" must not jump to the key-input prompt.
@@ -322,51 +327,55 @@ describe('ProgressApiKeyRetryController', () => {
     assert.deepEqual(harness.retries, []);
   });
 
-  it('disables the Kimi Code preference and retries with the existing Moonshot key, no prompt', async () => {
+  it('disables the GLM Coding Plan and retries with the existing GLM key, no prompt', async () => {
     const harness = createHarness({
-      keys: { moonshot: 'stored-moonshot' },
+      keys: { glm: 'stored-glm' },
     });
 
     const result = await harness.controller.useOwnApiKey({
-      stream: 'stream-kimi',
-      requestId: 'retry-kimi',
-      provider: 'moonshot',
-      exhaustionReason: 'kimi-code-subscription',
+      stream: 'stream-glm',
+      requestId: 'retry-glm',
+      provider: 'glm',
+      exhaustionReason: 'glm-coding-plan',
     });
 
-    // The Kimi Code switch also drops relay so the retry reaches the stored
-    // Moonshot key rather than the relay JWT.
     assert.deepEqual(result, {
       proceeded: true,
       retried: true,
-      disabledIncludedModelAccess: true,
+      disabledIncludedModelAccess: false,
       disabledChatGptSubscription: false,
-      disabledKimiCodeSubscription: true,
+      disabledCodingPlans: ['glm-coding-plan'],
     });
-    // The subscription quota failed, not the key — a stored key is already
+    // The coding-plan quota failed, not the key — a stored key is already
     // usable, so "Use your own API key" must not jump to the key-input prompt.
     assert.deepEqual(harness.prompts, []);
-    assert.deepEqual(harness.includedAccessValues, [false]);
-    assert.deepEqual(harness.kimiCodeSubscriptionValues, [false]);
-    assert.equal(harness.invalidations, 2);
-    assert.deepEqual(harness.retries, ['stream-kimi']);
+    assert.deepEqual(harness.includedAccessValues, []);
+    assert.deepEqual(harness.glmCodingPlanValues, [false]);
+    assert.equal(harness.invalidations, 1);
+    assert.deepEqual(harness.retries, ['stream-glm']);
   });
 
-  it('does not disable the Kimi Code preference when no usable Moonshot key is available', async () => {
-    const harness = createHarness({ keys: {} });
-
-    const result = await harness.controller.useOwnApiKey({
-      stream: 'stream-kimi2',
-      requestId: 'retry-kimi2',
-      provider: 'moonshot',
-      exhaustionReason: 'kimi-code-subscription',
+  it('does not disable the GLM Coding Plan when it is already off', async () => {
+    const harness = createHarness({
+      keys: { glm: 'stored-glm' },
+      glmCodingPlan: false,
     });
 
-    assert.deepEqual(result, IDLE_RESULT);
-    // No usable key exists, so the prompt is still shown (then declined here).
-    assert.deepEqual(harness.prompts, ['moonshot']);
-    assert.deepEqual(harness.kimiCodeSubscriptionValues, []);
-    assert.deepEqual(harness.retries, []);
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-glm2',
+      requestId: 'retry-glm2',
+      provider: 'glm',
+      exhaustionReason: 'glm-coding-plan',
+    });
+
+    assert.deepEqual(result, {
+      proceeded: true,
+      retried: true,
+      disabledIncludedModelAccess: false,
+      disabledChatGptSubscription: false,
+      disabledCodingPlans: [],
+    });
+    assert.deepEqual(harness.glmCodingPlanValues, []);
   });
 
   it('prepares an existing direct key for a fresh Copilot fallback without retrying in place', async () => {

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -152,6 +152,10 @@ export function getGLMCodingPlan(): boolean {
   return readPlatformSetting<boolean>(GlobalStateKey.GLM_CODING_PLAN);
 }
 
+export async function setGLMCodingPlan(enabled: boolean): Promise<void> {
+  await tryGlobalState()?.update(GlobalStateKey.GLM_CODING_PLAN, enabled);
+}
+
 /**
  * Whether the user opted to route dual-backend Kimi models (K3) through the
  * Kimi Code coding endpoint when a Kimi Code API key is set. The two


### PR DESCRIPTION
## Problem

When a GLM Coding Plan's usage quota is exhausted, the coding endpoint (`api.z.ai/api/coding/paas/v4`) rejects requests with a distinctive business error code (1308–1321, e.g. `1310` "Weekly/Monthly Limit Exhausted"). There was no way to fall back to the regular GLM pay-as-you-go endpoint — the request just failed.

## Fix

Mirror the existing ChatGPT-subscription (Codex) fallback. When a GLM Coding Plan quota-exhaustion error is detected, the retry UI offers to turn off the Coding Plan toggle so GLM requests re-route through the regular endpoint (`api.z.ai/api/paas/v4`).

- **Detection** (`glmCodingPlanDetection.ts` + `providerErrorFormat.ts`): a GLM Coding Plan usage-limit error (Z.AI error codes 1308–1321) is classified as `exhaustionReason: 'glm-coding-plan'` — a switchable credential exhaustion, so auto-retry is suppressed and the retry panel surfaces. The codes are distinctive to the coding-plan backend (regular GLM rate limits are 1302/1305), so no false positives.
- **Retry controller** (`ProgressApiKeyRetryController.ts`): accepting "use your own API key" turns off the **GLM Coding Plan** toggle, so GLM requests re-route through the regular pay-as-you-go endpoint. `ProxyConfigResolver` already routes to `/api/paas/v4` when the toggle is off.
- **CLI retry hints** (`approvalPrompts.ts`, `approvalSummaries.ts`, `subscribeApprovals.ts`): the retry prompt shows "switch to the regular GLM endpoint", and GLM Coding Plan exhaustion (like ChatGPT) requires an explicit decision rather than auto-switching.
- **Wiring** (`ProgressViewMessageHandler.ts`, `desktopAgentExecution.ts`): supply the `getGLMCodingPlan`/`setGLMCodingPlan` deps.
- **Schema** (`errors.ts`): new `glm-coding-plan` exhaustion reason + `isGlmCodingPlanLimitError` helper.

## Verification

- New tests cover detection (against the real Z.AI error codes), classification, and the retry routing switch.
- 274 tests pass across the relevant suites; root/extension/desktop/CLI typechecks, lint, formatting, and the architecture ratchet all clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential routing, persisted provider toggles, and retry rollback across CLI, extension, and desktop when GLM Coding Plan quotas fail; mistakes could mis-route GLM requests or leave toggles in the wrong state after a failed retry.
> 
> **Overview**
> Adds **GLM Coding Plan** quota exhaustion handling so exhausted coding-endpoint requests can fall back like ChatGPT subscription and Kimi Code limits already do.
> 
> **Detection and messaging:** New `glmCodingPlanDetection` maps Z.AI business codes **1308–1321** to `exhaustionReason: 'glm-coding-plan'`, with user-facing reset hints; codes **1302/1305** stay ordinary rate limits (retryable, no “switch endpoint” path). `providerErrorFormat` and the schema add the new exhaustion reason; Kimi-specific retry helpers are generalized via `codingPlanRetryHint` / `isCliCodingPlanRetry`.
> 
> **Retry routing:** `ProgressApiKeyRetryController` replaces Kimi-only toggle wiring with a **`codingPlanToggles`** list (GLM Coding Plan + Kimi Code), turning off the matching toggle on “use your own API key” and restoring on rollback. Extension, desktop, and CLI TUI wire `getGLMCodingPlan` / `setGLMCodingPlan`, including `disableGlmCodingPlan` on retry decisions and rollback in `subscribeApprovals`.
> 
> **Settings UI:** Subscriptions tab adds a shared **coding-plan section** pattern for GLM Coding Plan alongside Kimi Code setup steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 726038768ff0f9d8fbaa6dbffdb3253f2a77a841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->