### PR TITLE
refactor(auth): tighten the PKCE storage seam

### DIFF
--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -51,58 +51,50 @@ import type {
  * five and evicts the oldest, so the leftovers are bounded and hold spent
  * verifiers, which are worthless without their single-use auth code.
  */
-function gotrueStorage(
-  secrets: SessionSecretStore | undefined,
-): SupportedStorage {
+function gotrueStorage(secrets: SessionSecretStore): SupportedStorage {
   // Writes are mirrored here so a secret-store failure degrades to the old
   // in-process behavior (same-window sign-in still completes) instead of
   // losing the flow outright.
   const memory = new Map<string, string>();
-  const flowStore = (key: string): SessionSecretStore | null =>
-    secrets !== undefined && key !== SUPABASE_GOTRUE_STORAGE_KEY
-      ? secrets
-      : null;
-  const warn = (action: string, key: string, error: unknown): void => {
-    logger.warn(
-      'SupabaseClient',
-      `Could not ${action} PKCE flow state (${key}); sign-in will only be ` +
-        `completable in this window: ${toErrorMessage(error)}`,
-    );
+
+  /**
+   * Run one secret-store operation, unless the key is the session slot. That
+   * slot and a failed store both answer `undefined`, which every caller
+   * resolves against the memory mirror.
+   */
+  const onFlowState = async <T>(
+    action: string,
+    key: string,
+    run: () => Promise<T>,
+  ): Promise<T | undefined> => {
+    if (key === SUPABASE_GOTRUE_STORAGE_KEY) return undefined;
+    try {
+      return await run();
+    } catch (error) {
+      logger.warn(
+        'SupabaseClient',
+        `Could not ${action} PKCE flow state (${key}); sign-in will only be ` +
+          `completable in this window: ${toErrorMessage(error)}`,
+      );
+      return undefined;
+    }
   };
 
   return {
-    getItem: async (key) => {
-      const store = flowStore(key);
-      if (!store) return memory.get(key) ?? null;
-      try {
-        // A degraded store can answer an absent value instead of throwing
-        // (e.g. a locked keychain that denies decryption). The mirrored write
-        // is still this window's best answer, so treat a miss like a failure.
-        return (await store.get(key)) ?? memory.get(key) ?? null;
-      } catch (error) {
-        warn('read', key, error);
-        return memory.get(key) ?? null;
-      }
-    },
+    // A degraded store can answer an absent value instead of throwing (e.g. a
+    // locked keychain that denies decryption). The mirrored write is still
+    // this window's best answer, so a miss falls back like a failure does.
+    getItem: async (key) =>
+      (await onFlowState('read', key, () => secrets.get(key))) ??
+      memory.get(key) ??
+      null,
     setItem: async (key, value) => {
       memory.set(key, value);
-      const store = flowStore(key);
-      if (!store) return;
-      try {
-        await store.set(key, value);
-      } catch (error) {
-        warn('store', key, error);
-      }
+      await onFlowState('store', key, () => secrets.set(key, value));
     },
     removeItem: async (key) => {
       memory.delete(key);
-      const store = flowStore(key);
-      if (!store) return;
-      try {
-        await store.delete(key);
-      } catch (error) {
-        warn('clear', key, error);
-      }
+      await onFlowState('clear', key, () => secrets.delete(key));
     },
   };
 }
@@ -197,7 +189,7 @@ export class SupabaseClient {
   static initialize(
     url: string,
     publicKey: string,
-    secrets?: SessionSecretStore,
+    secrets: SessionSecretStore,
   ): void {
     if (!url || !publicKey) {
       throw new Error(

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -58,25 +58,6 @@ interface StableSessionSnapshot {
 }
 
 /**
- * A code exchange with no stored verifier means this callback belongs to a
- * sign-in attempt whose flow state is gone — a link opened on another machine,
- * or one left over from before the session was cleared. GoTrue's own wording
- * for it advises `@supabase/ssr` and cookies, which is meaningless in an
- * editor, so say what the user can actually do.
- */
-function describeCodeExchangeError(
-  error: { code?: string; message: string } | null,
-): string {
-  if (error?.code === 'pkce_code_verifier_not_found') {
-    return (
-      'this sign-in link is no longer valid. It was either opened on another ' +
-      'machine or left over from an earlier attempt. Start sign-in again.'
-    );
-  }
-  return error?.message || 'Code exchange failed';
-}
-
-/**
  * Host-neutral coordinator for Supabase session storage, token freshness,
  * OAuth callback conversion, and refresh. Host wrappers own UI and registration.
  */
@@ -248,9 +229,19 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
       .auth.exchangeCodeForSession(code);
 
     if (error || !data.session) {
+      // A missing verifier means this callback belongs to a sign-in attempt
+      // whose flow state is gone — a link opened on another machine, or one
+      // left over from before the session was cleared. GoTrue's own wording
+      // for it advises `@supabase/ssr` and cookies, which is meaningless in
+      // an editor, so say what the user can actually do.
       return {
         success: false,
-        error: describeCodeExchangeError(error),
+        error:
+          error?.code === 'pkce_code_verifier_not_found'
+            ? 'this sign-in link is no longer valid. It was either opened on ' +
+              'another machine or left over from an earlier attempt. Start ' +
+              'sign-in again.'
+            : error?.message || 'Code exchange failed',
         isAuthError: true,
       };
     }

--- a/src/test-kernel/auth/SupabaseClient.vitest.ts
+++ b/src/test-kernel/auth/SupabaseClient.vitest.ts
@@ -14,6 +14,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import type { AuthTokenProvider } from '@auth/TokenProvider';
 import type { SessionSecretStore } from '@auth/oauth/sessionAccess';
 import * as logger from '@logger/logUtils';
+import { FakeSecrets } from '@test/support/FakePlatform';
 import { createDeferred } from '@test/support/asyncTestUtils';
 
 async function withRelayTokenEnv(
@@ -219,7 +220,11 @@ describe('SupabaseClient', () => {
       whenReady: () => readiness.promise,
     });
 
-    SupabaseClient.initialize('https://example.supabase.co', 'public-key');
+    SupabaseClient.initialize(
+      'https://example.supabase.co',
+      'public-key',
+      new FakeSecrets(),
+    );
     SupabaseClient.setAuthProvider(provider);
 
     let settled = false;
@@ -243,7 +248,11 @@ describe('SupabaseClient', () => {
       },
     });
 
-    SupabaseClient.initialize('https://example.supabase.co', 'public-key');
+    SupabaseClient.initialize(
+      'https://example.supabase.co',
+      'public-key',
+      new FakeSecrets(),
+    );
     SupabaseClient.setAuthProvider(provider);
 
     assert.equal(await SupabaseClient.isReady(), false);
@@ -293,69 +302,14 @@ describe('SupabaseClient PKCE flow state', () => {
     vi.restoreAllMocks();
   });
 
-  /** Stand-in for the host secret store, shared by every editor window. */
-  function secretStore(): SessionSecretStore & {
-    entries: Map<string, string>;
-  } {
-    const entries = new Map<string, string>();
-    return {
-      entries,
-      get: async (key) => entries.get(key),
-      set: async (key, value) => {
-        entries.set(key, value);
-      },
-      delete: async (key) => {
-        entries.delete(key);
-      },
-    };
-  }
-
-  /** Start browser OAuth without navigating, as a host window would. */
-  async function startSignIn(): Promise<void> {
-    const { error } = await SupabaseClient.getClient().auth.signInWithOAuth({
-      provider: 'google',
-      options: {
-        redirectTo: 'https://remote.texra.ai/functions/v1/auth-bridge/cursor/x',
-        skipBrowserRedirect: true,
-      },
-    });
-    assert.equal(error, null);
-  }
-
-  it('persists only the flow state, never the session slot', async () => {
-    const secrets = secretStore();
-    SupabaseClient.initialize(SUPABASE_URL, 'public-key', secrets);
-
-    await startSignIn();
-
-    // A flow start writes its numbered slot, the slot index, and the fixed
-    // legacy key the callback reads. All three are keys GoTrue derives from
-    // its storage key; the storage key itself is the session slot and must
-    // never appear here.
-    const keys = [...secrets.entries.keys()];
-    assert.ok(keys.includes(VERIFIER_KEY));
-    assert.ok(!keys.includes(SUPABASE_GOTRUE_STORAGE_KEY));
-    assert.ok(
-      keys.every((key) => key.startsWith(`${SUPABASE_GOTRUE_STORAGE_KEY}-`)),
-      `unexpected persisted keys: ${keys.join(', ')}`,
-    );
-  });
-
-  it('completes a callback delivered to a different client instance', async () => {
-    const secrets = secretStore();
-    SupabaseClient.initialize(SUPABASE_URL, 'public-key', secrets);
-    await startSignIn();
-    // GoTrue JSON-encodes every stored value; the slot holds the verifier
-    // alone, or `verifier/redirectType` for a recovery link.
-    const stored: unknown = JSON.parse(secrets.entries.get(VERIFIER_KEY) ?? '');
-    const verifier = String(stored).split('/')[0];
-    assert.ok(verifier);
-
-    // A second window (or the same one after a host reload): a fresh client
-    // that never generated a verifier of its own.
-    let exchangeBody = '';
+  /**
+   * Answer every code exchange with one session, capturing the request body.
+   * Returns the captured body, which is only populated after the exchange.
+   */
+  function stubCodeExchange(): () => string {
+    let body = '';
     const exchange: typeof fetch = async (_input, init) => {
-      exchangeBody = String(init?.body);
+      body = String(init?.body);
       return new Response(
         JSON.stringify({
           access_token: 'pkce-access',
@@ -375,6 +329,55 @@ describe('SupabaseClient PKCE flow state', () => {
       );
     };
     vi.stubGlobal('fetch', exchange);
+    return () => body;
+  }
+
+  /** Start browser OAuth without navigating, as a host window would. */
+  async function startSignIn(): Promise<void> {
+    const { error } = await SupabaseClient.getClient().auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: 'https://remote.texra.ai/functions/v1/auth-bridge/cursor/x',
+        skipBrowserRedirect: true,
+      },
+    });
+    assert.equal(error, null);
+  }
+
+  it('persists only the flow state, never the session slot', async () => {
+    const secrets = new FakeSecrets();
+    SupabaseClient.initialize(SUPABASE_URL, 'public-key', secrets);
+
+    await startSignIn();
+
+    // A flow start writes its numbered slot, the slot index, and the fixed
+    // legacy key the callback reads. All three are keys GoTrue derives from
+    // its storage key; the storage key itself is the session slot and must
+    // never appear here.
+    const keys = await secrets.listStoredKeys();
+    assert.ok(keys.includes(VERIFIER_KEY));
+    assert.ok(!keys.includes(SUPABASE_GOTRUE_STORAGE_KEY));
+    assert.ok(
+      keys.every((key) => key.startsWith(`${SUPABASE_GOTRUE_STORAGE_KEY}-`)),
+      `unexpected persisted keys: ${keys.join(', ')}`,
+    );
+  });
+
+  it('completes a callback delivered to a different client instance', async () => {
+    const secrets = new FakeSecrets();
+    SupabaseClient.initialize(SUPABASE_URL, 'public-key', secrets);
+    await startSignIn();
+    // GoTrue JSON-encodes every stored value; the slot holds the verifier
+    // alone, or `verifier/redirectType` for a recovery link.
+    const stored: unknown = JSON.parse(
+      (await secrets.getStored(VERIFIER_KEY)) ?? '',
+    );
+    const verifier = String(stored).split('/')[0];
+    assert.ok(verifier);
+
+    // A second window (or the same one after a host reload): a fresh client
+    // that never generated a verifier of its own.
+    const exchangeBody = stubCodeExchange();
     SupabaseClient.resetForTests();
     SupabaseClient.initialize(SUPABASE_URL, 'public-key', secrets);
 
@@ -383,7 +386,7 @@ describe('SupabaseClient PKCE flow state', () => {
 
     assert.equal(error, null);
     assert.equal(data.session?.access_token, 'pkce-access');
-    assert.deepEqual(JSON.parse(exchangeBody), {
+    assert.deepEqual(JSON.parse(exchangeBody()), {
       auth_code: 'auth-code',
       code_verifier: verifier,
     });
@@ -391,8 +394,9 @@ describe('SupabaseClient PKCE flow state', () => {
     // not written here: the host's own session record stays its single owner.
     // (GoTrue leaves the numbered slot behind for a callback that carries no
     // flow id; its own ring caps those at five.)
-    assert.ok(!secrets.entries.has(VERIFIER_KEY));
-    assert.ok(!secrets.entries.has(SUPABASE_GOTRUE_STORAGE_KEY));
+    const remaining = await secrets.listStoredKeys();
+    assert.ok(!remaining.includes(VERIFIER_KEY));
+    assert.ok(!remaining.includes(SUPABASE_GOTRUE_STORAGE_KEY));
   });
 
   it('still signs in this window when the secret store is unwritable', async () => {
@@ -417,28 +421,7 @@ describe('SupabaseClient PKCE flow state', () => {
 
     // The callback lands in this window: the exchange must still succeed
     // using the mirrored verifier even though the store miss returned absent.
-    let exchangeBody = '';
-    const exchange: typeof fetch = async (_input, init) => {
-      exchangeBody = String(init?.body);
-      return new Response(
-        JSON.stringify({
-          access_token: 'pkce-access',
-          refresh_token: 'pkce-refresh',
-          token_type: 'bearer',
-          expires_in: 3600,
-          user: {
-            id: 'user-id',
-            aud: 'authenticated',
-            email: 'user@example.com',
-            app_metadata: {},
-            user_metadata: {},
-            created_at: new Date().toISOString(),
-          },
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } },
-      );
-    };
-    vi.stubGlobal('fetch', exchange);
+    const exchangeBody = stubCodeExchange();
 
     const { data, error } =
       await SupabaseClient.getClient().auth.exchangeCodeForSession('auth-code');
@@ -446,7 +429,7 @@ describe('SupabaseClient PKCE flow state', () => {
     assert.equal(error, null);
     assert.equal(data.session?.access_token, 'pkce-access');
     assert.ok(
-      JSON.parse(exchangeBody).code_verifier.length > 0,
+      JSON.parse(exchangeBody()).code_verifier.length > 0,
       'the exchange reused the verifier mirrored in memory',
     );
   });

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.ts
@@ -20,7 +20,7 @@ import {
   type DesktopSupabaseAuthHost,
 } from '@desktop/main/desktopSupabaseAuth';
 import { createDeferred } from '@test/support/asyncTestUtils';
-import { FakeStateStore } from '@test/support/FakePlatform';
+import { FakeSecrets, FakeStateStore } from '@test/support/FakePlatform';
 
 function createCoordinator() {
   const storedSession: { current: SupabaseSession | null } = { current: null };
@@ -202,7 +202,11 @@ function installAuthenticatedSupabaseProvider() {
     refreshToken: 'refresh-token',
   }));
   const getStoredSessionState = vi.fn(async () => 'authenticated' as const);
-  SupabaseClient.initialize('https://example.supabase.co', 'public-key');
+  SupabaseClient.initialize(
+    'https://example.supabase.co',
+    'public-key',
+    new FakeSecrets(),
+  );
   SupabaseClient.setAuthProvider({
     whenReady: vi.fn(async () => {}),
     ensureFreshToken,


### PR DESCRIPTION
Cleanup pass over #9884. No behavior change; net −30 lines.

## What changed

**`initialize`'s `secrets` parameter is now required.** Its only production caller (`createHostAuthCoordinator`) already has `secrets` as a *required* field, so all three hosts always supplied it — the `?` existed purely so three pre-existing, PKCE-unrelated tests could skip a fixture. Omitting it made `flowStore` return `null` for every key, silently routing all PKCE flow state back to an in-process map **with no warning**, unlike every other failure path in that function. That reinstates the exact bug #9884 fixed, with zero signal. Now it's a compile error; the three tests pass a fake.

**The three storage methods collapse onto one `onFlowState` helper.** They repeated the same session-slot check plus try/catch-and-warn skeleton, and `getItem` evaluated `memory.get(key) ?? null` three separate times in one body. With `secrets` required, the store lookup reduces to a plain key comparison, so `flowStore` and `warn` both fold into the helper.

**`describeCodeExchangeError` is inlined into its single call site.** It had exactly one caller, which is the pattern CLAUDE.md bans outright. Inlining also removes its hand-written `{ code?: string; message: string }` parameter type — a structural stand-in for `AuthError`, which the SDK already exports and which `error` already is at that call site.

**Tests.** The inline `secretStore()` fake duplicated the shared `FakeSecrets` (`src/test-kernel/support/FakePlatform.ts:547`), which satisfies `SessionSecretStore` and already exposes `listStoredKeys()`/`getStored()` — the two operations the fake reimplemented via an exposed `Map`. Both PKCE tests also carried a byte-identical 22-line code-exchange fetch stub; that's lifted into one `stubCodeExchange()`. The unwritable-store test keeps its own inline object, since it needs a store that *throws*.

## Not changed

Two things were examined and deliberately left alone:

- **Concurrent sign-ins from two windows** still share one fixed verifier key, so the second overwrites the first. Isolating them means either threading a flow id through the deep link — which puts a `?` back in `redirect_to`, the thing the auth-bridge design avoids — or scoping the key per window, which breaks the cross-window completion #9884 exists to provide. The race fails into actionable user guidance.
- **`_removeSession` deletes a `${storageKey}-user` key** that nothing ever writes (no `userStorage` is configured), so sign-out issues one inert `secrets.delete`. Harmless, and a caveat about it would add more comment than it's worth.

## Verification

`npm run typecheck`, `npm run lint`, `npm test` (833 files, 8774 tests), and `npm run check:dead-code-ratchet` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UE6vX8ZwUFw4sNUfGmEq93

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and type tightening on auth initialization and storage helpers; production callers already supplied secrets and PKCE behavior is unchanged aside from preventing silent test-only misconfiguration.
> 
> **Overview**
> Cleanup after PKCE cross-window storage (#9884): **no intended behavior change**, roughly −30 lines.
> 
> **`SupabaseClient.initialize`** now **requires** `secrets` (`SessionSecretStore`). Production already always passed it; optional `secrets` let tests skip a fixture and silently routed PKCE state to an in-memory map **without warnings**—the bug #9884 fixed. Tests use shared **`FakeSecrets`**.
> 
> **GoTrue PKCE adapter** (`gotrueStorage`) folds repeated session-slot checks, secret-store I/O, and warn-on-failure into one **`onFlowState`** helper; `getItem` / `setItem` / `removeItem` share that path and still mirror to memory on store failure.
> 
> **`SupabaseSession`**: removes standalone **`describeCodeExchangeError`** and inlines the `pkce_code_verifier_not_found` user message at the single **`exchangeCodeForSession`** failure site.
> 
> **Tests**: drop duplicate inline secret store and duplicate code-exchange fetch stubs; use **`FakeSecrets`**, **`stubCodeExchange()`**, and **`listStoredKeys` / `getStored`** where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc79e94a4c56703536f8f8ec050908aea90deccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->