### PR TITLE
ci: make remote-agents drift detection rename-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,14 @@ jobs:
           base='${{ github.event.pull_request.base.sha }}'
           head='${{ github.event.pull_request.head.sha }}'
           files="$(git diff --name-only "$base...$head")"
+          # --name-status keeps a rename's source path on the R### line, so a
+          # rename of either drift-gate file is still detected as touching it.
+          name_status="$(git diff --name-status "$base...$head")"
           echo "Changed files in this PR:"
           printf '%s\n' "$files"
           # Keep these docs-side paths synchronized with configPath and
           # defaultOutputPath in scripts/sync-remote-agents.mjs.
-          if printf '%s\n' "$files" | grep -qE '^docs/supabase/(SYNC_REMOTE_AGENTS\.sql|remote-agents\.config\.json)$'; then
+          if printf '%s\n' "$name_status" | grep -qE 'docs/supabase/(SYNC_REMOTE_AGENTS\.sql|remote-agents\.config\.json)'; then
             echo "remote_agent_docs=true" >> "$GITHUB_OUTPUT"
           else
             echo "remote_agent_docs=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           printf '%s\n' "$files"
           # Keep these docs-side paths synchronized with configPath and
           # defaultOutputPath in scripts/sync-remote-agents.mjs.
-          if printf '%s\n' "$name_status" | grep -qE 'docs/supabase/(SYNC_REMOTE_AGENTS\.sql|remote-agents\.config\.json)'; then
+          if printf '%s\n' "$name_status" | grep -qE '(^|\t)docs/supabase/(SYNC_REMOTE_AGENTS\.sql|remote-agents\.config\.json)(\t|$)'; then
             echo "remote_agent_docs=true" >> "$GITHUB_OUTPUT"
           else
             echo "remote_agent_docs=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Closes #10170. Make the `remote_agent_docs` drift detection rename-aware: `git diff --name-only` reports only the destination path for a detected rename, so renaming `docs/supabase/remote-agents.config.json` or `docs/supabase/SYNC_REMOTE_AGENTS.sql` out of `docs/supabase/` would skip the remote-agents sync job. Consult `git diff --name-status`, whose `R###` line keeps the source path, so a rename of either gate file is still classified as touching it.

## Issue acceptance gates

- Renaming either drift-gate file still triggers the remote-agents SQL sync check.

## Single source of truth

The two drift-gate file paths remain the single classification authority, now matched against `--name-status` output.

## Duplication and abstraction budget

No new abstraction; one additional `git diff` variant for the detection.

## Net elements (R6)

- Files changed: 1 (`.github/workflows/ci.yml`)
- Net LoC: +2

## Consumer counts (R8)

n/a.

## Host impact

Extension: none
Desktop: none
CLI: none

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --check .github/workflows/ci.yml`
