### PR TITLE
fix(cli): separate inquiry drop provenance

### DIFF
--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -265,18 +265,14 @@ export function ExternalInquiry(
 
   useInput((input, key) => {
     if (isEscapeInput(input, key)) {
-      props.onDecide({
-        accepted: false,
-        userMessage: 'External inquiry skipped by user.',
-      });
+      props.onDecide({ accepted: false });
       return;
     }
     if (key.ctrl && input.toLowerCase() === 'r') {
       const feedback = answer.trim();
       props.onDecide({
         accepted: false,
-        userMessage:
-          feedback.length > 0 ? feedback : 'External inquiry rejected by user.',
+        ...(feedback.length > 0 ? { userMessage: feedback } : {}),
       });
       return;
     }

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -470,7 +470,7 @@ async function requestUserQuestionInteraction(
 ): Promise<UserQuestionSettlement> {
   const denial = settleHumanInputDenial(context);
   if (denial != null) {
-    return { action: 'reject', reason: denial.userMessage };
+    return { action: 'reject', reason: denial.reason };
   }
 
   const decision = await enqueueTuiApproval({ kind: 'userQuestion', payload });
@@ -813,13 +813,25 @@ function handleExternalInquiry(
         });
         return;
       }
+      if (decision.rejectionCause !== undefined) {
+        void handleExternalInquiryAction({
+          action: 'drop',
+          threadId,
+          cause: decision.rejectionCause,
+        });
+        return;
+      }
+      if (decision.userMessage) {
+        void handleExternalInquiryAction({
+          action: 'drop',
+          threadId,
+          feedback: decision.userMessage,
+        });
+        return;
+      }
       void handleExternalInquiryAction({
         action: 'drop',
         threadId,
-        feedback:
-          decision.rejectionCause ??
-          decision.userMessage ??
-          'No answer provided.',
       });
     },
   );

