### PR TITLE
refactor: establish session and progress UI ownership

### DIFF
--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -9,12 +9,11 @@ import type {
   SessionHandle,
 } from '@agent/runtime';
 import { SessionFactApplier } from '@controllers/session/SessionFactApplier';
-import type { SessionRendererPort } from '@controllers/session/SessionRendererPort';
-import {
-  SessionState,
-  type ActiveStreamId,
-} from '@controllers/session/SessionState';
-import { MemoryStateStore } from '@platform/defaults/memoryState';
+import type {
+  PresentedStreamId,
+  SessionRendererPort,
+} from '@controllers/session/SessionRendererPort';
+import { SessionState } from '@controllers/session/SessionState';
 import {
   sumUsageStats,
   type ConversationProgress,
@@ -48,10 +47,9 @@ import type { StreamArtifactReader } from './subscribeStreamArtifacts';
 const GOAL_PAUSED_TRANSCRIPT_NOTICE =
   'Goal paused after a failed cycle. Review the error before starting a new goal.';
 
-/** Extract a stream id from a session fact for per-stream generation capture.
- *  The only fact types that trigger renderer callbacks after an async suspend
- *  are `setActiveStream` and `setParentStream`; other facts are handled
- *  synchronously and the exact id is a best-effort hint. */
+/** Extract a stream id for defensive per-dispatch generation capture.
+ *  Current session-fact application is synchronous; the exact id keeps each
+ *  callback tied to the CLI state generation that dispatched it. */
 function getSessionFactStreamId(fact: SessionFact): StreamTabId | undefined {
   switch (fact.type) {
     case 'status':
@@ -67,12 +65,10 @@ function getSessionFactStreamId(fact: SessionFact): StreamTabId | undefined {
 
 class TuiSessionRenderer implements SessionRendererPort {
   /**
-   * Generation snapshots captured per-stream at dispatch time, so a callback
-   * can detect that `resetCliState` ran between its dispatch and its
-   * invocation (the applier suspends in `handleSetActiveStream` while
-   * `streamLogs.ensureLoaded` is pending; the old single-field design let a
-   * second dispatch overwrite the captured generation, so the first callback
-   * could not tell a reset had happened).
+   * Defensive per-stream generation snapshots captured at dispatch time.
+   * Session facts are currently applied synchronously, but retaining the
+   * guard prevents a future asynchronous renderer callback from crossing a
+   * `resetCliState` boundary or borrowing another stream's snapshot.
    */
   private dispatchGenerations = new Map<StreamTabId, number>();
 
@@ -180,7 +176,7 @@ class TuiSessionRenderer implements SessionRendererPort {
     });
   }
 
-  onActiveStreamChanged(streamId: ActiveStreamId): void {
+  onActiveStreamChanged(streamId: PresentedStreamId): void {
     if (streamId && this.isStaleDispatch(streamId)) return;
     if (!streamId) {
       activeStreamId.set(undefined);
@@ -315,7 +311,7 @@ class TuiSessionRenderer implements SessionRendererPort {
   }
 
   syncStreamContent(
-    _stream: ActiveStreamId,
+    _stream: PresentedStreamId,
     _options?: { includeActiveState?: boolean },
   ): void {}
 }
@@ -332,13 +328,10 @@ export function attachSessionSignalsAdapter({
   session,
   snapshots,
 }: AttachSessionSignalsAdapterInit): () => void {
-  const state = new SessionState(new MemoryStateStore(), session);
+  const state = new SessionState(session);
   const renderer = new TuiSessionRenderer(state, snapshots, session);
   const applier = new SessionFactApplier(state, renderer, {
-    hasPendingPermissions: () => false,
     deleteStream: removeStream,
-    // CLI focus is the `activeStreamId` signal, not `SessionState.activeStream`.
-    evictOnStreamSwitch: false,
   });
   let generation = getCliStateGeneration();
   const detachResetHook = registerCliStateResetHook(() => {
@@ -348,13 +341,21 @@ export function attachSessionSignalsAdapter({
     if (generation !== getCliStateGeneration()) {
       return;
     }
-    // Status stays on `subscribeStreamStatus`: the shared applier's
-    // eviction keys off `SessionState.activeStream`, which is not the CLI
-    // focus id, and the old TUI ignored status facts here.
+    // Status stays on `subscribeStreamStatus`: the CLI owns its focus
+    // reaction there, while the shared applier only updates session facts and
+    // requests lease-aware eviction. The old TUI ignored status facts here.
     if (fact.type === 'status') return;
     const sessionStreamId = getSessionFactStreamId(fact);
     if (sessionStreamId) renderer.captureDispatchGeneration(sessionStreamId);
     applier.handleSessionFact(fact);
+    if (fact.type === 'setActiveStream') {
+      const streamId = fact.payload.streamId;
+      if (!streamId) {
+        renderer.onActiveStreamChanged('');
+      } else if (fact.payload.suppressViewSwitch !== true) {
+        renderer.onActiveStreamChanged(streamId);
+      }
+    }
   });
   const detachRunFacts = events.subscribeRunFacts(
     (runFact) => {

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -190,9 +190,8 @@ export function subscribeStreamLog(): () => void {
 
     if (previous && previous !== nextActiveStreamId) {
       trySyncStreamLog(previous);
-      // Focus is a lifecycle boundary: a stream that finished while it was
-      // focused (and so was never released at its status transition) is
-      // released the moment focus moves off it.
+      // Terminal status normally requests eviction immediately. This focus
+      // boundary remains a backstop when that status event was not observed.
       releaseInactiveStreamTranscript(previous);
     }
     if (!nextActiveStreamId || nextActiveStreamId === previous) return;

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -720,7 +720,7 @@ export class DesktopProgressBridge {
       },
       workflowFileActions: {
         state: {
-          getActiveStream: () => this.state.activeStream,
+          getActiveStream: () => this.backend.presentation.activeStream,
           getRunMetadata: (stream) => this.getRunMetadata(stream),
           getOutputFiles: (stream) =>
             this.state.snapshots.getOutputFiles(stream),
@@ -788,7 +788,8 @@ export class DesktopProgressBridge {
       },
       commands: {
         lifecycle: {
-          setActiveStream: (stream) => this.setActiveStream(stream),
+          setActiveStream: (stream, requestId) =>
+            this.setActiveStream(stream, requestId),
           deleteStream: (stream) => this.backend.deleteStream(stream),
           deleteAllStreams: () => this.backend.deleteAllStreams(),
           stopStream: (stream) => this.backend.stopStream(stream),
@@ -1048,8 +1049,11 @@ export class DesktopProgressBridge {
     await replayApprovalRequestHandlers(this.backend.approvalHandlers);
   }
 
-  private async setActiveStream(streamId: StreamTabId): Promise<void> {
-    await this.backend.activateStream(streamId);
+  private async setActiveStream(
+    streamId: StreamTabId | '',
+    requestId?: string,
+  ): Promise<void> {
+    await this.backend.activateStream(streamId, requestId);
   }
 
   /**
@@ -1057,7 +1061,11 @@ export class DesktopProgressBridge {
    * `getProgressStreamLabel`.
    */
   getStreamLabel(streamId: StreamTabId): string | undefined {
-    return buildStreamInfo(this.state, streamId).label;
+    return buildStreamInfo(
+      this.state,
+      streamId,
+      this.backend.presentation.activeStream,
+    ).label;
   }
 
   /**
@@ -1106,7 +1114,7 @@ export class DesktopProgressBridge {
   private getActiveLatexdiffRunContext(
     editedFile: string,
   ): DesktopLatexdiffRunContext | undefined {
-    const stream = this.state.activeStream;
+    const stream = this.backend.presentation.activeStream;
     if (!stream) return undefined;
 
     // Round keys are non-negative integers BY CONSTRUCTION: every write path

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -19,7 +19,6 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/popover/popover.js';
 import '@awesome.me/webawesome/dist/components/split-panel/split-panel.js';
 import { html, nothing, render, type TemplateResult } from 'lit';
-import { create as mutate } from 'mutative';
 import '@progressView/frontend';
 import './TexraDiffView';
 import type { StreamTabs } from '@progressView/frontend/components/StreamTabs';
@@ -36,6 +35,8 @@ import {
   handleStreamSwitch,
   handleToolbarCommand,
   runCompileFixer,
+  requestStreamDeselection,
+  requestStreamSwitch,
   sendFollowupCommand,
 } from '@progressView/frontend/eventHandlers';
 import { dispatchMessage } from '@progressView/frontend/messageDispatcher';
@@ -43,6 +44,7 @@ import {
   activeStreamId$,
   appState,
   childStreamsByParent$,
+  displayedActiveStreamId$,
   hasAnyStreams$,
   pendingApprovalIds$,
   streamStates$,
@@ -1109,7 +1111,7 @@ function rerenderShell(): void {
       activeWorkbenchTab(shellState, 'bottom')?.kind === 'logs',
   );
   railTabs.streams = topLevelStreams$.get();
-  railTabs.activeStreamId = activeStreamId$.get();
+  railTabs.activeStreamId = displayedActiveStreamId$.get();
   railTabs.streamStates = streamStates$.get();
   railTabs.pendingApprovalStreamIds = pendingApprovalIds$.get();
   railTabs.childStreamsByParent = childStreamsByParent$.get();
@@ -1191,6 +1193,7 @@ function installShellSignalWatcher(): void {
   // re-render on a microtask so multiple synchronous signal writes batch.
   const shellDeps = new Signal.Computed(() => {
     activeStreamId$.get();
+    displayedActiveStreamId$.get();
     hasAnyStreams$.get();
     topLevelStreams$.get();
     streamStates$.get();
@@ -1327,21 +1330,12 @@ function openCommandPalette(): void {
 
 function switchToStream(streamId: StreamTabId): void {
   if (!appState.get().streamById.has(streamId)) return;
-  appState.set(
-    mutate(appState.get(), (draft) => {
-      draft.activeStreamId = streamId;
-    }),
-  );
-  postMessage(PROGRESS_VIEW_COMMANDS.SWITCH_STREAM, { stream: streamId });
+  requestStreamSwitch(streamId);
 }
 
 // Clear the active stream so the center pane swaps back to <main-app>.
 function returnToLauncher(): void {
-  appState.set(
-    mutate(appState.get(), (draft) => {
-      draft.activeStreamId = null;
-    }),
-  );
+  requestStreamDeselection();
 }
 
 const LAYOUT_PANEL_TOGGLES: Record<DesktopLayoutPanel, () => void> = {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -362,7 +362,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       },
       workflowFileActions: {
         state: {
-          getActiveStream: () => this.provider.state.activeStream,
+          getActiveStream: () =>
+            this.provider.backend.presentation.activeStream,
           getRunMetadata: (stream) =>
             this.provider.state.snapshots.getRunMetadata(stream),
           getOutputFiles: (stream) =>
@@ -474,7 +475,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       },
       commands: {
         lifecycle: {
-          setActiveStream: (stream) => this.provider.setActiveStream(stream),
+          setActiveStream: (stream, requestId) =>
+            this.provider.setActiveStream(stream, requestId),
           deleteStream: (stream) => this.provider.backend.deleteStream(stream),
           deleteAllStreams: () => this.handleDeleteAll(),
           stopStream: (stream) => this.provider.backend.stopStream(stream),

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -359,8 +359,11 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     );
   }
 
-  public async setActiveStream(streamId: StreamTabId): Promise<void> {
-    await this.backend.activateStream(streamId);
+  public async setActiveStream(
+    streamId: StreamTabId | '',
+    requestId?: string,
+  ): Promise<void> {
+    await this.backend.activateStream(streamId, requestId);
   }
 
   private reportTranscriptLoadError(

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -29,6 +29,7 @@ import type { MutableWaTabGroup, WaTabShowEvent } from '@shared/wa/tabs';
 import { progressAppStyles } from './progressAppStyles';
 import {
   activeStreamId$,
+  displayedActiveStreamId$,
   childStreamsByParent$,
   diffStatusAnnouncement,
   hasAnyStreams$,
@@ -199,7 +200,7 @@ export class ProgressApp extends ProgressAppBase {
                       slot="end"
                       .compact=${compactTabs}
                       .streams=${topLevelStreams$.get()}
-                      .activeStreamId=${activeStreamId$.get()}
+                      .activeStreamId=${displayedActiveStreamId$.get()}
                       .streamStates=${streamStates$.get()}
                       .pendingApprovalStreamIds=${pendingApprovalIds$.get()}
                       .childStreamsByParent=${childStreamsByParent$.get()}

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -12,12 +12,6 @@ import {
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 // Local imports - progress view
-import {
-  deleteStreamState,
-  detachChildStreamTabs,
-  firstStreamId,
-} from './store';
-import { deleteFollowUpInputTransientState } from './followUpInputState';
 import { addResolvedProposalId, removePrompt } from './slices/permissionSlice';
 import { updateToolUseState } from './stateUtils';
 import { clearInquiryDraft } from './slices/inquiryDraftState';
@@ -37,36 +31,44 @@ import { appState, setStreamStateForId } from './progressState';
 export function handleStreamSwitch(
   event: CustomEvent<StreamEventDetail>,
 ): void {
-  const streamId = event.detail.streamId;
-  // Optimistic: highlight tab immediately
+  requestStreamSwitch(event.detail.streamId);
+}
+
+/** Record reversible tab feedback, then ask the backend to hydrate it. */
+export function requestStreamSwitch(streamId: StreamTabId): void {
+  const requestId = crypto.randomUUID();
   appState.set(
     create(appState.get(), (draft) => {
-      draft.activeStreamId = streamId;
+      draft.pendingStreamSelection = { requestId, streamId };
     }),
   );
-  postMessage(PROGRESS_VIEW_COMMANDS.SWITCH_STREAM, { stream: streamId });
+  postMessage(PROGRESS_VIEW_COMMANDS.SWITCH_STREAM, {
+    stream: streamId,
+    requestId,
+  });
+}
+
+/** Cancel transient tab intent and ask the backend to confirm no selection. */
+export function requestStreamDeselection(): void {
+  const requestId = crypto.randomUUID();
+  appState.set(
+    create(appState.get(), (draft) => {
+      draft.activeStreamId = null;
+      draft.pendingStreamSelection = null;
+    }),
+  );
+  postMessage(PROGRESS_VIEW_COMMANDS.SWITCH_STREAM, {
+    stream: '',
+    requestId,
+  });
 }
 
 export function handleStreamDelete(
   event: CustomEvent<StreamEventDetail>,
 ): void {
-  const streamId = event.detail.streamId;
-  deleteFollowUpInputTransientState(streamId);
-
-  // Optimistic removal: apply delete locally before notifying backend
-  appState.set(
-    create(appState.get(), (draft) => {
-      deleteStreamState(draft, streamId);
-      draft.streamById.delete(streamId);
-      detachChildStreamTabs(draft, streamId);
-      if (draft.activeStreamId === streamId) {
-        draft.activeStreamId = firstStreamId(draft.streamById);
-      }
-    }),
-  );
-
-  // Fire-and-forget to backend
-  postMessage(PROGRESS_VIEW_COMMANDS.DELETE_STREAM, { stream: streamId });
+  postMessage(PROGRESS_VIEW_COMMANDS.DELETE_STREAM, {
+    stream: event.detail.streamId,
+  });
 }
 
 export function handleToolbarCommand(

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -102,6 +102,14 @@ export const streamById$ = select(appState, (s) => s.streamById);
 export const streamStates$ = select(appState, (s) => s.streamStates);
 const streamLogs$ = select(appState, (s) => s.streamLogs);
 export const activeStreamId$ = select(appState, (s) => s.activeStreamId);
+const pendingStreamSelection$ = select(
+  appState,
+  (s) => s.pendingStreamSelection,
+);
+/** Pending selection drives only tab feedback; content uses confirmed state. */
+export const displayedActiveStreamId$ = new Signal.Computed(
+  () => pendingStreamSelection$.get()?.streamId ?? activeStreamId$.get(),
+);
 const inquiries$ = select(appState, (s) => s.inquiries);
 const followupOptions$ = select(appState, (s) => s.followupOptionsByStream);
 

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -20,6 +20,7 @@ import {
   deleteStreamState,
   detachChildStreamTabs,
   ensureStreamState,
+  releaseStreamContent,
   type ProgressState,
 } from '../store';
 import {
@@ -160,6 +161,10 @@ export const streamLifecycleHandlers = {
     appState.set(
       create(updated, (draft) => {
         draft.activeStreamId = nextActiveStreamId;
+        // A full roster is authoritative recovery after attachment or a
+        // transport interruption. Any unacknowledged visual intent is stale;
+        // a later activation message can still apply the backend's result.
+        draft.pendingStreamSelection = null;
       }),
     );
   },
@@ -170,10 +175,34 @@ export const streamLifecycleHandlers = {
       data.activeStream,
       prev.streamById,
     );
-    if (nextActiveStreamId === prev.activeStreamId) return;
+    if (
+      nextActiveStreamId === prev.activeStreamId &&
+      prev.pendingStreamSelection === null
+    )
+      return;
     appState.set(
       create(prev, (draft) => {
         draft.activeStreamId = nextActiveStreamId;
+        draft.pendingStreamSelection = null;
+      }),
+    );
+  },
+
+  [PROGRESS_VIEW_COMMANDS.SETTLE_STREAM_SELECTION]: (data) => {
+    const prev = appState.get();
+    if (prev.pendingStreamSelection?.requestId !== data.requestId) return;
+    appState.set(
+      create(prev, (draft) => {
+        draft.activeStreamId = data.activeStream || null;
+        draft.pendingStreamSelection = null;
+      }),
+    );
+  },
+
+  [PROGRESS_VIEW_COMMANDS.RELEASE_STREAM_CONTENT]: (data) => {
+    appState.set(
+      create(appState.get(), (draft) => {
+        releaseStreamContent(draft, data.stream);
       }),
     );
   },
@@ -199,6 +228,9 @@ export const streamLifecycleHandlers = {
         detachChildStreamTabs(draft, streamId);
         if (draft.activeStreamId === streamId) {
           draft.activeStreamId = null;
+        }
+        if (draft.pendingStreamSelection?.streamId === streamId) {
+          draft.pendingStreamSelection = null;
         }
       }),
     );
@@ -228,6 +260,7 @@ export const streamLifecycleHandlers = {
         draft.streamLogs = new Map();
         draft.followupOptionsByStream = new Map();
         draft.activeStreamId = null;
+        draft.pendingStreamSelection = null;
       }),
     );
   },

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -1,6 +1,7 @@
 // Shared imports
 import {
   createStreamState,
+  isToolUseState,
   type AgentCategory,
   type LogMessageData,
   type StreamState,
@@ -70,6 +71,11 @@ export const EMPTY_STREAM_LOGS: StreamLogs = createEmptyStreamLogs();
 
 export interface ProgressState {
   activeStreamId: StreamTabId | null;
+  /** Reversible user intent awaiting backend hydration and confirmation. */
+  pendingStreamSelection: {
+    requestId: string;
+    streamId: StreamTabId;
+  } | null;
   /** Canonical stream storage — Map preserves insertion order for iteration. */
   streamById: Map<StreamTabId, StreamTabInfo>;
   /** Meta state per stream (status, todos, usage, ui, taskGroups, etc.) */
@@ -98,6 +104,34 @@ export function deleteStreamState(
   draft.streamStates.delete(streamId);
   draft.streamLogs.delete(streamId);
   draft.followupOptionsByStream.delete(streamId);
+}
+
+/**
+ * Drop reloadable content while retaining the lightweight tab projection and
+ * unsent tool-use draft owned by this browser surface. Follow-up option
+ * catalogs are also lightweight and remain usable by an already-open panel.
+ */
+export function releaseStreamContent(
+  draft: Draft<ProgressState>,
+  streamId: StreamTabId,
+): void {
+  draft.streamLogs.delete(streamId);
+  const current = draft.streamStates.get(streamId);
+  if (!current) return;
+  const lightweight = {
+    status: current.status,
+    substate: current.substate,
+    userFollowUpSupport: current.userFollowUpSupport,
+    lastTimestamp: current.lastTimestamp,
+    conversationProgress: current.conversationProgress,
+    stage: current.stage,
+    subagents: current.subagents,
+    ...(isToolUseState(current) ? { ui: current.ui } : {}),
+  };
+  draft.streamStates.set(
+    streamId,
+    createStreamState(current.category, lightweight),
+  );
 }
 
 /** Clear every visible child edge targeting a deleted parent stream. */
@@ -147,16 +181,10 @@ export function ensureStreamState(
   return state;
 }
 
-/** Return the first stream ID from a streamById Map, or null if empty. */
-export function firstStreamId(
-  streamById: Map<StreamTabId, StreamTabInfo>,
-): StreamTabId | null {
-  return streamById.keys().next().value ?? null;
-}
-
 export function createInitialState(): ProgressState {
   return {
     activeStreamId: null,
+    pendingStreamSelection: null,
     streamById: new Map(),
     streamStates: new Map(),
     streamLogs: new Map(),

--- a/packages/extension/src/progressView/progressNavigation.ts
+++ b/packages/extension/src/progressView/progressNavigation.ts
@@ -16,7 +16,11 @@ export async function revealProgressStream(
 export function getProgressStreamLabel(
   streamId: StreamTabId,
 ): string | undefined {
-  const state = ProgressViewProvider.getInstance()?.state;
-  if (!state) return undefined;
-  return buildStreamInfo(state, streamId).label;
+  const provider = ProgressViewProvider.getInstance();
+  if (!provider) return undefined;
+  return buildStreamInfo(
+    provider.state,
+    streamId,
+    provider.backend.presentation.activeStream,
+  ).label;
 }

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -92,7 +92,10 @@ interface ProgressViewFollowUpSubmission {
 }
 
 export interface ProgressViewLifecycleCommandActions {
-  setActiveStream(stream: StreamTabId): Promise<void> | void;
+  setActiveStream(
+    stream: StreamTabId | '',
+    requestId: string,
+  ): Promise<void> | void;
   deleteStream(stream: StreamTabId): Promise<void> | void;
   deleteAllStreams(): Promise<void> | void;
   stopStream(stream: StreamTabId): Promise<void> | void;
@@ -223,7 +226,7 @@ export function createProgressViewCommandHandlers(
 
   return {
     [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]: (data) =>
-      lifecycle.setActiveStream(data.stream),
+      lifecycle.setActiveStream(data.stream, data.requestId),
     [PROGRESS_VIEW_COMMANDS.DELETE_STREAM]: (data) =>
       lifecycle.deleteStream(data.stream),
     [PROGRESS_VIEW_COMMANDS.DELETE_ALL]: () => lifecycle.deleteAllStreams(),

--- a/src/controllers/progressView/backend/LitSessionRenderer.ts
+++ b/src/controllers/progressView/backend/LitSessionRenderer.ts
@@ -1,16 +1,13 @@
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
+import type { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { WebviewBridge } from '@controllers/progressView/backend/WebviewBridge';
+import { ProgressStreamProjectionBuilder } from '@controllers/progressView/backend/ProgressStreamProjectionBuilder';
 import { WebviewUpdater } from '@controllers/progressView/backend/WebviewUpdater';
-import {
-  getDefaultProgressStreamControls,
-  type GetProgressStreamControls,
-} from '@controllers/progressView/progressStreamControls';
-import type { SessionRendererPort } from '@controllers/session/SessionRendererPort';
-import {
-  SessionState,
-  type ActiveStreamId,
-  type StreamBadgeSnapshot,
-} from '@controllers/session/SessionState';
+import type {
+  PresentedStreamId,
+  SessionRendererPort,
+} from '@controllers/session/SessionRendererPort';
+import type { StreamBadgeSnapshot } from '@controllers/session/SessionState';
 import type {
   ConversationProgress,
   GoalStatus,
@@ -23,20 +20,16 @@ import type {
   TodoItem,
   TokenUsageStats,
 } from '@shared/schemas';
-import { AgentCategory } from '@shared/schemas';
-import {
-  createFlushableDebounce,
-  mapToRecord,
-  type FlushableDebounce,
-} from '@utils/core';
+import type { StreamSnapshotStore } from '@transcript/StreamSnapshotStore';
+import { createFlushableDebounce, type FlushableDebounce } from '@utils/core';
 
 /** Throttle interval for conversation progress webview pushes (ms). */
 const PROGRESS_THROTTLE_MS = 500;
 
 /**
- * Lit/progress-view renderer over {@link SessionState}: owns postMessage push
- * policy (`sendIfActive`, conversation-progress debounce, phase-vs-round stage
- * delivery, bridge cursor sync, controls packing).
+ * Lit/progress-view delivery policy over immutable stream projections.
+ * Owns active-only delivery, conversation-progress debounce, phase-vs-round
+ * stage delivery, and bridge cursor synchronization.
  */
 export class LitSessionRenderer implements SessionRendererPort {
   private readonly progressDebounce: FlushableDebounce =
@@ -50,10 +43,12 @@ export class LitSessionRenderer implements SessionRendererPort {
   >();
 
   constructor(
-    private readonly state: SessionState,
+    private readonly projections: ProgressStreamProjectionBuilder,
+    private readonly snapshots: StreamSnapshotStore,
+    private readonly followUps: ToolUseFollowUpQueue,
     private readonly webviewUpdater: WebviewUpdater,
     private readonly webviewBridge: WebviewBridge,
-    private readonly getStreamControls: GetProgressStreamControls = getDefaultProgressStreamControls,
+    private readonly getActiveStream: () => PresentedStreamId = () => '',
   ) {}
 
   isAvailable(): boolean {
@@ -74,14 +69,16 @@ export class LitSessionRenderer implements SessionRendererPort {
     streamId: StreamTabId,
     options?: {
       streamStates?: Map<StreamTabId, StreamPhaseState>;
-      activeStream?: ActiveStreamId;
+      activeStream?: PresentedStreamId;
     },
   ): void {
     if (!this.webviewUpdater.isAvailable()) return;
     this.webviewUpdater.updateStreamMetadata(
-      this.state,
-      streamId,
-      options?.streamStates,
+      this.projections.streamMetadata(
+        streamId,
+        options?.streamStates,
+        options?.activeStream ?? this.getActiveStream(),
+      ),
       { activeStream: options?.activeStream },
     );
   }
@@ -102,7 +99,7 @@ export class LitSessionRenderer implements SessionRendererPort {
     );
   }
 
-  onActiveStreamChanged(streamId: ActiveStreamId): void {
+  onActiveStreamChanged(streamId: PresentedStreamId): void {
     this.webviewUpdater.setActiveStream(streamId);
   }
 
@@ -117,9 +114,11 @@ export class LitSessionRenderer implements SessionRendererPort {
     // Parent edge rides `StreamTabInfo.parentStreamId` on the metadata wire.
     if (!this.webviewUpdater.isAvailable()) return;
     this.webviewUpdater.updateStreamMetadata(
-      this.state,
-      childStreamId,
-      this.state.streamStatus.getAllStreamStates(),
+      this.projections.streamMetadata(
+        childStreamId,
+        undefined,
+        this.getActiveStream(),
+      ),
     );
   }
 
@@ -143,9 +142,11 @@ export class LitSessionRenderer implements SessionRendererPort {
       // cost nothing.
       if (!this.webviewUpdater.isAvailable()) return;
       this.webviewUpdater.updateStreamMetadata(
-        this.state,
-        streamId,
-        this.state.streamStatus.getAllStreamStates(),
+        this.projections.streamMetadata(
+          streamId,
+          undefined,
+          this.getActiveStream(),
+        ),
       );
       return;
     }
@@ -168,7 +169,7 @@ export class LitSessionRenderer implements SessionRendererPort {
 
   onFilesChanged(streamId: StreamTabId): void {
     this.sendIfActive(streamId, () => {
-      const rounds = this.state.snapshots.getOutputFiles(streamId);
+      const rounds = this.snapshots.getOutputFiles(streamId);
       this.webviewUpdater.updateFiles(streamId, {
         rounds: Object.keys(rounds).length ? rounds : undefined,
       });
@@ -184,7 +185,7 @@ export class LitSessionRenderer implements SessionRendererPort {
         this.webviewUpdater.updateMissingOutputs(streamId, { reset: true });
         return;
       }
-      const rounds = this.state.snapshots.getMissingOutputs(streamId);
+      const rounds = this.snapshots.getMissingOutputs(streamId);
       this.webviewUpdater.updateMissingOutputs(streamId, {
         rounds: Object.keys(rounds).length ? rounds : undefined,
       });
@@ -193,7 +194,7 @@ export class LitSessionRenderer implements SessionRendererPort {
 
   onCompileFailuresChanged(streamId: StreamTabId): void {
     this.sendIfActive(streamId, () => {
-      const rounds = this.state.snapshots.getCompileFailures(streamId);
+      const rounds = this.snapshots.getCompileFailures(streamId);
       this.webviewUpdater.updateCompileFailures(streamId, {
         rounds: Object.keys(rounds).length ? rounds : undefined,
         reset: true,
@@ -209,7 +210,7 @@ export class LitSessionRenderer implements SessionRendererPort {
     // Prefer the snapshot store's normalized per-key value when present (fills
     // cache/reasoning zeros); fall back to the event payload.
     const nextUsage =
-      this.state.snapshots.getRunUsage(streamId).get(storageKey) ?? usage;
+      this.snapshots.getRunUsage(streamId).get(storageKey) ?? usage;
     this.sendIfActive(streamId, () =>
       this.webviewUpdater.updateRunUsage(streamId, storageKey, nextUsage),
     );
@@ -228,7 +229,7 @@ export class LitSessionRenderer implements SessionRendererPort {
 
   onQueuedFollowUpsChanged(streamId: StreamTabId): void {
     this.sendIfActive(streamId, () => {
-      const messages = this.state.followUps.getAll(streamId);
+      const messages = this.followUps.getAll(streamId);
       this.webviewUpdater.updateQueuedFollowUps(streamId, messages);
     });
   }
@@ -250,7 +251,7 @@ export class LitSessionRenderer implements SessionRendererPort {
   }
 
   syncStreamContent(
-    stream: ActiveStreamId,
+    stream: PresentedStreamId,
     options: {
       includeActiveState?: boolean;
     } = {},
@@ -266,74 +267,17 @@ export class LitSessionRenderer implements SessionRendererPort {
 
     this.webviewBridge.syncStream(stream);
 
-    const existingState = this.state.getStreamState(stream);
-    const category =
-      this.state.getStreamMetadata(stream).agentCategory ??
-      existingState?.category;
-    // A stream whose category has not resolved yet has nothing to render —
-    // it stays pending until run.config or the snapshot seed supplies one.
-    if (category === undefined) return;
-
-    const executionState = includeActiveState
-      ? this.state.getOrCreateStreamState(stream, category)
-      : undefined;
-    const activeState = executionState
-      ? {
-          conversationProgress: executionState.conversationProgress,
-          stage: executionState.stage ?? null,
-          badges: { subagents: executionState.subagents },
-        }
-      : undefined;
-
-    const shared = {
-      action: 'render' as const,
+    const projection = this.projections.streamContent(
       stream,
-      runUsage: mapToRecord(this.state.snapshots.getRunUsage(stream)),
-      ...(activeState ? { activeState } : {}),
-    };
-
-    if (category === AgentCategory.Workflow) {
-      this.webviewUpdater.sendSyncStreamContent({
-        ...shared,
-        category,
-        outputs: {
-          files: this.state.snapshots.getOutputFiles(stream),
-          missing: this.state.snapshots.getMissingOutputs(stream),
-          compileFailures: this.state.snapshots.getCompileFailures(stream),
-        },
-      });
-      return;
-    }
-
-    const { todos, plan } = this.state.snapshots.getWorkPlan(stream);
-    const controls = this.getStreamControls(stream);
-    this.webviewUpdater.sendSyncStreamContent({
-      ...shared,
-      category,
-      workPlan: {
-        todos,
-        plan,
-        queuedFollowUps: this.state.followUps.getAll(stream),
-      },
-      controls: {
-        bashBypass: controls.bashBypass,
-        toolEditBypass: controls.toolEditBypass,
-        superYoloBypass: controls.superYoloBypass,
-        goal: controls.goalActive
-          ? {
-              active: true,
-              status: controls.goalStatus,
-              objective: controls.goalObjective,
-            }
-          : { active: false },
-      },
-    });
+      includeActiveState,
+    );
+    if (projection) this.webviewUpdater.sendSyncStreamContent(projection);
   }
 
   /** Send to webview only if streamId is the active stream. */
   private sendIfActive(streamId: string, send: () => void): void {
     if (
-      streamId === this.state.activeStream &&
+      streamId === this.getActiveStream() &&
       this.webviewUpdater.isAvailable()
     ) {
       send();
@@ -341,7 +285,7 @@ export class LitSessionRenderer implements SessionRendererPort {
   }
 
   private flushProgressUpdates(): void {
-    const { activeStream } = this.state;
+    const activeStream = this.getActiveStream();
     const progress = activeStream
       ? this.pendingProgressUpdates.get(activeStream)
       : undefined;

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -14,12 +14,15 @@ import {
 } from '@controllers/progressView/backend/WebviewBridge';
 import { WebviewUpdater } from '@controllers/progressView/backend/WebviewUpdater';
 import { LitSessionRenderer } from '@controllers/progressView/backend/LitSessionRenderer';
+import { ProgressPresentationState } from '@controllers/progressView/backend/ProgressPresentationState';
+import { ProgressStreamProjectionBuilder } from '@controllers/progressView/backend/ProgressStreamProjectionBuilder';
 import type { GetProgressStreamControls } from '@controllers/progressView/progressStreamControls';
 import {
   SessionFactApplier,
   type SessionRunFactEvent,
 } from '@controllers/session/SessionFactApplier';
 import { SessionState } from '@controllers/session/SessionState';
+import type { PresentedStreamId } from '@controllers/session/SessionRendererPort';
 import {
   buildApprovalRequestHandlerSet,
   createProgressBackendUiConfig,
@@ -28,10 +31,15 @@ import {
 } from '@controllers/progressView/backend/progressBackendUiConfig';
 import { createLog } from '@logger/logUtils';
 import type { StateStore } from '@platform/interfaces';
-import type { ProgressViewOutboundMessage, StreamTabId } from '@shared/schemas';
+import type {
+  ProgressViewOutboundMessage,
+  SetActiveStreamPayload,
+  StreamTabId,
+} from '@shared/schemas';
 import { STREAM_PHASE } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { isInFlightPhase } from '@shared/streams/streamStatus';
+import type { TranscriptPresentationLease } from '@transcript/StreamLogStore';
 import { canUseStreamDataDir } from '@transcript/streamDataPaths';
 
 const log = createLog('ProgressBackend');
@@ -90,8 +98,10 @@ export interface ProgressBackendOptions {
  */
 export class ProgressBackend {
   readonly state: SessionState;
+  readonly presentation: ProgressPresentationState;
   readonly webviewUpdater: WebviewUpdater;
   readonly webviewBridge: WebviewBridge;
+  readonly projections: ProgressStreamProjectionBuilder;
   readonly approvalHandlers: ApprovalRequestHandlerSet;
   readonly setApprovalBypassState: (
     update: HostApprovalBypassStateUpdate,
@@ -103,10 +113,15 @@ export class ProgressBackend {
   private readonly reportTranscriptLoadError: ProgressBackendOptions['reportTranscriptLoadError'];
   private readonly postMessage: (message: ProgressViewOutboundMessage) => void;
   private readonly stateOwnership: 'backend' | 'session';
+  private readonly hasPendingPermissions: (streamId: string) => boolean;
   private readonly storageOperationQueue = new PQueue({ concurrency: 1 });
   private readonly detachEventListeners: Array<() => void> = [];
   private storageGeneration = 0;
   private presentationReloadPending = false;
+  private activationGeneration = 0;
+  private latestActivationTarget: PresentedStreamId = '';
+  private readonly inFlightActivationGenerations = new Set<number>();
+  private transcriptPresentationLease?: TranscriptPresentationLease;
   private disposed = false;
 
   constructor(options: ProgressBackendOptions) {
@@ -128,20 +143,21 @@ export class ProgressBackend {
         },
       );
     };
-    this.state = new SessionState(
-      options.storage,
-      this.session,
-      options.stores,
-    );
+    this.state = new SessionState(this.session, options.stores);
+    this.presentation = new ProgressPresentationState(options.storage);
     this.webviewUpdater = new WebviewUpdater(
       this.postMessage,
       options.hasTarget,
       options.getUnsupportedCommands,
     );
+    this.projections = new ProgressStreamProjectionBuilder(
+      this.state,
+      options.getStreamControls,
+    );
     this.webviewBridge = new WebviewBridge(
       this.state.streamLogs,
       options.sendMessage,
-      () => this.state.activeStream || null,
+      () => this.presentation.activeStream || null,
     );
 
     this.approvalHandlers = buildApprovalRequestHandlerSet({
@@ -153,14 +169,16 @@ export class ProgressBackend {
       webviewUpdater: this.webviewUpdater,
       canSend: options.approvals.canSend,
     });
+    this.hasPendingPermissions = ui.hasPendingPermissions;
     this.litRenderer = new LitSessionRenderer(
-      this.state,
+      this.projections,
+      this.state.snapshots,
+      this.state.followUps,
       this.webviewUpdater,
       this.webviewBridge,
-      options.getStreamControls,
+      () => this.presentation.activeStream,
     );
     this.factApplier = new SessionFactApplier(this.state, this.litRenderer, {
-      hasPendingPermissions: ui.hasPendingPermissions,
       deleteStream: (stream) => this.deleteStream(stream),
     });
     this.setApprovalBypassState = ui.setApprovalBypassState;
@@ -179,71 +197,222 @@ export class ProgressBackend {
     syncActiveStream: boolean;
     theme?: 'dark' | 'light';
   }): Promise<void> {
-    const activeStream = this.webviewUpdater.sendStreamMetadata(
-      this.state,
-      this.state.streamStatus.getAllStreamStates(),
+    const selectableStreams = this.state.selectableStreamNames();
+    const activeStream = this.presentation.activeStream;
+    const desiredStream = this.presentation.choose(selectableStreams);
+    const rosterActiveStream = selectableStreams.includes(activeStream)
+      ? activeStream
+      : '';
+    const pendingSelectableActivation =
+      this.inFlightActivationGenerations.has(this.activationGeneration) &&
+      this.latestActivationTarget !== '' &&
+      selectableStreams.includes(this.latestActivationTarget);
+    let projectedStream = options.syncActiveStream
+      ? desiredStream
+      : rosterActiveStream;
+    if (options.syncActiveStream && pendingSelectableActivation) {
+      projectedStream = this.latestActivationTarget;
+    }
+    this.webviewUpdater.sendStreamMetadata(
+      this.projections.streamRoster(
+        projectedStream,
+        this.state.streamStatus.getAllStreamStates(),
+      ),
+      rosterActiveStream,
       options.theme,
     );
     if (!options.syncActiveStream) return;
+    if (pendingSelectableActivation) {
+      // A structural refresh must not supersede a newer user selection that
+      // the backend has already accepted and is still hydrating.
+      return;
+    }
 
-    const hasStreams = this.state.streamLogs.keys().length > 0;
-    if (!activeStream && hasStreams) return;
     try {
-      await this.syncActiveStream(activeStream, {
-        notifyActivation: false,
+      await this.hydrateAndCommitSelection(desiredStream, {
+        notifyActivation: activeStream !== desiredStream,
       });
     } catch (error) {
-      this.reportTranscriptLoadError(error, activeStream);
+      this.reportTranscriptLoadError(error, desiredStream);
     }
   }
 
   /** Select and render one existing stream without rebuilding the tab list. */
-  async activateStream(stream: StreamTabId): Promise<void> {
-    if (!this.state.streamLogs.has(stream)) return;
-    this.state.switchActiveStream(stream);
+  async activateStream(
+    stream: PresentedStreamId,
+    requestId?: string,
+  ): Promise<void> {
+    if (stream && !this.state.streamLogs.has(stream)) {
+      // A newer rejected request still supersedes every older hydration. Its
+      // visual intent is settled back to the confirmed selection below.
+      this.activationGeneration += 1;
+      this.latestActivationTarget = stream;
+      if (requestId) {
+        this.webviewUpdater.settleStreamSelection(
+          requestId,
+          'rejected',
+          this.presentation.activeStream,
+        );
+      }
+      return;
+    }
     try {
-      await this.syncActiveStream(stream, {
+      const committed = await this.hydrateAndCommitSelection(stream, {
         notifyActivation: true,
       });
+      if (!committed) await this.recoverFromFailedActivation(stream);
+      if (requestId) {
+        this.webviewUpdater.settleStreamSelection(
+          requestId,
+          committed ? 'accepted' : 'superseded',
+          this.presentation.activeStream,
+        );
+      }
     } catch (error) {
       this.reportTranscriptLoadError(error, stream);
+      await this.recoverFromFailedActivation(stream);
+      if (requestId) {
+        this.webviewUpdater.settleStreamSelection(
+          requestId,
+          'rejected',
+          this.presentation.activeStream,
+        );
+      }
     }
   }
 
-  private async syncActiveStream(
+  /**
+   * If deletion removed the confirmed stream while a replacement was loading,
+   * recover from that replacement's failure with one different survivor. A
+   * newer activation or explicit deselection always remains authoritative.
+   */
+  private async recoverFromFailedActivation(
+    failedStream: StreamTabId,
+  ): Promise<void> {
+    if (
+      this.presentation.activeStream !== '' ||
+      this.latestActivationTarget !== failedStream ||
+      this.inFlightActivationGenerations.has(this.activationGeneration)
+    ) {
+      return;
+    }
+    const fallback = this.presentation.choose(
+      this.state
+        .selectableStreamNames()
+        .filter((stream) => stream !== failedStream),
+    );
+    if (!fallback) return;
+
+    try {
+      // This is deliberately one-shot. A failed fallback is reported but does
+      // not recurse through the roster or retry a known failed target.
+      await this.hydrateAndCommitSelection(fallback, {
+        notifyActivation: true,
+      });
+    } catch (error) {
+      this.reportTranscriptLoadError(error, fallback);
+    }
+  }
+
+  private async hydrateAndCommitSelection(
     stream: StreamTabId | '',
     options: {
       notifyActivation: boolean;
     },
-  ): Promise<void> {
-    if (!this.litRenderer.isAvailable()) return;
-    let hydrationError: unknown;
-    if (stream) {
-      const hydration = await Promise.allSettled([
-        this.state.streamLogs.ensureLoaded(stream),
-        this.state.snapshots.preload([stream]),
-      ]);
-      const failures = hydration.filter(
-        (result): result is PromiseRejectedResult =>
-          result.status === 'rejected',
-      );
-      if (failures.length === 1) {
-        hydrationError = failures[0].reason;
-      } else if (failures.length > 1) {
-        hydrationError = new AggregateError(
-          failures.map((failure) => failure.reason),
-          `Failed to hydrate stream ${stream}`,
-        );
+  ): Promise<boolean> {
+    const generation = ++this.activationGeneration;
+    this.latestActivationTarget = stream;
+    if (!stream) {
+      const previousStream = this.presentation.activeStream;
+      this.presentation.select('');
+      this.releasePresentationLeases();
+      if (this.litRenderer.isAvailable()) {
+        this.litRenderer.onActiveStreamChanged('');
+        this.litRenderer.syncStreamContent('', { includeActiveState: true });
+        if (previousStream) {
+          this.webviewUpdater.releaseStreamContent(previousStream);
+        }
       }
+      return true;
     }
-    if (this.state.activeStream !== stream) {
-      if (hydrationError !== undefined) throw hydrationError;
-      return;
+    if (!this.litRenderer.isAvailable()) {
+      this.presentation.select(stream);
+      this.releasePresentationLeases();
+      return true;
     }
+
+    const leasePromise = this.state.streamLogs.ensureLoaded(stream, {
+      retainForPresentation: true,
+    });
+    this.inFlightActivationGenerations.add(generation);
+    const hydration = await Promise.allSettled([
+      leasePromise,
+      this.state.snapshots.preload([stream]),
+    ]);
+    this.inFlightActivationGenerations.delete(generation);
+    const transcriptLeaseResult = hydration[0];
+    const snapshotLeaseResult = hydration[1];
+    const failures = hydration.filter(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
+    );
+    if (generation !== this.activationGeneration) {
+      if (transcriptLeaseResult.status === 'fulfilled')
+        transcriptLeaseResult.value.close();
+      return false;
+    }
+    if (!this.state.streamLogs.has(stream)) {
+      if (transcriptLeaseResult.status === 'fulfilled')
+        transcriptLeaseResult.value.close();
+      return false;
+    }
+    if (failures.length > 0) {
+      if (transcriptLeaseResult.status === 'fulfilled')
+        transcriptLeaseResult.value.close();
+      if (failures.length === 1) throw failures[0].reason;
+      throw new AggregateError(
+        failures.map((failure) => failure.reason),
+        `Failed to hydrate stream ${stream}`,
+      );
+    }
+    if (transcriptLeaseResult.status !== 'fulfilled')
+      throw transcriptLeaseResult.reason;
+    if (snapshotLeaseResult.status !== 'fulfilled')
+      throw snapshotLeaseResult.reason;
+
+    const previousStream = this.presentation.activeStream;
+    const previousTranscriptLease = this.transcriptPresentationLease;
+    this.transcriptPresentationLease = transcriptLeaseResult.value;
+    this.presentation.select(stream);
     if (options.notifyActivation)
       this.litRenderer.onActiveStreamChanged(stream);
     this.litRenderer.syncStreamContent(stream, { includeActiveState: true });
-    if (hydrationError !== undefined) throw hydrationError;
+    if (previousStream && previousStream !== stream) {
+      this.webviewUpdater.releaseStreamContent(previousStream);
+    }
+    if (previousTranscriptLease !== transcriptLeaseResult.value)
+      previousTranscriptLease?.close();
+    return true;
+  }
+
+  private releasePresentationLeases(): void {
+    const transcriptLease = this.transcriptPresentationLease;
+    this.transcriptPresentationLease = undefined;
+    transcriptLease?.close();
+  }
+
+  /** Apply presentation policy carried beside a stream attachment fact. */
+  private handleStreamPresentationRequest(
+    payload: SetActiveStreamPayload,
+  ): void {
+    const stream = payload.streamId;
+    if (!stream) {
+      void this.hydrateAndCommitSelection('', { notifyActivation: true });
+      return;
+    }
+    if (payload.suppressViewSwitch === true) return;
+    const current = this.presentation.activeStream;
+    if (current && this.hasPendingPermissions(current)) return;
+    void this.activateStream(stream);
   }
 
   /**
@@ -274,6 +443,10 @@ export class ProgressBackend {
     ...args: Parameters<SessionFactApplier['handleSessionFact']>
   ): void {
     this.factApplier.handleSessionFact(...args);
+    const [fact] = args;
+    if (fact.type === 'setActiveStream') {
+      this.handleStreamPresentationRequest(fact.payload);
+    }
   }
 
   /** Inject a run fact (tests / rare host seeds). Prefer the hub in production. */
@@ -288,13 +461,14 @@ export class ProgressBackend {
   }
 
   async deleteStream(stream: StreamTabId): Promise<void> {
-    const wasActive = this.state.activeStream === stream;
+    const wasActive = this.presentation.activeStream === stream;
+    const activationGeneration = this.activationGeneration;
     const storageGeneration = this.storageGeneration;
     const retained = await this.enqueuePreparedStorageOperation(
       () => this.prepareStreamDeletion(stream),
       () =>
         storageGeneration === this.storageGeneration
-          ? this.deleteStreamNow(stream, wasActive)
+          ? this.deleteStreamNow(stream, wasActive, activationGeneration)
           : Promise.resolve(undefined),
     );
     if (retained) {
@@ -343,6 +517,7 @@ export class ProgressBackend {
   private async deleteStreamNow(
     stream: StreamTabId,
     wasActive: boolean,
+    activationGenerationAtStart: number,
   ): Promise<'active' | 'failed' | undefined> {
     if (!canUseStreamDataDir(stream)) return undefined;
 
@@ -355,31 +530,44 @@ export class ProgressBackend {
 
     this.lifecycle.cleanupDeletedStream(stream);
     this.webviewBridge.clearStream(stream);
+    const selectionWasDeleted = this.presentation.activeStream === stream;
+    if (selectionWasDeleted) {
+      this.presentation.select('');
+      this.releasePresentationLeases();
+    }
 
-    let shouldActivateStream = false;
-    const activeAfterClear = this.state.activeStream;
     const remainingStreams = this.state.selectableStreamNames();
+    const activeAfterClear = this.presentation.activeStream;
     const hasVisibleActive =
       activeAfterClear !== '' && remainingStreams.includes(activeAfterClear);
-    if (activeAfterClear === stream || (wasActive && !hasVisibleActive)) {
-      shouldActivateStream =
-        this.state.rotateActiveStream(remainingStreams) !== '';
-    } else if (wasActive && hasVisibleActive) {
-      shouldActivateStream = true;
-    }
+    const newerActivationPending =
+      activationGenerationAtStart !== this.activationGeneration;
+    const newerIntentControlsSelection =
+      newerActivationPending &&
+      (this.latestActivationTarget === '' ||
+        (this.latestActivationTarget !== stream &&
+          this.state.streamLogs.has(this.latestActivationTarget)));
+    // A concurrent switch to a surviving stream still needs reassertion after
+    // DELETE_STREAM. A concurrent explicit deselection is presentation intent
+    // and must remain empty rather than being replaced by a fallback.
+    const shouldActivateStream =
+      (selectionWasDeleted && !newerIntentControlsSelection) ||
+      (wasActive && hasVisibleActive && !newerIntentControlsSelection);
 
     this.postMessage({
       command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
       stream,
     });
 
-    const nextActive = this.state.activeStream;
+    const nextActive = hasVisibleActive
+      ? activeAfterClear
+      : this.presentation.choose(remainingStreams);
     if (shouldActivateStream && nextActive) {
       // DELETE_STREAM clears the frontend selection when the deleted tab was
       // active. Reassert the surviving selection even when a concurrent
       // activation already selected it while storage deletion was pending.
       await this.activateStream(nextActive);
-    } else {
+    } else if (!newerActivationPending) {
       // The deleted stream was not the active one, so only the stream list
       // changed; the active stream's content is still on screen and correct.
       await this.lifecycle.rebuildRenderedStreams({ syncActiveStream: false });
@@ -388,6 +576,7 @@ export class ProgressBackend {
   }
 
   async deleteAllStreams(): Promise<void> {
+    const activationGeneration = this.activationGeneration;
     const storageGeneration = this.storageGeneration;
     const outcome = await this.enqueuePreparedStorageOperation(
       () => this.prepareAllStreamDeletions(),
@@ -397,8 +586,12 @@ export class ProgressBackend {
           : Promise.resolve(undefined),
     );
     if (!outcome) return;
+    const newerIntentControlsSelection =
+      activationGeneration !== this.activationGeneration &&
+      (this.latestActivationTarget === '' ||
+        this.state.streamLogs.has(this.latestActivationTarget));
     await this.lifecycle.rebuildRenderedStreams({
-      syncActiveStream: !outcome.allDeleted,
+      syncActiveStream: !outcome.allDeleted && !newerIntentControlsSelection,
     });
     if (!outcome.allDeleted) {
       await this.lifecycle.notifyDeletionRetained(
@@ -433,6 +626,15 @@ export class ProgressBackend {
       this.webviewBridge.clearStream(stream);
     }
     const allDeleted = retainedStreams.size === 0;
+    if (allDeleted) {
+      this.presentation.reset();
+      this.releasePresentationLeases();
+    } else if (!retainedStreams.has(this.presentation.activeStream)) {
+      // The rebuild below chooses the ordered fallback, hydrates transcript
+      // and sidecar state, then persists it. Do not confirm before hydration.
+      this.presentation.select('');
+      this.releasePresentationLeases();
+    }
     this.lifecycle.cleanupDeletedStreams({ allDeleted });
     if (allDeleted) {
       this.postMessage({ command: PROGRESS_VIEW_COMMANDS.DELETE_ALL });
@@ -478,6 +680,8 @@ export class ProgressBackend {
       }
       if (!this.presentationReloadPending) return;
       this.state.resetAfterStorageRootChange();
+      this.presentation.reload();
+      this.releasePresentationLeases();
       this.webviewBridge.clearAll();
       try {
         await this.loadPresentationState();
@@ -548,6 +752,9 @@ export class ProgressBackend {
         (sessionEvent) => {
           if (sessionEvent.scope !== 'session') return;
           this.factApplier.handleSessionFact(sessionEvent.event);
+          if (sessionEvent.event.type === 'setActiveStream') {
+            this.handleStreamPresentationRequest(sessionEvent.event.payload);
+          }
         },
         { scope: 'session' },
       ),
@@ -572,6 +779,8 @@ export class ProgressBackend {
     this.disposed = true;
     for (const detach of this.detachEventListeners.splice(0)) detach();
     this.factApplier.dispose();
+    this.activationGeneration += 1;
+    this.releasePresentationLeases();
     this.webviewBridge.dispose();
   }
 }

--- a/src/controllers/progressView/backend/ProgressPresentationState.ts
+++ b/src/controllers/progressView/backend/ProgressPresentationState.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+
+// Local imports - platform
+import type { StateStore } from '@platform/interfaces';
+// Local imports - shared
+import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import {
+  PersistedState,
+  createBackendStorage,
+} from '@shared/state/PersistedState';
+
+/** Selected progress-view stream, or an empty string when none is selected. */
+type ActiveProgressStream = StreamTabId | '';
+
+const ProgressPresentationPrefsSchema = z.object({
+  activeStream: z
+    .union([StreamTabIdSchema, z.literal('')])
+    .prefault('') as z.ZodType<ActiveProgressStream>,
+});
+
+type ProgressPresentationPrefs = z.infer<
+  typeof ProgressPresentationPrefsSchema
+>;
+
+/**
+ * Persisted choices belonging to the progress presentation.
+ *
+ * This state is deliberately separate from the session: selecting a tab does
+ * not change a run, transcript, or execution. The existing workspace key is
+ * retained so upgrades preserve the user's last selected tab without a
+ * migration or a second persisted representation.
+ */
+export class ProgressPresentationState {
+  private readonly prefs: PersistedState<ProgressPresentationPrefs>;
+
+  constructor(storage: StateStore) {
+    this.prefs = new PersistedState(
+      createBackendStorage(storage),
+      WorkspaceStateKey.PROGRESS_VIEW_PREFS,
+      ProgressPresentationPrefsSchema,
+    );
+  }
+
+  get activeStream(): ActiveProgressStream {
+    return this.prefs.get('activeStream');
+  }
+
+  /** Persist one confirmed selection. Pending UI intent never enters here. */
+  select(stream: ActiveProgressStream): void {
+    if (this.activeStream === stream) return;
+    this.prefs.update({ activeStream: stream });
+  }
+
+  /**
+   * Keep the saved selection when it remains available; otherwise choose the
+   * first stream in the presentation's already-ordered roster.
+   */
+  choose(availableStreams: readonly StreamTabId[]): ActiveProgressStream {
+    const current = this.activeStream;
+    return availableStreams.includes(current)
+      ? current
+      : (availableStreams[0] ?? '');
+  }
+
+  reload(): void {
+    this.prefs.reload();
+  }
+
+  reset(): void {
+    this.prefs.reset();
+  }
+}

--- a/src/controllers/progressView/backend/ProgressStreamProjectionBuilder.ts
+++ b/src/controllers/progressView/backend/ProgressStreamProjectionBuilder.ts
@@ -1,0 +1,158 @@
+import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
+
+// Local imports - progress view
+import {
+  getDefaultProgressStreamControls,
+  type GetProgressStreamControls,
+} from '@controllers/progressView/progressStreamControls';
+// Local imports - session
+import {
+  buildStreamInfo,
+  buildStreamInfos,
+} from '@controllers/session/streamInfoUtils';
+import type { SessionState } from '@controllers/session/SessionState';
+import type { PresentedStreamId } from '@controllers/session/SessionRendererPort';
+// Local imports - shared
+import {
+  AgentCategory,
+  type StreamMetadata,
+  type StreamTabId,
+  type StreamTabInfo,
+  type SyncStreamContentPayload,
+} from '@shared/schemas';
+import { buildStreamMetadata } from '@shared/streams/streamMetadata';
+// Local imports - utilities
+import { mapToRecord } from '@utils/core';
+
+export interface ProjectedStreamMetadata {
+  readonly streamInfo: StreamTabInfo;
+  readonly streamState: StreamMetadata;
+}
+
+export interface ProjectedStreamRoster {
+  readonly streams: StreamTabInfo[];
+  readonly streamStates: Record<StreamTabId, StreamMetadata>;
+}
+
+/**
+ * Projection boundary from hydrated session authority to immutable
+ * composite progress-view values. Simple event payloads stay on the narrow
+ * snapshot and follow-up store interfaces consumed by the renderer.
+ */
+export class ProgressStreamProjectionBuilder {
+  constructor(
+    private readonly state: SessionState,
+    private readonly getStreamControls: GetProgressStreamControls = getDefaultProgressStreamControls,
+  ) {}
+
+  streamMetadata(
+    streamId: StreamTabId,
+    streamStates?: Map<StreamTabId, StreamPhaseState>,
+    activeStream: PresentedStreamId = '',
+  ): ProjectedStreamMetadata {
+    const streamInfo = buildStreamInfo(this.state, streamId, activeStream);
+    return {
+      streamInfo,
+      streamState: this.metadataFor(
+        streamInfo,
+        streamStates ?? this.state.streamStatus.getAllStreamStates(),
+      ),
+    };
+  }
+
+  streamRoster(
+    activeStream: PresentedStreamId,
+    streamStates?: Map<StreamTabId, StreamPhaseState>,
+  ): ProjectedStreamRoster {
+    const streams = buildStreamInfos(this.state, activeStream);
+    const states = streamStates ?? this.state.streamStatus.getAllStreamStates();
+    const projected: Record<StreamTabId, StreamMetadata> = {};
+    for (const streamInfo of streams) {
+      projected[streamInfo.name] = this.metadataFor(streamInfo, states);
+    }
+    return { streams, streamStates: projected };
+  }
+
+  streamContent(
+    stream: StreamTabId,
+    includeActiveState: boolean,
+  ): SyncStreamContentPayload | undefined {
+    const existingState = this.state.getStreamState(stream);
+    const category =
+      this.state.getStreamMetadata(stream).agentCategory ??
+      existingState?.category;
+    if (category === undefined) return undefined;
+
+    const executionState = includeActiveState
+      ? this.state.getOrCreateStreamState(stream, category)
+      : undefined;
+    const activeState = executionState
+      ? {
+          conversationProgress: executionState.conversationProgress,
+          stage: executionState.stage ?? null,
+          badges: { subagents: executionState.subagents },
+        }
+      : undefined;
+    const shared = {
+      action: 'render' as const,
+      stream,
+      runUsage: mapToRecord(this.state.snapshots.getRunUsage(stream)),
+      ...(activeState ? { activeState } : {}),
+    };
+
+    if (category === AgentCategory.Workflow) {
+      return {
+        ...shared,
+        category,
+        outputs: {
+          files: this.state.snapshots.getOutputFiles(stream),
+          missing: this.state.snapshots.getMissingOutputs(stream),
+          compileFailures: this.state.snapshots.getCompileFailures(stream),
+        },
+      };
+    }
+
+    const { todos, plan } = this.state.snapshots.getWorkPlan(stream);
+    const controls = this.getStreamControls(stream);
+    return {
+      ...shared,
+      category,
+      workPlan: {
+        todos,
+        plan,
+        queuedFollowUps: this.state.followUps.getAll(stream),
+      },
+      controls: {
+        bashBypass: controls.bashBypass,
+        toolEditBypass: controls.toolEditBypass,
+        superYoloBypass: controls.superYoloBypass,
+        goal: controls.goalActive
+          ? {
+              active: true,
+              status: controls.goalStatus,
+              objective: controls.goalObjective,
+            }
+          : { active: false },
+      },
+    };
+  }
+
+  private metadataFor(
+    streamInfo: StreamTabInfo,
+    streamStates?: Map<StreamTabId, StreamPhaseState>,
+  ): StreamMetadata {
+    const current = this.state.getStreamState(streamInfo.name);
+    const status = streamStates?.get(streamInfo.name);
+    return buildStreamMetadata({
+      category: streamInfo.agentCategory,
+      status: status?.phase,
+      substate: status?.substate,
+      userFollowUpSupport: streamInfo.userFollowUpSupport,
+      lastTimestamp: this.state.streamLogs.getTimestampRange(streamInfo.name)
+        .last,
+      conversationProgress: current?.conversationProgress,
+      stage: current?.stage,
+      subagents: current?.subagents,
+    });
+  }
+}

--- a/src/controllers/progressView/backend/WebviewUpdater.ts
+++ b/src/controllers/progressView/backend/WebviewUpdater.ts
@@ -1,15 +1,9 @@
-import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
-import {
-  buildStreamInfo,
-  buildStreamInfos,
-  type StreamInfoListSource,
-  type StreamInfoSource,
-} from '@controllers/session/streamInfoUtils';
 import type {
-  ActiveStreamId,
-  SessionState,
-  StreamBadgeSnapshot,
-} from '@controllers/session/SessionState';
+  ProjectedStreamMetadata,
+  ProjectedStreamRoster,
+} from '@controllers/progressView/backend/ProgressStreamProjectionBuilder';
+import type { StreamBadgeSnapshot } from '@controllers/session/SessionState';
+import type { PresentedStreamId } from '@controllers/session/SessionRendererPort';
 import type { ApprovalBypassKind } from '@shared/approvalBypassKind';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type {
@@ -22,28 +16,16 @@ import type {
   ProgressViewPlacement,
   ProgressViewOutboundMessage,
   RoundIndexed,
-  StreamMetadata,
   StreamPhase,
   StreamStage,
   StreamSubstate,
   StreamTabId,
-  StreamTabInfo,
   Plan,
   TodoItem,
   SyncStreamContentPayload,
   TokenUsageStats,
 } from '@shared/schemas';
-import { buildStreamMetadata } from '@shared/streams/streamMetadata';
 import type { GoalStatus } from '@shared/schemas/goal';
-
-/** The state one stream's wire metadata is projected from. */
-type StreamMetadataSource = StreamInfoSource &
-  Pick<SessionState, 'getStreamState' | 'streamLogs'>;
-
-/** The state a full stream-tabs refresh is projected from. */
-type StreamListMetadataSource = StreamMetadataSource &
-  StreamInfoListSource &
-  Pick<SessionState, 'rotateActiveStream'>;
 /**
  * Manages webview updates for the progress view.
  * Provides a clean interface for updating different parts of the webview
@@ -74,22 +56,12 @@ export class WebviewUpdater {
   }
 
   updateStreamMetadata(
-    state: StreamMetadataSource,
-    streamId: StreamTabId,
-    streamStates?: Map<StreamTabId, StreamPhaseState>,
-    options?: { activeStream?: ActiveStreamId },
+    projection: ProjectedStreamMetadata,
+    options?: { activeStream?: PresentedStreamId },
   ): void {
-    const streamInfo = buildStreamInfo(state, streamId);
-    const streamState = this.buildStreamMetadataForStream(
-      state,
-      streamInfo,
-      streamStates,
-    );
-
     this.sendMessage({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
-      streamInfo,
-      streamState,
+      ...projection,
       activeStream: options?.activeStream,
     });
   }
@@ -240,10 +212,30 @@ export class WebviewUpdater {
     });
   }
 
-  setActiveStream(activeStream: ActiveStreamId): void {
+  setActiveStream(activeStream: PresentedStreamId): void {
     this.sendMessage({
       command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
       activeStream,
+    });
+  }
+
+  settleStreamSelection(
+    requestId: string,
+    status: 'accepted' | 'rejected' | 'superseded',
+    activeStream: PresentedStreamId,
+  ): void {
+    this.sendMessage({
+      command: PROGRESS_VIEW_COMMANDS.SETTLE_STREAM_SELECTION,
+      requestId,
+      status,
+      activeStream,
+    });
+  }
+
+  releaseStreamContent(stream: StreamTabId): void {
+    this.sendMessage({
+      command: PROGRESS_VIEW_COMMANDS.RELEASE_STREAM_CONTENT,
+      stream,
     });
   }
 
@@ -322,81 +314,36 @@ export class WebviewUpdater {
 
   /**
    * Update stream metadata and theme for the webview.
-   * Returns the active stream after applying the update.
-   *
-   * Note: This method computes valid active stream via SessionState
-   * (single source of truth) and explicitly persists if changed.
-   *
    * Use this for structural updates (initial sync, stream add/remove).
    * For incremental updates, prefer targeted messages like:
    * setActiveStream(), updateConversationProgress(), updateStreamBadges(),
    * updateStreamStatus().
    */
   sendStreamMetadata(
-    state: StreamListMetadataSource,
-    streamStates?: Map<StreamTabId, StreamPhaseState>,
+    projection: ProjectedStreamRoster,
+    activeStream: PresentedStreamId,
     theme?: 'dark' | 'light',
-  ): ActiveStreamId {
-    const streams = buildStreamInfos(state);
-
-    // The previously-active stream may have finished while visible —
-    // setStreamStatus skipped release for the active tab, so the rotation
-    // below is what releases the completed log.
-    const activeStream = state.rotateActiveStream(
-      streams.map((info) => info.name),
-    );
-
+  ): void {
     if (!this.isAvailable()) {
-      return activeStream;
+      return;
     }
 
     if (theme) this.setTheme(theme);
-
-    // Send lightweight metadata — only backend-owned fields the frontend merges.
-    const streamMetadata: Record<StreamTabId, StreamMetadata> = {};
-    for (const streamInfo of streams) {
-      streamMetadata[streamInfo.name] = this.buildStreamMetadataForStream(
-        state,
-        streamInfo,
-        streamStates,
-      );
-    }
 
     // Full stream-tabs refresh, carrying the per-stream metadata patch.
     const unsupportedCommands = this.getUnsupportedCommands?.();
     this.sendMessage({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-      streams,
+      streams: projection.streams,
       activeStream,
       unsupportedCommands: unsupportedCommands
         ? [...unsupportedCommands]
         : undefined,
-      streamStates: streamMetadata,
+      streamStates: projection.streamStates,
     });
-
-    return activeStream;
   }
 
   isAvailable(): boolean {
     return this.hasTarget();
-  }
-
-  private buildStreamMetadataForStream(
-    state: StreamMetadataSource,
-    streamInfo: StreamTabInfo,
-    streamStates?: Map<StreamTabId, StreamPhaseState>,
-  ): StreamMetadata {
-    const current = state.getStreamState(streamInfo.name);
-    const streamState = streamStates?.get(streamInfo.name);
-    return buildStreamMetadata({
-      category: streamInfo.agentCategory,
-      status: streamState?.phase,
-      substate: streamState?.substate,
-      userFollowUpSupport: streamInfo.userFollowUpSupport,
-      lastTimestamp: state.streamLogs.getTimestampRange(streamInfo.name).last,
-      conversationProgress: current?.conversationProgress,
-      stage: current?.stage,
-      subagents: current?.subagents,
-    });
   }
 }

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -9,7 +9,6 @@ import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
 import type { SessionRendererPort } from '@controllers/session/SessionRendererPort';
 import {
   SessionState,
-  type ActiveStreamId,
   type StreamExecutionState,
 } from '@controllers/session/SessionState';
 import { withEventErrorHandling } from '@controllers/session/eventErrorHandling';
@@ -53,15 +52,7 @@ type RunFactHandlers = {
 };
 
 export type SessionFactApplierOptions = {
-  hasPendingPermissions: (streamId: string) => boolean;
   deleteStream: (stream: StreamTabId) => void | Promise<void>;
-  /**
-   * Set false to skip evicting the stream left behind on an active-stream
-   * switch. The CLI TUI needs this: its focus id is a CLI signal, not
-   * `SessionState.activeStream`, so switch-time eviction would key off the
-   * wrong stream. Defaults to evicting (Lit progress view behavior).
-   */
-  evictOnStreamSwitch?: boolean;
 };
 
 /**
@@ -69,9 +60,10 @@ export type SessionFactApplierOptions = {
  * a {@link SessionRendererPort}. Push policy (active-only, debounce, bridge)
  * lives in the host renderer.
  *
- * Attachment vs focus are separate deliveries: metadata (no `activeStream`)
- * registers a stream with the host; `onActiveStreamChanged` focuses. Do not
- * use `streamLogs.has` as a proxy for "host already has this tab" — the
+ * Attachment and focus are separate operations. This applier registers
+ * session facts; a host presentation decides whether an attachment should
+ * become its focused stream. Do not use `streamLogs.has` as a proxy for
+ * "host already has this tab" — the
  * transcript store outlives a renderer session (and can be warm from disk
  * before this host's in-memory tab map exists).
  */
@@ -164,7 +156,6 @@ export class SessionFactApplier {
     streamId: StreamTabId,
     options?: {
       streamStates?: Map<StreamTabId, StreamPhaseState>;
-      activeStream?: ActiveStreamId;
     },
   ): void {
     this.registeredWithRenderer.add(streamId);
@@ -255,16 +246,9 @@ export class SessionFactApplier {
     this.renderer.onParentStreamChanged(childStreamId, parentStreamId ?? null);
   }
 
-  private async handleSetActiveStream(
-    payload: SetActiveStreamPayload,
-  ): Promise<void> {
+  private handleSetActiveStream(payload: SetActiveStreamPayload): void {
     const { streamId, isRemote } = payload;
-    const evictPrevious = this.options.evictOnStreamSwitch !== false;
-    if (!streamId) {
-      this.state.switchActiveStream('', { evictPrevious });
-      this.renderer.onActiveStreamChanged('');
-      return;
-    }
+    if (!streamId) return;
 
     this.state.streamLogs.ensureStream(streamId);
     // Only pass fields the event actually knows; omitted fields retain the
@@ -287,65 +271,16 @@ export class SessionFactApplier {
     if (agentCategory) {
       this.state.getOrCreateStreamState(streamId, agentCategory);
     }
-    // Don't switch away from the current stream if it has pending permissions
-    // (retry, tool-edit, bash approval, or agent proposal) — the user needs to
-    // interact with the approval panel before losing sight of it.
-    // Background child streams (bash, codex) pass `suppressViewSwitch` so the
-    // tab appears without auto-switching the active view.
-    const currentStream = this.state.activeStream;
-    const shouldSwitch =
-      payload.suppressViewSwitch !== true &&
-      (!currentStream || !this.options.hasPendingPermissions(currentStream));
-    if (shouldSwitch) {
-      // The switch also releases the previously-active stream if it reached a
-      // terminal status while visible — setStreamStatus skips release for the
-      // active stream, so this is our only chance.
-      this.state.switchActiveStream(streamId, { evictPrevious });
-    }
-
     if (!this.renderer.isAvailable()) return;
 
-    // First delivery to *this* renderer (not `streamLogs.has`): register
-    // before rehydrate so signal hosts can mint a tab synchronously. Never
-    // pass `activeStream` here — flipping the visible tab before
-    // `ensureLoaded` races a newer activation that wins during the await.
+    // Register the attachment with this renderer. Transcript hydration and
+    // focus policy belong to the host presentation, not the session fact.
     const firstHostDelivery = !this.registeredWithRenderer.has(streamId);
     if (firstHostDelivery) {
       this.pushStreamMetadata(streamId, {
         streamStates: this.state.streamStatus.getAllStreamStates(),
       });
     }
-
-    // Rehydrate a potentially-evicted stream before syncing content, so the
-    // webview doesn't get an empty log. All synchronous state mutations are
-    // already done above; the await here only gates host delivery.
-    await this.state.streamLogs.ensureLoaded(streamId);
-
-    // A newer handleSetActiveStream may have resolved during our await and
-    // already taken over the active tab; skip delivery so we don't overwrite
-    // its content with stale data.
-    if (shouldSwitch && this.state.activeStream !== streamId) return;
-
-    // First host sighting: full metadata (optional `activeStream` for Lit).
-    // Later switches: cheap active-stream notify only. Always notify
-    // `onActiveStreamChanged` on switch so signal hosts that ignore
-    // metadata's `activeStream` option still focus.
-    if (firstHostDelivery) {
-      this.pushStreamMetadata(streamId, {
-        streamStates: this.state.streamStatus.getAllStreamStates(),
-        activeStream: shouldSwitch ? this.state.activeStream : undefined,
-      });
-    }
-    if (shouldSwitch) {
-      this.renderer.onActiveStreamChanged(streamId);
-    }
-    // Always sync content for the new stream so badges reach the webview —
-    // even when we suppress the view switch. (The parent edge itself rides
-    // `StreamTabInfo.parentStreamId` in the stream-metadata update.)
-    // includeActiveState is only relevant when this IS the active stream.
-    this.renderer.syncStreamContent(streamId, {
-      includeActiveState: shouldSwitch && !firstHostDelivery,
-    });
   }
 
   private handleGoalStateChanged(streamId: StreamTabId): void {
@@ -485,8 +420,9 @@ export class SessionFactApplier {
     // rehydrate can never overwrite a later phase.
     const rosterParents = this.state.recordChildPhase(streamId, status);
 
-    // Active phases keep the full log resident for runtime writes. Inactive,
-    // unfocused streams release heavy entries and rehydrate on demand.
+    // Active phases keep the full log resident for runtime writes. Terminal
+    // lifecycle requests release unconditionally; exact presentation and
+    // writer leases decide whether the store can satisfy it yet.
     if (isActivePhase(status)) {
       const requiresPersistentRehydrate =
         this.state.streamLogs.mode.kind === 'persistent' &&
@@ -501,7 +437,7 @@ export class SessionFactApplier {
     // any active-phase rehydrate and before inactive unfocused eviction —
     // summaries keep timestamps across release, but not the resident log head.
     const logHead = this.state.streamLogs.get(streamId)?.head ?? 0;
-    if (!isActivePhase(status) && streamId !== this.state.activeStream) {
+    if (!isActivePhase(status)) {
       this.state.streamLogs.requestEviction(streamId);
     }
 
@@ -532,20 +468,12 @@ export class SessionFactApplier {
     }
 
     if (isNewStream) {
-      if (!this.state.activeStream) {
-        this.state.switchActiveStream(streamId);
-      }
-      const activeStream =
-        !this.state.activeStream || this.state.activeStream === streamId
-          ? this.state.activeStream
-          : undefined;
       this.pushStreamMetadata(streamId, {
         streamStates: this.buildStreamStatesForRefresh(
           streamId,
           status,
           substate,
         ),
-        activeStream,
       });
     } else if (isNewRunningTransition) {
       this.pushStreamMetadata(streamId, {

--- a/src/controllers/session/SessionRendererPort.ts
+++ b/src/controllers/session/SessionRendererPort.ts
@@ -1,8 +1,5 @@
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
-import type {
-  ActiveStreamId,
-  StreamBadgeSnapshot,
-} from '@controllers/session/SessionState';
+import type { StreamBadgeSnapshot } from '@controllers/session/SessionState';
 import type {
   ConversationProgress,
   GoalStatus,
@@ -15,6 +12,9 @@ import type {
   TokenUsageStats,
   TodoItem,
 } from '@shared/schemas';
+
+/** A host presentation's focused stream, or no focused stream. */
+export type PresentedStreamId = StreamTabId | '';
 
 /**
  * Host-renderer notifications from {@link SessionFactApplier}.
@@ -32,7 +32,7 @@ export interface SessionRendererPort {
     streamId: StreamTabId,
     options?: {
       streamStates?: Map<StreamTabId, StreamPhaseState>;
-      activeStream?: ActiveStreamId;
+      activeStream?: PresentedStreamId;
     },
   ): void;
 
@@ -44,7 +44,7 @@ export interface SessionRendererPort {
     substate?: StreamSubstate,
   ): void;
 
-  onActiveStreamChanged(streamId: ActiveStreamId): void;
+  onActiveStreamChanged(streamId: PresentedStreamId): void;
 
   onStreamDescriptionChanged(streamId: StreamTabId, description: string): void;
 
@@ -107,7 +107,7 @@ export interface SessionRendererPort {
    * TUI no-ops (transcript projection is separate).
    */
   syncStreamContent(
-    stream: ActiveStreamId,
+    stream: PresentedStreamId,
     options?: { includeActiveState?: boolean },
   ): void;
 }

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -1,5 +1,3 @@
-import { z } from 'zod';
-
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import {
@@ -14,7 +12,6 @@ import {
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
 import { createSessionStores } from '@controllers/session/sessionStores';
-import type { StateStore } from '@platform/interfaces';
 import {
   type ActiveChildInfo,
   type ConversationProgress,
@@ -26,13 +23,7 @@ import {
   type UserFollowUpSupport,
   AgentCategory,
 } from '@shared/schemas';
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import {
-  PersistedState,
-  createBackendStorage,
-} from '@shared/state/PersistedState';
 import { compareByNewestCreationTime } from '@shared/streams/streamOrdering';
-import { isActivePhase } from '@shared/streams/streamStatus';
 import type { StreamLogStore, StreamSnapshotStore } from '@transcript';
 
 /**
@@ -82,16 +73,6 @@ interface StreamSessionState {
   provisionalCreationTimestamp: number;
 }
 
-/** Active stream identifier, or empty string when no stream is selected. */
-export type ActiveStreamId = StreamTabId | '';
-
-/** Schema for consolidated session presentation preferences. */
-const SessionPrefsSchema = z.object({
-  activeStream: z.string().prefault('') as z.ZodType<ActiveStreamId>,
-});
-
-type SessionPrefs = z.infer<typeof SessionPrefsSchema>;
-
 /**
  * Backend-owned ephemeral counters, updated during streaming.
  */
@@ -112,11 +93,11 @@ export interface StreamExecutionState {
 export type StreamBadgeSnapshot = Pick<StreamExecutionState, 'subagents'>;
 
 /**
- * Host-neutral session presentation state.
+ * Host-neutral session state.
  *
  * Coordinates two persistence stores — `streamLogs` (transcript) and
  * `snapshots` (all per-stream sidecar: output files, usage, todos, plan, and
- * meta) — plus ephemeral in-memory execution state and preferences. Workflow
+ * meta) — plus ephemeral in-memory execution state. Workflow
  * instructions live in the log stream (new runs write them directly; legacy
  * runs are backfilled there during load), not in separate progress-view state.
  */
@@ -129,9 +110,6 @@ export class SessionState {
   /** Atomic lifecycle owner across streamLogs, streamData, and executions. */
   readonly stores: SessionStores;
 
-  // -- Preferences ------------------------------------------------------------
-  private readonly _prefs: PersistedState<SessionPrefs>;
-
   // -- Ephemeral state (session-only, not persisted) --------------------------
   private readonly _streamStates = new Map<StreamTabId, StreamExecutionState>();
   private readonly _sessionState = new Map<StreamTabId, StreamSessionState>();
@@ -143,71 +121,16 @@ export class SessionState {
   private readonly session: SessionHandle;
 
   constructor(
-    storage: StateStore,
     session: SessionHandle = defaultSession(),
     stores?: SessionStores,
   ) {
     this.logger = createChannelTrace('SessionState');
     this.session = session;
     this.streamStatus = session.status;
-    this._prefs = new PersistedState(
-      createBackendStorage(storage),
-      WorkspaceStateKey.PROGRESS_VIEW_PREFS,
-      SessionPrefsSchema,
-    );
     this.streamLogs = session.transcripts;
     this.followUps = session.followUps;
     this.snapshots = session.snapshots;
     this.stores = stores ?? createSessionStores(session);
-  }
-
-  // -- Preferences ------------------------------------------------------------
-
-  get activeStream(): ActiveStreamId {
-    return this._prefs.get('activeStream');
-  }
-
-  /**
-   * Compute which stream should be active given available streams (pure query).
-   */
-  private pickValidActiveStream(availableStreams: StreamTabId[]): StreamTabId {
-    const current = this._prefs.get('activeStream');
-    if (availableStreams.includes(current)) {
-      return current;
-    }
-    return availableStreams[0] || current;
-  }
-
-  /**
-   * Release a previously-active stream's entries if its status is not
-   * in-flight. `SessionFactApplier.setStreamStatus` intentionally skips
-   * eviction for the active tab, so the switch below closes the loop on the
-   * stream being moved away from.
-   */
-  private releasePreviousActive(streamId: StreamTabId): void {
-    if (!isActivePhase(this.streamStatus.get(streamId))) {
-      this.streamLogs.requestEviction(streamId);
-    }
-  }
-
-  /**
-   * The single writer of the active tab: moves the selection to `next` and
-   * releases the tab left behind. There is no `activeStream` setter, so no
-   * switching path can forget the release above. `evictPrevious: false` is
-   * for hosts whose visible focus is not this active stream (the CLI TUI
-   * keys focus off its own signal), where the release would evict the wrong
-   * stream's transcript.
-   */
-  switchActiveStream(
-    next: ActiveStreamId,
-    options?: { evictPrevious?: boolean },
-  ): void {
-    const previous = this._prefs.get('activeStream');
-    if (previous === next) return;
-    this._prefs.update({ activeStream: next });
-    if (previous && options?.evictPrevious !== false) {
-      this.releasePreviousActive(previous);
-    }
   }
 
   /**
@@ -225,21 +148,6 @@ export class SessionState {
       }))
       .sort(compareByNewestCreationTime)
       .map((entry) => entry.name);
-  }
-
-  /**
-   * Re-select the active tab from the tabs currently offered, and switch to
-   * it. When nothing is selectable the tab is cleared rather than picked:
-   * `pickValidActiveStream`'s `[] || current` fallback would otherwise sticky
-   * on a stream the caller no longer shows.
-   */
-  rotateActiveStream(selectableStreams: StreamTabId[]): ActiveStreamId {
-    const next =
-      selectableStreams.length === 0
-        ? ''
-        : this.pickValidActiveStream(selectableStreams);
-    this.switchActiveStream(next);
-    return next;
   }
 
   // -- Ephemeral session state ------------------------------------------------
@@ -471,10 +379,6 @@ export class SessionState {
     this._sessionState.delete(stream);
     this._streamStates.delete(stream);
 
-    // Update active stream *after* deletion so keys() no longer includes it.
-    if (this._prefs.get('activeStream') === stream) {
-      this._prefs.update({ activeStream: this.topmostStreamTab() });
-    }
     return 'deleted';
   }
 
@@ -497,11 +401,6 @@ export class SessionState {
       this.streamStatus.clearStream(stream);
       this._sessionState.delete(stream);
       this._streamStates.delete(stream);
-    }
-    if (retainedStreams.size === 0) {
-      this._prefs.reset();
-    } else if (!retainedStreams.has(this._prefs.get('activeStream'))) {
-      this._prefs.update({ activeStream: this.topmostStreamTab() });
     }
     return deletion;
   }
@@ -531,14 +430,11 @@ export class SessionState {
 
     this.logger.info('[Persistence] Managers loaded');
 
-    this.validateActiveStream();
-
     this.logger.info('[Persistence] State load complete');
   }
 
   /** Drop workspace-scoped caches before loading a replacement storage root. */
   resetAfterStorageRootChange(): void {
-    this._prefs.reload();
     this._sessionState.clear();
     this._streamStates.clear();
   }
@@ -552,27 +448,4 @@ export class SessionState {
   }
 
   // -- Private helpers --------------------------------------------------------
-
-  /**
-   * The topmost (newest) visible stream tab, or '' when none exist.
-   *
-   * `streamLogs.keys()` is ascending by creation time (load() sorts by
-   * `firstTimestamp` ASC, session additions are appended), but the sidebar
-   * renders newest-first, so `.at(-1)` matches the topmost visible tab rather
-   * than the oldest one at the bottom.
-   */
-  private topmostStreamTab(): ActiveStreamId {
-    return this.streamLogs.keys().at(-1) ?? '';
-  }
-
-  /** Validate activeStream against available streams after load */
-  private validateActiveStream(): void {
-    const savedActiveStream = this._prefs.get('activeStream');
-    if (!savedActiveStream || !this.streamLogs.has(savedActiveStream)) {
-      const fallback = this.topmostStreamTab();
-      if (fallback !== savedActiveStream) {
-        this._prefs.update({ activeStream: fallback });
-      }
-    }
-  }
 }

--- a/src/controllers/session/streamInfoUtils.ts
+++ b/src/controllers/session/streamInfoUtils.ts
@@ -1,12 +1,12 @@
 import type { SessionState } from '@controllers/session/SessionState';
-import type { StreamTabInfo } from '@shared/schemas';
+import type { StreamTabId, StreamTabInfo } from '@shared/schemas';
 import { peekWorktreeInfo, resolveWorktreeInfo } from '@utils/git/worktreeInfo';
 import { buildStreamTabInfo } from './streamTabInfo';
 
 /** The state a single tab info is built from. */
 export type StreamInfoSource = Pick<
   SessionState,
-  'getStreamMetadata' | 'activeStream' | 'streamStatus'
+  'getStreamMetadata' | 'streamStatus'
 >;
 
 /** The state the full tab list is built from. */
@@ -17,6 +17,7 @@ export type StreamInfoListSource = StreamInfoSource &
 export function buildStreamInfo(
   state: StreamInfoSource,
   id: string,
+  activeStream?: StreamTabId | '',
 ): StreamTabInfo {
   const metadata = state.getStreamMetadata(id);
   const workingDirectory = metadata.config?.workingDirectory;
@@ -27,7 +28,7 @@ export function buildStreamInfo(
     // LRU holds 32 entries, so probing every historical stream on a metadata
     // rebuild thrashes the cache and spawns git per stream (#9959). Terminal
     // streams render their last-known value from the peek above, or nothing.
-    if (id === state.activeStream || state.streamStatus.isInFlight(id)) {
+    if (id === activeStream || state.streamStatus.isInFlight(id)) {
       // Fire-and-forget; the resolver owns TTL/in-flight de-duplication.
       void resolveWorktreeInfo(workingDirectory).catch(() => {
         /* best-effort chip enrichment */
@@ -43,8 +44,13 @@ export function buildStreamInfo(
 }
 
 /** Build metadata objects for all streams in the given state, newest first. */
-export function buildStreamInfos(state: StreamInfoListSource): StreamTabInfo[] {
+export function buildStreamInfos(
+  state: StreamInfoListSource,
+  activeStream?: StreamTabId | '',
+): StreamTabInfo[] {
   // selectableStreamNames() already returns newest-first, so the mapped
   // tab infos inherit that order without re-sorting.
-  return state.selectableStreamNames().map((id) => buildStreamInfo(state, id));
+  return state
+    .selectableStreamNames()
+    .map((id) => buildStreamInfo(state, id, activeStream));
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -141,6 +141,8 @@ export const PROGRESS_VIEW_COMMANDS = {
 
   UPDATE_STREAM_STATUS: 'updateStreamStatus',
   SET_ACTIVE_STREAM: 'setActiveStream',
+  SETTLE_STREAM_SELECTION: 'settleStreamSelection',
+  RELEASE_STREAM_CONTENT: 'releaseStreamContent',
   UPDATE_CONVERSATION_PROGRESS: 'updateConversationProgress',
   UPDATE_STAGE: 'updateStage',
   UPDATE_STREAM_BADGES: 'updateStreamBadges',

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -23,6 +23,7 @@ import {
   InquiryDropActionSchema,
   InquirySubmitActionSchema,
 } from '../inquiry';
+import { StreamTabIdSchema } from '../identifiers';
 import { AgentProposalSchema, UserQuestionAnswersSchema } from '../prompts';
 import { StreamScopedBaseSchema, streamScopedCommand } from './data';
 import { GettingStartedActionSchema } from '../mainView/state';
@@ -32,6 +33,12 @@ const TrimmedStringSchema = z
   .string()
   .transform((s) => s.trim())
   .pipe(z.string().min(1));
+
+const SwitchStreamMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.SWITCH_STREAM),
+  stream: z.union([StreamTabIdSchema, z.literal('')]),
+  requestId: z.string().min(1),
+});
 
 /** File action carrying the output file and an optional diff base. */
 function fileWithBaseCommand<T extends string>(command: T) {
@@ -267,7 +274,7 @@ export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
   [
     WebviewReadyMessageSchema,
     SwitchViewMessageSchema,
-    streamScopedCommand(PROGRESS_VIEW_COMMANDS.SWITCH_STREAM),
+    SwitchStreamMessageSchema,
     streamScopedCommand(PROGRESS_VIEW_COMMANDS.DELETE_STREAM),
     commandOnly(PROGRESS_VIEW_COMMANDS.DELETE_ALL),
     streamScopedCommand(PROGRESS_VIEW_COMMANDS.STOP_STREAM),

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -82,6 +82,18 @@ const SetActiveStreamMessageSchema = z.object({
   activeStream: z.union([StreamTabIdSchema, z.literal('')]),
 });
 
+const SettleStreamSelectionMessageSchema = z.strictObject({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.SETTLE_STREAM_SELECTION),
+  requestId: z.string().min(1),
+  status: z.enum(['accepted', 'rejected', 'superseded']),
+  activeStream: z.union([StreamTabIdSchema, z.literal('')]),
+});
+
+const ReleaseStreamContentMessageSchema = z.strictObject({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.RELEASE_STREAM_CONTENT),
+  stream: StreamTabIdSchema,
+});
+
 const UpdateConversationProgressMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_CONVERSATION_PROGRESS),
   progress: ConversationProgressSchema,
@@ -390,6 +402,8 @@ export const ProgressViewOutboundMessageSchema = z.discriminatedUnion(
     UpdateStreamsMessageSchema,
     UpdateStreamMetadataMessageSchema,
     SetActiveStreamMessageSchema,
+    SettleStreamSelectionMessageSchema,
+    ReleaseStreamContentMessageSchema,
     UpdateConversationProgressMessageSchema,
     UpdateStageMessageSchema,
     UpdateStreamBadgesMessageSchema,

--- a/src/test-kernel/architecture/sessionPresentationBoundary.vitest.ts
+++ b/src/test-kernel/architecture/sessionPresentationBoundary.vitest.ts
@@ -1,0 +1,31 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - test support
+import { REPO_ROOT, stripComments } from '../support/repoScan';
+
+function productionSource(path: string): string {
+  return stripComments(readFileSync(resolve(REPO_ROOT, path), 'utf8'));
+}
+
+describe('session and presentation ownership boundary', () => {
+  it('keeps selection and persisted presentation preferences out of SessionState', () => {
+    const source = productionSource('src/controllers/session/SessionState.ts');
+
+    expect(source).not.toMatch(/activeStream|PersistedState|presentation/i);
+  });
+
+  it('keeps focus policy and hydration reactions out of SessionFactApplier', () => {
+    const source = productionSource(
+      'src/controllers/session/SessionFactApplier.ts',
+    );
+
+    expect(source).not.toMatch(
+      /suppressViewSwitch|ensureVisible|hasPendingPermissions|onActiveStreamChanged|syncStreamContent/,
+    );
+  });
+});

--- a/src/test-kernel/architecture/transcriptResidencyLeaseSites.vitest.ts
+++ b/src/test-kernel/architecture/transcriptResidencyLeaseSites.vitest.ts
@@ -18,12 +18,10 @@ const SCAN_ROOTS = [
   'src',
 ] as const;
 
-/** Focus/runtime sites allowed to make a transcript resident. */
-const RESIDENCY_SITE_ALLOWLIST = new Set([
+/** Runtime sites allowed to perform ordinary transcript hydration. */
+const HYDRATION_SITE_ALLOWLIST = new Set([
   'packages/cli/src/chat/chatSessionController.ts',
   'packages/cli/src/chat/tui/state/subscribeStreamLog.ts',
-  'packages/desktop/src/main/desktopAgentExecution.ts',
-  'packages/extension/src/progressView/ProgressViewProvider.ts',
   'src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts',
   'src/agent/runtime/executeAgent.ts',
   'src/controllers/progressView/backend/ProgressBackend.ts',
@@ -31,10 +29,16 @@ const RESIDENCY_SITE_ALLOWLIST = new Set([
   'src/transcript/StreamLogStore.ts',
 ]);
 
+/** The progress coordinator is the sole production presentation lease owner. */
+const PRESENTATION_LEASE_SITE_ALLOWLIST = new Set([
+  'src/controllers/progressView/backend/ProgressBackend.ts',
+  'src/transcript/StreamLogStore.ts',
+]);
+
 describe('transcript residency lease sites', () => {
   it('keeps transcript hydration at the closed focus/runtime boundary', () => {
     const offenders = SCAN_ROOTS.flatMap(productionFilesUnder)
-      .filter((file) => !RESIDENCY_SITE_ALLOWLIST.has(file))
+      .filter((file) => !HYDRATION_SITE_ALLOWLIST.has(file))
       .filter((file) =>
         /\.ensureLoaded\s*\(/.test(
           stripComments(readFileSync(resolve(REPO_ROOT, file), 'utf8')),
@@ -48,5 +52,18 @@ describe('transcript residency lease sites', () => {
         ? undefined
         : 'Use zero-residency readEntries() for one-shot reads; extend the allowlist only for a new focus/runtime owner.',
     ).toEqual([]);
+  });
+
+  it('keeps exact presentation residency at the progress coordinator boundary', () => {
+    const offenders = SCAN_ROOTS.flatMap(productionFilesUnder)
+      .filter((file) => !PRESENTATION_LEASE_SITE_ALLOWLIST.has(file))
+      .filter((file) =>
+        /retainForPresentation\s*:\s*true/.test(
+          stripComments(readFileSync(resolve(REPO_ROOT, file), 'utf8')),
+        ),
+      )
+      .toSorted();
+
+    expect(offenders).toEqual([]);
   });
 });

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -186,7 +186,11 @@ describe('createProgressViewCommandHandlers', () => {
     const handlers = createProgressViewCommandHandlers(actions);
 
     expectDispatched(
-      { command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM, stream: 'stream-a' },
+      {
+        command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
+        stream: 'stream-a',
+        requestId: 'request-a',
+      },
       handlers,
     );
     expectDispatched(
@@ -199,7 +203,10 @@ describe('createProgressViewCommandHandlers', () => {
       handlers,
     );
 
-    expect(actions.lifecycle.setActiveStream).toHaveBeenCalledWith('stream-a');
+    expect(actions.lifecycle.setActiveStream).toHaveBeenCalledWith(
+      'stream-a',
+      'request-a',
+    );
     expect(actions.lifecycle.deleteStream).toHaveBeenCalledWith('stream-b');
     expect(actions.lifecycle.deleteAllStreams).toHaveBeenCalledWith();
     expect(actions.lifecycle.stopStream).toHaveBeenCalledWith('stream-c');

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -1931,10 +1931,6 @@ describe('DesktopProgressBridge', () => {
         activeStream: 'third',
         command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
       },
-      {
-        activeStream: 'third',
-        command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
-      },
     ]);
     expect(lastContentSync(messages)).toMatchObject({ stream: 'third' });
   });
@@ -1960,8 +1956,12 @@ describe('DesktopProgressBridge', () => {
         activeStream: 'second',
         command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
       },
+      {
+        activeStream: 'first',
+        command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      },
     ]);
-    expect(lastStreamSync(messages)).toMatchObject({ activeStream: 'first' });
+    expect(lastContentSync(messages)).toMatchObject({ stream: 'first' });
   });
 
   it('emits delete-all cleanup before syncing an empty stream list', async () => {
@@ -2022,7 +2022,9 @@ describe('DesktopProgressBridge', () => {
     await deleteAllStreamsViaInbound(bridge);
     await settleProgressEvents();
 
-    expect(lastStreamSync(messages)).toMatchObject({
+    expect(lastStreamSync(messages)).toMatchObject({ activeStream: '' });
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
       activeStream: retainedStream,
     });
     expect(

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.ts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.ts
@@ -114,11 +114,13 @@ describe('desktop Progress IPC', () => {
       ipc.handleMessage({
         command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
         stream: 'run-1',
+        requestId: 'request-1',
       }),
     ).toBe(true);
     expect(switchStream).toHaveBeenCalledWith({
       command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
       stream: 'run-1',
+      requestId: 'request-1',
     });
   });
 
@@ -136,6 +138,7 @@ describe('desktop Progress IPC', () => {
       ipc.handleMessage({
         command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
         stream: 'run-1',
+        requestId: 'request-2',
       }),
     ).toBe(true);
     await Promise.resolve();
@@ -144,6 +147,7 @@ describe('desktop Progress IPC', () => {
     expect(switchStream).toHaveBeenCalledWith({
       command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
       stream: 'run-1',
+      requestId: 'request-2',
     });
   });
 
@@ -198,6 +202,7 @@ describe('desktop Progress IPC', () => {
       ipc.handleMessage({
         command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
         stream: 'run-1',
+        requestId: 'request-3',
       }),
     ).toBe(true);
     await Promise.resolve();

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts
@@ -388,10 +388,12 @@ describe('desktop main-view IPC', () => {
     sendFromRenderer({
       command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
       stream: 'run-1',
+      requestId: 'request-1',
     });
     expect(progress.handleMessage).toHaveBeenCalledWith({
       command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
       stream: 'run-1',
+      requestId: 'request-1',
     });
   });
 

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -131,8 +131,11 @@ describe('ProgressBackend', () => {
     seedHistoryStreams(backend, 20);
 
     backend.webviewUpdater.sendStreamMetadata(
-      backend.state,
-      backend.state.streamStatus.getAllStreamStates(),
+      backend.projections.streamRoster(
+        backend.presentation.activeStream,
+        backend.state.streamStatus.getAllStreamStates(),
+      ),
+      backend.presentation.activeStream,
     );
 
     expect(
@@ -158,7 +161,9 @@ describe('ProgressBackend', () => {
       streamId: 'root',
       agentCategory: AgentCategory.Workflow,
     });
-    await vi.waitFor(() => expect(backend.state.activeStream).toBe('root'));
+    await vi.waitFor(() =>
+      expect(backend.presentation.activeStream).toBe('root'),
+    );
     messages.length = 0;
 
     emitActiveStream(target, {
@@ -172,7 +177,7 @@ describe('ProgressBackend', () => {
         backend.state.streamLogs.has('hidden-approval' as StreamTabId),
       ).toBe(true),
     );
-    expect(backend.state.activeStream).toBe('root');
+    expect(backend.presentation.activeStream).toBe('root');
     expect(messages).toContainEqual(
       expect.objectContaining({
         command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
@@ -191,7 +196,9 @@ describe('ProgressBackend', () => {
       streamId: 'root',
       agentCategory: AgentCategory.ToolUse,
     });
-    await vi.waitFor(() => expect(backend.state.activeStream).toBe('root'));
+    await vi.waitFor(() =>
+      expect(backend.presentation.activeStream).toBe('root'),
+    );
     emitActiveStream(target, {
       streamId: run,
       agentCategory: AgentCategory.Workflow,
@@ -213,7 +220,7 @@ describe('ProgressBackend', () => {
 
     // The parent's viewport reads this row, so the push must reach a stream
     // that is not the active one.
-    expect(backend.state.activeStream).toBe('root');
+    expect(backend.presentation.activeStream).toBe('root');
     await vi.waitFor(() =>
       expect(backend.state.getStreamState(run)).toMatchObject({
         stage: { kind: 'phase', label: 'Reduce', index: 1, total: 3 },
@@ -298,8 +305,11 @@ describe('ProgressBackend', () => {
     messages.length = 0;
 
     backend.webviewUpdater.sendStreamMetadata(
-      backend.state,
-      backend.state.streamStatus.getAllStreamStates(),
+      backend.projections.streamRoster(
+        backend.presentation.activeStream,
+        backend.state.streamStatus.getAllStreamStates(),
+      ),
+      backend.presentation.activeStream,
     );
     const fullSync = fullSyncFrom(messages);
 
@@ -321,9 +331,9 @@ describe('ProgressBackend', () => {
     });
 
     await vi.waitFor(() =>
-      expect(first.backend.state.activeStream).toBe(firstStream),
+      expect(first.backend.presentation.activeStream).toBe(firstStream),
     );
-    expect(second.backend.state.activeStream).not.toBe(firstStream);
+    expect(second.backend.presentation.activeStream).not.toBe(firstStream);
     expect(JSON.stringify(second.messages)).not.toContain(firstStream);
 
     emitActiveStream(second, {
@@ -332,9 +342,9 @@ describe('ProgressBackend', () => {
     });
 
     await vi.waitFor(() =>
-      expect(second.backend.state.activeStream).toBe(secondStream),
+      expect(second.backend.presentation.activeStream).toBe(secondStream),
     );
-    expect(first.backend.state.activeStream).toBe(firstStream);
+    expect(first.backend.presentation.activeStream).toBe(firstStream);
     expect(JSON.stringify(first.messages)).not.toContain(secondStream);
   });
 
@@ -475,10 +485,10 @@ describe('ProgressBackend', () => {
     });
 
     await vi.waitFor(() =>
-      expect(first.backend.state.activeStream).toBe(firstStream),
+      expect(first.backend.presentation.activeStream).toBe(firstStream),
     );
     await vi.waitFor(() =>
-      expect(second.backend.state.activeStream).toBe(secondStream),
+      expect(second.backend.presentation.activeStream).toBe(secondStream),
     );
 
     expect(first.backend.state.streamStatus.get(firstStream)).toBe(
@@ -575,6 +585,9 @@ describe('ProgressBackend', () => {
       streamId,
       agentCategory: AgentCategory.Workflow,
     });
+    await vi.waitFor(() =>
+      expect(backend.presentation.activeStream).toBe(streamId),
+    );
     for (const spy of [
       updateFiles,
       updateMissingOutputs,
@@ -777,7 +790,7 @@ describe('ProgressBackend', () => {
     });
 
     await vi.waitFor(() =>
-      expect(backend.state.activeStream).toBe(parentStreamId),
+      expect(backend.presentation.activeStream).toBe(parentStreamId),
     );
     messages.length = 0;
 
@@ -854,7 +867,7 @@ describe('ProgressBackend', () => {
       agentCategory: AgentCategory.ToolUse,
     });
     backend.state.getOrCreateStreamState('tool-stream', AgentCategory.ToolUse);
-    backend.state.switchActiveStream('tool-stream');
+    backend.presentation.select('tool-stream');
 
     await backend.applyStreamStatus('unknown-stream', STREAM_PHASE.RUNNING);
 
@@ -863,7 +876,7 @@ describe('ProgressBackend', () => {
         message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
         message.streamInfo.name === 'unknown-stream',
     );
-    expect(backend.state.activeStream).toBe('tool-stream');
+    expect(backend.presentation.activeStream).toBe('tool-stream');
     expect(patch).toMatchObject({
       activeStream: undefined,
       streamInfo: {
@@ -957,7 +970,7 @@ describe('ProgressBackend', () => {
 
     try {
       backend.state.streamLogs.ensureStream(focused);
-      backend.state.switchActiveStream(focused);
+      backend.presentation.select(focused);
       backend.state.streamLogs.ensureStream(background);
       backend.state.updateStreamMetadata(background, {
         agentCategory: AgentCategory.ToolUse,
@@ -1018,7 +1031,7 @@ describe('ProgressBackend', () => {
     try {
       await backend.state.snapshots.load([]);
       backend.state.streamLogs.ensureStream(stream);
-      backend.state.switchActiveStream(stream);
+      backend.presentation.select(stream);
       snapshotFacts(backend.state.snapshots).setRunConfig(
         stream,
         toolUseConfig('search', 'deepseekproT'),

--- a/src/test-kernel/progressView/ProgressBackendRetainedChildren.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendRetainedChildren.vitest.ts
@@ -60,7 +60,7 @@ describe('retained finished children', () => {
   function seedParent(backend: ProgressBackend): void {
     backend.state.streamLogs.ensureStream(PARENT);
     backend.state.getOrCreateStreamState(PARENT, AgentCategory.Workflow);
-    backend.state.switchActiveStream(PARENT);
+    backend.presentation.select(PARENT);
   }
 
   function parentRoster(backend: ProgressBackend): ActiveChildInfo[] {
@@ -105,7 +105,7 @@ describe('retained finished children', () => {
     const other = 'other-stream' as StreamTabId;
     backend.state.streamLogs.ensureStream(other);
     backend.state.getOrCreateStreamState(other, AgentCategory.ToolUse);
-    backend.state.switchActiveStream(other);
+    backend.presentation.select(other);
     messages.length = 0;
 
     applyRoster(backend, PARENT, []);
@@ -242,13 +242,18 @@ describe('retained finished children', () => {
     // frontend's other writer of `subagents`; it must overlay the stale row
     // with the authoritative status-machine outcome.
     backend.webviewUpdater.sendStreamMetadata(
-      backend.state,
-      backend.state.streamStatus.getAllStreamStates(),
+      backend.projections.streamRoster(
+        backend.presentation.activeStream,
+        backend.state.streamStatus.getAllStreamStates(),
+      ),
+      backend.presentation.activeStream,
     );
     backend.webviewUpdater.updateStreamMetadata(
-      backend.state,
-      PARENT,
-      backend.state.streamStatus.getAllStreamStates(),
+      backend.projections.streamMetadata(
+        PARENT,
+        backend.state.streamStatus.getAllStreamStates(),
+        backend.presentation.activeStream,
+      ),
     );
 
     const rosters = messages.flatMap((message) => {

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -91,7 +91,7 @@ describe('ProgressBackend', () => {
     );
   });
 
-  it('handles session facts through its local subscription', () => {
+  it('handles session facts through its local subscription', async () => {
     const target = createIsolatedRecordingBackend();
     const { backend } = target;
     backend.setupEventListeners();
@@ -102,7 +102,9 @@ describe('ProgressBackend', () => {
       agentCategory: AgentCategory.Workflow,
     });
 
-    expect(backend.state.activeStream).toBe(streamId);
+    await vi.waitFor(() =>
+      expect(backend.presentation.activeStream).toBe(streamId),
+    );
     expect(backend.state.streamLogs.has(streamId)).toBe(true);
   });
 
@@ -132,13 +134,17 @@ describe('ProgressBackend', () => {
     const { backend, messages } = target;
     backend.setupEventListeners();
 
-    backend.state.switchActiveStream('previous-stream');
+    backend.presentation.select('previous-stream');
     emitActiveStream(target, { streamId: null });
 
-    await vi.waitFor(() => expect(backend.state.activeStream).toBe(''));
+    await vi.waitFor(() => expect(backend.presentation.activeStream).toBe(''));
     expect(messages).toContainEqual({
       command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
       activeStream: '',
+    });
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.RELEASE_STREAM_CONTENT,
+      stream: 'previous-stream',
     });
   });
 
@@ -269,12 +275,12 @@ describe('ProgressBackend', () => {
 
     backend.state.streamLogs.ensureStream(first);
     backend.state.streamLogs.ensureStream(second);
-    backend.state.switchActiveStream(second);
+    backend.presentation.select(second);
 
     await backend.deleteStream(second);
 
     expect(lifecycle.cleanupDeletedStream).toHaveBeenCalledWith(second);
-    expect(backend.state.activeStream).toBe(first);
+    expect(backend.presentation.activeStream).toBe(first);
     expect(messages).toContainEqual({
       command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
       stream: second,
@@ -285,7 +291,7 @@ describe('ProgressBackend', () => {
     });
   });
 
-  it('keeps the fallback selected when its transcript fails to load', async () => {
+  it('does not select a fallback whose transcript fails to load', async () => {
     const target = createIsolatedRecordingBackend();
     const { backend, messages, reportTranscriptLoadError } = target;
     const fallback = 'fallback-stream' as StreamTabId;
@@ -294,16 +300,16 @@ describe('ProgressBackend', () => {
 
     backend.state.streamLogs.ensureStream(fallback);
     backend.state.streamLogs.ensureStream(active);
-    backend.state.switchActiveStream(active);
+    backend.presentation.select(active);
     vi.spyOn(backend.state.streamLogs, 'ensureLoaded').mockRejectedValueOnce(
       loadError,
     );
 
     await backend.deleteStream(active);
 
-    expect(backend.state.activeStream).toBe(fallback);
+    expect(backend.presentation.activeStream).toBe('');
     expect(reportTranscriptLoadError).toHaveBeenCalledWith(loadError, fallback);
-    expect(messages).toContainEqual({
+    expect(messages).not.toContainEqual({
       command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
       activeStream: fallback,
     });
@@ -314,37 +320,206 @@ describe('ProgressBackend', () => {
     const { backend, messages, reportTranscriptLoadError } = target;
     const stream = 'hydration-race' as StreamTabId;
     const sidecarError = new Error('sidecar unavailable');
-    let finishTranscriptLoad!: () => void;
+    let rejectSidecarLoad!: () => void;
 
     backend.state.streamLogs.ensureStream(stream);
-    vi.spyOn(backend.state.streamLogs, 'ensureLoaded').mockImplementationOnce(
+    vi.spyOn(backend.state.snapshots, 'preload').mockImplementationOnce(
       () =>
-        new Promise<void>((resolve) => {
-          finishTranscriptLoad = resolve;
+        new Promise<void>((_resolve, reject) => {
+          rejectSidecarLoad = () => reject(sidecarError);
         }),
-    );
-    vi.spyOn(backend.state.snapshots, 'preload').mockRejectedValueOnce(
-      sidecarError,
     );
 
     const activation = backend.activateStream(stream);
     await Promise.resolve();
     expect(reportTranscriptLoadError).not.toHaveBeenCalled();
 
-    finishTranscriptLoad();
+    rejectSidecarLoad();
     await activation;
 
     expect(reportTranscriptLoadError).toHaveBeenCalledWith(
       sidecarError,
       stream,
     );
+    expect(messages).not.toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: stream,
+    });
+  });
+
+  it('selects the newest available stream on an authoritative fresh sync', async () => {
+    const { backend, messages } = createIsolatedRecordingBackend();
+    const stream = 'fresh-sync-stream' as StreamTabId;
+
+    backend.state.streamLogs.ensureStream(stream);
+    await backend.syncRenderedStreams({ syncActiveStream: true });
+
+    expect(backend.presentation.activeStream).toBe(stream);
     expect(messages).toContainEqual({
       command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
       activeStream: stream,
     });
   });
 
-  it('reports the stream whose full refresh fails after selection changes', async () => {
+  it('does not commit a stream deleted while its hydration is pending', async () => {
+    const { backend, messages } = createIsolatedRecordingBackend();
+    const stream = 'deleted-during-hydration' as StreamTabId;
+    let finishPreload!: () => void;
+
+    backend.state.streamLogs.ensureStream(stream);
+    vi.spyOn(backend.state.snapshots, 'preload').mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishPreload = resolve;
+        }),
+    );
+
+    const activation = backend.activateStream(stream, 'deleted-request');
+    await vi.waitFor(() => expect(finishPreload).toBeTypeOf('function'));
+    await backend.deleteStream(stream);
+    finishPreload();
+    await activation;
+
+    expect(backend.presentation.activeStream).toBe('');
+    expect(messages).not.toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: stream,
+    });
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SETTLE_STREAM_SELECTION,
+      requestId: 'deleted-request',
+      status: 'superseded',
+      activeStream: '',
+    });
+  });
+
+  it('invalidates older hydration when a newer selection is rejected', async () => {
+    const { backend, messages } = createIsolatedRecordingBackend();
+    const confirmed = 'confirmed-before-rejection' as StreamTabId;
+    const older = 'older-pending-selection' as StreamTabId;
+    let finishOlderPreload!: () => void;
+
+    backend.state.streamLogs.ensureStream(confirmed);
+    backend.state.streamLogs.ensureStream(older);
+    backend.presentation.select(confirmed);
+    vi.spyOn(backend.state.snapshots, 'preload').mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishOlderPreload = resolve;
+        }),
+    );
+
+    const olderActivation = backend.activateStream(older);
+    await vi.waitFor(() => expect(finishOlderPreload).toBeTypeOf('function'));
+    await backend.activateStream(
+      'already-deleted-selection' as StreamTabId,
+      'newer-rejected-request',
+    );
+    finishOlderPreload();
+    await olderActivation;
+
+    expect(backend.presentation.activeStream).toBe(confirmed);
+    expect(messages).not.toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: older,
+    });
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SETTLE_STREAM_SELECTION,
+      requestId: 'newer-rejected-request',
+      status: 'rejected',
+      activeStream: confirmed,
+    });
+  });
+
+  it('lets explicit deselection supersede older hydration', async () => {
+    const { backend, messages } = createIsolatedRecordingBackend();
+    const stream = 'pending-before-deselection' as StreamTabId;
+    let finishPreload!: () => void;
+
+    backend.state.streamLogs.ensureStream(stream);
+    vi.spyOn(backend.state.snapshots, 'preload').mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishPreload = resolve;
+        }),
+    );
+
+    const activation = backend.activateStream(stream);
+    await vi.waitFor(() => expect(finishPreload).toBeTypeOf('function'));
+    await backend.activateStream('', 'deselection-request');
+    finishPreload();
+    await activation;
+
+    expect(backend.presentation.activeStream).toBe('');
+    expect(messages).not.toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: stream,
+    });
+  });
+
+  it('rejects a failed UI selection without changing the confirmed stream', async () => {
+    const target = createIsolatedRecordingBackend();
+    const { backend, messages, reportTranscriptLoadError } = target;
+    const confirmed = 'confirmed-stream' as StreamTabId;
+    const requested = 'requested-stream' as StreamTabId;
+    const requestId = 'selection-request-1';
+    const loadError = new Error('requested transcript unavailable');
+
+    backend.state.streamLogs.ensureStream(confirmed);
+    backend.state.streamLogs.ensureStream(requested);
+    backend.presentation.select(confirmed);
+    vi.spyOn(backend.state.streamLogs, 'ensureLoaded').mockRejectedValueOnce(
+      loadError,
+    );
+
+    await backend.activateStream(requested, requestId);
+
+    expect(backend.presentation.activeStream).toBe(confirmed);
+    expect(reportTranscriptLoadError).toHaveBeenCalledWith(
+      loadError,
+      requested,
+    );
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SETTLE_STREAM_SELECTION,
+      requestId,
+      status: 'rejected',
+      activeStream: confirmed,
+    });
+    expect(messages).not.toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: requested,
+    });
+  });
+
+  it('releases inactive frontend content only after the new selection commits', async () => {
+    const { backend, messages } = createIsolatedRecordingBackend();
+    const previous = 'previous-stream' as StreamTabId;
+    const selected = 'selected-stream' as StreamTabId;
+
+    backend.state.streamLogs.ensureStream(previous);
+    backend.state.streamLogs.ensureStream(selected);
+    await backend.activateStream(previous);
+    messages.length = 0;
+
+    await backend.activateStream(selected, 'selection-request-2');
+
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: selected,
+    });
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.RELEASE_STREAM_CONTENT,
+      stream: previous,
+    });
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SETTLE_STREAM_SELECTION,
+      requestId: 'selection-request-2',
+      status: 'accepted',
+      activeStream: selected,
+    });
+  });
+
+  it('ignores a stale refresh failure after a newer selection commits', async () => {
     const target = createIsolatedRecordingBackend();
     const { backend, reportTranscriptLoadError } = target;
     const refreshing = 'refreshing-stream' as StreamTabId;
@@ -354,23 +529,71 @@ describe('ProgressBackend', () => {
 
     backend.state.streamLogs.ensureStream(refreshing);
     backend.state.streamLogs.ensureStream(selected);
-    backend.state.switchActiveStream(refreshing);
+    backend.presentation.select(refreshing);
     vi.spyOn(backend.state.streamLogs, 'ensureLoaded').mockImplementationOnce(
       () =>
-        new Promise<void>((_resolve, reject) => {
+        new Promise((_resolve, reject) => {
           rejectRefresh = reject;
         }),
     );
 
     const refresh = backend.syncRenderedStreams({ syncActiveStream: true });
-    backend.state.switchActiveStream(selected);
+    await backend.activateStream(selected);
     rejectRefresh(loadError);
     await refresh;
 
-    expect(reportTranscriptLoadError).toHaveBeenCalledWith(
-      loadError,
-      refreshing,
+    expect(backend.presentation.activeStream).toBe(selected);
+    expect(reportTranscriptLoadError).not.toHaveBeenCalled();
+  });
+
+  it('preserves an in-flight switch across an authoritative refresh', async () => {
+    const { backend, messages } = createIsolatedRecordingBackend();
+    const confirmed = 'confirmed-before-refresh' as StreamTabId;
+    const requested = 'pending-across-refresh' as StreamTabId;
+    let finishPreload!: () => void;
+
+    backend.state.streamLogs.ensureStream(confirmed);
+    backend.state.streamLogs.ensureStream(requested);
+    backend.presentation.select(confirmed);
+    vi.spyOn(backend.state.snapshots, 'preload').mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishPreload = resolve;
+        }),
     );
+
+    const activation = backend.activateStream(requested, 'refresh-request');
+    await vi.waitFor(() => expect(finishPreload).toBeTypeOf('function'));
+    await backend.syncRenderedStreams({ syncActiveStream: true });
+    finishPreload();
+    await activation;
+
+    expect(backend.presentation.activeStream).toBe(requested);
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: requested,
+    });
+  });
+
+  it('projects the stream being hydrated without confirming it early', async () => {
+    const { backend, messages } = createIsolatedRecordingBackend();
+    const stream = 'fresh-projected-stream' as StreamTabId;
+    backend.state.streamLogs.ensureStream(stream);
+    const streamRoster = vi.spyOn(backend.projections, 'streamRoster');
+
+    await backend.syncRenderedStreams({ syncActiveStream: true });
+
+    expect(streamRoster).toHaveBeenCalledWith(stream, expect.any(Map));
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+        activeStream: '',
+      }),
+    );
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: stream,
+    });
   });
 
   it('releases the tab left behind when deletion rotates the selection', async () => {
@@ -385,14 +608,14 @@ describe('ProgressBackend', () => {
 
     backend.state.streamLogs.ensureStream(older);
     backend.state.streamLogs.ensureStream(active);
-    backend.state.switchActiveStream(active);
+    backend.presentation.select(active);
     requestEviction.mockClear();
 
     await backend.deleteStream(older);
 
     // `active` stays selected, so nothing is released; deleting the
     // non-selected tab only refreshes the list.
-    expect(backend.state.activeStream).toBe(active);
+    expect(backend.presentation.activeStream).toBe(active);
     expect(requestEviction).not.toHaveBeenCalled();
     expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
       syncActiveStream: false,
@@ -405,12 +628,12 @@ describe('ProgressBackend', () => {
     const only = 'only-stream' as StreamTabId;
 
     backend.state.streamLogs.ensureStream(only);
-    backend.state.switchActiveStream(only);
+    backend.presentation.select(only);
     const activateStream = vi.spyOn(backend, 'activateStream');
 
     await backend.deleteStream(only);
 
-    expect(backend.state.activeStream).toBe('');
+    expect(backend.presentation.activeStream).toBe('');
     expect(activateStream).not.toHaveBeenCalled();
     // No stream was activated, so only the stream list is resent.
     expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
@@ -443,14 +666,14 @@ describe('ProgressBackend', () => {
       agentCategory: AgentCategory.ToolUse,
     });
     backend.state.getOrCreateStreamState(selected, AgentCategory.ToolUse);
-    backend.state.switchActiveStream(active);
+    backend.presentation.select(active);
 
     const deletion = backend.deleteStream(active);
-    backend.state.switchActiveStream(selected);
+    backend.presentation.select(selected);
     releaseClear();
     await deletion;
 
-    expect(backend.state.activeStream).toBe(selected);
+    expect(backend.presentation.activeStream).toBe(selected);
     expect(messages).toContainEqual(
       expect.objectContaining({
         command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
@@ -462,6 +685,245 @@ describe('ProgressBackend', () => {
     expect(messages).toContainEqual({
       command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
       activeStream: selected,
+    });
+  });
+
+  it('recovers when an inactive stream becomes selected during deletion', async () => {
+    const { backend, messages } = createIsolatedRecordingBackend();
+    const fallback = 'surviving-fallback' as StreamTabId;
+    const deleting = 'selected-while-deleting' as StreamTabId;
+    const clearStream = backend.state.clearStream.bind(backend.state);
+    let releaseClear!: () => void;
+    const clearGate = new Promise<void>((resolve) => {
+      releaseClear = resolve;
+    });
+    vi.spyOn(backend.state, 'clearStream').mockImplementation(
+      async (stream) => {
+        await clearGate;
+        return clearStream(stream);
+      },
+    );
+
+    backend.state.streamLogs.ensureStream(fallback);
+    backend.state.streamLogs.ensureStream(deleting);
+    backend.presentation.select(fallback);
+
+    const deletion = backend.deleteStream(deleting);
+    await vi.waitFor(() =>
+      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting),
+    );
+    await backend.activateStream(deleting);
+    releaseClear();
+    await deletion;
+
+    expect(backend.presentation.activeStream).toBe(fallback);
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: fallback,
+    });
+  });
+
+  it('preserves explicit deselection during active-stream deletion', async () => {
+    const { backend, messages } = createIsolatedRecordingBackend();
+    const deleting = 'active-delete-in-progress' as StreamTabId;
+    const fallback = 'launcher-must-not-replace' as StreamTabId;
+    const clearStream = backend.state.clearStream.bind(backend.state);
+    let releaseClear!: () => void;
+    const clearGate = new Promise<void>((resolve) => {
+      releaseClear = resolve;
+    });
+    vi.spyOn(backend.state, 'clearStream').mockImplementation(
+      async (stream) => {
+        await clearGate;
+        return clearStream(stream);
+      },
+    );
+
+    backend.state.streamLogs.ensureStream(fallback);
+    backend.state.streamLogs.ensureStream(deleting);
+    backend.presentation.select(deleting);
+
+    const deletion = backend.deleteStream(deleting);
+    await vi.waitFor(() =>
+      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting),
+    );
+    backend.presentation.select('');
+    releaseClear();
+    await deletion;
+
+    expect(backend.presentation.activeStream).toBe('');
+    expect(messages).not.toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: fallback,
+    });
+  });
+
+  it('preserves a newer pending switch during active-stream deletion', async () => {
+    const { backend, messages } = createIsolatedRecordingBackend();
+    const deleting = 'active-being-deleted' as StreamTabId;
+    const fallback = 'older-roster-fallback' as StreamTabId;
+    const requested = 'newer-pending-switch' as StreamTabId;
+    const clearStream = backend.state.clearStream.bind(backend.state);
+    let releaseClear!: () => void;
+    let finishRequestedPreload!: () => void;
+    const clearGate = new Promise<void>((resolve) => {
+      releaseClear = resolve;
+    });
+    vi.spyOn(backend.state, 'clearStream').mockImplementation(
+      async (stream) => {
+        await clearGate;
+        return clearStream(stream);
+      },
+    );
+    vi.spyOn(backend.state.snapshots, 'preload').mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRequestedPreload = resolve;
+        }),
+    );
+
+    for (const stream of [fallback, requested, deleting]) {
+      backend.state.streamLogs.ensureStream(stream);
+    }
+    backend.presentation.select(deleting);
+
+    const deletion = backend.deleteStream(deleting);
+    await vi.waitFor(() =>
+      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting),
+    );
+    const activation = backend.activateStream(requested, 'pending-request');
+    await vi.waitFor(() =>
+      expect(finishRequestedPreload).toBeTypeOf('function'),
+    );
+    releaseClear();
+    await deletion;
+    finishRequestedPreload();
+    await activation;
+
+    expect(backend.presentation.activeStream).toBe(requested);
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: requested,
+    });
+    expect(messages).not.toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: fallback,
+    });
+  });
+
+  it('recovers once when a pending replacement fails after deletion', async () => {
+    const target = createIsolatedRecordingBackend();
+    const { backend, messages, reportTranscriptLoadError } = target;
+    const deleting = 'active-before-failed-switch' as StreamTabId;
+    const requested = 'failed-pending-switch' as StreamTabId;
+    const fallback = 'recovery-survivor' as StreamTabId;
+    const loadError = new Error('replacement hydration failed');
+    let rejectRequestedPreload!: (error: Error) => void;
+    let releaseClear!: () => void;
+    const clearGate = new Promise<void>((resolve) => {
+      releaseClear = resolve;
+    });
+    const clearStream = backend.state.clearStream.bind(backend.state);
+    vi.spyOn(backend.state, 'clearStream').mockImplementation(
+      async (stream) => {
+        await clearGate;
+        return clearStream(stream);
+      },
+    );
+
+    for (const stream of [fallback, requested, deleting]) {
+      backend.state.streamLogs.ensureStream(stream);
+    }
+    backend.presentation.select(deleting);
+    vi.spyOn(backend.state.snapshots, 'preload').mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectRequestedPreload = reject;
+        }),
+    );
+
+    const deletion = backend.deleteStream(deleting);
+    await vi.waitFor(() =>
+      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting),
+    );
+    const activation = backend.activateStream(requested, 'failed-request');
+    await vi.waitFor(() =>
+      expect(rejectRequestedPreload).toBeTypeOf('function'),
+    );
+    releaseClear();
+    await deletion;
+    rejectRequestedPreload(loadError);
+    await activation;
+
+    expect(reportTranscriptLoadError).toHaveBeenCalledWith(
+      loadError,
+      requested,
+    );
+    expect(backend.presentation.activeStream).toBe(fallback);
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: fallback,
+    });
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SETTLE_STREAM_SELECTION,
+      requestId: 'failed-request',
+      status: 'rejected',
+      activeStream: fallback,
+    });
+  });
+
+  it('preserves the newest of two switches during active-stream deletion', async () => {
+    const { backend, messages } = createIsolatedRecordingBackend();
+    const deleting = 'active-before-two-switches' as StreamTabId;
+    const committed = 'first-concurrent-switch' as StreamTabId;
+    const requested = 'second-pending-switch' as StreamTabId;
+    const clearStream = backend.state.clearStream.bind(backend.state);
+    let releaseClear!: () => void;
+    let finishRequestedPreload!: () => void;
+    const clearGate = new Promise<void>((resolve) => {
+      releaseClear = resolve;
+    });
+    vi.spyOn(backend.state, 'clearStream').mockImplementation(
+      async (stream) => {
+        await clearGate;
+        return clearStream(stream);
+      },
+    );
+
+    for (const stream of [committed, requested, deleting]) {
+      backend.state.streamLogs.ensureStream(stream);
+    }
+    backend.presentation.select(deleting);
+
+    const deletion = backend.deleteStream(deleting);
+    await vi.waitFor(() =>
+      expect(backend.state.clearStream).toHaveBeenCalledWith(deleting),
+    );
+    await backend.activateStream(committed);
+    vi.spyOn(backend.state.snapshots, 'preload').mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRequestedPreload = resolve;
+        }),
+    );
+    const activation = backend.activateStream(requested, 'newest-request');
+    await vi.waitFor(() =>
+      expect(finishRequestedPreload).toBeTypeOf('function'),
+    );
+    releaseClear();
+    await deletion;
+    finishRequestedPreload();
+    await activation;
+
+    expect(backend.presentation.activeStream).toBe(requested);
+    expect(
+      messages.findLast(
+        (message) =>
+          message.command === PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      ),
+    ).toEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: requested,
     });
   });
 
@@ -487,6 +949,62 @@ describe('ProgressBackend', () => {
       syncActiveStream: false,
     });
     expect(lifecycle.notifyDeletionRetained).not.toHaveBeenCalled();
+  });
+
+  it('defers a retained bulk fallback until the rebuild hydrates it', async () => {
+    const { backend, lifecycle } = createIsolatedRecordingBackend();
+    const first = 'retained-first' as StreamTabId;
+    const second = 'retained-second' as StreamTabId;
+    backend.state.streamLogs.ensureStream(first);
+    backend.state.streamLogs.ensureStream(second);
+    backend.presentation.select('deleted-selection');
+    stubClearAll(backend, new Set([first, second]));
+
+    await backend.deleteAllStreams();
+
+    expect(backend.presentation.activeStream).toBe('');
+    expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
+      syncActiveStream: true,
+    });
+  });
+
+  it('preserves a pending switch to a stream retained by bulk deletion', async () => {
+    const { backend, lifecycle } = createIsolatedRecordingBackend();
+    const deleting = 'bulk-active-delete' as StreamTabId;
+    const requested = 'bulk-retained-request' as StreamTabId;
+    let finishClear!: () => void;
+    let finishPreload!: () => void;
+    const clearGate = new Promise<void>((resolve) => {
+      finishClear = resolve;
+    });
+
+    backend.state.streamLogs.ensureStream(deleting);
+    backend.state.streamLogs.ensureStream(requested);
+    backend.presentation.select(deleting);
+    vi.spyOn(backend.state, 'clearAll').mockImplementation(async () => {
+      await clearGate;
+      return { active: new Set([requested]), failed: new Set() };
+    });
+
+    const deletion = backend.deleteAllStreams();
+    await vi.waitFor(() => expect(backend.state.clearAll).toHaveBeenCalled());
+    vi.spyOn(backend.state.snapshots, 'preload').mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishPreload = resolve;
+        }),
+    );
+    const activation = backend.activateStream(requested, 'bulk-request');
+    await vi.waitFor(() => expect(finishPreload).toBeTypeOf('function'));
+    finishClear();
+    await deletion;
+    finishPreload();
+    await activation;
+
+    expect(backend.presentation.activeStream).toBe(requested);
+    expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
+      syncActiveStream: false,
+    });
   });
 
   it('stops locally owned streams before bulk cleanup', async () => {
@@ -685,7 +1203,7 @@ describe('ProgressBackend', () => {
     });
     await Promise.resolve();
 
-    expect(backend.state.activeStream).toBe('');
+    expect(backend.presentation.activeStream).toBe('');
     expect(messages).toEqual([]);
   });
 
@@ -703,7 +1221,7 @@ describe('ProgressBackend', () => {
     });
     await Promise.resolve();
 
-    expect(backend.state.activeStream).toBe('');
+    expect(backend.presentation.activeStream).toBe('');
     expect(messages).toEqual([]);
   });
 });

--- a/src/test-kernel/progressView/ProgressViewStoresWiring.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewStoresWiring.vitest.ts
@@ -8,12 +8,11 @@ import { describe, expect, it } from 'vitest';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { SessionState } from '@controllers/session/SessionState';
 import type { StreamTabId } from '@shared/schemas';
-import { FakeStateStore } from '@test/support/FakePlatform';
 
 describe('SessionState session-store wiring', () => {
   it('clears session status for a stores-initiated canonical deletion', async () => {
     const session = defaultSession();
-    const state = new SessionState(new FakeStateStore());
+    const state = new SessionState();
     const stream = 'swept-stream' as StreamTabId;
     session.transcripts.ensureStream(stream);
     expect(session.status.tryAcquire(stream)).toBe(true);

--- a/src/test-kernel/progressView/StreamContentSync.vitest.ts
+++ b/src/test-kernel/progressView/StreamContentSync.vitest.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { LitSessionRenderer } from '@controllers/progressView/backend/LitSessionRenderer';
+import { ProgressStreamProjectionBuilder } from '@controllers/progressView/backend/ProgressStreamProjectionBuilder';
 import type { GetProgressStreamControls } from '@controllers/progressView/progressStreamControls';
 import type { WebviewUpdater } from '@controllers/progressView/backend/WebviewUpdater';
 import type { WebviewBridge } from '@controllers/progressView/backend/WebviewBridge';
@@ -90,7 +91,7 @@ interface SyncHarness {
 async function createSyncHarness(
   getControls?: GetProgressStreamControls,
 ): Promise<SyncHarness> {
-  const state = new SessionState(new FakeStateStore());
+  const state = new SessionState();
   await state.snapshots.load([]);
   const messages: SyncStreamContentPayload[] = [];
   const updater = {
@@ -103,7 +104,14 @@ async function createSyncHarness(
     syncStream: vi.fn(),
     clearAll: vi.fn(),
   } as unknown as WebviewBridge;
-  const renderer = new LitSessionRenderer(state, updater, bridge, getControls);
+  const projections = new ProgressStreamProjectionBuilder(state, getControls);
+  const renderer = new LitSessionRenderer(
+    projections,
+    state.snapshots,
+    state.followUps,
+    updater,
+    bridge,
+  );
   return { state, messages, bridge, renderer };
 }
 

--- a/src/test-kernel/progressView/StreamMetaState.vitest.ts
+++ b/src/test-kernel/progressView/StreamMetaState.vitest.ts
@@ -575,4 +575,109 @@ describe('stream meta frontend state', () => {
 
     expect(getState().activeStreamId).toBeNull();
   });
+
+  it('settles only the latest pending stream selection', () => {
+    const first = 'stream-a' as StreamTabId;
+    const second = 'stream-b' as StreamTabId;
+    const state = createInitialState();
+    registerStream(state, first);
+    registerStream(state, second);
+    state.activeStreamId = first;
+    state.pendingStreamSelection = {
+      requestId: 'request-new',
+      streamId: second,
+    };
+    const getState = seedState(state);
+
+    dispatch(streamLifecycleHandlers, {
+      command: PROGRESS_VIEW_COMMANDS.SETTLE_STREAM_SELECTION,
+      requestId: 'request-stale',
+      status: 'superseded',
+      activeStream: first,
+    });
+    expect(getState().pendingStreamSelection?.streamId).toBe(second);
+
+    dispatch(streamLifecycleHandlers, {
+      command: PROGRESS_VIEW_COMMANDS.SETTLE_STREAM_SELECTION,
+      requestId: 'request-new',
+      status: 'accepted',
+      activeStream: second,
+    });
+    expect(getState().activeStreamId).toBe(second);
+    expect(getState().pendingStreamSelection).toBeNull();
+  });
+
+  it('clears transient selection intent on an authoritative roster refresh', () => {
+    const first = 'stream-a' as StreamTabId;
+    const second = 'stream-b' as StreamTabId;
+    const state = createInitialState();
+    registerStream(state, first);
+    registerStream(state, second);
+    state.activeStreamId = first;
+    state.pendingStreamSelection = {
+      requestId: 'unacknowledged-request',
+      streamId: second,
+    };
+    const getState = seedState(state);
+
+    dispatch(streamLifecycleHandlers, {
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+      streams: [...state.streamById.values()],
+      streamStates: {},
+      activeStream: first,
+    });
+
+    expect(getState().activeStreamId).toBe(first);
+    expect(getState().pendingStreamSelection).toBeNull();
+  });
+
+  it('releases reloadable content while retaining lightweight state and drafts', () => {
+    const stream = 'tool-stream' as StreamTabId;
+    const state = createInitialState();
+    registerStream(state, stream, { agentCategory: AgentCategory.ToolUse });
+    state.streamStates.set(
+      stream,
+      createStreamState(AgentCategory.ToolUse, {
+        status: STREAM_PHASE.WAITING,
+        runUsage: {
+          run: { inputTokens: 50, outputTokens: 25, cost: 0.01 },
+        },
+        todos: [
+          {
+            content: 'Retain the draft',
+            status: 'pending',
+            activeForm: 'Retaining the draft',
+          },
+        ],
+        ui: {
+          followUpText: 'unsent observation',
+          polishedText: null,
+          polishRevision: 0,
+          transcribedText: null,
+          recording: false,
+          shouldFocusFollowUp: false,
+        },
+      }),
+    );
+    state.followupOptionsByStream.set(stream, {
+      toolUseAgentsData: [{ label: 'Search', value: 'search' }],
+    });
+    const getState = seedState(state);
+
+    dispatch(streamLifecycleHandlers, {
+      command: PROGRESS_VIEW_COMMANDS.RELEASE_STREAM_CONTENT,
+      stream,
+    });
+
+    const released = getState().streamStates.get(stream);
+    expect(released).toMatchObject({
+      status: STREAM_PHASE.WAITING,
+      runUsage: {},
+      todos: [],
+      ui: { followUpText: 'unsent observation' },
+    });
+    expect(getState().followupOptionsByStream.get(stream)).toEqual({
+      toolUseAgentsData: [{ label: 'Search', value: 'search' }],
+    });
+  });
 });

--- a/src/test-kernel/progressView/streamInfoUtils.vitest.ts
+++ b/src/test-kernel/progressView/streamInfoUtils.vitest.ts
@@ -68,16 +68,12 @@ describe('compareByNewestCreationTime', () => {
 });
 
 describe('buildStreamInfo git probe gating', () => {
-  function stateWith(overrides: {
-    activeStream?: string;
-    inFlight?: string[];
-  }): StreamInfoSource {
+  function stateWith(overrides: { inFlight?: string[] }): StreamInfoSource {
     return {
       getStreamMetadata: () => ({
         creationTimestamp: 1,
         config: { instruction: '', workingDirectory: '/wt' },
       }),
-      activeStream: overrides.activeStream ?? '',
       streamStatus: {
         isInFlight: (id: string) => overrides.inFlight?.includes(id) ?? false,
       },
@@ -90,13 +86,10 @@ describe('buildStreamInfo git probe gating', () => {
   });
 
   it('probes git for in-flight streams and the selected tab', () => {
-    const source = stateWith({
-      activeStream: 'selected#1',
-      inFlight: ['running#1'],
-    });
+    const source = stateWith({ inFlight: ['running#1'] });
 
     buildStreamInfo(source, 'running#1');
-    buildStreamInfo(source, 'selected#1');
+    buildStreamInfo(source, 'selected#1', 'selected#1');
 
     expect(vi.mocked(resolveWorktreeInfo).mock.calls).toEqual([
       ['/wt'],

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -538,6 +538,50 @@ describe('StreamLogStore load', () => {
     expect(store.get('alpha')?.size).toBe(1);
   });
 
+  it('releases only the presentation lease that owns its token', async () => {
+    mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 100)] },
+      summaries: {
+        alpha: summary(100, 100, { hasRunningGroup: false }),
+      },
+    });
+    const store = await StreamLogStore.open();
+    const first = await store.ensureLoaded('alpha', {
+      retainForPresentation: true,
+    });
+    const second = await store.ensureLoaded('alpha', {
+      retainForPresentation: true,
+    });
+
+    store.requestEviction('alpha');
+    first.close();
+    expect(store.get('alpha')?.size).toBe(1);
+
+    second.close();
+    expect(store.get('alpha')).toBeUndefined();
+    // Obsolete close is idempotent and cannot affect a later owner.
+    first.close();
+    expect(store.get('alpha')).toBeUndefined();
+  });
+
+  it('evicts a historical transcript when its final presentation closes', async () => {
+    mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 100)] },
+      summaries: {
+        alpha: summary(100, 100, { hasRunningGroup: false }),
+      },
+    });
+    const store = await StreamLogStore.open();
+    const lease = await store.ensureLoaded('alpha', {
+      retainForPresentation: true,
+    });
+
+    expect(store.get('alpha')?.size).toBe(1);
+    lease.close();
+
+    expect(store.get('alpha')).toBeUndefined();
+  });
+
   it('honors eviction requested while a focused rehydrate is pending', async () => {
     const readStarted = createDeferred();
     const readGate = createDeferred();

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -136,6 +136,12 @@ interface StreamWriterOwnership {
 
 type TranscriptResidencyLeaseReason = 'writer' | 'focus' | 'flush';
 
+/** Exact presentation ownership of one resident transcript. */
+export interface TranscriptPresentationLease {
+  readonly streamId: StreamTabId;
+  close(): void;
+}
+
 /**
  * Every per-stream field that shares the resident stream lifecycle, keyed by
  * stream id in ONE map (`streams`, a {@link ResidentStreamRegistry}) instead
@@ -162,6 +168,8 @@ interface StreamState {
   log?: StreamLog;
   /** Reasons that currently require the heavy transcript to stay resident. */
   leases?: Set<TranscriptResidencyLeaseReason>;
+  /** Exact presentation capabilities currently retaining this transcript. */
+  presentationLeases?: Set<symbol>;
   /**
    * Membership flag: this stream's rehydrate read from disk failed. While set,
    * saves skip it so we never overwrite the authoritative disk copy with a
@@ -360,6 +368,8 @@ export class StreamLogStore {
       (s) =>
         s.log === undefined &&
         (s.leases === undefined || s.leases.size === 0) &&
+        (s.presentationLeases === undefined ||
+          s.presentationLeases.size === 0) &&
         !s.loadFailed &&
         s.pendingLoad === undefined &&
         s.writer === undefined,
@@ -715,17 +725,64 @@ export class StreamLogStore {
     };
   }
 
+  async ensureLoaded(
+    streamId: StreamTabId,
+    options: { retainForPresentation: true },
+  ): Promise<TranscriptPresentationLease>;
+  async ensureLoaded(streamId: StreamTabId): Promise<void>;
   /**
    * Async reload entries from disk if they were released. No-op when already
-   * resident or when the stream is unknown.
+   * resident or when the stream is unknown. A presentation may request an
+   * exact lease so closing an obsolete selection cannot release a newer one.
    */
-  async ensureLoaded(streamId: StreamTabId): Promise<void> {
-    await this.hydrateStream(streamId, 'focus');
+  async ensureLoaded(
+    streamId: StreamTabId,
+    options?: { retainForPresentation: true },
+  ): Promise<void | TranscriptPresentationLease> {
+    if (!options?.retainForPresentation) {
+      await this.hydrateStream(streamId, 'focus');
+      return;
+    }
+    if (
+      this.mode.kind === 'ephemeral' ||
+      (this.streams.get(streamId) === undefined &&
+        !this.summaries.has(streamId))
+    ) {
+      return { streamId, close: () => undefined };
+    }
+
+    const token = Symbol(streamId);
+    const state = this.ensureStreamState(streamId);
+    state.presentationLeases ??= new Set();
+    state.presentationLeases.add(token);
+    let closed = false;
+    const close = (): void => {
+      if (closed) return;
+      closed = true;
+      const current = this.streams.get(streamId);
+      current?.presentationLeases?.delete(token);
+      if (current?.presentationLeases?.size === 0) {
+        current.presentationLeases = undefined;
+      }
+      // A presentation lease makes a historical transcript resident. Once
+      // the final exact owner leaves, request eviction even when no lifecycle
+      // status event previously did so.
+      this.requestEviction(streamId);
+      this.pruneStreamState(streamId);
+    };
+
+    try {
+      await this.hydrateStream(streamId, 'presentation');
+      return { streamId, close };
+    } catch (error) {
+      close();
+      throw error;
+    }
   }
 
   private async hydrateStream(
     streamId: StreamTabId,
-    reason: 'focus' | 'writer',
+    reason: 'focus' | 'presentation' | 'writer',
   ): Promise<void> {
     if (this.mode.kind === 'ephemeral') return;
 
@@ -1530,6 +1587,7 @@ export class StreamLogStore {
       !state ||
       !this.releaseRequests.has(streamId) ||
       (state.leases?.size ?? 0) > 0 ||
+      (state.presentationLeases?.size ?? 0) > 0 ||
       this.dirtyIds.has(streamId) ||
       state.pendingLoad
     ) {


### PR DESCRIPTION
## Summary

This change separates execution-session facts from progress-view presentation decisions.

- Move persisted stream selection out of `SessionState` into `ProgressPresentationState`.
- Keep session facts responsible for stream attachment, lifecycle phases, transcripts, sidecar facts, and execution state.
- Make `ProgressBackend` the owner of confirmed selection, approval-aware focus policy, hydration commit, and transcript presentation residency.
- Project composite immutable stream metadata and content through `ProgressStreamProjectionBuilder` before delivery.
- Treat a frontend tab click as reversible visual intent until the backend accepts, rejects, or supersedes it.
- Release inactive frontend content only after a replacement selection commits, including full deselection.
- Route desktop launcher navigation through backend-confirmed deselection so late hydration cannot restore an abandoned stream.

## Issue acceptance gates

This continues the ownership work associated with #9986.

- Session and progress-UI ownership are mechanically separated.
- Stream attachment does not imply focus.
- Confirmed content never changes before transcript and sidecar hydration both succeed.
- Stale selection completions and deleted-stream hydration cannot overwrite a newer selection.
- Extension, desktop, and CLI preserve their host-specific presentation behavior.
- Architecture and residency boundaries are covered by checked-in tests.

No acceptance gate remains incomplete in this PR.

## Single source of truth

- `SessionState`: session facts, transcript/snapshot stores, stream metadata, and ephemeral execution state.
- `ProgressPresentationState`: persisted confirmed progress-view selection.
- `ProgressBackend`: focus policy, transactional hydration, presentation lease, and selection settlement.
- Progress frontend store: pending reversible tab feedback and unsent local input.
- `ProgressStreamProjectionBuilder`: the single projection boundary for composite stream metadata and content.
- `LitSessionRenderer`: delivery policy over immutable projections plus the narrow snapshot/follow-up reads needed for simple event payloads.

## Duplication and abstraction budget

The change deletes selection persistence, rotation, eviction, hydration, and focus policy from `SessionState` and `SessionFactApplier`. It also removes broad `SessionState` reads from `LitSessionRenderer` and `WebviewUpdater`; the renderer receives only the snapshot and follow-up stores required for simple event delivery.

Two abstractions are added because they each own a distinct invariant:

- `ProgressPresentationState` owns the one persisted progress-view choice.
- `ProgressStreamProjectionBuilder` is the one boundary at which composite session facts become immutable presentation values.

The projection builder's five single-caller forwarding methods were removed during review. The transcript lease is folded into the existing `ensureLoaded` public method so the store public-surface budget does not grow.

## Net elements (R6)

Against `main`:

- 40 files changed
- 1,709 additions, 655 deletions; net +1,054 lines
- 3 files added, 0 files deleted
- Exported constructs added: `requestStreamSwitch`, `requestStreamDeselection`, `displayedActiveStreamId$`, `releaseStreamContent`, `ProgressPresentationState`, `ProjectedStreamMetadata`, `ProjectedStreamRoster`, `ProgressStreamProjectionBuilder`, `PresentedStreamId`, and `TranscriptPresentationLease`
- Exported constructs removed: `firstStreamId` and `ActiveStreamId`
- `buildStreamInfos` remains exported with an explicit presentation-selection argument
- New classes: 2; new interfaces: 3; new enums: 0

The positive line count is primarily the transactional selection protocol and its race, failure, residency, architecture, desktop, and frontend tests. It replaces implicit shared writers with explicit ownership and proof obligations.

## Consumer counts (R8)

Production grep after the reroute finds five `setActiveStream` fact consumers:

1. `SessionFactApplier` — attachment facts only
2. `ProgressBackend` — progress-presentation focus policy
3. `sessionSignalsAdapter` — interactive CLI focus
4. `runProgressRenderer` — headless CLI projection
5. `sessionProgressSubscription` — CLI progress subscription

Production references to the removed `SessionState.switchActiveStream`, `rotateActiveStream`, `ActiveStreamId`, and `evictOnStreamSwitch` contracts are zero.

The new `SETTLE_STREAM_SELECTION` and `RELEASE_STREAM_CONTENT` commands each have one frontend handler; their schemas and backend sender are centralized in the existing progress-view IPC surfaces.

## Host impact

Extension:

- Tabs show pending visual feedback while content remains bound to the confirmed selection.
- Failed or superseded hydration reverts gracefully.
- Inactive heavy content is explicitly released after commit; lightweight follow-up catalogs remain resident for open controls.
- Authoritative roster refreshes clear unacknowledged transient selection intent.

Desktop:

- Uses the same pending/confirmed selection protocol as the extension rail and center pane.
- Desktop IPC carries the selection request identifier.
- Returning to the launcher sends an explicit deselection request, invalidating older hydration.

CLI:

- Session facts attach streams through the shared applier.
- Interactive CLI focus remains a CLI-owned signal reaction.
- Headless progress behavior remains unchanged.

## Scheduled refactoring

None. All correctness findings from the automated review passes are addressed in this PR, including late deletion/activation races, pending-selection and launcher-intent preservation, and historical transcript release.

## Validation

- `npm run check:dead-code-ratchet`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- Complete Vitest run: 858 test files; 10,077 passed; 0 failed; 5 skipped
- Focused ownership, lifecycle, frontend recovery, transcript residency, and host-surface run: 192 tests passed
