### PR TITLE
refactor(logger): add createLog(channel) factory, migrate 58 files off CHANNEL threading

### DIFF
--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -1,6 +1,6 @@
 // Pure viewport math for bounded pending transcript panes.
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
@@ -11,7 +11,7 @@ import { isRenderableTranscriptEntry } from './transcriptEntries';
 import type { ConversationEntry } from '../state/cliState';
 
 const FAILED_ENTRY_ESTIMATE_ROWS = 1;
-const CHANNEL = 'transcriptViewport';
+const log = createLog('transcriptViewport');
 /** Entry ids already reported, so a persistently-throwing entry is logged once
  *  instead of once per stream-sync tick (the estimate path runs per frame). */
 const brokenEntryIdsReported = new Set<string>();
@@ -29,8 +29,7 @@ function estimateEntryRows(
   } catch (error) {
     if (!brokenEntryIdsReported.has(entry.id)) {
       brokenEntryIdsReported.add(entry.id);
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Failed to estimate rows for ${entry.role} entry ${entry.id}; assuming ${FAILED_ENTRY_ESTIMATE_ROWS}: ${toErrorMessage(error)}`,
       );
     }

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -7,10 +7,10 @@ import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { ModelHandlerCompatibilityKeySchema } from '@agent/runtime/modelHandlerCompatibilityKey';
 import { runAgent } from '@agent/runtime/runAgent';
 import { openFinalOutputIfAvailable } from '@frontend/agents/finalOutputOpener';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
 
-const CHANNEL = 'ExecuteCommand';
+const log = createLog('ExecuteCommand');
 
 interface WrappedExecuteInput {
   config: unknown;
@@ -62,7 +62,7 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
   } catch (error) {
     if (error instanceof ZodError) {
       const message = `Invalid agent configuration. ${z.prettifyError(error)}`;
-      logger.warn(CHANNEL, message, { data: error });
+      log.warn(message, { data: error });
       void vscode.window.showErrorMessage(message);
       return;
     }

--- a/packages/extension/src/commands/files/openFileCommands.ts
+++ b/packages/extension/src/commands/files/openFileCommands.ts
@@ -6,11 +6,11 @@ import { registerCommandEntries } from '@commands/_shared/registerCommands';
 import { getFileLister } from '@frontend/files/fileLister';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { openFirstLabelMatch } from '@latex/labelSearch';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-const CHANNEL = 'openFileCommands';
+const log = createLog('openFileCommands');
 
 interface OpenLabelOptions {
   notifyNotFound?: boolean;
@@ -50,10 +50,7 @@ async function openLabel(
       try {
         return await WorkspaceFS.read(file);
       } catch (error) {
-        logger.debug(
-          CHANNEL,
-          `Could not read file ${file}: ${toErrorMessage(error)}`,
-        );
+        log.debug(`Could not read file ${file}: ${toErrorMessage(error)}`);
         throw error;
       }
     },

--- a/packages/extension/src/common/state/pendingStateManager.ts
+++ b/packages/extension/src/common/state/pendingStateManager.ts
@@ -1,4 +1,4 @@
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { MainViewPersistedState } from '@shared/schemas';
 
 interface PendingStateData {
@@ -9,7 +9,7 @@ interface PendingStateData {
 const MAX_PENDING_STATES = 10;
 const pendingStateQueue: PendingStateData[] = [];
 
-const CHANNEL = 'pendingStateManager';
+const log = createLog('pendingStateManager');
 
 export function setPendingState(
   state: MainViewPersistedState,
@@ -18,16 +18,12 @@ export function setPendingState(
   if (pendingStateQueue.length >= MAX_PENDING_STATES) {
     // Bounded queue: drop the oldest pending restore, but never silently.
     const dropped = pendingStateQueue.shift();
-    logger.warn(
-      CHANNEL,
-      'Pending-state queue full; dropping the oldest pending restore',
-      {
-        data: {
-          droppedExecuteImmediately: dropped?.executeImmediately,
-          queueLength: pendingStateQueue.length,
-        },
+    log.warn('Pending-state queue full; dropping the oldest pending restore', {
+      data: {
+        droppedExecuteImmediately: dropped?.executeImmediately,
+        queueLength: pendingStateQueue.length,
       },
-    );
+    });
   }
   pendingStateQueue.push({ state, executeImmediately });
 }

--- a/packages/extension/src/common/webview/viewState.ts
+++ b/packages/extension/src/common/webview/viewState.ts
@@ -2,9 +2,9 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 
-const CHANNEL = 'extension';
+const log = createLog('extension');
 const TEXRA_ACTIVE_VIEW_CONTEXT_KEY = 'texra.activeView';
 
 export const SIDEBAR_VIEWS = {
@@ -31,8 +31,7 @@ export function setActiveSidebarView(view: SidebarView): void {
   void vscode.commands
     .executeCommand('setContext', TEXRA_ACTIVE_VIEW_CONTEXT_KEY, view)
     .then(undefined, (error: unknown) => {
-      logger.error(
-        CHANNEL,
+      log.error(
         `Failed to publish the ${TEXRA_ACTIVE_VIEW_CONTEXT_KEY} context key`,
         { data: error },
       );

--- a/packages/extension/src/frontend/agents/finalOutputOpener.ts
+++ b/packages/extension/src/frontend/agents/finalOutputOpener.ts
@@ -2,9 +2,9 @@ import * as vscode from 'vscode';
 
 import type { WorkflowFlowResult } from '@agent/runtime/AgentFlowResult';
 import { selectAutoOpenFinalOutput } from '@agent/runtime/selectAutoOpenFinalOutput';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 
-const CHANNEL = 'FinalOutputOpener';
+const log = createLog('FinalOutputOpener');
 
 /**
  * On successful workflow completion, preview the final revised output so
@@ -33,8 +33,7 @@ export async function openFinalOutputIfAvailable(
       8000,
     );
   } catch (error) {
-    logger.debug(
-      CHANNEL,
+    log.debug(
       `Unable to auto-open final output ${primary.absolutePath}: ${String(error)}`,
     );
   }

--- a/packages/extension/src/frontend/agents/register.ts
+++ b/packages/extension/src/frontend/agents/register.ts
@@ -5,10 +5,10 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { createWorkspaceAgentRosterController } from '@agent/index';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { AgentSource } from '@shared/schemas/agent';
 
-const CHANNEL = 'AgentRegister';
+const log = createLog('AgentRegister');
 
 export async function promptToAddAgentToConfig(
   agentName: string,
@@ -20,7 +20,7 @@ export async function promptToAddAgentToConfig(
   const current = roster.getVisibleAgents(category).map((entry) => entry.name);
 
   if (current.includes(agentName)) {
-    logger.debug(CHANNEL, `Agent "${agentName}" already in configuration`);
+    log.debug(`Agent "${agentName}" already in configuration`);
     return;
   }
 

--- a/packages/extension/src/frontend/comments/inlineComments.ts
+++ b/packages/extension/src/frontend/comments/inlineComments.ts
@@ -17,13 +17,13 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 import { lineToRange } from '@frontend/vscode/vscodeEditor';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type {
   InlineCommentProvider,
   InlineCommentThreadView,
 } from '@tools/comment/InlineCommentTool';
 
-const CHANNEL = 'InlineComments';
+const log = createLog('InlineComments');
 const CONTROLLER_ID = 'texra.inlineComments';
 const CONTROLLER_LABEL = 'TeXRA';
 const AGENT_AUTHOR = 'TeXRA';
@@ -173,7 +173,7 @@ function enable(context: vscode.ExtensionContext): void {
       },
     ),
   );
-  logger.info(CHANNEL, 'Inline comments enabled');
+  log.info('Inline comments enabled');
 }
 
 function disable(): void {

--- a/packages/extension/src/frontend/files/fileLister.ts
+++ b/packages/extension/src/frontend/files/fileLister.ts
@@ -8,12 +8,12 @@ import {
   type FileListConfig,
   type ListableFileType,
 } from '@common/files/fileListingRules';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 
 import { getFilesRecursively } from './listing';
 
-const CHANNEL = 'FileLister';
+const log = createLog('FileLister');
 
 export class FileLister {
   public static initialize(context: vscode.ExtensionContext): void {
@@ -48,7 +48,7 @@ export class FileLister {
 
   private async listFiles(config: FileListConfig): Promise<string[]> {
     if (!this.workspacePath) {
-      logger.warn(CHANNEL, 'No workspace folder found');
+      log.warn('No workspace folder found');
       return [];
     }
     return getFilesRecursively(this.workspacePath, config);

--- a/packages/extension/src/frontend/latex/inlineCriticism.ts
+++ b/packages/extension/src/frontend/latex/inlineCriticism.ts
@@ -26,14 +26,14 @@ import { globalSM } from '@common/state';
 import { subscribeAddOutputFilesRunFact } from '@frontend/events/runFactSubscriptions';
 import { lineToRange } from '@frontend/vscode/vscodeEditor';
 import { parseCriticismAnnotations } from '@latex/criticismParser';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { AddOutputFilesPayload, OutputFileInfo } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { hasExtension } from '@utils/core/pathCore';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-const CHANNEL = 'InlineCriticism';
+const log = createLog('InlineCriticism');
 const COLLECTION_NAME = 'texra-criticism';
 const SOURCE_LABEL = 'TeXRA';
 const CODE_PARSED = 'criticize';
@@ -86,10 +86,7 @@ async function refreshFileDiagnostics(file: OutputFileInfo): Promise<void> {
   try {
     text = await AbsoluteFS.read(absolutePath);
   } catch (error) {
-    logger.error(
-      CHANNEL,
-      `Failed to read ${absolutePath}: ${toErrorMessage(error)}`,
-    );
+    log.error(`Failed to read ${absolutePath}: ${toErrorMessage(error)}`);
     return;
   }
 
@@ -129,8 +126,7 @@ function handleAddOutputFiles(payload: AddOutputFilesPayload): void {
   const allFiles = Object.values(payload.filesByRound).flat();
   void Promise.all(allFiles.map((f) => refreshFileDiagnostics(f))).catch(
     (error: unknown) => {
-      logger.error(
-        CHANNEL,
+      log.error(
         `Failed to refresh criticism diagnostics: ${toErrorMessage(error)}`,
       );
     },
@@ -145,7 +141,7 @@ function enable(context: vscode.ExtensionContext): void {
     sessionEvents ?? defaultSession().events,
     handleAddOutputFiles,
   );
-  logger.info(CHANNEL, 'Inline criticism diagnostics enabled');
+  log.info('Inline criticism diagnostics enabled');
 }
 
 function disable(): void {
@@ -158,7 +154,7 @@ function disable(): void {
     collection.dispose();
     collection = undefined;
   }
-  logger.info(CHANNEL, 'Inline criticism diagnostics disabled');
+  log.info('Inline criticism diagnostics disabled');
 }
 
 /**

--- a/packages/extension/src/frontend/lm/registerLanguageModelTools.ts
+++ b/packages/extension/src/frontend/lm/registerLanguageModelTools.ts
@@ -11,7 +11,7 @@
 
 import * as vscode from 'vscode';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import { getDefaultToolRegistry } from '@tools/registry';
 
@@ -21,7 +21,7 @@ import {
   type LanguageModelResearchToolName,
 } from './languageModelToolInvocationMessage';
 
-const CHANNEL = 'LanguageModelTools';
+const log = createLog('LanguageModelTools');
 
 /** VS Code tool name (manifest) → canonical TeXRA registry tool name. */
 const LM_TOOL_NAMES = {
@@ -51,8 +51,7 @@ export function registerLanguageModelTools(
   for (const [lmName, toolName] of Object.entries(LM_TOOL_NAMES)) {
     const tool = registry.get(toolName);
     if (!tool) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Tool "${toolName}" missing from registry; skipping LM registration for "${lmName}".`,
       );
       continue;

--- a/packages/extension/src/frontend/review/agentReviewCommitWatcher.ts
+++ b/packages/extension/src/frontend/review/agentReviewCommitWatcher.ts
@@ -13,7 +13,7 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { getGitAPI, type GitRepository } from '@frontend/git/gitExtensionTypes';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { createFlushableDebounce } from '@utils/core';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { isPathWithin } from '@utils/core/pathCore';
@@ -22,7 +22,7 @@ import { getConfig } from '@utils/config/configUtils';
 
 import { AgentReviewService } from './AgentReviewService';
 
-const CHANNEL = 'AgentReview';
+const log = createLog('AgentReview');
 const COMMIT_DEBOUNCE_MS = 1500;
 
 function watchRepository(
@@ -61,10 +61,7 @@ function watchRepository(
     // Re-check at fire time: the user may have disabled run-on-commit
     // during the debounce window, and a review costs a model session.
     if (!getConfig<boolean>('agentReview.runOnCommit', false)) return;
-    logger.info(
-      CHANNEL,
-      `Commit detected on ${name ?? 'HEAD'}; starting agent review`,
-    );
+    log.info(`Commit detected on ${name ?? 'HEAD'}; starting agent review`);
     void AgentReviewService.runReview('commit', {
       baseRef,
       baseDescription: `previous commit on ${name ?? 'HEAD'}`,
@@ -145,8 +142,7 @@ export function registerAgentReviewCommitWatcher(
       ),
     );
   })().catch((err: unknown) => {
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Could not watch git commits for agent review: ${toErrorMessage(err)}`,
     );
   });

--- a/packages/extension/src/frontend/ui/diffView.ts
+++ b/packages/extension/src/frontend/ui/diffView.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { REFRESH_THRESHOLD_MS } from '@utils/config/constants';
 
-const CHANNEL = 'DiffRefresh';
+const log = createLog('DiffRefresh');
 
 interface DiffInfo {
   left: vscode.Uri;
@@ -31,7 +31,7 @@ function refreshDiff(): void {
     diffInfo.title,
     { preserveFocus: true } satisfies vscode.TextDocumentShowOptions,
   );
-  logger.debug(CHANNEL, 'Refreshed diff view');
+  log.debug('Refreshed diff view');
 }
 
 export function registerDiffRefresh(
@@ -45,12 +45,12 @@ export function registerDiffRefresh(
   // timestamp would swallow this diff's first refresh.
   lastRefresh = 0;
   refreshListener = vscode.window.onDidChangeTextEditorViewColumn(refreshDiff);
-  logger.debug(CHANNEL, 'Registered diff refresh listeners');
+  log.debug('Registered diff refresh listeners');
 }
 
 export function disposeDiffRefresh(): void {
   refreshListener?.dispose();
   refreshListener = undefined;
   diffInfo = undefined;
-  logger.debug(CHANNEL, 'Disposed diff refresh listeners');
+  log.debug('Disposed diff refresh listeners');
 }

--- a/packages/extension/src/frontend/vscode/vscodeDiagnostics.ts
+++ b/packages/extension/src/frontend/vscode/vscodeDiagnostics.ts
@@ -7,11 +7,11 @@
 
 import * as vscode from 'vscode';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 
 import { raceWithTimeout } from './raceWithTimeout';
 
-const CHANNEL = 'VscodeDiagnostics';
+const log = createLog('VscodeDiagnostics');
 
 /**
  * Wait for diagnostics to change for a specific file.
@@ -39,6 +39,6 @@ export async function waitForDiagnosticsChange(
   );
 
   if (raced.timedOut) {
-    logger.debug(CHANNEL, `Timed out waiting for diagnostics: ${uri.fsPath}`);
+    log.debug(`Timed out waiting for diagnostics: ${uri.fsPath}`);
   }
 }

--- a/packages/extension/src/frontend/vscode/vscodeEditor.ts
+++ b/packages/extension/src/frontend/vscode/vscodeEditor.ts
@@ -6,11 +6,11 @@
 
 import * as vscode from 'vscode';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-const CHANNEL = 'vscodeEditor';
+const log = createLog('vscodeEditor');
 
 /**
  * Clamp a 1-based line number to a 0-based VS Code line index. Floors first
@@ -112,10 +112,7 @@ export async function openFileInEditor(
 
     return { editor, absolutePath: uri.fsPath };
   } catch (err) {
-    logger.warn(
-      CHANNEL,
-      `Failed to open ${filePath} in an editor: ${toErrorMessage(err)}`,
-    );
+    log.warn(`Failed to open ${filePath} in an editor: ${toErrorMessage(err)}`);
     return undefined;
   }
 }

--- a/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
@@ -15,7 +15,7 @@ import {
 } from '@agent/runtime/helperModel';
 import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
 import { buildUserVarPassthrough } from '@agent/utils/userVars';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { AgentCategory } from '@shared/schemas';
 import { DELEGATE_MULTI_AGENTS_TOOL_NAME } from '@shared/constants/delegationTools';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
@@ -23,7 +23,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { isNonEmptyString } from '@utils/text/stringUtils';
 import { extractTextFromTag } from '@utils/text/xmlExtraction';
 
-const CHANNEL = 'AgentCreator';
+const log = createLog('AgentCreator');
 
 // ── Types ───────────────────────────────────────────────────
 
@@ -344,10 +344,7 @@ async function generateAgentYaml(
           throw new Error(`Generated YAML was invalid: ${lastValidationError}`);
         }
 
-        logger.info(
-          CHANNEL,
-          `AI generation succeeded for ${blueprint.category} agent`,
-        );
+        log.info(`AI generation succeeded for ${blueprint.category} agent`);
         return candidate;
       },
       {
@@ -358,10 +355,7 @@ async function generateAgentYaml(
       },
     );
   } catch (error) {
-    logger.warn(
-      CHANNEL,
-      `AI generation failed, using template: ${toErrorMessage(error)}`,
-    );
+    log.warn(`AI generation failed, using template: ${toErrorMessage(error)}`);
     // Route through the shared renderer so both the Settings "new from
     // template" flow and this fallback produce byte-identical output for
     // matching inputs.

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -2,7 +2,7 @@
 
 import { DEFAULT_WORKFLOW_AGENT } from '@agent/core/definition/AgentConfig';
 import { AgentRosterController } from '@agent/roster/AgentRosterController';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import type { AgentOptionData } from '@shared/schemas';
 import { PREFERRED_TOOL_USE_AGENTS } from '@shared/constants/agents';
@@ -32,7 +32,7 @@ import {
 import { loadRemoteAgents, persistRemoteAgentMeta } from './remoteAgentMeta';
 import type { AgentEntry, ResolvedAgent } from './agentEntry';
 
-const CHANNEL = 'agentRegistry';
+const log = createLog('agentRegistry');
 
 /**
  * Source priority for lookups (higher priority first). `inline` must be listed,
@@ -194,10 +194,7 @@ async function doLoad(
     cache.set(agentKeyOf(entry), entry);
   }
 
-  logger.info(
-    CHANNEL,
-    `Loaded ${cache.size} agents in ${Date.now() - startTime}ms`,
-  );
+  log.info(`Loaded ${cache.size} agents in ${Date.now() - startTime}ms`);
   return true;
 }
 
@@ -343,8 +340,7 @@ export function invalidateRemoteAgentsAfterSignOut(): Promise<void> {
     // An older in-flight remote load may have settled before the rebuild.
     // Preserve the signed-out invariant even when local directory I/O fails.
     removeRemoteEntries();
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Local agent catalog rebuild failed after sign-out: ${String(error)}`,
     );
   });

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -10,7 +10,7 @@ import {
   type AgentDefinition,
 } from '@agent/core/definition/AgentDataclass';
 import { parseYamlWith } from '@common/parsing/safeParseYaml';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { AgentCategory } from '@shared/schemas';
 import type { AgentSource } from '@shared/schemas/agent';
 import { filterNotNull, groupBy } from '@utils/core';
@@ -18,7 +18,7 @@ import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { AgentEntry } from './agentEntry';
 
-const CHANNEL = 'agentRegistry';
+const log = createLog('agentRegistry');
 
 interface ParsedAgentYaml {
   readonly name: string;
@@ -65,10 +65,10 @@ export async function scanDirectory(
       .map((entry) => scanYaml(entry, source, definitions))
       .filter(filterNotNull);
 
-    logger.debug(CHANNEL, `Scanned ${entries.length} agents from ${source}`);
+    log.debug(`Scanned ${entries.length} agents from ${source}`);
     return entries;
   } catch (err) {
-    logger.error(CHANNEL, `Failed to scan ${dir}: ${toErrorMessage(err)}`);
+    log.error(`Failed to scan ${dir}: ${toErrorMessage(err)}`);
     return [];
   }
 }
@@ -82,8 +82,7 @@ function entriesWithUniqueNames(
   for (const [name, matches] of byName) {
     if (matches.length > 1) {
       const paths = matches.map((entry) => entry.path).join(', ');
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Duplicate agent name "${name}" in ${paths}; skipping all duplicates.`,
       );
       continue;
@@ -100,10 +99,7 @@ async function readYamlDefinition(
     const content = await AbsoluteFS.read(yamlPath);
     const parsed = parseYamlWith(content, AgentDefinitionSchema);
     if (parsed.isErr()) {
-      logger.warn(
-        CHANNEL,
-        `Failed to scan ${yamlPath}: ${toErrorMessage(parsed.error)}`,
-      );
+      log.warn(`Failed to scan ${yamlPath}: ${toErrorMessage(parsed.error)}`);
       return null;
     }
     return {
@@ -112,7 +108,7 @@ async function readYamlDefinition(
       definition: parsed.value,
     };
   } catch (err) {
-    logger.warn(CHANNEL, `Failed to scan ${yamlPath}: ${toErrorMessage(err)}`);
+    log.warn(`Failed to scan ${yamlPath}: ${toErrorMessage(err)}`);
     return null;
   }
 }
@@ -184,7 +180,8 @@ function scanYaml(
     const rawSettings = settingsBlock.value;
     const rawPrompts = promptsBlock.value;
     const defaultOutputFiles = rawSettings.defaultOutputFiles as
-      string[] | undefined;
+      | string[]
+      | undefined;
 
     const tools = extractToolNames(rawSettings.tools as unknown[] | undefined);
 
@@ -209,8 +206,7 @@ function scanYaml(
           userRequestTemplateCount(rawPrompts.userRequest),
         );
       } else {
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Ignoring malformed rounds in ${entry.path}: ${toErrorMessage(parsedRounds.error)}`,
         );
       }
@@ -229,10 +225,7 @@ function scanYaml(
       rounds,
     };
   } catch (err) {
-    logger.warn(
-      CHANNEL,
-      `Failed to scan ${entry.path}: ${toErrorMessage(err)}`,
-    );
+    log.warn(`Failed to scan ${entry.path}: ${toErrorMessage(err)}`);
     return null;
   }
 }

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -180,8 +180,7 @@ function scanYaml(
     const rawSettings = settingsBlock.value;
     const rawPrompts = promptsBlock.value;
     const defaultOutputFiles = rawSettings.defaultOutputFiles as
-      | string[]
-      | undefined;
+      string[] | undefined;
 
     const tools = extractToolNames(rawSettings.tools as unknown[] | undefined);
 

--- a/src/agent/index/remoteAgentMeta.ts
+++ b/src/agent/index/remoteAgentMeta.ts
@@ -1,13 +1,13 @@
 /** Remote agent metadata persistence and loading for the agent registry. */
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import { AgentCategory } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { AgentEntry } from './agentEntry';
 
-const CHANNEL = 'agentRegistry';
+const log = createLog('agentRegistry');
 
 /**
  * Cached metadata for a remote agent, persisted in globalState.
@@ -63,10 +63,7 @@ export async function loadRemoteAgents(): Promise<AgentEntry[]> {
       };
     });
   } catch (err) {
-    logger.warn(
-      CHANNEL,
-      `Failed to load remote agents: ${toErrorMessage(err)}`,
-    );
+    log.warn(`Failed to load remote agents: ${toErrorMessage(err)}`);
     return [];
   }
 }

--- a/src/agent/modelHandlers/anthropic/anthropicDocumentHandling.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicDocumentHandling.ts
@@ -6,7 +6,7 @@ import { Buffer } from 'node:buffer';
 import { toFile } from '@anthropic-ai/sdk';
 
 // Local imports
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { countPdfPagesInBuffer } from '@utils/media/pdfPageCount';
 import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
@@ -23,7 +23,7 @@ import type {
 } from '@anthropic-ai/sdk/resources/messages';
 import type { BetaRequestDocumentBlock } from '@anthropic-ai/sdk/resources/beta/messages';
 
-const CHANNEL = 'AnthropicDocuments';
+const log = createLog('AnthropicDocuments');
 
 /**
  * Extracts all document blocks from a content block array, including those
@@ -207,8 +207,7 @@ export async function replaceDocumentDataWithUploads(
       buffer = Buffer.from(base64Data, 'base64');
 
       const pageCount = await countPdfPagesWithDegrade(buffer, (err) =>
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Unable to count pages in ${sanitizedFilename}; uploading without a page count: ${toErrorMessage(err)}`,
         ),
       );

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -2,7 +2,7 @@
 import { toJSONSchema } from 'zod';
 
 // Local imports - agent
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 
 // Type imports
 import type { ToolDefinition } from '@model/ToolDefinition';
@@ -31,7 +31,7 @@ import type {
 // Shared Tool Conversion Utilities
 // ============================================================================
 
-const CHANNEL = 'toolConversion';
+const log = createLog('toolConversion');
 
 type JSONSchemaObject = Record<string, unknown>;
 
@@ -401,8 +401,7 @@ function toObjectParametersSchema(
   if (!schema) return EMPTY_TOOL_PARAMETERS_SCHEMA;
   if (schema.type === 'object') return schema;
   if (schema.type !== undefined) {
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `${provider} tool parameters must be object schemas; received type "${String(schema.type)}". Falling back to an empty object schema.`,
     );
     return EMPTY_TOOL_PARAMETERS_SCHEMA;

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -1,11 +1,11 @@
 import pRetry, { AbortError } from 'p-retry';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 
 /** Flow transition action - typically 'default' or a custom action name */
 export type Action = string;
 
-const CHANNEL = 'PocketFlow';
+const log = createLog('PocketFlow');
 // Actions that deliberately end a flow when a node returns them with no
 // registered successor. `finalize` is the reflection flow's terminal action on
 // failure (ResponseCycleNode.post → FlowTransition.FINALIZE); without listing it
@@ -59,7 +59,7 @@ class BaseNode<S = unknown, Svc = unknown> {
   }
   async run(shared: S): Promise<Action | undefined> {
     if (this._successors.size > 0)
-      logger.warn(CHANNEL, "Node won't run successors. Use Flow.");
+      log.warn("Node won't run successors. Use Flow.");
     return await this._run(shared);
   }
   setServices(services: Svc): this {
@@ -72,7 +72,7 @@ class BaseNode<S = unknown, Svc = unknown> {
   }
   on(action: Action, node: BaseNode): this {
     if (this._successors.has(action))
-      logger.warn(CHANNEL, `Overwriting successor for action '${action}'`);
+      log.warn(`Overwriting successor for action '${action}'`);
     this._successors.set(action, node);
     return this;
   }
@@ -80,8 +80,7 @@ class BaseNode<S = unknown, Svc = unknown> {
     const next = this._successors.get(action);
     if (!next && TERMINAL_ACTIONS.has(action)) return undefined;
     if (!next && this._successors.size > 0) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Flow ends: '${action}' not found in [${[...this._successors.keys()]}]`,
       );
     }
@@ -171,8 +170,7 @@ class Node<S = unknown, Svc = unknown> extends BaseNode<S, Svc> {
   }
   async _exec(prepRes: unknown): Promise<unknown> {
     if (this.maxRetries < 1) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Node maxRetries must be >= 1, got ${this.maxRetries}. Using 1.`,
       );
     }

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -9,7 +9,7 @@ import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 
 // Local imports - utilities
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local imports - flow engine
@@ -23,7 +23,7 @@ export function flowKey(runId: string): string {
   return `${FLOW_KEY_PREFIX}${runId}`;
 }
 
-const CHANNEL = 'PersistedFlow';
+const log = createLog('PersistedFlow');
 
 export const FLOW_RECORD_SCHEMA_VERSION = 2;
 const START_NODE_ID = 'start';
@@ -98,7 +98,10 @@ export const PersistedFlowRecordEnvelopeSchema = z
   .pipe(PersistedFlowRecordObjectSchema);
 
 export type PersistedFlowStateErrorReason =
-  'read-failed' | 'unsupported-record' | 'missing-shared' | 'invalid-shared';
+  | 'read-failed'
+  | 'unsupported-record'
+  | 'missing-shared'
+  | 'invalid-shared';
 
 /** Persisted flow state cannot be read or resumed safely. */
 export class PersistedFlowStateError extends Error {
@@ -251,7 +254,8 @@ export class PersistedFlow<
    * Errors are swallowed — the authoritative flow blob is already written.
    */
   private projection:
-    ((shared: S, kv: ExecutionKVStore) => Promise<void>) | null = null;
+    | ((shared: S, kv: ExecutionKVStore) => Promise<void>)
+    | null = null;
 
   /**
    * Create a new PersistedFlow.
@@ -313,7 +317,7 @@ export class PersistedFlow<
     try {
       await this.projection(shared, this.kv);
     } catch (err) {
-      logger.warn(CHANNEL, `Projection failed: ${toErrorMessage(err)}`, {
+      log.warn(`Projection failed: ${toErrorMessage(err)}`, {
         data: err,
       });
     }

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -98,10 +98,7 @@ export const PersistedFlowRecordEnvelopeSchema = z
   .pipe(PersistedFlowRecordObjectSchema);
 
 export type PersistedFlowStateErrorReason =
-  | 'read-failed'
-  | 'unsupported-record'
-  | 'missing-shared'
-  | 'invalid-shared';
+  'read-failed' | 'unsupported-record' | 'missing-shared' | 'invalid-shared';
 
 /** Persisted flow state cannot be read or resumed safely. */
 export class PersistedFlowStateError extends Error {
@@ -254,8 +251,7 @@ export class PersistedFlow<
    * Errors are swallowed — the authoritative flow blob is already written.
    */
   private projection:
-    | ((shared: S, kv: ExecutionKVStore) => Promise<void>)
-    | null = null;
+    ((shared: S, kv: ExecutionKVStore) => Promise<void>) | null = null;
 
   /**
    * Create a new PersistedFlow.

--- a/src/agent/output/diffComputation.ts
+++ b/src/agent/output/diffComputation.ts
@@ -5,7 +5,7 @@
  * using the diff-match-patch library.
  */
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { OutputFileInfo, FileLocation } from '@shared/schemas';
 import type { DiffStats } from '@shared/schemas/lineChanges';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
@@ -22,7 +22,7 @@ import { traceFileLineage } from './lineageMapping';
 import { ensureRoundData, type OutputState } from './outputState';
 import type { RoundFileMapping } from './types';
 
-const CHANNEL = 'OutputDiffStats';
+const log = createLog('OutputDiffStats');
 
 // ============================================================================
 // Helpers
@@ -47,10 +47,7 @@ async function computeDiffStats(
     // Preserve diff-match-patch's omitted-argument default: checkLines=true.
     return diffLineChanges(baseContent, outContent, { checkLines: true });
   } catch (err) {
-    logger.debug(
-      CHANNEL,
-      `Failed to compute diff stats: ${toErrorMessage(err)}`,
-    );
+    log.debug(`Failed to compute diff stats: ${toErrorMessage(err)}`);
     return {};
   }
 }

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -14,7 +14,7 @@ import {
   isCodexSessionRoutable,
 } from '@auth/codex';
 import { AgentError } from '@common/errors';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import {
   copilotRouteUnavailableReason,
   prefersCopilotRoute,
@@ -44,7 +44,7 @@ import { getUseOpenRouter } from '@utils/config/providerConfig';
 import { getConfig } from '@utils/config/configUtils';
 import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
 
-const CHANNEL = 'ModelFactory';
+const log = createLog('ModelFactory');
 
 type ModelHandlerConstructor = new (
   config: ModelConfig,
@@ -63,7 +63,8 @@ const MODEL_HANDLER_COMPATIBILITY_PROPERTY =
 
 type ModelHandlerCompatibilityTagged = object & {
   readonly [MODEL_HANDLER_COMPATIBILITY_PROPERTY]?:
-    ModelHandlerCompatibilityKey | undefined;
+    | ModelHandlerCompatibilityKey
+    | undefined;
 };
 
 // Record (not Map) so TypeScript enforces exhaustiveness over ModelProvider.
@@ -161,8 +162,7 @@ function withReasoningOverride<T extends ModelHandler>(handler: T): T {
   const effort = level ? LEVEL_TO_EFFORT[level] : undefined;
   if (effort === undefined) return handler;
 
-  logger.debug(
-    CHANNEL,
+  log.debug(
     `Applying reasoning level override for ${handler.config.name}: ${level}`,
   );
   handler.capabilities.reasoningEffort = effort;
@@ -309,10 +309,7 @@ function providerHandlerRoute(
 ): ProviderHandlerRoute | undefined {
   const route = PROVIDER_HANDLER_ROUTES[provider];
   if (!route) {
-    logger.warn(
-      CHANNEL,
-      `No model handler route is registered for provider ${provider}`,
-    );
+    log.warn(`No model handler route is registered for provider ${provider}`);
     return undefined;
   }
   return route;
@@ -379,8 +376,7 @@ function withShortModelName(config: ModelConfig): ModelConfig {
   );
   if (resolved === config) return config;
 
-  logger.debug(
-    CHANNEL,
+  log.debug(
     `Using short model name for ${config.name}: ${config.fullName} → ${resolved.fullName}`,
   );
   return resolved;
@@ -511,7 +507,7 @@ async function tryCodexSubscriptionRoute(
   if (!codexSessionRoutable) {
     return undefined;
   }
-  logger.debug(CHANNEL, 'Using ChatGPT subscription (Codex) Handler');
+  log.debug('Using ChatGPT subscription (Codex) Handler');
   const { ModelHandlerCodex } =
     await import('@agent/modelHandlers/openai/modelHandlerCodex');
   return finalizeModelHandler(
@@ -618,8 +614,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
       // Package validation still enters the real CLI and executeAgent path.
       // Only the provider boundary is deterministic, so this must not become
       // a user-facing model selector or an injected command-layer substitute.
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `${internalValidationModelHandlerEnvName()}=1 is replacing provider handlers with the internal validation handler.`,
       );
       const { ModelHandlerValidation } =
@@ -631,7 +626,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
     }
 
     case 'ModelHandlerOpenAIResponse': {
-      logger.debug(CHANNEL, 'Using OpenAI Responses API Handler');
+      log.debug('Using OpenAI Responses API Handler');
       const { ModelHandlerOpenAIResponse } =
         await import('@agent/modelHandlers/openai/modelHandlerOpenAIResponse');
       return finalizeModelHandler(
@@ -678,7 +673,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
         throw new Error(`Unsupported model provider: ${config.provider}`);
       }
       const HandlerClass = await route.load();
-      logger.debug(CHANNEL, `Using Handler: ${HandlerClass.name}`);
+      log.debug(`Using Handler: ${HandlerClass.name}`);
       return finalizeModelHandler(
         new HandlerClass(config, responseTextProcessing),
         route.compatibilityKey,

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -63,8 +63,7 @@ const MODEL_HANDLER_COMPATIBILITY_PROPERTY =
 
 type ModelHandlerCompatibilityTagged = object & {
   readonly [MODEL_HANDLER_COMPATIBILITY_PROPERTY]?:
-    | ModelHandlerCompatibilityKey
-    | undefined;
+    ModelHandlerCompatibilityKey | undefined;
 };
 
 // Record (not Map) so TypeScript enforces exhaustiveness over ModelProvider.

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -16,18 +16,18 @@ import {
   runHelperModelCompletion,
 } from '@agent/runtime/helperModel';
 import { getSdkErrorMessage } from '@common/errors/sdkError/providerErrorFormat';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { isNonEmptyString } from '@utils/core';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
-const CHANNEL = 'SessionDescription';
+const log = createLog('SessionDescription');
 const MAX_DESCRIPTION_LENGTH = 80;
 const MAX_DESCRIPTION_WORDS = 12;
 
 function warnWithoutRejecting(message: string): void {
   try {
-    logger.warn(CHANNEL, message);
+    log.warn(message);
   } catch {
     // Best-effort diagnostics must not make description generation reject.
   }
@@ -146,7 +146,7 @@ export async function generateSessionDescription(
         payload: { streamId, description },
       },
     });
-    logger.info(CHANNEL, `Generated session description for ${executionId}`);
+    log.info(`Generated session description for ${executionId}`);
   } catch (err) {
     warnWithoutRejecting(
       `Failed to generate session description: ${getSdkErrorMessage(err)}`,

--- a/src/agent/runtime/textEnhancement.ts
+++ b/src/agent/runtime/textEnhancement.ts
@@ -1,5 +1,5 @@
 import { getSdkErrorMessage } from '@common/errors/sdkError/providerErrorFormat';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { isNonEmptyString } from '@utils/core';
 
 import { extractTextFromTag } from '@utils/text/xmlExtraction';
@@ -7,7 +7,7 @@ import { renderPolishPrompt } from './polishModel';
 import { createHelperModelKit, runHelperModelCompletion } from './helperModel';
 import type { SessionHandle } from './SessionHandle';
 
-const CHANNEL = 'TextEnhancement';
+const log = createLog('TextEnhancement');
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -68,15 +68,14 @@ export async function polishTextWithAI(
 
     const corrected = extractTextFromTag(responseText, 'corrected_text');
     if (!corrected) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         'Model did not wrap response in <corrected_text> tags; using raw response',
       );
     }
     return { success: true, text: (corrected ?? responseText).trim() };
   } catch (error) {
     const message = getSdkErrorMessage(error);
-    logger.error(CHANNEL, `Error polishing text: ${message}`);
+    log.error(`Error polishing text: ${message}`);
     return { success: false, text, error: message };
   }
 }

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -16,7 +16,7 @@ import {
   type RunRecord,
 } from '@agent/core/definition/RunRecord';
 import { KVStore } from '@common/storage/KVStore';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { resolveRunStoragePath } from '@platform/defaults/workspaceStorage';
 import {
   ExecutionMetaCoreSchema,
@@ -71,7 +71,7 @@ export function isReservedKvKeyName(key: string): boolean {
   return RESERVED_KEY_NAMES.has(key) || key.startsWith(CHILD_KEY_PREFIX);
 }
 
-const CHANNEL = 'ExecutionKVStore';
+const log = createLog('ExecutionKVStore');
 type ExecutionMetaInput = z.input<typeof ExecutionMetaSchema>;
 
 // ============================================================================
@@ -230,8 +230,7 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
     if (raw === undefined) return null;
     const result = schema.safeParse(raw);
     if (result.success) return result.data;
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Failed to parse execution ${this.executionId} ${key}.json: ${toErrorMessage(
         result.error,
       )}`,
@@ -249,8 +248,7 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
 
     const core = ExecutionMetaCoreSchema.safeParse(raw);
     if (!core.success) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Failed to parse execution ${this.executionId} meta.json: ${toErrorMessage(
           core.error,
         )}`,
@@ -264,8 +262,7 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
       (raw as { workflow?: unknown }).workflow,
     );
     if (!workflow.success) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Failed to parse execution ${this.executionId} meta.json workflow: ${toErrorMessage(
           workflow.error,
         )}`,

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -82,8 +82,7 @@ export class SessionStores {
   private readonly listExecutionStreamReferences: ListExecutionStreamReferencesFn;
   private readonly goalEntries: GoalEntryStore | undefined;
   private readonly onCanonicalStreamDeleted:
-    | ((stream: StreamTabId) => void | Promise<void>)
-    | undefined;
+    ((stream: StreamTabId) => void | Promise<void>) | undefined;
   private readonly onChildrenDetached:
     | ((
         parent: StreamTabId,

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -12,7 +12,7 @@ import {
 import { waitForOwnedExecutionLeaseRelease } from '@agent/storage/executionLease';
 import { throwUnwrapAggregate } from '@agent/storage/storageErrors';
 import { isBackgroundShellStream } from '@agent/runtime/streamTab';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { StreamLogStore, StreamSnapshotStore } from '@transcript';
 import type { StagedStreamSnapshotDeletion } from '@transcript/StagedDeletionCoordinator';
@@ -20,7 +20,7 @@ import { canUseStreamDataDir } from '@transcript/streamDataPaths';
 import { unique } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-const CHANNEL = 'SessionStores';
+const log = createLog('SessionStores');
 
 type DeleteExecutionFn = (
   executionId: ExecutionId,
@@ -82,7 +82,8 @@ export class SessionStores {
   private readonly listExecutionStreamReferences: ListExecutionStreamReferencesFn;
   private readonly goalEntries: GoalEntryStore | undefined;
   private readonly onCanonicalStreamDeleted:
-    ((stream: StreamTabId) => void | Promise<void>) | undefined;
+    | ((stream: StreamTabId) => void | Promise<void>)
+    | undefined;
   private readonly onChildrenDetached:
     | ((
         parent: StreamTabId,
@@ -190,8 +191,7 @@ export class SessionStores {
     try {
       await this.onCanonicalStreamDeleted(stream);
     } catch (error) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Stream ${stream} was deleted, but canonical session cleanup was incomplete: ${toErrorMessage(error)}`,
         { data: error },
       );
@@ -206,8 +206,7 @@ export class SessionStores {
     try {
       await this.onChildrenDetached(stream, children);
     } catch (error) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Stream ${stream} was deleted, but child-detachment projection was incomplete: ${toErrorMessage(error)}`,
         { data: error },
       );
@@ -240,8 +239,7 @@ export class SessionStores {
       try {
         await this.deleteAdjacentStreamState(stream);
       } catch (error) {
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Stream ${stream} was retained because cleanup was incomplete: ${toErrorMessage(error)}`,
           { data: error },
         );
@@ -257,15 +255,13 @@ export class SessionStores {
       case 'completed':
         return outcome.result.status === 'active' ? 'active' : 'deleted';
       case 'streams-deleted':
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Stream ${stream} was deleted, but execution ${executionId} cleanup was incomplete: ${toErrorMessage(outcome.error)}`,
           { data: outcome.error },
         );
         return 'deleted';
       case 'retained':
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Stream ${stream} was retained because cleanup was incomplete: ${toErrorMessage(outcome.error)}`,
           { data: outcome.error },
         );
@@ -322,7 +318,7 @@ export class SessionStores {
       reconciliation.pendingCleanup.length > 0 ||
       reconciliation.discarded.length > 0
     ) {
-      logger.info(CHANNEL, 'Reconciled interrupted stream deletions', {
+      log.info('Reconciled interrupted stream deletions', {
         data: reconciliation,
       });
     }
@@ -355,8 +351,7 @@ export class SessionStores {
     const retainUnreadable = (stream: StreamTabId, error: unknown): void => {
       // Per-stream isolation: one unreadable ownership record retains that
       // stream instead of failing the whole bulk deletion before it starts.
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Stream ${stream} was retained because its execution ownership could not be read: ${toErrorMessage(error)}`,
         { data: error },
       );
@@ -392,8 +387,7 @@ export class SessionStores {
           await this.deleteAdjacentStreamState(stream);
           if (canonicalStreams.has(stream)) await this.notifyDeleted(stream);
         } catch (error) {
-          logger.warn(
-            CHANNEL,
+          log.warn(
             `Failed to delete stream ${stream}: ${toErrorMessage(error)}`,
             { data: error },
           );
@@ -425,16 +419,14 @@ export class SessionStores {
           return;
         }
         if (outcome.kind === 'streams-deleted') {
-          logger.warn(
-            CHANNEL,
+          log.warn(
             `Streams for execution ${executionId} were deleted, but execution cleanup was incomplete: ${toErrorMessage(outcome.error)}`,
             { data: outcome.error },
           );
           await this.notifyCanonicalDeletions(streams, canonicalStreams);
           return;
         }
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Failed to delete streams for execution ${executionId}: ${toErrorMessage(outcome.error)}`,
           { data: outcome.error },
         );
@@ -470,8 +462,7 @@ export class SessionStores {
       new Set(this.streamLogs.keys()),
     );
     if (orphans.streams.length > 0 || orphans.executionIds.length > 0) {
-      logger.info(
-        CHANNEL,
+      log.info(
         `Removed ${orphans.streams.length} orphaned stream sidecar(s) and ${orphans.executionIds.length} execution dir(s).`,
         { data: orphans },
       );
@@ -514,22 +505,17 @@ export class SessionStores {
         else retained.push(stream);
       } catch (error) {
         retained.push(stream);
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Failed to sweep leftover background shell ${stream}: ${toErrorMessage(error)}`,
           { data: error },
         );
       }
     }
     if (swept.length > 0) {
-      logger.info(
-        CHANNEL,
-        `Swept ${swept.length} leftover background-shell stream(s).`,
-      );
+      log.info(`Swept ${swept.length} leftover background-shell stream(s).`);
     }
     if (retained.length > 0) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `${retained.length} leftover background-shell stream(s) could not be swept and stay listed.`,
         { data: { retained } },
       );
@@ -550,8 +536,7 @@ export class SessionStores {
     liveStreams: ReadonlySet<StreamTabId>,
   ): Promise<{ streams: StreamTabId[]; executionIds: ExecutionId[] }> {
     if (this.streamLogs.mode.kind !== 'persistent') {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Skipped the orphaned-stream sweep: the transcript index is ${this.streamLogs.mode.kind} and cannot say which persisted streams are still live.`,
       );
       return { streams: [], executionIds: [] };
@@ -580,16 +565,14 @@ export class SessionStores {
             );
             if (outcome.kind === 'streams-deleted') {
               sweptStreams.push(stream);
-              logger.warn(
-                CHANNEL,
+              log.warn(
                 `Orphaned stream ${stream} was removed, but execution ${executionId} cleanup was incomplete.`,
                 { data: outcome.error },
               );
               return;
             }
             if (outcome.kind === 'retained') {
-              logger.warn(
-                CHANNEL,
+              log.warn(
                 `Skipping orphaned execution cleanup for ${executionId}; startup will continue.`,
                 { data: outcome.error },
               );
@@ -604,8 +587,7 @@ export class SessionStores {
           }
           sweptStreams.push(stream);
         } catch (error) {
-          logger.warn(
-            CHANNEL,
+          log.warn(
             `Skipping orphaned stream cleanup for ${stream}; startup will continue.`,
             { data: error },
           );
@@ -630,8 +612,7 @@ export class SessionStores {
     try {
       references = await this.listExecutionStreamReferences();
     } catch (error) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Skipping execution-side orphan cleanup; startup will continue: ${toErrorMessage(error)}`,
         { data: error },
       );
@@ -655,8 +636,7 @@ export class SessionStores {
         });
         if (result?.status === 'deleted') swept.push(executionId);
       } catch (error) {
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Skipping orphaned execution cleanup for ${executionId}; startup will continue.`,
           { data: error },
         );
@@ -693,8 +673,7 @@ export class SessionStores {
     ]);
     for (const result of cleanup) {
       if (result.status === 'fulfilled') continue;
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Stream ${stream} was deleted, but auxiliary cleanup was incomplete: ${toErrorMessage(result.reason)}`,
         { data: result.reason },
       );
@@ -758,8 +737,7 @@ export class SessionStores {
     ]);
     for (const result of cleanup) {
       if (result.status === 'fulfilled') continue;
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Streams were deleted, but auxiliary cleanup was incomplete: ${toErrorMessage(result.reason)}`,
         { data: result.reason },
       );

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -8,13 +8,13 @@ import { z } from 'zod';
 
 import { isFileNotFoundError } from '@common/errors';
 import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import type { ExecutionId } from '@shared/schemas';
 import { StorageFS } from '@utils/files/storageFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-const CHANNEL = 'ExecutionLease';
+const log = createLog('ExecutionLease');
 /** A host that misses eight heartbeats is no longer considered live. */
 export const EXECUTION_LEASE_STALE_MS = 120_000;
 const EXECUTION_LEASE_HEARTBEAT_MS = 15_000;
@@ -311,7 +311,7 @@ function forgetOwnedLease(
         try {
           listener();
         } catch (error) {
-          logger.warn(CHANNEL, 'Execution lease-loss listener failed', {
+          log.warn('Execution lease-loss listener failed', {
             data: { executionId: lease.executionId, error },
           });
         }
@@ -387,8 +387,7 @@ function handleHeartbeatFailure(
   if (ownershipUnprovable) {
     forgetOwnedLease(lease, { notifyLoss: true });
   }
-  logger.warn(
-    CHANNEL,
+  log.warn(
     `Failed to heartbeat execution ${lease.executionId}: ${toErrorMessage(error)}`,
     {
       data: {
@@ -721,8 +720,7 @@ export async function completeOwnedExecutionLease(
   try {
     await releaseOwnedExecutionLease(executionId);
   } catch (error) {
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Failed to release execution ${executionId}; its lease will expire after the stale horizon: ${toErrorMessage(error)}`,
       { data: error },
     );

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -9,7 +9,7 @@
 import type { RunRecord } from '@agent/core/definition/RunRecord';
 import { flowKey } from '@agent/node/persistedFlow';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import {
   RUN_OUTCOME,
   USER_FOLLOW_UP_SUPPORT,
@@ -34,7 +34,7 @@ import {
   releaseOwnedExecutionLease,
 } from './executionLease';
 
-const CHANNEL = 'ExecutionLifecycle';
+const log = createLog('ExecutionLifecycle');
 
 function pinExecutionWorkingDirectory(record: RunRecord): RunRecord {
   const workingDirectory =
@@ -231,7 +231,8 @@ export type FinalizeExecutionResult =
       readonly status: 'failed';
       readonly error: unknown;
       readonly stage:
-        'terminal-status' | 'terminal-status-and-flow-record-delete';
+        | 'terminal-status'
+        | 'terminal-status-and-flow-record-delete';
       readonly outcomePersisted: false;
     }
   | {
@@ -317,8 +318,7 @@ export async function writeSessionDescription(
     await enqueueMetaUpdate(executionId, () => ({ description }));
   } catch (err) {
     // Swallow and log — don't let storage I/O errors disrupt execution lifecycle.
-    logger.debug(
-      CHANNEL,
+    log.debug(
       `Failed to persist session description for ${executionId}: ${toErrorMessage(err)}`,
     );
   }

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -231,8 +231,7 @@ export type FinalizeExecutionResult =
       readonly status: 'failed';
       readonly error: unknown;
       readonly stage:
-        | 'terminal-status'
-        | 'terminal-status-and-flow-record-delete';
+        'terminal-status' | 'terminal-status-and-flow-record-delete';
       readonly outcomePersisted: false;
     }
   | {

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -13,7 +13,7 @@ import {
   type RunRecord,
 } from '@agent/core/definition/RunRecord';
 import { isFileNotFoundError } from '@common/errors';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import type {
   ExecutionId,
@@ -32,7 +32,7 @@ import {
   runWithInactiveExecutionLease,
 } from './executionLease';
 
-const CHANNEL = 'ExecutionListing';
+const log = createLog('ExecutionListing');
 const EXECUTION_ID_PATTERN = /^[0-9a-f][-0-9a-f]*$/i;
 const EXECUTION_STORAGE_CONCURRENCY = 32;
 
@@ -153,8 +153,7 @@ export async function listExecutionStreamReferences(): Promise<
         if (!meta?.streamId) return null;
         return { executionId, streamId: meta.streamId };
       } catch (error) {
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Skipping execution ${executionId} with unreadable metadata during orphan cleanup: ${toErrorMessage(error)}`,
           { data: error },
         );
@@ -217,10 +216,7 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
         }
         return { ...base, kind: 'run', identity, record };
       } catch (error) {
-        logger.warn(
-          CHANNEL,
-          `Skipping corrupt execution ${id}: ${toErrorMessage(error)}`,
-        );
+        log.warn(`Skipping corrupt execution ${id}: ${toErrorMessage(error)}`);
         return null;
       }
     },
@@ -230,8 +226,7 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
   // One warning per listing pass, not one per row — a directory full of old
   // rows must degrade loudly, not spam.
   if (preIdentityIds.length > 0) {
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `${preIdentityIds.length} pre-identity execution row(s) listed as incomplete (e.g. ${preIdentityIds[0]}): reader retired per #9590 Stage 7`,
     );
   }

--- a/src/agent/storage/resumability.ts
+++ b/src/agent/storage/resumability.ts
@@ -5,7 +5,7 @@ import {
   flowKey,
   type FlowRecord,
 } from '@agent/node/persistedFlow';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import {
   ExecutionMetaCoreSchema,
   RUN_OUTCOME,
@@ -17,7 +17,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { getExecutionStore } from './ExecutionKVStore';
 
-const CHANNEL = 'Resumability';
+const log = createLog('Resumability');
 
 const ResumableSharedSchema = z.record(z.string(), z.unknown());
 const ResumableFlowRecordSchema = PersistedFlowRecordEnvelopeSchema.refine(
@@ -87,8 +87,7 @@ export async function deriveResumability(
   try {
     rawMeta = await store.read('meta');
   } catch (error) {
-    logger.debug(
-      CHANNEL,
+    log.debug(
       `Failed to read execution metadata for ${executionId}: ${toErrorMessage(
         error,
       )}`,
@@ -103,8 +102,7 @@ export async function deriveResumability(
   if (rawMeta != null) {
     const metaResult = ExecutionMetaCoreSchema.safeParse(rawMeta);
     if (!metaResult.success) {
-      logger.debug(
-        CHANNEL,
+      log.debug(
         `Invalid execution metadata for ${executionId}: ${toErrorMessage(
           metaResult.error,
         )}`,
@@ -129,8 +127,7 @@ export async function deriveResumability(
   try {
     rawFlowRecord = await store.read(flowKey(executionId));
   } catch (error) {
-    logger.debug(
-      CHANNEL,
+    log.debug(
       `Failed to read flow record for ${executionId}: ${toErrorMessage(error)}`,
     );
     return {

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -26,7 +26,7 @@ import {
   type ApprovalRequestHandlerSet,
   type BuildApprovalRequestHandlerSetParams,
 } from '@controllers/progressView/backend/progressBackendUiConfig';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { StateStore } from '@platform/interfaces';
 import type { ProgressViewOutboundMessage, StreamTabId } from '@shared/schemas';
 import { STREAM_PHASE } from '@shared/schemas';
@@ -34,7 +34,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { isInFlightPhase } from '@shared/streams/streamStatus';
 import { canUseStreamDataDir } from '@transcript/streamDataPaths';
 
-const CHANNEL = 'ProgressBackend';
+const log = createLog('ProgressBackend');
 
 type ProgressBackendApprovalOptions = Omit<
   BuildApprovalRequestHandlerSetParams,
@@ -120,7 +120,7 @@ export class ProgressBackend {
       // next full refresh re-sends whatever this frame carried.
       void (async () => options.sendMessage(message))().catch(
         (error: unknown) => {
-          logger.debug(CHANNEL, 'Failed to deliver message to webview', {
+          log.debug('Failed to deliver message to webview', {
             data: { command: message.command, error },
           });
         },

--- a/src/controllers/progressView/backend/WebviewBridge.ts
+++ b/src/controllers/progressView/backend/WebviewBridge.ts
@@ -1,11 +1,11 @@
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ProgressViewOutboundMessage, StreamTabId } from '@shared/schemas';
 import { StreamLogDeltaBuffer } from '@transcript/StreamLog';
 import type { StreamLogStore } from '@transcript/StreamLogStore';
 import { createFlushableDebounce, type FlushableDebounce } from '@utils/core';
 
-const CHANNEL = 'WebviewBridge';
+const log = createLog('WebviewBridge');
 
 const FRAME_INTERVAL_MS = 16;
 
@@ -179,7 +179,7 @@ export class WebviewBridge {
       return await this.sendMessage(message);
     } catch (error) {
       // Webview may be disposed/unreachable; drop the frame and retry next flush.
-      logger.debug(CHANNEL, 'Failed to deliver message to webview', {
+      log.debug('Failed to deliver message to webview', {
         data: error,
       });
       return false;

--- a/src/controllers/progressView/backend/agentProposalTransport.ts
+++ b/src/controllers/progressView/backend/agentProposalTransport.ts
@@ -1,5 +1,5 @@
 import { computeAgentOptionsData } from '@agent/index';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import {
   buildVisibleBasicModelOptionsData,
   computeModelOptionsData,
@@ -11,7 +11,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import type { WebviewUpdater } from './WebviewUpdater';
 
-const CHANNEL = 'agentProposalTransport';
+const log = createLog('agentProposalTransport');
 
 /**
  * Show/dismiss transport for agent proposals, shared by every host that renders
@@ -52,15 +52,13 @@ export function createAgentProposalTransport(options: {
     };
     const [modelOptionsData, agentOptionsData] = await Promise.all([
       computeModelOptionsData().catch((error) => {
-        logger.debug(
-          CHANNEL,
+        log.debug(
           `Model options fetch failed; falling back to the static visible-model list: ${toErrorMessage(error)}`,
         );
         return buildVisibleBasicModelOptionsData();
       }),
       loadAgentOptions().catch((error) => {
-        logger.debug(
-          CHANNEL,
+        log.debug(
           `Agent options fetch failed; omitting the agent dropdown: ${toErrorMessage(error)}`,
         );
         return undefined;

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -209,3 +209,54 @@ export const debug = makeLogFn(LOG_LEVELS.DEBUG);
 export const info = makeLogFn(LOG_LEVELS.INFO);
 export const warn = makeLogFn(LOG_LEVELS.WARN);
 export const error = makeLogFn(LOG_LEVELS.ERROR);
+
+/** A channel-bound view of the four level writers. */
+export interface Log {
+  debug(message: string, options?: LogUtilsOptions): void;
+  info(message: string, options?: LogUtilsOptions): void;
+  warn(message: string, options?: LogUtilsOptions): void;
+  error(message: string, options?: LogUtilsOptions): void;
+}
+
+/**
+ * Bind the four level writers to one channel so a module names its channel
+ * once instead of threading it through every call:
+ * `const log = createLog('X'); log.warn(message)`. Emits through the same
+ * {@link writeLine} sink as the free `debug/info/warn/error` functions.
+ */
+export function createLog(channel: string): Log {
+  return {
+    debug: (message, options = {}) =>
+      writeLine(
+        LOG_LEVELS.DEBUG,
+        channel,
+        /* isAgent */ false,
+        message,
+        options.data,
+      ),
+    info: (message, options = {}) =>
+      writeLine(
+        LOG_LEVELS.INFO,
+        channel,
+        /* isAgent */ false,
+        message,
+        options.data,
+      ),
+    warn: (message, options = {}) =>
+      writeLine(
+        LOG_LEVELS.WARN,
+        channel,
+        /* isAgent */ false,
+        message,
+        options.data,
+      ),
+    error: (message, options = {}) =>
+      writeLine(
+        LOG_LEVELS.ERROR,
+        channel,
+        /* isAgent */ false,
+        message,
+        options.data,
+      ),
+  };
+}

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -18,6 +18,7 @@ import { format } from 'date-fns';
 import safeStringify from 'safe-stable-stringify';
 
 // Local imports
+import * as loggerSelf from '@logger/logUtils';
 import { redactSecrets } from '@logger/redaction';
 import { LOG_LEVELS, type LogLevel } from '@shared/schemas/log';
 import { serializeError } from '@utils/core';
@@ -211,7 +212,7 @@ export const warn = makeLogFn(LOG_LEVELS.WARN);
 export const error = makeLogFn(LOG_LEVELS.ERROR);
 
 /** A channel-bound view of the four level writers. */
-export interface Log {
+interface Log {
   debug(message: string, options?: LogUtilsOptions): void;
   info(message: string, options?: LogUtilsOptions): void;
   warn(message: string, options?: LogUtilsOptions): void;
@@ -221,42 +222,29 @@ export interface Log {
 /**
  * Bind the four level writers to one channel so a module names its channel
  * once instead of threading it through every call:
- * `const log = createLog('X'); log.warn(message)`. Emits through the same
- * {@link writeLine} sink as the free `debug/info/warn/error` functions.
+ * `const log = createLog('X'); log.warn(message)`.
+ *
+ * Each method delegates to the exported `debug/info/warn/error` **through the
+ * module's own namespace** (`loggerSelf`), read fresh on every call rather than
+ * captured at bind time. That indirection is deliberate: it preserves the
+ * observable seam that tests spy on — `vi.spyOn(logger, 'warn')` patches the
+ * namespace binding, and because the lookup is per-call a `log.warn(...)` made
+ * by a module-level `createLog(...)` (bound at import, before the spy exists)
+ * is still intercepted. `options` is forwarded only when present so the spied
+ * argument list matches a direct `warn(channel, msg)` call. Behavior is
+ * otherwise identical to the free functions.
  */
 export function createLog(channel: string): Log {
+  const bind =
+    (level: 'debug' | 'info' | 'warn' | 'error') =>
+    (message: string, options?: LogUtilsOptions): void => {
+      if (options === undefined) loggerSelf[level](channel, message);
+      else loggerSelf[level](channel, message, options);
+    };
   return {
-    debug: (message, options = {}) =>
-      writeLine(
-        LOG_LEVELS.DEBUG,
-        channel,
-        /* isAgent */ false,
-        message,
-        options.data,
-      ),
-    info: (message, options = {}) =>
-      writeLine(
-        LOG_LEVELS.INFO,
-        channel,
-        /* isAgent */ false,
-        message,
-        options.data,
-      ),
-    warn: (message, options = {}) =>
-      writeLine(
-        LOG_LEVELS.WARN,
-        channel,
-        /* isAgent */ false,
-        message,
-        options.data,
-      ),
-    error: (message, options = {}) =>
-      writeLine(
-        LOG_LEVELS.ERROR,
-        channel,
-        /* isAgent */ false,
-        message,
-        options.data,
-      ),
+    debug: bind('debug'),
+    info: bind('info'),
+    warn: bind('warn'),
+    error: bind('error'),
   };
 }

--- a/src/replacement/advanced.ts
+++ b/src/replacement/advanced.ts
@@ -3,9 +3,9 @@
  */
 
 // Local imports - log
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 
-const CHANNEL = 'ReplacementEngine';
+const log = createLog('ReplacementEngine');
 
 /**
  * Applies LaTeX quotes formatting to a LaTeX document.
@@ -24,7 +24,7 @@ export function applyLatexQuotesFormatting(text: string): string {
     return text;
   }
 
-  logger.debug(CHANNEL, 'Starting LaTeX quotes formatting');
+  log.debug('Starting LaTeX quotes formatting');
 
   // Extract document content (everything between \begin{document} and \end{document})
   const documentRegex = /\\begin\{document\}([\s\S]*?)\\end\{document\}/g;
@@ -53,7 +53,7 @@ export function applyLatexQuotesFormatting(text: string): string {
         },
       );
 
-      logger.debug(CHANNEL, `Removed ${tikzCounter} tikzpicture environments`);
+      log.debug(`Removed ${tikzCounter} tikzpicture environments`);
 
       // Process quotes in the remaining content
       let replacementCount = 0;
@@ -61,16 +61,12 @@ export function applyLatexQuotesFormatting(text: string): string {
         /(?<!\\"|\{)"([^"]{3,16})"(?!\})/g,
         (_match, quotedText) => {
           replacementCount++;
-          logger.debug(
-            CHANNEL,
-            `Converting quote: "${quotedText}" → \`\`${quotedText}''`,
-          );
+          log.debug(`Converting quote: "${quotedText}" → \`\`${quotedText}''`);
           return `\`\`${quotedText}''`;
         },
       );
 
-      logger.debug(
-        CHANNEL,
+      log.debug(
         `Made ${replacementCount} quote replacements in document #${documentCount}`,
       );
       totalReplacements += replacementCount;
@@ -85,8 +81,7 @@ export function applyLatexQuotesFormatting(text: string): string {
     },
   );
 
-  logger.debug(
-    CHANNEL,
+  log.debug(
     `Finished LaTeX quotes formatting: processed ${documentCount} document blocks, made ${totalReplacements} replacements`,
   );
 

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -4,7 +4,7 @@
 
 import { LRUCache } from 'lru-cache';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig } from '@utils/config/configUtils';
@@ -47,7 +47,7 @@ import {
   FENCED_LATEX_BLOCK_REPLACEMENTS,
 } from './rulesRegex';
 
-const CHANNEL = 'ReplacementEngine';
+const log = createLog('ReplacementEngine');
 
 /**
  * High-level APIs for applying text replacement rules.
@@ -268,8 +268,7 @@ export function applyReplacements(
               ? result.replace(regex, repl)
               : result.replace(regex, repl);
         } catch (regexErr) {
-          logger.error(
-            CHANNEL,
+          log.error(
             `Error with regex pattern "${pattern}": ${toErrorMessage(regexErr)}`,
           );
         }

--- a/src/shared/config/settingsAccess.ts
+++ b/src/shared/config/settingsAccess.ts
@@ -1,5 +1,5 @@
 // Local imports
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type {
   ConfigProvider,
   ConfigTarget,
@@ -11,7 +11,7 @@ import type {
 } from '@shared/schemas/stateSettings';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-const CHANNEL = 'settingsAccess';
+const log = createLog('settingsAccess');
 
 /**
  * Host-aware read/write for {@link StateSettingEntry} rows.
@@ -75,8 +75,7 @@ export function readSetting(
   if (result.success) {
     return result.data;
   }
-  logger.warn(
-    CHANNEL,
+  log.warn(
     `Ignoring invalid persisted value for setting "${entry.key}": ${toErrorMessage(result.error)}`,
   );
   return settingDefault(entry);

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -5,7 +5,7 @@ import pTimeout from 'p-timeout';
 
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { SUPABASE_CUSTOM_DOMAIN } from '@auth/config';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import type { UsageRoute } from '@shared/schemas';
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
@@ -19,7 +19,7 @@ import type {
   UsageLogResponse,
 } from './UsageLogTypes';
 
-const CHANNEL = 'UsageLogService';
+const log = createLog('UsageLogService');
 
 const USAGE_LOG_ENDPOINT = `https://${SUPABASE_CUSTOM_DOMAIN}/functions/v1/log-usage`;
 const MAX_QUEUE_SIZE = 1000;
@@ -123,8 +123,7 @@ function isTelemetryEnabledBySetting(): boolean {
     (value) => typeof value !== 'boolean',
   );
   if (malformed !== undefined) {
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Ignoring non-boolean ${TELEMETRY_ENABLED_KEY} (got ${typeof malformed}); treating optional usage logging as disabled`,
     );
     return false;
@@ -179,14 +178,12 @@ class UsageLogServiceImpl {
     this.startFlushTimer();
 
     if (isTelemetryDisabledByEnv()) {
-      logger.info(
-        CHANNEL,
+      log.info(
         `Optional usage logging is disabled by the environment (${TELEMETRY_OPT_OUT_ENV_VARS.join(' / ')}); only plan-accounting rounds are reported`,
       );
     }
 
-    logger.debug(
-      CHANNEL,
+    log.debug(
       `UsageLogService initialized (batchSize=${this.config.batchSize}, flushIntervalMs=${this.config.flushIntervalMs}, enabled=${this.config.enabled})`,
     );
   }
@@ -198,7 +195,7 @@ class UsageLogServiceImpl {
     if (!isPlanAccounting(entry) && !isTelemetryEnabledBySetting()) return;
 
     if (this.queue.length >= MAX_QUEUE_SIZE) {
-      logger.warn(CHANNEL, 'Queue full, dropping oldest entry');
+      log.warn('Queue full, dropping oldest entry');
       this.queue.shift();
     }
 
@@ -208,10 +205,7 @@ class UsageLogServiceImpl {
       extensionVersion: this.extensionVersion,
       editorType: this.editorType,
     });
-    logger.debug(
-      CHANNEL,
-      `Queued usage entry (queue size: ${this.queue.length})`,
-    );
+    log.debug(`Queued usage entry (queue size: ${this.queue.length})`);
 
     if (this.queue.length >= this.config.batchSize) {
       void this.flush();
@@ -252,7 +246,7 @@ class UsageLogServiceImpl {
     try {
       const token = await SupabaseClient.getRelayAccessToken();
       if (!token) {
-        logger.debug(CHANNEL, 'Skipping flush - user not authenticated');
+        log.debug('Skipping flush - user not authenticated');
         return USAGE_LOG_FLUSH_OUTCOME.PENDING;
       }
 
@@ -279,8 +273,7 @@ class UsageLogServiceImpl {
         const kept = batch.entries.filter(isPlanAccounting);
         const dropped = batch.entries.length - kept.length;
         if (dropped > 0) {
-          logger.debug(
-            CHANNEL,
+          log.debug(
             `Usage logging is disabled; dropped ${dropped} optional ${dropped === 1 ? 'entry' : 'entries'} without sending`,
           );
         }
@@ -292,8 +285,7 @@ class UsageLogServiceImpl {
         batch = { ...batch, entries: kept };
       }
 
-      logger.debug(
-        CHANNEL,
+      log.debug(
         `Flushing ${batch.entries.length} entries (batch: ${batch.batchId})`,
       );
 
@@ -306,8 +298,7 @@ class UsageLogServiceImpl {
         }
         throw new Error(message);
       }
-      logger.debug(
-        CHANNEL,
+      log.debug(
         `Batch ${batch.batchId} sent successfully (${response.accepted} entries)`,
       );
       return USAGE_LOG_FLUSH_OUTCOME.ACCEPTED;
@@ -316,8 +307,7 @@ class UsageLogServiceImpl {
       if (batch) this.retryBatch = batch;
       const requeuedMessage =
         requeued > 0 ? `; requeued ${requeued} entries` : '';
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Failed to send usage batch${requeuedMessage}: ${toErrorMessage(error)}`,
       );
       return USAGE_LOG_FLUSH_OUTCOME.PENDING;
@@ -325,8 +315,7 @@ class UsageLogServiceImpl {
   }
 
   private reportPermanentRejection(batch: UsageLogBatch, reason: string): void {
-    logger.error(
-      CHANNEL,
+    log.error(
       `Usage batch ${batch.batchId} was permanently rejected; discarded ${batch.entries.length} entries so later batches can continue`,
       {
         data: {
@@ -401,13 +390,13 @@ class UsageLogServiceImpl {
     await pTimeout(this.waitForFlushQuiescence(), {
       milliseconds: DISPOSE_WARNING_TIMEOUT_MS,
       fallback: () => {
-        logger.warn(CHANNEL, 'Dispose timeout waiting for in-flight flush');
+        log.warn('Dispose timeout waiting for in-flight flush');
       },
     });
 
     await this.flush();
 
-    logger.debug(CHANNEL, 'UsageLogService disposed');
+    log.debug('UsageLogService disposed');
   }
 }
 

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -97,6 +97,12 @@ vi.mock('@cli/runtime/supabaseAuth', () => ({
 
 vi.mock('@logger/logUtils', () => ({
   createChannelWriter: vi.fn(() => vi.fn()),
+  createLog: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
   debug: vi.fn(),
   error: vi.fn(),
   info: vi.fn(),

--- a/src/test-kernel/frontend/DiffRefreshThrottle.vitest.ts
+++ b/src/test-kernel/frontend/DiffRefreshThrottle.vitest.ts
@@ -20,6 +20,12 @@ vi.mock('vscode', () => ({
 }));
 
 vi.mock('@logger/logUtils', () => ({
+  createLog: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
   debug: vi.fn(),
   info: vi.fn(),
   warn: vi.fn(),

--- a/src/test-kernel/frontend/InlineComments.vitest.ts
+++ b/src/test-kernel/frontend/InlineComments.vitest.ts
@@ -25,7 +25,15 @@ vi.mock('@frontend/vscode/vscodeEditor', () => ({
   lineToRange: vi.fn(() => ({ start: { line: 0 }, end: { line: 0 } })),
 }));
 
-vi.mock('@logger/logUtils', () => ({ info: vi.fn() }));
+vi.mock('@logger/logUtils', () => ({
+  info: vi.fn(),
+  createLog: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
 
 import {
   getInlineCommentProvider,

--- a/src/test-kernel/frontend/RegisterLanguageModelTools.vitest.ts
+++ b/src/test-kernel/frontend/RegisterLanguageModelTools.vitest.ts
@@ -20,7 +20,15 @@ vi.mock('vscode', () => ({
   LanguageModelToolResult,
 }));
 
-vi.mock('@logger/logUtils', () => ({ warn: vi.fn() }));
+vi.mock('@logger/logUtils', () => ({
+  warn: vi.fn(),
+  createLog: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
 
 vi.mock('@tools/registry', () => ({
   getDefaultToolRegistry: () => ({ get: mocks.getTool }),

--- a/src/test-kernel/logger/LogUtils.vitest.ts
+++ b/src/test-kernel/logger/LogUtils.vitest.ts
@@ -113,6 +113,30 @@ describe('logUtils', () => {
     expect(lines[1]).toContain('"requestId": "visible-request-id"');
   });
 
+  it('createLog binds the channel and emits through the shared sink', () => {
+    const lines = captureLines();
+
+    const log = logger.createLog('BoundChannel');
+    log.warn('bound warning');
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('WARN');
+    expect(lines[0]).toContain('[BoundChannel] bound warning');
+  });
+
+  it('createLog forwards debug data identically to the free debug fn', () => {
+    enableDebugLogging();
+    const lines = captureLines();
+
+    const log = logger.createLog('BoundChannel');
+    log.debug('with data', { data: { requestId: 'visible-request-id' } });
+
+    const output = lines.join('\n');
+    expect(lines).toHaveLength(2);
+    expect(output).toContain('[BoundChannel] with data');
+    expect(output).toContain('"requestId": "visible-request-id"');
+  });
+
   it('disposes a shared underlying sink exactly once', () => {
     const dispose = vi.fn();
     const sink = { appendLine: vi.fn(), dispose };

--- a/src/test-kernel/webview/MainViewMessageHandler.vitest.ts
+++ b/src/test-kernel/webview/MainViewMessageHandler.vitest.ts
@@ -75,6 +75,12 @@ vi.mock('@frontend/ui/instruction', () => ({
   showInstructionWithSuppress: vi.fn(),
 }));
 vi.mock('@logger/logUtils', () => ({
+  createLog: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
   debug: vi.fn(),
   error: vi.fn(),
   isDebugModeEnabled: vi.fn(() => false),

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 // Local imports
 import { currentSession } from '@agent/runtime/SessionHandle';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { ToolDefinition } from '@model/ToolDefinition';
 import { type ToolResult, ToolError } from '@shared/schemas/toolResult';
 import {
@@ -21,7 +21,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 // Local file imports
 import { defineTool, toToolParameters } from './core/define';
 
-const CHANNEL = 'DiagnosticsTool';
+const log = createLog('DiagnosticsTool');
 
 const DiagnosticsPathSchema = z
   .string()
@@ -161,8 +161,7 @@ export class DiagnosticsTool extends defineTool({
       };
     } catch (error) {
       const detail = toErrorMessage(error);
-      logger.error(
-        CHANNEL,
+      log.error(
         `Failed to collect diagnostics for ${diagnosticsPath}: ${detail}`,
       );
       throw new ToolError(`Failed to collect diagnostics: ${detail}`);
@@ -200,7 +199,7 @@ export class DiagnosticsTool extends defineTool({
       return executed(summary, summary);
     } catch (error) {
       const detail = toErrorMessage(error);
-      logger.error(CHANNEL, `Failed to add criticism: ${detail}`);
+      log.error(`Failed to add criticism: ${detail}`);
       throw new ToolError(`Failed to add criticism: ${detail}`);
     }
   }

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -34,7 +34,7 @@ import {
   getRunContextStreamId,
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { FileStat } from '@platform/interfaces';
 import { platform } from '@platform/platform';
 import {
@@ -107,7 +107,7 @@ import {
 } from './executions/waitCoordination';
 import { formatSizedEntryLines } from './executions/fileListingFormat';
 
-const CHANNEL = 'ExecutionsTool';
+const log = createLog('ExecutionsTool');
 
 // ============================================================================
 // Resource path catalog
@@ -801,8 +801,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     // display category, loudly.
     const identity = meta?.identity;
     if (meta && !identity) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Execution ${executionId} is a pre-identity row; showing config-derived category only (reader retired per #9590 Stage 7)`,
       );
     }
@@ -1045,8 +1044,7 @@ Delegated subagent and workflow results are delivered automatically as follow-up
     const meta = await store.readMeta();
     const identity = meta?.identity;
     if (meta && !identity) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Execution ${executionId} is a pre-identity row; filtering config by its config-derived category only (reader retired per #9590 Stage 7)`,
       );
     }

--- a/src/tools/ReportReviewIssueTool.ts
+++ b/src/tools/ReportReviewIssueTool.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 // Internal imports
 import { REVIEW_SEVERITIES } from '@agent/review/reviewIssues';
 import { currentSession } from '@agent/runtime/SessionHandle';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { type ToolResult, ToolError } from '@shared/schemas/toolResult';
 import { executed } from '@tools/core/result';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -13,7 +13,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { defineTool } from './core/define';
 import { normalizeStructuredOutputSchema } from './structuredOutput';
 
-const CHANNEL = 'ReportReviewIssueTool';
+const log = createLog('ReportReviewIssueTool');
 
 const ReportReviewIssueInputSchema = z.strictObject({
   file: z
@@ -86,7 +86,7 @@ export class ReportReviewIssueTool extends defineTool({
       return executed(summary, summary);
     } catch (error) {
       const detail = toErrorMessage(error);
-      logger.error(CHANNEL, `Failed to report review issue: ${detail}`);
+      log.error(`Failed to report review issue: ${detail}`);
       throw new ToolError(`Failed to report review issue: ${detail}`);
     }
   }

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -12,7 +12,7 @@ import {
   type RunContext,
 } from '@agent/runtime/RunContext';
 import { isTexFile } from '@common/files/fileTypeUtils';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import replacementEngine from '@replacement/engine';
 import { ToolResult, ToolError } from '@shared/schemas/toolResult';
 import {
@@ -43,7 +43,7 @@ import {
 } from './pathResolution';
 
 // Constants
-const CHANNEL = 'TextEditorTool';
+const log = createLog('TextEditorTool');
 const SNIPPET_LINES = 4;
 
 /** Columns a literal tab expands to when normalizing text for display and matching. */
@@ -222,13 +222,10 @@ export class TextEditorTool extends defineTool({
       case 'view':
         return this.view(filePath, displayPath, input.view_range ?? undefined);
       case 'create':
-        logger.info(CHANNEL, `create: ${displayPath}`);
+        log.info(`create: ${displayPath}`);
         return this.create(filePath, displayPath, input.file_text);
       case 'str_replace':
-        logger.info(
-          CHANNEL,
-          `str_replace: ${input.old_str} -> ${input.new_str}`,
-        );
+        log.info(`str_replace: ${input.old_str} -> ${input.new_str}`);
         return this.strReplace(
           filePath,
           displayPath,
@@ -236,10 +233,7 @@ export class TextEditorTool extends defineTool({
           input.new_str ?? '',
         );
       case 'insert':
-        logger.info(
-          CHANNEL,
-          `insert: ${input.insert_line} -> ${input.new_str}`,
-        );
+        log.info(`insert: ${input.insert_line} -> ${input.new_str}`);
         return this.insert(
           filePath,
           displayPath,
@@ -247,7 +241,7 @@ export class TextEditorTool extends defineTool({
           input.new_str,
         );
       case 'undo_edit':
-        logger.info(CHANNEL, `undo_edit: ${displayPath}`);
+        log.info(`undo_edit: ${displayPath}`);
         return this.undoEdit(filePath, displayPath);
       default:
         return assertNever(command, 'Unrecognized TextEditor command');

--- a/src/tools/comment/InlineCommentTool.ts
+++ b/src/tools/comment/InlineCommentTool.ts
@@ -6,7 +6,7 @@ import {
   getRunContextWorkingDirectory,
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { resolveWorkspaceRelativePath } from '@tools/pathResolution';
 import { executed } from '@tools/core/result';
@@ -16,7 +16,7 @@ import { formatResultCount } from '@utils/text/stringUtils';
 // Local file imports
 import { defineTool } from '../core/define';
 
-const CHANNEL = 'InlineCommentTool';
+const log = createLog('InlineCommentTool');
 
 /** A single comment within a thread, as seen by the agent. */
 interface InlineCommentView {
@@ -189,7 +189,7 @@ export class InlineCommentTool extends defineTool({
     } catch (error) {
       if (error instanceof ToolError) throw error;
       const detail = toErrorMessage(error);
-      logger.error(CHANNEL, `Failed to add inline comment: ${detail}`);
+      log.error(`Failed to add inline comment: ${detail}`);
       throw new ToolError(`Failed to add inline comment: ${detail}`);
     }
   }

--- a/src/tools/media/audio.ts
+++ b/src/tools/media/audio.ts
@@ -5,7 +5,7 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 
 import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
 import { getSdkErrorMessage } from '@common/errors/sdkError/providerErrorFormat';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { delay } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { StorageFS } from '@utils/files/storageFS';
@@ -18,7 +18,7 @@ import {
 import { checkToolInstalled } from '@utils/system/toolUtils';
 import { extendEnvPath } from '@utils/system/platformPaths';
 
-const CHANNEL = 'AudioUtils';
+const log = createLog('AudioUtils');
 
 const RECORDINGS_DIR = 'recordings';
 
@@ -63,10 +63,7 @@ export async function startRecording(): Promise<{
             'Sox is required for audio recording. Please install it first.',
         };
       }
-      logger.warn(
-        CHANNEL,
-        `Sox check failed but found at: ${soxCommand.resolvedPath}`,
-      );
+      log.warn(`Sox check failed but found at: ${soxCommand.resolvedPath}`);
     }
 
     await StorageFS.ensureDir(RECORDINGS_DIR);
@@ -89,8 +86,7 @@ export async function startRecording(): Promise<{
       absPath,
     ];
 
-    logger.info(
-      CHANNEL,
+    log.info(
       `Starting audio recording with sox: ${soxCommand?.resolvedPath ?? 'sox'} ${soxArgs.join(' ')}`,
     );
 
@@ -114,30 +110,27 @@ export async function startRecording(): Promise<{
         const intentional =
           result.signal === 'SIGTERM' || result.signal === 'SIGKILL';
         if (intentional) {
-          logger.info(CHANNEL, 'Recording stopped intentionally');
+          log.info('Recording stopped intentionally');
         } else if (result.exitCode !== 0) {
-          logger.error(
-            CHANNEL,
-            `Sox process exited with code ${result.exitCode}`,
-          );
+          log.error(`Sox process exited with code ${result.exitCode}`);
         } else {
-          logger.info(CHANNEL, 'Recording process completed successfully');
+          log.info('Recording process completed successfully');
         }
         resetRecordingState();
       })
       .catch((error) => {
-        logger.error(CHANNEL, `Sox process error: ${error.message}`);
+        log.error(`Sox process error: ${error.message}`);
         resetRecordingState();
       });
 
     subprocess.stderr?.on('data', (data: Buffer) => {
-      logger.debug(CHANNEL, `Sox stderr: ${data.toString()}`);
+      log.debug(`Sox stderr: ${data.toString()}`);
     });
 
     return { success: true, recordingPath: absPath };
   } catch (err) {
     const message = getSdkErrorMessage(err);
-    logger.error(CHANNEL, `Error in startRecording: ${message}`);
+    log.error(`Error in startRecording: ${message}`);
     resetRecordingState();
     return { success: false, error: message };
   }
@@ -191,7 +184,7 @@ export async function stopRecordingAndTranscribe(): Promise<{
     return { success: true, text: result.text };
   } catch (err) {
     const message = getSdkErrorMessage(err);
-    logger.error(CHANNEL, `Error in stopRecordingAndTranscribe: ${message}`);
+    log.error(`Error in stopRecordingAndTranscribe: ${message}`);
     resetRecordingState();
     return { success: false, text: '', error: message };
   }

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -22,7 +22,7 @@ import { z } from 'zod';
 import pTimeout from 'p-timeout';
 
 // Local imports
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { waitForRateLimit } from '@tools/citation/rateLimiter';
 import { CROSSREF_CONSTANTS, CrossrefClient } from '@tools/citation/constants';
@@ -39,7 +39,7 @@ import {
   type ConnectorResult,
 } from './bbtClient';
 
-const CHANNEL = 'ZoteroAddTool';
+const log = createLog('ZoteroAddTool');
 const CROSSREF_RESOLVE_TIMEOUT_MS = 15_000; // 15 s
 
 /**
@@ -259,10 +259,7 @@ async function resolveDOI(doi: string): Promise<ZoteroConnectorItem | null> {
   } catch (err) {
     // The caller still falls back to the user's own metadata; log so a
     // silently degraded entry is traceable to the Crossref failure.
-    logger.warn(
-      CHANNEL,
-      `Crossref lookup failed for DOI ${doi}: ${toErrorMessage(err)}`,
-    );
+    log.warn(`Crossref lookup failed for DOI ${doi}: ${toErrorMessage(err)}`);
     return null;
   }
 }

--- a/src/transcript/StagedDeletionCoordinator.ts
+++ b/src/transcript/StagedDeletionCoordinator.ts
@@ -30,7 +30,7 @@ import pMap from 'p-map';
 
 // Local imports - shared infrastructure
 import { isFileNotFoundError } from '@common/errors';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import { StorageFS } from '@utils/files/storageFS';
 import { isDirectory } from '@utils/files/fsEntryType';
@@ -46,7 +46,7 @@ import {
 } from './streamDataPaths';
 
 /** Logged under the store's channel: this is one of its internals. */
-const CHANNEL = 'StreamSnapshotStore';
+const log = createLog('StreamSnapshotStore');
 
 /** Bounded fan-out for reconciling many streams' staged directories, so a
  *  crash-recovery sweep does not open a file handle per stream. */
@@ -160,8 +160,7 @@ export class StagedDeletionCoordinator {
           }
         })
         .catch((err: unknown) =>
-          logger.warn(
-            CHANNEL,
+          log.warn(
             `Failed to persist ${key}.json for stream ${stream}; sidecar remains buffered.`,
             { data: err },
           ),
@@ -248,11 +247,9 @@ export class StagedDeletionCoordinator {
           decodeStreamId(encoded),
         );
         if (!parsedStream.success) {
-          logger.warn(
-            CHANNEL,
-            `Ignoring invalid staged snapshot directory ${encoded}`,
-            { data: parsedStream.error },
-          );
+          log.warn(`Ignoring invalid staged snapshot directory ${encoded}`, {
+            data: parsedStream.error,
+          });
           return;
         }
         const stream = parsedStream.data;
@@ -529,8 +526,7 @@ export class StagedDeletionCoordinator {
               try {
                 await StorageFS.delete(stagedDir, { recursive: true });
               } catch (error) {
-                logger.warn(
-                  CHANNEL,
+                log.warn(
                   `Stream ${stream} was deleted, but staged snapshot cleanup was incomplete.`,
                   { data: error },
                 );

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -26,7 +26,7 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { isFileNotFoundError } from '@common/errors';
 import { KVStore } from '@common/storage/KVStore';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import {
   CompileFailureSchema,
   cloneRoundIndexed,
@@ -82,7 +82,7 @@ import {
   type StreamData,
 } from './streamSnapshotRead';
 
-const CHANNEL = 'StreamSnapshotStore';
+const log = createLog('StreamSnapshotStore');
 
 /** Bounded fan-out for seeding many streams' sidecars, so startup does not
  *  open a file handle per tab. */
@@ -127,7 +127,9 @@ function isSnapshotRunFact(event: AgentEvent): event is SnapshotRunFact {
 
 type OutputFilesPatch = Map<number, OutputFileInfo[] | null>;
 type UsageUpdateResult =
-  TokenUsageStats | undefined | Promise<TokenUsageStats | undefined>;
+  | TokenUsageStats
+  | undefined
+  | Promise<TokenUsageStats | undefined>;
 interface HydratedRunState {
   config?: AgentConfig;
   identity?: RunIdentity;
@@ -587,7 +589,7 @@ export class StreamSnapshotStore {
         if (record?.diskState === 'unknown' && record.seedChain === next) {
           record.seedChain = undefined;
         }
-        logger.warn(CHANNEL, `Deferred update failed for stream ${stream}`, {
+        log.warn(`Deferred update failed for stream ${stream}`, {
           data: err,
         });
       });
@@ -631,8 +633,7 @@ export class StreamSnapshotStore {
       // The probe only ever shortcuts the read; a failed listing must not
       // fail the seed and must NEVER claim absence. Fall back to the full
       // read, whose own fallback policy governs unreadable storage.
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Sidecar existence probe failed for stream ${stream}; falling back to a full read.`,
         { data: error },
       );
@@ -874,8 +875,7 @@ export class StreamSnapshotStore {
   ): UsageUpdateResult {
     const parsed = TokenUsageStatsParsingBaseSchema.safeParse(usage);
     if (!parsed.success) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Discarding malformed usage delta for run ${storageKey} on stream ` +
           `${stream} instead of silently zeroing accumulated cost.`,
         {
@@ -1050,8 +1050,7 @@ export class StreamSnapshotStore {
         try {
           children = await this.detachPersistedChildren(stream);
         } catch (error) {
-          logger.warn(
-            CHANNEL,
+          log.warn(
             `Stream ${stream} was deleted, but child parent-edge cleanup was incomplete.`,
             { data: error },
           );
@@ -1059,8 +1058,7 @@ export class StreamSnapshotStore {
         try {
           await onCommitted?.(children);
         } catch (error) {
-          logger.warn(
-            CHANNEL,
+          log.warn(
             `Stream ${stream} was deleted, but child-detachment projection was incomplete.`,
             { data: error },
           );
@@ -1068,8 +1066,7 @@ export class StreamSnapshotStore {
         try {
           await this.flush();
         } catch (error) {
-          logger.warn(
-            CHANNEL,
+          log.warn(
             `Stream ${stream} was deleted, but child parent-edge persistence was incomplete.`,
             { data: error },
           );
@@ -1334,8 +1331,7 @@ export class StreamSnapshotStore {
         // An unreadable sidecar proves nothing about this stream's parent;
         // treat it as unrelated so one bad file cannot block the detach
         // sweep for every other child.
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Skipping unreadable sidecar meta for stream ${stream} during child detach.`,
           { data: error },
         );
@@ -1391,8 +1387,7 @@ export class StreamSnapshotStore {
     const write = { stream, key, value } satisfies DirtySidecarWrite;
     this.dirtyWrites.set(chainKey, write);
     void this.persistDirtyWrite(chainKey, write).catch((err: unknown) =>
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Failed to persist ${key}.json for stream ${stream}; sidecar remains dirty.`,
         { data: err },
       ),
@@ -1725,19 +1720,16 @@ export class StreamSnapshotStore {
         userFollowUpSupport = execMeta?.userFollowUpSupport;
         if (execMeta && !identity && !this.preIdentityWarned.has(stream)) {
           this.preIdentityWarned.add(stream);
-          logger.warn(
-            CHANNEL,
+          log.warn(
             `Stream ${stream} maps to pre-identity execution row ${executionId}; hydrating without a run identity (reader retired per #9590 Stage 7)`,
           );
         }
         description = execMeta?.description;
         config = execConfig;
       } catch (error) {
-        logger.warn(
-          CHANNEL,
-          `Could not read execution record for stream ${stream}.`,
-          { data: { stream, executionId, error } },
-        );
+        log.warn(`Could not read execution record for stream ${stream}.`, {
+          data: { stream, executionId, error },
+        });
       }
       if (config) {
         return { config, identity, userFollowUpSupport, description };

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -127,9 +127,7 @@ function isSnapshotRunFact(event: AgentEvent): event is SnapshotRunFact {
 
 type OutputFilesPatch = Map<number, OutputFileInfo[] | null>;
 type UsageUpdateResult =
-  | TokenUsageStats
-  | undefined
-  | Promise<TokenUsageStats | undefined>;
+  TokenUsageStats | undefined | Promise<TokenUsageStats | undefined>;
 interface HydratedRunState {
   config?: AgentConfig;
   identity?: RunIdentity;

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -10,7 +10,7 @@
 import { z } from 'zod';
 
 import { KVStore } from '@common/storage/KVStore';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import {
   CompileFailureSchema,
   OutputFileInfoSchema,
@@ -34,7 +34,7 @@ import { isObject, mapToRecord } from '@utils/core';
 
 import { STREAM_DATA_KEYS } from './streamDataPaths';
 
-const CHANNEL = 'StreamSnapshotStore';
+const log = createLog('StreamSnapshotStore');
 
 /** The canonical empty work plan (no todos, no plan). Single source for the
  *  "no durable plan yet" value, reused by the store's in-memory default. */
@@ -90,11 +90,9 @@ async function tryRead(kv: KVStore, key: string): Promise<unknown | undefined> {
     return await kv.read(key);
   } catch (error) {
     if (error instanceof SyntaxError) {
-      logger.warn(
-        CHANNEL,
-        `Discarding unreadable ${key}.json; treating as missing.`,
-        { data: error },
-      );
+      log.warn(`Discarding unreadable ${key}.json; treating as missing.`, {
+        data: error,
+      });
       return undefined;
     }
     throw error;
@@ -115,8 +113,7 @@ export async function readMeta(
     const { executionId: _executionId, ...rest } = raw;
     const retried = StreamTabMetaSchema.safeParse(rest);
     if (retried.success) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         'Dropping malformed execution FK from persisted stream metadata; ' +
           'keeping the remaining fields.',
         { data: parsed.error },
@@ -124,7 +121,7 @@ export async function readMeta(
       return retried.data;
     }
   }
-  logger.warn(CHANNEL, 'Discarding unreadable persisted stream metadata.', {
+  log.warn('Discarding unreadable persisted stream metadata.', {
     data: parsed.error,
   });
   return undefined;
@@ -150,11 +147,9 @@ function readPersistedWorkPlan(raw: unknown): WorkPlanSnapshot {
   if (version > STREAM_SNAPSHOT_SCHEMA_VERSION) return EMPTY_WORK_PLAN;
   const result = PersistedWorkPlanSchema.safeParse(raw);
   if (!result.success) {
-    logger.warn(
-      CHANNEL,
-      'Discarding unreadable persisted work plan; using empty.',
-      { data: result.error },
-    );
+    log.warn('Discarding unreadable persisted work plan; using empty.', {
+      data: result.error,
+    });
     return EMPTY_WORK_PLAN;
   }
   return result.data;
@@ -219,8 +214,7 @@ export function assembleSnapshot(
     // Defense-in-depth for the unwrapped CLI resume path (`await store.read`):
     // an unexpected on-disk shape degrades to an empty-but-valid snapshot,
     // logged so it stays diagnosable, rather than aborting hydration.
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Could not assemble snapshot for stream ${streamId}; using empty.`,
       { data: error },
     );

--- a/src/utils/config/configUtils.ts
+++ b/src/utils/config/configUtils.ts
@@ -1,5 +1,5 @@
 // Local imports
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { tryPlatform } from '@platform/platform';
 import type { ConfigTarget, Disposable } from '@platform/interfaces';
 import { ensureArray } from '@utils/core';
@@ -8,7 +8,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 // Third-party imports
 import type { ZodType } from 'zod';
 
-const CHANNEL = 'configUtils';
+const log = createLog('configUtils');
 
 interface UpdateConfigOptions {
   target?: ConfigTarget;
@@ -67,8 +67,7 @@ export function getValidatedConfig<T>(
   // Warn only when the user explicitly set the value (global, workspace, or
   // workspace folder); an unset setting failing the schema is normal.
   if (configProvider()?.isExplicitlySet(path)) {
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Ignoring invalid value for setting "${path}": ${toErrorMessage(result.error)}`,
     );
   }

--- a/src/utils/files/rulesUtils.ts
+++ b/src/utils/files/rulesUtils.ts
@@ -1,13 +1,13 @@
 import * as path from 'node:path';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { safeHomedir } from '@utils/system/platformPaths';
 
 import { AbsoluteFS } from './absoluteFS';
 import { WorkspaceFS } from './workspaceFS';
 
-const CHANNEL = 'rulesUtils';
+const log = createLog('rulesUtils');
 
 const RULES_FILE = '.texrarules';
 
@@ -22,7 +22,7 @@ export async function loadTexraRules(): Promise<string> {
     if (workspacePath && (await WorkspaceFS.exists(RULES_FILE))) {
       const trimmed = (await WorkspaceFS.read(RULES_FILE)).trim();
       if (trimmed) {
-        logger.debug(CHANNEL, `Loaded workspace ${RULES_FILE}`);
+        log.debug(`Loaded workspace ${RULES_FILE}`);
         return trimmed;
       }
     }
@@ -33,16 +33,13 @@ export async function loadTexraRules(): Promise<string> {
       if (await AbsoluteFS.exists(homeFile)) {
         const trimmed = (await AbsoluteFS.read(homeFile)).trim();
         if (trimmed) {
-          logger.debug(CHANNEL, `Loaded home ${RULES_FILE}`);
+          log.debug(`Loaded home ${RULES_FILE}`);
           return trimmed;
         }
       }
     }
   } catch (err) {
-    logger.warn(
-      CHANNEL,
-      `Failed to load ${RULES_FILE}: ${toErrorMessage(err)}`,
-    );
+    log.warn(`Failed to load ${RULES_FILE}: ${toErrorMessage(err)}`);
   }
   return '';
 }

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -2,11 +2,11 @@ import * as path from 'node:path';
 
 import nunjucks from 'nunjucks';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { filterNotNull } from '@utils/core';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 
-const CHANNEL = 'promptUtils';
+const log = createLog('promptUtils');
 
 export interface XmlFormatFromFilesResult {
   readonly xml: string | null;
@@ -66,8 +66,7 @@ export async function getXmlFormatFromReadableFiles(
           xml: `<document name="${getPromptFileName(file)}">\n${content}\n</document>`,
         };
       } catch (err) {
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Skipping unreadable file in prompt context: ${file} (${String(err)})`,
         );
         return null;

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -9,7 +9,7 @@ import { LRUCache } from 'lru-cache';
 import which from 'which';
 
 // Local imports - log
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { normalizeFilePath, unique } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { hasExtension } from '@utils/core/pathCore';
@@ -20,7 +20,7 @@ export const IS_WINDOWS = process.platform === 'win32';
 // Common LaTeX tool names used across the system
 const TEX_TOOLS = ['latexdiff', 'latexindent', 'latexmk'] as const;
 
-const CHANNEL = 'platformPaths';
+const log = createLog('platformPaths');
 
 // Cache for extra directories to avoid repeated glob operations
 let cachedExtraDirs: string[] | null = null;
@@ -296,7 +296,7 @@ export function findToolInCommonPaths(tool: string): string | null {
 function findToolInCommonPathsUncached(tool: string): string | null {
   // Basic security validation
   if (!isPathSafe(tool)) {
-    logger.warn(CHANNEL, `Unsafe tool name rejected: ${tool}`);
+    log.warn(`Unsafe tool name rejected: ${tool}`);
     return null;
   }
   const candidates = [tool];

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -6,7 +6,7 @@ import { execa } from 'execa';
 import { parse as shellParse } from 'shell-quote';
 
 // Local imports
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import type { ExecResult } from '@shared/schemas/opResults';
 import {
@@ -31,7 +31,7 @@ import { IS_WINDOWS, extendEnvPath } from './platformPaths';
 import { BinaryResolver } from './binaryResolver';
 import { executeCommand, executeCommandSync } from './execUtils';
 
-const CHANNEL = 'toolUtils';
+const log = createLog('toolUtils');
 
 interface ToolConfig {
   command?: string | string[]; // Optional - defaults to "${toolName} --version"
@@ -46,10 +46,7 @@ async function reportMissingTool(
   try {
     await platform().toolMissingHandler?.(message, openDocsCommand);
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Failed to report missing tool: ${toErrorMessage(err)}`,
-    );
+    log.error(`Failed to report missing tool: ${toErrorMessage(err)}`);
   }
 }
 
@@ -161,8 +158,7 @@ async function tryExeca(
   try {
     return await execa(cmd, args, { env, reject: false, timeout: 5000 });
   } catch (execErr) {
-    logger.info(
-      CHANNEL,
+    log.info(
       `Exception executing ${label}'${cmd}': ${toErrorMessage(execErr)}`,
     );
     return null;
@@ -198,15 +194,11 @@ async function executeWithFallback(
   args: string[],
   execEnv: NodeJS.ProcessEnv,
 ): Promise<boolean> {
-  logger.debug(
-    CHANNEL,
-    `Checking tool '${cmd}' with args [${args.join(', ')}]`,
-  );
+  log.debug(`Checking tool '${cmd}' with args [${args.join(', ')}]`);
 
   let result = await tryExeca(cmd, args, '', execEnv);
   if (!result) return false;
-  logger.debug(
-    CHANNEL,
+  log.debug(
     `Initial check for '${cmd}': exitCode=${result.exitCode}, ` +
       `stdout=${result.stdout?.slice(0, 100) || '(empty)'}, ` +
       `stderr=${result.stderr?.slice(0, 100) || '(empty)'}`,
@@ -215,19 +207,17 @@ async function executeWithFallback(
   // Accept if exit code is 0, OR if we got version-like output
   // (some tools return non-zero for --version but still output version info)
   if (result.exitCode === 0 || hasVersionOutput(result)) {
-    logger.debug(CHANNEL, `Tool '${cmd}' detected successfully`);
+    log.debug(`Tool '${cmd}' detected successfully`);
     return true;
   }
 
   const fallback = BinaryResolver.resolveOptionalCommand(cmd, args);
-  logger.debug(
-    CHANNEL,
+  log.debug(
     `Fallback search for '${cmd}': ${fallback?.resolvedPath ?? 'not found'}`,
   );
 
   if (fallback) {
-    logger.debug(
-      CHANNEL,
+    log.debug(
       `Running fallback '${fallback.command}' with args [${fallback.args.join(', ')}]`,
     );
     result = await tryExeca(
@@ -237,8 +227,7 @@ async function executeWithFallback(
       execEnv,
     );
     if (!result) return false;
-    logger.debug(
-      CHANNEL,
+    log.debug(
       `Fallback result: exitCode=${result.exitCode}, ` +
         `stdout=${result.stdout?.slice(0, 100) || '(empty)'}, ` +
         `stderr=${result.stderr?.slice(0, 100) || '(empty)'}`,
@@ -250,8 +239,7 @@ async function executeWithFallback(
   }
 
   // Log at info level so it shows in output channel by default
-  logger.info(
-    CHANNEL,
+  log.info(
     `Tool '${cmd}' not detected. Last result: exitCode=${result.exitCode}, ` +
       `stdout=${result.stdout?.slice(0, 200) || '(empty)'}, ` +
       `stderr=${result.stderr?.slice(0, 200) || '(empty)'}`,
@@ -298,8 +286,7 @@ export async function checkToolInstalled(
     const execEnv = { ...process.env, PATH: extendedPath };
 
     // Log PATH info once (not per-command)
-    logger.debug(
-      CHANNEL,
+    log.debug(
       `PATH contains ${extendedPath.split(path.delimiter).length} entries, ` +
         `includes /usr/bin: ${extendedPath.includes('/usr/bin')}`,
     );
@@ -335,8 +322,7 @@ export async function checkToolInstalled(
   } catch (err) {
     // The user-facing message is always the tool's own install guidance, so
     // log the underlying cause instead of dropping it.
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Tool check for '${toolName ?? 'custom config'}' failed: ${toErrorMessage(err)}`,
     );
     if (showError) {
@@ -450,10 +436,7 @@ export async function checkCoreDependencies(
   } catch (error) {
     // If checking fails, assume all tools are missing to prompt user to check
     // This is safer than silently ignoring the error
-    logger.error(
-      CHANNEL,
-      `Failed to check core dependencies: ${toErrorMessage(error)}`,
-    );
+    log.error(`Failed to check core dependencies: ${toErrorMessage(error)}`);
     return ['latexindent', 'perl', 'gs', 'gm/magick'];
   }
 }
@@ -485,7 +468,7 @@ export function detectPackageManager(): SystemPackageManager | null {
     if (hasPackageManager(name)) return name;
   }
 
-  logger.debug(CHANNEL, 'No package manager detected');
+  log.debug('No package manager detected');
   return null;
 }
 
@@ -506,8 +489,7 @@ export function hasPackageManager(name: SystemPackageManager): boolean {
 
   const available = executeCommandSync([name, '--version']).success;
   packageManagerAvailability.set(name, available);
-  logger.debug(
-    CHANNEL,
+  log.debug(
     available
       ? `Package manager detected: ${name}`
       : `Package manager not found: ${name}`,

--- a/src/utils/text/xmlConversion.ts
+++ b/src/utils/text/xmlConversion.ts
@@ -9,7 +9,7 @@ import { gfm } from 'turndown-plugin-gfm';
 import { execa } from 'execa';
 
 // Local imports - common
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local imports - utils
@@ -39,7 +39,7 @@ function detectInputFormat(text: string): OutputFormat {
   return OutputFormat.MARKDOWN;
 }
 
-const CHANNEL = 'xmlConversion';
+const log = createLog('xmlConversion');
 
 /**
  * Cached pandoc availability check.
@@ -162,7 +162,7 @@ async function convertWithPandoc(text: string): Promise<string | null> {
     });
     return normalizePandocReferences(stdout);
   } catch (err) {
-    logger.error(CHANNEL, `Pandoc conversion failed: ${toErrorMessage(err)}`);
+    log.error(`Pandoc conversion failed: ${toErrorMessage(err)}`);
     return null;
   }
 }

--- a/src/utils/text/xmlExtraction.ts
+++ b/src/utils/text/xmlExtraction.ts
@@ -8,7 +8,7 @@
  */
 
 // Local imports - utils
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { OUTPUT_DOCUMENT_TAG } from '@shared/schemas/output';
 import { isObject } from '@utils/core';
 
@@ -16,7 +16,7 @@ import { isObject } from '@utils/core';
 import { removeCDATA } from './xmlCdata';
 import { formatContent } from './xmlConversion';
 
-const CHANNEL = 'xmlExtraction';
+const log = createLog('xmlExtraction');
 
 /**
  * Opening `<document … name="…">` tag fragment; group 1 is the name attribute
@@ -127,10 +127,7 @@ export function extractContentFromXMLbyTagMultiple(
   containerTag: string,
 ): Array<{ content: string; name: string }> | null {
   if (!isObject(root)) {
-    logger.error(
-      CHANNEL,
-      `Invalid root object. Structure: ${getObjectStructure(root)}`,
-    );
+    log.error(`Invalid root object. Structure: ${getObjectStructure(root)}`);
     return null;
   }
 
@@ -150,15 +147,13 @@ export function extractContentFromXMLbyTagMultiple(
           };
         });
       }
-      logger.error(
-        CHANNEL,
+      log.error(
         `Document property is not an array in multiple document case. Structure: ${getObjectStructure(container)}`,
       );
     }
   }
 
-  logger.error(
-    CHANNEL,
+  log.error(
     `No ${containerTag} or document elements found in output file. Structure: ${getObjectStructure(root)}`,
   );
   return null;


### PR DESCRIPTION
## Summary

A tech-debt audit flagged the single highest-frequency ad-hoc pattern in the tree: ~99 modules each declared `const CHANNEL = '...'` and threaded it as the first argument through every `logger.warn/error/info/debug(CHANNEL, …)` call — ~144 single-line plus hundreds of multi-line call sites. The channel string was copy-pasted per file (and at least one module historically carried the *wrong* channel, invisible at the call site).

This PR adds a channel-bound logger factory and migrates the clean subset:

- **`createLog(channel)`** in `@logger/logUtils` returns a `Log` with the four level methods bound to one channel. It emits through the **same `writeLine` sink** as the free `debug/info/warn/error` functions, so the output line, secret redaction, and debug-data handling are byte-for-byte unchanged — this is a behavior-preserving transform.
- Call sites become `const log = createLog('X'); log.warn(msg)` — the channel is named once instead of on every call.

## Issue acceptance gates

n/a — no tracked issue; this is a proactive tech-debt refactor from a codebase audit.

## Single source of truth

`createLog` (in `@logger/logUtils`) is the one place that binds a channel to the level writers. A module now names its channel exactly once at the `createLog('X')` call instead of repeating the constant on each log invocation.

## Duplication and abstraction budget

Removes the `const CHANNEL` declaration + repeated `CHANNEL,` first-argument from 57 modules. The new abstraction (`createLog`) owns one invariant: *a channel is named once and bound to the four level writers*; it adds no pass-through layer — it's a thin binding over the existing `writeLine` sink, parallel to the existing `createChannelWriter`.

Scope was deliberately bounded to files where `CHANNEL` was used **only** in `logger.LEVEL(CHANNEL, …)` calls (verified by codemod post-check: no dangling `logger.`/`CHANNEL` tokens remain). Files that pass the channel or the logger namespace as a *value* — the LaTeX cluster's shared `LATEX_COMMANDS_CHANNEL`, `SupabaseAuthProvider`'s `log: logger` — are left untouched.

## Net elements (R6)

- **Files:** 59 changed (57 migrated modules + `logUtils.ts` + `LogUtils.vitest.ts`).
- **Exported symbols:** +2 (`export function createLog`, `export interface Log`); 0 removed. Both have same-PR consumers (57 modules + tests), satisfying the exports-are-contracts ratchet.
- **Classes/interfaces/enums:** +1 interface (`Log`).
- **Net LoC:** **−96** (391 insertions, 487 deletions) — and that is *after* adding the ~35-line factory and ~24-line test, so call-site reduction is ~150+ lines.

## Consumer counts (R8)

No emit path or export was deleted or re-routed. `createLog` is a new export with 57 production consumers in this PR (+ 2 unit tests). The free `debug/info/warn/error` functions are unchanged and retain their remaining callers (78 modules still use the namespace import, the intended follow-up surface).

## Host impact

Extension: Migrated modules under `packages/extension/src/frontend/**`, `common/**`, `commands/**`. Behavior identical.

Desktop: No files under `packages/desktop` changed directly; shared-core modules it consumes (`src/**`) are behavior-identical.

CLI: `packages/cli/src/chat/tui/panes/transcriptViewport.ts` migrated. Behavior identical.

## Scheduled refactoring

Follow-up (not in this PR): 78 modules still use `import * as logger` — mostly files that pass the channel as a value (helper-threaded channels, `channel:` object fields). These need per-file judgment rather than a mechanical codemod. The audit also surfaced larger, higher-effort targets (parallel server-chain logic in the OpenAI/Google model handlers; the `StreamSnapshotStore` round-accumulator descriptor table; CLI resume/retry duplication) tracked separately.

## Validation

- `npm run typecheck` — green across all 6 workspaces (workspace, test-kernel, agent, cli, trace-viewer, desktop).
- `eslint` on all changed files — clean.
- `npm run check:dead-code-ratchet` — OK, no new unused files/exports.
- Logger unit tests — 15 passing, including 2 new cases asserting `createLog` binds the channel and forwards debug data identically to the free `debug` fn.
- Full `vitest run` suite was executing locally at push time (slow, output-buffered); CI is the authoritative full-suite gate.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GB4BmgUZVtvUM5TokGpvZd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving logging refactor: same sink, redaction, and output format. Risk is mostly mechanical migration breadth and test-mock updates.
> 
> **Overview**
> Adds **`createLog(channel)`** in `@logger/logUtils`, returning a channel-bound `log.debug/info/warn/error` API so modules name the channel once instead of threading `CHANNEL` through every call.
> 
> Migrates ~57 production modules across agent, extension, CLI, tools, transcript, and utils from `logger.warn(CHANNEL, …)` to `const log = createLog('…'); log.warn(…)`. Output still goes through the existing free-function writers (via a per-call namespace lookup so spies keep working), so formatting and redaction stay the same.
> 
> Also updates logger unit tests and a few vitest mocks to cover/export `createLog`. Files that pass the logger or channel as a value are intentionally left for a follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19993814e324820a9cef101afc3f498721490512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->