### PR TITLE
refactor: remove dead webview IPC arms

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -2,11 +2,6 @@
   "semantics": "Per-symbol baseline of knip dead-code findings (files/exports/types/duplicate-export groups), each identified by (file, category, name) -- never by line number, so unrelated edits that shift lines never spuriously mark a baseline entry as fixed. The ratchet (scripts/check-dead-code-ratchet.mjs) fails only when the current knip run contains a finding not in this list. Removing entries here is always welcome (it means the dead code was cleaned up); a genuinely new unused file/export/type must either be deleted or, if intentionally kept, added here in the same PR. Regenerate by piping `knip --reporter json` through extractFindings() and sorting with compareFindings(); do not hand-edit into disorder.",
   "findings": [
     {
-      "file": "packages/desktop/src/main/desktopCrashReporting.ts",
-      "category": "exports",
-      "name": "scrubDesktopCrashEvent"
-    },
-    {
       "file": "packages/desktop/src/main/desktopNavigationPolicy.ts",
       "category": "exports",
       "name": "isAllowedExternalUrl"

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -834,7 +834,6 @@ export class DesktopProgressBridge {
         },
         file: {
           openFile: (file, line) => this.options.host.openPath(file, line),
-          openFileCompile: (file) => this.openFileCompile(file),
         },
         approval: {
           approvePendingDelegatedWork: (stream, initiatingProposalId) =>
@@ -995,13 +994,6 @@ export class DesktopProgressBridge {
           await this.reportRecordingError(toErrorMessage(error));
           this.postRecordingStatus({ status: 'stopped' });
         }
-      },
-      // Settings navigation
-      openMemoryView: () => {
-        this.showSettings(SETTINGS_TAB.MEMORY);
-      },
-      openProfile: () => {
-        this.showSettings();
       },
       // Pop-out-to-editor is a VS Code editor-tab concept; the desktop app is
       // a single window.
@@ -1251,10 +1243,6 @@ export class DesktopProgressBridge {
         });
       });
     return Promise.resolve();
