### PR TITLE
fix(cli): prevent cancelled recovery lease reacquisition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - **Session status reports active delegated work** — `/status` now shows the
   number of active background tasks while retaining the focused session's own
   status.
+- **Interrupted multi-agent chats can be resumed immediately** — leaving a
+  cancelled team session no longer leaves its printed resume command
+  temporarily unavailable.
 
 ### Shared (all surfaces)
 

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -277,6 +277,33 @@ export function createChatSessionController(
     ];
   };
 
+  // A cancelled root can publish completion just before its run promise
+  // settles. During that narrow interval its teardown can still overwrite a
+  // successor's root-slot state. Retain every unsettled interrupted generation
+  // so a later interruption cannot discard an earlier blocker.
+  const recoveryBlockedByInterruptedRuns = new Set<Promise<void>>();
+  const blockRecoveryUntilInterruptedRunSettles = (): void => {
+    const interruptedRun = session.runPromise;
+    if (
+      !interruptedRun ||
+      session.runCompleted ||
+      recoveryBlockedByInterruptedRuns.has(interruptedRun)
+    ) {
+      return;
+    }
+    recoveryBlockedByInterruptedRuns.add(interruptedRun);
+    const clearBlock = (): void => {
+      recoveryBlockedByInterruptedRuns.delete(interruptedRun);
+    };
+    void interruptedRun.then(clearBlock, clearBlock);
+  };
+
+  // Cancellation of an admitted automatic resume is monotone for that
+  // attempt. `/clear` may reset the shared session fields while asynchronous
+  // preparation is still running, but it must not re-enable lease admission.
+  let activeAutoResumeCancellation:
+    { cancellationRequested: boolean } | undefined;
+
   // -----------------------------------------------------------------------
   // Internal helpers
   // -----------------------------------------------------------------------
