### PR TITLE
perf(cli): defer polish template engine loading

### DIFF
--- a/src/agent/runtime/polishModel.ts
+++ b/src/agent/runtime/polishModel.ts
@@ -52,5 +52,10 @@ export async function renderPolishPrompt(
     loadPromptTemplate(),
     import('nunjucks'),
   ]);
-  return nunjucks.renderString(template, { FILE_CONTEXT: fileContext }) + text;
+  const environment = new nunjucks.Environment(undefined, {
+    autoescape: false,
+  });
+  return (
+    environment.renderString(template, { FILE_CONTEXT: fileContext }) + text
+  );
 }

--- a/src/agent/runtime/polishModel.ts
+++ b/src/agent/runtime/polishModel.ts
@@ -1,10 +1,7 @@
-import nunjucks from 'nunjucks';
 import { z } from 'zod';
 
 import { parseYamlWith } from '@common/parsing/safeParseYaml';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
-
-const nunjucksEnv = nunjucks.configure({ autoescape: false });
 
 let polishPromptPath: string | null = null;
 let templatePromise: Promise<string> | null = null;
@@ -51,8 +48,9 @@ export async function renderPolishPrompt(
   fileContext: string,
   text: string,
 ): Promise<string> {
-  const template = await loadPromptTemplate();
-  return (
-    nunjucksEnv.renderString(template, { FILE_CONTEXT: fileContext }) + text
-  );
+  const [template, { default: nunjucks }] = await Promise.all([
+    loadPromptTemplate(),
+    import('nunjucks'),
+  ]);
+  return nunjucks.renderString(template, { FILE_CONTEXT: fileContext }) + text;
 }

--- a/src/test-kernel/agent/PolishPromptLoader.vitest.ts
+++ b/src/test-kernel/agent/PolishPromptLoader.vitest.ts
@@ -26,9 +26,10 @@ describe('polish prompt loader', () => {
       ),
     );
 
-    const prompt = await renderPolishPrompt('', 'Fix teh typo.');
+    const prompt = await renderPolishPrompt('<paper & notes>', 'Fix teh typo.');
 
     expect(prompt).toContain('Correct any spelling errors');
+    expect(prompt).toContain('<paper & notes>');
     expect(prompt).toContain('Fix teh typo.');
   });
 


### PR DESCRIPTION
## Summary

Load Nunjucks only when text polishing is invoked, instead of evaluating and globally configuring it when the shared agent runtime barrel is imported.

Closes #10025.

## Issue acceptance gates

- Keep the curated `@agent/runtime` surface unchanged.
- Remove Nunjucks initialization from CLI startup module evaluation.
- Preserve the existing polish prompt rendering behavior.
- Do not add host-specific deep imports or widen an architecture baseline.

## Single source of truth

`renderPolishPrompt` remains the sole owner of loading and rendering the polish template. It constructs the same isolated `autoescape: false` environment after the deferred import.

## Duplication and abstraction budget

No abstraction was added. The process-global environment was replaced by a render-scoped environment so importing the runtime remains inert.

## Net elements (R6)

- Files: 0 added, 0 deleted.
- Lines: +10 / -6; net +4, including one behavior-preservation assertion.
- Exports, interfaces, classes, enums, and runtime barrel entries: unchanged.
- One process-global template environment removed.

## Consumer counts (R8)

- `renderPolishPrompt`: one production consumer (`textEnhancement.ts`).
- `initializePolishModel`: one production host initializer (extension startup).
- `polishTextWithAI`: three production consumers across extension, desktop, and the shared progress controller.
- CLI consumers of polishing symbols: zero.

## Host impact

CLI:

- Importing `@agent/runtime` no longer evaluates Nunjucks or calls `configure()` during startup.

Extension and desktop:

- Nunjucks is loaded on the first actual polish request. Rendering output remains unchanged.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/agent/PolishPromptLoader.vitest.ts src/test-kernel/agent/runtime/TextEnhancementSession.vitest.ts` (3 passed)
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- ESLint and Prettier on the changed files
- CLI production bundle completed before and after; output decreased from 12,007,876 to 12,007,811 bytes, and the Nunjucks load is now behind the render-time dynamic import
- Pre-commit and pre-push checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized startup optimization in polish prompt rendering with behavior preserved and existing vitest coverage.
> 
> **Overview**
> **Defers Nunjucks** so importing `@agent/runtime` no longer pulls in or configures the template engine at module load.
> 
> `renderPolishPrompt` now **dynamically imports** `nunjucks` alongside loading the YAML template and calls `renderString` locally, dropping the module-level `configure({ autoescape: false })` while keeping the same render path (`FILE_CONTEXT` via Nunjucks, user text appended raw).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0343f0c4f04675a6acf70b67a38a3729578f48db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
