### PR TITLE
fix(agent): preserve malformed progress blocks

### DIFF
--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -120,29 +120,43 @@ export function decodeXmlEntities(text: string): string {
     .replaceAll('&amp;', '&');
 }
 
-function progressDetail(xml: string): string {
-  const type = attr(xml, 'type') as SubagentProgressUpdate['kind'];
+function progressDetail(xml: string): string | undefined {
+  const type = attr(xml, 'type');
   switch (type) {
     case 'started':
       return 'started';
     case 'overview': {
-      const calls = attr(xml, 'tool-calls')!;
+      const calls = attr(xml, 'tool-calls');
+      if (calls === undefined) return undefined;
       const cost = attr(xml, 'cost');
       const toolCalls = `${calls} tool call${calls === '1' ? '' : 's'}`;
       return cost ? `${toolCalls} · $${cost}` : toolCalls;
     }
     case 'plan': {
-      if (attr(xml, 'status') === 'cleared') return 'plan cleared';
+      const status = attr(xml, 'status');
+      if (status === 'cleared') return 'plan cleared';
       // The producer (`formatSubagentProgress`) attaches the plan objective as
       // `summary`; there is no step count on the wire.
-      return `plan · ${decodeXmlEntities(attr(xml, 'summary')!)}`;
+      const summary = attr(xml, 'summary');
+      return status === 'updated' && summary !== undefined
+        ? `plan · ${decodeXmlEntities(summary)}`
+        : undefined;
     }
     case 'todos': {
       const completed = attr(xml, 'completed');
       const active = attr(xml, 'active');
       const pending = attr(xml, 'pending');
+      if (
+        completed === undefined ||
+        active === undefined ||
+        pending === undefined
+      ) {
+        return undefined;
+      }
       return `todos · ${completed} done, ${active} active, ${pending} pending`;
     }
+    default:
+      return undefined;
   }
 }
 
@@ -288,7 +302,8 @@ export function summarizeSubagentFollowup(text: unknown): string {
 
   if (tag === DELIVERY_TAG.subagentProgress) {
     const agent = attr(trimmed, 'agent') ?? 'subagent';
-    return `⟳ ${agent} · ${progressDetail(trimmed)}`;
+    const detail = progressDetail(trimmed);
+    return detail === undefined ? normalized : `⟳ ${agent} · ${detail}`;
   }
 
   if (

--- a/src/test-kernel/cli/SubagentFollowup.vitest.ts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.ts
@@ -128,6 +128,29 @@ describe('summarizeSubagentFollowup', () => {
     ).toBe('⟳ review · todos · 1 done, 1 active, 1 pending');
   });
 
+  it.each([
+    '<subagent-progress agent="a" />',
+    '<subagent-progress agent="a" type="bogus" />',
+    '<subagent-progress agent="a" type="overview" />',
+    '<subagent-progress agent="a" type="plan" status="updated" />',
+    '<subagent-progress agent="a" type="todos" completed="1" active="0" />',
+  ])('preserves a non-canonical progress block: %s', (xml) => {
+    expect(summarizeSubagentFollowup(xml)).toBe(xml);
+  });
+
+  it.each([
+    [
+      '<subagent-progress agent="a" type="plan" status="cleared" />',
+      '⟳ a · plan cleared',
+    ],
+    [
+      '<subagent-progress agent="a" type="plan" status="updated" summary="Build the proof" />',
+      '⟳ a · plan · Build the proof',
+    ],
+  ])('summarizes a canonical plan progress block', (xml, expected) => {
+    expect(summarizeSubagentFollowup(xml)).toBe(expected);
+  });
+
   it('summarizes embedded subagent blocks inside assistant text', () => {
     const text = [
       'before',


### PR DESCRIPTION
Closes #10067.

## Summary

- reject unknown or missing subagent progress kinds at the transcript boundary
- preserve progress blocks with missing kind-specific attributes instead of rendering `undefined`
- retain the existing concise summaries for canonical producer output

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/SubagentFollowup.vitest.ts`
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- focused ESLint and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only parsing at the transcript/follow-up boundary with no auth, data, or persistence changes.
> 
> **Overview**
> **Subagent progress** transcript collapsing no longer fabricates one-line summaries when the XML is incomplete or non-canonical.
> 
> `progressDetail` now returns **undefined** for unknown/missing `type`, missing kind-specific attributes (e.g. `tool-calls` on overview, all todo counts, or `summary` on `plan` with `status="updated"`), while still summarizing canonical producer output including **plan cleared** and **plan · …** when attributes are present. When detail cannot be built, `summarizeSubagentFollowup` **returns the original `<subagent-progress …>` block** instead of a line containing `undefined`.
> 
> Vitest coverage adds cases for malformed progress XML and canonical plan blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 287e7996c42f5eb0f5f5203f552e0856a38a9b2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->