### PR TITLE
refactor: merge globalStorage.ts constants into storageLayout.ts

### DIFF
--- a/packages/extension/src/frontend/vscode/sharedStorageRoot.ts
+++ b/packages/extension/src/frontend/vscode/sharedStorageRoot.ts
@@ -16,7 +16,11 @@ import { join } from 'node:path';
 import * as vscode from 'vscode';
 
 // Local imports
-import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
+import {
+  CUSTOM_AGENTS_STORAGE_DIR,
+  EXTERNAL_INQUIRY_THREADS_DIR,
+  WORKSPACE_STORAGE_LAYOUT,
+} from '@common/storage/storageLayout';
 import * as logger from '@logger/logUtils';
 import type { StorageProvider } from '@platform/interfaces';
 import {
@@ -24,10 +28,6 @@ import {
   mergeLegacyWorkspaceStorageBucket,
   type LegacyDataMigrationLogger,
 } from '@platform/defaults/legacyDataMigration';
-import {
-  CUSTOM_AGENTS_STORAGE_DIR,
-  EXTERNAL_INQUIRY_THREADS_DIR,
-} from '@platform/defaults/globalStorage';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 type BucketMigration = (

--- a/src/agent/index/AgentDirectoryService.ts
+++ b/src/agent/index/AgentDirectoryService.ts
@@ -2,7 +2,7 @@
 import * as path from 'node:path';
 
 // Local imports
-import { CUSTOM_AGENTS_STORAGE_DIR } from '@platform/defaults/globalStorage';
+import { CUSTOM_AGENTS_STORAGE_DIR } from '@common/storage/storageLayout';
 import type { AgentSource } from '@shared/schemas/agent';
 
 import {

--- a/src/common/storage/storageLayout.ts
+++ b/src/common/storage/storageLayout.ts
@@ -16,3 +16,7 @@ export const WORKSPACE_STORAGE_LAYOUT = Object.freeze({
   streamLogSummaries: 'streamLogSummaries',
   original: 'original',
 } as const);
+
+/** Global (non-workspace-scoped) storage directory names, shared across hosts. */
+export const CUSTOM_AGENTS_STORAGE_DIR = 'custom_agents';
+export const EXTERNAL_INQUIRY_THREADS_DIR = 'ei_threads';

--- a/src/platform/defaults/globalStorage.ts
+++ b/src/platform/defaults/globalStorage.ts
@@ -1,2 +1,0 @@
-export const CUSTOM_AGENTS_STORAGE_DIR = 'custom_agents';
-export const EXTERNAL_INQUIRY_THREADS_DIR = 'ei_threads';

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -4,8 +4,8 @@ import { z } from 'zod';
 
 import { createChannelTrace } from '@agent/trace';
 import { isFileNotFoundError } from '@common/errors';
+import { EXTERNAL_INQUIRY_THREADS_DIR } from '@common/storage/storageLayout';
 import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
-import { EXTERNAL_INQUIRY_THREADS_DIR } from '@platform/defaults/globalStorage';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import {
   InquirySessionLinksSchema,


### PR DESCRIPTION
## Summary

Scheduled codebase-consolidation audit (debt-audit workflow, 12 seams, 20 agents, adversarial verification) over the whole repo, looking for duplicate/similar logic to consolidate and custom implementations that native methods/stdlib already cover. Verdict: the codebase is broadly healthy — every seam (agent core/runtime, model handlers, controllers, tools, shared schemas, `src/utils/`, host-agnostic support dirs, and all three host packages) was read in full and found to already follow the repo's consolidation conventions (shared dispatchers, table-driven registries, single-owner resolvers, etc.), with no dual systems or native-method gaps found.

One trivial, adversarially-verified real finding survived: `src/platform/defaults/globalStorage.ts` was a 2-line module exporting `CUSTOM_AGENTS_STORAGE_DIR` and `EXTERNAL_INQUIRY_THREADS_DIR`, duplicating the ownership role already held by the sibling `src/common/storage/storageLayout.ts` registry (which `platform/defaults/workspaceStorage.ts` already reads from as SSOT). This PR folds both constants into `storageLayout.ts` and deletes the now-empty module.

A second candidate (a shared VS Code/Google conversation-block-shape classifier for `conversationFormat.ts` / `normalizeConversation.ts`) was investigated and rejected after verification found two undocumented behavioral divergences (mimeType casing, `functionResponse.result` unwrapping, plus a third — indented vs. compact JSON formatting) that a shared classifier would either silently break or fail to actually unify. Not included in this PR.

## Issue acceptance gates

No linked issue — this is a scheduled proactive audit. Acceptance gate (self-imposed): the merge must not change any persisted directory name and must not introduce a new cross-package import edge.

## Single source of truth

`src/common/storage/storageLayout.ts` is now the sole owner of both global storage directory name constants, alongside the workspace-storage layout it already owned. `src/platform/defaults/globalStorage.ts` is deleted.

## Duplication and abstraction budget

Removed one redundant module (and its distinct import path) that existed purely to hold two constants a sibling registry was already the natural home for. No new abstraction added.

## Net elements (R6)

- Files: 1 deleted (`src/platform/defaults/globalStorage.ts`), 4 modified (diffstat: `5 files changed, 11 insertions(+), 9 deletions(-)`)
- Exported symbols: net 0 (2 exports moved from `globalStorage.ts` into `storageLayout.ts`, none added or removed)
- Classes/interfaces/enums: none affected
- Net LoC: ~0 (2 lines removed from the deleted file, re-added inside `storageLayout.ts`; one import statement in `sharedStorageRoot.ts` merges two imports into one, saving 1 line there)
- The real win is element-count: one fewer file/module and one fewer distinct import path (`@platform/defaults/globalStorage`) to track.

## Consumer counts (R8)

Grepped `CUSTOM_AGENTS_STORAGE_DIR|EXTERNAL_INQUIRY_THREADS_DIR` across `*.ts`/`*.tsx`: exactly 4 files total (the definition plus 3 consumers), all updated in this PR:
- `src/agent/index/AgentDirectoryService.ts:5`
- `src/tools/inquiry/externalInquiryStorage.ts:8`
- `packages/extension/src/frontend/vscode/sharedStorageRoot.ts:27-30` (merged into its existing `storageLayout.ts` import)

No test file imports either constant directly, so no test changes were needed.

## Host impact

Extension: `sharedStorageRoot.ts` (VS Code-only shared-storage-root wiring) — import path updated, single merged import statement, no behavior change.

Desktop: none — no desktop code imported `globalStorage.ts`.

CLI: none — no CLI code imported `globalStorage.ts`.

## Scheduled refactoring

None. The one moderate-risk candidate identified by the audit (shared conversation-block classifier) was verified as a net loss and intentionally excluded from this and any follow-up PR.

## Validation

- `npm run typecheck` — full workspace, test-kernel, agent, cli, trace-viewer, desktop projects all pass
- `npm run lint` — clean
- `npm run check:dead-code-ratchet` — no new unused files/exports (15 baselined, 15 current)
- `npx vitest run` targeted at the touched modules and their existing suites — `AgentDirectoryService.vitest.ts`, `SharedStorageRoot.vitest.ts`, `ExternalInquiry.vitest.ts`, `ExternalInquiryResultFormatter.vitest.ts`, `ExternalInquiryAction.vitest.ts`, `ExternalInquiryHostInteractionRejection.vitest.ts`, `WorkspaceStorage.vitest.ts`, `SharedLiteralImmutability.vitest.ts` — all 69 tests pass
- Grep confirms `config/ratchets/architecture-edges-baseline.json` already lists `agent→common` and `tools→common` value edges, so no new architecture-edge is introduced by retargeting the two `agent`/`tools` import sites from `@platform/defaults` to `@common/storage`

---
_Generated by [Claude Code](https://claude.ai/code/session_011iB35cRjYoaQRTxnHEK8y2)_