### PR TITLE
refactor(auth): dedupe subscription-auth error classes; use escape-string-regexp

### DIFF
--- a/packages/desktop/src/main/desktopAppLog.ts
+++ b/packages/desktop/src/main/desktopAppLog.ts
@@ -10,6 +10,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { format } from 'node:util';
 
+import escapeRegExp from 'escape-string-regexp';
 import {
   app,
   type WebContents,
@@ -191,14 +192,10 @@ function redactPathPrefixes(
         ? ''
         : `(?=$|[\\s\\\\/,:;!?\\])}'"]|\\.(?:$|\\s))`;
       return redacted.replaceAll(
-        new RegExp(`${escapeRegex(prefix)}${boundary}`, 'g'),
+        new RegExp(`${escapeRegExp(prefix)}${boundary}`, 'g'),
         '[path]',
       );
     }, text);
-}
-
-function escapeRegex(value: string): string {
-  return value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function toConsoleLevel(

--- a/src/auth/codex/codexSessionTypes.ts
+++ b/src/auth/codex/codexSessionTypes.ts
@@ -7,6 +7,11 @@
  */
 import { z } from 'zod';
 
+import {
+  SubscriptionOAuthError,
+  type SubscriptionOAuthErrorKind,
+} from '../oauth/subscriptionOAuthError';
+
 /** Raw response from the OAuth token endpoint (code exchange + refresh). */
 export const CodexTokenResponseSchema = z.object({
   access_token: z.string().min(1),
@@ -69,38 +74,18 @@ export const CodexDeviceTokenSchema = z.object({
 });
 export type CodexDeviceToken = z.infer<typeof CodexDeviceTokenSchema>;
 
-/**
- * Errors from the Codex auth flow.
- *
- * - `fatal`     — the refresh/grant was rejected (400/401/403): the session is
- *                 dead and the user must sign in again.
- * - `expired`   — there is no usable session / it expired and cannot refresh.
- * - `transient` — a 5xx / network blip: keep the session, retry later.
- * - `config`    — misconfiguration (e.g. account id missing from the JWT).
- * - `pending`   — device-code authorization not completed yet.
- */
-export type CodexAuthErrorKind =
-  'fatal' | 'expired' | 'transient' | 'config' | 'pending';
+/** Error kinds match the shared subscription OAuth vocabulary. */
+export type CodexAuthErrorKind = SubscriptionOAuthErrorKind;
 
-export class CodexAuthError extends Error {
-  readonly kind: CodexAuthErrorKind;
-  readonly status?: number;
-
+export class CodexAuthError extends SubscriptionOAuthError {
   constructor(
     message: string,
     kind: CodexAuthErrorKind,
     status?: number,
     options?: ErrorOptions,
   ) {
-    super(message, options);
+    super(message, kind, status, options);
     this.name = 'CodexAuthError';
-    this.kind = kind;
-    this.status = status;
-  }
-
-  /** Whether the user must re-authenticate (vs. retry). */
-  get needsReauth(): boolean {
-    return this.kind === 'fatal' || this.kind === 'expired';
   }
 }
 

--- a/src/auth/xai/xaiSessionTypes.ts
+++ b/src/auth/xai/xaiSessionTypes.ts
@@ -5,7 +5,10 @@
 import { z } from 'zod';
 
 import { XAI_DEFAULT_EXPIRES_IN_SEC } from './xaiConstants';
-import type { SubscriptionOAuthErrorKind } from '../oauth/subscriptionOAuthError';
+import {
+  SubscriptionOAuthError,
+  type SubscriptionOAuthErrorKind,
+} from '../oauth/subscriptionOAuthError';
 
 /** Raw response from the OAuth token endpoint (code exchange + refresh). */
 export const XaiTokenResponseSchema = z.object({
@@ -54,24 +57,15 @@ export type XaiDeviceCode = z.infer<typeof XaiDeviceCodeSchema>;
 
 export type XaiAuthErrorKind = SubscriptionOAuthErrorKind;
 
-export class XaiAuthError extends Error {
-  readonly kind: XaiAuthErrorKind;
-  readonly status?: number;
-
+export class XaiAuthError extends SubscriptionOAuthError {
   constructor(
     message: string,
     kind: XaiAuthErrorKind,
     status?: number,
     options?: ErrorOptions,
   ) {
-    super(message, options);
+    super(message, kind, status, options);
     this.name = 'XaiAuthError';
-    this.kind = kind;
-    this.status = status;
-  }
-
-  get needsReauth(): boolean {
-    return this.kind === 'fatal' || this.kind === 'expired';
   }
 }
 


### PR DESCRIPTION
## Summary

Small, targeted consolidation pass found by a repo-wide scan for duplicate logic and hand-rolled code that already has a shared implementation:

- `CodexAuthError` and `XaiAuthError` each re-implemented `SubscriptionOAuthError`'s `kind`/`status` fields, constructor, and `needsReauth` getter verbatim (identical bodies, only `this.name` differed). Both now `extends SubscriptionOAuthError`, matching the `ProviderAuthErrorCtor` contract already used by `providerAuthBridge.ts` for `instanceof`-based rethrowing.
- `packages/desktop/src/main/desktopAppLog.ts` had a hand-rolled `escapeRegex()` duplicating the `escape-string-regexp` package the repo already depends on and already uses one file over (`desktopCrashReporting.ts`) plus 8 other call sites across `src/`. Swapped in the shared `escapeRegExp` import and deleted the local copy.

No behavior change: the `needsReauth` logic, error `kind`/`status` shape, and regex-escaping semantics are identical before and after.

## Issue acceptance gates

No linked issue — this is a proactive tech-debt consolidation pass (scheduled scan for duplicate/custom-vs-native code).

## Single source of truth

- `SubscriptionOAuthError` (`src/auth/oauth/subscriptionOAuthError.ts`) is now the sole owner of the auth-error shape and `needsReauth` rule; `CodexAuthError`/`XaiAuthError` are thin named subclasses used only for `instanceof` narrowing at provider boundaries.
- `escape-string-regexp` (already a root dependency) is the sole regex-escaping implementation reachable from `desktopAppLog.ts`.

## Duplication and abstraction budget

Removed ~30 duplicate lines (constructor + getter bodies) across `CodexAuthError`/`XaiAuthError`, and one duplicate regex-escape function. No new abstractions added — both fixes delete code in favor of an already-existing shared class/package.

## Net elements (R6)

- Exported symbols: unchanged (`CodexAuthErrorKind`, `CodexAuthError`, `XaiAuthErrorKind`, `XaiAuthError` all still exported; same names, same call sites).
- Classes: `CodexAuthError`/`XaiAuthError` now subclass `SubscriptionOAuthError` instead of `Error` — no new classes.
- Net LoC: 3 files changed, +17/-41 (diffstat).

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed; `CodexAuthError`/`XaiAuthError`/`escapeRegExp` usage sites are unchanged (grepped: `CodexAuthError` used at 12 call sites, `XaiAuthError` at 8, all still compile and pass under the new class hierarchy).

## Host impact

Extension: none (no extension-specific code touched).

Desktop: `desktopAppLog.ts` regex-escaping now goes through `escape-string-regexp` instead of a local regex — output is identical, verified by inspection (same character class escaped).

CLI: none.

## Scheduled refactoring

None. (A related but larger finding — three near-duplicate RFC 8628 device-code polling loops in `codexDeviceLogin.ts`, `xaiDeviceLogin.ts`, and `packages/cli/src/runtime/supabaseAuthDeviceCode.ts` — was intentionally left out of this PR as a bigger, riskier refactor; flagging here for a future pass rather than bundling it with this low-risk cleanup.)

## Validation

- `npm run typecheck` — full workspace (workspace, test-kernel, agent, extension, cli, trace-viewer, desktop) passes.
- `npx eslint` on the three changed files — clean.
- `npx vitest run` on the auth/model-factory tests exercising these classes (`CodexDeviceLogin`, `CodexSessionCoordinator`, `XaiSessionCoordinator`, `ModelFactoryRouting`) — 87/87 passing.
- No dedicated unit test exists for `desktopAppLog.ts`; verified by reading the diff that the escaped character class is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kaysz4dyTiJhoFPv44Wbgm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical inheritance and import swap with identical error semantics and regex escaping; validated by typecheck and auth-related tests per PR description.
> 
> **Overview**
> **Dedupes subscription OAuth errors and desktop log regex escaping** with no intended behavior change.
> 
> `CodexAuthError` and `XaiAuthError` now **extend** `SubscriptionOAuthError` instead of re-implementing `kind`, `status`, and `needsReauth`. Local `CodexAuthErrorKind` is removed in favor of the shared kind type; exported names and `instanceof` boundaries stay the same.
> 
> In `desktopAppLog.ts`, path redaction uses the **`escape-string-regexp`** import and drops the local `escapeRegex` helper (same escaping semantics as before).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88a40778cafed4c8db2154a321b20d7a04a6928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->