### PR TITLE
fix(cli): show current workflow rerun progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ All notable changes to this project will be documented in this file.
 - **Workflow task progress shows recognizable model names** — focused
   dashboards, interactive transcripts, and headless progress use catalog
   labels instead of internal model IDs.
+- **Workflow reruns show current task progress** — retrying a saved workflow no
+  longer counts completed or failed task states from earlier attempts in the
+  live dashboard.
 - **Workflow dashboards identify blocked tasks** — a task waiting for approval
   now shows the pending approval kind on its own row.
 - **Interrupted headless agent runs show how to resume** — stopping a tool-use

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -158,13 +158,15 @@ export function workflowRunStatusSummary(
   slice: StreamSlice | undefined,
 ): readonly WorkflowStatusSegment[] | undefined {
   if (slice?.category !== AgentCategory.Workflow) return undefined;
-  const currentAttemptId = latestWorkflowAttemptId(
-    slice.entries.map((entry) => {
-      if (entry.role === 'workflowTask') return entry.task.attemptId;
-      if (entry.role === 'phase') return entry.attemptId;
-      return undefined;
-    }),
-  );
+  const currentAttemptId =
+    slice.workflowAttemptId ??
+    latestWorkflowAttemptId(
+      slice.entries.map((entry) => {
+        if (entry.role === 'workflowTask') return entry.task.attemptId;
+        if (entry.role === 'phase') return entry.attemptId;
+        return undefined;
+      }),
+    );
   const phase = slice.entries.findLast(
     (entry): entry is Extract<ConversationEntry, { readonly role: 'phase' }> =>
       entry.role === 'phase' &&
@@ -174,9 +176,7 @@ export function workflowRunStatusSummary(
     slice.entries.flatMap((entry) =>
       entry.role === 'workflowTask' ? [entry.task] : [],
     ),
-  ).filter(
-    (call) =>
-      currentAttemptId === undefined || call.attemptId === currentAttemptId,
+    currentAttemptId,
   );
   const { done, total } = workflowPhaseCallProgress(
     phase ? currentCalls.filter((call) => call.phase === phase.phaseLabel) : [],

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -7,6 +7,7 @@ import { COLOR_WARNING } from '@cli/tui/ui/colors';
 import { AgentCategory } from '@shared/schemas';
 import {
   formatWorkflowPhaseHeading,
+  latestWorkflowAttemptId,
   latestWorkflowCallsById,
   workflowCallFailureTally,
   workflowPhaseCallProgress,
@@ -157,11 +158,25 @@ export function workflowRunStatusSummary(
   slice: StreamSlice | undefined,
 ): readonly WorkflowStatusSegment[] | undefined {
   if (slice?.category !== AgentCategory.Workflow) return undefined;
-  const phase = slice.entries.findLast((entry) => entry.role === 'phase');
+  const currentAttemptId = latestWorkflowAttemptId(
+    slice.entries.map((entry) => {
+      if (entry.role === 'workflowTask') return entry.task.attemptId;
+      if (entry.role === 'phase') return entry.attemptId;
+      return undefined;
+    }),
+  );
+  const phase = slice.entries.findLast(
+    (entry): entry is Extract<ConversationEntry, { readonly role: 'phase' }> =>
+      entry.role === 'phase' &&
+      (currentAttemptId === undefined || entry.attemptId === currentAttemptId),
+  );
   const currentCalls = latestWorkflowCallsById(
     slice.entries.flatMap((entry) =>
       entry.role === 'workflowTask' ? [entry.task] : [],
     ),
+  ).filter(
+    (call) =>
+      currentAttemptId === undefined || call.attemptId === currentAttemptId,
   );
   const { done, total } = workflowPhaseCallProgress(
     phase ? currentCalls.filter((call) => call.phase === phase.phaseLabel) : [],

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -8,7 +8,6 @@ import { AgentCategory } from '@shared/schemas';
 import {
   formatWorkflowPhaseHeading,
   latestWorkflowCallsById,
-  latestWorkflowEntryAttemptId,
   workflowCallFailureTally,
   workflowPhaseCallProgress,
 } from '@shared/copy/workflowCall';
@@ -16,6 +15,7 @@ import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 
 import {
   activeStreamId as activeStreamIdSignal,
+  currentWorkflowAttemptId,
   streams as streamsSignal,
   type ConversationEntry,
   type StreamSlice,
@@ -158,8 +158,10 @@ export function workflowRunStatusSummary(
   slice: StreamSlice | undefined,
 ): readonly WorkflowStatusSegment[] | undefined {
   if (slice?.category !== AgentCategory.Workflow) return undefined;
-  const currentAttemptId =
-    slice.workflowAttemptId ?? latestWorkflowEntryAttemptId(slice.entries);
+  const currentAttemptId = currentWorkflowAttemptId(
+    slice.workflowAttemptId,
+    slice.entries,
+  );
   const phase = slice.entries.findLast(
     (entry): entry is Extract<ConversationEntry, { readonly role: 'phase' }> =>
       entry.role === 'phase' &&

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -7,8 +7,8 @@ import { COLOR_WARNING } from '@cli/tui/ui/colors';
 import { AgentCategory } from '@shared/schemas';
 import {
   formatWorkflowPhaseHeading,
-  latestWorkflowAttemptId,
   latestWorkflowCallsById,
+  latestWorkflowEntryAttemptId,
   workflowCallFailureTally,
   workflowPhaseCallProgress,
 } from '@shared/copy/workflowCall';
@@ -159,14 +159,7 @@ export function workflowRunStatusSummary(
 ): readonly WorkflowStatusSegment[] | undefined {
   if (slice?.category !== AgentCategory.Workflow) return undefined;
   const currentAttemptId =
-    slice.workflowAttemptId ??
-    latestWorkflowAttemptId(
-      slice.entries.map((entry) => {
-        if (entry.role === 'workflowTask') return entry.task.attemptId;
-        if (entry.role === 'phase') return entry.attemptId;
-        return undefined;
-      }),
-    );
+    slice.workflowAttemptId ?? latestWorkflowEntryAttemptId(slice.entries);
   const phase = slice.entries.findLast(
     (entry): entry is Extract<ConversationEntry, { readonly role: 'phase' }> =>
       entry.role === 'phase' &&

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -7,6 +7,7 @@ import { COLOR_WARNING } from '@cli/tui/ui/colors';
 import { AgentCategory } from '@shared/schemas';
 import {
   formatWorkflowPhaseHeading,
+  latestWorkflowCallsById,
   workflowCallFailureTally,
   workflowPhaseCallProgress,
 } from '@shared/copy/workflowCall';
@@ -157,14 +158,13 @@ export function workflowRunStatusSummary(
 ): readonly WorkflowStatusSegment[] | undefined {
   if (slice?.category !== AgentCategory.Workflow) return undefined;
   const phase = slice.entries.findLast((entry) => entry.role === 'phase');
+  const currentCalls = latestWorkflowCallsById(
+    slice.entries.flatMap((entry) =>
+      entry.role === 'workflowTask' ? [entry.task] : [],
+    ),
+  );
   const { done, total } = workflowPhaseCallProgress(
-    phase
-      ? slice.entries.flatMap((entry) =>
-          entry.role === 'workflowTask' && entry.task.phase === phase.phaseLabel
-            ? [entry.task]
-            : [],
-        )
-      : [],
+    phase ? currentCalls.filter((call) => call.phase === phase.phaseLabel) : [],
   );
   const segments: WorkflowStatusSegment[] = [];
   if (phase) {
@@ -178,11 +178,7 @@ export function workflowRunStatusSummary(
   // is whole-run, so a failure persists after the run advances past its phase
   // (unlike the current-phase done/total).
   if (segments.length > 0) {
-    const { failed } = workflowCallFailureTally(
-      slice.entries.flatMap((entry) =>
-        entry.role === 'workflowTask' ? [entry.task] : [],
-      ),
-    );
+    const { failed } = workflowCallFailureTally(currentCalls);
     if (failed > 0) {
       segments.push({ text: `${failed} failed`, tone: 'warning' });
     }

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -79,15 +79,18 @@ interface PhaseHeaderDetails extends WorkflowPhaseHeading {
 
 function PhaseHeader({
   details,
+  focused = false,
 }: {
   readonly details: PhaseHeaderDetails;
+  readonly focused?: boolean;
 }): React.JSX.Element {
   const inlineProgress = details.progress ? ` · ${details.progress}` : '';
   return (
     <Box flexDirection="row" flexGrow={1} minWidth={0}>
       <Box minWidth={0} flexShrink={1}>
-        <Text dimColor>{'    '}</Text>
-        <Text aria-hidden dimColor>{`${STATUS_DIAMOND} `}</Text>
+        <Text aria-hidden dimColor>
+          {focused ? `${POINTER} ${STATUS_DIAMOND} ` : `    ${STATUS_DIAMOND} `}
+        </Text>
         <Text dimColor wrap="truncate-end">
           {`${formatWorkflowPhaseHeading(details)}${inlineProgress}`}
         </Text>
@@ -339,7 +342,11 @@ function WorkflowDashboard({
     value: workflowTaskListValue(entry.id),
   }));
   const narrowItems: SelectItem<ChildListValue>[] = groups.flatMap((group) => [
-    { label: group.label, value: group.value, disabled: true },
+    {
+      label: group.label,
+      value: group.value,
+      disabled: group.tasks.length > 0,
+    },
     ...group.tasks.map((entry) => ({
       label: entry.task.label,
       value: workflowTaskListValue(entry.id),
@@ -489,7 +496,10 @@ function WorkflowDashboard({
           renderItem={(item, state) => {
             const group = groupByValue.get(item.value);
             return group ? (
-              <PhaseHeader details={groupDetails(group)} />
+              <PhaseHeader
+                details={groupDetails(group)}
+                focused={state.focused}
+              />
             ) : (
               renderTask(item, state)
             );

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -373,7 +373,10 @@ function WorkflowDashboard({
     { isActive: keyboardActive },
   );
 
-  if (tasks.length === 0 || (contentRows !== undefined && contentRows <= 0)) {
+  if (
+    (tasks.length === 0 && groups.length === 0) ||
+    (contentRows !== undefined && contentRows <= 0)
+  ) {
     return null;
   }
   const heading = `${model.root.agent ?? 'Workflow'} · ${done}/${total} done`;

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -123,6 +123,8 @@ export type ConversationEntry = ConversationEntryOrigin &
         readonly phaseIndex?: number;
         /** Total phase count for the run, when the emitter provides it. */
         readonly phaseTotal?: number;
+        /** Physical workflow attempt that emitted this phase. */
+        readonly attemptId?: string;
       })
     | (ConversationEntryBase & {
         readonly role: 'tool';

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -215,6 +215,9 @@ export interface TranscriptFoldState {
   activeSkills: readonly ActiveSkillSummary[];
   /** Highest-seq live-activity entry (drives the thinking indicator). */
   liveActivityEntry?: StreamLogEntry;
+  /** Latest durable workflow-attempt marker and its source order. */
+  workflowAttemptId?: string;
+  workflowAttemptSeqNo: number;
   /** Synthetic rows reconciled into `items`, in slice order, by identity. */
   synthetics: readonly ConversationEntry[];
   /** Incremental task-group / compaction memos. Unlike the fold fields above
@@ -288,6 +291,8 @@ export interface StreamSlice {
   readonly compileFailuresByRound: RoundIndexed<CompileFailure>;
   /** Run/round/phase lifecycle projected from the canonical StreamLog. */
   readonly taskGroups: readonly TaskGroup[];
+  /** Latest physical workflow attempt declared by the durable stream. */
+  readonly workflowAttemptId?: string | undefined;
   readonly status: StreamPhase | undefined;
   readonly substate?: StreamSubstate;
   /** Epoch ms when this stream last entered `RUNNING`; cleared on any other
@@ -363,6 +368,7 @@ export function emptySlice(streamId: StreamTabId): StreamSlice {
     missingOutputsByRound: {},
     compileFailuresByRound: {},
     taskGroups: [],
+    workflowAttemptId: undefined,
     thinkingActive: false,
     compactingActive: false,
     usage: undefined,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -30,6 +30,7 @@ import {
   type UserFollowUpSupport,
   type WorkflowCallProgress,
 } from '@shared/schemas';
+import { latestWorkflowAttemptId } from '@shared/copy/workflowCall';
 import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
 import type {
   CompactionActivityBlock,
@@ -135,6 +136,23 @@ export type ConversationEntry = ConversationEntryOrigin &
         readonly images: readonly LoadedImage[];
       })
   );
+
+/** Resolve the current workflow attempt from session state, with a legacy transcript fallback. */
+export function currentWorkflowAttemptId(
+  declaredAttemptId: string | undefined,
+  entries: readonly ConversationEntry[],
+): string | undefined {
+  return (
+    declaredAttemptId ??
+    latestWorkflowAttemptId(
+      entries.map((entry) => {
+        if (entry.role === 'workflowTask') return entry.task.attemptId;
+        if (entry.role === 'phase') return entry.attemptId;
+        return undefined;
+      }),
+    )
+  );
+}
 
 /**
  * One transcript-projection candidate: a rendered row plus the ordering key

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -436,6 +436,7 @@ export function syncStreamLog(
       slice.latestLine === latestLine &&
       slice.thinkingActive === thinkingActive &&
       slice.compactingActive === compactingActive &&
+      slice.workflowAttemptId === state.workflowAttemptId &&
       isDeepStrictEqual(slice.activeSkills, activeSkills) &&
       slice.taskGroups === taskGroups
     ) {
@@ -449,6 +450,7 @@ export function syncStreamLog(
       activeSkills,
       thinkingActive,
       compactingActive,
+      workflowAttemptId: state.workflowAttemptId,
       taskGroups,
     };
   });

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -204,12 +204,12 @@ function phaseGroupData(
   ) {
     return null;
   }
-  // Same tolerant parse `updateTaskGroups` (progress-view logSlice) uses for
-  // the identical group-log payload: per-field `.catch(undefined)` so a
-  // malformed `index`/`total` drops just that field, not the whole header.
-  const { kind, index, total, attemptId } = GroupLogPayloadSchema.catch(
-    {},
-  ).parse(entry.data);
+  // Same parse `updateTaskGroups` uses for the identical group-log payload:
+  // display fields recover independently, while malformed attempt ownership
+  // rejects the payload and therefore cannot masquerade as a legacy omission.
+  const payload = GroupLogPayloadSchema.safeParse(entry.data);
+  if (!payload.success) return null;
+  const { kind, index, total, attemptId } = payload.data;
   if (kind !== 'phase') return null;
   return {
     ...(index !== undefined ? { index } : {}),

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -24,6 +24,7 @@ import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   TOOL_USE_STATUS,
+  WorkflowAttemptMarkerSchema,
   WorkflowCallProgressSchema,
   isPlainAgentIdentity,
   isTerminalWorkflowCallProgress,
@@ -574,6 +575,7 @@ export function createTranscriptFoldState(): TranscriptFoldState {
     finalizedFrontier: 0,
     latestUserPos: -1,
     latestResponsePos: -1,
+    workflowAttemptSeqNo: -1,
     fullLogChild: false,
     workflowOperationalOnly: false,
     projectLifecycleToTaskGroups: false,
@@ -591,6 +593,8 @@ export function resetTranscriptFoldState(state: TranscriptFoldState): void {
   state.finalizedFrontier = 0;
   state.latestUserPos = -1;
   state.latestResponsePos = -1;
+  state.workflowAttemptId = undefined;
+  state.workflowAttemptSeqNo = -1;
   state.activeSkillsEntry = undefined;
   state.activeSkillsParsedFor = undefined;
   state.activeSkills = [];
@@ -817,6 +821,16 @@ function applyChangedLogEntry(
   ctx: FoldContext,
 ): void {
   const messageType = entry.messageType ?? '';
+  if (
+    messageType === MESSAGE_TYPES.INTERNAL &&
+    entry.seqNo >= state.workflowAttemptSeqNo
+  ) {
+    const marker = WorkflowAttemptMarkerSchema.safeParse(entry.data);
+    if (marker.success) {
+      state.workflowAttemptId = marker.data.attemptId;
+      state.workflowAttemptSeqNo = entry.seqNo;
+    }
+  }
   const wOO = state.workflowOperationalOnly;
   // Detached child runs surface their full log output (phase group rows and
   // plain log lines, both `DEFAULT`) when focused, unlike the root/subagent

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -821,15 +821,23 @@ function applyChangedLogEntry(
   ctx: FoldContext,
 ): void {
   const messageType = entry.messageType ?? '';
+  const markerCandidate =
+    typeof entry.data === 'object' &&
+    entry.data !== null &&
+    'kind' in entry.data &&
+    entry.data.kind === 'workflowAttempt';
   if (
     messageType === MESSAGE_TYPES.INTERNAL &&
+    markerCandidate &&
     entry.seqNo >= state.workflowAttemptSeqNo
   ) {
     const marker = WorkflowAttemptMarkerSchema.safeParse(entry.data);
-    if (marker.success) {
-      state.workflowAttemptId = marker.data.attemptId;
-      state.workflowAttemptSeqNo = entry.seqNo;
-    }
+    // A malformed declared boundary must supersede the preceding attempt.
+    // Retaining its identifier would project prior-run rows as current.
+    state.workflowAttemptId = marker.success
+      ? marker.data.attemptId
+      : undefined;
+    state.workflowAttemptSeqNo = entry.seqNo;
   }
   const wOO = state.workflowOperationalOnly;
   // Detached child runs surface their full log output (phase group rows and

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -196,7 +196,7 @@ export function logEntryStreamIsRunning(entry: StreamLogEntry): boolean {
  */
 function phaseGroupData(
   entry: StreamLogEntry,
-): { index?: number; total?: number } | null {
+): { index?: number; total?: number; attemptId?: string } | null {
   if (
     entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_START &&
     entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_END
@@ -206,13 +206,14 @@ function phaseGroupData(
   // Same tolerant parse `updateTaskGroups` (progress-view logSlice) uses for
   // the identical group-log payload: per-field `.catch(undefined)` so a
   // malformed `index`/`total` drops just that field, not the whole header.
-  const { kind, index, total } = GroupLogPayloadSchema.catch({}).parse(
-    entry.data,
-  );
+  const { kind, index, total, attemptId } = GroupLogPayloadSchema.catch(
+    {},
+  ).parse(entry.data);
   if (kind !== 'phase') return null;
   return {
     ...(index !== undefined ? { index } : {}),
     ...(total !== undefined ? { total } : {}),
+    ...(attemptId !== undefined ? { attemptId } : {}),
   };
 }
 
@@ -346,6 +347,9 @@ function renderLogEntryFresh(
       phaseLabel,
       ...(phaseIndex !== undefined ? { phaseIndex } : {}),
       ...(phaseTotal !== undefined ? { phaseTotal } : {}),
+      ...(phaseData.attemptId !== undefined
+        ? { attemptId: phaseData.attemptId }
+        : {}),
     };
     return next;
   }

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -89,21 +89,21 @@ export function workflowDashboardModel(
   const groups: MutableWorkflowPhaseGroup[] = [];
   const byPhase = new Map<string | undefined, MutableWorkflowPhaseGroup>();
   const tasks: WorkflowTaskEntry[] = [];
-  const currentAttemptId = latestWorkflowAttemptId(
-    root.entries.map((entry) => {
-      if (entry.role === 'workflowTask') return entry.task.attemptId;
-      if (entry.role === 'phase') return entry.attemptId;
-      return undefined;
-    }),
-  );
+  const currentAttemptId =
+    root.workflowAttemptId ??
+    latestWorkflowAttemptId(
+      root.entries.map((entry) => {
+        if (entry.role === 'workflowTask') return entry.task.attemptId;
+        if (entry.role === 'phase') return entry.attemptId;
+        return undefined;
+      }),
+    );
   const currentCalls = new Set(
     latestWorkflowCallsById(
       root.entries.flatMap((entry) =>
         entry.role === 'workflowTask' ? [entry.task] : [],
       ),
-    ).filter(
-      (call) =>
-        currentAttemptId === undefined || call.attemptId === currentAttemptId,
+      currentAttemptId,
     ),
   );
   for (const entry of root.entries) {

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -150,9 +150,12 @@ export function workflowDashboardModel(
   }
 
   const taskValues = tasks.map((entry) => workflowTaskListValue(entry.id));
+  const narrowValues = groups.flatMap((group) =>
+    group.tasks.length === 0
+      ? [group.value]
+      : group.tasks.map((entry) => workflowTaskListValue(entry.id)),
+  );
   const wide = columns >= WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS;
-  const narrowListValues =
-    taskValues.length > 0 ? taskValues : groups.map((group) => group.value);
   return {
     root,
     groups,
@@ -162,12 +165,11 @@ export function workflowDashboardModel(
       tasks.map((entry) => [workflowTaskListValue(entry.id), entry]),
     ),
     groupByValue: new Map(groups.map((group) => [group.value, group])),
-    // Narrow rows normally expose task values while phase headers act as
-    // separators. A phase-only dashboard still needs one value so the panel
-    // can be focused and rendered before its first task arrives.
+    // Narrow phase headers with tasks are disabled separators. An empty phase
+    // is itself selectable so a phase-only dashboard remains keyboard-reachable.
     listValues: wide
       ? [...groups.map((group) => group.value), ...taskValues]
-      : narrowListValues,
+      : narrowValues,
     wide,
   };
 }

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -183,7 +183,9 @@ export function workflowDashboardPanelItemCount(
   model: WorkflowDashboardModel | undefined,
   selectedValue: ChildListValue | undefined,
 ): number {
-  if (!model || model.tasks.length === 0) return 0;
+  if (!model || (model.groups.length === 0 && model.tasks.length === 0)) {
+    return 0;
+  }
   if (!model.wide) {
     return 1 + model.groups.length + model.tasks.length;
   }

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -10,8 +10,8 @@
 // Local imports - shared stream identity
 import type { StreamTabId } from '@shared/schemas';
 import {
-  latestWorkflowAttemptId,
   latestWorkflowCallsById,
+  latestWorkflowEntryAttemptId,
 } from '@shared/copy/workflowCall';
 
 // Local imports - TUI presentation constants
@@ -90,14 +90,7 @@ export function workflowDashboardModel(
   const byPhase = new Map<string | undefined, MutableWorkflowPhaseGroup>();
   const tasks: WorkflowTaskEntry[] = [];
   const currentAttemptId =
-    root.workflowAttemptId ??
-    latestWorkflowAttemptId(
-      root.entries.map((entry) => {
-        if (entry.role === 'workflowTask') return entry.task.attemptId;
-        if (entry.role === 'phase') return entry.attemptId;
-        return undefined;
-      }),
-    );
+    root.workflowAttemptId ?? latestWorkflowEntryAttemptId(root.entries);
   const currentCalls = new Set(
     latestWorkflowCallsById(
       root.entries.flatMap((entry) =>

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -9,6 +9,7 @@
 
 // Local imports - shared stream identity
 import type { StreamTabId } from '@shared/schemas';
+import { latestWorkflowCallsById } from '@shared/copy/workflowCall';
 
 // Local imports - TUI presentation constants
 import { WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS } from '../panes/SubagentListDisplay';
@@ -85,8 +86,17 @@ export function workflowDashboardModel(
   const groups: MutableWorkflowPhaseGroup[] = [];
   const byPhase = new Map<string | undefined, MutableWorkflowPhaseGroup>();
   const tasks: WorkflowTaskEntry[] = [];
+  const currentCalls = new Set(
+    latestWorkflowCallsById(
+      root.entries.flatMap((entry) =>
+        entry.role === 'workflowTask' ? [entry.task] : [],
+      ),
+    ),
+  );
   for (const entry of root.entries) {
     if (entry.role !== 'phase' && entry.role !== 'workflowTask') continue;
+    if (entry.role === 'workflowTask' && !currentCalls.has(entry.task))
+      continue;
     const phase = entry.role === 'phase' ? entry.phaseLabel : entry.task.phase;
     let group = byPhase.get(phase);
     if (!group) {

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -9,10 +9,7 @@
 
 // Local imports - shared stream identity
 import type { StreamTabId } from '@shared/schemas';
-import {
-  latestWorkflowCallsById,
-  latestWorkflowEntryAttemptId,
-} from '@shared/copy/workflowCall';
+import { latestWorkflowCallsById } from '@shared/copy/workflowCall';
 
 // Local imports - TUI presentation constants
 import { WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS } from '../panes/SubagentListDisplay';
@@ -23,7 +20,7 @@ import {
   workflowTaskListValue,
   type ChildListValue,
 } from './childListSelection';
-import type { StreamSlice } from './cliState';
+import { currentWorkflowAttemptId, type StreamSlice } from './cliState';
 
 export type WorkflowTaskEntry = Extract<
   StreamSlice['entries'][number],
@@ -89,8 +86,10 @@ export function workflowDashboardModel(
   const groups: MutableWorkflowPhaseGroup[] = [];
   const byPhase = new Map<string | undefined, MutableWorkflowPhaseGroup>();
   const tasks: WorkflowTaskEntry[] = [];
-  const currentAttemptId =
-    root.workflowAttemptId ?? latestWorkflowEntryAttemptId(root.entries);
+  const currentAttemptId = currentWorkflowAttemptId(
+    root.workflowAttemptId,
+    root.entries,
+  );
   const currentCalls = new Set(
     latestWorkflowCallsById(
       root.entries.flatMap((entry) =>

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -108,14 +108,35 @@ export function workflowDashboardModel(
       };
       byPhase.set(phase, group);
       groups.push(group);
-    } else if (entry.role === 'phase' && group.heading === undefined) {
-      group.heading = entry;
+    } else if (entry.role === 'phase') {
+      // A rerun may retain the same phase label with revised index/total data.
+      // Keep the stable first-appearance row identity, but display the latest
+      // heading facts just as the status band does. A GROUP_END row can omit
+      // counts, so retain them from the preceding heading in that one case.
+      const priorHeading = group.heading;
+      group.heading =
+        entry.phaseIndex === undefined || entry.phaseTotal === undefined
+          ? {
+              ...entry,
+              ...(priorHeading?.phaseIndex !== undefined
+                ? { phaseIndex: priorHeading.phaseIndex }
+                : {}),
+              ...(priorHeading?.phaseTotal !== undefined
+                ? { phaseTotal: priorHeading.phaseTotal }
+                : {}),
+            }
+          : entry;
     }
     if (entry.role === 'workflowTask') {
       group.tasks.push(entry);
       tasks.push(entry);
     }
   }
+
+  // Phase transcript rows are durable history. If the current attempt moved
+  // or removed every task from an earlier phase, that phase has no
+  // live dashboard row even though its transcript heading remains auditable.
+  const currentGroups = groups.filter((group) => group.tasks.length > 0);
 
   const childTaskIndex = new Map<StreamTabId, WorkflowTaskEntry | null>();
   for (const entry of tasks) {
@@ -131,17 +152,17 @@ export function workflowDashboardModel(
   const wide = columns >= WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS;
   return {
     root,
-    groups,
+    groups: currentGroups,
     tasks,
     childTaskIndex,
     taskByValue: new Map(
       tasks.map((entry) => [workflowTaskListValue(entry.id), entry]),
     ),
-    groupByValue: new Map(groups.map((group) => [group.value, group])),
+    groupByValue: new Map(currentGroups.map((group) => [group.value, group])),
     // Narrow rows render phase headers as disabled separators, so they are not
     // reachable row values there.
     listValues: wide
-      ? [...groups.map((group) => group.value), ...taskValues]
+      ? [...currentGroups.map((group) => group.value), ...taskValues]
       : taskValues,
     wide,
   };

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -9,7 +9,10 @@
 
 // Local imports - shared stream identity
 import type { StreamTabId } from '@shared/schemas';
-import { latestWorkflowCallsById } from '@shared/copy/workflowCall';
+import {
+  latestWorkflowAttemptId,
+  latestWorkflowCallsById,
+} from '@shared/copy/workflowCall';
 
 // Local imports - TUI presentation constants
 import { WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS } from '../panes/SubagentListDisplay';
@@ -86,17 +89,34 @@ export function workflowDashboardModel(
   const groups: MutableWorkflowPhaseGroup[] = [];
   const byPhase = new Map<string | undefined, MutableWorkflowPhaseGroup>();
   const tasks: WorkflowTaskEntry[] = [];
+  const currentAttemptId = latestWorkflowAttemptId(
+    root.entries.map((entry) => {
+      if (entry.role === 'workflowTask') return entry.task.attemptId;
+      if (entry.role === 'phase') return entry.attemptId;
+      return undefined;
+    }),
+  );
   const currentCalls = new Set(
     latestWorkflowCallsById(
       root.entries.flatMap((entry) =>
         entry.role === 'workflowTask' ? [entry.task] : [],
       ),
+    ).filter(
+      (call) =>
+        currentAttemptId === undefined || call.attemptId === currentAttemptId,
     ),
   );
   for (const entry of root.entries) {
     if (entry.role !== 'phase' && entry.role !== 'workflowTask') continue;
     if (entry.role === 'workflowTask' && !currentCalls.has(entry.task))
       continue;
+    if (
+      entry.role === 'phase' &&
+      currentAttemptId !== undefined &&
+      entry.attemptId !== currentAttemptId
+    ) {
+      continue;
+    }
     const phase = entry.role === 'phase' ? entry.phaseLabel : entry.task.phase;
     let group = byPhase.get(phase);
     if (!group) {
@@ -113,30 +133,19 @@ export function workflowDashboardModel(
       // Keep the stable first-appearance row identity, but display the latest
       // heading facts just as the status band does. A GROUP_END row can omit
       // counts, so retain them from the preceding heading in that one case.
-      const priorHeading = group.heading;
-      group.heading =
-        entry.phaseIndex === undefined || entry.phaseTotal === undefined
-          ? {
-              ...entry,
-              ...(priorHeading?.phaseIndex !== undefined
-                ? { phaseIndex: priorHeading.phaseIndex }
-                : {}),
-              ...(priorHeading?.phaseTotal !== undefined
-                ? { phaseTotal: priorHeading.phaseTotal }
-                : {}),
-            }
-          : entry;
+      const phaseIndex = entry.phaseIndex ?? group.heading?.phaseIndex;
+      const phaseTotal = entry.phaseTotal ?? group.heading?.phaseTotal;
+      group.heading = {
+        ...entry,
+        ...(phaseIndex !== undefined ? { phaseIndex } : {}),
+        ...(phaseTotal !== undefined ? { phaseTotal } : {}),
+      };
     }
     if (entry.role === 'workflowTask') {
       group.tasks.push(entry);
       tasks.push(entry);
     }
   }
-
-  // Phase transcript rows are durable history. If the current attempt moved
-  // or removed every task from an earlier phase, that phase has no
-  // live dashboard row even though its transcript heading remains auditable.
-  const currentGroups = groups.filter((group) => group.tasks.length > 0);
 
   const childTaskIndex = new Map<StreamTabId, WorkflowTaskEntry | null>();
   for (const entry of tasks) {
@@ -152,17 +161,17 @@ export function workflowDashboardModel(
   const wide = columns >= WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS;
   return {
     root,
-    groups: currentGroups,
+    groups,
     tasks,
     childTaskIndex,
     taskByValue: new Map(
       tasks.map((entry) => [workflowTaskListValue(entry.id), entry]),
     ),
-    groupByValue: new Map(currentGroups.map((group) => [group.value, group])),
+    groupByValue: new Map(groups.map((group) => [group.value, group])),
     // Narrow rows render phase headers as disabled separators, so they are not
     // reachable row values there.
     listValues: wide
-      ? [...currentGroups.map((group) => group.value), ...taskValues]
+      ? [...groups.map((group) => group.value), ...taskValues]
       : taskValues,
     wide,
   };

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -151,6 +151,8 @@ export function workflowDashboardModel(
 
   const taskValues = tasks.map((entry) => workflowTaskListValue(entry.id));
   const wide = columns >= WORKFLOW_DASHBOARD_WIDE_MIN_COLUMNS;
+  const narrowListValues =
+    taskValues.length > 0 ? taskValues : groups.map((group) => group.value);
   return {
     root,
     groups,
@@ -160,11 +162,12 @@ export function workflowDashboardModel(
       tasks.map((entry) => [workflowTaskListValue(entry.id), entry]),
     ),
     groupByValue: new Map(groups.map((group) => [group.value, group])),
-    // Narrow rows render phase headers as disabled separators, so they are not
-    // reachable row values there.
+    // Narrow rows normally expose task values while phase headers act as
+    // separators. A phase-only dashboard still needs one value so the panel
+    // can be focused and rendered before its first task arrives.
     listValues: wide
       ? [...groups.map((group) => group.value), ...taskValues]
-      : taskValues,
+      : narrowListValues,
     wide,
   };
 }

--- a/src/agent/trace/AgentTrace.ts
+++ b/src/agent/trace/AgentTrace.ts
@@ -37,6 +37,8 @@ export interface StageOptions {
   readonly index?: number;
   /** Planned total count, when known, currently used for workflow rounds. */
   readonly total?: number;
+  /** Physical workflow attempt that owns this stage, when applicable. */
+  readonly attemptId?: string;
   /**
    * Outcome to emit at stage.end when no explicit status is supplied.
    * Defaults to `completed`.

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -232,6 +232,7 @@ export class TraceEmitter implements AgentTrace {
       kind: options.kind,
       index: options.index,
       total: options.total,
+      attemptId: options.attemptId,
     });
     return new StageHandleImpl(this, id, defaultStatus);
   }

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -146,6 +146,12 @@ interface WorkflowCallEvent extends StageStamp {
   readonly call: WorkflowCallProgress;
 }
 
+/** A physical workflow-script projection began, before any optional work. */
+interface WorkflowAttemptEvent extends StageStamp {
+  readonly type: 'workflow.attempt';
+  readonly attemptId: string;
+}
+
 /** Exact raw skill catalog accepted for this run's initial prompt. */
 interface ActiveSkillsEvent extends StageStamp {
   readonly type: 'skills.snapshot';
@@ -368,6 +374,7 @@ export type AgentEvent =
   | StageEndEvent
   | ToolStartEvent
   | ToolEndEvent
+  | WorkflowAttemptEvent
   | WorkflowCallEvent
   | ActiveSkillsEvent
   | UsageEvent

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -84,6 +84,7 @@ export interface StageStartEvent extends StageStamp {
   readonly kind?: 'run' | 'round' | 'phase' | 'session';
   readonly index?: number;
   readonly total?: number;
+  readonly attemptId?: string;
 }
 
 /** Immutable run identity emitted once when a stream enters RUNNING. */

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -6,6 +6,13 @@ import {
 import { filterNotNullish } from '@utils/core';
 import { formatCompactDuration, formatCostUsd } from '@utils/text/stringUtils';
 
+/** Latest physical workflow attempt named by an append-ordered projection. */
+export function latestWorkflowAttemptId(
+  attemptIds: readonly (string | undefined)[],
+): string | undefined {
+  return attemptIds.findLast((attemptId) => attemptId !== undefined);
+}
+
 /**
  * Select the current state of each logical workflow call.
  *
@@ -17,9 +24,9 @@ import { formatCompactDuration, formatCostUsd } from '@utils/text/stringUtils';
 export function latestWorkflowCallsById(
   calls: readonly WorkflowCallProgress[],
 ): WorkflowCallProgress[] {
-  const currentAttemptId = calls.findLast(
-    (call) => call.attemptId !== undefined,
-  )?.attemptId;
+  const currentAttemptId = latestWorkflowAttemptId(
+    calls.map((call) => call.attemptId),
+  );
   const candidates = currentAttemptId
     ? calls.filter((call) => call.attemptId === currentAttemptId)
     : calls;

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -7,6 +7,28 @@ import { filterNotNullish } from '@utils/core';
 import { formatCompactDuration, formatCostUsd } from '@utils/text/stringUtils';
 
 /**
+ * Select the current state of each logical workflow call.
+ *
+ * Durable script reruns append a fresh progress record for the same logical
+ * call id so the earlier attempt remains available in transcript history.
+ * Live projections must collapse those records at their boundary rather than
+ * count prior attempts as additional tasks.
+ */
+export function latestWorkflowCallsById(
+  calls: readonly WorkflowCallProgress[],
+): WorkflowCallProgress[] {
+  const seen = new Set<string>();
+  return calls
+    .toReversed()
+    .filter((call) => {
+      if (seen.has(call.id)) return false;
+      seen.add(call.id);
+      return true;
+    })
+    .toReversed();
+}
+
+/**
  * Canonical metadata copy for terminal workflow-call progress on every host.
  */
 export function formatWorkflowCallMetadataParts(

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -13,23 +13,6 @@ export function latestWorkflowAttemptId(
   return attemptIds.findLast((attemptId) => attemptId !== undefined);
 }
 
-interface WorkflowAttemptProjectionEntry {
-  readonly role: string;
-  readonly attemptId?: string;
-  readonly task?: { readonly attemptId?: string };
-}
-
-/** Latest workflow attempt named by phase or task entries in transcript order. */
-export function latestWorkflowEntryAttemptId(
-  entries: readonly WorkflowAttemptProjectionEntry[],
-): string | undefined {
-  return latestWorkflowAttemptId(
-    entries.map((entry) =>
-      entry.role === 'workflowTask' ? entry.task?.attemptId : entry.attemptId,
-    ),
-  );
-}
-
 /**
  * Select the current state of each logical workflow call.
  *

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -9,16 +9,22 @@ import { formatCompactDuration, formatCostUsd } from '@utils/text/stringUtils';
 /**
  * Select the current state of each logical workflow call.
  *
- * Durable script reruns append a fresh progress record for the same logical
- * call id so the earlier attempt remains available in transcript history.
- * Live projections must collapse those records at their boundary rather than
- * count prior attempts as additional tasks.
+ * Durable script reruns append progress under a fresh attempt id so the
+ * earlier attempt remains available in transcript history. Current writers
+ * stamp every call; older persisted transcripts without that fact fall back
+ * to their latest record per logical id.
  */
 export function latestWorkflowCallsById(
   calls: readonly WorkflowCallProgress[],
 ): WorkflowCallProgress[] {
+  const currentAttemptId = calls.findLast(
+    (call) => call.attemptId !== undefined,
+  )?.attemptId;
+  const candidates = currentAttemptId
+    ? calls.filter((call) => call.attemptId === currentAttemptId)
+    : calls;
   const seen = new Set<string>();
-  return calls
+  return candidates
     .toReversed()
     .filter((call) => {
       if (seen.has(call.id)) return false;

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -23,10 +23,11 @@ export function latestWorkflowAttemptId(
  */
 export function latestWorkflowCallsById(
   calls: readonly WorkflowCallProgress[],
+  declaredAttemptId?: string,
 ): WorkflowCallProgress[] {
-  const currentAttemptId = latestWorkflowAttemptId(
-    calls.map((call) => call.attemptId),
-  );
+  const currentAttemptId =
+    declaredAttemptId ??
+    latestWorkflowAttemptId(calls.map((call) => call.attemptId));
   const candidates = currentAttemptId
     ? calls.filter((call) => call.attemptId === currentAttemptId)
     : calls;

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -13,6 +13,23 @@ export function latestWorkflowAttemptId(
   return attemptIds.findLast((attemptId) => attemptId !== undefined);
 }
 
+interface WorkflowAttemptProjectionEntry {
+  readonly role: string;
+  readonly attemptId?: string;
+  readonly task?: { readonly attemptId?: string };
+}
+
+/** Latest workflow attempt named by phase or task entries in transcript order. */
+export function latestWorkflowEntryAttemptId(
+  entries: readonly WorkflowAttemptProjectionEntry[],
+): string | undefined {
+  return latestWorkflowAttemptId(
+    entries.map((entry) =>
+      entry.role === 'workflowTask' ? entry.task?.attemptId : entry.attemptId,
+    ),
+  );
+}
+
 /**
  * Select the current state of each logical workflow call.
  *

--- a/src/shared/schemas/taskGroup.ts
+++ b/src/shared/schemas/taskGroup.ts
@@ -51,7 +51,9 @@ export type TaskGroup = z.infer<typeof TaskGroupSchema>;
  * still-disjoint legacy `EndGroupStatus` vocabulary does. The shared
  * projection maps a legacy value UP to the native value it corresponds to;
  * a value in neither vocabulary still falls back to `undefined` here, same
- * as any other field.
+ * as any other field. A malformed `attemptId` likewise leaves the phase in
+ * durable scrollback but excludes it from the attempt-scoped live dashboard;
+ * presentation tolerance must not make one bad field reject the whole row.
  */
 export const GroupLogPayloadSchema = z.looseObject({
   status: z

--- a/src/shared/schemas/taskGroup.ts
+++ b/src/shared/schemas/taskGroup.ts
@@ -61,6 +61,7 @@ export const GroupLogPayloadSchema = z.looseObject({
   kind: StageKindSchema.optional().catch(undefined),
   index: taskGroupIndexField.optional().catch(undefined),
   total: taskGroupTotalField.optional().catch(undefined),
+  attemptId: z.string().min(1).optional().catch(undefined),
   name: z.string().optional().catch(undefined),
   endTime: taskGroupEndTimeField.optional().catch(undefined),
 });

--- a/src/shared/schemas/taskGroup.ts
+++ b/src/shared/schemas/taskGroup.ts
@@ -51,9 +51,9 @@ export type TaskGroup = z.infer<typeof TaskGroupSchema>;
  * still-disjoint legacy `EndGroupStatus` vocabulary does. The shared
  * projection maps a legacy value UP to the native value it corresponds to;
  * a value in neither vocabulary still falls back to `undefined` here, same
- * as any other field. A malformed `attemptId` likewise leaves the phase in
- * durable scrollback but excludes it from the attempt-scoped live dashboard;
- * presentation tolerance must not make one bad field reject the whole row.
+ * as any other display field. `attemptId` is different: it owns physical-run
+ * identity, so genuine absence remains valid for older rows while a malformed
+ * present value rejects the payload instead of becoming a legacy omission.
  */
 export const GroupLogPayloadSchema = z.looseObject({
   status: z
@@ -63,7 +63,7 @@ export const GroupLogPayloadSchema = z.looseObject({
   kind: StageKindSchema.optional().catch(undefined),
   index: taskGroupIndexField.optional().catch(undefined),
   total: taskGroupTotalField.optional().catch(undefined),
-  attemptId: z.string().min(1).optional().catch(undefined),
+  attemptId: z.string().min(1).optional(),
   name: z.string().optional().catch(undefined),
   endTime: taskGroupEndTimeField.optional().catch(undefined),
 });

--- a/src/shared/schemas/workflowCallProgress.ts
+++ b/src/shared/schemas/workflowCallProgress.ts
@@ -40,7 +40,7 @@ const WorkflowCallProgressBaseSchema = WorkflowCallIdentitySchema.extend({
    * Physical workflow-script projection attempt. All progress records from one
    * run share this id; older persisted transcripts may omit it.
    */
-  attemptId: z.string().min(1).optional().catch(undefined),
+  attemptId: z.string().min(1).optional(),
   /**
    * Live child stream that executes this call. Absent for planned, cached, and
    * not-yet-launched calls.

--- a/src/shared/schemas/workflowCallProgress.ts
+++ b/src/shared/schemas/workflowCallProgress.ts
@@ -38,7 +38,9 @@ const WorkflowCallTerminalMetadataSchema = z.strictObject({
 const WorkflowCallProgressBaseSchema = WorkflowCallIdentitySchema.extend({
   /**
    * Physical workflow-script projection attempt. All progress records from one
-   * run share this id; older persisted transcripts may omit it.
+   * run share this id; older persisted transcripts may omit it. A malformed
+   * present value must fail parsing: treating corrupted attempt ownership as
+   * absent could mix a prior run's task into the current live projection.
    */
   attemptId: z.string().min(1).optional(),
   /**

--- a/src/shared/schemas/workflowCallProgress.ts
+++ b/src/shared/schemas/workflowCallProgress.ts
@@ -22,6 +22,13 @@ export const WorkflowCallIdentitySchema = z.strictObject({
 });
 export type WorkflowCallIdentity = z.infer<typeof WorkflowCallIdentitySchema>;
 
+/** Durable boundary between physical runs appended to one workflow stream. */
+export const WorkflowAttemptMarkerSchema = z.strictObject({
+  kind: z.literal('workflowAttempt'),
+  attemptId: z.string().min(1),
+});
+export type WorkflowAttemptMarker = z.infer<typeof WorkflowAttemptMarkerSchema>;
+
 const WorkflowCallTerminalMetadataSchema = z.strictObject({
   model: z.string().min(1).optional(),
   durationMs: z.number().nonnegative().optional(),

--- a/src/shared/schemas/workflowCallProgress.ts
+++ b/src/shared/schemas/workflowCallProgress.ts
@@ -30,6 +30,11 @@ const WorkflowCallTerminalMetadataSchema = z.strictObject({
 
 const WorkflowCallProgressBaseSchema = WorkflowCallIdentitySchema.extend({
   /**
+   * Physical workflow-script projection attempt. All progress records from one
+   * run share this id; older persisted transcripts may omit it.
+   */
+  attemptId: z.string().min(1).optional(),
+  /**
    * Live child stream that executes this call. Absent for planned, cached, and
    * not-yet-launched calls.
    */

--- a/src/shared/schemas/workflowCallProgress.ts
+++ b/src/shared/schemas/workflowCallProgress.ts
@@ -40,7 +40,7 @@ const WorkflowCallProgressBaseSchema = WorkflowCallIdentitySchema.extend({
    * Physical workflow-script projection attempt. All progress records from one
    * run share this id; older persisted transcripts may omit it.
    */
-  attemptId: z.string().min(1).optional(),
+  attemptId: z.string().min(1).optional().catch(undefined),
   /**
    * Live child stream that executes this call. Absent for planned, cached, and
    * not-yet-launched calls.

--- a/src/shared/streams/taskGroupProjection.ts
+++ b/src/shared/streams/taskGroupProjection.ts
@@ -80,7 +80,14 @@ export function upsertTaskGroupFromStreamLog(
     return false;
   }
 
-  const payload = GroupLogPayloadSchema.catch({}).parse(entry.data);
+  // A missing payload is valid for legacy lifecycle rows. A present malformed
+  // payload is not: in particular, erasing corrupted attempt ownership would
+  // turn a phase row into an apparently unowned generic group.
+  const parsedPayload = GroupLogPayloadSchema.safeParse(
+    entry.data === undefined ? {} : entry.data,
+  );
+  if (!parsedPayload.success) return true;
+  const payload = parsedPayload.data;
   const cachedIndex = taskGroupIndex.get(entry.id);
   const groupIndex =
     cachedIndex !== undefined && taskGroups[cachedIndex]?.id === entry.id

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -159,6 +159,7 @@ return await agent('Inspect', { id: 'inspect' })`,
         kind: 'phase',
         index: 0,
         total: 2,
+        attemptId: planned?.call.attemptId,
       }),
     );
     expect(events.some((event) => event.type === 'child.activity')).toBe(false);

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -99,6 +99,25 @@ function latestWorkflowCallEvents(
 beforeEach(() => clearStoreCache());
 
 describe('workflow-script progress bridge', () => {
+  it('announces an attempt before script parsing can fail', async () => {
+    const { trace, events } = recordingTrace();
+
+    await expect(
+      runScript(trace, 'invalid-script', 'not valid js'),
+    ).rejects.toThrow();
+
+    expect(events[0]).toMatchObject({
+      type: 'workflow.attempt',
+      attemptId: expect.any(String),
+    });
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'workflow.call' || event.type === 'stage.start',
+      ),
+    ).toBe(false);
+  });
+
   it('keeps planned call cards in their phase stage across incremental updates', async () => {
     const { trace, events } = recordingTrace();
     const parent = trace.openStage('Parent');

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -137,16 +137,19 @@ return await agent('Inspect', { id: 'inspect' })`,
     expect(planned).toMatchObject({
       type: 'workflow.call',
       stageId: phaseId,
+      call: { attemptId: expect.any(String) },
     });
     expect(running).toMatchObject({
       type: 'workflow.call',
       logId: planned?.logId,
       stageId: phaseId,
+      call: { attemptId: planned?.call.attemptId },
     });
     expect(completed).toMatchObject({
       type: 'workflow.call',
       logId: planned?.logId,
       stageId: phaseId,
+      call: { attemptId: planned?.call.attemptId },
     });
     expect(events).toContainEqual(
       expect.objectContaining({

--- a/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
+++ b/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
@@ -479,6 +479,33 @@ describe('transcript fold vs from-scratch oracle', () => {
       const slice = streams.get().get(FOLD_STREAM);
       expect(slice?.workflowAttemptId).toBe('current-attempt');
       expect(slice?.entries).toEqual([]);
+
+      appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
+        id: 'unrelated-internal',
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: 2,
+        messageType: MESSAGE_TYPES.INTERNAL,
+        text: '',
+        data: { kind: 'otherInternalRecord' },
+      });
+      syncStreamLog(FOLD_STREAM);
+      expect(streams.get().get(FOLD_STREAM)?.workflowAttemptId).toBe(
+        'current-attempt',
+      );
+
+      appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
+        id: 'workflow-attempt-malformed',
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: 3,
+        messageType: MESSAGE_TYPES.INTERNAL,
+        text: '',
+        data: { kind: 'workflowAttempt', attemptId: '' },
+      });
+      syncStreamLog(FOLD_STREAM);
+      expect(streams.get().get(FOLD_STREAM)?.workflowAttemptId).toBeUndefined();
+      expect(streams.get().get(FOLD_STREAM)?.entries).toEqual([]);
     } finally {
       dispose();
     }

--- a/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
+++ b/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
@@ -95,6 +95,7 @@ function projectedView(slice: StreamSlice | undefined): unknown {
     compactingActive: slice?.compactingActive ?? false,
     activeSkills: slice?.activeSkills ?? [],
     taskGroups: slice?.taskGroups ?? [],
+    workflowAttemptId: slice?.workflowAttemptId,
   };
 }
 
@@ -454,6 +455,30 @@ describe('transcript fold vs from-scratch oracle', () => {
         ops.step();
         syncBothAndCompare(step, ' (compact)');
       }
+    } finally {
+      dispose();
+    }
+  });
+
+  it('folds a hidden workflow-attempt marker into projection state', () => {
+    const dispose = subscribeStreamLog();
+    try {
+      configureStreams(CONFIGS[1]);
+      appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
+        id: 'workflow-attempt-current',
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: 1,
+        messageType: MESSAGE_TYPES.INTERNAL,
+        text: '',
+        data: { kind: 'workflowAttempt', attemptId: 'current-attempt' },
+      });
+
+      syncStreamLog(FOLD_STREAM);
+
+      const slice = streams.get().get(FOLD_STREAM);
+      expect(slice?.workflowAttemptId).toBe('current-attempt');
+      expect(slice?.entries).toEqual([]);
     } finally {
       dispose();
     }

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -341,6 +341,24 @@ describe('CLI child list display model', () => {
     expect(workflowRunStatusSummary(slice)).toBeUndefined();
   });
 
+  it('clears the prior status when a new attempt has not emitted work', () => {
+    const slice = workflowAgentSlice('empty-rerun', {
+      workflowAttemptId: 'current',
+      entries: [
+        phaseEntry('phase-old', 'Verify', { attemptId: 'prior' }),
+        workflowTaskEntry('task-old', 'Finished: Verify', {
+          id: 'verification',
+          label: 'Verify',
+          phase: 'Verify',
+          status: 'completed',
+          attemptId: 'prior',
+        }),
+      ],
+    });
+
+    expect(workflowRunStatusSummary(slice)).toBeUndefined();
+  });
+
   it('tallys failures across the whole run, not just the current phase', () => {
     // A failure in an earlier phase must persist in the band after the run
     // advances, unlike the current-phase done/total. The whole-run tally keeps

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -276,6 +276,38 @@ describe('CLI child list display model', () => {
     ).toEqual(['muted', 'muted', 'warning']);
   });
 
+  it('uses the latest logical task state when a workflow is rerun', () => {
+    const slice = workflowAgentSlice('rerun', {
+      entries: [
+        phaseEntry('phase-verify-old', 'Verify', {
+          phaseIndex: 1,
+          phaseTotal: 2,
+        }),
+        workflowTaskEntry('task-verify-old', 'Failed: Verify', {
+          id: 'verification',
+          label: 'Verify',
+          phase: 'Verify',
+          status: 'failed',
+          error: 'Invalid first attempt.',
+        }),
+        phaseEntry('phase-verify-current', 'Verify', {
+          phaseIndex: 1,
+          phaseTotal: 2,
+        }),
+        workflowTaskEntry('task-verify-current', 'Running: Verify', {
+          id: 'verification',
+          label: 'Verify',
+          phase: 'Verify',
+          status: 'running',
+        }),
+      ],
+    });
+
+    expect(
+      workflowRunStatusSummary(slice)?.map((segment) => segment.text),
+    ).toEqual(['Verify (2/2)', '0/1 done']);
+  });
+
   it('tallys failures across the whole run, not just the current phase', () => {
     // A failure in an earlier phase must persist in the band after the run
     // advances, unlike the current-phase done/total. The whole-run tally keeps

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -88,6 +88,7 @@ function phaseEntry(
     readonly finalized?: boolean;
     readonly phaseIndex?: number;
     readonly phaseTotal?: number;
+    readonly attemptId?: string;
   } = {},
 ): ConversationEntry {
   return {
@@ -282,6 +283,7 @@ describe('CLI child list display model', () => {
         phaseEntry('phase-verify-old', 'Verify', {
           phaseIndex: 1,
           phaseTotal: 2,
+          attemptId: 'prior',
         }),
         workflowTaskEntry('task-verify-old', 'Failed: Verify', {
           id: 'verification',
@@ -294,6 +296,7 @@ describe('CLI child list display model', () => {
         phaseEntry('phase-verify-current', 'Verify', {
           phaseIndex: 1,
           phaseTotal: 2,
+          attemptId: 'current',
         }),
         workflowTaskEntry('task-verify-current', 'Running: Verify', {
           id: 'verification',
@@ -308,6 +311,34 @@ describe('CLI child list display model', () => {
     expect(
       workflowRunStatusSummary(slice)?.map((segment) => segment.text),
     ).toEqual(['Verify (2/2)', '0/1 done']);
+  });
+
+  it('does not combine a prior phase heading with a phase-less rerun', () => {
+    const slice = workflowAgentSlice('phase-removed', {
+      entries: [
+        phaseEntry('phase-old', 'Verify', {
+          phaseIndex: 1,
+          phaseTotal: 2,
+          attemptId: 'prior',
+        }),
+        workflowTaskEntry('task-old', 'Failed: Verify', {
+          id: 'verification',
+          label: 'Verify',
+          phase: 'Verify',
+          status: 'failed',
+          error: 'Old failure.',
+          attemptId: 'prior',
+        }),
+        workflowTaskEntry('task-current', 'Running: Direct check', {
+          id: 'direct-check',
+          label: 'Direct check',
+          status: 'running',
+          attemptId: 'current',
+        }),
+      ],
+    });
+
+    expect(workflowRunStatusSummary(slice)).toBeUndefined();
   });
 
   it('tallys failures across the whole run, not just the current phase', () => {

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -289,6 +289,7 @@ describe('CLI child list display model', () => {
           phase: 'Verify',
           status: 'failed',
           error: 'Invalid first attempt.',
+          attemptId: 'prior',
         }),
         phaseEntry('phase-verify-current', 'Verify', {
           phaseIndex: 1,
@@ -299,6 +300,7 @@ describe('CLI child list display model', () => {
           label: 'Verify',
           phase: 'Verify',
           status: 'running',
+          attemptId: 'current',
         }),
       ],
     });

--- a/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
+++ b/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
@@ -371,9 +371,11 @@ describe('workflow dashboard model', () => {
     });
     const narrowModel = workflowDashboardModel(
       { ...root, entries: [...entries, currentPhase] },
-      60,
+      NARROW_COLUMNS,
     );
-    expect(narrowModel.listValues).toEqual([narrowModel.groups[0]?.value]);
+    expect(narrowModel.listValues).toStrictEqual([
+      narrowModel.groups[0]?.value,
+    ]);
     const { ink, React } = await loadInk();
     const { instance, stdout } = renderInteractive(
       ink,
@@ -393,6 +395,26 @@ describe('workflow dashboard model', () => {
       expect(stdout.output).toContain('workflow · 0/0 done');
     } finally {
       instance.unmount();
+    }
+
+    const { instance: narrowInstance, stdout: narrowStdout } =
+      renderInteractive(
+        ink,
+        React.createElement(SubagentList, {
+          dashboard: narrowModel,
+          keyboardActive: true,
+          listRootStreamId: ROOT,
+          maxRows: 5,
+          selectedValue: narrowModel.groups[0]?.value,
+          sessions: [],
+          streams: new Map([[ROOT, root]]),
+        }),
+        { columns: NARROW_COLUMNS },
+      );
+    try {
+      await waitFor(() => narrowStdout.output.includes('› ◆ Explore'));
+    } finally {
+      narrowInstance.unmount();
     }
   });
 

--- a/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
+++ b/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
@@ -340,7 +340,7 @@ describe('workflow dashboard model', () => {
     });
   });
 
-  it('keeps a current empty dynamic phase while dropping prior attempts', () => {
+  it('renders a current empty dynamic phase while dropping prior attempts', async () => {
     const root = workflowRoot(['Prior'], [{ id: 'old', phase: 'Prior' }]);
     const entries = root.entries.map((entry) => {
       if (entry.role === 'workflowTask') {
@@ -369,6 +369,26 @@ describe('workflow dashboard model', () => {
       heading: currentPhase,
       tasks: [],
     });
+    const { ink, React } = await loadInk();
+    const { instance, stdout } = renderInteractive(
+      ink,
+      React.createElement(SubagentList, {
+        dashboard: model,
+        keyboardActive: false,
+        listRootStreamId: ROOT,
+        maxRows: 5,
+        selectedValue: model.groups[0]?.value,
+        sessions: [],
+        streams: new Map([[ROOT, root]]),
+      }),
+      { columns: WIDE_COLUMNS },
+    );
+    try {
+      await waitFor(() => stdout.output.includes('Explore · 0/0'));
+      expect(stdout.output).toContain('workflow · 0/0 done');
+    } finally {
+      instance.unmount();
+    }
   });
 
   it('renders exactly the narrow row values the reducer reconciles against', async () => {

--- a/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
+++ b/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
@@ -369,6 +369,11 @@ describe('workflow dashboard model', () => {
       heading: currentPhase,
       tasks: [],
     });
+    const narrowModel = workflowDashboardModel(
+      { ...root, entries: [...entries, currentPhase] },
+      60,
+    );
+    expect(narrowModel.listValues).toEqual([narrowModel.groups[0]?.value]);
     const { ink, React } = await loadInk();
     const { instance, stdout } = renderInteractive(
       ink,

--- a/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
+++ b/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
@@ -247,6 +247,66 @@ describe('workflow dashboard model', () => {
     expect(model.groups[0]?.tasks).toStrictEqual([current]);
   });
 
+  it('drops tasks and phases absent from the latest attempt', () => {
+    const prior = workflowRoot(
+      ['Draft', 'Verify'],
+      [
+        { id: 'draft', phase: 'Draft' },
+        { id: 'verification', phase: 'Verify' },
+      ],
+    );
+    const current = workflowRoot(
+      ['Verify'],
+      [{ id: 'verification', phase: 'Verify' }],
+    );
+    const priorEntries = prior.entries.map((entry) => ({
+      ...entry,
+      ...(entry.role === 'workflowTask'
+        ? { task: { ...entry.task, attemptId: 'prior' } }
+        : {}),
+    }));
+    const currentEntries = current.entries.map((entry) => ({
+      ...entry,
+      id: `current-${entry.id}`,
+      ...(entry.role === 'workflowTask'
+        ? { task: { ...entry.task, attemptId: 'current' } }
+        : {}),
+    }));
+
+    const model = workflowDashboardModel(
+      { ...prior, entries: [...priorEntries, ...currentEntries] },
+      WIDE_COLUMNS,
+    );
+
+    expect(model.tasks.map((entry) => entry.task.id)).toStrictEqual([
+      'verification',
+    ]);
+    expect(model.groups.map((group) => group.label)).toStrictEqual(['Verify']);
+  });
+
+  it('uses the latest heading facts when a rerun retains a phase label', () => {
+    const root = workflowRoot(
+      ['Verify'],
+      [{ id: 'verification', phase: 'Verify' }],
+    );
+    const currentHeading = {
+      id: 'phase-verify-current',
+      role: 'phase' as const,
+      text: 'Verify',
+      finalized: true,
+      phaseLabel: 'Verify',
+      phaseIndex: 2,
+      phaseTotal: 3,
+    };
+
+    const model = workflowDashboardModel(
+      { ...root, entries: [...root.entries, currentHeading] },
+      WIDE_COLUMNS,
+    );
+
+    expect(model.groups[0]?.heading).toBe(currentHeading);
+  });
+
   it('renders exactly the narrow row values the reducer reconciles against', async () => {
     const model = workflowDashboardModel(TWO_PHASE_ROOT, NARROW_COLUMNS);
     const visited = await navigateList(

--- a/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
+++ b/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
@@ -221,6 +221,32 @@ describe('workflow dashboard model', () => {
     ).toBeUndefined();
   });
 
+  it('shows only the latest row for a logical task after a rerun', () => {
+    const root = workflowRoot(
+      ['Verify'],
+      [{ id: 'verification', phase: 'Verify' }],
+    );
+    const original = root.entries.find(
+      (entry) => entry.role === 'workflowTask',
+    );
+    expect(original?.role).toBe('workflowTask');
+    if (original?.role !== 'workflowTask') return;
+    const current = {
+      ...original,
+      id: 'task-verification-current',
+      text: 'Running: verification again',
+      task: { ...original.task },
+    };
+
+    const model = workflowDashboardModel(
+      { ...root, entries: [...root.entries, current] },
+      WIDE_COLUMNS,
+    );
+
+    expect(model.tasks).toStrictEqual([current]);
+    expect(model.groups[0]?.tasks).toStrictEqual([current]);
+  });
+
   it('renders exactly the narrow row values the reducer reconciles against', async () => {
     const model = workflowDashboardModel(TWO_PHASE_ROOT, NARROW_COLUMNS);
     const visited = await navigateList(

--- a/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
+++ b/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
@@ -391,6 +391,28 @@ describe('workflow dashboard model', () => {
     }
   });
 
+  it('drops the prior dashboard at the next attempt boundary', () => {
+    const prior = workflowRoot(
+      ['Verify'],
+      [{ id: 'verification', phase: 'Verify' }],
+    );
+    const entries = prior.entries.map((entry) => {
+      if (entry.role === 'workflowTask') {
+        return { ...entry, task: { ...entry.task, attemptId: 'prior' } };
+      }
+      if (entry.role === 'phase') return { ...entry, attemptId: 'prior' };
+      return entry;
+    });
+
+    const model = workflowDashboardModel(
+      { ...prior, workflowAttemptId: 'current', entries },
+      WIDE_COLUMNS,
+    );
+
+    expect(model.groups).toStrictEqual([]);
+    expect(model.tasks).toStrictEqual([]);
+  });
+
   it('renders exactly the narrow row values the reducer reconciles against', async () => {
     const model = workflowDashboardModel(TWO_PHASE_ROOT, NARROW_COLUMNS);
     const visited = await navigateList(

--- a/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
+++ b/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
@@ -259,19 +259,26 @@ describe('workflow dashboard model', () => {
       ['Verify'],
       [{ id: 'verification', phase: 'Verify' }],
     );
-    const priorEntries = prior.entries.map((entry) => ({
-      ...entry,
-      ...(entry.role === 'workflowTask'
-        ? { task: { ...entry.task, attemptId: 'prior' } }
-        : {}),
-    }));
-    const currentEntries = current.entries.map((entry) => ({
-      ...entry,
-      id: `current-${entry.id}`,
-      ...(entry.role === 'workflowTask'
-        ? { task: { ...entry.task, attemptId: 'current' } }
-        : {}),
-    }));
+    const priorEntries = prior.entries.map((entry) => {
+      if (entry.role === 'workflowTask') {
+        return { ...entry, task: { ...entry.task, attemptId: 'prior' } };
+      }
+      if (entry.role === 'phase') return { ...entry, attemptId: 'prior' };
+      return entry;
+    });
+    const currentEntries = current.entries.map((entry) => {
+      if (entry.role === 'workflowTask') {
+        return {
+          ...entry,
+          id: `current-${entry.id}`,
+          task: { ...entry.task, attemptId: 'current' },
+        };
+      }
+      if (entry.role === 'phase') {
+        return { ...entry, id: `current-${entry.id}`, attemptId: 'current' };
+      }
+      return { ...entry, id: `current-${entry.id}` };
+    });
 
     const model = workflowDashboardModel(
       { ...prior, entries: [...priorEntries, ...currentEntries] },
@@ -297,6 +304,7 @@ describe('workflow dashboard model', () => {
       phaseLabel: 'Verify',
       phaseIndex: 2,
       phaseTotal: 3,
+      attemptId: 'current',
     };
 
     const model = workflowDashboardModel(
@@ -304,7 +312,63 @@ describe('workflow dashboard model', () => {
       WIDE_COLUMNS,
     );
 
-    expect(model.groups[0]?.heading).toBe(currentHeading);
+    expect(model.groups[0]?.heading).toStrictEqual(currentHeading);
+  });
+
+  it('fills only the heading count omitted by the latest phase row', () => {
+    const root = workflowRoot(
+      ['Verify'],
+      [{ id: 'verification', phase: 'Verify' }],
+    );
+    const currentHeading = {
+      id: 'phase-verify-partial',
+      role: 'phase' as const,
+      text: 'Verify',
+      finalized: true,
+      phaseLabel: 'Verify',
+      phaseIndex: 2,
+    };
+
+    const model = workflowDashboardModel(
+      { ...root, entries: [...root.entries, currentHeading] },
+      WIDE_COLUMNS,
+    );
+
+    expect(model.groups[0]?.heading).toMatchObject({
+      phaseIndex: 2,
+      phaseTotal: 1,
+    });
+  });
+
+  it('keeps a current empty dynamic phase while dropping prior attempts', () => {
+    const root = workflowRoot(['Prior'], [{ id: 'old', phase: 'Prior' }]);
+    const entries = root.entries.map((entry) => {
+      if (entry.role === 'workflowTask') {
+        return { ...entry, task: { ...entry.task, attemptId: 'prior' } };
+      }
+      if (entry.role === 'phase') return { ...entry, attemptId: 'prior' };
+      return entry;
+    });
+    const currentPhase = {
+      id: 'phase-current',
+      role: 'phase' as const,
+      text: 'Explore',
+      finalized: true,
+      phaseLabel: 'Explore',
+      attemptId: 'current',
+    };
+
+    const model = workflowDashboardModel(
+      { ...root, entries: [...entries, currentPhase] },
+      WIDE_COLUMNS,
+    );
+
+    expect(model.groups).toHaveLength(1);
+    expect(model.groups[0]).toMatchObject({
+      label: 'Explore',
+      heading: currentPhase,
+      tasks: [],
+    });
   });
 
   it('renders exactly the narrow row values the reducer reconciles against', async () => {

--- a/src/test-kernel/shared/TaskGroupProjection.vitest.ts
+++ b/src/test-kernel/shared/TaskGroupProjection.vitest.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   LOG_LEVELS,
+  GroupLogPayloadSchema,
   RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_PHASE,
@@ -46,6 +47,15 @@ function entry(
 }
 
 describe('task-group StreamLog projection', () => {
+  it('distinguishes absent attempt identity from malformed ownership', () => {
+    expect(GroupLogPayloadSchema.safeParse({ kind: 'phase' }).success).toBe(
+      true,
+    );
+    expect(
+      GroupLogPayloadSchema.safeParse({ kind: 'phase', attemptId: 7 }).success,
+    ).toBe(false);
+  });
+
   it('projects group metadata and completes groups in source order', () => {
     const taskGroups = projectTaskGroupsFromStreamLog([
       entry('run-1', STREAM_LOG_ENTRY_TYPES.GROUP_START, {

--- a/src/test-kernel/shared/TaskGroupProjection.vitest.ts
+++ b/src/test-kernel/shared/TaskGroupProjection.vitest.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import {
   LOG_LEVELS,
-  GroupLogPayloadSchema,
   RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_PHASE,
@@ -48,12 +47,27 @@ function entry(
 
 describe('task-group StreamLog projection', () => {
   it('distinguishes absent attempt identity from malformed ownership', () => {
-    expect(GroupLogPayloadSchema.safeParse({ kind: 'phase' }).success).toBe(
-      true,
+    const taskGroups = projectTaskGroupsFromStreamLog([
+      entry('valid-phase', STREAM_LOG_ENTRY_TYPES.GROUP_START, {
+        text: 'Explore',
+        data: { kind: 'phase' },
+      }),
+      entry('invalid-phase', STREAM_LOG_ENTRY_TYPES.GROUP_START, {
+        text: 'Stale phase',
+        data: { kind: 'phase', attemptId: '' },
+      }),
+    ]);
+
+    expect(taskGroups).toMatchObject([
+      {
+        id: 'valid-phase',
+        name: 'Explore',
+        kind: 'phase',
+      },
+    ]);
+    expect(taskGroups.some((group) => group.id === 'invalid-phase')).toBe(
+      false,
     );
-    expect(
-      GroupLogPayloadSchema.safeParse({ kind: 'phase', attemptId: 7 }).success,
-    ).toBe(false);
   });
 
   it('projects group metadata and completes groups in source order', () => {

--- a/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
@@ -46,6 +46,22 @@ describe('workflow call copy', () => {
     ).toStrictEqual([currentB]);
   });
 
+  it('honors an explicit attempt before it emits any calls', () => {
+    expect(
+      latestWorkflowCallsById(
+        [
+          {
+            id: 'old',
+            label: 'Old task',
+            status: 'completed',
+            attemptId: 'prior',
+          },
+        ],
+        'current',
+      ),
+    ).toStrictEqual([]);
+  });
+
   it('uses one terminal metadata representation across hosts', () => {
     expect(
       formatWorkflowCallMetadataParts({

--- a/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
@@ -3,23 +3,12 @@ import { describe, expect, it } from 'vitest';
 import {
   formatWorkflowCallMetadataParts,
   formatWorkflowCallLine,
-  latestWorkflowEntryAttemptId,
   latestWorkflowCallsById,
   workflowCallFailureTally,
   workflowPhaseCallProgress,
 } from '@shared/copy/workflowCall';
 
 describe('workflow call copy', () => {
-  it('selects the latest attempt from phase and task transcript entries', () => {
-    expect(
-      latestWorkflowEntryAttemptId([
-        { role: 'phase', attemptId: 'prior' },
-        { role: 'workflowTask', task: { attemptId: 'current' } },
-        { role: 'assistant' },
-      ]),
-    ).toBe('current');
-  });
-
   it('selects the latest state per id in retained transcript order', () => {
     const latestB = { id: 'b', label: 'B', status: 'running' as const };
     const latestA = { id: 'a', label: 'A', status: 'cached' as const };

--- a/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
@@ -3,11 +3,49 @@ import { describe, expect, it } from 'vitest';
 import {
   formatWorkflowCallMetadataParts,
   formatWorkflowCallLine,
+  latestWorkflowCallsById,
   workflowCallFailureTally,
   workflowPhaseCallProgress,
 } from '@shared/copy/workflowCall';
 
 describe('workflow call copy', () => {
+  it('selects the latest state per id in retained transcript order', () => {
+    const latestB = { id: 'b', label: 'B', status: 'running' as const };
+    const latestA = { id: 'a', label: 'A', status: 'cached' as const };
+
+    expect(
+      latestWorkflowCallsById([
+        { id: 'a', label: 'A', status: 'failed', error: 'old' },
+        { id: 'b', label: 'B', status: 'completed' },
+        latestB,
+        latestA,
+      ]),
+    ).toStrictEqual([latestB, latestA]);
+  });
+
+  it('uses the latest attempt as the current rerun task set', () => {
+    const currentB = {
+      id: 'b',
+      label: 'B revised',
+      status: 'running' as const,
+      attemptId: 'current',
+    };
+
+    expect(
+      latestWorkflowCallsById([
+        {
+          id: 'a',
+          label: 'A',
+          status: 'failed',
+          error: 'old',
+          attemptId: 'prior',
+        },
+        { id: 'b', label: 'B', status: 'completed', attemptId: 'prior' },
+        currentB,
+      ]),
+    ).toStrictEqual([currentB]);
+  });
+
   it('uses one terminal metadata representation across hosts', () => {
     expect(
       formatWorkflowCallMetadataParts({

--- a/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-import { WorkflowCallProgressSchema } from '@shared/schemas';
 import {
   formatWorkflowCallMetadataParts,
   formatWorkflowCallLine,
@@ -10,17 +9,6 @@ import {
 } from '@shared/copy/workflowCall';
 
 describe('workflow call copy', () => {
-  it('keeps a task row when its optional attempt id is malformed', () => {
-    expect(
-      WorkflowCallProgressSchema.parse({
-        id: 'audit',
-        label: 'Audit',
-        status: 'running',
-        attemptId: 7,
-      }),
-    ).toEqual({ id: 'audit', label: 'Audit', status: 'running' });
-  });
-
   it('selects the latest state per id in retained transcript order', () => {
     const latestB = { id: 'b', label: 'B', status: 'running' as const };
     const latestA = { id: 'a', label: 'A', status: 'cached' as const };

--- a/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
@@ -3,12 +3,23 @@ import { describe, expect, it } from 'vitest';
 import {
   formatWorkflowCallMetadataParts,
   formatWorkflowCallLine,
+  latestWorkflowEntryAttemptId,
   latestWorkflowCallsById,
   workflowCallFailureTally,
   workflowPhaseCallProgress,
 } from '@shared/copy/workflowCall';
 
 describe('workflow call copy', () => {
+  it('selects the latest attempt from phase and task transcript entries', () => {
+    expect(
+      latestWorkflowEntryAttemptId([
+        { role: 'phase', attemptId: 'prior' },
+        { role: 'workflowTask', task: { attemptId: 'current' } },
+        { role: 'assistant' },
+      ]),
+    ).toBe('current');
+  });
+
   it('selects the latest state per id in retained transcript order', () => {
     const latestB = { id: 'b', label: 'B', status: 'running' as const };
     const latestA = { id: 'a', label: 'A', status: 'cached' as const };

--- a/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowCallCopy.vitest.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { WorkflowCallProgressSchema } from '@shared/schemas';
 import {
   formatWorkflowCallMetadataParts,
   formatWorkflowCallLine,
@@ -9,6 +10,17 @@ import {
 } from '@shared/copy/workflowCall';
 
 describe('workflow call copy', () => {
+  it('keeps a task row when its optional attempt id is malformed', () => {
+    expect(
+      WorkflowCallProgressSchema.parse({
+        id: 'audit',
+        label: 'Audit',
+        status: 'running',
+        attemptId: 7,
+      }),
+    ).toEqual({ id: 'audit', label: 'Audit', status: 'running' });
+  });
+
   it('selects the latest state per id in retained transcript order', () => {
     const latestB = { id: 'b', label: 'B', status: 'running' as const };
     const latestA = { id: 'a', label: 'A', status: 'cached' as const };

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -49,6 +49,24 @@ function dataOf(entry: StreamLogEntry | undefined): Record<string, unknown> {
 }
 
 describe('attachTranscriptRecorder StreamPhase-native group rows (issue #7993)', () => {
+  it('persists a workflow attempt before it has tasks or phases', () => {
+    const { trace, rows } = attachRecorder();
+
+    trace.emit({ type: 'workflow.attempt', attemptId: 'attempt-empty' });
+
+    expect(rows()).toContainEqual(
+      expect.objectContaining({
+        id: 'workflow-attempt-attempt-empty',
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        messageType: MESSAGE_TYPES.INTERNAL,
+        data: {
+          kind: 'workflowAttempt',
+          attemptId: 'attempt-empty',
+        },
+      }),
+    );
+  });
+
   it("writes GROUP_START's data.status as StreamPhase.RUNNING", () => {
     const { trace, row } = attachRecorder();
 

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -60,6 +60,20 @@ describe('attachTranscriptRecorder StreamPhase-native group rows (issue #7993)',
     expect(dataOf(startEntry).status).toBe(STREAM_PHASE.RUNNING);
   });
 
+  it('retains workflow attempt identity when a phase settles', () => {
+    const { trace, row } = attachRecorder();
+
+    const stage = trace.openStage('Verify', {
+      kind: 'phase',
+      attemptId: 'attempt-current',
+    });
+    expect(dataOf(row(stage.id)).attemptId).toBe('attempt-current');
+
+    stage.end();
+
+    expect(dataOf(row(stage.id)).attemptId).toBe('attempt-current');
+  });
+
   it('defaults GROUP_END to the literal RunOutcome.COMPLETED, not a folded EndGroupStatus', () => {
     const { trace, row } = attachRecorder();
 

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -235,6 +235,7 @@ export async function runPersistedWorkflowScriptWithProgress(
         parentId: parentStageId,
         index,
         total,
+        attemptId: projectionId,
       }),
       failed: false,
     };

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -290,7 +290,7 @@ export async function runPersistedWorkflowScriptWithProgress(
     trace.emit({
       type: 'workflow.call',
       logId: projected.logId,
-      call: { ...call, phase },
+      call: { ...call, phase, attemptId: projectionId },
       stageId: phase === undefined ? parentStageId : phaseStageIdFor(phase),
     });
   };

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -417,6 +417,11 @@ export async function runPersistedWorkflowScriptWithProgress(
     }
   };
 
+  // The physical attempt exists even when parsing or initial persistence fails
+  // before the engine can emit a plan, phase, or call. Publish its boundary
+  // first so live projections never infer the current run from optional work.
+  trace.emit({ type: 'workflow.attempt', attemptId: projectionId });
+
   try {
     const result = await runPersistedWorkflowScript({
       ...runOptions,

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -360,8 +360,8 @@ export async function runPersistedWorkflowScriptWithProgress(
             ? { childStreamId: event.childStreamId }
             : {}),
         };
-        // Cached replays perform no live attempt, so they carry neither
-        // attempt metadata nor cost.
+        // Cached replays belong to the current projection attempt, but perform
+        // no live agent call and therefore carry no duration or cost metadata.
         if (event.outcome === 'cached') {
           emitCall({ ...identity, status: 'cached' });
           onActivity?.(`Using saved result: ${event.label}`);

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -153,7 +153,7 @@ interface StreamSinkState {
 
 type StageMetadata = Pick<
   Extract<AgentEvent, { type: 'stage.start' }>,
-  'kind' | 'index' | 'total'
+  'kind' | 'index' | 'total' | 'attemptId'
 >;
 
 /**
@@ -311,6 +311,9 @@ export function attachTranscriptRecorder(
             ...(event.kind !== undefined ? { kind: event.kind } : {}),
             ...(event.index !== undefined ? { index: event.index } : {}),
             ...(event.total !== undefined ? { total: event.total } : {}),
+            ...(event.attemptId !== undefined
+              ? { attemptId: event.attemptId }
+              : {}),
           } satisfies StageMetadata;
           stageMetadata.set(event.id, metadata);
           // A new round starts fresh: whatever MODEL_RESPONSE stream the

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -47,6 +47,7 @@ import {
   type LogLevel,
   type MessageType,
   type ToolUseLog,
+  type WorkflowAttemptMarker,
   type WorkflowCallProgress,
 } from '@shared/schemas';
 import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
@@ -402,6 +403,24 @@ export function attachTranscriptRecorder(
             writer.settle(event.logId, patch);
             activeToolEntries.delete(event.logId);
           }
+          return;
+        }
+
+        case 'workflow.attempt': {
+          const marker = {
+            kind: 'workflowAttempt',
+            attemptId: event.attemptId,
+          } satisfies WorkflowAttemptMarker;
+          writer.appendSettled({
+            id: `workflow-attempt-${event.attemptId}`,
+            type: STREAM_LOG_ENTRY_TYPES.LOG,
+            level: 'info',
+            timestamp: Date.now(),
+            groupId: event.stageId,
+            messageType: MESSAGE_TYPES.INTERNAL,
+            data: marker,
+            verbose: false,
+          });
           return;
         }
 


### PR DESCRIPTION
Closes #10141.\n\n## Summary\n\n- declare every physical workflow run before parsing or execution begins\n- stamp workflow-call and workflow-phase progress with that attempt identity\n- select only the declared current attempt, then the latest state per logical task ID, in both live CLI surfaces\n- retain all earlier attempt records in transcript scrollback\n\n## Ownership and separation of concerns\n\nThe workflow execution projection owns attempt identity. It publishes one attempt-start fact before entering the script engine, so an invalid script, failed initial checkpoint, empty dynamic workflow, or ordinary run all have the same boundary.\n\nThe transcript recorder persists that fact as a hidden internal marker. Task and phase records carry the same identity. The CLI state fold owns the current-attempt value reconstructed from the durable stream.\n\nThe status band and focused dashboard are presentation projections only. They select task and phase facts belonging to the declared attempt, collapse repeated states by logical task ID, and format the result. They do not infer a run boundary from task status, phase order, or the first optional task. The progress view retains the full historical transcript; its per-attempt phase groups already have distinct physical identities.\n\nOlder transcript rows without an attempt identity retain the previous latest-record-per-id projection until a current writer appends an explicit attempt marker.\n\n## Correctness cases\n\n- a corrected rerun that removes or renames a task does not retain the old task\n- repeated logical task IDs show only their latest state in the current attempt\n- prior phase headings and counts cannot combine with current tasks\n- a dynamic phase is visible before its first task\n- a rerun that fails before emitting any phase or task immediately clears the prior live dashboard and status summary\n- durable scrollback remains complete and auditable\n\n## Validation\n\n- 105 focused workflow, transcript, dashboard, status-band, and selector tests\n- full npm run typecheck\n- full npm run lint\n- npm run compile:fast\n- formatting, local hooks, and pre-push changed-file lint