### PR TITLE
fix(ui): clarify delegation approval scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ All notable changes to this project will be documented in this file.
 - **Headless team progress identifies delegated tasks** — direct multi-agent
   runs show what the active child is checking, not only its generic agent name.
 
+### Extension (VS Code) and Desktop
+
+#### Bug Fixes
+
+- **Delegation approvals state their full run-wide scope** — approval controls
+  no longer imply that later automatic approvals are limited to tasks requested
+  by one agent.
+
 ### Shared (all surfaces)
 
 #### Bug Fixes

--- a/src/shared/copy/delegationApproval.ts
+++ b/src/shared/copy/delegationApproval.ts
@@ -6,9 +6,9 @@ export const DELEGATION_APPROVAL_COPY = Object.freeze({
     'Press y to approve only this task. Press a to approve delegated tasks, file edits, and commands for this chat. Other prompts still ask.',
   progressViewAction: 'Approve agent work for this run',
   progressViewExplanation:
-    'Approves this request, queued and later agent tasks requested by this agent, and queued and later file edits and shell commands in this run. Plans, retries, external inquiries, and user questions still require a decision.',
+    'Approves this request, queued and later agent tasks, and queued and later file edits and shell commands in this run. Plans, retries, external inquiries, and user questions still require a decision.',
   progressViewToggle:
-    'Auto-approve later agent tasks requested by this agent, plus later file edits and shell commands in this run',
+    'Auto-approve later agent tasks, file edits, and shell commands in this run',
   progressViewEditAction:
     'Approve and later auto-approve file edits in this run',
   progressViewCommandAction:

--- a/src/test-kernel/shared/DelegationApprovalCopy.vitest.ts
+++ b/src/test-kernel/shared/DelegationApprovalCopy.vitest.ts
@@ -15,9 +15,9 @@ describe('delegated-work approval copy', () => {
         'Press y to approve only this task. Press a to approve delegated tasks, file edits, and commands for this chat. Other prompts still ask.',
       progressViewAction: 'Approve agent work for this run',
       progressViewExplanation:
-        'Approves this request, queued and later agent tasks requested by this agent, and queued and later file edits and shell commands in this run. Plans, retries, external inquiries, and user questions still require a decision.',
+        'Approves this request, queued and later agent tasks, and queued and later file edits and shell commands in this run. Plans, retries, external inquiries, and user questions still require a decision.',
       progressViewToggle:
-        'Auto-approve later agent tasks requested by this agent, plus later file edits and shell commands in this run',
+        'Auto-approve later agent tasks, file edits, and shell commands in this run',
       progressViewEditAction:
         'Approve and later auto-approve file edits in this run',
       progressViewCommandAction:


### PR DESCRIPTION
## Summary

- remove the requesting-agent qualifier from progress-view delegation approval descriptions
- keep the shared copy object as the single source for the tooltip and toggle
- document the corrected run-wide scope in the changelog

## Root cause

The progress view described a stream-scoped approval grant as though it applied only to tasks requested by one agent. The underlying grant is keyed by run stream and also covers later proposals from other requesters in that run.

## Validation

- `corepack pnpm run format`
- `corepack pnpm run compile:fast`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck:test-kernel`
- `corepack pnpm vitest run src/test-kernel/shared/DelegationApprovalCopy.vitest.ts src/test-kernel/progressView/ApproveSplitButton.vitest.ts`

Closes #10146