### PR TITLE
fix(cli): order interrupted-run artifact release

### DIFF
--- a/packages/cli/src/commands/resumeExecution.ts
+++ b/packages/cli/src/commands/resumeExecution.ts
@@ -27,6 +27,13 @@ function loadFailureMessage(id: ExecutionId, error: unknown): string {
   return `Could not load session ${id}: ${toErrorMessage(error)}`;
 }
 
+function leaseInspectionFailureMessage(
+  id: ExecutionId,
+  error: unknown,
+): string {
+  return `Could not check whether execution ${id} is active: ${toErrorMessage(error)}`;
+}
+
 function activeExecutionMessage(id: ExecutionId): string {
   return `Execution ${id} is active in TeXRA.`;
 }
@@ -63,7 +70,7 @@ export async function runResumeExecution(
       return CliExitCode.Usage;
     }
   } catch (error) {
-    writeTextStderr(loadFailureMessage(id, error));
+    writeTextStderr(leaseInspectionFailureMessage(id, error));
     return CliExitCode.AgentError;
   }
   // FK-first: the stream id stamped at registration is the reproduction

--- a/packages/cli/src/runtime/executionFinalization.ts
+++ b/packages/cli/src/runtime/executionFinalization.ts
@@ -65,8 +65,9 @@ export async function finalizeCliExecution(
 
 /**
  * Drain a CLI session's artifacts before releasing its execution lease.
- * Keeping this operation beside CLI finalization gives the host one local
- * boundary for the terminal durability sequence.
+ * This host-local seam lets CLI lifecycle tests replace the release operation
+ * without mocking the public agent-runtime barrel, which would replace every
+ * runtime export consumed by the same test module.
  */
 export function releaseCliExecutionLeaseAfterArtifacts(
   session: SessionHandle,

--- a/packages/cli/src/runtime/executionFinalization.ts
+++ b/packages/cli/src/runtime/executionFinalization.ts
@@ -1,3 +1,7 @@
+import {
+  releaseExecutionLeaseAfterArtifacts,
+  type SessionHandle,
+} from '@agent/runtime';
 import { finalizeExecution, type FinalizeExecutionInput } from '@agent/storage';
 import { markOwnedExecutionLeaseUndurable } from '@agent/storage/executionLease';
 import type { RunOutcome } from '@shared/schemas';
@@ -57,4 +61,16 @@ export async function finalizeCliExecution(
 
   const message = finalizationFailureMessage(result, executionId, outcome);
   reportFailure(new Error(message, { cause: result.error }));
+}
+
+/**
+ * Drain a CLI session's artifacts before releasing its execution lease.
+ * Keeping this operation beside CLI finalization gives the host one local
+ * boundary for the terminal durability sequence.
+ */
+export function releaseCliExecutionLeaseAfterArtifacts(
+  session: SessionHandle,
+  executionId: FinalizeExecutionInput['executionId'],
+): Promise<void> {
+  return releaseExecutionLeaseAfterArtifacts(session, executionId);
 }

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -75,6 +75,8 @@ export interface CliHistoryDetails {
   readonly conversationPreview: CliHistoryConversationPreview | null;
   readonly conversation?: CliHistoryConversationPreview | null;
   readonly files: readonly CliHistoryFile[];
+  /** Whether category-specific validation found a usable resume checkpoint. */
+  /** Whether a category-valid flow record is available for resumption. */
   readonly hasFlowRecord: boolean;
   readonly currentModel?: string;
 }

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -75,7 +75,6 @@ export interface CliHistoryDetails {
   readonly conversationPreview: CliHistoryConversationPreview | null;
   readonly conversation?: CliHistoryConversationPreview | null;
   readonly files: readonly CliHistoryFile[];
-  /** Whether category-specific validation found a usable resume checkpoint. */
   /** Whether a category-valid flow record is available for resumption. */
   readonly hasFlowRecord: boolean;
   readonly currentModel?: string;

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -391,6 +391,7 @@ export async function executeCliRequest(
   let runResult:
     | { readonly ok: true; readonly result: ExecuteAgentResult }
     | { readonly ok: false } = { ok: false };
+  let primaryRunFailure: { readonly error: unknown } | undefined;
   let presentationAttached = true;
   const detachPresentation = async (): Promise<void> => {
     if (!presentationAttached) return;
@@ -412,29 +413,54 @@ export async function executeCliRequest(
     // workspaceState.update failures) is unexpected and must keep
     // propagating to bin/texra.ts's crash handler.
     if (!(err instanceof AgentError)) {
-      throw err;
-    }
-    // A failure before lifecycle startup has no `result` event. Preserve the
-    // ordinary toast path when it ran, and provide the missing direct fallback
-    // while the presentation host is still attached.
-    if (!failurePresented && !terminalResult.isHandled()) {
+      primaryRunFailure = { error: err };
+    } else if (!failurePresented && !terminalResult.isHandled()) {
+      // A failure before lifecycle startup has no `result` event. Preserve the
+      // ordinary toast path when it ran, and provide the missing direct fallback
+      // while the presentation host is still attached.
       session.interactions.emit('requestShowError', {
         message: toErrorMessage(err),
       });
     }
+  }
+
+  disposeShutdownStatus?.dispose();
+  let finalizationCompleted = false;
+  const cleanupFailures: unknown[] = [];
+  try {
+    await finalizeShutdownStatus();
+    await session.flushArtifacts();
+    finalizationCompleted = true;
+  } catch (error) {
+    cleanupFailures.push(error);
   } finally {
-    disposeShutdownStatus?.dispose();
-    let finalizationCompleted = false;
-    try {
-      await finalizeShutdownStatus();
-      await session.flushArtifacts();
-      finalizationCompleted = true;
-    } finally {
-      settleShutdownFinalization();
-      if (!runResult.ok || !finalizationCompleted) {
+    settleShutdownFinalization();
+    if (!runResult.ok || !finalizationCompleted) {
+      try {
         await detachPresentation();
+      } catch (error) {
+        cleanupFailures.push(error);
       }
     }
+  }
+  if (cleanupFailures.length > 0) {
+    const cleanupFailure =
+      cleanupFailures.length === 1
+        ? cleanupFailures[0]
+        : new AggregateError(
+            cleanupFailures,
+            'CLI execution cleanup encountered multiple failures',
+          );
+    if (primaryRunFailure) {
+      throw new AggregateError(
+        [primaryRunFailure.error, cleanupFailure],
+        'CLI execution failed and its final artifacts could not be persisted',
+      );
+    }
+    throw cleanupFailure;
+  }
+  if (primaryRunFailure) {
+    throw primaryRunFailure.error;
   }
 
   if (!runResult.ok) {

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -1,10 +1,10 @@
 import {
   attachTerminalResultToast,
+  releaseExecutionLeaseAfterArtifacts,
   runAgent,
   trackTerminalResultPresentation,
   type RunAgentOptions,
 } from '@agent/runtime';
-import { releaseExecutionLeaseAfterArtifacts } from '@agent/runtime/executionOwnership';
 import {
   ExecutionLeaseLostError,
   type OwnedExecutionLeaseScope,

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -284,11 +284,10 @@ export async function executeCliRequest(
         });
         return true;
       } catch (error) {
-        // The runtime's ordinary artifact drain owns failure reporting and
-        // aggregation with any primary run error. A host-side drain failure
-        // may already have abandoned the lease; returning false asks the
-        // runtime to make its best effort without letting this memoized hook
-        // replace the primary error when the CLI awaits it again on shutdown.
+        // Record the original drain failure for the one-shot runtime adapter
+        // below, which rethrows it into runAgent's artifact aggregate. This
+        // memoized operation itself resolves false so the outer shutdown await
+        // cannot rethrow the same error over the primary run failure.
         if (!(error instanceof ExecutionLeaseLostError)) {
           shutdownArtifactFailure = error;
         }

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -4,7 +4,10 @@ import {
   trackTerminalResultPresentation,
   type RunAgentOptions,
 } from '@agent/runtime';
-import type { OwnedExecutionLeaseScope } from '@agent/storage/executionLease';
+import {
+  ExecutionLeaseLostError,
+  type OwnedExecutionLeaseScope,
+} from '@agent/storage/executionLease';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import {
   validateExecutionRequest,
@@ -238,6 +241,7 @@ export async function executeCliRequest(
     : () => undefined;
   let ownedExecutionId: ExecutionId | undefined;
   let shutdownInterrupted = false;
+  let shutdownArtifactFailure: unknown;
   let shutdownFinalizationFailureReported = false;
   const reportFinalizationFailure = (error: unknown): void => {
     session.interactions.emit('requestShowError', {
@@ -279,12 +283,15 @@ export async function executeCliRequest(
           await releaseCliExecutionLeaseAfterArtifacts(session, executionId);
         });
         return true;
-      } catch {
+      } catch (error) {
         // The runtime's ordinary artifact drain owns failure reporting and
         // aggregation with any primary run error. A host-side drain failure
         // may already have abandoned the lease; returning false asks the
         // runtime to make its best effort without letting this memoized hook
         // replace the primary error when the CLI awaits it again on shutdown.
+        if (!(error instanceof ExecutionLeaseLostError)) {
+          shutdownArtifactFailure = error;
+        }
         return false;
       }
     })();
@@ -294,6 +301,9 @@ export async function executeCliRequest(
     SHUTDOWN_PHASE.BEFORE,
     async () => {
       shutdownInterrupted = true;
+      if (ownedExecutionId) {
+        session.executions.kill(ownedExecutionId);
+      }
       // Earlier shutdown handlers interrupt the live agent sessions. Wait for
       // runAgent to finish unwinding before the final drain releases ownership,
       // so no transcript or checkpoint writer can race the lease release.
@@ -308,10 +318,25 @@ export async function executeCliRequest(
         registerExecution: options.registerExecution,
         openWorkflowOutput: options.openWorkflowOutput,
         modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
-        beforeLeaseRelease: finalizeShutdownStatus,
+        beforeLeaseRelease: async () => {
+          const handled = await finalizeShutdownStatus();
+          if (shutdownArtifactFailure !== undefined) {
+            const error = shutdownArtifactFailure;
+            shutdownArtifactFailure = undefined;
+            throw error;
+          }
+          return handled;
+        },
         onExecutionLeaseAcquired: (runWithOwnership, executionId) => {
           ownedExecutionId = executionId;
           settleLeaseScope(runWithOwnership);
+        },
+        onRun: () => {
+          // Acquisition precedes registry tracking. If shutdown landed in
+          // between, interrupt as soon as the canonical handle becomes live.
+          if (shutdownInterrupted && ownedExecutionId) {
+            session.executions.kill(ownedExecutionId);
+          }
         },
         stopAfterCycle: options.stopAfterCycle,
         approvalPromptsUnavailable: cliApprovalPromptsUnavailable(

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -4,8 +4,8 @@ import {
   trackTerminalResultPresentation,
   type RunAgentOptions,
 } from '@agent/runtime';
+import { releaseExecutionLeaseAfterArtifacts } from '@agent/runtime/executionOwnership';
 import {
-  completeOwnedExecutionLease,
   ExecutionLeaseLostError,
   type OwnedExecutionLeaseScope,
 } from '@agent/storage/executionLease';
@@ -258,13 +258,13 @@ export async function executeCliRequest(
       settleLeaseScope = resolve;
     },
   );
-  let shutdownStatusFinalized: Promise<void> | undefined;
-  const finalizeShutdownStatus = (): Promise<void> => {
-    if (!shutdownInterrupted) return Promise.resolve();
+  let shutdownStatusFinalized: Promise<boolean> | undefined;
+  const finalizeShutdownStatus = (): Promise<boolean> => {
+    if (!shutdownInterrupted) return Promise.resolve(false);
     shutdownStatusFinalized ??= (async () => {
       const runWithOwnership = await leaseScopeReady;
       const executionId = ownedExecutionId;
-      if (!runWithOwnership || !executionId) return;
+      if (!runWithOwnership || !executionId) return false;
       try {
         await runWithOwnership(async () => {
           await finalizeCliExecution(
@@ -273,10 +273,12 @@ export async function executeCliRequest(
             'preserve',
             reportShutdownFinalizationFailure,
           );
-          await completeOwnedExecutionLease(executionId);
+          await releaseExecutionLeaseAfterArtifacts(session, executionId);
         });
+        return true;
       } catch (error) {
         if (!(error instanceof ExecutionLeaseLostError)) throw error;
+        return false;
       }
     })();
     return shutdownStatusFinalized;

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -4,10 +4,7 @@ import {
   trackTerminalResultPresentation,
   type RunAgentOptions,
 } from '@agent/runtime';
-import {
-  ExecutionLeaseLostError,
-  type OwnedExecutionLeaseScope,
-} from '@agent/storage/executionLease';
+import type { OwnedExecutionLeaseScope } from '@agent/storage/executionLease';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import {
   validateExecutionRequest,
@@ -278,8 +275,12 @@ export async function executeCliRequest(
           await releaseCliExecutionLeaseAfterArtifacts(session, executionId);
         });
         return true;
-      } catch (error) {
-        if (!(error instanceof ExecutionLeaseLostError)) throw error;
+      } catch {
+        // The runtime's ordinary artifact drain owns failure reporting and
+        // aggregation with any primary run error. A host-side drain failure
+        // may already have abandoned the lease; returning false asks the
+        // runtime to make its best effort without letting this memoized hook
+        // replace the primary error when the CLI awaits it again on shutdown.
         return false;
       }
     })();

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -257,6 +257,10 @@ export async function executeCliRequest(
       settleLeaseScope = resolve;
     },
   );
+  let settleShutdownFinalization: () => void = () => undefined;
+  const shutdownFinalizationDone = new Promise<void>((resolve) => {
+    settleShutdownFinalization = resolve;
+  });
   let shutdownStatusFinalized: Promise<boolean> | undefined;
   const finalizeShutdownStatus = (): Promise<boolean> => {
     if (!shutdownInterrupted) return Promise.resolve(false);
@@ -290,7 +294,10 @@ export async function executeCliRequest(
     SHUTDOWN_PHASE.BEFORE,
     async () => {
       shutdownInterrupted = true;
-      await finalizeShutdownStatus();
+      // Earlier shutdown handlers interrupt the live agent sessions. Wait for
+      // runAgent to finish unwinding before the final drain releases ownership,
+      // so no transcript or checkpoint writer can race the lease release.
+      await shutdownFinalizationDone;
     },
   );
   const invoke = async (): Promise<ExecuteAgentResult> => {
@@ -367,6 +374,7 @@ export async function executeCliRequest(
       await session.flushArtifacts();
       finalizationCompleted = true;
     } finally {
+      settleShutdownFinalization();
       if (!runResult.ok || !finalizationCompleted) {
         await detachPresentation();
       }

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -1,6 +1,5 @@
 import {
   attachTerminalResultToast,
-  releaseExecutionLeaseAfterArtifacts,
   runAgent,
   trackTerminalResultPresentation,
   type RunAgentOptions,
@@ -24,7 +23,10 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { warnApprovalDenied } from './approval/approvalPrompts';
 import { cliApprovalPromptsUnavailable } from './approval/settleApprovals';
 import { createHeadlessCliHostInteractions } from './approvalAdapter';
-import { finalizeCliExecution } from './executionFinalization';
+import {
+  finalizeCliExecution,
+  releaseCliExecutionLeaseAfterArtifacts,
+} from './executionFinalization';
 import { attachCliSessionProgressProjection } from './sessionProgressSubscription';
 import { initializeHeadlessTranscriptSession } from './transcriptSession';
 import { createCliRuntimeHost } from './cliPresentationHost';
@@ -273,7 +275,7 @@ export async function executeCliRequest(
             'preserve',
             reportShutdownFinalizationFailure,
           );
-          await releaseExecutionLeaseAfterArtifacts(session, executionId);
+          await releaseCliExecutionLeaseAfterArtifacts(session, executionId);
         });
         return true;
       } catch (error) {

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -1,3 +1,5 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+
 import {
   attachTerminalResultToast,
   runAgent,
@@ -40,6 +42,8 @@ import {
 import { CLI_UNAVAILABLE_TOOLS } from './unavailableTools';
 import { attachWorkflowPlainOutput } from './workflowPlainOutput';
 import type { CliContext } from './cliContext';
+
+const CLI_RUN_SHUTDOWN_GRACE_MS = 5_000;
 
 interface CliExecuteOptions {
   /** Forwarded to `runAgent`. */
@@ -240,7 +244,10 @@ export async function executeCliRequest(
       })
     : () => undefined;
   let ownedExecutionId: ExecutionId | undefined;
+  const launchAbortController = new AbortController();
+  let shutdownRequested = false;
   let shutdownInterrupted = false;
+  let runLifecycleStarted = false;
   let shutdownArtifactFailure: unknown;
   let shutdownFinalizationFailureReported = false;
   const reportFinalizationFailure = (error: unknown): void => {
@@ -299,14 +306,33 @@ export async function executeCliRequest(
   const disposeShutdownStatus = tryPlatform()?.lifecycle.onShutdown(
     SHUTDOWN_PHASE.BEFORE,
     async () => {
-      shutdownInterrupted = true;
-      if (ownedExecutionId) {
-        session.executions.kill(ownedExecutionId);
-      }
+      shutdownRequested = true;
+      launchAbortController.abort();
+      const interruptionAccepted = ownedExecutionId
+        ? session.executions.kill(ownedExecutionId)
+        : false;
+      // Before lifecycle registration, the launch signal is the cancellation
+      // authority. Afterwards, only an accepted registry stop may replace the
+      // run's own terminal verdict with CANCELLED.
+      shutdownInterrupted =
+        !runLifecycleStarted || interruptionAccepted || shutdownInterrupted;
       // Earlier shutdown handlers interrupt the live agent sessions. Wait for
       // runAgent to finish unwinding before the final drain releases ownership,
-      // so no transcript or checkpoint writer can race the lease release.
-      await shutdownFinalizationDone;
+      // so no transcript or checkpoint writer can race the lease release. A
+      // provider or filesystem operation outside our abortable boundaries must
+      // not prevent signal termination indefinitely; on timeout, leave the
+      // lease intact for stale-owner recovery rather than releasing it early.
+      const grace = new AbortController();
+      try {
+        await Promise.race([
+          shutdownFinalizationDone,
+          sleep(CLI_RUN_SHUTDOWN_GRACE_MS, undefined, {
+            signal: grace.signal,
+          }),
+        ]);
+      } finally {
+        grace.abort();
+      }
     },
   );
   const invoke = async (): Promise<ExecuteAgentResult> => {
@@ -317,6 +343,7 @@ export async function executeCliRequest(
         registerExecution: options.registerExecution,
         openWorkflowOutput: options.openWorkflowOutput,
         modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
+        launchSignal: launchAbortController.signal,
         beforeLeaseRelease: async () => {
           const handled = await finalizeShutdownStatus();
           if (shutdownArtifactFailure !== undefined) {
@@ -329,12 +356,17 @@ export async function executeCliRequest(
         onExecutionLeaseAcquired: (runWithOwnership, executionId) => {
           ownedExecutionId = executionId;
           settleLeaseScope(runWithOwnership);
+          if (shutdownRequested && !runLifecycleStarted) {
+            shutdownInterrupted = true;
+          }
         },
         onRun: () => {
+          runLifecycleStarted = true;
           // Acquisition precedes registry tracking. If shutdown landed in
           // between, interrupt as soon as the canonical handle becomes live.
-          if (shutdownInterrupted && ownedExecutionId) {
-            session.executions.kill(ownedExecutionId);
+          if (shutdownRequested && ownedExecutionId) {
+            shutdownInterrupted =
+              session.executions.kill(ownedExecutionId) || shutdownInterrupted;
           }
         },
         stopAfterCycle: options.stopAfterCycle,

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -107,6 +107,8 @@ export interface AgentLaunchInput {
   modelHandlerCompatibilityKey?: ModelHandlerCompatibilityKey | null;
   /** Deliberate one-run bypass used only by a Copilot direct-key fallback. */
   copilotRouteOverride?: CopilotRouteOverride;
+  /** Cancel launch preparation and the resulting live run. */
+  signal?: AbortSignal;
 }
 
 const STATUS_MESSAGES: Record<string, string> = {
@@ -248,6 +250,7 @@ async function assembleAgentLaunchContext(
   streamId: StreamTabId,
   resources: AgentLaunchResources,
 ): Promise<AgentLaunchContext> {
+  input.signal?.throwIfAborted();
   const fullConfig = input.config;
   // Resolve by the source the delegation captured at validation time, so launch
   // lands on the exact entry validation/display resolved. When no source is
@@ -259,11 +262,13 @@ async function assembleAgentLaunchContext(
     fullConfig.agentCategory,
     fullConfig.agentSource,
   );
+  input.signal?.throwIfAborted();
   // `loadAgentSettingAndPrompts` already applies `ensureAgentCategoryForSource`
   // before parsing, and `AgentSettingSchema` prefaults `agentCategory` (to
   // Workflow when absent), so `setting.agentCategory` is always populated here —
   // a second `ensureAgentCategoryForSource` pass would be a guaranteed no-op.
   const [setting, prompt] = await loadAgentSettingAndPrompts(resolution);
+  input.signal?.throwIfAborted();
 
   // Block category mismatch: prevent launching a tool-use agent as a workflow
   // (or vice versa). Source-pinned resolution already guarantees launch lands on
@@ -287,6 +292,7 @@ async function assembleAgentLaunchContext(
   }
 
   const modelConfig = await validateModelExists(fullConfig.model, interactions);
+  input.signal?.throwIfAborted();
 
   const config: AgentConfig = {
     ...fullConfig,
@@ -300,6 +306,7 @@ async function assembleAgentLaunchContext(
   const modelHandlerCompatibilityKey =
     input.modelHandlerCompatibilityKey ??
     (await inferLaunchModelHandlerCompatibilityKey(executionId, config.model));
+  input.signal?.throwIfAborted();
   const modelHandler = resources.ownModelHandler(
     modelHandlerCompatibilityKey
       ? await createModelHandlerForCompatibilityKey(
@@ -313,12 +320,14 @@ async function assembleAgentLaunchContext(
           input.copilotRouteOverride,
         ),
   );
+  input.signal?.throwIfAborted();
   const modelCell = new ModelCell(modelHandler, config.model);
 
   const transcriptWriter = await session.transcripts.loadAndAcquireWriter(
     streamId,
     executionId,
   );
+  input.signal?.throwIfAborted();
   const rawRunTrace = createRunTrace(
     streamId,
     session.transcripts,
@@ -343,6 +352,7 @@ async function assembleAgentLaunchContext(
   modelHandler.setLogger(agentLogger);
 
   session.events.assertRunSubscribersAttachedBeforeActivation(streamId);
+  input.signal?.throwIfAborted();
   input.onBeforeActivation?.(streamId);
 
   session.events.emit({
@@ -403,6 +413,9 @@ async function assembleAgentLaunchContext(
   const agentPath = path.dirname(resolution.entry.path);
   const workingDirectory = config.workingDirectory?.trim() || undefined;
   const runAbortController = new AbortController();
+  const runSignal = input.signal
+    ? AbortSignal.any([input.signal, runAbortController.signal])
+    : runAbortController.signal;
   const runScope = createRunScope({
     streamId,
     executionId,
@@ -410,7 +423,7 @@ async function assembleAgentLaunchContext(
     workingDirectory,
     delegationAgentScope: fullConfig.delegationAgentScope,
     session,
-    signal: runAbortController.signal,
+    signal: runSignal,
   });
   const buildVars = () =>
     buildUserVars(
@@ -431,6 +444,7 @@ async function assembleAgentLaunchContext(
     setting.agentCategory === AgentCategory.ToolUse
       ? await buildVars()
       : await parentStage.child('Init').run(buildVars);
+  input.signal?.throwIfAborted();
 
   const userVarChannels: UserVariableChannels = {
     input: Object.freeze(baseVars),
@@ -564,6 +578,7 @@ function compensateFailedActivation(args: {
 export async function buildAgentLaunchContext(
   input: AgentLaunchInput,
 ): Promise<AgentLaunchContext> {
+  input.signal?.throwIfAborted();
   const { config } = input;
   const launchSession = input.session ?? currentSession();
   const interactions = launchSession.interactions;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -319,6 +319,8 @@ export interface SubagentRunOptions {
 
 /** Options for executeAgent. */
 export interface ExecuteAgentOptions extends SubagentRunOptions {
+  /** Cancel launch preparation before the per-run handle is available. */
+  launchSignal?: AbortSignal;
   /** Registration-stamped stream identity for a resumed workflow launch. */
   streamTabIdOverride?: StreamTabId;
   /** The caller owns presentation for failures before the run lifecycle. */
@@ -391,6 +393,7 @@ export async function executeAgent(
       session: options.session,
       modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
       copilotRouteOverride: options.copilotRouteOverride,
+      signal: options.launchSignal,
     });
     const runContextOptions = {
       approvalPromptsUnavailable: options.approvalPromptsUnavailable,
@@ -415,6 +418,7 @@ export async function executeAgent(
         runStreamId,
         config,
         runSession,
+        ctx.runScope.signal,
       );
       try {
         const result = await runFlowWithLifecycle(

--- a/src/agent/runtime/helperModel.ts
+++ b/src/agent/runtime/helperModel.ts
@@ -68,6 +68,8 @@ export interface HelperModelCompletion {
   systemPrompt?: string;
   /** Sampling temperature (defaults to 0 for deterministic helper calls). */
   temperature?: number;
+  /** Cancel this auxiliary request and its bounded retries. */
+  signal?: AbortSignal;
 }
 
 /**
@@ -81,8 +83,9 @@ export interface HelperModelCompletion {
  */
 export async function runHelperModelCompletion(
   kit: HelperModelKit,
-  { userPrompt, systemPrompt, temperature = 0 }: HelperModelCompletion,
+  { userPrompt, systemPrompt, temperature = 0, signal }: HelperModelCompletion,
 ): Promise<string> {
+  signal?.throwIfAborted();
   const messages = await kit.handler.initializeMessages(
     '',
     userPrompt,
@@ -91,13 +94,16 @@ export async function runHelperModelCompletion(
   );
   // Helper calls execute outside ModelInvocationNode, so they need their own
   // bounded retry policy now that generation clients disable SDK retries.
-  const result = await auxiliaryRetry(() =>
-    kit.handler.createResponse({
-      client: kit.client,
-      messages,
-      temperature,
-      systemPrompt,
-    }),
+  const result = await auxiliaryRetry(
+    () =>
+      kit.handler.createResponse({
+        client: kit.client,
+        messages,
+        temperature,
+        systemPrompt,
+        signal,
+      }),
+    signal,
   );
   return kit.handler.extractResponse(result.response, '').text;
 }

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -57,6 +57,7 @@ export type {
 // runAgent
 export { runAgent } from './runAgent';
 export type { RunAgentOptions } from './runAgent';
+export { releaseExecutionLeaseAfterArtifacts } from './executionOwnership';
 
 // SessionResumeRetrieval
 export { retrieveSessionResumeData } from './SessionResumeRetrieval';

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -47,6 +47,7 @@ export interface RunAgentOptions extends Pick<
   | 'onRun'
   | 'onStreamResolved'
   | 'onIdle'
+  | 'launchSignal'
 > {
   openWorkflowOutput?: (result: WorkflowFlowResult) => Promise<void>;
   /**

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -49,8 +49,11 @@ export interface RunAgentOptions extends Pick<
   | 'onIdle'
 > {
   openWorkflowOutput?: (result: WorkflowFlowResult) => Promise<void>;
-  /** Persist host-owned final artifacts while this run still owns its lease. */
-  beforeLeaseRelease?: () => Promise<void>;
+  /**
+   * Persist host-owned final state before the ordinary session drain. Return
+   * true when the hook already drained artifacts and disposed of ownership.
+   */
+  beforeLeaseRelease?: () => Promise<boolean | void>;
   /** Bind host callbacks that may run outside the agent's async context. */
   onExecutionLeaseAcquired?: (
     scope: OwnedExecutionLeaseScope,
@@ -137,6 +140,7 @@ export async function runAgent(
     let runResult: AgentFlowResult | undefined;
     let runFailure: { error: unknown } | undefined;
     let artifactsDurable = false;
+    let finalArtifactsHandled = false;
     let previousTerminalOutcome: RunOutcome | undefined;
     let resumedStreamId: StreamTabId | undefined;
     const callerOnRun = executeAgentOptions.onRun;
@@ -196,14 +200,16 @@ export async function runAgent(
 
       const artifactFailures: unknown[] = [];
       try {
-        await beforeLeaseRelease?.();
+        finalArtifactsHandled = (await beforeLeaseRelease?.()) === true;
       } catch (error) {
         artifactFailures.push(error);
       }
-      try {
-        await flushOwnedExecutionArtifacts(runSession, executionId);
-      } catch (error) {
-        artifactFailures.push(error);
+      if (!finalArtifactsHandled) {
+        try {
+          await flushOwnedExecutionArtifacts(runSession, executionId);
+        } catch (error) {
+          artifactFailures.push(error);
+        }
       }
       artifactsDurable = artifactFailures.length === 0;
 
@@ -229,9 +235,9 @@ export async function runAgent(
       }
       return runResult;
     } finally {
-      if (artifactsDurable) {
+      if (artifactsDurable && !finalArtifactsHandled) {
         await completeOwnedExecutionLease(executionId);
-      } else {
+      } else if (!artifactsDurable) {
         abandonOwnedExecutionLease(executionId);
       }
     }

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -205,6 +205,11 @@ export async function runAgent(
         artifactFailures.push(error);
       }
       if (!finalArtifactsHandled) {
+        // A failed host hook may already have abandoned ownership. Still try
+        // the ordinary drain: callbacks can also fail before touching session
+        // artifacts, and preserving those artifacts is worth the attempt. If
+        // ownership is gone, the resulting lease-lost error remains secondary
+        // to the host hook's original failure in the aggregate below.
         try {
           await flushOwnedExecutionArtifacts(runSession, executionId);
         } catch (error) {

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -103,12 +103,15 @@ export async function generateSessionDescription(
   streamId: StreamTabId,
   config: AgentConfig,
   session: SessionHandle,
+  signal?: AbortSignal,
 ): Promise<void> {
   try {
+    signal?.throwIfAborted();
     const instruction = getDisplayedInstruction(config);
     if (!instruction) return;
 
     const helperResult = await createHelperModelKit(session);
+    signal?.throwIfAborted();
     if (!helperResult.kit) {
       warnWithoutRejecting(helperResult.reason);
       return;
@@ -132,6 +135,7 @@ export async function generateSessionDescription(
     const text = await runHelperModelCompletion(helperResult.kit, {
       userPrompt,
       systemPrompt: SYSTEM_PROMPT,
+      signal,
     });
 
     if (!isNonEmptyString(text)) return;

--- a/src/test-kernel/agent/runtime/HelperModel.vitest.ts
+++ b/src/test-kernel/agent/runtime/HelperModel.vitest.ts
@@ -62,4 +62,24 @@ describe('helper model completion retries', () => {
     ).rejects.toBe(invalid);
     expect(createResponse).toHaveBeenCalledOnce();
   });
+
+  it('forwards cancellation to the provider request and retry policy', async () => {
+    const controller = new AbortController();
+    const createResponse = vi.fn(
+      async ({ signal }: { signal?: AbortSignal }) => {
+        expect(signal).toBe(controller.signal);
+        controller.abort();
+        signal?.throwIfAborted();
+        return { response: 'unreachable' };
+      },
+    );
+
+    await expect(
+      runHelperModelCompletion(createKit(createResponse), {
+        userPrompt: 'test',
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(createResponse).toHaveBeenCalledOnce();
+  });
 });

--- a/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
@@ -295,6 +295,25 @@ describe('runAgent execution ownership', () => {
     ]);
   });
 
+  it('does not drain artifacts again after the host disposed of ownership', async () => {
+    const order: string[] = [];
+    mocks.executeAgent.mockImplementationOnce(async () => {
+      order.push('execute');
+      return EXECUTE_RESULT;
+    });
+    await launch({
+      registerExecution: true,
+      beforeLeaseRelease: async () => {
+        order.push('host-artifacts-and-release');
+        return true;
+      },
+    });
+
+    expect(order).toEqual(['execute', 'host-artifacts-and-release']);
+    expect(flushArtifacts).not.toHaveBeenCalled();
+    expect(mocks.completeOwnedExecutionLease).not.toHaveBeenCalled();
+  });
+
   it('preserves run and final-artifact failures before releasing ownership', async () => {
     const runError = new Error('run failed');
     const artifactError = new Error('transcript flush failed');

--- a/src/test-kernel/cli/ResumeCommand.vitest.ts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.ts
@@ -277,6 +277,20 @@ describe('runResumeExecution', () => {
     }
   });
 
+  it('identifies lease inspection failures separately from session loading', async () => {
+    const executionLease = await import('@agent/storage/executionLease');
+    vi.spyOn(executionLease, 'inspectExecutionLease').mockRejectedValueOnce(
+      new Error('lease disk offline'),
+    );
+
+    await expect(run(cliContext())).resolves.toBe(1);
+
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      `Could not check whether execution ${EXECUTION_ID} is active: lease disk offline`,
+    );
+    expect(mocks.retrieveSessionResumeData).not.toHaveBeenCalled();
+  });
+
   it('reports empty retrieval as not resumable', async () => {
     mocks.retrieveSessionResumeData.mockResolvedValue(null);
 

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -159,6 +159,7 @@ function loadRunExecution(): Promise<
 type LeaseOptions = {
   beforeLeaseRelease?: () => Promise<boolean | void>;
   onRun?: () => void;
+  launchSignal?: AbortSignal;
   onExecutionLeaseAcquired?: (
     scope: (operation: () => unknown) => unknown,
     executionId: ExecutionId,
@@ -875,6 +876,61 @@ describe('executeCliRequest', () => {
     hangingRun.resolve(COMPLETED_RUN);
     await shutdown;
     await run;
+  });
+
+  it('cancels launch preparation when shutdown precedes run registration', async () => {
+    const { platform, executeCliRequest } = await installFakePlatform();
+    let launchSignal: AbortSignal | undefined;
+    mocks.runAgent.mockImplementationOnce(
+      async (_request: unknown, options: LeaseOptions) => {
+        launchSignal = options.launchSignal;
+        await new Promise<void>((_resolve, reject) => {
+          options.launchSignal?.addEventListener(
+            'abort',
+            () => reject(new AgentError('launch aborted')),
+            { once: true },
+          );
+        });
+        return COMPLETED_RUN;
+      },
+    );
+
+    const run = executeCliRequest(baseRequest(), cliContext(), {
+      registerExecution: true,
+    });
+    await vi.waitFor(() => expect(launchSignal).toBeDefined());
+
+    await platform.lifecycle.runShutdown();
+    await expect(run).rejects.toThrow('launch aborted');
+    expect(launchSignal?.aborted).toBe(true);
+    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
+  });
+
+  it('preserves a terminal outcome when shutdown cannot interrupt the finished run', async () => {
+    const { platform, executeCliRequest } = await installFakePlatform();
+    const { defaultSession } = await import('@agent/runtime/SessionHandle');
+    vi.spyOn(defaultSession().executions, 'kill').mockReturnValue(false);
+    let leaseOptions: LeaseOptions | undefined;
+    const hangingRun = stubHangingRun((options) => {
+      leaseOptions = options;
+    });
+    const run = executeCliRequest(baseRequest(), cliContext(), {
+      registerExecution: true,
+    });
+    await vi.waitFor(() => expect(leaseOptions).toBeDefined());
+    leaseOptions?.onExecutionLeaseAcquired?.(
+      (operation: () => unknown) => operation(),
+      'exec-1' as ExecutionId,
+    );
+    leaseOptions?.onRun?.();
+
+    const shutdown = platform.lifecycle.runShutdown();
+    hangingRun.resolve(COMPLETED_RUN);
+    await shutdown;
+    await run;
+
+    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
+    expect(mocks.releaseExecutionLeaseAfterArtifacts).not.toHaveBeenCalled();
   });
 
   it('does not finalize shutdown through a captured lease that is already lost', async () => {

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -83,8 +83,11 @@ vi.mock('@agent/runtime/runAgent', () => ({
   runAgent: mocks.runAgent,
 }));
 
-vi.mock('@agent/runtime/executionOwnership', () => ({
-  releaseExecutionLeaseAfterArtifacts:
+vi.mock('@cli/runtime/executionFinalization', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('@cli/runtime/executionFinalization')
+  >()),
+  releaseCliExecutionLeaseAfterArtifacts:
     mocks.releaseExecutionLeaseAfterArtifacts,
 }));
 

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -672,6 +672,28 @@ describe('executeCliRequest', () => {
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves a run failure when the final artifact flush also fails', async () => {
+    const { executeCliRequest } = await loadRunExecution();
+    const { flushSpy } = await spyOnTranscriptFlush();
+    const runError = new Error('provider transport failed');
+    const flushError = new Error('transcript flush failed');
+    mocks.runAgent.mockRejectedValueOnce(runError);
+    flushSpy.mockRejectedValueOnce(flushError);
+
+    const rejection = executeCliRequest(baseRequest(), cliContext()).catch(
+      (error: unknown) => error,
+    );
+
+    await expect(rejection).resolves.toEqual(
+      expect.objectContaining({
+        errors: [runError, flushError],
+        message:
+          'CLI execution failed and its final artifacts could not be persisted',
+      }),
+    );
+    expect(mocks.close).toHaveBeenCalledOnce();
+  });
+
   it('keeps a completed run terminal status when wrap cleanup fails after invoke succeeded (#7863)', async () => {
     const { executeCliRequest } = await loadRunExecution();
     const request = baseRequest();

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -834,6 +834,10 @@ describe('executeCliRequest', () => {
         outcome: RUN_OUTCOME.CANCELLED,
         flowRecord: 'preserve',
       });
+      expect(mocks.finalizeExecution.mock.invocationCallOrder[0]).toBeLessThan(
+        mocks.releaseExecutionLeaseAfterArtifacts.mock.invocationCallOrder[0] ??
+          Number.POSITIVE_INFINITY,
+      );
       await expect(run).resolves.toEqual({
         ok: true,
         result: {

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -157,6 +157,8 @@ function loadRunExecution(): Promise<
 }
 
 type LeaseOptions = {
+  beforeLeaseRelease?: () => Promise<boolean | void>;
+  onRun?: () => void;
   onExecutionLeaseAcquired?: (
     scope: (operation: () => unknown) => unknown,
     executionId: ExecutionId,
@@ -797,13 +799,17 @@ describe('executeCliRequest', () => {
     async ({ options }) => {
       const { platform, executeCliRequest } = await installFakePlatform();
       const { flushSpy } = await spyOnTranscriptFlush();
+      const { defaultSession } = await import('@agent/runtime/SessionHandle');
+      const killSpy = vi.spyOn(defaultSession().executions, 'kill');
       mocks.releaseExecutionLeaseAfterArtifacts.mockImplementationOnce(
         async (session, executionId) => session.flushArtifacts(executionId),
       );
       const runWithOwnership = vi.fn((operation: () => unknown) => operation());
       let publishLeaseScope: LeaseOptions['onExecutionLeaseAcquired'];
+      let publishRun: LeaseOptions['onRun'];
       const hangingRun = stubHangingRun((options) => {
         publishLeaseScope = options.onExecutionLeaseAcquired;
+        publishRun = options.onRun;
       });
 
       const run = executeCliRequest(baseRequest(), cliContext(), options);
@@ -812,7 +818,9 @@ describe('executeCliRequest', () => {
       await Promise.resolve();
       expect(mocks.finalizeExecution).not.toHaveBeenCalled();
       publishLeaseScope?.(runWithOwnership, 'exec-1' as ExecutionId);
+      publishRun?.();
       await Promise.resolve();
+      expect(killSpy).toHaveBeenCalledExactlyOnceWith('exec-1');
       expect(mocks.releaseExecutionLeaseAfterArtifacts).not.toHaveBeenCalled();
 
       mocks.readCliRunOutcome.mockResolvedValueOnce('cancelled');
@@ -838,6 +846,32 @@ describe('executeCliRequest', () => {
       expect(mocks.finalizeExecution).toHaveBeenCalledOnce();
     },
   );
+
+  it('forwards a failed shutdown drain to the runtime release hook', async () => {
+    const { platform, executeCliRequest } = await installFakePlatform();
+    const drainError = new Error('snapshot drain failed');
+    mocks.releaseExecutionLeaseAfterArtifacts.mockRejectedValueOnce(drainError);
+    const runWithOwnership = vi.fn((operation: () => unknown) => operation());
+    let leaseOptions: LeaseOptions | undefined;
+    const hangingRun = stubHangingRun((options) => {
+      leaseOptions = options;
+    });
+
+    const run = executeCliRequest(baseRequest(), cliContext(), {
+      registerExecution: true,
+    });
+    await vi.waitFor(() => expect(leaseOptions).toBeDefined());
+    leaseOptions?.onExecutionLeaseAcquired?.(
+      runWithOwnership,
+      'exec-1' as ExecutionId,
+    );
+    const shutdown = platform.lifecycle.runShutdown();
+
+    await expect(leaseOptions?.beforeLeaseRelease?.()).rejects.toBe(drainError);
+    hangingRun.resolve(COMPLETED_RUN);
+    await shutdown;
+    await run;
+  });
 
   it('does not finalize shutdown through a captured lease that is already lost', async () => {
     const { platform, executeCliRequest } = await installFakePlatform();

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -812,18 +812,20 @@ describe('executeCliRequest', () => {
       await Promise.resolve();
       expect(mocks.finalizeExecution).not.toHaveBeenCalled();
       publishLeaseScope?.(runWithOwnership, 'exec-1' as ExecutionId);
-      await shutdown;
+      await Promise.resolve();
+      expect(mocks.releaseExecutionLeaseAfterArtifacts).not.toHaveBeenCalled();
 
+      mocks.readCliRunOutcome.mockResolvedValueOnce('cancelled');
+      hangingRun.resolve(COMPLETED_RUN);
+      await shutdown;
       expect(runWithOwnership).toHaveBeenCalledOnce();
       expect(mocks.releaseExecutionLeaseAfterArtifacts).toHaveBeenCalledOnce();
-      expect(flushSpy).toHaveBeenCalledOnce();
+      expect(flushSpy).toHaveBeenCalled();
       expect(mocks.finalizeExecution).toHaveBeenCalledWith({
         executionId: 'exec-1',
         outcome: RUN_OUTCOME.CANCELLED,
         flowRecord: 'preserve',
       });
-      hangingRun.resolve(COMPLETED_RUN);
-      mocks.readCliRunOutcome.mockResolvedValueOnce('cancelled');
       await expect(run).resolves.toEqual({
         ok: true,
         result: {
@@ -854,10 +856,12 @@ describe('executeCliRequest', () => {
       registerExecution: true,
     });
     await vi.waitFor(() => expect(mocks.runAgent).toHaveBeenCalledOnce());
-    await platform.lifecycle.runShutdown();
+    const shutdown = platform.lifecycle.runShutdown();
+    await Promise.resolve();
     expect(mocks.finalizeExecution).not.toHaveBeenCalled();
 
     hangingRun.resolve(COMPLETED_RUN);
+    await shutdown;
     await run;
     expect(mocks.finalizeExecution).not.toHaveBeenCalled();
   });
@@ -882,13 +886,16 @@ describe('executeCliRequest', () => {
       registerExecution: true,
     });
     await vi.waitFor(() => expect(mocks.runAgent).toHaveBeenCalledOnce());
-    await platform.lifecycle.runShutdown();
+    const shutdown = platform.lifecycle.runShutdown();
+    await Promise.resolve();
+    expect(mocks.emit).not.toHaveBeenCalled();
+    mocks.readCliRunOutcome.mockResolvedValueOnce('cancelled');
+    hangingRun.resolve(COMPLETED_RUN);
+    await shutdown;
     expect(mocks.emit).toHaveBeenCalledExactlyOnceWith('requestShowError', {
       message:
         'Failed to persist cancelled status for execution exec-1: terminal metadata disk full',
     });
-    hangingRun.resolve(COMPLETED_RUN);
-    mocks.readCliRunOutcome.mockResolvedValueOnce('cancelled');
 
     await expect(run).resolves.toEqual({
       ok: true,

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -37,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   disposeHostInteractions: vi.fn(),
   prepareInteractivePrompt: vi.fn(),
   readCliRunOutcome: vi.fn(),
+  releaseExecutionLeaseAfterArtifacts: vi.fn(),
   runAgent: vi.fn(),
   writeTextStderr: vi.fn(),
   finalizeExecution: vi.fn(),
@@ -80,6 +81,11 @@ async function installStoragePlatform(): Promise<void> {
 
 vi.mock('@agent/runtime/runAgent', () => ({
   runAgent: mocks.runAgent,
+}));
+
+vi.mock('@agent/runtime/executionOwnership', () => ({
+  releaseExecutionLeaseAfterArtifacts:
+    mocks.releaseExecutionLeaseAfterArtifacts,
 }));
 
 vi.mock('@agent/storage', async (importOriginal) => ({
@@ -205,6 +211,7 @@ function stubRunExecutionDeps(): void {
     close: mocks.close,
   });
   mocks.readCliRunOutcome.mockResolvedValue('completed');
+  mocks.releaseExecutionLeaseAfterArtifacts.mockResolvedValue(undefined);
   mocks.finalizeExecution.mockResolvedValue({
     status: 'durable',
     outcomePersisted: true,
@@ -786,6 +793,10 @@ describe('executeCliRequest', () => {
     'marks $label owned executions interrupted during platform shutdown',
     async ({ options }) => {
       const { platform, executeCliRequest } = await installFakePlatform();
+      const { flushSpy } = await spyOnTranscriptFlush();
+      mocks.releaseExecutionLeaseAfterArtifacts.mockImplementationOnce(
+        async (session, executionId) => session.flushArtifacts(executionId),
+      );
       const runWithOwnership = vi.fn((operation: () => unknown) => operation());
       let publishLeaseScope: LeaseOptions['onExecutionLeaseAcquired'];
       const hangingRun = stubHangingRun((options) => {
@@ -801,6 +812,8 @@ describe('executeCliRequest', () => {
       await shutdown;
 
       expect(runWithOwnership).toHaveBeenCalledOnce();
+      expect(mocks.releaseExecutionLeaseAfterArtifacts).toHaveBeenCalledOnce();
+      expect(flushSpy).toHaveBeenCalledOnce();
       expect(mocks.finalizeExecution).toHaveBeenCalledWith({
         executionId: 'exec-1',
         outcome: RUN_OUTCOME.CANCELLED,


### PR DESCRIPTION
Closes #10050. Closes #10051.

## Summary

- persist cancelled shutdown state and wait for an interrupted CLI run to stop writing before draining session artifacts and releasing its execution lease
- interrupt the canonical owned execution even when shutdown lands between lease acquisition and runtime-handle registration
- preserve a shutdown-drain failure as the primary durability error while preventing duplicate successful release
- distinguish lease-inspection failures from session-load failures in texra resume
- document the validated history checkpoint flag

This is the immediate durability follow-up to #10048 for review findings that arrived as that PR merged.

## Ownership decision

The run lifecycle remains the writer authority. Shutdown first interrupts the owned run, then waits for runAgent to reach its final artifact boundary. Only at that quiescent point does the CLI persist cancelled status, drain artifacts, and release the lease. Ordinary runs continue to use the existing runAgent drain and release path.

## Validation

- 125 focused tests across CLI execution, ownership, resume, and history on the initial follow-up
- 33 CLI execution tests and 12 run-agent ownership tests on the final shutdown-ordering head
- npm run typecheck:workspace
- npm run typecheck:cli
- npm run typecheck:test-kernel
- npm run typecheck:desktop
- focused ESLint and Prettier checks
- exact-head GitHub Actions CI and automated review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes execution-lease release ordering and shutdown interruption paths in CLI and `runAgent`, which are durability-critical, but behavior is heavily covered by focused tests and preserves stale-lease recovery on shutdown timeout.
> 
> **Overview**
> Fixes **durability races** when a CLI run is interrupted by platform shutdown or when cleanup overlaps a failed run.
> 
> **CLI execution lifecycle** wires shutdown to abort launch prep (`launchSignal`), kill the owned execution when possible, and **wait up to 5s** for `runAgent` to unwind before persisting **CANCELLED** and releasing the lease **after** artifacts via `releaseCliExecutionLeaseAfterArtifacts`. Shutdown only marks a run cancelled when interruption is accepted (or before lifecycle registration). Failed shutdown drains surface through `beforeLeaseRelease` without double-releasing; run failures combined with flush failures become **`AggregateError`**.
> 
> **Runtime** adds optional **`launchSignal`** through `runAgent` / `buildAgentLaunchContext` (abort checks during assembly; merged into run scope). `beforeLeaseRelease` may return **`true`** when the host already drained and released—`runAgent` skips the default flush and `completeOwnedExecutionLease`. Helper-model completions and session-description generation forward **`AbortSignal`** to provider calls and retries.
> 
> **Resume CLI** reports lease-inspection errors separately from session-load failures. History types document **`hasFlowRecord`**. Tests cover shutdown ordering, launch abort, host-owned release, and cancellation forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 222dba04072347673f9f0c10910cf6c01033f7a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->