### PR TITLE
refactor(ratchet): enforce shared-schemas barrel in test-kernel

### DIFF
--- a/config/ratchets/shared-schemas-deep-import-baseline.json
+++ b/config/ratchets/shared-schemas-deep-import-baseline.json
@@ -1,8 +1,24 @@
 {
-  "semantics": "Production statements that reach past the published '@shared/schemas' barrel into a leaf module, keyed by specifier, valued by the importing file ('(type-only)' marks an `import type` statement, so a file that splits its value and type imports contributes two distinct entries). 'forced' statements name at least one symbol the barrel does not re-export: they are a report that a leaf module is missing from the published surface, and only a NEW off-surface specifier fails the ratchet. 'gratuitous' statements could have used the barrel verbatim; their per-specifier count may not grow. Classification is computed against src/shared/schemas/index.ts at test time, so widening the barrel reclassifies statements automatically (and requires regenerating this file in the same PR). The leaf-aware published-surface snapshot preserves the exact type/value bindings used by baseline gratuitous imports, so those bindings may not contract even if their importers move. Scan covers repo-root src/ and every packages/*/src directory, excluding src/test-kernel/ and the surface interior src/shared/schemas/.",
+  "semantics": "Production statements that reach past the published '@shared/schemas' barrel into a leaf module, keyed by specifier, valued by the importing file ('(type-only)' marks an `import type` statement, so a file that splits its value and type imports contributes two distinct entries). 'forced' statements name at least one symbol the barrel does not re-export: they are a report that a leaf module is missing from the published surface, and only a NEW off-surface specifier fails the ratchet. 'gratuitous' statements could have used the barrel verbatim; their per-specifier count may not grow. Classification is computed against src/shared/schemas/index.ts at test time, so widening the barrel reclassifies statements automatically (and requires regenerating this file in the same PR). The leaf-aware published-surface snapshot preserves the exact type/value bindings used by baseline gratuitous imports, so those bindings may not contract even if their importers move. Scan covers repo-root src/ and every packages/*/src directory, excluding only the surface interior src/shared/schemas/ (test-kernel files are ratcheted like production).",
   "surface": {
     "@shared/schemas/agent": {
-      "type": ["AgentCategory", "AgentSource", "ByCategory"],
+      "type": [
+        "AGENT_CATEGORIES",
+        "AGENT_SOURCE",
+        "AgentCategory",
+        "AgentCategorySchema",
+        "agentKey",
+        "agentKeyOf",
+        "agentMatchesIdentifier",
+        "AgentMetadataBaseSchema",
+        "agentName",
+        "AgentNameSchema",
+        "AgentSource",
+        "AgentSourceSchema",
+        "byCategory",
+        "ByCategory",
+        "getCleanAgentName"
+      ],
       "value": [
         "AGENT_CATEGORIES",
         "AGENT_SOURCE",
@@ -11,6 +27,7 @@
         "agentKey",
         "agentKeyOf",
         "agentMatchesIdentifier",
+        "AgentMetadataBaseSchema",
         "agentName",
         "AgentNameSchema",
         "AgentSourceSchema",
@@ -101,13 +118,23 @@
       "type": [],
       "value": [
         "CLI_CORE_SETTING_PATHS",
+        "CORE_SETTING_PATHS",
         "CoreSettingsShape",
         "DEFAULT_CORE_SETTINGS",
+        "EXTENSION_ONLY_CORE_SETTING_PATHS",
         "getCoreSettingDefault",
         "LATEXDIFF_TEMP_FILE_LOCATIONS",
         "MODEL_RETRY_MAX_ATTEMPTS_SETTING",
         "ModelRetryMaxAttemptsSchema",
         "TOOL_EDIT_APPROVAL_CONFIG_KEY"
+      ]
+    },
+    "@shared/schemas/errors": {
+      "type": ["ProviderError", "RetryErrorInfo"],
+      "value": [
+        "ErrorLogDataSchema",
+        "RetryErrorInfoSchema",
+        "toRetryErrorInfo"
       ]
     },
     "@shared/schemas/fileFields": {
@@ -137,6 +164,10 @@
         "isGoalInFlight"
       ]
     },
+    "@shared/schemas/historyViewMessages": {
+      "type": [],
+      "value": ["HISTORY_RUN_STATUS", "resolveHistoryRunStatus"]
+    },
     "@shared/schemas/identifiers": {
       "type": ["ExecutionId", "StreamTabId"],
       "value": ["ExecutionIdSchema", "StreamTabIdSchema"]
@@ -153,6 +184,8 @@
       "type": ["MainViewInboundMessage", "MainViewMessage"],
       "value": [
         "GETTING_STARTED_COMMANDS",
+        "MainViewExecuteInboundMessageSchema",
+        "MainViewExecuteMessageSchema",
         "MainViewInboundMessageSchema",
         "MainViewMessageSchema"
       ]
@@ -167,6 +200,10 @@
     },
     "@shared/schemas/mainView/state": {
       "type": ["TeamOptionData"],
+      "value": ["TeamOptionDataSchema"]
+    },
+    "@shared/schemas/memoryViewMessages": {
+      "type": ["MemoryViewItem"],
       "value": []
     },
     "@shared/schemas/onboarding": {
@@ -212,9 +249,17 @@
       "type": ["ProposalFileGroup"],
       "value": ["getProposalFileGroups"]
     },
+    "@shared/schemas/proposalInput": {
+      "type": [],
+      "value": ["parseDelegationToolInput"]
+    },
     "@shared/schemas/roundIndexed": {
       "type": [],
       "value": ["roundIndexedEntries"]
+    },
+    "@shared/schemas/settingsView/data": {
+      "type": ["AgentSelectionItem"],
+      "value": []
     },
     "@shared/schemas/settingsViewMessages": {
       "type": [
@@ -309,7 +354,10 @@
         "settingIsBoolean",
         "settingIsNumber",
         "settingIsString",
+        "SETTINGS_VIEW_CORE_SETTINGS",
         "settingsViewSettingByKey",
+        "STATE_SETTING_KEYS",
+        "STATE_SETTINGS",
         "stateSettingByKey"
       ]
     },
@@ -332,9 +380,13 @@
       "type": [],
       "value": ["STREAM_SNAPSHOT_SCHEMA_VERSION", "StreamSnapshotSchema"]
     },
+    "@shared/schemas/todo": {
+      "type": [],
+      "value": ["TODO_STATUS"]
+    },
     "@shared/schemas/todoDisplay": {
       "type": [],
-      "value": ["countByStatus", "STATUS_DISPLAY"]
+      "value": ["countByStatus", "STATUS_DISPLAY", "STATUS_ICONS"]
     },
     "@shared/schemas/toolConfig": {
       "type": ["ToolConfig"],
@@ -403,6 +455,34 @@
       "src/model/ToolDefinition.ts",
       "src/shared/constants/workflowOutput.ts",
       "src/telemetry/UsageLogTypes.ts",
+      "src/test-kernel/agent/modelHandlers/CodexEncryptedReasoning.vitest.ts",
+      "src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts",
+      "src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts",
+      "src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts",
+      "src/test-kernel/cli/ConfigForm.vitest.ts",
+      "src/test-kernel/cli/RunExecution.vitest.ts",
+      "src/test-kernel/cli/SlashRegistry.vitest.ts",
+      "src/test-kernel/controllers/AgentRosterController.vitest.ts (type-only)",
+      "src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts (type-only)",
+      "src/test-kernel/controllers/SettingsAgentControllerFactory.vitest.ts (type-only)",
+      "src/test-kernel/controllers/SettingsAgentVisibilityController.vitest.ts (type-only)",
+      "src/test-kernel/desktop/DesktopAgentSettingsController.vitest.ts (type-only)",
+      "src/test-kernel/desktop/DesktopCommandPalette.vitest.ts",
+      "src/test-kernel/desktop/DesktopHistoryHandlers.vitest.ts",
+      "src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts",
+      "src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts",
+      "src/test-kernel/settings/AgentSelectionPanelToggle.vitest.ts",
+      "src/test-kernel/settings/ExtensionAgentHandlers.vitest.ts (type-only)",
+      "src/test-kernel/settings/HistoryHandlers.vitest.ts",
+      "src/test-kernel/settings/settingsNotificationHandlers.vitest.ts",
+      "src/test-kernel/shared/MainViewExecuteMessage.vitest.ts",
+      "src/test-kernel/shared/ParseDelegationToolInput.vitest.ts",
+      "src/test-kernel/support/executionHandleFixtures.ts",
+      "src/test-kernel/tools/DelegationAgentScope.vitest.ts",
+      "src/test-kernel/tools/DelegationHeadless.vitest.ts",
+      "src/test-kernel/transcript/completedRunArchive.vitest.ts",
+      "src/test-kernel/transcript/StreamSnapshotStore.vitest.ts",
+      "src/test-kernel/webview/MainViewLaunchTarget.vitest.ts",
       "src/tools/delegation/delegationAvailability.ts (type-only)",
       "src/tools/executionFormatters.ts (type-only)",
       "src/tools/setup/ApplyTeamTool.ts"
@@ -411,6 +491,12 @@
       "packages/extension/src/settingsView/frontend/settingsState.ts",
       "packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts",
       "src/shared/settingsView/handlers/approvalHandlers.ts",
+      "src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts",
+      "src/test-kernel/schemas/SharedSchemas.vitest.ts",
+      "src/test-kernel/shared/stateSettings.vitest.ts",
+      "src/test-kernel/shared/StateSettingWrite.vitest.ts",
+      "src/test-kernel/tools/BashToolErrorFeedback.vitest.ts",
+      "src/test-kernel/tools/setup/SendToTerminalTool.vitest.ts",
       "src/tools/approval/bashApproval.ts",
       "src/tools/claudeAgentConfig.ts",
       "src/tools/codex.ts",
@@ -430,6 +516,12 @@
       "src/controllers/settingsView/SettingsAgentCatalogController.ts (type-only)",
       "src/controllers/settingsView/SettingsAgentControllerFactory.ts",
       "src/shared/settingsView/handlers/agentSelectionHandlers.ts (type-only)",
+      "src/test-kernel/common/teams/TeamPlan.vitest.ts",
+      "src/test-kernel/controllers/AgentRosterController.vitest.ts (type-only)",
+      "src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts",
+      "src/test-kernel/settings/MultiAgentTab.vitest.ts",
+      "src/test-kernel/settings/TeamRosterApplication.vitest.ts (type-only)",
+      "src/test-kernel/shared/AgentPresetHostedMetadata.vitest.ts",
       "src/tools/setup/ApplyTeamTool.ts"
     ],
     "@shared/schemas/agentRoster": [
@@ -443,6 +535,7 @@
       "src/agent/utils/userVars.ts (type-only)",
       "src/common/teams/TeamPlan.ts (type-only)",
       "src/controllers/mainView/MainViewExecutionController.ts (type-only)",
+      "src/test-kernel/tools/setup/ApplyTeamTool.vitest.ts (type-only)",
       "src/tools/delegation/delegationAvailability.ts (type-only)",
       "src/tools/delegation/proposalFlow.ts (type-only)"
     ],
@@ -450,11 +543,18 @@
       "packages/extension/src/settingsView/frontend/settingsState.ts",
       "packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts",
       "src/agent/utils/userVars.ts",
-      "src/shared/settingsView/handlers/agentSkillsHandlers.ts"
+      "src/shared/settingsView/handlers/agentSkillsHandlers.ts",
+      "src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts",
+      "src/test-kernel/settings/AgentSkillsSettings.vitest.ts",
+      "src/test-kernel/settings/AgentSkillsWorkspaceGuard.vitest.ts",
+      "src/test-kernel/settings/ToolsTab.vitest.ts",
+      "src/test-kernel/shared/stateSettings.vitest.ts"
     ],
     "@shared/schemas/codex": [
       "packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts",
       "packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts",
+      "src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts",
+      "src/test-kernel/tools/codexConfig.vitest.ts",
       "src/tools/codexShared.ts",
       "src/tools/codexShared.ts (type-only)"
     ],
