### PR TITLE
fix: retire unreachable Claude retry state

### DIFF
--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -315,6 +315,39 @@ describe('claude_agent tool launch and resume fallback', () => {
     expect(callArgs.options.resume).toBe('stale-session');
   });
 
+  it('preserves legacy usage when a result has no modelUsage', async () => {
+    const childStream = createFakeAgentCliChildStream(childStreamId);
+    const publishUsage = vi.spyOn(childStream.logger, 'usage');
+    mocks.createChildStream.mockReturnValue(childStream);
+    mocks.query.mockReturnValue(
+      (async function* () {
+        yield {
+          type: 'result',
+          subtype: 'error_during_execution',
+          errors: ['failed before the first model call'],
+          usage: { input_tokens: 12, output_tokens: 3 },
+          total_cost_usd: 0,
+        };
+      })(),
+    );
+    const captured = captureStrategy();
+
+    await new ClaudeAgentTool().call({ prompt: 'start Claude' });
+    const turn = await captured.strategy?.launch?.(
+      { notify: () => {}, recordCost: () => {} },
+      new AbortController(),
+    );
+    if (!turn) throw new Error('Expected a Claude turn result');
+    captured.strategy?.publishUsage?.(turn);
+
+    expect(publishUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        usage: expect.objectContaining({ inputTokens: 12, outputTokens: 3 }),
+      }),
+      { recordTranscript: false },
+    );
+  });
+
   it('launches one fallback loop when concurrent calls use the same stale session_id', async () => {
     const envStarted = pDefer<void>();
     const envReady = pDefer<NodeJS.ProcessEnv>();
@@ -501,65 +534,6 @@ describe('claude_agent tool launch and resume fallback', () => {
     expect(ClaudeAgentSessions.lookup('forked-session')).toBeDefined();
     captured.strategy?.releaseSessionOwnership?.();
     ClaudeAgentSessions.release('forked-session');
-  });
-
-  it('keeps forking the source after a failed first turn has no new session id', async () => {
-    ClaudeAgentSessions.register('source-session', {
-      childStreamId,
-      executionId,
-      executions: stubExecutions(),
-      model: 'claude-sonnet-4-6',
-      permissionMode: 'acceptEdits',
-      effort: 'high',
-    });
-    mocks.query
-      .mockImplementationOnce(() =>
-        (async function* () {
-          yield {
-            type: 'result',
-            subtype: 'error_during_execution',
-            errors: ['fork failed before initialization'],
-            modelUsage: {},
-            total_cost_usd: 0,
-          };
-        })(),
-      )
-      .mockImplementationOnce(() =>
-        (async function* () {
-          yield {
-            type: 'result',
-            subtype: 'success',
-            session_id: 'forked-session',
-            result: 'Fork retry succeeded',
-            modelUsage: {},
-            total_cost_usd: 0,
-          };
-        })(),
-      );
-    const captured = captureStrategy();
-
-    await new ClaudeAgentTool().call({
-      prompt: 'try a different proof',
-      session_id: 'source-session',
-      fork_session: true,
-    });
-
-    const ports: ChildRunPorts = { notify: () => {}, recordCost: () => {} };
-    await captured.strategy?.launch?.(ports, new AbortController());
-    await captured.strategy?.runTurn?.(
-      [{ text: 'retry the fork', origin: 'user' }],
-      ports,
-      new AbortController(),
-    );
-
-    expect(mocks.query.mock.calls[0]?.[0]).toMatchObject({
-      options: { resume: 'source-session', forkSession: true },
-    });
-    expect(mocks.query.mock.calls[1]?.[0]).toMatchObject({
-      options: { resume: 'source-session', forkSession: true },
-    });
-    captured.strategy?.releaseSessionOwnership?.();
-    ClaudeAgentSessions.release('source-session');
   });
 
   it('rejects a fork from a live session owned by another stream', async () => {

--- a/src/test-kernel/tools/ClaudeAgentSdkAdapter.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentSdkAdapter.vitest.ts
@@ -63,6 +63,7 @@ describe('Claude Agent SDK adapter', () => {
       cache_creation_input_tokens: 7,
       cost_usd: 0.03,
     });
+    if (!usage) throw new Error('Expected folded Claude usage');
     expect(buildClaudeUsageStats(usage)).toMatchObject({
       inputTokens: 170,
       outputTokens: 50,
@@ -70,6 +71,11 @@ describe('Claude Agent SDK adapter', () => {
       cacheCreationInputTokens: 7,
       cost: 0.03,
     });
+  });
+
+  it('keeps absent and empty model usage out of progress accounting', () => {
+    expect(aggregateClaudeModelUsage(undefined)).toBeNull();
+    expect(aggregateClaudeModelUsage({})).toBeNull();
   });
 
   it.each([

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -12,6 +12,7 @@ import {
   currentSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
+import type { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
 import {
   startChildRunLoop,
@@ -96,6 +97,18 @@ export interface AgentCliResumeLabels {
   queuedLabel: string;
 }
 
+function requireCallerOwnership(
+  id: string,
+  callerStreamId: StreamTabId | undefined,
+  handle: AgentExecutionHandle | undefined,
+  labels: AgentCliResumeLabels,
+): void {
+  if (!callerStreamId || !handle || handle.isOwnedBy(callerStreamId)) return;
+  throw new ToolError(
+    `${labels.notActiveLabel} '${id}' is owned by a different session; start a new session without ${labels.idParamName} to run in this context.`,
+  );
+}
+
 async function queueAgentCliFollowUp(
   stored: ResumableAgentCliSession,
   params: {
@@ -110,11 +123,7 @@ async function queueAgentCliFollowUp(
   // accept follow-ups from its former orchestrator. A missing handle falls
   // through to submitFollowUp's no-session outcome below.
   const handle = stored.executions.getHandle(stored.executionId);
-  if (callerStreamId && handle && !handle.isOwnedBy(callerStreamId)) {
-    throw new ToolError(
-      `${labels.notActiveLabel} '${id}' is owned by a different session; start a new session without ${labels.idParamName} to run in this context.`,
-    );
-  }
+  requireCallerOwnership(id, callerStreamId, handle, labels);
 
   const result = await submitFollowUp(stored.childStreamId, prompt, {
     session: currentSession(),
@@ -347,15 +356,8 @@ export function dispatchAgentCliTool(params: {
     const callerStreamId = getRunContextStreamId(runContext);
     const source = sourceId ? store.lookup(sourceId) : undefined;
     const sourceHandle = source?.executions.getHandle(source.executionId);
-    if (
-      sourceId &&
-      callerStreamId &&
-      sourceHandle instanceof AgentExecutionHandle &&
-      !sourceHandle.isOwnedBy(callerStreamId)
-    ) {
-      throw new ToolError(
-        `${labels.notActiveLabel} '${sourceId}' is owned by a different session; start a new session without ${labels.idParamName} to run in this context.`,
-      );
+    if (sourceId) {
+      requireCallerOwnership(sourceId, callerStreamId, sourceHandle, labels);
     }
     return resumeOrLaunchAgentCliSession(store, {
       id: resumeId,

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -271,7 +271,10 @@ export async function runStreamedTurn(params: {
           }
           break;
         case 'result':
-          usage = aggregateClaudeModelUsage(raw.modelUsage);
+          usage =
+            raw.modelUsage == null
+              ? (raw.usage ?? null)
+              : aggregateClaudeModelUsage(raw.modelUsage);
           totalCostUsd = raw.total_cost_usd;
           if (raw.subtype === 'success') {
             if (isNonEmptyString(raw.result)) {
@@ -419,7 +422,7 @@ function startClaudeAgentLoop(params: {
   // turns; it's threaded forward from each turn's result. Seeded from
   // params.resumeSessionId when this launch is a disk-based fallback resume.
   let resumeSessionId: string | undefined = params.resumeSessionId;
-  let forkNextTurn = params.forkSession;
+  let isFirstTurn = true;
   const fallbackSessionId = params.forkSession
     ? undefined
     : params.resumeSessionId;
@@ -445,10 +448,10 @@ function startClaudeAgentLoop(params: {
         additionalDirectories: params.additionalDirectories,
         env: params.env,
         resumeSessionId,
-        forkSession: forkNextTurn,
+        forkSession: isFirstTurn && params.forkSession,
         pathToClaudeCodeExecutable: params.pathToClaudeCodeExecutable,
       });
-      forkNextTurn = forkNextTurn && turn.sessionId == null;
+      isFirstTurn = false;
       if (turn.sessionId) resumeSessionId = turn.sessionId;
       return turn;
     },

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -63,8 +63,11 @@ export interface ClaudeTurnUsage {
 
 /** Collapse the SDK's authoritative per-model totals into one turn summary. */
 export function aggregateClaudeModelUsage(
-  modelUsage: Readonly<Record<string, ModelUsage>>,
-): ClaudeTurnUsage {
+  modelUsage: Readonly<Record<string, ModelUsage>> | undefined,
+): ClaudeTurnUsage | null {
+  const models = Object.values(modelUsage ?? {});
+  if (models.length === 0) return null;
+
   const usage: Required<ClaudeTurnUsage> = {
     input_tokens: 0,
     output_tokens: 0,
@@ -72,7 +75,7 @@ export function aggregateClaudeModelUsage(
     cache_creation_input_tokens: 0,
     cost_usd: 0,
   };
-  for (const model of Object.values(modelUsage)) {
+  for (const model of models) {
     usage.input_tokens += model.inputTokens;
     usage.output_tokens += model.outputTokens;
     usage.cache_read_input_tokens += model.cacheReadInputTokens;


### PR DESCRIPTION
Closes #10029.
Closes #10030.
Closes #10031.

## Summary

- give the Claude session caller-ownership authorization check one implementation
- preserve legacy turn usage when modelUsage is absent, while keeping empty current modelUsage out of progress accounting
- remove the unreachable failed-fork retry branch and its direct-strategy test

## Why these belong together

All three findings came from the native Claude SDK task integration in #10019 and concern the same turn/session boundary. The result is a smaller current-state implementation with one authorization path and one usage sentinel.

## Net elements

- files added: 0
- exported symbols added: 0
- production helpers added: 1 private helper replacing two authorization copies
- lines: 68 additions, 80 deletions (net -12)

## Validation

- 42 focused tests across Claude SDK adaptation, resume/fork behavior, and the integrated child run loop
- workspace TypeScript check
- ESLint on all changed TypeScript files
- formatting and diff checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Claude SDK tool changes with net deletion of retry logic and added tests; no auth or data-model changes beyond usage display and session fork flags.
> 
> **Overview**
> **Claude Agent SDK integration** is tightened at session boundaries: one shared **caller-ownership** check for resume follow-ups and fork sources, clearer **usage** when the SDK omits or empties `modelUsage`, and less fork state machine code.
> 
> **Authorization** moves into `requireCallerOwnership` in `agentCliShared.ts`, replacing duplicate checks in follow-up queueing and fork `sourceId` dispatch so cross-stream resume/fork errors stay consistent.
> 
> **Usage**: `aggregateClaudeModelUsage` returns `null` for missing/empty `modelUsage` so progress UI does not get fake zero-token stats; on `result`, when `modelUsage` is absent the turn still uses legacy top-level `usage`. Tests cover the legacy path and null aggregation.
> 
> **Forking**: `forkSession` is only passed on the **first** turn (`isFirstTurn`); the branch that re-forked from the source when the first turn failed without a new session id is removed, along with its test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5134bc536b8d24598aef5b971352f144d5e9c13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->