### PR TITLE
ci: catch field-2-only code-change rename regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
             echo 'code-change classifier self-test failed (rename into docs)' >&2
             exit 1
           fi
+          if ! printf 'R100\tdocs/foo.ts\tsrc/foo.ts\n' | code_change_match; then
+            echo 'code-change classifier self-test failed (rename dest only)' >&2
+            exit 1
+          fi
           if printf 'M\tdocs/guide.md\n' | code_change_match; then
             echo 'code-change classifier self-test failed (docs-only)' >&2
             exit 1


### PR DESCRIPTION
## Summary

#10240 isolated dest-only rename coverage for `drift_gate_match`, but `code_change_match` still only tested a rename whose code path sat in field 2 (`R100\tsrc/foo.ts\tdocs/foo.ts`). A matcher that inspects only `$2` (or skips rename destinations) would still pass, then silently treat a real rename out of `docs/` as docs-only.

Add a dest-only positive case in its own `awk` invocation: `R100\tdocs/foo.ts\tsrc/foo.ts`.

## Issue acceptance gates

- #10253: a field-2-only or rename-skipping `code_change_match` fails CI.

## Single source of truth

The classifier self-tests in `.github/workflows/ci.yml` remain the single guard for the `awk` classifiers.

## Duplication and abstraction budget

No new abstraction. Mirrors the dest-only `drift_gate_match` invocation.

## Net elements (R6)

n/a (CI workflow)

## Consumer counts (R8)

n/a

## Host impact

Extension: none

Desktop: none

CLI: none

## Scheduled refactoring

None

## Validation

- Locally verified the dest-only line matches the real matcher and fails a field-2-only variant