### PR TITLE
refactor(model): collapse apiKeyExists into hasUsableApiKey

### DIFF
--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -1,7 +1,10 @@
 import { getCodexStatus } from '@auth/codex';
 import { getXaiStatus, xaiAccountLabel } from '@auth/xai';
 import { codexAccountLabel } from '@auth/codex/codexSessionTypes';
-import { apiKeyExists, configuredApiKeyProviders } from '@model/apiProviders';
+import {
+  configuredApiKeyProviders,
+  hasUsableApiKey,
+} from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import {
   codingPlanSubscriptionRuntimes,
@@ -71,7 +74,7 @@ export async function readCliModelAccessStatus(
               runtime.descriptor.id,
               {
                 preferred: runtime.getEnabled(),
-                keySet: await apiKeyExists(
+                keySet: await hasUsableApiKey(
                   secrets,
                   runtime.descriptor.apiProvider,
                 ),
@@ -215,7 +218,7 @@ async function updateKeyedCliModelAccess(
 
   // The provider API key is the subscription credential — there is no
   // separate sign-in flow.
-  if (!(await apiKeyExists(platform().secrets, plan.apiProvider))) {
+  if (!(await hasUsableApiKey(platform().secrets, plan.apiProvider))) {
     return {
       apiMode,
       message: `No ${plan.credentialName} API key configured — add one with /key or /config → API keys (get one at ${plan.credentialSetupUrl}).`,

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -172,28 +172,15 @@ export async function getApiKey(
 /**
  * Check whether a usable API key is resolved for a provider (secret storage,
  * then environment, both already trimmed and blank-filtered by
- * {@link resolveApiKeyUncached}). `apiKeyExists` and `hasUsableApiKey` are
- * intentionally the same check under two names — kept distinct, like the
- * lookup trio above, so call sites read self-evidently: reach for
- * `apiKeyExists` at plain "is a key configured" display sites, and
- * `hasUsableApiKey` at security-sensitive sites (credential-retry decisions,
- * launch-readiness checks) where the name should make the stakes obvious.
- * There is only one implementation; do not let a future edit reintroduce a
- * real behavioral gap between them without renaming one away.
+ * {@link resolveApiKeyUncached}). This is the single cached existence check;
+ * `apiKeyExistsUncached` below is the uncached variant for call sites that
+ * must bypass the process-wide provider cache.
  */
 export async function hasUsableApiKey(
   secrets: PlatformSecrets,
   provider: ApiProvider,
 ): Promise<boolean> {
   return isNonEmptyString(await lookupApiKey(secrets, provider));
-}
-
-/** Alias of {@link hasUsableApiKey} for existence-check call sites. See its doc. */
-export async function apiKeyExists(
-  secrets: PlatformSecrets,
-  provider: ApiProvider,
-): Promise<boolean> {
-  return hasUsableApiKey(secrets, provider);
 }
 
 /** Check if an API key exists without using the process-wide provider cache. */

--- a/src/model/codingPlanSubscriptions.ts
+++ b/src/model/codingPlanSubscriptions.ts
@@ -1,6 +1,6 @@
 import { ModelProvider } from 'llm-zoo';
 
-import { apiKeyExists } from '@model/apiProviders';
+import { hasUsableApiKey } from '@model/apiProviders';
 import { includedModelAccess } from '@model/includedModelAccess';
 import { shouldRouteModelThroughOpenRouter } from '@model/openRouterRouting';
 import { isKimiCodeSubscriptionActive } from '@model/providerCapabilities';
@@ -46,7 +46,7 @@ async function isGlmCodingPlanActive(modelId: string): Promise<boolean> {
   ) {
     return false;
   }
-  return apiKeyExists(platform().secrets, 'glm');
+  return hasUsableApiKey(platform().secrets, 'glm');
 }
 
 const RUNTIME_BY_ID = {

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -22,8 +22,8 @@ import {
 } from '@utils/config/providerConfig';
 
 import {
-  apiKeyExists,
   apiKeyExistsUncached,
+  hasUsableApiKey,
   type ApiProvider,
 } from './apiProviders';
 import {
@@ -284,7 +284,7 @@ async function getPersonalAccessKindForModel(
   if (!provider) return null;
 
   try {
-    if (await ctx.apiKeyExists(provider)) {
+    if (await ctx.hasUsableApiKey(provider)) {
       return 'provider-key';
     }
   } catch {
@@ -298,7 +298,7 @@ async function getPersonalAccessKindForModel(
 }
 
 interface ModelAvailabilityContext {
-  apiKeyExists(provider: ApiProvider): Promise<boolean>;
+  hasUsableApiKey(provider: ApiProvider): Promise<boolean>;
   hasOpenRouter: boolean;
   hasServerAccess: boolean;
   relayQuotaExhausted: boolean;
@@ -474,7 +474,7 @@ async function buildAvailabilityContext(
   const { serverSideKeyService } = access;
   const hasApiKey = (provider: ApiProvider) =>
     useApiKeyCache
-      ? apiKeyExists(access.secrets, provider)
+      ? hasUsableApiKey(access.secrets, provider)
       : apiKeyExistsUncached(access.secrets, provider);
   const useIncludedAccess = serverSideKeyService.getUseIncludedModelAccess();
   const [
@@ -498,7 +498,7 @@ async function buildAvailabilityContext(
       : Promise.resolve(false),
   ]);
   return {
-    apiKeyExists: hasApiKey,
+    hasUsableApiKey: hasApiKey,
     hasOpenRouter,
     hasServerAccess,
     includedAccessSignedOut,

--- a/src/model/kimiCodeSubscriptionRouting.ts
+++ b/src/model/kimiCodeSubscriptionRouting.ts
@@ -24,7 +24,7 @@ import { platform } from '@platform/platform';
 import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
 import { getPreferKimiCode } from '@utils/config/providerConfig';
 
-import { apiKeyExists } from './apiProviders';
+import { hasUsableApiKey } from './apiProviders';
 import { includedModelAccess } from './includedModelAccess';
 import { zeroCostAccessOverrides } from './subscriptionAccessOverrides';
 
@@ -171,7 +171,7 @@ export async function resolveKimiCodeRoutingFacts(
     : false;
   return {
     useOpenRouter,
-    keySet: await apiKeyExists(platform().secrets, 'kimiCode'),
+    keySet: await hasUsableApiKey(platform().secrets, 'kimiCode'),
     preferKimiCode: getPreferKimiCode(),
     includedAccess,
   };

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.ts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.ts
@@ -29,7 +29,7 @@ const mocks = vi.hoisted(() => ({
   signInCliChatGpt: vi.fn(),
   signInCliGrok: vi.fn(),
   updateGlobalState: vi.fn(),
-  apiKeyExists: vi.fn(),
+  hasUsableApiKey: vi.fn(),
   lookupApiKeyOrigin: vi.fn(),
   getPreferKimiCode: vi.fn(),
   setPreferKimiCode: vi.fn(),
@@ -81,7 +81,7 @@ vi.mock('@model/apiProviders', () => {
   ];
   return {
     API_PROVIDERS: providers,
-    apiKeyExists: mocks.apiKeyExists,
+    hasUsableApiKey: mocks.hasUsableApiKey,
     lookupApiKeyOrigin: mocks.lookupApiKeyOrigin,
     configuredApiKeyProviders: async () => {
       const origins = await Promise.all(
@@ -194,7 +194,7 @@ beforeEach(() => {
     openRouterDisabled: false,
   }));
   mocks.shouldUseSubscriptionDeviceCode.mockReturnValue(false);
-  mocks.apiKeyExists.mockResolvedValue(false);
+  mocks.hasUsableApiKey.mockResolvedValue(false);
   mocks.lookupApiKeyOrigin.mockResolvedValue('none');
   mocks.getPreferKimiCode.mockReturnValue(false);
   mocks.setPreferKimiCode.mockResolvedValue(undefined);
@@ -384,7 +384,7 @@ describe('CLI model access routes', () => {
   });
 
   it('reports the Kimi preference independently of key and fallback', async () => {
-    mocks.apiKeyExists.mockImplementation(
+    mocks.hasUsableApiKey.mockImplementation(
       async (_secrets, provider) => provider === 'kimiCode',
     );
     mocks.getPreferKimiCode.mockReturnValue(true);
@@ -407,7 +407,7 @@ describe('CLI model access routes', () => {
       codingPlans: { kimiCode: { preferred: true, keySet: true } },
     });
 
-    mocks.apiKeyExists.mockResolvedValue(false);
+    mocks.hasUsableApiKey.mockResolvedValue(false);
     await expect(readCliModelAccessStatus('personal')).resolves.toMatchObject({
       apiFallback: 'personal',
       codingPlans: { kimiCode: { preferred: true, keySet: false } },
@@ -448,7 +448,7 @@ describe('CLI model access routes', () => {
   });
 
   it('enables Kimi Code routing on a personal fallback when a key exists', async () => {
-    mocks.apiKeyExists.mockResolvedValue(true);
+    mocks.hasUsableApiKey.mockResolvedValue(true);
 
     const result = await updateCliModelAccess(
       context,
@@ -482,7 +482,7 @@ describe('CLI model access routes', () => {
   });
 
   it('reports the GLM Coding Plan preference independently of key and fallback', async () => {
-    mocks.apiKeyExists.mockImplementation(
+    mocks.hasUsableApiKey.mockImplementation(
       async (_secrets, provider) => provider === 'glm',
     );
     mocks.getGLMCodingPlan.mockReturnValue(true);
@@ -507,7 +507,7 @@ describe('CLI model access routes', () => {
   });
 
   it('enables GLM Coding Plan routing on a personal fallback when a key exists', async () => {
-    mocks.apiKeyExists.mockResolvedValue(true);
+    mocks.hasUsableApiKey.mockResolvedValue(true);
 
     const result = await updateCliModelAccess(
       context,
@@ -550,7 +550,7 @@ describe('CLI model access routes', () => {
       { writeProgress: vi.fn() },
     );
 
-    expect(mocks.apiKeyExists).not.toHaveBeenCalled();
+    expect(mocks.hasUsableApiKey).not.toHaveBeenCalled();
     expect(mocks.setGLMCodingPlan).toHaveBeenCalledWith(false);
     expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
     expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
@@ -673,7 +673,7 @@ describe('CLI model access routes', () => {
     });
     mocks.isPreferCodexSubscription.mockReturnValue(true);
     mocks.getPreferKimiCode.mockReturnValue(true);
-    mocks.apiKeyExists.mockResolvedValue(true);
+    mocks.hasUsableApiKey.mockResolvedValue(true);
 
     const status = await readCliModelAccessStatus('personal');
     expect(status.preferences).toEqual({
@@ -769,7 +769,7 @@ describe('CLI model access routes', () => {
     vi.clearAllMocks();
     await updateCliModelAccess(context, selection.value);
 
-    expect(mocks.apiKeyExists).not.toHaveBeenCalled();
+    expect(mocks.hasUsableApiKey).not.toHaveBeenCalled();
     expect(mocks.setPreferKimiCode).toHaveBeenCalledWith(false);
     expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Delete the `apiKeyExists` one-line alias in `src/model/apiProviders.ts` and route every call site through `hasUsableApiKey`, the single cached existence check. `apiKeyExistsUncached` remains the separate uncached variant. The `ModelAvailabilityContext` seam is renamed to `hasUsableApiKey` so the alias name no longer appears in production code.

## Issue acceptance gates

- #10163: the alias is deleted; all former `apiKeyExists` call sites call `hasUsableApiKey`; `apiKeyExistsUncached` is unchanged and still used for uncached reads.

## Single source of truth

`hasUsableApiKey` is the single cached API-key existence check; `apiKeyExistsUncached` is the single uncached variant.

## Duplication and abstraction budget

Removes a duplicated exported name; no new abstraction.

## Net elements (R6)

- Files: 6 changed (+29/-39)
- Exported symbols: -1 (`apiKeyExists`)
- Classes/interfaces/enums: 0
- Net LoC: -10

## Consumer counts (R8)

- `apiKeyExists`: 5 production call sites + 1 test mock, all re-routed to `hasUsableApiKey` in this PR.

## Host impact

Extension: none

Desktop: none

CLI: none (same behavior, renamed symbol)

## Scheduled refactoring

None

## Validation

- `npm run typecheck` passed
- `npm run check:dead-code-ratchet` passed
- `npx vitest run src/test-kernel/cli/ModelAccessSelection.vitest.ts src/test-kernel/model/ApiProviders.vitest.ts` passed (54 tests)
- Full CI runs on this PR