### PR TITLE
fix(ci): preserve docs build with remote agent gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
           files="$(git diff --name-only "$base...$head")"
           echo "Changed files in this PR:"
           printf '%s\n' "$files"
+          # Keep these docs-side paths synchronized with configPath and
+          # defaultOutputPath in scripts/sync-remote-agents.mjs.
           if printf '%s\n' "$files" | grep -qE '^docs/supabase/(SYNC_REMOTE_AGENTS\.sql|remote-agents\.config\.json)$'; then
             echo "remote_agent_docs=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       code: ${{ steps.detect.outputs.code }}
+      remote_agent_docs: ${{ steps.detect.outputs.remote_agent_docs }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -49,6 +50,7 @@ jobs:
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "Event '${{ github.event_name }}' -> full validation."
             echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "remote_agent_docs=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           base='${{ github.event.pull_request.base.sha }}'
@@ -56,11 +58,15 @@ jobs:
           files="$(git diff --name-only "$base...$head")"
           echo "Changed files in this PR:"
           printf '%s\n' "$files"
-          # A file counts as "code" unless it lives under docs/ (outside
-          # docs/supabase/, whose remote-agents config and generated SQL must
-          # still pass the drift check) or is a *.md file.
-          if printf '%s\n' "$files" | grep -vE '\.md$' | grep -vE '^docs/' | grep -q . \
-            || printf '%s\n' "$files" | grep -qE '^docs/supabase/'; then
+          if printf '%s\n' "$files" | grep -qE '^docs/supabase/(SYNC_REMOTE_AGENTS\.sql|remote-agents\.config\.json)$'; then
+            echo "remote_agent_docs=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "remote_agent_docs=false" >> "$GITHUB_OUTPUT"
+          fi
+          # A file counts as "code" unless it lives under docs/ or is a *.md
+          # file. Remote-agent docs keep this classification: their separate
+          # drift job must not suppress the public docs build.
+          if printf '%s\n' "$files" | grep -vE '\.md$' | grep -vE '^docs/' | grep -q .; then
             echo "Non-docs changes detected -> full validation."
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
@@ -149,6 +155,34 @@ jobs:
 
       - name: Check tsconfig paths are in sync with the root
         run: pnpm run check:tsconfig-paths
+
+      - name: Check remote-agents SQL is in sync
+        run: pnpm run check:remote-agents
+
+  remote-agent-docs:
+    name: remote-agents SQL sync
+    needs: changes
+    if: needs.changes.outputs.code != 'true' && needs.changes.outputs.remote_agent_docs == 'true' && github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Check remote-agents SQL is in sync
         run: pnpm run check:remote-agents
@@ -437,6 +471,7 @@ jobs:
     needs:
       - changes
       - checks
+      - remote-agent-docs
       - guidance-refs
       - test
       - build
@@ -470,6 +505,7 @@ jobs:
           fi
           for result in \
             'checks:${{ needs.checks.result }}' \
+            'remote-agent-docs:${{ needs.remote-agent-docs.result }}' \
             'test:${{ needs.test.result }}' \
             'build:${{ needs.build.result }}' \
             'webview-smoke:${{ needs.webview-smoke.result }}' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Check remote-agents SQL is in sync
         run: pnpm run check:remote-agents
@@ -526,5 +526,12 @@ jobs:
              [ '${{ needs.checks.result }}' = 'skipped' ] && \
              [ '${{ needs.docs-check.result }}' != 'success' ]; then
             echo 'Docs-only PR but docs build did not succeed: ${{ needs.docs-check.result }}'
+            exit 1
+          fi
+          if [ '${{ github.event_name }}' = 'pull_request' ] && \
+             [ '${{ needs.changes.outputs.code }}' != 'true' ] && \
+             [ '${{ needs.changes.outputs.remote_agent_docs }}' = 'true' ] && \
+             [ '${{ needs.remote-agent-docs.result }}' != 'success' ]; then
+            echo 'Remote-agent docs changed but SQL sync did not succeed: ${{ needs.remote-agent-docs.result }}'
             exit 1
           fi

--- a/scripts/sync-remote-agents.mjs
+++ b/scripts/sync-remote-agents.mjs
@@ -19,6 +19,8 @@ import YAML from 'yaml';
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const rootDir = resolve(scriptDir, '..');
 const remoteAgentsDir = resolve(rootDir, 'prompts/agents/remote');
+// Keep these docs-side paths synchronized with the remote_agent_docs detector
+// in .github/workflows/ci.yml so docs-only changes still run this drift check.
 const configPath = resolve(rootDir, 'docs/supabase/remote-agents.config.json');
 const defaultOutputPath = 'docs/supabase/SYNC_REMOTE_AGENTS.sql';
 


### PR DESCRIPTION
## Summary

Follow-up to #10167. Keep the existing code-versus-docs classification intact so a PR that changes public docs together with `docs/supabase/` still builds the VitePress site.

Remote-agent SQL synchronization now has a separate lightweight job for docs-only changes to `remote-agents.config.json` or `SYNC_REMOTE_AGENTS.sql`. Code changes continue to run the same check in `static checks (linux)`. The aggregate `validate` job owns both paths and rejects whichever one runs if it fails.

## Ownership boundary

- `changes.code` decides between the heavy code suite and the public-docs build.
- `changes.remote_agent_docs` decides whether a docs-only remote-agent drift check is needed.
- `validate` aggregates both without allowing either concern to suppress the other.

## Validation

- `pnpm run check:remote-agents`
- Prettier on `.github/workflows/ci.yml`
- `git diff --check`

Closes the post-merge review finding on #10167.