--- a/packages/cli/src/runtime/approval/settleApprovals.ts
+++ b/packages/cli/src/runtime/approval/settleApprovals.ts
@@ -118,12 +118,12 @@ export function settleRetry(
 
 /**
  * Settle a human-input denial, or `undefined` when a prompt is allowed.
- * Callers wrap `userMessage` into their host-specific settlement shape.
+ * Callers wrap `reason` into their host-specific settlement shape.
  */
 export function settleHumanInputDenial(
   context: CliContext,
   yoloMessage?: string,
-): { readonly userMessage: string } | undefined {
+): { readonly reason: string } | undefined {
   const decision = decideHumanInputRequest({
     policy: livePolicy(),
     canPresent: canPresent(context),
@@ -133,14 +133,14 @@ export function settleHumanInputDenial(
     warnApprovalDenied(context, 'Human-input request');
   }
   return {
-    userMessage: texraHumanInputDenialMessage(decision.deny, yoloMessage),
+    reason: texraHumanInputDenialMessage(decision.deny, yoloMessage),
   };
 }
 
 /**
  * "No human input available" guard for external-inquiry requests, used by the
  * TUI approval queue (`subscribeApprovals.ts`). Drops the durable inquiry
- * thread with denial feedback and returns `true` when denied; returns `false`
+ * thread with a denial reason and returns `true` when denied; returns `false`
  * when a prompt is allowed and the caller should proceed with its own
  * handling. Non-TUI runs never reach here — the headless interaction port
  * drops the thread itself (`approvalAdapter.openExternalInquiry`).
@@ -154,7 +154,7 @@ export function denyExternalInquiryIfNoHumanInput(
   void handleExternalInquiryAction({
     action: 'drop',
     threadId,
-    feedback: denial.userMessage,
+    reason: denial.reason,
   });
   return true;
 }

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -212,7 +212,7 @@ async function askHeadlessUserQuestion(
 ): Promise<UserQuestionSettlement> {
   const denial = settleHumanInputDenial(context);
   if (denial != null) {
-    return { action: 'reject', reason: denial.userMessage };
+    return { action: 'reject', reason: denial.reason };
   }
 
   const answers: UserQuestionAnswers = {};
@@ -331,7 +331,7 @@ export function createHeadlessCliHostInteractions(
       await handleExternalInquiryAction({
         action: 'drop',
         threadId: request.threadId,
-        feedback:
+        cause:
           'External inquiry is not available in non-TUI CLI runs: inquiry answers are delivered as asynchronous continuations, and this process cannot resume them after the run finalizes. Use texra chat for the inquiry panel, or ask_user_question for synchronous CLI input.',
       });
       return { threadId: request.threadId };

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -194,7 +194,7 @@ describe('human input approval policy', () => {
     expect(handleExternalInquiryActionMock).toHaveBeenCalledWith({
       action: 'drop',
       threadId: 'ei_test',
-      feedback: TEXRA_APPROVAL_POLICY_DENIED_MESSAGE,
+      reason: TEXRA_APPROVAL_POLICY_DENIED_MESSAGE,
     });
   });
 
@@ -310,7 +310,7 @@ describe('approval prompt hooks', () => {
     expect(handleExternalInquiryActionMock).toHaveBeenCalledWith({
       action: 'drop',
       threadId: 'ei_aabbccdd0011',
-      feedback: expect.stringContaining('non-TUI CLI runs'),
+      cause: expect.stringContaining('non-TUI CLI runs'),
     });
   });
 });

--- a/src/test-kernel/cli/ExternalInquiry.vitest.ts
+++ b/src/test-kernel/cli/ExternalInquiry.vitest.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
+  ExternalInquiry,
   boundedExternalInquiryQuestionLines,
   externalInquiryAnswerRowsBudget,
   externalInquiryKeyHintsForWidth,
@@ -9,6 +10,8 @@ import {
 import { KEY_HINT_SEPARATOR } from '@cli/tui/ui/KeyHints';
 import { textInputDisplayWindow } from '@cli/chat/tui/input/BaseTextInput';
 import { textDisplayWidth } from '@cli/runtime/terminalText';
+import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
+import { loadInk, renderInteractive } from '@test/support/inkTestHarness.ts';
 
 describe('CLI external inquiry modal', () => {
   function hintText(
@@ -32,6 +35,39 @@ describe('CLI external inquiry modal', () => {
       width,
     });
   }
+
+  it.each([
+    { name: 'Esc skip', input: String.fromCharCode(27) },
+    { name: 'empty Ctrl-R rejection', input: String.fromCharCode(18) },
+  ])('does not synthesize feedback for $name', async ({ input }) => {
+    const { ink, React } = await loadInk();
+    const onDecide = vi.fn();
+    const { instance, stdin } = renderInteractive(
+      ink,
+      React.createElement(ExternalInquiry, {
+        payload: {
+          requestId: 'inquiry-note-free',
+          allowBypass: false,
+          streamId: 'inquiry-stream',
+          mode: 'new',
+          question: 'Which external fact should be checked?',
+          threadId: 'ei_000000000001',
+        },
+        onDecide,
+      }),
+      { columns: 100, rows: 30 },
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write(input);
+      await vi.waitFor(() =>
+        expect(onDecide).toHaveBeenCalledWith({ accepted: false }),
+      );
+    } finally {
+      instance.unmount();
+    }
+  });
 
   it.each([
     {

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -446,7 +446,7 @@ describe('TUI retry approvals', () => {
       expect(mocks.handleExternalInquiryAction).toHaveBeenCalledWith({
         action: 'drop',
         threadId: 'thread-interrupted',
-        feedback: 'Session interrupted.',
+        cause: 'Session interrupted.',
       }),
     );
   });

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -451,6 +451,33 @@ describe('TUI retry approvals', () => {
     );
   });
 
+  it('drops a note-free external inquiry without synthesized feedback', async () => {
+    const { interactions } = tui();
+    await interactions.openExternalInquiry?.({
+      requestId: 'inquiry-note-free',
+      allowBypass: false,
+      streamId: 'inquiry-stream',
+      mode: 'new',
+      question: 'Which external fact should be checked?',
+      threadId: 'thread-note-free',
+      sessionLinks: null,
+      draft: null,
+      transcript: null,
+    });
+    await waitForApproval('externalInquiry', {
+      threadId: 'thread-note-free',
+    });
+
+    currentApproval.get()?.decide({ accepted: false });
+
+    await vi.waitFor(() =>
+      expect(mocks.handleExternalInquiryAction).toHaveBeenCalledWith({
+        action: 'drop',
+        threadId: 'thread-note-free',
+      }),
+    );
+  });
+
   it('reports an automatic yolo retry rejection as a policy denial', async () => {
     const { interactions } = tui(host(), {
       approvalPolicy: 'yolo',

--- a/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
@@ -105,7 +105,7 @@ describe('handleExternalInquiryAction', () => {
     });
 
     expect(traceMocks.info).toHaveBeenCalledWith(
-      'Inquiry thread-cancelled cancelled',
+      'Inquiry thread-cancelled dropped with cause',
       { data: 'Session interrupted.' },
     );
   });

--- a/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
@@ -24,6 +24,15 @@ const continuationMocks = vi.hoisted(() => ({
   injectContinuationForDroppedThread: vi.fn(),
 }));
 
+const traceMocks = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('@agent/trace', () => ({
+  createChannelTrace: () => traceMocks,
+}));
+
 vi.mock('@tools/inquiry/externalInquiryStorage', () => storageMocks);
 
 vi.mock('@tools/inquiry/inquiryContinuation', () => continuationMocks);
@@ -53,7 +62,7 @@ describe('handleExternalInquiryAction', () => {
     ).toHaveBeenCalledWith('thread-submit', manifest, undefined);
   });
 
-  it('persists and continues drop actions', async () => {
+  it('persists note-free drops without synthesizing provenance', async () => {
     const manifest = { status: 'dropped' };
     storageMocks.markDropped.mockResolvedValue(manifest);
 
@@ -68,5 +77,36 @@ describe('handleExternalInquiryAction', () => {
     expect(
       continuationMocks.injectContinuationForDroppedThread,
     ).toHaveBeenCalledWith('thread-drop', manifest, undefined);
+    expect(traceMocks.info).not.toHaveBeenCalled();
+  });
+
+  it('logs policy reasons without labeling them as feedback', async () => {
+    storageMocks.markDropped.mockResolvedValue({ status: 'dropped' });
+
+    await handleExternalInquiryAction({
+      action: 'drop',
+      threadId: 'thread-denied',
+      reason: 'Human input is disabled by policy.',
+    });
+
+    expect(traceMocks.info).toHaveBeenCalledWith(
+      'Inquiry thread-denied denied',
+      { data: 'Human input is disabled by policy.' },
+    );
+  });
+
+  it('logs lifecycle causes without labeling them as feedback', async () => {
+    storageMocks.markDropped.mockResolvedValue({ status: 'dropped' });
+
+    await handleExternalInquiryAction({
+      action: 'drop',
+      threadId: 'thread-cancelled',
+      cause: 'Session interrupted.',
+    });
+
+    expect(traceMocks.info).toHaveBeenCalledWith(
+      'Inquiry thread-cancelled cancelled',
+      { data: 'Session interrupted.' },
+    );
   });
 });

--- a/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
@@ -29,9 +29,17 @@ const traceMocks = vi.hoisted(() => ({
   warn: vi.fn(),
 }));
 
-vi.mock('@agent/trace', () => ({
-  createChannelTrace: () => traceMocks,
-}));
+vi.mock('@agent/trace', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agent/trace')>();
+  return {
+    ...actual,
+    createChannelTrace: () => ({
+      ...actual.noopTrace,
+      info: traceMocks.info,
+      warn: traceMocks.warn,
+    }),
+  };
+});
 
 vi.mock('@tools/inquiry/externalInquiryStorage', () => storageMocks);
 

--- a/src/tools/inquiry/inquiryActions.ts
+++ b/src/tools/inquiry/inquiryActions.ts
@@ -105,7 +105,7 @@ export async function persistExternalInquiryAction(
       data: payload.reason,
     });
   } else if (payload.cause) {
-    logger.info(`Inquiry ${payload.threadId} cancelled`, {
+    logger.info(`Inquiry ${payload.threadId} dropped with cause`, {
       data: payload.cause,
     });
   }

--- a/src/tools/inquiry/inquiryActions.ts
+++ b/src/tools/inquiry/inquiryActions.ts
@@ -28,6 +28,34 @@ import {
 
 const logger = createChannelTrace('InquiryTool');
 
+type InquirySubmitAction = Extract<
+  InquiryActionMessage,
+  { readonly action: 'submit' }
+>;
+type InquiryDropBase = Omit<
+  Extract<InquiryActionMessage, { readonly action: 'drop' }>,
+  'feedback'
+>;
+type InquiryDropAction = InquiryDropBase &
+  (
+    | {
+        readonly feedback?: string;
+        readonly reason?: never;
+        readonly cause?: never;
+      }
+    | {
+        readonly feedback?: never;
+        readonly reason: string;
+        readonly cause?: never;
+      }
+    | {
+        readonly feedback?: never;
+        readonly reason?: never;
+        readonly cause: string;
+      }
+  );
+type ExternalInquiryAction = InquirySubmitAction | InquiryDropAction;
+
 export type ExternalInquiryTransition =
   | {
       readonly kind: 'answered';
@@ -46,7 +74,7 @@ export type ExternalInquiryTransition =
 
 /** Persist one terminal inquiry action without reaching into host presentation. */
 export async function persistExternalInquiryAction(
-  payload: InquiryActionMessage,
+  payload: ExternalInquiryAction,
 ): Promise<ExternalInquiryTransition> {
   if (payload.action === 'submit') {
     const persisted = await recordAnswerForOpenTurn({
@@ -71,6 +99,14 @@ export async function persistExternalInquiryAction(
   if (payload.feedback) {
     logger.info(`Inquiry ${payload.threadId} dropped with feedback`, {
       data: payload.feedback,
+    });
+  } else if (payload.reason) {
+    logger.info(`Inquiry ${payload.threadId} denied`, {
+      data: payload.reason,
+    });
+  } else if (payload.cause) {
+    logger.info(`Inquiry ${payload.threadId} cancelled`, {
+      data: payload.cause,
     });
   }
   const droppedManifest = await markDropped({ threadId: payload.threadId });
@@ -117,7 +153,7 @@ export async function continueExternalInquiryAction(
 
 /** Persist and continue an inquiry action for hosts without progress UI. */
 export async function handleExternalInquiryAction(
-  payload: InquiryActionMessage,
+  payload: ExternalInquiryAction,
   options: { session?: SessionHandle } = {},
 ): Promise<void> {
   const transition = await persistExternalInquiryAction(payload);


### PR DESCRIPTION
## Summary

- separate external-inquiry drop feedback from policy reasons and lifecycle or host causes
- stop synthesizing `No answer provided.` for a note-free drop
- preserve the existing progress-view wire format while making the internal action boundary mutually exclusive

Closes #10179.

## Ownership decision

`handleExternalInquiryAction` is the boundary where host decisions become durable inquiry actions. Its drop payload now carries exactly one of four states: user-authored `feedback`, automatic policy `reason`, lifecycle or host `cause`, or no provenance. The TUI, headless adapter, and policy guard declare that provenance directly instead of putting generated text into `feedback`.

The progress-view message schema remains unchanged because its optional `feedback` field represents text entered by the user and already has the correct meaning. No persisted inquiry format or compatibility path is added.

## Validation

Production head `42738ce4cc`:

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- `npm test` (857 files passed, 1 skipped; 10,170 tests passed, 5 skipped)
- repository pre-commit and pre-push checks

Review head `23bbca943c`:

- `corepack pnpm run typecheck:cli`
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- `npm run lint`
- focused external-inquiry and approval suites (115 tests)
- repository pre-commit and pre-push checks
