### PR TITLE
refactor: stop fetching remote-agent visibility on the client

### DIFF
--- a/src/agent/index/agentEntry.ts
+++ b/src/agent/index/agentEntry.ts
@@ -16,7 +16,6 @@ export interface AgentEntry {
   tools?: string[]; // tool names for tool-use agents
   defaultOutputFiles?: string[];
   rounds?: number; // workflow round count
-  visibility?: string[]; // remote only: group names that can access the agent
 }
 
 /**

--- a/src/agent/index/remoteAgentMeta.ts
+++ b/src/agent/index/remoteAgentMeta.ts
@@ -57,7 +57,6 @@ export async function loadRemoteAgents(): Promise<AgentEntry[]> {
         path: '',
         category: isToolUse ? AgentCategory.ToolUse : AgentCategory.Workflow,
         description: remote.description ?? undefined,
-        visibility: remote.visibility ?? undefined,
         tools: dbTools ?? cached?.tools,
         defaultOutputFiles: cached?.defaultOutputFiles,
       };

--- a/src/agent/remote/remoteAgentList.ts
+++ b/src/agent/remote/remoteAgentList.ts
@@ -27,13 +27,12 @@ import { RemoteAgentListItemSchema, type RemoteAgentListItem } from './types';
 export const CHANNEL = 'RemoteAgentLoader';
 
 const REMOTE_AGENT_LIST_COLUMNS =
-  'id, name, description, visibility, tools, agent_category';
+  'id, name, description, tools, agent_category';
 
 interface RemoteAgentListRow {
   id: string;
   name: string;
   description?: string | null;
-  visibility?: string[] | null;
   tools?: string[] | null;
   agent_category: string;
 }
@@ -59,7 +58,6 @@ function parseListItemRow(row: RemoteAgentListRow): RemoteAgentListItem | null {
     id: row.id,
     name: row.name,
     description: row.description,
-    visibility: row.visibility,
     tools: row.tools,
     agentCategory: row.agent_category,
   });

--- a/src/agent/remote/types.ts
+++ b/src/agent/remote/types.ts
@@ -17,7 +17,6 @@ export const RemoteAgentListItemSchema = z.object({
   id: z.string(),
   name: AgentNameSchema,
   description: z.string().nullish(),
-  visibility: z.array(z.string()).nullish(),
   /** Cached tool names from YAML. Available when DB column is populated. */
   tools: z.array(z.string()).nullish(),
   agentCategory: z.enum(AgentCategory),

--- a/src/test-kernel/agent/AgentRegistry.vitest.ts
+++ b/src/test-kernel/agent/AgentRegistry.vitest.ts
@@ -30,7 +30,6 @@ const { listRemoteAgents, ORCHESTRATOR_AGENT } = vi.hoisted(() => {
     id: 'remote-orchestrator',
     name: 'orchestrator',
     description: 'Remote team root',
-    visibility: ['researcher'],
     tools: ['delegate_agent'],
     agentCategory: 'toolUse',
   };
@@ -94,7 +93,6 @@ function remoteAgentFixture(id: string, name: string, description: string) {
     id,
     name,
     description,
-    visibility: [],
     tools: [],
     agentCategory: 'toolUse',
   };

--- a/src/test-kernel/agent/remote/RemoteAgentLoader.vitest.ts
+++ b/src/test-kernel/agent/remote/RemoteAgentLoader.vitest.ts
@@ -41,7 +41,6 @@ const canonicalReviewRow = {
   id: 'agent-2',
   name: 'review',
   description: 'Canonical row',
-  visibility: ['public'],
   tools: [],
   agent_category: 'toolUse',
 };
@@ -51,7 +50,6 @@ function invalidAgentRow(overrides: Record<string, unknown>) {
     id: 'agent-1',
     name: 'review team',
     description: 'Invalid row',
-    visibility: ['public'],
     tools: [],
     agent_category: 'toolUse',
     ...overrides,
@@ -102,7 +100,7 @@ describe('remote agent listing', () => {
 
     expect(agents).toEqual([]);
     expect(selectedColumns).toEqual([
-      'id, name, description, visibility, tools, agent_category',
+      'id, name, description, tools, agent_category',
     ]);
   });
 });

--- a/src/test-kernel/cli/AgentsCommand.vitest.ts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.ts
@@ -331,7 +331,6 @@ describe('CLI agents command', () => {
         category: AgentCategory.ToolUse,
         description: 'Relay-served Lean assistant.',
         tools: ['delegate_agent', 'lean_diagnostics'],
-        visibility: ['public'],
       },
       args: 'lean',
       textContain: 'source: remote',


### PR DESCRIPTION
## Summary

The hosted Lean PR removed `visibility` from the remote-agent wire schema and the human-readable CLI formatter, but the client still selected the column and copied it onto `AgentEntry`. `texra agents show --json` / `--ndjson` therefore still leaked access-group tags.

This deletes the field end-to-end on the client: drop it from the PostgREST column list, the list-item schema, `AgentEntry`, the row mapping, and the meta copy. The DB column stays for RLS. Fixtures in the three constructing tests are updated.

## Issue acceptance gates

- #10227: the client no longer selects, stores, or serializes remote-agent visibility.

## Single source of truth

Server-side RLS remains the only reader of `remote_agents.visibility`. The client catalog no longer carries a second copy.

## Duplication and abstraction budget

No new abstraction. Removed a dead field and its copies.

## Net elements (R6)

- Files: 7 changed
- Exports: `AgentEntry.visibility` and `RemoteAgentListItem.visibility` removed
- Net LoC: decrease

## Consumer counts (R8)

Production readers of `AgentEntry.visibility`: 0 (only JSON serialization of the whole entry). Test fixtures: 3 files updated.

## Host impact

Extension: none (settings agent visibility is a different field)

Desktop: none

CLI: `texra agents show --json` / `--ndjson` no longer include access-group tags

## Scheduled refactoring

None

## Validation

- `npx vitest run src/test-kernel/agent/remote/RemoteAgentLoader.vitest.ts src/test-kernel/agent/AgentRegistry.vitest.ts src/test-kernel/cli/AgentsCommand.vitest.ts` (28 passed)
- eslint on the touched files