### PR TITLE
fix(progress-view): offer the inline diff only where it can render

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -31,6 +31,25 @@ import { BaseBypassApprovalPanel } from './BaseBypassApprovalPanel';
 // Local imports - styles
 import { toolEditRequestPanelStyles } from './ToolEditRequestPanel.styles';
 
+/**
+ * Whether this host can render the inline Monaco diff.
+ *
+ * `<texra-diff-view>` is registered by the desktop renderer alone
+ * (`desktop/src/renderer/main.ts`). The extension webview and the trace viewer
+ * deliberately ship no Monaco — the extension opens the real diff through VS
+ * Code's own `vscode.diff`, which the `openDiff` action below reaches. Without
+ * this check the diff button toggled an unregistered, empty element in those
+ * hosts *and* shadowed the working path, since the inline branch wins whenever
+ * the payload carries content.
+ *
+ * Checked per call rather than once at module scope: this module is pulled in
+ * through the progressView barrel, which the desktop imports one line *before*
+ * it registers the element.
+ */
+function inlineDiffSupported(): boolean {
+  return customElements.get('texra-diff-view') !== undefined;
+}
+
 @customElement('tool-edit-request-panel')
 export class ToolEditRequestPanel extends BaseBypassApprovalPanel<'toolEdit'> {
   static override styles = [
@@ -205,6 +224,7 @@ export class ToolEditRequestPanel extends BaseBypassApprovalPanel<'toolEdit'> {
   };
 
   private hasInlineDiff(data: ToolEditPermission): boolean {
+    if (!inlineDiffSupported()) return false;
     return data.originalContent != null || data.proposedContent != null;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -31,25 +31,6 @@ import { BaseBypassApprovalPanel } from './BaseBypassApprovalPanel';
 // Local imports - styles
 import { toolEditRequestPanelStyles } from './ToolEditRequestPanel.styles';
 
-/**
- * Whether this host can render the inline Monaco diff.
- *
- * `<texra-diff-view>` is registered by the desktop renderer alone
- * (`desktop/src/renderer/main.ts`). The extension webview and the trace viewer
- * deliberately ship no Monaco — the extension opens the real diff through VS
- * Code's own `vscode.diff`, which the `openDiff` action below reaches. Without
- * this check the diff button toggled an unregistered, empty element in those
- * hosts *and* shadowed the working path, since the inline branch wins whenever
- * the payload carries content.
- *
- * Checked per call rather than once at module scope: this module is pulled in
- * through the progressView barrel, which the desktop imports one line *before*
- * it registers the element.
- */
-function inlineDiffSupported(): boolean {
-  return customElements.get('texra-diff-view') !== undefined;
-}
-
 @customElement('tool-edit-request-panel')
 export class ToolEditRequestPanel extends BaseBypassApprovalPanel<'toolEdit'> {
   static override styles = [
@@ -224,7 +205,11 @@ export class ToolEditRequestPanel extends BaseBypassApprovalPanel<'toolEdit'> {
   };
 
   private hasInlineDiff(data: ToolEditPermission): boolean {
-    if (!inlineDiffSupported()) return false;
+    // Only the desktop registers <texra-diff-view>; the extension and trace
+    // viewer ship no Monaco and fall through to openDiff (VS Code's own diff).
+    // Read per call, not at module scope: the desktop imports the progressView
+    // barrel — and so this module — one line before it registers the element.
+    if (customElements.get('texra-diff-view') === undefined) return false;
     return data.originalContent != null || data.proposedContent != null;
   }
 }

--- a/src/test-kernel/progressView/ToolEditRequestPanel.vitest.ts
+++ b/src/test-kernel/progressView/ToolEditRequestPanel.vitest.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports
 import type { ToolEditRequestPanel } from '@progressView/frontend/components/ToolEditRequestPanel';
@@ -67,6 +67,17 @@ describe('tool-edit-request-panel', () => {
   useLitComponentTestDom(
     () => import('@progressView/frontend/components/ToolEditRequestPanel'),
   );
+
+  // This suite exercises the desktop, the only host that registers
+  // `<texra-diff-view>` and so the only one offering the inline diff. A stub
+  // stands in for the Monaco-backed element: the panel only sets properties on
+  // it, and registration is what the panel actually branches on. The
+  // extension/trace-viewer behavior lives in
+  // ToolEditRequestPanelWithoutMonaco.vitest.ts, which needs a registry that
+  // never sees this definition.
+  beforeAll(() => {
+    customElements.define('texra-diff-view', class extends HTMLElement {});
+  });
 
   it('uses a shared tooltip for the direct diff action', async () => {
     const element = await mountPanel(

--- a/src/test-kernel/progressView/ToolEditRequestPanelWithoutMonaco.vitest.ts
+++ b/src/test-kernel/progressView/ToolEditRequestPanelWithoutMonaco.vitest.ts
@@ -1,0 +1,96 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import type { ToolEditRequestPanel } from '@progressView/frontend/components/ToolEditRequestPanel';
+import type { ToolEditPermission } from '@shared/schemas';
+import { recordPermissionActions } from '@test/support/permissionPanelEvents';
+
+// Local file imports
+import {
+  mountComponent,
+  useLitComponentTestDom,
+} from '../settings/litComponentTestUtils';
+
+// The extension webview and the trace viewer ship no Monaco and never register
+// `<texra-diff-view>`; the desktop renderer does. That registration is the only
+// difference, so this file deliberately defines no stub for it — a separate
+// file, because a custom-element registry cannot un-define a tag once
+// ToolEditRequestPanel.vitest.ts has registered it.
+function createPermission(
+  data: Partial<ToolEditPermission>,
+): ToolEditRequestPanel['permission'] {
+  return {
+    kind: 'toolEdit',
+    data: {
+      requestId: 'request-1',
+      allowBypass: false,
+      streamId: '',
+      path: '/workspace/example.ts',
+      relativePath: 'example.ts',
+      sourceTool: 'edit',
+      addedLines: 1,
+      removedLines: 0,
+      isLatex: false,
+      ...data,
+    },
+  };
+}
+
+function mountPanel(
+  permission: ToolEditRequestPanel['permission'],
+): Promise<ToolEditRequestPanel> {
+  return mountComponent<ToolEditRequestPanel>('tool-edit-request-panel', {
+    permission,
+  });
+}
+
+const WITH_CONTENT = {
+  originalContent: 'before',
+  proposedContent: 'after',
+} as const;
+
+describe('tool-edit-request-panel in a host without Monaco', () => {
+  useLitComponentTestDom(
+    () => import('@progressView/frontend/components/ToolEditRequestPanel'),
+  );
+
+  it('delegates to the host diff instead of rendering an unregistered element', async () => {
+    // Carrying the content is what used to switch the button to the inline
+    // branch. In a host that cannot render it, that branch produced an empty
+    // box and swallowed the openDiff action that opens VS Code's own diff.
+    const element = await mountPanel(createPermission(WITH_CONTENT));
+    const actions = recordPermissionActions(element);
+
+    expect(element.handleKeyboardShortcut('d')).toBe(true);
+    await element.updateComplete;
+
+    expect(actions).toEqual([{ action: 'openDiff' }]);
+    expect(element.shadowRoot?.querySelector('texra-diff-view')).toBeNull();
+  });
+
+  it('labels the button for the host diff, not an inline toggle', async () => {
+    const element = await mountPanel(createPermission(WITH_CONTENT));
+
+    const button = element.shadowRoot?.querySelector('#tool-edit-diff-button');
+    expect(button?.textContent?.trim()).toContain('Open diff');
+    expect(
+      element.shadowRoot
+        ?.querySelector('wa-tooltip[for="tool-edit-diff-button"]')
+        ?.textContent?.trim(),
+    ).toBe('Open diff (d)');
+  });
+
+  it('keeps delegating on a second press rather than toggling state', async () => {
+    const element = await mountPanel(createPermission(WITH_CONTENT));
+    const actions = recordPermissionActions(element);
+
+    element.handleKeyboardShortcut('d');
+    await element.updateComplete;
+    element.handleKeyboardShortcut('d');
+    await element.updateComplete;
+
+    expect(actions).toEqual([{ action: 'openDiff' }, { action: 'openDiff' }]);
+    expect(element.shadowRoot?.querySelector('texra-diff-view')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #9883. Follow-up to #9881, which surfaced this while tracing where Monaco was reachable from.

## The bug

`<texra-diff-view>` is registered by the desktop renderer alone (`desktop/src/renderer/main.ts:24`). `ToolEditRequestPanel` renders that tag from the shared component library, so in the **extension webview** and the **trace viewer** — neither of which ships Monaco — expanding the inline diff produced an empty, unregistered element.

The worse half was silent. `hasInlineDiff` was true whenever the payload carried `originalContent`/`proposedContent`, and that branch *wins* over the `openDiff` action:

```ts
private handleDiffAction = (): void => {
  if (this.hasInlineDiff(data)) { this.inlineDiffOpen = !this.inlineDiffOpen; return; }
  this.emitAction({ action: 'openDiff' });   // <- VS Code's own diff, unreachable
};
```

So in the extension the diff button stopped opening `vscode.diff` and started toggling an empty box — for exactly the requests that had content to show. The button label followed suit ("Open inline diff (d)").

## The fix

The extension does not need a second diff surface; `vscode.diff` is the right one there. Gate the inline branch on the element actually being registered:

```ts
function inlineDiffSupported(): boolean {
  return customElements.get('texra-diff-view') !== undefined;
}
```

Desktop keeps the inline diff. The extension and trace viewer fall through to `openDiff` — which is what the button did before payloads started carrying content.

A function, not a module-scope constant, and the comment says why: this module is pulled in through the progressView barrel, which the desktop imports one line *before* it registers the element, so evaluating once at import time reads `false` on every host.

## Tests

The existing suite covered only the desktop shape without saying so — it asserted the inline diff renders while never registering `<texra-diff-view>`, i.e. it asserted the bug (`querySelector` happily returns an unregistered tag, and Lit sets properties on it either way). It now registers a stub and reads as the desktop suite it always was.

The extension/trace-viewer behavior gets its own file, `ToolEditRequestPanelWithoutMonaco.vitest.ts`, because a custom-element registry cannot un-define a tag once the other file has defined it. It asserts the button delegates to `openDiff`, renders no `texra-diff-view`, keeps delegating on a second press rather than toggling hidden state, and is labelled "Open diff".

I removed the gate and re-ran: all three new tests fail. Restored, and they pass.

## Verified

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run check:dead-code-ratchet` — 16 findings vs 16 baselined, no new
- Full progressView suite — 57 files, 460 tests, all pass

## Note

This is behavior-visible in the extension: the diff button now opens the VS Code diff tab in cases where it previously toggled an empty inline panel. That is the intended restoration, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1v8pyQmxievwhMQzzzUsX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shared UI branching change with clear host detection and dedicated tests; extension behavior is an intentional fix restoring VS Code diff, not a silent regression.
> 
> **Overview**
> **Fixes extension/trace-viewer diff button** when edit payloads include `originalContent`/`proposedContent`. The panel used to treat that as inline-diff mode and toggle an empty `<texra-diff-view>` instead of emitting `openDiff` for VS Code’s diff tab.
> 
> `hasInlineDiff` in `ToolEditRequestPanel` now returns false unless `customElements.get('texra-diff-view')` is defined (desktop only), so hosts without Monaco keep the “Open diff” label and delegate every press to `openDiff`.
> 
> Tests are split: the existing suite registers a stub element and documents desktop behavior; **`ToolEditRequestPanelWithoutMonaco.vitest.ts`** asserts delegation, labels, and no inline toggle when the tag is never registered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc59af727812bd2bd77dcec4a462d2ec98f5f3ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->