### PR TITLE
docs(transcript): document workflow-call model-label projection on exports

### DIFF
--- a/src/transcript/traceDocumentSchema.ts
+++ b/src/transcript/traceDocumentSchema.ts
@@ -19,6 +19,12 @@ export const TraceDocumentSchema = z.object({
   /** The run's honest record: AgentConfig for agent runs, minimal otherwise. */
   config: RunRecordSchema,
   meta: ExecutionMetaSchema.nullable(),
+  /**
+   * Transcript entries. Workflow-call entries have their `data.model` already
+   * projected to the runtime display label (via `projectWorkflowCallEntry`) at
+   * export time, so an exported trace cannot recover the canonical
+   * `WorkflowCallProgress.model` id from that field.
+   */
   entries: z.array(StreamLogEntrySchema),
   snapshot: StreamSnapshotSchema,
   /** `null` for executions that predate outcome tracking or never terminated. */


### PR DESCRIPTION
## Summary

Documents the semantic change #10202 made to exported `TraceDocument` artifacts: workflow-call `entries[].data.model` now holds the projected runtime display label, not the canonical `WorkflowCallProgress.model` id.

## Issue acceptance gates

- #10224: `traceDocumentSchema.ts` documents that workflow-call entries are projected at export time and the canonical id is not recoverable from the field.

## Single source of truth

The `TraceDocumentSchema` entries field comment is the single statement of the exported-artifact semantic.

## Duplication and abstraction budget

n/a (doc-only)

## Net elements (R6)

n/a (doc-only)

## Consumer counts (R8)

n/a

## Host impact

Extension: none

Desktop: none

CLI: none

## Scheduled refactoring

None

## Validation

- `prettier --write src/transcript/traceDocumentSchema.ts` clean
- Full CI runs on this PR
