### PR TITLE
fix(cli): show "idle" for subagents waiting on a decision

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2844,7 +2844,7 @@ const SCENARIOS = [
     bootExpect: 'Tab sessions',
     keys: ['\t', DOWN, DOWN],
     resizes: [{ cols: 44, rows: 7 }],
-    expect: ['leanSolver w', '+3 sessions'],
+    expect: ['leanSolver…', '+3 sessions'],
     maxOccurrences: [{ text: 'leanSolver idle', max: 1 }],
   },
   {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2725,7 +2725,7 @@ const SCENARIOS = [
     keys: ['\t'],
     expect: [
       'strategy running',
-      'leanSolver waiting for you',
+      'leanSolver idle',
       'reviewer error',
       '3 sub',
       'Tab input',
@@ -2845,7 +2845,7 @@ const SCENARIOS = [
     keys: ['\t', DOWN, DOWN],
     resizes: [{ cols: 44, rows: 7 }],
     expect: ['leanSolver w', '+3 sessions'],
-    maxOccurrences: [{ text: 'leanSolver waiting for you', max: 1 }],
+    maxOccurrences: [{ text: 'leanSolver idle', max: 1 }],
   },
   {
     name: 'subagent-list-remembers-selection',
@@ -3122,7 +3122,7 @@ const SCENARIOS = [
     bootExpect: 'Tab sessions',
     keys: ['\t', DOWN, DOWN, DOWN, 'k', '\r', '\t', UP, '\r'],
     frame: 'viewport',
-    expect: ['◆ waiting for you', 'root active'],
+    expect: ['◆ idle', 'root active'],
     unexpect: [
       'Harness interrupt requested.',
       STOPPED_SUBAGENT_INPUT_MESSAGE_START,
@@ -3245,7 +3245,7 @@ const SCENARIOS = [
       'Harness focused interrupt requested for harness-stream-1.',
       '› ✓ ● main stopped',
       'strategy running',
-      'leanSolver waiting for you',
+      'leanSolver idle',
       'reviewer running',
       '3 sub',
       'Choosing a session',
@@ -3273,7 +3273,7 @@ const SCENARIOS = [
     frame: 'viewport',
     expect: [
       'strategy stopped',
-      'leanSolver waiting for you',
+      'leanSolver idle',
       'reviewer running',
       '3 subagents',
       'Choosing a session',
@@ -3294,7 +3294,7 @@ const SCENARIOS = [
     expect: [
       'strategy stopped',
       '› ✓ ● reviewer running',
-      'leanSolver waiting for you',
+      'leanSolver idle',
       'Tab input',
       'Ctrl-C stop root',
     ],
@@ -3328,7 +3328,7 @@ const SCENARIOS = [
     bootExpect: 'Tab sessions',
     keys: [{ input: ESC, delayMs: 80 }, '2'],
     frame: 'viewport',
-    expect: ['waiting for you', 'root active', 'Tab sessions'],
+    expect: ['idle', 'root active', 'Tab sessions'],
     unexpect: [
       'Harness focused interrupt requested',
       'Harness interrupt requested.',

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -44,16 +44,15 @@ export function formatCliStatusLabel(
   substate?: StreamSubstate,
   isChildStream?: boolean,
 ): string {
-  // `formatStreamStatusLabel`'s 'cli' style already covers the child-stream
-  // vocabulary end to end, including the WAITING -> "waiting for you"
-  // override (`CLI_CHILD_WAITING_LABEL`) — no separate probe is needed here.
-  // A blank status renders as '' for a child row (no status column yet) and
-  // as '—' for the root session (an established placeholder slot).
+  // `formatStreamStatusLabel`'s 'cli' style covers the child-stream
+  // vocabulary end to end, including WAITING -> "idle" — no separate probe is
+  // needed here. A blank status renders as '' for a child row (no status
+  // column yet) and as '—' for the root session (an established placeholder
+  // slot).
   return formatStreamStatusLabel(status, {
     style: 'cli',
     missingLabel: isChildStream ? '' : '—',
     ...(substate ? { substate } : {}),
-    ...(isChildStream ? { isChildStream } : {}),
   });
 }
 

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -70,21 +70,10 @@ const STREAM_STATUS_LABELS = {
 
 export type StreamStatusLabelStyle = keyof typeof STREAM_STATUS_LABELS;
 
-// A child/subagent stream suspended at WAITING is stalled awaiting a
-// reply-or-stop decision from whoever is looking at it — a different
-// situation from the root session's ordinary idle-between-turns WAITING, so
-// the CLI styles ('cli'/'cliCompact', which otherwise fold WAITING into the
-// root's "idle" wording) use this distinct label instead. `progressHeader`
-// shows the same "Idle" for root and child, so it needs no such split.
-const CLI_CHILD_WAITING_LABEL = 'waiting for you';
-
 interface FormatStreamStatusLabelOptions {
   readonly style?: StreamStatusLabelStyle;
   readonly missingLabel?: string;
   readonly substate?: StreamSubstate;
-  /** True when `status` belongs to a child/subagent stream rather than the
-   *  root session — see `CLI_CHILD_WAITING_LABEL`. */
-  readonly isChildStream?: boolean;
 }
 
 export function formatStreamStatusLabel(
@@ -110,13 +99,6 @@ export function formatStreamStatusLabel(
   const style = options.style ?? 'progressHeader';
   const key = streamStatusDisplayKey(status, options.substate);
   if (!key) return status;
-  if (
-    options.isChildStream &&
-    key === STREAM_PHASE.WAITING &&
-    (style === 'cli' || style === 'cliCompact')
-  ) {
-    return CLI_CHILD_WAITING_LABEL;
-  }
   return STREAM_STATUS_LABELS[style][key];
 }
 

--- a/src/test-kernel/cli/SessionStatus.vitest.ts
+++ b/src/test-kernel/cli/SessionStatus.vitest.ts
@@ -227,9 +227,9 @@ describe('CLI session status formatter', () => {
     ).toContain('status: idle');
   });
 
-  it('uses the distinct child-stream label for a subagent stalled on follow-up', () => {
+  it('uses the idle wording for a subagent stalled on follow-up', () => {
     expect(formatCliStatusLabel(STREAM_PHASE.WAITING, undefined, true)).toBe(
-      'waiting for you',
+      'idle',
     );
   });
 

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -922,7 +922,7 @@ describe('CLI StatusBar display model', () => {
     expect(leftTexts(stoppedRootDisplay)).not.toContain('root active');
   });
 
-  it('labels a focused WAITING child distinctly from the root idle wording', () => {
+  it('shows the idle wording for a focused WAITING child and root alike', () => {
     const rootDisplay = buildStatusBarDisplay(
       statusInput({ status: STREAM_PHASE.WAITING, isChildStream: false }),
     );
@@ -936,8 +936,7 @@ describe('CLI StatusBar display model', () => {
         shortcuts: STREAM_NAV_SHORTCUTS,
       }),
     );
-    expect(leftTexts(childDisplay)).toContain('waiting for you');
-    expect(leftTexts(childDisplay)).not.toContain('idle');
+    expect(leftTexts(childDisplay)).toContain('idle');
   });
 
   it.each([

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -709,7 +709,7 @@ describe('CLI child list display model', () => {
 
     expect(output).toContain('reviewer completed');
     expect(output).toContain('critic error');
-    expect(output).toContain('editor waiting for you');
+    expect(output).toContain('editor idle');
     expect(output).toContain('attached');
     expect(output).not.toContain('attached —');
   });

--- a/src/test-kernel/shared/SharedStreams.vitest.ts
+++ b/src/test-kernel/shared/SharedStreams.vitest.ts
@@ -224,6 +224,15 @@ describe('stream status display labels', () => {
     },
   );
 
+  it('labels a WAITING child stream with the same "idle" wording as the root', () => {
+    expect(
+      formatStreamStatusLabel(STREAM_PHASE.WAITING, { style: 'cli' }),
+    ).toBe('idle');
+    expect(
+      formatStreamStatusLabel(STREAM_PHASE.WAITING, { style: 'cliCompact' }),
+    ).toBe('idle');
+  });
+
   const substateWordingCases: Array<[StreamStatusLabelStyle, string]> = [
     ['cli', 'starting\u2026'],
     ['cliCompact', 'starting'],
@@ -241,43 +250,6 @@ describe('stream status display labels', () => {
       ).toBe(label);
     },
   );
-
-  it('labels a child stream WAITING distinctly from the root idle wording (cli)', () => {
-    expect(
-      formatStreamStatusLabel(STREAM_PHASE.WAITING, {
-        style: 'cli',
-        isChildStream: true,
-      }),
-    ).toBe('waiting for you');
-    // Unset (or false) isChildStream keeps the root's plain "idle" wording.
-    expect(
-      formatStreamStatusLabel(STREAM_PHASE.WAITING, { style: 'cli' }),
-    ).toBe('idle');
-    expect(
-      formatStreamStatusLabel(STREAM_PHASE.WAITING, {
-        style: 'cli',
-        isChildStream: false,
-      }),
-    ).toBe('idle');
-  });
-
-  it('ignores isChildStream for the progressHeader style, which shows the same "Idle" for root and child', () => {
-    expect(
-      formatStreamStatusLabel(STREAM_STATUS.WAITING, {
-        style: 'progressHeader',
-        isChildStream: true,
-      }),
-    ).toBe('Idle');
-  });
-
-  it('ignores isChildStream for statuses other than WAITING', () => {
-    expect(
-      formatStreamStatusLabel(STREAM_PHASE.COMPLETED, {
-        style: 'cli',
-        isChildStream: true,
-      }),
-    ).toBe('completed');
-  });
 
   it('passes through unknown statuses and supports an explicit missing label', () => {
     expect(formatStreamStatusLabel('custom')).toBe('custom');


### PR DESCRIPTION
## Summary

The CLI TUI's child-stream WAITING label ("waiting for you") is retired: a
subagent stalled awaiting a follow-up now reads the same "idle" wording as
the root session in the status bar, status line, and subagent list.

Since the child label would now be identical to the base `cli`/`cliCompact`
WAITING wording, the child-stream special case in
`formatStreamStatusLabel` is removed entirely rather than left as a no-op:

- `src/shared/streams/streamStatusDisplay.ts` — drop `CLI_CHILD_WAITING_LABEL`,
  the `isChildStream` option, and the WAITING branch.
- `packages/cli/src/chat/tui/sessionStatus.ts` — `formatCliStatusLabel` keeps
  its `isChildStream` parameter (still used for the blank-vs-em-dash missing
  label), but no longer forwards it to the label formatter.
- `packages/cli/scripts/validate-tui.mjs` — TUI golden expectations updated
  (`leanSolver idle`, `◆ idle`, ...).
- Test updates in `SharedStreams`, `StatusBar`, `SubagentListDisplay`,
  `SessionStatus` vitest files pin the new shared wording.

## Single source of truth

`STREAM_STATUS_LABELS` in `src/shared/streams/streamStatusDisplay.ts` remains
the sole owner of every status label; the child-specific override was the
exception and is gone.

## Duplication and abstraction budget

No new abstraction. The `isChildStream` flag survives only where it still
means something (placeholder vs missing-label in `formatCliStatusLabel`).

## Net elements (R6)

7 files, +26/−74 lines; no exported symbols added. One exported function's
option type (`FormatStreamStatusLabelOptions`) shrinks by one field.

## Consumer counts (R8)

`formatStreamStatusLabel`'s `isChildStream` option: 0 remaining consumers
(previously 1 — `formatCliStatusLabel`). Grep of the workspace confirms no
other reference to "waiting for you" remains in `src/` or `packages/`.

## Host impact

Extension/Desktop: none (progress-header styles already used "Idle" for
root and child).

CLI: TUI status bar, status line, and subagent list now show "idle" for a
WAITING child stream.

## Scheduled refactoring

None. Note: an obsolete local-only branch `fix/idle-stream-status`
(`4ce2ed36ad`, Aug 3) contains an unmerged predecessor of this change —
safe to delete once this PR lands.

## Validation

- `vitest run` on the four affected files: 180 tests pass.
- `tsc --noEmit` (workspace + test-kernel) and `@texra-ai/cli` typecheck pass.
- `validate:tui`: all subagent-label scenarios pass; one unrelated scenario
  (`root-print-full-tool-output`) fails identically on baseline `main`
  (pre-existing, transcript full-output modal — not touched by this change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI label change only in display code and tests; no auth, persistence, or stream lifecycle logic changes.
> 
> **Overview**
> **Unifies CLI wording** for streams in `WAITING`: child/subagent rows no longer use **"waiting for you"** and instead show **"idle"**, matching the root session in the status bar, status line, and subagent list.
> 
> In **`streamStatusDisplay.ts`**, the **`CLI_CHILD_WAITING_LABEL`** override and the **`isChildStream`** option on **`formatStreamStatusLabel`** are removed so **`STREAM_STATUS_LABELS`** is the only source for CLI labels. **`formatCliStatusLabel`** still accepts **`isChildStream`** for blank vs em-dash missing labels but no longer passes it into the formatter.
> 
> TUI harness expectations and vitest coverage are updated accordingly; no Extension/Desktop change (**progressHeader** already used **"Idle"** for everyone).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 238f2d9488eaba03fd7782e1c1cfe08fd99d61d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->