### PR TITLE
fix(cli): keep cancelled outputs in run storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Interrupted workflows keep provisional files in run storage** — cancelling
+  a workflow no longer copies unfinished rounds to `--output` or
+  `--output-dir` destinations.
 - **Multi-agent transcripts show the user's request** — team runs keep internal
   orchestration guidance out of history and resumed chat messages.
 - **Completed workflow tasks can be retried without restarting chat** — a new

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -333,7 +333,12 @@ export async function resolveWorkflowOutput(
 }
 
 export function formatWorkflowTextResult(result: CliWorkflowRunResult): string {
-  if (result.outcome === RUN_OUTCOME.CANCELLED && result.runDirectory) {
+  if (
+    result.outcome === RUN_OUTCOME.CANCELLED &&
+    result.runDirectory &&
+    !result.copiedOutput &&
+    !result.copiedOutputs?.length
+  ) {
     return result.runDirectory;
   }
   if (result.copiedOutputs?.length) {

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -243,14 +243,16 @@ export async function resolveWorkflowOutput(
   context: CliContext,
   options: WorkflowOutputResolutionOptions,
 ): Promise<CliWorkflowRunResult> {
+  const runDirectory = options.runDirectory ?? getRunDir(result.executionId);
+  if (result.outcome === RUN_OUTCOME.CANCELLED && (outputFile || outputDir)) {
+    return {
+      ...result,
+      workingDirectory: context.cwd,
+      runDirectory,
+    };
+  }
   const terminalStatus = runOutcomeToExecutionStatus(result.outcome);
   if (result.outputs.length === 0 && (outputFile || outputDir)) {
-    if (result.outcome === RUN_OUTCOME.CANCELLED) {
-      return {
-        ...result,
-        workingDirectory: context.cwd,
-      };
-    }
     if (outputDir) {
       throw new Error(
         `Workflow ${terminalStatus} without generated outputs; nothing was copied to ${outputDir}.`,
@@ -263,7 +265,6 @@ export async function resolveWorkflowOutput(
     }
   }
 
-  const runDirectory = options.runDirectory ?? getRunDir(result.executionId);
   if (outputDir) {
     const targetRoot = joinCwdRelative(outputDir, context.cwd);
     const expectedRelativePaths = (options.expectedOutputFiles ?? []).map(

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -244,6 +244,8 @@ export async function resolveWorkflowOutput(
   options: WorkflowOutputResolutionOptions,
 ): Promise<CliWorkflowRunResult> {
   const runDirectory = options.runDirectory ?? getRunDir(result.executionId);
+  // Interrupted rounds remain inspectable in run storage, but are not final
+  // artifacts and must not replace the user's requested destination.
   if (result.outcome === RUN_OUTCOME.CANCELLED && (outputFile || outputDir)) {
     return {
       ...result,
@@ -331,6 +333,9 @@ export async function resolveWorkflowOutput(
 }
 
 export function formatWorkflowTextResult(result: CliWorkflowRunResult): string {
+  if (result.outcome === RUN_OUTCOME.CANCELLED && result.runDirectory) {
+    return result.runDirectory;
+  }
   if (result.copiedOutputs?.length) {
     return result.copiedOutputs.join('\n');
   }

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.ts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.ts
@@ -536,4 +536,28 @@ describe('CLI workflow output resolution', () => {
 
     expect(formatWorkflowTextResult(result)).toBe('/run');
   });
+
+  it('reports destinations that were copied before cancellation', () => {
+    const result: CliWorkflowRunResult = {
+      ...workflowResult(
+        [{ absolutePath: '/run/r0/main.tex', relativePath: 'r0/main.tex' }],
+        RUN_OUTCOME.CANCELLED,
+      ),
+      workingDirectory: '/workspace',
+      runDirectory: '/run',
+      copiedOutput: '/workspace/final.tex',
+    };
+
+    expect(formatWorkflowTextResult(result)).toBe('/workspace/final.tex');
+    expect(
+      formatWorkflowTextResult({
+        ...result,
+        copiedOutput: undefined,
+        copiedOutputs: [
+          '/workspace/final/main.tex',
+          '/workspace/final/appendix.tex',
+        ],
+      }),
+    ).toBe('/workspace/final/main.tex\n/workspace/final/appendix.tex');
+  });
 });

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.ts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.ts
@@ -517,4 +517,23 @@ describe('CLI workflow output resolution', () => {
 
     expect(formatWorkflowTextResult(result)).toBe('/run/r2/appendix.tex');
   });
+
+  it('reports run storage instead of one provisional file after cancellation', () => {
+    const result: CliWorkflowRunResult = {
+      ...workflowResult(
+        [
+          { absolutePath: '/run/r0/main.tex', relativePath: 'r0/main.tex' },
+          {
+            absolutePath: '/run/r0/appendix.tex',
+            relativePath: 'r0/appendix.tex',
+          },
+        ],
+        RUN_OUTCOME.CANCELLED,
+      ),
+      workingDirectory: '/workspace',
+      runDirectory: '/run',
+    };
+
+    expect(formatWorkflowTextResult(result)).toBe('/run');
+  });
 });

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.ts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.ts
@@ -96,6 +96,57 @@ describe('CLI workflow output resolution', () => {
     ).rejects.toThrow(/b\.tex/);
   });
 
+  it('does not publish cancelled workflow outputs to requested destinations', async () => {
+    const cwd = await makeTempDir();
+    const runOutput = await writeRunFile(cwd, 'r0/paper.tex', 'provisional');
+    const outputFile = join(cwd, 'out.tex');
+    const outputDirectoryFile = join(cwd, 'out', 'paper.tex');
+    await writeFile(outputFile, 'existing file');
+    await mkdir(dirname(outputDirectoryFile), { recursive: true });
+    await writeFile(outputDirectoryFile, 'existing directory file');
+
+    const resultForFile = await resolveWorkflowOutput(
+      outputFile,
+      undefined,
+      workflowResult(
+        [{ absolutePath: runOutput, relativePath: 'r0/paper.tex', round: 0 }],
+        RUN_OUTCOME.CANCELLED,
+      ),
+      testContext(cwd),
+      { runDirectory: join(cwd, 'run') },
+    );
+    const resultForDirectory = await resolveWorkflowOutput(
+      undefined,
+      join(cwd, 'out'),
+      workflowResult(
+        [{ absolutePath: runOutput, relativePath: 'r0/paper.tex', round: 0 }],
+        RUN_OUTCOME.CANCELLED,
+      ),
+      testContext(cwd),
+      {
+        expectedOutputFiles: ['paper.tex'],
+        runDirectory: join(cwd, 'run'),
+      },
+    );
+
+    for (const result of [resultForFile, resultForDirectory]) {
+      expect(result).toMatchObject({
+        outcome: RUN_OUTCOME.CANCELLED,
+        workingDirectory: cwd,
+        runDirectory: join(cwd, 'run'),
+      });
+      expect(Object.hasOwn(result, 'status')).toBe(false);
+      expect(Object.hasOwn(result, 'terminalStatus')).toBe(false);
+      expect(Object.hasOwn(result, 'endGroupStatus')).toBe(false);
+      expect(Object.hasOwn(result, 'copiedOutput')).toBe(false);
+      expect(Object.hasOwn(result, 'copiedOutputs')).toBe(false);
+    }
+    await expect(readFile(outputFile, 'utf8')).resolves.toBe('existing file');
+    await expect(readFile(outputDirectoryFile, 'utf8')).resolves.toBe(
+      'existing directory file',
+    );
+  });
+
   it('carries only the cancelled outcome for missing workflow outputs', async () => {
     const cwd = await makeTempDir();
 
@@ -104,12 +155,13 @@ describe('CLI workflow output resolution', () => {
       undefined,
       workflowResult([], RUN_OUTCOME.CANCELLED),
       testContext(cwd),
-      {},
+      { runDirectory: join(cwd, 'run') },
     );
 
     expect(result).toMatchObject({
       outcome: RUN_OUTCOME.CANCELLED,
       workingDirectory: cwd,
+      runDirectory: join(cwd, 'run'),
     });
     expect(Object.hasOwn(result, 'status')).toBe(false);
     expect(Object.hasOwn(result, 'terminalStatus')).toBe(false);

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
@@ -706,28 +706,6 @@ describe('CLI workflow run command', () => {
     );
   });
 
-  it('prints the recovery command when cancelled output resolution fails', async () => {
-    mockWorkflowExecution(
-      workflowExecution('exec-interrupted-copy', {
-        outcome: RUN_OUTCOME.CANCELLED,
-        outputs: [
-          runOutputSummary('/missing/run/r1/paper.tex', '/workspace/paper.tex'),
-        ],
-      }),
-      true,
-    );
-
-    const exitCode = await runWorkflow({ output: 'polished.tex' });
-
-    expect(exitCode).toBe(CliExitCode.Interrupted);
-    expect(mocks.writeErrorStderr).toHaveBeenCalledExactlyOnceWith(
-      expect.objectContaining({ code: 'ENOENT' }),
-    );
-    expect(mocks.writeTextStderr).toHaveBeenCalledExactlyOnceWith(
-      expectedRecoveryHint(cliContext(), 'exec-interrupted-copy'),
-    );
-  });
-
   it('does not advertise resume when cancelled status is not durable', async () => {
     const durableExecution = workflowExecution('exec-undurable', {
       outcome: RUN_OUTCOME.CANCELLED,


### PR DESCRIPTION
## Summary

- stop cancelled workflows before the CLI output-publication boundary
- keep provisional rounds available only through the canonical run-storage directory
- preserve pre-existing `--output` and `--output-dir` destination files
- remove the test whose sole contract was that cancellation attempted a failing copy

Closes #10181.

## Evidence

A real `devise` run at 40×20 with two nested inputs was interrupted after its first of two rounds. TeXRA correctly persisted execution `7d7e56618fdb` as resumable and printed a resume command, but also copied both round-0 documents into the requested `corrected/` directory without reporting those writes. Resuming the same execution later overwrote them with the final round.

The output flags document destination files as final artifacts. The execution's run-storage tree is already the source of truth for provisional rounds and resume, so cancellation should not maintain a parallel published representation.

## Ownership and simplification

`resolveWorkflowOutput` is the single boundary that promotes run-storage artifacts to user-requested filesystem destinations. It now checks the canonical `RunOutcome` once before either the single-file or directory copy path. This avoids separate cancellation rules for `--output` and `--output-dir`, and removes an obsolete error path in which a cancelled run tried to copy an unavailable intermediate artifact.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- `npm test` — 857 files passed, 1 skipped; 10,175 tests passed, 5 skipped
- focused post-diff run: 39 tests passed across workflow output resolution and workflow run command

## Follow-up boundary

This PR handles runs whose outcome is already cancelled when output resolution begins. Issue #10183 tracks the separate commit-point race in which cancellation is accepted while destination publication is already in progress.
