### PR TITLE
refactor: code-simplifier sweep, round 1 part 2

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -77,11 +77,6 @@
       "name": "packages/trace-viewer/vite.standalone.config.ts"
     },
     {
-      "file": "src/shared/schemas/commonViewMessages.ts",
-      "category": "types",
-      "name": "SwitchViewTarget"
-    },
-    {
       "file": "src/test-kernel/support/setupFakePlatform.ts",
       "category": "files",
       "name": "src/test-kernel/support/setupFakePlatform.ts"

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -155,14 +155,12 @@ const GIT_INSTALL_OPTIONS: Partial<
 
 const GIT_DOWNLOAD_URL = 'https://git-scm.com/downloads';
 
-function isToolAvailable(tool: string): boolean {
-  return executeCommandSync([tool, '--version']).success;
-}
-
 async function promptGitMissing(): Promise<void> {
   const option = GIT_INSTALL_OPTIONS[process.platform] ?? null;
   const command =
-    option && isToolAvailable(option.tool) ? option.command : null;
+    option && executeCommandSync([option.tool, '--version']).success
+      ? option.command
+      : null;
 
   let message: string;
   if (command) {

--- a/src/agent/modelHandlers/openai/openAIResponseContent.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseContent.ts
@@ -68,14 +68,6 @@ export function extractTextContentPart(part: unknown): string | undefined {
     : undefined;
 }
 
-function contentHasText(content: unknown): boolean {
-  if (typeof content === 'string') return content.trim().length > 0;
-  if (!Array.isArray(content)) return false;
-  return content.some(
-    (part) => (extractTextContentPart(part)?.trim().length ?? 0) > 0,
-  );
-}
-
 /** Whether a completed Responses payload already carries assistant text. */
 export function hasResponseOutputText(response: {
   readonly output_text?: unknown;
@@ -98,7 +90,14 @@ export function hasResponseOutputText(response: {
     };
     if (candidate.type !== 'message') return false;
     if (candidate.role != null && candidate.role !== 'assistant') return false;
-    return contentHasText(candidate.content);
+    // Inlined from a former single-caller helper: this check decides whether
+    // compaction text is injected, so it stays auditable as one unit.
+    const { content } = candidate;
+    if (typeof content === 'string') return content.trim().length > 0;
+    if (!Array.isArray(content)) return false;
+    return content.some(
+      (part) => (extractTextContentPart(part)?.trim().length ?? 0) > 0,
+    );
   });
 }
 

--- a/src/eventBus/AppSignals.ts
+++ b/src/eventBus/AppSignals.ts
@@ -51,17 +51,7 @@ export interface AppSignalPayloads {
 
 type AppSignal = keyof AppSignalPayloads;
 
-interface AppSignalsLike {
-  on<K extends AppSignal>(
-    event: K,
-    listener: (payload: AppSignalPayloads[K]) => void,
-    options?: { signal?: AbortSignal },
-  ): () => void;
-
-  emit<K extends AppSignal>(event: K, payload: AppSignalPayloads[K]): void;
-}
-
-class AppSignals implements AppSignalsLike {
+class AppSignals {
   private readonly emitter = new EventEmitter();
 
   on<K extends AppSignal>(

--- a/src/shared/schemas/commonViewMessages.ts
+++ b/src/shared/schemas/commonViewMessages.ts
@@ -42,7 +42,6 @@ export const WebviewReadyMessageSchema = z.object({
 });
 
 const SwitchViewTargetSchema = z.enum(['main', 'progress', 'dashboard']);
-export type SwitchViewTarget = z.infer<typeof SwitchViewTargetSchema>;
 
 export const SwitchViewMessageSchema = z.object({
   command: z.literal(COMMON_COMMANDS.SWITCH_VIEW),


### PR DESCRIPTION
## Summary

Behavior-preserving simplifications continuing the code-simplifier sweep — **round 1 part 2** (the remaining batches deferred from part 1, PR #9868). Small disjoint cleanups: inlining single-caller helpers, dead-interface/type removal, and the matching knip ratchet entry.

## Changes

- `packages/extension/src/commands/git/gitCommands.ts` — inline single-caller `isToolAvailable` into `promptGitMissing`.
- `src/agent/modelHandlers/openai/openAIResponseContent.ts` — inline single-caller `contentHasText` into `hasResponseOutputText` (kept as an auditable unit since it gates compaction-text injection).
- `src/eventBus/AppSignals.ts` — drop unused `AppSignalsLike` interface.
- `src/shared/schemas/commonViewMessages.ts` — drop unused `SwitchViewTarget` type export.
- `config/ratchets/knip-baseline.json` — prune the now-removed `SwitchViewTarget` entry (ratchet verified 16/16).

No new abstractions, no behavior change, no exports re-routed.

## Validation

- `npm run typecheck:workspace`: green.
- `eslint` on all changed files: 0 errors.
- `prettier --check` on all changed files: clean.
- `npm run check:dead-code-ratchet`: OK (16 current vs 16 baselined).
- Full Vitest suite: running; will report on merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactors and removal of unused exports; no API or security-sensitive logic changes.
> 
> **Overview**
> Part of a **code-simplifier** sweep: removes small helpers and redundant typing while keeping behavior the same.
> 
> **Dead-code / exports:** Drops the exported `SwitchViewTarget` type from `commonViewMessages.ts` and removes the matching knip baseline entry. The Zod schema for switch-view targets is unchanged.
> 
> **Git commands:** In `promptGitMissing`, removes `isToolAvailable` and probes the package manager with `executeCommandSync` inline when building the install command.
> 
> **OpenAI response content:** Inlines the former `contentHasText` helper into `hasResponseOutputText` (with a short comment that compaction injection depends on this check).
> 
> **App signals:** Removes the `AppSignalsLike` interface; `AppSignals` is a concrete class only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4137b41e25a8a035313bdc3d47b90fe5d75110bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->