### PR TITLE
fix(progressView): unify stream status wording and feedback field sizing

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -35,13 +35,15 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import {
   STREAM_PHASE,
-  WORKFLOW_TASK_STATUS_LABEL,
   runIdentityDisplayName,
   type ActiveChildInfo,
   type InquiryThreadUpdatedEvent,
 } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { formatPhaseStageLabel } from '@shared/streams/streamStatusDisplay';
+import {
+  formatPhaseStageLabel,
+  formatStreamStatusLabel,
+} from '@shared/streams/streamStatusDisplay';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { ProgressEvents } from '../events';
@@ -530,14 +532,43 @@ function getTaskIcon(child: ActiveChildInfo): TeXRAIconName {
 }
 
 /**
- * Status badge for a background-task row. A retained subagent can briefly
- * keep its last in-flight phase while the terminal status catches up; show
- * that phase rather than falsely reporting success. Processes have no child
- * status source, so their retained rows use the terminal fallback below.
+ * Badge fill for a stream lifecycle phase. Matches the stream-tab rail/icon
+ * palette: green while active, brand/blue while idle, red on failure, and
+ * neutral for user stops (and unknown finished rows that must not claim
+ * success).
+ */
+function streamStatusBadgeVariant(
+  status: string | undefined,
+): 'neutral' | 'brand' | 'success' | 'danger' {
+  switch (status) {
+    case STREAM_PHASE.RUNNING:
+      return 'success';
+    case STREAM_PHASE.WAITING:
+      return 'brand';
+    case STREAM_PHASE.FAILED:
+      return 'danger';
+    case STREAM_PHASE.COMPLETED:
+      return 'success';
+    case STREAM_PHASE.CANCELLED:
+    default:
+      return 'neutral';
+  }
+}
+
+/**
+ * Status badge for a background-task row. Wording and color come from the
+ * same stream-lifecycle vocabulary as stream tabs / the progress header
+ * (`formatStreamStatusLabel` · `progressHeader`), so "Running / Idle /
+ * Completed / Stopped / Error" never diverge between the two surfaces.
+ *
+ * A retained subagent can briefly keep its last in-flight phase while the
+ * terminal status catches up; show that phase rather than falsely reporting
+ * success. Processes have no child status source, so their retained rows use
+ * the terminal fallback below.
  */
 function taskStatusBadge(child: ActiveChildInfo): {
   readonly text: string;
-  readonly variant: 'neutral' | 'warning' | 'success' | 'danger';
+  readonly variant: 'neutral' | 'brand' | 'success' | 'danger';
 } {
   // Membership is decided by `finishedAt` presence alone (see the schema
   // doc); the lagging display `status` may only soften HOW a retained
@@ -547,38 +578,33 @@ function taskStatusBadge(child: ActiveChildInfo): {
     (child.status === STREAM_PHASE.RUNNING ||
       child.status === STREAM_PHASE.WAITING);
   if (child.finishedAt === undefined || subagentStatusStillInFlight) {
-    return child.status === STREAM_PHASE.WAITING
-      ? {
-          text: WORKFLOW_TASK_STATUS_LABEL.waiting,
-          variant: 'neutral',
-        }
-      : {
-          text: WORKFLOW_TASK_STATUS_LABEL.running,
-          variant: 'warning',
-        };
+    const status =
+      child.status === STREAM_PHASE.WAITING
+        ? STREAM_PHASE.WAITING
+        : STREAM_PHASE.RUNNING;
+    return {
+      text: formatStreamStatusLabel(status, { style: 'progressHeader' }),
+      variant: streamStatusBadgeVariant(status),
+    };
   }
   switch (child.status) {
     case STREAM_PHASE.FAILED:
-      return {
-        text: WORKFLOW_TASK_STATUS_LABEL.failed,
-        variant: 'danger',
-      };
     case STREAM_PHASE.CANCELLED:
-      return {
-        text: WORKFLOW_TASK_STATUS_LABEL.cancelled,
-        variant: 'neutral',
-      };
     case STREAM_PHASE.COMPLETED:
       return {
-        text: WORKFLOW_TASK_STATUS_LABEL.completed,
-        variant: 'success',
+        text: formatStreamStatusLabel(child.status, {
+          style: 'progressHeader',
+        }),
+        variant: streamStatusBadgeVariant(child.status),
       };
     default:
       // Left the roster without a terminal status ever arriving. It did
       // finish, but claiming success would render a failed command green;
-      // say only what is known.
+      // say only what is known — use the completed word with a neutral fill.
       return {
-        text: WORKFLOW_TASK_STATUS_LABEL.completed,
+        text: formatStreamStatusLabel(STREAM_PHASE.COMPLETED, {
+          style: 'progressHeader',
+        }),
         variant: 'neutral',
       };
   }

--- a/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -102,7 +102,8 @@ export abstract class BaseFeedbackPanel<
           id="feedback-input"
           class=${inputClass}
           placeholder="Optional — this is sent back to the agent"
-          rows="3"
+          rows="2"
+          resize="vertical"
           data-feedback-input
         ></wa-textarea>
       </div>

--- a/src/shared/styles/requestPanelSharedStyles.ts
+++ b/src/shared/styles/requestPanelSharedStyles.ts
@@ -352,8 +352,46 @@ export const requestPanelSharedStyles: CSSResult = css`
     font-size: var(--font-size-sm);
   }
 
+  /* Prose feedback — same sizing contract as FollowUpInput's composer
+     (#9773): rest at two lines, grow with content, keep a vertical drag
+     handle. The shared formControlStyles skin is for mono editors (6rem
+     floor, 1px block padding, grid-centered), which left empty white
+     bands above/below a short rejection note. Mirror the follow-up
+     textarea rules so the two prose boxes stay in lockstep. */
   :is(${FEEDBACK_INPUTS}) {
+    display: block;
+    min-width: 0;
     width: 100%;
+    box-sizing: border-box;
+    line-height: var(--line-height-relaxed);
+    height: auto;
+    --textarea-min-height: calc(2lh + var(--wa-space-xs) + var(--wa-space-3xs));
+    --textarea-max-height: clamp(var(--textarea-min-height), 24vh, 10rem);
+  }
+
+  /* base is deprecated for textarea-wrapper (same node); style both so a
+     WA rename cannot reintroduce the centered empty bands. */
+  :is(${FEEDBACK_INPUTS})::part(textarea-wrapper),
+  :is(${FEEDBACK_INPUTS})::part(base) {
+    align-items: start;
+    min-height: var(--textarea-min-height);
+  }
+
+  :is(${FEEDBACK_INPUTS})::part(textarea) {
+    field-sizing: content;
+    width: 100%;
+    height: auto;
+    min-height: var(--textarea-min-height);
+    max-height: var(--textarea-max-height);
+    padding: var(--wa-space-xs) var(--wa-space-s) var(--wa-space-3xs);
+    box-sizing: border-box;
+    overflow-x: hidden;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    font-family: var(--wa-font-family-body);
+    font-size: var(--font-size);
+    line-height: var(--line-height-relaxed);
   }
 
   /* Carousel navigation for multiple external inquiries (rendered directly by

--- a/src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts
+++ b/src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts
@@ -128,7 +128,8 @@ describe('background-tasks-panel', () => {
     const badges = [...shadow.querySelectorAll('wa-badge.task-status')].map(
       (node) => node.textContent,
     );
-    expect(badges).toEqual(['Running', 'Finished']);
+    // Same progressHeader vocabulary as stream tabs (Completed, not Finished).
+    expect(badges).toEqual(['Running', 'Completed']);
     expect(shadow.textContent).not.toContain('completed</em>');
     expect(shadow.textContent).not.toMatch(/All \d+ subagents completed/);
 
@@ -187,7 +188,50 @@ describe('background-tasks-panel', () => {
 
     const badge = element.shadowRoot?.querySelector('wa-badge.task-status');
     expect(badge?.textContent).toBe('Running');
-    expect(badge?.getAttribute('variant')).toBe('warning');
+    // Running uses the stream-tab success green, not the workflow warning yellow.
+    expect(badge?.getAttribute('variant')).toBe('success');
+
+    element.remove();
+  });
+
+  it('uses the same lifecycle wording as stream tabs for terminal rows', async () => {
+    const element = await mountPanel([
+      subagentRow({
+        executionId: 'done',
+        status: 'completed',
+        finishedAt: 1_000,
+      }),
+      subagentRow({
+        executionId: 'stopped',
+        agentName: 'stopped-agent',
+        status: 'cancelled',
+        finishedAt: 1_000,
+      }),
+      subagentRow({
+        executionId: 'failed',
+        agentName: 'failed-agent',
+        status: 'failed',
+        finishedAt: 1_000,
+      }),
+      subagentRow({
+        executionId: 'idle',
+        agentName: 'idle-agent',
+        status: 'waiting',
+      }),
+    ]);
+
+    const badges = [
+      ...(element.shadowRoot?.querySelectorAll('wa-badge.task-status') ?? []),
+    ].map((node) => ({
+      text: node.textContent,
+      variant: node.getAttribute('variant'),
+    }));
+    expect(badges).toEqual([
+      { text: 'Completed', variant: 'success' },
+      { text: 'Stopped', variant: 'neutral' },
+      { text: 'Error', variant: 'danger' },
+      { text: 'Idle', variant: 'brand' },
+    ]);
 
     element.remove();
   });


### PR DESCRIPTION
## Summary

- Align Background tasks status badges with stream-tab lifecycle wording (`Running` / `Idle` / `Completed` / `Stopped` / `Error`) via `formatStreamStatusLabel(..., { style: 'progressHeader' })` and matching badge colors.
- Size rejection feedback textareas like the follow-up composer (#9773): two-line rest height, `field-sizing: content`, body type, start-aligned wrapper — removes empty white bands above/below short notes.

## Test plan

- [x] `npm test -- src/test-kernel/progressView/BackgroundTasksPanel.vitest.ts`
- [ ] Progress view: open a run with background subagents; confirm badge wording matches stream-tab tooltips (`Completed` not `Finished`, `Stopped` not `Cancelled`).
- [ ] Progress view: reject with feedback; confirm the field rests at ~2 lines with no empty white strips, grows with content, and remains vertically resizable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Progress-view UI consistency and textarea styling only; no backend or auth changes. Tests updated for badge text and variants.
> 
> **Overview**
> **Background tasks** status badges now use the same labels and colors as stream tabs and the progress header (`Running` / `Idle` / `Completed` / `Stopped` / `Error` via `formatStreamStatusLabel` with `progressHeader`), replacing workflow-specific strings like `Finished` and warning-yellow for running. Badge variants follow the stream-tab palette (e.g. running → success green).
> 
> **Rejection feedback** textareas match the follow-up composer: two-line rest height, vertical resize, `field-sizing: content`, and shared CSS in `requestPanelSharedStyles` so short notes no longer show empty bands from the mono form-control skin. `BaseFeedbackPanel` sets `rows="2"` and `resize="vertical"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70fe6bf5c5e23be19310c597082bea6d9c6308ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->