### PR TITLE
test: drop 2 tautological/duplicate tests

### DIFF
--- a/src/test-kernel/cli/ConfigForm.vitest.ts
+++ b/src/test-kernel/cli/ConfigForm.vitest.ts
@@ -8,7 +8,6 @@ import {
   buildConfigListItems,
   buildEnumItems,
   coerceSettingInput,
-  ConfigForm,
   formatSettingValue,
   isConfigResetInput,
   settingDisplayName,
@@ -459,9 +458,6 @@ describe('ConfigForm helpers', () => {
     expect(items[0]?.description).toBeTruthy();
   });
 
-  it('exports a renderable component', () => {
-    expect(typeof ConfigForm).toBe('function');
-  });
 });
 
 describe('CliConfigForm API-key status lifecycle', () => {

--- a/src/test-kernel/shared/SharedStreams.vitest.ts
+++ b/src/test-kernel/shared/SharedStreams.vitest.ts
@@ -224,15 +224,6 @@ describe('stream status display labels', () => {
     },
   );
 
-  it('labels a WAITING child stream with the same "idle" wording as the root', () => {
-    expect(
-      formatStreamStatusLabel(STREAM_PHASE.WAITING, { style: 'cli' }),
-    ).toBe('idle');
-    expect(
-      formatStreamStatusLabel(STREAM_PHASE.WAITING, { style: 'cliCompact' }),
-    ).toBe('idle');
-  });
-
   const substateWordingCases: Array<[StreamStatusLabelStyle, string]> = [
     ['cli', 'starting\u2026'],
     ['cliCompact', 'starting'],


### PR DESCRIPTION
## What

An exhaustive sweep of `src/test-kernel/` (853 files / 232k LOC, divided across 40 agents) found only **2 genuinely useless tests** — the rest of the suite is healthy.

## The 2 deletions (−13 LOC)

- **`ConfigForm.vitest.ts` — "exports a renderable component"**
  Asserted `typeof ConfigForm === 'function'`, but the file already imports `ConfigForm`, so the import itself proves the symbol exists. Tautological. The now-unused import is removed too.
- **`SharedStreams.vitest.ts` — "labels a WAITING child stream with the same 'idle' wording as the root"**
  Exact duplicate: `formatStreamStatusLabel` takes no child-stream parameter, so the `WAITING → 'idle'` case for both styles is already covered by the parameterized `wordingCases` table in the same `describe` block. The "child stream" framing was pure commentary.

## Why so little

The premise was "many tests are useless." The sweep falsifies that: 199 candidates were examined and explicitly kept (each with a cited reason), and 27 of 40 slices were entirely clean — not even a candidate worth flagging. The suspicious grep signals that prompted the sweep (`it`-count > `expect`-count, lots of `toBeTruthy()`) are real tests:
- high `it`/`expect` ratios come from helper assertion functions (`assertX`, custom matchers),
- `toBeTruthy()` calls are DOM/element existence checks.

What the suite actually contains: issue-numbered regression guards, architecture ratchets with `do-not-fold` comments, race-regression matrices, and billing/security-critical tests with documented rulings. Coverage-conservative judgment kept all of it.

## Verification

- Per-file `vitest run` green after each deletion.
- Full suite: **852 files / 9894 tests passed** (0 fail).

Net-negative, 0 behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f3f772d8c7809cb0b7cb55ade8ca14a845fe72cb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->