### PR TITLE
fix(tools): use key-order-stable comparison in registry override check

### DIFF
--- a/src/test-kernel/tools/ToolRegistryAliases.vitest.ts
+++ b/src/test-kernel/tools/ToolRegistryAliases.vitest.ts
@@ -43,6 +43,22 @@ describe('tool registry resolution', () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it('does not report an override when only key order differs', () => {
+    // Structural equality must be key-order independent: JSON.stringify
+    // comparison would false-positive here even though the content matches.
+    const warn = vi.fn();
+    const [registered] = resolveToolDefinitions(['grep']);
+    const reorderedParameters = Object.fromEntries(
+      Object.entries(
+        registered?.parameters as Record<string, unknown>,
+      ).reverse(),
+    );
+    const reordered = { ...registered, parameters: reorderedParameters };
+
+    expect(resolveToolDefinitions([reordered], warn)).toEqual([registered]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it('keeps a definition the registry does not hold', () => {
     // An embedder registering agents as values supplies tools the built-in
     // registry never sees; their definition is all the model has to go on.

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,3 +1,6 @@
+// Third-party imports
+import stableStringify from 'fast-json-stable-stringify';
+
 // Local imports
 import type { ITool, IToolRegistry } from '@agent/core/tools/ToolTypes';
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
@@ -183,7 +186,7 @@ type RawToolConfig = string | ToolDefinition;
 
 function differsFrom(declared: unknown, registered: unknown): boolean {
   if (declared === undefined || declared === registered) return false;
-  return JSON.stringify(declared) !== JSON.stringify(registered);
+  return stableStringify(declared) !== stableStringify(registered);
 }
 
 /**


### PR DESCRIPTION
## Summary

`differsFrom()` in `src/tools/registry.ts` decides whether a declared tool's `description`/`parameters` "override" the registry's own contract, by comparing them with `JSON.stringify`. `JSON.stringify` equality is key-order sensitive, so two structurally identical objects built via different code paths (e.g. different construction order for the same JSON-schema `parameters` object) can serialize differently and trip a false "override" — silently discarding the registry's contract with a spurious warning even though nothing actually changed. This surfaced during an ad-hoc audit for hand-rolled logic reimplementing solved problems. Swaps `JSON.stringify` for `stableStringify` from `fast-json-stable-stringify`, already a direct dependency used the same way elsewhere (`src/utils/core/idHash.ts`, `src/common/errors/sdkError/providerErrorFormat.ts`, `src/agent/core/flows/toolUseRound/toolCallParsing.ts`, `src/agent/workflowScript/*`).

## Issue acceptance gates

No tracked issue — found via an ad-hoc codebase audit, not filed as an issue first.

## Single source of truth

No ownership change. `differsFrom()` remains the sole comparison used by `overridesContract()`; only its comparison primitive changed.

## Duplication and abstraction budget

No new abstraction added — reuses the already-installed `fast-json-stable-stringify` dependency and its established `import stableStringify from 'fast-json-stable-stringify'` pattern instead of writing a new comparator.

## Net elements (R6)

n/a — this is a one-line behavioral bug fix plus a regression test, not a refactor/simplify/consolidate/dedupe/extract PR.

## Consumer counts (R8)

n/a — no emit path or export removed/rerouted.

## Host impact

Extension: same fix applies (tool registry is host-agnostic, shared by all hosts)
Desktop: same
CLI: same

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` (all workspaces: workspace, test-kernel, agent, extension, cli, trace-viewer, desktop) — passed
- `npx eslint src/tools/registry.ts src/test-kernel/tools/ToolRegistryAliases.vitest.ts` — clean
- `npx prettier --check` on both changed files — clean
- Added a regression test (`does not report an override when only key order differs`) to `src/test-kernel/tools/ToolRegistryAliases.vitest.ts`; verified it **fails** against the pre-fix `JSON.stringify` implementation and **passes** with the fix
- `npx vitest run src/test-kernel/tools` (full directory) — 727/727 tests passed

---
_Generated by [Claude Code](https://claude.ai/code/session_014tWfn64QKehb9ZzPswrKZa)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single comparison primitive swap in tool resolution with no API or security surface change; behavior only affects when override warnings fire.
> 
> **Overview**
> **Fixes false “override” warnings** when a declared tool’s `description` or `parameters` match the registry contract but object key order differs.
> 
> `differsFrom()` in `registry.ts` now compares via `stableStringify` from `fast-json-stable-stringify` instead of `JSON.stringify`, so inherited or re-built definitions are not treated as overriding the registered contract.
> 
> A regression test in `ToolRegistryAliases.vitest.ts` reverses `parameters` key order and asserts no warning is emitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66b303bdd24e6a6c67d8725ca06677a5442949ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->