### PR TITLE
fix(cli): keep narrow child kill hint visible

### DIFF
--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -801,6 +801,14 @@ function childListBindingsText(
         escBinding,
         ctrlCBinding,
       ]),
+      selectionKillable &&
+        statusBarBindingRow([
+          selectBinding,
+          killBinding,
+          tabBinding,
+          escBinding,
+          ctrlCBinding,
+        ]),
       statusBarBindingRow([
         selectBinding,
         enterBinding,

--- a/src/test-kernel/cli/StatusBar.vitest.ts
+++ b/src/test-kernel/cli/StatusBar.vitest.ts
@@ -389,6 +389,29 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).not.toContain('Tab sessions');
   });
 
+  it('prioritizes only an available child kill action at 70 columns', () => {
+    const input = statusInput({
+      width: 70,
+      ctrlCAction: 'stop',
+      foreground: { shortcutsActive: false },
+      childList: {
+        focused: true,
+        selectionKillable: true,
+      },
+    });
+    const display = buildStatusBarDisplay(input);
+
+    expect(display.bindings).toBe(
+      '↑/↓ select · k kill · Tab input · Esc input · Ctrl-C stop',
+    );
+    expect(
+      buildStatusBarDisplay({
+        ...input,
+        childList: { focused: true, selectionKillable: false },
+      }).bindings,
+    ).not.toContain('k kill');
+  });
+
   it('shows foreground actions while a list-owned surface is open', () => {
     const display = buildStatusBarDisplay(
       statusInput({


### PR DESCRIPTION
## Summary

- add a killable-only compact child-list footer candidate
- preserve selection, input return, and Ctrl-C controls while dropping the less urgent focus hint
- pin the 70-column footer and confirm non-killable rows omit `k kill`

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/StatusBar.vitest.ts`
- `npm run typecheck:cli`
- `npm run typecheck:test-kernel`
- targeted ESLint and Prettier checks
- pre-commit hooks
- pre-push checks

Closes #10096

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Status bar key-hint display only; behavior is covered by StatusBar vitest with no auth, data, or runtime logic changes.
> 
> **Overview**
> When the **child list** has focus and the selected row can be killed, the status bar bindings cascade now includes a **kill-only compact row** (`↑/↓ select`, `k kill`, Tab/Esc to input, Ctrl-C) that omits **Enter focus** so it fits on **~70-column** terminals.
> 
> Previously, width fitting could drop `k kill` before dropping the focus hint. Non-killable selections still omit `k kill`; a vitest case pins the 70-column footer string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc0d3cbe093017cd8121d9ed5e904cea681c0e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->