### PR TITLE
fix(cli): keep narrow child kill hint visible

### DIFF
--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -821,13 +821,6 @@ function childListBindingsText(
           escBinding,
           ctrlCBinding,
         ]),
-      statusBarBindingRow([
-        selectBinding,
-        enterBinding,
-        tabBinding,
-        escBinding,
-        ctrlCBinding,
-      ]),
       statusBarBindingRow([enterBinding, escBinding, ctrlCBinding]),
       ctrlCBinding,
     ],

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -413,6 +413,20 @@ describe('CLI StatusBar display model', () => {
     ).not.toContain('k kill');
   });
 
+  it('does not drop focus controls for a non-killable narrow selection', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        width: 55,
+        childList: {
+          focused: true,
+          selectionKillable: false,
+        },
+      }),
+    );
+
+    expect(display.bindings).toBe('Enter focus · Esc input · Ctrl-C exit');
+  });
+
   it('shows foreground actions while a list-owned surface is open', () => {
     const display = buildStatusBarDisplay(
       statusInput({


### PR DESCRIPTION
Closes #10096.

## Summary

- keep `k kill` visible for a selected running child in a narrow session chooser
- retain `Enter focus` when the selected row is not killable
- remove a dominated status-bar candidate that could never win

## Ownership decision

`statusBarDisplay` remains the single authority for fitting child-list controls. The selected row contributes only the fact that killing is currently available. The fitter then prefers the row-specific `k kill` action over `Enter focus` when necessary, but never drops `Enter focus` for a non-killable selection. Key dispatch and child lifecycle ownership are unchanged.

## Validation

- StatusBar suite: 97 tests passed
- workspace typecheck
- focused lint
- prior full CI and PTY validation were green before the rebase