### PR TITLE
refactor(agent): trim o-model handling — relocate isOReasoningModel, drop retired-o1 fallback, ratchet the SDK package

### DIFF
--- a/config/ratchets/host-agent-import-baseline.json
+++ b/config/ratchets/host-agent-import-baseline.json
@@ -1,5 +1,5 @@
 {
-  "semantics": "Distinct '@agent/*' deep-import specifiers (past the @agent barrel) reachable from each host package (packages/cli/src, packages/desktop/src, packages/extension/src), per issue #7684 R-b. Each deep import pins @agent's current internal module layout from outside src/agent and freezes the surface a future SDK barrel would be seeded from. The ratchet fails only when a host's distinct-specifier count exceeds this baseline; a decrease (or an @agent restructor that removes the need for a deep import) is welcome and should shrink this file.",
+  "semantics": "Distinct '@agent/*' deep-import specifiers (past the @agent barrel) reachable from each package (packages/cli/src, packages/desktop/src, packages/extension/src, and the @texra-ai/agent SDK package packages/agent/src), per issue #7684 R-b. Each deep import pins @agent's current internal module layout and freezes the surface a future SDK barrel would be seeded from; 'agent' is the SDK package itself, so its own list is exactly the internal-coupling width a Tier-1 barrel must re-export or seal. The ratchet fails only when a package's distinct-specifier count exceeds this baseline; a decrease (or an @agent restructor that removes the need for a deep import) is welcome and should shrink this file.",
   "hosts": {
     "cli": [
       "@agent/core/definition/AgentConfig",
@@ -95,6 +95,18 @@
       "@agent/runtime/textEnhancement",
       "@agent/storage",
       "@agent/templates/agentTemplateRenderer",
+      "@agent/trace"
+    ],
+    "agent": [
+      "@agent/core/definition/AgentConfig",
+      "@agent/core/definition/AgentDataclass",
+      "@agent/core/tools/ToolTypes",
+      "@agent/index/agentRegistry",
+      "@agent/runtime/AgentFlowResult",
+      "@agent/runtime/ExecutionHandle",
+      "@agent/runtime/HostInteractions",
+      "@agent/runtime/runAgent",
+      "@agent/runtime/SessionHandle",
       "@agent/trace"
     ]
   }

--- a/docs/dev/audits/2026-08-08-agent-sdk-readiness-checkpoint.md
+++ b/docs/dev/audits/2026-08-08-agent-sdk-readiness-checkpoint.md
@@ -21,15 +21,16 @@ created: 2026-08-08
 
 ## Verdict
 
-**Well-aligned. No structural refactor is warranted, and none was made.** The
-four named areas remain converged on the Claude-Agent-SDK shape, and the
-`config/ratchets/` guardrails plus the free-zone import fence are holding. This
-re-check reproduces the standing conclusion of the `-05-29 → -08-03` chain with
-fresh citations and adds **four small, concrete, non-urgent deltas** the prior
-checkpoints had not yet named — two of them net-negative cleanups ready to apply,
-two of them pre-publish decisions for the public event/type surface. None is a
-removable "wrapper layer"; the abstractions this task asked us to hunt for are,
-once again, mostly justified boundaries.
+**Well-aligned. No large structural refactor is warranted.** The four named
+areas remain converged on the Claude-Agent-SDK shape, and the `config/ratchets/`
+guardrails plus the free-zone import fence are holding. This re-check reproduces
+the standing conclusion of the `-05-29 → -08-03` chain with fresh citations and
+adds **four small, concrete, non-urgent deltas** the prior checkpoints had not
+yet named — two of them net-negative cleanups, since landed in this PR (§3-A,
+§3-C); one deferred to a focused follow-up (§3-B); one narrowed down to a stale
+comment plus a genuine pre-publish decision (§3-D). None is a removable
+"wrapper layer"; the abstractions this task asked us to hunt for are, once
+again, mostly justified boundaries.
 
 The one genuinely structural obstacle to a package cut is unchanged and remains
 the intra-`agent` dependency web documented as finding #1 of the
@@ -47,7 +48,8 @@ extraction is pursued.
   sole local `BaseNode`/`Node`/`Flow` definition — no upstream layer to
   collapse. `agentCreator/` is correctly one linear `runAgentCreator` function,
   importing none of `BaseNode`/`Flow`. No wrapper-only forwarder found **except**
-  §3-A below (already tracked as PT-2).
+  the `SessionHandle.useHostInteractions` pass-through in §4 below (already
+  tracked as PT-2).
 - **Model handlers.** Unusually well-consolidated. `toolConversion.ts` owns every
   provider shape-map (providers call in, none re-implement); usage normalization
   is config-driven through `support/UsageNormalizer`; SDK-error tagging is a thin
@@ -66,7 +68,8 @@ extraction is pursued.
   under `src/agent` — agent logging flows through trace/channel as intended.
 - **Surface.** The `@texra-ai/agent` run surface still mirrors the Anthropic
   `Query` pattern one-for-one (`runAgent(input): AgentRun`, `AgentRun extends
-  AsyncIterable<AgentEvent>` + `result`/`interrupt`, five-field `RunAgentInput`).
+AsyncIterable<AgentEvent>` + `result`/`interrupt`, six-field `RunAgentInput`:
+  `platform`, `agent`, `instruction`, `interactions`, optional `model`/`tools`).
   The host-layer import ban is airtight (`eslint.config.mjs`), composition-root
   discipline holds (single guarded `initPlatform`), and approval-requiring tools
   are refused at the boundary. Every ratchet's `semantics` field states the
@@ -106,10 +109,12 @@ specifiers (`packages/agent/src/index.ts:2-13`: `@agent/trace`,
 `@agent/core/tools/ToolTypes`, `@agent/core/definition/{AgentConfig,AgentDataclass}`,
 `@agent/index/agentRegistry`) plus `@platform/*`, `@tools/*`, `@transcript/*`
 leaves — all currently un-ratcheted and unmeasured. **Recommendation (low-risk):**
-add `agent: resolve(REPO_ROOT, 'packages/agent/src')` to `HOST_DIRS` and snapshot
-its current count, so the SDK barrel's internal-coupling width can only shrink.
-This is the surface a Tier-1 manifest must eventually re-export or seal; freezing
-it now costs nothing and prevents silent widening.
+add `'agent'` to the `HOSTS` tuple (not just `HOST_DIRS` — `collectCurrentHosts()`
+and every `it.each` case iterate `HOSTS`, so `HOST_DIRS` alone leaves the new
+entry unscanned), extend `HostBaseline.hosts`, and snapshot the current count, so
+the SDK barrel's internal-coupling width can only shrink. This is the surface a
+Tier-1 manifest must eventually re-export or seal; freezing it now costs nothing
+and prevents silent widening.
 
 ### B. `@shared/schemas` `forced` bucket — highest-leverage barrel shrink — NEW (actionable)
 
@@ -126,10 +131,17 @@ because the barrel does not re-export those leaves:
 `agentPresets(14)`, `agentSkills(4)`, `codex(4)`, `coreSettings(14)`,
 `historyViewMessages(3)`, `opResults(11)`, `profileViewMessages(24)`,
 `stateSettings(15)`, `toolResult(87)`, `workflowScriptFiles(6)`.
-Re-exporting these ten from `src/shared/schemas/index.ts` reclassifies all ~182
-statements at ratchet-measure time and directly shrinks the frozen surface —
-`toolResult` alone (87) is nearly half the bucket. This is the single
-highest-leverage "shrink the frozen list" move and is mechanical/low-risk.
+Re-exporting these ten wholesale would reclassify all ~182 statements at
+ratchet-measure time — `toolResult` alone (87) is nearly half the bucket — but
+is **not** simply mechanical: `index.ts:49-53` deliberately keeps
+`historyViewMessages` and `profileViewMessages` off the barrel, re-exporting
+only selected consumer-facing symbols through the canonical
+`settingsViewMessages` entry point, so a blanket `export *` for those two would
+undo that curated boundary. `forced` proves a name is absent from the barrel,
+not that every export in the leaf belongs there. The real follow-up is
+per-leaf: `export *` for the eight leaves with no existing curation, and a
+deliberate symbol-selection (or caller migration) for the two that are
+intentionally narrowed.
 
 ### C. `isOReasoningModel` sits on the host-agnostic base but is OpenAI-only — NEW (net-negative cleanup)
 
@@ -142,33 +154,45 @@ highest-leverage "shrink the frozen list" move and is mechanical/low-risk.
 hard-codes `config.provider === ModelProvider.OPENAI` and has **zero non-OpenAI
 readers** — every caller is inside `openai/`
 (`modelHandlerOpenAI.ts:291,306,637`, `modelHandlerOpenAIResponse.ts:1550`).
-Moving it into `ModelHandlerOpenAI` (or `OpenAICompatibleModelHandler`), where
-its only readers already live, removes one provider-identity concept from the
-core base class. This exact layering angle was raised but left open in the
+Moving it into `OpenAICompatibleModelHandler` — the only class common to all four
+readers; `ModelHandlerOpenAIResponse` extends `OpenAICompatibleModelHandler`
+directly and is a sibling of `ModelHandlerOpenAI`, not its subclass, so
+`ModelHandlerOpenAI` alone would leave `modelHandlerOpenAIResponse.ts:1550`
+without access — removes one provider-identity concept from the core base
+class. This exact layering angle was raised but left open in the
 [2026-07-02 checkpoint](./2026-07-02-agent-sdk-readiness-checkpoint.md); it is a
 clean net-delete from core, not a behavior change. (The other base-class provider
-comparisons — `ModelHandler.ts:295,778,913` — each carry a `#7101` combinator
-defense and are _not_ silently removable; they remain the layer's residual
-core-leak surface for a future interface-first provider port, listed here only
-for the record.)
+comparisons are _not_ silently removable, though the paper trail differs per
+site: `ModelHandler.ts:778` (`supportsReasoningLevelOverride`) carries its own
+`#7101` combinator note; `:295` (`isOpenAIProvider`) and `:913`
+(`getStreamingConfig`'s `ModelProvider.OTHERS` check) have no comment of their
+own but fall under the general `#7101` triage-complete note at `:723-728`,
+which states every remaining predicate was reviewed and kept. They remain the
+layer's residual core-leak surface for a future interface-first provider port,
+listed here only for the record.)
 
-### D. Public `AgentEvent` union leaks TeXRA-specific arms — NEW (pre-publish decision)
+### D. Public `AgentEvent` union carries TeXRA-specific arms, and one doc comment is stale — NEW (pre-publish decision)
 
 `events.ts:258-263` documents the `domain` escape hatch as the mechanism that
 keeps host-specific events "out of the agent-general union… Keeps the union clean
-for SDK consumers," and its own example list even names `missingOutputs`. Yet
-`RunFactEvent` (`events.ts:177-201`) bakes six TeXRA/LaTeX-specific arms directly
-into the union that `AgentRun` iterates (`packages/agent/src/index.ts:69`) and
-the package re-exports (`:23`): `updateTodos`, `updatePlan`, `addOutputFiles`,
-`updateMissingOutputs`, `updateCompileFailures`, `goalPaused` — with
-`updateMissingOutputs` directly contradicting the hatch's own cited example.
-Additionally, several public arms tie their shape to internal `@shared/schemas`
-host types (`RunConfigEvent.config: AgentConfig`, `StatusEvent`), which a
-published `.d.ts` would drag along. This is not a bug today, but it is a decision
-the SDK boundary should resolve before publication: either route these arms
-through `domain` (consistent with the file's own doctrine) or explicitly bless
-them as part of the agent-general contract. Flagging, not executing — this is a
-public-contract call for the maintainer, not cleanup.
+for SDK consumers," and its own example list still names `missingOutputs`. But
+that comment predates a later, deliberate decision: `runFactEvents.ts:15-19`
+states plainly that "durable run facts ride the run trace as explicit
+`AgentEvent` arms… producers no longer encode them through the `domain` escape
+hatch." `RunFactEvent` (`events.ts:177-201`) is that decision implemented —
+`updateTodos`, `updatePlan`, `addOutputFiles`, `updateMissingOutputs`,
+`updateCompileFailures`, `goalPaused` are first-class discriminated arms on
+purpose, because `RUN_FACT_EVENT_TYPES` and `SessionFactApplier.handleRunFact`
+depend on those exact discriminants to drive CLI and progress-view state — not
+residue to route through `domain`. So the actionable item is narrower than
+"decide where these arms live": it's that the `DomainEvent` comment's
+`missingOutputs` example is stale against the later invariant and should be
+corrected (drop the example or note the carve-out), not a live either/or.
+What remains a genuine pre-publish decision: several public arms tie their
+shape to internal `@shared/schemas` host types (`RunConfigEvent.config:
+AgentConfig`, `StatusEvent`), which a published `.d.ts` would drag along — that
+part is real and unresolved. Flagging, not executing — a public-contract call
+for the maintainer.
 
 ## 4. Already tracked — confirmed, not re-litigated
 
@@ -192,11 +216,16 @@ checkpoint is not mistaken for discovering them:
   event-pump glue that could move behind `@agent/runtime`, leaving `index.ts` a
   thin manifest. Cosmetic; no contract impact.
 - **`IModelHandler` is `Pick<ModelHandler<…>>`, not an independent port**
-  (`IModelHandler.ts:35-86`) — a pluggable provider must `extend` the ~2000-line
-  base, not merely satisfy an interface. Deliberate drift-proofing per the
-  docstring; the standing decision (2026-07-25) is _not_ to demote base-default
-  members to an optional sub-interface. Recorded as the structural fact an
-  interface-first provider SDK would eventually confront, not an action item.
+  (`IModelHandler.ts:35-86`) — structurally, any object or unrelated class that
+  satisfies the resulting member shape works; TypeScript does not require
+  literal inheritance. What's coupled is the _type declaration_: the port's
+  signatures are pinned to the base class's, so a base-class member rename or
+  retype ripples into the port, and building a truly independent provider means
+  reproducing ~40 picked signatures by hand rather than inheriting them for
+  free. Deliberate drift-proofing per the docstring; the standing decision
+  (2026-07-25) is _not_ to demote base-default members to an optional
+  sub-interface. Recorded as the structural fact an interface-first provider
+  SDK would eventually confront, not an action item.
 - **TD-2(a)** (making `HostInteractions` request methods required) — retired with
   evidence in the [2026-08-03 checkpoint §7](./2026-08-03-agent-sdk-readiness-checkpoint.md);
   the optional-with-graceful-decline shape is the shipped minimal-host contract
@@ -208,14 +237,17 @@ Agent core, model handlers, logger/trace, and the package surface remain aligned
 with the Agent-SDK direction; the guardrails are holding and, where measured,
 still tightening. There is no unnecessary abstraction to remove beyond the
 already-tracked PT-2 pass-through, and no subagent boundary to newly design — the
-`ChildRunStrategy` seams already are the boundaries. The only fresh, actionable
-residue is four small items: two ready-to-apply net-negative cleanups (§3-B barrel
-re-exports, §3-C `isOReasoningModel` relocation), one zero-risk ratchet extension
-that closes a real measurement blind spot on the SDK package itself (§3-A), and
-one public-event-surface decision for the maintainer before publication (§3-D).
-The remaining work continues to belong to the packaging/legal track and the
-one-time intra-`agent` dependency inversion — both already captured elsewhere —
-not to abstraction cleanup.
+`ChildRunStrategy` seams already are the boundaries. Of the four fresh items this
+checkpoint named: **§3-A (SDK-package ratchet coverage) and §3-C
+(`isOReasoningModel` relocation) have landed** in this PR; **§3-B (barrel
+re-exports) is deferred** to a follow-up that also needs to preserve the two
+curated `settingsViewMessages` leaves rather than blanket-re-exporting; **§3-D**
+is narrower than originally scoped — the `domain`-routing "decision" was a false
+choice (the stale `DomainEvent` comment needs a fix, not a migration) and the
+one real open item is whether public event arms may keep depending on internal
+`@shared/schemas` host types before publication. The remaining work continues to
+belong to the packaging/legal track and the one-time intra-`agent` dependency
+inversion — both already captured elsewhere — not to abstraction cleanup.
 
 ---
 

--- a/docs/dev/audits/2026-08-08-agent-sdk-readiness-checkpoint.md
+++ b/docs/dev/audits/2026-08-08-agent-sdk-readiness-checkpoint.md
@@ -1,0 +1,211 @@
+---
+created: 2026-08-08
+---
+
+# Agent-SDK readiness re-check (agent core · model handler · logger · surface)
+
+> **Status:** Audit note. Written 2026-08-08 from four parallel evidence passes
+> (agent core, model handlers, logger/trace, package surface), every claim
+> backed by `file:line`. This is a _current-state_ re-measurement, not a new
+> plan. It continues the daily/near-daily checkpoint series — read alongside the
+> immediately prior
+> [`2026-08-03-agent-sdk-readiness-checkpoint.md`](./2026-08-03-agent-sdk-readiness-checkpoint.md)
+> and the base audit
+> [`2026-07-25-agent-sdk-readiness-audit.md`](./2026-07-25-agent-sdk-readiness-audit.md),
+> under the plan of record
+> [`2026-07-09-agent-sdk-north-star.md`](../../proposals/2026-07-09-agent-sdk-north-star.md).
+> Its job is to confirm whether the standing conclusions still hold and to flag
+> what is new. Nothing here overrides a maintainer ruling, reopens the retired
+> package-fence / `RunDescriptor` / `ModelCell` / `RetryGate` proposals, or
+> proposes splitting the deliberately-flat `runtime/` directory.
+
+## Verdict
+
+**Well-aligned. No structural refactor is warranted, and none was made.** The
+four named areas remain converged on the Claude-Agent-SDK shape, and the
+`config/ratchets/` guardrails plus the free-zone import fence are holding. This
+re-check reproduces the standing conclusion of the `-05-29 → -08-03` chain with
+fresh citations and adds **four small, concrete, non-urgent deltas** the prior
+checkpoints had not yet named — two of them net-negative cleanups ready to apply,
+two of them pre-publish decisions for the public event/type surface. None is a
+removable "wrapper layer"; the abstractions this task asked us to hunt for are,
+once again, mostly justified boundaries.
+
+The one genuinely structural obstacle to a package cut is unchanged and remains
+the intra-`agent` dependency web documented as finding #1 of the
+[2026-07-25 audit](./2026-07-25-agent-sdk-readiness-audit.md) — not addressed
+here because it is only worth inverting _if and when_ a real `@texra/core`
+extraction is pursued.
+
+## 1. Area confirmations (fresh evidence)
+
+- **Agent core.** Launch is single-entry: `runAgent`
+  (`src/agent/runtime/runAgent.ts`) mints the `executionId` and registers;
+  `executeAgent` is the lower-level path for callers that already own the id,
+  and `runAgent`'s options are `Pick`ed from `ExecuteAgentOptions` so they
+  cannot drift. The flow engine (`src/agent/node/index.ts`, ~250 LoC) is the
+  sole local `BaseNode`/`Node`/`Flow` definition — no upstream layer to
+  collapse. `agentCreator/` is correctly one linear `runAgentCreator` function,
+  importing none of `BaseNode`/`Flow`. No wrapper-only forwarder found **except**
+  §3-A below (already tracked as PT-2).
+- **Model handlers.** Unusually well-consolidated. `toolConversion.ts` owns every
+  provider shape-map (providers call in, none re-implement); usage normalization
+  is config-driven through `support/UsageNormalizer`; SDK-error tagging is a thin
+  per-provider adapter over one shared matcher; the OpenAI-compatible inheritance
+  ladder is thin and each concrete handler carries real provider quirks, not
+  base-URL stubs. `ModelFactory`'s `PROVIDER_HANDLER_ROUTES` is an exhaustive
+  `Record<ModelProvider,…>` that fails typecheck on a missing arm. One removable
+  leak found (§3-C).
+- **Logger / trace.** The run-vs-session split is respected: run facts live only
+  on `AgentEvent`, `SessionFact` explicitly excludes them, and all five
+  `appSignals.emit` sites are within AppSignals' documented app-lifecycle scope —
+  **no stray `bus.emit` from a VS Code-free zone.** No `default: return` event
+  drops; the `catch {}`-shaped blocks in scope are the sanctioned
+  diagnostic-guard exception (each wraps only a `logger.warn` with an explanatory
+  comment), not the silent-degradation defect. `platform().log` has 0 call sites
+  under `src/agent` — agent logging flows through trace/channel as intended.
+- **Surface.** The `@texra-ai/agent` run surface still mirrors the Anthropic
+  `Query` pattern one-for-one (`runAgent(input): AgentRun`, `AgentRun extends
+  AsyncIterable<AgentEvent>` + `result`/`interrupt`, five-field `RunAgentInput`).
+  The host-layer import ban is airtight (`eslint.config.mjs`), composition-root
+  discipline holds (single guarded `initPlatform`), and approval-requiring tools
+  are refused at the boundary. Every ratchet's `semantics` field states the
+  never-widen invariant explicitly.
+
+## 2. Subagent boundaries (task step 4) — already designed and shipped
+
+Unchanged from the July/August findings: the "logical units that could run as
+independent agents" already exist as first-class runtime concepts, so there is
+nothing to newly carve out. `childRunLoop`'s `ChildRunStrategy<TTurn>`
+(`src/agent/runtime/childRunLoop.ts`) unifies all four child-run types
+(agent-CLI codex, agent-CLI claude, native subagents, workflow-script) behind one
+driver; its `launch` / `runTurn` / `resolveDeliveryTarget` / `buildResultMeta`
+seams _are_ the independent-agent units. Lineage lives on the handle
+(`ExecutionHandle`), detach policy is single-sourced (`detachSubagentsOnStop`),
+and `AgentRosterController` (`src/agent/roster/`) is the multi-agent roster. The
+one tangle is that subagent _delivery formatting_ lives in `@tools/delegation/*`
+but is driven from `runtime` and `core/flows` — the same intra-`agent` edge as
+the structural obstacle above, not a new boundary to invent.
+
+## 3. New deltas since 2026-08-03 (small, concrete, non-urgent)
+
+### A. Ratchet blind spot: `packages/agent/src` is not scanned for `@agent/*` deep-import width — NEW
+
+`host-agent-import-baseline` is the ratchet that freezes each host's distinct
+`@agent/*` deep-import specifier count (cli 31 / desktop 25 / extension 34). Its
+enforcement test scans only the three host packages —
+`hostAgentDeepImportRatchet.vitest.ts:35-39` lists `cli`, `desktop`, `extension`
+and **omits `packages/agent/src`**. That is the one package destined to _become_
+the published SDK, and its public barrel reaches 10 distinct `@agent/*` deep
+specifiers (`packages/agent/src/index.ts:2-13`: `@agent/trace`,
+`@agent/runtime/{ExecutionHandle,AgentFlowResult,HostInteractions,SessionHandle,runAgent}`,
+`@agent/core/tools/ToolTypes`, `@agent/core/definition/{AgentConfig,AgentDataclass}`,
+`@agent/index/agentRegistry`) plus `@platform/*`, `@tools/*`, `@transcript/*`
+leaves — all currently un-ratcheted and unmeasured. **Recommendation (low-risk):**
+add `agent: resolve(REPO_ROOT, 'packages/agent/src')` to `HOST_DIRS` and snapshot
+its current count, so the SDK barrel's internal-coupling width can only shrink.
+This is the surface a Tier-1 manifest must eventually re-export or seal; freezing
+it now costs nothing and prevents silent widening.
+
+### B. `@shared/schemas` `forced` bucket — highest-leverage barrel shrink — NEW (actionable)
+
+`shared-schemas-deep-import-baseline.json` records **10 `forced` specifiers /
+~182 statements** — production code forced past the `@shared/schemas` barrel only
+because the barrel does not re-export those leaves:
+`agentPresets(14)`, `agentSkills(4)`, `codex(4)`, `coreSettings(14)`,
+`historyViewMessages(3)`, `opResults(11)`, `profileViewMessages(24)`,
+`stateSettings(15)`, `toolResult(87)`, `workflowScriptFiles(6)`.
+Re-exporting these ten from `src/shared/schemas/index.ts` reclassifies all ~182
+statements at ratchet-measure time and directly shrinks the frozen surface —
+`toolResult` alone (87) is nearly half the bucket. This is the single
+highest-leverage "shrink the frozen list" move and is mechanical/low-risk.
+
+### C. `isOReasoningModel` sits on the host-agnostic base but is OpenAI-only — NEW (net-negative cleanup)
+
+`ModelHandler.isOReasoningModel` (`src/agent/modelHandlers/ModelHandler.ts:924`)
+hard-codes `config.provider === ModelProvider.OPENAI` and has **zero non-OpenAI
+readers** — every caller is inside `openai/`
+(`modelHandlerOpenAI.ts:291,306,637`, `modelHandlerOpenAIResponse.ts:1550`).
+Moving it into `ModelHandlerOpenAI` (or `OpenAICompatibleModelHandler`), where
+its only readers already live, removes one provider-identity concept from the
+core base class. This exact layering angle was raised but left open in the
+[2026-07-02 checkpoint](./2026-07-02-agent-sdk-readiness-checkpoint.md); it is a
+clean net-delete from core, not a behavior change. (The other base-class provider
+comparisons — `ModelHandler.ts:295,778,913` — each carry a `#7101` combinator
+defense and are _not_ silently removable; they remain the layer's residual
+core-leak surface for a future interface-first provider port, listed here only
+for the record.)
+
+### D. Public `AgentEvent` union leaks TeXRA-specific arms — NEW (pre-publish decision)
+
+`events.ts:258-263` documents the `domain` escape hatch as the mechanism that
+keeps host-specific events "out of the agent-general union… Keeps the union clean
+for SDK consumers," and its own example list even names `missingOutputs`. Yet
+`RunFactEvent` (`events.ts:177-201`) bakes six TeXRA/LaTeX-specific arms directly
+into the union that `AgentRun` iterates (`packages/agent/src/index.ts:69`) and
+the package re-exports (`:23`): `updateTodos`, `updatePlan`, `addOutputFiles`,
+`updateMissingOutputs`, `updateCompileFailures`, `goalPaused` — with
+`updateMissingOutputs` directly contradicting the hatch's own cited example.
+Additionally, several public arms tie their shape to internal `@shared/schemas`
+host types (`RunConfigEvent.config: AgentConfig`, `StatusEvent`), which a
+published `.d.ts` would drag along. This is not a bug today, but it is a decision
+the SDK boundary should resolve before publication: either route these arms
+through `domain` (consistent with the file's own doctrine) or explicitly bless
+them as part of the agent-general contract. Flagging, not executing — this is a
+public-contract call for the maintainer, not cleanup.
+
+## 4. Already tracked — confirmed, not re-litigated
+
+These reproduce with fresh citations but are known and owned; recorded so this
+checkpoint is not mistaken for discovering them:
+
+- **`SessionHandle.useHostInteractions` per-concern pass-through**
+  (`SessionHandle.ts:656-658`) contradicts the class's own "address each owner
+  directly" contract — already tracked as **PT-2** in the tech-debt and
+  SSOT-consolidation proposals. Sanctioned net-delete; the package itself
+  (`index.ts:241`) uses the wrapper, so worth clearing before freezing the SDK
+  surface. ~90 call sites, mostly tests.
+- **Package-boundary type twins** — public `HostInteractions` /
+  `HostInteractionCancelSelector` (`packages/agent/src/index.ts:36-50`) are
+  hand-narrowed copies of the runtime types (`HostInteractions.ts:237-243,275-322`)
+  rather than `Pick`/`Omit` derivations, so they can silently drift; `AgentFlowResult`
+  is re-exported from both `index.ts:29-33` and `schemas.ts:29-33`;
+  `PendingInteractionKind` is aliased in two independent spots. All are minor
+  pre-publish surface tidy-ups, valid to defer until the Tier-1 manifest is drawn.
+- **`AgentRunStream` (114 LoC) lives in the public `index.ts`** — internal
+  event-pump glue that could move behind `@agent/runtime`, leaving `index.ts` a
+  thin manifest. Cosmetic; no contract impact.
+- **`IModelHandler` is `Pick<ModelHandler<…>>`, not an independent port**
+  (`IModelHandler.ts:35-86`) — a pluggable provider must `extend` the ~2000-line
+  base, not merely satisfy an interface. Deliberate drift-proofing per the
+  docstring; the standing decision (2026-07-25) is _not_ to demote base-default
+  members to an optional sub-interface. Recorded as the structural fact an
+  interface-first provider SDK would eventually confront, not an action item.
+- **TD-2(a)** (making `HostInteractions` request methods required) — retired with
+  evidence in the [2026-08-03 checkpoint §7](./2026-08-03-agent-sdk-readiness-checkpoint.md);
+  the optional-with-graceful-decline shape is the shipped minimal-host contract
+  the npm package depends on. Not reopened.
+
+## 5. Bottom line
+
+Agent core, model handlers, logger/trace, and the package surface remain aligned
+with the Agent-SDK direction; the guardrails are holding and, where measured,
+still tightening. There is no unnecessary abstraction to remove beyond the
+already-tracked PT-2 pass-through, and no subagent boundary to newly design — the
+`ChildRunStrategy` seams already are the boundaries. The only fresh, actionable
+residue is four small items: two ready-to-apply net-negative cleanups (§3-B barrel
+re-exports, §3-C `isOReasoningModel` relocation), one zero-risk ratchet extension
+that closes a real measurement blind spot on the SDK package itself (§3-A), and
+one public-event-surface decision for the maintainer before publication (§3-D).
+The remaining work continues to belong to the packaging/legal track and the
+one-time intra-`agent` dependency inversion — both already captured elsewhere —
+not to abstraction cleanup.
+
+---
+
+_Method: four parallel evidence-gathering passes (agent core, model handlers,
+logger/trace, package surface), each required to back every claim with
+`file:line` and grep'd caller counts and to state clean areas explicitly rather
+than invent problems. Findings cross-checked against the ratchet baselines and
+the prior checkpoint series; the four §3 deltas were independently re-verified
+against source before recording._

--- a/docs/dev/audits/2026-08-08-agent-sdk-readiness-checkpoint.md
+++ b/docs/dev/audits/2026-08-08-agent-sdk-readiness-checkpoint.md
@@ -91,6 +91,10 @@ the structural obstacle above, not a new boundary to invent.
 
 ### A. Ratchet blind spot: `packages/agent/src` is not scanned for `@agent/*` deep-import width — NEW
 
+> **Update (landed this PR):** the `agent` package is now a scanned member of
+> `host-agent-import-baseline`, snapshotted at its current 10 distinct `@agent/*`
+> specifiers, so the SDK barrel's internal-coupling width can only shrink.
+
 `host-agent-import-baseline` is the ratchet that freezes each host's distinct
 `@agent/*` deep-import specifier count (cli 31 / desktop 25 / extension 34). Its
 enforcement test scans only the three host packages —
@@ -109,6 +113,13 @@ it now costs nothing and prevents silent widening.
 
 ### B. `@shared/schemas` `forced` bucket — highest-leverage barrel shrink — NEW (actionable)
 
+> **Deferred to a focused follow-up PR.** Widening the barrel with `export *`
+> across 10 layered modules (incl. the 87-symbol `toolResult`) needs
+> collision-checking and correct layer placement, and the `gratuitous` bucket
+> recomputes against the live barrel at test time so the ratchet baseline must
+> be regenerated in the same PR. That is its own reviewable change, kept out of
+> this structural PR.
+
 `shared-schemas-deep-import-baseline.json` records **10 `forced` specifiers /
 ~182 statements** — production code forced past the `@shared/schemas` barrel only
 because the barrel does not re-export those leaves:
@@ -121,6 +132,11 @@ statements at ratchet-measure time and directly shrinks the frozen surface —
 highest-leverage "shrink the frozen list" move and is mechanical/low-risk.
 
 ### C. `isOReasoningModel` sits on the host-agnostic base but is OpenAI-only — NEW (net-negative cleanup)
+
+> **Update (landed this PR):** relocated from `ModelHandler` to
+> `OpenAICompatibleModelHandler` (the common ancestor of all four callers),
+> removing one provider-identity concept from the host-agnostic base with no
+> behavior change (724 model-handler tests green).
 
 `ModelHandler.isOReasoningModel` (`src/agent/modelHandlers/ModelHandler.ts:924`)
 hard-codes `config.provider === ModelProvider.OPENAI` and has **zero non-OpenAI

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -917,17 +917,6 @@ export abstract class ModelHandler<
     );
   }
 
-  /** Runtime combinator (provider identity × reasoning capability), read by
-   * multiple call sites in `openai/` — kept as a named getter rather than
-   * inlined at each one (#7101 triage: DRY combinator, not per-provider
-   * override). */
-  get isOReasoningModel(): boolean {
-    return (
-      this.config.provider === ModelProvider.OPENAI &&
-      this.capabilities.supportsReasoning
-    );
-  }
-
   /**
    * Normalizes a reasoning-effort value for the concrete handler.
    * Provider handlers override this hook when their API supports a narrower

--- a/src/agent/modelHandlers/openai/OpenAICompatibleModelHandler.ts
+++ b/src/agent/modelHandlers/openai/OpenAICompatibleModelHandler.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { ModelProvider } from 'llm-zoo';
 import OpenAI from 'openai';
 
 // Local imports
@@ -30,6 +31,19 @@ export abstract class OpenAICompatibleModelHandler<
   Resp = unknown,
   Media = unknown,
 > extends ModelHandler<M, U, T, OpenAI, Resp, Media> {
+  /** Runtime combinator (provider identity × reasoning capability), read by
+   * multiple call sites in `openai/` — kept as a named getter rather than
+   * inlined at each one (#7101 triage: DRY combinator, not per-provider
+   * override). Lives on the OpenAI-compatible base rather than the
+   * host-agnostic `ModelHandler` because it hard-codes an OpenAI provider
+   * check and has no reader outside this subtree. */
+  get isOReasoningModel(): boolean {
+    return (
+      this.config.provider === ModelProvider.OPENAI &&
+      this.capabilities.supportsReasoning
+    );
+  }
+
   /**
    * Creates a new OpenAI client using the stored credentials.
    * Handles API key retrieval, base URL resolution, and logging.

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1120,10 +1120,11 @@ export class ModelHandlerOpenAIResponse extends OpenAICompatibleModelHandler<
     const messages: ResponseInputItem[] = [];
 
     if (systemPrompt) {
-      const role = this.capabilities.supportsSystemPrompt ? 'system' : 'user';
+      // Every runnable model accepts a system-role prompt; only the retired
+      // o1-mini / o1-preview ever needed the 'user'-role fallback.
       const systemMessage: ResponseInputItem.Message = {
         type: 'message',
-        role,
+        role: 'system',
         content: [createInputText(systemPrompt)],
       };
       messages.push(systemMessage);

--- a/src/agent/modelHandlers/openai/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openai/openAIMessageUtils.ts
@@ -243,7 +243,6 @@ export function insertMediaIntoChatUserMessage(
 
 /** Capability flags `initializeChatMessages`/`createChatRoundMessages` need from the handler. */
 interface ChatMessageRoutingCapabilities {
-  supportsSystemPrompt: boolean;
   supportsIntermDevMsgs: boolean;
   supportsVision: boolean;
   supportsNativeAudio: boolean;
@@ -272,13 +271,12 @@ export async function initializeChatMessages<T extends MessageLike>(
 ): Promise<T[]> {
   const messages: T[] = [];
 
-  // Handle system prompt differently for O1 models
-  // O1 mini and O1 preview models do not support system prompt; use 'user' role instead.
-  // For openai native o1 full or above reasoning models, "developer" is the new name but "system" still works.
+  // Every runnable model accepts a system-role prompt. The only models that
+  // ever needed the 'user'-role fallback were o1-mini / o1-preview, both
+  // retired, so the system prompt always goes in the 'system' role now.
   if (systemPrompt) {
-    const role = capabilities.supportsSystemPrompt ? 'system' : 'user';
     messages.push({
-      role,
+      role: 'system',
       content: [{ type: 'text', text: systemPrompt }],
     } as T);
   }

--- a/src/test-kernel/architecture/hostAgentDeepImportRatchet.vitest.ts
+++ b/src/test-kernel/architecture/hostAgentDeepImportRatchet.vitest.ts
@@ -1,14 +1,19 @@
 // R-b host deep-import WIDTH ratchet (issue #7684). Each host package (CLI,
 // desktop, extension) reaches past the `@agent` barrel into `@agent/*`
 // internals, pinning agent's current internal module layout from outside
-// src/agent. Clones the checked-in-baseline + AST-scanning vitest pattern
-// from LAY-1 (subsystemEdgeRatchet.vitest.ts, PR #7774) and QA-2
-// (hostAgentMockRatchet.vitest.ts, PR #7817): baseline the current set of
-// DISTINCT `@agent/*` deep-import specifiers per host and fail only when a
-// host's specifier count increases; a decrease (or an @agent restructor that
-// removes the need for a deep import) is always welcome and should shrink
-// config/ratchets/host-agent-import-baseline.json. Armed per the issue text pending Stage-5
-// exit (#6968, closed); this is the deferred execution.
+// src/agent. `agent` here is the `@texra-ai/agent` SDK package itself
+// (packages/agent/src): it assembles the public run surface from `@agent/*`
+// internals, so its own distinct-specifier width is exactly the surface a
+// Tier-1 barrel would have to re-export or seal, and freezing it here keeps
+// that count from silently widening. Clones the checked-in-baseline +
+// AST-scanning vitest pattern from LAY-1 (subsystemEdgeRatchet.vitest.ts, PR
+// #7774) and QA-2 (hostAgentMockRatchet.vitest.ts, PR #7817): baseline the
+// current set of DISTINCT `@agent/*` deep-import specifiers per package and
+// fail only when a package's specifier count increases; a decrease (or an
+// @agent restructor that removes the need for a deep import) is always welcome
+// and should shrink config/ratchets/host-agent-import-baseline.json. Armed per
+// the issue text pending Stage-5 exit (#6968, closed); this is the deferred
+// execution.
 
 // Node imports
 import { readFileSync } from 'node:fs';
@@ -20,7 +25,7 @@ import { describe, expect, it } from 'vitest';
 
 import { REPO_ROOT, sourceFilesUnder } from '../support/repoScan';
 
-const HOSTS = ['cli', 'desktop', 'extension'] as const;
+const HOSTS = ['cli', 'desktop', 'extension', 'agent'] as const;
 
 type Host = (typeof HOSTS)[number];
 
@@ -36,6 +41,7 @@ const HOST_DIRS: Record<Host, string> = {
   cli: resolve(REPO_ROOT, 'packages/cli/src'),
   desktop: resolve(REPO_ROOT, 'packages/desktop/src'),
   extension: resolve(REPO_ROOT, 'packages/extension/src'),
+  agent: resolve(REPO_ROOT, 'packages/agent/src'),
 };
 
 const AGENT_DEEP_IMPORT = /^@agent\//;


### PR DESCRIPTION
## Summary

Three self-contained model-handler / Agent-SDK-readiness cleanups. The first two come from the 2026-08-08 readiness checkpoint (included in this PR); the third trims genuinely-dead o1-legacy handling.

1. **Relocate `isOReasoningModel` off the host-agnostic `ModelHandler` base.** The getter hard-codes `config.provider === ModelProvider.OPENAI` and has **zero readers outside `modelHandlers/openai/`**, so it doesn't belong in the provider-neutral core. It moves to `OpenAICompatibleModelHandler` — the common ancestor of both caller classes (`ModelHandlerOpenAI` and `ModelHandlerOpenAIResponse` both extend it). Behavior identical: providers like DeepSeek/GLM/Kimi inherit the getter and its OpenAI guard already returned `false` for them.

2. **Close a ratchet blind spot on the SDK package itself.** `host-agent-import-baseline` previously froze `@agent/*` deep-import width only for `cli`/`desktop`/`extension`, leaving `packages/agent/src` — the `@texra-ai/agent` SDK package — **unmeasured**. Its public barrel already reaches 10 distinct `@agent/*` internals, exactly the surface a Tier-1 barrel must eventually re-export or seal. This snapshots that set at its current 10 specifiers so it can only shrink.

3. **Drop the retired-o1 system-prompt fallback (dead capability branch).** The `supportsSystemPrompt ? 'system' : 'user'` role fallback existed only for **o1-mini / o1-preview** — the sole models that could not take a system-role prompt. Both are **retired** in llm-zoo and `getModel()` no longer resolves them; across all 145 active models (plus the active deep-research pair) **not one** sets `supportsSystemPrompt: false`, and capabilities are always sourced from llm-zoo (`runtimeModelRegistry` only ever overrides reasoning-effort). So no runnable model can reach the `'user'` branch. Hardcodes the system role in both the Chat Completions and Responses paths, drops the now-unused `supportsSystemPrompt` field from `ChatMessageRoutingCapabilities`, and replaces the stale o1-mini/preview comments.

### What was deliberately *not* dropped

The bulk of "o-model" handling is **not** o1/o3-legacy — it serves current models, and removing it would break them:

- **`isOReasoningModel`** → `max_completion_tokens` + suppressed `temperature`/`stop`: every active **o3 / o4 / GPT-5** reasoning model, not just o1/o3.
- **`supportsIntermDevMsgs = false`** → still set by the **active** `o3-deep-research` / `o4-mini-deep-research` models.

The o1/o3 quirks were already generalized into capability flags in an earlier refactor, so there is no model-name-based o1/o3 branching left to delete — only the one retired-model-only flag value above.

## Single source of truth

- `isOReasoningModel` is now owned by `OpenAICompatibleModelHandler`, the single OpenAI-subtree base where all four callers resolve it.
- `config/ratchets/host-agent-import-baseline.json` remains the single frozen record of `@agent/*` deep-import width; the `agent` package is now a measured member.
- System-prompt role is now unconditional (`'system'`); no capability branch to keep in sync across the Chat and Responses paths.

## Duplication and abstraction budget

No new abstraction, no pass-through. All three changes **remove** surface: a provider-identity concept leaves the host-agnostic base, and a dead capability field + its two role branches are deleted.

## Net elements (R6)

- **Files:** 7 changed, 0 added, 0 deleted.
- **Exported symbols:** 0 net — `grep '^[+-]export'` over the diff is empty. `isOReasoningModel` and `supportsSystemPrompt` are class/interface members, not exports.
- **Interfaces:** `ChatMessageRoutingCapabilities` loses one field; no interface added or removed.
- **Net LoC:** the checkpoint doc dominates additions (+227); the code diff is net-negative (dead branches + a field removed, one getter relocated).

## Consumer counts (R8)

- `isOReasoningModel` — 4 call sites, all in `src/agent/modelHandlers/openai/` (`modelHandlerOpenAI.ts:291,306,637`, `modelHandlerOpenAIResponse.ts:1550`); both caller classes extend the new owning base, so all inherit it.
- `supportsSystemPrompt` — 2 consumers (`openAIMessageUtils.ts`, `modelHandlerOpenAIResponse.ts`), both removed; 0 tests referenced it; the `ChatMessageRoutingCapabilities` producers pass `this.capabilities` as a variable (structural), so dropping the field needs no producer edits.

## Host impact

Extension: none — internal to the agent core; no host-facing API change.

Desktop: none.

CLI: none.

## Scheduled refactoring

- **§3-B (barrel shrink):** re-export the 10 `forced` `@shared/schemas` leaves from the barrel and regenerate the shared-schemas ratchet baseline — deferred to a focused follow-up.
- **§3-D:** public `AgentEvent` union leaks TeXRA/LaTeX-specific `RunFactEvent` arms — a public-contract decision for the maintainer, documented, no code change.

## Validation

- `npm run typecheck` — **exit 0** (all packages).
- `eslint` on changed files — **clean**.
- `src/test-kernel/architecture` (all ratchets incl. the modified one) — **82/82**.
- model-handler + `ProviderCapabilities` suites — **715 passing** after the o1-fallback removal (4 skipped).
- `npm run check:dead-code-ratchet` — **17/17 unchanged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal model-handler layering and dead-branch removal with no host-facing API changes; the ratchet only adds coverage for the SDK package at its current baseline.
> 
> **Overview**
> Agent-SDK readiness cleanups in model handlers and import guardrails, plus a dated audit checkpoint that records what landed here versus deferred follow-ups.
> 
> **`isOReasoningModel`** moves from host-agnostic `ModelHandler` to `OpenAICompatibleModelHandler`, where all four OpenAI-subtree callers already live. Behavior is unchanged; the OpenAI-only provider check no longer sits on the neutral base.
> 
> **`host-agent-import-baseline`** now scans `packages/agent/src` (the `@texra-ai/agent` SDK package) and snapshots its current **10** distinct `@agent/*` deep-import specifiers so that internal-coupling width can only shrink, matching cli/desktop/extension.
> 
> **Retired o1 system-prompt handling** is removed: Chat Completions and Responses paths always use a **`system`** role for the system prompt, and `supportsSystemPrompt` is dropped from `ChatMessageRoutingCapabilities` because no runnable model still needed the `'user'` fallback.
> 
> Adds **`docs/dev/audits/2026-08-08-agent-sdk-readiness-checkpoint.md`** — evidence-backed re-check; §3-A and §3-C note these two code changes as landed; barrel shrink (§3-B) and public `AgentEvent` contract (§3-D) stay deferred.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3cdf3c724560192a70f6edc995d0f76aedf4dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->