### PR TITLE
refactor(auth): share RFC 8628 device-code poll loop

### DIFF
--- a/packages/cli/src/runtime/supabaseAuthDeviceCode.ts
+++ b/packages/cli/src/runtime/supabaseAuthDeviceCode.ts
@@ -5,16 +5,21 @@
 // code from a browser on any device. Session storage and relay-cache
 // invalidation live with the other sign-in flows in `supabaseAuth.ts`.
 
-import { setTimeout as sleepMs } from 'node:timers/promises';
-
+// Third-party imports
 import { z } from 'zod';
 
+// Local imports - auth
 import { DEVICE_AUTH_BASE_URL } from '@auth/config';
 import { fetchWithTimeout } from '@auth/fetchWithTimeout';
 import {
   parseTokenExchangeResponse,
   type GitHubTokenExchangeResponse,
 } from '@auth/SupabaseSession';
+import {
+  deviceCodeAuthorized,
+  deviceCodePending,
+  pollUntilDeviceAuthorized,
+} from '@auth/oauth/deviceCodePoll';
 
 const DEVICE_AUTH_REQUEST_TIMEOUT_MS = 30000;
 
@@ -102,73 +107,73 @@ export async function pollForDeviceSession(
   hooks: DeviceAuthPollHooks = {},
 ): Promise<GitHubTokenExchangeResponse> {
   const now = hooks.now ?? Date.now;
-  const sleep =
-    hooks.sleep ??
-    ((ms: number) => sleepMs(ms, undefined, { signal: hooks.signal }));
-  const deadline = now() + authorization.expires_in * 1000;
-  let intervalSeconds = authorization.interval;
   let transientFailures = 0;
+  const sleepHook = hooks.sleep;
 
-  for (;;) {
-    hooks.signal?.throwIfAborted();
-    await sleep(intervalSeconds * 1000);
-    hooks.signal?.throwIfAborted();
-    if (now() >= deadline) throw deviceCodeExpiredError();
-
-    let response: Response;
-    try {
-      response = await fetchWithTimeout(
-        `${hooks.baseUrl ?? DEVICE_AUTH_BASE_URL}/token`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ device_code: authorization.device_code }),
-          signal: hooks.signal,
-        },
-        DEVICE_AUTH_REQUEST_TIMEOUT_MS,
-        'Device sign-in poll timed out',
-        hooks.fetchImpl,
-      );
-    } catch (error) {
-      hooks.signal?.throwIfAborted();
-      // Headless/SSH connections blip; tolerate a few in a row before failing.
-      transientFailures += 1;
-      if (transientFailures >= MAX_TRANSIENT_POLL_FAILURES) throw error;
-      continue;
-    }
-
-    if (response.ok) {
-      return parseTokenExchangeResponse(response);
-    }
-
-    const errorCode = await readDeviceErrorCode(response);
-    switch (errorCode) {
-      case 'authorization_pending':
-        transientFailures = 0;
-        continue;
-      case 'slow_down':
-        transientFailures = 0;
-        intervalSeconds += SLOW_DOWN_INCREMENT_SECONDS;
-        continue;
-      case 'expired_token':
-        throw deviceCodeExpiredError();
-      case 'access_denied':
-        throw new Error('Sign-in was denied in the browser.');
-      default:
-        if (response.status === 429 || response.status >= 500) {
-          transientFailures += 1;
-          if (transientFailures >= MAX_TRANSIENT_POLL_FAILURES) {
-            throw new Error(
-              `Device sign-in failed (HTTP ${response.status}). Try again.`,
-            );
-          }
-          continue;
-        }
-        throw new Error(
-          `Device sign-in failed: ${errorCode ?? `HTTP ${response.status}`}`,
+  return pollUntilDeviceAuthorized({
+    intervalMs: authorization.interval * 1000,
+    deadlineMs: now() + authorization.expires_in * 1000,
+    signal: hooks.signal,
+    sleep: sleepHook ? (ms: number) => sleepHook(ms) : undefined,
+    now,
+    // Sleep first, then check the deadline (historical CLI timing).
+    checkDeadlineBeforeSleep: false,
+    createTimeoutError: deviceCodeExpiredError,
+    attempt: async () => {
+      let response: Response;
+      try {
+        response = await fetchWithTimeout(
+          `${hooks.baseUrl ?? DEVICE_AUTH_BASE_URL}/token`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ device_code: authorization.device_code }),
+            signal: hooks.signal,
+          },
+          DEVICE_AUTH_REQUEST_TIMEOUT_MS,
+          'Device sign-in poll timed out',
+          hooks.fetchImpl,
         );
-    }
-  }
+      } catch (error) {
+        hooks.signal?.throwIfAborted();
+        // Headless/SSH connections blip; tolerate a few in a row before failing.
+        transientFailures += 1;
+        if (transientFailures >= MAX_TRANSIENT_POLL_FAILURES) throw error;
+        return deviceCodePending();
+      }
+
+      if (response.ok) {
+        return deviceCodeAuthorized(await parseTokenExchangeResponse(response));
+      }
+
+      const errorCode = await readDeviceErrorCode(response);
+      switch (errorCode) {
+        case 'authorization_pending':
+          transientFailures = 0;
+          return deviceCodePending();
+        case 'slow_down':
+          transientFailures = 0;
+          return deviceCodePending(SLOW_DOWN_INCREMENT_SECONDS * 1000);
+        case 'expired_token':
+          throw deviceCodeExpiredError();
+        case 'access_denied':
+          throw new Error('Sign-in was denied in the browser.');
+        default:
+          if (response.status === 429 || response.status >= 500) {
+            transientFailures += 1;
+            if (transientFailures >= MAX_TRANSIENT_POLL_FAILURES) {
+              throw new Error(
+                `Device sign-in failed (HTTP ${response.status}). Try again.`,
+              );
+            }
+            return deviceCodePending();
+          }
+          throw new Error(
+            `Device sign-in failed: ${errorCode ?? `HTTP ${response.status}`}`,
+          );
+      }
+    },
+  });
 }
 
 function deviceCodeExpiredError(): Error {

--- a/src/auth/codex/codexDeviceLogin.ts
+++ b/src/auth/codex/codexDeviceLogin.ts
@@ -4,8 +4,14 @@
  * The user opens a URL and types a one-time code; we poll until they approve.
  * Host-neutral: the host renders the prompt (`onPrompt`) however it likes.
  */
-import { setTimeout as sleep } from 'node:timers/promises';
+// Local imports - oauth
+import {
+  deviceCodeAuthorized,
+  deviceCodePending,
+  pollUntilDeviceAuthorized,
+} from '@auth/oauth/deviceCodePoll';
 
+// Local imports - codex
 import { CODEX_DEVICE_VERIFICATION_URL } from './codexConstants';
 import { type CodexSessionCoordinator } from './CodexSessionCoordinator';
 import { CodexAuthError, type CodexSession } from './codexSessionTypes';
@@ -56,29 +62,35 @@ export async function loginWithDeviceCode(
     userCodeResponse.expires_in == null
       ? DEVICE_TIMEOUT_FALLBACK_MS
       : userCodeResponse.expires_in * 1000;
-  const deadline = Date.now() + expiresInMs;
-  while (Date.now() < deadline) {
-    await sleep(intervalMs, undefined, { signal: options.signal });
-    options.onPoll?.();
-    try {
-      const token = await pollDeviceToken(
-        {
-          deviceAuthId: userCodeResponse.device_auth_id,
-          userCode,
-        },
-        options.signal,
-      );
-      options.signal?.throwIfAborted();
-      return await options.coordinator.completeDeviceLogin({
-        authorizationCode: token.authorization_code,
-        codeVerifier: token.code_verifier,
-      });
-    } catch (error) {
-      if (error instanceof CodexAuthError && error.kind === 'pending') {
-        continue;
+
+  return pollUntilDeviceAuthorized({
+    intervalMs,
+    deadlineMs: Date.now() + expiresInMs,
+    signal: options.signal,
+    onPoll: options.onPoll,
+    createTimeoutError: () =>
+      new Error('Device-code sign-in timed out. Run sign-in again.'),
+    attempt: async () => {
+      try {
+        const token = await pollDeviceToken(
+          {
+            deviceAuthId: userCodeResponse.device_auth_id,
+            userCode,
+          },
+          options.signal,
+        );
+        options.signal?.throwIfAborted();
+        const session = await options.coordinator.completeDeviceLogin({
+          authorizationCode: token.authorization_code,
+          codeVerifier: token.code_verifier,
+        });
+        return deviceCodeAuthorized(session);
+      } catch (error) {
+        if (error instanceof CodexAuthError && error.kind === 'pending') {
+          return deviceCodePending();
+        }
+        throw error;
       }
-      throw error;
-    }
-  }
-  throw new Error('Device-code sign-in timed out. Run sign-in again.');
+    },
+  });
 }

--- a/src/auth/oauth/deviceCodePoll.ts
+++ b/src/auth/oauth/deviceCodePoll.ts
@@ -9,19 +9,19 @@
 import { setTimeout as defaultSleep } from 'node:timers/promises';
 
 /** Soft continue: keep polling; optionally grow the interval (slow_down). */
-export type DeviceCodePollPending = {
+type DeviceCodePollPending = {
   readonly ok: false;
   /** Extra milliseconds to add to the poll interval (RFC 8628 slow_down). */
   readonly intervalDeltaMs?: number;
 };
 
 /** Authorized: stop polling and return the value. */
-export type DeviceCodePollAuthorized<T> = {
+type DeviceCodePollAuthorized<T> = {
   readonly ok: true;
   readonly value: T;
 };
 
-export type DeviceCodePollAttemptResult<T> =
+type DeviceCodePollAttemptResult<T> =
   DeviceCodePollAuthorized<T> | DeviceCodePollPending;
 
 /** Mark a poll attempt as authorized (fixes generic inference at call sites). */
@@ -41,7 +41,7 @@ export function deviceCodePending(
     : { ok: false, intervalDeltaMs };
 }
 
-export interface DeviceCodePollOptions<T> {
+interface DeviceCodePollOptions<T> {
   /** Initial poll interval in milliseconds. */
   readonly intervalMs: number;
   /** Absolute deadline (epoch ms). */

--- a/src/auth/oauth/deviceCodePoll.ts
+++ b/src/auth/oauth/deviceCodePoll.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared RFC 8628 device-authorization poll loop skeleton.
+ *
+ * Providers own token exchange, error types, and soft-vs-hard failure policy.
+ * This only owns sleep, deadline, optional interval growth, and the continue
+ * decision after each attempt.
+ */
+// Node imports
+import { setTimeout as defaultSleep } from 'node:timers/promises';
+
+/** Soft continue: keep polling; optionally grow the interval (slow_down). */
+export type DeviceCodePollPending = {
+  readonly ok: false;
+  /** Extra milliseconds to add to the poll interval (RFC 8628 slow_down). */
+  readonly intervalDeltaMs?: number;
+};
+
+/** Authorized: stop polling and return the value. */
+export type DeviceCodePollAuthorized<T> = {
+  readonly ok: true;
+  readonly value: T;
+};
+
+export type DeviceCodePollAttemptResult<T> =
+  DeviceCodePollAuthorized<T> | DeviceCodePollPending;
+
+/** Mark a poll attempt as authorized (fixes generic inference at call sites). */
+export function deviceCodeAuthorized<T>(value: T): DeviceCodePollAuthorized<T> {
+  return { ok: true, value };
+}
+
+/**
+ * Mark a poll attempt as still pending. Pass `intervalDeltaMs` for RFC 8628
+ * `slow_down` (extra milliseconds added to the next wait).
+ */
+export function deviceCodePending(
+  intervalDeltaMs?: number,
+): DeviceCodePollPending {
+  return intervalDeltaMs === undefined
+    ? { ok: false }
+    : { ok: false, intervalDeltaMs };
+}
+
+export interface DeviceCodePollOptions<T> {
+  /** Initial poll interval in milliseconds. */
+  readonly intervalMs: number;
+  /** Absolute deadline (epoch ms). */
+  readonly deadlineMs: number;
+  readonly signal?: AbortSignal;
+  /** Called once per poll attempt, after the wait and before the attempt. */
+  readonly onPoll?: () => void;
+  /**
+   * Injectable sleep (tests). Defaults to `node:timers/promises` setTimeout
+   * with optional AbortSignal support.
+   */
+  readonly sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  /** Injectable clock (tests). Defaults to Date.now. */
+  readonly now?: () => number;
+  /**
+   * One token-poll attempt. Return {@link deviceCodeAuthorized} when done, or
+   * {@link deviceCodePending} for soft continues (authorization_pending,
+   * slow_down, transient). Hard failures must throw.
+   */
+  readonly attempt: () => Promise<DeviceCodePollAttemptResult<T>>;
+  /** Factory for the error thrown when the deadline elapses. */
+  readonly createTimeoutError: () => Error;
+  /**
+   * When true (default), check the deadline before each sleep (Codex / xAI).
+   * When false, sleep first then check the deadline before attempting
+   * (Supabase CLI device auth — preserves its historical timing).
+   */
+  readonly checkDeadlineBeforeSleep?: boolean;
+}
+
+/**
+ * Poll until {@link DeviceCodePollOptions.attempt} authorizes, the deadline
+ * elapses, the signal aborts, or a hard error is thrown.
+ */
+export async function pollUntilDeviceAuthorized<T>(
+  options: DeviceCodePollOptions<T>,
+): Promise<T> {
+  const now = options.now ?? Date.now;
+  const sleep =
+    options.sleep ??
+    ((ms: number, signal?: AbortSignal) =>
+      defaultSleep(ms, undefined, { signal }));
+  const checkBefore = options.checkDeadlineBeforeSleep ?? true;
+  let intervalMs = options.intervalMs;
+
+  for (;;) {
+    options.signal?.throwIfAborted();
+
+    if (checkBefore && now() >= options.deadlineMs) {
+      throw options.createTimeoutError();
+    }
+
+    await sleep(intervalMs, options.signal);
+    options.signal?.throwIfAborted();
+
+    if (!checkBefore && now() >= options.deadlineMs) {
+      throw options.createTimeoutError();
+    }
+
+    options.onPoll?.();
+
+    const outcome = await options.attempt();
+    if (outcome.ok) {
+      return outcome.value;
+    }
+    if (outcome.intervalDeltaMs != null && outcome.intervalDeltaMs > 0) {
+      intervalMs += outcome.intervalDeltaMs;
+    }
+  }
+}

--- a/src/auth/xai/xaiDeviceLogin.ts
+++ b/src/auth/xai/xaiDeviceLogin.ts
@@ -4,8 +4,14 @@
  * RFC 8628: the user opens a URL and types a one-time code; we poll the token
  * endpoint until they approve. Host-neutral: the host renders the prompt.
  */
-import { setTimeout as sleep } from 'node:timers/promises';
+// Local imports - oauth
+import {
+  deviceCodeAuthorized,
+  deviceCodePending,
+  pollUntilDeviceAuthorized,
+} from '@auth/oauth/deviceCodePoll';
 
+// Local imports - xai
 import {
   XAI_DEVICE_DEFAULT_EXPIRES_SEC,
   XAI_DEVICE_DEFAULT_INTERVAL_SEC,
@@ -41,7 +47,7 @@ export async function loginWithDeviceCode(
 ): Promise<XaiSession> {
   const device = await requestDeviceCode(options.signal);
   // Floor to 1s so a misbehaving endpoint cannot busy-loop us.
-  let intervalMs = Math.max(
+  const intervalMs = Math.max(
     (device.interval ?? XAI_DEVICE_DEFAULT_INTERVAL_SEC) * 1000,
     1000,
   );
@@ -54,23 +60,33 @@ export async function loginWithDeviceCode(
 
   const expiresInMs =
     (device.expires_in ?? XAI_DEVICE_DEFAULT_EXPIRES_SEC) * 1000;
-  const deadline = Date.now() + expiresInMs;
-  while (Date.now() < deadline) {
-    await sleep(intervalMs, undefined, { signal: options.signal });
-    options.onPoll?.();
-    try {
-      const tokens = await pollDeviceToken(device.device_code, options.signal);
-      options.signal?.throwIfAborted();
-      return await options.coordinator.completeDeviceLogin(tokens);
-    } catch (error) {
-      if (error instanceof XaiAuthError && error.kind === 'pending') {
-        if (error.message === 'slow_down') {
-          intervalMs += XAI_DEVICE_SLOW_DOWN_INCREMENT_SEC * 1000;
+
+  return pollUntilDeviceAuthorized({
+    intervalMs,
+    deadlineMs: Date.now() + expiresInMs,
+    signal: options.signal,
+    onPoll: options.onPoll,
+    createTimeoutError: () =>
+      new Error('Device-code sign-in timed out. Run sign-in again.'),
+    attempt: async () => {
+      try {
+        const tokens = await pollDeviceToken(
+          device.device_code,
+          options.signal,
+        );
+        options.signal?.throwIfAborted();
+        const session = await options.coordinator.completeDeviceLogin(tokens);
+        return deviceCodeAuthorized(session);
+      } catch (error) {
+        if (error instanceof XaiAuthError && error.kind === 'pending') {
+          return deviceCodePending(
+            error.message === 'slow_down'
+              ? XAI_DEVICE_SLOW_DOWN_INCREMENT_SEC * 1000
+              : undefined,
+          );
         }
-        continue;
+        throw error;
       }
-      throw error;
-    }
-  }
-  throw new Error('Device-code sign-in timed out. Run sign-in again.');
+    },
+  });
 }

--- a/src/test-kernel/auth/DeviceCodePoll.vitest.ts
+++ b/src/test-kernel/auth/DeviceCodePoll.vitest.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  deviceCodeAuthorized,
+  deviceCodePending,
+  pollUntilDeviceAuthorized,
+} from '@auth/oauth/deviceCodePoll';
+
+/** Deterministic clock: sleeping advances time, never waits for real timers. */
+function fakeClock(): {
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+  sleeps: number[];
+} {
+  let time = 0;
+  const sleeps: number[] = [];
+  return {
+    now: () => time,
+    sleep: (ms: number) => {
+      sleeps.push(ms);
+      time += ms;
+      return Promise.resolve();
+    },
+    sleeps,
+  };
+}
+
+describe('pollUntilDeviceAuthorized', () => {
+  it('returns the authorized value after soft continues', async () => {
+    const clock = fakeClock();
+    let attempts = 0;
+
+    const value = await pollUntilDeviceAuthorized({
+      intervalMs: 1000,
+      deadlineMs: 10_000,
+      now: clock.now,
+      sleep: clock.sleep,
+      createTimeoutError: () => new Error('timed out'),
+      attempt: async () => {
+        attempts += 1;
+        if (attempts < 3) return deviceCodePending();
+        return deviceCodeAuthorized('token');
+      },
+    });
+
+    expect(value).toBe('token');
+    expect(attempts).toBe(3);
+    expect(clock.sleeps).toEqual([1000, 1000, 1000]);
+  });
+
+  it('grows the interval on slow_down deltas', async () => {
+    const clock = fakeClock();
+    let attempts = 0;
+
+    await pollUntilDeviceAuthorized({
+      intervalMs: 5000,
+      deadlineMs: 60_000,
+      now: clock.now,
+      sleep: clock.sleep,
+      createTimeoutError: () => new Error('timed out'),
+      attempt: async () => {
+        attempts += 1;
+        if (attempts === 1) return deviceCodePending();
+        if (attempts === 2) return deviceCodePending(5000);
+        return deviceCodeAuthorized(true);
+      },
+    });
+
+    // 5s, 5s, then 10s after the slow_down bump.
+    expect(clock.sleeps).toEqual([5000, 5000, 10000]);
+  });
+
+  it('throws the timeout error when the deadline elapses (check before sleep)', async () => {
+    const clock = fakeClock();
+    let attempts = 0;
+
+    await expect(
+      pollUntilDeviceAuthorized({
+        intervalMs: 5000,
+        deadlineMs: 10_000,
+        now: clock.now,
+        sleep: clock.sleep,
+        createTimeoutError: () => new Error('deadline passed'),
+        attempt: async () => {
+          attempts += 1;
+          return deviceCodePending();
+        },
+      }),
+    ).rejects.toThrow('deadline passed');
+
+    // t=0 sleep 5 → attempt; t=5 sleep 5 → attempt; t=10 → timeout before sleep.
+    expect(attempts).toBe(2);
+    expect(clock.sleeps).toEqual([5000, 5000]);
+  });
+
+  it('checks the deadline after sleep when checkDeadlineBeforeSleep is false', async () => {
+    const clock = fakeClock();
+    let attempts = 0;
+
+    await expect(
+      pollUntilDeviceAuthorized({
+        intervalMs: 5000,
+        deadlineMs: 10_000,
+        now: clock.now,
+        sleep: clock.sleep,
+        checkDeadlineBeforeSleep: false,
+        createTimeoutError: () => new Error('expired after wait'),
+        attempt: async () => {
+          attempts += 1;
+          return deviceCodePending();
+        },
+      }),
+    ).rejects.toThrow('expired after wait');
+
+    // sleep 5 → attempt; sleep 5 → t=10 ≥ deadline → timeout (no second attempt).
+    expect(attempts).toBe(1);
+    expect(clock.sleeps).toEqual([5000, 5000]);
+  });
+
+  it('rethrows hard errors from attempt', async () => {
+    const clock = fakeClock();
+
+    await expect(
+      pollUntilDeviceAuthorized({
+        intervalMs: 1000,
+        deadlineMs: 10_000,
+        now: clock.now,
+        sleep: clock.sleep,
+        createTimeoutError: () => new Error('timed out'),
+        attempt: async () => {
+          throw new Error('access_denied');
+        },
+      }),
+    ).rejects.toThrow('access_denied');
+  });
+
+  it('honors AbortSignal before sleeping', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const attempt = vi.fn();
+
+    await expect(
+      pollUntilDeviceAuthorized({
+        intervalMs: 1000,
+        deadlineMs: Date.now() + 60_000,
+        signal: controller.signal,
+        createTimeoutError: () => new Error('timed out'),
+        attempt,
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    expect(attempt).not.toHaveBeenCalled();
+  });
+
+  it('calls onPoll once per attempt after the wait', async () => {
+    const clock = fakeClock();
+    const onPoll = vi.fn();
+    let attempts = 0;
+
+    await pollUntilDeviceAuthorized({
+      intervalMs: 100,
+      deadlineMs: 10_000,
+      now: clock.now,
+      sleep: clock.sleep,
+      onPoll,
+      createTimeoutError: () => new Error('timed out'),
+      attempt: async () => {
+        attempts += 1;
+        if (attempts < 2) return deviceCodePending();
+        return deviceCodeAuthorized(1);
+      },
+    });
+
+    expect(onPoll).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Deduplicates the RFC 8628 device-code **polling loop** across Codex, xAI, and CLI Supabase device sign-in behind a small shared helper in `src/auth/oauth/deviceCodePoll.ts`.

Each provider still owns:
- Token request / exchange APIs
- Provider-specific error types (`CodexAuthError`, `XaiAuthError`) and `instanceof` / kind routing
- Soft-vs-hard failure policy (pending, slow_down, transient HTTP, access_denied, expired_token)

The helper owns only the shared skeleton: sleep → optional heartbeat → attempt → continue or return, with deadline and optional interval growth.

## Issue acceptance gates

Closes #9930

- [x] Shared poll loop extracted under `src/auth/`
- [x] Codex device login uses it (no slow_down today — still none)
- [x] xAI device login uses it (slow_down interval bump preserved)
- [x] Supabase CLI device poll uses it (transient failures, access_denied, expired_token, injectable hooks preserved; historical post-sleep deadline check kept via `checkDeadlineBeforeSleep: false`)
- [x] Provider error types / instanceof routing unchanged
- [x] Tests updated/added and passing

## Single source of truth

`pollUntilDeviceAuthorized` in `src/auth/oauth/deviceCodePoll.ts` owns the loop timing skeleton. Providers return `deviceCodeAuthorized(value)` / `deviceCodePending(intervalDeltaMs?)` from `attempt`.

## Duplication and abstraction budget

Removed three near-identical `while`/`for` loops that each:
1. computed a deadline from `expires_in`
2. slept the poll interval
3. treated pending as continue
4. optionally bumped interval on slow_down
5. threw a timeout error

New abstraction is intentionally thin: no unified token client, no shared error class hierarchy for device poll results.

## Net elements (R6)

| | |
|---|---|
| Files | +2 new (`deviceCodePoll.ts`, `DeviceCodePoll.vitest.ts`); 3 call sites edited |
| Exported symbols | +`pollUntilDeviceAuthorized`, +`deviceCodeAuthorized`, +`deviceCodePending`, +related types |
| Classes/interfaces/enums | +`DeviceCodePollOptions` interface and attempt result types (no classes) |
| Call-site LoC | Codex/xAI/Supabase loops collapsed onto the helper; provider-specific attempt bodies retained |

## Consumer counts (R8)

n/a — no emit path or existing export deleted; new helper has three production consumers (Codex, xAI, Supabase CLI device poll).

## Host impact

Extension: unchanged surface; Codex/xAI device login behavior preserved through shared helper.

Desktop: none.

CLI: Supabase device-code path uses the shared helper; hooks (`fetch`, `sleep`, `now`, `signal`) and richer error semantics unchanged.

## Scheduled refactoring

None — full three-way unify shipped.

## Validation

- `npm test -- src/test-kernel/auth/DeviceCodePoll.vitest.ts src/test-kernel/auth/CodexDeviceLogin.vitest.ts src/test-kernel/cli/DeviceCodeAuth.vitest.ts` (20 tests pass)
- `npm run typecheck:workspace`
- `npm run typecheck:cli`
- eslint on changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors authentication polling across CLI and Codex/xAI flows; behavior is intended to be preserved but timing and error routing are easy to regress without the new tests.
> 
> **Overview**
> Introduces **`pollUntilDeviceAuthorized`** in `src/auth/oauth/deviceCodePoll.ts` as the shared RFC 8628 polling skeleton (sleep, deadline, optional `slow_down` interval growth, abort). Codex, xAI, and CLI Supabase device sign-in **replace** their local `while`/`for` loops with this helper and supply provider-specific **`attempt`** bodies that return **`deviceCodeAuthorized`** / **`deviceCodePending`**.
> 
> Provider-specific behavior stays at the call sites: Codex/xAI still map pending errors via `CodexAuthError` / `XaiAuthError`; xAI **`slow_down`** bumps are passed through **`intervalDeltaMs`**. The Supabase CLI path keeps transient HTTP tolerance, injectable **`sleep`/`now`/`fetch`**, and historical timing via **`checkDeadlineBeforeSleep: false`**.
> 
> Adds **`DeviceCodePoll.vitest.ts`** for the helper (deadline ordering, slow_down, abort, **`onPoll`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f6b769726e6fa6ed4c49f67645298a91fcae119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->