### PR TITLE
fix(ui): lead picker with Sonnet and collapse new background tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,14 @@ All notable changes to this project will be documented in this file.
 
 - **Lean Project remotes are available after sign-in** — the hosted Lean
   agents no longer need a special access group.
-- **The model picker now starts with Sonnet 5 (Thinking)** — Gemini is no
-  longer the first entry. New installs and chats without a saved picker
-  choice use Sonnet; an already-chosen model is left as-is.
 
 ### Extension (VS Code) and Desktop
 
 #### Features
 
+- **The model picker now starts with Sonnet 5 (Thinking)** — Gemini is no
+  longer the first entry. New installs and chats without a saved picker
+  choice use Sonnet; an already-chosen model is left as-is.
 - **Background tasks start collapsed in Sessions** — a new sub-agent or
   nested run no longer opens the parent row; expand it to inspect children.
 - **Remote agent prompts are available to every signed-in account** — Settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ All notable changes to this project will be documented in this file.
 
 - **Lean Project remotes are available after sign-in** — the hosted Lean
   agents no longer need a special access group.
+- **The model picker now starts with Sonnet 5 (Thinking)** — new chats use
+  that model by default, and Gemini is no longer the first entry.
 
 ### Extension (VS Code) and Desktop
 
 #### Features
 
+- **Background tasks start collapsed in Sessions** — a new sub-agent or
+  nested run no longer opens the parent row; expand it to inspect children.
 - **Remote agent prompts are available to every signed-in account** — Settings
   → Agents no longer hides View prompt behind an Ultra plan, and remote agents
   no longer show a Remote badge or access-group labels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ All notable changes to this project will be documented in this file.
 
 - **Lean Project remotes are available after sign-in** — the hosted Lean
   agents no longer need a special access group.
-- **The model picker now starts with Sonnet 5 (Thinking)** — new chats use
-  that model by default, and Gemini is no longer the first entry.
+- **The model picker now starts with Sonnet 5 (Thinking)** — Gemini is no
+  longer the first entry. New installs and chats without a saved picker
+  choice use Sonnet; an already-chosen model is left as-is.
 
 ### Extension (VS Code) and Desktop
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.
   choice use Sonnet; an already-chosen model is left as-is.
 - **Background tasks start collapsed in Sessions** — a new sub-agent or
   nested run no longer opens the parent row; expand it to inspect children.
