### PR TITLE
test(model): guard direct-route API-key ownership

### DIFF
--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -20,7 +20,10 @@ import {
 } from '@model/providerCapabilities';
 import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
 import type { ModelOptionData } from '@shared/schemas';
-import { FAST_FIRST_RESPONSE_HINT } from '@shared/constants/providers';
+import {
+  API_KEY_PROVIDER_IDS,
+  FAST_FIRST_RESPONSE_HINT,
+} from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { FakeSecrets } from '@test/support/FakePlatform';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
@@ -279,6 +282,16 @@ describe('computeModelOptionsData relay quota state', () => {
     expect(reason).toBe(
       'Model "haiku3" is retired and no longer available from its provider. Choose an active model.',
     );
+  });
+
+  it('keeps every active catalogue provider in the API-key registry', () => {
+    const apiKeyProviders = new Set<string>(API_KEY_PROVIDER_IDS);
+
+    for (const config of Object.values(MODEL_CONFIGS)) {
+      if (!config.retired && !config.deprecated) {
+        expect(apiKeyProviders).toContain(config.provider);
+      }
+    }
   });
 
   it('honors the catalogue retirement of the legacy Copilot model', async () => {

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -15,15 +15,16 @@ import {
   type ModelOptionsServerAccess,
 } from '@model/computeModelOptions';
 import {
+  resolveDirectModelApiKeyProvider,
+  shouldRouteModelThroughOpenRouter,
+} from '@model/openRouterRouting';
+import {
   CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
   isCodexSubscriptionEligible,
 } from '@model/providerCapabilities';
 import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
 import type { ModelOptionData } from '@shared/schemas';
-import {
-  API_KEY_PROVIDER_IDS,
-  FAST_FIRST_RESPONSE_HINT,
-} from '@shared/constants/providers';
+import { FAST_FIRST_RESPONSE_HINT } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { FakeSecrets } from '@test/support/FakePlatform';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
@@ -102,6 +103,20 @@ function initSubscriptionPlatform(
     secrets,
   });
 }
+
+describe('model catalogue direct-route key ownership', () => {
+  it('assigns every servable direct route to an API-key provider', () => {
+    for (const [modelId, config] of Object.entries(MODEL_CONFIGS)) {
+      if (config.retired) continue;
+      if (shouldRouteModelThroughOpenRouter(config, false)) continue;
+
+      expect(
+        resolveDirectModelApiKeyProvider(config),
+        `${modelId} (${config.provider}) is servable without OpenRouter but has no direct API-key owner`,
+      ).toBeDefined();
+    }
+  });
+});
 
 describe('computeModelOptionsData relay quota state', () => {
   setupPlatform({
@@ -282,16 +297,6 @@ describe('computeModelOptionsData relay quota state', () => {
     expect(reason).toBe(
       'Model "haiku3" is retired and no longer available from its provider. Choose an active model.',
     );
-  });
-
-  it('keeps every active catalogue provider in the API-key registry', () => {
-    const apiKeyProviders = new Set<string>(API_KEY_PROVIDER_IDS);
-
-    for (const config of Object.values(MODEL_CONFIGS)) {
-      if (!config.retired && !config.deprecated) {
-        expect(apiKeyProviders).toContain(config.provider);
-      }
-    }
   });
 
   it('honors the catalogue retirement of the legacy Copilot model', async () => {


### PR DESCRIPTION
## Summary

Guard the provider-key availability message against catalogue drift without changing runtime behavior. Every non-retired model whose selected route is direct must resolve to a registered direct API-key owner. Models routed through OpenRouter remain intentionally outside this invariant.

Closes #10061.

## Issue acceptance gates

- Every servable direct route has an API-key owner.
- OpenRouter-routed models are not falsely required to register their catalogue provider as a direct key owner.
- Deprecated-but-still-servable models remain covered; only retired entries are excluded.
- A future failure identifies the model and provider that violate the invariant.

## Single source of truth

The test calls `shouldRouteModelThroughOpenRouter` and `resolveDirectModelApiKeyProvider`, the same routing helpers used by production model availability. It does not reproduce provider-list membership logic independently.

## Duplication and abstraction budget

Test-only change. No new production abstraction, export, schema, compatibility path, or runtime branch.

## Net elements (R6)

- 1 test file changed.
- No production files changed.
- No exports, classes, interfaces, enums, schemas, or public methods added or removed.

## Consumer counts (R8)

The two imported routing helpers are existing production functions. This PR adds one test consumer for each and removes the raw `API_KEY_PROVIDER_IDS` test dependency.

## Host impact

None. Extension, desktop, and CLI runtime behavior is unchanged.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm vitest run src/test-kernel/model/ComputeModelOptions.vitest.ts` — 25 passed.
- `corepack pnpm exec eslint src/test-kernel/model/ComputeModelOptions.vitest.ts` — clean.
- `npm run typecheck:workspace` — clean.
- Prettier, diff check, pre-commit, and pre-push checks — clean.
