### PR TITLE
feat: open hosted Lean agents and remote prompts to signed-in users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,27 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Shared (all surfaces)
+
+#### Features
+
+- **Lean Project remotes are available after sign-in** — the hosted Lean
+  agents no longer need a special access group.
+
+### Extension (VS Code) and Desktop
+
+#### Features
+
+- **Remote agent prompts are available to every signed-in account** — Settings
+  → Agents no longer hides View prompt behind an Ultra plan, and remote agents
+  no longer show a Remote badge or access-group labels.
+
 ### CLI
+
+#### Features
+
+- **`texra agents show` omits access-group tags** — remote agent details no
+  longer print visibility labels.
 
 #### Bug Fixes
 

--- a/docs/supabase/SYNC_REMOTE_AGENTS.sql
+++ b/docs/supabase/SYNC_REMOTE_AGENTS.sql
@@ -278,7 +278,7 @@ VALUES (
   'lean',
   'Lean 4 proof assistant with VS Code integration and CLI fallback.',
   'tool-use-lean/lean.yaml',
-  ARRAY['researcher', 'lean'],
+  ARRAY['researcher', 'lean', 'public'],
   'toolUse',
   ARRAY['todo_write', 'lean_diagnostics', 'lean_file', 'lean_project', 'lean_inspect', 'lean_loogle', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'memory', 'github_subscription']
 )
@@ -294,7 +294,7 @@ VALUES (
   'leanBlueprint',
   'Creates and maintains dependency-tracked LeanBlueprint documents that bridge informal mathematics and Lean 4 formalization.',
   'tool-use-lean/leanBlueprint.yaml',
-  ARRAY['researcher', 'lean'],
+  ARRAY['researcher', 'lean', 'public'],
   'toolUse',
   ARRAY['todo_write', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'memory', 'lean_diagnostics', 'lean_file', 'lean_project', 'lean_inspect', 'lean_loogle', 'web_search', 'web_fetch', 'arxiv_search', 'arxiv_metadata', 'download_arxiv_source', 'crossref_search', 'zotero_add', 'zotero_search', 'zotero_export']
 )
@@ -310,7 +310,7 @@ VALUES (
   'leanOrchestrator',
   'Lean 4 project orchestrator. Coordinates formalization, delegates to specialized Lean agents, and manages proof development workflow.',
   'tool-use-lean/leanOrchestrator.yaml',
-  ARRAY['researcher', 'lean'],
+  ARRAY['researcher', 'lean', 'public'],
   'toolUse',
   ARRAY['delegate_workflow', 'delegate_agent', 'delegate_multi_agents', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'codex', 'claude_code', 'lean_diagnostics', 'lean_inspect', 'lean_loogle', 'lean_file', 'lean_project', 'github_subscription']
 )
@@ -326,7 +326,7 @@ VALUES (
   'leanSearch',
   'Lean 4 and Mathlib research assistant. Finds lemmas, explores APIs, and answers formalization questions.',
   'tool-use-lean/leanSearch.yaml',
-  ARRAY['researcher', 'lean'],
+  ARRAY['researcher', 'lean', 'public'],
   'toolUse',
   ARRAY['todo_write', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'memory', 'lean_diagnostics', 'lean_file', 'lean_project', 'lean_inspect', 'lean_loogle', 'web_search', 'web_fetch', 'arxiv_search', 'arxiv_metadata', 'download_arxiv_source']
 )
@@ -342,7 +342,7 @@ VALUES (
   'leanSimplifier',
   'Simplifies Lean 4 proofs and code into clear, general, upstream-ready Mathlib style.',
   'tool-use-lean/leanSimplifier.yaml',
-  ARRAY['researcher', 'lean'],
+  ARRAY['researcher', 'lean', 'public'],
   'toolUse',
   ARRAY['todo_write', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'memory', 'lean_diagnostics', 'lean_file', 'lean_project', 'lean_inspect', 'lean_loogle']
 )

--- a/docs/supabase/remote-agents.config.json
+++ b/docs/supabase/remote-agents.config.json
@@ -34,22 +34,25 @@
     "progressCheck": { "folder": "tool-use", "visibility": ["public"] },
     "search": { "folder": "tool-use", "visibility": ["public"] },
     "simplifier": { "folder": "tool-use", "visibility": ["public"] },
