### PR TITLE
feat(transcript): chunked streaming text + max-wait save throttle

### DIFF
--- a/src/test-kernel/transcript/StreamLog.vitest.ts
+++ b/src/test-kernel/transcript/StreamLog.vitest.ts
@@ -4,6 +4,7 @@ import {
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
+  type StreamLogEntry,
 } from '@shared/schemas';
 import { StreamLog } from '@transcript';
 
@@ -179,5 +180,82 @@ describe('StreamLog', () => {
     expect(log.getDirtyTextDeltas()).toEqual([
       { id: 'message', appendText: ' world' },
     ]);
+  });
+
+  it('returns point-in-time text on emitted entries across later appends', () => {
+    const log = logWithMessage();
+
+    const first = log.appendText('message', 'hel');
+    const second = log.appendText('message', 'lo');
+    log.appendText('message', '!');
+
+    // Each emitted entry object keeps the text as of its own mutation, even
+    // though the chunks live in one shared accumulator that keeps growing.
+    expect(second?.text).toBe('hello');
+    expect(first?.text).toBe('hel');
+    expect(log.getRange(0, log.head)[0]?.text).toBe('hello!');
+  });
+
+  it('keeps materialized text equal to the chunk-join oracle across interleavings', () => {
+    // Deterministic LCG so the append/update/settle interleaving corpus is
+    // reproducible without a fixture file.
+    let seed = 42;
+    const rand = (bound: number): number => {
+      seed = (seed * 1_103_515_245 + 12_345) % 2_147_483_648;
+      return seed % bound;
+    };
+
+    const log = new StreamLog();
+    const oracle = new Map<string, string>();
+    const ids: string[] = [];
+    const snapshots: Array<{ entry: StreamLogEntry; text: string }> = [];
+
+    for (let step = 0; step < 400; step += 1) {
+      const op = rand(10);
+      if (op < 2 || ids.length === 0) {
+        const id = `row-${ids.length}`;
+        ids.push(id);
+        log.append({
+          id,
+          type: STREAM_LOG_ENTRY_TYPES.LOG,
+          level: LOG_LEVELS.INFO,
+          timestamp: step,
+          text: 'seed',
+          messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+        });
+        oracle.set(id, 'seed');
+        continue;
+      }
+      const id = ids[rand(ids.length)];
+      if (op < 8) {
+        const chunk = `c${step}|`;
+        const updated = log.appendText(id, chunk);
+        oracle.set(id, `${oracle.get(id) ?? ''}${chunk}`);
+        const expected = oracle.get(id);
+        if (updated && expected !== undefined) {
+          snapshots.push({ entry: updated, text: expected });
+        }
+      } else if (op === 8) {
+        const text = `rewritten-${step}`;
+        if (log.update(id, { text })) oracle.set(id, text);
+      } else {
+        log.settle(id, { data: { status: 'completed', step } });
+      }
+    }
+
+    for (const entry of log.getRange(0)) {
+      expect(entry.text).toBe(oracle.get(entry.id));
+    }
+    // Emitted entries stay point-in-time even after later chunks landed.
+    for (const { entry, text } of snapshots) {
+      expect(entry.text).toBe(text);
+    }
+    // The save path (JSON serialization) sees the same materialized text.
+    const persisted = JSON.parse(
+      JSON.stringify(log.toPersistedEntries()),
+    ) as StreamLogEntry[];
+    for (const entry of persisted) {
+      expect(entry.text).toBe(oracle.get(entry.id));
+    }
   });
 });

--- a/src/test-kernel/transcript/StreamLog.vitest.ts
+++ b/src/test-kernel/transcript/StreamLog.vitest.ts
@@ -144,6 +144,27 @@ describe('StreamLog', () => {
     ]);
   });
 
