### PR TITLE
fix: align usage pricing model catalog

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -45,10 +45,10 @@ Releases. No local `vsce` / `ovsx` / `npm publish` invocation and no OTP.
    `true`.
 
 5. **`llm-zoo` pin.** If the release changes `llm-zoo`, also update the exact
-   pin in `supabase/functions/relay/deno.json` and refresh
-   `supabase/functions/relay/deno.lock`. This is called out in the
-   `version-bump.yml` PR body but is easy to miss, since it isn't part of the
-   automated bump.
+   pins in `supabase/functions/relay/deno.json` and
+   `supabase/functions/log-usage/deno.json`, then refresh both adjacent
+   `deno.lock` files. This is called out in the `version-bump.yml` PR body but
+   is easy to miss, since it isn't part of the automated bump.
 
 ## Gotchas
 

--- a/src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts
+++ b/src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts
@@ -27,6 +27,7 @@ const RELAY_TIERS = [RELAY_FREE_TIER, RELAY_MAX_TIER, RELAY_ULTRA_TIER];
 const require = createRequire(import.meta.url);
 
 const RELAY_DENO_JSON_PATH = 'supabase/functions/relay/deno.json';
+const LOG_USAGE_DENO_JSON_PATH = 'supabase/functions/log-usage/deno.json';
 
 function readJsonFile<T>(relativePath: string): T {
   return JSON.parse(
@@ -97,6 +98,16 @@ describe('relay shared configuration parity', () => {
         'supabase/functions/relay/deno.json (and refresh deno.lock) or ' +
         'package.json so both point to the same version.',
     ).toBe(workspaceVersion);
+  });
+
+  it('keeps the relay and usage-cost llm-zoo pins identical', () => {
+    const logUsageDenoJson = readJsonFile<{
+      imports?: Record<string, string>;
+    }>(LOG_USAGE_DENO_JSON_PATH);
+    expect(
+      logUsageDenoJson.imports?.['llm-zoo'],
+      `${LOG_USAGE_DENO_JSON_PATH} must match ${RELAY_DENO_JSON_PATH}`,
+    ).toBe(readRelayLlmZooSpecifier());
   });
 
   it('keeps the pnpm-resolved llm-zoo version in sync with the relay deno.json pin', () => {

--- a/supabase/functions/log-usage/deno.json
+++ b/supabase/functions/log-usage/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
     "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.111.0",
-    "llm-zoo": "npm:llm-zoo@1.25.0",
+    "llm-zoo": "npm:llm-zoo@1.27.0",
     "zod": "npm:zod@^4.4.3"
   }
 }

--- a/supabase/functions/log-usage/deno.lock
+++ b/supabase/functions/log-usage/deno.lock
@@ -7,7 +7,7 @@
     "npm:@supabase/postgrest-js@2.111.0": "2.111.0",
     "npm:@supabase/realtime-js@2.111.0": "2.111.0",
     "npm:@supabase/storage-js@2.111.0": "2.111.0",
-    "npm:llm-zoo@1.25.0": "1.25.0_zod@4.4.3",
+    "npm:llm-zoo@1.27.0": "1.27.0_zod@4.4.3",
     "npm:zod@^4.4.3": "4.4.3"
   },
   "jsr": {
@@ -61,8 +61,8 @@
     "iceberg-js@0.8.1": {
       "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
     },
-    "llm-zoo@1.25.0_zod@4.4.3": {
-      "integrity": "sha512-SA68zVn+25GX2xafX2zi7hmRMFAfRhp2FXJzBGIis4wyqfdgkY50iDfk3S+HEXxX6mp4FamgUNNTZM2kQ7cI8Q==",
+    "llm-zoo@1.27.0_zod@4.4.3": {
+      "integrity": "sha512-hx0SFcdKcqohlwr9styXqxnV4Zzend/RMEtLUrNPeWnQzK0LFjljMsvy6TtWIaWWrBgL3LGk3w2aHAMiJepCLA==",
       "dependencies": [
         "zod"
       ],
@@ -80,7 +80,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@supabase/supabase-js@2.111.0",
-      "npm:llm-zoo@1.25.0",
+      "npm:llm-zoo@1.27.0",
       "npm:zod@^4.4.3"
     ]
   }

--- a/supabase/functions/log-usage/equivalentCost_test.ts
+++ b/supabase/functions/log-usage/equivalentCost_test.ts
@@ -2,7 +2,7 @@ import { equal } from 'node:assert/strict';
 
 import { equivalentListCost } from './equivalentCost.ts';
 
-// gpt-5.6-sol list price in llm-zoo@1.25.0: $5/M input, $30/M output,
+// gpt-5.6-sol list price in llm-zoo@1.27.0: $5/M input, $30/M output,
 // cache discount 0.1. The fast-tier registry entry for the same model id
 // ($10/$60) must not be selected.
 Deno.test('prices a known model at standard-tier list price', () => {


### PR DESCRIPTION
Closes #10060.

## Summary

- update the `log-usage` Edge Function to the same `llm-zoo` 1.27.0 catalogue used by the workspace and relay
- regenerate its Deno lockfile and keep the price-regression documentation synchronized
- extend the existing catalogue-parity invariant and release checklist to cover both server-side consumers

## Why

The compatible dependency refresh in #10036 updated the client and relay catalogue, but `log-usage` remained on 1.25.0. Because that function derives subscription usage costs from `MODEL_CONFIGS`, the stale pin could make hosted cost accounting disagree with the current application catalogue. This follow-up incorporates the final review finding that arrived as #10036 merged and prevents the same drift from recurring.

## Validation

- `deno test --minimum-dependency-age=0 --lock=deno.lock equivalentCost_test.ts` (5 passed)
- `pnpm vitest run --config vitest.config.mjs src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts` (6 passed)
- Prettier and `git diff --check`
- exact-head GitHub Actions CI and automated review