### PR TITLE
feat(cli): declare the running session count in the status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
   without leaving the chat interface.
 - **The transcript reader pages with `PgUp`/`PgDn`** — the Ctrl-T full-output
   view scrolls a page at a time instead of one line per keypress.
+- **The status bar reports how many sessions are running** — while background
+  sessions are in flight, the status bar declares the count (e.g. "3 running
+  sessions") alongside the Tab sessions hint.
 
 #### Bug Fixes
 

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -14,6 +14,7 @@ import {
 // Local imports - shared runtime
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
 import { type StreamTabId } from '@shared/schemas';
+import { isActivePhase } from '@shared/streams/streamStatus';
 import { SESSION_LIST } from '@shared/copy/nestedRuns';
 
 // Local imports - TUI surfaces and state
@@ -264,6 +265,11 @@ export function App(props: AppProps): React.JSX.Element {
       streams,
     ],
   );
+  // Rows Tab navigates to that are still in flight — the count the status bar
+  // advertises next to the Tab binding.
+  const childRunningCount = sessionViews.filter(
+    (view) => view.slice !== undefined && isActivePhase(view.slice.status),
+  ).length;
   const pendingApprovalsForRows = useMemo(
     () => groupPendingApprovalsByRow(pendingSummaries, rootStreamId),
     [pendingSummaries, rootStreamId],
@@ -738,6 +744,7 @@ export function App(props: AppProps): React.JSX.Element {
                 selectedChildWorkflowControllable
               }
               childNavigationAvailable={childListAvailable}
+              runningSessions={childRunningCount}
               shortcutsActive={focusShortcutsActive}
               streamFocusAvailable={sessionViews.length > 0}
               transcriptAvailable={(activeSlice?.entries.length ?? 0) > 0}

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -266,9 +266,13 @@ export function App(props: AppProps): React.JSX.Element {
     ],
   );
   // Rows Tab navigates to that are still in flight — the count the status bar
-  // advertises next to the Tab binding.
+  // advertises next to the Tab binding. `sessionViews` leads with the list
+  // root, so require a parent: the root session is not a background session.
   const childRunningCount = sessionViews.filter(
-    (view) => view.slice !== undefined && isActivePhase(view.slice.status),
+    (view) =>
+      view.parentId !== undefined &&
+      view.slice !== undefined &&
+      isActivePhase(view.slice.status),
   ).length;
   const pendingApprovalsForRows = useMemo(
     () => groupPendingApprovalsByRow(pendingSummaries, rootStreamId),

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -48,6 +48,7 @@ interface StatusBarProps {
   readonly childListFocused?: boolean;
   readonly childListSelectionKillable?: boolean;
   readonly childListSelectionWorkflowControllable?: boolean;
+  readonly runningSessions?: number;
   readonly childNavigationAvailable: boolean;
   readonly commandName?: string;
   readonly foregroundEscapeAction?: string;
@@ -213,6 +214,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     usage: statusSlice?.usage,
     stage: statusSlice?.stage,
     subagents: subagentCount,
+    runningSessions: props.runningSessions ?? 0,
     approvalDepth: approvals.depth,
     approvalKind: approvals.kind,
     model: accessTarget.model,

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -29,6 +29,7 @@ import {
 import { INCLUDED_ACCESS } from '@shared/copy/modelAccess';
 import {
   FOREGROUND_OWNERSHIP,
+  RUNNING_SESSION,
   SESSION_LIST,
   SUBAGENT,
 } from '@shared/copy/nestedRuns';
@@ -100,6 +101,8 @@ export interface StatusBarDisplayInput {
   readonly stage: StreamStage | undefined;
   /** Retained and active direct subagents owned by the displayed stream. */
   readonly subagents: number;
+  /** Visible child sessions still in flight (see RUNNING_SESSION copy). */
+  readonly runningSessions: number;
   readonly approvalDepth: number;
   readonly approvalKind?: ApprovalQueueStatusKind;
   readonly model: string;
@@ -344,6 +347,19 @@ function subagentsSegment(subagents: number): StatusBarSegment | undefined {
     ? {
         text: formatResultCount(subagents, SUBAGENT.countNoun),
         compactText: `${subagents} ${SUBAGENT.compactCountSuffix}`,
+        color: 'dim',
+        compactPriority: STATUS_BAR_COMPACT_PRIORITY.activeSubagent,
+      }
+    : undefined;
+}
+
+function runningSessionsSegment(
+  runningSessions: number,
+): StatusBarSegment | undefined {
+  return runningSessions > 0
+    ? {
+        text: formatResultCount(runningSessions, RUNNING_SESSION.countNoun),
+        compactText: `${runningSessions} ${RUNNING_SESSION.compactCountSuffix}`,
         color: 'dim',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.activeSubagent,
       }
@@ -1045,6 +1061,7 @@ export function buildStatusBarDisplay(
       formatUsage(input.usage, input.model),
       queuedFollowUpsCountSegment(input.queuedFollowUpMessages),
       subagentsSegment(input.subagents),
+      runningSessionsSegment(input.runningSessions),
       pendingInteractionSegment({
         depth: input.approvalDepth,
         kind: input.approvalKind,

--- a/src/shared/copy/nestedRuns.ts
+++ b/src/shared/copy/nestedRuns.ts
@@ -54,6 +54,14 @@ export const SUBAGENT = {
   compactCountSuffix: 'sub',
 } as const;
 
+/** Status-bar count for child sessions still in flight, e.g. `3 running
+ *  sessions`. */
+export const RUNNING_SESSION = {
+  countNoun: 'running session',
+  /** Compact status-bar chip suffix, e.g. `3 run`. */
+  compactCountSuffix: 'run',
+} as const;
+
 /**
  * CLI session-list navigation. The list shows background tasks (and the root);
  * the user-facing noun for "a row I can focus" is session.

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -58,6 +58,7 @@ function statusInput(
     usage: undefined,
     stage: undefined,
     subagents: 0,
+    runningSessions: 0,
     approvalDepth: 0,
     model: 'deepseekT',
     modelAccess: 'personal',
@@ -248,6 +249,21 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('Tab sessions');
     expect(display.bindings).toContain('Ctrl-T transcript');
     expect(display.bindings).not.toContain('Alt-s subagents');
+  });
+
+  it('declares the running session count as a status segment', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        width: 80,
+        runningSessions: 3,
+        shortcuts: STREAM_NAV_SHORTCUTS,
+      }),
+    );
+
+    expect(display.left.map((segment) => segment.text)).toContain(
+      '3 running sessions',
+    );
+    expect(display.bindings).toContain('Tab sessions');
   });
 
   it('prioritizes Esc back at the narrowest width where it fits', () => {


### PR DESCRIPTION
## Summary

The CLI status bar now declares how many child sessions are running while any are in flight, e.g. `3 running sessions`, shown as a status segment alongside the `Tab sessions` binding (which stays as the Tab hint). Mirrors the existing `N subagents` segment: same dim colour, same compaction priority, same `formatResultCount` copy style (`RUNNING_SESSION` copy in `nestedRuns.ts`).

The count is derived from the visible session views' status (`isActivePhase`) in `App.tsx` and threaded through `StatusBar` into the display input.

## Issue acceptance gates

No issue; direct UX request from the TUI status bar.

## Single source of truth

The running count is derived from `streamTreeViews` (the same source the child list and Tab navigation render from), so the status bar can never disagree with what Tab opens.

## Duplication and abstraction budget

No new abstraction — `runningSessionsSegment` is the parallel of `subagentsSegment`, sharing `formatResultCount`, the `activeSubagent` compaction priority, and the `RUNNING_SESSION` copy constant added to `nestedRuns.ts`.

## Net elements (R6)

- Files: 6 changed, +33/−4.
- New exports: `RUNNING_SESSION` (`src/shared/copy/nestedRuns.ts`).
- No new interfaces; `StatusBarDisplayInput` gains one field (`runningSessions`).

## Consumer counts (R8)

n/a — no emit path or export removed; the new input field has exactly one consumer (`runningSessionsSegment`), the new copy constant one (`runningSessionsSegment`).

## Host impact

Extension: none. Desktop: none. CLI: status bar shows `N running sessions` while child sessions are in flight; `Tab sessions` hint unchanged.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck:cli` and `npm run typecheck:test-kernel` pass.
- `StatusBar.vitest.ts` (92 tests) passes, including a new test asserting the `3 running sessions` segment and that the `Tab sessions` binding is unaffected.

Note: this branch is stacked on #9890 (the branch base includes its commits); once #9890 merges, this PR will be retargeted to main and its diff will show only this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only TUI change with no auth, data, or API impact; count is derived from existing session view state.
> 
> **Overview**
> The CLI status bar now shows how many **child sessions** are still in flight (e.g. **`3 running sessions`**) while background work runs, using the same dim segment style and compaction behavior as the existing subagent count.
> 
> The count is computed in **`App.tsx`** from the same **`sessionViews`** tree Tab navigation uses: child rows with a parent and **`isActivePhase`** status, excluding the root session. It flows through **`StatusBar`** into a new **`runningSessionsSegment`** in **`statusBarDisplay`**, backed by **`RUNNING_SESSION`** copy in **`nestedRuns.ts`**. The **`Tab sessions`** binding is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 665bb6036258bcca04810e47470b3fb522a0e59e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->