-    "lean": { "folder": "tool-use-lean", "visibility": ["researcher", "lean"] },
+    "lean": {
+      "folder": "tool-use-lean",
+      "visibility": ["researcher", "lean", "public"]
+    },
     "leanBlueprint": {
       "folder": "tool-use-lean",
-      "visibility": ["researcher", "lean"]
+      "visibility": ["researcher", "lean", "public"]
     },
     "leanOrchestrator": {
       "folder": "tool-use-lean",
-      "visibility": ["researcher", "lean"]
+      "visibility": ["researcher", "lean", "public"]
     },
     "leanSearch": {
       "folder": "tool-use-lean",
-      "visibility": ["researcher", "lean"]
+      "visibility": ["researcher", "lean", "public"]
     },
     "leanSimplifier": {
       "folder": "tool-use-lean",
-      "visibility": ["researcher", "lean"]
+      "visibility": ["researcher", "lean", "public"]
     }
   }
 }

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -267,7 +267,6 @@ export function formatCliAgentDetails(entry: AgentEntry): string {
   const metadataFields: readonly [string, readonly string[] | undefined][] = [
     ['tools', entry.tools],
     ['defaultOutputFiles', entry.defaultOutputFiles],
-    ['visibility', entry.visibility],
   ];
   const metadataLines = metadataFields.flatMap(([label, values]) =>
     values?.length ? [`${label}: ${values.join(', ')}`] : [],

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -425,7 +425,6 @@ export class SettingsApp extends SettingsAppBase {
             .customAgentDir=${customAgentDir.get()}
             .customAgentDirIsDefault=${customAgentDirIsDefault.get()}
             .initialSubTab=${agentSubTab.get()}
-            .userTier=${tier.get()}
             .reliabilitySettings=${reliabilitySettings.get()}
             .unsupportedCommands=${unsupportedCommands.get()}
           ></agents-tab>

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -70,7 +70,6 @@ const SOURCE_META: Record<
   [AGENT_SOURCE.REMOTE]: {
     displayName: 'Remote',
     tone: 'remote',
-    badge: { icon: 'cloud', label: 'Remote' },
   },
   [AGENT_SOURCE.INLINE]: {
     displayName: 'Inline',
@@ -89,7 +88,6 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
 
   @property({ attribute: false }) agents: AgentSelectionItem[] = [];
   @property({ attribute: false }) category: AgentCategory = 'workflow';
-  @property({ attribute: false }) userTier = 'free';
 
   @state() private selectedKey: string | null = null;
 
@@ -337,7 +335,6 @@ export class AgentSelectionPanel extends UnsupportedCommandsMixin(LitElement) {
       {
         when:
           agent.source === AGENT_SOURCE.REMOTE &&
-          this.userTier === 'Ultra' &&
           !agent.hasPath &&
           this.supportsCommand(SETTINGS_VIEW_COMMANDS.VIEW_REMOTE_AGENT_PROMPT),
         button: {

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -79,7 +79,6 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
   @property({ attribute: false }) customAgentDir = '';
   @property({ attribute: false }) customAgentDirIsDefault = true;
   @property({ attribute: false }) initialSubTab?: AgentCategory;
-  @property({ attribute: false }) userTier = 'free';
   @property({ attribute: false }) reliabilitySettings: NumberSetting[] = [];
 
   protected override updated(changed: PropertyValues): void {
@@ -156,7 +155,6 @@ export class AgentsTab extends UnsupportedCommandsMixin(LitElement) {
         <agent-selection-panel
           .agents=${agents}
           .category=${category}
-          .userTier=${this.userTier}
           .unsupportedCommands=${this.unsupportedCommands}
         ></agent-selection-panel>
       </section>

--- a/src/agent/index/remoteAgentProfileData.ts
+++ b/src/agent/index/remoteAgentProfileData.ts
@@ -5,7 +5,6 @@ export function toRemoteAgentProfileData(entry: AgentEntry): RemoteAgent {
   return {
     name: entry.name,
     description: entry.description ?? '',
-    visibility: entry.visibility ?? ['public'],
     category: entry.category,
     supportsMultipleOutput: (entry.defaultOutputFiles?.length ?? 0) > 0,
   };

--- a/src/controllers/settingsView/SettingsAgentControllerFactory.ts
+++ b/src/controllers/settingsView/SettingsAgentControllerFactory.ts
@@ -121,7 +121,6 @@ export function createSettingsAgentControllers(
   });
   const fileController = new SettingsAgentFileController();
   const remotePromptController = new SettingsRemoteAgentPromptController({
-    getUserTier: () => SupabaseClient.getUserTier(),
     getAccessToken: () => SupabaseClient.getAccessToken(),
     fetchPromptConfig: fetchRemoteAgentConfigYaml,
   });

--- a/src/controllers/settingsView/SettingsRemoteAgentPromptController.ts
+++ b/src/controllers/settingsView/SettingsRemoteAgentPromptController.ts
@@ -1,6 +1,3 @@
-// Local imports - auth
-import { ULTRA_TIER, type UserTier } from '@auth/config';
-
 type SettingsRemoteAgentPromptResult =
   | { ok: true; config: string }
   | {
@@ -9,7 +6,6 @@ type SettingsRemoteAgentPromptResult =
     };
 
 interface SettingsRemoteAgentPromptControllerDeps {
-  getUserTier(): Promise<UserTier>;
   getAccessToken(): Promise<string | null>;
   fetchPromptConfig(agentName: string, accessToken: string): Promise<string>;
 }
@@ -20,14 +16,6 @@ export class SettingsRemoteAgentPromptController {
   async getPromptConfig(
     agentName: string,
   ): Promise<SettingsRemoteAgentPromptResult> {
-    const tier = await this.deps.getUserTier();
-    if (tier !== ULTRA_TIER) {
-      return {
-        ok: false,
-        message: 'Viewing remote agent prompts requires an Ultra plan.',
-      };
-    }
-
     const token = await this.deps.getAccessToken();
     if (!token) {
       return {

--- a/src/shared/schemas/profileViewMessages.ts
+++ b/src/shared/schemas/profileViewMessages.ts
@@ -40,7 +40,6 @@ const ProfileUserSchema = z.object({
  */
 const RemoteAgentSchema = AgentMetadataBaseSchema.extend({
   description: z.string(), // override optional → required for display
-  visibility: z.array(z.string()),
   supportsMultipleOutput: z.boolean(),
 });
 export type RemoteAgent = z.infer<typeof RemoteAgentSchema>;

--- a/src/test-kernel/controllers/SettingsRemoteAgentPromptController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsRemoteAgentPromptController.vitest.ts
@@ -2,11 +2,9 @@ import { strict as assert } from 'node:assert';
 
 import { describe, it, vi } from 'vitest';
 
-import { FREE_TIER, ULTRA_TIER, type UserTier } from '@auth/config';
 import { SettingsRemoteAgentPromptController } from '@controllers/settingsView/SettingsRemoteAgentPromptController';
 
 function createController(options: {
-  tier: UserTier;
   token: string | null;
   fetchPromptConfig?: (
     agentName: string,
@@ -22,7 +20,6 @@ function createController(options: {
   );
   return {
     controller: new SettingsRemoteAgentPromptController({
-      getUserTier: async () => options.tier,
       getAccessToken: async () => options.token,
       fetchPromptConfig,
     }),
@@ -31,24 +28,8 @@ function createController(options: {
 }
 
 describe('SettingsRemoteAgentPromptController', () => {
-  it('rejects non-Ultra users before requesting a token', async () => {
+  it('rejects users without an access token', async () => {
     const { controller, fetchPromptConfig } = createController({
-      tier: FREE_TIER,
-      token: 'token',
-    });
-
-    const result = await controller.getPromptConfig('remoteWriter');
-
-    assert.deepEqual(result, {
-      ok: false,
-      message: 'Viewing remote agent prompts requires an Ultra plan.',
-    });
-    assert.equal(fetchPromptConfig.mock.calls.length, 0);
-  });
-
-  it('rejects Ultra users without an access token', async () => {
-    const { controller, fetchPromptConfig } = createController({
-      tier: ULTRA_TIER,
       token: null,
     });
 
@@ -61,9 +42,8 @@ describe('SettingsRemoteAgentPromptController', () => {
     assert.equal(fetchPromptConfig.mock.calls.length, 0);
   });
 
-  it('fetches the remote prompt config for authenticated Ultra users', async () => {
+  it('fetches the remote prompt config for any signed-in user', async () => {
     const { controller, fetchPromptConfig } = createController({
-      tier: ULTRA_TIER,
       token: 'access-token',
     });
 

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.ts
@@ -898,7 +898,6 @@ describe('desktop Supabase auth', () => {
         defaultOutputFiles: ['main.tex'],
         category: AgentCategory.Workflow,
         description: 'Remote writer',
-        visibility: ['public', 'researcher'],
       },
     ]);
 
@@ -918,7 +917,6 @@ describe('desktop Supabase auth', () => {
         {
           name: 'remoteWriter',
           description: 'Remote writer',
-          visibility: ['public', 'researcher'],
           category: 'workflow',
           supportsMultipleOutput: true,
         },


### PR DESCRIPTION
## Summary

Hosted Lean agents (`lean`, `leanSearch`, `leanSimplifier`, `leanBlueprint`, `leanOrchestrator`) are now public after sign-in. Production visibility was already updated; this commit matches the repo config and seed SQL.

Also drops the Ultra-only remote-prompt gate and stops showing access-group tags in Settings and `texra agents show`. Any signed-in user can open a remote agent's prompt.

## Issue acceptance gates

n/a — follow-up to production visibility updates for public Lean remotes and the Ultra prompt viewer.

## Single source of truth

`docs/supabase/remote-agents.config.json` owns folder/visibility. `SettingsRemoteAgentPromptController` owns prompt access (sign-in only).

## Duplication and abstraction budget

No new abstraction. Removed the second Ultra check from the settings UI (`userTier === 'Ultra'`).

## Net elements (R6)

n/a — product access change, not a refactor PR.

## Consumer counts (R8)

n/a — no emit path or export removed from a public surface.

## Host impact

Extension: View prompt is available to every signed-in account; Remote badge removed.

Desktop: same settings webview.

CLI: `texra agents show` no longer prints visibility labels.

## Scheduled refactoring

None

## Validation

- `vitest` on SettingsRemoteAgentPromptController, DesktopSupabaseAuth, AgentsCommand, SettingsAgentControllerFactory, ExtensionAgentHandlers, AgentHandlersDelete, DesktopAgentSettingsController (70 tests)
- Production `remote_agents.visibility` already includes `public` for the Lean roster