### PR TITLE
Flow-persistence point fixes: compact JSON, boundary-only re-parse, snapshot clone at drain

### DIFF
--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -192,10 +192,11 @@ export async function runReflectionFlow<C = unknown>(
     // Boundary hydration: the one place a freshly-read persisted record
     // (possibly written by an older build, hence the legacy todos/plan
     // fallback in AgentWorkspaceStateSnapshotSchema) is parsed. Downstream,
-    // `RoundPersistedFlow`'s own per-step revalidation uses
-    // ReflectionFlowStateCanonicalSchema instead — see its constructor call
-    // below — since by then `shared` is always this run's own canonical
-    // toSnapshot() output, never a legacy shape.
+    // `RoundPersistedFlow` validates records it re-reads from storage with
+    // ReflectionFlowStateCanonicalSchema (see its constructor call below),
+    // since those are always this run's own canonical toSnapshot() output,
+    // never a legacy shape; records it wrote itself stay trusted per the
+    // boundary-only validation rule.
     const validated = ReflectionFlowStateSchema.safeParse(flowRecord.shared);
     if (!validated.success) {
       throw new PersistedFlowStateError(executionId, 'invalid-shared', {

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -217,6 +217,14 @@ export class PersistedFlow<
    * stepWithResult that immediately follows the previous step's write).
    */
   private cachedRecord: FlowRecord | null = null;
+
+  /**
+   * Whether `cachedRecord.shared` is already a validated `S`. Records this
+   * instance wrote itself are trusted; only a record deserialized from the
+   * KV store is parsed through `sharedSchema` (boundary-only validation), so
+   * steps served from the self-cache skip the per-transition re-parse.
+   */
+  private cachedSharedTrusted = false;
   private nodeIds: Map<BaseNode, string> | null = null;
   private nodesById: Map<string, BaseNode> | null = null;
 
@@ -250,16 +258,33 @@ export class PersistedFlow<
   }
 
   /** Single canonical cast site for trusting a persisted `shared` blob as `S`. */
-  private readShared(raw: unknown): S {
-    if (!this.sharedSchema) return raw as S;
-    const result = this.sharedSchema.safeParse(raw);
+  private readShared(flow: FlowRecord): S {
+    if (!this.sharedSchema || this.cachedSharedTrusted) {
+      return flow.shared as S;
+    }
+    const result = this.sharedSchema.safeParse(flow.shared);
     if (!result.success) {
       throw new Error(
         `Persisted shared state for flow run "${this.runId}" failed schema validation`,
         { cause: result.error },
       );
     }
+    // Keep the normalized value on the record so later reads reuse it.
+    flow.shared = result.data;
+    this.cachedSharedTrusted = true;
     return result.data;
+  }
+
+  /**
+   * Read the flow record, serving from this instance's cache when present. A
+   * true KV read marks the shared blob untrusted so the next `readShared`
+   * re-validates at the deserialization boundary.
+   */
+  private async loadRecord(): Promise<FlowRecord | undefined> {
+    if (this.cachedRecord) return this.cachedRecord;
+    const flow = await this.kv.read<FlowRecord>(flowKey(this.runId));
+    this.cachedSharedTrusted = false;
+    return flow;
   }
 
   /** Register a write-through projection that fires after each persist. */
@@ -310,7 +335,7 @@ export class PersistedFlow<
    */
   protected async stepWithResult(): Promise<StepResult<S>> {
     const key = flowKey(this.runId);
-    const flow = this.cachedRecord ?? (await this.kv.read<FlowRecord>(key));
+    const flow = await this.loadRecord();
 
     if (!flow || !Array.isArray(flow.nodes)) {
       throw new Error('Invalid or corrupted flow record');
@@ -324,11 +349,11 @@ export class PersistedFlow<
       return {
         hasMore: false,
         action: flow.cursor?.lastAction ?? flow.nodes.at(-1)?.action,
-        shared: this.readShared(flow.shared),
+        shared: this.readShared(flow),
       };
     }
 
-    const shared = this.readShared(flow.shared);
+    const shared = this.readShared(flow);
 
     if (!shared) {
       throw new Error('Missing shared state in flow record');
@@ -352,6 +377,7 @@ export class PersistedFlow<
     flow.shared = this.serializeShared(shared);
     await this.kv.write(key, stampFlowRecordSchemaVersion(flow));
     this.cachedRecord = flow;
+    this.cachedSharedTrusted = true;
     await this.fireProjection(shared);
 
     return {
@@ -361,14 +387,15 @@ export class PersistedFlow<
     };
   }
 
+  /**
+   * The flow's current shared state. Returns the record's live object rather
+   * than a copy; the caller owns reads directly, and mutations become
+   * durable only through setShared().
+   */
   async getShared(): Promise<S | undefined> {
-    const flow =
-      this.cachedRecord ??
-      (await this.kv.read<FlowRecord>(flowKey(this.runId)));
+    const flow = await this.loadRecord();
     if (flow) this.cachedRecord = flow;
-    return flow?.shared === undefined
-      ? undefined
-      : this.readShared(flow.shared);
+    return flow?.shared === undefined ? undefined : this.readShared(flow);
   }
 
   async setShared(newShared: S): Promise<void> {
@@ -470,7 +497,7 @@ export class PersistedFlow<
     mutate?: (flow: FlowRecord) => void,
   ): Promise<void> {
     const key = flowKey(this.runId);
-    const flow = this.cachedRecord ?? (await this.kv.read<FlowRecord>(key));
+    const flow = await this.loadRecord();
     if (!flow) {
       throw new Error('Invalid or corrupted flow record');
     }
@@ -479,12 +506,12 @@ export class PersistedFlow<
     flow.shared = this.serializeShared(shared);
     await this.kv.write(key, stampFlowRecordSchemaVersion(flow));
     this.cachedRecord = flow;
+    this.cachedSharedTrusted = true;
     await this.fireProjection(shared);
   }
 
   protected async ensureRecord(shared: S): Promise<void> {
-    const key = flowKey(this.runId);
-    const existing = await this.kv.read<FlowRecord>(key);
+    const existing = await this.loadRecord();
     if (existing) {
       this.cachedRecord = existing;
       return;
@@ -498,7 +525,8 @@ export class PersistedFlow<
       cursor: { nextNodeId: this.idForNode(this.start) },
       nodes: [],
     };
-    await this.kv.write(key, record);
+    await this.kv.write(flowKey(this.runId), record);
     this.cachedRecord = record;
+    this.cachedSharedTrusted = true;
   }
 }

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -188,7 +188,12 @@ export interface ExecutionKVStore {
  */
 class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   constructor(private readonly executionId: ExecutionId) {
-    super(resolveRunStoragePath(executionId), { throwOnErrors: true });
+    // Compact JSON: flow records rewrite full shared state on every node
+    // transition, so pretty-printing this machine-owned store is pure churn.
+    super(resolveRunStoragePath(executionId), {
+      compactJson: true,
+      throwOnErrors: true,
+    });
   }
 
   override async write<T = unknown>(key: string, value: T): Promise<void> {

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -258,7 +258,10 @@ class CoalescedSnapshotWriter {
   async #drain(): Promise<void> {
     try {
       while (this.#pending) {
-        const snapshot = this.#pending;
+        // The publisher hands over a live reference; snapshot it here, at
+        // drain time, so publications coalesced away never pay the clone and
+        // each onSnapshot consumer still gets its own frozen copy.
+        const snapshot = structuredClone(this.#pending);
         this.#pending = undefined;
         await this.#write?.(snapshot);
       }

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -260,7 +260,7 @@ class CoalescedSnapshotWriter {
       while (this.#pending) {
         // The publisher hands over a live reference; snapshot it here, at
         // drain time, so publications coalesced away never pay the clone and
-        // each onSnapshot consumer still gets its own frozen copy.
+        // each onSnapshot consumer still gets its own isolated copy.
         const snapshot = structuredClone(this.#pending);
         this.#pending = undefined;
         await this.#write?.(snapshot);

--- a/src/agent/workflowScript/workflowExecutionState.ts
+++ b/src/agent/workflowScript/workflowExecutionState.ts
@@ -33,6 +33,11 @@ export class WorkflowExecutionState {
     readonly phases: readonly { readonly title: string }[];
     readonly tasks: readonly WorkflowCallIdentity[];
     readonly initialSnapshot?: WorkflowExecutionSnapshot;
+    /**
+     * Receives the live snapshot on every transition, not a copy. Consumers
+     * that retain it or persist asynchronously must clone it first (the
+     * runner's snapshot writer clones at drain time).
+     */
     readonly publish: (snapshot: WorkflowExecutionSnapshot) => void;
   }) {
     this.#publish = options.publish;
@@ -447,7 +452,9 @@ export class WorkflowExecutionState {
 
   #emit(): void {
     this.#snapshot.timestamps.updatedAt = now();
-    this.#publish(structuredClone(this.#snapshot));
+    // Live reference by contract (see the publish option): coalesced-away
+    // publications then never pay a full structuredClone of the snapshot.
+    this.#publish(this.#snapshot);
   }
 }
 

--- a/src/test-kernel/agent/PersistedFlow.vitest.ts
+++ b/src/test-kernel/agent/PersistedFlow.vitest.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 
 import { getExecutionStore } from '@agent/storage';
 import { BaseNode } from '@agent/node';
@@ -10,8 +11,10 @@ import {
   PersistedFlow,
   type FlowRecord,
 } from '@agent/node/persistedFlow';
+import { resolveRunStoragePath } from '@platform/defaults/workspaceStorage';
 import type { ExecutionId } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
+import { StorageFS } from '@utils/files/storageFS';
 
 setupPlatform({ workspacePath: '/workspace' });
 
@@ -153,5 +156,54 @@ describe('PersistedFlow', () => {
         lastAction: FlowTransition.WAITING,
       },
     });
+  });
+
+  it('persists flow records as compact JSON', async () => {
+    const executionId = 'abc130' as ExecutionId;
+    const store = getExecutionStore(executionId);
+
+    await new PersistedFlow(new CompleteNode(), store, executionId).run({
+      count: 0,
+    });
+
+    const raw = await StorageFS.read(
+      resolveRunStoragePath(executionId, `${flowKey(executionId)}.json`),
+    );
+    expect(raw).toContain('"schemaVersion"');
+    expect(raw).not.toContain('\n');
+  });
+
+  it('parses shared through the schema only at the deserialization boundary', async () => {
+    const executionId = 'abc131' as ExecutionId;
+    const store = getExecutionStore(executionId);
+    interface Shared {
+      count: number;
+      continue: boolean;
+    }
+    let parses = 0;
+    const schema: z.ZodType<Shared> = z
+      .object({ count: z.number(), continue: z.boolean() })
+      .refine(() => {
+        parses += 1;
+        return true;
+      });
+    const buildFlow = () => {
+      const first = new ContinueOnceNode();
+      first.on('again', new CompleteNode());
+      return new PersistedFlow(first, store, executionId, schema);
+    };
+
+    // A fresh run owns every record it writes: no re-parse per transition.
+    await buildFlow().run({ count: 0, continue: true });
+    expect(parses).toBe(0);
+
+    // A new instance hits the true deserialization boundary exactly once,
+    // and getShared() returns the record's live object, not a copy.
+    const resumed = buildFlow();
+    const shared = await resumed.getShared();
+    expect(shared).toEqual({ count: 2, continue: true });
+    expect(parses).toBe(1);
+    await expect(resumed.getShared()).resolves.toBe(shared);
+    expect(parses).toBe(1);
   });
 });

--- a/src/test-kernel/agent/WorkflowExecutionObservability.vitest.ts
+++ b/src/test-kernel/agent/WorkflowExecutionObservability.vitest.ts
@@ -48,6 +48,8 @@ return 'done'`,
           'stageBlocked',
       ),
     ).toBe(true);
+    // Drain-time cloning: every delivered snapshot is its own frozen copy.
+    expect(new Set(snapshots).size).toBe(snapshots.length);
     expect(result.snapshot.stages.map((stage) => stage.lifecycle)).toEqual([
       'completed',
       'skipped',

--- a/src/test-kernel/agent/WorkflowExecutionObservability.vitest.ts
+++ b/src/test-kernel/agent/WorkflowExecutionObservability.vitest.ts
@@ -48,7 +48,7 @@ return 'done'`,
           'stageBlocked',
       ),
     ).toBe(true);
-    // Drain-time cloning: every delivered snapshot is its own frozen copy.
+    // Drain-time cloning: every delivered snapshot is its own isolated copy.
     expect(new Set(snapshots).size).toBe(snapshots.length);
     expect(result.snapshot.stages.map((stage) => stage.lifecycle)).toEqual([
       'completed',


### PR DESCRIPTION
Fixes #9960

Point fixes for audit Finding 8 (`docs/dev/audits/2026-08-10-long-lived-session-memory-investigation.md`), scoped per the PRD's flow-persistence item (`docs/prds/2026-08-11-transcript-memory-architecture.md`): the tournament explicitly rejected an event-log rewrite of PersistedFlow, so each change here is a small, independently justifiable cut on the existing per-transition write path.

## Changes

1. **Compact JSON on the execution KV write path.** `StorageFSKVStore` now passes `compactJson: true` (same option `StreamLogStore` already uses). Flow records rewrite full shared state on every node transition; indenting that machine-owned store was pure serialization and disk churn. All readers go through `JSON.parse`; no reader depends on formatting.
2. **Skip the self-cache Zod re-parse.** `PersistedFlow` now tracks whether `cachedRecord.shared` is already a validated `S`. Records the instance wrote itself are trusted; only a record actually deserialized from the KV store is parsed through `sharedSchema`, per the boundary-only validation rule (#9434). Previously every step and every `getShared()` re-parsed the full shared blob (a full-copy allocation per micro-transition) even though the instance is the record's sole owner and had just produced it.
3. **`getShared()` returns the shared reference.** With the trust tracking in place, `getShared()` returns the record's live object instead of allocating a fresh parsed copy per call, matching the pre-existing no-schema semantics; mutations become durable only through `setShared()` (documented on the method). Callers that do `await pf.run(...); shared = await pf.getShared()` now get the final state at zero copy cost.
4. **Workflow snapshot cloned at drain, not per publication.** `WorkflowExecutionState.#emit` publishes the live snapshot; `CoalescedSnapshotWriter` clones at drain time, immediately before the write. Publications coalesced away while a write is in flight no longer pay a full `structuredClone` of the whole snapshot. `onSnapshot` consumers still receive isolated frozen copies (pinned by a new assertion in the observability suite), and the external `snapshot()` accessor keeps its clone.

## Deviations from the issue's four-fix list

- **run() signature unchanged.** `PersistedFlow.run` overrides `Flow.run` (`Promise<Action | undefined>`), so it cannot return shared state without breaking the override. The intent (no re-parse/copy when the caller retrieves final state after `run()`) is delivered through fix 3 instead.
- **No separate `workflow.json` key.** The workflow snapshot already has its own persistence home distinct from the per-transition flow record (the `workflow` field of the execution's meta, via `writeWorkflowExecutionSnapshot`), so the "own key" sub-item does not match current code and splitting meta would touch schema plus every reader for no memory win.
- Three files outside the nominal two-file scope carry one small edit each because the fix lands there: the KV store option (fix 1), the drain-time clone (fix 4), and a stale "per-step revalidation" comment in `runReflectionFlow.ts` updated to describe the new boundary-only behavior.

## Tests

- `PersistedFlow.vitest.ts`: two new regressions: flow records persist as compact JSON; schema parse count is 0 for a fresh run and exactly 1 at the resume boundary, with `getShared()` returning a stable reference.
- `WorkflowExecutionObservability.vitest.ts`: new assertion that every delivered snapshot is a distinct object (drain-time clone isolation).
- Ran targeted suites: PersistedFlow, WorkflowExecutionObservability, RoundPersistedFlowCompileRepair, ReflectionFlowStateRecovery, ExecutionKVStore, WorkflowScriptEngine, WorkflowScriptPersistence, SessionResumeRetrieval, SessionRestartRepair, completedRunArchive, ExecutionsToolResumability, WorkflowScriptTool, ExecutionsToolOutput, ResumeToolUseCancellation, AgentRunLifecycle: all green. `npm run typecheck` and eslint on touched files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gtc6wQMD1hedgabjQMfAun

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core flow persistence and getShared() semantics (live shared references); isolation for workflow onSnapshot consumers is preserved via drain-time cloning, with targeted tests.
> 
> **Overview**
> Cuts memory and disk churn on the **per-transition flow persistence** path (audit Finding 8 / flow-persistence PRD item), without rewriting PersistedFlow as an event log.
> 
> **Execution storage** writes machine-owned execution KV JSON with **`compactJson: true`**, so full flow records rewritten on every node step are no longer pretty-printed.
> 
> **`PersistedFlow`** now treats shared state the instance wrote as trusted: **`cachedSharedTrusted`** skips repeated Zod parses on self-cached records; only a real KV deserialization resets trust and runs **`sharedSchema`** once at the boundary. **`getShared()`** returns the record’s live shared object (mutations need **`setShared()`** to persist). **`loadRecord()`** centralizes cache vs KV reads and marks externally loaded blobs untrusted.
> 
> **Workflow execution snapshots** publish the live snapshot from **`WorkflowExecutionState.#emit`**; **`CoalescedSnapshotWriter`** **`structuredClone`s at drain time** so coalesced publications avoid cloning while **`onSnapshot`** still gets isolated copies (new observability assertion).
> 
> Comments in **`runReflectionFlow`** describe the updated boundary-only validation story. Tests cover compact JSON, parse-count at resume, stable **`getShared()`** references, and snapshot isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25db520a116c47e940893262cfa5183f89c58ccb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

