### PR TITLE
fix(transcript): per-record disk provenance in StreamSnapshotStore

### DIFF
--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -2073,6 +2073,12 @@ describe('DesktopProgressBridge', () => {
       retrieveSessionResumeData,
       runAgent,
       canonicalStreamIds: ['stream-1'],
+      // The sidecar existence probe (listKeys) consults the backing map;
+      // reads themselves stay answered by kvRead above, as in production
+      // where the listing and the reads see the same directory.
+      kvStoreBacking: new Map<string, unknown>([
+        ['streamData/stream-1/meta', {}],
+      ]),
     });
 
     try {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -517,6 +517,95 @@ describe('StreamSnapshotStore', () => {
     });
   });
 
+  it('merges a mutation with on-disk sidecars for a stream outside the load() id set instead of clobbering them (#9956)', async () => {
+    // A prior session persisted usage and a plan for STREAM.
+    const previous = new StreamSnapshotStore();
+    const previousFacts = snapshotFacts(previous);
+    void previousFacts.addUsage(STREAM, RUN, usage(100, 20, 0.5));
+    previousFacts.setPlan(STREAM, PLAN);
+    await previous.flush();
+
+    // An authoritative load whose id set does NOT contain STREAM (its
+    // transcript is gone; the sidecar survives). A mutation for STREAM must
+    // still seed from disk first; no global "I know the full stream set"
+    // fact may stand in for this record's provenance.
+    const store = new StreamSnapshotStore();
+    await store.load([OTHER_STREAM]);
+    void snapshotFacts(store).addUsage(STREAM, RUN_2, usage(50, 10, 0.25));
+    await store.flush();
+
+    const raw = await readStreamFile(STREAM, 'usageStats.json');
+    expect(raw).toMatchObject({
+      [RUN]: usage(100, 20, 0.5),
+      [RUN_2]: usage(50, 10, 0.25),
+    });
+    expect((await reloadWorkPlan()).plan).toEqual(PLAN);
+  });
+
+  it('queues a mutation on a provenance-unknown stream behind its seed', async () => {
+    await writeStreamFile(STREAM, 'usageStats.json', {
+      [RUN]: usage(100, 20, 0.5),
+    });
+
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+
+    // Hold the seed's existence probe so the mutation cannot have persisted
+    // before the seed resolved this record's disk state.
+    const gate = pDefer<void>();
+    const originalReadDir = StorageFS.readDir.bind(StorageFS);
+    vi.spyOn(StorageFS, 'readDir').mockImplementation(async (target) => {
+      if (target === streamDataDir(STREAM)) await gate.promise;
+      return originalReadDir(target);
+    });
+
+    void snapshotFacts(store).addUsage(STREAM, RUN_2, usage(50, 10, 0.25));
+    // Eagerly readable from memory while the seed is still gated...
+    expect(store.getRunUsage(STREAM).get(RUN_2)).toMatchObject(
+      usage(50, 10, 0.25),
+    );
+    // ...but nothing has touched the on-disk sidecar yet.
+    expect(await readStreamFile(STREAM, 'usageStats.json')).toEqual({
+      [RUN]: usage(100, 20, 0.5),
+    });
+
+    gate.resolve();
+    await store.flush();
+
+    expect(await readStreamFile(STREAM, 'usageStats.json')).toMatchObject({
+      [RUN]: usage(100, 20, 0.5),
+      [RUN_2]: usage(50, 10, 0.25),
+    });
+  });
+
+  it('resolves a freshly minted stream to verified-absent and then mutates without consulting disk', async () => {
+    const store = new StreamSnapshotStore();
+    const facts = snapshotFacts(store);
+
+    // First mutation: the seed's existence probe finds no sidecar directory,
+    // so the record settles as 'verified-absent'.
+    facts.setTodos(STREAM, [TODO]);
+    await store.flush();
+    expect(
+      (await readStreamFile(STREAM, 'workPlan.json')) as object,
+    ).toMatchObject({ todos: [TODO] });
+
+    // Later mutations persist immediately from memory: no re-probe, no
+    // sidecar re-read for this stream.
+    const probeSpy = vi.spyOn(StorageFS, 'readDir');
+    const readSpy = vi.spyOn(StorageFS, 'read');
+    facts.setPlan(STREAM, PLAN);
+    await store.flush();
+
+    const streamDir = streamDataDir(STREAM);
+    const touched = [...probeSpy.mock.calls, ...readSpy.mock.calls].filter(
+      ([target]) => typeof target === 'string' && target.startsWith(streamDir),
+    );
+    expect(touched).toEqual([]);
+    expect((await reloadWorkPlan()).plan).toEqual(PLAN);
+    expect((await reloadWorkPlan()).todos).toEqual([TODO]);
+  });
+
   it('preserves an unparseable persisted usage entry across a save instead of deleting it', async () => {
     // Regression test for #7464: a run entry that fails to parse (e.g. a
     // corrupted or future-shaped value) must be logged loudly and carried
@@ -2464,7 +2553,9 @@ describe('StreamSnapshotStore', () => {
 
   it('serializes same-key writes so a slow first write finishes before a queued second write starts', async () => {
     const store = new StreamSnapshotStore();
-    await store.load([]);
+    // Seed STREAM so its provenance is settled ('verified-absent') and each
+    // mutation below persists synchronously as its own same-key write.
+    await store.load([STREAM]);
 
     const order: string[] = [];
     let releaseFirstWrite: () => void = () => {};

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -74,6 +74,7 @@ import {
 import {
   assembleSnapshot,
   EMPTY_WORK_PLAN,
+  emptyStreamData,
   readMeta,
   readStreamData,
   type StreamData,
@@ -262,9 +263,21 @@ function mergeUsagePatch(
 }
 
 /**
+ * Disk provenance for one stream record, a strictly per-record fact.
+ * 'unknown': this record's on-disk sidecar state has not been established, so
+ * a mutation must queue behind the per-stream seed chain (an accumulate/merge
+ * onto an unloaded base would persist empty+delta over the real sidecar).
+ * 'loaded': a seed/refresh read the sidecar files into memory.
+ * 'verified-absent': an existence probe found no sidecar directory, so the
+ * stream is new, memory is its full history, and mutations may persist
+ * without a disk read. Never inferred from any global fact (#9956).
+ */
+type DiskState = 'unknown' | 'verified-absent' | 'loaded';
+
+/**
  * Every per-stream field this store tracks, keyed by stream id in ONE map
- * (`records`): the accumulators, the `seeded`/`seedChain` seeding bookkeeping,
- * the overlay patches, and the cached `KVStore` handles. Because every field
+ * (`records`): the accumulators, the `diskState`/`seedChain` seeding
+ * bookkeeping, the overlay patches, and the cached `KVStore` handles. Because every field
  * for a stream lives on the same object, dropping a stream's memory is one
  * `records.delete(stream)` — every field disappears with it BY CONSTRUCTION,
  * so `evict()`/`evictAll()` cannot drift from the field list.
@@ -317,14 +330,14 @@ interface StreamRecord {
 
   // -- Lazy seeding: a stream's existing disk data is read into memory BEFORE
   // the first mutation so an accumulate/merge can't overwrite unloaded disk
-  // data. `seeded` = this stream's memory is current; `seedChain` serializes
+  // data. `diskState` = this record's disk provenance; `seedChain` serializes
   // refresh/seed/mutate for it.
-  seeded: boolean;
+  diskState: DiskState;
   seedChain: Promise<void> | undefined;
   /** Incremented for each refresh attempt; seed-gated mutations do not change it. */
   seedRefreshGeneration: number;
-  /** Authoritative seeded state captured before the current refresh chain began. */
-  seedRefreshBaseline: boolean | undefined;
+  /** Authoritative disk provenance captured before the current refresh chain began. */
+  seedRefreshBaseline: DiskState | undefined;
 
   // -- Overlays: patches applied eagerly to memory while a seed is in flight,
   // so `applyStreamData`'s post-seed reconciliation can replay them on top of
@@ -361,7 +374,7 @@ export class StreamSnapshotStore {
     userFollowUpSupport: undefined,
     runConfig: undefined,
     description: undefined,
-    seeded: false,
+    diskState: 'unknown',
     seedChain: undefined,
     seedRefreshGeneration: 0,
     seedRefreshBaseline: undefined,
@@ -390,8 +403,6 @@ export class StreamSnapshotStore {
   private readonly writeMutexes = new Map<string, Mutex>();
   /** Latest ordinary sidecar value not yet confirmed durable, by write lock. */
   private readonly dirtyWrites = new Map<string, DirtySidecarWrite>();
-
-  private hasAuthoritativeStreamSet = false;
 
   /** Streams already warned about a pre-identity execution row (#9590 Stage
    *  7), so repeated hydrations of the same old row stay one warning each. */
@@ -446,16 +457,16 @@ export class StreamSnapshotStore {
     return this.records.version(stream);
   }
 
-  private canMutateSynchronously(stream: StreamTabId): boolean {
-    const record = this.records.get(stream);
-    if (record?.seeded) return true;
-
-    if (this.hasAuthoritativeStreamSet && !record?.seedChain) {
-      this.getOrCreateRecord(stream).seeded = true;
-      return true;
-    }
-
-    return false;
+  /**
+   * Whether this record's disk provenance is established ('loaded' or
+   * 'verified-absent'), so a mutation may apply and persist without first
+   * consulting disk. Strictly per record: a record starts 'unknown' and only
+   * its own seed chain resolves that; no global fact ever stands in for
+   * "this record's disk state is in memory" (#9956).
+   */
+  private hasDiskProvenance(stream: StreamTabId): boolean {
+    const state = this.records.get(stream)?.diskState;
+    return state !== undefined && state !== 'unknown';
   }
 
   /**
@@ -558,15 +569,14 @@ export class StreamSnapshotStore {
   }
 
   /**
-   * Run a mutation only after existing disk state has been loaded. After an
-   * authoritative full load, streams outside that loaded set are treated as new
-   * and mutate synchronously so UI callers can read back their own writes.
-   * Partial preloads intentionally do not enable this fast path because other
-   * streams may still have sidecars on disk.
+   * Run a mutation only once the stream's disk provenance is established;
+   * otherwise queue it behind the per-stream seed chain so it merges onto the
+   * real sidecar state instead of an empty base. Eager memory application in
+   * the overlay mutators keeps read-back immediate either way.
    */
   private mutate<T>(stream: StreamTabId, apply: () => T): T | undefined {
     const version = this.streamVersion(stream);
-    if (this.canMutateSynchronously(stream)) return apply();
+    if (this.hasDiskProvenance(stream)) return apply();
 
     this.queueAfterSeed(stream, version, apply);
     return undefined;
@@ -579,12 +589,12 @@ export class StreamSnapshotStore {
   ): Promise<void> {
     const next: Promise<void> = this.ensureSeeded(stream, version)
       .catch((err: unknown) => {
-        if (!this.records.get(stream)?.seeded) throw err;
+        if (!this.hasDiskProvenance(stream)) throw err;
       })
       .then(() => {
         if (this.streamVersion(stream) !== version) return;
         const record = this.records.get(stream);
-        if (!record?.seeded) {
+        if (!record || record.diskState === 'unknown') {
           if (record?.seedChain === next) record.seedChain = undefined;
           return;
         }
@@ -592,7 +602,7 @@ export class StreamSnapshotStore {
       })
       .catch((err: unknown) => {
         const record = this.records.get(stream);
-        if (!record?.seeded && record?.seedChain === next) {
+        if (record?.diskState === 'unknown' && record.seedChain === next) {
           record.seedChain = undefined;
         }
         logger.warn(CHANNEL, `Deferred update failed for stream ${stream}`, {
@@ -614,12 +624,48 @@ export class StreamSnapshotStore {
 
   private async readSeed(stream: StreamTabId, version: number): Promise<void> {
     if (this.streamVersion(stream) !== version) return;
-    if (this.records.get(stream)?.seeded) return;
+    if (this.hasDiskProvenance(stream)) return;
     await this.retryDirtyWrites(stream);
     if (this.streamVersion(stream) !== version) return;
-    const data = await readStreamData(this.kv(stream));
+    await this.seedFromDisk(stream, version);
+  }
+
+  /**
+   * Establish a stream's disk provenance: one existence probe of the sidecar
+   * directory (a single `listKeys` through the same KVStore handle every
+   * other sidecar access uses), then the full read only when sidecar files
+   * exist. A freshly minted stream resolves to 'verified-absent' from the
+   * probe alone, so its first mutation costs one directory listing instead
+   * of a six-file read and every later mutation applies synchronously.
+   */
+  private async seedFromDisk(
+    stream: StreamTabId,
+    version: number,
+  ): Promise<void> {
+    let exists: boolean;
+    try {
+      exists = (await this.kv(stream).listKeys()).length > 0;
+    } catch (error) {
+      // The probe only ever shortcuts the read; a failed listing must not
+      // fail the seed and must NEVER claim absence. Fall back to the full
+      // read, whose own fallback policy governs unreadable storage.
+      logger.warn(
+        CHANNEL,
+        `Sidecar existence probe failed for stream ${stream}; falling back to a full read.`,
+        { data: error },
+      );
+      exists = true;
+    }
     if (this.streamVersion(stream) !== version) return;
-    await this.applyStreamData(stream, data);
+    const data = exists
+      ? await readStreamData(this.kv(stream))
+      : emptyStreamData();
+    if (this.streamVersion(stream) !== version) return;
+    await this.applyStreamData(
+      stream,
+      data,
+      exists ? 'loaded' : 'verified-absent',
+    );
   }
 
   // ==========================================================================
@@ -735,7 +781,7 @@ export class StreamSnapshotStore {
   ): { result: T; pending: Promise<void> | undefined } {
     const result = applyToMemory();
 
-    if (this.canMutateSynchronously(stream)) {
+    if (this.hasDiskProvenance(stream)) {
       persist();
       return { result, pending: undefined };
     }
@@ -883,7 +929,7 @@ export class StreamSnapshotStore {
     return pending.then(() => {
       if (
         this.streamVersion(stream) !== version ||
-        !this.records.get(stream)?.seeded
+        !this.hasDiskProvenance(stream)
       ) {
         return undefined;
       }
@@ -1540,7 +1586,7 @@ export class StreamSnapshotStore {
   private async awaitSeeded(streamId: StreamTabId): Promise<boolean> {
     // Awaiting `undefined` (no in-flight seed) resolves immediately.
     await this.records.get(streamId)?.seedChain;
-    return this.records.get(streamId)?.seeded ?? false;
+    return this.hasDiskProvenance(streamId);
   }
 
   /**
@@ -1589,10 +1635,8 @@ export class StreamSnapshotStore {
    * per-stream chain and apply after the disk snapshot.
    */
   async load(streamIds: readonly StreamTabId[]): Promise<void> {
-    this.hasAuthoritativeStreamSet = false;
     this.evictStreamsExcept(new Set(streamIds));
     await this.seedStreams(streamIds);
-    this.hasAuthoritativeStreamSet = true;
   }
 
   /**
@@ -1620,19 +1664,17 @@ export class StreamSnapshotStore {
   private refreshSeed(stream: StreamTabId): Promise<void> {
     const version = this.streamVersion(stream);
     const record = this.getOrCreateRecord(stream);
-    const refreshBaseline = record.seedRefreshBaseline ?? record.seeded;
+    const refreshBaseline = record.seedRefreshBaseline ?? record.diskState;
     record.seedRefreshBaseline = refreshBaseline;
     const refreshGeneration = ++record.seedRefreshGeneration;
-    record.seeded = false;
+    record.diskState = 'unknown';
     const prev = record.seedChain?.catch(() => undefined) ?? Promise.resolve();
     const work = prev.then(async () => {
       if (this.streamVersion(stream) !== version) return;
       await this.retryDirtyWrites(stream);
       if (this.streamVersion(stream) !== version) return;
       this.invalidateKvHandles(stream);
-      const data = await readStreamData(this.kv(stream));
-      if (this.streamVersion(stream) !== version) return;
-      await this.applyStreamData(stream, data);
+      await this.seedFromDisk(stream, version);
     });
     const next = work.then(
       () => {
@@ -1650,9 +1692,9 @@ export class StreamSnapshotStore {
           current?.seedRefreshGeneration === refreshGeneration &&
           this.streamVersion(stream) === version
         ) {
-          current.seeded = refreshBaseline;
+          current.diskState = refreshBaseline;
           current.seedRefreshBaseline = undefined;
-          if (refreshBaseline) {
+          if (refreshBaseline !== 'unknown') {
             this.persistEagerOverlays(stream, current);
           }
           if (current.seedChain === next) current.seedChain = undefined;
@@ -1715,6 +1757,7 @@ export class StreamSnapshotStore {
   private async applyStreamData(
     stream: StreamTabId,
     data: StreamData,
+    provenance: Exclude<DiskState, 'unknown'>,
   ): Promise<void> {
     const version = this.streamVersion(stream);
     const record = this.getOrCreateRecord(stream);
@@ -1841,7 +1884,7 @@ export class StreamSnapshotStore {
       sidecarsToWrite.add(OVERLAY_TO_SIDECAR_KEY.workPlan);
       overlays.workPlan = undefined;
     }
-    record.seeded = true;
+    record.diskState = provenance;
     this.writeMergedSidecars(stream, record, sidecarsToWrite);
   }
 

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -62,6 +62,23 @@ export interface StreamData {
 }
 
 /**
+ * Fresh empty {@link StreamData} for a stream whose sidecar directory was
+ * verified absent. Fresh containers per call: the store's accumulators mutate
+ * the round-indexed records in place.
+ */
+export function emptyStreamData(): StreamData {
+  return {
+    meta: undefined,
+    outputFiles: {},
+    missingOutputs: {},
+    compileFailures: {},
+    usage: new Map(),
+    usageUnparsed: new Map(),
+    workPlan: EMPTY_WORK_PLAN,
+  };
+}
+
+/**
  * Treat corrupt/truncated JSON (crash mid-write) as a missing file — the next
  * write replaces it — but log it so it is not silently swallowed.
  */


### PR DESCRIPTION
Fixes #9956

Blocker PR from the transcript-memory-architecture plan (`docs/prds/2026-08-11-transcript-memory-architecture.md`, item 2 first half). Ships before the other memory-architecture PRs because it removes the data-loss landmine they would otherwise widen.

## The bug

`canMutateSynchronously` flipped a record's `seeded = true` without any disk read whenever the global `hasAuthoritativeStreamSet` flag was set and no seed chain was in flight. The next mutation then merged onto an empty in-memory base and persisted, overwriting the real sidecar with empty+delta. A global "I know the full stream set" fact was asserting the per-record fact "this record's disk state is in memory". Any stream whose sidecar exists on disk but is outside the id set passed to `load()` (sidecar without transcript, CLI `load([resolution.streamId])` resume) hit silent data loss on its first mutation.

## The fix

- Replace the `seeded` boolean with a per-record `diskState` tri-state: `unknown | verified-absent | loaded`.
- Delete `hasAuthoritativeStreamSet` and `canMutateSynchronously`. Mutation gating is now `hasDiskProvenance(stream)`: synchronous only on `loaded` or `verified-absent`; mutations on `unknown` always queue behind the existing per-stream seed chain. Eager memory application in the overlay mutators keeps read-back immediate either way.
- The seed starts with one existence probe of the sidecar directory (a single `listKeys` through the same KVStore handle all other sidecar access uses). A freshly minted stream resolves to `verified-absent` from the probe alone and mutates synchronously afterward; an existing directory takes the full six-file read and resolves to `loaded`. A failed probe never claims absence: it logs at warn and falls back to the full read.
- `load()`/`preload()` keep their external behavior (`load` still evicts-except and refresh-seeds; `preload` still seeds a partial set).

## Tests

- New clobber regression: sidecar on disk, `load()` with an id set that does not contain the stream, mutate; asserts the persisted result is a merge with the on-disk data, not empty+delta. Verified to fail against the pre-change implementation.
- Mutation on a provenance-unknown stream queues behind its seed (probe gated with a deferred; disk untouched until the seed resolves).
- A freshly minted stream resolves to `verified-absent` and then mutates without consulting disk (spied probe/read; zero stream-dir accesses on the second mutation).
- One existing test updated (`serializes same-key writes`): it relied on the deleted global-flag fast path; it now seeds the stream first, preserving its serialization intent. One desktop bridge test now seeds the mocked KV backing so the probe and the mocked reads agree, as they do in production.

## Deviation from the issue wording

`verified-absent` is produced by the explicit existence probe integrated into the seed chain (the issue's "explicit stat probe" arm) rather than by a creation-path call. Every candidate minting site (`buildAgentLaunchContext`, `createChildStream`, `registerOwnedExecution`) sits outside this PR's scope and each has a reuse caveat (`streamTabIdOverride` resume, stable-executionId subagent retries, rehydrated child streams) where "minted new" is not locally provable; the probe gives the same guarantee without trusting callers, at the cost of one directory listing on a stream's first mutation. A synchronous minting hook can still be added later without changing this model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gtc6wQMD1hedgabjQMfAun

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core sidecar persistence and mutation gating across all streams; incorrect provenance logic could still corrupt or lose usage/plan/workPlan data on disk.
> 
> **Overview**
> Fixes **#9956** silent sidecar loss when a stream had on-disk data but was **outside** the id set passed to `load()`: a global “authoritative stream set” flag let mutations run without seeding, merging onto an empty base and overwriting real sidecars.
> 
> **`StreamSnapshotStore`** drops `hasAuthoritativeStreamSet` and the `seeded` flag. Each stream record now has **`diskState`**: `unknown` | `loaded` | `verified-absent`. Mutations only persist synchronously when provenance is established; otherwise they stay on the existing per-stream seed chain (overlay mutators still update memory immediately).
> 
> Seeding uses **`seedFromDisk`**: one **`listKeys`** existence probe on the sidecar KV handle, then either a full read (`loaded`) or **`emptyStreamData()`** (`verified-absent`). Failed probes log and fall back to a full read—they never mark absence.
> 
> **`emptyStreamData()`** is added in `streamSnapshotRead.ts` for verified-new streams.
> 
> Tests add the clobber regression, gated-seed ordering, and post-`verified-absent` mutations without re-probing; desktop bridge test seeds KV backing so the probe matches mocked reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f86c14d5bd994f38a71d4ceae48f06462031a59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->