### PR TITLE
refactor: consolidate duplicated helpers and inline single-use wrappers

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -3,11 +3,9 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import type { ApiAccessMode } from '@shared/schemas/profileViewMessages';
 
+import { implicitDefaultToolUseAgents } from '@shared/constants/agents';
 import { CLI_BUILTIN_DEFAULT_MODEL } from '../runtime/cliConfig';
-import {
-  implicitDefaultToolUseAgents,
-  pickDefaultToolUseAgent,
-} from '../runtime/defaultAgents';
+import { pickDefaultToolUseAgent } from '../runtime/defaultAgents';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -10,6 +10,7 @@ import {
   type RunModelDecisionReason,
 } from '@model/runModelDecision';
 import { TEXRA_CONFIG_FILE_NAME } from '@platform/defaults/nodeStorage';
+import { isImplicitDefaultEligible } from '@shared/constants/agents';
 import { toNewestFirstByTimestamp } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { GlobalStorageFS } from '@utils/files/storageFS';
@@ -22,10 +23,7 @@ import {
   resolveKnownCliModelId,
   type CliConfigValues,
 } from './cliConfig';
-import {
-  isImplicitDefaultEligible,
-  pickDefaultToolUseAgent,
-} from './defaultAgents';
+import { pickDefaultToolUseAgent } from './defaultAgents';
 import { writeTextStderr } from './logSinks';
 
 /**

--- a/packages/cli/src/runtime/defaultAgents.ts
+++ b/packages/cli/src/runtime/defaultAgents.ts
@@ -2,12 +2,7 @@ import { agentName } from '@shared/schemas';
 import {
   PREFERRED_TOOL_USE_AGENTS,
   implicitDefaultToolUseAgents,
-  isImplicitDefaultEligible,
 } from '@shared/constants/agents';
-
-// The implicit-default eligibility rule lives in @shared/constants/agents so
-// team planning (src/common/teams/TeamPlan) and the CLI share one definition.
-export { isImplicitDefaultEligible, implicitDefaultToolUseAgents };
 
 export const BUILTIN_DEFAULT_CHAT_AGENT = 'assistant';
 

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -6,6 +6,7 @@ import {
 import type { ExecutionId } from '@shared/schemas';
 import { agentKeyOf } from '@shared/schemas/agent';
 import type { ApiAccessMode } from '@shared/schemas/profileViewMessages';
+import { implicitDefaultToolUseAgents } from '@shared/constants/agents';
 import { formatResultCount } from '@utils/text/stringUtils';
 
 import {
@@ -13,10 +14,7 @@ import {
   formatCliMultiAgentPresetLauncherSummary,
   type CliMultiAgentPresetRunPlan,
 } from './multiAgentPresets';
-import {
-  implicitDefaultToolUseAgents,
-  pickDefaultToolUseAgent,
-} from './defaultAgents';
+import { pickDefaultToolUseAgent } from './defaultAgents';
 import { formatCliHistoryResumeSummary } from './historyLabels';
 import { resumableCliHistoryEntries, type CliHistoryEntry } from './history';
 import {

--- a/packages/extension/src/frontend/lean/VscodeIntegration.ts
+++ b/packages/extension/src/frontend/lean/VscodeIntegration.ts
@@ -11,8 +11,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
-import { showInstructionWithSuppress } from '@frontend/ui/instruction';
-import { safeExecuteCommand } from '@frontend/system/commandUtils';
+import { promptExtensionInstall } from '@frontend/ui/instruction';
 import { openFileInEditor } from '@frontend/vscode/vscodeEditor';
 import { waitForDiagnosticsChange } from '@frontend/vscode/vscodeDiagnostics';
 import {
@@ -208,29 +207,6 @@ export async function executeFileCommand(
 }
 
 /**
- * Prompt user to install Lean 4 extension if not already installed.
- * Used when Lean tools are invoked but the extension is not found.
- */
-async function promptLean4ExtensionInstall(): Promise<void> {
-  await showInstructionWithSuppress(
-    'lean4-install-tool',
-    'Lean 4 extension is required for this operation. Install now?',
-    [
-      {
-        title: 'Install',
-        callback: async () => {
-          await safeExecuteCommand(
-            'workbench.extensions.installExtension',
-            [LEAN4_EXTENSION_ID],
-            'lean',
-          );
-        },
-      },
-    ],
-  );
-}
-
-/**
  * Get the Lean 4 extension's client provider.
  * Returns null if the extension is not installed or not ready.
  * Prompts user to install the extension if not found.
@@ -239,7 +215,12 @@ async function getClientProvider(): Promise<LeanClientProvider | null> {
   const lean4Ext =
     vscode.extensions.getExtension<Lean4ExtensionApi>(LEAN4_EXTENSION_ID);
   if (!lean4Ext) {
-    await promptLean4ExtensionInstall();
+    await promptExtensionInstall({
+      suppressKey: 'lean4-install-tool',
+      message: 'Lean 4 extension is required for this operation. Install now?',
+      extensionId: LEAN4_EXTENSION_ID,
+      channel: 'lean',
+    });
     return null;
   }
 

--- a/packages/extension/src/frontend/setup.ts
+++ b/packages/extension/src/frontend/setup.ts
@@ -9,8 +9,7 @@ import {
 } from '@agent/index/AgentDirectorySync';
 import { GlobalStateKey, globalSM } from '@common/state';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
-import { showInstructionWithSuppress } from '@frontend/ui/instruction';
-import { safeExecuteCommand } from '@frontend/system/commandUtils';
+import { promptExtensionInstall } from '@frontend/ui/instruction';
 import * as logger from '@logger/logUtils';
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latex';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -163,7 +162,17 @@ export async function initializeLatexSupport(): Promise<void> {
       // prompted to install a TeX extension they don't need. They'll still
       // discover it via the LaTeX settings tab or compile errors later.
       if (await workspaceContainsLatexFiles()) {
-        await promptLatexWorkshopInstall();
+        logger.info(
+          'extension',
+          'LaTeX Workshop extension not found, prompting installation',
+        );
+        await promptExtensionInstall({
+          suppressKey: 'latex-workshop-install',
+          message:
+            'LaTeX Workshop extension is recommended for full TeXRA functionality (LaTeX compilation, PDF preview, and IntelliSense). Install now?',
+          extensionId: LATEX_WORKSHOP_EXT_ID,
+          channel: 'extension',
+        });
       }
     }
   } catch (err) {
@@ -185,26 +194,4 @@ async function workspaceContainsLatexFiles(): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-async function promptLatexWorkshopInstall(): Promise<void> {
-  logger.info(
-    'extension',
-    'LaTeX Workshop extension not found, prompting installation',
-  );
-  await showInstructionWithSuppress(
-    'latex-workshop-install',
-    'LaTeX Workshop extension is recommended for full TeXRA functionality (LaTeX compilation, PDF preview, and IntelliSense). Install now?',
-    [
-      {
-        title: 'Install',
-        callback: () =>
-          safeExecuteCommand(
-            'workbench.extensions.installExtension',
-            [LATEX_WORKSHOP_EXT_ID],
-            'extension',
-          ),
-      },
-    ],
-  );
 }

--- a/packages/extension/src/frontend/ui/instruction.ts
+++ b/packages/extension/src/frontend/ui/instruction.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { INSTRUCTION_PREFIX, globalSM } from '@common/state';
+import { safeExecuteCommand } from '@frontend/system/commandUtils';
 
 const NEVER_REMIND = 'Never remind again';
 
@@ -42,4 +43,28 @@ export async function showInstructionWithSuppress(
 
   const action = actions.find((a) => a.title === choice);
   await action?.callback();
+}
+
+/**
+ * Prompt the user to install a VS Code extension, with a suppressible
+ * "Never remind again" option. Fires the install command on confirm and
+ * warns on failure via {@link safeExecuteCommand}.
+ */
+export async function promptExtensionInstall(opts: {
+  suppressKey: string;
+  message: string;
+  extensionId: string;
+  channel: string;
+}): Promise<void> {
+  await showInstructionWithSuppress(opts.suppressKey, opts.message, [
+    {
+      title: 'Install',
+      callback: () =>
+        safeExecuteCommand(
+          'workbench.extensions.installExtension',
+          [opts.extensionId],
+          opts.channel,
+        ),
+    },
+  ]);
 }

