### PR TITLE
fix(cli): attribute workflow approvals to tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to this project will be documented in this file.
 - **Interrupted multi-agent chats can be resumed immediately** — leaving a
   cancelled team session no longer leaves its printed resume command
   temporarily unavailable.
+- **Workflow approvals identify the blocked task** — the workflow dashboard
+  marks the task waiting for command or edit approval, so parallel tasks no
+  longer have to be inspected one by one.
 
 ### Shared (all surfaces)
 

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -162,8 +162,11 @@ import type { CliModelAccess } from '../src/runtime/modelAccess';
 import type { InputHistory } from '../src/chat/tui/history/inputHistory';
 
 const STREAM_ID = 'harness-stream-1';
+const HARNESS_WORKFLOW_AGENT_STREAM_ID =
+  'correct@harness-model#harness-workflow-agent-a' as StreamTabId;
 const SHOW_WORKFLOW_TIMELINE = process.env.HARNESS_WORKFLOW_TIMELINE === '1';
 const SHOW_WORKFLOW_RUNNING = process.env.HARNESS_WORKFLOW_RUNNING === '1';
+const SHOW_WORKFLOW_DASHBOARD = process.env.HARNESS_WORKFLOW_DASHBOARD === '1';
 const SHOW_PROCESS_CHILD = process.env.HARNESS_PROCESS_CHILD === '1';
 const RESET_WORKFLOW_SCRIPT_DISABLED =
   process.env.HARNESS_WORKFLOW_SCRIPT_DISABLED === '1';
@@ -229,6 +232,8 @@ const BASH_APPROVAL_COMMAND =
   process.env.HARNESS_BASH_APPROVAL_COMMAND ?? 'npm run compile:safe';
 const SHOW_BASH_APPROVAL_AFTER_CHILD_FOCUS =
   process.env.HARNESS_BASH_APPROVAL_AFTER_CHILD_FOCUS === '1';
+const BASH_APPROVAL_WORKFLOW_AGENT =
+  process.env.HARNESS_BASH_APPROVAL_WORKFLOW_AGENT === '1';
 const EXTERNAL_INQUIRY_QUESTION =
   process.env.HARNESS_EXTERNAL_INQUIRY_QUESTION ??
   [
@@ -985,7 +990,9 @@ function makeBashApprovalPayload(index = 1) {
     command: BASH_APPROVAL_COMMAND,
     cwd: HARNESS_CWD,
     allowBypass: true,
-    streamId: STREAM_ID,
+    streamId: BASH_APPROVAL_WORKFLOW_AGENT
+      ? HARNESS_WORKFLOW_AGENT_STREAM_ID
+      : STREAM_ID,
   };
 }
 
@@ -1362,8 +1369,7 @@ function seedWorkflowTimeline(): void {
 function seedRunningWorkflow(): void {
   const executionId = 'aaaa0002f10e' as ExecutionId;
   const childStreamId = 'workflow-script#aaaa0002f10e' as StreamTabId;
-  const firstAgentStreamId =
-    'correct@harness-model#harness-workflow-agent-a' as StreamTabId;
+  const firstAgentStreamId = HARNESS_WORKFLOW_AGENT_STREAM_ID;
   const secondAgentStreamId =
     'correct@harness-model#harness-workflow-agent-b' as StreamTabId;
 
@@ -1381,6 +1387,15 @@ function seedRunningWorkflow(): void {
   ]);
   emitChildEventOrderEdge(childStreamId, STREAM_ID);
   transitionChildEventOrderRunning(childStreamId);
+  if (SHOW_WORKFLOW_DASHBOARD) {
+    patchStream(childStreamId, (slice) => ({
+      ...slice,
+      identity: {
+        kind: 'multiAgentWorkflow',
+        workflowName: 'live-workflow-validation',
+      },
+    }));
+  }
 
   const runTrace = createRunTrace(childStreamId, defaultSession().transcripts);
   const runStage = runTrace.trace.openStage(
@@ -1405,6 +1420,7 @@ function seedRunningWorkflow(): void {
       label: 'Proofread paper A',
       phase: 'Proofread',
       status: 'running',
+      childStreamId: firstAgentStreamId,
     },
     stageId: phaseStage.id,
   });
