### PR TITLE
fix: serialize bundled agent refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Concurrent app starts refresh bundled agents safely** — simultaneous TeXRA
+  processes sharing one data directory no longer fail while updating built-in
+  agent definitions.
 - **Claude Code forks leave the original conversation unchanged** — an
   incomplete fork now stops instead of continuing the original conversation.
 

--- a/src/agent/index/AgentDirectorySync.ts
+++ b/src/agent/index/AgentDirectorySync.ts
@@ -1,10 +1,10 @@
 import * as path from 'node:path';
 
+import pRetry from 'p-retry';
 import { z } from 'zod';
 
 import { isFileNotFoundError } from '@common/errors/errorPredicates';
 import { platform } from '@platform/platform';
-import { KeyedMutex } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 
@@ -15,6 +15,11 @@ import {
 
 const SYNC_MARKER_FILE = '.bundled-agent-sync.json';
 const RECENT_EXTERNAL_SYNC_MS = 5 * 60 * 1000;
+const LOCK_RETRY_TIMEOUT_MS = 30_000;
+
+function isLockContentionError(error: unknown): boolean {
+  return (error as { code?: string })?.code === 'ELOCKED';
+}
 
 const AgentDirectorySyncMarkerSchema = z.object({
   completedAt: z.number().nonnegative(),
@@ -89,15 +94,42 @@ export class GlobalStorageAgentDirectoryStorage implements AgentDirectoryStorage
 }
 
 export class BundledAgentDirectorySync {
-  private static readonly reconcileByStorageRoot = new KeyedMutex<string>();
-
   constructor(private readonly options: BundledAgentDirectorySyncOptions) {}
 
-  reconcile(currentVersion: string | undefined): Promise<boolean> {
-    return BundledAgentDirectorySync.reconcileByStorageRoot.runExclusive(
-      this.options.storage.fullPath(''),
-      () => this.reconcileUnlocked(currentVersion),
-    );
+  async reconcile(currentVersion: string | undefined): Promise<boolean> {
+    let operationStarted = false;
+
+    try {
+      return await pRetry(
+        () =>
+          platform().fileLocks.runExclusive(
+            this.options.storage.fullPath(SYNC_MARKER_FILE),
+            () => {
+              operationStarted = true;
+              return this.reconcileUnlocked(currentVersion);
+            },
+          ),
+        {
+          retries: 20,
+          minTimeout: 100,
+          maxTimeout: 1_000,
+          randomize: true,
+          maxRetryTime: LOCK_RETRY_TIMEOUT_MS,
+          shouldRetry: ({ error }) =>
+            !operationStarted && isLockContentionError(error),
+        },
+      );
+    } catch (error) {
+      // A live or stale owner must not make startup fail. If ownership remains
+      // unavailable, leave the shared cache untouched and try again next run.
+      if (!operationStarted && isLockContentionError(error)) {
+        this.options.logger.warn(
+          'Skipping bundled agent refresh because another process still owns the sync lock',
+        );
+        return false;
+      }
+      throw error;
+    }
   }
 
   private async reconcileUnlocked(

--- a/src/test-kernel/agent/AgentDirectorySync.vitest.ts
+++ b/src/test-kernel/agent/AgentDirectorySync.vitest.ts
@@ -12,7 +12,7 @@ import { join } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 
 // Third-party imports
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent
 import {
@@ -21,14 +21,7 @@ import {
   type AgentDirectoryStorage,
 } from '@agent/index/AgentDirectorySync';
 import type { BundledAgentDirectoryName } from '@agent/index/BundledAgentDirectories';
-
-function pendingReconcileCount(): number {
-  return (
-    BundledAgentDirectorySync as unknown as {
-      reconcileByStorageRoot: { mutexes: Map<string, unknown> };
-    }
-  ).reconcileByStorageRoot.mutexes.size;
-}
+import { platform } from '@platform/platform';
 
 class FsAgentDirectoryStorage implements AgentDirectoryStorage {
   constructor(private readonly root: string) {}
@@ -93,6 +86,8 @@ describe('BundledAgentDirectorySync', () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
     await rm(tempDir, { recursive: true, force: true });
   });
 
@@ -131,20 +126,30 @@ describe('BundledAgentDirectorySync', () => {
       'agents',
       'tool_use_agents',
     ]);
-    expect(pendingReconcileCount()).toBe(0);
   });
 
-  it('skips a recent same-version sync from another process', async () => {
+  it('retries contention and rechecks the marker after acquiring the shared lock', async () => {
     const copied: BundledAgentDirectoryName[] = [];
     let storedVersion: string | undefined;
-    await writeFile(
-      join(tempDir, '.bundled-agent-sync.json'),
-      `${JSON.stringify({
-        completedAt: Date.now(),
-        ownerPid: process.pid + 1,
-        version: '1.0.0',
-      })}\n`,
-    );
+    const runExclusive = vi
+      .spyOn(platform().fileLocks, 'runExclusive')
+      .mockImplementationOnce(async () => {
+        throw Object.assign(new Error('Lock file is already being held'), {
+          code: 'ELOCKED',
+        });
+      })
+      .mockImplementationOnce(async (lockPath, operation) => {
+        expect(lockPath).toBe(join(tempDir, '.bundled-agent-sync.json'));
+        await writeFile(
+          lockPath,
+          `${JSON.stringify({
+            completedAt: Date.now(),
+            ownerPid: process.pid + 1,
+            version: '1.0.0',
+          })}\n`,
+        );
+        return operation();
+      });
 
     const sync = createSync(
       new FsAgentDirectoryStorage(tempDir),
@@ -164,19 +169,72 @@ describe('BundledAgentDirectorySync', () => {
 
     expect(copied).toEqual([]);
     expect(storedVersion).toBe('1.0.0');
-    expect(pendingReconcileCount()).toBe(0);
+    expect(runExclusive).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips refresh when cross-process ownership remains unavailable', async () => {
+    vi.useFakeTimers();
+    const warnings: string[] = [];
+    const runExclusive = vi
+      .spyOn(platform().fileLocks, 'runExclusive')
+      .mockRejectedValue(
+        Object.assign(new Error('Lock file is already being held'), {
+          code: 'ELOCKED',
+        }),
+      );
+    const sync = createSync(
+      new FsAgentDirectoryStorage(tempDir),
+      { copyDirectory: async () => undefined },
+      { onWarn: (message) => warnings.push(message) },
+    );
+
+    const result = sync.reconcile('1.0.0');
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toBe(false);
+    expect(runExclusive).toHaveBeenCalledTimes(21);
+    expect(warnings).toEqual([
+      'Skipping bundled agent refresh because another process still owns the sync lock',
+    ]);
+  });
+
+  it('does not mistake an in-operation ELOCKED failure for lock contention', async () => {
+    const copied: BundledAgentDirectoryName[] = [];
+    const sync = createSync(
+      new FsAgentDirectoryStorage(tempDir),
+      {
+        async copyDirectory(directoryName) {
+          copied.push(directoryName);
+        },
+      },
+      {
+        onVersion: () => {
+          throw Object.assign(new Error('version store lock failed'), {
+            code: 'ELOCKED',
+          });
+        },
+      },
+    );
+
+    await expect(sync.reconcile('1.0.0')).rejects.toThrow(
+      'version store lock failed',
+    );
+    expect(copied).toEqual(['agents', 'tool_use_agents']);
   });
 
   it('clears the reconcile lock after copy failure', async () => {
+    let shouldFail = true;
     const sync = createSync(new FsAgentDirectoryStorage(tempDir), {
       async copyDirectory() {
-        throw new Error('copy failed');
+        if (shouldFail) {
+          shouldFail = false;
+          throw new Error('copy failed');
+        }
       },
     });
 
     await expect(sync.reconcile('1.0.0')).rejects.toThrow('copy failed');
-
-    expect(pendingReconcileCount()).toBe(0);
+    await expect(sync.reconcile('1.0.0')).resolves.toBe(true);
   });
 
   it('does not fail reconciliation when the marker write fails', async () => {
@@ -214,6 +272,5 @@ describe('BundledAgentDirectorySync', () => {
     expect(warnings).toEqual([
       'Failed to write bundled agent sync marker: marker unwritable',
     ]);
-    expect(pendingReconcileCount()).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #10100.

## Summary

- serialize bundled-agent reconciliation with the platform file-lock authority
- use the sync marker path as the common cross-process lock identity
- wait up to 30 seconds on lock contention without changing other lock callers
- re-read the completed marker only after acquiring ownership
- replace private-mutex assertions with behavioral lock, waiter, and failure-release coverage

## Ownership and simplification

`BundledAgentDirectorySync` previously owned a static `KeyedMutex`, although its destination is shared by CLI, desktop, and extension processes. That mutex could order calls only within one Node process. The platform already owns local shared-storage exclusion through `FileLockProvider`, backed by `proper-lockfile` and an in-process keyed mutex.

This change removes the narrower parallel mechanism. One existing authority now guards the complete marker-read, directory-copy, version-update, and marker-write transaction. A waiting process therefore observes the first process's completed marker before deciding whether another copy is needed.

The default lock provider has a deliberately short acquisition budget for ordinary state writes. Bundled-agent reconciliation alone retries `ELOCKED` for at most 30 seconds, so slower resource copies do not change the latency policy of execution leases or JSON stores. Non-contention and in-lock failures are not retried.

## Reproduced failure

On main `27188eac0c4ce9a53ea37b0109156226eee8dc15`, two simultaneous fresh CLI listings entered bundled-agent overwrite copy together. One succeeded; the other exited with:

```text
ENOENT: no such file or directory, unlink .../tool_use_agents/numerics.yaml
```

The sequential retry and five later concurrent pairs succeeded after the recent marker existed, isolating the failure to first-refresh ownership.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 856 files passed, 1 skipped; 10,021 tests passed, 5 skipped
- focused agent-sync and file-lock suites — 6 tests passed

No disposable terminal artifacts are committed.