--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -48,6 +48,7 @@ import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 // Local imports - progress view helpers
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { groupBy } from '@utils/core';
 import { isTextInput, selectExternalInquiryKey } from './RequestPanelsState';
 import { getPermissionKey, type PermissionState } from '../permissionState';
 import { streamDisplayLabel } from '../utils';
@@ -158,22 +159,6 @@ function renderPanel(
   ></${section.tag}>`;
 }
 
-/**
- * One pass over the queue. A kind with no section (malformed IPC data) lands
- * in a bucket nothing renders, so it is dropped rather than throwing.
- */
-function groupByKind(
-  permissions: readonly PermissionState[],
-): ReadonlyMap<PermissionState['kind'], PermissionState[]> {
-  const groups = new Map<PermissionState['kind'], PermissionState[]>();
-  for (const permission of permissions) {
-    const existing = groups.get(permission.kind);
-    if (existing) existing.push(permission);
-    else groups.set(permission.kind, [permission]);
-  }
-  return groups;
-}
-
 function externalInquiryKeys(
   permissions: readonly PermissionState[],
 ): string[] {
@@ -238,7 +223,7 @@ export class RequestPanels extends LitElement {
         (changedProperties.get('permissions') as
           PermissionState[] | undefined) ?? [],
       );
-      this.permissionsByKind = groupByKind(this.permissions);
+      this.permissionsByKind = groupBy(this.permissions, (p) => p.kind);
       this.selectedExternalInquiryKey = selectExternalInquiryKey(
         this.selectedExternalInquiryKey,
         previousKeys,

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -23,10 +23,7 @@ import {
   buildStatusBadge,
   SPINNER_ICON_NAME,
 } from '@progressView/frontend/formatters/htmlBuilders';
-import {
-  stringifyWithLanguage,
-  extractCodeOnlyInput,
-} from '@progressView/frontend/formatters/parseUtils';
+import { stringifyWithLanguage } from '@progressView/frontend/formatters/parseUtils';
 import {
   TOOL_CODE_LANGUAGES,
   getLanguageFromPath,
@@ -581,18 +578,20 @@ function buildDefaultSections(ctx: ToolSectionContext): TemplateResult[] {
   const { toolName, input } = ctx;
   if (input == null) return [];
   const codeLanguage = TOOL_CODE_LANGUAGES.get(toolName);
-  const { isCodeOnly, code } = codeLanguage
-    ? extractCodeOnlyInput(input)
-    : { isCodeOnly: false, code: '' };
 
-  if (isCodeOnly) {
-    return [
-      buildToolSection('', code, {
-        toolName,
-        language: codeLanguage,
-        extraClass: 'tool-command-input',
-      }),
-    ];
+  // Code-only input (wolfram `code` / bash `command`) renders with syntax
+  // highlighting instead of falling back to YAML serialization.
+  if (codeLanguage && isObject(input)) {
+    const codeValue = input.code ?? input.command;
+    if (typeof codeValue === 'string') {
+      return [
+        buildToolSection('', codeValue, {
+          toolName,
+          language: codeLanguage,
+          extraClass: 'tool-command-input',
+        }),
+      ];
+    }
   }
   const { text: inputValue, language: inputLanguage } =
     stringifyWithLanguage(input);

--- a/packages/extension/src/progressView/frontend/formatters/parseUtils.ts
+++ b/packages/extension/src/progressView/frontend/formatters/parseUtils.ts
@@ -10,9 +10,6 @@
 // Third-party imports
 import yaml from 'yaml';
 
-// Local imports - shared utilities
-import { isObject } from '@utils/core';
-
 /**
  * Result of stringifying a value with language metadata.
  */
@@ -39,25 +36,4 @@ export function stringifyWithLanguage(value: unknown): StringifyResult {
   } catch {
     return { text: String(value), language: 'plaintext' };
   }
-}
-
-/**
- * Extract the code/command field from a tool input object.
- * Supports 'code' field (wolfram) and 'command' field (bash).
- * Ignores metadata fields like `timeout` so the code is displayed
- * with proper syntax highlighting instead of falling back to YAML.
- */
-export function extractCodeOnlyInput(value: unknown): {
-  isCodeOnly: boolean;
-  code: string;
-} {
-  if (!isObject(value)) {
-    return { isCodeOnly: false, code: '' };
-  }
-  // Support both 'code' (wolfram) and 'command' (bash) field names
-  const codeValue = value.code ?? value.command;
-  if (typeof codeValue === 'string') {
-    return { isCodeOnly: true, code: codeValue };
-  }
-  return { isCodeOnly: false, code: '' };
 }

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -29,6 +29,7 @@ import type {
   ToolCategory,
 } from '@shared/schemas/settingsViewMessages';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { groupBy } from '@utils/core';
 
 // Side-effect imports - register WA button, icon, and switch components
 import '@awesome.me/webawesome/dist/components/button/button.js';
@@ -251,18 +252,6 @@ export class ToolsTab extends LitElement {
     return this.items.filter((item) => TOOLS_TAB_CATEGORIES.has(item.category));
   }
 
-  private groupByCategory(
-    items: readonly ToolDashboardItem[],
-  ): Map<ToolCategory, ToolDashboardItem[]> {
-    const groups = new Map<ToolCategory, ToolDashboardItem[]>();
-    for (const item of items) {
-      const list = groups.get(item.category) ?? [];
-      list.push(item);
-      groups.set(item.category, list);
-    }
-    return groups;
-  }
-
   private renderSummary(
     items: readonly ToolDashboardItem[],
   ): TemplateResult | typeof nothing {
@@ -328,7 +317,7 @@ export class ToolsTab extends LitElement {
     }
 
     const items = this.visibleItems();
-    const groups = this.groupByCategory(items);
+    const groups = groupBy(items, (i) => i.category);
 
     return html`
       <div class="tools-container tab-content-container">

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -14,7 +14,7 @@ import { parseYamlWith } from '@common/parsing/safeParseYaml';
 import * as logger from '@logger/logUtils';
 import type { AgentSource } from '@shared/schemas/agent';
 import { AbsoluteFS } from '@utils/files';
-import { filterNotNull } from '@utils/core';
+import { filterNotNull, groupBy } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { AgentEntry } from './agentEntry';
 
@@ -76,15 +76,7 @@ export async function scanDirectory(
 function entriesWithUniqueNames(
   entries: readonly ParsedAgentYaml[],
 ): ParsedAgentYaml[] {
-  const byName = new Map<string, ParsedAgentYaml[]>();
-  for (const entry of entries) {
-    const matches = byName.get(entry.name);
-    if (matches) {
-      matches.push(entry);
-    } else {
-      byName.set(entry.name, [entry]);
-    }
-  }
+  const byName = groupBy(entries, (entry) => entry.name);
 
   const unique: ParsedAgentYaml[] = [];
   for (const [name, matches] of byName) {

--- a/src/agent/modelHandlers/openai/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerKimi.ts
@@ -7,6 +7,7 @@ import type { TokenCountOptions } from '@agent/types/ModelHandlerContracts';
 import type { ToolDefinition } from '@model/ToolDefinition';
 import { isKimiCodeExclusiveModel } from '@model/kimiCodeSubscriptionRouting';
 import { hasManagedDirectRoute } from '@model/openRouterRouting';
+import { AUXILIARY_MAX_RETRIES } from '../support/auxiliaryRetry';
 import { resolveMoonshotRequestParameters } from '../support/moonshotRequestParameters';
 import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
 
@@ -50,7 +51,6 @@ const KimiTokenEstimateResponseSchema = z.object({
 });
 
 const KIMI_TOKEN_ESTIMATE_TIMEOUT_MS = 20_000; // 20 s
-const KIMI_TOKEN_ESTIMATE_RETRIES = 2;
 
 /**
  * Handler for Moonshot Kimi models using OpenAI-compatible API.
@@ -185,7 +185,7 @@ export class ModelHandlerKimi extends ReasoningModelHandlerOpenAI {
     const client = options?.client ?? (await this.getClient());
     const raw = await client.post<unknown>('/tokenizers/estimate-token-count', {
       body: { model: this.config.fullName, messages },
-      maxRetries: KIMI_TOKEN_ESTIMATE_RETRIES,
+      maxRetries: AUXILIARY_MAX_RETRIES,
       timeout: KIMI_TOKEN_ESTIMATE_TIMEOUT_MS,
       signal: options?.signal,
     });

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -33,6 +33,10 @@ import { extractMimeSubtype } from '@utils/text/stringUtils';
 // Local file imports
 import { toDataUrl } from '../support/dataUrl';
 import { auxiliaryRetry } from '../support/auxiliaryRetry';
+import {
+  classifyMediaEntry,
+  unknownMediaCategoryWarning,
+} from '../support/mediaClassification';
 import { getDeclaredMaxReasoningEffort } from '../support/reasoningEffort';
 import { OPENROUTER_BASE_URL } from '../support/ProxyConfigResolver';
 import {
@@ -475,39 +479,45 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
 
   createMediaContent(mediaMessage: MediaEntry[]): ChatContentItems[] {
     return mediaMessage.flatMap((media): ChatContentItems[] => {
-      switch (media.media_category) {
-        case 'image':
-          return [
-            { type: 'text', text: `Image: ${media.file_name}` },
-            {
-              type: 'image_url',
-              imageUrl: {
-                url: toDataUrl(media.media_type, media.data),
-                detail: 'high',
-              },
-            } as ChatContentItems,
-          ];
-        case 'audio':
-          if (!this.capabilities.supportsNativeAudio) {
-            this.logger.warn(
-              `Audio input received (${media.file_name}) but native audio is not supported by this model. Skipping.`,
-            );
-            return [];
-          }
-          return [
-            { type: 'text', text: `Audio: ${media.file_name}` },
-            {
-              type: 'input_audio',
-              inputAudio: {
-                data: media.data,
-                format: extractMimeSubtype(media.media_type).toLowerCase(),
-              },
-            } as ChatContentItems,
-          ];
-        default:
-          this.logger.warn(`Unknown media category: ${media.media_category}`);
-          return [];
+      const classification = classifyMediaEntry(media);
+
+      // PDFs (image-category entries with an application/pdf media type) render
+      // through the same image_url path — OpenRouter has no document-specific
+      // channel here, matching the other chat-style handlers.
+      if (classification === 'image' || classification === 'pdf') {
+        return [
+          { type: 'text', text: `Image: ${media.file_name}` },
+          {
+            type: 'image_url',
+            imageUrl: {
+              url: toDataUrl(media.media_type, media.data),
+              detail: 'high',
+            },
+          } as ChatContentItems,
+        ];
       }
+
+      if (classification === 'audio') {
+        if (!this.capabilities.supportsNativeAudio) {
+          this.logger.warn(
+            `Audio input received (${media.file_name}) but native audio is not supported by this model. Skipping.`,
+          );
+          return [];
+        }
+        return [
+          { type: 'text', text: `Audio: ${media.file_name}` },
+          {
+            type: 'input_audio',
+            inputAudio: {
+              data: media.data,
+              format: extractMimeSubtype(media.media_type).toLowerCase(),
+            },
+          } as ChatContentItems,
+        ];
+      }
+
+      this.logger.warn(unknownMediaCategoryWarning(media));
+      return [];
     });
   }
 

--- a/src/test-kernel/cli/DefaultAgents.vitest.ts
+++ b/src/test-kernel/cli/DefaultAgents.vitest.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import {
   BUILTIN_DEFAULT_CHAT_AGENT,
-  implicitDefaultToolUseAgents,
-  isImplicitDefaultEligible,
   pickDefaultToolUseAgent,
 } from '@cli/runtime/defaultAgents';
+import {
+  implicitDefaultToolUseAgents,
+  isImplicitDefaultEligible,
+} from '@shared/constants/agents';
 
 describe('CLI implicit default agent policy', () => {
   it('uses assistant as the built-in default chat agent', () => {

--- a/src/test-kernel/tools/Wolfram.vitest.ts
+++ b/src/test-kernel/tools/Wolfram.vitest.ts
@@ -156,7 +156,7 @@ describe('wolframScriptUtils', () => {
     vi.restoreAllMocks();
   });
 
-  it('executeWolframCode delegates to runWolfram with code args', async () => {
+  it('executeWolframCode runs wolframscript with code args', async () => {
     vi.spyOn(toolUtils, 'checkToolInstalled').mockResolvedValue(true);
     const executeCommand = vi
       .spyOn(execUtils, 'executeCommand')

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -5,14 +5,13 @@ import { z } from 'zod';
 import { normaliseArxivIdentifier } from '@latex/arxivIdentifier';
 import { ArxivProcessor } from '@latex/arxivProcessor';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import { wrapApiCall } from '@tools/utils';
 import {
   type ArxivPaperMetadata,
   createArxivClient,
   extractBasePaperMetadata,
 } from '@tools/latex/arxivShared';
 import { ARXIV_CONSTANTS } from '@tools/citation/constants';
-import { rateLimitedRequest } from '@tools/citation/rateLimiter';
+import { rateLimitedApiCall } from '@tools/citation/rateLimiter';
 import { defineTool } from '@tools/core/define';
 import { executed } from '@tools/core/result';
 
@@ -49,15 +48,12 @@ export class ArxivMetadataTool extends defineTool({
     const requestId = normaliseArxivIdentifier(rawId);
 
     // Use arxiv-client's ids() method for direct ID lookup.
-    const entries = await wrapApiCall(
-      () =>
-        rateLimitedRequest(
-          'arxiv',
-          ARXIV_CONSTANTS.RATE_LIMIT_DELAY_MS,
-          'arXiv metadata lookup',
-          () => createArxivClient().ids([requestId]).execute(),
-        ),
+    const entries = await rateLimitedApiCall(
+      'arxiv',
+      ARXIV_CONSTANTS.RATE_LIMIT_DELAY_MS,
+      'arXiv metadata lookup',
       'Failed to query arXiv API',
+      () => createArxivClient().ids([requestId]).execute(),
     );
 
     if (!entries?.length) {

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -13,9 +13,9 @@ import { z } from 'zod';
 import { normaliseArxivIdentifier } from '@latex/arxivIdentifier';
 import { warn } from '@logger/logUtils';
 import type { ToolResult } from '@shared/schemas/toolResult';
-import { requireNonEmptyString, wrapApiCall } from '@tools/utils';
+import { requireNonEmptyString } from '@tools/utils';
 import { ARXIV_CONSTANTS } from '@tools/citation/constants';
-import { rateLimitedRequest } from '@tools/citation/rateLimiter';
+import { rateLimitedApiCall } from '@tools/citation/rateLimiter';
 import { defineTool } from '@tools/core/define';
 import {
   type ArxivSearchResult,
@@ -129,15 +129,12 @@ export class ArxivSearchTool extends defineTool({
       client = client.sortOrder(input.sortOrder);
     }
 
-    const entries = await wrapApiCall(
-      () =>
-        rateLimitedRequest(
-          'arxiv',
-          ARXIV_CONSTANTS.RATE_LIMIT_DELAY_MS,
-          'arXiv search',
-          () => client.execute(),
-        ),
+    const entries = await rateLimitedApiCall(
+      'arxiv',
+      ARXIV_CONSTANTS.RATE_LIMIT_DELAY_MS,
+      'arXiv search',
       'Failed to query arXiv API',
+      () => client.execute(),
     );
 
     const results: ArxivSearchResult[] = entries.map((entry) => {

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -9,14 +9,14 @@ import { z } from 'zod';
 
 // Local imports
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import { requireNonEmptyString, wrapApiCall } from '@tools/utils';
+import { requireNonEmptyString } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 import { executed } from '@tools/core/result';
 import { pluralize } from '@utils/text/stringUtils';
 
 // Local file imports
 import { CROSSREF_CONSTANTS, CrossrefClient } from './constants';
-import { rateLimitedRequest } from './rateLimiter';
+import { rateLimitedApiCall } from './rateLimiter';
 
 const CROSSREF_SEARCH_FIELDS = {
   query: z.string().describe('Bibliographic search query for Crossref works.'),
@@ -76,24 +76,6 @@ export type CrossrefSearchInput = z.infer<typeof CrossrefSearchInputSchema>;
  */
 type ExtendedQueryWorksParams = QueryWorksParams & { filter?: string };
 
-/** Rate-limited, cancellable Crossref call with uniform error wrapping. */
-function crossrefRequest<T>(
-  label: string,
-  failureMessage: string,
-  request: () => Promise<T>,
-): Promise<T> {
-  return wrapApiCall(
-    () =>
-      rateLimitedRequest(
-        'crossref',
-        CROSSREF_CONSTANTS.RATE_LIMIT_DELAY_MS,
-        label,
-        request,
-      ),
-    failureMessage,
-  );
-}
-
 export class CrossrefSearchTool extends defineTool({
   name: 'crossref_search',
   parallelSafe: true,
@@ -105,7 +87,9 @@ export class CrossrefSearchTool extends defineTool({
     if (input.command === 'doi') {
       const trimmedDoi = requireNonEmptyString(input.doi, 'DOI');
 
-      const response = await crossrefRequest(
+      const response = await rateLimitedApiCall(
+        'crossref',
+        CROSSREF_CONSTANTS.RATE_LIMIT_DELAY_MS,
         'Crossref DOI lookup',
         'Crossref lookup failed',
         () => CrossrefClient.work(trimmedDoi),
@@ -151,7 +135,9 @@ export class CrossrefSearchTool extends defineTool({
       ...(input.filter && { filter: input.filter }),
     };
 
-    const response = await crossrefRequest(
+    const response = await rateLimitedApiCall(
+      'crossref',
+      CROSSREF_CONSTANTS.RATE_LIMIT_DELAY_MS,
       'Crossref search',
       'Crossref search failed',
       () => CrossrefClient.works(options),

--- a/src/tools/citation/rateLimiter.ts
+++ b/src/tools/citation/rateLimiter.ts
@@ -4,6 +4,7 @@ import pThrottle from 'p-throttle';
 // Local imports
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { ToolError } from '@shared/schemas/toolResult';
+import { wrapApiCall } from '@tools/utils';
 
 const limiters = new Map<
   string,
@@ -53,6 +54,25 @@ export async function rateLimitedRequest<T>(
 ): Promise<T> {
   await waitForRateLimit(apiName, minDelayMs);
   return abandonOnAbort(request(), getCurrentToolCallContext()?.signal, label);
+}
+
+/**
+ * Compose {@link rateLimitedRequest} with uniform error wrapping via
+ * {@link wrapApiCall}. The shape every arXiv/Crossref lookup repeats:
+ * rate-limit + cancellable request, then rethrow as a ToolError with a
+ * descriptive prefix.
+ */
+export async function rateLimitedApiCall<T>(
+  apiName: string,
+  minDelayMs: number,
+  label: string,
+  failureMessage: string,
+  request: () => Promise<T>,
+): Promise<T> {
+  return wrapApiCall(
+    () => rateLimitedRequest(apiName, minDelayMs, label, request),
+    failureMessage,
+  );
 }
 
 /**

--- a/src/tools/wolfram/wolframScriptUtils.ts
+++ b/src/tools/wolfram/wolframScriptUtils.ts
@@ -31,14 +31,13 @@ function wolframFailure(error: string): WolframScriptResult {
 }
 
 /**
- * Internal helper to run wolframscript commands with installation check.
- * @param commandArgs Array of command-line arguments to pass to wolframscript (e.g., ['-code', 'expr'] or ['-file', 'path'])
- * @param timeout Execution timeout in milliseconds
- * @returns Promise resolving to execution result with success status, output, and error information
+ * Execute Wolfram Language code through wolframscript.
+ * @param code The Wolfram Language code to execute
+ * @param options.timeout Execution timeout in milliseconds (default: 30 s)
  */
-async function runWolfram(
-  commandArgs: string[],
-  timeout?: number,
+export async function executeWolframCode(
+  code: string,
+  options: { timeout?: number } = {},
 ): Promise<WolframScriptResult> {
   const isInstalled = await checkToolInstalled('wolframscript', false);
   if (!isInstalled) {
@@ -46,9 +45,9 @@ async function runWolfram(
   }
 
   try {
-    const result = await executeCommand(['wolframscript', ...commandArgs], {
+    const result = await executeCommand(['wolframscript', '-code', code], {
       truncate: false,
-      timeout,
+      timeout: options.timeout ?? WOLFRAM_CODE_TIMEOUT_MS,
       channel: WOLFRAM_CHANNEL,
     });
 
@@ -62,19 +61,4 @@ async function runWolfram(
   } catch (err) {
     return wolframFailure(toErrorMessage(err));
   }
-}
-
-/**
- * Execute Wolfram Language code through wolframscript.
- * @param code The Wolfram Language code to execute
- * @param options.timeout Execution timeout in milliseconds (default: 30 s)
- */
-export async function executeWolframCode(
-  code: string,
-  options: { timeout?: number } = {},
-): Promise<WolframScriptResult> {
-  return runWolfram(
-    ['-code', code],
-    options.timeout ?? WOLFRAM_CODE_TIMEOUT_MS,
-  );
 }


### PR DESCRIPTION
## Summary

Wave 1 of a dedup/consolidation sweep: eight behavior-preserving edits that remove duplicated logic and inline single-use wrappers. **Net −82 LoC** (167 ins / 249 del across 21 files). Found by a multi-agent dedup audit; each item below is an isolated, independently reviewable change.

## Changes

- **`groupBy` × 3 → shared `@utils/core` `groupBy`** — replaces hand-rolled group-into-`Map` loops in `agentYamlScanner`, `RequestPanels`, `ToolsTab`.
- **`rateLimitedApiCall`** — new helper in `citation/rateLimiter.ts` (composing the existing `rateLimitedRequest` + `wrapApiCall`); deletes the inlined wrappers in `ArxivSearchTool`, `ArxivMetadataTool`, and Crossref's local `crossrefRequest`.
- **Inline `runWolfram`** into `executeWolframCode`; drops the speculative `commandArgs` param (only ever `['-code', code]`).
- **Inline `extractCodeOnlyInput`** into its sole caller in `toolSections`.
- **Kimi retry constant** — drop `KIMI_TOKEN_ESTIMATE_RETRIES`, reuse the shared `AUXILIARY_MAX_RETRIES`.
- **OpenRouter media classification** — route `createMediaContent` through the shared `classifyMediaEntry` / `unknownMediaCategoryWarning` (SSOT with the Anthropic/OpenAI handlers).
- **Drop `defaultAgents` barrel re-export** — callers import `isImplicitDefaultEligible` / `implicitDefaultToolUseAgents` directly from `@shared/constants/agents`.
- **`promptExtensionInstall`** — merge `promptLatexWorkshopInstall` + `promptLean4ExtensionInstall` into one helper in `ui/instruction`.

## Verification

- `npm run typecheck` — ✅ all 7 stages
- `npm run lint` — ✅ clean (import-order auto-fixed)
- Pre-push lint hook — ✅

Behavior-preserving by construction: each consolidation reuses an existing helper with identical semantics, and deleted wrappers had a single caller (grep-verified).

## Notes

This is the first wave from a dedup audit that was relay-quota-limited partway (11 of ~34 investigation agents completed). The remaining batches — the `src/agent` core, `shared/schemas`, `controllers`, and the cross-cutting schema/UI lenses — will follow in subsequent waves once the relay resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors consolidate existing helpers with identical semantics and remove single-caller wrappers; no auth, security, or data-path changes beyond import and call-site reshaping.
> 
> **Overview**
> Wave 1 of a dedup sweep: **net −82 LoC** by routing repeated patterns through shared helpers and deleting one-off wrappers, without intended behavior changes.
> 
> **Shared utilities** — Local “group into `Map`” loops in the agent YAML scanner, progress **RequestPanels**, and settings **ToolsTab** now call `@utils/core` **`groupBy`**. CLI code imports **`implicitDefaultToolUseAgents`** / **`isImplicitDefaultEligible`** from `@shared/constants/agents` instead of a CLI **`defaultAgents`** re-export barrel.
> 
> **Citation tools** — **`rateLimitedApiCall`** in `citation/rateLimiter` combines rate limiting, abort racing, and **`wrapApiCall`** error wrapping; arXiv and Crossref tools adopt it and drop duplicated **`crossrefRequest`** / inline **`wrapApiCall`** stacks.
> 
> **Extension UX** — Lean and LaTeX Workshop install prompts share **`promptExtensionInstall`** in `ui/instruction` (replacing separate Lean/LaTeX helpers).
> 
> **Progress view** — Default tool input rendering inlines code-only **`code`/`command`** handling in **`toolSections`** and removes **`extractCodeOnlyInput`** from **`parseUtils`**.
> 
> **Model handlers** — Kimi token estimation reuses **`AUXILIARY_MAX_RETRIES`**; OpenRouter native **`createMediaContent`** uses shared **`classifyMediaEntry`** / **`unknownMediaCategoryWarning`** like other chat handlers.
> 
> **Wolfram** — **`executeWolframCode`** inlines the former **`runWolfram`** helper (only ever **`['-code', code]`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1406dfe2810f1e509433a09c231521c628b69a34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->