### PR TITLE
fix(agent): stop exposing tool-use turns as rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ All notable changes to this project will be documented in this file.
 - **Read-only completion checks stay focused** — end-of-session review no
   longer asks to inspect project plans, Git history, or pull requests when the
   current task and its delegated results already contain the evidence needed.
+- **Tool-use chats no longer show misleading round jumps** — internal model
+  and tool calls no longer appear as skipped user-visible rounds after a chat
+  continues or resumes.
 - **Concurrent app starts refresh bundled agents safely** — simultaneous TeXRA
   processes sharing one data directory no longer fail while updating built-in
   agent definitions.

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -128,14 +128,14 @@ export class ToolUseCycleNode<C> extends Node<
       kind: 'session',
     });
 
-    let roundOutcome: RunOutcome = RUN_OUTCOME.FAILED;
+    let sessionOutcome: RunOutcome = RUN_OUTCOME.FAILED;
     try {
       await sessionStage.within(() => flow.run(roundShared));
 
       const lastError = roundShared.shouldStop
         ? roundShared.lastError
         : undefined;
-      roundOutcome = deriveRunOutcome({
+      sessionOutcome = deriveRunOutcome({
         failed: lastError !== undefined,
         cancelled: roundShared.shouldStop && !roundShared.endTurn,
       });
@@ -147,7 +147,7 @@ export class ToolUseCycleNode<C> extends Node<
           response: roundShared.latestAssistantText,
         };
       }
-      if (roundOutcome === RUN_OUTCOME.CANCELLED) {
+      if (sessionOutcome === RUN_OUTCOME.CANCELLED) {
         return {
           outcome: 'cancelled',
           response: roundShared.latestAssistantText,
@@ -171,7 +171,7 @@ export class ToolUseCycleNode<C> extends Node<
       }
       throw error;
     } finally {
-      sessionStage.end(roundOutcome);
+      sessionStage.end(sessionOutcome);
       if (roundShared.currentUserInstruction !== undefined) {
         prepRes.userChannels.transient[USER_VAR_INSTRUCTION] =
           roundShared.currentUserInstruction;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -120,17 +120,17 @@ export class ToolUseCycleNode<C> extends Node<
       },
     });
 
-    const roundStage = this.services.logger.openStage(
-      `r${roundShared.roundIndex}`,
-      {
-        kind: 'round',
-        index: roundShared.roundIndex,
-      },
-    );
+    // This outer cycle is one session turn that may contain many model/tool
+    // rounds. Keep it as a structural stage; only the inner invocations advance
+    // runState.totalRounds, so classifying this span as round progress leaves a
+    // stale badge that jumps by the hidden invocation count on the next turn.
+    const sessionStage = this.services.logger.openStage('Tool-use turn', {
+      kind: 'session',
+    });
 
     let roundOutcome: RunOutcome = RUN_OUTCOME.FAILED;
     try {
-      await roundStage.within(() => flow.run(roundShared));
+      await sessionStage.within(() => flow.run(roundShared));
 
       const lastError = roundShared.shouldStop
         ? roundShared.lastError
@@ -171,7 +171,7 @@ export class ToolUseCycleNode<C> extends Node<
       }
       throw error;
     } finally {
-      roundStage.end(roundOutcome);
+      sessionStage.end(roundOutcome);
       if (roundShared.currentUserInstruction !== undefined) {
         prepRes.userChannels.transient[USER_VAR_INSTRUCTION] =
           roundShared.currentUserInstruction;

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -198,9 +198,9 @@ export class UsageMonitor {
         },
         {
           recordTranscript: agentCategory === AgentCategory.Workflow,
-          // The round stage's AsyncLocalStorage scope already stamps the active
-          // round id (r0/r1...) onto emitted events; fall back to storageKey for
-          // any usage logged outside a round stage.
+          // The ambient stage's AsyncLocalStorage scope stamps its structural
+          // id onto emitted events; fall back to storageKey when usage is
+          // logged outside a stage.
           stageId: logger.activeStageId() ?? storageKey,
         },
       );

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -67,7 +67,7 @@ export type ActiveChildInfo = z.infer<typeof ActiveChildInfoSchema>;
 const RoundStageSchema = z.object({
   /** Zero-based round/turn index. */
   index: z.int().nonnegative(),
-  /** Planned total, when known. Workflow runs set this; tool-use turns may not. */
+  /** Planned total, when known. Reflection workflows set this. */
   total: z.int().positive().optional(),
 });
 
@@ -75,10 +75,10 @@ export type RoundStage = z.infer<typeof RoundStageSchema>;
 
 // Phase Stage (ephemeral phase label from typed stage.start metadata)
 //
-// A workflow-script run advances through named phases instead of numbered
-// rounds, so it fills this slot where a tool-use run fills `roundStage`. Both
-// are projected from the same `stage.start` fact, discriminated by its `kind`,
-// and a stream that opens phases never opens rounds.
+// A workflow-script run advances through named phases instead of the numbered
+// rounds used by reflection workflows. Both are projected from the same
+// `stage.start` fact, discriminated by its `kind`, and a stream that opens
+// phases never opens rounds.
 
 const PhaseStageSchema = z.object({
   /** Phase title, free-form text from the workflow script. */
@@ -93,9 +93,9 @@ const PhaseStageSchema = z.object({
 export type PhaseStage = z.infer<typeof PhaseStageSchema>;
 
 /**
- * The one discriminated run-progress slot: a tool-use run advances through
- * numbered rounds, a workflow-script run through named phases — never both —
- * so state and wire carry one `stage` field rather than two
+ * The one discriminated run-progress slot: a reflection workflow advances
+ * through numbered rounds, a workflow-script run through named phases — never
+ * both — so state and wire carry one `stage` field rather than two
  * independently-optional ones every reader has to fall back between. The arms
  * extend the payload schemas above, so projecting to either is a `kind` strip.
  */

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -378,7 +378,7 @@ describe('tool-use progress events', () => {
   });
 });
 
-describe('tool-use round outcome persistence (#8023)', () => {
+describe('tool-use session-stage outcome persistence (#8023)', () => {
   it.each([
     {
       name: 'completed',
@@ -405,7 +405,7 @@ describe('tool-use round outcome persistence (#8023)', () => {
       expectedStatus: RUN_OUTCOME.CANCELLED,
     },
   ])(
-    'persists a $name round with its canonical RunOutcome',
+    'persists a $name outer turn as a structural session stage',
     async ({
       name,
       shouldStop,
@@ -433,7 +433,7 @@ describe('tool-use round outcome persistence (#8023)', () => {
         );
 
         expect(result.outcome).toBe(expectedOutcome);
-        const roundEndStatuses =
+        const sessionStages =
           store
             .get(streamId)
             ?.getRange(0)
@@ -441,13 +441,23 @@ describe('tool-use round outcome persistence (#8023)', () => {
               if (
                 entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_END &&
                 isObject(entry.data) &&
-                entry.data.kind === 'round'
+                entry.data.kind === 'session'
               ) {
-                return [entry.data.status];
+                return [{ label: entry.text, status: entry.data.status }];
               }
               return [];
             }) ?? [];
-        expect(roundEndStatuses).toEqual([expectedStatus]);
+        expect(sessionStages).toEqual([
+          { label: 'Tool-use turn', status: expectedStatus },
+        ]);
+        expect(
+          store
+            .get(streamId)
+            ?.getRange(0)
+            .some(
+              (entry) => isObject(entry.data) && entry.data.kind === 'round',
+            ),
+        ).toBe(false);
       } finally {
         recorder.unsubscribe();
       }

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -202,8 +202,8 @@ export function attachTranscriptRecorder(
   // instead of appending a duplicate row. Set on `stream.start` for a
   // MODEL_RESPONSE stream, consumed (and cleared) by `response.finalized`, and
   // reset when the invocation proceeds to tool execution. A single tool-use
-  // round stage can contain several model invocations, so the outer round
-  // stage is too coarse to be the only reset boundary.
+  // session stage can contain several model invocations, so the outer stage is
+  // too coarse to be the only reset boundary.
   let pendingModelResponseId: string | undefined;
 
   const flushStream = (state: StreamSinkState, id: string): void => {


### PR DESCRIPTION
## Summary

- classify the outer tool-use cycle as the existing structural `session` stage instead of a progress `round`;
- preserve stage grouping and canonical completed, failed, and cancelled outcomes;
- keep genuine reflection/workflow `rN/M` progress unchanged;
- add a boundary regression test and a user-visible changelog entry.

Closes #10138.

## Root cause and ownership

`ToolUseRoundFlow` defines a round as one model invocation plus its tool dispatch. `ToolUseCycleNode`, by contrast, is the outer session turn and may execute many such rounds.

The outer node nevertheless opened one long-lived `kind: 'round'` stage using the initial `runState.totalRounds` value. The inner flow then incremented that counter after every model invocation without replacing the displayed stage. A tool-heavy first turn therefore remained at `r1`, while the next or resumed turn began at (for example) `r11`.

The fix uses the stage vocabulary's existing distinction: `session` stages structure a trace but are not projected as round progress. No new counter, display exception, or parallel representation is introduced.

## User impact

Continued and resumed tool-use chats no longer show round jumps caused solely by hidden model/tool invocations. Workflow agents with genuine fixed rounds continue to show their planned progress.

## PTY evidence

Reproduced on macOS with `TERM=xterm-256color`, a 60×20 PTY, included API mode, and approval policy `ask`:

- a three-agent quantum-channel workflow remained at `r1` through ten internal model/tool cycles;
- the first post-resume follow-up displayed `r11`;
- transcript rehydration and the mathematical result were otherwise correct.

After this change, the same persisted session was resumed and given another follow-up. The running bar showed elapsed time, access, quota, and context occupancy without a false round badge; the response completed normally.

## Validation

- `npm test` — 10,081 passed, 5 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `npm run texra-local:build`
- targeted stage/status suites — 149 passed
- Prettier and `git diff --check`
- real 60×20 PTY resume/follow-up verification