### PR TITLE
fix(cli): classify shutdown launch cancellation

### DIFF
--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -16,10 +16,11 @@ import {
   type ValidatedExecutionRequest,
 } from '@agent/core/state/executionRequests';
 import { AgentError } from '@common/errors';
+import { isUserAbort } from '@common/errors/sdkError/errorPatterns';
 import { tryPlatform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import { RUN_OUTCOME, type ExecutionId, AgentCategory } from '@shared/schemas';
-import { generateExecutionId } from '@utils/core';
+import { aggregateError, generateExecutionId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { warnApprovalDenied } from './approval/approvalPrompts';
@@ -323,15 +324,16 @@ export async function executeCliRequest(
       // not prevent signal termination indefinitely; on timeout, leave the
       // lease intact for stale-owner recovery rather than releasing it early.
       const grace = new AbortController();
+      const graceExpired = sleep(CLI_RUN_SHUTDOWN_GRACE_MS, undefined, {
+        signal: grace.signal,
+      }).catch((error: unknown) => {
+        if (!grace.signal.aborted) throw error;
+      });
       try {
-        await Promise.race([
-          shutdownFinalizationDone,
-          sleep(CLI_RUN_SHUTDOWN_GRACE_MS, undefined, {
-            signal: grace.signal,
-          }),
-        ]);
+        await Promise.race([shutdownFinalizationDone, graceExpired]);
       } finally {
         grace.abort();
+        await graceExpired;
       }
     },
   );
@@ -392,6 +394,7 @@ export async function executeCliRequest(
     | { readonly ok: true; readonly result: ExecuteAgentResult }
     | { readonly ok: false } = { ok: false };
   let primaryRunFailure: { readonly error: unknown } | undefined;
+  let shutdownLaunchAborted = false;
   let presentationAttached = true;
   const detachPresentation = async (): Promise<void> => {
     if (!presentationAttached) return;
@@ -412,7 +415,9 @@ export async function executeCliRequest(
     // exit code here; anything else (e.g. registerExecution disk I/O,
     // workspaceState.update failures) is unexpected and must keep
     // propagating to bin/texra.ts's crash handler.
-    if (!(err instanceof AgentError)) {
+    if (shutdownRequested && isUserAbort(err)) {
+      shutdownLaunchAborted = true;
+    } else if (!(err instanceof AgentError)) {
       primaryRunFailure = { error: err };
     } else if (!failurePresented && !terminalResult.isHandled()) {
       // A failure before lifecycle startup has no `result` event. Preserve the
@@ -444,15 +449,12 @@ export async function executeCliRequest(
     }
   }
   if (cleanupFailures.length > 0) {
-    const cleanupFailure =
-      cleanupFailures.length === 1
-        ? cleanupFailures[0]
-        : new AggregateError(
-            cleanupFailures,
-            'CLI execution cleanup encountered multiple failures',
-          );
+    const cleanupFailure = aggregateError(
+      cleanupFailures,
+      'CLI execution cleanup encountered multiple failures',
+    );
     if (primaryRunFailure) {
-      throw new AggregateError(
+      throw aggregateError(
         [primaryRunFailure.error, cleanupFailure],
         'CLI execution failed and its final artifacts could not be persisted',
       );
@@ -466,7 +468,9 @@ export async function executeCliRequest(
   if (!runResult.ok) {
     return {
       ok: false,
-      exitCode: runOutcomeExitCode(RUN_OUTCOME.FAILED),
+      exitCode: shutdownLaunchAborted
+        ? CliExitCode.Interrupted
+        : runOutcomeExitCode(RUN_OUTCOME.FAILED),
     };
   }
 

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -909,7 +909,7 @@ describe('executeCliRequest', () => {
         await new Promise<void>((_resolve, reject) => {
           options.launchSignal?.addEventListener(
             'abort',
-            () => reject(new AgentError('launch aborted')),
+            () => reject(new DOMException('Launch interrupted.', 'AbortError')),
             { once: true },
           );
         });
@@ -923,7 +923,10 @@ describe('executeCliRequest', () => {
     await vi.waitFor(() => expect(launchSignal).toBeDefined());
 
     await platform.lifecycle.runShutdown();
-    await expect(run).rejects.toThrow('launch aborted');
+    await expect(run).resolves.toEqual({
+      ok: false,
+      exitCode: CliExitCode.Interrupted,
+    });
     expect(launchSignal?.aborted).toBe(true);
     expect(mocks.finalizeExecution).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Follow-up to #10053 for automated review findings that arrived as that PR was merged externally.\n\n## Summary\n\n- classify shutdown-induced launch aborts as expected interrupted exits instead of CLI crashes\n- explicitly consume cancellation of the shutdown grace timer\n- use the shared aggregate-error helper for cleanup failures\n\n## Validation\n\n- 36 focused CLI execution tests\n- CLI and test-kernel type checks\n- focused ESLint and Prettier checks\n\nThis preserves the durability ordering from #10053 while closing its final exact-head review findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI shutdown and exit-code classification changes with focused test coverage; no auth, data, or broad API surface impact.
> 
> **Overview**
> When platform shutdown aborts launch preparation, the CLI now treats **`isUserAbort`** failures as an expected **interrupted** exit (`CliExitCode.Interrupted`) instead of a generic failed outcome or an unhandled crash.
> 
> Shutdown grace handling **awaits** the timer promise after aborting it so a cancelled sleep does not surface as an unhandled rejection. Cleanup paths use the shared **`aggregateError`** helper instead of constructing `AggregateError` inline.
> 
> The launch-cancel test now simulates a real **`AbortError`** and asserts a resolved interrupted result rather than a thrown error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 136fe24538aa58cadfb603bb2457d722f4797a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->