### PR TITLE
fix(lean): stop leftover CLI and desktop language servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **Leftover Lean language servers are stopped** — the CLI and desktop stop a
-  Lean server that has been idle for thirty minutes, so unused worktree servers
-  no longer exhaust the system file table. Parallel worktrees stay up while
-  they are in use.
+- **Unused Lean language servers no longer accumulate** — leftover CLI and
+  desktop Lean sessions stop after they sit unused, so later Lean work is not
+  disrupted by leftover servers from earlier worktrees.
 
 ### CLI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **Leftover Lean language servers are stopped** — the CLI and desktop keep at
-  most two Lean servers at a time and stop one that has been idle for ten
-  minutes, so unused servers no longer exhaust the system file table.
+- **Leftover Lean language servers are stopped** — the CLI and desktop stop a
+  Lean server that has been idle for ten minutes, so unused worktree servers
+  no longer exhaust the system file table. Parallel worktrees stay up while
+  they are in use.
 
 ### CLI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.
 #### Bug Fixes
 
 - **Leftover Lean language servers are stopped** — the CLI and desktop stop a
-  Lean server that has been idle for ten minutes, so unused worktree servers
+  Lean server that has been idle for thirty minutes, so unused worktree servers
   no longer exhaust the system file table. Parallel worktrees stay up while
   they are in use.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ All notable changes to this project will be documented in this file.
   → Agents no longer hides View prompt behind an Ultra plan, and remote agents
   no longer show a Remote badge or access-group labels.
 
+### CLI and Desktop
+
+#### Bug Fixes
+
+- **Leftover Lean language servers are stopped** — the CLI and desktop keep at
+  most two Lean servers at a time and stop one that has been idle for ten
+  minutes, so unused servers no longer exhaust the system file table.
+
 ### CLI
 
 #### Features

--- a/docs/guide/lean.md
+++ b/docs/guide/lean.md
@@ -29,7 +29,7 @@ TeXRA detects the running Lean 4 extension and routes its tools through it — s
 
 ### <wa-icon library="texra" name="terminal"></wa-icon> In the CLI
 
-There's no Lean 4 extension to lean on, so TeXRA spawns its own server (`lake env lean --server`). Each Lake project gets its own process; an unused one is stopped after ten minutes. You need `lake` on your `PATH`:
+There's no Lean 4 extension to lean on, so TeXRA spawns its own server (`lake env lean --server`). Each Lake project gets its own process; an unused one is stopped after thirty minutes. You need `lake` on your `PATH`:
 
 1. Install **elan** (the Lean version manager):
    ```bash

--- a/docs/guide/lean.md
+++ b/docs/guide/lean.md
@@ -29,7 +29,7 @@ TeXRA detects the running Lean 4 extension and routes its tools through it — s
 
 ### <wa-icon library="texra" name="terminal"></wa-icon> In the CLI
 
-There's no Lean 4 extension to lean on, so TeXRA spawns its own server (`lake env lean --server`, one process per project). You need `lake` on your `PATH`:
+There's no Lean 4 extension to lean on, so TeXRA spawns its own server (`lake env lean --server`). At most two project servers stay running; an unused one is stopped after ten minutes. You need `lake` on your `PATH`:
 
 1. Install **elan** (the Lean version manager):
    ```bash
@@ -52,7 +52,7 @@ If you don't have elan yet, see the [Lean community install guide](https://leanp
 There is **no switch to flip**. Lean support turns on automatically the moment a Lean-capable agent runs a Lean tool on a `.lean` file in a Lake project. To get going, just pick a Lean-capable agent (see below) and ask it to work on your proof.
 
 ::: tip Check that it's working
-Open **Dashboard → Tools** (<wa-icon library="texra" name="tools"></wa-icon>) → **Lean 4 Proof Assistant** (<wa-icon library="texra" name="beaker"></wa-icon>) to confirm your setup is detected. The panel shows whether the Lean 4 extension is available (VS Code) or whether `lake` was found (CLI), and lists any active language servers — one per Lake project root.
+Open **Dashboard → Tools** (<wa-icon library="texra" name="tools"></wa-icon>) → **Lean 4 Proof Assistant** (<wa-icon library="texra" name="beaker"></wa-icon>) to confirm your setup is detected. The panel shows whether the Lean 4 extension is available (VS Code) or whether `lake` was found (CLI), and lists any active language servers.
 :::
 
 ## Choosing an Agent

--- a/docs/guide/lean.md
+++ b/docs/guide/lean.md
@@ -29,7 +29,7 @@ TeXRA detects the running Lean 4 extension and routes its tools through it — s
 
 ### <wa-icon library="texra" name="terminal"></wa-icon> In the CLI
 
-There's no Lean 4 extension to lean on, so TeXRA spawns its own server (`lake env lean --server`). At most two project servers stay running; an unused one is stopped after ten minutes. You need `lake` on your `PATH`:
+There's no Lean 4 extension to lean on, so TeXRA spawns its own server (`lake env lean --server`). Each Lake project gets its own process; an unused one is stopped after ten minutes. You need `lake` on your `PATH`:
 
 1. Install **elan** (the Lean version manager):
    ```bash

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -352,6 +352,22 @@ describe('createDirectLspLeanAdapter', () => {
     expect(await countStarts()).toBe(starts);
   });
 
+  fakeLakeIt('stops a restarted session after it sits idle', async () => {
+    const adapter = createDirectLspLeanAdapter({
+      lakeCommand: fakeLakePath,
+      idleTimeoutMs: 50,
+    });
+    try {
+      await adapter.fetchDiagnosticsForFile(filePath);
+      await adapter.executeProjectCommand('restart_server');
+      expect(activeServerRoots()).toEqual([projectRoot]);
+      await delay(150);
+      expect(activeServerRoots()).toEqual([]);
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
   fakeLakeIt('treats project commands as session activity', async () => {
     const second = makeLakeProject(tempRoot, 'project-b');
     let clock = 0;

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -23,6 +23,10 @@ import { splitOutputLines } from '@utils/text/stringUtils';
 const FAKE_LAKE = `#!/usr/bin/env node
 const fs = require('node:fs');
 
+if (!process.argv.includes('--server')) {
+  process.exit(0);
+}
+
 const countPath = process.env.TEXRA_FAKE_LEAN_COUNT;
 if (countPath) fs.appendFileSync(countPath, 'start\\n');
 
