### PR TITLE
refactor(runtime): centralize failure-aggregation rethrow in throwAggregated

### DIFF
--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -50,6 +50,7 @@ import {
 import type { RunTraceFlushEntry } from '@transcript/runTrace';
 import type { StreamLogStore } from '@transcript/StreamLogStore';
 import { StreamSnapshotStore } from '@transcript/StreamSnapshotStore';
+import { throwAggregated } from '@utils/core';
 import { getRunContextSession, tryUseRunContext } from './RunContext';
 import { ExecutionRegistry } from './executionRegistry';
 import { ExecutionSubscriptionBinder } from './ExecutionSubscriptionBinder';
@@ -673,13 +674,7 @@ export class SessionHandle {
         failures.push(error);
       }
     }
-    if (failures.length === 1) throw failures[0];
-    if (failures.length > 1) {
-      throw new AggregateError(
-        failures,
-        'Multiple session trace writers failed to flush',
-      );
-    }
+    throwAggregated(failures, 'Multiple session trace writers failed to flush');
   }
 
   /** Register a session-owned durable writer such as a snapshot store. */
@@ -749,13 +744,10 @@ export class SessionHandle {
     const failures = results.flatMap((result) =>
       result.status === 'rejected' ? [result.reason] : [],
     );
-    if (failures.length === 1) throw failures[0];
-    if (failures.length > 1) {
-      throw new AggregateError(
-        failures,
-        'Multiple session artifact writers failed to flush',
-      );
-    }
+    throwAggregated(
+      failures,
+      'Multiple session artifact writers failed to flush',
+    );
   }
 
   /** Listeners for terminal run results in this session (the host channel). */
@@ -873,10 +865,7 @@ export class SessionHandle {
     } finally {
       liveSessions.delete(this);
     }
-    if (failures.length === 1) throw failures[0];
-    if (failures.length > 1) {
-      throw new AggregateError(failures, 'Session teardown failed');
-    }
+    throwAggregated(failures, 'Session teardown failed');
   }
 
   /** Dispose the runtime owners and drop result listeners. */

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -56,7 +56,7 @@ import type {
   ChildStream,
   ChildStreamOutcome,
 } from '@tools/delegation/childStream';
-import { formatDuration } from '@utils/core';
+import { formatDuration, throwAggregated } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 /** Minimal token usage shape consumed by the loop's turn summary. */
@@ -709,12 +709,12 @@ export function startChildRunLoop<TTurn>(
     cleanup(() => stopWatchingLease?.());
     cleanup(releaseChildActivation);
     cleanup(releaseSessionOwnershipOnce);
-    if (cleanupErrors.length > 0) {
-      throw new AggregateError(
-        [error, ...cleanupErrors],
-        `Child run ${executionId} setup failed and rollback was incomplete`,
-      );
-    }
+    // Non-empty by construction (the primary error is always first): one
+    // failure rethrows `error` unwrapped, several wrap into an AggregateError.
+    throwAggregated(
+      [error, ...cleanupErrors],
+      `Child run ${executionId} setup failed and rollback was incomplete`,
+    );
     throw error;
   }
 

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -56,7 +56,7 @@ import type {
   ChildStream,
   ChildStreamOutcome,
 } from '@tools/delegation/childStream';
