### PR TITLE
Use concise model access labels

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1199,7 +1199,7 @@ const SCENARIOS = [
     keys: ['/approval never', '\r', '/status', '\r'],
     expect: [
       'Approval mode: Deny Bash commands and tool edits.',
-      'own API keys',
+      'API keys',
       'never',
       '/status details',
     ],
@@ -2656,7 +2656,7 @@ const SCENARIOS = [
     // nothing under the removed parent is reachable from root. Opening and
     // confirming the root row must leave the frame and exit path intact.
     keys: ['\t', DOWN, '\r'],
-    expect: ['◆ — own API keys'],
+    expect: ['◆ — API keys'],
     unexpect: ['1 sub', 'orderChecker'],
     expectExit: true,
   },
@@ -2711,7 +2711,7 @@ const SCENARIOS = [
     // the removed child is unreachable, so confirming the root row must leave
     // the frame and exit path intact.
     keys: ['\t', DOWN, '\r'],
-    expect: ['◆ — own API keys'],
+    expect: ['◆ — API keys'],
     unexpect: ['orderChecker', '1 sub'],
     expectExit: true,
   },
@@ -3229,7 +3229,7 @@ const SCENARIOS = [
     frame: 'viewport',
     expect: [
       'Harness focused interrupt requested for harness-stream-1.',
-      '◆ stopped own API keys',
+      '◆ stopped API keys',
       'latest stopped prompt',
     ],
     unexpect: ['older stopped prompt', 'Choosing a session'],
@@ -3365,7 +3365,7 @@ const SCENARIOS = [
     frame: 'viewport',
     expect: [
       'Harness interrupt requested.',
-      '◆ stopped own API keys',
+      '◆ stopped API keys',
       '3 subagents',
       'Tab sessions',
       'Ctrl-C exit',

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -204,9 +204,6 @@ function accessModeSegment(access: CliModelAccessRoute): StatusBarSegment {
     : {
         text: label,
         color: 'dim',
-        // Narrow rows keep a recognizable stem of the full name rather than
-        // dropping how the session is paid for altogether.
-        compactText: access === 'included' ? 'included' : 'API keys',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.accessMode,
       };
 }

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -186,10 +186,9 @@ export function shortCliModelAccessRoute(route: CliModelAccessRoute): string {
       // form and /status name the subscription itself.
       return 'subscription';
     case 'included':
-      return INCLUDED_ACCESS.inline;
+      return INCLUDED_ACCESS.compactLabel;
     case 'personal':
-      // Trimmed from OWN_API_KEYS.inline to hold the bar's width budget.
-      return 'own API keys';
+      return OWN_API_KEYS.compactLabel;
     default:
       return route satisfies never;
   }

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -98,6 +98,7 @@ export class UsagePanel extends LitElement {
 
       .run-summary__route {
         font-weight: var(--wa-font-weight-semibold);
+        white-space: nowrap;
       }
 
       .run-summary__route--free {
@@ -137,6 +138,7 @@ export class UsagePanel extends LitElement {
       }
 
       .run-summary {
+        min-width: 0;
         margin-inline-start: auto;
       }
 
@@ -146,6 +148,10 @@ export class UsagePanel extends LitElement {
       :is(.run-summary__value, .context-state__value) {
         color: var(--wa-color-text-normal);
         font-variant-numeric: tabular-nums;
+      }
+
+      .run-summary__value {
+        min-width: 0;
       }
     `,
   ];
@@ -265,13 +271,13 @@ export class UsagePanel extends LitElement {
       return html`<span
         id="usage-route-badge"
         class="run-summary__route run-summary__route--free"
-        >Free · ${badge.label}</span
+        >Free · ${badge.compactLabel}</span
       >`;
     }
 
     return html`${formatCostUsd(cost)} ·
       <span id="usage-route-badge" class="run-summary__route">
-        ${badge.label}
+        ${badge.compactLabel}
       </span>`;
   }
 

--- a/src/shared/copy/modelAccess.ts
+++ b/src/shared/copy/modelAccess.ts
@@ -1,12 +1,13 @@
 /**
  * Canonical user-facing vocabulary for how model calls are paid for.
  *
- * Two concepts, two names, everywhere: model calls covered by your TeXRA plan
- * are "included access", and model calls billed to your own provider accounts
- * are "your own API keys". Settings pickers, quota notices, and model
- * availability messages import these strings instead of paraphrasing the
- * transport ("relay") or the internal enum values ('included' / 'personal'),
- * which stay wire identifiers and never reach the screen.
+ * Two concepts use canonical forms for each context. Model calls covered by
+ * your TeXRA plan are "included access", and model calls billed to your own
+ * provider accounts are "your own API keys". Settings pickers, quota notices,
+ * compact status labels, and model availability messages import these strings
+ * instead of paraphrasing the transport ("relay") or the internal enum values
+ * ('included' / 'personal'), which stay wire identifiers and never reach the
+ * screen.
  *
  * "Researcher Access" is the free program you sign in to, not a name for
  * included access; that copy lives in `onboarding.ts`.
@@ -16,8 +17,10 @@ import type { UsageRoute } from '@shared/schemas';
 
 /** Model calls paid for by your TeXRA plan. */
 export const INCLUDED_ACCESS = {
-  /** Standalone display name, e.g. a section heading or a status chip. */
+  /** Standalone display name, e.g. a section heading or detailed status. */
   label: 'Included access',
+  /** Width-constrained badge or status label. */
+  compactLabel: 'Included',
   /** Same name inside a sentence. */
   inline: 'included access',
   /** Model-access picker option. */
@@ -36,8 +39,10 @@ export const INCLUDED_ACCESS = {
 
 /** Model calls paid for by your own provider accounts. */
 export const OWN_API_KEYS = {
-  /** Standalone display name, e.g. a section heading or a status chip. */
+  /** Standalone display name, e.g. a section heading or detailed status. */
   label: 'Your own API keys',
+  /** Width-constrained badge or status label. */
+  compactLabel: 'API keys',
   /** Same name inside a sentence. */
   inline: 'your own API keys',
   /** Model-access picker option. */
@@ -48,14 +53,13 @@ export const OWN_API_KEYS = {
   },
 } as const;
 
-/** User-facing label and plan status for a {@link UsageRoute}. The label is
- *  the payment surface's display name — "included access", "your own API
- *  keys", or the subscription it runs on — and `subscription` marks routes
- *  covered by a top-up-free subscription plan. Hosts (CLI exit summary,
- *  extension usage panel) share this so payment attribution can't drift
- *  between surfaces. */
+/** User-facing labels and plan status for a {@link UsageRoute}. `label` is
+ *  the detailed payment name, `compactLabel` is its width-constrained badge
+ *  name, and `subscription` marks routes covered by a top-up-free plan. Hosts
+ *  share this contract so payment attribution and compact copy cannot drift. */
 export interface UsageRouteBadge {
   readonly label: string;
+  readonly compactLabel: string;
   readonly subscription: boolean;
 }
 
@@ -66,15 +70,27 @@ export function usageRouteBadge(
 ): UsageRouteBadge | undefined {
   switch (route) {
     case 'chatgpt-subscription':
-      return { label: 'ChatGPT', subscription: true };
+      return { label: 'ChatGPT', compactLabel: 'ChatGPT', subscription: true };
     case 'xai-subscription':
-      return { label: 'Grok', subscription: true };
+      return { label: 'Grok', compactLabel: 'Grok', subscription: true };
     case 'kimi-code-subscription':
-      return { label: 'Kimi Code', subscription: true };
+      return {
+        label: 'Kimi Code',
+        compactLabel: 'Kimi Code',
+        subscription: true,
+      };
     case 'relay':
-      return { label: INCLUDED_ACCESS.inline, subscription: false };
+      return {
+        label: INCLUDED_ACCESS.inline,
+        compactLabel: INCLUDED_ACCESS.compactLabel,
+        subscription: false,
+      };
     case 'api-key':
-      return { label: OWN_API_KEYS.inline, subscription: false };
+      return {
+        label: OWN_API_KEYS.inline,
+        compactLabel: OWN_API_KEYS.compactLabel,
+        subscription: false,
+      };
     default:
       return undefined;
   }

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.ts
@@ -320,8 +320,8 @@ describe('CLI model access routes', () => {
       ['chatgpt', 'subscription'],
       ['grok', 'subscription'],
       ['kimi-code', 'subscription'],
-      ['included', 'included access'],
-      ['personal', 'own API keys'],
+      ['included', 'Included'],
+      ['personal', 'API keys'],
     ];
 
     for (const [route, text] of detailed) {

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -22,9 +22,6 @@ import { AgentCategory, STREAM_PHASE, STREAM_SUBSTATE } from '@shared/schemas';
 // The bar renders the access route, not the raw `ApiAccessMode` enum.
 const INCLUDED_ACCESS_LABEL = shortCliModelAccessRoute('included');
 const PERSONAL_API_MODE_LABEL = shortCliModelAccessRoute('personal');
-// Narrow rows shrink the access segment to its compact stem instead of
-// dropping how the session is paid for.
-const PERSONAL_API_MODE_COMPACT = 'API keys';
 
 type StatusBarDisplay = ReturnType<typeof buildStatusBarDisplay>;
 
@@ -140,8 +137,8 @@ describe('CLI StatusBar display model', () => {
   it('uses clear compact labels for API access mode', () => {
     // The session header and the status bar share one mapper, so neither can
     // print the raw enum value ('included' / 'personal') the way they once did.
-    expect(shortCliModelAccessRoute('included')).toBe('included access');
-    expect(shortCliModelAccessRoute('personal')).toBe('own API keys');
+    expect(shortCliModelAccessRoute('included')).toBe('Included');
+    expect(shortCliModelAccessRoute('personal')).toBe('API keys');
   });
 
   it('keeps an ephemeral transcript warning in the durable status row', () => {
@@ -818,11 +815,11 @@ describe('CLI StatusBar display model', () => {
       '◆',
       'running',
       '1m 15s',
-      PERSONAL_API_MODE_COMPACT,
+      PERSONAL_API_MODE_LABEL,
       '3 sub',
     ]);
     expect(leftTexts(display).join(' ')).not.toContain(
-      `${PERSONAL_API_MODE_COMPACT}3`,
+      `${PERSONAL_API_MODE_LABEL}3`,
     );
   });
 
@@ -841,7 +838,7 @@ describe('CLI StatusBar display model', () => {
       '◆',
       'running',
       '1m 15s',
-      PERSONAL_API_MODE_COMPACT,
+      PERSONAL_API_MODE_LABEL,
     ]);
   });
 
@@ -877,7 +874,7 @@ describe('CLI StatusBar display model', () => {
       '◆',
       'running',
       '1m 15s',
-      PERSONAL_API_MODE_COMPACT,
+      PERSONAL_API_MODE_LABEL,
     ]);
   });
 

--- a/src/test-kernel/progressView/UsagePanel.vitest.ts
+++ b/src/test-kernel/progressView/UsagePanel.vitest.ts
@@ -73,17 +73,17 @@ describe('usage-panel route badges', () => {
   it.each([
     {
       route: 'relay' as UsageRoute,
-      visibleLabel: 'included access',
-      ariaCost: '$0.123 via included access',
+      visibleLabel: 'Included',
+      detailedLabel: 'included access',
     },
     {
       route: 'api-key' as UsageRoute,
-      visibleLabel: 'your own API keys',
-      ariaCost: '$0.123 via your own API keys',
+      visibleLabel: 'API keys',
+      detailedLabel: 'your own API keys',
     },
   ])(
     'shows $visibleLabel beside the cost',
-    async ({ route, visibleLabel, ariaCost }) => {
+    async ({ route, visibleLabel, detailedLabel }) => {
       const element = await mountUsagePanel(
         usage({
           usageRoute: route,
@@ -93,7 +93,25 @@ describe('usage-panel route badges', () => {
       const text = panelText(element);
       expect(text).toContain('$0.123');
       expect(text).toContain(visibleLabel);
-      expect(usageAriaLabel(element)).toContain(ariaCost);
+      expect(text).not.toContain(detailedLabel);
+      expect(usageAriaLabel(element)).toContain(`$0.123 via ${detailedLabel}`);
     },
   );
+
+  it('keeps the route badge intact while the summary can shrink', async () => {
+    const element = await mountUsagePanel(usage({ usageRoute: 'api-key' }));
+    const styles = (element.constructor as typeof UsagePanel).elementStyles
+      .flatMap((style) =>
+        'cssText' in style
+          ? style.cssText
+          : [...style.cssRules].map((rule) => rule.cssText),
+      )
+      .join('\n');
+
+    expect(styles).toMatch(
+      /\.run-summary__route\s*{[^}]*white-space:\s*nowrap/s,
+    );
+    expect(styles).toMatch(/\.run-summary\s*{[^}]*min-width:\s*0/s);
+    expect(styles).toMatch(/\.run-summary__value\s*{[^}]*min-width:\s*0/s);
+  });
 });


### PR DESCRIPTION
## Summary
- add canonical compact model-access labels, `Included` and `API keys`, alongside detailed shared copy
- use the compact labels in extension, desktop, and TUI status surfaces while preserving detailed accessibility and command copy
- keep route badges intact under narrow reflow without blocking surrounding summary layout

## Verification
- 140 focused tests passed
- full test suite passed: 8,834 tests, 5 skipped
- 4 focused TUI PTY scenarios passed
- workspace, test-kernel, extension, and CLI typechecks passed
- extension/webview build, lint, Prettier, and `git diff --check` passed
- simplifier removed duplicated test copy
- final independent review found no correctness or accessibility issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing label and layout changes only; detailed copy and accessibility strings are preserved. No auth, billing, or routing logic changes.
> 
> **Overview**
> Introduces shared **compact** payment labels (`Included`, `API keys`) alongside existing detailed copy in `modelAccess`, and wires them through narrow UI instead of ad hoc shortening.
> 
> The CLI status bar and `shortCliModelAccessRoute` now show those compact strings for included and personal routes; the extension usage footer shows `compactLabel` on route badges while **aria** labels still use the full `label` text. Layout tweaks (`nowrap` on the route badge, `min-width: 0` on the summary strip) keep badges readable when the footer reflows.
> 
> TUI harness expectations and unit tests were updated to match the new strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1784577fa0ec066f0dc4621f3d96c7bc90d047d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->