### PR TITLE
ci: harden drift-gate classifier self-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,12 @@ jobs:
 
           # Self-test the classifiers before trusting them on real input, so a
           # shell/awk regression fails CI instead of silently misrouting it.
-          if ! printf 'M\tdocs/supabase/remote-agents.config.json\nR100\tdocs/supabase/SYNC_REMOTE_AGENTS.sql\tdocs/supabase/SYNC_REMOTE_AGENTS.sql\n' | drift_gate_match; then
+          if ! printf 'M\tdocs/supabase/remote-agents.config.json\nR100\tdocs/supabase/remote-agents.config.json.old\tdocs/supabase/remote-agents.config.json\n' | drift_gate_match; then
             echo 'drift-gate classifier self-test failed' >&2
+            exit 1
+          fi
+          if printf 'M\tdocs/guide.md\n' | drift_gate_match; then
+            echo 'drift-gate classifier self-test failed (must not match non-gate docs)' >&2
             exit 1
           fi
           if ! printf 'M\tdocs/guide.md\nR100\tsrc/foo.ts\tdocs/foo.ts\n' | code_change_match; then
@@ -103,6 +107,10 @@ jobs:
           fi
           if printf 'M\tdocs/guide.md\n' | code_change_match; then
             echo 'code-change classifier self-test failed (docs-only)' >&2
+            exit 1
+          fi
+          if printf 'M\tREADME.md\n' | code_change_match; then
+            echo 'code-change classifier self-test failed (markdown outside docs)' >&2
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,15 @@ jobs:
 
           # Self-test the classifiers before trusting them on real input, so a
           # shell/awk regression fails CI instead of silently misrouting it.
-          if ! printf 'M\tdocs/supabase/remote-agents.config.json\nR100\tdocs/supabase/remote-agents.config.json.old\tdocs/supabase/remote-agents.config.json\n' | drift_gate_match; then
-            echo 'drift-gate classifier self-test failed' >&2
+          # Keep each positive case in its own invocation so `found` cannot
+          # leak across records. The rename dest-only case is the one that
+          # fails a field-2-only (or rename-skipping) matcher.
+          if ! printf 'M\tdocs/supabase/remote-agents.config.json\n' | drift_gate_match; then
+            echo 'drift-gate classifier self-test failed (modified gate file)' >&2
+            exit 1
+          fi
+          if ! printf 'R100\tdocs/supabase/remote-agents.config.json.old\tdocs/supabase/SYNC_REMOTE_AGENTS.sql\n' | drift_gate_match; then
+            echo 'drift-gate classifier self-test failed (rename dest only)' >&2
             exit 1
           fi
           if printf 'M\tdocs/guide.md\n' | drift_gate_match; then


### PR DESCRIPTION
## Summary

Hardens the CI change-classifier self-tests so a silent `awk`/shell regression fails CI:

- `drift_gate_match` gets a negative non-gate case (`M\tdocs/guide.md`) and a dest-only rename case (`R100` whose gate path appears only in field 3), so an always-true or field-2-only regression is caught.
- Each positive drift-gate case runs in its own `awk` invocation so `found` cannot leak across records.
- The dest-only rename uses `SYNC_REMOTE_AGENTS.sql`, which also keeps that gate alternative under positive coverage.
- `code_change_match` gets a standalone markdown-outside-`docs/` negative case.

## Issue acceptance gates

- #10229: the self-tests now cover the negative drift-gate case, a distinct rename src/dst for the drift gate, and the `\.md$` code-classifier branch.

## Single source of truth

The classifier self-tests in `.github/workflows/ci.yml` remain the single guard for the `awk` classifiers.

## Duplication and abstraction budget

No new abstraction.

## Net elements (R6)

n/a (CI workflow change)

## Consumer counts (R8)

n/a

## Host impact

Extension: none

Desktop: none

CLI: none (CI only)

## Scheduled refactoring

None

## Validation

- Ran the updated self-tests locally against representative `--name-status` lines, including a field-2-only matcher regression that now fails the dest-only rename case
- `prettier --write .github/workflows/ci.yml` clean
- Full CI runs on this PR