### PR TITLE
docs: PRD for transcript, persistence, and projection architecture in long-lived sessions

### DIFF
--- a/docs/dev/audits/2026-08-10-long-lived-session-memory-investigation.md
+++ b/docs/dev/audits/2026-08-10-long-lived-session-memory-investigation.md
@@ -143,7 +143,7 @@ At a 16 ms cadence, transcript synchronization can create/recreate:
 - a `Set` of dashboard IDs;
 - another filtered array.
 
-The `filter -> slice -> map -> new Set` chain around lines 954-959 fits the final `Array.map` then `Set` frames from `error8`. `error5` also reports `Array.map` and `Array.prototype.reverse`, consistent with this general projection/render family.
+The `filter -> slice -> map -> new Set` chain at lines 1021-1026 fits the final `Array.map` then `Set` frames from `error8`. `error5` also reports `Array.map` and `Array.prototype.reverse`, consistent with this general projection/render family.
 
 This likely creates large temporary allocation pressure proportional to total resident transcript history rather than to the new delta. Some rendered entries are then retained by TUI signals and static transcript state.
 
@@ -194,7 +194,7 @@ The CLI status subscriber depends on later projection or focus changes to set `r
 
 ### Finding 6: process-global task-group projections outlive transcript eviction
 
-**Location:** `packages/cli/src/chat/tui/state/subscribeStreamLog.ts:682-710`
+**Location:** `packages/cli/src/chat/tui/state/subscribeStreamLog.ts:681-710`
 
 `TASK_GROUP_PROJECTIONS` is process-global. It is cleared only by whole-CLI reset or explicit child removal. Evicting a stream log does not clear its task projection. The projection retains original group-entry objects in `applied`, plus working/snapshot representations.
 
@@ -204,7 +204,7 @@ This is a genuine cross-stream retention leak. It may not explain 4 GB alone, bu
 
 **Candidate remediation:** tie projection lifecycle to stream eviction/removal, or retain only minimal group version metadata.
 
-**Verification (2026-08-10, code-confirmed — severity downgraded):** the structural facts hold (`TASK_GROUP_PROJECTIONS` at `subscribeStreamLog.ts:682` is module-level; cleared only by the reset hook (`:683`) or `.delete()` on explicit `removeStream` (`:796` via `isChildStreamRemoved`); eviction at `:996` → `requestEviction` does not touch it). However, "defeats transcript eviction" is overstated. `requestEviction` (`StreamLogStore.ts:473-504`) sets `state.log = undefined`, which **does** release the heavy per-message transcript (model responses, tool output, user text). The leaked `applied` map (`:704`) retains only `GROUP_START`/`GROUP_END` boundary entries — the loop at `:695-701` filters to those — whose `data` payload is small scalars (`GroupLogPayload`: status, kind, index, total, name, endTime). Heavy entries are not retained. The leak also self-heals: on re-sync, rehydrated entries are new objects, so the identity check at `:702` fails and `:704` overwrites stale references. This is a minor structural nit, not a material 4 GB contributor; a fix here would not cut elements that matter. Deprioritize relative to Finding 1.
+**Verification (2026-08-10, code-confirmed — severity downgraded):** the structural facts hold (`TASK_GROUP_PROJECTIONS` at `subscribeStreamLog.ts:681` is module-level; cleared only by the reset hook (`:683`) or `.delete()` on explicit `removeStream` (`:796` via `isChildStreamRemoved`); eviction at `:996` → `requestEviction` does not touch it). However, "defeats transcript eviction" is overstated. `requestEviction` (`StreamLogStore.ts:473-504`) sets `state.log = undefined`, which **does** release the heavy per-message transcript (model responses, tool output, user text). The leaked `applied` map (`:704`) retains only `GROUP_START`/`GROUP_END` boundary entries — the loop at `:695-701` filters to those — whose `data` payload is small scalars (`GroupLogPayload`: status, kind, index, total, name, endTime). Heavy entries are not retained. The leak also self-heals: on re-sync, rehydrated entries are new objects, so the identity check at `:702` fails and `:704` overwrites stale references. This is a minor structural nit, not a material 4 GB contributor; a fix here would not cut elements that matter. Deprioritize relative to Finding 1.
 
 ### Finding 7: streaming text has duplicate retention and superlinear copying
 

--- a/docs/dev/audits/2026-08-10-long-lived-session-memory-investigation.md
+++ b/docs/dev/audits/2026-08-10-long-lived-session-memory-investigation.md
@@ -1,0 +1,311 @@
+# Long-lived multi-agent session memory investigation
+
+**Status:** investigation. No remediation implemented. Findings 1 and 6 were verified against code on 2026-08-10; see the per-finding verification notes. Finding 1 is confirmed (and its fix surface is narrower than originally proposed); Finding 6's severity is downgraded. The remaining findings still require a heap snapshot to prove dominance.
+
+**Scope:** recurring Node/V8 out-of-memory failures in long-lived TeXRA CLI sessions with many subagents. This report distinguishes retained JavaScript heap from persistent on-disk artifacts. It is written as a handoff for a deeper architecture review.
+
+## Executive summary
+
+Three failures (`errorLogs/error4.txt`, `error5.txt`, and `error8.txt`) ended with:
+
+```text
+FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
+```
+
+All failed near Node's approximately 4 GB old-space limit. The best current explanation is **unbounded process-wide retention combined with allocation-heavy TUI projections**, not a single active agent response, a single workflow, or LaTeX/PDF output files.
+
+The strongest concrete code issue is that startup currently hydrates and retains a full sidecar `StreamRecord` for **every historical transcript in the workspace**. In the affected `TNLean` workspace, that means 1,923 stream IDs. Additional strong candidates are the TUI's whole-transcript re-projection on a 16 ms cadence, unbounded static terminal scrollback representations, and retention structures not tied to central transcript eviction.
+
+A heap snapshot is still required to prove the dominant retaining path. The evidence is sufficient to prioritize explicit byte-budgeted residency and incremental projections over raising Node's heap limit or deleting build artifacts.
+
+## Incident evidence
+
+### OOM logs
+
+All three available logs report V8 being unable to recover space after GC near a 4 GB heap:
+
+| Log                    | Approximate GC clock at failure | Final error                               |
+| ---------------------- | ------------------------------: | ----------------------------------------- |
+| `errorLogs/error4.txt` |         128,305 s, about 35.6 h | ineffective mark-compacts near heap limit |
+| `errorLogs/error5.txt` |         116,404 s, about 32.3 h | ineffective mark-compacts near heap limit |
+| `errorLogs/error8.txt` |         167,824 s, about 46.6 h | ineffective mark-compacts near heap limit |
+
+`error8.txt` displayed a run duration of `1h 3m`, 154k/500k tokens, and 3 subagents. That displayed duration does **not** equal Node process lifetime. The GC clock shows the process had lived for about 46.6 hours, consistent with gradual accumulation across sessions or runs inside a long-lived process.
+
+The final `error8` GC messages included roughly:
+
+```text
+4030.2 MB -> 3998.3 MB
+4004.6 MB -> 3972.6 MB
+```
+
+The native stack includes `Array.map` and `Set` construction. Those frames identify the final failed allocation, not necessarily the object graph retaining the preceding gigabytes.
+
+### The active run was not large enough to explain 4 GB
+
+Inspection of the exact `error8` root context found approximately:
+
+- root stream log: 375 entries, about 602 KB;
+- root persisted flow: about 126 KB;
+- listed child execution directories: at most about 684 KB each.
+
+Therefore, the active workflow alone cannot explain the failure. The relevant state is process-wide retained history and/or repeated projection of it.
+
+## Affected persistent workspace: TNLean
+
+The principal workspace is:
+
+```text
+~/.texra/workspace-storage/TNLean-ad72a6a8
+```
+
+Its total persisted size is approximately **2.7 GB**:
+
+| Area                  |   Size |                       Count | Interpretation                                            |
+| --------------------- | -----: | --------------------------: | --------------------------------------------------------- |
+| `streamLogs/`         | 991 MB |                 1,922 files | canonical transcript records                              |
+| `executions/`         | 1.7 GB | 2,270 execution directories | durable execution inputs, outputs, records, and artifacts |
+| `streamData/`         |  22 MB |                 5,274 files | stream sidecars                                           |
+| `streamLogSummaries/` | 7.5 MB |                 1,922 files | lightweight transcript summaries                          |
+| `recordings/`         | 1.8 MB |                     2 files | recordings                                                |
+
+Other workspaces are much smaller. Across 438 workspaces, total storage is about 5.27 GB; TNLean alone is 2.70 GB, MIPStarRE is 1.50 GB, and coauthor is 0.68 GB. The top three account for about 93% of retained storage.
+
+This persistent size is evidence of an unusually large historical workload. It is **not proof that 2.7 GB is resident in V8**. The code must be examined to see which pieces are eagerly parsed, cached, copied, or re-projected.
+
+### Important non-cause: LaTeX/PDF artifacts
+
+The execution tree has generated PDFs, TeX, build logs, and intermediate artifacts. Some PDFs are physically duplicated between compiler output, `output/rN`, and `output/latest`. That is a disk-efficiency issue, but it is not a credible direct cause of the Node OOM unless the process reads and retains their bytes. This investigation deliberately does not treat PDF cleanup as the heap fix.
+
+## Code-level findings
+
+### Finding 1: all historical stream sidecars are eagerly hydrated and retained
+
+**Severity:** highest-confidence retained-heap candidate.
+
+**Locations:**
+
+- `src/agent/runtime/SessionHandle.ts:408`
+- `src/transcript/StreamSnapshotStore.ts:1572`
+
+At startup, `SessionHandle` calls snapshot loading with every transcript key. In TNLean, this is 1,923 stream IDs. `StreamSnapshotStore.load()` creates and retains a `StreamRecord` per stream. Each full record can include:
+
+- output and missing-output structures;
+- compile failures;
+- usage maps;
+- work plans;
+- parsed run config and identity;
+- metadata and overlays;
+- two `KVStore` handles.
+
+The subsequent eviction excludes the same full input set, so all seeded records remain. This is long-lived heap retention, not a temporary allocation spike.
+
+The raw `streamData` sidecars are about 22 MB on disk. Parsed JSON, object/Map/Set overhead, Zod parsing, config objects, and related references can cost materially more than disk bytes, especially for 1,923 separate records.
+
+**Why it matches the incident:** it creates a growing baseline proportional to every historical stream in the current workspace. A process may survive initially, then later fail when TUI projection, workflow serialization, or a large response needs temporary headroom.
+
+**Required proof:**
+
+1. Export `StreamSnapshotStore.records.size` and estimated retained bytes per field.
+2. Take a heap snapshot after startup and inspect dominators rooted at `StreamSnapshotStore.records`.
+3. Compare startup with all historical IDs against startup limited to active plus unfinished streams.
+4. After switching away from an inactive seeded stream, force GC in a diagnostic harness and verify output/work-plan/config objects are collectible.
+
+**Candidate remediation:** split an all-stream lightweight metadata index from full sidecar records. Hydrate full sidecars only for active, running, visible, or explicitly queried streams. Give inactive records a byte-accounted LRU.
+
+**Verification (2026-08-10, code-confirmed):** the startup path is confirmed and sharper than the original finding. The CLI constructor enqueues `repairStoresAfterRestart` (`SessionHandle.ts:242-249`), which at `:408` calls `this.snapshots.load(this.transcripts.keys())`; desktop defers the same call to `waitUntilReady()` (`:272-276`). It runs once per session. `StreamLogStore.keys()` (`StreamLogStore.ts:436-438`) returns `[...this.summaries.keys()]`, populated from `kv.listKeys()` at open (`:1111-1132`) — every persisted stream, unfiltered. `load()` (`StreamSnapshotStore.ts:1572-1577`) applies no filter: it `evictStreamsExcept`s to the passed set, then `seedStreams` reads 6 sidecar files per stream (`streamSnapshotRead.ts:144-175`) and retains them in `records`.
+
+Two facts narrow the fix: (1) a bounding filter already exists — `getUnfinishedStreamIds()` (`StreamLogStore.ts:441-445`) — but is applied only to the post-load status/repair phases (`markUnfinishedStreamsRunning` `:539-547`, `runRestartRepair` `:585`,`:596`), never to the snapshot `load()`; (2) lazy hydration already partially works — `readOutputFiles` (`StreamSnapshotStore.ts:1555-1562`) serves unseeded streams from disk via `awaitSeeded`.
+
+Element accounting: the candidate remediation above (split a metadata index + byte-accounted LRU) **adds** subsystems. The element-reducing fix is instead to bound the startup load to the unfinished set plus active lineage via the _existing_ filter, relying on the _existing_ disk fallback for the rest — this deletes wasted eager seeding of finished streams (less retained state, no new cache). Pending: an audit of which callers assume eager seeding (Q6).
+
+**Safety audit (2026-08-10, code-confirmed) — the lazy-hydrate/LRU fix is larger than it looks and has a data-loss landmine:**
+
+- `awaitSeeded` (`StreamSnapshotStore.ts:1521`) is a status check, **not** a self-heal: it only awaits an already-in-flight `seedChain`, and returns `false` otherwise without touching disk. The lazy fallback in `read`/`readOutputFiles` works only because they carry an explicit disk read after `awaitSeeded` — not because `awaitSeeded` hydrates anything.
+- Nine synchronous accessors assume the record is seeded and return empty/default/undefined for an unseeded stream, with no fallback: `getOutputFiles` (`:883`), `getMissingOutputs` (`:887`), `getCompileFailures` (`:891`), `getRunUsage` (`:895`), `getKnownFilePaths` (`:900`), `getWorkPlan` (`:1101`), `getRunMetadata` (`:1231`), `getParentStreamId` (`:1273`), `getExecutionIdMap` (`:1294`).
+- Callers that would break for finished streams: `SessionState.load` all-streams metadata loop (`src/controllers/session/SessionState.ts:550`); desktop presentation seed all-streams loops (`packages/desktop/src/main/desktopAgentExecution.ts:437-448`); extension `ProgressViewProvider.setActiveStream` → `syncStreamContent` with no preload (`packages/extension/src/progressView/ProgressViewProvider.ts:393-414`); `resumeFromResumeData` (`packages/extension/src/commands/agent/resumeFromResumeData.ts:53,62`). The active-stream progress-view controllers/handlers are safe _iff_ `setActiveStream` preloads first.
+- **Data-loss landmine:** `canMutateSynchronously` (`StreamSnapshotStore.ts:430-440`) flips `seeded = true` without reading disk when `hasAuthoritativeStreamSet === true` and no `seedChain` is in flight. A subsequent mutation merges onto an empty base and persists, overwriting the real sidecar with empty+delta — silent data loss. A lazy design must **never** set `hasAuthoritativeStreamSet = true` while finished streams with sidecars remain unseeded; use `preload()` semantics (which leaves the flag false) for the partial set, or split `load()` so the flag reflects only the genuinely-authoritative set.
+- Safe model to generalize: `subscribeStreamArtifacts.ts:66` does `await store.preload([streamId])` before its synchronous reads. Already self-healing and needing no change: `SessionStores.executionIdForStream`, `SessionHandle.runRestartRepair`, the CLI/desktop resume paths, and all `read()`/`readOutputFiles()` consumers (which construct fresh stores).
+
+### Finding 2: the TUI rebuilds the entire transcript repeatedly
+
+**Severity:** highest-confidence temporary-allocation candidate; it may also retain derived state.
+
+**Location:** `packages/cli/src/chat/tui/state/subscribeStreamLog.ts:810-966`
+
+At a 16 ms cadence, transcript synchronization can create/recreate:
+
+- `allEntries`;
+- an ID map;
+- synthetic/candidate/rendered arrays;
+- sorted and filtered arrays;
+- sliced and mapped arrays;
+- a `Set` of dashboard IDs;
+- another filtered array.
+
+The `filter -> slice -> map -> new Set` chain around lines 954-959 fits the final `Array.map` then `Set` frames from `error8`. `error5` also reports `Array.map` and `Array.prototype.reverse`, consistent with this general projection/render family.
+
+This likely creates large temporary allocation pressure proportional to total resident transcript history rather than to the new delta. Some rendered entries are then retained by TUI signals and static transcript state.
+
+**Required proof:** log per-sync input-entry count, derived-output count, elapsed time, and heap before/after. Allocation profiling should attribute churn to `syncStreamLog`, `renderLogEntry`, and this filter/map/Set chain. A benchmark should compare a multi-megabyte log at high update rate before and after incremental projection.
+
+**Candidate remediation:** cursor-based projection. Consume appended/changed entries since the last projection, update an ID index incrementally, and keep workflow dashboard membership incrementally. Per-tick work should be proportional to changed entries, not total transcript size.
+
+### Finding 3: TUI static transcript / Ink scrollback keeps multiple representations indefinitely
+
+**Severity:** high-confidence retained-heap candidate for long root sessions.
+
+**Locations:**
+
+- `packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx:245-344,391-445`
+- `patches/ink@7.1.1.patch:71-118`
+
+Finalized transcript data is retained as:
+
+1. source `StreamLogEntry` values;
+2. React `ConversationEntry` / `StaticTranscriptItem` objects;
+3. Ink's rendered ANSI `fullStaticOutput` string.
+
+This duplicates assistant text and tool results. It resets when the scrollback owner changes, but a long root session can retain output for its entire lifetime without a row or byte budget.
+
+**Required proof:** inspect heap dominators for `StaticTranscriptState.items`, React fibers rooted under `Static`, and Ink `fullStaticOutput`. Record item count, total entry/tool-output text length, and `fullStaticOutput.length` over a long run.
+
+**Candidate remediation:** after terminal scrollback acknowledges finalized output, release rich React item objects. If resize replay is required, retain a bounded/disk-backed compact ANSI replay buffer rather than React data plus a second complete rendered string. Define explicit row and byte budgets.
+
+### Finding 4: transcript eviction is request-driven and has no global byte budget
+
+**Location:** `src/transcript/StreamLogStore.ts:467-503,1428-1538`
+
+`requestEviction()` works when called, but no central resident-log maximum, byte budget, age limit, or pin accounting exists. A missed terminal transition, writer ownership, dirty state, failed flush, or rehydration with no later release can keep a full parsed stream log resident indefinitely.
+
+TNLean currently has 41 summaries marked with running groups, representing 44 MB of authoritative JSON before parsed-object and projection overhead. The recovery path limits I/O concurrency and requests eviction afterward, but ordinary residency has no backstop.
+
+**Required proof:** identify `StreamLog` dominators under `StreamLogStore.streams`, including stream ID, estimated bytes, and pin reason. After a child reaches terminal status and flush completes, its full log should vanish after GC.
+
+**Candidate remediation:** central byte-accounted residency manager. Active writer, visible stream, flushing, and recovery can pin logs. All other logs participate in LRU eviction.
+
+### Finding 5: CLI terminal status does not directly release a stream
+
+**Location:** `packages/cli/src/chat/tui/state/subscribeStreamStatus.ts:18-48`
+
+The CLI status subscriber depends on later projection or focus changes to set `releaseAfterSync` in `syncStreamLog`. This makes lifecycle cleanup dependent on render ordering. A terminal, non-visible stream with no later usable projection can remain resident.
+
+**Candidate remediation:** terminal lifecycle ownership should request release directly after writes and writers settle. Rendering can pin visible state, but should not own durability eviction.
+
+### Finding 6: process-global task-group projections outlive transcript eviction
+
+**Location:** `packages/cli/src/chat/tui/state/subscribeStreamLog.ts:682-710`
+
+`TASK_GROUP_PROJECTIONS` is process-global. It is cleared only by whole-CLI reset or explicit child removal. Evicting a stream log does not clear its task projection. The projection retains original group-entry objects in `applied`, plus working/snapshot representations.
+
+This is a genuine cross-stream retention leak. It may not explain 4 GB alone, but it defeats transcript eviction for projected streams.
+
+**Required proof:** project then evict hundreds of streams, force GC, and inspect `TASK_GROUP_PROJECTIONS.size` plus retained `StreamLogEntry` objects. The size should track visible/resident streams, not every stream ever projected.
+
+**Candidate remediation:** tie projection lifecycle to stream eviction/removal, or retain only minimal group version metadata.
+
+**Verification (2026-08-10, code-confirmed — severity downgraded):** the structural facts hold (`TASK_GROUP_PROJECTIONS` at `subscribeStreamLog.ts:682` is module-level; cleared only by the reset hook (`:683`) or `.delete()` on explicit `removeStream` (`:796` via `isChildStreamRemoved`); eviction at `:996` → `requestEviction` does not touch it). However, "defeats transcript eviction" is overstated. `requestEviction` (`StreamLogStore.ts:473-504`) sets `state.log = undefined`, which **does** release the heavy per-message transcript (model responses, tool output, user text). The leaked `applied` map (`:704`) retains only `GROUP_START`/`GROUP_END` boundary entries — the loop at `:695-701` filters to those — whose `data` payload is small scalars (`GroupLogPayload`: status, kind, index, total, name, endTime). Heavy entries are not retained. The leak also self-heals: on re-sync, rehydrated entries are new objects, so the identity check at `:702` fails and `:704` overwrites stale references. This is a minor structural nit, not a material 4 GB contributor; a fix here would not cut elements that matter. Deprioritize relative to Finding 1.
+
+### Finding 7: streaming text has duplicate retention and superlinear copying
+
+**Location:** `src/transcript/StreamLog.ts:241-262`
+
+During streaming, text is retained both in `entries[index].text` and in `dirtyTextDeltas[id].appendText`. Both are repeatedly rebuilt through string concatenation. A CLI-only consumer does not acknowledge the delta, so the second copy can remain until settlement.
+
+This is both temporary allocation churn and duplicate retained payload during a large response or tool output.
+
+**Required proof:** stream a synthetic 50-200 MB entry under CLI-only subscriptions. Measure `entry.text.length`, dirty-delta length, allocation, and CPU. The current design should show near-equal retained strings and superlinear allocation.
+
+**Candidate remediation:** retain chunks/rope-like segments until settlement and use per-consumer cursors rather than a single accumulated dirty string.
+
+### Finding 8: workflow and flow persistence clone and serialize full state
+
+**Locations:**
+
+- `src/agent/node/persistedFlow.ts:211-231,282-288,311-355,468-482`
+- `src/agent/workflowScript/workflowExecutionState.ts:87-89,434-442`
+
+Active flow persistence retains a full `cachedRecord`, then applies `structuredClone` and `JSON.stringify` to full shared state at transitions. Workflow execution snapshots are also fully cloned and serialized on publication. These paths cause temporary duplication proportional to the full history/snapshot.
+
+For the exact `error8` run, the root flow was only 126 KB and its children were small. Therefore this is not sufficient by itself for that crash. It can still trigger OOM once the baseline heap is already high.
+
+**Candidate remediation:** separate append-only conversation storage from small resumability state; checkpoint/chunk large state; publish deltas or coalesced snapshots rather than a full clone on every micro-transition.
+
+### Finding 9: full Progress View synchronization scales with all workspace history
+
+**Locations:**
+
+- `src/controllers/progressView/backend/WebviewUpdater.ts:325-370`
+- `src/controllers/session/SessionState.ts:217-225`
+
+A full Progress View synchronization rebuilds metadata for every historical stream, copies the all-stream list, creates metadata records, and sends a structured-cloned bridge payload. With 1,923 streams, this is a material temporary allocation spike in the extension host and webview.
+
+This is not the CLI path shown in `error8`, but it is the analogous GUI risk.
+
+**Candidate remediation:** page/virtualize historical tabs and send incremental metadata patches. Initial synchronization should send a bounded recent set plus active lineage.
+
+## Important negative findings
+
+These observations avoid attributing the OOM to irrelevant disk data:
+
+- `ExecutionKVStore` uses an LRU of only 50 thin store wrappers. It does not cache parsed execution values. The 1.7 GB execution directory is not automatically resident.
+- `StreamLogStore` startup uses the 7.5 MB summary sidecars and does not normally load all 991 MB of transcript files. In TNLean, all summaries were present and non-stale, so no full-log fallback read was required at startup.
+- The exact active root workflow and its children were far too small to explain a 4 GB heap by themselves.
+- PDF/LaTeX output duplication is a disk-efficiency concern, not the direct heap diagnosis.
+
+## Recommended architecture, not ad hoc cleanup
+
+1. **Separate metadata from payloads.** Keep a small all-history index. Hydrate full transcript/snapshot details only for active, running, visible, or explicitly opened streams.
+2. **Use byte-budgeted hot caches.** Track resident bytes, pins, and eviction reasons for logs, sidecars, and rendered history.
+3. **Make terminal cleanup lifecycle-owned.** A terminal child must release heavy transcript state after flush even if no UI update follows.
+4. **Use incremental projections.** TUI and GUI updates should process deltas, not rescan full history.
+5. **Bound terminal rendering.** Do not retain unbounded source entries, React objects, and ANSI scrollback simultaneously.
+6. **Keep one canonical large payload.** UI projections and parent child rosters should use references and bounded summaries, not full copies.
+
+## Measurement plan for a deeper reviewer
+
+Before changing behavior, add or use a diagnostic mode that emits:
+
+```text
+resident StreamLog count, entry count, estimated text bytes, dirty-delta bytes, pin reason
+StreamSnapshotStore record count and bytes by field
+TUI stream/slice count, rendered entry count, task-projection count
+static transcript item count/text bytes and Ink fullStaticOutput byte length
+active flow count and approximate cached shared-state bytes
+workflow snapshot clone count and serialized byte count
+```
+
+Then reproduce with the long-lived CLI against TNLean and collect:
+
+1. an early baseline heap snapshot;
+2. a snapshot after many child completions;
+3. a snapshot after stream-focus changes;
+4. automatic near-limit heap snapshots using Node options such as:
+
+```text
+--heapsnapshot-near-heap-limit=3
+--track-heap-objects
+--trace-gc
+```
+
+Compare dominators rooted at:
+
+```text
+StreamSnapshotStore.records
+StreamLogStore.streams
+TASK_GROUP_PROJECTIONS
+TUI signal-backed stream maps
+StaticTranscriptState / Ink fullStaticOutput
+PersistedFlow.cachedRecord
+```
+
+A synthetic soak test should launch hundreds of short child executions and assert that, after terminal transitions and forced GC, retained heap returns to a bounded envelope. The current correctness tests cover transcript/delta behavior but not long-session memory bounds.
+
+## Questions for the next reviewer
+
+1. Which of the identified structures dominates retained bytes in a heap snapshot?
+2. Can `StreamSnapshotStore` load only metadata at startup while preserving current resume/recovery guarantees?
+3. What is the minimum durable state needed for a completed child to remain inspectable and resumable?
+4. Can TUI static output be delegated to terminal scrollback without retaining rich React rows indefinitely?
+5. What precise byte and item budgets preserve useful UX while bounding a long session?
+6. Which existing execution/history APIs still require legacy full records, and can they load them lazily?

--- a/docs/prds/2026-08-11-transcript-memory-architecture.md
+++ b/docs/prds/2026-08-11-transcript-memory-architecture.md
@@ -1,0 +1,420 @@
+# PRD: Transcript, persistence, and projection architecture for long-lived sessions
+
+**Status:** draft. Companion to the investigation in
+`docs/dev/audits/2026-08-10-long-lived-session-memory-investigation.md`.
+Tracks issues #9945, #9946, #9947.
+
+**Problem in one line:** long-lived `texra` CLI processes die at Node's ~4 GB
+heap limit after 30-47 hours, and the VS Code extension gets sluggish in long
+sessions, because resident memory and per-update work both scale with total
+workspace history instead of with the active delta.
+
+## Evidence
+
+Three OOM crashes (local `errorLogs/`, gitignored) all end with
+`Ineffective mark-compacts near heap limit` at ~4 GB after 32-47 h of process
+life. The fatal allocation frames map directly onto the hot paths below:
+
+- `error8`: `SetConstructor` inside `ArrayMap` = the
+  `new Set(next.filter().slice().map())` built at
+  `packages/cli/src/chat/tui/state/subscribeStreamLog.ts:1021` on every 16 ms
+  sync tick, for every stream.
+- `error5`: `ArrayPrototypeReverse` + `ArrayMap` in the same projection family.
+- `error4`: OOM at an `fs` read completion, consistent with sidecar/summary
+  seeding.
+
+The affected workspace (`TNLean`) has 1,923 persisted streams: 991 MB of
+transcripts, 5,274 sidecar files (22 MB), 7.5 MB of summaries. The active run
+at each crash was small (hundreds of KB). The heap is history, not the run.
+
+## Current architecture
+
+### Component and ownership map
+
+```mermaid
+flowchart TB
+  subgraph disk["~/.texra workspace storage (per workspace)"]
+    SL[("streamLogs/ 991MB<br/>1,922 transcripts")]
+    SD[("streamData/ 22MB<br/>5,274 sidecars, 6 files/stream")]
+    SM[("streamLogSummaries/ 7.5MB")]
+  end
+
+  subgraph core["src/transcript + src/agent/runtime (host-agnostic)"]
+    SH["SessionHandle<br/>repairStoresAfterRestart"]
+    LOG["StreamLogStore<br/>summaries: ALL streams, always resident<br/>streams: parsed StreamLog per opened stream<br/>requestEviction(): works only if someone calls it"]
+    SNAP["StreamSnapshotStore<br/>records: StreamRecord per stream<br/>seeded flag + hasAuthoritativeStreamSet flag<br/>canMutateSynchronously() footgun"]
+  end
+
+  subgraph cli["packages/cli TUI"]
+    SUB["subscribeStreamLog<br/>16ms tick, getRange(0) full rescan<br/>computes releaseAfterSync inside render"]
+    MEMOS["process-global memos<br/>TASK_GROUP_PROJECTIONS<br/>COMPACTION_PROJECTIONS"]
+    STATIC["StaticConversationTranscript<br/>+ Ink fullStaticOutput<br/>3 copies of finalized text, unbounded"]
+  end
+
+  subgraph ext["extension / desktop hosts"]
+    WVU["WebviewUpdater full sync<br/>metadata for ALL streams + structuredClone bridge"]
+    PVP["ProgressViewProvider<br/>syncStreamContent"]
+  end
+
+  SM -->|"startup: kv.listKeys()"| LOG
+  SH -->|"snapshots.load(transcripts.keys())<br/>= ALL 1,923 streams"| SNAP
+  SD -->|"6 file reads x 1,923"| SNAP
+  SL -->|"lazy per stream"| LOG
+  LOG -->|"onChange(streamId) only,<br/>delta discarded"| SUB
+  LOG --> WVU
+  SNAP --> WVU
+  SUB --> MEMOS
+  SUB --> STATIC
+  WVU --> PVP
+```
+
+Ownership as it stands: the stores own hydration but nobody clearly owns
+release. `StreamLogStore.requestEviction` exists but its only production
+caller is a flag computed inside the CLI render closure. The snapshot store
+retains every seeded record until a `load()` with a smaller set happens, which
+never does. The CLI memos are process-global and outlive stream eviction.
+
+### Round trip 1: one streamed text chunk (CLI hot path)
+
+```mermaid
+sequenceDiagram
+  participant M as Model stream
+  participant T as AgentTrace (50ms buffer)
+  participant L as StreamLog
+  participant S as StreamLogStore.onChange
+  participant P as subscribeStreamLog (16ms tick)
+  participant I as Ink/React
+
+  M->>T: text chunk
+  T->>L: appendText(id, chunk)
+  Note over L: re-concats FULL entry text (O(n) per chunk, O(n^2) total)<br/>plus grows parallel dirtyTextDeltas copy
+  L->>S: onChange(streamId)
+  Note over S: entry-level delta discarded here
+  S->>P: schedule tick (16ms debounce)
+  P->>L: getRange(0) = ALL entries
+  Note over P: filter -> renderLogEntry x N -> sort -><br/>finalizeSettledPrefix -> re-filter -><br/>new Set(filter.slice.map) [OOM site] -><br/>deep-equal against previous (O(N))
+  P->>I: signal write (only if changed)
+  I->>I: render, append finalized rows to Static
+  Note over I: finalized text now held 3x:<br/>StreamLogEntry + ConversationEntry + fullStaticOutput
+```
+
+Cost per chunk is O(total transcript), not O(chunk). The deep-equal that
+suppresses the signal write runs after all the work is done.
+
+### Round trip 2: startup
+
+```mermaid
+sequenceDiagram
+  participant H as SessionHandle
+  participant LOG as StreamLogStore
+  participant SNAP as StreamSnapshotStore
+  participant D as Disk
+
+  H->>LOG: open()
+  LOG->>D: read ALL summaries (7.5MB, fine)
+  H->>SNAP: load(transcripts.keys())  [ALL 1,923 ids]
+  SNAP->>D: 6 sidecar reads x 1,923 streams
+  Note over SNAP: every StreamRecord retained forever:<br/>outputs, usage maps, work plans,<br/>parsed configs, 2 KVStore handles each
+  H->>H: markUnfinishedStreamsRunning()
+  Note over H: getUnfinishedStreamIds() filter EXISTS<br/>but is applied only here, after the<br/>unbounded load already happened
+```
+
+The extension/desktop analog: full progress-view sync rebuilds metadata for
+every historical stream and ships it over a structured-clone bridge
+(`WebviewUpdater.ts:325-370`, `desktopAgentExecution.ts:437-448`).
+
+### Cross-cutting and ownership problems
+
+1. **Release decided by rendering.** `releaseAfterSync` is computed inside the
+   projection closure (`subscribeStreamLog.ts:1013-1016`); a terminal stream
+   is only released if a sync happens to run for it. Lifecycle facts are
+   available in `subscribeStreamStatus`, which does nothing with them.
+2. **The change feed discards the change.** `StreamLogStore.onChange` reports
+   only `streamId`. Every consumer that needs the delta must either rescan
+   (CLI does) or maintain its own shadow state (the process-global memos do).
+   One lossy feed has spawned two compensating systems.
+3. **Flag conflation with a data-loss edge.** `hasAuthoritativeStreamSet`
+   ("I know the full stream set") is used by `canMutateSynchronously`
+   (`StreamSnapshotStore.ts:430-440`) to assert the per-record fact "this
+   record is hydrated": it flips `seeded = true` without a disk read, so a
+   mutation merges onto an empty base and persists empty+delta over the real
+   sidecar.
+4. **Silent degradation at 9 accessors.** Nine synchronous snapshot accessors
+   return empty defaults for unseeded records with no error and no fallback,
+   which is exactly the failure mode the repo's design guardrails call a
+   defect.
+5. **Duplicate representations.** Streaming text is held twice during a
+   response (`entries[].text` + `dirtyTextDeltas`); finalized text is held
+   three times (source entry, React row, Ink ANSI string); flow persistence
+   `structuredClone`s + `JSON.stringify`s full state per transition.
+6. **History-scaled work in every host.** CLI tick, extension full sync, and
+   desktop presentation seed all do work proportional to total workspace
+   history on paths that fire per event.
+
+## Extension-host stickiness (investigated 2026-08-11)
+
+A dedicated pass over the extension host found that the CLI's central defect
+does not exist there: `WebviewBridge`
+(`src/controllers/progressView/backend/WebviewBridge.ts:118-160`) is already
+cursor-based. Per 16 ms frame it ships `getRange(cursor, head)` plus dirty
+deltas, only for the active stream, and advances the cursor on ack. The
+extension also already evicts finished transcripts on terminal transition and
+tab switch (`SessionFactApplier.ts:510-512`, `SessionState.ts:185-189`).
+
+This is the sharpest cross-cutting fact in the whole investigation: **the
+repo contains both the correct pattern (extension: cursor + delta + ack) and
+the broken one (CLI: full rescan per tick) for the same problem.** The CLI
+projection is a second, worse system, exactly the dual-system smell the design
+guardrails ban.
+
+The extension's sluggishness has three separate causes, all event-shaped
+rather than tick-shaped:
+
+1. **One VS Code `OutputChannel` per run, never disposed.**
+   `src/transcript/runTrace.ts:76` names the channel after the streamId
+   (unique per run); `src/logger/logUtils.ts:49` holds channels in a
+   module-level map that is only ever `.set()` or `.clear()`, never
+   `.delete()`. Every agent run and every delegated child mints a live
+   `OutputChannel` (extension-host object, renderer registration, spool file,
+   Output-view dropdown entry) that survives for the life of the host. A
+   multi-day session accumulates hundreds to thousands. This degrades VS Code
+   itself, not just the extension.
+2. **`executions/**` watcher drives a full history rescan per write burst.**
+   `SettingsViewMessageHandler.ts:287-322` watches the entire executions tree
+   (2,270 dirs in TNLean); each event debounces 300 ms into
+   `listExecutions()`, which re-reads meta + run record for every execution
+   directory (thousands of reads and Zod parses per refresh). `PersistedFlow`
+   persists after every node execution, so during an active run this executes
+   back-to-back continuously. The gate is "Dashboard webview exists", and the
+   Dashboard is a `retainContextWhenHidden` panel, so a background tab keeps
+   it running invisibly for days.
+3. **`syncFullView` rebuilds all ~1,923 stream tabs on every visibility
+   toggle.** `ProgressViewProvider.ts:287-317` →
+   `WebviewUpdater.sendStreamMetadata` (`:327-375`) rebuilds
+   `StreamTabInfo` + metadata for every persisted stream and posts a ~1-2 MB
+   structured-clone payload; it fires on webview ready, theme change, sidebar
+   show, pop-out, and every `onDidChangeViewState` when the user switches back
+   to the panel. This is the direct match for "sticky when I come back to the
+   view". A per-stream worktree-info LRU capped at 32 entries thrashes and
+   spawns `git rev-parse`/`git status` subprocesses beyond 32 distinct
+   working directories.
+
+Secondary, lower magnitude: `StreamStatusService.getAllStreamStates()`
+allocates a fresh Map of every stream ever touched per status event (the
+status-bar tracker triggers four such allocations per event); `SessionState`
+retains a `StreamSessionState` (including the full run instruction string)
+for all 1,923 streams after load; `MainViewProvider`'s workspace file watcher
+runs an undebounced full `findFiles('**/*')` per created/deleted file, which a
+LaTeX compile burst triggers once per artifact.
+
+## Target architecture
+
+The target design was selected by a four-way design tournament (independent
+proposals under a delete-first, a delta-feed, a residency-manager, and a
+storage-split thesis) scored by a three-judge panel. The delta-feed thesis
+("Source-Fed Views") won 2 of 3 judges; the panel then grafted the winners'
+gaps from the losers. All four designs independently converged on the same
+verified core: the store already computes the delta it discards at `notify()`;
+`canMutateSynchronously` fabricates per-record state from a global flag;
+eviction must move from render closures to lifecycle; and no LRU is needed
+anywhere. The decisive argument for the delta feed: once the full rescan is
+deleted, the worst regression class is an in-place mutation site that forgets
+to mark dirty, producing silently stale rows in every host; only the delta
+design makes that mechanically checkable, via a fold-vs-oracle equivalence
+harness whose from-scratch path doubles as the production resync path.
+
+```mermaid
+flowchart TB
+  subgraph store["StreamLog / StreamLogStore (single change authority)"]
+    LOG2["StreamLog<br/>entries hold text as chunk segments,<br/>joined once at settle"]
+    DELTA["delta payload per notify:<br/>{seq, appended, dirtied-by-value,<br/>textChunks, reset}<br/>drained once, multicast, no acks"]
+    LEASE["residency = writer/focus/flush leases<br/>release at zero; flush lease releases only<br/>on confirmed durable write<br/>lease-site set pinned by architecture ratchet"]
+  end
+
+  subgraph snap2["StreamSnapshotStore"]
+    TRI["per-record diskState:<br/>unknown | verified-absent | loaded<br/>unknown mutations queue behind the seed<br/>(canMutateSynchronously deleted)"]
+    BOUND["startup hydrates unfinished + active lineage only;<br/>summaries carry identity/executionId/parent<br/>so sidebars never touch sidecars"]
+  end
+
+  subgraph views["views = pure folds over the delta"]
+    CLI2["CLI reducers (per output):<br/>O(delta) per tick, state lives in the<br/>stream slice, dies with the stream"]
+    EXT2["WebviewBridge consumes the same feed<br/>(private cursor + ack protocol deleted)"]
+    TAIL["scrollback: bounded structured tail,<br/>ANSI regenerated from the tail on repaint"]
+  end
+
+  LOG2 --> DELTA
+  DELTA --> CLI2
+  DELTA --> EXT2
+  CLI2 --> TAIL
+  LEASE -.owns residency of.-> LOG2
+  TRI --> BOUND
+```
+
+Component summary of the grafted architecture:
+
+- **Delta contract:** `notify` carries an immutable
+  `{seq, appended entries, dirtied entries by value, textChunks, reset}`
+  payload. A dirtied entry supersedes buffered text chunks for its id.
+  Emission seq is monotonic; a detected gap triggers a `getRange(0)` resync
+  that shares the oracle code path.
+- **Streaming text:** entries hold chunk segments, joined at settle. Both
+  quadratic re-concats and `dirtyTextDeltas` die.
+- **Save path:** a max-wait throttle replaces perfect-debounce; mutators call
+  a void `scheduleSave()`, and only `flush()` is awaitable.
+- **Residency:** writer/focus/flush leases with release at zero, a
+  zero-residency one-shot read API for ExecutionsTool-style readers, a debug
+  dump of resident streams with lease reasons and byte gauges, and a kernel
+  architecture ratchet pinning the closed set of lease-acquisition sites.
+- **Snapshot store:** per-record `diskState` tri-state; `verified-absent`
+  only from stream minting or a one-stat probe. Overlay/replay machinery is
+  retained and shrunk later behind a per-mutator caller audit.
+- **Startup:** hydration bounded to unfinished plus active lineage. The
+  persisted summary widens (derived tier per #9434: rebuild loudly, never
+  migrate, never `.catch`) with identity, executionId, and parentStreamId,
+  with lazy backfill for the ~4,610 legacy rows. The 9 silent-empty accessors
+  go loud one full release before the bounding lands.
+- **CLI:** five per-output reducers folding the delta; background streams
+  render zero transcript entries; projection state moves into the stream
+  slice and the module-global memos are deleted as globals (memo semantics
+  kept, relocated, lifetime tied to the stream).
+- **Extension/desktop:** WebviewBridge consumes the same feed; bounded
+  metadata wire list from a single sorted source; theme changes send
+  `THEME_SET` alone; git worktree probes gated to active/running streams;
+  the executions history watcher registered only while a settings webview is
+  actually active.
+- **Flow persistence:** point fixes only (compact JSON, skip the self-cache
+  Zod re-parse, `run()` returns shared state, workflow snapshot cloned at
+  drain into its own `workflow.json` key).
+
+## The top 5 changes
+
+Ranked by operations cut times memory cut over risk. Shippable in this order;
+each step is independently landable.
+
+### 1. Store-emitted delta feed + O(delta) CLI reducers (#9946 rescoped)
+
+Pattern: one authoritative change channel; every view is a pure fold.
+Deletes: the CLI per-tick full rescan (`getRange(0)`, id-map rebuild, the
+`subscribeStreamLog.ts:1021` filter/slice/map/Set chain that is `error8`'s
+fatal allocation, the reverse+second-sort pass, `forceFull`,
+`dedupeEntry`/`entriesEqual`/`toolUseSourceCache`), StreamLog's destructive
+ack protocol (~150 LoC), and WebviewBridge's private cursor (~120 LoC).
+Adds: the delta type + `mergeDelta` (~110 LoC) and a test-only harness. Net
+strongly negative. Scope: `src/transcript/StreamLog.ts`, `StreamLogStore.ts`,
+`packages/cli/.../subscribeStreamLog.ts`, extension `WebviewBridge`. Risk:
+medium. Required test: the fold-vs-oracle equivalence property test (fold
+over deltas deep-equals from-scratch projection) with a fuzz corpus covering
+appendText/update/settle interleavings and GROUP upserts.
+
+### 2. Tri-state disk provenance, then bounded startup + summary metadata view (#9947 rescoped)
+
+The provenance fix ships first as its own small PR: delete
+`hasAuthoritativeStreamSet` and `canMutateSynchronously`, replace with the
+per-record `diskState` tri-state; unknown mutations queue behind the seed.
+Then bound startup to unfinished + active lineage and widen summaries so the
+sidebar never touches sidecars; delete the load/preload fork, the ~15k-read
+startup sweep, SessionState's all-streams loop, desktop's second pass, and
+the cached Keyv handles. Risk: highest of the five (the 9-accessor caller
+audit), mitigated by shipping loud unhydrated-access warnings one full
+release before the bound. Required test: the clobber regression (mutate a
+stream whose sidecar exists on disk but is absent from `transcripts.keys()`;
+assert merge, not overwrite).
+
+### 3. Chunked streaming text + max-wait save throttle
+
+Deletes both quadratic per-chunk re-concats, the `dirtyTextDeltas` duplicate
+string, `pendingSaveAwaiters`, and perfect-debounce on the save path. Adds
+`textChunks` with a memoized join and the flushable-throttle idiom already in
+`@utils/core`. Scope: `StreamLog.ts` + `StreamLogStore.ts` only. Risk: low.
+Required test: cadence test that sustained sub-300 ms appends still produce
+periodic durable writes; text-materialization equivalence in the harness.
+
+### 4. Lease residency + lifecycle-owned eviction (#9945 rescoped)
+
+Deletes the five-flag eviction interlock (~150 LoC), `releaseAfterSync` in
+the render closure, and the module-global TASK_GROUP/COMPACTION maps as
+globals (memo relocated into per-stream slice state that dies with the
+stream). Adds writer/focus/flush leases (~60 LoC), a zero-residency
+`readEntries`, the residency debug dump, and the lease-site architecture
+ratchet. Risk: medium (an unpaired lease is a new leak class, countered by
+the dump plus the closed-site ratchet). Required test: soak test that after N
+child completions plus forced GC, retained heap returns to a bounded
+envelope.
+
+### 5. Bounded static scrollback tail + regenerate-ANSI repaint
+
+Deletes the per-tick seen-Set diff, the char-by-char stripAnsi re-walk of all
+finalized entries, the double `buildFreshItems` run, and the unbounded
+`items`/`fullStaticOutput` growth. Adds a row/byte ring at
+emulator-scrollback scale with trim hysteresis, settled-cursor append
+(depends on item 1), and ink-patch regeneration from the structured tail on
+clear-and-reprint. Scope: `StaticConversationTranscript.tsx`,
+`transcriptEntries.ts`, `patches/ink@7.1.1.patch`. Risk: medium (vendored
+ink patch). Required test: tmux TUI drive of overflow/resume/resize against a
+clean-main baseline, plus a budget invariant test.
+
+## Issue mapping
+
+- **New blocker issue to file:** "Per-record disk provenance in
+  StreamSnapshotStore (delete canMutateSynchronously /
+  hasAuthoritativeStreamSet)", extracted from #9947. Ships before everything,
+  with the clobber regression test.
+- **#9946:** rescope to store-emitted entry-level deltas (appended range +
+  dirtied entries by value + text chunks + emission seq); renderer-side
+  cursors are out. Includes the CLI reducer split and the WebviewBridge port
+  that deletes the ack protocol. Every PR gated on the equivalence harness.
+- **#9945:** rescope. Eviction moves to lifecycle via leases. Drop the
+  "delete TASK_GROUP_PROJECTIONS" wording: the memo survives, relocated into
+  per-stream slice state.
+- **#9947:** close the LRU half (the resident set is small by construction
+  once residency is lease-owned). The remainder becomes top-5 item 2.
+- **New issues to file:** (a) chunked text + save throttle (item 3);
+  (b) bounded static tail + ink repaint (item 5); (c) extension-edge bounding
+  (bounded `sendStreamMetadata` wire list from a single sorted source,
+  `THEME_SET`-only theme handling, gated git probes, executions watcher
+  registered only while the settings webview is active); (d) flow-persistence
+  point fixes; (e) overlay-arm shrink, gated on the per-mutator caller audit;
+  (f) dispose per-run `OutputChannel`s: `runTrace.ts:76` +
+  `logUtils.ts:49` currently mint one live VS Code output channel per run and
+  never delete it, a host-level resource leak independent of the heap work.
+
+## Explicitly rejected
+
+Tournament losers, recorded so effort is not wasted re-proposing them:
+
+- **6-file to single-file sidecar collapse:** silent cross-host data loss
+  under version-skewed hosts sharing `~/.texra`; bounded load already
+  neutralizes the read cost.
+- **A ResidencyLedger subsystem:** a refcount plus a 20-line debug dump
+  yields identical deletions without a new subsystem.
+- **Any LRU** (logs or snapshot records): resident set is small by
+  construction once residency is lease-owned.
+- **Event-log rewrite of PersistedFlow:** per-turn full-record checkpointing
+  is defensible; delta capture/replay/compaction is three new elements for a
+  3-node graph.
+- **Replacing the meta.json FK with derived index rows:** a stale derived row
+  silently mis-wires restart repair; executionId goes into the summary as a
+  bounded convenience, meta.json stays authoritative.
+- **Deleting the overlay/replay machinery up front:** unearned until the
+  per-mutator caller audit; it becomes hot-path load-bearing under lazy
+  loading.
+- **Deleting the task-group memo:** refuted in review; relocate, keep.
+- **Trim-via-renderKey with no ink patch change:** mechanically unsound;
+  Static re-renders from index 0 and duplicates the entire tail to stdout on
+  every trim.
+- **Extending the ack/cursor protocol to the CLI:** single-consumer by
+  construction; the protocol is deleted, not adopted.
+- **An mtime cache for the shared-storage history listing:** accepted
+  recompute; the real fix is registering the watcher only while a settings
+  webview is active.
+
+## Test strategy
+
+- Property test for any incremental projection: incremental result equals
+  from-scratch result for the same log, on every tick, under randomized
+  in-place mutation. This is the only reliable guard for the settled-prefix
+  and synthetic-merge ordering semantics.
+- Soak test: hundreds of short child executions; after terminal transitions
+  and forced GC, retained heap must return to a bounded envelope.
+- Heap-snapshot confirmation before the multi-host hydration change
+  (`--heapsnapshot-near-heap-limit=3`), per the audit's measurement plan.

