### PR TITLE
Distinguish active and stopped stream rows

### DIFF
--- a/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
@@ -20,37 +20,39 @@ export const streamTabStyles = css`
     min-width: 0;
     max-width: 100%;
     gap: var(--wa-space-3xs);
-    border-inline-start: var(--border-medium) solid transparent;
+    border-inline-start: var(--border-medium) solid
+      var(--stream-status-rail-color, var(--stream-status-color, transparent));
     box-sizing: border-box;
     overflow: hidden;
   }
 
   .tab-container.status-running {
-    border-inline-start-color: var(--color-success);
+    --stream-status-color: var(--color-success);
   }
 
   .tab-container.status-error,
   .tab-container.status-failed {
-    border-inline-start-color: var(--color-error);
+    --stream-status-color: var(--color-error);
   }
 
   .tab-container.status-waiting,
   .tab-container.status-resuming {
-    border-inline-start-color: var(--wa-color-text-link);
+    --stream-status-color: var(--wa-color-text-link);
+  }
+
+  .tab-container.status-initializing,
+  .tab-container.status-starting {
+    --stream-status-color: var(--color-warning);
   }
 
   /* Finished states (stopped/completed/cancelled/ready) keep the
      transparent default: the rail only lights up while something is
      happening or needs attention. */
 
-  .tab-container.status-initializing,
-  .tab-container.status-starting {
-    border-inline-start-color: var(--color-warning);
-  }
-
   /* Pending approval — solid orange start rail. */
   .tab-container.has-pending-approval {
-    border-inline-start-color: var(--wa-color-chart-orange, #d18616);
+    --stream-status-color: var(--color-warning);
+    --stream-status-rail-color: var(--wa-color-chart-orange, #d18616);
   }
 
   .tab {
@@ -85,13 +87,34 @@ export const streamTabStyles = css`
     text-overflow: ellipsis;
   }
 