+  it('builds text deltas across the joined prefix and chunk tail', () => {
+    const log = logWithMessage();
+
+    log.appendText('message', 'hello');
+    // Materialize the joined prefix, then keep streaming unjoined chunks:
+    // the delta must be assembled piecewise, not by re-joining the text.
+    expect(log.getRange(0, log.head)[0]?.text).toBe('hello');
+    log.appendText('message', ' wor');
+    log.appendText('message', 'ld');
+
+    expect(log.getDirtyTextDeltas()).toEqual([
+      { id: 'message', appendText: 'hello world' },
+    ]);
+
+    log.ackDirtyTextDeltas(log.getDirtyTextDeltas());
+    log.appendText('message', '!');
+    expect(log.getDirtyTextDeltas()).toEqual([
+      { id: 'message', appendText: '!' },
+    ]);
+  });
+
   it('keeps text appended while a delta frame is in flight', () => {
     const log = logWithMessage();
 

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -1639,4 +1639,39 @@ describe('StreamLogStore save throttle', () => {
     expect(writtenLog(storage.writes, 'alpha')).toHaveLength(1);
     writer.close();
   });
+
+  it('queues a save window that fires while a write batch is in flight', async () => {
+    const bothWritesLanded = createDeferred();
+    let logWrites = 0;
+    const storage = mockStorage({
+      logs: {},
+      summaries: {},
+      pauseLogWriteKey: 'alpha',
+      onLogWrite: () => {
+        logWrites += 1;
+        if (logWrites === 2) bothWritesLanded.resolve();
+      },
+    });
+    const store = await StreamLogStore.open();
+    vi.useFakeTimers();
+
+    const writer = store.acquireWriter('alpha', 'execution-alpha');
+    writer.append(namedEntry('m1', 1, ''));
+    writer.appendText('m1', 'first ');
+    await vi.advanceTimersByTimeAsync(300);
+    await storage.waitForPausedWrite();
+
+    // Mutate while the first batch's write hangs, and let a second window
+    // fire. An unserialized second batch would persist the newer snapshot
+    // during the pause and then get clobbered when the paused older write
+    // completes last; the queued batch must instead run after it.
+    writer.appendText('m1', 'second');
+    await vi.advanceTimersByTimeAsync(300);
+    storage.releasePausedWrite();
+    await bothWritesLanded.promise;
+    writer.close();
+    await store.flush();
+
+    expect(writtenLog(storage.writes, 'alpha')[0]?.text).toBe('first second');
+  });
 });

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -1674,4 +1674,33 @@ describe('StreamLogStore save throttle', () => {
 
     expect(writtenLog(storage.writes, 'alpha')[0]?.text).toBe('first second');
   });
+
+  it('drains an in-flight write batch before a discarding reload', async () => {
+    const storage = mockStorage({
+      logs: {},
+      summaries: {},
+      pauseLogWriteKey: 'alpha',
+    });
+    const store = await StreamLogStore.open();
+    vi.useFakeTimers();
+
+    const writer = store.acquireWriter('alpha', 'execution-alpha');
+    writer.append(namedEntry('m1', 1, 'first'));
+    await vi.advanceTimersByTimeAsync(300);
+    await storage.waitForPausedWrite();
+
+    // A rollback reload must not resolve while a write batch is still
+    // running against the pre-rollback adapters.
+    let reloaded = false;
+    const reload = store.reload({ discardPendingWrites: true }).then(() => {
+      reloaded = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(reloaded).toBe(false);
+
+    storage.releasePausedWrite();
+    await reload;
+    expect(reloaded).toBe(true);
+    writer.close();
+  });
 });

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -1586,3 +1586,57 @@ describe('StreamLogStore load', () => {
     expect(storage.writes.size).toBe(0);
   });
 });
