### PR TITLE
test: route test-kernel toolResult imports through @shared/schemas barrel

### DIFF
--- a/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
+++ b/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
@@ -13,7 +13,7 @@ import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ITool } from '@agent/core/tools/ToolTypes';
 import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 import type { StreamTabId } from '@shared/schemas';
-import type { ToolResult } from '@shared/schemas/toolResult';
+import type { ToolResult } from '@shared/schemas';
 import { installPlatform } from '@test/support/setupPlatform';
 import { createRunTrace, StreamLogStore } from '@transcript';
 import { delay } from '@utils/core';

--- a/src/test-kernel/agent/modelHandlers/AnthropicToolAttachmentUploadPolicy.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicToolAttachmentUploadPolicy.vitest.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { noopTrace, type AgentTrace } from '@agent/trace';
 import { uploadToolAttachments } from '@agent/modelHandlers/anthropic/anthropicTools';
-import type { ToolFileAttachment } from '@shared/schemas/toolResult';
+import type { ToolFileAttachment } from '@shared/schemas';
 
 function createWarningRecorder(): {
   logger: AgentTrace;

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { noopTrace } from '@agent/trace';
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
 import type { GoogleToolCall } from '@agent/types/ModelHandlerContracts';
-import type { ToolResult } from '@shared/schemas/toolResult';
+import type { ToolResult } from '@shared/schemas';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 import * as configModule from '@utils/config/configUtils';
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -38,7 +38,7 @@ import {
 import * as serverKeysModule from '@auth/serverKeys';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { AgentCategory } from '@shared/schemas';
-import type { ToolFileAttachment } from '@shared/schemas/toolResult';
+import type { ToolFileAttachment } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 import { pathToLocation } from '@utils/files/fileLocation';

--- a/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
@@ -13,7 +13,7 @@ import {
   TOOL_RESULT_TRUNCATION_HEAD_CHARS,
   TOOL_RESULT_TRUNCATION_TAIL_CHARS,
 } from '@agent/modelHandlers/contextManagementConstants';
-import type { ToolFileAttachment } from '@shared/schemas/toolResult';
+import type { ToolFileAttachment } from '@shared/schemas';
 
 /** Head and tail well over their truncation budgets, with an elidable middle. */
 function oversizedText(): { head: string; tail: string; text: string } {

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -44,7 +44,7 @@ import {
   AgentCategory,
 } from '@shared/schemas';
 import type { ExecResult } from '@shared/schemas/opResults';
-import type { ToolResult } from '@shared/schemas/toolResult';
+import type { ToolResult } from '@shared/schemas';
 import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -41,10 +41,10 @@ import {
   RUN_OUTCOME,
   STREAM_PHASE,
   type StreamTabId,
+  type ToolResult,
   AgentCategory,
 } from '@shared/schemas';
 import type { ExecResult } from '@shared/schemas/opResults';
-import type { ToolResult } from '@shared/schemas';
 import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,

--- a/src/test-kernel/tools/Cancellation.vitest.ts
+++ b/src/test-kernel/tools/Cancellation.vitest.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports
-import { ToolError } from '@shared/schemas/toolResult';
+import { ToolError } from '@shared/schemas';
 import { abandonOnAbort } from '@tools/citation/rateLimiter';
 
 const neverSettles = new Promise<never>(() => {});

--- a/src/test-kernel/tools/FetchToolErrorClassification.vitest.ts
+++ b/src/test-kernel/tools/FetchToolErrorClassification.vitest.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { HTTPError, TimeoutError } from 'ky';
 
-import { ToolError } from '@shared/schemas/toolResult';
+import { ToolError } from '@shared/schemas';
 import { toFetchToolError } from '@tools/timeouts';
 
 const MESSAGES = {

--- a/src/test-kernel/tools/FileEditFlow.vitest.ts
+++ b/src/test-kernel/tools/FileEditFlow.vitest.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { ToolError } from '@shared/schemas/toolResult';
+import { ToolError } from '@shared/schemas';
 import {
   findOccurrenceLineNumbers,
   replaceAllLiteral,

--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -9,7 +9,7 @@ import {
   type InquiryThreadId,
   type StreamTabId,
 } from '@shared/schemas';
-import { ToolError } from '@shared/schemas/toolResult';
+import { ToolError } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
   getOpenTurnDraft,

--- a/src/test-kernel/tools/PathResolution.vitest.ts
+++ b/src/test-kernel/tools/PathResolution.vitest.ts
@@ -2,7 +2,7 @@ import * as path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { ToolError } from '@shared/schemas/toolResult';
+import { ToolError } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { installPlatform } from '@test/support/setupPlatform';
 import {


### PR DESCRIPTION
## Summary

Closes #10132. Eleven test-kernel specs still reached past the published `@shared/schemas` barrel into `@shared/schemas/toolResult` after #10118 codemodded production imports. Rewrite those eleven imports to use the barrel so the convention is uniform and cannot drift back into production via copy-paste.

## Issue acceptance gates

- All remaining `@shared/schemas/toolResult` imports under `src/test-kernel/` now go through `@shared/schemas`.
- The ratchet's test-kernel exclusion is left as-is for now (see Scheduled refactoring).

## Single source of truth

`src/shared/schemas/index.ts` remains the single published surface; tests now consume it the same way production does.

## Duplication and abstraction budget

No duplication added. The change removes eleven bypass sites of the barrel.

## Net elements (R6)

- Files changed: 11 (test-kernel specs)
- Exported symbols added/deleted: 0
- Classes/interfaces/enums: 0
- Net LoC: 0 (import specifiers only)

## Consumer counts (R8)

n/a — no export, emit path, or route changed.

## Host impact

Extension: none
Desktop: none
CLI: none

## Scheduled refactoring

The issue's optional follow-up — narrowing or dropping the `src/test-kernel/` exclusion in `sharedSchemasDeepImportRatchet.vitest.ts` so the convention is enforced for tests too — is deferred. It requires regenerating `shared-schemas-deep-import-baseline.json` across every test-kernel deep-import specifier (not just `toolResult`) and is a broader ratchet-surface decision, not a mechanical import fix.

## Validation

- `npm run typecheck:test-kernel`
- Focused vitest on all 11 changed specs (207 tests passed)
- `src/test-kernel/architecture/sharedSchemasDeepImportRatchet.vitest.ts` (7 tests passed)