@@ -464,7 +564,9 @@
       "packages/extension/src/webview/frontend/MainApp.ts (type-only)",
       "packages/extension/src/webview/frontend/persistence.ts (type-only)",
       "src/shared/BaseWebviewApp.ts",
-      "src/shared/wa/hostTheme.ts (type-only)"
+      "src/shared/wa/hostTheme.ts (type-only)",
+      "src/test-kernel/desktop/DesktopReviewPane.vitest.ts",
+      "src/test-kernel/desktop/TexraDiffView.vitest.ts"
     ],
     "@shared/schemas/coreSettings": [
       "packages/cli/src/schemas/knownKeys.ts",
@@ -480,7 +582,14 @@
       "src/shared/settingsView/handlers/approvalHandlers.ts",
       "src/shared/settingsView/handlers/telemetrySettingsHandlers.ts",
       "src/telemetry/UsageLogService.ts",
+      "src/test-kernel/agent/runtime/RetryState.vitest.ts",
+      "src/test-kernel/controllers/SettingsProfileController.vitest.ts",
+      "src/test-kernel/shared/stateSettings.vitest.ts",
       "src/tools/approval/latexPreview.ts"
+    ],
+    "@shared/schemas/errors": [
+      "src/test-kernel/common/SdkErrorUtils.vitest.ts",
+      "src/test-kernel/common/SdkErrorUtils.vitest.ts (type-only)"
     ],
     "@shared/schemas/fileFields": ["src/agent/core/definition/AgentConfig.ts"],
     "@shared/schemas/fileTypes": [
@@ -494,13 +603,21 @@
       "packages/extension/src/progressView/frontend/slices/permissionSlice.ts",
       "src/agent/goal/maybeBuildGoalContinuation.ts",
       "src/controllers/progressView/backend/WebviewUpdater.ts (type-only)",
+      "src/test-kernel/agent/GoalContinuation.vitest.ts",
+      "src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts",
       "src/tools/goal/goalFeatureFlag.ts",
       "src/tools/goal/goalStore.ts",
       "src/tools/plan/PlanTool.ts"
     ],
