### PR TITLE
Extract utcMonthStart utility function

### DIFF
--- a/packages/cli/src/runtime/relayUsage.ts
+++ b/packages/cli/src/runtime/relayUsage.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { SUPABASE_CONFIG, getRelaySpendingLimit } from '@auth/config';
+import { utcMonthStart } from '@utils/core';
 
 const USAGE_PAGE_SIZE = 1000;
 
@@ -56,11 +57,12 @@ export function currentUtcMonthRange(now = new Date()): {
   start: Date;
   end: Date;
 } {
-  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
-  const end = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1),
-  );
-  return { start, end };
+  const year = now.getUTCFullYear();
+  const monthIndex = now.getUTCMonth();
+  return {
+    start: utcMonthStart(year, monthIndex),
+    end: utcMonthStart(year, monthIndex + 1),
+  };
 }
 
 export function parseUtcMonth(month: string): { start: Date; end: Date } {
@@ -74,9 +76,10 @@ export function parseUtcMonth(month: string): { start: Date; end: Date } {
     throw new Error('Expected month in YYYY-MM format.');
   }
 
-  const start = new Date(Date.UTC(year, monthIndex, 1));
-  const end = new Date(Date.UTC(year, monthIndex + 1, 1));
-  return { start, end };
+  return {
+    start: utcMonthStart(year, monthIndex),
+    end: utcMonthStart(year, monthIndex + 1),
+  };
 }
 
 export async function fetchRelayUsageSummary(input: {

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -30,6 +30,7 @@ import {
   registerTeXRAWebAwesomeIcons,
   waIcon,
 } from '@shared/wa/webAwesomeIcons';
+import { utcMonthStart } from '@utils/core';
 
 // Local imports - settings view
 import {
@@ -169,11 +170,10 @@ export class SettingsApp extends SettingsAppBase {
     }
     const now = Date.now();
     const date = new Date(now);
-    const nextMonthUtc = Date.UTC(
+    const nextMonthUtc = utcMonthStart(
       date.getUTCFullYear(),
       date.getUTCMonth() + 1,
-      1,
-    );
+    ).getTime();
     const delay = Math.min(nextMonthUtc - now, MAX_TIMEOUT_MS);
     this.monthlyProfileRefreshTimer = setTimeout(() => {
       if (Date.now() >= nextMonthUtc) {

--- a/src/test-kernel/utils/UtilsCore.vitest.ts
+++ b/src/test-kernel/utils/UtilsCore.vitest.ts
@@ -14,24 +14,9 @@ import {
   KeyedMutex,
   throwAggregated,
   toNewestFirstByTimestamp,
-  utcMonthStart,
   type FlushableDebounce,
 } from '@utils/core';
 import { deriveExecutionId } from '@utils/core/idHash';
-
-describe('utcMonthStart', () => {
-  it('builds midnight UTC on the 1st of the given month', () => {
-    expect(utcMonthStart(2026, 4).toISOString()).toBe(
-      '2026-05-01T00:00:00.000Z',
-    );
-  });
-
-  it('rolls a 12-index month into the next year, for exclusive-end ranges', () => {
-    expect(utcMonthStart(2026, 12).toISOString()).toBe(
-      '2027-01-01T00:00:00.000Z',
-    );
-  });
-});
 
 describe('toNewestFirstByTimestamp', () => {
   it('orders values by newest timestamp first', () => {

--- a/src/test-kernel/utils/UtilsCore.vitest.ts
+++ b/src/test-kernel/utils/UtilsCore.vitest.ts
@@ -14,9 +14,24 @@ import {
   KeyedMutex,
   throwAggregated,
   toNewestFirstByTimestamp,
+  utcMonthStart,
   type FlushableDebounce,
 } from '@utils/core';
 import { deriveExecutionId } from '@utils/core/idHash';
+
+describe('utcMonthStart', () => {
+  it('builds midnight UTC on the 1st of the given month', () => {
+    expect(utcMonthStart(2026, 4).toISOString()).toBe(
+      '2026-05-01T00:00:00.000Z',
+    );
+  });
+
+  it('rolls a 12-index month into the next year, for exclusive-end ranges', () => {
+    expect(utcMonthStart(2026, 12).toISOString()).toBe(
+      '2027-01-01T00:00:00.000Z',
+    );
+  });
+});
 
 describe('toNewestFirstByTimestamp', () => {
   it('orders values by newest timestamp first', () => {

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -440,6 +440,20 @@ export function jitteredExponentialBackoffMs(
 }
 
 // ---------------------------------------------------------------------------
+// dateCore
+// ---------------------------------------------------------------------------
+
+/**
+ * Start of the given UTC month as a `Date`, e.g. `utcMonthStart(2026, 0)` is
+ * midnight UTC on 2026-01-01. `monthIndex` is 0-based and not clamped to
+ * 0-11 — pass 12 to get the start of the following year's January, which is
+ * how callers compute a month's exclusive end boundary.
+ */
+export function utcMonthStart(year: number, monthIndex: number): Date {
+  return new Date(Date.UTC(year, monthIndex, 1));
+}
+
+// ---------------------------------------------------------------------------
 // urlCore
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Extracts the repeated pattern of creating a UTC month boundary `Date` into a dedicated utility function `utcMonthStart(year, monthIndex)`. This eliminates duplication across three call sites and centralizes the logic for computing month boundaries used in relay usage tracking and settings refresh scheduling.

This is a follow-up to a scheduled npm-package-replacement audit that originally flagged three candidates (a hand-rolled debounce utility, a hand-rolled auth-cache TTL/coalescing pattern, and this duplicated UTC math). The other two were investigated and found unsafe to swap on closer inspection (see PR discussion history / prior revision of this body if needed) and are intentionally not touched here — this PR is scoped to the one genuinely safe dedup.

## Issue acceptance gates

N/a — refactoring/deduplication, not tied to a filed issue.

## Single source of truth

`utcMonthStart` in `src/utils/core/index.ts` now owns the logic for constructing UTC month boundary dates.

## Duplication and abstraction budget

Removed three instances of `new Date(Date.UTC(year, monthIndex, 1))`:
- `packages/cli/src/runtime/relayUsage.ts`: `currentUtcMonthRange()` and `parseUtcMonth()`
- `packages/extension/src/settingsView/frontend/SettingsApp.ts`: monthly profile refresh timer calculation

`utcMonthStart` encapsulates the invariant that `monthIndex` is 0-based and unclamped (month 12 rolls into next year), which callers rely on for exclusive-end range boundaries.

## Net elements (R6)

- **Files changed:** 3
- **Exported symbols added:** 1 (`utcMonthStart`)
- **Diffstat (current head):** +28 / −11 across 3 files, net +17

## Consumer counts (R8)

n/a — new export with 3 internal call sites, no external consumers; nothing deleted or re-routed.

## Host impact

**Extension:** Monthly profile refresh timer now uses the centralized utility.

**Desktop:** n/a

**CLI:** Relay usage month range calculations now use the centralized utility.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` (all workspaces) — clean.
- `npx eslint` / `npx prettier --check` on all changed files — clean.
- `node scripts/check-browser-safe-utils.mjs` — OK, reachable-set unchanged.
- `npm run check:dead-code-ratchet` — OK, no new unused exports.
- Full `npm test` — 857 test files, 10189 tests passed, 0 failures (run prior to the test-suite trim below; re-verified locally after).
- Behavioral coverage for `utcMonthStart`'s rollover semantics lives in `src/test-kernel/cli/RelayUsage.vitest.ts:45-56` (`parseUtcMonth('2026-05')` for the normal case, `currentUtcMonthRange` from `2026-12-31` for the year-rollover case) — a redundant implementation-level unit-test suite was added directly against `utcMonthStart` and then removed per Codex review feedback (AGENTS.md testing-discipline: prefer behavioral tests at the true boundary over unit tests of pass-through wrappers).
