### PR TITLE
fix(extension): bound event-edge work for long-lived sessions

### DIFF
--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -226,10 +226,14 @@ export class ProgressViewProvider extends BaseWebviewProvider {
           },
         );
       }),
-      vscode.window.onDidChangeActiveColorTheme(() => {
-        if (this.isViewVisible()) {
-          this.syncFullView();
-        }
+      vscode.window.onDidChangeActiveColorTheme(({ kind }) => {
+        // The webview only needs the THEME_SET message here (BaseWebviewApp's
+        // onThemeChange swaps the body class); rebuilding metadata for every
+        // persisted stream on a theme flip is pure waste (#9959).
+        if (!this.isViewVisible() || !this.canSendToWebview()) return;
+        this.webviewUpdater.setTheme(
+          kind === vscode.ColorThemeKind.Dark ? 'dark' : 'light',
+        );
       }),
     );
   }

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -128,6 +128,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 > {
   private executionsWatcher: vscode.FileSystemWatcher | undefined;
   private executionsWatcherGeneration = 0;
+  private executionsWatcherWanted = false;
+  private visibilityTrackedView:
+    vscode.WebviewView | vscode.WebviewPanel | undefined;
+  private visibilityListener: vscode.Disposable | undefined;
   private readonly handlerRegistry: SettingsViewInboundHandlerRegistry;
 
   // Domain-specific handler delegates
@@ -260,16 +264,72 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
     // Cross-host history refresh (#8625): the shared ~/.texra executions dir
     // is written by the CLI and desktop too, so an open history tab re-lists
-    // when any host adds, finishes, or deletes a run. Re-registered on
-    // workspace-folder changes because the storage path follows the current
-    // workspace.
-    void this.registerExecutionsWatcher();
+    // when any host adds, finishes, or deletes a run. The watcher lives only
+    // while the settings webview is visible — every event debounces into a
+    // full listExecutions() rescan, and the Dashboard panel retains its
+    // context when hidden, so a background tab would otherwise keep rescanning
+    // for days (#9959). Re-registered on workspace-folder changes because the
+    // storage path follows the current workspace.
     context.subscriptions.push(
       vscode.workspace.onDidChangeWorkspaceFolders(() => {
-        void this.registerExecutionsWatcher();
+        if (this.executionsWatcherWanted) {
+          void this.registerExecutionsWatcher();
+        }
       }),
-      { dispose: () => this.invalidateExecutionsWatcher() },
+      { dispose: () => this.detachViewVisibility() },
     );
+  }
+
+  /**
+   * Track the dispatching view's visibility so the executions watcher runs
+   * only while the settings webview is actually on screen. Dispatch is the
+   * first (and only) place this handler learns which view it serves.
+   */
+  protected override onDispatch(
+    view: vscode.WebviewView | vscode.WebviewPanel,
+  ): void {
+    if (this.visibilityTrackedView === view) return;
+    this.visibilityListener?.dispose();
+    this.visibilityTrackedView = view;
+    const onVisibilityChange = () =>
+      this.syncWatcherToVisibility({ refreshOnShow: true });
+    this.visibilityListener =
+      'viewColumn' in view
+        ? view.onDidChangeViewState(onVisibilityChange)
+        : view.onDidChangeVisibility(onVisibilityChange);
+    // The dispatch in flight already produces fresh data; no extra refresh.
+    this.syncWatcherToVisibility({ refreshOnShow: false });
+  }
+
+  public override clearActiveView(): void {
+    super.clearActiveView();
+    this.detachViewVisibility();
+  }
+
+  private detachViewVisibility(): void {
+    this.visibilityListener?.dispose();
+    this.visibilityListener = undefined;
+    this.visibilityTrackedView = undefined;
+    this.executionsWatcherWanted = false;
+    this.invalidateExecutionsWatcher();
+  }
+
+  private syncWatcherToVisibility(options: { refreshOnShow: boolean }): void {
+    const visible = this.visibilityTrackedView?.visible === true;
+    if (visible === this.executionsWatcherWanted) return;
+    this.executionsWatcherWanted = visible;
+    if (!visible) {
+      this.invalidateExecutionsWatcher();
+      return;
+    }
+    void this.registerExecutionsWatcher();
+    // Runs recorded while hidden never fired the watcher; one list refresh
+    // brings the history tab current on re-show.
+    if (options.refreshOnShow) {
+      void this.withActiveWebview((w) =>
+        this.historyHandlers.sendHistoryData(w),
+      );
+    }
   }
 
   private invalidateExecutionsWatcher(): number {

--- a/src/controllers/progressView/backend/WebviewUpdater.ts
+++ b/src/controllers/progressView/backend/WebviewUpdater.ts
@@ -202,6 +202,14 @@ export class WebviewUpdater {
     });
   }
 
