### PR TITLE
Add workflow execution observability

### DIFF
--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -272,6 +272,10 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
         )}`,
         { data: workflow.error },
       );
+      // Ordinary reads keep core metadata so listing/finalization survive a
+      // bad workflow projection. Strict recovery must fail closed so a present
+      // but corrupt snapshot is never treated as "no prior state."
+      if (malformed === 'throw') throw workflow.error;
       return core.data;
     }
     return workflow.data === undefined

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -22,7 +22,9 @@ import { KVStore } from '@common/storage/KVStore';
 import * as logger from '@logger/logUtils';
 import { resolveRunStoragePath } from '@platform/defaults/workspaceStorage';
 import {
+  ExecutionMetaCoreSchema,
   ExecutionMetaSchema,
+  WorkflowExecutionSnapshotSchema,
   type ExecutionId,
   type ExecutionMeta,
 } from '@shared/schemas';
@@ -240,8 +242,45 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
     return null;
   }
 
+  private async readValidatedMeta(
+    malformed: 'return-null' | 'throw' = 'return-null',
+  ): Promise<ExecutionMeta | null> {
+    const raw = await this.read(KEYS.META);
+    if (raw === undefined) return null;
+
+    const core = ExecutionMetaCoreSchema.safeParse(raw);
+    if (!core.success) {
+      logger.warn(
+        CHANNEL,
+        `Failed to parse execution ${this.executionId} meta.json: ${toErrorMessage(
+          core.error,
+        )}`,
+        { data: core.error },
+      );
+      if (malformed === 'throw') throw core.error;
+      return null;
+    }
+
+    const workflow = WorkflowExecutionSnapshotSchema.optional().safeParse(
+      (raw as { workflow?: unknown }).workflow,
+    );
+    if (!workflow.success) {
+      logger.warn(
+        CHANNEL,
+        `Failed to parse execution ${this.executionId} meta.json workflow: ${toErrorMessage(
+          workflow.error,
+        )}`,
+        { data: workflow.error },
+      );
+      return core.data;
+    }
+    return workflow.data === undefined
+      ? core.data
+      : { ...core.data, workflow: workflow.data };
+  }
+
   async readMeta(): Promise<ExecutionMeta | null> {
-    return this.readValidated(KEYS.META, ExecutionMetaSchema);
+    return this.readValidatedMeta();
   }
 
   async readRunRecord(): Promise<RunRecord | null> {
@@ -249,7 +288,7 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   }
 
   async readMetaStrict(): Promise<ExecutionMeta | null> {
-    return this.readValidated(KEYS.META, ExecutionMetaSchema, 'throw');
+    return this.readValidatedMeta('throw');
   }
 
   /**

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -20,6 +20,7 @@ import {
   type RunOutcome,
   type StreamTabId,
   type UserFollowUpSupport,
+  type WorkflowExecutionSnapshot,
 } from '@shared/schemas';
 import { KeyedMutex } from '@utils/core';
 import { WorkspaceFS } from '@utils/files';
@@ -77,6 +78,14 @@ function enqueueMetaUpdate(
     }
     await store.writeMeta({ ...existing, ...updater(existing) });
   });
+}
+
+/** Persist the workflow runner's canonical execution snapshot on its run. */
+export function writeWorkflowExecutionSnapshot(
+  executionId: ExecutionId,
+  workflow: WorkflowExecutionSnapshot,
+): Promise<void> {
+  return enqueueMetaUpdate(executionId, () => ({ workflow }));
 }
 
 /**

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -34,6 +34,7 @@ export {
   type FinalizeExecutionInput,
   type FinalizeExecutionResult,
   writeSessionDescription,
+  writeWorkflowExecutionSnapshot,
 } from './executionLifecycle';
 export {
   type AgentExecutionListingEntry,

--- a/src/agent/storage/resumability.ts
+++ b/src/agent/storage/resumability.ts
@@ -7,7 +7,7 @@ import {
 } from '@agent/node/persistedFlow';
 import * as logger from '@logger/logUtils';
 import {
-  ExecutionMetaSchema,
+  ExecutionMetaCoreSchema,
   RUN_OUTCOME,
   type ExecutionId,
   type ExecutionMeta,
@@ -101,7 +101,7 @@ export async function deriveResumability(
 
   let meta: ExecutionMeta | null = null;
   if (rawMeta != null) {
-    const metaResult = ExecutionMetaSchema.safeParse(rawMeta);
+    const metaResult = ExecutionMetaCoreSchema.safeParse(rawMeta);
     if (!metaResult.success) {
       logger.debug(
         CHANNEL,

--- a/src/agent/workflowScript/persistence.ts
+++ b/src/agent/workflowScript/persistence.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 // Local imports - storage
 import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
+import { WorkflowExecutionSnapshotSchema } from '@shared/schemas';
 import {
   WorkflowScriptFilesSchema,
   type WorkflowScriptFiles,
@@ -252,25 +253,26 @@ async function runPersistedWorkflowScriptLocked(
   const journalByIndex = new Map(
     (prior?.journal ?? []).map((entry) => [entry.index, entry]),
   );
-  const persistJournal = (journal: WorkflowJournalEntry[]): Promise<void> =>
+  const persistCheckpoint = (): Promise<void> =>
     writeWorkflowScriptCheckpoint(store, checkpointId, {
       script,
       args,
       files,
-      journal,
+      journal: orderedJournal(journalByIndex.values()),
     });
-  await persistJournal(orderedJournal(journalByIndex.values()));
 
   let acceptingEntries = true;
   const writeQueue = new PQueue({ concurrency: 1 });
   const persistEntry = async (entry: WorkflowJournalEntry): Promise<void> => {
     if (!acceptingEntries) return;
     journalByIndex.set(entry.index, entry);
-    const snapshot = orderedJournal(journalByIndex.values());
-    await writeQueue.add(() => persistJournal(snapshot));
+    await writeQueue.add(persistCheckpoint);
   };
 
   try {
+    // Establish the checkpoint once before execution. Snapshot transitions are
+    // persisted separately and never rewrite script or journal metadata.
+    await persistCheckpoint();
     const result = await runWorkflowScript({
       ...runOptions,
       script,
@@ -278,10 +280,18 @@ async function runPersistedWorkflowScriptLocked(
       files,
       journal: prior?.journal,
       onJournalEntry: persistEntry,
+      // The caller supplies snapshots from the detached execution that owns
+      // their writes. The checkpoint store may belong to its orchestrator.
+      onSnapshot: async (snapshot) => {
+        await runOptions.onSnapshot?.(
+          WorkflowExecutionSnapshotSchema.parse(snapshot),
+        );
+      },
     });
     acceptingEntries = false;
+    for (const entry of result.journal) journalByIndex.set(entry.index, entry);
     await writeQueue.onIdle();
-    await persistJournal(result.journal);
+    await persistCheckpoint();
     return result;
   } catch (error) {
     acceptingEntries = false;

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -214,6 +214,28 @@ function isRunFatalAbort(reason: unknown): reason is WorkflowRunAbortError {
   );
 }
 
+class JournalCommitFence {
+  readonly #pending = new Set<Promise<void>>();
+  #sealed = false;
+
+  async commit(write: () => Promise<void>): Promise<boolean> {
+    if (this.#sealed) return false;
+    const pending = write();
+    this.#pending.add(pending);
+    try {
+      await pending;
+      return true;
+    } finally {
+      this.#pending.delete(pending);
+    }
+  }
+
+  async sealAndFlush(): Promise<void> {
+    this.#sealed = true;
+    await Promise.allSettled([...this.#pending]);
+  }
+}
+
 class CoalescedSnapshotWriter {
   readonly #write: WorkflowScriptRunOptions['onSnapshot'];
   readonly #onFailure: (failure: WorkflowRunAbortError) => void;
@@ -311,10 +333,11 @@ export async function runWorkflowScript(
   const journal = new Map<number, WorkflowJournalEntry>();
   const queue = new PQueue({ concurrency });
   const runAbort = new AbortController();
+  let firstFatalFault: WorkflowRunAbortError | undefined;
   const failRun = (fault: WorkflowRunAbortError): WorkflowRunAbortError => {
+    if (isRunFatalAbort(fault)) firstFatalFault ??= fault;
     runAbort.abort(fault);
-    const { reason } = runAbort.signal;
-    return isRunFatalAbort(reason) ? reason : fault;
+    return firstFatalFault ?? fault;
   };
   // One record per in-flight call, keyed by call index and linked to runAbort
   // (a run abort cascades to every entry; a per-call abort leaves the others
@@ -337,6 +360,7 @@ export async function runWorkflowScript(
   const hasTaskPlan = meta.tasks !== undefined;
   const plannedTasks = meta.tasks ?? [];
   const plannedTasksById = new Map(plannedTasks.map((task) => [task.id, task]));
+  const journalCommitFence = new JournalCommitFence();
   const snapshotWriter = new CoalescedSnapshotWriter(
     options.onSnapshot,
     (failure) => {
@@ -387,18 +411,15 @@ export async function runWorkflowScript(
     emit({ type: 'plan', tasks: plannedTasks });
   }
 
-  // The run's abort reason is its fault register: AbortController keeps the
-  // first reason, so the earliest fault wins over every abort that cascades
-  // from it and the run reports that reason rather than a copy of it. A
-  // cleanup, timeout, or parent reason is not a fault, so a fault raised
-  // afterwards (only reachable while abandoned calls drain) still reports
-  // itself.
-  const recordJournalEntry = async (
+  // failRun records faults separately from cancellation. Cleanup, timeout, or
+  // a parent abort may already own the controller reason when an abandoned
+  // persistence callback rejects, but the first fatal rejection still wins.
+  const persistJournalEntry = async (
     entry: WorkflowJournalEntry,
   ): Promise<void> => {
-    journal.set(entry.index, entry);
     try {
       await onJournalEntry?.(entry);
+      journal.set(entry.index, entry);
     } catch (error) {
       const message = `Failed to persist workflow journal entry ${entry.index}: ${toErrorMessage(error)}`;
       throw failRun(
@@ -632,8 +653,16 @@ export async function runWorkflowScript(
             payload === undefined ? undefined : JSON.parse(payload),
         };
       } catch (error) {
-        emitFailedEnd(error, metadata);
-        throw error;
+        const fault = failRun(
+          error instanceof WorkflowRunAbortError
+            ? error
+            : new WorkflowRunAbortError(toErrorMessage(error), {
+                kind: 'runner',
+                cause: error,
+              }),
+        );
+        emitFailedEnd(fault, metadata);
+        throw fault;
       }
     };
 
@@ -676,15 +705,7 @@ export async function runWorkflowScript(
       ...(childStreamId !== undefined && { childStreamId }),
       durationMs: Date.now() - startedAt,
     });
-    executionState.updateCall(progressId, {
-      status: WORKFLOW_CALL_STATUS.QUEUED,
-      blockedReason: undefined,
-      timestamps: {
-        ...executionState.call(progressId).timestamps,
-        queuedAt: now(),
-        updatedAt: now(),
-      },
-    });
+    executionState.queueCall(progressId);
     emit({ type: 'agent:queued', ...eventBase });
 
     // Attempt loop: retry() re-enters with a fresh AbortController and a fresh
@@ -720,6 +741,8 @@ export async function runWorkflowScript(
               ),
             );
           }
+          resolvedModel = undefined;
+          childStreamId = undefined;
           executionState.beginAttempt(progressId);
           if (!startEmitted) {
             startEmitted = true;
@@ -742,14 +765,14 @@ export async function runWorkflowScript(
               signal: callController.signal,
               reportModel: (model) => {
                 resolvedModel = model;
-                executionState.updateCall(progressId, { model });
+                executionState.reportModel(progressId, model);
               },
               reportAgent: (agent) =>
                 executionState.updateCall(progressId, { agent }),
               reportChildExecution: (executionId) =>
                 executionState.reportChildExecution(progressId, executionId),
               reportCostUsd: (costUsd) =>
-                executionState.updateCall(progressId, { costUsd }),
+                executionState.reportCostUsd(progressId, costUsd),
               reportChildStream: (streamId) => {
                 executionState.reportChildStream(progressId, streamId);
                 childStreamId = streamId;
@@ -782,16 +805,16 @@ export async function runWorkflowScript(
         }
       }
 
-      executionState.settleAttempt(progressId);
-      if (executionState.isSealed) return undefined;
+      // The terminal drain may have timed out while this runner ignored its
+      // abort signal. Do not let that late settlement mutate sealed state or
+      // append a journal entry after the terminal snapshot was persisted.
+      if (!executionState.settleAttempt(progressId)) return undefined;
 
       // Control action wins over whatever the (possibly signal-ignoring) runner
       // did: a deliberate skip/retry discards this attempt's outcome.
       const action = call.action;
       if (action === 'retry') {
-        executionState.updateCall(progressId, {
-          status: WORKFLOW_CALL_STATUS.QUEUED,
-        });
+        executionState.queueCall(progressId);
         emit({ type: 'agent:queued', ...eventBase });
         continue;
       }
@@ -863,29 +886,32 @@ export async function runWorkflowScript(
         attemptMetadata(),
       );
       try {
-        await recordJournalEntry({
-          index,
-          key,
-          result: normalizedResult,
+        const committed = await journalCommitFence.commit(async () => {
+          await persistJournalEntry({
+            index,
+            key,
+            result: normalizedResult,
+          });
+          executionState.updateCall(progressId, {
+            status: WORKFLOW_CALL_STATUS.COMPLETED,
+            timestamps: {
+              ...executionState.call(progressId).timestamps,
+              updatedAt: now(),
+              completedAt: now(),
+            },
+          });
+          emit({
+            type: 'agent:end',
+            ...eventBase,
+            outcome: 'completed',
+            ...attemptMetadata(),
+          });
         });
+        if (!committed) return undefined;
       } catch (error) {
         emitFailedEnd(error, attemptMetadata());
         throw error;
       }
-      executionState.updateCall(progressId, {
-        status: WORKFLOW_CALL_STATUS.COMPLETED,
-        timestamps: {
-          ...executionState.call(progressId).timestamps,
-          updatedAt: now(),
-          completedAt: now(),
-        },
-      });
-      emit({
-        type: 'agent:end',
-        ...eventBase,
-        outcome: 'completed',
-        ...attemptMetadata(),
-      });
       return payload;
     }
   }
@@ -898,9 +924,6 @@ export async function runWorkflowScript(
 
   let result: unknown;
   let scriptFailure: { readonly error: unknown } | undefined;
-  // The fault an abandoned call raised while draining, after the cleanup abort
-  // had already fixed the run's abort reason.
-  let drainFault: WorkflowRunAbortError | undefined;
   try {
     result = await runScriptInSandbox(
       body,
@@ -935,12 +958,10 @@ export async function runWorkflowScript(
                 }),
               );
             }
-            const { phaseIndex, phaseTotal } = phaseContextFor(
-              executionState.currentPhase,
-            );
+            const { phaseIndex, phaseTotal } = phaseContextFor(nextPhase);
             emit({
               type: 'phase',
-              title: executionState.currentPhase!,
+              title: nextPhase,
               ...(phaseIndex !== undefined && {
                 index: phaseIndex,
                 total: phaseTotal,
@@ -990,38 +1011,30 @@ export async function runWorkflowScript(
       // past its timeout by more than the grace period; stragglers beyond
       // it are orphaned (their journal entries may be lost, which resume
       // treats as a retry).
-      const drained = await pTimeout(
-        Promise.allSettled([...pendingAgentCalls]),
-        { milliseconds: DRAIN_GRACE_MS, fallback: () => [] },
-      );
-      // A draining call can still hit a run-level fault, typically a
-      // checkpoint write that fails after the script settled. Its rejection
-      // is that fault, so read it here instead of mirroring it into run state.
-      for (const outcome of drained) {
-        if (outcome.status === 'rejected' && isRunFatalAbort(outcome.reason)) {
-          drainFault = outcome.reason;
-          break;
-        }
-      }
+      await pTimeout(Promise.allSettled([...pendingAgentCalls]), {
+        milliseconds: DRAIN_GRACE_MS,
+        fallback: () => [],
+      });
     }
   }
 
+  // Stop admitting journal commits before writing the terminal snapshot. An
+  // admitted persistence callback is opaque and cannot be cancelled safely, so
+  // it must settle even after the runner drain grace expires. If it never
+  // settles, the run deliberately remains unsealed rather than persisting a
+  // terminal snapshot that the callback could later invalidate.
+  await journalCommitFence.sealAndFlush();
+
   const succeeded =
-    scriptFailure === undefined &&
-    drainFault === undefined &&
-    !isRunFatalAbort(runAbort.signal.reason);
+    scriptFailure === undefined && firstFatalFault === undefined;
   let terminalLifecycle: 'completed' | 'failed' | 'cancelled' =
     WORKFLOW_EXECUTION_LIFECYCLE.FAILED;
   if (succeeded) {
     terminalLifecycle = WORKFLOW_EXECUTION_LIFECYCLE.COMPLETED;
-  } else if (options.signal?.aborted) {
+  } else if (firstFatalFault === undefined && options.signal?.aborted) {
     terminalLifecycle = WORKFLOW_EXECUTION_LIFECYCLE.CANCELLED;
   }
-  const terminalError =
-    drainFault ??
-    (isRunFatalAbort(runAbort.signal.reason)
-      ? runAbort.signal.reason
-      : scriptFailure?.error);
+  const terminalError = firstFatalFault ?? scriptFailure?.error;
   executionState.finish(
     terminalLifecycle,
     terminalError === undefined ? undefined : toErrorMessage(terminalError),
@@ -1034,9 +1047,7 @@ export async function runWorkflowScript(
   // reject while the final drain is running. Checkpoint failure is a run-level
   // invariant, so a fault outranks the script outcome, and the earliest fault
   // outranks the ones that cascade from it.
-  const abortReason: unknown = runAbort.signal.reason;
-  if (isRunFatalAbort(abortReason)) throw abortReason;
-  if (drainFault) throw drainFault;
+  if (firstFatalFault) throw firstFatalFault;
   if (scriptFailure) throw scriptFailure.error;
 
   return {

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -1,9 +1,15 @@
 import { createHash } from 'node:crypto';
+import { basename } from 'node:path';
 
 import stableStringify from 'fast-json-stable-stringify';
 import PQueue from 'p-queue';
 import pTimeout from 'p-timeout';
-import type { StreamTabId } from '@shared/schemas';
+import {
+  WORKFLOW_CALL_STATUS,
+  WORKFLOW_EXECUTION_LIFECYCLE,
+  type StreamTabId,
+  type WorkflowExecutionSnapshot,
+} from '@shared/schemas';
 import {
   WorkflowScriptFilesSchema,
   type WorkflowScriptFiles,
@@ -14,6 +20,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { parseWorkflowScript } from './parseScript';
 import { runScriptInSandbox } from './sandbox';
+import { WorkflowExecutionState } from './workflowExecutionState';
 import {
   WORKFLOW_SKIPPED_RESULT,
   normalizeWorkflowScriptPhaseTitle,
@@ -60,7 +67,7 @@ const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_MAX_AGENT_CALLS = 200;
 const MAX_FANOUT = 512;
 const DRAIN_GRACE_MS = 5_000;
-const LABEL_EXCERPT_LENGTH = 48;
+const LABEL_EXCERPT_LENGTH = 80;
 const STRING_AGENT_OPTION_FIELDS = [
   'id',
   'label',
@@ -207,6 +214,71 @@ function isRunFatalAbort(reason: unknown): reason is WorkflowRunAbortError {
   );
 }
 
+class CoalescedSnapshotWriter {
+  readonly #write: WorkflowScriptRunOptions['onSnapshot'];
+  readonly #onFailure: (failure: WorkflowRunAbortError) => void;
+  #pending: WorkflowExecutionSnapshot | undefined;
+  #running: Promise<void> | undefined;
+  #failure: WorkflowRunAbortError | undefined;
+  #sealed = false;
+
+  constructor(
+    write: WorkflowScriptRunOptions['onSnapshot'],
+    onFailure: (failure: WorkflowRunAbortError) => void,
+  ) {
+    this.#write = write;
+    this.#onFailure = onFailure;
+  }
+
+  publish(snapshot: WorkflowExecutionSnapshot): void {
+    if (!this.#write || this.#failure !== undefined || this.#sealed) return;
+    this.#pending = snapshot;
+    this.#running ??= this.#drain();
+  }
+
+  async flush(): Promise<void> {
+    while (this.#running) await this.#running;
+  }
+
+  throwIfFailed(): void {
+    if (this.#failure !== undefined) throw this.#failure;
+  }
+
+  seal(): void {
+    if (this.#running || this.#pending) {
+      throw new Error('Cannot seal workflow snapshot writes before flush.');
+    }
+    this.#sealed = true;
+  }
+
+  async #drain(): Promise<void> {
+    try {
+      while (this.#pending) {
+        const snapshot = this.#pending;
+        this.#pending = undefined;
+        await this.#write?.(snapshot);
+      }
+    } catch (cause) {
+      const failure = new WorkflowRunAbortError(
+        `Failed to persist workflow execution snapshot: ${toErrorMessage(cause)}`,
+        { kind: 'checkpoint', cause },
+      );
+      this.#failure = failure;
+      this.#pending = undefined;
+      this.#onFailure(failure);
+    } finally {
+      this.#running = undefined;
+      if (this.#pending && this.#failure === undefined) {
+        this.#running = this.#drain();
+      }
+    }
+  }
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
 /**
  * Runs a workflow script: deterministic JS orchestration over host-executed
  * agents. The script's control flow (loops, fan-out, joins, reduction) runs
@@ -228,6 +300,7 @@ export async function runWorkflowScript(
     onControl,
   } = options;
   const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
+  // This is the one total physical attempt bound. Cached replays are free.
   const maxAgentCalls = options.maxAgentCalls ?? DEFAULT_MAX_AGENT_CALLS;
 
   const { meta, body } = parseWorkflowScript(options.script);
@@ -238,6 +311,11 @@ export async function runWorkflowScript(
   const journal = new Map<number, WorkflowJournalEntry>();
   const queue = new PQueue({ concurrency });
   const runAbort = new AbortController();
+  const failRun = (fault: WorkflowRunAbortError): WorkflowRunAbortError => {
+    runAbort.abort(fault);
+    const { reason } = runAbort.signal;
+    return isRunFatalAbort(reason) ? reason : fault;
+  };
   // One record per in-flight call, keyed by call index and linked to runAbort
   // (a run abort cascades to every entry; a per-call abort leaves the others
   // running). skip()/retry() target a single entry; the entry is removed as
@@ -259,8 +337,20 @@ export async function runWorkflowScript(
   const hasTaskPlan = meta.tasks !== undefined;
   const plannedTasks = meta.tasks ?? [];
   const plannedTasksById = new Map(plannedTasks.map((task) => [task.id, task]));
-  const issuedPlannedTaskIds = new Set<string>();
-  let currentPhase: string | undefined;
+  const snapshotWriter = new CoalescedSnapshotWriter(
+    options.onSnapshot,
+    (failure) => {
+      failRun(failure);
+    },
+  );
+  const executionState = new WorkflowExecutionState({
+    phases: plannedPhases,
+    tasks: plannedTasks,
+    initialSnapshot: options.initialSnapshot,
+    publish: (snapshot) => snapshotWriter.publish(snapshot),
+  });
+  await snapshotWriter.flush();
+  snapshotWriter.throwIfFailed();
 
   const emit = (event: WorkflowScriptEvent) => onEvent?.(event);
 
@@ -303,12 +393,6 @@ export async function runWorkflowScript(
   // cleanup, timeout, or parent reason is not a fault, so a fault raised
   // afterwards (only reachable while abandoned calls drain) still reports
   // itself.
-  const failRun = (fault: WorkflowRunAbortError): WorkflowRunAbortError => {
-    runAbort.abort(fault);
-    const { reason } = runAbort.signal;
-    return isRunFatalAbort(reason) ? reason : fault;
-  };
-
   const recordJournalEntry = async (
     entry: WorkflowJournalEntry,
   ): Promise<void> => {
@@ -387,13 +471,21 @@ export async function runWorkflowScript(
       callOptions.label = plannedTask.label;
       callOptions.phase = plannedTask.phase;
     } else {
-      callOptions.phase ??= currentPhase;
+      callOptions.phase ??= executionState.currentPhase;
     }
 
+    const primaryFile =
+      callOptions.inputFiles?.[0] ?? callOptions.contextFiles?.[0];
+    const role = callOptions.agentName ?? 'Agent';
     const label =
       plannedTask?.label ??
       callOptions.label ??
       prompt.slice(0, LABEL_EXCERPT_LENGTH).replaceAll(/\s+/g, ' ').trim();
+    const snapshotLabel =
+      plannedTask?.label ??
+      callOptions.label ??
+      (primaryFile ? `${basename(primaryFile)}: ${role}` : undefined) ??
+      `${role} ${index + 1}`;
     const hasFileDependencies =
       (callOptions.inputFiles?.length ?? 0) > 0 ||
       (callOptions.contextFiles?.length ?? 0) > 0 ||
@@ -431,24 +523,50 @@ export async function runWorkflowScript(
       ? await readDependencyFingerprint()
       : undefined;
     let key = journalKey(prompt, callOptions, dependencyFingerprint);
-    const progressId = plannedTask?.id ?? `call-${index}`;
-    if (plannedTask) {
-      if (issuedPlannedTaskIds.has(progressId)) {
-        throw failRun(
-          new WorkflowRunAbortError(
-            `Workflow task "${progressId}" may be issued only once per run.`,
-            { kind: 'contract' },
-          ),
-        );
-      }
-      issuedPlannedTaskIds.add(progressId);
-    }
+    const progressId = plannedTask?.id ?? callOptions.id ?? `call-${index}`;
     const eventBase = {
       progressId,
       index,
       label,
       ...phaseContextFor(callOptions.phase),
     };
+    if (
+      callOptions.phase !== undefined &&
+      executionState.currentPhaseIndex === -1
+    ) {
+      try {
+        executionState.enterStage(callOptions.phase);
+      } catch (error) {
+        throw failRun(
+          new WorkflowRunAbortError(toErrorMessage(error), {
+            kind: 'contract',
+            cause: error,
+          }),
+        );
+      }
+    }
+    try {
+      executionState.issueCall({
+        id: progressId,
+        label: snapshotLabel,
+        phase: callOptions.phase,
+        agent: callOptions.agentName,
+        files: {
+          input: (callOptions.inputFiles ?? []).map((file) => basename(file)),
+          context: (callOptions.contextFiles ?? []).map((file) =>
+            basename(file),
+          ),
+          media: (callOptions.mediaFiles ?? []).map((file) => basename(file)),
+        },
+      });
+    } catch (error) {
+      throw failRun(
+        new WorkflowRunAbortError(toErrorMessage(error), {
+          kind: 'contract',
+          cause: error,
+        }),
+      );
+    }
     if (issuedCallKeys.has(key)) {
       throw failRun(
         new WorkflowRunAbortError(
@@ -532,6 +650,14 @@ export async function runWorkflowScript(
         key,
         result: normalizedResult,
       });
+      executionState.updateCall(progressId, {
+        status: WORKFLOW_CALL_STATUS.CACHED,
+        timestamps: {
+          ...executionState.call(progressId).timestamps,
+          updatedAt: now(),
+          completedAt: now(),
+        },
+      });
       emit({ type: 'agent:end', ...eventBase, outcome: 'cached' });
       return payload;
     }
@@ -550,25 +676,22 @@ export async function runWorkflowScript(
       ...(childStreamId !== undefined && { childStreamId }),
       durationMs: Date.now() - startedAt,
     });
+    executionState.updateCall(progressId, {
+      status: WORKFLOW_CALL_STATUS.QUEUED,
+      blockedReason: undefined,
+      timestamps: {
+        ...executionState.call(progressId).timestamps,
+        queuedAt: now(),
+        updatedAt: now(),
+      },
+    });
+    emit({ type: 'agent:queued', ...eventBase });
+
     // Attempt loop: retry() re-enters with a fresh AbortController and a fresh
     // runAgent call for this same index/key; skip() and normal settlement exit.
     // Every physical model attempt is charged against liveCallCounter; the
     // logical call key and eventual journal entry remain index-scoped.
     for (;;) {
-      liveCallCounter += 1;
-      if (liveCallCounter > maxAgentCalls) {
-        // Abort first so in-flight siblings stop consuming quota. Retried
-        // attempts consume the same cap as first attempts; cached calls never
-        // enter this loop.
-        const fatal = failRun(
-          new WorkflowRunAbortError(
-            `Workflow exceeded the ${maxAgentCalls} live agent-call cap (runaway-loop backstop; journal replays are free).`,
-            { kind: 'cap' },
-          ),
-        );
-        emitFailedEnd(fatal, startEmitted ? attemptMetadata() : undefined);
-        throw fatal;
-      }
       const callController = new AbortController();
       const call: InFlightAgentCall = { controller: callController };
       // Link this call to the run: any run-level abort cascades to it, so a
@@ -576,11 +699,6 @@ export async function runWorkflowScript(
       const cascade = () => callController.abort(runAbort.signal.reason);
       const detachCascade = onAbort(runAbort.signal, cascade);
       inFlightCalls.set(index, call);
-      if (!startEmitted) {
-        startEmitted = true;
-        emit({ type: 'agent:start', ...eventBase });
-      }
-
       let result: unknown;
       let attemptError: { readonly error: unknown } | undefined;
       try {
@@ -591,9 +709,30 @@ export async function runWorkflowScript(
           // soft per-call failure while a fault still stops the run.
           runAbort.signal.throwIfAborted();
           callController.signal.throwIfAborted();
-          const launch = () =>
-            runAgent({
+          // Charge physical work only after p-queue admits this attempt. Calls
+          // cancelled while queued never consume the live-attempt budget.
+          liveCallCounter += 1;
+          if (liveCallCounter > maxAgentCalls) {
+            throw failRun(
+              new WorkflowRunAbortError(
+                `Workflow exceeded the ${maxAgentCalls} live agent-call cap (runaway-loop backstop; journal replays are free).`,
+                { kind: 'cap' },
+              ),
+            );
+          }
+          executionState.beginAttempt(progressId);
+          if (!startEmitted) {
+            startEmitted = true;
+            emit({ type: 'agent:start', ...eventBase });
+          }
+          executionState.updateCall(progressId, {
+            status: WORKFLOW_CALL_STATUS.RUNNING,
+          });
+          const launch = () => {
+            callController.signal.throwIfAborted();
+            return runAgent({
               index,
+              progressId,
               key,
               ...(dependencyFingerprint !== undefined && {
                 dependencyFingerprint,
@@ -603,8 +742,16 @@ export async function runWorkflowScript(
               signal: callController.signal,
               reportModel: (model) => {
                 resolvedModel = model;
+                executionState.updateCall(progressId, { model });
               },
+              reportAgent: (agent) =>
+                executionState.updateCall(progressId, { agent }),
+              reportChildExecution: (executionId) =>
+                executionState.reportChildExecution(progressId, executionId),
+              reportCostUsd: (costUsd) =>
+                executionState.updateCall(progressId, { costUsd }),
               reportChildStream: (streamId) => {
+                executionState.reportChildStream(progressId, streamId);
                 childStreamId = streamId;
                 emit({
                   type: 'agent:stream',
@@ -613,6 +760,7 @@ export async function runWorkflowScript(
                 });
               },
             });
+          };
           // File contents can change while this call waits for a concurrency
           // slot or between interactive attempts. Refresh the identity before
           // every physical launch so the journal and stable child id describe
@@ -634,11 +782,28 @@ export async function runWorkflowScript(
         }
       }
 
+      executionState.settleAttempt(progressId);
+      if (executionState.isSealed) return undefined;
+
       // Control action wins over whatever the (possibly signal-ignoring) runner
       // did: a deliberate skip/retry discards this attempt's outcome.
       const action = call.action;
-      if (action === 'retry') continue;
+      if (action === 'retry') {
+        executionState.updateCall(progressId, {
+          status: WORKFLOW_CALL_STATUS.QUEUED,
+        });
+        emit({ type: 'agent:queued', ...eventBase });
+        continue;
+      }
       if (action === 'skip') {
+        executionState.updateCall(progressId, {
+          status: WORKFLOW_CALL_STATUS.SKIPPED,
+          timestamps: {
+            ...executionState.call(progressId).timestamps,
+            updatedAt: now(),
+            completedAt: now(),
+          },
+        });
         emit({
           type: 'agent:end',
           ...eventBase,
@@ -675,6 +840,17 @@ export async function runWorkflowScript(
         }
         // A failed agent resolves to null and is deliberately NOT journaled, so
         // a resume retries it. Callers also exclude the truthy skip sentinel.
+        executionState.updateCall(progressId, {
+          status: options.signal?.aborted
+            ? WORKFLOW_CALL_STATUS.CANCELLED
+            : WORKFLOW_CALL_STATUS.FAILED,
+          error: toErrorMessage(attemptError.error),
+          timestamps: {
+            ...executionState.call(progressId).timestamps,
+            updatedAt: now(),
+            completedAt: now(),
+          },
+        });
         emitFailedEnd(attemptError.error, attemptMetadata());
         return 'null';
       }
@@ -696,6 +872,14 @@ export async function runWorkflowScript(
         emitFailedEnd(error, attemptMetadata());
         throw error;
       }
+      executionState.updateCall(progressId, {
+        status: WORKFLOW_CALL_STATUS.COMPLETED,
+        timestamps: {
+          ...executionState.call(progressId).timestamps,
+          updatedAt: now(),
+          completedAt: now(),
+        },
+      });
       emit({
         type: 'agent:end',
         ...eventBase,
@@ -738,11 +922,25 @@ export async function runWorkflowScript(
             return undefined;
           },
           phase: (args) => {
-            currentPhase = normalizeWorkflowScriptPhaseTitle(String(args[0]));
-            const { phaseIndex, phaseTotal } = phaseContextFor(currentPhase);
+            const nextPhase = normalizeWorkflowScriptPhaseTitle(
+              String(args[0]),
+            );
+            try {
+              executionState.enterStage(nextPhase);
+            } catch (error) {
+              throw failRun(
+                new WorkflowRunAbortError(toErrorMessage(error), {
+                  kind: 'contract',
+                  cause: error,
+                }),
+              );
+            }
+            const { phaseIndex, phaseTotal } = phaseContextFor(
+              executionState.currentPhase,
+            );
             emit({
               type: 'phase',
-              title: currentPhase,
+              title: executionState.currentPhase!,
               ...(phaseIndex !== undefined && {
                 index: phaseIndex,
                 total: phaseTotal,
@@ -808,6 +1006,30 @@ export async function runWorkflowScript(
     }
   }
 
+  const succeeded =
+    scriptFailure === undefined &&
+    drainFault === undefined &&
+    !isRunFatalAbort(runAbort.signal.reason);
+  let terminalLifecycle: 'completed' | 'failed' | 'cancelled' =
+    WORKFLOW_EXECUTION_LIFECYCLE.FAILED;
+  if (succeeded) {
+    terminalLifecycle = WORKFLOW_EXECUTION_LIFECYCLE.COMPLETED;
+  } else if (options.signal?.aborted) {
+    terminalLifecycle = WORKFLOW_EXECUTION_LIFECYCLE.CANCELLED;
+  }
+  const terminalError =
+    drainFault ??
+    (isRunFatalAbort(runAbort.signal.reason)
+      ? runAbort.signal.reason
+      : scriptFailure?.error);
+  executionState.finish(
+    terminalLifecycle,
+    terminalError === undefined ? undefined : toErrorMessage(terminalError),
+  );
+  await snapshotWriter.flush();
+  snapshotWriter.throwIfFailed();
+  snapshotWriter.seal();
+
   // Guest code may catch an agent() rejection, and an abandoned call can
   // reject while the final drain is running. Checkpoint failure is a run-level
   // invariant, so a fault outranks the script outcome, and the earliest fault
@@ -822,6 +1044,7 @@ export async function runWorkflowScript(
     result,
     journal: [...journal.values()].toSorted((a, b) => a.index - b.index),
     agentCalls: callCounter,
+    snapshot: executionState.snapshot(),
   };
 }
 

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 
 import {
   WorkflowCallIdentitySchema,
+  type ExecutionId,
   type WorkflowCallIdentity,
+  type WorkflowExecutionSnapshot,
   type StreamTabId,
 } from '@shared/schemas';
 import type { WorkflowScriptFiles } from '@shared/schemas/workflowScriptFiles';
@@ -88,11 +90,11 @@ export type WorkflowScriptMeta = z.infer<typeof WorkflowScriptMetaSchema>;
 
 interface WorkflowAgentCallBaseOptions {
   /**
-   * Journal disambiguator when otherwise-identical calls occur more than
-   * once. This does not identify the call's run-local progress record.
+   * Stable logical call id and journal disambiguator. Dynamic calls use it as
+   * their persisted progress id; when omitted they fall back to call order.
    */
   id?: string;
-  /** Display label for progress UIs; defaults to a prompt excerpt. */
+  /** Display label for progress UIs. */
   label?: string;
   /** Progress group; defaults to the `phase()` active at call time. */
   phase?: string;
@@ -140,6 +142,8 @@ export type WorkflowAgentCallOptions =
 export interface WorkflowAgentInvocation {
   /** 0-based call sequence number; also the journal key position. */
   index: number;
+  /** Stable logical call identity within the workflow execution snapshot. */
+  progressId: WorkflowScriptProgressId;
   /** Stable hash of the prompt and normalized execution-affecting options. */
   key: string;
   /** Opaque host fingerprint already incorporated into `key`, when present. */
@@ -158,6 +162,12 @@ export interface WorkflowAgentInvocation {
    * for progress UIs. Never journaled — it does not affect resume identity.
    */
   reportModel?: (model: string) => void;
+  /** Reports the resolved agent selected by the host. */
+  reportAgent?: (agent: string) => void;
+  /** Reports the physical child execution selected for this attempt. */
+  reportChildExecution?: (executionId: ExecutionId) => void;
+  /** Reports cost available on the child result. */
+  reportCostUsd?: (costUsd: number) => void;
   /**
    * Reports the live child stream once the host has resolved its agent, model,
    * and execution identity. Progress renderers use it as the task card's
@@ -220,6 +230,9 @@ export type WorkflowScriptEvent =
       total?: number;
     }
   | { type: 'log'; message: string }
+  | (WorkflowScriptAgentEventBase & {
+      type: 'agent:queued';
+    })
   | (WorkflowScriptAgentEventBase & {
       type: 'agent:start';
     })
@@ -308,12 +321,16 @@ export interface WorkflowScriptRunOptions {
   concurrency?: number;
   /** Journal from a prior run; per-index key matches return cached results. */
   journal?: WorkflowJournalEntry[];
+  /** Recovery snapshot from the prior attempt, re-published after reconciliation. */
+  initialSnapshot?: WorkflowExecutionSnapshot;
   /**
    * Durable checkpoint hook for a successfully validated live call. The
    * engine awaits it before the result becomes visible to the script, so a
    * host restart cannot expose work whose journal entry was never persisted.
    */
   onJournalEntry?: (entry: WorkflowJournalEntry) => void | Promise<void>;
+  /** Receives each canonical snapshot after the transition has been applied. */
+  onSnapshot?: (snapshot: WorkflowExecutionSnapshot) => void | Promise<void>;
   onEvent?: (event: WorkflowScriptEvent) => void;
   /**
    * Handed the per-call control handle once, synchronously, before the script
@@ -334,4 +351,6 @@ export interface WorkflowScriptRunResult {
   journal: WorkflowJournalEntry[];
   /** Total agent() calls issued (cached and live). */
   agentCalls: number;
+  /** Final canonical execution snapshot. */
+  snapshot: WorkflowExecutionSnapshot;
 }

--- a/src/agent/workflowScript/workflowExecutionState.ts
+++ b/src/agent/workflowScript/workflowExecutionState.ts
@@ -1,22 +1,14 @@
 import {
+  TERMINAL_WORKFLOW_CALL_STATUSES,
   WORKFLOW_CALL_STATUS,
   WORKFLOW_EXECUTION_LIFECYCLE,
   type ExecutionId,
   type StreamTabId,
   type WorkflowExecutionCall,
-  type WorkflowExecutionCallStatus,
   type WorkflowExecutionSnapshot,
 } from '@shared/schemas';
 
 import type { WorkflowScriptTask } from './types';
-
-const TERMINAL_CALL_STATUSES = new Set<WorkflowExecutionCallStatus>([
-  WORKFLOW_CALL_STATUS.COMPLETED,
-  WORKFLOW_CALL_STATUS.FAILED,
-  WORKFLOW_CALL_STATUS.CANCELLED,
-  WORKFLOW_CALL_STATUS.SKIPPED,
-  WORKFLOW_CALL_STATUS.CACHED,
-]);
 
 interface WorkflowCallDefinition {
   readonly id: string;
@@ -94,10 +86,6 @@ export class WorkflowExecutionState {
 
   snapshot(): WorkflowExecutionSnapshot {
     return structuredClone(this.#snapshot);
-  }
-
-  get isSealed(): boolean {
-    return this.#sealed;
   }
 
   enterStage(title: string): number {
@@ -237,6 +225,24 @@ export class WorkflowExecutionState {
     return call;
   }
 
+  queueCall(id: string): void {
+    const call = this.call(id);
+    const queuedAt = now();
+    this.updateCall(id, {
+      status: WORKFLOW_CALL_STATUS.QUEUED,
+      childExecutionId: undefined,
+      childStreamId: undefined,
+      model: undefined,
+      blockedReason: undefined,
+      error: undefined,
+      timestamps: {
+        createdAt: call.timestamps.createdAt,
+        queuedAt,
+        updatedAt: queuedAt,
+      },
+    });
+  }
+
   beginAttempt(id: string): void {
     if (this.#sealed) return;
     const call = this.call(id);
@@ -261,11 +267,36 @@ export class WorkflowExecutionState {
 
   reportChildStream(id: string, streamId: StreamTabId): void {
     if (this.#sealed) return;
-    this.updateCall(id, { childStreamId: streamId });
+    const call = this.call(id);
+    call.childStreamId = streamId;
+    const attempt = call.attempts.at(-1);
+    if (attempt) attempt.childStreamId = streamId;
+    call.timestamps.updatedAt = now();
+    this.#emit();
   }
 
-  settleAttempt(id: string): void {
+  reportModel(id: string, model: string): void {
     if (this.#sealed) return;
+    const call = this.call(id);
+    call.model = model;
+    const attempt = call.attempts.at(-1);
+    if (attempt) attempt.model = model;
+    call.timestamps.updatedAt = now();
+    this.#emit();
+  }
+
+  reportCostUsd(id: string, costUsd: number): void {
+    if (this.#sealed) return;
+    const call = this.call(id);
+    const attempt = call.attempts.at(-1);
+    if (attempt) attempt.costUsd = costUsd;
+    call.costUsd = totalAttemptCost(call.attempts);
+    call.timestamps.updatedAt = now();
+    this.#emit();
+  }
+
+  settleAttempt(id: string): boolean {
+    if (this.#sealed) return false;
     const call = this.call(id);
     const attempt = call.attempts.at(-1);
     if (attempt && attempt.completedAt === undefined) {
@@ -273,6 +304,7 @@ export class WorkflowExecutionState {
       call.timestamps.updatedAt = now();
       this.#emit();
     }
+    return true;
   }
 
   finish(
@@ -329,7 +361,9 @@ export class WorkflowExecutionState {
     const calls = this.#snapshot.calls.filter(
       (call) => call.stageId === stageId,
     );
-    if (calls.every((call) => TERMINAL_CALL_STATUSES.has(call.status))) {
+    if (
+      calls.every((call) => TERMINAL_WORKFLOW_CALL_STATUSES.has(call.status))
+    ) {
       this.#settleStage(stageId, now());
     }
   }
@@ -397,6 +431,28 @@ function emptyCounts(): WorkflowExecutionSnapshot['counts'] {
   };
 }
 
+function totalAttemptCost(
+  attempts: WorkflowExecutionCall['attempts'],
+): number | undefined {
+  const costs = attempts.flatMap((attempt) =>
+    attempt.costUsd === undefined ? [] : [attempt.costUsd],
+  );
+  return costs.length === 0
+    ? undefined
+    : costs.reduce((total, costUsd) => total + costUsd, 0);
+}
+
+function closeOpenAttempts(
+  attempts: WorkflowExecutionCall['attempts'],
+  recoveryAt: string,
+): WorkflowExecutionCall['attempts'] {
+  return attempts.map((attempt) =>
+    attempt.completedAt === undefined
+      ? { ...attempt, completedAt: recoveryAt }
+      : attempt,
+  );
+}
+
 function hydrate(
   fresh: WorkflowExecutionSnapshot,
   persisted: WorkflowExecutionSnapshot | undefined,
@@ -412,22 +468,24 @@ function hydrate(
     if (!prior) return call;
     const reusable =
       prior.status === WORKFLOW_CALL_STATUS.COMPLETED ||
-      prior.status === WORKFLOW_CALL_STATUS.CACHED ||
-      prior.status === WORKFLOW_CALL_STATUS.SKIPPED;
+      prior.status === WORKFLOW_CALL_STATUS.CACHED;
+    const attempts = closeOpenAttempts(prior.attempts, recoveryAt);
     return {
       ...prior,
       label: call.label,
       stageId: call.stageId,
       stageTitle: call.stageTitle,
       files: call.files,
+      attempts,
+      costUsd: totalAttemptCost(attempts),
       status: reusable ? prior.status : call.status,
       ...(!reusable && {
         childExecutionId: undefined,
         childStreamId: undefined,
+        model: undefined,
         blockedReason: call.blockedReason,
         error: undefined,
         timestamps: {
-          ...call.timestamps,
           createdAt: prior.timestamps.createdAt,
           updatedAt: recoveryAt,
         },
@@ -436,16 +494,28 @@ function hydrate(
   });
   for (const prior of persisted.calls) {
     if (!freshIds.has(prior.id)) {
+      const reusable =
+        prior.status === WORKFLOW_CALL_STATUS.COMPLETED ||
+        prior.status === WORKFLOW_CALL_STATUS.CACHED;
+      const attempts = closeOpenAttempts(prior.attempts, recoveryAt);
       snapshot.calls.push({
         ...prior,
         stageId: undefined,
         stageTitle: undefined,
-        status: WORKFLOW_CALL_STATUS.PLANNED,
-        childExecutionId: undefined,
-        childStreamId: undefined,
-        blockedReason: undefined,
-        error: undefined,
-        timestamps: { ...prior.timestamps, updatedAt: recoveryAt },
+        attempts,
+        costUsd: totalAttemptCost(attempts),
+        status: reusable ? prior.status : WORKFLOW_CALL_STATUS.PLANNED,
+        ...(!reusable && {
+          childExecutionId: undefined,
+          childStreamId: undefined,
+          model: undefined,
+          blockedReason: undefined,
+          error: undefined,
+          timestamps: {
+            createdAt: prior.timestamps.createdAt,
+            updatedAt: recoveryAt,
+          },
+        }),
       });
     }
   }

--- a/src/agent/workflowScript/workflowExecutionState.ts
+++ b/src/agent/workflowScript/workflowExecutionState.ts
@@ -176,12 +176,17 @@ export class WorkflowExecutionState {
       );
     }
     const timestamp = now();
+    // Only assign agent when the call definition supplies one. Engine issue
+    // often omits agentName; reportAgent later fills the host-resolved name.
+    // Re-issuing on resume must not wipe a hydrated agent with undefined —
+    // the journal-cache path only patches status/timestamps and would leave
+    // /executions without the resolved agent after a cached replay.
     const canonical = {
       label: definition.label,
       stageId: stageIndex < 0 ? undefined : stageIdFor(stageIndex),
       stageTitle: definition.phase,
-      agent: definition.agent,
       files: definition.files,
+      ...(definition.agent !== undefined && { agent: definition.agent }),
     };
     if (!call) {
       call = {

--- a/src/agent/workflowScript/workflowExecutionState.ts
+++ b/src/agent/workflowScript/workflowExecutionState.ts
@@ -228,6 +228,12 @@ export class WorkflowExecutionState {
   queueCall(id: string): void {
     const call = this.call(id);
     const queuedAt = now();
+    // Interactive retry re-queues a still-live call: keep the logical start so
+    // duration covers every physical attempt. A terminal call re-queued after
+    // identity change / resume must start a fresh execution window instead.
+    const preserveStartedAt =
+      call.timestamps.startedAt !== undefined &&
+      !TERMINAL_WORKFLOW_CALL_STATUSES.has(call.status);
     this.updateCall(id, {
       status: WORKFLOW_CALL_STATUS.QUEUED,
       childExecutionId: undefined,
@@ -237,6 +243,7 @@ export class WorkflowExecutionState {
       error: undefined,
       timestamps: {
         createdAt: call.timestamps.createdAt,
+        ...(preserveStartedAt && { startedAt: call.timestamps.startedAt }),
         queuedAt,
         updatedAt: queuedAt,
       },

--- a/src/agent/workflowScript/workflowExecutionState.ts
+++ b/src/agent/workflowScript/workflowExecutionState.ts
@@ -1,0 +1,453 @@
+import {
+  WORKFLOW_CALL_STATUS,
+  WORKFLOW_EXECUTION_LIFECYCLE,
+  type ExecutionId,
+  type StreamTabId,
+  type WorkflowExecutionCall,
+  type WorkflowExecutionCallStatus,
+  type WorkflowExecutionSnapshot,
+} from '@shared/schemas';
+
+import type { WorkflowScriptTask } from './types';
+
+const TERMINAL_CALL_STATUSES = new Set<WorkflowExecutionCallStatus>([
+  WORKFLOW_CALL_STATUS.COMPLETED,
+  WORKFLOW_CALL_STATUS.FAILED,
+  WORKFLOW_CALL_STATUS.CANCELLED,
+  WORKFLOW_CALL_STATUS.SKIPPED,
+  WORKFLOW_CALL_STATUS.CACHED,
+]);
+
+interface WorkflowCallDefinition {
+  readonly id: string;
+  readonly label: string;
+  readonly phase?: string;
+  readonly agent?: string;
+  readonly files: WorkflowExecutionCall['files'];
+}
+
+/** Owns canonical workflow stage/call transitions and interrupted-run hydration. */
+export class WorkflowExecutionState {
+  readonly #snapshot: WorkflowExecutionSnapshot;
+  readonly #publish: (snapshot: WorkflowExecutionSnapshot) => void;
+  readonly #hasDeclaredStages: boolean;
+  readonly #issuedCallIds = new Set<string>();
+  #sealed = false;
+
+  constructor(options: {
+    readonly phases: readonly { readonly title: string }[];
+    readonly tasks: readonly WorkflowScriptTask[];
+    readonly initialSnapshot?: WorkflowExecutionSnapshot;
+    readonly publish: (snapshot: WorkflowExecutionSnapshot) => void;
+  }) {
+    this.#publish = options.publish;
+    this.#hasDeclaredStages = options.phases.length > 0;
+    const createdAt = now();
+    const fresh: WorkflowExecutionSnapshot = {
+      lifecycle: WORKFLOW_EXECUTION_LIFECYCLE.WAITING,
+      stages: options.phases.map((phase, index) => ({
+        id: stageIdFor(index),
+        title: phase.title,
+        order: index,
+        lifecycle: WORKFLOW_EXECUTION_LIFECYCLE.WAITING,
+      })),
+      calls: options.tasks.map((task) => {
+        const timestamp = now();
+        const stageIndex = options.phases.findIndex(
+          (phase) => phase.title === task.phase,
+        );
+        return {
+          id: task.id,
+          label: task.label,
+          ...(task.phase !== undefined && {
+            stageId: stageIdFor(stageIndex),
+            stageTitle: task.phase,
+          }),
+          files: { input: [], context: [], media: [] },
+          attempts: [],
+          status:
+            task.phase === undefined
+              ? WORKFLOW_CALL_STATUS.PLANNED
+              : WORKFLOW_CALL_STATUS.STAGE_BLOCKED,
+          ...(task.phase !== undefined && {
+            blockedReason: `Waiting for stage ${task.phase}`,
+          }),
+          timestamps: { createdAt: timestamp, updatedAt: timestamp },
+        };
+      }),
+      counts: emptyCounts(),
+      timestamps: { createdAt, updatedAt: createdAt },
+    };
+    this.#snapshot = hydrate(fresh, options.initialSnapshot, createdAt);
+    this.#emit();
+  }
+
+  get currentPhase(): string | undefined {
+    return this.#snapshot.stages[this.currentPhaseIndex]?.title;
+  }
+
+  get currentPhaseIndex(): number {
+    return this.#snapshot.stages.findIndex(
+      (stage) => stage.id === this.#snapshot.currentStageId,
+    );
+  }
+
+  snapshot(): WorkflowExecutionSnapshot {
+    return structuredClone(this.#snapshot);
+  }
+
+  get isSealed(): boolean {
+    return this.#sealed;
+  }
+
+  enterStage(title: string): number {
+    if (this.#sealed) throw new Error('Workflow execution state is sealed.');
+    let nextIndex = this.#snapshot.stages.findIndex(
+      (stage) => stage.title === title,
+    );
+    if (nextIndex < 0 && this.#hasDeclaredStages) {
+      throw new Error(`phase() references undeclared stage "${title}".`);
+    }
+    if (nextIndex < 0) {
+      nextIndex = this.#snapshot.stages.length;
+      this.#snapshot.stages.push({
+        id: stageIdFor(nextIndex),
+        title,
+        order: nextIndex,
+        lifecycle: WORKFLOW_EXECUTION_LIFECYCLE.WAITING,
+      });
+    }
+    const currentStageIndex = this.currentPhaseIndex;
+    if (nextIndex < currentStageIndex) {
+      throw new Error(
+        `Workflow stages must advance monotonically; cannot enter "${title}" after ${this.currentPhase ?? 'the same stage'}.`,
+      );
+    }
+    if (nextIndex === currentStageIndex) return nextIndex;
+
+    const transitionAt = now();
+    const prior = this.#snapshot.stages[currentStageIndex];
+    if (prior) this.#settleStage(prior.id, transitionAt);
+    for (const stage of this.#snapshot.stages) {
+      if (
+        stage.order < nextIndex &&
+        stage.lifecycle === WORKFLOW_EXECUTION_LIFECYCLE.WAITING
+      ) {
+        stage.lifecycle = WORKFLOW_EXECUTION_LIFECYCLE.SKIPPED;
+        stage.completedAt = transitionAt;
+      }
+    }
+    const active = this.#snapshot.stages[nextIndex];
+    active.lifecycle = WORKFLOW_EXECUTION_LIFECYCLE.ACTIVE;
+    active.startedAt ??= transitionAt;
+    active.completedAt = undefined;
+    this.#snapshot.currentStageId = active.id;
+    this.#snapshot.lifecycle = WORKFLOW_EXECUTION_LIFECYCLE.ACTIVE;
+    for (const call of this.#snapshot.calls) {
+      if (
+        call.stageId === active.id &&
+        call.status === WORKFLOW_CALL_STATUS.STAGE_BLOCKED
+      ) {
+        call.status = WORKFLOW_CALL_STATUS.PLANNED;
+        call.blockedReason = undefined;
+        call.timestamps.updatedAt = transitionAt;
+      }
+    }
+    this.#emit();
+    return nextIndex;
+  }
+
+  issueCall(definition: WorkflowCallDefinition): void {
+    if (this.#sealed) throw new Error('Workflow execution state is sealed.');
+    if (this.#issuedCallIds.has(definition.id)) {
+      throw new Error(
+        `Workflow call id "${definition.id}" may be issued only once per run.`,
+      );
+    }
+    this.#issuedCallIds.add(definition.id);
+    let call = this.#snapshot.calls.find(
+      (candidate) => candidate.id === definition.id,
+    );
+    const stageIndex =
+      definition.phase === undefined
+        ? -1
+        : this.#snapshot.stages.findIndex(
+            (stage) => stage.title === definition.phase,
+          );
+    if (definition.phase !== undefined && stageIndex < 0) {
+      throw new Error(
+        `agent() references stage "${definition.phase}" before phase() entered it.`,
+      );
+    }
+    if (
+      definition.phase !== undefined &&
+      stageIndex !== this.currentPhaseIndex
+    ) {
+      throw new Error(
+        `agent() task ${definition.id} belongs to stage "${definition.phase}", but the current stage is ${this.currentPhase ?? 'not set'}.`,
+      );
+    }
+    const timestamp = now();
+    const canonical = {
+      label: definition.label,
+      stageId: stageIndex < 0 ? undefined : stageIdFor(stageIndex),
+      stageTitle: definition.phase,
+      agent: definition.agent,
+      files: definition.files,
+    };
+    if (!call) {
+      call = {
+        id: definition.id,
+        ...canonical,
+        attempts: [],
+        status: WORKFLOW_CALL_STATUS.PLANNED,
+        timestamps: { createdAt: timestamp, updatedAt: timestamp },
+      };
+      this.#snapshot.calls.push(call);
+    } else {
+      Object.assign(call, canonical);
+      call.timestamps.updatedAt = timestamp;
+    }
+    this.#emit();
+  }
+
+  call(id: string): WorkflowExecutionCall {
+    const call = this.#snapshot.calls.find((candidate) => candidate.id === id);
+    if (!call) throw new Error(`Workflow snapshot call ${id} is missing.`);
+    return call;
+  }
+
+  updateCall(
+    id: string,
+    patch: Partial<WorkflowExecutionCall>,
+  ): WorkflowExecutionCall {
+    const call = this.call(id);
+    if (this.#sealed) return call;
+    Object.assign(call, patch);
+    call.timestamps.updatedAt = now();
+    if (
+      patch.status === WORKFLOW_CALL_STATUS.QUEUED ||
+      patch.status === WORKFLOW_CALL_STATUS.STARTING ||
+      patch.status === WORKFLOW_CALL_STATUS.RUNNING
+    ) {
+      this.#snapshot.lifecycle = WORKFLOW_EXECUTION_LIFECYCLE.ACTIVE;
+    }
+    this.#refreshExitedStage(call.stageId);
+    this.#emit();
+    return call;
+  }
+
+  beginAttempt(id: string): void {
+    if (this.#sealed) return;
+    const call = this.call(id);
+    const startedAt = now();
+    call.attempts.push({ number: call.attempts.length + 1, startedAt });
+    call.status = WORKFLOW_CALL_STATUS.STARTING;
+    call.timestamps.startedAt ??= startedAt;
+    call.timestamps.updatedAt = startedAt;
+    this.#snapshot.lifecycle = WORKFLOW_EXECUTION_LIFECYCLE.ACTIVE;
+    this.#emit();
+  }
+
+  reportChildExecution(id: string, executionId: ExecutionId): void {
+    if (this.#sealed) return;
+    const call = this.call(id);
+    call.childExecutionId = executionId;
+    const attempt = call.attempts.at(-1);
+    if (attempt) attempt.id = executionId;
+    call.timestamps.updatedAt = now();
+    this.#emit();
+  }
+
+  reportChildStream(id: string, streamId: StreamTabId): void {
+    if (this.#sealed) return;
+    this.updateCall(id, { childStreamId: streamId });
+  }
+
+  settleAttempt(id: string): void {
+    if (this.#sealed) return;
+    const call = this.call(id);
+    const attempt = call.attempts.at(-1);
+    if (attempt && attempt.completedAt === undefined) {
+      attempt.completedAt = now();
+      call.timestamps.updatedAt = now();
+      this.#emit();
+    }
+  }
+
+  finish(
+    lifecycle: 'completed' | 'failed' | 'cancelled',
+    error?: string,
+  ): void {
+    if (this.#sealed) return;
+    const completedAt = now();
+    this.#snapshot.lifecycle = lifecycle;
+    this.#snapshot.currentStageId = undefined;
+    this.#snapshot.timestamps.completedAt = completedAt;
+    if (error) this.#snapshot.error = error;
+    for (const call of this.#snapshot.calls) {
+      const latestAttempt = call.attempts.at(-1);
+      if (latestAttempt && latestAttempt.completedAt === undefined) {
+        latestAttempt.completedAt = completedAt;
+      }
+      if (
+        call.status === WORKFLOW_CALL_STATUS.PLANNED ||
+        call.status === WORKFLOW_CALL_STATUS.STAGE_BLOCKED
+      ) {
+        call.status = WORKFLOW_CALL_STATUS.SKIPPED;
+        call.blockedReason = 'Workflow ended before this call was reached';
+        call.timestamps.completedAt = completedAt;
+        call.timestamps.updatedAt = completedAt;
+      } else if (
+        call.status === WORKFLOW_CALL_STATUS.QUEUED ||
+        call.status === WORKFLOW_CALL_STATUS.STARTING ||
+        call.status === WORKFLOW_CALL_STATUS.RUNNING
+      ) {
+        call.status =
+          lifecycle === WORKFLOW_EXECUTION_LIFECYCLE.CANCELLED
+            ? WORKFLOW_CALL_STATUS.CANCELLED
+            : WORKFLOW_CALL_STATUS.FAILED;
+        call.error ??= 'Workflow ended before this call completed';
+        call.timestamps.completedAt = completedAt;
+        call.timestamps.updatedAt = completedAt;
+      }
+    }
+    for (const stage of this.#snapshot.stages) {
+      if (stage.lifecycle === WORKFLOW_EXECUTION_LIFECYCLE.WAITING) {
+        stage.lifecycle = WORKFLOW_EXECUTION_LIFECYCLE.SKIPPED;
+        stage.completedAt = completedAt;
+      } else {
+        this.#settleStage(stage.id, completedAt);
+      }
+    }
+    this.#emit();
+    this.#sealed = true;
+  }
+
+  #refreshExitedStage(stageId: string | undefined): void {
+    if (!stageId || stageId === this.#snapshot.currentStageId) return;
+    const calls = this.#snapshot.calls.filter(
+      (call) => call.stageId === stageId,
+    );
+    if (calls.every((call) => TERMINAL_CALL_STATUSES.has(call.status))) {
+      this.#settleStage(stageId, now());
+    }
+  }
+
+  #settleStage(stageId: string, completedAt: string): void {
+    const stage = this.#snapshot.stages.find(
+      (candidate) => candidate.id === stageId,
+    );
+    if (!stage) return;
+    const calls = this.#snapshot.calls.filter(
+      (call) => call.stageId === stageId,
+    );
+    if (
+      calls.length === 0 ||
+      calls.every((call) => call.status === WORKFLOW_CALL_STATUS.SKIPPED)
+    ) {
+      stage.lifecycle = WORKFLOW_EXECUTION_LIFECYCLE.SKIPPED;
+    } else if (
+      calls.some((call) => call.status === WORKFLOW_CALL_STATUS.FAILED)
+    ) {
+      stage.lifecycle = WORKFLOW_EXECUTION_LIFECYCLE.FAILED;
+    } else if (
+      calls.some((call) => call.status === WORKFLOW_CALL_STATUS.CANCELLED)
+    ) {
+      stage.lifecycle = WORKFLOW_EXECUTION_LIFECYCLE.CANCELLED;
+    } else {
+      stage.lifecycle = WORKFLOW_EXECUTION_LIFECYCLE.COMPLETED;
+    }
+    stage.completedAt = completedAt;
+  }
+
+  #emit(): void {
+    const counts = emptyCounts();
+    for (const call of this.#snapshot.calls) counts[call.status] += 1;
+    counts.total = this.#snapshot.calls.length;
+    counts.waiting = counts.planned + counts.stageBlocked;
+    this.#snapshot.counts = counts;
+    this.#snapshot.timestamps.updatedAt = now();
+    this.#publish(structuredClone(this.#snapshot));
+  }
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function stageIdFor(index: number): string {
+  return `stage-${index + 1}`;
+}
+
+function emptyCounts(): WorkflowExecutionSnapshot['counts'] {
+  return {
+    total: 0,
+    waiting: 0,
+    planned: 0,
+    stageBlocked: 0,
+    queued: 0,
+    starting: 0,
+    running: 0,
+    completed: 0,
+    failed: 0,
+    cancelled: 0,
+    skipped: 0,
+    cached: 0,
+  };
+}
+
+function hydrate(
+  fresh: WorkflowExecutionSnapshot,
+  persisted: WorkflowExecutionSnapshot | undefined,
+  recoveryAt: string,
+): WorkflowExecutionSnapshot {
+  if (!persisted) return fresh;
+  const snapshot = structuredClone(fresh);
+  snapshot.timestamps.createdAt = persisted.timestamps.createdAt;
+  const freshIds = new Set(snapshot.calls.map((call) => call.id));
+  const priorById = new Map(persisted.calls.map((call) => [call.id, call]));
+  snapshot.calls = snapshot.calls.map((call) => {
+    const prior = priorById.get(call.id);
+    if (!prior) return call;
+    const reusable =
+      prior.status === WORKFLOW_CALL_STATUS.COMPLETED ||
+      prior.status === WORKFLOW_CALL_STATUS.CACHED ||
+      prior.status === WORKFLOW_CALL_STATUS.SKIPPED;
+    return {
+      ...prior,
+      label: call.label,
+      stageId: call.stageId,
+      stageTitle: call.stageTitle,
+      files: call.files,
+      status: reusable ? prior.status : call.status,
+      ...(!reusable && {
+        childExecutionId: undefined,
+        childStreamId: undefined,
+        blockedReason: call.blockedReason,
+        error: undefined,
+        timestamps: {
+          ...call.timestamps,
+          createdAt: prior.timestamps.createdAt,
+          updatedAt: recoveryAt,
+        },
+      }),
+    };
+  });
+  for (const prior of persisted.calls) {
+    if (!freshIds.has(prior.id)) {
+      snapshot.calls.push({
+        ...prior,
+        stageId: undefined,
+        stageTitle: undefined,
+        status: WORKFLOW_CALL_STATUS.PLANNED,
+        childExecutionId: undefined,
+        childStreamId: undefined,
+        blockedReason: undefined,
+        error: undefined,
+        timestamps: { ...prior.timestamps, updatedAt: recoveryAt },
+      });
+    }
+  }
+  return snapshot;
+}

--- a/src/agent/workflowScript/workflowExecutionState.ts
+++ b/src/agent/workflowScript/workflowExecutionState.ts
@@ -320,6 +320,9 @@ export class WorkflowExecutionState {
   ): void {
     if (this.#sealed) return;
     const completedAt = now();
+    // Capture before clearing so orchestration failures can terminalize the
+    // stage the script was inside even when no call encodes that failure.
+    const activeStageId = this.#snapshot.currentStageId;
     this.#snapshot.lifecycle = lifecycle;
     this.#snapshot.currentStageId = undefined;
     this.#snapshot.timestamps.completedAt = completedAt;
@@ -357,6 +360,27 @@ export class WorkflowExecutionState {
         stage.completedAt = completedAt;
       } else {
         this.#settleStage(stage.id, completedAt);
+      }
+    }
+    // Call-derived settlement alone can mark the active stage completed or
+    // skipped when the script threw/cancelled after phase() with no live
+    // failed call (e.g. a JS reduction error). Force the active stage to the
+    // workflow terminal lifecycle so /executions/{id} shows where orchestration
+    // failed.
+    if (
+      activeStageId !== undefined &&
+      (lifecycle === WORKFLOW_EXECUTION_LIFECYCLE.FAILED ||
+        lifecycle === WORKFLOW_EXECUTION_LIFECYCLE.CANCELLED)
+    ) {
+      const activeStage = this.#snapshot.stages.find(
+        (stage) => stage.id === activeStageId,
+      );
+      if (activeStage) {
+        activeStage.lifecycle =
+          lifecycle === WORKFLOW_EXECUTION_LIFECYCLE.CANCELLED
+            ? WORKFLOW_EXECUTION_LIFECYCLE.CANCELLED
+            : WORKFLOW_EXECUTION_LIFECYCLE.FAILED;
+        activeStage.completedAt = completedAt;
       }
     }
     this.#emit();
@@ -482,7 +506,12 @@ function hydrate(
       label: call.label,
       stageId: call.stageId,
       stageTitle: call.stageTitle,
-      files: call.files,
+      // Reusable completed/cached calls keep their resolved file lists. The
+      // fresh meta.tasks stub has empty arrays; overwriting would flush blank
+      // files on the constructor emit before the script re-issues those calls.
+      // Non-reusable interrupted calls take the fresh plan (issueCall fills
+      // files when the call is relaunched).
+      files: reusable ? prior.files : call.files,
       attempts,
       costUsd: totalAttemptCost(attempts),
       status: reusable ? prior.status : call.status,

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -36,6 +36,7 @@ export * from './roundIndexed';
 export * from './output';
 export * from './progressEvents';
 export * from './workflowCallProgress';
+export * from './workflowExecutionSnapshot';
 export * from './workflowScriptDelivery';
 
 // Layer 3: Depends on layer 2

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -79,8 +79,8 @@ export const USER_FOLLOW_UP_SUPPORT = {
 export const UserFollowUpSupportSchema = z.enum(USER_FOLLOW_UP_SUPPORT);
 export type UserFollowUpSupport = z.infer<typeof UserFollowUpSupportSchema>;
 
-/** Execution metadata stored alongside config at launch time. */
-export const ExecutionMetaSchema = z.object({
+/** Core execution metadata that remains readable without workflow observability. */
+export const ExecutionMetaCoreSchema = z.object({
   schemaVersion: z.literal(EXECUTION_META_SCHEMA_VERSION).prefault(1),
   timestamp: z.string(),
   parentExecutionId: ExecutionIdSchema.optional(),
@@ -99,14 +99,18 @@ export const ExecutionMetaSchema = z.object({
   userFollowUpSupport: UserFollowUpSupportSchema.optional(),
   /** AI-generated summary of what the session aimed to accomplish. */
   description: z.string().optional(),
-  /** Canonical execution state for a detached workflow run. */
-  workflow: WorkflowExecutionSnapshotSchema.optional(),
   /**
    * The transcript stream this execution's data lives under — the ONE
    * execution→stream mapping, written at registration. A row without one has
    * no persisted stream; nothing re-derives it from names or scans.
    */
   streamId: StreamTabIdSchema.optional(),
+});
+
+/** Execution metadata stored alongside config at launch time. */
+export const ExecutionMetaSchema = ExecutionMetaCoreSchema.extend({
+  /** Canonical execution state for a detached workflow run. */
+  workflow: WorkflowExecutionSnapshotSchema.optional(),
 });
 
 export type ExecutionMeta = z.infer<typeof ExecutionMetaSchema>;

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { AgentCategorySchema } from './agent';
 import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
 import { RunIdentitySchema } from './runIdentity';
+import { WorkflowExecutionSnapshotSchema } from './workflowExecutionSnapshot';
 
 /**
  * The retired 7-value live-status vocabulary. **Read-only residue** — no
@@ -98,6 +99,8 @@ export const ExecutionMetaSchema = z.object({
   userFollowUpSupport: UserFollowUpSupportSchema.optional(),
   /** AI-generated summary of what the session aimed to accomplish. */
   description: z.string().optional(),
+  /** Canonical execution state for a detached workflow run. */
+  workflow: WorkflowExecutionSnapshotSchema.optional(),
   /**
    * The transcript stream this execution's data lives under — the ONE
    * execution→stream mapping, written at registration. A row without one has

--- a/src/shared/schemas/workflowExecutionSnapshot.ts
+++ b/src/shared/schemas/workflowExecutionSnapshot.ts
@@ -50,6 +50,9 @@ const WorkflowExecutionStageSchema = z.strictObject({
 const WorkflowExecutionAttemptSchema = z.strictObject({
   number: z.int().positive(),
   id: ExecutionIdSchema.optional(),
+  childStreamId: StreamTabIdSchema.optional(),
+  model: z.string().optional(),
+  costUsd: z.number().nonnegative().optional(),
   startedAt: z.iso.datetime(),
   completedAt: z.iso.datetime().optional(),
 });
@@ -90,20 +93,14 @@ const WorkflowExecutionCountsSchema = z.strictObject({
   skipped: z.int().nonnegative(),
   cached: z.int().nonnegative(),
 });
-const LIVE_CALL_STATUSES = new Set<WorkflowExecutionCallStatus>([
-  WORKFLOW_CALL_STATUS.PLANNED,
-  WORKFLOW_CALL_STATUS.STAGE_BLOCKED,
-  WORKFLOW_CALL_STATUS.QUEUED,
-  WORKFLOW_CALL_STATUS.STARTING,
-  WORKFLOW_CALL_STATUS.RUNNING,
-]);
-const TERMINAL_CALL_STATUSES = new Set<WorkflowExecutionCallStatus>([
-  WORKFLOW_CALL_STATUS.COMPLETED,
-  WORKFLOW_CALL_STATUS.FAILED,
-  WORKFLOW_CALL_STATUS.CANCELLED,
-  WORKFLOW_CALL_STATUS.SKIPPED,
-  WORKFLOW_CALL_STATUS.CACHED,
-]);
+export const TERMINAL_WORKFLOW_CALL_STATUSES: ReadonlySet<WorkflowExecutionCallStatus> =
+  new Set([
+    WORKFLOW_CALL_STATUS.COMPLETED,
+    WORKFLOW_CALL_STATUS.FAILED,
+    WORKFLOW_CALL_STATUS.CANCELLED,
+    WORKFLOW_CALL_STATUS.SKIPPED,
+    WORKFLOW_CALL_STATUS.CACHED,
+  ]);
 const TERMINAL_LIFECYCLES = new Set<WorkflowExecutionLifecycle>([
   WORKFLOW_EXECUTION_LIFECYCLE.COMPLETED,
   WORKFLOW_EXECUTION_LIFECYCLE.FAILED,
@@ -221,7 +218,7 @@ export const WorkflowExecutionSnapshotSchema = z
           });
       }
       if (
-        TERMINAL_CALL_STATUSES.has(call.status) &&
+        TERMINAL_WORKFLOW_CALL_STATUSES.has(call.status) &&
         call.timestamps.completedAt === undefined
       )
         context.addIssue({
@@ -230,7 +227,7 @@ export const WorkflowExecutionSnapshotSchema = z
           message: 'A terminal workflow call requires completedAt.',
         });
       if (
-        TERMINAL_CALL_STATUSES.has(call.status) &&
+        TERMINAL_WORKFLOW_CALL_STATUSES.has(call.status) &&
         call.attempts.some((attempt) => attempt.completedAt === undefined)
       )
         context.addIssue({
@@ -270,7 +267,11 @@ export const WorkflowExecutionSnapshotSchema = z
           path: ['timestamps', 'completedAt'],
           message: 'A terminal workflow snapshot requires completedAt.',
         });
-      if (snapshot.calls.some((call) => LIVE_CALL_STATUSES.has(call.status)))
+      if (
+        snapshot.calls.some(
+          (call) => !TERMINAL_WORKFLOW_CALL_STATUSES.has(call.status),
+        )
+      )
         context.addIssue({
           code: 'custom',
           path: ['calls'],

--- a/src/shared/schemas/workflowExecutionSnapshot.ts
+++ b/src/shared/schemas/workflowExecutionSnapshot.ts
@@ -1,0 +1,283 @@
+import { z } from 'zod';
+
+import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
+
+export const WORKFLOW_EXECUTION_LIFECYCLE = {
+  WAITING: 'waiting',
+  ACTIVE: 'active',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+  SKIPPED: 'skipped',
+  CANCELLED: 'cancelled',
+} as const;
+const WorkflowExecutionLifecycleSchema = z.enum(WORKFLOW_EXECUTION_LIFECYCLE);
+type WorkflowExecutionLifecycle = z.infer<
+  typeof WorkflowExecutionLifecycleSchema
+>;
+
+export const WORKFLOW_CALL_STATUS = {
+  PLANNED: 'planned',
+  STAGE_BLOCKED: 'stageBlocked',
+  QUEUED: 'queued',
+  STARTING: 'starting',
+  RUNNING: 'running',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+  CANCELLED: 'cancelled',
+  SKIPPED: 'skipped',
+  CACHED: 'cached',
+} as const;
+const WorkflowExecutionCallStatusSchema = z.enum(WORKFLOW_CALL_STATUS);
+export type WorkflowExecutionCallStatus = z.infer<
+  typeof WorkflowExecutionCallStatusSchema
+>;
+
+const WorkflowExecutionTimestampsSchema = z.strictObject({
+  createdAt: z.iso.datetime(),
+  queuedAt: z.iso.datetime().optional(),
+  startedAt: z.iso.datetime().optional(),
+  updatedAt: z.iso.datetime(),
+  completedAt: z.iso.datetime().optional(),
+});
+const WorkflowExecutionStageSchema = z.strictObject({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  order: z.int().nonnegative(),
+  lifecycle: WorkflowExecutionLifecycleSchema,
+  startedAt: z.iso.datetime().optional(),
+  completedAt: z.iso.datetime().optional(),
+});
+const WorkflowExecutionAttemptSchema = z.strictObject({
+  number: z.int().positive(),
+  id: ExecutionIdSchema.optional(),
+  startedAt: z.iso.datetime(),
+  completedAt: z.iso.datetime().optional(),
+});
+const WorkflowExecutionCallSchema = z.strictObject({
+  id: z.string().min(1),
+  label: z.string(),
+  stageId: z.string().min(1).optional(),
+  stageTitle: z.string().min(1).optional(),
+  agent: z.string().optional(),
+  model: z.string().optional(),
+  files: z.strictObject({
+    input: z.array(z.string()),
+    context: z.array(z.string()),
+    media: z.array(z.string()),
+  }),
+  childExecutionId: ExecutionIdSchema.optional(),
+  childStreamId: StreamTabIdSchema.optional(),
+  attempts: z.array(WorkflowExecutionAttemptSchema),
+  status: WorkflowExecutionCallStatusSchema,
+  blockedReason: z.string().optional(),
+  error: z.string().optional(),
+  costUsd: z.number().nonnegative().optional(),
+  timestamps: WorkflowExecutionTimestampsSchema,
+});
+export type WorkflowExecutionCall = z.infer<typeof WorkflowExecutionCallSchema>;
+
+const WorkflowExecutionCountsSchema = z.strictObject({
+  total: z.int().nonnegative(),
+  waiting: z.int().nonnegative(),
+  planned: z.int().nonnegative(),
+  stageBlocked: z.int().nonnegative(),
+  queued: z.int().nonnegative(),
+  starting: z.int().nonnegative(),
+  running: z.int().nonnegative(),
+  completed: z.int().nonnegative(),
+  failed: z.int().nonnegative(),
+  cancelled: z.int().nonnegative(),
+  skipped: z.int().nonnegative(),
+  cached: z.int().nonnegative(),
+});
+const LIVE_CALL_STATUSES = new Set<WorkflowExecutionCallStatus>([
+  WORKFLOW_CALL_STATUS.PLANNED,
+  WORKFLOW_CALL_STATUS.STAGE_BLOCKED,
+  WORKFLOW_CALL_STATUS.QUEUED,
+  WORKFLOW_CALL_STATUS.STARTING,
+  WORKFLOW_CALL_STATUS.RUNNING,
+]);
+const TERMINAL_CALL_STATUSES = new Set<WorkflowExecutionCallStatus>([
+  WORKFLOW_CALL_STATUS.COMPLETED,
+  WORKFLOW_CALL_STATUS.FAILED,
+  WORKFLOW_CALL_STATUS.CANCELLED,
+  WORKFLOW_CALL_STATUS.SKIPPED,
+  WORKFLOW_CALL_STATUS.CACHED,
+]);
+const TERMINAL_LIFECYCLES = new Set<WorkflowExecutionLifecycle>([
+  WORKFLOW_EXECUTION_LIFECYCLE.COMPLETED,
+  WORKFLOW_EXECUTION_LIFECYCLE.FAILED,
+  WORKFLOW_EXECUTION_LIFECYCLE.SKIPPED,
+  WORKFLOW_EXECUTION_LIFECYCLE.CANCELLED,
+]);
+
+export const WorkflowExecutionSnapshotSchema = z
+  .strictObject({
+    lifecycle: WorkflowExecutionLifecycleSchema,
+    currentStageId: z.string().min(1).optional(),
+    stages: z.array(WorkflowExecutionStageSchema),
+    calls: z.array(WorkflowExecutionCallSchema),
+    counts: WorkflowExecutionCountsSchema,
+    error: z.string().optional(),
+    timestamps: z.strictObject({
+      createdAt: z.iso.datetime(),
+      updatedAt: z.iso.datetime(),
+      completedAt: z.iso.datetime().optional(),
+    }),
+  })
+  .superRefine((snapshot, context) => {
+    const stageIds = new Set<string>();
+    const stageOrders = new Set<number>();
+    const activeStages = snapshot.stages.filter(
+      (stage) => stage.lifecycle === WORKFLOW_EXECUTION_LIFECYCLE.ACTIVE,
+    );
+    if (activeStages.length > 1) {
+      context.addIssue({
+        code: 'custom',
+        path: ['stages'],
+        message: 'A workflow snapshot can have at most one active stage.',
+      });
+    }
+    for (const [index, stage] of snapshot.stages.entries()) {
+      if (stageIds.has(stage.id))
+        context.addIssue({
+          code: 'custom',
+          path: ['stages', index, 'id'],
+          message: `Duplicate workflow stage id "${stage.id}".`,
+        });
+      if (stageOrders.has(stage.order))
+        context.addIssue({
+          code: 'custom',
+          path: ['stages', index, 'order'],
+          message: `Duplicate workflow stage order ${stage.order}.`,
+        });
+      if (
+        stage.lifecycle !== WORKFLOW_EXECUTION_LIFECYCLE.WAITING &&
+        stage.lifecycle !== WORKFLOW_EXECUTION_LIFECYCLE.ACTIVE &&
+        stage.completedAt === undefined
+      ) {
+        context.addIssue({
+          code: 'custom',
+          path: ['stages', index, 'completedAt'],
+          message: 'A terminal workflow stage requires completedAt.',
+        });
+      }
+      stageIds.add(stage.id);
+      stageOrders.add(stage.order);
+    }
+    if (snapshot.currentStageId !== activeStages[0]?.id) {
+      context.addIssue({
+        code: 'custom',
+        path: ['currentStageId'],
+        message: 'currentStageId must identify the one active workflow stage.',
+      });
+    }
+
+    const callIds = new Set<string>();
+    const actualCounts = Object.fromEntries(
+      Object.values(WORKFLOW_CALL_STATUS).map((status) => [status, 0]),
+    ) as Record<WorkflowExecutionCallStatus, number>;
+    for (const [index, call] of snapshot.calls.entries()) {
+      if (callIds.has(call.id))
+        context.addIssue({
+          code: 'custom',
+          path: ['calls', index, 'id'],
+          message: `Duplicate workflow call id "${call.id}".`,
+        });
+      callIds.add(call.id);
+      actualCounts[call.status] += 1;
+      if (call.stageId !== undefined) {
+        const stage = snapshot.stages.find(
+          (candidate) => candidate.id === call.stageId,
+        );
+        if (!stage || call.stageTitle !== stage.title)
+          context.addIssue({
+            code: 'custom',
+            path: ['calls', index, 'stageId'],
+            message: 'A workflow call stage must reference a matching stage.',
+          });
+      } else if (call.stageTitle !== undefined) {
+        context.addIssue({
+          code: 'custom',
+          path: ['calls', index, 'stageTitle'],
+          message: 'Workflow call stageTitle requires stageId.',
+        });
+      }
+      for (const [attemptIndex, attempt] of call.attempts.entries()) {
+        if (attempt.number !== attemptIndex + 1)
+          context.addIssue({
+            code: 'custom',
+            path: ['calls', index, 'attempts', attemptIndex, 'number'],
+            message: 'Workflow attempt numbers must be contiguous from 1.',
+          });
+        if (
+          attemptIndex < call.attempts.length - 1 &&
+          attempt.completedAt === undefined
+        )
+          context.addIssue({
+            code: 'custom',
+            path: ['calls', index, 'attempts', attemptIndex, 'completedAt'],
+            message: 'A superseded workflow attempt requires completedAt.',
+          });
+      }
+      if (
+        TERMINAL_CALL_STATUSES.has(call.status) &&
+        call.timestamps.completedAt === undefined
+      )
+        context.addIssue({
+          code: 'custom',
+          path: ['calls', index, 'timestamps', 'completedAt'],
+          message: 'A terminal workflow call requires completedAt.',
+        });
+      if (
+        TERMINAL_CALL_STATUSES.has(call.status) &&
+        call.attempts.some((attempt) => attempt.completedAt === undefined)
+      )
+        context.addIssue({
+          code: 'custom',
+          path: ['calls', index, 'attempts'],
+          message: 'A terminal workflow call cannot have an open attempt.',
+        });
+    }
+    for (const status of Object.values(WORKFLOW_CALL_STATUS)) {
+      if (snapshot.counts[status] !== actualCounts[status])
+        context.addIssue({
+          code: 'custom',
+          path: ['counts', status],
+          message: `Workflow ${status} count must equal direct calls.`,
+        });
+    }
+    if (snapshot.counts.total !== snapshot.calls.length)
+      context.addIssue({
+        code: 'custom',
+        path: ['counts', 'total'],
+        message: 'Workflow total count must equal direct calls.',
+      });
+    if (
+      snapshot.counts.waiting !==
+      actualCounts.planned + actualCounts.stageBlocked
+    )
+      context.addIssue({
+        code: 'custom',
+        path: ['counts', 'waiting'],
+        message:
+          'Workflow waiting count must equal planned plus stage-blocked calls.',
+      });
+    if (TERMINAL_LIFECYCLES.has(snapshot.lifecycle)) {
+      if (snapshot.timestamps.completedAt === undefined)
+        context.addIssue({
+          code: 'custom',
+          path: ['timestamps', 'completedAt'],
+          message: 'A terminal workflow snapshot requires completedAt.',
+        });
+      if (snapshot.calls.some((call) => LIVE_CALL_STATUSES.has(call.status)))
+        context.addIssue({
+          code: 'custom',
+          path: ['calls'],
+          message: 'A terminal workflow snapshot cannot contain live calls.',
+        });
+    }
+  });
+export type WorkflowExecutionSnapshot = z.infer<
+  typeof WorkflowExecutionSnapshotSchema
+>;

--- a/src/test-kernel/agent/WorkflowExecutionObservability.vitest.ts
+++ b/src/test-kernel/agent/WorkflowExecutionObservability.vitest.ts
@@ -223,6 +223,13 @@ return await agent('retry secret', { label: 'Retry task' })`,
       { number: 1, id: 'aaaaaaaaaaaa' },
       { number: 2, id: 'bbbbbbbbbbbb' },
     ]);