-import { formatDuration, throwAggregated } from '@utils/core';
+import { aggregateError, formatDuration } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 /** Minimal token usage shape consumed by the loop's turn summary. */
@@ -709,13 +709,13 @@ export function startChildRunLoop<TTurn>(
     cleanup(() => stopWatchingLease?.());
     cleanup(releaseChildActivation);
     cleanup(releaseSessionOwnershipOnce);
-    // Non-empty by construction (the primary error is always first): one
-    // failure rethrows `error` unwrapped, several wrap into an AggregateError.
-    throwAggregated(
+    // The primary error always heads the list, so a single throw covers both
+    // shapes: `error` unwrapped when rollback was clean, an AggregateError when
+    // cleanup also failed.
+    throw aggregateError(
       [error, ...cleanupErrors],
       `Child run ${executionId} setup failed and rollback was incomplete`,
     );
-    throw error;
   }
 
   let bestCostUsd: number | undefined;

--- a/src/test-kernel/utils/UtilsCore.vitest.ts
+++ b/src/test-kernel/utils/UtilsCore.vitest.ts
@@ -5,6 +5,7 @@ import * as assert from 'node:assert';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  aggregateError,
   coalesceAsync,
   createFlushableDebounce,
   delay,
@@ -14,6 +15,7 @@ import {
   getBasename,
   getFileStem,
   KeyedMutex,
+  throwAggregated,
   toNewestFirstByTimestamp,
   type FlushableDebounce,
 } from '@utils/core';
@@ -81,6 +83,56 @@ describe('core type guard predicates', () => {
 
   it('wraps scalar values in an array', () => {
     expect(ensureArray('alpha')).toEqual(['alpha']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure aggregation
+// ---------------------------------------------------------------------------
+
+describe('aggregateError', () => {
+  it('unwraps the lone failure when exactly one is collected', () => {
+    const only = new Error('boom');
+    expect(aggregateError([only], 'ignored')).toBe(only);
+  });
+
+  it('wraps several failures in an AggregateError carrying the message', () => {
+    const a = new Error('a');
+    const b = new Error('b');
+    const result = aggregateError([a, b], 'both failed');
+    expect(result).toBeInstanceOf(AggregateError);
+    const aggregate = result as AggregateError;
+    expect(aggregate.message).toBe('both failed');
+    expect(aggregate.errors).toEqual([a, b]);
+  });
+
+  it('preserves a lone falsy failure rather than aggregating it', () => {
+    // A single collected `undefined` must round-trip unwrapped, matching a
+    // bare `throw failures[0]`.
+    expect(aggregateError([undefined], 'ignored')).toBeUndefined();
+  });
+});
+
+describe('throwAggregated', () => {
+  it('is a no-op when no failures were collected', () => {
+    expect(() => throwAggregated([], 'nothing failed')).not.toThrow();
+  });
+
+  it('throws the lone failure unwrapped', () => {
+    const only = new Error('boom');
+    expect(() => throwAggregated([only], 'ignored')).toThrow(only);
+  });
+
+  it('throws an AggregateError when several failed', () => {
+    const a = new Error('a');
+    const b = new Error('b');
+    try {
+      throwAggregated([a, b], 'both failed');
+      assert.fail('expected throwAggregated to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      expect((error as AggregateError).errors).toEqual([a, b]);
+    }
   });
 });
 

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -53,7 +53,7 @@ import {
   type TokenUsageStats,
   type WorkPlanSnapshot,
 } from '@shared/schemas';
-import { mapToRecord } from '@utils/core';
+import { mapToRecord, throwAggregated } from '@utils/core';
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 
@@ -1437,10 +1437,7 @@ export class StreamSnapshotStore {
     const remainingFailures = dirtyWritesDurable
       ? failures.filter((error) => !(error instanceof DirtySidecarWritesError))
       : failures;
-    if (remainingFailures.length === 1) throw remainingFailures[0];
-    if (remainingFailures.length > 1) {
-      throw new AggregateError(remainingFailures, 'Snapshot flush failed');
-    }
+    throwAggregated(remainingFailures, 'Snapshot flush failed');
   }
 
   // ==========================================================================

--- a/src/transcript/runTrace.ts
+++ b/src/transcript/runTrace.ts
@@ -64,7 +64,10 @@ export function createRunTrace(
       new Error(`Execution ${ownerKey} already owns a run trace.`),
     ];
     collectFailure(failures, () => writer.close());
-    throw aggregateError(failures, 'Duplicate run trace setup and cleanup failed');
+    throw aggregateError(
+      failures,
+      'Duplicate run trace setup and cleanup failed',
+    );
   }
   const trace = new TraceEmitter();
   let unsubscribeChannel: (() => void) | undefined;

--- a/src/transcript/runTrace.ts
+++ b/src/transcript/runTrace.ts
@@ -14,6 +14,7 @@ import {
   type AgentTrace,
 } from '@agent/trace';
 import type { StreamTabId } from '@shared/schemas';
+import { aggregateError } from '@utils/core';
 
 import { attachTranscriptRecorder } from './TexraTranscriptRecorder';
 import type { StreamLogStore, TranscriptWriter } from './StreamLogStore';
@@ -40,13 +41,6 @@ function collectFailure(failures: unknown[], action: () => void): void {
   }
 }
 
-/** Reduce a non-empty failure list to the lone failure, or an aggregate of all. */
-function toFailure(failures: unknown[], message: string): unknown {
-  return failures.length === 1
-    ? failures[0]
-    : new AggregateError(failures, message);
-}
-
 /**
  * Produce a trace wired with the standard agent-run subscribers: per-channel
  * channel output AND the transcript recorder.
@@ -70,7 +64,7 @@ export function createRunTrace(
       new Error(`Execution ${ownerKey} already owns a run trace.`),
     ];
     collectFailure(failures, () => writer.close());
-    throw toFailure(failures, 'Duplicate run trace setup and cleanup failed');
+    throw aggregateError(failures, 'Duplicate run trace setup and cleanup failed');
   }
   const trace = new TraceEmitter();
   let unsubscribeChannel: (() => void) | undefined;
@@ -85,7 +79,7 @@ export function createRunTrace(
     const failures = [error];
     collectFailure(failures, () => unsubscribeChannel?.());
     collectFailure(failures, () => writer.close());
-    throw toFailure(failures, 'Run trace setup and cleanup failed');
+    throw aggregateError(failures, 'Run trace setup and cleanup failed');
   }
 
   const pendingFailures =
@@ -100,7 +94,7 @@ export function createRunTrace(
         pendingFailures.length = 0;
       }
       if (failures.length > 0) {
-        throw toFailure(failures, 'Run trace flush failed');
+        throw aggregateError(failures, 'Run trace flush failed');
       }
     },
   };
@@ -126,7 +120,7 @@ export function createRunTrace(
         flushers.delete(ownerKey);
         return;
       }
-      const failure = toFailure(failures, 'Run trace cleanup failed');
+      const failure = aggregateError(failures, 'Run trace cleanup failed');
       const failedEntry: RunTraceFlushEntry = {
         state: 'failed',
         error: failure,

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -306,6 +306,22 @@ export async function coalesceAsync<Key, Value>(
 }
 
 /**
+ * Reduce a NON-EMPTY failure list to the value to throw: the lone failure
+ * unwrapped when there is exactly one, or an {@link AggregateError} carrying
+ * `message` when there are several. Use as `throw aggregateError(...)` where a
+ * failure is guaranteed, or to build an error for a `cause`. Callers that may
+ * have collected nothing want {@link throwAggregated} instead.
+ */
+export function aggregateError(
+  failures: readonly unknown[],
+  message: string,
+): unknown {
+  return failures.length === 1
+    ? failures[0]
+    : new AggregateError(failures, message);
+}
+
+/**
  * Rethrow a collected set of independent failures with the conventional
  * shape: a no-op when empty, the single error unwrapped when there is exactly
  * one, and an {@link AggregateError} carrying `message` when there are
@@ -316,8 +332,7 @@ export function throwAggregated(
   failures: readonly unknown[],
   message: string,
 ): void {
-  if (failures.length === 1) throw failures[0];
-  if (failures.length > 1) throw new AggregateError(failures, message);
+  if (failures.length > 0) throw aggregateError(failures, message);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -305,6 +305,21 @@ export async function coalesceAsync<Key, Value>(
   }
 }
 
+/**
+ * Rethrow a collected set of independent failures with the conventional
+ * shape: a no-op when empty, the single error unwrapped when there is exactly
+ * one, and an {@link AggregateError} carrying `message` when there are
+ * several. Centralizes the "run each teardown step, collect what threw, then
+ * surface them together" tail that session and run shutdown paths repeat.
+ */
+export function throwAggregated(
+  failures: readonly unknown[],
+  message: string,
+): void {
+  if (failures.length === 1) throw failures[0];
+  if (failures.length > 1) throw new AggregateError(failures, message);
+}
+
 // ---------------------------------------------------------------------------
 // comparators
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Several shutdown/flush paths independently hand-rolled the same tail: given a
list of collected failures, rethrow the lone error unwrapped or wrap several in
an `AggregateError`. This consolidates that idiom into two leaf helpers in
`@utils/core` and adopts them at each site. Behavior-preserving.

- `aggregateError(failures, message)` — the *reducer*: returns the value to
  throw (lone error unwrapped, else an `AggregateError`). Use as
  `throw aggregateError(...)` where a failure is guaranteed, or to build a `cause`.
- `throwAggregated(failures, message)` — the *statement*: no-op on empty, else
  throws `aggregateError(...)`. For "collected N≥0 failures, surface them" tails.

This PR is the outcome of a repo-wide tech-debt scan. The scan's headline finding
is that TeXRA is already unusually well-factored — the obvious duplication
(`classifyMediaEntry`, `mutateWithOverlay`, `applyTokenCountLimit`,
`handleStreamingFailure`, `ResidentStreamRegistry`, …) has been extracted, and
most remaining look-alike code is either irreducibly provider/field-specific or
guards subtle race/format invariants. This failure-aggregation idiom was the one
clean, safe, net-positive consolidation that survived close reading. See
**Scheduled refactoring** for the larger candidates that were deliberately *not*
taken and why.

## Issue acceptance gates

No tracking issue — this originates from a scheduled tech-debt audit. No
acceptance gates apply.

## Single source of truth

`aggregateError` / `throwAggregated` in `@utils/core` (`src/utils/core/index.ts`)
now own the "reduce a collected failure list to the correct throw" decision. This
absorbs the previously-private `toFailure` reducer in `src/transcript/runTrace.ts`
(identical logic, 4 call sites), which is deleted in this PR — so both the
reduce-shape and the throw-shape have exactly one home.

## Duplication and abstraction budget

Removed: the `if (len === 1) throw failures[0]; if (len > 1) throw new
AggregateError(...)` idiom from `SessionHandle.flushPendingTraces`,
`SessionHandle.flushArtifactsOnce`, `SessionHandle.dispose`, and
`StreamSnapshotStore.flush`; the redundant `if (cleanupErrors.length > 0)` branch
plus a now-unreachable `throw error;` from the `childRunLoop` setup-rollback; and
the private `toFailure` reducer from `runTrace.ts`.

The new abstractions are leaf pure functions, not pass-through layers.
`aggregateError` owns *non-empty → unwrapped-or-aggregate*; `throwAggregated`
adds the *empty → no-op* statement wrapper.

## Net elements (R6)

- Files: 5 changed. Non-test LoC roughly flat; the win is removing ~6 copies of
  an easy-to-get-subtly-wrong idiom, not raw line reduction.
- Exported symbols (`^[+-]export` over the diff): +2 (`aggregateError`,
  `throwAggregated`); 0 removed. One private function (`toFailure`) deleted.
- Classes/interfaces/enums: 0 added, 0 removed.
- Added: direct unit tests for both exports in `UtilsCore.vitest.ts`.

## Consumer counts (R8)

No emit path or existing export was deleted or re-routed. Two new exports added,
both with in-PR consumers (`check:dead-code-ratchet` passes: 16 vs 16 baselined):
`throwAggregated` — 4 (`SessionHandle` ×3, `StreamSnapshotStore`);
`aggregateError` — 5 (`runTrace` ×4, `childRunLoop`). n/a otherwise.

## Host impact

Extension: none — shared core only; no behavior change.

Desktop: none — shared core only; no behavior change.

CLI: none — shared core only; no behavior change.

## Scheduled refactoring

The audit's larger candidates were analyzed and **deliberately deferred**, not
missed. None is filed as a follow-up issue yet; recommend the two high-value ones
be done interactively with the maintainer given their risk profile:

- **Unify the two terminal-finalization state machines** (`executionRegistry`
  waiting-stop cluster vs `AgentRunLifecycle.finalizeRunTerminal`, ~80–120 LoC).
  Load-bearing shutdown path with lease-lost / generation-handoff arms; needs
  dedicated test coverage before merging — unsafe to land autonomously.
- **Templatize the per-provider `createResponseImpl` pipeline** (~120–180 LoC).
  Touches all five provider hot paths with subtle retry/compaction invariants;
  same caveat.
- **Table-drive the `StreamSnapshotStore` accumulators** — on close reading the
  store is already factored via `mutateWithOverlay`, and the residual enumeration
  guards a pre-await usage-overlay capture (#8226-class race) plus a
  `missingOutputs` reset special case. A faithful table saves little for real
  regression risk; not recommended as-is.
- **`createMediaContent` / `appendTextToLastAssistantMessage` base templates** —
  same *shape* across providers but the bodies differ in every guard, block
  constructor, and pop condition. A base template nets ~even on line count while
  reducing per-provider readability (shallow indirection). Not recommended.
- **Zod `.catch()` logging on persisted state** — the flagged sites
  (`streamSnapshot.ts`, `RunUsageAccumulator.ts`, `taskGroup.ts`) are documented,
  deliberate per-field resilience in the VS Code-free `src/shared/schemas` zone;
  adding a logger there is a layering concern and the "defect" is borderline. Left
  for a focused decision.

## Validation

- `tsc --noEmit --checkers 8` (workspace + `tsconfig.test-kernel.json`): pass.
- `vitest run` over `utils`, `transcript`, `agent/runtime`, and `agent/storage`
  suites: 765 passed (includes new `aggregateError` / `throwAggregated` tests).
- `eslint` on all changed files: pass.
- `npm run check:dead-code-ratchet`: pass (no new unused exports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only consolidation of error-throwing logic with direct unit tests; no new runtime behavior beyond matching the previous aggregation rules.
> 
> **Overview**
> Adds **`aggregateError`** and **`throwAggregated`** in `@utils/core` to replace repeated “one failure → throw it; many → `AggregateError`” tails across session shutdown, snapshot flush, run trace, and child-run rollback.
> 
> **`SessionHandle`** (trace flush, artifact flush, dispose), **`StreamSnapshotStore.flush`**, and **`runTrace`** (deleting private **`toFailure`**) now call these helpers. **`childRunLoop`** setup rollback uses **`aggregateError`** so the primary error always leads the list, removing a redundant branch and unreachable **`throw error`**.
> 
> Unit tests cover both exports in **`UtilsCore.vitest.ts`**. Behavior is intended to stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76e75902ddd273cfebe2568a9f8a7cb0334d203b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->