### PR TITLE
docs: refresh xAI PRD and pin KaTeX shortcut drift

### DIFF
--- a/docs/prds/2026-08-04-prd-xai-responses-previous-response-id.md
+++ b/docs/prds/2026-08-04-prd-xai-responses-previous-response-id.md
@@ -52,15 +52,15 @@ This PRD sequences a **setting-gated** migration for direct `api.x.ai` Grok mode
 
 ## 3. Current state (TeXRA)
 
-| Layer                   | Today                                                           |
-| ----------------------- | --------------------------------------------------------------- |
-| Endpoint                | `https://api.x.ai/v1`                                           |
-| Handler                 | `ModelHandlerXAI` extends chat-completions `ModelHandlerOpenAI` |
-| Factory                 | `ModelProvider.XAI` → `ModelHandlerXAI` only                    |
-| `shouldUseResponsesAPI` | **OpenAI only**                                                 |
-| Chain                   | None for xAI; OpenAI uses `ServerChainState`                    |
-| Auth                    | API key / server key / OpenRouter / SuperGrok OAuth Bearer      |
-| Catalog                 | `grok-4.5`, `grok-4.3`, retired older; no build/4.20            |
+| Layer                   | Today                                                                                                                                                                                                      |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Endpoint                | `https://api.x.ai/v1`                                                                                                                                                                                      |
+| Handler                 | `ModelHandlerXAI` extends chat-completions `ModelHandlerOpenAI`                                                                                                                                            |
+| Factory                 | `ModelProvider.XAI` → `ModelHandlerXAI` only                                                                                                                                                               |
+| `shouldUseResponsesAPI` | **OpenAI only**                                                                                                                                                                                            |
+| Chain                   | None for xAI; OpenAI uses `ServerChainState`                                                                                                                                                               |
+| Auth                    | API key / server key / OpenRouter / SuperGrok OAuth Bearer                                                                                                                                                 |
+| Catalog                 | llm-zoo 1.27.0: `grok46` (xAI `grok-4.6`), `grok45`, `grok43`, retired older. Not in catalogue: `grok-build-0.1`, `grok-4.20-multi-agent-0309`, `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning` |
 
 OpenAI Responses already provides:
 
@@ -75,7 +75,7 @@ OpenAI Responses already provides:
 
 1. **Preferred long-term path for direct xAI is Responses.** Chat Completions remains a supported fallback, not the destination.
 2. **MVP is chaining + client tools**, not “full xAI agent API.”
-3. **Ship behind a setting first** (mirror `texra.model.useOpenAIResponsesAPI`), default **off**, until soak criteria pass.
+3. **Ship behind a setting first** (mirror `texra.model.useOpenAIResponsesAPI`), default **off**, until soak criteria pass. After soak, flip default **on** in the **next release** (one release behind the flag), not a longer hold: xAI now labels Chat Completions “Deprecated,” so staying on Completions past one soak cycle is the riskier path. The first ship stays default-off so a Responses regression cannot take production Grok traffic without an explicit opt-in.
 4. **Default `store: true`** for xAI (docs default). Rely on `previous_response_id` for continuity; do not invent a second history system.
 5. **OpenRouter keeps Completions** for xAI models.
 6. **Do not enable xAI native server tools in MVP** even if the Responses tools array supports them later.
@@ -227,7 +227,7 @@ Items 1–3 help Completions **and** make Responses land cleaner; none require w
 
 ## 11. Open questions
 
-1. Default-on timeline after soak — one release behind the flag, or longer?
+1. Default-on timeline after soak — **decided 2026-08-14:** one release behind the flag. Completions is now explicitly deprecated on xAI’s comparison page; a longer hold is not justified once soak criteria pass. First ship remains default-off.
 2. Does xAI `/responses/input_tokens` exist and match OpenAI enough to enable token counting?
 3. Does xAI `/responses/compact` match our OpenAI compact client path, or client-only compaction forever?
 4. Is `reasoning_effort` on Responses for grok-4.5 the same as docs’ “4.3 only” note on Chat Completions?
@@ -293,8 +293,10 @@ catalog changes made — recon only**, per the §2 non-goals.
    every OpenAI-compatible handler, `ModelHandlerXAI` included. The only gap
    is the long-context _tier_ switch in point 3, not cache-token extraction.
 
