### PR TITLE
fix(cli): identify workflow task approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to this project will be documented in this file.
   background-task rows use catalog labels instead of internal model IDs.
 - **Workflow task rows show recognizable model names** — focused workflow
   dashboards use catalog labels instead of internal model IDs.
+- **Workflow dashboards identify blocked tasks** — a task waiting for approval
+  now shows the pending approval kind on its own row.
 
 ### Shared (all surfaces)
 

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -162,6 +162,8 @@ import type { CliModelAccess } from '../src/runtime/modelAccess';
 import type { InputHistory } from '../src/chat/tui/history/inputHistory';
 
 const STREAM_ID = 'harness-stream-1';
+const RUNNING_WORKFLOW_FIRST_AGENT_STREAM_ID =
+  'correct@harness-model#harness-workflow-agent-a' as StreamTabId;
 const SHOW_WORKFLOW_TIMELINE = process.env.HARNESS_WORKFLOW_TIMELINE === '1';
 const SHOW_WORKFLOW_RUNNING = process.env.HARNESS_WORKFLOW_RUNNING === '1';
 const SHOW_PROCESS_CHILD = process.env.HARNESS_PROCESS_CHILD === '1';
@@ -985,7 +987,9 @@ function makeBashApprovalPayload(index = 1) {
     command: BASH_APPROVAL_COMMAND,
     cwd: HARNESS_CWD,
     allowBypass: true,
-    streamId: STREAM_ID,
+    streamId: SHOW_WORKFLOW_RUNNING
+      ? RUNNING_WORKFLOW_FIRST_AGENT_STREAM_ID
+      : STREAM_ID,
   };
 }
 
@@ -1362,8 +1366,7 @@ function seedWorkflowTimeline(): void {
 function seedRunningWorkflow(): void {
   const executionId = 'aaaa0002f10e' as ExecutionId;
   const childStreamId = 'workflow-script#aaaa0002f10e' as StreamTabId;
-  const firstAgentStreamId =
-    'correct@harness-model#harness-workflow-agent-a' as StreamTabId;
+  const firstAgentStreamId = RUNNING_WORKFLOW_FIRST_AGENT_STREAM_ID;
   const secondAgentStreamId =
     'correct@harness-model#harness-workflow-agent-b' as StreamTabId;
 
@@ -1405,6 +1408,7 @@ function seedRunningWorkflow(): void {
       label: 'Proofread paper A',
       phase: 'Proofread',
       status: 'running',
+      childStreamId: firstAgentStreamId,
     },
     stageId: phaseStage.id,
   });
@@ -1416,6 +1420,7 @@ function seedRunningWorkflow(): void {
       label: 'Proofread paper B',
       phase: 'Proofread',
       status: 'running',
+      childStreamId: secondAgentStreamId,
     },
     stageId: phaseStage.id,
   });
@@ -1448,6 +1453,13 @@ function seedRunningWorkflow(): void {
     transitionChildEventOrderRunning(child.childStreamId);
   }
   emitChildEventOrderRoster(childStreamId, workflowChildren);
