### PR TITLE
ci: skip type-only imports in browser-safe utils walk

### DIFF
--- a/scripts/check-browser-safe-utils.mjs
+++ b/scripts/check-browser-safe-utils.mjs
@@ -126,18 +126,37 @@ function insideRanges(index, ranges) {
 
 /**
  * True when the matched specifier is erased by TypeScript (`import type` /
- * `export type ... from` / a named import whose every binding is `type`).
+ * `export type ... from` / a named import whose every binding is `type Foo`).
  * Mixed `{ type X, y }` stays reachable because `y` is a value import.
+ * A binding named `type` (`import { type } from`) is a value import.
  */
-function isTypeOnlySpecifier(text, match) {
+function isTypeOnlyBinding(binding) {
+  return /^type\s+[A-Za-z_$]/.test(binding);
+}
+
+function isTypeOnlySpecifier(text, match, ranges) {
   const matched = match[0];
   if (/^(?:import\s*\(|require|import\.meta\.resolve)/.test(matched)) {
     return false;
   }
-  const before = text.slice(Math.max(0, match.index - 400), match.index);
-  const keyword = [...before.matchAll(/\b(?:import|export)\b/g)].at(-1);
-  if (keyword == null) return false;
-  const clause = before.slice(keyword.index);
+  // Bare side-effect `import 'x'` is always a value edge. Its match includes
+  // the `import` keyword, so looking backward would see the previous clause.
+  if (/^import\s*['"]/.test(matched)) {
+    return false;
+  }
+  if (!/^from\b/.test(matched)) {
+    return false;
+  }
+
+  const before = text.slice(0, match.index);
+  let keywordIndex = -1;
+  for (const keyword of before.matchAll(/\b(?:import|export)\b/g)) {
+    if (!insideRanges(keyword.index, ranges)) {
+      keywordIndex = keyword.index;
+    }
+  }
+  if (keywordIndex < 0) return false;
+  const clause = before.slice(keywordIndex);
   if (/^(?:import|export)\s+type\b/.test(clause)) return true;
   const named = clause.match(/^(?:import|export)\s*\{([^}]*)\}\s*$/);
   if (named == null) return false;
@@ -145,9 +164,7 @@ function isTypeOnlySpecifier(text, match) {
     .split(',')
     .map((part) => part.trim())
     .filter((part) => part.length > 0);
-  return (
-    bindings.length > 0 && bindings.every((binding) => /^type\b/.test(binding))
-  );
+  return bindings.length > 0 && bindings.every(isTypeOnlyBinding);
 }
 
 /** Every module specifier in import/require/export-from positions. */
@@ -158,7 +175,7 @@ function importSpecifiers(text) {
     /(?:from\s*|import\s*(?:\(\s*)?|require(?:\.resolve)?\s*\(\s*|import\.meta\.resolve\s*\(\s*)['"]([^'"]+)['"]/g;
   for (const match of text.matchAll(pattern)) {
     if (insideRanges(match.index, ranges)) continue;
-    if (isTypeOnlySpecifier(text, match)) continue;
+    if (isTypeOnlySpecifier(text, match, ranges)) continue;
     specifiers.add(match[1]);
   }
   return specifiers;
@@ -198,6 +215,22 @@ function selfTestImportSpecifiers() {
     {
       text: "import './side-effect';\n",
       expected: ['./side-effect'],
+    },
+    {
+      text: "import type { X } from './typeOnly';\nimport './side-effect';\n",
+      expected: ['./side-effect'],
+    },
+    {
+      text: "import { type } from './value';\n",
+      expected: ['./value'],
+    },
+    {
+      text: "import { y /* import type */ } from './value';\n",
+      expected: ['./value'],
+    },
+    {
+      text: `${'import type {\n'}  ${'A,\n'.repeat(80)}} from './typeOnly';\n`,
+      expected: [],
     },
   ];
   for (const { text, expected } of cases) {

--- a/scripts/check-browser-safe-utils.mjs
+++ b/scripts/check-browser-safe-utils.mjs
@@ -124,6 +124,32 @@ function insideRanges(index, ranges) {
   return ranges.some(([start, end]) => index >= start && index < end);
 }
 
+/**
+ * True when the matched specifier is erased by TypeScript (`import type` /
+ * `export type ... from` / a named import whose every binding is `type`).
+ * Mixed `{ type X, y }` stays reachable because `y` is a value import.
+ */
+function isTypeOnlySpecifier(text, match) {
+  const matched = match[0];
+  if (/^(?:import\s*\(|require|import\.meta\.resolve)/.test(matched)) {
+    return false;
+  }
+  const before = text.slice(Math.max(0, match.index - 400), match.index);
+  const keyword = [...before.matchAll(/\b(?:import|export)\b/g)].at(-1);
+  if (keyword == null) return false;
+  const clause = before.slice(keyword.index);
+  if (/^(?:import|export)\s+type\b/.test(clause)) return true;
+  const named = clause.match(/^(?:import|export)\s*\{([^}]*)\}\s*$/);
+  if (named == null) return false;
+  const bindings = named[1]
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  return (
+    bindings.length > 0 && bindings.every((binding) => /^type\b/.test(binding))
+  );
+}
+
 /** Every module specifier in import/require/export-from positions. */
 function importSpecifiers(text) {
   const ranges = maskedRanges(text);
@@ -132,9 +158,59 @@ function importSpecifiers(text) {
     /(?:from\s*|import\s*(?:\(\s*)?|require(?:\.resolve)?\s*\(\s*|import\.meta\.resolve\s*\(\s*)['"]([^'"]+)['"]/g;
   for (const match of text.matchAll(pattern)) {
     if (insideRanges(match.index, ranges)) continue;
+    if (isTypeOnlySpecifier(text, match)) continue;
     specifiers.add(match[1]);
   }
   return specifiers;
+}
+
+/** Fail the guard itself if type-only detection regresses. */
+function selfTestImportSpecifiers() {
+  const cases = [
+    {
+      text: "import type { X } from './typeOnly';\n",
+      expected: [],
+    },
+    {
+      text: "export type { X } from './typeOnly';\n",
+      expected: [],
+    },
+    {
+      text: "import { type X } from './typeOnly';\n",
+      expected: [],
+    },
+    {
+      text: "import {\n  type X,\n} from './typeOnly';\n",
+      expected: [],
+    },
+    {
+      text: "export { type X } from './typeOnly';\n",
+      expected: [],
+    },
+    {
+      text: "import { type X, y } from './mixed';\n",
+      expected: ['./mixed'],
+    },
+    {
+      text: "import { y } from './value';\n",
+      expected: ['./value'],
+    },
+    {
+      text: "import './side-effect';\n",
+      expected: ['./side-effect'],
+    },
+  ];
+  for (const { text, expected } of cases) {
+    const actual = [...importSpecifiers(text)].toSorted(compareCodePoints);
+    const wanted = [...expected].toSorted(compareCodePoints);
+    if (!sameSet(actual, wanted)) {
+      console.error(
+        'importSpecifiers self-test failed:',
+        JSON.stringify({ text, actual, expected: wanted }),
+      );
+      process.exit(1);
+    }
+  }
 }
 
 function isTsFile(path) {
@@ -315,6 +391,7 @@ function sameSet(a, b) {
 }
 
 function main() {
+  selfTestImportSpecifiers();
   const total = listSourceFiles(utilsDir).length;
   const facts = documentedFacts();
   const { reachable, unresolvable } = reachableUtils();


### PR DESCRIPTION
## Summary

The browser-safe utils reachability walk treated every `from` / `import` specifier as a runtime edge. TypeScript and esbuild erase `import type`, `export type ... from`, and named `{ type X }` bindings, so a future type-only import between `src/utils` modules would either force a false reachable-set update or block a valid erased dependency.

Skip those type-only edges. Mixed `{ type X, y }` imports stay reachable because `y` is a value import. The scanner now self-tests the type-only cases so a detection regression fails the guard.

## Issue acceptance gates

- #10212: `import type`, `export type ... from`, and all-type named imports are not queued by `reachableUtils()`. Mixed named imports still are.

## Single source of truth

`scripts/check-browser-safe-utils.mjs` remains the only reachability walker. Type-only detection lives next to `importSpecifiers()`.

## Duplication and abstraction budget

No new file. One local helper plus a self-test table.

## Net elements (R6)

n/a (CI script)

## Consumer counts (R8)

n/a

## Host impact

Extension: none

Desktop: none

CLI: none

## Scheduled refactoring

#10213 still tracks replacing the lexical scanner entirely.

## Validation

- `node scripts/check-browser-safe-utils.mjs` (self-tests + live walk: 61 total, 7 reachable)