### PR TITLE
refactor(cli): use lru-cache for transcript-lines cache eviction

### DIFF
--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -2,6 +2,8 @@
 // display lines. Unlike the finalized scrollback and the live region, this
 // renders every tool-output line.
 
+import { LRUCache } from 'lru-cache';
+
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 
 import { isRenderableTranscriptEntry } from '../panes/transcriptEntries';
@@ -35,17 +37,18 @@ function labelsToken(executionLabels: ExecutionLabels): number {
 }
 
 // Cap each entry's composite-key slots so a long session with many terminal
-// resizes / labels-roster changes can't grow an entry's inner Map forever —
+// resizes / labels-roster changes can't grow an entry's inner cache forever —
 // only the outer WeakMap's entry-level eviction is free (GC-tied); the
 // `${token}:${cols}` keys inside it are strong references the entry itself
 // won't drop on its own. In practice only the current width and the current
 // labels snapshot are re-rendered at once, so a small cap costs no realistic
-// hit rate.
+// hit rate. Genuine LRU (not insertion-order) eviction costs nothing extra
+// here and avoids evicting a slot that was just re-hit.
 const MAX_LINES_PER_ENTRY = 4;
 
 const entryLinesCache = new WeakMap<
   ConversationEntry,
-  Map<string, readonly string[]>
+  LRUCache<string, readonly string[]>
 >();
 
 function transcriptEntryLines(
@@ -59,13 +62,13 @@ function transcriptEntryLines(
   if (cached) return cached;
   const lines = fullTranscriptEntryLayout(entry, cols, executionLabels).lines;
   if (cachedByEntry) {
-    if (cachedByEntry.size >= MAX_LINES_PER_ENTRY) {
-      const oldestKey = cachedByEntry.keys().next().value;
-      if (oldestKey !== undefined) cachedByEntry.delete(oldestKey);
-    }
     cachedByEntry.set(key, lines);
   } else {
-    entryLinesCache.set(entry, new Map([[key, lines]]));
+    const cache = new LRUCache<string, readonly string[]>({
+      max: MAX_LINES_PER_ENTRY,
+    });
+    cache.set(key, lines);
+    entryLinesCache.set(entry, cache);
   }
   return lines;
 }


### PR DESCRIPTION
## Summary

Follow-up to a scheduled dependency-reinvention audit that scanned the codebase for hand-rolled logic that well-maintained npm packages already solve. Most candidates turned out to be deliberate, documented tradeoffs (see below), but one real fix survived scrutiny: `transcriptLines.ts`'s per-entry line cache evicted by `Map` insertion order (a FIFO), which the code's own framing (a bounded cache meant to protect memory under repeated re-renders) implies should be recency-based. This PR swaps the hand-rolled eviction for the project's existing `lru-cache` dependency, used the same way elsewhere in `boundedIdSet.ts` and `replacement/engine.ts`.

## Issue acceptance gates

No tracked issue — ad hoc audit follow-up. Gate: replace the FIFO-as-cap eviction in `entryLinesCache` with genuine LRU eviction, without changing cache capacity (`MAX_LINES_PER_ENTRY = 4`) or the outer `WeakMap`-per-entry GC-tied structure.

## Single source of truth

`lru-cache`'s `LRUCache` now owns eviction-order tracking for each entry's composite-key slots; no other code computes or assumes insertion order.

## Duplication and abstraction budget

Removed the hand-rolled "evict oldest key" splice (`cachedByEntry.keys().next().value` + manual `delete`) in favor of the already-installed `lru-cache`. No new abstraction added — this is a straight swap of the inner container type.

## Net elements (R6)

1 file changed, +11/-8 (diffstat). No new exports, classes, or types. Net constructs: -1 hand-rolled eviction branch, +1 `LRUCache` import (already a transitive/declared dependency of `packages/cli`, not a new package).

## Consumer counts (R8)

n/a — no emit path or export changed; `transcriptEntryLines` and `transcriptToLines` keep their existing signatures and call sites.

## Host impact

Extension: none (file is CLI-only).

Desktop: none.

CLI: `entryLinesCache` in `packages/cli/src/chat/tui/state/transcriptLines.ts` now evicts by least-recently-used slot instead of insertion order when a session re-renders an entry at more than 4 distinct (width, execution-labels) combinations. Cache capacity is unchanged.

## Scheduled refactoring

None. Other audit candidates were investigated and intentionally excluded from this PR:
- `src/agent/runtime/ModelRetryGate.ts` (hand-rolled circuit breaker) — `cockatiel` is a plausible replacement but this is a reliability-critical component with app-specific probe/cohort semantics; needs a scoped design spike, not a blind swap in an automated PR.
- `src/utils/text/stringUtils.ts` `formatTimestamp` — confirmed **not** a safe swap to `date-fns`: the current implementation is deliberately UTC-safe via `toISOString()` regardless of host timezone; `date-fns`'s `format()` uses local time by default and would silently change output on any non-UTC host.
- `packages/cli/src/runtime/runProgressRenderer.ts` `formatElapsed` — confirmed **not** a safe swap to `pretty-ms`: the function deliberately never rolls over to hour units past 60 minutes (`100m 00s`, not `1h 40m`), a behavior `pretty-ms`'s public options don't expose.
- `src/tools/github/annotationFetchBudget.ts` (hand-rolled token bucket) — `bottleneck` doesn't actually satisfy the documented requirement (synchronous non-blocking `tryClaim()` with an injectable clock); would not be a genuine improvement.

## Validation

- `npm run typecheck:cli` — passes, no new errors.
- `npx eslint packages/cli/src/chat/tui/state/transcriptLines.ts` — clean.
- `npx vitest run src/test-kernel/cli/ConversationTranscript.vitest.ts` (the centralized test covering `transcriptToLines`) — 50/50 passed.
- `npm run check:dead-code-ratchet` — no new findings vs. baseline.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YNwCqbTPi9hEHb9N6gpwG6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only transcript rendering cache with unchanged capacity and public APIs; behavior change is limited to eviction order under the same bound.
> 
> **Overview**
> The per-entry wrapped-line cache in **`transcriptLines.ts`** now uses **`lru-cache`**’s `LRUCache` instead of a plain `Map` with manual “delete first key” eviction when **`MAX_LINES_PER_ENTRY`** (4) slots are exceeded.
> 
> Eviction is **least-recently-used** rather than insertion-order FIFO, so a composite key that was just re-hit is not dropped when a new `(execution-labels token, cols)` pair is added. The outer **`WeakMap`** keyed by conversation entries and cache capacity are unchanged; only the inner container and eviction policy change, aligned with existing **`lru-cache`** usage elsewhere in the CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce67345fd3c5fe835a7f6d240e8708f964bc2b6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->