### PR TITLE
test(progress-view): pin compaction activity a11y contracts

### DIFF
--- a/src/test-kernel/progressView/CompactionActivityRender.vitest.ts
+++ b/src/test-kernel/progressView/CompactionActivityRender.vitest.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports
 import type { CompactionActivity } from '@progressView/frontend/components/CompactionActivity';
-import type { CompactionActivityStatus } from '@shared/streams/compactionActivityProjection';
+import {
+  COMPACTION_ACTIVITY_LABEL,
+  type CompactionActivityStatus,
+} from '@shared/streams/compactionActivityProjection';
 
 // Local file imports
 import {
@@ -41,24 +44,35 @@ describe('compaction-activity render branches', () => {
   it('renders an aria-hidden wa-spinner while running', async () => {
     const element = await mount('running');
 
+    const row = query(element, '.activity');
+    expect(row?.getAttribute('role')).toBe('status');
+    expect(row?.getAttribute('aria-live')).toBe('polite');
+    expect(query(element, '.label')?.textContent).toBe(
+      COMPACTION_ACTIVITY_LABEL.running,
+    );
+
     const spinner = query(element, '.icon');
     expect(spinner?.tagName).toBe('WA-SPINNER');
+    // The row announces via role="status"; hide the spinner from AT.
     expect(spinner?.getAttribute('aria-hidden')).toBe('true');
-    // The row already announces via role="status"; no nested progressbar.
-    expect(query(element, '[role="progressbar"]')).toBeFalsy();
   });
 
   it('keeps the reduced-motion override on the shared spinner', async () => {
     const { CompactionActivity: Component } =
       await import('@progressView/frontend/components/CompactionActivity');
 
-    const cssText = Component.styles
-      ?.map((style) => (typeof style === 'string' ? style : style.cssText))
-      .join('\n');
+    // designTokens also mention prefers-reduced-motion, so pin the
+    // component-owned rule rather than the joined stylesheet text.
+    const componentStyle = Component.styles?.at(-1);
+    const cssText =
+      typeof componentStyle === 'string'
+        ? componentStyle
+        : (componentStyle?.cssText ?? '');
+    const collapsed = cssText.replaceAll(/\s+/g, ' ').trim();
 
-    expect(cssText).toContain('prefers-reduced-motion');
-    expect(cssText).toContain('wa-spinner::part(base)');
-    expect(cssText).toContain('animation: none');
+    expect(collapsed).toContain(
+      '@media (prefers-reduced-motion: reduce) { wa-spinner::part(base) { animation: none; } }',
+    );
   });
 
   it('renders the expected status icon for every non-running status', async () => {


### PR DESCRIPTION
## Summary

Hardens the CompactionActivity render tests so they fail when the accessibility contracts they exist to protect actually break.

- Running state: drop the vacuous `[role="progressbar"]` query of the host shadow root (it cannot pierce `<wa-spinner>` and the component never renders that role itself). Assert the row's `role="status"` / `aria-live="polite"` live region, the running label, and `aria-hidden` on the spinner.
- Reduced motion: stop joining every adopted stylesheet (designTokens already contains `prefers-reduced-motion`) and pin the component-owned `@media (prefers-reduced-motion: reduce) { wa-spinner::part(base) { animation: none; } }` rule.

## Issue acceptance gates

- #10239: the running-state assertion is no longer vacuous; it checks the live region and spinner `aria-hidden`.
- #10238: the reduced-motion assertion fails if the component rule is removed or flipped, even when `designTokens` still mention the media query.

## Single source of truth

`CompactionActivity` remains the owner of the row markup and the spinner reduced-motion override. The tests now pin those owned contracts instead of joined stylesheet text or an unreachable nested role.

## Duplication and abstraction budget

No new abstraction.

## Net elements (R6)

n/a (test-only)

## Consumer counts (R8)

n/a

## Host impact

Extension: none (test only)

Desktop: none

CLI: none

## Scheduled refactoring

None

## Validation

- `npx vitest run src/test-kernel/progressView/CompactionActivityRender.vitest.ts` (3 passed)