### PR TITLE
refactor(cli): remove transcript print-to-scrollback; advertise PgUp/PgDn paging

### DIFF
--- a/.claude/skills/texra-cli/SKILL.md
+++ b/.claude/skills/texra-cli/SKILL.md
@@ -41,8 +41,8 @@ search, and mouse-scroll for finalized history, so don't reinvent them.
   belongs to that child's Static scrollback owner. Ctrl-T opens the focused
   stream's full output in a scrollable, closable `TranscriptReader`
   (`panes/TranscriptReader.tsx`) rendered in the live region — `Esc` closes it
-  and restores the conversation exactly as it was, `p` prints the transcript to
-  native scrollback (for selecting/copying text out of the terminal). The reader
+  and restores the conversation exactly as it was; `↑/↓` scrolls line by line
+  and `PgUp/PgDn` pages. The reader
   never takes over the viewport (the TUI avoids the alternate screen), so it is
   sized by the same row budget as every other foreground surface.
   Cap root panels (`BOTTOM_PANEL_MAX_ROWS` in `panes/ConversationRegion.tsx`) so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
   chat session now reports how much it cost and how it was paid for.
 - **The model catalog is reachable from the TUI** — browse and enable models
   without leaving the chat interface.
+- **The transcript reader pages with `PgUp`/`PgDn`** — the Ctrl-T full-output
+  view scrolls a page at a time instead of one line per keypress.
 
 #### Bug Fixes
 

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -320,8 +320,6 @@ export function App(props: AppProps): React.JSX.Element {
       : undefined;
   const selectedChildStreamId =
     childListStreamId(selectedChildValue) ?? selectedWorkflowChildStreamId;
-  const selectedChildKind =
-    selectedChildStreamId !== undefined ? 'stream' : undefined;
   const selectedChildKillable =
     selectedChildStreamId !== undefined &&
     activeSubagentExecutionIds.has(selectedChildStreamId);
@@ -735,7 +733,6 @@ export function App(props: AppProps): React.JSX.Element {
                 foregroundOpen || reverseSearchOpen || slashPaletteOpen
               }
               childListFocused={childListFocused}
-              childListSelectionKind={selectedChildKind}
               childListSelectionKillable={selectedChildKillable}
               childListSelectionWorkflowControllable={
                 selectedChildWorkflowControllable

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -9,15 +9,12 @@ import {
   useMemo,
   useReducer,
   useRef,
-  useState,
 } from 'react';
 
 // Local imports - shared runtime
-import { defaultSession } from '@agent/runtime/SessionHandle';
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
 import { type StreamTabId } from '@shared/schemas';
 import { SESSION_LIST } from '@shared/copy/nestedRuns';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local imports - TUI surfaces and state
 import {
@@ -46,7 +43,6 @@ import {
 import { InputBar, type InputBarHandle } from './panes/InputBar';
 import { ConversationRegion } from './panes/ConversationRegion';
 import { StatusBar } from './panes/StatusBar';
-import { orderedStaticTranscriptEntries } from './panes/transcriptEntries';
 import {
   currentApproval,
   pendingApprovalSummaries,
@@ -79,10 +75,8 @@ import {
   openTranscriptReader,
   transcriptReaderStreamId as transcriptReaderStreamIdSignal,
   reverseSearchOpen as reverseSearchOpenSignal,
-  setTransientNotice,
   slashPaletteOpen as slashPaletteOpenSignal,
   streams as streamsSignal,
-  type StreamSlice,
 } from './state/cliState';
 import { appendLocalAssistantTranscript } from './state/transcript';
 import {
@@ -92,10 +86,6 @@ import {
   subagentExecutionLabels as subagentExecutionLabelsSignal,
 } from './state/childExecutions';
 import { focusedChildInputDisabledMessage } from './state/focusedChildFollowUp';
-import {
-  createTranscriptPrintRequest,
-  type TranscriptPrintRequest,
-} from './state/transcriptLines';
 import {
   childListStreamId,
   childStreamListValue,
@@ -111,8 +101,6 @@ import {
 } from './state/workflowDashboardModel';
 import { streamDisplayLabel, streamTreeViews } from './state/streamViews';
 import { useSignal } from './state/useSignal';
-import { syncStreamLog } from './state/subscribeStreamLog';
-import { transcriptViewportKey } from './state/transcriptViewportMode';
 import type { InputHistory } from './history/inputHistory';
 
 // Narrow subset of Ink's internal stdin emitter used to synthesize Enter.
@@ -120,13 +108,6 @@ interface InputEventEmitterLike {
   emit(event: 'input', data: string): void;
   on(event: 'input', listener: (data: string) => void): void;
   off(event: 'input', listener: (data: string) => void): void;
-}
-
-const NO_TRANSCRIPT_PRINTS: readonly TranscriptPrintRequest[] = [];
-
-function lastStaticEntryId(slice: StreamSlice | undefined): string | undefined {
-  if (!slice) return undefined;
-  return orderedStaticTranscriptEntries(slice.entries, slice.status).at(-1)?.id;
 }
 
 // Jump-to-waiting: surface the newly focused stream's pending approval right
@@ -194,10 +175,6 @@ export function App(props: AppProps): React.JSX.Element {
   const selectedChildValue = childListSelection.selectedValue;
   const { columns, rows } = useWindowSize();
   const { exit } = useApp();
-  const [transcriptPrints, setTranscriptPrints] = useState<
-    readonly TranscriptPrintRequest[]
-  >([]);
-  const nextTranscriptPrintId = useRef(0);
   const activeDraftRegistry = useMemo(() => createActiveDraftRegistry(), []);
   const canStopActiveRun =
     props.canStopActiveRun ?? props.canInterruptActiveRun;
@@ -270,18 +247,6 @@ export function App(props: AppProps): React.JSX.Element {
   }, [inputDisabled, stdin]);
 
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
-  const transcriptOwnerKey = transcriptViewportKey({
-    activeStreamId,
-    parentStream,
-  });
-  const sessionEmpty = rootStreamId === undefined && streams.size === 0;
-  const visibleTranscriptPrints = sessionEmpty
-    ? NO_TRANSCRIPT_PRINTS
-    : transcriptPrints;
-  useEffect(() => {
-    if (!sessionEmpty) return;
-    setTranscriptPrints((current) => (current.length > 0 ? [] : current));
-  }, [sessionEmpty]);
   const sessionViews = useMemo(
     () =>
       streamTreeViews({
@@ -485,7 +450,6 @@ export function App(props: AppProps): React.JSX.Element {
             availableRows={availableRows}
             executionLabels={subagentExecutionLabels}
             onClose={closeTranscriptReader}
-            onPrintToScrollback={printStreamOutput}
             streamId={transcriptReaderStreamId}
             title={title}
           />
@@ -539,40 +503,6 @@ export function App(props: AppProps): React.JSX.Element {
       return true;
     }
     return false;
-  };
-
-  const printStreamOutput = (streamId: StreamTabId): void => {
-    void defaultSession()
-      .transcripts.ensureLoaded(streamId)
-      .then(() => {
-        syncStreamLog(streamId, { forceFull: true });
-        const currentActiveStreamId = activeStreamIdSignal.get();
-        const currentStreams = streamsSignal.get();
-        nextTranscriptPrintId.current += 1;
-        const request = createTranscriptPrintRequest({
-          afterEntryId: lastStaticEntryId(
-            currentActiveStreamId
-              ? currentStreams.get(currentActiveStreamId)
-              : undefined,
-          ),
-          id: `printed-transcript:${nextTranscriptPrintId.current}`,
-          ownerKey: transcriptOwnerKey,
-          slice: currentStreams.get(streamId),
-          title: streamDisplayLabel({
-            childStreamEntries,
-            parentStream,
-            streamId,
-            streams: currentStreams,
-          }),
-        });
-        setTranscriptPrints((current) => [...current, request]);
-        if (currentActiveStreamId !== streamId) syncStreamLog(streamId);
-      })
-      .catch((error: unknown) => {
-        setTransientNotice(
-          `Could not load transcript: ${toErrorMessage(error)}`,
-        );
-      });
   };
 
   const appOwnsEscape = (): boolean => {
@@ -835,14 +765,12 @@ export function App(props: AppProps): React.JSX.Element {
           activeSubagentExecutionIds,
           childListTarget,
           pendingApprovals: pendingApprovalsForRows,
-          transcriptPrints: visibleTranscriptPrints,
         }}
         onCancelChildList={cancelChildList}
         onFocusSession={focusSession}
         onKillExecution={props.onKillExecution}
         onSkipExecution={props.onSkipExecution}
         onRetryExecution={props.onRetryExecution}
-        onPrintStream={printStreamOutput}
         onChildSelectionChange={(value) =>
           dispatchChildListSelection({ kind: 'highlight', value })
         }

--- a/packages/cli/src/chat/tui/commands/helpText.ts
+++ b/packages/cli/src/chat/tui/commands/helpText.ts
@@ -73,8 +73,8 @@ function keyboardSection(options: SlashCommandHelpOptions): string {
     // bindings that actually exist (see textInputBindings.ts).
     `- ${textInputEditingHelp()}`,
     '- `Esc` stops the focused agent · `Ctrl-C` exits idle chats; stops active responses',
-    "- `Ctrl-T` opens the focused stream's full output in a scrollable reader (`p` prints it to scrollback)",
-    `- \`Tab\` ${SESSION_LIST.openHelp} · \`v\` prints the selected stream's full output`,
+    "- `Ctrl-T` opens the focused stream's full output in a scrollable reader (PgUp/PgDn pages)",
+    `- \`Tab\` ${SESSION_LIST.openHelp}`,
     `- \`${focusChord}\` focuses a stream directly`,
   ].join('\n');
 }

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -40,7 +40,6 @@ import type { ForegroundSurfaceKind } from '../appInteractionPolicy';
 import type { PendingApprovalKind } from '../state/approvalQueue';
 import type { ChildListTarget } from '../state/childControls';
 import type { StreamSlice } from '../state/cliState';
-import type { TranscriptPrintRequest } from '../state/transcriptLines';
 import type { StreamView } from '../state/streamViews';
 
 // Cap the bottom subagent/todos panels so they never crowd out the
@@ -65,7 +64,6 @@ interface ConversationRegionSnapshot {
     string,
     readonly PendingApprovalKind[]
   >;
-  readonly transcriptPrints: readonly TranscriptPrintRequest[];
 }
 
 interface ConversationRegionProps {
@@ -82,7 +80,6 @@ interface ConversationRegionProps {
   readonly onKillExecution: (executionId: string) => void;
   readonly onSkipExecution: (executionId: string) => void;
   readonly onRetryExecution: (executionId: string) => void;
-  readonly onPrintStream: (streamId: StreamTabId) => void;
 }
 
 export function ConversationRegion({
@@ -94,7 +91,6 @@ export function ConversationRegion({
   onKillExecution,
   onSkipExecution,
   onRetryExecution,
-  onPrintStream,
   onStaticTranscriptChange,
   renderFooterChrome,
   renderForegroundSurface,
@@ -108,13 +104,6 @@ export function ConversationRegion({
     parentStream: snapshot.parentStream,
   });
   const scopedTranscript = isScopedTranscriptViewport(viewportKey);
-  const ownerPrintRequests = useMemo(
-    () =>
-      snapshot.transcriptPrints.filter(
-        (request) => request.ownerKey === viewportKey,
-      ),
-    [snapshot.transcriptPrints, viewportKey],
-  );
   const scrollbackTarget = staticScrollbackTarget({
     activeStreamId: snapshot.activeStreamId,
     rootStreamId: snapshot.rootStreamId,
@@ -228,7 +217,6 @@ export function ConversationRegion({
         ownerKey={scrollbackTarget.ownerKey}
         onRenderKeyChange={onStaticTranscriptChange}
         renderKey={staticTranscriptKey}
-        printRequests={ownerPrintRequests}
         scrollbackStreamId={scrollbackTarget.streamId}
         subagentExecutionLabels={snapshot.subagentExecutionLabels}
         width={transcriptWidth}
@@ -277,7 +265,6 @@ export function ConversationRegion({
               onSkipExecution={onSkipExecution}
               onRetryExecution={onRetryExecution}
               onSelectionChange={onChildSelectionChange}
-              onPrintStream={onPrintStream}
               pendingApprovals={snapshot.pendingApprovals}
               listRootStreamId={snapshot.childListTarget.streamId}
               listRootSlice={snapshot.childListTarget.slice}

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -13,7 +13,6 @@ import { shortCliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
 import { COLOR_HINT } from '@cli/tui/ui/colors';
 import type { StreamTabId } from '@shared/schemas';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
-import { groupBy } from '@utils/core';
 import { safeHomedir } from '@utils/system/platformPaths';
 
 import {
@@ -29,10 +28,6 @@ import {
   type ChildStreamEntries,
 } from '../state/childExecutions';
 import { streamViewForId } from '../state/streamViews';
-import {
-  formatTranscriptForScrollback,
-  type TranscriptPrintRequest,
-} from '../state/transcriptLines';
 import { useSignal } from '../state/useSignal';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
 import { orderedStaticTranscriptEntries } from './transcriptEntries';
@@ -55,11 +50,6 @@ export type StaticTranscriptItem =
       readonly id: string;
       readonly kind: 'entry';
       readonly entry: ConversationEntry;
-    }
-  | {
-      readonly id: string;
-      readonly kind: 'printedTranscript';
-      readonly request: TranscriptPrintRequest;
     };
 
 interface StaticTranscriptState {
@@ -193,13 +183,6 @@ function staticTranscriptItemRowCount(
       ? COMPACT_SESSION_HEADER_ROWS
       : FULL_SESSION_HEADER_ROWS;
   }
-  if (item.kind === 'printedTranscript') {
-    return formatTranscriptForScrollback({
-      cols: transcriptColumns(width),
-      executionLabels,
-      request: item.request,
-    }).split('\n').length;
-  }
   return transcriptEntryLayoutRows(
     transcriptEntryLayout(item.entry, {
       executionLabels,
@@ -211,8 +194,8 @@ function staticTranscriptItemRowCount(
 }
 
 /** The transcript entry an item sits directly below, when that neighbor is
- *  itself an entry. A header or printed-output block above carries no margin
- *  for the next entry to collapse against. */
+ *  itself an entry. A header above carries no margin for the next entry to
+ *  collapse against. */
 function entryAbove(
   item: StaticTranscriptItem | undefined,
 ): ConversationEntry | undefined {
@@ -256,18 +239,6 @@ function StaticTranscriptItemContent({
           />
         </EntryErrorBoundary>
       );
-    case 'printedTranscript':
-      return (
-        <EntryErrorBoundary label="full output">
-          <Text>
-            {formatTranscriptForScrollback({
-              cols: width,
-              executionLabels,
-              request: item.request,
-            })}
-          </Text>
-        </EntryErrorBoundary>
-      );
   }
 }
 
@@ -279,7 +250,6 @@ export function appendStaticTranscriptItems({
   meta,
   maxRows,
   parentStream = new Map(),
-  printRequests = [],
   scrollbackStreamId,
   width,
 }: {
@@ -290,7 +260,6 @@ export function appendStaticTranscriptItems({
   readonly meta: SessionMeta;
   readonly maxRows?: number;
   readonly parentStream?: ReadonlyMap<StreamTabId, StreamTabId>;
-  readonly printRequests?: readonly TranscriptPrintRequest[];
   readonly scrollbackStreamId: StreamTabId | undefined;
   readonly width?: number;
 }): readonly StaticTranscriptItem[] {
@@ -350,7 +319,7 @@ export function appendStaticTranscriptItems({
 
   // Only the selected scrollback owner feeds `<Static>` output. Root focus owns
   // root history; child focus owns that child's history. Other streams stay
-  // available through their own focus or print-once full output.
+  // available through their own focus.
   const slice = scrollbackStreamId
     ? streams.get(scrollbackStreamId)
     : undefined;
@@ -359,43 +328,15 @@ export function appendStaticTranscriptItems({
     entries,
     slice?.status,
   );
-  const unseenRequests = printRequests.filter(
-    (request) => !seen.has(request.id),
-  );
   const appendItem = (item: StaticTranscriptItem): void => {
     nextItems ??= [...currentItems];
     nextItems.push(item);
     seen.add(item.id);
   };
 
-  // Requests carry the last static entry visible when the user invoked the
-  // command. Interleave against that anchor so an owner round trip rebuilds
-  // exactly the same chronology as incremental append-only rendering.
-  const anchoredRequests: TranscriptPrintRequest[] = [];
-  for (const request of unseenRequests) {
-    if (request.afterEntryId === undefined || seen.has(request.afterEntryId)) {
-      appendItem({ id: request.id, kind: 'printedTranscript', request });
-      continue;
-    }
-    anchoredRequests.push(request);
-  }
-  const requestsByUnseenAnchor = groupBy(
-    anchoredRequests,
-    (request) => request.afterEntryId,
-  );
   for (const entry of orderedStaticEntries) {
     if (!seen.has(entry.id)) {
       appendItem({ id: entry.id, kind: 'entry', entry });
-    }
-    for (const request of requestsByUnseenAnchor.get(entry.id) ?? []) {
-      appendItem({ id: request.id, kind: 'printedTranscript', request });
-    }
-  }
-  // A legacy or externally restored request may name an entry no longer in
-  // the owner transcript. Keep the output rather than dropping it silently.
-  for (const request of unseenRequests) {
-    if (!seen.has(request.id)) {
-      appendItem({ id: request.id, kind: 'printedTranscript', request });
     }
   }
   // Same reference when nothing was appended so the `setItems` functional
@@ -409,7 +350,6 @@ export function StaticConversationTranscript({
   onRenderKeyChange,
   ownerKey,
   renderKey = ownerKey,
-  printRequests = [],
   scrollbackStreamId,
   subagentExecutionLabels,
   width,
@@ -419,7 +359,6 @@ export function StaticConversationTranscript({
   readonly onRenderKeyChange?: () => void;
   readonly ownerKey: string;
   readonly renderKey?: string;
-  readonly printRequests?: readonly TranscriptPrintRequest[];
   readonly scrollbackStreamId: StreamTabId | undefined;
   readonly subagentExecutionLabels?: ExecutionLabels;
   readonly width?: number;
@@ -446,7 +385,6 @@ export function StaticConversationTranscript({
       meta: sessionMeta,
       maxRows,
       parentStream,
-      printRequests,
       scrollbackStreamId,
       width: normalizedWidth,
     });
@@ -474,7 +412,6 @@ export function StaticConversationTranscript({
         meta: sessionMeta,
         maxRows,
         parentStream,
-        printRequests,
         scrollbackStreamId,
         width: normalizedWidth,
       });
@@ -488,7 +425,6 @@ export function StaticConversationTranscript({
     maxRows,
     ownerKey,
     parentStream,
-    printRequests,
     scrollbackStreamId,
     sessionMeta,
     streams,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -46,7 +46,6 @@ const RELAY_QUOTA_REFRESH_MS = 10_000;
 interface StatusBarProps {
   readonly agentSelectionAvailable?: boolean;
   readonly childListFocused?: boolean;
-  readonly childListSelectionKind?: 'stream';
   readonly childListSelectionKillable?: boolean;
   readonly childListSelectionWorkflowControllable?: boolean;
   readonly childNavigationAvailable: boolean;
@@ -231,7 +230,6 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     },
     childList: {
       focused: props.childListFocused,
-      selectionKind: props.childListSelectionKind,
       selectionKillable: props.childListSelectionKillable,
       selectionWorkflowControllable:
         props.childListSelectionWorkflowControllable,

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -535,7 +535,6 @@ export interface SubagentListProps {
   /** Retry the focused, in-flight workflow-script grandchild `agent()` call. */
   readonly onRetryExecution?: (executionId: string) => void;
   readonly onSelectionChange?: (value: ChildListValue) => void;
-  readonly onPrintStream?: (streamId: StreamTabId) => void;
   /** Pending approval kinds per stream id (see `pendingApprovalSummaries`,
    *  root bucket already folded onto the root stream id by the caller). */
   readonly pendingApprovals?: ReadonlyMap<
@@ -688,10 +687,6 @@ export function SubagentList(
         childListStreamId(props.selectedValue) ?? workflowChildStreamId;
       if (!streamId) return;
       const pressed = input.toLowerCase();
-      if (pressed === 'v') {
-        props.onPrintStream?.(streamId);
-        return;
-      }
       // Kill/skip/retry target only a focused subagent stream (a
       // workflow-script grandchild); the session control registry no-ops for
       // any execution id that is not an in-flight grandchild, so non-workflow

--- a/packages/cli/src/chat/tui/panes/TranscriptReader.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptReader.tsx
@@ -1,8 +1,8 @@
 // Scrollable, closable full-transcript reader. Ctrl-T's predecessor printed the
 // same content straight into terminal scrollback, which the terminal owns and
 // nothing can take back. This renders it in the live region instead, so Esc
-// restores the conversation exactly as it was. `p` still prints, for when the
-// point is to select and copy the text out of the terminal.
+// restores the conversation exactly as it was. ↑/↓ scrolls line by line;
+// PgUp/PgDn pages through the transcript.
 //
 // The TUI never enters the alternate screen (see tui/terminalCleanup.ts), so a
 // full-screen pager is not an option here — this is an ordinary foreground
@@ -38,14 +38,12 @@ export function TranscriptReader({
   availableRows,
   executionLabels,
   onClose,
-  onPrintToScrollback,
   streamId,
   title,
 }: {
   readonly availableRows: number;
   readonly executionLabels?: ExecutionLabels;
   readonly onClose: () => void;
-  readonly onPrintToScrollback: (streamId: StreamTabId) => void;
   readonly streamId: StreamTabId;
   readonly title: string;
 }): React.JSX.Element {
@@ -67,11 +65,6 @@ export function TranscriptReader({
   useInput((input, key) => {
     if (isEscapeInput(input, key)) {
       onClose();
-      return;
-    }
-    if (input.toLowerCase() === 'p') {
-      onPrintToScrollback(streamId);
-      onClose();
     }
   });
 
@@ -84,7 +77,7 @@ export function TranscriptReader({
         <KeyHints
           hints={[
             { key: '↑/↓', action: 'scroll' },
-            { key: 'p', action: 'print to scrollback' },
+            { key: 'PgUp/PgDn', action: 'page' },
             { key: 'Esc', action: 'close' },
           ]}
           confirmCancel={false}

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -714,7 +714,6 @@ function foregroundBindingsText(
 
 function childListBindingsText(
   {
-    selectionKind,
     selectionKillable = false,
     selectionWorkflowControllable = false,
   }: StatusBarChildListInput,
@@ -723,10 +722,6 @@ function childListBindingsText(
 ): string {
   const ctrlCBinding = keyHintText({ key: 'Ctrl-C', action: ctrlCAction });
   const enterBinding = keyHintText({ key: 'Enter', action: 'focus' });
-  const fullOutputBinding =
-    selectionKind === 'stream'
-      ? keyHintText({ key: 'v', action: 'full output' })
-      : undefined;
   const killBinding = selectionKillable
     ? keyHintText({ key: 'k', action: 'kill' })
     : undefined;
@@ -744,7 +739,6 @@ function childListBindingsText(
       statusBarBindingRow([
         selectBinding,
         enterBinding,
-        fullOutputBinding,
         killBinding,
         skipBinding,
         retryBinding,
@@ -755,7 +749,6 @@ function childListBindingsText(
       statusBarBindingRow([
         selectBinding,
         enterBinding,
-        fullOutputBinding,
         killBinding,
         tabBinding,
         escBinding,

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -141,7 +141,6 @@ interface StatusBarForegroundInput {
 interface StatusBarChildListInput {
   /** True while the persistent child list, rather than the input, owns keys. */
   readonly focused?: boolean;
-  readonly selectionKind?: 'stream';
   readonly selectionKillable?: boolean;
   /** True while the focused row is an in-flight workflow-script grandchild
    *  that can be skipped or retried. */

--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -1,38 +1,12 @@
-// Flatten a stream's conversation entries into full-fidelity plain-text lines
-// for print-once terminal output. Unlike the finalized scrollback and the live
-// region, this renders every tool-output line.
+// Flatten a stream's conversation entries into full-fidelity plain-text
+// display lines. Unlike the finalized scrollback and the live region, this
+// renders every tool-output line.
 
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 
 import { isRenderableTranscriptEntry } from '../panes/transcriptEntries';
 import { fullTranscriptEntryLayout } from '../panes/transcriptEntryLayout';
-import { safeTerminalText } from '../render/terminalText';
 import type { ConversationEntry, StreamSlice } from './cliState';
-
-export interface TranscriptPrintRequest {
-  readonly afterEntryId?: string;
-  readonly id: string;
-  readonly ownerKey: string;
-  readonly slice: StreamSlice | undefined;
-  readonly title?: string;
-}
-
-/** Capture the stream state at the moment the user asks to print it. */
-export function createTranscriptPrintRequest({
-  afterEntryId,
-  id,
-  ownerKey,
-  slice,
-  title,
-}: TranscriptPrintRequest): TranscriptPrintRequest {
-  return {
-    afterEntryId,
-    id,
-    ownerKey,
-    title,
-    slice: slice ? { ...slice, entries: [...slice.entries] } : undefined,
-  };
-}
 
 // Wrapped-line cache keyed by the immutable entry object. Entries are
 // replaced (never mutated in place) when their content changes, so hits are
@@ -161,24 +135,4 @@ export function transcriptToLines(
     previousLines = lines;
   }
   return out;
-}
-
-/** Format one immutable request for the terminal's static scrollback. */
-export function formatTranscriptForScrollback({
-  cols,
-  executionLabels = EMPTY_EXECUTION_LABELS,
-  request,
-}: {
-  readonly cols: number;
-  readonly executionLabels?: ExecutionLabels;
-  readonly request: TranscriptPrintRequest;
-}): string {
-  const heading = safeTerminalText(request.title ?? '')
-    .replaceAll('\n', ' ')
-    .trim();
-  const body = safeTerminalText(
-    transcriptToLines(request.slice, cols, executionLabels).join('\n'),
-  );
-  const label = heading ? `Full output: ${heading}` : 'Full output';
-  return `\n[${label}]\n${body.trimEnd() || '(no output yet)'}\n`;
 }

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -60,13 +60,9 @@ export const chatCommand = withUsageSections(
         ['/login, /logout', 'sign in or out of ChatGPT or Researcher Access'],
         [
           'Ctrl-T',
-          "open the focused stream's full output in a scrollable reader (`p` prints it to scrollback)",
+          "open the focused stream's full output in a scrollable reader (PgUp/PgDn pages)",
         ],
         ['Tab', 'select a visible child session or process'],
-        [
-          'v (child list)',
-          "print the selected stream's full output once into terminal scrollback",
-        ],
         [
           focusShortcut,
           `focus a visible stream by number (${alternateFocusShortcut} when configured)`,

--- a/src/test-kernel/cli/ChildListInteraction.vitest.ts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.ts
@@ -112,11 +112,10 @@ describe('CLI child list interaction', () => {
     expect(output).not.toContain(POINTER);
   });
 
-  it('prints and kills only the selected active session, then focuses it', async () => {
+  it('kills the selected active session, then focuses it', async () => {
     const { ink, React } = await loadInk();
     const onFocusStream = vi.fn();
     const onKillExecution = vi.fn();
-    const onPrintStream = vi.fn();
     const onCancel = vi.fn();
     const { Harness, current } = controlledList(
       React,
@@ -128,7 +127,6 @@ describe('CLI child list interaction', () => {
         onCancel,
         onFocusStream,
         onKillExecution,
-        onPrintStream,
         sessions: [session(root, true), session(child)],
       },
     );
@@ -142,8 +140,6 @@ describe('CLI child list interaction', () => {
       await waitForInput(stdin);
       stdin.write('\u001B[B');
       await waitFor(() => current() === childStreamListValue(child));
-      stdin.write('v');
-      await waitFor(() => onPrintStream.mock.calls.length === 1);
       stdin.write('k');
       await waitFor(() => onKillExecution.mock.calls.length === 1);
       stdin.write('\r');
@@ -151,7 +147,6 @@ describe('CLI child list interaction', () => {
       stdin.write('\u001B');
       await waitFor(() => onCancel.mock.calls.length === 1);
 
-      expect(onPrintStream).toHaveBeenCalledWith(child);
       expect(onKillExecution).toHaveBeenCalledWith('child-exec');
       expect(onFocusStream).toHaveBeenCalledWith(child);
       expect(onCancel).toHaveBeenCalledOnce();
@@ -261,7 +256,6 @@ describe('CLI child list interaction', () => {
     const callbacks = {
       onFocusStream: vi.fn(),
       onKillExecution: vi.fn(),
-      onPrintStream: vi.fn(),
       onRetryExecution: vi.fn(),
       onSkipExecution: vi.fn(),
     };
@@ -284,7 +278,7 @@ describe('CLI child list interaction', () => {
 
     try {
       await waitForInput(stdin);
-      for (const input of ['v', 'k', 's', 'r', '\r']) stdin.write(input);
+      for (const input of ['k', 's', 'r', '\r']) stdin.write(input);
       await sleep(30);
 
       for (const callback of Object.values(callbacks)) {
@@ -442,7 +436,6 @@ describe('CLI child list interaction', () => {
   it('keeps detail and controls inert when workflow tasks reuse a child id', async () => {
     const { ink, React } = await loadInk();
     const onFocusStream = vi.fn();
-    const onPrintStream = vi.fn();
     const onSkipExecution = vi.fn();
     const rootSlice = workflowRootSlice([
       ...['first', 'second'].map((id) => ({
@@ -483,7 +476,6 @@ describe('CLI child list interaction', () => {
           maxRows: 6,
           onCancel: vi.fn(),
           onFocusStream,
-          onPrintStream,
           onSkipExecution,
           sessions: [],
           ...props,
@@ -491,10 +483,9 @@ describe('CLI child list interaction', () => {
       );
       try {
         await waitForInput(stdin);
-        for (const input of ['\r', 'v', 's']) stdin.write(input);
+        for (const input of ['\r', 's']) stdin.write(input);
         await sleep(30);
         expect(onFocusStream).not.toHaveBeenCalled();
-        expect(onPrintStream).not.toHaveBeenCalled();
         expect(onSkipExecution).not.toHaveBeenCalled();
       } finally {
         instance.unmount();

--- a/src/test-kernel/cli/CliRootArgs.vitest.ts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.ts
@@ -1322,14 +1322,10 @@ describe('runCli usage output stream routing', () => {
     expect(stdout).toContain('/login, /logout');
     expect(stdout).toContain('ChatGPT or Researcher Access');
     expect(stdout).toContain(
-      "open the focused stream's full output in a scrollable reader (`p` prints it to scrollback)",
+      "open the focused stream's full output in a scrollable reader (PgUp/PgDn pages)",
     );
     expect(stdout).toContain('Tab');
     expect(stdout).toContain('select a visible child session or process');
-    expect(stdout).toContain('v (child list)');
-    expect(stdout).toContain(
-      "print the selected stream's full output once into terminal scrollback",
-    );
     expect(stdout).not.toContain('open tasks and sub-workflows');
     expect(stdout).not.toContain('open subagents when available');
     expect(stdout).toContain('Esc 1..9');

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -45,12 +45,7 @@ import {
   type StreamSlice,
   setStreamStatusInCliState,
 } from '@cli/chat/tui/state/cliState';
-import {
-  createTranscriptPrintRequest,
-  formatTranscriptForScrollback,
-  transcriptToLines,
-  type TranscriptPrintRequest,
-} from '@cli/chat/tui/state/transcriptLines';
+import { transcriptToLines } from '@cli/chat/tui/state/transcriptLines';
 import {
   CLI_LOCAL_STREAM_ID,
   finalizeAssistantTranscriptEntries,
@@ -723,87 +718,6 @@ describe('CLI conversation transcript', () => {
     expect(second.slice(1).map((item) => item.id)).toEqual(['u1', 'a1']);
   });
 
-  it('appends each print request once in transcript order', () => {
-    const user = entry('u1', 'user', 'Print the derivation.', true);
-    const assistant = entry('a1', 'assistant', 'Later result.', true);
-    const request = createTranscriptPrintRequest({
-      afterEntryId: 'u1',
-      id: 'printed-transcript:1',
-      ownerKey: 'root-scrollback',
-      slice: sliceWithEntries(STREAM_ID, [
-        user,
-        toolEntry('t1', TOOL_USE_STATUS.COMPLETED, 'complete result'),
-      ]),
-      title: 'assistant',
-    });
-    const beforePrint = staticItems([user]);
-    const first = staticItems([user, assistant], {
-      currentItems: beforePrint,
-      printRequests: [request],
-    });
-
-    expect(first.map((item) => item.id)).toEqual([
-      'session-header',
-      'u1',
-      'printed-transcript:1',
-      'a1',
-    ]);
-    expect(first.at(-2)).toMatchObject({
-      kind: 'printedTranscript',
-      request: { title: 'assistant' },
-    });
-    expect(
-      staticItems([user, assistant], {
-        currentItems: first,
-        printRequests: [request],
-      }),
-    ).toBe(first);
-  });
-
-  it('rebuilds owner-scoped print history with the header first', () => {
-    const user = entry('u1', 'user', 'Before printing.', true);
-    const assistant = entry('a1', 'assistant', 'After printing.', true);
-    const request = createTranscriptPrintRequest({
-      afterEntryId: 'u1',
-      id: 'printed-transcript:root',
-      ownerKey: 'root-scrollback',
-      slice: sliceWithEntries(STREAM_ID, [
-        toolEntry('t1', TOOL_USE_STATUS.COMPLETED, 'complete result'),
-      ]),
-      title: 'assistant',
-    });
-    const compact = staticItems([user, assistant], {
-      maxRows: 0,
-      printRequests: [request],
-      width: 80,
-    });
-    expect(compact.map((item) => item.id)).toEqual([
-      'u1',
-      'printed-transcript:root',
-      'a1',
-    ]);
-
-    const withHeader = [
-      'session-header',
-      'u1',
-      'printed-transcript:root',
-      'a1',
-    ];
-    expect(
-      staticItemIds([user, assistant], {
-        printRequests: [request],
-        width: 80,
-      }),
-    ).toEqual(withHeader);
-    expect(
-      staticItemIds([user, assistant], {
-        currentItems: compact,
-        printRequests: [request],
-        width: 80,
-      }),
-    ).toEqual(withHeader);
-  });
-
   it('shows the session header exactly once', () => {
     const first = appendStaticTranscriptItems({
       scrollbackStreamId: undefined,
@@ -1268,45 +1182,6 @@ describe('CLI conversation transcript', () => {
       expect(printed.lines.every((line) => line.length <= 20)).toBe(true);
     }
   });
-
-  it('prints full output as one control-safe terminal block', () => {
-    const text = formatTranscriptForScrollback({
-      cols: 80,
-      request: createTranscriptPrintRequest({
-        id: 'printed-transcript:1',
-        ownerKey: 'root-scrollback',
-        slice: sliceWithEntries(STREAM_ID, [
-          entry(
-            'a1',
-            'assistant',
-            '\u0000\u001b[31manswer\u001b[0m\u001b[2J\u0007\b\u007f',
-            true,
-          ),
-          toolEntry(
-            't1',
-            'completed',
-            'first\rsecond\tindented\u001b]0;unsafe\u001b\\\u009b2J\u009dtitle\u009c',
-          ),
-        ]),
-        title: 'assistant\nrenamed\u0007',
-      }),
-    });
-
-    expect(text).toContain('[Full output: assistant renamed]');
-    expect(text).toContain('answer');
-    expect(text).toContain('first');
-    expect(text).toContain('second');
-    expect(text).toContain('  indented');
-    expect(text).not.toContain('\u001b');
-    expect(text).not.toContain('\u0007');
-    expect(
-      [...text].every((char) => {
-        const code = char.charCodeAt(0);
-        return code === 10 || (code >= 32 && (code < 127 || code > 159));
-      }),
-    ).toBe(true);
-    expect(text.endsWith('\n')).toBe(true);
-  });
 });
 
 function sliceWithEntries(
@@ -1342,7 +1217,6 @@ function staticItems(
   options: {
     readonly currentItems?: readonly StaticTranscriptItem[];
     readonly maxRows?: number;
-    readonly printRequests?: readonly TranscriptPrintRequest[];
     readonly width?: number;
   } = {},
 ): readonly StaticTranscriptItem[] {
@@ -1350,7 +1224,6 @@ function staticItems(
     currentItems: options.currentItems ?? [],
     maxRows: options.maxRows,
     meta: SESSION_META,
-    printRequests: options.printRequests,
     scrollbackStreamId: STREAM_ID,
     streams: new Map([[STREAM_ID, sliceWithEntries(STREAM_ID, entries)]]),
     width: options.width,

--- a/src/test-kernel/cli/SlashHelpText.vitest.ts
+++ b/src/test-kernel/cli/SlashHelpText.vitest.ts
@@ -78,10 +78,7 @@ describe('formatSlashCommandHelp', () => {
     expect(macKittyHelp).toContain('`Esc 1..9`');
     expect(macKittyHelp).toContain('`Shift-Enter` or `Ctrl-J`');
     expect(macKittyHelp).toContain(
-      "`Ctrl-T` opens the focused stream's full output in a scrollable reader (`p` prints it to scrollback)",
-    );
-    expect(macKittyHelp).toContain(
-      "`v` prints the selected stream's full output",
+      "`Ctrl-T` opens the focused stream's full output in a scrollable reader (PgUp/PgDn pages)",
     );
   });
 

--- a/src/test-kernel/cli/StaticBandResize.vitest.ts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.ts
@@ -153,8 +153,6 @@ describe('Static band resize', () => {
       StaticConversationTranscript,
     } = await loadTranscriptStack();
     const { createElement } = React;
-    const { createTranscriptPrintRequest } =
-      await import('@cli/chat/tui/state/transcriptLines');
     const streamId = 'resize-static-stream' as StreamTabId;
     const prompt = 'resize geometry prompt';
     const finalizedUser: ConversationEntry = {
@@ -169,13 +167,13 @@ describe('Static band resize', () => {
       text: 'working',
       finalized: false,
     };
-    const hiddenPrintLine = 'full-output-middle-line';
     const tool = completedToolEntry({
       id: 'full-output-tool',
       toolName: 'Bash',
       input: { command: 'long-command' },
-      outputText: Array.from({ length: 15 }, (_, index) =>
-        index === 7 ? hiddenPrintLine : `tool line ${index}`,
+      outputText: Array.from(
+        { length: 15 },
+        (_, index) => `tool line ${index}`,
       ).join('\n'),
       finalized: false,
     });
@@ -185,20 +183,12 @@ describe('Static band resize', () => {
       liveAssistant,
       tool,
     ]);
-    const printRequest = createTranscriptPrintRequest({
-      afterEntryId: finalizedUser.id,
-      id: 'printed-transcript:resize',
-      ownerKey: 'resize-owner',
-      slice: cliState.streams.get().get(streamId),
-      title: 'assistant',
-    });
 
     function App(): unknown {
       const { columns } = ink.useWindowSize();
       return createElement(StaticConversationTranscript, {
         colorEnabled: true,
         ownerKey: 'resize-owner',
-        printRequests: [printRequest],
         scrollbackStreamId: streamId,
         width: columns,
       });
@@ -215,8 +205,7 @@ describe('Static band resize', () => {
       await expectEventually(
         () =>
           horizontalRuleWidths(out.output).includes(40) &&
-          inverseBandWidths(out.output, prompt).includes(38) &&
-          out.output.includes(hiddenPrintLine),
+          inverseBandWidths(out.output, prompt).includes(38),
       );
 
       // Widen: bump columns and fire the resize the patched Ink handler listens
@@ -237,9 +226,7 @@ describe('Static band resize', () => {
       expect(bandWidths).toEqual([78]);
       expect(bandWidths).not.toContain(38);
       expect(occurrences(visibleFrame, '{ T } TeXRA')).toBe(1);
-      expect(occurrences(visibleFrame, `› ${prompt}`)).toBe(2);
-      expect(occurrences(visibleFrame, hiddenPrintLine)).toBe(1);
-      expect(occurrences(visibleFrame, '[Full output: assistant]')).toBe(1);
+      expect(occurrences(visibleFrame, `› ${prompt}`)).toBe(1);
     } finally {
       inst.unmount();
       cliState.resetCliState();

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -354,7 +354,6 @@ describe('CLI StatusBar display model', () => {
         foreground: { shortcutsActive: false },
         childList: {
           focused: true,
-          selectionKind: 'stream',
           selectionKillable: true,
         },
         shortcuts: {
@@ -386,7 +385,6 @@ describe('CLI StatusBar display model', () => {
         },
         childList: {
           focused: true,
-          selectionKind: 'stream',
           selectionKillable: true,
         },
         shortcuts: { parentNavigationAvailable: true },

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -367,7 +367,6 @@ describe('CLI StatusBar display model', () => {
 
     expect(display.bindings).toContain('↑/↓ select');
     expect(display.bindings).toContain('Enter focus');
-    expect(display.bindings).toContain('v full output');
     expect(display.bindings).not.toContain('i details');
     expect(display.bindings).toContain('k kill');
     expect(display.bindings).toContain('Tab input');
@@ -397,7 +396,6 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('Esc close');
     expect(display.bindings).not.toContain('Esc back');
     expect(display.bindings).not.toContain('↑/↓ select');
-    expect(display.bindings).not.toContain('v full output');
   });
 
   it('keeps the full-output shortcut in narrow stream views', () => {

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -18,10 +18,7 @@ import {
   StaticConversationTranscript,
   appendStaticTranscriptItems,
 } from '@cli/chat/tui/panes/StaticConversationTranscript';
-import {
-  orderedStaticTranscriptEntries,
-  splitTranscriptEntries,
-} from '@cli/chat/tui/panes/transcriptEntries';
+import { splitTranscriptEntries } from '@cli/chat/tui/panes/transcriptEntries';
 import {
   patchStream,
   resetCliState,
@@ -31,7 +28,6 @@ import {
 } from '@cli/chat/tui/state/cliState';
 import { syncStreamLog } from '@cli/chat/tui/state/subscribeStreamLog';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
-import { createTranscriptPrintRequest } from '@cli/chat/tui/state/transcriptLines';
 import { projectStreamTranscript } from '@cli/chat/tui/state/transcriptProjection';
 import {
   AgentCategory,
@@ -526,7 +522,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     ]);
   });
 
-  it('keeps declared-plan phase-task and print chronology identical live and cold', async () => {
+  it('keeps declared-plan phase-task ordering identical live and cold', async () => {
     const runTrace = openRunTrace(STREAM_ID);
     for (const [id, label] of [
       ['core', 'Audit core'],
@@ -606,38 +602,11 @@ describe('CLI workflow-script child-stream transcript', () => {
     expect(settledSlice?.entries.findLast((entry) => entry.finalized)?.id).toBe(
       'audit-phase',
     );
-    const printAnchor = settledSlice
-      ? orderedStaticTranscriptEntries(
-          settledSlice.entries,
-          settledSlice.status,
-        ).at(-1)?.id
-      : undefined;
-    expect(printAnchor).toBe('core-task');
-    const printRequest = createTranscriptPrintRequest({
-      afterEntryId: printAnchor,
-      id: 'printed-transcript:declared-plan',
-      ownerKey: 'root',
-      slice: settledSlice,
-      title: 'repository audit',
-    });
-    incrementalItems = appendItems(incrementalItems, {
-      printRequests: [printRequest],
-    });
-
-    const coldItems = appendItems([], { printRequests: [printRequest] });
 
     const incrementalEntryIds = entryIds(incrementalItems);
     expect(incrementalEntryIds.at(-2)).toBe('audit-phase');
     expect(incrementalEntryIds.at(-1)).toBe('core-task');
-    expect(entryIds(coldItems)).toEqual(entryIds(incrementalItems));
-    expect(incrementalItems.map((item) => item.id).slice(-3)).toEqual([
-      'audit-phase',
-      'core-task',
-      'printed-transcript:declared-plan',
-    ]);
-    expect(coldItems.map((item) => item.id)).toEqual(
-      incrementalItems.map((item) => item.id),
-    );
+    expect(entryIds(appendItems([]))).toEqual(incrementalEntryIds);
     const coldOutput = await renderStaticTranscript();
     expectOutputOrder(coldOutput, [
       'Preparing repository audit',


### PR DESCRIPTION
## Summary

Removes the print-to-scrollback feature and advertises PgUp/PgDn paging in the Ctrl-T transcript reader.

- **`p` in the Ctrl-T transcript reader** previously dumped the focused stream's full output into native terminal scrollback — a permanent, one-shot snapshot the TUI cannot take back. The handler, prop, and hint are removed.
- **`v` in the child list** invoked the same `printStreamOutput` codepath; the binding, its status-bar hint, and its help rows are removed too.
- The whole supporting machinery is deleted: `printStreamOutput` / `transcriptPrints` state in `App.tsx`, `createTranscriptPrintRequest` / `formatTranscriptForScrollback` in `transcriptLines.ts`, the `printedTranscript` static-item kind with its anchor/interleave logic in `StaticConversationTranscript.tsx`.
- **PgUp/PgDn paging** was already wired through the shared scroll hook (`useScrollableOffset` → `ScrollableModalText`) but hidden; the reader footer now shows `↑/↓ scroll · PgUp/PgDn page · Esc close`, and `/help` + `--help` mention it. Line-by-line ↑/↓ over a 10k-row transcript was unusably slow.
- Follow-up cleanup from review: the `selectionKind` status-bar chain became write-only after removing the `v` binding and is now deleted, and `.claude/skills/texra-cli/SKILL.md` no longer documents the removed `p` binding.

## Issue acceptance gates

No issue; direct UX refactor requested from the TUI (Ctrl-T reader).

## Single source of truth

The transcript reader's scroll behavior now lives solely in the shared `useScrollableOffset` hook (↑/↓ line scroll, PgUp/PgDn page), rendered by `ScrollableModalText`. The status bar reads only live bindings (`k`/`s`/`r`/`Tab`/`Enter`).

## Duplication and abstraction budget

Deletion PR — no new abstractions. The only scroll-surface change is the reader's footer hint row, which reuses the existing `KeyHints` vocabulary (`PgUp/PgDn page`, matching other scrollable surfaces).

## Net elements (R6)

- Files: 17 changed, +28/−445 (2 commits: feature removal, then review follow-up).
- Exported symbols deleted: `TranscriptPrintRequest`, `createTranscriptPrintRequest`, `formatTranscriptForScrollback` (`state/transcriptLines.ts`); `onPrintStream` prop (`ConversationRegion`, `SubagentList`); `onPrintToScrollback` prop (`TranscriptReader`).
- Type/interface deleted: `StatusBarChildListInput.selectionKind`, `StatusBarProps.childListSelectionKind`, `ConversationRegionSnapshot.transcriptPrints`, `StaticTranscriptItem` `printedTranscript` variant.
- Net LoC: ≈ −417.

## Consumer counts (R8)

The removed emit path (full-output print into terminal scrollback) had exactly two entry points — Ctrl-T reader `p` and child-list `v` — and one render consumer (`StaticConversationTranscript` `printedTranscript` items). All were deleted in this same PR; `grep` over `packages/cli/src` and `src/test-kernel` for `print to scrollback|onPrintStream|printStreamOutput|createTranscriptPrintRequest|formatTranscriptForScrollback|TranscriptPrintRequest|printed-transcript` returns zero hits. `syncStreamLog`'s `forceFull` option is kept: it is generic projection infrastructure exercised by tests, not part of the print path.

## Host impact

Extension: none. Desktop: none. CLI: Ctrl-T reader and child-list status bar lose the `p`/`v` bindings; reader footer and help text advertise PgUp/PgDn paging.

## Scheduled refactoring

None — the review-flagged `selectionKind` dead code was removed in this PR.

## Validation

- 7 affected suites updated and green (`ChildListInteraction`, `ConversationTranscript`, `StaticBandResize`, `WorkflowScriptStreamTranscript`, `CliRootArgs`, `SlashHelpText`, `StatusBar`), plus `AppInteractionPolicy` / `TuiStateAndFocus` for the status-bar input change.
- `npm run typecheck:cli` and `npm run typecheck:test-kernel` pass.
- Cursor Bugbot, TeXRA Code Review, and Claude review all reported the removal clean; both flagged findings (PR template sections, `selectionKind` dead chain, stale SKILL.md) addressed in this revision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Large deletion in CLI TUI presentation only; no auth, persistence, or runtime execution changes. Risk is limited to transcript viewing UX and help text accuracy.
> 
> **Overview**
> Removes **print-to-scrollback** for full stream transcripts and documents **PgUp/PgDn** paging on the Ctrl-T reader instead.
> 
> **Removed behavior:** `p` in the Ctrl-T `TranscriptReader` and `v` in the child session list used to dump a stream’s full output into native terminal scrollback (and interleave “printed transcript” blocks into `<Static>` scrollback). That path is deleted end-to-end: `printStreamOutput` / `transcriptPrints` in `App.tsx`, `TranscriptPrintRequest` / `createTranscriptPrintRequest` / `formatTranscriptForScrollback` in `transcriptLines.ts`, the `printedTranscript` static item kind in `StaticConversationTranscript`, and related props (`onPrintStream`, `onPrintToScrollback`). Status-bar and help text no longer mention `v` or print-to-scrollback; dead `selectionKind` wiring is removed.
> 
> **Ctrl-T reader:** Footer hints now show `↑/↓ scroll` and **PgUp/PgDn page** (paging was already available via shared `ScrollableModalText` / scroll hooks). `/help`, `chat --help`, and the texra-cli skill doc are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b955a4e1074da2501212617a7d896ec6ea3a234. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->