### PR TITLE
fix(cli): loud invariant throw in the textChunks fold resolution

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -1400,8 +1400,15 @@ export function syncStreamLog(
         );
         for (const chunk of changes.textChunks) {
           // `canFold` pinned the log instance and emission head, so a chunk's
-          // id always resolves to a live entry — `getById` cannot miss here.
-          const current = log.getById(chunk.id)!;
+          // id always resolves to a live entry. A miss means the fold
+          // invariant broke upstream — fail loudly instead of letting
+          // `undefined` corrupt the fold state (#9985 review finding).
+          const current = log.getById(chunk.id);
+          if (!current) {
+            throw new Error(
+              `Transcript fold invariant violation: text chunk for unknown entry ${chunk.id} in stream ${streamId}`,
+            );
+          }
           const appendedIndex = appendedIndexById.get(chunk.id);
           if (appendedIndex !== undefined) {
             appended[appendedIndex] = current;


### PR DESCRIPTION
Addresses the non-blocking review finding on #9985: `log.getById(chunk.id)!` silently propagated `undefined` if the fold invariant (`canFold` pinning instance + emission head) were ever broken. Now a miss throws a descriptive invariant error, surfaced through `trySyncStreamLog`'s existing transient-notice path — loud failure instead of corrupted fold state, per the repo's silent-degradation rule.

One-line behavior change; fold-vs-oracle harness and CLI typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gtc6wQMD1hedgabjQMfAun

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive hardening of a rare invariant-failure path only; normal fold behavior is unchanged and errors already surface via the existing notice handler.
> 
> **Overview**
> Replaces `log.getById(chunk.id)!` in the transcript fold's text-chunk resolution with an explicit miss check that throws a descriptive invariant error.
> 
> If the `canFold` pinning invariant is ever broken upstream, the miss now fails loudly through `trySyncStreamLog`'s existing transient-notice path instead of letting `undefined` corrupt fold state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64e63ce45e5ddd136d95429f616ad229191081b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->