### PR TITLE
Show skills active for each run

### DIFF
--- a/packages/cli/src/chat/tui/appLayout.ts
+++ b/packages/cli/src/chat/tui/appLayout.ts
@@ -151,6 +151,26 @@ export function allocateSidePanelRows({
   return { subagentRows, todosPlanRows: available - subagentRows };
 }
 
+/**
+ * Reserve one live conversation row before skills and other bottom panels
+ * divide the remaining transcript budget.
+ */
+export function allocateConversationAuxiliaryRows({
+  desiredSkillsRows,
+  transcriptRows,
+}: {
+  readonly desiredSkillsRows: number;
+  readonly transcriptRows: number;
+}): { readonly skillsRows: number; readonly otherPanelRows: number } {
+  const available = Math.max(0, transcriptRows);
+  const auxiliaryRows = Math.max(0, available - 1);
+  const skillsRows = Math.min(Math.max(0, desiredSkillsRows), auxiliaryRows);
+  return {
+    skillsRows,
+    otherPanelRows: auxiliaryRows - skillsRows,
+  };
+}
+
 export function allocateConversationBottomPanelRows({
   maxRows,
   sessionCount,

--- a/packages/cli/src/chat/tui/panes/ActiveSkillsPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/ActiveSkillsPanel.tsx
@@ -1,0 +1,64 @@
+import { Box, Text } from 'ink';
+
+import type { ActiveSkillSummary } from '@shared/schemas';
+
+const MAX_SKILL_ROWS = 3;
+const NARROW_SKILLS_COLUMNS = 48;
+
+export function activeSkillsPanelRowCount(
+  skills: readonly ActiveSkillSummary[],
+  columns: number,
+): number {
+  if (skills.length === 0 || columns <= 0) return 0;
+  if (columns < NARROW_SKILLS_COLUMNS) return 1;
+  return Math.min(MAX_SKILL_ROWS, skills.length + 1);
+}
+
+interface ActiveSkillsPanelProps {
+  readonly columns: number;
+  readonly maxRows: number;
+  readonly skills: readonly ActiveSkillSummary[];
+}
+
+/** Compact bounded catalog for the focused stream. */
+export function ActiveSkillsPanel({
+  columns,
+  maxRows,
+  skills,
+}: ActiveSkillsPanelProps): React.JSX.Element | null {
+  if (skills.length === 0 || maxRows <= 0 || columns <= 0) return null;
+
+  if (maxRows === 1 || columns < NARROW_SKILLS_COLUMNS) {
+    return (
+      <Box width={columns} height={1} overflowY="hidden">
+        <Text bold wrap="truncate-end">
+          {`Skills (${skills.length}): ${skills.map((skill) => skill.name).join(', ')}`}
+        </Text>
+      </Box>
+    );
+  }
+
+  const visible = skills.slice(0, maxRows - 1);
+  const remaining = skills.length - visible.length;
+  return (
+    <Box
+      flexDirection="column"
+      width={columns}
+      maxHeight={maxRows}
+      overflowY="hidden"
+    >
+      <Text bold>{`Skills (${skills.length})`}</Text>
+      {visible.map((skill, index) => {
+        const suffix =
+          index === visible.length - 1 && remaining > 0
+            ? ` (+${remaining} more)`
+            : '';
+        return (
+          <Text key={`${skill.name}:${skill.source}`} wrap="truncate-end">
+            {`  ${skill.name} [${skill.source}] ${skill.description}${suffix}`}
+          </Text>
+        );
+      })}
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -14,6 +14,7 @@ import { clamp } from '@utils/core';
 
 // Local imports - conversation panes and layout
 import {
+  allocateConversationAuxiliaryRows,
   allocateConversationBottomPanelRows,
   allocateMiddleRows,
   PINNED_CHROME_ROWS,
@@ -25,6 +26,10 @@ import {
   isScopedTranscriptViewport,
   transcriptViewportKey,
 } from '../state/transcriptViewportMode';
+import {
+  ActiveSkillsPanel,
+  activeSkillsPanelRowCount,
+} from './ActiveSkillsPanel';
 import { ConversationPane } from './ConversationPane';
 import {
   QueuedFollowUpsPanel,
@@ -180,20 +185,27 @@ export function ConversationRegion({
     workflowDashboardItemCount > 0
       ? workflowDashboardItemCount
       : snapshot.sessionViews.length;
+  const desiredSkillsRows = foregroundOpen
+    ? 0
+    : activeSkillsPanelRowCount(activeSlice?.activeSkills ?? [], columns);
+  const { skillsRows, otherPanelRows } = allocateConversationAuxiliaryRows({
+    desiredSkillsRows,
+    transcriptRows,
+  });
   const minimumSessionPanelRows = workflowDashboardItemCount > 0 ? 3 : 2;
   const {
     bottomPanelRows: bottomPanelBudget,
     sessionPanelRows: subagentRows,
     todosPlanRows,
   } = allocateConversationBottomPanelRows({
-    maxRows: BOTTOM_PANEL_MAX_ROWS,
+    maxRows: BOTTOM_PANEL_MAX_ROWS - skillsRows,
     sessionCount: foregroundOpen ? 0 : sessionPanelItemCount,
     childListFocused: snapshot.childListFocused,
     minimumSessionPanelRows,
     todosPlanContentRows,
-    transcriptRows,
+    transcriptRows: otherPanelRows,
   });
-  const conversationRows = transcriptRows - bottomPanelBudget;
+  const conversationRows = transcriptRows - skillsRows - bottomPanelBudget;
   const childListHasRows = sessionPanelItemCount > 0;
   const childListVisible =
     childListHasRows && subagentRows >= minimumSessionPanelRows;
@@ -254,8 +266,13 @@ export function ConversationRegion({
           />
         ) : null}
         {renderFooterChrome()}
-        {bottomPanelBudget > 0 ? (
+        {skillsRows + bottomPanelBudget > 0 ? (
           <Box flexDirection="column" overflowY="hidden">
+            <ActiveSkillsPanel
+              columns={columns}
+              maxRows={skillsRows}
+              skills={activeSlice?.activeSkills ?? []}
+            />
             <SubagentList
               keyboardActive={snapshot.childListFocused && childListVisible}
               maxRows={subagentRows}

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -10,6 +10,7 @@ import {
 } from '@shared/approvalPolicy';
 import {
   AgentCategory,
+  type ActiveSkillSummary,
   type CompileFailure,
   type ConversationProgress,
   type MessageType,
@@ -216,6 +217,7 @@ export interface StreamSlice {
   readonly stage?: StreamStage | undefined;
   readonly entries: readonly ConversationEntry[];
   readonly queuedFollowUpMessages: readonly string[];
+  readonly activeSkills: readonly ActiveSkillSummary[];
   readonly todos: readonly TodoItem[];
   readonly plan: Plan | null;
   /** YOLO / auto-approval state is stream-scoped upstream (see
@@ -276,6 +278,7 @@ export function emptySlice(streamId: StreamTabId): StreamSlice {
     stage: undefined,
     entries: [],
     queuedFollowUpMessages: [],
+    activeSkills: [],
     todos: [],
     plan: null,
     bypass: NO_BYPASS,

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -15,6 +15,7 @@ import { appendCliApiSwitchHint } from '@cli/runtime/approval/approvalPrompts';
 import { TOOL_OUTPUT_CORNER } from '@cli/tui/ui/glyphs';
 import { redactSecrets } from '@logger/redaction';
 import {
+  ActiveSkillsSnapshotSchema,
   AgentCategory,
   CompactionActivityDataSchema,
   ErrorLogDataSchema,
@@ -807,6 +808,12 @@ export function syncStreamLog(
   if (!log) return;
 
   const allEntries = log.getRange(0);
+  const activeSkillsEntry = allEntries.findLast(
+    (entry) => entry.messageType === MESSAGE_TYPES.ACTIVE_SKILLS,
+  );
+  const parsedActiveSkills = activeSkillsEntry
+    ? ActiveSkillsSnapshotSchema.safeParse(activeSkillsEntry.data)
+    : undefined;
   const taskGroups = projectTaskGroupsIncrementally(streamId, allEntries);
   const thinkingActive = latestLogActivityIsThinking(allEntries);
   const compactingActive = latestCompactionActivityIsRunning(allEntries);
@@ -823,6 +830,12 @@ export function syncStreamLog(
   patchStream(streamId, (slice, lifecycle) => {
     const existing = new Map(slice.entries.map((e) => [e.id, e]));
     const workflowStream = slice.category === AgentCategory.Workflow;
+    let activeSkills = slice.activeSkills;
+    if (slice.category === AgentCategory.ToolUse && parsedActiveSkills) {
+      activeSkills = parsedActiveSkills.success
+        ? parsedActiveSkills.data.skills
+        : [];
+    }
     const workflowOperationalOnly =
       workflowStream && !isFullLogChildStream(slice);
     const syntheticEntries = slice.entries.filter(
@@ -964,6 +977,7 @@ export function syncStreamLog(
       slice.latestLine === latestLine &&
       slice.thinkingActive === thinkingActive &&
       slice.compactingActive === compactingActive &&
+      isDeepStrictEqual(slice.activeSkills, activeSkills) &&
       slice.taskGroups === taskGroups
     ) {
       return slice;
@@ -972,6 +986,7 @@ export function syncStreamLog(
       ...slice,
       latestLine,
       entries: nextEntries,
+      activeSkills,
       thinkingActive,
       compactingActive,
       taskGroups,

--- a/packages/extension/src/progressView/frontend/components/ActiveSkillsDetails.ts
+++ b/packages/extension/src/progressView/frontend/components/ActiveSkillsDetails.ts
@@ -1,0 +1,81 @@
+import { css, html, LitElement, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import type { ActiveSkillSummary } from '@shared/schemas';
+
+@customElement('active-skills-details')
+export class ActiveSkillsDetails extends LitElement {
+  static override styles = css`
+    :host,
+    details,
+    ul,
+    li {
+      min-width: 0;
+    }
+
+    :host {
+      display: contents;
+    }
+
+    details {
+      box-sizing: border-box;
+      max-width: 100%;
+      overflow: hidden;
+      margin: 0 0 var(--wa-space-xs);
+      padding: var(--wa-space-2xs) var(--wa-space-xs);
+      border: 1px solid var(--wa-color-neutral-border-quiet);
+      border-radius: var(--wa-border-radius-m);
+      color: var(--wa-color-text-normal);
+      font-size: var(--wa-font-size-s);
+    }
+
+    summary {
+      cursor: pointer;
+      font-weight: var(--font-weight-semibold, 600);
+    }
+
+    ul {
+      display: grid;
+      gap: var(--wa-space-2xs);
+      margin: var(--wa-space-xs) 0 0;
+      padding-inline-start: var(--wa-space-l);
+    }
+
+    li {
+      overflow-wrap: anywhere;
+    }
+
+    .source {
+      color: var(--wa-color-text-quiet);
+    }
+  `;
+
+  @property({ attribute: false })
+  skills: readonly ActiveSkillSummary[] = [];
+
+  override render(): TemplateResult | typeof nothing {
+    if (this.skills.length === 0) return nothing;
+    return html`
+      <details>
+        <summary>Skills (${this.skills.length})</summary>
+        <ul>
+          ${this.skills.map(
+            (skill) => html`
+              <li>
+                <strong>${skill.name}</strong>
+                <span class="source">(${skill.source})</span>
+                ${skill.description}
+              </li>
+            `,
+          )}
+        </ul>
+      </details>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'active-skills-details': ActiveSkillsDetails;
+  }
+}

--- a/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -14,6 +14,7 @@ import { totalRunUsage } from '../stateUtils';
 import { isToolUseState, type ToolUseStreamState } from '../store';
 
 // Side-effect imports - sibling components
+import './ActiveSkillsDetails';
 import './RequestPanels';
 import './TodoList';
 import './PlanView';
@@ -60,6 +61,10 @@ export class ToolUseStreamContent extends BaseStreamContent {
         }
 
         <div class="conversation-column conversation-prelude">
+          <active-skills-details
+            .skills=${currentState.activeSkills}
+          ></active-skills-details>
+
           <todo-list
             .todos=${currentState.todos}
             .collapseKey=${streamInfo.name}

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -2,9 +2,11 @@ import { create } from 'mutative';
 
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
+  ActiveSkillsSnapshotSchema,
   ContextStateDataSchema,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
+  isToolUseState,
   type LogMessageData,
   type ProgressViewOutboundHandlerRegistry,
   type StreamLogEntry,
@@ -40,6 +42,21 @@ function applyEntry(
   streamLogs: StreamLogs,
   streamState: StreamState,
 ): EntryResult {
+  if (entry.messageType === MESSAGE_TYPES.ACTIVE_SKILLS) {
+    if (!isToolUseState(streamState)) {
+      return { logChanged: false, stateChanged: false };
+    }
+    const snapshot = ActiveSkillsSnapshotSchema.safeParse(entry.data);
+    if (!snapshot.success) {
+      console.warn(
+        '[logSlice] Cleared malformed active-skills entry',
+        snapshot.error,
+      );
+    }
+    streamState.activeSkills = snapshot.success ? snapshot.data.skills : [];
+    return { logChanged: false, stateChanged: true };
+  }
+
   // These records are persisted for diagnostics or live CLI/TUI state, not
   // progress presentation. Drop them before invisible rows consume timeline
   // windows or fall through to the default log formatter.

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -13,7 +13,7 @@ import type { RunUsageTotals } from '@agent/core/usage/RunUsageAccumulator';
 import type { AgentErrorKind } from '@common/errors';
 import type {
   ActiveChildInfo,
-  ActiveSkillsSnapshot,
+  RawAcceptedSkill,
   AddOutputFilesPayload,
   AgentCategory,
   ConversationProgress,
@@ -143,9 +143,10 @@ interface WorkflowCallEvent extends StageStamp {
   readonly call: WorkflowCallProgress;
 }
 
-/** Exact safe skill catalog accepted for this run's initial prompt. */
-interface ActiveSkillsEvent extends StageStamp, ActiveSkillsSnapshot {
+/** Exact raw skill catalog accepted for this run's initial prompt. */
+interface ActiveSkillsEvent extends StageStamp {
   readonly type: 'skills.snapshot';
+  readonly skills: readonly RawAcceptedSkill[];
 }
 
 /** Token-usage report. */

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -13,6 +13,7 @@ import type { RunUsageTotals } from '@agent/core/usage/RunUsageAccumulator';
 import type { AgentErrorKind } from '@common/errors';
 import type {
   ActiveChildInfo,
+  ActiveSkillsSnapshot,
   AddOutputFilesPayload,
   AgentCategory,
   ConversationProgress,
@@ -140,6 +141,11 @@ interface WorkflowCallEvent extends StageStamp {
   readonly type: 'workflow.call';
   readonly logId: string;
   readonly call: WorkflowCallProgress;
+}
+
+/** Exact safe skill catalog accepted for this run's initial prompt. */
+interface ActiveSkillsEvent extends StageStamp, ActiveSkillsSnapshot {
+  readonly type: 'skills.snapshot';
 }
 
 /** Token-usage report. */
@@ -354,6 +360,7 @@ export type AgentEvent =
   | ToolStartEvent
   | ToolEndEvent
   | WorkflowCallEvent
+  | ActiveSkillsEvent
   | UsageEvent
   | StatusEvent
   | ChildActivityEvent

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -186,12 +186,16 @@ export async function buildUserVars(
       getConfig<unknown>(AGENT_SKILLS_CONFIG_KEY, AGENT_SKILLS_ENABLED_DEFAULT),
     )
       ? loadRuntimeSkillCatalog()
-      : Promise.resolve({ catalog: '', issues: [] }),
+      : Promise.resolve({ catalog: '', skills: [], issues: [] }),
   ]);
 
   for (const issue of runtimeSkills.issues) {
     const location = issue.path ? ` (${issue.path})` : '';
     logger.warn(`Skill import ${issue.severity}: ${issue.message}${location}`);
+  }
+
+  if (agentSetting.agentCategory === AgentCategory.ToolUse) {
+    logger.emit({ type: 'skills.snapshot', skills: runtimeSkills.skills });
   }
 
   // Merge all variable sources using spread operator.

--- a/src/shared/schemas/activeSkills.ts
+++ b/src/shared/schemas/activeSkills.ts
@@ -20,12 +20,15 @@ const ANSI_ESCAPE_SEQUENCE =
   // eslint-disable-next-line no-control-regex -- untrusted summaries may contain terminal escapes
   /\u001b\][\s\S]*?(?:\u0007|\u001b\\|\u009c)|[\u001b\u009b][[\]()#;?]*(?:\d{1,4}(?:[;:]\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]/g;
 const ORDINARY_URL_VALUE = /\b(?!file:)[a-z][a-z0-9+.-]*:\/\/[^\s<>{}]+/gi;
-const FILESYSTEM_SHAPED_VALUE =
-  /(?:^|[^A-Za-z0-9_./\\-])(?:file:\/\/|[A-Za-z]:[\\/]|\\\\|~(?:[A-Za-z0-9._-]+)?[\\/]|\.\.?[\\/]|\/)/i;
+const ORDINARY_SLASH_PROSE = /\binput\/output\b/gi;
 
 function containsFilesystemShapedValue(description: string): boolean {
-  const withoutOrdinaryUrls = description.replaceAll(ORDINARY_URL_VALUE, '');
-  return FILESYSTEM_SHAPED_VALUE.test(withoutOrdinaryUrls);
+  if (description.includes('\\')) return true;
+
+  const pathCandidates = description
+    .replaceAll(ORDINARY_URL_VALUE, '')
+    .replaceAll(ORDINARY_SLASH_PROSE, '');
+  return pathCandidates.includes('/');
 }
 
 /** Normalize untrusted frontmatter before it crosses the persistence boundary. */
@@ -52,11 +55,14 @@ export const ActiveSkillSummarySchema = z.strictObject({
 
 export type ActiveSkillSummary = z.infer<typeof ActiveSkillSummarySchema>;
 
-/** Canonical payload used by the live event and its persisted transcript row. */
+/** Accepted runtime metadata before the transcript boundary sanitizes it. */
+export type RawAcceptedSkill = Readonly<
+  z.input<typeof ActiveSkillSummarySchema>
+>;
+
+/** Canonical payload persisted in the transcript and projected by hosts. */
 export const ActiveSkillsSnapshotSchema = z.strictObject({
   skills: z
     .array(ActiveSkillSummarySchema)
     .max(ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS),
 });
-
-export type ActiveSkillsSnapshot = z.infer<typeof ActiveSkillsSnapshotSchema>;

--- a/src/shared/schemas/activeSkills.ts
+++ b/src/shared/schemas/activeSkills.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+
+import { collapseWhitespace } from '@utils/text/stringUtils';
+
+import { SkillNameSchema } from './skillName';
+
+const ACTIVE_SKILL_DESCRIPTION_MAX_LENGTH = 180;
+const ACTIVE_SKILL_DESCRIPTION_FALLBACK = 'Details available on activation.';
+export const ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS = 200;
+
+const ActiveSkillSourceScopeSchema = z.enum([
+  'bundled',
+  'user',
+  'project',
+  'interop',
+  'custom',
+]);
+
+const ANSI_ESCAPE_SEQUENCE =
+  // eslint-disable-next-line no-control-regex -- untrusted summaries may contain terminal escapes
+  /\u001b\][\s\S]*?(?:\u0007|\u001b\\|\u009c)|[\u001b\u009b][[\]()#;?]*(?:\d{1,4}(?:[;:]\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]/g;
+const ORDINARY_URL_VALUE = /\b(?!file:)[a-z][a-z0-9+.-]*:\/\/[^\s<>{}]+/gi;
+const FILESYSTEM_SHAPED_VALUE =
+  /(?:^|[^A-Za-z0-9_./\\-])(?:file:\/\/|[A-Za-z]:[\\/]|\\\\|~(?:[A-Za-z0-9._-]+)?[\\/]|\.\.?[\\/]|\/)/i;
+
+function containsFilesystemShapedValue(description: string): boolean {
+  const withoutOrdinaryUrls = description.replaceAll(ORDINARY_URL_VALUE, '');
+  return FILESYSTEM_SHAPED_VALUE.test(withoutOrdinaryUrls);
+}
+
+/** Normalize untrusted frontmatter before it crosses the persistence boundary. */
+function sanitizeActiveSkillDescription(description: string): string {
+  const withoutAnsi = description.replaceAll(ANSI_ESCAPE_SEQUENCE, '');
+  // eslint-disable-next-line no-control-regex -- persisted UI text excludes C0/C1 controls
+  const withoutControls = withoutAnsi.replaceAll(/[\x00-\x1f\x7f-\x9f]/g, ' ');
+  const normalized = collapseWhitespace(withoutControls).trim();
+  const safeDescription =
+    normalized && !containsFilesystemShapedValue(normalized)
+      ? normalized
+      : ACTIVE_SKILL_DESCRIPTION_FALLBACK;
+  return safeDescription.slice(0, ACTIVE_SKILL_DESCRIPTION_MAX_LENGTH);
+}
+
+export const ActiveSkillSummarySchema = z.strictObject({
+  name: SkillNameSchema,
+  description: z
+    .string()
+    .transform(sanitizeActiveSkillDescription)
+    .pipe(z.string().min(1).max(ACTIVE_SKILL_DESCRIPTION_MAX_LENGTH)),
+  source: ActiveSkillSourceScopeSchema,
+});
+
+export type ActiveSkillSummary = z.infer<typeof ActiveSkillSummarySchema>;
+
+/** Canonical payload used by the live event and its persisted transcript row. */
+export const ActiveSkillsSnapshotSchema = z.strictObject({
+  skills: z
+    .array(ActiveSkillSummarySchema)
+    .max(ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS),
+});
+
+export type ActiveSkillsSnapshot = z.infer<typeof ActiveSkillsSnapshotSchema>;

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -18,6 +18,8 @@ export * from './onboarding';
 
 // Layer 1b: Standalone schemas and shared settings
 export * from './agentSkills';
+export * from './activeSkills';
+export * from './skillName';
 export * from './codex';
 export * from './coreSettings';
 export * from './opResults';

--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -48,6 +48,7 @@ export const MESSAGE_TYPES = {
   INTERNAL: 'internal',
   CONTEXT_MANAGEMENT: 'contextManagement',
   CONTEXT_STATE: 'contextState',
+  ACTIVE_SKILLS: 'activeSkills',
   // Legacy protocol spelling retained for stored histories and consumers.
   WORKFLOW_TASK: 'workflowTask',
   DEFAULT: 'default',

--- a/src/shared/schemas/skillName.ts
+++ b/src/shared/schemas/skillName.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+import { collapseWhitespace } from '@utils/text/stringUtils';
+
+const SKILL_NAME_MAX_LENGTH = 64;
+
+/** Canonical grammar for discovered and persisted skill names. */
+export const SkillNameSchema = z
+  .string()
+  .transform((name) => collapseWhitespace(name))
+  .refine((name) => name.length > 0, 'Skill name is required')
+  .refine(
+    (name) => name.length <= SKILL_NAME_MAX_LENGTH,
+    `Skill name must be at most ${SKILL_NAME_MAX_LENGTH} characters`,
+  )
+  .refine(
+    (name) => /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(name),
+    'Skill name must contain only lowercase letters, digits, and hyphens',
+  )
+  .refine(
+    (name) => !name.includes('--'),
+    'Skill name must not contain repeated hyphens',
+  );

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { ActiveSkillSummarySchema } from './activeSkills';
 import { GoalStatusSchema } from './goal';
 import { AgentCategory, AgentCategorySchema } from './agent';
 import { RunIdentitySchema } from './runIdentity';
@@ -176,6 +177,7 @@ const ToolUseStreamStateSchema = BaseStreamStateSchema.extend({
   todos: z.array(TodoItemSchema).prefault([]),
   plan: PlanSchema.nullable().prefault(null),
   queuedFollowUps: z.array(z.string()).prefault([]),
+  activeSkills: z.array(ActiveSkillSummarySchema).prefault([]),
   bashBypass: z.boolean().optional(),
   toolEditBypass: z.boolean().optional(),
   superYoloBypass: z.boolean().optional(),

--- a/src/skills/SkillSchema.ts
+++ b/src/skills/SkillSchema.ts
@@ -1,28 +1,13 @@
 // Third-party imports
 import { z } from 'zod';
 
-// Local imports - utilities
+// Local imports - shared schemas and utilities
+import { SkillNameSchema } from '@shared/schemas';
 import { collapseWhitespace } from '@utils/text/stringUtils';
 
-const SKILL_NAME_MAX_LENGTH = 64;
-export const SKILL_DESCRIPTION_MAX_LENGTH = 1024;
+export { SkillNameSchema } from '@shared/schemas';
 
-export const SkillNameSchema = z
-  .string()
-  .transform((name) => collapseWhitespace(name))
-  .refine((name) => name.length > 0, 'Skill name is required')
-  .refine(
-    (name) => name.length <= SKILL_NAME_MAX_LENGTH,
-    `Skill name must be at most ${SKILL_NAME_MAX_LENGTH} characters`,
-  )
-  .refine(
-    (name) => /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(name),
-    'Skill name must contain only lowercase letters, digits, and hyphens',
-  )
-  .refine(
-    (name) => !name.includes('--'),
-    'Skill name must not contain repeated hyphens',
-  );
+export const SKILL_DESCRIPTION_MAX_LENGTH = 1024;
 
 const SkillDescriptionSchema = z
   .string()

--- a/src/skills/runtimeSkills.ts
+++ b/src/skills/runtimeSkills.ts
@@ -1,8 +1,6 @@
-import { redactSecrets } from '@logger/redaction';
 import {
   ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS,
-  ActiveSkillsSnapshotSchema,
-  type ActiveSkillSummary,
+  type RawAcceptedSkill,
 } from '@shared/schemas';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 
@@ -17,7 +15,7 @@ let runtimeSkillSources: readonly SkillSource[] = [];
 
 export interface RuntimeSkillCatalogResult {
   catalog: string;
-  skills: ActiveSkillSummary[];
+  skills: RawAcceptedSkill[];
   issues: SkillLoadIssue[];
 }
 
@@ -69,16 +67,13 @@ export async function loadRuntimeSkillCatalog(): Promise<RuntimeSkillCatalogResu
   // Discovery already orders by source precedence and then skill directory.
   // Bound that accepted set once here, before either prompt or event projection.
   const accepted = result.skills.slice(0, ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS);
-  const snapshot = ActiveSkillsSnapshotSchema.parse({
-    skills: accepted.map(({ skill, source }) => ({
-      name: skill.name,
-      description: redactSecrets(skill.description),
-      source: source.scope,
-    })),
-  });
   return {
     catalog: formatRuntimeSkillCatalog(accepted),
-    skills: snapshot.skills,
+    skills: accepted.map(({ skill, source }) => ({
+      name: skill.name,
+      description: skill.description,
+      source: source.scope,
+    })),
     issues: result.errors,
   };
 }

--- a/src/skills/runtimeSkills.ts
+++ b/src/skills/runtimeSkills.ts
@@ -1,3 +1,9 @@
+import { redactSecrets } from '@logger/redaction';
+import {
+  ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS,
+  ActiveSkillsSnapshotSchema,
+  type ActiveSkillSummary,
+} from '@shared/schemas';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 
 import {
@@ -11,6 +17,7 @@ let runtimeSkillSources: readonly SkillSource[] = [];
 
 export interface RuntimeSkillCatalogResult {
   catalog: string;
+  skills: ActiveSkillSummary[];
   issues: SkillLoadIssue[];
 }
 
@@ -56,11 +63,22 @@ export function formatRuntimeSkillActivation({
 
 export async function loadRuntimeSkillCatalog(): Promise<RuntimeSkillCatalogResult> {
   const sources = listRuntimeSkillSources();
-  if (sources.length === 0) return { catalog: '', issues: [] };
+  if (sources.length === 0) return { catalog: '', skills: [], issues: [] };
 
   const result = await discoverSkillSources(sources);
+  // Discovery already orders by source precedence and then skill directory.
+  // Bound that accepted set once here, before either prompt or event projection.
+  const accepted = result.skills.slice(0, ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS);
+  const snapshot = ActiveSkillsSnapshotSchema.parse({
+    skills: accepted.map(({ skill, source }) => ({
+      name: skill.name,
+      description: redactSecrets(skill.description),
+      source: source.scope,
+    })),
+  });
   return {
-    catalog: formatRuntimeSkillCatalog(result.skills),
+    catalog: formatRuntimeSkillCatalog(accepted),
+    skills: snapshot.skills,
     issues: result.errors,
   };
 }

--- a/src/test-kernel/agent/utils/userVars.vitest.ts
+++ b/src/test-kernel/agent/utils/userVars.vitest.ts
@@ -24,6 +24,8 @@ import {
 import { setRuntimeSkillSources } from '@skills/runtimeSkills';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { spiedTrace } from '@test/support/spiedTrace';
+import { writeSkill } from '@test/support/skillFixtures';
+import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 import {
   createFakePlatform,
   FakeConfigProvider,
@@ -96,6 +98,7 @@ describe('getToolFlags', () => {
 
 describe('buildUserVars runtime skill diagnostics', () => {
   const missingSource = '/missing/runtime-skill-source';
+  const tempRoots: string[] = [];
 
   beforeEach(() => {
     fakeConfig.set('texra.skills.enabled', true);
@@ -112,6 +115,7 @@ describe('buildUserVars runtime skill diagnostics', () => {
   afterEach(async () => {
     setRuntimeSkillSources([]);
     await fakeConfig.update('texra.skills.enabled', undefined);
+    await cleanupTempDirs(tempRoots);
   });
 
   it('emits catalog load issues and the exact accepted snapshot through the agent trace', async () => {
@@ -135,6 +139,42 @@ describe('buildUserVars runtime skill diagnostics', () => {
       type: 'skills.snapshot',
       skills: [],
     });
+  });
+
+  it('emits the raw accepted catalog without changing prompt membership', async () => {
+    const root = await makeTempDir('texra-user-vars-skills-', tempRoots);
+    const rawDescription =
+      'Use \u001b[31mcare\u001b[0m with clients/acme/private key.';
+    await writeSkill(
+      root,
+      'client-review',
+      { name: 'client-review', description: rawDescription },
+      'Apply the skill.',
+    );
+    setRuntimeSkillSources([{ scope: 'project', path: root }]);
+    const emit = vi.fn();
+
+    const vars = await buildUserVars(
+      baseConfig,
+      { ...baseSetting, agentCategory: AgentCategory.ToolUse },
+      basePrompt,
+      '/agents/generic',
+      { isOpenai: false, isAnthropic: false, isGoogle: false },
+      spiedTrace({ emit }),
+      { workspacePath: '/workspace' },
+    );
+
+    expect(emit).toHaveBeenCalledExactlyOnceWith({
+      type: 'skills.snapshot',
+      skills: [
+        {
+          name: 'client-review',
+          description: rawDescription,
+          source: 'project',
+        },
+      ],
+    });
+    expect(vars.AVAILABLE_SKILLS).toContain('- client-review:');
   });
 
   it('does not publish a parent catalog for workflow runs', async () => {

--- a/src/test-kernel/agent/utils/userVars.vitest.ts
+++ b/src/test-kernel/agent/utils/userVars.vitest.ts
@@ -114,15 +114,16 @@ describe('buildUserVars runtime skill diagnostics', () => {
     await fakeConfig.update('texra.skills.enabled', undefined);
   });
 
-  it('emits catalog load issues through the agent trace', async () => {
+  it('emits catalog load issues and the exact accepted snapshot through the agent trace', async () => {
     const warn = vi.fn();
+    const emit = vi.fn();
     const vars = await buildUserVars(
       baseConfig,
       { ...baseSetting, agentCategory: AgentCategory.ToolUse },
       basePrompt,
       '/agents/generic',
       { isOpenai: false, isAnthropic: false, isGoogle: false },
-      spiedTrace({ warn }),
+      spiedTrace({ warn, emit }),
       { workspacePath: '/workspace' },
     );
 
@@ -130,6 +131,25 @@ describe('buildUserVars runtime skill diagnostics', () => {
     expect(warn).toHaveBeenCalledExactlyOnceWith(
       `Skill import error: Skill source does not exist (${missingSource})`,
     );
+    expect(emit).toHaveBeenCalledExactlyOnceWith({
+      type: 'skills.snapshot',
+      skills: [],
+    });
+  });
+
+  it('does not publish a parent catalog for workflow runs', async () => {
+    const emit = vi.fn();
+    await buildUserVars(
+      baseConfig,
+      baseSetting,
+      basePrompt,
+      '/agents/generic',
+      { isOpenai: false, isAnthropic: false, isGoogle: false },
+      spiedTrace({ emit }),
+      { workspacePath: '/workspace' },
+    );
+
+    expect(emit).not.toHaveBeenCalled();
   });
 });
 

--- a/src/test-kernel/cli/ActiveSkillsPanel.vitest.ts
+++ b/src/test-kernel/cli/ActiveSkillsPanel.vitest.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ActiveSkillsPanel,
+  activeSkillsPanelRowCount,
+} from '@cli/chat/tui/panes/ActiveSkillsPanel';
+import { textDisplayWidth } from '@cli/chat/tui/render/terminalText';
+import {
+  ActiveSkillSummarySchema,
+  type ActiveSkillSummary,
+} from '@shared/schemas';
+import { loadInk } from '@test/support/inkTestHarness.ts';
+
+const SKILLS: ActiveSkillSummary[] = [
+  {
+    name: 'proof-audit',
+    description: 'Check proof steps and assumptions.',
+    source: 'project',
+  },
+  {
+    name: 'literature-search',
+    description: 'Find and compare relevant references.',
+    source: 'bundled',
+  },
+  {
+    name: 'writing-review',
+    description: 'Review structure and clarity.',
+    source: 'user',
+  },
+  {
+    name: 'extra-skill',
+    description: 'This item is beyond the row cap.',
+    source: 'custom',
+  },
+];
+
+describe('ActiveSkillsPanel', () => {
+  it('stays one line in a narrow terminal', async () => {
+    const { ink, React } = await loadInk();
+    const output = ink.renderToString(
+      React.createElement(ActiveSkillsPanel, {
+        columns: 24,
+        maxRows: activeSkillsPanelRowCount(SKILLS, 24),
+        skills: SKILLS,
+      }),
+      { columns: 24 },
+    );
+
+    expect(output.split('\n')).toHaveLength(1);
+    expect(output).toContain('Skills (4):');
+    expect(textDisplayWidth(output)).toBeLessThanOrEqual(24);
+  });
+
+  it('renders only schema-sanitized text from adversarial summaries', async () => {
+    const { ink, React } = await loadInk();
+    const skill = ActiveSkillSummarySchema.parse({
+      name: 'safe-terminal',
+      description:
+        '\u001b[31mInspect\u001b[0m C:\\Users\\Jane Doe\\private notes.txt before ./release/key.pem.',
+      source: 'project',
+    });
+    const output = ink.renderToString(
+      React.createElement(ActiveSkillsPanel, {
+        columns: 80,
+        maxRows: 2,
+        skills: [skill],
+      }),
+      { columns: 80 },
+    );
+
+    expect(output).toContain('Details available on activation.');
+    expect(output).not.toContain('Users');
+    expect(output).not.toContain('private');
+    expect(output).not.toContain('release');
+    expect(output).not.toContain('\u001b');
+  });
+
+  it('caps normal layouts and hides empty catalogs', async () => {
+    const { ink, React } = await loadInk();
+    const output = ink.renderToString(
+      React.createElement(ActiveSkillsPanel, {
+        columns: 80,
+        maxRows: activeSkillsPanelRowCount(SKILLS, 80),
+        skills: SKILLS,
+      }),
+      { columns: 80 },
+    );
+
+    expect(output.split('\n').length).toBeLessThanOrEqual(3);
+    expect(output).toContain('(+2 more)');
+    expect(activeSkillsPanelRowCount([], 80)).toBe(0);
+    expect(
+      ActiveSkillsPanel({ columns: 80, maxRows: 0, skills: SKILLS }),
+    ).toBeNull();
+  });
+});

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -26,6 +26,7 @@ import {
   transientNotice,
 } from '@cli/chat/tui/state/cliState';
 import {
+  allocateConversationAuxiliaryRows,
   allocateConversationBottomPanelRows,
   allocateMiddleRows,
   allocateSidePanelRows,
@@ -824,6 +825,41 @@ describe('CLI TUI row allocation', () => {
     ).toEqual({ subagentRows: 0, todosPlanRows: 1 });
   });
 
+  it('reserves a conversation row before skills, todos, and focused children', () => {
+    for (const transcriptRows of [1, 2, 3]) {
+      const auxiliary = allocateConversationAuxiliaryRows({
+        desiredSkillsRows: 3,
+        transcriptRows,
+      });
+      const bottom = allocateConversationBottomPanelRows({
+        maxRows: 10 - auxiliary.skillsRows,
+        sessionCount: 4,
+        childListFocused: true,
+        todosPlanContentRows: 2,
+        transcriptRows: auxiliary.otherPanelRows,
+      });
+      expect(
+        transcriptRows - auxiliary.skillsRows - bottom.bottomPanelRows,
+      ).toBe(1);
+    }
+
+    const auxiliary = allocateConversationAuxiliaryRows({
+      desiredSkillsRows: 3,
+      transcriptRows: 8,
+    });
+    const bottom = allocateConversationBottomPanelRows({
+      maxRows: 10 - auxiliary.skillsRows,
+      sessionCount: 4,
+      childListFocused: true,
+      todosPlanContentRows: 2,
+      transcriptRows: auxiliary.otherPanelRows,
+    });
+    expect(auxiliary.skillsRows).toBe(3);
+    expect(bottom.sessionPanelRows).toBeGreaterThanOrEqual(2);
+    expect(bottom.todosPlanRows).toBeGreaterThanOrEqual(2);
+    expect(8 - auxiliary.skillsRows - bottom.bottomPanelRows).toBe(1);
+  });
+
   it('hides the child list when its gap and content cannot both fit', () => {
     expect(
       allocateConversationBottomPanelRows({
@@ -1595,6 +1631,58 @@ describe('CLI transcript state', () => {
   // it in place here so store-backed tests need no reset of their own.
   beforeEach(async () => {
     await defaultSession().transcripts.clear();
+  });
+
+  it('restores the latest active skills per stream and clears malformed snapshots', () => {
+    patchStream(root, (slice) => ({
+      ...slice,
+      category: AgentCategory.ToolUse,
+    }));
+    patchStream(child1, (slice) => ({
+      ...slice,
+      category: AgentCategory.ToolUse,
+    }));
+    const logger = runTrace(root);
+    logger.emit({
+      type: 'skills.snapshot',
+      skills: [
+        {
+          name: 'proof-audit',
+          description: 'Check proof steps.',
+          source: 'project',
+        },
+      ],
+    });
+
+    syncStreamLog(root);
+    syncStreamLog(child1);
+    expect(streams.get().get(root)?.activeSkills).toMatchObject([
+      { name: 'proof-audit', source: 'project' },
+    ]);
+    expect(streams.get().get(child1)?.activeSkills).toEqual([]);
+
+    resetCliState();
+    patchStream(root, (slice) => ({
+      ...slice,
+      category: AgentCategory.ToolUse,
+    }));
+    syncStreamLog(root);
+    expect(streams.get().get(root)?.activeSkills).toMatchObject([
+      { name: 'proof-audit' },
+    ]);
+
+    defaultSession()
+      .transcripts.get(root)
+      ?.appendSettled({
+        id: 'malformed-skills',
+        type: 'log',
+        level: 'info',
+        timestamp: 2,
+        messageType: MESSAGE_TYPES.ACTIVE_SKILLS,
+        data: { skills: [{ path: '/secret' }] },
+      });
+    syncStreamLog(root);
+    expect(streams.get().get(root)?.activeSkills).toEqual([]);
   });
 
   it('renders orchestrator follow-ups without protocol tags', () => {

--- a/src/test-kernel/progressView/ActiveSkillsDetails.vitest.ts
+++ b/src/test-kernel/progressView/ActiveSkillsDetails.vitest.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ActiveSkillsDetails as ActiveSkillsDetailsElement } from '@progressView/frontend/components/ActiveSkillsDetails';
+import { ActiveSkillSummarySchema } from '@shared/schemas';
+
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+interface StyledConstructor extends CustomElementConstructor {
+  readonly elementStyles: readonly (
+    CSSStyleSheet | { readonly cssText: string }
+  )[];
+}
+
+function createElement(): ActiveSkillsDetailsElement {
+  return document.createElement(
+    'active-skills-details',
+  ) as ActiveSkillsDetailsElement;
+}
+
+describe('active-skills-details', () => {
+  useLitComponentTestDom(async () => {
+    await import('@progressView/frontend/components/ActiveSkillsDetails');
+  });
+
+  it('hides empty catalogs and renders a native collapsed details block', async () => {
+    const element = createElement();
+    document.body.append(element);
+    await element.updateComplete;
+    expect(element.shadowRoot?.querySelector('details')).toBeNull();
+
+    element.skills = [
+      ActiveSkillSummarySchema.parse({
+        name: 'proof-audit',
+        description: 'Review proofs.',
+        source: 'project',
+      }),
+    ];
+    await element.updateComplete;
+
+    const details = element.shadowRoot?.querySelector('details');
+    expect(details).toBeInstanceOf(HTMLElement);
+    expect(details?.hasAttribute('open')).toBe(false);
+    expect(details?.querySelector('summary')?.textContent).toContain(
+      'Skills (1)',
+    );
+  });
+
+  it('wraps a maximum-length unbroken description within narrow containers', async () => {
+    const description = 'x'.repeat(300);
+    const skill = ActiveSkillSummarySchema.parse({
+      name: 'long-description',
+      description,
+      source: 'custom',
+    });
+    const element = createElement();
+    element.skills = [skill];
+    document.body.append(element);
+    await element.updateComplete;
+
+    const item = element.shadowRoot?.querySelector('li');
+    expect(skill.description).toHaveLength(180);
+    expect(item?.textContent).toContain(skill.description);
+
+    const constructor = element.constructor as StyledConstructor;
+    const styleText = constructor.elementStyles
+      .map((style) => {
+        if ('cssText' in style) return style.cssText;
+        return [...style.cssRules].map((rule) => rule.cssText).join('\n');
+      })
+      .join('\n');
+    expect(styleText).toMatch(/min-width:\s*0/);
+    expect(styleText).toMatch(/overflow-wrap:\s*anywhere/);
+  });
+});

--- a/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
+++ b/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
@@ -291,3 +291,118 @@ describe('LOG_DELTA GROUP_END task-group status (#7993 step 3)', () => {
     expect(extensionTaskGroups?.[0]?.index).toBeUndefined();
   });
 });
+
+describe('LOG_DELTA active skill snapshots', () => {
+  beforeEach(() => {
+    resetProgressState();
+  });
+
+  function activeSkillsEntry(seqNo: number, data: unknown): StreamLogEntry {
+    return {
+      seqNo,
+      settlementSeqNo: seqNo,
+      id: `skills-${seqNo}`,
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: seqNo,
+      messageType: MESSAGE_TYPES.ACTIVE_SKILLS,
+      data,
+    };
+  }
+
+  it('replays the latest stream-scoped snapshot and hides its metadata rows', () => {
+    const state = createInitialState();
+    state.streamStates.set(STREAM_ID, createStreamState(AgentCategory.ToolUse));
+    appState.set(state);
+
+    dispatchLogDelta([
+      activeSkillsEntry(1, {
+        skills: [
+          {
+            name: 'first',
+            description: 'First skill.',
+            source: 'bundled',
+          },
+        ],
+      }),
+      activeSkillsEntry(2, { skills: [] }),
+    ]);
+
+    const current = appState.get();
+    expect(current.streamStates.get(STREAM_ID)).toMatchObject({
+      activeSkills: [],
+    });
+    expect(current.streamLogs.get(STREAM_ID)?.logs).toEqual([]);
+  });
+
+  it('sanitizes adversarial persisted summaries during replay', () => {
+    const state = createInitialState();
+    state.streamStates.set(STREAM_ID, createStreamState(AgentCategory.ToolUse));
+    appState.set(state);
+
+    dispatchLogDelta([
+      activeSkillsEntry(1, {
+        skills: [
+          {
+            name: 'safe-replay',
+            description:
+              '\u001b[31mReview\u001b[0m /Users/Jane Doe/private notes.txt before ../release/key.pem.',
+            source: 'project',
+          },
+        ],
+      }),
+    ]);
+
+    expect(appState.get().streamStates.get(STREAM_ID)).toMatchObject({
+      activeSkills: [
+        {
+          name: 'safe-replay',
+          description: 'Details available on activation.',
+          source: 'project',
+        },
+      ],
+    });
+  });
+
+  it('clears malformed latest data and never projects it onto workflow streams', () => {
+    const toolState = createInitialState();
+    toolState.streamStates.set(
+      STREAM_ID,
+      createStreamState(AgentCategory.ToolUse, {
+        activeSkills: [
+          {
+            name: 'stale',
+            description: 'Stale skill.',
+            source: 'user',
+          },
+        ],
+      }),
+    );
+    appState.set(toolState);
+    dispatchLogDelta([activeSkillsEntry(1, { skills: [{ path: '/secret' }] })]);
+    expect(appState.get().streamStates.get(STREAM_ID)).toMatchObject({
+      activeSkills: [],
+    });
+
+    const workflowState = createInitialState();
+    workflowState.streamStates.set(
+      STREAM_ID,
+      createStreamState(AgentCategory.Workflow),
+    );
+    appState.set(workflowState);
+    dispatchLogDelta([
+      activeSkillsEntry(2, {
+        skills: [
+          {
+            name: 'parent-only',
+            description: 'Must not inherit.',
+            source: 'project',
+          },
+        ],
+      }),
+    ]);
+    expect(appState.get().streamStates.get(STREAM_ID)).not.toHaveProperty(
+      'activeSkills',
+    );
+  });
+});

--- a/src/test-kernel/shared/ActiveSkillsSchema.vitest.ts
+++ b/src/test-kernel/shared/ActiveSkillsSchema.vitest.ts
@@ -54,6 +54,24 @@ describe('active skill safe summaries', () => {
       'parent relative',
       '..\\Jane Doe\\Top Secret Draft\\final-private-notes.tex',
     ],
+    ['POSIX neutral names', 'clients/acme'],
+    ['POSIX extensionless two-component', 'private/key'],
+    ['POSIX hyphenated names', 'client-name/private-key'],
+    ['POSIX whitespace path', 'Client Name/private key'],
+    ['Windows neutral names', 'clients\\acme'],
+    ['Windows extensionless two-component', 'private\\key'],
+    ['Windows hyphenated names', 'client-name\\private-key'],
+    ['Windows whitespace path', 'Client Name\\private key'],
+    ['POSIX relative', 'secrets/client-name/key.pem'],
+    ['POSIX relative with spaces', 'secrets/Client Name/private key.pem'],
+    ['POSIX dotted directory', 'config.d/key.pem'],
+    ['POSIX hidden filename', 'secrets/.env'],
+    ['POSIX extensionless filename', 'secrets/credentials'],
+    ['Windows relative', 'secrets\\client-name\\key.pem'],
+    ['Windows relative with spaces', 'secrets\\Client Name\\private key.pem'],
+    ['Windows dotted directory', 'config.d\\key.pem'],
+    ['Windows hidden filename', 'secrets\\.env'],
+    ['Windows extensionless filename', 'secrets\\credentials'],
     [
       'file URI',
       'file:///Users/Jane Doe/Top Secret Draft/final-private-notes.tex',
@@ -80,20 +98,18 @@ describe('active skill safe summaries', () => {
     }
   });
 
-  it('fails closed when otherwise useful prose contains a path', () => {
-    expect(
-      parseDescription(
-        'Review the proof using /Users/Jane Doe/Top Secret Draft/final-private-notes.tex before publication.',
-      ),
-    ).toBe(DESCRIPTION_FALLBACK);
-    expect(
-      parseDescription(
-        'Compare against C:\\Users\\Jane Doe\\Top Secret Draft\\final-private-notes.tex before publication.',
-      ),
-    ).toBe(DESCRIPTION_FALLBACK);
+  it.each([
+    'Review the proof using /Users/Jane Doe/Top Secret Draft/final-private-notes.tex before publication.',
+    'Compare against C:\\Users\\Jane Doe\\Top Secret Draft\\final-private-notes.tex before publication.',
+    'Review clients/acme before publication.',
+    'Review clients\\acme before publication.',
+    'Load Client Name/private key before publication.',
+    'Load Client Name\\private key before publication.',
+  ])('fails closed when otherwise useful prose contains a path: %s', (text) => {
+    expect(parseDescription(text)).toBe(DESCRIPTION_FALLBACK);
   });
 
-  it('preserves ordinary URL schemes while stripping controls', () => {
+  it('preserves ordinary prose and URL schemes while stripping controls', () => {
     expect(
       parseDescription(
         'Read \u001b[31mhttps://example.com/docs/file.html\u001b[0m and custom+https://example.org/reference.',
@@ -101,6 +117,39 @@ describe('active skill safe summaries', () => {
     ).toBe(
       'Read https://example.com/docs/file.html and custom+https://example.org/reference.',
     );
+    expect(parseDescription('Compare input/output formatting choices.')).toBe(
+      'Compare input/output formatting choices.',
+    );
+    expect(parseDescription('Compare inputs/outputs formatting choices.')).toBe(
+      DESCRIPTION_FALLBACK,
+    );
+    expect(parseDescription('Compare input\\output formatting choices.')).toBe(
+      DESCRIPTION_FALLBACK,
+    );
+    expect(
+      parseDescription(
+        'Read https://example.com/config.d/key.pem, https://example.org/secrets/.env, and custom+https://example.net/secrets/credentials.',
+      ),
+    ).toBe(
+      'Read https://example.com/config.d/key.pem, https://example.org/secrets/.env, and custom+https://example.net/secrets/credentials.',
+    );
+    expect(
+      parseDescription(
+        'Search https://example.com/find?q=proof%20audit&sort=name#result:top, then continue.',
+      ),
+    ).toBe(
+      'Search https://example.com/find?q=proof%20audit&sort=name#result:top, then continue.',
+    );
+    expect(parseDescription('Visit https://example.com for details.')).toBe(
+      'Visit https://example.com for details.',
+    );
+  });
+
+  it.each([
+    'Read https://example.com\\C:\\Users\\Jane\\secret.tex before continuing.',
+    'Read https://example.com/docs?source=C:\\Users\\Jane\\secret.tex.',
+  ])('rejects a URL followed by or containing a Windows path: %s', (text) => {
+    expect(parseDescription(text)).toBe(DESCRIPTION_FALLBACK);
   });
 
   it('uses the same fallback when sanitization removes all content', () => {

--- a/src/test-kernel/shared/ActiveSkillsSchema.vitest.ts
+++ b/src/test-kernel/shared/ActiveSkillsSchema.vitest.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ActiveSkillSummarySchema,
+  ActiveSkillsSnapshotSchema,
+} from '@shared/schemas';
+
+const DESCRIPTION_FALLBACK = 'Details available on activation.';
+
+function parseDescription(description: string): string {
+  return ActiveSkillSummarySchema.parse({
+    name: 'proof-audit',
+    description,
+    source: 'project',
+  }).description;
+}
+
+describe('active skill safe summaries', () => {
+  it('uses the canonical skill-name grammar', () => {
+    expect(parseDescription('Review proofs.')).toBe('Review proofs.');
+
+    for (const name of [
+      'Proof Audit',
+      'proof_audit',
+      'proof--audit',
+      '-proof-audit',
+      'proof-audit-',
+      '\u001b[31mproof-audit\u001b[0m',
+    ]) {
+      expect(
+        ActiveSkillSummarySchema.safeParse({
+          name,
+          description: 'Review proofs.',
+          source: 'project',
+        }).success,
+      ).toBe(false);
+    }
+  });
+
+  it.each([
+    ['POSIX', '/Users/Jane Doe/Top Secret Draft/final-private-notes.tex'],
+    [
+      'Windows drive',
+      'C:\\Users\\Jane Doe\\Top Secret Draft\\final-private-notes.tex',
+    ],
+    [
+      'UNC',
+      '\\\\research-server\\Jane Doe\\Top Secret Draft\\final-private-notes.tex',
+    ],
+    ['home', '~/Jane Doe/Top Secret Draft/final-private-notes.tex'],
+    ['named home', '~janedoe/Top Secret Draft/final-private-notes.tex'],
+    ['dot relative', './Jane Doe/Top Secret Draft/final-private-notes.tex'],
+    [
+      'parent relative',
+      '..\\Jane Doe\\Top Secret Draft\\final-private-notes.tex',
+    ],
+    [
+      'file URI',
+      'file:///Users/Jane Doe/Top Secret Draft/final-private-notes.tex',
+    ],
+    [
+      'colon adjacent',
+      'Path:/Users/Jane Doe/Top Secret Draft/final-private-notes.tex',
+    ],
+  ])('fails closed for %s paths', (_label, path) => {
+    const description = parseDescription(path);
+
+    expect(description).toBe(DESCRIPTION_FALLBACK);
+    for (const leakedPart of [
+      'Jane',
+      'Top',
+      'Secret',
+      'Draft',
+      'final',
+      'private',
+      'notes',
+      '.tex',
+    ]) {
+      expect(description).not.toContain(leakedPart);
+    }
+  });
+
+  it('fails closed when otherwise useful prose contains a path', () => {
+    expect(
+      parseDescription(
+        'Review the proof using /Users/Jane Doe/Top Secret Draft/final-private-notes.tex before publication.',
+      ),
+    ).toBe(DESCRIPTION_FALLBACK);
+    expect(
+      parseDescription(
+        'Compare against C:\\Users\\Jane Doe\\Top Secret Draft\\final-private-notes.tex before publication.',
+      ),
+    ).toBe(DESCRIPTION_FALLBACK);
+  });
+
+  it('preserves ordinary URL schemes while stripping controls', () => {
+    expect(
+      parseDescription(
+        'Read \u001b[31mhttps://example.com/docs/file.html\u001b[0m and custom+https://example.org/reference.',
+      ),
+    ).toBe(
+      'Read https://example.com/docs/file.html and custom+https://example.org/reference.',
+    );
+  });
+
+  it('uses the same fallback when sanitization removes all content', () => {
+    for (const description of [
+      '\u001b[31m\u001b[0m',
+      '\u0001\u0002\u007f\u009b',
+    ]) {
+      expect(parseDescription(description)).toBe(DESCRIPTION_FALLBACK);
+    }
+  });
+
+  it('caps safe descriptions after sanitization', () => {
+    const parsed = ActiveSkillsSnapshotSchema.parse({
+      skills: [
+        {
+          name: 'long-description',
+          description: `\u001b[31m${'a'.repeat(240)}\u001b[0m`,
+          source: 'custom',
+        },
+      ],
+    });
+
+    expect(parsed.skills[0]?.description).toBe('a'.repeat(180));
+  });
+});

--- a/src/test-kernel/skills/RuntimeSkills.vitest.ts
+++ b/src/test-kernel/skills/RuntimeSkills.vitest.ts
@@ -4,7 +4,12 @@ import * as path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { TraceEmitter } from '@agent/trace';
 import { buildInitialToolUsePrompts } from '@agent/prompt/PromptBuilder';
+import {
+  ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS,
+  MESSAGE_TYPES,
+} from '@shared/schemas';
 import {
   formatRuntimeSkillActivation,
   loadRuntimeSkillCatalog,
@@ -13,6 +18,8 @@ import {
 import { setupPlatform } from '@test/support/setupPlatform';
 import { writeSkill } from '@test/support/skillFixtures';
 import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+import { attachTranscriptRecorder } from '@transcript/TexraTranscriptRecorder';
+import { StreamLogStore } from '@transcript/StreamLogStore';
 
 const tempRoots: string[] = [];
 
@@ -77,7 +84,119 @@ describe('runtime skills', () => {
     );
     expect(result.catalog).toContain('Source: project');
     expect(result.catalog).toContain(`Path: ${skillPath}`);
+    expect(result.skills).toStrictEqual([
+      {
+        name: 'manuscript-review',
+        description: 'Review mathematical manuscripts.',
+        source: 'project',
+      },
+    ]);
     expect(result.issues).toEqual([]);
+  });
+
+  it('sanitizes the accepted summary before prompt-boundary emission', async () => {
+    const root = await createTempRoot();
+    await writeSkill(
+      root,
+      'safe-summary',
+      {
+        name: 'safe-summary',
+        description:
+          'Use \u001b[31mcare\u001b[0m with C:\\Users\\Jane Doe\\secret.tex and ./private/key.pem.',
+      },
+      'Apply the skill.',
+    );
+    setRuntimeSkillSources([{ scope: 'project', path: root }]);
+
+    const result = await loadRuntimeSkillCatalog();
+
+    expect(result.skills).toStrictEqual([
+      {
+        name: 'safe-summary',
+        description: 'Details available on activation.',
+        source: 'project',
+      },
+    ]);
+  });
+
+  it('keeps ANSI-only and controls-only skills with safe fallback summaries', async () => {
+    const root = await createTempRoot();
+    const descriptions = [
+      ['ansi-only', '"\\u001b[31m\\u001b[0m"'],
+      ['controls-only', '"\\u0001\\u0002\\u007f\\u009b"'],
+    ] as const;
+    for (const [name, description] of descriptions) {
+      const skillDir = path.join(root, name);
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillDir, 'SKILL.md'),
+        `---\nname: ${name}\ndescription: ${description}\n---\n\nApply the skill.\n`,
+      );
+    }
+    setRuntimeSkillSources([{ scope: 'project', path: root }]);
+
+    const result = await loadRuntimeSkillCatalog();
+
+    expect(result.skills).toStrictEqual([
+      {
+        name: 'ansi-only',
+        description: 'Details available on activation.',
+        source: 'project',
+      },
+      {
+        name: 'controls-only',
+        description: 'Details available on activation.',
+        source: 'project',
+      },
+    ]);
+    expect(
+      [...result.catalog.matchAll(/^- ([^:]+):/gm)].map((match) => match[1]),
+    ).toStrictEqual(result.skills.map((skill) => skill.name));
+  });
+
+  it('bounds the accepted set once before prompt and snapshot projection', async () => {
+    const root = await createTempRoot();
+    const discoveredCount = ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS + 2;
+    await Promise.all(
+      Array.from({ length: discoveredCount }, (_, index) => {
+        const name = `skill-${index.toString().padStart(3, '0')}`;
+        return writeSkill(
+          root,
+          name,
+          { name, description: `Description ${index}.` },
+          `Apply ${name}.`,
+        );
+      }),
+    );
+    setRuntimeSkillSources([{ scope: 'project', path: root }]);
+
+    const result = await loadRuntimeSkillCatalog();
+    const catalogNames = [...result.catalog.matchAll(/^- ([^:]+):/gm)].map(
+      (match) => match[1],
+    );
+    const snapshotNames = result.skills.map((skill) => skill.name);
+
+    expect(snapshotNames).toHaveLength(ACTIVE_SKILLS_SNAPSHOT_MAX_SKILLS);
+    expect(catalogNames).toStrictEqual(snapshotNames);
+    expect(snapshotNames.at(-1)).toBe('skill-199');
+    expect(result.catalog).not.toContain('skill-200');
+
+    const trace = new TraceEmitter();
+    const store = StreamLogStore.ephemeral('bounded-skills');
+    const streamId = 'stream:bounded-skills';
+    store.ensureStream(streamId);
+    attachTranscriptRecorder(trace, store.acquireWriter(streamId, streamId));
+
+    expect(() =>
+      trace.emit({ type: 'skills.snapshot', skills: result.skills }),
+    ).not.toThrow();
+    expect(
+      store
+        .get(streamId)
+        ?.getRange(0)
+        .find((entry) => entry.messageType === MESSAGE_TYPES.ACTIVE_SKILLS)
+        ?.data,
+    ).toStrictEqual({ skills: result.skills });
   });
 
   it('returns structured issues when a required source is unavailable', async () => {
@@ -91,6 +210,7 @@ describe('runtime skills', () => {
 
     expect(result).toEqual({
       catalog: '',
+      skills: [],
       issues: [
         {
           severity: 'error',

--- a/src/test-kernel/skills/RuntimeSkills.vitest.ts
+++ b/src/test-kernel/skills/RuntimeSkills.vitest.ts
@@ -94,7 +94,7 @@ describe('runtime skills', () => {
     expect(result.issues).toEqual([]);
   });
 
-  it('sanitizes the accepted summary before prompt-boundary emission', async () => {
+  it('preserves raw descriptions in the accepted runtime projection', async () => {
     const root = await createTempRoot();
     await writeSkill(
       root,
@@ -113,13 +113,14 @@ describe('runtime skills', () => {
     expect(result.skills).toStrictEqual([
       {
         name: 'safe-summary',
-        description: 'Details available on activation.',
+        description:
+          'Use \u001b[31mcare\u001b[0m with C:\\Users\\Jane Doe\\secret.tex and ./private/key.pem.',
         source: 'project',
       },
     ]);
   });
 
-  it('keeps ANSI-only and controls-only skills with safe fallback summaries', async () => {
+  it('keeps ANSI-only and controls-only skills in the raw accepted projection', async () => {
     const root = await createTempRoot();
     const descriptions = [
       ['ansi-only', '"\\u001b[31m\\u001b[0m"'],
@@ -140,12 +141,12 @@ describe('runtime skills', () => {
     expect(result.skills).toStrictEqual([
       {
         name: 'ansi-only',
-        description: 'Details available on activation.',
+        description: '\u001b[31m\u001b[0m',
         source: 'project',
       },
       {
         name: 'controls-only',
-        description: 'Details available on activation.',
+        description: '\u0001\u0002\u007f\u009b',
         source: 'project',
       },
     ]);

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { TraceEmitter } from '@agent/trace';
 import {
@@ -11,6 +11,11 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
+import { setupPlatform } from '@test/support/setupPlatform';
+import {
+  cleanupTempDirs,
+  createTempDirPlatform,
+} from '@test/support/tempDirPlatform';
 import { attachTranscriptRecorder } from '@transcript/TexraTranscriptRecorder';
 import { StreamLogStore } from '@transcript/StreamLogStore';
 import { isObject } from '@utils/core';
@@ -587,6 +592,13 @@ describe('attachTranscriptRecorder timer failure boundary', () => {
 });
 
 describe('attachTranscriptRecorder active skills', () => {
+  const tempDirs: string[] = [];
+  setupPlatform(() => createTempDirPlatform('texra-recorder-', tempDirs));
+
+  afterEach(async () => {
+    await cleanupTempDirs(tempDirs);
+  });
+
   it('persists only sanitized summaries and lets the latest empty snapshot clear state', () => {
     const { trace, rows } = attachRecorder();
 
@@ -620,6 +632,48 @@ describe('attachTranscriptRecorder active skills', () => {
     expect(JSON.stringify(records[0]?.data)).not.toContain('baseDir');
     expect(JSON.stringify(records[0]?.data)).not.toContain('instructions');
     expect(records.at(-1)?.data).toStrictEqual({ skills: [] });
+  });
+
+  it('redacts summaries before truncating the disk projection', async () => {
+    const trace = new TraceEmitter();
+    const streamId = 'stream:skill-redaction' as StreamTabId;
+    const store = await StreamLogStore.open();
+    store.ensureStream(streamId);
+    const writer = store.acquireWriter(streamId, streamId);
+    const recorder = attachTranscriptRecorder(trace, writer);
+    const descriptionPrefix = `${'Review credentials carefully. '.padEnd(168, 'a')} `;
+    const providerKey = 'sk-proj-redaction-example-1234567890abcdef';
+
+    trace.emit({
+      type: 'skills.snapshot',
+      skills: [
+        {
+          name: 'credential-check',
+          description: `${descriptionPrefix}${providerKey}`,
+          source: 'project',
+        },
+      ],
+    });
+    recorder.unsubscribe();
+    writer.close();
+    await store.flush();
+
+    const reopened = await StreamLogStore.openReadOnly();
+    await reopened.ensureLoaded(streamId);
+    const persisted = reopened
+      .get(streamId)
+      ?.getRange(0)
+      .find((entry) => entry.messageType === MESSAGE_TYPES.ACTIVE_SKILLS)?.data;
+    expect(persisted).toStrictEqual({
+      skills: [
+        {
+          name: 'credential-check',
+          description: `${descriptionPrefix}[redacted]`,
+          source: 'project',
+        },
+      ],
+    });
+    expect(JSON.stringify(persisted)).not.toContain('sk-proj-red');
   });
 
   it('records fallback summaries for ANSI-only and controls-only descriptions', () => {

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -585,3 +585,78 @@ describe('attachTranscriptRecorder timer failure boundary', () => {
     }
   });
 });
+
+describe('attachTranscriptRecorder active skills', () => {
+  it('persists only sanitized summaries and lets the latest empty snapshot clear state', () => {
+    const { trace, rows } = attachRecorder();
+
+    trace.emit({
+      type: 'skills.snapshot',
+      skills: [
+        {
+          name: 'proof-audit',
+          description:
+            'Review   proofs from /Users/researcher/private/checklist.md with API_KEY=secret-value.',
+          source: 'project',
+        },
+      ],
+    });
+    trace.emit({ type: 'skills.snapshot', skills: [] });
+
+    const records = rows().filter(
+      (entry) => entry.messageType === MESSAGE_TYPES.ACTIVE_SKILLS,
+    );
+    expect(records).toHaveLength(2);
+    expect(records[0]?.data).toStrictEqual({
+      skills: [
+        {
+          name: 'proof-audit',
+          description: 'Details available on activation.',
+          source: 'project',
+        },
+      ],
+    });
+    expect(JSON.stringify(records[0]?.data)).not.toContain('/Users/researcher');
+    expect(JSON.stringify(records[0]?.data)).not.toContain('baseDir');
+    expect(JSON.stringify(records[0]?.data)).not.toContain('instructions');
+    expect(records.at(-1)?.data).toStrictEqual({ skills: [] });
+  });
+
+  it('records fallback summaries for ANSI-only and controls-only descriptions', () => {
+    const { trace, rows } = attachRecorder();
+
+    trace.emit({
+      type: 'skills.snapshot',
+      skills: [
+        {
+          name: 'ansi-only',
+          description: '\u001b[31m\u001b[0m',
+          source: 'project',
+        },
+        {
+          name: 'controls-only',
+          description: '\u0001\u0002\u007f\u009b',
+          source: 'project',
+        },
+      ],
+    });
+
+    expect(
+      rows().find((entry) => entry.messageType === MESSAGE_TYPES.ACTIVE_SKILLS)
+        ?.data,
+    ).toStrictEqual({
+      skills: [
+        {
+          name: 'ansi-only',
+          description: 'Details available on activation.',
+          source: 'project',
+        },
+        {
+          name: 'controls-only',
+          description: 'Details available on activation.',
+          source: 'project',
+        },
+      ],
+    });
+  });
+});

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -36,6 +36,7 @@ import { computeUtilizationPercent } from '@agent/modelHandlers/support/contextU
 import { isDebugModeEnabled } from '@logger/logUtils';
 import { redactSecrets } from '@logger/redaction';
 import {
+  ActiveSkillsSnapshotSchema,
   MESSAGE_TYPES,
   RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
@@ -430,6 +431,26 @@ export function attachTranscriptRecorder(
             if (terminal) writer.appendSettled(taskEntry);
             else writer.append(taskEntry);
           }
+          return;
+        }
+
+        case 'skills.snapshot': {
+          const snapshot = ActiveSkillsSnapshotSchema.parse({
+            skills: event.skills.map((skill) => ({
+              ...skill,
+              description: redactSecrets(skill.description),
+            })),
+          });
+          writer.appendSettled({
+            id: generateShortId(),
+            type: STREAM_LOG_ENTRY_TYPES.LOG,
+            level: 'info',
+            timestamp: Date.now(),
+            groupId: event.stageId,
+            messageType: MESSAGE_TYPES.ACTIVE_SKILLS,
+            data: snapshot,
+            verbose: false,
+          });
           return;
         }
 

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -276,6 +276,7 @@ function conversationMessagesForEntry(entry: StreamLogEntry): unknown[] {
     case MESSAGE_TYPES.INTERNAL:
     case MESSAGE_TYPES.CONTEXT_MANAGEMENT:
     case MESSAGE_TYPES.CONTEXT_STATE:
+    case MESSAGE_TYPES.ACTIVE_SKILLS:
     case MESSAGE_TYPES.WORKFLOW_TASK:
     case MESSAGE_TYPES.DEFAULT:
       return [];


### PR DESCRIPTION
## Summary
- capture the exact precedence-resolved, bounded skill set at the prompt boundary
- persist one safe stream-scoped snapshot and replay it through extension and CLI without host rediscovery
- show compact active-skill details in the extension and a bounded narrow-safe TUI panel
- fail closed on filesystem-shaped descriptions, strip terminal controls, and keep workflows and unrelated child streams isolated

## Verification
- 220 focused security, runtime, recorder, replay, extension, and CLI tests passed in the final implementation
- full typecheck, lint, dead-code ratchet, Prettier, `compile:fast`, Electron webview smoke, and `git diff --check` passed
- deterministic 200-skill prompt/snapshot exactness is covered
- one-to-three-row TUI budgeting and 180-character extension wrapping are covered
- final simplifier and repeated independent security reviews found no remaining issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transcript persistence, multi-host replay (CLI + extension), and security-sensitive description sanitization for untrusted skill frontmatter; layout changes in the TUI conversation region add moderate integration risk.
> 
> **Overview**
> Tool-use runs now **capture and display** the precedence-resolved skill catalog that was accepted at prompt build time, without hosts re-discovering skills from disk.
> 
> At the prompt boundary, **`loadRuntimeSkillCatalog`** bounds the accepted set (max 200) and **`buildUserVars`** emits a **`skills.snapshot`** trace event for tool-use agents only. The transcript recorder persists **`activeSkills`** log rows with **sanitized** summaries (path-shaped text, ANSI, and controls fail closed to a generic fallback; secrets redacted). Extension and CLI **replay the latest snapshot** per stream from the transcript; workflow streams and unrelated child streams stay isolated.
> 
> **Extension:** collapsible **active-skills-details** above todos/plan in tool-use stream content.
> 
> **CLI TUI:** **`ActiveSkillsPanel`** in the conversation footer with **`allocateConversationAuxiliaryRows`** so skills share the bottom budget while **one conversation row** stays reserved for live transcript.
> 
> Shared **`ActiveSkillSummary`** / **`SkillNameSchema`** schemas centralize name grammar and description sanitization; **`SkillNameSchema`** is re-exported from the skills package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf91ce38a5641bc1f3f247a5130fde87412273e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->