@@ -152,15 +156,12 @@ describe('createDirectLspLeanAdapter', () => {
     await session.ensureReady();
 
     const pendingDiagnostics = session.fetchDiagnostics(filePath);
+    const settled = expect(pendingDiagnostics).rejects.toThrow(
+      'Lean session has been disposed.',
+    );
     await delay(100);
     await session.dispose();
-
-    await expect(
-      Promise.race([
-        pendingDiagnostics.then(() => 'settled'),
-        delay(500).then(() => 'timed out'),
-      ]),
-    ).resolves.toBe('settled');
+    await settled;
   });
 
   fakeLakeIt(
@@ -275,6 +276,97 @@ describe('createDirectLspLeanAdapter', () => {
       await adapter.fetchDiagnosticsForFile(second.filePath);
       expect(await countStarts()).toBe(2);
       expect(activeServerRoots()).toEqual([second.projectRoot]);
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
+  fakeLakeIt(
+    'does not stop a session while a diagnostics request is in flight',
+    async () => {
+      vi.stubEnv('TEXRA_FAKE_LEAN_SUPPRESS_DIAGNOSTICS', '1');
+      const adapter = createDirectLspLeanAdapter({
+        lakeCommand: fakeLakePath,
+        idleTimeoutMs: 50,
+      });
+      const pending = adapter.fetchDiagnosticsForFile(filePath);
+      try {
+        await delay(700);
+        expect(activeServerRoots()).toEqual([projectRoot]);
+        await delay(150);
+        expect(activeServerRoots()).toEqual([projectRoot]);
+        await adapter.dispose();
+        await expect(pending).resolves.toMatchObject({
+          ok: false,
+          kind: 'toolchain_unavailable',
+        });
+      } finally {
+        await adapter.dispose();
+        await Promise.allSettled([pending]);
+      }
+    },
+  );
+
+  fakeLakeIt(
+    'does not evict a workspace that still has an in-flight request',
+    async () => {
+      vi.stubEnv('TEXRA_FAKE_LEAN_SUPPRESS_DIAGNOSTICS', '1');
+      const second = makeLakeProject(tempRoot, 'project-b');
+      const adapter = createDirectLspLeanAdapter({
+        lakeCommand: fakeLakePath,
+        maxSessions: 1,
+        idleTimeoutMs: 0,
+      });
+      const pendingFirst = adapter.fetchDiagnosticsForFile(filePath);
+      try {
+        await delay(100);
+        const pendingSecond = adapter.fetchDiagnosticsForFile(second.filePath);
+        await delay(100);
+        expect(activeServerRoots()).toEqual([projectRoot]);
+        await adapter.dispose();
+        await Promise.allSettled([pendingFirst, pendingSecond]);
+      } finally {
+        await adapter.dispose();
+        await Promise.allSettled([pendingFirst]);
+      }
+    },
+  );
+
+  fakeLakeIt('does not start queued servers after dispose', async () => {
+    const second = makeLakeProject(tempRoot, 'project-b');
+    const third = makeLakeProject(tempRoot, 'project-c');
+    const adapter = createDirectLspLeanAdapter({
+      lakeCommand: fakeLakePath,
+      idleTimeoutMs: 0,
+    });
+    const pending = Promise.allSettled([
+      adapter.fetchDiagnosticsForFile(filePath),
+      adapter.fetchDiagnosticsForFile(second.filePath),
+      adapter.fetchDiagnosticsForFile(third.filePath),
+    ]);
+    await adapter.dispose();
+    await pending;
+    expect(activeServerRoots()).toEqual([]);
+    const starts = await countStarts();
+    await delay(100);
+    expect(await countStarts()).toBe(starts);
+  });
+
+  fakeLakeIt('treats project commands as session activity', async () => {
+    const second = makeLakeProject(tempRoot, 'project-b');
+    let clock = 0;
+    const adapter = createDirectLspLeanAdapter({
+      lakeCommand: fakeLakePath,
+      maxSessions: 2,
+      idleTimeoutMs: 1_000,
+      now: () => clock,
+    });
+    try {
+      await adapter.fetchDiagnosticsForFile(filePath);
+      clock = 2_000;
+      await adapter.executeProjectCommand('build');
+      await adapter.fetchDiagnosticsForFile(second.filePath);
+      expect(activeServerRoots()).toEqual([projectRoot, second.projectRoot]);
     } finally {
       await adapter.dispose();
     }

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import {
   chmodSync,
   mkdirSync,
@@ -8,8 +9,24 @@ import {
 import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
+import { PassThrough } from 'node:stream';
 import { pathToFileURL } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { spawnOverride } = vi.hoisted(() => ({
+  spawnOverride: {
+    current: undefined as undefined | ((...args: unknown[]) => unknown),
+  },
+}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: (...args: Parameters<typeof actual.spawn>) =>
+      (spawnOverride.current ?? actual.spawn)(...args),
+  };
+});
 
 import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
 import { fileUriToPath, LeanSession } from '@tools/lean/direct/leanSession';
@@ -24,7 +41,9 @@ const FAKE_LAKE = `#!/usr/bin/env node
 const fs = require('node:fs');
 
 if (!process.argv.includes('--server')) {
-  process.exit(0);
+  const delayMs = Number(process.env.TEXRA_FAKE_LEAN_LAKE_DELAY || 0);
+  setTimeout(() => process.exit(0), delayMs);
+  return;
 }
 
 const countPath = process.env.TEXRA_FAKE_LEAN_COUNT;
@@ -48,7 +67,9 @@ function handle(message) {
     return;
   }
   if (message.method === 'exit') {
-    process.exit(0);
+    const delayMs = Number(process.env.TEXRA_FAKE_LEAN_EXIT_DELAY || 0);
+    setTimeout(() => process.exit(0), delayMs);
+    return;
   }
   if (message.method === 'textDocument/didOpen') {
     if (process.env.TEXRA_FAKE_LEAN_SUPPRESS_DIAGNOSTICS === '1') return;
@@ -114,6 +135,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  spawnOverride.current = undefined;
   vi.unstubAllEnvs();
   rmSync(tempRoot, { recursive: true, force: true });
 });
@@ -388,6 +410,106 @@ describe('createDirectLspLeanAdapter', () => {
     },
   );
 
+  fakeLakeIt(
+    'does not SIGKILL a live server two seconds after spawn',
+    async () => {
+      const adapter = createDirectLspLeanAdapter({
+        lakeCommand: fakeLakePath,
+        idleTimeoutMs: 0,
+      });
+      try {
+        await adapter.fetchDiagnosticsForFile(filePath);
+        await delay(2_200);
+        expect(activeServerRoots()).toEqual([projectRoot]);
+        expect(await countStarts()).toBe(1);
+        await expect(
+          adapter.fetchDiagnosticsForFile(filePath),
+        ).resolves.toMatchObject({ ok: true });
+        expect(await countStarts()).toBe(1);
+      } finally {
+        await adapter.dispose();
+      }
+    },
+  );
+
+  it('waits for the child to close before a failed start finishes disposing', async () => {
+    const child = createFakeLeanChild({ closeDelayMs: 80, silent: true });
+    spawnOverride.current = () => child;
+
+    const session = new LeanSession({
+      workspaceRoot: projectRoot,
+      lakeCommand: fakeLakePath,
+    });
+    const ready = session.ensureReady();
+    await delay(20);
+    const disposed = session.dispose();
+    let finished = false;
+    void Promise.allSettled([ready, disposed]).then(() => {
+      finished = true;
+    });
+    await delay(30);
+    expect(finished).toBe(false);
+    child.closeSoon();
+    await disposed;
+    await Promise.allSettled([ready]);
+    expect(finished).toBe(true);
+  });
+
+  fakeLakeIt(
+    'does not release a replacement session from a project command that never acquired it',
+    async () => {
+      vi.stubEnv('TEXRA_FAKE_LEAN_EXIT_DELAY', '150');
+      vi.stubEnv('TEXRA_FAKE_LEAN_LAKE_DELAY', '400');
+      const second = makeLakeProject(tempRoot, 'project-b');
+      const adapter = createDirectLspLeanAdapter({
+        lakeCommand: fakeLakePath,
+        maxSessions: 1,
+        idleTimeoutMs: 40,
+      });
+      try {
+        await adapter.fetchDiagnosticsForFile(filePath);
+        await delay(80);
+        const build = adapter.executeProjectCommand('build');
+        void build.catch(() => undefined);
+        await delay(200);
+        vi.stubEnv('TEXRA_FAKE_LEAN_SUPPRESS_DIAGNOSTICS', '1');
+        const pending = adapter.fetchDiagnosticsForFile(filePath);
+        await Promise.allSettled([build]);
+        const other = adapter.fetchDiagnosticsForFile(second.filePath);
+        await delay(80);
+        expect(activeServerRoots()).toContain(projectRoot);
+        await adapter.dispose();
+        await Promise.allSettled([pending, other]);
+      } finally {
+        await adapter.dispose();
+      }
+    },
+  );
+
+  it('keeps a disposing session reserved until the child closes', async () => {
+    let spawnCount = 0;
+    spawnOverride.current = () => {
+      spawnCount += 1;
+      return createFakeLeanChild({ closeDelayMs: 200 });
+    };
+    const adapter = createDirectLspLeanAdapter({
+      lakeCommand: fakeLakePath,
+      idleTimeoutMs: 30,
+    });
+    try {
+      await adapter.fetchDiagnosticsForFile(filePath);
+      expect(spawnCount).toBe(1);
+      await delay(60);
+      const pending = adapter.fetchDiagnosticsForFile(filePath);
+      await delay(40);
+      expect(spawnCount).toBe(1);
+      await pending;
+      expect(spawnCount).toBe(2);
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
   fakeLakeIt('stops a restarted session after it sits idle', async () => {
     const adapter = createDirectLspLeanAdapter({
       lakeCommand: fakeLakePath,
@@ -442,4 +564,119 @@ function activeServerRoots(): string[] {
     .filter(isLeanServerActive)
     .map((info) => info.workspaceRoot)
     .toSorted((a, b) => a.localeCompare(b));
+}
+
+interface FakeLeanChild extends EventEmitter {
+  stdin: PassThrough;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  pid: number | undefined;
+  killed: boolean;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  kill: (signal?: NodeJS.Signals) => boolean;
+  closeSoon: () => void;
+}
+
+function createFakeLeanChild(options?: {
+  closeDelayMs?: number;
+  silent?: boolean;
+}): FakeLeanChild {
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  let buffer = Buffer.alloc(0);
+  const closeDelayMs = options?.closeDelayMs ?? 0;
+
+  function send(message: unknown): void {
+    const body = Buffer.from(JSON.stringify(message), 'utf8');
+    stdout.write(`Content-Length: ${body.length}\r\n\r\n`);
+    stdout.write(body);
+  }
+
+  function handle(message: {
+    id?: number;
+    method?: string;
+    params?: { textDocument?: { uri?: string } };
+  }): void {
+    if (message.method === 'initialize') {
+      if (options?.silent) return;
+      send({ jsonrpc: '2.0', id: message.id, result: { capabilities: {} } });
+      return;
+    }
+    if (message.method === 'shutdown') {
+      send({ jsonrpc: '2.0', id: message.id, result: null });
+      return;
+    }
+    if (message.method === 'textDocument/didOpen') {
+      const uri = message.params?.textDocument?.uri;
+      if (!uri) return;
+      send({
+        jsonrpc: '2.0',
+        method: 'textDocument/publishDiagnostics',
+        params: {
+          uri,
+          diagnostics: [
+            {
+              severity: 1,
+              message: 'fake diagnostic',
+              range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 1 },
+              },
+              source: 'fake-lean',
+            },
+          ],
+        },
+      });
+    }
+  }
+
+  stdin.on('data', (chunk: Buffer) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    for (;;) {
+      const headerEnd = buffer.indexOf('\r\n\r\n');
+      if (headerEnd < 0) return;
+      const header = buffer.subarray(0, headerEnd).toString('utf8');
+      const match = header.match(/Content-Length: (\d+)/i);
+      if (!match) return;
+      const length = Number.parseInt(match[1], 10);
+      const bodyStart = headerEnd + 4;
+      const frameEnd = bodyStart + length;
+      if (buffer.length < frameEnd) return;
+      const body = buffer.subarray(bodyStart, frameEnd).toString('utf8');
+      buffer = buffer.subarray(frameEnd);
+      handle(JSON.parse(body) as Parameters<typeof handle>[0]);
+    }
+  });
+
+  const child = Object.assign(new EventEmitter(), {
+    stdin,
+    stdout,
+    stderr,
+    pid: 4242,
+    killed: false,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    kill(signal?: NodeJS.Signals) {
+      if (this.exitCode != null || this.signalCode != null) return true;
+      this.killed = true;
+      this.exitCode = 0;
+      this.emit('exit', 0, signal ?? null);
+      const finish = () => {
+        if (!stdin.destroyed) stdin.end();
+        if (!stdout.destroyed) stdout.end();
+        if (!stderr.destroyed) stderr.end();
+        this.emit('close', 0, null);
+      };
+      if (closeDelayMs > 0) setTimeout(finish, closeDelayMs);
+      else finish();
+      return true;
+    },
+    closeSoon() {
+      this.exitCode = 1;
+      this.emit('close', 1, null);
+    },
+  });
+  return child;
 }

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -238,6 +238,28 @@ describe('createDirectLspLeanAdapter', () => {
     },
   );
 
+  fakeLakeIt('keeps more than two active workspaces by default', async () => {
+    const second = makeLakeProject(tempRoot, 'project-b');
+    const third = makeLakeProject(tempRoot, 'project-c');
+    const adapter = createDirectLspLeanAdapter({
+      lakeCommand: fakeLakePath,
+      idleTimeoutMs: 0,
+    });
+    try {
+      await adapter.fetchDiagnosticsForFile(filePath);
+      await adapter.fetchDiagnosticsForFile(second.filePath);
+      await adapter.fetchDiagnosticsForFile(third.filePath);
+      expect(await countStarts()).toBe(3);
+      expect(activeServerRoots()).toEqual([
+        projectRoot,
+        second.projectRoot,
+        third.projectRoot,
+      ]);
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
   fakeLakeIt('stops an idle workspace before opening another', async () => {
     const second = makeLakeProject(tempRoot, 'project-b');
     let clock = 0;

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -352,6 +352,42 @@ describe('createDirectLspLeanAdapter', () => {
     expect(await countStarts()).toBe(starts);
   });
 
+  fakeLakeIt(
+    'settles a start that was already queued when dispose runs',
+    async () => {
+      vi.stubEnv('TEXRA_FAKE_LEAN_SUPPRESS_DIAGNOSTICS', '1');
+      const second = makeLakeProject(tempRoot, 'project-b');
+      const adapter = createDirectLspLeanAdapter({
+        lakeCommand: fakeLakePath,
+        maxSessions: 1,
+        idleTimeoutMs: 0,
+      });
+      const first = adapter.fetchDiagnosticsForFile(filePath);
+      try {
+        await delay(150);
+        expect(activeServerRoots()).toEqual([projectRoot]);
+        const queued = adapter.fetchDiagnosticsForFile(second.filePath);
+        await delay(50);
+        const disposed = adapter.dispose();
+        await expect(
+          Promise.race([
+            queued,
+            delay(1_000).then(() => {
+              throw new Error('queued start did not settle after dispose');
+            }),
+          ]),
+        ).resolves.toMatchObject({
+          ok: false,
+          kind: 'toolchain_unavailable',
+        });
+        await disposed;
+      } finally {
+        await adapter.dispose();
+        await Promise.allSettled([first]);
+      }
+    },
+  );
+
   fakeLakeIt('stops a restarted session after it sits idle', async () => {
     const adapter = createDirectLspLeanAdapter({
       lakeCommand: fakeLakePath,

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -486,6 +486,56 @@ describe('createDirectLspLeanAdapter', () => {
     },
   );
 
+  it('retries EMFILE after evicting idle sessions without waiting for busy ones', async () => {
+    const second = makeLakeProject(tempRoot, 'project-b');
+    const third = makeLakeProject(tempRoot, 'project-c');
+    let spawnCount = 0;
+    let failNextSpawn = false;
+    spawnOverride.current = () => {
+      spawnCount += 1;
+      if (failNextSpawn) {
+        failNextSpawn = false;
+        throw Object.assign(new Error('too many open files'), {
+          code: 'EMFILE',
+        });
+      }
+      return createFakeLeanChild();
+    };
+
+    const adapter = createDirectLspLeanAdapter({
+      lakeCommand: fakeLakePath,
+      idleTimeoutMs: 0,
+    });
+    try {
+      await adapter.fetchDiagnosticsForFile(filePath);
+      await adapter.fetchDiagnosticsForFile(second.filePath);
+
+      // Keep the first workspace in-flight so recovery cannot evict it.
+      const pendingBusy = adapter.getHoverInfo(filePath, 0, 0);
+      await delay(50);
+
+      failNextSpawn = true;
+      const started = adapter.fetchDiagnosticsForFile(third.filePath);
+      await expect(
+        Promise.race([
+          started,
+          delay(1_000).then(() => {
+            throw new Error('EMFILE recovery waited for the busy session');
+          }),
+        ]),
+      ).resolves.toMatchObject({
+        ok: true,
+        diagnostics: [{ message: 'fake diagnostic' }],
+      });
+      expect(activeServerRoots()).toEqual([projectRoot, third.projectRoot]);
+      expect(spawnCount).toBe(4);
+      await adapter.dispose();
+      await Promise.allSettled([pendingBusy]);
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
   it('keeps a disposing session reserved until the child closes', async () => {
     let spawnCount = 0;
     spawnOverride.current = () => {
@@ -650,7 +700,8 @@ function createFakeLeanChild(options?: {
     }
   });
 
-  const child = Object.assign(new EventEmitter(), {
+  const events = new EventEmitter();
+  const child = Object.assign(events, {
     stdin,
     stdout,
     stderr,
@@ -658,6 +709,7 @@ function createFakeLeanChild(options?: {
     killed: false,
     exitCode: null as number | null,
     signalCode: null as NodeJS.Signals | null,
+    emit: events.emit.bind(events),
     kill(signal?: NodeJS.Signals) {
       if (this.exitCode != null || this.signalCode != null) return true;
       this.killed = true;

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -1,3 +1,4 @@
+// Node imports
 import { EventEmitter } from 'node:events';
 import {
   chmodSync,
@@ -11,6 +12,8 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { PassThrough } from 'node:stream';
 import { pathToFileURL } from 'node:url';
+
+// Third-party imports
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { spawnOverride } = vi.hoisted(() => ({
@@ -28,6 +31,7 @@ vi.mock('node:child_process', async (importOriginal) => {
   };
 });
 
+// Local imports
 import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
 import { fileUriToPath, LeanSession } from '@tools/lean/direct/leanSession';
 import {
@@ -531,6 +535,56 @@ describe('createDirectLspLeanAdapter', () => {
       expect(spawnCount).toBe(4);
       await adapter.dispose();
       await Promise.allSettled([pendingBusy]);
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
+  it('awaits already-disposing sessions before retrying EMFILE', async () => {
+    const second = makeLakeProject(tempRoot, 'project-b');
+    let spawnCount = 0;
+    let firstClosed = false;
+    spawnOverride.current = () => {
+      spawnCount += 1;
+      if (spawnCount > 1 && !firstClosed) {
+        throw Object.assign(new Error('too many open files'), {
+          code: 'EMFILE',
+        });
+      }
+      const child = createFakeLeanChild({
+        closeDelayMs: spawnCount === 1 ? 200 : 0,
+      });
+      if (spawnCount === 1) {
+        child.on('close', () => {
+          firstClosed = true;
+        });
+      }
+      return child;
+    };
+
+    const adapter = createDirectLspLeanAdapter({
+      lakeCommand: fakeLakePath,
+      idleTimeoutMs: 30,
+    });
+    try {
+      await adapter.fetchDiagnosticsForFile(filePath);
+      await delay(80);
+      const started = adapter.fetchDiagnosticsForFile(second.filePath);
+      await expect(
+        Promise.race([
+          started,
+          delay(1_000).then(() => {
+            throw new Error(
+              'EMFILE recovery did not wait for the disposing session',
+            );
+          }),
+        ]),
+      ).resolves.toMatchObject({
+        ok: true,
+        diagnostics: [{ message: 'fake diagnostic' }],
+      });
+      expect(firstClosed).toBe(true);
+      expect(spawnCount).toBe(3);
     } finally {
       await adapter.dispose();
     }

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -13,6 +13,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
 import { fileUriToPath, LeanSession } from '@tools/lean/direct/leanSession';
+import {
+  isLeanServerActive,
+  listLeanServers,
+} from '@tools/lean/leanServerRegistry';
 import { delay } from '@utils/core';
 import { splitOutputLines } from '@utils/text/stringUtils';
 
@@ -213,4 +217,63 @@ describe('createDirectLspLeanAdapter', () => {
       }
     },
   );
+
+  fakeLakeIt(
+    'evicts the least-recent workspace when the session cap is reached',
+    async () => {
+      const second = makeLakeProject(tempRoot, 'project-b');
+      const adapter = createDirectLspLeanAdapter({
+        lakeCommand: fakeLakePath,
+        maxSessions: 1,
+        idleTimeoutMs: 0,
+      });
+      try {
+        await adapter.fetchDiagnosticsForFile(filePath);
+        await adapter.fetchDiagnosticsForFile(second.filePath);
+        expect(await countStarts()).toBe(2);
+        expect(activeServerRoots()).toEqual([second.projectRoot]);
+      } finally {
+        await adapter.dispose();
+      }
+    },
+  );
+
+  fakeLakeIt('stops an idle workspace before opening another', async () => {
+    const second = makeLakeProject(tempRoot, 'project-b');
+    let clock = 0;
+    const adapter = createDirectLspLeanAdapter({
+      lakeCommand: fakeLakePath,
+      maxSessions: 2,
+      idleTimeoutMs: 1_000,
+      now: () => clock,
+    });
+    try {
+      await adapter.fetchDiagnosticsForFile(filePath);
+      clock = 2_000;
+      await adapter.fetchDiagnosticsForFile(second.filePath);
+      expect(await countStarts()).toBe(2);
+      expect(activeServerRoots()).toEqual([second.projectRoot]);
+    } finally {
+      await adapter.dispose();
+    }
+  });
 });
+
+function makeLakeProject(
+  root: string,
+  name: string,
+): { projectRoot: string; filePath: string } {
+  const projectRoot = path.join(root, name);
+  mkdirSync(projectRoot);
+  writeFileSync(path.join(projectRoot, 'lakefile.toml'), `name = "${name}"\n`);
+  const filePath = path.join(projectRoot, 'Test.lean');
+  writeFileSync(filePath, 'example : True := by trivial\n');
+  return { projectRoot, filePath };
+}
+
+function activeServerRoots(): string[] {
+  return listLeanServers()
+    .filter(isLeanServerActive)
+    .map((info) => info.workspaceRoot)
+    .toSorted((a, b) => a.localeCompare(b));
+}

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -393,7 +393,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       '  • VS Code build: uses the "lean4" extension\n' +
       '    (leanprover.lean4) and its running language server.\n' +
       '  • CLI / desktop build: spawns `lake env lean --server`\n' +
-      '    directly (at most two project servers; idle ones stop\n' +
+      '    directly (one process per Lake project; idle ones stop\n' +
       '    after ten minutes). Requires `lake` (from elan/Lean) on\n' +
       '    PATH; install via\n' +
       '    https://leanprover-community.github.io/install/.\n\n' +
@@ -410,7 +410,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     installExtensionId: LEAN4_EXTENSION_ID,
     configNotes:
       'VS Code build: requires the leanprover.lean4 extension. ' +
-      'CLI / desktop builds: requires `lake` on PATH; at most two Lake project servers stay running and idle ones stop after ten minutes, surfaced below.',
+      'CLI / desktop builds: requires `lake` on PATH; each Lake project can have its own language server, and idle ones stop after ten minutes, surfaced below.',
     ...prerequisitesChecks({
       probe: async () => {
         const extensionAvailable =

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -387,14 +387,15 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     name: 'Lean 4 Proof Assistant',
     category: 'lean',
     description:
-      'Interact with Lean 4 projects: check diagnostics, inspect terms, search Loogle, and manage files. Active language servers (one per project root) are listed below.',
+      'Interact with Lean 4 projects: check diagnostics, inspect terms, search Loogle, and manage files. Active language servers are listed below.',
     installGuide:
       'TeXRA can drive Lean 4 in two ways:\n\n' +
       '  • VS Code build: uses the "lean4" extension\n' +
       '    (leanprover.lean4) and its running language server.\n' +
       '  • CLI / desktop build: spawns `lake env lean --server`\n' +
-      '    directly, one process per Lake project root. Requires\n' +
-      '    `lake` (from elan/Lean) on PATH; install via\n' +
+      '    directly (at most two project servers; idle ones stop\n' +
+      '    after ten minutes). Requires `lake` (from elan/Lean) on\n' +
+      '    PATH; install via\n' +
       '    https://leanprover-community.github.io/install/.\n\n' +
       'Setup (VS Code):\n' +
       '  1. Install the "lean4" extension from VS Code Marketplace\n' +
@@ -409,7 +410,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     installExtensionId: LEAN4_EXTENSION_ID,
     configNotes:
       'VS Code build: requires the leanprover.lean4 extension. ' +
-      'CLI / desktop builds: requires `lake` on PATH; each Lake project root gets its own language server, surfaced below.',
+      'CLI / desktop builds: requires `lake` on PATH; at most two Lake project servers stay running and idle ones stop after ten minutes, surfaced below.',
     ...prerequisitesChecks({
       probe: async () => {
         const extensionAvailable =

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -394,7 +394,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       '    (leanprover.lean4) and its running language server.\n' +
       '  • CLI / desktop build: spawns `lake env lean --server`\n' +
       '    directly (one process per Lake project; idle ones stop\n' +
-      '    after ten minutes). Requires `lake` (from elan/Lean) on\n' +
+      '    after thirty minutes). Requires `lake` (from elan/Lean) on\n' +
       '    PATH; install via\n' +
       '    https://leanprover-community.github.io/install/.\n\n' +
       'Setup (VS Code):\n' +
@@ -410,7 +410,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     installExtensionId: LEAN4_EXTENSION_ID,
     configNotes:
       'VS Code build: requires the leanprover.lean4 extension. ' +
-      'CLI / desktop builds: requires `lake` on PATH; each Lake project can have its own language server, and idle ones stop after ten minutes, surfaced below.',
+      'CLI / desktop builds: requires `lake` on PATH; each Lake project can have its own language server, and idle ones stop after thirty minutes, surfaced below.',
     ...prerequisitesChecks({
       probe: async () => {
         const extensionAvailable =

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -301,26 +301,25 @@ export function createDirectLspLeanAdapter(
     }
   }
 
+  /**
+   * Stop currently-idle other workspaces after EMFILE/ENFILE, then return so
+   * the caller can retry the spawn. Do not wait for busy sessions: position
+   * RPCs have no timeout, so one hung hover/goal would stall the start queue.
+   */
   async function evictOthersForExhausted(
     exceptRoot: string,
     generation: number,
   ): Promise<void> {
-    while ([...sessions.keys()].some((key) => key !== exceptRoot)) {
-      throwIfStopped(generation);
-      const idleOthers = [...sessions.entries()]
-        .filter(
-          ([key, tracked]) =>
-            key !== exceptRoot && !tracked.disposing && tracked.inFlight === 0,
-        )
-        .map(([key]) => key);
-      if (idleOthers.length === 0) {
-        await waitForSessionFreed();
-        continue;
-      }
-      await Promise.all(
-        idleOthers.map((key) => disposeSession(key, 'exhausted')),
-      );
-    }
+    throwIfStopped(generation);
+    const idleOthers = [...sessions.entries()]
+      .filter(
+        ([key, tracked]) =>
+          key !== exceptRoot && !tracked.disposing && tracked.inFlight === 0,
+      )
+      .map(([key]) => key);
+    await Promise.all(
+      idleOthers.map((key) => disposeSession(key, 'exhausted')),
+    );
   }
 
   /** Dispose every session and reject starts that have not begun. */

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -303,7 +303,8 @@ export function createDirectLspLeanAdapter(
 
   /**
    * Stop currently-idle other workspaces after EMFILE/ENFILE, then return so
-   * the caller can retry the spawn. Do not wait for busy sessions: position
+   * the caller can retry the spawn. Await sessions already shutting down so
+   * their descriptors are gone first. Do not wait for busy sessions: position
    * RPCs have no timeout, so one hung hover/goal would stall the start queue.
    */
   async function evictOthersForExhausted(
@@ -311,15 +312,20 @@ export function createDirectLspLeanAdapter(
     generation: number,
   ): Promise<void> {
     throwIfStopped(generation);
-    const idleOthers = [...sessions.entries()]
-      .filter(
-        ([key, tracked]) =>
-          key !== exceptRoot && !tracked.disposing && tracked.inFlight === 0,
-      )
-      .map(([key]) => key);
-    await Promise.all(
-      idleOthers.map((key) => disposeSession(key, 'exhausted')),
-    );
+    const idleOthers: string[] = [];
+    const alreadyDisposing: Array<Promise<void>> = [];
+    for (const [key, tracked] of sessions) {
+      if (key === exceptRoot) continue;
+      if (tracked.disposing) {
+        alreadyDisposing.push(tracked.disposing);
+        continue;
+      }
+      if (tracked.inFlight === 0) idleOthers.push(key);
+    }
+    await Promise.all([
+      ...idleOthers.map((key) => disposeSession(key, 'exhausted')),
+      ...alreadyDisposing,
+    ]);
   }
 
   /** Dispose every session and reject starts that have not begun. */

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -5,7 +5,7 @@
  * integration. Per-workspace sessions are cached: the first request that
  * targets a file in a given Lake project spawns `lake env lean --server`
  * from that project root; subsequent requests from any agent reuse the
- * same session. An unused server is stopped after ten minutes. Sessions
+ * same session. An unused server is stopped after thirty minutes. Sessions
  * are also torn down on platform shutdown.
  */
 
@@ -35,7 +35,7 @@ import type {
 const LOG_CHANNEL = 'lean.direct';
 
 /** Long-lived CLI/desktop hosts otherwise keep unused servers forever. */
-const DEFAULT_LEAN_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_LEAN_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
  * Lake arguments for project commands that fan out across all active sessions.

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -5,8 +5,8 @@
  * integration. Per-workspace sessions are cached: the first request that
  * targets a file in a given Lake project spawns `lake env lean --server`
  * from that project root; subsequent requests from any agent reuse the
- * same session. At most two servers stay alive; an unused one is stopped
- * after ten minutes. Sessions are also torn down on platform shutdown.
+ * same session. An unused server is stopped after ten minutes. Sessions
+ * are also torn down on platform shutdown.
  */
 
 import { access } from 'node:fs/promises';
@@ -34,8 +34,6 @@ import type {
 
 const LOG_CHANNEL = 'lean.direct';
 
-/** Mathlib-sized servers hold thousands of file descriptors each. */
-const DEFAULT_MAX_LEAN_SESSIONS = 2;
 /** Long-lived CLI/desktop hosts otherwise keep unused servers forever. */
 const DEFAULT_LEAN_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 
@@ -56,7 +54,10 @@ export interface DirectLspLeanAdapterOptions {
   lakeCommand?: string;
   /** Override the project-root locator (mostly for tests). */
   resolveWorkspaceRoot?: (filePath: string) => Promise<string | null>;
-  /** Cap on simultaneous `lean --server` processes. Minimum 1. */
+  /**
+   * Optional cap on simultaneous `lean --server` processes. Unset means no
+   * capacity eviction — parallel worktrees stay up until they go idle.
+   */
   maxSessions?: number;
   /** Stop a session after this much idle time. `0` disables idle eviction. */
   idleTimeoutMs?: number;
@@ -89,10 +90,8 @@ export function createDirectLspLeanAdapter(
   const lakeCommand = options.lakeCommand ?? 'lake';
   const resolveRoot =
     options.resolveWorkspaceRoot ?? defaultResolveWorkspaceRoot;
-  const maxSessions = Math.max(
-    1,
-    options.maxSessions ?? DEFAULT_MAX_LEAN_SESSIONS,
-  );
+  const maxSessions =
+    options.maxSessions == null ? undefined : Math.max(1, options.maxSessions);
   const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_LEAN_IDLE_TIMEOUT_MS;
   const now = options.now ?? Date.now;
   const sessions = new Map<string, TrackedLeanSession>();
@@ -179,6 +178,7 @@ export function createDirectLspLeanAdapter(
 
   async function evictForNewSession(newRoot: string): Promise<void> {
     await evictIdleSessions();
+    if (maxSessions == null) return;
     while (sessions.size >= maxSessions) {
       const victim = lruRootExcept(newRoot);
       if (!victim) break;

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -160,9 +160,10 @@ export function createDirectLspLeanAdapter(
     return tracked;
   }
 
-  function endUse(root: string): void {
+  function endUse(root: string, session?: LeanSession): void {
     const tracked = sessions.get(root);
     if (!tracked) return;
+    if (session && tracked.session !== session) return;
     tracked.inFlight = Math.max(0, tracked.inFlight - 1);
     if (tracked.inFlight > 0) return;
     tracked.lastUsedAt = now();
@@ -181,7 +182,7 @@ export function createDirectLspLeanAdapter(
       await session.ensureReady();
       return session;
     } catch (error) {
-      endUse(root);
+      endUse(root, session);
       throw error;
     }
   }
@@ -194,7 +195,7 @@ export function createDirectLspLeanAdapter(
     try {
       return await invoke(session);
     } finally {
-      endUse(session.workspaceRoot);
+      endUse(session.workspaceRoot, session);
     }
   }
 
@@ -325,9 +326,10 @@ export function createDirectLspLeanAdapter(
   /** Dispose every session and reject starts that have not begun. */
   async function disposeAll(): Promise<void> {
     startGeneration += 1;
-    startAbort.abort();
+    // Abort queued `add()` promises in place. `clear()` would drop them
+    // without settling, leaving Lean tool calls pending forever.
+    startAbort.abort(new Error(ADAPTER_STOPPED_MESSAGE));
     startAbort = new AbortController();
-    startQueue.clear();
     notifySessionFreed();
     await Promise.all(
       [...sessions.keys()].map((root) => disposeSession(root, 'shutdown')),
@@ -401,6 +403,8 @@ export function createDirectLspLeanAdapter(
       workspaceRoot: root,
       lakeCommand,
       onExit: () => {
+        const tracked = sessions.get(root);
+        if (tracked?.disposing) return;
         forgetSession(root, session);
       },
     });
@@ -488,7 +492,7 @@ export function createDirectLspLeanAdapter(
         );
         return { ok: false, kind: 'file_missing', message };
       } finally {
-        endUse(session.workspaceRoot);
+        endUse(session.workspaceRoot, session);
       }
     },
 
@@ -542,18 +546,26 @@ export function createDirectLspLeanAdapter(
         case 'clean':
         case 'fetch_cache':
         case 'fetch_file_cache': {
-          const active = new Map(
-            [...sessions].map(([root, tracked]) => [root, tracked.session]),
-          );
-          for (const root of active.keys()) beginUse(root);
+          const acquired: TrackedLeanSession[] = [];
+          for (const [root] of [...sessions]) {
+            const tracked = beginUse(root);
+            if (tracked) acquired.push(tracked);
+          }
           try {
             await runForAllSessions(
-              active,
+              new Map(
+                acquired.map((tracked) => [
+                  tracked.session.workspaceRoot,
+                  tracked.session,
+                ]),
+              ),
               lakeCommand,
               LAKE_PROJECT_ARGS[command],
             );
           } finally {
-            for (const root of active.keys()) endUse(root);
+            for (const tracked of acquired) {
+              endUse(tracked.session.workspaceRoot, tracked.session);
+            }
           }
           return;
         }

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -5,13 +5,16 @@
  * integration. Per-workspace sessions are cached: the first request that
  * targets a file in a given Lake project spawns `lake env lean --server`
  * from that project root; subsequent requests from any agent reuse the
- * same session. Sessions are torn down on platform shutdown.
+ * same session. At most two servers stay alive; an unused one is stopped
+ * after ten minutes. Sessions are also torn down on platform shutdown.
  */
 
 import { access } from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { warn } from '@logger/logUtils';
+import PQueue from 'p-queue';
+
+import { info, warn } from '@logger/logUtils';
 import { SHUTDOWN_PHASE, type LifecycleHost } from '@platform/interfaces';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -31,6 +34,11 @@ import type {
 
 const LOG_CHANNEL = 'lean.direct';
 
+/** Mathlib-sized servers hold thousands of file descriptors each. */
+const DEFAULT_MAX_LEAN_SESSIONS = 2;
+/** Long-lived CLI/desktop hosts otherwise keep unused servers forever. */
+const DEFAULT_LEAN_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+
 /**
  * Lake arguments for project commands that fan out across all active sessions.
  * Commands absent here (restart_server, stop_server, install_elan, …) are
@@ -48,6 +56,12 @@ export interface DirectLspLeanAdapterOptions {
   lakeCommand?: string;
   /** Override the project-root locator (mostly for tests). */
   resolveWorkspaceRoot?: (filePath: string) => Promise<string | null>;
+  /** Cap on simultaneous `lean --server` processes. Minimum 1. */
+  maxSessions?: number;
+  /** Stop a session after this much idle time. `0` disables idle eviction. */
+  idleTimeoutMs?: number;
+  /** Clock for idle/LRU decisions (tests). */
+  now?: () => number;
 }
 
 /**
@@ -75,8 +89,15 @@ export function createDirectLspLeanAdapter(
   const lakeCommand = options.lakeCommand ?? 'lake';
   const resolveRoot =
     options.resolveWorkspaceRoot ?? defaultResolveWorkspaceRoot;
-  const sessions = new Map<string, LeanSession>();
+  const maxSessions = Math.max(
+    1,
+    options.maxSessions ?? DEFAULT_MAX_LEAN_SESSIONS,
+  );
+  const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_LEAN_IDLE_TIMEOUT_MS;
+  const now = options.now ?? Date.now;
+  const sessions = new Map<string, TrackedLeanSession>();
   const sessionStarts = new Map<string, Promise<LeanSession>>();
+  const startQueue = new PQueue({ concurrency: 1 });
 
   async function getSession(filePath: string): Promise<LeanSession> {
     const absolute = path.resolve(filePath);
@@ -87,6 +108,82 @@ export function createDirectLspLeanAdapter(
       );
     }
     return getOrStartSession(root);
+  }
+
+  function trackedSession(root: string): LeanSession | undefined {
+    return sessions.get(root)?.session;
+  }
+
+  function touch(root: string): void {
+    const tracked = sessions.get(root);
+    if (!tracked) return;
+    tracked.lastUsedAt = now();
+    armIdleTimer(root, tracked);
+  }
+
+  function armIdleTimer(root: string, tracked: TrackedLeanSession): void {
+    if (tracked.idleTimer) {
+      clearTimeout(tracked.idleTimer);
+      tracked.idleTimer = undefined;
+    }
+    if (idleTimeoutMs <= 0) return;
+    const timer = setTimeout(() => {
+      void disposeSession(root, 'idle');
+    }, idleTimeoutMs);
+    timer.unref?.();
+    tracked.idleTimer = timer;
+  }
+
+  function forgetSession(root: string, session?: LeanSession): void {
+    const tracked = sessions.get(root);
+    if (!tracked) return;
+    if (session && tracked.session !== session) return;
+    if (tracked.idleTimer) clearTimeout(tracked.idleTimer);
+    sessions.delete(root);
+  }
+
+  async function disposeSession(
+    root: string,
+    reason: 'idle' | 'capacity' | 'exhausted' | 'restart' | 'shutdown',
+  ): Promise<void> {
+    const tracked = sessions.get(root);
+    if (!tracked) return;
+    forgetSession(root, tracked.session);
+    if (reason === 'idle' || reason === 'capacity' || reason === 'exhausted') {
+      info(LOG_CHANNEL, `Stopping Lean server at ${root} (${reason})`);
+    }
+    await tracked.session.dispose();
+  }
+
+  async function evictIdleSessions(): Promise<void> {
+    if (idleTimeoutMs <= 0) return;
+    const cutoff = now() - idleTimeoutMs;
+    const idleRoots = [...sessions.entries()]
+      .filter(([, tracked]) => tracked.lastUsedAt <= cutoff)
+      .map(([root]) => root);
+    await Promise.all(idleRoots.map((root) => disposeSession(root, 'idle')));
+  }
+
+  function lruRootExcept(exceptRoot: string): string | undefined {
+    let oldestRoot: string | undefined;
+    let oldestAt = Number.POSITIVE_INFINITY;
+    for (const [root, tracked] of sessions) {
+      if (root === exceptRoot) continue;
+      if (tracked.lastUsedAt < oldestAt) {
+        oldestAt = tracked.lastUsedAt;
+        oldestRoot = root;
+      }
+    }
+    return oldestRoot;
+  }
+
+  async function evictForNewSession(newRoot: string): Promise<void> {
+    await evictIdleSessions();
+    while (sessions.size >= maxSessions) {
+      const victim = lruRootExcept(newRoot);
+      if (!victim) break;
+      await disposeSession(victim, 'capacity');
+    }
   }
 
   /**
@@ -102,9 +199,7 @@ export function createDirectLspLeanAdapter(
     sessionStarts.set(root, start);
     void start
       .catch(() => {
-        if (session && sessions.get(root) === session) {
-          sessions.delete(root);
-        }
+        forgetSession(root, session);
       })
       .finally(() => {
         if (sessionStarts.get(root) === start) {
@@ -116,26 +211,56 @@ export function createDirectLspLeanAdapter(
 
   /** Dispose every session and clear all tracking. */
   async function disposeAll(): Promise<void> {
-    const all = [...sessions.values()];
-    sessions.clear();
+    const roots = [...sessions.keys()];
     sessionStarts.clear();
-    await Promise.all(all.map((session) => session.dispose()));
+    await Promise.all(roots.map((root) => disposeSession(root, 'shutdown')));
   }
 
   function getOrStartSession(root: string): Promise<LeanSession> {
-    const inFlight = sessionStarts.get(root);
-    if (inFlight) return inFlight;
-
-    const existing = sessions.get(root);
+    const existing = trackedSession(root);
     if (existing) {
+      touch(root);
       return trackStart(
         root,
         existing,
         existing.ensureReady().then(() => existing),
       );
     }
+    return startQueue.add(() =>
+      getOrStartSessionLocked(root),
+    ) as Promise<LeanSession>;
+  }
 
-    return startFreshSession(root);
+  async function getOrStartSessionLocked(root: string): Promise<LeanSession> {
+    const inFlight = sessionStarts.get(root);
+    if (inFlight) {
+      touch(root);
+      return inFlight;
+    }
+    const existing = trackedSession(root);
+    if (existing) {
+      touch(root);
+      return trackStart(
+        root,
+        existing,
+        existing.ensureReady().then(() => existing),
+      );
+    }
+    await evictForNewSession(root);
+    try {
+      return await startFreshSession(root);
+    } catch (error) {
+      if (!isFileTableExhausted(error) || sessions.size === 0) {
+        throw error;
+      }
+      warn(
+        LOG_CHANNEL,
+        `Lean spawn hit a full file table; stopping other servers and retrying (${toErrorMessage(error)})`,
+      );
+      const others = [...sessions.keys()].filter((key) => key !== root);
+      await Promise.all(others.map((key) => disposeSession(key, 'exhausted')));
+      return startFreshSession(root);
+    }
   }
 
   function startFreshSession(root: string): Promise<LeanSession> {
@@ -143,12 +268,15 @@ export function createDirectLspLeanAdapter(
       workspaceRoot: root,
       lakeCommand,
       onExit: () => {
-        if (sessions.get(root) === session) {
-          sessions.delete(root);
-        }
+        forgetSession(root, session);
       },
     });
-    sessions.set(root, session);
+    const tracked: TrackedLeanSession = {
+      session,
+      lastUsedAt: now(),
+    };
+    sessions.set(root, tracked);
+    armIdleTimer(root, tracked);
     return trackStart(
       root,
       session,
@@ -157,18 +285,10 @@ export function createDirectLspLeanAdapter(
   }
 
   function restartSession(root: string): Promise<LeanSession> {
-    return trackStart(
-      root,
-      undefined,
-      (async () => {
-        const existing = sessions.get(root);
-        if (existing) {
-          sessions.delete(root);
-          await existing.dispose();
-        }
-        return startFreshSession(root);
-      })(),
-    );
+    return startQueue.add(async () => {
+      await disposeSession(root, 'restart');
+      return startFreshSession(root);
+    }) as Promise<LeanSession>;
   }
 
   return {
@@ -258,7 +378,9 @@ export function createDirectLspLeanAdapter(
         case 'fetch_cache':
         case 'fetch_file_cache':
           await runForAllSessions(
-            sessions,
+            new Map(
+              [...sessions].map(([root, tracked]) => [root, tracked.session]),
+            ),
             lakeCommand,
             LAKE_PROJECT_ARGS[command],
           );
@@ -342,6 +464,22 @@ export function createDirectLspLeanAdapter(
       };
     }
   }
+}
+
+interface TrackedLeanSession {
+  session: LeanSession;
+  lastUsedAt: number;
+  idleTimer?: ReturnType<typeof setTimeout>;
+}
+
+function isFileTableExhausted(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; current != null && depth < 4; depth += 1) {
+    const code = (current as NodeJS.ErrnoException).code;
+    if (code === 'EMFILE' || code === 'ENFILE') return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
 }
 
 async function runForAllSessions(

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -9,11 +9,14 @@
  * are also torn down on platform shutdown.
  */
 
+// Node imports
 import { access } from 'node:fs/promises';
 import * as path from 'node:path';
 
+// Third-party imports
 import PQueue from 'p-queue';
 
+// Local imports
 import { info, warn } from '@logger/logUtils';
 import { SHUTDOWN_PHASE, type LifecycleHost } from '@platform/interfaces';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -33,6 +36,7 @@ import type {
 } from '../leanTypes';
 
 const LOG_CHANNEL = 'lean.direct';
+const ADAPTER_STOPPED_MESSAGE = 'Lean adapter was stopped.';
 
 /** Long-lived CLI/desktop hosts otherwise keep unused servers forever. */
 const DEFAULT_LEAN_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
@@ -95,29 +99,107 @@ export function createDirectLspLeanAdapter(
   const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_LEAN_IDLE_TIMEOUT_MS;
   const now = options.now ?? Date.now;
   const sessions = new Map<string, TrackedLeanSession>();
-  const sessionStarts = new Map<string, Promise<LeanSession>>();
   const startQueue = new PQueue({ concurrency: 1 });
+  const sessionFreedWaiters = new Set<() => void>();
+  const startsIdleWaiters = new Set<() => void>();
+  let startsInFlight = 0;
+  let startGeneration = 0;
+  let startAbort = new AbortController();
 
   async function getSession(filePath: string): Promise<LeanSession> {
+    const generation = startGeneration;
     const absolute = path.resolve(filePath);
     const root = await resolveRoot(absolute);
+    throwIfStopped(generation);
     if (!root) {
       throw new Error(
         `No Lean project found for ${absolute}. Lake projects need a lakefile.lean or lakefile.toml in an ancestor directory.`,
       );
     }
-    return getOrStartSession(root);
+    return getOrStartSession(root, generation);
   }
 
   function trackedSession(root: string): LeanSession | undefined {
     return sessions.get(root)?.session;
   }
 
-  function touch(root: string): void {
+  function throwIfStopped(generation: number): void {
+    if (startGeneration !== generation) {
+      throw new Error(ADAPTER_STOPPED_MESSAGE);
+    }
+  }
+
+  function notifySessionFreed(): void {
+    for (const resolve of sessionFreedWaiters) resolve();
+    sessionFreedWaiters.clear();
+  }
+
+  function waitForSessionFreed(): Promise<void> {
+    return new Promise((resolve) => {
+      sessionFreedWaiters.add(resolve);
+    });
+  }
+
+  function notifyStartsIdle(): void {
+    for (const resolve of startsIdleWaiters) resolve();
+    startsIdleWaiters.clear();
+  }
+
+  function waitForStartsIdle(): Promise<void> {
+    if (startsInFlight === 0) return Promise.resolve();
+    return new Promise((resolve) => {
+      startsIdleWaiters.add(resolve);
+    });
+  }
+
+  function beginUse(root: string): TrackedLeanSession | undefined {
+    const tracked = sessions.get(root);
+    if (!tracked) return undefined;
+    tracked.inFlight += 1;
+    tracked.lastUsedAt = now();
+    if (tracked.idleTimer) {
+      clearTimeout(tracked.idleTimer);
+      tracked.idleTimer = undefined;
+    }
+    return tracked;
+  }
+
+  function endUse(root: string): void {
     const tracked = sessions.get(root);
     if (!tracked) return;
+    tracked.inFlight = Math.max(0, tracked.inFlight - 1);
+    if (tracked.inFlight > 0) return;
     tracked.lastUsedAt = now();
     armIdleTimer(root, tracked);
+    notifySessionFreed();
+  }
+
+  async function leaseSession(
+    root: string,
+    session: LeanSession,
+  ): Promise<LeanSession> {
+    if (!beginUse(root)) {
+      throw new Error(ADAPTER_STOPPED_MESSAGE);
+    }
+    try {
+      await session.ensureReady();
+      return session;
+    } catch (error) {
+      endUse(root);
+      throw error;
+    }
+  }
+
+  async function withSession<T>(
+    filePath: string,
+    invoke: (session: LeanSession) => Promise<T>,
+  ): Promise<T> {
+    const session = await getSession(filePath);
+    try {
+      return await invoke(session);
+    } finally {
+      endUse(session.workspaceRoot);
+    }
   }
 
   function armIdleTimer(root: string, tracked: TrackedLeanSession): void {
@@ -125,9 +207,14 @@ export function createDirectLspLeanAdapter(
       clearTimeout(tracked.idleTimer);
       tracked.idleTimer = undefined;
     }
-    if (idleTimeoutMs <= 0) return;
+    if (idleTimeoutMs <= 0 || tracked.inFlight > 0) return;
     const timer = setTimeout(() => {
-      void disposeSession(root, 'idle');
+      void disposeSession(root, 'idle').catch((error) => {
+        warn(
+          LOG_CHANNEL,
+          `Idle stop failed for ${root}: ${toErrorMessage(error)}`,
+        );
+      });
     }, idleTimeoutMs);
     timer.unref?.();
     tracked.idleTimer = timer;
@@ -139,6 +226,7 @@ export function createDirectLspLeanAdapter(
     if (session && tracked.session !== session) return;
     if (tracked.idleTimer) clearTimeout(tracked.idleTimer);
     sessions.delete(root);
+    notifySessionFreed();
   }
 
   async function disposeSession(
@@ -158,7 +246,9 @@ export function createDirectLspLeanAdapter(
     if (idleTimeoutMs <= 0) return;
     const cutoff = now() - idleTimeoutMs;
     const idleRoots = [...sessions.entries()]
-      .filter(([, tracked]) => tracked.lastUsedAt <= cutoff)
+      .filter(
+        ([, tracked]) => tracked.inFlight === 0 && tracked.lastUsedAt <= cutoff,
+      )
       .map(([root]) => root);
     await Promise.all(idleRoots.map((root) => disposeSession(root, 'idle')));
   }
@@ -167,7 +257,7 @@ export function createDirectLspLeanAdapter(
     let oldestRoot: string | undefined;
     let oldestAt = Number.POSITIVE_INFINITY;
     for (const [root, tracked] of sessions) {
-      if (root === exceptRoot) continue;
+      if (root === exceptRoot || tracked.inFlight > 0) continue;
       if (tracked.lastUsedAt < oldestAt) {
         oldestAt = tracked.lastUsedAt;
         oldestRoot = root;
@@ -176,79 +266,74 @@ export function createDirectLspLeanAdapter(
     return oldestRoot;
   }
 
-  async function evictForNewSession(newRoot: string): Promise<void> {
+  async function evictForNewSession(
+    newRoot: string,
+    generation: number,
+  ): Promise<void> {
     await evictIdleSessions();
     if (maxSessions == null) return;
     while (sessions.size >= maxSessions) {
+      throwIfStopped(generation);
       const victim = lruRootExcept(newRoot);
-      if (!victim) break;
-      await disposeSession(victim, 'capacity');
+      if (victim) {
+        await disposeSession(victim, 'capacity');
+        continue;
+      }
+      await waitForSessionFreed();
     }
   }
 
-  /**
-   * Register an in-flight start so concurrent callers join the same promise,
-   * dropping the session on failure and clearing the in-flight slot once it
-   * settles.
-   */
-  function trackStart(
-    root: string,
-    session: LeanSession | undefined,
-    start: Promise<LeanSession>,
-  ): Promise<LeanSession> {
-    sessionStarts.set(root, start);
-    void start
-      .catch(() => {
-        forgetSession(root, session);
-      })
-      .finally(() => {
-        if (sessionStarts.get(root) === start) {
-          sessionStarts.delete(root);
-        }
-      });
-    return start;
-  }
-
-  /** Dispose every session and clear all tracking. */
+  /** Dispose every session and reject starts that have not begun. */
   async function disposeAll(): Promise<void> {
-    const roots = [...sessions.keys()];
-    sessionStarts.clear();
-    await Promise.all(roots.map((root) => disposeSession(root, 'shutdown')));
+    startGeneration += 1;
+    startAbort.abort();
+    startAbort = new AbortController();
+    startQueue.clear();
+    notifySessionFreed();
+    await Promise.all(
+      [...sessions.keys()].map((root) => disposeSession(root, 'shutdown')),
+    );
+    await waitForStartsIdle();
+    await Promise.all(
+      [...sessions.keys()].map((root) => disposeSession(root, 'shutdown')),
+    );
   }
 
-  function getOrStartSession(root: string): Promise<LeanSession> {
-    const existing = trackedSession(root);
-    if (existing) {
-      touch(root);
-      return trackStart(
-        root,
-        existing,
-        existing.ensureReady().then(() => existing),
-      );
-    }
-    return startQueue.add(() =>
-      getOrStartSessionLocked(root),
-    ) as Promise<LeanSession>;
+  function enqueueStart<T>(task: () => Promise<T>): Promise<T> {
+    return startQueue.add(
+      async () => {
+        startsInFlight += 1;
+        try {
+          return await task();
+        } finally {
+          startsInFlight -= 1;
+          if (startsInFlight === 0) notifyStartsIdle();
+        }
+      },
+      { signal: startAbort.signal },
+    ) as Promise<T>;
   }
 
-  async function getOrStartSessionLocked(root: string): Promise<LeanSession> {
-    const inFlight = sessionStarts.get(root);
-    if (inFlight) {
-      touch(root);
-      return inFlight;
-    }
+  function getOrStartSession(
+    root: string,
+    generation = startGeneration,
+  ): Promise<LeanSession> {
+    return enqueueStart(() => getOrStartSessionLocked(root, generation));
+  }
+
+  async function getOrStartSessionLocked(
+    root: string,
+    generation: number,
+  ): Promise<LeanSession> {
+    throwIfStopped(generation);
     const existing = trackedSession(root);
     if (existing) {
-      touch(root);
-      return trackStart(
-        root,
-        existing,
-        existing.ensureReady().then(() => existing),
-      );
+      return leaseSession(root, existing);
     }
-    await evictForNewSession(root);
+    await evictForNewSession(root, generation);
+    throwIfStopped(generation);
     try {
-      return await startFreshSession(root);
+      return await startAndLease(root, generation);
     } catch (error) {
       if (!isFileTableExhausted(error) || sessions.size === 0) {
         throw error;
@@ -259,11 +344,16 @@ export function createDirectLspLeanAdapter(
       );
       const others = [...sessions.keys()].filter((key) => key !== root);
       await Promise.all(others.map((key) => disposeSession(key, 'exhausted')));
-      return startFreshSession(root);
+      throwIfStopped(generation);
+      return startAndLease(root, generation);
     }
   }
 
-  function startFreshSession(root: string): Promise<LeanSession> {
+  async function startFreshSession(
+    root: string,
+    generation: number,
+  ): Promise<LeanSession> {
+    throwIfStopped(generation);
     const session = new LeanSession({
       workspaceRoot: root,
       lakeCommand,
@@ -271,24 +361,46 @@ export function createDirectLspLeanAdapter(
         forgetSession(root, session);
       },
     });
-    const tracked: TrackedLeanSession = {
+    sessions.set(root, {
       session,
       lastUsedAt: now(),
-    };
-    sessions.set(root, tracked);
-    armIdleTimer(root, tracked);
-    return trackStart(
-      root,
-      session,
-      session.ensureReady().then(() => session),
-    );
+      inFlight: 0,
+    });
+    if (startGeneration !== generation) {
+      await disposeSession(root, 'shutdown');
+      throw new Error(ADAPTER_STOPPED_MESSAGE);
+    }
+    try {
+      await session.ensureReady();
+    } catch (error) {
+      await disposeSession(root, 'shutdown');
+      throw error;
+    }
+    if (startGeneration !== generation) {
+      await disposeSession(root, 'shutdown');
+      throw new Error(ADAPTER_STOPPED_MESSAGE);
+    }
+    return session;
   }
 
-  function restartSession(root: string): Promise<LeanSession> {
-    return startQueue.add(async () => {
+  async function startAndLease(
+    root: string,
+    generation: number,
+  ): Promise<LeanSession> {
+    const session = await startFreshSession(root, generation);
+    return leaseSession(root, session);
+  }
+
+  function restartSession(root: string): Promise<void> {
+    const generation = startGeneration;
+    return enqueueStart(async () => {
+      throwIfStopped(generation);
       await disposeSession(root, 'restart');
-      return startFreshSession(root);
-    }) as Promise<LeanSession>;
+      throwIfStopped(generation);
+      await evictForNewSession(root, generation);
+      throwIfStopped(generation);
+      await startFreshSession(root, generation);
+    });
   }
 
   return {
@@ -315,14 +427,23 @@ export function createDirectLspLeanAdapter(
         const diagnostics = await session.fetchDiagnostics(file);
         return { ok: true, diagnostics };
       } catch (error) {
+        const message = toErrorMessage(error);
+        if (isInterruptedLeanSession(message)) {
+          warn(
+            LOG_CHANNEL,
+            `fetchDiagnosticsForFile: session interrupted for ${file}: ${message}`,
+          );
+          return { ok: false, kind: 'toolchain_unavailable', message };
+        }
         // Opening/reading the file itself failed (e.g. ENOENT) — the file is
         // the problem, so the tool keeps its "could not open file" framing.
-        const message = toErrorMessage(error);
         warn(
           LOG_CHANNEL,
           `fetchDiagnosticsForFile: could not read ${file}: ${message}`,
         );
         return { ok: false, kind: 'file_missing', message };
+      } finally {
+        endUse(session.workspaceRoot);
       }
     },
 
@@ -339,8 +460,7 @@ export function createDirectLspLeanAdapter(
       try {
         // Both file commands have the same effect from our point of view: drop
         // the cached open state and re-open with fresh contents.
-        const session = await getSession(filePath);
-        await session.restartFile(filePath);
+        await withSession(filePath, (session) => session.restartFile(filePath));
         return true;
       } catch (error) {
         // Return false (LeanFileTool surfaces it as a failure result) and log
@@ -376,15 +496,22 @@ export function createDirectLspLeanAdapter(
         case 'build':
         case 'clean':
         case 'fetch_cache':
-        case 'fetch_file_cache':
-          await runForAllSessions(
-            new Map(
-              [...sessions].map(([root, tracked]) => [root, tracked.session]),
-            ),
-            lakeCommand,
-            LAKE_PROJECT_ARGS[command],
+        case 'fetch_file_cache': {
+          const active = new Map(
+            [...sessions].map(([root, tracked]) => [root, tracked.session]),
           );
+          for (const root of active.keys()) beginUse(root);
+          try {
+            await runForAllSessions(
+              active,
+              lakeCommand,
+              LAKE_PROJECT_ARGS[command],
+            );
+          } finally {
+            for (const root of active.keys()) endUse(root);
+          }
           return;
+        }
         case 'install_elan':
         case 'install_deps':
         case 'update_elan':
@@ -449,8 +576,7 @@ export function createDirectLspLeanAdapter(
     invoke: (session: LeanSession) => Promise<T | null>,
   ): Promise<LspResult<T>> {
     try {
-      const session = await getSession(filePath);
-      const data = await invoke(session);
+      const data = await withSession(filePath, invoke);
       if (!data)
         return {
           data: null,
@@ -469,7 +595,16 @@ export function createDirectLspLeanAdapter(
 interface TrackedLeanSession {
   session: LeanSession;
   lastUsedAt: number;
+  inFlight: number;
   idleTimer?: ReturnType<typeof setTimeout>;
+}
+
+function isInterruptedLeanSession(message: string): boolean {
+  return (
+    message.includes('Lean session has been disposed') ||
+    message.includes('Lean session is not running') ||
+    message.includes(ADAPTER_STOPPED_MESSAGE)
+  );
 }
 
 function isFileTableExhausted(error: unknown): boolean {

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -119,10 +119,6 @@ export function createDirectLspLeanAdapter(
     return getOrStartSession(root, generation);
   }
 
-  function trackedSession(root: string): LeanSession | undefined {
-    return sessions.get(root)?.session;
-  }
-
   function throwIfStopped(generation: number): void {
     if (startGeneration !== generation) {
       throw new Error(ADAPTER_STOPPED_MESSAGE);
@@ -154,7 +150,7 @@ export function createDirectLspLeanAdapter(
 
   function beginUse(root: string): TrackedLeanSession | undefined {
     const tracked = sessions.get(root);
-    if (!tracked) return undefined;
+    if (!tracked || tracked.disposing) return undefined;
     tracked.inFlight += 1;
     tracked.lastUsedAt = now();
     if (tracked.idleTimer) {
@@ -235,11 +231,27 @@ export function createDirectLspLeanAdapter(
   ): Promise<void> {
     const tracked = sessions.get(root);
     if (!tracked) return;
-    forgetSession(root, tracked.session);
+    if (tracked.disposing) {
+      await tracked.disposing;
+      return;
+    }
+    let settleDisposing!: () => void;
+    tracked.disposing = new Promise<void>((resolve) => {
+      settleDisposing = resolve;
+    });
+    if (tracked.idleTimer) {
+      clearTimeout(tracked.idleTimer);
+      tracked.idleTimer = undefined;
+    }
     if (reason === 'idle' || reason === 'capacity' || reason === 'exhausted') {
       info(LOG_CHANNEL, `Stopping Lean server at ${root} (${reason})`);
     }
-    await tracked.session.dispose();
+    try {
+      await tracked.session.dispose();
+    } finally {
+      forgetSession(root, tracked.session);
+      settleDisposing();
+    }
   }
 
   async function evictIdleSessions(): Promise<void> {
@@ -247,7 +259,10 @@ export function createDirectLspLeanAdapter(
     const cutoff = now() - idleTimeoutMs;
     const idleRoots = [...sessions.entries()]
       .filter(
-        ([, tracked]) => tracked.inFlight === 0 && tracked.lastUsedAt <= cutoff,
+        ([, tracked]) =>
+          !tracked.disposing &&
+          tracked.inFlight === 0 &&
+          tracked.lastUsedAt <= cutoff,
       )
       .map(([root]) => root);
     await Promise.all(idleRoots.map((root) => disposeSession(root, 'idle')));
@@ -257,7 +272,9 @@ export function createDirectLspLeanAdapter(
     let oldestRoot: string | undefined;
     let oldestAt = Number.POSITIVE_INFINITY;
     for (const [root, tracked] of sessions) {
-      if (root === exceptRoot || tracked.inFlight > 0) continue;
+      if (root === exceptRoot || tracked.disposing || tracked.inFlight > 0) {
+        continue;
+      }
       if (tracked.lastUsedAt < oldestAt) {
         oldestAt = tracked.lastUsedAt;
         oldestRoot = root;
@@ -280,6 +297,28 @@ export function createDirectLspLeanAdapter(
         continue;
       }
       await waitForSessionFreed();
+    }
+  }
+
+  async function evictOthersForExhausted(
+    exceptRoot: string,
+    generation: number,
+  ): Promise<void> {
+    while ([...sessions.keys()].some((key) => key !== exceptRoot)) {
+      throwIfStopped(generation);
+      const idleOthers = [...sessions.entries()]
+        .filter(
+          ([key, tracked]) =>
+            key !== exceptRoot && !tracked.disposing && tracked.inFlight === 0,
+        )
+        .map(([key]) => key);
+      if (idleOthers.length === 0) {
+        await waitForSessionFreed();
+        continue;
+      }
+      await Promise.all(
+        idleOthers.map((key) => disposeSession(key, 'exhausted')),
+      );
     }
   }
 
@@ -326,9 +365,14 @@ export function createDirectLspLeanAdapter(
     generation: number,
   ): Promise<LeanSession> {
     throwIfStopped(generation);
-    const existing = trackedSession(root);
+    const existing = sessions.get(root);
+    if (existing?.disposing) {
+      await existing.disposing;
+      throwIfStopped(generation);
+      return getOrStartSessionLocked(root, generation);
+    }
     if (existing) {
-      return leaseSession(root, existing);
+      return leaseSession(root, existing.session);
     }
     await evictForNewSession(root, generation);
     throwIfStopped(generation);
@@ -342,8 +386,7 @@ export function createDirectLspLeanAdapter(
         LOG_CHANNEL,
         `Lean spawn hit a full file table; stopping other servers and retrying (${toErrorMessage(error)})`,
       );
-      const others = [...sessions.keys()].filter((key) => key !== root);
-      await Promise.all(others.map((key) => disposeSession(key, 'exhausted')));
+      await evictOthersForExhausted(root, generation);
       throwIfStopped(generation);
       return startAndLease(root, generation);
     }
@@ -400,6 +443,8 @@ export function createDirectLspLeanAdapter(
       await evictForNewSession(root, generation);
       throwIfStopped(generation);
       await startFreshSession(root, generation);
+      const tracked = sessions.get(root);
+      if (tracked) armIdleTimer(root, tracked);
     });
   }
 
@@ -597,6 +642,7 @@ interface TrackedLeanSession {
   lastUsedAt: number;
   inFlight: number;
   idleTimer?: ReturnType<typeof setTimeout>;
+  disposing?: Promise<void>;
 }
 
 function isInterruptedLeanSession(message: string): boolean {

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -106,12 +106,17 @@ export class LeanSession {
       if (!child.killed) {
         child.kill();
       }
+      await waitForProcessClose(child);
     }
   }
 
   async fetchDiagnostics(filePath: string): Promise<LeanDiagnostic[]> {
     const absolute = await this.openAndSettle(filePath);
-    return this.openFiles.get(absolute)?.diagnostics ?? [];
+    const diagnostics = this.openFiles.get(absolute)?.diagnostics;
+    if (this.disposed || diagnostics == null) {
+      throw new Error('Lean session has been disposed.');
+    }
+    return diagnostics;
   }
 
   async restartFile(filePath: string): Promise<void> {
@@ -335,7 +340,9 @@ export class LeanSession {
     if (!state) return;
     const start = Date.now();
     while (Date.now() - start < DIAGNOSTICS_WAIT_MS) {
-      if (this.disposed || this.openFiles.get(absolute) !== state) return;
+      if (this.disposed || this.openFiles.get(absolute) !== state) {
+        throw new Error('Lean session has been disposed.');
+      }
       const sinceLast = state.lastDiagnosticsAt
         ? Date.now() - state.lastDiagnosticsAt
         : 0;
@@ -405,6 +412,29 @@ function lspSeverityToVsCode(severity: number): DiagnosticSeverity {
   // unexpected out-of-range value is still dropped by SEVERITY_CONFIG's
   // numeric lookup downstream, exactly as before).
   return Math.max(0, severity - 1) as DiagnosticSeverity;
+}
+
+async function waitForProcessClose(
+  child: ChildProcessWithoutNullStreams,
+): Promise<void> {
+  if (child.exitCode != null || child.signalCode != null) return;
+  const closed = new Promise<void>((resolve) => {
+    child.once('close', () => resolve());
+  });
+  try {
+    await pTimeout(closed, {
+      milliseconds: SHUTDOWN_TIMEOUT_MS,
+      message: 'Lean process close timeout',
+    });
+  } catch {
+    if (!child.killed) {
+      child.kill('SIGKILL');
+    }
+    await pTimeout(closed, {
+      milliseconds: SHUTDOWN_TIMEOUT_MS,
+      message: 'Lean process close timeout after SIGKILL',
+    }).catch(() => undefined);
+  }
 }
 
 function pathToUri(absolute: string): string {

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -111,11 +111,13 @@ export class LeanSession {
           rpc.dispose('LeanSession.dispose');
         }
       }
-      if (spawned && !spawned.killed) {
+      if (spawned && spawned.exitCode == null && spawned.signalCode == null) {
         spawned.kill();
       }
     } finally {
-      await closeWait;
+      if (spawned) {
+        await waitForProcessClose(spawned, closeWait);
+      }
     }
   }
 
@@ -204,7 +206,9 @@ export class LeanSession {
     }
     this.child = child;
     this.spawned = child;
-    this.closeWait = waitForProcessClose(child);
+    this.closeWait = new Promise<void>((resolve) => {
+      child.once('close', () => resolve());
+    });
     let stderrTail = '';
     const STDERR_TAIL_LIMIT = 4096;
     let finalized = false;
@@ -427,11 +431,17 @@ function lspSeverityToVsCode(severity: number): DiagnosticSeverity {
 
 async function waitForProcessClose(
   child: ChildProcessWithoutNullStreams,
+  alreadyClosed?: Promise<void>,
 ): Promise<void> {
-  if (child.exitCode != null || child.signalCode != null) return;
-  const closed = new Promise<void>((resolve) => {
-    child.once('close', () => resolve());
-  });
+  const closed =
+    alreadyClosed ??
+    new Promise<void>((resolve) => {
+      if (child.exitCode != null || child.signalCode != null) {
+        resolve();
+        return;
+      }
+      child.once('close', () => resolve());
+    });
   try {
     await pTimeout(closed, {
       milliseconds: SHUTDOWN_TIMEOUT_MS,

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -427,7 +427,7 @@ async function waitForProcessClose(
       message: 'Lean process close timeout',
     });
   } catch {
-    if (!child.killed) {
+    if (child.exitCode == null && child.signalCode == null) {
       child.kill('SIGKILL');
     }
     await pTimeout(closed, {

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -59,7 +59,9 @@ export interface LeanSessionOptions {
 
 export class LeanSession {
   private child?: ChildProcessWithoutNullStreams;
+  private spawned?: ChildProcessWithoutNullStreams;
   private rpc?: JsonRpcConnection;
+  private closeWait?: Promise<void>;
   private readonly id: string;
   private readyPromise?: Promise<void>;
   private disposed = false;
@@ -87,26 +89,33 @@ export class LeanSession {
     if (this.disposed) return;
     this.disposed = true;
     const child = this.child;
+    const spawned = this.spawned;
     const rpc = this.rpc;
+    const closeWait = this.closeWait;
     this.child = undefined;
+    this.spawned = undefined;
     this.rpc = undefined;
     this.readyPromise = undefined;
     this.releaseAllDiagnosticsWaiters();
     this.openFiles.clear();
     unregisterLeanServer(this.id);
-    if (!rpc || !child) return;
     try {
-      await pTimeout(rpc.request('shutdown'), {
-        milliseconds: SHUTDOWN_TIMEOUT_MS,
-        message: 'Lean LSP shutdown timeout',
-      }).catch(() => undefined);
-      rpc.notify('exit');
-    } finally {
-      rpc.dispose('LeanSession.dispose');
-      if (!child.killed) {
-        child.kill();
+      if (rpc && child) {
+        try {
+          await pTimeout(rpc.request('shutdown'), {
+            milliseconds: SHUTDOWN_TIMEOUT_MS,
+            message: 'Lean LSP shutdown timeout',
+          }).catch(() => undefined);
+          rpc.notify('exit');
+        } finally {
+          rpc.dispose('LeanSession.dispose');
+        }
       }
-      await waitForProcessClose(child);
+      if (spawned && !spawned.killed) {
+        spawned.kill();
+      }
+    } finally {
+      await closeWait;
     }
   }
 
@@ -194,6 +203,8 @@ export class LeanSession {
       });
     }
     this.child = child;
+    this.spawned = child;
+    this.closeWait = waitForProcessClose(child);
     let stderrTail = '';
     const STDERR_TAIL_LIMIT = 4096;
     let finalized = false;


### PR DESCRIPTION
## Summary

Long-lived CLI and desktop hosts kept one `lake env lean --server` process per Lake project root until the host exited. Parallel worktrees (especially Mathlib-sized ones) therefore accumulated leftover servers and exhausted the system file table (`ENFILE`), which then failed later process spawns.

This stops a server after thirty minutes idle and retries a spawn once after `ENFILE`/`EMFILE` by shutting the other servers down first. Active worktrees are not capped: you can keep as many Lean servers as you are actually using.

## Issue acceptance gates

No tracked issue. Reproduced locally: leftover `/tmp` Lean worktree servers from `texra-local` held tens of thousands of file descriptors until the next `spawn` failed.

## Single source of truth

`createDirectLspLeanAdapter` in `src/tools/lean/direct/directLspAdapter.ts` owns session start, idle eviction, optional capacity eviction, and the one-shot file-table retry.

## Duplication and abstraction budget

No new module. Session tracking stays inside the existing adapter; start/eviction is serialized with `p-queue`.

## Net elements (R6)

n/a — bug fix, not a refactor/extract PR.

## Consumer counts (R8)

n/a — no emit path or export was removed. New adapter options (`maxSessions`, `idleTimeoutMs`, `now`) are optional and used by tests. `maxSessions` is unset in production.

## Host impact

Extension: none (still uses the Lean 4 extension server).

Desktop: same direct LSP adapter; leftover idle servers now stop.

CLI: same. Restart existing `texra-local` processes to pick this up.

## Scheduled refactoring

None in this PR. A later improvement is to stop a worktree's Lean server when that agent run ends, with idle timeout remaining as the backstop.

## Validation

- `npx eslint` on the changed TypeScript files
- `npx vitest run src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts`