### PR TITLE
refactor(ui): consolidate duplicated getting-started, approval, and CLI hint markup

### DIFF
--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -9,6 +9,7 @@ import { BorderedPanel } from '@cli/tui/ui/BorderedPanel';
 import {
   KEY_HINT_SEPARATOR,
   KeyHints,
+  keyHintSpans,
   type KeyHint,
 } from '@cli/tui/ui/KeyHints';
 import { POINTER } from '@cli/tui/ui/glyphs';
@@ -27,6 +28,10 @@ import type {
   ApprovalBypassKind,
   ApprovalDecision,
 } from '../state/approvalQueue';
+
+/** Rejection-note prompt for every ConfirmCard-based approval modal. */
+export const CONFIRM_CARD_FEEDBACK_PLACEHOLDER =
+  'Feedback to send with rejection';
 
 export interface ConfirmCardProps {
   readonly borderStyle: BoxProps['borderStyle'];
@@ -61,7 +66,7 @@ export function ConfirmCard({
   rejectionMode,
   alwaysAllow,
   extraActions = [],
-  feedbackPlaceholder = 'Feedback to send with rejection',
+  feedbackPlaceholder = CONFIRM_CARD_FEEDBACK_PLACEHOLDER,
   compact = false,
   onFeedbackModeChange,
   onFeedbackValueChange,
@@ -197,14 +202,7 @@ export function ConfirmCard({
           <Text bold color={color} wrap="truncate-end">
             {pulsedTitle}
             <Text dimColor>{KEY_HINT_SEPARATOR}</Text>
-            <Text dimColor>
-              {hints.map((hint, index) => (
-                <Text key={`${hint.key}-${hint.action}-${index}`}>
-                  {index > 0 ? KEY_HINT_SEPARATOR : ''}
-                  <Text bold>{hint.key}</Text> {hint.action}
-                </Text>
-              ))}
-            </Text>
+            <Text dimColor>{keyHintSpans(hints)}</Text>
           </Text>
         )}
         {feedbackMode ? feedbackInput(0) : children}

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -12,7 +12,7 @@ import { KeyHints } from '@cli/tui/ui/KeyHints';
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 import { formatResultCount } from '@utils/text/stringUtils';
 
-import { ConfirmCard } from './ConfirmCard';
+import { ConfirmCard, CONFIRM_CARD_FEEDBACK_PLACEHOLDER } from './ConfirmCard';
 import {
   confirmCardContentRowsBudget,
   confirmCardFeedbackRows,
@@ -33,7 +33,6 @@ const EDIT_APPROVAL_SPACIOUS_FIXED_ROWS_EXCLUDING_TITLE = 8;
 const EDIT_APPROVAL_COMPACT_FIXED_ROWS_EXCLUDING_TITLE = 5;
 export const COMPACT_EDIT_APPROVAL_MAX_ROWS = 9;
 const DEFAULT_EDIT_DIFF_ROWS = 30;
-const EDIT_APPROVAL_FEEDBACK_PLACEHOLDER = 'Feedback to send with rejection';
 
 export interface EditApprovalProps {
   readonly availableRows?: number;
@@ -44,7 +43,7 @@ export interface EditApprovalProps {
 export function editApprovalDiffRowsBudget({
   availableRows,
   columns,
-  feedbackPlaceholder = EDIT_APPROVAL_FEEDBACK_PLACEHOLDER,
+  feedbackPlaceholder = CONFIRM_CARD_FEEDBACK_PLACEHOLDER,
   feedbackMode,
   feedbackValue = '',
   title,
@@ -177,7 +176,7 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
       title={title}
       rejectionMode="feedback"
       alwaysAllow={{ kind: 'toolEdit', label: 'approve edits for session' }}
-      feedbackPlaceholder={EDIT_APPROVAL_FEEDBACK_PLACEHOLDER}
+      feedbackPlaceholder={CONFIRM_CARD_FEEDBACK_PLACEHOLDER}
       compact={compactCard}
       onFeedbackModeChange={handleFeedbackModeChange}
       onFeedbackValueChange={setFeedbackValue}

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -10,7 +10,7 @@ import {
 import type { PlanApprovalPermission } from '@shared/schemas';
 import { PLAN_GOAL_COPY } from '@shared/copy/delegationApproval';
 
-import { ConfirmCard } from './ConfirmCard';
+import { ConfirmCard, CONFIRM_CARD_FEEDBACK_PLACEHOLDER } from './ConfirmCard';
 import { confirmCardFeedbackRows } from './confirmCardRowsBudget';
 import {
   ScrollableModalText,
@@ -29,8 +29,6 @@ export interface PlanApprovalProps {
 const COMPACT_PLAN_APPROVAL_MAX_ROWS = 7;
 const PLAN_APPROVAL_TITLE = 'Approve plan?';
 const PLAN_APPROVAL_GOAL_NOTICE_ROWS = 2;
-export const PLAN_APPROVAL_FEEDBACK_PLACEHOLDER =
-  'Feedback to send with rejection';
 const PLAN_APPROVAL_HIDDEN_NOUN = 'plan rows';
 const PLAN_APPROVAL_GOAL_ACTION = {
   key: 'r',
@@ -126,7 +124,7 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
           (feedbackMode
             ? confirmCardFeedbackRows({
                 columns,
-                placeholder: PLAN_APPROVAL_FEEDBACK_PLACEHOLDER,
+                placeholder: CONFIRM_CARD_FEEDBACK_PLACEHOLDER,
                 value: feedbackValue,
               })
             : 0),
@@ -154,7 +152,7 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
             ]
           : []
       }
-      feedbackPlaceholder={PLAN_APPROVAL_FEEDBACK_PLACEHOLDER}
+      feedbackPlaceholder={CONFIRM_CARD_FEEDBACK_PLACEHOLDER}
       onFeedbackModeChange={setFeedbackMode}
       onFeedbackValueChange={setFeedbackValue}
       onDecide={props.onDecide}

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -1,7 +1,10 @@
 import { useMemo, useState } from 'react';
 import { Box, Text, useInput, useWindowSize } from 'ink';
 
-import { parseUserQuestionAnswer } from '@cli/runtime/userQuestionAnswer';
+import {
+  parseUserQuestionAnswer,
+  USER_QUESTION_SKIPPED_FEEDBACK,
+} from '@cli/runtime/userQuestionAnswer';
 import { wrapAnsiToWidth } from '@cli/tui/ansiWrap';
 import { isEscapeInput } from '@cli/tui/inputKeys';
 import {
@@ -27,7 +30,6 @@ import type {
 import {
   toggleUserQuestionSelection,
   updateUserQuestionAnswers,
-  USER_QUESTION_SKIPPED_FEEDBACK,
   userQuestionDecision,
 } from './UserQuestionState';
 import { BaseTextInput } from '../input/BaseTextInput';

--- a/packages/cli/src/chat/tui/modals/UserQuestionState.ts
+++ b/packages/cli/src/chat/tui/modals/UserQuestionState.ts
@@ -1,8 +1,7 @@
+import { USER_QUESTION_SKIPPED_FEEDBACK } from '@cli/runtime/userQuestionAnswer';
 import type { UserQuestionAnswers, UserQuestionPrompt } from '@shared/schemas';
 
 import type { ApprovalDecision } from '../state/approvalQueue';
-
-export const USER_QUESTION_SKIPPED_FEEDBACK = 'User question skipped by user.';
 
 export function updateUserQuestionAnswers(
   answers: UserQuestionAnswers,

--- a/packages/cli/src/chat/tui/panes/TranscriptReader.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptReader.tsx
@@ -13,7 +13,7 @@ import { useInput, useWindowSize } from 'ink';
 
 import { isEscapeInput } from '@cli/tui/inputKeys';
 import { BorderedPanel } from '@cli/tui/ui/BorderedPanel';
-import { KeyHints } from '@cli/tui/ui/KeyHints';
+import { KeyHints, READER_SCROLL_HINTS } from '@cli/tui/ui/KeyHints';
 import { COLOR_HINT } from '@cli/tui/ui/colors';
 import { CONFIRM_CARD_HORIZONTAL_DECORATION } from '@cli/tui/ui/theme';
 import type { StreamTabId } from '@shared/schemas';
@@ -73,16 +73,7 @@ export function TranscriptReader({
       color={COLOR_HINT}
       title={title}
       width={frameWidth}
-      footer={
-        <KeyHints
-          hints={[
-            { key: '↑/↓', action: 'scroll' },
-            { key: 'PgUp/PgDn', action: 'page' },
-            { key: 'Esc', action: 'close' },
-          ]}
-          confirmCancel={false}
-        />
-      }
+      footer={<KeyHints hints={READER_SCROLL_HINTS} confirmCancel={false} />}
     >
       <ScrollableModalText
         hiddenNoun="transcript rows"

--- a/packages/cli/src/chat/tui/panes/WorkPlanReader.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkPlanReader.tsx
@@ -9,6 +9,7 @@ import {
   KeyHints,
   KEY_HINT_SEPARATOR,
   keyHintText,
+  READER_SCROLL_HINTS,
   type KeyHint,
 } from '@cli/tui/ui/KeyHints';
 import { COLOR_HINT } from '@cli/tui/ui/colors';
@@ -32,11 +33,6 @@ const TODO_STATUS_LABELS: Record<TodoStatus, string> = {
   [TODO_STATUS.COMPLETED]: 'completed',
 };
 
-const WORK_PLAN_READER_HINTS: readonly KeyHint[] = [
-  { key: '↑/↓', action: 'scroll' },
-  { key: 'PgUp/PgDn', action: 'page' },
-  { key: 'Esc', action: 'close' },
-];
 const WORK_PLAN_LOADING_HINTS: readonly KeyHint[] = [
   { key: 'Esc', action: 'close' },
 ];
@@ -51,7 +47,7 @@ function wrappedRows(text: string, width: number): number {
 export function workPlanReaderLayout({
   availableRows,
   contentWidth,
-  hints = WORK_PLAN_READER_HINTS,
+  hints = READER_SCROLL_HINTS,
   title,
 }: {
   readonly availableRows: number;
@@ -119,7 +115,7 @@ export function WorkPlanReader({
   const slice = streams.get(streamId);
   const frameWidth = formFrameWidth(columns);
   const width = Math.max(1, frameWidth - CONFIRM_CARD_HORIZONTAL_DECORATION);
-  const hints = loading ? WORK_PLAN_LOADING_HINTS : WORK_PLAN_READER_HINTS;
+  const hints = loading ? WORK_PLAN_LOADING_HINTS : READER_SCROLL_HINTS;
   const layout = workPlanReaderLayout({
     availableRows,
     contentWidth: width,

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -46,6 +46,7 @@ import {
 } from '@cli/runtime/approval/settleApprovals';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/cliPresentationHost';
+import { USER_QUESTION_SKIPPED_FEEDBACK } from '@cli/runtime/userQuestionAnswer';
 import { missingApiKeyRetryMessage } from '@cli/tui/ui/retryCopy';
 import { warn as logWarning } from '@logger/logUtils';
 import {
@@ -468,7 +469,7 @@ async function requestUserQuestionInteraction(
     ? { action: 'submit', answers: decision.userQuestionAnswers }
     : {
         action: 'skip',
-        feedback: decision.userMessage || 'User question skipped by user.',
+        feedback: decision.userMessage || USER_QUESTION_SKIPPED_FEEDBACK,
       };
 }
 

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -39,7 +39,10 @@ import {
   formatToolEditApprovalSummary,
   formatUserQuestionPrompt,
 } from './approval/approvalSummaries';
-import { parseUserQuestionAnswer } from './userQuestionAnswer';
+import {
+  parseUserQuestionAnswer,
+  USER_QUESTION_SKIPPED_FEEDBACK,
+} from './userQuestionAnswer';
 import { type CliContext } from './cliContext';
 import { writeTextStderr } from './logSinks';
 
@@ -199,7 +202,7 @@ async function askHeadlessUserQuestion(
   }
 
   if (Object.keys(answers).length === 0) {
-    return { action: 'skip', feedback: 'User question skipped by user.' };
+    return { action: 'skip', feedback: USER_QUESTION_SKIPPED_FEEDBACK };
   }
   return { action: 'submit', answers };
 }

--- a/packages/cli/src/runtime/userQuestionAnswer.ts
+++ b/packages/cli/src/runtime/userQuestionAnswer.ts
@@ -1,5 +1,11 @@
 import type { UserQuestionPrompt } from '@shared/schemas';
 
+/**
+ * Feedback the agent receives when a user question ends with no answers —
+ * one wording for both the TUI modal and the headless prompt adapter.
+ */
+export const USER_QUESTION_SKIPPED_FEEDBACK = 'User question skipped by user.';
+
 export function parseUserQuestionAnswer(
   raw: string,
   question: UserQuestionPrompt,

--- a/packages/cli/src/tui/ui/KeyHints.tsx
+++ b/packages/cli/src/tui/ui/KeyHints.tsx
@@ -38,6 +38,28 @@ const DEFAULT_TAIL: readonly KeyHint[] = [
   { key: 'Esc', action: 'cancel' },
 ];
 
+/** Footer for the closable scroll-only readers (transcript, work plan). */
+export const READER_SCROLL_HINTS: readonly KeyHint[] = [
+  { key: '↑/↓', action: 'scroll' },
+  { key: 'PgUp/PgDn', action: 'page' },
+  { key: 'Esc', action: 'close' },
+];
+
+/** Hint spans without the surrounding dim/truncating `<Text>`. Callers that
+ *  cannot use {@link KeyHints} because the strip has to share one terminal row
+ *  with other content (ConfirmCard's compact title line) render these inside
+ *  their own `<Text>` instead of restating the markup. */
+export function keyHintSpans(
+  hints: readonly KeyHint[],
+): readonly React.JSX.Element[] {
+  return hints.map((hint, index) => (
+    <Text key={`${hint.key}-${hint.action}-${index}`}>
+      {index > 0 ? KEY_HINT_SEPARATOR : ''}
+      <Text bold>{hint.key}</Text> {hint.action}
+    </Text>
+  ));
+}
+
 export function KeyHints(props: KeyHintsProps): React.JSX.Element {
   const all =
     props.confirmCancel === false
@@ -46,12 +68,7 @@ export function KeyHints(props: KeyHintsProps): React.JSX.Element {
   return (
     <Box>
       <Text dimColor wrap={props.wrap ? 'wrap' : 'truncate-end'}>
-        {all.map((hint, index) => (
-          <Text key={`${hint.key}-${hint.action}-${index}`}>
-            {index > 0 ? KEY_HINT_SEPARATOR : ''}
-            <Text bold>{hint.key}</Text> {hint.action}
-          </Text>
-        ))}
+        {keyHintSpans(all)}
       </Text>
     </Box>
   );

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -274,14 +274,7 @@ export class ProgressApp extends ProgressAppBase {
 
   protected override handleMessage(raw: unknown): void {
     dispatchMessage(raw, (error) => {
-      const command =
-        raw && typeof raw === 'object' && 'command' in raw
-          ? String((raw as { command: unknown }).command)
-          : 'unknown';
-      this.logSchemaError(
-        `[ProgressApp] Message validation failed for command "${command}".`,
-        error,
-      );
+      this.logMessageSchemaError('[ProgressApp]', raw, error);
     });
   }
 

--- a/packages/extension/src/progressView/frontend/components/BaseApprovalPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseApprovalPanel.ts
@@ -82,7 +82,6 @@ export abstract class BaseApprovalPanel<
     leadingActions?: TemplateResult | typeof nothing;
     middleActions?: TemplateResult | typeof nothing;
     trailingActions?: TemplateResult | typeof nothing;
-    feedbackPlaceholder?: string;
     trailing?: TemplateResult | typeof nothing;
   }): TemplateResult {
     const { prefix } = options;
@@ -104,7 +103,6 @@ export abstract class BaseApprovalPanel<
         ${this.renderFeedbackSection(
           `${prefix}__feedback`,
           `${prefix}__feedback-input`,
-          options.feedbackPlaceholder,
         )}
         ${options.trailing ?? nothing}
       </div>

--- a/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -16,6 +16,12 @@ import { BaseRequestPanel } from './BaseRequestPanel';
 // Local imports - progress view events
 import type { FeedbackPermissionKind } from '../events';
 
+/**
+ * Rejection prompt for panels that ask the agent a question rather than review
+ * its work — rejecting redirects the agent instead of revising a proposal.
+ */
+export const REDIRECT_FEEDBACK_PROMPT = 'What should the agent do instead?';
+
 export abstract class BaseFeedbackPanel<
   K extends FeedbackPermissionKind = FeedbackPermissionKind,
 > extends BaseRequestPanel<K> {

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -49,7 +49,10 @@ import {
   isInquiryDraftResolved,
   setInquiryDraft,
 } from '../slices/inquiryDraftState';
-import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+import {
+  BaseFeedbackPanel,
+  REDIRECT_FEEDBACK_PROMPT,
+} from './BaseFeedbackPanel';
 import { externalInquiryPanelStyles } from './ExternalInquiryPanel.styles';
 import type { PermissionState } from '../permissionState';
 
@@ -245,7 +248,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
           ${this.renderFeedbackSection(
             'external-inquiry-request__feedback',
             'external-inquiry-request__feedback-input',
-            'What should the agent do instead?',
+            REDIRECT_FEEDBACK_PROMPT,
           )}
         </div>
         ${this.renderActions()}

--- a/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
@@ -82,7 +82,6 @@ export class PlanApprovalRequestPanel extends BaseApprovalPanel<'planApproval'> 
             onClick: () => this.emitAction({ action: 'approve_and_goal' }),
           })
         : nothing,
-      feedbackPlaceholder: 'What should the agent change?',
     });
   }
 

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -9,6 +9,8 @@ import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports - shared schemas
 import {
+  GETTING_STARTED_ACTION_PRESENTATION,
+  GettingStartedActionSchema,
   MESSAGE_TYPES,
   STREAM_PHASE,
   StreamPhaseSchema,
@@ -578,39 +580,11 @@ export class TaskGroupList extends LitElement {
         body: 'Start an agent from the New tab or Commands.',
         headingTag: 'h3',
         className: 'log-placeholder',
-        actions: [
-          {
-            label: 'Run setup assistant',
-            icon: 'rocket',
-            size: 's',
-            onClick: () => this.handleGettingStartedAction('runSetup'),
-          },
-          {
-            label: 'Create sample project',
-            icon: 'file-circle-plus',
-            size: 's',
-            onClick: () =>
-              this.handleGettingStartedAction('createSampleProject'),
-          },
-          {
-            label: 'Import Overleaf',
-            icon: 'cloud-arrow-down',
-            size: 's',
-            onClick: () => this.handleGettingStartedAction('cloneOverleaf'),
-          },
-          {
-            label: 'Import arXiv',
-            icon: 'download',
-            size: 's',
-            onClick: () => this.handleGettingStartedAction('downloadArxiv'),
-          },
-          {
-            label: 'Open walkthrough',
-            icon: 'book',
-            size: 's',
-            onClick: () => this.handleGettingStartedAction('openWalkthrough'),
-          },
-        ],
+        actions: GettingStartedActionSchema.options.map((action) => ({
+          ...GETTING_STARTED_ACTION_PRESENTATION[action],
+          size: 's' as const,
+          onClick: () => this.handleGettingStartedAction(action),
+        })),
       });
     }
 

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -27,7 +27,10 @@ import type {
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - base class
-import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+import {
+  BaseFeedbackPanel,
+  REDIRECT_FEEDBACK_PROMPT,
+} from './BaseFeedbackPanel';
 
 // Local imports - styles
 import { userQuestionPanelStyles } from './UserQuestionPanel.styles';
@@ -81,7 +84,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
         ${this.renderFeedbackSection(
           'user-question-request__feedback',
           'user-question-request__feedback-input',
-          'What should the agent do instead?',
+          REDIRECT_FEEDBACK_PROMPT,
         )}
       </div>
     `;

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -207,14 +207,7 @@ export class SettingsApp extends SettingsAppBase {
 
   protected override handleMessage(raw: unknown): void {
     dispatchSettingsViewOutbound(raw, this.messageHandlers, (error) => {
-      const command =
-        raw && typeof raw === 'object' && 'command' in raw
-          ? String((raw as { command: unknown }).command)
-          : 'unknown';
-      this.logSchemaError(
-        `[SettingsApp] Message validation failed for command "${command}".`,
-        error,
-      );
+      this.logMessageSchemaError('[SettingsApp]', raw, error);
     });
   }
 

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -1,9 +1,13 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { designTokens, commonViewStyles, bannerStyles } from '@shared/styles';
-import type { GettingStartedAction } from '@shared/schemas';
+import {
+  GETTING_STARTED_ACTION_PRESENTATION,
+  type GettingStartedAction,
+} from '@shared/schemas';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import { renderBannerFrame } from '@shared/wa/bannerFrame';
@@ -79,6 +83,24 @@ export class GettingStartedBanner extends LitElement {
     this.dispatchEvent(MainViewEvents.gettingStartedAction({ action }));
   }
 
+  private renderAction(
+    action: GettingStartedAction,
+    appearance: 'filled' | 'outlined',
+    variant?: 'brand',
+  ): TemplateResult {
+    const { icon, label } = GETTING_STARTED_ACTION_PRESENTATION[action];
+    return html`
+      <wa-button
+        variant=${ifDefined(variant)}
+        appearance=${appearance}
+        size="s"
+        @click=${() => this.handleAction(action)}
+      >
+        ${waIcon(icon, { slot: 'start' })} ${label}
+      </wa-button>
+    `;
+  }
+
   override render(): TemplateResult {
     return renderBannerFrame({
       id: 'gettingStartedBanner',
@@ -96,43 +118,11 @@ export class GettingStartedBanner extends LitElement {
               agent team.
             </p>
             <div class="getting-started-actions actions">
-              <wa-button
-                variant="brand"
-                appearance="filled"
-                size="s"
-                @click=${() => this.handleAction('runSetup')}
-              >
-                ${waIcon('rocket', { slot: 'start' })} Run setup assistant
-              </wa-button>
-              <wa-button
-                appearance="outlined"
-                size="s"
-                @click=${() => this.handleAction('createSampleProject')}
-              >
-                ${waIcon('file-circle-plus', { slot: 'start' })} Create sample
-                project
-              </wa-button>
-              <wa-button
-                appearance="outlined"
-                size="s"
-                @click=${() => this.handleAction('cloneOverleaf')}
-              >
-                ${waIcon('cloud-arrow-down', { slot: 'start' })} Import Overleaf
-              </wa-button>
-              <wa-button
-                appearance="outlined"
-                size="s"
-                @click=${() => this.handleAction('downloadArxiv')}
-              >
-                ${waIcon('download', { slot: 'start' })} Import arXiv
-              </wa-button>
-              <wa-button
-                appearance="outlined"
-                size="s"
-                @click=${() => this.handleAction('openWalkthrough')}
-              >
-                ${waIcon('book', { slot: 'start' })} Open walkthrough
-              </wa-button>
+              ${this.renderAction('runSetup', 'filled', 'brand')}
+              ${this.renderAction('createSampleProject', 'outlined')}
+              ${this.renderAction('cloneOverleaf', 'outlined')}
+              ${this.renderAction('downloadArxiv', 'outlined')}
+              ${this.renderAction('openWalkthrough', 'outlined')}
             </div>
           </div>
           <wa-button

--- a/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
@@ -5,10 +5,14 @@ import { LitElement, css, html, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { GETTING_STARTED_ACTION_PRESENTATION } from '@shared/schemas';
 import { ONBOARDING_SETUP_HANDOFF } from '@shared/copy/onboarding';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import { MainViewEvents } from '../events';
+
+const { runSetup: RUN_SETUP, openWalkthrough: OPEN_WALKTHROUGH } =
+  GETTING_STARTED_ACTION_PRESENTATION;
 
 /**
  * State 1 onboarding handoff: a credential exists, but the first setup run has
@@ -77,7 +81,7 @@ export class OnboardingSetupCard extends LitElement {
             size="s"
             @click=${this.handleRunSetup}
           >
-            ${waIcon('rocket', { slot: 'start' })} Run setup assistant
+            ${waIcon(RUN_SETUP.icon, { slot: 'start' })} ${RUN_SETUP.label}
           </wa-button>
           <wa-button
             id="onboardingOpenWalkthroughButton"
@@ -85,7 +89,8 @@ export class OnboardingSetupCard extends LitElement {
             size="s"
             @click=${this.handleOpenGettingStarted}
           >
-            ${waIcon('book', { slot: 'start' })} Open walkthrough
+            ${waIcon(OPEN_WALKTHROUGH.icon, { slot: 'start' })}
+            ${OPEN_WALKTHROUGH.label}
           </wa-button>
           <wa-button
             id="onboardingSkipSetupButton"

--- a/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
@@ -5,6 +5,7 @@ import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { GETTING_STARTED_ACTION_PRESENTATION } from '@shared/schemas';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import {
   ONBOARDING_CARD_TITLE,
@@ -15,6 +16,9 @@ import {
 } from '@shared/copy/onboarding';
 
 import { MainViewEvents } from '../events';
+
+const { openWalkthrough: OPEN_WALKTHROUGH } =
+  GETTING_STARTED_ACTION_PRESENTATION;
 
 /**
  * State 0 welcome card (PRD: agent-native onboarding) — a port of the CLI
@@ -344,7 +348,8 @@ export class OnboardingWelcomeCard extends LitElement {
               size="s"
               @click=${this.handleOpenGettingStarted}
             >
-              ${waIcon('book', { slot: 'start' })} Open walkthrough
+              ${waIcon(OPEN_WALKTHROUGH.icon, { slot: 'start' })}
+              ${OPEN_WALKTHROUGH.label}
             </wa-button>
             <wa-button
               id="onboardingSkipButton"

--- a/src/shared/BaseWebviewApp.ts
+++ b/src/shared/BaseWebviewApp.ts
@@ -127,6 +127,26 @@ export abstract class BaseWebviewApp<TMessage = unknown> extends LitElement {
   }
 
   /**
+   * Dispatcher `onError` reporter: names the command the raw message claimed
+   * so a validation failure points at one command instead of the whole union.
+   * `appLabel` is the bracketed app tag (e.g. `[ProgressApp]`).
+   */
+  protected logMessageSchemaError(
+    appLabel: string,
+    raw: unknown,
+    error: unknown,
+  ): void {
+    const command =
+      raw && typeof raw === 'object' && 'command' in raw
+        ? String((raw as { command: unknown }).command)
+        : 'unknown';
+    this.logSchemaError(
+      `${appLabel} Message validation failed for command "${command}".`,
+      error,
+    );
+  }
+
+  /**
    * Handle theme updates from the extension host.
    *
    * Mirrors the theme kind onto `<html>` as `wa-light` / `wa-dark` so Web

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -7,7 +7,10 @@ import { z } from 'zod';
 
 import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
 import { AgentCategorySchema } from '@shared/schemas/agent';
-import { TEXRA_ICON_CANONICAL_NAMES } from '@shared/wa/iconNames';
+import {
+  TEXRA_ICON_CANONICAL_NAMES,
+  type TeXRAIconName,
+} from '@shared/wa/iconNames';
 import { UIFileFieldsSchema, requiredFileListFields } from '../fileFields';
 import {
   CurrentFileTypeSchema,
@@ -417,6 +420,27 @@ export const GETTING_STARTED_COMMANDS = {
   downloadArxiv: 'texra.downloadArXivSource',
   openWalkthrough: 'texra.openGettingStarted',
 } satisfies Record<GettingStartedAction, string>;
+
+/**
+ * Button label and leading icon for each getting-started action — the
+ * presentation counterpart to {@link GETTING_STARTED_COMMANDS}. The Main view
+ * getting-started banner, the Progress view empty state, and the onboarding
+ * cards all render the same actions, so the words and glyph live here rather
+ * than being re-typed per surface.
+ */
+export const GETTING_STARTED_ACTION_PRESENTATION = {
+  runSetup: { label: 'Run setup assistant', icon: 'rocket' },
+  createSampleProject: {
+    label: 'Create sample project',
+    icon: 'file-circle-plus',
+  },
+  cloneOverleaf: { label: 'Import Overleaf', icon: 'cloud-arrow-down' },
+  downloadArxiv: { label: 'Import arXiv', icon: 'download' },
+  openWalkthrough: { label: 'Open walkthrough', icon: 'book' },
+} as const satisfies Record<
+  GettingStartedAction,
+  { readonly label: string; readonly icon: TeXRAIconName }
+>;
 
 const GettingStartedActionDetailSchema = z.object({
   action: GettingStartedActionSchema,

--- a/src/test-kernel/cli/PlanApproval.vitest.ts
+++ b/src/test-kernel/cli/PlanApproval.vitest.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { CONFIRM_CARD_FEEDBACK_PLACEHOLDER } from '@cli/chat/tui/modals/ConfirmCard';
 import {
-  PLAN_APPROVAL_FEEDBACK_PLACEHOLDER,
   isCompactPlanApprovalRows,
   isPlanApprovalGoalActionVisible,
   planApprovalCompactBodyRowsBudget,
@@ -78,14 +78,14 @@ describe('CLI plan approval layout', () => {
     expect(
       confirmCardFeedbackRows({
         columns: 80,
-        placeholder: PLAN_APPROVAL_FEEDBACK_PLACEHOLDER,
+        placeholder: CONFIRM_CARD_FEEDBACK_PLACEHOLDER,
         value: '',
       }),
     ).toBe(2);
     expect(
       confirmCardFeedbackRows({
         columns: 44,
-        placeholder: PLAN_APPROVAL_FEEDBACK_PLACEHOLDER,
+        placeholder: CONFIRM_CARD_FEEDBACK_PLACEHOLDER,
         value:
           'This rejection note is intentionally long enough to wrap on a narrow card.',
       }),

--- a/src/test-kernel/cli/UserQuestionState.vitest.ts
+++ b/src/test-kernel/cli/UserQuestionState.vitest.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import { USER_QUESTION_SKIPPED_FEEDBACK } from '@cli/runtime/userQuestionAnswer';
 import {
   toggleUserQuestionSelection,
   updateUserQuestionAnswers,
-  USER_QUESTION_SKIPPED_FEEDBACK,
   userQuestionDecision,
 } from '@cli/chat/tui/modals/UserQuestionState';
 


### PR DESCRIPTION
## Summary

A scheduled UI-consistency audit checked Font Awesome icon usage, inline-style usage in the webview frontends, and Ink-vs-hand-rolled spinner/table/input duplication — all three were already well-consolidated. This PR is the follow-up: a real search for UI-code duplication beyond those three angles, with actual fixes. Eight small, unrelated-to-each-other markup/string blocks were reimplemented near-identically in 2-4 files each; each is now extracted to one canonical source with call sites updated. No behavior change.

## Issue acceptance gates

No linked issue — this is a proactive consolidation pass from a scheduled UI-audit routine. Acceptance gate: each change removes a genuine 2+-site duplicate and keeps output identical (verified by targeted tests below).

## Single source of truth

- `GETTING_STARTED_ACTION_PRESENTATION` (`src/shared/schemas/mainView/state.ts`) — label + icon per getting-started action, now the presentation counterpart to the existing `GETTING_STARTED_COMMANDS` table. Consumed by `GettingStartedBanner`, `TaskGroupList`, `OnboardingSetupCard`, `OnboardingWelcomeCard`.
- `CONFIRM_CARD_FEEDBACK_PLACEHOLDER` (`ConfirmCard.tsx`) — the rejection-note prompt shared by every `ConfirmCard`-based modal (`EditApproval`, `PlanApproval`).
- `USER_QUESTION_SKIPPED_FEEDBACK` — moved from the TUI-only `UserQuestionState.ts` to `runtime/userQuestionAnswer.ts`, a module already shared by the TUI and the headless adapter, so both `subscribeApprovals.ts` and `approvalAdapter.ts` read one string.
- `keyHintSpans` / `READER_SCROLL_HINTS` (`KeyHints.tsx`) — hint-span rendering and the transcript/work-plan reader footer, previously restated per caller.
- `REDIRECT_FEEDBACK_PROMPT` (`BaseFeedbackPanel.ts`) — the "What should the agent do instead?" prompt shared by `UserQuestionPanel` and `ExternalInquiryPanel`.
- `BaseWebviewApp.logMessageSchemaError` — the dispatcher-error command-extraction block shared by `ProgressApp` and `SettingsApp`.

## Duplication and abstraction budget

Removed: 5 re-typed action-button blocks (getting-started actions), 3 duplicate feedback-placeholder string constants, 1 duplicated skip-feedback string constant, 1 duplicated key-hint span map, 1 duplicated reader-hints array, 1 duplicated redirect-prompt string, 1 duplicated dispatcher-error block, and one dead `feedbackPlaceholder` pass-through option on `BaseApprovalPanel` (its one caller passed exactly the method's own default). No new abstraction layers were added — each extraction is a data table or a plain function pulled up to the module both/all callers already shared or could trivially share, not a new indirection. Left alone (documented in the implementing agent's report as genuine, not lookalike, duplication): three divergent `wrappedRows` helpers with different width algorithms, `formatElapsed` vs `formatDuration` (intentional divergence, already commented), and per-surface BEM style files with real per-surface deltas.

## Net elements (R6)

- Files: 26 changed (`git diff --stat`), +174/-151 lines, net +23.
- Exported symbols (`^[+-]export` over the diff): +5 new (`keyHintSpans`, `REDIRECT_FEEDBACK_PROMPT`, `READER_SCROLL_HINTS`, `GETTING_STARTED_ACTION_PRESENTATION`, `CONFIRM_CARD_FEEDBACK_PLACEHOLDER`), -1 (`PLAN_APPROVAL_FEEDBACK_PLACEHOLDER`, replaced by the existing `CONFIRM_CARD_FEEDBACK_PLACEHOLDER`), 1 relocated with no net change (`USER_QUESTION_SKIPPED_FEEDBACK`, moved module). Net +4 exports, but each backs 2-4 deleted inline duplicates — the small export-count rise is the SSOT tables/constants themselves, not new indirection layers.
- Classes/interfaces/enums: none added or removed.

## Consumer counts (R8)

No emit path was re-routed. Export removals/relocations and their consumer counts, all updated in this PR:
- `PLAN_APPROVAL_FEEDBACK_PLACEHOLDER` removed: 2 consumers (`PlanApproval.tsx`, `PlanApproval.vitest.ts`) repointed to `CONFIRM_CARD_FEEDBACK_PLACEHOLDER`.
- `USER_QUESTION_SKIPPED_FEEDBACK` moved: 4 consumers (`UserQuestion.tsx`, `subscribeApprovals.ts`, `approvalAdapter.ts`, `UserQuestionState.vitest.ts`) repointed to the new module.
- `BaseApprovalPanel`'s `feedbackPlaceholder` option removed: 1 consumer (`PlanApprovalRequestPanel.ts`), which now relies on `renderFeedbackSection`'s existing default (the string it was passing was identical to that default).

## Host impact

Extension: getting-started banners (main view + progress-view empty state + both onboarding cards) and the approval/feedback panels (plan approval, user question, external inquiry) render identically, now from shared tables/constants instead of restated literals.

Desktop: no direct changes; inherits the extension webview-frontend consolidation above via the shared renderer surface.

CLI: `ConfirmCard`-family modals (edit approval, plan approval), the transcript/work-plan readers, and user-question skip handling (TUI + headless) render identically from shared constants/helpers instead of restated literals.

## Scheduled refactoring

None — this pass fully resolved the duplication it targeted. Two intentionally-left items are noted in-code/above (`wrappedRows` divergence, `formatElapsed`/`formatDuration` divergence) as *not* needing follow-up; a third (`runtime/workflowPlainOutput.ts` hardcoding `'◆ '` instead of importing `STATUS_DIAMOND` from `tui/`) was flagged as a real but non-mechanical drift risk requiring a layering decision (`runtime/` currently has no import from `tui/`) — left as a lead for a future PR, not fixed here.

## Validation

- `npm run typecheck` — all 6 projects pass.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — OK, no new unused exports (2 pre-existing baseline entries were found already-fixed, unrelated to this diff, left untouched).
- `npx prettier --check` on all changed files — clean.
- Targeted `vitest run` on every touched test file plus tests covering touched components (`PlanApproval`, `EditApproval`, `UserQuestion`, `UserQuestionState`, `UserQuestionAnswer`, `ApprovalAdapter`, `WorkPlanReader`, `ConfirmCardState`, `ConfirmCardRowsBudget`, `StatusBar`, `Orchestration`, `ExternalInquiry`, `ConversationTranscript`, `StreamViews`, `UserQuestionPanel`, `ExternalInquiryPanelTextarea`, `TaskGroupListIndex`, `ProgressViewMessageDispatcher`, `ApprovalRequestHandler`, `SettingsNavigation`, `MainAppDesktopGating`, `HostTheme`, `DesktopIpcAdapters`, `DesktopControlSystem`, `ExtensionCommandRegistry`) — all passing.
- Full test suite not run (slow); no behavior change intended, and every touched code path has a passing targeted test.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01F3LLJfAXZQMF1RNHZ2tWDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3LLJfAXZQMF1RNHZ2tWDR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor consolidating duplicated UI strings and markup with no intended behavior or control-flow changes.
> 
> **Overview**
> **Consolidates duplicated UI strings and hint markup** into shared sources of truth across CLI and extension surfaces. No behavior change.
> 
> **Getting-started actions** now share `GETTING_STARTED_ACTION_PRESENTATION` (label + icon) across the main banner, progress empty state, and onboarding cards.
> 
> **Approval/feedback copy** is centralized: `CONFIRM_CARD_FEEDBACK_PLACEHOLDER` for CLI ConfirmCard modals, `REDIRECT_FEEDBACK_PROMPT` for extension redirect panels, and `USER_QUESTION_SKIPPED_FEEDBACK` moved to shared runtime so TUI and headless adapters use one string.
> 
> **CLI hint rendering** extracts `keyHintSpans` and `READER_SCROLL_HINTS` so ConfirmCard and the transcript/work-plan readers stop restating the same markup. Extension apps also share `logMessageSchemaError` for dispatcher validation failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ffce082591a966612f1204dd3808d6fb6d36a7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->