### PR TITLE
fix(cli): show model labels in session identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
 - **Workflow footers show only usable controls** — focused workflows and
   background processes no longer advertise slash commands while their chat
   input is hidden.
+- **Session views show recognizable model names** — headers, `/status`, and
+  background-task rows use catalog labels instead of internal model IDs.
 
 ### Shared (all surfaces)
 

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -11,6 +11,7 @@ import { Box, Static, Text } from 'ink';
 
 import { shortCliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
 import { COLOR_HINT } from '@cli/tui/ui/colors';
+import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import type { StreamTabId } from '@shared/schemas';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { safeHomedir } from '@utils/system/platformPaths';
@@ -82,7 +83,7 @@ export function sessionHeaderIdentityLine(
     context.streamId && parentStream?.get(context.streamId);
   if (context.streamId && parentStreamId && parentStream && context.streams) {
     const slice = context.streams.get(context.streamId);
-    const model = slice?.model || meta.model || '—';
+    const model = getRuntimeModelLabel(slice?.model || meta.model || '—');
     const view = streamViewForId({
       activeStreamId: context.streamId,
       childStreamEntries: context.childStreamEntries ?? new Map(),
@@ -96,7 +97,7 @@ export function sessionHeaderIdentityLine(
         : 'subagent';
     return `${streamKind}: ${view.label} · parent: ${view.parentLabel} · model: ${model}`;
   }
-  const model = meta.model || '—';
+  const model = getRuntimeModelLabel(meta.model || '—');
   const agent = meta.agent || 'chat';
   if (meta.teamName) {
     return `team: ${meta.teamName} · root: ${agent} · model: ${model}`;

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -18,6 +18,7 @@ import {
   TOKENS_GENERATED,
 } from '@cli/tui/ui/glyphs';
 import { useLiveNowMsSince } from '@cli/tui/useLiveNowMs';
+import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import {
   WORKFLOW_TASK_STATUS_LABEL,
   isTerminalWorkflowCallProgress,
@@ -137,10 +138,11 @@ function SessionRow({
   // can each resolve a different model); the list-root row is the conversation
   // itself, whose model already rides the status bar. A background bash stream
   // inherits its parent's configuration, but the shell does not use a model.
-  const modelLabel =
+  const model =
     !isListRoot && session.slice?.identity?.kind !== 'process'
       ? session.slice?.model
       : undefined;
+  const modelLabel = model ? getRuntimeModelLabel(model) : undefined;
   // The right-aligned `elapsed · ↓tokens` column is pushed to the terminal edge
   // so the figures line up across rows. Non-shrinking: the summary segment
   // yields first; rows drop the column entirely on narrow terminals (see

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -2,6 +2,7 @@ import {
   formatCliModelAccessRoute,
   type CliModelAccessRoute,
 } from '@cli/runtime/modelAccessRoute';
+import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
 import type { StreamSubstate } from '@shared/schemas';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
@@ -89,7 +90,7 @@ export function formatCliSessionStatus(input: CliSessionStatusInput): string {
   return [
     ...(input.teamName ? [`team: ${input.teamName}`] : []),
     `agent: ${input.agent}`,
-    `model: ${input.model}`,
+    `model: ${getRuntimeModelLabel(input.model)}`,
     `model access: ${formatCliModelAccessRoute(input.modelAccess)}`,
     `approval: ${input.approval}`,
     ...(bypassLabels.length > 0

--- a/src/controllers/session/streamTabInfo.ts
+++ b/src/controllers/session/streamTabInfo.ts
@@ -1,7 +1,7 @@
 import { isRemoteAgent } from '@agent/index/agentRegistry';
 import { getStreamTabDisplayName } from '@agent/runtime/streamTab';
 import type { SessionStreamMetadata } from '@controllers/session/SessionState';
-import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
+import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import type { StreamTabInfo, WorktreeInfo } from '@shared/schemas';
 import { runIdentityName } from '@shared/schemas';
 import { getCleanAgentName } from '@shared/schemas/agent';
@@ -79,9 +79,7 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
     userFollowUpSupport: metadata.userFollowUpSupport,
     agentCategory: metadata.agentCategory,
     model,
-    modelLabel: model
-      ? (getRuntimeModelConfig(model)?.label ?? model)
-      : undefined,
+    modelLabel: model ? getRuntimeModelLabel(model) : undefined,
     command,
     isRemote,
     creationTimestamp: metadata.creationTimestamp,

--- a/src/model/runtimeModelRegistry.ts
+++ b/src/model/runtimeModelRegistry.ts
@@ -214,6 +214,11 @@ export function getRuntimeModelConfig(model: string): ModelConfig | undefined {
   return MODEL_CONFIGS[normalizePersistedCopilotModelId(model)];
 }
 
+/** Resolve a persisted model id to its user-facing registry label. */
+export function getRuntimeModelLabel(model: string): string {
+  return getRuntimeModelConfig(model)?.label ?? model;
+}
+
 /** All static model entries owned by TeXRA and llm-zoo. */
 export function staticModelConfigEntries(): readonly (readonly [
   string,

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -932,11 +932,12 @@ describe('CLI conversation transcript', () => {
       sessionHeaderIdentityLine({
         ...SESSION_META,
         agent: 'orchestrator',
+        model: 'gpt56-',
         teamName: 'Physicist',
       }),
-    ).toBe('team: Physicist · root: orchestrator · model: deepseekT');
+    ).toBe('team: Physicist · root: orchestrator · model: GPT-5.6 Terra');
     expect(sessionHeaderIdentityLine(SESSION_META)).toBe(
-      'agent: research · model: deepseekT',
+      'agent: research · model: DeepSeek V4 Flash (Thinking)',
     );
   });
 
@@ -1005,7 +1006,7 @@ describe('CLI conversation transcript', () => {
         streamId: CHILD,
         streams,
       }),
-    ).toBe('subagent: search · parent: main · model: kimi26T');
+    ).toBe('subagent: search · parent: main · model: Kimi K2.6 (Thinking)');
 
     expect(
       appendStaticTranscriptItems({
@@ -1018,7 +1019,8 @@ describe('CLI conversation transcript', () => {
       })[0],
     ).toMatchObject({
       kind: 'header',
-      identityLine: 'subagent: search · parent: main · model: kimi26T',
+      identityLine:
+        'subagent: search · parent: main · model: Kimi K2.6 (Thinking)',
     });
   });
 

--- a/src/test-kernel/cli/SessionStatus.vitest.ts
+++ b/src/test-kernel/cli/SessionStatus.vitest.ts
@@ -194,10 +194,11 @@ describe('CLI session status formatter', () => {
 
   it('reports ChatGPT as the selected model access', () => {
     const status = sessionStatus({
-      model: 'gpt55',
+      model: 'gpt56-',
       modelAccess: 'chatgpt',
     });
 
+    expect(status).toContain('model: GPT-5.6 Terra');
     expect(status).toContain(
       ['model access: ChatGPT subscription', 'approval: ask'].join('\n'),
     );

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -716,7 +716,7 @@ describe('CLI child list display model', () => {
     });
     expect(output.match(/bash running/g)).toHaveLength(2);
     expect(output).not.toContain('gemini35f');
-    expect(output).toContain('bash running · gpt56');
+    expect(output).toContain('bash running · GPT-5.6 Sol');
     expect(output).toContain('5 tool calls');
     expect(output).toContain('↓40k');
   });

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -972,7 +972,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     });
     expect(staticItems.at(0)).toMatchObject({
       identityLine:
-        'workflow script: draft-sections · parent: main · model: deepseekT',
+        'workflow script: draft-sections · parent: main · model: DeepSeek V4 Flash (Thinking)',
       kind: 'header',
     });
 


### PR DESCRIPTION
Closes #10102.

## Summary

- render registry-owned model labels in the root session header and `/status`
- use the same labels for focused child/workflow headers and background-task rows
- retain raw model ids as the fallback for unknown or dynamically supplied models
- centralize id-to-label projection in the runtime model registry and reuse it in the existing shared stream view

## Ownership and simplification

Canonical model ids remain authoritative for execution requests, routing, and persisted session state. The runtime model registry already owns the corresponding user-facing labels, so this change projects the label only at presentation boundaries. It does not add a second identity representation or migrate stored data.

The new `getRuntimeModelLabel` helper also replaces the matching inline registry lookup in `buildStreamTabInfo`, leaving one fallback rule for all hosts.

## Reproduction and verification

On `origin/main`, selecting **GPT-5.6 Terra** in the orchestration launcher produced `model: gpt56-` in both the persistent header and `/status`.

After this change, I rebuilt the CLI, resumed the same session in an 80×24 `xterm-256color` PTY, and observed:

```text
team: Physicist · root: orchestrator · model: GPT-5.6 Terra
```

and:

```text
model: GPT-5.6 Terra
```

No model call or state migration was required.

## Validation

- `corepack pnpm run format`
- `corepack pnpm run typecheck`
- `corepack pnpm run compile:fast`
- `corepack pnpm run lint`
- `corepack pnpm test` — 856 files passed, 1 skipped; 10,021 tests passed, 5 skipped
- real built-CLI PTY verification at 80×24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only mapping at display boundaries; persisted model ids and routing are unchanged.
> 
> **Overview**
> **Session-facing UI now shows catalog model names** instead of internal ids like `gpt56-` in the CLI header, `/status`, focused child/workflow headers, and background-task rows. Unknown or dynamic ids still display as-is.
> 
> A new **`getRuntimeModelLabel`** helper in the runtime model registry centralizes id→label lookup (with registry fallback to the raw id) and replaces the duplicate inline label logic in **`buildStreamTabInfo`** for shared stream tabs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 213e70ee3dbeb706e91c12eea77a7a628ca6676b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->