### PR TITLE
fix(cli): hide inactive workflow shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this project will be documented in this file.
 - **Interrupted multi-agent chats can be resumed immediately** — leaving a
   cancelled team session no longer leaves its printed resume command
   temporarily unavailable.
+- **Workflow footers show only usable controls** — focused workflows and
+  background processes no longer advertise slash commands while their chat
+  input is hidden.
 
 ### Shared (all surfaces)
 

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -211,6 +211,10 @@ const SCENARIOS = [
       'must not reach workflow',
       'Harness received: must not reach workflow',
       STOPPED_SUBAGENT_INPUT_MESSAGE_START,
+      '/status details',
+      '/model models',
+      '/api api',
+      'Ctrl-J newline',
     ],
   },
   {
@@ -229,6 +233,10 @@ const SCENARIOS = [
       'must not reach bash',
       'Harness received: must not reach bash',
       STOPPED_SUBAGENT_INPUT_MESSAGE_START,
+      '/status details',
+      '/model models',
+      '/api api',
+      'Ctrl-J newline',
     ],
   },
   {

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -754,6 +754,7 @@ export function App(props: AppProps): React.JSX.Element {
             />
             <StatusBar
               agentSelectionAvailable={rootRunStartAvailable}
+              chatInputAvailable={!childInputHidden}
               commandName={props.commandName}
               foregroundEscapeAction={foregroundEscapeAction({
                 activeFormEscapeAction: formBusy

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -51,6 +51,8 @@ const RELAY_QUOTA_REFRESH_MS = 10_000;
 const SUBSCRIPTION_QUOTA_REFRESH_MS = 30_000;
 interface StatusBarProps {
   readonly agentSelectionAvailable?: boolean;
+  /** True when the focused stream has a composer for slash commands and text. */
+  readonly chatInputAvailable: boolean;
   readonly childListFocused?: boolean;
   readonly childListSelectionKillable?: boolean;
   readonly childListSelectionWorkflowControllable?: boolean;
@@ -296,6 +298,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     },
     shortcuts: {
       agentSelectionAvailable: props.agentSelectionAvailable,
+      chatInputAvailable: props.chatInputAvailable,
       childNavigationAvailable: props.childNavigationAvailable,
       parentNavigationAvailable:
         activeStreamId !== undefined && parentStream.has(activeStreamId),

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -183,6 +183,8 @@ interface StatusBarChildListInput {
 
 interface StatusBarShortcutsInput {
   readonly agentSelectionAvailable?: boolean;
+  /** True when slash commands and text entry are actionable in this view. */
+  readonly chatInputAvailable: boolean;
   /** True when bare Escape can focus the active stream's immediate parent. */
   readonly parentNavigationAvailable?: boolean;
   /** True when the persistent child list has a session row. */
@@ -653,6 +655,7 @@ function firstRowThatFits(
 function statusBarBindingsText(
   {
     agentSelectionAvailable = false,
+    chatInputAvailable,
     childNavigationAvailable = false,
     parentNavigationAvailable = false,
     streamFocusAvailable = false,
@@ -678,19 +681,28 @@ function statusBarBindingsText(
   const fullOutput = transcriptAvailable
     ? keyHintText({ key: 'Ctrl-T', action: 'transcript' })
     : undefined;
-  const agent = agentSelectionAvailable
-    ? keyHintText({ key: '/agent', action: 'agents' })
+  const agent =
+    chatInputAvailable && agentSelectionAvailable
+      ? keyHintText({ key: '/agent', action: 'agents' })
+      : undefined;
+  const status = chatInputAvailable
+    ? keyHintText({ key: '/status', action: 'details' })
     : undefined;
-  const status = keyHintText({ key: '/status', action: 'details' });
-  const model = keyHintText({ key: '/model', action: 'models' });
-  const api = keyHintText({ key: '/api', action: 'api' });
-  const newline = keyHintText({
-    key: shiftEnterNewline ? 'Shift-Enter' : 'Ctrl-J',
-    action: 'newline',
-  });
+  const model = chatInputAvailable
+    ? keyHintText({ key: '/model', action: 'models' })
+    : undefined;
+  const api = chatInputAvailable
+    ? keyHintText({ key: '/api', action: 'api' })
+    : undefined;
+  const newline = chatInputAvailable
+    ? keyHintText({
+        key: shiftEnterNewline ? 'Shift-Enter' : 'Ctrl-J',
+        action: 'newline',
+      })
+    : undefined;
   const ctrlC = keyHintText({ key: 'Ctrl-C', action: ctrlCAction });
   const setupControlsOnly =
-    agentSelectionAvailable && !childNavigationAvailable;
+    chatInputAvailable && agentSelectionAvailable && !childNavigationAvailable;
   const candidates = [
     // Child navigation only applies when the current tree has a visible row;
     // unrelated or not-yet-attached streams do not make Tab actionable.

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -60,6 +60,7 @@ function statusInput(
     foreground: { ...foreground },
     childList: { ...childList },
     shortcuts: {
+      chatInputAvailable: true,
       childNavigationAvailable: false,
       streamFocusAvailable: false,
       modifierLabel: 'Alt',
@@ -544,6 +545,26 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('Ctrl-C stop');
     expect(display.bindings).not.toContain('Option-p tasks');
     expect(display.bindings).not.toContain('Option-s subagents');
+  });
+
+  it('does not advertise composer controls when chat input is unavailable', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        status: STREAM_PHASE.RUNNING,
+        ctrlCAction: 'stop root',
+        shortcuts: {
+          agentSelectionAvailable: true,
+          chatInputAvailable: false,
+          childNavigationAvailable: true,
+          parentNavigationAvailable: true,
+          transcriptAvailable: true,
+        },
+      }),
+    );
+
+    expect(display.bindings).toBe(
+      'Esc back · Tab sessions · Ctrl-T transcript · Ctrl-C stop root',
+    );
   });
 
   it('keeps child navigation grouped with stream focus', () => {


### PR DESCRIPTION
Closes #10107.

## Summary

- pass the focused stream's existing chat-input availability into the status bar
- hide slash-command, agent-picker, and newline hints while workflow or process views intentionally hide the composer
- retain parent/session navigation, transcript inspection, and interruption controls
- pin the running-workflow footer in the deterministic PTY validator

## Ownership and simplification

`App` already owns the `childInputHidden` decision through `focusedChildFollowUpRoute`; it uses that decision to mount or hide the composer and to discard input for non-conversational streams. The status bar previously reconstructed only navigation availability and therefore had no way to distinguish an actionable slash command from an inert one.

This change passes that existing decision across the rendering boundary as one required boolean. The status bar does not infer availability from agent category, workflow identity, or process names, so there is no parallel list of stream kinds to maintain.

## Validation

- deterministic PTY: `workflow-running-composer-hidden`
- focused status-bar suite: 95 tests passed
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- `npm test` — 856 files passed, 1 skipped; 10,022 tests passed, 5 skipped
- pre-commit and pre-push hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only status bar hint gating wired to an existing `childInputHidden` decision; no auth, data, or execution path changes.
> 
> **Overview**
> **Workflow and process footers no longer advertise unusable composer shortcuts.** When the focused stream intentionally hides the chat input (`childInputHidden`), the status bar now receives `chatInputAvailable={false}` from `App` instead of always showing `/status`, `/model`, `/api`, `/agent`, and newline hints.
> 
> **Binding logic is gated on that flag.** `statusBarBindingsText` only includes those slash and newline rows when `chatInputAvailable` is true; navigation (Tab sessions, Esc back, Ctrl-T transcript, Ctrl-C) stays visible. The “setup controls only” shortcut row also requires chat input.
> 
> **Regression coverage.** A unit test asserts bindings when `chatInputAvailable: false`, and the deterministic PTY harness expects those hints absent for workflow-running and process-child composer-hidden scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e1384467e4947961f277ed4cee55fe49c1d53a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->