### PR TITLE
test: remove the env-conditional permission tests

### DIFF
--- a/src/test-kernel/cli/CliRootArgs.vitest.ts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.ts
@@ -833,33 +833,6 @@ describe('CLI root argument routing', () => {
     });
   });
 
-  // Skip on Windows (no POSIX chmod semantics) and when running as root, where
-  // mode-0 doesn't block stat.
-  const skipPermissionTest =
-    process.platform === 'win32' ||
-    (typeof process.getuid === 'function' && process.getuid() === 0);
-  (skipPermissionTest ? it.skip : it)(
-    'propagates non-ENOENT stat errors instead of misreporting as not-found',
-    async () => {
-      await withTempDir('texra-cli-perm-', async (root) => {
-        const blocked = path.join(root, 'blocked');
-        const inner = path.join(blocked, 'paper.tex');
-        try {
-          await fs.mkdir(blocked, { recursive: true });
-          await fs.writeFile(inner, 'draft');
-          // Strip search/execute permission on the parent so stat(inner) fails
-          // with EACCES. The not-found fast path must not swallow this.
-          await fs.chmod(blocked, 0o000);
-          await expect(expandWorkflowInputSpecs([inner], root)).rejects.toThrow(
-            /(EACCES|permission)/i,
-          );
-        } finally {
-          await fs.chmod(blocked, 0o755).catch(() => undefined);
-        }
-      });
-    },
-  );
-
   it('reports missing workflow outputs as a failed copy operation', async () => {
     await expect(
       resolveWorkflowOutput(

--- a/src/test-kernel/cli/InitConfig.vitest.ts
+++ b/src/test-kernel/cli/InitConfig.vitest.ts
@@ -1,4 +1,4 @@
-import { chmod, readFile as nodeReadFile, writeFile } from 'node:fs/promises';
+import { readFile as nodeReadFile, writeFile } from 'node:fs/promises';
 import path, { join } from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -128,53 +128,6 @@ describe('ensureTexraGitignored', () => {
     await expect(ensureTexraGitignored(workspace)).resolves.toBe(outcome);
     await expect(nodeReadFile(gitignorePath, 'utf8')).resolves.toBe(expected);
   });
-
-  const skipPermissionTest =
-    process.platform === 'win32' ||
-    (typeof process.getuid === 'function' && process.getuid() === 0);
-  (skipPermissionTest ? it.skip : it)(
-    'does not atomically replace a read-only .gitignore',
-    async () => {
-      const workspace = await makeTempDir('texra-gitignore-', tempDirs);
-      const gitignorePath = join(workspace, '.gitignore');
-      await writeFile(gitignorePath, 'node_modules\n', 'utf8');
-      await chmod(gitignorePath, 0o444);
-
-      try {
-        await expect(ensureTexraGitignored(workspace)).rejects.toThrow(
-          /(EACCES|permission)/i,
-        );
-        await expect(nodeReadFile(gitignorePath, 'utf8')).resolves.toBe(
-          'node_modules\n',
-        );
-      } finally {
-        await chmod(gitignorePath, 0o644);
-      }
-    },
-  );
-
-  (skipPermissionTest ? it.skip : it)(
-    'still atomically replaces a write-only config',
-    async () => {
-      const workspace = await makeTempDir('texra-config-', tempDirs);
-      const configPath = workspaceTexraConfigPath(workspace);
-      await writeInitConfig(configPath, buildInitConfig(ANSWERS));
-      await chmod(configPath, 0o200);
-
-      try {
-        const updated = buildInitConfig({ ...ANSWERS, model: 'gemini35f' });
-        await expect(
-          writeInitConfig(configPath, updated),
-        ).resolves.toBeUndefined();
-        await chmod(configPath, 0o600);
-        await expect(nodeReadFile(configPath, 'utf8')).resolves.toContain(
-          '"model": "gemini35f"',
-        );
-      } finally {
-        await chmod(configPath, 0o600);
-      }
-    },
-  );
 
   it('does not overwrite .gitignore on a non-ENOENT read failure', async () => {
     // Reproduces #7470: a transient EACCES (or any non-missing-file error)

--- a/src/test-kernel/cli/OutputGuards.vitest.ts
+++ b/src/test-kernel/cli/OutputGuards.vitest.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, stat, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, win32 } from 'node:path';
 
@@ -235,29 +235,6 @@ describe('assertOutputDirAvailable', () => {
       /is not a directory/,
     );
   });
-
-  // Skip on Windows (no POSIX chmod semantics) and when running as root, where
-  // mode-0 doesn't restrict stat.
-  const skipPermissionTest =
-    process.platform === 'win32' ||
-    (typeof process.getuid === 'function' && process.getuid() === 0);
-  (skipPermissionTest ? it.skip : it)(
-    'propagates non-ENOENT/ENOTDIR stat errors with their original cause',
-    async () => {
-      const root = await makeTempDir('texra-cli-outdir-perm-', tempDirs);
-      const blocked = join(root, 'blocked');
-      const inner = join(blocked, 'dir');
-      try {
-        await mkdir(blocked);
-        await chmod(blocked, 0o000);
-        await expect(assertOutputDirAvailable(inner, root)).rejects.toThrow(
-          /(EACCES|permission)/i,
-        );
-      } finally {
-        await chmod(blocked, 0o755).catch(() => undefined);
-      }
-    },
-  );
 });
 
 describe('assertOutputFileAvailable', () => {

--- a/src/test-kernel/skills/LoadSkills.vitest.ts
+++ b/src/test-kernel/skills/LoadSkills.vitest.ts
@@ -233,36 +233,4 @@ describe('discoverSkillSources', () => {
       }),
     ]);
   });