+    "@shared/schemas/historyViewMessages": [
+      "src/test-kernel/cli/HistoryStatus.vitest.ts",
+      "src/test-kernel/settings/HistoryHandlers.vitest.ts",
+      "src/test-kernel/settings/HistorySearchPrefilter.vitest.ts"
+    ],
     "@shared/schemas/identifiers": [
       "packages/extension/src/commands/extensionCommandHandlers.ts",
       "src/agent/goal/maybeBuildGoalContinuation.ts (type-only)",
+      "src/test-kernel/desktop/DesktopHistoryHandlers.vitest.ts (type-only)",
       "src/tools/goal/goalAutoApproval.ts (type-only)",
       "src/tools/goal/goalStore.ts (type-only)",
       "src/transcript/traceDocumentSchema.ts"
@@ -517,7 +634,9 @@
       "packages/desktop/src/main/desktopShellIpc.ts",
       "packages/desktop/src/main/hostBridge.ts",
       "packages/extension/src/progressView/ProgressViewMessageHandler.ts",
-      "packages/extension/src/webview/managers/BaseWebviewManager.ts"
+      "packages/extension/src/webview/managers/BaseWebviewManager.ts",
+      "src/test-kernel/schemas/SharedSchemas.vitest.ts",
+      "src/test-kernel/shared/MainViewExecuteMessage.vitest.ts"
     ],
     "@shared/schemas/mainView/executeMessage": [
       "packages/desktop/src/main/desktopAgentExecution.ts (type-only)",
@@ -532,7 +651,11 @@
       "packages/extension/src/webview/managers/executionHandlers.ts (type-only)"
     ],
     "@shared/schemas/mainView/state": [
-      "src/common/teams/TeamPlan.ts (type-only)"
+      "src/common/teams/TeamPlan.ts (type-only)",
+      "src/test-kernel/desktop/DesktopAgentSettingsController.vitest.ts"
+    ],
+    "@shared/schemas/memoryViewMessages": [
+      "src/test-kernel/settings/MemoryItemActionGroup.vitest.ts (type-only)"
     ],
     "@shared/schemas/onboarding": [
       "src/controllers/onboarding/onboardingFunnel.ts (type-only)"
@@ -559,6 +682,8 @@
       "src/agent/runtime/AgentFlowResult.ts",
       "src/agent/runtime/executeAgent.ts",
       "src/agent/runtime/selectAutoOpenFinalOutput.ts (type-only)",
+      "src/test-kernel/agent/runtime/AgentFinalResult.vitest.ts (type-only)",
+      "src/test-kernel/desktop/desktopAgentExecutionTestHarness.ts (type-only)",
       "src/tools/delegation/subagentDiffs.ts (type-only)",
       "src/tools/delegation/subagentResults.ts (type-only)",
       "src/utils/text/xmlExtraction.ts"
@@ -569,7 +694,10 @@
       "packages/extension/src/progressView/ProgressViewMessageHandler.ts",
       "packages/trace-viewer/src/replayTrace.ts (type-only)",
       "src/controllers/progressView/ProgressAgentProposalController.ts (type-only)",
-      "src/controllers/progressView/ProgressViewCommandHandlers.ts (type-only)"
+      "src/controllers/progressView/ProgressViewCommandHandlers.ts (type-only)",
+      "src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts",
+      "src/test-kernel/desktop/DesktopAgentExecution.vitest.ts (type-only)",
+      "src/test-kernel/desktop/DesktopProgressIpc.vitest.ts (type-only)"
     ],
     "@shared/schemas/prompts": [
       "src/controllers/approval/ToolEditApprovalController.ts (type-only)"
@@ -578,8 +706,14 @@
       "packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts",
       "packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts"
     ],
