### PR TITLE
fix(progress-view): show runtime model labels on workflow-task cards

### DIFF
--- a/src/controllers/progressView/backend/WebviewBridge.ts
+++ b/src/controllers/progressView/backend/WebviewBridge.ts
@@ -1,6 +1,14 @@
 import { createLog } from '@logger/logUtils';
+import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import type { ProgressViewOutboundMessage, StreamTabId } from '@shared/schemas';
+import {
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  WorkflowCallProgressSchema,
+  type ProgressViewOutboundMessage,
+  type StreamLogEntry,
+  type StreamTabId,
+} from '@shared/schemas';
 import { StreamLogDeltaBuffer } from '@transcript/StreamLog';
 import type { StreamLogStore } from '@transcript/StreamLogStore';
 import { createFlushableDebounce, type FlushableDebounce } from '@utils/core';
@@ -8,6 +16,28 @@ import { createFlushableDebounce, type FlushableDebounce } from '@utils/core';
 const log = createLog('WebviewBridge');
 
 const FRAME_INTERVAL_MS = 16;
+
+/**
+ * Webview-facing copy of one transcript entry. The stream-log store keeps the
+ * canonical `WorkflowCallProgress.model` id; only the copy that crosses the
+ * `postMessage` boundary projects it through the runtime model registry. This
+ * mirrors `formatCliWorkflowCallLine` while keeping `@model/runtimeModelRegistry`
+ * out of the browser frontend import graph.
+ */
+function projectWorkflowCallEntry(entry: StreamLogEntry): StreamLogEntry {
+  if (
+    entry.type !== STREAM_LOG_ENTRY_TYPES.LOG ||
+    entry.messageType !== MESSAGE_TYPES.WORKFLOW_TASK
+  ) {
+    return entry;
+  }
+  const call = WorkflowCallProgressSchema.safeParse(entry.data);
+  if (!call.success) return entry;
+  if (!('model' in call.data) || call.data.model === undefined) return entry;
+  const model = getRuntimeModelLabel(call.data.model);
+  if (model === call.data.model) return entry;
+  return { ...entry, data: { ...call.data, model } };
+}
 
 export type ProgressViewMessageSender = (
   message: ProgressViewOutboundMessage,
@@ -128,7 +158,7 @@ export class WebviewBridge {
       // is based at the emission head read in the same synchronous snapshot
       // as `getRange(0)`, so deltas emitted during the async delivery below
       // fold on top of exactly this frame.
-      const entries = log.getRange(0);
+      const entries = log.getRange(0).map(projectWorkflowCallEntry);
       entry.buffer = new StreamLogDeltaBuffer(log.emissionHead);
       if (entries.length === 0) {
         entry.dirty = false;
@@ -154,8 +184,8 @@ export class WebviewBridge {
       payload = {
         command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
         streamId: activeStream,
-        entries: appended,
-        updates: dirtied,
+        entries: appended.map(projectWorkflowCallEntry),
+        updates: dirtied.map(projectWorkflowCallEntry),
         textDeltas: textChunks,
       };
     }

--- a/src/controllers/progressView/backend/WebviewBridge.ts
+++ b/src/controllers/progressView/backend/WebviewBridge.ts
@@ -31,12 +31,14 @@ function projectWorkflowCallEntry(entry: StreamLogEntry): StreamLogEntry {
   ) {
     return entry;
   }
-  const call = WorkflowCallProgressSchema.safeParse(entry.data);
+  const data = entry.data;
+  if (typeof data !== 'object' || data === null) return entry;
+  const call = WorkflowCallProgressSchema.safeParse(data);
   if (!call.success) return entry;
   if (!('model' in call.data) || call.data.model === undefined) return entry;
   const model = getRuntimeModelLabel(call.data.model);
   if (model === call.data.model) return entry;
-  return { ...entry, data: { ...call.data, model } };
+  return { ...entry, data: { ...data, model } };
 }
 
 export type ProgressViewMessageSender = (

--- a/src/test-kernel/progressView/WebviewBridge.vitest.ts
+++ b/src/test-kernel/progressView/WebviewBridge.vitest.ts
@@ -172,6 +172,34 @@ describe('WebviewBridge', () => {
     expect(store.get(ACTIVE)?.getRange(0)[0]?.data).toEqual(
       expect.objectContaining({ model: 'gpt56-' }),
     );
+
+    sendMessage.mockClear();
+    appendTranscriptEntry(store, ACTIVE, {
+      id: 'workflow-call-2',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 200,
+      messageType: MESSAGE_TYPES.WORKFLOW_TASK,
+      text: 'Review',
+      data: {
+        id: 'call-2',
+        label: 'Review',
+        status: 'completed',
+        model: 'gpt56-',
+      },
+    });
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      logDeltaMessage(ACTIVE, {
+        entries: [
+          expect.objectContaining({
+            id: 'workflow-call-2',
+            data: expect.objectContaining({ model: 'GPT-5.6 Terra' }),
+          }),
+        ],
+      }),
+    );
   });
 
   it('projects workflow-call model labels on in-place terminal updates', async () => {

--- a/src/test-kernel/progressView/WebviewBridge.vitest.ts
+++ b/src/test-kernel/progressView/WebviewBridge.vitest.ts
@@ -132,6 +132,89 @@ describe('WebviewBridge', () => {
     );
   });
 
+  it('projects workflow-call model ids to runtime labels at the webview boundary', async () => {
+    const { store, sendMessage, bridge } = setupBridge();
+
+    bridge.syncStream(ACTIVE);
+    appendTranscriptEntry(store, ACTIVE, {
+      id: 'workflow-call-1',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 100,
+      messageType: MESSAGE_TYPES.WORKFLOW_TASK,
+      text: 'Summarize',
+      data: {
+        id: 'call-1',
+        label: 'Summarize',
+        status: 'completed',
+        model: 'gpt56-',
+        durationMs: 7000,
+        totalCostUsd: 0.04,
+      },
+    });
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      logDeltaMessage(ACTIVE, {
+        entries: [
+          expect.objectContaining({
+            id: 'workflow-call-1',
+            data: expect.objectContaining({ model: 'GPT-5.6 Terra' }),
+          }),
+        ],
+      }),
+    );
+
+    // The canonical id stays in the stream-log entry the webview copy projects from.
+    expect(store.get(ACTIVE)?.getRange(0)[0]?.data).toEqual(
+      expect.objectContaining({ model: 'gpt56-' }),
+    );
+  });
+
+  it('projects workflow-call model labels on in-place terminal updates', async () => {
+    const { store, sendMessage, bridge } = setupBridge();
+
+    bridge.syncStream(ACTIVE);
+    appendTranscriptEntry(store, ACTIVE, {
+      id: 'workflow-call-1',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 100,
+      messageType: MESSAGE_TYPES.WORKFLOW_TASK,
+      text: 'Summarize',
+      data: {
+        id: 'call-1',
+        label: 'Summarize',
+        status: 'running',
+      },
+    });
+    await vi.advanceTimersByTimeAsync(20);
+    sendMessage.mockClear();
+
+    updateTranscriptEntry(store, ACTIVE, 'workflow-call-1', {
+      data: {
+        id: 'call-1',
+        label: 'Summarize',
+        status: 'completed',
+        model: 'gpt56-',
+        durationMs: 7000,
+        totalCostUsd: 0.04,
+      },
+    });
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      logDeltaMessage(ACTIVE, {
+        updates: [
+          expect.objectContaining({
+            id: 'workflow-call-1',
+            data: expect.objectContaining({ model: 'GPT-5.6 Terra' }),
+          }),
+        ],
+      }),
+    );
+  });
+
   it('pushes restart-repair group settlements through log deltas', async () => {
     const repairStream = 'active-repair' as StreamTabId;
     const { store, sendMessage, bridge } = setupBridge({

--- a/src/test-kernel/progressView/WebviewBridge.vitest.ts
+++ b/src/test-kernel/progressView/WebviewBridge.vitest.ts
@@ -145,7 +145,7 @@ describe('WebviewBridge', () => {
       text: 'Summarize',
       data: {
         id: 'call-1',
-        label: 'Summarize',
+        label: '  Summarize  ',
         status: 'completed',
         model: 'gpt56-',
         durationMs: 7000,
@@ -159,7 +159,10 @@ describe('WebviewBridge', () => {
         entries: [
           expect.objectContaining({
             id: 'workflow-call-1',
-            data: expect.objectContaining({ model: 'GPT-5.6 Terra' }),
+            data: expect.objectContaining({
+              label: '  Summarize  ',
+              model: 'GPT-5.6 Terra',
+            }),
           }),
         ],
       }),


### PR DESCRIPTION
## Summary

Closes #10137. The VS Code progress-view workflow-task card now renders the runtime model label (e.g. `GPT-5.6 Terra`) instead of the opaque canonical id (e.g. `gpt56-`), matching the CLI surfaces fixed by #10119/#10121.

The projection happens in `WebviewBridge` at the host-side `LOG_DELTA` boundary — the one place workflow-task log entries cross the `postMessage` boundary into the browser webview. `projectWorkflowCallEntry` projects only the webview-facing copy's `model` field through `getRuntimeModelLabel`; the persisted stream-log entry and model-facing state keep the canonical id. This mirrors the CLI's `formatCliWorkflowCallLine` pattern and keeps `@model/runtimeModelRegistry` (which is not browser-safe) out of the webview frontend import graph.

## Issue acceptance gates

- Progress-view workflow-call card shows the runtime label.
- Canonical ids stay in events/task data/persisted state.
- The browser frontend (`workflowCallFormatter.ts`) is untouched and still does not import `@model/runtimeModelRegistry`.
- Focused tests pin both the from-scratch/appended path and the in-place terminal-update path.

## Single source of truth

`getRuntimeModelLabel` in `@model/runtimeModelRegistry` remains the single authority for the display label; `WebviewBridge` is the single projection boundary for webview-facing transcript copies.

## Duplication and abstraction budget

No new abstraction or pass-through layer; a single small pure projection function at the existing boundary. No duplication added.

## Net elements (R6)

- Files changed: 2
- Exported symbols added: 0 (one module-local function)
- Classes/interfaces/enums: 0
- Net LoC: +117 (includes ~83 lines of focused tests)

## Consumer counts (R8)

n/a — no export/emit/route deleted or re-routed.

## Host impact

Extension: progress-view task card now shows labeled model names
Desktop: none (uses its own presentation path; no change)
CLI: none

## Scheduled refactoring

None.

## Validation

- `npm run typecheck:workspace` and `npm run typecheck:test-kernel`
- `npm run lint`
- `npx vitest run src/test-kernel/progressView/WebviewBridge.vitest.ts` (13 tests passed)
- `npx vitest run src/test-kernel/architecture/dependencyDirection.vitest.ts src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts` (20 tests passed)
- `npx vitest run src/test-kernel/architecture/sharedSchemasDeepImportRatchet.vitest.ts` (7 tests passed)
- `corepack pnpm exec prettier --check` on changed files
