### PR TITLE
refactor(agent): remove progress display fallbacks

### DIFF
--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -121,35 +121,28 @@ export function decodeXmlEntities(text: string): string {
 }
 
 function progressDetail(xml: string): string {
-  switch (attr(xml, 'type')) {
+  const type = attr(xml, 'type') as SubagentProgressUpdate['kind'];
+  switch (type) {
     case 'started':
       return 'started';
     case 'overview': {
-      const calls = attr(xml, 'tool-calls');
+      const calls = attr(xml, 'tool-calls')!;
       const cost = attr(xml, 'cost');
-      const parts: string[] = [];
-      if (calls) parts.push(`${calls} tool call${calls === '1' ? '' : 's'}`);
-      if (cost) parts.push(`$${cost}`);
-      return parts.length > 0 ? parts.join(' · ') : 'working';
+      const toolCalls = `${calls} tool call${calls === '1' ? '' : 's'}`;
+      return cost ? `${toolCalls} · $${cost}` : toolCalls;
     }
     case 'plan': {
       if (attr(xml, 'status') === 'cleared') return 'plan cleared';
       // The producer (`formatSubagentProgress`) attaches the plan objective as
       // `summary`; there is no step count on the wire.
-      const summary = attr(xml, 'summary');
-      return summary ? `plan · ${decodeXmlEntities(summary)}` : 'plan updated';
+      return `plan · ${decodeXmlEntities(attr(xml, 'summary')!)}`;
     }
     case 'todos': {
       const completed = attr(xml, 'completed');
       const active = attr(xml, 'active');
       const pending = attr(xml, 'pending');
-      if (completed || active || pending) {
-        return `todos · ${completed ?? '0'} done, ${active ?? '0'} active, ${pending ?? '0'} pending`;
-      }
-      return 'todos updated';
+      return `todos · ${completed} done, ${active} active, ${pending} pending`;
     }
-    default:
-      return 'working';
   }
 }
 


### PR DESCRIPTION
## Summary

- remove the unknown progress-kind fallback requested in #10056
- trust the canonical producer attributes for todo, overview, and plan progress
- delete the remaining display-only recovery branches instead of adding tests for formats the product does not emit

## Why

`formatSubagentProgress` owns this XML and emits a closed four-kind union with the required attributes. Retaining presentation fallbacks for malformed or historical shapes adds branches and ambiguous output without protecting a current contract. The parser now follows the typed producer directly.

Net change: 7 insertions, 14 deletions.

## Validation

- `pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/SubagentFollowup.vitest.ts src/test-kernel/tools/ToolStatusFormatting.vitest.ts` (38 passed)
- `pnpm run typecheck:test-kernel`
- `git diff --check`

Closes #10056

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only CLI/extension status text for subagent progress; no auth, persistence, or wire-format changes beyond trusting the canonical producer.
> 
> **Overview**
> **`progressDetail`** in `subagentFollowup.ts` now assumes XML from **`formatSubagentProgress`** only: `type` is typed as **`SubagentProgressUpdate['kind']`**, and display-only recovery paths are gone.
> 
> For **overview**, **plan**, and **todos**, status lines always use the producer’s attributes (`tool-calls`, `summary`, completed/active/pending counts) instead of fallbacks like **`working`**, **`plan updated`**, **`todos updated`**, or default **`0`** when attributes are missing. The **`default`** switch branch that returned **`working`** for unknown kinds is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d5d49686bf5f71c03a745aaa2b1cf42ba3ca26e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->