-  }
-
-  openFileCompile(filePath: string): Promise<void> {
-    return this.fileActions.openFileCompile(filePath);
   }
 
   /**

--- a/packages/desktop/src/main/desktopCrashEventScrubber.ts
+++ b/packages/desktop/src/main/desktopCrashEventScrubber.ts
@@ -1,0 +1,51 @@
+import escapeRegExp from 'escape-string-regexp';
+import { unique } from '@utils/core';
+import type { ErrorEvent } from '@sentry/electron/main';
+
+const REDACTED_PATH = '<redacted-path>';
+
+function pathVariants(path: string): string[] {
+  const trimmed = path.trim();
+  if (!trimmed) return [];
+  const forward = trimmed.replaceAll('\\', '/');
+  const backward = forward.replaceAll('/', '\\');
+  return unique([trimmed, forward, backward]);
+}
+
+function scrubValue(value: unknown, scrubbers: readonly RegExp[]): unknown {
+  if (typeof value === 'string') {
+    return scrubbers.reduce(
+      (current, scrubber) => current.replace(scrubber, REDACTED_PATH),
+      value,
+    );
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => scrubValue(item, scrubbers));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        scrubbers.reduce(
+          (current, scrubber) => current.replace(scrubber, REDACTED_PATH),
+          key,
+        ),
+        scrubValue(entry, scrubbers),
+      ]),
+    );
+  }
+  return value;
+}
+
+export function createDesktopCrashEventScrubber(
+  sensitivePaths: readonly (string | undefined)[],
+): (event: ErrorEvent) => ErrorEvent | null {
+  const scrubbers = sensitivePaths
+    .flatMap((path) => (path ? pathVariants(path) : []))
+    .filter((path) => path.length > 1)
+    .sort((a, b) => b.length - a.length)
+    .map((path) => new RegExp(escapeRegExp(path), 'gi'));
+  return (event) => {
+    if (event.platform !== 'native') return null;
+    return scrubValue(event, scrubbers) as ErrorEvent;
+  };
+}

--- a/packages/desktop/src/main/desktopCrashReporting.ts
+++ b/packages/desktop/src/main/desktopCrashReporting.ts
@@ -1,70 +1,8 @@
-import escapeRegExp from 'escape-string-regexp';
-import { unique } from '@utils/core';
-import type { ErrorEvent } from '@sentry/electron/main';
-
-const REDACTED_PATH = '<redacted-path>';
+import { createDesktopCrashEventScrubber } from './desktopCrashEventScrubber.js';
 
 export interface DesktopCrashReportingInitOptions {
   sensitivePaths: readonly (string | undefined)[];
   log?: Pick<Console, 'debug' | 'error'>;
-}
-
-function pathVariants(path: string): string[] {
-  const trimmed = path.trim();
-  if (!trimmed) return [];
-  const forward = trimmed.replaceAll('\\', '/');
-  const backward = forward.replaceAll('/', '\\');
-  return unique([trimmed, forward, backward]);
-}
-
-function buildPathScrubbers(paths: readonly (string | undefined)[]): RegExp[] {
-  return paths
-    .flatMap((path) => (path ? pathVariants(path) : []))
-    .filter((path) => path.length > 1)
-    .sort((a, b) => b.length - a.length)
-    .map((path) => new RegExp(escapeRegExp(path), 'gi'));
-}
-
-function scrubString(value: string, scrubbers: readonly RegExp[]): string {
-  return scrubbers.reduce(
-    (current, scrubber) => current.replace(scrubber, REDACTED_PATH),
-    value,
-  );
-}
-
-function scrubValue(value: unknown, scrubbers: readonly RegExp[]): unknown {
-  if (typeof value === 'string') {
-    return scrubString(value, scrubbers);
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => scrubValue(item, scrubbers));
-  }
-  if (value && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, entry]) => [
-        scrubString(key, scrubbers),
-        scrubValue(entry, scrubbers),
-      ]),
-    );
-  }
-  return value;
-}
-
-export function scrubDesktopCrashEvent(
-  event: ErrorEvent,
-  sensitivePaths: readonly (string | undefined)[],
-): ErrorEvent | null {
-  return createDesktopCrashEventScrubber(sensitivePaths)(event);
-}
-
-function createDesktopCrashEventScrubber(
-  sensitivePaths: readonly (string | undefined)[],
-): (event: ErrorEvent) => ErrorEvent | null {
-  const scrubbers = buildPathScrubbers(sensitivePaths);
-  return (event) => {
-    if (event.platform !== 'native') return null;
-    return scrubValue(event, scrubbers) as ErrorEvent;
-  };
 }
 
 /**

--- a/packages/desktop/src/main/desktopProgressFileActions.ts
+++ b/packages/desktop/src/main/desktopProgressFileActions.ts
@@ -65,14 +65,6 @@ export class DesktopProgressFileActions {
     private readonly host: DesktopProgressFileActionHost,
   ) {}
 
-  openFileCompile(filePath: string): Promise<void> {
-    return this.ui.openBuildDisplay(
-      path.isAbsolute(filePath)
-        ? createExternalLocation(filePath)
-        : pathToLocation(filePath),
-    );
-  }
-
   async compareFiles(baseFile: string, editedFile: string): Promise<void> {
     await this.ui.openDiff(
       { filePath: baseFile },

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -13,11 +13,7 @@ import {
   type DesktopMessageHandler,
 } from './desktopIpcTypes.js';
 
-const PASS_THROUGH_COMMANDS = [
-  PROGRESS_VIEW_COMMANDS.SWITCH_VIEW,
-  PROGRESS_VIEW_COMMANDS.THEME_SET,
-  PROGRESS_VIEW_COMMANDS.DEBUG_MODE_SET,
-] as const;
+const PASS_THROUGH_COMMANDS = [PROGRESS_VIEW_COMMANDS.SWITCH_VIEW] as const;
 
 type DesktopProgressIpcOwnedCommand =
   | typeof PROGRESS_VIEW_COMMANDS.WEBVIEW_READY

--- a/packages/extension/src/common/webview/BaseWebviewProvider.ts
+++ b/packages/extension/src/common/webview/BaseWebviewProvider.ts
@@ -35,30 +35,6 @@ export abstract class BaseWebviewProvider {
 
   constructor(protected readonly context: vscode.ExtensionContext) {}
 
-  /**
-   * Returns the view folder name for resource roots.
-   * Subclasses should override this to specify their view path.
-   * Used by resolveWebviewView to set up localResourceRoots.
-   */
-  protected getViewPath(): string | undefined {
-    return undefined;
-  }
-
-  public resolveWebviewView(
-    webviewView: vscode.WebviewView,
-    _context: vscode.WebviewViewResolveContext,
-    _token: vscode.CancellationToken,
-  ): void {
-    const viewPath = this.getViewPath();
-    if (viewPath) {
-      webviewView.webview.options = {
-        enableScripts: true,
-        localResourceRoots: getSharedLocalResourceRoots(this.context, viewPath),
-      };
-    }
-    this.resolveWebviewViewInternal(webviewView);
-  }
-
   protected resolveWebviewViewInternal(
     webviewView: vscode.WebviewView | vscode.WebviewPanel,
   ): void {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -166,15 +166,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
    * Each handler receives typed data - no casts or validation needed.
    */
   private createHandlerRegistry(): ProgressViewInboundHandlerRegistry {
-    const forwardToActiveView = (message: ProgressViewInboundMessage) => {
-      this.postToActiveView(message);
-    };
-    const runCommand = (command: string, ...args: unknown[]) => {
-      return async () => {
-        await this.runViewCommand(command, args);
-      };
-    };
-
     // Set for the duration of a POLISH_FOLLOW_UP notification below, so the
     // shared handler's stage reports land in the open progress notification.
     let polishProgress: vscode.Progress<{ message?: string }> | undefined;
@@ -255,8 +246,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           await this.provider.markWebviewReady(view);
         }
       },
