### PR TITLE
fix: reject Claude forks without session ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ All notable changes to this project will be documented in this file.
   number of active background tasks while retaining the focused session's own
   status.
 
+### Shared (all surfaces)
+
+#### Bug Fixes
+
+- **Malformed Claude Code forks stop safely** — a fork cannot continue in the
+  original conversation if Claude Code fails to return the new session id.
+
 ## [0.40.2] - 2026-08-12
 
 ### CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **Malformed Claude Code forks stop safely** — a fork cannot continue in the
-  original conversation if Claude Code fails to return the new session id.
+- **Claude Code forks leave the original conversation unchanged** — an
+  incomplete fork now stops instead of continuing the original conversation.
 
 ## [0.40.2] - 2026-08-12
 

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -509,6 +509,7 @@ describe('claude_agent tool launch and resume fallback', () => {
       ports,
       new AbortController(),
     );
+    if (!firstTurn) throw new Error('Expected a Claude fork turn');
     captured.strategy?.onTurnSuccess?.(firstTurn, {
       executions: stubExecutions(),
     } as any);
@@ -536,7 +537,18 @@ describe('claude_agent tool launch and resume fallback', () => {
     ClaudeAgentSessions.release('forked-session');
   });
 
-  it('fails a fork that succeeds without returning a new session id', async () => {
+  it.each([
+    { caseName: 'omits the new session id', subtype: 'success' },
+    {
+      caseName: 'echoes the source session id',
+      subtype: 'success',
+      sessionId: 'source-session',
+    },
+    {
+      caseName: 'reports an error without a new session id',
+      subtype: 'error_during_execution',
+    },
+  ])('fails a fork that $caseName', async ({ subtype, sessionId }) => {
     ClaudeAgentSessions.register('source-session', {
       childStreamId,
       executionId,
@@ -549,10 +561,13 @@ describe('claude_agent tool launch and resume fallback', () => {
       (async function* () {
         yield {
           type: 'result',
-          subtype: 'success',
-          result: 'Fork turn without an id',
-          modelUsage: {},
-          total_cost_usd: 0,
+          subtype,
+          ...(subtype === 'success'
+            ? { result: 'Malformed fork turn' }
+            : { errors: ['Provider fork failure'] }),
+          ...(sessionId ? { session_id: sessionId } : {}),
+          usage: { input_tokens: 7, output_tokens: 3 },
+          total_cost_usd: 0.25,
         };
       })(),
     );
@@ -566,13 +581,38 @@ describe('claude_agent tool launch and resume fallback', () => {
 
     expect(result.status).toBe('executed');
     const ports: ChildRunPorts = { notify: () => {}, recordCost: () => {} };
-    await expect(
-      captured.strategy?.launch?.(ports, new AbortController()),
-    ).rejects.toThrow('Claude Code fork completed without a new session id');
-    expect(mocks.query).toHaveBeenCalledOnce();
+    const firstTurn = await captured.strategy?.launch?.(
+      ports,
+      new AbortController(),
+    );
+    expect(firstTurn).toMatchObject({
+      isError: true,
+      usage: { input_tokens: 7, output_tokens: 3 },
+      totalCostUsd: 0.25,
+      errorMessage: expect.stringContaining(
+        'Claude Code fork did not create a distinct session',
+      ),
+    });
+    expect(captured.strategy?.isTurnError?.(firstTurn)).toBe(true);
+    const formattedError = await captured.strategy?.formatError(
+      firstTurn,
+      null,
+    );
+    expect(formattedError).toContain('<cost-usd>0.2500</cost-usd>');
+
+    await captured.strategy?.runTurn?.(
+      [{ text: 'must not resume the source', origin: 'user' }],
+      ports,
+      new AbortController(),
+    );
+    expect(mocks.query).toHaveBeenCalledTimes(2);
     expect(mocks.query.mock.calls[0]?.[0]).toMatchObject({
       options: { resume: 'source-session', forkSession: true },
     });
+    expect(mocks.query.mock.calls[1]?.[0].options).not.toHaveProperty('resume');
+    expect(mocks.query.mock.calls[1]?.[0].options).not.toHaveProperty(
+      'forkSession',
+    );
   });
 
   it('rejects a fork from a live session owned by another stream', async () => {

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -536,6 +536,45 @@ describe('claude_agent tool launch and resume fallback', () => {
     ClaudeAgentSessions.release('forked-session');
   });
 
+  it('fails a fork that succeeds without returning a new session id', async () => {
+    ClaudeAgentSessions.register('source-session', {
+      childStreamId,
+      executionId,
+      executions: stubExecutions(),
+      model: 'claude-sonnet-4-6',
+      permissionMode: 'acceptEdits',
+      effort: 'high',
+    });
+    mocks.query.mockImplementation(() =>
+      (async function* () {
+        yield {
+          type: 'result',
+          subtype: 'success',
+          result: 'Fork turn without an id',
+          modelUsage: {},
+          total_cost_usd: 0,
+        };
+      })(),
+    );
+    const captured = captureStrategy();
+
+    const result = await new ClaudeAgentTool().call({
+      prompt: 'try a different proof',
+      session_id: 'source-session',
+      fork_session: true,
+    });
+
+    expect(result.status).toBe('executed');
+    const ports: ChildRunPorts = { notify: () => {}, recordCost: () => {} };
+    await expect(
+      captured.strategy?.launch?.(ports, new AbortController()),
+    ).rejects.toThrow('Claude Code fork completed without a new session id');
+    expect(mocks.query).toHaveBeenCalledOnce();
+    expect(mocks.query.mock.calls[0]?.[0]).toMatchObject({
+      options: { resume: 'source-session', forkSession: true },
+    });
+  });
+
   it('rejects a fork from a live session owned by another stream', async () => {
     const sourceExecutionId = 'source-execution' as ExecutionId;
     const sourceOwner = 'stream:other-owner' as StreamTabId;

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -153,16 +153,21 @@ interface TurnResult {
   errorMessage?: string;
 }
 
+const INVALID_FORK_SESSION_MESSAGE =
+  'Claude Code fork did not create a distinct session';
+
+function claudeCostLines(turn: TurnResult): string[] | undefined {
+  return typeof turn.totalCostUsd === 'number' && turn.totalCostUsd > 0
+    ? [`<cost-usd>${turn.totalCostUsd.toFixed(4)}</cost-usd>`]
+    : undefined;
+}
+
 function formatClaudeDelivery(
   executionId: string,
   prompt: string,
   wallTimeMs: number,
   turn: TurnResult,
 ): string {
-  const extraLines =
-    typeof turn.totalCostUsd === 'number' && turn.totalCostUsd > 0
-      ? [`<cost-usd>${turn.totalCostUsd.toFixed(4)}</cost-usd>`]
-      : undefined;
   return formatChildRunDelivery(
     {
       tag: DELIVERY_TAG.claudeAgentResult,
@@ -179,7 +184,7 @@ function formatClaudeDelivery(
             output: turn.usage.output_tokens ?? 0,
           }
         : null,
-      lines: extraLines,
+      lines: claudeCostLines(turn),
     },
   );
 }
@@ -301,8 +306,14 @@ export async function runStreamedTurn(params: {
     backgroundTasks.finish();
   }
 
-  if (params.forkSession && !isError && !sessionId) {
-    throw new Error('Claude Code fork completed without a new session id');
+  if (
+    params.forkSession &&
+    (!sessionId || sessionId === params.resumeSessionId)
+  ) {
+    isError = true;
+    errorMessage = [errorMessage, INVALID_FORK_SESSION_MESSAGE]
+      .filter(isNonEmptyString)
+      .join('\n');
   }
 
   return {
@@ -440,6 +451,7 @@ function startClaudeAgentLoop(params: {
     store: ClaudeAgentSessions,
     releaseFallbackClaim: params.releaseFallbackClaim,
     runProviderTurn: async (prompt, _ports, abortController) => {
+      const forkSession = isFirstTurn && params.forkSession;
       const turn = await runStreamedTurn({
         prompt,
         logger,
@@ -451,11 +463,15 @@ function startClaudeAgentLoop(params: {
         additionalDirectories: params.additionalDirectories,
         env: params.env,
         resumeSessionId,
-        forkSession: isFirstTurn && params.forkSession,
+        forkSession,
         pathToClaudeCodeExecutable: params.pathToClaudeCodeExecutable,
       });
       isFirstTurn = false;
-      if (turn.sessionId) resumeSessionId = turn.sessionId;
+      if (forkSession && turn.isError) {
+        resumeSessionId = undefined;
+      } else if (turn.sessionId) {
+        resumeSessionId = turn.sessionId;
+      }
       return turn;
     },
     buildEntry: (session) => ({
@@ -482,6 +498,7 @@ function startClaudeAgentLoop(params: {
       formatChildRunError(
         { tag: DELIVERY_TAG.claudeAgentError, executionId, prompt: lastPrompt },
         {
+          lines: turn ? claudeCostLines(turn) : undefined,
           message: toErrorMessage(
             err ?? turn?.errorMessage ?? turn?.finalResponse,
           ),

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -301,6 +301,10 @@ export async function runStreamedTurn(params: {
     backgroundTasks.finish();
   }
 
+  if (params.forkSession && !isError && !sessionId) {
+    throw new Error('Claude Code fork completed without a new session id');
+  }
+
   return {
     finalResponse: responseParts.join('\n\n'),
     usage,


### PR DESCRIPTION
## Summary

- reject a successful Claude Code fork when the provider omits the new session identity
- prevent a later turn from resuming and modifying the source conversation
- pin the malformed-provider behavior with a session-loop regression test

## Validation

- npm run lint
- npm run compile:fast
- npm test -- --reporter=dot (10,003 passed, 5 skipped)
- npm run typecheck:workspace
- npm run typecheck:test-kernel
- focused Claude-agent suite (44 passed)

Closes #10037

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Claude Code child-run session resume behavior on failed forks; incorrect logic could block valid forks or still resume the wrong session, but scope is limited to fork_session flows and is covered by new tests.
> 
> **Overview**
> **Claude Code forks must return a new session id** — when `fork_session` is used, the streamed turn is now treated as failed if the provider omits `session_id` or echoes the source id (including some “successful” result shapes). Users see a clear error and any reported USD cost still appears on the error delivery.
> 
> **Follow-up turns no longer touch the original conversation after a bad fork** — if that first fork turn is in error, the child loop clears the resume id instead of adopting a bogus session, so the next user follow-up calls the SDK without `resume` / `forkSession` rather than continuing or mutating the source thread.
> 
> Regression tests cover missing id, echoed source id, and error subtypes; the changelog notes that incomplete forks stop instead of continuing the original chat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76fe0809033394c8d45b19bbc3ef741bbd2ac149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->