### PR TITLE
refactor: dedupe settings write path, CLI transcript entries, and ExecutionsTool file reads

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -392,6 +392,37 @@ function computeFinalized(
   );
 }
 
+/**
+ * Fields every {@link ConversationEntry} shares, regardless of role: the
+ * source identity plus the two spreads (`messageType`, `settlementSeqNo`)
+ * that must stay absent — not merely `undefined` — when the source entry
+ * doesn't carry them, matching {@link ConversationEntry}'s optional-key shape.
+ */
+function baseLogEntryFields<R extends ConversationEntry['role']>(
+  entry: StreamLogEntry,
+  role: R,
+  text: string,
+) {
+  return {
+    id: entry.id,
+    sourceSeqNo: entry.seqNo,
+    role,
+    text,
+    ...(entry.messageType ? { messageType: entry.messageType } : {}),
+    ...(entry.settlementSeqNo !== undefined
+      ? { settlementSeqNo: entry.settlementSeqNo }
+      : {}),
+  };
+}
+
+/** Reuses `prev` when `next` is content-equal, so an unchanged row keeps identity. */
+function dedupeEntry(
+  prev: ConversationEntry | undefined,
+  next: ConversationEntry,
+): ConversationEntry {
+  return prev && entriesEqual(prev, next) ? prev : next;
+}
+
 function renderLogEntry(
   entry: StreamLogEntry,
   prev: ConversationEntry | undefined,
@@ -401,18 +432,11 @@ function renderLogEntry(
     const images = projectFileListImages(entry.data);
     if (images.length === 0) return null;
     const next: ConversationEntry = {
-      id: entry.id,
-      sourceSeqNo: entry.seqNo,
-      role: 'media',
-      text: '',
-      messageType: MESSAGE_TYPES.FILE_LIST,
+      ...baseLogEntryFields(entry, 'media', ''),
       finalized: true,
-      ...(entry.settlementSeqNo !== undefined
-        ? { settlementSeqNo: entry.settlementSeqNo }
-        : {}),
       images,
     };
-    return prev && entriesEqual(prev, next) ? prev : next;
+    return dedupeEntry(prev, next);
   }
 
   if (entry.messageType === MESSAGE_TYPES.TOOL_USE) {
@@ -433,15 +457,8 @@ function renderLogEntry(
     // `<Static>` (which is append-only). Inherit the prior flag so a sync
     // tick can't roll an already-promoted entry back to false.
     const next: ConversationEntry = {
-      id: entry.id,
-      sourceSeqNo: entry.seqNo,
-      role: 'tool',
-      text: '',
-      ...(entry.messageType ? { messageType: entry.messageType } : {}),
+      ...baseLogEntryFields(entry, 'tool', ''),
       finalized: computeFinalized(entry, prev),
-      ...(entry.settlementSeqNo !== undefined
-        ? { settlementSeqNo: entry.settlementSeqNo }
-        : {}),
       toolUse,
     };
     if (prev && entriesEqual(prev, next)) {
@@ -462,18 +479,11 @@ function renderLogEntry(
     if (!parsed.success) return null;
     const call = parsed.data;
     const next: ConversationEntry = {
-      id: entry.id,
-      sourceSeqNo: entry.seqNo,
-      role: 'workflowTask',
-      text: formatWorkflowCallLine(call),
-      messageType: entry.messageType,
+      ...baseLogEntryFields(entry, 'workflowTask', formatWorkflowCallLine(call)),
       finalized: computeFinalized(entry, prev),
-      ...(entry.settlementSeqNo !== undefined
-        ? { settlementSeqNo: entry.settlementSeqNo }
-        : {}),
       task: call,
     };
-    return prev && entriesEqual(prev, next) ? prev : next;
+    return dedupeEntry(prev, next);
   }
 
   // A phase header is immutable at GROUP_START and therefore printable
@@ -490,20 +500,13 @@ function renderLogEntry(
     const phaseIndex = phaseData.index ?? prevPhase?.phaseIndex;
     const phaseTotal = phaseData.total ?? prevPhase?.phaseTotal;
     const next: ConversationEntry = {
-      id: entry.id,
-      sourceSeqNo: entry.seqNo,
-      role: 'phase',
-      text: phaseLabel,
-      ...(entry.messageType ? { messageType: entry.messageType } : {}),
+      ...baseLogEntryFields(entry, 'phase', phaseLabel),
       finalized: true,
-      ...(entry.settlementSeqNo !== undefined
-        ? { settlementSeqNo: entry.settlementSeqNo }
-        : {}),
       phaseLabel,
       ...(phaseIndex !== undefined ? { phaseIndex } : {}),
       ...(phaseTotal !== undefined ? { phaseTotal } : {}),
     };
-    return prev && entriesEqual(prev, next) ? prev : next;
+    return dedupeEntry(prev, next);
   }
 
   // Workflow run/round/session lifecycle rows are projected into `taskGroups`,
@@ -535,14 +538,7 @@ function renderLogEntry(
   // change after they appear, so they finalize immediately.
   const finalized = computeFinalized(entry, prev, role !== 'assistant');
   const next: ConversationEntry = {
-    id: entry.id,
-    sourceSeqNo: entry.seqNo,
-    role,
-    text: renderedText,
-    ...(entry.messageType ? { messageType: entry.messageType } : {}),
-    ...(entry.settlementSeqNo !== undefined
-      ? { settlementSeqNo: entry.settlementSeqNo }
-      : {}),
+    ...baseLogEntryFields(entry, role, renderedText),
     ...(assistantTranscript !== undefined &&
     hasIncompleteEmbeddedSubagentFollowup(assistantTranscript)
       ? { pendingEmbeddedSubagentFollowup: true }
@@ -550,7 +546,7 @@ function renderLogEntry(
     finalized,
   };
   if (!isRenderableTranscriptEntry(next)) return null;
-  return prev && entriesEqual(prev, next) ? prev : next;
+  return dedupeEntry(prev, next);
 }
 
 // An entry is "settled" once its content can no longer change, so it is

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -479,7 +479,11 @@ function renderLogEntry(
     if (!parsed.success) return null;
     const call = parsed.data;
     const next: ConversationEntry = {
-      ...baseLogEntryFields(entry, 'workflowTask', formatWorkflowCallLine(call)),
+      ...baseLogEntryFields(
+        entry,
+        'workflowTask',
+        formatWorkflowCallLine(call),
+      ),
       finalized: computeFinalized(entry, prev),
       task: call,
     };

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -12,13 +12,10 @@ import { platform } from '@platform/platform';
 import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
-  TEXRA_APPROVAL_POLICY_CONFIG_KEY,
-  readPersistedTexraApprovalPolicy,
-  type TexraApprovalPolicy,
-} from '@shared/approvalPolicy';
-import { resetSetting, writeSetting } from '@shared/config/settingsAccess';
-import type { SettingsViewSnapshot } from '@shared/schemas/stateSettings';
-import { resolveStateSettingWrite } from '@shared/settingsView/handlers/stateSettingWrite';
+  applyStateSettingUpdate,
+  postStateSettingSnapshot,
+  type SettingsSnapshotPosters,
+} from '@shared/settingsView/handlers/stateSettingWrite';
 import {
   dispatchSettingsViewInbound,
   SettingsViewInboundMessageSchema,
@@ -35,7 +32,6 @@ import {
   GITHUB_TOKEN_STORAGE_KEY,
   resolveGitHubTokenSource,
 } from '@tools/github/githubAuth';
-import { assertNever } from '@utils/core';
 import { StorageFS } from '@utils/files';
 import {
   applyGitAuthorSettings,
@@ -242,6 +238,15 @@ export function createDesktopSettingsIpc(
     await options.agentSettingsController.refreshCatalogData();
   }
 
+  const stateSettingSnapshotPosters: SettingsSnapshotPosters = {
+    'agent-skills': postAgentSkillsSettings,
+    approval: postApprovalSettings,
+    'git-author': () => postGitAuthorSettings(applyCurrentGitAuthorSettings()),
+    latex: () => options.toolingSettingsController.postLatexConfigValues(),
+    'multi-agent': postReliabilityAndOrchestrationSettings,
+    telemetry: postTelemetrySettings,
+  };
+
   /**
    * Generic write path for catalog-backed settings-view rows.
    */
@@ -249,69 +254,33 @@ export function createDesktopSettingsIpc(
     key: string,
     value: unknown,
   ): Promise<void> {
-    const write = resolveStateSettingWrite(key, value);
-    if (!write) return;
-    if (write.kind === 'rejected') {
-      options.ui.onError(write.error);
+    const result = await applyStateSettingUpdate(key, value, {
+      stores: { config: options.config, workspaceState, globalState },
+      onApprovalPolicyChanged: (policy) =>
+        options.session.setApprovalPolicy(policy),
+    });
+    if (result.kind === 'ignored') return;
+    if (result.kind === 'rejected') {
+      options.ui.onError(result.error);
       await options.ui.showErrorMessage(
         formatError(
-          `Invalid value for "${write.entry.title ?? write.entry.key}"`,
-          write.error,
+          `Invalid value for "${result.entry.title ?? result.entry.key}"`,
+          result.error,
         ),
       );
-      postStateSettingSnapshot(write.entry.settingsViewSnapshot);
-      return;
-    }
-    const stores = { config: options.config, workspaceState, globalState };
-    try {
-      await (write.kind === 'reset'
-        ? resetSetting(write.entry, stores)
-        : writeSetting(write.entry, write.value, stores));
-      if (write.entry.key === TEXRA_APPROVAL_POLICY_CONFIG_KEY) {
-        options.session.setApprovalPolicy(
-          write.kind === 'reset'
-            ? readPersistedTexraApprovalPolicy((key, fallback) =>
-                options.config.get(key, fallback),
-              )
-            : (write.value as TexraApprovalPolicy),
-        );
-      }
-    } catch (error) {
-      options.ui.onError(error);
+    } else if (result.kind === 'failed') {
+      options.ui.onError(result.error);
       await options.ui.showErrorMessage(
         formatError(
-          `Failed to update "${write.entry.title ?? write.entry.key}"`,
-          error,
+          `Failed to update "${result.entry.title ?? result.entry.key}"`,
+          result.error,
         ),
       );
-    } finally {
-      postStateSettingSnapshot(write.entry.settingsViewSnapshot);
     }
-  }
-
-  function postStateSettingSnapshot(snapshot: SettingsViewSnapshot): void {
-    switch (snapshot) {
-      case 'agent-skills':
-        postAgentSkillsSettings();
-        break;
-      case 'approval':
-        postApprovalSettings();
-        break;
-      case 'git-author':
-        postGitAuthorSettings(applyCurrentGitAuthorSettings());
-        break;
-      case 'latex':
-        options.toolingSettingsController.postLatexConfigValues();
-        break;
-      case 'multi-agent':
-        postReliabilityAndOrchestrationSettings();
-        break;
-      case 'telemetry':
-        postTelemetrySettings();
-        break;
-      default:
-        assertNever(snapshot, 'Unhandled settings-view snapshot');
-    }
+    await postStateSettingSnapshot(
+      result.entry.settingsViewSnapshot,
+      stateSettingSnapshotPosters,
+    );
   }
 
   function runAsync(work: Promise<void>): void {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -61,15 +61,12 @@ import {
 } from '@platform/defaults/workspaceStorage';
 import { revealProgressStream } from '@progressView/progressNavigation';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import {
-  TEXRA_APPROVAL_POLICY_CONFIG_KEY,
-  readPersistedTexraApprovalPolicy,
-  type TexraApprovalPolicy,
-} from '@shared/approvalPolicy';
-import { resetSetting, writeSetting } from '@shared/config/settingsAccess';
 import { INCLUDED_ACCESS, OWN_API_KEYS } from '@shared/copy/modelAccess';
 import type { SettingsViewSnapshot } from '@shared/schemas/stateSettings';
-import { resolveStateSettingWrite } from '@shared/settingsView/handlers/stateSettingWrite';
+import {
+  applyStateSettingUpdate,
+  postStateSettingSnapshot as dispatchStateSettingSnapshot,
+} from '@shared/settingsView/handlers/stateSettingWrite';
 import {
   dispatchSettingsViewInbound,
   type SettingsViewInboundHandlerRegistry,
@@ -93,7 +90,7 @@ import {
 } from '@tools/toolAvailability';
 import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
 import { StorageFS, WorkspaceFS } from '@utils/files';
-import { assertNever, debounce } from '@utils/core';
+import { debounce } from '@utils/core';
 import { hasExtension } from '@utils/core/pathCore';
 import {
   buildGitAuthorSettingsMessage,
@@ -714,91 +711,66 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
    * Generic write path for catalog-backed settings-view rows.
    */
   private async updateStateSetting(key: string, value: unknown): Promise<void> {
-    const write = resolveStateSettingWrite(key, value);
-    if (!write) return;
-    if (write.kind === 'rejected') {
+    const result = await applyStateSettingUpdate(key, value, {
+      stores: {
+        config: platform().config,
+        workspaceState: workspaceSM,
+        globalState: globalSM,
+      },
+      requiresOpenWorkspace: (entry) =>
+        entry.configTarget !== 'global' && !WorkspaceFS.getPath(),
+      onApprovalPolicyChanged: (policy) => {
+        defaultSession().setApprovalPolicy(policy);
+        refreshApprovalPolicyTooltip();
+      },
+    });
+    if (result.kind === 'ignored') return;
+    if (result.kind === 'rejected') {
       await showLoggedErrorMessage(
         this.channel,
-        `Invalid value for “${write.entry.title ?? write.entry.key}”`,
-        write.error,
+        `Invalid value for “${result.entry.title ?? result.entry.key}”`,
+        result.error,
       );
-      await this.postStateSettingSnapshot(write.entry.settingsViewSnapshot);
-      return;
-    }
-    if (
-      write.entry.store === 'config' &&
-      write.entry.configTarget !== 'global' &&
-      !WorkspaceFS.getPath()
-    ) {
+    } else if (result.kind === 'workspace-required') {
       void showLoggedInfoMessage(
         this.channel,
-        `Open a workspace folder before changing the “${write.entry.title ?? write.entry.key}” setting.`,
+        `Open a workspace folder before changing the “${result.entry.title ?? result.entry.key}” setting.`,
       );
-      await this.postStateSettingSnapshot(write.entry.settingsViewSnapshot);
-      return;
-    }
-    const stores = {
-      config: platform().config,
-      workspaceState: workspaceSM,
-      globalState: globalSM,
-    };
-    try {
-      await (write.kind === 'reset'
-        ? resetSetting(write.entry, stores)
-        : writeSetting(write.entry, write.value, stores));
-      if (write.entry.key === TEXRA_APPROVAL_POLICY_CONFIG_KEY) {
-        defaultSession().setApprovalPolicy(
-          write.kind === 'reset'
-            ? readPersistedTexraApprovalPolicy((key, fallback) =>
-                platform().config.get(key, fallback),
-              )
-            : (write.value as TexraApprovalPolicy),
-        );
-        refreshApprovalPolicyTooltip();
-      }
-    } catch (error) {
+    } else if (result.kind === 'failed') {
       await showLoggedErrorMessage(
         this.channel,
-        `Failed to update “${write.entry.title ?? write.entry.key}”`,
-        error,
+        `Failed to update “${result.entry.title ?? result.entry.key}”`,
+        result.error,
       );
     }
-    await this.postStateSettingSnapshot(write.entry.settingsViewSnapshot);
+    await this.postStateSettingSnapshot(result.entry.settingsViewSnapshot);
   }
 
   private async postStateSettingSnapshot(
     snapshot: SettingsViewSnapshot,
   ): Promise<void> {
-    switch (snapshot) {
-      case 'agent-skills':
-        await this.withActiveWebview((w) => this.sendAgentSkillsSettings(w));
-        break;
-      case 'approval':
-        await this.withActiveWebview((w) => this.sendApprovalSettings(w));
-        break;
-      case 'git-author': {
+    await dispatchStateSettingSnapshot(snapshot, {
+      'agent-skills': () =>
+        this.withActiveWebview((w) => this.sendAgentSkillsSettings(w)),
+      approval: () =>
+        this.withActiveWebview((w) => this.sendApprovalSettings(w)),
+      'git-author': () => {
         const settings = applyGitAuthorConfig();
-        await this.withActiveWebview((w) =>
+        return this.withActiveWebview((w) =>
           this.sendGitAuthorSettings(w, settings),
         );
-        break;
-      }
-      case 'latex':
-        await this.withActiveWebview((w) =>
+      },
+      latex: () =>
+        this.withActiveWebview((w) =>
           this.latexHandlers.sendLatexConfigValues(w),
-        );
-        break;
-      case 'multi-agent':
-        await this.withActiveWebview((w) =>
+        ),
+      'multi-agent': () =>
+        this.withActiveWebview((w) =>
           this.sendReliabilityAndOrchestrationSettings(w),
-        );
-        break;
-      case 'telemetry':
-        await this.withActiveWebview((w) => this.sendTelemetrySettings(w));
-        break;
-      default:
-        assertNever(snapshot, 'Unhandled settings-view snapshot');
-    }
+        ),
+      telemetry: () =>
+        this.withActiveWebview((w) => this.sendTelemetrySettings(w)),
+    });
   }
 
   // ============================================================

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -717,8 +717,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         workspaceState: workspaceSM,
         globalState: globalSM,
       },
-      requiresOpenWorkspace: (entry) =>
-        entry.configTarget !== 'global' && !WorkspaceFS.getPath(),
+      // The shared function already gates this hook on
+      // `configTarget !== 'global'`; this checks only the workspace half.
+      requiresOpenWorkspace: () => !WorkspaceFS.getPath(),
       onApprovalPolicyChanged: (policy) => {
         defaultSession().setApprovalPolicy(policy);
         refreshApprovalPolicyTooltip();

--- a/src/shared/settingsView/handlers/stateSettingWrite.ts
+++ b/src/shared/settingsView/handlers/stateSettingWrite.ts
@@ -9,7 +9,18 @@
 //   - only catalog rows tagged for a settings-view snapshot are writable.
 
 import {
+  TEXRA_APPROVAL_POLICY_CONFIG_KEY,
+  readPersistedTexraApprovalPolicy,
+  type TexraApprovalPolicy,
+} from '@shared/approvalPolicy';
+import {
+  resetSetting,
+  writeSetting,
+  type SettingsStores,
+} from '@shared/config/settingsAccess';
+import {
   settingsViewSettingByKey,
+  type SettingsViewSnapshot,
   type SettingsViewStateSettingEntry,
 } from '@shared/schemas/stateSettings';
 
@@ -51,4 +62,96 @@ export function resolveStateSettingWrite(
   const parsed = entry.schema.safeParse(value);
   if (!parsed.success) return { kind: 'rejected', entry, error: parsed.error };
   return { kind: 'write', entry, value: parsed.data };
+}
+
+/** Outcome of {@link applyStateSettingUpdate}, for host-specific UI feedback. */
+export type StateSettingUpdateResult =
+  | { readonly kind: 'ignored' }
+  | {
+      readonly kind: 'rejected';
+      readonly entry: SettingsViewStateSettingEntry;
+      readonly error: Error;
+    }
+  | {
+      readonly kind: 'workspace-required';
+      readonly entry: SettingsViewStateSettingEntry;
+    }
+  | { readonly kind: 'applied'; readonly entry: SettingsViewStateSettingEntry }
+  | {
+      readonly kind: 'failed';
+      readonly entry: SettingsViewStateSettingEntry;
+      readonly error: unknown;
+    };
+
+export interface StateSettingUpdatePorts {
+  readonly stores: SettingsStores;
+  /**
+   * Extension-only guard: a workspace-target config write needs an open
+   * workspace folder. Hosts without that constraint (desktop, CLI) omit this.
+   */
+  readonly requiresOpenWorkspace?: (
+    entry: SettingsViewStateSettingEntry,
+  ) => boolean;
+  /** Applies the approval-policy side effect when that setting changes. */
+  readonly onApprovalPolicyChanged?: (policy: TexraApprovalPolicy) => void;
+}
+
+/**
+ * Host-neutral write path for a generic `UPDATE_STATE_SETTING` message:
+ * resolve, guard, persist, and apply the approval-policy side effect. Callers
+ * own all UI feedback and the outbound snapshot rebroadcast — this performs
+ * only the decision and the write.
+ */
+export async function applyStateSettingUpdate(
+  key: string,
+  value: unknown,
+  ports: StateSettingUpdatePorts,
+): Promise<StateSettingUpdateResult> {
+  const write = resolveStateSettingWrite(key, value);
+  if (!write) return { kind: 'ignored' };
+  if (write.kind === 'rejected') {
+    return { kind: 'rejected', entry: write.entry, error: write.error };
+  }
+  if (
+    write.entry.store === 'config' &&
+    write.entry.configTarget !== 'global' &&
+    ports.requiresOpenWorkspace?.(write.entry)
+  ) {
+    return { kind: 'workspace-required', entry: write.entry };
+  }
+  try {
+    await (write.kind === 'reset'
+      ? resetSetting(write.entry, ports.stores)
+      : writeSetting(write.entry, write.value, ports.stores));
+    if (write.entry.key === TEXRA_APPROVAL_POLICY_CONFIG_KEY) {
+      ports.onApprovalPolicyChanged?.(
+        write.kind === 'reset'
+          ? readPersistedTexraApprovalPolicy((k, fallback) =>
+              ports.stores.config.get(k, fallback),
+            )
+          : (write.value as TexraApprovalPolicy),
+      );
+    }
+    return { kind: 'applied', entry: write.entry };
+  } catch (error) {
+    return { kind: 'failed', entry: write.entry, error };
+  }
+}
+
+/**
+ * Rebroadcast posters for every {@link SettingsViewSnapshot}. A `Record` (not a
+ * `switch`) so a new snapshot variant fails the object-literal check at both
+ * call sites instead of silently falling through a `default`.
+ */
+export type SettingsSnapshotPosters = Record<
+  SettingsViewSnapshot,
+  () => void | Promise<void>
+>;
+
+/** Rebroadcasts the settings-view snapshot a state-setting write belongs to. */
+export async function postStateSettingSnapshot(
+  snapshot: SettingsViewSnapshot,
+  posters: SettingsSnapshotPosters,
+): Promise<void> {
+  await posters[snapshot]();
 }

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -36,6 +36,7 @@ import {
 } from '@agent/runtime/RunContext';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import * as logger from '@logger/logUtils';
+import type { FileStat } from '@platform/interfaces';
 import { platform } from '@platform/platform';
 import {
   ExecutionIdSchema,
@@ -1076,21 +1077,10 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       throw new ToolError(`File not found: ${displayPath}`);
     }
 
-    const stats = await StorageFS.stat(fullPath);
-    if (isDirectory(stats.type)) {
-      throw new ToolError(
-        `Path is a directory: ${displayPath}. Use without trailing path to list.`,
-      );
-    }
-
-    const content = await StorageFS.read(fullPath);
-    const lines = splitContentLines(content);
-
-    return formatFileView({
-      path: displayPath,
-      lines,
+    return readFileContent(StorageFS, fullPath, {
+      directoryErrorPath: displayPath,
+      resultPath: displayPath,
       viewRange,
-      maxLines: Infinity,
     });
   }
 
@@ -1163,19 +1153,51 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       );
     }
 
-    const stats = await AbsoluteFS.stat(resolved.absolutePath);
-    if (isDirectory(stats.type)) {
-      throw new ToolError(
-        `Path is a directory: /executions/${executionId}/workspace-files/${filePath}. Use without trailing path to list.`,
-      );
-    }
-
-    const content = await AbsoluteFS.read(resolved.absolutePath);
-    return formatFileView({
-      path: `/executions/${executionId}/workspace-files/${resolved.path}`,
-      lines: splitContentLines(content),
+    return readFileContent(AbsoluteFS, resolved.absolutePath, {
+      directoryErrorPath: `/executions/${executionId}/workspace-files/${filePath}`,
+      resultPath: `/executions/${executionId}/workspace-files/${resolved.path}`,
       viewRange,
-      maxLines: Infinity,
     });
   }
+}
+
+/**
+ * Shared stat → directory-guard → read → format tail for `readFile` and
+ * `readWorkspaceFile`, which differ only in which FS backend resolved the
+ * path. `directoryErrorPath` and `resultPath` can differ (a workspace-file
+ * read reports the raw requested path on error but the canonical resolved
+ * path on success).
+ */
+interface FileBackend {
+  stat: (target: string) => Promise<FileStat>;
+  read: (target: string) => Promise<string>;
+}
+
+async function readFileContent(
+  fs: FileBackend,
+  fullPath: string,
+  {
+    directoryErrorPath,
+    resultPath,
+    viewRange,
+  }: {
+    directoryErrorPath: string;
+    resultPath: string;
+    viewRange: [number, number] | undefined;
+  },
+): Promise<ToolResult> {
+  const stats = await fs.stat(fullPath);
+  if (isDirectory(stats.type)) {
+    throw new ToolError(
+      `Path is a directory: ${directoryErrorPath}. Use without trailing path to list.`,
+    );
+  }
+
+  const content = await fs.read(fullPath);
+  return formatFileView({
+    path: resultPath,
+    lines: splitContentLines(content),
+    viewRange,
+    maxLines: Infinity,
+  });
 }


### PR DESCRIPTION
## Summary

Ran a scan for the largest ad-hoc/duplicated areas in the codebase, then dug into every top finding, implementing the ones that survived close inspection and declining (with evidence) the ones that didn't. Net result: 3 small, verified, behavior-preserving dedups landed; several larger-looking "opportunities" turned out to be well-factored code that a surface-level scan mistook for duplication.

**Landed:**
1. **Settings write/snapshot dispatch** (`src/shared/settingsView/handlers/stateSettingWrite.ts`) — extension and desktop each hand-rolled the same `UPDATE_STATE_SETTING` write-decision chain (resolve → workspace-guard → persist → approval-policy side effect) and the same 6-case snapshot-rebroadcast `switch`. Both now delegate to shared `applyStateSettingUpdate`/`postStateSettingSnapshot`.
2. **CLI transcript entry construction** (`packages/cli/src/chat/tui/state/subscribeStreamLog.ts`) — `renderLogEntry` built a `ConversationEntry` five times with identical field-spread boilerplate and the identical `prev && entriesEqual(prev, next) ? prev : next` dedup check four times. Collapsed into `baseLogEntryFields`/`dedupeEntry`.
3. **ExecutionsTool file reads** (`src/tools/ExecutionsTool.ts`) — `readFile`/`readWorkspaceFile` repeated the same stat → directory-guard → read → format tail, differing only in FS backend. Extracted `readFileContent()` behind a minimal `FileBackend` port, preserving the one real behavioral asymmetry (the workspace variant shows the raw requested path on a directory error but the resolved path on success).

**Investigated and declined** (each checked against actual code/tests, not just the scan's description):
- **Host settings/credential/history handlers "duplicated" across extension+desktop** (~1,200-1,500 lines per the initial estimate) — turned out to already be shared via `@controllers/settingsView/*` and `@shared/settingsView/handlers/*`; the only real duplicate was #1 above. The remaining per-host code is legitimate UI glue (VS Code dialogs vs Electron IPC).
- **Provider-region "China endpoint" toggles "scattered" across 3+ files** — already a single `ProviderSettingDef` registry in `providers.ts`, reused by reference from `stateSettings.ts` and `ConfigForm.tsx`, not copy-pasted.
- **CLI status-bar candidate-ladder "declarative priority list" rewrite** — verified the existing 14-row fallback ladder is a hand-tuned lookup table, not a uniform priority-drop sequence (with no special flags active it jumps from a 5-hint row straight to a 2-hint row, skipping widths a generic per-item dropper would introduce). Collapsing it would risk changing which key hints show at which terminal widths.
- **GitHub `PRPollingSource`/`RepoPollingSource` `pollOne` "god-method" split** — the two files' bodies implement genuinely different business logic (ETag-based per-PR tracking + CI/annotations vs since-cursor repo-wide polling + merge-conflict probing) wrapped around a thin shared shape already owned by `PollingSourceBase`. Both carry extensive prose-documented ordering invariants (ETag-advance timing, deferred cache commits) with thin test coverage (~12 tests, zero for `RepoPollingSource`) — restructuring risks silently breaking live GitHub event delivery.
- **`modelHandlers` `createResponseImpl` "orchestration skeleton" template method** — the 4 provider handlers share a narrative arc (build → count → compact → dispatch) but each phase's actual logic diverges completely (Anthropic cache-slot/PDF handling, Google's stateful chain-invalidation state machine, OpenAI's background-resume/compaction-cache staleness detection). A template method would need 10+ leaky provider-specific hooks — worse than 4 well-documented functions.
- **`compactConversation` wrapper duplication** — only 2 of the 3 claimed handlers share a literal 2-line closure; Google's message type is structurally incompatible. Not worth a generic abstraction.
- **`toolConversion.ts` per-provider duplication** — the file is already the shared consolidation point; per-provider exports encode real API-shape differences (OpenAI Responses vs Anthropic tool blocks vs Gemini's stricter OpenAPI subset).
- **`block.type`/`event.type` switch-family "dispatch table" consolidation** — the two files sharing block-type labels (`conversationFormat.ts`, `normalizeConversation.ts`) are deliberate, differently-typed projections (truncated display string vs structured `ExportNode`) over the same tagged union, already cross-referenced via an explicit maintainer comment on both sides. The `event.type` family (9 files) each switches over its own distinct event union into differently-shaped method calls — ordinary per-domain dispatch, not copy-pasted logic.

## Issue acceptance gates

No linked issue — proactive refactor from a scheduled code-quality scan. Gate: land every dedup that's genuinely safe and mechanical; leave well-factored code alone rather than force abstractions for surface-level shape similarity.

## Single source of truth

`applyStateSettingUpdate`/`postStateSettingSnapshot` (`stateSettingWrite.ts`) own the write decision and snapshot dispatch. `baseLogEntryFields`/`dedupeEntry` (`subscribeStreamLog.ts`) own the common `ConversationEntry` field shape and reuse check. `readFileContent`/`FileBackend` (`ExecutionsTool.ts`) own the stat→read→format tail for execution file reads.

## Duplication and abstraction budget

Each new helper has exactly the caller count that motivated it (2, 5, and 2 respectively) — no hypothetical-future generalization. Declined items are documented above specifically to avoid re-litigating them: several looked like duplication from file-level pattern matching but encode genuinely different logic, output types, or intentional cross-file documentation of a shared-tag/divergent-output relationship.

## Net elements (R6)

- Files changed: 4 (`stateSettingWrite.ts`, `SettingsViewMessageHandler.ts`, `desktopSettingsIpc.ts`, `subscribeStreamLog.ts`) in the first commit set, plus `ExecutionsTool.ts` in the follow-up commit.
- Exported symbols: +5 in `stateSettingWrite.ts` (`StateSettingUpdateResult`, `StateSettingUpdatePorts`, `applyStateSettingUpdate`, `SettingsSnapshotPosters`, `postStateSettingSnapshot`). `readFileContent`/`FileBackend` in `ExecutionsTool.ts` are module-private (not exported) — 2 callers within the same file.
- Diffstat: +219/-179 (settings + CLI), +48/-26 (ExecutionsTool).

## Consumer counts (R8)

`applyStateSettingUpdate`/`postStateSettingSnapshot`: 2 consumers each (extension, desktop) — the same call sites that previously duplicated this logic. `readFileContent`: 2 consumers (`readFile`, `readWorkspaceFile`) in the same file.

## Host impact

Extension: `updateStateSetting` delegates to the shared function via a `requiresOpenWorkspace` port (extension-only guard, preserved exactly — including a redundant `configTarget` check caught and fixed during review).

Desktop: same delegation, omitting the workspace port (desktop never had that guard).

CLI: `renderLogEntry` internal-only change, no interface change.

Neither host: `ExecutionsTool` is host-agnostic (`src/tools/`).

## Scheduled refactoring

None. Every larger item from the original scan was individually investigated in this PR's thread rather than deferred — see "Investigated and declined" above.

## Validation

- `corepack pnpm install`
- `npm run typecheck` — full workspace (workspace, test-kernel, agent, extension, cli, trace-viewer, desktop) — clean, run after every commit
- `npm run lint` — clean
- `npx prettier --check .` — clean (caught and fixed a formatting miss from the first commit via CI)
- `npm run check:dead-code-ratchet` — no new unused files/exports/types
- Full local `src/test-kernel` suite: 8756/8768 passing, 2 pre-existing failures in `ExtensionTexraConfig.vitest.ts` confirmed present identically on unmodified `main` (sandbox `/tmp` ENOENT, unrelated to this diff)
- CI: static checks, build, webview smoke, CLI Windows workflow paths all green on the current head; kernel tests running