### PR TITLE
fix(logger): dispose per-run output channels at run-trace teardown

### DIFF
--- a/src/agent/trace/channelTrace.ts
+++ b/src/agent/trace/channelTrace.ts
@@ -68,8 +68,13 @@ export function attachChannelSubscriber(
   };
 
   const unsubscribe = trace.subscribe(subscriber);
+  // Run-once: a second invocation after a same-name re-attach (resumed runs
+  // reuse their stream ID) must not dispose the new owner's channel.
+  let released = false;
   return () => {
     unsubscribe();
+    if (released) return;
+    released = true;
     // A per-run agent channel dies with its run; without this every run leaks
     // a live host output channel. Shared channels outlive the subscriber.
     if (options.isAgent) disposeAgentChannel(options.channel);

--- a/src/agent/trace/channelTrace.ts
+++ b/src/agent/trace/channelTrace.ts
@@ -3,7 +3,11 @@
  */
 
 // Local imports
-import { createChannelWriter, type ChannelWriter } from '@logger/logUtils';
+import {
+  createChannelWriter,
+  disposeAgentChannel,
+  type ChannelWriter,
+} from '@logger/logUtils';
 import { MESSAGE_TYPES, type LogLevel } from '@shared/schemas';
 
 // Local file imports
@@ -63,5 +67,11 @@ export function attachChannelSubscriber(
     writer(event.level, event.message, event.data);
   };
 
-  return trace.subscribe(subscriber);
+  const unsubscribe = trace.subscribe(subscriber);
+  return () => {
+    unsubscribe();
+    // A per-run agent channel dies with its run; without this every run leaks
+    // a live host output channel. Shared channels outlive the subscriber.
+    if (options.isAgent) disposeAgentChannel(options.channel);
+  };
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -79,8 +79,12 @@ function createOutputChannel(channel: string, isAgent: boolean): OutputSink {
   return outputSinksTrusted ? sink : createRedactingSink(sink);
 }
 
+function channelKey(channel: string, isAgent: boolean): string {
+  return `${channel}::${isAgent ? 'agent' : 'shared'}`;
+}
+
 function ensureChannel(channel: string, isAgent: boolean): OutputSink {
-  const key = `${channel}::${isAgent ? 'agent' : 'shared'}`;
+  const key = channelKey(channel, isAgent);
   const existing = channels.get(key);
   if (existing) return existing;
 
@@ -89,6 +93,19 @@ function ensureChannel(channel: string, isAgent: boolean): OutputSink {
     : (mainOutputChannel ??= createOutputChannel(channel, false));
   channels.set(key, output);
   return output;
+}
+
+/**
+ * Dispose one agent channel's sink and forget it, so a writer re-created for
+ * the same name starts on a fresh sink. Only agent channels are eligible: the
+ * shared main channel lives until {@link setOutputChannelFactory} replaces it.
+ */
+export function disposeAgentChannel(channel: string): void {
+  const key = channelKey(channel, /* isAgent */ true);
+  const sink = channels.get(key);
+  if (!sink) return;
+  channels.delete(key);
+  sink.dispose?.();
 }
 
 /**

--- a/src/test-kernel/agent/trace/ChannelTrace.vitest.ts
+++ b/src/test-kernel/agent/trace/ChannelTrace.vitest.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import {
@@ -93,5 +93,56 @@ describe('channel trace adapters', () => {
     expect(output).toContain('visible emitter line');
     expect(output).not.toContain('internal emitter line');
     expect(output).not.toContain('detached emitter line');
+  });
+
+  it('disposes the per-run agent sink on detach and re-creates it fresh', () => {
+    const dispose = vi.fn();
+    let created = 0;
+    logUtils.setOutputChannelFactory(() => {
+      created += 1;
+      return { appendLine: vi.fn(), dispose };
+    });
+
+    const trace = new TraceEmitter();
+    const detach = attachChannelSubscriber(trace, {
+      channel: 'run-stream',
+      isAgent: true,
+    });
+    expect(created).toBe(1);
+
+    detach();
+    expect(dispose).toHaveBeenCalledOnce();
+
+    // Double detach must not dispose again: the channel entry is gone.
+    detach();
+    expect(dispose).toHaveBeenCalledOnce();
+
+    // Re-attaching the same channel name mints a fresh sink, proving the
+    // channel map entry was removed rather than left pointing at a disposed
+    // sink.
+    const reattach = attachChannelSubscriber(trace, {
+      channel: 'run-stream',
+      isAgent: true,
+    });
+    expect(created).toBe(2);
+    reattach();
+    expect(dispose).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the shared channel alive when a shared subscriber detaches', () => {
+    const dispose = vi.fn();
+    logUtils.setOutputChannelFactory(() => ({
+      appendLine: vi.fn(),
+      dispose,
+    }));
+
+    const trace = new TraceEmitter();
+    const detach = attachChannelSubscriber(trace, {
+      channel: 'Agent',
+      isAgent: false,
+    });
+
+    detach();
+    expect(dispose).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/agent/trace/ChannelTrace.vitest.ts
+++ b/src/test-kernel/agent/trace/ChannelTrace.vitest.ts
@@ -129,6 +129,31 @@ describe('channel trace adapters', () => {
     expect(dispose).toHaveBeenCalledTimes(2);
   });
 
+  it('stale detach after a same-name re-attach leaves the new sink alive', () => {
+    const dispose = vi.fn();
+    logUtils.setOutputChannelFactory(() => ({
+      appendLine: vi.fn(),
+      dispose,
+    }));
+
+    const trace = new TraceEmitter();
+    const detachFirst = attachChannelSubscriber(trace, {
+      channel: 'run-stream',
+      isAgent: true,
+    });
+    detachFirst();
+    expect(dispose).toHaveBeenCalledOnce();
+
+    // A resumed run reuses the stream ID; the stale first detach must not
+    // tear down the channel the second attachment now owns.
+    attachChannelSubscriber(trace, {
+      channel: 'run-stream',
+      isAgent: true,
+    });
+    detachFirst();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
   it('keeps the shared channel alive when a shared subscriber detaches', () => {
     const dispose = vi.fn();
     logUtils.setOutputChannelFactory(() => ({

--- a/src/test-kernel/logger/RunTraceDispose.vitest.ts
+++ b/src/test-kernel/logger/RunTraceDispose.vitest.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import * as logUtils from '@logger/logUtils';
 import { MESSAGE_TYPES, type StreamTabId } from '@shared/schemas';
 import { createRunTrace, StreamLogStore } from '@transcript';
 import type { RunTraceFlushEntry } from '@transcript/runTrace';
@@ -14,6 +15,22 @@ describe('createRunTrace dispose', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    logUtils.setOutputChannelFactory(null);
+  });
+
+  it('disposes the per-run output channel on teardown', () => {
+    const dispose = vi.fn();
+    logUtils.setOutputChannelFactory(() => ({
+      appendLine: vi.fn(),
+      dispose,
+    }));
+    const handle = createRunTrace('channel-stream', store);
+
+    handle.dispose();
+    expect(dispose).toHaveBeenCalledOnce();
+
+    handle.dispose();
+    expect(dispose).toHaveBeenCalledOnce();
   });
 
   it('removes the flusher from its owning session set on dispose', () => {


### PR DESCRIPTION
Fixes #9962

## Problem

`createRunTrace` (`src/transcript/runTrace.ts`) attaches a channel subscriber whose channel name is the streamId, unique per run. `src/logger/logUtils.ts` holds those sinks in a module-level map that was only ever `.set()` or `.clear()`, never `.delete()`, and channel creation is eager. Detaching the trace subscriber never disposed the channel, so every agent run and every delegated child (`childStream.ts`) leaked a live VS Code `OutputChannel` (extension-host object, renderer registration, Output-dropdown entry) for the host's lifetime. Multi-day sessions accumulate hundreds to thousands.

## Fix

- `logUtils`: new `disposeAgentChannel(channel)` disposes the sink (when it exposes `dispose`) and deletes the map entry. Only agent channels are eligible; the shared main "TeXRA" channel lives until `setOutputChannelFactory` replaces it. `ensureChannel` mints a fresh sink if the same name is used again after disposal.
- `channelTrace`: the unsubscribe returned by `attachChannelSubscriber` now also disposes the per-run channel when `isAgent` is true. This is the existing run-trace teardown path, so both leak sites (main runs via `AgentLaunchContext` and delegated children via `childStream`) are covered with no call-site changes. `ModelHandler`'s shared `isAgent: false` attach is unaffected.
- No extension wiring change needed: `vscode.window.createOutputChannel(name)` already satisfies the optional `dispose` on `OutputSink`, and the redacting wrapper forwards disposal. CLI/desktop console fallbacks have no `dispose`, so disposal is a no-op there.

## Tests

- `ChannelTrace.vitest.ts`: detach disposes the per-run sink exactly once, double-detach is safe, re-attaching the same channel name creates a fresh sink (map entry removed), and a shared-channel detach never disposes.
- `RunTraceDispose.vitest.ts`: run-trace teardown disposes the run channel; double teardown stays a no-op.
- `npm run typecheck` and `npm run lint` pass; targeted vitest files (ChannelTrace, RunTraceDispose, LogUtils) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gtc6wQMD1hedgabjQMfAun

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lifecycle fix for logging sinks with explicit guards for shared channels and resumed runs; no auth, data, or business-logic changes.
> 
> **Overview**
> Fixes a **leak of VS Code output channels** where per-run agent sinks stayed in a module-level map after trace detach, so long sessions accumulated hundreds of live `OutputChannel` instances.
> 
> Adds **`disposeAgentChannel`** in `logUtils` to call optional `dispose` on the sink and remove the map entry (agent channels only; the shared main TeXRA channel is unchanged). **`attachChannelSubscriber`** now disposes on detach when `isAgent` is true, with a **run-once guard** so a stale detach after a same-name re-attach (resumed runs) does not tear down the new owner's channel.
> 
> Tests cover single/double detach, re-attach with a fresh sink, stale detach after re-attach, shared-channel non-disposal, and run-trace teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b9d09024afb7fa99fa2ced634b3a39ca22fdf76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->