### PR TITLE
Port WebviewBridge to the StreamLogDelta feed and delete the ack/dirty protocol

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -1409,12 +1409,34 @@ export function syncStreamLog(
     if (canFold) {
       foldApplicationsForTest += 1;
       const changes = buffer?.drain();
-      projections = applyStreamChanges(
-        state,
-        changes?.appended ?? [],
-        changes?.dirtied ?? [],
-        ctx,
-      );
+      const appended = changes?.appended ?? [];
+      let dirtied = changes?.dirtied ?? [];
+      if (changes && changes.textChunks.length > 0) {
+        // The fold applies whole entry values, so resolve each text chunk to
+        // its entry's current object. Safe: `canFold` pinned the buffer at
+        // the log's emission head, so current values are exactly the
+        // post-burst state the chunks stream toward. A chunk's id may also
+        // be buffered by (older) value; the resolved current value replaces
+        // it in place to keep appended/dirtied disjoint by id.
+        const appendedIndexById = new Map(
+          appended.map((entry, index) => [entry.id, index] as const),
+        );
+        const dirtiedById = new Map(
+          dirtied.map((entry) => [entry.id, entry] as const),
+        );
+        for (const chunk of changes.textChunks) {
+          const current = log.getById(chunk.id);
+          if (!current) continue;
+          const appendedIndex = appendedIndexById.get(chunk.id);
+          if (appendedIndex !== undefined) {
+            appended[appendedIndex] = current;
+          } else {
+            dirtiedById.set(chunk.id, current);
+          }
+        }
+        dirtied = [...dirtiedById.values()].sort((a, b) => a.seqNo - b.seqNo);
+      }
+      projections = applyStreamChanges(state, appended, dirtied, ctx);
       state.emissionSeq = log.emissionHead;
     } else {
       rebuildApplicationsForTest += 1;

--- a/src/controllers/progressView/backend/WebviewBridge.ts
+++ b/src/controllers/progressView/backend/WebviewBridge.ts
@@ -1,7 +1,7 @@
 import * as logger from '@logger/logUtils';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ProgressViewOutboundMessage, StreamTabId } from '@shared/schemas';
-import type { StreamLog } from '@transcript/StreamLog';
+import { StreamLogDeltaBuffer } from '@transcript/StreamLog';
 import type { StreamLogStore } from '@transcript/StreamLogStore';
 import { createFlushableDebounce, type FlushableDebounce } from '@utils/core';
 
@@ -13,30 +13,30 @@ export type ProgressViewMessageSender = (
   message: ProgressViewOutboundMessage,
 ) => boolean | PromiseLike<boolean>;
 
-type ProgressLogSource = Pick<
-  StreamLog,
-  | 'head'
-  | 'getRange'
-  | 'getDirtyUpdates'
-  | 'getDirtyTextDeltas'
-  | 'ackDirtyUpdates'
-  | 'ackDirtyTextDeltas'
->;
+type ProgressLogStore = Pick<StreamLogStore, 'onChange' | 'get'>;
 
-type ProgressLogStore = Pick<
-  StreamLogStore,
-  'onChange' | 'get' | 'clearDirtyUpdates'
->;
-
-/** Per-stream cursor and pending-flush state, created by `syncStream`. */
+/**
+ * Per-stream feed state, created by `syncStream`. `buffer` folds the store's
+ * multicast deltas between flushes; `undefined` routes the next flush through
+ * the from-scratch resync (registration, reconnect, failed delivery).
+ */
 interface StreamEntry {
-  cursor: number;
+  buffer: StreamLogDeltaBuffer | undefined;
   dirty: boolean;
 }
 
+/**
+ * Mirrors the active stream's transcript to the progress webview by folding
+ * the store's `StreamLogDelta` feed into `LOG_DELTA` wire frames. The feed is
+ * multicast and nothing is acked store-side; delivery guarantees toward the
+ * webview come from the explicit resync handshake instead — consumer
+ * registration (`syncStream`), a detected emission gap, and any failed
+ * `postMessage` all replay `getRange(0)` from scratch, the same oracle path
+ * a from-scratch projection uses.
+ */
 export class WebviewBridge {
   private readonly flushDebounce: FlushableDebounce;
-  /** Registered streams: presence means cursor is seeded; `dirty` means pending flush. */
+  /** Registered streams: presence means the webview knows the stream exists. */
   private readonly streams = new Map<StreamTabId, StreamEntry>();
   private readonly unsubscribe: () => void;
   private flushInProgress = false;
@@ -51,18 +51,20 @@ export class WebviewBridge {
       () => void this.runFlush(),
       FRAME_INTERVAL_MS,
     );
-    this.unsubscribe = this.store.onChange((streamId) => {
+    this.unsubscribe = this.store.onChange((streamId, delta) => {
       if (streamId !== this.getActiveStream()) return;
-      // A stream is mirrored to the webview only after `syncStream` seeds its
-      // cursor. That call is the registration handshake, run once the webview
-      // knows the stream exists. A run appends its earliest entries (the "Init"
-      // stage and files-loaded logs) during launch, before that handshake;
-      // streaming them here would post a LOG_DELTA the frontend drops (no
-      // streamState yet) while this bridge advances its cursor past them,
-      // losing them until a manual reload. Until then the on-disk log is
-      // authoritative and `syncStream` replays it in full.
+      // A stream is mirrored to the webview only after `syncStream` registers
+      // it. That call is the registration handshake, run once the webview
+      // knows the stream exists. A run appends its earliest entries (the
+      // "Init" stage and files-loaded logs) during launch, before that
+      // handshake; streaming them here would post a LOG_DELTA the frontend
+      // drops (no streamState yet). Until then deltas are ignored and
+      // `syncStream`'s from-scratch replay covers the whole log.
       const entry = this.streams.get(streamId);
       if (!entry) return;
+      // No buffer while a resync is pending: the resync replays the whole
+      // log, so buffering earlier deltas would only double-apply them.
+      entry.buffer?.push(delta);
       entry.dirty = true;
       this.scheduleFlush();
     });
@@ -75,8 +77,7 @@ export class WebviewBridge {
   }
 
   syncStream(streamId: StreamTabId): void {
-    this.streams.set(streamId, { cursor: 0, dirty: true });
-    this.store.clearDirtyUpdates(streamId);
+    this.streams.set(streamId, { buffer: undefined, dirty: true });
     this.scheduleFlush();
   }
 
@@ -121,34 +122,52 @@ export class WebviewBridge {
       return true;
     }
 
-    const { cursor } = entry;
-    const nextCursor = log.head;
-    const entries = log.getRange(cursor, nextCursor);
-    const updates = log.getDirtyUpdates(cursor);
-    const textDeltas = log.getDirtyTextDeltas(cursor);
-
-    if (
-      entries.length === 0 &&
-      updates.length === 0 &&
-      textDeltas.length === 0
-    ) {
-      entry.dirty = false;
-      return true;
+    let payload: ProgressViewOutboundMessage;
+    if (!entry.buffer || entry.buffer.resyncRequired) {
+      // Resync from scratch through the oracle path. The replacement buffer
+      // is based at the emission head read in the same synchronous snapshot
+      // as `getRange(0)`, so deltas emitted during the async delivery below
+      // fold on top of exactly this frame.
+      const entries = log.getRange(0);
+      entry.buffer = new StreamLogDeltaBuffer(log.emissionHead);
+      if (entries.length === 0) {
+        entry.dirty = false;
+        return true;
+      }
+      payload = {
+        command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+        streamId: activeStream,
+        entries,
+        updates: [],
+        textDeltas: [],
+      };
+    } else {
+      const { appended, dirtied, textChunks } = entry.buffer.drain();
+      if (
+        appended.length === 0 &&
+        dirtied.length === 0 &&
+        textChunks.length === 0
+      ) {
+        entry.dirty = false;
+        return true;
+      }
+      payload = {
+        command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+        streamId: activeStream,
+        entries: appended,
+        updates: dirtied,
+        textDeltas: textChunks,
+      };
     }
 
-    const payload = {
-      command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
-      streamId: activeStream,
-      entries,
-      updates,
-      textDeltas,
-    } as const;
-
-    if (!(await this.deliver(payload))) return false;
-
-    log.ackDirtyUpdates(updates);
-    log.ackDirtyTextDeltas(textDeltas, entries);
-    entry.cursor = nextCursor;
+    if (!(await this.deliver(payload))) {
+      // The frame is gone and nothing store-side retains it: route the next
+      // flush through the from-scratch resync so the webview cannot stay
+      // stale. `dirty` remains set; the next store delta (or `syncStream`)
+      // triggers the retry.
+      entry.buffer = undefined;
+      return false;
+    }
     entry.dirty = this.flushRequested;
     return true;
   }

--- a/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
+++ b/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
@@ -171,6 +171,13 @@ class MirroredOps {
         appendTranscriptText(store, streamId, id, ` chunk${this.nextId}`);
       }
       this.nextId += 1;
+    } else if (roll < 0.45 && this.openText.length > 0) {
+      // Non-terminal in-place update on a row that keeps streaming: emits a
+      // dirtied entry by value while the row stays open, so later appendText
+      // chunks land on top of a buffered value (the delta feed's
+      // value-supersedes-chunks precedence, exercised in both directions).
+      const id = pick(this.rng, this.openText);
+      this.update(id, { data: { status: 'running', tick: this.nextId++ } });
     } else if (roll < 0.5 && this.openText.length > 0) {
       const id = this.openText.shift() as string;
       this.update(id, { data: { status: 'completed' } }, true);

--- a/src/test-kernel/progressView/WebviewBridge.vitest.ts
+++ b/src/test-kernel/progressView/WebviewBridge.vitest.ts
@@ -27,6 +27,7 @@ import {
   appendTranscriptEntry,
   appendTranscriptText,
   updateTranscriptEntry,
+  withTranscriptWriter,
 } from '@test/support/storeTestDrivers';
 import { StreamLogStore, type StreamLogAppendInput } from '@transcript';
 
@@ -228,7 +229,7 @@ describe('WebviewBridge', () => {
     );
   });
 
-  it('keeps the cursor and dirty updates when no target accepts a log delta', async () => {
+  it('resyncs from scratch when no target accepts a log delta', async () => {
     const { store, sendMessage, bridge } = setupBridge({
       sendMessage: vi
         .fn()
@@ -254,6 +255,9 @@ describe('WebviewBridge', () => {
 
     expect(sendMessage).toHaveBeenCalledTimes(2);
 
+    // The rejected frame is gone — nothing store-side retains it. The next
+    // flush must replay the whole log through the oracle path so the
+    // disposed-and-restored webview cannot stay stale.
     appendTranscriptEntry(
       store,
       ACTIVE,
@@ -263,10 +267,61 @@ describe('WebviewBridge', () => {
 
     expect(sendMessage).toHaveBeenLastCalledWith(
       logDeltaMessage(ACTIVE, {
-        entries: [entryContaining('active-2', 'retry trigger')],
-        updates: [entryContaining('active-1', 'edited log')],
+        entries: [
+          entryContaining('active-1', 'edited log'),
+          entryContaining('active-2', 'retry trigger'),
+        ],
       }),
     );
+  });
+
+  it('re-registers and replays from scratch on a mid-stream reconnect', async () => {
+    const { store, sendMessage, bridge } = setupBridge();
+
+    bridge.syncStream(ACTIVE);
+    appendTranscriptEntry(store, ACTIVE, logEntry('active-1', '', 100));
+    appendTranscriptText(store, ACTIVE, 'active-1', 'hello');
+    await vi.advanceTimersByTimeAsync(20);
+    sendMessage.mockClear();
+
+    // Webview disposed and restored: the provider re-runs the registration
+    // handshake, which must resync instead of resuming the chunk feed.
+    bridge.syncStream(ACTIVE);
+    appendTranscriptText(store, ACTIVE, 'active-1', ' world');
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenLastCalledWith(
+      logDeltaMessage(ACTIVE, {
+        entries: [entryContaining('active-1', 'hello world')],
+      }),
+    );
+  });
+
+  it('delivers a stream lifecycle as append, chunk, and settle frames', async () => {
+    const { store, sendMessage, bridge } = setupBridge();
+
+    bridge.syncStream(ACTIVE);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    appendTranscriptEntry(store, ACTIVE, logEntry('m1', '', 100));
+    await vi.advanceTimersByTimeAsync(20);
+    appendTranscriptText(store, ACTIVE, 'm1', 'hel');
+    appendTranscriptText(store, ACTIVE, 'm1', 'lo');
+    await vi.advanceTimersByTimeAsync(20);
+    withTranscriptWriter(store, ACTIVE, (writer) =>
+      writer.settle('m1', { text: 'hello!' }),
+    );
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sendMessage.mock.calls.map(([message]) => message)).toEqual([
+      logDeltaMessage(ACTIVE, { entries: [entryContaining('m1', '')] }),
+      logDeltaMessage(ACTIVE, {
+        textDeltas: [{ id: 'm1', appendText: 'hello' }],
+      }),
+      logDeltaMessage(ACTIVE, { updates: [entryContaining('m1', 'hello!')] }),
+    ]);
   });
 
   it('serializes async flushes and preserves updates made during delivery', async () => {

--- a/src/test-kernel/transcript/StreamLog.vitest.ts
+++ b/src/test-kernel/transcript/StreamLog.vitest.ts
@@ -55,6 +55,9 @@ describe('StreamLog', () => {
     expect(entries[0]?.seqNo).toBe(1);
     expect(entries.at(-1)?.seqNo).toBe(5_001);
 
+    // Drain the appends so the update emission below is isolated.
+    log.drainEmission();
+
     const updated = log.update('message-2500', { text: 'changed' });
     expect(updated?.seqNo).toBe(2_502);
 
@@ -64,13 +67,16 @@ describe('StreamLog', () => {
     });
     expect(log.hasRunningGroup).toBe(false);
 
-    const dirty = log.getDirtyUpdates();
-    expect(dirty.map((entry) => entry.id)).toEqual(['run', 'message-2500']);
-    log.ackDirtyUpdates(dirty);
-    expect(log.getDirtyUpdates()).toEqual([]);
+    const delta = log.drainEmission();
+    expect(delta.appended).toEqual([]);
+    expect(delta.dirtied.map((entry) => entry.id)).toEqual([
+      'run',
+      'message-2500',
+    ]);
+    expect(log.hasUndrainedChanges).toBe(false);
   });
 
-  it('does not mark no-op updates dirty', () => {
+  it('does not emit no-op updates', () => {
     const log = new StreamLog();
     log.append({
       id: 'message',
@@ -80,9 +86,14 @@ describe('StreamLog', () => {
       text: 'unchanged',
       messageType: MESSAGE_TYPES.DEFAULT,
     });
+    log.drainEmission();
 
     expect(log.update('message', { text: 'unchanged' })).toBeUndefined();
-    expect(log.getDirtyUpdates()).toEqual([]);
+    expect(log.hasUndrainedChanges).toBe(false);
+    const delta = log.drainEmission();
+    expect(delta.appended).toEqual([]);
+    expect(delta.dirtied).toEqual([]);
+    expect(delta.textChunks).toEqual([]);
   });
 
   it('assigns one durable settlement order when rows become printable', () => {
@@ -131,75 +142,78 @@ describe('StreamLog', () => {
     expect(later.settlementSeqNo).toBe(3);
   });
 
-  it('tracks text appends separately from whole-entry updates', () => {
+  it('emits text appends as merged chunks, not dirtied entries', () => {
     const log = logWithMessage();
+    log.drainEmission();
 
     log.appendText('message', 'hello');
     log.appendText('message', ' world');
 
     expect(log.getRange(0, log.head)[0]?.text).toBe('hello world');
-    expect(log.getDirtyUpdates()).toEqual([]);
-    expect(log.getDirtyTextDeltas()).toEqual([
+    const delta = log.drainEmission();
+    expect(delta.dirtied).toEqual([]);
+    expect(delta.textChunks).toEqual([
       { id: 'message', appendText: 'hello world' },
     ]);
   });
 
-  it('builds text deltas across the joined prefix and chunk tail', () => {
+  it('starts a fresh chunk window after each drain, across materialization', () => {
     const log = logWithMessage();
+    log.drainEmission();
 
     log.appendText('message', 'hello');
     // Materialize the joined prefix, then keep streaming unjoined chunks:
-    // the delta must be assembled piecewise, not by re-joining the text.
+    // the chunk window is captured at append time, not re-derived from text.
     expect(log.getRange(0, log.head)[0]?.text).toBe('hello');
     log.appendText('message', ' wor');
     log.appendText('message', 'ld');
 
-    expect(log.getDirtyTextDeltas()).toEqual([
+    expect(log.drainEmission().textChunks).toEqual([
       { id: 'message', appendText: 'hello world' },
     ]);
 
-    log.ackDirtyTextDeltas(log.getDirtyTextDeltas());
     log.appendText('message', '!');
-    expect(log.getDirtyTextDeltas()).toEqual([
+    expect(log.drainEmission().textChunks).toEqual([
       { id: 'message', appendText: '!' },
     ]);
   });
 
-  it('keeps text appended while a delta frame is in flight', () => {
+  it('lets a same-window update supersede text chunks with its full value', () => {
+    const log = logWithMessage();
+    log.drainEmission();
+
+    log.appendText('message', 'hel');
+    log.update('message', { text: 'rewritten' });
+
+    const delta = log.drainEmission();
+    expect(delta.textChunks).toEqual([]);
+    expect(delta.dirtied.map((entry) => entry.text)).toEqual(['rewritten']);
+  });
+
+  it('folds same-window chunks into a newly appended entry by value', () => {
     const log = logWithMessage();
 
     log.appendText('message', 'hello');
-    const inFlight = log.getDirtyTextDeltas();
-    log.appendText('message', ' world');
-    log.ackDirtyTextDeltas(inFlight);
 
-    expect(log.getDirtyTextDeltas()).toEqual([
-      { id: 'message', appendText: ' world' },
-    ]);
+    const delta = log.drainEmission();
+    expect(delta.textChunks).toEqual([]);
+    expect(delta.dirtied).toEqual([]);
+    expect(delta.appended.map((entry) => entry.text)).toEqual(['hello']);
   });
 
-  it('drops pending text deltas when a full entry replay covers them', () => {
-    const log = logWithMessage();
+  it('carries chunks appended after a same-window update inside the dirtied value', () => {
+    const log = logWithMessage('base');
+    log.drainEmission();
 
-    log.appendText('message', 'hello');
-    const [entry] = log.getRange(0, log.head);
-    if (!entry) throw new Error('expected delivered entry');
-    log.ackDirtyTextDeltas([], [entry]);
+    log.update('message', { text: 'rewritten' });
+    log.appendText('message', ' plus');
 
-    expect(log.getDirtyTextDeltas()).toEqual([]);
-  });
-
-  it('keeps only text appended while a full entry replay is in flight', () => {
-    const log = logWithMessage('prefix ');
-
-    log.appendText('message', 'hello');
-    const [entry] = log.getRange(0, log.head);
-    if (!entry) throw new Error('expected delivered entry');
-    log.appendText('message', ' world');
-    log.ackDirtyTextDeltas([], [entry]);
-
-    expect(log.getDirtyTextDeltas()).toEqual([
-      { id: 'message', appendText: ' world' },
+    // The dirtied entry resolves to the current object at drain time, whose
+    // text already includes the trailing chunk — so the chunk is dropped.
+    const delta = log.drainEmission();
+    expect(delta.textChunks).toEqual([]);
+    expect(delta.dirtied.map((entry) => entry.text)).toEqual([
+      'rewritten plus',
     ]);
   });
 

--- a/src/test-kernel/transcript/StreamLogDelta.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogDelta.vitest.ts
@@ -1,8 +1,9 @@
 // The store-emitted entry-level change feed (#9946): every onChange
 // notification carries an immutable StreamLogDelta, drained once and
-// multicast — nothing is acked and nothing is destroyed, unlike the webview
-// dirty-update machinery. Consumers coalesce bursts with
-// StreamLogDeltaBuffer and rebuild from getRange(0) on any discontinuity.
+// multicast — nothing is acked and nothing is destroyed; this is the single
+// change-feed surface (#9969 deleted the webview ack/dirty protocol).
+// Consumers coalesce bursts with StreamLogDeltaBuffer and rebuild from
+// getRange(0) on any discontinuity.
 
 import { describe, expect, it } from 'vitest';
 
@@ -48,7 +49,7 @@ function captureDeltas(store: StreamLogStore): StreamLogDelta[] {
 }
 
 describe('StreamLogStore delta emission', () => {
-  it('emits appended entries, then dirtied entries by value, with a monotonic seq', () => {
+  it('emits appends by value, text appends as chunks, updates by value, with a monotonic seq', () => {
     const store = StreamLogStore.ephemeral('delta test');
     const deltas = captureDeltas(store);
 
@@ -61,16 +62,19 @@ describe('StreamLogStore delta emission', () => {
 
     expect(deltas[0].appended.map((entry) => entry.text)).toEqual(['hel']);
     expect(deltas[0].dirtied).toEqual([]);
+    expect(deltas[0].textChunks).toEqual([]);
 
+    // appendText emits a chunk instead of a dirtied entry by value.
     expect(deltas[1].appended).toEqual([]);
-    expect(deltas[1].dirtied.map((entry) => entry.text)).toEqual(['hello']);
+    expect(deltas[1].dirtied).toEqual([]);
+    expect(deltas[1].textChunks).toEqual([{ id: 'm1', appendText: 'lo' }]);
 
     expect(deltas[2].dirtied.map((entry) => entry.text)).toEqual(['hello!']);
+    expect(deltas[2].textChunks).toEqual([]);
 
     // By value: the captured payloads are the immutable post-mutation entry
     // objects, so later mutations must not rewrite an already-emitted delta.
     expect(deltas[0].appended[0].text).toBe('hel');
-    expect(deltas[1].dirtied[0].text).toBe('hello');
   });
 
   it('coalesces one commit covering several mutations into one delta', () => {
@@ -148,8 +152,16 @@ describe('StreamLogDeltaBuffer', () => {
     appended: StreamLogEntry[],
     dirtied: StreamLogEntry[] = [],
     reset = false,
+    textChunks: StreamLogDelta['textChunks'] = [],
   ): StreamLogDelta {
-    return { emissionSeq, appended, dirtied, reset };
+    return { emissionSeq, appended, dirtied, textChunks, reset };
+  }
+
+  function chunkDelta(
+    emissionSeq: number,
+    textChunks: StreamLogDelta['textChunks'],
+  ): StreamLogDelta {
+    return delta(emissionSeq, [], [], false, textChunks);
   }
 
   it('coalesces a contiguous burst, letting a dirtied value supersede its appended one', () => {
@@ -166,6 +178,50 @@ describe('StreamLogDeltaBuffer', () => {
     const drained = buffer.drain();
     expect(drained.appended).toEqual([superseded]);
     expect(drained.dirtied).toEqual([other]);
+    expect(drained.textChunks).toEqual([]);
+  });
+
+  it('merges buffered chunks per id and drains them alongside values', () => {
+    const buffer = new StreamLogDeltaBuffer(4);
+    buffer.push(delta(5, [entryAt(1, 'a', '')]));
+    buffer.push(chunkDelta(6, [{ id: 'a', appendText: 'hel' }]));
+    buffer.push(
+      chunkDelta(7, [
+        { id: 'a', appendText: 'lo' },
+        { id: 'b', appendText: '!' },
+      ]),
+    );
+
+    const drained = buffer.drain();
+    // Chunks postdate their id's buffered value: consumers apply
+    // appended/dirtied first, then append the chunks on top.
+    expect(drained.appended).toEqual([entryAt(1, 'a', '')]);
+    expect(drained.textChunks).toEqual([
+      { id: 'a', appendText: 'hello' },
+      { id: 'b', appendText: '!' },
+    ]);
+  });
+
+  it('drops buffered chunks when a later dirtied value supersedes them', () => {
+    const buffer = new StreamLogDeltaBuffer(4);
+    buffer.push(chunkDelta(5, [{ id: 'a', appendText: 'hel' }]));
+    const full = entryAt(1, 'a', 'rewritten');
+    buffer.push(delta(6, [], [full]));
+
+    const drained = buffer.drain();
+    expect(drained.dirtied).toEqual([full]);
+    expect(drained.textChunks).toEqual([]);
+  });
+
+  it('keeps chunks that arrive after a dirtied value', () => {
+    const buffer = new StreamLogDeltaBuffer(4);
+    const full = entryAt(1, 'a', 'rewritten');
+    buffer.push(delta(5, [], [full]));
+    buffer.push(chunkDelta(6, [{ id: 'a', appendText: ' plus' }]));
+
+    const drained = buffer.drain();
+    expect(drained.dirtied).toEqual([full]);
+    expect(drained.textChunks).toEqual([{ id: 'a', appendText: ' plus' }]);
   });
 
   it('marks a gap as requiring resync while still tracking the newest seq', () => {
@@ -183,7 +239,11 @@ describe('StreamLogDeltaBuffer', () => {
     buffer.push(delta(4, [entryAt(2, 'b', 'y')]));
 
     expect(buffer.resyncRequired).toBe(false);
-    expect(buffer.drain()).toEqual({ appended: [], dirtied: [] });
+    expect(buffer.drain()).toEqual({
+      appended: [],
+      dirtied: [],
+      textChunks: [],
+    });
   });
 
   it('treats a reset emission as requiring resync', () => {

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -41,6 +41,15 @@ export interface StreamLogDelta {
    */
   readonly dirtied: readonly StreamLogEntry[];
   /**
+   * Streaming-text appends since the previous emission, merged to one chunk
+   * per entry id. An `appendText` mutation emits here *instead of* `dirtied`.
+   * An entry present in `appended`/`dirtied` already carries its full current
+   * text, so no id appears both by value and as a chunk within one delta —
+   * and across deltas, an entry-by-value supersedes any chunks a consumer
+   * has buffered for its id.
+   */
+  readonly textChunks: readonly StreamLogTextDelta[];
+  /**
    * The stream's log instance was replaced (disk history merged under live
    * appends), renumbering seqNos. Consumers must resync, not fold.
    */
@@ -59,6 +68,9 @@ export class StreamLogDeltaBuffer {
   private appended: StreamLogEntry[] = [];
   private readonly appendedIndexById = new Map<string, number>();
   private readonly dirtiedById = new Map<string, StreamLogEntry>();
+  /** Buffered streaming-text chunks per id, in arrival order. Cleared for an
+   *  id when a later entry-by-value supersedes them. */
+  private readonly textChunksById = new Map<string, string[]>();
   private lastSeq: number;
   private needsResync = false;
 
@@ -99,6 +111,9 @@ export class StreamLogDeltaBuffer {
       this.appended.push(entry);
     }
     for (const entry of delta.dirtied) {
+      // The by-value entry carries its full current text: chunks buffered
+      // from earlier emissions are already included, so drop them.
+      this.textChunksById.delete(entry.id);
       const appendedIndex = this.appendedIndexById.get(entry.id);
       if (appendedIndex !== undefined) {
         this.appended[appendedIndex] = entry;
@@ -106,18 +121,40 @@ export class StreamLogDeltaBuffer {
         this.dirtiedById.set(entry.id, entry);
       }
     }
+    for (const chunk of delta.textChunks) {
+      const chunks = this.textChunksById.get(chunk.id);
+      if (chunks) {
+        chunks.push(chunk.appendText);
+      } else {
+        this.textChunksById.set(chunk.id, [chunk.appendText]);
+      }
+    }
   }
 
-  /** The coalesced changes, dirtied in seqNo order. Call once, then discard. */
-  drain(): { appended: StreamLogEntry[]; dirtied: StreamLogEntry[] } {
+  /**
+   * The coalesced changes, dirtied in seqNo order. Call once, then discard.
+   * Apply `appended`/`dirtied` before `textChunks`: buffered chunks for an id
+   * always postdate its buffered value (a later value deletes earlier
+   * chunks), so chunks append on top of the value.
+   */
+  drain(): {
+    appended: StreamLogEntry[];
+    dirtied: StreamLogEntry[];
+    textChunks: StreamLogTextDelta[];
+  } {
     const dirtied = [...this.dirtiedById.values()].sort(
       (a, b) => a.seqNo - b.seqNo,
     );
+    const textChunks = [...this.textChunksById].map(([id, chunks]) => ({
+      id,
+      appendText: chunks.join(''),
+    }));
     const appended = this.appended;
     this.appended = [];
     this.appendedIndexById.clear();
     this.dirtiedById.clear();
-    return { appended, dirtied };
+    this.textChunksById.clear();
+    return { appended, dirtied, textChunks };
   }
 }
 
@@ -142,35 +179,6 @@ function materializeText(acc: StreamingTextAccumulator, end: number): string {
     acc.chunks.length = 0;
   }
   return end === acc.joined.length ? acc.joined : acc.joined.slice(0, end);
-}
-
-/**
- * Read `[from, end)` from the accumulator without collapsing its chunk tail:
- * the webview delta path calls this at render cadence during streaming, and
- * materializing there would re-copy the whole joined prefix per frame. The
- * chunk walk stays short because every throttled save materializes (via the
- * persisted entries' `text` getters) and resets the tail.
- */
-function sliceAccumulatedText(
-  acc: StreamingTextAccumulator,
-  from: number,
-  end: number,
-): string {
-  if (end <= acc.joined.length) return acc.joined.slice(from, end);
-  const parts: string[] = [];
-  if (from < acc.joined.length) parts.push(acc.joined.slice(from));
-  let pos = acc.joined.length;
-  for (const chunk of acc.chunks) {
-    if (pos >= end) break;
-    const next = pos + chunk.length;
-    if (next > from) {
-      parts.push(
-        chunk.slice(Math.max(0, from - pos), Math.min(chunk.length, end - pos)),
-      );
-    }
-    pos = next;
-  }
-  return parts.join('');
 }
 
 /**
@@ -256,7 +264,6 @@ export class StreamLog {
   private readonly preservedRawEntries: StreamLogPreservedRawEntry[] = [];
   private seqCounter = 0;
   private readonly indexById = new Map<string, number>();
-  private readonly dirtyUpdates = new Set<string>();
   /**
    * Per-entry chunk accumulators for in-flight streaming text. An entry whose
    * id is present here carries a lazy `text` getter over the accumulator;
@@ -264,15 +271,16 @@ export class StreamLog {
    * accumulator, so persisted and settled entries are always plain.
    */
   private readonly streamingText = new Map<string, StreamingTextAccumulator>();
-  /**
-   * Offset into an entry's text where the webview's unacked text-delta window
-   * starts, keyed by id. The delta itself is a slice of the one canonical
-   * text, replacing the old second accumulated delta string per entry.
-   */
-  private readonly dirtyTextFrom = new Map<string, number>();
   private emissionSeqCounter = 0;
   private pendingAppendedIds: string[] = [];
   private readonly pendingDirtiedIds = new Set<string>();
+  /**
+   * Streaming-text appends since the last drain, per id in arrival order.
+   * Drained into the emission's `textChunks` arm — except for ids the same
+   * emission carries by value (`appended`/`dirtied`), whose current text
+   * already includes them.
+   */
+  private readonly pendingTextChunks = new Map<string, string[]>();
   private settlementSeqCounter = 0;
   private runningGroupCount = 0;
   private runningStreamingTextCount = 0;
@@ -355,7 +363,9 @@ export class StreamLog {
    */
   get hasUndrainedChanges(): boolean {
     return (
-      this.pendingAppendedIds.length > 0 || this.pendingDirtiedIds.size > 0
+      this.pendingAppendedIds.length > 0 ||
+      this.pendingDirtiedIds.size > 0 ||
+      this.pendingTextChunks.size > 0
     );
   }
 
@@ -369,18 +379,30 @@ export class StreamLog {
     const emissionSeq = ++this.emissionSeqCounter;
     if (
       this.pendingAppendedIds.length === 0 &&
-      this.pendingDirtiedIds.size === 0
+      this.pendingDirtiedIds.size === 0 &&
+      this.pendingTextChunks.size === 0
     ) {
-      return { emissionSeq, appended: [], dirtied: [] };
+      return { emissionSeq, appended: [], dirtied: [], textChunks: [] };
     }
     const appendedIds = new Set(this.pendingAppendedIds);
     const appended = this.resolveEntries(this.pendingAppendedIds);
     const dirtied = this.resolveEntries(
       [...this.pendingDirtiedIds].filter((id) => !appendedIds.has(id)),
     ).sort((a, b) => a.seqNo - b.seqNo);
+    // An entry emitted by value resolves to its *current* object, whose text
+    // already includes every chunk accumulated in this window — emitting its
+    // chunks too would double-apply them, so they are dropped here. This is
+    // the precedence rule consumers rely on: value supersedes chunks.
+    const textChunks: StreamLogTextDelta[] = [];
+    for (const [id, chunks] of this.pendingTextChunks) {
+      if (!appendedIds.has(id) && !this.pendingDirtiedIds.has(id)) {
+        textChunks.push({ id, appendText: chunks.join('') });
+      }
+    }
     this.pendingAppendedIds = [];
     this.pendingDirtiedIds.clear();
-    return { emissionSeq, appended, dirtied };
+    this.pendingTextChunks.clear();
+    return { emissionSeq, appended, dirtied, textChunks };
   }
 
   /** Current entry objects for `ids`; entries are never removed, so every id resolves. */
@@ -491,8 +513,6 @@ export class StreamLog {
 
     this.entries[index] = updated;
     this.streamingText.delete(id);
-    this.dirtyUpdates.add(id);
-    this.dirtyTextFrom.delete(id);
     this.pendingDirtiedIds.add(id);
     return updated;
   }
@@ -519,10 +539,12 @@ export class StreamLog {
 
     const updated = entryWithLazyText(current, acc, acc.length);
     this.entries[index] = updated;
-    if (!this.dirtyUpdates.has(id) && !this.dirtyTextFrom.has(id)) {
-      this.dirtyTextFrom.set(id, acc.length - appendText.length);
+    const chunks = this.pendingTextChunks.get(id);
+    if (chunks) {
+      chunks.push(appendText);
+    } else {
+      this.pendingTextChunks.set(id, [appendText]);
     }
-    this.pendingDirtiedIds.add(id);
     return updated;
   }
 
@@ -533,130 +555,10 @@ export class StreamLog {
     return this.entries.slice(safeFrom, safeTo);
   }
 
-  getDirtyUpdates(maxSeqInclusive: number = this.seqCounter): StreamLogEntry[] {
-    const updates: StreamLogEntry[] = [];
-    for (const id of this.dirtyUpdates) {
-      const index = this.indexById.get(id);
-      if (index === undefined) {
-        this.dirtyUpdates.delete(id);
-        continue;
-      }
-      const entry = this.entries[index];
-      if (entry.seqNo <= maxSeqInclusive) {
-        updates.push(entry);
-      }
-    }
-    updates.sort((a, b) => a.seqNo - b.seqNo);
-    return updates;
-  }
-
-  getDirtyTextDeltas(
-    maxSeqInclusive: number = this.seqCounter,
-  ): StreamLogTextDelta[] {
-    const deltas: Array<{
-      delta: StreamLogTextDelta;
-      seqNo: number;
-    }> = [];
-    for (const [id, from] of this.dirtyTextFrom) {
-      const index = this.indexById.get(id);
-      if (index === undefined) {
-        this.dirtyTextFrom.delete(id);
-        continue;
-      }
-      const entry = this.entries[index];
-      if (entry.seqNo <= maxSeqInclusive) {
-        const acc = this.streamingText.get(id);
-        deltas.push({
-          delta: {
-            id,
-            appendText: acc
-              ? sliceAccumulatedText(acc, from, acc.length)
-              : (entry.text ?? '').slice(from),
-          },
-          seqNo: entry.seqNo,
-        });
-      }
-    }
-    deltas.sort((a, b) => a.seqNo - b.seqNo);
-    return deltas.map(({ delta }) => delta);
-  }
-
-  clearDirtyUpdates(maxSeqInclusive: number = this.seqCounter): void {
-    for (const dirty of [this.dirtyUpdates, this.dirtyTextFrom] as const) {
-      for (const id of dirty.keys()) {
-        const index = this.indexById.get(id);
-        if (
-          index === undefined ||
-          this.entries[index].seqNo <= maxSeqInclusive
-        ) {
-          dirty.delete(id);
-        }
-      }
-    }
-  }
-
-  ackDirtyUpdates(updates: readonly StreamLogEntry[]): void {
-    for (const update of updates) {
-      const index = this.indexById.get(update.id);
-      if (index === undefined || this.entries[index] === update) {
-        this.dirtyUpdates.delete(update.id);
-      }
-    }
-  }
-
-  ackDirtyTextDeltas(
-    deltas: readonly StreamLogTextDelta[],
-    fullEntries: readonly StreamLogEntry[] = [],
-  ): void {
-    for (const entry of fullEntries) {
-      const index = this.indexById.get(entry.id);
-      if (index === undefined || this.entries[index] === entry) {
-        this.dirtyTextFrom.delete(entry.id);
-        continue;
-      }
-
-      const from = this.dirtyTextFrom.get(entry.id);
-      if (from === undefined) continue;
-      const currentText = this.entries[index].text ?? '';
-      const deliveredText = typeof entry.text === 'string' ? entry.text : '';
-      // A full-entry frame covers all appended text up to the delivered
-      // text's length, even if later appends replaced the row.
-      if (
-        deliveredText.length > from &&
-        currentText.startsWith(deliveredText)
-      ) {
-        if (deliveredText.length >= currentText.length) {
-          this.dirtyTextFrom.delete(entry.id);
-        } else {
-          this.dirtyTextFrom.set(entry.id, deliveredText.length);
-        }
-      }
-    }
-
-    for (const delta of deltas) {
-      const from = this.dirtyTextFrom.get(delta.id);
-      if (from === undefined) continue;
-      const index = this.indexById.get(delta.id);
-      if (index === undefined) {
-        this.dirtyTextFrom.delete(delta.id);
-        continue;
-      }
-      const currentText = this.entries[index].text ?? '';
-      const end = from + delta.appendText.length;
-      // Advance only when the delivered frame still matches the canonical
-      // text at the window start (an interleaved update() resets the window).
-      if (
-        end > currentText.length ||
-        !currentText.startsWith(delta.appendText, from)
-      ) {
-        continue;
-      }
-      if (end === currentText.length) {
-        this.dirtyTextFrom.delete(delta.id);
-      } else {
-        this.dirtyTextFrom.set(delta.id, end);
-      }
-    }
+  /** The current (immutable, post-mutation) entry object for `id`, if any. */
+  getById(id: string): StreamLogEntry | undefined {
+    const index = this.indexById.get(id);
+    return index === undefined ? undefined : this.entries[index];
   }
 
   toJSON(): StreamLogEntry[] {

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -794,11 +794,6 @@ export class StreamLogStore {
     return updated;
   }
 
-  clearDirtyUpdates(streamId: StreamTabId): void {
-    this.assertWritableStore('clear transcript update state');
-    this.streams.get(streamId)?.log?.clearDirtyUpdates();
-  }
-
   getFirstTimestamp(streamId: StreamTabId): number | undefined {
     return (
       this.streams.get(streamId)?.log?.firstTimestamp ??
@@ -1385,8 +1380,8 @@ export class StreamLogStore {
    * Drain the log's pending entry-level changes into one immutable delta and
    * multicast it. The delta is drained exactly once per notification and
    * shared by every listener; no listener acks anything and nothing here is
-   * destructive, unlike the webview ack machinery (`getDirtyUpdates` et al.),
-   * which stays a separate per-consumer channel.
+   * destructive — this is the single change-feed surface, and consumers that
+   * miss or lose a delta resync from `getRange(0)`.
    */
   private notify(
     streamId: StreamTabId,


### PR DESCRIPTION
Fixes #9969.

Removes the deliberate transitional dual change-channel introduced by #9967: `StreamLog` no longer carries both the multicast `StreamLogDelta` feed and the webview's private, destructive ack/dirty protocol. The delta feed is now the single change-feed surface for every consumer (CLI fold and WebviewBridge).

## What changed

**Delta contract (`src/transcript/StreamLog.ts`)** — `StreamLogDelta` gains the PRD's `textChunks` arm (`docs/prds/2026-08-11-transcript-memory-architecture.md`): `appendText` emits `{id, appendText}` chunks *instead of* a full dirtied entry. Precedence rule, enforced at both ends: an entry emitted by value supersedes chunks for its id — `drainEmission` drops same-window chunks for ids in `appended`/`dirtied` (the resolved current value already includes them), and `StreamLogDeltaBuffer` deletes buffered chunks when a later by-value entry arrives, while chunks arriving after a value are kept and applied on top.

**WebviewBridge port (`src/controllers/progressView/backend/WebviewBridge.ts`)** — consumes the delta feed through a per-stream `StreamLogDeltaBuffer` instead of `getRange(cursor)` + `getDirtyUpdates` + `getDirtyTextDeltas` + acks. The webview-facing `LOG_DELTA` wire protocol is byte-identical (`entries`/`updates`/`textDeltas`); this PR is store-to-bridge only. The explicit resync handshake is preserved: `syncStream` registration, a detected emission gap/reset, and any failed `postMessage` all replay `getRange(0)` from scratch — the same oracle path a from-scratch projection uses — so the no-ack multicast can never leave a disposed-and-restored view stale. The resync's replacement buffer is based at the emission head read in the same synchronous snapshot as `getRange(0)`, so deltas emitted during async delivery fold on top of exactly that frame (no livelock under continuous streaming, no double-apply).

**Deleted in the same PR (no re-export shims):**
- `StreamLog`: `dirtyUpdates` set, `dirtyTextFrom` map, `getDirtyUpdates`, `ackDirtyUpdates`, `getDirtyTextDeltas`, `ackDirtyTextDeltas`, `clearDirtyUpdates`, and the `sliceAccumulatedText` helper (its only caller died)
- `StreamLogStore`: the `clearDirtyUpdates` pass-through
- `WebviewBridge`: the private cursor and `ProgressLogSource` pick
- Every test asserting the old ack contract, replaced with delta-contract equivalents

**CLI fold (`packages/cli/.../subscribeStreamLog.ts`, minimal footprint)** — the fold applies whole entry values, so drained `textChunks` are resolved to their entries' current objects via the new `StreamLog.getById`. This is exactly the old dirtied-by-value semantics: `canFold` pins the buffer at the log's emission head, so current values are the post-burst state the chunks stream toward. Fold-vs-oracle harness stays green.

**Desktop** — consumes the same `ProgressBackend`/`WebviewBridge` controllers; grep confirms zero references to the deleted ack surface anywhere in `packages/desktop` (or anywhere else).

## Element accounting

Deleted: 2 tracking fields + 5 `StreamLog` methods + 1 helper function + 1 store pass-through + 1 bridge-local type + the bridge's cursor bookkeeping = **10 elements**.
Added: `StreamLogDelta.textChunks` field, `StreamLog.pendingTextChunks` field, `StreamLog.getById`, buffer `textChunksById` field = **4 elements**.
Net: **-6 elements**; production LoC net **-62** (`StreamLog.ts` +74/-172, `WebviewBridge.ts` +75/-56, `StreamLogStore.ts` +2/-7, CLI +28/-6).

## Tests

- `StreamLogDelta.vitest.ts`: `textChunks` emission, value-supersedes-chunks in both directions (drain-window and buffer), chunk merging per id.
- `StreamLog.vitest.ts`: ack-contract tests rewritten as `drainEmission` contract tests, including same-window append/update/appendText precedence in every order.
- `WebviewBridge.vitest.ts`: full lifecycle (append → chunk frames → settle) asserting the exact wire frame sequence; mid-stream reconnect replays from scratch; failed delivery resyncs through the oracle path instead of relying on store-side retention.
- `StreamLogDeltaFold.vitest.ts`: op corpus extended with a non-terminal in-place update on a still-streaming row, so the equivalence property covers chunks landing after a buffered value.
- Full `src/test-kernel/transcript` + `progressView` + `cli` suites: 218 files, 3093 tests passing. `npm run typecheck` green across all packages; lint and dead-code ratchet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gtc6wQMD1hedgabjQMfAun

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live transcript streaming for CLI and progress webview; correctness depends on chunk/value precedence and resync on delivery failure, though behavior is heavily tested and the webview protocol is unchanged.
> 
> **Overview**
> **Unifies transcript change notification on the multicast `StreamLogDelta` feed** and removes the old per-consumer ack/dirty path on `StreamLog` / `StreamLogStore`.
> 
> `StreamLogDelta` now includes **`textChunks`**: `appendText` emits merged `{id, appendText}` chunks instead of dirtied full entries. **Entry-by-value supersedes chunks** for the same id (enforced in `drainEmission` and `StreamLogDeltaBuffer`). `appendText` no longer marks rows dirty; **`getById`** is added for consumers that need the live entry object.
> 
> **`WebviewBridge`** folds store deltas through **`StreamLogDeltaBuffer`** instead of cursor + `getDirtyUpdates` / `getDirtyTextDeltas` + acks. The **`LOG_DELTA`** wire shape is unchanged. **Resync** on `syncStream`, emission gaps/resets, or failed `postMessage` replays **`getRange(0)`**; failed delivery clears the buffer so the next flush cannot leave the webview stale.
> 
> **CLI transcript fold** resolves drained **`textChunks`** to current entries via **`getById`** before applying whole-entry fold logic.
> 
> Tests are updated/extended for the delta contract, bridge lifecycle/resync, and fold-vs-oracle coverage (including in-place updates while streaming).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a3d1ec85db1b43d187190bff532706b876ee3b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->