### PR TITLE
refactor: share subagent delivery persistence

### DIFF
--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -20,7 +20,6 @@ import {
 import type { AgentTrace, StageHandle } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import {
-  markOwnedExecutionLeaseUndurable,
   onOwnedExecutionLeaseLost,
   runWithOwnedExecutionLease,
 } from '@agent/storage/executionLease';

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -44,10 +44,7 @@ import type {
 } from '@agent/followUp/FollowUpQueue';
 import type { FollowUpConsumerLease } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { deliverChildRunFollowUp } from '@agent/followUp/childRunDelivery';
-import {
-  persistChildRunReport,
-  persistChildRunResultMeta,
-} from '@agent/storage/childRunPersistence';
+import { persistChildRunDeliveryBestEffort } from '@agent/storage/childRunDeliveryPersistence';
 import { classifyAgentError } from '@common/errors';
 import { isUserAbort } from '@common/errors/sdkError/errorPatterns';
 import {
@@ -389,40 +386,6 @@ async function attemptTurn<TTurn>(
 }
 
 /**
- * Persist a turn report, swallowing storage errors. Best-effort — but the report
- * is the only durable copy of the result when delivery fails, so leave a trace.
- */
-async function persistReportBestEffort(
-  executionId: ExecutionId,
-  msg: string,
-  logger: AgentTrace,
-): Promise<void> {
-  const result = await persistChildRunReport(executionId, msg);
-  if (result.kind === 'failed') {
-    markOwnedExecutionLeaseUndurable(executionId);
-    logger.warn(`Failed to persist report for ${executionId}`, {
-      data: result.err,
-    });
-  }
-}
-
-/** Persist the optional structured result manifest. Best-effort. */
-async function persistResultMetaBestEffort(
-  executionId: ExecutionId,
-  resultMeta: ResultMeta | undefined,
-  logger: AgentTrace,
-): Promise<void> {
-  if (!resultMeta) return;
-  const result = await persistChildRunResultMeta(executionId, resultMeta);
-  if (result.kind === 'failed') {
-    markOwnedExecutionLeaseUndurable(executionId);
-    logger.warn(`Failed to persist result manifest for ${executionId}`, {
-      data: result.err,
-    });
-  }
-}
-
-/**
  * Mint the logical identity of one accepted child turn (#9531): a stable turn
  * token plus the delivery id the turn's single parent delivery is admitted
  * under. Deterministic per execution and turn index — execution-owned, no
@@ -589,8 +552,16 @@ async function deliverTurn<TTurn>(params: {
       ? { ...resultMeta, turnToken: turnRef.token }
       : resultMeta;
 
-  await persistReportBestEffort(executionId, msg, logger);
-  await persistResultMetaBestEffort(executionId, stampedMeta, logger);
+  await persistChildRunDeliveryBestEffort(
+    executionId,
+    msg,
+    stampedMeta,
+    (kind, error) => {
+      logger.warn(`Failed to persist ${kind} for ${executionId}`, {
+        data: error,
+      });
+    },
+  );
   // The turn's result slots now hold this turn: record it as the latest
   // completed turn, clearing the active marker written at acceptance. The
   // store does not serialize per-key writes, so this must queue behind the

--- a/src/agent/storage/childRunDeliveryPersistence.ts
+++ b/src/agent/storage/childRunDeliveryPersistence.ts
@@ -1,0 +1,31 @@
+/** Best-effort persistence of the artifacts delivered by a child run. */
+import type { ExecutionId } from '@shared/schemas';
+
+import {
+  persistChildRunReport,
+  persistChildRunResultMeta,
+} from './childRunPersistence';
+import { markOwnedExecutionLeaseUndurable } from './executionLease';
+import type { ResultMeta } from './resultMeta';
+
+export async function persistChildRunDeliveryBestEffort(
+  executionId: ExecutionId,
+  message: string,
+  resultMeta: ResultMeta | undefined,
+  onFailure: (kind: 'report' | 'result manifest', error: unknown) => void,
+): Promise<void> {
+  const [report, manifest] = await Promise.all([
+    persistChildRunReport(executionId, message),
+    resultMeta
+      ? persistChildRunResultMeta(executionId, resultMeta)
+      : Promise.resolve({ kind: 'persisted' } as const),
+  ]);
+  for (const [kind, result] of [
+    ['report', report],
+    ['result manifest', manifest],
+  ] as const) {
+    if (result.kind !== 'failed') continue;
+    markOwnedExecutionLeaseUndurable(executionId);
+    onFailure(kind, result.err);
+  }
+}

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -27,7 +27,26 @@ const mocks = vi.hoisted(() => ({
   writeTurnState: vi.fn(),
   resumeToolUseFromResumeData: vi.fn(),
   retrieveSessionResumeData: vi.fn(),
+  throwDeliveryFormatting: false,
 }));
+
+vi.mock('@tools/delegation/subagentDeliveryFormat', async (importOriginal) => {
+  const original =
+    await importOriginal<
+      typeof import('@tools/delegation/subagentDeliveryFormat')
+    >();
+  return {
+    ...original,
+    formatBuiltSubagentDelivery: (
+      ...args: Parameters<typeof original.formatBuiltSubagentDelivery>
+    ) => {
+      if (mocks.throwDeliveryFormatting) {
+        throw new Error('delivery formatting failed');
+      }
+      return original.formatBuiltSubagentDelivery(...args);
+    },
+  };
+});
 
 vi.mock('@agent/runtime/executeAgent', () => ({
   executeAgent: mocks.executeAgent,
@@ -157,6 +176,7 @@ async function launchWaitingTurn(
 describe('NativeSubagentStrategy', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    mocks.throwDeliveryFormatting = false;
     mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
     mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
     mocks.persistChildRunResultMeta.mockResolvedValue({ kind: 'skipped' });
@@ -400,6 +420,20 @@ describe('NativeSubagentStrategy', () => {
     expect(msg).toContain('<response>');
     expect(msg).toContain('The proof holds.');
     expect(msg).toContain('status="completed"');
+  });
+
+  it('builds the durable result before fallible delivery formatting', async () => {
+    const params = baseParams();
+    const strategy = createNativeSubagentStrategy(params);
+    const turn = toolUseTurnResult('completed', params.executionId) as never;
+
+    const built = await strategy.buildResult(turn);
+    mocks.throwDeliveryFormatting = true;
+
+    await expect(strategy.formatDelivery(turn, 1000)).rejects.toThrow(
+      'delivery formatting failed',
+    );
+    await expect(strategy.buildResult(turn)).resolves.toBe(built);
   });
 
   it('reports a non-throwing subagent failure via isTurnError, captured from onRunError', async () => {

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -14,6 +14,7 @@
 
 // Local imports
 import { getExecutionStore, type ResultMeta } from '@agent/storage';
+import { persistChildRunDeliveryBestEffort } from '@agent/storage/childRunDeliveryPersistence';
 import {
   persistChildRunReport,
   persistChildRunResultMeta,
@@ -47,11 +48,7 @@ import {
 // Local file imports
 // Type-only: the strategy module pulls in `@agent/runtime/executeAgent` at
 // runtime (see the lazy import below), but a type import is erased at build.
-import {
-  buildSubagentResult,
-  formatBuiltSubagentDelivery,
-  type BuiltSubagentResult,
-} from './subagentDeliveryFormat';
+import { type BuiltSubagentResult } from './subagentDeliveryFormat';
 import {
   readStableSubagentAttempt,
   readStableSubagentSequence,
@@ -248,7 +245,6 @@ function logPersistenceFailure(
   executionId: ExecutionId,
   error: unknown,
 ): void {
-  markOwnedExecutionLeaseUndurable(executionId);
   logger.warn(
     LOG_CHANNEL,
     `Failed to persist subagent ${kind} for ${executionId}: ${toErrorMessage(error)}`,
@@ -291,23 +287,6 @@ async function throwRetryableDurabilityError(
     );
   }
   throw error;
-}
-
-async function persistDeliveryBestEffort(
-  executionId: ExecutionId,
-  delivery: string,
-  resultMeta: ResultMeta,
-): Promise<void> {
-  const [reportResult, metaResult] = await Promise.all([
-    persistChildRunReport(executionId, delivery),
-    persistChildRunResultMeta(executionId, resultMeta),
-  ]);
-  if (reportResult.kind === 'failed') {
-    logPersistenceFailure('report', executionId, reportResult.err);
-  }
-  if (metaResult.kind === 'failed') {
-    logPersistenceFailure('result manifest', executionId, metaResult.err);
-  }
 }
 
 function recordCost(
@@ -393,7 +372,12 @@ async function persistFailure(
     workingDirectory,
     memoryMisses: result?.memoryMisses,
   });
-  await persistDeliveryBestEffort(executionId, delivery, resultMeta);
+  await persistChildRunDeliveryBestEffort(
+    executionId,
+    delivery,
+    resultMeta,
+    (kind, failure) => logPersistenceFailure(kind, executionId, failure),
+  );
 }
 
 /**
@@ -512,15 +496,7 @@ async function executeInBand(
 
       let built: BuiltSubagentResult;
       try {
-        built = await buildSubagentResult(
-          executionId,
-          options.agentName,
-          flowResult,
-          {
-            startedAt,
-            parentExecutionId: options.parentExecutionId,
-          },
-        );
+        built = await strategy.buildResult(flowResult);
       } catch (error) {
         // The runtime has already finalized this child. A post-flow construction
         // error must not rewrite a completed execution as failed or try to parse
@@ -550,29 +526,31 @@ async function executeInBand(
         await persistResultMetaRequired(executionId, built.resultMeta);
       } else {
         try {
-          delivery = formatBuiltSubagentDelivery(
-            executionId,
-            options.agentName,
+          delivery = await strategy.formatDelivery(
             flowResult,
-            built,
-            workingDirectory,
+            built.wallTimeMs,
           );
         } catch (error) {
-          await persistDeliveryBestEffort(
+          await persistChildRunDeliveryBestEffort(
             executionId,
-            formatSubagentError(executionId, options.agentName, error, {
-              wallTimeMs: built.wallTimeMs,
-              workingDirectory,
-              memoryMisses: flowResult.memoryMisses,
-            }),
+            await strategy.formatError(flowResult, error),
             built.resultMeta,
+            (kind, failure) =>
+              logPersistenceFailure(kind, executionId, failure),
           );
           throw error;
         }
-        await persistDeliveryBestEffort(
+        const resultMeta =
+          (await strategy.buildResultMeta?.(
+            flowResult,
+            false,
+            built.wallTimeMs,
+          )) ?? built.resultMeta;
+        await persistChildRunDeliveryBestEffort(
           executionId,
           delivery,
-          built.resultMeta,
+          resultMeta,
+          (kind, error) => logPersistenceFailure(kind, executionId, error),
         );
       }
 

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -540,16 +540,10 @@ async function executeInBand(
           );
           throw error;
         }
-        const resultMeta =
-          (await strategy.buildResultMeta?.(
-            flowResult,
-            false,
-            built.wallTimeMs,
-          )) ?? built.resultMeta;
         await persistChildRunDeliveryBestEffort(
           executionId,
           delivery,
-          resultMeta,
+          built.resultMeta,
           (kind, error) => logPersistenceFailure(kind, executionId, error),
         );
       }

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -159,10 +159,11 @@ export function createNativeSubagentStrategy(
   // observable through this callback.
   let lastErr: unknown;
   let lastResult: AgentFlowResult | undefined;
-  // formatDelivery always runs before buildResultMeta for the same turn (see
-  // childRunLoop's deliverTurn) — cache the one diff-computing pass here so
-  // the subagent's diffs are written once per turn, not twice.
-  let cachedDelivery: { msg: string; built: BuiltSubagentResult } | undefined;
+  // Result construction computes and persists diffs, so every consumer of a
+  // turn shares one result. Formatting remains separate: if it throws, the
+  // already-built result manifest is still available for persistence.
+  let cachedBuilt: BuiltSubagentResult | undefined;
+  let cachedDelivery: string | undefined;
 
   const resolveDeliveryTarget = (): StreamTabId | undefined =>
     runHandle ? runHandle.deliveryTargetStreamId : params.parentStreamId;
@@ -176,6 +177,7 @@ export function createNativeSubagentStrategy(
   ): Promise<AgentRuntimeFlowResult> => {
     lastErr = undefined;
     lastResult = undefined;
+    cachedBuilt = undefined;
     cachedDelivery = undefined;
     let detachAbort = (): void => {};
     try {
@@ -200,12 +202,12 @@ export function createNativeSubagentStrategy(
     }
   };
 
-  const buildDelivery = async (
+  const buildResult = async (
     turn: AgentRuntimeFlowResult,
-  ): Promise<{ msg: string; built: BuiltSubagentResult }> => {
-    if (!cachedDelivery) {
+  ): Promise<BuiltSubagentResult> => {
+    if (!cachedBuilt) {
       const result = toDeliveryResult(turn, params.executionId);
-      const built = await buildSubagentResult(
+      cachedBuilt = await buildSubagentResult(
         params.executionId,
         params.agentName,
         result,
@@ -214,18 +216,8 @@ export function createNativeSubagentStrategy(
           parentExecutionId: params.parentExecutionId,
         },
       );
-      cachedDelivery = {
-        msg: formatBuiltSubagentDelivery(
-          params.executionId,
-          params.agentName,
-          result,
-          built,
-          params.workingDirectory,
-        ),
-        built,
-      };
     }
-    return cachedDelivery;
+    return cachedBuilt;
   };
 
   return {
@@ -342,10 +334,18 @@ export function createNativeSubagentStrategy(
 
     resolveDeliveryTarget,
 
-    buildResult: async (turn: AgentRuntimeFlowResult) =>
-      (await buildDelivery(turn)).built,
+    buildResult,
 
-    formatDelivery: async (turn) => (await buildDelivery(turn)).msg,
+    formatDelivery: async (turn) => {
+      cachedDelivery ??= formatBuiltSubagentDelivery(
+        params.executionId,
+        params.agentName,
+        toDeliveryResult(turn, params.executionId),
+        await buildResult(turn),
+        params.workingDirectory,
+      );
+      return cachedDelivery;
+    },
 
     formatError: (turn, err) => {
       const wallTimeMs = Date.now() - params.startedAt;
@@ -379,7 +379,7 @@ export function createNativeSubagentStrategy(
           { parentExecutionId: params.parentExecutionId },
         );
       }
-      return (await buildDelivery(turn)).built.resultMeta;
+      return (await buildResult(turn)).resultMeta;
     },
   };
 }

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -26,7 +26,6 @@
  * launching, resuming (tool-use only), and formatting its result shape.
  */
 
-import type { ResultMeta } from '@agent/storage';
 import { getExecutionStore } from '@agent/storage';
 import {
   isWaitingFlowResult,
@@ -64,6 +63,7 @@ import {
 import {
   buildSubagentResult,
   formatBuiltSubagentDelivery,
+  type BuiltSubagentResult,
 } from './subagentDeliveryFormat';
 
 /**
@@ -146,6 +146,10 @@ export function createNativeSubagentStrategy(
   readonly getTurnError: () => unknown;
   /** Terminal-shaped result captured from the most recent turn's return. */
   readonly getTurnResult: () => AgentFlowResult | undefined;
+  /** Shared typed result construction used by detached and in-band drivers. */
+  readonly buildResult: (
+    turn: AgentRuntimeFlowResult,
+  ) => Promise<BuiltSubagentResult>;
 } {
   let runHandle: AgentRunHandle | undefined;
   // Captured for the turn currently in flight; read once the call resolves.
@@ -158,7 +162,7 @@ export function createNativeSubagentStrategy(
   // formatDelivery always runs before buildResultMeta for the same turn (see
   // childRunLoop's deliverTurn) — cache the one diff-computing pass here so
   // the subagent's diffs are written once per turn, not twice.
-  let cachedDelivery: { msg: string; resultMeta: ResultMeta } | undefined;
+  let cachedDelivery: { msg: string; built: BuiltSubagentResult } | undefined;
 
   const resolveDeliveryTarget = (): StreamTabId | undefined =>
     runHandle ? runHandle.deliveryTargetStreamId : params.parentStreamId;
@@ -198,7 +202,7 @@ export function createNativeSubagentStrategy(
 
   const buildDelivery = async (
     turn: AgentRuntimeFlowResult,
-  ): Promise<{ msg: string; resultMeta: ResultMeta }> => {
+  ): Promise<{ msg: string; built: BuiltSubagentResult }> => {
     if (!cachedDelivery) {
       const result = toDeliveryResult(turn, params.executionId);
       const built = await buildSubagentResult(
@@ -218,7 +222,7 @@ export function createNativeSubagentStrategy(
           built,
           params.workingDirectory,
         ),
-        resultMeta: built.resultMeta,
+        built,
       };
     }
     return cachedDelivery;
@@ -338,6 +342,9 @@ export function createNativeSubagentStrategy(
 
     resolveDeliveryTarget,
 
+    buildResult: async (turn: AgentRuntimeFlowResult) =>
+      (await buildDelivery(turn)).built,
+
     formatDelivery: async (turn) => (await buildDelivery(turn)).msg,
 
     formatError: (turn, err) => {
@@ -372,7 +379,7 @@ export function createNativeSubagentStrategy(
           { parentExecutionId: params.parentExecutionId },
         );
       }
-      return (await buildDelivery(turn)).resultMeta;
+      return (await buildDelivery(turn)).built.resultMeta;
     },
   };
 }


### PR DESCRIPTION
Closes #9983.

## Summary

Routes in-band subagent delivery through the native child-run strategy and shares one best-effort delivery persistence operation. Durable result construction is deliberately separate from fallible presentation formatting.

## Issue acceptance gates

- Removes the independent in-band delivery strategy and persistence pair.
- Keeps the required terminal result-manifest write and its failure semantics.
- Ensures a formatting failure cannot prevent an already-built result manifest from being persisted.
- Removes the redundant second result-metadata construction.

## Single source of truth

`createNativeSubagentStrategy` owns native result construction and delivery formatting. `persistChildRunDeliveryBestEffort` owns the paired report/result persistence policy.

## Duplication and abstraction budget

One persistence helper replaces two caller-owned pairs. The strategy caches one built result per turn; it does not add a second result model.

## Net elements (R6)

- Files: 1 added, 4 modified.
- Exported symbols: no change.
- LoC: 122 added, 108 deleted; net +14. The additions are chiefly the shared helper and regression proof; two independent persistence paths are removed.

## Consumer counts (R8)

The shared persistence operation has two consumers: loop-driven delivery and in-band delivery. No emit path or export was deleted.

## Host impact

Extension: No host-specific change.

Desktop: No host-specific change.

CLI: No host-specific change.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- `corepack pnpm test`
- `corepack pnpm run check:dead-code-ratchet`
- Focused delegation and child-run tests, including formatting-failure regression
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subagent result durability and delivery persistence paths, so regressions could drop or mis-persist child-run artifacts. Scope is mostly consolidation of existing behavior with a focused formatting-failure regression test.
> 
> **Overview**
> Unifies child-run delivery persistence and makes durable result construction independent of fallible presentation formatting.
> 
> Adds shared `persistChildRunDeliveryBestEffort` used by both the child-run loop and in-band subagent execution, replacing duplicated best-effort report/manifest persistence. Routes in-band delivery through `createNativeSubagentStrategy` via new `buildResult` / `formatDelivery` separation so a formatting failure can still persist an already-built result manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 629c21366685511097cd7fb69321bd008401e1c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

