### PR TITLE
fix(ui): stop wa-spinner dash under reduced motion

### DIFF
--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -3,11 +3,11 @@ import { html, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
-import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 import '@awesome.me/webawesome/dist/components/split-panel/split-panel.js';
 
 // Local imports - shared webview
 import { COMMON_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import '@shared/wa/spinner';
 import { BaseWebviewApp } from '@shared/BaseWebviewApp';
 import { postMessage } from '@shared/hostBridge';
 

--- a/packages/extension/src/progressView/frontend/components/CompactionActivity.ts
+++ b/packages/extension/src/progressView/frontend/components/CompactionActivity.ts
@@ -1,6 +1,4 @@
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
-
 import { LitElement, css, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
@@ -10,6 +8,7 @@ import {
   type CompactionActivityStatus,
 } from '@shared/streams/compactionActivityProjection';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
+import { stopSpinnerMotion } from '@shared/wa/spinner';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 const ACTIVITY_ICON: Record<
@@ -97,7 +96,11 @@ export class CompactionActivity extends LitElement {
     >
       ${
         this.status === 'running'
-          ? html`<wa-spinner class="icon" aria-hidden="true"></wa-spinner>`
+          ? html`<wa-spinner
+              class="icon"
+              aria-hidden="true"
+              ${stopSpinnerMotion()}
+            ></wa-spinner>`
           : waIcon(ACTIVITY_ICON[this.status], { className: 'icon' })
       }
       <span class="label">${label}</span>

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -25,10 +25,10 @@ import './TaskGroupList';
 
 // Side-effect imports - register WA icon and spinner components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 
 // Local imports
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import '@shared/wa/spinner';
 import type { LogMessageData, TaskGroup } from '@shared/schemas';
 import { designTokens } from '@shared/styles';
 import { postMessage } from '@shared/hostBridge';

--- a/packages/extension/src/progressView/frontend/components/TodoList.ts
+++ b/packages/extension/src/progressView/frontend/components/TodoList.ts
@@ -6,11 +6,11 @@ import { classMap } from 'lit/directives/class-map.js';
 
 // Side-effect imports - register WA icon and spinner components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { TODO_STATUS, STATUS_ICONS, type TodoItem } from '@shared/schemas';
+import { stopSpinnerMotion } from '@shared/wa/spinner';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import { ELEMENT_IDS } from '../constants';
@@ -129,7 +129,10 @@ export class TodoList extends CollapsiblePanel {
       >
         ${
           isInProgress
-            ? html`<wa-spinner class="todo-item__icon"></wa-spinner>`
+            ? html`<wa-spinner
+                class="todo-item__icon"
+                ${stopSpinnerMotion()}
+              ></wa-spinner>`
             : waIcon(icon, { className: 'todo-item__icon' })
         }
         <span class="todo-item__content">${content}</span>

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -21,6 +21,7 @@ import { hljs } from '@shared/highlighting/hljs';
 
 // Local imports - shared utilities
 import type { TeXRAIconName } from '@shared/wa/iconNames';
+import { stopSpinnerMotion } from '@shared/wa/spinner';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { getBasename } from '@utils/core';
 import { DIFF_DELETE, DIFF_INSERT, diffTextByChar } from '@utils/text/diff';
@@ -159,7 +160,7 @@ function renderIconOrSpinner(
 ): TemplateResult {
   if (iconName === SPINNER_ICON_NAME) {
     // prettier-ignore
-    return html`<wa-spinner class=${ifDefined(className)}></wa-spinner>`;
+    return html`<wa-spinner class=${ifDefined(className)} ${stopSpinnerMotion()}></wa-spinner>`;
   }
   return waIcon(iconName, { className });
 }

--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -1,12 +1,12 @@
 // Third-party imports
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 import { html, nothing, type TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 // Local imports - Web Awesome
+import { stopSpinnerMotion } from './spinner';
 import { waIcon } from './webAwesomeIcons';
 import type { TeXRAIconName } from './iconNames';
 
@@ -202,6 +202,7 @@ function renderActionButtonBase(
           ? html`<wa-spinner
               class="action-busy-spinner"
               aria-hidden="true"
+              ${stopSpinnerMotion()}
             ></wa-spinner>`
           : nothing
       }

--- a/src/shared/wa/index.ts
+++ b/src/shared/wa/index.ts
@@ -12,6 +12,7 @@
 
 import '@awesome.me/webawesome/dist/styles/themes/default.css';
 
+import './spinner';
 import { registerTeXRAWebAwesomeIcons } from './webAwesomeIcons';
 import { applyInitialWaColorScheme } from './waColorScheme';
 

--- a/src/shared/wa/loadingState.ts
+++ b/src/shared/wa/loadingState.ts
@@ -2,15 +2,16 @@
 // renderEmptyState: consumers style via the .loading-state class hook
 // (shared rule in commonViewStyles); the helper owns the structure.
 
-import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 import { html, type TemplateResult } from 'lit';
+
+import { stopSpinnerMotion } from './spinner';
 
 export function renderLoadingState(label: string): TemplateResult {
   // Stable role="status" region: the label announces when the loading state
   // appears, and aria-busy marks the region while content is being loaded.
   return html`
     <div class="loading-state" role="status" aria-busy="true">
-      <wa-spinner></wa-spinner>
+      <wa-spinner ${stopSpinnerMotion()}></wa-spinner>
       ${label}
     </div>
   `;

--- a/src/shared/wa/spinner.ts
+++ b/src/shared/wa/spinner.ts
@@ -6,8 +6,7 @@
 
 import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 import { nothing } from 'lit';
-import { AsyncDirective, directive } from 'lit/async-directive.js';
-import type { ElementPart } from 'lit/directive.js';
+import { Directive, directive, type ElementPart } from 'lit/directive.js';
 
 const REDUCED_MOTION_STYLE_ATTR = 'data-texra-reduced-motion';
 const REDUCED_MOTION_CSS = `@media (prefers-reduced-motion: reduce) {
@@ -41,12 +40,12 @@ function scheduleAdopt(host: Element): void {
   queueMicrotask(() => adoptReducedMotion(host));
 }
 
-class StopSpinnerMotionDirective extends AsyncDirective {
+class StopSpinnerMotionDirective extends Directive {
   render(): typeof nothing {
     return nothing;
   }
 
-  protected override update(part: ElementPart): typeof nothing {
+  override update(part: ElementPart): typeof nothing {
     scheduleAdopt(part.element);
     return nothing;
   }

--- a/src/shared/wa/spinner.ts
+++ b/src/shared/wa/spinner.ts
@@ -1,0 +1,56 @@
+// Registers <wa-spinner> and stops both of its animations under
+// prefers-reduced-motion. The spin lives on the svg (::part(base)); the dash
+// stroke morph lives on the inner .indicator circle, which is not a part, so
+// a host stylesheet cannot reach it. A Lit directive injects one style into
+// the spinner shadow after its first render.
+
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
+import { nothing } from 'lit';
+import { AsyncDirective, directive } from 'lit/async-directive.js';
+import type { ElementPart } from 'lit/directive.js';
+
+const REDUCED_MOTION_STYLE_ATTR = 'data-texra-reduced-motion';
+const REDUCED_MOTION_CSS = `@media (prefers-reduced-motion: reduce) {
+  svg,
+  .indicator {
+    animation: none !important;
+  }
+}`;
+
+function adoptReducedMotion(host: Element): void {
+  const root = host.shadowRoot;
+  if (
+    root == null ||
+    root.querySelector(`style[${REDUCED_MOTION_STYLE_ATTR}]`)
+  ) {
+    return;
+  }
+  const style = document.createElement('style');
+  style.setAttribute(REDUCED_MOTION_STYLE_ATTR, '');
+  style.textContent = REDUCED_MOTION_CSS;
+  root.append(style);
+}
+
+function scheduleAdopt(host: Element): void {
+  const pending = (host as { updateComplete?: Promise<unknown> })
+    .updateComplete;
+  if (pending) {
+    void pending.then(() => adoptReducedMotion(host));
+    return;
+  }
+  queueMicrotask(() => adoptReducedMotion(host));
+}
+
+class StopSpinnerMotionDirective extends AsyncDirective {
+  render(): typeof nothing {
+    return nothing;
+  }
+
+  protected override update(part: ElementPart): typeof nothing {
+    scheduleAdopt(part.element);
+    return nothing;
+  }
+}
+
+/** Attach to every `<wa-spinner>` so its dash animation honors reduced motion. */
+export const stopSpinnerMotion = directive(StopSpinnerMotionDirective);

--- a/src/test-kernel/progressView/CompactionActivityRender.vitest.ts
+++ b/src/test-kernel/progressView/CompactionActivityRender.vitest.ts
@@ -55,6 +55,16 @@ describe('compaction-activity render branches', () => {
     expect(spinner?.tagName).toBe('WA-SPINNER');
     // The row announces via role="status"; hide the spinner from AT.
     expect(spinner?.getAttribute('aria-hidden')).toBe('true');
+
+    // The dash stroke lives on .indicator inside the spinner shadow root.
+    const litSpinner = spinner as
+      (Element & { updateComplete?: Promise<unknown> }) | null | undefined;
+    await litSpinner?.updateComplete;
+    const reducedMotion = spinner?.shadowRoot?.querySelector(
+      'style[data-texra-reduced-motion]',
+    );
+    expect(reducedMotion?.textContent).toContain('.indicator');
+    expect(reducedMotion?.textContent).toMatch(/animation:\s*none/);
   });
 
   it('keeps the reduced-motion override on the shared spinner', async () => {


### PR DESCRIPTION
## Summary

\`<wa-spinner>\` runs two animations. The host \`::part(base)\` rule stops the outer rotation, but the hardcoded \`dash\` stroke morph on the inner \`.indicator\` circle is not a part, so users with \`prefers-reduced-motion: reduce\` still see continuous motion.

\`@shared/wa/spinner\` now owns spinner registration and a \`stopSpinnerMotion()\` directive that injects one reduced-motion style into the spinner shadow after first render. Every \`<wa-spinner>\` call site uses that directive.

## Issue acceptance gates

- #10195: CompactionActivity, TodoList, htmlBuilders, loadingState, and actionButtons all stop both spinner animations under reduced motion.

## Single source of truth

\`stopSpinnerMotion\` / \`src/shared/wa/spinner.ts\` owns the reduced-motion CSS and when it is applied.

## Duplication and abstraction budget

One directive, five existing call sites. No extra wrapper element. CompactionActivity still keeps its \`::part(base)\` rule as a CSS-only fallback for the spin.

## Net elements (R6)

- Files: +1 (\`spinner.ts\`), 8 edited
- Exports: +\`stopSpinnerMotion\`
- Net LoC: small increase

## Consumer counts (R8)

\`stopSpinnerMotion\`: 5 production call sites in this PR.

## Host impact

Extension: compaction / todo / tool-use spinners honor reduced motion

Desktop: loading-state and busy-button spinners honor reduced motion (shared helpers)

CLI: none

## Scheduled refactoring

None

## Validation

- \`npx vitest run src/test-kernel/progressView/CompactionActivityRender.vitest.ts\` (3 passed)
- desktop renderer \`tsc --noEmit\`
- eslint on the touched files