### PR TITLE
Remove dead src/tools/latex barrel, import tools directly

### DIFF
--- a/src/test-kernel/tools/latex/ExtractBibliographyTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractBibliographyTool.vitest.ts
@@ -7,7 +7,7 @@ import { describe, it, afterEach, vi } from 'vitest';
 // Local imports
 import * as bibliographyModule from '@latex/extractBibliography';
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
-import { ExtractBibliographyTool } from '@tools/latex';
+import { ExtractBibliographyTool } from '@tools/latex/ExtractBibliographyTool';
 
 type BibliographyContext = Awaited<
   ReturnType<typeof bibliographyModule.extractBibliographyContext>

--- a/src/test-kernel/tools/latex/ExtractFiguresTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractFiguresTool.vitest.ts
@@ -7,7 +7,7 @@ import { describe, it, afterEach, vi } from 'vitest';
 // Local imports
 import * as figureModule from '@latex/extractFigure';
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
-import { ExtractLatexFiguresTool } from '@tools/latex';
+import { ExtractLatexFiguresTool } from '@tools/latex/ExtractFiguresTool';
 
 function installPlatform(files: Record<string, string>) {
   return installFakePlatform({ workspacePath: '/workspace', files });

--- a/src/test-kernel/tools/latex/ExtractTikzFiguresTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractTikzFiguresTool.vitest.ts
@@ -7,7 +7,7 @@ import { describe, it, afterEach, vi } from 'vitest';
 // Local imports
 import { TikzPictureManager } from '@latex/TikzPictureManager';
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
-import { ExtractTikzFiguresTool } from '@tools/latex';
+import { ExtractTikzFiguresTool } from '@tools/latex/ExtractTikzFiguresTool';
 import { pathToLocation } from '@utils/files';
 
 function installPlatform(files: Record<string, string>) {

--- a/src/tools/latex/index.ts
+++ b/src/tools/latex/index.ts
@@ -1,3 +1,0 @@
-export { ExtractLatexFiguresTool } from './ExtractFiguresTool';
-export { ExtractBibliographyTool } from './ExtractBibliographyTool';
-export { ExtractTikzFiguresTool } from './ExtractTikzFiguresTool';

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -19,11 +19,9 @@ import { ReportReviewIssueTool } from './ReportReviewIssueTool';
 import { EditFileTool } from './EditTool';
 import { GlobTool } from './glob';
 import { GrepTool } from './grep';
-import {
-  ExtractBibliographyTool,
-  ExtractLatexFiguresTool,
-  ExtractTikzFiguresTool,
-} from './latex';
+import { ExtractBibliographyTool } from './latex/ExtractBibliographyTool';
+import { ExtractLatexFiguresTool } from './latex/ExtractFiguresTool';
+import { ExtractTikzFiguresTool } from './latex/ExtractTikzFiguresTool';
 import { ArxivDownloadTool } from './arxiv/ArxivDownloadTool';
 import { ArxivMetadataTool } from './arxiv/ArxivMetadataTool';
 import { ArxivSearchTool } from './arxiv/ArxivSearchTool';


### PR DESCRIPTION
## Summary

Scheduled codebase audit for confusing/overlapped responsibilities. `src/tools/latex/index.ts` was a 3-line convenience re-export barrel with a single production consumer (`src/tools/registry.ts`) and no doc comment declaring a public surface. CLAUDE.md/AGENTS.md explicitly ban this pattern: "A barrel/index re-export file exists only for a documented public surface... Everything else imports the file that defines the symbol directly." Sibling barrels in the same directory (`src/tools/setup/index.ts`, `src/tools/approval/index.ts`) are legitimate — each has many real multi-file consumers and a doc comment stating what it exposes and why — which made this one stand out as the odd one out rather than the norm.

This PR deletes the barrel and points its four consumers (`registry.ts` plus the three latex-tool vitest files) directly at the modules that define `ExtractLatexFiguresTool`, `ExtractBibliographyTool`, and `ExtractTikzFiguresTool`. Pure import-path change, no behavior change.

## Issue acceptance gates

No tracked issue — this came from a scheduled structural-debt sweep across the repo. Acceptance gate: remove the dead barrel without changing behavior, keep the module's public API for its real consumers unchanged.

## Single source of truth

`ExtractFiguresTool.ts`, `ExtractBibliographyTool.ts`, and `ExtractTikzFiguresTool.ts` already own their respective tool classes; the barrel added no logic, so removing it doesn't move ownership anywhere — it just deletes an indirection layer between callers and those files.

## Duplication and abstraction budget

Removed: one unjustified re-export layer (single-caller barrel, explicitly banned by AGENTS.md's abstraction-discipline rule). No new abstraction added.

## Net elements (R6)

- Files: 5 changed (1 deleted, 4 modified), diffstat `+6/-11`
- Exported symbols: 0 net change — the 3 re-exports deleted from the barrel were pass-throughs of symbols still exported at their original definition sites; no symbol lost its export.
- Classes/interfaces/enums: none touched
- Net LoC: -5

## Consumer counts (R8)

`from './latex'` / `@tools/latex` had 4 consumers total before this change (grepped): `src/tools/registry.ts` (production) and 3 vitest files under `src/test-kernel/tools/latex/`. All 4 are updated in this PR to import directly from the defining file; no dangling references remain (verified via repo-wide grep for `tools/latex'` post-change).

## Host impact

Extension: none (shared core file, no host-specific behavior)
Desktop: none
CLI: none

## Scheduled refactoring

None needed for this change. The broader audit that produced this PR surfaced a few larger, genuinely more significant structural issues that were deliberately **not** attempted here because they need careful, reviewed follow-up rather than an unattended sweep:

- `src/transcript/StreamSnapshotStore.ts` (`refreshSeed`, ~line 1546) hand-rolls a per-stream promise chain (`record.seedChain`) with generation counters instead of using the repo's `KeyedMutex` (`src/utils/core/keyedMutex.ts`) or `p-queue` pattern mandated elsewhere (e.g. `writeChains` in `jsonStore.ts`). `StagedDeletionCoordinator.ts` (~line 479) polls that same field externally, so a fix needs to redesign both sides together — not a small PR.
- The `Session*` naming cluster (`SessionHandle`, `SessionEventHub`, `SessionStores`, `SessionState`, `SessionFactApplier`, `sessionStores.ts`) spans `src/agent/runtime/`, `src/agent/storage/`, and `src/controllers/session/` with well-documented but easily-confused boundaries — worth a naming/doc pass, but touches ~180 call sites.
- `src/agent/` and `src/latex/` have an accepted bidirectional dependency tracked in `config/ratchets/architecture-edges-baseline.json`; untangling it would mean introducing a port for the remaining touchpoints, similar to how `texraResponseTextProcessing.ts` already does for one seam.

Flagging these here for visibility/triage rather than opening throwaway issues without maintainer buy-in on priority.

## Validation

- `npm run typecheck:workspace` — clean
- `npx vitest run src/test-kernel/tools/latex/` — 3 files, 11 tests passed
- `npm run check:dead-code-ratchet` — no new unused files/exports (16 baselined, 16 current)
- `npx eslint` on all changed files — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01SEYvcxRijS22gwYrDoQi8S)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path-only refactor with no runtime behavior changes; verified no remaining `@tools/latex` barrel references.
> 
> **Overview**
> Removes **`src/tools/latex/index.ts`**, a three-line re-export barrel that only forwarded the three LaTeX extract tools and had a single production consumer (`registry.ts`), which conflicts with the repo rule to import symbols from their defining modules unless a barrel documents a real public surface.
> 
> **`registry.ts`** and the three **`src/test-kernel/tools/latex/*.vitest.ts`** files now import **`ExtractBibliographyTool`**, **`ExtractLatexFiguresTool`**, and **`ExtractTikzFiguresTool`** from **`ExtractBibliographyTool.ts`**, **`ExtractFiguresTool.ts`**, and **`ExtractTikzFiguresTool.ts`** respectively. No logic or exports change—only import paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcd35b68487d968023d34d352c3143efe270d4d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->