### PR TITLE
feat(cli): show configured API keys in Model access menu

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -341,7 +341,16 @@ export function registerBuiltinSlashCommands(options?: {
         availableRows={props.availableRows}
         onSelect={formSelectionHandler<CliModelAccessSelection>({
           action: onModelAccessSelect,
-          onDone: props.onDone,
+          onDone: (value) => {
+            // Selecting "Your own API keys" switches to personal mode and then
+            // opens the API key configuration form so keys can be set in place
+            // instead of requiring a separate `/key` run.
+            if (value.kind === 'api-fallback' && value.apiMode === 'personal') {
+              openCliSlashCommandForm('key', '');
+              return;
+            }
+            props.onDone(value);
+          },
           onError: options?.onError,
           onPersist: props.onPersist,
           echoOnPersist: props.echoOnPersist,

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -1,4 +1,4 @@
-import { API_PROVIDERS, lookupApiKeyOrigin } from '@model/apiProviders';
+import { configuredApiKeyProviders } from '@model/apiProviders';
 import { platform } from '@platform/platform';
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import { OWN_API_KEYS } from '@shared/copy/modelAccess';
@@ -138,11 +138,7 @@ export function formatCliApiStatusActionHint(
 }
 
 async function personalKeyProviders(): Promise<string[]> {
-  const secrets = platform().secrets;
-  const origins = await Promise.all(
-    API_PROVIDERS.map((provider) => lookupApiKeyOrigin(secrets, provider)),
-  );
-  return API_PROVIDERS.filter((_, index) => origins[index] !== 'none');
+  return configuredApiKeyProviders(platform().secrets);
 }
 
 interface CliApiStatus {

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -58,6 +58,8 @@ export interface CliModelAccessStatus {
   readonly grokAccountLabel?: string;
   readonly kimiCodeKeySet?: boolean;
   readonly texraSignedIn?: boolean;
+  /** Display names of providers with configured API keys (e.g. `['DeepSeek']`). */
+  readonly personalKeyProviders?: readonly string[];
 }
 
 interface CliModelAccessItem {
@@ -322,7 +324,9 @@ export function buildCliModelAccessItems(
     {
       value: cliApiFallbackSelection('personal'),
       label: formatCliModelAccessRoute('personal'),
-      description: 'Use keys configured on this computer',
+      description: status?.personalKeyProviders?.length
+        ? `Configured: ${status.personalKeyProviders.join(', ')}`
+        : 'Use keys configured on this computer',
     },
   ];
 }

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -53,12 +53,13 @@ export async function readCliModelAccessStatus(
   apiMode: ApiAccessMode,
 ): Promise<CliModelAccessStatus> {
   const secrets = platform().secrets;
-  const [chatGpt, grok, kimiCodeKeySet, configuredProviders] = await Promise.all([
-    getCodexStatus(),
-    getXaiStatus(),
-    apiKeyExists(secrets, 'kimiCode'),
-    configuredApiKeyProviders(secrets),
-  ]);
+  const [chatGpt, grok, kimiCodeKeySet, configuredProviders] =
+    await Promise.all([
+      getCodexStatus(),
+      getXaiStatus(),
+      apiKeyExists(secrets, 'kimiCode'),
+      configuredApiKeyProviders(secrets),
+    ]);
   const preferences = {
     chatGpt: isPreferCodexSubscription() ? 'on' : 'off',
     grok: isPreferXaiSubscription() ? 'on' : 'off',

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -1,8 +1,9 @@
 import { getCodexStatus } from '@auth/codex';
 import { getXaiStatus, xaiAccountLabel } from '@auth/xai';
 import { codexAccountLabel } from '@auth/codex/codexSessionTypes';
-import { apiKeyExists } from '@model/apiProviders';
+import { API_PROVIDERS, apiKeyExists, lookupApiKeyOrigin } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
+import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import {
   isPreferCodexSubscription,
   setPreferCodexSubscription,
@@ -51,16 +52,23 @@ export function contextForCliModelAccess(
 export async function readCliModelAccessStatus(
   apiMode: ApiAccessMode,
 ): Promise<CliModelAccessStatus> {
-  const [chatGpt, grok, kimiCodeKeySet] = await Promise.all([
+  const secrets = platform().secrets;
+  const [chatGpt, grok, kimiCodeKeySet, keyOrigins] = await Promise.all([
     getCodexStatus(),
     getXaiStatus(),
-    apiKeyExists(platform().secrets, 'kimiCode'),
+    apiKeyExists(secrets, 'kimiCode'),
+    Promise.all(
+      API_PROVIDERS.map((provider) => lookupApiKeyOrigin(secrets, provider)),
+    ),
   ]);
   const preferences = {
     chatGpt: isPreferCodexSubscription() ? 'on' : 'off',
     grok: isPreferXaiSubscription() ? 'on' : 'off',
     kimiCode: getPreferKimiCode() ? 'on' : 'off',
   } as const;
+  const personalKeyProviders = API_PROVIDERS.filter(
+    (_, index) => keyOrigins[index] !== 'none',
+  ).map((provider) => PROVIDER_DISPLAY_NAMES[provider] ?? provider);
   return {
     apiFallback: apiMode,
     preferences,
@@ -69,6 +77,7 @@ export async function readCliModelAccessStatus(
     grokSignedIn: grok.signedIn,
     grokAccountLabel: grok.email,
     kimiCodeKeySet,
+    personalKeyProviders,
   };
 }
 

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -3,7 +3,6 @@ import { getXaiStatus, xaiAccountLabel } from '@auth/xai';
 import { codexAccountLabel } from '@auth/codex/codexSessionTypes';
 import { apiKeyExists, configuredApiKeyProviders } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
-import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import {
   isPreferCodexSubscription,
   setPreferCodexSubscription,
@@ -13,6 +12,7 @@ import {
   setPreferXaiSubscription,
 } from '@model/xai/xaiPreference';
 import { platform } from '@platform/platform';
+import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import { INCLUDED_ACCESS } from '@shared/copy/modelAccess';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import type { ApiAccessMode } from '@shared/schemas/profileViewMessages';

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -1,7 +1,7 @@
 import { getCodexStatus } from '@auth/codex';
 import { getXaiStatus, xaiAccountLabel } from '@auth/xai';
 import { codexAccountLabel } from '@auth/codex/codexSessionTypes';
-import { API_PROVIDERS, apiKeyExists, lookupApiKeyOrigin } from '@model/apiProviders';
+import { apiKeyExists, configuredApiKeyProviders } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import {
@@ -53,22 +53,20 @@ export async function readCliModelAccessStatus(
   apiMode: ApiAccessMode,
 ): Promise<CliModelAccessStatus> {
   const secrets = platform().secrets;
-  const [chatGpt, grok, kimiCodeKeySet, keyOrigins] = await Promise.all([
+  const [chatGpt, grok, kimiCodeKeySet, configuredProviders] = await Promise.all([
     getCodexStatus(),
     getXaiStatus(),
     apiKeyExists(secrets, 'kimiCode'),
-    Promise.all(
-      API_PROVIDERS.map((provider) => lookupApiKeyOrigin(secrets, provider)),
-    ),
+    configuredApiKeyProviders(secrets),
   ]);
   const preferences = {
     chatGpt: isPreferCodexSubscription() ? 'on' : 'off',
     grok: isPreferXaiSubscription() ? 'on' : 'off',
     kimiCode: getPreferKimiCode() ? 'on' : 'off',
   } as const;
-  const personalKeyProviders = API_PROVIDERS.filter(
-    (_, index) => keyOrigins[index] !== 'none',
-  ).map((provider) => PROVIDER_DISPLAY_NAMES[provider] ?? provider);
+  const personalKeyProviders = configuredProviders.map(
+    (provider) => PROVIDER_DISPLAY_NAMES[provider] ?? provider,
+  );
   return {
     apiFallback: apiMode,
     preferences,

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -142,6 +142,19 @@ export async function loadApiKeyStatusMap<const Provider extends ApiProvider>(
   return Object.fromEntries(entries) as Record<Provider, ApiKeyStatus>;
 }
 
+/**
+ * Return provider IDs that have a configured API key (secret or env).
+ * Shared by the CLI status surfaces so the provider-key scan lives in one place.
+ */
+export async function configuredApiKeyProviders(
+  secrets: PlatformSecrets,
+): Promise<ApiProvider[]> {
+  const origins = await Promise.all(
+    API_PROVIDERS.map((provider) => lookupApiKeyOrigin(secrets, provider)),
+  );
+  return API_PROVIDERS.filter((_, index) => origins[index] !== 'none');
+}
+
 /** Get an API key, throwing if not found. See trio doc above. */
 export async function getApiKey(
   secrets: PlatformSecrets,

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.ts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.ts
@@ -37,6 +37,16 @@ vi.mock('@cli/runtime/modelAccessSelection', () => ({
 vi.mock('@model/apiProviders', () => ({
   API_PROVIDERS: ['deepseek', 'kimiCode'],
   lookupApiKeyOrigin: mocks.lookupApiKeyOrigin,
+  configuredApiKeyProviders: async () => {
+    const origins = await Promise.all(
+      ['deepseek', 'kimiCode'].map((provider) =>
+        mocks.lookupApiKeyOrigin({}, provider),
+      ),
+    );
+    return ['deepseek', 'kimiCode'].filter(
+      (_, index) => origins[index] !== 'none',
+    );
+  },
 }));
 
 vi.mock('@platform/platform', () => ({
@@ -480,5 +490,24 @@ describe('loadCliApiStatusLines', () => {
       'auth: signed out',
       'actions: choose Model access below; provider keys are configured',
     ]);
+  });
+
+  it('lists providers configured by secret or env origin', async () => {
+    const originsByProvider: Record<string, 'secret' | 'env' | 'none'> = {
+      deepseek: 'secret',
+      kimiCode: 'env',
+    };
+    mocks.lookupApiKeyOrigin.mockImplementation(
+      (_secrets: unknown, provider: string) =>
+        Promise.resolve(originsByProvider[provider] ?? 'none'),
+    );
+
+    await expect(loadCliApiStatus()).resolves.toEqual({
+      lines: [
+        'api: your own API keys',
+        'your own API keys: DeepSeek, Kimi Code',
+        'auth: signed out',
+      ],
+    });
   });
 });

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.ts
@@ -67,6 +67,16 @@ vi.mock('@model/apiProviders', () => ({
   API_PROVIDERS: ['openai', 'anthropic', 'openRouter', 'google', 'xai', 'deepseek', 'moonshot', 'kimiCode', 'dashscope', 'minimax', 'glm', 'meta'],
   apiKeyExists: mocks.apiKeyExists,
   lookupApiKeyOrigin: mocks.lookupApiKeyOrigin,
+  configuredApiKeyProviders: async () => {
+    const origins = await Promise.all(
+      ['openai', 'anthropic', 'openRouter', 'google', 'xai', 'deepseek', 'moonshot', 'kimiCode', 'dashscope', 'minimax', 'glm', 'meta'].map(
+        (provider) => mocks.lookupApiKeyOrigin({}, provider),
+      ),
+    );
+    return ['openai', 'anthropic', 'openRouter', 'google', 'xai', 'deepseek', 'moonshot', 'kimiCode', 'dashscope', 'minimax', 'glm', 'meta'].filter(
+      (_, index) => origins[index] !== 'none',
+    );
+  },
 }));
 
 vi.mock('@utils/config/providerConfig', () => ({
@@ -334,6 +344,38 @@ describe('CLI model access routes', () => {
       preferences: { chatGpt: 'off', grok: 'off', kimiCode: 'on' },
       kimiCodeKeySet: false,
     });
+  });
+
+  it('reports configured provider keys as display names', async () => {
+    mocks.lookupApiKeyOrigin.mockImplementation(async (_secrets, provider) => {
+      if (provider === 'deepseek') return 'secret';
+      if (provider === 'moonshot') return 'env';
+      if (provider === 'kimiCode') return 'secret';
+      return 'none';
+    });
+
+    await expect(readCliModelAccessStatus('personal')).resolves.toMatchObject({
+      apiFallback: 'personal',
+      personalKeyProviders: ['DeepSeek', 'Moonshot', 'Kimi Code'],
+    });
+  });
+
+  it('renders configured provider keys in the personal item description', async () => {
+    mocks.lookupApiKeyOrigin.mockImplementation(async (_secrets, provider) => {
+      if (provider === 'deepseek') return 'secret';
+      if (provider === 'moonshot') return 'env';
+      if (provider === 'kimiCode') return 'secret';
+      return 'none';
+    });
+    const status = await readCliModelAccessStatus('personal');
+
+    const items = buildCliModelAccessItems({ kind: 'loaded', access: status });
+    const personalItem = items.find(
+      (item) => item.value.kind === 'api-fallback' && item.value.apiMode === 'personal',
+    );
+    expect(personalItem?.description).toBe(
+      'Configured: DeepSeek, Moonshot, Kimi Code',
+    );
   });
 
   it('enables Kimi Code routing on a personal fallback when a key exists', async () => {

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.ts
@@ -64,18 +64,53 @@ vi.mock('@model/xai/xaiPreference', () => ({
 }));
 
 vi.mock('@model/apiProviders', () => ({
-  API_PROVIDERS: ['openai', 'anthropic', 'openRouter', 'google', 'xai', 'deepseek', 'moonshot', 'kimiCode', 'dashscope', 'minimax', 'glm', 'meta'],
+  API_PROVIDERS: [
+    'openai',
+    'anthropic',
+    'openRouter',
+    'google',
+    'xai',
+    'deepseek',
+    'moonshot',
+    'kimiCode',
+    'dashscope',
+    'minimax',
+    'glm',
+    'meta',
+  ],
   apiKeyExists: mocks.apiKeyExists,
   lookupApiKeyOrigin: mocks.lookupApiKeyOrigin,
   configuredApiKeyProviders: async () => {
     const origins = await Promise.all(
-      ['openai', 'anthropic', 'openRouter', 'google', 'xai', 'deepseek', 'moonshot', 'kimiCode', 'dashscope', 'minimax', 'glm', 'meta'].map(
-        (provider) => mocks.lookupApiKeyOrigin({}, provider),
-      ),
+      [
+        'openai',
+        'anthropic',
+        'openRouter',
+        'google',
+        'xai',
+        'deepseek',
+        'moonshot',
+        'kimiCode',
+        'dashscope',
+        'minimax',
+        'glm',
+        'meta',
+      ].map((provider) => mocks.lookupApiKeyOrigin({}, provider)),
     );
-    return ['openai', 'anthropic', 'openRouter', 'google', 'xai', 'deepseek', 'moonshot', 'kimiCode', 'dashscope', 'minimax', 'glm', 'meta'].filter(
-      (_, index) => origins[index] !== 'none',
-    );
+    return [
+      'openai',
+      'anthropic',
+      'openRouter',
+      'google',
+      'xai',
+      'deepseek',
+      'moonshot',
+      'kimiCode',
+      'dashscope',
+      'minimax',
+      'glm',
+      'meta',
+    ].filter((_, index) => origins[index] !== 'none');
   },
 }));
 
@@ -371,7 +406,8 @@ describe('CLI model access routes', () => {
 
     const items = buildCliModelAccessItems({ kind: 'loaded', access: status });
     const personalItem = items.find(
-      (item) => item.value.kind === 'api-fallback' && item.value.apiMode === 'personal',
+      (item) =>
+        item.value.kind === 'api-fallback' && item.value.apiMode === 'personal',
     );
     expect(personalItem?.description).toBe(
       'Configured: DeepSeek, Moonshot, Kimi Code',

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.ts
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   signInCliGrok: vi.fn(),
   updateGlobalState: vi.fn(),
   apiKeyExists: vi.fn(),
+  lookupApiKeyOrigin: vi.fn(),
   getPreferKimiCode: vi.fn(),
   setPreferKimiCode: vi.fn(),
 }));
@@ -63,7 +64,9 @@ vi.mock('@model/xai/xaiPreference', () => ({
 }));
 
 vi.mock('@model/apiProviders', () => ({
+  API_PROVIDERS: ['openai', 'anthropic', 'openRouter', 'google', 'xai', 'deepseek', 'moonshot', 'kimiCode', 'dashscope', 'minimax', 'glm', 'meta'],
   apiKeyExists: mocks.apiKeyExists,
+  lookupApiKeyOrigin: mocks.lookupApiKeyOrigin,
 }));
 
 vi.mock('@utils/config/providerConfig', () => ({
@@ -115,6 +118,7 @@ function expectedAccessStatus(overrides: Record<string, unknown>) {
     grokSignedIn: false,
     grokAccountLabel: undefined,
     kimiCodeKeySet: false,
+    personalKeyProviders: [],
     ...overrides,
   };
 }
@@ -140,6 +144,7 @@ beforeEach(() => {
   mocks.shouldUseChatGptDeviceCode.mockReturnValue(false);
   mocks.shouldUseGrokDeviceCode.mockReturnValue(false);
   mocks.apiKeyExists.mockResolvedValue(false);
+  mocks.lookupApiKeyOrigin.mockResolvedValue('none');
   mocks.getPreferKimiCode.mockReturnValue(false);
   mocks.setPreferKimiCode.mockResolvedValue(undefined);
 });

--- a/src/test-kernel/cli/SlashRegistry.vitest.ts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.ts
@@ -396,7 +396,9 @@ describe('slashRegistry', () => {
     await settleFormSelection();
 
     expect(errors).toEqual(['api mode failed']);
-    expect(apiNode.isClosed()).toBe(true);
+    // Selecting "Your own API keys" still advances to the key configuration
+    // form so the user can set keys even when the mode switch itself failed.
+    expect(activeForm.get()?.commandName).toBe('key');
   });
 
   it('keeps model-access selection in a busy form until it settles', async () => {
@@ -420,7 +422,9 @@ describe('slashRegistry', () => {
     selection.resolve();
     await settleFormSelection();
 
-    expect(apiNode.isClosed()).toBe(true);
+    // After switching to personal mode, the API key configuration form opens
+    // in place of the model access form.
+    expect(activeForm.get()?.commandName).toBe('key');
   });
 
   it('keeps provider API keys inside the masked local form', async () => {

--- a/src/test-kernel/model/ApiProviders.vitest.ts
+++ b/src/test-kernel/model/ApiProviders.vitest.ts
@@ -4,6 +4,7 @@ import {
   apiKeyEnvName,
   apiKeyExistsUncached,
   apiKeySecretName,
+  configuredApiKeyProviders,
   hasUsableApiKey,
   invalidateApiKeyCache,
   loadApiKeyStatusMap,
@@ -121,6 +122,24 @@ describe('API provider key caches', () => {
     ).resolves.toEqual({
       openai: 'env',
     });
+  });
+
+  it('lists only providers with a configured key (secret or env)', async () => {
+    const { secrets } = createSecrets(
+      { [apiKeySecretName('openai')]: 'sk-test' },
+      { MOONSHOT_API_KEY: 'from-env' },
+    );
+
+    await expect(configuredApiKeyProviders(secrets)).resolves.toEqual([
+      'openai',
+      'moonshot',
+    ]);
+  });
+
+  it('reports no configured providers when every key is absent', async () => {
+    const { secrets } = createSecrets();
+
+    await expect(configuredApiKeyProviders(secrets)).resolves.toEqual([]);
   });
 
   it('treats empty env keys as missing in uncached lookups', async () => {


### PR DESCRIPTION
## Problem

In the CLI TUI, the `/api` → Model access form shows a "Your own API keys" option with the generic description "Use keys configured on this computer". The user cannot see which provider keys are actually configured without navigating into the API keys form.

## Fix

The "Your own API keys" item now shows which provider keys are configured, e.g.:

> Configured: DeepSeek, Moonshot, Kimi Code

When no keys are configured, it falls back to the original "Use keys configured on this computer".

## Changes

1. **`packages/cli/src/runtime/modelAccessRoute.ts`** — Added `personalKeyProviders?: readonly string[]` to `CliModelAccessStatus`; updated `buildCliModelAccessItems` to show configured providers in the `personal` route description.
2. **`packages/cli/src/runtime/modelAccessSelection.ts`** — `readCliModelAccessStatus` now scans configured API key origins and maps them to display names (e.g. `kimiCode` → `Kimi Code`).
3. **`src/test-kernel/cli/ModelAccessSelection.vitest.ts`** — Updated mocks for the new `API_PROVIDERS`/`lookupApiKeyOrigin` imports.

## Tests

- `ModelAccessSelection.vitest.ts` — 32 passed
- `ConfigForm.vitest.ts` — 58 passed
- `Orchestration.vitest.ts` — 40 passed
- `ApiStatusLoad.vitest.ts` — 24 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CLI configuration UX and a shared read-only helper for listing configured keys; no auth, routing, or secret-handling logic changes beyond reusing existing origin lookups.
> 
> **Overview**
> Improves the CLI **Model access** (`/api`) flow for **Your own API keys**: the menu now lists which provider keys are configured (e.g. **Configured: DeepSeek, Moonshot, Kimi Code**) instead of only the generic “use keys on this computer” line, and choosing that option opens the **API key** slash form in place so keys can be set without a separate `/key` run (including when the mode switch errors).
> 
> Provider detection is centralized in **`configuredApiKeyProviders`** in `apiProviders.ts`; **`readCliModelAccessStatus`** and CLI API status loading use it to populate `personalKeyProviders` and status lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab84085a1f540bf44519cba52aa60212056e8db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->