### PR TITLE
fix(cli): surface session approvals in workflow dashboard

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -118,7 +118,7 @@ interface InputEventEmitterLike {
 // list-root row also owns session-wide (stream-less) approvals.
 function focusStreamAndPromoteApprovals(
   streamId: StreamTabId,
-  visibleListRootStreamId = rootStreamIdSignal.get(),
+  visibleListRootStreamId: StreamTabId | undefined,
 ): void {
   focusStream(streamId);
   promoteApprovalsForStream(streamId, {

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -591,7 +591,13 @@ export function App(props: AppProps): React.JSX.Element {
     }
     const parentId = parentStreamSignal.get().get(streamId);
     if (parentId !== undefined) {
-      focusStreamAndPromoteApprovals(parentId, childListTarget.streamId);
+      const destinationListRoot = resolveChildListTarget({
+        activeStreamId: parentId,
+        childStreamEntries: childStreamEntriesSignal.get(),
+        parentStream: parentStreamSignal.get(),
+        streams: streamsSignal.get(),
+      }).streamId;
+      focusStreamAndPromoteApprovals(parentId, destinationListRoot);
       if (
         selectedWorkflowChildStreamId === streamId &&
         workflowDashboard?.root.streamId === parentId

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -275,10 +275,6 @@ export function App(props: AppProps): React.JSX.Element {
       view.slice !== undefined &&
       isActivePhase(view.slice.status),
   ).length;
-  const pendingApprovalsForRows = useMemo(
-    () => groupPendingApprovalsByRow(pendingSummaries, rootStreamId),
-    [pendingSummaries, rootStreamId],
-  );
   const activeSubagentExecutionIds = useMemo(() => {
     const executionIds = new Map<StreamTabId, string>();
     const parentIds = new Set(
@@ -310,6 +306,14 @@ export function App(props: AppProps): React.JSX.Element {
         ? workflowDashboardModel(workflowDashboardRoot, columns)
         : undefined,
     [columns, workflowDashboardRoot],
+  );
+  const pendingApprovalsForRows = useMemo(
+    () =>
+      groupPendingApprovalsByRow(
+        pendingSummaries,
+        workflowDashboard?.root.streamId ?? rootStreamId,
+      ),
+    [pendingSummaries, rootStreamId, workflowDashboard],
   );
   const childListValues = useMemo<readonly ChildListValue[]>(
     () =>

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -312,11 +312,7 @@ export function App(props: AppProps): React.JSX.Element {
     () =>
       groupPendingApprovalsByRow(
         pendingSummaries,
-        visibleApprovalRootStreamId(
-          rootStreamId,
-          childListTarget.streamId,
-          workflowDashboard?.root.streamId,
-        ),
+        visibleApprovalRootStreamId(rootStreamId, childListTarget.streamId),
       ),
     [
       childListTarget.streamId,
@@ -331,7 +327,12 @@ export function App(props: AppProps): React.JSX.Element {
       sessionViews.map((session) => childStreamListValue(session.id)),
     [sessionViews, workflowDashboard],
   );
-  const childListAvailable = childListValues.length > 0;
+  const workflowDashboardRootHasApproval =
+    workflowDashboard !== undefined &&
+    (pendingApprovalsForRows.get(workflowDashboard.root.streamId)?.length ??
+      0) > 0;
+  const childListAvailable =
+    childListValues.length > 0 || workflowDashboardRootHasApproval;
   const selectedWorkflowTask =
     selectedChildValue && workflowDashboard
       ? workflowDashboard.taskByValue.get(selectedChildValue)
@@ -404,10 +405,10 @@ export function App(props: AppProps): React.JSX.Element {
   }, []);
   const focusChildList = useCallback(() => {
     const firstChildValue = childListValues.at(0);
-    if (firstChildValue) {
+    if (firstChildValue || workflowDashboardRootHasApproval) {
       dispatchChildListSelection({ kind: 'focus', value: firstChildValue });
     }
-  }, [childListValues]);
+  }, [childListValues, workflowDashboardRootHasApproval]);
   const focusSession = useCallback(
     (streamId: StreamTabId) => {
       if (isWorkflowTaskListValue(selectedChildValue)) {
@@ -808,6 +809,7 @@ export function App(props: AppProps): React.JSX.Element {
           selectedChildValue,
           selectedChildStreamId,
           workflowDashboard,
+          workflowDashboardRootHasApproval,
           streams,
           subagentExecutionLabels,
           activeSubagentExecutionIds,

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -39,6 +39,7 @@ import {
   shouldDeferEscapeInterruptForMetaChord,
   triggerAppCtrlC,
   triggerEscapeInterrupt,
+  visibleApprovalRootStreamId,
   type EscapeInterruptState,
 } from './appInteractionPolicy';
 import { ApprovalModal } from './modals/ApprovalModal';
@@ -311,7 +312,10 @@ export function App(props: AppProps): React.JSX.Element {
     () =>
       groupPendingApprovalsByRow(
         pendingSummaries,
-        workflowDashboard?.root.streamId ?? rootStreamId,
+        visibleApprovalRootStreamId(
+          rootStreamId,
+          workflowDashboard?.root.streamId,
+        ),
       ),
     [pendingSummaries, rootStreamId, workflowDashboard],
   );

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -314,10 +314,16 @@ export function App(props: AppProps): React.JSX.Element {
         pendingSummaries,
         visibleApprovalRootStreamId(
           rootStreamId,
+          childListTarget.streamId,
           workflowDashboard?.root.streamId,
         ),
       ),
-    [pendingSummaries, rootStreamId, workflowDashboard],
+    [
+      childListTarget.streamId,
+      pendingSummaries,
+      rootStreamId,
+      workflowDashboard,
+    ],
   );
   const childListValues = useMemo<readonly ChildListValue[]>(
     () =>

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -114,12 +114,15 @@ interface InputEventEmitterLike {
 }
 
 // Jump-to-waiting: surface the newly focused stream's pending approval right
-// away instead of leaving it queued behind other streams' items. The root
-// row also owns session-wide (stream-less) approvals.
-function focusStreamAndPromoteApprovals(streamId: StreamTabId): void {
+// away instead of leaving it queued behind other streams' items. The visible
+// list-root row also owns session-wide (stream-less) approvals.
+function focusStreamAndPromoteApprovals(
+  streamId: StreamTabId,
+  visibleListRootStreamId = rootStreamIdSignal.get(),
+): void {
   focusStream(streamId);
   promoteApprovalsForStream(streamId, {
-    includeSessionWide: streamId === rootStreamIdSignal.get(),
+    includeSessionWide: streamId === visibleListRootStreamId,
   });
 }
 
@@ -405,6 +408,9 @@ export function App(props: AppProps): React.JSX.Element {
         workflowDashboardRootHasApproval &&
         childListTarget.streamId !== undefined
       ) {
+        // The dashboard heading is not a selectable row. Focusing the list is
+        // therefore the jump-to-waiting action for its advertised root bucket,
+        // whether or not task rows already exist.
         promoteApprovalsForStream(childListTarget.streamId, {
           includeSessionWide: true,
         });
@@ -423,9 +429,9 @@ export function App(props: AppProps): React.JSX.Element {
       } else {
         dispatchChildListSelection({ kind: 'focusStream', streamId });
       }
-      focusStreamAndPromoteApprovals(streamId);
+      focusStreamAndPromoteApprovals(streamId, childListTarget.streamId);
     },
-    [selectedChildValue],
+    [childListTarget.streamId, selectedChildValue],
   );
   const foregroundKind = foregroundSurfaceKind({
     activeFormOpen: activeForm !== undefined,
@@ -551,7 +557,7 @@ export function App(props: AppProps): React.JSX.Element {
         zeroBasedIndex: digit - 1,
       });
       if (!target) return false;
-      focusStreamAndPromoteApprovals(target);
+      focusStreamAndPromoteApprovals(target, childListTarget.streamId);
       return true;
     }
     return false;
@@ -585,7 +591,7 @@ export function App(props: AppProps): React.JSX.Element {
     }
     const parentId = parentStreamSignal.get().get(streamId);
     if (parentId !== undefined) {
-      focusStreamAndPromoteApprovals(parentId);
+      focusStreamAndPromoteApprovals(parentId, childListTarget.streamId);
       if (
         selectedWorkflowChildStreamId === streamId &&
         workflowDashboard?.root.streamId === parentId

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -314,12 +314,7 @@ export function App(props: AppProps): React.JSX.Element {
         pendingSummaries,
         visibleApprovalRootStreamId(rootStreamId, childListTarget.streamId),
       ),
-    [
-      childListTarget.streamId,
-      pendingSummaries,
-      rootStreamId,
-      workflowDashboard,
-    ],
+    [childListTarget.streamId, pendingSummaries, rootStreamId],
   );
   const childListValues = useMemo<readonly ChildListValue[]>(
     () =>

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -116,10 +116,13 @@ interface InputEventEmitterLike {
 // Jump-to-waiting: surface the newly focused stream's pending approval right
 // away instead of leaving it queued behind other streams' items. The visible
 // list-root row also owns session-wide (stream-less) approvals.
-function focusStreamAndPromoteApprovals(
-  streamId: StreamTabId,
-  visibleListRootStreamId: StreamTabId | undefined,
-): void {
+function focusStreamAndPromoteApprovals(streamId: StreamTabId): void {
+  const visibleListRootStreamId = resolveChildListTarget({
+    activeStreamId: streamId,
+    childStreamEntries: childStreamEntriesSignal.get(),
+    parentStream: parentStreamSignal.get(),
+    streams: streamsSignal.get(),
+  }).streamId;
   focusStream(streamId);
   promoteApprovalsForStream(streamId, {
     includeSessionWide: streamId === visibleListRootStreamId,
@@ -408,12 +411,9 @@ export function App(props: AppProps): React.JSX.Element {
         workflowDashboardRootHasApproval &&
         childListTarget.streamId !== undefined
       ) {
-        // The dashboard heading is not a selectable row. Focusing the list is
-        // therefore the jump-to-waiting action for its advertised root bucket,
-        // whether or not task rows already exist.
-        promoteApprovalsForStream(childListTarget.streamId, {
-          includeSessionWide: true,
-        });
+        // The dashboard heading is not selectable, so focusing the list also
+        // focuses its root and presents the approval advertised there.
+        focusStreamAndPromoteApprovals(childListTarget.streamId);
       }
       dispatchChildListSelection({ kind: 'focus', value: firstChildValue });
     }
@@ -429,9 +429,9 @@ export function App(props: AppProps): React.JSX.Element {
       } else {
         dispatchChildListSelection({ kind: 'focusStream', streamId });
       }
-      focusStreamAndPromoteApprovals(streamId, childListTarget.streamId);
+      focusStreamAndPromoteApprovals(streamId);
     },
-    [childListTarget.streamId, selectedChildValue],
+    [selectedChildValue],
   );
   const foregroundKind = foregroundSurfaceKind({
     activeFormOpen: activeForm !== undefined,
@@ -557,7 +557,7 @@ export function App(props: AppProps): React.JSX.Element {
         zeroBasedIndex: digit - 1,
       });
       if (!target) return false;
-      focusStreamAndPromoteApprovals(target, childListTarget.streamId);
+      focusStreamAndPromoteApprovals(target);
       return true;
     }
     return false;
@@ -591,13 +591,7 @@ export function App(props: AppProps): React.JSX.Element {
     }
     const parentId = parentStreamSignal.get().get(streamId);
     if (parentId !== undefined) {
-      const destinationListRoot = resolveChildListTarget({
-        activeStreamId: parentId,
-        childStreamEntries: childStreamEntriesSignal.get(),
-        parentStream: parentStreamSignal.get(),
-        streams: streamsSignal.get(),
-      }).streamId;
-      focusStreamAndPromoteApprovals(parentId, destinationListRoot);
+      focusStreamAndPromoteApprovals(parentId);
       if (
         selectedWorkflowChildStreamId === streamId &&
         workflowDashboard?.root.streamId === parentId

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -401,9 +401,21 @@ export function App(props: AppProps): React.JSX.Element {
   const focusChildList = useCallback(() => {
     const firstChildValue = childListValues.at(0);
     if (firstChildValue || workflowDashboardRootHasApproval) {
+      if (
+        workflowDashboardRootHasApproval &&
+        childListTarget.streamId !== undefined
+      ) {
+        promoteApprovalsForStream(childListTarget.streamId, {
+          includeSessionWide: true,
+        });
+      }
       dispatchChildListSelection({ kind: 'focus', value: firstChildValue });
     }
-  }, [childListValues, workflowDashboardRootHasApproval]);
+  }, [
+    childListTarget.streamId,
+    childListValues,
+    workflowDashboardRootHasApproval,
+  ]);
   const focusSession = useCallback(
     (streamId: StreamTabId) => {
       if (isWorkflowTaskListValue(selectedChildValue)) {

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -257,9 +257,10 @@ export function foregroundMaxRowsForKind({
 }
 
 // Group the flat FIFO summaries per row, folding stream-less (session-wide)
-// approvals onto the root/main row. Grouping from the flat list keeps each
-// row's first shown kind the first-to-present even when the root's own and
-// session-wide items interleave in the global queue.
+// approvals onto the root of the visible surface: normally the main row, or
+// the workflow-dashboard heading while that surface replaces the session
+// list. Grouping from the flat list keeps each row's first shown kind the
+// first-to-present even when bound and stream-less items interleave globally.
 export function groupPendingApprovalsByRow(
   summaries: readonly PendingApprovalSummary[],
   rootStreamId: StreamTabId | undefined,

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -283,9 +283,14 @@ export function groupPendingApprovalsByRow(
 /** Row key that owns stream-less approvals on the currently visible surface. */
 export function visibleApprovalRootStreamId(
   sessionRootStreamId: StreamTabId | undefined,
+  childListRootStreamId: StreamTabId | undefined,
   workflowDashboardRootStreamId: StreamTabId | undefined,
 ): StreamTabId | undefined {
-  return workflowDashboardRootStreamId ?? sessionRootStreamId;
+  return (
+    workflowDashboardRootStreamId ??
+    childListRootStreamId ??
+    sessionRootStreamId
+  );
 }
 
 // A workflow-script grandchild `agent()` call is the only interactively

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -284,13 +284,8 @@ export function groupPendingApprovalsByRow(
 export function visibleApprovalRootStreamId(
   sessionRootStreamId: StreamTabId | undefined,
   childListRootStreamId: StreamTabId | undefined,
-  workflowDashboardRootStreamId: StreamTabId | undefined,
 ): StreamTabId | undefined {
-  return (
-    workflowDashboardRootStreamId ??
-    childListRootStreamId ??
-    sessionRootStreamId
-  );
+  return childListRootStreamId ?? sessionRootStreamId;
 }
 
 // A workflow-script grandchild `agent()` call is the only interactively

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -280,6 +280,14 @@ export function groupPendingApprovalsByRow(
   );
 }
 
+/** Row key that owns stream-less approvals on the currently visible surface. */
+export function visibleApprovalRootStreamId(
+  sessionRootStreamId: StreamTabId | undefined,
+  workflowDashboardRootStreamId: StreamTabId | undefined,
+): StreamTabId | undefined {
+  return workflowDashboardRootStreamId ?? sessionRootStreamId;
+}
+
 // A workflow-script grandchild `agent()` call is the only interactively
 // skip/retry-able row: a NATIVE agent run (no external CLI tool — those
 // children are driven by their own tool and would no-op here) whose parent

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -190,8 +190,7 @@ export function ConversationRegion({
       : snapshot.sessionViews.length;
   const approvalOnlyDashboard =
     snapshot.workflowDashboardRootHasApproval &&
-    snapshot.workflowDashboard?.groups.length === 0 &&
-    snapshot.workflowDashboard.tasks.length === 0;
+    workflowDashboardItemCount === 1;
   const minimumSessionPanelRows =
     workflowDashboardItemCount > 0 && !approvalOnlyDashboard ? 3 : 2;
   const {

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -188,9 +188,7 @@ export function ConversationRegion({
     workflowDashboardItemCount > 0
       ? workflowDashboardItemCount
       : snapshot.sessionViews.length;
-  const approvalOnlyDashboard =
-    snapshot.workflowDashboardRootHasApproval &&
-    workflowDashboardItemCount === 1;
+  const approvalOnlyDashboard = workflowDashboardItemCount === 1;
   const minimumSessionPanelRows =
     workflowDashboardItemCount > 0 && !approvalOnlyDashboard ? 3 : 2;
   const {

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -62,6 +62,7 @@ interface ConversationRegionSnapshot {
   readonly selectedChildStreamId: StreamTabId | undefined;
   /** Dashboard rows for a workflow-script list root, derived once by `App`. */
   readonly workflowDashboard: WorkflowDashboardModel | undefined;
+  readonly workflowDashboardRootHasApproval: boolean;
   readonly childListFocused: boolean;
   readonly sessionViews: readonly StreamView[];
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
@@ -181,12 +182,18 @@ export function ConversationRegion({
   const workflowDashboardItemCount = workflowDashboardPanelItemCount(
     snapshot.workflowDashboard,
     snapshot.selectedChildValue,
+    snapshot.workflowDashboardRootHasApproval,
   );
   const sessionPanelItemCount =
     workflowDashboardItemCount > 0
       ? workflowDashboardItemCount
       : snapshot.sessionViews.length;
-  const minimumSessionPanelRows = workflowDashboardItemCount > 0 ? 3 : 2;
+  const approvalOnlyDashboard =
+    snapshot.workflowDashboardRootHasApproval &&
+    snapshot.workflowDashboard?.groups.length === 0 &&
+    snapshot.workflowDashboard.tasks.length === 0;
+  const minimumSessionPanelRows =
+    workflowDashboardItemCount > 0 && !approvalOnlyDashboard ? 3 : 2;
   const {
     bottomPanelRows: bottomPanelBudget,
     conversationRows,

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -133,8 +133,8 @@ function SessionRow({
     nowMs,
   );
   // Significance order — the summary segment sheds first (flexShrink 2), then
-  // this truncate-end text sheds inline elapsed (narrow mode only), the round,
-  // and last the pending-approval kind. The metadata column never shrinks.
+  // this truncate-end text sheds inline elapsed, model, stage, and label. The
+  // approval kind and metadata column never shrink.
   const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
   const stageLabel = formatStageLabel(session.slice?.stage);
   // The resolved model is per-agent identity (a workflow run's grandchildren
@@ -188,7 +188,6 @@ function SessionRow({
         <Text bold={active} wrap="truncate-end">
           {session.label}
           {statusLabel ? ` ${statusLabel}` : ''}
-          {approvalSuffix ? ` · ${approvalSuffix}` : ''}
           {stageLabel ? ` · ${stageLabel}` : ''}
           {modelLabel ? ` · ${modelLabel}` : ''}
           {!metadataColumn && elapsed ? ` · ${elapsed}` : ''}
@@ -199,6 +198,11 @@ function SessionRow({
           <Text dimColor wrap="truncate-end">
             {` · ${truncateSummaryToWidth(summary, SUBAGENT_SUMMARY_MAX_COLUMNS)}`}
           </Text>
+        </Box>
+      ) : null}
+      {approvalSuffix ? (
+        <Box flexShrink={0}>
+          <Text>{` · ${approvalSuffix}`}</Text>
         </Box>
       ) : null}
       {focused && hiddenRowSummary ? (

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -132,9 +132,9 @@ function SessionRow({
     },
     nowMs,
   );
-  // Significance order — the summary segment sheds first (flexShrink 2), then
-  // this truncate-end text sheds inline elapsed, model, stage, and label. The
-  // approval kind and metadata column never shrink.
+  // Significance order — informational counts shed first, then the summary,
+  // then this truncate-end text sheds inline elapsed, model, stage, and label.
+  // The actionable approval kind and metadata column never shrink.
   const approval = pendingApprovalRowDisplay(pendingKinds);
   const stageLabel = formatStageLabel(session.slice?.stage);
   // The resolved model is per-agent identity (a workflow run's grandchildren
@@ -147,8 +147,8 @@ function SessionRow({
       : undefined;
   const modelLabel = model ? getRuntimeModelLabel(model) : undefined;
   // The right-aligned `elapsed · ↓tokens` column is pushed to the terminal edge
-  // so the figures line up across rows. Non-shrinking: the summary segment
-  // yields first; rows drop the column entirely on narrow terminals (see
+  // so the figures line up across rows. Lower-priority inline segments yield;
+  // rows drop the column entirely on narrow terminals (see
   // `CHILD_ROW_METADATA_MIN_COLUMNS`).
   const metadata = metadataColumn
     ? childRowMetadataText({
@@ -211,8 +211,8 @@ function SessionRow({
         </Box>
       ) : null}
       {focused && hiddenRowSummary ? (
-        <Box flexShrink={0}>
-          <Text dimColor>{` · ${hiddenRowSummary}`}</Text>
+        <Box minWidth={0} flexShrink={4}>
+          <Text dimColor wrap="truncate-end">{` · ${hiddenRowSummary}`}</Text>
         </Box>
       ) : null}
       {metadata ? (

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -65,7 +65,7 @@ import {
   CHILD_STATUS_MARKER,
   childRowMetadataText,
   childStatusColor,
-  pendingApprovalRowSuffix,
+  pendingApprovalRowDisplay,
 } from './SubagentListDisplay';
 import type { PendingApprovalKind } from '../state/approvalQueue';
 import type { StreamSlice } from '../state/cliState';
@@ -135,7 +135,7 @@ function SessionRow({
   // Significance order — the summary segment sheds first (flexShrink 2), then
   // this truncate-end text sheds inline elapsed, model, stage, and label. The
   // approval kind and metadata column never shrink.
-  const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
+  const approval = pendingApprovalRowDisplay(pendingKinds);
   const stageLabel = formatStageLabel(session.slice?.stage);
   // The resolved model is per-agent identity (a workflow run's grandchildren
   // can each resolve a different model); the list-root row is the conversation
@@ -200,9 +200,14 @@ function SessionRow({
           </Text>
         </Box>
       ) : null}
-      {approvalSuffix ? (
+      {approval ? (
         <Box flexShrink={0}>
-          <Text>{` · ${approvalSuffix}`}</Text>
+          <Text>{` · ${approval.label}`}</Text>
+        </Box>
+      ) : null}
+      {approval?.overflow ? (
+        <Box minWidth={0} flexShrink={3}>
+          <Text wrap="truncate-end">{` ${approval.overflow}`}</Text>
         </Box>
       ) : null}
       {focused && hiddenRowSummary ? (
@@ -272,7 +277,7 @@ function WorkflowTaskRow({
 }): React.JSX.Element {
   const style = WORKFLOW_TASK_STATUS_STYLE[entry.task.status];
   const metadata = workflowTaskMetadata(entry.task, child, nowMs);
-  const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
+  const approval = pendingApprovalRowDisplay(pendingKinds);
   return (
     <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
       <Text aria-hidden color={focused ? COLOR_HINT : undefined}>
@@ -284,9 +289,14 @@ function WorkflowTaskRow({
           {entry.task.label} · {WORKFLOW_TASK_STATUS_LABEL[entry.task.status]}
         </Text>
       </Box>
-      {approvalSuffix ? (
+      {approval ? (
         <Box flexShrink={0}>
-          <Text>{` · ${approvalSuffix}`}</Text>
+          <Text>{` · ${approval.label}`}</Text>
+        </Box>
+      ) : null}
+      {approval?.overflow ? (
+        <Box minWidth={0} flexShrink={3}>
+          <Text wrap="truncate-end">{` ${approval.overflow}`}</Text>
         </Box>
       ) : null}
       {metadata ? (
@@ -384,17 +394,15 @@ function WorkflowDashboard({
     { isActive: keyboardActive },
   );
 
-  const sessionApprovalSuffix = pendingApprovalRowSuffix(
+  const sessionApproval = pendingApprovalRowDisplay(
     pendingApprovals?.get(model.root.streamId),
   );
   const approvalOnlyDashboard =
-    tasks.length === 0 &&
-    groups.length === 0 &&
-    sessionApprovalSuffix !== undefined;
+    tasks.length === 0 && groups.length === 0 && sessionApproval !== undefined;
   if (
     (tasks.length === 0 &&
       groups.length === 0 &&
-      sessionApprovalSuffix === undefined) ||
+      sessionApproval === undefined) ||
     (contentRows !== undefined && contentRows <= 0 && !approvalOnlyDashboard)
   ) {
     return null;
@@ -469,10 +477,17 @@ function WorkflowDashboard({
             </Text>
           </Box>
         ) : null}
-        {sessionApprovalSuffix ? (
+        {sessionApproval ? (
           <Box flexShrink={0}>
             <Text bold color={COLOR_WARNING}>
-              {` · ${sessionApprovalSuffix}`}
+              {` · ${sessionApproval.label}`}
+            </Text>
+          </Box>
+        ) : null}
+        {sessionApproval?.overflow ? (
+          <Box minWidth={0} flexShrink={3}>
+            <Text bold color={COLOR_WARNING} wrap="truncate-end">
+              {` ${sessionApproval.overflow}`}
             </Text>
           </Box>
         ) : null}

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -380,17 +380,19 @@ function WorkflowDashboard({
     { isActive: keyboardActive },
   );
 
+  const sessionApprovalSuffix = pendingApprovalRowSuffix(
+    pendingApprovals?.get(model.root.streamId),
+  );
   if (
-    (tasks.length === 0 && groups.length === 0) ||
+    (tasks.length === 0 &&
+      groups.length === 0 &&
+      sessionApprovalSuffix === undefined) ||
     (contentRows !== undefined && contentRows <= 0)
   ) {
     return null;
   }
   const heading = `${model.root.agent ?? 'Workflow'} · ${done}/${total} done`;
   const { failed } = workflowCallFailureTally(calls);
-  const sessionApprovalSuffix = pendingApprovalRowSuffix(
-    pendingApprovals?.get(model.root.streamId),
-  );
   const renderTask = (
     item: SelectItem<ChildListValue>,
     state: { readonly focused: boolean },

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -383,11 +383,15 @@ function WorkflowDashboard({
   const sessionApprovalSuffix = pendingApprovalRowSuffix(
     pendingApprovals?.get(model.root.streamId),
   );
+  const approvalOnlyDashboard =
+    tasks.length === 0 &&
+    groups.length === 0 &&
+    sessionApprovalSuffix !== undefined;
   if (
     (tasks.length === 0 &&
       groups.length === 0 &&
       sessionApprovalSuffix === undefined) ||
-    (contentRows !== undefined && contentRows <= 0)
+    (contentRows !== undefined && contentRows <= 0 && !approvalOnlyDashboard)
   ) {
     return null;
   }

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -544,14 +544,15 @@ export interface SubagentListProps {
   readonly onSelectionChange?: (value: ChildListValue) => void;
   /**
    * Pending approval kinds per stream id (see `pendingApprovalSummaries`; the
-   * caller folds session-wide / stream-less approvals onto the root stream id
-   * via `groupPendingApprovalsByRow`).
+   * caller folds stream-less approvals onto the visible surface root via
+   * `groupPendingApprovalsByRow`).
    *
    * When `dashboard` is present, per-task buckets render on their task rows and
-   * the root-folded session-wide bucket (plan, proposal, stream-less retry,
-   * …) renders in the dashboard heading. The queue remains the authority for
-   * approval identity and order; this map only projects that state onto the
-   * rows which present it.
+   * the root-folded stream-less bucket renders in the dashboard heading.
+   * Stream-bound plan, proposal, and retry approvals remain keyed to their
+   * actual owning stream. The queue remains the authority for approval
+   * identity and order; this map only projects that state onto the rows which
+   * present it.
    */
   readonly pendingApprovals?: ReadonlyMap<
     string,

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -388,6 +388,9 @@ function WorkflowDashboard({
   }
   const heading = `${model.root.agent ?? 'Workflow'} · ${done}/${total} done`;
   const { failed } = workflowCallFailureTally(calls);
+  const sessionApprovalSuffix = pendingApprovalRowSuffix(
+    pendingApprovals?.get(model.root.streamId),
+  );
   const renderTask = (
     item: SelectItem<ChildListValue>,
     state: { readonly focused: boolean },
@@ -441,12 +444,23 @@ function WorkflowDashboard({
       paddingX={1}
       width={columns}
     >
-      <Text bold wrap="truncate-end">
-        {heading}
+      <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
+        <Box minWidth={0} flexShrink={1}>
+          <Text bold wrap="truncate-end">
+            {heading}
+          </Text>
+        </Box>
         {failed > 0 ? (
           <Text bold color={COLOR_WARNING}>{` · ${failed} failed`}</Text>
         ) : null}
-      </Text>
+        {sessionApprovalSuffix ? (
+          <Box flexShrink={0}>
+            <Text bold color={COLOR_WARNING}>
+              {` · waiting: ${sessionApprovalSuffix}`}
+            </Text>
+          </Box>
+        ) : null}
+      </Box>
       {wide ? (
         <Box flexDirection="row" height={contentRows} minWidth={0}>
           <Box flexDirection="column" width="32%" paddingRight={1}>
@@ -533,13 +547,11 @@ export interface SubagentListProps {
    * caller folds session-wide / stream-less approvals onto the root stream id
    * via `groupPendingApprovalsByRow`).
    *
-   * When `dashboard` is present, the dashboard replaces the session list and
-   * renders only per-task rows keyed by each task's child stream id. There is
-   * no root row, so the root-folded session-wide bucket (plan, proposal,
-   * stream-less retry, …) is not rendered by the dashboard — it remains
-   * visible only through the global approval count. This pane is therefore
-   * intentionally scoped to per-task agent approvals while a dashboard is
-   * displayed.
+   * When `dashboard` is present, per-task buckets render on their task rows and
+   * the root-folded session-wide bucket (plan, proposal, stream-less retry,
+   * …) renders in the dashboard heading. The queue remains the authority for
+   * approval identity and order; this map only projects that state onto the
+   * rows which present it.
    */
   readonly pendingApprovals?: ReadonlyMap<
     string,

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -528,8 +528,19 @@ export interface SubagentListProps {
     action: WorkflowControlAction,
   ) => void;
   readonly onSelectionChange?: (value: ChildListValue) => void;
-  /** Pending approval kinds per stream id (see `pendingApprovalSummaries`,
-   *  root bucket already folded onto the root stream id by the caller). */
+  /**
+   * Pending approval kinds per stream id (see `pendingApprovalSummaries`; the
+   * caller folds session-wide / stream-less approvals onto the root stream id
+   * via `groupPendingApprovalsByRow`).
+   *
+   * When `dashboard` is present, the dashboard replaces the session list and
+   * renders only per-task rows keyed by each task's child stream id. There is
+   * no root row, so the root-folded session-wide bucket (plan, proposal,
+   * stream-less retry, …) is not rendered by the dashboard — it remains
+   * visible only through the global approval count. This pane is therefore
+   * intentionally scoped to per-task agent approvals while a dashboard is
+   * displayed.
+   */
   readonly pendingApprovals?: ReadonlyMap<
     string,
     readonly PendingApprovalKind[]

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -453,7 +453,11 @@ function WorkflowDashboard({
         {failed > 0 ? (
           // A pending approval needs action, so this tally yields before the
           // fixed approval suffix when the two cannot both fit.
-          <Text bold color={COLOR_WARNING}>{` · ${failed} failed`}</Text>
+          <Box minWidth={0} flexShrink={2}>
+            <Text bold color={COLOR_WARNING} wrap="truncate-end">
+              {` · ${failed} failed`}
+            </Text>
+          </Box>
         ) : null}
         {sessionApprovalSuffix ? (
           <Box flexShrink={0}>

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -451,12 +451,14 @@ function WorkflowDashboard({
           </Text>
         </Box>
         {failed > 0 ? (
+          // A pending approval needs action, so this tally yields before the
+          // fixed approval suffix when the two cannot both fit.
           <Text bold color={COLOR_WARNING}>{` · ${failed} failed`}</Text>
         ) : null}
         {sessionApprovalSuffix ? (
           <Box flexShrink={0}>
             <Text bold color={COLOR_WARNING}>
-              {` · waiting: ${sessionApprovalSuffix}`}
+              {` · ${sessionApprovalSuffix}`}
             </Text>
           </Box>
         ) : null}

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -91,13 +91,18 @@ export function childRowMetadataText({
   return parts.length > 0 ? parts.join(' · ') : undefined;
 }
 
-/** One-word "waiting on what" suffix for a session row: the row's first
- *  pending approval kind, plus a `+N` overflow when more are queued. */
-export function pendingApprovalRowSuffix(
+/** Compact "waiting on what" display for a row. The first kind and overflow
+ * count are separate so narrow layouts can preserve the actionable kind while
+ * allowing the informational count to yield. */
+export function pendingApprovalRowDisplay(
   kinds: readonly PendingApprovalKind[] | undefined,
-): string | undefined {
+):
+  | { readonly label: string; readonly overflow: string | undefined }
+  | undefined {
   const first = kinds?.[0];
   if (kinds === undefined || first === undefined) return undefined;
-  const label = PENDING_APPROVAL_ROW_LABELS[first];
-  return kinds.length > 1 ? `${label} +${kinds.length - 1}` : label;
+  return {
+    label: PENDING_APPROVAL_ROW_LABELS[first],
+    overflow: kinds.length > 1 ? `+${kinds.length - 1}` : undefined,
+  };
 }

--- a/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
+++ b/packages/cli/src/chat/tui/state/workflowDashboardModel.ts
@@ -180,9 +180,11 @@ export function workflowDashboardModel(
 export function workflowDashboardPanelItemCount(
   model: WorkflowDashboardModel | undefined,
   selectedValue: ChildListValue | undefined,
+  rootHasApproval: boolean,
 ): number {
-  if (!model || (model.groups.length === 0 && model.tasks.length === 0)) {
-    return 0;
+  if (!model) return 0;
+  if (model.groups.length === 0 && model.tasks.length === 0) {
+    return rootHasApproval ? 1 : 0;
   }
   if (!model.wide) {
     return 1 + model.groups.length + model.tasks.length;

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -10,6 +10,7 @@ import { App, type AppProps } from '@cli/chat/tui/App';
 import { ESC_META_CHORD_INTERRUPT_DELAY_MS } from '@cli/chat/tui/appInteractionPolicy';
 import {
   clearApprovals,
+  currentApproval,
   enqueueApproval,
 } from '@cli/chat/tui/state/approvalQueue';
 import { POINTER } from '@cli/tui/ui/glyphs';
@@ -1144,7 +1145,7 @@ describe('App foreground Escape ownership', () => {
 });
 
 describe('App workflow dashboard ownership', () => {
-  it('allocates an approval-only dashboard before workflow rows exist', async () => {
+  it('promotes an approval-only dashboard before workflow rows exist', async () => {
     seedRootStream();
     patchStream(ROOT, (slice) => ({
       ...slice,
@@ -1182,9 +1183,15 @@ describe('App workflow dashboard ownership', () => {
 
     try {
       stdin.write('\t');
-      await waitFor(() =>
-        stdout.output.includes('Starting workflow · 0/0 done · inquiry'),
+      await waitFor(
+        () =>
+          currentApproval.get()?.payload.payload.requestId ===
+          'external-session',
       );
+      await waitFor(() =>
+        stdout.output.includes('Verify the workflow before it emits rows.'),
+      );
+      expect(stdout.output).not.toContain('Wait outside the active stream.');
     } finally {
       instance.unmount();
     }

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -1144,7 +1144,55 @@ describe('App foreground Escape ownership', () => {
   });
 });
 
-describe('App workflow dashboard ownership', () => {
+describe('App approval surface ownership', () => {
+  it('promotes a session-wide approval from a scoped-list root', async () => {
+    seedChildHierarchy();
+    focusStream(GRANDCHILD);
+    void enqueueApproval({
+      kind: 'externalInquiry',
+      payload: {
+        requestId: 'external-other-scoped',
+        mode: 'followUp',
+        question: 'Wait outside the scoped list.',
+        threadId: 'ei_000000000003',
+        allowBypass: false,
+        streamId: 'other-stream',
+      },
+    });
+    void enqueueApproval({
+      kind: 'externalInquiry',
+      payload: {
+        requestId: 'external-session-scoped',
+        mode: 'followUp',
+        question: 'Verify the scoped child session.',
+        threadId: 'ei_000000000004',
+        allowBypass: false,
+        streamId: '',
+      },
+    });
+    const { instance, stdin, stdout } = await renderApp(appProps(vi.fn()));
+
+    try {
+      stdin.write('\t');
+      await waitFor(() => stdout.output.includes('inquiry'));
+      stdin.write(ARROW_KEYS.Up);
+      stdin.write('\r');
+      await waitFor(() => {
+        const pending = currentApproval.get()?.payload;
+        return (
+          pending?.kind === 'externalInquiry' &&
+          pending.payload.requestId === 'external-session-scoped'
+        );
+      });
+      await waitFor(() =>
+        stdout.output.includes('Verify the scoped child session.'),
+      );
+      expect(stdout.output).not.toContain('Wait outside the scoped list.');
+    } finally {
+      instance.unmount();
+    }
+  });
+
   it('promotes an approval-only dashboard before workflow rows exist', async () => {
     seedRootStream();
     patchStream(ROOT, (slice) => ({

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -8,6 +8,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { App, type AppProps } from '@cli/chat/tui/App';
 import { ESC_META_CHORD_INTERRUPT_DELAY_MS } from '@cli/chat/tui/appInteractionPolicy';
+import {
+  clearApprovals,
+  enqueueApproval,
+} from '@cli/chat/tui/state/approvalQueue';
 import { POINTER } from '@cli/tui/ui/glyphs';
 import type { InputHistory } from '@cli/chat/tui/history/inputHistory';
 import {
@@ -178,7 +182,10 @@ function fakeHistory(entries: readonly string[]): InputHistory {
 }
 
 beforeEach(() => resetCliState());
-afterEach(() => resetCliState());
+afterEach(() => {
+  clearApprovals();
+  resetCliState();
+});
 
 describe('App foreground Escape ownership', () => {
   it('lets a foreground information pane own Escape before child back', async () => {
@@ -1130,6 +1137,54 @@ describe('App foreground Escape ownership', () => {
       await waitFor(() => stdout.output.includes('latest prompt'));
 
       expect(stdout.output).not.toContain('Choosing a session');
+    } finally {
+      instance.unmount();
+    }
+  });
+});
+
+describe('App workflow dashboard ownership', () => {
+  it('allocates an approval-only dashboard before workflow rows exist', async () => {
+    seedRootStream();
+    patchStream(ROOT, (slice) => ({
+      ...slice,
+      agent: 'Starting workflow',
+      category: AgentCategory.Workflow,
+      identity: {
+        kind: 'multiAgentWorkflow',
+        workflowName: 'starting-workflow',
+      },
+      entries: [],
+    }));
+    void enqueueApproval({
+      kind: 'externalInquiry',
+      payload: {
+        requestId: 'external-other',
+        mode: 'followUp',
+        question: 'Wait outside the active stream.',
+        threadId: 'ei_000000000001',
+        allowBypass: false,
+        streamId: 'other-stream',
+      },
+    });
+    void enqueueApproval({
+      kind: 'externalInquiry',
+      payload: {
+        requestId: 'external-session',
+        mode: 'followUp',
+        question: 'Verify the workflow before it emits rows.',
+        threadId: 'ei_000000000002',
+        allowBypass: false,
+        streamId: '',
+      },
+    });
+    const { instance, stdin, stdout } = await renderApp(appProps(vi.fn()));
+
+    try {
+      stdin.write('\t');
+      await waitFor(() =>
+        stdout.output.includes('Starting workflow · 0/0 done · inquiry'),
+      );
     } finally {
       instance.unmount();
     }

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -1145,6 +1145,130 @@ describe('App foreground Escape ownership', () => {
 });
 
 describe('App approval surface ownership', () => {
+  it('promotes a session-wide approval when a child becomes the scoped root', async () => {
+    seedChildHierarchy();
+    focusStream(ROOT);
+    void enqueueApproval({
+      kind: 'externalInquiry',
+      payload: {
+        requestId: 'external-other-new-scope',
+        mode: 'followUp',
+        question: 'Wait outside the new scope.',
+        threadId: 'ei_000000000007',
+        allowBypass: false,
+        streamId: 'other-stream',
+      },
+    });
+    void enqueueApproval({
+      kind: 'externalInquiry',
+      payload: {
+        requestId: 'external-session-new-scope',
+        mode: 'followUp',
+        question: 'Verify the newly scoped child.',
+        threadId: 'ei_000000000008',
+        allowBypass: false,
+        streamId: '',
+      },
+    });
+    const { instance, stdin, stdout } = await renderApp(appProps(vi.fn()));
+
+    try {
+      stdin.write('\t');
+      await waitFor(() => stdout.output.includes('Choosing a session'));
+      stdin.write(ARROW_KEYS.Down);
+      await waitFor(() =>
+        stripAnsi(stdout.output)
+          .split('\n')
+          .some((line) => line.includes('child') && line.includes(POINTER)),
+      );
+      stdin.write('\r');
+      await waitFor(() => activeStreamId.get() === CHILD);
+      await waitFor(() => {
+        const pending = currentApproval.get()?.payload;
+        return (
+          pending?.kind === 'externalInquiry' &&
+          pending.payload.requestId === 'external-session-new-scope'
+        );
+      });
+      await waitFor(() =>
+        stdout.output.includes('Verify the newly scoped child.'),
+      );
+      expect(stdout.output).not.toContain('Wait outside the new scope.');
+    } finally {
+      instance.unmount();
+    }
+  });
+
+  it('focuses a dashboard root before presenting its bound approval', async () => {
+    seedRootStream();
+    setRunning(CHILD);
+    projectChildRoster(ROOT, [
+      runningChild('approval-task-execution', 'approval-task', CHILD),
+    ]);
+    setParentStream(CHILD, ROOT);
+    patchStream(ROOT, (slice) => ({
+      ...slice,
+      agent: 'approval-workflow',
+      identity: {
+        kind: 'multiAgentWorkflow' as const,
+        workflowName: 'approval-workflow',
+      },
+      category: AgentCategory.Workflow,
+      entries: [
+        {
+          id: 'approval-task',
+          role: 'workflowTask' as const,
+          text: 'Running: Approval task',
+          finalized: false,
+          task: {
+            id: 'approval-task',
+            label: 'Approval task',
+            status: 'running' as const,
+            childStreamId: CHILD,
+          },
+        },
+      ],
+    }));
+    focusStream(CHILD);
+    void enqueueApproval({
+      kind: 'externalInquiry',
+      payload: {
+        requestId: 'external-other-dashboard',
+        mode: 'followUp',
+        question: 'Wait outside the dashboard root.',
+        threadId: 'ei_000000000009',
+        allowBypass: false,
+        streamId: 'other-stream',
+      },
+    });
+    void enqueueApproval({
+      kind: 'planApproval',
+      payload: {
+        approvalId: 'plan-dashboard-root',
+        streamId: ROOT,
+        plan: { objective: 'Verify the dashboard root.' },
+        goalEnabled: false,
+      },
+    });
+    const { instance, stdin, stdout } = await renderApp(appProps(vi.fn()));
+
+    try {
+      stdin.write('\t');
+      await waitFor(() => activeStreamId.get() === ROOT);
+      await waitFor(() => {
+        const pending = currentApproval.get()?.payload;
+        return (
+          pending?.kind === 'planApproval' &&
+          pending.payload.approvalId === 'plan-dashboard-root'
+        );
+      });
+      await waitFor(() => stdout.output.includes('Approve plan?'));
+      expect(stdout.output).not.toContain('Wait outside the dashboard root.');
+    } finally {
+      instance.unmount();
+    }
+  });
+
   it('promotes a session-wide approval against the post-Escape root', async () => {
     seedChildHierarchy();
     focusStream(CHILD);

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -1145,6 +1145,52 @@ describe('App foreground Escape ownership', () => {
 });
 
 describe('App approval surface ownership', () => {
+  it('promotes a session-wide approval against the post-Escape root', async () => {
+    seedChildHierarchy();
+    focusStream(CHILD);
+    void enqueueApproval({
+      kind: 'externalInquiry',
+      payload: {
+        requestId: 'external-other-after-escape',
+        mode: 'followUp',
+        question: 'Wait outside the destination root.',
+        threadId: 'ei_000000000005',
+        allowBypass: false,
+        streamId: 'other-stream',
+      },
+    });
+    void enqueueApproval({
+      kind: 'externalInquiry',
+      payload: {
+        requestId: 'external-session-after-escape',
+        mode: 'followUp',
+        question: 'Verify the destination root.',
+        threadId: 'ei_000000000006',
+        allowBypass: false,
+        streamId: '',
+      },
+    });
+    const { instance, stdin, stdout } = await renderApp(appProps(vi.fn()));
+
+    try {
+      stdin.write(ESC);
+      await waitFor(() => activeStreamId.get() === ROOT);
+      await waitFor(() => {
+        const pending = currentApproval.get()?.payload;
+        return (
+          pending?.kind === 'externalInquiry' &&
+          pending.payload.requestId === 'external-session-after-escape'
+        );
+      });
+      await waitFor(() =>
+        stdout.output.includes('Verify the destination root.'),
+      );
+      expect(stdout.output).not.toContain('Wait outside the destination root.');
+    } finally {
+      instance.unmount();
+    }
+  });
+
   it('promotes a session-wide approval from a scoped-list root', async () => {
     seedChildHierarchy();
     focusStream(GRANDCHILD);

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -1183,11 +1183,13 @@ describe('App workflow dashboard ownership', () => {
 
     try {
       stdin.write('\t');
-      await waitFor(
-        () =>
-          currentApproval.get()?.payload.payload.requestId ===
-          'external-session',
-      );
+      await waitFor(() => {
+        const pending = currentApproval.get()?.payload;
+        return (
+          pending?.kind === 'externalInquiry' &&
+          pending.payload.requestId === 'external-session'
+        );
+      });
       await waitFor(() =>
         stdout.output.includes('Verify the workflow before it emits rows.'),
       );

--- a/src/test-kernel/cli/AppInteractionPolicy.vitest.ts
+++ b/src/test-kernel/cli/AppInteractionPolicy.vitest.ts
@@ -14,6 +14,7 @@ import {
   shouldDeferEscapeInterruptForMetaChord,
   triggerAppCtrlC,
   triggerEscapeInterrupt,
+  visibleApprovalRootStreamId,
   type AppCtrlCState,
   type EscapeInterruptState,
   type ForegroundSurfaceKind,
@@ -109,6 +110,18 @@ function foregroundInput(
 }
 
 describe('app interaction policy', () => {
+  it('folds stream-less approvals onto the root of the visible surface', () => {
+    const sessionRoot = 'session-root' as StreamTabId;
+    const workflowRoot = 'workflow-root' as StreamTabId;
+
+    expect(visibleApprovalRootStreamId(sessionRoot, undefined)).toBe(
+      sessionRoot,
+    );
+    expect(visibleApprovalRootStreamId(sessionRoot, workflowRoot)).toBe(
+      workflowRoot,
+    );
+  });
+
   it.each([
     {
       scenario:

--- a/src/test-kernel/cli/AppInteractionPolicy.vitest.ts
+++ b/src/test-kernel/cli/AppInteractionPolicy.vitest.ts
@@ -113,17 +113,13 @@ describe('app interaction policy', () => {
   it('folds stream-less approvals onto the root of the visible surface', () => {
     const sessionRoot = 'session-root' as StreamTabId;
     const scopedListRoot = 'scoped-list-root' as StreamTabId;
-    const workflowRoot = 'workflow-root' as StreamTabId;
 
-    expect(visibleApprovalRootStreamId(sessionRoot, undefined, undefined)).toBe(
+    expect(visibleApprovalRootStreamId(sessionRoot, undefined)).toBe(
       sessionRoot,
     );
-    expect(
-      visibleApprovalRootStreamId(sessionRoot, scopedListRoot, undefined),
-    ).toBe(scopedListRoot);
-    expect(
-      visibleApprovalRootStreamId(sessionRoot, scopedListRoot, workflowRoot),
-    ).toBe(workflowRoot);
+    expect(visibleApprovalRootStreamId(sessionRoot, scopedListRoot)).toBe(
+      scopedListRoot,
+    );
   });
 
   it.each([

--- a/src/test-kernel/cli/AppInteractionPolicy.vitest.ts
+++ b/src/test-kernel/cli/AppInteractionPolicy.vitest.ts
@@ -112,14 +112,18 @@ function foregroundInput(
 describe('app interaction policy', () => {
   it('folds stream-less approvals onto the root of the visible surface', () => {
     const sessionRoot = 'session-root' as StreamTabId;
+    const scopedListRoot = 'scoped-list-root' as StreamTabId;
     const workflowRoot = 'workflow-root' as StreamTabId;
 
-    expect(visibleApprovalRootStreamId(sessionRoot, undefined)).toBe(
+    expect(visibleApprovalRootStreamId(sessionRoot, undefined, undefined)).toBe(
       sessionRoot,
     );
-    expect(visibleApprovalRootStreamId(sessionRoot, workflowRoot)).toBe(
-      workflowRoot,
-    );
+    expect(
+      visibleApprovalRootStreamId(sessionRoot, scopedListRoot, undefined),
+    ).toBe(scopedListRoot);
+    expect(
+      visibleApprovalRootStreamId(sessionRoot, scopedListRoot, workflowRoot),
+    ).toBe(workflowRoot);
   });
 
   it.each([

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -1324,6 +1324,37 @@ describe('CLI child list display model', () => {
     ).toBe(true);
   });
 
+  it('keeps a scoped-root approval visible when its label truncates', async () => {
+    const run = 'approval-run-with-a-deliberately-long-id' as StreamTabId;
+    const rootSlice = workflowAgentSlice(run, {
+      agent: 'A scoped conversation with a deliberately long label',
+      status: STREAM_PHASE.RUNNING,
+    });
+    const output = await renderSubagentList(
+      {
+        listRootStreamId: run,
+        maxRows: 3,
+        pendingApprovals: new Map([[run, ['externalInquiry']]]),
+        sessions: [
+          {
+            id: run,
+            label: 'A scoped conversation with a deliberately long label',
+            active: true,
+            slice: rootSlice,
+          },
+        ],
+      },
+      18,
+      { until: (frame) => frame.includes('inquiry') },
+    );
+
+    expect(output).toContain(' · inquiry');
+    expect(output).not.toContain('deliberately');
+    expect(
+      output.split('\n').every((line) => textDisplayWidth(line) <= 18),
+    ).toBe(true);
+  });
+
   it('keeps session-wide approvals visible in a workflow dashboard', async () => {
     const sessionRoot = 'session-root' as StreamTabId;
     const run = 'approval-run' as StreamTabId;

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -10,6 +10,7 @@ import {
   ConversationPane,
   workflowRunStatusSummary,
 } from '@cli/chat/tui/panes/ConversationPane';
+import { groupPendingApprovalsByRow } from '@cli/chat/tui/appInteractionPolicy';
 import {
   SubagentList,
   type SubagentListProps,
@@ -1307,6 +1308,7 @@ describe('CLI child list display model', () => {
   });
 
   it('keeps session-wide approvals visible in a workflow dashboard', async () => {
+    const sessionRoot = 'session-root' as StreamTabId;
     const run = 'approval-run' as StreamTabId;
     const child = 'approval-child' as StreamTabId;
     const rootSlice = workflowAgentSlice(run, {
@@ -1325,10 +1327,14 @@ describe('CLI child list display model', () => {
       {
         dashboard: workflowDashboardModel(rootSlice, 36),
         maxRows: 4,
-        pendingApprovals: new Map([
-          [run, ['planApproval', 'proposal']],
-          [child, ['bash']],
-        ]),
+        pendingApprovals: groupPendingApprovalsByRow(
+          [
+            { streamKey: '', kind: 'bash' },
+            { streamKey: sessionRoot, kind: 'planApproval' },
+            { streamKey: child, kind: 'toolEdit' },
+          ],
+          run,
+        ),
         selectedValue: workflowTaskListValue('task'),
         streams: new Map([
           [run, rootSlice],
@@ -1338,8 +1344,9 @@ describe('CLI child list display model', () => {
       36,
     );
 
-    expect(output).toContain('waiting: plan +1');
-    expect(output).toContain('Check · Running · bash');
+    expect(output).toContain('waiting: bash');
+    expect(output).toContain('Check · Running · edit');
+    expect(output).not.toContain('plan');
     expect(
       output.split('\n').every((line) => textDisplayWidth(line) <= 36),
     ).toBe(true);

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -21,6 +21,7 @@ import {
 } from '@cli/chat/tui/state/workflowDashboardModel';
 import { textDisplayWidth } from '@cli/runtime/terminalText';
 import {
+  childStreamListValue,
   workflowPhaseListValue,
   workflowTaskListValue,
 } from '@cli/chat/tui/state/childListSelection';
@@ -1357,6 +1358,41 @@ describe('CLI child list display model', () => {
     expect(output).toContain(' · inquiry');
     expect(output).not.toContain('+1');
     expect(output).not.toContain('deliberately');
+    expect(
+      output.split('\n').every((line) => textDisplayWidth(line) <= 18),
+    ).toBe(true);
+  });
+
+  it('keeps the approval kind when the hidden-session count also truncates', async () => {
+    const run = 'approval-root' as StreamTabId;
+    const childOne = 'approval-child-one' as StreamTabId;
+    const childTwo = 'approval-child-two' as StreamTabId;
+    const output = await renderSubagentList(
+      {
+        keyboardActive: true,
+        listRootStreamId: run,
+        maxRows: 2,
+        pendingApprovals: new Map([[run, ['proposal', 'proposal']]]),
+        selectedValue: childStreamListValue(run),
+        sessions: [
+          {
+            id: run,
+            label: 'A deliberately long scoped root',
+            active: true,
+            slice: workflowAgentSlice(run, {
+              status: STREAM_PHASE.RUNNING,
+            }),
+          },
+          session(childOne),
+          session(childTwo),
+        ],
+      },
+      18,
+      { until: (frame) => frame.includes('proposal') },
+    );
+
+    expect(output).toContain(' · proposal');
+    expect(output).not.toContain('sessions');
     expect(
       output.split('\n').every((line) => textDisplayWidth(line) <= 18),
     ).toBe(true);

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -1358,6 +1358,30 @@ describe('CLI child list display model', () => {
     ).toBe(true);
   });
 
+  it('shows a session approval before workflow dashboard rows exist', async () => {
+    const run = 'approval-run' as StreamTabId;
+    const rootSlice = workflowAgentSlice(run, {
+      agent: 'Starting workflow',
+      identity: {
+        kind: 'multiAgentWorkflow',
+        workflowName: 'starting-workflow',
+      },
+      status: STREAM_PHASE.RUNNING,
+      entries: [],
+    });
+    const output = await renderSubagentList(
+      {
+        dashboard: workflowDashboardModel(rootSlice, 40),
+        maxRows: 3,
+        pendingApprovals: new Map([[run, ['externalInquiry']]]),
+        streams: new Map([[run, rootSlice]]),
+      },
+      40,
+    );
+
+    expect(output).toContain('Starting workflow · 0/0 done · inquiry');
+  });
+
   // The right-aligned metadata column is the one row element `SubagentList`
   // drops purely on terminal width (`CHILD_ROW_METADATA_MIN_COLUMNS`), so it is
   // what proves a width test drives the width it names: through

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -156,15 +156,24 @@ describe('CLI child list display model', () => {
     const narrow = workflowDashboardModel(root, 99);
 
     expect(
-      workflowDashboardPanelItemCount(wide, workflowPhaseListValue('phase-a')),
+      workflowDashboardPanelItemCount(
+        wide,
+        workflowPhaseListValue('phase-a'),
+        false,
+      ),
     ).toBe(3);
     expect(
-      workflowDashboardPanelItemCount(wide, workflowTaskListValue('task-b-1')),
+      workflowDashboardPanelItemCount(
+        wide,
+        workflowTaskListValue('task-b-1'),
+        false,
+      ),
     ).toBe(6);
     expect(
       workflowDashboardPanelItemCount(
         narrow,
         workflowPhaseListValue('phase-a'),
+        false,
       ),
     ).toBe(10);
     // No workflow root, no reserved rows.
@@ -172,8 +181,16 @@ describe('CLI child list display model', () => {
       workflowDashboardPanelItemCount(
         undefined,
         workflowPhaseListValue('phase-a'),
+        false,
       ),
     ).toBe(0);
+
+    const empty = workflowDashboardModel(
+      workflowAgentSlice('empty-dashboard', { entries: [] }),
+      100,
+    );
+    expect(workflowDashboardPanelItemCount(empty, undefined, false)).toBe(0);
+    expect(workflowDashboardPanelItemCount(empty, undefined, true)).toBe(1);
   });
 
   it('omits static input and context counts from the live workflow band', () => {

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -1306,6 +1306,45 @@ describe('CLI child list display model', () => {
     ).toBe(true);
   });
 
+  it('keeps session-wide approvals visible in a workflow dashboard', async () => {
+    const run = 'approval-run' as StreamTabId;
+    const child = 'approval-child' as StreamTabId;
+    const rootSlice = workflowAgentSlice(run, {
+      agent: 'A workflow with a deliberately long name',
+      status: STREAM_PHASE.RUNNING,
+      entries: [
+        workflowTaskEntry('task', 'Running: Check', {
+          id: 'task',
+          label: 'Check',
+          status: 'running',
+          childStreamId: child,
+        }),
+      ],
+    });
+    const output = await renderSubagentList(
+      {
+        dashboard: workflowDashboardModel(rootSlice, 36),
+        maxRows: 4,
+        pendingApprovals: new Map([
+          [run, ['planApproval', 'proposal']],
+          [child, ['bash']],
+        ]),
+        selectedValue: workflowTaskListValue('task'),
+        streams: new Map([
+          [run, rootSlice],
+          [child, workflowAgentSlice(child, {})],
+        ]),
+      },
+      36,
+    );
+
+    expect(output).toContain('waiting: plan +1');
+    expect(output).toContain('Check · Running · bash');
+    expect(
+      output.split('\n').every((line) => textDisplayWidth(line) <= 36),
+    ).toBe(true);
+  });
+
   // The right-aligned metadata column is the one row element `SubagentList`
   // drops purely on terminal width (`CHILD_ROW_METADATA_MIN_COLUMNS`), so it is
   // what proves a width test drives the width it names: through

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -1325,11 +1325,11 @@ describe('CLI child list display model', () => {
     });
     const output = await renderSubagentList(
       {
-        dashboard: workflowDashboardModel(rootSlice, 36),
-        maxRows: 4,
+        dashboard: workflowDashboardModel(rootSlice, 18),
+        maxRows: 5,
         pendingApprovals: groupPendingApprovalsByRow(
           [
-            { streamKey: '', kind: 'bash' },
+            { streamKey: '', kind: 'externalInquiry' },
             { streamKey: sessionRoot, kind: 'planApproval' },
             { streamKey: child, kind: 'toolEdit' },
           ],
@@ -1341,14 +1341,14 @@ describe('CLI child list display model', () => {
           [child, workflowAgentSlice(child, {})],
         ]),
       },
-      36,
+      18,
     );
 
-    expect(output).toContain('waiting: bash');
-    expect(output).toContain('Check · Running · edit');
+    expect(output).toContain(' · inquiry');
+    expect(output).toContain('edit');
     expect(output).not.toContain('plan');
     expect(
-      output.split('\n').every((line) => textDisplayWidth(line) <= 36),
+      output.split('\n').every((line) => textDisplayWidth(line) <= 18),
     ).toBe(true);
   });
 

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -1321,12 +1321,18 @@ describe('CLI child list display model', () => {
           status: 'running',
           childStreamId: child,
         }),
+        workflowTaskEntry('failed-task', 'Failed: Refute', {
+          id: 'failed-task',
+          label: 'Refute',
+          status: 'failed',
+          error: 'Counterexample found.',
+        }),
       ],
     });
     const output = await renderSubagentList(
       {
         dashboard: workflowDashboardModel(rootSlice, 18),
-        maxRows: 5,
+        maxRows: 6,
         pendingApprovals: groupPendingApprovalsByRow(
           [
             { streamKey: '', kind: 'externalInquiry' },

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -4,7 +4,7 @@ import {
   CHILD_STATUS_MARKER,
   childRowMetadataText,
   childStatusColor,
-  pendingApprovalRowSuffix,
+  pendingApprovalRowDisplay,
 } from '@cli/chat/tui/panes/SubagentListDisplay';
 import {
   ConversationPane,
@@ -636,13 +636,19 @@ describe('CLI child list display model', () => {
   });
 
   it('summarizes what a row is waiting on from its pending approval kinds', () => {
-    expect(pendingApprovalRowSuffix(undefined)).toBeUndefined();
-    expect(pendingApprovalRowSuffix([])).toBeUndefined();
-    expect(pendingApprovalRowSuffix(['bash'])).toBe('bash');
-    expect(pendingApprovalRowSuffix(['externalInquiry'])).toBe('inquiry');
-    expect(pendingApprovalRowSuffix(['toolEdit', 'bash', 'userQuestion'])).toBe(
-      'edit +2',
-    );
+    expect(pendingApprovalRowDisplay(undefined)).toBeUndefined();
+    expect(pendingApprovalRowDisplay([])).toBeUndefined();
+    expect(pendingApprovalRowDisplay(['bash'])).toEqual({
+      label: 'bash',
+      overflow: undefined,
+    });
+    expect(pendingApprovalRowDisplay(['externalInquiry'])).toEqual({
+      label: 'inquiry',
+      overflow: undefined,
+    });
+    expect(
+      pendingApprovalRowDisplay(['toolEdit', 'bash', 'userQuestion']),
+    ).toEqual({ label: 'edit', overflow: '+2' });
   });
 
   it('moves selection through every session and wraps at the ends', () => {
@@ -1334,7 +1340,7 @@ describe('CLI child list display model', () => {
       {
         listRootStreamId: run,
         maxRows: 3,
-        pendingApprovals: new Map([[run, ['externalInquiry']]]),
+        pendingApprovals: new Map([[run, ['externalInquiry', 'proposal']]]),
         sessions: [
           {
             id: run,
@@ -1349,6 +1355,7 @@ describe('CLI child list display model', () => {
     );
 
     expect(output).toContain(' · inquiry');
+    expect(output).not.toContain('+1');
     expect(output).not.toContain('deliberately');
     expect(
       output.split('\n').every((line) => textDisplayWidth(line) <= 18),


### PR DESCRIPTION
## Summary

Closes #10128. The CLI now projects pending approvals onto the root of the surface that is actually visible: the ordinary session list, a nested scoped list, or the workflow dashboard. Per-task approvals remain on their task rows. An approval-only dashboard heading is allocated before any workflow phase or task rows exist.

The heading preserves the actionable approval kind on narrow terminals while lower-priority status text truncates.

## Ownership boundary

- The session approval queue owns request identity, FIFO order, stream binding, and the stream-less marker.
- The App layer derives a presentation-only row map. It folds only truly stream-less tool-edit, shell, inquiry, and question requests onto the visible surface root.
- Stream-bound plan, proposal, and retry requests remain keyed to their actual owning stream.
- Task rows and the dashboard heading only render this projection; they do not mutate queue state or reconstruct ownership.
- The global count remains a summary, not the only indication that action is required.

## Validation

- pnpm vitest run src/test-kernel/cli/AppEscapeRouting.vitest.ts src/test-kernel/cli/AppInteractionPolicy.vitest.ts src/test-kernel/cli/SubagentListDisplay.vitest.ts (91 tests passed)
- pnpm run typecheck:cli
- ESLint and Prettier on all changed files
- git diff --check