### PR TITLE
refactor: centralize active stream rendering

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1070,10 +1070,11 @@ export class DesktopProgressBridge {
   }
 
   private async syncRenderedStreams(syncActiveStream: boolean): Promise<void> {
+    const activeStream = this.state.activeStream;
     try {
       await this.backend.syncRenderedStreams({ syncActiveStream });
     } catch (error) {
-      this.reportTranscriptLoadError(error);
+      this.reportTranscriptLoadError(error, activeStream);
     }
   }
 
@@ -1087,7 +1088,7 @@ export class DesktopProgressBridge {
     try {
       await this.backend.activateStream(streamId);
     } catch (error) {
-      this.reportTranscriptLoadError(error);
+      this.reportTranscriptLoadError(error, streamId);
     }
   }
 
@@ -1114,10 +1115,16 @@ export class DesktopProgressBridge {
     return 'revealed';
   }
 
-  private reportTranscriptLoadError(error: unknown): void {
-    this.logger.error('Failed to load desktop transcript', {
-      data: toLogData(error),
-    });
+  private reportTranscriptLoadError(
+    error: unknown,
+    streamId?: StreamTabId | '',
+  ): void {
+    this.logger.error(
+      `Failed to load desktop transcript${streamId ? ` ${streamId}` : ''}`,
+      {
+        data: toLogData(error),
+      },
+    );
     void this.options.host.showErrorMessage(
       `Transcript load failed: ${toErrorMessage(error)}`,
     );

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -326,10 +326,8 @@ export class DesktopProgressBridge {
           this.workflowFileActions.clearAllBackups();
         },
         rebuildRenderedStreams: ({ syncActiveStream }) => {
-          const activeStream = this.updateStreamMetadata();
-          if (syncActiveStream) this.syncStreamContent(activeStream);
+          void this.syncRenderedStreams(syncActiveStream);
         },
-        activateStream: () => this.syncFullView(),
         notifyDeletionRetained: (activeCount, failedCount) =>
           this.options.host.showInfoMessage(
             failedCount === 0
@@ -1067,15 +1065,16 @@ export class DesktopProgressBridge {
     dispatchPresentationEvent(this.presentationEventHandlers, event, payload);
   }
 
-  private updateStreamMetadata(): StreamTabId | '' {
-    return this.backend.webviewUpdater.sendStreamMetadata(
-      this.state,
-      this.session.status.getAllStreamStates(),
-    );
+  private syncFullView(): void {
+    void this.syncRenderedStreams(true);
   }
 
-  private syncFullView(): void {
-    this.syncStreamContent(this.updateStreamMetadata());
+  private async syncRenderedStreams(syncActiveStream: boolean): Promise<void> {
+    try {
+      await this.backend.syncRenderedStreams({ syncActiveStream });
+    } catch (error) {
+      this.reportTranscriptLoadError(error);
+    }
   }
 
   /** Send canonical state and replay pending prompts after attachment. */
@@ -1084,14 +1083,12 @@ export class DesktopProgressBridge {
     await replayApprovalRequestHandlers(this.backend.approvalHandlers);
   }
 
-  private setActiveStream(streamId: StreamTabId): void {
-    if (!this.streamLogs.has(streamId)) {
-      return;
+  private async setActiveStream(streamId: StreamTabId): Promise<void> {
+    try {
+      await this.backend.activateStream(streamId);
+    } catch (error) {
+      this.reportTranscriptLoadError(error);
     }
-    this.state.switchActiveStream(streamId);
-    this.updateStreamMetadata();
-    this.backend.webviewUpdater.setActiveStream(streamId);
-    this.syncStreamContent(streamId);
   }
 
   /**
@@ -1113,32 +1110,17 @@ export class DesktopProgressBridge {
     if (!this.streamLogs.has(streamId)) {
       return 'missing';
     }
-    this.setActiveStream(streamId);
+    await this.setActiveStream(streamId);
     return 'revealed';
   }
 
-  private syncStreamContent(streamId: StreamTabId | ''): void {
-    if (!streamId) {
-      this.backend.syncStreamContent('');
-      return;
-    }
-
-    void this.streamLogs
-      .ensureLoaded(streamId)
-      .then(() => {
-        if (this.state.activeStream !== streamId) return;
-        this.backend.syncStreamContent(streamId, {
-          includeActiveState: true,
-        });
-      })
-      .catch((error: unknown) => {
-        this.logger.error(`Failed to load desktop transcript ${streamId}`, {
-          data: toLogData(error),
-        });
-        void this.options.host.showErrorMessage(
-          `Transcript load failed: ${toErrorMessage(error)}`,
-        );
-      });
+  private reportTranscriptLoadError(error: unknown): void {
+    this.logger.error('Failed to load desktop transcript', {
+      data: toLogData(error),
+    });
+    void this.options.host.showErrorMessage(
+      `Transcript load failed: ${toErrorMessage(error)}`,
+    );
   }
 
   private async runLatexdiffFile(

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -272,6 +272,8 @@ export class DesktopProgressBridge {
         getProgressStreamControls(stream, this.session),
       getUnsupportedCommands: () =>
         unsupportedCommands(this.progressViewInboundHandlers),
+      reportTranscriptLoadError: (error, stream) =>
+        this.reportTranscriptLoadError(error, stream),
       approvals: {
         // The desktop renderer is always attached (no sidebar/editor re-target).
         canSend: () => true,
@@ -1070,12 +1072,7 @@ export class DesktopProgressBridge {
   }
 
   private async syncRenderedStreams(syncActiveStream: boolean): Promise<void> {
-    const activeStream = this.state.activeStream;
-    try {
-      await this.backend.syncRenderedStreams({ syncActiveStream });
-    } catch (error) {
-      this.reportTranscriptLoadError(error, activeStream);
-    }
+    await this.backend.syncRenderedStreams({ syncActiveStream });
   }
 
   /** Send canonical state and replay pending prompts after attachment. */
@@ -1085,11 +1082,7 @@ export class DesktopProgressBridge {
   }
 
   private async setActiveStream(streamId: StreamTabId): Promise<void> {
-    try {
-      await this.backend.activateStream(streamId);
-    } catch (error) {
-      this.reportTranscriptLoadError(error, streamId);
-    }
+    await this.backend.activateStream(streamId);
   }
 
   /**

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -315,7 +315,9 @@ export class ProgressViewProvider extends BaseWebviewProvider {
 
     void this.backend
       .syncRenderedStreams({ syncActiveStream, theme })
-      .catch((error: unknown) => this.reportTranscriptLoadError(error));
+      .catch((error: unknown) =>
+        this.reportTranscriptLoadError(error, this.state.activeStream),
+      );
   }
 
   public async markWebviewReady(
@@ -364,12 +366,18 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     try {
       await this.backend.activateStream(streamId);
     } catch (error) {
-      this.reportTranscriptLoadError(error);
+      this.reportTranscriptLoadError(error, streamId);
     }
   }
 
-  private reportTranscriptLoadError(error: unknown): void {
-    this.logger.error('Failed to load transcript for display', { data: error });
+  private reportTranscriptLoadError(
+    error: unknown,
+    streamId?: StreamTabId | '',
+  ): void {
+    this.logger.error(
+      `Failed to load transcript for display${streamId ? ` ${streamId}` : ''}`,
+      { data: error },
+    );
     void vscode.window.showErrorMessage(
       'TeXRA could not read this transcript. Select the run again to retry.',
     );

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -110,6 +110,8 @@ export class ProgressViewProvider extends BaseWebviewProvider {
       getStreamControls: getProgressStreamControls,
       getUnsupportedCommands: () =>
         this.messageHandler.getUnsupportedCommands(),
+      reportTranscriptLoadError: (error, stream) =>
+        this.reportTranscriptLoadError(error, stream),
       approvals: {
         canSend: () => this.canSendToWebview(),
         logger: this.logger,
@@ -313,12 +315,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
 
     this.webviewUpdater.setPlacement(target.placement);
 
-    const activeStream = this.state.activeStream;
-    void this.backend
-      .syncRenderedStreams({ syncActiveStream, theme })
-      .catch((error: unknown) =>
-        this.reportTranscriptLoadError(error, activeStream),
-      );
+    void this.backend.syncRenderedStreams({ syncActiveStream, theme });
   }
 
   public async markWebviewReady(
@@ -364,11 +361,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
   }
 
   public async setActiveStream(streamId: StreamTabId): Promise<void> {
-    try {
-      await this.backend.activateStream(streamId);
-    } catch (error) {
-      this.reportTranscriptLoadError(error, streamId);
-    }
+    await this.backend.activateStream(streamId);
   }
 
   private reportTranscriptLoadError(

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -139,7 +139,6 @@ export class ProgressViewProvider extends BaseWebviewProvider {
         cleanupDeletedStreams: (options) =>
           this.messageHandler.cleanupDeletedStreams(options),
         rebuildRenderedStreams: (options) => this.syncRenderedStreams(options),
-        activateStream: (stream) => this.setActiveStream(stream),
         notifyDeletionRetained: async (activeCount, failedCount) => {
           await vscode.window.showInformationMessage(
             failedCount === 0
@@ -314,40 +313,9 @@ export class ProgressViewProvider extends BaseWebviewProvider {
 
     this.webviewUpdater.setPlacement(target.placement);
 
-    const activeStream = this.webviewUpdater.sendStreamMetadata(
-      this.state,
-      this.state.streamStatus.getAllStreamStates(),
-      theme,
-    );
-    if (!syncActiveStream) return;
-
-    // Skip content sync when streams exist but filter excludes all of them
-    const hasStreams = this.state.streamLogs.keys().length > 0;
-    if (activeStream || !hasStreams) {
-      // If the active stream's entries were released (e.g. filter change
-      // moved active to a previously-evicted stream), rehydrate before
-      // syncing so the webview doesn't render an empty log. Fall back to
-      // an immediate sync when the log is already resident.
-      if (activeStream && !this.state.streamLogs.get(activeStream)) {
-        void this.state.streamLogs
-          .ensureLoaded(activeStream)
-          .then(() => {
-            if (this.state.activeStream !== activeStream) return;
-            this.backend.syncStreamContent(activeStream);
-          })
-          .catch((error: unknown) => {
-            this.logger.error(
-              `Failed to load transcript ${activeStream} for display`,
-              { data: error },
-            );
-            void vscode.window.showErrorMessage(
-              'TeXRA could not read this transcript. Select the run again to retry.',
-            );
-          });
-      } else {
-        this.backend.syncStreamContent(activeStream);
-      }
-    }
+    void this.backend
+      .syncRenderedStreams({ syncActiveStream, theme })
+      .catch((error: unknown) => this.reportTranscriptLoadError(error));
   }
 
   public async markWebviewReady(
@@ -393,27 +361,18 @@ export class ProgressViewProvider extends BaseWebviewProvider {
   }
 
   public async setActiveStream(streamId: StreamTabId): Promise<void> {
-    // The switch also catches the "terminal-while-active" case: a stream that
-    // reached a non-in-flight status while it was the visible tab never
-    // triggered release (the setStreamStatus guard excludes the active
-    // stream). Now that the user has moved on, it's eligible.
-    this.state.switchActiveStream(streamId);
+    try {
+      await this.backend.activateStream(streamId);
+    } catch (error) {
+      this.reportTranscriptLoadError(error);
+    }
+  }
 
-    if (!this.canSendToWebview()) return;
-
-    // Rehydrate entries released by the status-change eviction so the
-    // newly-active tab shows its full log instead of an empty view.
-    if (streamId) await this.state.streamLogs.ensureLoaded(streamId);
-
-    // Another setActiveStream may have run while we awaited rehydration;
-    // let the newer call own the webview sync so we don't overwrite it.
-    if (this.state.activeStream !== streamId) return;
-
-    this.webviewUpdater.setActiveStream(streamId);
-    // Hydrate content (logs, todos, follow-ups, instruction, bypass state) + active-state metadata
-    this.backend.syncStreamContent(streamId, {
-      includeActiveState: true,
-    });
+  private reportTranscriptLoadError(error: unknown): void {
+    this.logger.error('Failed to load transcript for display', { data: error });
+    void vscode.window.showErrorMessage(
+      'TeXRA could not read this transcript. Select the run again to retry.',
+    );
   }
 
   public async revealStream(

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -313,10 +313,11 @@ export class ProgressViewProvider extends BaseWebviewProvider {
 
     this.webviewUpdater.setPlacement(target.placement);
 
+    const activeStream = this.state.activeStream;
     void this.backend
       .syncRenderedStreams({ syncActiveStream, theme })
       .catch((error: unknown) =>
-        this.reportTranscriptLoadError(error, this.state.activeStream),
+        this.reportTranscriptLoadError(error, activeStream),
       );
   }
 

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -49,7 +49,6 @@ interface ProgressBackendLifecycleOptions {
   cleanupDeletedStream(stream: StreamTabId): void;
   cleanupDeletedStreams(options: { allDeleted: boolean }): void;
   rebuildRenderedStreams(options: { syncActiveStream: boolean }): void;
-  activateStream(stream: StreamTabId): Promise<void> | void;
   notifyDeletionRetained(
     activeCount: number,
     failedCount: number,
@@ -172,6 +171,43 @@ export class ProgressBackend {
     this.litRenderer.syncStreamContent(stream, options);
   }
 
+  /** Rebuild stream tabs and, when requested, rehydrate the active viewport. */
+  async syncRenderedStreams(options: {
+    syncActiveStream: boolean;
+    theme?: 'dark' | 'light';
+  }): Promise<void> {
+    const activeStream = this.webviewUpdater.sendStreamMetadata(
+      this.state,
+      this.state.streamStatus.getAllStreamStates(),
+      options.theme,
+    );
+    if (!options.syncActiveStream) return;
+
+    const hasStreams = this.state.streamLogs.keys().length > 0;
+    if (!activeStream && hasStreams) return;
+    await this.syncActiveStream(activeStream, false, false);
+  }
+
+  /** Select and render one existing stream without rebuilding the tab list. */
+  async activateStream(stream: StreamTabId): Promise<boolean> {
+    if (!this.state.streamLogs.has(stream)) return false;
+    this.state.switchActiveStream(stream);
+    await this.syncActiveStream(stream, true, true);
+    return true;
+  }
+
+  private async syncActiveStream(
+    stream: StreamTabId | '',
+    includeActiveState: boolean,
+    notifyActivation: boolean,
+  ): Promise<void> {
+    if (!this.litRenderer.isAvailable()) return;
+    if (stream) await this.state.streamLogs.ensureLoaded(stream);
+    if (this.state.activeStream !== stream) return;
+    if (notifyActivation) this.litRenderer.onActiveStreamChanged(stream);
+    this.litRenderer.syncStreamContent(stream, { includeActiveState });
+  }
+
   /**
    * Cancel every still-running stream because the app itself is going away.
    * App-lifecycle only (extension deactivating); not a session fact.
@@ -285,6 +321,7 @@ export class ProgressBackend {
     this.webviewBridge.clearStream(stream);
 
     let shouldActivateStream = false;
+    let notifyActivation = true;
     const activeAfterClear = this.state.activeStream;
     const remainingStreams = this.state.selectableStreamNames();
     const hasVisibleActive =
@@ -294,6 +331,9 @@ export class ProgressBackend {
         this.state.rotateActiveStream(remainingStreams) !== '';
     } else if (wasActive && hasVisibleActive) {
       shouldActivateStream = true;
+      // A newer activation won while deletion awaited storage. Its fact
+      // already focused the renderer; only refresh its content here.
+      notifyActivation = false;
     }
 
     this.postMessage({
@@ -303,7 +343,11 @@ export class ProgressBackend {
 
     const nextActive = this.state.activeStream;
     if (shouldActivateStream && nextActive) {
-      await this.lifecycle.activateStream(nextActive);
+      if (notifyActivation) {
+        await this.activateStream(nextActive);
+      } else {
+        await this.syncActiveStream(nextActive, true, false);
+      }
     } else {
       // The deleted stream was not the active one, so only the stream list
       // changed; the active stream's content is still on screen and correct.

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -327,7 +327,6 @@ export class ProgressBackend {
     this.webviewBridge.clearStream(stream);
 
     let shouldActivateStream = false;
-    let notifyActivation = true;
     const activeAfterClear = this.state.activeStream;
     const remainingStreams = this.state.selectableStreamNames();
     const hasVisibleActive =
@@ -337,9 +336,6 @@ export class ProgressBackend {
         this.state.rotateActiveStream(remainingStreams) !== '';
     } else if (wasActive && hasVisibleActive) {
       shouldActivateStream = true;
-      // A newer activation won while deletion awaited storage. Its fact
-      // already focused the renderer; only refresh its content here.
-      notifyActivation = false;
     }
 
     this.postMessage({
@@ -349,13 +345,10 @@ export class ProgressBackend {
 
     const nextActive = this.state.activeStream;
     if (shouldActivateStream && nextActive) {
-      if (notifyActivation) {
-        await this.activateStream(nextActive);
-      } else {
-        await this.syncActiveStream(nextActive, {
-          notifyActivation: false,
-        });
-      }
+      // DELETE_STREAM clears the frontend selection when the deleted tab was
+      // active. Reassert the surviving selection even when a concurrent
+      // activation already selected it while storage deletion was pending.
+      await this.activateStream(nextActive);
     } else {
       // The deleted stream was not the active one, so only the stream list
       // changed; the active stream's content is still on screen and correct.

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -185,27 +185,33 @@ export class ProgressBackend {
 
     const hasStreams = this.state.streamLogs.keys().length > 0;
     if (!activeStream && hasStreams) return;
-    await this.syncActiveStream(activeStream, false, false);
+    await this.syncActiveStream(activeStream, {
+      notifyActivation: false,
+    });
   }
 
   /** Select and render one existing stream without rebuilding the tab list. */
   async activateStream(stream: StreamTabId): Promise<boolean> {
     if (!this.state.streamLogs.has(stream)) return false;
     this.state.switchActiveStream(stream);
-    await this.syncActiveStream(stream, true, true);
+    await this.syncActiveStream(stream, {
+      notifyActivation: true,
+    });
     return true;
   }
 
   private async syncActiveStream(
     stream: StreamTabId | '',
-    includeActiveState: boolean,
-    notifyActivation: boolean,
+    options: {
+      notifyActivation: boolean;
+    },
   ): Promise<void> {
     if (!this.litRenderer.isAvailable()) return;
     if (stream) await this.state.streamLogs.ensureLoaded(stream);
     if (this.state.activeStream !== stream) return;
-    if (notifyActivation) this.litRenderer.onActiveStreamChanged(stream);
-    this.litRenderer.syncStreamContent(stream, { includeActiveState });
+    if (options.notifyActivation)
+      this.litRenderer.onActiveStreamChanged(stream);
+    this.litRenderer.syncStreamContent(stream, { includeActiveState: true });
   }
 
   /**
@@ -346,7 +352,9 @@ export class ProgressBackend {
       if (notifyActivation) {
         await this.activateStream(nextActive);
       } else {
-        await this.syncActiveStream(nextActive, true, false);
+        await this.syncActiveStream(nextActive, {
+          notifyActivation: false,
+        });
       }
     } else {
       // The deleted stream was not the active one, so only the stream list

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -62,6 +62,7 @@ export interface ProgressBackendOptions {
   hasTarget(): boolean;
   approvals: ProgressBackendApprovalOptions;
   lifecycle: ProgressBackendLifecycleOptions;
+  reportTranscriptLoadError(error: unknown, stream: StreamTabId | ''): void;
   getStreamControls?: GetProgressStreamControls;
   /** Session that owns this backend's coordination state (defaults to the process session). */
   session?: SessionHandle;
@@ -99,6 +100,7 @@ export class ProgressBackend {
   private readonly litRenderer: LitSessionRenderer;
   private readonly session: SessionHandle;
   private readonly lifecycle: ProgressBackendLifecycleOptions;
+  private readonly reportTranscriptLoadError: ProgressBackendOptions['reportTranscriptLoadError'];
   private readonly postMessage: (message: ProgressViewOutboundMessage) => void;
   private readonly stateOwnership: 'backend' | 'session';
   private readonly storageOperationQueue = new PQueue({ concurrency: 1 });
@@ -111,6 +113,7 @@ export class ProgressBackend {
     this.session = options.session ?? defaultSession();
     this.stateOwnership = options.stateOwnership ?? 'backend';
     this.lifecycle = options.lifecycle;
+    this.reportTranscriptLoadError = options.reportTranscriptLoadError;
     this.postMessage = (message) => {
       if (!options.hasTarget()) return;
       // View refreshes are best-effort; a closed transport must not take down
@@ -185,19 +188,26 @@ export class ProgressBackend {
 
     const hasStreams = this.state.streamLogs.keys().length > 0;
     if (!activeStream && hasStreams) return;
-    await this.syncActiveStream(activeStream, {
-      notifyActivation: false,
-    });
+    try {
+      await this.syncActiveStream(activeStream, {
+        notifyActivation: false,
+      });
+    } catch (error) {
+      this.reportTranscriptLoadError(error, activeStream);
+    }
   }
 
   /** Select and render one existing stream without rebuilding the tab list. */
-  async activateStream(stream: StreamTabId): Promise<boolean> {
-    if (!this.state.streamLogs.has(stream)) return false;
+  async activateStream(stream: StreamTabId): Promise<void> {
+    if (!this.state.streamLogs.has(stream)) return;
     this.state.switchActiveStream(stream);
-    await this.syncActiveStream(stream, {
-      notifyActivation: true,
-    });
-    return true;
+    try {
+      await this.syncActiveStream(stream, {
+        notifyActivation: true,
+      });
+    } catch (error) {
+      this.reportTranscriptLoadError(error, stream);
+    }
   }
 
   private async syncActiveStream(
@@ -207,7 +217,16 @@ export class ProgressBackend {
     },
   ): Promise<void> {
     if (!this.litRenderer.isAvailable()) return;
-    if (stream) await this.state.streamLogs.ensureLoaded(stream);
+    if (stream) {
+      try {
+        await this.state.streamLogs.ensureLoaded(stream);
+      } catch (error) {
+        if (options.notifyActivation && this.state.activeStream === stream) {
+          this.litRenderer.onActiveStreamChanged(stream);
+        }
+        throw error;
+      }
+    }
     if (this.state.activeStream !== stream) return;
     if (options.notifyActivation)
       this.litRenderer.onActiveStreamChanged(stream);

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -1782,6 +1782,7 @@ describe('DesktopProgressBridge', () => {
         messages.map((message) => (message as ProgressMessage).command),
       ).toEqual([
         PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
+        PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
         PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
         PROGRESS_VIEW_COMMANDS.LOG_DELTA,
       ]),
@@ -1791,6 +1792,10 @@ describe('DesktopProgressBridge', () => {
       stream: 'second',
     });
     expect(messages[1]).toMatchObject({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: 'first',
+    });
+    expect(messages[2]).toMatchObject({
       command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
       action: 'render',
       stream: 'first',
@@ -1805,7 +1810,7 @@ describe('DesktopProgressBridge', () => {
         },
       },
     });
-    expect(messages[2]).toMatchObject({
+    expect(messages[3]).toMatchObject({
       command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
       streamId: 'first',
       entries: [expect.objectContaining({ text: 'first stream log' })],
@@ -1922,6 +1927,10 @@ describe('DesktopProgressBridge', () => {
     expect(
       progressMessages(messages, PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM),
     ).toEqual([
+      {
+        activeStream: 'third',
+        command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      },
       {
         activeStream: 'third',
         command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -761,6 +761,13 @@ function lastStreamSync(messages: unknown[]): ProgressMessage | undefined {
   );
 }
 
+function lastContentSync(messages: unknown[]): ProgressMessage | undefined {
+  return progressMessages(
+    messages,
+    PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+  ).at(-1);
+}
+
 function expectPermissionResolved(
   messages: unknown[],
   kind: PermissionKind,
@@ -1673,8 +1680,8 @@ describe('DesktopProgressBridge', () => {
       activeStream: 'goal-owning-stream',
       command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
     });
-    expect(lastStreamSync(messages)).toMatchObject({
-      activeStream: 'goal-owning-stream',
+    expect(lastContentSync(messages)).toMatchObject({
+      stream: 'goal-owning-stream',
     });
   });
 
@@ -1712,7 +1719,7 @@ describe('DesktopProgressBridge', () => {
 
     await bridge.revealStream(streamId);
 
-    expect(lastStreamSync(messages)).toMatchObject({ activeStream: streamId });
+    expect(lastContentSync(messages)).toMatchObject({ stream: streamId });
   });
 
   it('reveals a goal-owned stream after persistent opening completes', async () => {
@@ -1775,7 +1782,6 @@ describe('DesktopProgressBridge', () => {
         messages.map((message) => (message as ProgressMessage).command),
       ).toEqual([
         PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
-        PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
         PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
         PROGRESS_VIEW_COMMANDS.LOG_DELTA,
       ]),
@@ -1785,10 +1791,6 @@ describe('DesktopProgressBridge', () => {
       stream: 'second',
     });
     expect(messages[1]).toMatchObject({
-      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-      activeStream: 'first',
-    });
-    expect(messages[2]).toMatchObject({
       command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
       action: 'render',
       stream: 'first',
@@ -1803,7 +1805,7 @@ describe('DesktopProgressBridge', () => {
         },
       },
     });
-    expect(messages[3]).toMatchObject({
+    expect(messages[2]).toMatchObject({
       command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
       streamId: 'first',
       entries: [expect.objectContaining({ text: 'first stream log' })],
@@ -1925,7 +1927,7 @@ describe('DesktopProgressBridge', () => {
         command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
       },
     ]);
-    expect(lastStreamSync(messages)).toMatchObject({ activeStream: 'third' });
+    expect(lastContentSync(messages)).toMatchObject({ stream: 'third' });
   });
 
   it('falls back if a deleted stream is reactivated during deletion', async () => {
@@ -3204,8 +3206,7 @@ describe('DesktopProgressBridge', () => {
       const { bridgeB } = await owner.reopen(messagesB);
 
       try {
-        // Activate the stream to trigger UPDATE_STREAMS delivery
-        bridgeB.revealStream(streamId);
+        await bridgeB.revealStream(streamId);
         await vi.waitFor(() => {
           const approvalShows = progressMessages(
             messagesB,
@@ -3217,16 +3218,8 @@ describe('DesktopProgressBridge', () => {
                 'plan-requested-while-headless',
           );
           expect(approvalShows).toHaveLength(1);
-          expect(
-            progressMessages(
-              messagesB,
-              PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-            ).at(-1),
-          ).toMatchObject({
-            activeStream: streamId,
-            streams: expect.arrayContaining([
-              expect.objectContaining({ name: streamId }),
-            ]),
+          expect(lastContentSync(messagesB)).toMatchObject({
+            stream: streamId,
           });
         });
         expect(
@@ -3959,7 +3952,8 @@ describe('DesktopProgressBridge', () => {
           1: [outputFile],
         });
 
-        bridgeB.setActiveStream(childStreamId);
+        await bridgeB.completeWebviewReady();
+        await bridgeB.setActiveStream(childStreamId);
         const childMessages = (command: string, idKey: string) =>
           progressMessages(messagesB, command).filter(
             (message) =>
@@ -3975,7 +3969,6 @@ describe('DesktopProgressBridge', () => {
           ).toHaveLength(1);
         });
         expect(lastStreamSync(messagesB)).toMatchObject({
-          activeStream: childStreamId,
           streams: expect.arrayContaining([
             expect.objectContaining({
               name: childStreamId,

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -279,6 +279,10 @@ describe('ProgressBackend', () => {
       command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
       stream: second,
     });
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: first,
+    });
   });
 
   it('releases the tab left behind when deletion rotates the selection', async () => {
@@ -367,12 +371,10 @@ describe('ProgressBackend', () => {
         activeState: expect.any(Object),
       }),
     );
-    expect(
-      messages.filter(
-        (message) =>
-          message.command === PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
-      ),
-    ).toHaveLength(0);
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: selected,
+    });
   });
 
   it('cleans every stream and emits one bulk deletion', async () => {

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -328,7 +328,7 @@ describe('ProgressBackend', () => {
 
   it('preserves a stream switch during active-stream deletion', async () => {
     const target = createIsolatedRecordingBackend();
-    const { backend, lifecycle } = target;
+    const { backend, messages } = target;
     const active = 'active-stream' as StreamTabId;
     const fallback = 'fallback-stream' as StreamTabId;
     const selected = 'selected-during-delete' as StreamTabId;
@@ -347,6 +347,10 @@ describe('ProgressBackend', () => {
     for (const stream of [active, fallback, selected]) {
       backend.state.streamLogs.ensureStream(stream);
     }
+    backend.state.updateStreamMetadata(selected, {
+      agentCategory: AgentCategory.ToolUse,
+    });
+    backend.state.getOrCreateStreamState(selected, AgentCategory.ToolUse);
     backend.state.switchActiveStream(active);
 
     const deletion = backend.deleteStream(active);
@@ -355,6 +359,20 @@ describe('ProgressBackend', () => {
     await deletion;
 
     expect(backend.state.activeStream).toBe(selected);
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+        action: 'render',
+        stream: selected,
+        activeState: expect.any(Object),
+      }),
+    );
+    expect(
+      messages.filter(
+        (message) =>
+          message.command === PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      ),
+    ).toHaveLength(0);
   });
 
   it('cleans every stream and emits one bulk deletion', async () => {

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -274,7 +274,7 @@ describe('ProgressBackend', () => {
     await backend.deleteStream(second);
 
     expect(lifecycle.cleanupDeletedStream).toHaveBeenCalledWith(second);
-    expect(lifecycle.activateStream).toHaveBeenCalledWith(first);
+    expect(backend.state.activeStream).toBe(first);
     expect(messages).toContainEqual({
       command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
       stream: second,
@@ -314,11 +314,12 @@ describe('ProgressBackend', () => {
 
     backend.state.streamLogs.ensureStream(only);
     backend.state.switchActiveStream(only);
+    const activateStream = vi.spyOn(backend, 'activateStream');
 
     await backend.deleteStream(only);
 
     expect(backend.state.activeStream).toBe('');
-    expect(lifecycle.activateStream).not.toHaveBeenCalled();
+    expect(activateStream).not.toHaveBeenCalled();
     // No stream was activated, so only the stream list is resent.
     expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
       syncActiveStream: false,
@@ -354,7 +355,6 @@ describe('ProgressBackend', () => {
     await deletion;
 
     expect(backend.state.activeStream).toBe(selected);
-    expect(lifecycle.activateStream).toHaveBeenCalledWith(selected);
   });
 
   it('cleans every stream and emits one bulk deletion', async () => {

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -285,6 +285,59 @@ describe('ProgressBackend', () => {
     });
   });
 
+  it('keeps the fallback selected when its transcript fails to load', async () => {
+    const target = createIsolatedRecordingBackend();
+    const { backend, messages, reportTranscriptLoadError } = target;
+    const fallback = 'fallback-stream' as StreamTabId;
+    const active = 'active-stream' as StreamTabId;
+    const loadError = new Error('transcript unavailable');
+
+    backend.state.streamLogs.ensureStream(fallback);
+    backend.state.streamLogs.ensureStream(active);
+    backend.state.switchActiveStream(active);
+    vi.spyOn(backend.state.streamLogs, 'ensureLoaded').mockRejectedValueOnce(
+      loadError,
+    );
+
+    await backend.deleteStream(active);
+
+    expect(backend.state.activeStream).toBe(fallback);
+    expect(reportTranscriptLoadError).toHaveBeenCalledWith(loadError, fallback);
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: fallback,
+    });
+  });
+
+  it('reports the stream whose full refresh fails after selection changes', async () => {
+    const target = createIsolatedRecordingBackend();
+    const { backend, reportTranscriptLoadError } = target;
+    const refreshing = 'refreshing-stream' as StreamTabId;
+    const selected = 'new-selection' as StreamTabId;
+    const loadError = new Error('read failed');
+    let rejectRefresh!: (error: Error) => void;
+
+    backend.state.streamLogs.ensureStream(refreshing);
+    backend.state.streamLogs.ensureStream(selected);
+    backend.state.switchActiveStream(refreshing);
+    vi.spyOn(backend.state.streamLogs, 'ensureLoaded').mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectRefresh = reject;
+        }),
+    );
+
+    const refresh = backend.syncRenderedStreams({ syncActiveStream: true });
+    backend.state.switchActiveStream(selected);
+    rejectRefresh(loadError);
+    await refresh;
+
+    expect(reportTranscriptLoadError).toHaveBeenCalledWith(
+      loadError,
+      refreshing,
+    );
+  });
+
   it('releases the tab left behind when deletion rotates the selection', async () => {
     const target = createIsolatedRecordingBackend();
     const { backend, lifecycle } = target;
@@ -500,6 +553,7 @@ describe('ProgressBackend', () => {
         session,
         sendMessage: vi.fn(),
         hasTarget: () => true,
+        reportTranscriptLoadError: vi.fn(),
         approvals: createApprovalOptions(),
         lifecycle,
       }),
@@ -525,6 +579,7 @@ describe('ProgressBackend', () => {
         storage: new FakeStateStore(),
         sendMessage: sent,
         hasTarget: () => hasTarget,
+        reportTranscriptLoadError: vi.fn(),
         approvals: createApprovalOptions(),
         lifecycle: createLifecycleOptions(),
       }),
@@ -556,6 +611,7 @@ describe('ProgressBackend', () => {
         storage: new FakeStateStore(),
         sendMessage: sent,
         hasTarget: () => true,
+        reportTranscriptLoadError: vi.fn(),
         approvals: createApprovalOptions(),
         lifecycle: createLifecycleOptions(),
       }),

--- a/src/test-kernel/progressView/ProgressTargetOwnership.vitest.ts
+++ b/src/test-kernel/progressView/ProgressTargetOwnership.vitest.ts
@@ -114,6 +114,7 @@ function createProvider() {
     streamStatus: { getAllStreamStates: () => new Map() },
   };
   injected.backend = {
+    activateStream: vi.fn(async () => false),
     approvalHandlers: {},
     syncRenderedStreams: vi.fn(async () => {}),
   };

--- a/src/test-kernel/progressView/ProgressTargetOwnership.vitest.ts
+++ b/src/test-kernel/progressView/ProgressTargetOwnership.vitest.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   createWebviewPanel: vi.fn(),
   executeCommand: vi.fn(async () => undefined),
   replayApprovalRequestHandlers: vi.fn(async () => undefined),
+  showErrorMessage: vi.fn(async () => undefined),
 }));
 
 vi.mock('vscode', async (importOriginal) => {
@@ -17,6 +18,7 @@ vi.mock('vscode', async (importOriginal) => {
       ...(actual.window as Record<string, unknown>),
       activeColorTheme: { kind: 1 },
       createWebviewPanel: mocks.createWebviewPanel,
+      showErrorMessage: mocks.showErrorMessage,
     },
     commands: { executeCommand: mocks.executeCommand },
     Uri: {
@@ -108,22 +110,26 @@ function createProvider() {
   injected.context = { extensionUri: { fsPath: '/ext' } };
   injected.contentProvider = { getHtmlContent: () => '<progress-view />' };
   injected.messageHandler = { handleMessage: vi.fn() };
-  injected.state = {
+  const state = {
     activeStream: undefined,
     streamLogs: { keys: () => [], get: () => undefined },
     streamStatus: { getAllStreamStates: () => new Map() },
   };
-  injected.backend = {
+  injected.state = state;
+  const backend = {
     activateStream: vi.fn(async () => false),
     approvalHandlers: {},
     syncRenderedStreams: vi.fn(async () => {}),
   };
+  injected.backend = backend;
+  const logger = { error: vi.fn() };
+  injected.logger = logger;
   injected.webviewUpdater = {
     isAvailable: () => true,
     setPlacement: vi.fn(),
     sendStreamMetadata: vi.fn(() => undefined),
   };
-  return { provider, mainViewProvider, sidebarView };
+  return { provider, mainViewProvider, sidebarView, backend, logger, state };
 }
 
 describe('progress target ownership', () => {
@@ -149,6 +155,27 @@ describe('progress target ownership', () => {
 
     await provider.markWebviewReady(panel as unknown as vscode.WebviewPanel);
     expect(mocks.replayApprovalRequestHandlers).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports the stream whose refresh failed after selection changes', async () => {
+    const { provider, backend, logger, state } = createProvider();
+    let rejectRefresh!: (error: Error) => void;
+    backend.syncRenderedStreams.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectRefresh = reject;
+        }),
+    );
+    state.activeStream = 'refreshing-stream' as never;
+    (provider as unknown as { target: { ready: boolean } }).target.ready = true;
+
+    provider.syncFullView();
+    state.activeStream = 'new-selection' as never;
+    rejectRefresh(new Error('read failed'));
+
+    await vi.waitFor(() => expect(logger.error).toHaveBeenCalledOnce());
+    expect(logger.error.mock.calls[0]?.[0]).toContain('refreshing-stream');
+    expect(logger.error.mock.calls[0]?.[0]).not.toContain('new-selection');
   });
 
   it('drops the target when the editor panel is closed', async () => {

--- a/src/test-kernel/progressView/ProgressTargetOwnership.vitest.ts
+++ b/src/test-kernel/progressView/ProgressTargetOwnership.vitest.ts
@@ -115,7 +115,7 @@ function createProvider() {
   };
   injected.backend = {
     approvalHandlers: {},
-    syncStreamContent: vi.fn(),
+    syncRenderedStreams: vi.fn(async () => {}),
   };
   injected.webviewUpdater = {
     isAvailable: () => true,

--- a/src/test-kernel/progressView/ProgressTargetOwnership.vitest.ts
+++ b/src/test-kernel/progressView/ProgressTargetOwnership.vitest.ts
@@ -117,7 +117,7 @@ function createProvider() {
   };
   injected.state = state;
   const backend = {
-    activateStream: vi.fn(async () => false),
+    activateStream: vi.fn(async () => undefined),
     approvalHandlers: {},
     syncRenderedStreams: vi.fn(async () => {}),
   };
@@ -129,7 +129,7 @@ function createProvider() {
     setPlacement: vi.fn(),
     sendStreamMetadata: vi.fn(() => undefined),
   };
-  return { provider, mainViewProvider, sidebarView, backend, logger, state };
+  return { provider, mainViewProvider, sidebarView, backend, state };
 }
 
 describe('progress target ownership', () => {
@@ -155,27 +155,6 @@ describe('progress target ownership', () => {
 
     await provider.markWebviewReady(panel as unknown as vscode.WebviewPanel);
     expect(mocks.replayApprovalRequestHandlers).toHaveBeenCalledTimes(2);
-  });
-
-  it('reports the stream whose refresh failed after selection changes', async () => {
-    const { provider, backend, logger, state } = createProvider();
-    let rejectRefresh!: (error: Error) => void;
-    backend.syncRenderedStreams.mockImplementationOnce(
-      () =>
-        new Promise<void>((_resolve, reject) => {
-          rejectRefresh = reject;
-        }),
-    );
-    state.activeStream = 'refreshing-stream' as never;
-    (provider as unknown as { target: { ready: boolean } }).target.ready = true;
-
-    provider.syncFullView();
-    state.activeStream = 'new-selection' as never;
-    rejectRefresh(new Error('read failed'));
-
-    await vi.waitFor(() => expect(logger.error).toHaveBeenCalledOnce());
-    expect(logger.error.mock.calls[0]?.[0]).toContain('refreshing-stream');
-    expect(logger.error.mock.calls[0]?.[0]).not.toContain('new-selection');
   });
 
   it('drops the target when the editor panel is closed', async () => {

--- a/src/test-kernel/progressView/progressBackendHarness.ts
+++ b/src/test-kernel/progressView/progressBackendHarness.ts
@@ -4,7 +4,7 @@
 // channels.
 
 // Third-party imports
-import { afterEach } from 'vitest';
+import { afterEach, vi } from 'vitest';
 
 // Local imports
 import { getExecutionStore } from '@agent/storage';
@@ -81,6 +81,7 @@ export function createRecordingBackend(): {
         return true;
       },
       hasTarget: () => true,
+      reportTranscriptLoadError: vi.fn(),
       approvals: createApprovalOptions(),
       lifecycle: createLifecycleOptions(),
     }),
@@ -96,8 +97,10 @@ export function createIsolatedRecordingBackend(
   messages: ProgressViewOutboundMessage[];
   session: SessionHandle;
   lifecycle: ProgressBackendOptions['lifecycle'];
+  reportTranscriptLoadError: ReturnType<typeof vi.fn>;
 } {
   const messages: ProgressViewOutboundMessage[] = [];
+  const reportTranscriptLoadError = vi.fn();
   track(session);
   const backend = track(
     new ProgressBackend({
@@ -108,11 +111,12 @@ export function createIsolatedRecordingBackend(
         return true;
       },
       hasTarget: () => true,
+      reportTranscriptLoadError,
       approvals: createApprovalOptions(),
       lifecycle,
     }),
   );
-  return { backend, lifecycle, messages, session };
+  return { backend, lifecycle, messages, reportTranscriptLoadError, session };
 }
 
 export async function createPersistentRecordingBackend(): Promise<

--- a/src/test-kernel/support/ProgressControllerHarnesses.ts
+++ b/src/test-kernel/support/ProgressControllerHarnesses.ts
@@ -185,7 +185,6 @@ export function createLifecycleOptions(
     cleanupDeletedStream: vi.fn(),
     cleanupDeletedStreams: vi.fn(),
     rebuildRenderedStreams: vi.fn(),
-    activateStream: vi.fn(),
     notifyDeletionRetained: vi.fn(),
     ...overrides,
   };


### PR DESCRIPTION
Closes #9981.

## Summary

Moves active-stream selection, transcript rehydration, and viewport synchronization into `ProgressBackend` for both hosts. Full synchronization preserves the complete active state, and deletion reasserts the surviving selection through the same activation sequence.

## Issue acceptance gates

- Replaces four host/fact activation sequences with one backend-owned sequence.
- Preserves stale-activation protection and complete active-state hydration.
- Preserves stream identifiers in one backend-owned host error path, including fallback-load failures.
- Proves that automatic fallback selection and a selection made during deletion are both reasserted after the deletion message.

## Single source of truth

`ProgressBackend.activateStream` and its private synchronization helper own active-stream activation and rendering.

## Duplication and abstraction budget

No new layer was added; existing host adapters now call the backend. The internal always-true active-state option was removed after the paths converged.

## Net elements (R6)

- Files: 7 modified.
- Exported symbols: no change.
- LoC: 225 added, 130 deleted; net +95, principally strengthened race tests and host diagnostics; three host-owned sequences are removed.

## Consumer counts (R8)

Two hosts consume `activateStream` and `syncRenderedStreams`. The formerly repeated activation behavior existed in four paths and now has one implementation.

## Host impact

Extension: Delegates activation and records the failing stream identifier.

Desktop: Delegates activation, avoids metadata rebuilds on tab switches, preserves full active state, and records the failing stream identifier.

CLI: None.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- `corepack pnpm test`
- `corepack pnpm run check:dead-code-ratchet`
- 102 focused desktop and progress tests for the latest review changes
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stream selection, deletion fallback, and transcript rehydration for both desktop and extension progress views. Race and error-path behavior is covered by tests, but regressions would affect the active run UI.
> 
> **Overview**
> **Centralizes active-stream rendering in `ProgressBackend`.** Selection, transcript rehydration, and viewport sync now live in `activateStream` / `syncRenderedStreams` instead of duplicated host logic.
> 
> Desktop and extension hosts delegate to those backend methods and only supply host-specific `reportTranscriptLoadError` diagnostics. The lifecycle `activateStream` hook is removed; after deletion the backend reasserts the surviving selection through the same activation sequence, including concurrent switches and load failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4edb773d9545eed78b63f653b0a0ade6d6df919. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->