+  Selecting a child, or a pending approval on one, still reveals the ancestor
+  path.
 - **Remote agent prompts are available to every signed-in account** — Settings
   → Agents no longer hides View prompt behind an Ultra plan, and remote agents
   no longer show a Remote badge or access-group labels.

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -396,6 +396,8 @@ export class StreamTabs extends LitElement {
   /** Which parent streams have their child list expanded — derived from
    *  inputs + `userOverride` on every reactive update. Not a source of truth. */
   @state() private expandedParents: Set<string> = new Set();
+  /** Self or ancestor of a pending-approval stream — derived with expansion. */
+  private approvalBadgeStreamIds: Set<string> = new Set();
 
   /**
    * Per-parent user intent. Child lists start collapsed; this map records
@@ -405,16 +407,23 @@ export class StreamTabs extends LitElement {
   private userOverride: Map<string, StreamTreeExpansionOverride> = new Map();
 
   protected override willUpdate(changed: PropertyValues): void {
-    if (!changed.has('childStreamsByParent') && !changed.has('streamStates'))
+    if (
+      !changed.has('childStreamsByParent') &&
+      !changed.has('streamStates') &&
+      !changed.has('pendingApprovalStreamIds')
+    ) {
       return;
+    }
 
     const projection = computeStreamTreeProjection({
       streamStates: this.streamStates,
       childStreamsByParent: this.childStreamsByParent,
       userOverrides: this.userOverride,
+      pendingApprovalStreamIds: this.pendingApprovalStreamIds,
     });
 
     this.userOverride = projection.userOverrides;
+    this.approvalBadgeStreamIds = projection.approvalBadgeStreamIds;
     if (!setsEqual(projection.expandedParents, this.expandedParents)) {
       this.expandedParents = projection.expandedParents;
     }
@@ -455,7 +464,7 @@ export class StreamTabs extends LitElement {
         .substate=${streamState?.substate}
         .lastTimestamp=${streamState?.lastTimestamp}
         ?active=${stream.name === this.activeStreamId}
-        .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)}
+        .hasPendingApproval=${this.approvalBadgeStreamIds.has(stream.name)}
         .childCount=${childCount}
         ?expanded=${expanded}
       ></stream-tab>

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -410,7 +410,8 @@ export class StreamTabs extends LitElement {
     if (
       !changed.has('childStreamsByParent') &&
       !changed.has('streamStates') &&
-      !changed.has('pendingApprovalStreamIds')
+      !changed.has('pendingApprovalStreamIds') &&
+      !changed.has('activeStreamId')
     ) {
       return;
     }
@@ -420,6 +421,7 @@ export class StreamTabs extends LitElement {
       childStreamsByParent: this.childStreamsByParent,
       userOverrides: this.userOverride,
       pendingApprovalStreamIds: this.pendingApprovalStreamIds,
+      activeStreamId: this.activeStreamId,
     });
 
     this.userOverride = projection.userOverrides;

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -398,10 +398,9 @@ export class StreamTabs extends LitElement {
   @state() private expandedParents: Set<string> = new Set();
 
   /**
-   * Per-parent user intent that overrides the auto-expand/collapse rules.
-   * Entries live as long as the parent is in `childStreamsByParent`; a new
-   * appearance (new run) starts from auto. One map replaces the former
-   * `manuallyCollapsed` + `finishedCollapseHandled` sets.
+   * Per-parent user intent. Child lists start collapsed; this map records
+   * whether the user has expanded or collapsed a given parent. Entries live
+   * as long as the parent is in `childStreamsByParent`.
    */
   private userOverride: Map<string, StreamTreeExpansionOverride> = new Map();
 

--- a/packages/extension/src/progressView/frontend/streamTree.ts
+++ b/packages/extension/src/progressView/frontend/streamTree.ts
@@ -24,22 +24,31 @@ export function computeStreamTreeProjection(
   inputs: StreamTreeInputs & {
     readonly userOverrides: ReadonlyMap<string, StreamTreeExpansionOverride>;
     readonly pendingApprovalStreamIds?: ReadonlySet<string>;
+    readonly activeStreamId?: string | null;
   },
 ): StreamTreeProjection {
   const userOverrides = pruneStreamTreeUserOverrides(
     inputs.userOverrides,
     inputs.childStreamsByParent,
   );
+  const parentByChild = parentByChildMap(inputs.childStreamsByParent);
   const approvalSignals = collectPendingApprovalSignals(
-    inputs.childStreamsByParent,
+    parentByChild,
     inputs.pendingApprovalStreamIds ?? new Set(),
+  );
+  // Viewing a child (Background-tasks jump, or after an approval clears)
+  // must keep its ancestor path open. Running siblings stay collapsed.
+  const activeAncestors = collectAncestorIds(
+    parentByChild,
+    inputs.activeStreamId,
   );
   const expandedParents = new Set<string>();
 
   for (const parentId of inputs.childStreamsByParent.keys()) {
     if (
       userOverrides.get(parentId) === 'expanded' ||
-      approvalSignals.expandParents.has(parentId)
+      approvalSignals.expandParents.has(parentId) ||
+      activeAncestors.has(parentId)
     ) {
       expandedParents.add(parentId);
     }
@@ -52,32 +61,49 @@ export function computeStreamTreeProjection(
   };
 }
 
-/**
- * A pending approval on a hidden descendant is still blocking. Walk from each
- * pending stream up to the root so ancestors expand and show the same badge
- * the child row would have shown.
- */
-function collectPendingApprovalSignals(
+function parentByChildMap(
   childStreamsByParent: ReadonlyMap<string, readonly StreamTabInfo[]>,
-  pendingApprovalStreamIds: ReadonlySet<string>,
-): { expandParents: Set<string>; badgeStreamIds: Set<string> } {
+): Map<string, string> {
   const parentByChild = new Map<string, string>();
   for (const [parentId, children] of childStreamsByParent) {
     for (const child of children) {
       parentByChild.set(child.name, parentId);
     }
   }
+  return parentByChild;
+}
 
+function collectAncestorIds(
+  parentByChild: ReadonlyMap<string, string>,
+  streamId: string | null | undefined,
+): Set<string> {
+  const ancestors = new Set<string>();
+  if (streamId == null || streamId === '') return ancestors;
+  const seen = new Set<string>();
+  let current = parentByChild.get(streamId);
+  while (current !== undefined && !seen.has(current)) {
+    seen.add(current);
+    ancestors.add(current);
+    current = parentByChild.get(current);
+  }
+  return ancestors;
+}
+
+/**
+ * A pending approval on a hidden descendant is still blocking. Walk from each
+ * pending stream up to the root so ancestors expand and show the same badge
+ * the child row would have shown.
+ */
+function collectPendingApprovalSignals(
+  parentByChild: ReadonlyMap<string, string>,
+  pendingApprovalStreamIds: ReadonlySet<string>,
+): { expandParents: Set<string>; badgeStreamIds: Set<string> } {
   const expandParents = new Set<string>();
   const badgeStreamIds = new Set(pendingApprovalStreamIds);
   for (const pendingId of pendingApprovalStreamIds) {
-    const seen = new Set<string>();
-    let current = parentByChild.get(pendingId);
-    while (current !== undefined && !seen.has(current)) {
-      seen.add(current);
-      expandParents.add(current);
-      badgeStreamIds.add(current);
-      current = parentByChild.get(current);
+    for (const ancestor of collectAncestorIds(parentByChild, pendingId)) {
+      expandParents.add(ancestor);
+      badgeStreamIds.add(ancestor);
     }
   }
   return { expandParents, badgeStreamIds };

--- a/packages/extension/src/progressView/frontend/streamTree.ts
+++ b/packages/extension/src/progressView/frontend/streamTree.ts
@@ -16,41 +16,71 @@ interface StreamTreeInputs {
 
 export interface StreamTreeProjection {
   readonly expandedParents: Set<string>;
-  readonly branchActivityByStream: Map<StreamTabId, StreamBranchActivity>;
+  readonly approvalBadgeStreamIds: Set<string>;
   readonly userOverrides: Map<string, StreamTreeExpansionOverride>;
 }
 
 export function computeStreamTreeProjection(
   inputs: StreamTreeInputs & {
     readonly userOverrides: ReadonlyMap<string, StreamTreeExpansionOverride>;
+    readonly pendingApprovalStreamIds?: ReadonlySet<string>;
   },
 ): StreamTreeProjection {
-  const branchActivityByStream = new Map<StreamTabId, StreamBranchActivity>();
   const userOverrides = pruneStreamTreeUserOverrides(
     inputs.userOverrides,
     inputs.childStreamsByParent,
   );
+  const approvalSignals = collectPendingApprovalSignals(
+    inputs.childStreamsByParent,
+    inputs.pendingApprovalStreamIds ?? new Set(),
+  );
   const expandedParents = new Set<string>();
 
-  for (const [parentId, children] of inputs.childStreamsByParent) {
-    for (const child of children) {
-      getStreamBranchActivity(
-        inputs,
-        child.name,
-        new Set([parentId]),
-        branchActivityByStream,
-      );
-    }
-    if (userOverrides.get(parentId) === 'expanded') {
+  for (const parentId of inputs.childStreamsByParent.keys()) {
+    if (
+      userOverrides.get(parentId) === 'expanded' ||
+      approvalSignals.expandParents.has(parentId)
+    ) {
       expandedParents.add(parentId);
     }
   }
 
   return {
     expandedParents,
-    branchActivityByStream,
+    approvalBadgeStreamIds: approvalSignals.badgeStreamIds,
     userOverrides,
   };
+}
+
+/**
+ * A pending approval on a hidden descendant is still blocking. Walk from each
+ * pending stream up to the root so ancestors expand and show the same badge
+ * the child row would have shown.
+ */
+function collectPendingApprovalSignals(
+  childStreamsByParent: ReadonlyMap<string, readonly StreamTabInfo[]>,
+  pendingApprovalStreamIds: ReadonlySet<string>,
+): { expandParents: Set<string>; badgeStreamIds: Set<string> } {
+  const parentByChild = new Map<string, string>();
+  for (const [parentId, children] of childStreamsByParent) {
+    for (const child of children) {
+      parentByChild.set(child.name, parentId);
+    }
+  }
+
+  const expandParents = new Set<string>();
+  const badgeStreamIds = new Set(pendingApprovalStreamIds);
+  for (const pendingId of pendingApprovalStreamIds) {
+    const seen = new Set<string>();
+    let current = parentByChild.get(pendingId);
+    while (current !== undefined && !seen.has(current)) {
+      seen.add(current);
+      expandParents.add(current);
+      badgeStreamIds.add(current);
+      current = parentByChild.get(current);
+    }
+  }
+  return { expandParents, badgeStreamIds };
 }
 
 function pruneStreamTreeUserOverrides(

--- a/packages/extension/src/progressView/frontend/streamTree.ts
+++ b/packages/extension/src/progressView/frontend/streamTree.ts
@@ -33,15 +33,15 @@ export function computeStreamTreeProjection(
   const expandedParents = new Set<string>();
 
   for (const [parentId, children] of inputs.childStreamsByParent) {
-    if (
-      shouldExpandStreamParent(
+    for (const child of children) {
+      getStreamBranchActivity(
         inputs,
-        parentId,
-        children,
-        userOverrides,
+        child.name,
+        new Set([parentId]),
         branchActivityByStream,
-      )
-    ) {
+      );
+    }
+    if (userOverrides.get(parentId) === 'expanded') {
       expandedParents.add(parentId);
     }
   }
@@ -66,8 +66,8 @@ function pruneStreamTreeUserOverrides(
 
 /**
  * Classify an entire child branch, not just the direct row. Absent entries in
- * `streamStates` are `unknown` so expansion can wait for a real lifecycle
- * signal instead of immediately treating a new child as finished.
+ * `streamStates` are `unknown` so a brand-new child is not treated as
+ * finished before it reports a lifecycle signal.
  */
 export function getStreamBranchActivity(
   inputs: StreamTreeInputs,
@@ -110,27 +110,6 @@ export function getStreamBranchActivity(
   const activity = anyUnknown ? 'unknown' : 'finished';
   cache.set(streamId, activity);
   return activity;
-}
-
-function shouldExpandStreamParent(
-  inputs: StreamTreeInputs,
-  parentId: string,
-  children: readonly StreamTabInfo[],
-  userOverrides: ReadonlyMap<string, StreamTreeExpansionOverride>,
-  cache: Map<StreamTabId, StreamBranchActivity>,
-): boolean {
-  const override = userOverrides.get(parentId);
-  if (override) return override === 'expanded';
-
-  return children.some(
-    (child) =>
-      getStreamBranchActivity(
-        inputs,
-        child.name,
-        new Set([parentId]),
-        cache,
-      ) !== 'finished',
-  );
 }
 
 function classifyStreamActivity(

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -82,15 +82,32 @@ function reconcileEnabledModels(
   // resolveDefaultModels (modelOptionsBasic.ts) drops retired/deprecated
   // picks before this module ever sees them -- so the only remaining check
   // here is "not already present".
+  const keptSet = new Set(kept);
   const added = addDefaults
-    ? DEFAULT_MODELS.filter((model) => !kept.includes(model))
+    ? DEFAULT_MODELS.filter((model) => !keptSet.has(model))
     : [];
+  // Preferred defaults keep their curated order in the picker. User-enabled
+  // extras stay after that block so a stale Gemini-first list cannot keep
+  // leading once Sonnet is the default.
+  const defaultOrdered = DEFAULT_MODELS.filter(
+    (model) => keptSet.has(model) || added.includes(model),
+  );
+  const extras = kept.filter((model) => !DEFAULT_MODELS.includes(model));
 
   return {
-    models: [...kept, ...added],
+    models: [...defaultOrdered, ...extras],
     added,
     removed: [...strippedSet],
   };
+}
+
+function sameModelList(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length && left.every((model, i) => model === right[i])
+  );
 }
 
 /** Sweep retired entries and reconcile defaults when MODEL_LIST_VERSION changes. */
@@ -102,6 +119,7 @@ export async function refreshModelListStateIfNeeded(
   const currentModels = state.get<string[]>(GlobalStateKey.ENABLED_MODELS);
   let added: string[] = [];
   let removed: string[] = [];
+  let reordered = false;
   if (currentModels) {
     const reconciliation = reconcileEnabledModels(
       currentModels,
@@ -110,7 +128,8 @@ export async function refreshModelListStateIfNeeded(
     );
     added = reconciliation.added;
     removed = reconciliation.removed;
-    if (added.length > 0 || removed.length > 0) {
+    reordered = !sameModelList(currentModels, reconciliation.models);
+    if (added.length > 0 || removed.length > 0 || reordered) {
       await state.update(GlobalStateKey.ENABLED_MODELS, reconciliation.models);
     }
   }
@@ -119,7 +138,11 @@ export async function refreshModelListStateIfNeeded(
     await state.update(GlobalStateKey.MODEL_LIST_VERSION, MODEL_LIST_VERSION);
   }
   return {
-    skipped: !versionChanged && removed.length === 0,
+    skipped:
+      !versionChanged &&
+      added.length === 0 &&
+      removed.length === 0 &&
+      !reordered,
     previousVersion,
     currentVersion: MODEL_LIST_VERSION,
     added,

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -34,14 +34,16 @@ export function isRetiredModel(model: string): boolean {
  * includes this membership and each preferred pick's lifecycle status.
  */
 export const PREFERRED_DEFAULT_MODELS: readonly string[] = [
-  'gemini36f',
-  'gemini31p',
+  // First entry is the picker / new-chat default (`DEFAULT_AGENT_MODEL`).
+  // Do not lead with Gemini — Sonnet is the quality default.
   'sonnet5T',
   'opus5T',
   'fable5',
   'gpt56',
   'gpt56-',
   'gpt56--',
+  'gemini36f',
+  'gemini31p',
   'deepseekT',
   'deepseekproT',
   'kimi26T',

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -285,8 +285,10 @@ export const DEFAULT_HELPER_MODEL = 'deepseek';
  * truth shared by the agent config schema (`@agent/core/definition/AgentConfig`),
  * the main-view persisted state, and the progress-view proposal reconstruction —
  * so a change here propagates to all three instead of drifting per call site.
+ * Keep this aligned with the first default-list entry — the picker leads
+ * with that model, and it must not be a Gemini id.
  */
-export const DEFAULT_AGENT_MODEL = 'gemini35f';
+export const DEFAULT_AGENT_MODEL = 'sonnet5T';
 
 /**
  * Zod schema for a boolean setting surfaced per provider (without runtime value).

--- a/src/test-kernel/model/ModelListRefresh.vitest.ts
+++ b/src/test-kernel/model/ModelListRefresh.vitest.ts
@@ -74,6 +74,18 @@ describe('refreshModelListStateIfNeeded', () => {
     expect(result.removed).toContain('grok4');
     expect(enabledModels(state)).not.toContain('grok4');
   });
+
+  it('restabilizes a Gemini-first list so the curated default leads', async () => {
+    const state = new FakeStateStore({
+      [GlobalStateKey.MODEL_LIST_VERSION]: MODEL_LIST_VERSION,
+      [GlobalStateKey.ENABLED_MODELS]: ['gemini31p', 'sonnet5T', 'custom'],
+    });
+
+    const result = await refreshModelListStateIfNeeded(state);
+
+    expect(result.skipped).toBe(false);
+    expect(enabledModels(state)).toEqual(['sonnet5T', 'gemini31p', 'custom']);
+  });
 });
 
 /**

--- a/src/test-kernel/model/ModelOptionsBasic.vitest.ts
+++ b/src/test-kernel/model/ModelOptionsBasic.vitest.ts
@@ -12,7 +12,10 @@ import {
   PREFERRED_DEFAULT_MODELS,
   resolveDefaultModels,
 } from '@model/modelOptionsBasic';
-import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
+import {
+  DEFAULT_AGENT_MODEL,
+  DEFAULT_HELPER_MODEL,
+} from '@shared/constants/providers';
 
 describe('default helper model', () => {
   it('resolves to a valid, non-deprecated DeepSeek model in llm-zoo', () => {
@@ -21,6 +24,18 @@ describe('default helper model', () => {
     expect(config).toBeDefined();
     expect(config.provider).toBe('deepseek');
     expect(config.deprecated ?? false).toBe(false);
+  });
+});
+
+describe('default agent model', () => {
+  it('is the first default-list entry and is not a Gemini model', () => {
+    const config = MODEL_CONFIGS[DEFAULT_AGENT_MODEL];
+
+    expect(DEFAULT_AGENT_MODEL).toBe(DEFAULT_MODELS[0]);
+    expect(DEFAULT_AGENT_MODEL.startsWith('gemini')).toBe(false);
+    expect(config).toBeDefined();
+    expect(config.deprecated ?? false).toBe(false);
+    expect(config.retired ?? false).toBe(false);
   });
 });
 

--- a/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.ts
+++ b/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.ts
@@ -67,17 +67,13 @@ describe('stream-tab expand chevron', () => {
     expect(expandButton?.tagName).toBe('WA-BUTTON');
     expect(expandButton?.getAttribute('data-stream')).toBe('parent');
     expect(expandButton?.getAttribute('data-action')).toBe('toggle-children');
-    expect(expandButton?.hasAttribute('aria-expanded')).toBe(true);
-    const expectedLabel =
-      expandButton?.getAttribute('aria-expanded') === 'true'
-        ? 'Collapse background tasks'
-        : '1 background task';
-    expect(expandButton?.getAttribute('aria-label')).toBe(expectedLabel);
+    expect(expandButton?.getAttribute('aria-expanded')).toBe('false');
+    expect(expandButton?.getAttribute('aria-label')).toBe('1 background task');
     expect(
       parentTab?.shadowRoot
         ?.querySelector('wa-tooltip[for="stream-tab-expand-button"]')
         ?.textContent?.trim(),
-    ).toBe(expectedLabel);
+    ).toBe('1 background task');
   });
 
   it('identifies an unlabeled stream by name in the select aria-label', async () => {

--- a/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.ts
+++ b/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.ts
@@ -76,6 +76,27 @@ describe('stream-tab expand chevron', () => {
     ).toBe('1 background task');
   });
 
+  it('expands ancestors when a child stream is the active session', async () => {
+    const tabs = await mountTabs({
+      streams: [makeStream('parent')],
+      childStreamsByParent: new Map([['parent', [makeStream('child')]]]),
+    });
+    const parentTab = tabs.shadowRoot?.querySelector('stream-tab');
+    const expandButton = parentTab?.shadowRoot?.querySelector('.tab-expand');
+    expect(expandButton?.getAttribute('aria-expanded')).toBe('false');
+
+    tabs.activeStreamId = 'child';
+    await tabs.updateComplete;
+    await settleChildRender();
+
+    expect(
+      parentTab?.shadowRoot
+        ?.querySelector('.tab-expand')
+        ?.getAttribute('aria-expanded'),
+    ).toBe('true');
+    expect(tabs.shadowRoot?.querySelectorAll('stream-tab')).toHaveLength(2);
+  });
+
   it('identifies an unlabeled stream by name in the select aria-label', async () => {
     const tabs = await mountTabs({
       streams: [{ ...makeStream('unlabeled-stream'), label: '' }],

--- a/src/test-kernel/progressView/StreamTabsStatus.vitest.ts
+++ b/src/test-kernel/progressView/StreamTabsStatus.vitest.ts
@@ -274,6 +274,37 @@ describe('stream-tab lifecycle distinction', () => {
     expect(compactStyles).toContain('max-width: none');
   });
 
+  it('surfaces a descendant approval on the compact parent row', async () => {
+    const tabs = await mountComponent<StreamTabs>('stream-tabs', {
+      streams: [stream('parent')],
+      streamStates: new Map([['parent', streamState(STREAM_PHASE.RUNNING)]]),
+      pendingApprovalStreamIds: new Set(['child']),
+      childStreamsByParent: new Map([
+        ['parent', [{ ...stream('child'), parentStreamId: 'parent' }]],
+      ]),
+      compact: true,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const row = tabs.shadowRoot?.querySelector('stream-tab');
+
+    expect(
+      row?.shadowRoot
+        ?.querySelector('.tab-container')
+        ?.classList.contains('has-pending-approval'),
+    ).toBe(true);
+    expect(
+      (
+        row?.shadowRoot?.querySelector('.tab-status-icon') as
+          (Element & { name?: string }) | null
+      )?.name,
+    ).toBe('triangle-exclamation');
+    expect(
+      row?.shadowRoot
+        ?.querySelector('#stream-tab-select-button')
+        ?.getAttribute('aria-label'),
+    ).toContain('Status: Approval required');
+  });
+
   it('keeps selection primary while retaining the accessible lifecycle label', async () => {
     const tabs = await mountTabs(
       [stream('selected-running'), stream('selected-stopped')],

--- a/src/test-kernel/progressView/StreamTree.vitest.ts
+++ b/src/test-kernel/progressView/StreamTree.vitest.ts
@@ -45,12 +45,12 @@ function project(
 }
 
 describe('progress stream tree policy', () => {
-  it('keeps a parent expanded while a child has not reported status yet', () => {
+  it('starts a parent collapsed while a child has not reported status yet', () => {
     const childStreamsByParent = new Map([['root', [stream('child', 'root')]]]);
 
     const projection = project(childStreamsByParent);
 
-    assert.equal(projection.expandedParents.has('root'), true);
+    assert.equal(projection.expandedParents.has('root'), false);
     assert.equal(
       getStreamBranchActivity(
         { streamStates: new Map(), childStreamsByParent },
@@ -76,7 +76,7 @@ describe('progress stream tree policy', () => {
     assert.equal(projection.branchActivityByStream.get('child-b'), 'finished');
   });
 
-  it('expands ancestors when a descendant is active', () => {
+  it('keeps ancestors collapsed when a descendant is active', () => {
     const childStreamsByParent = new Map([
       ['root', [stream('child', 'root')]],
       ['child', [stream('grandchild', 'child')]],
@@ -88,8 +88,8 @@ describe('progress stream tree policy', () => {
 
     const projection = project(childStreamsByParent, streamStates);
 
-    assert.equal(projection.expandedParents.has('root'), true);
-    assert.equal(projection.expandedParents.has('child'), true);
+    assert.equal(projection.expandedParents.has('root'), false);
+    assert.equal(projection.expandedParents.has('child'), false);
     assert.equal(projection.branchActivityByStream.get('child'), 'active');
     assert.equal(projection.branchActivityByStream.get('grandchild'), 'active');
   });

--- a/src/test-kernel/progressView/StreamTree.vitest.ts
+++ b/src/test-kernel/progressView/StreamTree.vitest.ts
@@ -37,12 +37,14 @@ function project(
   streamStates: Map<string, StreamState> = new Map(),
   userOverrides: Map<string, StreamTreeExpansionOverride> = new Map(),
   pendingApprovalStreamIds: ReadonlySet<string> = new Set(),
+  activeStreamId: string | null = null,
 ): StreamTreeProjection {
   return computeStreamTreeProjection({
     streamStates,
     childStreamsByParent,
     userOverrides,
     pendingApprovalStreamIds,
+    activeStreamId,
   });
 }
 
@@ -169,6 +171,26 @@ describe('progress stream tree policy', () => {
     assert.equal(projection.approvalBadgeStreamIds.has('root'), true);
     assert.equal(projection.approvalBadgeStreamIds.has('child'), true);
     assert.equal(projection.approvalBadgeStreamIds.has('grandchild'), true);
+  });
+
+  it('expands ancestors of the viewed stream without opening sibling branches', () => {
+    const childStreamsByParent = new Map([
+      ['root', [stream('child', 'root'), stream('other', 'root')]],
+      ['child', [stream('grandchild', 'child')]],
+      ['other', [stream('other-child', 'other')]],
+    ]);
+
+    const projection = project(
+      childStreamsByParent,
+      new Map(),
+      new Map(),
+      new Set(),
+      'grandchild',
+    );
+
+    assert.equal(projection.expandedParents.has('root'), true);
+    assert.equal(projection.expandedParents.has('child'), true);
+    assert.equal(projection.expandedParents.has('other'), false);
   });
 
   it('guards cycles while preserving the stream own activity', () => {

--- a/src/test-kernel/progressView/StreamTree.vitest.ts
+++ b/src/test-kernel/progressView/StreamTree.vitest.ts
@@ -183,7 +183,7 @@ describe('progress stream tree policy', () => {
     const projection = project(
       childStreamsByParent,
       new Map(),
-      new Map(),
+      new Map([['root', 'collapsed']]),
       new Set(),
       'grandchild',
     );
@@ -191,6 +191,21 @@ describe('progress stream tree policy', () => {
     assert.equal(projection.expandedParents.has('root'), true);
     assert.equal(projection.expandedParents.has('child'), true);
     assert.equal(projection.expandedParents.has('other'), false);
+    assert.equal(projection.approvalBadgeStreamIds.size, 0);
+  });
+
+  it('does not expand a parent just because it is the active stream', () => {
+    const childStreamsByParent = new Map([['root', [stream('child', 'root')]]]);
+
+    const projection = project(
+      childStreamsByParent,
+      new Map([['child', streamState(STREAM_STATUS.RUNNING)]]),
+      new Map(),
+      new Set(),
+      'root',
+    );
+
+    assert.equal(projection.expandedParents.has('root'), false);
   });
 
   it('guards cycles while preserving the stream own activity', () => {

--- a/src/test-kernel/progressView/StreamTree.vitest.ts
+++ b/src/test-kernel/progressView/StreamTree.vitest.ts
@@ -36,11 +36,13 @@ function project(
   childStreamsByParent: Map<string, StreamTabInfo[]>,
   streamStates: Map<string, StreamState> = new Map(),
   userOverrides: Map<string, StreamTreeExpansionOverride> = new Map(),
+  pendingApprovalStreamIds: ReadonlySet<string> = new Set(),
 ): StreamTreeProjection {
   return computeStreamTreeProjection({
     streamStates,
     childStreamsByParent,
     userOverrides,
+    pendingApprovalStreamIds,
   });
 }
 
@@ -72,8 +74,20 @@ describe('progress stream tree policy', () => {
     const projection = project(childStreamsByParent, streamStates);
 
     assert.equal(projection.expandedParents.has('root'), false);
-    assert.equal(projection.branchActivityByStream.get('child-a'), 'finished');
-    assert.equal(projection.branchActivityByStream.get('child-b'), 'finished');
+    assert.equal(
+      getStreamBranchActivity(
+        { streamStates, childStreamsByParent },
+        'child-a',
+      ),
+      'finished',
+    );
+    assert.equal(
+      getStreamBranchActivity(
+        { streamStates, childStreamsByParent },
+        'child-b',
+      ),
+      'finished',
+    );
   });
 
   it('keeps ancestors collapsed when a descendant is active', () => {
@@ -90,8 +104,17 @@ describe('progress stream tree policy', () => {
 
     assert.equal(projection.expandedParents.has('root'), false);
     assert.equal(projection.expandedParents.has('child'), false);
-    assert.equal(projection.branchActivityByStream.get('child'), 'active');
-    assert.equal(projection.branchActivityByStream.get('grandchild'), 'active');
+    assert.equal(
+      getStreamBranchActivity({ streamStates, childStreamsByParent }, 'child'),
+      'active',
+    );
+    assert.equal(
+      getStreamBranchActivity(
+        { streamStates, childStreamsByParent },
+        'grandchild',
+      ),
+      'active',
+    );
   });
 
   it('honors user overrides and drops overrides for missing parents', () => {
@@ -126,6 +149,26 @@ describe('progress stream tree policy', () => {
     );
 
     assert.equal(projection.expandedParents.has('root'), true);
+  });
+
+  it('expands and badges ancestors when a descendant needs approval', () => {
+    const childStreamsByParent = new Map([
+      ['root', [stream('child', 'root')]],
+      ['child', [stream('grandchild', 'child')]],
+    ]);
+
+    const projection = project(
+      childStreamsByParent,
+      new Map(),
+      new Map([['root', 'collapsed']]),
+      new Set(['grandchild']),
+    );
+
+    assert.equal(projection.expandedParents.has('root'), true);
+    assert.equal(projection.expandedParents.has('child'), true);
+    assert.equal(projection.approvalBadgeStreamIds.has('root'), true);
+    assert.equal(projection.approvalBadgeStreamIds.has('child'), true);
+    assert.equal(projection.approvalBadgeStreamIds.has('grandchild'), true);
   });
 
   it('guards cycles while preserving the stream own activity', () => {


### PR DESCRIPTION
## Summary

Two small default-behavior fixes in the main UI:

- The model picker and new-chat default now lead with **Sonnet 5 (Thinking)** instead of Gemini. The previous default was the deprecated Gemini 3.5 Flash id; existing enabled-model lists are reordered on next launch so a stale Gemini-first order cannot keep winning.
- New sub-agent and nested-run rows in Sessions **start collapsed**. A busy orchestrator no longer auto-opens the parent row when a child starts; expand it to inspect children.

## Issue acceptance gates

No linked issue. Requested from the running UI: Gemini should not be first in the picker, and sub-agent streams should start collapsed.

## Single source of truth

- Picker / new-chat default: `DEFAULT_AGENT_MODEL` (`src/shared/constants/providers.ts`) aligned with the first `PREFERRED_DEFAULT_MODELS` entry (`src/model/modelOptionsBasic.ts`).
- Enabled-list order: `reconcileEnabledModels` in `src/model/modelListRefresh.ts`.
- Sessions expand/collapse: `computeStreamTreeProjection` in `packages/extension/src/progressView/frontend/streamTree.ts`. Child lists expand only when the user has expanded them.

## Duplication and abstraction budget

No new abstraction. Deleted the auto-expand helper `shouldExpandStreamParent`; expansion is now the user-override check. Reorder uses the existing reconcile path rather than a one-off migration.

## Net elements (R6)

n/a — not a refactor/simplify/consolidate PR.

## Consumer counts (R8)

n/a — no emit path or export was deleted. `getStreamBranchActivity` remains and still feeds the projection's activity map.

## Host impact

Extension: model picker default, Sessions tree default.

Desktop: same shared defaults (picker + Sessions).

CLI: unchanged. CLI already uses `deepseekproT` as its builtin default and already keeps the child list collapsed until focus.

## Scheduled refactoring

None.

## Validation

- `npx vitest run` on `ModelOptionsBasic`, `ModelListRefresh`, `helperModelName`, `SetupLaunch`, `ParseDelegationToolInput`, `traceViewerSchema`, `SettingsModelSelectionController`, `SettingsViewHost`, the rest of `src/test-kernel/model/`, `StreamTree`, `StreamTabsExpandChevron`, and `StreamTabsStatus`.
- `npx eslint` on the edited TypeScript files.
- Not verified in a running extension/desktop session.