### PR TITLE
fix(claude): fail fork missing session id

### DIFF
--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -555,17 +555,56 @@ describe('claude_agent tool launch and resume fallback', () => {
       session_id: 'source-session',
       fork_session: true,
     });
-    const turn = await captured.strategy?.launch?.(
+    const turn = (await captured.strategy?.launch?.(
       { notify: () => {}, recordCost: () => {} },
       new AbortController(),
-    );
+    )) as
+      | { isError: boolean; sessionId?: string; errorMessage?: string }
+      | undefined;
 
-    expect(turn).toMatchObject({
-      isError: true,
-      sessionId: undefined,
-      errorMessage: expect.stringContaining('missing session_id'),
-    });
+    expect(turn?.isError).toBe(true);
+    expect(turn?.sessionId).toBeUndefined();
+    expect(turn?.errorMessage).toContain('missing session_id');
+    expect(captured.strategy?.isTurnError?.(turn)).toBe(true);
     expect(mocks.query).toHaveBeenCalledOnce();
+  });
+
+  it('preserves a provider error after an earlier fork success result', async () => {
+    mocks.query.mockReturnValue(
+      (async function* () {
+        yield {
+          type: 'result',
+          subtype: 'success',
+          result: 'Intermediate success without a session id.',
+          modelUsage: {},
+          total_cost_usd: 0,
+        };
+        yield {
+          type: 'result',
+          subtype: 'error_during_execution',
+          errors: ['provider failed after success'],
+          modelUsage: {},
+          total_cost_usd: 0,
+        };
+      })(),
+    );
+    const captured = captureStrategy();
+
+    await new ClaudeAgentTool().call({
+      prompt: 'try a different proof',
+      session_id: 'source-session',
+      fork_session: true,
+    });
+    const turn = (await captured.strategy?.launch?.(
+      { notify: () => {}, recordCost: () => {} },
+      new AbortController(),
+    )) as
+      | { isError: boolean; sessionId?: string; errorMessage?: string }
+      | undefined;
+
+    expect(turn?.isError).toBe(true);
+    expect(turn?.sessionId).toBeUndefined();
+    expect(turn?.errorMessage).toBe('provider failed after success');
   });
 
   it('rejects a fork from a live session owned by another stream', async () => {

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -536,6 +536,38 @@ describe('claude_agent tool launch and resume fallback', () => {
     ClaudeAgentSessions.release('forked-session');
   });
 
+  it('fails a fork whose success result omits session_id', async () => {
+    mocks.query.mockReturnValue(
+      (async function* () {
+        yield {
+          type: 'result',
+          subtype: 'success',
+          result: 'Forked without identifying the new session.',
+          modelUsage: {},
+          total_cost_usd: 0,
+        };
+      })(),
+    );
+    const captured = captureStrategy();
+
+    await new ClaudeAgentTool().call({
+      prompt: 'try a different proof',
+      session_id: 'source-session',
+      fork_session: true,
+    });
+    const turn = await captured.strategy?.launch?.(
+      { notify: () => {}, recordCost: () => {} },
+      new AbortController(),
+    );
+
+    expect(turn).toMatchObject({
+      isError: true,
+      sessionId: undefined,
+      errorMessage: expect.stringContaining('missing session_id'),
+    });
+    expect(mocks.query).toHaveBeenCalledOnce();
+  });
+
   it('rejects a fork from a live session owned by another stream', async () => {
     const sourceExecutionId = 'source-execution' as ExecutionId;
     const sourceOwner = 'stream:other-owner' as StreamTabId;

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -250,6 +250,7 @@ export async function runStreamedTurn(params: {
   let totalCostUsd: number | undefined;
   let isError = false;
   let errorMessage: string | undefined;
+  let succeeded = false;
 
   try {
     for await (const raw of stream) {
@@ -276,6 +277,7 @@ export async function runStreamedTurn(params: {
               : aggregateClaudeModelUsage(raw.modelUsage);
           totalCostUsd = raw.total_cost_usd;
           if (raw.subtype === 'success') {
+            succeeded = true;
             if (isNonEmptyString(raw.result)) {
               responseParts.push(raw.result);
             }
@@ -299,6 +301,12 @@ export async function runStreamedTurn(params: {
     }
   } finally {
     backgroundTasks.finish();
+  }
+
+  if (params.forkSession && succeeded && !sessionId) {
+    isError = true;
+    errorMessage =
+      'Claude SDK fork success result is missing session_id; refusing to resume the source session.';
   }
 
   return {

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -303,7 +303,7 @@ export async function runStreamedTurn(params: {
     backgroundTasks.finish();
   }
 
-  if (params.forkSession && succeeded && !sessionId) {
+  if (params.forkSession && succeeded && !isError && !sessionId) {
     isError = true;
     errorMessage =
       'Claude SDK fork success result is missing session_id; refusing to resume the source session.';


### PR DESCRIPTION
## Summary

A successful Claude fork must acquire a distinct session identity before any later turn may resume. This change treats a fork success without `session_id` as an explicit failed turn, preventing follow-ups from resuming and mutating the source conversation.

The missing-ID diagnosis is applied only when the turn would otherwise be successful. If the provider later reports a real error, that error remains authoritative.

Closes #10037.

## Issue acceptance gates

- A successful fork without `session_id` fails loudly.
- The failed turn satisfies the child-loop `isTurnError` boundary, so the loop stops before another provider turn can resume the source session.
- A normal fork with a distinct ID still resumes the forked session on later turns and never repeats `forkSession`.
- A provider error is not overwritten by the missing-ID guard.

## Single source of truth

`runStreamedTurn` owns interpretation of the provider stream and returns one `TurnResult`. The shared child-run loop owns whether a failed turn terminates the loop. The Claude session registry is updated only by the existing successful-turn path, after a valid session identity exists.

## Duplication and abstraction budget

No abstraction or compatibility path is added. The change adds one post-stream invariant to the existing turn interpreter and focused regression coverage.

## Net elements (R6)

- 2 files changed.
- No exports, classes, interfaces, enums, schemas, or public methods added or removed.
- One boolean turn invariant added; tests expanded for missing identity and diagnostic precedence.

## Consumer counts (R8)

`runStreamedTurn` has two production consumers in `src/tools/claudeAgent.ts`: first-turn launch and subsequent-turn execution through the same strategy. Both receive the same `TurnResult`; the existing `isTurnError: turn => turn.isError` boundary has one strategy registration and is unchanged.

## Host impact

Extension, desktop, and CLI share the same Claude-agent tool and child-run loop. All now reject an unidentified fork before any host can submit a follow-up against the source session.

## Scheduled refactoring

None. A fork that echoes the source ID rather than omitting it is not generalized here without evidence that the provider can produce that response.

## Validation

- `corepack pnpm vitest run src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts src/test-kernel/agent/followUp/ClaudeAgentProgressEvents.vitest.ts` — 16 passed.
- `corepack pnpm exec eslint src/tools/claudeAgent.ts src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts` — clean.
- `corepack pnpm exec tsc --noEmit --checkers 8 -p tsconfig.test-kernel.json` — clean.
- `corepack pnpm exec prettier --check ...` and `git diff --check` — clean.
