### PR TITLE
fix: set fetch duplex so Node 24 can launch subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,6 @@ All notable changes to this project will be documented in this file.
   → Agents no longer hides View prompt behind an Ultra plan, and remote agents
   no longer show a Remote badge or access-group labels.
 
-### CLI and Desktop
-
-#### Bug Fixes
-
-- **Leftover Lean language servers are stopped** — the CLI and desktop keep at
-  most two Lean servers at a time and stop one that has been idle for ten
-  minutes, so unused servers no longer exhaust the system file table.
-
 ### CLI
 
 #### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ All notable changes to this project will be documented in this file.
   → Agents no longer hides View prompt behind an Ultra plan, and remote agents
   no longer show a Remote badge or access-group labels.
 
+### CLI and Desktop
+
+#### Bug Fixes
+
+- **Leftover Lean language servers are stopped** — the CLI and desktop keep at
+  most two Lean servers at a time and stop one that has been idle for ten
+  minutes, so unused servers no longer exhaust the system file table.
+
 ### CLI
 
 #### Features
@@ -83,6 +91,8 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Delegating to a tool-use agent no longer fails on newer Node.js** —
+  launching a subagent no longer dies immediately with a request-body error.
 - **Command rejections preserve the user's actual instructions** — rejecting a
   shell-backed action without a note no longer presents generated retry
   guidance to the agent as though the user had written it.

--- a/src/platform/defaults/longRunningModelTransport.ts
+++ b/src/platform/defaults/longRunningModelTransport.ts
@@ -12,10 +12,20 @@ const MODEL_STREAM_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000;
 const MODEL_RESPONSE_HEADERS_TIMEOUT_MS = 10 * 60 * 1000;
 type UploadCompatibleFetch = typeof fetch & { Response: typeof Response };
 
+/** Node/undici require this for stream bodies; SDKs omit it inconsistently. */
+function requestInitWithDuplex(init?: RequestInit): UndiciRequestInit {
+  const next = { ...(init ?? {}) } as UndiciRequestInit;
+  if (next.body != null && next.duplex == null) {
+    next.duplex = 'half';
+  }
+  return next;
+}
+
 async function normalizeModelRequest(
   input: RequestInfo | URL,
   init?: RequestInit,
 ): Promise<[UndiciRequestInfo, UndiciRequestInit]> {
+  const requestInit = requestInitWithDuplex(init);
   if (!(input instanceof Request)) {
     if (init?.body instanceof FormData) {
       // OpenAI builds multipart bodies with the host-global FormData, while
@@ -31,17 +41,17 @@ async function normalizeModelRequest(
       return [
         input as UndiciRequestInfo,
         {
-          ...init,
+          ...requestInit,
           body,
-        } as UndiciRequestInit,
+        },
       ];
     }
-    return [input as UndiciRequestInfo, init as UndiciRequestInit];
+    return [input as UndiciRequestInfo, requestInit];
   }
 
   // OpenRouter supplies Node's native Request, while package Undici expects
   // its own branded Request. Rebuild it from interoperable primitives here.
-  const request = new Request(input, init);
+  const request = new Request(input, requestInit as RequestInit);
   const body = request.body === null ? undefined : await request.arrayBuffer();
   return [
     request.url,
@@ -50,7 +60,9 @@ async function normalizeModelRequest(
       headers: Object.fromEntries(request.headers.entries()),
       redirect: request.redirect,
       signal: request.signal,
-      ...(body === undefined ? {} : { body }),
+      ...(body === undefined
+        ? {}
+        : { body, duplex: requestInit.duplex ?? 'half' }),
     },
   ];
 }

--- a/src/platform/defaults/longRunningModelTransport.ts
+++ b/src/platform/defaults/longRunningModelTransport.ts
@@ -12,20 +12,15 @@ const MODEL_STREAM_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000;
 const MODEL_RESPONSE_HEADERS_TIMEOUT_MS = 10 * 60 * 1000;
 type UploadCompatibleFetch = typeof fetch & { Response: typeof Response };
 
