### PR TITLE
feat(model,cli): add GLM-5.2 default with GLM Coding Plan access

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -522,6 +522,7 @@ const HARNESS_MODEL_ACCESS =
           // remain the visible "on" pair (Grok still appears as a row).
           grok: 'off' as const,
           kimiCode: 'on' as const,
+          glmCode: 'off' as const,
         },
         chatGptSignedIn: SHOW_BOTH_SUBSCRIPTION_PREFERENCES,
         ...(SHOW_BOTH_SUBSCRIPTION_PREFERENCES
@@ -529,6 +530,7 @@ const HARNESS_MODEL_ACCESS =
           : {}),
         grokSignedIn: false,
         kimiCodeKeySet: true,
+        glmKeySet: true,
       }
     : undefined;
 const HARNESS_ORCHESTRATION_ITEMS = buildCliOrchestrationItems({

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -462,7 +462,7 @@ const SCENARIOS = [
       HARNESS_VISIBLE_TOOL_USE_AGENTS: '',
       HARNESS_VISIBLE_WORKFLOW_AGENTS: '',
     },
-    bootExpect: 'Model access — ChatGPT On · Grok Off · Kimi On',
+    bootExpect: 'Model access — ChatGPT On · Grok Off · Kimi On · GLM Off',
     keys: ['3'],
     exitKeys: [ESC, ESC],
     expectExit: true,
@@ -475,16 +475,19 @@ const SCENARIOS = [
       'Off · sign in required to enable',
       'Prefer Kimi Code subscr',
       'On · key configured',
+      'Prefer GLM Coding Plan',
+      'Off · key configured',
       'Included access',
       'Your own API keys',
-      // ChatGPT + Grok + Kimi + Included + Personal → Personal is item 5.
-      '✓ 5. Your own API keys',
+      // ChatGPT + Grok + Kimi + GLM + Included + Personal → Personal is item 6.
+      '✓ 6. Your own API keys',
       'Esc back',
     ],
     unexpect: [
       '✓ 1. Prefer ChatGPT',
       '✓ 2. Prefer Grok',
       '✓ 3. Prefer Kimi Code',
+      '✓ 4. Prefer GLM Coding Plan',
     ],
   },
   {

--- a/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
@@ -33,7 +33,7 @@ import {
 import { loadCliAccountStatusLines } from './statusAssembly';
 
 const MODEL_ACCESS_USAGE =
-  'Usage: /api chatgpt | grok | kimi-code | included | personal | status';
+  'Usage: /api chatgpt | grok | kimi-code | glm-code | included | personal | status';
 
 async function reconcileRootModelAfterApiModeChange(
   context: SlashCommandContext | undefined,

--- a/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
@@ -53,6 +53,7 @@ export interface CreateCliConfigFormPropsInput extends CliConfigFormProps {
 const MODEL_ROUTING_SETTING_KEYS: ReadonlySet<string> = new Set([
   GlobalStateKey.USE_OPENROUTER,
   GlobalStateKey.KIMI_CODE_PREFER,
+  GlobalStateKey.GLM_CODING_PLAN,
 ]);
 
 const INITIAL_API_KEY_STATUS_VIEW: ProviderApiKeyStatusView = {

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -11,6 +11,7 @@ import { formatPercent } from '@utils/text/stringUtils';
 import { getCliApiMode } from './apiAccessMode';
 import {
   formatCliChatGptPreference,
+  formatCliGlmCodingPlanPreference,
   formatCliGrokPreference,
   formatCliKimiCodePreference,
   formatCliModelAccessRoute,
@@ -79,6 +80,7 @@ export async function loadCliModelAccessOverview(
     `ChatGPT preference: ${formatCliChatGptPreference(access)}`,
     `Grok preference: ${formatCliGrokPreference(access)}`,
     `Kimi Code preference: ${formatCliKimiCodePreference(access)}`,
+    `GLM Coding Plan preference: ${formatCliGlmCodingPlanPreference(access)}`,
     `Otherwise: ${formatCliModelAccessRoute(access.apiFallback)}`,
     formatAccountStatusLine(
       RESEARCHER_ACCESS.label,
@@ -259,6 +261,11 @@ export async function loadCliDetailedAccountStatusLines(options: {
           ? 'key configured'
           : 'key not configured',
     },
+    glmCode: {
+      preferred: access.preferences.glmCode === 'on',
+      credential:
+        access.glmKeySet === true ? 'key configured' : 'key not configured',
+    },
     fallback:
       access.apiFallback === 'included'
         ? {
@@ -300,6 +307,15 @@ export async function loadCliDetailedAccountStatusLines(options: {
     routes.kimiCode.credential,
   );
   if (kimiLine) lines.push(kimiLine);
+
+  const glmLine = formatModelPreferenceLine(
+    'GLM Coding Plan',
+    routes.glmCode.preferred,
+    access.glmKeySet === true,
+    'key required',
+    routes.glmCode.credential,
+  );
+  if (glmLine) lines.push(glmLine);
 
   const fallbackLine = `Otherwise: ${formatCliModelAccessRoute(access.apiFallback)}`;
   if (routes.fallback.kind === 'included') {

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -14,6 +14,7 @@ import { INCLUDED_ACCESS, OWN_API_KEYS } from '@shared/copy/modelAccess';
 import type { AgentCategory } from '@shared/schemas/agent';
 import type { ApiAccessMode } from '@shared/schemas/profileViewMessages';
 import { unique } from '@utils/core';
+import { getGLMCodingPlan } from '@utils/config/providerConfig';
 
 // Local file imports
 import { resolveKnownCliModelId } from './cliConfig';
@@ -259,9 +260,20 @@ export function formatModelStatusForCliMode(
   apiMode: ApiAccessMode,
 ): string {
   if (apiMode === 'personal') {
-    return model.model.provider === 'kimiCode'
-      ? 'api: Kimi Code subscription'
-      : `api: ${model.status}`;
+    if (model.model.provider === 'kimiCode')
+      return 'api: Kimi Code subscription';
+    // GLM models route through the Coding Plan endpoint when the toggle is on.
+    // Gate on the resolved provider-key route (not just provider + toggle): the
+    // coding-plan path only applies to the direct GLM endpoint, never to an
+    // OpenRouter route, which stays reported as its own key status.
+    if (
+      model.model.provider === 'glm' &&
+      model.model.availability === 'provider-key' &&
+      getGLMCodingPlan()
+    ) {
+      return 'api: GLM Coding Plan';
+    }
+    return `api: ${model.status}`;
   }
 
   const availability = model.model.availability;

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -13,12 +13,13 @@ export type CliModelAccessRoute =
   'chatgpt' | 'grok' | 'kimi-code' | 'included' | 'personal';
 
 type CliSubscriptionPreferenceState = 'off' | 'on';
-type CliSubscriptionProvider = 'chatgpt' | 'grok' | 'kimi-code';
+type CliSubscriptionProvider = 'chatgpt' | 'grok' | 'kimi-code' | 'glm-code';
 
 interface CliSubscriptionPreferences {
   readonly chatGpt: CliSubscriptionPreferenceState;
   readonly grok: CliSubscriptionPreferenceState;
   readonly kimiCode: CliSubscriptionPreferenceState;
+  readonly glmCode: CliSubscriptionPreferenceState;
 }
 
 export type CliModelAccessSelection =
@@ -57,6 +58,7 @@ export interface CliModelAccessStatus {
   readonly grokSignedIn: boolean;
   readonly grokAccountLabel?: string;
   readonly kimiCodeKeySet?: boolean;
+  readonly glmKeySet?: boolean;
   readonly texraSignedIn?: boolean;
   /** Display names of providers with configured API keys (e.g. `['DeepSeek']`). */
   readonly personalKeyProviders?: readonly string[];
@@ -114,6 +116,16 @@ export function parseCliModelAccessSelection(
       return {
         kind: 'subscription-preference',
         provider: 'kimi-code',
+        state: 'on',
+      };
+    case 'glm':
+    case 'glmcode':
+    case 'glm-code':
+    case 'glm-coding':
+    case 'glm-coding-plan':
+      return {
+        kind: 'subscription-preference',
+        provider: 'glm-code',
         state: 'on',
       };
     default:
@@ -257,6 +269,19 @@ export function formatCliKimiCodePreference(
     : 'Off · key required to enable';
 }
 
+/** Format the GLM Coding Plan preference independently of key availability. */
+export function formatCliGlmCodingPlanPreference(
+  status: CliModelAccessStatus,
+): string {
+  if (status.preferences.glmCode === 'on' && status.glmKeySet !== true) {
+    return 'On · key required';
+  }
+  if (status.preferences.glmCode === 'on') return 'On · key configured';
+  return status.glmKeySet === true
+    ? 'Off · key configured'
+    : 'Off · key required to enable';
+}
+
 const cliSubscriptionAccessItems = [
   {
     provider: 'chatgpt',
@@ -275,6 +300,12 @@ const cliSubscriptionAccessItems = [
     preference: 'kimiCode',
     label: 'Prefer Kimi Code subscription',
     formatDescription: formatCliKimiCodePreference,
+  },
+  {
+    provider: 'glm-code',
+    preference: 'glmCode',
+    label: 'Prefer GLM Coding Plan',
+    formatDescription: formatCliGlmCodingPlanPreference,
   },
 ] as const satisfies ReadonlyArray<{
   readonly provider: CliSubscriptionProvider;
@@ -338,5 +369,6 @@ export function formatCliModelAccessSummary(
   const chatGpt = status.preferences.chatGpt === 'on' ? 'On' : 'Off';
   const grok = status.preferences.grok === 'on' ? 'On' : 'Off';
   const kimiCode = status.preferences.kimiCode === 'on' ? 'On' : 'Off';
-  return `ChatGPT ${chatGpt} · Grok ${grok} · Kimi ${kimiCode} · otherwise: ${formatCliModelAccessRouteInline(status.apiFallback)}`;
+  const glmCode = status.preferences.glmCode === 'on' ? 'On' : 'Off';
+  return `ChatGPT ${chatGpt} · Grok ${grok} · Kimi ${kimiCode} · GLM ${glmCode} · otherwise: ${formatCliModelAccessRouteInline(status.apiFallback)}`;
 }

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -17,7 +17,9 @@ import { INCLUDED_ACCESS } from '@shared/copy/modelAccess';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import type { ApiAccessMode } from '@shared/schemas/profileViewMessages';
 import {
+  getGLMCodingPlan,
   getPreferKimiCode,
+  setGLMCodingPlan,
   setPreferKimiCode,
 } from '@utils/config/providerConfig';
 
@@ -53,17 +55,19 @@ export async function readCliModelAccessStatus(
   apiMode: ApiAccessMode,
 ): Promise<CliModelAccessStatus> {
   const secrets = platform().secrets;
-  const [chatGpt, grok, kimiCodeKeySet, configuredProviders] =
+  const [chatGpt, grok, kimiCodeKeySet, glmKeySet, configuredProviders] =
     await Promise.all([
       getCodexStatus(),
       getXaiStatus(),
       apiKeyExists(secrets, 'kimiCode'),
+      apiKeyExists(secrets, 'glm'),
       configuredApiKeyProviders(secrets),
     ]);
   const preferences = {
     chatGpt: isPreferCodexSubscription() ? 'on' : 'off',
     grok: isPreferXaiSubscription() ? 'on' : 'off',
     kimiCode: getPreferKimiCode() ? 'on' : 'off',
+    glmCode: getGLMCodingPlan() ? 'on' : 'off',
   } as const;
   const personalKeyProviders = configuredProviders.map(
     (provider) => PROVIDER_DISPLAY_NAMES[provider] ?? provider,
@@ -76,6 +80,7 @@ export async function readCliModelAccessStatus(
     grokSignedIn: grok.signedIn,
     grokAccountLabel: grok.email,
     kimiCodeKeySet,
+    glmKeySet,
     personalKeyProviders,
   };
 }
@@ -127,6 +132,33 @@ export async function updateCliModelAccess(
     return {
       apiMode,
       message: `Prefer Kimi Code subscription enabled for Kimi models · other models still use ${formatCliModelAccessRouteInline(apiMode)}.`,
+    };
+  }
+
+  if (selection.provider === 'glm-code') {
+    if (selection.state === 'off') {
+      await setGLMCodingPlan(false);
+      invalidateModelOptionsCache();
+      return {
+        apiMode,
+        message: 'Prefer GLM Coding Plan disabled for GLM models.',
+      };
+    }
+
+    // The GLM API key is the Coding Plan credential — there is no separate
+    // sign-in flow.
+    if (!(await apiKeyExists(platform().secrets, 'glm'))) {
+      return {
+        apiMode,
+        message:
+          'No GLM API key configured — add one with /key or /config → API keys (get one at https://open.bigmodel.cn or https://z.ai).',
+      };
+    }
+    await setGLMCodingPlan(true);
+    invalidateModelOptionsCache();
+    return {
+      apiMode,
+      message: `Prefer GLM Coding Plan enabled for GLM models · other models still use ${formatCliModelAccessRouteInline(apiMode)}.`,
     };
   }
 

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -55,6 +55,8 @@ export const PREFERRED_DEFAULT_MODELS: readonly string[] = [
   'deepseekproT',
   'kimi26T',
   'kimi3',
+  // Current non-retired GLM flagship.
+  'glm52',
   // Current non-retired xAI flagship — API key or experimental Grok OAuth.
   'grok45',
 ];

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.ts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.ts
@@ -75,10 +75,16 @@ function setPersonalKeys(...providers: string[]): void {
 function useIncludedAccessStatus(): void {
   mocks.readCliModelAccessStatus.mockResolvedValue({
     apiFallback: 'included',
-    preferences: { chatGpt: 'off', grok: 'off', kimiCode: 'off' },
+    preferences: {
+      chatGpt: 'off',
+      grok: 'off',
+      kimiCode: 'off',
+      glmCode: 'off',
+    },
     chatGptSignedIn: false,
     grokSignedIn: false,
     kimiCodeKeySet: false,
+    glmKeySet: false,
   });
 }
 
@@ -101,10 +107,16 @@ describe('loadCliApiStatusLines', () => {
     mocks.resolveCliUsageTier.mockReset().mockResolvedValue('free');
     mocks.readCliModelAccessStatus.mockReset().mockResolvedValue({
       apiFallback: 'personal',
-      preferences: { chatGpt: 'off', grok: 'off', kimiCode: 'off' },
+      preferences: {
+        chatGpt: 'off',
+        grok: 'off',
+        kimiCode: 'off',
+        glmCode: 'off',
+      },
       chatGptSignedIn: false,
       grokSignedIn: false,
       kimiCodeKeySet: false,
+      glmKeySet: false,
     });
     mocks.lookupApiKeyOrigin.mockReset().mockResolvedValue('none');
   });
@@ -207,11 +219,17 @@ describe('loadCliApiStatusLines', () => {
   it('renders preferred Kimi and ChatGPT routes with their owned credentials', async () => {
     mocks.readCliModelAccessStatus.mockResolvedValue({
       apiFallback: 'included',
-      preferences: { chatGpt: 'on', grok: 'off', kimiCode: 'on' },
+      preferences: {
+        chatGpt: 'on',
+        grok: 'off',
+        kimiCode: 'on',
+        glmCode: 'off',
+      },
       chatGptSignedIn: true,
       grokSignedIn: false,
       chatGptAccountLabel: 'chatgpt@example.com',
       kimiCodeKeySet: true,
+      glmKeySet: false,
     });
     mocks.getCliAuthProfile.mockResolvedValue({
       authenticated: true,
@@ -282,10 +300,16 @@ describe('loadCliApiStatusLines', () => {
     async ({ expected, preference, signedIn }) => {
       mocks.readCliModelAccessStatus.mockResolvedValue({
         apiFallback: 'personal',
-        preferences: { chatGpt: preference, grok: 'off', kimiCode: 'off' },
+        preferences: {
+          chatGpt: preference,
+          grok: 'off',
+          kimiCode: 'off',
+          glmCode: 'off',
+        },
         chatGptSignedIn: signedIn,
         chatGptAccountLabel: signedIn ? 'chatgpt@example.com' : undefined,
         kimiCodeKeySet: false,
+        glmKeySet: false,
       });
 
       await expect(accountStatusLines('personal')).resolves.toEqual(expected);
@@ -331,10 +355,71 @@ describe('loadCliApiStatusLines', () => {
     async ({ expected, keySet, preference }) => {
       mocks.readCliModelAccessStatus.mockResolvedValue({
         apiFallback: 'personal',
-        preferences: { chatGpt: 'off', grok: 'off', kimiCode: preference },
+        preferences: {
+          chatGpt: 'off',
+          grok: 'off',
+          kimiCode: preference,
+          glmCode: 'off',
+        },
         chatGptSignedIn: false,
         grokSignedIn: false,
         kimiCodeKeySet: keySet,
+        glmKeySet: false,
+      });
+
+      await expect(accountStatusLines('personal')).resolves.toEqual(expected);
+    },
+  );
+
+  it.each([
+    {
+      name: 'off without a key',
+      preference: 'off',
+      keySet: false,
+      expected: ['Otherwise: Your own API keys'],
+    },
+    {
+      name: 'off with a key',
+      preference: 'off',
+      keySet: true,
+      expected: [
+        'GLM Coding Plan: not preferred · key configured',
+        'Otherwise: Your own API keys',
+      ],
+    },
+    {
+      name: 'on without a key',
+      preference: 'on',
+      keySet: false,
+      expected: [
+        'GLM Coding Plan: preferred · key required',
+        'Otherwise: Your own API keys',
+      ],
+    },
+    {
+      name: 'on with a key',
+      preference: 'on',
+      keySet: true,
+      expected: [
+        'GLM Coding Plan: preferred · key configured',
+        'Otherwise: Your own API keys',
+      ],
+    },
+  ] as const)(
+    'renders the GLM Coding Plan route when available: $name',
+    async ({ expected, keySet, preference }) => {
+      mocks.readCliModelAccessStatus.mockResolvedValue({
+        apiFallback: 'personal',
+        preferences: {
+          chatGpt: 'off',
+          grok: 'off',
+          kimiCode: 'off',
+          glmCode: preference,
+        },
+        chatGptSignedIn: false,
+        grokSignedIn: false,
+        kimiCodeKeySet: false,
+        glmKeySet: keySet,
       });
 
       await expect(accountStatusLines('personal')).resolves.toEqual(expected);
@@ -442,11 +527,17 @@ describe('loadCliApiStatusLines', () => {
   it('reports the legacy model-access overview without reading key storage', async () => {
     mocks.readCliModelAccessStatus.mockResolvedValue({
       apiFallback: 'personal',
-      preferences: { chatGpt: 'on', grok: 'off', kimiCode: 'off' },
+      preferences: {
+        chatGpt: 'on',
+        grok: 'off',
+        kimiCode: 'off',
+        glmCode: 'off',
+      },
       chatGptSignedIn: true,
       grokSignedIn: false,
       chatGptAccountLabel: 'chatgpt@example.com',
       kimiCodeKeySet: false,
+      glmKeySet: false,
     });
     mocks.getCliAuthProfile.mockResolvedValue({
       authenticated: true,
@@ -459,17 +550,24 @@ describe('loadCliApiStatusLines', () => {
     ).resolves.toEqual({
       access: {
         apiFallback: 'personal',
-        preferences: { chatGpt: 'on', grok: 'off', kimiCode: 'off' },
+        preferences: {
+          chatGpt: 'on',
+          grok: 'off',
+          kimiCode: 'off',
+          glmCode: 'off',
+        },
         chatGptSignedIn: true,
         grokSignedIn: false,
         chatGptAccountLabel: 'chatgpt@example.com',
         kimiCodeKeySet: false,
+        glmKeySet: false,
         texraSignedIn: true,
       },
       lines: [
         'ChatGPT preference: On · chatgpt@example.com',
         'Grok preference: Off · sign in required to enable',
         'Kimi Code preference: Off · key required to enable',
+        'GLM Coding Plan preference: Off · key required to enable',
         'Otherwise: Your own API keys',
         'Researcher Access: signed in as texra@example.com',
       ],

--- a/src/test-kernel/cli/ModelAccess.vitest.ts
+++ b/src/test-kernel/cli/ModelAccess.vitest.ts
@@ -20,8 +20,14 @@ import { computeModelOptionsData } from '@model/computeModelOptions';
 import type { ModelOptionData } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas/agent';
 
+const getGLMCodingPlanMock = vi.hoisted(() => vi.fn());
+
 vi.mock('@model/computeModelOptions', () => ({
   computeModelOptionsData: vi.fn(),
+}));
+
+vi.mock('@utils/config/providerConfig', () => ({
+  getGLMCodingPlan: getGLMCodingPlanMock,
 }));
 
 vi.mock('llm-zoo', async (importOriginal) => {
@@ -402,9 +408,53 @@ describe('CLI model access resolution', () => {
       apiMode: 'included' as const,
       expected: 'grok subscription',
     },
-  ])('formats model picker status: $name', ({ entry, apiMode, expected }) => {
-    expect(formatModelStatusForCliMode(entry, apiMode)).toBe(expected);
-  });
+    {
+      name: 'labels a GLM provider-key row as GLM Coding Plan when the toggle is on',
+      entry: model('glm52', {
+        model: modelOption('glm52', {
+          availability: 'provider-key',
+          provider: 'glm',
+        }),
+        status: 'api key set',
+      }),
+      apiMode: 'personal' as const,
+      codingPlan: true,
+      expected: 'api: GLM Coding Plan',
+    },
+    {
+      name: 'keeps the plain api status for GLM provider-key rows when the toggle is off',
+      entry: model('glm52', {
+        model: modelOption('glm52', {
+          availability: 'provider-key',
+          provider: 'glm',
+        }),
+        status: 'api key set',
+      }),
+      apiMode: 'personal' as const,
+      codingPlan: false,
+      expected: 'api: api key set',
+    },
+    {
+      name: 'never claims GLM Coding Plan for an OpenRouter-routed GLM row',
+      entry: model('glm52', {
+        model: modelOption('glm52', {
+          availability: 'openrouter-key',
+          provider: 'glm',
+        }),
+        status: 'openrouter key',
+      }),
+      apiMode: 'personal' as const,
+      codingPlan: true,
+      expected: 'api: openrouter key',
+    },
+  ])(
+    'formats model picker status: $name',
+    ({ entry, apiMode, expected, codingPlan }) => {
+      if (codingPlan !== undefined)
+        getGLMCodingPlanMock.mockReturnValue(codingPlan);
+      expect(formatModelStatusForCliMode(entry, apiMode)).toBe(expected);
+    },
+  );
 
   it('builds model picker rows from the access-list source of truth', () => {
     const rows = modelSelectItemsForCliMode(

--- a/src/test-kernel/cli/ModelAccessForm.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessForm.vitest.ts
@@ -40,12 +40,12 @@ describe('ModelAccessForm status', () => {
       await waitFor(() => stdout.output.includes('Loading current preference'));
       expect(stdout.output).not.toContain('Off ·');
 
-      // Preference rows are disabled until status loads; 1–3 are subscriptions.
+      // Preference rows are disabled until status loads; 1–4 are subscriptions.
       stdin.write('1');
       await Promise.resolve();
       expect(onSelect).not.toHaveBeenCalled();
 
-      stdin.write('4');
+      stdin.write('5');
       await waitFor(() => onSelect.mock.calls.length === 1);
       expect(onSelect).toHaveBeenCalledWith(
         cliApiFallbackSelection('included'),
@@ -67,13 +67,13 @@ describe('ModelAccessForm status', () => {
       await waitFor(() => stdout.output.includes('model access unavailable'));
       expect(stdout.output).toContain('Current preference unavailable');
       expect(stdout.output).not.toContain('Off ·');
-      expect(stdout.output).toContain('✓ 4. Included access');
+      expect(stdout.output).toContain('✓ 5. Included access');
 
       stdin.write('2');
       await Promise.resolve();
       expect(onSelect).not.toHaveBeenCalled();
 
-      stdin.write('5');
+      stdin.write('6');
       await waitFor(() => onSelect.mock.calls.length === 1);
       expect(onSelect).toHaveBeenCalledWith(
         cliApiFallbackSelection('personal'),
@@ -87,7 +87,12 @@ describe('ModelAccessForm status', () => {
     loadCliModelAccessOverview.mockResolvedValue({
       access: {
         apiFallback: 'personal',
-        preferences: { chatGpt: 'on', grok: 'off', kimiCode: 'on' },
+        preferences: {
+          chatGpt: 'on',
+          grok: 'off',
+          kimiCode: 'on',
+          glmCode: 'off',
+        },
         chatGptSignedIn: true,
         grokSignedIn: false,
         chatGptAccountLabel: 'user@example.com',

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.ts
@@ -34,6 +34,8 @@ const mocks = vi.hoisted(() => ({
   lookupApiKeyOrigin: vi.fn(),
   getPreferKimiCode: vi.fn(),
   setPreferKimiCode: vi.fn(),
+  getGLMCodingPlan: vi.fn(),
+  setGLMCodingPlan: vi.fn(),
 }));
 
 vi.mock('@platform/platform', () => ({
@@ -117,6 +119,8 @@ vi.mock('@model/apiProviders', () => ({
 vi.mock('@utils/config/providerConfig', () => ({
   getPreferKimiCode: mocks.getPreferKimiCode,
   setPreferKimiCode: mocks.setPreferKimiCode,
+  getGLMCodingPlan: mocks.getGLMCodingPlan,
+  setGLMCodingPlan: mocks.setGLMCodingPlan,
 }));
 
 vi.mock('@model/computeModelOptions', () => ({
@@ -149,7 +153,7 @@ const context = createTestCliContext({ apiMode: 'personal' });
 type AccessRoute = Parameters<typeof formatCliModelAccessRoute>[0];
 
 function subscriptionPreference(
-  provider: 'chatgpt' | 'grok' | 'kimi-code',
+  provider: 'chatgpt' | 'grok' | 'kimi-code' | 'glm-code',
   state: 'on' | 'off',
 ) {
   return { kind: 'subscription-preference', provider, state } as const;
@@ -157,12 +161,18 @@ function subscriptionPreference(
 
 function expectedAccessStatus(overrides: Record<string, unknown>) {
   return {
-    preferences: { chatGpt: 'off', grok: 'off', kimiCode: 'off' },
+    preferences: {
+      chatGpt: 'off',
+      grok: 'off',
+      kimiCode: 'off',
+      glmCode: 'off',
+    },
     chatGptSignedIn: false,
     chatGptAccountLabel: undefined,
     grokSignedIn: false,
     grokAccountLabel: undefined,
     kimiCodeKeySet: false,
+    glmKeySet: false,
     personalKeyProviders: [],
     ...overrides,
   };
@@ -192,6 +202,8 @@ beforeEach(() => {
   mocks.lookupApiKeyOrigin.mockResolvedValue('none');
   mocks.getPreferKimiCode.mockReturnValue(false);
   mocks.setPreferKimiCode.mockResolvedValue(undefined);
+  mocks.getGLMCodingPlan.mockReturnValue(false);
+  mocks.setGLMCodingPlan.mockResolvedValue(undefined);
 });
 
 describe('CLI model access routes', () => {
@@ -203,6 +215,11 @@ describe('CLI model access routes', () => {
     ['kimi', subscriptionPreference('kimi-code', 'on')],
     ['kimicode', subscriptionPreference('kimi-code', 'on')],
     ['kimi-code', subscriptionPreference('kimi-code', 'on')],
+    ['glm', subscriptionPreference('glm-code', 'on')],
+    ['glmcode', subscriptionPreference('glm-code', 'on')],
+    ['glm-code', subscriptionPreference('glm-code', 'on')],
+    ['glm-coding', subscriptionPreference('glm-code', 'on')],
+    ['glm-coding-plan', subscriptionPreference('glm-code', 'on')],
     ['included', cliApiFallbackSelection('included')],
     ['relay', cliApiFallbackSelection('included')],
     ['personal', cliApiFallbackSelection('personal')],
@@ -340,7 +357,12 @@ describe('CLI model access routes', () => {
     await expect(readCliModelAccessStatus('included')).resolves.toEqual(
       expectedAccessStatus({
         apiFallback: 'included',
-        preferences: { chatGpt: 'on', grok: 'off', kimiCode: 'off' },
+        preferences: {
+          chatGpt: 'on',
+          grok: 'off',
+          kimiCode: 'off',
+          glmCode: 'off',
+        },
         chatGptSignedIn: true,
         chatGptAccountLabel: 'user@example.com',
       }),
@@ -350,19 +372,31 @@ describe('CLI model access routes', () => {
     await expect(readCliModelAccessStatus('included')).resolves.toEqual(
       expectedAccessStatus({
         apiFallback: 'included',
-        preferences: { chatGpt: 'on', grok: 'off', kimiCode: 'off' },
+        preferences: {
+          chatGpt: 'on',
+          grok: 'off',
+          kimiCode: 'off',
+          glmCode: 'off',
+        },
       }),
     );
   });
 
   it('reports the Kimi preference independently of key and fallback', async () => {
-    mocks.apiKeyExists.mockResolvedValue(true);
+    mocks.apiKeyExists.mockImplementation(
+      async (_secrets, provider) => provider === 'kimiCode',
+    );
     mocks.getPreferKimiCode.mockReturnValue(true);
 
     await expect(readCliModelAccessStatus('personal')).resolves.toEqual(
       expectedAccessStatus({
         apiFallback: 'personal',
-        preferences: { chatGpt: 'off', grok: 'off', kimiCode: 'on' },
+        preferences: {
+          chatGpt: 'off',
+          grok: 'off',
+          kimiCode: 'on',
+          glmCode: 'off',
+        },
         kimiCodeKeySet: true,
       }),
     );
@@ -450,6 +484,92 @@ describe('CLI model access routes', () => {
     expect(result.apiMode).toBe('personal');
     expect(result.message).toContain('No Kimi Code API key configured');
     expect(result.message).toContain('https://www.kimi.com/code/console');
+  });
+
+  it('reports the GLM Coding Plan preference independently of key and fallback', async () => {
+    mocks.apiKeyExists.mockImplementation(
+      async (_secrets, provider) => provider === 'glm',
+    );
+    mocks.getGLMCodingPlan.mockReturnValue(true);
+
+    await expect(readCliModelAccessStatus('personal')).resolves.toEqual(
+      expectedAccessStatus({
+        apiFallback: 'personal',
+        preferences: {
+          chatGpt: 'off',
+          grok: 'off',
+          kimiCode: 'off',
+          glmCode: 'on',
+        },
+        glmKeySet: true,
+      }),
+    );
+
+    await expect(readCliModelAccessStatus('included')).resolves.toMatchObject({
+      apiFallback: 'included',
+      preferences: {
+        chatGpt: 'off',
+        grok: 'off',
+        kimiCode: 'off',
+        glmCode: 'on',
+      },
+      glmKeySet: true,
+    });
+  });
+
+  it('enables GLM Coding Plan routing on a personal fallback when a key exists', async () => {
+    mocks.apiKeyExists.mockResolvedValue(true);
+
+    const result = await updateCliModelAccess(
+      context,
+      subscriptionPreference('glm-code', 'on'),
+      { writeProgress: vi.fn() },
+    );
+
+    expect(mocks.setGLMCodingPlan).toHaveBeenCalledWith(true);
+    expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
+    expect(mocks.setPreferXaiSubscription).not.toHaveBeenCalled();
+    expect(mocks.updateGlobalState).not.toHaveBeenCalled();
+    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      apiMode: 'personal',
+      message:
+        'Prefer GLM Coding Plan enabled for GLM models · other models still use your own API keys.',
+    });
+  });
+
+  it('guides to key entry when GLM Coding Plan is selected without a key', async () => {
+    const result = await updateCliModelAccess(
+      context,
+      subscriptionPreference('glm-code', 'on'),
+      { writeProgress: vi.fn() },
+    );
+
+    expect(mocks.setGLMCodingPlan).not.toHaveBeenCalled();
+    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+    expect(result.apiMode).toBe('personal');
+    expect(result.message).toContain('No GLM API key configured');
+    expect(result.message).toContain('https://open.bigmodel.cn');
+  });
+
+  it('turns off GLM Coding Plan without requiring a key', async () => {
+    const result = await updateCliModelAccess(
+      context,
+      subscriptionPreference('glm-code', 'off'),
+      { writeProgress: vi.fn() },
+    );
+
+    expect(mocks.apiKeyExists).not.toHaveBeenCalled();
+    expect(mocks.setGLMCodingPlan).toHaveBeenCalledWith(false);
+    expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
+    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      apiMode: 'personal',
+      message: 'Prefer GLM Coding Plan disabled for GLM models.',
+    });
   });
 
   it('switches API-based routes through one policy boundary', async () => {
@@ -571,6 +691,7 @@ describe('CLI model access routes', () => {
       chatGpt: 'on',
       grok: 'off',
       kimiCode: 'on',
+      glmCode: 'off',
     });
     const descriptions = Object.fromEntries(
       buildCliModelAccessItems({ kind: 'loaded', access: status })
@@ -586,6 +707,7 @@ describe('CLI model access routes', () => {
       chatgpt: 'On · user@example.com',
       grok: 'Off · sign in required to enable',
       'kimi-code': 'On · key configured',
+      'glm-code': 'Off · key configured',
     });
 
     await updateCliModelAccess(

--- a/src/test-kernel/cli/Orchestration.vitest.ts
+++ b/src/test-kernel/cli/Orchestration.vitest.ts
@@ -366,7 +366,12 @@ describe('CLI orchestration items', () => {
   it('keeps model access directly below new chat and presents every access route', () => {
     const status = {
       apiFallback: 'included' as const,
-      preferences: { chatGpt: 'off', grok: 'off', kimiCode: 'off' } as const,
+      preferences: {
+        chatGpt: 'off',
+        grok: 'off',
+        kimiCode: 'off',
+        glmCode: 'off',
+      } as const,
       chatGptSignedIn: true,
       grokSignedIn: false,
       chatGptAccountLabel: 'researcher@example.com',
@@ -376,7 +381,7 @@ describe('CLI orchestration items', () => {
     expect(items[1]).toEqual({
       label: 'Model access',
       description:
-        'ChatGPT Off · Grok Off · Kimi Off · otherwise: included access',
+        'ChatGPT Off · Grok Off · Kimi Off · GLM Off · otherwise: included access',
       value: { kind: 'configure-model-access' },
     });
     expect(
@@ -410,6 +415,15 @@ describe('CLI orchestration items', () => {
         description: 'Off · key required to enable',
       },
       {
+        value: {
+          kind: 'subscription-preference',
+          provider: 'glm-code',
+          state: 'on',
+        },
+        label: 'Prefer GLM Coding Plan',
+        description: 'Off · key required to enable',
+      },
+      {
         value: { kind: 'api-fallback', apiMode: 'included' },
         label: 'Included access',
         description: 'Covered by your TeXRA plan',
@@ -425,7 +439,12 @@ describe('CLI orchestration items', () => {
   it('describes the Kimi Code route by key state and activity', () => {
     const kimiOff = kimiCodePreferenceItem({
       apiFallback: 'personal',
-      preferences: { chatGpt: 'off', grok: 'off', kimiCode: 'off' },
+      preferences: {
+        chatGpt: 'off',
+        grok: 'off',
+        kimiCode: 'off',
+        glmCode: 'off',
+      },
       chatGptSignedIn: false,
       grokSignedIn: false,
       kimiCodeKeySet: true,
@@ -442,7 +461,12 @@ describe('CLI orchestration items', () => {
 
     const kimiOnAccess: CliModelAccessStatus = {
       apiFallback: 'personal',
-      preferences: { chatGpt: 'off', grok: 'off', kimiCode: 'on' },
+      preferences: {
+        chatGpt: 'off',
+        grok: 'off',
+        kimiCode: 'on',
+        glmCode: 'off',
+      },
       chatGptSignedIn: false,
       grokSignedIn: false,
       kimiCodeKeySet: true,
@@ -454,7 +478,7 @@ describe('CLI orchestration items', () => {
     expect(orchestrationItems({ modelAccess: kimiOnAccess })[1]).toEqual({
       label: 'Model access',
       description:
-        'ChatGPT Off · Grok Off · Kimi On · otherwise: your own API keys',
+        'ChatGPT Off · Grok Off · Kimi On · GLM Off · otherwise: your own API keys',
       value: { kind: 'configure-model-access' },
     });
   });
@@ -464,7 +488,12 @@ describe('CLI orchestration items', () => {
       kind: 'loaded',
       access: {
         apiFallback: 'personal',
-        preferences: { chatGpt: 'on', grok: 'off', kimiCode: 'on' },
+        preferences: {
+          chatGpt: 'on',
+          grok: 'off',
+          kimiCode: 'on',
+          glmCode: 'off',
+        },
         chatGptSignedIn: true,
         grokSignedIn: false,
         chatGptAccountLabel: 'researcher@example.com',
@@ -483,6 +512,7 @@ describe('CLI orchestration items', () => {
       chatgpt: 'On · researcher@example.com',
       grok: 'Off · sign in required to enable',
       'kimi-code': 'On · key configured',
+      'glm-code': 'Off · key required to enable',
     });
   });
 
@@ -563,7 +593,12 @@ describe('CLI orchestration items', () => {
         kind: 'loaded',
         access: {
           apiFallback: 'personal',
-          preferences: { chatGpt: 'off', grok: 'off', kimiCode: 'off' },
+          preferences: {
+            chatGpt: 'off',
+            grok: 'off',
+            kimiCode: 'off',
+            glmCode: 'off',
+          },
           chatGptSignedIn: false,
           grokSignedIn: false,
           texraSignedIn: false,

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -69,7 +69,12 @@ function mockModelAccessOverview(): void {
   vi.spyOn(apiStatus, 'loadCliModelAccessOverview').mockResolvedValue({
     access: {
       apiFallback: 'personal',
-      preferences: { chatGpt: 'off', grok: 'off', kimiCode: 'off' },
+      preferences: {
+        chatGpt: 'off',
+        grok: 'off',
+        kimiCode: 'off',
+        glmCode: 'off',
+      },
       chatGptSignedIn: false,
       grokSignedIn: false,
     },


### PR DESCRIPTION
## Summary

Adds GLM-5.2 as a default model and gives it the same CLI access surface as the Kimi K3 pattern.

## Changes

**feat(model): add GLM-5.2 to the default model list** (src/model/modelOptionsBasic.ts)

- glm52 (GLM-5.2, active in llm-zoo, CLI-supported) joins PREFERRED_DEFAULT_MODELS, so it appears in the model picker by default (CLI and VS Code).
- MODEL_LIST_VERSION is hash-derived from the preferred list, so existing users' enabled-model lists reconcile automatically - no manual bump.

**feat(cli): add GLM Coding Plan access preference and picker status**

Kimi-style CLI parity for GLM:
- /api gains a glm-code route and a "Prefer GLM Coding Plan" row in the model-access form (aliases: glm, glmcode, glm-code, glm-coding, glm-coding-plan), wired to the existing GLM_CODING_PLAN toggle - no separate key (the GLM API key is the credential), no OpenRouter interaction (the coding plan is a path on the same direct GLM endpoint, /api/coding/paas/v4).
- Model rows in personal mode show "api: GLM Coding Plan" for direct-key GLM models when the toggle is on (never for OpenRouter-routed rows).
- /api status, the account-status overview, and the compact summary all surface the GLM preference and key state.
- /config toggling of the GLM Coding Plan now refreshes picker views like the OpenRouter/Kimi Code toggles.

## Notes

- GLM-5.2 was already usable via own API key (api: api key set) and included access before this PR - no availability changes were needed.
- The GLM key remains listed under "Other API keys" in detailed status even when the Coding Plan is on, since the same key also works pay-as-you-go.

## Verification

- corepack pnpm --filter @texra-ai/cli typecheck - passed
- npx tsc --noEmit -p tsconfig.test-kernel.json - passed
- Affected vitest suites (8 files, 274 tests) - passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model routing preferences and API-mode UI across several CLI paths, but reuses the existing GLM Coding Plan toggle and mirrors the proven Kimi Code pattern rather than new auth flows.
> 
> **Overview**
> **GLM-5.2** is added to the preferred default model list so it shows up in pickers by default (alongside existing hash-driven list reconciliation).
> 
> The CLI now treats **GLM Coding Plan** like Kimi Code for model access: a fourth subscription preference (`glmCode`), a **Prefer GLM Coding Plan** row in `/api` and orchestration (with aliases such as `glm-code`), and wiring to the existing `GLM_CODING_PLAN` toggle using the GLM API key as the credential. Toggling on/off updates preferences via `setGLMCodingPlan`, refreshes the model-options cache from config, and surfaces GLM preference/key state in status, summaries, and account overview lines.
> 
> In **personal** API mode, direct-key GLM rows can display **api: GLM Coding Plan** when the toggle is on; OpenRouter-routed GLM rows keep their own key status. The `/api` usage string and harness/TUI validation expectations are updated for the extra row and menu indices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dd6dfbb3e1b1e5875b58de0cd1dd5b46ecf9644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->