-      [PROGRESS_VIEW_COMMANDS.THEME_SET]: forwardToActiveView,
-      [PROGRESS_VIEW_COMMANDS.DEBUG_MODE_SET]: forwardToActiveView,
       [COMMON_COMMANDS.SWITCH_VIEW]: (data) => this.switchView(data),
       [PROGRESS_VIEW_COMMANDS.POP_OUT]: () => this.provider.popOutToEditor(),
       [PROGRESS_VIEW_COMMANDS.POP_BACK]: () => this.provider.showInSidebar(),
@@ -310,12 +299,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         const view = this.getActiveView();
         if (view) await this.recordingManager.stop(view);
       },
-
-      // Profile & Memory - direct command execution
-      [PROGRESS_VIEW_COMMANDS.OPEN_PROFILE]: runCommand(
-        'texra.auth.viewProfile',
-      ),
-      [PROGRESS_VIEW_COMMANDS.OPEN_MEMORY_VIEW]: runCommand('texra.showMemory'),
 
       [PROGRESS_VIEW_COMMANDS.GETTING_STARTED_ACTION]: (data) =>
         this.runGettingStartedAction(data.action),
@@ -527,9 +510,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         file: {
           openFile: async (file, line) => {
             await this.runViewCommand('texra.openFile', [file, line]);
-          },
-          openFileCompile: async (file) => {
-            await this.runViewCommand('texra.openFileCompile', [file]);
           },
         },
         approval: {

--- a/packages/extension/src/settingsView/SettingsViewProvider.ts
+++ b/packages/extension/src/settingsView/SettingsViewProvider.ts
@@ -18,10 +18,7 @@ import type { AgentCategory } from '@shared/schemas/agent';
 // Local file imports
 import { SettingsViewMessageHandler } from './SettingsViewMessageHandler';
 
-export class SettingsViewProvider
-  extends BaseWebviewProvider
-  implements vscode.WebviewViewProvider
-{
+export class SettingsViewProvider extends BaseWebviewProvider {
   public static readonly viewType = 'texra.settingsView';
   protected contentProvider: BundledViewContentProvider;
   protected messageHandler: SettingsViewMessageHandler;
@@ -53,10 +50,6 @@ export class SettingsViewProvider
         void this.messageHandler.sendAllData(this._view.webview);
       }
     });
-  }
-
-  protected override getViewPath(): string {
-    return 'settingsView';
   }
 
   /** Refresh every credential-dependent surface after any API-key mutation. */

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -110,8 +110,6 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       runWithActiveView: (fn) => this.runWithActiveView(fn),
       getActiveView: () => this.getActiveView(),
       postToActiveView: (message) => this.postToActiveView(message),
-      handleTheme: (m, view) => this.handleTheme(m, view),
-      handleDebugMode: (m, view) => this.handleDebugMode(m, view),
       handleWebviewReady: () => this.handleWebviewReady(),
       handleThemeRequest: () => this.handleThemeRequest(),
       handleDebugModeRequest: () => this.handleDebugModeRequest(),
@@ -163,35 +161,6 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       vscode.commands.executeCommand('texra.refreshAllOptions'),
       this.refreshOnboardingFunnel?.(),
     ]);
