### PR TITLE
test(cli): match output failure messages by containment

### DIFF
--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -1280,9 +1280,12 @@ describe('executeCliRequest', () => {
     });
     expect(publicationCommitted).toBe(true);
     expect(mocks.finalizeExecution).not.toHaveBeenCalled();
-    expect(mocks.emit).toHaveBeenCalledExactlyOnceWith('requestShowError', {
-      message: outputFailure.message,
-    });
+    expect(mocks.emit).toHaveBeenCalledExactlyOnceWith(
+      'requestShowError',
+      expect.objectContaining({
+        message: expect.stringContaining(outputFailure.message),
+      }),
+    );
   });
 
   it('does not finalize shutdown through a captured lease that is already lost', async () => {

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -1253,9 +1253,12 @@ describe('executeCliRequest', () => {
         }
         await runGate;
         // runAgent classifies the host output failure before it reaches the
-        // CLI boundary; the copy/missing-output error must stay the primary
-        // run failure below.
-        throw new RuntimeAgentError(outputFailure.message);
+        // CLI boundary. Emit the same prefixed AgentError finalizeFailedRun
+        // throws so this test pins the production message, not the mock's raw
+        // copy error.
+        throw new RuntimeAgentError(
+          `Error executing agent polish: ${outputFailure.message}`,
+        );
       },
     );
 
@@ -1280,12 +1283,9 @@ describe('executeCliRequest', () => {
     });
     expect(publicationCommitted).toBe(true);
     expect(mocks.finalizeExecution).not.toHaveBeenCalled();
-    expect(mocks.emit).toHaveBeenCalledExactlyOnceWith(
-      'requestShowError',
-      expect.objectContaining({
-        message: expect.stringContaining(outputFailure.message),
-      }),
-    );
+    expect(mocks.emit).toHaveBeenCalledExactlyOnceWith('requestShowError', {
+      message: `Error executing agent polish: ${outputFailure.message}`,
+    });
   });
 
   it('does not finalize shutdown through a captured lease that is already lost', async () => {


### PR DESCRIPTION
## Summary

The publication-wins copy-failure test exact-matched `outputFailure.message`. Production classifies that error and surfaces `Error executing agent <id>: <msg>`, so the exact match only verified the mock's unprefixed throw.

The `runAgent` stub now throws that classified `AgentError`, and the `requestShowError` assertion pins the prefixed message. The regression gates stay: publication commit, no `kill`/finalize-to-cancelled, `CliExitCode.AgentError`.

## Issue acceptance gates

- #10235: the surfaced message is the classified production shape, not the raw copy-error mock text.

## Single source of truth

Production still owns the classified message shape in `AgentRunLifecycle.finalizeFailedRun`. The test now emits and pins that shape.

## Duplication and abstraction budget

No new abstraction.

## Net elements (R6)

n/a (test-only)

## Consumer counts (R8)

n/a

## Host impact

Extension: none

Desktop: none

CLI: none (test only)

## Scheduled refactoring

None

## Validation

- `npx vitest run src/test-kernel/cli/RunExecution.vitest.ts -t "does not convert a committed output failure"` (1 passed)