+    "@shared/schemas/proposalInput": [
+      "src/test-kernel/shared/ParseDelegationToolInput.vitest.ts"
+    ],
     "@shared/schemas/roundIndexed": [
       "packages/extension/src/progressView/frontend/components/FileList.ts"
+    ],
+    "@shared/schemas/settingsView/data": [
+      "src/test-kernel/settings/AgentSelectionPanelToggle.vitest.ts (type-only)"
     ],
     "@shared/schemas/settingsViewMessages": [
       "packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts (type-only)",
@@ -645,6 +779,19 @@
       "src/shared/settingsView/handlers/approvalHandlers.ts (type-only)",
       "src/shared/settingsView/handlers/superYoloHandlers.ts (type-only)",
       "src/shared/tools/toolStatusLabels.ts (type-only)",
+      "src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts",
+      "src/test-kernel/controllers/LatexToolingController.vitest.ts",
+      "src/test-kernel/desktop/DesktopCommandPalette.vitest.ts",
+      "src/test-kernel/desktop/DesktopCommandSurface.vitest.ts",
+      "src/test-kernel/desktop/DesktopIpcAdapters.vitest.ts",
+      "src/test-kernel/desktop/DesktopToolingSettingsController.vitest.ts (type-only)",
+      "src/test-kernel/desktop/ElectronMainViewIpc.vitest.ts",
+      "src/test-kernel/settings/CopilotModelAccess.vitest.ts (type-only)",
+      "src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts (type-only)",
+      "src/test-kernel/settings/ProviderKeyRows.vitest.ts (type-only)",
+      "src/test-kernel/settings/settingsNotificationHandlers.vitest.ts (type-only)",
+      "src/test-kernel/settings/ToolsTab.vitest.ts (type-only)",
+      "src/test-kernel/shared/stateSettings.vitest.ts",
       "src/tools/externalToolDefs.ts (type-only)",
       "src/utils/system/gitAuthorSettings.ts (type-only)"
     ],
