### PR TITLE
fix: preserve rejection guidance provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Command rejections preserve the user's actual instructions** — rejecting a
+  shell-backed action without a note no longer presents generated retry
+  guidance to the agent as though the user had written it.
 - **Read-only completion checks stay focused** — end-of-session review no
   longer asks to inspect project plans, Git history, or pull requests when the
   current task and its delegated results already contain the evidence needed.

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -62,6 +62,8 @@ export type ApprovalPayload =
 export interface ApprovalDecision extends Readonly<SharedApprovalDecision> {
   /** Queue or prompt lifecycle failure, never text entered by the user. */
   readonly rejectionCause?: string;
+  /** Automatic policy denial, never text entered by the user. */
+  readonly rejectionReason?: string;
   /** Session bypass to activate before accepting this approval. */
   readonly bypass?: ApprovalBypassKind;
   /** Credential mode to apply before accepting this approval. */

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -60,6 +60,8 @@ export type ApprovalPayload =
  * docs/proposals/2026-05-31-tui-extension-sharing.md (Rung 1).
  */
 export interface ApprovalDecision extends Readonly<SharedApprovalDecision> {
+  /** Queue or prompt lifecycle failure, never text entered by the user. */
+  readonly rejectionCause?: string;
   /** Session bypass to activate before accepting this approval. */
   readonly bypass?: ApprovalBypassKind;
   /** Credential mode to apply before accepting this approval. */
@@ -184,7 +186,7 @@ export const pendingApprovalSummaries: Signal.Computed<
 
 const INTERRUPT: ApprovalDecision = {
   accepted: false,
-  userMessage: 'Session interrupted.',
+  rejectionCause: 'Session interrupted.',
 };
 
 /** The entry the modal shows: the first one waiting for a user decision. */

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -32,11 +32,13 @@ import {
 import { getCliApiMode, setCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
   toApprovalSettlement,
+  toBashApprovalSettlement,
   toToolEditResult,
 } from '@cli/runtime/approvalAdapter';
 import {
   classifyCliRetryAction,
   isCliApiSwitchableRetry,
+  type CliApprovalDecision,
 } from '@cli/runtime/approval/approvalPrompts';
 import {
   denyExternalInquiryIfNoHumanInput,
@@ -252,7 +254,7 @@ function prepareRetryClient(
 async function decidePresentedApproval<
   K extends 'bash' | 'toolEdit' | 'planApproval' | 'proposal',
   P,
->(kind: K, payload: P): Promise<ApprovalDecision> {
+>(kind: K, payload: P): Promise<ApprovalDecision & CliApprovalDecision> {
   try {
     return await enqueueTuiApproval({ kind, payload } as Extract<
       ApprovalPayload,
@@ -261,7 +263,7 @@ async function decidePresentedApproval<
   } catch {
     return {
       accepted: false,
-      userMessage: 'CLI approval prompt failed.',
+      rejectionCause: 'CLI approval prompt failed.',
     };
   }
 }
@@ -283,7 +285,7 @@ async function requestBashInteraction(
   if (decision.accepted && decision.bypass === 'bash' && request.streamId) {
     setBashApprovalSessionBypass(request.streamId, true);
   }
-  return toApprovalSettlement(decision);
+  return toBashApprovalSettlement(decision);
 }
 
 async function requestPlanInteraction(

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -280,7 +280,7 @@ async function decideWithPolicy<K extends 'planApproval' | 'proposal', P>(
   if (policy && !policy.accepted) {
     return {
       accepted: false,
-      rejectionReason: policy.userMessage,
+      rejectionReason: policy.userMessage ?? '',
     };
   }
   return policy ?? decidePresentedApproval(kind, payload);

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -38,7 +38,6 @@ import {
 import {
   classifyCliRetryAction,
   isCliApiSwitchableRetry,
-  type CliApprovalDecision,
 } from '@cli/runtime/approval/approvalPrompts';
 import {
   denyExternalInquiryIfNoHumanInput,
@@ -254,7 +253,7 @@ function prepareRetryClient(
 async function decidePresentedApproval<
   K extends 'bash' | 'toolEdit' | 'planApproval' | 'proposal',
   P,
->(kind: K, payload: P): Promise<ApprovalDecision & CliApprovalDecision> {
+>(kind: K, payload: P): Promise<ApprovalDecision> {
   try {
     return await enqueueTuiApproval({ kind, payload } as Extract<
       ApprovalPayload,

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -816,7 +816,10 @@ function handleExternalInquiry(
       void handleExternalInquiryAction({
         action: 'drop',
         threadId,
-        feedback: decision.userMessage || 'No answer provided.',
+        feedback:
+          decision.rejectionCause ??
+          decision.userMessage ??
+          'No answer provided.',
       });
     },
   );

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -260,7 +260,11 @@ async function decidePresentedApproval<
       ApprovalPayload,
       { kind: K }
     >);
-  } catch {
+  } catch (error) {
+    logWarning(
+      'cli.tui',
+      `The approval prompt failed: ${toErrorMessage(error)}`,
+    );
     return {
       accepted: false,
       rejectionCause: 'CLI approval prompt failed.',
@@ -274,6 +278,12 @@ async function decideWithPolicy<K extends 'planApproval' | 'proposal', P>(
   payload: P,
 ): Promise<ApprovalDecision> {
   const policy = settleExecutable(context);
+  if (policy && !policy.accepted) {
+    return {
+      accepted: false,
+      rejectionReason: policy.userMessage,
+    };
+  }
   return policy ?? decidePresentedApproval(kind, payload);
 }
 
@@ -461,10 +471,13 @@ async function requestUserQuestionInteraction(
 ): Promise<UserQuestionSettlement> {
   const denial = settleHumanInputDenial(context);
   if (denial != null) {
-    return { action: 'reject', feedback: denial.userMessage };
+    return { action: 'reject', reason: denial.userMessage };
   }
 
   const decision = await enqueueTuiApproval({ kind: 'userQuestion', payload });
+  if (decision.rejectionCause !== undefined) {
+    return { action: 'reject', cause: decision.rejectionCause };
+  }
   return decision.accepted && decision.userQuestionAnswers
     ? { action: 'submit', answers: decision.userQuestionAnswers }
     : {

--- a/packages/cli/src/runtime/approval/approvalPrompts.ts
+++ b/packages/cli/src/runtime/approval/approvalPrompts.ts
@@ -49,6 +49,11 @@ export interface CliApprovalPromptHooks {
   readonly beforePrompt?: () => void;
 }
 
+/** CLI-local extension that keeps host failures separate from user text. */
+export type CliApprovalDecision = ApprovalDecision & {
+  readonly rejectionCause?: string;
+};
+
 export interface CliApprovalContent {
   readonly summary: string;
   /** Complete content behind a bounded summary, shown only on request. */
@@ -271,7 +276,7 @@ export async function askApproval(
   context: CliContext,
   content: CliApprovalContent,
   hooks: CliApprovalPromptHooks = {},
-): Promise<ApprovalDecision> {
+): Promise<CliApprovalDecision> {
   const getDetails = content.details;
   try {
     return await cliPromptQueue(context).add(async () => {
@@ -309,12 +314,13 @@ export async function askApproval(
 
       return {
         accepted: parsed.accepted,
-        userMessage: parsed.accepted
-          ? undefined
-          : feedback || 'Rejected from CLI approval prompt.',
+        userMessage: parsed.accepted ? undefined : feedback,
       };
     });
   } catch {
-    return { accepted: false, userMessage: 'CLI approval prompt failed.' };
+    return {
+      accepted: false,
+      rejectionCause: 'CLI approval prompt failed.',
+    };
   }
 }

--- a/packages/cli/src/runtime/approval/approvalPrompts.ts
+++ b/packages/cli/src/runtime/approval/approvalPrompts.ts
@@ -2,6 +2,7 @@ import PQueue from 'p-queue';
 
 import { defaultSession } from '@agent/runtime';
 import { isRelayMonthlyLimitMessage } from '@common/errors/sdkError/relayDetection';
+import { warn as logWarning } from '@logger/logUtils';
 import {
   isChatGptSubscriptionLimitError,
   isCredentialExhausted,
@@ -15,6 +16,7 @@ import {
   CODING_PLAN_SUBSCRIPTIONS,
   type CodingPlanSubscriptionId,
 } from '@shared/codingPlanSubscriptions';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { type CliContext, type CliPromptRequest } from '../cliContext';
 import { askCliQuestion, writeTextStderr } from '../logSinks';
@@ -317,7 +319,11 @@ export async function askApproval(
         userMessage: parsed.accepted ? undefined : feedback,
       };
     });
-  } catch {
+  } catch (error) {
+    logWarning(
+      'cli.approval',
+      `The CLI approval prompt failed: ${toErrorMessage(error)}`,
+    );
     return {
       accepted: false,
       rejectionCause: 'CLI approval prompt failed.',

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -60,7 +60,10 @@ export function toToolEditResult(
 ): ToolEditApprovalResult {
   return decision.accepted
     ? { accepted: true, appliedContent: proposedContent }
-    : { accepted: false, userMessage: decision.userMessage };
+    : {
+        accepted: false,
+        ...(decision.userMessage ? { feedback: decision.userMessage } : {}),
+      };
 }
 
 async function decideToolEdit(

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -9,6 +9,7 @@ import {
   type RetryResult,
   type UserQuestionSettlement,
 } from '@agent/runtime';
+import { warn as logWarning } from '@logger/logUtils';
 import {
   type AgentProposalPermission,
   type ApprovalDecision,
@@ -21,6 +22,7 @@ import {
   type ToolEditApprovalRequest,
   type ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   settleExecutable,
   settleHumanInputDenial,
@@ -152,9 +154,22 @@ async function decideApprovalEvent<K extends CliDecisionApprovalEvent>(
  *  the approve branch. A rejection without a user message omits `feedback`
  *  rather than sending an explicit `undefined`. */
 export function toApprovalSettlement(
-  decision: ApprovalDecision,
-): { action: 'approve' } | { action: 'reject'; feedback?: string } {
+  decision: ApprovalDecision & {
+    readonly rejectionCause?: string;
+    readonly rejectionReason?: string;
+  },
+):
+  | { action: 'approve' }
+  | { action: 'reject'; feedback?: string }
+  | { action: 'reject'; reason: string }
+  | { action: 'reject'; cause: string | undefined } {
   if (decision.accepted) return { action: 'approve' };
+  if (decision.rejectionCause !== undefined) {
+    return { action: 'reject', cause: decision.rejectionCause };
+  }
+  if (decision.rejectionReason !== undefined) {
+    return { action: 'reject', reason: decision.rejectionReason };
+  }
   return {
     action: 'reject',
     ...(decision.userMessage ? { feedback: decision.userMessage } : {}),
@@ -197,7 +212,7 @@ async function askHeadlessUserQuestion(
 ): Promise<UserQuestionSettlement> {
   const denial = settleHumanInputDenial(context);
   if (denial != null) {
-    return { action: 'reject', feedback: denial.userMessage };
+    return { action: 'reject', reason: denial.userMessage };
   }
 
   const answers: UserQuestionAnswers = {};
@@ -218,10 +233,14 @@ async function askHeadlessUserQuestion(
       const parsed = parseUserQuestionAnswer(answer, question);
       if (parsed != null) answers[question.question] = parsed;
     }
-  } catch {
+  } catch (error) {
+    logWarning(
+      'cli.approval',
+      `The CLI user-question prompt failed: ${toErrorMessage(error)}`,
+    );
     return {
       action: 'reject',
-      feedback: 'CLI user question prompt failed.',
+      cause: 'CLI user question prompt failed.',
     };
   }
 
@@ -254,22 +273,32 @@ export function createHeadlessCliHostInteractions(
       return toBashApprovalSettlement(decision);
     },
     async requestPlanApproval(request) {
-      const { decision } = await decideApprovalEvent(
+      const { decision, prompted } = await decideApprovalEvent(
         'showPlanApproval',
         request,
         context,
         hooks,
       );
-      return toApprovalSettlement(decision);
+      return toApprovalSettlement({
+        ...decision,
+        ...(!prompted && !decision.accepted && decision.userMessage
+          ? { rejectionReason: decision.userMessage, userMessage: undefined }
+          : {}),
+      });
     },
     async requestAgentProposal(request: HostAgentProposalRequest) {
-      const { decision } = await decideApprovalEvent(
+      const { decision, prompted } = await decideApprovalEvent(
         'showAgentProposal',
         request,
         context,
         hooks,
       );
-      return toApprovalSettlement(decision);
+      return toApprovalSettlement({
+        ...decision,
+        ...(!prompted && !decision.accepted && decision.userMessage
+          ? { rejectionReason: decision.userMessage, userMessage: undefined }
+          : {}),
+      });
     },
     async requestRetry(request: HostRetryRequest) {
       const payload: RetryPermission = {

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -1,5 +1,6 @@
 import {
   defaultSession,
+  type BashSettlement,
   type HostAgentProposalRequest,
   type HostApprovalBypassStateUpdate,
   type HostInteractions,
@@ -27,6 +28,7 @@ import {
 } from './approval/settleApprovals';
 import {
   type CliApprovalContent,
+  type CliApprovalDecision,
   type CliApprovalPromptHooks,
   type CliDecisionApprovalEvent,
   type CliDecisionApprovalPayloads,
@@ -55,15 +57,19 @@ interface HeadlessCliHostInteractionHooks extends CliApprovalPromptHooks {
 }
 
 export function toToolEditResult(
-  decision: ApprovalDecision,
+  decision: CliApprovalDecision,
   proposedContent: string,
 ): ToolEditApprovalResult {
-  return decision.accepted
-    ? { accepted: true, appliedContent: proposedContent }
-    : {
-        accepted: false,
-        ...(decision.userMessage ? { feedback: decision.userMessage } : {}),
-      };
+  if (decision.accepted) {
+    return { accepted: true, appliedContent: proposedContent };
+  }
+  if (decision.rejectionCause !== undefined) {
+    return { accepted: false, cause: decision.rejectionCause };
+  }
+  return {
+    accepted: false,
+    ...(decision.userMessage ? { feedback: decision.userMessage } : {}),
+  };
 }
 
 async function decideToolEdit(
@@ -155,6 +161,16 @@ export function toApprovalSettlement(
   };
 }
 
+/** Preserve a CLI host failure as a Bash cancellation, not user feedback. */
+export function toBashApprovalSettlement(
+  decision: CliApprovalDecision,
+): BashSettlement {
+  if (decision.rejectionCause !== undefined) {
+    return { action: 'reject', cause: decision.rejectionCause };
+  }
+  return toApprovalSettlement(decision);
+}
+
 function toRetryResult(
   decision: ApprovalDecision,
   humanInputAvailable: boolean,
@@ -235,7 +251,7 @@ export function createHeadlessCliHostInteractions(
         { summary: formatBashApprovalSummary(request) },
         hooks,
       );
-      return toApprovalSettlement(decision);
+      return toBashApprovalSettlement(decision);
     },
     async requestPlanApproval(request) {
       const { decision } = await decideApprovalEvent(

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -281,8 +281,11 @@ export function createHeadlessCliHostInteractions(
       );
       return toApprovalSettlement({
         ...decision,
-        ...(!prompted && !decision.accepted && decision.userMessage
-          ? { rejectionReason: decision.userMessage, userMessage: undefined }
+        ...(!prompted && !decision.accepted
+          ? {
+              rejectionReason: decision.userMessage ?? '',
+              userMessage: undefined,
+            }
           : {}),
       });
     },
@@ -295,8 +298,11 @@ export function createHeadlessCliHostInteractions(
       );
       return toApprovalSettlement({
         ...decision,
-        ...(!prompted && !decision.accepted && decision.userMessage
-          ? { rejectionReason: decision.userMessage, userMessage: undefined }
+        ...(!prompted && !decision.accepted
+          ? {
+              rejectionReason: decision.userMessage ?? '',
+              userMessage: undefined,
+            }
           : {}),
       });
     },

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -451,7 +451,7 @@ export class SessionHostInteractions implements HostInteractions {
       request.streamId as StreamTabId | null | undefined,
       (interactions) =>
         interactions.requestToolEditApproval?.(request, options),
-      (cause) => ({ accepted: false, userMessage: cause }),
+      (cause) => ({ accepted: false, reason: cause }),
     );
   }
 

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -180,7 +180,16 @@ export interface HostExternalInquiryHandle {
 
 export type BashSettlement =
   | { readonly action: 'approve'; readonly feedback?: never }
-  | { readonly action: 'reject'; readonly feedback?: string };
+  | {
+      readonly action: 'reject';
+      readonly feedback?: string;
+      readonly reason?: never;
+    }
+  | {
+      readonly action: 'reject';
+      readonly reason: string;
+      readonly feedback?: never;
+    };
 
 export type UserQuestionSettlement =
   | {

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -459,7 +459,7 @@ export class SessionHostInteractions implements HostInteractions {
       request.streamId as StreamTabId | null | undefined,
       (interactions) =>
         interactions.requestToolEditApproval?.(request, options),
-      (cause) => ({ accepted: false, reason: cause }),
+      (cause) => ({ accepted: false, cause }),
     );
   }
 

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -184,11 +184,19 @@ export type BashSettlement =
       readonly action: 'reject';
       readonly feedback?: string;
       readonly reason?: never;
+      readonly cause?: never;
     }
   | {
       readonly action: 'reject';
       readonly reason: string;
       readonly feedback?: never;
+      readonly cause?: never;
+    }
+  | {
+      readonly action: 'reject';
+      readonly cause: string | undefined;
+      readonly feedback?: never;
+      readonly reason?: never;
     };
 
 export type UserQuestionSettlement =
@@ -212,7 +220,7 @@ type CancellationResultFactories = {
 };
 
 const cancellationResultFactories: CancellationResultFactories = {
-  bash: (feedback) => ({ action: 'reject', feedback: feedback?.trim() }),
+  bash: (cause) => ({ action: 'reject', cause: cause?.trim() }),
   planApproval: (feedback) => ({ action: 'reject', feedback }),
   proposal: (feedback) => ({ action: 'reject', feedback }),
   retry: () => ({ action: 'cancel' }),

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -93,9 +93,21 @@ export interface HostRetryInteractionOptions extends HostInteractionOptions {
 }
 
 export type PlanApprovalResult =
-  | { action: 'approve'; feedback?: never }
-  | { action: 'approve_and_goal'; feedback?: never }
-  | { action: 'reject'; feedback?: string };
+  | { action: 'approve'; feedback?: never; reason?: never; cause?: never }
+  | {
+      action: 'approve_and_goal';
+      feedback?: never;
+      reason?: never;
+      cause?: never;
+    }
+  | { action: 'reject'; feedback?: string; reason?: never; cause?: never }
+  | { action: 'reject'; reason: string; feedback?: never; cause?: never }
+  | {
+      action: 'reject';
+      cause: string | undefined;
+      feedback?: never;
+      reason?: never;
+    };
 
 export type ProposalResult =
   | {
@@ -103,10 +115,30 @@ export type ProposalResult =
       model?: string;
       agent?: string;
       feedback?: never;
+      reason?: never;
+      cause?: never;
     }
   | {
       action: 'reject';
       feedback?: string;
+      reason?: never;
+      cause?: never;
+      model?: never;
+      agent?: never;
+    }
+  | {
+      action: 'reject';
+      reason: string;
+      feedback?: never;
+      cause?: never;
+      model?: never;
+      agent?: never;
+    }
+  | {
+      action: 'reject';
+      cause: string | undefined;
+      feedback?: never;
+      reason?: never;
       model?: never;
       agent?: never;
     }
@@ -115,6 +147,8 @@ export type ProposalResult =
       model?: never;
       agent?: never;
       feedback?: never;
+      reason?: never;
+      cause?: never;
     };
 
 export type RetrySettlement =
@@ -204,35 +238,53 @@ export type UserQuestionSettlement =
       readonly action: 'submit';
       readonly answers: UserQuestionAnswers;
       readonly feedback?: never;
+      readonly reason?: never;
+      readonly cause?: never;
     }
   | {
       readonly action: 'reject' | 'skip';
       readonly feedback?: string;
       readonly answers?: never;
+      readonly reason?: never;
+      readonly cause?: never;
+    }
+  | {
+      readonly action: 'reject';
+      readonly reason: string;
+      readonly feedback?: never;
+      readonly answers?: never;
+      readonly cause?: never;
+    }
+  | {
+      readonly action: 'reject';
+      readonly cause: string | undefined;
+      readonly feedback?: never;
+      readonly answers?: never;
+      readonly reason?: never;
     };
 
 export type SettledInteractionKind = keyof HostInteractionResultByKind;
 
 type CancellationResultFactories = {
   [K in SettledInteractionKind]: (
-    feedback?: string,
+    cause?: string,
   ) => HostInteractionResultByKind[K];
 };
 
 const cancellationResultFactories: CancellationResultFactories = {
   bash: (cause) => ({ action: 'reject', cause: cause?.trim() }),
-  planApproval: (feedback) => ({ action: 'reject', feedback }),
-  proposal: (feedback) => ({ action: 'reject', feedback }),
+  planApproval: (cause) => ({ action: 'reject', cause }),
+  proposal: (cause) => ({ action: 'reject', cause }),
   retry: () => ({ action: 'cancel' }),
-  userQuestion: (feedback) => ({ action: 'reject', feedback }),
+  userQuestion: (cause) => ({ action: 'reject', cause }),
 };
 
 /** Typed cancellation result shared by every presenting host. */
 export function cancellationResultFor<K extends SettledInteractionKind>(
   kind: K,
-  feedback?: string,
+  cause?: string,
 ): HostInteractionResultByKind[K] {
-  return cancellationResultFactories[kind](feedback);
+  return cancellationResultFactories[kind](cause);
 }
 
 export interface HostApprovalBypassStateUpdate {

--- a/src/controllers/approval/ToolEditApprovalController.ts
+++ b/src/controllers/approval/ToolEditApprovalController.ts
@@ -278,7 +278,7 @@ export class ToolEditApprovalController {
       }
       const rejection: ToolEditApprovalResult = {
         accepted: false,
-        reason: selector.cause,
+        cause: selector.cause,
       };
       if (state.phase === 'initializing') {
         state.resolution ??= rejection;

--- a/src/controllers/approval/ToolEditApprovalController.ts
+++ b/src/controllers/approval/ToolEditApprovalController.ts
@@ -220,7 +220,7 @@ export class ToolEditApprovalController {
       case 'reject':
         this.settle(payload.requestId, {
           accepted: false,
-          userMessage: payload.feedback?.trim() || undefined,
+          feedback: payload.feedback?.trim() || undefined,
         });
         return;
       case 'openDiff':
@@ -278,7 +278,7 @@ export class ToolEditApprovalController {
       }
       const rejection: ToolEditApprovalResult = {
         accepted: false,
-        userMessage: selector.cause,
+        reason: selector.cause,
       };
       if (state.phase === 'initializing') {
         state.resolution ??= rejection;

--- a/src/shared/copy/interactionCancellation.ts
+++ b/src/shared/copy/interactionCancellation.ts
@@ -1,7 +1,7 @@
 /**
- * Cancellation causes that reach the agent verbatim as the feedback on a
- * dropped interaction. One event gets one explanation across every host, so a
- * model reading a transcript never has to reconcile host-specific wording.
+ * Cancellation causes that reach the agent verbatim, separately from human
+ * feedback on a dropped interaction. One event gets one explanation across
+ * every host, so a model never has to reconcile host-specific wording.
  */
 
 /** The session that owned the interaction was torn down. */

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -245,7 +245,7 @@ describe('accept_run_files progress events', () => {
 
     expect(result.status).toBe('error');
     expect(result.summary).toBe(
-      'Tool edit approval cancelled: accept_run_files for first.tex.',
+      'Tool edit approval cancelled: accept_run_files for multiple files.',
     );
     expect(result.error).toContain('Denied by approval policy.');
     expect(result.error).toContain('Session disposed.');

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -179,6 +179,31 @@ describe('accept_run_files progress events', () => {
     dispose();
   });
 
+  it('reports an all-file user rejection without calling it a cancellation', async () => {
+    const tool = new AcceptRunFilesTool();
+
+    setRunStorageEntries({
+      [`executions/${executionId}/output.tex`]: FileType.File,
+    });
+    stubWorkspaceFiles(false, '');
+    vi.spyOn(AbsoluteFS, 'read').mockResolvedValue('proposed content');
+    testApprovalHandler = async () => ({
+      accepted: false,
+      feedback: 'keep the original normalization',
+    });
+
+    const result = await runAccept(tool, [
+      { path: 'output.tex', original: 'paper.tex' },
+    ]);
+
+    expect(result.status).toBe('error');
+    expect(result.summary).toBe(
+      'User rejected accept_run_files for paper.tex.',
+    );
+    expect(result.userInstruction).toBe('keep the original normalization');
+    expect(result.error).not.toContain('cancelled');
+  });
+
   it('does not require a runtime host to publish accepted workspace files', async () => {
     const tool = new AcceptRunFilesTool();
     const { written, dispose } = recordWrittenFiles();

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -204,6 +204,26 @@ describe('accept_run_files progress events', () => {
     expect(result.error).not.toContain('cancelled');
   });
 
+  it('preserves a cause-free cancellation while aggregating rejections', async () => {
+    const tool = new AcceptRunFilesTool();
+
+    setRunStorageEntries({
+      [`executions/${executionId}/output.tex`]: FileType.File,
+    });
+    stubWorkspaceFiles(false, '');
+    vi.spyOn(AbsoluteFS, 'read').mockResolvedValue('proposed content');
+    testApprovalHandler = async () => ({ accepted: false, cause: undefined });
+
+    const result = await runAccept(tool, [
+      { path: 'output.tex', original: 'paper.tex' },
+    ]);
+
+    expect(result.summary).toBe(
+      'Tool edit approval cancelled: accept_run_files for paper.tex.',
+    );
+    expect(result.userInstruction).toBeUndefined();
+  });
+
   it('preserves mixed policy-denial and cancellation details', async () => {
     const tool = new AcceptRunFilesTool();
 

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -204,6 +204,34 @@ describe('accept_run_files progress events', () => {
     expect(result.error).not.toContain('cancelled');
   });
 
+  it('preserves mixed policy-denial and cancellation details', async () => {
+    const tool = new AcceptRunFilesTool();
+
+    setRunStorageEntries({
+      [`executions/${executionId}/first.tex`]: FileType.File,
+      [`executions/${executionId}/second.tex`]: FileType.File,
+    });
+    stubWorkspaceFiles(false, '');
+    vi.spyOn(AbsoluteFS, 'read').mockResolvedValue('proposed content');
+    testApprovalHandler = async (request) =>
+      request.path === 'first.tex'
+        ? { accepted: false, reason: 'Denied by approval policy.' }
+        : { accepted: false, cause: 'Session disposed.' };
+
+    const result = await runAccept(tool, [
+      { path: 'first.tex', original: 'first.tex' },
+      { path: 'second.tex', original: 'second.tex' },
+    ]);
+
+    expect(result.status).toBe('error');
+    expect(result.summary).toBe(
+      'Tool edit approval cancelled: accept_run_files for first.tex.',
+    );
+    expect(result.error).toContain('Denied by approval policy.');
+    expect(result.error).toContain('Session disposed.');
+    expect(result.userInstruction).toBeUndefined();
+  });
+
   it('does not require a runtime host to publish accepted workspace files', async () => {
     const tool = new AcceptRunFilesTool();
     const { written, dispose } = recordWrittenFiles();

--- a/src/test-kernel/agent/runtime/HostInteractionSettlements.vitest.ts
+++ b/src/test-kernel/agent/runtime/HostInteractionSettlements.vitest.ts
@@ -54,9 +54,21 @@ it("returns each interaction kind's exact cancellation result", () => {
   ).toEqualTypeOf<UserQuestionSettlement>();
 });
 
-it('keeps bash cancellation causes distinct from user feedback', () => {
+it('keeps cancellation causes distinct from user feedback', () => {
   expect(cancellationResultFor('bash', '  reason  ')).toEqual({
     action: 'reject',
     cause: 'reason',
+  });
+  expect(cancellationResultFor('planApproval', 'Run ended.')).toEqual({
+    action: 'reject',
+    cause: 'Run ended.',
+  });
+  expect(cancellationResultFor('proposal', 'Run ended.')).toEqual({
+    action: 'reject',
+    cause: 'Run ended.',
+  });
+  expect(cancellationResultFor('userQuestion', 'Run ended.')).toEqual({
+    action: 'reject',
+    cause: 'Run ended.',
   });
 });

--- a/src/test-kernel/agent/runtime/HostInteractionSettlements.vitest.ts
+++ b/src/test-kernel/agent/runtime/HostInteractionSettlements.vitest.ts
@@ -54,9 +54,9 @@ it("returns each interaction kind's exact cancellation result", () => {
   ).toEqualTypeOf<UserQuestionSettlement>();
 });
 
-it('normalizes bash cancellation feedback like an explicit rejection', () => {
+it('keeps bash cancellation causes distinct from user feedback', () => {
   expect(cancellationResultFor('bash', '  reason  ')).toEqual({
     action: 'reject',
-    feedback: 'reason',
+    cause: 'reason',
   });
 });

--- a/src/test-kernel/agent/runtime/RunLifecycleInteractionCancel.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunLifecycleInteractionCancel.vitest.ts
@@ -78,7 +78,7 @@ async function expectRunEndedRejection(
 ): Promise<void> {
   await expect(pending).resolves.toEqual({
     action: 'reject',
-    feedback: 'Run ended.',
+    cause: 'Run ended.',
   });
 }
 
@@ -205,10 +205,10 @@ describe('run lifecycle host-interaction cancel', () => {
 
     expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
     // The interrupt-time cancel wins; the lifecycle's second cancel matches no
-    // pending request and cannot overwrite the settled feedback.
+    // pending request and cannot overwrite the settled cause.
     await expect(pending).resolves.toEqual({
       action: 'reject',
-      feedback: 'Run interrupted.',
+      cause: 'Run interrupted.',
     });
     session.dispose();
   });

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -781,12 +781,12 @@ describe('session.interactions request bookkeeping', () => {
 
     await expect(pending).resolves.toEqual({
       action: 'reject',
-      feedback: 'Run ended.',
+      cause: 'Run ended.',
     });
     session.dispose();
   });
 
-  it('preserves user-question feedback while unattached', async () => {
+  it('preserves user-question cancellation cause while unattached', async () => {
     const session = createTestSession();
     const pending = session.interactions.askUserQuestion({
       requestId: 'question:cancel-unattached',
@@ -807,7 +807,7 @@ describe('session.interactions request bookkeeping', () => {
 
     await expect(pending).resolves.toEqual({
       action: 'reject',
-      feedback: 'No stream owns this question.',
+      cause: 'No stream owns this question.',
     });
     session.dispose();
   });
@@ -820,7 +820,7 @@ describe('session.interactions request bookkeeping', () => {
 
     await expect(pending).resolves.toEqual({
       action: 'reject',
-      feedback: SESSION_DISPOSED_CAUSE,
+      cause: SESSION_DISPOSED_CAUSE,
     });
   });
 
@@ -838,7 +838,7 @@ describe('session.interactions request bookkeeping', () => {
 
     await expect(pending).resolves.toEqual({
       action: 'reject',
-      feedback: SESSION_DISPOSED_CAUSE,
+      cause: SESSION_DISPOSED_CAUSE,
     });
     expect(pendingCounts).toEqual([1, 0]);
   });
@@ -855,7 +855,7 @@ describe('session.interactions request bookkeeping', () => {
 
     await expect(pending).resolves.toEqual({
       action: 'reject',
-      feedback: SESSION_DISPOSED_CAUSE,
+      cause: SESSION_DISPOSED_CAUSE,
     });
   });
 

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -500,7 +500,7 @@ describe('buildToolEditApprovalContent', () => {
 
     expect(result).toMatchObject({
       accepted: false,
-      userMessage: 'proof misses the p = 5 case',
+      feedback: 'proof misses the p = 5 case',
     });
   });
 
@@ -528,7 +528,7 @@ describe('buildToolEditApprovalContent', () => {
     expect(summaries[1]).toBe('');
     expect(result).toMatchObject({
       accepted: false,
-      userMessage: 'use the workspace-local file path',
+      feedback: 'use the workspace-local file path',
     });
   });
 

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -269,7 +269,22 @@ describe('approval prompt hooks', () => {
 
     expect(result).toEqual({
       action: 'reject',
-      feedback: 'Denied by TeXRA approval policy.',
+      reason: 'Denied by TeXRA approval policy.',
+    });
+  });
+
+  it('preserves a failed proposal prompt as an automatic cancellation', async () => {
+    const result = await createHeadlessCliHostInteractions(
+      context({
+        approvalPrompt: async () => {
+          throw new Error('terminal input closed');
+        },
+      }),
+    ).requestAgentProposal?.(proposal);
+
+    expect(result).toEqual({
+      action: 'reject',
+      cause: 'CLI approval prompt failed.',
     });
   });
 

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -504,6 +504,54 @@ describe('buildToolEditApprovalContent', () => {
     });
   });
 
+  it('does not synthesize feedback for a note-free rejection', async () => {
+    useCliHostInteractions(
+      context({
+        approvalPrompt: async () => '',
+      }),
+    );
+
+    const result = await requestNewProofEdit();
+
+    expect(result).toEqual({ accepted: false });
+  });
+
+  it('preserves a failed edit prompt as an automatic cancellation', async () => {
+    useCliHostInteractions(
+      context({
+        approvalPrompt: async () => {
+          throw new Error('terminal input closed');
+        },
+      }),
+    );
+
+    const result = await requestNewProofEdit();
+
+    expect(result).toEqual({
+      accepted: false,
+      cause: 'CLI approval prompt failed.',
+    });
+  });
+
+  it('preserves a failed Bash prompt as an automatic cancellation', async () => {
+    useCliHostInteractions(
+      context({
+        approvalPrompt: async () => {
+          throw new Error('terminal input closed');
+        },
+      }),
+    );
+
+    const result = await defaultSession().interactions.requestBashApproval({
+      command: 'latexmk paper.tex',
+    });
+
+    expect(result).toEqual({
+      action: 'reject',
+      cause: 'CLI approval prompt failed.',
+    });
+  });
+
   it('prompts for rejection feedback after an explicit no', async () => {
     const prompts: string[] = [];
     const summaries: string[] = [];

--- a/src/test-kernel/cli/ApprovalQueue.vitest.ts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.ts
@@ -27,7 +27,7 @@ import type { StreamTabId } from '@shared/schemas';
 
 const INTERRUPTED = {
   accepted: false,
-  userMessage: 'Session interrupted.',
+  rejectionCause: 'Session interrupted.',
 };
 
 function bashPayload(streamId: string): ApprovalPayload {

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   apiKeyExistsUncached: vi.fn(),
   apiMode: 'included' as 'included' | 'personal',
   hasUsableApiKey: vi.fn(),
+  handleExternalInquiryAction: vi.fn(),
   invalidateApiKeyCache: vi.fn(),
   preferSubscription: true,
   preferKimiCode: false,
@@ -30,6 +31,10 @@ const mocks = vi.hoisted(() => ({
   setPreferKimiCode: vi.fn(),
   setGLMCodingPlan: vi.fn(),
   updateGlobalState: vi.fn(),
+}));
+
+vi.mock('@tools/inquiry/inquiryActions', () => ({
+  handleExternalInquiryAction: mocks.handleExternalInquiryAction,
 }));
 
 // Injection point for a pre-modal preparation failure: the retry copy is read
@@ -405,6 +410,7 @@ afterEach(() => {
   mocks.retryCopyFailure = undefined;
   mocks.apiKeyExistsUncached.mockReset();
   mocks.hasUsableApiKey.mockReset();
+  mocks.handleExternalInquiryAction.mockReset();
   mocks.invalidateApiKeyCache.mockReset();
   mocks.notify.mockReset();
   mocks.setCliApiMode.mockReset();
@@ -417,6 +423,34 @@ afterEach(() => {
 });
 
 describe('TUI retry approvals', () => {
+  it('preserves the lifecycle cause when an external inquiry is interrupted', async () => {
+    const { interactions } = tui();
+    await interactions.openExternalInquiry?.({
+      requestId: 'inquiry-interrupted',
+      allowBypass: false,
+      streamId: 'inquiry-stream',
+      mode: 'new',
+      question: 'Which external fact should be checked?',
+      threadId: 'thread-interrupted',
+      sessionLinks: null,
+      draft: null,
+      transcript: null,
+    });
+    await waitForApproval('externalInquiry', {
+      threadId: 'thread-interrupted',
+    });
+
+    clearApprovals();
+
+    await vi.waitFor(() =>
+      expect(mocks.handleExternalInquiryAction).toHaveBeenCalledWith({
+        action: 'drop',
+        threadId: 'thread-interrupted',
+        feedback: 'Session interrupted.',
+      }),
+    );
+  });
+
   it('reports an automatic yolo retry rejection as a policy denial', async () => {
     const { interactions } = tui(host(), {
       approvalPolicy: 'yolo',

--- a/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.ts
+++ b/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.ts
@@ -76,9 +76,6 @@ const proposal: AgentProposal = {
   memories: [],
 };
 
-/** Result a per-stream cancel produces for every approval it settles. */
-const INTERRUPTED = { action: 'reject', feedback: 'Session interrupted.' };
-
 afterEach(() => {
   clearApprovals();
 });
@@ -115,7 +112,7 @@ describe('createTuiHostInteractions', () => {
 
     interactions.cancel({ streamId: 'stream-a' });
 
-    await expect(planResult).resolves.toEqual(INTERRUPTED);
+    await expect(planResult).resolves.toEqual({ action: 'reject' });
 
     // stream-b's request was never touched and now becomes the foreground
     // modal instead of being left permanently pending.
@@ -167,7 +164,7 @@ describe('createTuiHostInteractions', () => {
 
     interactions.cancel({ streamId: 'stream-a' });
 
-    await expect(proposalResult).resolves.toEqual(INTERRUPTED);
+    await expect(proposalResult).resolves.toEqual({ action: 'reject' });
     expect(currentApproval.get()).toBeUndefined();
   });
 
@@ -182,7 +179,30 @@ describe('createTuiHostInteractions', () => {
 
     interactions.cancel({ streamId: 'stream-a' });
 
-    await expect(bashResult).resolves.toEqual(INTERRUPTED);
+    await expect(bashResult).resolves.toEqual({
+      action: 'reject',
+      cause: 'Session interrupted.',
+    });
+    expect(currentApproval.get()).toBeUndefined();
+  });
+
+  it('keeps queued tool-edit cancellation separate from user feedback', async () => {
+    const interactions = tuiInteractions();
+    const editResult = interactions.requestToolEditApproval?.({
+      path: '/work/paper.tex',
+      originalContent: 'old',
+      proposedContent: 'new',
+      sourceTool: 'edit',
+      streamId: 'stream-a',
+    });
+
+    await waitForApproval('toolEdit', { streamId: 'stream-a' });
+    interactions.cancel({ streamId: 'stream-a' });
+
+    await expect(editResult).resolves.toEqual({
+      accepted: false,
+      cause: 'Session interrupted.',
+    });
     expect(currentApproval.get()).toBeUndefined();
   });
 

--- a/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.ts
+++ b/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.ts
@@ -112,7 +112,10 @@ describe('createTuiHostInteractions', () => {
 
     interactions.cancel({ streamId: 'stream-a' });
 
-    await expect(planResult).resolves.toEqual({ action: 'reject' });
+    await expect(planResult).resolves.toEqual({
+      action: 'reject',
+      cause: 'Session interrupted.',
+    });
 
     // stream-b's request was never touched and now becomes the foreground
     // modal instead of being left permanently pending.
@@ -164,7 +167,10 @@ describe('createTuiHostInteractions', () => {
 
     interactions.cancel({ streamId: 'stream-a' });
 
-    await expect(proposalResult).resolves.toEqual({ action: 'reject' });
+    await expect(proposalResult).resolves.toEqual({
+      action: 'reject',
+      cause: 'Session interrupted.',
+    });
     expect(currentApproval.get()).toBeUndefined();
   });
 

--- a/src/test-kernel/controllers/ToolEditApprovalController.vitest.ts
+++ b/src/test-kernel/controllers/ToolEditApprovalController.vitest.ts
@@ -95,7 +95,7 @@ describe('tool edit approval controller', () => {
 
     await expect(approval).resolves.toEqual({
       accepted: false,
-      reason: 'Stream resources released.',
+      cause: 'Stream resources released.',
     });
     // No prompt is ever published for a request that never reached the user,
     // and the staged copies are cleaned up on the way out.

--- a/src/test-kernel/controllers/ToolEditApprovalController.vitest.ts
+++ b/src/test-kernel/controllers/ToolEditApprovalController.vitest.ts
@@ -95,7 +95,7 @@ describe('tool edit approval controller', () => {
 
     await expect(approval).resolves.toEqual({
       accepted: false,
-      userMessage: 'Stream resources released.',
+      reason: 'Stream resources released.',
     });
     // No prompt is ever published for a request that never reached the user,
     // and the staged copies are cleaned up on the way out.

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -3029,7 +3029,7 @@ describe('DesktopProgressBridge', () => {
 
         await expect(approvalPromise).resolves.toMatchObject({
           accepted: false,
-          userMessage: 'Not this edit.',
+          feedback: 'Not this edit.',
         });
       } finally {
         bridgeB.dispose();

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -748,6 +748,11 @@ const STREAM_RELEASED_REJECTION = {
   feedback: 'Stream resources released.',
 } as const;
 
+const BASH_STREAM_RELEASED_REJECTION = {
+  action: 'reject',
+  cause: 'Stream resources released.',
+} as const;
+
 function activateStream(bridge: TestableBridge, streamId: string): void {
   emitSessionFact(bridge, 'setActiveStream', {
     streamId,
@@ -2049,7 +2054,7 @@ describe('DesktopProgressBridge', () => {
 
     // This promise must settle through releaseStreamResources, which owns
     // stream-scoped interaction cleanup.
-    await expect(result).resolves.toEqual(STREAM_RELEASED_REJECTION);
+    await expect(result).resolves.toEqual(BASH_STREAM_RELEASED_REJECTION);
   });
 
   it('resumes workflow streams from persisted meta', async () => {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -745,7 +745,7 @@ function completedRootResult(executionId: ExecutionId): ResultEvent {
  * stream's resources are released (delete, delete-all, headless cleanup). */
 const STREAM_RELEASED_REJECTION = {
   action: 'reject',
-  feedback: 'Stream resources released.',
+  cause: 'Stream resources released.',
 } as const;
 
 const BASH_STREAM_RELEASED_REJECTION = {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -748,11 +748,6 @@ const STREAM_RELEASED_REJECTION = {
   cause: 'Stream resources released.',
 } as const;
 
-const BASH_STREAM_RELEASED_REJECTION = {
-  action: 'reject',
-  cause: 'Stream resources released.',
-} as const;
-
 function activateStream(bridge: TestableBridge, streamId: string): void {
   emitSessionFact(bridge, 'setActiveStream', {
     streamId,
@@ -2054,7 +2049,7 @@ describe('DesktopProgressBridge', () => {
 
     // This promise must settle through releaseStreamResources, which owns
     // stream-scoped interaction cleanup.
-    await expect(result).resolves.toEqual(BASH_STREAM_RELEASED_REJECTION);
+    await expect(result).resolves.toEqual(STREAM_RELEASED_REJECTION);
   });
 
   it('resumes workflow streams from persisted meta', async () => {

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.ts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.ts
@@ -493,7 +493,7 @@ describe('createDesktopHostInteractions', () => {
     });
     await expect(planPromise).resolves.toEqual({
       action: 'reject',
-      feedback: SESSION_DISPOSED_CAUSE,
+      cause: SESSION_DISPOSED_CAUSE,
     });
     expect(handlers.transport.bash.dismiss).toHaveBeenCalled();
     expect(handlers.transport.planApproval.dismiss).toHaveBeenCalled();

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.ts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.ts
@@ -356,7 +356,7 @@ describe('createDesktopHostInteractions', () => {
     expectStreamRegistered(sessionEvents, 'stream-a' as StreamTabId);
   });
 
-  it('forwards a cancellation cause as bash reject feedback', async () => {
+  it('forwards a bash cancellation cause without user provenance', async () => {
     const handlers = createHandlers();
     const { interactions, toolEditApprovals } =
       await createInteractions(handlers);
@@ -373,7 +373,7 @@ describe('createDesktopHostInteractions', () => {
 
     await expect(resultPromise).resolves.toEqual({
       action: 'reject',
-      feedback: 'Stream resources released.',
+      cause: 'Stream resources released.',
     });
     expect(handlers.transport.bash.dismiss).toHaveBeenCalled();
     expect(toolEditApprovals.cancel).toHaveBeenCalledWith({
@@ -400,7 +400,7 @@ describe('createDesktopHostInteractions', () => {
 
     await expect(result).resolves.toEqual({
       action: 'reject',
-      feedback: 'Stopped during presentation.',
+      cause: 'Stopped during presentation.',
     });
   });
 
@@ -489,7 +489,7 @@ describe('createDesktopHostInteractions', () => {
 
     await expect(bashPromise).resolves.toEqual({
       action: 'reject',
-      feedback: SESSION_DISPOSED_CAUSE,
+      cause: SESSION_DISPOSED_CAUSE,
     });
     await expect(planPromise).resolves.toEqual({
       action: 'reject',

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts
@@ -424,7 +424,7 @@ describe('desktop tool edit approval', () => {
       });
       await expect(resultPromise).resolves.toMatchObject({
         accepted: false,
-        userMessage: 'not yet',
+        feedback: 'not yet',
       });
       await vi.waitFor(async () => {
         await expect(pathExists(opened[0])).resolves.toBe(false);
@@ -712,7 +712,7 @@ describe('desktop tool edit approval', () => {
 
       await expect(resultPromise).resolves.toMatchObject({
         accepted: false,
-        userMessage: 'Owning execution ended.',
+        reason: 'Owning execution ended.',
       });
       expect(interactions.shownToolEditPermissions).toEqual([]);
       expect(interactions.resolvedToolEditPermissions).toEqual([]);
@@ -737,7 +737,7 @@ describe('desktop tool edit approval', () => {
 
       await expect(resultPromise).resolves.toMatchObject({
         accepted: false,
-        userMessage: SESSION_DISPOSED_CAUSE,
+        reason: SESSION_DISPOSED_CAUSE,
       });
       expect(interactions.shownToolEditPermissions).toEqual([]);
       expect(interactions.resolvedToolEditPermissions).toEqual([]);
@@ -788,7 +788,7 @@ describe('desktop tool edit approval', () => {
 
       await expect(cancelledPromise).resolves.toMatchObject({
         accepted: false,
-        userMessage: 'Owning execution ended.',
+        reason: 'Owning execution ended.',
       });
       expect(resolved).toEqual([{ requestId: cancelledRequest.requestId }]);
 
@@ -799,7 +799,7 @@ describe('desktop tool edit approval', () => {
       });
       await expect(retainedPromise).resolves.toMatchObject({
         accepted: false,
-        userMessage: 'Retained request resolved normally.',
+        feedback: 'Retained request resolved normally.',
       });
       await waitForEmptyDir(tempRoot);
     },
@@ -839,7 +839,7 @@ describe('desktop tool edit approval', () => {
 
       await expect(resultPromise).resolves.toMatchObject({
         accepted: false,
-        userMessage: 'Stream resources released.',
+        reason: 'Stream resources released.',
       });
       expect(resolved).toEqual([{ requestId: shown[0].requestId }]);
       await waitForEmptyDir(tempRoot);

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts
@@ -712,7 +712,7 @@ describe('desktop tool edit approval', () => {
 
       await expect(resultPromise).resolves.toMatchObject({
         accepted: false,
-        reason: 'Owning execution ended.',
+        cause: 'Owning execution ended.',
       });
       expect(interactions.shownToolEditPermissions).toEqual([]);
       expect(interactions.resolvedToolEditPermissions).toEqual([]);
@@ -737,7 +737,7 @@ describe('desktop tool edit approval', () => {
 
       await expect(resultPromise).resolves.toMatchObject({
         accepted: false,
-        reason: SESSION_DISPOSED_CAUSE,
+        cause: SESSION_DISPOSED_CAUSE,
       });
       expect(interactions.shownToolEditPermissions).toEqual([]);
       expect(interactions.resolvedToolEditPermissions).toEqual([]);
@@ -788,7 +788,7 @@ describe('desktop tool edit approval', () => {
 
       await expect(cancelledPromise).resolves.toMatchObject({
         accepted: false,
-        reason: 'Owning execution ended.',
+        cause: 'Owning execution ended.',
       });
       expect(resolved).toEqual([{ requestId: cancelledRequest.requestId }]);
 
@@ -839,7 +839,7 @@ describe('desktop tool edit approval', () => {
 
       await expect(resultPromise).resolves.toMatchObject({
         accepted: false,
-        reason: 'Stream resources released.',
+        cause: 'Stream resources released.',
       });
       expect(resolved).toEqual([{ requestId: shown[0].requestId }]);
       await waitForEmptyDir(tempRoot);

--- a/src/test-kernel/frontend/VscodeToolEditApproval.vitest.ts
+++ b/src/test-kernel/frontend/VscodeToolEditApproval.vitest.ts
@@ -337,7 +337,7 @@ describe('VS Code tool edit approval', () => {
 
     await expect(approval).resolves.toMatchObject({
       accepted: false,
-      reason: 'Run ended.',
+      cause: 'Run ended.',
     });
     expect(interactions.shown).toEqual([]);
   });
@@ -386,7 +386,7 @@ describe('VS Code tool edit approval', () => {
 
     await expect(approval).resolves.toMatchObject({
       accepted: false,
-      reason: 'Stream resources released.',
+      cause: 'Stream resources released.',
     });
     expect(interactions.resolved).toEqual([{ requestId }]);
   });

--- a/src/test-kernel/frontend/VscodeToolEditApproval.vitest.ts
+++ b/src/test-kernel/frontend/VscodeToolEditApproval.vitest.ts
@@ -337,7 +337,7 @@ describe('VS Code tool edit approval', () => {
 
     await expect(approval).resolves.toMatchObject({
       accepted: false,
-      userMessage: 'Run ended.',
+      reason: 'Run ended.',
     });
     expect(interactions.shown).toEqual([]);
   });
@@ -386,7 +386,7 @@ describe('VS Code tool edit approval', () => {
 
     await expect(approval).resolves.toMatchObject({
       accepted: false,
-      userMessage: 'Stream resources released.',
+      reason: 'Stream resources released.',
     });
     expect(interactions.resolved).toEqual([{ requestId }]);
   });

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
@@ -558,11 +558,10 @@ describe('createExtensionHostInteractions', () => {
       cause: 'No stream owns this question.',
     });
 
-    // Cancellation forwards `cause` as agent-visible feedback, matching how
-    // a live UI rejection settles (see the desktop host, which does the same).
+    // Cancellation remains distinct from a live UI rejection with feedback.
     await expect(resultPromise).resolves.toEqual({
       action: 'reject',
-      feedback: 'No stream owns this question.',
+      cause: 'No stream owns this question.',
     });
     expect(handlers.transport.userQuestion.dismiss).toHaveBeenCalledWith(
       'question-a',

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
@@ -425,7 +425,7 @@ describe('createExtensionHostInteractions', () => {
     expect(toolEditApprovals.cancel).toHaveBeenCalledWith(selector);
   });
 
-  it('forwards a cancellation cause as bash reject feedback', async () => {
+  it('forwards a bash cancellation cause without user provenance', async () => {
     const { handlers, interactions } = createInteractions({
       session: createTestSession(),
     });
@@ -442,7 +442,7 @@ describe('createExtensionHostInteractions', () => {
 
     await expect(resultPromise).resolves.toEqual({
       action: 'reject',
-      feedback: 'Stream resources released.',
+      cause: 'Stream resources released.',
     });
     expect(handlers.transport.bash.dismiss).toHaveBeenCalled();
   });

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -74,7 +74,7 @@ describe('approval cleanup scope', () => {
       cleanupApprovalsForStream(streamId, session);
       await expect(pending).resolves.toEqual({
         accepted: false,
-        reason: 'Stream resources released.',
+        cause: 'Stream resources released.',
       });
       expect(cancel).toHaveBeenCalledWith({
         streamId,
@@ -103,11 +103,11 @@ describe('approval cleanup scope', () => {
     const streamlessCleanupSettlements = [
       {
         accepted: false,
-        reason: 'Streamless approval cleanup.',
+        cause: 'Streamless approval cleanup.',
       },
       {
         action: 'reject',
-        feedback: 'Streamless approval cleanup.',
+        cause: 'Streamless approval cleanup.',
       },
     ];
 
@@ -248,7 +248,7 @@ describe('session-owned approval state (#8144)', () => {
 
     await expect(pending).resolves.toEqual({
       accepted: false,
-      reason: 'Session disposed.',
+      cause: 'Session disposed.',
     });
     expect(isBashApprovalBypassedForStream(streamId, session)).toBe(false);
   });

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -74,7 +74,7 @@ describe('approval cleanup scope', () => {
       cleanupApprovalsForStream(streamId, session);
       await expect(pending).resolves.toEqual({
         accepted: false,
-        userMessage: 'Stream resources released.',
+        reason: 'Stream resources released.',
       });
       expect(cancel).toHaveBeenCalledWith({
         streamId,
@@ -103,7 +103,7 @@ describe('approval cleanup scope', () => {
     const streamlessCleanupSettlements = [
       {
         accepted: false,
-        userMessage: 'Streamless approval cleanup.',
+        reason: 'Streamless approval cleanup.',
       },
       {
         action: 'reject',
@@ -248,7 +248,7 @@ describe('session-owned approval state (#8144)', () => {
 
     await expect(pending).resolves.toEqual({
       accepted: false,
-      userMessage: 'Session disposed.',
+      reason: 'Session disposed.',
     });
     expect(isBashApprovalBypassedForStream(streamId, session)).toBe(false);
   });

--- a/src/test-kernel/tools/BashApprovalPrompt.vitest.ts
+++ b/src/test-kernel/tools/BashApprovalPrompt.vitest.ts
@@ -99,7 +99,7 @@ describe('requestBashApproval queueing', () => {
 
       expect(result).toEqual({
         action: 'reject',
-        feedback: 'Denied by TeXRA approval policy.',
+        reason: 'Denied by TeXRA approval policy.',
       });
       expect(policyDenials).toBe(1);
       expect(prompts).toBe(0);

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -243,4 +243,17 @@ describe('BashTool error feedback', () => {
     expect(toolResult?.output).toContain('Denied by TeXRA approval policy.');
     expect(toolResult?.output).not.toContain('User feedback:');
   });
+
+  it('preserves policy-denial provenance when its reason is blank', async () => {
+    vi.mocked(requestBashApproval).mockResolvedValueOnce({
+      action: 'reject',
+      reason: '   ',
+    });
+    const rejected = await new BashTool().call({ command: 'echo rejected' });
+
+    expect(rejected.error).toContain('Command denied');
+    expect(rejected.error).not.toContain('User rejected command');
+    expect(rejected.error).not.toContain('Do not retry');
+    expect(rejected.userInstruction).toBeUndefined();
+  });
 });

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -188,5 +188,59 @@ describe('BashTool error feedback', () => {
     const rejected = await new BashTool().call({ command: 'echo rejected' });
     expect(rejected.status).toBe('error');
     expect(rejected.error).toContain('User rejected command');
+    expect(rejected.userInstruction).toBe('No thanks.');
+  });
+
+  it('does not present generated rejection guidance as user feedback', async () => {
+    vi.mocked(requestBashApproval).mockResolvedValueOnce({ action: 'reject' });
+    const rejected = await new BashTool().call({ command: 'echo rejected' });
+
+    expect(rejected.status).toBe('error');
+    expect(rejected.error).toContain('Do not retry');
+    expect(rejected.userInstruction).toBeUndefined();
+
+    const { attachments, sanitizedResult } = extractToolAttachments(rejected);
+    const messages = await createHandler().createToolUseFollowUpMessages(
+      undefined,
+      createBashCall(),
+      sanitizedResult,
+      attachments,
+      AgentWorkspaceState.create(),
+    );
+    const toolResult = messages.find(
+      (message) => message.type === 'function_call_output',
+    );
+
+    expect(toolResult?.output).toContain('Do not retry');
+    expect(toolResult?.output).not.toContain('User feedback:');
+  });
+
+  it('does not present an approval-policy denial as user feedback', async () => {
+    vi.mocked(requestBashApproval).mockResolvedValueOnce({
+      action: 'reject',
+      reason: 'Denied by TeXRA approval policy.',
+    });
+    const rejected = await new BashTool().call({ command: 'echo rejected' });
+
+    expect(rejected.status).toBe('error');
+    expect(rejected.error).toContain('Command denied');
+    expect(rejected.error).toContain('Denied by TeXRA approval policy.');
+    expect(rejected.error).not.toContain('User rejected command');
+    expect(rejected.userInstruction).toBeUndefined();
+
+    const { attachments, sanitizedResult } = extractToolAttachments(rejected);
+    const messages = await createHandler().createToolUseFollowUpMessages(
+      undefined,
+      createBashCall(),
+      sanitizedResult,
+      attachments,
+      AgentWorkspaceState.create(),
+    );
+    const toolResult = messages.find(
+      (message) => message.type === 'function_call_output',
+    );
+
+    expect(toolResult?.output).toContain('Denied by TeXRA approval policy.');
+    expect(toolResult?.output).not.toContain('User feedback:');
   });
 });

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -256,4 +256,17 @@ describe('BashTool error feedback', () => {
     expect(rejected.error).not.toContain('Do not retry');
     expect(rejected.userInstruction).toBeUndefined();
   });
+
+  it('does not present an automatic cancellation as user feedback', async () => {
+    vi.mocked(requestBashApproval).mockResolvedValueOnce({
+      action: 'reject',
+      cause: 'Session disposed.',
+    });
+    const rejected = await new BashTool().call({ command: 'echo rejected' });
+
+    expect(rejected.error).toContain('Command approval cancelled');
+    expect(rejected.error).toContain('Session disposed.');
+    expect(rejected.error).not.toContain('User rejected command');
+    expect(rejected.userInstruction).toBeUndefined();
+  });
 });

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -11,7 +11,10 @@ import {
 } from '@agent/runtime/RunContext';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
 import type { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
-import type { HostInteractions } from '@agent/runtime/HostInteractions';
+import type {
+  HostInteractions,
+  ProposalResult,
+} from '@agent/runtime/HostInteractions';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import { markOwnedExecutionLeaseUndurable } from '@agent/storage/executionLease';
 import {
@@ -176,11 +179,7 @@ function callDelegateReview() {
 /** The same delegation routed through the host's proposal port, with the host
  *  fake answering `decision`. The session owns the fake port, so it is created
  *  and disposed per case. */
-async function delegateWithProposalDecision(
-  decision:
-    | { readonly action: 'reject' }
-    | { readonly action: 'approve'; readonly model: string },
-) {
+async function delegateWithProposalDecision(decision: ProposalResult) {
   mocks.isProposalBypassed.mockReturnValue(false);
   const session = createTestSession();
   session.useHostInteractions({
@@ -1123,6 +1122,18 @@ describe('headless delegation', () => {
       'Do not retry the same or equivalent delegation',
     );
     expect(result.error).toContain('continue directly with available context');
+    expect(mocks.executeAgent).not.toHaveBeenCalled();
+  });
+
+  it('does not attribute proposal cancellation to the user', async () => {
+    const result = await delegateWithProposalDecision({
+      action: 'reject',
+      cause: 'CLI approval prompt failed.',
+    });
+
+    expect(result.summary).toBe("Delegation approval cancelled for 'review'");
+    expect(result.error).toContain('CLI approval prompt failed.');
+    expect(result.error).not.toContain('User feedback:');
     expect(mocks.executeAgent).not.toHaveBeenCalled();
   });
 

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -177,6 +177,29 @@ describe('PlanTool — update (plan approval)', () => {
     expect(workPlanState.planSummary).toBeNull();
   });
 
+  it('does not attribute a lifecycle cancellation to the user', async () => {
+    await installPlatform(false);
+    const { decisions, resultPromise, events } = startPlanUpdate(
+      'stream:plan-cancel' as StreamTabId,
+      plan.objective,
+    );
+
+    const approval = findPlanApproval(events);
+    expect(
+      submitPlanDecision(decisions, approval, {
+        action: 'reject',
+        cause: 'CLI approval prompt failed.',
+      }),
+    ).toBe(true);
+
+    const result = await resultPromise;
+    expect(result.status).toBe('error');
+    expect(result.summary).toBe('Plan approval cancelled');
+    expect(result.error).toContain('CLI approval prompt failed.');
+    expect(result.error).not.toContain('user rejected');
+    expect(result.userInstruction).toBeUndefined();
+  });
+
   it('approve_and_goal starts a goal using the plan document as the objective', async () => {
     const streamId = 'stream:plan-goal' as StreamTabId;
     await installPlatform(true);

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -165,6 +165,25 @@ describe('Tool edit approval gating', () => {
     assert.strictEqual(result.userInstruction, undefined);
   });
 
+  it('preserves an automatic cancellation without a cause', async () => {
+    const tool = new WriteFileTool();
+    const write = stubWorkspaceFile({ exists: true, content: 'base' });
+    testApprovalHandler = async () => ({
+      accepted: false,
+      cause: undefined,
+    });
+
+    const result = await tool.call({
+      path: 'summary.txt',
+      content: 'new content',
+    });
+
+    assert.strictEqual(write.mock.calls.length, 0);
+    assert.match(result.error ?? '', /Tool edit approval cancelled/);
+    assert.doesNotMatch(result.error ?? '', /User rejected/);
+    assert.strictEqual(result.userInstruction, undefined);
+  });
+
   it('write_file skips approval when disabled via config', async () => {
     await installPlatform({ 'texra.toolUse.requireEditApproval': false });
     const tool = new WriteFileTool();

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -125,7 +125,7 @@ describe('Tool edit approval gating', () => {
 
     testApprovalHandler = async () => ({
       accepted: false,
-      userMessage: 'Rejected by user',
+      feedback: 'Rejected by user',
     });
 
     const result = await tool.call({
@@ -173,10 +173,8 @@ describe('Tool edit approval gating', () => {
     assert.strictEqual(approvalRequests.length, 0);
     assert.strictEqual(write.mock.calls.length, 0);
     assert.strictEqual(result.status, 'error');
-    assert.strictEqual(
-      result.userInstruction,
-      'Denied by TeXRA approval policy.',
-    );
+    assert.strictEqual(result.userInstruction, undefined);
+    assert.match(result.error ?? '', /Denied by TeXRA approval policy\./);
     assert.strictEqual(policyDenials, 1);
   });
 

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -99,7 +99,11 @@ describe('Tool edit approval gating', () => {
     assert.strictEqual(request?.proposedContent, 'new content');
     assert.strictEqual(request?.sourceTool, 'write_file');
     assert.strictEqual(write.mock.lastCall?.[1], 'new content');
-    assert.strictEqual(result.output, 'written');
+    assert.strictEqual(
+      result.output,
+      'written\n\nReplaced 1 lines with 1 lines.',
+    );
+    assert.strictEqual(result.userInstruction, undefined);
   });
 
   it('write_file reports the content adjusted during approval', async () => {

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -146,6 +146,25 @@ describe('Tool edit approval gating', () => {
     assert.strictEqual(result.userInstruction, 'Rejected by user');
   });
 
+  it('does not present an automatic cancellation as user feedback', async () => {
+    const tool = new WriteFileTool();
+    const write = stubWorkspaceFile({ exists: true, content: 'base' });
+    testApprovalHandler = async () => ({
+      accepted: false,
+      cause: 'Session disposed.',
+    });
+
+    const result = await tool.call({
+      path: 'summary.txt',
+      content: 'new content',
+    });
+
+    assert.strictEqual(write.mock.calls.length, 0);
+    assert.match(result.error ?? '', /Tool edit approval cancelled/);
+    assert.match(result.error ?? '', /Session disposed\./);
+    assert.strictEqual(result.userInstruction, undefined);
+  });
+
   it('write_file skips approval when disabled via config', async () => {
     await installPlatform({ 'texra.toolUse.requireEditApproval': false });
     const tool = new WriteFileTool();

--- a/src/test-kernel/tools/Wolfram.vitest.ts
+++ b/src/test-kernel/tools/Wolfram.vitest.ts
@@ -82,13 +82,15 @@ describe('WolframTool approval', () => {
       name: 'does not execute wolframscript when approval is rejected',
       feedback: 'Use the requested node check instead.',
       expectedInstruction: 'Use the requested node check instead.',
+      expectedGuidance: false,
     },
     {
       name: 'tells the model not to retry after rejection without feedback',
       feedback: undefined,
-      expectedInstruction: expect.stringContaining('Do not retry'),
+      expectedInstruction: undefined,
+      expectedGuidance: true,
     },
-  ])('$name', async ({ feedback, expectedInstruction }) => {
+  ])('$name', async ({ feedback, expectedInstruction, expectedGuidance }) => {
     const execute = vi.spyOn(wolframScriptUtils, 'executeWolframCode');
 
     const { explicit, result, show } = await dispatchWolfram(
@@ -102,10 +104,11 @@ describe('WolframTool approval', () => {
       }),
     ).toBe(true);
 
-    await expect(result).resolves.toMatchObject({
-      status: 'error',
-      userInstruction: expectedInstruction,
-    });
+    const rejection = await result;
+    expect(rejection.status).toBe('error');
+    if (rejection.status !== 'error') throw new Error('Expected rejection');
+    expect(rejection.userInstruction).toBe(expectedInstruction);
+    expect(rejection.error.includes('Do not retry')).toBe(expectedGuidance);
     expect(execute).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -194,6 +194,7 @@ Parameters map directly to subagent-result delivery attributes:
     let firstRejectedPath: string | undefined;
     const rejectionFeedback: string[] = [];
     const rejectionReasons: string[] = [];
+    const rejectionCauses: string[] = [];
 
     let totalStripped = 0;
 
@@ -219,6 +220,7 @@ Parameters map directly to subagent-result delivery attributes:
         firstRejectedPath ??= entry.original;
         if (approval.feedback) rejectionFeedback.push(approval.feedback);
         if (approval.reason) rejectionReasons.push(approval.reason);
+        if (approval.cause) rejectionCauses.push(approval.cause);
         results.push(`rejected: ${entry.original}${mappingNote}`);
         continue;
       }
@@ -277,6 +279,7 @@ Parameters map directly to subagent-result delivery attributes:
         {
           feedback: rejectionFeedback.join('\n') || undefined,
           reason: rejectionReasons.join('\n') || undefined,
+          cause: rejectionCauses.join('\n') || undefined,
         },
       );
     }

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -192,7 +192,8 @@ Parameters map directly to subagent-result delivery attributes:
     let rejected = 0;
     let unchanged = 0;
     let firstRejectedPath: string | undefined;
-    const rejectionMessages: string[] = [];
+    const rejectionFeedback: string[] = [];
+    const rejectionReasons: string[] = [];
 
     let totalStripped = 0;
 
@@ -216,7 +217,8 @@ Parameters map directly to subagent-result delivery attributes:
       if (!approval.accepted) {
         rejected++;
         firstRejectedPath ??= entry.original;
-        if (approval.userMessage) rejectionMessages.push(approval.userMessage);
+        if (approval.feedback) rejectionFeedback.push(approval.feedback);
+        if (approval.reason) rejectionReasons.push(approval.reason);
         results.push(`rejected: ${entry.original}${mappingNote}`);
         continue;
       }
@@ -272,7 +274,10 @@ Parameters map directly to subagent-result delivery attributes:
       return buildApprovalRejectedResult(
         firstRejectedPath ?? prepared[0].original,
         'accept_run_files',
-        rejectionMessages.join('\n'),
+        {
+          feedback: rejectionFeedback.join('\n') || undefined,
+          reason: rejectionReasons.join('\n') || undefined,
+        },
       );
     }
 

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -195,6 +195,7 @@ Parameters map directly to subagent-result delivery attributes:
     const rejectionFeedback: string[] = [];
     const rejectionReasons: string[] = [];
     const rejectionCauses: string[] = [];
+    let sawCancellation = false;
 
     let totalStripped = 0;
 
@@ -220,7 +221,10 @@ Parameters map directly to subagent-result delivery attributes:
         firstRejectedPath ??= entry.original;
         if (approval.feedback) rejectionFeedback.push(approval.feedback);
         if (approval.reason) rejectionReasons.push(approval.reason);
-        if (approval.cause) rejectionCauses.push(approval.cause);
+        if ('cause' in approval) {
+          sawCancellation = true;
+          if (approval.cause) rejectionCauses.push(approval.cause);
+        }
         results.push(`rejected: ${entry.original}${mappingNote}`);
         continue;
       }
@@ -283,8 +287,8 @@ Parameters map directly to subagent-result delivery attributes:
           ...(rejectionReasons.length > 0
             ? { reason: rejectionReasons.join('\n') }
             : {}),
-          ...(rejectionCauses.length > 0
-            ? { cause: rejectionCauses.join('\n') }
+          ...(sawCancellation
+            ? { cause: rejectionCauses.join('\n') || undefined }
             : {}),
         },
       );

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -277,9 +277,15 @@ Parameters map directly to subagent-result delivery attributes:
         firstRejectedPath ?? prepared[0].original,
         'accept_run_files',
         {
-          feedback: rejectionFeedback.join('\n') || undefined,
-          reason: rejectionReasons.join('\n') || undefined,
-          cause: rejectionCauses.join('\n') || undefined,
+          ...(rejectionFeedback.length > 0
+            ? { feedback: rejectionFeedback.join('\n') }
+            : {}),
+          ...(rejectionReasons.length > 0
+            ? { reason: rejectionReasons.join('\n') }
+            : {}),
+          ...(rejectionCauses.length > 0
+            ? { cause: rejectionCauses.join('\n') }
+            : {}),
         },
       );
     }

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -195,6 +195,11 @@ Parameters map directly to subagent-result delivery attributes:
     const rejectionFeedback: string[] = [];
     const rejectionReasons: string[] = [];
     const rejectionCauses: string[] = [];
+    let firstUserRejectionPath: string | undefined;
+    let firstPolicyDenialPath: string | undefined;
+    let firstCancellationPath: string | undefined;
+    let sawUserRejection = false;
+    let sawPolicyDenial = false;
     let sawCancellation = false;
 
     let totalStripped = 0;
@@ -219,11 +224,18 @@ Parameters map directly to subagent-result delivery attributes:
       if (!approval.accepted) {
         rejected++;
         firstRejectedPath ??= entry.original;
-        if (approval.feedback) rejectionFeedback.push(approval.feedback);
-        if (approval.reason) rejectionReasons.push(approval.reason);
         if ('cause' in approval) {
           sawCancellation = true;
+          firstCancellationPath ??= entry.original;
           if (approval.cause) rejectionCauses.push(approval.cause);
+        } else if ('reason' in approval) {
+          sawPolicyDenial = true;
+          firstPolicyDenialPath ??= entry.original;
+          if (approval.reason) rejectionReasons.push(approval.reason);
+        } else {
+          sawUserRejection = true;
+          firstUserRejectionPath ??= entry.original;
+          if (approval.feedback) rejectionFeedback.push(approval.feedback);
         }
         results.push(`rejected: ${entry.original}${mappingNote}`);
         continue;
@@ -277,21 +289,28 @@ Parameters map directly to subagent-result delivery attributes:
 
     // All changed files rejected → return rejection result
     if (rejected === changed && acceptedEntries.length === 0) {
-      return buildApprovalRejectedResult(
-        firstRejectedPath ?? prepared[0].original,
-        'accept_run_files',
-        {
-          ...(rejectionFeedback.length > 0
-            ? { feedback: rejectionFeedback.join('\n') }
-            : {}),
-          ...(rejectionReasons.length > 0
-            ? { reason: rejectionReasons.join('\n') }
-            : {}),
-          ...(sawCancellation
-            ? { cause: rejectionCauses.join('\n') || undefined }
-            : {}),
-        },
-      );
+      const provenanceKindCount = [
+        sawUserRejection,
+        sawPolicyDenial,
+        sawCancellation,
+      ].filter(Boolean).length;
+      const summaryPath =
+        provenanceKindCount > 1
+          ? 'multiple files'
+          : (firstCancellationPath ??
+            firstPolicyDenialPath ??
+            firstUserRejectionPath ??
+            firstRejectedPath ??
+            prepared[0].original);
+      return buildApprovalRejectedResult(summaryPath, 'accept_run_files', {
+        ...(rejectionFeedback.length > 0
+          ? { feedback: rejectionFeedback.join('\n') }
+          : {}),
+        ...(sawPolicyDenial ? { reason: rejectionReasons.join('\n') } : {}),
+        ...(sawCancellation
+          ? { cause: rejectionCauses.join('\n') || undefined }
+          : {}),
+      });
     }
 
     // Phase 3: Clean up diff files from workspace for accepted files

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -53,13 +53,13 @@ export class WriteFileTool extends defineTool({
         const originalLineCount = countLines(originalContent);
         const newLineCount = countLines(appliedContent);
         const action = exists ? 'Overwrote' : 'Created';
+        const replacementNote =
+          exists && originalLineCount > 0
+            ? `Replaced ${originalLineCount} lines with ${newLineCount} lines.`
+            : undefined;
         return {
           summary: `${action} ${displayPath} (${newLineCount} lines)`,
-          output: 'written',
-          userInstruction:
-            exists && originalLineCount > 0
-              ? `Replaced ${originalLineCount} lines with ${newLineCount} lines.`
-              : undefined,
+          output: replacementNote ? `written\n\n${replacementNote}` : 'written',
         };
       },
     });

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -303,7 +303,7 @@ async function withAgentCliApproval(
 
   const approval = await requestBashApproval({ command: approvalLabel });
   if (approval.action !== 'approve') {
-    return buildBashApprovalRejectedResult(approvalLabel, approval.feedback);
+    return buildBashApprovalRejectedResult(approvalLabel, approval);
   }
 
   contexts?.callContext?.hooks?.onExecutionReady?.();

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -39,7 +39,7 @@ const BashApprovalRequestSchema = z.object({
 });
 type BashApprovalRequest = z.infer<typeof BashApprovalRequestSchema>;
 
-const DEFAULT_BASH_REJECTION_INSTRUCTION =
+const DEFAULT_BASH_REJECTION_GUIDANCE =
   'Do not retry this rejected command or another approval-gated shell command for the same check. ' +
   'Continue without running it, use a non-shell method, or explain what approval would be needed.';
 
@@ -113,7 +113,7 @@ export async function requestBashApproval(
     context?.onApprovalPolicyDenial?.();
     return {
       action: 'reject',
-      feedback: texraApprovalDenialMessage(decision),
+      reason: texraApprovalDenialMessage(decision),
     };
   }
 
@@ -132,13 +132,18 @@ export async function requestBashApproval(
 
 export function buildBashApprovalRejectedResult(
   command: string,
-  rejectionFeedback?: string,
+  rejection: Extract<BashSettlement, { action: 'reject' }>,
 ): ToolResult {
   const preview = truncateWithEllipsis(command, 60);
-  const message = `User rejected command: ${preview}`;
-  const feedback = rejectionFeedback?.trim();
-  return errorResult(message, {
+  const feedback = rejection.feedback?.trim();
+  const reason = rejection.reason?.trim();
+  const message = reason
+    ? `Command denied: ${preview}`
+    : `User rejected command: ${preview}`;
+  const guidance = reason || DEFAULT_BASH_REJECTION_GUIDANCE;
+  const error = feedback ? message : `${message}\n\n${guidance}`;
+  return errorResult(error, {
     summary: message,
-    userInstruction: feedback || DEFAULT_BASH_REJECTION_INSTRUCTION,
+    ...(feedback && { userInstruction: feedback }),
   });
 }

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -136,12 +136,13 @@ export function buildBashApprovalRejectedResult(
 ): ToolResult {
   const preview = truncateWithEllipsis(command, 60);
   const feedback = rejection.feedback?.trim();
+  const isPolicyDenial = rejection.reason != null;
   const reason = rejection.reason?.trim();
-  const message = reason
+  const message = isPolicyDenial
     ? `Command denied: ${preview}`
     : `User rejected command: ${preview}`;
-  const guidance = reason || DEFAULT_BASH_REJECTION_GUIDANCE;
-  const error = feedback ? message : `${message}\n\n${guidance}`;
+  const guidance = isPolicyDenial ? reason : DEFAULT_BASH_REJECTION_GUIDANCE;
+  const error = feedback || !guidance ? message : `${message}\n\n${guidance}`;
   return errorResult(error, {
     summary: message,
     ...(feedback && { userInstruction: feedback }),

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -137,11 +137,19 @@ export function buildBashApprovalRejectedResult(
   const preview = truncateWithEllipsis(command, 60);
   const feedback = rejection.feedback?.trim();
   const isPolicyDenial = rejection.reason != null;
+  const isAutomaticCancellation = 'cause' in rejection;
   const reason = rejection.reason?.trim();
-  const message = isPolicyDenial
-    ? `Command denied: ${preview}`
-    : `User rejected command: ${preview}`;
-  const guidance = isPolicyDenial ? reason : DEFAULT_BASH_REJECTION_GUIDANCE;
+  const cause = rejection.cause?.trim();
+  let message = `User rejected command: ${preview}`;
+  let guidance: string | undefined = DEFAULT_BASH_REJECTION_GUIDANCE;
+  if (isPolicyDenial) {
+    message = `Command denied: ${preview}`;
+    guidance = reason;
+  }
+  if (isAutomaticCancellation) {
+    message = `Command approval cancelled: ${preview}`;
+    guidance = cause;
+  }
   const error = feedback || !guidance ? message : `${message}\n\n${guidance}`;
   return errorResult(error, {
     summary: message,

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -422,8 +422,11 @@ export function buildApprovalRejectedResult(
   if (isAutomaticCancellation) {
     summary = `Tool edit approval cancelled: ${sourceTool} for ${path}.`;
   }
-  const detail = cause || reason;
-  const error = detail ? `${summary}\n\n${detail}` : summary;
+  const details = [reason, cause].filter(
+    (detail): detail is string => detail !== undefined && detail.length > 0,
+  );
+  const error =
+    details.length > 0 ? `${summary}\n\n${details.join('\n')}` : summary;
   return errorResult(error, {
     summary,
     ...(feedback && { userInstruction: feedback }),

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -71,11 +71,19 @@ export type ToolEditApprovalResult =
       readonly accepted: false;
       readonly feedback?: string;
       readonly reason?: never;
+      readonly cause?: never;
     }
   | {
       readonly accepted: false;
       readonly reason: string;
       readonly feedback?: never;
+      readonly cause?: never;
+    }
+  | {
+      readonly accepted: false;
+      readonly cause: string | undefined;
+      readonly feedback?: never;
+      readonly reason?: never;
     };
 
 const TOOL_EDIT_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireEditApproval';
@@ -394,6 +402,7 @@ export function appendApprovalDiffNote(
 export interface ToolEditRejectionProvenance {
   readonly feedback?: string;
   readonly reason?: string;
+  readonly cause?: string;
 }
 
 export function buildApprovalRejectedResult(
@@ -402,11 +411,19 @@ export function buildApprovalRejectedResult(
   rejection: ToolEditRejectionProvenance,
 ): ToolResult {
   const feedback = rejection.feedback?.trim();
+  const isPolicyDenial = rejection.reason !== undefined;
+  const isAutomaticCancellation = 'cause' in rejection;
   const reason = rejection.reason?.trim();
-  const summary = reason
-    ? `Tool edit denied: ${sourceTool} for ${path}.`
-    : `User rejected ${sourceTool} for ${path}.`;
-  const error = reason ? `${summary}\n\n${reason}` : summary;
+  const cause = rejection.cause?.trim();
+  let summary = `User rejected ${sourceTool} for ${path}.`;
+  if (isPolicyDenial) {
+    summary = `Tool edit denied: ${sourceTool} for ${path}.`;
+  }
+  if (isAutomaticCancellation) {
+    summary = `Tool edit approval cancelled: ${sourceTool} for ${path}.`;
+  }
+  const detail = cause || reason;
+  const error = detail ? `${summary}\n\n${detail}` : summary;
   return errorResult(error, {
     summary,
     ...(feedback && { userInstruction: feedback }),

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -69,7 +69,13 @@ export type ToolEditApprovalResult =
     }
   | {
       readonly accepted: false;
-      readonly userMessage?: string;
+      readonly feedback?: string;
+      readonly reason?: never;
+    }
+  | {
+      readonly accepted: false;
+      readonly reason: string;
+      readonly feedback?: never;
     };
 
 const TOOL_EDIT_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireEditApproval';
@@ -268,7 +274,7 @@ export async function requestToolEditApproval(
     context?.onApprovalPolicyDenial?.();
     return {
       accepted: false,
-      userMessage: texraApprovalDenialMessage(decision),
+      reason: texraApprovalDenialMessage(decision),
     };
   }
 
@@ -385,15 +391,24 @@ export function appendApprovalDiffNote(
     : baseOutput;
 }
 
+export interface ToolEditRejectionProvenance {
+  readonly feedback?: string;
+  readonly reason?: string;
+}
+
 export function buildApprovalRejectedResult(
   path: string,
   sourceTool: string,
-  userMessage?: string,
+  rejection: ToolEditRejectionProvenance,
 ): ToolResult {
-  const baseMessage = `User rejected ${sourceTool} for ${path}.`;
-  const feedback = userMessage?.trim();
-  return errorResult(baseMessage, {
-    summary: baseMessage,
+  const feedback = rejection.feedback?.trim();
+  const reason = rejection.reason?.trim();
+  const summary = reason
+    ? `Tool edit denied: ${sourceTool} for ${path}.`
+    : `User rejected ${sourceTool} for ${path}.`;
+  const error = reason ? `${summary}\n\n${reason}` : summary;
+  return errorResult(error, {
+    summary,
     ...(feedback && { userInstruction: feedback }),
   });
 }
@@ -432,11 +447,7 @@ export async function requestAndWriteApprovedEdit(request: {
 
   if (!approval.accepted) {
     return {
-      rejected: buildApprovalRejectedResult(
-        displayPath,
-        sourceTool,
-        approval.userMessage,
-      ),
+      rejected: buildApprovalRejectedResult(displayPath, sourceTool, approval),
     };
   }
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -399,7 +399,7 @@ export function appendApprovalDiffNote(
     : baseOutput;
 }
 
-export interface ToolEditRejectionProvenance {
+interface ToolEditRejectionProvenance {
   readonly feedback?: string;
   readonly reason?: string;
   readonly cause?: string;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -305,7 +305,7 @@ export class BashTool extends defineTool({
     const approval = await requestBashApproval({ command: input.command, cwd });
 
     if (approval.action !== 'approve') {
-      return buildBashApprovalRejectedResult(input.command, approval.feedback);
+      return buildBashApprovalRejectedResult(input.command, approval);
     }
 
     // Signal execution starting (triggers in-progress log after approval)

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -122,6 +122,22 @@ export function proposalResultToToolResult(
   switch (result.action) {
     case 'reject': {
       const feedback = result.feedback?.trim();
+      const reason = result.reason?.trim();
+      const cause = result.cause?.trim();
+      if ('cause' in result) {
+        const detail = cause ? `\n${cause}` : '';
+        return errorResult(
+          `Delegation approval for '${agentName}' was cancelled.\nYour delegation was: ${echo}${detail}`,
+          { summary: `Delegation approval cancelled for '${agentName}'` },
+        );
+      }
+      if ('reason' in result) {
+        const detail = reason ? `\n${reason}` : '';
+        return errorResult(
+          `Delegation to '${agentName}' was denied.\nYour delegation was: ${echo}${detail}`,
+          { summary: `Delegation denied for '${agentName}'` },
+        );
+      }
       const feedbackLine = feedback
         ? `\nUser feedback: ${feedback}`
         : `\n${DEFAULT_DELEGATION_REJECTION_FEEDBACK}`;

--- a/src/tools/fileEditFlow.ts
+++ b/src/tools/fileEditFlow.ts
@@ -219,7 +219,6 @@ interface AppliedFileEdit {
 interface FileEditPresentation {
   summary: string;
   output: string;
-  userInstruction?: string;
 }
 
 interface ApprovedFileEditRequest {
@@ -291,8 +290,5 @@ export async function applyApprovedFileEdit({
         }),
       },
     ],
-    ...(presentation.userInstruction && {
-      userInstruction: presentation.userInstruction,
-    }),
   };
 }

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -267,7 +267,29 @@ pause/complete only affect autonomous goals; with no goal running they return gu
     // Rejected — clear the plan from UI
     workPlanState.updatePlan(null);
 
-    const feedback = result.feedback;
+    const feedback = result.feedback?.trim();
+    const reason = result.reason?.trim();
+    const cause = result.cause?.trim();
+    if ('cause' in result) {
+      const message = cause
+        ? `Plan approval was cancelled.\n\n${cause}`
+        : 'Plan approval was cancelled.';
+      logger.info(
+        'Plan approval cancelled',
+        cause ? { data: cause } : undefined,
+      );
+      return errorResult(message, { summary: 'Plan approval cancelled' });
+    }
+    if ('reason' in result) {
+      const message = reason
+        ? `Plan approval was denied.\n\n${reason}`
+        : 'Plan approval was denied.';
+      logger.info(
+        'Plan approval denied',
+        reason ? { data: reason } : undefined,
+      );
+      return errorResult(message, { summary: 'Plan approval denied' });
+    }
     const feedbackNote = feedback
       ? `\nUser feedback: ${feedback}`
       : '\nNo specific feedback was provided.';

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -66,7 +66,7 @@ export class SendToTerminalTool extends defineTool({
 
     const approval = await requestBashApproval({ command });
     if (approval.action !== 'approve') {
-      return buildBashApprovalRejectedResult(command, approval.feedback);
+      return buildBashApprovalRejectedResult(command, approval);
     }
 
     const name = TERMINAL_NAME_PREFIX + input.label.trim();

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -66,6 +66,20 @@ The tool returns a JSON object whose keys are the original question texts and wh
     const result = await session.interactions.askUserQuestion(permission);
 
     if (result.action !== 'submit') {
+      if ('cause' in result) {
+        return executed(
+          result.cause
+            ? `The user question was cancelled: ${result.cause}`
+            : 'The user question was cancelled.',
+        );
+      }
+      if ('reason' in result) {
+        return executed(
+          result.reason
+            ? `The user question was denied: ${result.reason}`
+            : 'The user question was denied.',
+        );
+      }
       return executed(
         result.feedback
           ? `The user declined to answer: ${result.feedback}`

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -63,7 +63,7 @@ export class WolframTool extends defineTool({
     const command = wolframApprovalCommand(input.code);
     const approval = await requestBashApproval({ command });
     if (approval.action !== 'approve') {
-      return buildBashApprovalRejectedResult(command, approval.feedback);
+      return buildBashApprovalRejectedResult(command, approval);
     }
 
     getCurrentToolContexts()?.callContext?.hooks?.onExecutionReady?.();


### PR DESCRIPTION
## Summary

- separate user-authored rejection feedback from generated guidance, policy denials, and lifecycle cancellation causes
- preserve this distinction across Bash, tool edits, plans, delegation proposals, user questions, and CLI/TUI prompt failures
- keep generated execution facts in ordinary tool output
- preserve mixed rejection provenance without assigning a false single-file cause

Fixes #10148.

## Ownership boundary

Session and tool-control code own both the authority and provenance of an approval settlement. Interactive text is `feedback`; an automatic policy decision is `reason`; lifecycle cancellation or a failed input channel is `cause`; generated execution facts remain ordinary output or error detail. UI and model-formatting surfaces render those declared facts without inferring authorship from message text.

This removes the previous ambiguity in which explicit rejection notes, generated anti-retry guidance, automatic policy denials, cancellation causes, failed CLI prompts, and successful write statistics could all pass through a field rendered as `User feedback`.

## Behavior

- A user rejection note becomes `userInstruction` and is rendered as user feedback.
- A note-free rejection does not synthesize a user message.
- A note-free Bash rejection receives generated anti-retry guidance in its error, without user attribution.
- Policy denials are carried as reasons and rendered as denied operations.
- Lifecycle cancellation and failed CLI input channels are carried as causes and rendered as cancellations.
- Plan, delegation-proposal, and user-question paths preserve the same distinction.
- TUI queue interruption preserves lifecycle provenance instead of synthesizing user feedback.
- Mixed `accept_run_files` rejections retain all observed provenance and use `multiple files` when no single path represents the aggregate authority.
- Successful file overwrites report replaced-line counts in tool output, not user feedback.

## Validation

Current head `46785bb3d2`:

- `corepack pnpm run typecheck`
- `corepack pnpm run compile:fast`
- `corepack pnpm run lint`
- `corepack pnpm test` (857 files passed, 1 skipped; 10,163 tests passed, 5 skipped)
- focused approval, lifecycle, desktop, delegation, plan, queue, and aggregation suites (226 tests)
- repository pre-commit and pre-push checks
- built CLI PTY rejection at 72 × 24; rejected write remained absent

GitHub CI is running on this head.