@@ -1416,6 +1432,7 @@ function seedRunningWorkflow(): void {
       label: 'Proofread paper B',
       phase: 'Proofread',
       status: 'running',
+      childStreamId: secondAgentStreamId,
     },
     stageId: phaseStage.id,
   });

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -214,6 +214,28 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'workflow-grandchild-approval-attribution',
+    frame: 'viewport',
+    rows: 30,
+    cols: 100,
+    env: {
+      HARNESS_ENTRIES: '0',
+      HARNESS_WORKFLOW_RUNNING: '1',
+      HARNESS_WORKFLOW_DASHBOARD: '1',
+      HARNESS_BASH_APPROVAL: '1',
+      HARNESS_BASH_APPROVAL_AFTER_CHILD_FOCUS: '1',
+      HARNESS_BASH_APPROVAL_WORKFLOW_AGENT: '1',
+    },
+    bootExpect: '1 approval',
+    keys: ['\t'],
+    expect: [
+      'Proofread paper A · Running · bash',
+      'Proofread paper B · Running',
+      '1 approval',
+    ],
+    unexpect: ['Proofread paper B · Running · bash', 'ERROR'],
+  },
+  {
     name: 'process-child-composer-hidden',
     frame: 'viewport',
     rows: 24,

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -253,14 +253,17 @@ function WorkflowTaskRow({
   entry,
   focused,
   nowMs,
+  pendingKinds,
 }: {
   readonly child: StreamSlice | undefined;
   readonly entry: WorkflowTaskEntry;
   readonly focused: boolean;
   readonly nowMs: number;
+  readonly pendingKinds: readonly PendingApprovalKind[] | undefined;
 }): React.JSX.Element {
   const style = WORKFLOW_TASK_STATUS_STYLE[entry.task.status];
   const metadata = workflowTaskMetadata(entry.task, child, nowMs);
+  const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
   return (
     <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
       <Text aria-hidden color={focused ? COLOR_HINT : undefined}>
@@ -270,6 +273,7 @@ function WorkflowTaskRow({
       <Box minWidth={0} flexShrink={1}>
         <Text wrap="truncate-end">
           {entry.task.label} · {WORKFLOW_TASK_STATUS_LABEL[entry.task.status]}
+          {approvalSuffix ? ` · ${approvalSuffix}` : ''}
         </Text>
       </Box>
       {metadata ? (
@@ -289,6 +293,7 @@ function WorkflowDashboard({
   onCancel,
   onFocusStream,
   onSelectionChange,
+  pendingApprovals,
   selectedValue,
   streams,
 }: {
@@ -299,6 +304,8 @@ function WorkflowDashboard({
   readonly onCancel: () => void;
   readonly onFocusStream: ((streamId: StreamTabId) => void) | undefined;
   readonly onSelectionChange: ((value: ChildListValue) => void) | undefined;
+  readonly pendingApprovals:
+    ReadonlyMap<string, readonly PendingApprovalKind[]> | undefined;
   readonly selectedValue: ChildListValue | undefined;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): React.JSX.Element | null {
@@ -380,6 +387,11 @@ function WorkflowDashboard({
         entry={entry}
         focused={state.focused}
         nowMs={nowMs}
+        pendingKinds={
+          childStreamId === undefined
+            ? undefined
+            : pendingApprovals?.get(childStreamId)
+        }
       />
     );
   };
@@ -595,6 +607,7 @@ export function SubagentList(
         onCancel={props.onCancel ?? (() => undefined)}
         onFocusStream={props.onFocusStream}
         onSelectionChange={props.onSelectionChange}
+        pendingApprovals={props.pendingApprovals}
         selectedValue={props.selectedValue}
         streams={props.streams ?? new Map()}
       />

--- a/src/test-kernel/cli/ChildListInteraction.vitest.ts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.ts
@@ -398,6 +398,48 @@ describe('CLI child list interaction', () => {
     }
   });
 
+  it('marks only the workflow task whose child awaits approval', async () => {
+    const { ink, React } = await loadInk();
+    const otherChild = 'other-child' as StreamTabId;
+    const rootSlice = workflowRootSlice([
+      ...[
+        { id: 'inspect', childStreamId: child },
+        { id: 'summarize', childStreamId: otherChild },
+      ].map(({ id, childStreamId }) => ({
+        id: `task-${id}`,
+        role: 'workflowTask' as const,
+        text: `Running: ${id}`,
+        finalized: false,
+        task: {
+          id,
+          label: id,
+          status: 'running' as const,
+          childStreamId,
+        },
+      })),
+    ]);
+
+    const output = await renderOutputAtTerminalSize(
+      ink,
+      React.createElement(SubagentList, {
+        dashboard: workflowDashboardModel(rootSlice, 100),
+        maxRows: 6,
+        pendingApprovals: new Map([[child, ['bash'] as const]]),
+        streams: new Map([
+          [root, rootSlice],
+          [child, emptySlice(child)],
+          [otherChild, emptySlice(otherChild)],
+        ]),
+      }),
+      100,
+      { until: (frame) => frame.includes('inspect · Running · bash') },
+    );
+
+    expect(output).toContain('inspect · Running · bash');
+    expect(output).toContain('summarize · Running');
+    expect(output).not.toContain('summarize · Running · bash');
+  });
+
   it('keeps detail and controls inert when workflow tasks reuse a child id', async () => {
     const { ink, React } = await loadInk();
     const onFocusStream = vi.fn();


### PR DESCRIPTION
Closes #10112.

## Summary

- mark the workflow task whose child stream owns a pending command or edit approval
- reuse the existing stream-keyed approval projection already rendered by ordinary session rows
- add a deterministic PTY case with two same-named workflow agents and one grandchild-owned bash approval
- document the user-visible correction in the changelog

## Root cause and ownership

`App` already derives one canonical map of pending approval kinds keyed by stream. `SubagentList` passed that map to ordinary `SessionRow` instances, but dropped it when a workflow dashboard replaced the ordinary list.

The dashboard now resolves each task's unique child stream through the existing `childTaskIndex`, then reads the same approval map. This keeps task focus, approval-modal ownership, and the displayed suffix on one stream identity; no parallel approval or workflow representation is introduced.

Before:

```text
Workflow · 0/2 done
☐ Proofread paper A · Running
☐ Proofread paper B · Running
... 1 approval
```

After:

```text
Workflow · 0/2 done
☐ Proofread paper A · Running · bash
☐ Proofread paper B · Running
... 1 approval
```

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- `npm test` — 856 files passed, 1 skipped; 10,052 tests passed, 5 skipped
- focused dashboard/list tests — 34 passed
- `workflow-grandchild-approval-attribution` PTY scenario at 100 × 30

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only display wiring in the workflow child list; reuses existing approval projection with no change to approval handling or stream identity.
> 
> **Overview**
> **Workflow dashboard rows now show which parallel task is blocked on approval.** When the child list switches to the workflow dashboard, each task row resolves its unique child stream and reads the same stream-keyed `pendingApprovals` map that `App` already passes to `SubagentList` for ordinary sessions. The matching row appends the existing approval suffix (e.g. `· bash`) via `pendingApprovalRowSuffix`, so only the task waiting on command/edit approval is labeled—not every running task.
> 
> **Tests and harness:** A Vitest case asserts one of two parallel tasks gets `· bash` while the other does not. The TUI harness gains `HARNESS_WORKFLOW_DASHBOARD`, workflow-agent stream IDs on running workflow seeds and bash-approval payloads, and a `workflow-grandchild-approval-attribution` PTY scenario. **CHANGELOG** documents the user-visible fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 949dcff4ced3b3b757af4221b5dccb915821bbb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->