### PR TITLE
refactor: extract shared agent-CLI tool dispatch skeleton

### DIFF
--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -22,7 +22,12 @@ import {
 import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
 import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
-import type { RunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextExecutionId,
+  getRunContextStreamId,
+  getRunContextWorkingDirectory,
+  type RunContext,
+} from '@agent/runtime/RunContext';
 import {
   USER_FOLLOW_UP_SUPPORT,
   type ExecutionId,
@@ -31,6 +36,7 @@ import {
   type TokenUsageStats,
 } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
+import { requireRunStream } from '@tools/contextHelpers';
 import {
   requestBashApproval,
   buildBashApprovalRejectedResult,
@@ -142,7 +148,7 @@ async function queueAgentCliFollowUp(
  * cleanup so an acknowledged follow-up can never be stranded behind a failed
  * initial turn.
  */
-export async function resumeOrLaunchAgentCliSession(
+async function resumeOrLaunchAgentCliSession(
   store: ClaimableAgentCliStore,
   params: {
     id: string | undefined;
@@ -277,7 +283,7 @@ export async function launchAgentCliSession(
  * in a turn that never happens and the child's result is stranded. Fail before
  * prompting for approval rather than launching work nobody collects.
  */
-export async function withAgentCliApproval(
+async function withAgentCliApproval(
   toolName: string,
   approvalLabel: string,
   run: (runContext: RunContext | undefined) => ToolResult | Promise<ToolResult>,
@@ -296,6 +302,59 @@ export async function withAgentCliApproval(
 
   contexts?.callContext?.hooks?.onExecutionReady?.();
   return run(contexts?.runContext);
+}
+
+/** Run context resolved for an agent-CLI launch, handed to the provider's
+ * `launch` callback by {@link dispatchAgentCliTool}. */
+export interface AgentCliLaunchContext {
+  parentStreamId: StreamTabId;
+  parentExecutionId: ExecutionId | undefined;
+  parentWorkingDirectory: string | undefined;
+  /** Release the disk-based fallback claim if the launch fails before promoting
+   * it. Undefined for a fresh (non-resumed) launch. */
+  releaseFallbackClaim: (() => void) | undefined;
+}
+
+/**
+ * The shared execute() dispatch skeleton for an agent-CLI tool. Wraps the
+ * boilerplate-identical chain both providers (codex, claudeAgent) run: request
+ * approval for the labelled command, choose atomically between queueing onto an
+ * owned session and launching a disk-based fallback, and resolve the run context
+ * a launch needs (parent stream/execution/working-directory). A missing
+ * in-memory entry denotes a disk-based SDK fallback, so `launch` receives the
+ * `releaseFallbackClaim` it must promote or release. Callers supply only their
+ * approval label, session store, resume id, resume labels, and the
+ * provider-specific launch.
+ */
+export function dispatchAgentCliTool(params: {
+  agentName: string;
+  approvalLabel: string;
+  store: ClaimableAgentCliStore;
+  resumeId: string | undefined;
+  prompt: string;
+  labels: AgentCliResumeLabels;
+  launch: (context: AgentCliLaunchContext) => Promise<ToolResult>;
+}): Promise<ToolResult> {
+  const { agentName, approvalLabel, store, resumeId, prompt, labels, launch } =
+    params;
+  return withAgentCliApproval(agentName, approvalLabel, (runContext) =>
+    resumeOrLaunchAgentCliSession(store, {
+      id: resumeId,
+      prompt,
+      callerStreamId: getRunContextStreamId(runContext),
+      labels,
+      launch: (releaseFallbackClaim) => {
+        // A missing in-memory entry denotes a disk-based SDK fallback.
+        const { streamId } = requireRunStream(agentName, runContext);
+        return launch({
+          parentStreamId: streamId,
+          parentExecutionId: getRunContextExecutionId(runContext),
+          parentWorkingDirectory: getRunContextWorkingDirectory(runContext),
+          releaseFallbackClaim,
+        });
+      },
+    }),
+  );
 }
 
 // ============================================================================

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -32,11 +32,6 @@ import {
   type ToolUseCardRef,
 } from '@agent/trace';
 import {
-  getRunContextExecutionId,
-  getRunContextStreamId,
-  getRunContextWorkingDirectory,
-} from '@agent/runtime/RunContext';
-import {
   ClaudeAgentEffortSchema,
   ClaudeAgentPermissionModeSchema,
   MESSAGE_TYPES,
@@ -50,7 +45,6 @@ import type {
 } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
 import { type ToolResult } from '@shared/schemas/toolResult';
-import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import { formatWallTimeSeconds, isNonEmptyString } from '@utils/core';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -66,10 +60,9 @@ import {
 import { type ChildStream } from './delegation/childStream';
 import { ClaudeAgentSessions } from './agentCliSessionStores';
 import {
+  dispatchAgentCliTool,
   launchAgentCliSession,
-  resumeOrLaunchAgentCliSession,
   startAgentCliLoop,
-  withAgentCliApproval,
 } from './agentCliShared';
 import {
   formatChildRunDelivery,
@@ -515,40 +508,30 @@ export class ClaudeAgentTool extends defineTool({
     const model = input.model ?? config.getClaudeAgentModel();
     const effort = input.effort ?? config.getClaudeAgentEffort();
 
-    return withAgentCliApproval(
-      CLAUDE_AGENT_NAME,
-      `[${CLAUDE_AGENT_NAME} ${permissionMode}] ${input.prompt}`,
-      (runContext) => {
-        return resumeOrLaunchAgentCliSession(ClaudeAgentSessions, {
-          id: input.session_id ?? undefined,
-          prompt: input.prompt,
-          callerStreamId: getRunContextStreamId(runContext),
-          labels: {
-            notActiveLabel: 'Claude Code CLI session',
-            idParamName: 'session_id',
-            summaryLabel: 'Claude Code CLI',
-            queuedLabel: 'Claude Code session',
-          },
-          launch: (releaseClaim) => {
-            // A missing in-memory entry denotes a disk-based SDK fallback.
-            const { streamId } = requireRunStream(
-              CLAUDE_AGENT_NAME,
-              runContext,
-            );
-            return launchClaudeAgentSession(
-              input,
-              permissionMode,
-              model,
-              effort,
-              streamId,
-              getRunContextExecutionId(runContext),
-              getRunContextWorkingDirectory(runContext),
-              releaseClaim,
-            );
-          },
-        });
+    return dispatchAgentCliTool({
+      agentName: CLAUDE_AGENT_NAME,
+      approvalLabel: `[${CLAUDE_AGENT_NAME} ${permissionMode}] ${input.prompt}`,
+      store: ClaudeAgentSessions,
+      resumeId: input.session_id ?? undefined,
+      prompt: input.prompt,
+      labels: {
+        notActiveLabel: 'Claude Code CLI session',
+        idParamName: 'session_id',
+        summaryLabel: 'Claude Code CLI',
+        queuedLabel: 'Claude Code session',
       },
-    );
+      launch: (context) =>
+        launchClaudeAgentSession(
+          input,
+          permissionMode,
+          model,
+          effort,
+          context.parentStreamId,
+          context.parentExecutionId,
+          context.parentWorkingDirectory,
+          context.releaseFallbackClaim,
+        ),
+    });
   }
 }
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -29,11 +29,6 @@ import {
   type ToolUseCardRef,
 } from '@agent/trace';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
-import {
-  getRunContextExecutionId,
-  getRunContextStreamId,
-  getRunContextWorkingDirectory,
-} from '@agent/runtime/RunContext';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
 import type {
@@ -44,7 +39,6 @@ import type {
 } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { CodexSandboxModeSchema } from '@shared/schemas/agentCliSettings';
-import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import { formatWallTimeSeconds } from '@utils/core';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -57,10 +51,9 @@ import { importCodexClass, findCodexBinaryPath } from './codexImport';
 import { type ChildStream } from './delegation/childStream';
 import { CodexThreads } from './agentCliSessionStores';
 import {
+  dispatchAgentCliTool,
   launchAgentCliSession,
-  resumeOrLaunchAgentCliSession,
   startAgentCliLoop,
-  withAgentCliApproval,
 } from './agentCliShared';
 import {
   formatChildRunDelivery,
@@ -490,34 +483,27 @@ export class CodexTool extends defineTool({
       input.sandbox_mode = config.getCodexSandboxMode();
     }
 
-    return withAgentCliApproval(
-      'codex',
-      `[codex ${input.sandbox_mode}] ${input.prompt}`,
-      (runContext) => {
-        return resumeOrLaunchAgentCliSession(CodexThreads, {
-          id: input.thread_id ?? undefined,
-          prompt: input.prompt,
-          callerStreamId: getRunContextStreamId(runContext),
-          labels: {
-            notActiveLabel: 'Codex thread',
-            idParamName: 'thread_id',
-            summaryLabel: 'Codex',
-            queuedLabel: 'Codex thread',
-          },
-          launch: (releaseClaim) => {
-            // A missing in-memory entry denotes a disk-based SDK fallback.
-            const { streamId } = requireRunStream('codex', runContext);
-            return launchCodexSession(
-              input,
-              streamId,
-              getRunContextExecutionId(runContext),
-              getRunContextWorkingDirectory(runContext),
-              releaseClaim,
-            );
-          },
-        });
+    return dispatchAgentCliTool({
+      agentName: 'codex',
+      approvalLabel: `[codex ${input.sandbox_mode}] ${input.prompt}`,
+      store: CodexThreads,
+      resumeId: input.thread_id ?? undefined,
+      prompt: input.prompt,
+      labels: {
+        notActiveLabel: 'Codex thread',
+        idParamName: 'thread_id',
+        summaryLabel: 'Codex',
+        queuedLabel: 'Codex thread',
       },
-    );
+      launch: (context) =>
+        launchCodexSession(
+          input,
+          context.parentStreamId,
+          context.parentExecutionId,
+          context.parentWorkingDirectory,
+          context.releaseFallbackClaim,
+        ),
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

The `codex` and `claude_agent` tools' `execute()` methods each ran a line-for-line identical dispatch skeleton: request bash approval for the labelled command, atomically choose between queueing onto an owned session and launching a disk-based fallback, then resolve the `RunContext` a launch needs (parent stream / execution id / working directory) and thread the fallback-claim contract through. Two providers that must stay in behavioral lockstep each maintained their own copy of this plumbing — the kind of drift risk the comments already flagged ("Mirrors codex behavior…").

This extracts that skeleton into a single `dispatchAgentCliTool()` in `agentCliShared.ts`. Each tool now supplies only its approval label, session store, resume id, resume labels, and provider-specific `launch`; the `launch` receives a resolved `AgentCliLaunchContext`. Behavior is unchanged.

## Issue acceptance gates

No tracking issue — this is a standalone tech-debt cleanup surfaced by a codebase audit of the largest ad-hoc/duplicated areas. Gate satisfied: the two agent-CLI tools now share one dispatch path with identical observable behavior.

## Single source of truth

`dispatchAgentCliTool()` in `src/tools/agentCliShared.ts` is now the single owner of the agent-CLI `execute()` dispatch decision: the approval → resume-or-launch → RunContext-resolution → disk-fallback-claim contract. The "missing in-memory entry = disk-based SDK fallback" rule and the `releaseFallbackClaim` promote/release contract live there in exactly one place.

## Duplication and abstraction budget

Removed the duplicated ~30-line dispatch skeleton from both `codex.ts` and `claudeAgent.ts` (RunContext plumbing via `getRunContextStreamId`/`getRunContextExecutionId`/`getRunContextWorkingDirectory`, the `requireRunStream` disk-fallback comment, and the `withAgentCliApproval` → `resumeOrLaunchAgentCliSession` chain). The one new abstraction, `dispatchAgentCliTool`, owns the invariant that both agent-CLI providers dispatch through an identical approval + resume/launch + fallback-claim contract. It is not a pass-through: it composes two previously-exported helpers (`withAgentCliApproval`, `resumeOrLaunchAgentCliSession`) that are now internal, and resolves the RunContext once on their behalf.

## Net elements (R6)

- **Files:** 3 changed, 0 added/deleted.
- **Exported symbols:** net 0 — added `dispatchAgentCliTool` + `AgentCliLaunchContext`; removed the `export` on `resumeOrLaunchAgentCliSession` + `withAgentCliApproval` (now internal, no external callers).
- **Interfaces:** +1 (`AgentCliLaunchContext`).
- **Net LoC:** +28 (+107 / −79). The added lines are the shared helper plus its docstring and the `AgentCliLaunchContext` type; against that, the duplicated dispatch skeleton collapses from two copies to one, and both call sites shrink.

## Consumer counts (R8)

- `dispatchAgentCliTool`: 2 consumers (`codex.ts`, `claudeAgent.ts`).
- `resumeOrLaunchAgentCliSession` and `withAgentCliApproval`: 0 external consumers after this change (previously 1 each, both re-routed through `dispatchAgentCliTool`) → un-exported. Verified by grep across `src/` and `packages/`.
- No `bus.emit` / event-emit path added, removed, or re-routed.

## Host impact

This is host-agnostic core (`src/tools/`); the agent-CLI tools behave identically across all three hosts.

Extension: no change in behavior.

Desktop: no change in behavior.

CLI: no change in behavior.

## Scheduled refactoring

None. (The audit that surfaced this also flagged larger structural targets — e.g. the Google model-handler monolith and the tri-modeled settings schemas — but those are separate, higher-effort efforts, not follow-ups to this PR.)

## Validation

- `npm run typecheck` — full workspace + all host projects, passes.
- `npx eslint src/tools/codex.ts src/tools/claudeAgent.ts src/tools/agentCliShared.ts` — clean.
- `npm run check:dead-code-ratchet` — 16 vs 16 baselined; no new unused exports (confirms the un-exports were required).
- `npx vitest run` on `CodexResumeFallback`, `ClaudeAgentResumeFallback`, `ClaudeAgentSchema`, `CodexProgressEvents`, `ChildStreamProgressEvents` — 33 tests pass. These exercise the exact resume/launch/disk-fallback path that was refactored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvwkrkvocjbNi2J7tfPUdE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only consolidation of duplicated dispatch logic with no new behavior paths; session resume and disk-fallback claim contracts remain centralized in one helper.
> 
> **Overview**
> **Codex** and **claude_agent** no longer duplicate the same `execute()` path (bash approval → resume-or-launch session → resolve parent `RunContext` → disk-fallback claim). Both tools now call **`dispatchAgentCliTool`** in `agentCliShared.ts`, passing only approval label, session store, resume id, labels, and a provider-specific `launch`.
> 
> The shared helper composes **`withAgentCliApproval`** and **`resumeOrLaunchAgentCliSession`** (now module-internal, not exported) and hands launches a resolved **`AgentCliLaunchContext`** (`parentStreamId`, execution id, working directory, `releaseFallbackClaim`). Observable behavior is intended to stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b846855be01f3e9c3aae3e6ddddbe0bcad2a1fc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->