-
-  // Skip on Windows (no POSIX chmod semantics) and when running as root, where
-  // mode-0 doesn't restrict reads.
-  const skipPermissionTest =
-    process.platform === 'win32' ||
-    (typeof process.getuid === 'function' && process.getuid() === 0);
-  (skipPermissionTest ? it.skip : it)(
-    'reports required source read errors as source failures',
-    async () => {
-      const root = await createTempRoot();
-      const required = path.join(root, 'blocked-skills');
-      await fs.mkdir(required);
-      await fs.chmod(required, 0o000);
-
-      try {
-        const result = await discoverSkillSources([
-          { scope: 'custom', path: required, required: true },
-        ]);
-
-        expect(result.skills).toEqual([]);
-        expect(result.errors).toEqual([
-          expect.objectContaining({
-            severity: 'error',
-            code: 'source_read_error',
-            path: required,
-          }),
-        ]);
-      } finally {
-        await fs.chmod(required, 0o700);
-      }
-    },
-  );
 });


### PR DESCRIPTION
## Summary

Follow-up to #9948, which is merged.

**Five `skipPermissionTest`-guarded tests removed.** #9948 removed three tests whose outcome depended on the host rather than the code. Cursor Bugbot correctly pointed out that the suite had an established guard for the same class of fixture — `process.platform === 'win32' || process.getuid() === 0` — used at five sites across four files. Those are the same problem wearing a skip instead of a failure: on Windows or as root they report green without having checked anything. Removed rather than kept.

| File | Test |
| --- | --- |
| `LoadSkills.vitest.ts` | reports required source read errors as source failures |
| `OutputGuards.vitest.ts` | propagates non-ENOENT/ENOTDIR stat errors with their original cause |
| `CliRootArgs.vitest.ts` | propagates non-ENOENT stat errors instead of misreporting as not-found |
| `InitConfig.vitest.ts` | does not atomically replace a read-only `.gitignore` |
| `InitConfig.vitest.ts` | still atomically replaces a write-only config |

No `skipPermissionTest` reference remains. The guard itself and the imports it orphaned (`chmod` in two files) are gone with it.

> **A pre-commit hook change was dropped from this PR.** It made the formatting hook `git add` its own output so commits stopped aborting. Codex and Cursor Bugbot both flagged the partially-staged path; I reproduced it and it loses uncommitted work — see [this comment](https://github.com/LionSR/TeXRA/pull/9953#issuecomment-5250396928) for the transcript and resulting state. Reverted; that ergonomics fix needs an approach outside pre-commit's stash lifecycle.

## Issue acceptance gates

No issue — direct maintainer request to remove tests that don't hold across environments.

## Single source of truth

n/a — no ownership moved. This is a deletion of test cases whose result was a function of the host.

## Duplication and abstraction budget

Removed, no abstraction added: five tests whose result depended on the environment, and the guard expression duplicated once per file across four files.

## Net elements (R6)

| Metric | Value |
| --- | --- |
| Files changed | 4 (`+2 / -131`, net **-129** LoC) |
| Exported symbols | 0 added, 0 removed |
| Classes / interfaces / enums | 0 added, 0 removed |
| Tests | **-5** (9848 → 9843); skipped **10 → 5** |
| Guard expressions | **-4** (`skipPermissionTest`, one per file) |

No production code changed — the diff is four test files.

## Consumer counts (R8)

No emit path or export re-routed. `skipPermissionTest` was a file-local `const` in each of the four files, not a shared export — 0 consumers outside its own file, confirmed by grep across `src` and `packages`. Orphaned imports were removed only after checking the rest of each file still had no use for them: `chmod` dropped from `OutputGuards` and `InitConfig`; `fs`/`path` namespace imports retained in `LoadSkills` and `CliRootArgs`, which still use them (4 and 33 references respectively).

## Host impact

Extension: none.

Desktop: none.

CLI: three CLI-suite tests removed (`OutputGuards`, `CliRootArgs`, `InitConfig`). No CLI source changed.

## Scheduled refactoring

One related observation, not acted on: `CliRootArgs.vitest.ts` has a test gated `process.platform === 'win32' ? it : it.skip` ("expands an absolute drive-letter glob"), so it runs *only* on Windows. With Windows now dispatch-only after #9948, it never runs in normal CI. It is a platform case rather than a permission case, so it is left alone here — say the word if it should go too.

## Validation

| Check | Result |
| --- | --- |
| `pnpm run test` | **849 files passed, 1 skipped, 0 failed** (9843 tests) |
| `pnpm run typecheck:test-kernel` | pass |
| `eslint` on the four edited test files | pass |
| `prettier --check` on all changed files | pass |
| `node scripts/check-guidance-refs.mjs` | pass — 51 files |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No production code changes—test suite and local commit workflow only. Slightly less coverage for real EACCES propagation on Unix non-root hosts.
> 
> **Overview**
> Removes **five Vitest cases** that relied on POSIX `chmod` to simulate permission errors. Each was wrapped in a `skipPermissionTest` guard (Windows or root), so they often ran without actually checking behavior—the same class of problem addressed in #9948. Coverage drops in `CliRootArgs`, `InitConfig`, `OutputGuards`, and `LoadSkills`; unused `chmod` imports are removed. **`InitConfig`** still keeps the mocked `readFile` EACCES test for `.gitignore` clobbering (#7470).
> 
> The **pre-commit Prettier hook** now runs `git add` on the staged paths after `prettier --write`, so formatted content is re-staged and commits proceed without a manual restage. **`AGENTS.md`** drops the redundant “run `npm run format`” pre-commit step; CI `format:check` remains the gate where the hook does not run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 895ae3a9b215c93943dda63fdade75a53f3fa751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->