### PR TITLE
refactor(utils): dedupe UTC month-boundary math into shared utcMonthStart

### DIFF
--- a/packages/cli/src/runtime/relayUsage.ts
+++ b/packages/cli/src/runtime/relayUsage.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { SUPABASE_CONFIG, getRelaySpendingLimit } from '@auth/config';
+import { utcMonthStart } from '@utils/core';
 
 const USAGE_PAGE_SIZE = 1000;
 
@@ -56,11 +57,12 @@ export function currentUtcMonthRange(now = new Date()): {
   start: Date;
   end: Date;
 } {
-  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
-  const end = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1),
-  );
-  return { start, end };
+  const year = now.getUTCFullYear();
+  const monthIndex = now.getUTCMonth();
+  return {
+    start: utcMonthStart(year, monthIndex),
+    end: utcMonthStart(year, monthIndex + 1),
+  };
 }
 
 export function parseUtcMonth(month: string): { start: Date; end: Date } {
@@ -74,9 +76,10 @@ export function parseUtcMonth(month: string): { start: Date; end: Date } {
     throw new Error('Expected month in YYYY-MM format.');
   }
 
-  const start = new Date(Date.UTC(year, monthIndex, 1));
-  const end = new Date(Date.UTC(year, monthIndex + 1, 1));
-  return { start, end };
+  return {
+    start: utcMonthStart(year, monthIndex),
+    end: utcMonthStart(year, monthIndex + 1),
+  };
 }
 
 export async function fetchRelayUsageSummary(input: {

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -30,6 +30,7 @@ import {
   registerTeXRAWebAwesomeIcons,
   waIcon,
 } from '@shared/wa/webAwesomeIcons';
+import { utcMonthStart } from '@utils/core';
 
 // Local imports - settings view
 import {
@@ -169,11 +170,10 @@ export class SettingsApp extends SettingsAppBase {
     }
     const now = Date.now();
     const date = new Date(now);
-    const nextMonthUtc = Date.UTC(
+    const nextMonthUtc = utcMonthStart(
       date.getUTCFullYear(),
       date.getUTCMonth() + 1,
-      1,
-    );
+    ).getTime();
     const delay = Math.min(nextMonthUtc - now, MAX_TIMEOUT_MS);
     this.monthlyProfileRefreshTimer = setTimeout(() => {
       if (Date.now() >= nextMonthUtc) {

--- a/src/test-kernel/utils/UtilsCore.vitest.ts
+++ b/src/test-kernel/utils/UtilsCore.vitest.ts
@@ -14,9 +14,24 @@ import {
   KeyedMutex,
   throwAggregated,
   toNewestFirstByTimestamp,
+  utcMonthStart,
   type FlushableDebounce,
 } from '@utils/core';
 import { deriveExecutionId } from '@utils/core/idHash';
+
+describe('utcMonthStart', () => {
+  it('builds midnight UTC on the 1st of the given month', () => {
+    expect(utcMonthStart(2026, 4).toISOString()).toBe(
+      '2026-05-01T00:00:00.000Z',
+    );
+  });
+
+  it('rolls a 12-index month into the next year, for exclusive-end ranges', () => {
+    expect(utcMonthStart(2026, 12).toISOString()).toBe(
+      '2027-01-01T00:00:00.000Z',
+    );
+  });
+});
 
 describe('toNewestFirstByTimestamp', () => {
   it('orders values by newest timestamp first', () => {

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -440,6 +440,20 @@ export function jitteredExponentialBackoffMs(
 }
 
 // ---------------------------------------------------------------------------
+// dateCore
+// ---------------------------------------------------------------------------
+
+/**
+ * Start of the given UTC month as a `Date`, e.g. `utcMonthStart(2026, 0)` is
+ * midnight UTC on 2026-01-01. `monthIndex` is 0-based and not clamped to
+ * 0-11 — pass 12 to get the start of the following year's January, which is
+ * how callers compute a month's exclusive end boundary.
+ */
+export function utcMonthStart(year: number, monthIndex: number): Date {
+  return new Date(Date.UTC(year, monthIndex, 1));
+}
+
+// ---------------------------------------------------------------------------
 // urlCore
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Follow-up to a scheduled npm-package-replacement audit that identified three candidate "ad-hoc implementations" worth investigating: a hand-rolled debounce utility, a hand-rolled TTL cache/coalescing pattern, and duplicated UTC month-boundary math. On closer inspection, only the third candidate turned out to be a safe, worthwhile change. This PR implements that one and deliberately leaves the other two untouched, with the reasoning below so the audit trail isn't lost.

**What changed:** `packages/cli/src/runtime/relayUsage.ts` (`currentUtcMonthRange`, `parseUtcMonth`) and `packages/extension/src/settingsView/frontend/SettingsApp.ts` (`scheduleMonthlyProfileRefresh`) each independently computed `Date.UTC(y, m + 1, 1)` to find a UTC month boundary. Extracted the shared primitive `utcMonthStart(year, monthIndex)` into `src/utils/core/index.ts` (already browser-safe and already imported by both hosts) so the arithmetic exists in exactly one place.

**What I investigated and declined, with evidence:**

- **`createFlushableDebounce` → the `debounce` npm package.** I downloaded the package source and traced its `flush()`/`trigger()` path: it runs the callback *then* clears its timer/args state. A re-entrant `schedule()` call from inside the callback — which `StreamLogStore.ts`'s save-throttle and the CLI's transcript sync both depend on — would have its reschedule silently dropped. The hand-rolled version's own doc comment already explains this exact failure mode (naming `es-toolkit` as an example of a library that gets it wrong); swapping in `debounce` would reintroduce the same class of bug it was written to avoid. Left unchanged.
- **`ServerSideKeyService`'s access cache → `lru-cache`'s `fetchMethod`** (the pattern its sibling `TierService.ts` already uses correctly). I traced the existing test `"does not let a stale anonymous fetch erase authenticated access"` line by line: it requires starting a *second* concurrent fetch while the first is still in flight, and letting only the most-recently-started one commit to shared state while each caller still sees its own fetch's outcome. `lru-cache`'s `fetchMethod` does the opposite — single-flight dedup per key, where a second caller joins the first fetch rather than starting a new one. Mapping this onto `lru-cache` would break that guarantee, not just risk it. Left unchanged.
- **UTC math itself → `@date-fns/tz`.** Bare `date-fns` (already a dependency) resolves `startOfMonth`/`addMonths` in the local timezone, not UTC — using it without the separate `@date-fns/tz` package would silently produce wrong boundaries. Pulling in a new, currently-unused dependency into billing-critical code (`relayUsage.ts` has an explicit comment about a real abuse incident this schema guards against) for two ~10-line functions wasn't worth it. Plain `Date.UTC()`, deduplicated once, is simpler and more auditable.

## Issue acceptance gates

No linked issue — this is follow-up work from an ad-hoc scheduled codebase audit (not a filed issue).

## Single source of truth

`utcMonthStart(year, monthIndex)` in `src/utils/core/index.ts` is now the one place UTC month-boundary arithmetic is computed; both `relayUsage.ts` and `SettingsApp.ts` call it instead of repeating `Date.UTC(...)`.

## Duplication and abstraction budget

Removed: two independent copies of `Date.UTC(y, m + 1, 1)` boundary math (in `relayUsage.ts`'s two functions and in `SettingsApp.ts`'s timer scheduler). Added: one small, pure, browser-safe helper with no host coupling — not a pass-through wrapper, it owns the actual arithmetic both callers previously duplicated.

## Net elements (R6)

+1 exported function (`utcMonthStart`), 0 new files, 0 new classes/interfaces. Diff: `+43 / -11` across 4 files (incl. 1 new test block).

## Consumer counts (R8)

n/a — no emit path or existing export was deleted or re-routed; this only adds a new shared export and updates its two intended call sites.

## Host impact

Extension: `SettingsApp.ts` (settingsView frontend) — same computed timer delay, now via the shared helper.

Desktop: none.

CLI: `relayUsage.ts` (`texra usage` command's month-range resolution) — same computed boundaries, now via the shared helper.

## Scheduled refactoring

None — the two declined candidates (debounce library swap, lru-cache-based auth cache) are not recommended for future follow-up; the investigation above found each incompatible with existing, tested behavior, not merely risky.

## Validation

- `npm run typecheck` (all workspaces: root, test-kernel, agent, cli, trace-viewer, desktop) — clean.
- `npx eslint` on all 4 changed files — clean.
- `npx prettier --check` on all 4 changed files — clean (one auto-fix applied to `relayUsage.ts`).
- `node scripts/check-browser-safe-utils.mjs` — OK, 6 reachable modules unchanged (new export added to an already-reachable module).
- `npm run check:dead-code-ratchet` — OK, no new unused exports.
- Targeted `vitest run` on `UtilsCore.vitest.ts`, `RelayUsage.vitest.ts`, `ServerSideKeyService.vitest.ts`, `TierService.vitest.ts` (110 tests, including the exact UTC-boundary assertions this change touches) — all passed.
- Full `npm test` — **857 test files, 10189 tests passed (5 skipped, unrelated), 0 failures.**
