### PR TITLE
fix(cli): show direct-run resume hint on interrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ All notable changes to this project will be documented in this file.
   input is hidden.
 - **Session views show recognizable model names** — headers, `/status`, and
   background-task rows use catalog labels instead of internal model IDs.
+- **Interrupted headless agent runs show how to resume** — stopping a tool-use
+  agent or multi-agent team now prints a command that preserves its workspace,
+  approval policy, and skill sources while reopening the interactive session
+  required for continuation.
 
 ### Shared (all surfaces)
 

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -62,7 +62,7 @@ export async function runToolUseAgent(
       requireWorkspaceFiles: true,
       readStdinText: readCliStdinText,
     },
-    async ({ inputFiles, contextFiles }) => {
+    async ({ inputFiles, contextFiles, hasMaterializedStdinInput }) => {
       const config: AgentConfigPayload = {
         agent: init.agent,
         model,
@@ -82,6 +82,7 @@ export async function runToolUseAgent(
         enforceCategory: true,
         registerExecution: true,
         stopAfterCycle: true,
+        recoveryInputIsDurable: hasMaterializedStdinInput !== true,
         categoryMismatchMessage: `Agent "${init.agent}" resolved to a non tool-use run.`,
       });
       if (!execution.ok) return execution.exitCode;

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -194,7 +194,7 @@ export async function runMultiAgentPreset(
       requireWorkspaceFiles: true,
       readStdinText: readCliStdinText,
     },
-    async ({ inputFiles, contextFiles }) => {
+    async ({ inputFiles, contextFiles, hasMaterializedStdinInput }) => {
       if (runContext.approvalPolicy === 'never') {
         writeTextStderr(
           `WARN preset ${plan.preset.id} may run without subagent delegation because approval policy "never" denies approval-gated delegation tools. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`,
@@ -225,6 +225,7 @@ export async function runMultiAgentPreset(
         enforceCategory: true,
         registerExecution: true,
         stopAfterCycle: true,
+        recoveryInputIsDurable: hasMaterializedStdinInput !== true,
         categoryMismatchMessage: `Multi-agent preset "${init.preset}" resolved to a non tool-use execution.`,
       });
       if (!execution.ok) return execution.exitCode;

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -13,10 +13,13 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   CliUsageError,
   readCliStdinText,
-  readCliCwd,
   type CliContext,
 } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
+import {
+  formatInterruptedResumeHint,
+  tryReadCliCwd,
+} from '../runtime/interruptedResumeHint';
 import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
 import {
   buildHeadlessRunContext,
@@ -34,7 +37,6 @@ import {
   emitCliResult,
   writeCliProgressAndWait,
 } from './_helpers/output';
-import { formatResumeCommand } from '../chat/tui/state/resumeHint';
 import {
   AGENT_RUN_GLOBAL_ARGS,
   collectCommonAgentRunFlags,
@@ -71,15 +73,6 @@ function absoluteOutputDestination(
   return path.isAbsolute(destination)
     ? destination
     : path.join(cwd, destination);
-}
-
-/** Read the launch directory without making recovery depend on its lifetime. */
-function tryReadCliCwd(): string | undefined {
-  try {
-    return readCliCwd();
-  } catch {
-    return undefined;
-  }
 }
 
 interface WorkflowRunInit {
@@ -217,9 +210,10 @@ export async function executeCliWorkflowConfig(
     if (!recoveryInputIsDurable) return;
     if (resumeHintWritten) return;
     resumeHintWritten = true;
-    const hint = formatWorkflowResumeHint(
+    const hint = formatInterruptedResumeHint(
       runContext,
       executionId,
+      'workflow',
       config.workingDirectory || runContext.cwd,
       recoveryProcessCwd,
     );
@@ -309,24 +303,6 @@ export async function executeCliWorkflowConfig(
   }
 
   return runOutcomeExitCode(result.outcome);
-}
-
-function formatWorkflowResumeHint(
-  context: CliContext,
-  executionId: string,
-  workingDirectory: string,
-  processCwd: string | undefined,
-): string {
-  const resumeCommand = formatResumeCommand(context.commandName, executionId, {
-    cwd: workingDirectory,
-    processCwd,
-    approvalPolicy: context.approvalPolicy,
-    outputFormat: context.outputFormat,
-    print: context.mode === 'headless',
-    includeInteropSkills: context.skillSourceOptions.includeInterop,
-    skillSourcePaths: context.skillSourceOptions.additionalPaths,
-  });
-  return `Resume this workflow with: ${resumeCommand}`;
 }
 
 async function persistWorkflowResultMeta(

--- a/packages/cli/src/runtime/interruptedResumeHint.ts
+++ b/packages/cli/src/runtime/interruptedResumeHint.ts
@@ -1,0 +1,33 @@
+import type { ExecutionId } from '@shared/schemas';
+
+import { formatResumeCommand } from '../chat/tui/state/resumeHint';
+import { readCliCwd, type CliContext } from './cliContext';
+
+/** Read the launch directory without making recovery depend on its lifetime. */
+export function tryReadCliCwd(): string | undefined {
+  try {
+    return readCliCwd();
+  } catch {
+    return undefined;
+  }
+}
+
+/** Format a copyable command after the caller has established resumability. */
+export function formatInterruptedResumeHint(
+  context: CliContext,
+  executionId: ExecutionId,
+  subject: 'session' | 'workflow',
+  workingDirectory: string,
+  processCwd: string | undefined,
+): string {
+  const resumeCommand = formatResumeCommand(context.commandName, executionId, {
+    cwd: workingDirectory,
+    processCwd,
+    approvalPolicy: context.approvalPolicy,
+    outputFormat: subject === 'workflow' ? context.outputFormat : undefined,
+    print: subject === 'workflow' && context.mode === 'headless',
+    includeInteropSkills: context.skillSourceOptions.includeInterop,
+    skillSourcePaths: context.skillSourceOptions.additionalPaths,
+  });
+  return `Resume this ${subject} with: ${resumeCommand}`;
+}

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -35,11 +35,15 @@ import {
   finalizeCliExecution,
   releaseCliExecutionLeaseAfterArtifacts,
 } from './executionFinalization';
+import {
+  formatInterruptedResumeHint,
+  tryReadCliCwd,
+} from './interruptedResumeHint';
 import { attachCliSessionProgressProjection } from './sessionProgressSubscription';
 import { initializeHeadlessTranscriptSession } from './transcriptSession';
 import { createCliRuntimeHost } from './cliPresentationHost';
 import { CliExitCode } from './exitCodes';
-import { writeTextStderr } from './logSinks';
+import { writeTextStderr, writeTextStderrAndWait } from './logSinks';
 import {
   readCliRunOutcomeState,
   runOutcomeExitCode,
@@ -171,10 +175,30 @@ export async function executeCliConfig<
 export async function executeCliToolUseConfig(
   config: AgentConfigPayload,
   runContext: CliContext,
-  options: CliConfigExecuteOptions<typeof AgentCategory.ToolUse> = {},
+  options: CliConfigExecuteOptions<typeof AgentCategory.ToolUse> & {
+    /** False when invocation-owned temporary inputs will not survive exit. */
+    readonly recoveryInputIsDurable?: boolean;
+  } = {},
 ) {
+  const { recoveryInputIsDurable = true, ...executeOptions } = options;
+  const recoveryProcessCwd = tryReadCliCwd();
+  const workingDirectory = config.workingDirectory || runContext.cwd;
   const execution = await executeCliConfig(config, runContext, {
-    ...options,
+    ...executeOptions,
+    onInterruptedExecutionFinalized:
+      recoveryInputIsDurable === true
+        ? (executeOptions.onInterruptedExecutionFinalized ??
+          ((executionId) =>
+            writeTextStderrAndWait(
+              formatInterruptedResumeHint(
+                runContext,
+                executionId,
+                'session',
+                workingDirectory,
+                recoveryProcessCwd,
+              ),
+            )))
+        : undefined,
     expectedCategory: AgentCategory.ToolUse,
   });
   if (!execution.ok) return execution;

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.ts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.ts
@@ -150,6 +150,9 @@ describe('CLI agents run command', () => {
     expect(config?.inputFiles).toEqual(['problem.md']);
     expect(config?.contextFiles).toEqual(['notes.md']);
     expect(config?.displayInstruction).toBe('Assess the proof concisely.');
+    expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
+      recoveryInputIsDurable: true,
+    });
     expect(config?.instruction).toContain('Primary user input files:');
     expect(config?.instruction).toContain('- "problem.md"');
     expect(config?.instruction).toContain('Read-only context files:');
@@ -179,6 +182,40 @@ describe('CLI agents run command', () => {
       result: emission.json,
     });
     expect(emission?.text).toBe('Correct.');
+  });
+
+  it('marks materialized stdin as unavailable for recovery advertising', async () => {
+    mocks.withExpandedRunInputs.mockImplementationOnce(
+      async (
+        _inputSpecs: readonly string[],
+        _contextSpecs: readonly string[],
+        _cwd: string,
+        _options: unknown,
+        run: (inputs: {
+          readonly inputFiles: string[];
+          readonly contextFiles: string[];
+          readonly hasMaterializedStdinInput: boolean;
+        }) => Promise<unknown>,
+      ) =>
+        run({
+          inputFiles: ['.texra-tmp/stdin.tex'],
+          contextFiles: [],
+          hasMaterializedStdinInput: true,
+        }),
+    );
+    const { runToolUseAgent } = await import('@cli/commands/agentsRun');
+
+    await runToolUseAgent(cliContext(), {
+      agent: 'chat',
+      inputFiles: ['-'],
+      contextFiles: [],
+      model: 'gpt54',
+      instruction: 'Assess the proof.',
+    });
+
+    expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
+      recoveryInputIsDurable: false,
+    });
   });
 
   it('publishes the canonical outcome for a shutdown cancellation', async () => {

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
@@ -294,6 +294,7 @@ describe('CLI multi-agent run command', () => {
     expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
       enforceCategory: true,
       registerExecution: true,
+      recoveryInputIsDurable: true,
       stopAfterCycle: true,
     });
     expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
@@ -339,6 +340,36 @@ describe('CLI multi-agent run command', () => {
       ...emission.json,
     });
     expect(emission?.text).toBe('The proof is correct.');
+  });
+
+  it('marks materialized stdin as unavailable for team recovery advertising', async () => {
+    mocks.withExpandedRunInputs.mockImplementationOnce(
+      async (
+        _inputSpecs: readonly string[],
+        _contextSpecs: readonly string[],
+        _cwd: string,
+        _options: unknown,
+        run: (inputs: {
+          readonly inputFiles: string[];
+          readonly contextFiles: string[];
+          readonly hasMaterializedStdinInput: boolean;
+        }) => Promise<unknown>,
+      ) =>
+        run({
+          inputFiles: ['.texra-tmp/stdin.tex'],
+          contextFiles: [],
+          hasMaterializedStdinInput: true,
+        }),
+    );
+
+    await runPreset({
+      inputFiles: ['-'],
+      instruction: 'Inspect the proof.',
+    });
+
+    expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
+      recoveryInputIsDurable: false,
+    });
   });
 
   it('marks run-plan resolution when authenticated gaps triggered a remote load', async () => {

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -42,6 +42,7 @@ const mocks = vi.hoisted(() => ({
   releaseExecutionLeaseAfterArtifacts: vi.fn(),
   runAgent: vi.fn(),
   writeTextStderr: vi.fn(),
+  writeTextStderrAndWait: vi.fn<() => Promise<void>>(async () => undefined),
   finalizeExecution: vi.fn(),
 }));
 
@@ -126,6 +127,7 @@ vi.mock('@cli/runtime/workflowPlainOutput', () => ({
 
 vi.mock('@cli/runtime/logSinks', () => ({
   writeTextStderr: mocks.writeTextStderr,
+  writeTextStderrAndWait: mocks.writeTextStderrAndWait,
 }));
 
 type CliRequest = Parameters<typeof executeCliRequest>[0];
@@ -1247,6 +1249,92 @@ describe('executeCliConfig', () => {
       stopAfterCycle: true,
     });
   }
+
+  it('prints a complete resume command after interrupted tool-use recovery is available', async () => {
+    const { platform } = await installFakePlatform();
+    const { executeCliToolUseConfig } = await loadRunExecution();
+    const context = cliContext({
+      approvalPolicy: 'yolo',
+      outputFormat: 'ndjson',
+      skillSourceOptions: {
+        includeInterop: true,
+        additionalPaths: ['/tmp/skill path'],
+      },
+    });
+    let publishLeaseScope: LeaseOptions['onExecutionLeaseAcquired'];
+    let publishRun: LeaseOptions['onRun'];
+    const hangingRun = stubHangingRun((options) => {
+      publishLeaseScope = options.onExecutionLeaseAcquired;
+      publishRun = options.onRun;
+    });
+    let settleRecoveryWrite!: () => void;
+    const recoveryWrite = new Promise<void>((resolve) => {
+      settleRecoveryWrite = resolve;
+    });
+    mocks.writeTextStderrAndWait.mockReturnValueOnce(recoveryWrite);
+
+    const run = executeCliToolUseConfig(toolUseConfig(), context, {
+      registerExecution: true,
+      stopAfterCycle: true,
+    });
+    await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
+    const shutdown = platform.lifecycle.runShutdown();
+    publishLeaseScope?.((operation) => operation(), 'exec-1' as ExecutionId);
+    publishRun?.();
+    mocks.readCliRunOutcomeState.mockResolvedValueOnce({
+      outcome: RUN_OUTCOME.CANCELLED,
+      outcomePersisted: true,
+    });
+    hangingRun.resolve(COMPLETED_RUN);
+
+    await vi.waitFor(() =>
+      expect(mocks.writeTextStderrAndWait).toHaveBeenCalledOnce(),
+    );
+    let shutdownResolved = false;
+    void shutdown.then(() => {
+      shutdownResolved = true;
+    });
+    await Promise.resolve();
+    expect(shutdownResolved).toBe(false);
+    settleRecoveryWrite();
+    await shutdown;
+    await expect(run).resolves.toMatchObject({
+      ok: true,
+      exitCode: CliExitCode.Interrupted,
+    });
+    expect(mocks.writeTextStderrAndWait).toHaveBeenCalledExactlyOnceWith(
+      "Resume this session with: texra resume exec-1 --cwd /tmp/project --approval-policy yolo --include-interop --source '/tmp/skill path'",
+    );
+  });
+
+  it('does not advertise recovery for invocation-owned temporary inputs', async () => {
+    const { platform } = await installFakePlatform();
+    const { executeCliToolUseConfig } = await loadRunExecution();
+    let publishLeaseScope: LeaseOptions['onExecutionLeaseAcquired'];
+    let publishRun: LeaseOptions['onRun'];
+    const hangingRun = stubHangingRun((options) => {
+      publishLeaseScope = options.onExecutionLeaseAcquired;
+      publishRun = options.onRun;
+    });
+
+    const run = executeCliToolUseConfig(toolUseConfig(), cliContext(), {
+      registerExecution: true,
+      recoveryInputIsDurable: false,
+    });
+    await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
+    const shutdown = platform.lifecycle.runShutdown();
+    publishLeaseScope?.((operation) => operation(), 'exec-1' as ExecutionId);
+    publishRun?.();
+    mocks.readCliRunOutcomeState.mockResolvedValueOnce({
+      outcome: RUN_OUTCOME.CANCELLED,
+      outcomePersisted: true,
+    });
+    hangingRun.resolve(COMPLETED_RUN);
+
+    await shutdown;
+    await run;
+    expect(mocks.writeTextStderrAndWait).not.toHaveBeenCalled();
+  });
 
   /** Stubs a workflow-category result where a tool-use run was expected. */
   async function runWorkflowCategoryMismatch() {


### PR DESCRIPTION
Closes #10104.

## Summary

- print one canonical `texra resume <id>` command after an interrupted `agents run` or `multi-agent run` becomes durably resumable
- preserve the effective workspace, approval policy, and skill-source flags while reopening the interactive session required by tool-use resume
- suppress recovery guidance when stdin-backed temporary inputs will be deleted
- leave completed and failed runs, JSON/NDJSON stdout framing, and non-durable interruptions unchanged

## Scope correction

Workflow recovery shipped independently in #10095. This branch was rebuilt from current `main`, deleting the obsolete workflow shutdown changes from the earlier draft and retaining only the unresolved direct tool-use behavior from #10104.

## Ownership and simplification

The shared headless execution boundary already owns signal cancellation, checkpoint draining, terminal-state persistence, and lease release. Direct tool-use commands now provide only an awaited presentation callback. The boundary invokes it after cancellation is durable, generic resumability succeeds, and the execution lease is missing or stale, then waits until the recovery line has flushed.

The workflow and direct-run paths share one formatter for recovery commands. Workflow recovery preserves headless output flags; tool-use recovery omits `--print` and `--output-format` because it resumes in the interactive chat TUI. The existing input-expansion boundary tells the executor whether invocation-owned stdin materialization is durable; no second file or checkpoint inspection was added.

Direct recovery remains on stderr. This satisfies #10104 and keeps stdout free of recovery prose for every headless result mode; workflow progress retains its existing text-mode stdout policy.

## PTY evidence

Built CLI v0.40.3 on macOS, in a real PTY sized 30 rows by 100 columns:

```text
texra agents run assistant --print --model gpt56 --approval-policy never --instruction "<quantum-channel derivation and independent verification>"
assistant · Deriving depolarizing channel Choi eigenvalues and complete positivity · 4s
^C
assistant · stopped · 13s
Resume this session with: texra resume 7902fde8a0f7 --approval-policy never
```

The command appeared after the stopped state, omitted headless-only flags so the resumable tool-use session can reopen interactively, and omitted `--cwd` because the workspace equalled the shell directory. Boundary tests cover a distinct workspace, `yolo`, interoperation skills, a quoted additional skill path, awaited stream flushing, and suppression for temporary stdin inputs in both direct callers.

A separate attempt through the default configured provider returned HTTP 402 before a checkpoint existed; no recovery command was printed, as required.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- `npm test` — 856 files passed, 1 skipped; 10,054 tests passed, 5 skipped
- focused execution, workflow recovery, resume-command, direct-agent, and multi-agent suites — 112 tests passed
- built-bundle PTY interruption at 100×30 after the interactive-resume correction
- pre-commit and pre-push hooks
