### PR TITLE
fix(usage): log malformed legacy normalizedSnapshots entries instead of silently dropping them

### DIFF
--- a/src/agent/core/usage/RunUsageAccumulator.ts
+++ b/src/agent/core/usage/RunUsageAccumulator.ts
@@ -7,8 +7,6 @@ import {
   type NormalizedUsage,
 } from '@agent/types/NormalizedUsage';
 import * as logger from '@logger/logUtils';
-
-// Local imports - types
 import { TokenCountSchema } from '@shared/schemas';
 
 const CHANNEL = 'RunUsageAccumulator';

--- a/src/agent/core/usage/RunUsageAccumulator.ts
+++ b/src/agent/core/usage/RunUsageAccumulator.ts
@@ -1,12 +1,17 @@
 // Third-party imports
 import { z } from 'zod';
 
-// Local imports - types
+// Local imports
 import {
   NormalizedUsageSchema,
   type NormalizedUsage,
 } from '@agent/types/NormalizedUsage';
+import * as logger from '@logger/logUtils';
+
+// Local imports - types
 import { TokenCountSchema } from '@shared/schemas';
+
+const CHANNEL = 'RunUsageAccumulator';
 
 /**
  * Schema for run usage totals. Internal only.
@@ -81,16 +86,23 @@ export type RunUsageAccumulatorJSON = z.output<
  * Each snapshot is parsed tolerantly (`.catch`): the old preprocess only ever
  * read the last element's `usage`, so a malformed earlier snapshot must not
  * fail the whole arm (which would drop the latest valid usage on resume). A
- * malformed `usage` degrades to `null` rather than rejecting the payload.
+ * malformed `usage` degrades to `null` rather than rejecting the payload, but
+ * the degradation is logged so a corrupted legacy record doesn't vanish
+ * silently.
  */
 const LegacyRunUsageAccumulatorSchema = z
   .object({
     totals: RunUsageTotalsSchema.prefault({}),
     latestUsage: NormalizedUsageSchema.nullish(),
     normalizedSnapshots: z.array(
-      z
-        .object({ usage: NormalizedUsageSchema.nullish() })
-        .catch({ usage: null }),
+      z.object({ usage: NormalizedUsageSchema.nullish() }).catch((ctx) => {
+        logger.warn(
+          CHANNEL,
+          'Malformed legacy normalizedSnapshots entry, discarding its usage',
+          { data: ctx.issues },
+        );
+        return { usage: null };
+      }),
     ),
   })
   .transform((legacy): RunUsageAccumulatorJSON => ({

--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { RunUsageAccumulatorJSONSchema } from '@agent/core/usage/RunUsageAccumulator';
+import * as logger from '@logger/logUtils';
 import {
   ActiveChildInfoSchema,
   ContextManagementDataSchema,
@@ -52,15 +53,26 @@ describe('RunUsageAccumulatorJSONSchema — legacy normalizedSnapshots migration
   });
 
   it('preserves the last valid usage when an earlier snapshot is malformed', () => {
-    const result = RunUsageAccumulatorJSONSchema.parse({
-      normalizedSnapshots: [
-        { round: 0, usage: { bogus: 'not a usage' } },
-        { round: 1, usage: usageFixture },
-      ],
-    });
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      const result = RunUsageAccumulatorJSONSchema.parse({
+        normalizedSnapshots: [
+          { round: 0, usage: { bogus: 'not a usage' } },
+          { round: 1, usage: usageFixture },
+        ],
+      });
 
-    // A malformed earlier snapshot must not drop the latest valid usage.
-    expect(result.latestUsage).toMatchObject(usageFixture);
+      // A malformed earlier snapshot must not drop the latest valid usage.
+      expect(result.latestUsage).toMatchObject(usageFixture);
+      // The degradation must be logged, not silent.
+      expect(warnSpy).toHaveBeenCalledWith(
+        'RunUsageAccumulator',
+        expect.stringContaining('Malformed legacy normalizedSnapshots entry'),
+        expect.anything(),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('parses empty object to zero totals and null latestUsage', () => {


### PR DESCRIPTION
## Summary

Ran an abstraction-layer audit of the codebase (webview frontend, host-agnostic domain core, controllers/tools/eventBus boundaries) looking for business logic in the wrong layer, infra concerns leaking into domain code, and CLAUDE.md's other named anti-patterns. The codebase is well-disciplined: no VS Code imports outside allowed zones, no new ad-hoc `bus.emit` for run-scoped facts, no single-caller pass-through wrappers, no infra leaking into `src/agent/core`. The one real finding was a "silent degradation" defect in `RunUsageAccumulator`'s legacy-data migration schema, fixed here.

`LegacyRunUsageAccumulatorSchema` (used to migrate old persisted `normalizedSnapshots` arrays into the canonical `latestUsage` shape) parsed each snapshot with `.catch({ usage: null })` — a bare fallback with no log call. Per CLAUDE.md's "Silent degradation is a defect" rule, a fallback that masks a failure must be loud (`logger.warn` + surfaced) or not exist. A corrupted legacy usage record previously vanished with zero trace.

## Issue acceptance gates

No tracked issue — this is a scheduled abstraction-layer audit; the one finding it produced is fixed in this PR.

## Single source of truth

`LegacyRunUsageAccumulatorSchema` in `src/agent/core/usage/RunUsageAccumulator.ts` remains the sole owner of legacy `normalizedSnapshots` → `latestUsage` migration; this PR only makes its existing fallback path observable.

## Duplication and abstraction budget

No new abstraction. The fix imports `@logger/logUtils` directly (the same `import * as logger from '@logger/logUtils'` + module-level `CHANNEL` constant pattern already used in `src/agent/node/persistedFlow.ts`), matching an existing convention rather than inventing a new one. `agent → logger` is already an allowed architecture edge in `config/ratchets/architecture-edges-baseline.json`.

## Net elements (R6)

Not a refactor/simplify/consolidate/dedupe PR — n/a. Diff: +1 import, +1 constant, `.catch(value)` → `.catch(ctx => ...)` callback (2 files, +39/-15 lines, no new exports).

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed; a `logger.warn` call was added inside an existing schema.

## Host impact

Extension: none (shared schema, no host-specific behavior).

Desktop: none (shared schema, no host-specific behavior).

CLI: none (shared schema, no host-specific behavior).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — full workspace (extension, desktop, cli, agent SDK, trace-viewer) passes.
- `npx vitest run src/test-kernel/schemas/SchemaMigrations.vitest.ts` — 17/17 pass, including the extended test that now asserts `logger.warn` is called on a malformed legacy snapshot.
- `npx eslint` on both changed files — clean (import-order auto-fixed).
- `npx prettier --check` on both changed files — clean.
- `npx vitest run src/test-kernel/architecture/dependencyDirection.vitest.ts` — 17/17 pass (confirms the `agent → logger` import doesn't widen any architecture-edge ratchet).
- `npm run check:dead-code-ratchet` — no new dead-code findings introduced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRZY12t5qyWJ7ywGB3HLih)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to an existing tolerant parse fallback; migration behavior is unchanged and covered by an updated unit test.
> 
> **Overview**
> Makes legacy usage migration **observable** when a corrupted `normalizedSnapshots` entry is discarded.
> 
> `LegacyRunUsageAccumulatorSchema` still degrades malformed snapshot entries to `{ usage: null }`, but now emits a `logger.warn` with the Zod issues instead of failing silently. The migration test asserts that warning is fired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea039f1e1748a97f5305f2194c966c0ee2fadef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->