### PR TITLE
test(cli): share cancelled-output fixture with a real source

### DIFF
--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
@@ -260,6 +260,26 @@ async function writeGeneratedOutput(root: string): Promise<string> {
   return generated;
 }
 
+/** Cancelled-run fixture: real source file plus a cancelled execution mock. */
+async function setupCancelledOutput(
+  root: string,
+  executionId: string,
+): Promise<ReturnType<typeof runOutputSummary>> {
+  const generated = await writeGeneratedOutput(root);
+  const outputSummary = runOutputSummary(
+    generated,
+    path.join(root, 'paper.tex'),
+  );
+  mockWorkflowExecution(
+    workflowExecution(executionId, {
+      outcome: RUN_OUTCOME.CANCELLED,
+      outputs: [outputSummary],
+    }),
+    true,
+  );
+  return outputSummary;
+}
+
 function expectNoModelOrInputWork(): void {
   expect(mocks.selectCliRunModel).not.toHaveBeenCalled();
   expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
@@ -671,16 +691,9 @@ describe('CLI workflow run command', () => {
 
   it('keeps non-empty cancelled outputs in run storage without copying to --output', async () => {
     await withTempRoot(async (root) => {
-      const outputSummary = runOutputSummary(
-        path.join(root, 'run', 'r1', 'paper.tex'),
-        path.join(root, 'paper.tex'),
-      );
-      mockWorkflowExecution(
-        workflowExecution('exec-cancelled-output', {
-          outcome: RUN_OUTCOME.CANCELLED,
-          outputs: [outputSummary],
-        }),
-        true,
+      const outputSummary = await setupCancelledOutput(
+        root,
+        'exec-cancelled-output',
       );
 
       const context = cliContext({
@@ -717,16 +730,9 @@ describe('CLI workflow run command', () => {
 
   it('keeps non-empty cancelled outputs in run storage without copying to --output-dir', async () => {
     await withTempRoot(async (root) => {
-      const outputSummary = runOutputSummary(
-        path.join(root, 'run', 'r1', 'paper.tex'),
-        path.join(root, 'paper.tex'),
-      );
-      mockWorkflowExecution(
-        workflowExecution('exec-cancelled-output-dir', {
-          outcome: RUN_OUTCOME.CANCELLED,
-          outputs: [outputSummary],
-        }),
-        true,
+      const outputSummary = await setupCancelledOutput(
+        root,
+        'exec-cancelled-output-dir',
       );
 
       const context = cliContext({
@@ -768,17 +774,7 @@ describe('CLI workflow run command', () => {
     await withTempRoot(async (root) => {
       const destination = path.join(root, 'polished.tex');
       await fs.writeFile(destination, 'keep-me');
-      const outputSummary = runOutputSummary(
-        path.join(root, 'run', 'r1', 'paper.tex'),
-        path.join(root, 'paper.tex'),
-      );
-      mockWorkflowExecution(
-        workflowExecution('exec-cancelled-existing-output', {
-          outcome: RUN_OUTCOME.CANCELLED,
-          outputs: [outputSummary],
-        }),
-        true,
-      );
+      await setupCancelledOutput(root, 'exec-cancelled-existing-output');
 
       const exitCode = await runWorkflow(
         { output: 'polished.tex' },


### PR DESCRIPTION
## Summary

The three cancelled-output cases in `WorkflowRunCommand` tests each rebuilt the same `outputSummary` plus cancelled execution mock. The pre-existing `--output` case also never materialized the run-storage source, so a copy-skip regression would throw ENOENT, still exit Interrupted, and leave `keep-me` green.

This extracts a file-local `setupCancelledOutput` helper that writes the generated source via `writeGeneratedOutput` and installs the cancelled mock. All three cases now share that fixture, so a guard regression actually copies the file and fails the destination assertions.

## Issue acceptance gates

- #10232: the pre-existing `--output` test materializes `root/run/r1/paper.tex` and uses that path as `absolutePath`.
- #10233: the three cancelled-output setups share one file-local helper.

## Single source of truth

`setupCancelledOutput` is the only cancelled-output fixture in this file. `writeGeneratedOutput` remains the primitive that creates the source file.

## Duplication and abstraction budget

Removed three independently maintained setup blocks. One file-local helper; no new export.

## Net elements (R6)

n/a (test-only)

## Consumer counts (R8)

n/a

## Host impact

Extension: none

Desktop: none

CLI: none (test only)

## Scheduled refactoring

None

## Validation

- `npx vitest run src/test-kernel/cli/WorkflowRunCommand.vitest.ts` (32 passed)