### PR TITLE
refactor: share truncated hex IDs through idHash

### DIFF
--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import * as path from 'node:path';
 
 import type { AgentTrace } from '@agent/trace';
@@ -23,6 +22,7 @@ import {
 import { type TaskRunFileService } from '@utils/files/taskRunStorage';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { truncatedHexId } from '@utils/core/idHash';
 import { hasExtension } from '@utils/core/pathCore';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 import { getRunDir } from '@utils/files/runStorageFs';
@@ -282,10 +282,7 @@ async function compileOne(
     invalidCharPattern: /[^a-zA-Z0-9._-]/g,
     replacement: '_',
   });
-  const pathHash = createHash('sha1')
-    .update(pathForSafeName)
-    .digest('hex')
-    .slice(0, PATH_HASH_LENGTH);
+  const pathHash = truncatedHexId(pathForSafeName, PATH_HASH_LENGTH, 'sha1');
   const sanitizedStem = legacySafeName.slice(0, MAX_SANITIZED_STEM_LENGTH);
   const safeName = `${sanitizedStem}_${pathHash}`;
   const buildDir = path.join(
@@ -310,12 +307,11 @@ async function compileOne(
     invalidCharPattern: /[^a-zA-Z0-9._-]/g,
     replacement: '_',
   });
-  const rawSafeName = `${rawLegacySafeName.slice(0, MAX_SANITIZED_STEM_LENGTH)}_${createHash(
+  const rawSafeName = `${rawLegacySafeName.slice(0, MAX_SANITIZED_STEM_LENGTH)}_${truncatedHexId(
+    rawPathForSafeName,
+    PATH_HASH_LENGTH,
     'sha1',
-  )
-    .update(rawPathForSafeName)
-    .digest('hex')
-    .slice(0, PATH_HASH_LENGTH)}`;
+  )}`;
   const legacyLogPaths = [
     ...new Set([legacySafeName, rawLegacySafeName, rawSafeName]),
   ].map((name) => path.join(opts.compileRoot, `r${currentRound}_${name}.log`));

--- a/src/agent/workflowScript/checkpointKey.ts
+++ b/src/agent/workflowScript/checkpointKey.ts
@@ -4,6 +4,9 @@ import { createHash } from 'node:crypto';
 // Third-party imports
 import stableStringify from 'fast-json-stable-stringify';
 
+// Local imports
+import { truncatedHexId } from '@utils/core/idHash';
+
 const WORKFLOW_SCRIPT_CHECKPOINT_KEY_PREFIX = 'workflow-script-';
 
 /**
@@ -21,16 +24,14 @@ export function deriveWorkflowScriptCheckpointId(identity: {
   readonly defaultAgent: string;
   readonly parentExecutionId: string;
 }): string {
-  return createHash('sha256')
-    .update(
-      stableStringify({
-        defaultAgent: identity.defaultAgent,
-        name: identity.name,
-        parentExecutionId: identity.parentExecutionId,
-      }),
-    )
-    .digest('hex')
-    .slice(0, 32);
+  return truncatedHexId(
+    stableStringify({
+      defaultAgent: identity.defaultAgent,
+      name: identity.name,
+      parentExecutionId: identity.parentExecutionId,
+    }),
+    32,
+  );
 }
 
 /** Build the execution-KV key owned by one workflow invocation. */

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import { basename } from 'node:path';
 
 import stableStringify from 'fast-json-stable-stringify';
@@ -15,6 +14,7 @@ import {
 } from '@shared/schemas';
 import { WorkflowScriptFilesSchema } from '@shared/schemas/workflowScriptFiles';
 import { isNonEmptyString, onAbort } from '@utils/core';
+import { truncatedHexId } from '@utils/core/idHash';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { parseWorkflowScript } from './parseScript';
@@ -49,16 +49,14 @@ function journalKey(
   const executionOptions: WorkflowAgentCallOptions = { ...options };
   delete executionOptions.label;
   delete executionOptions.phase;
-  return createHash('sha256')
-    .update(
-      stableStringify({
-        options: executionOptions,
-        prompt,
-        dependencyFingerprint,
-      }),
-    )
-    .digest('hex')
-    .slice(0, 16);
+  return truncatedHexId(
+    stableStringify({
+      options: executionOptions,
+      prompt,
+      dependencyFingerprint,
+    }),
+    16,
+  );
 }
 
 const DEFAULT_CONCURRENCY = 4;

--- a/src/platform/defaults/workspaceStorage.ts
+++ b/src/platform/defaults/workspaceStorage.ts
@@ -1,5 +1,4 @@
 // Node imports
-import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
 import { basename, join, posix, relative } from 'node:path';
 
@@ -8,6 +7,7 @@ import {
   WORKSPACE_STORAGE_LAYOUT,
 } from '@common/storage/storageLayout';
 import * as logger from '@logger/logUtils';
+import { truncatedHexId } from '@utils/core/idHash';
 import { isPathWithin } from '@utils/core/pathCore';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
