### PR TITLE
refactor: share history settings actions

### DIFF
--- a/packages/desktop/src/main/desktopHistoryHandlers.ts
+++ b/packages/desktop/src/main/desktopHistoryHandlers.ts
@@ -1,39 +1,16 @@
 import { readFileSync } from 'node:fs';
 import * as path from 'node:path';
 
-import {
-  deleteAllExecutions,
-  deleteExecution,
-  getExecutionStore,
-} from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import {
-  validateExecutionRequest,
-  type ValidatedExecutionRequest,
-} from '@agent/core/state/executionRequests';
-import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
+import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
 import type { ChatExportController } from '@controllers/settingsView/ChatExportController';
 import {
-  ACTIVE_EXECUTION_DELETE_BLOCKED_MESSAGE,
-  CLEAR_HISTORY_CONFIRM_LABEL,
-  CLEAR_HISTORY_CONFIRM_MESSAGE,
-  describeClearHistoryResult,
-  describeDeleteExecutionResult,
-  describeLatexExportResult,
-  exportedFileMessage,
-  exportInputErrorMessage,
-  HISTORY_CLEARED_MESSAGE,
-  HISTORY_CONFIG_UNREADABLE_MESSAGE,
-  htmlExportErrorMessage,
-} from '@controllers/settingsView/HistoryActionOutcomes';
-import type {
-  ExecutionId,
-  SettingsViewInboundHandlerRegistry,
-} from '@shared/schemas';
+  HistoryActions,
+  type HistoryActionPorts,
+} from '@controllers/settingsView/backend/HistoryActions';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import { GoalStore } from '@tools/goal';
+import type { SettingsViewInboundHandlerRegistry } from '@shared/schemas';
 
-type HistoryExportFormat = 'md' | 'tex' | 'html';
 type DesktopHistoryHandlerRegistry = Pick<
   SettingsViewInboundHandlerRegistry,
   | typeof SETTINGS_VIEW_COMMANDS.RERUN_AGENT
@@ -45,23 +22,17 @@ type DesktopHistoryHandlerRegistry = Pick<
   | typeof SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_HTML
 >;
 
