### PR TITLE
fix(cli): report active child sessions in status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### CLI
+
+#### Bug Fixes
+
+- **Session status reports active delegated work** — `/status` now shows the
+  number of active child sessions while retaining the focused session's own
+  status.
+
 ## [0.40.2] - 2026-08-12
 
 ### CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 #### Bug Fixes
 
 - **Session status reports active delegated work** — `/status` now shows the
-  number of active child sessions while retaining the focused session's own
+  number of active background tasks while retaining the focused session's own
   status.
 
 ## [0.40.2] - 2026-08-12

--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -98,12 +98,26 @@ export async function showCliSessionStatus(
   const activeStreamId = activeStreamIdSignal.get();
   const streamSlices = streams.get();
   const slice = activeStreamId ? streamSlices.get(activeStreamId) : undefined;
-  const workflowStreamId = activeStreamId
-    ? activeStreamParentOrSelfId({
-        activeStreamId,
-        parentStream: parentStream.get(),
-      })
-    : undefined;
+  const directActiveChildren = activeStreamId
+    ? activeSubagentsFor(activeStreamId, childStreamEntries.get(), streamSlices)
+    : [];
+  const workflowStreamId =
+    activeStreamId && directActiveChildren.length === 0
+      ? activeStreamParentOrSelfId({
+          activeStreamId,
+          parentStream: parentStream.get(),
+        })
+      : activeStreamId;
+  let activeChildSessions = directActiveChildren.length;
+  if (workflowStreamId !== activeStreamId) {
+    activeChildSessions = workflowStreamId
+      ? activeSubagentsFor(
+          workflowStreamId,
+          childStreamEntries.get(),
+          streamSlices,
+        ).length
+      : 0;
+  }
   // Use root-session access facts only before any stream exists.
   const model = slice?.model ?? (meta.model || context.initialModel);
   const subscriptionActive = await isCodexSubscriptionActive(model);
@@ -125,13 +139,7 @@ export async function showCliSessionStatus(
       approvalBypasses: slice?.bypass,
       status: slice?.status ?? 'not started',
       substate: slice?.substate,
-      activeChildSessions: workflowStreamId
-        ? activeSubagentsFor(
-            workflowStreamId,
-            childStreamEntries.get(),
-            streamSlices,
-          ).length
-        : 0,
+      activeChildSessions,
       goal: activeStreamId ? GoalStore.getForStream(activeStreamId) : undefined,
       // Only surface the resume id once a stream exists — never next to
       // a "not started" status.

--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -10,6 +10,7 @@ import { requestCliCompaction } from '@cli/chat/tui/state/compactionRequest';
 import {
   activeSubagentsFor,
   childStreamEntries,
+  parentStream,
 } from '@cli/chat/tui/state/childExecutions';
 import {
   activeStreamId as activeStreamIdSignal,
@@ -30,6 +31,7 @@ import {
 } from '@cli/chat/tui/state/subscribeStreamArtifacts';
 import { terminalCapabilities } from '@cli/chat/tui/state/terminalCapabilities';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
+import { activeStreamParentOrSelfId } from '@cli/chat/tui/state/streamViews';
 import {
   isCodexSubscriptionActive,
   isKimiCodeSubscriptionActive,
@@ -96,6 +98,12 @@ export async function showCliSessionStatus(
   const activeStreamId = activeStreamIdSignal.get();
   const streamSlices = streams.get();
   const slice = activeStreamId ? streamSlices.get(activeStreamId) : undefined;
+  const workflowStreamId = activeStreamId
+    ? activeStreamParentOrSelfId({
+        activeStreamId,
+        parentStream: parentStream.get(),
+      })
+    : undefined;
   // Use root-session access facts only before any stream exists.
   const model = slice?.model ?? (meta.model || context.initialModel);
   const subscriptionActive = await isCodexSubscriptionActive(model);
@@ -117,9 +125,9 @@ export async function showCliSessionStatus(
       approvalBypasses: slice?.bypass,
       status: slice?.status ?? 'not started',
       substate: slice?.substate,
-      activeChildSessions: activeStreamId
+      activeChildSessions: workflowStreamId
         ? activeSubagentsFor(
-            activeStreamId,
+            workflowStreamId,
             childStreamEntries.get(),
             streamSlices,
           ).length

--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -8,6 +8,10 @@ import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
 import { formatCliSessionStatus } from '@cli/chat/tui/sessionStatus';
 import { requestCliCompaction } from '@cli/chat/tui/state/compactionRequest';
 import {
+  activeSubagentsFor,
+  childStreamEntries,
+} from '@cli/chat/tui/state/childExecutions';
+import {
   activeStreamId as activeStreamIdSignal,
   beginWorkPlanReaderRequest,
   cancelPendingWorkPlanReaderRequest,
@@ -90,7 +94,8 @@ export async function showCliSessionStatus(
 ): Promise<void> {
   const meta = sessionMeta.get();
   const activeStreamId = activeStreamIdSignal.get();
-  const slice = activeStreamId ? streams.get().get(activeStreamId) : undefined;
+  const streamSlices = streams.get();
+  const slice = activeStreamId ? streamSlices.get(activeStreamId) : undefined;
   // Use root-session access facts only before any stream exists.
   const model = slice?.model ?? (meta.model || context.initialModel);
   const subscriptionActive = await isCodexSubscriptionActive(model);
@@ -112,6 +117,13 @@ export async function showCliSessionStatus(
       approvalBypasses: slice?.bypass,
       status: slice?.status ?? 'not started',
       substate: slice?.substate,
+      activeChildSessions: activeStreamId
+        ? activeSubagentsFor(
+            activeStreamId,
+            childStreamEntries.get(),
+            streamSlices,
+          ).length
+        : 0,
       goal: activeStreamId ? GoalStore.getForStream(activeStreamId) : undefined,
       // Only surface the resume id once a stream exists — never next to
       // a "not started" status.

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -5,6 +5,7 @@ import {
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
 import type { StreamSubstate } from '@shared/schemas';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
+import { BACKGROUND_TASK } from '@shared/copy/nestedRuns';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 import { truncateSummary } from '@utils/text/stringUtils';
 
@@ -96,7 +97,7 @@ export function formatCliSessionStatus(input: CliSessionStatusInput): string {
       : []),
     `status: ${formatCliStatusLabel(input.status, input.substate)}`,
     ...(input.activeChildSessions && input.activeChildSessions > 0
-      ? [`active child sessions: ${input.activeChildSessions}`]
+      ? [`active ${BACKGROUND_TASK.inlinePlural}: ${input.activeChildSessions}`]
       : []),
     ...(input.goal
       ? [

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -28,6 +28,7 @@ export interface CliSessionStatusInput {
   readonly approvalBypasses?: Partial<BypassState>;
   readonly status: string;
   readonly substate?: StreamSubstate;
+  readonly activeChildSessions?: number;
   readonly goal?: CliSessionGoalStatus | null;
   readonly queuedFollowUpMessages: readonly string[];
   /** Root execution id, when a run has started. Surfaces the resume command
@@ -94,6 +95,9 @@ export function formatCliSessionStatus(input: CliSessionStatusInput): string {
       ? [`auto-approvals: ${bypassLabels.join(', ')}`]
       : []),
     `status: ${formatCliStatusLabel(input.status, input.substate)}`,
+    ...(input.activeChildSessions && input.activeChildSessions > 0
+      ? [`active child sessions: ${input.activeChildSessions}`]
+      : []),
     ...(input.goal
       ? [
           `goal: ${input.goal.status}`,

--- a/src/test-kernel/cli/SessionStatus.vitest.ts
+++ b/src/test-kernel/cli/SessionStatus.vitest.ts
@@ -149,6 +149,16 @@ describe('CLI session status formatter', () => {
     ).toContain('queued follow-ups: 0');
   });
 
+  it('reports active child sessions only when the count is nonzero', () => {
+    expect(sessionStatus({ activeChildSessions: 1 })).toContain(
+      ['status: running', 'active child sessions: 1'].join('\n'),
+    );
+    expect(sessionStatus({ activeChildSessions: 0 })).not.toContain(
+      'active child sessions:',
+    );
+    expect(sessionStatus()).not.toContain('active child sessions:');
+  });
+
   it('reports active session approval bypasses', () => {
     const status = sessionStatus({
       approval: 'ask before privileged actions',

--- a/src/test-kernel/cli/SessionStatus.vitest.ts
+++ b/src/test-kernel/cli/SessionStatus.vitest.ts
@@ -151,12 +151,12 @@ describe('CLI session status formatter', () => {
 
   it('reports active child sessions only when the count is nonzero', () => {
     expect(sessionStatus({ activeChildSessions: 1 })).toContain(
-      ['status: running', 'active child sessions: 1'].join('\n'),
+      ['status: running', 'active background tasks: 1'].join('\n'),
     );
     expect(sessionStatus({ activeChildSessions: 0 })).not.toContain(
-      'active child sessions:',
+      'active background tasks:',
     );
-    expect(sessionStatus()).not.toContain('active child sessions:');
+    expect(sessionStatus()).not.toContain('active background tasks:');
   });
 
   it('reports active session approval bypasses', () => {

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -936,6 +936,45 @@ describe('handleTuiSlashCommand', () => {
     expect(statusText).toContain('active background tasks: 2');
   });
 
+  it('counts delegated work owned by a focused intermediate parent', async () => {
+    registerBuiltinSlashCommands();
+    const session = createSession();
+    const rootStreamId = 'stream-root' as StreamTabId;
+    const parentStreamId = 'stream-parent' as StreamTabId;
+    const rootSiblingIds = [
+      'stream-root-sibling-1',
+      'stream-root-sibling-2',
+    ] as StreamTabId[];
+    const grandchildId = 'stream-grandchild' as StreamTabId;
+    activeStreamId.set(parentStreamId);
+    for (const streamId of [parentStreamId, ...rootSiblingIds, grandchildId]) {
+      setStreamStatusInCliState({
+        streamId,
+        status: STREAM_PHASE.RUNNING,
+      });
+    }
+    const rosterRow = (childStreamId: StreamTabId, index: number) => ({
+      executionId: `nested-exec-${index}`,
+      identity: { kind: 'agent' as const, agent: `reviewer-${index}` },
+      agentName: `reviewer-${index}`,
+      status: STREAM_PHASE.RUNNING,
+      startedAt: index + 1,
+      elapsed: '1s',
+      childStreamId,
+    });
+    projectChildRoster(
+      rootStreamId,
+      [parentStreamId, ...rootSiblingIds].map(rosterRow),
+    );
+    projectChildRoster(parentStreamId, [rosterRow(grandchildId, 3)]);
+
+    await handleTuiSlashCommand('/status', createContext(session));
+
+    const statusText = lastEntryText(rootStreamId);
+    expect(statusText).toContain('active background tasks: 1');
+    expect(statusText).not.toContain('active background tasks: 3');
+  });
+
   it('reports the access route that produced the focused stream usage', async () => {
     registerBuiltinSlashCommands();
     const overview = vi.spyOn(apiStatus, 'loadCliModelAccessOverview');

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -900,7 +900,7 @@ describe('handleTuiSlashCommand', () => {
 
     const statusText = lastEntryText(rootStreamId);
     expect(statusText).toContain('status: idle');
-    expect(statusText).toContain('active child sessions: 1');
+    expect(statusText).toContain('active background tasks: 1');
   });
 
   it('reports the access route that produced the focused stream usage', async () => {

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -39,6 +39,7 @@ import {
   type ConversationEntry,
   setStreamStatusInCliState,
 } from '@cli/chat/tui/state/cliState';
+import { projectChildRoster } from '@cli/chat/tui/state/childExecutions';
 import type { StreamArtifactReader } from '@cli/chat/tui/state/subscribeStreamArtifacts';
 import * as apiStatus from '@cli/runtime/apiStatus';
 import * as chatGptLogin from '@cli/runtime/chatgptLogin';
@@ -867,6 +868,39 @@ describe('handleTuiSlashCommand', () => {
     const statusText = lastEntryText(streamId);
     expect(statusText).toContain('resume later with: texra resume exec-1');
     expect(statusText).not.toContain('--cwd');
+  });
+
+  it('reports active children while preserving an idle focused root status', async () => {
+    registerBuiltinSlashCommands();
+    const session = createSession();
+    const rootStreamId = 'stream-root' as StreamTabId;
+    const childStreamId = 'stream-child' as StreamTabId;
+    activeStreamId.set(rootStreamId);
+    setStreamStatusInCliState({
+      streamId: rootStreamId,
+      status: STREAM_PHASE.WAITING,
+    });
+    setStreamStatusInCliState({
+      streamId: childStreamId,
+      status: STREAM_PHASE.RUNNING,
+    });
+    projectChildRoster(rootStreamId, [
+      {
+        executionId: 'child-exec',
+        identity: { kind: 'agent', agent: 'critic' },
+        agentName: 'critic',
+        status: STREAM_PHASE.RUNNING,
+        startedAt: 1,
+        elapsed: '1s',
+        childStreamId,
+      },
+    ]);
+
+    await handleTuiSlashCommand('/status', createContext(session));
+
+    const statusText = lastEntryText(rootStreamId);
+    expect(statusText).toContain('status: idle');
+    expect(statusText).toContain('active child sessions: 1');
   });
 
   it('reports the access route that produced the focused stream usage', async () => {

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -903,6 +903,39 @@ describe('handleTuiSlashCommand', () => {
     expect(statusText).toContain('active background tasks: 1');
   });
 
+  it('reports the owning workflow count while a background task is focused', async () => {
+    registerBuiltinSlashCommands();
+    const session = createSession();
+    const rootStreamId = 'stream-root' as StreamTabId;
+    const focusedChildId = 'stream-focused-child' as StreamTabId;
+    const siblingChildId = 'stream-sibling-child' as StreamTabId;
+    activeStreamId.set(focusedChildId);
+    for (const streamId of [focusedChildId, siblingChildId]) {
+      setStreamStatusInCliState({
+        streamId,
+        status: STREAM_PHASE.RUNNING,
+      });
+    }
+    projectChildRoster(
+      rootStreamId,
+      [focusedChildId, siblingChildId].map((childStreamId, index) => ({
+        executionId: `child-exec-${index}`,
+        identity: { kind: 'agent' as const, agent: `critic-${index}` },
+        agentName: `critic-${index}`,
+        status: STREAM_PHASE.RUNNING,
+        startedAt: index + 1,
+        elapsed: '1s',
+        childStreamId,
+      })),
+    );
+
+    await handleTuiSlashCommand('/status', createContext(session));
+
+    const statusText = lastEntryText(rootStreamId);
+    expect(statusText).toContain('status: running');
+    expect(statusText).toContain('active background tasks: 2');
+  });
+
   it('reports the access route that produced the focused stream usage', async () => {
     registerBuiltinSlashCommands();
     const overview = vi.spyOn(apiStatus, 'loadCliModelAccessOverview');


### PR DESCRIPTION
Closes #10039.\n\n## Summary\n\n- show the number of active child sessions in /status when nonzero\n- derive the count from the canonical child-session selector and stream state\n- preserve the focused stream status and ordinary single-session output\n\n## Validation\n\n- 267 focused CLI formatter, slash-command, and TUI state tests\n- CLI and test-kernel type checks\n- focused ESLint and Prettier checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only status formatting and read-only aggregation of existing TUI state; no auth, persistence, or execution-path changes.
> 
> **Overview**
> **`/status` now surfaces delegated work** when background tasks are running, without changing how the focused stream’s own status line reads.
> 
> The handler derives an **active child session count** from `activeSubagentsFor` and child-stream state. When the focused tab has no direct children (e.g. you’re on a background task), it walks up via `activeStreamParentOrSelfId` so the count reflects the **owning workflow**—siblings under the same parent, or grandchildren under an intermediate parent—not unrelated streams.
> 
> `formatCliSessionStatus` adds an **`active background tasks: N`** line only when **N > 0**, using shared nested-run copy. Tests cover idle root + running child, focused child with siblings, and nested parent/grandchild counting; the changelog documents the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e094136ef54e7464e03bf2922e15b827e1f0cab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->