### PR TITLE
docs(agent): clarify DomainEvent run-fact carve-out

### DIFF
--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -258,8 +258,9 @@ export interface ResponseFinalizedEvent extends StageStamp {
 /**
  * Host-specific escape hatch. Hosts use this for events that aren't part
  * of the agent-general union (TeXRA: `latexdiff`, `scratchpad`,
- * `filesLoaded`, `missingOutputs`, `webSearch`, `webFetch`, …). Keeps the
- * union clean for SDK consumers; host subscribers switch on `key`.
+ * `filesLoaded`, `webSearch`, `webFetch`, …). Durable run facts such as
+ * `updateMissingOutputs` remain explicit `RunFactEvent` arms. Keeps the union
+ * clean for SDK consumers; host subscribers switch on `key`.
  */
 interface DomainEvent extends StageStamp {
   readonly type: 'domain';


### PR DESCRIPTION
Closes #9880

Clarifies that durable run facts such as `updateMissingOutputs` intentionally remain explicit `RunFactEvent` arms rather than using the host-specific `domain` escape hatch.

## Verification
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no runtime or type contract modifications.
> 
> **Overview**
> Updates the **`DomainEvent`** JSDoc in `events.ts` to state that durable run facts (e.g. **`updateMissingOutputs`**) stay as explicit **`RunFactEvent`** union arms instead of the host **`domain`** escape hatch.
> 
> The example list for **`domain`** keys no longer includes **`missingOutputs`**, aligning the comment with **`RUN_FACT_EVENT_TYPES`** / **`updateMissingOutputs`** as a typed run fact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 568b2a1b31da2303db82fb9d6367764ce719e821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->