### PR TITLE
test(cli): pin cancelled non-empty output command path

### DIFF
--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
@@ -669,6 +669,61 @@ describe('CLI workflow run command', () => {
     });
   });
 
+  it('keeps cancelled non-empty outputs in run storage and still prints the run directory and recovery hint', async () => {
+    await withTempRoot(async (root) => {
+      const generated = await writeGeneratedOutput(root);
+      const outputSummary = runOutputSummary(
+        generated,
+        path.join(root, 'paper.tex'),
+      );
+      mockWorkflowExecution(
+        workflowExecution('exec-cancelled-outputs', {
+          outcome: RUN_OUTCOME.CANCELLED,
+          outputs: [outputSummary],
+        }),
+        true,
+      );
+
+      const exitCode = await runWorkflow(
+        { output: 'polished.tex' },
+        cliContext({
+          cwd: root,
+          commandName: 'texra-local',
+          approvalPolicy: 'never',
+        }),
+      );
+
+      expect(exitCode).toBe(CliExitCode.Interrupted);
+      await expect(fs.stat(path.join(root, 'polished.tex'))).rejects.toThrow();
+      expect(mocks.writeResultMeta).toHaveBeenCalledWith(
+        expectedResultMeta({
+          outcome: RUN_OUTCOME.CANCELLED,
+          outputs: [outputSummary],
+          compileFailures: [],
+        }),
+      );
+      const emitted = mocks.emitCliResult.mock.calls[0]?.[1];
+      expect(emitted?.json).toMatchObject({
+        outcome: RUN_OUTCOME.CANCELLED,
+        runDirectory: '/tmp/runs/exec-cancelled-outputs',
+        outputs: [outputSummary],
+      });
+      expect(emitted?.json).not.toHaveProperty('copiedOutput');
+      expect(emitted?.json).not.toHaveProperty('copiedOutputs');
+      expect(emitted?.text).toBe('/tmp/runs/exec-cancelled-outputs');
+      expect(mocks.writeTextStderr).toHaveBeenCalledExactlyOnceWith(
+        expectedRecoveryHint(
+          cliContext({
+            cwd: root,
+            commandName: 'texra-local',
+            approvalPolicy: 'never',
+          }),
+          'exec-cancelled-outputs',
+        ),
+      );
+    });
+  });
+
   it('presents the lifecycle verdict when cancellation lands during output finalization', async () => {
     const provisional = workflowExecution('exec-output-interrupted');
     if (!provisional.ok) throw new Error('Expected a workflow result.');


### PR DESCRIPTION
## Summary

Adds a command-level `mockWorkflowExecution` regression test for a cancelled workflow run with non-empty provisional outputs and a requested `--output` destination. The test pins the full path that #10182's fix moved to `resolveWorkflowOutput`: the destination is never created, the emitted result carries no `copiedOutput`/`copiedOutputs`, the text result reports the run-storage directory, and the recovery hint is still printed.

## Issue acceptance gates

- #10186: one command-level test covers the cancelled run with non-empty outputs plus a requested destination, asserting all four acceptance points (no destination write, no copy metadata, run-directory text result, recovery hint).

## Single source of truth

n/a (test-only)

## Duplication and abstraction budget

n/a

## Net elements (R6)

n/a (test-only)

## Consumer counts (R8)

n/a

## Host impact

Extension: none

Desktop: none

CLI: test-only

## Scheduled refactoring

None

## Validation

- `npx vitest run src/test-kernel/cli/WorkflowRunCommand.vitest.ts` passed (30 tests)
- Full CI runs on this PR