-/** Dependencies required by the desktop history controller. */
 export interface DesktopHistoryOptions {
-  /** Resolved extension resources used by chat export templates. */
   readonly resourcesPath: string;
-  /** Run a validated request created from a persisted history entry. */
   readonly runExecution: (request: ValidatedExecutionRequest) => Promise<void>;
-  /** Restore a persisted agent configuration into the main view. */
   readonly restoreRunConfig: (config: AgentConfig) => Promise<boolean>;
   readonly postToRenderer: (message: unknown) => void;
   readonly openPath: (filePath: string) => Promise<void>;
   readonly showInfoMessage: (message: string) => Promise<void>;
-  /** Ask before a destructive action; resolves true when the user confirms. */
   readonly confirmAction: (
     message: string,
     confirmLabel: string,
   ) => Promise<boolean>;
-  /** Surface for an action that did not happen, such as a refused delete. */
   readonly showWarningMessage: (message: string) => Promise<void>;
   readonly showErrorMessage: (message: string) => Promise<void>;
   readonly onError: (error: unknown) => void;
@@ -72,183 +43,68 @@ export interface DesktopHistorySettingsController {
   postHistoryData(): Promise<void>;
 }
 
-/** Own desktop history settings actions behind the dispatcher contract. */
+/** Desktop ports and dispatcher bindings for shared history actions. */
 export class DesktopHistoryHandlers implements DesktopHistorySettingsController {
   readonly handlers: DesktopHistoryHandlerRegistry;
-
+  private readonly actions: HistoryActions;
   private chatExportControllerLoad: Promise<ChatExportController> | undefined;
 
   constructor(private readonly dependencies: DesktopHistoryOptions) {
+    const ports: HistoryActionPorts = {
+      getChatExportController: () => this.getChatExportController(),
+      traceViewerTemplate: path.join(
+        dependencies.resourcesPath,
+        'traceViewer',
+        'index.html',
+      ),
+      runExecution: dependencies.runExecution,
+      restoreRunConfig: dependencies.restoreRunConfig,
+      postMessage: dependencies.postToRenderer,
+      openPath: (filePath) => dependencies.openPath(filePath),
+      showInfo: dependencies.showInfoMessage,
+      showWarning: dependencies.showWarningMessage,
+      showError: dependencies.showErrorMessage,
+      confirm: dependencies.confirmAction,
+      reportDetail: (message) => dependencies.onError(new Error(message)),
+    };
+    this.actions = new HistoryActions(ports);
     this.handlers = {
-      deleteAgent: (message) => this.deleteItem(message.historyId),
-      clearHistory: () => this.clear(),
-      rerunAgent: (message) => this.rerun(message.historyId),
-      restoreAgent: (message) => this.restore(message.historyId),
-      exportChatMd: (message) => this.exportChat(message.historyId, 'md'),
-      exportChatTex: (message) => this.exportChat(message.historyId, 'tex'),
-      exportChatHtml: (message) => this.exportChat(message.historyId, 'html'),
+      deleteAgent: ({ historyId }) => this.actions.deleteItem(historyId),
+      clearHistory: () => this.actions.clear(),
+      rerunAgent: ({ historyId }) => this.actions.rerun(historyId),
+      restoreAgent: ({ historyId }) => this.actions.restore(historyId),
+      exportChatMd: ({ historyId }) => this.actions.exportChat(historyId, 'md'),
+      exportChatTex: ({ historyId }) =>
+        this.actions.exportChat(historyId, 'tex'),
+      exportChatHtml: ({ historyId }) =>
+        this.actions.exportChat(historyId, 'html'),
     };
   }
 
-  async postHistoryData(): Promise<void> {
-    this.dependencies.postToRenderer(await buildHistoryMessage());
-  }
-
-  private async deleteItem(historyId: string): Promise<void> {
-    const executionId = historyId as ExecutionId;
-    const result = await deleteExecution(executionId);
-    const outcome = describeDeleteExecutionResult(result);
-    switch (outcome.kind) {
-      case 'active':
-        await this.dependencies.showWarningMessage(
-          ACTIVE_EXECUTION_DELETE_BLOCKED_MESSAGE,
-        );
-        return;
-      case 'not-found':
-        await this.dependencies.showWarningMessage(outcome.message);
-        return;
-      case 'deleted':
-        await GoalStore.forgetByExecutionIds([executionId]);
-        await this.postHistoryData();
-        return;
-    }
-  }
-
-  private async clear(): Promise<void> {
-    const confirmed = await this.dependencies.confirmAction(
-      CLEAR_HISTORY_CONFIRM_MESSAGE,
-      CLEAR_HISTORY_CONFIRM_LABEL,
-    );
-    if (!confirmed) return;
-    const result = await deleteAllExecutions();
-    await GoalStore.forgetByExecutionIds(result.deleted);
-    const outcome = describeClearHistoryResult(result);
-    if (outcome.kind === 'cleared') {
-      await this.dependencies.showInfoMessage(HISTORY_CLEARED_MESSAGE);
-      this.dependencies.postToRenderer({
-        command: SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED,
-      });
-      return;
-    }
-    await this.dependencies.showInfoMessage(outcome.message);
-    await this.postHistoryData();
-  }
-
-  // readConfig() validates and returns null for missing and corrupt configs;
-  // distinguishing them must happen in the storage layer, not here.
-  private async readHistoryConfig(
-    historyId: string,
-  ): Promise<AgentConfig | undefined> {
-    const config = await getExecutionStore(
-      historyId as ExecutionId,
-    ).readConfig();
-    if (!config) {
-      await this.dependencies.showErrorMessage(
-        HISTORY_CONFIG_UNREADABLE_MESSAGE,
-      );
-      return undefined;
-    }
-    return config;
-  }
-
-  private async rerun(historyId: string): Promise<void> {
-    const config = await this.readHistoryConfig(historyId);
-    if (!config) return;
-    const validated = validateExecutionRequest({ config });
-    if (!validated.valid) {
-      await this.dependencies.showErrorMessage(validated.message);
-      return;
-    }
-    await this.dependencies.showInfoMessage('Rerunning agent from history');
-    void this.dependencies
-      .runExecution(validated.request)
-      .catch(this.dependencies.onError);
-  }
-
-  private async restore(historyId: string): Promise<void> {
-    const config = await this.readHistoryConfig(historyId);
-    if (!config) return;
-    const restored = await this.dependencies.restoreRunConfig(config);
-    if (!restored) {
-      await this.dependencies.showErrorMessage(
-        'Failed to restore configuration',
-      );
-    }
+  postHistoryData(): Promise<void> {
+    return this.actions.postHistoryData();
   }
 
   private getChatExportController(): Promise<ChatExportController> {
     this.chatExportControllerLoad ??=
       import('@controllers/settingsView/ChatExportController')
-        .then(({ ChatExportController }) => {
-          const latexPreamble = readFileSync(
-            path.join(
-              this.dependencies.resourcesPath,
-              'templates',
-              'chatExport.tex',
-            ),
-            'utf8',
-          );
-          return new ChatExportController({ latexPreamble });
-        })
+        .then(
+          ({ ChatExportController }) =>
+            new ChatExportController({
+              latexPreamble: readFileSync(
+                path.join(
+                  this.dependencies.resourcesPath,
+                  'templates',
+                  'chatExport.tex',
+                ),
+                'utf8',
+              ),
+            }),
+        )
         .catch((error: unknown) => {
           this.chatExportControllerLoad = undefined;
           throw error;
         });
     return this.chatExportControllerLoad;
-  }
-
-  private async exportChatHtml(historyId: string): Promise<void> {
-    const controller = await this.getChatExportController();
-    const outcome = await controller.exportAsHtml(
-      historyId,
-      path.join(this.dependencies.resourcesPath, 'traceViewer', 'index.html'),
-    );
-    if (outcome.status !== 'ok') {
-      await this.dependencies.showInfoMessage(
-        htmlExportErrorMessage(outcome.status),
-      );
-      return;
-    }
-    const { absolutePath, storagePath } = outcome.result;
-    await this.dependencies.openPath(absolutePath);
-    await this.dependencies.showInfoMessage(exportedFileMessage(storagePath));
-  }
-
-  private async exportChat(
-    historyId: string,
-    format: HistoryExportFormat,
-  ): Promise<void> {
-    if (format === 'html') {
-      await this.exportChatHtml(historyId);
-      return;
-    }
-
-    const controller = await this.getChatExportController();
-    const result = await controller.buildExportInput(historyId);
-    if (result.status !== 'ok') {
-      await this.dependencies.showInfoMessage(
-        exportInputErrorMessage(result.status),
-      );
-      return;
-    }
-    const { exportInput } = result;
-
-    if (format === 'md') {
-      const { absolutePath, storagePath } = await controller.exportAsMarkdown(
-        historyId,
-        exportInput,
-      );
-      await this.dependencies.openPath(absolutePath);
-      await this.dependencies.showInfoMessage(exportedFileMessage(storagePath));
-      return;
-    }
-
-    const latexResult = await controller.exportAsLatex(historyId, exportInput);
-    const outcome = describeLatexExportResult(latexResult);
-    if (outcome.kind === 'compileFailed' && outcome.logDetail) {
-      this.dependencies.onError(new Error(outcome.logDetail));
-    }
-    await this.dependencies.openPath(outcome.pathToOpen);
-    await this.dependencies.showInfoMessage(outcome.message);
   }
 }

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -1,288 +1,126 @@
-/**
- * History and chat-export domain handlers.
- *
- * Handles rerun/restore/delete of past executions, clearing history,
- * and exporting a conversation as Markdown, LaTeX/PDF, or self-contained HTML.
- */
+/** Extension ports and dispatcher bindings for shared history actions. */
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
-import {
-  getExecutionStore,
-  deleteExecution,
-  deleteAllExecutions,
-} from '@agent/storage';
-import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { runExecuteCommand } from '@commands/agent/executeCommand';
-import {
-  ChatExportController,
-  type ChatExportInput,
-} from '@controllers/settingsView/ChatExportController';
+import { ChatExportController } from '@controllers/settingsView/ChatExportController';
 import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
 import {
-  ACTIVE_EXECUTION_DELETE_BLOCKED_MESSAGE,
-  CLEAR_HISTORY_CONFIRM_LABEL,
-  CLEAR_HISTORY_CONFIRM_MESSAGE,
-  describeClearHistoryResult,
-  describeDeleteExecutionResult,
-  describeLatexExportResult,
-  exportedFileMessage,
-  exportInputErrorMessage,
-  HISTORY_CLEARED_MESSAGE,
-  HISTORY_CONFIG_UNREADABLE_MESSAGE,
-  htmlExportErrorMessage,
-} from '@controllers/settingsView/HistoryActionOutcomes';
+  HistoryActions,
+  type HistoryActionPorts,
+  type HistoryOpenKind,
+} from '@controllers/settingsView/backend/HistoryActions';
 import { confirmModal } from '@frontend/ui/dialogs';
 import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
-// Bundled in the extension's resources/ tree and loaded as raw text by the
-// esbuild `.tex: text` loader, then injected into the host-neutral
-// ChatExportController so core stays free of `@resources`.
 import latexPreamble from '@resources/templates/chatExport.tex';
-import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   SETTINGS_VIEW_CMD,
   type SettingsMessageFor,
 } from '@shared/schemas/settingsViewMessages';
