### PR TITLE
fix(cli): resume cancelled reflection workflow rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@ All notable changes to this project will be documented in this file.
 - **Interrupted multi-agent chats can be resumed immediately** — leaving a
   cancelled team session no longer leaves its printed resume command
   temporarily unavailable.
-- **Cancelled reflection workflows resume their unfinished round** — resuming
-  no longer stops immediately with another interruption.
 
 ### Shared (all surfaces)
 
 #### Bug Fixes
 
+- **Cancelled reflection workflows resume their unfinished round** — resuming
+  no longer stops immediately with another interruption.
 - **Claude Code forks leave the original conversation unchanged** — an
   incomplete fork now stops instead of continuing the original conversation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 - **Interrupted multi-agent chats can be resumed immediately** — leaving a
   cancelled team session no longer leaves its printed resume command
   temporarily unavailable.
+- **Cancelled reflection workflows resume their unfinished round** — resuming
+  no longer stops immediately with another interruption.
 
 ### Shared (all surfaces)
 

--- a/src/agent/implementations/flows/reflection/RoundPersistedFlow.ts
+++ b/src/agent/implementations/flows/reflection/RoundPersistedFlow.ts
@@ -173,6 +173,12 @@ export class RoundPersistedFlow<
     return outcome;
   }
 
+  /** Restart the current round after a persisted cancellation. */
+  async restartCurrentRound(shared: S): Promise<void> {
+    shared.continueRounds = true;
+    await this.resetNodeHistory(shared);
+  }
+
   /**
    * Execute all nodes in the current round, checking for interruption
    * between each step. Returns the final shared state.

--- a/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
@@ -80,7 +80,6 @@ export class PrepareContextNode<C = unknown> extends Node<
     context: RoundContext,
   ): Promise<string | undefined> {
     shared.context = context;
-    delete shared.compileFailureContext;
     return FlowTransition.DEFAULT;
   }
 }

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -315,9 +315,17 @@ export async function runReflectionFlow<C = unknown>(
     // once had that conversation imported into the transcript sidecar here;
     // the importer was retired per #9590 Stage 7, so such a session's
     // pre-resume turns stay out of the durable transcript.
-    // Persist the synced totalRounds into the flow record so that
-    // stepWithResult() picks up the current config, not the stale one.
-    await pf.setShared(shared);
+    // A cancelled response leaves the current round terminal with
+    // continueRounds=false and no failure. A fresh resume signal should retry
+    // that unfinished round from its first node; completed earlier rounds stay
+    // in shared.roundOutputs. Failures retain their terminal cursor and error.
+    if (!shared.continueRounds && !shared.lastError) {
+      await pf.restartCurrentRound(shared);
+    } else {
+      // Persist the synced totalRounds into the flow record so that
+      // stepWithResult() picks up the current config, not the stale one.
+      await pf.setShared(shared);
+    }
   }
 
   const outcome = await pf.run(shared);

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -22,6 +22,7 @@ import {
 } from '@agent/implementations/flows/reflection/runReflectionFlow';
 import { ReflectionFlowStateCanonicalSchema } from '@agent/implementations/flows/reflection/ReflectionFlowState';
 import { RoundPersistedFlow } from '@agent/implementations/flows/reflection/RoundPersistedFlow';
+import { PrepareContextNode } from '@agent/implementations/flows/reflection/nodes/PrepareContextNode';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { createRunScope } from '@agent/runtime/RunScope';
 import {
@@ -272,5 +273,18 @@ describe('runReflectionFlow persisted-state recovery', () => {
     await failed.run();
 
     expect(restartSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps repair context available while an unfinished round is resumable', async () => {
+    const node = new PrepareContextNode();
+    const shared = reflectionFlowShared({
+      currentRound: 1,
+      compileFailureContext: 'Compilation failed in round 0.',
+    });
+    const context = shared.context!;
+
+    await node.post(shared, {} as never, context);
+
+    expect(shared.compileFailureContext).toBe('Compilation failed in round 0.');
   });
 });

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -21,6 +21,7 @@ import {
   type RunReflectionFlowInput,
 } from '@agent/implementations/flows/reflection/runReflectionFlow';
 import { ReflectionFlowStateCanonicalSchema } from '@agent/implementations/flows/reflection/ReflectionFlowState';
+import { RoundPersistedFlow } from '@agent/implementations/flows/reflection/RoundPersistedFlow';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { createRunScope } from '@agent/runtime/RunScope';
 import {
@@ -231,5 +232,45 @@ describe('runReflectionFlow persisted-state recovery', () => {
     const shared = ReflectionFlowStateCanonicalSchema.parse(stored?.shared);
     expect(shared.workspaceSnapshot.workPlan.todos).toEqual([todo]);
     expect(Object.hasOwn(shared.workspaceSnapshot, 'todos')).toBe(false);
+  });
+
+  it('restarts a persisted cancellation but preserves a persisted failure', async () => {
+    const restartSpy = vi.spyOn(
+      RoundPersistedFlow.prototype,
+      'restartCurrentRound',
+    );
+    const cancelled = recoveryCase('cancelled-round');
+    await cancelled.store.write(
+      cancelled.key,
+      flowRecord(
+        reflectionFlowShared({
+          totalRounds: 1,
+          context: null,
+          continueRounds: false,
+        }),
+      ),
+    );
+
+    await cancelled.run();
+
+    expect(restartSpy).toHaveBeenCalledOnce();
+
+    restartSpy.mockClear();
+    const failed = recoveryCase('failed-round');
+    await failed.store.write(
+      failed.key,
+      flowRecord(
+        reflectionFlowShared({
+          totalRounds: 1,
+          context: null,
+          continueRounds: false,
+          lastError: { message: 'model failed', userRetryable: true },
+        }),
+      ),
+    );
+
+    await failed.run();
+
+    expect(restartSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
+++ b/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
@@ -86,6 +86,10 @@ function makeFlow() {
   });
 }
 
+function makeFlowWithKv(kv: ReturnType<typeof createFakeKv>) {
+  return new RoundPersistedFlow<FakeShared>(new FakeRoundNode(), kv);
+}
+
 function initialShared(overrides: Partial<FakeShared>): FakeShared {
   return {
     currentRound: 0,
@@ -141,6 +145,26 @@ describe('RoundPersistedFlow bounded compile-repair round (#7077)', () => {
     // Exactly one repair round (2) — no round 3, even though round 2 also failed.
     expect(shared.roundsRun).toEqual([0, 1, 2]);
     expect(shared.compileRepairRoundGranted).toBe(true);
+  });
+});
+
+describe('RoundPersistedFlow cancelled-round recovery (#10098)', () => {
+  it('restarts the terminal current-round cursor without advancing the round', async () => {
+    const kv = createFakeKv();
+    const initialFlow = makeFlowWithKv(kv);
+    const shared = initialShared({ totalRounds: 1 });
+    await initialFlow.run(shared);
+    const cancelledShared = (await initialFlow.getShared())!;
+    cancelledShared.continueRounds = false;
+    await initialFlow.setShared(cancelledShared);
+
+    const resumedFlow = makeFlowWithKv(kv);
+    await resumedFlow.restartCurrentRound(cancelledShared);
+    await expect(resumedFlow.run(cancelledShared)).resolves.toBe(
+      RUN_OUTCOME.COMPLETED,
+    );
+
+    expect((await resumedFlow.getShared())?.roundsRun).toEqual([0, 0]);
   });
 });
 


### PR DESCRIPTION
Closes #10098.

## What changed

- Treat a persisted reflection state with `continueRounds = false` and no `lastError` as a cancelled, unfinished round when a new resume begins.
- Let `RoundPersistedFlow`, which already owns the replay cursor, reset that current round to its first node.
- Keep completed earlier rounds and the current round index unchanged.
- Preserve failed terminal states instead of reopening them.
- Document the user-visible CLI fix in the changelog.

## Root cause

Cancellation made the response node set `continueRounds = false`, then persisted a terminal cursor. A later resume hydrated both values unchanged. The round loop therefore executed no node and derived another cancelled outcome immediately.

The reflection-flow hydration boundary is the single place that distinguishes cancellation from failure: failures carry `lastError`; cancellations do not. Cursor reset remains with the round-flow owner rather than introducing another resume representation.

## User impact

A cancelled `correct` or `polish` workflow can resume its unfinished round instead of repeatedly printing `interrupted` and exiting with status 130.

## Validation

- Reproduced before the change in an 80×24 PTY with execution `88d3eda7f533`: three resume attempts returned cancelled immediately.
- Rebuilt the CLI and resumed that exact execution after the change: it entered round 1 and reached the configured model provider. The provider then returned HTTP 402 because the local account balance was exhausted, demonstrating that recovery advanced beyond the former terminal cursor.
- Focused recovery tests: 18 passed.
- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm run typecheck`
- `npm test`: 10,023 passed, 5 skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reflection-flow resume hydration and persisted cursor reset, which affects CLI workflow recovery after cancellation; behavior is scoped by cancellation vs failure signals and covered by new tests.
> 
> **Overview**
> Fixes **#10098**: resuming a cancelled `correct`/`polish` workflow no longer hits an empty round loop and prints **interrupted** again.
> 
> On resume, persisted state with **`continueRounds = false` and no `lastError`** is treated as a **user cancellation**, not a terminal failure. **`runReflectionFlow`** calls **`RoundPersistedFlow.restartCurrentRound`**, which sets **`continueRounds`** back to true and **resets the persisted node cursor** so the **current round** replays from its first node. **Earlier completed rounds** and **`roundOutputs`** stay put; states with **`lastError`** still resume without reopening the round.
> 
> **`PrepareContextNode`** no longer clears **`compileFailureContext`** when preparing context, so a resumed mid-round retry still gets compile-repair prompt text.
> 
> Changelog documents the shared user-visible fix; recovery and compile-repair tests cover cancellation vs failure and repair context retention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a63d22df4543716eb33ca16abeb0362c446f621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->