### PR TITLE
fix(cli): show direct-run resume hint on interrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ All notable changes to this project will be documented in this file.
   labels instead of internal model IDs.
 - **Workflow dashboards identify blocked tasks** — a task waiting for approval
   now shows the pending approval kind on its own row.
+- **Interrupted headless agent runs show how to resume** — stopping a tool-use
+  agent or multi-agent team now prints a command that preserves its workspace,
+  approval policy, and skill sources while reopening the interactive session
+  required for continuation.
 
 ### Shared (all surfaces)
 

--- a/packages/cli/src/commands/_helpers/output.ts
+++ b/packages/cli/src/commands/_helpers/output.ts
@@ -1,9 +1,7 @@
 import {
   writeNdjsonStdout,
   writeTextStderr,
-  writeTextStderrAndWait,
   writeTextStdout,
-  writeTextStdoutAndWait,
 } from '@cli/runtime/logSinks';
 import { pageStdout } from '@cli/runtime/pager';
 import type { CliContext } from '@cli/runtime/cliContext';
@@ -17,17 +15,6 @@ export function cliProgressWriter(
   context: Pick<CliContext, 'outputFormat'>,
 ): (text: string) => void {
   return context.outputFormat === 'text' ? writeTextStdout : writeTextStderr;
-}
-
-/** Awaitable counterpart for signal shutdown, where process.exit follows the
- * lifecycle drain and accepted text must reach its destination first. */
-export function writeCliProgressAndWait(
-  context: Pick<CliContext, 'outputFormat'>,
-  text: string,
-): Promise<void> {
-  return context.outputFormat === 'text'
-    ? writeTextStdoutAndWait(text)
-    : writeTextStderrAndWait(text);
 }
 
 /**

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -62,7 +62,7 @@ export async function runToolUseAgent(
       requireWorkspaceFiles: true,
       readStdinText: readCliStdinText,
     },
-    async ({ inputFiles, contextFiles }) => {
+    async ({ inputFiles, contextFiles, hasMaterializedStdinInput }) => {
       const config: AgentConfigPayload = {
         agent: init.agent,
         model,
@@ -82,6 +82,7 @@ export async function runToolUseAgent(
         enforceCategory: true,
         registerExecution: true,
         stopAfterCycle: true,
+        recoveryInputIsDurable: hasMaterializedStdinInput !== true,
         categoryMismatchMessage: `Agent "${init.agent}" resolved to a non tool-use run.`,
       });
       if (!execution.ok) return execution.exitCode;

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -194,7 +194,7 @@ export async function runMultiAgentPreset(
       requireWorkspaceFiles: true,
       readStdinText: readCliStdinText,
     },
-    async ({ inputFiles, contextFiles }) => {
+    async ({ inputFiles, contextFiles, hasMaterializedStdinInput }) => {
       if (runContext.approvalPolicy === 'never') {
         writeTextStderr(
           `WARN preset ${plan.preset.id} may run without subagent delegation because approval policy "never" denies approval-gated delegation tools. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`,
@@ -225,6 +225,7 @@ export async function runMultiAgentPreset(
         enforceCategory: true,
         registerExecution: true,
         stopAfterCycle: true,
+        recoveryInputIsDurable: hasMaterializedStdinInput !== true,
         categoryMismatchMessage: `Multi-agent preset "${init.preset}" resolved to a non tool-use execution.`,
       });
       if (!execution.ok) return execution.exitCode;

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -13,10 +13,14 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   CliUsageError,
   readCliStdinText,
-  readCliCwd,
   type CliContext,
 } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
+import {
+  formatInterruptedResumeHint,
+  tryReadCliCwd,
+  writeInterruptedResumeHint,
+} from '../runtime/interruptedResumeHint';
 import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
 import {
   buildHeadlessRunContext,
@@ -29,12 +33,7 @@ import {
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
-import {
-  cliProgressWriter,
-  emitCliResult,
-  writeCliProgressAndWait,
-} from './_helpers/output';
-import { formatResumeCommand } from '../chat/tui/state/resumeHint';
+import { emitCliResult } from './_helpers/output';
 import {
   AGENT_RUN_GLOBAL_ARGS,
   collectCommonAgentRunFlags,
@@ -71,15 +70,6 @@ function absoluteOutputDestination(
   return path.isAbsolute(destination)
     ? destination
     : path.join(cwd, destination);
-}
-
-/** Read the launch directory without making recovery depend on its lifetime. */
-function tryReadCliCwd(): string | undefined {
-  try {
-    return readCliCwd();
-  } catch {
-    return undefined;
-  }
 }
 
 interface WorkflowRunInit {
@@ -217,14 +207,14 @@ export async function executeCliWorkflowConfig(
     if (!recoveryInputIsDurable) return;
     if (resumeHintWritten) return;
     resumeHintWritten = true;
-    const hint = formatWorkflowResumeHint(
+    const hint = formatInterruptedResumeHint(
       runContext,
       executionId,
+      'workflow',
       config.workingDirectory || runContext.cwd,
       recoveryProcessCwd,
     );
-    if (waitForWrite) return writeCliProgressAndWait(runContext, hint);
-    cliProgressWriter(runContext)(hint);
+    return writeInterruptedResumeHint(hint, waitForWrite);
   };
   const execution = await executeCliConfig(config, runContext, {
     enforceCategory: true,
@@ -309,24 +299,6 @@ export async function executeCliWorkflowConfig(
   }
 
   return runOutcomeExitCode(result.outcome);
-}
-
-function formatWorkflowResumeHint(
-  context: CliContext,
-  executionId: string,
-  workingDirectory: string,
-  processCwd: string | undefined,
-): string {
-  const resumeCommand = formatResumeCommand(context.commandName, executionId, {
-    cwd: workingDirectory,
-    processCwd,
-    approvalPolicy: context.approvalPolicy,
-    outputFormat: context.outputFormat,
-    print: context.mode === 'headless',
-    includeInteropSkills: context.skillSourceOptions.includeInterop,
-    skillSourcePaths: context.skillSourceOptions.additionalPaths,
-  });
-  return `Resume this workflow with: ${resumeCommand}`;
 }
 
 async function persistWorkflowResultMeta(

--- a/packages/cli/src/runtime/interruptedResumeHint.ts
+++ b/packages/cli/src/runtime/interruptedResumeHint.ts
@@ -1,0 +1,45 @@
+import type { ExecutionId } from '@shared/schemas';
+
+import { formatResumeCommand } from '../chat/tui/state/resumeHint';
+import { readCliCwd, type CliContext } from './cliContext';
+import { writeTextStderr, writeTextStderrAndWait } from './logSinks';
+
+/** Read the launch directory without making recovery depend on its lifetime. */
+export function tryReadCliCwd(): string | undefined {
+  try {
+    return readCliCwd();
+  } catch {
+    // process.cwd() can fail after the launch directory is deleted. Omitting
+    // it safely makes the resume formatter state the workspace explicitly.
+    return undefined;
+  }
+}
+
+/** Keep recovery commands on the human-facing error stream. */
+export function writeInterruptedResumeHint(
+  hint: string,
+  waitForWrite = false,
+): Promise<void> | undefined {
+  if (waitForWrite) return writeTextStderrAndWait(hint);
+  writeTextStderr(hint);
+}
+
+/** Format a copyable command after the caller has established resumability. */
+export function formatInterruptedResumeHint(
+  context: CliContext,
+  executionId: ExecutionId,
+  subject: 'session' | 'workflow',
+  workingDirectory: string,
+  processCwd: string | undefined,
+): string {
+  const resumeCommand = formatResumeCommand(context.commandName, executionId, {
+    cwd: workingDirectory,
+    processCwd,
+    approvalPolicy: context.approvalPolicy,
+    outputFormat: subject === 'workflow' ? context.outputFormat : undefined,
+    print: subject === 'workflow' && context.mode === 'headless',
+    includeInteropSkills: context.skillSourceOptions.includeInterop,
+    skillSourcePaths: context.skillSourceOptions.additionalPaths,
+  });
+  return `Resume this ${subject} with: ${resumeCommand}`;
+}

--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -130,10 +130,6 @@ export function writeTextStderr(text: string): void {
   writeRaw('stderr', `${text}\n`);
 }
 
-export function writeTextStdoutAndWait(text: string): Promise<void> {
-  return writeRawAndWait('stdout', `${text}\n`);
-}
-
 export function writeTextStderrAndWait(text: string): Promise<void> {
   return writeRawAndWait('stderr', `${text}\n`);
 }

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -36,6 +36,11 @@ import {
   finalizeCliExecution,
   releaseCliExecutionLeaseAfterArtifacts,
 } from './executionFinalization';
+import {
+  formatInterruptedResumeHint,
+  tryReadCliCwd,
+  writeInterruptedResumeHint,
+} from './interruptedResumeHint';
 import { attachCliSessionProgressProjection } from './sessionProgressSubscription';
 import { initializeHeadlessTranscriptSession } from './transcriptSession';
 import { createCliRuntimeHost } from './cliPresentationHost';
@@ -172,10 +177,31 @@ export async function executeCliConfig<
 export async function executeCliToolUseConfig(
   config: AgentConfigPayload,
   runContext: CliContext,
-  options: CliConfigExecuteOptions<typeof AgentCategory.ToolUse> = {},
+  options: CliConfigExecuteOptions<typeof AgentCategory.ToolUse> & {
+    /** False when invocation-owned temporary inputs will not survive exit. */
+    readonly recoveryInputIsDurable?: boolean;
+  } = {},
 ) {
+  const { recoveryInputIsDurable = true, ...executeOptions } = options;
+  const recoveryProcessCwd = tryReadCliCwd();
+  const workingDirectory = config.workingDirectory || runContext.cwd;
   const execution = await executeCliConfig(config, runContext, {
-    ...options,
+    ...executeOptions,
+    onInterruptedExecutionFinalized:
+      recoveryInputIsDurable === true
+        ? (executeOptions.onInterruptedExecutionFinalized ??
+          ((executionId) =>
+            writeInterruptedResumeHint(
+              formatInterruptedResumeHint(
+                runContext,
+                executionId,
+                'session',
+                workingDirectory,
+                recoveryProcessCwd,
+              ),
+              true,
+            )))
+        : undefined,
     expectedCategory: AgentCategory.ToolUse,
   });
   if (!execution.ok) return execution;

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.ts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.ts
@@ -150,6 +150,9 @@ describe('CLI agents run command', () => {
     expect(config?.inputFiles).toEqual(['problem.md']);
     expect(config?.contextFiles).toEqual(['notes.md']);
     expect(config?.displayInstruction).toBe('Assess the proof concisely.');
+    expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
+      recoveryInputIsDurable: true,
+    });
     expect(config?.instruction).toContain('Primary user input files:');
     expect(config?.instruction).toContain('- "problem.md"');
     expect(config?.instruction).toContain('Read-only context files:');
@@ -179,6 +182,40 @@ describe('CLI agents run command', () => {
       result: emission.json,
     });
     expect(emission?.text).toBe('Correct.');
+  });
+
+  it('marks materialized stdin as unavailable for recovery advertising', async () => {
+    mocks.withExpandedRunInputs.mockImplementationOnce(
+      async (
+        _inputSpecs: readonly string[],
+        _contextSpecs: readonly string[],
+        _cwd: string,
+        _options: unknown,
+        run: (inputs: {
+          readonly inputFiles: string[];
+          readonly contextFiles: string[];
+          readonly hasMaterializedStdinInput: boolean;
+        }) => Promise<unknown>,
+      ) =>
+        run({
+          inputFiles: ['.texra-tmp/stdin.tex'],
+          contextFiles: [],
+          hasMaterializedStdinInput: true,
+        }),
+    );
+    const { runToolUseAgent } = await import('@cli/commands/agentsRun');
+
+    await runToolUseAgent(cliContext(), {
+      agent: 'chat',
+      inputFiles: ['-'],
+      contextFiles: [],
+      model: 'gpt54',
+      instruction: 'Assess the proof.',
+    });
+
+    expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
+      recoveryInputIsDurable: false,
+    });
   });
 
   it('publishes the canonical outcome for a shutdown cancellation', async () => {

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
@@ -294,6 +294,7 @@ describe('CLI multi-agent run command', () => {
     expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
       enforceCategory: true,
       registerExecution: true,
+      recoveryInputIsDurable: true,
       stopAfterCycle: true,
     });
     expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
@@ -339,6 +340,36 @@ describe('CLI multi-agent run command', () => {
       ...emission.json,
     });
     expect(emission?.text).toBe('The proof is correct.');
+  });
+
+  it('marks materialized stdin as unavailable for team recovery advertising', async () => {
+    mocks.withExpandedRunInputs.mockImplementationOnce(
+      async (
+        _inputSpecs: readonly string[],
+        _contextSpecs: readonly string[],
+        _cwd: string,
+        _options: unknown,
+        run: (inputs: {
+          readonly inputFiles: string[];
+          readonly contextFiles: string[];
+          readonly hasMaterializedStdinInput: boolean;
+        }) => Promise<unknown>,
+      ) =>
+        run({
+          inputFiles: ['.texra-tmp/stdin.tex'],
+          contextFiles: [],
+          hasMaterializedStdinInput: true,
+        }),
+    );
+
+    await runPreset({
+      inputFiles: ['-'],
+      instruction: 'Inspect the proof.',
+    });
+
+    expect(mocks.executeCliToolUseConfig.mock.calls[0]?.[2]).toMatchObject({
+      recoveryInputIsDurable: false,
+    });
   });
 
   it('marks run-plan resolution when authenticated gaps triggered a remote load', async () => {

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -42,6 +42,7 @@ const mocks = vi.hoisted(() => ({
   releaseExecutionLeaseAfterArtifacts: vi.fn(),
   runAgent: vi.fn(),
   writeTextStderr: vi.fn(),
+  writeTextStderrAndWait: vi.fn<() => Promise<void>>(async () => undefined),
   finalizeExecution: vi.fn(),
 }));
 
@@ -126,6 +127,7 @@ vi.mock('@cli/runtime/workflowPlainOutput', () => ({
 
 vi.mock('@cli/runtime/logSinks', () => ({
   writeTextStderr: mocks.writeTextStderr,
+  writeTextStderrAndWait: mocks.writeTextStderrAndWait,
 }));
 
 type CliRequest = Parameters<typeof executeCliRequest>[0];
@@ -1247,6 +1249,92 @@ describe('executeCliConfig', () => {
       stopAfterCycle: true,
     });
   }
+
+  it('prints a complete resume command after interrupted tool-use recovery is available', async () => {
+    const { platform } = await installFakePlatform();
+    const { executeCliToolUseConfig } = await loadRunExecution();
+    const context = cliContext({
+      approvalPolicy: 'yolo',
+      outputFormat: 'ndjson',
+      skillSourceOptions: {
+        includeInterop: true,
+        additionalPaths: ['/tmp/skill path'],
+      },
+    });
+    let publishLeaseScope: LeaseOptions['onExecutionLeaseAcquired'];
+    let publishRun: LeaseOptions['onRun'];
+    const hangingRun = stubHangingRun((options) => {
+      publishLeaseScope = options.onExecutionLeaseAcquired;
+      publishRun = options.onRun;
+    });
+    let settleRecoveryWrite!: () => void;
+    const recoveryWrite = new Promise<void>((resolve) => {
+      settleRecoveryWrite = resolve;
+    });
+    mocks.writeTextStderrAndWait.mockReturnValueOnce(recoveryWrite);
+
+    const run = executeCliToolUseConfig(toolUseConfig(), context, {
+      registerExecution: true,
+      stopAfterCycle: true,
+    });
+    await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
+    const shutdown = platform.lifecycle.runShutdown();
+    publishLeaseScope?.((operation) => operation(), 'exec-1' as ExecutionId);
+    publishRun?.();
+    mocks.readCliRunOutcomeState.mockResolvedValueOnce({
+      outcome: RUN_OUTCOME.CANCELLED,
+      outcomePersisted: true,
+    });
+    hangingRun.resolve(COMPLETED_RUN);
+
+    await vi.waitFor(() =>
+      expect(mocks.writeTextStderrAndWait).toHaveBeenCalledOnce(),
+    );
+    let shutdownResolved = false;
+    void shutdown.then(() => {
+      shutdownResolved = true;
+    });
+    await Promise.resolve();
+    expect(shutdownResolved).toBe(false);
+    settleRecoveryWrite();
+    await shutdown;
+    await expect(run).resolves.toMatchObject({
+      ok: true,
+      exitCode: CliExitCode.Interrupted,
+    });
+    expect(mocks.writeTextStderrAndWait).toHaveBeenCalledExactlyOnceWith(
+      "Resume this session with: texra resume exec-1 --cwd /tmp/project --approval-policy yolo --include-interop --source '/tmp/skill path'",
+    );
+  });
+
+  it('does not advertise recovery for invocation-owned temporary inputs', async () => {
+    const { platform } = await installFakePlatform();
+    const { executeCliToolUseConfig } = await loadRunExecution();
+    let publishLeaseScope: LeaseOptions['onExecutionLeaseAcquired'];
+    let publishRun: LeaseOptions['onRun'];
+    const hangingRun = stubHangingRun((options) => {
+      publishLeaseScope = options.onExecutionLeaseAcquired;
+      publishRun = options.onRun;
+    });
+
+    const run = executeCliToolUseConfig(toolUseConfig(), cliContext(), {
+      registerExecution: true,
+      recoveryInputIsDurable: false,
+    });
+    await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
+    const shutdown = platform.lifecycle.runShutdown();
+    publishLeaseScope?.((operation) => operation(), 'exec-1' as ExecutionId);
+    publishRun?.();
+    mocks.readCliRunOutcomeState.mockResolvedValueOnce({
+      outcome: RUN_OUTCOME.CANCELLED,
+      outcomePersisted: true,
+    });
+    hangingRun.resolve(COMPLETED_RUN);
+
+    await shutdown;
+    await run;
+    expect(mocks.writeTextStderrAndWait).not.toHaveBeenCalled();
+  });
 
   /** Stubs a workflow-category result where a tool-use run was expected. */
   async function runWorkflowCategoryMismatch() {

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
@@ -30,7 +30,6 @@ const mocks = vi.hoisted(() => {
     writeTextStderr: vi.fn(),
     writeTextStderrAndWait: vi.fn(async () => undefined),
     writeTextStdout: vi.fn(),
-    writeTextStdoutAndWait: vi.fn(async () => undefined),
   };
 });
 
@@ -90,7 +89,6 @@ vi.mock('@cli/runtime/logSinks', () => ({
   writeTextStderr: mocks.writeTextStderr,
   writeTextStderrAndWait: mocks.writeTextStderrAndWait,
   writeTextStdout: mocks.writeTextStdout,
-  writeTextStdoutAndWait: mocks.writeTextStdoutAndWait,
 }));
 
 vi.mock('@cli/runtime/workflowInputs', () => ({
@@ -652,7 +650,7 @@ describe('CLI workflow run command', () => {
           compileFailures: [],
         }),
       );
-      expect(mocks.writeTextStdout).toHaveBeenCalledExactlyOnceWith(
+      expect(mocks.writeTextStderr).toHaveBeenCalledExactlyOnceWith(
         expectedRecoveryHint(
           cliContext({
             cwd: root,
@@ -663,7 +661,7 @@ describe('CLI workflow run command', () => {
         ),
       );
       expect(mocks.writeResultMeta.mock.invocationCallOrder[0]).toBeLessThan(
-        mocks.writeTextStdout.mock.invocationCallOrder[0],
+        mocks.writeTextStderr.mock.invocationCallOrder[0],
       );
     });
   });
@@ -725,7 +723,7 @@ describe('CLI workflow run command', () => {
     expect(mocks.writeErrorStderr).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({ code: 'ENOENT' }),
     );
-    expect(mocks.writeTextStdout).toHaveBeenCalledExactlyOnceWith(
+    expect(mocks.writeTextStderr).toHaveBeenCalledExactlyOnceWith(
       expectedRecoveryHint(cliContext(), 'exec-interrupted-copy'),
     );
   });
@@ -803,7 +801,7 @@ describe('CLI workflow run command', () => {
     expect(
       mocks.executeCliConfig.mock.calls[0]?.[2].onInterruptedExecutionFinalized,
     ).toBeTypeOf('function');
-    expect(mocks.writeTextStdout).toHaveBeenCalledOnce();
+    expect(mocks.writeTextStderr).toHaveBeenCalledOnce();
   });
 
   it('rejects recovery advertising for a checkpoint carrying a flow failure', async () => {
@@ -860,7 +858,7 @@ describe('CLI workflow run command', () => {
 
     expect(exitCode).toBe(CliExitCode.Interrupted);
     expect(mocks.writeTextStdout).not.toHaveBeenCalled();
-    expect(mocks.writeTextStdoutAndWait).toHaveBeenCalledExactlyOnceWith(
+    expect(mocks.writeTextStderrAndWait).toHaveBeenCalledExactlyOnceWith(
       expectedRecoveryHint(context, 'exec-signal', persistedWorkspace),
     );
   });
@@ -890,7 +888,7 @@ describe('CLI workflow run command', () => {
     await expect(result).resolves.toBe(CliExitCode.Interrupted);
     expect(cwdSpy).toHaveBeenCalledOnce();
     cwdSpy.mockRestore();
-    expect(mocks.writeTextStdout).toHaveBeenCalledExactlyOnceWith(
+    expect(mocks.writeTextStderr).toHaveBeenCalledExactlyOnceWith(
       `Resume this workflow with: ${formatResumeCommand(
         context.commandName,
         'exec-deleted-cwd',


### PR DESCRIPTION
Closes #10104.

## What changed

- Print one canonical `texra resume <execution-id>` command after an interrupted headless tool-use execution becomes durably resumable.
- Preserve the effective working directory, non-default approval policy, interop-skill choice, and repeated custom skill sources.
- Apply the same recovery boundary to `agents run` and `multi-agent run`.
- Suppress recovery guidance when standard input was materialized into invocation-owned temporary files.
- Reuse the workflow recovery formatter and launch-directory probe so the two headless recovery surfaces cannot drift.

## Root cause

The shared shutdown boundary already persisted `CANCELLED`, drained artifacts, released the execution lease, recomputed resumability, and inspected the released lease. Workflow runs supplied a callback at that boundary, but direct tool-use runs did not. Consequently, recovery was valid but invisible unless the operator queried history separately.

## User impact

Pressing Ctrl-C during `agents run` or `multi-agent run` now prints a copyable recovery command only after that command is immediately usable. Completed runs, failed runs, and machine-readable standard output are unchanged; the recovery line is written to standard error.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm run typecheck:cli`
- `npm run typecheck:test-kernel`
- Focused CLI command and shutdown suites: 90 tests passed.
- Full Vitest suite: 10,082 passed, 5 skipped.