@@ -590,6 +617,13 @@ export function createChatSessionController(
     streamId: StreamTabId,
     options: AutoResumeOptions = {},
   ): Promise<boolean> => {
+    // Do not let a recovery wake claim the slot after the interrupted root
+    // publishes completion but before that root's teardown settles. The
+    // captured promise remains authoritative even if `/clear` resets the
+    // mutable session state in the meantime.
+    if (options.recovery && recoveryBlockedByInterruptedRuns.size > 0) {
+      return Promise.resolve(false);
+    }
     const {
       promise: runPromise,
       resolve: resolveRun,
@@ -601,6 +635,10 @@ export function createChatSessionController(
     if (!session.tryClaimRootRunSlot(runPromise.then(() => undefined))) {
       return Promise.resolve(false);
     }
+    const attemptCancellation = { cancellationRequested: false };
+    activeAutoResumeCancellation = attemptCancellation;
+    const isCancellationRequested = (): boolean =>
+      attemptCancellation.cancellationRequested || session.stopRequested;
 
     const runResume = async (): Promise<boolean> => {
       let finalize = (): void => session.markRunCompleted();
@@ -616,7 +654,7 @@ export function createChatSessionController(
           runMetadata.config ??
           (await getExecutionStore(executionId).readConfig());
         if (!config) return false;
-        if (session.stopRequested) return false;
+        if (isCancellationRequested()) return false;
         const parentStreamId = snapshotStore.getParentStreamId(streamId);
 
         const sessionContext = beginRunContext(config, 'history');
@@ -653,7 +691,7 @@ export function createChatSessionController(
             {
               interactions: runtimeSession.interactions,
               streamStatus: runtimeSession.status,
-              isCancellationRequested: () => session.stopRequested,
+              isCancellationRequested,
               resolveResumeState: async () => ({
                 runState: config,
                 executionId,
@@ -676,11 +714,12 @@ export function createChatSessionController(
                       restoreRecoveryFollowUps(recovery, lease);
                     }
                   },
-                  isCancellationRequested: () => session.stopRequested,
+                  isCancellationRequested,
                   onResult: (result) => {
                     resumedOutcome = result.outcome;
                   },
                   onError: reportRunFailure,
+                  canAcquireResumeLease: () => !isCancellationRequested(),
                 }),
               executeWorkflow: async () => {
                 throw new Error(
@@ -701,7 +740,7 @@ export function createChatSessionController(
 
         if (resumed) {
           settleResumedTurn(resumedOutcome);
-        } else if (session.stopRequested) {
+        } else if (isCancellationRequested()) {
           session.runExitCode = CliExitCode.Interrupted;
         }
         return resumed;
@@ -710,6 +749,9 @@ export function createChatSessionController(
         return false;
       } finally {
         finalize();
+        if (activeAutoResumeCancellation === attemptCancellation) {
+          activeAutoResumeCancellation = undefined;
+        }
       }
     };
 
@@ -780,6 +822,10 @@ export function createChatSessionController(
   // -----------------------------------------------------------------------
 
   const stop = (): void => {
+    blockRecoveryUntilInterruptedRunSettles();
+    if (activeAutoResumeCancellation) {
+      activeAutoResumeCancellation.cancellationRequested = true;
+    }
     session.stopRequested = true;
     interruptActiveRun();
   };
@@ -790,6 +836,10 @@ export function createChatSessionController(
       cause: 'Run interrupted.',
     });
     if (streamId === session.streamId) {
+      blockRecoveryUntilInterruptedRunSettles();
+      if (activeAutoResumeCancellation) {
+        activeAutoResumeCancellation.cancellationRequested = true;
+      }
       session.stopRequested = true;
       session.interruptedStreamId = streamId;
     }

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -1498,9 +1498,15 @@ describe('createChatSessionController', () => {
       'stream-1',
       makeAutoResumeData(),
       expect.objectContaining({
+        canAcquireResumeLease: expect.any(Function),
         isCancellationRequested: expect.any(Function),
       }),
     );
+    const resumeOptions = mocks.resumeQueuedToolUseFromResumeData.mock
+      .calls[0]?.[2] as ResumeQueuedToolUseOptions | undefined;
+    expect(resumeOptions?.canAcquireResumeLease?.()).toBe(true);
+    session.stopRequested = true;
+    expect(resumeOptions?.canAcquireResumeLease?.()).toBe(false);
     expect(mocks.syncStreamLog).toHaveBeenCalledWith('stream-1', {
       forceFinal: true,
     });
@@ -1508,6 +1514,49 @@ describe('createChatSessionController', () => {
     expect(mocks.notify).not.toHaveBeenCalledWith('agentFinished');
     expect(sessionMeta.get().cliMultiAgentPresetId).toBeUndefined();
     expect(sessionMeta.get().delegationAgentScope).toBeUndefined();
+  });
+
+  it('keeps an automatic resume cancelled after clear resets session state', async () => {
+    const leaseCheckStarted = pDefer<void>();
+    const releaseLeaseCheck = pDefer<void>();
+    const snapshotStore = makeResumeSnapshotStore({
+      executionId: 'exec-1',
+      config: makeResumeConfig(),
+    });
+    const session = makeSession({ runCompleted: true });
+    resumeWithAutoResumeData();
+    let resumeOptions: ResumeQueuedToolUseOptions | undefined;
+    mocks.resumeQueuedToolUseFromResumeData.mockImplementationOnce(
+      async (
+        _streamId: StreamTabId,
+        _snapshot: unknown,
+        options: ResumeQueuedToolUseOptions,
+      ) => {
+        resumeOptions = options;
+        leaseCheckStarted.resolve();
+        await releaseLeaseCheck.promise;
+        return options.canAcquireResumeLease?.() ?? true;
+      },
+    );
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore }),
+    );
+
+    const resume = ctrl.tryResumeStream('stream-1', {
+      streamId: 'stream-1' as StreamTabId,
+      generation: 1,
+      kind: 'recovery',
+    });
+    await leaseCheckStarted.promise;
+
+    ctrl.stop();
+    session.clearRunState();
+    expect(session.stopRequested).toBe(false);
+    expect(resumeOptions?.canAcquireResumeLease?.()).toBe(false);
+
+    releaseLeaseCheck.resolve();
+    await expect(resume).resolves.toBe(false);
+    expect(session.runExitCode).toBe(CliExitCode.Interrupted);
   });
 
   it('launcher resume supersedes stale interrupted recovery state', async () => {
@@ -1522,6 +1571,106 @@ describe('createChatSessionController', () => {
     expect(ctrl.admitInterruptedFollowUp({ text: 'Route normally.' })).toEqual({
       kind: 'not_interrupted',
     });
+  });
+
+  it('rejects recovery only until the interrupted run promise settles', async () => {
+    const teardown = pDefer<void>();
+    const snapshotStore = makeResumeSnapshotStore({
+      executionId: 'exec-1',
+      config: makeResumeConfig(),
+    });
+    const session = makeSession({
+      streamId: 'stream-1',
+      runPromise: teardown.promise,
+    });
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore }),
+    );
+
+    ctrl.stop();
+    // Root finalization publishes slot availability before its promise has
+    // completely settled.
+    session.markRunCompleted();
+    // `/clear` may reset the mutable session state while the interrupted
+    // promise is still settling. The captured promise must remain the guard.
+    session.clearRunState();
+
+    await expect(
+      ctrl.tryResumeStream('stream-1', {
+        streamId: 'stream-1' as StreamTabId,
+        generation: 1,
+        kind: 'recovery',
+      }),
+    ).resolves.toBe(false);
+
+    expect(snapshotStore.preload).not.toHaveBeenCalled();
+    expect(session.stopRequested).toBe(false);
+    expect(mocks.resumeQueuedToolUseFromResumeData).not.toHaveBeenCalled();
+
+    teardown.resolve();
+    await teardown.promise;
+    resumeWithAutoResumeData();
+
+    await expect(
+      ctrl.tryResumeStream('stream-1', {
+        streamId: 'stream-1' as StreamTabId,
+        generation: 2,
+        kind: 'recovery',
+      }),
+    ).resolves.toBe(true);
+
+    expect(snapshotStore.preload).toHaveBeenCalledWith(['stream-1']);
+    expect(mocks.resumeQueuedToolUseFromResumeData).toHaveBeenCalledOnce();
+  });
+
+  it('retains every unsettled interrupted-run recovery blocker', async () => {
+    const firstTeardown = pDefer<void>();
+    const secondTeardown = pDefer<void>();
+    const snapshotStore = makeResumeSnapshotStore({
+      executionId: 'exec-1',
+      config: makeResumeConfig(),
+    });
+    const session = makeSession({
+      streamId: 'stream-1',
+      runPromise: firstTeardown.promise,
+    });
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore }),
+    );
+
+    ctrl.stop();
+    session.markRunCompleted();
+    session.clearRunState();
+
+    session.markRunPending(secondTeardown.promise);
+    session.streamId = 'stream-2' as StreamTabId;
+    ctrl.stop();
+    session.markRunCompleted();
+    session.clearRunState();
+
+    secondTeardown.resolve();
+    await secondTeardown.promise;
+    await expect(
+      ctrl.tryResumeStream('stream-1', {
+        streamId: 'stream-1' as StreamTabId,
+        generation: 1,
+        kind: 'recovery',
+      }),
+    ).resolves.toBe(false);
+
+    firstTeardown.resolve();
+    await firstTeardown.promise;
+    resumeWithAutoResumeData();
+    await expect(
+      ctrl.tryResumeStream('stream-1', {
+        streamId: 'stream-1' as StreamTabId,
+        generation: 2,
+        kind: 'recovery',
+      }),
+    ).resolves.toBe(true);
+
+    expect(snapshotStore.preload).toHaveBeenCalledOnce();
+    expect(mocks.resumeQueuedToolUseFromResumeData).toHaveBeenCalledOnce();
   });
 
   it('transfers an admitted interruption batch to launcher resume', async () => {


### PR DESCRIPTION
Fixes #10078.

## Summary

- reject platform-triggered follow-up recovery only while the exact interrupted root promise is still settling
- preserve later detached-child delivery and explicit user resume
- pass the live cancellation predicate into atomic lease acquisition for automatic queued-follow-up recovery
- add a two-sided boundary regression test and update the unreleased CLI changelog

## Reproduced failure

In a 24x60 PTY, a Physicist team root delegated independent analytic and symbolic checks to two live children. Ctrl-C cancelled the root and both children, but a child-result recovery wake claimed the root slot while cancellation was settling. That claim reset `stopRequested`, reacquired the root execution, and then lost its generation during teardown. The CLI printed a valid resume command but rejected it for the 120-second stale-lease interval.

Immediate resume failed twice with `Execution <id> is active in TeXRA`; it succeeded only when the retained lease reached 137 seconds of age.

## Ownership decision

The controller records the exact in-flight root promise when interruption begins. A platform `RecoveryContinuation` may not claim the root slot while that same promise remains unsettled, because the interrupted generation can still own its execution lease. The block clears on either promise settlement, so later results from intentionally detached children can resume the interrupted conversation as before. Explicit launcher/manual resume also remains allowed and intentionally starts a new turn.

Once automatic recovery is admitted, the storage lease remains the final authority through the existing `canAcquireResumeLease` callback. This uses the existing root promise, recovery continuation, and lease admission; it adds no durable phase flag or compatibility path.

## Live verification

After the fix, the same 24x60 PTY scenario cancelled a root with two active children without the lost-ownership diagnostic. The CLI exited with main and child resume identifiers, and `texra resume <main-id>` was admitted immediately.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- focused resume, lease, and controller suites: 79 passed
- final full `npm test` after rebasing: 856 files passed, 1 skipped; 10,003 tests passed, 5 skipped
- pre-commit and pre-push hooks

No files in the mathematical test workspace were modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes root-slot admission and execution lease acquisition during interrupt/recovery races in the CLI session controller; regression could affect resume, follow-up recovery, or multi-agent cancel, though behavior is covered by new controller tests.
> 
> **Overview**
> **Fixes cancelled multi-agent sessions printing a resume command that fails for ~2 minutes** by tightening when automatic recovery may claim the root run slot and when it may acquire a resume storage lease.
> 
> The chat session controller now **blocks platform recovery wakes** while any interrupted root `runPromise` is still settling (tracked in a set so overlapping Ctrl-C on successive roots cannot drop an earlier guard). **`stop` / `stopStream`** register that blocker and set a **per auto-resume attempt** cancellation flag that stays true even if `/clear` clears mutable session fields like `stopRequested`.
> 
> During **`tryResumeStream`**, cancellation checks use that attempt-scoped predicate everywhere (including **`canAcquireResumeLease`** passed into queued follow-up recovery), so a cancelled automatic resume cannot reacquire the execution lease after teardown races or after clear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5afed67ddc240a3be733114018e2cf563aac232d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->