### PR TITLE
docs(agent): document refreshClient override seam

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1123,7 +1123,16 @@ export abstract class ModelHandler<
   /** Creates and configures a client instance for the specific model provider. */
   abstract getClient(selection?: ModelCredentialSelection): Promise<C>;
 
-  /** Rebuild a client for an explicit route without publishing settings. */
+  /**
+   * Rebuild a client for an explicit route without publishing settings.
+   *
+   * This is a deliberate override seam, not a redundant alias for
+   * {@link getClient}: handlers that cache a client across calls (for example
+   * `modelHandlerGoogleInteractions`) invalidate that cache here before
+   * rebuilding, so a credential rotation actually produces a fresh client
+   * instead of returning the cached one. Handlers without a cache keep the
+   * base pass-through default.
+   */
   async refreshClient(
     selection: ModelCredentialSelection = 'configured',
   ): Promise<C> {

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1127,11 +1127,11 @@ export abstract class ModelHandler<
    * Rebuild a client for an explicit route without publishing settings.
    *
    * This is a deliberate override seam, not a redundant alias for
-   * {@link getClient}: handlers that cache a client across calls (for example
-   * `modelHandlerGoogleInteractions`) invalidate that cache here before
-   * rebuilding, so a credential rotation actually produces a fresh client
-   * instead of returning the cached one. Handlers without a cache keep the
-   * base pass-through default.
+   * {@link getClient}. `ModelHandlerGoogleInteractions` caches its SDK client
+   * across calls; its override clears that cache here so `refreshClient`
+   * never reuses a cached instance, even when the resolved credential matches
+   * the cached one. Handlers without a cache keep the base pass-through
+   * default.
    */
   async refreshClient(
     selection: ModelCredentialSelection = 'configured',


### PR DESCRIPTION
## Summary

Resolves #9940 by recording the resolution of each of its three findings. Two
of the three pass-through sites were already collapsed by later work; the third
is a load-bearing override seam and now carries that contract in its docblock
so a future simplification pass does not collapse it.

- `ModelHandler.refreshClient` (#1): kept as a deliberate seam. The base is a
  pass-through to `getClient`, but `modelHandlerGoogleInteractions` overrides
  it to invalidate its cached `GoogleGenAI` client before rebuilding, so a
  credential rotation produces a fresh client. Added a docblock explaining the
  contract. `refreshClient` remains on the `IModelHandler` surface and has one
  caller (`ModelCell.rebind`).
- `TraceEmitter.StageHandle.run` (#2): no longer a pass-through. It now wraps
  `within` with stage-lifecycle `end()`/failure handling, so `run` and `within`
  are semantically distinct.
- `SettingsMemoryController.pinMemory`/`unpinMemory` (#3): already collapsed
  into a single `setMemoryPinned(storagePath, pinned)` method.

## Issue acceptance gates

- Each site is either simplified, documented as a deliberate seam, or verified
  as already-collapsed; the issue closes rather than leaving an open action.

## Single source of truth

`IModelHandler` / `ModelHandler` remains the single authority for the
`refreshClient` override contract; the docblock names the only subclass that
relies on the seam.

## Duplication and abstraction budget

No new abstraction. No duplication removed (the two real collapses predate this
change). This PR only documents an existing, load-bearing seam to prevent a
future pass-through collapse.

## Net elements (R6)

- Files changed: 1 (`src/agent/modelHandlers/ModelHandler.ts`)
- Exported symbols added/deleted: 0
- Classes/interfaces/enums added/deleted: 0
- Net LoC: +7 (docblock only)

## Consumer counts (R8)

n/a — no export, emit path, or route changed.

## Host impact

Extension: none
Desktop: none
CLI: none

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --check src/agent/modelHandlers/ModelHandler.ts`
- Change is documentation-only; full CI runs on the PR.