+    // Logical call start must survive re-queue so duration covers every attempt.
+    const firstAttemptStarted =
+      retried.snapshot.calls[0]?.attempts[0]?.startedAt;
+    expect(firstAttemptStarted).toEqual(expect.any(String));
+    expect(retried.snapshot.calls[0]?.timestamps.startedAt).toBe(
+      firstAttemptStarted,
+    );
 
     let skipControl!: WorkflowScriptControl;
     let skipStarted = false;

--- a/src/test-kernel/agent/WorkflowExecutionObservability.vitest.ts
+++ b/src/test-kernel/agent/WorkflowExecutionObservability.vitest.ts
@@ -373,6 +373,59 @@ return [failed, passed]`,
     ).toBe(true);
   });
 
+  it('marks the active stage failed when orchestration throws with no failed call', async () => {
+    const snapshots: WorkflowExecutionSnapshot[] = [];
+    await expect(
+      runWorkflowScript({
+        script: `export const meta = {
+  name: 'orchestration-fail',
+  description: 'stage fails without a failed call',
+  phases: ['Merge'],
+}
+phase('Merge')
+const ok = await agent('already done', { id: 'done' })
+throw new Error('reduce failed after success')`,
+        runAgent: async () => 'done',
+        onSnapshot: (snapshot) => {
+          snapshots.push(snapshot);
+        },
+      }),
+    ).rejects.toThrow(/reduce failed after success/);
+
+    // Script throw after a successful call must not leave Merge as completed
+    // just because call-derived settlement saw only completed work.
+    const terminal = finalSnapshot(snapshots);
+    expect(terminal.lifecycle).toBe('failed');
+    expect(terminal.stages[0]?.lifecycle).toBe('failed');
+    expect(terminal.calls[0]?.status).toBe('completed');
+  });
+
+  it('marks a call-less active stage failed on orchestration throw', async () => {
+    const snapshots: WorkflowExecutionSnapshot[] = [];
+    await expect(
+      runWorkflowScript({
+        script: `export const meta = {
+  name: 'empty-stage-fail',
+  description: 'phase with no agent() then throw',
+  phases: ['Merge'],
+}
+phase('Merge')
+throw new Error('reduce only')`,
+        runAgent: async () => {
+          throw new Error('must not run');
+        },
+        onSnapshot: (snapshot) => {
+          snapshots.push(snapshot);
+        },
+      }),
+    ).rejects.toThrow(/reduce only/);
+
+    const terminal = finalSnapshot(snapshots);
+    expect(terminal.lifecycle).toBe('failed');
+    // Without the active-stage override, call-less stages settle as skipped.
+    expect(terminal.stages[0]?.lifecycle).toBe('failed');
+  });
+
   it('terminalizes cancellation with no live tasks and balanced counts', async () => {
     const controller = new AbortController();
     const snapshots: WorkflowExecutionSnapshot[] = [];

--- a/src/test-kernel/agent/WorkflowExecutionObservability.vitest.ts
+++ b/src/test-kernel/agent/WorkflowExecutionObservability.vitest.ts
@@ -1,0 +1,547 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  WORKFLOW_SKIPPED_RESULT,
+  runWorkflowScript,
+  type WorkflowAgentInvocation,
+  type WorkflowScriptControl,
+} from '@agent/workflowScript';
+import {
+  WorkflowExecutionSnapshotSchema,
+  type ExecutionId,
+  type WorkflowExecutionSnapshot,
+} from '@shared/schemas';
+
+const META = `export const meta = {
+  name: 'observable',
+  description: 'observable workflow',
+  phases: ['Draft', 'Review'],
+  tasks: [
+    { id: 'draft', label: 'Draft', phase: 'Draft' },
+    { id: 'review', label: 'Review', phase: 'Review' },
+  ],
+}
+`;
+
+function finalSnapshot(snapshots: readonly WorkflowExecutionSnapshot[]) {
+  return snapshots.at(-1)!;
+}
+
+describe('workflow execution observability', () => {
+  it('keeps later tasks stage-blocked, advances stages monotonically, and skips unreached work', async () => {
+    const snapshots: WorkflowExecutionSnapshot[] = [];
+    const result = await runWorkflowScript({
+      script: `${META}phase('Draft')
+await agent('draft privately', { id: 'draft' })
+return 'done'`,
+      runAgent: async () => 'done',
+      onSnapshot: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    });
+
+    expect(
+      snapshots.some(
+        (snapshot) =>
+          snapshot.calls.find((call) => call.id === 'review')?.status ===
+          'stageBlocked',
+      ),
+    ).toBe(true);
+    expect(result.snapshot.stages.map((stage) => stage.lifecycle)).toEqual([
+      'completed',
+      'skipped',
+    ]);
+    expect(result.snapshot.calls.map((call) => call.status)).toEqual([
+      'completed',
+      'skipped',
+    ]);
+    expect(result.snapshot.currentStageId).toBeUndefined();
+    expect(() =>
+      WorkflowExecutionSnapshotSchema.parse(result.snapshot),
+    ).not.toThrow();
+    const openTerminalAttempt = structuredClone(result.snapshot);
+    openTerminalAttempt.calls[0]!.attempts[0]!.completedAt = undefined;
+    expect(
+      WorkflowExecutionSnapshotSchema.safeParse(openTerminalAttempt).success,
+    ).toBe(false);
+
+    const failedSnapshots: WorkflowExecutionSnapshot[] = [];
+    await expect(
+      runWorkflowScript({
+        script: `${META}phase('Review')
+phase('Draft')
+return null`,
+        runAgent: async () => 'unused',
+        onSnapshot: (snapshot) => {
+          failedSnapshots.push(snapshot);
+        },
+      }),
+    ).rejects.toThrow(/monotonically/);
+    expect(finalSnapshot(failedSnapshots).lifecycle).toBe('failed');
+  });
+
+  it('rejects empty structural identities, titles, and stage references', async () => {
+    const snapshots: WorkflowExecutionSnapshot[] = [];
+    const result = await runWorkflowScript({
+      script: `export const meta = {
+  name: 'structural-fields',
+  description: 'structural field validation',
+  phases: ['Work'],
+}
+phase('Work')
+return await agent('work', { id: 'work-call' })`,
+      runAgent: async (invocation) => {
+        invocation.reportChildExecution?.('aaaaaaaaaaaa');
+        return 'done';
+      },
+      onSnapshot: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    });
+
+    const emptyStageId = structuredClone(result.snapshot);
+    emptyStageId.stages[0]!.id = '';
+    emptyStageId.calls[0]!.stageId = '';
+    expect(
+      WorkflowExecutionSnapshotSchema.safeParse(emptyStageId).success,
+    ).toBe(false);
+
+    const emptyStageTitle = structuredClone(result.snapshot);
+    emptyStageTitle.stages[0]!.title = '';
+    emptyStageTitle.calls[0]!.stageTitle = '';
+    expect(
+      WorkflowExecutionSnapshotSchema.safeParse(emptyStageTitle).success,
+    ).toBe(false);
+
+    const emptyCallId = structuredClone(result.snapshot);
+    emptyCallId.calls[0]!.id = '';
+    expect(WorkflowExecutionSnapshotSchema.safeParse(emptyCallId).success).toBe(
+      false,
+    );
+
+    const emptyAttemptId = structuredClone(result.snapshot);
+    emptyAttemptId.calls[0]!.attempts[0]!.id = '' as ExecutionId;
+    expect(
+      WorkflowExecutionSnapshotSchema.safeParse(emptyAttemptId).success,
+    ).toBe(false);
+
+    const active = structuredClone(
+      snapshots.find(
+        (snapshot) =>
+          snapshot.currentStageId !== undefined &&
+          snapshot.calls[0]?.status === 'running',
+      )!,
+    );
+    active.stages[0]!.id = '';
+    active.calls[0]!.stageId = '';
+    active.currentStageId = '';
+    expect(WorkflowExecutionSnapshotSchema.safeParse(active).success).toBe(
+      false,
+    );
+  });
+
+  it('records queued work before admission and starts attempts only inside the queue slot', async () => {
+    let release!: () => void;
+    const firstRun = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const runner = vi.fn(async (invocation: WorkflowAgentInvocation) => {
+      if (invocation.index === 0) await firstRun;
+      return 'done';
+    });
+    const snapshots: WorkflowExecutionSnapshot[] = [];
+    const run = runWorkflowScript({
+      script: `export const meta = {
+  name: 'queue',
+  description: 'queue observation',
+}
+return await parallel([
+  () => agent('first secret', { id: 'first', label: 'First' }),
+  () => agent('second secret', { id: 'second', label: 'Second' }),
+])`,
+      concurrency: 1,
+      runAgent: runner,
+      onSnapshot: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(runner).toHaveBeenCalledTimes(1);
+      expect(
+        snapshots.some(
+          (snapshot) =>
+            snapshot.calls[0]?.status === 'running' &&
+            snapshot.calls[1]?.status === 'queued' &&
+            snapshot.calls[1]?.attempts.length === 0,
+        ),
+      ).toBe(true);
+    });
+    release();
+    const result = await run;
+    expect(result.snapshot.counts.completed).toBe(2);
+    expect(
+      result.snapshot.calls.every((call) => call.attempts.length === 1),
+    ).toBe(true);
+  });
+
+  it('tracks retry attempts, interactive skip, cached replay, and failure-continue', async () => {
+    let control!: WorkflowScriptControl;
+    let attempts = 0;
+    const releases: Array<() => void> = [];
+    const retryRun = runWorkflowScript({
+      script: `export const meta = {
+  name: 'retry',
+  description: 'retry observation',
+}
+return await agent('retry secret', { label: 'Retry task' })`,
+      runAgent: async (invocation) => {
+        attempts += 1;
+        invocation.reportChildExecution?.(
+          attempts === 1 ? 'aaaaaaaaaaaa' : 'bbbbbbbbbbbb',
+        );
+        await new Promise<void>((resolve, reject) => {
+          releases.push(resolve);
+          invocation.signal.addEventListener(
+            'abort',
+            () => reject(new Error('retrying')),
+            { once: true },
+          );
+        });
+        return `attempt-${attempts}`;
+      },
+      onControl: (value) => {
+        control = value;
+      },
+    });
+    await vi.waitFor(() => expect(attempts).toBe(1));
+    control.retry(0);
+    await vi.waitFor(() => expect(attempts).toBe(2));
+    releases.at(-1)?.();
+    const retried = await retryRun;
+    expect(retried.snapshot.calls[0]?.attempts).toMatchObject([
+      { number: 1, id: 'aaaaaaaaaaaa' },
+      { number: 2, id: 'bbbbbbbbbbbb' },
+    ]);
+
+    let skipControl!: WorkflowScriptControl;
+    let skipStarted = false;
+    const skipRun = runWorkflowScript({
+      script: `export const meta = {
+  name: 'skip',
+  description: 'skip observation',
+}
+return await agent('skip secret', { label: 'Skip task' })`,
+      runAgent: async (invocation) => {
+        skipStarted = true;
+        return new Promise((_resolve, reject) =>
+          invocation.signal.addEventListener('abort', () =>
+            reject(new Error('stopped')),
+          ),
+        );
+      },
+      onControl: (value) => {
+        skipControl = value;
+      },
+    });
+    await vi.waitFor(() => expect(skipStarted).toBe(true));
+    skipControl.skip(0);
+    const skipped = await skipRun;
+    expect(skipped.result).toBe(WORKFLOW_SKIPPED_RESULT);
+    expect(skipped.snapshot.calls[0]?.status).toBe('skipped');
+
+    const failed = await runWorkflowScript({
+      script: `export const meta = {
+  name: 'continue',
+  description: 'failure continue observation',
+}
+const failed = await agent('fails', { label: 'Failing task' })
+const passed = await agent('passes', { label: 'Passing task' })
+return [failed, passed]`,
+      runAgent: async ({ index }) => {
+        if (index === 0) throw new Error('expected failure');
+        return 'passed';
+      },
+    });
+    expect(failed.result).toEqual([null, 'passed']);
+    expect(failed.snapshot.lifecycle).toBe('completed');
+    expect(failed.snapshot.counts).toMatchObject({ failed: 1, completed: 1 });
+
+    const cached = await runWorkflowScript({
+      script: `export const meta = {
+  name: 'continue',
+  description: 'failure continue observation',
+}
+return await agent('passes', { label: 'Passing task' })`,
+      runAgent: async () => 'passed',
+    });
+    const replay = await runWorkflowScript({
+      script: `export const meta = {
+  name: 'continue',
+  description: 'failure continue observation',
+}
+return await agent('passes', { label: 'Passing task' })`,
+      journal: cached.journal,
+      runAgent: async () => {
+        throw new Error('must not run');
+      },
+    });
+    expect(replay.snapshot.calls[0]?.status).toBe('cached');
+  });
+
+  it('keeps a failed logical call active until its phase can settle and permits later phases while prior calls run', async () => {
+    let releaseDraft!: () => void;
+    const snapshots: WorkflowExecutionSnapshot[] = [];
+    const result = await runWorkflowScript({
+      script: `export const meta = {
+  name: 'parallel-phases',
+  description: 'parallel phase observation',
+  phases: ['Draft', 'Review'],
+}
+phase('Draft')
+const draft = agent('draft', { id: 'draft-call' })
+phase('Review')
+const review = await agent('review', { id: 'review-call' })
+return [await draft, review]`,
+      runAgent: async ({ index }) => {
+        if (index === 0) {
+          return new Promise<string>((resolve) => {
+            releaseDraft = () => resolve('draft');
+          });
+        }
+        releaseDraft();
+        return 'review';
+      },
+      onSnapshot: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    });
+
+    expect(result.result).toEqual(['draft', 'review']);
+    expect(result.snapshot.calls.map((call) => call.id)).toEqual([
+      'draft-call',
+      'review-call',
+    ]);
+    expect(
+      snapshots.some((snapshot) => {
+        const draft = snapshot.calls.find((call) => call.id === 'draft-call');
+        const review = snapshot.calls.find((call) => call.id === 'review-call');
+        return (
+          snapshot.currentStageId === 'stage-2' &&
+          draft?.status === 'running' &&
+          review?.status === 'running' &&
+          snapshot.stages[0]?.lifecycle === 'completed'
+        );
+      }),
+    ).toBe(true);
+
+    const failureSnapshots: WorkflowExecutionSnapshot[] = [];
+    const continued = await runWorkflowScript({
+      script: `export const meta = {
+  name: 'failure-stage',
+  description: 'failure stage',
+  phases: ['Work'],
+}
+phase('Work')
+const failed = await agent('fails')
+const passed = await agent('passes')
+return [failed, passed]`,
+      runAgent: async ({ index }) => {
+        if (index === 0) throw new Error('expected failure');
+        return 'passed';
+      },
+      onSnapshot: (snapshot) => {
+        failureSnapshots.push(snapshot);
+      },
+    });
+    expect(continued.result).toEqual([null, 'passed']);
+    expect(continued.snapshot.stages[0]?.lifecycle).toBe('failed');
+    expect(
+      failureSnapshots.some(
+        (snapshot) =>
+          snapshot.calls[0]?.status === 'failed' &&
+          snapshot.stages[0]?.lifecycle === 'active' &&
+          snapshot.stages[0]?.completedAt === undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it('terminalizes cancellation with no live tasks and balanced counts', async () => {
+    const controller = new AbortController();
+    const snapshots: WorkflowExecutionSnapshot[] = [];
+    const run = runWorkflowScript({
+      script: `export const meta = {
+  name: 'cancel',
+  description: 'cancel observation',
+}
+return await agent('cancel secret', { label: 'Cancelled task' })`,
+      signal: controller.signal,
+      runAgent: async (invocation) =>
+        new Promise((_resolve, reject) =>
+          invocation.signal.addEventListener('abort', () =>
+            reject(new Error('cancelled')),
+          ),
+        ),
+      onSnapshot: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    });
+    await vi.waitFor(() =>
+      expect(snapshots.some((snapshot) => snapshot.counts.running === 1)).toBe(
+        true,
+      ),
+    );
+    controller.abort(new DOMException('cancelled', 'AbortError'));
+    await expect(run).rejects.toMatchObject({ name: 'AbortError' });
+
+    const terminal = finalSnapshot(snapshots);
+    expect(terminal.lifecycle).toBe('cancelled');
+    expect(terminal.counts.cancelled).toBe(1);
+    expect(
+      terminal.counts.running +
+        terminal.counts.starting +
+        terminal.counts.queued,
+    ).toBe(0);
+    expect(
+      terminal.counts.completed +
+        terminal.counts.failed +
+        terminal.counts.cancelled +
+        terminal.counts.skipped +
+        terminal.counts.cached,
+    ).toBe(terminal.calls.length);
+  });
+  it('stops after a first snapshot write failure and preserves its cause', async () => {
+    const failure = new Error('initial snapshot disk full');
+    const runner = vi.fn(async () => 'unused');
+    const onSnapshot = vi.fn(async () => {
+      throw failure;
+    });
+
+    await expect(
+      runWorkflowScript({
+        script: `export const meta = {
+  name: 'initial-persistence-failure',
+  description: 'initial persistence failure',
+}
+return await agent('must not start')`,
+        runAgent: runner,
+        onSnapshot,
+      }),
+    ).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      cause: failure,
+    });
+    expect(runner).not.toHaveBeenCalled();
+    expect(onSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses coalesced and later snapshots after an active write fails', async () => {
+    const failure = new Error('active snapshot disk full');
+    let rejectWrite!: () => void;
+    const failedWrite = new Promise<void>((_resolve, reject) => {
+      rejectWrite = () => reject(failure);
+    });
+    let childAborted = false;
+    let childAbortReason: unknown;
+    const onSnapshot = vi.fn(async () => {
+      if (onSnapshot.mock.calls.length === 2) await failedWrite;
+    });
+    const run = runWorkflowScript({
+      script: `export const meta = {
+  name: 'active-persistence-failure',
+  description: 'active persistence failure',
+}
+return await agent('active work')`,
+      runAgent: async (invocation) =>
+        new Promise((_resolve, reject) =>
+          invocation.signal.addEventListener(
+            'abort',
+            () => {
+              childAborted = true;
+              childAbortReason = invocation.signal.reason;
+              reject(invocation.signal.reason);
+            },
+            { once: true },
+          ),
+        ),
+      onSnapshot,
+    });
+
+    await vi.waitFor(() => expect(onSnapshot).toHaveBeenCalledTimes(2));
+    rejectWrite();
+    const rejection = await run.catch((error: unknown) => error);
+    expect(rejection).toMatchObject({
+      name: 'WorkflowRunAbortError',
+      cause: failure,
+    });
+    expect(childAborted).toBe(true);
+    expect(childAbortReason).toBe(rejection);
+    expect(onSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces snapshot transitions while a metadata write is pending', async () => {
+    let releaseWrite!: () => void;
+    const blockedWrite = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    let releaseAgent!: () => void;
+    const agentResult = new Promise<string>((resolve) => {
+      releaseAgent = () => resolve('done');
+    });
+    let runnerStarted = false;
+    let writes = 0;
+    const run = runWorkflowScript({
+      script: `export const meta = {
+  name: 'coalesced-writes',
+  description: 'coalesced writes',
+}
+return await agent('work')`,
+      runAgent: async () => {
+        runnerStarted = true;
+        return agentResult;
+      },
+      onSnapshot: async () => {
+        writes += 1;
+        if (writes === 2) await blockedWrite;
+      },
+    });
+
+    await vi.waitFor(() => expect(runnerStarted).toBe(true));
+    releaseWrite();
+    releaseAgent();
+    await run;
+
+    expect(writes).toBeLessThan(8);
+  });
+
+  it('aborts active work when snapshot persistence fails', async () => {
+    let writes = 0;
+    let runnerStarted = false;
+    const run = runWorkflowScript({
+      script: `export const meta = {
+  name: 'persistence-failure',
+  description: 'persistence failure',
+}
+return await agent('work')`,
+      runAgent: async (invocation) => {
+        runnerStarted = true;
+        return new Promise((_resolve, reject) =>
+          invocation.signal.addEventListener(
+            'abort',
+            () => reject(invocation.signal.reason),
+            { once: true },
+          ),
+        );
+      },
+      onSnapshot: async (snapshot) => {
+        writes += 1;
+        if (snapshot.counts.running > 0) {
+          throw new Error('snapshot disk full');
+        }
+      },
+    });
+
+    await expect(run).rejects.toThrow(/snapshot disk full/);
+    expect(runnerStarted).toBe(true);
+  });
+});

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -653,6 +653,8 @@ describe('createWorkflowScriptAgentRunner', () => {
   it('does not report recovered stable child cost as live execution', async () => {
     const onCost = vi.fn();
     const reportChildStream = vi.fn();
+    const reportChildExecution = vi.fn();
+    const reportCostUsd = vi.fn();
     const recoveredStreamId = 'correct@child-model#bbbbbb222222' as StreamTabId;
     mocks.readExecutionMeta.mockResolvedValueOnce({
       streamId: recoveredStreamId,
@@ -663,10 +665,20 @@ describe('createWorkflowScriptAgentRunner', () => {
     });
     const runner = defaultRunner({ onCost });
 
-    await runner({ ...invocation(), index: 3, reportChildStream });
+    await runner({
+      ...invocation(),
+      index: 3,
+      reportChildStream,
+      reportChildExecution,
+      reportCostUsd,
+    });
 
     expect(onCost).not.toHaveBeenCalled();
+    // Recovered durable children never fire onActiveExecutionId — re-attach the
+    // known child id, but do not charge the synthetic resume attempt.
+    expect(reportChildExecution).toHaveBeenCalledWith('bbbbbb222222');
     expect(reportChildStream).toHaveBeenCalledWith(recoveredStreamId);
+    expect(reportCostUsd).not.toHaveBeenCalled();
   });
 
   it('keeps a recovered result when navigation metadata cannot be read', async () => {

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -634,6 +634,7 @@ describe('createWorkflowScriptAgentRunner', () => {
 
   it('reports live child cost with its workflow invocation identity', async () => {
     const onCost = vi.fn();
+    const reportCostUsd = vi.fn();
     mocks.executeStableSubagentInBand.mockImplementationOnce(
       async (options) => {
         options.onActiveExecutionId?.(options.executionId);
@@ -643,11 +644,39 @@ describe('createWorkflowScriptAgentRunner', () => {
       },
     );
     const runner = defaultRunner({ onCost });
-    const call = invocation();
+    const call = { ...invocation(), reportCostUsd };
 
     await runner(call);
 
     expect(onCost).toHaveBeenCalledWith(call, 0.25);
+    // Progressive onCost stamps the live snapshot attempt (not only success).
+    expect(reportCostUsd).toHaveBeenCalledWith(0.25);
+    // Terminal result cost is also stamped (same value here).
+    expect(reportCostUsd).toHaveBeenCalledWith(result.cost);
+  });
+
+  it('stamps terminal cost on failed outcomes before throwing', async () => {
+    const reportCostUsd = vi.fn();
+    mocks.executeStableSubagentInBand.mockImplementationOnce(
+      async (options) => {
+        options.onActiveExecutionId?.(options.executionId);
+        await options.prepare();
+        return {
+          executionId: 'bbbbbb222222',
+          result: {
+            ...result,
+            outcome: 'failed',
+            cost: 0.42,
+          },
+        };
+      },
+    );
+    const runner = defaultRunner();
+
+    await expect(
+      runner({ ...invocation(), reportCostUsd }),
+    ).rejects.toThrow(/ended with failed outcome/);
+    expect(reportCostUsd).toHaveBeenCalledWith(0.42);
   });
 
   it('does not report recovered stable child cost as live execution', async () => {

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -164,6 +164,7 @@ function invocation(
 ): WorkflowAgentInvocation {
   return {
     index: 0,
+    progressId: 'call-0',
     key: '0123456789abcdef',
     prompt: 'Draft the section.',
     options,
@@ -294,8 +295,12 @@ describe('createWorkflowScriptAgentRunner', () => {
       inputFiles: ['paper.tex'],
       contextFiles: ['notes.tex'],
       mediaFiles: ['figure.pdf'],
+      label: 'Draft paper',
     });
     call.reportModel = vi.fn();
+    call.reportAgent = vi.fn();
+    call.reportChildExecution = vi.fn();
+    call.reportCostUsd = vi.fn();
     call.reportChildStream = vi.fn();
     mocks.executeStableSubagentInBand.mockImplementationOnce(
       async (options) => {
@@ -363,6 +368,11 @@ describe('createWorkflowScriptAgentRunner', () => {
       }),
     );
     expect(call.reportModel).toHaveBeenCalledWith('child-model');
+    expect(call.reportAgent).toHaveBeenCalledWith('correct');
+    expect(call.reportChildExecution).toHaveBeenCalledWith(
+      expect.stringMatching(/^[a-f0-9]{24}$/),
+    );
+    expect(call.reportCostUsd).toHaveBeenCalledWith(result.cost);
     expect(call.reportChildStream).toHaveBeenCalledWith(
       expect.stringMatching(/^correct@child-model#[a-f0-9]{24}$/),
     );

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -673,9 +673,9 @@ describe('createWorkflowScriptAgentRunner', () => {
     );
     const runner = defaultRunner();
 
-    await expect(
-      runner({ ...invocation(), reportCostUsd }),
-    ).rejects.toThrow(/ended with failed outcome/);
+    await expect(runner({ ...invocation(), reportCostUsd })).rejects.toThrow(
+      /ended with failed outcome/,
+    );
     expect(reportCostUsd).toHaveBeenCalledWith(0.42);
   });
 

--- a/src/test-kernel/agent/WorkflowScriptCost.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptCost.vitest.ts
@@ -4,7 +4,9 @@ import { clearStoreCache, getExecutionStore } from '@agent/storage';
 import {
   readWorkflowScriptCheckpoint,
   runPersistedWorkflowScript,
+  runWorkflowScript,
   type WorkflowJournalEntry,
+  type WorkflowScriptControl,
 } from '@agent/workflowScript';
 import { RUN_OUTCOME, type ExecutionId } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
@@ -59,6 +61,43 @@ function toolUseResult(cost: number): unknown {
 beforeEach(() => clearStoreCache());
 
 describe('workflow attempt cost', () => {
+  it('aggregates observability cost across physical interactive attempts', async () => {
+    let control!: WorkflowScriptControl;
+    let attempt = 0;
+    const run = runWorkflowScript({
+      script: `${meta}
+return await agent('retry cost')`,
+      runAgent: async (invocation) => {
+        attempt += 1;
+        invocation.reportCostUsd?.(attempt === 1 ? 0.2 : 0.3);
+        if (attempt === 1) {
+          await new Promise<void>((_resolve, reject) =>
+            invocation.signal.addEventListener(
+              'abort',
+              () => reject(new Error('retrying')),
+              { once: true },
+            ),
+          );
+        }
+        return 'done';
+      },
+      onControl: (value) => {
+        control = value;
+      },
+    });
+
+    await vi.waitFor(() => expect(attempt).toBe(1));
+    control.retry(0);
+    await vi.waitFor(() => expect(attempt).toBe(2));
+    const result = await run;
+
+    expect(result.snapshot.calls[0]?.attempts).toMatchObject([
+      { number: 1, costUsd: 0.2 },
+      { number: 2, costUsd: 0.3 },
+    ]);
+    expect(result.snapshot.calls[0]?.costUsd).toBeCloseTo(0.5);
+  });
+
   it('adds discarded retry cost before an undefined final observer fallback', () => {
     const completed = entry(0, workflowResult(0.5), 'completed');
     const tracker = createWorkflowAttemptCostTracker();

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -477,29 +477,18 @@ return await parallel([
       undefined,
       'second',
     ]);
+    expect(invocations.map(({ progressId }) => progressId)).toEqual([
+      'first',
+      'call-1',
+      'second',
+    ]);
 
-    const reusedIdInvocations: WorkflowAgentInvocation[] = [];
-    const reusedIdEvents: WorkflowScriptEvent[] = [];
-    await runWorkflowScript({
-      script: `${META}return await parallel([
+    await expect(
+      runScript(`return await parallel([
   () => agent('first prompt', { id: 'shared-id' }),
   () => agent('second prompt', { id: 'shared-id' }),
-])`,
-      runAgent: (invocation) => {
-        reusedIdInvocations.push(invocation);
-        return echoRunner(invocation);
-      },
-      onEvent: (event) => reusedIdEvents.push(event),
-    });
-    expect(reusedIdInvocations).toHaveLength(2);
-    expect(
-      reusedIdInvocations.map((invocation) => invocation.options.id),
-    ).toEqual(['shared-id', 'shared-id']);
-    expect(
-      reusedIdEvents
-        .filter((event) => event.type === 'agent:start')
-        .map((event) => event.progressId),
-    ).toEqual(['call-0', 'call-1']);
+])`),
+    ).rejects.toThrow(/call id "shared-id" may be issued only once/i);
 
     await expect(
       runScript(`return await parallel([
@@ -513,7 +502,7 @@ return await parallel([
   () => agent('same', { id: 'same-id' }),
   () => agent('same', { id: ' same-id ' }),
         ])`),
-    ).rejects.toThrow(/require distinct non-empty "id" options/i);
+    ).rejects.toThrow(/call id "same-id" may be issued only once/i);
   });
 
   it('passes typed workflow outputs into the next stage input files', async () => {
@@ -1552,6 +1541,13 @@ while (true) {}`,
     ).rejects.toThrow(/agent\(\) result must be JSON-serializable/i);
     expect(events).toEqual([
       {
+        type: 'agent:queued',
+        progressId: 'call-0',
+        index: 0,
+        label: 'function-result',
+        phase: undefined,
+      },
+      {
         type: 'agent:start',
         progressId: 'call-0',
         index: 0,
@@ -1930,7 +1926,7 @@ return await parallel([() => agent('running'), () => agent('queued')])`,
     expect(run.journal.map((entry) => entry.index).toSorted()).toEqual([0, 2]);
     expect(events).toContainEqual({
       type: 'agent:end',
-      progressId: 'call-1',
+      progressId: 'b',
       index: 1,
       label: 'b',
       phase: undefined,
@@ -2070,6 +2066,78 @@ return await parallel([() => agent('running'), () => agent('queued')])`,
 
     await expect(runPromise).rejects.toMatchObject({ name: 'AbortError' });
     expect(aborted).toEqual(new Set([0, 1]));
+  });
+
+  it('owns a terminal canonical snapshot with direct-call counts', async () => {
+    const snapshots: WorkflowScriptRunResult['snapshot'][] = [];
+    const result = await runWorkflowScript({
+      script: `export const meta = {
+  name: 'observable',
+  description: 'observable workflow',
+  phases: ['Draft', 'Review'],
+  tasks: [
+    { id: 'draft', label: 'Draft paper', phase: 'Draft' },
+    { id: 'review', label: 'Review paper', phase: 'Review' },
+  ],
+}
+phase('Draft')
+await agent('draft instruction', { id: 'draft' })
+return 'done'`,
+      runAgent: async (invocation) => {
+        invocation.reportAgent?.('writer');
+        invocation.reportModel?.('model-a');
+        invocation.reportChildExecution?.('abcdef123456');
+        invocation.reportChildStream?.('writer#abcdef123456');
+        return 'drafted';
+      },
+      onSnapshot: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    });
+
+    expect(snapshots.length).toBeGreaterThan(0);
+    expect(result.snapshot).toMatchObject({
+      lifecycle: 'completed',
+      currentStageId: undefined,
+      counts: { completed: 1, skipped: 1 },
+      calls: [
+        {
+          id: 'draft',
+          status: 'completed',
+          agent: 'writer',
+          model: 'model-a',
+          childExecutionId: 'abcdef123456',
+          childStreamId: 'writer#abcdef123456',
+          attempts: [{ number: 1, id: 'abcdef123456' }],
+        },
+        { id: 'review', status: 'skipped' },
+      ],
+    });
+    expect(result.snapshot.counts.total).toBe(result.snapshot.calls.length);
+  });
+
+  it('uses safe canonical labels for dynamic calls', async () => {
+    const result = await runWorkflowScript({
+      script: `export const meta = {
+  name: 'labels',
+  description: 'label workflow',
+}
+return await agent('secret full instruction', {
+  inputFiles: ['/private/host/path/paper.tex'],
+  agentName: 'proofreader',
+})`,
+      fingerprintAgentDependencies: async () => 'fingerprint',
+      runAgent: async () => 'done',
+    });
+
+    expect(result.snapshot.calls[0]).toMatchObject({
+      label: 'paper.tex: proofreader',
+      files: { input: ['paper.tex'], context: [], media: [] },
+    });
+    expect(JSON.stringify(result.snapshot)).not.toContain('/private/host/path');
+    expect(JSON.stringify(result.snapshot)).not.toContain(
+      'secret full instruction',
+    );
   });
 
   it('removes Intl so scripts cannot read the wall clock implicitly', async () => {

--- a/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
@@ -412,6 +412,39 @@ return await agent('run dynamic call', { id: 'dynamic-call' })`;
     }
   });
 
+  it('keeps host-resolved agent on cached resume when issueCall omits agentName', async () => {
+    const originalScript = `export const meta = {
+  name: 'resume-cached-agent',
+  description: 'cached resume keeps resolved agent',
+}
+return await agent('cache me', { id: 'cached-call' })`;
+    const completed = await runWorkflowScript({
+      script: originalScript,
+      runAgent: async (invocation) => {
+        invocation.reportAgent?.('resolved-writer');
+        return 'original result';
+      },
+    });
+    expect(completed.snapshot.calls[0]?.agent).toBe('resolved-writer');
+
+    const snapshots: WorkflowExecutionSnapshot[] = [];
+    const cached = await runWorkflowScript({
+      script: originalScript,
+      initialSnapshot: completed.snapshot,
+      journal: completed.journal,
+      runAgent: vi.fn(() => Promise.reject(new Error('must replay'))),
+      onSnapshot: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    });
+
+    // issueCall re-runs before the journal cache hit and typically has no
+    // agentName; it must not wipe the hydrated reportAgent value.
+    expect(snapshots[0]?.calls[0]?.agent).toBe('resolved-writer');
+    expect(cached.snapshot.calls[0]?.status).toBe('cached');
+    expect(cached.snapshot.calls[0]?.agent).toBe('resolved-writer');
+  });
+
   it('re-runs a cached dynamic call with fresh execution timestamps after its identity changes', async () => {
     vi.useFakeTimers({ toFake: ['Date'] });
     try {

--- a/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
@@ -12,7 +12,11 @@ import {
   type ExecutionKVStore,
 } from '@agent/storage';
 import { workflowScriptCheckpointKvKey } from '@agent/workflowScript/checkpointKey';
-import type { ExecutionId } from '@shared/schemas';
+import {
+  WorkflowExecutionSnapshotSchema,
+  type ExecutionId,
+  type WorkflowExecutionSnapshot,
+} from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { delay } from '@utils/core';
 
@@ -69,7 +73,146 @@ describe('workflow-script persistence', () => {
     });
 
     expect(restarted.result).toEqual(['result:first', 'result:second']);
+    expect(restarted.snapshot.counts.cached).toBe(2);
+    await expect(
+      readWorkflowScriptCheckpoint(getExecutionStore(executionId), 'call-1'),
+    ).resolves.toMatchObject({
+      journal: [{ result: 'result:first' }, { result: 'result:second' }],
+    });
     expect(restartedRunner).not.toHaveBeenCalled();
+  });
+
+  it('persists and hydrates runtime-valid unbounded snapshot fields', async () => {
+    const store = getExecutionStore(executionId);
+    const longId = `call-${'i'.repeat(2_500)}`;
+    const longPhase = `Phase ${'p'.repeat(3_000)}`;
+    const longError = `failure-${'e'.repeat(4_000)}`;
+    const files = Array.from(
+      { length: 513 },
+      (_, index) => `/workspace/${'f'.repeat(600)}-${index}.tex`,
+    );
+    const snapshots: WorkflowExecutionSnapshot[] = [];
+    const adversarialScript = `export const meta = {
+  name: 'unbounded-snapshot',
+  description: 'persists runtime-valid snapshot fields',
+}
+phase(${JSON.stringify(longPhase)})
+return await agent('fail after snapshotting', {
+  id: ${JSON.stringify(longId)},
+  label: '   ',
+  inputFiles: ${JSON.stringify(files)},
+})`;
+
+    const result = await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'unbounded-snapshot',
+      script: adversarialScript,
+      fingerprintAgentDependencies: async () => 'fingerprint',
+      runAgent: async () => {
+        throw new Error(longError);
+      },
+      onSnapshot: async (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    });
+
+    expect(result.snapshot.calls[0]).toMatchObject({
+      id: longId,
+      label: '',
+      error: longError,
+    });
+    expect(result.snapshot.stages[0]?.title).toBe(longPhase);
+    expect(result.snapshot.calls[0]?.files.input).toHaveLength(513);
+    expect(result.snapshot.calls[0]?.files.input[0]?.length).toBeGreaterThan(
+      512,
+    );
+    expect(() =>
+      WorkflowExecutionSnapshotSchema.parse(result.snapshot),
+    ).not.toThrow();
+    expect(snapshots.at(-1)).toEqual(result.snapshot);
+
+    const hydrated = await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'unbounded-snapshot',
+      initialSnapshot: result.snapshot,
+      fingerprintAgentDependencies: async () => 'fingerprint',
+      runAgent: async () => {
+        throw new Error(longError);
+      },
+    });
+    expect(hydrated.snapshot.calls[0]).toMatchObject({
+      id: longId,
+      label: '',
+      error: longError,
+    });
+    expect(hydrated.snapshot.stages[0]?.title).toBe(longPhase);
+    expect(hydrated.snapshot.calls[0]?.files.input).toHaveLength(513);
+    expect(() =>
+      WorkflowExecutionSnapshotSchema.parse(hydrated.snapshot),
+    ).not.toThrow();
+  });
+
+  it('seals snapshots and checkpoints after a late child exceeds drain grace', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      const store = getExecutionStore(executionId);
+      const snapshots: WorkflowExecutionSnapshot[] = [];
+      let resolveChild!: (value: string) => void;
+      let markStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      const child = new Promise<string>((resolve) => {
+        resolveChild = resolve;
+      });
+      const run = runPersistedWorkflowScript({
+        store,
+        checkpointId: 'late-sealed-child',
+        script: `export const meta = {
+  name: 'late-sealed-child',
+  description: 'late sealed child',
+}
+agent('ignores cancellation')
+return 'guest success'`,
+        runAgent: async () => {
+          markStarted();
+          return child;
+        },
+        onSnapshot: async (snapshot) => {
+          snapshots.push(snapshot);
+        },
+      });
+
+      await started;
+      await vi.advanceTimersByTimeAsync(5_000);
+      const result = await run;
+      const terminalWriteCount = snapshots.length;
+      const terminalSnapshot = snapshots.at(-1);
+      expect(terminalSnapshot).toEqual(result.snapshot);
+      expect(terminalSnapshot?.calls[0]?.attempts[0]?.completedAt).toEqual(
+        expect.any(String),
+      );
+      expect(() =>
+        WorkflowExecutionSnapshotSchema.parse(result.snapshot),
+      ).not.toThrow();
+      await expect(
+        readWorkflowScriptCheckpoint(store, 'late-sealed-child'),
+      ).resolves.toMatchObject({ journal: [] });
+
+      resolveChild('late result');
+      await vi.advanceTimersByTimeAsync(1);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(snapshots).toHaveLength(terminalWriteCount);
+      expect(snapshots.at(-1)).toEqual(result.snapshot);
+      expect(result.journal).toEqual([]);
+      await expect(
+        readWorkflowScriptCheckpoint(store, 'late-sealed-child'),
+      ).resolves.toMatchObject({ journal: [] });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('keeps checkpoints isolated by tool call id', async () => {

--- a/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
@@ -223,6 +223,60 @@ return [first, second]`;
     });
   });
 
