### PR TITLE
fix(cli): preserve narrow approval actions

### DIFF
--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -37,6 +37,7 @@ export interface ConfirmCardProps {
   readonly borderStyle: BoxProps['borderStyle'];
   readonly color: string;
   readonly title: string;
+  /** Omitted labels are resolved by `confirmCardKeyHints`. */
   readonly approveLabel?: string;
   readonly rejectLabel?: string;
   readonly rejectionMode: ConfirmCardRejectionMode;
@@ -61,8 +62,8 @@ export function ConfirmCard({
   borderStyle,
   color,
   title,
-  approveLabel = 'approve',
-  rejectLabel = 'reject with note',
+  approveLabel,
+  rejectLabel,
   rejectionMode,
   alwaysAllow,
   extraActions = [],
@@ -156,15 +157,13 @@ export function ConfirmCard({
     key: action.key,
     action: action.label,
   }));
-  // Immediate: Esc and `n` share rejectLabel; feedback: Esc is note-free "reject".
-  const escapeLabel = rejectionMode === 'immediate' ? rejectLabel : 'reject';
   const compactHintLayout =
     compact && !feedbackMode
       ? confirmCardCompactHintLayout({
           title,
           approveLabel,
           rejectLabel,
-          escapeLabel,
+          rejectionMode,
           alwaysAllowLabel: alwaysAllow?.label,
           extraActions: mappedExtraActions,
           columns,
@@ -179,7 +178,7 @@ export function ConfirmCard({
     hints = confirmCardKeyHintsForWidth({
       approveLabel,
       rejectLabel,
-      escapeLabel,
+      rejectionMode,
       alwaysAllowLabel: alwaysAllow?.label,
       extraActions: mappedExtraActions,
       maxColumns: Math.max(0, columns - CONFIRM_CARD_HORIZONTAL_DECORATION),

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -29,6 +29,7 @@ export interface ConfirmCardKeyOptions {
 export interface ConfirmCardHintOptions {
   readonly approveLabel?: string;
   readonly rejectLabel?: string;
+  readonly rejectionMode?: ConfirmCardRejectionMode;
   /** Esc maps to `reject` (`confirmCardKeyAction`), not a dismiss — label the consequence. */
   readonly escapeLabel?: string;
   readonly alwaysAllowLabel?: string;
@@ -81,19 +82,25 @@ export function confirmCardKeyAction(
 
 export function confirmCardKeyHints({
   approveLabel = 'approve',
-  rejectLabel = 'reject & note',
-  escapeLabel = 'reject',
+  rejectLabel,
+  rejectionMode = 'feedback',
+  escapeLabel,
   alwaysAllowLabel,
   extraActions = [],
 }: ConfirmCardHintOptions): KeyHint[] {
+  const resolvedRejectLabel =
+    rejectLabel ?? (rejectionMode === 'feedback' ? 'reject & note' : 'reject');
+  const resolvedEscapeLabel =
+    escapeLabel ??
+    (rejectionMode === 'immediate' ? resolvedRejectLabel : 'reject');
   return [
     { key: 'y', action: approveLabel },
-    { key: 'n', action: rejectLabel },
+    { key: 'n', action: resolvedRejectLabel },
     ...(alwaysAllowLabel == null
       ? []
       : [{ key: 'a', action: alwaysAllowLabel }]),
     ...extraActions,
-    { key: 'Esc', action: escapeLabel },
+    { key: 'Esc', action: resolvedEscapeLabel },
   ];
 }
 
@@ -158,7 +165,7 @@ export function confirmCardKeyHintsForWidth(
   const coreHints = compactHints.filter(isCoreApprovalHint);
   if (hintsFit(coreHints, options.maxColumns)) return coreHints;
 
-  return [{ key: 'Esc', action: options.escapeLabel ?? 'reject' }];
+  return fullHints.slice(-1);
 }
 
 export function confirmCardCompactHintLayout({
@@ -166,6 +173,7 @@ export function confirmCardCompactHintLayout({
   columns,
   approveLabel,
   rejectLabel,
+  rejectionMode,
   escapeLabel,
   alwaysAllowLabel,
   extraActions,
@@ -174,6 +182,7 @@ export function confirmCardCompactHintLayout({
   const inlineHints = confirmCardKeyHintsForWidth({
     approveLabel,
     rejectLabel,
+    rejectionMode,
     escapeLabel,
     alwaysAllowLabel,
     extraActions,
@@ -185,6 +194,7 @@ export function confirmCardCompactHintLayout({
   const stackedHints = confirmCardKeyHintsForWidth({
     approveLabel,
     rejectLabel,
+    rejectionMode,
     escapeLabel,
     alwaysAllowLabel,
     extraActions,

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -30,8 +30,6 @@ export interface ConfirmCardHintOptions {
   readonly approveLabel?: string;
   readonly rejectLabel?: string;
   readonly rejectionMode?: ConfirmCardRejectionMode;
-  /** Esc maps to `reject` (`confirmCardKeyAction`), not a dismiss — label the consequence. */
-  readonly escapeLabel?: string;
   readonly alwaysAllowLabel?: string;
   readonly extraActions?: readonly KeyHint[];
 }
@@ -84,15 +82,13 @@ export function confirmCardKeyHints({
   approveLabel = 'approve',
   rejectLabel,
   rejectionMode = 'feedback',
-  escapeLabel,
   alwaysAllowLabel,
   extraActions = [],
 }: ConfirmCardHintOptions): KeyHint[] {
   const resolvedRejectLabel =
     rejectLabel ?? (rejectionMode === 'feedback' ? 'reject & note' : 'reject');
   const resolvedEscapeLabel =
-    escapeLabel ??
-    (rejectionMode === 'immediate' ? resolvedRejectLabel : 'reject');
+    rejectionMode === 'immediate' ? resolvedRejectLabel : 'reject';
   return [
     { key: 'y', action: approveLabel },
     { key: 'n', action: resolvedRejectLabel },
@@ -174,7 +170,6 @@ export function confirmCardCompactHintLayout({
   approveLabel,
   rejectLabel,
   rejectionMode,
-  escapeLabel,
   alwaysAllowLabel,
   extraActions,
 }: ConfirmCardCompactHintLayoutOptions): ConfirmCardCompactHintLayout {
@@ -183,7 +178,6 @@ export function confirmCardCompactHintLayout({
     approveLabel,
     rejectLabel,
     rejectionMode,
-    escapeLabel,
     alwaysAllowLabel,
     extraActions,
     maxColumns: Math.max(
@@ -195,7 +189,6 @@ export function confirmCardCompactHintLayout({
     approveLabel,
     rejectLabel,
     rejectionMode,
-    escapeLabel,
     alwaysAllowLabel,
     extraActions,
     maxColumns: columns,

--- a/src/test-kernel/cli/ConfirmCardState.vitest.ts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.ts
@@ -118,6 +118,24 @@ describe('CLI confirm-card key handling', () => {
     expect(compactRendered.length).toBeLessThanOrEqual(80);
   });
 
+  it('uses the same note-free default for immediate rejection keys', () => {
+    expect(confirmCardKeyHints({ rejectionMode: 'immediate' })).toEqual([
+      { key: 'y', action: 'approve' },
+      { key: 'n', action: 'reject' },
+      { key: 'Esc', action: 'reject' },
+    ]);
+  });
+
+  it('preserves the immediate rejection label in the narrow fallback', () => {
+    expect(
+      confirmCardKeyHintsForWidth({
+        rejectionMode: 'immediate',
+        rejectLabel: 'dismiss',
+        maxColumns: 1,
+      }),
+    ).toEqual([{ key: 'Esc', action: 'dismiss' }]);
+  });
+
   it('shows submit/back hints while collecting rejection feedback', () => {
     expect(confirmCardFeedbackHints()).toEqual([
       { key: 'Enter', action: 'send note' },


### PR DESCRIPTION
Fixes #10032.

Replacement delivery for #10035: that PR was accidentally merged into its obsolete stacked base rather than `main`. This branch contains only the already reviewed and fully validated narrow-approval commit, applied to current `main`.

## Summary

- remove `ConfirmCard` competing default labels
- resolve and compact labels once in `ConfirmCardState`
- keep approve, reject/feedback, and Escape actions visible at 40 columns

## Validation

- workspace TypeScript check
- CLI TypeScript check
- ESLint on all three changed files
- #10035 full CI and review were green for the identical patch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI copy and hint layout only; no auth, data, or API behavior changes.
> 
> **Overview**
> **Centralizes approval key-hint labels** so `ConfirmCard` no longer supplies its own defaults; omitted `approveLabel` / `rejectLabel` are resolved once in `confirmCardKeyHints` from `rejectionMode` (feedback vs immediate), including when **Esc** should mirror **n** or stay a note-free **reject**.
> 
> **Narrow-width hint fallback** now keeps the last hint from the fully resolved hint list (`fullHints.slice(-1)`) instead of a separate `escapeLabel`, so custom reject text (e.g. `dismiss`) still appears when only one action fits at ~40 columns.
> 
> Tests cover immediate-mode defaults and the narrow fallback with a custom reject label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5304aadfc1769dea5e9502a2f312fa8cde864a9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->