@@ -653,7 +800,9 @@
       "packages/extension/src/settingsView/frontend/slices/profileSlice.ts",
       "packages/extension/src/settingsView/frontend/tabs/AccountTab.ts (type-only)",
       "src/auth/serverKeys/ServerSideKeyService.ts (type-only)",
-      "src/auth/serverKeys/TierService.ts"
+      "src/auth/serverKeys/TierService.ts",
+      "src/test-kernel/controllers/SettingsProfileController.vitest.ts (type-only)",
+      "src/test-kernel/shared/SpendingQuota.vitest.ts"
     ],
     "@shared/schemas/stateSettings": [
       "packages/cli/src/chat/tui/forms/CliConfigForm.tsx",
@@ -668,22 +817,45 @@
       "src/shared/config/settingsAccess.ts (type-only)",
       "src/shared/settingsView/handlers/approvalHandlers.ts",
       "src/shared/settingsView/handlers/stateSettingWrite.ts",
+      "src/test-kernel/cli/ConfigForm.vitest.ts",
+      "src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts",
+      "src/test-kernel/settings/AgentSkillsSettings.vitest.ts",
+      "src/test-kernel/settings/BashApprovalSettings.vitest.ts",
+      "src/test-kernel/shared/stateSettings.vitest.ts",
       "src/utils/config/platformSettings.ts",
       "src/utils/system/gitAuthorSettings.ts"
     ],
     "@shared/schemas/stream": [
       "src/shared/streams/streamStatus.ts",
+      "src/test-kernel/settings/HistoryHandlers.vitest.ts",
       "src/transcript/traceDocumentSchema.ts"
     ],
     "@shared/schemas/streamSnapshot": [
       "packages/trace-viewer/src/traceDataSchema.ts",
       "src/transcript/traceDocumentSchema.ts"
     ],
