### PR TITLE
refactor: remove model routing residue

### DIFF
--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Text, useWindowSize } from 'ink';
 
+import { buildHunks } from '@cli/runtime/diffHunks';
 import { COLOR_HINT } from '@cli/tui/ui/colors';
 import {
   clampModalWidth,
@@ -18,7 +19,6 @@ import {
   confirmCardFeedbackRows,
 } from './confirmCardRowsBudget';
 import {
-  buildHunks,
   DiffView,
   initialDiffScrollOffset,
   maxDiffScrollOffset,

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -3,8 +3,8 @@
 // (see DIFF_LINE_STYLE for the color rationale).
 
 import { Box, Text } from 'ink';
-import { structuredPatch, type StructuredPatchHunk } from 'diff';
 
+import { buildHunks } from '@cli/runtime/diffHunks';
 import { wrapAnsiToWidth } from '@cli/tui/ansiWrap';
 import {
   hiddenRowsText,
@@ -20,6 +20,7 @@ import {
   scrollBoundedRows,
 } from './scrollBounds';
 import { clipToWidth, fillRows, textDisplayWidth } from './terminalText';
+import type { StructuredPatchHunk } from 'diff';
 
 type Hunk = StructuredPatchHunk;
 
@@ -43,17 +44,6 @@ const NO_NEWLINE_MARKER = '\\';
 const DEFAULT_DIFF_WIDTH = 74;
 
 type OverflowMarkerKind = 'hidden' | 'more' | 'previous';
-
-/** Compute hunks once; callers reuse for both stats and the renderer. */
-export function buildHunks(
-  fileLabel: string,
-  original: string,
-  proposed: string,
-): Hunk[] {
-  return structuredPatch(fileLabel, fileLabel, original, proposed, '', '', {
-    context: 3,
-  }).hunks;
-}
 
 export function statsFromHunks(hunks: readonly Hunk[]): DiffStats {
   let added = 0;

--- a/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
+++ b/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
@@ -1,6 +1,7 @@
 import {
   AgentCategory,
   USER_FOLLOW_UP_SUPPORT,
+  isPlainAgentIdentity,
   type StreamTabId,
 } from '@shared/schemas';
 import { isInFlightPhase } from '@shared/streams/streamStatus';
@@ -32,8 +33,7 @@ export function focusedChildFollowUpRoute(init: {
   // keeps their composer hidden until terminal-backed interaction has parity.
   const acceptsFollowUps =
     slice?.userFollowUpSupport === USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE &&
-    slice.identity?.kind === 'agent' &&
-    slice.identity.tool === undefined &&
+    isPlainAgentIdentity(slice.identity) &&
     slice.category === AgentCategory.ToolUse &&
     slice.status !== undefined &&
     isInFlightPhase(slice.status);

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -23,6 +23,7 @@ import {
   STREAM_LOG_ENTRY_TYPES,
   TOOL_USE_STATUS,
   WorkflowCallProgressSchema,
+  isPlainAgentIdentity,
   isTerminalWorkflowCallProgress,
   type StreamLogEntry,
   type TaskGroup,
@@ -141,10 +142,7 @@ export function isFullLogChildStream(
   slice: Pick<StreamSlice, 'identity'> | undefined,
 ): boolean {
   const identity = slice?.identity;
-  return (
-    identity !== undefined &&
-    !(identity.kind === 'agent' && identity.tool === undefined)
-  );
+  return identity !== undefined && !isPlainAgentIdentity(identity);
 }
 
 function safeWorkflowOperationalSummary(text: string): string | undefined {

--- a/packages/cli/src/runtime/approval/approvalSummaries.ts
+++ b/packages/cli/src/runtime/approval/approvalSummaries.ts
@@ -1,9 +1,8 @@
-import { structuredPatch } from 'diff';
-
 import type {
   HostBashApprovalRequest,
   HostUserQuestionRequest,
 } from '@agent/runtime/HostInteractions';
+import { buildHunks, formatHunkHeader } from '@cli/runtime/diffHunks';
 import {
   agentProposalCategoryLabel,
   getProposalFileGroups,
@@ -134,34 +133,20 @@ export function formatBashApprovalSummary(
   return `Command requested:\n${cwd}${request.command}`;
 }
 
-function formatDiffRange(start: number, lineCount: number): string {
-  return lineCount === 1 ? String(start) : `${start},${lineCount}`;
-}
-
 function toolEditDiffLines(
   request: ToolEditApprovalRequest,
 ): readonly string[] {
-  const patch = structuredPatch(
-    request.path,
+  const hunks = buildHunks(
     request.path,
     request.originalContent,
     request.proposedContent,
-    '',
-    '',
-    { context: 3 },
   );
-  if (patch.hunks.length === 0) return [];
+  if (hunks.length === 0) return [];
 
   return [
     `--- ${request.path}`,
     `+++ ${request.path}`,
-    ...patch.hunks.flatMap((hunk) => [
-      `@@ -${formatDiffRange(hunk.oldStart, hunk.oldLines)} +${formatDiffRange(
-        hunk.newStart,
-        hunk.newLines,
-      )} @@`,
-      ...hunk.lines,
-    ]),
+    ...hunks.flatMap((hunk) => [formatHunkHeader(hunk), ...hunk.lines]),
   ];
 }
 

--- a/packages/cli/src/runtime/diffHunks.ts
+++ b/packages/cli/src/runtime/diffHunks.ts
@@ -1,0 +1,19 @@
+import { structuredPatch, type StructuredPatchHunk } from 'diff';
+
+/** Compute unified-diff hunks once for both text and Ink renderers. */
+export function buildHunks(
+  fileLabel: string,
+  original: string,
+  proposed: string,
+): StructuredPatchHunk[] {
+  return structuredPatch(fileLabel, fileLabel, original, proposed, '', '', {
+    context: 3,
+  }).hunks;
+}
+
+/** Render a unified-diff hunk header without redundant `,1` ranges. */
+export function formatHunkHeader(hunk: StructuredPatchHunk): string {
+  const range = (start: number, lines: number) =>
+    lines === 1 ? String(start) : `${start},${lines}`;
+  return `@@ -${range(hunk.oldStart, hunk.oldLines)} +${range(hunk.newStart, hunk.newLines)} @@`;
+}

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_STREAM_METADATA_STATUS,
   STREAM_PHASE,
   STREAM_SUBSTATE,
+  isPlainAgentIdentity,
   isToolUseState,
   type ConversationProgress,
   type StreamStage,
@@ -365,8 +366,7 @@ export class StreamHeader extends UnsupportedCommandsMixin(LitElement) {
     const goalObjective = toolUse?.goalObjective ?? '';
     const hasExecutionId = Boolean(this.stream.executionId);
     const identity = this.stream.identity;
-    const isNativeAgentRun =
-      identity?.kind === 'agent' && identity.tool === undefined;
+    const isNativeAgentRun = isPlainAgentIdentity(identity);
     const agentCategory = this.stream.agentCategory;
     // Identity decides the chrome: a non-agent run (process, multi-agent-
     // workflow container) gets the neutral toolbar even when a borrowed

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -169,36 +169,6 @@ function withReasoningOverride<T extends ModelHandler>(handler: T): T {
   return handler;
 }
 
-/**
- * Whether a model is pinned to the Interactions API. `requiresInteractionsAPI`
- * is a future per-model opt-in (parallel to `requiresResponsesAPI`); it is not
- * yet on the external llm-zoo ModelConfig, so read it defensively. v0 registers
- * no model with it set.
- */
-function modelRequiresInteractionsAPI(config: ModelConfig): boolean {
-  return (
-    config.provider === ModelProvider.GOOGLE &&
-    !config.openRouterOnly &&
-    (config as { requiresInteractionsAPI?: boolean })
-      .requiresInteractionsAPI === true
-  );
-}
-
-/**
- * Fail loudly when an Interactions-only model resolves to OpenRouter —
- * OpenRouter cannot proxy Interactions, so silently routing it through the
- * OpenRouter handler would be wrong (spec §6.3). Called from
- * `createModelHandler` only (the live-routing path that actually instantiates a
- * handler), keeping the routing predicate pure.
- */
-function assertGoogleInteractionsRoutable(config: ModelConfig): void {
-  if (modelRequiresInteractionsAPI(config)) {
-    throw new Error(
-      `Model ${config.name} requires the Google Interactions API, which cannot be used through OpenRouter. Disable OpenRouter or select a different model.`,
-    );
-  }
-}
-
 /** Check if OpenAI Responses API should be used for this config. */
 export function shouldUseResponsesAPI(
   config: ModelConfig,
@@ -430,10 +400,6 @@ export async function createModelHandler(
     false,
     copilotRouteOverride,
   );
-  if (compatibilityKey === 'ModelHandlerOpenRouterNative') {
-    assertGoogleInteractionsRoutable(config);
-  }
-
   return createModelHandlerForResolvedCompatibilityKey(
     config,
     compatibilityKey,

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -8,8 +8,9 @@ import type {
   AgentOptionData,
   AgentProposal,
   ModelOptionData,
+  StreamTabId,
 } from '@shared/schemas';
-import type { RunIdentity, StreamTabId } from '@shared/schemas';
+import { isPlainAgentIdentity } from '@shared/schemas';
 import type {
   ProgressViewInboundHandlerRegistry,
   ProgressViewInboundMessage,
@@ -48,10 +49,6 @@ import type {
  * all three, relaunching the stored config would run the wrong thing
  * (live defect 3 of the run-classification consolidation).
  */
-function isNativeAgentRun(identity: RunIdentity | undefined): boolean {
-  return identity?.kind === 'agent' && identity.tool === undefined;
-}
-
 /** User-facing refusal for the resume/re-run/restore gate. Front-end button
  *  hiding makes this rare (stale renderer state, direct IPC), but a refused
  *  action must still say why instead of silently doing nothing. */
@@ -80,7 +77,7 @@ export async function resolveNativeAgentRun(
   (RunMetadata & { config: NonNullable<RunMetadata['config']> }) | null
 > {
   const metadata = getRunMetadata(stream);
-  if (!isNativeAgentRun(metadata.identity)) {
+  if (!isPlainAgentIdentity(metadata.identity)) {
     await reportNonNativeRunRefusal(showInfo, action);
     return null;
   }

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -43,29 +43,12 @@ import type {
 } from './ProgressFollowUpPolishController';
 
 /**
- * Resume, rerun, and restore are native-agent affordances. A workflow-script
- * stream's persisted config is a borrowed default agent, a process stream's is
- * synthetic, and an external-CLI session resumes through its own tool — for
- * all three, relaunching the stored config would run the wrong thing
- * (live defect 3 of the run-classification consolidation).
- */
-/** User-facing refusal for the resume/re-run/restore gate. Front-end button
- *  hiding makes this rare (stale renderer state, direct IPC), but a refused
- *  action must still say why instead of silently doing nothing. */
-async function reportNonNativeRunRefusal(
-  showInfo: (message: string) => void | PromiseLike<unknown>,
-  action: string,
-): Promise<void> {
-  await showInfo(
-    `Only TeXRA agent runs can be ${action} from here; this stream's run is ` +
-      'not one.',
-  );
-}
-
-/**
  * Shared native-agent-run gate for the resume / re-run / restore affordances:
  * resolve the stream's run metadata, refuse with a user-facing message when
  * the run is not a native TeXRA agent run, and require a persisted config.
+ * Workflow-script configs are borrowed, process configs are synthetic, and
+ * external CLI sessions resume through their own tool, so relaunching any of
+ * those stored configs would run the wrong thing.
  * Returns the resolved metadata when the action may proceed, else null.
  */
 export async function resolveNativeAgentRun(
@@ -78,7 +61,10 @@ export async function resolveNativeAgentRun(
 > {
   const metadata = getRunMetadata(stream);
   if (!isPlainAgentIdentity(metadata.identity)) {
-    await reportNonNativeRunRefusal(showInfo, action);
+    await showInfo(
+      `Only TeXRA agent runs can be ${action} from here; this stream's run is ` +
+        'not one.',
+    );
     return null;
   }
   const { config, ...rest } = metadata;

--- a/src/model/copilotRouting.ts
+++ b/src/model/copilotRouting.ts
@@ -3,11 +3,9 @@
  * through the editor's GitHub Copilot language-model access instead of a
  * provider key, OpenRouter, or a subscription.
  *
- * Mirrors the OpenRouter precedent (`openRouterRouting.ts`): the preference
- * is persisted state, the discovered route lives in
- * `runtimeModelRegistry`, and this module owns the single predicate both the
- * availability computation and `ModelFactory` consult, so picker and request
- * construction can never drift on which transport a model uses.
+ * The preference is persisted state, while the discovered route lives in
+ * `runtimeModelRegistry`. This module combines those facts when explaining
+ * why a preferred route is unavailable.
  */
 
 import { platform } from '@platform/platform';
@@ -55,20 +53,6 @@ export async function setCopilotRoutePreference(
 }
 
 /**
- * Whether a request for this model should be served through Copilot. The
- * preference alone is not enough: the editor must currently offer the model
- * with access granted. When the route cannot serve a preferred model, the
- * availability layer reports the route state (consent required / unavailable)
- * instead of silently switching transports.
- */
-export function shouldRouteModelThroughCopilot(model: string): boolean {
-  return (
-    prefersCopilotRoute(model) &&
-    copilotRouteForModel(model)?.access === 'allowed'
-  );
-}
-
-/**
  * Why a Copilot-preferred model cannot be served through Copilot right now,
  * or undefined when it can. The preference is a hard route choice (#9635):
  * handler routing reports this reason and never falls through to a provider
@@ -78,16 +62,14 @@ export function copilotRouteUnavailableReason(
   model: string,
 ): string | undefined {
   if (!prefersCopilotRoute(model)) return undefined;
-  if (shouldRouteModelThroughCopilot(model)) return undefined;
   const access = copilotRouteForModel(model)?.access;
+  if (access === 'allowed') return undefined;
   switch (access) {
     case 'consent-required':
       return `Copilot access to "${model}" needs your approval in VS Code. Grant it from Settings → Models, or stop using Copilot for this model.`;
     case 'unavailable':
       return `Copilot access to "${model}" is temporarily unavailable in VS Code.`;
-    // No discovered route, or a route reported allowed that something else
-    // blocked: both mean Copilot cannot serve the model right now.
-    case 'allowed':
+    // No discovered route means Copilot cannot serve the model right now.
     case undefined:
       break;
     default:

--- a/src/shared/schemas/runIdentity.ts
+++ b/src/shared/schemas/runIdentity.ts
@@ -31,6 +31,13 @@ export const RunIdentitySchema = z.discriminatedUnion('kind', [
 
 export type RunIdentity = z.infer<typeof RunIdentitySchema>;
 
+/** Whether an identity denotes a native agent rather than an external CLI. */
+export function isPlainAgentIdentity(
+  identity: RunIdentity | null | undefined,
+): boolean {
+  return identity?.kind === 'agent' && identity.tool === undefined;
+}
+
 /** The identity's display name — what a listing row or tab label leads with. */
 export function runIdentityName(id: RunIdentity): string {
   switch (id.kind) {

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -808,12 +808,6 @@ describe('Google Interactions API routing', () => {
 
   const googleConfig = (): ModelConfig => modelConfig(ModelProvider.GOOGLE);
 
-  const forcedInteractionsConfig = (): ModelConfig =>
-    ({
-      ...googleConfig(),
-      requiresInteractionsAPI: true,
-    }) as ModelConfig;
-
   // Re-imports the factory alongside the platform it reads from (see the
   // module-header note on this file's vi.resetModules() calls).
   async function initGoogleRouting(
@@ -831,26 +825,6 @@ describe('Google Interactions API routing', () => {
     expect(
       factory.resolveModelHandlerCompatibilityKey(googleConfig(), false, false),
     ).toBe('ModelHandlerGoogleInteractions');
-  });
-
-  it('keeps key derivation pure for Interactions-only models under OpenRouter', async () => {
-    const factory = await initGoogleRouting();
-    expect(
-      factory.resolveModelHandlerCompatibilityKey(
-        forcedInteractionsConfig(),
-        true,
-        false,
-      ),
-    ).toBe('ModelHandlerOpenRouterNative');
-  });
-
-  it('createModelHandler fails loudly for an Interactions-only model under active OpenRouter', async () => {
-    // OpenRouter cannot proxy Interactions — the live-routing path must error
-    // rather than silently route to OpenRouter (spec §6.3).
-    const factory = await initGoogleRouting(true);
-    await expect(
-      factory.createModelHandler(forcedInteractionsConfig()),
-    ).rejects.toThrow(/OpenRouter/);
   });
 
   it('creates the Interactions handler tagged with its compatibility key', async () => {

--- a/src/test-kernel/cli/DiffView.vitest.ts
+++ b/src/test-kernel/cli/DiffView.vitest.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { buildHunks } from '@cli/runtime/diffHunks';
 import {
-  buildHunks,
   initialDiffScrollOffset,
   maxDiffScrollOffset,
   scrollBoundedDiffDisplayLines,

--- a/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
+++ b/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
@@ -7,8 +7,8 @@ import {
   type ModelOptionsAccess,
 } from '@model/computeModelOptions';
 import {
+  copilotRouteUnavailableReason,
   preferredCopilotRouteModels,
-  shouldRouteModelThroughCopilot,
   setCopilotRoutePreference,
 } from '@model/copilotRouting';
 import { apiKeySecretName } from '@model/apiProviders';
@@ -416,20 +416,26 @@ describe('runtime model registry', () => {
     ).toBe('ModelHandlerVscodeLm');
   });
 
-  it('routes a preferred model through Copilot only when access is allowed', async () => {
+  it('reports no route error only when preferred Copilot access is allowed', async () => {
     const port = languageModelPort([GEMINI_FLASH]);
     await installPlatform(
-      { globalState: { [GlobalStateKey.COPILOT_ROUTE_MODELS]: ['gemini36f'] } },
+      {
+        globalState: {
+          [GlobalStateKey.COPILOT_ROUTE_MODELS]: ['gemini36f', 'gpt56'],
+        },
+      },
       { languageModel: port },
     );
 
     await refreshRuntimeModelRegistry();
-    expect(shouldRouteModelThroughCopilot('gemini36f')).toBe(true);
+    expect(copilotRouteUnavailableReason('gemini36f')).toBeUndefined();
     // A preference for a model the editor does not offer cannot route.
-    expect(shouldRouteModelThroughCopilot('gpt56')).toBe(false);
+    expect(copilotRouteUnavailableReason('gpt56')).toMatch(
+      /does not currently/,
+    );
 
     await setCopilotRoutePreference('gemini36f', false);
-    expect(shouldRouteModelThroughCopilot('gemini36f')).toBe(false);
+    expect(copilotRouteUnavailableReason('gemini36f')).toBeUndefined();
   });
 
   it('replaces route state after invalidation', async () => {


### PR DESCRIPTION
Closes #9982.

## Summary

Removes unused model-routing residue, retains the single Kimi Code fact resolver already on `main`, and consolidates the repeated plain-agent predicate and approval-diff hunk construction.

## Issue acceptance gates

- Removes the producer-less `requiresInteractionsAPI` guard and unreachable tests.
- Removes the dead `shouldRouteModelThroughCopilot` export by inlining its sole use.
- Confirms Kimi Code dispatch and availability already share `resolveKimiCodeRoutingFacts`.
- Shares the remaining repeated identity and diff helpers.

## Single source of truth

`resolveKimiCodeRoutingFacts` owns Kimi routing facts; `copilotRouteUnavailableReason` owns Copilot route rejection; `isPlainAgentIdentity` and `buildHunks` own their respective repeated computations.

## Duplication and abstraction budget

One small pure diff module was added because two consumers performed the same hunk construction. The single-use native-run refusal helper was inlined after review.

## Net elements (R6)

- Files: 1 added, 13 modified.
- Exported symbols: 3 added, 2 deleted; net +1.
- LoC: 67 added, 157 deleted; net -90.

## Consumer counts (R8)

`requiresInteractionsAPI` had zero producers. `shouldRouteModelThroughCopilot` had one consumer, now direct. The shared plain-identity predicate has three host consumers; the hunk builder has two CLI consumers.

## Host impact

Extension: Uses the shared plain-agent predicate.

Desktop: Uses the shared backend predicate through the progress controller.

CLI: Uses the shared predicate and diff hunk builder.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- `corepack pnpm test`
- `corepack pnpm run check:dead-code-ratchet`
- Focused routing, Kimi, diff, and progress-controller tests
- `git diff --check`
