### PR TITLE
chore: shrink dead-code baseline

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -77,16 +77,6 @@
       "name": "packages/trace-viewer/vite.standalone.config.ts"
     },
     {
-      "file": "src/common/errors/sdkError/chatgptSubscriptionDetection.ts",
-      "category": "files",
-      "name": "src/common/errors/sdkError/chatgptSubscriptionDetection.ts"
-    },
-    {
-      "file": "src/controllers/modelAccess/chatGptAuthStatus.ts",
-      "category": "files",
-      "name": "src/controllers/modelAccess/chatGptAuthStatus.ts"
-    },
-    {
       "file": "src/test-kernel/support/setupFakePlatform.ts",
       "category": "files",
       "name": "src/test-kernel/support/setupFakePlatform.ts"


### PR DESCRIPTION
Closes #9992.

## What changed

Removed two obsolete file entries from the knip baseline. The 17 findings reported by the original sweep have already been removed on `main`; these were the remaining stale allowances for files that have since gained live consumers and are no longer reported by knip.

## Impact

The dead-code ratchet now represents the current 16 intentional findings exactly. This is a maintenance-only change with no runtime behavior change.

## Validation

- `corepack pnpm run check:dead-code-ratchet`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Maintenance-only baseline cleanup with no code or runtime behavior changes.
> 
> **Overview**
> Removes two stale unused-file entries from `knip-baseline.json` for `chatgptSubscriptionDetection.ts` and `chatGptAuthStatus.ts`, which knip no longer reports.
> 
> Tightens the dead-code ratchet to the current intentional findings only. No runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26375560b92f7b33066b94a3b17c33f0eaef9f5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->