### PR TITLE
refactor(replacement): use shared createPatterns helper in maxRules

### DIFF
--- a/src/replacement/helpers.ts
+++ b/src/replacement/helpers.ts
@@ -15,7 +15,10 @@ type PatternMapper<T> = (item: T) => [string, string][];
  * Creates a pattern dictionary from items using a mapper function.
  * This is the core abstraction for all pattern generators.
  */
-function createPatterns<T>(items: T[], mapper: PatternMapper<T>): PatternDict {
+export function createPatterns<T>(
+  items: T[],
+  mapper: PatternMapper<T>,
+): PatternDict {
   return Object.fromEntries(items.flatMap(mapper));
 }
 

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -6,6 +6,7 @@ import type {
 import { GREEK_LETTERS } from './constants';
 import { NonRegexReplacementCategory, RegexReplacementCategory } from './types';
 import {
+  createPatterns,
   generateDecoratedMathShortcuts,
   generateDecoratorShortcuts,
   generateNestedDecoratorShortcuts,
@@ -147,49 +148,41 @@ const MAX_AUTO_PATTERNS: Record<string, string> = (() => {
   return {
     ...generateBackslashFixes(backslashFixCommands),
     // Math Operators: \mathrm{op} -> \op and \text{op} -> \op
-    ...Object.fromEntries(
-      mathOperators.flatMap((op) => [
-        [`\\mathrm{${op}}`, `\\${op}`],
-        [`\\text{${op}}`, `\\${op}`],
-        [`\\mbox{${op}}`, `\\${op}`],
-        [`\\textrm{${op}}`, `\\${op}`],
-        [`{\\rm ${op}}`, `\\${op}`],
-        [`_\\op`, `_{\\${op}}`],
-        [`^\\op`, `^{\\${op}}`],
-      ]),
-    ),
+    ...createPatterns(mathOperators, (op) => [
+      [`\\mathrm{${op}}`, `\\${op}`],
+      [`\\text{${op}}`, `\\${op}`],
+      [`\\mbox{${op}}`, `\\${op}`],
+      [`\\textrm{${op}}`, `\\${op}`],
+      [`{\\rm ${op}}`, `\\${op}`],
+      [`_\\op`, `_{\\${op}}`],
+      [`^\\op`, `^{\\${op}}`],
+    ]),
     // Text Commands: \text{cmd} -> \cmd
-    ...Object.fromEntries(
-      textCommands.flatMap((cmd) => [
-        [`\\text{${cmd}}`, `\\${cmd}`],
-        [`\\mathrm{${cmd}}`, `\\${cmd}`],
-        [`\\mbox{${cmd}}`, `\\${cmd}`],
-        [`\\textrm{${cmd}}`, `\\${cmd}`],
-        [`{\\rm ${cmd}}`, `\\${cmd}`],
-        [`_{\\${cmd}}`, `_\\${cmd}`],
-        [`^{\\${cmd}}`, `^\\${cmd}`],
-        [`_{${cmd}}`, `_\\${cmd}`],
-        [`^{${cmd}}`, `^\\${cmd}`],
-      ]),
-    ),
+    ...createPatterns(textCommands, (cmd) => [
+      [`\\text{${cmd}}`, `\\${cmd}`],
+      [`\\mathrm{${cmd}}`, `\\${cmd}`],
+      [`\\mbox{${cmd}}`, `\\${cmd}`],
+      [`\\textrm{${cmd}}`, `\\${cmd}`],
+      [`{\\rm ${cmd}}`, `\\${cmd}`],
+      [`_{\\${cmd}}`, `_\\${cmd}`],
+      [`^{\\${cmd}}`, `^\\${cmd}`],
+      [`_{${cmd}}`, `_\\${cmd}`],
+      [`^{${cmd}}`, `^\\${cmd}`],
+    ]),
     // Symbol operators: _{op} -> _\op (no braces needed)
-    ...Object.fromEntries(
-      symbolOperators.flatMap((op) => [
-        [`_{\\${op}}`, `_\\${op}`],
-        [`^{\\${op}}`, `^\\${op}`],
-      ]),
-    ),
+    ...createPatterns(symbolOperators, (op) => [
+      [`_{\\${op}}`, `_\\${op}`],
+      [`^{\\${op}}`, `^\\${op}`],
+    ]),
     ...generateDifferentialSpacing(differentialVariables, '~'),
-    ...Object.fromEntries(
-      fractionDiffVariables.flatMap((variable) => [
-        // Handle cases like {dx} -> {\\dd x}
-        [`{d${variable}}`, `{\\dd${variable}}`],
-        // Handle cases like \\frac{dx} -> \\frac{\\dd x}
-        [`\\frac{d${variable}`, `\\frac{\\dd${variable}`],
-        // Handle cases like \\frac{d}{dx} -> \\frac{\\dd}{\\dd x}
-        [`\\frac{d}{d${variable}}`, `\\frac{\\dd}{\\dd${variable}}`],
-      ]),
-    ),
+    ...createPatterns(fractionDiffVariables, (variable) => [
+      // Handle cases like {dx} -> {\\dd x}
+      [`{d${variable}}`, `{\\dd${variable}}`],
+      // Handle cases like \\frac{dx} -> \\frac{\\dd x}
+      [`\\frac{d${variable}`, `\\frac{\\dd${variable}`],
+      // Handle cases like \\frac{d}{dx} -> \\frac{\\dd}{\\dd x}
+      [`\\frac{d}{d${variable}}`, `\\frac{\\dd}{\\dd${variable}}`],
+    ]),
     '\\int d\\': '\\int \\dd\\',
     '\\int \\dd \\bx \\': '\\int \\dd \\bx~ \\',
     ...generateArrowRelationShortcuts(arrowRelationMap),
@@ -241,28 +234,25 @@ const MAX_AUTO_PATTERNS: Record<string, string> = (() => {
       'c',
     ),
     // Tilde with Greek: \tilde{\gamma} -> \tga
-    ...Object.fromEntries(
-      tildeGreekLetters.map((letter) => [
+    ...createPatterns(tildeGreekLetters, (letter) => [
+      [
         `\\tilde{\\${letter}}`,
         `\\t${GREEK_LETTER_SHORTCUTS[letter] ?? letter}`,
-      ]),
-    ),
+      ],
+    ]),
     // Tilde with boldsymbol+Greek: \tilde{\boldsymbol{\zeta}} -> \tbze
-    ...Object.fromEntries(
-      tildeGreekBoldLetters.map((letter) => [
+    ...createPatterns(tildeGreekBoldLetters, (letter) => [
+      [
         `\\tilde{\\boldsymbol{\\${letter}}}`,
         `\\tb${GREEK_LETTER_SHORTCUTS[letter] ?? letter}`,
-      ]),
-    ),
+      ],
+    ]),
     // Hat variables: \hat{H} -> \hH
     ...generateDecoratorShortcuts('hat', hatLetters, 'h'),
     // Hat with Greek: \hat{\sigma} -> \hsg
-    ...Object.fromEntries(
-      hatGreekLetters.map((letter) => [
-        `\\hat{\\${letter}}`,
-        `\\h${GREEK_LETTER_SHORTCUTS[letter] ?? letter}`,
-      ]),
-    ),
+    ...createPatterns(hatGreekLetters, (letter) => [
+      [`\\hat{\\${letter}}`, `\\h${GREEK_LETTER_SHORTCUTS[letter] ?? letter}`],
+    ]),
     // Hat with mathbf: \hat{\mathbf{n}} -> \hbn
     ...generateNestedDecoratorShortcuts(
       'hat',
@@ -272,23 +262,21 @@ const MAX_AUTO_PATTERNS: Record<string, string> = (() => {
       'b',
     ),
     // Hat with boldsymbol+Greek: \hat{\boldsymbol{\zeta}} -> \hbze
-    ...Object.fromEntries(
-      hatBoldsymbolLetters.map((letter) => [
+    ...createPatterns(hatBoldsymbolLetters, (letter) => [
+      [
         `\\hat{\\boldsymbol{\\${letter}}}`,
         `\\hb${GREEK_LETTER_SHORTCUTS[letter] ?? letter}`,
-      ]),
-    ),
+      ],
+    ]),
     // Bold backslash fixes: \\ba -> \ba (lowercase), \\bA -> \bA (uppercase)
     ...generateBackslashFixes(
       [...lowerLetters, ...mathbfUpperLetters].map((letter) => `b${letter}`),
     ),
-    ...Object.fromEntries(
-      functionNames.flatMap((name) => [
-        [`\\${name}_`, `${name}_`],
-        [`\\${name}^`, `${name}^`],
-        [`\\${name}(`, `${name}(`],
-      ]),
-    ),
+    ...createPatterns(functionNames, (name) => [
+      [`\\${name}_`, `${name}_`],
+      [`\\${name}^`, `${name}^`],
+      [`\\${name}(`, `${name}(`],
+    ]),
   };
 })();
 

--- a/src/replacement/rules.ts
+++ b/src/replacement/rules.ts
@@ -6,6 +6,7 @@ import {
   SECTION_TYPES,
 } from '@replacement/constants';
 import {
+  createPatterns,
   generateBackslashFixes,
   generateEnvironmentBracesFixes,
   generateEnvironmentLinebreakFixes,
@@ -104,20 +105,18 @@ export const EQUATION_REPLACEMENTS: NonRegexReplacementCategory = {
     // Greek letter notation fixes
     // Examples: \a_ -> a_, \a^ -> a^
     const letters = [...'abcdefghijklmnopqrstuvwyz'];
-    const letterNotationFixes = Object.fromEntries(
-      letters.flatMap((letter) => [
-        [`\\${letter}_`, `${letter}_`],
-        [`\\${letter}^`, `${letter}^`],
-      ]),
-    );
+    const letterNotationFixes = createPatterns(letters, (letter) => [
+      [`\\${letter}_`, `${letter}_`],
+      [`\\${letter}^`, `${letter}^`],
+    ]);
 
     // Environment end command fixes
     // Examples: \n\\nend{align} -> \n\end{align}
     const environments =
       'align equation itemize enumerate figure tikzpicture document'.split(' ');
-    const envEndFixes = Object.fromEntries(
-      environments.map((env) => [`\n\\\nend{${env}}`, `\n\\end{${env}}`]),
-    );
+    const envEndFixes = createPatterns(environments, (env) => [
+      [`\n\\\nend{${env}}`, `\n\\end{${env}}`],
+    ]);
 
     // Environment braces/brackets fixes
     // Examples: {\align} -> {align}
@@ -176,23 +175,19 @@ export const FONT_COMMAND_REPLACEMENTS: NonRegexReplacementCategory = {
   description: 'Normalize deprecated font commands to modern equivalents',
   isRegex: false,
   patterns: {
-    ...Object.fromEntries(
-      [...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'].flatMap(
-        (letter) => [
-          [`{\\rm ${letter}}`, `\\mathrm{${letter}}`],
-          [`{\\bf ${letter}}`, `\\mathbf{${letter}}`],
-          [`{\\it ${letter}}`, `\\mathit{${letter}}`],
-          [`{\\sf ${letter}}`, `\\mathsf{${letter}}`],
-          [`{\\tt ${letter}}`, `\\mathtt{${letter}}`],
-        ],
-      ),
+    ...createPatterns(
+      [...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'],
+      (letter) => [
+        [`{\\rm ${letter}}`, `\\mathrm{${letter}}`],
+        [`{\\bf ${letter}}`, `\\mathbf{${letter}}`],
+        [`{\\it ${letter}}`, `\\mathit{${letter}}`],
+        [`{\\sf ${letter}}`, `\\mathsf{${letter}}`],
+        [`{\\tt ${letter}}`, `\\mathtt{${letter}}`],
+      ],
     ),
-    ...Object.fromEntries(
-      [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'].map((letter) => [
-        `{\\cal ${letter}}`,
-        `\\mathcal{${letter}}`,
-      ]),
-    ),
+    ...createPatterns([...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'], (letter) => [
+      [`{\\cal ${letter}}`, `\\mathcal{${letter}}`],
+    ]),
   },
 };
 
@@ -491,18 +486,16 @@ export const LATEX_XML_REPLACEMENTS: NonRegexReplacementCategory = {
       // Fix LaTeX tags closed as XML-style end tags with a trailing '>'; the
       // plain `\end{env>}`/`\end{env>` spellings already come from
       // generateXmlLatexConversions above.
-      ...Object.fromEntries(
-        LATEX_ENVIRONMENTS.map((env) => [`</end{${env}>`, `\\end{${env}}`]),
-      ),
+      ...createPatterns(LATEX_ENVIRONMENTS, (env) => [
+        [`</end{${env}>`, `\\end{${env}}`],
+      ]),
 
       // ===== 2. XML BRACE FIXES =====
       // Fix XML tags with extra braces that remain as XML
-      ...Object.fromEntries(
-        pureXmlTags.flatMap((tag) => [
-          [`<${tag}}`, `<${tag}>`],
-          [`</${tag}}`, `</${tag}>`],
-        ]),
-      ),
+      ...createPatterns(pureXmlTags, (tag) => [
+        [`<${tag}}`, `<${tag}>`],
+        [`</${tag}}`, `</${tag}>`],
+      ]),
 
       // ===== 3. Special Case Handling =====
       // Special cases for minipage

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -6,6 +6,7 @@ import {
   FENCED_LATEX_BLOCK_PATTERN_INLINE,
   FENCED_LATEX_BLOCK_PATTERN_MULTILINE,
 } from './constants';
+import { createPatterns } from './helpers';
 
 const EQUATION_ENVIRONMENT_PATTERN =
   '(?:align\\*?|aligned\\*?|alignat\\*?|flalign\\*?|gather\\*?|multline\\*?|equation\\*?|eqnarray\\*?|split\\*?)';
@@ -399,7 +400,7 @@ export const EQUATION_STYLE_REPLACEMENTS: RegexReplacementCategory = {
     // '\\\\(textbf|textit|emph|underline)\\{([^{}]*)\\s+\\}': '\\\\$1{$2}', // might not working now
 
     // Remove spaces inside textbf/textit/emph/underline/overbrace/underbrace/label
-    ...Object.fromEntries(
+    ...createPatterns(
       [
         'textbf',
         'textit',
@@ -408,7 +409,8 @@ export const EQUATION_STYLE_REPLACEMENTS: RegexReplacementCategory = {
         'overbrace',
         'underbrace',
         'label',
-      ].map((cmd) => [`\\\\${cmd}\\{\\s+([^}]*)\\s+\\}`, `\\${cmd}{$1}`]),
+      ],
+      (cmd) => [[`\\\\${cmd}\\{\\s+([^}]*)\\s+\\}`, `\\${cmd}{$1}`]],
     ),
     // Remove spaces inside caption (only horizontal whitespace, preserving newlines for multi-line captions)
     '\\\\caption\{((?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*)\}':


### PR DESCRIPTION
## Summary

`src/replacement/helpers.ts` already defines a `createPatterns(items, mapper)` factory documented as "the core abstraction for all pattern generators," but it was not exported, so other modules in the replacement package open-coded the identical `Object.fromEntries(items.flatMap/map(...))` idiom for their bespoke pattern groups.

This PR exports `createPatterns` and routes all 16 open-coded sites in the package through it:
- **`maxRules.ts`** — 9 sites (math operators, text commands, symbol operators, fraction differentials, tilde Greek, tilde-boldsymbol Greek, hat Greek, hat-boldsymbol Greek, function names).
- **`rules.ts`** — 6 sites (letter-notation fixes, environment-end fixes, legacy-font normalization, mathcal-font normalization, and two XML tag-fix groups).
- **`rulesRegex.ts`** — 1 site (spaced text-command normalization).

The transformation is behavior-preserving by construction: `createPatterns(items, m)` *is* `Object.fromEntries(items.flatMap(m))`, and each former `.map(x => [k, v])` becomes a mapper returning `[[k, v]]` (flattened identically). Key insertion order and duplicate-key last-wins semantics are unchanged because both paths feed the same entry sequence to `Object.fromEntries`.

This is the cleanly-safe, self-contained item from a broader tech-debt audit of the replacement/model-handler/host/tool layers. The other audited areas turned out to be already factored to a shared kernel with genuinely-divergent remainders, or to be larger behavior-sensitive refactors better suited to their own reviewed PRs — so they are intentionally out of scope here. (The extension from `maxRules.ts` alone to the rest of the package follows a reviewer suggestion on this PR.)

## Issue acceptance gates

No issue — proactive tech-debt cleanup. No acceptance gates.

## Single source of truth

`createPatterns` in `src/replacement/helpers.ts` is now the single owner of the "build a pattern dictionary from items via a mapper" construction across the whole package — the in-module generators, `maxRules.ts`, `rules.ts`, and `rulesRegex.ts`. After this PR, no `Object.fromEntries` open-coding of pattern maps remains in `src/replacement/` outside the helper's own definition.

## Duplication and abstraction budget

Removed all 16 open-coded `Object.fromEntries(items.flatMap/map(...))` pattern-map sites in the package, replacing them with calls to the pre-existing `createPatterns` factory. No new abstraction introduced — the factory already existed with multiple in-module callers; this only widens its visibility to same-package consumers. No pass-through layer added. A singular-pair helper variant was deliberately not added (it would be an unjustified new abstraction); single-pair sites use the `[[k, v]]` mapper shape inherent to `PatternMapper`.

## Net elements (R6)

- Files: 4 changed (`helpers.ts`, `maxRules.ts`, `rules.ts`, `rulesRegex.ts`), 0 added, 0 deleted.
- Exported symbols: +1 (`createPatterns`), −0. (`PatternMapper` deliberately kept unexported — a type export with no consumer would trip the dead-code ratchet.)
- Classes/interfaces/enums: no change.
- Net LoC: **−14** (88 insertions, 102 deletions).

## Consumer counts (R8)

No emit path or export was deleted or re-routed. The one new export, `createPatterns`, gains consumers in the same PR: `maxRules.ts` (9 call sites), `rules.ts` (6), `rulesRegex.ts` (1) — plus its existing in-module callers in `helpers.ts`. This satisfies the dead-code-ratchet's "new export needs a consumer" rule.

## Host impact

Extension: none (shared `src/` core only; no host wiring touched).

Desktop: none.

CLI: none.

## Scheduled refactoring

None. The broader audit's remaining items (KaTeX-macro drift guard, model-handler `createResponseImpl` template method, per-stream KV-store base class) are noted for potential follow-up PRs but are not tracked by an issue here.

## Validation

- `npm run typecheck` — full monorepo type check, green (exit 0); root `tsconfig.json` project re-checked green after the `rules.ts`/`rulesRegex.ts` additions.
- `npx vitest run src/test-kernel/replacement/` — 65/65 pass.
- Confirmed generated `max_style` pattern maps unchanged (1232 `max_style` + 13 `max_style_regex`).
- `eslint` + `prettier --check` on all changed files — clean.
- Grep confirms no `Object.fromEntries` pattern-map open-coding remains in `src/replacement/` outside `helpers.ts`, and no `vscode` import exists anywhere in the package (VS Code-free zone preserved).
