### PR TITLE
refactor(progressView): delete duplicate active-stream fallback re-derivation

### DIFF
--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -20,7 +20,6 @@ import {
   deleteStreamState,
   detachChildStreamTabs,
   ensureStreamState,
-  firstStreamId,
   type ProgressState,
 } from '../store';
 import {
@@ -117,19 +116,21 @@ function updateStreamInfo(
   });
 }
 
-/**
- * Resolve the next active stream id for an incoming `activeStream` value:
- * an explicit empty string means "no selection", a known stream id is kept
- * as-is, and anything else (unset or no-longer-present) falls back to the
- * first available stream.
- */
-function resolveActiveStreamId(
+// Backend is sole source of truth for activeStream selection (see
+// WebviewUpdater.sendStreamMetadata); pass its value through unchanged and
+// warn rather than silently re-deriving one if it's locally unknown.
+function assertKnownActiveStreamId(
   activeStream: StreamTabId | '',
   streamById: Map<StreamTabId, StreamTabInfo>,
 ): StreamTabId | null {
   if (activeStream === '') return null;
-  if (activeStream && streamById.has(activeStream)) return activeStream;
-  return firstStreamId(streamById);
+  if (!streamById.has(activeStream)) {
+    console.warn(
+      '[streamLifecycleSlice] activeStream not present in streamById',
+      activeStream,
+    );
+  }
+  return activeStream;
 }
 
 // ============================================================
@@ -150,10 +151,8 @@ export const streamLifecycleHandlers = {
       data.streamStates,
     );
     // Honor explicit empty-string as "no selection" — backend sends this
-    // when the current filter excludes every stream. Since the backend now
-    // emits all streams unfiltered, falling back to firstStreamId would
-    // re-pick a filtered-out tab and render hidden-category content.
-    const nextActiveStreamId = resolveActiveStreamId(
+    // when the current filter excludes every stream.
+    const nextActiveStreamId = assertKnownActiveStreamId(
       data.activeStream,
       updated.streamById,
     );
@@ -167,7 +166,7 @@ export const streamLifecycleHandlers = {
 
   [PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM]: (data) => {
     const prev = appState.get();
-    const nextActiveStreamId = resolveActiveStreamId(
+    const nextActiveStreamId = assertKnownActiveStreamId(
       data.activeStream,
       prev.streamById,
     );


### PR DESCRIPTION
## Summary

Ran a repo-wide structural debt audit (22-agent scout/map/ideate/shortlist/verify workflow) scoped to two goals: consolidate duplicate/similar logic into shared utilities, and replace custom implementations with native language/standard-library methods where they exist.

Four candidates were shortlisted; adversarial verification (with fresh repo evidence per candidate, not just the ideation-stage claims) confirmed only **one** as a genuine net gain. The other three were rejected on re-verification:

- **`doctorPlatformInitContext` inline** — BLOCKED. A repo-wide grep the ideation pass missed found a third, cross-file consumer (`src/test-kernel/cli/CliRootArgs.vitest.ts`), disqualifying it from the single-caller-inline bucket.
- **Collapse `grokLogin.ts`/`chatgptLogin.ts` into one factory** — WASH. The real per-provider delta is ~15–20 lines out of 58; the rest is boilerplate a factory has to re-emit anyway. The command layer (`subscriptionAuthCommand.ts`) already consumes these two files as config values, so a second factory underneath it would just nest two factories over a 2-item enumeration. A recent dedup sweep (#9951) touched these exact files yesterday and left them in this shape deliberately.
- **Converge test-kernel `sleep`/mock-teardown helpers** — NET_LOSS. LoC arithmetic under `elementDelta: 0` actually comes out to roughly **+10** lines once each call site's added import/decl is counted, not the claimed −17. One of the seven proposed conversions (`RunExecution.vitest.ts`) would also introduce a latent same-test correctness bug, because `createModuleMocks()`'s `onTestFinished`-deferred unmock fires too late for that test's synchronous same-test module reinstall.
- **`resolveActiveStreamId` fallback re-derivation** — **REAL_NET_GAIN** (this PR).

Most of the codebase's real duplication was already cleaned up by the recent 100-agent code-simplifier sweeps (#9989, #9990); several seams audited this session (provider/auth integration, tools/latex) came back explicitly healthy with no actionable findings.

## Issue acceptance gates

No linked issue — this is a scheduled/proactive consolidation audit. Acceptance gate: identify and land the highest-confidence, behavior-preserving consolidation surfaced by the audit.

## Single source of truth

`WebviewUpdater.sendStreamMetadata` (`src/controllers/progressView/backend/WebviewUpdater.ts`) is confirmed as sole owner of active-stream selection policy — it computes the id via `SessionState.rotateActiveStream`/`pickValidActiveStream` and sends it on the wire. The frontend now trusts that value instead of re-deriving it.

## Duplication and abstraction budget

Removed: `resolveActiveStreamId` (`packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts`), which re-implemented the backend's exact fallback policy. A comment at the deleted call site documented that this duplication previously shipped a bug (a filtered-out tab reappearing). Replaced with `assertKnownActiveStreamId`, a pass-through plus a loud `console.warn` (not a silent fallback) if the backend ever sends an id the frontend doesn't recognize — per the repo's "silent degradation is a defect" rule. No new abstraction layer added; same two call sites, same shape.

## Net elements (R6)

- Files: 1 changed, 0 added, 0 removed.
- Exported/internal symbols: `resolveActiveStreamId` deleted, `assertKnownActiveStreamId` added (net 0 functions, but the retained one no longer re-derives — it asserts).
- LoC: 14 insertions, 15 deletions (net −1).
- Also dropped the now-unused `firstStreamId` import from this file (`firstStreamId` itself keeps its live caller in `eventHandlers.ts`, so it's not orphaned).

## Consumer counts (R8)

`resolveActiveStreamId`: repo-wide grep found exactly 3 references — 1 definition + 2 call sites, both in this file, both updated in this PR. `firstStreamId`: repo-wide grep confirms a second live caller (`packages/extension/src/progressView/frontend/eventHandlers.ts:63`) remains, so removing this file's usage does not orphan the export.

## Host impact

Extension: `progressView` frontend slice — active-stream selection on `UPDATE_STREAMS`/`SET_ACTIVE_STREAM` now trusts the backend-sent id directly instead of re-deriving a fallback.

Desktop: n/a (extension-only surface, not consumed by desktop).

CLI: n/a (extension-only surface, not consumed by the CLI/TUI).

## Scheduled refactoring

None — the three other shortlisted candidates were rejected on adversarial verification (blocked/wash/net-loss), not deferred; no further follow-up is queued from this audit.

## Validation

- `npm run typecheck` (full workspace: workspace, test-kernel, agent, cli, trace-viewer, desktop) — clean.
- `npx eslint packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts` — clean.
- `npx vitest run src/test-kernel/progressView/` — 57 files / 496 tests passed.
- `npm run check:dead-code-ratchet` — no new unused exports/files (baseline unaffected by this change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01F69vJn5BHV9JDVbZ1pAydu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized refactor of stream-selection handling; removes a duplicate fallback rather than changing auth or data paths. Residual risk is limited to how unknown backend ids are surfaced in the UI.
> 
> **Overview**
> Stops the progress-view frontend from silently re-picking an active stream when the backend-sent id is missing or unknown.
> 
> `resolveActiveStreamId` (which fell back to `firstStreamId`) is replaced with `assertKnownActiveStreamId`, a pass-through that keeps the backend value and only `console.warn`s on mismatch. `UPDATE_STREAMS` and `SET_ACTIVE_STREAM` now treat the backend as the sole source of truth for selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccf2fad99d7a1ec6b87618c6dc952151269aed41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->