### PR TITLE
fix(cli): preserve long Markdown table cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **CLI tables preserve long mathematical expressions** — narrow columns wrap
+  LaTeX formulas and other indivisible values instead of replacing their tails
+  with an ellipsis.
 - **Delegation approvals distinguish one task from chat-wide access** — proposal
   cards now state that `y` approves only the visible task, while `a` also
   approves later agent tasks, file edits, and commands in the chat.

--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -139,6 +139,22 @@ function tableColWidths(
   return widths;
 }
 
+// cli-table3 truncates a word that is wider than its cell, replacing the
+// omitted suffix with an ellipsis. That is harmless for prose but destructive
+// for indivisible mathematical notation such as a LaTeX expression. Opt only
+// those cells into hard wrapping; ordinary cells retain word-boundary wrapping.
+function tableCell(content: string, colWidth: number | undefined): Table.Cell {
+  if (
+    colWidth !== undefined &&
+    content
+      .split(/\s/u)
+      .some((word) => textDisplayWidth(word) > colWidth - TABLE_CELL_PADDING)
+  ) {
+    return { content, wrapOnWordBoundary: false };
+  }
+  return content;
+}
+
 // Lay out a parsed markdown table through cli-table3 (borders, per-cell word
 // wrap, column widths) rather than hand-rolling alignment math.
 function renderAnsiTable(
@@ -149,16 +165,24 @@ function renderAnsiTable(
   style: AnsiMarkdownStyle,
 ): string {
   const numCols = Math.max(head.length, ...rows.map((row) => row.length), 1);
+  const colWidths = tableColWidths(head, rows, numCols, width);
+  const styledHead = head
+    .map(style.bold)
+    .map((cell, col) => tableCell(cell, colWidths?.[col]));
   const table = new Table({
-    head: head.map(style.bold),
-    colWidths: tableColWidths(head, rows, numCols, width),
+    // cli-table3 accepts CellOptions in headers at runtime, although its
+    // declaration unnecessarily narrows this field to strings.
+    head: styledHead as string[],
+    colWidths,
     colAligns: Array.from({ length: numCols }, (_, i) => aligns[i] ?? 'left'),
     wordWrap: true,
     // No cli-table3 colorizing — cell content already carries its own ANSI and
     // the border stays the terminal's default foreground.
     style: { head: [], border: [] },
   });
-  for (const row of rows) table.push([...row]);
+  for (const row of rows) {
+    table.push(row.map((cell, col) => tableCell(cell, colWidths?.[col])));
+  }
   return table.toString();
 }
 

--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -140,17 +140,17 @@ function tableColWidths(
 }
 
 // cli-table3 truncates a word that is wider than its cell, replacing the
-// omitted suffix with an ellipsis. That is harmless for prose but destructive
-// for indivisible mathematical notation such as a LaTeX expression. Opt only
-// those cells into hard wrapping; ordinary cells retain word-boundary wrapping.
-function tableCell(content: string, colWidth: number | undefined): Table.Cell {
-  if (
-    colWidth !== undefined &&
-    content
-      .split(/\s/u)
-      .some((word) => textDisplayWidth(word) > colWidth - TABLE_CELL_PADDING)
-  ) {
-    return { content, wrapOnWordBoundary: false };
+// omitted suffix with an ellipsis. Pre-wrap only affected cells with TeXRA's
+// ANSI- and display-width-aware wrapper; ordinary cells retain cli-table3's
+// word-boundary wrapping.
+function tableCell(content: string, colWidth: number | undefined): string {
+  if (colWidth !== undefined) {
+    const contentWidth = colWidth - TABLE_CELL_PADDING;
+    if (
+      content.split(/\s/u).some((word) => textDisplayWidth(word) > contentWidth)
+    ) {
+      return wrapAnsiToWidth(content, contentWidth);
+    }
   }
   return content;
 }
@@ -170,9 +170,7 @@ function renderAnsiTable(
     .map(style.bold)
     .map((cell, col) => tableCell(cell, colWidths?.[col]));
   const table = new Table({
-    // cli-table3 accepts CellOptions in headers at runtime, although its
-    // declaration unnecessarily narrows this field to strings.
-    head: styledHead as string[],
+    head: styledHead,
     colWidths,
     colAligns: Array.from({ length: numCols }, (_, i) => aligns[i] ?? 'left'),
     wordWrap: true,

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.ts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.ts
@@ -327,6 +327,17 @@ describe('renderAnsiMarkdown', () => {
     plainLinesWithinWidth(renderAnsiMarkdown(md, { width: 40 }), 40);
   });
 
+  it('wraps ordinary prose table cells at word boundaries', () => {
+    const md = '| Words |\n|---|\n| alpha beta gamma delta |';
+    const cells = renderPlain(md, { width: 16 })
+      .split('\n')
+      .filter((line) => line.startsWith('│'))
+      .map((line) => line.split('│')[1]?.trim());
+
+    expect(cells).toContain('alpha beta');
+    expect(cells).toContain('gamma delta');
+  });
+
   it('preserves long unbroken LaTeX cells in width-constrained tables', () => {
     const heading = '$\\operatorname{eig}(\\rho_{\\mathcal{A}_\\gamma}^{T_B})$';
     const spectrum = '$\\{-\\tfrac12,\\tfrac12,\\tfrac12,\\tfrac12\\}$';

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.ts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.ts
@@ -327,6 +327,29 @@ describe('renderAnsiMarkdown', () => {
     plainLinesWithinWidth(renderAnsiMarkdown(md, { width: 40 }), 40);
   });
 
+  it('preserves long unbroken LaTeX cells in width-constrained tables', () => {
+    const heading = '$\\operatorname{eig}(\\rho_{\\mathcal A_\\gamma}^{T_B})$';
+    const spectrum = '$\\{-\\tfrac12,\\tfrac12,\\tfrac12,\\tfrac12\\}$';
+    const md = [
+      `| $\\gamma$ | $\\operatorname{eig}(\\rho_{\\mathcal A_\\gamma})$ | ${heading} |`,
+      '|---|---|---|',
+      `| $0$ | $\\{0,0,0,1\\}$ | ${spectrum} |`,
+    ].join('\n');
+    const lines = plainLinesWithinWidth(
+      renderAnsiMarkdown(md, { width: 100 }),
+      100,
+    );
+    const thirdColumn = lines
+      .filter((line) => line.startsWith('│'))
+      .map((line) => line.split('│')[3] ?? '')
+      .join('')
+      .replaceAll(/\s/gu, '');
+
+    expect(thirdColumn).toContain(heading.replaceAll(/\s/gu, ''));
+    expect(thirdColumn).toContain(spectrum);
+    expect(lines.join('\n')).not.toContain('…');
+  });
+
   it('sizes a small table to its content instead of stretching to full width', () => {
     const md = '| n | digits |\n|---|---|\n| 447 | 993.3 |';
     const plain = renderPlain(md, { width: 80 });

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.ts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.ts
@@ -328,17 +328,20 @@ describe('renderAnsiMarkdown', () => {
   });
 
   it('preserves long unbroken LaTeX cells in width-constrained tables', () => {
-    const heading = '$\\operatorname{eig}(\\rho_{\\mathcal A_\\gamma}^{T_B})$';
+    const heading = '$\\operatorname{eig}(\\rho_{\\mathcal{A}_\\gamma}^{T_B})$';
     const spectrum = '$\\{-\\tfrac12,\\tfrac12,\\tfrac12,\\tfrac12\\}$';
+    const fullwidth = '量'.repeat(20);
     const md = [
       `| $\\gamma$ | $\\operatorname{eig}(\\rho_{\\mathcal A_\\gamma})$ | ${heading} |`,
       '|---|---|---|',
       `| $0$ | $\\{0,0,0,1\\}$ | ${spectrum} |`,
+      `| $1$ | channel | ${fullwidth} |`,
     ].join('\n');
-    const lines = plainLinesWithinWidth(
-      renderAnsiMarkdown(md, { width: 100 }),
-      100,
-    );
+    const rendered = renderAnsiMarkdown(md, {
+      width: 100,
+      colorEnabled: true,
+    });
+    const lines = plainLinesWithinWidth(rendered, 100);
     const thirdColumn = lines
       .filter((line) => line.startsWith('│'))
       .map((line) => line.split('│')[3] ?? '')
@@ -347,7 +350,11 @@ describe('renderAnsiMarkdown', () => {
 
     expect(thirdColumn).toContain(heading.replaceAll(/\s/gu, ''));
     expect(thirdColumn).toContain(spectrum);
+    expect(thirdColumn).toContain(fullwidth);
     expect(lines.join('\n')).not.toContain('…');
+    expect(
+      rendered.replaceAll(new RegExp(`${ESC}\\[[0-9;]*m`, 'gu'), ''),
+    ).not.toContain(ESC);
   });
 
   it('sizes a small table to its content instead of stretching to full width', () => {


### PR DESCRIPTION
Fixes #10126.

## Summary

CLI Markdown tables currently ask cli-table3 to wrap at word boundaries. When a cell contains one token wider than its assigned column—most notably a LaTeX expression—cli-table3 replaces the omitted suffix with an ellipsis. The rendered answer therefore loses mathematical content.

This change keeps the existing word-boundary wrapping for ordinary prose and opts only cells with an overlong indivisible token into hard wrapping. The same decision is applied to header and body cells at the renderer boundary, so downstream TUI components continue to receive one canonical rendered table.

## Evidence

The defect was reproduced in a real 100-column CLI chat while deriving and numerically checking the Choi spectrum of the amplitude-damping channel. Both a spectrum header and an eigenvalue cell were truncated. A renderer-level regression test now reconstructs the affected column from the terminal output and verifies that the complete LaTeX header and spectrum remain present, no ellipsis is introduced, and every line remains within 100 columns.

## Validation

- npm run format
- npm run compile:fast
- npm run lint
- npm run typecheck
- npm test (856 files passed, 1 skipped; 10,057 tests passed, 5 skipped)
