### PR TITLE
docs: drop stale lean omission from remote-agents config

### DIFF
--- a/docs/supabase/remote-agents.config.json
+++ b/docs/supabase/remote-agents.config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "Placement and visibility for agents in prompts/agents/remote/. Seeded from production remote_agents on 2026-04-15. Update this file (not YAML) when an agent's storage folder or visibility tags change. Agents managed outside prompts/agents/remote/ (e.g. lean, ocr, transcribe_audio — present in Supabase Storage but not in the repo) are intentionally omitted; the script leaves them alone. Only add names to `retired` when an agent has been deleted from Supabase Storage and should also be removed from the remote_agents table.",
+  "$schema": "Placement and visibility for agents in prompts/agents/remote/. Seeded from production remote_agents on 2026-04-15. Update this file (not YAML) when an agent's storage folder or visibility tags change. The sync script only upserts names discovered under prompts/agents/remote/ and only deletes names listed in `retired`; any other remote_agents rows are left alone. Only add names to `retired` when an agent has been deleted from Supabase Storage and should also be removed from the remote_agents table.",
   "retired": [
     "apply_multiple",
     "criticize_multiple",


### PR DESCRIPTION
## Summary

The `$schema` comment in `docs/supabase/remote-agents.config.json` still listed `lean` as a storage-only agent omitted from this file. Lean YAML now lives under `prompts/agents/remote/Lean4/` and has placement rows here.

`ocr` and `transcribe_audio` are packaged local workflow agents, not remote-agent rows, so they should not be named as storage-only omissions either.

The comment now states the actual sync contract from `scripts/sync-remote-agents.mjs`: upsert names discovered under `prompts/agents/remote/`, delete only names in `retired`, leave any other `remote_agents` rows alone.

## Issue acceptance gates

- #10228: the `$schema` note no longer names `lean` (or other in-file agents) as omitted, and it agrees with the sync script.

## Single source of truth

`scripts/sync-remote-agents.mjs` remains the owner of upsert/delete behavior. This comment now describes that contract instead of listing stale agent names.

## Duplication and abstraction budget

No new abstraction. One comment rewrite.

## Net elements (R6)

n/a (docs comment)

## Consumer counts (R8)

n/a

## Host impact

Extension: none

Desktop: none

CLI: none

## Scheduled refactoring

None

## Validation

- Checked `prompts/agents/remote/Lean4/` and the `agents` map for lean rows
- Confirmed `ocr` / `transcribe_audio` live in `packages/extension/resources/agents/` only
- Confirmed the script upserts discovered YAML and deletes only `retired`