### PR TITLE
fix(cli): label workflow task progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ All notable changes to this project will be documented in this file.
 - **Session views show recognizable model names** — headers, `/status`, and
   background-task rows use catalog labels instead of internal model IDs.
 - **Workflow task progress shows recognizable model names** — focused
-  dashboards and interactive transcripts use catalog labels instead of
-  internal model IDs.
+  dashboards, interactive transcripts, and headless progress use catalog
+  labels instead of internal model IDs.
 - **Workflow dashboards identify blocked tasks** — a task waiting for approval
   now shows the pending approval kind on its own row.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ All notable changes to this project will be documented in this file.
   input is hidden.
 - **Session views show recognizable model names** — headers, `/status`, and
   background-task rows use catalog labels instead of internal model IDs.
-- **Workflow task rows show recognizable model names** — focused workflow
-  dashboards use catalog labels instead of internal model IDs.
+- **Workflow task progress shows recognizable model names** — focused
+  dashboards and interactive transcripts use catalog labels instead of
+  internal model IDs.
 - **Workflow dashboards identify blocked tasks** — a task waiting for approval
   now shows the pending approval kind on its own row.
 

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -16,6 +16,7 @@ import { appendCliApiSwitchHint } from '@cli/runtime/approval/approvalPrompts';
 import { safeTerminalText } from '@cli/runtime/terminalText';
 import { TOOL_OUTPUT_CORNER } from '@cli/tui/ui/glyphs';
 import { redactSecrets } from '@logger/redaction';
