### PR TITLE
fix(streams): detach children when deleting parents

### DIFF
--- a/config/ratchets/store-public-surface-baseline.json
+++ b/config/ratchets/store-public-surface-baseline.json
@@ -30,6 +30,7 @@
       "attachSessionEvents",
       "deleteAll",
       "deleteStream",
+      "detachChildrenOf",
       "evictAll",
       "flush",
       "getCompileFailures",

--- a/config/ratchets/store-public-surface-baseline.json
+++ b/config/ratchets/store-public-surface-baseline.json
@@ -30,7 +30,6 @@
       "attachSessionEvents",
       "deleteAll",
       "deleteStream",
-      "detachChildrenOf",
       "evictAll",
       "flush",
       "getCompileFailures",

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -11,7 +11,12 @@ import {
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 // Local imports - progress view
-import { deleteStreamState, firstStreamId, isToolUseState } from './store';
+import {
+  deleteStreamState,
+  detachChildStreamTabs,
+  firstStreamId,
+  isToolUseState,
+} from './store';
 import { deleteFollowUpInputTransientState } from './followUpInputState';
 import { addResolvedProposalId, removePrompt } from './slices/permissionSlice';
 import { updateToolUseState } from './stateUtils';
@@ -53,6 +58,7 @@ export function handleStreamDelete(
     create(appState.get(), (draft) => {
       deleteStreamState(draft, streamId);
       draft.streamById.delete(streamId);
+      detachChildStreamTabs(draft, streamId);
       if (draft.activeStreamId === streamId) {
         draft.activeStreamId = firstStreamId(draft.streamById);
       }

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -17,6 +17,7 @@ import {
 
 import {
   deleteStreamState,
+  detachChildStreamTabs,
   ensureStreamState,
   firstStreamId,
   type ProgressState,
@@ -199,6 +200,7 @@ export const streamLifecycleHandlers = {
       create(appState.get(), (draft) => {
         deleteStreamState(draft, streamId);
         draft.streamById.delete(streamId);
+        detachChildStreamTabs(draft, streamId);
         if (draft.activeStreamId === streamId) {
           draft.activeStreamId = null;
         }

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -105,6 +105,17 @@ export function deleteStreamState(
   draft.followupOptionsByStream.delete(streamId);
 }
 
+/** Clear every visible child edge targeting a deleted parent stream. */
+export function detachChildStreamTabs(
+  draft: Draft<ProgressState>,
+  parentStreamId: StreamTabId,
+): void {
+  for (const [childId, child] of draft.streamById) {
+    if (child.parentStreamId !== parentStreamId) continue;
+    draft.streamById.set(childId, { ...child, parentStreamId: undefined });
+  }
+}
+
 /**
  * Create default entries — for whichever of the same key list
  * `deleteStreamState` owns (`streamStates`, `streamLogs`,

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -146,7 +146,6 @@ export class SessionStores {
     const hadCanonicalStream = this.streamLogs.has(stream);
     const result = await this.deleteStreamOnce(stream);
     if (result === 'deleted' && hadCanonicalStream) {
-      await this.detachChildrenAfterCanonicalDeletion(stream);
       await this.notifyDeleted(stream);
     }
     return result;
@@ -197,22 +196,10 @@ export class SessionStores {
     }
   }
 
-  private async detachChildrenAfterCanonicalDeletion(
+  private async notifyChildrenDetached(
     stream: StreamTabId,
+    children: readonly StreamTabId[],
   ): Promise<void> {
-    let children: StreamTabId[] = [];
-    try {
-      children = await this.snapshots.detachChildrenOf(stream);
-    } catch (error) {
-      // The transcript commit is irreversible, so preserve its successful
-      // result instead of reporting the parent as retained. Runtime children
-      // still detach below even when durable discovery failed.
-      logger.warn(
-        CHANNEL,
-        `Stream ${stream} was deleted, but child parent-edge cleanup was incomplete: ${toErrorMessage(error)}`,
-        { data: error },
-      );
-    }
     if (!this.onChildrenDetached) return;
     try {
       await this.onChildrenDetached(stream, children);
@@ -466,11 +453,6 @@ export class SessionStores {
         }
       }),
     );
-    const retainedStreams = new Set<StreamTabId>([...active, ...failed]);
-    for (const stream of canonicalStreams) {
-      if (retainedStreams.has(stream)) continue;
-      await this.detachChildrenAfterCanonicalDeletion(stream);
-    }
     return { active, failed };
   }
 
@@ -685,7 +667,10 @@ export class SessionStores {
   }
 
   private async deleteAdjacentStreamState(stream: StreamTabId): Promise<void> {
-    const snapshotDeletion = await this.snapshots.stageDeleteStream(stream);
+    const snapshotDeletion = await this.snapshots.stageDeleteStream(
+      stream,
+      (children) => this.notifyChildrenDetached(stream, children),
+    );
     try {
       // The transcript registry is the commit point for tab visibility.
       // Snapshot sidecars are only renamed before this, so a failure can roll
@@ -732,7 +717,12 @@ export class SessionStores {
     await Promise.all(
       streams.map(async (stream) => {
         try {
-          staged.set(stream, await this.snapshots.stageDeleteStream(stream));
+          staged.set(
+            stream,
+            await this.snapshots.stageDeleteStream(stream, (children) =>
+              this.notifyChildrenDetached(stream, children),
+            ),
+          );
         } catch (error) {
           failed.add(stream);
           failures.push(error);

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -41,6 +41,11 @@ export interface SessionStoresOptions {
   goalEntries?: GoalEntryStore;
   /** Runs after a canonical transcript stream is committed as deleted. */
   onCanonicalStreamDeleted?: (stream: StreamTabId) => void | Promise<void>;
+  /** Projects parent-edge removals after their durable repair commits. */
+  onChildrenDetached?: (
+    parent: StreamTabId,
+    children: readonly StreamTabId[],
+  ) => void | Promise<void>;
 }
 
 export interface DeleteAllStreamsResult {
@@ -76,6 +81,12 @@ export class SessionStores {
   private readonly goalEntries: GoalEntryStore | undefined;
   private readonly onCanonicalStreamDeleted:
     ((stream: StreamTabId) => void | Promise<void>) | undefined;
+  private readonly onChildrenDetached:
+    | ((
+        parent: StreamTabId,
+        children: readonly StreamTabId[],
+      ) => void | Promise<void>)
+    | undefined;
   private readonly pendingStreamDeletions = new Map<
     StreamTabId,
     Promise<DeleteStreamResult>
@@ -91,6 +102,7 @@ export class SessionStores {
       options.listExecutionStreamReferences ?? listExecutionStreamReferences;
     this.goalEntries = options.goalEntries;
     this.onCanonicalStreamDeleted = options.onCanonicalStreamDeleted;
+    this.onChildrenDetached = options.onChildrenDetached;
   }
 
   async waitForOwnedExecutionRelease(stream: StreamTabId): Promise<void> {
@@ -134,6 +146,7 @@ export class SessionStores {
     const hadCanonicalStream = this.streamLogs.has(stream);
     const result = await this.deleteStreamOnce(stream);
     if (result === 'deleted' && hadCanonicalStream) {
+      await this.detachChildrenAfterCanonicalDeletion(stream);
       await this.notifyDeleted(stream);
     }
     return result;
@@ -179,6 +192,34 @@ export class SessionStores {
       logger.warn(
         CHANNEL,
         `Stream ${stream} was deleted, but canonical session cleanup was incomplete: ${toErrorMessage(error)}`,
+        { data: error },
+      );
+    }
+  }
+
+  private async detachChildrenAfterCanonicalDeletion(
+    stream: StreamTabId,
+  ): Promise<void> {
+    let children: StreamTabId[];
+    try {
+      children = await this.snapshots.detachChildrenOf(stream);
+    } catch (error) {
+      // The transcript commit is irreversible, so preserve its successful
+      // result instead of reporting the parent as retained.
+      logger.warn(
+        CHANNEL,
+        `Stream ${stream} was deleted, but child parent-edge cleanup was incomplete: ${toErrorMessage(error)}`,
+        { data: error },
+      );
+      return;
+    }
+    if (children.length === 0 || !this.onChildrenDetached) return;
+    try {
+      await this.onChildrenDetached(stream, children);
+    } catch (error) {
+      logger.warn(
+        CHANNEL,
+        `Stream ${stream} was deleted, but child-detachment projection was incomplete: ${toErrorMessage(error)}`,
         { data: error },
       );
     }
@@ -425,6 +466,11 @@ export class SessionStores {
         }
       }),
     );
+    const retainedStreams = new Set<StreamTabId>([...active, ...failed]);
+    for (const stream of canonicalStreams) {
+      if (retainedStreams.has(stream)) continue;
+      await this.detachChildrenAfterCanonicalDeletion(stream);
+    }
     return { active, failed };
   }
 

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -200,20 +200,20 @@ export class SessionStores {
   private async detachChildrenAfterCanonicalDeletion(
     stream: StreamTabId,
   ): Promise<void> {
-    let children: StreamTabId[];
+    let children: StreamTabId[] = [];
     try {
       children = await this.snapshots.detachChildrenOf(stream);
     } catch (error) {
       // The transcript commit is irreversible, so preserve its successful
-      // result instead of reporting the parent as retained.
+      // result instead of reporting the parent as retained. Runtime children
+      // still detach below even when durable discovery failed.
       logger.warn(
         CHANNEL,
         `Stream ${stream} was deleted, but child parent-edge cleanup was incomplete: ${toErrorMessage(error)}`,
         { data: error },
       );
-      return;
     }
-    if (children.length === 0 || !this.onChildrenDetached) return;
+    if (!this.onChildrenDetached) return;
     try {
       await this.onChildrenDetached(stream, children);
     } catch (error) {

--- a/src/controllers/session/sessionStores.ts
+++ b/src/controllers/session/sessionStores.ts
@@ -27,5 +27,23 @@ export function createSessionStores(session: SessionHandle): SessionStores {
       session.status.clearStream(stream);
       releaseStreamResources(stream, session);
     },
+    onChildrenDetached: (parent, children) => {
+      const activeChildren = new Set(
+        session.executions
+          .getActiveChildren(parent)
+          .map(({ childStreamId }) => childStreamId),
+      );
+      session.executions.detachActiveChildren(parent);
+      for (const child of children) {
+        if (activeChildren.has(child)) continue;
+        session.events.emit({
+          scope: 'session',
+          event: {
+            type: 'setParentStream',
+            payload: { childStreamId: child, parentStreamId: null },
+          },
+        });
+      }
+    },
   });
 }

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -84,12 +84,12 @@ describe('SessionStores deletion coordination', () => {
     }
   });
 
-  it('keeps a committed deletion successful when durable child repair fails', async () => {
+  it('projects child detachment when durable discovery fails', async () => {
     const session = createTestSession();
-    const parent = 'repair-failure-parent' as StreamTabId;
+    const parent = 'discovery-failure-parent' as StreamTabId;
     session.transcripts.ensureStream(parent);
     const snapshots = new StreamSnapshotStore();
-    vi.spyOn(snapshots, 'detachChildrenOf').mockRejectedValueOnce(
+    vi.spyOn(snapshots, 'listPersistedStreams').mockRejectedValueOnce(
       new Error('sidecar unavailable'),
     );
     const onChildrenDetached = vi.fn();
@@ -101,7 +101,6 @@ describe('SessionStores deletion coordination', () => {
 
     try {
       await expect(stores.deleteStream(parent)).resolves.toBe('deleted');
-      expect(session.transcripts.has(parent)).toBe(false);
       expect(onChildrenDetached).toHaveBeenCalledWith(parent, []);
     } finally {
       session.dispose();
@@ -484,7 +483,10 @@ describe('SessionStores orphan sweep', () => {
     const result = await stores.sweepOrphanedStreams(new Set());
 
     expect(result.streams).toEqual([orphan]);
-    expect(stageDeleteStream).toHaveBeenCalledWith(orphan);
+    expect(stageDeleteStream).toHaveBeenCalledWith(
+      orphan,
+      expect.any(Function),
+    );
   });
 
   it('removes an execution whose stream lost its sidecar FK before deletion', async () => {

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -45,6 +45,80 @@ function deletionSpy() {
 }
 
 describe('SessionStores deletion coordination', () => {
+  it('detaches durable child parent edges only after deleting the parent', async () => {
+    const session = createTestSession();
+    const parent = 'deleted-parent' as StreamTabId;
+    const child = 'retained-child' as StreamTabId;
+    session.transcripts.ensureStream(parent);
+    session.transcripts.ensureStream(child);
+    const snapshots = new StreamSnapshotStore();
+    snapshotFacts(snapshots).setParentStream(child, parent);
+    await snapshots.flush();
+    const detached: Array<[StreamTabId, readonly StreamTabId[]]> = [];
+    const stores = new SessionStores({
+      streamLogs: session.transcripts,
+      snapshots,
+      onChildrenDetached: (deletedParent, children) => {
+        detached.push([deletedParent, children]);
+      },
+    });
+
+    try {
+      await expect(stores.deleteStream(parent)).resolves.toBe('deleted');
+      expect(snapshots.getParentStreamId(child)).toBeUndefined();
+      expect(detached).toEqual([[parent, [child]]]);
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('keeps a committed deletion successful when durable child repair fails', async () => {
+    const session = createTestSession();
+    const parent = 'repair-failure-parent' as StreamTabId;
+    session.transcripts.ensureStream(parent);
+    const snapshots = new StreamSnapshotStore();
+    vi.spyOn(snapshots, 'detachChildrenOf').mockRejectedValueOnce(
+      new Error('sidecar unavailable'),
+    );
+    const stores = new SessionStores({
+      streamLogs: session.transcripts,
+      snapshots,
+    });
+
+    try {
+      await expect(stores.deleteStream(parent)).resolves.toBe('deleted');
+      expect(session.transcripts.has(parent)).toBe(false);
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('keeps a committed deletion successful when child projection fails', async () => {
+    const session = createTestSession();
+    const parent = 'projection-failure-parent' as StreamTabId;
+    const child = 'projection-failure-child' as StreamTabId;
+    session.transcripts.ensureStream(parent);
+    session.transcripts.ensureStream(child);
+    const snapshots = new StreamSnapshotStore();
+    snapshotFacts(snapshots).setParentStream(child, parent);
+    await snapshots.flush();
+    const stores = new SessionStores({
+      streamLogs: session.transcripts,
+      snapshots,
+      onChildrenDetached: () => {
+        throw new Error('renderer unavailable');
+      },
+    });
+
+    try {
+      await expect(stores.deleteStream(parent)).resolves.toBe('deleted');
+      expect(session.transcripts.has(parent)).toBe(false);
+      expect(snapshots.getParentStreamId(child)).toBeUndefined();
+    } finally {
+      session.dispose();
+    }
+  });
+
   it('tracks lease-gated deletion without blocking its artifact flush', async () => {
     const session = createTestSession();
     const stream = 'lease-gated-delete' as StreamTabId;

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -49,15 +49,26 @@ describe('SessionStores deletion coordination', () => {
     const session = createTestSession();
     const parent = 'deleted-parent' as StreamTabId;
     const child = 'retained-child' as StreamTabId;
+    const childExecution = 'c9862001' as ExecutionId;
     session.transcripts.ensureStream(parent);
     session.transcripts.ensureStream(child);
     const snapshots = new StreamSnapshotStore();
+    snapshotFacts(snapshots).setRunConfig(
+      child,
+      AgentConfigSchema.parse({
+        agent: 'chat',
+        model: 'deepseekT',
+        agentCategory: 'toolUse',
+      }),
+      childExecution,
+    );
     snapshotFacts(snapshots).setParentStream(child, parent);
     await snapshots.flush();
+    const reloadedSnapshots = new StreamSnapshotStore();
     const detached: Array<[StreamTabId, readonly StreamTabId[]]> = [];
     const stores = new SessionStores({
       streamLogs: session.transcripts,
-      snapshots,
+      snapshots: reloadedSnapshots,
       onChildrenDetached: (deletedParent, children) => {
         detached.push([deletedParent, children]);
       },
@@ -65,7 +76,8 @@ describe('SessionStores deletion coordination', () => {
 
     try {
       await expect(stores.deleteStream(parent)).resolves.toBe('deleted');
-      expect(snapshots.getParentStreamId(child)).toBeUndefined();
+      expect(reloadedSnapshots.getParentStreamId(child)).toBeUndefined();
+      expect(reloadedSnapshots.getExecutionId(child)).toBe(childExecution);
       expect(detached).toEqual([[parent, [child]]]);
     } finally {
       session.dispose();
@@ -80,14 +92,17 @@ describe('SessionStores deletion coordination', () => {
     vi.spyOn(snapshots, 'detachChildrenOf').mockRejectedValueOnce(
       new Error('sidecar unavailable'),
     );
+    const onChildrenDetached = vi.fn();
     const stores = new SessionStores({
       streamLogs: session.transcripts,
       snapshots,
+      onChildrenDetached,
     });
 
     try {
       await expect(stores.deleteStream(parent)).resolves.toBe('deleted');
       expect(session.transcripts.has(parent)).toBe(false);
+      expect(onChildrenDetached).toHaveBeenCalledWith(parent, []);
     } finally {
       session.dispose();
     }

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -65,12 +65,16 @@ describe('SessionStores deletion coordination', () => {
     snapshotFacts(snapshots).setParentStream(child, parent);
     await snapshots.flush();
     const reloadedSnapshots = new StreamSnapshotStore();
+    const projectionFacts = snapshotFacts(reloadedSnapshots);
     const detached: Array<[StreamTabId, readonly StreamTabId[]]> = [];
     const stores = new SessionStores({
       streamLogs: session.transcripts,
       snapshots: reloadedSnapshots,
       onChildrenDetached: (deletedParent, children) => {
         detached.push([deletedParent, children]);
+        for (const detachedChild of children) {
+          projectionFacts.setParentStream(detachedChild, null);
+        }
       },
     });
 
@@ -127,7 +131,7 @@ describe('SessionStores deletion coordination', () => {
     try {
       await expect(stores.deleteStream(parent)).resolves.toBe('deleted');
       expect(session.transcripts.has(parent)).toBe(false);
-      expect(snapshots.getParentStreamId(child)).toBeUndefined();
+      expect(snapshots.getParentStreamId(child)).toBe(parent);
     } finally {
       session.dispose();
     }

--- a/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
@@ -234,6 +234,26 @@ describe('progressView dispatchMessage (createDispatcher migration)', () => {
     expect(webviewStorage.get(logListStateKey(streamId))).toBeUndefined();
   });
 
+  it('DELETE_STREAM clears retained child parent references', () => {
+    const parent = 'stream-parent' as StreamTabId;
+    const child = 'stream-child' as StreamTabId;
+    seedStreamWithLogListToggle(parent);
+    seedStreamWithLogListToggle(child);
+    appState.get().streamById.set(child, {
+      ...appState.get().streamById.get(child)!,
+      parentStreamId: parent,
+    });
+
+    dispatchMessage(
+      { command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM, stream: parent },
+      vi.fn(),
+    );
+
+    expect(
+      appState.get().streamById.get(child)?.parentStreamId,
+    ).toBeUndefined();
+  });
+
   it('routes a malformed message to onError instead of throwing inside a handler body', () => {
     const before = appState.get();
     const onError = vi.fn();

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -959,8 +959,34 @@ export class StreamSnapshotStore {
    */
   async stageDeleteStream(
     stream: StreamTabId,
+    onCommitted?: (children: readonly StreamTabId[]) => void | Promise<void>,
   ): Promise<StagedStreamSnapshotDeletion> {
-    return this.deletions.stage(stream);
+    const deletion = await this.deletions.stage(stream);
+    return {
+      commit: async () => {
+        await deletion.commit();
+        let children: StreamTabId[] = [];
+        try {
+          children = await this.detachPersistedChildren(stream);
+        } catch (error) {
+          logger.warn(
+            CHANNEL,
+            `Stream ${stream} was deleted, but child parent-edge cleanup was incomplete.`,
+            { data: error },
+          );
+        }
+        try {
+          await onCommitted?.(children);
+        } catch (error) {
+          logger.warn(
+            CHANNEL,
+            `Stream ${stream} was deleted, but child-detachment projection was incomplete.`,
+            { data: error },
+          );
+        }
+      },
+      rollback: () => deletion.rollback(),
+    };
   }
 
   /** Delete a stream's sidecars and in-memory state as one committed action. */
@@ -1175,24 +1201,22 @@ export class StreamSnapshotStore {
     return this.records.get(stream)?.meta?.parentStreamId;
   }
 
-  /**
-   * Clear durable parent edges that point at a stream whose transcript has
-   * already been removed. Ordinary parent changes still enter through the
-   * `setParentStream` session fact; this is the deletion lifecycle repair.
-   */
-  async detachChildrenOf(parent: StreamTabId): Promise<StreamTabId[]> {
+  /** Remove parent edges from fresh sidecar metadata after a parent commits. */
+  private async detachPersistedChildren(
+    parent: StreamTabId,
+  ): Promise<StreamTabId[]> {
     await this.flush();
-    const streams = await this.listPersistedStreams();
     const children: StreamTabId[] = [];
-    for (const stream of streams) {
+    for (const stream of await this.listPersistedStreams()) {
       if (stream === parent) continue;
       const meta = await readMeta(this.kv(stream));
       if (meta?.parentStreamId !== parent) continue;
-      // A lifecycle scan can encounter a persisted child that this process has
-      // never seeded. Preserve its execution FK before applying the patch.
       const record = this.getOrCreateRecord(stream);
-      record.meta ??= meta;
-      this.queueMetaPatch(stream, { parentStreamId: undefined });
+      const next = { ...meta, parentStreamId: undefined };
+      record.meta = next;
+      record.runExecutionId = meta.executionId;
+      record.metaOverlay = true;
+      this.writeMeta(stream, next);
       children.push(stream);
     }
     await this.flush();

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1176,6 +1176,26 @@ export class StreamSnapshotStore {
   }
 
   /**
+   * Clear durable parent edges that point at a stream whose transcript has
+   * already been removed. Ordinary parent changes still enter through the
+   * `setParentStream` session fact; this is the deletion lifecycle repair.
+   */
+  async detachChildrenOf(parent: StreamTabId): Promise<StreamTabId[]> {
+    await this.flush();
+    const streams = await this.listPersistedStreams();
+    const children: StreamTabId[] = [];
+    for (const stream of streams) {
+      if (stream === parent) continue;
+      const meta = await readMeta(this.kv(stream));
+      if (meta?.parentStreamId !== parent) continue;
+      this.queueMetaPatch(stream, { parentStreamId: undefined });
+      children.push(stream);
+    }
+    await this.flush();
+    return children;
+  }
+
+  /**
    * The stream's display description, projected from the one authority,
    * `ExecutionMeta.description` (#9590 A4) — live event or load-time
    * hydration. The legacy sidecar mirror is retired.

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1223,7 +1223,7 @@ export class StreamSnapshotStore {
       }
     }
     await this.preload(children);
-    return children;
+    return children.filter((child) => this.getParentStreamId(child) === parent);
   }
 
   /**

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -984,6 +984,15 @@ export class StreamSnapshotStore {
             { data: error },
           );
         }
+        try {
+          await this.flush();
+        } catch (error) {
+          logger.warn(
+            CHANNEL,
+            `Stream ${stream} was deleted, but child parent-edge persistence was incomplete.`,
+            { data: error },
+          );
+        }
       },
       rollback: () => deletion.rollback(),
     };
@@ -1201,7 +1210,7 @@ export class StreamSnapshotStore {
     return this.records.get(stream)?.meta?.parentStreamId;
   }
 
-  /** Remove parent edges from fresh sidecar metadata after a parent commits. */
+  /** Find and seed children before their canonical parent-detach facts emit. */
   private async detachPersistedChildren(
     parent: StreamTabId,
   ): Promise<StreamTabId[]> {
@@ -1209,17 +1218,11 @@ export class StreamSnapshotStore {
     const children: StreamTabId[] = [];
     for (const stream of await this.listPersistedStreams()) {
       if (stream === parent) continue;
-      const meta = await readMeta(this.kv(stream));
-      if (meta?.parentStreamId !== parent) continue;
-      const record = this.getOrCreateRecord(stream);
-      const next = { ...meta, parentStreamId: undefined };
-      record.meta = next;
-      record.runExecutionId = meta.executionId;
-      record.metaOverlay = true;
-      this.writeMeta(stream, next);
-      children.push(stream);
+      if ((await readMeta(this.kv(stream)))?.parentStreamId === parent) {
+        children.push(stream);
+      }
     }
-    await this.flush();
+    await this.preload(children);
     return children;
   }
 

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1188,6 +1188,10 @@ export class StreamSnapshotStore {
       if (stream === parent) continue;
       const meta = await readMeta(this.kv(stream));
       if (meta?.parentStreamId !== parent) continue;
+      // A lifecycle scan can encounter a persisted child that this process has
+      // never seeded. Preserve its execution FK before applying the patch.
+      const record = this.getOrCreateRecord(stream);
+      record.meta ??= meta;
       this.queueMetaPatch(stream, { parentStreamId: undefined });
       children.push(stream);
     }


### PR DESCRIPTION
Closes #9862

- repair persisted child parent edges after a parent transcript deletion commits
- reuse the existing execution-registry detachment for active children and canonical session facts for inactive children
- apply the same lifecycle to individual and bulk deletion
- keep optimistic and confirmed frontend topology consistent through one shared reducer helper
- preserve committed-delete semantics if post-commit repair/projection fails

## Deliberate scope
This fixes the ordinary authoritative deletion lifecycle without adding a persistent cross-host parent-deletion fence. A contrived late parent fact from another host after the repair scan remains possible; preventing it would require a new coordination/tombstone subsystem disproportionate to this currently harmless structural bug. Repair failures are logged rather than misreporting an already committed parent deletion.

## Verification
- `pnpm exec vitest run src/test-kernel/agent/storage/SessionStores.vitest.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts` (126 tests)
- `pnpm run typecheck:workspace`
- ESLint, Prettier, dead-code ratchet, and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stream deletion commit ordering and parent/child topology across transcripts, snapshots, and the progress view; failures are isolated with warn-only callbacks, but incorrect ordering could still leave inconsistent parent edges until a later repair.
> 
> **Overview**
> When a **parent stream tab is deleted**, child streams no longer keep a stale `parentStreamId` in the UI or in persisted snapshot meta.
> 
> **Backend:** After a parent transcript deletion commits, `StreamSnapshotStore` scans persisted sidecars for children pointing at that parent, clears those parent edges in memory, and flushes. `SessionStores` passes an `onChildrenDetached` callback through staged deletion so projection runs after the repair commit. The session controller detaches **active** children via the execution registry and emits **`setParentStream` with `null`** for inactive children so canonical session facts match durable storage. Post-commit repair or projection failures are **logged**; the parent delete still counts as committed.
> 
> **Frontend:** Optimistic and confirmed delete paths both call shared **`detachChildStreamTabs`** so retained child tabs drop their parent reference immediately and stay consistent when the backend confirms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3bcbd08ba853f9f95e8e34bbefa1ef47fac5479. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->