### PR TITLE
refactor(model): inline hasManagedDirectRoute into isKimiCodeExclusiveModel

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerKimi.ts
@@ -6,7 +6,6 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { TokenCountOptions } from '@agent/types/ModelHandlerContracts';
 import type { ToolDefinition } from '@model/ToolDefinition';
 import { isKimiCodeExclusiveModel } from '@model/kimiCodeSubscriptionRouting';
-import { hasManagedDirectRoute } from '@model/openRouterRouting';
 import { AUXILIARY_MAX_RETRIES } from '../support/auxiliaryRetry';
 import { resolveMoonshotRequestParameters } from '../support/moonshotRequestParameters';
 import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
@@ -160,7 +159,7 @@ export class ModelHandlerKimi extends ReasoningModelHandlerOpenAI {
     // may expose only the configured chat endpoint, so they must opt in via
     // capabilities before this handler calls the auxiliary tokenizer route.
     return (
-      !hasManagedDirectRoute(this.config) ||
+      !isKimiCodeExclusiveModel(this.config) ||
       this.capabilities.supportsTokenCounting
     );
   }

--- a/src/model/openRouterRouting.ts
+++ b/src/model/openRouterRouting.ts
@@ -40,19 +40,12 @@ interface OpenRouterRoutingConfig {
 export type ModelRoutingConfig = OpenRouterRoutingConfig &
   KimiSubscriptionModelFields;
 
-/** Whether a registry entry owns an atomic managed-service route. */
-export function hasManagedDirectRoute(
-  config: Pick<ModelRoutingConfig, 'provider' | 'kimiSubscription' | 'baseUrl'>,
-): boolean {
-  return isKimiCodeExclusiveModel(config);
-}
-
 function isOpenRouterAccessSelected(
   config: ModelRoutingConfig,
   useOpenRouter: boolean,
 ): boolean {
   return (
-    !hasManagedDirectRoute(config) &&
+    !isKimiCodeExclusiveModel(config) &&
     !config.forceDirectProvider &&
     (config.openRouterOnly || useOpenRouter)
   );
@@ -84,7 +77,7 @@ export function resolveModelApiKeyProvider(
 export function resolveDirectModelApiKeyProvider(
   config: Pick<ModelRoutingConfig, 'provider' | 'kimiSubscription' | 'baseUrl'>,
 ): ApiProvider | undefined {
-  if (hasManagedDirectRoute(config)) return 'kimiCode';
+  if (isKimiCodeExclusiveModel(config)) return 'kimiCode';
   return config.provider && isApiProvider(config.provider)
     ? config.provider
     : undefined;
@@ -94,14 +87,14 @@ export function resolveDirectModelApiKeyProvider(
 export function resolveModelSource(
   config: Pick<ModelRoutingConfig, 'provider' | 'kimiSubscription' | 'baseUrl'>,
 ): string | undefined {
-  return hasManagedDirectRoute(config) ? 'kimiCode' : config.provider;
+  return isKimiCodeExclusiveModel(config) ? 'kimiCode' : config.provider;
 }
 
 /** Whether a model may be sent through TeXRA's included-access relay. */
 export function allowsModelRelay(
   config: Pick<ModelRoutingConfig, 'provider' | 'kimiSubscription' | 'baseUrl'>,
 ): boolean {
-  return !hasManagedDirectRoute(config);
+  return !isKimiCodeExclusiveModel(config);
 }
 
 /** Return whether this model request should be routed through OpenRouter. */


### PR DESCRIPTION
## Summary

Inline the one-line `hasManagedDirectRoute` alias in `src/model/openRouterRouting.ts` into the single managed-route resolver `isKimiCodeExclusiveModel`. The alias forwarded straight to that resolver and owned no distinct fact, so it was pure module indirection. All five call sites (four in `openRouterRouting.ts`, one in `modelHandlerKimi.ts`) now read `isKimiCodeExclusiveModel` directly, and the exported alias is deleted.

## Issue acceptance gates

- #10165: the alias is removed, every call site reads the single resolver, and behavior is identical (`hasManagedDirectRoute` was `return isKimiCodeExclusiveModel(config)`).

## Single source of truth

`isKimiCodeExclusiveModel` in `src/model/kimiCodeSubscriptionRouting.ts` remains the single resolver for whether a registry entry owns an atomic managed-service route.

## Duplication and abstraction budget

Removes one exported pass-through alias; no new abstraction.

## Net elements (R6)

- Files: 2 changed (+5/-13)
- Exported symbols: -1 (`hasManagedDirectRoute`)
- Classes/interfaces/enums: 0
- Net LoC: -8

## Consumer counts (R8)

- `hasManagedDirectRoute`: 5 call sites, all re-routed to `isKimiCodeExclusiveModel` in this PR.

## Host impact

Extension: none

Desktop: none

CLI: none

## Scheduled refactoring

None

## Validation

- `npm run typecheck:workspace` passed
- Full CI (static checks, kernel tests, build artifacts) runs on this PR