### PR TITLE
refactor(agent): remove dead progress formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,7 @@ jobs:
             orchestrate-independent-subscription-preferences \
             orchestrate-history orchestrate-resume-submenu \
             compact-orchestrate-launcher single-run-liveness \
+            subagent-followup-summary \
             agent-proposal-approve-all workflow-timeline
 
       - name: Upload CLI TUI smoke frames

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -869,7 +869,7 @@ function seedSubagentFollowupTranscript(): void {
   const writer = store.acquireWriter(STREAM_ID, 'tui-harness');
   const timestamp = Date.now();
   const followups = [
-    '<subagent-progress id="child-a" agent="strategy" type="round" current="2" total="3" />',
+    '<subagent-progress id="child-a" agent="strategy" type="overview" tool-calls="3" files-changed="none" />',
     [
       '<subagent-result id="child-b" agent="leanSolver" category="toolUse" status="completed">',
       '<wall-time>2min, 3sec</wall-time>',

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -387,7 +387,7 @@ const SCENARIOS = [
     frame: 'scrollback',
     env: { HARNESS_ENTRIES: '0', HARNESS_SUBAGENT_FOLLOWUPS: '1' },
     expect: [
-      '⟳ strategy · round 2/3',
+      '⟳ strategy · 3 tool calls',
       '✓ leanSolver completed · 2min, 3sec',
       'Proved </response> is escaped & visible.',
       '✗ reviewer failed (retryable)',

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -26,7 +26,6 @@ import {
 import { countByStatus, STATUS_DISPLAY } from '@shared/schemas/todoDisplay';
 import { planSummaryLine } from '@shared/schemas/workPlan';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
-import { isObject } from '@utils/core';
 import {
   formatCompactDuration,
   formatCostUsd,
@@ -133,11 +132,6 @@ function progressDetail(xml: string): string {
       if (cost) parts.push(`$${cost}`);
       return parts.length > 0 ? parts.join(' · ') : 'working';
     }
-    case 'round': {
-      const current = attr(xml, 'current');
-      const total = attr(xml, 'total');
-      return current && total ? `round ${current}/${total}` : 'working';
-    }
     case 'plan': {
       if (attr(xml, 'status') === 'cleared') return 'plan cleared';
       // The producer (`formatSubagentProgress`) attaches the plan objective as
@@ -152,35 +146,7 @@ function progressDetail(xml: string): string {
       if (completed || active || pending) {
         return `todos · ${completed ?? '0'} done, ${active ?? '0'} active, ${pending ?? '0'} pending`;
       }
-      const body = elementBody(xml, DELIVERY_TAG.subagentProgress);
-      if (!body) return 'todos updated';
-      const parsed = safeParseJson(decodeXmlEntities(body));
-      if (parsed.isErr() || !Array.isArray(parsed.value)) {
-        return 'todos updated';
-      }
-      const statuses = parsed.value.map((item) =>
-        isObject(item) ? item.status : undefined,
-      );
-      const done = statuses.filter((status) => status === 'completed').length;
-      const inProgress = statuses.filter(
-        (status) => status === 'in_progress',
-      ).length;
-      const todo = statuses.length - done - inProgress;
-      return `todos · ${done} done, ${inProgress} active, ${todo} pending`;
-    }
-    case 'conversations': {
-      const turns = attr(xml, 'turns');
-      const chars = attr(xml, 'characters');
-      const parts: string[] = [];
-      if (turns) parts.push(`${turns} turns`);
-      if (chars) parts.push(`${chars} chars`);
-      return parts.length > 0
-        ? `conversation · ${parts.join(' · ')}`
-        : 'conversation update';
-    }
-    case 'activity': {
-      const body = elementBody(xml, DELIVERY_TAG.subagentProgress);
-      return body ? decodeXmlEntities(body).split('\n')[0]! : 'activity';
+      return 'todos updated';
     }
     default:
       return 'working';

--- a/src/test-kernel/cli/SubagentFollowup.vitest.ts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.ts
@@ -120,47 +120,26 @@ describe('summarizeSubagentFollowup', () => {
     ).toBe('⟳ research · 3 tool calls');
   });
 
-  it('summarizes a round progress block', () => {
+  it('summarizes todo progress attributes', () => {
     expect(
       summarizeSubagentFollowup(
-        '<subagent-progress id="abc" agent="numerics" type="round" current="2" total="5">\n<file path="a.tex" />\n</subagent-progress>',
+        '<subagent-progress id="abc" agent="review" type="todos" completed="1" active="1" pending="1" />',
       ),
-    ).toBe('⟳ numerics · round 2/5');
-  });
-
-  it('summarizes todo progress blocks that carry JSON bodies', () => {
-    const xml = [
-      '<subagent-progress id="abc" agent="review" type="todos">',
-      '[',
-      '{"content":"done","status":"completed"},',
-      '{"content":"active","status":"in_progress"},',
-      '{"content":"todo","status":"pending"}',
-      ']',
-      '</subagent-progress>',
-    ].join('');
-    expect(summarizeSubagentFollowup(xml)).toBe(
-      '⟳ review · todos · 1 done, 1 active, 1 pending',
-    );
+    ).toBe('⟳ review · todos · 1 done, 1 active, 1 pending');
   });
 
   it('summarizes embedded subagent blocks inside assistant text', () => {
     const text = [
       'before',
       '<subagent-progress id="abc" agent="review" type="started" />',
-      '<subagent-progress id="abc" agent="review" type="conversations" turns="4" characters="4471">',
-      'Last message',
-      '</subagent-progress>',
-      '<subagent-progress id="abc" agent="review" type="round" current="2" total="3">',
-      '<file path="a.tex" />',
-      '</subagent-progress>',
+      '<subagent-progress id="abc" agent="review" type="todos" completed="2" active="1" pending="0" />',
       'after',
     ].join('\n');
     expect(summarizeEmbeddedSubagentFollowups(text)).toBe(
       [
         'before',
         '⟳ review · started',
-        '⟳ review · conversation · 4 turns · 4471 chars',
-        '⟳ review · round 2/3',
+        '⟳ review · todos · 2 done, 1 active, 0 pending',
         'after',
       ].join('\n'),
     );

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -1983,8 +1983,8 @@ describe('CLI transcript state', () => {
       [
         'Waiting for the child.',
         '<subagent-progress id="abc" agent="prover" type="todos" completed="1" active="1" pending="0">',
-        '  ✓ check',
-        '  ◉ prove',
+        '  ● check',
+        '  ◐ prove',
         '</subagent-progress>',
       ].join('\n'),
     );

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -1982,10 +1982,10 @@ describe('CLI transcript state', () => {
       logger,
       [
         'Waiting for the child.',
-        '<subagent-progress id="abc" agent="prover" type="todos">',
-        '[{"content":"check","status":"completed"},{"content":"prove","status":"in_progress"}]',
+        '<subagent-progress id="abc" agent="prover" type="todos" completed="1" active="1" pending="0">',
+        '  ✓ check',
+        '  ◉ prove',
         '</subagent-progress>',
-        '<subagent-progress id="abc" agent="prover" type="activity">Subagent prover is proving completeness.</subagent-progress>',
       ].join('\n'),
     );
 
@@ -1996,7 +1996,6 @@ describe('CLI transcript state', () => {
       [
         'Waiting for the child.',
         '⟳ prover · todos · 1 done, 1 active, 0 pending',
-        '⟳ prover · Subagent prover is proving completeness.',
       ].join('\n'),
     ]);
     expect(entries[0]?.text).not.toContain('<subagent-progress');


### PR DESCRIPTION
## Summary

Remove subagent progress rendering branches that have no producer and align tests and the TUI smoke fixture with the typed progress protocol.

## Issue acceptance gates

Closes #9950. Removes the round, conversations, and activity arms, the JSON-body todo fallback, and their test and harness fixtures.

## Single source of truth

SubagentProgressUpdate defines the supported variants; formatSubagentProgress is the sole XML producer. The renderer now follows those two authorities.

## Duplication and abstraction budget

No abstraction was added. Four dead parsing and rendering paths and their fixtures were deleted.

## Net elements (R6)

- files: 6 modified, none added or deleted
- exported symbols: 0 added, 0 deleted
- classes, interfaces, and enums: 0 added, 0 deleted
- lines: +12 / -67, net -55

## Consumer counts (R8)

- round progress XML producers: 0
- conversations progress XML producers: 0
- activity progress XML producers: 0
- JSON-body todo progress producers: 0
- canonical formatSubagentProgress call sites: 1, in childRunLoop.ts

## Host impact

Extension: Current progress rendering is unchanged; unsupported historical shapes fall back to working.

Desktop: No producer or desktop-specific path changes.

CLI: Transcript and queued-follow-up rendering retain the four canonical progress variants; the smoke fixture and validator now use overview.

## Scheduled refactoring

None.

## Validation

- focused CLI transcript tests: 243 passed
- npm run typecheck:workspace
- npm run typecheck:test-kernel
- changed-file ESLint and Prettier checks
- dead-code ratchet
- TUI smoke scenario subagent-followup-summary passed with the corrected 3 tool calls expectation

The full local TUI smoke command was stopped after this target passed because unrelated terminal-timing scenarios failed in the local environment; CI runs the complete selected smoke suite on the supported runner.