### PR TITLE
test(cli): cover mixed-status direct-children /status count

### DIFF
--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -53,6 +53,7 @@ import {
   STREAM_PHASE,
   type ExecutionId,
   type Plan,
+  type StreamPhase,
   type StreamTabId,
   type TodoItem,
 } from '@shared/schemas';
@@ -907,11 +908,22 @@ describe('handleTuiSlashCommand', () => {
     registerBuiltinSlashCommands();
     const session = createSession();
     const rootStreamId = 'stream-root' as StreamTabId;
+    const parentStreamId = 'stream-parent' as StreamTabId;
+    const rootSiblingIds = [
+      'stream-root-sibling-1',
+      'stream-root-sibling-2',
+    ] as StreamTabId[];
     const runningChildId = 'stream-child-running' as StreamTabId;
     const waitingChildId = 'stream-child-waiting' as StreamTabId;
-    activeStreamId.set(rootStreamId);
+    activeStreamId.set(parentStreamId);
+    for (const streamId of rootSiblingIds) {
+      setStreamStatusInCliState({
+        streamId,
+        status: STREAM_PHASE.RUNNING,
+      });
+    }
     setStreamStatusInCliState({
-      streamId: rootStreamId,
+      streamId: parentStreamId,
       status: STREAM_PHASE.WAITING,
     });
     setStreamStatusInCliState({
@@ -922,26 +934,35 @@ describe('handleTuiSlashCommand', () => {
       streamId: waitingChildId,
       status: STREAM_PHASE.WAITING,
     });
-    projectChildRoster(
-      rootStreamId,
-      [runningChildId, waitingChildId].map((childStreamId, index) => ({
-        executionId: `child-exec-${index}`,
-        identity: { kind: 'agent' as const, agent: `critic-${index}` },
-        agentName: `critic-${index}`,
-        status:
-          childStreamId === runningChildId
-            ? STREAM_PHASE.RUNNING
-            : STREAM_PHASE.WAITING,
-        startedAt: index + 1,
-        elapsed: '1s',
-        childStreamId,
-      })),
-    );
+    const rosterRow = (
+      childStreamId: StreamTabId,
+      index: number,
+      status: StreamPhase,
+    ) => ({
+      executionId: `child-exec-${index}`,
+      identity: { kind: 'agent' as const, agent: `critic-${index}` },
+      agentName: `critic-${index}`,
+      status,
+      startedAt: index + 1,
+      elapsed: '1s',
+      childStreamId,
+    });
+    projectChildRoster(rootStreamId, [
+      rosterRow(parentStreamId, 0, STREAM_PHASE.WAITING),
+      ...rootSiblingIds.map((streamId, index) =>
+        rosterRow(streamId, index + 1, STREAM_PHASE.RUNNING),
+      ),
+    ]);
+    projectChildRoster(parentStreamId, [
+      rosterRow(runningChildId, 3, STREAM_PHASE.RUNNING),
+      rosterRow(waitingChildId, 4, STREAM_PHASE.WAITING),
+    ]);
 
     await handleTuiSlashCommand('/status', createContext(session));
 
     const statusText = lastEntryText(rootStreamId);
     expect(statusText).toContain('active background tasks: 1');
+    expect(statusText).not.toContain('active background tasks: 2');
   });
 
   it('does not count retained idle children as active background tasks', async () => {

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -903,6 +903,47 @@ describe('handleTuiSlashCommand', () => {
     expect(statusText).toContain('active background tasks: 1');
   });
 
+  it('counts only running children among mixed direct-children phases', async () => {
+    registerBuiltinSlashCommands();
+    const session = createSession();
+    const rootStreamId = 'stream-root' as StreamTabId;
+    const runningChildId = 'stream-child-running' as StreamTabId;
+    const waitingChildId = 'stream-child-waiting' as StreamTabId;
+    activeStreamId.set(rootStreamId);
+    setStreamStatusInCliState({
+      streamId: rootStreamId,
+      status: STREAM_PHASE.WAITING,
+    });
+    setStreamStatusInCliState({
+      streamId: runningChildId,
+      status: STREAM_PHASE.RUNNING,
+    });
+    setStreamStatusInCliState({
+      streamId: waitingChildId,
+      status: STREAM_PHASE.WAITING,
+    });
+    projectChildRoster(
+      rootStreamId,
+      [runningChildId, waitingChildId].map((childStreamId, index) => ({
+        executionId: `child-exec-${index}`,
+        identity: { kind: 'agent' as const, agent: `critic-${index}` },
+        agentName: `critic-${index}`,
+        status:
+          childStreamId === runningChildId
+            ? STREAM_PHASE.RUNNING
+            : STREAM_PHASE.WAITING,
+        startedAt: index + 1,
+        elapsed: '1s',
+        childStreamId,
+      })),
+    );
+
+    await handleTuiSlashCommand('/status', createContext(session));
+
+    const statusText = lastEntryText(rootStreamId);
+    expect(statusText).toContain('active background tasks: 1');
+  });
+
   it('does not count retained idle children as active background tasks', async () => {
     registerBuiltinSlashCommands();
     const session = createSession();


### PR DESCRIPTION
## Summary

Closes #10094. Add the missing mixed-status direct-children test for `/status` in `src/test-kernel/cli/SlashCommandDispatch.vitest.ts`: a focused root owning one `RUNNING` and one `WAITING` child must report `active background tasks: 1`.

## Issue acceptance gates

- A direct-children test now pins `.filter(isActivePhase)` on the branch where the focused stream owns children, with mixed `RUNNING`/`WAITING` phases, asserting the count is `1`.

## Single source of truth

`showCliSessionStatus`'s active-child count remains the single authority; the test pins its direct-children branch against future topology-selector refactors.

## Duplication and abstraction budget

No production change; no new abstraction.

## Net elements (R6)

n/a (test-only).

## Consumer counts (R8)

n/a.

## Host impact

Extension: none
Desktop: none
CLI: none (test-only)

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --check src/test-kernel/cli/SlashCommandDispatch.vitest.ts`
- `npx vitest run src/test-kernel/cli/SlashCommandDispatch.vitest.ts` (42 tests passed)
