### PR TITLE
refactor: share xterm theme resolution across hosts

### DIFF
--- a/packages/desktop/src/renderer/terminalPane.ts
+++ b/packages/desktop/src/renderer/terminalPane.ts
@@ -13,6 +13,8 @@ import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import xtermStyles from '@xterm/xterm/css/xterm.css?inline';
 
+import { resolveXtermTheme } from '@shared/wa/xtermTheme';
+
 import { getDesktopChromeFontSize } from './desktopTypography';
 
 export interface TerminalPaneCallbacks {
@@ -65,23 +67,6 @@ function injectXtermStyles(): void {
   stylesInjected = true;
 }
 
-/**
- * Reads terminal colors from the app's own token layer so the terminal matches
- * the active theme instead of shipping a second hardcoded palette. The tokens
- * are the `--wa-color-*` promotions documented in themeTokens.css.
- */
-function themeFromTokens(): Record<string, string> {
-  const styles = getComputedStyle(document.body);
-  const token = (name: string, fallback: string): string =>
-    styles.getPropertyValue(name).trim() || fallback;
-  return {
-    background: token('--wa-color-surface-default', '#1e1e1e'),
-    foreground: token('--wa-color-text-normal', '#d4d4d4'),
-    cursor: token('--wa-color-text-normal', '#d4d4d4'),
-    selectionBackground: token('--wa-color-terminal-selection-bg', '#264f78'),
-  };
-}
-
 export function createTerminalPane(
   callbacks: TerminalPaneCallbacks,
 ): TerminalPane {
@@ -98,14 +83,12 @@ export function createTerminalPane(
     host.className = 'desktop-terminal-surface';
     element.append(host);
 
+    const { theme, fontFamily } = resolveXtermTheme(document.body);
     const terminal = new Terminal({
       allowProposedApi: true,
       convertEol: false,
       cursorBlink: true,
-      fontFamily:
-        getComputedStyle(document.body)
-          .getPropertyValue('--wa-font-family-mono')
-          .trim() || 'monospace',
+      fontFamily,
       fontSize: getDesktopChromeFontSize(),
       // Build logs and test output are long; a shallow buffer would discard the
       // beginning of exactly the runs users need to read.
@@ -113,7 +96,7 @@ export function createTerminalPane(
       // Pty output is canvas-only without this; screen reader mode exposes the
       // buffer (including the in-band exit/error lines) as text.
       screenReaderMode: true,
-      theme: themeFromTokens(),
+      theme,
     });
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);

--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -4,33 +4,9 @@ import { customElement, property, query } from 'lit/decorators.js';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import xtermStyles from '@xterm/xterm/css/xterm.css?inline';
+
+import { resolveXtermTheme } from '@shared/wa/xtermTheme';
 import { clamp } from '@utils/core';
-
-const DEFAULT_THEME = {
-  background: '#1e1e1e',
-  foreground: '#cccccc',
-  fontFamily: 'monospace',
-} as const;
-
-/** Web Awesome terminal ANSI color tokens mapped to xterm.js theme keys. */
-const ANSI_COLOR_MAP = [
-  ['black', '--wa-color-terminal-ansi-black'],
-  ['red', '--wa-color-terminal-ansi-red'],
-  ['green', '--wa-color-terminal-ansi-green'],
-  ['yellow', '--wa-color-terminal-ansi-yellow'],
-  ['blue', '--wa-color-terminal-ansi-blue'],
-  ['magenta', '--wa-color-terminal-ansi-magenta'],
-  ['cyan', '--wa-color-terminal-ansi-cyan'],
-  ['white', '--wa-color-terminal-ansi-white'],
-  ['brightBlack', '--wa-color-terminal-ansi-bright-black'],
-  ['brightRed', '--wa-color-terminal-ansi-bright-red'],
-  ['brightGreen', '--wa-color-terminal-ansi-bright-green'],
-  ['brightYellow', '--wa-color-terminal-ansi-bright-yellow'],
-  ['brightBlue', '--wa-color-terminal-ansi-bright-blue'],
-  ['brightMagenta', '--wa-color-terminal-ansi-bright-magenta'],
-  ['brightCyan', '--wa-color-terminal-ansi-bright-cyan'],
-  ['brightWhite', '--wa-color-terminal-ansi-bright-white'],
-] as const;
 
 const MIN_SCROLLBACK = 4_000;
 
@@ -138,7 +114,7 @@ export class TerminalOutput extends LitElement {
   };
 
   override firstUpdated(): void {
-    const { theme, fontFamily } = this.resolveTerminalOptions();
+    const { theme, fontFamily } = resolveXtermTheme(this);
     this.terminal = new Terminal({
       disableStdin: true,
       convertEol: true,
@@ -290,42 +266,6 @@ export class TerminalOutput extends LitElement {
       terminal.write(text, () => resolve());
       setTimeout(() => resolve(), 100);
     });
-  }
-
-  /** Resolve theme colors and font family from `--wa-*` tokens in a single getComputedStyle call. */
-  private resolveTerminalOptions(): {
-    theme: Record<string, string>;
-    fontFamily: string;
-  } {
-    const styles = getComputedStyle(this);
-
-    const theme: Record<string, string> = {
-      background:
-        styles.getPropertyValue('--wa-color-surface-default').trim() ||
-        DEFAULT_THEME.background,
-      foreground:
-        styles.getPropertyValue('--wa-color-text-normal').trim() ||
-        DEFAULT_THEME.foreground,
-    };
-
-    for (const [key, cssVar] of ANSI_COLOR_MAP) {
-      const value = styles.getPropertyValue(cssVar).trim();
-      if (value) theme[key] = value;
-    }
-
-    const cursor = styles.getPropertyValue('--wa-color-terminal-cursor').trim();
-    if (cursor) theme['cursor'] = cursor;
-
-    const selectionBg = styles
-      .getPropertyValue('--wa-color-terminal-selection-bg')
-      .trim();
-    if (selectionBg) theme['selectionBackground'] = selectionBg;
-
-    const fontFamily =
-      styles.getPropertyValue('--wa-font-family-mono').trim() ||
-      DEFAULT_THEME.fontFamily;
-
-    return { theme, fontFamily };
   }
 
   override render() {

--- a/src/shared/wa/xtermTheme.ts
+++ b/src/shared/wa/xtermTheme.ts
@@ -2,16 +2,21 @@
  * Resolve an xterm.js theme from Web Awesome CSS tokens on a host element.
  * Extension and desktop both call this with their own DOM target so the
  * terminal matches the active theme instead of a second hardcoded palette.
+ *
+ * Background and foreground keep the surface/text tokens the two hosts
+ * already used. Dedicated `--wa-color-terminal-background` /
+ * `--wa-color-terminal-foreground` exist on both sheets; switching would
+ * change the progress-view palette and is out of this extraction's scope.
  */
 
-export const XTERM_THEME_FALLBACKS = {
+const XTERM_THEME_FALLBACKS = {
   background: '#1e1e1e',
   foreground: '#cccccc',
   fontFamily: 'monospace',
 } as const;
 
 /** Web Awesome terminal ANSI color tokens mapped to xterm.js theme keys. */
-export const XTERM_ANSI_COLOR_TOKENS = [
+const XTERM_ANSI_COLOR_TOKENS = [
   ['black', '--wa-color-terminal-ansi-black'],
   ['red', '--wa-color-terminal-ansi-red'],
   ['green', '--wa-color-terminal-ansi-green'],
@@ -30,7 +35,7 @@ export const XTERM_ANSI_COLOR_TOKENS = [
   ['brightWhite', '--wa-color-terminal-ansi-bright-white'],
 ] as const;
 
-export interface ResolvedXtermTheme {
+interface ResolvedXtermTheme {
   readonly theme: Record<string, string>;
   readonly fontFamily: string;
 }
@@ -52,8 +57,13 @@ export function resolveXtermTheme(target: Element): ResolvedXtermTheme {
     if (value) theme[key] = value;
   }
 
-  const cursor = token('--wa-color-terminal-cursor');
-  theme.cursor = cursor || theme.foreground;
+  // Dedicated cursor token first; `--wa-color-text-normal` next so a host
+  // that omits the cursor token keeps the desktop high-contrast source
+  // (CanvasText) rather than jumping to FieldText via input-foreground.
+  theme.cursor =
+    token('--wa-color-terminal-cursor') ||
+    token('--wa-color-text-normal') ||
+    theme.foreground;
 
   const selectionBackground = token('--wa-color-terminal-selection-bg');
   if (selectionBackground) theme.selectionBackground = selectionBackground;

--- a/src/shared/wa/xtermTheme.ts
+++ b/src/shared/wa/xtermTheme.ts
@@ -1,0 +1,66 @@
+/**
+ * Resolve an xterm.js theme from Web Awesome CSS tokens on a host element.
+ * Extension and desktop both call this with their own DOM target so the
+ * terminal matches the active theme instead of a second hardcoded palette.
+ */
+
+export const XTERM_THEME_FALLBACKS = {
+  background: '#1e1e1e',
+  foreground: '#cccccc',
+  fontFamily: 'monospace',
+} as const;
+
+/** Web Awesome terminal ANSI color tokens mapped to xterm.js theme keys. */
+export const XTERM_ANSI_COLOR_TOKENS = [
+  ['black', '--wa-color-terminal-ansi-black'],
+  ['red', '--wa-color-terminal-ansi-red'],
+  ['green', '--wa-color-terminal-ansi-green'],
+  ['yellow', '--wa-color-terminal-ansi-yellow'],
+  ['blue', '--wa-color-terminal-ansi-blue'],
+  ['magenta', '--wa-color-terminal-ansi-magenta'],
+  ['cyan', '--wa-color-terminal-ansi-cyan'],
+  ['white', '--wa-color-terminal-ansi-white'],
+  ['brightBlack', '--wa-color-terminal-ansi-bright-black'],
+  ['brightRed', '--wa-color-terminal-ansi-bright-red'],
+  ['brightGreen', '--wa-color-terminal-ansi-bright-green'],
+  ['brightYellow', '--wa-color-terminal-ansi-bright-yellow'],
+  ['brightBlue', '--wa-color-terminal-ansi-bright-blue'],
+  ['brightMagenta', '--wa-color-terminal-ansi-bright-magenta'],
+  ['brightCyan', '--wa-color-terminal-ansi-bright-cyan'],
+  ['brightWhite', '--wa-color-terminal-ansi-bright-white'],
+] as const;
+
+export interface ResolvedXtermTheme {
+  readonly theme: Record<string, string>;
+  readonly fontFamily: string;
+}
+
+/** Read `--wa-*` tokens from `target` in one getComputedStyle call. */
+export function resolveXtermTheme(target: Element): ResolvedXtermTheme {
+  const styles = getComputedStyle(target);
+  const token = (name: string): string => styles.getPropertyValue(name).trim();
+
+  const theme: Record<string, string> = {
+    background:
+      token('--wa-color-surface-default') || XTERM_THEME_FALLBACKS.background,
+    foreground:
+      token('--wa-color-text-normal') || XTERM_THEME_FALLBACKS.foreground,
+  };
+
+  for (const [key, cssVar] of XTERM_ANSI_COLOR_TOKENS) {
+    const value = token(cssVar);
+    if (value) theme[key] = value;
+  }
+
+  const cursor = token('--wa-color-terminal-cursor');
+  theme.cursor = cursor || theme.foreground;
+
+  const selectionBackground = token('--wa-color-terminal-selection-bg');
+  if (selectionBackground) theme.selectionBackground = selectionBackground;
+
+  return {
+    theme,
+    fontFamily:
+      token('--wa-font-family-mono') || XTERM_THEME_FALLBACKS.fontFamily,
+  };
+}

--- a/src/test-kernel/shared/XtermTheme.vitest.ts
+++ b/src/test-kernel/shared/XtermTheme.vitest.ts
@@ -6,21 +6,70 @@ import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
 
 useLitComponentTestDom();
 
+const ANSI_TOKENS = [
+  ['black', '--wa-color-terminal-ansi-black', '#010101'],
+  ['red', '--wa-color-terminal-ansi-red', '#ff0000'],
+  ['green', '--wa-color-terminal-ansi-green', '#00ff00'],
+  ['yellow', '--wa-color-terminal-ansi-yellow', '#ffff00'],
+  ['blue', '--wa-color-terminal-ansi-blue', '#0000ff'],
+  ['magenta', '--wa-color-terminal-ansi-magenta', '#ff00ff'],
+  ['cyan', '--wa-color-terminal-ansi-cyan', '#00ffff'],
+  ['white', '--wa-color-terminal-ansi-white', '#f0f0f0'],
+  ['brightBlack', '--wa-color-terminal-ansi-bright-black', '#111111'],
+  ['brightRed', '--wa-color-terminal-ansi-bright-red', '#ff1111'],
+  ['brightGreen', '--wa-color-terminal-ansi-bright-green', '#11ff11'],
+  ['brightYellow', '--wa-color-terminal-ansi-bright-yellow', '#ffff11'],
+  ['brightBlue', '--wa-color-terminal-ansi-bright-blue', '#1111ff'],
+  ['brightMagenta', '--wa-color-terminal-ansi-bright-magenta', '#ff11ff'],
+  ['brightCyan', '--wa-color-terminal-ansi-bright-cyan', '#11ffff'],
+  ['brightWhite', '--wa-color-terminal-ansi-bright-white', '#ffffff'],
+] as const;
+
 describe('resolveXtermTheme', () => {
-  it('reads tokens from the supplied target and falls cursor back to foreground', () => {
+  it('reads the full token map from the supplied target', () => {
     const target = document.createElement('div');
     target.style.setProperty('--wa-color-surface-default', '#111111');
     target.style.setProperty('--wa-color-text-normal', '#eeeeee');
-    target.style.setProperty('--wa-color-terminal-ansi-red', '#ff0000');
+    target.style.setProperty('--wa-color-terminal-cursor', '#00aa00');
+    target.style.setProperty('--wa-color-terminal-selection-bg', '#264f78');
     target.style.setProperty('--wa-font-family-mono', '"JetBrains Mono"');
+    for (const [, cssVar, value] of ANSI_TOKENS) {
+      target.style.setProperty(cssVar, value);
+    }
     document.body.append(target);
 
     const { theme, fontFamily } = resolveXtermTheme(target);
 
     expect(theme.background).toBe('#111111');
     expect(theme.foreground).toBe('#eeeeee');
-    expect(theme.cursor).toBe('#eeeeee');
-    expect(theme.red).toBe('#ff0000');
+    expect(theme.cursor).toBe('#00aa00');
+    expect(theme.selectionBackground).toBe('#264f78');
     expect(fontFamily).toBe('"JetBrains Mono"');
+    for (const [key, , value] of ANSI_TOKENS) {
+      expect(theme[key]).toBe(value);
+    }
+  });
+
+  it('falls cursor back to text-normal, then to foreground', () => {
+    const target = document.createElement('div');
+    target.style.setProperty('--wa-color-text-normal', '#eeeeee');
+    document.body.append(target);
+
+    expect(resolveXtermTheme(target).theme.cursor).toBe('#eeeeee');
+
+    target.style.removeProperty('--wa-color-text-normal');
+    expect(resolveXtermTheme(target).theme.cursor).toBe('#cccccc');
+  });
+
+  it('uses hardcoded fallbacks when surface tokens are unset', () => {
+    const target = document.createElement('div');
+    document.body.append(target);
+
+    const { theme, fontFamily } = resolveXtermTheme(target);
+    expect(theme.background).toBe('#1e1e1e');
+    expect(theme.foreground).toBe('#cccccc');
+    expect(theme.selectionBackground).toBeUndefined();
+    expect(theme.red).toBeUndefined();
+    expect(fontFamily).toBe('monospace');
   });
 });

--- a/src/test-kernel/shared/XtermTheme.vitest.ts
+++ b/src/test-kernel/shared/XtermTheme.vitest.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveXtermTheme } from '@shared/wa/xtermTheme';
+
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+useLitComponentTestDom();
+
+describe('resolveXtermTheme', () => {
+  it('reads tokens from the supplied target and falls cursor back to foreground', () => {
+    const target = document.createElement('div');
+    target.style.setProperty('--wa-color-surface-default', '#111111');
+    target.style.setProperty('--wa-color-text-normal', '#eeeeee');
+    target.style.setProperty('--wa-color-terminal-ansi-red', '#ff0000');
+    target.style.setProperty('--wa-font-family-mono', '"JetBrains Mono"');
+    document.body.append(target);
+
+    const { theme, fontFamily } = resolveXtermTheme(target);
+
+    expect(theme.background).toBe('#111111');
+    expect(theme.foreground).toBe('#eeeeee');
+    expect(theme.cursor).toBe('#eeeeee');
+    expect(theme.red).toBe('#ff0000');
+    expect(fontFamily).toBe('"JetBrains Mono"');
+  });
+});


### PR DESCRIPTION
## Summary

Extension `TerminalOutput` and the desktop interactive terminal each resolved an xterm.js theme from `--wa-*` tokens. That mapping now lives in `resolveXtermTheme(target)` so a token or fallback change cannot drift between hosts.

Review follow-up: the mapping tables and `ResolvedXtermTheme` stay file-local (knip requires a same-PR consumer for new exports). Cursor falls back through `--wa-color-text-normal` before the hardcoded foreground so a host that omits the dedicated cursor token keeps the desktop high-contrast source.

## Issue acceptance gates

- #10243: one shared, host-agnostic helper; each host supplies its DOM target (`this` vs `document.body`).

## Single source of truth

`src/shared/wa/xtermTheme.ts` owns token → xterm theme keys and fallbacks.

## Duplication and abstraction budget

Deleted two local resolvers. One helper, two callers. No xterm import in shared code.

## Net elements (R6)

- Files: +2 (`xtermTheme.ts`, test), 2 edited
- Exports: +`resolveXtermTheme` only
- Deleted: `themeFromTokens`, `resolveTerminalOptions`, local ANSI map

## Consumer counts (R8)

`resolveXtermTheme`: 2 production callers (extension TerminalOutput, desktop terminalPane).

## Host impact

Extension: same token mapping; cursor still prefers `--wa-color-terminal-cursor`.

Desktop: same helper; ANSI colors now resolve when the token sheet defines them. Cursor still reads `--wa-color-terminal-cursor` (maps to FieldText in high-contrast). When that token is unset, fallback is `--wa-color-text-normal` (CanvasText), matching the old desktop resolver.

CLI: none

## Scheduled refactoring

None. Dedicated `--wa-color-terminal-background` / `--wa-color-terminal-foreground` tokens exist on both hosts; switching the resolver to them would change the progress-view palette and is left as a later mapping decision.

## Validation

- `npx vitest run src/test-kernel/shared/XtermTheme.vitest.ts src/test-kernel/progressView/TerminalOutput.vitest.ts` (8 passed)
- `npm run check:dead-code-ratchet` (OK)