### PR TITLE
refactor(progress-view): rename executeAgent look-alikes to stop naming collisions

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -762,7 +762,7 @@ export class DesktopProgressBridge {
             this.state.snapshots.getRunIdentity(stream),
           getExecutionId: (stream) => this.getStreamExecutionId(stream),
         },
-        executeAgent: (request) => {
+        runExecutionRequest: (request) => {
           const validated = validateExecutionRequest(request);
           if (!validated.valid) {
             this.logger.error('Invalid desktop workflow execution request', {

--- a/packages/desktop/src/main/desktopExecutionIpc.ts
+++ b/packages/desktop/src/main/desktopExecutionIpc.ts
@@ -10,7 +10,13 @@ import {
 } from './desktopIpcTypes.js';
 
 export interface DesktopExecutionIpcOptions {
-  executeAgent(message: MainViewExecuteMessage): Promise<void>;
+  /**
+   * Handle a validated EXECUTE message from the renderer. Named apart from
+   * `@agent/runtime`'s `executeAgent`/`runAgent` pair — this is a raw IPC
+   * message handler, not either of those functions, though it eventually
+   * reaches `runAgent`.
+   */
+  handleExecuteMessage(message: MainViewExecuteMessage): Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
 
@@ -35,7 +41,7 @@ export function createDesktopExecutionIpc(
           );
           return;
         }
-        return options.executeAgent(parsed.data);
+        return options.handleExecuteMessage(parsed.data);
       },
     },
     { onAsyncError: options.onAsyncError },

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1028,7 +1028,7 @@ function createWindow(options: {
   });
   const mainViewIpc = installDesktopMainViewIpc(window, {
     workspace: workspaceIpc,
-    executeAgent: async (message) => {
+    handleExecuteMessage: async (message) => {
       const execution = await getAgentExecution();
       void execution.handleExecute(message).catch(reportAsyncError);
     },

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -46,7 +46,7 @@ export interface DesktopMainViewIpcOptions {
   shellActions: DesktopShellActions;
   getAuthStatus?: () => Promise<MainViewAuthStatus>;
   loadStartupOptions?: () => Promise<MainViewStartupOptions>;
-  executeAgent(message: MainViewExecuteMessage): Promise<void>;
+  handleExecuteMessage(message: MainViewExecuteMessage): Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
 
@@ -77,7 +77,7 @@ export function installDesktopMainViewIpc(
   });
   const shell = createDesktopShellIpc(options.shellActions);
   const execution = createDesktopExecutionIpc({
-    executeAgent: options.executeAgent,
+    handleExecuteMessage: options.handleExecuteMessage,
     onAsyncError: options.onAsyncError,
   });
   const logs = createDesktopLogIpc(bridge, {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -390,7 +390,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           getExecutionId: this.getExecutionId,
         },
         // Workflow actions intentionally wait for the run to finish.
-        executeAgent: (request) => this.executeValidated(request),
+        runExecutionRequest: (request) => this.executeValidated(request),
       },
       workflowFileActions: {
         state: {

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -93,7 +93,6 @@ import {
   changeWorkingDirectory,
   emptyFile,
   emptyFiles,
-  executeAgent,
   getCurrentFile,
   refreshEditedFiles,
   refreshInstructionPlaceholder,
@@ -103,6 +102,7 @@ import {
   runLatexDiffsAction,
   runPanelAction,
   selectMultipleFiles,
+  sendExecuteMessage,
   setBaseFile,
   setInstruction,
   updateCheckboxValue,
@@ -263,7 +263,7 @@ export class MainApp extends MainAppBase {
       this.logSchemaError(context, error),
     );
     if (restored && message.executeImmediately) {
-      executeAgent();
+      sendExecuteMessage();
     }
   }
 
@@ -436,7 +436,7 @@ export class MainApp extends MainAppBase {
         @instruction-input=${this.onInstructionInput}
         @panel-action=${({ detail }: CustomEvent<ActionDetail>) =>
           runPanelAction(detail.action)}
-        @execute=${() => executeAgent()}
+        @execute=${() => sendExecuteMessage()}
         @agent-settings=${() => runAgentConfigAction('edit')}
         @browse-all-agents=${() => runAgentConfigAction('edit')}
         @team-settings=${this.onOpenMultiAgentSettings}

--- a/packages/extension/src/webview/frontend/mainViewActions.ts
+++ b/packages/extension/src/webview/frontend/mainViewActions.ts
@@ -373,7 +373,8 @@ export function buildExecuteMessage(): MainViewExecuteMessage {
   });
 }
 
-export function executeAgent(): void {
+/** Post the current form state to the host as an EXECUTE message. */
+export function sendExecuteMessage(): void {
   postMessage(MAIN_VIEW_COMMANDS.EXECUTE, buildExecuteMessage());
 }
 

--- a/src/controllers/progressView/ProgressViewHost.ts
+++ b/src/controllers/progressView/ProgressViewHost.ts
@@ -53,7 +53,13 @@ interface ProgressViewRunState {
 
 interface ProgressViewRunDependencies {
   readonly state: ProgressViewRunState;
-  executeAgent(request: ExecutionRequest): Promise<void>;
+  /**
+   * Launch or resume a run for this request. This is a host callback, not
+   * the `@agent/runtime` `executeAgent`/`runAgent` functions it dispatches
+   * to — hosts wire it to their own command/IPC handling, which eventually
+   * reaches `runAgent`.
+   */
+  runExecutionRequest(request: ExecutionRequest): Promise<void>;
 }
 
 /**
@@ -80,7 +86,7 @@ async function resumeStream(
   }
 
   const executionId = dependencies.state.getExecutionId(stream);
-  await dependencies.executeAgent({
+  await dependencies.runExecutionRequest({
     config,
     ...(executionId && { executionId }),
   });
@@ -98,7 +104,7 @@ async function runNewStream(
   const config = dependencies.state.getRunConfig(stream);
   if (!config) return;
 
-  await dependencies.executeAgent({ config });
+  await dependencies.runExecutionRequest({ config });
 }
 
 export interface ProgressViewHostOptions {

--- a/src/test-kernel/controllers/ProgressViewHost.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewHost.vitest.ts
@@ -52,7 +52,7 @@ function createHostHarness(
           identity ?? { kind: 'agent', agent: runConfig.agent },
         getExecutionId: () => 'exec-1',
       },
-      executeAgent: async (request) => {
+      runExecutionRequest: async (request) => {
         executed.push(request);
       },
     },

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts
@@ -335,16 +335,16 @@ describe('desktop IPC adapters', () => {
       agent: 'direct-agent',
       model: 'gpt-5.4',
     };
-    const executeAgent = vi.fn(async (_message: unknown) => {});
-    const executionIpc = createDesktopExecutionIpc({ executeAgent });
+    const handleExecuteMessage = vi.fn(async (_message: unknown) => {});
+    const executionIpc = createDesktopExecutionIpc({ handleExecuteMessage });
 
     expect(executionIpc.handleMessage(executeMessage)).toBe(true);
     await Promise.resolve();
-    expect(executeAgent).toHaveBeenCalledWith(executeMessage);
+    expect(handleExecuteMessage).toHaveBeenCalledWith(executeMessage);
 
     const malformedError = vi.fn();
     const malformedExecutionIpc = createDesktopExecutionIpc({
-      executeAgent,
+      handleExecuteMessage,
       onAsyncError: malformedError,
     });
     expect(
@@ -353,13 +353,13 @@ describe('desktop IPC adapters', () => {
         files: { inputFiles: 'main.tex' },
       }),
     ).toBe(true);
-    expect(executeAgent).toHaveBeenCalledTimes(1);
+    expect(handleExecuteMessage).toHaveBeenCalledTimes(1);
     expect(malformedError).toHaveBeenCalledWith(expect.any(Error));
 
     const error = new Error('execution failed');
     const onAsyncError = vi.fn();
     createDesktopExecutionIpc({
-      executeAgent: vi.fn(async () => {
+      handleExecuteMessage: vi.fn(async () => {
         throw error;
       }),
       onAsyncError,

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
@@ -75,7 +75,7 @@ interface MainViewIpcModule {
         copyLog(text: string): Promise<void>;
         exportLog(text: string): Promise<void>;
       };
-      executeAgent(message: unknown): Promise<void>;
+      handleExecuteMessage(message: unknown): Promise<void>;
       onAsyncError?: (error: unknown) => void;
     },
   ): {
@@ -185,7 +185,7 @@ function createMainViewCommandCapabilities() {
     handleMessage: vi.fn(() => false),
   });
   return {
-    executeAgent: vi.fn(async (_message: unknown) => {}),
+    handleExecuteMessage: vi.fn(async (_message: unknown) => {}),
     fileSelection: createUnhandledCapability(),
     prompt: { ...createUnhandledCapability(), dispose: vi.fn() },
     settings: createUnhandledCapability(),
@@ -503,8 +503,8 @@ describe('desktop main-view IPC', () => {
 
   it('forwards EXECUTE messages to the injected executor', async () => {
     const harness = await createMainViewHarness();
-    const executeAgent = vi.fn(async (_message: unknown) => {});
-    installMainView(harness, { executeAgent });
+    const handleExecuteMessage = vi.fn(async (_message: unknown) => {});
+    installMainView(harness, { handleExecuteMessage });
     const { sendFromRenderer } = harness;
 
     const executeMessage = {
@@ -514,7 +514,7 @@ describe('desktop main-view IPC', () => {
     };
     sendFromRenderer(executeMessage);
     await Promise.resolve();
-    expect(executeAgent).toHaveBeenCalledWith(executeMessage);
+    expect(handleExecuteMessage).toHaveBeenCalledWith(executeMessage);
   });
 
   it('pushes the new theme when the native theme changes', async () => {


### PR DESCRIPTION
## Summary

This came out of a scheduled structural-review pass looking for confusing or overlapped responsibilities across the codebase. Most of the codebase held up well (heavily commented, clear ownership), but one concrete, verified naming collision stood out: three unrelated host/UI callbacks are all named `executeAgent`, distinct from the actual `@agent/runtime/executeAgent` engine function that CLAUDE.md explicitly documents as the low-level counterpart to `runAgent` ("Use the lower-level `executeAgent` only when you already own the `executionId`").

Traced each one end-to-end before touching anything:

- `ProgressViewRunDependencies.executeAgent` (`src/controllers/progressView/ProgressViewHost.ts`) — a host callback that resumes/re-runs a progress-view stream. In the extension it dispatches through the VS Code command `texra.execute`; in desktop it calls `this.runExecution(...)`. Neither is the runtime `executeAgent`. Renamed to **`runExecutionRequest`**.
- `DesktopMainViewIpcOptions`/`DesktopExecutionIpcOptions.executeAgent` (`packages/desktop/src/main/mainViewIpc.ts`, `desktopExecutionIpc.ts`) — handles a raw, schema-validated `EXECUTE` IPC message from the renderer. Renamed to **`handleExecuteMessage`**.
- Webview frontend `executeAgent()` (`packages/extension/src/webview/frontend/mainViewActions.ts`) — posts the `EXECUTE` message to the host. Renamed to **`sendExecuteMessage`**, matching the file's other `postMessage`-action naming and its neighbor `buildExecuteMessage`.

I initially also looked at `TextEditorTool` (`str_replace_editor`) as a candidate "duplicate tool" (it looks like it overlaps `EditFileTool`/`WriteFileTool`), but on tracing `toolConversion.ts`'s `ANTHROPIC_TOOL_TYPE_MAP` it turned out to implement Anthropic's native `text_editor` server-tool contract — a legitimate, distinct responsibility, not confusion. No change made there.

## Issue acceptance gates

No linked issue — self-directed structural-clarity fix from a scheduled codebase audit. Gate: the `executeAgent` name resolves to exactly one thing in the codebase (the `@agent/runtime` engine function) once this merges.

## Single source of truth

Unchanged — `src/agent/runtime/executeAgent.ts` remains the sole owner of the `executeAgent` name and the low-level execution engine. This PR only removes look-alikes that shadowed it in unrelated layers.

## Duplication and abstraction budget

No duplication removed (these were never duplicate implementations, just duplicate names) and no abstraction added — pure identifier rename across the field's interface declaration, implementers, and call sites. No pass-through layers introduced.

## Net elements (R6)

11 files changed, 0 added/removed. `git diff` `^[+-]export` count: 1 (`export function executeAgent` → `export function sendExecuteMessage`, straight rename, net zero exported symbols). No new files, classes, or interfaces.

## Consumer counts (R8)

n/a — no emit path or export was deleted/re-routed; every call site of each renamed field/function was updated in this same PR (verified via repo-wide grep for `executeAgent` before and after).

## Host impact

Extension: `ProgressViewMessageHandler.ts` (implementer) and `mainViewActions.ts`/`MainApp.ts` (webview frontend caller) updated.

Desktop: `desktopAgentExecution.ts` (implementer), `mainViewIpc.ts`, `desktopExecutionIpc.ts`, and `index.ts` (implementer) updated.

CLI: not affected — no `executeAgent`-named host callback exists in `packages/cli`.

## Scheduled refactoring

None — this fully resolves the naming collision found during the audit.

## Validation

- `npm run typecheck` (workspace, test-kernel, extension, desktop) — all pass
- `npx vitest run` on the affected test files (`ProgressViewHost.vitest.ts`, `ElectronMainViewIpc.vitest.ts`, `DesktopIpcAdapters.vitest.ts`, `DesktopAgentExecution.vitest.ts`, `MainViewActions.vitest.ts`, `MainViewLaunchTarget.vitest.ts`) — 154/154 tests pass
- `npx eslint` on all changed files — clean
- Repo-wide grep for `executeAgent` post-change to confirm every remaining occurrence refers to the real `@agent/runtime/executeAgent` function (or a comment about it), not a look-alike


---
_Generated by [Claude Code](https://claude.ai/code/session_01NTBCmivemx1nLkafpqYi4W)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Identifier-only renames with all call sites updated in the same PR; no execution, auth, or IPC contract changes.
> 
> **Overview**
> Renames three unrelated callbacks that were all called **`executeAgent`** so they no longer shadow the **`@agent/runtime`** **`executeAgent`** engine function (the low-level counterpart to **`runAgent`**).
> 
> **Progress view host wiring** — **`ProgressViewRunDependencies.executeAgent`** becomes **`runExecutionRequest`**, with a comment clarifying it is a host callback that eventually reaches **`runAgent`**, not the runtime **`executeAgent`**. Extension and desktop **`ProgressViewHost`** implementers and resume/re-run call sites are updated.
> 
> **Desktop main-view IPC** — **`executeAgent`** on **`DesktopMainViewIpcOptions`** / **`DesktopExecutionIpcOptions`** becomes **`handleExecuteMessage`**, documenting that it handles a validated **`EXECUTE`** IPC message from the renderer.
> 
> **Extension webview launcher** — the frontend **`executeAgent()`** that posts **`MAIN_VIEW_COMMANDS.EXECUTE`** becomes **`sendExecuteMessage`**, aligned with **`buildExecuteMessage`** and other post-message actions.
> 
> Tests and harness mocks follow the new names; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c12d42fa83cad71c44a5fc5151266f035acc7dcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->