### PR TITLE
refactor: tighten desktop IPC, ExecutionsTool schema, and OpenRouter message casts

### DIFF
--- a/packages/desktop/src/main/desktopFileSelection.ts
+++ b/packages/desktop/src/main/desktopFileSelection.ts
@@ -13,12 +13,25 @@ import { listWorkspaceFiles } from '@common/files/workspaceFileListing';
 import { platform } from '@platform/platform';
 import { relativeToRoot } from '@platform/defaults/nodeWorkspace';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  MainViewInboundMessageSchema,
+  type MainViewInboundMessage,
+} from '@shared/schemas';
 import { normalizeFilePath } from '@utils/core';
 
 import type {
   DesktopCommandMessage,
   DesktopMessageHandler,
 } from './desktopIpcTypes.js';
+
+type MessageFor<C extends MainViewInboundMessage['command']> = Extract<
+  MainViewInboundMessage,
+  { command: C }
+>;
+
+type SelectMultipleFilesMessage = MessageFor<
+  typeof MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES
+>;
 
 interface DesktopFileSelectionDialogOptions {
   title: string;
@@ -168,22 +181,19 @@ export function createDesktopFileSelection(
   }
 
   function isDesktopMultiFileType(
-    value: unknown,
+    value: string,
   ): value is DesktopMultiFileType {
-    return (
-      typeof value === 'string' &&
-      Object.hasOwn(MULTI_SET_COMMAND_BY_FILE_TYPE, value)
-    );
+    return Object.hasOwn(MULTI_SET_COMMAND_BY_FILE_TYPE, value);
   }
 
-  async function selectMultipleFiles(message: DesktopCommandMessage) {
+  async function selectMultipleFiles(message: SelectMultipleFilesMessage) {
     if (!options.showOpenFileDialog) return;
     if (!isDesktopMultiFileType(message.fileType)) {
       // The shared webview posts this for 'output' too, which the desktop has
       // no picker for. Say so rather than dropping it: handleMessage already
       // reported the message as handled.
       createChannelTrace('DesktopFileSelection').warn(
-        `Unsupported multiple file selection: ${String(message.fileType)}`,
+        `Unsupported multiple file selection: ${message.fileType}`,
       );
       return;
     }
@@ -192,8 +202,7 @@ export function createDesktopFileSelection(
 
     const fileType = message.fileType;
     const listConfig = getFileListConfig(fileType, loadFileListSettings());
-    const currentFile =
-      typeof message.currentFile === 'string' ? message.currentFile : undefined;
+    const currentFile = message.currentFile;
     const defaultPath =
       currentFile != null
         ? resolveWorkspaceFile(workspacePath, currentFile)
@@ -223,7 +232,7 @@ export function createDesktopFileSelection(
     });
   }
 
-  function handleMessage(message: DesktopCommandMessage): boolean {
+  function dispatch(message: MainViewInboundMessage): boolean {
     switch (message.command) {
       case MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES:
         runAsync(selectMultipleFiles(message));
@@ -235,15 +244,20 @@ export function createDesktopFileSelection(
         runAsync(refreshDiskBackedDropdowns());
         return true;
       case MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE:
-        runAsync(
-          updateEditedFiles(
-            typeof message.baseFile === 'string' ? message.baseFile : undefined,
-          ),
-        );
+        runAsync(updateEditedFiles(message.baseFile));
         return true;
       default:
         return false;
     }
+  }
+
+  // Single discriminated-union parse at the entry point, matching every
+  // other desktop IPC adapter (see desktopShellIpc.ts) — the switch above
+  // then operates on the narrowed variant with no per-case guessing at field
+  // types or presence.
+  function handleMessage(message: DesktopCommandMessage): boolean {
+    const parsed = MainViewInboundMessageSchema.safeParse(message);
+    return parsed.success ? dispatch(parsed.data) : false;
   }
 
   return { handleMessage };

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -73,10 +73,8 @@ import type {
   ChatStreamChunk,
   ChatUsage,
   ChatMessages,
-  ChatAssistantMessage,
   ChatToolCall,
   ChatContentItems,
-  ChatContentText,
   ChatRequest,
 } from '@openrouter/sdk/models';
 
@@ -462,7 +460,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   }
 
   createAssistantMessage(text: string): ChatMessages {
-    return { role: 'assistant', content: text } as ChatMessages;
+    return { role: 'assistant', content: text };
   }
 
   extractAssistantText(message: ChatMessages): string | undefined {
@@ -489,7 +487,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
               url: toDataUrl(media.media_type, media.data),
               detail: 'high',
             },
-          } as ChatContentItems,
+          },
         ];
       }
 
