### PR TITLE
fix(auth): persist PKCE flow state so any window can finish sign-in

### DIFF
--- a/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
+++ b/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
@@ -337,11 +337,11 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
   /**
    * Remove the authentication session. Sign-out clears local storage only,
-   * matching the desktop and CLI hosts: the shared client runs with
-   * `persistSession: false`, so `auth.signOut()` has no session of this
-   * provider's to revoke and would target whatever session was last handed to
-   * the client, revoking every device's refresh tokens with its default
-   * global scope.
+   * matching the desktop and CLI hosts: the shared client never persists a
+   * session of its own (its storage holds PKCE flow state only), so
+   * `auth.signOut()` has no session of this provider's to revoke and would
+   * target whatever session was last handed to the client, revoking every
+   * device's refresh tokens with its default global scope.
    */
   async removeSession(sessionId: string): Promise<void> {
     await this.clearLocalSession(sessionId);

--- a/src/auth/SupabaseAuthCoordinator.ts
+++ b/src/auth/SupabaseAuthCoordinator.ts
@@ -33,7 +33,11 @@ export function createHostAuthCoordinator(
   init: HostAuthCoordinatorInit,
 ): SupabaseSessionCoordinator {
   try {
-    SupabaseClient.initialize(SUPABASE_CONFIG.url, SUPABASE_CONFIG.publicKey);
+    SupabaseClient.initialize(
+      SUPABASE_CONFIG.url,
+      SUPABASE_CONFIG.publicKey,
+      init.secrets,
+    );
   } catch (error) {
     throw new Error(
       `Supabase authentication is not configured: ${toErrorMessage(error)}`,

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -2,21 +2,107 @@ import {
   createClient,
   SupabaseClient as Client,
   User,
+  type SupportedStorage,
 } from '@supabase/supabase-js';
 import * as logger from '@logger/logUtils';
 import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
-import { UserTierSchema, type UserTier } from './config';
+import {
+  SUPABASE_GOTRUE_STORAGE_KEY,
+  UserTierSchema,
+  type UserTier,
+} from './config';
 import {
   fetchRelayTokenStatus,
   getCachedRelayTokenState,
   getConfiguredRelayToken,
   markRelayTokenRejected,
 } from './relayToken';
+import type { SessionSecretStore } from './oauth/sessionAccess';
 import type {
   AuthTokenProvider,
   SessionTokens,
   StoredSessionState,
 } from './TokenProvider';
+
+/**
+ * GoTrue storage for the shared client.
+ *
+ * Browser OAuth is a two-hop handshake: the window that starts sign-in
+ * generates the PKCE `code_verifier`, and the deep link carrying the one-time
+ * `?code=` back is delivered by the OS to whichever editor window the host
+ * picks — not necessarily that one. GoTrue's own storage is a plain
+ * in-process object, so a callback landing in another window (or after the
+ * extension host reloaded) found no verifier and failed the exchange with
+ * `pkce_code_verifier_not_found`.
+ *
+ * Every key GoTrue derives from its storage key is PKCE flow state (the
+ * `-code-verifier` slots and their flow index); those go to the host secret
+ * store, which is shared across windows and survives a reload. The bare
+ * storage key is GoTrue's session slot and stays in memory on purpose: the
+ * host's own session record remains the single owner of the signed-in
+ * session, so nothing session-shaped is ever persisted here.
+ *
+ * This is the one shape `@supabase/auth-js` accepts, and it is only consulted
+ * when `persistSession` is true — hence that flag below.
+ *
+ * A callback that carries no flow id (TeXRA's does not: the auth-bridge deep
+ * link keeps `redirect_to` free of query parameters) clears the fixed verifier
+ * key on exchange but leaves its numbered slot behind. GoTrue caps those at
+ * five and evicts the oldest, so the leftovers are bounded and hold spent
+ * verifiers, which are worthless without their single-use auth code.
+ */
+function gotrueStorage(
+  secrets: SessionSecretStore | undefined,
+): SupportedStorage {
+  // Writes are mirrored here so a secret-store failure degrades to the old
+  // in-process behavior (same-window sign-in still completes) instead of
+  // losing the flow outright.
+  const memory = new Map<string, string>();
+  const flowStore = (key: string): SessionSecretStore | null =>
+    secrets !== undefined && key !== SUPABASE_GOTRUE_STORAGE_KEY
+      ? secrets
+      : null;
+  const warn = (action: string, key: string, error: unknown): void => {
+    logger.warn(
+      'SupabaseClient',
+      `Could not ${action} PKCE flow state (${key}); sign-in will only be ` +
+        `completable in this window: ${toErrorMessage(error)}`,
+    );
+  };
+
+  return {
+    getItem: async (key) => {
+      const store = flowStore(key);
+      if (!store) return memory.get(key) ?? null;
+      try {
+        return (await store.get(key)) ?? null;
+      } catch (error) {
+        warn('read', key, error);
+        return memory.get(key) ?? null;
+      }
+    },
+    setItem: async (key, value) => {
+      memory.set(key, value);
+      const store = flowStore(key);
+      if (!store) return;
+      try {
+        await store.set(key, value);
+      } catch (error) {
+        warn('store', key, error);
+      }
+    },
+    removeItem: async (key) => {
+      memory.delete(key);
+      const store = flowStore(key);
+      if (!store) return;
+      try {
+        await store.delete(key);
+      } catch (error) {
+        warn('clear', key, error);
+      }
+    },
+  };
+}
 
 /**
  * Singleton Supabase client with authentication helpers.
@@ -105,15 +191,19 @@ export class SupabaseClient {
   /**
    * Initialize the Supabase client with project credentials.
    */
-  static initialize(url: string, publicKey: string): void {
+  static initialize(
+    url: string,
+    publicKey: string,
+    secrets?: SessionSecretStore,
+  ): void {
     if (!url || !publicKey) {
       throw new Error(
         'Supabase credentials missing. Check the TeXRA configuration.',
       );
     }
-    // Idempotent re-init: returning the existing client preserves the in-memory
-    // PKCE code_verifier (persistSession:false) across the OAuth round-trip even
-    // if a host wires up the auth coordinator more than once.
+    // Idempotent re-init: returning the existing client preserves the pending
+    // PKCE flow state across the OAuth round-trip even if a host wires up the
+    // auth coordinator more than once.
     if (
       this.instance &&
       this.config?.url === url &&
@@ -124,11 +214,16 @@ export class SupabaseClient {
     this.config = { url, publicKey };
     this.instance = createClient(url, publicKey, {
       auth: {
-        persistSession: false, // The host's secret storage owns the session
+        // `persistSession` is what gates GoTrue's use of `storage` at all; the
+        // adapter above is what keeps this honest, writing PKCE flow state
+        // only and never the session, which the host's secret storage owns.
+        persistSession: true,
+        storage: gotrueStorage(secrets),
+        storageKey: SUPABASE_GOTRUE_STORAGE_KEY,
         autoRefreshToken: false, // Manual refresh via auth provider
         // PKCE: browser OAuth returns a one-time ?code= (not tokens) to the
-        // callback. The code_verifier stays in this client and is consumed by
-        // exchangeCodeForSession, so no access/refresh token ever transits the
+        // callback, which exchangeCodeForSession trades for a session using
+        // the stored verifier, so no access/refresh token ever transits the
         // browser or the auth-bridge page. detectSessionInUrl is off because
         // every host parses its own callback and exchanges the code explicitly.
         flowType: 'pkce',

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -75,7 +75,10 @@ function gotrueStorage(
       const store = flowStore(key);
       if (!store) return memory.get(key) ?? null;
       try {
-        return (await store.get(key)) ?? null;
+        // A degraded store can answer an absent value instead of throwing
+        // (e.g. a locked keychain that denies decryption). The mirrored write
+        // is still this window's best answer, so treat a miss like a failure.
+        return (await store.get(key)) ?? memory.get(key) ?? null;
       } catch (error) {
         warn('read', key, error);
         return memory.get(key) ?? null;

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -58,6 +58,25 @@ interface StableSessionSnapshot {
 }
 
 /**
+ * A code exchange with no stored verifier means this callback belongs to a
+ * sign-in attempt whose flow state is gone — a link opened on another machine,
+ * or one left over from before the session was cleared. GoTrue's own wording
+ * for it advises `@supabase/ssr` and cookies, which is meaningless in an
+ * editor, so say what the user can actually do.
+ */
+function describeCodeExchangeError(
+  error: { code?: string; message: string } | null,
+): string {
+  if (error?.code === 'pkce_code_verifier_not_found') {
+    return (
+      'this sign-in link is no longer valid. It was either opened on another ' +
+      'machine or left over from an earlier attempt. Start sign-in again.'
+    );
+  }
+  return error?.message || 'Code exchange failed';
+}
+
+/**
  * Host-neutral coordinator for Supabase session storage, token freshness,
  * OAuth callback conversion, and refresh. Host wrappers own UI and registration.
  */
@@ -231,7 +250,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     if (error || !data.session) {
       return {
         success: false,
-        error: error?.message || 'Code exchange failed',
+        error: describeCodeExchangeError(error),
         isAuthError: true,
       };
     }

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -271,3 +271,11 @@ export const TOKEN_REFRESH_THRESHOLD_MS = 30 * 60 * 1000;
 
 /** Key the stored Supabase session takes in the host's secret storage. */
 export const SUPABASE_SESSION_KEY = 'texra.supabase.session';
+
+/**
+ * GoTrue's own storage key. Pinned rather than left to the default derived
+ * from the URL host so the client's storage can tell the session slot (this
+ * exact key, kept in memory) from the PKCE flow state it derives from it
+ * (suffixed keys, persisted so a callback can land in any window).
+ */
+export const SUPABASE_GOTRUE_STORAGE_KEY = 'texra.supabase.gotrue';

--- a/src/test-kernel/auth/SupabaseClient.vitest.ts
+++ b/src/test-kernel/auth/SupabaseClient.vitest.ts
@@ -3,6 +3,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it, afterEach, expect, vi } from 'vitest';
 
 // Local imports - auth
+import { SUPABASE_GOTRUE_STORAGE_KEY } from '@auth/config';
 import {
   RELAY_CI_TOKEN_PREFIX,
   RELAY_TOKEN_ENV_VAR,
@@ -11,6 +12,7 @@ import {
 } from '@auth/relayToken';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import type { AuthTokenProvider } from '@auth/TokenProvider';
+import type { SessionSecretStore } from '@auth/oauth/sessionAccess';
 import * as logger from '@logger/logUtils';
 import { createDeferred } from '@test/support/asyncTestUtils';
 
@@ -278,5 +280,137 @@ describe('SupabaseClient', () => {
     );
 
     assert.equal(SupabaseClient.isTokenExpiringSoon(), true);
+  });
+});
+
+describe('SupabaseClient PKCE flow state', () => {
+  const SUPABASE_URL = 'https://example.supabase.co';
+  const VERIFIER_KEY = `${SUPABASE_GOTRUE_STORAGE_KEY}-code-verifier`;
+
+  afterEach(() => {
+    SupabaseClient.resetForTests();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  /** Stand-in for the host secret store, shared by every editor window. */
+  function secretStore(): SessionSecretStore & {
+    entries: Map<string, string>;
+  } {
+    const entries = new Map<string, string>();
+    return {
+      entries,
+      get: async (key) => entries.get(key),
+      set: async (key, value) => {
+        entries.set(key, value);
+      },
+      delete: async (key) => {
+        entries.delete(key);
+      },
+    };
+  }
+
+  /** Start browser OAuth without navigating, as a host window would. */
+  async function startSignIn(): Promise<void> {
+    const { error } = await SupabaseClient.getClient().auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: 'https://remote.texra.ai/functions/v1/auth-bridge/cursor/x',
+        skipBrowserRedirect: true,
+      },
+    });
+    assert.equal(error, null);
+  }
+
+  it('persists only the flow state, never the session slot', async () => {
+    const secrets = secretStore();
+    SupabaseClient.initialize(SUPABASE_URL, 'public-key', secrets);
+
+    await startSignIn();
+
+    // A flow start writes its numbered slot, the slot index, and the fixed
+    // legacy key the callback reads. All three are keys GoTrue derives from
+    // its storage key; the storage key itself is the session slot and must
+    // never appear here.
+    const keys = [...secrets.entries.keys()];
+    assert.ok(keys.includes(VERIFIER_KEY));
+    assert.ok(!keys.includes(SUPABASE_GOTRUE_STORAGE_KEY));
+    assert.ok(
+      keys.every((key) => key.startsWith(`${SUPABASE_GOTRUE_STORAGE_KEY}-`)),
+      `unexpected persisted keys: ${keys.join(', ')}`,
+    );
+  });
+
+  it('completes a callback delivered to a different client instance', async () => {
+    const secrets = secretStore();
+    SupabaseClient.initialize(SUPABASE_URL, 'public-key', secrets);
+    await startSignIn();
+    // GoTrue JSON-encodes every stored value; the slot holds the verifier
+    // alone, or `verifier/redirectType` for a recovery link.
+    const stored: unknown = JSON.parse(secrets.entries.get(VERIFIER_KEY) ?? '');
+    const verifier = String(stored).split('/')[0];
+    assert.ok(verifier);
+
+    // A second window (or the same one after a host reload): a fresh client
+    // that never generated a verifier of its own.
+    let exchangeBody = '';
+    const exchange: typeof fetch = async (_input, init) => {
+      exchangeBody = String(init?.body);
+      return new Response(
+        JSON.stringify({
+          access_token: 'pkce-access',
+          refresh_token: 'pkce-refresh',
+          token_type: 'bearer',
+          expires_in: 3600,
+          user: {
+            id: 'user-id',
+            aud: 'authenticated',
+            email: 'user@example.com',
+            app_metadata: {},
+            user_metadata: {},
+            created_at: new Date().toISOString(),
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    };
+    vi.stubGlobal('fetch', exchange);
+    SupabaseClient.resetForTests();
+    SupabaseClient.initialize(SUPABASE_URL, 'public-key', secrets);
+
+    const { data, error } =
+      await SupabaseClient.getClient().auth.exchangeCodeForSession('auth-code');
+
+    assert.equal(error, null);
+    assert.equal(data.session?.access_token, 'pkce-access');
+    assert.deepEqual(JSON.parse(exchangeBody), {
+      auth_code: 'auth-code',
+      code_verifier: verifier,
+    });
+    // The consumed verifier is cleared, and the session that replaced it is
+    // not written here: the host's own session record stays its single owner.
+    // (GoTrue leaves the numbered slot behind for a callback that carries no
+    // flow id; its own ring caps those at five.)
+    assert.ok(!secrets.entries.has(VERIFIER_KEY));
+    assert.ok(!secrets.entries.has(SUPABASE_GOTRUE_STORAGE_KEY));
+  });
+
+  it('still signs in this window when the secret store is unwritable', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const secrets: SessionSecretStore = {
+      get: async () => undefined,
+      set: async () => {
+        throw new Error('keychain locked');
+      },
+      delete: async () => {},
+    };
+    SupabaseClient.initialize(SUPABASE_URL, 'public-key', secrets);
+
+    await startSignIn();
+
+    expect(warn).toHaveBeenCalledWith(
+      'SupabaseClient',
+      expect.stringContaining('keychain locked'),
+    );
   });
 });

--- a/src/test-kernel/auth/SupabaseClient.vitest.ts
+++ b/src/test-kernel/auth/SupabaseClient.vitest.ts
@@ -397,6 +397,8 @@ describe('SupabaseClient PKCE flow state', () => {
 
   it('still signs in this window when the secret store is unwritable', async () => {
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    // A locked keychain answers an absent value (rather than throwing) on
+    // reads and throws on writes; only the in-process mirror remains usable.
     const secrets: SessionSecretStore = {
       get: async () => undefined,
       set: async () => {
@@ -411,6 +413,41 @@ describe('SupabaseClient PKCE flow state', () => {
     expect(warn).toHaveBeenCalledWith(
       'SupabaseClient',
       expect.stringContaining('keychain locked'),
+    );
+
+    // The callback lands in this window: the exchange must still succeed
+    // using the mirrored verifier even though the store miss returned absent.
+    let exchangeBody = '';
+    const exchange: typeof fetch = async (_input, init) => {
+      exchangeBody = String(init?.body);
+      return new Response(
+        JSON.stringify({
+          access_token: 'pkce-access',
+          refresh_token: 'pkce-refresh',
+          token_type: 'bearer',
+          expires_in: 3600,
+          user: {
+            id: 'user-id',
+            aud: 'authenticated',
+            email: 'user@example.com',
+            app_metadata: {},
+            user_metadata: {},
+            created_at: new Date().toISOString(),
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    };
+    vi.stubGlobal('fetch', exchange);
+
+    const { data, error } =
+      await SupabaseClient.getClient().auth.exchangeCodeForSession('auth-code');
+
+    assert.equal(error, null);
+    assert.equal(data.session?.access_token, 'pkce-access');
+    assert.ok(
+      JSON.parse(exchangeBody).code_verifier.length > 0,
+      'the exchange reused the verifier mirrored in memory',
     );
   });
 });

--- a/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
+++ b/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
@@ -473,6 +473,33 @@ describe('SupabaseSession', () => {
       assert.equal(result.isAuthError, true);
     });
 
+    it('rewrites a missing-verifier exchange failure as a dead link', async () => {
+      const client = {
+        auth: {
+          exchangeCodeForSession: async () => ({
+            data: { session: null },
+            error: {
+              code: 'pkce_code_verifier_not_found',
+              message:
+                'PKCE code verifier not found in storage. ... use @supabase/ssr ...',
+            },
+          }),
+        },
+      } as unknown as Client;
+      const { coordinator } = createCoordinator({ client });
+
+      const result = await coordinator.createSessionFromCallback({
+        path: '/auth-callback',
+        query: 'code=stale-code',
+      });
+
+      assert.equal(result.success, false);
+      if (result.success) return;
+      assert.match(result.error, /no longer valid/);
+      assert.doesNotMatch(result.error, /supabase\/ssr/);
+      assert.equal(result.isAuthError, true);
+    });
+
     it('rejects retired implicit-token callbacks', async () => {
       const { coordinator } = createCoordinator();
 


### PR DESCRIPTION
## The bug

Signing in through the browser fails with:

> Sign-in failed: PKCE code verifier not found in storage. This can happen if the auth flow was initiated in a different browser or device, or if the storage was cleared. For SSR frameworks (Next.js, SvelteKit, etc.), use @supabase/ssr on both the server and client to store the code verifier in cookies.

Browser OAuth is a two-hop handshake: the editor window that starts sign-in generates the PKCE `code_verifier`, and the deep link carrying the one-time `?code=` back is delivered by the OS to whichever window the editor picks — not necessarily that one. GoTrue's storage for a `persistSession: false` client is a plain in-process object (`GoTrueClient.ts:511`), so a callback landing in another window, or in the same one after an extension-host reload, found no verifier and died on the late-callback path (`SupabaseAuthProvider.ts:143` — the `Sign-in failed:` prefix is unique to it, and it only runs when no sign-in is in flight in that window).

Recovering means signing out and starting over, which is what the reporter did.

## The fix

Give the shared client a storage that routes every key GoTrue derives from its storage key — the `-code-verifier` slots and their index — to the host secret store, which is shared across windows and survives a reload.

The bare storage key is GoTrue's session slot and deliberately stays in memory: the host's own session record remains the single owner of the signed-in session, so nothing session-shaped is ever persisted. `persistSession` flips to `true` only because that flag is what gates GoTrue's use of `storage` at all — it changes nothing about session ownership, and `SupabaseAuthProvider.removeSession`'s reasoning (never call `auth.signOut()`) still holds for the same reason it did before.

Two details worth knowing:

- **auth-js 2.112 writes three flow-state keys per start**, not one: a numbered slot, a slot index, and the fixed legacy key. The legacy key is what a callback without a flow id reads, and TeXRA's callbacks never carry one — the auth-bridge deep link deliberately keeps `redirect_to` free of query parameters, and adopting `sb_flow_id` would reintroduce the `?` that design avoids. So the numbered slot is left behind on exchange. GoTrue's own ring caps those at five and evicts the oldest, and they hold spent verifiers, worthless without their single-use auth code. Bounded, and documented in the code.
- **A secret-store failure degrades loudly**: writes are mirrored in memory, so a locked keychain logs a warning and falls back to today's same-window-only behavior rather than losing the flow outright.

## Also

A genuinely dead link (opened on another machine, or left over from before a sign-out) no longer surfaces GoTrue's wording, which advises `@supabase/ssr` and cookies — meaningless in an editor. It now says the link is no longer valid and to start sign-in again.

## Tests

`src/test-kernel/auth/`:

- **the cross-window case, end to end** — drives a real sign-in through one client, then builds a *fresh* client instance over the same secret store and asserts it sends the first client's verifier in the exchange body
- only flow state is persisted, never the session slot
- a completed exchange clears the consumed verifier and writes no session
- an unwritable secret store warns and still signs in this window
- the dead-link message rewrite

## Verification

`npm run typecheck`, `npm run lint`, `npm test` (833 files, 8770 tests), and `npm run check:dead-code-ratchet` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UE6vX8ZwUFw4sNUfGmEq93

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth PKCE persistence and Supabase client init across hosts; session tokens are still not written to the secret store by design, but auth sign-in reliability is security-sensitive.
> 
> **Overview**
> Fixes browser sign-in failing with **`pkce_code_verifier_not_found`** when the OAuth callback lands in a different editor window or after an extension-host reload. The shared Supabase client now uses custom GoTrue **`storage`** that writes **PKCE flow keys** (verifier slots and index) to the host **secret store**, shared across windows, while keeping the bare session storage key **in memory** so the host’s session record stays the sole persisted session owner.
> 
> **`persistSession`** is set to **`true`** only so GoTrue uses that adapter; **`createHostAuthCoordinator`** passes **`init.secrets`** into **`SupabaseClient.initialize`**. **`SUPABASE_GOTRUE_STORAGE_KEY`** pins the storage key for routing. Secret-store failures **warn** and fall back to an in-process mirror (same-window sign-in still works).
> 
> Stale or cross-machine callbacks map **`pkce_code_verifier_not_found`** to a user-facing “link no longer valid, start sign-in again” message instead of GoTrue’s SSR/cookie guidance. Tests cover cross-instance exchange, flow-only persistence, and degraded storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b7adfda1a139115880a4a71ae893f4867e10d86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->