+  patchStream(childStreamId, (slice) => ({
+    ...slice,
+    identity: {
+      kind: 'multiAgentWorkflow',
+      workflowName: 'live-workflow-validation',
+    },
+  }));
 
   HARNESS_DISPOSERS.push(() => {
     phaseStage.end('cancelled');

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -176,6 +176,7 @@ const SCENARIOS = [
     cols: 100,
     env: {
       HARNESS_ENTRIES: '0',
+      HARNESS_BASH_APPROVAL: '1',
       HARNESS_WORKFLOW_RUNNING: '1',
     },
     bootExpect: 'Tab sessions',
@@ -185,11 +186,13 @@ const SCENARIOS = [
       'Proofread (1/1) · 0/2 done',
       'Running: Proofread paper A',
       'Running: Proofread paper B',
-      'live-workflow-validation running',
+      'Proofread paper A · Running · bash',
+      'Proofread paper B · Running',
+      '1 approval',
       'Proofread (1/1)',
-      'correct running',
       '2 agents',
     ],
+    unexpect: ['Proofread paper B · Running · bash'],
   },
   {
     name: 'workflow-running-composer-hidden',

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -255,14 +255,17 @@ function WorkflowTaskRow({
   entry,
   focused,
   nowMs,
+  pendingKinds,
 }: {
   readonly child: StreamSlice | undefined;
   readonly entry: WorkflowTaskEntry;
   readonly focused: boolean;
   readonly nowMs: number;
+  readonly pendingKinds: readonly PendingApprovalKind[] | undefined;
 }): React.JSX.Element {
   const style = WORKFLOW_TASK_STATUS_STYLE[entry.task.status];
   const metadata = workflowTaskMetadata(entry.task, child, nowMs);
+  const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
   return (
     <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
       <Text aria-hidden color={focused ? COLOR_HINT : undefined}>
@@ -274,6 +277,11 @@ function WorkflowTaskRow({
           {entry.task.label} · {WORKFLOW_TASK_STATUS_LABEL[entry.task.status]}
         </Text>
       </Box>
+      {approvalSuffix ? (
+        <Box flexShrink={0}>
+          <Text>{` · ${approvalSuffix}`}</Text>
+        </Box>
+      ) : null}
       {metadata ? (
         <Box minWidth={0} flexShrink={2}>
           <Text dimColor wrap="truncate-end">{`  ${metadata}`}</Text>
@@ -291,6 +299,7 @@ function WorkflowDashboard({
   onCancel,
   onFocusStream,
   onSelectionChange,
+  pendingApprovals,
   selectedValue,
   streams,
 }: {
@@ -301,6 +310,8 @@ function WorkflowDashboard({
   readonly onCancel: () => void;
   readonly onFocusStream: ((streamId: StreamTabId) => void) | undefined;
   readonly onSelectionChange: ((value: ChildListValue) => void) | undefined;
+  readonly pendingApprovals:
+    ReadonlyMap<string, readonly PendingApprovalKind[]> | undefined;
   readonly selectedValue: ChildListValue | undefined;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): React.JSX.Element | null {
@@ -382,6 +393,11 @@ function WorkflowDashboard({
         entry={entry}
         focused={state.focused}
         nowMs={nowMs}
+        pendingKinds={
+          childStreamId === undefined
+            ? undefined
+            : pendingApprovals?.get(childStreamId)
+        }
       />
     );
   };
@@ -597,6 +613,7 @@ export function SubagentList(
         onCancel={props.onCancel ?? (() => undefined)}
         onFocusStream={props.onFocusStream}
         onSelectionChange={props.onSelectionChange}
+        pendingApprovals={props.pendingApprovals}
         selectedValue={props.selectedValue}
         streams={props.streams ?? new Map()}
       />

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -1094,6 +1094,10 @@ describe('CLI child list display model', () => {
     const props: SubagentListProps = {
       listRootStreamId: run,
       maxRows: 15,
+      pendingApprovals: new Map([
+        [shared, ['bash'] as const],
+        [fallback, ['toolEdit'] as const],
+      ]),
       sessions: [],
       streams,
     };
@@ -1138,6 +1142,7 @@ describe('CLI child list display model', () => {
     expect(reusedTerminalLine).toContain('$0.500');
     expect(reusedTerminalLine).not.toContain('ambiguous-model');
     expect(reusedTerminalLine).not.toContain('↓999');
+    expect(reusedTerminalLine).not.toContain('bash');
     const labelledModelLine = narrowOutput
       .split('\n')
       .find((line) => line.includes('Labelled model · Finished'));
@@ -1152,9 +1157,51 @@ describe('CLI child list display model', () => {
       .split('\n')
       .find((line) => line.includes('Fallback · Finished'));
     expect(fallbackLine).toContain('fallback-model');
+    expect(fallbackLine).toContain('edit');
     expect(fallbackLine).toContain('↓321');
     expect(fallbackLine).toContain('$0.007');
     expect(fallbackLine).not.toContain('5s');
+  });
+
+  it('keeps a task approval visible when its label truncates', async () => {
+    const run = 'approval-run' as StreamTabId;
+    const child = 'approval-child' as StreamTabId;
+    const rootSlice = workflowAgentSlice(run, {
+      agent: 'workflow',
+      identity: {
+        kind: 'multiAgentWorkflow',
+        workflowName: 'workflow',
+      },
+      status: STREAM_PHASE.RUNNING,
+      entries: [
+        workflowTaskEntry('task', 'Running: Long task', {
+          id: 'task',
+          label: 'Check every intermediate lemma in the manuscript',
+          status: 'running',
+          childStreamId: child,
+        }),
+      ],
+    });
+    const output = await renderSubagentList(
+      {
+        dashboard: workflowDashboardModel(rootSlice, 36),
+        maxRows: 4,
+        pendingApprovals: new Map([[child, ['bash']]]),
+        selectedValue: workflowTaskListValue('task'),
+        streams: new Map([
+          [run, rootSlice],
+          [child, workflowAgentSlice(child, {})],
+        ]),
+      },
+      36,
+      { until: (frame) => frame.includes('bash') },
+    );
+
+    expect(output).toContain(' · bash');
+    expect(output).not.toContain('manuscript');
+    expect(
+      output.split('\n').every((line) => textDisplayWidth(line) <= 36),
+    ).toBe(true);
   });
 
   // The right-aligned metadata column is the one row element `SubagentList`


### PR DESCRIPTION
## Summary

- pass the existing per-stream pending-approval map into workflow dashboard rows
- show the shared compact approval-kind suffix only on the uniquely owning task
- extend the deterministic two-task PTY fixture to cover ownership and non-ownership

## Verification

- `node packages/cli/scripts/validate-tui.mjs` (164/164 scenarios)
- `corepack pnpm exec vitest run src/test-kernel/cli/SubagentListDisplay.vitest.ts`
- `npm run lint`
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- `git diff --check`

Closes #10112