@@ -508,7 +506,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
               data: media.data,
               format: extractMimeSubtype(media.media_type).toLowerCase(),
             },
-          } as ChatContentItems,
+          },
         ];
       }
 
@@ -541,7 +539,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       newResponse = this.normalizeResponseText(msg.content);
     } else if (Array.isArray(msg.content)) {
       newResponse = this.normalizeResponseText(
-        (msg.content as ChatContentItems[])
+        msg.content
           .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
           .map((p) => p.text)
           .join(''),
@@ -601,7 +599,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     if (!message) return null;
 
     // Try reasoningDetails first (OpenRouter normalized format)
-    const reasoningDetails = (message as ChatAssistantMessage).reasoningDetails;
+    const reasoningDetails = message.reasoningDetails;
     if (reasoningDetails) {
       const extracted = extractTextFromReasoningDetails(reasoningDetails);
       if (extracted) {
@@ -611,7 +609,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     }
 
     // Fall back to reasoning string
-    const reasoning = (message as ChatAssistantMessage).reasoning;
+    const reasoning = message.reasoning;
     if (isNonEmptyString(reasoning)) {
       this.setThinkingState(reasoning, workspaceState);
       return reasoning;
@@ -683,19 +681,18 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       role: 'assistant',
       toolCalls: entries.map(({ call }) => call.raw),
       ...(text ? { content: text } : {}),
-    } as ChatMessages;
+    };
 
     const resultMsgs: ChatMessages[] = entries.map(
-      ({ call, result, attachments }) =>
-        ({
-          role: 'tool',
-          toolCallId: call.callId,
-          content: formatToolResultTextWithAttachments(
-            result,
-            attachments,
-            this.canProcessToolResultAttachments,
-          ),
-        }) as ChatMessages,
+      ({ call, result, attachments }) => ({
+        role: 'tool',
+        toolCallId: call.callId,
+        content: formatToolResultTextWithAttachments(
+          result,
+          attachments,
+          this.canProcessToolResultAttachments,
+        ),
+      }),
     );
 
     return [callMsg, ...resultMsgs];
@@ -738,17 +735,17 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     }
 
     const targetMessage = messages.at(targetIndex);
-    if (targetMessage?.role !== 'assistant') return false;
+    if (!targetMessage || targetMessage.role !== 'assistant') return false;
 
-    const message = targetMessage as ChatAssistantMessage;
+    const message = targetMessage;
     if (Array.isArray(message.content)) {
       if (this.isAnthropicViaOpenRouter && !options.afterContinuationPrompt) {
-        const lastPart = (message.content as ChatContentItems[]).at(-1);
+        const lastPart = message.content.at(-1);
         if (lastPart && 'text' in lastPart) {
-          (lastPart as ChatContentText).text = text;
+          lastPart.text = text;
         }
       } else {
-        (message.content as ChatContentItems[]).push({ type: 'text', text });
+        message.content.push({ type: 'text', text });
       }
     } else {
       message.content = [

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -449,19 +449,28 @@ const PathFieldSchema = z.string().describe('Path starting with /executions');
 
 const ViewActionSchema = z.strictObject({
   path: PathFieldSchema,
-  // nullish + normalized (not a bare literal, unlike the other branches):
-  // 'view' is the common no-op-preamble call, so omitting `action` — or, per
-  // AGENTS.md's tool-input-schema rule, sending it as `null` (OpenAI-
-  // compatible structured-output providers represent an omitted optional
-  // field that way) — must both dispatch to this branch and keep `action`
-  // out of the JSON-schema `required` list, matching the pre-refactor
-  // `.prefault('view')`. z.discriminatedUnion matches a missing/null
-  // discriminator against a branch whose discriminator schema itself accepts
-  // it, so no top-level preprocess is needed.
+  // Optional + defaulted, NOT .nullish() (unlike every other nullish field in
+  // this file): 'view' is the common no-op-preamble call, so omitting
+  // `action` must both dispatch to this branch and keep `action` out of the
+  // JSON-schema `required` list, matching the pre-refactor `.prefault('view')`
+  // and AGENTS.md's "design for the model's first call" rule.
+  // `.optional().default('view')` keeps the emitted per-branch JSON schema a
+  // clean single-value `const` (not an `anyOf` with `null`) — required so
+  // `convertToolSchema`'s `flattenTopLevelUnion`/`schemaLiteralValue` (which
+  // only recognizes a bare `const`/one-item `enum` as a discriminator
+  // literal) still merges all five actions into one enum for the
+  // OpenAI/Anthropic/Google-facing schema. `.nullish()` here produces an
+  // `anyOf` that flattening can't read as a literal, silently dropping
+  // wait/kill/subscribe/unsubscribe from the advertised schema instead.
+  // The explicit-`null` case AGENTS.md's rule calls out (a structured-output
+  // provider representing an omitted optional field as `null` rather than
+  // absent) is handled separately below by ExecutionsToolInputSchema's
+  // preprocess, which strips a `null` action down to omitted before this
+  // branch's own default runs — so the type stays a plain optional literal.
   action: z
     .literal('view')
-    .nullish()
-    .transform((v) => v ?? ('view' as const))
+    .optional()
+    .default('view')
     .describe('Read execution data (returns immediately). Default action.'),
 
   /** Optional line range [start, end] for large outputs. */
@@ -572,7 +581,7 @@ const UnsubscribeActionSchema = z.strictObject({
     ),
 });
 
-const ExecutionsToolInputSchema = z.discriminatedUnion('action', [
+const ExecutionsToolActionSchema = z.discriminatedUnion('action', [
   ViewActionSchema,
   WaitActionSchema,
   KillActionSchema,
@@ -580,7 +589,29 @@ const ExecutionsToolInputSchema = z.discriminatedUnion('action', [
   UnsubscribeActionSchema,
 ]);
 
-type ExecutionsToolInput = z.infer<typeof ExecutionsToolInputSchema>;
+// A structured-output provider represents an omitted optional field as an
+// explicit `action: null` rather than leaving the key absent (AGENTS.md's
+// tool-input-schema rule). z.discriminatedUnion reads the raw `action` value
+// to pick a branch before any field-level default runs, and `null` isn't one
+// of the branch literals, so strip it down to "key absent" here — the view
+// branch's own `.optional().default('view')` then takes over exactly as it
+// does for a truly omitted key. A genuinely absent key needs no help: Zod
+// already matches that against the one branch whose discriminator accepts
+// undefined.
+const ExecutionsToolInputSchema = z.preprocess((value) => {
+  if (
+    value &&
+    typeof value === 'object' &&
+    'action' in value &&
+    value.action === null
+  ) {
+    const { action: _null, ...rest } = value;
+    return rest;
+  }
+  return value;
+}, ExecutionsToolActionSchema);
+
+type ExecutionsToolInput = z.infer<typeof ExecutionsToolActionSchema>;
 
 export class ExecutionsTool extends defineTool({
   name: 'executions',

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -449,17 +449,19 @@ const PathFieldSchema = z.string().describe('Path starting with /executions');
 
 const ViewActionSchema = z.strictObject({
   path: PathFieldSchema,
-  // Optional + defaulted (not a bare literal, unlike the other branches):
-  // 'view' is the common no-op-preamble call, so omitting `action` entirely
-  // must both dispatch to this branch and keep it out of the JSON-schema
-  // `required` list — matching the pre-refactor `.prefault('view')` and the
-  // "design for the model's first call" rule (AGENTS.md). z.discriminatedUnion
-  // matches an omitted discriminator against a branch whose discriminator
-  // schema itself accepts undefined, so no top-level preprocess is needed.
+  // nullish + normalized (not a bare literal, unlike the other branches):
+  // 'view' is the common no-op-preamble call, so omitting `action` — or, per
+  // AGENTS.md's tool-input-schema rule, sending it as `null` (OpenAI-
+  // compatible structured-output providers represent an omitted optional
+  // field that way) — must both dispatch to this branch and keep `action`
+  // out of the JSON-schema `required` list, matching the pre-refactor
+  // `.prefault('view')`. z.discriminatedUnion matches a missing/null
+  // discriminator against a branch whose discriminator schema itself accepts
+  // it, so no top-level preprocess is needed.
   action: z
     .literal('view')
-    .optional()
-    .default('view')
+    .nullish()
+    .transform((v) => v ?? ('view' as const))
     .describe('Read execution data (returns immediately). Default action.'),
 
   /** Optional line range [start, end] for large outputs. */

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -444,40 +444,61 @@ function projectProcessOutput(
 // Schema
 // ============================================================================
 
-const ExecutionsToolInputSchema = z.strictObject({
-  /** Virtual path: /executions, /executions/{id}, /executions/{id}/files, /executions/{id}/workspace-files/{path} */
-  path: z.string().describe('Path starting with /executions'),
+/** Virtual path: /executions, /executions/{id}, /executions/{id}/files, /executions/{id}/workspace-files/{path} */
+const PathFieldSchema = z.string().describe('Path starting with /executions');
 
-  /** Action to perform. */
+const ViewActionSchema = z.strictObject({
+  path: PathFieldSchema,
   action: z
-    .enum(['view', 'wait', 'kill', 'subscribe', 'unsubscribe'])
-    .prefault('view')
-    .describe(
-      'view: read execution data (returns immediately). ' +
-        'wait: wait for a status change on /executions or /executions/{id}, then return the same data as view (avoids sleep-poll loops). ' +
-        'kill: terminate a running execution by ID (use on /executions/{id}). ' +
-        'subscribe: receive future status changes for /executions/{id} as <execution-activity> follow-ups; auto-disposes when the execution finishes or this stream is released. ' +
-        'unsubscribe: stop receiving <execution-activity> follow-ups for /executions/{id}.',
-    ),
+    .literal('view')
+    .describe('Read execution data (returns immediately).'),
 
-  /** Optional line range [start, end] for large outputs (action="view" only). */
+  /** Optional line range [start, end] for large outputs. */
   view_range: ViewRangeSchema.nullish().describe(
-    'Line range [start, end] for paginating file and background-command output (action="view" only). Conversation pagination uses offset and limit.',
+    'Line range [start, end] for paginating file and background-command output. Conversation pagination uses offset and limit.',
   ),
 
-  /** Execution IDs to wait on (action="wait" with /executions only). */
+  /** Zero-based offset for list or conversation pagination. */
+  offset: z
+    .int()
+    .min(0)
+    .nullish()
+    .describe(
+      'Zero-based offset into the executions list or conversation messages. Use with limit on /executions or /executions/{id}/conversation. Default: 0.',
+    ),
+
+  /** Maximum list entries or conversation messages to return. */
+  limit: z
+    .int()
+    .min(1)
+    .max(200)
+    .nullish()
+    .describe(
+      'Max entries or conversation messages to return. Use on /executions or /executions/{id}/conversation. Default: 100, max: 200.',
+    ),
+});
+
+const WaitActionSchema = z.strictObject({
+  path: PathFieldSchema,
+  action: z
+    .literal('wait')
+    .describe(
+      'Wait for a status change on /executions or /executions/{id}, then return the same data as view (avoids sleep-poll loops).',
+    ),
+
+  /** Execution IDs to wait on (with /executions only; ignored on /executions/{id}). */
   ids: z
     .array(ExecutionIdSchema)
     .min(1)
     .max(50)
     .nullish()
     .describe(
-      'List of execution IDs to wait on (action="wait" with /executions only). ' +
+      'List of execution IDs to wait on (with /executions only). ' +
         'Waits for any of the listed executions to change status. ' +
         'If omitted, waits for any active execution.',
     ),
 
-  /** Max seconds to wait (action="wait" only). Default: 300. */
+  /** Max seconds to wait. Default: 300. */
   timeout: z
     .number()
     .finite()
@@ -492,30 +513,77 @@ const ExecutionsToolInputSchema = z.strictObject({
       ),
     )
     .describe(
-      `Max seconds to wait for a status change (action="wait" only). Default: ${EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS}; finite values are clamped to the ${EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS}-${EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS} range.`,
+      `Max seconds to wait for a status change. Default: ${EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS}; finite values are clamped to the ${EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS}-${EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS} range.`,
     ),
 
-  /** Zero-based offset for list or conversation pagination (action="view" only). */
+  /** Zero-based offset for the /executions listing returned once the wait resolves. */
   offset: z
     .int()
     .min(0)
     .nullish()
     .describe(
-      'Zero-based offset into the executions list or conversation messages. Use with limit on /executions or /executions/{id}/conversation. Default: 0.',
+      'Zero-based offset into the executions list returned once the wait resolves (with /executions only). Default: 0.',
     ),
 
-  /** Maximum list entries or conversation messages to return (action="view" only). */
+  /** Maximum list entries in the /executions listing returned once the wait resolves. */
   limit: z
     .int()
     .min(1)
     .max(200)
     .nullish()
     .describe(
-      'Max entries or conversation messages to return. Use on /executions or /executions/{id}/conversation. Default: 100, max: 200.',
+      'Max entries in the executions list returned once the wait resolves (with /executions only). Default: 100, max: 200.',
     ),
 });
 
-type ExecutionsToolInput = z.infer<typeof ExecutionsToolInputSchema>;
+const KillActionSchema = z.strictObject({
+  path: PathFieldSchema,
+  action: z
+    .literal('kill')
+    .describe('Terminate a running execution by ID (use on /executions/{id}).'),
+});
+
+const SubscribeActionSchema = z.strictObject({
+  path: PathFieldSchema,
+  action: z
+    .literal('subscribe')
+    .describe(
+      'Receive future status changes for /executions/{id} as <execution-activity> follow-ups; auto-disposes when the execution finishes or this stream is released.',
+    ),
+});
+
+const UnsubscribeActionSchema = z.strictObject({
+  path: PathFieldSchema,
+  action: z
+    .literal('unsubscribe')
+    .describe(
+      'Stop receiving <execution-activity> follow-ups for /executions/{id}.',
+    ),
+});
+
+const ExecutionsToolActionSchema = z.discriminatedUnion('action', [
+  ViewActionSchema,
+  WaitActionSchema,
+  KillActionSchema,
+  SubscribeActionSchema,
+  UnsubscribeActionSchema,
+]);
+
+// Preprocess rather than a per-branch default: z.discriminatedUnion picks a
+// branch by reading the raw `action` value before any field-level default
+// runs, so an omitted `action` (the common "just view this path" call) would
+// otherwise match no branch at all. Defaulting here keeps that call shape
+// working exactly like the pre-refactor `.prefault('view')` did, while every
+// branch below only declares the fields that action actually uses instead of
+// one flat bag of cross-action-optional fields.
+const ExecutionsToolInputSchema = z.preprocess((value) => {
+  if (value && typeof value === 'object' && !('action' in value)) {
+    return { ...value, action: 'view' };
+  }
+  return value;
+}, ExecutionsToolActionSchema);
+
+type ExecutionsToolInput = z.infer<typeof ExecutionsToolActionSchema>;
 
 export class ExecutionsTool extends defineTool({
   name: 'executions',
@@ -547,13 +615,18 @@ Delegated subagent and workflow results are delivered automatically as follow-up
 
     // /executions - list all executions
     if (!id) {
-      if (input.action === 'subscribe' || input.action === 'unsubscribe') {
+      if (
+        input.action === 'subscribe' ||
+        input.action === 'unsubscribe' ||
+        input.action === 'kill'
+      ) {
         throw new ToolError(
           `action='${input.action}' requires a specific execution: use /executions/{id}.`,
         );
       }
-      if (input.action === 'wait')
+      if (input.action === 'wait') {
         await this.waitForAnyChange(input.timeout, input.ids);
+      }
       return this.listExecutions(input.offset ?? 0, input.limit ?? 100);
     }
 
@@ -561,21 +634,32 @@ Delegated subagent and workflow results are delivered automatically as follow-up
 
     // /executions/{id} - execution summary or actions
     if (!resource) {
-      // Kill action: terminate a running execution (only valid on /executions/{id})
-      if (input.action === 'kill') {
-        return this.handleKill(executionId);
+      switch (input.action) {
+        case 'kill':
+          return this.handleKill(executionId);
+        case 'subscribe':
+          return this.handleSubscribe(executionId);
+        case 'unsubscribe':
+          return this.handleUnsubscribe(executionId);
+        case 'wait':
+          await this.waitForChange(executionId, input.timeout);
+          return this.showSummary(executionId, {
+            suppressAutoDeliveredSubagentReport: true,
+          });
+        case 'view':
+          return this.showSummary(executionId, {
+            suppressAutoDeliveredSubagentReport: false,
+          });
       }
-      if (input.action === 'subscribe') {
-        return this.handleSubscribe(executionId);
-      }
-      if (input.action === 'unsubscribe') {
-        return this.handleUnsubscribe(executionId);
-      }
-      if (input.action === 'wait')
-        await this.waitForChange(executionId, input.timeout);
-      return this.showSummary(executionId, {
-        suppressAutoDeliveredSubagentReport: input.action === 'wait',
-      });
+    }
+
+    // Sub-resource paths (config, conversation, files, ...) only support
+    // reading — wait/kill/subscribe/unsubscribe operate on /executions or
+    // /executions/{id}, never a deeper resource.
+    if (input.action !== 'view') {
+      throw new ToolError(
+        `action='${input.action}' is only valid on /executions or /executions/{id}; use action='view' to read /executions/${id}/${resource}.`,
+      );
     }
 
     const viewRange = input.view_range ?? undefined;

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -67,7 +67,7 @@ import {
   readCompletedRunConversation,
   readCompletedRunTodos,
 } from '@transcript';
-import { clamp, unique } from '@utils/core';
+import { assertNever, clamp, unique } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { StorageFS } from '@utils/files/storageFS';
 import { isDirectory } from '@utils/files/fsEntryType';
@@ -449,9 +449,18 @@ const PathFieldSchema = z.string().describe('Path starting with /executions');
 
 const ViewActionSchema = z.strictObject({
   path: PathFieldSchema,
+  // Optional + defaulted (not a bare literal, unlike the other branches):
+  // 'view' is the common no-op-preamble call, so omitting `action` entirely
+  // must both dispatch to this branch and keep it out of the JSON-schema
+  // `required` list — matching the pre-refactor `.prefault('view')` and the
+  // "design for the model's first call" rule (AGENTS.md). z.discriminatedUnion
+  // matches an omitted discriminator against a branch whose discriminator
+  // schema itself accepts undefined, so no top-level preprocess is needed.
   action: z
     .literal('view')
-    .describe('Read execution data (returns immediately).'),
+    .optional()
+    .default('view')
+    .describe('Read execution data (returns immediately). Default action.'),
 
   /** Optional line range [start, end] for large outputs. */
   view_range: ViewRangeSchema.nullish().describe(
@@ -561,7 +570,7 @@ const UnsubscribeActionSchema = z.strictObject({
     ),
 });
 
-const ExecutionsToolActionSchema = z.discriminatedUnion('action', [
+const ExecutionsToolInputSchema = z.discriminatedUnion('action', [
   ViewActionSchema,
   WaitActionSchema,
   KillActionSchema,
@@ -569,21 +578,7 @@ const ExecutionsToolActionSchema = z.discriminatedUnion('action', [
   UnsubscribeActionSchema,
 ]);
 
-// Preprocess rather than a per-branch default: z.discriminatedUnion picks a
-// branch by reading the raw `action` value before any field-level default
-// runs, so an omitted `action` (the common "just view this path" call) would
-// otherwise match no branch at all. Defaulting here keeps that call shape
-// working exactly like the pre-refactor `.prefault('view')` did, while every
-// branch below only declares the fields that action actually uses instead of
-// one flat bag of cross-action-optional fields.
-const ExecutionsToolInputSchema = z.preprocess((value) => {
-  if (value && typeof value === 'object' && !('action' in value)) {
-    return { ...value, action: 'view' };
-  }
-  return value;
-}, ExecutionsToolActionSchema);
-
-type ExecutionsToolInput = z.infer<typeof ExecutionsToolActionSchema>;
+type ExecutionsToolInput = z.infer<typeof ExecutionsToolInputSchema>;
 
 export class ExecutionsTool extends defineTool({
   name: 'executions',
@@ -650,6 +645,8 @@ Delegated subagent and workflow results are delivered automatically as follow-up
           return this.showSummary(executionId, {
             suppressAutoDeliveredSubagentReport: false,
           });
+        default:
+          return assertNever(input, 'Unrecognized executions action');
       }
     }
 


### PR DESCRIPTION
## Summary

Follow-up from a scheduled data-structure-design audit of the codebase. Fixes the highest-confidence findings — mechanical, behavior-preserving tightenings, each verified with a full workspace typecheck and targeted tests:

1. **`packages/desktop/src/main/desktopFileSelection.ts` (High)** — routed inbound messages through the shared `MainViewInboundMessageSchema` discriminated union at the entry point, matching every sibling desktop IPC adapter (`desktopShellIpc.ts`, `desktopWorkspaceIpc.ts`, `desktopSettingsIpc.ts`, ...). Previously this file alone read the loose `DesktopCommandMessage` envelope with hand-rolled `typeof x === 'string'` guards, so the desktop and extension hosts could silently diverge on what's valid for the same wire command.

2. **`src/tools/ExecutionsTool.ts` (Medium)** — converted the flat `z.strictObject` input schema (5 independently-optional fields whose validity actually depends on `action`) into a `z.discriminatedUnion('action', [...])`, matching the pattern every sibling multi-command tool already uses (`PlanTool`, `MemoryTool`, `ExternalInquiryTool`). Each branch now only declares the fields that action actually uses. A `z.preprocess` step preserves the pre-existing "omitted `action` defaults to `view`" call shape. Previously-silent invalid combinations are now rejected instead of quietly ignored (e.g. `action=kill` with no execution id, or `wait`/`kill`/`subscribe`/`unsubscribe` against a sub-resource path like `/executions/{id}/output`).

3. **`src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts` (Medium)** — removed all 12 `as ChatMessages` / `as ChatContentItems` / `as ChatAssistantMessage` / `as ChatContentText` casts. Each one turned out to be unnecessary once traced against the OpenRouter SDK's actual (already-discriminated) types — `ChatChoice.message` is already typed `ChatAssistantMessage`, and `ChatMessages`/`ChatContentItems` are `role`/`type`-discriminated unions that TypeScript narrows correctly through plain `Array.isArray`/equality checks. No behavior change; the casts were pure noise hiding correct narrowing that already worked.

## Issue acceptance gates

No linked issue — this is a direct implementation of the audit's High/Medium findings (desktop IPC bypass, ExecutionsTool grab-bag schema, OpenRouter cast noise) reported earlier in the session that requested this refactor.

## Single source of truth

- Desktop file-selection dispatch now defers to `MainViewInboundMessageSchema` (`src/shared/schemas/mainView/inbound.ts`) as the sole validator for main-view inbound commands, same as every other desktop IPC adapter.
- `ExecutionsTool`'s action-to-valid-fields mapping is now owned by the schema itself (`ExecutionsToolActionSchema`), not re-derived by hand in `execute()`.

## Duplication and abstraction budget

Removed duplication: `desktopFileSelection.ts` no longer re-implements ad hoc field guards that `MainViewInboundMessageSchema` already encodes. No new cross-file abstractions were added — the new `ViewActionSchema`/`WaitActionSchema`/`KillActionSchema`/`SubscribeActionSchema`/`UnsubscribeActionSchema` are module-private schema literals local to `ExecutionsTool.ts`, following the same in-file pattern as `PlanTool.ts`'s discriminated union.

## Net elements (R6)

3 files changed, +174/-79 (diffstat), net +95 lines. No new exported symbols (`git diff | grep '^[+-]export'` is empty). No new classes/interfaces. `ExecutionsTool.ts` gains 6 module-private `const` schema declarations replacing 1 flat one — the growth is the discriminated-union branches carrying their own descriptions (previously interpolated into one shared description string), not new abstraction layers.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed.

## Host impact

Extension: none (dispatch path untouched; already used the shared schema correctly).

Desktop: `desktopFileSelection.ts`'s `handleMessage` now validates via `MainViewInboundMessageSchema.safeParse` before dispatch, same as `desktopShellIpc.ts`. Behavior-preserving for all four handled commands (`SELECT_MULTIPLE_FILES`, `REQUEST_BASE_FILE`, `REFRESH_ALL_FILES`, `REQUEST_EDITED_FILE`).

CLI: none.

## Scheduled refactoring

None. The audit also flagged a larger, riskier finding (the `UserVars = Record<string, unknown>` template-variable grab-bag in `src/agent/utils/userVars.ts`, ~50+ keys across 5 functions) that was intentionally left out of this PR — it needs a broader restructuring across `PromptBuilder.ts` and template-substitution call sites that deserves its own focused pass rather than being bundled here.

## Validation

- `npm run typecheck` (full workspace: root, test-kernel, agent package build, cli, trace-viewer, desktop) — clean.
- `npx vitest run` targeted suites: `ExecutionsTool*.vitest.ts` (4 files), `ToolInputPreview.vitest.ts`, `ElectronFileSelection.vitest.ts`, `ElectronMainViewIpc.vitest.ts`, and all OpenRouter/model-handler suites (`ModelHandlerOpenRouterNative.vitest.ts` + 8 related files) — 253 tests, all passing.
- `npx eslint` and `npx prettier --check` on all three changed files — clean.
- `npm run check:dead-code-ratchet` — no new unused exports/files.
- Full `npm test` was attempted but exceeds this session's time budget (853 test files); not run to completion. The full workspace typecheck plus the targeted suites above cover the changed code paths directly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DfodXxBPqVo8wEhr8zB3vB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop IPC validation and the ExecutionsTool input schema (agent-facing tool contract). Mostly behavior-preserving, but schema tightening can newly reject previously-ignored invalid inputs.
> 
> **Overview**
> Aligns three audit findings with existing codebase patterns — behavior-preserving type and schema tightenings.
> 
> **Desktop file selection** now validates inbound IPC through `MainViewInboundMessageSchema` at the entry point (matching `desktopShellIpc` and siblings), replacing ad-hoc `typeof` field guards so desktop and extension hosts share one wire contract.
> 
> **`ExecutionsTool`** converts its flat grab-bag input schema into a `z.discriminatedUnion` on `action`, so each branch only accepts fields that action uses. Invalid combos (e.g. `kill` without an id, or non-`view` actions on sub-resource paths) are now rejected instead of silently ignored. A preprocess step preserves omitted/`null` `action` defaulting to `view`.
> 
> **OpenRouter native handler** drops unnecessary `as ChatMessages` / `as ChatAssistantMessage` casts; SDK types already narrow correctly without them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0b311aefc3dfee2c485554cfa5b89e31399979a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->