### PR TITLE
refactor(cli): remove legacy coding plan status fields

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -520,16 +520,16 @@ const HARNESS_MODEL_ACCESS =
           // Grok stays off in the dual-subscription harness so ChatGPT + Kimi
           // remain the visible "on" pair (Grok still appears as a row).
           grok: 'off' as const,
-          kimiCode: 'on' as const,
-          glmCode: 'off' as const,
+        },
+        codingPlans: {
+          kimiCode: { preferred: true, keySet: true },
+          glmCodingPlan: { preferred: false, keySet: true },
         },
         chatGptSignedIn: SHOW_BOTH_SUBSCRIPTION_PREFERENCES,
         ...(SHOW_BOTH_SUBSCRIPTION_PREFERENCES
           ? { chatGptAccountLabel: 'harness@example.edu' }
           : {}),
         grokSignedIn: false,
-        kimiCodeKeySet: true,
-        glmKeySet: true,
       }
     : undefined;
 const HARNESS_ORCHESTRATION_ITEMS = buildCliOrchestrationItems({

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -29,8 +29,6 @@ export interface CliCodingPlanStatus {
 interface CliSubscriptionPreferences {
   readonly chatGpt: CliSubscriptionPreferenceState;
   readonly grok: CliSubscriptionPreferenceState;
-  readonly kimiCode: CliSubscriptionPreferenceState;
-  readonly glmCode: CliSubscriptionPreferenceState;
 }
 
 export type CliModelAccessSelection =
@@ -68,12 +66,7 @@ export interface CliModelAccessStatus {
   readonly chatGptAccountLabel?: string;
   readonly grokSignedIn: boolean;
   readonly grokAccountLabel?: string;
-  readonly kimiCodeKeySet?: boolean;
-  readonly glmKeySet?: boolean;
-  /** Canonical coding-plan state. The named fields remain temporarily for
-   * callers predating this map (introduced 2026-08-12); remove them once all
-   * callers construct `codingPlans`, no later than 2026-11-12. */
-  readonly codingPlans?: Readonly<
+  readonly codingPlans: Readonly<
     Record<CodingPlanSubscriptionId, CliCodingPlanStatus>
   >;
   readonly texraSignedIn?: boolean;
@@ -290,22 +283,12 @@ function formatCliKeyedSubscriptionPreference(
     : 'Off · key required to enable';
 }
 
-/** Read one plan from the canonical status map, with named-field fallback. */
+/** Read one plan from the canonical status map. */
 export function cliCodingPlanStatus(
   status: CliModelAccessStatus,
   plan: CodingPlanSubscription,
 ): CliCodingPlanStatus {
-  const canonical = status.codingPlans?.[plan.id];
-  if (canonical) return canonical;
-  return plan.id === 'kimiCode'
-    ? {
-        preferred: status.preferences.kimiCode === 'on',
-        keySet: status.kimiCodeKeySet === true,
-      }
-    : {
-        preferred: status.preferences.glmCode === 'on',
-        keySet: status.glmKeySet === true,
-      };
+  return status.codingPlans[plan.id];
 }
 
 /** Format any catalogued coding-plan preference. */

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -80,14 +80,12 @@ export async function readCliModelAccessStatus(
         ),
       ),
     ]);
-  const codingPlans = Object.fromEntries(codingPlanEntries) as NonNullable<
-    CliModelAccessStatus['codingPlans']
-  >;
+  const codingPlans = Object.fromEntries(
+    codingPlanEntries,
+  ) as CliModelAccessStatus['codingPlans'];
   const preferences = {
     chatGpt: isPreferCodexSubscription() ? 'on' : 'off',
     grok: isPreferXaiSubscription() ? 'on' : 'off',
-    kimiCode: codingPlans.kimiCode.preferred ? 'on' : 'off',
-    glmCode: codingPlans.glmCodingPlan.preferred ? 'on' : 'off',
   } as const;
   const personalKeyProviders = configuredProviders.map((provider) =>
     providerDisplayName(provider),
@@ -99,8 +97,6 @@ export async function readCliModelAccessStatus(
     chatGptAccountLabel: chatGpt.email ?? chatGpt.accountId,
     grokSignedIn: grok.signedIn,
     grokAccountLabel: grok.email,
-    kimiCodeKeySet: codingPlans.kimiCode.keySet,
-    glmKeySet: codingPlans.glmCodingPlan.keySet,
     codingPlans,
     personalKeyProviders,
   };

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.ts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.ts
@@ -82,6 +82,18 @@ function setPersonalKeys(...providers: string[]): void {
   );
 }
 
+function codingPlans(
+  kimiPreferred = false,
+  kimiKeySet = false,
+  glmPreferred = false,
+  glmKeySet = false,
+) {
+  return {
+    kimiCode: { preferred: kimiPreferred, keySet: kimiKeySet },
+    glmCodingPlan: { preferred: glmPreferred, keySet: glmKeySet },
+  };
+}
+
 /** Model-access status with the included fallback and every route off. */
 function useIncludedAccessStatus(): void {
   mocks.readCliModelAccessStatus.mockResolvedValue({
@@ -89,13 +101,10 @@ function useIncludedAccessStatus(): void {
     preferences: {
       chatGpt: 'off',
       grok: 'off',
-      kimiCode: 'off',
-      glmCode: 'off',
     },
+    codingPlans: codingPlans(),
     chatGptSignedIn: false,
     grokSignedIn: false,
-    kimiCodeKeySet: false,
-    glmKeySet: false,
   });
 }
 
@@ -115,15 +124,17 @@ function renderPreferenceRoute(
     preferences: {
       chatGpt: route === 'chatGpt' ? preference : 'off',
       grok: 'off',
-      kimiCode: route === 'kimiCode' ? preference : 'off',
-      glmCode: route === 'glmCode' ? preference : 'off',
     },
+    codingPlans: codingPlans(
+      route === 'kimiCode' && preference === 'on',
+      route === 'kimiCode' && enabled,
+      route === 'glmCode' && preference === 'on',
+      route === 'glmCode' && enabled,
+    ),
     chatGptSignedIn: route === 'chatGpt' && enabled,
     grokSignedIn: false,
     chatGptAccountLabel:
       route === 'chatGpt' && enabled ? 'chatgpt@example.com' : undefined,
-    kimiCodeKeySet: route === 'kimiCode' && enabled,
-    glmKeySet: route === 'glmCode' && enabled,
   });
   return accountStatusLines('personal');
 }