-/** Node/undici require this for stream bodies; SDKs omit it inconsistently. */
-function requestInitWithDuplex(init?: RequestInit): UndiciRequestInit {
-  const next = { ...(init ?? {}) } as UndiciRequestInit;
-  if (next.body != null && next.duplex == null) {
-    next.duplex = 'half';
-  }
-  return next;
-}
-
 async function normalizeModelRequest(
   input: RequestInfo | URL,
   init?: RequestInit,
 ): Promise<[UndiciRequestInfo, UndiciRequestInit]> {
-  const requestInit = requestInitWithDuplex(init);
+  // Node/undici require duplex for any non-null body; SDKs omit it inconsistently.
+  const requestInit = { ...(init ?? {}) } as UndiciRequestInit;
+  if (requestInit.body != null && requestInit.duplex == null) {
+    requestInit.duplex = 'half';
+  }
   if (!(input instanceof Request)) {
     if (init?.body instanceof FormData) {
       // OpenAI builds multipart bodies with the host-global FormData, while

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -73,6 +73,7 @@ describe('long-running model transport', () => {
     expect(new TextDecoder().decode(init?.body as ArrayBuffer)).toBe(
       JSON.stringify({ prompt: 'hello' }),
     );
+    expect(init?.duplex).toBe('half');
     stub.composed?.dispatch(
       { method: 'GET', origin: 'https://example.test', path: '/' },
       {} as never,

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -109,4 +109,51 @@ describe('long-running model transport', () => {
     const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
     expect(init?.body).toBeInstanceOf(UndiciFormData);
   });
+
+  it('sets duplex: half when a caller sends a stream body without it', async () => {
+    stubComposedDispatcher();
+    transportMocks.undiciFetch.mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"ok":true}'));
+        controller.close();
+      },
+    });
+
+    await expect(
+      longRunningModelFetch('https://api.example/v1/chat', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body,
+      }),
+    ).resolves.toBeInstanceOf(Response);
+
+    const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
+    expect(init?.body).toBe(body);
+    expect(init?.duplex).toBe('half');
+  });
+
+  it('preserves an explicit duplex value on a streamed body', async () => {
+    stubComposedDispatcher();
+    transportMocks.undiciFetch.mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+
+    await longRunningModelFetch('https://api.example/v1/chat', {
+      method: 'POST',
+      body,
+      // Provider SDKs already set this; do not overwrite it.
+      duplex: 'half',
+    } as RequestInit);
+
+    const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
+    expect(init?.duplex).toBe('half');
+  });
 });


### PR DESCRIPTION
## Summary

Launching a tool-use subagent on Node 24 failed immediately with
`RequestInit: duplex option is required when sending a body`, so the
child run never started. Newer undici requires `duplex: "half"` for a
streaming request body; axios/octokit already set it, but the shared
model fetch transport did not.

This sets `duplex: "half"` on that transport whenever a body is present
and the caller did not already set it, so `delegate_agent` can start on
Node 24.

## Issue acceptance gates

- Closes #10156
- Addresses texra-ai/texra-issues#9
- Gate: launching a tool-use subagent no longer fails immediately with the duplex TypeError; the child run starts. Workaround ("do the work without subagents") is no longer required.

## Single source of truth

`longRunningModelFetch` / `normalizeModelRequest` in
`src/platform/defaults/longRunningModelTransport.ts` now owns duplex for
every model request that goes through the long-running transport.

## Duplication and abstraction budget

No new abstraction. A file-local helper installs the same `duplex: "half"`
default octokit already applies, only at this transport boundary.

## Net elements (R6)

n/a — bug fix, not a refactor/simplify PR.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed.

## Host impact

Extension: yes — VS Code on Node 24 can launch `delegate_agent` again.

Desktop: yes — same transport.

CLI: yes — same transport.

## Scheduled refactoring

None

## Validation

- `npx vitest run src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts` (4 passed)
- `npx eslint` on the changed TypeScript files
- `npx prettier --write` on the changed files
- Did not run the full `npm test` / `npm run typecheck` suite (scoped transport change)