+import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import {
   ErrorLogDataSchema,
   FileListEntrySchema,
@@ -315,11 +316,17 @@ function renderLogEntryFresh(
     const parsed = WorkflowCallProgressSchema.safeParse(entry.data);
     if (!parsed.success) return null;
     const call = parsed.data;
+    const displayCall =
+      isTerminalWorkflowCallProgress(call) &&
+      'model' in call &&
+      call.model !== undefined
+        ? { ...call, model: getRuntimeModelLabel(call.model) }
+        : call;
     const next: ConversationEntry = {
       ...baseLogEntryFields(
         entry,
         'workflowTask',
-        formatWorkflowCallLine(call),
+        formatWorkflowCallLine(displayCall),
       ),
       finalized: entry.settlementSeqNo !== undefined,
       task: call,

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -14,9 +14,9 @@
 
 import { appendCliApiSwitchHint } from '@cli/runtime/approval/approvalPrompts';
 import { safeTerminalText } from '@cli/runtime/terminalText';
+import { formatCliWorkflowCallLine } from '@cli/runtime/workflowCallText';
 import { TOOL_OUTPUT_CORNER } from '@cli/tui/ui/glyphs';
 import { redactSecrets } from '@logger/redaction';
-import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import {
   ErrorLogDataSchema,
   FileListEntrySchema,
@@ -35,7 +35,6 @@ import {
   summarizeFollowupMessage,
 } from '@shared/subagentFollowup';
 import { normalizeToolUseData } from '@shared/toolUse';
-import { formatWorkflowCallLine } from '@shared/copy/workflowCall';
 import {
   applyCompactionActivityEntries,
   COMPACTION_ACTIVITY_LABEL,
@@ -316,17 +315,11 @@ function renderLogEntryFresh(
     const parsed = WorkflowCallProgressSchema.safeParse(entry.data);
     if (!parsed.success) return null;
     const call = parsed.data;
-    const displayCall =
-      isTerminalWorkflowCallProgress(call) &&
-      'model' in call &&
-      call.model !== undefined
-        ? { ...call, model: getRuntimeModelLabel(call.model) }
-        : call;
     const next: ConversationEntry = {
       ...baseLogEntryFields(
         entry,
         'workflowTask',
-        formatWorkflowCallLine(displayCall),
+        formatCliWorkflowCallLine(call),
       ),
       finalized: entry.settlementSeqNo !== undefined,
       task: call,

--- a/packages/cli/src/runtime/workflowCallText.ts
+++ b/packages/cli/src/runtime/workflowCallText.ts
@@ -1,0 +1,17 @@
+import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
+import {
+  isTerminalWorkflowCallProgress,
+  type WorkflowCallProgress,
+} from '@shared/schemas';
+import { formatWorkflowCallLine } from '@shared/copy/workflowCall';
+
+/** Format workflow-call progress for CLI surfaces without changing its model ID. */
+export function formatCliWorkflowCallLine(call: WorkflowCallProgress): string {
+  const displayCall =
+    isTerminalWorkflowCallProgress(call) &&
+    'model' in call &&
+    call.model !== undefined
+      ? { ...call, model: getRuntimeModelLabel(call.model) }
+      : call;
+  return formatWorkflowCallLine(displayCall);
+}

--- a/packages/cli/src/runtime/workflowCallText.ts
+++ b/packages/cli/src/runtime/workflowCallText.ts
@@ -1,16 +1,11 @@
 import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
-import {
-  isTerminalWorkflowCallProgress,
-  type WorkflowCallProgress,
-} from '@shared/schemas';
+import type { WorkflowCallProgress } from '@shared/schemas';
 import { formatWorkflowCallLine } from '@shared/copy/workflowCall';
 
 /** Format workflow-call progress for CLI surfaces without changing its model ID. */
 export function formatCliWorkflowCallLine(call: WorkflowCallProgress): string {
   const displayCall =
-    isTerminalWorkflowCallProgress(call) &&
-    'model' in call &&
-    call.model !== undefined
+    'model' in call && call.model !== undefined
       ? { ...call, model: getRuntimeModelLabel(call.model) }
       : call;
   return formatWorkflowCallLine(displayCall);

--- a/packages/cli/src/runtime/workflowPlainOutput.ts
+++ b/packages/cli/src/runtime/workflowPlainOutput.ts
@@ -8,11 +8,10 @@ import {
   type StreamTabId,
   type WorkflowCallProgress,
 } from '@shared/schemas';
-import {
-  formatWorkflowCallLine,
-  formatWorkflowPhaseHeading,
-} from '@shared/copy/workflowCall';
+import { formatWorkflowPhaseHeading } from '@shared/copy/workflowCall';
 import { assertNever } from '@utils/core';
+
+import { formatCliWorkflowCallLine } from './workflowCallText';
 
 const WORKFLOW_PLAIN_EVENT_TYPES = [
   'run.start',
@@ -53,7 +52,7 @@ function createWorkflowStreamProjection(
     options.writeLine(line);
   };
   const writeCall = (logId: string, call: WorkflowCallProgress): void => {
-    const line = formatWorkflowCallLine(call);
+    const line = formatCliWorkflowCallLine(call);
     if (lastCallLines.get(logId) === line) return;
     lastCallLines.set(logId, line);
     write(line);

--- a/src/test-kernel/cli/WorkflowPlainOutput.vitest.ts
+++ b/src/test-kernel/cli/WorkflowPlainOutput.vitest.ts
@@ -52,6 +52,7 @@ function readTask(
       phase: 'Map',
       status,
       ...(childStreamId ? { childStreamId } : {}),
+      ...(status === 'completed' ? { model: 'gpt56-' } : {}),
     },
   };
 }
@@ -148,7 +149,7 @@ describe('attachWorkflowPlainOutput', () => {
       'Planned: Read the argument',
       'Running: Read the argument',
       'Found two boundary cases.',
-      'Finished: Read the argument',
+      'Finished: Read the argument · GPT-5.6 Terra',
       'Finished: proof-workflow',
     ]);
     expect(beforeWrite).toHaveBeenCalledTimes(lines.length);

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -235,7 +235,7 @@ describe('CLI workflow-script child-stream transcript', () => {
         id: 'core-task',
         finalized: true,
         task: { status: 'completed' },
-        text: 'Finished: Audit core · deepseekT',
+        text: 'Finished: Audit core · DeepSeek V4 Flash (Thinking)',
       },
       {
         id: 'extension-task',
@@ -247,7 +247,7 @@ describe('CLI workflow-script child-stream transcript', () => {
 
     const updatedItems = appendItems(plannedItems);
     expect(entryTexts(updatedItems)).toEqual([
-      'Finished: Audit core · deepseekT',
+      'Finished: Audit core · DeepSeek V4 Flash (Thinking)',
     ]);
   });
 
@@ -917,7 +917,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     // The phase group row and the task's current state both surface.
     expect(texts).toContain('Draft sections');
     expect(texts).toContain(
-      'Finished: Draft introduction · deepseekT · 12s · $0.002',
+      'Finished: Draft introduction · DeepSeek V4 Flash (Thinking) · 12s · $0.002',
     );
     expect(
       entries.filter((entry) => entry.id === 'introduction-task'),
@@ -981,6 +981,6 @@ describe('CLI workflow-script child-stream transcript', () => {
     // the call row carries its own per-status marker.
     expect(output).toContain('◆ Draft sections');
     expect(output).toContain('☑ Finished: Draft introduction');
-    expect(output).toContain('deepseekT · 12s · $0.002');
+    expect(output).toContain('DeepSeek V4 Flash (Thinking) · 12s · $0.002');
   });
 });

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -234,7 +234,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       {
         id: 'core-task',
         finalized: true,
-        task: { status: 'completed' },
+        task: { status: 'completed', model: 'deepseekT' },
         text: 'Finished: Audit core · DeepSeek V4 Flash (Thinking)',
       },
       {


### PR DESCRIPTION
## Summary

- render known model IDs with their catalog labels in interactive workflow-task transcripts
- use the same CLI formatter for headless plain-text workflow progress
- retain canonical model IDs in workflow events, task data, execution requests, and persisted state
- preserve the raw-string fallback for unknown or harness-supplied model IDs

Follow-up to #10116 and #10121. The dashboard-row fix merged independently in #10121 while this PR was under review; this branch is rebased on that change and contains no duplicate dashboard code.

## Root cause

The workflow dashboard now projects known model IDs through `getRuntimeModelLabel`, but the interactive transcript fold and headless plain-text renderer still passed canonical `WorkflowCallProgress.model` values directly to the shared text formatter. Those surfaces therefore printed opaque IDs such as `gpt56-`.

This change keeps model identity canonical below the presentation boundary and projects a label only while constructing CLI text. The interactive transcript and headless renderer share one CLI-local projection. No schema, event, or storage format changes.

## Validation

Before the upstream dashboard fix merged:

- `npm run compile:fast`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 856 files passed, 1 skipped; 10,054 tests passed, 5 skipped
- `corepack pnpm --filter @texra-ai/cli run validate:tui --no-build workflow-running`

After rebasing onto #10121 and dropping the duplicated dashboard changes:

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts src/test-kernel/cli/WorkflowPlainOutput.vitest.ts` — 15 tests passed
- `corepack pnpm --filter @texra-ai/cli typecheck`
- targeted ESLint on all changed production files
- pre-push formatting, guidance-reference, and changed-file lint hooks