### PR TITLE
chore: mark devise remote agent as public

### DIFF
--- a/docs/supabase/SYNC_REMOTE_AGENTS.sql
+++ b/docs/supabase/SYNC_REMOTE_AGENTS.sql
@@ -46,7 +46,7 @@ VALUES (
   'devise',
   'Mathematical paper enhancer with two-phase workflow. Rewrites document(s) by first adding rigorous derivations then revising to publication-ready scientific style.',
   'QITBench/devise.yaml',
-  ARRAY['researcher', 'QITBench'],
+  ARRAY['researcher', 'QITBench', 'public'],
   'workflow',
   NULL
 )

--- a/docs/supabase/remote-agents.config.json
+++ b/docs/supabase/remote-agents.config.json
@@ -19,7 +19,7 @@
     },
     "devise": {
       "folder": "QITBench",
-      "visibility": ["researcher", "QITBench"]
+      "visibility": ["researcher", "QITBench", "public"]
     },
     "elevate": { "folder": "researcher", "visibility": ["researcher"] },
     "enhance": { "folder": "whitelist", "visibility": ["public"] },


### PR DESCRIPTION
## Summary

- Add `public` to the `devise` agent visibility tags in `docs/supabase/remote-agents.config.json`.
- Keep the matching seed row in `docs/supabase/SYNC_REMOTE_AGENTS.sql` in sync.

## Context

`devise` was limited to `researcher` and `QITBench`. This makes it available under the `public` visibility tag as well (alongside the existing tags).

## After merge

Re-run the remote-agents sync against Supabase if production should pick up the new tag.

## Test plan

- [ ] Confirm config JSON remains valid
- [ ] Confirm SQL seed `ARRAY[...]` matches the config visibility list
- [ ] After deploy/sync, verify `devise` appears for public-tier users as intended

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only visibility metadata for one agent; no application logic changes, though production needs a sync to take effect.
> 
> **Overview**
> Adds the **`public`** visibility tag to the **`devise`** workflow agent so it can be offered to public-tier users, not only **`researcher`** and **`QITBench`**.
> 
> The tag is updated in **`docs/supabase/remote-agents.config.json`** (source of truth for folder/visibility) and mirrored in the **`devise`** seed row in **`docs/supabase/SYNC_REMOTE_AGENTS.sql`** so the generated SQL stays aligned.
> 
> After merge, re-run the remote-agents sync against Supabase if production should pick up the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6c8ce07b642a1fcb0235bb4d7b03a4b20341fd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->