-import { GoalStore } from '@tools/goal';
 
 import {
-  withHandlerErrorHandling,
   type SettingsHandlerContext,
+  withHandlerErrorHandling,
 } from './SettingsHandlerContext';
 
-type ChatExportFormat = 'md' | 'tex' | 'html';
-
-/** History and chat-export handler delegate. */
 export class HistoryHandlers {
-  private readonly chatExportController = new ChatExportController({
-    latexPreamble,
-  });
-
-  /** Path to the bundled trace-viewer template (under extension resources). */
-  private readonly traceViewerTemplate: string;
+  private readonly actions: HistoryActions;
 
   constructor(private readonly ctx: SettingsHandlerContext) {
-    this.traceViewerTemplate = path.join(
-      ctx.extensionContext.extensionPath,
-      'resources',
-      'traceViewer',
-      'index.html',
-    );
+    const controller = new ChatExportController({ latexPreamble });
+    const ports: HistoryActionPorts = {
+      getChatExportController: () => Promise.resolve(controller),
+      traceViewerTemplate: path.join(
+        ctx.extensionContext.extensionPath,
+        'resources',
+        'traceViewer',
+        'index.html',
+      ),
+      runExecution: ({ config }) => runExecuteCommand(config),
+      restoreRunConfig: async (config) => {
+        await vscode.commands.executeCommand('texra.restoreState', config);
+      },
+      postMessage: async (message) => {
+        await ctx.withActiveWebview(async (webview) => {
+          await webview.postMessage(message);
+        });
+      },
+      openPath: (filePath, kind) => this.openPath(filePath, kind),
+      showInfo: async (message) => {
+        await vscode.window.showInformationMessage(message);
+      },
+      showWarning: async (message) => {
+        await vscode.window.showWarningMessage(message);
+      },
+      showError: async (message) => {
+        await showLoggedMessage(ctx.channel, message);
+      },
+      confirm: confirmModal,
+      reportDetail: (message, data) =>
+        ctx.logger.error(ctx.channel, message, { data }),
+    };
+    this.actions = new HistoryActions(ports);
   }
 
   async sendHistoryData(webview: vscode.Webview): Promise<void> {
     await webview.postMessage(await buildHistoryMessage());
   }
 
-  async handleRerunAgent(
+  handleRerunAgent(
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.RERUN_AGENT>,
   ): Promise<void> {
-    await this.withHistoryConfig(
-      data.historyId,
-      'Failed to rerun agent',
-      async (config) => {
-        await vscode.window.showInformationMessage(
-          'Rerunning agent from history',
-        );
-        await runExecuteCommand(config);
-      },
+    return this.run('Failed to rerun agent', () =>
+      this.actions.rerun(data.historyId),
     );
   }
 
-  async handleRestoreAgent(
+  handleRestoreAgent(
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.RESTORE_AGENT>,
   ): Promise<void> {
-    await this.withHistoryConfig(
-      data.historyId,
-      'Failed to restore configuration',
-      async (config) => {
-        await vscode.commands.executeCommand('texra.restoreState', config);
-      },
+    return this.run('Failed to restore configuration', () =>
+      this.actions.restore(data.historyId),
     );
   }
 
-  async handleDeleteAgent(
+  handleDeleteAgent(
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.DELETE_AGENT>,
   ): Promise<void> {
-    await withHandlerErrorHandling(
-      this.ctx,
-      'Failed to delete history item',
-      async () => {
-        const executionId = data.historyId;
-        const result = await deleteExecution(executionId);
-        const outcome = describeDeleteExecutionResult(result);
-        switch (outcome.kind) {
-          case 'active':
-            await vscode.window.showWarningMessage(
-              ACTIVE_EXECUTION_DELETE_BLOCKED_MESSAGE,
-            );
-            return;
-          case 'not-found':
-            await vscode.window.showWarningMessage(outcome.message);
-            return;
-          case 'deleted':
-            await GoalStore.forgetByExecutionIds([executionId]);
-            await this.ctx.withActiveWebview((w) => this.sendHistoryData(w));
-            return;
-        }
-      },
+    return this.run('Failed to delete history item', () =>
+      this.actions.deleteItem(data.historyId),
     );
   }
 
-  async handleClearHistory(): Promise<void> {
-    await withHandlerErrorHandling(
-      this.ctx,
-      'Failed to clear history',
-      async () => {
-        const confirmed = await confirmModal(
-          CLEAR_HISTORY_CONFIRM_MESSAGE,
-          CLEAR_HISTORY_CONFIRM_LABEL,
-        );
-        if (!confirmed) return;
-        const result = await deleteAllExecutions();
-        await GoalStore.forgetByExecutionIds(result.deleted);
-        const outcome = describeClearHistoryResult(result);
-        if (outcome.kind === 'cleared') {
-          await vscode.window.showInformationMessage(HISTORY_CLEARED_MESSAGE);
-          await this.ctx.withActiveWebview(async (w) => {
-            await w.postMessage({
-              command: SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED,
-            });
-          });
-        } else {
-          await vscode.window.showInformationMessage(outcome.message);
-          await this.ctx.withActiveWebview((w) => this.sendHistoryData(w));
-        }
-      },
-    );
+  handleClearHistory(): Promise<void> {
+    return this.run('Failed to clear history', () => this.actions.clear());
   }
 
-  async handleExportChat(
+  handleExportChat(
     data: { historyId: string },
-    format: ChatExportFormat,
+    format: 'md' | 'tex' | 'html',
   ): Promise<void> {
-    await withHandlerErrorHandling(
-      this.ctx,
-      'Failed to export chat',
-      async () => {
-        // HTML reads the execution's trace directly via assembleTrace, whose
-        // missing-data statuses are shaped differently from
-        // buildExportInput's, so it takes its own path.
-        if (format === 'html') {
-          await this.exportAndOpenHtml(data.historyId);
-          return;
-        }
-
-        const result = await this.chatExportController.buildExportInput(
-          data.historyId,
-        );
-
-        if (result.status !== 'ok') {
-          void showLoggedMessage(
-            this.ctx.channel,
-            exportInputErrorMessage(result.status),
-          );
-          return;
-        }
-
-        const { exportInput } = result;
-
-        switch (format) {
-          case 'md':
-            await this.exportAndOpenMarkdown(data.historyId, exportInput);
-            return;
-          case 'tex':
-            await this.exportAndOpenLatex(data.historyId, exportInput);
-            return;
-        }
-      },
+    return this.run('Failed to export chat', () =>
+      this.actions.exportChat(data.historyId, format),
     );
   }
 
-  // ==========================================================
-  // Private helpers
-  // ==========================================================
-
-  private async exportAndOpenMarkdown(
-    historyId: string,
-    exportInput: ChatExportInput,
-  ): Promise<void> {
-    const { absolutePath, storagePath } =
-      await this.chatExportController.exportAsMarkdown(historyId, exportInput);
-    const doc = await vscode.workspace.openTextDocument(absolutePath);
-    await vscode.window.showTextDocument(doc, { preview: false });
-    void vscode.window.showInformationMessage(exportedFileMessage(storagePath));
+  private run(errorPrefix: string, action: () => Promise<void>): Promise<void> {
+    return withHandlerErrorHandling(this.ctx, errorPrefix, action);
   }
 
-  private async exportAndOpenLatex(
-    historyId: string,
-    exportInput: ChatExportInput,
+  private async openPath(
+    filePath: string,
+    kind: HistoryOpenKind,
   ): Promise<void> {
-    const result = await this.chatExportController.exportAsLatex(
-      historyId,
-      exportInput,
-    );
-    const outcome = describeLatexExportResult(result);
-
-    if (outcome.kind === 'compiled') {
-      const pdfUri = vscode.Uri.file(outcome.pathToOpen);
-      await vscode.commands.executeCommand('vscode.open', pdfUri);
-      void vscode.window.showInformationMessage(outcome.message);
+    const uri = vscode.Uri.file(filePath);
+    if (kind === 'external') {
+      await vscode.env.openExternal(uri);
       return;
     }
-
-    // Compilation failed — open the .tex source instead, and log the
-    // compile log tail so the failure reason is discoverable. Included in
-    // the visible message itself, not just `data` — the logger only shows
-    // `data` when texra.logger.debugMode is on (default off).
-    if (outcome.logDetail) {
-      this.ctx.logger.error(this.ctx.channel, outcome.logDetail, {
-        data: { storagePath: result.storagePath, logTail: result.logTail },
-      });
-    }
-    const doc = await vscode.workspace.openTextDocument(outcome.pathToOpen);
-    await vscode.window.showTextDocument(doc, { preview: false });
-    void vscode.window.showWarningMessage(outcome.message);
-  }
-
-  private async exportAndOpenHtml(historyId: string): Promise<void> {
-    const outcome = await this.chatExportController.exportAsHtml(
-      historyId,
-      this.traceViewerTemplate,
-    );
-
-    // assembleTrace's failure statuses, surfaced through exportAsHtml.
-    if (outcome.status !== 'ok') {
-      void showLoggedMessage(
-        this.ctx.channel,
-        htmlExportErrorMessage(outcome.status),
-      );
+    if (kind === 'pdf') {
+      await vscode.commands.executeCommand('vscode.open', uri);
       return;
     }
-
-    const { absolutePath, storagePath } = outcome.result;
-    await vscode.env.openExternal(vscode.Uri.file(absolutePath));
-    void vscode.window.showInformationMessage(exportedFileMessage(storagePath));
-  }
-
-  private async withHistoryConfig(
-    historyId: string,
-    errorPrefix: string,
-    action: (config: AgentConfig) => Promise<void>,
-  ): Promise<void> {
-    await withHandlerErrorHandling(this.ctx, errorPrefix, async () => {
-      // readConfig() validates against AgentConfigSchema and returns null for
-      // both missing and corrupt configs; distinguishing them belongs to the
-      // storage layer, not here.
-      const config = await getExecutionStore(historyId).readConfig();
-      if (!config) {
-        await showLoggedMessage(
-          this.ctx.channel,
-          HISTORY_CONFIG_UNREADABLE_MESSAGE,
-        );
-        return;
-      }
-      await action(config);
-    });
+    const document = await vscode.workspace.openTextDocument(filePath);
+    await vscode.window.showTextDocument(document, { preview: false });
   }
 }

--- a/src/controllers/settingsView/backend/HistoryActions.ts
+++ b/src/controllers/settingsView/backend/HistoryActions.ts
@@ -1,0 +1,196 @@
+import {
+  deleteAllExecutions,
+  deleteExecution,
+  getExecutionStore,
+} from '@agent/storage';
+import { type AgentConfig } from '@agent/core/definition/AgentConfig';
+import {
+  type ValidatedExecutionRequest,
+  validateExecutionRequest,
+} from '@agent/core/state/executionRequests';
+import {
+  type ChatExportController,
+  type ChatExportInput,
+} from '@controllers/settingsView/ChatExportController';
+import {
+  ACTIVE_EXECUTION_DELETE_BLOCKED_MESSAGE,
+  CLEAR_HISTORY_CONFIRM_LABEL,
+  CLEAR_HISTORY_CONFIRM_MESSAGE,
+  describeClearHistoryResult,
+  describeDeleteExecutionResult,
+  describeLatexExportResult,
+  exportedFileMessage,
+  exportInputErrorMessage,
+  HISTORY_CLEARED_MESSAGE,
+  HISTORY_CONFIG_UNREADABLE_MESSAGE,
+  htmlExportErrorMessage,
+} from '@controllers/settingsView/HistoryActionOutcomes';
+import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type { ExecutionId } from '@shared/schemas';
+import { GoalStore } from '@tools/goal';
+
+export type HistoryExportFormat = 'md' | 'tex' | 'html';
+export type HistoryOpenKind = 'text' | 'pdf' | 'external';
+
+export interface HistoryActionPorts {
+  getChatExportController(): Promise<ChatExportController>;
+  readonly traceViewerTemplate: string;
+  runExecution(request: ValidatedExecutionRequest): Promise<void>;
+  restoreRunConfig(config: AgentConfig): Promise<boolean | void>;
+  postMessage(message: unknown): Promise<void> | void;
+  openPath(filePath: string, kind: HistoryOpenKind): Promise<void>;
+  showInfo(message: string): Promise<void>;
+  showWarning(message: string): Promise<void>;
+  showError(message: string): Promise<void>;
+  confirm(message: string, confirmLabel: string): Promise<boolean>;
+  reportDetail(message: string, data?: unknown): void;
+}
+
+/** Host-neutral orchestration for the seven history settings actions. */
+export class HistoryActions {
+  constructor(private readonly ports: HistoryActionPorts) {}
+
+  async postHistoryData(): Promise<void> {
+    await this.ports.postMessage(await buildHistoryMessage());
+  }
+
+  async deleteItem(historyId: string): Promise<void> {
+    const executionId = historyId as ExecutionId;
+    const outcome = describeDeleteExecutionResult(
+      await deleteExecution(executionId),
+    );
+    if (outcome.kind !== 'deleted') {
+      await this.ports.showWarning(
+        outcome.kind === 'active'
+          ? ACTIVE_EXECUTION_DELETE_BLOCKED_MESSAGE
+          : outcome.message,
+      );
+      return;
+    }
+    await GoalStore.forgetByExecutionIds([executionId]);
+    await this.postHistoryData();
+  }
+
+  async clear(): Promise<void> {
+    if (
+      !(await this.ports.confirm(
+        CLEAR_HISTORY_CONFIRM_MESSAGE,
+        CLEAR_HISTORY_CONFIRM_LABEL,
+      ))
+    ) {
+      return;
+    }
+    const result = await deleteAllExecutions();
+    await GoalStore.forgetByExecutionIds(result.deleted);
+    const outcome = describeClearHistoryResult(result);
+    if (outcome.kind === 'cleared') {
+      await this.ports.showInfo(HISTORY_CLEARED_MESSAGE);
+      await this.ports.postMessage({
+        command: SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED,
+      });
+      return;
+    }
+    await this.ports.showInfo(outcome.message);
+    await this.postHistoryData();
+  }
+
+  async rerun(historyId: string): Promise<void> {
+    const config = await this.readHistoryConfig(historyId);
+    if (!config) return;
+    const validated = validateExecutionRequest({ config });
+    if (!validated.valid) {
+      await this.ports.showError(validated.message);
+      return;
+    }
+    await this.ports.showInfo('Rerunning agent from history');
+    await this.ports.runExecution(validated.request);
+  }
+
+  async restore(historyId: string): Promise<void> {
+    const config = await this.readHistoryConfig(historyId);
+    if (!config) return;
+    if ((await this.ports.restoreRunConfig(config)) === false) {
+      await this.ports.showError('Failed to restore configuration');
+    }
+  }
+
+  async exportChat(
+    historyId: string,
+    format: HistoryExportFormat,
+  ): Promise<void> {
+    const controller = await this.ports.getChatExportController();
+    if (format === 'html') {
+      await this.exportHtml(controller, historyId);
+      return;
+    }
+    const result = await controller.buildExportInput(historyId);
+    if (result.status !== 'ok') {
+      await this.ports.showError(exportInputErrorMessage(result.status));
+      return;
+    }
+    if (format === 'md') {
+      await this.exportMarkdown(controller, historyId, result.exportInput);
+      return;
+    }
+    await this.exportLatex(controller, historyId, result.exportInput);
+  }
+
+  private async readHistoryConfig(
+    historyId: string,
+  ): Promise<AgentConfig | undefined> {
+    const config = await getExecutionStore(
+      historyId as ExecutionId,
+    ).readConfig();
+    if (!config) await this.ports.showError(HISTORY_CONFIG_UNREADABLE_MESSAGE);
+    return config ?? undefined;
+  }
+
+  private async exportMarkdown(
+    controller: ChatExportController,
+    historyId: string,
+    input: ChatExportInput,
+  ): Promise<void> {
+    const result = await controller.exportAsMarkdown(historyId, input);
+    await this.ports.openPath(result.absolutePath, 'text');
+    await this.ports.showInfo(exportedFileMessage(result.storagePath));
+  }
+
+  private async exportLatex(
+    controller: ChatExportController,
+    historyId: string,
+    input: ChatExportInput,
+  ): Promise<void> {
+    const result = await controller.exportAsLatex(historyId, input);
+    const outcome = describeLatexExportResult(result);
+    if (outcome.kind === 'compileFailed' && outcome.logDetail) {
+      this.ports.reportDetail(outcome.logDetail, {
+        storagePath: result.storagePath,
+        logTail: result.logTail,
+      });
+    }
+    await this.ports.openPath(
+      outcome.pathToOpen,
+      outcome.kind === 'compiled' ? 'pdf' : 'text',
+    );
+    await (outcome.kind === 'compiled'
+      ? this.ports.showInfo(outcome.message)
+      : this.ports.showWarning(outcome.message));
+  }
+
+  private async exportHtml(
+    controller: ChatExportController,
+    historyId: string,
+  ): Promise<void> {
+    const outcome = await controller.exportAsHtml(
+      historyId,
+      this.ports.traceViewerTemplate,
+    );
+    if (outcome.status !== 'ok') {
+      await this.ports.showError(htmlExportErrorMessage(outcome.status));
+      return;
+    }
+    await this.ports.openPath(outcome.result.absolutePath, 'external');
+    await this.ports.showInfo(exportedFileMessage(outcome.result.storagePath));
+  }
+}

--- a/src/controllers/settingsView/backend/HistoryActions.ts
+++ b/src/controllers/settingsView/backend/HistoryActions.ts
@@ -30,7 +30,7 @@ import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ExecutionId } from '@shared/schemas';
 import { GoalStore } from '@tools/goal';
 
-export type HistoryExportFormat = 'md' | 'tex' | 'html';
+type HistoryExportFormat = 'md' | 'tex' | 'html';
 export type HistoryOpenKind = 'text' | 'pdf' | 'external';
 
 export interface HistoryActionPorts {

--- a/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.ts
+++ b/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.ts
@@ -452,8 +452,8 @@ describe('DesktopHistoryHandlers', () => {
       logTail: '! Undefined control sequence.',
     });
     const openPath = vi.fn();
-    const showInfoMessage = vi.fn();
-    const actions = createHistoryHandlers({ openPath, showInfoMessage });
+    const showWarningMessage = vi.fn();
+    const actions = createHistoryHandlers({ openPath, showWarningMessage });
 
     await assertSupported(actions.exportChatTex)({
       command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_TEX,
@@ -461,7 +461,7 @@ describe('DesktopHistoryHandlers', () => {
     });
 
     expect(openPath).toHaveBeenCalledWith('/tmp/executions/abc/chat.tex');
-    expect(showInfoMessage).toHaveBeenCalledWith(
+    expect(showWarningMessage).toHaveBeenCalledWith(
       'LaTeX compilation failed. The .tex source file has been opened instead.',
     );
   });
@@ -493,11 +493,11 @@ describe('DesktopHistoryHandlers', () => {
     chatExportMocks.buildExportInput.mockResolvedValue({
       status: 'config_missing',
     });
-    const showInfoMessage = vi.fn();
-    const actions = createHistoryHandlers({ showInfoMessage });
+    const showErrorMessage = vi.fn();
+    const actions = createHistoryHandlers({ showErrorMessage });
 
     await exportChatMd(actions, 'missing');
 
-    expect(showInfoMessage).toHaveBeenCalledWith('History item not found');
+    expect(showErrorMessage).toHaveBeenCalledWith('History item not found');
   });
 });


### PR DESCRIPTION
Closes #9979.

## Summary

Moves all seven history settings actions into one host-neutral controller. Desktop and extension retain only resource, presentation, and dispatcher adapters.

## Issue acceptance gates

- Replaces both seven-command host orchestrations with one controller.
- Uses one rerun validation path and one restore outcome path.
- Aligns missing-export and LaTeX compilation-failure reporting.
- Keeps the controller's export-format type private.

## Single source of truth

`HistoryActions` owns delete, clear, rerun, restore, and Markdown/LaTeX/HTML export orchestration.

## Duplication and abstraction budget

One controller replaces fourteen host-owned command bodies. Its ports correspond to genuine host capabilities; no pass-through controller hierarchy was added.

## Net elements (R6)

- Files: 1 added, 3 modified.
- Exported symbols: 3 added, none deleted; net +3 (`HistoryActions` and its two externally consumed port types).
- LoC: 319 added, 429 deleted; net -110.

## Consumer counts (R8)

`HistoryActions` and `HistoryActionPorts` each have two host consumers. `HistoryOpenKind` has one external adapter consumer. `HistoryExportFormat` has zero external consumers and is now private.

## Host impact

Extension: Thin history command and presentation adapter.

Desktop: Thin history command and presentation adapter.

CLI: None.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- `corepack pnpm test`
- `corepack pnpm run check:dead-code-ratchet`
- Focused history tests
- `git diff --check`
