### PR TITLE
Consolidate apiKeyExists/hasUsableApiKey into one implementation

### DIFF
--- a/packages/extension/src/frontend/secretManager.ts
+++ b/packages/extension/src/frontend/secretManager.ts
@@ -2,7 +2,6 @@
 import { getServerSideKeyService } from '@auth/serverKeys';
 import {
   API_PROVIDERS,
-  apiKeyExists as resolvedApiKeyExists,
   apiKeySecretName,
   hasUsableApiKey as resolvedHasUsableApiKey,
   type ApiProvider,
@@ -61,14 +60,13 @@ export class SecretManager {
   }
 
   private static async apiKeyExists(provider: ApiProvider): Promise<boolean> {
-    return resolvedApiKeyExists(platform().secrets, provider);
+    return resolvedHasUsableApiKey(platform().secrets, provider);
   }
 
   /**
-   * Like `apiKeyExists` but also rejects whitespace-only values from any
-   * resolved credential. The canonical resolver already treats empty env vars
-   * as missing; this helper is for launch checks that need an actually usable
-   * authentication value.
+   * Same check as the private `apiKeyExists` above (both delegate to
+   * `@model/apiProviders`'s `hasUsableApiKey`); exposed publicly under this
+   * name for launch-readiness call sites that want the "usable" framing.
    */
   public static async hasUsableApiKey(provider: ApiProvider): Promise<boolean> {
     return resolvedHasUsableApiKey(platform().secrets, provider);

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -169,24 +169,31 @@ export async function getApiKey(
   return key;
 }
 
-/** Check if an API key exists for a provider. */
-export async function apiKeyExists(
-  secrets: PlatformSecrets,
-  provider: ApiProvider,
-): Promise<boolean> {
-  return (await lookupApiKey(secrets, provider)) !== undefined;
-}
-
 /**
- * Check whether the resolved key is usable for authentication.
- * This rejects whitespace-only SecretStorage values while still sharing the
- * canonical secret → environment fallback and cache.
+ * Check whether a usable API key is resolved for a provider (secret storage,
+ * then environment, both already trimmed and blank-filtered by
+ * {@link resolveApiKeyUncached}). `apiKeyExists` and `hasUsableApiKey` are
+ * intentionally the same check under two names — kept distinct, like the
+ * lookup trio above, so call sites read self-evidently: reach for
+ * `apiKeyExists` at plain "is a key configured" display sites, and
+ * `hasUsableApiKey` at security-sensitive sites (credential-retry decisions,
+ * launch-readiness checks) where the name should make the stakes obvious.
+ * There is only one implementation; do not let a future edit reintroduce a
+ * real behavioral gap between them without renaming one away.
  */
 export async function hasUsableApiKey(
   secrets: PlatformSecrets,
   provider: ApiProvider,
 ): Promise<boolean> {
   return isNonEmptyString(await lookupApiKey(secrets, provider));
+}
+
+/** Alias of {@link hasUsableApiKey} for existence-check call sites. See its doc. */
+export async function apiKeyExists(
+  secrets: PlatformSecrets,
+  provider: ApiProvider,
+): Promise<boolean> {
+  return hasUsableApiKey(secrets, provider);
 }
 
 /** Check if an API key exists without using the process-wide provider cache. */

--- a/src/tools/setup/UnsetApiKeyTool.ts
+++ b/src/tools/setup/UnsetApiKeyTool.ts
@@ -46,9 +46,6 @@ export class UnsetApiKeyTool extends defineTool({
       // If no persisted entry exists but a *usable* (non-blank) key
       // is still reported, it's coming from the `<PROVIDER>_API_KEY`
       // env var — `deleteApiKey` can't touch that, so be explicit.
-      // Use `hasUsableApiKey` (not `apiKeyExists`) so a stale
-      // `PROVIDER_API_KEY=""` doesn't falsely claim an env var is
-      // supplying credentials.
       const envExists = await setupSecrets.hasUsableApiKey(provider);
       if (envExists) {
         return executed(
@@ -79,8 +76,6 @@ export class UnsetApiKeyTool extends defineTool({
 
     // A shell env var can shadow the deletion — flag that so the agent can
     // tell the user why the key still appears to exist after removal.
-    // `hasUsableApiKey` here too, so a blank env var doesn't trip the
-    // "env var still active" branch.
     const stillPresent = await setupSecrets.hasUsableApiKey(provider);
     if (stillPresent) {
       return executed(

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -35,16 +35,16 @@ import { resolveGitHubTokenSource } from '@tools/github/githubAuth';
 export interface SetupSecretsAdapter {
   deleteApiKey(provider: ApiProvider): Promise<void>;
   /**
-   * Like `apiKeyExists` but rejects empty values. A stale
-   * `PROVIDER_API_KEY=""` env var is "present" but unusable at launch,
-   * so setup-readiness checks must use this helper rather than raw
-   * `apiKeyExists` to avoid misleading the agent (and the user).
+   * Whether a usable key is resolved for the provider (secret storage, then
+   * environment; blank values already filtered — see `hasUsableApiKey` in
+   * `@model/apiProviders`). Named for the launch/retry-readiness call sites
+   * here, which want the "is this actually usable" framing.
    */
   hasUsableApiKey(provider: ApiProvider): Promise<boolean>;
   /** Whether a usable key comes from TeXRA secrets, the environment, or neither. */
   apiKeyOrigin(provider: ApiProvider): Promise<ApiKeyOrigin>;
   /**
-   * Like `apiKeyExists` but only reports persisted entries — ignores
+   * Unlike `hasUsableApiKey`, only reports persisted entries — ignores
    * environment-variable-backed keys. Needed by `unset_api_key` so the
    * agent doesn't claim to have removed a key that still comes from
    * `PROVIDER_API_KEY` in the user's shell.


### PR DESCRIPTION
## Summary

Scheduled architecture-health audit found that `apiKeyExists` and `hasUsableApiKey` in `src/model/apiProviders.ts` had two independent implementations that had quietly become behaviorally identical: `resolveApiKeyUncached` (the shared secret → env resolver both funnel through) already trims and blank-filters every resolved key before either predicate runs. Despite that, three call sites (`UnsetApiKeyTool`, `SetupSecretsAdapter`, extension `SecretManager`) carried comments claiming `apiKeyExists` could still be fooled by a stale/blank `PROVIDER_API_KEY=""` env var and that `hasUsableApiKey` was needed to avoid it. That claim is false today and is exactly the kind of "which one do I call, and why" trap that makes a future bug fix land in only one of the two twins.

This PR removes the duplicate implementation (one function now delegates to the other) and corrects the stale comments, without changing behavior anywhere.

## Issue acceptance gates

Ad hoc scheduled audit, no tracked issue. Acceptance gate: the two predicates have one implementation, and every comment describing the relationship between them is accurate.

## Single source of truth

`hasUsableApiKey` in `src/model/apiProviders.ts` is now the sole implementation; `apiKeyExists` is a one-line alias. Both names are kept (mirroring the file's existing `lookupApiKey`/`lookupApiKeyOrigin`/`getApiKey` "trio" pattern) because they carry real call-site meaning — `apiKeyExists` for plain "is a key configured" display checks, `hasUsableApiKey` for security-sensitive launch/credential-retry checks — even though the check itself is identical.

## Duplication and abstraction budget

Removed: one duplicate function body (`apiKeyExists` no longer reimplements the existence check; it calls `hasUsableApiKey`). No new abstraction — the alias is a single delegating line, not a new layer.

## Net elements (R6)

4 files changed, +26/-26 lines. Exported symbol count unchanged (`apiKeyExists` and `hasUsableApiKey` both still exported from `src/model/apiProviders.ts`); no export added or removed. Net LoC ~0.

## Consumer counts (R8)

n/a — no export deleted or re-routed; all existing call sites of both `apiKeyExists` and `hasUsableApiKey` keep working unchanged (verified by grep across `src/` and `packages/*`).

## Host impact

Extension: `packages/extension/src/frontend/secretManager.ts` — `SecretManager.apiKeyExists`/`hasUsableApiKey` now share one delegate call; public API unchanged.

Desktop: none (only consumes `hasUsableApiKey`, untouched).

CLI: none (only consumes `apiKeyExists`/`hasUsableApiKey`, untouched).

## Scheduled refactoring

None. Note for future reference: the same audit also flagged a larger, higher-risk duplication between `src/transcript/StreamLogStore.ts` and `src/transcript/StreamSnapshotStore.ts` (independent dirty-write/retry/lock machinery for the same "don't lose an in-flight write" concern). The repo's own `docs/proposals/2026-08-07-prod-structural-leads-triage.md` already flags this and explicitly declined to unify it without first formalizing flush semantics — that's out of scope for an unattended automated PR and is left for dedicated design work, not silently dropped.

## Validation

- `npm run typecheck` (full workspace: workspace, test-kernel, agent, cli, trace-viewer, desktop) — pass
- `npx eslint` on all four changed files — clean
- `npx vitest run` on `ApiProviders`, `TuiApprovalRetry`, `ModelAccessSelection`, `DefaultSetupPlatform`, `SetupAssistantRouting` vitest suites (all suites that reference `apiKeyExists`/`hasUsableApiKey`) — 109/109 pass
- `npm run check:dead-code-ratchet` — no new dead code, ratchet unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01LT4DGLetwU8SCtUxauMGJ8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only consolidation of credential predicates with tests and typecheck noted in the PR; no new auth paths or export removals.
> 
> **Overview**
> **Unifies API key existence checks** so `apiKeyExists` and `hasUsableApiKey` in `apiProviders.ts` share a single implementation (`hasUsableApiKey` via `isNonEmptyString` on `lookupApiKey`; `apiKeyExists` delegates). Both names stay for call-site clarity (display vs launch/security framing).
> 
> **Updates misleading comments** in `UnsetApiKeyTool`, `SetupSecretsAdapter`, and extension `SecretManager` that claimed the two helpers could disagree on blank env vars—`resolveApiKeyUncached` already trims and filters blanks.
> 
> **Extension `SecretManager`**: private `apiKeyExists` now calls `hasUsableApiKey` instead of the removed duplicate import path; public surface unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d817a985e59e10d6209c1f7a6f5dfd27a673635a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->