### PR TITLE
fix(cli): preserve invalid attempt boundaries

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -161,11 +161,13 @@ export function workflowRunStatusSummary(
   const currentAttemptId = currentWorkflowAttemptId(
     slice.workflowAttemptId,
     slice.entries,
+    slice.workflowAttemptBoundaryDeclared,
   );
   const phase = slice.entries.findLast(
     (entry): entry is Extract<ConversationEntry, { readonly role: 'phase' }> =>
       entry.role === 'phase' &&
-      (currentAttemptId === undefined || entry.attemptId === currentAttemptId),
+      (currentAttemptId === undefined ||
+        (currentAttemptId !== null && entry.attemptId === currentAttemptId)),
   );
   const currentCalls = latestWorkflowCallsById(
     slice.entries.flatMap((entry) =>

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -141,7 +141,7 @@ export type ConversationEntry = ConversationEntryOrigin &
 export function currentWorkflowAttemptId(
   declaredAttemptId: string | undefined,
   entries: readonly ConversationEntry[],
-  boundaryDeclared = false,
+  boundaryDeclared: boolean,
 ): string | null | undefined {
   if (boundaryDeclared) return declaredAttemptId ?? null;
   return (

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -141,7 +141,9 @@ export type ConversationEntry = ConversationEntryOrigin &
 export function currentWorkflowAttemptId(
   declaredAttemptId: string | undefined,
   entries: readonly ConversationEntry[],
-): string | undefined {
+  boundaryDeclared = false,
+): string | null | undefined {
+  if (boundaryDeclared) return declaredAttemptId ?? null;
   return (
     declaredAttemptId ??
     latestWorkflowAttemptId(
@@ -235,6 +237,7 @@ export interface TranscriptFoldState {
   liveActivityEntry?: StreamLogEntry;
   /** Latest durable workflow-attempt marker and its source order. */
   workflowAttemptId?: string;
+  workflowAttemptBoundaryDeclared: boolean;
   workflowAttemptSeqNo: number;
   /** Synthetic rows reconciled into `items`, in slice order, by identity. */
   synthetics: readonly ConversationEntry[];
@@ -311,6 +314,8 @@ export interface StreamSlice {
   readonly taskGroups: readonly TaskGroup[];
   /** Latest physical workflow attempt declared by the durable stream. */
   readonly workflowAttemptId?: string | undefined;
+  /** Whether the stream declared an attempt boundary, valid or malformed. */
+  readonly workflowAttemptBoundaryDeclared: boolean;
   readonly status: StreamPhase | undefined;
   readonly substate?: StreamSubstate;
   /** Epoch ms when this stream last entered `RUNNING`; cleared on any other
@@ -387,6 +392,7 @@ export function emptySlice(streamId: StreamTabId): StreamSlice {
     compileFailuresByRound: {},
     taskGroups: [],
     workflowAttemptId: undefined,
+    workflowAttemptBoundaryDeclared: false,
     thinkingActive: false,
     compactingActive: false,
     usage: undefined,

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -437,6 +437,8 @@ export function syncStreamLog(
       slice.thinkingActive === thinkingActive &&
       slice.compactingActive === compactingActive &&
       slice.workflowAttemptId === state.workflowAttemptId &&
+      slice.workflowAttemptBoundaryDeclared ===
+        state.workflowAttemptBoundaryDeclared &&
       isDeepStrictEqual(slice.activeSkills, activeSkills) &&
       slice.taskGroups === taskGroups
     ) {
@@ -451,6 +453,7 @@ export function syncStreamLog(
       thinkingActive,
       compactingActive,
       workflowAttemptId: state.workflowAttemptId,
+      workflowAttemptBoundaryDeclared: state.workflowAttemptBoundaryDeclared,
       taskGroups,
     };
   });

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -576,6 +576,7 @@ export function createTranscriptFoldState(): TranscriptFoldState {
     latestUserPos: -1,
     latestResponsePos: -1,
     workflowAttemptSeqNo: -1,
+    workflowAttemptBoundaryDeclared: false,
     fullLogChild: false,
     workflowOperationalOnly: false,
     projectLifecycleToTaskGroups: false,
@@ -594,6 +595,7 @@ export function resetTranscriptFoldState(state: TranscriptFoldState): void {
   state.latestUserPos = -1;
   state.latestResponsePos = -1;
   state.workflowAttemptId = undefined;
+  state.workflowAttemptBoundaryDeclared = false;
   state.workflowAttemptSeqNo = -1;
   state.activeSkillsEntry = undefined;
   state.activeSkillsParsedFor = undefined;
@@ -837,6 +839,7 @@ function applyChangedLogEntry(
     state.workflowAttemptId = marker.success
       ? marker.data.attemptId
       : undefined;
+    state.workflowAttemptBoundaryDeclared = true;
     state.workflowAttemptSeqNo = entry.seqNo;
   }
   const wOO = state.workflowOperationalOnly;

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -89,6 +89,7 @@ export function workflowDashboardModel(
   const currentAttemptId = currentWorkflowAttemptId(
     root.workflowAttemptId,
     root.entries,
+    root.workflowAttemptBoundaryDeclared,
   );
   const currentCalls = new Set(
     latestWorkflowCallsById(
@@ -105,7 +106,7 @@ export function workflowDashboardModel(
     if (
       entry.role === 'phase' &&
       currentAttemptId !== undefined &&
-      entry.attemptId !== currentAttemptId
+      (currentAttemptId === null || entry.attemptId !== currentAttemptId)
     ) {
       continue;
     }

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -23,8 +23,9 @@ export function latestWorkflowAttemptId(
  */
 export function latestWorkflowCallsById(
   calls: readonly WorkflowCallProgress[],
-  declaredAttemptId?: string,
+  declaredAttemptId?: string | null,
 ): WorkflowCallProgress[] {
+  if (declaredAttemptId === null) return [];
   const currentAttemptId =
     declaredAttemptId ??
     latestWorkflowAttemptId(calls.map((call) => call.attemptId));

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -19,7 +19,8 @@ export function latestWorkflowAttemptId(
  * Durable script reruns append progress under a fresh attempt id so the
  * earlier attempt remains available in transcript history. Current writers
  * stamp every call; older persisted transcripts without that fact fall back
- * to their latest record per logical id.
+ * to their latest record per logical id. A `null` declared attempt means a
+ * durable boundary was present but invalid, so inference must remain disabled.
  */
 export function latestWorkflowCallsById(
   calls: readonly WorkflowCallProgress[],

--- a/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
+++ b/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
@@ -96,6 +96,8 @@ function projectedView(slice: StreamSlice | undefined): unknown {
     activeSkills: slice?.activeSkills ?? [],
     taskGroups: slice?.taskGroups ?? [],
     workflowAttemptId: slice?.workflowAttemptId,
+    workflowAttemptBoundaryDeclared:
+      slice?.workflowAttemptBoundaryDeclared ?? false,
   };
 }
 
@@ -478,6 +480,7 @@ describe('transcript fold vs from-scratch oracle', () => {
 
       const slice = streams.get().get(FOLD_STREAM);
       expect(slice?.workflowAttemptId).toBe('current-attempt');
+      expect(slice?.workflowAttemptBoundaryDeclared).toBe(true);
       expect(slice?.entries).toEqual([]);
 
       appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
@@ -504,8 +507,10 @@ describe('transcript fold vs from-scratch oracle', () => {
         data: { kind: 'workflowAttempt', attemptId: '' },
       });
       syncStreamLog(FOLD_STREAM);
-      expect(streams.get().get(FOLD_STREAM)?.workflowAttemptId).toBeUndefined();
-      expect(streams.get().get(FOLD_STREAM)?.entries).toEqual([]);
+      const invalidSlice = streams.get().get(FOLD_STREAM);
+      expect(invalidSlice?.workflowAttemptId).toBeUndefined();
+      expect(invalidSlice?.workflowAttemptBoundaryDeclared).toBe(true);
+      expect(invalidSlice?.entries).toEqual([]);
     } finally {
       dispose();
     }

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -359,6 +359,25 @@ describe('CLI child list display model', () => {
     expect(workflowRunStatusSummary(slice)).toBeUndefined();
   });
 
+  it('does not infer status after a malformed declared attempt boundary', () => {
+    const slice = workflowAgentSlice('invalid-rerun', {
+      workflowAttemptBoundaryDeclared: true,
+      workflowAttemptId: undefined,
+      entries: [
+        phaseEntry('phase-old', 'Verify', { attemptId: 'prior' }),
+        workflowTaskEntry('task-old', 'Finished: Verify', {
+          id: 'verification',
+          label: 'Verify',
+          phase: 'Verify',
+          status: 'completed',
+          attemptId: 'prior',
+        }),
+      ],
+    });
+
+    expect(workflowRunStatusSummary(slice)).toBeUndefined();
+  });
+
   it('tallys failures across the whole run, not just the current phase', () => {
     // A failure in an earlier phase must persist in the band after the run
     // advances, unlike the current-phase done/total. The whole-run tally keeps

--- a/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
+++ b/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
@@ -440,6 +440,25 @@ describe('workflow dashboard model', () => {
     expect(model.tasks).toStrictEqual([]);
   });
 
+  it('does not revive prior rows after a malformed declared boundary', () => {
+    const prior = workflowRoot(
+      ['Verify'],
+      [{ id: 'verification', phase: 'Verify' }],
+    );
+
+    const model = workflowDashboardModel(
+      {
+        ...prior,
+        workflowAttemptId: undefined,
+        workflowAttemptBoundaryDeclared: true,
+      },
+      WIDE_COLUMNS,
+    );
+
+    expect(model.groups).toStrictEqual([]);
+    expect(model.tasks).toStrictEqual([]);
+  });
+
   it('renders exactly the narrow row values the reducer reconciles against', async () => {
     const model = workflowDashboardModel(TWO_PHASE_ROOT, NARROW_COLUMNS);
     const visited = await navigateList(


### PR DESCRIPTION
## Summary

- preserve whether a workflow attempt boundary was declared independently of whether its identifier parsed successfully
- allow legacy phase/task inference only when no durable boundary exists
- keep malformed declared boundaries from reviving rows from an earlier workflow attempt

This is a focused follow-up to #10142. The late commit included in that merge cleared an invalid marker to `undefined`, which was also the legacy no-marker representation and therefore re-enabled transcript inference.

## Validation

- `pnpm vitest run src/test-kernel/cli/StreamLogDeltaFold.vitest.ts src/test-kernel/cli/WorkflowDashboardModel.vitest.ts src/test-kernel/cli/SubagentListDisplay.vitest.ts src/test-kernel/shared/WorkflowCallCopy.vitest.ts` (68 tests)
- `pnpm typecheck:workspace`
- `pnpm typecheck:test-kernel`
- focused ESLint and Prettier checks
- pre-push checks