### PR TITLE
fix: require progress attribute boundaries

### DIFF
--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -95,7 +95,7 @@ export function stripOrchestratorFollowup(text: unknown): string {
 }
 
 function attr(xml: string, name: string): string | undefined {
-  return new RegExp(`\\b${escapeRegExp(name)}="([^"]*)"`).exec(xml)?.[1];
+  return new RegExp(`(?:^|\\s)${escapeRegExp(name)}="([^"]*)"`).exec(xml)?.[1];
 }
 
 function innerTag(xml: string, tag: string): string | undefined {

--- a/src/test-kernel/cli/SubagentFollowup.vitest.ts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.ts
@@ -134,6 +134,7 @@ describe('summarizeSubagentFollowup', () => {
     '<subagent-progress agent="a" type="overview" />',
     '<subagent-progress agent="a" type="plan" status="updated" />',
     '<subagent-progress agent="a" type="todos" completed="1" active="0" />',
+    '<subagent-progress agent="a" tool-type="started" />',
   ])('preserves a non-canonical progress block: %s', (xml) => {
     expect(summarizeSubagentFollowup(xml)).toBe(xml);
   });


### PR DESCRIPTION
## Summary

- require whitespace or string start before parsed delivery-envelope attribute names
- preserve malformed progress blocks whose suffix attributes only resemble canonical names
- cover the `tool-type` / `type` collision in the existing malformed-block table

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/SubagentFollowup.vitest.ts`
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- targeted ESLint and Prettier checks
- pre-commit hooks
- pre-push checks

Closes #10091

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small parsing change in follow-up summarization with explicit regression coverage; no auth, data, or API surface impact.
> 
> **Overview**
> Tightens how **`subagentFollowup`** reads XML attributes when collapsing subagent progress blocks to transcript lines.
> 
> The **`attr()`** helper no longer uses a word boundary before attribute names; it only matches names at the start of the attribute string or after whitespace. That stops suffix-style names like **`tool-type`** from being treated as a canonical **`type`** attribute (e.g. falsely summarizing **`tool-type="started"`** as “started”).
> 
> A **`SubagentFollowup`** test asserts malformed blocks with **`tool-type`** stay passthrough like other non-canonical progress XML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 629bcd27b19417b44cc863edf8f8ff1c592274c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->