### PR TITLE
fix(tools): single-source CLI session ownership

### DIFF
--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -96,6 +96,22 @@ export interface AgentCliResumeLabels {
   queuedLabel: string;
 }
 
+function assertAgentCliSessionOwnedByCaller(
+  stored: ResumableAgentCliSession | undefined,
+  id: string | undefined,
+  callerStreamId: StreamTabId | undefined,
+  labels: AgentCliResumeLabels,
+): void {
+  if (!stored || !id || !callerStreamId) return;
+
+  const handle = stored.executions.getHandle(stored.executionId);
+  if (handle && !handle.isOwnedBy(callerStreamId)) {
+    throw new ToolError(
+      `${labels.notActiveLabel} '${id}' is owned by a different session; start a new session without ${labels.idParamName} to run in this context.`,
+    );
+  }
+}
+
 async function queueAgentCliFollowUp(
   stored: ResumableAgentCliSession,
   params: {
@@ -109,12 +125,7 @@ async function queueAgentCliFollowUp(
   // Ownership is a live-handle fact: a detached or re-parented child must not
   // accept follow-ups from its former orchestrator. A missing handle falls
   // through to submitFollowUp's no-session outcome below.
-  const handle = stored.executions.getHandle(stored.executionId);
-  if (callerStreamId && handle && !handle.isOwnedBy(callerStreamId)) {
-    throw new ToolError(
-      `${labels.notActiveLabel} '${id}' is owned by a different session; start a new session without ${labels.idParamName} to run in this context.`,
-    );
-  }
+  assertAgentCliSessionOwnedByCaller(stored, id, callerStreamId, labels);
 
   const result = await submitFollowUp(stored.childStreamId, prompt, {
     session: currentSession(),
@@ -346,17 +357,12 @@ export function dispatchAgentCliTool(params: {
   return withAgentCliApproval(agentName, approvalLabel, (runContext) => {
     const callerStreamId = getRunContextStreamId(runContext);
     const source = sourceId ? store.lookup(sourceId) : undefined;
-    const sourceHandle = source?.executions.getHandle(source.executionId);
-    if (
-      sourceId &&
-      callerStreamId &&
-      sourceHandle instanceof AgentExecutionHandle &&
-      !sourceHandle.isOwnedBy(callerStreamId)
-    ) {
-      throw new ToolError(
-        `${labels.notActiveLabel} '${sourceId}' is owned by a different session; start a new session without ${labels.idParamName} to run in this context.`,
-      );
-    }
+    assertAgentCliSessionOwnedByCaller(
+      source,
+      sourceId,
+      callerStreamId,
+      labels,
+    );
     return resumeOrLaunchAgentCliSession(store, {
       id: resumeId,
       prompt,

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -102,6 +102,8 @@ function assertAgentCliSessionOwnedByCaller(
   callerStreamId: StreamTabId | undefined,
   labels: AgentCliResumeLabels,
 ): void {
+  // Without a live session id and caller there is no ownership claim to check;
+  // a missing in-memory fork source continues through the disk-backed fallback.
   if (!stored || !id || !callerStreamId) return;
 
   const handle = stored.executions.getHandle(stored.executionId);


### PR DESCRIPTION
## Summary

- centralize the live agent-CLI caller-ownership check used by queued follow-ups and fresh forks
- remove the stale `AgentExecutionHandle` runtime class check left after execution handles were collapsed
- preserve the existing authorization error and missing-handle behavior

Closes #10031.

## Ownership decision

The execution registry already returns the one current live-handle type, and `isOwnedBy` is the authority for caller ownership. Both entry points now pass their session record, public session id, and caller stream to one guard. This avoids restoring the retired class distinction merely to make one copied predicate compile.

The guard deliberately permits a missing live handle. Follow-up submission remains responsible for reporting that the continuation no longer exists, while a disk-backed fork source can continue through its existing fallback path.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- `corepack pnpm --filter @texra-ai/cli build`
- `npx vitest run --config vitest.config.mjs src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts` — 12 passed
- `npm test` — 9,943 passed, 5 skipped, with one unrelated PID-file timing failure in `SystemUtils.vitest.ts`
- isolated rerun of `SystemUtils.vitest.ts` — 23 passed

The complete-suite failure observed the PID file after creation but before it contained a parseable PID. The unchanged test passed immediately in isolation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor of authorization predicates in agent-CLI tools with explicit intent to preserve errors and fallback paths; no new surfaces beyond existing resume/follow-up flows.
> 
> **Overview**
> **Centralizes** the agent-CLI caller-ownership check in `assertAgentCliSessionOwnedByCaller` in `agentCliShared.ts`, so queued follow-ups and fresh forks (via `sourceId`) use the same rule instead of duplicated logic.
> 
> The fork path **drops** the stale `instanceof AgentExecutionHandle` gate and relies on `getHandle` + `isOwnedBy`, matching the follow-up path. **Unchanged behavior:** missing session id, caller, or live handle still skips the guard (disk-backed fork fallback); a handle owned by another stream still throws the same `ToolError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db24ff9e64ad33d26ceb50167a529561546b8519. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->