### PR TITLE
fix(cli): count only running background tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ All notable changes to this project will be documented in this file.
 - **Direct approval prompts reveal complete proposals and edits** — when a
   compact preview hides instruction or diff lines, press `v` to inspect the
   full content before approving or rejecting it.
-- **Session status reports active delegated work** — `/status` now shows the
-  number of active background tasks while retaining the focused session's own
-  status.
+- **Session status distinguishes running from finished delegated work** —
+  `/status` now shows the number of currently active background tasks while
+  retaining the focused session's own status.
 - **Interrupted multi-agent chats can be resumed immediately** — leaving a
   cancelled team session no longer leaves its printed resume command
   temporarily unavailable.

--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -38,6 +38,8 @@ import {
   isXaiSubscriptionActive,
 } from '@model/providerCapabilities';
 import { formatTexraApprovalPolicy } from '@shared/approvalPolicy';
+import type { StreamTabId } from '@shared/schemas';
+import { isActivePhase } from '@shared/streams/streamStatus';
 import { GoalStore } from '@tools/goal';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -98,8 +100,12 @@ export async function showCliSessionStatus(
   const activeStreamId = activeStreamIdSignal.get();
   const streamSlices = streams.get();
   const slice = activeStreamId ? streamSlices.get(activeStreamId) : undefined;
+  const runningChildrenFor = (streamId: StreamTabId) =>
+    activeSubagentsFor(streamId, childStreamEntries.get(), streamSlices).filter(
+      (child) => isActivePhase(child.status),
+    );
   const directActiveChildren = activeStreamId
-    ? activeSubagentsFor(activeStreamId, childStreamEntries.get(), streamSlices)
+    ? runningChildrenFor(activeStreamId)
     : [];
   const workflowStreamId =
     activeStreamId && directActiveChildren.length === 0
@@ -111,11 +117,7 @@ export async function showCliSessionStatus(
   let activeChildSessions = directActiveChildren.length;
   if (workflowStreamId !== activeStreamId) {
     activeChildSessions = workflowStreamId
-      ? activeSubagentsFor(
-          workflowStreamId,
-          childStreamEntries.get(),
-          streamSlices,
-        ).length
+      ? runningChildrenFor(workflowStreamId).length
       : 0;
   }
   // Use root-session access facts only before any stream exists.

--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -100,21 +100,25 @@ export async function showCliSessionStatus(
   const activeStreamId = activeStreamIdSignal.get();
   const streamSlices = streams.get();
   const slice = activeStreamId ? streamSlices.get(activeStreamId) : undefined;
+  const topologyChildrenFor = (streamId: StreamTabId) =>
+    activeSubagentsFor(streamId, childStreamEntries.get(), streamSlices);
   const runningChildrenFor = (streamId: StreamTabId) =>
-    activeSubagentsFor(streamId, childStreamEntries.get(), streamSlices).filter(
-      (child) => isActivePhase(child.status),
+    topologyChildrenFor(streamId).filter((child) =>
+      isActivePhase(child.status),
     );
-  const directActiveChildren = activeStreamId
-    ? runningChildrenFor(activeStreamId)
+  const directTopologyChildren = activeStreamId
+    ? topologyChildrenFor(activeStreamId)
     : [];
   const workflowStreamId =
-    activeStreamId && directActiveChildren.length === 0
+    activeStreamId && directTopologyChildren.length === 0
       ? activeStreamParentOrSelfId({
           activeStreamId,
           parentStream: parentStream.get(),
         })
       : activeStreamId;
-  let activeChildSessions = directActiveChildren.length;
+  let activeChildSessions = activeStreamId
+    ? runningChildrenFor(activeStreamId).length
+    : 0;
   if (workflowStreamId !== activeStreamId) {
     activeChildSessions = workflowStreamId
       ? runningChildrenFor(workflowStreamId).length

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -1022,6 +1022,56 @@ describe('handleTuiSlashCommand', () => {
     expect(statusText).not.toContain('active background tasks: 3');
   });
 
+  it('does not inherit ancestor siblings when a focused parent retains idle children', async () => {
+    registerBuiltinSlashCommands();
+    const session = createSession();
+    const rootStreamId = 'stream-idle-nested-root' as StreamTabId;
+    const parentStreamId = 'stream-idle-nested-parent' as StreamTabId;
+    const siblingStreamId = 'stream-running-sibling' as StreamTabId;
+    const childStreamId = 'stream-idle-grandchild' as StreamTabId;
+    activeStreamId.set(parentStreamId);
+    for (const streamId of [parentStreamId, siblingStreamId, childStreamId]) {
+      setStreamStatusInCliState({
+        streamId,
+        status: STREAM_PHASE.RUNNING,
+      });
+    }
+    setStreamStatusInCliState({
+      streamId: parentStreamId,
+      status: STREAM_PHASE.WAITING,
+    });
+    setStreamStatusInCliState({
+      streamId: childStreamId,
+      status: STREAM_PHASE.WAITING,
+    });
+    const rosterRow = (
+      childId: StreamTabId,
+      index: number,
+      status: typeof STREAM_PHASE.RUNNING | typeof STREAM_PHASE.WAITING,
+    ) => ({
+      executionId: `idle-nested-exec-${index}`,
+      identity: { kind: 'agent' as const, agent: `reviewer-${index}` },
+      agentName: `reviewer-${index}`,
+      status,
+      startedAt: index + 1,
+      elapsed: '1s',
+      childStreamId: childId,
+    });
+    projectChildRoster(rootStreamId, [
+      rosterRow(parentStreamId, 0, STREAM_PHASE.WAITING),
+      rosterRow(siblingStreamId, 1, STREAM_PHASE.RUNNING),
+    ]);
+    projectChildRoster(parentStreamId, [
+      rosterRow(childStreamId, 2, STREAM_PHASE.WAITING),
+    ]);
+
+    await handleTuiSlashCommand('/status', createContext(session));
+
+    const statusText = lastEntryText(rootStreamId);
+    expect(statusText).toContain('status: idle');
+    expect(statusText).not.toContain('active background tasks:');
+  });
+
   it('reports the access route that produced the focused stream usage', async () => {
     registerBuiltinSlashCommands();
     const overview = vi.spyOn(apiStatus, 'loadCliModelAccessOverview');

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -903,6 +903,53 @@ describe('handleTuiSlashCommand', () => {
     expect(statusText).toContain('active background tasks: 1');
   });
 
+  it('does not report retained idle children as active', async () => {
+    registerBuiltinSlashCommands();
+    const session = createSession();
+    const rootStreamId = 'stream-idle-root' as StreamTabId;
+    const childStreamIds = [
+      'stream-child-1',
+      'stream-child-2',
+    ] as StreamTabId[];
+    activeStreamId.set(rootStreamId);
+    setStreamStatusInCliState({
+      streamId: rootStreamId,
+      status: STREAM_PHASE.RUNNING,
+    });
+    setStreamStatusInCliState({
+      streamId: rootStreamId,
+      status: STREAM_PHASE.WAITING,
+    });
+    for (const childStreamId of childStreamIds) {
+      setStreamStatusInCliState({
+        streamId: childStreamId,
+        status: STREAM_PHASE.RUNNING,
+      });
+      setStreamStatusInCliState({
+        streamId: childStreamId,
+        status: STREAM_PHASE.WAITING,
+      });
+    }
+    projectChildRoster(
+      rootStreamId,
+      childStreamIds.map((childStreamId, index) => ({
+        executionId: `child-exec-${index}`,
+        identity: { kind: 'agent' as const, agent: `critic-${index}` },
+        agentName: `critic-${index}`,
+        status: STREAM_PHASE.WAITING,
+        startedAt: index + 1,
+        elapsed: '1s',
+        childStreamId,
+      })),
+    );
+
+    await handleTuiSlashCommand('/status', createContext(session));
+
+    const statusText = lastEntryText(rootStreamId);
+    expect(statusText).toContain('status: idle');
+    expect(statusText).not.toContain('active background tasks:');
+  });
+
   it('reports the owning workflow count while a background task is focused', async () => {
     registerBuiltinSlashCommands();
     const session = createSession();


### PR DESCRIPTION
## Summary

Fixes the CLI `/status` active-background-task count so it describes only running delegated child sessions. Completed or waiting child sessions remain in the session chooser but no longer make an idle workflow appear active.

The previous count reused the child-topology selector, whose contract is current addressability and killability rather than lifecycle liveness. This change keeps topology as the workflow-ownership authority, then applies the canonical `isActivePhase` predicate already used by the status bar when deriving the count.

Closes #10085.

## Issue acceptance gates

- A delegated child counts only while its canonical stream phase is running.
- Two retained idle children produce no `active background tasks` line.
- A running child still produces `active background tasks: 1`.
- Focusing a child continues to report the owning workflow's running-child count.
- An intermediate parent with retained idle children does not inherit its ancestor's running-sibling count.
- Session chooser history and child-control ownership are unchanged.

All gates are complete.

## Single source of truth

`StreamSlice.status` remains the lifecycle authority. `isActivePhase` is the existing canonical predicate for whether that phase is running. The canonical child topology remains the ownership authority; no parallel counter or parent map is introduced.

## Duplication and abstraction budget

Two local projections inside `showCliSessionStatus` make the distinction explicit: `topologyChildrenFor` determines ownership, while `runningChildrenFor` filters that projection by canonical phase. They introduce no exported surface or stored representation.

## Net elements (R6)

- Files: 3 modified, 0 added, 0 deleted.
- Exported symbols: 0 added, 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Production structure: two local projections replace raw topology counts.

## Consumer counts (R8)

n/a — no emit path, event key, or export is deleted or rerouted.

## Host impact

Extension: None.

Desktop: None.

CLI: `/status` no longer labels retained idle child sessions as active. Historical child navigation and nested ownership are unchanged.

## Scheduled refactoring

None.

## Validation

- Real PTY, 100×30, `TERM=xterm-256color`: reproduced two idle children reported as `active background tasks: 2`.
- Controlled PTY cancellation: stopped only the focused child and observed parent recovery.
- Rebuilt CLI and resumed persisted session `f30342c4ab7a`; `/status` reported idle with no false active-task line.
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- `npm test` — 856 files passed, 1 skipped; 10,010 tests passed, 5 skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI display logic in `/status` with no changes to child topology, persistence, or kill/ownership behavior; risk is limited to miscounting if `isActivePhase` disagrees with user expectations.
> 
> **Overview**
> **`/status` no longer treats retained idle delegated sessions as active work.** The active background-task count now applies the shared `isActivePhase` filter on top of the existing child-topology ownership rules, so completed or waiting children still appear in navigation but no longer inflate the count when the focused workflow is idle.
> 
> When focus sits on an intermediate parent with only idle descendants, the count also avoids inheriting a running sibling count from an ancestor workflow.
> 
> Tests cover idle retained children, focused-child workflow reporting, and the nested idle-parent case; the changelog wording is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4577298133995362d2ef5adb2b1b04a9893510d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->