### PR TITLE
docs: update xAI PRD with 2026-08-12 recon findings

### DIFF
--- a/docs/prds/2026-08-04-prd-xai-responses-previous-response-id.md
+++ b/docs/prds/2026-08-04-prd-xai-responses-previous-response-id.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-08-04
-updated: 2026-08-04
+updated: 2026-08-12
 ---
 
 # PRD: xAI Responses API and `previous_response_id` for Grok
@@ -247,3 +247,50 @@ Items 1–3 help Completions **and** make Responses land cleaner; none require w
 - `src/agent/runtime/ModelFactory.ts` — `shouldUseResponsesAPI`
 - `src/model/providerCapabilities.ts` — `OpenAIResponseProviderCapabilities` / Codex profile
 - `src/agent/modelHandlers/support/ProxyConfigResolver.ts` — `https://api.x.ai/v1`
+
+## 14. Update — 2026-08-12 (re-check against current xAI docs)
+
+Recon pass through the current `docs.x.ai` Pricing, Prompt Caching, and Context
+Compaction pages, prompted by a request to check whether TeXRA's Grok
+integration needs anything for the current model/pricing lineup. **No code or
+catalog changes made — recon only**, per the §2 non-goals.
+
+1. **Chat Completions is now labeled "Deprecated" on xAI's own
+   Responses-vs-Completions comparison page**, not merely "not preferred."
+   §4.1 already treats Responses as the long-term destination for direct
+   xAI; this raises the priority of that call — `ModelHandlerXAI`, TeXRA's
+   only xAI path, is Chat-Completions-only today.
+2. **`grok-4.6` is a new model** on the current pricing page, alongside
+   `grok-build-0.1` and three `grok-4.20-*` variants
+   (`multi-agent-0309`, `0309-reasoning`, `0309-non-reasoning`) — none are in
+   TeXRA's catalog yet (§3 still shows only 4.5/4.3). The catalog is
+   `llm-zoo`-sourced; `package.json` pins `1.25.0`, npm's current latest is
+   `1.26.0`. Unverified whether `1.26.0` already carries these models —
+   check before bumping.
+3. **Long-context pricing is a real, documented xAI mechanic**, not
+   speculative: once a prompt's total tokens (cached and non-cached both)
+   cross a model's threshold, xAI bills *all* prompt tokens for that request
+   at roughly double the short-context rate. Still unmodeled anywhere in
+   TeXRA — `StandardPricingConfig` / `computeStandardPrice`
+   (`src/agent/utils/priceUtils.ts`) only carries one flat `inputPrice` /
+   `outputPrice` pair, and `llm-zoo`'s public schema has no long-context tier
+   field either (per its npm package description). Already flagged as a
+   non-goal in §2 ("long-context pricing accuracy | llm-zoo / billing
+   follow-up"); still open, now with a concrete billing mechanism to model
+   against once a rate source exists.
+4. **§11 open question 3 (does `/responses/compact` exist) is answered:
+   yes.** `POST /v1/responses/compact` is documented and generally
+   available. It takes the same `input` shape as `/v1/responses` and returns
+   a `response.compaction` object carrying an opaque `encrypted_content`
+   blob to replay verbatim as the head of the next request. Responses-only —
+   unreachable from TeXRA until this PRD's routing lands.
+5. Prompt-cache accounting itself is already correct at the *rate* level:
+   Chat Completions' `usage.prompt_tokens_details.cached_tokens` is exactly
+   what `src/agent/modelHandlers/openai/openAIUsage.ts` already reads for
+   every OpenAI-compatible handler, `ModelHandlerXAI` included. The only gap
+   is the long-context *tier* switch in point 3, not cache-token extraction.
+
+Candidate next steps, smallest first: (a) verify and bump `llm-zoo` for the
+new model IDs, (b) model long-context tiered pricing in
+`computeStandardPrice` once a rate source exists, (c) revisit this PRD's
+default-off timeline given Chat Completions' now-explicit deprecated status.

--- a/docs/prds/2026-08-04-prd-xai-responses-previous-response-id.md
+++ b/docs/prds/2026-08-04-prd-xai-responses-previous-response-id.md
@@ -260,21 +260,22 @@ catalog changes made — recon only**, per the §2 non-goals.
    §4.1 already treats Responses as the long-term destination for direct
    xAI; this raises the priority of that call — `ModelHandlerXAI`, TeXRA's
    only xAI path, is Chat-Completions-only today.
-2. **`grok-4.6` is a new model** on the current pricing page, alongside
-   `grok-build-0.1` and three `grok-4.20-*` variants
-   (`multi-agent-0309`, `0309-reasoning`, `0309-non-reasoning`) — none are in
-   TeXRA's catalog yet (§3 still shows only 4.5/4.3). The catalog is
-   `llm-zoo`-sourced; `package.json` pins `1.25.0`, npm's current latest is
-   `1.26.0`. Unverified whether `1.26.0` already carries these models —
-   check before bumping.
+2. **The current pricing page adds `grok-4.6`, `grok-build-0.1`, and three
+   `grok-4.20-*` variants** (`multi-agent-0309`, `0309-reasoning`,
+   `0309-non-reasoning`). TeXRA now uses `llm-zoo` 1.27.0, which already
+   contains `grok-4.6`; the other listed IDs remain absent from that catalogue.
+   Section 3's older 4.5/4.3 inventory should therefore be refreshed, while
+   the remaining IDs require upstream catalogue support before TeXRA can offer
+   them.
 3. **Long-context pricing is a real, documented xAI mechanic**, not
    speculative: once a prompt's total tokens (cached and non-cached both)
-   cross a model's threshold, xAI bills *all* prompt tokens for that request
+   cross a model's threshold, xAI bills _all_ prompt tokens for that request
    at roughly double the short-context rate. Still unmodeled anywhere in
    TeXRA — `StandardPricingConfig` / `computeStandardPrice`
-   (`src/agent/utils/priceUtils.ts`) only carries one flat `inputPrice` /
-   `outputPrice` pair, and `llm-zoo`'s public schema has no long-context tier
-   field either (per its npm package description). Already flagged as a
+   (`src/agent/utils/priceUtils.ts`) carries flat input/output rates plus a
+   cache discount factor, but no long-context tier; `llm-zoo`'s public schema
+   likewise has no long-context tier field (per its npm package description).
+   Already flagged as a
    non-goal in §2 ("long-context pricing accuracy | llm-zoo / billing
    follow-up"); still open, now with a concrete billing mechanism to model
    against once a rate source exists.
@@ -284,13 +285,14 @@ catalog changes made — recon only**, per the §2 non-goals.
    a `response.compaction` object carrying an opaque `encrypted_content`
    blob to replay verbatim as the head of the next request. Responses-only —
    unreachable from TeXRA until this PRD's routing lands.
-5. Prompt-cache accounting itself is already correct at the *rate* level:
+5. Prompt-cache accounting itself is already correct at the _rate_ level:
    Chat Completions' `usage.prompt_tokens_details.cached_tokens` is exactly
    what `src/agent/modelHandlers/openai/openAIUsage.ts` already reads for
    every OpenAI-compatible handler, `ModelHandlerXAI` included. The only gap
-   is the long-context *tier* switch in point 3, not cache-token extraction.
+   is the long-context _tier_ switch in point 3, not cache-token extraction.
 
-Candidate next steps, smallest first: (a) verify and bump `llm-zoo` for the
-new model IDs, (b) model long-context tiered pricing in
-`computeStandardPrice` once a rate source exists, (c) revisit this PRD's
-default-off timeline given Chat Completions' now-explicit deprecated status.
+Candidate next steps, smallest first: (a) refresh §3 for `grok-4.6` and track
+upstream catalogue support for the remaining model IDs, (b) model long-context
+tiered pricing in `computeStandardPrice` once a rate source exists, (c) revisit
+this PRD's default-off timeline given Chat Completions' now-explicit deprecated
+status.


### PR DESCRIPTION
## Summary

Update the xAI Responses API PRD with a 2026-08-12 reconnaissance pass against xAI pricing, prompt-caching, and context-compaction documentation. This is documentation only; it changes no runtime behavior.

## Findings recorded

- xAI now labels Chat Completions deprecated, increasing the priority of the planned Responses migration.
- xAI documents `grok-4.6`, `grok-build-0.1`, and three `grok-4.20-*` variants. TeXRA’s current `llm-zoo` 1.27.0 catalogue already contains `grok-4.6`; the remaining listed IDs still require upstream catalogue support.
- xAI documents a long-context pricing tier. TeXRA models flat input/output rates and cache discounts, but not a context-length tier.
- `POST /v1/responses/compact` exists and returns opaque compaction content for later Responses requests.
- the existing OpenAI-compatible usage path already reads xAI cached-token accounting; the remaining pricing gap is the long-context tier.

## Review corrections

The original reconnaissance text referred to obsolete `llm-zoo` 1.25/1.26 versions and implied that `grok-4.6` was absent. The current head is rebased onto `main`, states the 1.27.0 catalogue facts, and describes the existing cache-discount pricing support accurately.

## Validation

- Prettier
- docs boundary and guidance-reference hooks
- `git diff --check`
- exact-head docs CI and automated re-review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only PRD update with no runtime, auth, or billing code changes.
> 
> **Overview**
> Adds **§14** to the xAI Responses / `previous_response_id` PRD and bumps the doc’s `updated` date to **2026-08-12**. This is **recon-only** documentation—no product or code changes.
> 
> The new section records five findings from current xAI docs: **Chat Completions is explicitly deprecated** (raising urgency for the planned Responses migration via `ModelHandlerXAI`), **new pricing-page model IDs** (`grok-4.6` already in `llm-zoo` 1.27.0; others still need catalogue support), **documented long-context tier billing** still absent from `computeStandardPrice` / `StandardPricingConfig`, confirmation that **`POST /v1/responses/compact` exists** (closes §11 Q3), and that **prompt cache token extraction is already correct** via `openAIUsage.ts` with the remaining gap being long-context tiers.
> 
> It also lists follow-ups: refresh §3 for `grok-4.6`, model long-context pricing when rates exist, and revisit the default-off rollout timeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd1aaca504c66a780103a82190b85fe1fd086d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->