+  /** Push the host theme alone — theme flips need no metadata rebuild. */
+  setTheme(theme: 'dark' | 'light'): void {
+    this.sendMessage({
+      command: PROGRESS_VIEW_COMMANDS.THEME_SET,
+      theme,
+    });
+  }
+
   /**
    * Update a single stream's status in the stream tabs.
    * More efficient than updateStreams when only status changed.
@@ -342,12 +350,7 @@ export class WebviewUpdater {
       return activeStream;
     }
 
-    if (theme) {
-      this.sendMessage({
-        command: PROGRESS_VIEW_COMMANDS.THEME_SET,
-        theme,
-      });
-    }
+    if (theme) this.setTheme(theme);
 
     // Send lightweight metadata — only backend-owned fields the frontend merges.
     const streamMetadata: Record<StreamTabId, StreamMetadata> = {};

--- a/src/controllers/session/streamInfoUtils.ts
+++ b/src/controllers/session/streamInfoUtils.ts
@@ -5,7 +5,10 @@ import { peekWorktreeInfo, resolveWorktreeInfo } from '@utils/git/worktreeInfo';
 import { buildStreamTabInfo } from './streamTabInfo';
 
 /** The state a single tab info is built from. */
-export type StreamInfoSource = Pick<SessionState, 'getStreamMetadata'>;
+export type StreamInfoSource = Pick<
+  SessionState,
+  'getStreamMetadata' | 'activeStream' | 'streamStatus'
+>;
 
 /** The state the full tab list is built from. */
 export type StreamInfoListSource = StreamInfoSource &