+  it('preserves completed task-plan call files across resume hydrate', async () => {
+    const resumeScript = `export const meta = {
+  name: 'resume-completed-files',
+  description: 'completed planned call keeps files on resume',
+  tasks: [{ id: 'planned-call', label: 'Planned call', phase: 'Work' }],
+  phases: ['Work'],
+}
+phase('Work')
+return await agent('run planned call', {
+  id: 'planned-call',
+  inputFiles: ['/workspace/paper.tex'],
+  contextFiles: ['/workspace/notes.tex'],
+})`;
+    const completed = await runWorkflowScript({
+      script: resumeScript,
+      fingerprintAgentDependencies: async () => 'fingerprint',
+      runAgent: async () => 'done',
+    });
+    expect(completed.snapshot.calls[0]?.status).toBe('completed');
+    expect(completed.snapshot.calls[0]?.files).toEqual({
+      input: ['paper.tex'],
+      context: ['notes.tex'],
+      media: [],
+    });
+
+    const snapshots: WorkflowExecutionSnapshot[] = [];
+    const resumed = await runWorkflowScript({
+      script: resumeScript,
+      initialSnapshot: completed.snapshot,
+      journal: completed.journal,
+      fingerprintAgentDependencies: async () => 'fingerprint',
+      runAgent: async () => {
+        throw new Error('must replay from journal');
+      },
+      onSnapshot: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    });
+
+    // Constructor hydrate emits before the script re-issues calls. Reusable
+    // completed calls must keep prior files, not the empty meta.tasks stub.
+    expect(snapshots[0]?.calls[0]?.files).toEqual({
+      input: ['paper.tex'],
+      context: ['notes.tex'],
+      media: [],
+    });
+    expect(resumed.snapshot.calls[0]?.status).toBe('cached');
+    expect(resumed.snapshot.calls[0]?.files).toEqual({
+      input: ['paper.tex'],
+      context: ['notes.tex'],
+      media: [],
+    });
+  });
+
   it('re-runs a skipped planned call with fresh execution timestamps', async () => {
     vi.useFakeTimers({ toFake: ['Date'] });
     try {

--- a/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
@@ -3,8 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   readWorkflowScriptCheckpoint,
   runPersistedWorkflowScript,
+  runWorkflowScript,
   WorkflowScriptPersistenceError,
   writeWorkflowScriptCheckpoint,
+  type WorkflowScriptControl,
+  type WorkflowScriptEvent,
 } from '@agent/workflowScript';
 import {
   clearStoreCache,
@@ -17,6 +20,7 @@ import {
   type ExecutionId,
   type WorkflowExecutionSnapshot,
 } from '@shared/schemas';
+import { createDeferred } from '@test/support/asyncTestUtils';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { delay } from '@utils/core';
 
@@ -152,19 +156,520 @@ return await agent('fail after snapshotting', {
     ).not.toThrow();
   });
 
+  it('closes every prior open attempt before a resumed attempt starts', async () => {
+    const store = getExecutionStore(executionId);
+    const resumeScript = `export const meta = {
+  name: 'resume-open-attempt',
+  description: 'resume an interrupted attempt',
+}
+const first = await agent('resume first', { id: 'resume-first' })
+const second = await agent('resume second', { id: 'resume-second' })
+return [first, second]`;
+    const priorRun = await runWorkflowScript({
+      script: resumeScript,
+      runAgent: async () => 'prior result',
+    });
+    const interrupted = structuredClone(priorRun.snapshot);
+    interrupted.lifecycle = 'active';
+    interrupted.timestamps.completedAt = undefined;
+    for (const call of interrupted.calls) {
+      call.status = 'running';
+      call.timestamps.completedAt = undefined;
+      call.attempts[0]!.completedAt = undefined;
+    }
+    interrupted.counts.completed = 0;
+    interrupted.counts.running = 2;
+
+    await store.writeMeta({
+      timestamp: new Date(0).toISOString(),
+      workflow: interrupted,
+    });
+    const snapshots: WorkflowExecutionSnapshot[] = [];
+    const resumed = await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'resume-open-attempt',
+      script: resumeScript,
+      initialSnapshot: interrupted,
+      runAgent: async () => 'resumed result',
+      onSnapshot: async (snapshot) => {
+        snapshots.push(snapshot);
+        await store.writeMeta({
+          timestamp: new Date(0).toISOString(),
+          workflow: snapshot,
+        });
+      },
+    });
+
+    expect(snapshots[0]?.calls).toHaveLength(2);
+    expect(
+      snapshots[0]?.calls.every(
+        (call) =>
+          call.attempts.length === 1 &&
+          call.attempts[0]?.completedAt !== undefined,
+      ),
+    ).toBe(true);
+    expect(
+      resumed.snapshot.calls.every(
+        (call) =>
+          call.attempts.length === 2 &&
+          call.attempts.every((attempt) => attempt.completedAt !== undefined),
+      ),
+    ).toBe(true);
+    const persistedSnapshot = WorkflowExecutionSnapshotSchema.parse(
+      JSON.parse(JSON.stringify(resumed.snapshot)),
+    );
+    await expect(store.readMeta()).resolves.toMatchObject({
+      workflow: persistedSnapshot,
+    });
+  });
+
+  it('re-runs a skipped planned call with fresh execution timestamps', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+      let control!: WorkflowScriptControl;
+      const resumeScript = `export const meta = {
+  name: 'resume-skipped-call',
+  description: 'resume a skipped planned call',
+  tasks: [{ id: 'planned-call', label: 'Planned call' }],
+}
+return await agent('run planned call', { id: 'planned-call' })`;
+      const skipped = await runWorkflowScript({
+        script: resumeScript,
+        runAgent: async () => 'must be skipped',
+        onControl: (value) => {
+          control = value;
+        },
+        onEvent: (event) => {
+          if (event.type === 'agent:start') control.skip(event.index);
+        },
+      });
+      const prior = skipped.snapshot.calls[0]!;
+      expect(prior.status).toBe('skipped');
+      Object.assign(prior, {
+        childExecutionId: 'aaaaaaaaaaaa',
+        childStreamId: 'prior#aaaaaaaaaaaa',
+        model: 'prior-model',
+        costUsd: 1.25,
+      });
+      Object.assign(prior.attempts[0]!, {
+        id: prior.childExecutionId,
+        childStreamId: prior.childStreamId,
+        model: prior.model,
+        costUsd: prior.costUsd,
+      });
+
+      vi.setSystemTime(new Date('2026-01-02T00:00:00.000Z'));
+      const runner = vi.fn(async () => 'resumed result');
+      const snapshots: WorkflowExecutionSnapshot[] = [];
+      const resumed = await runWorkflowScript({
+        script: resumeScript,
+        initialSnapshot: skipped.snapshot,
+        journal: skipped.journal,
+        runAgent: runner,
+        onSnapshot: async (snapshot) => {
+          snapshots.push(snapshot);
+        },
+      });
+      const call = resumed.snapshot.calls[0]!;
+
+      expect(snapshots[0]?.calls[0]?.timestamps).toEqual({
+        createdAt: prior.timestamps.createdAt,
+        updatedAt: '2026-01-02T00:00:00.000Z',
+      });
+      expect(snapshots[0]?.calls[0]?.childExecutionId).toBeUndefined();
+      expect(snapshots[0]?.calls[0]?.childStreamId).toBeUndefined();
+      expect(snapshots[0]?.calls[0]?.model).toBeUndefined();
+      expect(snapshots[0]?.calls[0]?.costUsd).toBe(1.25);
+      expect(snapshots[0]?.calls[0]?.attempts[0]).toMatchObject({
+        id: 'aaaaaaaaaaaa',
+        childStreamId: 'prior#aaaaaaaaaaaa',
+        model: 'prior-model',
+        costUsd: 1.25,
+      });
+      expect(runner).toHaveBeenCalledOnce();
+      expect(call.status).toBe('completed');
+      expect(call.timestamps.createdAt).toBe(prior.timestamps.createdAt);
+      expect(call.timestamps.queuedAt).toBe('2026-01-02T00:00:00.000Z');
+      expect(call.timestamps.startedAt).toBe('2026-01-02T00:00:00.000Z');
+      expect(call.timestamps.completedAt).toBe('2026-01-02T00:00:00.000Z');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('re-runs a prior dynamic call with fresh execution timestamps', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    try {
+      vi.setSystemTime(new Date('2026-02-01T00:00:00.000Z'));
+      const resumeScript = `export const meta = {
+  name: 'resume-dynamic-call',
+  description: 'resume a prior dynamic call',
+}
+return await agent('run dynamic call', { id: 'dynamic-call' })`;
+      const failed = await runWorkflowScript({
+        script: resumeScript,
+        runAgent: async (invocation) => {
+          invocation.reportChildExecution?.('bbbbbbbbbbbb');
+          invocation.reportChildStream?.('prior#bbbbbbbbbbbb');
+          invocation.reportModel?.('prior-model');
+          invocation.reportCostUsd?.(2.5);
+          throw new Error('interrupted');
+        },
+      });
+      const prior = failed.snapshot.calls[0]!;
+      expect(prior.status).toBe('failed');
+
+      vi.setSystemTime(new Date('2026-02-02T00:00:00.000Z'));
+      const snapshots: WorkflowExecutionSnapshot[] = [];
+      const resumed = await runWorkflowScript({
+        script: resumeScript,
+        initialSnapshot: failed.snapshot,
+        journal: failed.journal,
+        runAgent: async () => 'resumed result',
+        onSnapshot: async (snapshot) => {
+          snapshots.push(snapshot);
+        },
+      });
+      const call = resumed.snapshot.calls[0]!;
+
+      expect(snapshots[0]?.calls[0]?.timestamps).toEqual({
+        createdAt: prior.timestamps.createdAt,
+        updatedAt: '2026-02-02T00:00:00.000Z',
+      });
+      expect(snapshots[0]?.calls[0]?.childExecutionId).toBeUndefined();
+      expect(snapshots[0]?.calls[0]?.childStreamId).toBeUndefined();
+      expect(snapshots[0]?.calls[0]?.model).toBeUndefined();
+      expect(snapshots[0]?.calls[0]?.costUsd).toBe(2.5);
+      expect(snapshots[0]?.calls[0]?.attempts[0]).toMatchObject({
+        id: 'bbbbbbbbbbbb',
+        childStreamId: 'prior#bbbbbbbbbbbb',
+        model: 'prior-model',
+        costUsd: 2.5,
+      });
+      expect(resumed.result).toBe('resumed result');
+      expect(call.status).toBe('completed');
+      expect(call.timestamps.createdAt).toBe(prior.timestamps.createdAt);
+      expect(call.timestamps.queuedAt).toBe('2026-02-02T00:00:00.000Z');
+      expect(call.timestamps.startedAt).toBe('2026-02-02T00:00:00.000Z');
+      expect(call.timestamps.completedAt).toBe('2026-02-02T00:00:00.000Z');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('re-runs a cached dynamic call with fresh execution timestamps after its identity changes', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    try {
+      vi.setSystemTime(new Date('2026-03-01T00:00:00.000Z'));
+      const originalScript = `export const meta = {
+  name: 'resume-completed-dynamic-call',
+  description: 'resume a completed dynamic call after script drift',
+}
+return await agent('original prompt', { id: 'dynamic-call', model: 'first-model' })`;
+      const completed = await runWorkflowScript({
+        script: originalScript,
+        runAgent: async (invocation) => {
+          invocation.reportChildExecution?.('cccccccccccc');
+          invocation.reportChildStream?.('prior#cccccccccccc');
+          invocation.reportModel?.('prior-model');
+          invocation.reportCostUsd?.(3.75);
+          return 'original result';
+        },
+      });
+      const cached = await runWorkflowScript({
+        script: originalScript,
+        initialSnapshot: completed.snapshot,
+        journal: completed.journal,
+        runAgent: vi.fn(() => Promise.reject(new Error('must replay'))),
+      });
+      const prior = cached.snapshot.calls[0]!;
+      expect(prior.status).toBe('cached');
+
+      vi.setSystemTime(new Date('2026-03-02T00:00:00.000Z'));
+      const snapshots: WorkflowExecutionSnapshot[] = [];
+      const finishRunner = createDeferred();
+      const runnerStarted = createDeferred();
+      const runner = vi.fn(async (invocation) => {
+        runnerStarted.resolve();
+        await finishRunner.promise;
+        invocation.reportModel?.('replacement-model');
+        throw new Error('replacement failed before reporting cost');
+      });
+      const resumedRun = runWorkflowScript({
+        script: originalScript
+          .replace('original prompt', 'changed prompt')
+          .replace('first-model', 'changed-model'),
+        initialSnapshot: cached.snapshot,
+        journal: cached.journal,
+        runAgent: runner,
+        onSnapshot: async (snapshot) => {
+          snapshots.push(snapshot);
+        },
+      });
+      await runnerStarted.promise;
+      await Promise.resolve();
+      const rerunSnapshots = snapshots.filter((snapshot) =>
+        ['queued', 'starting', 'running'].includes(
+          snapshot.calls[0]?.status ?? '',
+        ),
+      );
+      const running = rerunSnapshots.find(
+        (snapshot) => snapshot.calls[0]?.status === 'running',
+      )?.calls[0];
+      finishRunner.resolve();
+      const resumed = await resumedRun;
+      const call = resumed.snapshot.calls[0]!;
+
+      expect(runner).toHaveBeenCalledOnce();
+      expect(rerunSnapshots.length).toBeGreaterThan(0);
+      for (const snapshot of rerunSnapshots) {
+        expect(snapshot.calls[0]?.childExecutionId).toBeUndefined();
+        expect(snapshot.calls[0]?.childStreamId).toBeUndefined();
+        expect(snapshot.calls[0]?.model).toBeUndefined();
+        expect(snapshot.calls[0]?.costUsd).toBe(3.75);
+        expect(snapshot.calls[0]?.attempts[0]).toMatchObject({
+          id: 'cccccccccccc',
+          childStreamId: 'prior#cccccccccccc',
+          model: 'prior-model',
+          costUsd: 3.75,
+        });
+      }
+      expect(running?.timestamps).toEqual({
+        createdAt: prior.timestamps.createdAt,
+        queuedAt: '2026-03-02T00:00:00.000Z',
+        startedAt: '2026-03-02T00:00:00.000Z',
+        updatedAt: '2026-03-02T00:00:00.000Z',
+      });
+      expect(call.timestamps).toEqual({
+        createdAt: prior.timestamps.createdAt,
+        queuedAt: '2026-03-02T00:00:00.000Z',
+        startedAt: '2026-03-02T00:00:00.000Z',
+        updatedAt: '2026-03-02T00:00:00.000Z',
+        completedAt: '2026-03-02T00:00:00.000Z',
+      });
+      expect(call).toMatchObject({
+        status: 'failed',
+        model: 'replacement-model',
+        error: 'replacement failed before reporting cost',
+      });
+      expect(call.childExecutionId).toBeUndefined();
+      expect(call.childStreamId).toBeUndefined();
+      expect(call.costUsd).toBe(3.75);
+      expect(call.attempts).toEqual([
+        expect.objectContaining({
+          id: 'cccccccccccc',
+          childStreamId: 'prior#cccccccccccc',
+          model: 'prior-model',
+          costUsd: 3.75,
+        }),
+        expect.objectContaining({ model: 'replacement-model' }),
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears event metadata before an interactive replacement fails early', async () => {
+    let control!: WorkflowScriptControl;
+    let attempt = 0;
+    const events: WorkflowScriptEvent[] = [];
+    const run = runWorkflowScript({
+      script: `export const meta = {
+  name: 'retry-metadata',
+  description: 'does not report abandoned attempt metadata',
+}
+return await agent('retry metadata')`,
+      runAgent: async (invocation) => {
+        attempt += 1;
+        if (attempt === 1) {
+          invocation.reportModel?.('abandoned-model');
+          invocation.reportChildStream?.('writer#aaaaaaaaaaaa');
+          await new Promise<void>((_resolve, reject) =>
+            invocation.signal.addEventListener(
+              'abort',
+              () => reject(new Error('retrying')),
+              { once: true },
+            ),
+          );
+        }
+        throw new Error('replacement failed early');
+      },
+      onControl: (value) => {
+        control = value;
+      },
+      onEvent: (event) => events.push(event),
+    });
+
+    await vi.waitFor(() => expect(attempt).toBe(1));
+    control.retry(0);
+    await vi.waitFor(() => expect(attempt).toBe(2));
+    const result = await run;
+    const end = events.findLast((event) => event.type === 'agent:end');
+
+    expect(end).toMatchObject({
+      type: 'agent:end',
+      outcome: 'failed',
+      error: 'replacement failed early',
+    });
+    expect(end).not.toHaveProperty('model');
+    expect(end).not.toHaveProperty('childStreamId');
+    expect(result.snapshot.calls[0]?.attempts).toMatchObject([
+      {
+        number: 1,
+        model: 'abandoned-model',
+        childStreamId: 'writer#aaaaaaaaaaaa',
+      },
+      { number: 2 },
+    ]);
+  });
+
+  it('fails cancellation when an abandoned call returns a non-serializable result during drain', async () => {
+    const controller = new AbortController();
+    const child = createDeferred<unknown>();
+    const runnerStarted = createDeferred();
+    const cleanupStarted = createDeferred();
+    const snapshots: WorkflowExecutionSnapshot[] = [];
+    const run = runWorkflowScript({
+      script: `export const meta = {
+  name: 'abandoned-invalid-result',
+  description: 'rejects invalid abandoned output',
+}
+return await agent('ignores cancellation')`,
+      signal: controller.signal,
+      runAgent: async (invocation) => {
+        runnerStarted.resolve();
+        invocation.signal.addEventListener('abort', () =>
+          cleanupStarted.resolve(),
+        );
+        return child.promise;
+      },
+      onSnapshot: async (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    });
+
+    await runnerStarted.promise;
+    controller.abort(new Error('cancel requested'));
+    await cleanupStarted.promise;
+    child.resolve(() => undefined);
+
+    await expect(run).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: expect.stringMatching(
+        /agent\(\) result must be JSON-serializable/i,
+      ),
+    });
+    expect(snapshots.at(-1)).toMatchObject({
+      lifecycle: 'failed',
+      error: expect.stringMatching(/must be JSON-serializable/i),
+    });
+  });
+
+  it('keeps the first persistence rejection in time when abandoned writes reject in reverse call order', async () => {
+    const writes = Array.from({ length: 2 }, () => {
+      let reject!: (reason: Error) => void;
+      const promise = new Promise<void>((_resolve, rejectPromise) => {
+        reject = rejectPromise;
+      });
+      return { promise, reject };
+    });
+    const started = [createDeferred(), createDeferred()];
+    const run = runWorkflowScript({
+      script: `export const meta = {
+  name: 'reverse-persistence-failures',
+  description: 'preserves the first persistence failure in time',
+}
+agent('first')
+agent('second')
+return 'guest success'`,
+      concurrency: 2,
+      runAgent: async ({ prompt }) => prompt,
+      onJournalEntry: async ({ index }) => {
+        started[index]?.resolve();
+        await writes[index]?.promise;
+      },
+    }).catch((error: unknown) => error);
+
+    await Promise.all(started.map(({ promise }) => promise));
+    writes[1]!.reject(new Error('second call rejected first'));
+    await Promise.resolve();
+    writes[0]!.reject(new Error('first call rejected second'));
+
+    await expect(run).resolves.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: expect.stringContaining('second call rejected first'),
+    });
+  });
+
+  it('does not seal while an admitted journal persistence is still pending', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      const snapshots: WorkflowExecutionSnapshot[] = [];
+      const child = createDeferred<string>();
+      const childStarted = createDeferred();
+      const journalWriteStarted = createDeferred();
+      const journalWrite = createDeferred();
+      let settled = false;
+      const run = runWorkflowScript({
+        script: `export const meta = {
+  name: 'deferred-journal-write',
+  description: 'waits for admitted journal persistence',
+}
+agent('finishes during drain')
+return 'guest success'`,
+        runAgent: async () => {
+          childStarted.resolve();
+          return child.promise;
+        },
+        onJournalEntry: async () => {
+          journalWriteStarted.resolve();
+          await journalWrite.promise;
+        },
+        onSnapshot: async (snapshot) => {
+          snapshots.push(snapshot);
+        },
+      });
+      void run.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+
+      await childStarted.promise;
+      await vi.advanceTimersByTimeAsync(4_000);
+      child.resolve('child result');
+      await journalWriteStarted.promise;
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+
+      expect(settled).toBe(false);
+      expect(snapshots.at(-1)?.lifecycle).not.toBe('completed');
+
+      journalWrite.resolve();
+      const result = await run;
+      const terminalWriteCount = snapshots.length;
+
+      expect(result.journal).toHaveLength(1);
+      expect(result.snapshot.calls[0]?.status).toBe('completed');
+      expect(snapshots.at(-1)).toEqual(result.snapshot);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(snapshots).toHaveLength(terminalWriteCount);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('seals snapshots and checkpoints after a late child exceeds drain grace', async () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
     try {
       const store = getExecutionStore(executionId);
       const snapshots: WorkflowExecutionSnapshot[] = [];
-      let resolveChild!: (value: string) => void;
-      let markStarted!: () => void;
-      const started = new Promise<void>((resolve) => {
-        markStarted = resolve;
-      });
-      const child = new Promise<string>((resolve) => {
-        resolveChild = resolve;
-      });
+      const child = createDeferred<string>();
+      const started = createDeferred();
       const run = runPersistedWorkflowScript({
         store,
         checkpointId: 'late-sealed-child',
@@ -175,15 +680,15 @@ return await agent('fail after snapshotting', {
 agent('ignores cancellation')
 return 'guest success'`,
         runAgent: async () => {
-          markStarted();
-          return child;
+          started.resolve();
+          return child.promise;
         },
         onSnapshot: async (snapshot) => {
           snapshots.push(snapshot);
         },
       });
 
-      await started;
+      await started.promise;
       await vi.advanceTimersByTimeAsync(5_000);
       const result = await run;
       const terminalWriteCount = snapshots.length;
@@ -199,7 +704,7 @@ return 'guest success'`,
         readWorkflowScriptCheckpoint(store, 'late-sealed-child'),
       ).resolves.toMatchObject({ journal: [] });
 
-      resolveChild('late result');
+      child.resolve('late result');
       await vi.advanceTimersByTimeAsync(1);
       await Promise.resolve();
       await Promise.resolve();

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -354,66 +354,20 @@ return await agent('Run refused', { id: 'refused' })`,
     ).toBeUndefined();
   });
 
-  it.each([
-    [
-      'sequential',
-      `await agent('First prompt', {
-  id: 'shared-journal-id',
-  label: 'First task',
-  phase: 'Review',
-})
-return await agent('Second prompt', {
-  id: 'shared-journal-id',
-  label: 'Second task',
-  phase: 'Write',
-})`,
-    ],
-    [
-      'parallel',
-      `return await parallel([
-  () => agent('First prompt', {
-    id: 'shared-journal-id',
-    label: 'First task',
-    phase: 'Review',
-  }),
-  () => agent('Second prompt', {
-    id: 'shared-journal-id',
-    label: 'Second task',
-    phase: 'Write',
-  }),
-])`,
-    ],
-  ] as const)(
-    'keeps %s calls with one journal id as separate progress records',
-    async (mode, body) => {
-      const { trace, events } = recordingTrace();
-      await runScript(
+  it('rejects duplicate dynamic logical call ids', async () => {
+    const { trace } = recordingTrace();
+    await expect(
+      runScript(
         trace,
-        `reused-journal-id-${mode}`,
+        'duplicate-logical-id',
         `${meta}
-${body}`,
-      );
-
-      const firstRunning = workflowCallEvent(events, 'First task', 'running');
-      const firstCompleted = workflowCallEvent(
-        events,
-        'First task',
-        'completed',
-      );
-      const secondRunning = workflowCallEvent(events, 'Second task', 'running');
-      const secondCompleted = workflowCallEvent(
-        events,
-        'Second task',
-        'completed',
-      );
-
-      expect(firstRunning?.call.id).toBe('call-0');
-      expect(firstCompleted?.logId).toBe(firstRunning?.logId);
-      expect(secondRunning?.call.id).toBe('call-1');
-      expect(secondCompleted?.logId).toBe(secondRunning?.logId);
-      expect(firstRunning?.logId).not.toBe(secondRunning?.logId);
-    },
-  );
+return await parallel([
+  () => agent('First prompt', { id: 'shared-journal-id' }),
+  () => agent('Second prompt', { id: 'shared-journal-id' }),
+])`,
+      ),
+    ).rejects.toThrow(/call id "shared-journal-id" may be issued only once/i);
+  });
 
   it('projects a cached completion without synthesizing a start event', async () => {
     const script = `${meta}
@@ -702,10 +656,11 @@ return await agent('Unsuccessful')`,
       trace,
       'parallel-phases',
       `${meta}
-return await parallel([
-  () => agent('slow', { phase: 'First' }),
-  () => agent('fast', { phase: 'Second' }),
-])`,
+phase('First')
+const slow = agent('slow')
+phase('Second')
+const fast = agent('fast')
+return await Promise.all([slow, fast])`,
       { runAgent },
     );
 

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -255,7 +255,7 @@ describe('ExecutionKVStore meta read shims', () => {
     await expect(getExecutionStore(id).readMeta()).resolves.toBeNull();
   });
 
-  it('drops only malformed workflow observability from otherwise valid metadata', async () => {
+  it('drops only malformed workflow observability from ordinary metadata reads', async () => {
     const id = 'bad-workflow-meta' as ExecutionId;
     const warnSpy = mockWarn();
     const store = getExecutionStore(id);
@@ -274,8 +274,11 @@ describe('ExecutionKVStore meta read shims', () => {
       identity: { kind: 'process', tool: 'bash' },
       description: 'Readable core metadata',
     };
+    // Ordinary reads keep core metadata available for listing/finalization.
     await expect(store.readMeta()).resolves.toEqual(expectedCore);
-    await expect(store.readMetaStrict()).resolves.toEqual(expectedCore);
+    // Strict recovery must fail closed so a present corrupt snapshot is never
+    // treated as "no prior workflow state."
+    await expect(store.readMetaStrict()).rejects.toThrow();
     expect(warnSpy).toHaveBeenCalledWith(
       'ExecutionKVStore',
       expect.stringContaining(

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -21,6 +21,7 @@ import {
   RUN_OUTCOME,
   type ExecutionId,
   type RunOutcome,
+  type WorkflowExecutionSnapshot,
 } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 
@@ -48,6 +49,34 @@ function expectParseWarning(
     expect.stringContaining(`Failed to parse execution ${id} ${fileName}`),
     { data: expect.any(Error) },
   );
+}
+
+function validWorkflowSnapshot(): WorkflowExecutionSnapshot {
+  const timestamp = '2026-07-04T00:00:00.000Z';
+  return {
+    lifecycle: 'completed',
+    stages: [],
+    calls: [],
+    counts: {
+      total: 0,
+      waiting: 0,
+      planned: 0,
+      stageBlocked: 0,
+      queued: 0,
+      starting: 0,
+      running: 0,
+      completed: 0,
+      failed: 0,
+      cancelled: 0,
+      skipped: 0,
+      cached: 0,
+    },
+    timestamps: {
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp,
+    },
+  };
 }
 
 /** The shared subagent result-meta envelope the projection tests permute. */
@@ -224,6 +253,57 @@ describe('ExecutionKVStore meta read shims', () => {
     await expect(clearTerminalExecutionState(id)).resolves.toBeUndefined();
 
     await expect(getExecutionStore(id).readMeta()).resolves.toBeNull();
+  });
+
+  it('drops only malformed workflow observability from otherwise valid metadata', async () => {
+    const id = 'bad-workflow-meta' as ExecutionId;
+    const warnSpy = mockWarn();
+    const store = getExecutionStore(id);
+    await store.write('meta', {
+      timestamp: '2026-07-04T00:00:00.000Z',
+      outcome: RUN_OUTCOME.CANCELLED,
+      identity: { kind: 'process', tool: 'bash' },
+      description: 'Readable core metadata',
+      workflow: { lifecycle: 'active' },
+    });
+
+    const expectedCore = {
+      schemaVersion: EXECUTION_META_SCHEMA_VERSION,
+      timestamp: '2026-07-04T00:00:00.000Z',
+      outcome: RUN_OUTCOME.CANCELLED,
+      identity: { kind: 'process', tool: 'bash' },
+      description: 'Readable core metadata',
+    };
+    await expect(store.readMeta()).resolves.toEqual(expectedCore);
+    await expect(store.readMetaStrict()).resolves.toEqual(expectedCore);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'ExecutionKVStore',
+      expect.stringContaining(
+        `Failed to parse execution ${id} meta.json workflow`,
+      ),
+      { data: expect.any(Error) },
+    );
+  });
+
+  it('round-trips valid workflow metadata and rejects malformed writes', async () => {
+    const id = 'strict-workflow-meta' as ExecutionId;
+    const store = getExecutionStore(id);
+    const workflow = validWorkflowSnapshot();
+
+    await store.writeMeta({
+      timestamp: '2026-07-04T00:00:00.000Z',
+      workflow,
+    });
+    await expect(store.readMeta()).resolves.toMatchObject({ workflow });
+
+    const malformed = structuredClone(workflow);
+    malformed.currentStageId = '';
+    await expect(
+      store.writeMeta({
+        timestamp: '2026-07-04T00:00:00.000Z',
+        workflow: malformed,
+      }),
+    ).rejects.toThrow();
   });
 
   it('warns when execution meta is malformed instead of silently dropping it', async () => {

--- a/src/test-kernel/agent/storage/ExecutionMetaWrites.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionMetaWrites.vitest.ts
@@ -30,6 +30,34 @@ describe('execution metadata updates', () => {
     expect(meta?.outcome).toBe(RUN_OUTCOME.COMPLETED);
   });
 
+  it('updates and finalizes core metadata despite malformed workflow observability', async () => {
+    const id = 'bbb003' as ExecutionId;
+    const store = getExecutionStore(id);
+    await store.write('meta', {
+      timestamp: new Date(0).toISOString(),
+      identity: { kind: 'process', tool: 'bash' },
+      description: 'Original description',
+      workflow: { lifecycle: 'active' },
+    });
+
+    await writeSessionDescription(id, 'Updated description');
+    await expect(
+      finalizeExecution({
+        executionId: id,
+        outcome: RUN_OUTCOME.COMPLETED,
+        flowRecord: 'preserve',
+      }),
+    ).resolves.toMatchObject({ status: 'durable' });
+
+    const meta = await store.readMeta();
+    expect(meta).toMatchObject({
+      identity: { kind: 'process', tool: 'bash' },
+      description: 'Updated description',
+      outcome: RUN_OUTCOME.COMPLETED,
+    });
+    expect(meta?.workflow).toBeUndefined();
+  });
+
   it('accepts a later update after one fails on absent metadata', async () => {
     const id = 'bbb002' as ExecutionId;
     // Nothing to read-modify-write yet: this update fails inside the lock and

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -449,10 +449,8 @@ describe('ExecutionsTool /executions/{id}/output', () => {
             stageId: longStageId,
             stageTitle: longTitle,
             agent: 'writer',
-            model: 'model-a',
             files: { input: longFiles, context: [], media: [] },
             childExecutionId: 'abcdef123456',
-            childStreamId: 'writer#abcdef123456',
             attempts: [
               {
                 number: 1,
@@ -463,12 +461,18 @@ describe('ExecutionsTool /executions/{id}/output', () => {
               {
                 number: 2,
                 id: '222222222222',
+                childStreamId: 'writer#222222222222',
+                model: 'historical-model',
+                costUsd: 0.2,
                 startedAt: timestamp,
                 completedAt: timestamp,
               },
               {
                 number: 3,
                 id: 'abcdef123456',
+                childStreamId: 'writer#abcdef123456',
+                model: 'replacement-model',
+                costUsd: 0.3,
                 startedAt: timestamp,
                 completedAt: timestamp,
               },
@@ -512,6 +516,9 @@ describe('ExecutionsTool /executions/{id}/output', () => {
     assert.ok(output.includes('"stageBlocked": 0'));
     assert.ok(output.includes('"childExecutionId": "abcdef123456"'));
     assert.ok(output.includes('"number": 3'));
+    assert.ok(output.includes('"childStreamId": "writer#222222222222"'));
+    assert.ok(output.includes('"model": "historical-model"'));
+    assert.ok(output.includes('"costUsd": 0.2'));
     assert.ok(!output.includes('"number": 1'));
     assert.ok(!output.includes('private full instruction'));
     assert.ok(!output.includes('stage-tail'));
@@ -521,6 +528,103 @@ describe('ExecutionsTool /executions/{id}/output', () => {
     assert.ok(!output.includes('file-tail'));
     assert.ok(output.length < 20_000);
     assert.ok((await getExecutionStore(executionId).readMeta())?.workflow);
+  });
+
+  it('keeps an earlier-stage live call ahead of current-stage terminal calls when bounded', async () => {
+    const executionId = generateExecutionId();
+    await registerExecution(
+      executionId,
+      { name: 'ranked', instruction: 'Workflow script ranked' },
+      'ranked',
+      {
+        streamId: `workflow-script#${executionId}` as StreamTabId,
+        identity: {
+          kind: 'multiAgentWorkflow',
+          workflowName: 'ranked',
+        },
+      },
+    );
+    const timestamp = new Date().toISOString();
+    const terminalCalls = Array.from({ length: 8 }, (_, index) => ({
+      id: `current-terminal-${index}`,
+      label: `Current terminal ${index}`,
+      stageId: 'stage-2',
+      stageTitle: 'Current stage',
+      files: { input: [], context: [], media: [] },
+      attempts: [],
+      status: 'completed' as const,
+      timestamps: {
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        completedAt: timestamp,
+      },
+    }));
+    await captureOwnedExecutionLease(executionId)(() =>
+      writeWorkflowExecutionSnapshot(executionId, {
+        lifecycle: 'active',
+        currentStageId: 'stage-2',
+        stages: [
+          {
+            id: 'stage-1',
+            title: 'Earlier stage',
+            order: 0,
+            lifecycle: 'completed',
+            startedAt: timestamp,
+            completedAt: timestamp,
+          },
+          {
+            id: 'stage-2',
+            title: 'Current stage',
+            order: 1,
+            lifecycle: 'active',
+            startedAt: timestamp,
+          },
+        ],
+        calls: [
+          ...terminalCalls,
+          {
+            id: 'earlier-live',
+            label: 'Earlier live',
+            stageId: 'stage-1',
+            stageTitle: 'Earlier stage',
+            files: { input: [], context: [], media: [] },
+            attempts: [{ number: 1, startedAt: timestamp }],
+            status: 'running',
+            timestamps: {
+              createdAt: timestamp,
+              queuedAt: timestamp,
+              startedAt: timestamp,
+              updatedAt: timestamp,
+            },
+          },
+        ],
+        counts: {
+          total: 9,
+          waiting: 0,
+          planned: 0,
+          stageBlocked: 0,
+          queued: 0,
+          starting: 0,
+          running: 1,
+          completed: 8,
+          failed: 0,
+          cancelled: 0,
+          skipped: 0,
+          cached: 0,
+        },
+        timestamps: { createdAt: timestamp, updatedAt: timestamp },
+      }),
+    );
+
+    const result = await new ExecutionsTool().call({
+      path: `/executions/${executionId}`,
+    });
+    const output = result.output ?? '';
+
+    assert.equal(result.status, 'executed');
+    assert.ok(output.includes('"id": "earlier-live"'));
+    assert.ok(output.includes('"omittedCalls": 1'));
+    assert.ok(!output.includes('"id": "current-terminal-7"'));
   });
 
   it('errors on an unknown execution id', async () => {

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -530,6 +530,114 @@ describe('ExecutionsTool /executions/{id}/output', () => {
     assert.ok((await getExecutionStore(executionId).readMeta())?.workflow);
   });
 
+  it('keeps a failed call ahead of newer completed current-stage calls when bounded', async () => {
+    const executionId = generateExecutionId();
+    await registerExecution(
+      executionId,
+      { name: 'failed-rank', instruction: 'Workflow script failed-rank' },
+      'failed-rank',
+      {
+        streamId: `workflow-script#${executionId}` as StreamTabId,
+        identity: {
+          kind: 'multiAgentWorkflow',
+          workflowName: 'failed-rank',
+        },
+      },
+    );
+    const base = Date.parse('2026-04-01T00:00:00.000Z');
+    const completedCalls = Array.from({ length: 8 }, (_, index) => {
+      const updatedAt = new Date(base + (index + 1) * 1_000).toISOString();
+      return {
+        id: `completed-${index}`,
+        label: `Completed ${index}`,
+        stageId: 'stage-2',
+        stageTitle: 'Current stage',
+        files: { input: [], context: [], media: [] },
+        attempts: [],
+        status: 'completed' as const,
+        timestamps: {
+          createdAt: updatedAt,
+          updatedAt,
+          completedAt: updatedAt,
+        },
+      };
+    });
+    const failedAt = new Date(base).toISOString();
+    await captureOwnedExecutionLease(executionId)(() =>
+      writeWorkflowExecutionSnapshot(executionId, {
+        lifecycle: 'active',
+        currentStageId: 'stage-2',
+        stages: [
+          {
+            id: 'stage-1',
+            title: 'Earlier stage',
+            order: 0,
+            lifecycle: 'failed',
+            startedAt: failedAt,
+            completedAt: failedAt,
+          },
+          {
+            id: 'stage-2',
+            title: 'Current stage',
+            order: 1,
+            lifecycle: 'active',
+            startedAt: failedAt,
+          },
+        ],
+        calls: [
+          {
+            id: 'older-failed',
+            label: 'Older failed',
+            stageId: 'stage-1',
+            stageTitle: 'Earlier stage',
+            files: { input: [], context: [], media: [] },
+            attempts: [
+              {
+                number: 1,
+                startedAt: failedAt,
+                completedAt: failedAt,
+              },
+            ],
+            status: 'failed',
+            error: 'expected failure',
+            timestamps: {
+              createdAt: failedAt,
+              startedAt: failedAt,
+              updatedAt: failedAt,
+              completedAt: failedAt,
+            },
+          },
+          ...completedCalls,
+        ],
+        counts: {
+          total: 9,
+          waiting: 0,
+          planned: 0,
+          stageBlocked: 0,
+          queued: 0,
+          starting: 0,
+          running: 0,
+          completed: 8,
+          failed: 1,
+          cancelled: 0,
+          skipped: 0,
+          cached: 0,
+        },
+        timestamps: { createdAt: failedAt, updatedAt: failedAt },
+      }),
+    );
+
+    const result = await new ExecutionsTool().call({
+      path: `/executions/${executionId}`,
+    });
+    const output = result.output ?? '';
+
+    assert.equal(result.status, 'executed');
+    assert.ok(output.includes('"id": "older-failed"'));
+    assert.ok(output.includes('"omittedCalls": 1'));
+    assert.ok(!output.includes('"id": "completed-0"'));
+  });
+
   it('keeps an earlier-stage live call ahead of current-stage terminal calls when bounded', async () => {
     const executionId = generateExecutionId();
     await registerExecution(

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -8,8 +8,13 @@ import { strict as assert } from 'node:assert';
 import { afterEach, describe, it, vi } from 'vitest';
 
 // Local imports
-import { registerExecution } from '@agent/storage';
+import {
+  getExecutionStore,
+  registerExecution,
+  writeWorkflowExecutionSnapshot,
+} from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { captureOwnedExecutionLease } from '@agent/storage/executionLease';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { FileInteractionState } from '@agent/core/state/AgentWorkspaceState';
 import { withToolEnvironment } from '@agent/followUp/ToolFileInteractionContext';
@@ -137,7 +142,10 @@ async function registerProcessExecution(
       agentCategory: AgentCategory.ToolUse,
     }),
     'bash',
-    { streamId, identity: { kind: 'process', tool: 'bash' } },
+    {
+      streamId,
+      identity: { kind: 'process', tool: 'bash' },
+    },
   );
   return { executionId, streamId };
 }
@@ -396,6 +404,123 @@ describe('ExecutionsTool /executions/{id}/output', () => {
     assert.ok(
       (result.output ?? '').includes(`/executions/${executionId}/conversation`),
     );
+  });
+
+  it('exposes the canonical workflow aggregate without full instructions', async () => {
+    const executionId = generateExecutionId();
+    await registerExecution(
+      executionId,
+      { name: 'observable', instruction: 'Workflow script observable' },
+      'observable',
+      {
+        streamId: `workflow-script#${executionId}` as StreamTabId,
+        identity: {
+          kind: 'multiAgentWorkflow',
+          workflowName: 'observable',
+        },
+      },
+    );
+    const timestamp = new Date().toISOString();
+    const longStageId = `stage-${'s'.repeat(2_500)}-stage-tail`;
+    const longCallId = `call-${'i'.repeat(2_500)}-call-tail`;
+    const longTitle = `Draft ${'t'.repeat(3_000)}-title-tail`;
+    const longError = `Failure ${'e'.repeat(4_000)}-error-tail`;
+    const longFiles = Array.from(
+      { length: 513 },
+      (_, index) => `${'f'.repeat(600)}-${index}-file-tail.tex`,
+    );
+    await captureOwnedExecutionLease(executionId)(() =>
+      writeWorkflowExecutionSnapshot(executionId, {
+        lifecycle: 'active',
+        currentStageId: longStageId,
+        stages: [
+          {
+            id: longStageId,
+            title: longTitle,
+            order: 0,
+            lifecycle: 'active',
+            startedAt: timestamp,
+          },
+        ],
+        calls: [
+          {
+            id: longCallId,
+            label: '   ',
+            stageId: longStageId,
+            stageTitle: longTitle,
+            agent: 'writer',
+            model: 'model-a',
+            files: { input: longFiles, context: [], media: [] },
+            childExecutionId: 'abcdef123456',
+            childStreamId: 'writer#abcdef123456',
+            attempts: [
+              {
+                number: 1,
+                id: '111111111111',
+                startedAt: timestamp,
+                completedAt: timestamp,
+              },
+              {
+                number: 2,
+                id: '222222222222',
+                startedAt: timestamp,
+                completedAt: timestamp,
+              },
+              {
+                number: 3,
+                id: 'abcdef123456',
+                startedAt: timestamp,
+                completedAt: timestamp,
+              },
+            ],
+            status: 'failed',
+            error: longError,
+            timestamps: {
+              createdAt: timestamp,
+              queuedAt: timestamp,
+              startedAt: timestamp,
+              updatedAt: timestamp,
+              completedAt: timestamp,
+            },
+          },
+        ],
+        counts: {
+          total: 1,
+          waiting: 0,
+          planned: 0,
+          stageBlocked: 0,
+          queued: 0,
+          starting: 0,
+          running: 0,
+          completed: 0,
+          failed: 1,
+          cancelled: 0,
+          skipped: 0,
+          cached: 0,
+        },
+        timestamps: { createdAt: timestamp, updatedAt: timestamp },
+      }),
+    );
+
+    const result = await new ExecutionsTool().call({
+      path: `/executions/${executionId}`,
+    });
+    const output = result.output ?? '';
+    assert.equal(result.status, 'executed');
+    assert.ok(output.includes('"currentStage"'));
+    assert.ok(output.includes('"calls"'));
+    assert.ok(output.includes('"stageBlocked": 0'));
+    assert.ok(output.includes('"childExecutionId": "abcdef123456"'));
+    assert.ok(output.includes('"number": 3'));
+    assert.ok(!output.includes('"number": 1'));
+    assert.ok(!output.includes('private full instruction'));
+    assert.ok(!output.includes('stage-tail'));
+    assert.ok(!output.includes('call-tail'));
+    assert.ok(!output.includes('title-tail'));
+    assert.ok(!output.includes('error-tail'));
+    assert.ok(!output.includes('file-tail'));
+    assert.ok(output.length < 20_000);
+    assert.ok((await getExecutionStore(executionId).readMeta())?.workflow);
   });
 
   it('errors on an unknown execution id', async () => {

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -37,7 +37,9 @@ const mocks = vi.hoisted(() => ({
   configureDelegatedChildApprovals: vi.fn(),
   requireWorkflowOrToolUseAgent: vi.fn(),
   selectAvailableDelegationModel: vi.fn(),
+  createWorkflowScriptStrategy: vi.fn(),
   childLoggerError: vi.fn(),
+  lastStrategyParams: undefined as { initialSnapshot?: unknown } | undefined,
 }));
 
 // Spread the real storage module so `getExecutionStore` stays authentic;
@@ -47,6 +49,23 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@agent/storage', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@agent/storage')>();
   return { ...actual, registerExecution: mocks.registerExecution };
+});
+
+vi.mock('@tools/delegation/workflowScriptStrategy', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@tools/delegation/workflowScriptStrategy')
+    >();
+  return {
+    ...actual,
+    createWorkflowScriptStrategy: (params: { initialSnapshot?: unknown }) => {
+      mocks.lastStrategyParams = params;
+      mocks.createWorkflowScriptStrategy(params);
+      return actual.createWorkflowScriptStrategy(
+        params as Parameters<typeof actual.createWorkflowScriptStrategy>[0],
+      );
+    },
+  };
 });
 
 vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
@@ -198,6 +217,7 @@ async function callToolInput(
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  mocks.lastStrategyParams = undefined;
   await WorkspaceFS.ensureDir('.');
   await WorkspaceFS.write('paper.tex', '\\documentclass{article}');
   await WorkspaceFS.write('references.bib', '@book{example}');
@@ -755,6 +775,92 @@ describe('WorkflowScriptTool', () => {
 
     expect(first).toBe(runExecutionIdFor('tool-test'));
     expect(second).toBe(first);
+  });
+
+  it('captures prior workflow snapshot before registerExecution overwrites meta', async () => {
+    const runId = runExecutionIdFor('tool-test');
+    const store = getExecutionStore(runId);
+    const priorWorkflow = {
+      lifecycle: 'active' as const,
+      stages: [],
+      calls: [
+        {
+          id: 'interrupted',
+          label: 'Interrupted call',
+          files: { input: [], context: [], media: [] },
+          attempts: [
+            {
+              number: 1,
+              id: 'bbbbbb222222',
+              startedAt: '2026-08-01T00:00:00.000Z',
+            },
+          ],
+          status: 'running' as const,
+          costUsd: 1.25,
+          childExecutionId: 'bbbbbb222222',
+          timestamps: {
+            createdAt: '2026-08-01T00:00:00.000Z',
+            updatedAt: '2026-08-01T00:00:01.000Z',
+            startedAt: '2026-08-01T00:00:00.000Z',
+          },
+        },
+      ],
+      counts: {
+        total: 1,
+        waiting: 0,
+        planned: 0,
+        stageBlocked: 0,
+        queued: 0,
+        starting: 0,
+        running: 1,
+        completed: 0,
+        failed: 0,
+        cancelled: 0,
+        skipped: 0,
+        cached: 0,
+      },
+      timestamps: {
+        createdAt: '2026-08-01T00:00:00.000Z',
+        updatedAt: '2026-08-01T00:00:01.000Z',
+      },
+    };
+    await store.writeMeta({
+      timestamp: '2026-08-01T00:00:00.000Z',
+      workflow: priorWorkflow,
+    });
+
+    const callOrder: string[] = [];
+    const readStrict = vi
+      .spyOn(store, 'readMetaStrict')
+      .mockImplementation(async () => {
+        callOrder.push('readMetaStrict');
+        return {
+          schemaVersion: 1,
+          timestamp: '2026-08-01T00:00:00.000Z',
+          workflow: priorWorkflow,
+        };
+      });
+    mocks.registerExecution.mockImplementation(async () => {
+      callOrder.push('registerExecution');
+      // Simulate production: registration replaces meta without workflow.
+      await store.writeMeta({
+        timestamp: '2026-08-10T00:00:00.000Z',
+        streamId: `workflow-script#${runId}`,
+        identity: { kind: 'multiAgentWorkflow', workflowName: 'tool-test' },
+        userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.UNSUPPORTED,
+      });
+    });
+
+    const result = await callTool();
+
+    expect(result.status).toBe('executed');
+    expect(callOrder).toEqual(['readMetaStrict', 'registerExecution']);
+    // Strategy must receive the pre-register snapshot, not a post-wipe read.
+    expect(mocks.lastStrategyParams?.initialSnapshot).toEqual(priorWorkflow);
+    // Post-register meta no longer has workflow — a post-register read would
+    // have lost hydration state.
+    await expect(store.readMeta()).resolves.not.toHaveProperty('workflow');
+    readStrict.mockRestore();
   });
 
   it('reports already-running when the deterministic id is still leased', async () => {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -44,6 +44,7 @@ import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   TERMINAL_WORKFLOW_CALL_STATUSES,
+  WORKFLOW_CALL_STATUS,
   type ExecutionId,
   type StreamLogEntry,
   type WorkflowExecutionSnapshot,
@@ -266,11 +267,25 @@ function workflowAttemptView(
   };
 }
 
+function workflowCallFailurePriority(status: string): number {
+  // Within terminal calls, elevate failed/cancelled so the bounded projection
+  // keeps the outcomes that matter for debugging (matches stage ranking).
+  if (
+    status === WORKFLOW_CALL_STATUS.FAILED ||
+    status === WORKFLOW_CALL_STATUS.CANCELLED
+  ) {
+    return 0;
+  }
+  return 1;
+}
+
 function workflowExecutionView(snapshot: WorkflowExecutionSnapshot): unknown {
   const byPriority = snapshot.calls.toSorted(
     (left, right) =>
       Number(TERMINAL_WORKFLOW_CALL_STATUSES.has(left.status)) -
         Number(TERMINAL_WORKFLOW_CALL_STATUSES.has(right.status)) ||
+      workflowCallFailurePriority(left.status) -
+        workflowCallFailurePriority(right.status) ||
       Number(left.stageId !== snapshot.currentStageId) -
         Number(right.stageId !== snapshot.currentStageId) ||
       right.timestamps.updatedAt.localeCompare(left.timestamps.updatedAt),

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -43,6 +43,7 @@ import {
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
+  TERMINAL_WORKFLOW_CALL_STATUSES,
   type ExecutionId,
   type StreamLogEntry,
   type WorkflowExecutionSnapshot,
@@ -233,13 +234,6 @@ const WORKFLOW_SUMMARY_MAX_ENTRIES = 8;
 const WORKFLOW_SUMMARY_MAX_ATTEMPTS = 2;
 const WORKFLOW_SUMMARY_MAX_FILES_PER_KIND = 3;
 const WORKFLOW_SUMMARY_TEXT_LENGTH = 160;
-const WORKFLOW_LIVE_CALL_STATUSES = new Set([
-  'planned',
-  'stageBlocked',
-  'queued',
-  'starting',
-  'running',
-]);
 
 function compactWorkflowText(value: string | undefined): string | undefined {
   return value?.slice(0, WORKFLOW_SUMMARY_TEXT_LENGTH);
@@ -264,24 +258,23 @@ function workflowAttemptView(
   return {
     number: attempt.number,
     id: compactWorkflowText(attempt.id),
+    childStreamId: compactWorkflowText(attempt.childStreamId),
+    model: compactWorkflowText(attempt.model),
+    costUsd: attempt.costUsd,
     startedAt: attempt.startedAt,
     completedAt: attempt.completedAt,
   };
 }
 
 function workflowExecutionView(snapshot: WorkflowExecutionSnapshot): unknown {
-  const byPriority = snapshot.calls.toSorted((left, right) => {
-    const priority = (call: (typeof snapshot.calls)[number]): number => {
-      if (call.stageId === snapshot.currentStageId) return 0;
-      if (WORKFLOW_LIVE_CALL_STATUSES.has(call.status)) return 1;
-      if (call.status === 'failed' || call.status === 'cancelled') return 2;
-      return 3;
-    };
-    return (
-      priority(left) - priority(right) ||
-      right.timestamps.updatedAt.localeCompare(left.timestamps.updatedAt)
-    );
-  });
+  const byPriority = snapshot.calls.toSorted(
+    (left, right) =>
+      Number(TERMINAL_WORKFLOW_CALL_STATUSES.has(left.status)) -
+        Number(TERMINAL_WORKFLOW_CALL_STATUSES.has(right.status)) ||
+      Number(left.stageId !== snapshot.currentStageId) -
+        Number(right.stageId !== snapshot.currentStageId) ||
+      right.timestamps.updatedAt.localeCompare(left.timestamps.updatedAt),
+  );
   const stages = snapshot.stages
     .toSorted((left, right) => {
       const priority = (stage: (typeof snapshot.stages)[number]): number => {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -45,6 +45,7 @@ import {
   STREAM_LOG_ENTRY_TYPES,
   type ExecutionId,
   type StreamLogEntry,
+  type WorkflowExecutionSnapshot,
 } from '@shared/schemas';
 import {
   BASH_BACKGROUND_LOG_CAP_CHARS,
@@ -227,6 +228,138 @@ const OUTPUT_MAX_LINES = 1_000;
 
 /** Marks a projected line that the command wrote to stderr. */
 const OUTPUT_STDERR_PREFIX = 'err: ';
+
+const WORKFLOW_SUMMARY_MAX_ENTRIES = 8;
+const WORKFLOW_SUMMARY_MAX_ATTEMPTS = 2;
+const WORKFLOW_SUMMARY_MAX_FILES_PER_KIND = 3;
+const WORKFLOW_SUMMARY_TEXT_LENGTH = 160;
+const WORKFLOW_LIVE_CALL_STATUSES = new Set([
+  'planned',
+  'stageBlocked',
+  'queued',
+  'starting',
+  'running',
+]);
+
+function compactWorkflowText(value: string | undefined): string | undefined {
+  return value?.slice(0, WORKFLOW_SUMMARY_TEXT_LENGTH);
+}
+
+function workflowStageView(
+  stage: WorkflowExecutionSnapshot['stages'][number],
+): unknown {
+  return {
+    id: compactWorkflowText(stage.id),
+    title: compactWorkflowText(stage.title),
+    order: stage.order,
+    lifecycle: stage.lifecycle,
+    startedAt: stage.startedAt,
+    completedAt: stage.completedAt,
+  };
+}
+
+function workflowAttemptView(
+  attempt: WorkflowExecutionSnapshot['calls'][number]['attempts'][number],
+): unknown {
+  return {
+    number: attempt.number,
+    id: compactWorkflowText(attempt.id),
+    startedAt: attempt.startedAt,
+    completedAt: attempt.completedAt,
+  };
+}
+
+function workflowExecutionView(snapshot: WorkflowExecutionSnapshot): unknown {
+  const byPriority = snapshot.calls.toSorted((left, right) => {
+    const priority = (call: (typeof snapshot.calls)[number]): number => {
+      if (call.stageId === snapshot.currentStageId) return 0;
+      if (WORKFLOW_LIVE_CALL_STATUSES.has(call.status)) return 1;
+      if (call.status === 'failed' || call.status === 'cancelled') return 2;
+      return 3;
+    };
+    return (
+      priority(left) - priority(right) ||
+      right.timestamps.updatedAt.localeCompare(left.timestamps.updatedAt)
+    );
+  });
+  const stages = snapshot.stages
+    .toSorted((left, right) => {
+      const priority = (stage: (typeof snapshot.stages)[number]): number => {
+        if (stage.id === snapshot.currentStageId) return 0;
+        if (stage.lifecycle === 'failed' || stage.lifecycle === 'cancelled') {
+          return 1;
+        }
+        return 2;
+      };
+      return priority(left) - priority(right) || right.order - left.order;
+    })
+    .slice(0, WORKFLOW_SUMMARY_MAX_ENTRIES)
+    .map(workflowStageView);
+  const calls = byPriority
+    .slice(0, WORKFLOW_SUMMARY_MAX_ENTRIES)
+    .map((call) => {
+      const compactFiles = (files: readonly string[]) => ({
+        sample: files
+          .slice(0, WORKFLOW_SUMMARY_MAX_FILES_PER_KIND)
+          .map((file) => compactWorkflowText(file)!),
+        ...(files.length > WORKFLOW_SUMMARY_MAX_FILES_PER_KIND && {
+          omitted: files.length - WORKFLOW_SUMMARY_MAX_FILES_PER_KIND,
+        }),
+      });
+      return {
+        id: compactWorkflowText(call.id),
+        label: compactWorkflowText(call.label),
+        stageId: compactWorkflowText(call.stageId),
+        stageTitle: compactWorkflowText(call.stageTitle),
+        agent: compactWorkflowText(call.agent),
+        model: compactWorkflowText(call.model),
+        files: {
+          input: compactFiles(call.files.input),
+          context: compactFiles(call.files.context),
+          media: compactFiles(call.files.media),
+        },
+        childExecutionId: compactWorkflowText(call.childExecutionId),
+        childStreamId: compactWorkflowText(call.childStreamId),
+        attempts: call.attempts
+          .slice(-WORKFLOW_SUMMARY_MAX_ATTEMPTS)
+          .map(workflowAttemptView),
+        ...(call.attempts.length > WORKFLOW_SUMMARY_MAX_ATTEMPTS && {
+          omittedAttempts: call.attempts.length - WORKFLOW_SUMMARY_MAX_ATTEMPTS,
+        }),
+        status: call.status,
+        blockedReason: compactWorkflowText(call.blockedReason),
+        error: compactWorkflowText(call.error),
+        costUsd: call.costUsd,
+        timestamps: call.timestamps,
+      };
+    });
+  const currentStage = snapshot.stages.find(
+    (stage) => stage.id === snapshot.currentStageId,
+  );
+  return {
+    aggregate: {
+      lifecycle: snapshot.lifecycle,
+      error: compactWorkflowText(snapshot.error),
+      counts: snapshot.counts,
+      timestamps: snapshot.timestamps,
+      responseBounds: {
+        maxStages: WORKFLOW_SUMMARY_MAX_ENTRIES,
+        maxCalls: WORKFLOW_SUMMARY_MAX_ENTRIES,
+        maxAttemptsPerCall: WORKFLOW_SUMMARY_MAX_ATTEMPTS,
+        maxFilesPerKind: WORKFLOW_SUMMARY_MAX_FILES_PER_KIND,
+      },
+    },
+    currentStage: currentStage ? workflowStageView(currentStage) : null,
+    stages,
+    calls,
+    ...(snapshot.stages.length > stages.length && {
+      omittedStages: snapshot.stages.length - stages.length,
+    }),
+    ...(snapshot.calls.length > calls.length && {
+      omittedCalls: snapshot.calls.length - calls.length,
+    }),
+  };
+}
 
 /**
  * Line break in captured terminal output. A bare CR counts: progress bars
@@ -615,6 +748,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
         todos,
         report,
         {
+          workflow: meta?.workflow,
           suppressReport: shouldSuppressAutoDeliveredSubagentReport(
             options,
             handle,
@@ -672,9 +806,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
       children,
       todosResult.todos,
       report,
-      {
-        suppressReport: false,
-      },
+      { workflow: meta?.workflow },
     );
 
     return executed(lines.join('\n'));
@@ -691,8 +823,18 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     children: ChildRecord[],
     todos: TodoEntry[],
     report: string | null,
-    options: { readonly suppressReport?: boolean } = {},
+    options: {
+      readonly workflow?: WorkflowExecutionSnapshot;
+      readonly suppressReport?: boolean;
+    } = {},
   ): Promise<void> {
+    if (options.workflow) {
+      lines.push(
+        '',
+        'Workflow:',
+        JSON.stringify(workflowExecutionView(options.workflow), null, 2),
+      );
+    }
     if (children.length > 0) {
       lines.push('', `Children (${children.length}):`);
       const formatted = await this.formatChildren(children);

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -2,7 +2,11 @@
 import { z } from 'zod';
 
 // Local imports
-import { getExecutionStore, registerExecution } from '@agent/storage';
+import {
+  getExecutionStore,
+  registerExecution,
+  writeWorkflowExecutionSnapshot,
+} from '@agent/storage';
 import {
   deriveWorkflowScriptCheckpointId,
   parseWorkflowScript,
@@ -197,8 +201,8 @@ Script rules:
 - Meta: start with an export const meta object containing name and description. No imports or require: only the injected primitives exist: agent, phase, log, parallel, args, and files. Metadata and agent() options reject unknown fields, so typos fail at the saved script instead of being ignored. meta.phases accepts title strings such as ['Draft', 'Merge'] or objects such as [{ title: 'Draft' }].
 - Tasks: when the calls are known in advance, declare meta.tasks as { id, label, phase? } records so progress shows the pending plan before execution. A task phase must name a title in meta.phases. Every agent() call must then reference one declared task with { id }; omit label and phase from the call because meta.tasks owns them (exact matching duplicates are accepted, but conflicts fail). Omit meta.tasks when the call set is data-dependent.
 - Files: the tool's files field binds workspace files to the whole run as files.inputFiles (editable), files.contextFiles (read-only documents), and files.mediaFiles (read-only visual or audio inputs). A workflow agent() call may use inputFiles, contextFiles, and mediaFiles; inputFiles is required unless the agent declares default outputs. Paths may name workspace files, launch files, or a previous call's outputs. Structured (tool-use) agent() calls do not accept file options.
-- Calls: every call may use agentName (another visible workflow or tool-use agent; defaults to this tool's agent field) and model (an available model short name for this call); omit model to follow ordinary delegation policy. A call without meta.tasks may also use id, label, and phase.
-- Awaiting: agent() and parallel() return Promises: await them. Use ordinary JavaScript loops and awaited calls for sequential stages.
+- Calls: every call may use agentName (another visible workflow or tool-use agent; defaults to this tool's agent field) and model (an available model short name for this call); omit model to follow ordinary delegation policy. A call without meta.tasks may also use id, label, and phase. Its logical identity is the explicit id when present, otherwise its call ordinal. Logical ids must be unique. Canonical labels prefer an explicit label, then a meaningful file and agent, then agent role and ordinal.
+- Awaiting: agent() and parallel() return Promises — await them. Use ordinary JavaScript loops and awaited calls for sequential stages.
 - Failures: a failed agent call, including a workflow agent that produces no output files, resolves to null. An interactive skip resolves to the truthy '__WORKFLOW_SKIPPED__' sentinel; exclude both non-results before synthesis. JavaScript errors in parallel() thunks fail the workflow and preserve the editable script path rather than being silently converted to null.
 
 Structured output: agent(prompt, { agentName, model, schema }) runs a tool-use agent that finishes by calling submit_output with a value matching the JSON Schema. Structured calls do not accept file options and must name the tool-use agent explicitly; model remains optional. The call resolves to an envelope whose .structured is the validated object rather than edited files.
@@ -481,6 +485,9 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
             files,
             name: meta.name,
             workflowControls: runScope.session.workflowControls,
+            initialSnapshot: (await runStore.readMeta())?.workflow,
+            onSnapshot: (snapshot) =>
+              writeWorkflowExecutionSnapshot(runExecutionId, snapshot),
             ...(parent.stopAfterCycle && {
               deliveryMode: 'persistOnly' as const,
             }),

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -29,6 +29,7 @@ import {
   RUN_OUTCOME,
   USER_FOLLOW_UP_SUPPORT,
   type StreamTabId,
+  type WorkflowExecutionSnapshot,
 } from '@shared/schemas';
 import { WorkflowScriptFilesSchema } from '@shared/schemas/workflowScriptFiles';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
@@ -379,6 +380,25 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
       AgentConfigSchema.parse(runConfigPayload),
     );
 
+    // Capture any prior workflow snapshot *before* registerExecution overwrites
+    // meta.json. Deterministic meta.name reuses the same execution id, so a
+    // post-register read always sees a fresh meta with no workflow field and
+    // hydration would drop interrupted attempts, costs, and child identities.
+    // Strict read preserves absent-vs-malformed: corrupt present snapshots stop
+    // recovery rather than being treated as a clean first launch.
+    const runStore = getExecutionStore(runExecutionId);
+    let initialSnapshot: WorkflowExecutionSnapshot | undefined;
+    try {
+      initialSnapshot = (await runStore.readMetaStrict())?.workflow;
+    } catch (error) {
+      throw workflowScriptToolError(
+        new ToolError(
+          `Failed to launch workflow script '${meta.name}': prior workflow execution snapshot is malformed and cannot be recovered (${toErrorMessage(error)})`,
+        ),
+        scriptPath,
+      );
+    }
+
     try {
       // The durable record states only what the container run has: the
       // workflow's name and the real model its agent steps will use. The
@@ -434,7 +454,6 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
       // the deterministic run lease is held, so a throw here must release the
       // lease — otherwise it survives to its heartbeat timeout and a prompt
       // relaunch is refused.
-      const runStore = getExecutionStore(runExecutionId);
       let runChildStreamId: StreamTabId;
       let runCompletion: Promise<void>;
       try {
@@ -485,7 +504,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
             files,
             name: meta.name,
             workflowControls: runScope.session.workflowControls,
-            initialSnapshot: (await runStore.readMeta())?.workflow,
+            initialSnapshot,
             onSnapshot: (snapshot) =>
               writeWorkflowExecutionSnapshot(runExecutionId, snapshot),
             ...(parent.stopAfterCycle && {

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -184,7 +184,7 @@ function withScriptReference(
  * Execute a durable, deterministic workflow script from an agent whose tool
  * list names it. Gated by the "Multi-Agent Workflow" dashboard switch (id
  * `workflow-script` in {@link @tools/externalToolDefs}), which
- * `resolveAgentTools()` enforces regardless of any agent's configured tools —
+ * `resolveAgentTools()` enforces regardless of any agent's configured tools -
  * new installs start with the switch off.
  */
 export class WorkflowScriptTool extends defineTool({
@@ -203,7 +203,7 @@ Script rules:
 - Tasks: when the calls are known in advance, declare meta.tasks as { id, label, phase? } records so progress shows the pending plan before execution. A task phase must name a title in meta.phases. Every agent() call must then reference one declared task with { id }; omit label and phase from the call because meta.tasks owns them (exact matching duplicates are accepted, but conflicts fail). Omit meta.tasks when the call set is data-dependent.
 - Files: the tool's files field binds workspace files to the whole run as files.inputFiles (editable), files.contextFiles (read-only documents), and files.mediaFiles (read-only visual or audio inputs). A workflow agent() call may use inputFiles, contextFiles, and mediaFiles; inputFiles is required unless the agent declares default outputs. Paths may name workspace files, launch files, or a previous call's outputs. Structured (tool-use) agent() calls do not accept file options.
 - Calls: every call may use agentName (another visible workflow or tool-use agent; defaults to this tool's agent field) and model (an available model short name for this call); omit model to follow ordinary delegation policy. A call without meta.tasks may also use id, label, and phase. Its logical identity is the explicit id when present, otherwise its call ordinal. Logical ids must be unique. Canonical labels prefer an explicit label, then a meaningful file and agent, then agent role and ordinal.
-- Awaiting: agent() and parallel() return Promises — await them. Use ordinary JavaScript loops and awaited calls for sequential stages.
+- Awaiting: agent() and parallel() return Promises: await them. Use ordinary JavaScript loops and awaited calls for sequential stages.
 - Failures: a failed agent call, including a workflow agent that produces no output files, resolves to null. An interactive skip resolves to the truthy '__WORKFLOW_SKIPPED__' sentinel; exclude both non-results before synthesis. JavaScript errors in parallel() thunks fail the workflow and preserve the editable script path rather than being silently converted to null.
 
 Structured output: agent(prompt, { agentName, model, schema }) runs a tool-use agent that finishes by calling submit_output with a value matching the JSON Schema. Structured calls do not accept file options and must name the tool-use agent explicitly; model remains optional. The call resolves to an envelope whose .structured is the validated object rather than edited files.
@@ -452,7 +452,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
     const runResult = runWithOwnership(async () => {
       // Attempt-scoped setup is inside the lease-protected try: it runs after
       // the deterministic run lease is held, so a throw here must release the
-      // lease — otherwise it survives to its heartbeat timeout and a prompt
+      // lease - otherwise it survives to its heartbeat timeout and a prompt
       // relaunch is refused.
       let runChildStreamId: StreamTabId;
       let runCompletion: Promise<void>;

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -370,7 +370,13 @@ export function createWorkflowScriptAgentRunner(
                 runScope.session,
               );
             },
-            onCost: (totalCostUsd) => hooks?.onCost?.(invocation, totalCostUsd),
+            onCost: (totalCostUsd) => {
+              hooks?.onCost?.(invocation, totalCostUsd);
+              // Stamp progressive spend onto the live snapshot attempt so a
+              // failed/cancelled/retried attempt still shows what it consumed
+              // even when execution never reaches the success path below.
+              invocation.reportCostUsd?.(totalCostUsd);
+            },
           };
         },
       });
@@ -395,6 +401,14 @@ export function createWorkflowScriptAgentRunner(
         }
       }
       const { result } = completed;
+      // Live physical attempts always charge the terminal result cost (covers
+      // failed/cancelled outcomes and empty-output validation throws that
+      // never reach a success-only callback). Recovered durable results must
+      // not charge the synthetic resume attempt — the interrupted snapshot may
+      // already hold the same cost on a closed prior attempt.
+      if (!recovered) {
+        invocation.reportCostUsd?.(result.cost);
+      }
       if (result.outcome !== 'completed') {
         throw new Error(
           `Workflow subagent ended with ${result.outcome} outcome.`,
@@ -404,13 +418,6 @@ export function createWorkflowScriptAgentRunner(
         throw new Error(
           'Workflow subagent completed without producing any output files.',
         );
-      }
-      // Live physical attempts always charge. Recovered durable results must
-      // not charge the synthetic resume attempt — the interrupted snapshot may
-      // already hold the same cost on a closed prior attempt, and double-counting
-      // would inflate totalAttemptCost on /executions/{id}.
-      if (!recovered) {
-        invocation.reportCostUsd?.(result.cost);
       }
       return result;
     } catch (error) {

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -374,20 +374,24 @@ export function createWorkflowScriptAgentRunner(
           };
         },
       });
-      if (
-        activeExecutionId === undefined &&
-        invocation.reportChildStream !== undefined
-      ) {
-        try {
-          const recoveredStreamId = (
-            await getExecutionStore(completed.executionId).readMeta()
-          )?.streamId;
-          if (recoveredStreamId !== undefined) {
-            invocation.reportChildStream(recoveredStreamId);
+      const recovered = activeExecutionId === undefined;
+      if (recovered) {
+        // Durable recovery never fires onActiveExecutionId; re-attach the
+        // known child id (and stream when available) so /executions/{id}
+        // can navigate to the child that supplied the result.
+        invocation.reportChildExecution?.(completed.executionId);
+        if (invocation.reportChildStream !== undefined) {
+          try {
+            const recoveredStreamId = (
+              await getExecutionStore(completed.executionId).readMeta()
+            )?.streamId;
+            if (recoveredStreamId !== undefined) {
+              invocation.reportChildStream(recoveredStreamId);
+            }
+          } catch {
+            // A recovered result is authoritative. Navigation metadata is
+            // optional and must not invalidate the completed computation.
           }
-        } catch {
-          // A recovered result is authoritative. Navigation metadata is
-          // optional and must not invalidate the completed computation.
         }
       }
       const { result } = completed;
@@ -401,7 +405,13 @@ export function createWorkflowScriptAgentRunner(
           'Workflow subagent completed without producing any output files.',
         );
       }
-      invocation.reportCostUsd?.(result.cost);
+      // Live physical attempts always charge. Recovered durable results must
+      // not charge the synthetic resume attempt — the interrupted snapshot may
+      // already hold the same cost on a closed prior attempt, and double-counting
+      // would inflate totalAttemptCost on /executions/{id}.
+      if (!recovered) {
+        invocation.reportCostUsd?.(result.cost);
+      }
       return result;
     } catch (error) {
       if (error instanceof SubagentDurabilityError) {

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -375,7 +375,9 @@ export function createWorkflowScriptAgentRunner(
               // Stamp progressive spend onto the live snapshot attempt so a
               // failed/cancelled/retried attempt still shows what it consumed
               // even when execution never reaches the success path below.
-              invocation.reportCostUsd?.(totalCostUsd);
+              if (totalCostUsd !== undefined) {
+                invocation.reportCostUsd?.(totalCostUsd);
+              }
             },
           };
         },

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -229,6 +229,7 @@ export function createWorkflowScriptAgentRunner(
         signal: invocation.signal,
         onActiveExecutionId: (executionId) => {
           activeExecutionId = executionId;
+          invocation.reportChildExecution?.(executionId);
           hooks?.onChildActive?.(executionId, invocation, true);
         },
         prepare: async () => {
@@ -340,6 +341,7 @@ export function createWorkflowScriptAgentRunner(
           // Surface the resolved child model so the engine can attach it to
           // this call's `agent:end` progress event.
           invocation.reportModel?.(configPayload.model);
+          invocation.reportAgent?.(agentName);
           return {
             configPayload,
             agentName,
@@ -399,6 +401,7 @@ export function createWorkflowScriptAgentRunner(
           'Workflow subagent completed without producing any output files.',
         );
       }
+      invocation.reportCostUsd?.(result.cost);
       return result;
     } catch (error) {
       if (error instanceof SubagentDurabilityError) {

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -326,6 +326,8 @@ export async function runPersistedWorkflowScriptWithProgress(
       case 'log':
         info(event.message, openPhaseStage(currentPhase));
         break;
+      case 'agent:queued':
+        break;
       case 'agent:start': {
         const phaseTitle = event.phase ?? currentPhase;
         callPhases.set(event.progressId, phaseTitle);

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -28,7 +28,7 @@ import type {
   WorkflowControlRegistry,
   WorkflowRunControl,
 } from '@agent/runtime/workflowControlRegistry';
-import type { ExecutionId } from '@shared/schemas';
+import type { ExecutionId, WorkflowExecutionSnapshot } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
 import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import type { WorkflowScriptFiles } from '@shared/schemas/workflowScriptFiles';
@@ -113,6 +113,10 @@ export interface WorkflowScriptStrategyParams {
    * on while the run is in flight, so a host can target a focused grandchild.
    */
   readonly workflowControls: WorkflowControlRegistry;
+  /** Snapshot read from the detached run metadata that receives subsequent writes. */
+  readonly initialSnapshot?: WorkflowExecutionSnapshot;
+  /** Persist the canonical snapshot on the detached run metadata. */
+  readonly onSnapshot?: (snapshot: WorkflowExecutionSnapshot) => Promise<void>;
   /** Persist-only when a headless caller awaits and returns the report itself. */
   readonly deliveryMode?: ChildRunStrategy<WorkflowScriptRunResult>['deliveryMode'];
   /**
@@ -181,6 +185,9 @@ export function createWorkflowScriptStrategy(
         run = await runPersistedWorkflowScriptWithProgress(params.logger, {
           store: params.store,
           checkpointId: params.checkpointId,
+          ...(params.initialSnapshot !== undefined && {
+            initialSnapshot: params.initialSnapshot,
+          }),
           script: params.script,
           ...(params.args != null && { args: params.args }),
           ...(params.files !== undefined && {
@@ -193,6 +200,7 @@ export function createWorkflowScriptStrategy(
           getCallCostUsd: (index) => attemptCost.costForCall(index),
           onActivity: runLog.add,
           onEvent: summary.onEvent,
+          ...(params.onSnapshot && { onSnapshot: params.onSnapshot }),
           onControl: (control) => {
             // Translate an execution-id-keyed host request into an
             // index-keyed engine action; unknown/settled children no-op,


### PR DESCRIPTION
## Summary
- add one canonical durable workflow execution snapshot with stable call identity, stages, attempts, queue state, and explicit aggregates
- extract workflow stage and call transitions into one state machine with terminal sealing
- coalesce detached metadata writes, separate checkpoint persistence, and abort cleanly on the first persistence failure
- add one bounded `/executions` projection that prioritizes current, nonterminal, failed, cancelled, and recent attempts

## Scope
This is the narrow observability foundation only. It excludes follow-up capability, trace suppression, generic session descriptions, structured summary suppression, token/tool metrics, and workflow-call child plumbing.

## Verification
- 189 focused workflow, schema, persistence, and projection tests passed
- full typecheck and lint passed
- production build and VSIX packaging passed
- Prettier and `git diff --check` passed
- full suite reached 8,836 passing tests with 2 unrelated desktop timeout failures; the complete 73-test desktop file passed in isolation
- simplifier reduced duplicate state and transition plumbing
- final independent review found no remaining issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes execution metadata parsing, workflow runner sealing/persistence, and resume hydration on deterministic workflow ids; mistakes could corrupt or misrepresent interrupted runs, though behavior is heavily covered by new tests.
> 
> **Overview**
> Introduces a **canonical `WorkflowExecutionSnapshot`** (stages, calls, attempts, queue/running status, aggregates) persisted on detached workflow execution `meta.workflow`, with a strict Zod schema and a new **`WorkflowExecutionState`** state machine driving transitions from the script runner.
> 
> The workflow engine now **publishes coalesced snapshots** via `onSnapshot`, seals terminal state after journal commits drain, and **fails the run** on snapshot persistence errors. **Checkpoint writes** stay separate from snapshot metadata; **`writeWorkflowExecutionSnapshot`** updates meta under the existing lock. **`ExecutionMeta`** splits into **`ExecutionMetaCoreSchema`** plus optional workflow: ordinary reads drop malformed workflow blobs but keep core meta; strict reads fail closed for recovery.
> 
> **Resume/relaunch** reads the prior snapshot **before** `registerExecution` wipes meta, hydrates interrupted calls, and enforces **unique logical call `id`** (duplicate `id` is rejected, not split into separate progress records). Child **`agent()`** invocations report agent, child execution, stream, and cost into the snapshot; live-attempt caps move to after p-queue admission.
> 
> **`/executions/{id}`** adds a bounded JSON **Workflow** section prioritizing current stage, live calls, failures, and recent attempts without leaking full prompts or huge file lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8caea67658456949366d38d7d383208ebe33d71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->