-  }
-
-  /** Push the current theme into the webview on request. */
-  protected async handleTheme(
-    message: { theme?: string },
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
-    if (!message?.theme) {
-      this.logger.warn(this.channel, 'Invalid theme message', {
-        data: message,
-      });
-      return;
-    }
-
-    webviewView.webview.postMessage({
-      command: COMMON_COMMANDS.THEME_SET,
-      theme: message.theme,
-    });
-  }
-
-  /** Push the current debug mode into the webview on request. */
-  protected async handleDebugMode(
-    message: { debugMode?: boolean },
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
-    webviewView.webview.postMessage({
-      command: COMMON_COMMANDS.DEBUG_MODE_SET,
-      debugMode: message.debugMode,
-    });
   }
 
   protected async handleWebviewReady(): Promise<void> {

--- a/packages/extension/src/webview/mainViewInboundContext.ts
+++ b/packages/extension/src/webview/mainViewInboundContext.ts
@@ -32,14 +32,6 @@ export interface MainViewInboundHost {
   runWithActiveView<T>(fn: (view: vscode.WebviewView) => T): T | undefined;
   getActiveView(): vscode.WebviewView | undefined;
   postToActiveView(message: unknown): void;
-  handleTheme(
-    message: { theme?: string },
-    view: vscode.WebviewView,
-  ): Promise<void>;
-  handleDebugMode(
-    message: { debugMode?: boolean },
-    view: vscode.WebviewView,
-  ): Promise<void>;
   handleWebviewReady(): Promise<void>;
   handleThemeRequest(): void;
   handleDebugModeRequest(): void;

--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -64,18 +64,6 @@ type GetCurrentFileMessage = MessageFor<
 const CHANNEL = 'FileManager';
 
 export class FileManager extends BaseWebviewManager {
-  async handleEditedFileSelection(): Promise<void> {
-    const editedFile = await vscode.commands.executeCommand<string>(
-      FILE_SELECTION_COMMAND_IDS.selectEditedFile,
-    );
-    if (editedFile) {
-      this.postMessage({
-        command: MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED,
-        filePath: editedFile,
-      });
-    }
-  }
-
   async handleRequestEditedFile(
     message: RequestEditedFileMessage,
   ): Promise<void> {

--- a/packages/extension/src/webview/slices/commonSlice.ts
+++ b/packages/extension/src/webview/slices/commonSlice.ts
@@ -15,10 +15,6 @@ import type { MainViewInboundHost } from '../mainViewInboundContext';
 
 export function createCommonHandlers(host: MainViewInboundHost) {
   return {
-    [MAIN_VIEW_COMMANDS.THEME_SET]: (m) =>
-      host.runWithActiveView((view) => host.handleTheme(m, view)),
-    [MAIN_VIEW_COMMANDS.DEBUG_MODE_SET]: (m) =>
-      host.runWithActiveView((view) => host.handleDebugMode(m, view)),
     [MAIN_VIEW_COMMANDS.WEBVIEW_READY]: () => host.handleWebviewReady(),
     [MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]: (m) => {
       vscode.window.showInformationMessage(m.text);
@@ -79,7 +75,5 @@ export function createCommonHandlers(host: MainViewInboundHost) {
     },
     [MAIN_VIEW_COMMANDS.OPEN_AGENT_DOCS]: () =>
       safeExecuteCommand('texra.openDoc', ['custom-agents'], host.viewName),
-    [MAIN_VIEW_COMMANDS.OPEN_INSTALLATION_DOCS]: () =>
-      safeExecuteCommand('texra.openDoc', ['installation'], host.viewName),
   } satisfies Partial<MainViewInboundHandlerRegistry>;
 }

--- a/packages/extension/src/webview/slices/documentSlice.ts
+++ b/packages/extension/src/webview/slices/documentSlice.ts
@@ -10,8 +10,6 @@ import type { MainViewInboundHost } from '../mainViewInboundContext';
 
 export function createDocumentHandlers(host: MainViewInboundHost) {
   return {
-    [MAIN_VIEW_COMMANDS.SELECT_EDITED_FILE]: () =>
-      host.fileManager.handleEditedFileSelection(),
     [MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES]: (m) =>
       host.fileManager.handleSelectMultipleFiles(m),
 

--- a/packages/extension/src/webview/slices/sessionSlice.ts
+++ b/packages/extension/src/webview/slices/sessionSlice.ts
@@ -3,7 +3,6 @@
  * commands routed through the shared executionHandlers module.
  */
 
-import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import type { MainViewInboundHandlerRegistry } from '@shared/schemas';
 
@@ -33,8 +32,5 @@ export function createSessionHandlers(host: MainViewInboundHost) {
       executionHandlers.handleMultipleOperation(m),
     [MAIN_VIEW_COMMANDS.CLEAN_MULTIPLE]: (m) =>
       executionHandlers.handleMultipleOperation(m),
-
-    [MAIN_VIEW_COMMANDS.SHOW_AGENT_HISTORY]: () =>
-      safeExecuteCommand('texra.showAgentHistory', [], host.viewName),
   } satisfies Partial<MainViewInboundHandlerRegistry>;
 }

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -122,7 +122,6 @@ interface ProgressViewRunCommandActions {
 
 export interface ProgressViewFileCommandActions {
   openFile(file: string, line?: number): Promise<void> | void;
-  openFileCompile(file: string): Promise<void> | void;
   openTaskStorage(stream: StreamTabId): Promise<void> | void;
   compareOriginal(file: string, base?: string): Promise<void> | void;
   comparePrevious(
@@ -253,8 +252,6 @@ export function createProgressViewCommandHandlers(
 
     [PROGRESS_VIEW_COMMANDS.OPEN_FILE]: (data) =>
       file.openFile(data.file, data.line),
-    [PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE]: (data) =>
-      file.openFileCompile(data.file),
     [PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE]: (data) =>
       file.openTaskStorage(data.stream),
     [PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL]: (data) =>
@@ -541,11 +538,6 @@ export function createProgressViewSecondTierHandlers(
           );
           return;
       }
-    },
-
-    // ── Show info ──
-    [CMD.SHOW_INFORMATION_MESSAGE]: async (data) => {
-      await deps.host.showInfo(data.text);
     },
 
     // ── Proposal config restore ──

--- a/src/controllers/progressView/ProgressViewHost.ts
+++ b/src/controllers/progressView/ProgressViewHost.ts
@@ -27,7 +27,7 @@ import {
 
 type ProgressViewFileHostActions = Pick<
   ProgressViewFileCommandActions,
-  'openFile' | 'openFileCompile'
+  'openFile'
 >;
 
 type ProgressViewApprovalHostActions = Omit<
@@ -138,7 +138,6 @@ export class ProgressViewHost {
       bypass: options.commands.bypass,
       file: {
         openFile: options.commands.file.openFile,
-        openFileCompile: options.commands.file.openFileCompile,
         openTaskStorage: (stream) =>
           this.workflowFileActionsController.openTaskStorage(stream),
         compareOriginal: (file, base) =>

--- a/src/shared/BaseWebviewApp.ts
+++ b/src/shared/BaseWebviewApp.ts
@@ -20,7 +20,6 @@ interface CommonMessageContext {
   setTheme: (theme: string) => void;
   setDebugMode: (enabled: boolean) => void;
   restoreState: (message: StateRestoreMessage) => void;
-  onError: (message: string, details?: unknown) => void;
   onSchemaError?: (context: string, error: ZodError) => void;
 }
 
@@ -46,9 +45,6 @@ function handleCommonMessage(
       return true;
     case COMMON_COMMANDS.STATE_RESTORE:
       context.restoreState(result.data);
-      return true;
-    case COMMON_COMMANDS.ERROR:
-      context.onError(result.data.message, result.data.details);
       return true;
     case COMMON_COMMANDS.WEBVIEW_READY:
       return true;
@@ -84,7 +80,6 @@ export abstract class BaseWebviewApp<TMessage = unknown> extends LitElement {
         this.debugMode = enabled;
       },
       restoreState: (message) => this.onStateRestore(message),
-      onError: (message, details) => this.onError(message, details),
       onSchemaError: (context, error) => this.logSchemaError(context, error),
     });
     if (!handled) {
@@ -157,13 +152,6 @@ export abstract class BaseWebviewApp<TMessage = unknown> extends LitElement {
    */
   protected onStateRestore(_message: StateRestoreMessage): void {
     // Override in subclasses if needed.
-  }
-
-  /**
-   * Handle error messages from the extension host.
-   */
-  protected onError(message: string, details?: unknown): void {
-    console.error(message, details);
   }
 
   override connectedCallback(): void {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -5,7 +5,6 @@ export const COMMON_COMMANDS = {
   DEBUG_MODE_SET: 'setDebugMode',
   STATE_RESTORE: 'restoreState',
   WEBVIEW_READY: 'webviewReady',
-  ERROR: 'error',
   SWITCH_VIEW: 'switchView',
 } as const;
 
@@ -21,7 +20,6 @@ export const MAIN_VIEW_COMMANDS = {
   SETTINGS_OPEN: 'openSettings',
 
   // File selection cases (single-file pickers; multi pickers go through SELECT_MULTIPLE_FILES)
-  SELECT_EDITED_FILE: 'selectEditedFile',
 
   // File selected cases (single-file response messages)
   EDITED_FILE_SELECTED: 'editedFileSelected',
@@ -48,7 +46,6 @@ export const MAIN_VIEW_COMMANDS = {
   START_RECORDING: 'startRecording',
   STOP_RECORDING: 'stopRecording',
   RECORDING_STOPPED: 'recordingStopped',
-  SHOW_AGENT_HISTORY: 'showAgentHistory',
   OPEN_AGENT_SETTINGS: 'openAgentSettings',
   OPEN_MODEL_SETTINGS: 'openModelSettings',
   OPEN_MULTI_AGENT_SETTINGS: 'openMultiAgentSettings',
@@ -61,7 +58,6 @@ export const MAIN_VIEW_COMMANDS = {
   HIDE_API_KEY_BANNER: 'hideApiKeyBanner',
   OPEN_AGENT_DIRECTORY: 'openAgentDirectory',
   OPEN_AGENT_DOCS: 'openAgentDocs',
-  OPEN_INSTALLATION_DOCS: 'openInstallationDocs',
   OPEN_INSTALL_GUIDE: 'openInstallGuide',
   RECHECK_DEPENDENCIES: 'recheckDependencies',
   SHOW_AGENT_CONFIG_BANNER: 'showAgentConfigBanner',
@@ -183,7 +179,6 @@ export const PROGRESS_VIEW_COMMANDS = {
   START_RECORDING: 'startRecording',
   STOP_RECORDING: 'stopRecording',
   UPDATE_RECORDING: 'updateRecording',
-  SHOW_INFORMATION_MESSAGE: 'showInformationMessage',
   OPEN_TASK_STORAGE: 'openTaskStorage',
   RUN_COMPILE_FIXER: 'runCompileFixer',
   TOOL_EDIT_APPROVAL_ACTION: 'toolEditApprovalAction',
@@ -199,18 +194,13 @@ export const PROGRESS_VIEW_COMMANDS = {
   ENABLE_SUPER_YOLO_BYPASS: 'enableSuperYoloBypass',
   GOAL_ACTIVE_UPDATED: 'goalActiveUpdated',
 
-  OPEN_MEMORY_VIEW: 'openMemoryView',
-
   OPEN_FILE: 'openFile',
-  OPEN_FILE_COMPILE: 'openFileCompile',
   COMPARE_ORIGINAL: 'compareOriginal',
   COMPARE_PREVIOUS: 'comparePrevious',
   ACCEPT_FILE: 'acceptFile',
   MERGE_FILE: 'mergeFile',
   LATEXDIFF_FILE: 'latexdiffFile',
   OPEN_LABEL: 'openLabel',
-
-  OPEN_PROFILE: 'openProfile',
 
   GETTING_STARTED_ACTION: 'progressGettingStartedAction',
 

--- a/src/shared/schemas/commonViewMessages.ts
+++ b/src/shared/schemas/commonViewMessages.ts
@@ -24,7 +24,7 @@ export const SetThemeMessageSchema = z.object({
   theme: ThemeSchema,
 });
 
-export const SetDebugModeMessageSchema = z.object({
+const SetDebugModeMessageSchema = z.object({
   command: z.literal(COMMON_COMMANDS.DEBUG_MODE_SET),
   debugMode: z.boolean(),
 });
@@ -49,19 +49,12 @@ export const SwitchViewMessageSchema = z.object({
   openInEditor: z.boolean().nullish(),
 });
 
-const ErrorMessageSchema = z.object({
-  command: z.literal(COMMON_COMMANDS.ERROR),
-  message: z.string(),
-  details: z.unknown().nullish(),
-});
-
 export const CommonViewMessageSchema = z.discriminatedUnion('command', [
   SetThemeMessageSchema,
   SetDebugModeMessageSchema,
   StateRestoreMessageSchema,
   WebviewReadyMessageSchema,
   SwitchViewMessageSchema,
-  ErrorMessageSchema,
 ]);
 
 export type StateRestoreMessage = z.infer<typeof StateRestoreMessageSchema>;

--- a/src/shared/schemas/mainView/inbound.ts
+++ b/src/shared/schemas/mainView/inbound.ts
@@ -14,11 +14,7 @@ import {
   type HandlerRegistry,
 } from '@shared/utils/dispatcher';
 
-import {
-  SetDebugModeMessageSchema,
-  SetThemeMessageSchema,
-  SwitchViewMessageSchema,
-} from '../commonViewMessages';
+import { SwitchViewMessageSchema } from '../commonViewMessages';
 import { commandOnly, withFilesArray } from '../messageFactories';
 import {
   CurrentFileTypeSchema,
@@ -37,8 +33,6 @@ const CommonMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.GET_THEME),
   commandOnly(MAIN_VIEW_COMMANDS.GET_DEBUG_MODE),
   SwitchViewMessageSchema,
-  SetThemeMessageSchema,
-  SetDebugModeMessageSchema,
   z.object({
     command: z.literal(MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE),
     text: z.string().min(1),
@@ -65,7 +59,6 @@ const SettingsMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS),
   commandOnly(MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS),
   commandOnly(MAIN_VIEW_COMMANDS.OPEN_AGENT_DOCS),
-  commandOnly(MAIN_VIEW_COMMANDS.OPEN_INSTALLATION_DOCS),
   OpenAgentSettingsMessageSchema,
   OpenAgentDirectoryMessageSchema,
 ] as const;
@@ -112,7 +105,6 @@ const ExecutionMessages = [
 ] as const;
 
 const FileSelectionMessages = [
-  commandOnly(MAIN_VIEW_COMMANDS.SELECT_EDITED_FILE),
   z.object({
     command: z.literal(MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES),
     fileType: ExtendedDocumentFileTypeSchema,
@@ -317,10 +309,6 @@ const HousekeepingMessages = [
   CleanMultipleMessageSchema,
 ] as const;
 
-const NavigationMessages = [
-  commandOnly(MAIN_VIEW_COMMANDS.SHOW_AGENT_HISTORY),
-] as const;
-
 // Onboarding funnel (PRD: agent-native onboarding). Common commands stay
 // shared where possible; ChatGPT sign-in and State 1 setup actions need
 // explicit messages because they update the funnel after host-side effects.
@@ -345,7 +333,6 @@ export const MainViewInboundMessageSchema = z.discriminatedUnion('command', [
   ...BannerMessages,
   ...GitDiffMessages,
   ...HousekeepingMessages,
-  ...NavigationMessages,
   ...OnboardingMessages,
 ]);
 

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -13,8 +13,6 @@ import {
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 import {
-  SetDebugModeMessageSchema,
-  SetThemeMessageSchema,
   SwitchViewMessageSchema,
   WebviewReadyMessageSchema,
 } from '../commonViewMessages';
@@ -124,11 +122,6 @@ const RetryStreamRequestMessageSchema = StreamScopedBaseSchema.extend({
 const CancelRetryRequestMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST),
   requestId: z.string(),
-});
-
-const ShowInformationMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE),
-  text: TrimmedStringSchema,
 });
 
 const ToolEditActionMessageBase = {
@@ -253,11 +246,6 @@ const OpenFileMessageSchema = z.object({
   line: z.int().nonnegative().optional(),
 });
 
-const OpenFileCompileMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE),
-  file: z.string().min(1),
-});
-
 const ComparePreviousMessageSchema = fileWithBaseCommand(
   PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS,
 ).extend({
@@ -279,8 +267,6 @@ export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
   [
     WebviewReadyMessageSchema,
     SwitchViewMessageSchema,
-    SetThemeMessageSchema,
-    SetDebugModeMessageSchema,
     streamScopedCommand(PROGRESS_VIEW_COMMANDS.SWITCH_STREAM),
     streamScopedCommand(PROGRESS_VIEW_COMMANDS.DELETE_STREAM),
     commandOnly(PROGRESS_VIEW_COMMANDS.DELETE_ALL),
@@ -316,11 +302,7 @@ export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
     ExternalInquiryActionMessageSchema,
     UserQuestionActionMessageSchema,
     RestoreProposalConfigMessageSchema,
-    ShowInformationMessageSchema,
-    commandOnly(PROGRESS_VIEW_COMMANDS.OPEN_PROFILE),
-    commandOnly(PROGRESS_VIEW_COMMANDS.OPEN_MEMORY_VIEW),
     OpenFileMessageSchema,
-    OpenFileCompileMessageSchema,
     fileWithBaseCommand(PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL),
     ComparePreviousMessageSchema,
     fileWithBaseCommand(PROGRESS_VIEW_COMMANDS.ACCEPT_FILE),

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -79,7 +79,6 @@ function createActions(
     },
     file: {
       openFile: vi.fn(),
-      openFileCompile: vi.fn(),
       openTaskStorage: vi.fn(),
       compareOriginal: vi.fn(),
       comparePrevious: vi.fn(),
@@ -237,13 +236,6 @@ describe('createProgressViewCommandHandlers', () => {
     );
     expectDispatched(
       {
-        command: PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE,
-        file: 'paper.tex',
-      },
-      handlers,
-    );
-    expectDispatched(
-      {
         command: PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE,
         stream: 'stream-a',
       },
@@ -296,7 +288,6 @@ describe('createProgressViewCommandHandlers', () => {
     );
 
     expect(actions.file.openFile).toHaveBeenCalledWith('paper.tex', 12);
-    expect(actions.file.openFileCompile).toHaveBeenCalledWith('paper.tex');
     expect(actions.file.openTaskStorage).toHaveBeenCalledWith('stream-a');
     expect(actions.file.compareOriginal).toHaveBeenCalledWith(
       'edited.tex',
@@ -881,7 +872,6 @@ describe('createProgressViewSecondTierHandlers', () => {
         PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY,
         PROGRESS_VIEW_COMMANDS.RESTORE_STATE,
         PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE,
-        PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
         PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG,
         PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP,
         PROGRESS_VIEW_COMMANDS.SETUP_FOLLOWUP,
@@ -890,25 +880,6 @@ describe('createProgressViewSecondTierHandlers', () => {
         PROGRESS_VIEW_COMMANDS.RUN_COMPILE_FIXER,
       ].toSorted(),
     );
-  });
-
-  it('awaits host information messages', async () => {
-    const failure = new Error('message host failed');
-    const actions = createSecondTierActions({
-      host: {
-        showInfo: vi.fn().mockRejectedValue(failure),
-      },
-    });
-    const handlers = createProgressViewSecondTierHandlers(actions);
-
-    await expect(
-      assertSupported(
-        handlers[PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE],
-      )({
-        command: PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
-        text: 'Ready',
-      }),
-    ).rejects.toBe(failure);
   });
 
   it('reports an unavailable retry through the host', async () => {

--- a/src/test-kernel/controllers/ProgressViewHost.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewHost.vitest.ts
@@ -106,7 +106,6 @@ function createHostHarness(
       },
       file: {
         openFile: vi.fn(),
-        openFileCompile: vi.fn(),
       },
       approval: {
         approvePendingDelegatedWork: vi.fn(async () => undefined),

--- a/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.ts
@@ -25,7 +25,6 @@ import { loadSourceModule } from './loadSourceModule.ts';
 
 type DesktopExecution = {
   handleExecute(message: unknown): Promise<void>;
-  openFileCompile(filePath: string): Promise<void>;
   dispose(): void;
 };
 
@@ -441,23 +440,6 @@ describe('createDesktopAgentExecution', () => {
     });
 
     await execution.handleExecute({ command: 'execute' });
-    expect(opener.openPath).not.toHaveBeenCalled();
-  });
-
-  it('opens compile-file actions through the desktop preview host', async () => {
-    const opener = makeOpener();
-    const execution = await createExecution({
-      opener,
-      prepareMainViewExecutionRequest: vi.fn(() => ({
-        valid: false,
-        message: 'not used',
-      })),
-    });
-
-    await execution.openFileCompile('/tmp/output.tex');
-    expect(opener.openBuildDisplay).toHaveBeenCalledWith(
-      expect.objectContaining({ absolutePath: '/tmp/output.tex' }),
-    );
     expect(opener.openPath).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/desktop/DesktopCrashReporting.vitest.ts
+++ b/src/test-kernel/desktop/DesktopCrashReporting.vitest.ts
@@ -1,50 +1,38 @@
-import { beforeAll, describe, expect, it } from 'vitest';
-
-import { loadSourceModule } from './loadSourceModule.ts';
-
-type ScrubDesktopCrashEvent =
-  (typeof import('@desktop/main/desktopCrashReporting'))['scrubDesktopCrashEvent'];
+import { describe, expect, it } from 'vitest';
+import { createDesktopCrashEventScrubber } from '@desktop/main/desktopCrashEventScrubber';
 
 describe('desktop crash reporting', () => {
-  let scrubDesktopCrashEvent: ScrubDesktopCrashEvent;
-
-  beforeAll(async () => {
-    ({ scrubDesktopCrashEvent } = await loadSourceModule(
-      '@desktop/main/desktopCrashReporting',
-    ));
-  });
-
   it('drops non-native events for the v1 crash-reporting scope', () => {
-    expect(
-      scrubDesktopCrashEvent({ type: undefined, platform: 'javascript' }, []),
-    ).toBeNull();
+    const scrub = createDesktopCrashEventScrubber([]);
+    expect(scrub({ type: undefined, platform: 'javascript' })).toBeNull();
   });
 
   it('scrubs workspace and app paths from native crash events', () => {
-    const scrubbed = scrubDesktopCrashEvent(
-      {
-        type: undefined,
-        platform: 'native',
-        message: 'Crash in /Users/alice/paper/main.tex',
-        exception: {
-          values: [
-            {
-              stacktrace: {
-                frames: [
-                  { filename: 'C:\\Users\\Alice\\TeXRA\\workspace\\agent.ts' },
-                ],
-              },
+    const scrub = createDesktopCrashEventScrubber([
+      '/Users/alice/paper',
+      'C:\\Users\\Alice\\TeXRA\\workspace',
+    ]);
+    const scrubbed = scrub({
+      type: undefined,
+      platform: 'native',
+      message: 'Crash in /Users/alice/paper/main.tex',
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                { filename: 'C:\\Users\\Alice\\TeXRA\\workspace\\agent.ts' },
+              ],
             },
-          ],
-        },
-        extra: {
-          cwd: '/Users/alice/paper',
-          log: 'C:\\Users\\Alice\\TeXRA\\workspace\\logs\\main.log',
-          '/Users/alice/paper/output.pdf': 'build output',
-        },
+          },
+        ],
       },
-      ['/Users/alice/paper', 'C:\\Users\\Alice\\TeXRA\\workspace'],
-    );
+      extra: {
+        cwd: '/Users/alice/paper',
+        log: 'C:\\Users\\Alice\\TeXRA\\workspace\\logs\\main.log',
+        '/Users/alice/paper/output.pdf': 'build output',
+      },
+    });
 
     const serialized = JSON.stringify(scrubbed);
     expect(serialized).toContain('<redacted-path>');


### PR DESCRIPTION
Closes #9977.

## Summary

Removes five producer-less webview IPC families and their schemas, dispatch arms, host ports, tests, and now-stranded helper methods. Host-to-view theme and debug updates remain unchanged.

## Issue acceptance gates

- Removes the five message families named in #9977 end to end.
- Preserves the registered VS Code commands; only unreachable IPC routes are removed.
- Removes adjacent helpers left without consumers by those deletions.

## Single source of truth

The surviving inbound command registries and Zod schemas remain the authoritative host boundaries for each webview.

## Duplication and abstraction budget

No abstraction was added. The PR deletes dead routes, an unused view resolver, a wrapper with no independent policy, and the stranded edited-file selection helper.

## Net elements (R6)

- Files: 1 added, 25 modified.
- Exported symbols: 2 added, 3 deleted; net -1.
- LoC: 84 added, 367 deleted; net -283.

## Consumer counts (R8)

Every removed inbound message family had zero producers. `handleEditedFileSelection` had zero callers. The retained `texra.openFileCompile` command is registered independently of the deleted progress-view IPC arm.

## Host impact

Extension: Dead inbound handlers and support methods removed.

Desktop: Dead inbound handlers and the unused crash-scrubber wrapper removed.

CLI: None.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm run typecheck`
- `corepack pnpm run compile:fast`
- `corepack pnpm run lint`
- `corepack pnpm test`
- `corepack pnpm run check:dead-code-ratchet`
- Focused controller, extension, and desktop tests
- `git diff --check`
