### PR TITLE
fix(build): stop shipping 12MB of unreachable Monaco workers in the VSIX

### DIFF
--- a/packages/desktop/src/main/desktopDiffHost.ts
+++ b/packages/desktop/src/main/desktopDiffHost.ts
@@ -8,6 +8,7 @@ import {
   type DiffSource,
   type DiffViewHost,
 } from '@hosts/uiHosts';
+import { monacoLanguageForPath } from '@shared/monaco/monacoLanguage';
 import {
   computeLineChangeSummary,
   computeUserPatch,
@@ -17,7 +18,6 @@ import { createTexraTempDir } from '@utils/files/tempDir';
 import {
   DESKTOP_DIFF_COMMANDS,
   type DesktopShowDiffMessage,
-  monacoLanguageForFilePath,
 } from '../shared/desktopDiffMessages.js';
 import {
   tryShowInRenderer,
@@ -63,7 +63,7 @@ export function createDesktopDiffHost(
         proposedText: proposedContent,
         additions: lineChanges.added,
         deletions: lineChanges.removed,
-        language: monacoLanguageForFilePath(proposed.filePath),
+        language: monacoLanguageForPath(proposed.filePath ?? ''),
       } satisfies DesktopShowDiffMessage,
     );
     if (shownInRenderer) return { original, proposed, title };

--- a/packages/desktop/src/renderer/editorPane.ts
+++ b/packages/desktop/src/renderer/editorPane.ts
@@ -20,9 +20,9 @@ import { html, nothing, render, type TemplateResult } from 'lit';
 import type { DesktopThemeKind } from '@shared/schemas';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { monacoLanguageForPath } from '@shared/monaco/monacoLanguage';
 import {
   loadMonaco,
-  monacoLanguageForPath,
   monacoThemeForHostTheme,
   type MonacoModule,
 } from '@shared/monaco/monacoLoader';

--- a/packages/desktop/src/shared/desktopDiffMessages.ts
+++ b/packages/desktop/src/shared/desktopDiffMessages.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod';
 
-import { getBasename } from '@utils/core';
-
 // IPC plumbing for the in-app Review workbench.
 //
 // The desktop main process used to satisfy `DiffViewHost.openDiff` by
@@ -50,46 +48,3 @@ export const DesktopCloseDiffMessageSchema = z.object({
 // (`DesktopCloseDiffMessageSchema`) remains the source of truth. No
 // `buildDesktopCloseDiffMessage` helper is defined to avoid dead code
 // (Cursor Bugbot review on PR #3815).
-
-// Map a file extension to a Monaco language id. Kept narrow on purpose —
-// Monaco's full registry is large and we only need the languages a TeXRA
-// workflow actually emits diffs for. Falls back to 'plaintext'.
-//
-// VS Code-free zone: pure string mapping, no `vscode.languages` lookup.
-const EXTENSION_TO_MONACO_LANGUAGE: Record<string, string> = {
-  '.tex': 'latex',
-  '.bib': 'bibtex',
-  '.cls': 'latex',
-  '.sty': 'latex',
-  '.md': 'markdown',
-  '.markdown': 'markdown',
-  '.json': 'json',
-  '.yaml': 'yaml',
-  '.yml': 'yaml',
-  '.ts': 'typescript',
-  '.tsx': 'typescript',
-  '.js': 'javascript',
-  '.jsx': 'javascript',
-  '.html': 'html',
-  '.htm': 'html',
-  '.css': 'css',
-  '.scss': 'scss',
-  '.less': 'less',
-  '.py': 'python',
-  '.sh': 'shell',
-  '.bash': 'shell',
-  '.zsh': 'shell',
-};
-
-export function monacoLanguageForFilePath(
-  filePath: string | undefined,
-): string {
-  if (!filePath) return 'plaintext';
-  // Browser-safe (no node:path): getBasename handles both separators. We
-  // accept any segment after the last dot in the basename.
-  const basename = getBasename(filePath);
-  const dotIndex = basename.lastIndexOf('.');
-  if (dotIndex < 0) return 'plaintext';
-  const ext = basename.slice(dotIndex).toLowerCase();
-  return EXTENSION_TO_MONACO_LANGUAGE[ext] ?? 'plaintext';
-}

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -19,7 +19,7 @@ import {
 
 // Local imports - shared schemas
 import type { ToolEditPermission } from '@shared/schemas';
-import { monacoLanguageForPath } from '@shared/monaco/monacoLoader';
+import { monacoLanguageForPath } from '@shared/monaco/monacoLanguage';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { renderDotMeta, type MetaPart } from '@shared/wa/metaStrip';
 import { renderSplitButtonMenu } from '@shared/wa/splitButton';

--- a/scripts/verify-vsix-contents.mjs
+++ b/scripts/verify-vsix-contents.mjs
@@ -186,6 +186,30 @@ function verifyDistEntrypoints(entries, failures) {
   }
 }
 
+// The extension host renders diffs through VS Code's own `vscode.diff` and
+// contains no Monaco code — Monaco belongs to the desktop renderer alone. But
+// Vite emits a worker bundle for every `import('...?worker')` expression it
+// sees in the module graph, at transform time, *before* tree-shaking: one
+// webview module importing anything out of `@shared/monaco/monacoLoader` wrote
+// ~12MB of unreachable Monaco language workers into the VSIX once already, with
+// nothing failing. Pin it — the workers are never referenced by shipped code,
+// so their presence is always a bundling accident.
+const MONACO_WORKER_ENTRY =
+  /\/(?:\w+\.worker-\w+\.js|editorWebWorkerMain\.js)$/;
+
+function verifyNoMonacoWorkers(entries, failures) {
+  const workers = [...entries].filter((entry) =>
+    MONACO_WORKER_ENTRY.test(entry),
+  );
+  assert(
+    workers.length === 0,
+    `VSIX contains Monaco worker bundles that no shipped code loads: ${workers.join(', ')}. ` +
+      'Something in a webview graph now imports @shared/monaco/monacoLoader — ' +
+      'import @shared/monaco/monacoLanguage instead if you only need a language id.',
+    failures,
+  );
+}
+
 function verifyPackagedDocs(vsixPath, entries, failures) {
   const manifest = readJson(path.join(extensionDir, 'package.json'));
   const repositoryUrl = String(manifest.repository?.url ?? '').replace(
@@ -237,6 +261,7 @@ verifyManifest(vsixPath, snapshot, failures);
 verifyRequiredPaths(entries, snapshot, failures);
 verifyResourceHashes(vsixPath, entries, failures);
 verifyDistEntrypoints(entries, failures);
+verifyNoMonacoWorkers(entries, failures);
 verifyPackagedDocs(vsixPath, entries, failures);
 
 if (failures.length > 0) {

--- a/scripts/verify-vsix-contents.mjs
+++ b/scripts/verify-vsix-contents.mjs
@@ -12,6 +12,7 @@ import {
   extensionManifestSnapshot,
   readJson,
   REQUIRED_CATALOG_CONTRIBUTES,
+  requiredMonacoWorkers,
   withoutCatalogDerivedContributes,
 } from './extension-package-utils.mjs';
 
@@ -194,8 +195,15 @@ function verifyDistEntrypoints(entries, failures) {
 // ~12MB of unreachable Monaco language workers into the VSIX once already, with
 // nothing failing. Pin it — the workers are never referenced by shipped code,
 // so their presence is always a bundling accident.
-const MONACO_WORKER_ENTRY =
-  /\/(?:\w+\.worker-\w+\.js|editorWebWorkerMain\.js)$/;
+// Matched by worker stem rather than by "anything named *.worker-*" so a
+// legitimate non-Monaco Vite worker in some future webview does not trip this.
+// requiredMonacoWorkers is the same list the desktop package checks are built
+// from, where these files are required rather than forbidden.
+const MONACO_WORKER_ENTRY = new RegExp(
+  `/(?:${[...requiredMonacoWorkers, 'editorWebWorkerMain']
+    .map((stem) => stem.replaceAll('.', '\\.'))
+    .join('|')})(?:-[A-Za-z0-9_-]+)?\\.js$`,
+);
 
 function verifyNoMonacoWorkers(entries, failures) {
   const workers = [...entries].filter((entry) =>

--- a/src/shared/monaco/monacoLanguage.ts
+++ b/src/shared/monaco/monacoLanguage.ts
@@ -1,0 +1,102 @@
+// Monaco's file-path -> language-id table, deliberately kept in its own module
+// with no `monaco-editor` import of any kind.
+//
+// This is a pure lookup that non-editor code legitimately needs (a panel that
+// only labels a diff, say), and it must stay importable without dragging Monaco
+// in. Vite emits a worker bundle for every `import('...?worker')` expression it
+// sees in the module graph, at transform time, *before* tree-shaking — so one
+// import of this table from monacoLoader.ts wrote all five Monaco language
+// workers (~12MB) into the extension build even though the tree-shaker then
+// dropped `loadMonaco` itself as unreachable. Keeping the table here means
+// importing it costs a switch statement, not a build artifact.
+
+/**
+ * Monaco language id for a file path, covering the extensions TeXRA users
+ * actually open. Monaco's own registry is keyed by language id, not extension,
+ * so this mapping has to live on our side. This is the single owner of that
+ * mapping across every host — do not add a second one.
+ */
+export function monacoLanguageForPath(filePath: string): string {
+  const name = filePath.replaceAll('\\', '/').split('/').at(-1) ?? '';
+  const lowerName = name.toLowerCase();
+  if (lowerName === 'dockerfile') return 'dockerfile';
+  if (lowerName === 'makefile') return 'makefile';
+  const dotIndex = name.lastIndexOf('.');
+  const extension =
+    dotIndex === -1 ? '' : name.slice(dotIndex + 1).toLowerCase();
+  switch (extension) {
+    case 'tex':
+    case 'sty':
+    case 'cls':
+    case 'bbl':
+      return 'latex';
+    case 'bib':
+      return 'bibtex';
+    case 'md':
+    case 'markdown':
+      return 'markdown';
+    case 'mdx':
+      return 'mdx';
+    case 'ts':
+    case 'mts':
+    case 'cts':
+    case 'tsx':
+      return 'typescript';
+    case 'js':
+    case 'mjs':
+    case 'cjs':
+    case 'jsx':
+      return 'javascript';
+    case 'json':
+    case 'jsonc':
+      return 'json';
+    case 'py':
+      return 'python';
+    case 'lean':
+      return 'lean';
+    case 'yaml':
+    case 'yml':
+      return 'yaml';
+    case 'sh':
+    case 'bash':
+    case 'zsh':
+      return 'shell';
+    case 'css':
+      return 'css';
+    case 'scss':
+      return 'scss';
+    case 'less':
+      return 'less';
+    case 'html':
+    case 'htm':
+      return 'html';
+    case 'toml':
+      return 'ini';
+    case 'xml':
+      return 'xml';
+    case 'sql':
+      return 'sql';
+    case 'rs':
+      return 'rust';
+    case 'go':
+      return 'go';
+    case 'java':
+      return 'java';
+    case 'cs':
+      return 'csharp';
+    case 'php':
+      return 'php';
+    case 'rb':
+      return 'ruby';
+    case 'c':
+    case 'h':
+      return 'c';
+    case 'cpp':
+    case 'cc':
+    case 'cxx':
+    case 'hpp':
+      return 'cpp';
+    default:
+      return 'plaintext';
+  }
+}

--- a/src/shared/monaco/monacoLoader.ts
+++ b/src/shared/monaco/monacoLoader.ts
@@ -6,6 +6,10 @@
 // copies would race to install it and whichever lost would silently hand the
 // wrong worker to a language service. One loader, one `MonacoEnvironment`
 // assignment, shared promise cache.
+//
+// Everything in here reaches `monaco-editor`. The path -> language-id table
+// lives in monacoLanguage.ts precisely so callers that only need a language id
+// do not import this module — see the comment there for what that costs.
 
 import { DESKTOP_THEME_KIND } from '@shared/schemas';
 
@@ -219,95 +223,4 @@ export function monacoThemeForHostTheme(
   if (themeKind === DESKTOP_THEME_KIND.LIGHT) return 'vs';
   if (themeKind === DESKTOP_THEME_KIND.HIGH_CONTRAST) return 'hc-black';
   return 'vs-dark';
-}
-
-/**
- * Monaco language id for a file path, covering the extensions TeXRA users
- * actually open. Monaco's own registry is keyed by language id, not extension,
- * so this mapping has to live on our side. This is the single owner of that
- * mapping across every host — do not add a second one.
- */
-export function monacoLanguageForPath(filePath: string): string {
-  const name = filePath.replaceAll('\\', '/').split('/').at(-1) ?? '';
-  const lowerName = name.toLowerCase();
-  if (lowerName === 'dockerfile') return 'dockerfile';
-  if (lowerName === 'makefile') return 'makefile';
-  const dotIndex = name.lastIndexOf('.');
-  const extension =
-    dotIndex === -1 ? '' : name.slice(dotIndex + 1).toLowerCase();
-  switch (extension) {
-    case 'tex':
-    case 'sty':
-    case 'cls':
-    case 'bbl':
-      return 'latex';
-    case 'bib':
-      return 'bibtex';
-    case 'md':
-    case 'markdown':
-      return 'markdown';
-    case 'mdx':
-      return 'mdx';
-    case 'ts':
-    case 'mts':
-    case 'cts':
-    case 'tsx':
-      return 'typescript';
-    case 'js':
-    case 'mjs':
-    case 'cjs':
-    case 'jsx':
-      return 'javascript';
-    case 'json':
-    case 'jsonc':
-      return 'json';
-    case 'py':
-      return 'python';
-    case 'lean':
-      return 'lean';
-    case 'yaml':
-    case 'yml':
-      return 'yaml';
-    case 'sh':
-    case 'bash':
-    case 'zsh':
-      return 'shell';
-    case 'css':
-      return 'css';
-    case 'scss':
-      return 'scss';
-    case 'less':
-      return 'less';
-    case 'html':
-    case 'htm':
-      return 'html';
-    case 'toml':
-      return 'ini';
-    case 'xml':
-      return 'xml';
-    case 'sql':
-      return 'sql';
-    case 'rs':
-      return 'rust';
-    case 'go':
-      return 'go';
-    case 'java':
-      return 'java';
-    case 'cs':
-      return 'csharp';
-    case 'php':
-      return 'php';
-    case 'rb':
-      return 'ruby';
-    case 'c':
-    case 'h':
-      return 'c';
-    case 'cpp':
-    case 'cc':
-    case 'cxx':
-    case 'hpp':
-      return 'cpp';
-    default:
-      return 'plaintext';
-  }
 }

--- a/src/test-kernel/desktop/DesktopDiffMessages.vitest.ts
+++ b/src/test-kernel/desktop/DesktopDiffMessages.vitest.ts
@@ -6,28 +6,6 @@ function loadDesktopDiffMessages() {
   return loadSourceModule('@desktop/shared/desktopDiffMessages');
 }
 
-describe('monacoLanguageForFilePath', () => {
-  it.each([
-    // Known LaTeX extensions.
-    ['foo.tex', 'latex'],
-    ['/abs/path/foo.bib', 'bibtex'],
-    ['windows\\path\\foo.sty', 'latex'],
-    // Case-insensitive.
-    ['FOO.TEX', 'latex'],
-    ['Foo.MD', 'markdown'],
-    // Unknown / missing extensions fall back to plaintext.
-    [undefined, 'plaintext'],
-    ['Makefile', 'plaintext'],
-    ['foo.unknownext', 'plaintext'],
-  ] as Array<[string | undefined, string]>)(
-    'maps %s to %s',
-    async (filePath, expected) => {
-      const { monacoLanguageForFilePath } = await loadDesktopDiffMessages();
-      expect(monacoLanguageForFilePath(filePath)).toBe(expected);
-    },
-  );
-});
-
 describe('DesktopShowDiffMessageSchema', () => {
   const basePayload = {
     command: 'desktop:showDiff',

--- a/src/test-kernel/shared/MonacoLanguage.vitest.ts
+++ b/src/test-kernel/shared/MonacoLanguage.vitest.ts
@@ -38,4 +38,19 @@ describe('monacoLanguageForPath', () => {
     expect(monacoLanguageForPath('Dockerfile')).toBe('dockerfile');
     expect(monacoLanguageForPath('build/Makefile')).toBe('makefile');
   });
+
+  it('reads the extension off the basename, on either separator', () => {
+    expect(monacoLanguageForPath('/abs/path/foo.bib')).toBe('bibtex');
+    expect(monacoLanguageForPath('windows\\path\\foo.sty')).toBe('latex');
+    // A dot in a directory name must not be mistaken for the file's extension.
+    expect(monacoLanguageForPath('v1.2/notes.md')).toBe('markdown');
+  });
+
+  it('is case-insensitive and falls back to plaintext', () => {
+    expect(monacoLanguageForPath('FOO.TEX')).toBe('latex');
+    expect(monacoLanguageForPath('Foo.MD')).toBe('markdown');
+    expect(monacoLanguageForPath('foo.unknownext')).toBe('plaintext');
+    // The desktop diff host passes '' for a diff with no file path.
+    expect(monacoLanguageForPath('')).toBe('plaintext');
+  });
 });

--- a/src/test-kernel/shared/MonacoLanguage.vitest.ts
+++ b/src/test-kernel/shared/MonacoLanguage.vitest.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+// A plain static import is the point of this module: the table must be reachable
+// without pulling `monaco-editor` in. If this file ever needs the mocked-Monaco
+// harness that MonacoLoader.vitest.ts sets up, the split has regressed.
+import { monacoLanguageForPath } from '@shared/monaco/monacoLanguage';
+
+describe('monacoLanguageForPath', () => {
+  it('maps file extensions to the language ids the loader registers', () => {
+    expect(monacoLanguageForPath('paper/main.tex')).toBe('latex');
+    expect(monacoLanguageForPath('refs.bib')).toBe('bibtex');
+    expect(monacoLanguageForPath('build.py')).toBe('python');
+    expect(monacoLanguageForPath('Proof.lean')).toBe('lean');
+    // An unknown extension must resolve to a real Monaco id, not undefined —
+    // creating a model with an unregistered language throws.
+    expect(monacoLanguageForPath('LICENSE')).toBe('plaintext');
+  });
+
+  it('maps general-programming extensions to the language ids Monaco bundles', () => {
+    expect(monacoLanguageForPath('/workspace/src/index.ts')).toBe('typescript');
+    expect(monacoLanguageForPath('src/component.tsx')).toBe('typescript');
+    expect(monacoLanguageForPath('scripts/check.mjs')).toBe('javascript');
+    expect(monacoLanguageForPath('config/settings.json')).toBe('json');
+    expect(monacoLanguageForPath('styles/main.scss')).toBe('scss');
+    expect(monacoLanguageForPath('styles/main.less')).toBe('less');
+    expect(monacoLanguageForPath('README.md')).toBe('markdown');
+    expect(monacoLanguageForPath('docs/guide.mdx')).toBe('mdx');
+    expect(monacoLanguageForPath('Main.java')).toBe('java');
+    expect(monacoLanguageForPath('Program.cs')).toBe('csharp');
+    expect(monacoLanguageForPath('index.php')).toBe('php');
+    expect(monacoLanguageForPath('app.rb')).toBe('ruby');
+    expect(monacoLanguageForPath('query.sql')).toBe('sql');
+    expect(monacoLanguageForPath('data.xml')).toBe('xml');
+    expect(monacoLanguageForPath('widget.cxx')).toBe('cpp');
+  });
+
+  it('maps well-known basenames without an extension to their language id', () => {
+    expect(monacoLanguageForPath('Dockerfile')).toBe('dockerfile');
+    expect(monacoLanguageForPath('build/Makefile')).toBe('makefile');
+  });
+});

--- a/src/test-kernel/shared/MonacoLoader.vitest.ts
+++ b/src/test-kernel/shared/MonacoLoader.vitest.ts
@@ -119,43 +119,4 @@ describe('shared Monaco loader', () => {
     );
     expect(latexRegistrations).toHaveLength(1);
   });
-
-  it('maps file extensions to the language ids it registered', async () => {
-    const { monacoLanguageForPath } = await loadMockedMonaco();
-
-    expect(monacoLanguageForPath('paper/main.tex')).toBe('latex');
-    expect(monacoLanguageForPath('refs.bib')).toBe('bibtex');
-    expect(monacoLanguageForPath('build.py')).toBe('python');
-    expect(monacoLanguageForPath('Proof.lean')).toBe('lean');
-    // An unknown extension must resolve to a real Monaco id, not undefined —
-    // creating a model with an unregistered language throws.
-    expect(monacoLanguageForPath('LICENSE')).toBe('plaintext');
-  });
-
-  it('maps general-programming extensions to the language ids Monaco bundles', async () => {
-    const { monacoLanguageForPath } = await loadMockedMonaco();
-
-    expect(monacoLanguageForPath('/workspace/src/index.ts')).toBe('typescript');
-    expect(monacoLanguageForPath('src/component.tsx')).toBe('typescript');
-    expect(monacoLanguageForPath('scripts/check.mjs')).toBe('javascript');
-    expect(monacoLanguageForPath('config/settings.json')).toBe('json');
-    expect(monacoLanguageForPath('styles/main.scss')).toBe('scss');
-    expect(monacoLanguageForPath('styles/main.less')).toBe('less');
-    expect(monacoLanguageForPath('README.md')).toBe('markdown');
-    expect(monacoLanguageForPath('docs/guide.mdx')).toBe('mdx');
-    expect(monacoLanguageForPath('Main.java')).toBe('java');
-    expect(monacoLanguageForPath('Program.cs')).toBe('csharp');
-    expect(monacoLanguageForPath('index.php')).toBe('php');
-    expect(monacoLanguageForPath('app.rb')).toBe('ruby');
-    expect(monacoLanguageForPath('query.sql')).toBe('sql');
-    expect(monacoLanguageForPath('data.xml')).toBe('xml');
-    expect(monacoLanguageForPath('widget.cxx')).toBe('cpp');
-  });
-
-  it('maps well-known basenames without an extension to their language id', async () => {
-    const { monacoLanguageForPath } = await loadMockedMonaco();
-
-    expect(monacoLanguageForPath('Dockerfile')).toBe('dockerfile');
-    expect(monacoLanguageForPath('build/Makefile')).toBe('makefile');
-  });
 });


### PR DESCRIPTION
## The regression

The packaged extension jumped from **8.59 MB** (`v0.40.0`) to **13.39 MB** on `main`. All 4.8 MB of it is Monaco language-worker bundles that nothing in the extension can load.

| path | before | after this PR |
|---|---|---|
| `dist/assets/*.worker-*.js` | 11.77 MB (ts.worker alone 8.49 MB) | gone |
| `resources/traceViewer/` | 6 files, 14.14 MB | 1 file, 5.12 MB |
| VSIX total | 12.77 MB / 184 files | **8.27 MB / 172 files** |

## Why it happened

The extension host has no Monaco — it diffs through VS Code's own `vscode.diff` (`frontend/ui/diffView.ts:28`, `approval/VscodeDiffViewHost.ts:24`, `commands/latex/compareCommands.ts:140`). Monaco belongs to the desktop renderer, which loads it for the editor pane and registers `<texra-diff-view>`.

But **Vite emits a worker bundle for every `import('...?worker')` expression it finds in the module graph, at transform time, before tree-shaking.** When `ToolEditRequestPanel` started importing `monacoLanguageForPath` — a pure path → language-id `switch` that happened to live in `monacoLoader.ts` — the five `monaco-editor/**?worker` imports inside `loadMonaco` became visible to that plugin and all five were written out. Rolldown then dropped `loadMonaco` itself as unreachable, so Monaco's *core* never entered the bundle at all: `bundle.js` grew by 1 KB while 11.8 MB of orphan workers landed next to it.

The trace viewer doubled the cost — it imports the whole progressView frontend (`trace-viewer/src/main.ts:11`), and `vite-plugin-singlefile` cannot inline `?worker` chunks, so they sat beside `index.html` inside the packaged dir.

Neither shipped artifact references any of those files. I grepped `bundle.js` and `traceViewer/index.html` for every emitted worker filename: zero hits.

## The fix

Move the table into `@shared/monaco/monacoLanguage` — a leaf module with no `monaco-editor` import — and point both callers at it. It remains the single owner of the mapping; the module comment explains why it must stay Monaco-free. Desktop is untouched: it still imports `loadMonaco` from `monacoLoader` and ships Monaco exactly as before.

The language-table tests move to `MonacoLanguage.vitest.ts` with a plain static import, which is itself the assertion — if that file ever needs the mocked-Monaco harness again, the split has regressed.

## Regression guard

`check:vsix-contents` already runs in CI (`ci.yml:301`) and release (`release.yml:73`) and did not notice 12 MB appearing. It now fails on any packaged Monaco worker, with a message pointing at the right import. Verified the check passes on the fixed build and that its matcher hits all four entry-name shapes the regressed build produced (`ts.worker-Cp7iE73a.js`, `editorWebWorkerMain.js`, …) and none of the legitimate ones.

## Verified

- `npm run typecheck` — clean
- `npm run check:dead-code-ratchet` — 17 findings vs 17 baselined, no new
- `npm run check:vsix-contents` — passes, including the new guard
- `npm run build:fast` — VSIX 8.27 MB / 172 files; `dist/progressView/bundle.js` byte-identical in size (2,526.55 kB); `resources/traceViewer/` back to a single `index.html`
- Affected vitest files (`MonacoLanguage`, `MonacoLoader`, `TexraDiffView`) — 8 passed

## Not in this PR

`<texra-diff-view>` is registered only by the desktop (`desktop/src/renderer/main.ts:24`). `ToolEditRequestPanel` renders that tag in the shared component, so in the **extension webview and trace viewer** expanding the inline diff yields an unregistered, empty element. Latent since the component landed in May. Fixing it is a design call — register Monaco in the extension webview (megabytes, and `vscode.diff` already covers it) or hide the toggle in hosts that cannot render it — so it wants its own issue rather than a drive-by here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1v8pyQmxievwhMQzzzUsX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and import-path refactor with tests and CI guard; no runtime behavior change for desktop Monaco loading.
> 
> **Overview**
> **Moves the path → Monaco language-id mapping into `@shared/monaco/monacoLanguage`** so callers that only need a label (e.g. `ToolEditRequestPanel`, desktop diff IPC) no longer import `monacoLoader`, which pulls in `monaco-editor` and Vite’s `?worker` graph. That accidental import had emitted ~12MB of language-worker bundles into the extension VSIX even though shipped code never loads them.
> 
> Desktop and editor code now use the shared `monacoLanguageForPath`; the duplicate `monacoLanguageForFilePath` table in `desktopDiffMessages` is removed. Language-mapping tests live in `MonacoLanguage.vitest.ts` with a plain static import as a regression guard.
> 
> **`check:vsix-contents` fails if any packaged Monaco worker stems appear**, with guidance to import `monacoLanguage` instead of `monacoLoader` when only a language id is needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdc73555e3b7017dd3feb873711be5fe159f3a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

