### PR TITLE
fix(progress-view): stop hiding the agent name for a not-yet-resolved stream

### DIFF
--- a/packages/extension/src/progressView/frontend/utils.ts
+++ b/packages/extension/src/progressView/frontend/utils.ts
@@ -7,11 +7,14 @@ import type { StreamTabInfo } from '@shared/schemas';
  * `StreamTabInfo.label` is guaranteed non-empty by `buildStreamTabInfo()`
  * (`src/controllers/session/streamTabInfo.ts`) — this function exists so no
  * call site is tempted to add its own `?? info.name` / `?? streamId`
- * fallback. `.name` and `StreamTabId` are the opaque `agent#executionId`
- * handle (`src/agent/runtime/streamTab.ts`) and must never reach the user as
- * display text. Returns undefined when there's no entry to read from (e.g. a
- * lookup by id came back empty because that stream's tab was evicted) —
- * callers decide their own placeholder or omit the label entirely.
+ * fallback on top of it. `.label` itself may still equal the stream's own
+ * opaque id for a stream whose identity hasn't resolved yet — deliberately:
+ * that id's prefix already is the clean agent name (`getStreamTabId()`,
+ * `src/agent/runtime/streamTab.ts`), so it's the best available label, not a
+ * fallback to avoid. Returns undefined only when there's no entry to read
+ * from at all (e.g. a lookup by id came back empty because that stream's
+ * tab was evicted) — callers decide their own placeholder or omit the label
+ * entirely.
  */
 export function streamDisplayLabel(info: Pick<StreamTabInfo, 'label'>): string;
 export function streamDisplayLabel(

--- a/src/controllers/session/streamTabInfo.ts
+++ b/src/controllers/session/streamTabInfo.ts
@@ -33,14 +33,17 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   const { identity, config } = metadata;
 
   // A stream whose identity hasn't resolved yet (no `run.start` seen, no
-  // durable record hydrated) has nothing readable to show — never fall back
-  // to `streamId`, the opaque `agent#executionId` handle (never parsed back;
-  // see `src/agent/runtime/streamTab.ts`), which every consumer of `label`
-  // (this file's callers, `streamDisplayLabel()`, the desktop command
-  // palette, …) trusts as display-safe.
+  // durable record hydrated) has nothing readable to show. `streamId` is the
+  // opaque `agent#executionId` handle (never parsed back; see
+  // `src/agent/runtime/streamTab.ts`) — but it's what we have, and its
+  // prefix (minted by `getStreamTabId()`) already *is* the clean agent name,
+  // so it reads as e.g. "review#a4c8939992cf" rather than pure noise. A
+  // generic placeholder here (tried in #9861, reverted) is strictly worse:
+  // it hides the one piece of real information — which agent this is — that
+  // the id string still carries even before identity resolves.
   const identityName = identity
     ? getCleanAgentName(runIdentityName(identity))
-    : 'Pending session';
+    : streamId;
 
   // Surface the full untruncated command for process streams (description
   // is capped for tab/tooltip rendering).

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -1090,8 +1090,7 @@ describe('ProgressBackend', () => {
     const infos = buildStreamInfos(backend.state);
     expect(infos.map((info) => info.name)).toContain(stream);
     expect(infos.find((info) => info.name === stream)).toMatchObject({
-      // Pending (no identity yet) — never the raw `agent#executionId` id.
-      label: 'Pending session',
+      label: stream,
       agentCategory: AgentCategory.ToolUse,
       isRemote: true,
       executionId,

--- a/src/test-kernel/progressView/streamInfoUtils.vitest.ts
+++ b/src/test-kernel/progressView/streamInfoUtils.vitest.ts
@@ -65,8 +65,9 @@ describe('buildStreamTabInfo', () => {
       },
     });
 
-    // Never the raw `agent#executionId` handle — see streamTabInfo.ts.
-    expect(info.label).toBe('Pending session');
+    // The id's own prefix already is the clean agent name — see
+    // streamTabInfo.ts — so it's the label until identity resolves.
+    expect(info.label).toBe(CHILD_STREAM_ID);
     expect(info.identity).toBeUndefined();
     expect(info.agentCategory).toBeUndefined();
   });


### PR DESCRIPTION
## What broke

#9861 (merged) replaced the pending-stream label fallback (`identityName = identity ? ... : streamId`) with a generic `'Pending session'` placeholder, on the reasoning that `streamId` is an opaque handle that shouldn't reach the user as display text.

In practice this was a regression, reported live against `main`: `streamId` is minted as `${cleanAgentName}#${executionId}` (`getStreamTabId()`), so its prefix already *is* the clean agent name — the pre-#9861 fallback read as e.g. `review#a4c8939992cf`, readable if imperfect. The generic placeholder hides that one piece of real information entirely, and — worse — the placeholder text was observed leaking into other generated strings that interpolate the label (e.g. an internal execution-view description rendered as `"executions — view: Pending session/conversation"`), for a session that had already completed real work (6/6 todos, tool calls, a written summary) — not an about-to-start run the word "pending" would fairly describe.

## Fix

Reverted the `identityName` fallback in `buildStreamTabInfo()` (`src/controllers/session/streamTabInfo.ts`) back to `streamId`, softened the `streamDisplayLabel()` doc comment in `progressView/frontend/utils.ts` that had overstated the guarantee, and restored the two kernel test assertions #9861 had changed.

Everything else from #9861 is unaffected: the `streamDisplayLabel()` consolidation itself, the agent-name-visible Sessions row, the genuine eviction-case "Parent session" placeholder (`StreamHeader.ts`'s `renderParentLink()`, which is a different code path — a stream missing entirely from `streamById`, not a stream present but not-yet-identified), and the title-duplication guard all stay as they were.

## Verification

- `npm run typecheck` (extension package) — clean
- `npx eslint` / `npx prettier --check` on touched files — clean
- `src/test-kernel/progressView` (56 files, 469 tests) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-label fallback only in progress view tab metadata and docs; no auth, persistence, or runtime behavior changes.
> 
> **Overview**
> Reverts the #9861 regression where pending stream tabs showed a generic **"Pending session"** label instead of the stream id.
> 
> **`buildStreamTabInfo()`** again uses **`streamId`** when run identity is not yet available. That id is minted as `cleanAgentName#executionId`, so labels like `review#a4c8939992cf` still expose which agent the tab is for. The generic placeholder hid that and could leak into other strings that interpolate the label.
> 
> **`streamDisplayLabel()`** documentation is updated to say labels may equal the opaque id pre-resolution (intentional, not a bug) and that undefined only means no tab entry (e.g. eviction).
> 
> Kernel tests for pending-tab labeling are restored to expect **`streamId`** rather than **"Pending session"**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df550ca6410a8627542793e8be2d2b43a77c040b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->