### PR TITLE
Store-emitted transcript delta feed + O(delta) CLI projection fold

### DIFF
--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -19,6 +19,7 @@ import {
   type Plan,
   type RoundIndexed,
   type RunIdentity,
+  type StreamLogEntry,
   type StreamPhase,
   type StreamStage,
   type StreamSubstate,
@@ -130,6 +131,70 @@ export type ConversationEntry = ConversationEntryOrigin &
       })
   );
 
+/**
+ * One transcript-projection candidate: a rendered row plus the ordering key
+ * that places it in the final merged transcript order (log rows by seqNo,
+ * compaction rows by start position, CLI-synthetic rows by their insertion
+ * anchor). `rank` preserves the relative order of equal keys across the three
+ * sources. `rendered` is replaced in place when the source row changes or the
+ * settled-prefix promotion reaches it; the item object itself is stable.
+ */
+export interface TranscriptFoldItem {
+  rendered: ConversationEntry;
+  readonly sortSeq: number;
+  readonly tieBreak: number;
+  /** Equal-key source order: 0 = compaction row, 1 = log row, 2 = synthetic. */
+  readonly rank: 0 | 1 | 2;
+  /** Compaction rows: the block `rendered` was built from; reference equality
+   *  means the row is current. */
+  block?: CompactionActivityBlock;
+}
+
+/**
+ * Mutable per-stream transcript-projection working state. Carried on the
+ * stream's slice (never rendered) so its lifetime is exactly the stream's:
+ * it dies with stream removal and CLI-state reset, and is cleared when the
+ * stream's transcript is released. `subscribeStreamLog`'s fold over
+ * store-emitted `StreamLogDelta`s maintains it in O(delta); a fresh or gapped
+ * consumer rebuilds it from `getRange(0)` through the same application path.
+ */
+export interface TranscriptFoldState {
+  /** False until a rebuild has run; cleared again when the stream's transcript is released. */
+  hydrated: boolean;
+  /** The `StreamLog` instance + emission seq `items` reflects. A mismatch
+   *  with the store's current log means fold continuity is broken: rebuild. */
+  logInstanceId: number;
+  emissionSeq: number;
+  /** Final transcript order: log, compaction, and synthetic rows merged. */
+  readonly items: TranscriptFoldItem[];
+  readonly indexById: Map<string, number>;
+  /** First index the contiguous settled-prefix promotion has not covered. */
+  finalizedFrontier: number;
+  /** Index of the last user row with text, or -1 (latest-line fallback). */
+  latestUserPos: number;
+  /** Index of the last finalized model-response row with text, or -1. */
+  latestResponsePos: number;
+  /** Projection-mode bits `items` was built under; a flip forces a rebuild. */
+  fullLogChild: boolean;
+  workflowOperationalOnly: boolean;
+  projectLifecycleToTaskGroups: boolean;
+  /** Highest-seq ACTIVE_SKILLS entry, with its parse cached by reference. */
+  activeSkillsEntry?: StreamLogEntry;
+  activeSkillsParsedFor?: StreamLogEntry;
+  activeSkills: readonly ActiveSkillSummary[];
+  /** Highest-seq live-activity entry (drives the thinking indicator). */
+  liveActivityEntry?: StreamLogEntry;
+  /** Synthetic rows reconciled into `items`, in slice order, by identity. */
+  synthetics: readonly ConversationEntry[];
+  /** Whether the last emitted `entries` was the full transcript or compact;
+   *  undefined until the first emission. */
+  lastOutputFull?: boolean;
+  /** The exact `entries` array last emitted. A slice whose entries no longer
+   *  match was patched out of band (synthetic rows), so the next application
+   *  must rebuild its output instead of reusing `slice.entries`. */
+  lastEntriesOutput?: readonly ConversationEntry[];
+}
+
 export interface SessionMeta {
   readonly agent: string;
   readonly category: AgentCategory;
@@ -224,6 +289,9 @@ export interface StreamSlice {
    *  to fall back between. */
   readonly stage?: StreamStage | undefined;
   readonly entries: readonly ConversationEntry[];
+  /** Transcript-projection working state (see {@link TranscriptFoldState}).
+   *  A mutable box owned by `subscribeStreamLog`; renderers ignore it. */
+  readonly transcriptFold?: TranscriptFoldState;
   readonly queuedFollowUpMessages: readonly string[];
   readonly activeSkills: readonly ActiveSkillSummary[];
   readonly todos: readonly TodoItem[];

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -3,6 +3,14 @@
 // entries land in side panels and modals; tool rows render inline alongside
 // assistant prose.
 //
+// The projection is a fold over the store's entry-level change feed: every
+// `StreamLogStore.onChange` emission carries a `StreamLogDelta` (appended
+// entries + dirtied entries by value + a monotonic emission seq), and the
+// per-stream `TranscriptFoldState` on the slice is advanced in O(delta) per
+// tick. A fresh consumer, an emission gap, a reset emission, or a
+// projection-mode flip rebuilds the state from `getRange(0)` through the
+// same application path — the from-scratch build IS the resync path.
+//
 // Secrets are redacted at record time by TexraTranscriptRecorder, which is
 // what every host and the HTML export share. The `redactSecrets` calls below
 // remain only to cover rows persisted before that landed; they are idempotent
@@ -25,7 +33,6 @@ import {
   TOOL_USE_STATUS,
   WorkflowCallProgressSchema,
   isTerminalWorkflowCallProgress,
-  type NormalizedToolUse,
   type StreamLogEntry,
   type StreamTabId,
   type TaskGroup,
@@ -48,6 +55,11 @@ import {
   isTranscriptSettlementPhase,
 } from '@shared/streams/streamStatus';
 import { upsertTaskGroupFromStreamLog } from '@shared/streams/taskGroupProjection';
+import {
+  StreamLogDeltaBuffer,
+  type StreamLog,
+  type StreamLogDelta,
+} from '@transcript';
 import { createFlushableDebounce } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { truncateSummary } from '@utils/text/stringUtils';
@@ -69,6 +81,8 @@ import {
   type ConversationEntry,
   type LoadedImage,
   type StreamSlice,
+  type TranscriptFoldItem,
+  type TranscriptFoldState,
 } from './cliState';
 import { isChildStreamRemoved } from './childExecutions';
 import { subscribeToSignalChanges } from './signalSubscription';
@@ -169,9 +183,10 @@ function safeWorkflowOperationalSummary(text: string): string | undefined {
 }
 
 function workflowOperationalLatestLine(
-  entries: readonly ConversationEntry[],
+  items: readonly TranscriptFoldItem[],
 ): string | undefined {
-  for (const entry of entries.toReversed()) {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const entry = items[index].rendered;
     if (entry.role === 'tool') {
       const line =
         safeWorkflowOperationalSummary(entry.toolUse.headerSummary) ??
@@ -197,102 +212,12 @@ function workflowOperationalLatestLine(
   return undefined;
 }
 
-function transcriptMessageTypesForStream(
-  slice: Pick<StreamSlice, 'identity'> | undefined,
-): Set<string> {
-  // Detached child runs surface their full log output (phase group rows and
-  // plain log lines, both `DEFAULT`) when focused, unlike the root/subagent
-  // transcript which shows only model/tool/user/error rows. A workflow-script
-  // run is one such child: its phases and per-agent Running/Finished lines
-  // project onto its own stream trace and must render in its focused viewport.
-  return isFullLogChildStream(slice)
-    ? CHILD_STREAM_LOG_MESSAGE_TYPES
-    : TRANSCRIPT_MESSAGE_TYPES;
-}
-
 function logEntryStreamIsRunning(entry: StreamLogEntry): boolean {
   const data = entry.data;
   if (typeof data !== 'object' || data === null || !('status' in data)) {
     return (entry.text ?? '').trim().length > 0;
   }
   return data.status === 'running';
-}
-
-function latestLogActivityIsThinking(
-  entries: readonly StreamLogEntry[],
-): boolean {
-  const entry = entries.findLast((candidate) =>
-    LIVE_ACTIVITY_MESSAGE_TYPES.has(candidate.messageType ?? ''),
-  );
-  if (!entry) return false;
-  return (
-    entry.messageType === MESSAGE_TYPES.THINKING &&
-    logEntryStreamIsRunning(entry)
-  );
-}
-
-/** Tool inputs are typed `unknown` (model-supplied JSON) and reach us
- *  via Zod passthrough, so a `===` compare would defeat the cache the
- *  moment any upstream code reconstructs `data` (deserialization,
- *  structured clone, future log replay). Inputs are small — tool call
- *  args, not output — so a structural comparison is cheap. */
-function inputEqual(prev: unknown, next: unknown): boolean {
-  return prev === next || isDeepStrictEqual(prev, next);
-}
-
-// Field-by-field — a stringified signature over the whole NormalizedToolUse
-// would allocate the full outputText (potentially 50 KB+ of bash output) on
-// every comparison. Cover every field ToolUseRow reads so future changes
-// can't be silently swallowed.
-function toolUseEqual(
-  prev: NormalizedToolUse,
-  next: NormalizedToolUse,
-): boolean {
-  return (
-    prev.status === next.status &&
-    prev.toolName === next.toolName &&
-    prev.outputText === next.outputText &&
-    prev.errorText === next.errorText &&
-    prev.exitCode === next.exitCode &&
-    prev.headerSummary === next.headerSummary &&
-    prev.isError === next.isError &&
-    prev.isUserFeedback === next.isUserFeedback &&
-    prev.userInstructionText === next.userInstructionText &&
-    inputEqual(prev.input, next.input)
-  );
-}
-
-function entriesEqual(
-  prev: ConversationEntry,
-  next: ConversationEntry,
-): boolean {
-  if (
-    prev.role !== next.role ||
-    prev.text !== next.text ||
-    prev.sourceSeqNo !== next.sourceSeqNo ||
-    prev.messageType !== next.messageType ||
-    prev.pendingEmbeddedSubagentFollowup !==
-      next.pendingEmbeddedSubagentFollowup ||
-    prev.finalized !== next.finalized ||
-    prev.settlementSeqNo !== next.settlementSeqNo
-  ) {
-    return false;
-  }
-  if (prev.role === 'tool' && next.role === 'tool') {
-    return toolUseEqual(prev.toolUse, next.toolUse);
-  }
-  if (prev.role === 'media' && next.role === 'media') {
-    return isDeepStrictEqual(prev.images, next.images);
-  }
-  if (prev.role === 'phase' && next.role === 'phase') {
-    return (
-      prev.phaseIndex === next.phaseIndex && prev.phaseTotal === next.phaseTotal
-    );
-  }
-  if (prev.role === 'workflowTask' && next.role === 'workflowTask') {
-    return isDeepStrictEqual(prev.task, next.task);
-  }
-  return true;
 }
 
 /**
@@ -379,50 +304,11 @@ function baseLogEntryFields<R extends ConversationEntry['role']>(
   };
 }
 
-/** Reuses `prev` when `next` is content-equal, so an unchanged row keeps identity. */
-function dedupeEntry(
-  prev: ConversationEntry | undefined,
-  next: ConversationEntry,
-): ConversationEntry {
-  return prev && entriesEqual(prev, next) ? prev : next;
-}
-
-/**
- * One log entry's cached render. `StreamLog` is append-only and replaces
- * the entry object on any mutation (tool-output patches, text appends, the
- * in-place GROUP_START → GROUP_END upsert), so an unchanged entry reference
- * guarantees an unchanged render.
- */
-interface CachedLogRender {
-  /** The log-entry object `rendered` was computed from. */
-  readonly source: StreamLogEntry;
-  /**
-   * The render with only source-owned finalization applied
-   * (`settlementSeqNo`, or the always-finalized kinds). Promotion inherited
-   * from the slice's copy is applied at assembly time, never baked in here,
-   * so a cached render stays valid even after the slice drops and
-   * re-projects the row (compact workflow dashboard ↔ full transcript).
-   */
-  readonly rendered: ConversationEntry | null;
-  /** `rendered` with inherited promotion applied — computed at most once. */
-  promoted?: ConversationEntry;
-}
-
-interface StreamRenderState {
-  readonly renders: Map<string, CachedLogRender>;
-  /**
-   * The `renderLogEntryFresh` parameter the cache was built under. A stream
-   * whose category flips the lifecycle-to-taskGroups projection rebuilds
-   * from scratch rather than serving renders computed for the other mode.
-   */
-  readonly projectLifecycleToTaskGroups: boolean;
-}
-
 /**
  * Renders a log entry from scratch. `prev` is consulted only for phase
  * count inheritance (a GROUP_END row carries no index/total of its own);
- * finalization here is source-owned only — the slice's promotion is
- * re-inherited by {@link renderLogEntry} at assembly time.
+ * finalization here is source-owned only — the fold re-applies inherited
+ * promotion at the row's slot, so an already-promoted row never rolls back.
  */
 function renderLogEntryFresh(
   entry: StreamLogEntry,
@@ -445,8 +331,8 @@ function renderLogEntryFresh(
     // Drop malformed tool entries rather than crash. The progress view
     // does the same — a bad payload shouldn't take down the transcript.
     if (!toolUse) return null;
-    // Never finalize here. `finalizeSettledPrefix` promotes a tool row only
-    // once it completes AND every entry before it has promoted, so a
+    // Never finalize here. The settled-prefix promotion advances over a tool
+    // row only once it completes AND every entry before it has promoted, so a
     // fast tool can't jump ahead of still-streaming assistant text in
     // `<Static>` (which is append-only).
     const next: ConversationEntry = {
@@ -524,7 +410,7 @@ function renderLogEntryFresh(
   ) {
     renderedText = redactSecrets(safeTerminalText(renderedText));
   }
-  // Assistant text is promoted by `finalizeSettledPrefix` once the model
+  // Assistant text is promoted by the settled-prefix advance once the model
   // moves on to a later entry. User/error rows can't change after they
   // appear, so they finalize immediately.
   const finalized = entry.settlementSeqNo !== undefined || role !== 'assistant';
@@ -540,40 +426,6 @@ function renderLogEntryFresh(
   return next;
 }
 
-/**
- * Renders one log entry against the slice's previous entries, re-rendering
- * only when the entry object has changed since the last sync (see
- * {@link STREAM_RENDER_STATES}). Once an entry settles — or, for its kind,
- * always finalizes — it stays finalized: an entry the slice already
- * promoted to `<Static>` re-inherits the flag here, so a re-sync tick can
- * never roll an already-promoted entry back.
- */
-function renderLogEntry(
-  state: StreamRenderState,
-  entry: StreamLogEntry,
-  prev: ConversationEntry | undefined,
-): ConversationEntry | null {
-  let cached = state.renders.get(entry.id);
-  if (cached === undefined || cached.source !== entry) {
-    cached = {
-      source: entry,
-      rendered: renderLogEntryFresh(
-        entry,
-        prev,
-        state.projectLifecycleToTaskGroups,
-      ),
-    };
-    state.renders.set(entry.id, cached);
-  }
-  const { rendered } = cached;
-  if (rendered === null || prev === undefined) return rendered;
-  const candidate =
-    prev.finalized && !rendered.finalized
-      ? (cached.promoted ??= { ...rendered, finalized: true })
-      : rendered;
-  return dedupeEntry(prev, candidate);
-}
-
 // An entry is "settled" once its content can no longer change, so it is
 // safe to print once into `<Static>` scrollback:
 //   - user / error: fixed the moment they appear.
@@ -584,7 +436,7 @@ function renderLogEntry(
 function isSettledEntry(
   entry: ConversationEntry,
   index: number,
-  entries: readonly ConversationEntry[],
+  total: number,
 ): boolean {
   switch (entry.role) {
     case 'activity':
@@ -602,9 +454,7 @@ function isSettledEntry(
     case 'workflowTask':
       return isTerminalWorkflowCallProgress(entry.task);
     case 'assistant':
-      return (
-        !entry.pendingEmbeddedSubagentFollowup && index < entries.length - 1
-      );
+      return !entry.pendingEmbeddedSubagentFollowup && index < total - 1;
   }
 }
 
@@ -625,7 +475,7 @@ export function finalizeSettledPrefix(
   let sealed = false; // hit the first still-pending entry in this round
   for (const [index, entry] of entries.entries()) {
     if (entry.finalized) continue;
-    const settled = isSettledEntry(entry, index, entries);
+    const settled = isSettledEntry(entry, index, entries.length);
     if (
       sealed ||
       ((entry.role === 'activity' || entry.role === 'workflowTask') &&
@@ -648,36 +498,6 @@ export function finalizeSettledPrefix(
 // can land before the first sync fires); one animation frame is enough
 // to batch chunks and keeps the transcript feeling live.
 const STREAM_SYNC_THROTTLE_MS = 16;
-
-type TranscriptCandidate = {
-  readonly rendered: ConversationEntry;
-  readonly sortSeq: number;
-  readonly tieBreak: number;
-};
-
-function compareTranscriptCandidates(
-  left: TranscriptCandidate,
-  right: TranscriptCandidate,
-): number {
-  return left.sortSeq - right.sortSeq || left.tieBreak - right.tieBreak;
-}
-
-// Log entries already arrive in seqNo order, so the per-tick common case is
-// fully sorted — only synthetic rows (spliced in by syntheticAfterSeq) can
-// land out of order. Detect sortedness in O(N) instead of paying the sort's
-// comparator churn on every streaming delta.
-function sortTranscriptCandidatesIfNeeded(
-  candidates: TranscriptCandidate[],
-): TranscriptCandidate[] {
-  for (let index = 1; index < candidates.length; index += 1) {
-    if (
-      compareTranscriptCandidates(candidates[index - 1], candidates[index]) > 0
-    ) {
-      return candidates.sort(compareTranscriptCandidates);
-    }
-  }
-  return candidates;
-}
 
 /**
  * Incremental task-group projection state, kept beside the slice: the
@@ -709,30 +529,60 @@ const COMPACTION_PROJECTIONS = new Map<
 >();
 
 /**
- * Per-stream render caches for the transcript projection, keyed beside the
- * other incremental projections. Same proven in-file pattern as
- * {@link TASK_GROUP_PROJECTIONS}: walk the log each tick, skip every entry
- * whose object reference is unchanged, re-render exactly the appended or
- * in-place-updated rows — never a full re-render per tick.
+ * Store-emitted deltas awaiting the next batched sync, coalesced per stream.
+ * Written by the `onChange` subscriber; drained by `syncStreamLog`, so an
+ * out-of-band sync (status transition, focus switch, tests) folds the same
+ * buffered changes instead of rescanning the log.
  */
-const STREAM_RENDER_STATES = new Map<StreamTabId, StreamRenderState>();
+interface PendingStreamDeltas {
+  readonly buffer: StreamLogDeltaBuffer;
+  generation: number;
+}
+
+const PENDING_DELTAS = new Map<StreamTabId, PendingStreamDeltas>();
 
 registerCliStateResetHook(() => {
   TASK_GROUP_PROJECTIONS.clear();
   COMPACTION_PROJECTIONS.clear();
-  STREAM_RENDER_STATES.clear();
+  PENDING_DELTAS.clear();
 });
 
-/** Test-only: per-stream render-cache occupancy, for eviction-path regression coverage. */
+let foldApplicationsForTest = 0;
+let rebuildApplicationsForTest = 0;
+
+/** Test-only: how many syncs folded buffered deltas vs rebuilt from scratch.
+ *  The equivalence property test asserts the fold path actually ran. */
+export function transcriptFoldCountersForTest(): {
+  readonly folds: number;
+  readonly rebuilds: number;
+} {
+  return {
+    folds: foldApplicationsForTest,
+    rebuilds: rebuildApplicationsForTest,
+  };
+}
+
+/** Test-only: drop a stream's fold state so the next sync rebuilds from
+ *  scratch — the production resync path, used as the equivalence oracle. */
+export function invalidateTranscriptFoldForTest(streamId: StreamTabId): void {
+  const fold = streams.get().get(streamId)?.transcriptFold;
+  if (fold) resetTranscriptFoldState(fold);
+}
+
+/** Test-only: per-stream projection-state occupancy, for eviction-path regression coverage. */
 export function streamRenderCacheSizesForTest(): {
   readonly taskGroups: number;
   readonly compaction: number;
   readonly render: number;
 } {
+  let render = 0;
+  for (const slice of streams.get().values()) {
+    if (slice.transcriptFold?.hydrated) render += 1;
+  }
   return {
     taskGroups: TASK_GROUP_PROJECTIONS.size,
     compaction: COMPACTION_PROJECTIONS.size,
-    render: STREAM_RENDER_STATES.size,
+    render,
   };
 }
 
@@ -766,11 +616,11 @@ function projectTaskGroupsIncrementally(
 
 function projectCompactionIncrementally(
   streamId: StreamTabId,
-  entries: readonly StreamLogEntry[],
+  log: StreamLog,
   streamTerminal: boolean,
 ): CompactionActivityProjection {
   let state = COMPACTION_PROJECTIONS.get(streamId);
-  if (!state || state.appliedHead > entries.length) {
+  if (!state || state.appliedHead > log.size) {
     state = {
       projection: createCompactionActivityProjection(),
       appliedHead: 0,
@@ -779,19 +629,600 @@ function projectCompactionIncrementally(
     COMPACTION_PROJECTIONS.set(streamId, state);
   }
 
+  // Only the appended tail is read (O(delta)); in-place mutations behind the
+  // head were already applied when their entries were first appended.
   applyCompactionActivityEntries(
     state.projection,
-    entries.slice(state.appliedHead),
+    log.getRange(state.appliedHead),
   );
-  state.appliedHead = entries.length;
+  state.appliedHead = log.size;
   if (streamTerminal && !state.terminal) {
     settleCompactionActivities(state.projection, {
-      throughSeqNo: entries.length,
+      throughSeqNo: log.size,
     });
   }
   state.terminal = streamTerminal;
   return state.projection;
 }
+
+// ---------------------------------------------------------------------------
+// Transcript fold: items maintenance
+// ---------------------------------------------------------------------------
+
+/** Per-application change summary, driving output rebuilds and cursor rescans. */
+interface FoldChangeFlags {
+  itemsChanged: boolean;
+  /** A change touched a row the compact workflow output selects. */
+  compactAffected: boolean;
+  syntheticsChanged: boolean;
+  userRescan: boolean;
+  responseRescan: boolean;
+}
+
+function newFoldChangeFlags(): FoldChangeFlags {
+  return {
+    itemsChanged: false,
+    compactAffected: false,
+    syntheticsChanged: false,
+    userRescan: false,
+    responseRescan: false,
+  };
+}
+
+function createTranscriptFoldState(): TranscriptFoldState {
+  return {
+    hydrated: false,
+    logInstanceId: 0,
+    emissionSeq: 0,
+    items: [],
+    indexById: new Map(),
+    finalizedFrontier: 0,
+    latestUserPos: -1,
+    latestResponsePos: -1,
+    fullLogChild: false,
+    workflowOperationalOnly: false,
+    projectLifecycleToTaskGroups: false,
+    activeSkills: [],
+    synthetics: [],
+  };
+}
+
+function resetTranscriptFoldState(state: TranscriptFoldState): void {
+  state.hydrated = false;
+  state.logInstanceId = 0;
+  state.emissionSeq = 0;
+  state.items.length = 0;
+  state.indexById.clear();
+  state.finalizedFrontier = 0;
+  state.latestUserPos = -1;
+  state.latestResponsePos = -1;
+  state.activeSkillsEntry = undefined;
+  state.activeSkillsParsedFor = undefined;
+  state.activeSkills = [];
+  state.liveActivityEntry = undefined;
+  state.synthetics = [];
+  state.lastOutputFull = undefined;
+  state.lastEntriesOutput = undefined;
+}
+
+/** `sortSeq`/`tieBreak`/`rank` total order over fold items. `Infinity`
+ *  anchors compare as equal on the first term (NaN is falsy), falling
+ *  through to the tiebreaks, which is exactly the order wanted. */
+function compareFoldOrder(
+  a: TranscriptFoldItem,
+  b: TranscriptFoldItem,
+): number {
+  return a.sortSeq - b.sortSeq || a.tieBreak - b.tieBreak || a.rank - b.rank;
+}
+
+/** Upper bound: first index whose item orders strictly after `item`, so an
+ *  equal-key later insert lands after its equals (stable across sources). */
+function foldInsertPosition(
+  items: readonly TranscriptFoldItem[],
+  item: TranscriptFoldItem,
+): number {
+  let low = 0;
+  let high = items.length;
+  while (low < high) {
+    const mid = (low + high) >>> 1;
+    if (compareFoldOrder(items[mid], item) <= 0) low = mid + 1;
+    else high = mid;
+  }
+  return low;
+}
+
+function isUserLineRow(entry: ConversationEntry): boolean {
+  return entry.role === 'user' && entry.text.trim().length > 0;
+}
+
+function isFinalizedResponseRow(entry: ConversationEntry): boolean {
+  return (
+    entry.role === 'assistant' &&
+    entry.messageType === MESSAGE_TYPES.MODEL_RESPONSE &&
+    entry.finalized &&
+    entry.text.trim().length > 0
+  );
+}
+
+function touchesCompactOutput(entry: ConversationEntry): boolean {
+  return entry.synthetic === true || WORKFLOW_DASHBOARD_ROLES.has(entry.role);
+}
+
+function findLastFoldPos(
+  items: readonly TranscriptFoldItem[],
+  matches: (entry: ConversationEntry) => boolean,
+): number {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (matches(items[index].rendered)) return index;
+  }
+  return -1;
+}
+
+function reindexFoldFrom(state: TranscriptFoldState, from: number): void {
+  for (let index = from; index < state.items.length; index += 1) {
+    state.indexById.set(state.items[index].rendered.id, index);
+  }
+}
+
+function insertFoldItem(
+  state: TranscriptFoldState,
+  item: TranscriptFoldItem,
+  flags: FoldChangeFlags,
+): void {
+  const items = state.items;
+  const last = items.at(-1);
+  const pos =
+    last === undefined || compareFoldOrder(last, item) <= 0
+      ? items.length
+      : foldInsertPosition(items, item);
+  if (pos === items.length) {
+    items.push(item);
+    state.indexById.set(item.rendered.id, pos);
+  } else {
+    items.splice(pos, 0, item);
+    reindexFoldFrom(state, pos);
+    if (pos < state.finalizedFrontier) state.finalizedFrontier = pos;
+    if (state.latestUserPos >= pos) state.latestUserPos += 1;
+    if (state.latestResponsePos >= pos) state.latestResponsePos += 1;
+  }
+  if (isUserLineRow(item.rendered) && pos > state.latestUserPos) {
+    state.latestUserPos = pos;
+  }
+  if (isFinalizedResponseRow(item.rendered) && pos > state.latestResponsePos) {
+    state.latestResponsePos = pos;
+  }
+  flags.itemsChanged = true;
+  if (touchesCompactOutput(item.rendered)) flags.compactAffected = true;
+}
+
+function replaceFoldRendered(
+  state: TranscriptFoldState,
+  pos: number,
+  rendered: ConversationEntry,
+  flags: FoldChangeFlags,
+): void {
+  const item = state.items[pos];
+  const previous = item.rendered;
+  item.rendered = rendered;
+  flags.itemsChanged = true;
+  if (touchesCompactOutput(previous) || touchesCompactOutput(rendered)) {
+    flags.compactAffected = true;
+  }
+  if (pos < state.finalizedFrontier && !rendered.finalized) {
+    state.finalizedFrontier = pos;
+  }
+  if (pos === state.latestUserPos && !isUserLineRow(rendered)) {
+    flags.userRescan = true;
+  } else if (isUserLineRow(rendered) && pos > state.latestUserPos) {
+    state.latestUserPos = pos;
+  }
+  if (pos === state.latestResponsePos && !isFinalizedResponseRow(rendered)) {
+    flags.responseRescan = true;
+  } else if (
+    isFinalizedResponseRow(rendered) &&
+    pos > state.latestResponsePos
+  ) {
+    state.latestResponsePos = pos;
+  }
+}
+
+function removeFoldItemAt(
+  state: TranscriptFoldState,
+  pos: number,
+  flags: FoldChangeFlags,
+): void {
+  const [removed] = state.items.splice(pos, 1);
+  state.indexById.delete(removed.rendered.id);
+  reindexFoldFrom(state, pos);
+  if (pos < state.finalizedFrontier) state.finalizedFrontier -= 1;
+  if (pos === state.latestUserPos) flags.userRescan = true;
+  else if (pos < state.latestUserPos) state.latestUserPos -= 1;
+  if (pos === state.latestResponsePos) flags.responseRescan = true;
+  else if (pos < state.latestResponsePos) state.latestResponsePos -= 1;
+  flags.itemsChanged = true;
+  if (touchesCompactOutput(removed.rendered)) flags.compactAffected = true;
+}
+
+/** Recompute every position-derived cursor after a bulk items rebuild. */
+function recomputeFoldCursors(state: TranscriptFoldState): void {
+  const items = state.items;
+  let frontier = 0;
+  while (frontier < items.length && items[frontier].rendered.finalized) {
+    frontier += 1;
+  }
+  state.finalizedFrontier = frontier;
+  state.latestUserPos = findLastFoldPos(items, isUserLineRow);
+  state.latestResponsePos = findLastFoldPos(items, isFinalizedResponseRow);
+}
+
+// ---------------------------------------------------------------------------
+// Transcript fold: change application
+// ---------------------------------------------------------------------------
+
+interface FoldContext {
+  readonly streamId: StreamTabId;
+  readonly log: StreamLog;
+  /** Current slice entries, consulted only for CLI-synthetic rows. */
+  readonly sliceEntries: readonly ConversationEntry[];
+  readonly streamFinal: boolean;
+  /** Resync only: previous rows by id, so an already-promoted row keeps its
+   *  `finalized` flag and a closed phase keeps its inherited counts. */
+  readonly inherit?: ReadonlyMap<string, ConversationEntry>;
+  readonly flags: FoldChangeFlags;
+}
+
+/** Merge two seqNo-ascending change lists into one seqNo-ascending pass. */
+function mergeChangedBySeqNo(
+  dirtied: readonly StreamLogEntry[],
+  appended: readonly StreamLogEntry[],
+): readonly StreamLogEntry[] {
+  if (dirtied.length === 0) return appended;
+  if (appended.length === 0) return dirtied;
+  const merged: StreamLogEntry[] = [];
+  let d = 0;
+  let a = 0;
+  while (d < dirtied.length && a < appended.length) {
+    merged.push(
+      dirtied[d].seqNo <= appended[a].seqNo ? dirtied[d++] : appended[a++],
+    );
+  }
+  while (d < dirtied.length) merged.push(dirtied[d++]);
+  while (a < appended.length) merged.push(appended[a++]);
+  return merged;
+}
+
+/**
+ * A tracked singleton row was mutated away from its tracked message type:
+ * re-derive both singletons from the full log (rare, producer-anomaly path;
+ * keeps the ordinary fold allocation-free).
+ */
+function retrackFoldSingletons(
+  state: TranscriptFoldState,
+  log: StreamLog,
+): void {
+  const entries = log.getRange(0);
+  state.activeSkillsEntry = entries.findLast(
+    (entry) => entry.messageType === MESSAGE_TYPES.ACTIVE_SKILLS,
+  );
+  state.liveActivityEntry = entries.findLast((entry) =>
+    LIVE_ACTIVITY_MESSAGE_TYPES.has(entry.messageType ?? ''),
+  );
+}
+
+/** Fold one changed (appended or dirtied) log entry into the items array. */
+function applyChangedLogEntry(
+  state: TranscriptFoldState,
+  entry: StreamLogEntry,
+  ctx: FoldContext,
+): void {
+  const messageType = entry.messageType ?? '';
+  const wOO = state.workflowOperationalOnly;
+  // Detached child runs surface their full log output (phase group rows and
+  // plain log lines, both `DEFAULT`) when focused, unlike the root/subagent
+  // transcript which shows only model/tool/user/error rows.
+  const transcriptCandidate = (
+    state.fullLogChild
+      ? CHILD_STREAM_LOG_MESSAGE_TYPES
+      : TRANSCRIPT_MESSAGE_TYPES
+  ).has(messageType);
+  const workflowDefaultLog =
+    wOO &&
+    entry.type === STREAM_LOG_ENTRY_TYPES.LOG &&
+    entry.level !== 'debug' &&
+    messageType === MESSAGE_TYPES.DEFAULT;
+  const workflowPhaseHeader =
+    wOO &&
+    messageType === MESSAGE_TYPES.DEFAULT &&
+    phaseGroupData(entry) !== null;
+  const workflowCall = wOO && messageType === MESSAGE_TYPES.WORKFLOW_TASK;
+
+  const trackedPos = state.indexById.get(entry.id);
+  const existingPos =
+    trackedPos !== undefined && state.items[trackedPos].rank === 1
+      ? trackedPos
+      : undefined;
+
+  if (
+    !transcriptCandidate &&
+    !workflowDefaultLog &&
+    !workflowPhaseHeader &&
+    !workflowCall
+  ) {
+    if (existingPos !== undefined)
+      removeFoldItemAt(state, existingPos, ctx.flags);
+    return;
+  }
+
+  const prev =
+    existingPos !== undefined
+      ? state.items[existingPos].rendered
+      : ctx.inherit?.get(entry.id);
+  let rendered = renderLogEntryFresh(
+    entry,
+    prev,
+    state.projectLifecycleToTaskGroups,
+  );
+  // Workflow-agent details are an operational feed, not a model transcript.
+  // Detached workflow-script runs intentionally keep their full child log,
+  // including Running/Finished and error rows. A phase uses the DEFAULT
+  // message type, but remains an operational row.
+  if (
+    rendered !== null &&
+    wOO &&
+    !WORKFLOW_OPERATIONAL_ROLES.has(rendered.role) &&
+    !workflowDefaultLog
+  ) {
+    rendered = null;
+  }
+  if (rendered === null) {
+    if (existingPos !== undefined)
+      removeFoldItemAt(state, existingPos, ctx.flags);
+    return;
+  }
+  // An entry the slice already promoted re-inherits the flag here, so a
+  // re-render can never roll an already-printed `<Static>` row back.
+  if (prev?.finalized && !rendered.finalized) {
+    rendered = { ...rendered, finalized: true };
+  }
+  if (existingPos !== undefined) {
+    replaceFoldRendered(state, existingPos, rendered, ctx.flags);
+  } else {
+    insertFoldItem(
+      state,
+      { rendered, sortSeq: entry.seqNo, tieBreak: 0, rank: 1 },
+      ctx.flags,
+    );
+  }
+}
+
+/** Reconcile projected compaction blocks into their transcript rows. */
+function reconcileCompactionRows(
+  state: TranscriptFoldState,
+  projection: CompactionActivityProjection,
+  flags: FoldChangeFlags,
+): void {
+  for (const block of projection.blocks) {
+    const id = `compaction:${block.operationId}`;
+    const pos = state.indexById.get(id);
+    if (pos !== undefined && state.items[pos].block === block) continue;
+    const rendered: ConversationEntry = {
+      id,
+      sourceSeqNo: block.startPosition,
+      role: 'activity',
+      text: COMPACTION_ACTIVITY_LABEL[block.status],
+      messageType: MESSAGE_TYPES.CONTEXT_COMPACTION_ACTIVITY,
+      finalized: block.finalized,
+      activity: block,
+    };
+    if (pos !== undefined) {
+      state.items[pos].block = block;
+      replaceFoldRendered(state, pos, rendered, flags);
+    } else {
+      insertFoldItem(
+        state,
+        { rendered, sortSeq: block.startPosition, tieBreak: 0, rank: 0, block },
+        flags,
+      );
+    }
+  }
+}
+
+/**
+ * Reconcile CLI-synthetic rows from the slice into the items array. Synthetic
+ * rows are CLI-owned objects appended to `slice.entries` out of band, so the
+ * fold detects them by object identity against the last reconciled list.
+ * Changes are rare, user-paced events; the bulk rebuild keeps insertion-order
+ * tiebreaks exact and recomputes the position cursors in one pass.
+ */
+function reconcileSynthetics(
+  state: TranscriptFoldState,
+  sliceEntries: readonly ConversationEntry[],
+  flags: FoldChangeFlags,
+): void {
+  const wOO = state.workflowOperationalOnly;
+  const current: ConversationEntry[] = [];
+  for (const entry of sliceEntries) {
+    if (
+      entry.synthetic &&
+      (!wOO || WORKFLOW_OPERATIONAL_ROLES.has(entry.role))
+    ) {
+      current.push(entry);
+    }
+  }
+  const previous = state.synthetics;
+  if (
+    current.length === previous.length &&
+    current.every((entry, index) => entry === previous[index])
+  ) {
+    return;
+  }
+  flags.syntheticsChanged = true;
+  flags.itemsChanged = true;
+  flags.compactAffected = true;
+  let removed = false;
+  for (let index = state.items.length - 1; index >= 0; index -= 1) {
+    if (state.items[index].rank === 2) {
+      state.items.splice(index, 1);
+      removed = true;
+    }
+  }
+  if (removed) {
+    state.indexById.clear();
+    reindexFoldFrom(state, 0);
+  }
+  for (const [index, entry] of current.entries()) {
+    const item: TranscriptFoldItem = {
+      rendered: entry,
+      // Synthetic (CLI-owned) rows are positioned by `syntheticAfterSeq`
+      // alongside the ordered log entries.
+      sortSeq: entry.syntheticAfterSeq ?? Number.POSITIVE_INFINITY,
+      tieBreak: index + 1,
+      rank: 2,
+    };
+    const pos = foldInsertPosition(state.items, item);
+    state.items.splice(pos, 0, item);
+  }
+  reindexFoldFrom(state, 0);
+  recomputeFoldCursors(state);
+  flags.userRescan = false;
+  flags.responseRescan = false;
+  state.synthetics = current;
+}
+
+// Advance the contiguous settled-prefix promotion (same rule as
+// `finalizeSettledPrefix`, folded: positions below the frontier are already
+// finalized, so each application only touches newly promotable rows).
+function advanceSettledPrefix(
+  state: TranscriptFoldState,
+  streamFinal: boolean,
+  flags: FoldChangeFlags,
+): void {
+  const items = state.items;
+  let index = state.finalizedFrontier;
+  while (index < items.length) {
+    const entry = items[index].rendered;
+    if (entry.finalized) {
+      index += 1;
+      continue;
+    }
+    const settled = isSettledEntry(entry, index, items.length);
+    if (
+      !settled &&
+      (entry.role === 'activity' ||
+        entry.role === 'workflowTask' ||
+        !streamFinal)
+    ) {
+      break;
+    }
+    replaceFoldRendered(state, index, { ...entry, finalized: true }, flags);
+    index += 1;
+  }
+  state.finalizedFrontier = index;
+}
+
+/**
+ * Apply one coalesced change set to the fold state. The from-scratch rebuild
+ * is this same function fed `getRange(0)` as the appended list over a reset
+ * state — the resync path and the fold share every ordering rule.
+ */
+function applyStreamChanges(
+  state: TranscriptFoldState,
+  appended: readonly StreamLogEntry[],
+  dirtied: readonly StreamLogEntry[],
+  ctx: FoldContext,
+): {
+  taskGroups: readonly TaskGroup[];
+  compaction: CompactionActivityProjection;
+} {
+  const changed = mergeChangedBySeqNo(dirtied, appended);
+  let retrack = false;
+  for (const entry of changed) {
+    if (entry.messageType === MESSAGE_TYPES.ACTIVE_SKILLS) {
+      if (
+        !state.activeSkillsEntry ||
+        entry.seqNo >= state.activeSkillsEntry.seqNo
+      ) {
+        state.activeSkillsEntry = entry;
+      }
+    } else if (state.activeSkillsEntry?.id === entry.id) {
+      retrack = true;
+    }
+    if (LIVE_ACTIVITY_MESSAGE_TYPES.has(entry.messageType ?? '')) {
+      if (
+        !state.liveActivityEntry ||
+        entry.seqNo >= state.liveActivityEntry.seqNo
+      ) {
+        state.liveActivityEntry = entry;
+      }
+    } else if (state.liveActivityEntry?.id === entry.id) {
+      retrack = true;
+    }
+  }
+  if (retrack) retrackFoldSingletons(state, ctx.log);
+
+  const taskGroups = projectTaskGroupsIncrementally(ctx.streamId, changed);
+  const compaction = projectCompactionIncrementally(
+    ctx.streamId,
+    ctx.log,
+    ctx.streamFinal,
+  );
+  for (const entry of changed) applyChangedLogEntry(state, entry, ctx);
+  reconcileCompactionRows(state, compaction, ctx.flags);
+  reconcileSynthetics(state, ctx.sliceEntries, ctx.flags);
+  // Promote only after the merged order is final: "is there a later entry"
+  // and `<Static>` append order are both defined on the final stream order.
+  advanceSettledPrefix(state, ctx.streamFinal, ctx.flags);
+  if (ctx.flags.userRescan) {
+    state.latestUserPos = findLastFoldPos(state.items, isUserLineRow);
+    ctx.flags.userRescan = false;
+  }
+  if (ctx.flags.responseRescan) {
+    state.latestResponsePos = findLastFoldPos(
+      state.items,
+      isFinalizedResponseRow,
+    );
+    ctx.flags.responseRescan = false;
+  }
+  return { taskGroups, compaction };
+}
+
+/** The bounded dashboard + synthetic selection for an unfocused workflow stream. */
+function compactWorkflowEntries(
+  items: readonly TranscriptFoldItem[],
+): ConversationEntry[] {
+  let dashboardCount = 0;
+  for (const item of items) {
+    if (
+      !item.rendered.synthetic &&
+      WORKFLOW_DASHBOARD_ROLES.has(item.rendered.role)
+    ) {
+      dashboardCount += 1;
+    }
+  }
+  let skip = Math.max(
+    0,
+    dashboardCount - MAX_COMPACT_WORKFLOW_DASHBOARD_ENTRIES,
+  );
+  const out: ConversationEntry[] = [];
+  for (const item of items) {
+    const entry = item.rendered;
+    if (entry.synthetic) {
+      out.push(entry);
+      continue;
+    }
+    if (!WORKFLOW_DASHBOARD_ROLES.has(entry.role)) continue;
+    if (skip > 0) {
+      skip -= 1;
+      continue;
+    }
+    out.push(entry);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Subscription + sync entry points
+// ---------------------------------------------------------------------------
 
 function trySyncStreamLog(streamId: StreamTabId): void {
   try {
@@ -806,26 +1237,37 @@ function trySyncStreamLog(streamId: StreamTabId): void {
 
 export function subscribeStreamLog(): () => void {
   const store = defaultSession().transcripts;
-  const pendingStreams = new Map<StreamTabId, number>();
   let previousActiveStreamId = activeStreamId.get();
 
   // One trailing timer shared by every stream: during a multi-subagent burst
   // the root and each child emit within the same window, and per-stream
   // timers would fire staggered — one sync→render pass per stream. A shared
-  // batch window coalesces them into a single pass; syncStreamLog reads the
-  // full log when it fires, so batching loses nothing.
+  // batch window coalesces them into a single pass; each stream's buffered
+  // delta is folded when it fires, so batching loses nothing.
   const syncDebounce = createFlushableDebounce(() => {
-    const streamIds = [...pendingStreams];
-    pendingStreams.clear();
-    for (const [id, generation] of streamIds) {
-      if (generation !== getCliStateGeneration()) continue;
-      trySyncStreamLog(id);
+    for (const [streamId, pending] of [...PENDING_DELTAS]) {
+      if (pending.generation !== getCliStateGeneration()) {
+        PENDING_DELTAS.delete(streamId);
+        continue;
+      }
+      trySyncStreamLog(streamId);
     }
   }, STREAM_SYNC_THROTTLE_MS);
 
-  const dispose = store.onChange((streamId) => {
+  const dispose = store.onChange((streamId, delta) => {
     if (isCliStreamRetired(streamId)) return;
-    pendingStreams.set(streamId, getCliStateGeneration());
+    const pending = PENDING_DELTAS.get(streamId);
+    if (pending) {
+      pending.buffer.push(delta);
+      pending.generation = getCliStateGeneration();
+    } else {
+      const buffer = new StreamLogDeltaBuffer(delta.emissionSeq - 1);
+      buffer.push(delta);
+      PENDING_DELTAS.set(streamId, {
+        buffer,
+        generation: getCliStateGeneration(),
+      });
+    }
     // Only start the window on its first tick — later ticks in the same
     // window join the batch without resetting the countdown (`pending`
     // guard), unlike a classic debounce that would restart on every call.
@@ -867,43 +1309,54 @@ export function subscribeStreamLog(): () => void {
     // unmount), so a final render of whatever was still pending isn't
     // needed and would race an already-torn-down UI.
     syncDebounce.cancel();
-    pendingStreams.clear();
+    PENDING_DELTAS.clear();
   };
 }
 
 export function syncStreamLog(
   streamId: StreamTabId,
-  options: { readonly forceFull?: boolean } = {},
+  options: {
+    readonly forceFull?: boolean;
+    /** Treat the stream as final for settled-prefix promotion, even when its
+     *  status has not reached a settlement phase (turn-boundary callers). */
+    readonly forceFinal?: boolean;
+  } = {},
 ): void {
   if (isChildStreamRemoved(streamId)) {
+    PENDING_DELTAS.delete(streamId);
     TASK_GROUP_PROJECTIONS.delete(streamId);
     COMPACTION_PROJECTIONS.delete(streamId);
-    STREAM_RENDER_STATES.delete(streamId);
     return;
   }
   // AgentTrace throttles MODEL_RESPONSE chunks into the store via a 50ms
   // timer. If we read before that timer fires (e.g. the stream finalized
   // between two TUI sync ticks), the assistant text is still sitting in
   // an in-memory buffer and never reaches the transcript. Force any
-  // pending flushers to materialize before we read.
+  // pending flushers to materialize before we read — their emissions land
+  // in this stream's pending buffer and are folded below.
   const session = defaultSession();
   session.flushPendingTraces();
   const store = session.transcripts;
   const log = store.get(streamId);
-  if (!log) return;
+  const pending = PENDING_DELTAS.get(streamId);
+  PENDING_DELTAS.delete(streamId);
+  if (!log) {
+    // No resident log (never created, or evicted): nothing to fold, but a
+    // turn-boundary caller may still promote rows the slice already holds.
+    // Fold continuity is gone either way, so drop any hydrated state; the
+    // next rebuild inherits promotion from the slice rows.
+    if (options.forceFinal === true) {
+      patchStream(streamId, (slice) => {
+        const entries = finalizeSettledPrefix(slice.entries, true);
+        return entries === slice.entries ? slice : { ...slice, entries };
+      });
+      const fold = streams.get().get(streamId)?.transcriptFold;
+      if (fold) resetTranscriptFoldState(fold);
+    }
+    return;
+  }
+  const buffer = pending?.buffer;
 
-  const allEntries = log.getRange(0);
-  const activeSkillsEntry = allEntries.findLast(
-    (entry) => entry.messageType === MESSAGE_TYPES.ACTIVE_SKILLS,
-  );
-  const parsedActiveSkills = activeSkillsEntry
-    ? ActiveSkillsSnapshotSchema.safeParse(activeSkillsEntry.data)
-    : undefined;
-  const taskGroups = projectTaskGroupsIncrementally(streamId, allEntries);
-  const thinkingActive = latestLogActivityIsThinking(allEntries);
-  const transcriptMessageTypes = transcriptMessageTypesForStream(
-    streams.get().get(streamId),
-  );
   const currentActiveStreamId = activeStreamId.get();
   const projectFullTranscript =
     options.forceFull === true ||
@@ -912,190 +1365,142 @@ export function syncStreamLog(
   let releaseAfterSync = false;
 
   patchStream(streamId, (slice, lifecycle) => {
-    const existing = new Map(slice.entries.map((e) => [e.id, e]));
     const workflowStream = slice.category === AgentCategory.Workflow;
-    let activeSkills = slice.activeSkills;
-    if (slice.category === AgentCategory.ToolUse && parsedActiveSkills) {
-      activeSkills = parsedActiveSkills.success
-        ? parsedActiveSkills.data.skills
-        : [];
-    }
-    const workflowOperationalOnly =
-      workflowStream && !isFullLogChildStream(slice);
-    const syntheticEntries = slice.entries.filter(
-      (entry) =>
-        entry.synthetic &&
-        (!workflowOperationalOnly ||
-          WORKFLOW_OPERATIONAL_ROLES.has(entry.role)),
-    );
-    const streamFinal = isTranscriptSettlementPhase(lifecycle.status);
-    const compactionProjection = projectCompactionIncrementally(
+    const fullLogChild = isFullLogChildStream(slice);
+    const workflowOperationalOnly = workflowStream && !fullLogChild;
+    const streamFinal =
+      options.forceFinal === true ||
+      isTranscriptSettlementPhase(lifecycle.status);
+    const state = slice.transcriptFold ?? createTranscriptFoldState();
+    const flags = newFoldChangeFlags();
+    const modeCurrent =
+      state.fullLogChild === fullLogChild &&
+      state.workflowOperationalOnly === workflowOperationalOnly &&
+      state.projectLifecycleToTaskGroups === workflowStream;
+    // Fold continuity: same log instance, and either the buffered burst picks
+    // up exactly where the state left off and reaches the log's emission
+    // head, or (no buffer) the state already sits at the head. Anything else
+    // — fresh state, gap, reset emission, mode flip — rebuilds from scratch.
+    const canFold =
+      state.hydrated &&
+      modeCurrent &&
+      state.logInstanceId === log.instanceId &&
+      !log.hasUndrainedChanges &&
+      (buffer
+        ? !buffer.resyncRequired &&
+          buffer.baseEmissionSeq === state.emissionSeq &&
+          buffer.emissionSeq === log.emissionHead
+        : state.emissionSeq === log.emissionHead);
+
+    const ctx: FoldContext = {
       streamId,
-      allEntries,
+      log,
+      sliceEntries: slice.entries,
       streamFinal,
-    );
-    const compactingActive = compactionProjection.blocks.some(
-      (block) => block.status === 'running',
-    );
-    const projectLifecycleToTaskGroups =
-      slice.category === AgentCategory.Workflow;
-    let renderState = STREAM_RENDER_STATES.get(streamId);
-    if (
-      renderState === undefined ||
-      renderState.projectLifecycleToTaskGroups !== projectLifecycleToTaskGroups
-    ) {
-      renderState = {
-        renders: new Map(),
-        projectLifecycleToTaskGroups,
-      };
-      STREAM_RENDER_STATES.set(streamId, renderState);
-    }
-    const logCandidates: TranscriptCandidate[] = [];
-    const workflowLatestLineCandidates: TranscriptCandidate[] = [];
-    for (const block of compactionProjection.blocks) {
-      const id = `compaction:${block.operationId}`;
-      const next: ConversationEntry = {
-        id,
-        sourceSeqNo: block.startPosition,
-        role: 'activity',
-        text: COMPACTION_ACTIVITY_LABEL[block.status],
-        messageType: MESSAGE_TYPES.CONTEXT_COMPACTION_ACTIVITY,
-        finalized: block.finalized,
-        activity: block,
-      };
-      logCandidates.push({
-        rendered: dedupeEntry(existing.get(id), next),
-        sortSeq: block.startPosition,
-        tieBreak: 0,
+      flags,
+    };
+    let projections;
+    if (canFold) {
+      foldApplicationsForTest += 1;
+      const changes = buffer?.drain();
+      projections = applyStreamChanges(
+        state,
+        changes?.appended ?? [],
+        changes?.dirtied ?? [],
+        ctx,
+      );
+      state.emissionSeq = log.emissionHead;
+    } else {
+      rebuildApplicationsForTest += 1;
+      const inheritRows = state.hydrated
+        ? state.items.map((item) => item.rendered)
+        : slice.entries;
+      const inherit = new Map<string, ConversationEntry>();
+      for (const row of inheritRows) {
+        if (!row.synthetic) inherit.set(row.id, row);
+      }
+      resetTranscriptFoldState(state);
+      state.fullLogChild = fullLogChild;
+      state.workflowOperationalOnly = workflowOperationalOnly;
+      state.projectLifecycleToTaskGroups = workflowStream;
+      state.logInstanceId = log.instanceId;
+      state.emissionSeq = log.emissionHead;
+      state.hydrated = true;
+      flags.itemsChanged = true;
+      flags.compactAffected = true;
+      flags.syntheticsChanged = true;
+      projections = applyStreamChanges(state, log.getRange(0), [], {
+        ...ctx,
+        inherit,
       });
     }
-    for (const entry of allEntries) {
-      const messageType = entry.messageType ?? '';
-      const transcriptCandidate = transcriptMessageTypes.has(messageType);
-      const workflowDefaultLog =
-        workflowOperationalOnly &&
-        entry.type === STREAM_LOG_ENTRY_TYPES.LOG &&
-        entry.level !== 'debug' &&
-        messageType === MESSAGE_TYPES.DEFAULT;
-      const workflowPhaseHeader =
-        workflowOperationalOnly &&
-        messageType === MESSAGE_TYPES.DEFAULT &&
-        phaseGroupData(entry) !== null;
-      const workflowCall =
-        workflowOperationalOnly && messageType === MESSAGE_TYPES.WORKFLOW_TASK;
-      if (
-        !transcriptCandidate &&
-        !workflowDefaultLog &&
-        !workflowPhaseHeader &&
-        !workflowCall
-      ) {
-        continue;
-      }
-      const rendered = renderLogEntry(
-        renderState,
-        entry,
-        existing.get(entry.id),
-      );
-      if (!rendered) continue;
-      if (workflowOperationalOnly) {
-        workflowLatestLineCandidates.push({
-          rendered,
-          sortSeq: entry.seqNo,
-          tieBreak: 0,
-        });
-      }
-      // Workflow-agent details are an operational feed, not a model
-      // transcript. Detached workflow-script runs intentionally keep their
-      // full child log, including Running/Finished and error rows. A phase
-      // uses the DEFAULT message type, but remains an operational row.
-      if (
-        workflowOperationalOnly &&
-        !WORKFLOW_OPERATIONAL_ROLES.has(rendered.role) &&
-        !workflowDefaultLog
-      ) {
-        continue;
-      }
-      logCandidates.push({ rendered, sortSeq: entry.seqNo, tieBreak: 0 });
-    }
-    // Synthetic (CLI-owned) rows are positioned by `syntheticAfterSeq`
-    // alongside the ordered log entries; push into a copy so we don't mutate
-    // `logCandidates` itself.
-    const candidates: TranscriptCandidate[] =
-      syntheticEntries.length === 0 ? logCandidates : [...logCandidates];
 
-    for (const [index, entry] of syntheticEntries.entries()) {
-      const candidate = {
-        rendered: entry,
-        sortSeq: entry.syntheticAfterSeq ?? Number.POSITIVE_INFINITY,
-        tieBreak: index + 1,
-      };
-      candidates.push(candidate);
-      if (workflowOperationalOnly) {
-        workflowLatestLineCandidates.push(candidate);
+    const { taskGroups, compaction } = projections;
+    const compactingActive = compaction.blocks.some(
+      (block) => block.status === 'running',
+    );
+    const live = state.liveActivityEntry;
+    const thinkingActive =
+      live !== undefined &&
+      live.messageType === MESSAGE_TYPES.THINKING &&
+      logEntryStreamIsRunning(live);
+
+    let activeSkills = slice.activeSkills;
+    if (slice.category === AgentCategory.ToolUse && state.activeSkillsEntry) {
+      if (state.activeSkillsParsedFor !== state.activeSkillsEntry) {
+        const parsed = ActiveSkillsSnapshotSchema.safeParse(
+          state.activeSkillsEntry.data,
+        );
+        state.activeSkills = parsed.success ? parsed.data.skills : [];
+        state.activeSkillsParsedFor = state.activeSkillsEntry;
       }
+      activeSkills = state.activeSkills;
     }
 
-    const ordered = sortTranscriptCandidatesIfNeeded(candidates).map(
-      (candidate) => candidate.rendered,
-    );
-    // Promote the settled prefix only after sorting: "is there a later
-    // entry" and Static append order are both defined on the final stream
-    // order, not the per-entry render order.
-    const next = finalizeSettledPrefix(ordered, streamFinal);
-    const latestUserIndex = next.findLastIndex(
-      (entry) => entry.role === 'user' && entry.text.trim(),
-    );
-    const latestInstruction =
-      latestUserIndex >= 0 ? next[latestUserIndex]?.text : undefined;
     // Transcript-derived live status only. `slice.description` is the
     // runtime's own one-liner and is never written from here.
+    const latestUserPos = state.latestUserPos;
+    const latestInstruction =
+      latestUserPos >= 0 ? state.items[latestUserPos].rendered.text : undefined;
     const latestLine = workflowOperationalOnly
-      ? (workflowOperationalLatestLine(
-          sortTranscriptCandidatesIfNeeded(workflowLatestLineCandidates).map(
-            (candidate) => candidate.rendered,
-          ),
-        ) ?? slice.latestLine)
-      : (next.findLast(
-          (entry, index) =>
-            index > latestUserIndex &&
-            entry.role === 'assistant' &&
-            entry.messageType === MESSAGE_TYPES.MODEL_RESPONSE &&
-            entry.finalized &&
-            entry.text.trim(),
-        )?.text ??
+      ? (workflowOperationalLatestLine(state.items) ?? slice.latestLine)
+      : ((state.latestResponsePos > latestUserPos
+          ? state.items[state.latestResponsePos].rendered.text
+          : undefined) ??
         latestInstruction ??
         slice.latestLine);
+
     releaseAfterSync =
       !projectFullTranscript &&
       lifecycle.status !== undefined &&
       !isActivePhase(lifecycle.status);
 
     // A compact workflow keeps only its bounded canonical dashboard rows plus
-    // synthetic operational rows. Ordinary inactive streams retain the prior
-    // synthetic-only behavior.
-    const compactWorkflowDashboardIds = new Set(
-      next
-        .filter((entry) => WORKFLOW_DASHBOARD_ROLES.has(entry.role))
-        .slice(-MAX_COMPACT_WORKFLOW_DASHBOARD_ENTRIES)
-        .map((entry) => entry.id),
-    );
-    const compactEntries = workflowStream
-      ? next.filter(
-          (entry) =>
-            entry.synthetic || compactWorkflowDashboardIds.has(entry.id),
-        )
-      : syntheticEntries;
-    const nextEntries = projectFullTranscript ? next : compactEntries;
-    const entriesUnchanged =
-      slice.entries.length === nextEntries.length &&
-      slice.entries.every((entry, index) => {
-        const candidate = nextEntries[index];
-        return projectFullTranscript
-          ? entry.id === candidate.id && entriesEqual(entry, candidate)
-          : entry === candidate;
-      });
+    // synthetic operational rows; ordinary inactive streams keep synthetic
+    // rows only. Each selection is rebuilt only when a change touched it —
+    // the change detection comes from the delta, not from re-deriving and
+    // deep-comparing the whole projection.
+    const outputStale =
+      state.lastEntriesOutput !== slice.entries ||
+      state.lastOutputFull !== projectFullTranscript;
+    let entries: readonly ConversationEntry[] = slice.entries;
+    if (projectFullTranscript) {
+      if (flags.itemsChanged || outputStale) {
+        entries = state.items.map((item) => item.rendered);
+      }
+    } else if (workflowStream) {
+      if (flags.compactAffected || outputStale) {
+        entries = compactWorkflowEntries(state.items);
+      }
+    } else if (flags.syntheticsChanged || outputStale) {
+      entries = state.synthetics;
+    }
+    state.lastOutputFull = projectFullTranscript;
+    state.lastEntriesOutput = entries;
+
     if (
-      entriesUnchanged &&
+      slice.transcriptFold === state &&
+      entries === slice.entries &&
       slice.latestLine === latestLine &&
       slice.thinkingActive === thinkingActive &&
       slice.compactingActive === compactingActive &&
@@ -1106,8 +1511,9 @@ export function syncStreamLog(
     }
     return {
       ...slice,
+      transcriptFold: state,
       latestLine,
-      entries: nextEntries,
+      entries,
       activeSkills,
       thinkingActive,
       compactingActive,
@@ -1120,11 +1526,12 @@ export function syncStreamLog(
     // The store dropped its resident log; these incremental caches would
     // otherwise keep every entry (and rendered row) of a completed stream
     // alive for the rest of the session. Safe to drop: each projection
-    // rebuilds from scratch — cheaply, from the store's own summary — the
-    // next time this stream syncs (e.g. if it's reactivated).
+    // rebuilds from scratch — through the shared resync path — the next
+    // time this stream syncs (e.g. if it's reactivated).
     TASK_GROUP_PROJECTIONS.delete(streamId);
     COMPACTION_PROJECTIONS.delete(streamId);
-    STREAM_RENDER_STATES.delete(streamId);
+    const fold = streams.get().get(streamId)?.transcriptFold;
+    if (fold) resetTranscriptFoldState(fold);
   }
 
   // Surface stream as active if we don't already have one — handles bare

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -864,7 +864,14 @@ interface FoldContext {
   readonly log: StreamLog;
   /** Current slice entries, consulted only for CLI-synthetic rows. */
   readonly sliceEntries: readonly ConversationEntry[];
+  /** Settled-prefix promotion signal: real settlement OR a turn-boundary
+   *  caller's `forceFinal`. Never drives compaction settlement. */
   readonly streamFinal: boolean;
+  /** The stream's lifecycle actually reached a settlement phase. Only this
+   *  settles compaction activities: a turn-boundary `forceFinal` while a
+   *  compaction is still running must not record it as interrupted — its
+   *  completion event is still to come. */
+  readonly streamSettled: boolean;
   /** Resync only: previous rows by id, so an already-promoted row keeps its
    *  `finalized` flag and a closed phase keeps its inherited counts. */
   readonly inherit?: ReadonlyMap<string, ConversationEntry>;
@@ -1066,10 +1073,9 @@ function reconcileSynthetics(
       removed = true;
     }
   }
-  if (removed) {
-    state.indexById.clear();
-    reindexFoldFrom(state, 0);
-  }
+  // Stale ids of removed rows must leave the map; positions are rebuilt by
+  // the unconditional reindex after the inserts below.
+  if (removed) state.indexById.clear();
   for (const [index, entry] of current.entries()) {
     const item: TranscriptFoldItem = {
       rendered: entry,
@@ -1164,7 +1170,7 @@ function applyStreamChanges(
   const compaction = projectCompactionIncrementally(
     ctx.streamId,
     ctx.log,
-    ctx.streamFinal,
+    ctx.streamSettled,
   );
   for (const entry of changed) applyChangedLogEntry(state, entry, ctx);
   reconcileCompactionRows(state, compaction, ctx.flags);
@@ -1368,9 +1374,8 @@ export function syncStreamLog(
     const workflowStream = slice.category === AgentCategory.Workflow;
     const fullLogChild = isFullLogChildStream(slice);
     const workflowOperationalOnly = workflowStream && !fullLogChild;
-    const streamFinal =
-      options.forceFinal === true ||
-      isTranscriptSettlementPhase(lifecycle.status);
+    const streamSettled = isTranscriptSettlementPhase(lifecycle.status);
+    const streamFinal = options.forceFinal === true || streamSettled;
     const state = slice.transcriptFold ?? createTranscriptFoldState();
     const flags = newFoldChangeFlags();
     const modeCurrent =
@@ -1397,6 +1402,7 @@ export function syncStreamLog(
       log,
       sliceEntries: slice.entries,
       streamFinal,
+      streamSettled,
       flags,
     };
     let projections;

--- a/packages/cli/src/chat/tui/state/transcriptProjection.ts
+++ b/packages/cli/src/chat/tui/state/transcriptProjection.ts
@@ -1,8 +1,7 @@
 import type { StreamTabId } from '@shared/schemas';
 
 import { isChildStreamRemoved } from './childExecutions';
-import { patchStream } from './cliState';
-import { finalizeSettledPrefix, syncStreamLog } from './subscribeStreamLog';
+import { syncStreamLog } from './subscribeStreamLog';
 
 export interface ProjectStreamTranscriptOptions {
   /** Treat the stream as final: promote the settled prefix as far as it
@@ -15,22 +14,17 @@ export interface ProjectStreamTranscriptOptions {
  *
  * Callers that know a stream reached a turn boundary should project through
  * this helper instead of open-coding sync + finalization. That keeps
- * transcript ordering owned by one path.
+ * transcript ordering owned by one path. `finalize` applies the same
+ * promotion rule the live sync uses, with `streamFinal` forced: the caller
+ * knows the turn ended even when the stream's status has not reached its
+ * settlement phase yet. A nonterminal workflow call or a running compaction
+ * still seals the prefix — bridge cleanup can replace their state after the
+ * turn boundary, and `<Static>` is append-only.
  */
 export function projectStreamTranscript(
   streamId: StreamTabId,
   options: ProjectStreamTranscriptOptions = {},
 ): void {
   if (isChildStreamRemoved(streamId)) return;
-  syncStreamLog(streamId);
-  if (!options.finalize) return;
-  // Same promotion rule the live sync applies, run with `streamFinal` forced:
-  // the caller knows the turn ended even when the stream's status has not
-  // reached its settlement phase yet. A nonterminal workflow call or a running
-  // compaction still seals the prefix — bridge cleanup can replace their state
-  // after the turn boundary, and `<Static>` is append-only.
-  patchStream(streamId, (slice) => {
-    const entries = finalizeSettledPrefix(slice.entries, true);
-    return entries === slice.entries ? slice : { ...slice, entries };
-  });
+  syncStreamLog(streamId, options.finalize ? { forceFinal: true } : {});
 }

--- a/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
+++ b/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
@@ -339,7 +339,7 @@ class MirroredOps {
 function syncBothAndCompare(
   step: number,
   extra = '',
-  options: { readonly forceFull?: boolean } = {},
+  options: { readonly forceFull?: boolean; readonly forceFinal?: boolean } = {},
 ): void {
   syncStreamLog(FOLD_STREAM, options);
   invalidateTranscriptFoldForTest(ORACLE_STREAM);
@@ -443,6 +443,89 @@ describe('transcript fold vs from-scratch oracle', () => {
         ops.step();
         syncBothAndCompare(step, ' (compact)');
       }
+    } finally {
+      dispose();
+    }
+  });
+
+  it('does not settle a running compaction on a turn-boundary forceFinal', () => {
+    // Regression: `forceFinal` (projectStreamTranscript at turn boundaries)
+    // must only drive settled-prefix promotion. Compaction settlement derives
+    // from the real lifecycle phase — a forceFinal while a compaction is
+    // still running must not record it as interrupted, or the later
+    // completion event lands beyond the settlement boundary and is ignored.
+    const dispose = subscribeStreamLog();
+    try {
+      const store = defaultSession().transcripts;
+      configureStreams(CONFIGS[0]);
+      activeStreamId.set(undefined);
+      for (const streamId of MIRRORED) {
+        setStreamStatusInCliState({ streamId, status: STREAM_PHASE.RUNNING });
+        appendTranscriptEntry(store, streamId, {
+          id: 'u1',
+          type: STREAM_LOG_ENTRY_TYPES.LOG,
+          level: LOG_LEVELS.INFO,
+          timestamp: 1,
+          messageType: MESSAGE_TYPES.USER_MESSAGE,
+          text: 'please compact',
+        });
+        appendTranscriptEntry(store, streamId, {
+          id: 'c-start',
+          type: STREAM_LOG_ENTRY_TYPES.LOG,
+          level: LOG_LEVELS.INFO,
+          timestamp: 2,
+          messageType: MESSAGE_TYPES.CONTEXT_COMPACTION_ACTIVITY,
+          text: 'Compacting context…',
+          data: {
+            activity: 'context_compaction',
+            operationId: 'op-1',
+            state: 'started',
+          },
+        });
+      }
+      syncBothAndCompare(0, ' (running compaction)', { forceFull: true });
+
+      // Turn-boundary finalize while the compaction is still running.
+      const before = transcriptFoldCountersForTest();
+      syncBothAndCompare(1, ' (forceFinal)', {
+        forceFull: true,
+        forceFinal: true,
+      });
+      expect(transcriptFoldCountersForTest().folds).toBeGreaterThan(
+        before.folds,
+      );
+      const slice = streams.get().get(FOLD_STREAM);
+      const row = slice?.entries.find((e) => e.id === 'compaction:op-1');
+      expect(row?.text).toBe('Compacting context…');
+      expect(row?.finalized).toBe(false);
+      expect(slice?.compactingActive).toBe(true);
+      // The settled prefix ahead of the compaction is still promoted.
+      expect(slice?.entries.find((e) => e.id === 'u1')?.finalized).toBe(true);
+
+      // The later completion event must still complete the block.
+      for (const streamId of MIRRORED) {
+        appendTranscriptEntry(store, streamId, {
+          id: 'c-done',
+          type: STREAM_LOG_ENTRY_TYPES.LOG,
+          level: LOG_LEVELS.INFO,
+          timestamp: 3,
+          messageType: MESSAGE_TYPES.CONTEXT_COMPACTION_ACTIVITY,
+          text: 'Conversation context compacted',
+          data: {
+            activity: 'context_compaction',
+            operationId: 'op-1',
+            state: 'completed',
+          },
+        });
+      }
+      syncBothAndCompare(2, ' (completion)', { forceFull: true });
+      const done = streams
+        .get()
+        .get(FOLD_STREAM)
+        ?.entries.find((e) => e.id === 'compaction:op-1');
+      expect(done?.text).toBe('Context compacted');
+      expect(done?.finalized).toBe(true);
+      expect(streams.get().get(FOLD_STREAM)?.compactingActive).toBe(false);
     } finally {
       dispose();
     }

--- a/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
+++ b/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
@@ -1,0 +1,508 @@
+// Fold-vs-oracle equivalence for the CLI transcript projection (#9946).
+//
+// The projection over store-emitted StreamLogDeltas is a fold; the oracle is
+// the same application code run from scratch over getRange(0) — which is
+// also the production resync path. Two streams receive an identical
+// randomized op interleaving: stream A keeps its fold state across every
+// emission, stream B has its state invalidated before every sync so it
+// always rebuilds. After every op, both slices must project identically.
+// A divergence means an in-place mutation, ordering rule, or promotion was
+// folded incorrectly — the regression class this change makes possible.
+
+import '@test/support/defaultSessionTestSetup';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { defaultSession } from '@agent/runtime/SessionHandle';
+import {
+  activeStreamId,
+  patchStream,
+  resetCliState,
+  setStreamStatusInCliState,
+  streams,
+  type ConversationEntry,
+  type StreamSlice,
+} from '@cli/chat/tui/state/cliState';
+import {
+  invalidateTranscriptFoldForTest,
+  subscribeStreamLog,
+  syncStreamLog,
+  transcriptFoldCountersForTest,
+} from '@cli/chat/tui/state/subscribeStreamLog';
+import {
+  AgentCategory,
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  STREAM_PHASE,
+  type RunIdentity,
+  type StreamLogEntry,
+  type StreamTabId,
+} from '@shared/schemas';
+import {
+  appendTranscriptEntry,
+  appendTranscriptText,
+  updateTranscriptEntry,
+  withTranscriptWriter,
+} from '@test/support/storeTestDrivers';
+
+const FOLD_STREAM = 'fold-stream' as StreamTabId;
+const ORACLE_STREAM = 'oracle-stream' as StreamTabId;
+const OTHER_STREAM = 'other-stream' as StreamTabId;
+const MIRRORED = [FOLD_STREAM, ORACLE_STREAM] as const;
+
+/** Deterministic PRNG (mulberry32) so failures reproduce from the seed. */
+function createRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pick<T>(rng: () => number, values: readonly T[]): T {
+  return values[Math.floor(rng() * values.length)];
+}
+
+interface StreamConfig {
+  readonly name: string;
+  readonly category: AgentCategory;
+  readonly identity?: RunIdentity;
+}
+
+const CONFIGS: readonly StreamConfig[] = [
+  { name: 'tool-use transcript', category: AgentCategory.ToolUse },
+  { name: 'workflow operational feed', category: AgentCategory.Workflow },
+  {
+    name: 'workflow full-log child',
+    category: AgentCategory.Workflow,
+    identity: {
+      kind: 'multiAgentWorkflow',
+      workflowName: 'draft-sections',
+    } as RunIdentity,
+  },
+];
+
+/** The projected fields the fold and the oracle must agree on. */
+function projectedView(slice: StreamSlice | undefined): unknown {
+  return {
+    entries: slice?.entries ?? [],
+    latestLine: slice?.latestLine,
+    thinkingActive: slice?.thinkingActive ?? false,
+    compactingActive: slice?.compactingActive ?? false,
+    activeSkills: slice?.activeSkills ?? [],
+    taskGroups: slice?.taskGroups ?? [],
+  };
+}
+
+/** Mutation-op generator driving both mirrored streams identically. */
+class MirroredOps {
+  private readonly openText: string[] = [];
+  private readonly openThinking: string[] = [];
+  private readonly openTools: string[] = [];
+  private readonly openGroups: Array<{ id: string; kind?: string }> = [];
+  private readonly openCalls: Array<{ id: string; label: string }> = [];
+  private nextId = 0;
+  private syntheticSeq = 0;
+
+  constructor(private readonly rng: () => number) {}
+
+  private id(prefix: string): string {
+    return `${prefix}-${this.nextId++}`;
+  }
+
+  private append(
+    entry: Omit<StreamLogEntry, 'seqNo' | 'settlementSeqNo'>,
+  ): void {
+    const store = defaultSession().transcripts;
+    for (const streamId of MIRRORED) {
+      appendTranscriptEntry(store, streamId, entry);
+    }
+  }
+
+  private update(
+    id: string,
+    patch: Parameters<typeof updateTranscriptEntry>[3],
+    settle = false,
+  ): void {
+    const store = defaultSession().transcripts;
+    for (const streamId of MIRRORED) {
+      if (settle) {
+        withTranscriptWriter(store, streamId, (writer) =>
+          writer.settle(id, patch),
+        );
+      } else {
+        updateTranscriptEntry(store, streamId, id, patch);
+      }
+    }
+  }
+
+  /** Apply one random mutation to both streams. */
+  step(): void {
+    const roll = this.rng();
+    if (roll < 0.08) {
+      this.append({
+        id: this.id('u'),
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: this.nextId,
+        messageType: MESSAGE_TYPES.USER_MESSAGE,
+        text: `question ${this.nextId}`,
+      });
+    } else if (roll < 0.2) {
+      const id = this.id('m');
+      this.openText.push(id);
+      this.append({
+        id,
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: this.nextId,
+        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+        text: '',
+        data: { status: 'running' },
+      });
+    } else if (roll < 0.42 && this.openText.length > 0) {
+      const id = pick(this.rng, this.openText);
+      const store = defaultSession().transcripts;
+      for (const streamId of MIRRORED) {
+        appendTranscriptText(store, streamId, id, ` chunk${this.nextId}`);
+      }
+      this.nextId += 1;
+    } else if (roll < 0.5 && this.openText.length > 0) {
+      const id = this.openText.shift() as string;
+      this.update(id, { data: { status: 'completed' } }, true);
+    } else if (roll < 0.55) {
+      const id = this.id('th');
+      this.openThinking.push(id);
+      this.append({
+        id,
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: this.nextId,
+        messageType: MESSAGE_TYPES.THINKING,
+        text: 'thinking…',
+        data: { status: 'running' },
+      });
+    } else if (roll < 0.6 && this.openThinking.length > 0) {
+      const id = this.openThinking.shift() as string;
+      this.update(id, { data: { status: 'completed' } });
+    } else if (roll < 0.68) {
+      const id = this.id('t');
+      this.openTools.push(id);
+      this.append({
+        id,
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: this.nextId,
+        messageType: MESSAGE_TYPES.TOOL_USE,
+        text: 'Bash',
+        data: {
+          toolName: 'Bash',
+          input: { command: `echo ${this.nextId}` },
+          status: 'in_progress',
+        },
+      });
+    } else if (roll < 0.74 && this.openTools.length > 0) {
+      const id = this.openTools.shift() as string;
+      const failed = this.rng() < 0.25;
+      this.update(
+        id,
+        {
+          data: {
+            toolName: 'Bash',
+            input: { command: 'echo' },
+            status: failed ? 'failed' : 'completed',
+            output: failed ? undefined : `ok ${id}`,
+            error: failed ? `exit 1 from ${id}` : undefined,
+          },
+        },
+        true,
+      );
+    } else if (roll < 0.8) {
+      const kind = pick(this.rng, ['phase', 'round', undefined] as const);
+      const id = this.id('g');
+      this.openGroups.push({ id, kind });
+      this.append({
+        id,
+        type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
+        level: LOG_LEVELS.INFO,
+        timestamp: this.nextId,
+        messageType: MESSAGE_TYPES.DEFAULT,
+        text: `Stage ${this.nextId}`,
+        data: {
+          status: 'running',
+          ...(kind ? { kind } : {}),
+          ...(kind === 'phase' ? { index: this.nextId % 5, total: 5 } : {}),
+        },
+      });
+    } else if (roll < 0.84 && this.openGroups.length > 0) {
+      const group = this.openGroups.shift() as { id: string; kind?: string };
+      this.update(
+        group.id,
+        {
+          type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+          data: {
+            status: this.rng() < 0.2 ? 'failed' : 'completed',
+            ...(group.kind ? { kind: group.kind } : {}),
+            endTime: this.nextId,
+          },
+        },
+        true,
+      );
+    } else if (roll < 0.88) {
+      const id = this.id('w');
+      const call = { id, label: `call ${this.nextId}` };
+      this.openCalls.push(call);
+      this.append({
+        id,
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: this.nextId,
+        messageType: MESSAGE_TYPES.WORKFLOW_TASK,
+        text: call.label,
+        data: { id: call.id, label: call.label, status: 'planned' },
+      });
+    } else if (roll < 0.91 && this.openCalls.length > 0) {
+      const call = pick(this.rng, this.openCalls);
+      const terminal = this.rng() < 0.5;
+      if (terminal) {
+        this.openCalls.splice(this.openCalls.indexOf(call), 1);
+      }
+      this.update(
+        call.id,
+        {
+          data: {
+            id: call.id,
+            label: call.label,
+            status: terminal ? 'completed' : 'running',
+          },
+        },
+        terminal,
+      );
+    } else if (roll < 0.94) {
+      this.append({
+        id: this.id('e'),
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.ERROR,
+        timestamp: this.nextId,
+        messageType: MESSAGE_TYPES.ERROR,
+        text: `failure ${this.nextId}`,
+        data: { message: `detail ${this.nextId}` },
+      });
+    } else if (roll < 0.97) {
+      const malformed = this.rng() < 0.4;
+      this.append({
+        id: this.id('sk'),
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: this.nextId,
+        messageType: MESSAGE_TYPES.ACTIVE_SKILLS,
+        text: 'skills',
+        data: malformed
+          ? { skills: [{ path: '/secret' }] }
+          : {
+              skills: [
+                {
+                  name: `skill-${this.nextId}`,
+                  description: 'A skill.',
+                  source: 'project',
+                },
+              ],
+            },
+      });
+    } else {
+      const syntheticId = `local:${this.syntheticSeq++}`;
+      const store = defaultSession().transcripts;
+      for (const streamId of MIRRORED) {
+        const head = store.get(streamId)?.head ?? 0;
+        patchStream(streamId, (slice) => {
+          const entry: ConversationEntry = {
+            id: syntheticId,
+            role: 'assistant',
+            text: `local notice ${syntheticId}`,
+            finalized: true,
+            synthetic: true,
+            syntheticKind: 'local',
+            syntheticAfterSeq: head,
+            syntheticAfterSettlementSeqNo: 0,
+          };
+          return { ...slice, entries: [...slice.entries, entry] };
+        });
+      }
+    }
+  }
+}
+
+function syncBothAndCompare(
+  step: number,
+  extra = '',
+  options: { readonly forceFull?: boolean } = {},
+): void {
+  syncStreamLog(FOLD_STREAM, options);
+  invalidateTranscriptFoldForTest(ORACLE_STREAM);
+  syncStreamLog(ORACLE_STREAM, options);
+  const fold = projectedView(streams.get().get(FOLD_STREAM));
+  const oracle = projectedView(streams.get().get(ORACLE_STREAM));
+  expect(fold, `step ${step}${extra}`).toEqual(oracle);
+}
+
+function configureStreams(config: StreamConfig): void {
+  for (const streamId of MIRRORED) {
+    patchStream(streamId, (slice) => ({
+      ...slice,
+      category: config.category,
+      ...(config.identity ? { identity: config.identity } : {}),
+    }));
+  }
+}
+
+describe('transcript fold vs from-scratch oracle', () => {
+  beforeEach(async () => {
+    await defaultSession().transcripts.clear();
+    // Twice: the first reset retires the ids this suite reuses across tests,
+    // the second starts the lifetime with no retired identity.
+    resetCliState();
+    resetCliState();
+  });
+
+  it.each(
+    CONFIGS.flatMap((config) =>
+      [1337, 20260811].map((seed) => ({ config, seed })),
+    ),
+  )(
+    'folds identically to the oracle: $config.name (seed $seed)',
+    ({ config, seed }) => {
+      const dispose = subscribeStreamLog();
+      try {
+        const rng = createRng(seed);
+        const ops = new MirroredOps(rng);
+        configureStreams(config);
+        activeStreamId.set(undefined);
+        for (const streamId of MIRRORED) {
+          setStreamStatusInCliState({
+            streamId,
+            status: STREAM_PHASE.RUNNING,
+          });
+        }
+        const before = transcriptFoldCountersForTest();
+
+        const STEPS = 160;
+        for (let step = 0; step < STEPS; step += 1) {
+          ops.step();
+          // Occasionally settle the whole stream, then resume: exercises the
+          // streamFinal promotion flip in both directions.
+          const statusRoll = rng();
+          if (statusRoll < 0.05) {
+            for (const streamId of MIRRORED) {
+              setStreamStatusInCliState({
+                streamId,
+                status: STREAM_PHASE.WAITING,
+              });
+            }
+          } else if (statusRoll < 0.1) {
+            for (const streamId of MIRRORED) {
+              setStreamStatusInCliState({
+                streamId,
+                status: STREAM_PHASE.RUNNING,
+              });
+            }
+          }
+          // forceFull keeps both streams on the full-transcript projection:
+          // the trailing focusStream(onlyIfUnset) inside sync would otherwise
+          // focus whichever mirrored stream synced first.
+          syncBothAndCompare(step, ` (seed ${seed})`, { forceFull: true });
+        }
+
+        // The property is only meaningful if the fold path actually ran:
+        // stream A folds every step after its first sync's rebuild.
+        const after = transcriptFoldCountersForTest();
+        expect(after.folds - before.folds).toBeGreaterThanOrEqual(STEPS - 1);
+      } finally {
+        dispose();
+      }
+    },
+  );
+
+  it('projects the compact unfocused-workflow selection identically', () => {
+    const dispose = subscribeStreamLog();
+    try {
+      const rng = createRng(4242);
+      const ops = new MirroredOps(rng);
+      configureStreams(CONFIGS[1]);
+      // Focus a third stream: both mirrored streams project the compact
+      // dashboard selection. Status stays RUNNING so no release path fires.
+      activeStreamId.set(OTHER_STREAM);
+      for (const streamId of MIRRORED) {
+        setStreamStatusInCliState({ streamId, status: STREAM_PHASE.RUNNING });
+      }
+
+      for (let step = 0; step < 120; step += 1) {
+        ops.step();
+        syncBothAndCompare(step, ' (compact)');
+      }
+    } finally {
+      dispose();
+    }
+  });
+
+  it('recovers from a delta gap by rebuilding through the oracle path', () => {
+    const store = defaultSession().transcripts;
+    const first = subscribeStreamLog();
+    appendTranscriptEntry(store, FOLD_STREAM, {
+      id: 'u1',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      messageType: MESSAGE_TYPES.USER_MESSAGE,
+      text: 'first',
+    });
+    syncStreamLog(FOLD_STREAM);
+    expect(
+      streams
+        .get()
+        .get(FOLD_STREAM)
+        ?.entries.map((entry) => entry.text),
+    ).toEqual(['first']);
+
+    // Deltas emitted while unsubscribed are lost: a real gap.
+    first();
+    for (const text of ['second', 'third']) {
+      appendTranscriptEntry(store, FOLD_STREAM, {
+        id: `u-${text}`,
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: 2,
+        messageType: MESSAGE_TYPES.USER_MESSAGE,
+        text,
+      });
+    }
+
+    const second = subscribeStreamLog();
+    appendTranscriptEntry(store, FOLD_STREAM, {
+      id: 'u4',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 3,
+      messageType: MESSAGE_TYPES.USER_MESSAGE,
+      text: 'fourth',
+    });
+    const before = transcriptFoldCountersForTest();
+    syncStreamLog(FOLD_STREAM);
+    const after = transcriptFoldCountersForTest();
+
+    // The buffered delta's base does not match the fold state: the sync must
+    // rebuild (not fold) and converge on the full transcript.
+    expect(after.rebuilds - before.rebuilds).toBe(1);
+    expect(
+      streams
+        .get()
+        .get(FOLD_STREAM)
+        ?.entries.map((entry) => entry.text),
+    ).toEqual(['first', 'second', 'third', 'fourth']);
+
+    second();
+  });
+});

--- a/src/test-kernel/transcript/StreamLogDelta.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogDelta.vitest.ts
@@ -1,0 +1,196 @@
+// The store-emitted entry-level change feed (#9946): every onChange
+// notification carries an immutable StreamLogDelta, drained once and
+// multicast — nothing is acked and nothing is destroyed, unlike the webview
+// dirty-update machinery. Consumers coalesce bursts with
+// StreamLogDeltaBuffer and rebuild from getRange(0) on any discontinuity.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  type StreamLogEntry,
+  type StreamTabId,
+} from '@shared/schemas';
+import { StreamLogDeltaBuffer, type StreamLogDelta } from '@transcript';
+import { StreamLogStore } from '@transcript/StreamLogStore';
+
+import {
+  appendTranscriptEntry,
+  appendTranscriptText,
+  updateTranscriptEntry,
+  withTranscriptWriter,
+} from '../support/storeTestDrivers';
+
+const STREAM = 'delta-stream' as StreamTabId;
+
+function logRow(
+  id: string,
+  text: string,
+): Parameters<typeof appendTranscriptEntry>[2] {
+  return {
+    id,
+    type: STREAM_LOG_ENTRY_TYPES.LOG,
+    level: LOG_LEVELS.INFO,
+    timestamp: 1,
+    messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    text,
+  };
+}
+
+function captureDeltas(store: StreamLogStore): StreamLogDelta[] {
+  const deltas: StreamLogDelta[] = [];
+  store.onChange((streamId, delta) => {
+    if (streamId === STREAM) deltas.push(delta);
+  });
+  return deltas;
+}
+
+describe('StreamLogStore delta emission', () => {
+  it('emits appended entries, then dirtied entries by value, with a monotonic seq', () => {
+    const store = StreamLogStore.ephemeral('delta test');
+    const deltas = captureDeltas(store);
+
+    appendTranscriptEntry(store, STREAM, logRow('m1', 'hel'));
+    appendTranscriptText(store, STREAM, 'm1', 'lo');
+    updateTranscriptEntry(store, STREAM, 'm1', { text: 'hello!' });
+
+    expect(deltas.map((delta) => delta.emissionSeq)).toEqual([1, 2, 3]);
+    expect(deltas.map((delta) => delta.reset)).toEqual([false, false, false]);
+
+    expect(deltas[0].appended.map((entry) => entry.text)).toEqual(['hel']);
+    expect(deltas[0].dirtied).toEqual([]);
+
+    expect(deltas[1].appended).toEqual([]);
+    expect(deltas[1].dirtied.map((entry) => entry.text)).toEqual(['hello']);
+
+    expect(deltas[2].dirtied.map((entry) => entry.text)).toEqual(['hello!']);
+
+    // By value: the captured payloads are the immutable post-mutation entry
+    // objects, so later mutations must not rewrite an already-emitted delta.
+    expect(deltas[0].appended[0].text).toBe('hel');
+    expect(deltas[1].dirtied[0].text).toBe('hello');
+  });
+
+  it('coalesces one commit covering several mutations into one delta', () => {
+    const store = StreamLogStore.ephemeral('delta test');
+    appendTranscriptEntry(store, STREAM, {
+      id: 'g1',
+      type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      text: 'r0',
+      data: { status: 'running' },
+    });
+    appendTranscriptEntry(store, STREAM, {
+      id: 't1',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 2,
+      messageType: MESSAGE_TYPES.THINKING,
+      text: 'thinking',
+      data: { status: 'running' },
+    });
+    const deltas = captureDeltas(store);
+
+    // endRunningGroupsForStreams settles both running rows under a single
+    // commit, so one delta carries both dirtied entries in seqNo order.
+    void store.endRunningGroupsForStreams([STREAM], 99);
+
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0].appended).toEqual([]);
+    expect(deltas[0].dirtied.map((entry) => entry.id)).toEqual(['g1', 't1']);
+  });
+
+  it('does not emit for a no-op update', () => {
+    const store = StreamLogStore.ephemeral('delta test');
+    appendTranscriptEntry(store, STREAM, logRow('m1', 'hello'));
+    const deltas = captureDeltas(store);
+
+    updateTranscriptEntry(store, STREAM, 'm1', { text: 'hello' });
+
+    expect(deltas).toEqual([]);
+  });
+
+  it('reports undrained changes only for mutations that bypassed the store', () => {
+    const store = StreamLogStore.ephemeral('delta test');
+    appendTranscriptEntry(store, STREAM, logRow('m1', 'hello'));
+    const log = store.get(STREAM);
+    expect(log?.hasUndrainedChanges).toBe(false);
+
+    log?.append(logRow('direct', 'not via writer'));
+    expect(log?.hasUndrainedChanges).toBe(true);
+
+    // The next store-mediated commit drains the direct mutation too.
+    withTranscriptWriter(store, STREAM, (writer) =>
+      writer.appendText('m1', '!'),
+    );
+    expect(log?.hasUndrainedChanges).toBe(false);
+  });
+});
+
+describe('StreamLogDeltaBuffer', () => {
+  function entryAt(seqNo: number, id: string, text: string): StreamLogEntry {
+    return {
+      id,
+      seqNo,
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+      text,
+    } as StreamLogEntry;
+  }
+
+  function delta(
+    emissionSeq: number,
+    appended: StreamLogEntry[],
+    dirtied: StreamLogEntry[] = [],
+    reset = false,
+  ): StreamLogDelta {
+    return { emissionSeq, appended, dirtied, reset };
+  }
+
+  it('coalesces a contiguous burst, letting a dirtied value supersede its appended one', () => {
+    const buffer = new StreamLogDeltaBuffer(4);
+    const first = entryAt(10, 'a', 'v1');
+    const superseded = entryAt(10, 'a', 'v2');
+    const other = entryAt(3, 'b', 'w2');
+    buffer.push(delta(5, [first]));
+    buffer.push(delta(6, [], [superseded, other]));
+
+    expect(buffer.baseEmissionSeq).toBe(4);
+    expect(buffer.emissionSeq).toBe(6);
+    expect(buffer.resyncRequired).toBe(false);
+    const drained = buffer.drain();
+    expect(drained.appended).toEqual([superseded]);
+    expect(drained.dirtied).toEqual([other]);
+  });
+
+  it('marks a gap as requiring resync while still tracking the newest seq', () => {
+    const buffer = new StreamLogDeltaBuffer(4);
+    buffer.push(delta(5, [entryAt(1, 'a', 'x')]));
+    buffer.push(delta(7, [entryAt(2, 'b', 'y')]));
+
+    expect(buffer.resyncRequired).toBe(true);
+    expect(buffer.emissionSeq).toBe(7);
+  });
+
+  it('skips stale emissions at or below the base', () => {
+    const buffer = new StreamLogDeltaBuffer(4);
+    buffer.push(delta(3, [entryAt(1, 'a', 'x')]));
+    buffer.push(delta(4, [entryAt(2, 'b', 'y')]));
+
+    expect(buffer.resyncRequired).toBe(false);
+    expect(buffer.drain()).toEqual({ appended: [], dirtied: [] });
+  });
+
+  it('treats a reset emission as requiring resync', () => {
+    const buffer = new StreamLogDeltaBuffer(4);
+    buffer.push(delta(5, [entryAt(1, 'a', 'x')]));
+    buffer.push(delta(1, [], [], true));
+
+    expect(buffer.resyncRequired).toBe(true);
+  });
+});

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -18,6 +18,111 @@ export type StreamLogUpdatePatch = Partial<
   Omit<StreamLogEntry, 'id' | 'seqNo' | 'settlementSeqNo'>
 >;
 
+/**
+ * One store notification's worth of entry-level change, multicast to every
+ * `StreamLogStore.onChange` listener. Entry values are the immutable
+ * post-mutation objects (`StreamLog` replaces the entry object on every
+ * mutation), so a delta stays valid after later mutations. A dirtied entry
+ * supersedes any earlier buffered value for its id.
+ */
+export interface StreamLogDelta {
+  /**
+   * Monotonic per-log-instance emission counter. A consumer that detects a
+   * gap (`emissionSeq !== lastSeen + 1`) must resync from `getRange(0)`
+   * through the same code path as its from-scratch projection.
+   */
+  readonly emissionSeq: number;
+  /** Entries appended since the previous emission, in seqNo order. */
+  readonly appended: readonly StreamLogEntry[];
+  /**
+   * Current values of entries mutated in place since the previous emission
+   * (excluding ones also in `appended`, which already carry the latest
+   * value), in seqNo order.
+   */
+  readonly dirtied: readonly StreamLogEntry[];
+  /**
+   * The stream's log instance was replaced (disk history merged under live
+   * appends), renumbering seqNos. Consumers must resync, not fold.
+   */
+  readonly reset: boolean;
+}
+
+/**
+ * Consumer-side accumulator that coalesces a burst of {@link StreamLogDelta}
+ * emissions into one fold application. Tracks emission continuity: a gap, an
+ * explicit reset emission, or a stale-looking sequence marks the buffer as
+ * requiring a resync instead of a fold.
+ */
+export class StreamLogDeltaBuffer {
+  /** Emission seq the fold state must be at for `drain()` to be foldable. */
+  readonly baseEmissionSeq: number;
+  private appended: StreamLogEntry[] = [];
+  private readonly appendedIndexById = new Map<string, number>();
+  private readonly dirtiedById = new Map<string, StreamLogEntry>();
+  private lastSeq: number;
+  private needsResync = false;
+
+  constructor(baseEmissionSeq: number) {
+    this.baseEmissionSeq = baseEmissionSeq;
+    this.lastSeq = baseEmissionSeq;
+  }
+
+  /** Latest emission folded into (or invalidating) this buffer. */
+  get emissionSeq(): number {
+    return this.lastSeq;
+  }
+
+  get resyncRequired(): boolean {
+    return this.needsResync;
+  }
+
+  push(delta: StreamLogDelta): void {
+    if (delta.reset) {
+      this.needsResync = true;
+      return;
+    }
+    // A stale emission (at or below the base) is already covered by the
+    // resync that established the base; drop it. Skipping while a resync is
+    // pending is equally safe: the resync rereads the whole log.
+    if (delta.emissionSeq <= this.lastSeq || this.needsResync) {
+      this.lastSeq = Math.max(this.lastSeq, delta.emissionSeq);
+      return;
+    }
+    if (delta.emissionSeq !== this.lastSeq + 1) {
+      this.needsResync = true;
+      this.lastSeq = delta.emissionSeq;
+      return;
+    }
+    this.lastSeq = delta.emissionSeq;
+    for (const entry of delta.appended) {
+      this.appendedIndexById.set(entry.id, this.appended.length);
+      this.appended.push(entry);
+    }
+    for (const entry of delta.dirtied) {
+      const appendedIndex = this.appendedIndexById.get(entry.id);
+      if (appendedIndex !== undefined) {
+        this.appended[appendedIndex] = entry;
+      } else {
+        this.dirtiedById.set(entry.id, entry);
+      }
+    }
+  }
+
+  /** The coalesced changes, dirtied in seqNo order. Call once, then discard. */
+  drain(): { appended: StreamLogEntry[]; dirtied: StreamLogEntry[] } {
+    const dirtied = [...this.dirtiedById.values()].sort(
+      (a, b) => a.seqNo - b.seqNo,
+    );
+    const appended = this.appended;
+    this.appended = [];
+    this.appendedIndexById.clear();
+    this.dirtiedById.clear();
+    return { appended, dirtied };
+  }
+}
+
+let nextStreamLogInstanceId = 1;
+
 export interface StreamLogPreservedRawEntry {
   readonly beforeTypedIndex: number;
   readonly raw: unknown;
@@ -68,12 +173,21 @@ export function nonterminalWorkflowCall(
 }
 
 export class StreamLog {
+  /**
+   * Distinguishes log instances for the same stream id, so a delta consumer
+   * can detect that its fold state was built from an evicted-and-rehydrated
+   * (or disk-merged) instance whose seqNos and emission counter restarted.
+   */
+  readonly instanceId = nextStreamLogInstanceId++;
   private entries: StreamLogEntry[] = [];
   private readonly preservedRawEntries: StreamLogPreservedRawEntry[] = [];
   private seqCounter = 0;
   private readonly indexById = new Map<string, number>();
   private readonly dirtyUpdates = new Set<string>();
   private readonly dirtyTextDeltas = new Map<string, StreamLogTextDelta>();
+  private emissionSeqCounter = 0;
+  private pendingAppendedIds: string[] = [];
+  private readonly pendingDirtiedIds = new Set<string>();
   private settlementSeqCounter = 0;
   private runningGroupCount = 0;
   private runningStreamingTextCount = 0;
@@ -139,6 +253,61 @@ export class StreamLog {
     return this.settlementSeqCounter;
   }
 
+  /**
+   * Latest {@link StreamLogDelta.emissionSeq} drained from this instance. A
+   * consumer whose fold state matches `(instanceId, emissionHead)` is current
+   * and can fold subsequent deltas instead of rereading the log.
+   */
+  get emissionHead(): number {
+    return this.emissionSeqCounter;
+  }
+
+  /**
+   * True while mutations since the last drain have not been emitted. In the
+   * store-mediated flow every mutation is drained synchronously by the
+   * notification it triggers, so pending changes at read time mean the log
+   * was mutated directly — a fold consumer must rebuild, not fold.
+   */
+  get hasUndrainedChanges(): boolean {
+    return (
+      this.pendingAppendedIds.length > 0 || this.pendingDirtiedIds.size > 0
+    );
+  }
+
+  /**
+   * Drain the entries changed since the previous drain into an emission
+   * payload, allocating its emission seq. Called by `StreamLogStore` exactly
+   * once per notification; the payload is multicast unchanged to every
+   * listener, so nothing here is consumer-specific and nothing is acked.
+   */
+  drainEmission(): Omit<StreamLogDelta, 'reset'> {
+    const emissionSeq = ++this.emissionSeqCounter;
+    if (
+      this.pendingAppendedIds.length === 0 &&
+      this.pendingDirtiedIds.size === 0
+    ) {
+      return { emissionSeq, appended: [], dirtied: [] };
+    }
+    const appendedIds = new Set(this.pendingAppendedIds);
+    const appended = this.resolveEntries(this.pendingAppendedIds);
+    const dirtied = this.resolveEntries(
+      [...this.pendingDirtiedIds].filter((id) => !appendedIds.has(id)),
+    ).sort((a, b) => a.seqNo - b.seqNo);
+    this.pendingAppendedIds = [];
+    this.pendingDirtiedIds.clear();
+    return { emissionSeq, appended, dirtied };
+  }
+
+  /** Current entry objects for `ids`; entries are never removed, so every id resolves. */
+  private resolveEntries(ids: readonly string[]): StreamLogEntry[] {
+    const resolved: StreamLogEntry[] = [];
+    for (const id of ids) {
+      const index = this.indexById.get(id);
+      if (index !== undefined) resolved.push(this.entries[index]);
+    }
+    return resolved;
+  }
+
   get firstTimestamp(): number | undefined {
     return this.entries[0]?.timestamp;
   }
@@ -182,6 +351,7 @@ export class StreamLog {
     this.indexById.set(fullEntry.id, this.entries.length);
     this.entries.push(fullEntry);
     this.countEntry(fullEntry, 1);
+    this.pendingAppendedIds.push(fullEntry.id);
     return fullEntry;
   }
 
@@ -235,6 +405,7 @@ export class StreamLog {
     this.entries[index] = updated;
     this.dirtyUpdates.add(id);
     this.dirtyTextDeltas.delete(id);
+    this.pendingDirtiedIds.add(id);
     return updated;
   }
 
@@ -260,6 +431,7 @@ export class StreamLog {
         appendText: `${currentDelta?.appendText ?? ''}${appendText}`,
       });
     }
+    this.pendingDirtiedIds.add(id);
     return updated;
   }
 

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -25,6 +25,7 @@ import {
   nonterminalWorkflowCall,
   StreamLog,
   type StreamLogAppendInput,
+  type StreamLogDelta,
   type StreamLogPreservedRawEntry,
   type StreamLogUpdatePatch,
 } from './StreamLog';
@@ -49,7 +50,7 @@ function createSummaryKv(): KVStore {
   });
 }
 
-type StreamLogListener = (streamId: StreamTabId) => void;
+type StreamLogListener = (streamId: StreamTabId, delta: StreamLogDelta) => void;
 
 // No per-field `.catch()`: this schema covers the crash-recovery flags
 // (`hasRunningGroup`, `hasRunningStreamingText`, `hasNonterminalWorkflowCall`)
@@ -681,7 +682,9 @@ export class StreamLogStore {
           this.refreshSummary(streamId, merged);
           this.markDirty(streamId);
           void this.save();
-          this.notify(streamId);
+          // The merge renumbered seqNos under a fresh log instance, so
+          // fold-state consumers must rebuild rather than apply a delta.
+          this.notify(streamId, { reset: true });
         } else {
           const logInstance = new StreamLog(
             diskEntries.entries,
@@ -1378,9 +1381,25 @@ export class StreamLogStore {
     this.dirtyIds.add(streamId);
   }
 
-  private notify(streamId: StreamTabId): void {
+  /**
+   * Drain the log's pending entry-level changes into one immutable delta and
+   * multicast it. The delta is drained exactly once per notification and
+   * shared by every listener; no listener acks anything and nothing here is
+   * destructive, unlike the webview ack machinery (`getDirtyUpdates` et al.),
+   * which stays a separate per-consumer channel.
+   */
+  private notify(
+    streamId: StreamTabId,
+    options: { readonly reset?: boolean } = {},
+  ): void {
+    const logInstance = this.streams.get(streamId)?.log;
+    if (!logInstance) return;
+    const delta: StreamLogDelta = Object.freeze({
+      ...logInstance.drainEmission(),
+      reset: options.reset === true,
+    });
     for (const listener of this.listeners) {
-      listener(streamId);
+      listener(streamId, delta);
     }
   }
 

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -15,7 +15,12 @@ export {
   STREAM_LOGS_DIR,
   STREAM_LOG_SUMMARIES_DIR,
 } from './StreamLogStore';
-export { StreamLog, type StreamLogAppendInput } from './StreamLog';
+export {
+  StreamLog,
+  StreamLogDeltaBuffer,
+  type StreamLogAppendInput,
+  type StreamLogDelta,
+} from './StreamLog';
 export { createRunTrace, type RunTrace } from './runTrace';
 export { streamDataDir } from './streamDataPaths';
 export { StreamSnapshotStore } from './StreamSnapshotStore';


### PR DESCRIPTION
Fixes #9946 (rescoped per the issue comments and the PRD in `docs/prds/2026-08-11-transcript-memory-architecture.md`, top-5 item 1). This PR lands the store-emitted delta feed and the O(delta) CLI fold. Per the sequencing decision, the extension `WebviewBridge` port (which deletes its private cursor and the destructive ack protocol) is the follow-up PR; the ack machinery is untouched here.

## Store side: one authoritative change channel

- `StreamLog` now tracks, per notification, the entries appended and dirtied since the previous emission. `StreamLogStore.notify` drains that exactly once into an immutable `StreamLogDelta { emissionSeq, appended, dirtied, reset }` and multicasts it to every `onChange` listener. Dirtied entries are carried by value: `StreamLog` replaces the entry object on every mutation, so the payload can never be rewritten after emission (covered by a test).
- `emissionSeq` is monotonic per log instance; `StreamLog.instanceId` distinguishes evicted-and-rehydrated instances. The disk-merge path in `ensureLoaded` (the one place seqNos get renumbered under a live consumer) emits `reset: true`.
- `StreamLogDeltaBuffer` is the consumer-side coalescer: contiguous bursts merge (a dirtied value supersedes its buffered appended value), and a gap, a reset, or a stale sequence marks the buffer as requiring resync.
- No consumer acks anything and nothing is destroyed. The existing `dirtyUpdates`/`dirtyTextDeltas` ack machinery stays as-is for the bridge until the follow-up. The `StreamLogStore` public surface is unchanged (the emission counter lives on `StreamLog`, keeping the store-surface ratchet at its baseline).

## CLI side: the projection is a fold

`syncStreamLog`'s per-tick full pipeline (`getRange(0)` rescan, per-entry render walk with a reference cache, sort, settled-prefix recompute, the `:1021` filter/slice/map/`Set` chain that was `error8`'s fatal allocation, and the O(total) deep-equal) is replaced by a fold over buffered deltas:

- Per-stream `TranscriptFoldState` lives on the stream slice, so its lifetime is exactly the stream's: it dies with removal and CLI reset, and is cleared on the existing release path. It maintains the merged final transcript order (log rows, compaction rows, synthetic rows under one ordering key with a source-rank tiebreak), the contiguous settled-prefix promotion frontier, and the latest-line cursors incrementally.
- Change detection now comes from the producer: the deep-equal is gone, and the compact workflow dashboard selection is rebuilt only when a delta actually touches a dashboard/synthetic row, not per tick per stream. Streaming text chunks on unfocused streams typically produce no signal write at all.
- Order-dependent semantics are preserved exactly: settled-prefix finalization is defined on the final sorted order, synthetic rows merge by `syntheticAfterSeq`, workflow-operational filtering is unchanged, and `releaseAfterSync` keeps working (its relocation is #9945).
- The consumer contract from the PRD: a fresh consumer, an emission gap, a reset emission, a projection-mode flip, or a mutation that bypassed the store rebuilds from `getRange(0)` through the same application code as the fold. The from-scratch build IS the production resync path.
- `projectStreamTranscript`'s finalize step now runs through the same pipeline (`forceFinal`), so promotion can no longer diverge from the fold state; the no-resident-log case keeps the previous direct `finalizeSettledPrefix` behavior.

`TASK_GROUP_PROJECTIONS` and `COMPACTION_PROJECTIONS` keep their current shape (their relocation is #9945's scope); they are now fed the delta / the log tail instead of a full `getRange(0)` array.

## Tests (the gate)

- **Fold-vs-oracle equivalence property test** (`src/test-kernel/cli/StreamLogDeltaFold.vitest.ts`): mirrored streams receive an identical seeded randomized interleaving of user/model/thinking/tool appends, in-place updates and settles, GROUP_START to GROUP_END upserts (phase, round, untyped), workflow-call transitions, malformed and valid skills snapshots, error rows, synthetic inserts, and stream-final status flips in both directions. One stream folds every emission; the other has its state invalidated before every sync so it always rebuilds from scratch. After every emission both must project identically (entries, latestLine, thinkingActive, compactingActive, activeSkills, taskGroups), across three projection modes (tool-use transcript, workflow operational feed, workflow full-log child) and the compact unfocused-workflow selection, with a counter assertion proving the fold path actually ran.
- **Gap recovery**: deltas dropped while unsubscribed produce a real gap on resubscribe; the sync must rebuild (asserted via counters) and converge on the full transcript.
- **Store emission tests** (`src/test-kernel/transcript/StreamLogDelta.vitest.ts`): appended/dirtied-by-value payloads, multi-mutation commit coalescing, no-op update silence, direct-mutation detection, and the buffer's merge/gap/stale/reset rules.

## Element accounting

Deleted: the per-tick `getRange(0)` rescan, `dedupeEntry`/`entriesEqual`/`toolUseEqual`/`inputEqual`, the `CachedLogRender`/`StreamRenderState`/`STREAM_RENDER_STATES` render cache and its `renderLogEntry` wrapper, `TranscriptCandidate`/`compareTranscriptCandidates`/`sortTranscriptCandidatesIfNeeded`, `latestLogActivityIsThinking`, the `workflowLatestLineCandidates` second pipeline with its `toReversed()` copy, the per-tick dashboard-id `Set` build, and the O(total) deep-equal block. Added: the delta type + buffer, and the fold engine (items maintenance, frontier, cursors). Net production LoC is positive in this PR (about +660 before tests): the PRD's net-negative accounting includes the WebviewBridge cursor + ack deletion (about 270 LoC) that the task explicitly deferred to the follow-up, and the ack machinery retained here is on that same follow-up's deletion list.

## Known behavior deltas (deliberate, noted for review)

- A content-equal re-render of a dirtied row produces a new row object instead of being deduped to the previous reference (one extra row-level React render on producer-reported changes; `update()` already suppresses true no-ops at the store).
- Fold state retains full rows for unfocused streams, so `finalized` stickiness survives focus flips that previously lost promotion inheritance for rows dropped from the compact selection (monotone promotion, strictly less rollback than before).
- `forceFinal` promotion now updates the latest-line cursors in the same application instead of one sync later.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run check:dead-code-ratchet` all clean.
- `npx vitest run src/test-kernel/cli/ src/test-kernel/transcript/ src/test-kernel/architecture/` (174 files, 2671 tests) and `src/test-kernel/controllers/` (37 files) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gtc6wQMD1hedgabjQMfAun

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core transcript notification and CLI projection semantics (ordering, finalization, compact selection); regressions would show wrong or stale TUI transcripts, but the fold is guarded by property tests and explicit gap/forceFinal cases.
> 
> **Overview**
> Adds an **entry-level change feed** on `StreamLog` / `StreamLogStore`: each `onChange` now multicasts an immutable `StreamLogDelta` (`emissionSeq`, appended rows, dirtied rows by value, optional `reset` after disk merge / instance replacement). `StreamLogDeltaBuffer` coalesces bursts and flags gaps that require a full resync.
> 
> The CLI transcript projection in `subscribeStreamLog` **folds** those deltas into per-stream `TranscriptFoldState` (merged log, compaction, and synthetic order; settled-prefix promotion; latest-line cursors) instead of rescanning `getRange(0)` every tick. Rebuild from `getRange(0)` is the same code path when continuity breaks (fresh consumer, gap, reset, mode flip, direct log mutation). Compact workflow / synthetic `entries` are rebuilt only when deltas touch relevant rows, not via per-tick deep equality.
> 
> `projectStreamTranscript` turn-boundary finalize goes through `syncStreamLog` with `forceFinal`; compaction settlement still follows real lifecycle settlement, not `forceFinal` alone.
> 
> New tests: store delta emission, buffer rules, fold-vs-oracle property equivalence, gap recovery, and compaction + `forceFinal` regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f0b4d3a8e9256dbe713152ebb9db67a5fce8b76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->