### PR TITLE
refactor: simplify type aliases, inline one-shot helpers, drop dead code

### DIFF
--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -25,6 +25,7 @@ import {
   type CliConfigValues,
 } from './cliConfig';
 import { resolveCliResourcesPath } from './resourcesPath';
+import type { Stats } from 'node:fs';
 
 type CliMode = 'headless' | 'interactive';
 
@@ -367,7 +368,7 @@ export async function resolveCliCwd(
     return canonicalizeWorkspacePath(readCliCwd());
   }
   const requested = path.resolve(cwdFlag.trim());
-  let info: Awaited<ReturnType<typeof stat>>;
+  let info: Stats;
   try {
     info = await stat(requested);
   } catch (error: unknown) {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -584,18 +584,15 @@ export class DesktopProgressBridge {
   private async applyFollowUpPolishResult(
     result: ProgressFollowUpPolishResult,
   ): Promise<void> {
+    if (result.kind === 'skipped') return;
+    this.postToRenderer(result.update);
     switch (result.kind) {
-      case 'skipped':
-        return;
       case 'updated':
-        this.postToRenderer(result.update);
         return;
       case 'failed':
-        this.postToRenderer(result.update);
         await this.options.host.showErrorMessage(result.userMessage);
         return;
       case 'exception':
-        this.postToRenderer(result.update);
         this.logger.error(result.logMessage, {
           data: result.logData ? toLogData(result.logData) : undefined,
         });

--- a/packages/desktop/src/main/fatalStartupError.ts
+++ b/packages/desktop/src/main/fatalStartupError.ts
@@ -2,18 +2,12 @@ import { app, dialog } from 'electron';
 
 let fatalStartupErrorReported = false;
 
-function formatFatalStartupError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.stack ?? error.message;
-  }
-  return String(error);
-}
-
 export function reportFatalStartupError(error: unknown): void {
   if (fatalStartupErrorReported) return;
   fatalStartupErrorReported = true;
 
-  const detail = formatFatalStartupError(error);
+  const detail =
+    error instanceof Error ? (error.stack ?? error.message) : String(error);
   console.error(`Fatal TeXRA desktop error:\n${detail}`);
 
   const showFailureDialog = () => {

--- a/packages/desktop/src/renderer/desktopIconLibrary.ts
+++ b/packages/desktop/src/renderer/desktopIconLibrary.ts
@@ -174,15 +174,6 @@ function lucideSvg(name: string): string | undefined {
  * ordering that reliably wins.
  */
 
-/**
- * Resolves a TeXRA icon name to Lucide geometry.
- *
- * Direct lookup: canonical name → Lucide equivalent → fallback to name.
- */
-function resolveLucideName(name: string): string {
-  return LUCIDE_NAME_BY_TEXRA_NAME[name] ?? name;
-}
-
 function svgDataUri(svg: string): string {
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
@@ -201,7 +192,7 @@ const missingIconUri = svgDataUri(
  * or silently introduce a different visual family.
  */
 const desktopIconResolver: IconLibraryResolver = (name) => {
-  const svg = lucideSvg(resolveLucideName(name));
+  const svg = lucideSvg(LUCIDE_NAME_BY_TEXRA_NAME[name] ?? name);
   return svg ? svgDataUri(svg) : missingIconUri;
 };
 

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -26,7 +26,6 @@ const CHANNEL = 'ApiKeyCommands';
 
 export const apiKeyCommands = {
   setApiKey: 'texra.setApiKey',
-  removeApiKey: 'texra.removeApiKey',
 };
 
 /**

--- a/packages/extension/src/progressView/frontend/components/messageIndex.ts
+++ b/packages/extension/src/progressView/frontend/components/messageIndex.ts
@@ -35,13 +35,12 @@ function insertByTime<T>(
     target.push(entry);
     return target.length - 1;
   }
+  // findIndex always returns >= 0 here: we only reach this point when the
+  // target is non-empty and time < lastTime, so the last element satisfies
+  // the predicate.
   const idx = target.findIndex((item) => timeOf(item) > time);
-  if (idx >= 0) {
-    target.splice(idx, 0, entry);
-    return idx;
-  }
-  target.push(entry);
-  return target.length - 1;
+  target.splice(idx, 0, entry);
+  return idx;
 }
 
 function messageTime(message: LogMessageData): number {

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -2,7 +2,6 @@
 import {
   createStreamState,
   type AgentCategory,
-  type ContextStateData,
   type LogMessageData,
   type StreamState,
   type StreamTabInfo,
@@ -20,9 +19,8 @@ export {
   type StreamState,
   type ToolUseStreamState,
   type WorkflowStreamState,
+  type ContextStateData,
 } from '@shared/schemas';
-
-export type { ContextStateData };
 
 /** Followup options derived from schema (minus command/stream fields) */
 export type FollowupOptionsState = Omit<

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -106,10 +106,6 @@ export class ProviderKeyModal extends LitElement {
     this.dispatchEvent(createEvent('provider-key-cancel'));
   }
 
-  private handleCancelClick(): void {
-    this.close();
-  }
-
   private handleInput(event: Event): void {
     this.value = (event.target as WaInput).value ?? '';
     if (this.error) {
@@ -171,7 +167,7 @@ export class ProviderKeyModal extends LitElement {
             appearance="outlined"
             variant="neutral"
             type="button"
-            @click=${this.handleCancelClick}
+            @click=${() => this.close()}
           >
             Cancel
           </wa-button>

--- a/src/agent/core/definition/AgentConfig.ts
+++ b/src/agent/core/definition/AgentConfig.ts
@@ -10,8 +10,6 @@ import { AgentCategory } from './AgentDataclass';
 /** Agent assumed when a config omits `agent`, and sorted first in the workflow dropdown. */
 export const DEFAULT_WORKFLOW_AGENT = 'correct';
 
-const DEFAULT_AGENT_INSTRUCTION = '';
-
 /** Fields shared by both category-specific config variants. */
 const AgentConfigSharedFieldsSchema = NullableFileFieldsSchema.extend({
   agent: z.string().prefault(DEFAULT_WORKFLOW_AGENT),
@@ -24,7 +22,7 @@ const AgentConfigSharedFieldsSchema = NullableFileFieldsSchema.extend({
    */
   agentSource: AgentSourceSchema.nullish(),
   model: z.string().prefault(DEFAULT_AGENT_MODEL),
-  instruction: z.string().prefault(DEFAULT_AGENT_INSTRUCTION),
+  instruction: z.string().prefault(''),
   /** Original user instruction preserved across nested tool-use delegation. */
   rootUserInstruction: z.string().nullish(),
   /** Optional user-facing text for logs when instruction contains hidden context. */

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -15,6 +15,7 @@ import { inferAndLogPersistedModelHandlerCompatibilityKey } from '@agent/runtime
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
+import { userRequestTemplateCount } from '@agent/index/agentYamlScanner';
 import type { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
 import {
   PersistedFlowStateError,
@@ -143,15 +144,10 @@ export async function runReflectionFlow<C = unknown>(
 
   const latexMediaManager = new LatexMediaManager(logger, fileService);
 
-  let requestCount: number;
-  if (Array.isArray(prompt.userRequest)) {
-    requestCount = prompt.userRequest.length;
-  } else if (prompt.userRequest) {
-    requestCount = 1;
-  } else {
-    requestCount = 0;
-  }
-  const totalRounds = Math.max(setting.rounds ?? 2, requestCount);
+  const totalRounds = Math.max(
+    setting.rounds ?? 2,
+    userRequestTemplateCount(prompt.userRequest),
+  );
 
   const getOutputFileLocation =
     input.getOutputFileLocation ??

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -12,7 +12,6 @@ import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import { isNonEmptyString } from '@utils/core';
 
 import { DEFAULT_ATTACHMENT_MIME_TYPE } from '../utils/toolAttachmentUtils';
-import type { MediaFileResult } from '../support/MediaAttachmentProcessor';
 
 /**
  * Client setup and the media-attachment pipeline for `ModelHandlerGoogleInteractions`,
@@ -104,8 +103,6 @@ interface UploadGoogleMediaEntriesOptions<T> {
   onInsertedEntry?: (entry: MediaEntry) => void;
 }
 
-type GoogleMediaUploadSummary = Pick<MediaFileResult, 'path' | 'ok'>;
-
 /**
  * Media-attachment pipeline for the Interactions handler, kept here alongside
  * the client setup so the handler file stays focused on wire logic. Entries
@@ -123,7 +120,7 @@ export async function uploadGoogleMediaEntries<T>(
     options;
   const client = await getClient();
   const parts: T[] = [];
-  const summaries: GoogleMediaUploadSummary[] = [];
+  let hadFailure = false;
   const failures: string[] = [];
 
   for (const entry of entries) {
@@ -139,7 +136,6 @@ export async function uploadGoogleMediaEntries<T>(
         );
         parts.push(buildMedia({ data: inlinePayload }, mimeType));
         onInsertedEntry?.(entry);
-        summaries.push({ path: fileName, ok: true });
         continue;
       }
       logger.debug(
@@ -156,7 +152,7 @@ export async function uploadGoogleMediaEntries<T>(
       logger.error(
         `Skipping media entry ${fileName} due to missing upload source`,
       );
-      summaries.push({ path: fileName, ok: false });
+      hadFailure = true;
       continue;
     }
 
@@ -173,21 +169,20 @@ export async function uploadGoogleMediaEntries<T>(
         logger.error(
           `Upload result for ${fileName} is missing a URI. Skipping entry.`,
         );
-        summaries.push({ path: fileName, ok: false });
+        hadFailure = true;
         continue;
       }
       const resolvedMimeType =
         uploaded.mimeType || entry.media_type || DEFAULT_ATTACHMENT_MIME_TYPE;
       parts.push(buildMedia({ uri: fileUri }, resolvedMimeType));
       onInsertedEntry?.(entry);
-      summaries.push({ path: fileName, ok: true });
     } catch (error) {
-      summaries.push({ path: fileName, ok: false });
+      hadFailure = true;
       failures.push(`${fileName}: ${getSdkErrorMessage(error)}`);
     }
   }
 
-  if (summaries.some((summary) => !summary.ok)) {
+  if (hadFailure) {
     const failureSummary = failures.join('; ');
     logger.warn(
       failureSummary

--- a/src/agent/modelHandlers/openrouter/openRouterUsage.ts
+++ b/src/agent/modelHandlers/openrouter/openRouterUsage.ts
@@ -17,9 +17,6 @@ import {
 import { normalizeUsage } from '../support/UsageNormalizer';
 import type { ChatUsage } from '@openrouter/sdk/models';
 
-/** Pricing inputs the handler supplies from its `config`/`capabilities`. */
-type OpenRouterPricingConfig = StandardPricingConfig;
-
 /**
  * Prefer OpenRouter's billed cost for credit-backed requests. BYOK cost is
  * split between OpenRouter credits and the upstream provider account, so keep
@@ -27,7 +24,7 @@ type OpenRouterPricingConfig = StandardPricingConfig;
  */
 export function computeOpenRouterPrice(
   responseUsage: ChatUsage | null,
-  config: OpenRouterPricingConfig,
+  config: StandardPricingConfig,
 ): number {
   if (!responseUsage) return 0;
   if (responseUsage.isByok !== true && responseUsage.cost != null) {
@@ -51,7 +48,7 @@ export function normalizeOpenRouterUsage(
   rawUsage: ChatUsage | null,
   responseTimeMs: number,
   provider: NormalizedUsage['provider'],
-  config: OpenRouterPricingConfig,
+  config: StandardPricingConfig,
 ): NormalizedUsage {
   return normalizeUsage(
     {

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -602,7 +602,7 @@ async function acquireExecutionLease(
     const key = ownershipKey(root, executionId);
     const existingOwnership = ownedLeases.get(key);
     if (mode === 'resume' && existingOwnership) {
-      let heartbeatResult: Awaited<ReturnType<typeof heartbeat>> | undefined;
+      let heartbeatResult: 'owned' | 'lost' | 'cancelled' | undefined;
       try {
         heartbeatResult = await heartbeat(existingOwnership, canAcquire);
       } catch (error) {

--- a/src/auth/xai/XaiSessionCoordinator.ts
+++ b/src/auth/xai/XaiSessionCoordinator.ts
@@ -38,7 +38,6 @@ import {
 export type XaiSessionStorage = SubscriptionSessionStorage;
 export type XaiOAuthClient = SubscriptionOAuthClient;
 export type XaiSessionStatus = SubscriptionSessionStatus;
-type XaiAuthorizeRequest = SubscriptionAuthorizeRequest;
 
 export interface XaiSessionCoordinatorInit {
   storage: XaiSessionStorage;
@@ -114,7 +113,7 @@ export class XaiSessionCoordinator extends SubscriptionOAuthCoordinator<XaiSessi
     });
   }
 
-  buildAuthorizeRequest(_port?: number): XaiAuthorizeRequest {
+  buildAuthorizeRequest(_port?: number): SubscriptionAuthorizeRequest {
     // Port is fixed by the Grok-CLI registration; policy ignores the argument.
     return super.buildAuthorizeRequest(0);
   }

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 
 // Local imports
 import * as logger from '@logger/logUtils';
-import type { FileLocation } from '@shared/schemas';
+import type { ExecResult, FileLocation } from '@shared/schemas';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { runToolWithCheck } from '@utils/system/toolUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -224,7 +224,7 @@ export async function compileLatex2Pdf(
       });
     }
 
-    let result: Awaited<ReturnType<typeof runToolWithCheck>>;
+    let result: ExecResult | false;
     if (compiler === 'latexmk') {
       result = await runToolWithCheck('latexmk', latexmkArgs, {
         channel,

--- a/src/shared/markdown/createMarkdownRenderer.ts
+++ b/src/shared/markdown/createMarkdownRenderer.ts
@@ -3,7 +3,7 @@
 //
 // The factory takes a highlight hook and an optional `configure` hook. Math
 // is wired by the caller through a `usePlugin` callback (see
-// `markdownTexmathPlugin`) so non-math hosts — the CLI TUI in particular —
+// `createTexmathPlugin`) so non-math hosts — the CLI TUI in particular —
 // don't pull `markdown-it-texmath` into their bundle.
 
 import MarkdownIt from 'markdown-it';

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -18,12 +18,9 @@ const NO_ENTRIES_MESSAGE = '(no entries)';
 const DEFAULT_HIDDEN_NAMES = new Set(['.git', '.gitignore']);
 
 function formatDirEntry(name: string, type: number): string {
-  const isDir = isDirectory(type);
-  let label = 'other';
-  if (isDir) label = 'dir';
-  else if (isFile(type)) label = 'file';
-  const suffix = isDir ? '/' : '';
-  return `${label.padEnd(4)} ${name}${suffix}`;
+  if (isDirectory(type)) return `dir  ${name}/`;
+  if (isFile(type)) return `file ${name}`;
+  return `other ${name}`;
 }
 
 /** List the freshly-extracted source directory, skipping VCS noise. */

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -74,6 +74,7 @@ import {
   buildCodexTodoToolLog,
   buildCodexTurnToolLog,
   buildCodexUsageStats,
+  type ToolUseStatus,
 } from './codexShared';
 
 // Third-party imports
@@ -156,8 +157,6 @@ function formatCodexDelivery(
 // ============================================================================
 // Stream tab helpers
 // ============================================================================
-
-type ToolUseStatus = NonNullable<ToolUseLog['status']>;
 
 export function publishCodexTodos(
   childStreamId: StreamTabId,

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -28,7 +28,7 @@ import type {
 export const CODEX_AGENT_NAME = 'codex';
 export const CODEX_DISPLAY_MODEL = 'gpt55';
 const CODEX_COMMAND_SUMMARY_MAX_LENGTH = 60;
-type ToolUseStatus = NonNullable<ToolUseLog['status']>;
+export type ToolUseStatus = NonNullable<ToolUseLog['status']>;
 
 type CodexFileChange = FileChangeItem['changes'][number];
 type CodexCommandToolLogOptions = Pick<

--- a/src/tools/wolfram/wolframScriptUtils.ts
+++ b/src/tools/wolfram/wolframScriptUtils.ts
@@ -11,7 +11,6 @@ const WOLFRAM_NOT_INSTALLED_ERROR =
   'Wolfram Engine (https://www.wolfram.com/engine/) which includes WolframScript.';
 const WOLFRAM_CHANNEL = 'WolframTool';
 
-// Interface for execution result
 export interface WolframScriptResult {
   success: boolean;
   output: string | null;

--- a/src/utils/text/diff.ts
+++ b/src/utils/text/diff.ts
@@ -11,9 +11,9 @@ import { countLines } from './stringUtils';
 
 export { DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT };
 
-type DiffMatchPatch = InstanceType<typeof diff_match_patch>;
-
-export type TextDiff = ReturnType<DiffMatchPatch['diff_main']>[number];
+export type TextDiff = ReturnType<
+  InstanceType<typeof diff_match_patch>['diff_main']
+>[number];
 
 export interface TextDiffOptions {
   /**


### PR DESCRIPTION
## Summary

Element-neutral cleanup sweep across CLI, desktop, extension, and agent sources, with no behavior change:

- **Type simplification**: replace `Awaited<ReturnType<...>>` chains with direct types (`Stats`, `ExecResult`, heartbeat's literal union), drop redundant local type aliases (`DiffMatchPatch`, `GoogleMediaUploadSummary`, `XaiAuthorizeRequest`, `OpenRouterPricingConfig`).
- **Single-source exports**: `ToolUseStatus` is now exported from `codexShared.ts` instead of being duplicated as a local type in both `codexShared.ts` and `codex.ts`.
- **Dead code removal**: `resolveLucideName`, `formatFatalStartupError`, `handleCancelClick`, `DEFAULT_AGENT_INSTRUCTION`, `apiKeyCommands.removeApiKey` (constant with zero consumers), the `summaries` collection in `uploadGoogleMediaEntries` (replaced by a boolean flag).
- **Behavior-preserving rewrites**: hoist the common `postToRenderer` call in `applyFollowUpPolishResult`; document the `insertByTime` invariant that makes `findIndex` guaranteed non-negative; inline the `userRequest` count block via `userRequestTemplateCount`; early-return `formatDirEntry`.
- **Comment/consistency fixes**: stale `markdownTexmathPlugin` reference, `ContextStateData` re-export via the shared export block.

## Issue acceptance gates

No issue — cleanup sweep of uncommitted local changes.

## Single source of truth

- `ToolUseStatus` is now owned solely by `codexShared.ts` and imported by `codex.ts`.
- The `insertByTime` ordering invariant is documented at its single use site.
- `ContextStateData` remains owned by `@shared/schemas` and re-exported from `progressView/frontend/store.ts` (unchanged contract).

## Duplication and abstraction budget

Removed duplicated local type aliases and single-use helpers (~85 deleted lines vs ~40 added). No new abstractions or pass-through layers introduced.

## Net elements (R6)

- 21 files changed, +40 / −85 net LoC.
- Exported symbols: +1 (`ToolUseStatus` from `codexShared.ts`), 0 removed; `TextDiff` and `ContextStateData` unchanged in name/contract.
- Classes/interfaces/enums: 0 added, 0 removed.

## Consumer counts (R8)

- `apiKeyCommands.removeApiKey` constant: 0 consumers (command string itself untouched — still registered in `package.json`, `catalog.ts`, and `extensionCommandHandlers.ts`).
- `ContextStateData` re-export: consumer `UsagePanel.ts` imports from `../store` unchanged.
- `ToolUseStatus`: 8 references in `src/tools`, all resolve to the new export.

## Host impact

Extension: removed unused command constant only.
Desktop: `applyFollowUpPolishResult` posts the renderer update once for all non-skipped kinds — same observable behavior.
CLI: no behavior change.

## Scheduled refactoring

None.

## Validation

- `typecheck:workspace`, `typecheck:extension`, `typecheck:cli`, `typecheck:test-kernel`, `typecheck:desktop` — all pass.
- `prettier --check` and `eslint` on all changed files — clean.
- `typecheck:workspace`, `typecheck:extension`, `typecheck:cli`, `typecheck:test-kernel`, `typecheck:desktop` — all pass.
- `prettier --check` and `eslint` on all changed files — clean (one import-order fix and a `no-nested-ternary` rewrite applied from the sweep itself).
- Full vitest suite: 4 failures, all timing timeouts under parallel load (`RunChatSignalOwnership` TUI mounting ×2, `DesktopAgentExecution` IPC resume ×2); all 4 pass in isolation (75/75 in the two affected files, 7.5s). No assertion failures.
