### PR TITLE
Surface workflow subagent failures in the status band

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -3,9 +3,11 @@
 
 import { Box, Text } from 'ink';
 
+import { COLOR_WARNING } from '@cli/tui/ui/colors';
 import { AgentCategory } from '@shared/schemas';
 import {
   formatWorkflowPhaseHeading,
+  workflowCallFailureTally,
   workflowPhaseCallProgress,
 } from '@shared/copy/workflowCall';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
@@ -129,14 +131,30 @@ function renderConversationPaneEntry({
 }
 
 /**
+ * One colored fragment of the workflow status band. Neutral progress is
+ * `muted` (the band's prior dim styling); a failure tally is `warning` so a
+ * degraded run does not read as a clean one. Separators are added by the
+ * renderer, never stored here, so the data stays a clean logical list.
+ */
+export interface WorkflowStatusSegment {
+  readonly text: string;
+  readonly tone: 'muted' | 'warning';
+}
+
+/**
  * One-line workflow status band. Phase progress leads so it survives
  * `truncate-end` on a narrow terminal. The running `done/total` lives here
  * rather than on the `◆` divider because that divider prints once into
  * scrollback and can never be rewritten.
+ *
+ * A whole-run failure tally is appended in a warning tone the moment any call
+ * fails. The engine deliberately keeps the run going after a failed subagent
+ * (it resolves to `null`), so the lifecycle stays `completed` — but the status
+ * band must not let that read as a clean run.
  */
 export function workflowRunStatusSummary(
   slice: StreamSlice | undefined,
-): string | undefined {
+): readonly WorkflowStatusSegment[] | undefined {
   if (slice?.category !== AgentCategory.Workflow) return undefined;
   const phase = slice.entries.findLast((entry) => entry.role === 'phase');
   const { done, total } = workflowPhaseCallProgress(
@@ -148,11 +166,28 @@ export function workflowRunStatusSummary(
         )
       : [],
   );
-  const segments = [
-    ...(phase ? [formatWorkflowPhaseHeading(phase)] : []),
-    ...(total > 0 ? [`${done}/${total} done`] : []),
-  ];
-  return segments.length > 0 ? segments.join(' · ') : undefined;
+  const segments: WorkflowStatusSegment[] = [];
+  if (phase) {
+    segments.push({ text: formatWorkflowPhaseHeading(phase), tone: 'muted' });
+  }
+  if (total > 0) {
+    segments.push({ text: `${done}/${total} done`, tone: 'muted' });
+  }
+  // Surface failures only once the band has a phase/progress anchor, so a
+  // stray phase-less failed call does not invent a band on its own. The tally
+  // is whole-run, so a failure persists after the run advances past its phase
+  // (unlike the current-phase done/total).
+  if (segments.length > 0) {
+    const { failed } = workflowCallFailureTally(
+      slice.entries.flatMap((entry) =>
+        entry.role === 'workflowTask' ? [entry.task] : [],
+      ),
+    );
+    if (failed > 0) {
+      segments.push({ text: `${failed} failed`, tone: 'warning' });
+    }
+  }
+  return segments.length > 0 ? segments : undefined;
 }
 
 export function ConversationPane(
@@ -217,10 +252,18 @@ export function ConversationPane(
   // stealing rows reserved for the footer chrome.
   return (
     <Box flexDirection="column" height={visibleRows} overflowY="hidden">
-      {metadataRows > 0 ? (
+      {workflowMetadata !== undefined && metadataRows > 0 ? (
         <Box height={1} width={metadataWidth} overflowY="hidden">
-          <Text dimColor wrap="truncate-end">
-            {workflowMetadata}
+          <Text wrap="truncate-end">
+            {workflowMetadata.map((segment, index) => (
+              <Text
+                key={index}
+                dimColor={segment.tone === 'muted'}
+                color={segment.tone === 'warning' ? COLOR_WARNING : undefined}
+              >
+                {index > 0 ? ` · ${segment.text}` : segment.text}
+              </Text>
+            ))}
           </Text>
         </Box>
       ) : null}

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -136,7 +136,7 @@ function renderConversationPaneEntry({
  * degraded run does not read as a clean one. Separators are added by the
  * renderer, never stored here, so the data stays a clean logical list.
  */
-export interface WorkflowStatusSegment {
+interface WorkflowStatusSegment {
   readonly text: string;
   readonly tone: 'muted' | 'warning';
 }

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -5,7 +5,7 @@ import { Box, Text, useInput, useWindowSize } from 'ink';
 import { useMemo } from 'react';
 
 // Local imports - shared stream state
-import { COLOR_HINT } from '@cli/tui/ui/colors';
+import { COLOR_HINT, COLOR_WARNING } from '@cli/tui/ui/colors';
 import {
   POINTER,
   STATUS_DIAMOND,
@@ -26,6 +26,7 @@ import {
 } from '@shared/schemas';
 import {
   formatWorkflowPhaseHeading,
+  workflowCallFailureTally,
   workflowPhaseCallProgress,
   type WorkflowPhaseHeading,
 } from '@shared/copy/workflowCall';
@@ -377,9 +378,8 @@ function WorkflowDashboard({
       value: workflowTaskListValue(entry.id),
     })),
   ]);
-  const { done, total } = workflowPhaseCallProgress(
-    tasks.map((entry) => entry.task),
-  );
+  const calls = tasks.map((entry) => entry.task);
+  const { done, total } = workflowPhaseCallProgress(calls);
   const contentRows =
     maxRows === undefined ? undefined : Math.max(0, maxRows - 2);
 
@@ -410,6 +410,7 @@ function WorkflowDashboard({
     return null;
   }
   const heading = `${model.root.agent ?? 'Workflow'} · ${done}/${total} done`;
+  const { failed } = workflowCallFailureTally(calls);
   const renderTask = (
     item: SelectItem<ChildListValue>,
     state: { readonly focused: boolean },
@@ -460,6 +461,9 @@ function WorkflowDashboard({
     >
       <Text bold wrap="truncate-end">
         {heading}
+        {failed > 0 ? (
+          <Text bold color={COLOR_WARNING}>{` · ${failed} failed`}</Text>
+        ) : null}
       </Text>
       {wide ? (
         <Box flexDirection="row" height={contentRows} minWidth={0}>

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -45,6 +45,22 @@ export function workflowPhaseCallProgress(
   };
 }
 
+/**
+ * Whole-run failure tally shared by every host, so the terminal and the
+ * progress view can never disagree on whether a workflow had failed calls.
+ * Mirrors `workflowPhaseCallProgress` in taking a caller-selected call list.
+ *
+ * `WorkflowCallProgress` carries no `cancelled` variant: a cancelled attempt
+ * surfaces in the transcript as a `failed` call, so this count already
+ * captures it. Snapshot consumers (`/executions`) read `counts.failed` /
+ * `counts.cancelled` directly and do not need this helper.
+ */
+export function workflowCallFailureTally(
+  calls: readonly WorkflowCallProgress[],
+): { readonly failed: number } {
+  return { failed: calls.filter((call) => call.status === 'failed').length };
+}
+
 /** One workflow phase as its emitter names and orders it. */
 export interface WorkflowPhaseHeading {
   readonly phaseLabel: string;

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -227,7 +227,85 @@ describe('CLI child list display model', () => {
 
     // Only the current phase's tasks are folded, and the phase segment leads so
     // it survives truncation on a narrow terminal.
-    expect(workflowRunStatusSummary(slice)).toBe('Map (1/3) · 1/2 done');
+    expect(
+      workflowRunStatusSummary(slice)?.map((segment) => segment.text),
+    ).toEqual(['Map (1/3)', '1/2 done']);
+    expect(
+      workflowRunStatusSummary(slice)?.map((segment) => segment.tone),
+    ).toEqual(['muted', 'muted']);
+  });
+
+  it('appends a warning failure tally when any call has failed', () => {
+    const slice = workflowAgentSlice('partial-failure', {
+      files: files(['paper.tex']),
+      entries: [
+        phaseEntry('phase-map', 'Map', { phaseIndex: 0, phaseTotal: 1 }),
+        workflowTaskEntry(
+          'task-ok',
+          'Finished: Map the seams',
+          {
+            id: 'seams',
+            label: 'Map the seams',
+            phase: 'Map',
+            status: 'completed',
+            durationMs: 1_000,
+          },
+          true,
+        ),
+        workflowTaskEntry('task-bad', 'Failed: Read the contracts', {
+          id: 'contracts',
+          label: 'Read the contracts',
+          phase: 'Map',
+          status: 'failed',
+          error: 'Runner stopped.',
+        }),
+      ],
+    });
+
+    // A failed call is terminal, so it still counts toward `done` — the
+    // warning-toned failure tally is what distinguishes a degraded run from a
+    // clean one at the status level.
+    expect(
+      workflowRunStatusSummary(slice)?.map((segment) => segment.text),
+    ).toEqual(['Map (1/1)', '2/2 done', '1 failed']);
+    expect(
+      workflowRunStatusSummary(slice)?.map((segment) => segment.tone),
+    ).toEqual(['muted', 'muted', 'warning']);
+  });
+
+  it('tallys failures across the whole run, not just the current phase', () => {
+    // A failure in an earlier phase must persist in the band after the run
+    // advances, unlike the current-phase done/total. The whole-run tally keeps
+    // it visible.
+    const slice = workflowAgentSlice('cross-phase-failure', {
+      files: files(['paper.tex']),
+      entries: [
+        phaseEntry('phase-write', 'Write', { phaseIndex: 1, phaseTotal: 2 }),
+        workflowTaskEntry('task-old-bad', 'Failed: Map the seams', {
+          id: 'seams',
+          label: 'Map the seams',
+          phase: 'Map',
+          status: 'failed',
+          error: 'Runner stopped.',
+        }),
+        workflowTaskEntry('task-now', 'Running: Draft', {
+          id: 'draft',
+          label: 'Draft',
+          phase: 'Write',
+          status: 'running',
+        }),
+        workflowTaskEntry('task-now2', 'Running: Edit', {
+          id: 'edit',
+          label: 'Edit',
+          phase: 'Write',
+          status: 'running',
+        }),
+      ],
+    });
+
+    expect(
+      workflowRunStatusSummary(slice)?.map((segment) => segment.text),
+    ).toEqual(['Write (2/2)', '0/2 done', '1 failed']);
   });
 
   it('does not invent a phase fold for phase-less tasks', () => {
@@ -280,7 +358,9 @@ describe('CLI child list display model', () => {
       ],
     });
 
-    expect(workflowRunStatusSummary(slice)).toBe('Map (1/2) · 0/1 done');
+    expect(
+      workflowRunStatusSummary(slice)?.map((segment) => segment.text),
+    ).toEqual(['Map (1/2)', '0/1 done']);
   });
 
   it('prioritizes live workflow activity over metadata in a one-row viewport', async () => {

--- a/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   formatWorkflowCallMetadataParts,
   formatWorkflowCallLine,
+  workflowCallFailureTally,
   workflowPhaseCallProgress,
 } from '@shared/copy/workflowCall';
 
@@ -59,6 +60,27 @@ describe('workflow call copy', () => {
 
   it('counts an empty phase as no work rather than complete', () => {
     expect(workflowPhaseCallProgress([])).toEqual({ done: 0, total: 0 });
+  });
+
+  it('tallys no failures for a clean or empty run', () => {
+    expect(workflowCallFailureTally([])).toEqual({ failed: 0 });
+    expect(
+      workflowCallFailureTally([
+        { id: 'a', label: 'A', status: 'completed', durationMs: 1 },
+        { id: 'b', label: 'B', status: 'running' },
+      ]),
+    ).toEqual({ failed: 0 });
+  });
+
+  it('tallys only failed calls across a mixed run', () => {
+    expect(
+      workflowCallFailureTally([
+        { id: 'a', label: 'A', status: 'completed', durationMs: 1 },
+        { id: 'b', label: 'B', status: 'failed', error: 'boom' },
+        { id: 'c', label: 'C', status: 'skipped', reason: 'not-reached' },
+        { id: 'd', label: 'D', status: 'failed', error: 'also boom' },
+      ]),
+    ).toEqual({ failed: 2 });
   });
 
   it('counts every terminal status as done, not just completions', () => {


### PR DESCRIPTION
## Problem

When a workflow subagent fails, the failure is recorded on the call row (snapshot `status: failed`, `counts.failed++`, and the focused-detail row already shows a red cross) — but the **top-level workflow status band does not reflect it**. The band shows only the phase heading and `done/total`, so a run with failed subagents looks indistinguishable from a clean one at the status level. Users read this as "it didn't notice the failure" / "still running," which is confusing.

This is surfaced (not caused) by the observability work in #9918. The behavior is intended at the engine level: a failed subagent resolves to `null` and the workflow lifecycle tracks *orchestration* outcome only (completed/failed/cancelled), never *agent* outcome. So the lifecycle stays `completed` even when agents failed.

## Approach

**Surface failure counts as a derived display signal — do not change the lifecycle enum or collapse `completed` → `failed`.**

Folding agent outcome into the lifecycle (the tempting one-line fix) would mark every fan-out workflow that filters nulls as "failed," and would require a Zod enum change plus invariant/consumer updates for what is really a display problem. The failure data already exists everywhere it's needed; it just wasn't shown at the status level. So the fix keeps `lifecycle` about orchestration and adds a whole-run failure tally segment to the status band, in a warning tone, the moment any call fails — live mid-run and at completion.

## Changes

- **`src/shared/copy/workflowCall.ts`** — `workflowCallFailureTally(calls)`: pure whole-run tally shared by every host (next to the existing `workflowPhaseCallProgress`). `WorkflowCallProgress` has no `cancelled` variant in the transcript projection (a cancelled attempt surfaces as `failed`), so this count already captures it.
- **`packages/cli/.../ConversationPane.tsx`** — `workflowRunStatusSummary` now returns tone-tagged segments instead of a plain string. Appends a warning-toned `· {N} failed` segment once the band has a phase/progress anchor (a stray phase-less failed call won't invent a band). Tally is whole-run, so the failure persists after the run advances past its phase (unlike the current-phase `done/total`). Phase progress still leads so it survives `truncate-end` on a narrow terminal.
- **`packages/cli/.../SubagentList.tsx`** — workflow dashboard heading gets the same warning-toned `· {N} failed` suffix via the shared helper, so the two surfaces can't disagree.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- Tests pass: `workflowCallFailureTally` unit tests (clean/empty/mixed) + ConversationPane band tests (failure segment appears with warning tone, tallys across phases, absent on clean runs). Existing band assertions updated for the structured-segment return type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation and shared copy helpers only; no changes to workflow lifecycle, auth, or persistence.
> 
> **Overview**
> Workflow runs that keep orchestration **completed** after subagent failures no longer look “clean” in the CLI: the live status band and workflow dashboard heading now append a **warning-toned** `· N failed` when any workflow call has `status: 'failed'`.
> 
> A shared **`workflowCallFailureTally`** helper (alongside **`workflowPhaseCallProgress`**) counts failures across the caller’s call list so the conversation pane and subagent list stay aligned. **`workflowRunStatusSummary`** now returns **tone-tagged segments** (`muted` vs `warning`) instead of a single dim string, and only adds the failure segment when the band already has phase/progress anchors—the tally is **whole-run**, so an earlier-phase failure still shows after the run advances.
> 
> Orchestration lifecycle enums are unchanged; this is display-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc418a21faf92aacc1ce3c575c821038f64025f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->