-Candidate next steps, smallest first: (a) refresh §3 for `grok-4.6` and track
-upstream catalogue support for the remaining model IDs, (b) model long-context
-tiered pricing in `computeStandardPrice` once a rate source exists, (c) revisit
+Candidate next steps, smallest first: (a) ~~refresh §3 for `grok-4.6` and track
+upstream catalogue support for the remaining model IDs~~ (done 2026-08-14;
+remaining IDs still wait on llm-zoo), (b) model long-context
+tiered pricing in `computeStandardPrice` once a rate source exists, (c) ~~revisit
 this PRD's default-off timeline given Chat Completions' now-explicit deprecated
-status.
+status~~ (done 2026-08-14: one release behind the flag; see §4 decision 3 and
+§11 Q1).

--- a/src/test-kernel/shared/KatexMacroDrift.vitest.ts
+++ b/src/test-kernel/shared/KatexMacroDrift.vitest.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { MAX_STYLE_REPLACEMENTS } from '@replacement/maxRules';
+import { katexMacros } from '@shared/markdown/katexMacros';
+
+/** Command tokens that max-style replacements introduce (the shortcut side). */
+function maxStyleShortcutTokens(): Set<string> {
+  const tokens = new Set<string>();
+  const command = /\\[A-Za-z][A-Za-z0-9]*/g;
+  for (const destination of Object.values(MAX_STYLE_REPLACEMENTS.patterns)) {
+    for (const match of destination.matchAll(command)) {
+      tokens.add(match[0]);
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Shortcuts that KaTeX renders but max-style replacement does not emit.
+ * Keep this list explicit: a new katex-only key must be added here or
+ * given a max-style destination, so the two tables cannot drift silently.
+ */
+const KATEX_ONLY_SHORTCUTS = [
+  '\\De',
+  '\\bGa',
+  '\\bLa',
+  '\\bal',
+  '\\bbt',
+  '\\bga',
+  '\\bla',
+  '\\bom',
+  '\\bpsi',
+  '\\brho',
+  '\\bta',
+  '\\btau',
+  '\\eZ',
+  '\\tv',
+] as const;
+
+describe('katexMacros vs maxRules shortcuts', () => {
+  it('keeps every KaTeX shortcut key in max-style destinations or the explicit katex-only list', () => {
+    const shortcuts = maxStyleShortcutTokens();
+    const katexKeys = Object.keys(katexMacros);
+    const unexplained = katexKeys
+      .filter(
+        (key) =>
+          !shortcuts.has(key) &&
+          !KATEX_ONLY_SHORTCUTS.includes(
+            key as (typeof KATEX_ONLY_SHORTCUTS)[number],
+          ),
+      )
+      .toSorted();
+    const staleAllowlist = KATEX_ONLY_SHORTCUTS.filter(
+      (key) => !katexKeys.includes(key),
+    );
+
+    expect(unexplained).toEqual([]);
+    expect(staleAllowlist).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Batches three small SSOT follow-ups:

- #10074: §3 catalogue now lists llm-zoo 1.27.0 \`grok46\` (xAI \`grok-4.6\`) and names the IDs still missing from the catalogue.
- #10076: default-on after soak is **one release behind the flag**. First ship stays default-off. Chat Completions is explicitly deprecated, so a longer hold is not justified.
- #10198: a kernel test fails if a new \`katexMacros\` shortcut is neither a max-style replacement destination nor on the explicit katex-only allowlist (14 current extras).

## Issue acceptance gates

- #10074: §3 inventory matches llm-zoo 1.27.0; remaining Grok IDs are tracked as catalogue gaps.
- #10076: §4 decision 3 and §11 Q1 record the one-release-behind default-on decision.
- #10198: adding, renaming, or removing a shortcut on either side fails the test unless the allowlist is updated.

## Single source of truth

- xAI catalogue/timeline: the PRD.
- Shortcut overlap: \`MAX_STYLE_REPLACEMENTS.patterns\` plus the explicit \`KATEX_ONLY_SHORTCUTS\` list in the test.

## Duplication and abstraction budget

No new production abstraction. One test-local allowlist for the known katex-only extras.

## Net elements (R6)

n/a (docs + test)

## Consumer counts (R8)

n/a

## Host impact

Extension / Desktop / CLI: none

## Scheduled refactoring

#10073 still tracks long-context tiered pricing.

## Validation

- \`npx vitest run src/test-kernel/shared/KatexMacroDrift.vitest.ts\` (1 passed)