### PR TITLE
refactor(model): fold codex/xai subscription-preference wrappers

### DIFF
--- a/src/model/codex/codexPreference.ts
+++ b/src/model/codex/codexPreference.ts
@@ -19,13 +19,7 @@ export type CodexSubscriptionPreferenceUpdate = SubscriptionPreferenceUpdate;
 const preference = createSubscriptionPreference(CODEX_PREFER_SUBSCRIPTION_KEY);
 
 /** Whether the user has switched on "prefer ChatGPT subscription". */
-export function isPreferCodexSubscription(): boolean {
-  return preference.isPrefer();
-}
+export const isPreferCodexSubscription = preference.isPrefer;
 
 /** Update the preference at the scope that currently controls its value. */
-export async function setPreferCodexSubscription(
-  enabled: boolean,
-): Promise<CodexSubscriptionPreferenceUpdate> {
-  return preference.setPrefer(enabled);
-}
+export const setPreferCodexSubscription = preference.setPrefer;

--- a/src/model/xai/xaiPreference.ts
+++ b/src/model/xai/xaiPreference.ts
@@ -18,13 +18,7 @@ export type XaiSubscriptionPreferenceUpdate = SubscriptionPreferenceUpdate;
 const preference = createSubscriptionPreference(XAI_PREFER_SUBSCRIPTION_KEY);
 
 /** Whether the user has switched on "prefer Grok subscription". */
-export function isPreferXaiSubscription(): boolean {
-  return preference.isPrefer();
-}
+export const isPreferXaiSubscription = preference.isPrefer;
 
 /** Update the preference at the scope that currently controls its value. */
-export async function setPreferXaiSubscription(
-  enabled: boolean,
-): Promise<XaiSubscriptionPreferenceUpdate> {
-  return preference.setPrefer(enabled);
-}
+export const setPreferXaiSubscription = preference.setPrefer;


### PR DESCRIPTION
## Summary

`codexPreference.ts` and `xaiPreference.ts` each wrapped the same `createSubscriptionPreference(configKey)` accessors in two one-line functions. They now re-export the accessors directly, so each provider differs only in its config key, type alias, and public names.

## Issue acceptance gates

- #10164: the two provider modules no longer open-code the wrapper functions; they re-export the shared accessors, and the existing exported names are unchanged.

## Single source of truth

`createSubscriptionPreference` in `src/model/subscriptionPreference.ts` remains the single implementation of read/write preference semantics.

## Duplication and abstraction budget

Removes 12 lines of duplicated one-line wrappers; no new abstraction.

## Net elements (R6)

- Files: 2 changed (+4/-16)
- Exported symbols: 0 net change
- Classes/interfaces/enums: 0
- Net LoC: -12

## Consumer counts (R8)

- n/a: no export or emit path was deleted or re-routed; the four functions and two type aliases keep identical names and types.

## Host impact

Extension: none (same named exports)

Desktop: none (same named exports)

CLI: none (same named exports)

## Scheduled refactoring

None

## Validation

- `npm run typecheck:workspace` passed
- `npx vitest run src/test-kernel/auth/CodexPreference.vitest.ts src/test-kernel/cli/SlashCommandDispatch.vitest.ts` passed (44 tests)
- Full CI runs on this PR