### PR TITLE
fix(cli): label workflow task models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable changes to this project will be documented in this file.
   input is hidden.
 - **Session views show recognizable model names** — headers, `/status`, and
   background-task rows use catalog labels instead of internal model IDs.
+- **Workflow task rows show recognizable model names** — focused workflow
+  dashboards use catalog labels instead of internal model IDs.
 
 ### Shared (all surfaces)
 

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -240,7 +240,7 @@ function workflowTaskMetadata(
     cost = usage?.cost;
   }
   const parts = [
-    model,
+    model ? getRuntimeModelLabel(model) : undefined,
     elapsed,
     usage && usage.outputTokens > 0
       ? `${TOKENS_GENERATED}${formatCompactTokenCount(usage.outputTokens)}`

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -1035,6 +1035,17 @@ describe('CLI child list display model', () => {
           },
           true,
         ),
+        workflowTaskEntry(
+          'task-labelled',
+          'Finished: Labelled model',
+          {
+            id: 'labelled-model',
+            label: 'Labelled model',
+            status: 'completed',
+            model: 'deepseekT',
+          },
+          true,
+        ),
         workflowTaskEntry('task-missing', 'Running: Missing', {
           id: 'missing',
           label: 'Missing',
@@ -1107,11 +1118,11 @@ describe('CLI child list display model', () => {
 
     expect(wideOutput.match(/Map \(1\/2\) · 0\/1/g)).toHaveLength(1);
     expect(wideOutput).toContain('Synthesis · 0/1');
-    expect(wideOutput).toContain('Unphased · 2/6');
+    expect(wideOutput).toContain('Unphased · 3/7');
     expect(wideOutput).toContain('Synthesize · Planned');
     expect(narrowOutput.match(/Map \(1\/2\) · 0\/1/g)).toHaveLength(1);
     expect(narrowOutput).toContain('Synthesis · 0/1');
-    expect(narrowOutput).toContain('Unphased · 2/6');
+    expect(narrowOutput).toContain('Unphased · 3/7');
     expect(narrowOutput).toContain('Loose · Planned');
 
     const reusedLine = narrowOutput
@@ -1127,6 +1138,11 @@ describe('CLI child list display model', () => {
     expect(reusedTerminalLine).toContain('$0.500');
     expect(reusedTerminalLine).not.toContain('ambiguous-model');
     expect(reusedTerminalLine).not.toContain('↓999');
+    const labelledModelLine = narrowOutput
+      .split('\n')
+      .find((line) => line.includes('Labelled model · Finished'));
+    expect(labelledModelLine).toContain('DeepSeek V4 Flash (Thinking)');
+    expect(labelledModelLine).not.toContain('deepseekT');
     const missingLine = narrowOutput
       .split('\n')
       .find((line) => line.includes('Missing · Running'));


### PR DESCRIPTION
## Summary

- route workflow-dashboard task model identifiers through the runtime model registry
- retain raw identifiers when the registry has no matching model
- cover both the catalog-label projection and existing unknown-model fallbacks

## Verification

- `corepack pnpm exec vitest run src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts src/test-kernel/cli/SubagentListDisplay.vitest.ts`
- `npm run lint`
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `git diff --check`

Closes #10116