-  /* Shape half of the status cue — border-left carries the hue. Renders in
-     the row's own foreground so it stays legible on the selection background
-     and adds no new color pair to verify. No opacity fade: this is the only
-     non-color signal the status has, so it is information, not decoration. */
-  .tab-status-icon {
+  /* The label and glyph are redundant non-color cues. The glyph uses the
+     semantic foreground while the text keeps normal-text contrast; selection
+     overrides both below so row hierarchy remains stronger than lifecycle. */
+  .tab-status {
+    display: inline-flex;
+    align-items: center;
     flex-shrink: 0;
+    gap: var(--wa-space-3xs);
+    max-width: 50%;
+    overflow: hidden;
+    color: var(--wa-color-text-normal);
     font-size: var(--font-size-xs);
+    line-height: var(--line-height-tight);
+    white-space: nowrap;
+  }
+
+  .tab-status-icon {
+    display: inline-flex;
+    flex-shrink: 0;
+    inline-size: 1em;
+    min-inline-size: 1em;
+    block-size: 1em;
+    color: var(--stream-status-color, var(--color-text-muted));
+  }
+
+  .tab-status-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .tab-meta {
@@ -182,6 +205,21 @@ export const streamTabStyles = css`
     color: var(--wa-color-list-active-fg, var(--wa-color-text-normal));
   }
 
+  /* Selection is the primary row state. Keep the lifecycle rail present, but
+     neutralize its hue against the selected surface. */
+  .tab-container.is-active:is(
+      .status-running,
+      .status-waiting,
+      .status-resuming,
+      .status-initializing,
+      .status-starting,
+      .status-failed,
+      .status-error,
+      .has-pending-approval
+    ) {
+    --stream-status-rail-color: currentColor;
+  }
+
   /*
    * Destructive-action cue on hover: a color flip only, no hover box — the
    * row's own hover background already carries the affordance. The descendant
@@ -210,13 +248,23 @@ export const streamTabStyles = css`
      sub-minimum hit area back on the layout that most needs a reliable one. */
 
   .tab-container.is-compact .tab-header {
-    gap: var(--wa-space-3xs);
+    justify-content: center;
+    gap: 0;
   }
 
-  .compact-subagent-hint {
-    font-size: var(--font-size-xs);
-    color: var(--color-text-muted);
-    flex-shrink: 0;
+  /* The 48px rail reserves its remaining select width for lifecycle state.
+     The accessible button name retains the title and child count, but neither
+     can shrink or clip the status glyph at 200% zoom. */
+  .tab-container.is-compact .tab-title,
+  .tab-container.is-compact .tab-status-label {
+    display: none;
+  }
+
+  .tab-container.is-compact .tab-status {
+    inline-size: 1em;
+    min-inline-size: 1em;
+    max-width: none;
+    overflow: visible;
   }
 
   .nested-stream-icon {
@@ -287,5 +335,53 @@ export const streamTabStyles = css`
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  @media (forced-colors: active) {
+    .tab-container:is(
+      .status-running,
+      .status-waiting,
+      .status-resuming,
+      .status-initializing,
+      .status-starting,
+      .has-pending-approval
+    ) {
+      --stream-status-color: Highlight;
+      --stream-status-rail-color: Highlight;
+    }
+
+    .tab-container.status-failed,
+    .tab-container.status-error {
+      --stream-status-color: CanvasText;
+      --stream-status-rail-color: CanvasText;
+    }
+
+    .tab-container:is(.status-completed, .status-cancelled, .status-ready) {
+      --stream-status-color: GrayText;
+    }
+
+    /* System selection colors override authored status hues. The focused
+       button keeps its native forced-color outline. */
+    .tab-container.is-active {
+      background-color: Highlight;
+      color: HighlightText;
+    }
+
+    .tab-container.is-active:is(
+        .status-running,
+        .status-waiting,
+        .status-resuming,
+        .status-initializing,
+        .status-starting,
+        .status-failed,
+        .status-error,
+        .has-pending-approval
+      ) {
+      --stream-status-rail-color: HighlightText;
+    }
+
+    .tab-container.is-active * {
+      color: HighlightText;
+    }
   }
 `;

--- a/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
@@ -55,6 +55,12 @@ export const streamTabStyles = css`
     --stream-status-rail-color: var(--wa-color-chart-orange, #d18616);
   }
 
+  .tab-select-tooltip-anchor {
+    flex: 1;
+    display: flex;
+    min-width: 0;
+  }
+
   .tab {
     flex: 1;
     display: flex;
@@ -243,8 +249,8 @@ export const streamTabStyles = css`
     padding: var(--wa-space-3xs) var(--wa-space-3xs);
   }
 
-  /* No compact override for .tab-delete: the narrow rail is 48px wide, which
-     still fits the 24px target, and shrinking it there would put the same
+  /* No compact override for .tab-delete: even the narrow rail's 48px minimum
+     fits the 24px target, and shrinking it there would put the same
      sub-minimum hit area back on the layout that most needs a reliable one. */
 
   .tab-container.is-compact .tab-header {
@@ -252,9 +258,9 @@ export const streamTabStyles = css`
     gap: 0;
   }
 
-  /* The 48px rail reserves its remaining select width for lifecycle state.
-     The accessible button name retains the title and child count, but neither
-     can shrink or clip the status glyph at 200% zoom. */
+  /* The compact rail reserves its remaining select width for lifecycle state.
+     The accessible button name and visual tooltip retain the title, while the
+     hidden title cannot shrink or clip the status glyph. */
   .tab-container.is-compact .tab-title,
   .tab-container.is-compact .tab-status-label {
     display: none;
@@ -358,6 +364,7 @@ export const streamTabStyles = css`
 
     .tab-container:is(.status-completed, .status-cancelled, .status-ready) {
       --stream-status-color: GrayText;
+      --stream-status-rail-color: transparent;
     }
 
     /* System selection colors override authored status hues. The focused

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -241,78 +241,89 @@ class StreamTab extends LitElement {
                 >`
             : nothing
         }
-        <button
-          id="stream-tab-select-button"
-          class="tab"
-          data-stream=${stream.name}
-          data-action="select"
-          aria-label=${compactSelectLabel}
+        <div
+          id="stream-tab-select-tooltip-anchor"
+          class="tab-select-tooltip-anchor"
         >
-          <div class="tab-header">
-            <span id="stream-tab-title" class="tab-title"
-              >${
-                stream.parentStreamId
-                  ? waIcon('chevron-right', { className: 'nested-stream-icon' })
-                  : nothing
-              }${streamTitle}</span
-            >
-            <span class="tab-status" aria-hidden="true">
-              ${
-                statusGlyph
-                  ? waIcon(statusGlyph, { className: 'tab-status-icon' })
-                  : nothing
-              }
-              <span class="tab-status-label">${visibleStatusLabel}</span>
-            </span>
-          </div>
-          ${
-            this.compact
-              ? nothing
-              : html`
-                  <div id="stream-tab-meta" class="tab-meta">
-                    ${
-                      metaAgentName
-                        ? html`<span class="agent-name">${metaAgentName}</span>`
-                        : nothing
-                    }
-                    ${
-                      stream.worktree
-                        ? html`<worktree-chip
-                            .info=${stream.worktree}
-                          ></worktree-chip>`
-                        : nothing
-                    }
-                    ${
-                      this.lastTimestamp
-                        ? html`<wa-relative-time
-                            class="last-active"
-                            .date=${new Date(this.lastTimestamp)}
-                            format="narrow"
-                            sync
-                          ></wa-relative-time>`
-                        : nothing
-                    }
-                    <span class="model"
-                      >${
-                        stream.identity?.kind === 'agent'
-                          ? (stream.modelLabel ?? stream.model ?? '')
-                          : ''
-                      }</span
-                    >
-                    ${waIcon(streamDecorator.icon, { id: 'stream-tab-kind', className: 'stream-kind' })}
-                    ${when(
-                      stream.isRemote,
-                      () => html`
-                        ${waIcon(AGENT_DECORATORS.properties.remote.icon, { id: 'stream-tab-remote', className: 'remote-agent' })}
-                      `,
-                    )}
-                  </div>
-                `
-          }
-        </button>
+          <button
+            id="stream-tab-select-button"
+            class="tab"
+            data-stream=${stream.name}
+            data-action="select"
+            aria-label=${compactSelectLabel}
+          >
+            <div class="tab-header">
+              <span id="stream-tab-title" class="tab-title"
+                >${
+                  stream.parentStreamId
+                    ? waIcon('chevron-right', {
+                        className: 'nested-stream-icon',
+                      })
+                    : nothing
+                }${streamTitle}</span
+              >
+              <span class="tab-status" aria-hidden="true">
+                ${
+                  statusGlyph
+                    ? waIcon(statusGlyph, { className: 'tab-status-icon' })
+                    : nothing
+                }
+                <span class="tab-status-label">${visibleStatusLabel}</span>
+              </span>
+            </div>
+            ${
+              this.compact
+                ? nothing
+                : html`
+                    <div id="stream-tab-meta" class="tab-meta">
+                      ${
+                        metaAgentName
+                          ? html`<span class="agent-name"
+                              >${metaAgentName}</span
+                            >`
+                          : nothing
+                      }
+                      ${
+                        stream.worktree
+                          ? html`<worktree-chip
+                              .info=${stream.worktree}
+                            ></worktree-chip>`
+                          : nothing
+                      }
+                      ${
+                        this.lastTimestamp
+                          ? html`<wa-relative-time
+                              class="last-active"
+                              .date=${new Date(this.lastTimestamp)}
+                              format="narrow"
+                              sync
+                            ></wa-relative-time>`
+                          : nothing
+                      }
+                      <span class="model"
+                        >${
+                          stream.identity?.kind === 'agent'
+                            ? (stream.modelLabel ?? stream.model ?? '')
+                            : ''
+                        }</span
+                      >
+                      ${waIcon(streamDecorator.icon, { id: 'stream-tab-kind', className: 'stream-kind' })}
+                      ${when(
+                        stream.isRemote,
+                        () => html`
+                          ${waIcon(AGENT_DECORATORS.properties.remote.icon, { id: 'stream-tab-remote', className: 'remote-agent' })}
+                        `,
+                      )}
+                    </div>
+                  `
+            }
+          </button>
+        </div>
         ${
           this.compact
-            ? nothing
+            ? html`<wa-tooltip for="stream-tab-select-tooltip-anchor"
+                >${streamTitle}</wa-tooltip
+              >`
             : html`<wa-tooltip for="stream-tab-kind"
                   >${
                     // Only agent runs have an execution-mode category; other

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -55,8 +55,6 @@ import {
 } from '../utils';
 import {
   computeStreamTreeProjection,
-  getStreamBranchActivity,
-  type StreamBranchActivity,
   type StreamTreeExpansionOverride,
 } from '../streamTree';
 import type { StreamState } from '../store';
@@ -64,23 +62,16 @@ import type { StreamState } from '../store';
 // Web Awesome native components
 import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
-/**
- * Non-color cue for the states that light the row's status rail. The rail's
- * `border-left-color` alone put running/failed/waiting/starting apart by hue
- * only, which is no distinction at all for a red-green colorblind reader and
- * left "blocked on your approval" — the one state that wants you now —
- * carrying no shape. Finished states (completed/cancelled/ready) leave the
- * rail transparent and get no glyph, so a settled rail stays quiet.
- *
- * Rendered in `currentColor`: the border carries hue for fast scanning, the
- * glyph carries shape, and neither introduces a new foreground to contrast-check.
- */
-const STATUS_ICONS: Partial<Record<StreamStatusDisplayKey, TeXRAIconName>> = {
+/** Shape cue paired with the visible status label on every canonical state. */
+const STATUS_ICONS: Record<StreamStatusDisplayKey, TeXRAIconName> = {
   [STREAM_SUBSTATE.STARTING]: 'spinner',
   [STREAM_SUBSTATE.RESUMING]: 'spinner',
   [STREAM_PHASE.RUNNING]: 'play',
   [STREAM_PHASE.WAITING]: 'clock',
+  [STREAM_PHASE.COMPLETED]: 'circle-check',
   [STREAM_PHASE.FAILED]: 'circle-exclamation',
+  [STREAM_PHASE.CANCELLED]: 'circle-stop',
+  ready: 'circle',
 };
 
 function buildTooltip(
@@ -155,30 +146,14 @@ class StreamTab extends LitElement {
     readonly icon: TeXRAIconName;
     readonly label: string;
   } = getAgentCategoryDecorator('toolUse');
-  private _tooltip = '';
 
   protected override willUpdate(changed: PropertyValues): void {
-    if (
-      !changed.has('info') &&
-      !changed.has('status') &&
-      !changed.has('substate') &&
-      !changed.has('lastTimestamp')
-    )
-      return;
-    if (changed.has('info')) {
-      const identityKind = this.info.identity?.kind;
-      this._streamDecorator =
-        identityKind === 'multiAgentWorkflow' || identityKind === 'process'
-          ? AGENT_DECORATORS.streamKinds[identityKind]
-          : getAgentCategoryDecorator(this.info.agentCategory);
-    }
-    const status = this.status || DEFAULT_STREAM_METADATA_STATUS;
-    const statusLabel =
-      formatStreamStatusLabel(status, {
-        style: 'progressHeader',
-        ...(this.substate ? { substate: this.substate } : {}),
-      }) ?? status;
-    this._tooltip = buildTooltip(this.info, this.lastTimestamp, statusLabel);
+    if (!changed.has('info')) return;
+    const identityKind = this.info.identity?.kind;
+    this._streamDecorator =
+      identityKind === 'multiAgentWorkflow' || identityKind === 'process'
+        ? AGENT_DECORATORS.streamKinds[identityKind]
+        : getAgentCategoryDecorator(this.info.agentCategory);
   }
 
   override render(): TemplateResult {
@@ -186,13 +161,22 @@ class StreamTab extends LitElement {
     const status = this.status || DEFAULT_STREAM_METADATA_STATUS;
     const displayKey = streamStatusDisplayKey(status, this.substate);
     const statusKey = displayKey ?? status;
+    const lifecycleStatusLabel =
+      formatStreamStatusLabel(status, {
+        style: 'progressHeader',
+        ...(this.substate ? { substate: this.substate } : {}),
+      }) ?? status;
     // Pending approval outranks the lifecycle phase: a run held at the
     // approval gate is still "running", and the gate is what you act on.
-    const phaseGlyph =
-      displayKey === undefined ? undefined : STATUS_ICONS[displayKey];
-    const statusGlyph: TeXRAIconName | undefined = this.hasPendingApproval
+    const statusGlyph = this.hasPendingApproval
       ? 'triangle-exclamation'
-      : phaseGlyph;
+      : displayKey && STATUS_ICONS[displayKey];
+    const visibleStatusLabel = this.hasPendingApproval
+      ? 'Approval'
+      : lifecycleStatusLabel;
+    const accessibleStatusLabel = this.hasPendingApproval
+      ? 'Approval required'
+      : lifecycleStatusLabel;
     // Also names the delete button: one "Delete" repeated down the rail tells
     // a screen-reader user nothing about which session it destroys.
     const streamTitle = stream.description || streamDisplayLabel(stream);
@@ -209,6 +193,14 @@ class StreamTab extends LitElement {
     const childToggleLabel = this.expanded
       ? BACKGROUND_TASK.collapseAction
       : childCountLabel;
+    const selectLabel = buildTooltip(
+      stream,
+      this.lastTimestamp,
+      accessibleStatusLabel,
+    );
+    const compactSelectLabel = showCompactChildHint
+      ? `${selectLabel}\n${childCountLabel}`
+      : selectLabel;
     // RunIdentity is the declared authority for what owns the stream, shown
     // in the meta line so a glance at the row says who ran it. Only when the
     // title is the AI one-liner (`stream.description`) — otherwise the title
@@ -254,14 +246,9 @@ class StreamTab extends LitElement {
           class="tab"
           data-stream=${stream.name}
           data-action="select"
-          aria-label=${this._tooltip}
+          aria-label=${compactSelectLabel}
         >
           <div class="tab-header">
-            ${
-              statusGlyph
-                ? waIcon(statusGlyph, { className: 'tab-status-icon' })
-                : nothing
-            }
             <span id="stream-tab-title" class="tab-title"
               >${
                 stream.parentStreamId
@@ -269,15 +256,14 @@ class StreamTab extends LitElement {
                   : nothing
               }${streamTitle}</span
             >
-            ${
-              showCompactChildHint
-                ? waIcon('chevron-right', {
-                    id: 'stream-tab-compact-children',
-                    className: 'compact-subagent-hint',
-                    label: childCountLabel,
-                  })
-                : nothing
-            }
+            <span class="tab-status" aria-hidden="true">
+              ${
+                statusGlyph
+                  ? waIcon(statusGlyph, { className: 'tab-status-icon' })
+                  : nothing
+              }
+              <span class="tab-status-label">${visibleStatusLabel}</span>
+            </span>
           </div>
           ${
             this.compact
@@ -324,13 +310,6 @@ class StreamTab extends LitElement {
                 `
           }
         </button>
-        ${
-          showCompactChildHint
-            ? html`<wa-tooltip for="stream-tab-compact-children"
-                >${childCountLabel}</wa-tooltip
-              >`
-            : nothing
-        }
         ${
           this.compact
             ? nothing
@@ -410,8 +389,6 @@ export class StreamTabs extends LitElement {
    * `manuallyCollapsed` + `finishedCollapseHandled` sets.
    */
   private userOverride: Map<string, StreamTreeExpansionOverride> = new Map();
-  private branchActivityByStream: Map<StreamTabId, StreamBranchActivity> =
-    new Map();
 
   protected override willUpdate(changed: PropertyValues): void {
     if (!changed.has('childStreamsByParent') && !changed.has('streamStates'))
@@ -423,7 +400,6 @@ export class StreamTabs extends LitElement {
       userOverrides: this.userOverride,
     });
 
-    this.branchActivityByStream = projection.branchActivityByStream;
     this.userOverride = projection.userOverrides;
     if (!setsEqual(projection.expandedParents, this.expandedParents)) {
       this.expandedParents = projection.expandedParents;
@@ -460,21 +436,9 @@ export class StreamTabs extends LitElement {
       childCount > 0 &&
       this.expandedParents.has(stream.name);
     const streamState = this.streamStates.get(stream.name);
-    const isFinished =
-      stream.parentStreamId != null &&
-      getStreamBranchActivity(
-        {
-          streamStates: this.streamStates,
-          childStreamsByParent: this.childStreamsByParent,
-        },
-        stream.name,
-        options.visited,
-        this.branchActivityByStream,
-      ) === 'finished';
 
     return html`
       <stream-tab
-        class=${classMap({ 'is-finished': isFinished })}
         .info=${stream}
         .compact=${options.compact}
         .status=${streamState?.status ?? DEFAULT_STREAM_METADATA_STATUS}

--- a/packages/extension/src/progressView/frontend/components/StreamTabsContainer.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabsContainer.styles.ts
@@ -55,13 +55,4 @@ export const streamTabsContainerStyles = css`
     max-width: 100%;
     overflow: hidden;
   }
-
-  .child-streams stream-tab {
-    opacity: 1;
-    transition: opacity var(--transition-fast);
-  }
-
-  .child-streams stream-tab.is-finished {
-    opacity: var(--opacity-subtle, 0.5);
-  }
 `;

--- a/scripts/smoke-webviews-electron-runner.cjs
+++ b/scripts/smoke-webviews-electron-runner.cjs
@@ -595,8 +595,146 @@ async function assertToolEditApprovalLayout(window, view) {
   );
 }
 
-async function assertViewSpecificLayout(window, view) {
+async function assertCompactStreamStatusGeometry(window, view) {
+  return window.webContents.executeJavaScript(
+    `
+      (async () => {
+        function findDeep(selector, root = document) {
+          const direct = root.querySelector?.(selector);
+          if (direct) return direct;
+          for (const element of root.querySelectorAll?.('*') ?? []) {
+            const found = element.shadowRoot ? findDeep(selector, element.shadowRoot) : null;
+            if (found) return found;
+          }
+          return null;
+        }
+
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+        const tabs = findDeep('stream-tabs');
+        const row = tabs?.shadowRoot?.querySelector('stream-tab');
+        if (row?.updateComplete) await row.updateComplete;
+        const select = row?.shadowRoot?.querySelector('#stream-tab-select-button');
+        const glyph = row?.shadowRoot?.querySelector('.tab-status-icon');
+        const title = row?.shadowRoot?.querySelector('.tab-title');
+        const status = row?.shadowRoot?.querySelector('.tab-status');
+        const childHint = row?.shadowRoot?.querySelector('.compact-subagent-hint');
+        const deleteButton = row?.shadowRoot?.querySelector('.tab-delete');
+        if (glyph?.updateComplete) await glyph.updateComplete;
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+        const missing = [
+          ['stream-tabs', tabs],
+          ['stream-tab', row],
+          ['select target', select],
+          ['lifecycle glyph', glyph],
+          ['title', title],
+          ['status wrapper', status],
+          ['delete target', deleteButton],
+        ]
+          .filter(([, element]) => !element)
+          .map(([label]) => label);
+        if (missing.length > 0) {
+          throw new Error(
+            \`${view.name} missing compact status elements: \${missing.join(', ')}\`,
+          );
+        }
+
+        const railRect = tabs.getBoundingClientRect();
+        const selectRect = select.getBoundingClientRect();
+        const glyphRect = glyph.getBoundingClientRect();
+        const deleteRect = deleteButton.getBoundingClientRect();
+        const statusStyle = getComputedStyle(status);
+        const titleStyle = getComputedStyle(title);
+        const epsilon = 0.5;
+
+        if (!tabs.compact) {
+          throw new Error(\`${view.name} did not activate compact stream rows.\`);
+        }
+        if (Math.abs(railRect.width - 48) > 1) {
+          throw new Error(
+            \`${view.name} compact rail is not 48px: \${railRect.width.toFixed(2)}px\`,
+          );
+        }
+        if (glyphRect.width <= 0.5 || glyphRect.height <= 0.5) {
+          throw new Error(
+            \`${view.name} lifecycle glyph collapsed: \${glyphRect.width.toFixed(2)}x\${glyphRect.height.toFixed(2)}\`,
+          );
+        }
+        if (
+          glyphRect.left < selectRect.left - epsilon ||
+          glyphRect.right > selectRect.right + epsilon ||
+          glyphRect.top < selectRect.top - epsilon ||
+          glyphRect.bottom > selectRect.bottom + epsilon
+        ) {
+          throw new Error(
+            \`${view.name} lifecycle glyph escaped select target: glyph=[\${glyphRect.left.toFixed(2)}, \${glyphRect.top.toFixed(2)}, \${glyphRect.right.toFixed(2)}, \${glyphRect.bottom.toFixed(2)}] select=[\${selectRect.left.toFixed(2)}, \${selectRect.top.toFixed(2)}, \${selectRect.right.toFixed(2)}, \${selectRect.bottom.toFixed(2)}]\`,
+          );
+        }
+        if (deleteRect.width < 24 || deleteRect.height < 24) {
+          throw new Error(
+            \`${view.name} compact delete target shrank: \${deleteRect.width.toFixed(2)}x\${deleteRect.height.toFixed(2)}\`,
+          );
+        }
+        if (titleStyle.display !== 'none') {
+          throw new Error(\`${view.name} compact title still consumes layout width.\`);
+        }
+        if (statusStyle.maxWidth !== 'none' || statusStyle.overflow !== 'visible') {
+          throw new Error(
+            \`${view.name} compact status remains capped or clipped: max-width=\${statusStyle.maxWidth} overflow=\${statusStyle.overflow}\`,
+          );
+        }
+        if (childHint !== null) {
+          throw new Error(\`${view.name} compact child hint still displaces lifecycle status.\`);
+        }
+        if (!select.getAttribute('aria-label')?.includes('1 background task')) {
+          throw new Error(\`${view.name} compact child count is missing from the accessible name.\`);
+        }
+
+        const devicePixelRatio = window.devicePixelRatio;
+        const deviceGlyphRect = {
+          bottom: glyphRect.bottom * devicePixelRatio,
+          left: glyphRect.left * devicePixelRatio,
+          right: glyphRect.right * devicePixelRatio,
+          top: glyphRect.top * devicePixelRatio,
+        };
+        const deviceSelectRect = {
+          bottom: selectRect.bottom * devicePixelRatio,
+          left: selectRect.left * devicePixelRatio,
+          right: selectRect.right * devicePixelRatio,
+          top: selectRect.top * devicePixelRatio,
+        };
+        const deviceEpsilon = 1;
+        if (
+          deviceGlyphRect.left < deviceSelectRect.left - deviceEpsilon ||
+          deviceGlyphRect.right > deviceSelectRect.right + deviceEpsilon ||
+          deviceGlyphRect.top < deviceSelectRect.top - deviceEpsilon ||
+          deviceGlyphRect.bottom > deviceSelectRect.bottom + deviceEpsilon
+        ) {
+          throw new Error(\`${view.name} lifecycle glyph escaped the select target in device pixels.\`);
+        }
+
+        return {
+          deleteHeight: deleteRect.height,
+          deleteWidth: deleteRect.width,
+          deviceGlyphRect,
+          devicePixelRatio,
+          deviceSelectRect,
+          glyphHeight: glyphRect.height,
+          glyphWidth: glyphRect.width,
+          railWidth: railRect.width,
+          selectHeight: selectRect.height,
+          selectWidth: selectRect.width,
+        };
+      })();
+    `,
+    true,
+  );
+}
+
+async function assertViewSpecificLayout(window, view, evidence) {
   const assertions = Array.isArray(view.assertions) ? view.assertions : [];
+  let compactStatusGeometry = null;
   for (const assertion of assertions) {
     switch (assertion) {
       case 'progressComposerLayout': {
@@ -617,17 +755,41 @@ async function assertViewSpecificLayout(window, view) {
         );
         break;
       }
+      case 'compactStreamStatusGeometry': {
+        compactStatusGeometry = await assertCompactStreamStatusGeometry(
+          window,
+          view,
+        );
+        console.log(
+          `Verified ${view.name} compact CSS and device-pixel geometry: ${JSON.stringify(
+            {
+              ...compactStatusGeometry,
+              electronZoomFactor: evidence.electronZoomFactor,
+            },
+          )}`,
+        );
+        break;
+      }
       default:
         throw new Error(`Unknown webview smoke assertion: ${assertion}`);
     }
   }
+  return compactStatusGeometry;
 }
 
 async function smokeView(window, view, outputDir, errors) {
   errors.length = 0;
   const viewport = view.viewport ?? DEFAULT_VIEWPORT;
+  const zoomFactor = view.zoomFactor ?? 1;
   window.setBounds({ width: viewport.width, height: viewport.height });
   await window.loadFile(view.htmlPath);
+  window.webContents.setZoomFactor(zoomFactor);
+  const electronZoomFactor = window.webContents.getZoomFactor();
+  if (Math.abs(electronZoomFactor - zoomFactor) > 0.01) {
+    throw new Error(
+      `${view.name} zoom factor did not apply: actual=${electronZoomFactor} expected=${zoomFactor}`,
+    );
+  }
   let result;
   try {
     result = await waitForRenderedElement(window, view);
@@ -652,10 +814,45 @@ async function smokeView(window, view, outputDir, errors) {
   }
   await assertWebviewRuntime(window);
   const fixtureResult = await applyViewFixture(window, view);
-  await assertViewSpecificLayout(window, view);
+  const compactStatusGeometry = await assertViewSpecificLayout(window, view, {
+    electronZoomFactor,
+  });
 
   const screenshotPath = path.join(outputDir, `${view.name}.png`);
   const image = await window.webContents.capturePage();
+  if (compactStatusGeometry) {
+    const screenshotScaleFactors = image.getScaleFactors();
+    if (screenshotScaleFactors.length === 0) {
+      throw new Error(
+        `${view.name} screenshot has no device-scale representation.`,
+      );
+    }
+    const screenshotScaleFactor = Math.max(...screenshotScaleFactors);
+    const screenshotPixelSize = image.getSize(screenshotScaleFactor);
+    const expectedPixelSize = {
+      height: Math.round(
+        result.height * compactStatusGeometry.devicePixelRatio,
+      ),
+      width: Math.round(result.width * compactStatusGeometry.devicePixelRatio),
+    };
+    if (
+      Math.abs(screenshotPixelSize.width - expectedPixelSize.width) > 1 ||
+      Math.abs(screenshotPixelSize.height - expectedPixelSize.height) > 1
+    ) {
+      throw new Error(
+        `${view.name} screenshot pixels do not match the renderer device scale: actual=${screenshotPixelSize.width}x${screenshotPixelSize.height} expected=${expectedPixelSize.width}x${expectedPixelSize.height}`,
+      );
+    }
+    console.log(
+      `Verified ${view.name} screenshot device scale: ${JSON.stringify({
+        cssSize: { height: result.height, width: result.width },
+        devicePixelRatio: compactStatusGeometry.devicePixelRatio,
+        electronZoomFactor,
+        screenshotPixelSize,
+        screenshotScaleFactor,
+      })}`,
+    );
+  }
   await writeFile(screenshotPath, image.toPNG());
   console.log(
     `Rendered ${view.name}: ${result.width}x${result.height}, screenshot ${screenshotPath}${

--- a/scripts/smoke-webviews-electron-runner.cjs
+++ b/scripts/smoke-webviews-electron-runner.cjs
@@ -595,7 +595,7 @@ async function assertToolEditApprovalLayout(window, view) {
   );
 }
 
-async function assertCompactStreamStatusGeometry(window, view) {
+async function assertCompactStreamStatusLayout(window, view) {
   return window.webContents.executeJavaScript(
     `
       (async () => {
@@ -618,9 +618,16 @@ async function assertCompactStreamStatusGeometry(window, view) {
         const glyph = row?.shadowRoot?.querySelector('.tab-status-icon');
         const title = row?.shadowRoot?.querySelector('.tab-title');
         const status = row?.shadowRoot?.querySelector('.tab-status');
+        const tooltipAnchor = row?.shadowRoot?.querySelector(
+          '#stream-tab-select-tooltip-anchor',
+        );
+        const identityTooltip = row?.shadowRoot?.querySelector(
+          'wa-tooltip[for="stream-tab-select-tooltip-anchor"]',
+        );
         const childHint = row?.shadowRoot?.querySelector('.compact-subagent-hint');
         const deleteButton = row?.shadowRoot?.querySelector('.tab-delete');
         if (glyph?.updateComplete) await glyph.updateComplete;
+        if (identityTooltip?.updateComplete) await identityTooltip.updateComplete;
         await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 
         const missing = [
@@ -630,6 +637,8 @@ async function assertCompactStreamStatusGeometry(window, view) {
           ['lifecycle glyph', glyph],
           ['title', title],
           ['status wrapper', status],
+          ['tooltip anchor', tooltipAnchor],
+          ['identity tooltip', identityTooltip],
           ['delete target', deleteButton],
         ]
           .filter(([, element]) => !element)
@@ -640,6 +649,7 @@ async function assertCompactStreamStatusGeometry(window, view) {
           );
         }
 
+        const viewportWidth = document.documentElement.clientWidth;
         const railRect = tabs.getBoundingClientRect();
         const selectRect = select.getBoundingClientRect();
         const glyphRect = glyph.getBoundingClientRect();
@@ -648,12 +658,14 @@ async function assertCompactStreamStatusGeometry(window, view) {
         const titleStyle = getComputedStyle(title);
         const epsilon = 0.5;
 
-        if (!tabs.compact) {
-          throw new Error(\`${view.name} did not activate compact stream rows.\`);
-        }
-        if (Math.abs(railRect.width - 48) > 1) {
+        if (viewportWidth >= 500 || !tabs.compact) {
           throw new Error(
-            \`${view.name} compact rail is not 48px: \${railRect.width.toFixed(2)}px\`,
+            \`${view.name} did not activate narrow compact rows: viewport=\${viewportWidth}px compact=\${tabs.compact}\`,
+          );
+        }
+        if (railRect.width < 48) {
+          throw new Error(
+            \`${view.name} compact rail fell below its 48px minimum: \${railRect.width.toFixed(2)}px\`,
           );
         }
         if (glyphRect.width <= 0.5 || glyphRect.height <= 0.5) {
@@ -687,44 +699,32 @@ async function assertCompactStreamStatusGeometry(window, view) {
         if (childHint !== null) {
           throw new Error(\`${view.name} compact child hint still displaces lifecycle status.\`);
         }
-        if (!select.getAttribute('aria-label')?.includes('1 background task')) {
+        const selectLabel = select.getAttribute('aria-label');
+        if (!selectLabel?.includes('1 background task')) {
           throw new Error(\`${view.name} compact child count is missing from the accessible name.\`);
         }
-
-        const devicePixelRatio = window.devicePixelRatio;
-        const deviceGlyphRect = {
-          bottom: glyphRect.bottom * devicePixelRatio,
-          left: glyphRect.left * devicePixelRatio,
-          right: glyphRect.right * devicePixelRatio,
-          top: glyphRect.top * devicePixelRatio,
-        };
-        const deviceSelectRect = {
-          bottom: selectRect.bottom * devicePixelRatio,
-          left: selectRect.left * devicePixelRatio,
-          right: selectRect.right * devicePixelRatio,
-          top: selectRect.top * devicePixelRatio,
-        };
-        const deviceEpsilon = 1;
+        if (select.hasAttribute('aria-labelledby')) {
+          throw new Error(\`${view.name} compact tooltip overrides the select target's accessible name.\`);
+        }
         if (
-          deviceGlyphRect.left < deviceSelectRect.left - deviceEpsilon ||
-          deviceGlyphRect.right > deviceSelectRect.right + deviceEpsilon ||
-          deviceGlyphRect.top < deviceSelectRect.top - deviceEpsilon ||
-          deviceGlyphRect.bottom > deviceSelectRect.bottom + deviceEpsilon
+          !identityTooltip.id ||
+          !tooltipAnchor.getAttribute('aria-labelledby')?.split(' ').includes(identityTooltip.id)
         ) {
-          throw new Error(\`${view.name} lifecycle glyph escaped the select target in device pixels.\`);
+          throw new Error(\`${view.name} compact tooltip is not initialized on its wrapper anchor.\`);
+        }
+        if (!identityTooltip.textContent?.includes('A long compact execution title')) {
+          throw new Error(\`${view.name} compact identity tooltip does not expose the session title.\`);
         }
 
         return {
           deleteHeight: deleteRect.height,
           deleteWidth: deleteRect.width,
-          deviceGlyphRect,
-          devicePixelRatio,
-          deviceSelectRect,
           glyphHeight: glyphRect.height,
           glyphWidth: glyphRect.width,
           railWidth: railRect.width,
           selectHeight: selectRect.height,
           selectWidth: selectRect.width,
+          viewportWidth,
         };
       })();
     `,
@@ -732,9 +732,8 @@ async function assertCompactStreamStatusGeometry(window, view) {
   );
 }
 
-async function assertViewSpecificLayout(window, view, evidence) {
+async function assertViewSpecificLayout(window, view) {
   const assertions = Array.isArray(view.assertions) ? view.assertions : [];
-  let compactStatusGeometry = null;
   for (const assertion of assertions) {
     switch (assertion) {
       case 'progressComposerLayout': {
@@ -755,17 +754,11 @@ async function assertViewSpecificLayout(window, view, evidence) {
         );
         break;
       }
-      case 'compactStreamStatusGeometry': {
-        compactStatusGeometry = await assertCompactStreamStatusGeometry(
-          window,
-          view,
-        );
+      case 'compactStreamStatusLayout': {
+        const result = await assertCompactStreamStatusLayout(window, view);
         console.log(
-          `Verified ${view.name} compact CSS and device-pixel geometry: ${JSON.stringify(
-            {
-              ...compactStatusGeometry,
-              electronZoomFactor: evidence.electronZoomFactor,
-            },
+          `Verified ${view.name} compact narrow-row layout: ${JSON.stringify(
+            result,
           )}`,
         );
         break;
@@ -774,22 +767,14 @@ async function assertViewSpecificLayout(window, view, evidence) {
         throw new Error(`Unknown webview smoke assertion: ${assertion}`);
     }
   }
-  return compactStatusGeometry;
 }
 
 async function smokeView(window, view, outputDir, errors) {
   errors.length = 0;
   const viewport = view.viewport ?? DEFAULT_VIEWPORT;
-  const zoomFactor = view.zoomFactor ?? 1;
   window.setBounds({ width: viewport.width, height: viewport.height });
+  window.webContents.setZoomFactor(1);
   await window.loadFile(view.htmlPath);
-  window.webContents.setZoomFactor(zoomFactor);
-  const electronZoomFactor = window.webContents.getZoomFactor();
-  if (Math.abs(electronZoomFactor - zoomFactor) > 0.01) {
-    throw new Error(
-      `${view.name} zoom factor did not apply: actual=${electronZoomFactor} expected=${zoomFactor}`,
-    );
-  }
   let result;
   try {
     result = await waitForRenderedElement(window, view);
@@ -814,45 +799,10 @@ async function smokeView(window, view, outputDir, errors) {
   }
   await assertWebviewRuntime(window);
   const fixtureResult = await applyViewFixture(window, view);
-  const compactStatusGeometry = await assertViewSpecificLayout(window, view, {
-    electronZoomFactor,
-  });
+  await assertViewSpecificLayout(window, view);
 
   const screenshotPath = path.join(outputDir, `${view.name}.png`);
   const image = await window.webContents.capturePage();
-  if (compactStatusGeometry) {
-    const screenshotScaleFactors = image.getScaleFactors();
-    if (screenshotScaleFactors.length === 0) {
-      throw new Error(
-        `${view.name} screenshot has no device-scale representation.`,
-      );
-    }
-    const screenshotScaleFactor = Math.max(...screenshotScaleFactors);
-    const screenshotPixelSize = image.getSize(screenshotScaleFactor);
-    const expectedPixelSize = {
-      height: Math.round(
-        result.height * compactStatusGeometry.devicePixelRatio,
-      ),
-      width: Math.round(result.width * compactStatusGeometry.devicePixelRatio),
-    };
-    if (
-      Math.abs(screenshotPixelSize.width - expectedPixelSize.width) > 1 ||
-      Math.abs(screenshotPixelSize.height - expectedPixelSize.height) > 1
-    ) {
-      throw new Error(
-        `${view.name} screenshot pixels do not match the renderer device scale: actual=${screenshotPixelSize.width}x${screenshotPixelSize.height} expected=${expectedPixelSize.width}x${expectedPixelSize.height}`,
-      );
-    }
-    console.log(
-      `Verified ${view.name} screenshot device scale: ${JSON.stringify({
-        cssSize: { height: result.height, width: result.width },
-        devicePixelRatio: compactStatusGeometry.devicePixelRatio,
-        electronZoomFactor,
-        screenshotPixelSize,
-        screenshotScaleFactor,
-      })}`,
-    );
-  }
   await writeFile(screenshotPath, image.toPNG());
   console.log(
     `Rendered ${view.name}: ${result.width}x${result.height}, screenshot ${screenshotPath}${

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -155,8 +155,7 @@ const views = [
       width: 320,
       height: 600,
     },
-    zoomFactor: 2,
-    assertions: ['compactStreamStatusGeometry'],
+    assertions: ['compactStreamStatusLayout'],
     seedMessages: [
       {
         command: 'updateStreams',
@@ -398,7 +397,6 @@ async function prepareViewHtml(view) {
     seedMessages: view.seedMessages ?? [],
     assertions: view.assertions ?? [],
     viewport: view.viewport,
-    zoomFactor: view.zoomFactor,
   };
 }
 

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -148,6 +148,62 @@ const views = [
     replacements: progressViewReplacements,
   },
   {
+    name: 'progress-compact-status',
+    tagName: 'progress-app',
+    templatePath: join(extensionRoot, 'src', 'progressView', 'index.html'),
+    viewport: {
+      width: 320,
+      height: 600,
+    },
+    zoomFactor: 2,
+    assertions: ['compactStreamStatusGeometry'],
+    seedMessages: [
+      {
+        command: 'updateStreams',
+        streams: [
+          {
+            kind: 'agent',
+            name: 'compact-parent',
+            label: 'compact-parent',
+            agent: 'research',
+            agentCategory: 'toolUse',
+            creationTimestamp: 1_783_353_600_000,
+            description:
+              'A long compact execution title that must not displace status.',
+          },
+          {
+            kind: 'agent',
+            name: 'compact-child',
+            label: 'compact-child',
+            agent: 'reviewer',
+            agentCategory: 'toolUse',
+            creationTimestamp: 1_783_353_601_000,
+            parentStreamId: 'compact-parent',
+          },
+        ],
+        activeStream: 'compact-parent',
+        agentFilter: 'all',
+        streamStates: {
+          'compact-parent': {
+            kind: 'toolUse',
+            status: 'running',
+            lastTimestamp: 1_783_353_600_000,
+            subagents: [],
+            processes: [],
+          },
+          'compact-child': {
+            kind: 'toolUse',
+            status: 'waiting',
+            lastTimestamp: 1_783_353_601_000,
+            subagents: [],
+            processes: [],
+          },
+        },
+      },
+    ],
+    replacements: progressViewReplacements,
+  },
+  {
     name: 'progress-approval',
     tagName: 'progress-app',
     templatePath: join(extensionRoot, 'src', 'progressView', 'index.html'),
@@ -342,6 +398,7 @@ async function prepareViewHtml(view) {
     seedMessages: view.seedMessages ?? [],
     assertions: view.assertions ?? [],
     viewport: view.viewport,
+    zoomFactor: view.zoomFactor,
   };
 }
 

--- a/src/test-kernel/progressView/StreamTabsStatus.vitest.ts
+++ b/src/test-kernel/progressView/StreamTabsStatus.vitest.ts
@@ -226,14 +226,29 @@ describe('stream-tab lifecycle distinction', () => {
         ?.querySelector('#stream-tab-select-button')
         ?.getAttribute('aria-label'),
     ).toContain('Status: Approval required');
-    expect(
-      rows[0]?.shadowRoot
-        ?.querySelector('#stream-tab-select-button')
-        ?.getAttribute('aria-label'),
-    ).toContain('1 background task');
+    const startingSelect = rows[0]?.shadowRoot?.querySelector(
+      '#stream-tab-select-button',
+    );
     expect(
       rows[0]?.shadowRoot?.querySelector('.compact-subagent-hint'),
     ).toBeNull();
+    const identityTooltip = rows[0]?.shadowRoot?.querySelector<HTMLElement>(
+      'wa-tooltip[for="stream-tab-select-tooltip-anchor"]',
+    );
+    await (identityTooltip as HTMLElement & { updateComplete?: Promise<void> })
+      ?.updateComplete;
+    const tooltipAnchor = rows[0]?.shadowRoot?.querySelector(
+      '#stream-tab-select-tooltip-anchor',
+    );
+    expect(identityTooltip?.textContent?.trim()).toBe('starting');
+    expect(
+      tooltipAnchor?.getAttribute('aria-labelledby')?.split(/\s+/),
+    ).toContain(identityTooltip?.id);
+    expect(startingSelect?.getAttribute('aria-labelledby')).toBeNull();
+    const accessibleLabel = startingSelect?.getAttribute('aria-label');
+    expect(accessibleLabel).toContain('starting');
+    expect(accessibleLabel).toContain('Status: Initializing');
+    expect(accessibleLabel).toContain('1 background task');
     const compactStyles = styleText(rows[0]!);
     expect(compactStyles).toContain(
       '.tab-container.is-compact .tab-status-label',
@@ -261,6 +276,11 @@ describe('stream-tab lifecycle distinction', () => {
         ?.querySelector('.tab-container')
         ?.classList.contains('is-active'),
     ).toBe(false);
+    const select = rows[0]?.shadowRoot?.querySelector<HTMLElement>(
+      '#stream-tab-select-button',
+    );
+    select?.focus();
+    expect(rows[0]?.shadowRoot?.activeElement).toBe(select);
     expect(styleText(tabs)).not.toContain('stream-tab.is-finished');
   });
 
@@ -289,11 +309,26 @@ describe('stream-tab lifecycle distinction', () => {
     expect(styles).toContain('--stream-status-color: Highlight');
     expect(styles).toContain('--stream-status-color: CanvasText');
     expect(styles).toContain('--stream-status-color: GrayText');
+    expect(styles).toContain('--stream-status-rail-color: transparent');
     expect(styles).not.toContain('--stream-status-rail-color: GrayText');
+    expect(styles).toContain(
+      'var(--stream-status-rail-color, var(--stream-status-color, transparent))',
+    );
+    for (const status of [
+      'running',
+      'waiting',
+      'starting',
+      'resuming',
+      'failed',
+      'error',
+    ]) {
+      expect(styles).toContain(`.tab-container.status-${status}`);
+    }
     expect(styles).toContain('.tab-container.is-active:is(');
     expect(styles).toContain('--stream-status-rail-color: HighlightText');
     expect(styles).toContain('background-color: Highlight');
     expect(styles).toContain('color: HighlightText');
+    expect(styles).toContain('.tab-container.is-active *');
     expect(styles).not.toContain('outline: none');
     expect(
       row?.shadowRoot?.querySelector('.tab-status-label')?.textContent?.trim(),

--- a/src/test-kernel/progressView/StreamTabsStatus.vitest.ts
+++ b/src/test-kernel/progressView/StreamTabsStatus.vitest.ts
@@ -1,0 +1,302 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import type { StreamTabs } from '@progressView/frontend/components/StreamTabs';
+import type { StreamState } from '@progressView/frontend/store';
+import {
+  AgentCategory,
+  createStreamState,
+  STREAM_PHASE,
+  STREAM_STATUS,
+  STREAM_SUBSTATE,
+  type StreamLifecycleStatus,
+  type StreamTabInfo,
+} from '@shared/schemas';
+
+// Local file imports
+import {
+  mountComponent,
+  useLitComponentTestDom,
+} from '../settings/litComponentTestUtils';
+
+interface StyledElementConstructor extends CustomElementConstructor {
+  readonly elementStyles: readonly (
+    CSSStyleSheet | { readonly cssText: string }
+  )[];
+}
+
+function stream(name: string): StreamTabInfo {
+  return {
+    identity: { kind: 'agent', agent: name },
+    name,
+    label: name,
+    agentCategory: AgentCategory.ToolUse,
+    creationTimestamp: 1,
+  };
+}
+
+function streamState(status: StreamLifecycleStatus): StreamState {
+  return createStreamState(AgentCategory.ToolUse, { status });
+}
+
+function styleText(element: Element): string {
+  const constructor = element.constructor as StyledElementConstructor;
+  return constructor.elementStyles
+    .map((style) => {
+      if ('cssText' in style) return style.cssText;
+      return [...style.cssRules].map((rule) => rule.cssText).join('\n');
+    })
+    .join('\n');
+}
+
+async function mountTabs(
+  streams: StreamTabInfo[],
+  statuses: readonly StreamLifecycleStatus[],
+  activeStreamId: string | null = null,
+): Promise<StreamTabs> {
+  const streamStates = new Map(
+    streams.map((item, index) => [
+      item.name,
+      streamState(statuses[index] ?? STREAM_PHASE.RUNNING),
+    ]),
+  );
+  const tabs = await mountComponent<StreamTabs>('stream-tabs', {
+    streams,
+    streamStates,
+    activeStreamId,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return tabs;
+}
+
+describe('stream-tab lifecycle distinction', () => {
+  useLitComponentTestDom(
+    () => import('@progressView/frontend/components/StreamTabs'),
+  );
+
+  it('shows every canonical lifecycle state with text and distinct glyphs', async () => {
+    const streams = [
+      stream('running'),
+      stream('waiting'),
+      stream('completed'),
+      stream('failed'),
+      stream('cancelled'),
+      stream('ready'),
+    ];
+    const tabs = await mountTabs(streams, [
+      STREAM_PHASE.RUNNING,
+      STREAM_PHASE.WAITING,
+      STREAM_PHASE.COMPLETED,
+      STREAM_PHASE.FAILED,
+      STREAM_PHASE.CANCELLED,
+      STREAM_STATUS.READY,
+    ]);
+    const rows = [...(tabs.shadowRoot?.querySelectorAll('stream-tab') ?? [])];
+
+    expect(
+      rows.map((row) =>
+        row.shadowRoot?.querySelector('.tab-status-label')?.textContent?.trim(),
+      ),
+    ).toEqual(['Running', 'Idle', 'Completed', 'Error', 'Stopped', 'Ready']);
+    expect(
+      rows.map(
+        (row) =>
+          (
+            row.shadowRoot?.querySelector('.tab-status-icon') as
+              (Element & { name?: string }) | null
+          )?.name,
+      ),
+    ).toEqual([
+      'play',
+      'clock',
+      'circle-check',
+      'circle-exclamation',
+      'circle-stop',
+      'circle',
+    ]);
+
+    const containers = rows.map((row) =>
+      row.shadowRoot?.querySelector('.tab-container'),
+    );
+    expect(containers[0]?.classList.contains('status-running')).toBe(true);
+    expect(containers[1]?.classList.contains('status-waiting')).toBe(true);
+    expect(containers[2]?.classList.contains('status-completed')).toBe(true);
+    expect(containers[3]?.classList.contains('status-failed')).toBe(true);
+    expect(containers[4]?.classList.contains('status-cancelled')).toBe(true);
+    expect(containers[5]?.classList.contains('status-ready')).toBe(true);
+
+    for (const row of rows) {
+      expect(
+        row.shadowRoot
+          ?.querySelector('#stream-tab-select-button')
+          ?.getAttribute('aria-label'),
+      ).toContain('Status:');
+      expect(
+        row.shadowRoot
+          ?.querySelector('.tab-status')
+          ?.getAttribute('aria-hidden'),
+      ).toBe('true');
+    }
+  });
+
+  it('keeps an unknown lifecycle value visible as its defensive fallback', async () => {
+    const item = stream('unknown');
+    const tabs = await mountComponent<StreamTabs>('stream-tabs', {
+      streams: [item],
+      streamStates: new Map([
+        [
+          item.name,
+          {
+            ...streamState(STREAM_PHASE.RUNNING),
+            status: 'paused-by-host',
+          } as unknown as StreamState,
+        ],
+      ]),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const row = tabs.shadowRoot?.querySelector('stream-tab');
+
+    expect(
+      row?.shadowRoot?.querySelector('.tab-status-label')?.textContent?.trim(),
+    ).toBe('paused-by-host');
+    expect(
+      row?.shadowRoot
+        ?.querySelector('#stream-tab-select-button')
+        ?.getAttribute('aria-label'),
+    ).toContain('Status: paused-by-host');
+    expect(
+      row?.shadowRoot
+        ?.querySelector('.tab-container')
+        ?.classList.contains('status-paused-by-host'),
+    ).toBe(true);
+  });
+
+  it('keeps starting, resuming, and approval cues accessible in the collapsed rail', async () => {
+    const streams = [
+      stream('starting'),
+      stream('resuming'),
+      stream('approval'),
+    ];
+    const streamStates = new Map([
+      [
+        'starting',
+        createStreamState(AgentCategory.ToolUse, {
+          status: STREAM_PHASE.RUNNING,
+          substate: STREAM_SUBSTATE.STARTING,
+        }),
+      ],
+      [
+        'resuming',
+        createStreamState(AgentCategory.ToolUse, {
+          status: STREAM_PHASE.RUNNING,
+          substate: STREAM_SUBSTATE.RESUMING,
+        }),
+      ],
+      ['approval', streamState(STREAM_PHASE.RUNNING)],
+    ]);
+    const tabs = await mountComponent<StreamTabs>('stream-tabs', {
+      streams,
+      streamStates,
+      pendingApprovalStreamIds: new Set(['approval']),
+      childStreamsByParent: new Map([
+        ['starting', [{ ...stream('child'), parentStreamId: 'starting' }]],
+      ]),
+      compact: true,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const rows = [...(tabs.shadowRoot?.querySelectorAll('stream-tab') ?? [])];
+
+    expect(
+      rows.map((row) =>
+        row.shadowRoot?.querySelector('.tab-status-label')?.textContent?.trim(),
+      ),
+    ).toEqual(['Initializing', 'Resuming', 'Approval']);
+    expect(
+      rows.map(
+        (row) =>
+          (
+            row.shadowRoot?.querySelector('.tab-status-icon') as
+              (Element & { name?: string }) | null
+          )?.name,
+      ),
+    ).toEqual(['spinner', 'spinner', 'triangle-exclamation']);
+    expect(
+      rows[2]?.shadowRoot
+        ?.querySelector('#stream-tab-select-button')
+        ?.getAttribute('aria-label'),
+    ).toContain('Status: Approval required');
+    expect(
+      rows[0]?.shadowRoot
+        ?.querySelector('#stream-tab-select-button')
+        ?.getAttribute('aria-label'),
+    ).toContain('1 background task');
+    expect(
+      rows[0]?.shadowRoot?.querySelector('.compact-subagent-hint'),
+    ).toBeNull();
+    const compactStyles = styleText(rows[0]!);
+    expect(compactStyles).toContain(
+      '.tab-container.is-compact .tab-status-label',
+    );
+    expect(compactStyles).toContain('min-inline-size: 1em');
+    expect(compactStyles).toContain('max-width: none');
+  });
+
+  it('keeps selection primary without removing the visible lifecycle label', async () => {
+    const tabs = await mountTabs(
+      [stream('selected-running'), stream('selected-stopped')],
+      [STREAM_PHASE.RUNNING, STREAM_PHASE.CANCELLED],
+      'selected-running',
+    );
+    const rows = [...(tabs.shadowRoot?.querySelectorAll('stream-tab') ?? [])];
+    const selected = rows[0]?.shadowRoot?.querySelector('.tab-container');
+
+    expect(selected?.classList.contains('is-active')).toBe(true);
+    expect(selected?.classList.contains('status-running')).toBe(true);
+    expect(
+      selected?.querySelector('.tab-status-label')?.textContent?.trim(),
+    ).toBe('Running');
+    expect(
+      rows[1]?.shadowRoot
+        ?.querySelector('.tab-container')
+        ?.classList.contains('is-active'),
+    ).toBe(false);
+    expect(styleText(tabs)).not.toContain('stream-tab.is-finished');
+  });
+
+  it('preserves long-title truncation, status text, semantic tokens, and forced-color overrides', async () => {
+    const tabs = await mountTabs(
+      [
+        stream(
+          'a very long execution label that must yield space to lifecycle status',
+        ),
+      ],
+      [STREAM_PHASE.COMPLETED],
+    );
+    const row = tabs.shadowRoot?.querySelector('stream-tab');
+    expect(row).toBeTruthy();
+    const styles = styleText(row!);
+
+    expect(styles).toContain('.tab-title');
+    expect(styles).toContain('min-width: 0');
+    expect(styles).toContain('text-overflow: ellipsis');
+    expect(styles).toContain('.tab-status');
+    expect(styles).toContain('flex-shrink: 0');
+    expect(styles).toContain('var(--color-success)');
+    expect(styles).toContain('var(--color-error)');
+    expect(styles).toContain('var(--color-text-muted)');
+    expect(styles).toContain('@media (forced-colors: active)');
+    expect(styles).toContain('--stream-status-color: Highlight');
+    expect(styles).toContain('--stream-status-color: CanvasText');
+    expect(styles).toContain('--stream-status-color: GrayText');
+    expect(styles).not.toContain('--stream-status-rail-color: GrayText');
+    expect(styles).toContain('.tab-container.is-active:is(');
+    expect(styles).toContain('--stream-status-rail-color: HighlightText');
+    expect(styles).toContain('background-color: Highlight');
+    expect(styles).toContain('color: HighlightText');
+    expect(styles).not.toContain('outline: none');
+    expect(
+      row?.shadowRoot?.querySelector('.tab-status-label')?.textContent?.trim(),
+    ).toBe('Completed');
+  });
+});


### PR DESCRIPTION
## Summary
- add visible lifecycle text and distinct glyphs for active, waiting, completed, failed, cancelled, starting, resuming, and approval states
- preserve selected-row hierarchy with semantic rails and system forced-color tokens
- remove finished-row opacity and keep lifecycle cues visible in the 48px compact rail
- add a real Electron fixture at 200% zoom that verifies glyph containment and accessible child-count copy

## Verification
- 54 focused stream tests passed after simplification
- extension, desktop, and test-kernel typechecks passed
- full lint, Prettier, `compile:fast`, and `git diff --check` passed
- Electron webview smoke passed for all fixtures
- 48px rail at 2x zoom measured a nonzero 10.4px glyph fully inside its select target
- final independent review found no issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to progress stream tabs with added tests and smoke coverage; no auth, data, or backend logic.
> 
> **Overview**
> Progress **stream tab rows** now show **visible lifecycle text** and **paired icons** for running, waiting, completed, failed, cancelled, ready, starting, resuming, and approval—not only a colored left rail.
> 
> **Status styling** drives rail and icon color through `--stream-status-color` / `--stream-status-rail-color`; **selected rows** keep the rail but neutralize its hue so selection stays visually primary. **Forced-colors** media rules map statuses to system tokens.
> 
> In **compact (narrow) mode**, title and status labels are hidden so the **status glyph** stays visible; session identity moves to a **tooltip** on a wrapper anchor, and **child background-task counts** stay in the select button’s **accessible name** (the old compact child chevron hint is removed).
> 
> **Finished nested rows** no longer use reduced opacity (`is-finished` / branch-activity logic removed). **Tests** add Vitest coverage for lifecycle display and an Electron smoke fixture at 320px width for compact layout and a11y.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23259897a11507e3e44bee1c3558e4125110f908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->