-    "@shared/schemas/todoDisplay": ["src/shared/subagentFollowup.ts"],
+    "@shared/schemas/todo": [
+      "src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts"
+    ],
+    "@shared/schemas/todoDisplay": [
+      "src/shared/subagentFollowup.ts",
+      "src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts"
+    ],
     "@shared/schemas/toolConfig": [
       "src/agent/core/definition/AgentConfig.ts",
       "src/controllers/mainView/MainViewExecutionController.ts",
-      "src/latex/LatexMediaManager.ts"
+      "src/latex/LatexMediaManager.ts",
+      "src/test-kernel/agent/core/ConfigSchemas.vitest.ts",
+      "src/test-kernel/agent/export/loadChatExportInput.vitest.ts",
+      "src/test-kernel/cli/AgentProposal.vitest.ts",
+      "src/test-kernel/cli/CliSessionProgressSubscription.vitest.ts",
+      "src/test-kernel/controllers/ChatExportController.vitest.ts",
+      "src/test-kernel/controllers/ChatExportControllerHtml.vitest.ts",
+      "src/test-kernel/controllers/ProgressAgentProposalController.vitest.ts",
+      "src/test-kernel/desktop/DesktopAgentExecution.vitest.ts",
+      "src/test-kernel/latex/LatexProcessingHelpers.vitest.ts (type-only)",
+      "src/test-kernel/progressView/ProposalRequestPanel.vitest.ts",
+      "src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts"
     ],
     "@shared/schemas/usage": [
       "src/agent/utils/UsageMonitor.ts",
@@ -694,9 +866,13 @@
       "src/agent/workflowScript/persistence.ts",
       "src/agent/workflowScript/runWorkflowScript.ts",
       "src/agent/workflowScript/types.ts (type-only)",
+      "src/test-kernel/tools/WorkflowScriptTool.vitest.ts (type-only)",
       "src/tools/delegation/workflowScriptStrategy.ts (type-only)",
       "src/tools/delegation/WorkflowScriptTool.ts"
     ],
-    "@shared/schemas/workPlan": ["src/shared/subagentFollowup.ts"]
+    "@shared/schemas/workPlan": [
+      "src/shared/subagentFollowup.ts",
+      "src/test-kernel/schemas/SharedSchemas.vitest.ts"
+    ]
   }
 }

--- a/src/test-kernel/architecture/sharedSchemasDeepImportRatchet.vitest.ts
+++ b/src/test-kernel/architecture/sharedSchemasDeepImportRatchet.vitest.ts
@@ -58,8 +58,9 @@ const SEMANTICS =
   'file in the same PR). The leaf-aware published-surface snapshot preserves ' +
   'the exact type/value bindings used by baseline gratuitous imports, so those ' +
   'bindings may not contract even if their importers move. Scan covers ' +
