### PR TITLE
fix(model): scope duplex default to stream bodies

### DIFF
--- a/src/platform/defaults/longRunningModelTransport.ts
+++ b/src/platform/defaults/longRunningModelTransport.ts
@@ -16,9 +16,14 @@ async function normalizeModelRequest(
   input: RequestInfo | URL,
   init?: RequestInit,
 ): Promise<[UndiciRequestInfo, UndiciRequestInit]> {
-  // Node/undici require duplex for any non-null body; SDKs omit it inconsistently.
+  // Only ReadableStream bodies require the WHATWG `duplex` hint. String,
+  // FormData, and ArrayBuffer bodies must stay free of it; undici tolerates the
+  // field on non-stream bodies today, but the Fetch spec does not.
   const requestInit = { ...(init ?? {}) } as UndiciRequestInit;
-  if (requestInit.body != null && requestInit.duplex == null) {
+  if (
+    requestInit.body instanceof ReadableStream &&
+    requestInit.duplex == null
+  ) {
     requestInit.duplex = 'half';
   }
   if (!(input instanceof Request)) {
@@ -55,9 +60,7 @@ async function normalizeModelRequest(
       headers: Object.fromEntries(request.headers.entries()),
       redirect: request.redirect,
       signal: request.signal,
-      ...(body === undefined
-        ? {}
-        : { body, duplex: requestInit.duplex ?? 'half' }),
+      ...(body === undefined ? {} : { body }),
     },
   ];
 }

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -73,7 +73,7 @@ describe('long-running model transport', () => {
     expect(new TextDecoder().decode(init?.body as ArrayBuffer)).toBe(
       JSON.stringify({ prompt: 'hello' }),
     );
-    expect(init?.duplex).toBe('half');
+    expect(init?.duplex).toBeUndefined();
     stub.composed?.dispatch(
       { method: 'GET', origin: 'https://example.test', path: '/' },
       {} as never,


### PR DESCRIPTION
## Summary

Scopes the `duplex: 'half'` default in `normalizeModelRequest` to `ReadableStream` bodies only. String, `FormData`, and `ArrayBuffer` bodies stay byte-identical to their pre-#10246 shape, and the native-`Request` rebuild branch no longer attaches a never-needed `duplex` fallback.

## Issue acceptance gates

- #10263: the guard is `body instanceof ReadableStream && duplex == null`; the ArrayBuffer rebuild path drops `duplex`; the string-body test asserts `duplex` is undefined.

## Single source of truth

`normalizeModelRequest` remains the single request-shape normalization boundary.

## Duplication and abstraction budget

No new abstraction.

## Net elements (R6)

n/a (fix)

## Consumer counts (R8)

n/a

## Host impact

Extension: none

Desktop: none

CLI: none (shared model transport)

## Scheduled refactoring

None

## Validation

- `npx vitest run src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts` passed (4 tests)
- Full CI runs on this PR
