### PR TITLE
fix(delegation): skip the proposal gate when approval prompts are unavailable

### DIFF
--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -149,6 +149,7 @@ function parentRunContext(
     streamId: StreamTabId;
     stopAfterCycle: boolean;
     session: SessionHandle;
+    approvalPromptsUnavailable: boolean;
   }> = {},
 ): RunContext {
   return createRunContext({
@@ -1127,6 +1128,37 @@ describe('headless delegation', () => {
     );
     expect(result.error).toContain('continue directly with available context');
     expect(mocks.executeAgent).not.toHaveBeenCalled();
+  });
+
+  it('proceeds without a proposal when the run cannot present approval prompts', async () => {
+    // Headless `--approval-policy never` withholds `requiresApproval` tools up
+    // front, so a delegation tool that still executes was deliberately offered
+    // (delegate_multi_agents). The proposal gate must not settle a
+    // guaranteed denial; the child stays on inherited approval state.
+    mocks.isProposalBypassed.mockReturnValue(false);
+    const session = createTestSession();
+    const requestAgentProposal = vi.fn();
+    session.useHostInteractions({
+      cancel: vi.fn(),
+      requestAgentProposal,
+    } satisfies HostInteractions);
+    try {
+      const result = await withRunContext(
+        parentRunContext({ session, approvalPromptsUnavailable: true }),
+        () => callDelegateReview(),
+      );
+
+      expect(requestAgentProposal).not.toHaveBeenCalled();
+      expect(result.status).toBe('executed');
+      expect(result.summary).toBe("Launched 'review' (async)");
+      expect(mocks.executeAgent).toHaveBeenCalledWith(
+        expect.objectContaining({ agent: 'review' }),
+        expect.any(String),
+        expect.anything(),
+      );
+    } finally {
+      session.dispose();
+    }
   });
 
   it('rejects an approved model override unavailable in the active API mode', async () => {

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -8,6 +8,7 @@
 // Local imports
 import type { AgentEntry } from '@agent/index/agentRegistry';
 import { currentSession } from '@agent/runtime/SessionHandle';
+import { tryUseRunContext } from '@agent/runtime/RunContext';
 import type { ProposalResult } from '@agent/runtime/HostInteractions';
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import {
@@ -152,6 +153,18 @@ export async function requestDelegationProposal(
 ): Promise<DelegationProposalDecision> {
   if (proposalApprovals().isBypassed(streamId)) {
     return { result: { action: 'approve' }, autoApproved: true };
+  }
+
+  // A run that can never present approval prompts withholds `requiresApproval`
+  // tools from the model up front (resolveAgentTools), so a delegation tool
+  // that still executes here was deliberately offered for unattended use —
+  // delegate_multi_agents in a headless CLI run. The proposal is the
+  // interactive review surface, not the security gate: proceed without one.
+  // `autoApproved: false` keeps the child on inherited per-kind approval
+  // state, so `--approval-policy never` still denies bash and edits
+  // downstream.
+  if (tryUseRunContext()?.approvalPromptsUnavailable === true) {
+    return { result: { action: 'approve' }, autoApproved: false };
   }
 
   const interaction = currentSession().interactions.requestAgentProposal({


### PR DESCRIPTION
Fixes the main-only **runtime validation (linux)** failure: `workflow-script run should wait for and return the terminal child report to the headless parent` (`packages/cli/scripts/validate-run.mjs`).

## Root cause

Commit a1a87401d1 ("feat: compact workflow approvals and session status", pushed directly to main 2026-08-10) added a `requestDelegationProposal` call to `WorkflowScriptTool`. Unlike `delegate_agent`/`delegate_workflow`, `delegate_multi_agents` does **not** declare `requiresApproval: true` — deliberately, so headless runs (which withhold approval-gated tools from the model up front via `resolveAgentTools`) still offer it. The new proposal request then reached the headless interaction port and settled as a guaranteed denial under `--approval-policy never`:

```
[warn] [cli-approval] Approval policy denied under policy "never".
```

The tool returned a rejection, the workflow-script child never launched, no `workflow-script#…` stream appeared in NDJSON, and no terminal `report.json` was persisted — exactly the assertion that has been red on main since.

## Bisect evidence

The job is main-only, so per-commit CI history is the bisect:

- `85cfb14581` (2026-08-10 11:29) — last **green** main CI run
- `a1a87401d1` (2026-08-10 13:10) — first **red** run, failing with this exact assertion; its diff introduces the proposal gate in `WorkflowScriptTool.ts`/`proposalFlow.ts`
- Every subsequent main run fails the same assertion, including `cc31c4e976` (docs-only) and `b7aa38df4e` — both **before** the transcript PRs

The suspected transcript changes #9967/#9968 and the #9972 dependency bumps are ruled out: the failure predates all of them, and with this fix the full `validate:run` suite passes on head of main (fold + finalize + lazy-text all project the child report correctly).

## Fix

`requestDelegationProposal` returns approve (`autoApproved: false`) when the run context declares `approvalPromptsUnavailable`. Rationale: a run that can never present prompts withholds `requiresApproval` tools up front, so a delegation tool that still executes was deliberately offered for unattended use — the proposal is the interactive review surface, not the security gate. `autoApproved: false` keeps the child on inherited per-kind approval state, so `--approval-policy never` still denies bash and edits downstream. This restores the exact pre-a1a87401d1 headless behavior while keeping the new interactive proposal UX intact (TUI/extension/desktop, and headless yolo, are unchanged — `approvalPromptsUnavailable` is false there).

## Verification

- `node scripts/validate-run.mjs` (full suite): **CLI run validation passed**; the workflow-script scenario shows `workflow-script#… → completed` before `agent-result`, with all three prover children and the persisted `<workflow-script-result` report
- `npm run typecheck` clean
- `npx vitest run src/test-kernel/cli/StreamLogDeltaFold.vitest.ts src/test-kernel/transcript/ src/test-kernel/tools/WorkflowScriptTool.vitest.ts src/test-kernel/tools/DelegationTools.vitest.ts` — 269 passed
- New regression test in `DelegationHeadless.vitest.ts`: proposal port is not consulted and the launch proceeds when `approvalPromptsUnavailable` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gtc6wQMD1hedgabjQMfAun

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delegation approval handshake logic; scope is narrow and preserves inherited per-tool approval via autoApproved: false.
> 
> **Overview**
> Fixes headless workflow-script runs where delegation hit the interactive **proposal** step and was denied under `--approval-policy never`, so child agents never launched.
> 
> **`requestDelegationProposal`** now returns approve immediately when the run context has **`approvalPromptsUnavailable`**, without calling **`requestAgentProposal`**. **`autoApproved: false`** keeps downstream tool approval behavior unchanged (bash/edits still follow inherited policy).
> 
> A regression test in **`DelegationHeadless.vitest.ts`** asserts the proposal port is not used and delegation still launches async when that flag is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac211bb1a92caeb3ee42ac6e88ad6df4b6cd2c4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->