@@ -21,11 +24,16 @@ export function buildStreamInfo(
   let worktreeInfo;
   if (workingDirectory) {
     worktreeInfo = peekWorktreeInfo(workingDirectory);
-    // Fire-and-forget; the resolver owns TTL/in-flight de-duplication. Calling
-    // it on each render lets branch/dirty state refresh after the cache expires.
-    void resolveWorktreeInfo(workingDirectory).catch(() => {
-      /* best-effort chip enrichment */
-    });
+    // Probe git only for live streams plus the selected tab: the resolver's
+    // LRU holds 32 entries, so probing every historical stream on a metadata
+    // rebuild thrashes the cache and spawns git per stream (#9959). Terminal
+    // streams render their last-known value from the peek above, or nothing.
+    if (id === state.activeStream || state.streamStatus.isInFlight(id)) {
+      // Fire-and-forget; the resolver owns TTL/in-flight de-duplication.
+      void resolveWorktreeInfo(workingDirectory).catch(() => {
+        /* best-effort chip enrichment */
+      });
+    }
   }
 
   return buildStreamTabInfo({

--- a/src/test-kernel/progressView/ProgressThemeSync.vitest.ts
+++ b/src/test-kernel/progressView/ProgressThemeSync.vitest.ts
@@ -1,0 +1,172 @@
+// Theme flips must send THEME_SET alone — never a full stream-metadata
+// rebuild, which scales with total workspace history (#9959).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as vscode from 'vscode';
+
+const mocks = vi.hoisted(() => ({
+  backend: {
+    approvalHandlers: { toolEdit: { show: vi.fn(), dismiss: vi.fn() } },
+    dispose: vi.fn(),
+    setupEventListeners: vi.fn(),
+    setApprovalBypassState: vi.fn(),
+    state: {
+      streamStatus: { getAllStreamStates: vi.fn(() => new Map()) },
+    },
+    webviewUpdater: {
+      isAvailable: vi.fn(() => true),
+      setTheme: vi.fn(),
+      setPlacement: vi.fn(),
+      sendStreamMetadata: vi.fn(),
+    },
+  },
+  themeListeners: [] as Array<(theme: { kind: number }) => void>,
+}));
+
+vi.mock('vscode', () => ({
+  ColorThemeKind: { Light: 1, Dark: 2 },
+  Uri: { file: (fsPath: string) => ({ fsPath }) },
+  window: {
+    activeColorTheme: { kind: 1 },
+    onDidChangeActiveColorTheme: (
+      listener: (theme: { kind: number }) => void,
+    ) => {
+      mocks.themeListeners.push(listener);
+      return { dispose: vi.fn() };
+    },
+    showErrorMessage: vi.fn(),
+    showInformationMessage: vi.fn(),
+  },
+  workspace: {
+    onDidChangeWorkspaceFolders: () => ({ dispose: vi.fn() }),
+  },
+}));
+
+vi.mock('@common/webview', () => ({
+  BaseWebviewProvider: class {
+    protected readonly _disposables: Array<{ dispose(): void }> = [];
+
+    dispose(): void {
+      for (const disposable of this._disposables) disposable.dispose();
+    }
+  },
+  BundledViewContentProvider: class {},
+  getActiveSidebarView: () => 'main',
+  getSharedLocalResourceRoots: () => [],
+  SIDEBAR_VIEWS: { MAIN: 'main', PROGRESS: 'progress' },
+}));
+vi.mock('@common/state', () => ({ workspaceSM: {} }));
+vi.mock('@agent/trace', () => ({
+  createChannelTrace: () => ({ debug: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('@agent/runtime/SessionHandle', () => ({
+  defaultSession: () => ({
+    interactions: {},
+    useHostInteractions: () => () => {},
+  }),
+  tryDefaultSession: () => ({
+    interactions: {},
+    useHostInteractions: () => () => {},
+  }),
+}));
+vi.mock('@agent/runtime/terminalResultToast', () => ({
+  attachTerminalResultToast: () => () => {},
+}));
+vi.mock('@controllers/progressView/backend/ProgressBackend', () => ({
+  ProgressBackend: class {
+    constructor() {
+      return mocks.backend;
+    }
+  },
+}));
+vi.mock('@controllers/approval/ToolEditApprovalController', () => ({
+  ToolEditApprovalController: class {
+    dispose(): void {}
+  },
+}));
+vi.mock('@controllers/progressView/backend/agentProposalTransport', () => ({
+  createAgentProposalTransport: () => ({}),
+}));
+vi.mock('@controllers/progressView/backend/progressBackendUiConfig', () => ({
+  replayApprovalRequestHandlers: vi.fn(),
+}));
+vi.mock('@frontend/approval/VscodeToolEditApprovalHost', () => ({
+  VscodeToolEditApprovalHost: class {},
+}));
+vi.mock('@frontend/hosts/VscodePromptHost', () => ({
+  VscodePromptHost: class {},
+}));
+vi.mock('@frontend/events/agentEventListeners', () => ({
+  createAgentPresentationHost: () => ({}),
+}));
+vi.mock('@progressView/extensionHostInteractions', () => ({
+  createExtensionHostInteractions: () => ({}),
+}));
+vi.mock('@progressView/ProgressViewMessageHandler', () => ({
+  ProgressViewMessageHandler: class {},
+}));
+vi.mock('@eventBus/AppSignals', () => ({
+  appSignals: { on: () => () => {} },
+}));
+
+const { ProgressViewProvider } =
+  await import('@progressView/ProgressViewProvider');
+
+function createProvider(): InstanceType<typeof ProgressViewProvider> {
+  return new ProgressViewProvider(
+    {
+      storageUri: { fsPath: '/tmp/ext-storage' },
+    } as unknown as vscode.ExtensionContext,
+    {} as never,
+    { getWorkspacePath: () => undefined } as never,
+  );
+}
+
+function fireThemeChange(kind: number): void {
+  for (const listener of mocks.themeListeners) listener({ kind });
+}
+
+describe('progress view theme sync', () => {
+  beforeEach(() => {
+    mocks.themeListeners.length = 0;
+    mocks.backend.webviewUpdater.setTheme.mockClear();
+    mocks.backend.webviewUpdater.sendStreamMetadata.mockClear();
+  });
+
+  it('sends only the theme message on theme change, mapped by kind', () => {
+    const provider = createProvider();
+    const panel = { visible: true };
+    (provider as unknown as Record<string, unknown>).target = {
+      placement: 'editor',
+      panel,
+      disposables: [],
+      ready: true,
+    };
+
+    fireThemeChange(2);
+    fireThemeChange(1);
+
+    expect(
+      mocks.backend.webviewUpdater.setTheme.mock.calls.map(([theme]) => theme),
+    ).toEqual(['dark', 'light']);
+    // The regression this pins down: no full stream-metadata rebuild.
+    expect(
+      mocks.backend.webviewUpdater.sendStreamMetadata,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('drops theme changes while no progress surface is visible', () => {
+    const provider = createProvider();
+    (provider as unknown as Record<string, unknown>).target = {
+      placement: 'editor',
+      panel: { visible: false },
+      disposables: [],
+      ready: true,
+    };
+
+    fireThemeChange(2);
+
+    expect(mocks.backend.webviewUpdater.setTheme).not.toHaveBeenCalled();
+  });
+});

--- a/src/test-kernel/progressView/streamInfoUtils.vitest.ts
+++ b/src/test-kernel/progressView/streamInfoUtils.vitest.ts
@@ -2,11 +2,21 @@
 // (streamOrdering + streamTabInfo).
 
 import { strict as assert } from 'node:assert';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getStreamTabDisplayName } from '@agent/runtime/streamTab';
+import {
+  buildStreamInfo,
+  type StreamInfoSource,
+} from '@controllers/session/streamInfoUtils';
 import { buildStreamTabInfo } from '@controllers/session/streamTabInfo';
 import { AgentCategory, type StreamTabInfo } from '@shared/schemas';
 import { compareByNewestCreationTime } from '@shared/streams/streamOrdering';
+import { peekWorktreeInfo, resolveWorktreeInfo } from '@utils/git/worktreeInfo';
+
+vi.mock('@utils/git/worktreeInfo', () => ({
+  peekWorktreeInfo: vi.fn(() => undefined),
+  resolveWorktreeInfo: vi.fn(async () => ({ workingDirectory: '/wt' })),
+}));
 
 const CHILD_STREAM_ID = 'bash@tool#exec:child-stream';
 
@@ -57,6 +67,54 @@ describe('compareByNewestCreationTime', () => {
       streams.sort(compareByNewestCreationTime).map((stream) => stream.name),
       expected,
     );
+  });
+});
+
+describe('buildStreamInfo git probe gating', () => {
+  function stateWith(overrides: {
+    activeStream?: string;
+    inFlight?: string[];
+  }): StreamInfoSource {
+    return {
+      getStreamMetadata: () => ({
+        creationTimestamp: 1,
+        config: { instruction: '', workingDirectory: '/wt' },
+      }),
+      activeStream: overrides.activeStream ?? '',
+      streamStatus: {
+        isInFlight: (id: string) => overrides.inFlight?.includes(id) ?? false,
+      },
+    } as unknown as StreamInfoSource;
+  }
+
+  beforeEach(() => {
+    vi.mocked(resolveWorktreeInfo).mockClear();
+    vi.mocked(peekWorktreeInfo).mockClear().mockReturnValue(undefined);
+  });
+
+  it('probes git for in-flight streams and the selected tab', () => {
+    const source = stateWith({
+      activeStream: 'selected#1',
+      inFlight: ['running#1'],
+    });
+
+    buildStreamInfo(source, 'running#1');
+    buildStreamInfo(source, 'selected#1');
+
+    expect(vi.mocked(resolveWorktreeInfo).mock.calls).toEqual([
+      ['/wt'],
+      ['/wt'],
+    ]);
+  });
+
+  it('shows the last-known value for terminal streams without spawning git', () => {
+    const cached = { workingDirectory: '/wt', branch: 'main', dirty: false };
+    vi.mocked(peekWorktreeInfo).mockReturnValue(cached);
+
+    const info = buildStreamInfo(stateWith({}), 'finished#1');
+
+    expect(info.worktree).toEqual(cached);
+    expect(resolveWorktreeInfo).not.toHaveBeenCalled();
   });
 });
 

--- a/src/test-kernel/settings/CopilotRoutePreferenceHandler.vitest.ts
+++ b/src/test-kernel/settings/CopilotRoutePreferenceHandler.vitest.ts
@@ -91,7 +91,12 @@ function createHandler(): SettingsViewMessageHandler {
 }
 
 function createWebviewView(): vscode.WebviewView {
+  // Dispatch attaches visibility tracking for the executions watcher (#9959),
+  // so the view must expose the visibility surface. `visible: false` keeps the
+  // watcher unregistered — history refresh is orthogonal to routing.
   return {
+    visible: false,
+    onDidChangeVisibility: () => ({ dispose: () => {} }),
     webview: { postMessage: vi.fn(async () => true) },
   } as unknown as vscode.WebviewView;
 }

--- a/src/test-kernel/settings/ExecutionHistoryWatcher.vitest.ts
+++ b/src/test-kernel/settings/ExecutionHistoryWatcher.vitest.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 
 import * as logger from '@logger/logUtils';
 import { SettingsViewMessageHandler } from '@settingsView/SettingsViewMessageHandler';
+import { HistoryHandlers } from '@settingsView/handlers/historyHandlers';
 import { createDeferred } from '@test/support/asyncTestUtils';
 import { StorageFS } from '@utils/files/storageFS';
 
@@ -30,6 +31,7 @@ vi.mock('vscode', async (importOriginal) => {
 });
 
 type HandlerFixture = {
+  handler: SettingsViewMessageHandler;
   /** Fires the workspace-folders-changed event the handler subscribes to. */
   fireWorkspaceFoldersChanged(): void;
   /** Disposes every subscription the constructor registered (view teardown). */
@@ -37,17 +39,19 @@ type HandlerFixture = {
 };
 
 /**
- * The real constructor kicks off the initial watcher registration and wires
- * re-registration to folder changes and teardown to context subscriptions, so
- * every scenario below is driven through those public triggers.
+ * The watcher registers only while a settings webview is visible (#9959), so
+ * every scenario below drives registration through a dispatch from a fake
+ * panel plus its visibility events, and teardown through the context
+ * subscriptions the constructor registered.
  */
 function createHandler(): HandlerFixture {
   const subscriptions: Array<{ dispose(): void }> = [];
-  new SettingsViewMessageHandler({
+  const handler = new SettingsViewMessageHandler({
     subscriptions,
     extensionPath: '/ext',
   } as unknown as vscode.ExtensionContext);
   return {
+    handler,
     fireWorkspaceFoldersChanged: () => {
       for (const listener of mocks.workspaceFoldersListeners) listener();
     },
@@ -57,6 +61,42 @@ function createHandler(): HandlerFixture {
       }
     },
   };
+}
+
+type ViewFixture = {
+  view: vscode.WebviewPanel;
+  setVisible(visible: boolean): void;
+};
+
+function createView(visible = true): ViewFixture {
+  const listeners: Array<() => void> = [];
+  const view = {
+    visible,
+    viewColumn: 1,
+    onDidChangeViewState: (listener: () => void) => {
+      listeners.push(listener);
+      return { dispose: vi.fn() };
+    },
+    webview: { postMessage: vi.fn(async () => true) },
+  };
+  return {
+    view: view as unknown as vscode.WebviewPanel,
+    setVisible: (next: boolean) => {
+      view.visible = next;
+      for (const listener of listeners) listener();
+    },
+  };
+}
+
+/**
+ * Any dispatch attaches visibility tracking (`onDispatch` runs before the
+ * command is resolved), so an unknown command exercises nothing else.
+ */
+function attach(
+  handler: SettingsViewMessageHandler,
+  view: vscode.WebviewPanel,
+): Promise<void> {
+  return handler.handleMessage({ command: 'visibility-probe' }, view);
 }
 
 /** Let queued registration continuations (microtasks) run to completion. */
@@ -77,18 +117,99 @@ function watcher(): vscode.FileSystemWatcher {
 }
 
 describe('settings execution history watcher', () => {
+  let sendHistoryData: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     mocks.workspaceFoldersListeners.length = 0;
+    // The on-show refresh lists executions from storage; the lifecycle under
+    // test only cares that the refresh was requested.
+    sendHistoryData = vi
+      .spyOn(HistoryHandlers.prototype, 'sendHistoryData')
+      .mockResolvedValue(undefined) as ReturnType<typeof vi.spyOn>;
   });
 
   afterEach(() => vi.restoreAllMocks());
+
+  it('registers only once a visible view dispatches, not on construction', async () => {
+    vi.spyOn(StorageFS, 'ensureDir').mockResolvedValue(undefined);
+    const createWatcher = vi
+      .spyOn(vscode.workspace, 'createFileSystemWatcher')
+      .mockReturnValue(watcher());
+
+    const fixture = createHandler();
+    fixture.fireWorkspaceFoldersChanged();
+    await flushRegistrations();
+    expect(createWatcher).not.toHaveBeenCalled();
+
+    await attach(fixture.handler, createView().view);
+    await vi.waitFor(() => expect(createWatcher).toHaveBeenCalledOnce());
+  });
+
+  it('does not register while the view is hidden', async () => {
+    vi.spyOn(StorageFS, 'ensureDir').mockResolvedValue(undefined);
+    const createWatcher = vi
+      .spyOn(vscode.workspace, 'createFileSystemWatcher')
+      .mockReturnValue(watcher());
+
+    const fixture = createHandler();
+    const { view, setVisible } = createView(false);
+    await attach(fixture.handler, view);
+    await flushRegistrations();
+    expect(createWatcher).not.toHaveBeenCalled();
+
+    setVisible(true);
+    await vi.waitFor(() => expect(createWatcher).toHaveBeenCalledOnce());
+  });
+
+  it('disposes the watcher on hide and re-registers with one refresh on show', async () => {
+    vi.spyOn(StorageFS, 'ensureDir').mockResolvedValue(undefined);
+    const firstWatcher = watcher();
+    const secondWatcher = watcher();
+    const createWatcher = vi
+      .spyOn(vscode.workspace, 'createFileSystemWatcher')
+      .mockReturnValueOnce(firstWatcher)
+      .mockReturnValue(secondWatcher);
+
+    const fixture = createHandler();
+    const { view, setVisible } = createView();
+    await attach(fixture.handler, view);
+    await vi.waitFor(() => expect(createWatcher).toHaveBeenCalledOnce());
+    // The attach dispatch produces its own data; no extra refresh on it.
+    expect(sendHistoryData).not.toHaveBeenCalled();
+
+    setVisible(false);
+    expect(firstWatcher.dispose).toHaveBeenCalledOnce();
+
+    setVisible(true);
+    await vi.waitFor(() => expect(createWatcher).toHaveBeenCalledTimes(2));
+    expect(sendHistoryData).toHaveBeenCalledOnce();
+    expect(secondWatcher.dispose).not.toHaveBeenCalled();
+  });
+
+  it('tears the watcher down when the view is cleared', async () => {
+    vi.spyOn(StorageFS, 'ensureDir').mockResolvedValue(undefined);
+    const currentWatcher = watcher();
+    vi.spyOn(vscode.workspace, 'createFileSystemWatcher').mockReturnValue(
+      currentWatcher,
+    );
+
+    const fixture = createHandler();
+    await attach(fixture.handler, createView().view);
+    await vi.waitFor(() =>
+      expect(currentWatcher.onDidCreate).toHaveBeenCalled(),
+    );
+
+    fixture.handler.clearActiveView();
+    expect(currentWatcher.dispose).toHaveBeenCalledOnce();
+  });
 
   it('logs and absorbs directory setup failures', async () => {
     const failure = new Error('permission denied');
     vi.spyOn(StorageFS, 'ensureDir').mockRejectedValue(failure);
     const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
 
-    createHandler();
+    const fixture = createHandler();
+    await attach(fixture.handler, createView().view);
 
     await vi.waitFor(() => {
       expect(errorSpy).toHaveBeenCalledWith(
@@ -110,9 +231,10 @@ describe('settings execution history watcher', () => {
       .spyOn(vscode.workspace, 'createFileSystemWatcher')
       .mockReturnValue(currentWatcher);
 
-    // The constructor's registration pends on firstSetup; the folder-change
+    // The attach registration pends on firstSetup; the folder-change
     // re-registration pends on secondSetup and wins the generation race.
     const fixture = createHandler();
+    await attach(fixture.handler, createView().view);
     fixture.fireWorkspaceFoldersChanged();
     secondSetup.resolve();
     await vi.waitFor(() => expect(createWatcher).toHaveBeenCalledOnce());
@@ -135,13 +257,14 @@ describe('settings execution history watcher', () => {
     const createWatcher = vi
       .spyOn(vscode.workspace, 'createFileSystemWatcher')
       .mockImplementationOnce(() => {
-        // A folder change lands while the constructor's registration is
-        // mid-setup: its candidate is stale the moment it returns.
+        // A folder change lands while the attach registration is mid-setup:
+        // its candidate is stale the moment it returns.
         fixture.fireWorkspaceFoldersChanged();
         return staleWatcher;
       })
       .mockReturnValue(currentWatcher);
     const fixture = createHandler();
+    await attach(fixture.handler, createView().view);
 
     await vi.waitFor(() => expect(createWatcher).toHaveBeenCalledTimes(2));
     await flushRegistrations();
@@ -158,6 +281,7 @@ describe('settings execution history watcher', () => {
     vi.spyOn(StorageFS, 'ensureDir').mockReturnValue(setup.promise);
     const createWatcher = vi.spyOn(vscode.workspace, 'createFileSystemWatcher');
     const fixture = createHandler();
+    await attach(fixture.handler, createView().view);
 
     fixture.disposeSubscriptions();
     setup.resolve();


### PR DESCRIPTION
Fixes #9959

Three extension event edges did work proportional to total workspace history (1,923 persisted streams in the audited workspace) instead of the active delta. Per the transcript-memory PRD (`docs/prds/2026-08-11-transcript-memory-architecture.md`, extension/desktop bullet), each gets a bounding fix; the bounded metadata wire list and pagination are explicitly out of scope here.

## Fix 1: executions watcher lifetime (`SettingsViewMessageHandler`)

The recursive watcher over the shared executions tree debounced every event into a full `listExecutions()` rescan (thousands of file reads plus Zod parses), gated only on "webview exists". Because the Dashboard panel retains its context when hidden, a background tab kept this running for days while `PersistedFlow` wrote after every node execution.

Now the watcher exists only while the settings webview is actually visible:

- visibility tracked from the dispatching view (`onDidChangeViewState` for panels, `onDidChangeVisibility` for sidebar views), attached in `onDispatch`
- registered on show, disposed on hide, torn down with the view (`clearActiveView`) and on context disposal
- one history refresh on becoming visible again, so runs recorded while hidden appear without a watcher
- workspace-folder re-registration only happens while the watcher is wanted
- no mtime cache (explicitly rejected in the PRD; the listing recompute is accepted, the fix is lifetime)

## Fix 2: theme flip sends `THEME_SET` alone (`ProgressViewProvider`, `WebviewUpdater`)

`onDidChangeActiveColorTheme` ran a full `syncFullView`, rebuilding `StreamTabInfo` + metadata for every persisted stream into a 1-2 MB structured-clone payload. The webview only consumes the theme string on a flip: `BaseWebviewApp.onThemeChange` swaps the body class and WA color scheme; no stream data is theme-dependent. The listener now sends only the theme message via a new `WebviewUpdater.setTheme`, which the full-sync path (`sendStreamMetadata`) also reuses, keeping one send site for the message. Visibility/readiness gating is unchanged.

## Fix 3: git probes gated to live streams (`streamInfoUtils`)

`buildStreamInfo` fired a fire-and-forget `resolveWorktreeInfo` (two git subprocesses) for every stream on every metadata rebuild. The backing LRU holds 32 entries with a 10 s TTL, so with thousands of historical streams it thrashed and spawned git per stream. The probe is now gated to in-flight streams (running or waiting) plus the selected tab; terminal streams render their last-known cached value from `peekWorktreeInfo`, or nothing, without spawning git. Label-only callers (`progressNavigation`, desktop) no longer trigger probes at all.

## Tests

- `ExecutionHistoryWatcher.vitest.ts` reworked for the visibility-gated lifecycle: registration only after a visible dispatch, no registration while hidden, dispose-on-hide plus one refresh on re-show, teardown on view clear, and the pre-existing generation-race and failure-logging scenarios preserved
- new `ProgressThemeSync.vitest.ts`: theme change sends `setTheme` with the mapped kind and never a stream-metadata rebuild; dropped while no surface is visible
- `streamInfoUtils.vitest.ts`: probes for in-flight and selected streams, last-known value without `resolveWorktreeInfo` for terminal streams

`npm run typecheck` clean; targeted suites (ExecutionHistoryWatcher, streamInfoUtils, ProgressThemeSync, plus ProgressBackend*, StreamContentSync, ApprovalRequestHandlerSet, ProgressTargetOwnership, ExtensionWorkspaceTransition, ProgressExecutionLabels) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gtc6wQMD1hedgabjQMfAun

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lifecycle of file watching and progress webview sync paths used during normal IDE use; behavior is intentionally narrower (visible-only watcher, lighter theme updates) with targeted tests, but regressions could affect history freshness or worktree chips on old streams.
> 
> **Overview**
> Bounds three extension event paths that previously scaled with **total workspace history** (thousands of persisted streams), addressing #9959.
> 
> **Settings history watcher** — The shared executions `FileSystemWatcher` now runs only while the settings webview is **visible** (tracked via `onDispatch` / visibility listeners). It is disposed when hidden, on `clearActiveView`, or context teardown; workspace-folder re-registration happens only when the watcher is wanted. Re-showing triggers one history refresh so runs recorded while hidden still appear.
> 
> **Progress theme changes** — `onDidChangeActiveColorTheme` no longer calls a full view sync. It sends only **`THEME_SET`** through `WebviewUpdater.setTheme` when the progress surface is visible and ready; full metadata sync reuses the same helper for theme.
> 
> **Stream tab metadata** — `buildStreamInfo` only fire-and-forgets **`resolveWorktreeInfo`** for the **active tab** and **in-flight** streams; terminal streams use **`peekWorktreeInfo`** without spawning git, avoiding LRU thrash on large histories.
> 
> Tests cover watcher visibility lifecycle, theme-only IPC, and git probe gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 510009fddbb52703b1163835a472cdfa850c2643. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->