### PR TITLE
fix(cli): preserve user prompt in team transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Multi-agent transcripts show the user's request** — team runs keep internal
+  orchestration guidance out of history and resumed chat messages.
 - **Completed workflow tasks can be retried without restarting chat** — a new
   workflow attempt may reuse its saved task identity after the previous
   attempt has delivered its result.

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -36,10 +36,7 @@ import {
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { withUsageSections } from './_helpers/dispatch';
-import {
-  formatCliRunFileInstruction,
-  formatMultiAgentRunInstruction,
-} from './_helpers/runInstructions';
+import { formatMultiAgentRunInstruction } from './_helpers/runInstructions';
 import { emitCliResult } from './_helpers/output';
 import {
   AGENT_RUN_GLOBAL_ARGS,
@@ -67,6 +64,35 @@ interface MultiAgentRunInit {
 
 const MULTI_AGENT_TASK_REQUIRED_MESSAGE =
   'Provide --input, --instruction, or --instruction-file for the team task. Example: texra multi-agent run physicist --instruction "Check this derivation"';
+
+function formatAttachedFileList(
+  title: string,
+  files: readonly string[],
+): string | undefined {
+  if (files.length === 0) return undefined;
+  return [
+    title,
+    ...files.map((file) =>
+      file === '-' ? '- Standard input' : `- ${JSON.stringify(file)}`,
+    ),
+  ].join('\n');
+}
+
+/** Preserve the user's launch input without copying model-only directives. */
+function formatMultiAgentDisplayInstruction(
+  instruction: string,
+  inputFiles: readonly string[],
+  contextFiles: readonly string[],
+): string {
+  if (instruction) return instruction;
+
+  return [
+    formatAttachedFileList('Attached input files:', inputFiles),
+    formatAttachedFileList('Attached read-only context files:', contextFiles),
+  ]
+    .filter((part): part is string => part !== undefined)
+    .join('\n\n');
+}
 
 function headlessAskMultiAgentMessage(presetId: string): string {
   return `Cannot run multi-agent preset "${presetId}" with headless approval policy "ask": delegation prompts cannot be answered. Use an interactive run to answer prompts, pass --approval-policy never to deny approval-gated tools, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`;
@@ -204,9 +230,11 @@ export async function runMultiAgentPreset(
         );
       }
 
-      const displayInstruction =
-        instruction ||
-        formatCliRunFileInstruction({ inputFiles, contextFiles });
+      const displayInstruction = formatMultiAgentDisplayInstruction(
+        instruction,
+        init.inputFiles,
+        init.contextFiles,
+      );
       const config: AgentConfigPayload = {
         agent: rootAgent.name,
         model,

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -36,7 +36,10 @@ import {
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { withUsageSections } from './_helpers/dispatch';
-import { formatMultiAgentRunInstruction } from './_helpers/runInstructions';
+import {
+  formatCliRunFileInstruction,
+  formatMultiAgentRunInstruction,
+} from './_helpers/runInstructions';
 import { emitCliResult } from './_helpers/output';
 import {
   AGENT_RUN_GLOBAL_ARGS,
@@ -201,6 +204,9 @@ export async function runMultiAgentPreset(
         );
       }
 
+      const displayInstruction =
+        instruction ||
+        formatCliRunFileInstruction({ inputFiles, contextFiles });
       const config: AgentConfigPayload = {
         agent: rootAgent.name,
         model,
@@ -213,7 +219,7 @@ export async function runMultiAgentPreset(
           approvalContext: runContext,
           workingDirectory: runContext.cwd,
         }),
-        displayInstruction: instruction,
+        displayInstruction,
         workingDirectory: runContext.cwd,
         agentCategory: AgentCategory.ToolUse,
         cliMultiAgentPresetId: plan.preset.id,

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -72,9 +72,10 @@ function formatAttachedFileList(
   if (files.length === 0) return undefined;
   return [
     title,
-    ...files.map((file) =>
-      file === '-' ? '- Standard input' : `- ${JSON.stringify(file)}`,
-    ),
+    ...files.map((file) => {
+      const spec = file.trim();
+      return spec === '-' ? '- Standard input' : `- ${JSON.stringify(spec)}`;
+    }),
   ].join('\n');
 }
 

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -213,6 +213,7 @@ export async function runMultiAgentPreset(
           approvalContext: runContext,
           workingDirectory: runContext.cwd,
         }),
+        displayInstruction: instruction,
         workingDirectory: runContext.cwd,
         agentCategory: AgentCategory.ToolUse,
         cliMultiAgentPresetId: plan.preset.id,

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
@@ -531,8 +531,13 @@ describe('CLI multi-agent run command', () => {
   });
 
   it('shows attached inputs instead of orchestration guidance without an instruction', async () => {
-    const exitCode = await runPreset({
+    mockExpandedRunInputs({
       inputFiles: ['problem.tex'],
+      contextFiles: ['reference.tex'],
+    });
+    const exitCode = await runPreset({
+      inputFiles: [' problem.tex '],
+      contextFiles: [' reference.tex '],
       instruction: '',
     });
 
@@ -540,6 +545,9 @@ describe('CLI multi-agent run command', () => {
     const config = mocks.executeCliToolUseConfig.mock.calls[0]?.[0];
     expect(config?.displayInstruction).toContain('Attached input files:');
     expect(config?.displayInstruction).toContain('- "problem.tex"');
+    expect(config?.displayInstruction).toContain(
+      '\n\nAttached read-only context files:\n- "reference.tex"',
+    );
     expect(config?.displayInstruction).not.toContain(
       'Run the "Mathematician" multi-agent team preset.',
     );
@@ -571,7 +579,7 @@ describe('CLI multi-agent run command', () => {
         }),
     );
 
-    const exitCode = await runPreset({ inputFiles: ['-'], instruction: '' });
+    const exitCode = await runPreset({ inputFiles: [' - '], instruction: '' });
 
     expect(exitCode).toBe(0);
     const config = mocks.executeCliToolUseConfig.mock.calls[0]?.[0];

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
@@ -538,14 +538,50 @@ describe('CLI multi-agent run command', () => {
 
     expect(exitCode).toBe(0);
     const config = mocks.executeCliToolUseConfig.mock.calls[0]?.[0];
-    expect(config?.displayInstruction).toContain('Primary user input files:');
+    expect(config?.displayInstruction).toContain('Attached input files:');
     expect(config?.displayInstruction).toContain('- "problem.tex"');
     expect(config?.displayInstruction).not.toContain(
       'Run the "Mathematician" multi-agent team preset.',
     );
+    expect(config?.displayInstruction).not.toContain(
+      'Read and use them before delegating work.',
+    );
     expect(config?.instruction).toContain(
       'Run the "Mathematician" multi-agent team preset.',
     );
+  });
+
+  it('uses a stable display label for a file-only stdin launch', async () => {
+    mocks.withExpandedRunInputs.mockImplementationOnce(
+      async (
+        _inputSpecs: readonly string[],
+        _contextSpecs: readonly string[],
+        _cwd: string,
+        _options: unknown,
+        run: (inputs: {
+          readonly inputFiles: string[];
+          readonly contextFiles: string[];
+          readonly hasMaterializedStdinInput: boolean;
+        }) => Promise<unknown>,
+      ) =>
+        run({
+          inputFiles: ['.texra-tmp/texra-stdin-123/stdin.tex'],
+          contextFiles: [],
+          hasMaterializedStdinInput: true,
+        }),
+    );
+
+    const exitCode = await runPreset({ inputFiles: ['-'], instruction: '' });
+
+    expect(exitCode).toBe(0);
+    const config = mocks.executeCliToolUseConfig.mock.calls[0]?.[0];
+    expect(config?.displayInstruction).toBe(
+      'Attached input files:\n- Standard input',
+    );
+    expect(config?.displayInstruction).not.toContain('texra-stdin-123');
+    expect(config?.inputFiles).toEqual([
+      '.texra-tmp/texra-stdin-123/stdin.tex',
+    ]);
   });
 
   it('allows instruction-file-only team runs without input files', async () => {

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
@@ -309,6 +309,9 @@ describe('CLI multi-agent run command', () => {
       expect.any(Function),
     );
     const config = mocks.executeCliToolUseConfig.mock.calls[0]?.[0];
+    expect(config?.displayInstruction).toBe(
+      'Inspect the proof without editing files.',
+    );
     expect(config?.instruction).toContain('Primary user input files:');
     expect(config?.instruction).toContain('- "problem.tex"');
     expect(config?.instruction).toContain(

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
@@ -530,6 +530,24 @@ describe('CLI multi-agent run command', () => {
     );
   });
 
+  it('shows attached inputs instead of orchestration guidance without an instruction', async () => {
+    const exitCode = await runPreset({
+      inputFiles: ['problem.tex'],
+      instruction: '',
+    });
+
+    expect(exitCode).toBe(0);
+    const config = mocks.executeCliToolUseConfig.mock.calls[0]?.[0];
+    expect(config?.displayInstruction).toContain('Primary user input files:');
+    expect(config?.displayInstruction).toContain('- "problem.tex"');
+    expect(config?.displayInstruction).not.toContain(
+      'Run the "Mathematician" multi-agent team preset.',
+    );
+    expect(config?.instruction).toContain(
+      'Run the "Mathematician" multi-agent team preset.',
+    );
+  });
+
   it('allows instruction-file-only team runs without input files', async () => {
     mockExpandedRunInputs({
       inputFiles: [],


### PR DESCRIPTION
Closes #10153.

## What changed

- Preserve the resolved user request as `displayInstruction` when launching a CLI multi-agent preset.
- For file-only launches, record a display-only attachment list without model guidance or temporary stdin paths.
- Keep the fully formatted team-orchestration prompt as the model-facing `instruction`.
- Add a command-boundary assertion for the user-facing value.
- Record the user-visible transcript correction in the changelog.

## Ownership decision

The transcript renderer and resume path already distinguish `displayInstruction` from the model-facing instruction. Ordinary `texra agents run` launches also supply both values. This change makes `texra multi-agent run` use that existing authority instead of adding filtering or reconstruction during resume.

Consequently, the persisted initial user row is faithful at its source, and every later consumer—history, transcript view, and resumed chat—receives the same canonical user-facing text.

## Evidence

Before the change, resuming an interrupted team run in a 72x24 PTY displayed the generated preset header, absolute workspace guidance, delegation policy, and internal checklist as the user's message. The original request appeared only near the end.

After rebuilding and launching the same path, the resumed 72x24 TUI displayed only:

```text
State the Bloch-vector criterion for equality in trace-distance
contraction. Delegate one independent check. Do not use files or
shell commands.
```

The model-facing wrapper remains present in the existing command assertion.

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/commands/multiAgent.ts src/test-kernel/cli/MultiAgentRunCommand.vitest.ts CHANGELOG.md`
- `corepack pnpm vitest run src/test-kernel/cli/MultiAgentRunCommand.vitest.ts` (18 passed)
- `corepack pnpm run typecheck:cli`
- `corepack pnpm run typecheck:test-kernel`
- `corepack pnpm run compile:fast`
- `corepack pnpm run texra-local:build`
- `corepack pnpm run lint`
- `corepack pnpm test` (857 files passed, 1 skipped; 10,150 tests passed, 5 skipped)
- Real PTY launch at 100x30, interruption after 8 seconds, and resume at 72x24