+
+describe('StreamLogStore save throttle', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('writes periodically under sustained sub-window appends and drains on flush', async () => {
+    let logWrites = 0;
+    const storage = mockStorage({
+      logs: {},
+      summaries: {},
+      onLogWrite: () => {
+        logWrites += 1;
+      },
+    });
+    const store = await StreamLogStore.open();
+    vi.useFakeTimers();
+
+    const writer = store.acquireWriter('alpha', 'execution-alpha');
+    writer.append(namedEntry('m1', 1, ''));
+    // 20 chunks 100ms apart: a trailing debounce would reset its timer on
+    // every append and never write until the stream pauses; the max-wait
+    // throttle must produce a durable write per 300ms window regardless.
+    for (let i = 0; i < 20; i += 1) {
+      writer.appendText('m1', `chunk-${i} `);
+      await vi.advanceTimersByTimeAsync(100);
+    }
+    expect(logWrites).toBeGreaterThanOrEqual(5);
+
+    // The tail landed after the last periodic write; flush drains it.
+    const writesBeforeFlush = logWrites;
+    writer.close();
+    await store.flush();
+    expect(logWrites).toBeGreaterThan(writesBeforeFlush);
+    expect(writtenLog(storage.writes, 'alpha')[0]?.text).toBe(
+      Array.from({ length: 20 }, (_, i) => `chunk-${i} `).join(''),
+    );
+  });
+
+  it('bounds the durability gap to one throttle window for a first append', async () => {
+    const storage = mockStorage({ logs: {}, summaries: {} });
+    const store = await StreamLogStore.open();
+    vi.useFakeTimers();
+
+    const writer = store.acquireWriter('alpha', 'execution-alpha');
+    writer.append(namedEntry('m1', 1, 'first entry'));
+    expect(writtenLog(storage.writes, 'alpha')).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(writtenLog(storage.writes, 'alpha')).toHaveLength(1);
+    writer.close();
+  });
+});

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -145,6 +145,35 @@ function materializeText(acc: StreamingTextAccumulator, end: number): string {
 }
 
 /**
+ * Read `[from, end)` from the accumulator without collapsing its chunk tail:
+ * the webview delta path calls this at render cadence during streaming, and
+ * materializing there would re-copy the whole joined prefix per frame. The
+ * chunk walk stays short because every throttled save materializes (via the
+ * persisted entries' `text` getters) and resets the tail.
+ */
+function sliceAccumulatedText(
+  acc: StreamingTextAccumulator,
+  from: number,
+  end: number,
+): string {
+  if (end <= acc.joined.length) return acc.joined.slice(from, end);
+  const parts: string[] = [];
+  if (from < acc.joined.length) parts.push(acc.joined.slice(from));
+  let pos = acc.joined.length;
+  for (const chunk of acc.chunks) {
+    if (pos >= end) break;
+    const next = pos + chunk.length;
+    if (next > from) {
+      parts.push(
+        chunk.slice(Math.max(0, from - pos), Math.min(chunk.length, end - pos)),
+      );
+    }
+    pos = next;
+  }
+  return parts.join('');
+}
+
+/**
  * The immutable post-mutation entry object for a text append: every field of
  * `current` is carried over by descriptor (never invoking `current`'s own
  * lazy getter), while `text` becomes a memoized getter that joins the
@@ -536,8 +565,14 @@ export class StreamLog {
       }
       const entry = this.entries[index];
       if (entry.seqNo <= maxSeqInclusive) {
+        const acc = this.streamingText.get(id);
         deltas.push({
-          delta: { id, appendText: (entry.text ?? '').slice(from) },
+          delta: {
+            id,
+            appendText: acc
+              ? sliceAccumulatedText(acc, from, acc.length)
+              : (entry.text ?? '').slice(from),
+          },
           seqNo: entry.seqNo,
         });
       }

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -123,6 +123,50 @@ export class StreamLogDeltaBuffer {
 
 let nextStreamLogInstanceId = 1;
 
+/**
+ * Chunked accumulation for one streaming entry's text. Provider chunks are
+ * collected in `chunks` and joined lazily, so a hot appendText path costs
+ * O(chunk) instead of re-copying the whole entry text per chunk. `joined` is
+ * the memoized join so far; `length` is the full text length including the
+ * unjoined tail.
+ */
+interface StreamingTextAccumulator {
+  joined: string;
+  chunks: string[];
+  length: number;
+}
+
+function materializeText(acc: StreamingTextAccumulator, end: number): string {
+  if (acc.joined.length < end) {
+    acc.joined += acc.chunks.join('');
+    acc.chunks.length = 0;
+  }
+  return end === acc.joined.length ? acc.joined : acc.joined.slice(0, end);
+}
+
+/**
+ * The immutable post-mutation entry object for a text append: every field of
+ * `current` is carried over by descriptor (never invoking `current`'s own
+ * lazy getter), while `text` becomes a memoized getter that joins the
+ * accumulator's chunks up to this entry's point-in-time length on first read.
+ * Readers that never touch `.text` (delta buffering, superseded emissions)
+ * pay nothing.
+ */
+function entryWithLazyText(
+  current: StreamLogEntry,
+  acc: StreamingTextAccumulator,
+  end: number,
+): StreamLogEntry {
+  const descriptors = Object.getOwnPropertyDescriptors(current);
+  let memo: string | undefined;
+  descriptors.text = {
+    get: () => (memo ??= materializeText(acc, end)),
+    enumerable: true,
+    configurable: true,
+  };
+  return Object.defineProperties({}, descriptors) as StreamLogEntry;
+}
+
 export interface StreamLogPreservedRawEntry {
   readonly beforeTypedIndex: number;
   readonly raw: unknown;
@@ -184,7 +228,19 @@ export class StreamLog {
   private seqCounter = 0;
   private readonly indexById = new Map<string, number>();
   private readonly dirtyUpdates = new Set<string>();
-  private readonly dirtyTextDeltas = new Map<string, StreamLogTextDelta>();
+  /**
+   * Per-entry chunk accumulators for in-flight streaming text. An entry whose
+   * id is present here carries a lazy `text` getter over the accumulator;
+   * settle/update materializes the join into a plain value and drops the
+   * accumulator, so persisted and settled entries are always plain.
+   */
+  private readonly streamingText = new Map<string, StreamingTextAccumulator>();
+  /**
+   * Offset into an entry's text where the webview's unacked text-delta window
+   * starts, keyed by id. The delta itself is a slice of the one canonical
+   * text, replacing the old second accumulated delta string per entry.
+   */
+  private readonly dirtyTextFrom = new Map<string, number>();
   private emissionSeqCounter = 0;
   private pendingAppendedIds: string[] = [];
   private readonly pendingDirtiedIds = new Set<string>();
@@ -388,6 +444,8 @@ export class StreamLog {
     // Direct merge — no Zod parse. update() is on the streaming hot path
     // (tool output chunks at ~200/sec) and receives trusted data from
     // AgentTrace. Persisted entries are parsed when loaded from storage.
+    // Spreading `current` reads its (possibly lazy) text getter, so this is
+    // where a streaming entry's chunks are joined into a plain value.
     const updated: StreamLogEntry = {
       ...current,
       ...patch,
@@ -403,8 +461,9 @@ export class StreamLog {
     this.countEntry(updated, 1);
 
     this.entries[index] = updated;
+    this.streamingText.delete(id);
     this.dirtyUpdates.add(id);
-    this.dirtyTextDeltas.delete(id);
+    this.dirtyTextFrom.delete(id);
     this.pendingDirtiedIds.add(id);
     return updated;
   }
@@ -418,18 +477,21 @@ export class StreamLog {
     const current = this.entries[index];
     if (current.type !== STREAM_LOG_ENTRY_TYPES.LOG) return undefined;
 
-    const updated: StreamLogEntry = {
-      ...current,
-      text: `${current.text ?? ''}${appendText}`,
-    };
+    let acc = this.streamingText.get(id);
+    if (!acc) {
+      // Reading `current.text` here materializes any lazy value left behind
+      // by a log merge; on the ordinary path it is already a plain value.
+      const base = current.text ?? '';
+      acc = { joined: base, chunks: [], length: base.length };
+      this.streamingText.set(id, acc);
+    }
+    acc.chunks.push(appendText);
+    acc.length += appendText.length;
 
+    const updated = entryWithLazyText(current, acc, acc.length);
     this.entries[index] = updated;
-    if (!this.dirtyUpdates.has(id)) {
-      const currentDelta = this.dirtyTextDeltas.get(id);
-      this.dirtyTextDeltas.set(id, {
-        id,
-        appendText: `${currentDelta?.appendText ?? ''}${appendText}`,
-      });
+    if (!this.dirtyUpdates.has(id) && !this.dirtyTextFrom.has(id)) {
+      this.dirtyTextFrom.set(id, acc.length - appendText.length);
     }
     this.pendingDirtiedIds.add(id);
     return updated;
@@ -466,15 +528,18 @@ export class StreamLog {
       delta: StreamLogTextDelta;
       seqNo: number;
     }> = [];
-    for (const [id, delta] of this.dirtyTextDeltas) {
+    for (const [id, from] of this.dirtyTextFrom) {
       const index = this.indexById.get(id);
       if (index === undefined) {
-        this.dirtyTextDeltas.delete(id);
+        this.dirtyTextFrom.delete(id);
         continue;
       }
       const entry = this.entries[index];
       if (entry.seqNo <= maxSeqInclusive) {
-        deltas.push({ delta, seqNo: entry.seqNo });
+        deltas.push({
+          delta: { id, appendText: (entry.text ?? '').slice(from) },
+          seqNo: entry.seqNo,
+        });
       }
     }
     deltas.sort((a, b) => a.seqNo - b.seqNo);
@@ -482,7 +547,7 @@ export class StreamLog {
   }
 
   clearDirtyUpdates(maxSeqInclusive: number = this.seqCounter): void {
-    for (const dirty of [this.dirtyUpdates, this.dirtyTextDeltas] as const) {
+    for (const dirty of [this.dirtyUpdates, this.dirtyTextFrom] as const) {
       for (const id of dirty.keys()) {
         const index = this.indexById.get(id);
         if (
@@ -511,52 +576,50 @@ export class StreamLog {
     for (const entry of fullEntries) {
       const index = this.indexById.get(entry.id);
       if (index === undefined || this.entries[index] === entry) {
-        this.dirtyTextDeltas.delete(entry.id);
+        this.dirtyTextFrom.delete(entry.id);
         continue;
       }
 
-      const current = this.dirtyTextDeltas.get(entry.id);
-      if (!current) continue;
-      const currentEntry = this.entries[index];
-      const currentText =
-        typeof currentEntry.text === 'string' ? currentEntry.text : '';
+      const from = this.dirtyTextFrom.get(entry.id);
+      if (from === undefined) continue;
+      const currentText = this.entries[index].text ?? '';
       const deliveredText = typeof entry.text === 'string' ? entry.text : '';
-      // A full-entry frame covers all appended text between the stable base
-      // prefix and the delivered text, even if later appends replaced the row.
-      const baseLength = currentText.length - current.appendText.length;
-      const deliveredDeltaLength = deliveredText.length - baseLength;
-
+      // A full-entry frame covers all appended text up to the delivered
+      // text's length, even if later appends replaced the row.
       if (
-        baseLength >= 0 &&
-        deliveredDeltaLength > 0 &&
-        currentText.endsWith(current.appendText) &&
+        deliveredText.length > from &&
         currentText.startsWith(deliveredText)
       ) {
-        if (deliveredDeltaLength >= current.appendText.length) {
-          this.dirtyTextDeltas.delete(entry.id);
-          continue;
+        if (deliveredText.length >= currentText.length) {
+          this.dirtyTextFrom.delete(entry.id);
+        } else {
+          this.dirtyTextFrom.set(entry.id, deliveredText.length);
         }
-        this.dirtyTextDeltas.set(entry.id, {
-          id: entry.id,
-          appendText: current.appendText.slice(deliveredDeltaLength),
-        });
       }
     }
 
     for (const delta of deltas) {
-      const current = this.dirtyTextDeltas.get(delta.id);
-      if (!current) continue;
-
-      if (current.appendText === delta.appendText) {
-        this.dirtyTextDeltas.delete(delta.id);
+      const from = this.dirtyTextFrom.get(delta.id);
+      if (from === undefined) continue;
+      const index = this.indexById.get(delta.id);
+      if (index === undefined) {
+        this.dirtyTextFrom.delete(delta.id);
         continue;
       }
-
-      if (current.appendText.startsWith(delta.appendText)) {
-        this.dirtyTextDeltas.set(delta.id, {
-          id: delta.id,
-          appendText: current.appendText.slice(delta.appendText.length),
-        });
+      const currentText = this.entries[index].text ?? '';
+      const end = from + delta.appendText.length;
+      // Advance only when the delivered frame still matches the canonical
+      // text at the window start (an interleaved update() resets the window).
+      if (
+        end > currentText.length ||
+        !currentText.startsWith(delta.appendText, from)
+      ) {
+        continue;
+      }
+      if (end === currentText.length) {
+        this.dirtyTextFrom.delete(delta.id);
+      } else {
+        this.dirtyTextFrom.set(delta.id, end);
       }
     }
   }

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -1,4 +1,5 @@
 import pMap from 'p-map';
+import PQueue from 'p-queue';
 import { z } from 'zod';
 
 import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
@@ -285,12 +286,11 @@ export class StreamLogStore {
     SAVE_MAX_WAIT_MS,
   );
   /**
-   * Tracks the active write. A flush can cancel the throttle and start a write
-   * while an already-queued throttle callback also runs; that is safe because
-   * each write snapshots and clears `dirtyIds`, so the second call only
-   * sees newly dirtied streams or settles with no work.
+   * Serializes write batches: a throttle window, a flush, or a delete that
+   * starts a write while one is still in flight queues behind it instead of
+   * racing it, so two batches can never persist the same stream out of order.
    */
-  private inFlightWrite: Promise<void> | null = null;
+  private readonly writeQueue = new PQueue({ concurrency: 1 });
   private writeGeneration = 0;
   private readonly writeTombstones = new Set<StreamTabId>();
   private clearing = false;
@@ -819,7 +819,6 @@ export class StreamLogStore {
     this.saveThrottle.cancel();
 
     try {
-      await this.inFlightWrite;
       await this.executeWrite();
       if (this.mode.kind !== 'ephemeral') {
         log.info(LOG_TAG, `Deleting stream: ${streamId}`);
@@ -852,7 +851,7 @@ export class StreamLogStore {
     this.stateRevision += 1;
 
     try {
-      await this.inFlightWrite;
+      await this.writeQueue.onIdle();
       this.forgetAllStreamState();
       if (this.mode.kind === 'ephemeral') return;
 
@@ -1026,8 +1025,8 @@ export class StreamLogStore {
         this.saveThrottle.cancel();
         await this.executeWrite();
         writeAttempts++;
-      } else if (this.inFlightWrite) {
-        await this.inFlightWrite;
+      } else if (this.writeQueue.size > 0 || this.writeQueue.pending > 0) {
+        await this.writeQueue.onIdle();
       } else if (loads.length > 0) {
         await Promise.allSettled(loads);
       } else {
@@ -1449,6 +1448,16 @@ export class StreamLogStore {
   }
 
   private executeWrite(): Promise<void> {
+    // One batch at a time: a save window that fires while a batch is still
+    // writing queues behind it, so two batches can never interleave `kv`
+    // writes for the same stream (the later batch could otherwise persist
+    // the older snapshot last). The batch snapshots `dirtyIds` when it
+    // starts, so a queued batch picks up mutations made during its
+    // predecessor; a batch that finds nothing dirty is a no-op.
+    return this.writeQueue.add(() => this.runWriteBatch());
+  }
+
+  private async runWriteBatch(): Promise<void> {
     // Skip streams whose rehydrate is pending or errored — writing now
     // would clobber the authoritative on-disk history with a fresh
     // empty-plus-new-appends log before `ensureLoaded` merges disk entries
@@ -1466,9 +1475,7 @@ export class StreamLogStore {
       }
     }
 
-    if (toWrite.length === 0) {
-      return Promise.resolve();
-    }
+    if (toWrite.length === 0) return;
 
     log.debug(LOG_TAG, `Writing ${toWrite.length} dirty stream(s)`);
     const writeGeneration = this.writeGeneration;
@@ -1484,7 +1491,7 @@ export class StreamLogStore {
     // stream together retains all of those large JSON strings simultaneously.
     // Sequential writes keep peak memory proportional to one serialized
     // transcript while preserving independent per-stream failure handling.
-    const writePromise = (async () => {
+    try {
       for (const streamId of toWrite) {
         const logInstance = this.streams.get(streamId)?.log;
         if (!logInstance) continue;
@@ -1498,7 +1505,7 @@ export class StreamLogStore {
             this.markDirty(streamId);
         }
       }
-    })().finally(() => {
+    } finally {
       for (const streamId of toWrite) {
         const state = this.streams.get(streamId);
         if (state) {
@@ -1506,14 +1513,8 @@ export class StreamLogStore {
           this.pruneStreamState(streamId);
         }
       }
-      if (this.inFlightWrite === writePromise) {
-        this.inFlightWrite = null;
-      }
       this.drainPendingReleases();
-    });
-
-    this.inFlightWrite = writePromise;
-    return writePromise;
+    }
   }
 
   /**

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -1096,6 +1096,13 @@ export class StreamLogStore {
   private async executeReload(discardPendingWrites: boolean): Promise<void> {
     if (discardPendingWrites) {
       this.saveThrottle.cancel();
+      // Invalidate and drain any in-flight batch before the adapters
+      // repoint: a write started before a storage-root rollback must not
+      // keep landing streams against the restored root. The generation
+      // bump makes the batch's remaining per-stream writes skip; the
+      // drain keeps a mid-write stream from straddling the repoint.
+      this.writeGeneration += 1;
+      await this.writeQueue.onIdle();
     } else if (this.mode.kind === 'persistent') {
       await this.flush();
     }

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -13,7 +13,7 @@ import {
   type StreamLogEntry,
   type StreamTabId,
 } from '@shared/schemas';
-import { debounce, filterNotNull, isObject } from '@utils/core';
+import { createFlushableDebounce, filterNotNull, isObject } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { StorageFS } from '@utils/files/storageFS';
 import { formatResultCount } from '@utils/text/stringUtils';
@@ -30,7 +30,7 @@ import {
   type StreamLogUpdatePatch,
 } from './StreamLog';
 
-const SAVE_DEBOUNCE_MS = 300;
+const SAVE_MAX_WAIT_MS = 300;
 export const STREAM_LOGS_DIR = WORKSPACE_STORAGE_LAYOUT.streamLogs;
 export const STREAM_LOG_SUMMARIES_DIR = 'streamLogSummaries';
 const STREAM_LOG_LOAD_CONCURRENCY = 8;
@@ -273,20 +273,20 @@ export class StreamLogStore {
    */
   private readonly summaries = new Map<StreamTabId, StreamLogSummary>();
 
-  private readonly debouncedSave = debounce(
-    () => this.executeWrite(),
-    SAVE_DEBOUNCE_MS,
+  /**
+   * Max-wait throttle for the persistence path: the first dirty mutation in a
+   * window starts the timer and later mutations join it without resetting it
+   * (`scheduleSave`'s `pending` guard), so sustained sub-window appends still
+   * produce a durable write every SAVE_MAX_WAIT_MS instead of starving a
+   * trailing debounce. A crash mid-stream loses at most one window.
+   */
+  private readonly saveThrottle = createFlushableDebounce(
+    () => void this.executeWrite(),
+    SAVE_MAX_WAIT_MS,
   );
   /**
-   * Track save() awaiters so we can settle them when the debounced write is
-   * cancelled (flush / delete / clear). perfect-debounce's cancel() drops
-   * pending resolvers without settling them, which would hang any awaited
-   * save() indefinitely.
-   */
-  private pendingSaveAwaiters: Array<() => void> = [];
-  /**
-   * Tracks the active write. A flush can cancel the debounce and start a write
-   * while an already-queued debounce callback also runs; that is safe because
+   * Tracks the active write. A flush can cancel the throttle and start a write
+   * while an already-queued throttle callback also runs; that is safe because
    * each write snapshots and clears `dirtyIds`, so the second call only
    * sees newly dirtied streams or settles with no work.
    */
@@ -480,7 +480,7 @@ export class StreamLogStore {
     this.stateRevision += 1;
     if (this.mode.kind === 'persistent') {
       this.markDirty(streamId);
-      void this.save();
+      this.scheduleSave();
     }
   }
 
@@ -681,7 +681,7 @@ export class StreamLogStore {
           this.stateRevision += 1;
           this.refreshSummary(streamId, merged);
           this.markDirty(streamId);
-          void this.save();
+          this.scheduleSave();
           // The merge renumbered seqNos under a fresh log instance, so
           // fold-state consumers must rebuild rather than apply a delta.
           this.notify(streamId, { reset: true });
@@ -710,7 +710,7 @@ export class StreamLogStore {
         // append to unblock it.
         const recovered = this.streams.get(streamId);
         if (recovered) recovered.loadFailed = false;
-        if (this.dirtyIds.has(streamId)) void this.save();
+        if (this.dirtyIds.has(streamId)) this.scheduleSave();
       } catch (err) {
         // Keep the disk copy authoritative and surface the failed read. A
         // caller may retry `ensureLoaded`, but no append is accepted until a
@@ -769,7 +769,7 @@ export class StreamLogStore {
       ? logInstance.appendSettled(entry)
       : logInstance.append(entry);
     this.commitChange(streamId, logInstance);
-    void this.save();
+    this.scheduleSave();
     return appended;
   }
 
@@ -790,7 +790,7 @@ export class StreamLogStore {
     if (!updated) return undefined;
 
     this.commitChange(streamId, logInstance);
-    void this.save();
+    this.scheduleSave();
     return updated;
   }
 
@@ -816,7 +816,7 @@ export class StreamLogStore {
   async delete(streamId: StreamTabId): Promise<void> {
     this.assertWritableStore('delete a transcript stream');
     this.writeTombstones.add(streamId);
-    this.debouncedSave.cancel();
+    this.saveThrottle.cancel();
 
     try {
       await this.inFlightWrite;
@@ -847,7 +847,7 @@ export class StreamLogStore {
     const count = this.summaries.size;
     this.clearing = true;
     this.writeGeneration += 1;
-    this.cancelPendingSave();
+    this.saveThrottle.cancel();
     this.forgetAllStreamState();
     this.stateRevision += 1;
 
@@ -888,7 +888,7 @@ export class StreamLogStore {
       status,
     );
     if (affected.length > 0) {
-      void this.save();
+      this.scheduleSave();
     }
     // Preserve logs that were resident before this call; only release the
     // cold logs loaded specifically for recovery.
@@ -993,22 +993,16 @@ export class StreamLogStore {
   }
 
   /**
-   * Debounced internal persistence trigger; every mutator schedules it.
-   * External durability is `flush()`, which drains, retries, and throws.
+   * Throttled internal persistence trigger; every mutator schedules it.
+   * Fire-and-forget by design: only `flush()` is awaitable, and it drains,
+   * retries, and throws.
    */
-  private save(): Promise<void> {
+  private scheduleSave(): void {
     this.assertWritableStore('save transcripts');
-    if (this.mode.kind === 'ephemeral' || this.dirtyIds.size === 0) {
-      return Promise.resolve();
-    }
-    // Start/extend the debounce timer. perfect-debounce handles timer
-    // management and returns a shared promise, but we ignore it and track
-    // our own awaiters so we can settle them when the debounce is cancelled
-    // during flush / delete / clear.
-    this.debouncedSave();
-    return new Promise<void>((resolve) => {
-      this.pendingSaveAwaiters.push(resolve);
-    });
+    if (this.mode.kind === 'ephemeral' || this.dirtyIds.size === 0) return;
+    // Throttle, not debounce: only start a window when none is open, so a
+    // sustained stream of mutations cannot keep pushing the write out.
+    if (!this.saveThrottle.pending) this.saveThrottle.schedule();
   }
 
   async flush(): Promise<void> {
@@ -1028,8 +1022,8 @@ export class StreamLogStore {
     let writeAttempts = 0;
     while (true) {
       const loads = this.pendingLoads();
-      if (this.debouncedSave.isPending()) {
-        this.debouncedSave.cancel();
+      if (this.saveThrottle.pending) {
+        this.saveThrottle.cancel();
         await this.executeWrite();
         writeAttempts++;
       } else if (this.inFlightWrite) {
@@ -1102,7 +1096,7 @@ export class StreamLogStore {
 
   private async executeReload(discardPendingWrites: boolean): Promise<void> {
     if (discardPendingWrites) {
-      this.cancelPendingSave();
+      this.saveThrottle.cancel();
     } else if (this.mode.kind === 'persistent') {
       await this.flush();
     }
@@ -1403,18 +1397,6 @@ export class StreamLogStore {
     }
   }
 
-  private cancelPendingSave(): void {
-    this.debouncedSave.cancel();
-    // `clear()` discards all streams, so there is nothing left for pending
-    // save() callers to wait on.
-    this.settlePendingSaveAwaiters();
-  }
-
-  private settlePendingSaveAwaiters(): void {
-    const awaiters = this.pendingSaveAwaiters.splice(0);
-    for (const resolve of awaiters) resolve();
-  }
-
   private parsePersistedEntries(
     streamId: StreamTabId,
     rawEntries: unknown,
@@ -1485,15 +1467,8 @@ export class StreamLogStore {
     }
 
     if (toWrite.length === 0) {
-      this.settlePendingSaveAwaiters();
       return Promise.resolve();
     }
-
-    // Snapshot current save awaiters so new save() calls during this write
-    // get fresh awaiters for the next debounce window. We settle these after
-    // the write completes (success or failure) so flush / delete / clear
-    // don't strand callers that are awaiting save().
-    const awaiters = this.pendingSaveAwaiters.splice(0);
 
     log.debug(LOG_TAG, `Writing ${toWrite.length} dirty stream(s)`);
     const writeGeneration = this.writeGeneration;
@@ -1535,10 +1510,6 @@ export class StreamLogStore {
         this.inFlightWrite = null;
       }
       this.drainPendingReleases();
-      // Settle the snapshotted save awaiters — on failure the dirty
-      // streams have already been re-marked for retry, so resolve
-      // regardless.
-      for (const resolve of awaiters) resolve();
     });
 
     this.inFlightWrite = writePromise;


### PR DESCRIPTION
Fixes #9957

Stacked on #9967 (`feat/streamlog-delta-feed`); base is that branch, and this should merge after it (or be retargeted to `main` once it lands).

Implements PRD item 3 of `docs/prds/2026-08-11-transcript-memory-architecture.md` (audit Finding 7).

## StreamLog: chunked streaming text

- `appendText` no longer rebuilds the full entry text per provider chunk (previously O(n) per chunk, O(n^2) per stream). Chunks are pushed into a per-entry `StreamingTextAccumulator` (memoized join), costing O(chunk) per append.
- Each post-mutation entry object carries a memoized lazy `text` getter that joins the accumulator up to that entry's point-in-time length on first read. The delta feed's by-value contract is preserved: an entry emitted at chunk k still reads as the text as of chunk k, and superseded emissions that no consumer reads never pay the join. Public reads keep returning a plain string.
- The join materializes into a plain value at settle/update (spread reads the getter) and at each throttled save (KV serialization reads it), so the durable schema is unchanged: text persists as a string, O(text) per save at the throttle cadence, not per chunk.
- The second parallel accumulated string in `dirtyTextDeltas` is deleted. The webview delta window is now an offset (`dirtyTextFrom`) into the one canonical text; `getDirtyTextDeltas` slices it and `ackDirtyTextDeltas` advances the offset, keeping the `WebviewBridge` contract intact (all four existing ack tests pass unchanged).

## StreamLogStore: max-wait save throttle

- The trailing `debounce` from perfect-debounce is replaced with the repo's flushable-throttle idiom: `createFlushableDebounce` guarded by `pending`, so the first dirty mutation opens a 300ms window and later mutations join it without resetting it. Sustained sub-300ms appends now produce a durable write every window instead of starving the save; a kill mid-stream loses at most one throttle window.
- Mutators call a void `scheduleSave()`; the per-mutation promise pairs (`pendingSaveAwaiters`, `settlePendingSaveAwaiters`, `cancelPendingSave`) are deleted. Only `flush()` is awaitable, which is how every caller already used it (all mutator sites were `void this.save()`).

## Tests

- Cadence: 20 appends at 100ms intervals under fake timers yield periodic durable writes (a debounce would never fire), and `flush()` drains the tail; plus a first-append durability-gap bound test.
- Equivalence: seeded 400-step append/update/settle interleaving fuzz comparing materialized text against a string oracle, including point-in-time snapshots of emitted entries and the JSON save path.
- The stacked delta feed's fold-vs-oracle harness (`StreamLogDeltaFold.vitest.ts`) stays green, as do the transcript, progressView, and CLI persistence suites (715 tests) and the full `npm run typecheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gtc6wQMD1hedgabjQMfAun

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the streaming hot path and transcript durability ordering (lazy text + serialized writes); regressions could corrupt displayed or persisted stream text, but behavior is heavily covered by new tests.
> 
> **Overview**
> **StreamLog** stops rebuilding full entry text on every `appendText` chunk. Chunks live in a per-entry accumulator; new entry objects use a lazy `text` getter so emissions stay **point-in-time** while appends stay O(chunk). `update`/`settle` materialize plain strings. Webview text deltas no longer duplicate a second accumulated string—`dirtyTextFrom` marks an offset into canonical text, with slice/ack logic updated accordingly.
> 
> **StreamLogStore** replaces trailing debounce with a **max-wait** throttle (`createFlushableDebounce` + `pending` guard) so sustained streaming still durably writes about every 300ms. Mutators call void `scheduleSave()`; per-mutation save promises are removed. **`PQueue`** runs one write batch at a time so overlapping throttle windows cannot persist stale snapshots after newer ones. Discarding reload bumps write generation and awaits the queue before repointing storage.
> 
> Tests add delta/oracle fuzz, save-throttle cadence, queued writes during paused I/O, and reload ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd17b047a38a475a8f8c3b4f9c123413eda648f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->