### PR TITLE
fix(cli): count only running child sessions

### DIFF
--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -38,6 +38,7 @@ import {
   isXaiSubscriptionActive,
 } from '@model/providerCapabilities';
 import { formatTexraApprovalPolicy } from '@shared/approvalPolicy';
+import { isActivePhase } from '@shared/streams/streamStatus';
 import { GoalStore } from '@tools/goal';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -108,16 +109,19 @@ export async function showCliSessionStatus(
           parentStream: parentStream.get(),
         })
       : activeStreamId;
-  let activeChildSessions = directActiveChildren.length;
+  let workflowChildren = directActiveChildren;
   if (workflowStreamId !== activeStreamId) {
-    activeChildSessions = workflowStreamId
+    workflowChildren = workflowStreamId
       ? activeSubagentsFor(
           workflowStreamId,
           childStreamEntries.get(),
           streamSlices,
-        ).length
-      : 0;
+        )
+      : [];
   }
+  const activeChildSessions = workflowChildren.filter((child) =>
+    isActivePhase(child.status),
+  ).length;
   // Use root-session access facts only before any stream exists.
   const model = slice?.model ?? (meta.model || context.initialModel);
   const subscriptionActive = await isCodexSubscriptionActive(model);

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -903,6 +903,45 @@ describe('handleTuiSlashCommand', () => {
     expect(statusText).toContain('active background tasks: 1');
   });
 
+  it('does not count retained idle children as active background tasks', async () => {
+    registerBuiltinSlashCommands();
+    const session = createSession();
+    const rootStreamId = 'stream-root' as StreamTabId;
+    const childStreamIds = [
+      'stream-child-1',
+      'stream-child-2',
+    ] as StreamTabId[];
+    activeStreamId.set(rootStreamId);
+    setStreamStatusInCliState({
+      streamId: rootStreamId,
+      status: STREAM_PHASE.WAITING,
+    });
+    for (const [index, childStreamId] of childStreamIds.entries()) {
+      setStreamStatusInCliState({
+        streamId: childStreamId,
+        status: index === 0 ? STREAM_PHASE.WAITING : STREAM_PHASE.COMPLETED,
+      });
+    }
+    projectChildRoster(
+      rootStreamId,
+      childStreamIds.map((childStreamId, index) => ({
+        executionId: `child-exec-${index}`,
+        identity: { kind: 'agent' as const, agent: `critic-${index}` },
+        agentName: `critic-${index}`,
+        status: index === 0 ? STREAM_PHASE.WAITING : STREAM_PHASE.COMPLETED,
+        startedAt: index + 1,
+        elapsed: '1s',
+        childStreamId,
+      })),
+    );
+
+    await handleTuiSlashCommand('/status', createContext(session));
+
+    expect(lastEntryText(rootStreamId)).not.toContain(
+      'active background tasks:',
+    );
+  });
+
   it('reports the owning workflow count while a background task is focused', async () => {
     registerBuiltinSlashCommands();
     const session = createSession();
@@ -934,6 +973,51 @@ describe('handleTuiSlashCommand', () => {
     const statusText = lastEntryText(rootStreamId);
     expect(statusText).toContain('status: running');
     expect(statusText).toContain('active background tasks: 2');
+  });
+
+  it('filters idle siblings from the owning workflow count', async () => {
+    registerBuiltinSlashCommands();
+    const session = createSession();
+    const rootStreamId = 'stream-root' as StreamTabId;
+    const focusedChildId = 'stream-focused-child' as StreamTabId;
+    const runningSiblingId = 'stream-running-sibling' as StreamTabId;
+    const idleSiblingId = 'stream-idle-sibling' as StreamTabId;
+    activeStreamId.set(focusedChildId);
+    setStreamStatusInCliState({
+      streamId: focusedChildId,
+      status: STREAM_PHASE.WAITING,
+    });
+    setStreamStatusInCliState({
+      streamId: runningSiblingId,
+      status: STREAM_PHASE.RUNNING,
+    });
+    setStreamStatusInCliState({
+      streamId: idleSiblingId,
+      status: STREAM_PHASE.WAITING,
+    });
+    projectChildRoster(
+      rootStreamId,
+      [focusedChildId, runningSiblingId, idleSiblingId].map(
+        (childStreamId, index) => ({
+          executionId: `child-exec-${index}`,
+          identity: { kind: 'agent' as const, agent: `critic-${index}` },
+          agentName: `critic-${index}`,
+          status:
+            childStreamId === runningSiblingId
+              ? STREAM_PHASE.RUNNING
+              : STREAM_PHASE.WAITING,
+          startedAt: index + 1,
+          elapsed: '1s',
+          childStreamId,
+        }),
+      ),
+    );
+
+    await handleTuiSlashCommand('/status', createContext(session));
+
+    const statusText = lastEntryText(rootStreamId);
+    expect(statusText).toContain('active background tasks: 1');
+    expect(statusText).not.toContain('active background tasks: 3');
   });
 
   it('counts delegated work owned by a focused intermediate parent', async () => {


### PR DESCRIPTION
Closes #10085.

## Summary

- retain topology-based workflow ownership for `/status`
- count only child streams in an active canonical phase
- cover retained idle children and mixed running/idle siblings while a child is focused

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/SlashCommandDispatch.vitest.ts`
- `npm run typecheck:cli`
- `npm run typecheck:test-kernel`
- focused ESLint and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI display fix for `/status` with no auth, persistence, or execution changes; behavior is covered by new slash-command tests.
> 
> **Overview**
> Fixes inflated **active background tasks** on `/status` by counting only workflow-owned child streams whose status is in an **active canonical phase** (`isActivePhase`), instead of every child still on the roster.
> 
> Workflow ownership logic is unchanged: when the focused stream has no direct children, `/status` still resolves the owning workflow via `activeStreamParentOrSelfId` and aggregates that parent’s children. The count now filters those children by phase before taking `.length`, aligning with how the TUI tab/status bar treats in-flight background work.
> 
> New tests cover retained idle/completed children under an idle root and mixed running vs idle siblings while a child is focused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a24e235da9e42ab089fb2e0a3962861fd8025b10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->