--- a/docs/prds/2026-08-11-transcript-memory-architecture.md
+++ b/docs/prds/2026-08-11-transcript-memory-architecture.md
@@ -1,3 +1,8 @@
+---
+created: 2026-08-11
+updated: 2026-08-11
+---
+
 # PRD: Transcript, persistence, and projection architecture for long-lived sessions
 
 **Status:** draft. Companion to the investigation in
@@ -13,9 +18,12 @@ workspace history instead of with the active delta.
 
 Three OOM crashes (local `errorLogs/`, gitignored) all end with
 `Ineffective mark-compacts near heap limit` at ~4 GB after 32-47 h of process
-life. The fatal allocation frames map directly onto the hot paths below:
+life. The native frames identify the final failed allocation, not the graph
+retaining the preceding gigabytes; the sites below are the code whose shape
+fits those frames (a JS allocation profile is the confirming step, per the
+audit's measurement plan):
 
-- `error8`: `SetConstructor` inside `ArrayMap` = the
+- `error8`: `SetConstructor` inside `ArrayMap` fits the
   `new Set(next.filter().slice().map())` built at
   `packages/cli/src/chat/tui/state/subscribeStreamLog.ts:1021` on every 16 ms
   sync tick, for every stream.
@@ -68,9 +76,12 @@ flowchart TB
   WVU --> PVP
 ```
 
-Ownership as it stands: the stores own hydration but nobody clearly owns
-release. `StreamLogStore.requestEviction` exists but its only production
-caller is a flag computed inside the CLI render closure. The snapshot store
+Ownership as it stands: the stores own hydration but release ownership is
+split. The extension and desktop hosts do evict correctly, on terminal
+transition and on tab switch (`SessionFactApplier.ts:510-512`,
+`SessionState.ts:185-189`); in the CLI, the only `requestEviction` caller is
+a flag computed inside the render closure, so the missing-cleanup work is
+CLI-side. The snapshot store
 retains every seeded record until a `load()` with a smaller set happens, which
 never does. The CLI memos are process-global and outlive stream eviction.
 
@@ -256,7 +267,11 @@ Component summary of the grafted architecture:
   `{seq, appended entries, dirtied entries by value, textChunks, reset}`
   payload. A dirtied entry supersedes buffered text chunks for its id.
   Emission seq is monotonic; a detected gap triggers a `getRange(0)` resync
-  that shares the oracle code path.
+  that shares the oracle code path. Because a gap is only detectable when a
+  later frame arrives, webview delivery keeps an explicit handshake: consumer
+  registration or reconnect (and any failed `postMessage`) re-registers and
+  resyncs from scratch through the same oracle path, so the no-ack multicast
+  cannot leave a disposed-and-restored view permanently stale.
 - **Streaming text:** entries hold chunk segments, joined at settle. Both
   quadratic re-concats and `dirtyTextDeltas` die.
 - **Save path:** a max-wait throttle replaces perfect-debounce; mutators call
@@ -270,15 +285,23 @@ Component summary of the grafted architecture:
   retained and shrunk later behind a per-mutator caller audit.
 - **Startup:** hydration bounded to unfinished plus active lineage. The
   persisted summary widens (derived tier per #9434: rebuild loudly, never
-  migrate, never `.catch`) with identity, executionId, and parentStreamId,
-  with lazy backfill for the ~4,610 legacy rows. The 9 silent-empty accessors
+  migrate, never `.catch`) with identity, executionId, parentStreamId, and
+  whatever else tab construction actually needs. The exact field set comes
+  from a `buildStreamTabInfo` caller audit: it also consumes category,
+  description, model/working-directory config, and follow-up capability, so
+  either those ride in the summary as bounded scalars or a lazy per-stream
+  metadata fetch covers them; "sidebars never touch sidecars" is the
+  invariant, not the three-field list. Lazy backfill covers the ~4,610
+  legacy rows. The 9 silent-empty accessors
   go loud one full release before the bounding lands.
 - **CLI:** five per-output reducers folding the delta; background streams
   render zero transcript entries; projection state moves into the stream
   slice and the module-global memos are deleted as globals (memo semantics
   kept, relocated, lifetime tied to the stream).
 - **Extension/desktop:** WebviewBridge consumes the same feed; bounded
-  metadata wire list from a single sorted source; theme changes send
+  metadata wire list from a single sorted source, with an explicit on-demand
+  path (paging or per-stream fetch) so streams outside the bound remain
+  selectable; the webview must never lose access to on-disk history; theme changes send
   `THEME_SET` alone; git worktree probes gated to active/running streams;
   the executions history watcher registered only while a settings webview is
   actually active.
@@ -288,8 +311,12 @@ Component summary of the grafted architecture:
 
 ## The top 5 changes
 
-Ranked by operations cut times memory cut over risk. Shippable in this order;
-each step is independently landable.
+Ranked by operations cut times memory cut over risk; each step is
+independently landable. One dependency-order exception to the ranking: the
+tri-state disk provenance PR (the first half of item 2) is a small standalone
+blocker that lands before everything else, because it removes the
+data-loss landmine every later change would otherwise widen. After it,
+items land in ranked order.
 
 ### 1. Store-emitted delta feed + O(delta) CLI reducers (#9946 rescoped)
 
@@ -325,8 +352,11 @@ assert merge, not overwrite).
 Deletes both quadratic per-chunk re-concats, the `dirtyTextDeltas` duplicate
 string, `pendingSaveAwaiters`, and perfect-debounce on the save path. Adds
 `textChunks` with a memoized join and the flushable-throttle idiom already in
-`@utils/core`. Scope: `StreamLog.ts` + `StreamLogStore.ts` only. Risk: low.
-Required test: cadence test that sustained sub-300 ms appends still produce
+`@utils/core`. Scope: `StreamLog.ts` + `StreamLogStore.ts` only. The durable schema keeps text as
+a string: each throttled save joins the chunks (memoized join, O(text) per
+save at the throttle cadence, not per provider chunk), so crash-resilient
+partial-response durability is preserved without a sidecar format change.
+Risk: low. Required test: cadence test that sustained sub-300 ms appends still produce
 periodic durable writes; text-materialization equivalence in the harness.
 
 ### 4. Lease residency + lifecycle-owned eviction (#9945 rescoped)

--- a/docs/prds/README.md
+++ b/docs/prds/README.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-06-21
-updated: 2026-08-04
+updated: 2026-08-11
 ---
 
 # PRD Index
@@ -24,6 +24,7 @@ that archived source branch, not `main`.
 
 | Document                                                                                                                                 | Created    | Updated    |
 | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ---------- |
+| [PRD: Transcript, persistence, and projection architecture for long-lived sessions](./2026-08-11-transcript-memory-architecture.md)      | 2026-08-11 | 2026-08-11 |
 | [PRD: xAI Responses API and `previous_response_id` for Grok](./2026-08-04-prd-xai-responses-previous-response-id.md)                     | 2026-08-04 | 2026-08-04 |
 | [PRD: Unified approval policy across CLI, desktop, and extension](./2026-08-03-prd-approval-policy-unification.md)                       | 2026-08-03 | 2026-08-03 |
 | [PRD: Non-blocking `inquiry` — Async Q&A with the User](./2026-05-15-prd-external-inquiry-async.md)                                      | 2026-05-15 | 2026-06-20 |


### PR DESCRIPTION
## Summary

Docs-only. Two documents:

- `docs/dev/audits/2026-08-10-long-lived-session-memory-investigation.md`: the previously uncommitted OOM investigation (Findings 1-9, verified against code, with the measurement plan).
- `docs/prds/2026-08-11-transcript-memory-architecture.md`: the PRD consolidating three inputs into one target architecture and a ranked top-5 plan:
  1. crash-stack correlation of the three ~4 GB CLI OOMs (the `error8` fatal allocation is the per-tick `new Set(filter().slice().map())` at `subscribeStreamLog.ts:1021`);
  2. a dedicated extension-host stickiness investigation (key negative: the extension's `WebviewBridge` is already cursor-based, so the CLI's full rescan is a second, worse system for the same problem; three extension-specific causes found, including the never-disposed per-run `OutputChannel` leak);
  3. a four-design tournament with a three-judge panel. Winner: store-emitted delta feed ("Source-Fed Views") with grafts; all four designs independently converged on deleting `canMutateSynchronously`, moving eviction to lifecycle ownership, and rejecting any LRU.

The PRD includes current-state architecture diagrams (ownership map, chunk round trip, startup round trip), the grafted target architecture, the top-5 shippable sequence, issue rescoping for #9945/#9946/#9947, and an explicitly-rejected list so tournament losers don't get re-proposed.

Refs #9945, #9946, #9947.

## Review notes

- Both files are in publish-excluded internal directories (`docs/dev/`, `docs/prds/`); no root-level docs touched.
- No code changes; the top-5 items land as separate PRs per the issue mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gtc6wQMD1hedgabjQMfAun

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation only in internal `docs/dev/` and `docs/prds/` paths; no runtime or schema changes in this PR.
> 
> **Overview**
> Adds **docs-only** handoff material for recurring CLI OOMs (~4 GB after 30–47 h) and extension sluggishness in workspaces with thousands of historical streams (e.g. TNLean: 1,923 streams).
> 
> **New audit** (`docs/dev/audits/2026-08-10-long-lived-session-memory-investigation.md`): ties three OOM logs to **history-scaled retention and projection**, not the active run or PDF artifacts. Nine code findings with verification notes (Finding 1: eager `StreamSnapshotStore` seeding for all transcript keys at startup; Finding 6 severity downgraded). Includes measurement plan (heap snapshots, dominator targets) and architecture principles (metadata vs payloads, incremental projections, lifecycle-owned eviction).
> 
> **New PRD** (`docs/prds/2026-08-11-transcript-memory-architecture.md`): consolidates crash correlation, extension-host stickiness (notes extension `WebviewBridge` is already cursor-based vs CLI full rescan), and a four-design tournament → **store-emitted delta feed** target architecture with diagrams. **Ranked top-5** implementation sequence (delta feed + CLI reducers; tri-state disk provenance then bounded startup; chunked text + save throttle; lease residency; bounded static scrollback). Rescopes **#9945 / #9946 / #9947**, lists new follow-up issues, explicitly rejected alternatives (LRU, sidecar collapse, etc.), and test strategy (fold-vs-oracle property tests, soak tests).
> 
> **Index:** `docs/prds/README.md` updated (`updated` frontmatter + row for the new PRD).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f531eb245a14f77283885be26a43a9606323b6ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->