### PR TITLE
perf(cli): defer shared prompt template engine

### DIFF
--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,7 +1,5 @@
 import * as path from 'node:path';
 
-import nunjucks from 'nunjucks';
-
 import { createLog } from '@logger/logUtils';
 import { filterNotNull } from '@utils/core';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
@@ -110,10 +108,16 @@ async function resolveValue(value: unknown): Promise<unknown> {
   return Object.fromEntries(entries);
 }
 
-// One environment for every prompt render, as in polishModel.ts: configuring
-// nunjucks builds a filesystem loader, and renderString compiles its template
-// per call regardless, so a per-call environment was pure setup cost.
-const promptEnv = nunjucks.configure({ autoescape: false });
+let promptEnvironmentPromise: Promise<import('nunjucks').Environment> | null =
+  null;
+
+function promptEnvironment(): Promise<import('nunjucks').Environment> {
+  promptEnvironmentPromise ??= import('nunjucks').then(
+    ({ default: nunjucks }) =>
+      new nunjucks.Environment(undefined, { autoescape: false }),
+  );
+  return promptEnvironmentPromise;
+}
 
 /**
  * Render a prompt string using nunjucks templating
@@ -125,8 +129,11 @@ export async function renderPrompt(
   prompt: string,
   variables: Record<string, unknown>,
 ): Promise<string> {
-  const resolvedVariables = await resolveValue(variables);
-  return promptEnv.renderString(
+  const [environment, resolvedVariables] = await Promise.all([
+    promptEnvironment(),
+    resolveValue(variables),
+  ]);
+  return environment.renderString(
     prompt,
     resolvedVariables as Record<string, unknown>,
   );

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -114,7 +114,9 @@ let promptEnvironmentPromise: Promise<import('nunjucks').Environment> | null =
 function promptEnvironment(): Promise<import('nunjucks').Environment> {
   promptEnvironmentPromise ??= import('nunjucks').then(
     ({ default: nunjucks }) =>
-      new nunjucks.Environment(undefined, { autoescape: false }),
+      new nunjucks.Environment(new nunjucks.FileSystemLoader('.'), {
+        autoescape: false,
+      }),
   );
   return promptEnvironmentPromise;
 }


### PR DESCRIPTION
Closes #10027.

## Summary

Remove the remaining import-time Nunjucks initialization from the shared prompt module. The first real prompt render now imports Nunjucks and constructs one isolated environment; later renders reuse it.

## Scope

- no prompt syntax or rendered output changes
- no new exported symbols
- one module changed
- removes the stale shared-singleton configuration comment

## Validation

- 12 focused prompt/file-name tests
- workspace TypeScript check
- ESLint and formatting
- production CLI bundle build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-module performance refactor with isolated Nunjucks environment; behavior is intended to be unchanged aside from lazy loading timing.
> 
> **Overview**
> **Defers Nunjucks startup** in the shared prompt helper so importing `prompt.ts` no longer pulls in or configures Nunjucks at module load.
> 
> On the **first** `renderPrompt` call, Nunjucks is loaded with a dynamic `import()`, a dedicated `Environment` (with `FileSystemLoader` and `autoescape: false`) is created once and cached, and that environment init runs in **parallel** with `resolveValue` for template variables. Later renders reuse the same environment. The previous top-level `nunjucks.configure` singleton setup and its comment are removed.
> 
> No intended change to template syntax or rendered output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 777635b553cff86e21b9f08ae5869deba6dd3017. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->