-  'repo-root src/ and every packages/*/src directory, excluding ' +
-  'src/test-kernel/ and the surface interior src/shared/schemas/.';
+  'repo-root src/ and every packages/*/src directory, excluding only the ' +
+  'surface interior src/shared/schemas/ (test-kernel files are ratcheted ' +
+  'like production).';
 
 type DeepImports = Record<string, string[]>;
 type ExportSpace = 'type' | 'value';
@@ -557,7 +558,7 @@ function collectCurrent(): Pick<
 
   for (const root of scanRoots()) {
     for (const file of sourceFilesUnder(resolve(REPO_ROOT, root), {
-      excludeTestKernel: true,
+      excludeTestKernel: false,
       missingDirReturnsEmpty: true,
     })) {
       const repoPath = toRepoPath(file);

--- a/src/test-kernel/latex/TexTools.vitest.ts
+++ b/src/test-kernel/latex/TexTools.vitest.ts
@@ -6,7 +6,7 @@ import {
   buildLatexSearchParts,
   compileLatex2Pdf,
 } from '@latex/texTools';
-import type { ExecResult } from '@shared/schemas/opResults';
+import type { ExecResult } from '@shared/schemas';
 import { installPlatform } from '@test/support/setupPlatform';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { pathToLocation } from '@utils/files/fileLocation';

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -40,11 +40,11 @@ import { formatToolResultAsText } from '@agent/modelHandlers/utils/toolAttachmen
 import {
   RUN_OUTCOME,
   STREAM_PHASE,
+  type ExecResult,
   type StreamTabId,
   type ToolResult,
   AgentCategory,
 } from '@shared/schemas';
-import type { ExecResult } from '@shared/schemas/opResults';
 import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -23,10 +23,10 @@ import {
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
+  type ExecResult,
   type StreamTabId,
   AgentCategory,
 } from '@shared/schemas';
-import type { ExecResult } from '@shared/schemas/opResults';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { ExecutionsTool } from '@tools/ExecutionsTool';
 import { BashTool } from '@tools/bash';


### PR DESCRIPTION
## Summary

The `shared-schemas-deep-import` ratchet now scans `src/test-kernel/` like production instead of excluding it, so the `@shared/schemas` barrel-bypass convention is enforced for tests and cannot drift back into production via copy-paste. The baseline is regenerated across every remaining test-kernel deep-import specifier.

Three gratuitous `@shared/schemas/opResults` type imports in test files are folded through the barrel first (`ExecResult` is already re-exported there).

## Issue acceptance gates

- #10168: `excludeTestKernel` is false in the ratchet scan; the baseline covers the remaining test-kernel deep imports; the known `opResults` bypasses are folded through the barrel.

## Single source of truth

`@shared/schemas` remains the published surface; the ratchet now enforces it uniformly for production and tests.

## Duplication and abstraction budget

No new abstraction; removes three gratuitous deep imports.

## Net elements (R6)

- Files: 5 changed (+195/-18)
- Exported symbols: 0 net change
- Classes/interfaces/enums: 0
- Net LoC: +177 (baseline entries)

## Consumer counts (R8)

- n/a: no emit path or export changed; deep-import baseline entries are re-keyed and expanded.

## Host impact

Extension: none

Desktop: none

CLI: none (test-kernel only)

## Scheduled refactoring

None

## Validation

- `TEXRA_UPDATE_SHARED_SCHEMAS_BASELINE=1 npx vitest run src/test-kernel/architecture/sharedSchemasDeepImportRatchet` regenerated the baseline
- `npx vitest run src/test-kernel/architecture/sharedSchemasDeepImportRatchet` passed (7 tests)
- `npx vitest run src/test-kernel/tools/BashTool.vitest.ts src/test-kernel/latex/TexTools.vitest.ts src/test-kernel/tools/ExecutionsToolOutput.vitest.ts` passed (56 tests)
- Full CI runs on this PR