### PR TITLE
fix(cli): reveal complete direct approval content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Direct approval prompts reveal complete proposals and edits** — when a
+  compact preview hides instruction or diff lines, press `v` to inspect the
+  full content before approving or rejecting it.
 - **Session status reports active delegated work** — `/status` now shows the
   number of active background tasks while retaining the focused session's own
   status.

--- a/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
@@ -6,6 +6,7 @@
 
 import { Box, Text } from 'ink';
 
+import { safeTerminalText } from '@cli/runtime/terminalText';
 import {
   COLOR_BORDER,
   COLOR_ERROR,
@@ -30,7 +31,6 @@ import {
 import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
 import { formatCompactDuration } from '@utils/core';
 
-import { safeTerminalText } from '../render/terminalText';
 import type { StreamSlice } from '../state/cliState';
 
 type WorkflowRunDetailTone =

--- a/packages/cli/src/chat/tui/panes/loadedImageDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/loadedImageDisplay.ts
@@ -1,10 +1,10 @@
 // Local imports - shared formatting
+import { safeTerminalText } from '@cli/runtime/terminalText';
 import { POINTER } from '@cli/tui/ui/glyphs';
 import { collapseWhitespace, formatBytes } from '@utils/text/stringUtils';
 
 // Local imports - CLI TUI rendering
 import {
-  safeTerminalText,
   textDisplayWidth,
   truncateSummaryToWidth,
   truncateToWidth,

--- a/packages/cli/src/chat/tui/render/terminalText.ts
+++ b/packages/cli/src/chat/tui/render/terminalText.ts
@@ -1,22 +1,8 @@
 import cliTruncate from 'cli-truncate';
 import sliceAnsi from 'slice-ansi';
 import stringWidth from 'string-width';
-import stripAnsi from 'strip-ansi';
 
 import { collapseWhitespace } from '@utils/text/stringUtils';
-
-const UNSAFE_TERMINAL_CONTROLS =
-  // eslint-disable-next-line no-control-regex -- terminal output must exclude C0/C1 controls
-  /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g;
-
-/** Remove terminal control sequences while preserving printable text and line breaks. */
-export function safeTerminalText(text: string): string {
-  return stripAnsi(text)
-    .replaceAll('\r\n', '\n')
-    .replaceAll('\r', '\n')
-    .replaceAll('\t', '  ')
-    .replaceAll(UNSAFE_TERMINAL_CONTROLS, '');
-}
 
 export function textDisplayWidth(text: string): number {
   return stringWidth(text);

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -13,6 +13,7 @@
  */
 
 import { appendCliApiSwitchHint } from '@cli/runtime/approval/approvalPrompts';
+import { safeTerminalText } from '@cli/runtime/terminalText';
 import { TOOL_OUTPUT_CORNER } from '@cli/tui/ui/glyphs';
 import { redactSecrets } from '@logger/redaction';
 import {
@@ -45,7 +46,6 @@ import { upsertTaskGroupFromStreamLog } from '@shared/streams/taskGroupProjectio
 import type { StreamLog } from '@transcript';
 import { truncateSummary } from '@utils/text/stringUtils';
 import { normalizeKnownHtmlForCliMarkdown } from '../render/htmlMarkdownNormalize';
-import { safeTerminalText } from '../render/terminalText';
 import {
   isRenderableTranscriptEntry,
   trimAssistantTranscriptLead,

--- a/packages/cli/src/runtime/approval/approvalPrompts.ts
+++ b/packages/cli/src/runtime/approval/approvalPrompts.ts
@@ -18,6 +18,7 @@ import {
 
 import { type CliContext, type CliPromptRequest } from '../cliContext';
 import { askCliQuestion, writeTextStderr } from '../logSinks';
+import { safeTerminalText } from '../terminalText';
 
 /**
  * Approval requests the CLI can settle by policy (auto-approve / auto-deny)
@@ -51,11 +52,20 @@ export interface CliApprovalPromptHooks {
 export interface CliApprovalContent {
   readonly summary: string;
   /** Complete content behind a bounded summary, shown only on request. */
-  readonly details?: string;
+  readonly details?: () => string;
 }
 
 const cliPromptQueues = new WeakMap<CliContext, PQueue>();
 const warnedApprovalContexts = new WeakSet<CliContext>();
+
+function cliPromptQueue(context: CliContext): PQueue {
+  let queue = cliPromptQueues.get(context);
+  if (!queue) {
+    queue = new PQueue({ concurrency: 1 });
+    cliPromptQueues.set(context, queue);
+  }
+  return queue;
+}
 
 /**
  * Tell the operator, once per run, that the policy closed a gate. The model
@@ -239,6 +249,10 @@ function parseApprovalAnswer(answer: string): ParsedApprovalAnswer {
   };
 }
 
+function isViewDetailsAnswer(answer: string): boolean {
+  return /^v(?:iew)?$/i.test(answer.trim());
+}
+
 /**
  * Queue a CLI prompt against the context's serial prompt queue. Exposed so the
  * user-question handler can interleave its own per-question prompts with
@@ -248,12 +262,9 @@ export function queueCliApprovalQuestion(
   context: CliContext,
   request: CliPromptRequest,
 ): Promise<string> {
-  let queue = cliPromptQueues.get(context);
-  if (!queue) {
-    queue = new PQueue({ concurrency: 1 });
-    cliPromptQueues.set(context, queue);
-  }
-  return queue.add(() => askCliApprovalQuestion(context, request));
+  return cliPromptQueue(context).add(() =>
+    askCliApprovalQuestion(context, request),
+  );
 }
 
 export async function askApproval(
@@ -261,46 +272,49 @@ export async function askApproval(
   content: CliApprovalContent,
   hooks: CliApprovalPromptHooks = {},
 ): Promise<ApprovalDecision> {
-  let answer: string;
+  const getDetails = content.details;
   try {
-    while (true) {
-      hooks.beforePrompt?.();
-      answer = await queueCliApprovalQuestion(context, {
-        kind: 'approval',
-        summary: content.summary,
-        prompt: content.details
-          ? 'Approve? [y/N, v view full, or n <feedback>] '
-          : 'Approve? [y/N, or n <feedback>] ',
-      });
-      if (content.details == null || answer.trim().toLowerCase() !== 'v') {
-        break;
+    return await cliPromptQueue(context).add(async () => {
+      let answer: string;
+      while (true) {
+        hooks.beforePrompt?.();
+        answer = await askCliApprovalQuestion(context, {
+          kind: 'approval',
+          summary: content.summary,
+          prompt: getDetails
+            ? 'Approve? [y/N, v view full, or n <feedback>] '
+            : 'Approve? [y/N, or n <feedback>] ',
+        });
+        if (getDetails == null || !isViewDetailsAnswer(answer)) {
+          break;
+        }
+        writeTextStderr(safeTerminalText(getDetails()));
       }
-      writeTextStderr(content.details);
-    }
+
+      const parsed = parseApprovalAnswer(answer);
+      let feedback = parsed.feedback;
+      if (!parsed.accepted && parsed.shouldPromptForFeedback) {
+        try {
+          hooks.beforePrompt?.();
+          const feedbackAnswer = await askCliApprovalQuestion(context, {
+            kind: 'approval',
+            summary: '',
+            prompt: 'Rejection feedback (optional, Enter to skip): ',
+          });
+          feedback = feedbackAnswer.trim() || undefined;
+        } catch {
+          feedback = undefined;
+        }
+      }
+
+      return {
+        accepted: parsed.accepted,
+        userMessage: parsed.accepted
+          ? undefined
+          : feedback || 'Rejected from CLI approval prompt.',
+      };
+    });
   } catch {
     return { accepted: false, userMessage: 'CLI approval prompt failed.' };
   }
-
-  const parsed = parseApprovalAnswer(answer);
-  let feedback = parsed.feedback;
-  if (!parsed.accepted && parsed.shouldPromptForFeedback) {
-    try {
-      hooks.beforePrompt?.();
-      const feedbackAnswer = await queueCliApprovalQuestion(context, {
-        kind: 'approval',
-        summary: '',
-        prompt: 'Rejection feedback (optional, Enter to skip): ',
-      });
-      feedback = feedbackAnswer.trim() || undefined;
-    } catch {
-      feedback = undefined;
-    }
-  }
-
-  return {
-    accepted: parsed.accepted,
-    userMessage: parsed.accepted
-      ? undefined
-      : feedback || 'Rejected from CLI approval prompt.',
-  };
 }

--- a/packages/cli/src/runtime/approval/approvalPrompts.ts
+++ b/packages/cli/src/runtime/approval/approvalPrompts.ts
@@ -48,6 +48,12 @@ export interface CliApprovalPromptHooks {
   readonly beforePrompt?: () => void;
 }
 
+export interface CliApprovalContent {
+  readonly summary: string;
+  /** Complete content behind a bounded summary, shown only on request. */
+  readonly details?: string;
+}
+
 const cliPromptQueues = new WeakMap<CliContext, PQueue>();
 const warnedApprovalContexts = new WeakSet<CliContext>();
 
@@ -252,17 +258,25 @@ export function queueCliApprovalQuestion(
 
 export async function askApproval(
   context: CliContext,
-  summary: string,
+  content: CliApprovalContent,
   hooks: CliApprovalPromptHooks = {},
 ): Promise<ApprovalDecision> {
   let answer: string;
   try {
-    hooks.beforePrompt?.();
-    answer = await queueCliApprovalQuestion(context, {
-      kind: 'approval',
-      summary,
-      prompt: 'Approve? [y/N, or n <feedback>] ',
-    });
+    while (true) {
+      hooks.beforePrompt?.();
+      answer = await queueCliApprovalQuestion(context, {
+        kind: 'approval',
+        summary: content.summary,
+        prompt: content.details
+          ? 'Approve? [y/N, v view full, or n <feedback>] '
+          : 'Approve? [y/N, or n <feedback>] ',
+      });
+      if (content.details == null || answer.trim().toLowerCase() !== 'v') {
+        break;
+      }
+      writeTextStderr(content.details);
+    }
   } catch {
     return { accepted: false, userMessage: 'CLI approval prompt failed.' };
   }

--- a/packages/cli/src/runtime/approval/approvalSummaries.ts
+++ b/packages/cli/src/runtime/approval/approvalSummaries.ts
@@ -77,13 +77,16 @@ function truncateLineToWidth(line: string, maxChars: number): string {
   return `${line.slice(0, prefixLength)}${TRUNCATED_DIFF_LINE_MARKER}`;
 }
 
-function boundedAgentProposalInstructionLines(
-  instruction: string,
-): readonly string[] {
-  const instructionLines = instruction
+function agentProposalInstructionLines(instruction: string): readonly string[] {
+  return instruction
     .replaceAll('\r\n', '\n')
     .replaceAll('\r', '\n')
     .split('\n');
+}
+
+function boundedAgentProposalInstructionLines(
+  instructionLines: readonly string[],
+): readonly string[] {
   return boundedLines(instructionLines, {
     maxLines: AGENT_PROPOSAL_INSTRUCTION_MAX_LINES,
     maxChars: AGENT_PROPOSAL_INSTRUCTION_MAX_CHARS,
@@ -91,6 +94,16 @@ function boundedAgentProposalInstructionLines(
     truncateLine: (line) =>
       truncateLineToWidth(line, AGENT_PROPOSAL_INSTRUCTION_MAX_LINE_CHARS),
   });
+}
+
+function equalLines(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((line, index) => line === right[index])
+  );
 }
 
 function formatAgentProposalFileGroup(
@@ -105,15 +118,9 @@ function formatAgentProposalFileGroup(
 
 function agentProposalApprovalSummary(
   proposal: AgentProposalPermission,
-  bounded: boolean,
+  instructionLines: readonly string[],
+  boundFileGroups: boolean,
 ): string {
-  const fullInstructionLines = proposal.instruction
-    .replaceAll('\r\n', '\n')
-    .replaceAll('\r', '\n')
-    .split('\n');
-  const instructionLines = bounded
-    ? boundedAgentProposalInstructionLines(proposal.instruction)
-    : fullInstructionLines;
   const workingDirectory = proposal.workingDirectory?.trim();
   return [
     `Agent proposal requested: ${proposal.agent} (${agentProposalCategoryLabel(
@@ -122,7 +129,7 @@ function agentProposalApprovalSummary(
     `Model: ${proposal.model}`,
     ...(workingDirectory ? [`Working directory: ${workingDirectory}`] : []),
     ...getProposalFileGroups(proposal).map((group) =>
-      bounded
+      boundFileGroups
         ? formatAgentProposalFileGroup(group.label, group.files)
         : `${group.label}: ${group.files.join(', ')}`,
     ),
@@ -134,9 +141,26 @@ function agentProposalApprovalSummary(
 export function buildAgentProposalApprovalContent(
   proposal: AgentProposalPermission,
 ): CliApprovalContent {
-  const summary = agentProposalApprovalSummary(proposal, true);
-  const details = agentProposalApprovalSummary(proposal, false);
-  return summary === details ? { summary } : { summary, details };
+  const instructionLines = agentProposalInstructionLines(proposal.instruction);
+  const boundedInstructionLines =
+    boundedAgentProposalInstructionLines(instructionLines);
+  const hasHiddenContent =
+    !equalLines(boundedInstructionLines, instructionLines) ||
+    getProposalFileGroups(proposal).some(
+      (group) => group.files.length > AGENT_PROPOSAL_FILE_GROUP_MAX_FILES,
+    );
+  const summary = agentProposalApprovalSummary(
+    proposal,
+    boundedInstructionLines,
+    true,
+  );
+  return hasHiddenContent
+    ? {
+        summary,
+        details: () =>
+          agentProposalApprovalSummary(proposal, instructionLines, false),
+      }
+    : { summary };
 }
 
 export function formatRetryRequestMessage(payload: RetryPermission): string {
@@ -183,27 +207,28 @@ function boundedToolEditDiffLines(
 
 function toolEditApprovalSummary(
   request: ToolEditApprovalRequest,
-  bounded: boolean,
+  diffLines: readonly string[],
 ): string {
   const header = `Tool edit requested by ${request.sourceTool}: ${request.path}`;
-  const diffLines = toolEditDiffLines(request);
   if (diffLines.length === 0) {
     return `${header}\nNo content changes proposed.`;
   }
 
-  const visibleLines = bounded
-    ? boundedToolEditDiffLines(diffLines)
-    : diffLines;
-
-  return `${header}\nProposed diff:\n${visibleLines.join('\n')}`;
+  return `${header}\nProposed diff:\n${diffLines.join('\n')}`;
 }
 
 export function buildToolEditApprovalContent(
   request: ToolEditApprovalRequest,
 ): CliApprovalContent {
-  const summary = toolEditApprovalSummary(request, true);
-  const details = toolEditApprovalSummary(request, false);
-  return summary === details ? { summary } : { summary, details };
+  const diffLines = toolEditDiffLines(request);
+  const boundedDiffLines = boundedToolEditDiffLines(diffLines);
+  const summary = toolEditApprovalSummary(request, boundedDiffLines);
+  return equalLines(boundedDiffLines, diffLines)
+    ? { summary }
+    : {
+        summary,
+        details: () => toolEditApprovalSummary(request, diffLines),
+      };
 }
 
 export function formatUserQuestionPrompt(

--- a/packages/cli/src/runtime/approval/approvalSummaries.ts
+++ b/packages/cli/src/runtime/approval/approvalSummaries.ts
@@ -11,7 +11,11 @@ import {
 } from '@shared/schemas';
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
-import { cliRetryActionHint, classifyCliRetryAction } from './approvalPrompts';
+import {
+  cliRetryActionHint,
+  classifyCliRetryAction,
+  type CliApprovalContent,
+} from './approvalPrompts';
 
 const TRUNCATED_DIFF_LINE_MARKER = ' … [line truncated]';
 const TOOL_EDIT_APPROVAL_DIFF_MAX_CHARS = 12_000;
@@ -99,12 +103,17 @@ function formatAgentProposalFileGroup(
   return `${label}: ${visibleFiles.join(', ')}${suffix}`;
 }
 
-export function formatAgentProposalApprovalSummary(
+function agentProposalApprovalSummary(
   proposal: AgentProposalPermission,
+  bounded: boolean,
 ): string {
-  const instructionLines = boundedAgentProposalInstructionLines(
-    proposal.instruction,
-  );
+  const fullInstructionLines = proposal.instruction
+    .replaceAll('\r\n', '\n')
+    .replaceAll('\r', '\n')
+    .split('\n');
+  const instructionLines = bounded
+    ? boundedAgentProposalInstructionLines(proposal.instruction)
+    : fullInstructionLines;
   const workingDirectory = proposal.workingDirectory?.trim();
   return [
     `Agent proposal requested: ${proposal.agent} (${agentProposalCategoryLabel(
@@ -113,11 +122,21 @@ export function formatAgentProposalApprovalSummary(
     `Model: ${proposal.model}`,
     ...(workingDirectory ? [`Working directory: ${workingDirectory}`] : []),
     ...getProposalFileGroups(proposal).map((group) =>
-      formatAgentProposalFileGroup(group.label, group.files),
+      bounded
+        ? formatAgentProposalFileGroup(group.label, group.files)
+        : `${group.label}: ${group.files.join(', ')}`,
     ),
     'Instruction:',
     ...instructionLines.map((line) => `  ${line}`),
   ].join('\n');
+}
+
+export function buildAgentProposalApprovalContent(
+  proposal: AgentProposalPermission,
+): CliApprovalContent {
+  const summary = agentProposalApprovalSummary(proposal, true);
+  const details = agentProposalApprovalSummary(proposal, false);
+  return summary === details ? { summary } : { summary, details };
 }
 
 export function formatRetryRequestMessage(payload: RetryPermission): string {
@@ -162,8 +181,9 @@ function boundedToolEditDiffLines(
   });
 }
 
-export function formatToolEditApprovalSummary(
+function toolEditApprovalSummary(
   request: ToolEditApprovalRequest,
+  bounded: boolean,
 ): string {
   const header = `Tool edit requested by ${request.sourceTool}: ${request.path}`;
   const diffLines = toolEditDiffLines(request);
@@ -171,9 +191,19 @@ export function formatToolEditApprovalSummary(
     return `${header}\nNo content changes proposed.`;
   }
 
-  const visibleLines = boundedToolEditDiffLines(diffLines);
+  const visibleLines = bounded
+    ? boundedToolEditDiffLines(diffLines)
+    : diffLines;
 
   return `${header}\nProposed diff:\n${visibleLines.join('\n')}`;
+}
+
+export function buildToolEditApprovalContent(
+  request: ToolEditApprovalRequest,
+): CliApprovalContent {
+  const summary = toolEditApprovalSummary(request, true);
+  const details = toolEditApprovalSummary(request, false);
+  return summary === details ? { summary } : { summary, details };
 }
 
 export function formatUserQuestionPrompt(

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -26,6 +26,7 @@ import {
   settleRetry,
 } from './approval/settleApprovals';
 import {
+  type CliApprovalContent,
   type CliApprovalPromptHooks,
   type CliDecisionApprovalEvent,
   type CliDecisionApprovalPayloads,
@@ -33,10 +34,10 @@ import {
   queueCliApprovalQuestion,
 } from './approval/approvalPrompts';
 import {
-  formatAgentProposalApprovalSummary,
+  buildAgentProposalApprovalContent,
+  buildToolEditApprovalContent,
   formatBashApprovalSummary,
   formatRetryRequestMessage,
-  formatToolEditApprovalSummary,
   formatUserQuestionPrompt,
 } from './approval/approvalSummaries';
 import {
@@ -69,7 +70,7 @@ async function decideToolEdit(
 ): Promise<ToolEditApprovalResult> {
   const decision = await askApproval(
     context,
-    formatToolEditApprovalSummary(request),
+    buildToolEditApprovalContent(request),
     hooks,
   );
   return toToolEditResult(decision, request.proposedContent);
@@ -78,26 +79,28 @@ async function decideToolEdit(
 function summarizeApprovalEvent<K extends CliDecisionApprovalEvent>(
   event: K,
   payload: CliDecisionApprovalPayloads[K],
-): string {
+): CliApprovalContent {
   switch (event) {
     case 'showPlanApproval': {
       const data = payload as PlanApprovalPermission;
-      return `Plan approval requested:\n${JSON.stringify(data.plan, null, 2)}`;
+      return {
+        summary: `Plan approval requested:\n${JSON.stringify(data.plan, null, 2)}`,
+      };
     }
     case 'showAgentProposal': {
       const data = payload as AgentProposalPermission;
-      return formatAgentProposalApprovalSummary(data);
+      return buildAgentProposalApprovalContent(data);
     }
     case 'showRetryRequest': {
       // The prompt surface owns the retry hint: the operator must see the
       // `/api personal` / coding-plan switch guidance in the prompt they
       // actually answer, not only in the pre-prompt stderr line.
       // `formatRetryRequestMessage` is the single retry formatter.
-      return formatRetryRequestMessage(payload as RetryPermission);
+      return { summary: formatRetryRequestMessage(payload as RetryPermission) };
     }
     default: {
       const never: never = event;
-      return String(never);
+      return { summary: String(never) };
     }
   }
 }
@@ -122,11 +125,13 @@ async function decideApprovalEvent<K extends CliDecisionApprovalEvent>(
 
   if (immediate) return { decision: immediate, prompted: false };
 
-  const summary = summarizeApprovalEvent(event, payload);
-  const decision = await askApproval(context, summary, hooks);
+  const content = summarizeApprovalEvent(event, payload);
+  const decision = await askApproval(context, content, hooks);
   if (!decision.accepted && options.writeRejectionToStderr) {
     writeTextStderr(
-      decision.userMessage ? `${summary}\n${decision.userMessage}` : summary,
+      decision.userMessage
+        ? `${content.summary}\n${decision.userMessage}`
+        : content.summary,
     );
   }
   return { decision, prompted: true };
@@ -224,7 +229,7 @@ export function createHeadlessCliHostInteractions(
     async requestBashApproval(request) {
       const decision = await askApproval(
         context,
-        formatBashApprovalSummary(request),
+        { summary: formatBashApprovalSummary(request) },
         hooks,
       );
       return toApprovalSettlement(decision);

--- a/packages/cli/src/runtime/terminalText.ts
+++ b/packages/cli/src/runtime/terminalText.ts
@@ -1,0 +1,14 @@
+import stripAnsi from 'strip-ansi';
+
+const UNSAFE_TERMINAL_CONTROLS =
+  // eslint-disable-next-line no-control-regex -- terminal output must exclude C0/C1 controls
+  /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g;
+
+/** Remove terminal control sequences while preserving printable text and line breaks. */
+export function safeTerminalText(text: string): string {
+  return stripAnsi(text)
+    .replaceAll('\r\n', '\n')
+    .replaceAll('\r', '\n')
+    .replaceAll('\t', '  ')
+    .replaceAll(UNSAFE_TERMINAL_CONTROLS, '');
+}

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -23,6 +23,7 @@ import { CliExitCode } from '@cli/runtime/exitCodes';
 import { runOutcomeExitCode } from '@cli/runtime/terminalStatus';
 import {
   appendCliApiSwitchHint,
+  askApproval,
   classifyCliRetryAction,
   cliRetryApiSwitchDecision,
   isCliApiSwitchableRetry,
@@ -30,9 +31,9 @@ import {
 } from '@cli/runtime/approval/approvalPrompts';
 import { denyExternalInquiryIfNoHumanInput } from '@cli/runtime/approval/settleApprovals';
 import {
-  formatAgentProposalApprovalSummary,
+  buildAgentProposalApprovalContent,
+  buildToolEditApprovalContent,
   formatRetryRequestMessage,
-  formatToolEditApprovalSummary,
 } from '@cli/runtime/approval/approvalSummaries';
 import {
   decideRetryApproval,
@@ -438,7 +439,7 @@ describe('bounded yolo retry batches (#9532)', () => {
 
 describe('formatToolEditApprovalSummary', () => {
   it('includes the proposed edit diff in interactive CLI prompts', () => {
-    const summary = formatToolEditApprovalSummary({
+    const { summary } = buildToolEditApprovalContent({
       path: '/tmp/proof.tex',
       originalContent: 'Let G be a group.\nThis is wrong.\n',
       proposedContent: 'Let G be a group.\nThis is correct.\n',
@@ -526,9 +527,44 @@ describe('formatToolEditApprovalSummary', () => {
     });
   });
 
+  it('shows complete bounded content without settling the approval', async () => {
+    const prompts: string[] = [];
+    const summaries: string[] = [];
+    const answers = ['v', 'y'];
+    const stderrWrite = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+
+    try {
+      const decision = await askApproval(
+        context({
+          approvalPrompt: async (request) => {
+            prompts.push(request.prompt);
+            summaries.push(request.summary);
+            return answers.shift() ?? '';
+          },
+        }),
+        { summary: 'bounded preview', details: 'complete proposal' },
+      );
+
+      expect(decision).toEqual({ accepted: true, userMessage: undefined });
+      expect(prompts).toEqual([
+        'Approve? [y/N, v view full, or n <feedback>] ',
+        'Approve? [y/N, v view full, or n <feedback>] ',
+      ]);
+      expect(summaries).toEqual(['bounded preview', 'bounded preview']);
+      expect(stderrWrite).toHaveBeenCalledWith(
+        'complete proposal\n',
+        expect.any(Function),
+      );
+    } finally {
+      stderrWrite.mockRestore();
+    }
+  });
+
   it('bounds long diff lines before prompting', () => {
     const longLine = 'x'.repeat(1_000);
-    const summary = formatToolEditApprovalSummary({
+    const { summary, details } = buildToolEditApprovalContent({
       path: '/tmp/generated.json',
       originalContent: '',
       proposedContent: `${longLine}\n`,
@@ -538,6 +574,7 @@ describe('formatToolEditApprovalSummary', () => {
     expect(summary).toContain('[line truncated]');
     expect(summary).not.toContain(longLine);
     expect(summary.length).toBeLessThan(1_000);
+    expect(details).toContain(longLine);
   });
 
   it('marks hidden diff lines when the line budget is exceeded', () => {
@@ -545,7 +582,7 @@ describe('formatToolEditApprovalSummary', () => {
       { length: 100 },
       (_, index) => `generated line ${index + 1}`,
     ).join('\n');
-    const summary = formatToolEditApprovalSummary({
+    const { summary, details } = buildToolEditApprovalContent({
       path: '/tmp/generated.tex',
       originalContent: '',
       proposedContent,
@@ -553,6 +590,8 @@ describe('formatToolEditApprovalSummary', () => {
     });
 
     expect(summary).toContain('diff lines hidden');
+    expect(details).toContain('+generated line 100');
+    expect(details).not.toContain('diff lines hidden');
   });
 
   it('skips prompting for auto-approved edits', async () => {
@@ -581,7 +620,7 @@ describe('formatToolEditApprovalSummary', () => {
 
 describe('formatAgentProposalApprovalSummary', () => {
   it('formats subagent approvals without raw JSON internals', () => {
-    const summary = formatAgentProposalApprovalSummary(
+    const { summary, details } = buildAgentProposalApprovalContent(
       agentProposal({
         instruction:
           'Please verify the proof carefully.\nReport any gaps or hidden cases.',
@@ -597,6 +636,7 @@ describe('formatAgentProposalApprovalSummary', () => {
     expect(summary).not.toContain('proposalId');
     expect(summary).not.toContain('streamId');
     expect(summary).not.toContain('{');
+    expect(details).toBeUndefined();
   });
 
   it('bounds long subagent instructions before prompting', () => {
@@ -606,7 +646,7 @@ describe('formatAgentProposalApprovalSummary', () => {
       (_, index) => `${index + 1}. ${longLine}`,
     ).join('\n');
 
-    const summary = formatAgentProposalApprovalSummary(
+    const { summary, details } = buildAgentProposalApprovalContent(
       agentProposal({
         instruction,
         memories: ['/memories/proof-style.md'],
@@ -619,14 +659,20 @@ describe('formatAgentProposalApprovalSummary', () => {
     expect(summary).toContain('[line truncated]');
     expect(summary).toContain('instruction lines hidden');
     expect(summary).not.toContain(longLine);
+    expect(details).toContain(`  60. ${longLine}`);
+    expect(details).not.toContain('instruction lines hidden');
   });
 
   it('includes workflow proposal file groups', () => {
-    const summary = formatAgentProposalApprovalSummary(
+    const inputFiles = Array.from(
+      { length: 12 },
+      (_, index) => `draft-${index + 1}.tex`,
+    );
+    const { summary, details } = buildAgentProposalApprovalContent(
       agentProposal({
         agent: 'polish',
         instruction: 'Polish the draft and write the revised file.',
-        inputFiles: ['draft.tex'],
+        inputFiles,
         contextFiles: ['notes.md'],
         mediaFiles: ['figure.png'],
         outputFiles: ['draft-polished.tex'],
@@ -638,7 +684,11 @@ describe('formatAgentProposalApprovalSummary', () => {
     expect(summary).toContain(
       'Agent proposal requested: polish (workflow agent)',
     );
-    expect(summary).toContain('Input: draft.tex');
+    expect(summary).toContain('Input: draft-1.tex');
+    expect(summary).toContain('+2 more');
+    expect(summary).not.toContain('draft-12.tex');
+    expect(details).toContain('draft-12.tex');
+    expect(details).not.toContain('+2 more');
     expect(summary).toContain('Context: notes.md');
     expect(summary).toContain('Media: figure.png');
     expect(summary).toContain('Output: draft-polished.tex');

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -62,6 +62,10 @@ function context(overrides: Partial<CliContext> = {}): CliContext {
   return ctx;
 }
 
+function stubStderrWrites() {
+  return vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+}
+
 function useCliHostInteractions(
   cliContext: CliContext,
   hooks: CliApprovalPromptHooks = {},
@@ -156,6 +160,7 @@ afterEach(() => {
   detachHostInteractions();
   detachHostInteractions = () => {};
   handleExternalInquiryActionMock.mockClear();
+  vi.restoreAllMocks();
 });
 
 describe('shared retry and human-input decisions', () => {
@@ -437,7 +442,7 @@ describe('bounded yolo retry batches (#9532)', () => {
   });
 });
 
-describe('formatToolEditApprovalSummary', () => {
+describe('buildToolEditApprovalContent', () => {
   it('includes the proposed edit diff in interactive CLI prompts', () => {
     const { summary } = buildToolEditApprovalContent({
       path: '/tmp/proof.tex',
@@ -530,36 +535,108 @@ describe('formatToolEditApprovalSummary', () => {
   it('shows complete bounded content without settling the approval', async () => {
     const prompts: string[] = [];
     const summaries: string[] = [];
+    const answers = ['view', 'y'];
+    const beforePrompt = vi.fn();
+    const stderrWrite = stubStderrWrites();
+
+    const decision = await askApproval(
+      context({
+        approvalPrompt: async (request) => {
+          prompts.push(request.prompt);
+          summaries.push(request.summary);
+          return answers.shift() ?? '';
+        },
+      }),
+      { summary: 'bounded preview', details: () => 'complete proposal' },
+      { beforePrompt },
+    );
+
+    expect(decision).toEqual({ accepted: true, userMessage: undefined });
+    expect(prompts).toEqual([
+      'Approve? [y/N, v view full, or n <feedback>] ',
+      'Approve? [y/N, v view full, or n <feedback>] ',
+    ]);
+    expect(summaries).toEqual(['bounded preview', 'bounded preview']);
+    expect(beforePrompt).toHaveBeenCalledTimes(2);
+    expect(stderrWrite).toHaveBeenCalledWith(
+      'complete proposal\n',
+      expect.any(Function),
+    );
+  });
+
+  it('does not construct complete content unless it is requested', async () => {
+    const details = vi.fn(() => 'complete proposal');
+    const decision = await askApproval(
+      context({
+        approvalPrompt: async () => 'y',
+      }),
+      { summary: 'bounded preview', details },
+    );
+
+    expect(details).not.toHaveBeenCalled();
+    expect(decision).toEqual({ accepted: true, userMessage: undefined });
+  });
+
+  it('removes terminal control sequences from complete content', async () => {
     const answers = ['v', 'y'];
-    const stderrWrite = vi
-      .spyOn(process.stderr, 'write')
-      .mockImplementation(() => true);
+    const stderrWrite = stubStderrWrites();
 
-    try {
-      const decision = await askApproval(
-        context({
-          approvalPrompt: async (request) => {
-            prompts.push(request.prompt);
-            summaries.push(request.summary);
-            return answers.shift() ?? '';
-          },
-        }),
-        { summary: 'bounded preview', details: 'complete proposal' },
-      );
+    await askApproval(
+      context({
+        approvalPrompt: async () => answers.shift() ?? '',
+      }),
+      {
+        summary: 'bounded preview',
+        details: () => 'safe\u001b]0;unsafe\u0007\ntext',
+      },
+    );
 
-      expect(decision).toEqual({ accepted: true, userMessage: undefined });
-      expect(prompts).toEqual([
-        'Approve? [y/N, v view full, or n <feedback>] ',
-        'Approve? [y/N, v view full, or n <feedback>] ',
-      ]);
-      expect(summaries).toEqual(['bounded preview', 'bounded preview']);
-      expect(stderrWrite).toHaveBeenCalledWith(
-        'complete proposal\n',
-        expect.any(Function),
-      );
-    } finally {
-      stderrWrite.mockRestore();
-    }
+    expect(stderrWrite).toHaveBeenCalledWith(
+      'safe\ntext\n',
+      expect.any(Function),
+    );
+  });
+
+  it('holds the prompt queue while complete content is viewed', async () => {
+    const summaries: string[] = [];
+    let firstPromptCount = 0;
+    let resolveView!: (answer: string) => void;
+    let resolveDecision!: (answer: string) => void;
+    const viewAnswer = new Promise<string>((resolve) => {
+      resolveView = resolve;
+    });
+    const decisionAnswer = new Promise<string>((resolve) => {
+      resolveDecision = resolve;
+    });
+    stubStderrWrites();
+    const cliContext = context({
+      approvalPrompt: async (request) => {
+        summaries.push(request.summary);
+        if (request.summary !== 'first') return 'y';
+        firstPromptCount += 1;
+        return firstPromptCount === 1 ? viewAnswer : decisionAnswer;
+      },
+    });
+
+    const first = askApproval(cliContext, {
+      summary: 'first',
+      details: () => 'complete first proposal',
+    });
+    const second = askApproval(cliContext, { summary: 'second' });
+
+    resolveView('v');
+    await vi.waitFor(() => expect(summaries).toEqual(['first', 'first']));
+
+    resolveDecision('y');
+    await expect(first).resolves.toEqual({
+      accepted: true,
+      userMessage: undefined,
+    });
+    await expect(second).resolves.toEqual({
+      accepted: true,
+      userMessage: undefined,
+    });
+    expect(summaries).toEqual(['first', 'first', 'second']);
   });
 
   it('bounds long diff lines before prompting', () => {
@@ -574,7 +651,7 @@ describe('formatToolEditApprovalSummary', () => {
     expect(summary).toContain('[line truncated]');
     expect(summary).not.toContain(longLine);
     expect(summary.length).toBeLessThan(1_000);
-    expect(details).toContain(longLine);
+    expect(details?.()).toContain(longLine);
   });
 
   it('marks hidden diff lines when the line budget is exceeded', () => {
@@ -590,8 +667,8 @@ describe('formatToolEditApprovalSummary', () => {
     });
 
     expect(summary).toContain('diff lines hidden');
-    expect(details).toContain('+generated line 100');
-    expect(details).not.toContain('diff lines hidden');
+    expect(details?.()).toContain('+generated line 100');
+    expect(details?.()).not.toContain('diff lines hidden');
   });
 
   it('skips prompting for auto-approved edits', async () => {
@@ -618,7 +695,7 @@ describe('formatToolEditApprovalSummary', () => {
   });
 });
 
-describe('formatAgentProposalApprovalSummary', () => {
+describe('buildAgentProposalApprovalContent', () => {
   it('formats subagent approvals without raw JSON internals', () => {
     const { summary, details } = buildAgentProposalApprovalContent(
       agentProposal({
@@ -659,8 +736,8 @@ describe('formatAgentProposalApprovalSummary', () => {
     expect(summary).toContain('[line truncated]');
     expect(summary).toContain('instruction lines hidden');
     expect(summary).not.toContain(longLine);
-    expect(details).toContain(`  60. ${longLine}`);
-    expect(details).not.toContain('instruction lines hidden');
+    expect(details?.()).toContain(`  60. ${longLine}`);
+    expect(details?.()).not.toContain('instruction lines hidden');
   });
 
   it('includes workflow proposal file groups', () => {
@@ -687,8 +764,8 @@ describe('formatAgentProposalApprovalSummary', () => {
     expect(summary).toContain('Input: draft-1.tex');
     expect(summary).toContain('+2 more');
     expect(summary).not.toContain('draft-12.tex');
-    expect(details).toContain('draft-12.tex');
-    expect(details).not.toContain('+2 more');
+    expect(details?.()).toContain('draft-12.tex');
+    expect(details?.()).not.toContain('+2 more');
     expect(summary).toContain('Context: notes.md');
     expect(summary).toContain('Media: figure.png');
     expect(summary).toContain('Output: draft-polished.tex');


### PR DESCRIPTION
## Summary

Direct CLI approval prompts retain their bounded proposal or edit preview, but now advertise `v view full` whenever content was hidden. Pressing `v` prints the complete instruction, file lists, or diff and returns to the same unresolved approval. The entire view-and-decision interaction keeps one reservation in the per-context input queue, so parallel approvals cannot interleave. Short prompts, approval policies, and the rich chat TUI are unchanged.

The defect was reproduced in a 72-column, 24-row PTY: a 390-line generated edit hid 313 lines, and a later 123-line edit hid 46, while the direct prompt accepted only approval or rejection.

Closes #10083.

## Issue acceptance gates

- Compact direct-CLI previews remain bounded.
- Truncated proposal instructions, proposal file lists, and edit diffs expose a discoverable full-view action.
- Viewing complete content does not settle the approval or release its input-queue reservation.
- Short approval prompts retain their previous text and behavior.
- Approval policies and the rich TUI path are unchanged.
- Boundary tests cover proposal and edit truncation, the view-then-approve loop, and parallel prompt exclusion.

## Single source of truth

The direct CLI approval boundary now owns one ephemeral `{ summary, details? }` value. `approvalSummaries.ts` derives both renderings from the same proposal or edit request; edit rendering computes its structured diff once. `askApproval` owns the complete interaction within one prompt-queue reservation. No second durable representation is introduced.

## Duplication and abstraction budget

The two bounded formatters became content builders because the prompt needs both renderings. A small `CliApprovalContent` interface records the invariant that full details are optional and only exist when they differ from the compact summary. The existing line-bounding and diff construction remain shared.

## Net elements (R6)

- Files: 5 changed.
- Diffstat: +244 / -73.
- Exported symbols: adds `CliApprovalContent`, `buildAgentProposalApprovalContent`, and `buildToolEditApprovalContent`; replaces the two exported summary-only formatters.
- Classes/enums: none.

## Consumer counts (R8)

n/a — no event, dispatch, or subscription key is removed or rerouted.

## Host impact

Extension: None.

Desktop: None.

CLI: Direct interactive proposal and tool-edit approvals can reveal complete truncated content before a decision; parallel prompts remain serialized throughout inspection.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- `npm test` — 856 files passed, 1 skipped; 10,010 tests passed, 5 skipped
- `corepack pnpm vitest run src/test-kernel/cli/ApprovalAdapter.vitest.ts` — 35 tests passed
- Focused ESLint on all changed TypeScript files
- Commit and pre-push hooks passed

The original failure was reproduced through a real PTY. The corrected prompt loop and queue ownership are covered at the direct approval boundary with the actual `askApproval` implementation and deterministic prompt callbacks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to direct CLI approval prompting and terminal text sanitization; policies, bash/plan prompts, and the rich TUI are unchanged, with broad boundary tests added.
> 
> **Overview**
> Direct CLI approval prompts keep their **bounded** previews for tool edits and agent proposals, but when lines or file lists are truncated they now advertise **`v view full`**. Pressing `v` prints the complete diff, instruction, or file groups to stderr (sanitized via shared `safeTerminalText`) and returns to the same unresolved prompt without approving or rejecting.
> 
> Approval content is modeled as **`CliApprovalContent`** (`summary` plus optional lazy `details`), built by **`buildToolEditApprovalContent`** and **`buildAgentProposalApprovalContent`** instead of summary-only formatters. **`askApproval`** runs the view loop inside a **single** per-context prompt-queue reservation so parallel approvals cannot interleave while someone inspects full content. **`safeTerminalText`** moves to `@cli/runtime/terminalText` for reuse across approval and TUI paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b66d1e1759a84fc227492c37e1b0430657146cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

