### PR TITLE
fix(cli): drain artifacts before shutdown release

### DIFF
--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -1,10 +1,10 @@
 import {
   attachTerminalResultToast,
+  releaseExecutionLeaseAfterArtifacts,
   runAgent,
   trackTerminalResultPresentation,
   type RunAgentOptions,
 } from '@agent/runtime';
-import { releaseExecutionLeaseAfterArtifacts } from '@agent/runtime/executionOwnership';
 import {
   ExecutionLeaseLostError,
   type OwnedExecutionLeaseScope,
@@ -258,13 +258,15 @@ export async function executeCliRequest(
       settleLeaseScope = resolve;
     },
   );
-  let shutdownStatusFinalized: Promise<boolean> | undefined;
-  const finalizeShutdownStatus = (): Promise<boolean> => {
-    if (!shutdownInterrupted) return Promise.resolve(false);
+  type ShutdownFinalizationResult =
+    { readonly artifactsHandled: true; readonly error?: unknown } | undefined;
+  let shutdownStatusFinalized: Promise<ShutdownFinalizationResult> | undefined;
+  const finalizeShutdownStatus = (): Promise<ShutdownFinalizationResult> => {
+    if (!shutdownInterrupted) return Promise.resolve(undefined);
     shutdownStatusFinalized ??= (async () => {
       const runWithOwnership = await leaseScopeReady;
       const executionId = ownedExecutionId;
-      if (!runWithOwnership || !executionId) return false;
+      if (!runWithOwnership || !executionId) return undefined;
       try {
         await runWithOwnership(async () => {
           await finalizeCliExecution(
@@ -275,10 +277,15 @@ export async function executeCliRequest(
           );
           await releaseExecutionLeaseAfterArtifacts(session, executionId);
         });
-        return true;
+        return { artifactsHandled: true };
       } catch (error) {
-        if (!(error instanceof ExecutionLeaseLostError)) throw error;
-        return false;
+        if (error instanceof ExecutionLeaseLostError) return undefined;
+        reportShutdownFinalizationFailure(
+          error instanceof Error
+            ? error
+            : new Error(toErrorMessage(error), { cause: error }),
+        );
+        return { artifactsHandled: true, error };
       }
     })();
     return shutdownStatusFinalized;

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -4,8 +4,8 @@ import {
   trackTerminalResultPresentation,
   type RunAgentOptions,
 } from '@agent/runtime';
+import { releaseExecutionLeaseAfterArtifacts } from '@agent/runtime/executionOwnership';
 import {
-  completeOwnedExecutionLease,
   ExecutionLeaseLostError,
   type OwnedExecutionLeaseScope,
 } from '@agent/storage/executionLease';
@@ -258,13 +258,13 @@ export async function executeCliRequest(
       settleLeaseScope = resolve;
     },
   );
-  let shutdownStatusFinalized: Promise<void> | undefined;
-  const finalizeShutdownStatus = (): Promise<void> => {
-    if (!shutdownInterrupted) return Promise.resolve();
+  let shutdownStatusFinalized: Promise<boolean> | undefined;
+  const finalizeShutdownStatus = (): Promise<boolean> => {
+    if (!shutdownInterrupted) return Promise.resolve(false);
     shutdownStatusFinalized ??= (async () => {
       const runWithOwnership = await leaseScopeReady;
       const executionId = ownedExecutionId;
-      if (!runWithOwnership || !executionId) return;
+      if (!runWithOwnership || !executionId) return false;
       try {
         await runWithOwnership(async () => {
           await finalizeCliExecution(
@@ -273,10 +273,12 @@ export async function executeCliRequest(
             'preserve',
             reportShutdownFinalizationFailure,
           );
-          await completeOwnedExecutionLease(executionId);
+          await releaseExecutionLeaseAfterArtifacts(session, executionId);
         });
+        return true;
       } catch (error) {
         if (!(error instanceof ExecutionLeaseLostError)) throw error;
+        return false;
       }
     })();
     return shutdownStatusFinalized;

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -58,6 +58,9 @@ export type {
 export { runAgent } from './runAgent';
 export type { RunAgentOptions } from './runAgent';
 
+// executionOwnership
+export { releaseExecutionLeaseAfterArtifacts } from './executionOwnership';
+
 // SessionResumeRetrieval
 export { retrieveSessionResumeData } from './SessionResumeRetrieval';
 export type { ToolUseResumeData } from './SessionResumeRetrieval';

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -51,9 +51,13 @@ export interface RunAgentOptions extends Pick<
   openWorkflowOutput?: (result: WorkflowFlowResult) => Promise<void>;
   /**
    * Persist host-owned final state before the ordinary session drain. Return
-   * true when the hook already drained artifacts and disposed of ownership.
+   * an explicit result when the hook already drained artifacts and disposed
+   * of ownership, including any failure that should remain observable.
    */
-  beforeLeaseRelease?: () => Promise<boolean | void>;
+  beforeLeaseRelease?: () => Promise<{
+    readonly artifactsHandled: true;
+    readonly error?: unknown;
+  } | void>;
   /** Bind host callbacks that may run outside the agent's async context. */
   onExecutionLeaseAcquired?: (
     scope: OwnedExecutionLeaseScope,
@@ -200,7 +204,11 @@ export async function runAgent(
 
       const artifactFailures: unknown[] = [];
       try {
-        finalArtifactsHandled = (await beforeLeaseRelease?.()) === true;
+        const hostArtifacts = await beforeLeaseRelease?.();
+        finalArtifactsHandled = hostArtifacts?.artifactsHandled === true;
+        if (hostArtifacts?.error !== undefined) {
+          artifactFailures.push(hostArtifacts.error);
+        }
       } catch (error) {
         artifactFailures.push(error);
       }

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -49,8 +49,11 @@ export interface RunAgentOptions extends Pick<
   | 'onIdle'
 > {
   openWorkflowOutput?: (result: WorkflowFlowResult) => Promise<void>;
-  /** Persist host-owned final artifacts while this run still owns its lease. */
-  beforeLeaseRelease?: () => Promise<void>;
+  /**
+   * Persist host-owned final state before the ordinary session drain. Return
+   * true when the hook already drained artifacts and disposed of ownership.
+   */
+  beforeLeaseRelease?: () => Promise<boolean | void>;
   /** Bind host callbacks that may run outside the agent's async context. */
   onExecutionLeaseAcquired?: (
     scope: OwnedExecutionLeaseScope,
@@ -137,6 +140,7 @@ export async function runAgent(
     let runResult: AgentFlowResult | undefined;
     let runFailure: { error: unknown } | undefined;
     let artifactsDurable = false;
+    let finalArtifactsHandled = false;
     let previousTerminalOutcome: RunOutcome | undefined;
     let resumedStreamId: StreamTabId | undefined;
     const callerOnRun = executeAgentOptions.onRun;
@@ -196,14 +200,16 @@ export async function runAgent(
 
       const artifactFailures: unknown[] = [];
       try {
-        await beforeLeaseRelease?.();
+        finalArtifactsHandled = (await beforeLeaseRelease?.()) === true;
       } catch (error) {
         artifactFailures.push(error);
       }
-      try {
-        await flushOwnedExecutionArtifacts(runSession, executionId);
-      } catch (error) {
-        artifactFailures.push(error);
+      if (!finalArtifactsHandled) {
+        try {
+          await flushOwnedExecutionArtifacts(runSession, executionId);
+        } catch (error) {
+          artifactFailures.push(error);
+        }
       }
       artifactsDurable = artifactFailures.length === 0;
 
@@ -229,9 +235,9 @@ export async function runAgent(
       }
       return runResult;
     } finally {
-      if (artifactsDurable) {
+      if (artifactsDurable && !finalArtifactsHandled) {
         await completeOwnedExecutionLease(executionId);
-      } else {
+      } else if (!artifactsDurable) {
         abandonOwnedExecutionLease(executionId);
       }
     }

--- a/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
@@ -295,6 +295,25 @@ describe('runAgent execution ownership', () => {
     ]);
   });
 
+  it('does not drain artifacts again after the host disposed of ownership', async () => {
+    const order: string[] = [];
+    mocks.executeAgent.mockImplementationOnce(async () => {
+      order.push('execute');
+      return EXECUTE_RESULT;
+    });
+    await launch({
+      registerExecution: true,
+      beforeLeaseRelease: async () => {
+        order.push('host-artifacts-and-release');
+        return true;
+      },
+    });
+
+    expect(order).toEqual(['execute', 'host-artifacts-and-release']);
+    expect(flushArtifacts).not.toHaveBeenCalled();
+    expect(mocks.completeOwnedExecutionLease).not.toHaveBeenCalled();
+  });
+
   it('preserves run and final-artifact failures before releasing ownership', async () => {
     const runError = new Error('run failed');
     const artifactError = new Error('transcript flush failed');

--- a/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
@@ -305,13 +305,30 @@ describe('runAgent execution ownership', () => {
       registerExecution: true,
       beforeLeaseRelease: async () => {
         order.push('host-artifacts-and-release');
-        return true;
+        return { artifactsHandled: true };
       },
     });
 
     expect(order).toEqual(['execute', 'host-artifacts-and-release']);
     expect(flushArtifacts).not.toHaveBeenCalled();
     expect(mocks.completeOwnedExecutionLease).not.toHaveBeenCalled();
+  });
+
+  it('does not retry after a handled host artifact failure', async () => {
+    const artifactError = new Error('shutdown transcript flush failed');
+
+    const failure = await launch({
+      registerExecution: true,
+      beforeLeaseRelease: async () => ({
+        artifactsHandled: true,
+        error: artifactError,
+      }),
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBe(artifactError);
+    expect(flushArtifacts).not.toHaveBeenCalled();
+    expect(mocks.completeOwnedExecutionLease).not.toHaveBeenCalled();
+    expect(mocks.abandonOwnedExecutionLease).toHaveBeenCalledWith(EXECUTION_ID);
   });
 
   it('preserves run and final-artifact failures before releasing ownership', async () => {

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -37,7 +37,6 @@ const mocks = vi.hoisted(() => ({
   disposeHostInteractions: vi.fn(),
   prepareInteractivePrompt: vi.fn(),
   readCliRunOutcome: vi.fn(),
-  releaseExecutionLeaseAfterArtifacts: vi.fn(),
   runAgent: vi.fn(),
   writeTextStderr: vi.fn(),
   finalizeExecution: vi.fn(),
@@ -81,11 +80,6 @@ async function installStoragePlatform(): Promise<void> {
 
 vi.mock('@agent/runtime/runAgent', () => ({
   runAgent: mocks.runAgent,
-}));
-
-vi.mock('@agent/runtime/executionOwnership', () => ({
-  releaseExecutionLeaseAfterArtifacts:
-    mocks.releaseExecutionLeaseAfterArtifacts,
 }));
 
 vi.mock('@agent/storage', async (importOriginal) => ({
@@ -211,7 +205,6 @@ function stubRunExecutionDeps(): void {
     close: mocks.close,
   });
   mocks.readCliRunOutcome.mockResolvedValue('completed');
-  mocks.releaseExecutionLeaseAfterArtifacts.mockResolvedValue(undefined);
   mocks.finalizeExecution.mockResolvedValue({
     status: 'durable',
     outcomePersisted: true,
@@ -794,10 +787,11 @@ describe('executeCliRequest', () => {
     async ({ options }) => {
       const { platform, executeCliRequest } = await installFakePlatform();
       const { flushSpy } = await spyOnTranscriptFlush();
-      mocks.releaseExecutionLeaseAfterArtifacts.mockImplementationOnce(
-        async (session, executionId) => session.flushArtifacts(executionId),
-      );
-      const runWithOwnership = vi.fn((operation: () => unknown) => operation());
+      const { acquireFreshExecutionLease, captureOwnedExecutionLease } =
+        await import('@agent/storage/executionLease');
+      const executionId = 'exec-1' as ExecutionId;
+      await acquireFreshExecutionLease(executionId);
+      const runWithOwnership = captureOwnedExecutionLease(executionId);
       let publishLeaseScope: LeaseOptions['onExecutionLeaseAcquired'];
       const hangingRun = stubHangingRun((options) => {
         publishLeaseScope = options.onExecutionLeaseAcquired;
@@ -808,11 +802,9 @@ describe('executeCliRequest', () => {
       const shutdown = platform.lifecycle.runShutdown();
       await Promise.resolve();
       expect(mocks.finalizeExecution).not.toHaveBeenCalled();
-      publishLeaseScope?.(runWithOwnership, 'exec-1' as ExecutionId);
+      publishLeaseScope?.(runWithOwnership, executionId);
       await shutdown;
 
-      expect(runWithOwnership).toHaveBeenCalledOnce();
-      expect(mocks.releaseExecutionLeaseAfterArtifacts).toHaveBeenCalledOnce();
       expect(flushSpy).toHaveBeenCalledOnce();
       expect(mocks.finalizeExecution).toHaveBeenCalledWith({
         executionId: 'exec-1',
@@ -904,14 +896,15 @@ describe('executeCliRequest', () => {
   it('reports a shutdown artifact drain failure once', async () => {
     const { platform, executeCliRequest } = await installFakePlatform();
     const artifactError = new Error('shutdown transcript flush failed');
-    mocks.releaseExecutionLeaseAfterArtifacts.mockRejectedValueOnce(
-      artifactError,
-    );
+    const { flushSpy } = await spyOnTranscriptFlush();
+    flushSpy.mockRejectedValueOnce(artifactError);
+    const { acquireFreshExecutionLease, captureOwnedExecutionLease } =
+      await import('@agent/storage/executionLease');
+    const executionId = 'exec-1' as ExecutionId;
+    await acquireFreshExecutionLease(executionId);
+    const runWithOwnership = captureOwnedExecutionLease(executionId);
     const hangingRun = stubHangingRun((options) => {
-      options.onExecutionLeaseAcquired?.(
-        (operation: () => unknown) => operation(),
-        'exec-1' as ExecutionId,
-      );
+      options.onExecutionLeaseAcquired?.(runWithOwnership, executionId);
     });
 
     const run = executeCliRequest(baseRequest(), cliContext(), {

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -901,6 +901,35 @@ describe('executeCliRequest', () => {
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
+  it('reports a shutdown artifact drain failure once', async () => {
+    const { platform, executeCliRequest } = await installFakePlatform();
+    const artifactError = new Error('shutdown transcript flush failed');
+    mocks.releaseExecutionLeaseAfterArtifacts.mockRejectedValueOnce(
+      artifactError,
+    );
+    const hangingRun = stubHangingRun((options) => {
+      options.onExecutionLeaseAcquired?.(
+        (operation: () => unknown) => operation(),
+        'exec-1' as ExecutionId,
+      );
+    });
+
+    const run = executeCliRequest(baseRequest(), cliContext(), {
+      registerExecution: true,
+    });
+    await vi.waitFor(() => expect(mocks.runAgent).toHaveBeenCalledOnce());
+    await platform.lifecycle.runShutdown();
+
+    expect(mocks.emit).toHaveBeenCalledExactlyOnceWith('requestShowError', {
+      message: artifactError.message,
+    });
+
+    hangingRun.resolve(COMPLETED_RUN);
+    mocks.readCliRunOutcome.mockResolvedValueOnce('cancelled');
+    await run;
+    expect(mocks.emit).toHaveBeenCalledTimes(1);
+  });
+
   it('removes the shutdown status hook after owned executions finish', async () => {
     const { platform, executeCliRequest } = await installFakePlatform();
     const request = baseRequest();

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -37,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   disposeHostInteractions: vi.fn(),
   prepareInteractivePrompt: vi.fn(),
   readCliRunOutcome: vi.fn(),
+  releaseExecutionLeaseAfterArtifacts: vi.fn(),
   runAgent: vi.fn(),
   writeTextStderr: vi.fn(),
   finalizeExecution: vi.fn(),
@@ -80,6 +81,11 @@ async function installStoragePlatform(): Promise<void> {
 
 vi.mock('@agent/runtime/runAgent', () => ({
   runAgent: mocks.runAgent,
+}));
+
+vi.mock('@agent/runtime/executionOwnership', () => ({
+  releaseExecutionLeaseAfterArtifacts:
+    mocks.releaseExecutionLeaseAfterArtifacts,
 }));
 
 vi.mock('@agent/storage', async (importOriginal) => ({
@@ -205,6 +211,7 @@ function stubRunExecutionDeps(): void {
     close: mocks.close,
   });
   mocks.readCliRunOutcome.mockResolvedValue('completed');
+  mocks.releaseExecutionLeaseAfterArtifacts.mockResolvedValue(undefined);
   mocks.finalizeExecution.mockResolvedValue({
     status: 'durable',
     outcomePersisted: true,
@@ -786,6 +793,10 @@ describe('executeCliRequest', () => {
     'marks $label owned executions interrupted during platform shutdown',
     async ({ options }) => {
       const { platform, executeCliRequest } = await installFakePlatform();
+      const { flushSpy } = await spyOnTranscriptFlush();
+      mocks.releaseExecutionLeaseAfterArtifacts.mockImplementationOnce(
+        async (session, executionId) => session.flushArtifacts(executionId),
+      );
       const runWithOwnership = vi.fn((operation: () => unknown) => operation());
       let publishLeaseScope: LeaseOptions['onExecutionLeaseAcquired'];
       const hangingRun = stubHangingRun((options) => {
@@ -801,6 +812,8 @@ describe('executeCliRequest', () => {
       await shutdown;
 
       expect(runWithOwnership).toHaveBeenCalledOnce();
+      expect(mocks.releaseExecutionLeaseAfterArtifacts).toHaveBeenCalledOnce();
+      expect(flushSpy).toHaveBeenCalledOnce();
       expect(mocks.finalizeExecution).toHaveBeenCalledWith({
         executionId: 'exec-1',
         outcome: RUN_OUTCOME.CANCELLED,


### PR DESCRIPTION
Fixes #10050.

## Summary

- finalize an interrupted CLI execution and drain its artifacts before releasing the execution lease
- let the shutdown hook report that it already handled the final drain and lease disposition
- prevent the resumed `runAgent` continuation from renewing, flushing, or releasing that lease a second time

## Ownership decision

The shutdown hook owns the exceptional signal path as one durability boundary: terminal status, artifact drain, then lease release. The ordinary `runAgent` path remains the owner for all other final drains. A boolean result on the existing boundary distinguishes those two mutually exclusive cases without adding another lease state or compatibility representation.

## Validation

- `npm test -- --run src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts src/test-kernel/cli/RunExecution.vitest.ts` (44 tests)
- focused ESLint on the four changed files
- `npm run typecheck:cli`
- `npm run typecheck:test-kernel`
- `npm run typecheck:workspace`
- pre-commit and pre-push checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes execution lease teardown and shutdown durability ordering; mistakes could double-release or skip artifact persistence, but behavior is covered by focused ownership and CLI shutdown tests.
> 
> **Overview**
> **Shutdown-interrupted CLI runs** now finalize as cancelled, **flush session artifacts**, then release the execution lease in one path via `releaseExecutionLeaseAfterArtifacts`, instead of completing the lease without draining.
> 
> The **`beforeLeaseRelease` hook** can return `{ artifactsHandled: true, optional error }` so the host (e.g. shutdown finalization wired through `finalizeShutdownStatus`) owns terminal status, artifact drain, and lease disposition. **`runAgent`** skips the default artifact flush and **`completeOwnedExecutionLease`** when that flag is set, avoiding a second drain or lease release when the run resumes after shutdown.
> 
> Shutdown finalization **surfaces artifact drain failures once** to the user and still treats the host as having handled artifacts; lease-lost errors are ignored without duplicate reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec2d621e3fb34895baa02890d5fcc39ea0f18c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->