### PR TITLE
fix(cli): arbitrate cancellation before output publication

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -227,14 +227,17 @@ export async function executeCliWorkflowConfig(
     canAdvertiseInterruptedExecution,
     expectedCategory: AgentCategory.Workflow,
     categoryMismatchMessage: options.categoryMismatchMessage,
-    openWorkflowOutput: async (result) => {
+    openWorkflowOutput: async (result, tryCommitPublication) => {
       try {
         workflowResult = await resolveWorkflowOutput(
           options.output,
           options.outputDir,
           result,
           runContext,
-          { expectedOutputFiles: options.expectedOutputFiles },
+          {
+            expectedOutputFiles: options.expectedOutputFiles,
+            tryCommitPublication,
+          },
         );
       } catch (error) {
         workflowOutputError = error;

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -57,6 +57,14 @@ import type { CliContext } from './cliContext';
 
 const CLI_RUN_SHUTDOWN_GRACE_MS = 5_000;
 
+type RunAgentWorkflowOutput = NonNullable<
+  RunAgentOptions['openWorkflowOutput']
+>;
+type CliWorkflowOutputHandler = (
+  result: Parameters<RunAgentWorkflowOutput>[0],
+  tryCommitPublication: () => boolean,
+) => ReturnType<RunAgentWorkflowOutput>;
+
 interface CliExecuteOptions {
   /** Forwarded to `runAgent`. */
   readonly enforceCategory?: boolean;
@@ -65,7 +73,7 @@ interface CliExecuteOptions {
   readonly stopAfterCycle?: boolean;
   /** Additional tools unavailable in this CLI runtime. */
   readonly runtimeUnavailableTools?: readonly string[];
-  readonly openWorkflowOutput?: RunAgentOptions['openWorkflowOutput'];
+  readonly openWorkflowOutput?: CliWorkflowOutputHandler;
   /** Forwarded to `runAgent` on resume, pinning the original handler dialect. */
   readonly modelHandlerCompatibilityKey?: RunAgentOptions['modelHandlerCompatibilityKey'];
   /** Called during signal shutdown after CANCELLED status is durable and the
@@ -295,6 +303,7 @@ export async function executeCliRequest(
   const launchAbortController = new AbortController();
   let shutdownRequested = false;
   let shutdownInterrupted = false;
+  let workflowOutputPublicationCommitted = false;
   let runLifecycleStarted = false;
   let shutdownArtifactFailure: unknown;
   let shutdownFinalizationFailureReported = false;
@@ -325,6 +334,13 @@ export async function executeCliRequest(
     settleRecoveryNoticeStarted = resolve;
   });
   let shutdownStatusFinalized: Promise<boolean> | undefined;
+  // Both callbacks enter on this event loop, and neither yields between the
+  // check and assignment. Exactly one can therefore own the terminal verdict.
+  const tryCommitWorkflowOutputPublication = (): boolean => {
+    if (shutdownInterrupted) return false;
+    workflowOutputPublicationCommitted = true;
+    return true;
+  };
   const finalizeShutdownStatus = (): Promise<boolean> => {
     if (!shutdownInterrupted) return Promise.resolve(false);
     shutdownStatusFinalized ??= (async () => {
@@ -386,14 +402,17 @@ export async function executeCliRequest(
     async () => {
       shutdownRequested = true;
       launchAbortController.abort();
-      const interruptionAccepted = ownedExecutionId
-        ? session.executions.kill(ownedExecutionId)
-        : false;
+      const interruptionAccepted =
+        !workflowOutputPublicationCommitted && ownedExecutionId
+          ? session.executions.kill(ownedExecutionId)
+          : false;
       // Before lifecycle registration, the launch signal is the cancellation
       // authority. Afterwards, only an accepted registry stop may replace the
       // run's own terminal verdict with CANCELLED.
       shutdownInterrupted =
-        !runLifecycleStarted || interruptionAccepted || shutdownInterrupted;
+        (!workflowOutputPublicationCommitted && !runLifecycleStarted) ||
+        interruptionAccepted ||
+        shutdownInterrupted;
       let resumableCheckpoint:
         Extract<ResumabilityDecision, { resumable: true }> | undefined;
       if (shutdownInterrupted && ownedExecutionId) {
@@ -445,13 +464,18 @@ export async function executeCliRequest(
       }
     },
   );
+  const openWorkflowOutput = options.openWorkflowOutput;
   const invoke = async (): Promise<ExecuteAgentResult> => {
     try {
       return await runAgent(request, {
         session,
         enforceCategory: options.enforceCategory,
         registerExecution: options.registerExecution,
-        openWorkflowOutput: options.openWorkflowOutput,
+        openWorkflowOutput:
+          openWorkflowOutput === undefined
+            ? undefined
+            : (result) =>
+                openWorkflowOutput(result, tryCommitWorkflowOutputPublication),
         modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
         launchSignal: launchAbortController.signal,
         beforeLeaseRelease: async () => {

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -73,6 +73,8 @@ interface CliExecuteOptions {
   readonly stopAfterCycle?: boolean;
   /** Additional tools unavailable in this CLI runtime. */
   readonly runtimeUnavailableTools?: readonly string[];
+  /** Workflow output handler extended with the CLI publication gate; attempt
+   *  the commit synchronously once before destination validation or I/O. */
   readonly openWorkflowOutput?: CliWorkflowOutputHandler;
   /** Forwarded to `runAgent` on resume, pinning the original handler dialect. */
   readonly modelHandlerCompatibilityKey?: RunAgentOptions['modelHandlerCompatibilityKey'];
@@ -402,6 +404,8 @@ export async function executeCliRequest(
     async () => {
       shutdownRequested = true;
       launchAbortController.abort();
+      // Paired with tryCommitWorkflowOutputPublication: keep this flag read
+      // and the shutdownInterrupted assignment below in one synchronous turn.
       const interruptionAccepted =
         !workflowOutputPublicationCommitted && ownedExecutionId
           ? session.executions.kill(ownedExecutionId)

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -150,6 +150,7 @@ type WorkflowAgentResult = Extract<
 interface WorkflowOutputResolutionOptions {
   readonly expectedOutputFiles?: readonly string[];
   readonly runDirectory?: string;
+  readonly tryCommitPublication?: () => boolean;
 }
 
 function outputCopyRelativePath(output: OutputFileSummary): string {
@@ -247,6 +248,15 @@ export async function resolveWorkflowOutput(
   // Interrupted rounds remain inspectable in run storage, but are not final
   // artifacts and must not replace the user's requested destination.
   if (result.outcome === RUN_OUTCOME.CANCELLED && (outputFile || outputDir)) {
+    return {
+      ...result,
+      workingDirectory: context.cwd,
+      runDirectory,
+    };
+  }
+  // Commit before validation as well as copying: once output finalization owns
+  // the verdict, its missing-output and filesystem failures must stay visible.
+  if ((outputFile || outputDir) && options.tryCommitPublication?.() === false) {
     return {
       ...result,
       workingDirectory: context.cwd,

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { RunAgentOptions } from '@agent/runtime/runAgent';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { executeCliRequest } from '@cli/runtime/runExecution';
 import { AgentError } from '@common/errors';
@@ -140,6 +141,17 @@ const COMPLETED_RUN = {
   streamId: 'stream-1',
 } as const;
 
+const COMPLETED_WORKFLOW_RUN: Parameters<
+  NonNullable<RunAgentOptions['openWorkflowOutput']>
+>[0] = {
+  category: 'workflow',
+  executionId: 'exec-1',
+  outcome: 'completed',
+  streamId: 'stream-1',
+  outputs: [],
+  compileFailures: [],
+};
+
 function baseRequest(): CliRequest {
   return { config: {}, executionId: 'exec-1' } as CliRequest;
 }
@@ -164,6 +176,7 @@ function loadRunExecution(): Promise<
 
 type LeaseOptions = {
   beforeLeaseRelease?: () => Promise<boolean | void>;
+  openWorkflowOutput?: RunAgentOptions['openWorkflowOutput'];
   onRun?: () => void;
   launchSignal?: AbortSignal;
   onExecutionLeaseAcquired?: (
@@ -1129,6 +1142,83 @@ describe('executeCliRequest', () => {
 
     expect(mocks.finalizeExecution).not.toHaveBeenCalled();
     expect(mocks.releaseExecutionLeaseAfterArtifacts).not.toHaveBeenCalled();
+  });
+
+  it('denies workflow output publication after shutdown interruption commits', async () => {
+    const { platform, executeCliRequest } = await installFakePlatform();
+    let leaseOptions: LeaseOptions | undefined;
+    const hangingRun = stubHangingRun((options) => {
+      leaseOptions = options;
+    });
+    let publicationCommitted: boolean | undefined;
+    const run = executeCliRequest(baseRequest(), cliContext(), {
+      registerExecution: true,
+      openWorkflowOutput: async (_result, tryCommitPublication) => {
+        publicationCommitted = tryCommitPublication();
+      },
+    });
+    await vi.waitFor(() => expect(leaseOptions).toBeDefined());
+
+    const shutdown = platform.lifecycle.runShutdown();
+    leaseOptions?.onExecutionLeaseAcquired?.(
+      (operation: () => unknown) => operation(),
+      'exec-1' as ExecutionId,
+    );
+    leaseOptions?.onRun?.();
+    await leaseOptions?.openWorkflowOutput?.(COMPLETED_WORKFLOW_RUN);
+    mocks.readCliRunOutcomeState.mockResolvedValueOnce({
+      outcome: RUN_OUTCOME.CANCELLED,
+      outcomePersisted: true,
+    });
+    hangingRun.resolve(COMPLETED_WORKFLOW_RUN);
+
+    await shutdown;
+    await expect(run).resolves.toMatchObject({
+      ok: true,
+      result: { outcome: RUN_OUTCOME.CANCELLED },
+    });
+    expect(publicationCommitted).toBe(false);
+    expect(mocks.finalizeExecution).toHaveBeenCalledWith({
+      executionId: 'exec-1',
+      outcome: RUN_OUTCOME.CANCELLED,
+      flowRecord: 'preserve',
+    });
+  });
+
+  it('preserves the workflow verdict after output publication commits', async () => {
+    const { platform, executeCliRequest } = await installFakePlatform();
+    const { defaultSession } = await import('@agent/runtime/SessionHandle');
+    const killSpy = vi.spyOn(defaultSession().executions, 'kill');
+    let leaseOptions: LeaseOptions | undefined;
+    const hangingRun = stubHangingRun((options) => {
+      leaseOptions = options;
+    });
+    let publicationCommitted: boolean | undefined;
+    const run = executeCliRequest(baseRequest(), cliContext(), {
+      registerExecution: true,
+      openWorkflowOutput: async (_result, tryCommitPublication) => {
+        publicationCommitted = tryCommitPublication();
+      },
+    });
+    await vi.waitFor(() => expect(leaseOptions).toBeDefined());
+    leaseOptions?.onExecutionLeaseAcquired?.(
+      (operation: () => unknown) => operation(),
+      'exec-1' as ExecutionId,
+    );
+    leaseOptions?.onRun?.();
+    await leaseOptions?.openWorkflowOutput?.(COMPLETED_WORKFLOW_RUN);
+
+    const shutdown = platform.lifecycle.runShutdown();
+    hangingRun.resolve(COMPLETED_WORKFLOW_RUN);
+
+    await shutdown;
+    await expect(run).resolves.toMatchObject({
+      ok: true,
+      result: { outcome: RUN_OUTCOME.COMPLETED },
+    });
+    expect(publicationCommitted).toBe(true);
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
   });
 
   it('does not finalize shutdown through a captured lease that is already lost', async () => {

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
@@ -212,7 +212,10 @@ function mockWorkflowExecution(
     },
   ) => {
     if (result.ok) {
-      const outputOutcome = await options.openWorkflowOutput?.(result.result);
+      const outputOutcome = await options.openWorkflowOutput?.(
+        result.result,
+        () => true,
+      );
       if (outputOutcome !== undefined) {
         return {
           ...result,
@@ -677,7 +680,7 @@ describe('CLI workflow run command', () => {
           readonly openWorkflowOutput?: CliConfigExecuteOptions['openWorkflowOutput'];
         },
       ) => {
-        await options.openWorkflowOutput?.(provisional.result);
+        await options.openWorkflowOutput?.(provisional.result, () => true);
         return {
           ...provisional,
           result: {
@@ -705,6 +708,98 @@ describe('CLI workflow run command', () => {
       }),
     );
   });
+
+  it.each([
+    {
+      label: '--output',
+      state: 'missing',
+      existing: false,
+      init: { output: 'published.tex' },
+      destination: (root: string) => path.join(root, 'published.tex'),
+    },
+    {
+      label: '--output-dir',
+      state: 'missing',
+      existing: false,
+      init: { outputDir: 'published' },
+      destination: (root: string) => path.join(root, 'published', 'paper.tex'),
+    },
+    {
+      label: '--output',
+      state: 'existing',
+      existing: true,
+      init: { output: 'published.tex' },
+      destination: (root: string) => path.join(root, 'published.tex'),
+    },
+    {
+      label: '--output-dir',
+      state: 'existing',
+      existing: true,
+      init: { outputDir: 'published' },
+      destination: (root: string) => path.join(root, 'published', 'paper.tex'),
+    },
+  ])(
+    'leaves a $state $label destination untouched when cancellation commits first',
+    async ({ init, destination, existing }) => {
+      await withTempRoot(async (root) => {
+        const generated = await writeGeneratedOutput(root);
+        const outputSummary = runOutputSummary(
+          generated,
+          path.join(root, 'paper.tex'),
+        );
+        const provisional = workflowExecution('exec-output-interrupted', {
+          outputs: [outputSummary],
+        });
+        if (!provisional.ok) throw new Error('Expected a workflow result.');
+        mocks.executeCliConfig.mockImplementationOnce(
+          async (
+            _config: unknown,
+            _context: unknown,
+            options: {
+              readonly openWorkflowOutput?: CliConfigExecuteOptions['openWorkflowOutput'];
+            },
+          ) => {
+            await options.openWorkflowOutput?.(provisional.result, () => false);
+            return {
+              ...provisional,
+              result: {
+                ...provisional.result,
+                outcome: RUN_OUTCOME.CANCELLED,
+              },
+            };
+          },
+        );
+        const target = destination(root);
+        if (existing) {
+          await fs.mkdir(path.dirname(target), { recursive: true });
+          await fs.writeFile(target, 'existing');
+        }
+
+        const exitCode = await runWorkflow(init, cliContext({ cwd: root }));
+
+        expect(exitCode).toBe(CliExitCode.Interrupted);
+        if (existing) {
+          await expect(fs.readFile(target, 'utf8')).resolves.toBe('existing');
+        } else {
+          await expect(fs.stat(target)).rejects.toThrow();
+        }
+        expect(mocks.writeResultMeta).toHaveBeenCalledWith(
+          expectedResultMeta({
+            outcome: RUN_OUTCOME.CANCELLED,
+            outputs: [outputSummary],
+            compileFailures: [],
+          }),
+        );
+        const emitted = mocks.emitCliResult.mock.calls[0]?.[1]?.json;
+        expect(emitted).toMatchObject({
+          outcome: RUN_OUTCOME.CANCELLED,
+          runDirectory: '/tmp/runs/exec-output-interrupted',
+        });
+        expect(emitted).not.toHaveProperty('copiedOutput');
+        expect(emitted).not.toHaveProperty('copiedOutputs');
+      });
+    },
+  );
 
   it('does not advertise resume when cancelled status is not durable', async () => {
     const durableExecution = workflowExecution('exec-undurable', {


### PR DESCRIPTION
## Summary

- establish one synchronous commit point between CLI shutdown cancellation and workflow output publication
- leave `--output` and `--output-dir` destinations untouched when cancellation commits first
- preserve the workflow verdict when publication commits first, while retaining the existing missing-output and copy-failure paths

Closes #10183.

## Ownership and simplification

The CLI execution lifecycle owns whether a shutdown signal may replace the run verdict. It now also owns the publication decision. The shutdown callback and workflow-output callback enter on the same event loop, and neither yields between checking and recording the decision, so exactly one side commits.

`workflowOutput.ts` remains the single owner of destination validation and copying. It asks for the lifecycle decision immediately before destination validation or filesystem mutation. If cancellation already owns the verdict, it returns the provisional result with run-storage metadata and performs no destination work. If publication wins, a later shutdown request does not kill that completed run; missing-output and copy errors therefore remain visible through the established CLI error path.

The agent runtime API is unchanged. No staging format, lock, compatibility path, or second output representation is introduced.

## Evidence

Command-level tests drive a completed provisional workflow result into a lifecycle-resolved cancelled verdict. For both `--output` and `--output-dir`, they verify that a missing destination is not created and an existing destination is not overwritten. The emitted and persisted result remains cancelled, exposes run storage, and contains no copied-destination metadata.

Lifecycle tests cover both orderings directly: shutdown committed before publication denies the publication attempt and persists cancellation; publication committed first prevents the later signal from killing the run and preserves completion.

Existing completed-publication and copy-failure tests remain green.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm run typecheck`
- `npm test` (857 files passed, 1 skipped; 10,193 tests passed, 5 skipped)
- focused lifecycle/output suites (89 tests passed)
- pre-commit and pre-push hooks
