### PR TITLE
fix: skills-active follow-ups from #9919

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ActiveSkillsDetails.ts
+++ b/packages/extension/src/progressView/frontend/components/ActiveSkillsDetails.ts
@@ -1,64 +1,63 @@
-import { css, html, LitElement, nothing, type TemplateResult } from 'lit';
+/**
+ * ActiveSkillsDetails — collapsible panel listing skills active for a run.
+ * Extends CollapsiblePanel so stream switches reset open state via collapseKey.
+ */
+
+// Third-party imports
+import { css, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
+// Local imports - shared styles
+import { designTokens, commonViewStyles } from '@shared/styles';
 import type { ActiveSkillSummary } from '@shared/schemas';
 
+// Local imports - progress view constants
+import { ELEMENT_IDS } from '../constants';
+
+// Local imports - base class
+import { CollapsiblePanel } from './CollapsiblePanel';
+
 @customElement('active-skills-details')
-export class ActiveSkillsDetails extends LitElement {
-  static override styles = css`
-    :host,
-    details,
-    ul,
-    li {
-      min-width: 0;
-    }
+export class ActiveSkillsDetails extends CollapsiblePanel {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+        min-width: 0;
+      }
 
-    :host {
-      display: contents;
-    }
+      .skills-list {
+        display: grid;
+        gap: var(--wa-space-2xs);
+        margin: 0;
+        padding-inline-start: var(--wa-space-l);
+        min-width: 0;
+      }
 
-    details {
-      box-sizing: border-box;
-      max-width: 100%;
-      overflow: hidden;
-      margin: 0 0 var(--wa-space-xs);
-      padding: var(--wa-space-2xs) var(--wa-space-xs);
-      border: 1px solid var(--wa-color-neutral-border-quiet);
-      border-radius: var(--wa-border-radius-m);
-      color: var(--wa-color-text-normal);
-      font-size: var(--wa-font-size-s);
-    }
+      .skills-list li {
+        min-width: 0;
+        overflow-wrap: anywhere;
+      }
 
-    summary {
-      cursor: pointer;
-      font-weight: var(--font-weight-semibold, 600);
-    }
-
-    ul {
-      display: grid;
-      gap: var(--wa-space-2xs);
-      margin: var(--wa-space-xs) 0 0;
-      padding-inline-start: var(--wa-space-l);
-    }
-
-    li {
-      overflow-wrap: anywhere;
-    }
-
-    .source {
-      color: var(--wa-color-text-quiet);
-    }
-  `;
+      .source {
+        color: var(--wa-color-text-quiet);
+      }
+    `,
+  ];
 
   @property({ attribute: false })
   skills: readonly ActiveSkillSummary[] = [];
 
   override render(): TemplateResult | typeof nothing {
     if (this.skills.length === 0) return nothing;
-    return html`
-      <details>
-        <summary>Skills (${this.skills.length})</summary>
-        <ul>
+
+    return this.renderCollapsibleDetails({
+      id: ELEMENT_IDS.ACTIVE_SKILLS_CONTAINER,
+      summary: `Skills (${this.skills.length})`,
+      body: html`
+        <ul id=${ELEMENT_IDS.ACTIVE_SKILLS_LIST} class="skills-list">
           ${this.skills.map(
             (skill) => html`
               <li>
@@ -69,8 +68,8 @@ export class ActiveSkillsDetails extends LitElement {
             `,
           )}
         </ul>
-      </details>
-    `;
+      `,
+    });
   }
 }
 

--- a/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -63,6 +63,7 @@ export class ToolUseStreamContent extends BaseStreamContent {
         <div class="conversation-column conversation-prelude">
           <active-skills-details
             .skills=${currentState.activeSkills}
+            .collapseKey=${streamInfo.name}
           ></active-skills-details>
 
           <todo-list

--- a/packages/extension/src/progressView/frontend/constants.ts
+++ b/packages/extension/src/progressView/frontend/constants.ts
@@ -38,6 +38,9 @@ export const ELEMENT_IDS = {
   TODO_LIST: 'todoList',
   PLAN_VIEW_CONTAINER: 'planViewContainer',
   PLAN_VIEW: 'planView',
+  ACTIVE_SKILLS_CONTAINER: 'activeSkillsContainer',
+  ACTIVE_SKILLS_LIST: 'activeSkillsList',
+
   TOOLBAR_CONTAINER: 'toolbarContainer',
   STOP_STREAM_BTN: 'stopStreamBtn',
   RUN_NEW_BTN: 'runNewBtn',

--- a/src/shared/schemas/activeSkills.ts
+++ b/src/shared/schemas/activeSkills.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { redactSecrets } from '@logger/redaction';
 import { collapseWhitespace } from '@utils/text/stringUtils';
 
 import { SkillNameSchema } from './skillName';
@@ -31,9 +32,16 @@ function containsFilesystemShapedValue(description: string): boolean {
   return pathCandidates.includes('/');
 }
 
-/** Normalize untrusted frontmatter before it crosses the persistence boundary. */
+/**
+ * Normalize untrusted frontmatter before it crosses the persistence boundary.
+ * Owns secret redaction, path/ANSI sanitization, and length truncation in one
+ * place so transcript recorders parse raw skills without a parallel scrub.
+ */
 function sanitizeActiveSkillDescription(description: string): string {
-  const withoutAnsi = description.replaceAll(ANSI_ESCAPE_SEQUENCE, '');
+  // Redact before path/ANSI scrub and truncation so long secret tokens are
+  // replaced, not sliced mid-token into a still-sensitive prefix.
+  const redacted = redactSecrets(description);
+  const withoutAnsi = redacted.replaceAll(ANSI_ESCAPE_SEQUENCE, '');
   // eslint-disable-next-line no-control-regex -- persisted UI text excludes C0/C1 controls
   const withoutControls = withoutAnsi.replaceAll(/[\x00-\x1f\x7f-\x9f]/g, ' ');
   const normalized = collapseWhitespace(withoutControls).trim();

--- a/src/test-kernel/progressView/ActiveSkillsDetails.vitest.ts
+++ b/src/test-kernel/progressView/ActiveSkillsDetails.vitest.ts
@@ -17,32 +17,51 @@ function createElement(): ActiveSkillsDetailsElement {
   ) as ActiveSkillsDetailsElement;
 }
 
+function sampleSkill() {
+  return ActiveSkillSummarySchema.parse({
+    name: 'proof-audit',
+    description: 'Review proofs.',
+    source: 'project',
+  });
+}
+
 describe('active-skills-details', () => {
   useLitComponentTestDom(async () => {
     await import('@progressView/frontend/components/ActiveSkillsDetails');
   });
 
-  it('hides empty catalogs and renders a native collapsed details block', async () => {
+  it('hides empty catalogs and renders a collapsed wa-details panel', async () => {
     const element = createElement();
     document.body.append(element);
     await element.updateComplete;
-    expect(element.shadowRoot?.querySelector('details')).toBeNull();
+    expect(element.shadowRoot?.querySelector('wa-details')).toBeNull();
 
-    element.skills = [
-      ActiveSkillSummarySchema.parse({
-        name: 'proof-audit',
-        description: 'Review proofs.',
-        source: 'project',
-      }),
-    ];
+    element.skills = [sampleSkill()];
     await element.updateComplete;
 
-    const details = element.shadowRoot?.querySelector('details');
+    const details = element.shadowRoot?.querySelector('wa-details');
     expect(details).toBeInstanceOf(HTMLElement);
     expect(details?.hasAttribute('open')).toBe(false);
-    expect(details?.querySelector('summary')?.textContent).toContain(
-      'Skills (1)',
-    );
+    expect(details?.getAttribute('summary')).toContain('Skills (1)');
+  });
+
+  it('closes an open panel when collapseKey changes', async () => {
+    const element = createElement();
+    element.skills = [sampleSkill()];
+    element.collapseKey = 'stream-a';
+    document.body.append(element);
+    await element.updateComplete;
+
+    const details = element.shadowRoot?.querySelector('wa-details');
+    expect(details).toBeInstanceOf(HTMLElement);
+
+    details?.dispatchEvent(new Event('wa-show'));
+    await element.updateComplete;
+    expect(details?.hasAttribute('open')).toBe(true);
+
+    element.collapseKey = 'stream-b';
+    await element.updateComplete;
+    expect(details?.hasAttribute('open')).toBe(false);
   });
 
   it('wraps a maximum-length unbroken description within narrow containers', async () => {

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -435,11 +435,9 @@ export function attachTranscriptRecorder(
         }
 
         case 'skills.snapshot': {
+          // Schema owns redaction + sanitize + truncate for descriptions.
           const snapshot = ActiveSkillsSnapshotSchema.parse({
-            skills: event.skills.map((skill) => ({
-              ...skill,
-              description: redactSecrets(skill.description),
-            })),
+            skills: event.skills,
           });
           writer.appendSettled({
             id: generateShortId(),


### PR DESCRIPTION
## Summary

Follow-ups from #9919 (show skills active for each run).

- **Closes #9927** — `ActiveSkillsDetails` now extends shared `CollapsiblePanel` (same scaffold as `PlanView` / `TodoList`), uses `renderCollapsibleDetails` with `wa-details`, wires `.collapseKey=${streamInfo.name}` from `ToolUseStreamContent`, and resets open state on stream switches.
- **Closes #9928** — Secret redaction for skill descriptions lives in `sanitizeActiveSkillDescription` (schema boundary). `TexraTranscriptRecorder` parses `{ skills: event.skills }` without a parallel per-skill `redactSecrets` map; redaction still runs before truncation.
- **Closes #9926** — tracking issue for both children above.

## Test plan

- [x] `npx vitest run src/test-kernel/progressView/ActiveSkillsDetails.vitest.ts src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts src/test-kernel/shared/ActiveSkillsSchema.vitest.ts src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI scaffolding and moving redaction into an existing schema sanitization path; behavior is covered by targeted vitest suites with no auth or persistence contract changes beyond consistent scrubbing at parse time.
> 
> **Overview**
> **Active skills UI** now matches **PlanView** / **TodoList**: `ActiveSkillsDetails` extends `CollapsiblePanel`, renders via `wa-details` and shared design tokens, and receives `.collapseKey=${streamInfo.name}` so switching streams collapses an open panel. Stable element IDs were added for the container and list.
> 
> **Skill description handling** consolidates secret redaction into `sanitizeActiveSkillDescription` in the active-skills schema (before ANSI/path scrub and truncation). `TexraTranscriptRecorder` on `skills.snapshot` parses raw `event.skills` through the schema instead of applying a separate per-description `redactSecrets` pass.
> 
> Tests were updated for `wa-details`, summary text, and collapse-on-`collapseKey` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 278ca923c286958e09cbf082d52389e38c793207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->