@@ -33,13 +33,9 @@ export const WORKSPACE_STORAGE_COLLECTIONS_MERGED_PER_CHILD = [
 
 type WorkspacePathSource = string | undefined | (() => string | undefined);
 
-function workspaceStorageHash(source: string, length: number): string {
-  return createHash('sha256').update(source).digest('hex').slice(0, length);
-}
-
 function legacyWorkspaceStorageId(workspacePath: string | undefined): string {
   const source = workspacePath?.trim() || 'no-workspace';
-  return workspaceStorageHash(source, 16);
+  return truncatedHexId(source, 16);
 }
 
 function sanitizeWorkspaceBasename(workspacePath: string): string {
@@ -58,7 +54,7 @@ export function workspaceStorageId(workspacePath: string | undefined): string {
     source === 'no-workspace'
       ? 'no-workspace'
       : sanitizeWorkspaceBasename(source);
-  return `${stem}-${workspaceStorageHash(source, 8)}`;
+  return `${stem}-${truncatedHexId(source, 8)}`;
 }
 
 export function resolveGlobalStoragePath(storageRoot: string): string {

--- a/src/test-kernel/utils/UtilsCore.vitest.ts
+++ b/src/test-kernel/utils/UtilsCore.vitest.ts
@@ -17,7 +17,7 @@ import {
   utcMonthStart,
   type FlushableDebounce,
 } from '@utils/core';
-import { deriveExecutionId } from '@utils/core/idHash';
+import { deriveExecutionId, truncatedHexId } from '@utils/core/idHash';
 
 describe('utcMonthStart', () => {
   it('builds midnight UTC on the 1st of the given month', () => {
@@ -361,6 +361,17 @@ describe('coalesceAsync', () => {
       return 'recovered';
     });
     expect(recomputeCount).toBe(1);
+  });
+});
+
+describe('truncatedHexId', () => {
+  it('defaults to a sha256 prefix of the requested length', () => {
+    expect(truncatedHexId('source', 8)).toBe('41cf6794');
+    expect(truncatedHexId('source', 16)).toBe('41cf6794ba4200b8');
+  });
+
+  it('keeps the compile-log sha1 spelling', () => {
+    expect(truncatedHexId('path.tex', 8, 'sha1')).toBe('eefc4296');
   });
 });
 

--- a/src/utils/core/idHash.ts
+++ b/src/utils/core/idHash.ts
@@ -1,5 +1,5 @@
 // Node imports
-import { createHash } from 'node:crypto';
+import { createHash, type BinaryLike } from 'node:crypto';
 
 // Third-party imports
 import stableStringify from 'fast-json-stable-stringify';
@@ -9,10 +9,22 @@ import type { ExecutionId } from '@shared/schemas';
 
 type ExecutionIdentity = Readonly<Record<string, string | number>>;
 
+/**
+ * Algorithms used by truncated hex IDs. `sha1` is compile-log only — drop
+ * that member with the 2026-11-09 legacy compile-log spellings.
+ */
+export type TruncatedHexAlgorithm = 'sha256' | 'sha1';
+
+/** Stable hex prefix of a digest. Default algorithm is sha256. */
+export function truncatedHexId(
+  source: BinaryLike,
+  length: number,
+  algorithm: TruncatedHexAlgorithm = 'sha256',
+): string {
+  return createHash(algorithm).update(source).digest('hex').slice(0, length);
+}
+
 /** Derive a stable execution ID from named identity fields. */
 export function deriveExecutionId(identity: ExecutionIdentity): ExecutionId {
-  return createHash('sha256')
-    .update(stableStringify(identity))
-    .digest('hex')
-    .slice(0, 24) as ExecutionId;
+  return truncatedHexId(stableStringify(identity), 24) as ExecutionId;
 }

--- a/src/utils/core/idHash.ts
+++ b/src/utils/core/idHash.ts
@@ -13,7 +13,7 @@ type ExecutionIdentity = Readonly<Record<string, string | number>>;
  * Algorithms used by truncated hex IDs. `sha1` is compile-log only — drop
  * that member with the 2026-11-09 legacy compile-log spellings.
  */
-export type TruncatedHexAlgorithm = 'sha256' | 'sha1';
+type TruncatedHexAlgorithm = 'sha256' | 'sha1';
 
 /** Stable hex prefix of a digest. Default algorithm is sha256. */
 export function truncatedHexId(


### PR DESCRIPTION
## Summary

Six hash-then-slice ID sites used the same `createHash(...).digest('hex').slice(0, N)` pattern with different algorithms and lengths. They now call `truncatedHexId` in `src/utils/core/idHash.ts`.

- Default algorithm is sha256 (execution IDs, workspace storage names, workflow journal/checkpoint keys).
- Compile-log names keep `sha1` explicitly, including the 2026-11-09 legacy raw-path spelling. After that date, drop the `'sha1'` union member with the legacy names.
- The helper is not re-exported from `@utils/core`, so the browser-reachable utils graph stays free of `node:crypto`.

## Issue acceptance gates

- #10242: the hash-truncated-ID sites share one helper; the compile-log legacy sha1 spelling is preserved.

## Single source of truth

`truncatedHexId` in `src/utils/core/idHash.ts` owns the digest-and-slice contract.

## Duplication and abstraction budget

Removed five independent `createHash`+`slice` copies. One helper with callers at six sites. Inlined the now-trivial `workspaceStorageHash` wrapper.

## Net elements (R6)

- Files: 6 changed
- Exports: +`truncatedHexId`, +`TruncatedHexAlgorithm`
- Deleted: local `workspaceStorageHash`
- Net LoC: small decrease in callers, small increase in `idHash.ts` + tests

## Consumer counts (R8)

`truncatedHexId`: 6 production call sites in this PR (deriveExecutionId, workspace current/legacy, journalKey, checkpoint id, compile current, compile legacy).

## Host impact

Extension: none

Desktop: none

CLI: none (shared Node helper)

## Scheduled refactoring

After 2026-11-09: delete the compile-log `rawSafeName` / `legacySafeName` spellings and the `'sha1'` algorithm member together.

## Validation

- `npx vitest run src/test-kernel/utils/UtilsCore.vitest.ts src/test-kernel/platform/WorkspaceStorage.vitest.ts` (90 passed)
- eslint on the touched files