### PR TITLE
fix(ui): reset response correlation per session turn

### DIFF
--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -237,6 +237,30 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
     expect(modelResponseEntries[1]?.id).not.toBe(output.id);
   });
 
+  it('does not let an earlier tool-use turn leak into a later session stage', () => {
+    const { trace, rows } = attachRecorder();
+
+    const turn0 = trace.openStage('Tool-use turn', { kind: 'session' });
+    const output = trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
+    output.append('I will inspect the workspace.');
+    output.finalize();
+    turn0.end();
+
+    const turn1 = trace.openStage('Tool-use turn', { kind: 'session' });
+    trace.responseFinalized('The workspace is ready.');
+    turn1.end();
+
+    const modelResponseEntries = rows().filter(
+      (entry) => entry.messageType === MESSAGE_TYPES.MODEL_RESPONSE,
+    );
+    expect(modelResponseEntries.map((entry) => entry.text)).toEqual([
+      'I will inspect the workspace.',
+      'The workspace is ready.',
+    ]);
+    expect(modelResponseEntries[0]?.id).toBe(output.id);
+    expect(modelResponseEntries[1]?.id).not.toBe(output.id);
+  });
+
   it('does not let an earlier invocation in the same round stage overwrite a later finalized response', () => {
     const { trace, rows } = attachRecorder();
 

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -317,9 +317,13 @@ export function attachTranscriptRecorder(
               : {}),
           } satisfies StageMetadata;
           stageMetadata.set(event.id, metadata);
-          // A new round starts fresh: whatever MODEL_RESPONSE stream the
-          // previous round may have opened is no longer this round's to reuse.
-          if (event.kind === 'round') pendingModelResponseId = undefined;
+          // A new model-turn boundary starts fresh: whatever MODEL_RESPONSE
+          // stream the previous turn may have opened is no longer this turn's
+          // to reuse. Tool-use turns are session stages containing several
+          // inner model/tool rounds, while other flows expose round stages.
+          if (event.kind === 'round' || event.kind === 'session') {
+            pendingModelResponseId = undefined;
+          }
           writer.appendSettled({
             id: event.id,
             type: STREAM_LOG_ENTRY_TYPES.GROUP_START,


### PR DESCRIPTION
## Summary

- reset transcript model-response correlation when a new tool-use session turn begins
- preserve the existing round-stage reset for other agent flows
- add a regression test proving a later `response.finalized` event cannot reuse the prior tool-use turn response id

## Separation of concerns

This is a UI reaction boundary. The session stage event already declares that a new tool-use turn began; the transcript recorder consumes that event and clears presentation-only correlation state. It does not create or modify continuation generations, recovery authority, queue ownership, or execution leases. Those remain session responsibilities.

The reset is defensive under the current streaming flow, which normally opens a same-turn response stream before `response.finalized`; it restores the explicit turn-boundary invariant after tool-use turns changed from round stages to session stages. Non-streaming responses use the independent log path and are not the regression covered here.

## Validation

- `typecheck:workspace`
- `typecheck:test-kernel`
- ESLint on changed files
- 42 focused transcript and tool-use progress tests
- pre-push checks
- full CI, including both kernel shards, static checks, build artifacts, and webview smoke