### PR TITLE
fix(ui): distinguish queued delegation approval scope

### DIFF
--- a/src/shared/copy/delegationApproval.ts
+++ b/src/shared/copy/delegationApproval.ts
@@ -6,7 +6,7 @@ export const DELEGATION_APPROVAL_COPY = Object.freeze({
     'Press y to approve only this task. Press a to approve delegated tasks, file edits, and commands for this chat. Other prompts still ask.',
   progressViewAction: 'Approve agent work for this run',
   progressViewExplanation:
-    'Approves this request and other work already queued in the current task. Later agent tasks, file edits, and shell commands in the current task and tasks delegated from it are auto-approved. Plans, retries, external inquiries, and user questions still require a decision.',
+    'Approves this request and other work already queued in the current run. Later agent tasks, file edits, and shell commands in the current run and any runs delegated from it are auto-approved. Plans, retries, external inquiries, and user questions still require a decision.',
   progressViewToggle:
     'Auto-approve later agent tasks, file edits, and shell commands in this run',
   progressViewEditAction:

--- a/src/shared/copy/delegationApproval.ts
+++ b/src/shared/copy/delegationApproval.ts
@@ -6,7 +6,7 @@ export const DELEGATION_APPROVAL_COPY = Object.freeze({
     'Press y to approve only this task. Press a to approve delegated tasks, file edits, and commands for this chat. Other prompts still ask.',
   progressViewAction: 'Approve agent work for this run',
   progressViewExplanation:
-    'Approves this request, queued and later agent tasks, and queued and later file edits and shell commands in this run. Plans, retries, external inquiries, and user questions still require a decision.',
+    'Approves this request and other work already queued in the current task. Later agent tasks, file edits, and shell commands in the current task and tasks delegated from it are auto-approved. Plans, retries, external inquiries, and user questions still require a decision.',
   progressViewToggle:
     'Auto-approve later agent tasks, file edits, and shell commands in this run',
   progressViewEditAction:

--- a/src/test-kernel/shared/DelegationApprovalCopy.vitest.ts
+++ b/src/test-kernel/shared/DelegationApprovalCopy.vitest.ts
@@ -15,7 +15,7 @@ describe('delegated-work approval copy', () => {
         'Press y to approve only this task. Press a to approve delegated tasks, file edits, and commands for this chat. Other prompts still ask.',
       progressViewAction: 'Approve agent work for this run',
       progressViewExplanation:
-        'Approves this request, queued and later agent tasks, and queued and later file edits and shell commands in this run. Plans, retries, external inquiries, and user questions still require a decision.',
+        'Approves this request and other work already queued in the current task. Later agent tasks, file edits, and shell commands in the current task and tasks delegated from it are auto-approved. Plans, retries, external inquiries, and user questions still require a decision.',
       progressViewToggle:
         'Auto-approve later agent tasks, file edits, and shell commands in this run',
       progressViewEditAction:

--- a/src/test-kernel/shared/DelegationApprovalCopy.vitest.ts
+++ b/src/test-kernel/shared/DelegationApprovalCopy.vitest.ts
@@ -15,7 +15,7 @@ describe('delegated-work approval copy', () => {
         'Press y to approve only this task. Press a to approve delegated tasks, file edits, and commands for this chat. Other prompts still ask.',
       progressViewAction: 'Approve agent work for this run',
       progressViewExplanation:
-        'Approves this request and other work already queued in the current task. Later agent tasks, file edits, and shell commands in the current task and tasks delegated from it are auto-approved. Plans, retries, external inquiries, and user questions still require a decision.',
+        'Approves this request and other work already queued in the current run. Later agent tasks, file edits, and shell commands in the current run and any runs delegated from it are auto-approved. Plans, retries, external inquiries, and user questions still require a decision.',
       progressViewToggle:
         'Auto-approve later agent tasks, file edits, and shell commands in this run',
       progressViewEditAction:


### PR DESCRIPTION
## Summary

- distinguish work already queued in the current task from later work
- state that later automatic approval also applies to tasks delegated from the current task
- retain user-facing terminology rather than exposing the internal stream model

## Validation

- `corepack pnpm vitest run src/test-kernel/shared/DelegationApprovalCopy.vitest.ts src/test-kernel/progressView/ApproveSplitButton.vitest.ts`
- `corepack pnpm run typecheck:test-kernel`
- `corepack pnpm run lint`

Follow-up to #10150, addressing its substantive review finding.