@@ -144,13 +155,10 @@ describe('loadCliApiStatus', () => {
       preferences: {
         chatGpt: 'off',
         grok: 'off',
-        kimiCode: 'off',
-        glmCode: 'off',
       },
+      codingPlans: codingPlans(),
       chatGptSignedIn: false,
       grokSignedIn: false,
-      kimiCodeKeySet: false,
-      glmKeySet: false,
     });
     mocks.lookupApiKeyOrigin.mockReset().mockResolvedValue('none');
     mocks.getSubscriptionUsage
@@ -264,14 +272,11 @@ describe('loadCliApiStatus', () => {
       preferences: {
         chatGpt: 'on',
         grok: 'off',
-        kimiCode: 'on',
-        glmCode: 'off',
       },
+      codingPlans: codingPlans(true, true),
       chatGptSignedIn: true,
       grokSignedIn: false,
       chatGptAccountLabel: 'chatgpt@example.com',
-      kimiCodeKeySet: true,
-      glmKeySet: false,
     });
     mocks.getCliAuthProfile.mockResolvedValue({
       authenticated: true,
@@ -312,13 +317,10 @@ describe('loadCliApiStatus', () => {
       preferences: {
         chatGpt: 'off',
         grok: 'off',
-        kimiCode: 'on',
-        glmCode: 'on',
       },
+      codingPlans: codingPlans(true, true, true, true),
       chatGptSignedIn: false,
       grokSignedIn: false,
-      kimiCodeKeySet: true,
-      glmKeySet: true,
     });
     mocks.getSubscriptionUsage.mockImplementation(async (provider: string) => {
       if (provider === 'glmCodingPlan') {
@@ -507,13 +509,10 @@ describe('loadCliApiStatus', () => {
       preferences: {
         chatGpt: 'off',
         grok: 'off',
-        kimiCode: 'off',
-        glmCode: 'off',
       },
+      codingPlans: codingPlans(false, false, false, true),
       chatGptSignedIn: false,
       grokSignedIn: false,
-      kimiCodeKeySet: false,
-      glmKeySet: true,
     });
     setPersonalKeys('glm');
 
@@ -626,14 +625,11 @@ describe('loadCliApiStatus', () => {
       preferences: {
         chatGpt: 'on',
         grok: 'off',
-        kimiCode: 'off',
-        glmCode: 'off',
       },
+      codingPlans: codingPlans(),
       chatGptSignedIn: true,
       grokSignedIn: false,
       chatGptAccountLabel: 'chatgpt@example.com',
-      kimiCodeKeySet: false,
-      glmKeySet: false,
     });
     mocks.getCliAuthProfile.mockResolvedValue({
       authenticated: true,
@@ -649,14 +645,11 @@ describe('loadCliApiStatus', () => {
         preferences: {
           chatGpt: 'on',
           grok: 'off',
-          kimiCode: 'off',
-          glmCode: 'off',
         },
+        codingPlans: codingPlans(),
         chatGptSignedIn: true,
         grokSignedIn: false,
         chatGptAccountLabel: 'chatgpt@example.com',
-        kimiCodeKeySet: false,
-        glmKeySet: false,
         texraSignedIn: true,
       },
       lines: [

--- a/src/test-kernel/cli/ModelAccessForm.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessForm.vitest.ts
@@ -90,13 +90,14 @@ describe('ModelAccessForm status', () => {
         preferences: {
           chatGpt: 'on',
           grok: 'off',
-          kimiCode: 'on',
-          glmCode: 'off',
+        },
+        codingPlans: {
+          kimiCode: { preferred: true, keySet: true },
+          glmCodingPlan: { preferred: false, keySet: false },
         },
         chatGptSignedIn: true,
         grokSignedIn: false,
         chatGptAccountLabel: 'user@example.com',
-        kimiCodeKeySet: true,
         texraSignedIn: true,
       },
       lines: [],

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.ts
@@ -142,33 +142,34 @@ function subscriptionPreference(
   return { kind: 'subscription-preference', provider, state } as const;
 }
 
-function expectedAccessStatus(overrides: Record<string, unknown>) {
-  const status = {
+function expectedAccessStatus(
+  overrides: Record<string, unknown>,
+  plans: {
+    kimiPreferred?: boolean;
+    kimiKeySet?: boolean;
+    glmPreferred?: boolean;
+    glmKeySet?: boolean;
+  } = {},
+) {
+  return {
     preferences: {
       chatGpt: 'off',
       grok: 'off',
-      kimiCode: 'off',
-      glmCode: 'off',
     },
     chatGptSignedIn: false,
     chatGptAccountLabel: undefined,
     grokSignedIn: false,
     grokAccountLabel: undefined,
-    kimiCodeKeySet: false,
-    glmKeySet: false,
     personalKeyProviders: [],
     ...overrides,
-  };
-  return {
-    ...status,
     codingPlans: {
       glmCodingPlan: {
-        preferred: status.preferences.glmCode === 'on',
-        keySet: status.glmKeySet === true,
+        preferred: plans.glmPreferred ?? false,
+        keySet: plans.glmKeySet ?? false,
       },
       kimiCode: {
-        preferred: status.preferences.kimiCode === 'on',
-        keySet: status.kimiCodeKeySet === true,
+        preferred: plans.kimiPreferred ?? false,
+        keySet: plans.kimiKeySet ?? false,
       },
     },
   };
@@ -364,8 +365,6 @@ describe('CLI model access routes', () => {
         preferences: {
           chatGpt: 'on',
           grok: 'off',
-          kimiCode: 'off',
-          glmCode: 'off',
         },
         chatGptSignedIn: true,
         chatGptAccountLabel: 'user@example.com',
@@ -379,8 +378,6 @@ describe('CLI model access routes', () => {
         preferences: {
           chatGpt: 'on',
           grok: 'off',
-          kimiCode: 'off',
-          glmCode: 'off',
         },
       }),
     );
@@ -393,29 +390,27 @@ describe('CLI model access routes', () => {
     mocks.getPreferKimiCode.mockReturnValue(true);
 
     await expect(readCliModelAccessStatus('personal')).resolves.toEqual(
-      expectedAccessStatus({
-        apiFallback: 'personal',
-        preferences: {
-          chatGpt: 'off',
-          grok: 'off',
-          kimiCode: 'on',
-          glmCode: 'off',
+      expectedAccessStatus(
+        {
+          apiFallback: 'personal',
+          preferences: {
+            chatGpt: 'off',
+            grok: 'off',
+          },
         },
-        kimiCodeKeySet: true,
-      }),
+        { kimiPreferred: true, kimiKeySet: true },
+      ),
     );
 
     await expect(readCliModelAccessStatus('included')).resolves.toMatchObject({
       apiFallback: 'included',
-      preferences: { chatGpt: 'off', grok: 'off', kimiCode: 'on' },
-      kimiCodeKeySet: true,
+      codingPlans: { kimiCode: { preferred: true, keySet: true } },
     });
 
     mocks.apiKeyExists.mockResolvedValue(false);
     await expect(readCliModelAccessStatus('personal')).resolves.toMatchObject({
       apiFallback: 'personal',
-      preferences: { chatGpt: 'off', grok: 'off', kimiCode: 'on' },
-      kimiCodeKeySet: false,
+      codingPlans: { kimiCode: { preferred: true, keySet: false } },
     });
   });
 
@@ -493,27 +488,21 @@ describe('CLI model access routes', () => {
     mocks.getGLMCodingPlan.mockReturnValue(true);
 
     await expect(readCliModelAccessStatus('personal')).resolves.toEqual(
-      expectedAccessStatus({
-        apiFallback: 'personal',
-        preferences: {
-          chatGpt: 'off',
-          grok: 'off',
-          kimiCode: 'off',
-          glmCode: 'on',
+      expectedAccessStatus(
+        {
+          apiFallback: 'personal',
+          preferences: {
+            chatGpt: 'off',
+            grok: 'off',
+          },
         },
-        glmKeySet: true,
-      }),
+        { glmPreferred: true, glmKeySet: true },
+      ),
     );
 
     await expect(readCliModelAccessStatus('included')).resolves.toMatchObject({
       apiFallback: 'included',
-      preferences: {
-        chatGpt: 'off',
-        grok: 'off',
-        kimiCode: 'off',
-        glmCode: 'on',
-      },
-      glmKeySet: true,
+      codingPlans: { glmCodingPlan: { preferred: true, keySet: true } },
     });
   });
 
@@ -690,8 +679,6 @@ describe('CLI model access routes', () => {
     expect(status.preferences).toEqual({
       chatGpt: 'on',
       grok: 'off',
-      kimiCode: 'on',
-      glmCode: 'off',
     });
     const descriptions = Object.fromEntries(
       buildCliModelAccessItems({ kind: 'loaded', access: status })

--- a/src/test-kernel/cli/Orchestration.vitest.ts
+++ b/src/test-kernel/cli/Orchestration.vitest.ts
@@ -38,6 +38,18 @@ import { planTeamRun } from '@common/teams/TeamPlan';
 import type { ExecutionId } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
 
+function codingPlans(
+  kimiPreferred = false,
+  kimiKeySet = false,
+  glmPreferred = false,
+  glmKeySet = false,
+): CliModelAccessStatus['codingPlans'] {
+  return {
+    kimiCode: { preferred: kimiPreferred, keySet: kimiKeySet },
+    glmCodingPlan: { preferred: glmPreferred, keySet: glmKeySet },
+  };
+}
+
 function historyEntry(
   id: string,
   overrides: Partial<CliHistoryEntry> = {},
@@ -369,9 +381,8 @@ describe('CLI orchestration items', () => {
       preferences: {
         chatGpt: 'off',
         grok: 'off',
-        kimiCode: 'off',
-        glmCode: 'off',
       } as const,
+      codingPlans: codingPlans(),
       chatGptSignedIn: true,
       grokSignedIn: false,
       chatGptAccountLabel: 'researcher@example.com',
@@ -442,12 +453,10 @@ describe('CLI orchestration items', () => {
       preferences: {
         chatGpt: 'off',
         grok: 'off',
-        kimiCode: 'off',
-        glmCode: 'off',
       },
+      codingPlans: codingPlans(false, true),
       chatGptSignedIn: false,
       grokSignedIn: false,
-      kimiCodeKeySet: true,
     });
     expect(kimiOff).toEqual({
       value: {
@@ -464,12 +473,10 @@ describe('CLI orchestration items', () => {
       preferences: {
         chatGpt: 'off',
         grok: 'off',
-        kimiCode: 'on',
-        glmCode: 'off',
       },
+      codingPlans: codingPlans(true, true),
       chatGptSignedIn: false,
       grokSignedIn: false,
-      kimiCodeKeySet: true,
     };
     expect(kimiCodePreferenceItem(kimiOnAccess)?.description).toBe(
       'On · key configured',
@@ -491,13 +498,11 @@ describe('CLI orchestration items', () => {
         preferences: {
           chatGpt: 'on',
           grok: 'off',
-          kimiCode: 'on',
-          glmCode: 'off',
         },
+        codingPlans: codingPlans(true, true),
         chatGptSignedIn: true,
         grokSignedIn: false,
         chatGptAccountLabel: 'researcher@example.com',
-        kimiCodeKeySet: true,
       },
     });
     const byProvider = Object.fromEntries(
@@ -596,9 +601,8 @@ describe('CLI orchestration items', () => {
           preferences: {
             chatGpt: 'off',
             grok: 'off',
-            kimiCode: 'off',
-            glmCode: 'off',
           },
+          codingPlans: codingPlans(),
           chatGptSignedIn: false,
           grokSignedIn: false,
           texraSignedIn: false,

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -77,8 +77,10 @@ function mockModelAccessOverview(): void {
       preferences: {
         chatGpt: 'off',
         grok: 'off',
-        kimiCode: 'off',
-        glmCode: 'off',
+      },
+      codingPlans: {
+        kimiCode: { preferred: false, keySet: false },
+        glmCodingPlan: { preferred: false, keySet: false },
       },
       chatGptSignedIn: false,
       grokSignedIn: false,


### PR DESCRIPTION
## Summary

- make the canonical coding-plan status map required
- remove the duplicate named preference/key fields and their fallback branch
- migrate all CLI status fixtures and the TUI scripts harness to the sole representation

Net change: 34 lines removed. No behavior change. The status object is an internal, non-persisted value; all constructors now use the current shape.

## Verification

- 154 focused CLI tests
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `npm run typecheck:cli`
- ESLint on all changed files
- `orchestrate-independent-subscription-preferences` TUI harness scenario passes

Closes #10047.