### PR TITLE
refactor(test): 128-agent simplification sweep — 88 files, net -231 LOC

### DIFF
--- a/src/test-kernel/agent/AgentDirectoryService.vitest.ts
+++ b/src/test-kernel/agent/AgentDirectoryService.vitest.ts
@@ -17,7 +17,7 @@ import type {
 const STORAGE_BASE_PATH = path.resolve('/global-storage');
 const VALID_PARENT_PATH = path.resolve('/valid-parent');
 const VALID_CUSTOM_PATH = path.join(VALID_PARENT_PATH, 'custom');
-const MISSING_CUSTOM_PATH = path.join(path.resolve('/missing'), 'custom');
+const MISSING_CUSTOM_PATH = path.join('/missing', 'custom');
 
 class RecordingStorage implements AgentDirectoryPathStorage {
   readonly ensured: string[] = [];

--- a/src/test-kernel/agent/AgentPromptContracts.vitest.ts
+++ b/src/test-kernel/agent/AgentPromptContracts.vitest.ts
@@ -619,6 +619,7 @@ describe('progress-check agent prompts', () => {
   const progressCheck = loadAgentYaml<ToolUseAgentYaml>(
     'prompts/agents/remote/progressCheck.yaml',
   );
+  const { systemPrompt } = progressCheck.prompts;
   const orchestrator = loadAgentYaml<ToolUseAgentYaml>(
     'prompts/agents/remote/orchestrator.yaml',
   );
@@ -627,19 +628,19 @@ describe('progress-check agent prompts', () => {
   );
 
   it('keeps self-contained read-only reviews on the narrow evidence path', () => {
-    expect(progressCheck.prompts.systemPrompt).toContain(
+    expect(systemPrompt).toContain(
       'This narrow path takes precedence even when the session is part of a standing project goal.',
     );
-    expect(progressCheck.prompts.systemPrompt).toContain(
+    expect(systemPrompt).toContain(
       'On the narrow path, evaluate only signals stated in the named execution reports.',
     );
-    expect(progressCheck.prompts.systemPrompt).toContain(
+    expect(systemPrompt).toContain(
       'On the narrow path, evaluate only the named reports and explicitly named files.',
     );
-    expect(progressCheck.prompts.systemPrompt).toContain(
+    expect(systemPrompt).toContain(
       'Otherwise, continue with the broader checks below',
     );
-    expect(progressCheck.prompts.systemPrompt).toContain(
+    expect(systemPrompt).toContain(
       'Do not call `/executions/current`, list sibling executions, or inspect unnamed reports.',
     );
   });

--- a/src/test-kernel/agent/GoalContinuation.vitest.ts
+++ b/src/test-kernel/agent/GoalContinuation.vitest.ts
@@ -3,7 +3,7 @@ import '@test/support/defaultSessionTestSetup';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { maybeBuildGoalContinuation } from '@agent/goal/maybeBuildGoalContinuation';
-import { platform, type Platform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import type { StreamTabId } from '@shared/schemas';
 import { GOAL_FEATURE_FLAG_KEY } from '@shared/schemas/goal';
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
@@ -14,9 +14,8 @@ const STREAM_ID = 'stream:goal-cont' as StreamTabId;
 
 async function installPlatformWithConfig(
   config: Record<string, unknown>,
-): Promise<Platform> {
+): Promise<void> {
   await installFakePlatform({ config });
-  return platform();
 }
 
 describe('isGoalEnabled', () => {

--- a/src/test-kernel/agent/PocketFlowNode.vitest.ts
+++ b/src/test-kernel/agent/PocketFlowNode.vitest.ts
@@ -168,12 +168,7 @@ describe('Node manual retry', () => {
   it('returns success from the single approved attempt', async () => {
     const node = new ScriptedRetryNode(
       3,
-      [
-        new Error('failure 1'),
-        new Error('failure 2'),
-        new Error('failure 3'),
-        'completed',
-      ],
+      [...failureSequence(3), 'completed'],
       [true],
     );
 

--- a/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
+++ b/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
@@ -61,6 +61,16 @@ function executionMeta(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function registrationArgs(
+  executionId: ExecutionId,
+): Parameters<typeof registerExecution>[3] {
+  return {
+    streamId: `chat@deepseekT#${executionId}` as StreamTabId,
+    identity: { kind: 'agent', agent: 'chat' },
+    userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
+  };
+}
+
 describe('execution lifecycle', () => {
   setupPlatform({ workspacePath: '/workspace/root' });
 
@@ -84,11 +94,12 @@ describe('execution lifecycle', () => {
 
   it('pins the active workspace path when a config has no working directory', async () => {
     const executionId = 'abc123' as ExecutionId;
-    await registerExecution(executionId, baseConfig, 'chat', {
-      streamId: 'chat@deepseekT#abc123' as StreamTabId,
-      identity: { kind: 'agent', agent: 'chat' },
-      userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
-    });
+    await registerExecution(
+      executionId,
+      baseConfig,
+      'chat',
+      registrationArgs(executionId),
+    );
 
     expect(mocks.writeRunRecord).toHaveBeenCalledWith({
       ...baseConfig,
@@ -117,11 +128,7 @@ describe('execution lifecycle', () => {
       executionId,
       { ...baseConfig, workingDirectory },
       'chat',
-      {
-        streamId: 'chat@deepseekT#workspace-whitespace' as StreamTabId,
-        identity: { kind: 'agent', agent: 'chat' },
-        userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
-      },
+      registrationArgs(executionId),
     );
 
     expect(mocks.writeRunRecord).toHaveBeenCalledWith({
@@ -152,11 +159,12 @@ describe('execution lifecycle', () => {
     fail();
 
     await expect(
-      registerExecution(executionId, baseConfig, 'chat', {
-        streamId: 'chat@deepseekT#abc124' as StreamTabId,
-        identity: { kind: 'agent', agent: 'chat' },
-        userFollowUpSupport: USER_FOLLOW_UP_SUPPORT.NATIVE_INTERACTIVE,
-      }),
+      registerExecution(
+        executionId,
+        baseConfig,
+        'chat',
+        registrationArgs(executionId),
+      ),
     ).rejects.toThrow(error);
 
     await expect(inspectExecutionLease(executionId)).resolves.toEqual({

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -66,6 +66,18 @@ const WORKFLOW_CONFIG: AgentConfig = {
   ...CONFIG,
   agentCategory: AgentCategory.Workflow,
 };
+
+function structuredOutputConfig(): AgentConfig {
+  return AgentConfigSchema.parse({
+    ...CONFIG,
+    outputSchema: {
+      type: 'object',
+      properties: { answer: { type: 'string' } },
+      required: ['answer'],
+    },
+  });
+}
+
 const TOOL_USE_SETTING = AgentToolUseSettingSchema.parse({});
 const TOOL_USE_PROMPT = AgentPromptSchema.parse({});
 const ACTIVE_COMPATIBILITY_KEY = 'ModelHandlerOpenAIResponse';
@@ -773,14 +785,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const executionId = 'abc-flow-terminal-tool-response' as ExecutionId;
     const streamId =
       'chat@gpt54#abc-flow-terminal-tool-response' as StreamTabId;
-    const config = AgentConfigSchema.parse({
-      ...CONFIG,
-      outputSchema: {
-        type: 'object',
-        properties: { answer: { type: 'string' } },
-        required: ['answer'],
-      },
-    });
+    const config = structuredOutputConfig();
 
     const result = await runPersistedFlow(executionId, streamId, undefined, {
       config,
@@ -1094,14 +1099,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       'chat@gpt54#abc-flow-structured-output-and-teardown-failure' as StreamTabId;
     const snapshot = {
       ...buildToolUseResumeData(executionId, streamId),
-      agentConfig: AgentConfigSchema.parse({
-        ...CONFIG,
-        outputSchema: {
-          type: 'object',
-          properties: { answer: { type: 'string' } },
-          required: ['answer'],
-        },
-      }),
+      agentConfig: structuredOutputConfig(),
     };
     // A terminal cursor makes the resumed flow exit COMPLETE without stepping
     // any node, so the run completes without a structured result.

--- a/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
@@ -56,8 +56,8 @@ function interceptFirstEntryWrite(
 describe('workflow-script persistence', () => {
   it('replays a completed journal after restart without new agent calls', async () => {
     const store = getExecutionStore(executionId);
-    const firstRunner = vi.fn(async ({ prompt }: { prompt: string }) =>
-      Promise.resolve(`result:${prompt}`),
+    const firstRunner = vi.fn(
+      async ({ prompt }: { prompt: string }) => `result:${prompt}`,
     );
 
     const first = await runPersistedWorkflowScript({
@@ -728,14 +728,9 @@ return 'guest success'`,
           snapshots.push(snapshot);
         },
       });
-      void run.then(
-        () => {
-          settled = true;
-        },
-        () => {
-          settled = true;
-        },
-      );
+      void run.finally(() => {
+        settled = true;
+      });
 
       await childStarted.promise;
       await vi.advanceTimersByTimeAsync(4_000);

--- a/src/test-kernel/agent/core/ToolUseProcessNodeResponseFinalized.vitest.ts
+++ b/src/test-kernel/agent/core/ToolUseProcessNodeResponseFinalized.vitest.ts
@@ -12,9 +12,7 @@ import type { ToolUseRoundShared } from '@agent/core/flows/toolUseRound/roundSha
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { testModelCell } from '../modelCellTestUtils';
 
-function buildServices(
-  overrides: Partial<ToolUseRoundServices<unknown>> = {},
-): ToolUseRoundServices<unknown> {
+function buildServices(): ToolUseRoundServices<unknown> {
   return {
     run: { totalResponseTimeMs: 0, usageAccumulator: {}, totalRounds: 0 },
     workspace: {
@@ -37,7 +35,6 @@ function buildServices(
       error: vi.fn(),
       responseFinalized: vi.fn(),
     },
-    ...overrides,
   } as unknown as ToolUseRoundServices<unknown>;
 }
 

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -36,6 +36,11 @@ let testApprovalHandler:
   | undefined;
 let detachHostInteractions = (): void => {};
 
+const executionId = 'abcdef' as ExecutionId;
+const streamId = 'stream:accept-run-files' as StreamTabId;
+const workspacePath = '/workspace';
+const storagePath = '/storage';
+
 function installTestPlatform(): Promise<void> {
   return installPlatform({
     workspacePath,
@@ -55,11 +60,6 @@ function installTestPlatform(): Promise<void> {
     });
   });
 }
-
-const executionId = 'abcdef' as ExecutionId;
-const streamId = 'stream:accept-run-files' as StreamTabId;
-const workspacePath = '/workspace';
-const storagePath = '/storage';
 
 function runStorageStat(type: number): FileStat {
   return { type, ctime: 0, mtime: 0, size: 1 };

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -19,6 +19,7 @@ import {
   setToolEditApprovalSessionBypass,
 } from '@tools/approval';
 
+// Local file imports
 import { createRecordingHost } from '../progressTestUtils';
 
 function streamPair(label: string): {

--- a/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
@@ -1,6 +1,4 @@
 // Test composition imports
-
-// Local imports
 import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
@@ -18,8 +16,6 @@ vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { appSignals, type AppSignalPayloads } from '@eventBus/AppSignals';
 import type { StreamTabId } from '@shared/schemas';
-
-// Test support imports
 import { createTestSession } from '@test/support/sessionTestUtils';
 import { GitHubAuthError } from '@tools/github/githubClient';
 import {

--- a/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
@@ -1,6 +1,4 @@
 // Test composition imports
-
-// Local imports
 import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports

--- a/src/test-kernel/agent/followUp/MediaExtractionNodeTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/MediaExtractionNodeTranscriptLog.vitest.ts
@@ -48,11 +48,9 @@ describe('MediaExtractionNode transcript logging (regression #7508)', () => {
     const services = buildServices({
       initialUserMessageForTranscript: 'Do the thing.',
     });
-    (
-      services.modelCell.handler.addMediaToUserMessage as ReturnType<
-        typeof vi.fn
-      >
-    ).mockRejectedValue(new Error('media insertion failed'));
+    vi
+      .mocked(services.modelCell.handler.addMediaToUserMessage)
+      .mockRejectedValue(new Error('media insertion failed'));
     const node = new MediaExtractionNode().setServices(services);
     const shared = reflectionFlowShared();
 
@@ -82,11 +80,9 @@ describe('MediaExtractionNode transcript logging (regression #7508)', () => {
     const services = buildServices({
       initialUserMessageForTranscript: 'Do the thing.',
     });
-    (
-      services.modelCell.handler.addMediaToUserMessage as ReturnType<
-        typeof vi.fn
-      >
-    ).mockRejectedValue(new Error('boom'));
+    vi
+      .mocked(services.modelCell.handler.addMediaToUserMessage)
+      .mockRejectedValue(new Error('boom'));
     const node = new MediaExtractionNode().setServices(services);
     const shared = reflectionFlowShared({ currentRound: 1 });
 

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -53,6 +53,32 @@ function activeTarget(
 
 const id = (value: string) => value as StreamTabId;
 
+/** Stub the run-metadata read the durable-producer path performs. */
+function mockPersistedExecution(session: SessionHandle): void {
+  vi.spyOn(session.snapshots, 'getRunMetadata').mockReturnValue({
+    executionId: 'persisted-execution',
+  } as never);
+}
+
+/**
+ * The resumability decision every durable-admission scenario shares: a
+ * resumable flow whose snapshot carries the given continuation generation.
+ */
+function durableResumabilityDecision(
+  generationId: string,
+): resumability.ResumabilityDecision {
+  return {
+    resumable: true,
+    cause: resumability.RESUMABILITY_CAUSE.MISSING_TERMINAL_WITH_FLOW,
+    flowRecord: {
+      flowName: 'texra',
+      shared: { continuationGenerationId: generationId },
+      createdAt: '2026-08-13T12:00:00.000Z',
+      nodes: [],
+    },
+  };
+}
+
 describe('submitFollowUp', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -388,21 +414,11 @@ describe('submitFollowUp', () => {
   it('restores the persisted generation before admitting a durable producer', async () => {
     const streamId = id('stream:persisted-generation');
     const session = fakeSession({ kind: 'queue', reason: 'waiting' });
-    const executionId = 'persisted-execution';
     const generationId = 'e63883b0-0fe0-48c7-9888-a2daeaab30a5';
-    vi.spyOn(session.snapshots, 'getRunMetadata').mockReturnValue({
-      executionId,
-    } as never);
-    vi.spyOn(resumability, 'deriveResumability').mockResolvedValue({
-      resumable: true,
-      cause: resumability.RESUMABILITY_CAUSE.MISSING_TERMINAL_WITH_FLOW,
-      flowRecord: {
-        flowName: 'texra',
-        shared: { continuationGenerationId: generationId },
-        createdAt: '2026-08-13T12:00:00.000Z',
-        nodes: [],
-      },
-    });
+    mockPersistedExecution(session);
+    vi.spyOn(resumability, 'deriveResumability').mockResolvedValue(
+      durableResumabilityDecision(generationId),
+    );
     const tryResumeStream = mockTryResume();
 
     await expect(
@@ -421,11 +437,8 @@ describe('submitFollowUp', () => {
   it('serializes durable generation lookup before later ordinary admission', async () => {
     const streamId = id('stream:serialized-generation-lookup');
     const session = fakeSession({ kind: 'queue', reason: 'waiting' });
-    const executionId = 'persisted-execution';
     const generationId = '5038fe96-7113-449a-82a9-3e58f292d1ba';
-    vi.spyOn(session.snapshots, 'getRunMetadata').mockReturnValue({
-      executionId,
-    } as never);
+    mockPersistedExecution(session);
     const lookup =
       deferred<Awaited<ReturnType<typeof resumability.deriveResumability>>>();
     const deriveResumability = vi
@@ -448,16 +461,7 @@ describe('submitFollowUp', () => {
     expect(tryResumeStream).not.toHaveBeenCalled();
     expect(session.followUps.getAll(streamId)).toEqual([]);
 
-    lookup.resolve({
-      resumable: true,
-      cause: resumability.RESUMABILITY_CAUSE.MISSING_TERMINAL_WITH_FLOW,
-      flowRecord: {
-        flowName: 'texra',
-        shared: { continuationGenerationId: generationId },
-        createdAt: '2026-08-13T12:00:00.000Z',
-        nodes: [],
-      },
-    });
+    lookup.resolve(durableResumabilityDecision(generationId));
 
     await vi.waitFor(() =>
       expect(session.followUps.getAll(streamId)).toEqual([
@@ -501,21 +505,11 @@ describe('submitFollowUp', () => {
   it('rebinds a provisional recovery before admitting a durable producer', async () => {
     const streamId = id('stream:provisional-recovery');
     const session = fakeSession({ kind: 'queue', reason: 'waiting' });
-    const executionId = 'persisted-execution';
     const generationId = 'a2047268-908c-4ac5-8194-71fb377bd7f3';
-    vi.spyOn(session.snapshots, 'getRunMetadata').mockReturnValue({
-      executionId,
-    } as never);
-    vi.spyOn(resumability, 'deriveResumability').mockResolvedValue({
-      resumable: true,
-      cause: resumability.RESUMABILITY_CAUSE.MISSING_TERMINAL_WITH_FLOW,
-      flowRecord: {
-        flowName: 'texra',
-        shared: { continuationGenerationId: generationId },
-        createdAt: '2026-08-13T12:00:00.000Z',
-        nodes: [],
-      },
-    });
+    mockPersistedExecution(session);
+    vi.spyOn(resumability, 'deriveResumability').mockResolvedValue(
+      durableResumabilityDecision(generationId),
+    );
     const provisional = session.followUps.claimRecovery(streamId, true)!;
     expect(provisional.generationId).not.toBe(generationId);
 
@@ -532,21 +526,11 @@ describe('submitFollowUp', () => {
   it('rebinds a released provisional recovery before durable admission', async () => {
     const streamId = id('stream:released-provisional-recovery');
     const session = fakeSession({ kind: 'queue', reason: 'waiting' });
-    const executionId = 'persisted-execution';
     const generationId = '51c54412-e977-48ab-8304-53007cc0bb7a';
-    vi.spyOn(session.snapshots, 'getRunMetadata').mockReturnValue({
-      executionId,
-    } as never);
-    vi.spyOn(resumability, 'deriveResumability').mockResolvedValue({
-      resumable: true,
-      cause: resumability.RESUMABILITY_CAUSE.MISSING_TERMINAL_WITH_FLOW,
-      flowRecord: {
-        flowName: 'texra',
-        shared: { continuationGenerationId: generationId },
-        createdAt: '2026-08-13T12:00:00.000Z',
-        nodes: [],
-      },
-    });
+    mockPersistedExecution(session);
+    vi.spyOn(resumability, 'deriveResumability').mockResolvedValue(
+      durableResumabilityDecision(generationId),
+    );
     const provisional = session.followUps.claimRecovery(streamId, true)!;
     session.followUps.release(provisional, 'recoverable');
 

--- a/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
@@ -46,9 +46,9 @@ describe('ToolUsePrepareNode transcript logging (regression #7508)', () => {
     const services = buildServices({
       initialUserMessageForTranscript: 'Do the thing.',
     });
-    services.modelCell.handler.initializeMessages = vi
-      .fn()
-      .mockRejectedValue(new Error('media processing failed')) as never;
+    vi.mocked(services.modelCell.handler.initializeMessages).mockRejectedValue(
+      new Error('media processing failed'),
+    );
     const node = new ToolUsePrepareNode().setServices(services);
 
     await expect(node.exec(undefined)).rejects.toThrow(
@@ -79,9 +79,9 @@ describe('ToolUsePrepareNode transcript logging (regression #7508)', () => {
     const services = buildServices({
       initialUserMessageForTranscript: undefined,
     });
-    services.modelCell.handler.initializeMessages = vi
-      .fn()
-      .mockRejectedValue(new Error('boom')) as never;
+    vi
+      .mocked(services.modelCell.handler.initializeMessages)
+      .mockRejectedValue(new Error('boom'));
     const node = new ToolUsePrepareNode().setServices(services);
 
     await expect(node.exec(undefined)).rejects.toThrow('boom');

--- a/src/test-kernel/agent/modelHandlers/BackgroundRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/BackgroundRunLifecycle.vitest.ts
@@ -182,14 +182,12 @@ describe('BackgroundRunLifecycle.retrieveAndRemember', () => {
   it('remembers the id as pending before retrieving', async () => {
     const lifecycle = createLifecycle();
     let pendingDuringRetrieve: string | null = null;
-    const client = {
-      responses: {
-        retrieve: vi.fn(async () => {
-          pendingDuringRetrieve = lifecycle.getPendingId();
-          return completedResponse('resp-recovered');
-        }),
-      },
-    } as unknown as OpenAI;
+    const client = clientWith(
+      vi.fn(async () => {
+        pendingDuringRetrieve = lifecycle.getPendingId();
+        return completedResponse('resp-recovered');
+      }),
+    );
 
     const result = await lifecycle.retrieveAndRemember(
       client,
@@ -205,13 +203,11 @@ describe('BackgroundRunLifecycle.retrieveAndRemember', () => {
   it('rethrows and clears pending on a non-retryable retrieve failure', async () => {
     const lifecycle = createLifecycle();
     const notFound = Object.assign(new Error('not found'), { status: 404 });
-    const client = {
-      responses: {
-        retrieve: vi.fn(async () => {
-          throw notFound;
-        }),
-      },
-    } as unknown as OpenAI;
+    const client = clientWith(
+      vi.fn(async () => {
+        throw notFound;
+      }),
+    );
 
     await expect(
       lifecycle.retrieveAndRemember(client, 'resp-x', undefined, undefined),
@@ -229,7 +225,7 @@ describe('BackgroundRunLifecycle.retrieveAndRemember', () => {
         vi.setSystemTime(Date.now() + 2);
         throw new Error('socket hang up');
       });
-    const client = { responses: { retrieve } } as unknown as OpenAI;
+    const client = clientWith(retrieve);
 
     await expect(
       lifecycle.retrieveAndRemember(client, 'resp-late', undefined, undefined),
@@ -245,7 +241,7 @@ describe('BackgroundRunLifecycle.retrieveAndRemember', () => {
 describe('BackgroundRunLifecycle.waitForCompletion', () => {
   it('returns the initial response unchanged when it has no id', async () => {
     const lifecycle = createLifecycle();
-    const client = { responses: { retrieve: vi.fn() } } as unknown as OpenAI;
+    const client = clientWith(vi.fn());
     const response = { status: 'completed' } as Response;
 
     const result = await lifecycle.waitForCompletion(client, response);
@@ -259,15 +255,13 @@ describe('BackgroundRunLifecycle.waitForCompletion', () => {
     // instead of swapping in a fast poller through the private field.
     vi.useFakeTimers();
     const lifecycle = createLifecycle();
-    const client = {
-      responses: {
-        retrieve: vi.fn(async () => ({
-          id: 'resp-terminal',
-          status: 'failed',
-          error: { message: 'server error' },
-        })),
-      },
-    } as unknown as OpenAI;
+    const client = clientWith(
+      vi.fn(async () => ({
+        id: 'resp-terminal',
+        status: 'failed',
+        error: { message: 'server error' },
+      })),
+    );
 
     const completion = lifecycle.waitForCompletion(client, {
       id: 'resp-terminal',

--- a/src/test-kernel/agent/modelHandlers/GoogleClientRefresh.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleClientRefresh.vitest.ts
@@ -1,3 +1,5 @@
+// Third-party imports
+import type { GoogleGenAI } from '@google/genai';
 import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it } from 'vitest';
 
@@ -5,9 +7,6 @@ import { describe, expect, it } from 'vitest';
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 import { testModelCell } from '../modelCellTestUtils';
-
-// Third-party imports
-import type { GoogleGenAI } from '@google/genai';
 
 const GOOGLE_TEST_CONFIG = Object.freeze({
   name: 'google-client-refresh',

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsChaining.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsChaining.vitest.ts
@@ -15,7 +15,7 @@ import {
   userStep,
 } from './googleInteractionsTestUtils';
 
-// Third-party imports
+// Provider SDK types
 import type { Interactions } from '@google/genai';
 
 type Step = Interactions.Step;
@@ -335,7 +335,6 @@ describe('ModelHandlerGoogleInteractions store:true chaining', () => {
   it('T6: compaction clears the chain and returns updatedMessages', async () => {
     const handler = createHandler();
     handler.setAgentCategory(AgentCategory.ToolUse);
-    handler.setLogger({ ...noopTrace });
     (
       handler as unknown as {
         postProcessResponse: (text: string) => string;

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
@@ -14,7 +14,7 @@ import {
   userStep,
 } from './googleInteractionsTestUtils';
 
-// Third-party imports
+// Provider SDK types
 import type { GoogleGenAI, Interactions } from '@google/genai';
 
 type Step = Interactions.Step;

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsStreaming.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsStreaming.vitest.ts
@@ -14,6 +14,8 @@ import {
   GOOGLE_INTERACTIONS_TEST_CONFIG,
   StreamingGoogleInteractionsHandler,
 } from './googleInteractionsTestUtils';
+
+// Provider SDK types
 import type { Interactions } from '@google/genai';
 
 type StreamRecord = {

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
@@ -16,6 +16,8 @@ import {
   GOOGLE_INTERACTIONS_TEST_CONFIG,
   StreamingGoogleInteractionsHandler,
 } from './googleInteractionsTestUtils';
+
+// Provider SDK types
 import type { Interactions } from '@google/genai';
 
 const originalGetConfig = configModule.getConfig;

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -806,7 +806,9 @@ describe('Google Interactions API routing', () => {
     vi.unstubAllEnvs();
   });
 
-  const googleConfig = (): ModelConfig => modelConfig(ModelProvider.GOOGLE);
+  function googleConfig(): ModelConfig {
+    return modelConfig(ModelProvider.GOOGLE);
+  }
 
   // Re-imports the factory alongside the platform it reads from (see the
   // module-header note on this file's vi.resetModules() calls).

--- a/src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts
@@ -2,7 +2,7 @@
 import { strict as assert } from 'node:assert';
 
 // Third-party imports
-import { describe, expect, it, vi } from 'vitest';
+import { describe, it, vi } from 'vitest';
 import { ModelProvider, ReasoningEffort } from 'llm-zoo';
 
 // Local imports
@@ -206,10 +206,11 @@ describe('OpenAI-compatible provider request params', () => {
       temperature: 0,
     });
 
-    expect(handler.getLastCredentialUsageRoute()).toBe(
+    assert.equal(
+      handler.getLastCredentialUsageRoute(),
       'glm-coding-plan-subscription',
     );
-    expect(
+    assert.equal(
       handler.normalizeUsage(
         {
           prompt_tokens: 1_000_000,
@@ -218,7 +219,8 @@ describe('OpenAI-compatible provider request params', () => {
         },
         10,
       ).cost,
-    ).toBe(0);
+      0,
+    );
   });
 
   it('records coding-endpoint Kimi requests as subscription usage', async () => {

--- a/src/test-kernel/agent/modelHandlers/ReasoningEffortMapping.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ReasoningEffortMapping.vitest.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { ReasoningEffort } from 'llm-zoo';
 
 // Local imports - mappings under test

--- a/src/test-kernel/agent/prompt/userVars.vitest.ts
+++ b/src/test-kernel/agent/prompt/userVars.vitest.ts
@@ -8,10 +8,8 @@ import {
 import {
   AgentPromptSchema,
   AgentWorkflowSettingSchema,
-} from '@agent/core/definition/AgentDataclass';
-import type {
-  AgentSetting,
-  AgentPrompt,
+  type AgentPrompt,
+  type AgentSetting,
 } from '@agent/core/definition/AgentDataclass';
 import {
   buildUserVars,

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -988,8 +988,7 @@ describe('childRunLoop E2E fixtures', () => {
 
   it('keeps the failing turn diagnosis when an interrupt lands after the failure', async () => {
     const executionId = 'fa11ed01' as ExecutionId;
-    const parentStreamId = 'parent' as StreamTabId;
-    const childStream = createChildStream(executionId, parentStreamId, {
+    const childStream = createChildStream(executionId, PARENT_STREAM_ID, {
       streamPrefix: 'codex',
       run: { kind: 'agent', agent: 'fake-cli', tool: 'codex' },
       description: 'Fail a turn, then take an interrupt',
@@ -1006,15 +1005,11 @@ describe('childRunLoop E2E fixtures', () => {
       mocks.leaseLossListener?.();
     });
 
-    startChildRunLoop({
-      childStream,
-      childStreamId,
-      parentStreamId,
-      executionId,
-      agentName: 'fake-cli',
+    startLoop(
+      { childStreamId, executionId },
       strategy,
-      recordCost: interruptAfterFailure,
-    });
+      { childStream, agentName: 'fake-cli', recordCost: interruptAfterFailure },
+    );
 
     await waitForLiveOwner(childStreamId);
     await rejectTurn(1, new Error('turn blew up'));

--- a/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, type Mock, vi } from 'vitest';
 
 import { clearStoreCache, getExecutionStore } from '@agent/storage';
 import { flowKey } from '@agent/node/persistedFlow';
@@ -101,6 +101,21 @@ async function seedSidecarFk(
     ownedExecutionId,
   );
   await snapshots.flush();
+}
+
+/**
+ * Mocks a pending workspace-storage root change, returning the commit mock so
+ * callers can assert whether it was invoked.
+ */
+function mockPendingWorkspaceChange(
+  opts: { pending?: boolean; commit?: boolean } = {},
+): Mock<() => boolean> {
+  const commitWorkspaceStorageChange = vi.fn(() => opts.commit ?? true);
+  Object.assign(platform().storage, {
+    hasPendingWorkspaceStorageChange: () => opts.pending ?? true,
+    commitWorkspaceStorageChange,
+  });
+  return commitWorkspaceStorageChange;
 }
 
 afterEach(async () => {
@@ -457,12 +472,7 @@ describe('SessionHandle restart repair', () => {
   it('does not commit a new root when the old transcript flush fails', async () => {
     const transcripts = await StreamLogStore.open();
     const session = openDeferredSession(transcripts);
-    const storage = platform().storage;
-    const commitWorkspaceStorageChange = vi.fn(() => true);
-    Object.assign(storage, {
-      hasPendingWorkspaceStorageChange: () => true,
-      commitWorkspaceStorageChange,
-    });
+    const commitWorkspaceStorageChange = mockPendingWorkspaceChange();
     const flushError = new Error('old transcript writes remain unresolved');
     vi.spyOn(transcripts, 'flush').mockRejectedValue(flushError);
     const reload = vi.spyOn(transcripts, 'reload');
@@ -478,11 +488,7 @@ describe('SessionHandle restart repair', () => {
   it('does not commit a new root after disposal during the old-root flush', async () => {
     const transcripts = await StreamLogStore.open();
     const session = openDeferredSession(transcripts);
-    const commitWorkspaceStorageChange = vi.fn(() => true);
-    Object.assign(platform().storage, {
-      hasPendingWorkspaceStorageChange: () => true,
-      commitWorkspaceStorageChange,
-    });
+    const commitWorkspaceStorageChange = mockPendingWorkspaceChange();
     let finishFlush: (() => void) | undefined;
     const flushBlocked = new Promise<void>((resolve) => {
       finishFlush = resolve;
@@ -641,11 +647,9 @@ describe('SessionHandle restart repair', () => {
   it('skips replacement when the workspace storage root is unchanged', async () => {
     const transcripts = await StreamLogStore.open();
     const session = openDeferredSession(transcripts);
-    const storage = platform().storage;
-    const commitWorkspaceStorageChange = vi.fn(() => false);
-    Object.assign(storage, {
-      hasPendingWorkspaceStorageChange: () => false,
-      commitWorkspaceStorageChange,
+    const commitWorkspaceStorageChange = mockPendingWorkspaceChange({
+      pending: false,
+      commit: false,
     });
     const reload = vi.spyOn(transcripts, 'reload').mockResolvedValue();
 
@@ -659,11 +663,7 @@ describe('SessionHandle restart repair', () => {
     const liveExecutionId = 'workspace-disposed' as ExecutionId;
     const transcripts = await StreamLogStore.open();
     const session = openDeferredSession(transcripts);
-    const commitWorkspaceStorageChange = vi.fn(() => true);
-    Object.assign(platform().storage, {
-      hasPendingWorkspaceStorageChange: () => true,
-      commitWorkspaceStorageChange,
-    });
+    const commitWorkspaceStorageChange = mockPendingWorkspaceChange();
     await acquireFreshExecutionLease(liveExecutionId);
 
     try {

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { TraceEmitter, type StatusEvent } from '@agent/trace';
+import type { StatusEvent } from '@agent/trace';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -35,6 +35,8 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+const META_TIMESTAMP = '2026-07-04T00:00:00.000Z';
+
 function mockWarn(): MockInstance<typeof logger.warn> {
   return vi.spyOn(logger, 'warn').mockImplementation(() => {});
 }
@@ -52,15 +54,14 @@ function expectParseWarning(
 }
 
 function validWorkflowSnapshot(): WorkflowExecutionSnapshot {
-  const timestamp = '2026-07-04T00:00:00.000Z';
   return {
     lifecycle: 'completed',
     stages: [],
     calls: [],
     timestamps: {
-      createdAt: timestamp,
-      updatedAt: timestamp,
-      completedAt: timestamp,
+      createdAt: META_TIMESTAMP,
+      updatedAt: META_TIMESTAMP,
+      completedAt: META_TIMESTAMP,
     },
   };
 }
@@ -110,7 +111,7 @@ describe('ExecutionKVStore meta read shims', () => {
     async (outcome) => {
       const id = `canonical-${outcome}` as ExecutionId;
       await getExecutionStore(id).write('meta', {
-        timestamp: '2026-07-04T00:00:00.000Z',
+        timestamp: META_TIMESTAMP,
         outcome,
       });
 
@@ -125,26 +126,26 @@ describe('ExecutionKVStore meta read shims', () => {
     const id = 'versioned-meta' as ExecutionId;
 
     await getExecutionStore(id).writeMeta({
-      timestamp: '2026-07-04T00:00:00.000Z',
+      timestamp: META_TIMESTAMP,
     });
 
     await expect(getExecutionStore(id).read('meta')).resolves.toMatchObject({
       schemaVersion: EXECUTION_META_SCHEMA_VERSION,
-      timestamp: '2026-07-04T00:00:00.000Z',
+      timestamp: META_TIMESTAMP,
     });
   });
 
   it('ignores obsolete delegation depth in persisted metadata', async () => {
     const id = 'legacy-delegation-depth' as ExecutionId;
     await getExecutionStore(id).write('meta', {
-      timestamp: '2026-07-04T00:00:00.000Z',
+      timestamp: META_TIMESTAMP,
       parentExecutionId: 'abcdef',
       delegationDepth: 3,
     });
 
     await expect(getExecutionStore(id).readMeta()).resolves.toEqual({
       schemaVersion: EXECUTION_META_SCHEMA_VERSION,
-      timestamp: '2026-07-04T00:00:00.000Z',
+      timestamp: META_TIMESTAMP,
       parentExecutionId: 'abcdef',
     });
   });
@@ -154,7 +155,7 @@ describe('ExecutionKVStore meta read shims', () => {
     const interim = interimResultMeta('Interim result.');
     await getExecutionStore(id).write('result-meta', interim);
     await getExecutionStore(id).write('meta', {
-      timestamp: '2026-07-04T00:00:00.000Z',
+      timestamp: META_TIMESTAMP,
       outcome: RUN_OUTCOME.CANCELLED,
     });
 
@@ -176,7 +177,7 @@ describe('ExecutionKVStore meta read shims', () => {
       interimResultMeta('The subagent reported an error.', RUN_OUTCOME.FAILED),
     );
     await getExecutionStore(id).write('meta', {
-      timestamp: '2026-07-04T00:00:00.000Z',
+      timestamp: META_TIMESTAMP,
       outcome: RUN_OUTCOME.COMPLETED,
     });
 
@@ -192,7 +193,7 @@ describe('ExecutionKVStore meta read shims', () => {
       interimResultMeta('Waiting for the next turn.'),
     );
     await getExecutionStore(id).write('meta', {
-      timestamp: '2026-07-04T00:00:00.000Z',
+      timestamp: META_TIMESTAMP,
     });
 
     await expect(getExecutionStore(id).readResultMeta()).resolves.toMatchObject(
@@ -209,7 +210,7 @@ describe('ExecutionKVStore meta read shims', () => {
     const interim = interimResultMeta('Interim result before the stop.');
     await getExecutionStore(id).write('result-meta', interim);
     await getExecutionStore(id).write('meta', {
-      timestamp: '2026-07-04T00:00:00.000Z',
+      timestamp: META_TIMESTAMP,
       outcome: RUN_OUTCOME.CANCELLED,
       streamId: 'assistant#resume-boundary',
     });
@@ -230,7 +231,7 @@ describe('ExecutionKVStore meta read shims', () => {
     );
     await expect(getExecutionStore(id).readMeta()).resolves.toEqual({
       schemaVersion: EXECUTION_META_SCHEMA_VERSION,
-      timestamp: '2026-07-04T00:00:00.000Z',
+      timestamp: META_TIMESTAMP,
       streamId: 'assistant#resume-boundary',
     });
   });
@@ -251,7 +252,7 @@ describe('ExecutionKVStore meta read shims', () => {
     const warnSpy = mockWarn();
     const store = getExecutionStore(id);
     await store.write('meta', {
-      timestamp: '2026-07-04T00:00:00.000Z',
+      timestamp: META_TIMESTAMP,
       outcome: RUN_OUTCOME.CANCELLED,
       identity: { kind: 'process', tool: 'bash' },
       description: 'Readable core metadata',
@@ -260,7 +261,7 @@ describe('ExecutionKVStore meta read shims', () => {
 
     const expectedCore = {
       schemaVersion: EXECUTION_META_SCHEMA_VERSION,
-      timestamp: '2026-07-04T00:00:00.000Z',
+      timestamp: META_TIMESTAMP,
       outcome: RUN_OUTCOME.CANCELLED,
       identity: { kind: 'process', tool: 'bash' },
       description: 'Readable core metadata',
@@ -285,7 +286,7 @@ describe('ExecutionKVStore meta read shims', () => {
     const workflow = validWorkflowSnapshot();
 
     await store.writeMeta({
-      timestamp: '2026-07-04T00:00:00.000Z',
+      timestamp: META_TIMESTAMP,
       workflow,
     });
     await expect(store.readMeta()).resolves.toMatchObject({ workflow });
@@ -294,7 +295,7 @@ describe('ExecutionKVStore meta read shims', () => {
     malformed.currentStageId = '';
     await expect(
       store.writeMeta({
-        timestamp: '2026-07-04T00:00:00.000Z',
+        timestamp: META_TIMESTAMP,
         workflow: malformed,
       }),
     ).rejects.toThrow();

--- a/src/test-kernel/agent/storage/ExecutionWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionWorkspaceFiles.vitest.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { listExecutionWorkspaceFiles } from '@agent/storage';
 import { platform } from '@platform/platform';

--- a/src/test-kernel/agent/trace/logUserMessage.vitest.ts
+++ b/src/test-kernel/agent/trace/logUserMessage.vitest.ts
@@ -12,9 +12,8 @@ describe('logUserMessage', () => {
   let disposeTrace: () => void;
   let store: StreamLogStore;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     store = StreamLogStore.ephemeral('test');
-    await store.clear();
     const runTrace = createRunTrace('TestUserMessageLogger', store);
     logger = runTrace.trace;
     disposeTrace = runTrace.dispose;

--- a/src/test-kernel/agent/utils/debugMessageSaver.vitest.ts
+++ b/src/test-kernel/agent/utils/debugMessageSaver.vitest.ts
@@ -1,7 +1,6 @@
-import { strict as assert } from 'node:assert';
 import * as path from 'node:path';
 
-import { describe, it, afterEach, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentTrace } from '@agent/trace';
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
@@ -52,23 +51,21 @@ describe('maybeSaveDebugObject', () => {
     });
 
     const expectedDir = resolveRunStoragePath('run-42' as ExecutionId);
-    assert.deepEqual(
+    expect(
       ensureDir.mock.calls.map(([relativePath]) => relativePath),
-      [RUNS_STORAGE_DIR, expectedDir],
-    );
+    ).toEqual([RUNS_STORAGE_DIR, expectedDir]);
 
     const expectedRelativePath = resolveRunStoragePath(
       'run-42' as ExecutionId,
       'response.json',
     );
-    assert.equal(writeStorage.mock.calls.length, 1);
-    assert.equal(writeStorage.mock.calls[0]?.[0], expectedRelativePath);
-    assert.equal(writeWorkspace.mock.calls.length, 0);
+    expect(writeStorage.mock.calls.length).toBe(1);
+    expect(writeStorage.mock.calls[0]?.[0]).toBe(expectedRelativePath);
+    expect(writeWorkspace.mock.calls.length).toBe(0);
 
-    assert.equal(info.mock.calls.length, 1);
-    assert.equal(error.mock.calls.length, 0);
-    assert.equal(
-      info.mock.calls[0]?.[0],
+    expect(info.mock.calls.length).toBe(1);
+    expect(error.mock.calls.length).toBe(0);
+    expect(info.mock.calls[0]?.[0]).toBe(
       `Saved response object to ${path.join(
         '/mock/storage',
         expectedRelativePath,

--- a/src/test-kernel/architecture/toolRegistryCycle.vitest.ts
+++ b/src/test-kernel/architecture/toolRegistryCycle.vitest.ts
@@ -56,7 +56,7 @@ function defineToolModules(): string[] {
     .filter((file) =>
       readFileSync(`${REPO_ROOT}/${file}`, 'utf8').includes('defineTool('),
     )
-    .sort();
+    .toSorted();
 }
 
 async function valueClosure(entry: string): Promise<string[]> {
@@ -104,7 +104,7 @@ describe('tool module closures', () => {
           files.includes(TOOL_REGISTRY),
       )
       .map(([entry]) => entry)
-      .sort();
+      .toSorted();
 
     expect(offenders).toEqual([]);
   });

--- a/src/test-kernel/architecture/transcriptResidencyLeaseSites.vitest.ts
+++ b/src/test-kernel/architecture/transcriptResidencyLeaseSites.vitest.ts
@@ -35,16 +35,24 @@ const PRESENTATION_LEASE_SITE_ALLOWLIST = new Set([
   'src/transcript/StreamLogStore.ts',
 ]);
 
+/** Files under a scan root that match `pattern` and are not allowlisted. */
+function findOffenders(pattern: RegExp, allowlist: Set<string>): string[] {
+  return SCAN_ROOTS.flatMap(productionFilesUnder)
+    .filter((file) => !allowlist.has(file))
+    .filter((file) =>
+      pattern.test(
+        stripComments(readFileSync(resolve(REPO_ROOT, file), 'utf8')),
+      ),
+    )
+    .toSorted();
+}
+
 describe('transcript residency lease sites', () => {
   it('keeps transcript hydration at the closed focus/runtime boundary', () => {
-    const offenders = SCAN_ROOTS.flatMap(productionFilesUnder)
-      .filter((file) => !HYDRATION_SITE_ALLOWLIST.has(file))
-      .filter((file) =>
-        /\.ensureLoaded\s*\(/.test(
-          stripComments(readFileSync(resolve(REPO_ROOT, file), 'utf8')),
-        ),
-      )
-      .toSorted();
+    const offenders = findOffenders(
+      /\.ensureLoaded\s*\(/,
+      HYDRATION_SITE_ALLOWLIST,
+    );
 
     expect(
       offenders,
@@ -55,14 +63,10 @@ describe('transcript residency lease sites', () => {
   });
 
   it('keeps exact presentation residency at the progress coordinator boundary', () => {
-    const offenders = SCAN_ROOTS.flatMap(productionFilesUnder)
-      .filter((file) => !PRESENTATION_LEASE_SITE_ALLOWLIST.has(file))
-      .filter((file) =>
-        /retainForPresentation\s*:\s*true/.test(
-          stripComments(readFileSync(resolve(REPO_ROOT, file), 'utf8')),
-        ),
-      )
-      .toSorted();
+    const offenders = findOffenders(
+      /retainForPresentation\s*:\s*true/,
+      PRESENTATION_LEASE_SITE_ALLOWLIST,
+    );
 
     expect(offenders).toEqual([]);
   });

--- a/src/test-kernel/auth/SupabaseClient.vitest.ts
+++ b/src/test-kernel/auth/SupabaseClient.vitest.ts
@@ -17,6 +17,13 @@ import * as logger from '@logger/logUtils';
 import { FakeSecrets } from '@test/support/FakePlatform';
 import { createDeferred } from '@test/support/asyncTestUtils';
 
+const SUPABASE_URL = 'https://example.supabase.co';
+const PUBLIC_KEY = 'public-key';
+
+function initializeSupabase(secrets: SessionSecretStore): void {
+  SupabaseClient.initialize(SUPABASE_URL, PUBLIC_KEY, secrets);
+}
+
 async function withRelayTokenEnv(
   token: string,
   run: () => Promise<void>,
@@ -218,11 +225,7 @@ describe('SupabaseClient', () => {
       whenReady: () => readiness.promise,
     });
 
-    SupabaseClient.initialize(
-      'https://example.supabase.co',
-      'public-key',
-      new FakeSecrets(),
-    );
+    initializeSupabase(new FakeSecrets());
     SupabaseClient.setAuthProvider(provider);
 
     let settled = false;
@@ -246,11 +249,7 @@ describe('SupabaseClient', () => {
       },
     });
 
-    SupabaseClient.initialize(
-      'https://example.supabase.co',
-      'public-key',
-      new FakeSecrets(),
-    );
+    initializeSupabase(new FakeSecrets());
     SupabaseClient.setAuthProvider(provider);
 
     assert.equal(await SupabaseClient.isReady(), false);
@@ -291,7 +290,6 @@ describe('SupabaseClient', () => {
 });
 
 describe('SupabaseClient PKCE flow state', () => {
-  const SUPABASE_URL = 'https://example.supabase.co';
   const VERIFIER_KEY = `${SUPABASE_GOTRUE_STORAGE_KEY}-code-verifier`;
 
   afterEach(() => {
@@ -344,7 +342,7 @@ describe('SupabaseClient PKCE flow state', () => {
 
   it('persists only the flow state, never the session slot', async () => {
     const secrets = new FakeSecrets();
-    SupabaseClient.initialize(SUPABASE_URL, 'public-key', secrets);
+    initializeSupabase(secrets);
 
     await startSignIn();
 
@@ -363,7 +361,7 @@ describe('SupabaseClient PKCE flow state', () => {
 
   it('completes a callback delivered to a different client instance', async () => {
     const secrets = new FakeSecrets();
-    SupabaseClient.initialize(SUPABASE_URL, 'public-key', secrets);
+    initializeSupabase(secrets);
     await startSignIn();
     // GoTrue JSON-encodes every stored value; the slot holds the verifier
     // alone, or `verifier/redirectType` for a recovery link.
@@ -377,7 +375,7 @@ describe('SupabaseClient PKCE flow state', () => {
     // that never generated a verifier of its own.
     const exchangeBody = stubCodeExchange();
     SupabaseClient.resetForTests();
-    SupabaseClient.initialize(SUPABASE_URL, 'public-key', secrets);
+    initializeSupabase(secrets);
 
     const { data, error } =
       await SupabaseClient.getClient().auth.exchangeCodeForSession('auth-code');
@@ -408,7 +406,7 @@ describe('SupabaseClient PKCE flow state', () => {
       },
       delete: async () => {},
     };
-    SupabaseClient.initialize(SUPABASE_URL, 'public-key', secrets);
+    initializeSupabase(secrets);
 
     await startSignIn();
 

--- a/src/test-kernel/auth/XaiSessionCoordinator.vitest.ts
+++ b/src/test-kernel/auth/XaiSessionCoordinator.vitest.ts
@@ -56,6 +56,14 @@ function makeCoordinator(options: {
   return new XaiSessionCoordinator({ ...options, now: () => NOW });
 }
 
+function makeClient(overrides: Partial<XaiOAuthClient> = {}): XaiOAuthClient {
+  return {
+    exchangeAuthorizationCode: vi.fn(),
+    refreshTokens: vi.fn(),
+    ...overrides,
+  };
+}
+
 describe('XaiSessionCoordinator', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -108,10 +116,9 @@ describe('XaiSessionCoordinator', () => {
     const storage = memoryStorage();
     const coordinator = makeCoordinator({
       storage,
-      client: {
+      client: makeClient({
         exchangeAuthorizationCode: vi.fn(async () => tokens()),
-        refreshTokens: vi.fn(),
-      },
+      }),
     });
     const stored = await coordinator.completeLoginWithCode({
       code: 'code',
@@ -129,10 +136,7 @@ describe('XaiSessionCoordinator', () => {
     const refreshTokens = vi.fn(() => refreshDeferred.promise);
     const coordinator = makeCoordinator({
       storage,
-      client: {
-        exchangeAuthorizationCode: vi.fn(),
-        refreshTokens,
-      },
+      client: makeClient({ refreshTokens }),
     });
 
     const a = coordinator.getFreshAccessToken();
@@ -150,12 +154,11 @@ describe('XaiSessionCoordinator', () => {
     const storage = memoryStorage(session({ expiresAtMs: NOW + FIVE_MIN - 1 }));
     const coordinator = makeCoordinator({
       storage,
-      client: {
-        exchangeAuthorizationCode: vi.fn(),
+      client: makeClient({
         refreshTokens: vi.fn(async () => {
           throw new XaiAuthError('revoked', 'fatal', 400);
         }),
-      },
+      }),
     });
     await expect(coordinator.getFreshAccessToken()).rejects.toMatchObject({
       kind: 'fatal',

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.ts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.ts
@@ -73,6 +73,10 @@ function cliContext(overrides: Partial<CliContext> = {}): CliContext {
   });
 }
 
+// Import the module under test after the mock factories above so its imports
+// resolve to the mocked modules.
+const { runToolUseAgent } = await import('@cli/commands/agentsRun');
+
 describe('CLI agents run command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -114,8 +118,6 @@ describe('CLI agents run command', () => {
   });
 
   it('anchors headless tool-use runs on provided files without polluting display text', async () => {
-    const { runToolUseAgent } = await import('@cli/commands/agentsRun');
-
     const exitCode = await runToolUseAgent(cliContext(), {
       agent: 'chat',
       inputFiles: ['problem.md'],
@@ -203,8 +205,6 @@ describe('CLI agents run command', () => {
           hasMaterializedStdinInput: true,
         }),
     );
-    const { runToolUseAgent } = await import('@cli/commands/agentsRun');
-
     await runToolUseAgent(cliContext(), {
       agent: 'chat',
       inputFiles: ['-'],
@@ -230,8 +230,6 @@ describe('CLI agents run command', () => {
       },
       exitCode: CliExitCode.Interrupted,
     });
-    const { runToolUseAgent } = await import('@cli/commands/agentsRun');
-
     const exitCode = await runToolUseAgent(cliContext(), {
       agent: 'chat',
       inputFiles: ['problem.md'],
@@ -246,8 +244,6 @@ describe('CLI agents run command', () => {
   });
 
   it('reports missing instruction before resolving the model', async () => {
-    const { runToolUseAgent } = await import('@cli/commands/agentsRun');
-
     await expect(
       runToolUseAgent(cliContext(), {
         agent: 'chat',
@@ -281,8 +277,6 @@ describe('CLI agents run command', () => {
     'reports $scenario before resolving the model',
     async ({ agent, message }) => {
       mocks.resolveCliLaunchAgent.mockRejectedValueOnce(new Error(message));
-      const { runToolUseAgent } = await import('@cli/commands/agentsRun');
-
       await expect(
         runToolUseAgent(cliContext(), {
           agent,

--- a/src/test-kernel/cli/AppEscapeRouting.vitest.ts
+++ b/src/test-kernel/cli/AppEscapeRouting.vitest.ts
@@ -173,6 +173,21 @@ async function renderWithInterrupt(
   return { ...handles, onInterruptStream };
 }
 
+async function renderDebugApp(
+  props: AppProps,
+  size: { columns: number; rows: number },
+): Promise<InkRenderHandles> {
+  const { ink, React } = await loadInk();
+  return renderInteractive(ink, React.createElement(App, props), {
+    ...size,
+    debug: true,
+  });
+}
+
+function currentFrame(stdout: InkRenderHandles['stdout']): string {
+  return stripAnsi(stdout.writes.findLast((write) => write.length > 0) ?? '');
+}
+
 function fakeHistory(entries: readonly string[]): InputHistory {
   return {
     push: async () => undefined,
@@ -377,24 +392,20 @@ describe('App foreground Escape ownership', () => {
       })),
     }));
     const onInterruptStream = vi.fn();
-    const { ink, React } = await loadInk();
-    const { instance, stdin, stdout } = renderInteractive(
-      ink,
-      React.createElement(App, appProps(onInterruptStream)),
-      { columns: 100, debug: true, rows: 30 },
+    const { instance, stdin, stdout } = await renderDebugApp(
+      appProps(onInterruptStream),
+      { columns: 100, rows: 30 },
     );
-    const currentFrame = (): string =>
-      stripAnsi(stdout.writes.findLast((write) => write.length > 0) ?? '');
 
     try {
       await waitFor(() => stdin.listenerCount('readable') > 0);
       stdin.write('\t');
       await waitFor(() =>
-        currentFrame().includes('ambiguous-workflow · 0/2 done'),
+        currentFrame(stdout).includes('ambiguous-workflow · 0/2 done'),
       );
       stdin.write('\r');
       await waitFor(() =>
-        currentFrame()
+        currentFrame(stdout)
           .split('\n')
           .some(
             (line) =>
@@ -403,7 +414,7 @@ describe('App foreground Escape ownership', () => {
       );
       stdin.write(ARROW_KEYS.Down);
       await waitFor(() =>
-        currentFrame()
+        currentFrame(stdout)
           .split('\n')
           .some(
             (line) =>
@@ -416,7 +427,7 @@ describe('App foreground Escape ownership', () => {
       focusStream(ROOT);
       await waitFor(() => activeStreamId.get() === ROOT);
       await waitFor(() =>
-        currentFrame()
+        currentFrame(stdout)
           .split('\n')
           .some(
             (line) =>
@@ -757,22 +768,15 @@ describe('App foreground Escape ownership', () => {
     focusStream(ROOT);
     const onSubmit = vi.fn();
     const onInterruptStream = vi.fn();
-    const { ink, React } = await loadInk();
-    const { instance, stdin, stdout } = renderInteractive(
-      ink,
-      React.createElement(App, {
-        ...appProps(onInterruptStream),
-        onSubmit,
-      }),
-      { columns: 100, debug: true, rows: 30 },
+    const { instance, stdin, stdout } = await renderDebugApp(
+      { ...appProps(onInterruptStream), onSubmit },
+      { columns: 100, rows: 30 },
     );
-    const currentFrame = (): string =>
-      stripAnsi(stdout.writes.findLast((write) => write.length > 0) ?? '');
 
     try {
       await waitFor(() => stdin.listenerCount('readable') > 0);
       stdin.write('preserved root draft');
-      await waitFor(() => currentFrame().includes('preserved root draft'));
+      await waitFor(() => currentFrame(stdout).includes('preserved root draft'));
 
       patchStream(CHILD, (slice) => ({
         ...slice,
@@ -783,12 +787,12 @@ describe('App foreground Escape ownership', () => {
       }));
       focusStream(CHILD);
       await waitFor(() => activeStreamId.get() === CHILD);
-      await waitFor(() => !currentFrame().includes('preserved root draft'));
+      await waitFor(() => !currentFrame(stdout).includes('preserved root draft'));
 
       stdin.write('ignored printable submit\r');
       await sleep(30);
       expect(onSubmit).not.toHaveBeenCalled();
-      expect(currentFrame()).not.toContain('ignored printable submit');
+      expect(currentFrame(stdout)).not.toContain('ignored printable submit');
 
       stdin.write('\t');
       await sleep(30);
@@ -808,7 +812,7 @@ describe('App foreground Escape ownership', () => {
       await waitFor(() => foregroundReader.get() === undefined);
       stdin.write(ESC);
       await waitFor(() => activeStreamId.get() === ROOT);
-      await waitFor(() => currentFrame().includes('preserved root draft'));
+      await waitFor(() => currentFrame(stdout).includes('preserved root draft'));
       stdin.write('\r');
       await waitFor(() => onSubmit.mock.calls.length === 1);
 
@@ -838,23 +842,19 @@ describe('App foreground Escape ownership', () => {
         ],
       }));
     }
-    const { ink, React } = await loadInk();
-    const { instance, stdout } = renderInteractive(
-      ink,
-      React.createElement(App, appProps(vi.fn())),
-      { columns: 40, debug: true, rows: 12 },
-    );
-    const currentFrame = (): string =>
-      stripAnsi(stdout.writes.findLast((write) => write.length > 0) ?? '');
+    const { instance, stdout } = await renderDebugApp(appProps(vi.fn()), {
+      columns: 40,
+      rows: 12,
+    });
     const visibleTranscriptRows = (): number =>
-      (currentFrame().match(/layout line \d+/gu) ?? []).length;
+      (currentFrame(stdout).match(/layout line \d+/gu) ?? []).length;
 
     try {
       await waitFor(() => visibleTranscriptRows() > 0);
       const rootRows = visibleTranscriptRows();
 
       focusStream(CHILD);
-      await waitFor(() => currentFrame().includes('Esc back'));
+      await waitFor(() => currentFrame(stdout).includes('Esc back'));
       const supportedChildRows = visibleTranscriptRows();
       expect(rootRows).toBe(2);
       expect(supportedChildRows).toBe(7);
@@ -920,35 +920,31 @@ describe('App foreground Escape ownership', () => {
         },
       ],
     }));
-    const { ink, React } = await loadInk();
-    const { instance, stdin, stdout } = renderInteractive(
-      ink,
-      React.createElement(App, appProps(vi.fn())),
-      { ...viewport, debug: true },
+    const { instance, stdin, stdout } = await renderDebugApp(
+      appProps(vi.fn()),
+      viewport,
     );
-    const currentFrame = (): string =>
-      stripAnsi(stdout.writes.findLast((write) => write.length > 0) ?? '');
     const visibleTranscriptRows = (): number =>
-      (currentFrame().match(/unsupported list line \d+/gu) ?? []).length;
+      (currentFrame(stdout).match(/unsupported list line \d+/gu) ?? []).length;
 
     try {
       await waitFor(() => visibleTranscriptRows() === 10);
       expect(visibleTranscriptRows()).toBe(10);
-      expect(currentFrame()).not.toContain('Choosing a session');
+      expect(currentFrame(stdout)).not.toContain('Choosing a session');
 
       stdin.write('\t');
       await waitFor(
         () =>
-          currentFrame().includes('Choosing a session') &&
+          currentFrame(stdout).includes('Choosing a session') &&
           visibleTranscriptRows() === 4,
       );
-      expect(currentFrame()).toContain('Choosing a session');
+      expect(currentFrame(stdout)).toContain('Choosing a session');
       expect(visibleTranscriptRows()).toBe(4);
 
       stdin.write('\t');
       await waitFor(() => visibleTranscriptRows() === 10);
       expect(visibleTranscriptRows()).toBe(10);
-      expect(currentFrame()).not.toContain('Choosing a session');
+      expect(currentFrame(stdout)).not.toContain('Choosing a session');
     } finally {
       instance.unmount();
     }

--- a/src/test-kernel/cli/ChildControls.vitest.ts
+++ b/src/test-kernel/cli/ChildControls.vitest.ts
@@ -155,13 +155,7 @@ describe('CLI child controls', () => {
   // Alt+1..9 numbers follow the rows exactly as the tree yields them.
   it('assigns visible shortcut indices in newest-first roster order', () => {
     const ids = ['a', 'b', 'c', 'd', 'e'].map((id) => id as StreamTabId);
-    const [a, b, c, d, e] = ids as [
-      StreamTabId,
-      StreamTabId,
-      StreamTabId,
-      StreamTabId,
-      StreamTabId,
-    ];
+    const [a, b, c, d, e] = ids;
     const entries = buildChildStreamEntries({
       parentStreamId: root,
       retained: [
@@ -183,6 +177,8 @@ describe('CLI child controls', () => {
       ids.filter((id) => id !== b).map((id) => [id, root] as const),
     );
 
+    // Retained oldest-first (a…e), reversed for display; the `Map`/`Reduce`
+    // tags on the roster rows do not move anybody.
     expect(
       streamTreeEntries({
         activeStreamId: root,
@@ -191,8 +187,6 @@ describe('CLI child controls', () => {
         rootStreamId: root,
         streams,
       }),
-      // Retained oldest-first (a…e), reversed for display; the `Map`/`Reduce`
-      // tags on the roster rows do not move anybody.
     ).toEqual([
       { id: root },
       { id: e, shortcutIndex: 1 },

--- a/src/test-kernel/cli/CliSkills.vitest.ts
+++ b/src/test-kernel/cli/CliSkills.vitest.ts
@@ -132,6 +132,13 @@ describe('CLI skills runtime', () => {
   });
 
   it('deduplicates repeated source paths while preserving required custom roots', () => {
+    const projectSkillsPath = path.resolve(
+      path.sep,
+      'tmp',
+      'project',
+      '.texra',
+      'skills',
+    );
     const sources = defaultSkillSources(
       {
         cwd: path.resolve(path.sep, 'tmp', 'project'),
@@ -143,11 +150,7 @@ describe('CLI skills runtime', () => {
     );
 
     expect(
-      sources.filter(
-        (source) =>
-          source.path ===
-          path.resolve(path.sep, 'tmp', 'project', '.texra', 'skills'),
-      ),
+      sources.filter((source) => source.path === projectSkillsPath),
     ).toEqual([
       expect.objectContaining({
         scope: 'custom',
@@ -191,10 +194,9 @@ describe('CLI skills runtime', () => {
         scope: 'custom',
       },
     ]);
-    expect(formatCliSkillList(result.skills)).toContain(
-      'custom\tshared-skill\tThe custom skill.',
-    );
-    expect(formatCliSkillList(result.skills)).not.toContain(
+    const formatted = formatCliSkillList(result.skills);
+    expect(formatted).toContain('custom\tshared-skill\tThe custom skill.');
+    expect(formatted).not.toContain(
       'bundled\tshared-skill\tThe bundled skill.',
     );
     expect(result.errors).toContainEqual(
@@ -235,10 +237,9 @@ describe('CLI skills runtime', () => {
         scope: 'project',
       },
     ]);
-    expect(formatCliSkillList(result.skills)).toContain(
-      'project\tshared-skill\tThe project skill.',
-    );
-    expect(formatCliSkillList(result.skills)).not.toContain(
+    const formatted = formatCliSkillList(result.skills);
+    expect(formatted).toContain('project\tshared-skill\tThe project skill.');
+    expect(formatted).not.toContain(
       'bundled\tshared-skill\tThe bundled skill.',
     );
     expect(result.errors).toContainEqual(

--- a/src/test-kernel/cli/DeviceCodeAuth.vitest.ts
+++ b/src/test-kernel/cli/DeviceCodeAuth.vitest.ts
@@ -26,12 +26,14 @@ const AUTHORIZATION = {
   interval: 5,
 };
 
+type FetchCall = { url: string; body: unknown };
+
 /** Fetch fake that serves one queued result per call (Response or throw). */
 function queuedFetch(queue: Array<Response | Error>): {
   fetchImpl: typeof fetch;
-  calls: Array<{ url: string; body: unknown }>;
+  calls: FetchCall[];
 } {
-  const calls: Array<{ url: string; body: unknown }> = [];
+  const calls: FetchCall[] = [];
   const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) => {
     calls.push({
       url: String(input),
@@ -71,7 +73,7 @@ function pollWithQueue(
 ): {
   completion: ReturnType<typeof pollForDeviceSession>;
   clock: ReturnType<typeof fakeClock>;
-  calls: Array<{ url: string; body: unknown }>;
+  calls: FetchCall[];
 } {
   const clock = fakeClock();
   const { fetchImpl, calls } = queuedFetch(queue);

--- a/src/test-kernel/cli/History.vitest.ts
+++ b/src/test-kernel/cli/History.vitest.ts
@@ -138,6 +138,20 @@ const config = AgentConfigSchema.parse({
 
 const tempDirs: string[] = [];
 
+// An internal tool-use agent config with no input/output files, built from
+// the base `config` with per-test field overrides.
+function toolUseAgentConfig(
+  overrides: Record<string, unknown> = {},
+): typeof config {
+  return AgentConfigSchema.parse({
+    ...config,
+    agentCategory: 'toolUse',
+    inputFiles: [],
+    outputFiles: [],
+    ...overrides,
+  });
+}
+
 function mockToolUseWorkspace(workspace: string): void {
   mocks.readConfig.mockResolvedValue({
     ...config,
@@ -345,13 +359,7 @@ describe('CLI history runtime', () => {
   });
 
   it('hides internal process-bookkeeping and configless entries from the history list', async () => {
-    const processConfig = AgentConfigSchema.parse({
-      ...config,
-      agent: 'bash',
-      agentCategory: 'toolUse',
-      inputFiles: [],
-      outputFiles: [],
-    });
+    const processConfig = toolUseAgentConfig({ agent: 'bash' });
     mocks.listExecutions.mockResolvedValue([
       runListEntry('visible'),
       {
@@ -390,12 +398,8 @@ describe('CLI history runtime', () => {
   });
 
   it('labels multi-agent team runs by preset in history lists', async () => {
-    const teamConfig = AgentConfigSchema.parse({
-      ...config,
+    const teamConfig = toolUseAgentConfig({
       agent: 'engineer',
-      agentCategory: 'toolUse',
-      inputFiles: [],
-      outputFiles: [],
       cliMultiAgentPresetId: ' software-engineer ',
     });
     mocks.listExecutions.mockResolvedValue([
@@ -418,13 +422,7 @@ describe('CLI history runtime', () => {
   });
 
   it('uses the history description for no-input chat rows', async () => {
-    const chatConfig = AgentConfigSchema.parse({
-      ...config,
-      agent: 'assistant',
-      agentCategory: 'toolUse',
-      inputFiles: [],
-      outputFiles: [],
-    });
+    const chatConfig = toolUseAgentConfig({ agent: 'assistant' });
     mocks.listExecutions.mockResolvedValue([
       runListEntry('chat1', {
         identity: { kind: 'agent', agent: 'assistant' },

--- a/src/test-kernel/cli/InstallGithubAction.vitest.ts
+++ b/src/test-kernel/cli/InstallGithubAction.vitest.ts
@@ -98,13 +98,7 @@ describe('install-github-action command', () => {
       'https://github.com/example/project.git',
     );
 
-    const result = await runCli([
-      '--cwd',
-      repo,
-      'install-github-action',
-      '--no-pr',
-      '--no-color',
-    ]);
+    const result = await runInstall(repo);
 
     expect(result.exitCode).toBe(CliExitCode.Success);
     expect(browserMocks.tryOpenBrowser).toHaveBeenCalledWith(

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
@@ -70,21 +70,19 @@ vi.mock('@cli/commands/_helpers/output', () => ({
   emitCliResult: mocks.emitCliResult,
 }));
 
-vi.mock('@cli/runtime/multiAgentPresets', () => {
-  return {
-    cliMultiAgentPresetNdjsonRecords: vi.fn(() => []),
-    formatCliMultiAgentPresetInspection: vi.fn(() => ''),
-    formatCliMultiAgentPresetList: vi.fn(() => ''),
-    formatCliMultiAgentPresetRunWarnings:
-      mocks.formatCliMultiAgentPresetRunWarnings,
-    formatCliMultiAgentTeamLaunchBlockMessage:
-      mocks.formatCliMultiAgentTeamLaunchBlockMessage,
-    MULTI_AGENT_TEAM_ROOT_AGENT_DESCRIPTION:
-      'Root agent for the team run (defaults to the preset orchestrator)',
-    MULTI_AGENT_TEAM_ROOT_MODEL_DESCRIPTION: 'Model for the team root agent',
-    readCliMultiAgentPresets: vi.fn(() => []),
-  };
-});
+vi.mock('@cli/runtime/multiAgentPresets', () => ({
+  cliMultiAgentPresetNdjsonRecords: vi.fn(() => []),
+  formatCliMultiAgentPresetInspection: vi.fn(() => ''),
+  formatCliMultiAgentPresetList: vi.fn(() => ''),
+  formatCliMultiAgentPresetRunWarnings:
+    mocks.formatCliMultiAgentPresetRunWarnings,
+  formatCliMultiAgentTeamLaunchBlockMessage:
+    mocks.formatCliMultiAgentTeamLaunchBlockMessage,
+  MULTI_AGENT_TEAM_ROOT_AGENT_DESCRIPTION:
+    'Root agent for the team run (defaults to the preset orchestrator)',
+  MULTI_AGENT_TEAM_ROOT_MODEL_DESCRIPTION: 'Model for the team root agent',
+  readCliMultiAgentPresets: vi.fn(() => []),
+}));
 
 vi.mock('@common/teams/TeamPlan', async (importOriginal) => {
   const actual =
@@ -235,6 +233,27 @@ function mockExpandedRunInputs(inputs: {
   );
 }
 
+function mockMaterializedStdin(inputFiles: string[]): void {
+  mocks.withExpandedRunInputs.mockImplementationOnce(
+    async (
+      _inputSpecs: readonly string[],
+      _contextSpecs: readonly string[],
+      _cwd: string,
+      _options: unknown,
+      run: (expanded: {
+        readonly inputFiles: string[];
+        readonly contextFiles: string[];
+        readonly hasMaterializedStdinInput: boolean;
+      }) => Promise<unknown>,
+    ) =>
+      run({
+        inputFiles,
+        contextFiles: [],
+        hasMaterializedStdinInput: true,
+      }),
+  );
+}
+
 describe('CLI multi-agent run command', () => {
   const approvalUnavailableWarning =
     'WARN preset mathematician may run without subagent delegation because approval policy "never" denies approval-gated delegation tools. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.';
@@ -346,24 +365,7 @@ describe('CLI multi-agent run command', () => {
   });
 
   it('marks materialized stdin as unavailable for team recovery advertising', async () => {
-    mocks.withExpandedRunInputs.mockImplementationOnce(
-      async (
-        _inputSpecs: readonly string[],
-        _contextSpecs: readonly string[],
-        _cwd: string,
-        _options: unknown,
-        run: (inputs: {
-          readonly inputFiles: string[];
-          readonly contextFiles: string[];
-          readonly hasMaterializedStdinInput: boolean;
-        }) => Promise<unknown>,
-      ) =>
-        run({
-          inputFiles: ['.texra-tmp/stdin.tex'],
-          contextFiles: [],
-          hasMaterializedStdinInput: true,
-        }),
-    );
+    mockMaterializedStdin(['.texra-tmp/stdin.tex']);
 
     await runPreset({
       inputFiles: ['-'],
@@ -560,24 +562,7 @@ describe('CLI multi-agent run command', () => {
   });
 
   it('uses a stable display label for a file-only stdin launch', async () => {
-    mocks.withExpandedRunInputs.mockImplementationOnce(
-      async (
-        _inputSpecs: readonly string[],
-        _contextSpecs: readonly string[],
-        _cwd: string,
-        _options: unknown,
-        run: (inputs: {
-          readonly inputFiles: string[];
-          readonly contextFiles: string[];
-          readonly hasMaterializedStdinInput: boolean;
-        }) => Promise<unknown>,
-      ) =>
-        run({
-          inputFiles: ['.texra-tmp/texra-stdin-123/stdin.tex'],
-          contextFiles: [],
-          hasMaterializedStdinInput: true,
-        }),
-    );
+    mockMaterializedStdin(['.texra-tmp/texra-stdin-123/stdin.tex']);
 
     const exitCode = await runPreset({ inputFiles: [' - '], instruction: '' });
 

--- a/src/test-kernel/cli/Pager.vitest.ts
+++ b/src/test-kernel/cli/Pager.vitest.ts
@@ -1,7 +1,8 @@
+import type * as childProcess from 'node:child_process';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
-import type * as childProcess from 'node:child_process';
 
 const spawnSyncMock =
   vi.fn<(...args: Parameters<typeof childProcess.spawnSync>) => unknown>();

--- a/src/test-kernel/cli/ResumeCommand.vitest.ts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.ts
@@ -123,6 +123,15 @@ async function run(context: CliContext, id: ExecutionId = EXECUTION_ID) {
   return runResumeExecution(context, id);
 }
 
+function stubWorkflowResume(config: AgentConfig): void {
+  mocks.readConfig.mockResolvedValue(config);
+  mocks.retrieveSessionResumeData.mockResolvedValue({
+    type: 'workflow',
+    agentConfig: config,
+    executionId: EXECUTION_ID,
+  });
+}
+
 describe('runResumeExecution', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -213,12 +222,7 @@ describe('runResumeExecution', () => {
       cliOutputDirectory: outputDirectory,
       cliExpectedOutputFiles: ['paper.tex', 'appendix.tex'],
     });
-    mocks.readConfig.mockResolvedValue(workflowConfig);
-    mocks.retrieveSessionResumeData.mockResolvedValue({
-      type: 'workflow',
-      agentConfig: workflowConfig,
-      executionId: EXECUTION_ID,
-    });
+    stubWorkflowResume(workflowConfig);
 
     await expect(run(cliContext())).resolves.toBe(0);
 
@@ -240,12 +244,7 @@ describe('runResumeExecution', () => {
       workingDirectory,
       cliOutputDirectory: outputDirectory,
     });
-    mocks.readConfig.mockResolvedValue(workflowConfig);
-    mocks.retrieveSessionResumeData.mockResolvedValue({
-      type: 'workflow',
-      agentConfig: workflowConfig,
-      executionId: EXECUTION_ID,
-    });
+    stubWorkflowResume(workflowConfig);
 
     await expect(run(cliContext())).resolves.toBe(0);
 
@@ -265,12 +264,7 @@ describe('runResumeExecution', () => {
       workingDirectory,
       cliOutputDirectory: path.join(workingDirectory, 'out'),
     });
-    mocks.readConfig.mockResolvedValue(workflowConfig);
-    mocks.retrieveSessionResumeData.mockResolvedValue({
-      type: 'workflow',
-      agentConfig: workflowConfig,
-      executionId: EXECUTION_ID,
-    });
+    stubWorkflowResume(workflowConfig);
     mocks.assertOutputDirAvailable.mockRejectedValue(
       new CliUsageError('--output-dir must refer to a directory.'),
     );

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -168,6 +168,14 @@ function toolUseConfig() {
   };
 }
 
+/** Tools the CLI runtime hides by default during agent execution. */
+const DEFAULT_RUNTIME_UNAVAILABLE_TOOLS = [
+  'inquiry',
+  ...SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES,
+  'inline_comment',
+  DIAGNOSTICS_READ_RUNTIME_CAPABILITY,
+];
+
 function loadRunExecution(): Promise<
   typeof import('@cli/runtime/runExecution')
 > {
@@ -408,12 +416,7 @@ describe('executeCliRequest', () => {
       request,
       expect.objectContaining({
         approvalPromptsUnavailable: false,
-        runtimeUnavailableTools: [
-          'inquiry',
-          ...SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES,
-          'inline_comment',
-          DIAGNOSTICS_READ_RUNTIME_CAPABILITY,
-        ],
+        runtimeUnavailableTools: DEFAULT_RUNTIME_UNAVAILABLE_TOOLS,
       }),
     );
   });
@@ -429,13 +432,7 @@ describe('executeCliRequest', () => {
     expect(mocks.runAgent).toHaveBeenCalledWith(
       request,
       expect.objectContaining({
-        runtimeUnavailableTools: [
-          'inquiry',
-          ...SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES,
-          'inline_comment',
-          DIAGNOSTICS_READ_RUNTIME_CAPABILITY,
-          'custom_tool',
-        ],
+        runtimeUnavailableTools: [...DEFAULT_RUNTIME_UNAVAILABLE_TOOLS, 'custom_tool'],
       }),
     );
   });

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.ts
@@ -158,6 +158,20 @@ function silentOutput(): SlashCommandOutput {
   return { appendOutcome: vi.fn(), setNotice: vi.fn(), writeProgress: vi.fn() };
 }
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function workPlanSnapshots(
   read: (streamId: StreamTabId) => {
     readonly plan: Plan | null;
@@ -287,10 +301,7 @@ describe('handleTuiSlashCommand', () => {
   });
 
   it('waits for canonical hydration before deciding a focused plan is empty', async () => {
-    let resolvePreload: () => void = () => undefined;
-    const preload = new Promise<void>((resolve) => {
-      resolvePreload = resolve;
-    });
+    const { promise: preload, resolve: resolvePreload } = deferred<void>();
     const streamId = 'historical-plan' as StreamTabId;
     registerBuiltinSlashCommands({
       workPlanSnapshots: workPlanSnapshots(
@@ -368,10 +379,7 @@ describe('handleTuiSlashCommand', () => {
   });
 
   it('lets a newer no-focus request cancel pending ownership', async () => {
-    let resolvePreload: () => void = () => undefined;
-    const preload = new Promise<void>((resolve) => {
-      resolvePreload = resolve;
-    });
+    const { promise: preload, resolve: resolvePreload } = deferred<void>();
     const streamId = 'superseded-loading-plan' as StreamTabId;
     registerBuiltinSlashCommands({
       workPlanSnapshots: workPlanSnapshots(
@@ -395,10 +403,7 @@ describe('handleTuiSlashCommand', () => {
   });
 
   it('does not reopen a loading plan reader after Escape', async () => {
-    let resolvePreload: () => void = () => undefined;
-    const preload = new Promise<void>((resolve) => {
-      resolvePreload = resolve;
-    });
+    const { promise: preload, resolve: resolvePreload } = deferred<void>();
     const streamId = 'escape-loading-plan' as StreamTabId;
     registerBuiltinSlashCommands({
       workPlanSnapshots: workPlanSnapshots(
@@ -420,10 +425,7 @@ describe('handleTuiSlashCommand', () => {
   });
 
   it('closes a loading reader and reports a current preload error', async () => {
-    let rejectPreload: (error: unknown) => void = () => undefined;
-    const preload = new Promise<void>((_resolve, reject) => {
-      rejectPreload = reject;
-    });
+    const { promise: preload, reject: rejectPreload } = deferred<void>();
     const streamId = 'error-loading-plan' as StreamTabId;
     registerBuiltinSlashCommands({
       workPlanSnapshots: workPlanSnapshots(

--- a/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
+++ b/src/test-kernel/cli/StreamLogDeltaFold.vitest.ts
@@ -376,6 +376,16 @@ function configureStreams(config: StreamConfig): void {
   }
 }
 
+/** Subscribe for the duration of `fn`, disposing even if an assertion throws. */
+function withStreamSubscription(fn: () => void): void {
+  const dispose = subscribeStreamLog();
+  try {
+    fn();
+  } finally {
+    dispose();
+  }
+}
+
 describe('transcript fold vs from-scratch oracle', () => {
   beforeEach(async () => {
     await defaultSession().transcripts.clear();
@@ -392,8 +402,7 @@ describe('transcript fold vs from-scratch oracle', () => {
   )(
     'folds identically to the oracle: $config.name (seed $seed)',
     ({ config, seed }) => {
-      const dispose = subscribeStreamLog();
-      try {
+      withStreamSubscription(() => {
         const rng = createRng(seed);
         const ops = new MirroredOps(rng);
         configureStreams(config);
@@ -434,15 +443,12 @@ describe('transcript fold vs from-scratch oracle', () => {
         // stream A folds every step after its first sync's rebuild.
         const after = transcriptFoldCountersForTest();
         expect(after.folds - before.folds).toBeGreaterThanOrEqual(STEPS - 1);
-      } finally {
-        dispose();
-      }
+      });
     },
   );
 
   it('projects the compact unfocused-workflow selection identically', () => {
-    const dispose = subscribeStreamLog();
-    try {
+    withStreamSubscription(() => {
       const rng = createRng(4242);
       const ops = new MirroredOps(rng);
       configureStreams(CONFIGS[1]);
@@ -457,14 +463,11 @@ describe('transcript fold vs from-scratch oracle', () => {
         ops.step();
         syncBothAndCompare(step, ' (compact)');
       }
-    } finally {
-      dispose();
-    }
+    });
   });
 
   it('folds a hidden workflow-attempt marker into projection state', () => {
-    const dispose = subscribeStreamLog();
-    try {
+    withStreamSubscription(() => {
       configureStreams(CONFIGS[1]);
       appendTranscriptEntry(defaultSession().transcripts, FOLD_STREAM, {
         id: 'workflow-attempt-current',
@@ -511,9 +514,7 @@ describe('transcript fold vs from-scratch oracle', () => {
       expect(invalidSlice?.workflowAttemptId).toBeUndefined();
       expect(invalidSlice?.workflowAttemptBoundaryDeclared).toBe(true);
       expect(invalidSlice?.entries).toEqual([]);
-    } finally {
-      dispose();
-    }
+    });
   });
 
   it('does not settle a running compaction on a turn-boundary forceFinal', () => {
@@ -522,8 +523,7 @@ describe('transcript fold vs from-scratch oracle', () => {
     // from the real lifecycle phase — a forceFinal while a compaction is
     // still running must not record it as interrupted, or the later
     // completion event lands beyond the settlement boundary and is ignored.
-    const dispose = subscribeStreamLog();
-    try {
+    withStreamSubscription(() => {
       const store = defaultSession().transcripts;
       configureStreams(CONFIGS[0]);
       activeStreamId.set(undefined);
@@ -591,9 +591,7 @@ describe('transcript fold vs from-scratch oracle', () => {
       expect(done?.text).toBe('Context compacted');
       expect(done?.finalized).toBe(true);
       expect(streams.get().get(FOLD_STREAM)?.compactingActive).toBe(false);
-    } finally {
-      dispose();
-    }
+    });
   });
 
   it('recovers from a delta gap by rebuilding through the oracle path', () => {

--- a/src/test-kernel/cli/TextInputEditing.vitest.ts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.ts
@@ -32,7 +32,7 @@ import {
   SYNTHETIC_SHIFT_RETURN_INPUT,
 } from '@cli/tui/inputKeys';
 
-const ESC = String.fromCharCode(27);
+const ESC = '\u001B';
 const NEWLINE_MODE = { shiftEnter: 'newline' } as const;
 const PRESERVE_MODE = { shiftEnter: 'preserve' } as const;
 

--- a/src/test-kernel/cli/TuiValidatorArgs.vitest.ts
+++ b/src/test-kernel/cli/TuiValidatorArgs.vitest.ts
@@ -56,25 +56,23 @@ describe('TUI validator args', () => {
 
   it('prints scenario names without building the harness', () => {
     const result = runValidator(['--list']);
+    const lines = result.stdout.split('\n');
 
     expect(result.status).toBe(0);
-    expect(result.stdout.split('\n')).toContain('transcript');
-    expect(result.stdout.split('\n')).toContain('no-color-model-form');
-    expect(result.stdout.split('\n')).toContain(
-      'subagent-list-focus-full-frame',
-    );
+    expect(lines).toContain('transcript');
+    expect(lines).toContain('no-color-model-form');
+    expect(lines).toContain('subagent-list-focus-full-frame');
     expect(result.stdout).not.toContain('Available scenarios:');
     expect(result.stderr).not.toContain('building tui-harness bundle');
   });
 
   it('treats list-scenarios as a scenario list alias', () => {
     const result = runValidator(['--list-scenarios']);
+    const lines = result.stdout.split('\n');
 
     expect(result.status).toBe(0);
-    expect(result.stdout.split('\n')).toContain('transcript');
-    expect(result.stdout.split('\n')).toContain(
-      'subagent-list-focus-full-frame',
-    );
+    expect(lines).toContain('transcript');
+    expect(lines).toContain('subagent-list-focus-full-frame');
     expect(result.stdout).not.toContain('Available scenarios:');
     expect(result.stderr).toBe('');
   });

--- a/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
+++ b/src/test-kernel/cli/WorkflowDashboardModel.vitest.ts
@@ -71,6 +71,17 @@ function workflowRoot(
   };
 }
 
+/** Mark every task and phase of a slice as belonging to a prior attempt. */
+function markPriorAttempt(entries: StreamSlice['entries']) {
+  return entries.map((entry) => {
+    if (entry.role === 'workflowTask') {
+      return { ...entry, task: { ...entry.task, attemptId: 'prior' } };
+    }
+    if (entry.role === 'phase') return { ...entry, attemptId: 'prior' };
+    return entry;
+  });
+}
+
 /** Two phases, two tasks each, in the order the transcript emitted them. */
 const TWO_PHASE_ROOT = workflowRoot(
   ['Map', 'Reduce'],
@@ -259,13 +270,7 @@ describe('workflow dashboard model', () => {
       ['Verify'],
       [{ id: 'verification', phase: 'Verify' }],
     );
-    const priorEntries = prior.entries.map((entry) => {
-      if (entry.role === 'workflowTask') {
-        return { ...entry, task: { ...entry.task, attemptId: 'prior' } };
-      }
-      if (entry.role === 'phase') return { ...entry, attemptId: 'prior' };
-      return entry;
-    });
+    const priorEntries = markPriorAttempt(prior.entries);
     const currentEntries = current.entries.map((entry) => {
       if (entry.role === 'workflowTask') {
         return {
@@ -342,13 +347,7 @@ describe('workflow dashboard model', () => {
 
   it('renders a current empty dynamic phase while dropping prior attempts', async () => {
     const root = workflowRoot(['Prior'], [{ id: 'old', phase: 'Prior' }]);
-    const entries = root.entries.map((entry) => {
-      if (entry.role === 'workflowTask') {
-        return { ...entry, task: { ...entry.task, attemptId: 'prior' } };
-      }
-      if (entry.role === 'phase') return { ...entry, attemptId: 'prior' };
-      return entry;
-    });
+    const entries = markPriorAttempt(root.entries);
     const currentPhase = {
       id: 'phase-current',
       role: 'phase' as const,
@@ -423,13 +422,7 @@ describe('workflow dashboard model', () => {
       ['Verify'],
       [{ id: 'verification', phase: 'Verify' }],
     );
-    const entries = prior.entries.map((entry) => {
-      if (entry.role === 'workflowTask') {
-        return { ...entry, task: { ...entry.task, attemptId: 'prior' } };
-      }
-      if (entry.role === 'phase') return { ...entry, attemptId: 'prior' };
-      return entry;
-    });
+    const entries = markPriorAttempt(prior.entries);
 
     const model = workflowDashboardModel(
       { ...prior, workflowAttemptId: 'current', entries },

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
@@ -229,6 +229,35 @@ function mockWorkflowExecution(
   else mocks.executeCliConfig.mockImplementation(implementation);
 }
 
+/** Mocks a run whose cancellation lands during output finalization. */
+function mockCancellationDuringOutputFinalization(
+  provisional: WorkflowExecuteResult,
+  tryCommitPublication: () => boolean,
+): void {
+  if (!provisional.ok) throw new Error('Expected a workflow result.');
+  mocks.executeCliConfig.mockImplementationOnce(
+    async (
+      _config: unknown,
+      _context: unknown,
+      options: {
+        readonly openWorkflowOutput?: CliConfigExecuteOptions['openWorkflowOutput'];
+      },
+    ) => {
+      await options.openWorkflowOutput?.(
+        provisional.result,
+        tryCommitPublication,
+      );
+      return {
+        ...provisional,
+        result: {
+          ...provisional.result,
+          outcome: RUN_OUTCOME.CANCELLED,
+        },
+      };
+    },
+  );
+}
+
 /** The result envelope the command persists for history details. */
 function expectedResultMeta(options: {
   readonly outcome: string;
@@ -655,14 +684,12 @@ describe('CLI workflow run command', () => {
         true,
       );
 
-      const exitCode = await runWorkflow(
-        { output: 'polished.tex' },
-        cliContext({
-          cwd: root,
-          commandName: 'texra-local',
-          approvalPolicy: 'never',
-        }),
-      );
+      const context = cliContext({
+        cwd: root,
+        commandName: 'texra-local',
+        approvalPolicy: 'never',
+      });
+      const exitCode = await runWorkflow({ output: 'polished.tex' }, context);
 
       expect(exitCode).toBe(CliExitCode.Interrupted);
       await expect(fs.stat(path.join(root, 'polished.tex'))).rejects.toThrow();
@@ -674,14 +701,7 @@ describe('CLI workflow run command', () => {
         }),
       );
       expect(mocks.writeTextStderr).toHaveBeenCalledExactlyOnceWith(
-        expectedRecoveryHint(
-          cliContext({
-            cwd: root,
-            commandName: 'texra-local',
-            approvalPolicy: 'never',
-          }),
-          'exec-interrupted',
-        ),
+        expectedRecoveryHint(context, 'exec-interrupted'),
       );
       expect(mocks.writeResultMeta.mock.invocationCallOrder[0]).toBeLessThan(
         mocks.writeTextStderr.mock.invocationCallOrder[0],
@@ -787,25 +807,9 @@ describe('CLI workflow run command', () => {
   });
 
   it('presents the lifecycle verdict when cancellation lands during output finalization', async () => {
-    const provisional = workflowExecution('exec-output-interrupted');
-    if (!provisional.ok) throw new Error('Expected a workflow result.');
-    mocks.executeCliConfig.mockImplementationOnce(
-      async (
-        _config: unknown,
-        _context: unknown,
-        options: {
-          readonly openWorkflowOutput?: CliConfigExecuteOptions['openWorkflowOutput'];
-        },
-      ) => {
-        await options.openWorkflowOutput?.(provisional.result, () => true);
-        return {
-          ...provisional,
-          result: {
-            ...provisional.result,
-            outcome: RUN_OUTCOME.CANCELLED,
-          },
-        };
-      },
+    mockCancellationDuringOutputFinalization(
+      workflowExecution('exec-output-interrupted'),
+      () => true,
     );
 
     const exitCode = await runWorkflow();
@@ -864,27 +868,11 @@ describe('CLI workflow run command', () => {
           generated,
           path.join(root, 'paper.tex'),
         );
-        const provisional = workflowExecution('exec-output-interrupted', {
-          outputs: [outputSummary],
-        });
-        if (!provisional.ok) throw new Error('Expected a workflow result.');
-        mocks.executeCliConfig.mockImplementationOnce(
-          async (
-            _config: unknown,
-            _context: unknown,
-            options: {
-              readonly openWorkflowOutput?: CliConfigExecuteOptions['openWorkflowOutput'];
-            },
-          ) => {
-            await options.openWorkflowOutput?.(provisional.result, () => false);
-            return {
-              ...provisional,
-              result: {
-                ...provisional.result,
-                outcome: RUN_OUTCOME.CANCELLED,
-              },
-            };
-          },
+        mockCancellationDuringOutputFinalization(
+          workflowExecution('exec-output-interrupted', {
+            outputs: [outputSummary],
+          }),
+          () => false,
         );
         const target = destination(root);
         if (existing) {

--- a/src/test-kernel/cli/WorkflowRunDetails.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunDetails.vitest.ts
@@ -13,6 +13,7 @@ import {
   type CompileFailure,
   LOG_LEVELS,
   MESSAGE_TYPES,
+  type OutputFileInfo,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_PHASE,
   type StreamLogEntry,
@@ -57,7 +58,7 @@ function completedRound(
   total: number,
   startTime: number,
   endTime: number,
-) {
+): TaskGroup {
   return {
     id: `r${index}`,
     name: `r${index}`,
@@ -73,7 +74,7 @@ function completedRound(
 function generatedFile(
   relativePath: string,
   diff: { added: number; removed: number } | null,
-) {
+): OutputFileInfo {
   return {
     source: 'paper.tex',
     round: 0,

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -130,10 +130,9 @@ function streamEntries(): readonly ConversationEntry[] {
 }
 
 function expectOutputOrder(output: string, markers: readonly string[]): void {
-  for (const [index, marker] of markers.entries()) {
-    if (index === 0) continue;
+  for (let index = 1; index < markers.length; index++) {
     expect(output.indexOf(markers[index - 1])).toBeLessThan(
-      output.indexOf(marker),
+      output.indexOf(markers[index]),
     );
   }
 }

--- a/src/test-kernel/common/GlmCodingPlanDetection.vitest.ts
+++ b/src/test-kernel/common/GlmCodingPlanDetection.vitest.ts
@@ -24,14 +24,6 @@ const FIVE_HOUR_LIMIT_BODY = {
   },
 } as const;
 
-/** The real GLM Coding Plan error: a UTC+8 China-time reset timestamp. */
-const CST_TIMESTAMP_BODY = {
-  error: {
-    code: '1308',
-    message: '已达到 5 小时的使用上限。您的限额将在 2026-08-08 11:32:36 重置。',
-  },
-} as const;
-
 /** Build a UTC+8 reset timestamp a fixed window in the future. */
 function futureCstTimestampBody(minutesFromNow: number): {
   error: { code: string; message: string };

--- a/src/test-kernel/common/WorktreeMemento.vitest.ts
+++ b/src/test-kernel/common/WorktreeMemento.vitest.ts
@@ -5,8 +5,6 @@ import { describe, expect, it } from 'vitest';
 import { WorktreeMemento } from '@common/state/worktreeMemento';
 
 class FakeMemento {
-  readonly writes: Array<[string, unknown]> = [];
-
   constructor(private readonly values = new Map<string, unknown>()) {}
 
   keys(): readonly string[] {
@@ -20,7 +18,6 @@ class FakeMemento {
   }
 
   update(key: string, value: unknown): Thenable<void> {
-    this.writes.push([key, value]);
     if (value === undefined) {
       this.values.delete(key);
     } else {

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -30,7 +30,6 @@ const RETRIED_WITH_OWN_KEY_RESULT = {
 interface HarnessOptions {
   keys?: Partial<Record<ApiProvider, string | undefined>>;
   prompt?(keys: Map<ApiProvider, string | undefined>): void;
-  preferChatGptSubscription?: boolean;
   glmCodingPlan?: boolean;
   retryAvailable?: boolean;
   retryPending?: boolean;
@@ -55,7 +54,7 @@ function createHarness(options: HarnessOptions = {}): {
   const includedAccessValues: boolean[] = [];
   const chatGptSubscriptionValues: boolean[] = [];
   const glmCodingPlanValues: boolean[] = [];
-  let preferChatGptSubscription = options.preferChatGptSubscription ?? true;
+  let preferChatGptSubscription = true;
   let glmCodingPlan = options.glmCodingPlan ?? true;
   let invalidations = 0;
   const retries: string[] = [];

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -834,14 +834,13 @@ function stubWorkflowResumeData(
 
 /** Creates a bridge with the given runAgent mock and starts one workflow
  * execution through the host file actions. */
-async function startMergeExecution(runAgent: RunExecutionRequest): Promise<{
-  bridge: TestableBridge;
-  showErrorMessage: ReturnType<typeof vi.fn>;
-}> {
+async function startMergeExecution(
+  runAgent: RunExecutionRequest,
+): Promise<{ showErrorMessage: ReturnType<typeof vi.fn> }> {
   const showErrorMessage = vi.fn(async () => undefined);
   const bridge = await createBridge([], { runAgent, showErrorMessage });
   bridge.fileActions.host.startExecution({ config: workflowConfig() });
-  return { bridge, showErrorMessage };
+  return { showErrorMessage };
 }
 
 /** Builds a bridge behind a transcript-open gate, asserts nothing reaches the
@@ -2789,11 +2788,7 @@ describe('DesktopProgressBridge', () => {
               PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
             ).filter(
               (message) =>
-                (
-                  message as ProgressMessage & {
-                    permission?: { data?: { approvalId?: string } };
-                  }
-                ).permission?.data?.approvalId ===
+                message.permission?.data?.approvalId ===
                 'approval-during-reopen-load',
             ),
           ).toHaveLength(1);

--- a/src/test-kernel/desktop/DesktopAgentResume.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentResume.vitest.ts
@@ -10,6 +10,7 @@ import { ToolUseAgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import * as AgentExecution from '@agent/runtime/executeAgent';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import * as SessionResumeRetrieval from '@agent/runtime/SessionResumeRetrieval';
+import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 import * as AgentRunner from '@agent/runtime/runAgent';
 import { ResumeAdmissionCancelledError } from '@agent/runtime/resumeAdmission';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
@@ -69,6 +70,17 @@ function completedResult(): ResultEvent {
     agentName: 'proofreader',
     category: 'workflow',
     isSubagent: false,
+  };
+}
+
+function completedRunResult(): AgentFlowResult {
+  return {
+    executionId,
+    streamId: stream,
+    category: 'workflow',
+    outcome: RUN_OUTCOME.COMPLETED,
+    outputs: [],
+    compileFailures: [],
   };
 }
 
@@ -160,14 +172,7 @@ describe('desktop process resume owner', () => {
   beforeEach(() => {
     retrieveSessionResumeData.mockReset();
     resumeToolUseFromResumeData.mockReset();
-    runAgent.mockReset().mockResolvedValue({
-      executionId,
-      streamId: stream,
-      category: 'workflow',
-      outcome: RUN_OUTCOME.COMPLETED,
-      outputs: [],
-      compileFailures: [],
-    });
+    runAgent.mockReset().mockResolvedValue(completedRunResult());
   });
 
   it('resumes while no BrowserWindow presentation exists', async () => {
@@ -328,14 +333,7 @@ describe('desktop process resume owner', () => {
       if ((await options.canAcquireResumeLease?.()) === false) {
         throw new ResumeAdmissionCancelledError(executionId);
       }
-      return {
-        executionId,
-        streamId: stream,
-        category: 'workflow',
-        outcome: RUN_OUTCOME.COMPLETED,
-        outputs: [],
-        compileFailures: [],
-      };
+      return completedRunResult();
     });
 
     await expect(harness.owner.tryResumeStream(stream)).resolves.toBe(false);

--- a/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.ts
@@ -42,7 +42,6 @@ function createControllerFixture(options: ControllerFixtureOptions = {}) {
   const globalState = options.globalState ?? new FakeStateStore();
   const posted: unknown[] = [];
   const opened: string[] = [];
-  const revealed: string[] = [];
   const infoMessages: string[] = [];
   const errorMessages: string[] = [];
   const confirmed: string[] = [];
@@ -77,9 +76,7 @@ function createControllerFixture(options: ControllerFixtureOptions = {}) {
       openPath: async (filePath) => {
         opened.push(filePath);
       },
-      revealPath: async (filePath) => {
-        revealed.push(filePath);
-      },
+      revealPath: async () => undefined,
     },
     renderer: { postToRenderer: (message) => posted.push(message) },
     prompts: {
@@ -113,7 +110,6 @@ function createControllerFixture(options: ControllerFixtureOptions = {}) {
     infoMessages,
     opened,
     posted,
-    revealed,
     workspaceState,
   };
 }

--- a/src/test-kernel/desktop/DesktopDiffMessages.vitest.ts
+++ b/src/test-kernel/desktop/DesktopDiffMessages.vitest.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import { loadSourceModule } from './loadSourceModule.ts';
+
+type DesktopDiffMessagesModule = typeof import('@desktop/shared/desktopDiffMessages');
+
+let DesktopShowDiffMessageSchema!: DesktopDiffMessagesModule['DesktopShowDiffMessageSchema'];
 
 describe('DesktopShowDiffMessageSchema', () => {
   const basePayload = {
@@ -10,10 +14,13 @@ describe('DesktopShowDiffMessageSchema', () => {
     proposedText: 'b',
   } as const;
 
-  it('round-trips a complete payload', async () => {
-    const { DesktopShowDiffMessageSchema } = await loadSourceModule(
+  beforeAll(async () => {
+    ({ DesktopShowDiffMessageSchema } = await loadSourceModule(
       '@desktop/shared/desktopDiffMessages',
-    );
+    ));
+  });
+
+  it('round-trips a complete payload', () => {
     const parsed = DesktopShowDiffMessageSchema.parse({
       ...basePayload,
       displayPath: 'src/file.ts',
@@ -26,18 +33,12 @@ describe('DesktopShowDiffMessageSchema', () => {
     expect(parsed.displayPath).toBe('src/file.ts');
   });
 
-  it('requires displayPath', async () => {
-    const { DesktopShowDiffMessageSchema } = await loadSourceModule(
-      '@desktop/shared/desktopDiffMessages',
-    );
+  it('requires displayPath', () => {
     const result = DesktopShowDiffMessageSchema.safeParse(basePayload);
     expect(result.success).toBe(false);
   });
 
-  it('defaults missing language to plaintext', async () => {
-    const { DesktopShowDiffMessageSchema } = await loadSourceModule(
-      '@desktop/shared/desktopDiffMessages',
-    );
+  it('defaults missing language to plaintext', () => {
     const parsed = DesktopShowDiffMessageSchema.parse({
       ...basePayload,
       displayPath: 'src/file.ts',

--- a/src/test-kernel/desktop/DesktopThemeTokens.vitest.ts
+++ b/src/test-kernel/desktop/DesktopThemeTokens.vitest.ts
@@ -46,6 +46,11 @@ function tokenPx(name: string): number {
   return Number.parseFloat(tokenValue(name));
 }
 
+/** Strip CSS block comments so prose references can't satisfy token matches. */
+function stripCssComments(text: string): string {
+  return text.replaceAll(/\/\*[\s\S]*?\*\//g, '');
+}
+
 describe('desktop theme tokens', () => {
   it('defines textarea and text input colors via the WA form-control tokens', () => {
     // Per #3741, consumer code references --wa-* tokens directly and the
@@ -164,7 +169,7 @@ describe('desktop theme tokens', () => {
     //       or src/ references --desktop-color-* or --desktop-font-*.
     // Strip CSS comments before matching so prose in doc-comments cannot
     // accidentally satisfy the inside-file expectations.
-    const insideCss = readThemeTokens().replaceAll(/\/\*[\s\S]*?\*\//g, '');
+    const insideCss = stripCssComments(readThemeTokens());
     expect(insideCss).toMatch(/--desktop-color-[a-zA-Z-]+\s*:/);
     expect(insideCss).toMatch(/var\(--desktop-color-[a-zA-Z-]+\)/);
 
@@ -186,12 +191,8 @@ function collectDesktopTokenOffenders(): string[] {
   // CSS comments + multi-line JS/TS comments. The regex pass ignores
   // declarations/refs that live inside any comment so doc-comments referencing
   // these tokens don't trip the test.
-  const stripCommentsCss = (text: string): string =>
-    text.replaceAll(/\/\*[\s\S]*?\*\//g, '');
   const stripCommentsTs = (text: string): string =>
-    text
-      .replaceAll(/\/\*[\s\S]*?\*\//g, '')
-      .replaceAll(/(^|[^:])\/\/.*$/gm, '$1');
+    stripCssComments(text).replaceAll(/(^|[^:])\/\/.*$/gm, '$1');
 
   for (const dir of [
     repoPath('packages/desktop/src'),
@@ -203,7 +204,7 @@ function collectDesktopTokenOffenders(): string[] {
       if (!/\.(css|ts|mts|tsx|js|mjs|cjs)$/.test(absPath)) return;
       const raw = readFileSync(absPath, 'utf8');
       const text = absPath.endsWith('.css')
-        ? stripCommentsCss(raw)
+        ? stripCssComments(raw)
         : stripCommentsTs(raw);
       if (tokenPattern.test(text)) {
         offenders.push(relative(repoRoot, absPath));

--- a/src/test-kernel/model/CodingPlanSubscriptionsRuntime.vitest.ts
+++ b/src/test-kernel/model/CodingPlanSubscriptionsRuntime.vitest.ts
@@ -45,6 +45,11 @@ describe('coding-plan subscription runtime', () => {
     });
   });
 
+  afterEach(async () => {
+    setIncludedModelAccess(null);
+    await setProviderEndpoint('glm', '');
+  });
+
   it('freezes every runtime catalog entry', () => {
     expect(Object.isFrozen(codingPlanSubscriptionRuntimes)).toBe(true);
     expect(codingPlanSubscriptionRuntimes.every(Object.isFrozen)).toBe(true);
@@ -78,11 +83,6 @@ describe('coding-plan subscription runtime', () => {
         useOpenRouter: true,
       }),
     ).toEqual({ baseUrl: 'https://openrouter.ai/api/v1' });
-  });
-
-  afterEach(async () => {
-    setIncludedModelAccess(null);
-    await setProviderEndpoint('glm', '');
   });
 
   it('does not report the GLM plan when included access serves the model', async () => {

--- a/src/test-kernel/platform/FakePlatform.vitest.ts
+++ b/src/test-kernel/platform/FakePlatform.vitest.ts
@@ -19,7 +19,6 @@ import {
 } from '../support/FakePlatform';
 
 type ProviderCase = {
-  name: string;
   provider: FileSystemProvider;
   resolve(testPath: string): string;
   expectedRealPath(testPath: string): Promise<string>;
@@ -31,7 +30,6 @@ async function createProviderCase(
 ): Promise<ProviderCase> {
   if (name === 'fake') {
     return {
-      name,
       provider: new FakeFileSystemProvider(),
       resolve: (testPath) => testPath,
       expectedRealPath: async (testPath) => testPath,
@@ -43,7 +41,6 @@ async function createProviderCase(
   const resolve = (testPath: string): string =>
     path.join(root, testPath.slice(1));
   return {
-    name,
     provider: nodeFilesystem,
     resolve,
     expectedRealPath: (testPath) => fs.realpath(resolve(testPath)),

--- a/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
@@ -157,11 +157,10 @@ describe('follow-up-input pasted-image state across stream switches', () => {
     const element = createFollowUpInput('stream-a');
     await element.updateComplete;
 
-    const streamB = getFollowUpInputTransientState('stream-b');
     const imageA = seedPendingImage('stream-a', 'pasted-a.png');
     const imageB = image('pasted-b.png');
 
-    bindStream(element, 'stream-b');
+    const streamB = bindStream(element, 'stream-b');
     streamB.pendingImages = [imageB];
     await element.updateComplete;
 

--- a/src/test-kernel/progressView/ProgressBackendCleanup.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendCleanup.vitest.ts
@@ -111,6 +111,17 @@ async function expectStored(path: string, expected: boolean): Promise<void> {
   expect(await StorageFS.exists(path)).toBe(expected);
 }
 
+/** Tears down the foreign-lease fixtures: lease file, goal, execution store. */
+async function cleanupForeignLease(
+  backend: IsolatedBackend,
+  ids: StreamExecution,
+): Promise<void> {
+  await StorageFS.delete(executionLeasePath(ids.executionId)).catch(() => {});
+  await GoalStore.forget(ids.stream);
+  await getExecutionStore(ids.executionId).clear();
+  await backend.state.clearAll();
+}
+
 describe('ProgressBackend cleanup', () => {
   it('deletes the execution directory named by stream metadata when a stream is cleared', async () => {
     const { backend } = createIsolatedRecordingBackend();
@@ -221,10 +232,7 @@ describe('ProgressBackend cleanup', () => {
       await expectStored(streamDataDir(stream), true);
       expect(GoalStore.getForStream(stream)).not.toBeNull();
     } finally {
-      await StorageFS.delete(executionLeasePath(executionId)).catch(() => {});
-      await GoalStore.forget(stream);
-      await getExecutionStore(executionId).clear();
-      await backend.state.clearAll();
+      await cleanupForeignLease(backend, { stream, executionId });
     }
   });
 
@@ -249,10 +257,7 @@ describe('ProgressBackend cleanup', () => {
       await expectStored(streamDataDir(stream), false);
       expect(GoalStore.getForStream(stream)).toBeNull();
     } finally {
-      await StorageFS.delete(executionLeasePath(executionId)).catch(() => {});
-      await GoalStore.forget(stream);
-      await getExecutionStore(executionId).clear();
-      await backend.state.clearAll();
+      await cleanupForeignLease(backend, { stream, executionId });
     }
   });
 
@@ -274,10 +279,7 @@ describe('ProgressBackend cleanup', () => {
       expect(backend.state.streamLogs.has(stream)).toBe(false);
       await expectStored(`executions/${executionId}`, true);
     } finally {
-      await StorageFS.delete(executionLeasePath(executionId)).catch(() => {});
-      await GoalStore.forget(stream);
-      await getExecutionStore(executionId).clear();
-      await backend.state.clearAll();
+      await cleanupForeignLease(backend, { stream, executionId });
     }
   });
 

--- a/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts
@@ -68,6 +68,25 @@ function stubClearAll(
   });
 }
 
+/**
+ * Stalls `clearStream` until the returned release is called, so a test can
+ * interleave a selection change while a stream deletion is in flight.
+ */
+function gateClearStream(backend: RecordingTarget['backend']): () => void {
+  const clearStream = backend.state.clearStream.bind(backend.state);
+  let releaseClear!: () => void;
+  const clearGate = new Promise<void>((resolve) => {
+    releaseClear = resolve;
+  });
+  vi.spyOn(backend.state, 'clearStream').mockImplementation(
+    async (stream) => {
+      await clearGate;
+      return clearStream(stream);
+    },
+  );
+  return releaseClear;
+}
+
 describe('ProgressBackend', () => {
   it('projects every approval bypass kind through one backend port', () => {
     const { backend, messages } = createRecordingBackend();
@@ -647,17 +666,7 @@ describe('ProgressBackend', () => {
     const active = 'active-stream' as StreamTabId;
     const fallback = 'fallback-stream' as StreamTabId;
     const selected = 'selected-during-delete' as StreamTabId;
-    const clearStream = backend.state.clearStream.bind(backend.state);
-    let releaseClear!: () => void;
-    const clearGate = new Promise<void>((resolve) => {
-      releaseClear = resolve;
-    });
-    vi.spyOn(backend.state, 'clearStream').mockImplementation(
-      async (stream) => {
-        await clearGate;
-        return clearStream(stream);
-      },
-    );
+    const releaseClear = gateClearStream(backend);
 
     for (const stream of [active, fallback, selected]) {
       backend.state.streamLogs.ensureStream(stream);
@@ -692,17 +701,7 @@ describe('ProgressBackend', () => {
     const { backend, messages } = createIsolatedRecordingBackend();
     const fallback = 'surviving-fallback' as StreamTabId;
     const deleting = 'selected-while-deleting' as StreamTabId;
-    const clearStream = backend.state.clearStream.bind(backend.state);
-    let releaseClear!: () => void;
-    const clearGate = new Promise<void>((resolve) => {
-      releaseClear = resolve;
-    });
-    vi.spyOn(backend.state, 'clearStream').mockImplementation(
-      async (stream) => {
-        await clearGate;
-        return clearStream(stream);
-      },
-    );
+    const releaseClear = gateClearStream(backend);
 
     backend.state.streamLogs.ensureStream(fallback);
     backend.state.streamLogs.ensureStream(deleting);
@@ -727,17 +726,7 @@ describe('ProgressBackend', () => {
     const { backend, messages } = createIsolatedRecordingBackend();
     const deleting = 'active-delete-in-progress' as StreamTabId;
     const fallback = 'launcher-must-not-replace' as StreamTabId;
-    const clearStream = backend.state.clearStream.bind(backend.state);
-    let releaseClear!: () => void;
-    const clearGate = new Promise<void>((resolve) => {
-      releaseClear = resolve;
-    });
-    vi.spyOn(backend.state, 'clearStream').mockImplementation(
-      async (stream) => {
-        await clearGate;
-        return clearStream(stream);
-      },
-    );
+    const releaseClear = gateClearStream(backend);
 
     backend.state.streamLogs.ensureStream(fallback);
     backend.state.streamLogs.ensureStream(deleting);
@@ -763,18 +752,8 @@ describe('ProgressBackend', () => {
     const deleting = 'active-being-deleted' as StreamTabId;
     const fallback = 'older-roster-fallback' as StreamTabId;
     const requested = 'newer-pending-switch' as StreamTabId;
-    const clearStream = backend.state.clearStream.bind(backend.state);
-    let releaseClear!: () => void;
+    const releaseClear = gateClearStream(backend);
     let finishRequestedPreload!: () => void;
-    const clearGate = new Promise<void>((resolve) => {
-      releaseClear = resolve;
-    });
-    vi.spyOn(backend.state, 'clearStream').mockImplementation(
-      async (stream) => {
-        await clearGate;
-        return clearStream(stream);
-      },
-    );
     vi.spyOn(backend.state.snapshots, 'preload').mockImplementationOnce(
       () =>
         new Promise<void>((resolve) => {
@@ -819,17 +798,7 @@ describe('ProgressBackend', () => {
     const fallback = 'recovery-survivor' as StreamTabId;
     const loadError = new Error('replacement hydration failed');
     let rejectRequestedPreload!: (error: Error) => void;
-    let releaseClear!: () => void;
-    const clearGate = new Promise<void>((resolve) => {
-      releaseClear = resolve;
-    });
-    const clearStream = backend.state.clearStream.bind(backend.state);
-    vi.spyOn(backend.state, 'clearStream').mockImplementation(
-      async (stream) => {
-        await clearGate;
-        return clearStream(stream);
-      },
-    );
+    const releaseClear = gateClearStream(backend);
 
     for (const stream of [fallback, requested, deleting]) {
       backend.state.streamLogs.ensureStream(stream);
@@ -877,18 +846,8 @@ describe('ProgressBackend', () => {
     const deleting = 'active-before-two-switches' as StreamTabId;
     const committed = 'first-concurrent-switch' as StreamTabId;
     const requested = 'second-pending-switch' as StreamTabId;
-    const clearStream = backend.state.clearStream.bind(backend.state);
-    let releaseClear!: () => void;
+    const releaseClear = gateClearStream(backend);
     let finishRequestedPreload!: () => void;
-    const clearGate = new Promise<void>((resolve) => {
-      releaseClear = resolve;
-    });
-    vi.spyOn(backend.state, 'clearStream').mockImplementation(
-      async (stream) => {
-        await clearGate;
-        return clearStream(stream);
-      },
-    );
 
     for (const stream of [committed, requested, deleting]) {
       backend.state.streamLogs.ensureStream(stream);

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
@@ -3,6 +3,7 @@ import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as vscode from 'vscode';
 
 // Local imports
 import type { ProgressHostInteractions } from '@controllers/progressView/backend/progressHostInteractions';
@@ -18,8 +19,6 @@ import {
   createOutputFile,
   createWorkflowConfig,
 } from '../support/ProgressControllerHarnesses';
-
-import type * as vscode from 'vscode';
 
 const mocks = vi.hoisted(() => ({
   safeExecuteCommand: vi.fn(),

--- a/src/test-kernel/progressView/StreamTabsStatus.vitest.ts
+++ b/src/test-kernel/progressView/StreamTabsStatus.vitest.ts
@@ -50,6 +50,11 @@ function styleText(element: Element): string {
     .join('\n');
 }
 
+/** Let the nested <stream-tab> finish its own first render. */
+function settleChildRender(): Promise<unknown> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 async function mountTabs(
   streams: StreamTabInfo[],
   statuses: readonly StreamLifecycleStatus[],
@@ -66,7 +71,7 @@ async function mountTabs(
     streamStates,
     activeStreamId,
   });
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await settleChildRender();
   return tabs;
 }
 
@@ -166,7 +171,7 @@ describe('stream-tab lifecycle distinction', () => {
         ],
       ]),
     });
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await settleChildRender();
     const row = tabs.shadowRoot?.querySelector('stream-tab');
 
     expect(
@@ -216,7 +221,7 @@ describe('stream-tab lifecycle distinction', () => {
       ]),
       compact: true,
     });
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await settleChildRender();
     const rows = [...(tabs.shadowRoot?.querySelectorAll('stream-tab') ?? [])];
 
     expect(

--- a/src/test-kernel/progressView/StreamTree.vitest.ts
+++ b/src/test-kernel/progressView/StreamTree.vitest.ts
@@ -1,5 +1,4 @@
-import { strict as assert } from 'node:assert';
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   computeStreamTreeProjection,
@@ -50,14 +49,13 @@ describe('progress stream tree policy', () => {
 
     const projection = project(childStreamsByParent);
 
-    assert.equal(projection.expandedParents.has('root'), true);
-    assert.equal(
+    expect(projection.expandedParents.has('root')).toBe(true);
+    expect(
       getStreamBranchActivity(
         { streamStates: new Map(), childStreamsByParent },
         'child',
       ),
-      'unknown',
-    );
+    ).toBe('unknown');
   });
 
   it('collapses a parent once every child branch is finished', () => {
@@ -71,9 +69,9 @@ describe('progress stream tree policy', () => {
 
     const projection = project(childStreamsByParent, streamStates);
 
-    assert.equal(projection.expandedParents.has('root'), false);
-    assert.equal(projection.branchActivityByStream.get('child-a'), 'finished');
-    assert.equal(projection.branchActivityByStream.get('child-b'), 'finished');
+    expect(projection.expandedParents.has('root')).toBe(false);
+    expect(projection.branchActivityByStream.get('child-a')).toBe('finished');
+    expect(projection.branchActivityByStream.get('child-b')).toBe('finished');
   });
 
   it('expands ancestors when a descendant is active', () => {
@@ -88,10 +86,10 @@ describe('progress stream tree policy', () => {
 
     const projection = project(childStreamsByParent, streamStates);
 
-    assert.equal(projection.expandedParents.has('root'), true);
-    assert.equal(projection.expandedParents.has('child'), true);
-    assert.equal(projection.branchActivityByStream.get('child'), 'active');
-    assert.equal(projection.branchActivityByStream.get('grandchild'), 'active');
+    expect(projection.expandedParents.has('root')).toBe(true);
+    expect(projection.expandedParents.has('child')).toBe(true);
+    expect(projection.branchActivityByStream.get('child')).toBe('active');
+    expect(projection.branchActivityByStream.get('grandchild')).toBe('active');
   });
 
   it('honors user overrides and drops overrides for missing parents', () => {
@@ -109,8 +107,8 @@ describe('progress stream tree policy', () => {
       ]),
     );
 
-    assert.equal(projection.expandedParents.has('root'), false);
-    assert.deepEqual([...projection.userOverrides], [['root', 'collapsed']]);
+    expect(projection.expandedParents.has('root')).toBe(false);
+    expect([...projection.userOverrides]).toEqual([['root', 'collapsed']]);
   });
 
   it('allows users to keep a finished parent expanded', () => {
@@ -125,7 +123,7 @@ describe('progress stream tree policy', () => {
       new Map([['root', 'expanded']]),
     );
 
-    assert.equal(projection.expandedParents.has('root'), true);
+    expect(projection.expandedParents.has('root')).toBe(true);
   });
 
   it('guards cycles while preserving the stream own activity', () => {
@@ -138,14 +136,13 @@ describe('progress stream tree policy', () => {
       ['child', streamState(STREAM_PHASE.CANCELLED)],
     ]);
 
-    assert.equal(
+    expect(
       getStreamBranchActivity(
         { streamStates, childStreamsByParent },
         'child',
         new Set(['root']),
       ),
-      'finished',
-    );
+    ).toBe('finished');
   });
 
   it('guards direct self-loops', () => {
@@ -154,13 +151,12 @@ describe('progress stream tree policy', () => {
       ['root', streamState(STREAM_PHASE.CANCELLED)],
     ]);
 
-    assert.equal(
+    expect(
       getStreamBranchActivity(
         { streamStates, childStreamsByParent },
         'root',
         new Set(['root']),
       ),
-      'finished',
-    );
+    ).toBe('finished');
   });
 });

--- a/src/test-kernel/progressView/ToolEditRequestPanel.vitest.ts
+++ b/src/test-kernel/progressView/ToolEditRequestPanel.vitest.ts
@@ -16,7 +16,7 @@ import {
 } from '../settings/litComponentTestUtils';
 
 function createPermission(
-  data: Partial<ToolEditPermission>,
+  data: Partial<ToolEditPermission> = {},
 ): ToolEditRequestPanel['permission'] {
   return {
     kind: 'toolEdit',
@@ -84,7 +84,7 @@ describe('tool-edit-request-panel', () => {
   );
 
   it('uses a shared tooltip for the direct diff action', async () => {
-    const element = await mountPanel(createPermission({}));
+    const element = await mountPanel(createPermission());
     const button = element.shadowRoot?.querySelector('#tool-edit-diff-button');
 
     expect(button).toBeTruthy();
@@ -93,7 +93,7 @@ describe('tool-edit-request-panel', () => {
   });
 
   it('keeps the non-LaTeX diff action as a plain standalone button', async () => {
-    const element = await mountPanel(createPermission({}));
+    const element = await mountPanel(createPermission());
     const button = element.shadowRoot?.querySelector(
       'wa-button[data-action="openDiff"]',
     );
@@ -220,7 +220,7 @@ describe('tool-edit-request-panel', () => {
     // Each host answers openDiff its own way — the extension opens a VS Code
     // diff tab, the desktop posts desktop:showDiff to its Review workbench —
     // so the panel never renders a diff itself and holds no toggle state.
-    const element = await mountPanel(createPermission({}));
+    const element = await mountPanel(createPermission());
     const actions = recordPermissionActions(element);
 
     expect(element.handleKeyboardShortcut('d')).toBe(true);

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.ts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.ts
@@ -459,18 +459,13 @@ const SUMMARY_CONTROL_CASES = [
     detailsSelector: 'wa-details.tool-use-details',
     controlSelector: 'button.proposal-restore-link',
     buildTemplate: () =>
-      formatToolUseTemplate({
-        id: 'proposal-2',
-        text: '',
-        level: LOG_LEVELS.INFO,
-        timestamp: 1,
-        messageType: 'toolUse',
-        data: {
+      formatToolUseTemplate(
+        toolUseMessage('proposal-2', {
           toolName: 'delegate_agent',
           input: { agent: 'assistant', instruction: 'do the thing' },
           output: 'proposed',
-        },
-      }),
+        }),
+      ),
   },
   {
     control: 'copy button',

--- a/src/test-kernel/progressView/streamInfoUtils.vitest.ts
+++ b/src/test-kernel/progressView/streamInfoUtils.vitest.ts
@@ -1,4 +1,3 @@
-import { strict as assert } from 'node:assert';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getStreamTabDisplayName } from '@agent/runtime/streamTab';
 import {
@@ -60,10 +59,9 @@ describe('compareByNewestCreationTime', () => {
       expected: ['a-stream', 'b-stream'],
     },
   ])('$title', ({ streams, expected }) => {
-    assert.deepEqual(
+    expect(
       streams.sort(compareByNewestCreationTime).map((stream) => stream.name),
-      expected,
-    );
+    ).toEqual(expected);
   });
 });
 

--- a/src/test-kernel/replacement/ReplacementRules.vitest.ts
+++ b/src/test-kernel/replacement/ReplacementRules.vitest.ts
@@ -431,9 +431,9 @@ describe('latex forbidden commands replacements', () => {
     const input =
       '\\chapter{Ch}\n\\end{chapter}\n\\section{S}\n\\end{section}\n\\subsubsection{SS}\n\\end{subsubsection}';
     const result = apply(input, LATEX_FORBIDDEN_REPLACEMENTS);
-    assert.strictEqual(result.includes('\\end{chapter}'), false);
-    assert.strictEqual(result.includes('\\end{section}'), false);
-    assert.strictEqual(result.includes('\\end{subsubsection}'), false);
+    assert.ok(!result.includes('\\end{chapter}'));
+    assert.ok(!result.includes('\\end{section}'));
+    assert.ok(!result.includes('\\end{subsubsection}'));
   });
 });
 

--- a/src/test-kernel/settings/SubscriptionUsageRendering.vitest.ts
+++ b/src/test-kernel/settings/SubscriptionUsageRendering.vitest.ts
@@ -71,6 +71,18 @@ function getKimiUsageRow(
   );
 }
 
+function mountTab(): Promise<SubscriptionsTabElement> {
+  return mountComponent<SubscriptionsTabElement>('subscriptions-tab', {
+    usage: snapshots,
+  });
+}
+
+function mountTabWithFakeTimers(): Promise<SubscriptionsTabElement> {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  return mountTab();
+}
+
 describe('subscription usage rendering', () => {
   useLitComponentTestDom(
     () => import('@settingsView/frontend/tabs/SubscriptionsTab'),
@@ -80,10 +92,7 @@ describe('subscription usage rendering', () => {
   afterEach(() => vi.useRealTimers());
 
   it('renders native collapsed summaries, accessible meters, and one refresh action', async () => {
-    const tab = await mountComponent<SubscriptionsTabElement>(
-      'subscriptions-tab',
-      { usage: snapshots },
-    );
+    const tab = await mountTab();
 
     expect(mocks.postMessage).toHaveBeenCalledWith(
       SETTINGS_VIEW_COMMANDS.GET_SUBSCRIPTION_USAGE,
@@ -128,12 +137,7 @@ describe('subscription usage rendering', () => {
   });
 
   it('advances one tab clock while connected and stops it after disconnect', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-    const tab = await mountComponent<SubscriptionsTabElement>(
-      'subscriptions-tab',
-      { usage: snapshots },
-    );
+    const tab = await mountTabWithFakeTimers();
     expect(tab.now).toBe(NOW);
     expect(vi.getTimerCount()).toBe(1);
 
@@ -155,12 +159,7 @@ describe('subscription usage rendering', () => {
   });
 
   it('restarts one fresh clock when the same tab reconnects', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-    const tab = await mountComponent<SubscriptionsTabElement>(
-      'subscriptions-tab',
-      { usage: snapshots },
-    );
+    const tab = await mountTabWithFakeTimers();
 
     tab.remove();
     expect(vi.getTimerCount()).toBe(0);
@@ -176,12 +175,7 @@ describe('subscription usage rendering', () => {
   });
 
   it('refreshes the tab clock when fresh usage arrives', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-    const tab = await mountComponent<SubscriptionsTabElement>(
-      'subscriptions-tab',
-      { usage: snapshots },
-    );
+    const tab = await mountTabWithFakeTimers();
     tab.now = NOW - 10 * 60_000;
     vi.setSystemTime(NOW + 30_000);
     tab.usage = {

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -416,13 +416,13 @@ describe('UsageLogService', () => {
     // records populate, so an opt-out that suppressed them would let hosted
     // calls run on against a stale total. Only `api-key` rounds are optional.
     it.each([
-      ['relay', 'relay'],
-      ['chatgpt-subscription', 'chatgpt-subscription'],
-      ['kimi-code-subscription', 'kimi-code-subscription'],
-      ['glm-coding-plan-subscription', 'glm-coding-plan-subscription'],
+      'relay',
+      'chatgpt-subscription',
+      'kimi-code-subscription',
+      'glm-coding-plan-subscription',
     ] as const)(
       'still sends %s usage while the setting is off',
-      async (_label, usageRoute) => {
+      async (usageRoute) => {
         stubRelayToken();
         await platform().config.update(TELEMETRY_ENABLED_KEY, false, 'global');
 
@@ -495,7 +495,7 @@ describe('UsageLogService', () => {
       await expectOptedOutFlush();
     });
 
-    it.each([['0'], ['false'], ['']])(
+    it.each(['0', 'false', ''])(
       'ignores TEXRA_NO_TELEMETRY=%p',
       async (value) => {
         stubRelayToken();
@@ -533,7 +533,7 @@ describe('UsageLogService', () => {
 
     // JsonConfigProvider returns raw JSON from a hand-edited .texra/config.json,
     // so a mistyped string must not read as truthy and re-enable logging.
-    it.each([['false'], ['0'], [0], [null]])(
+    it.each(['false', '0', 0, null])(
       'treats the non-boolean value %p as opted out',
       async (value) => {
         stubRelayToken();

--- a/src/test-kernel/tools/ArxivDownloadTool.vitest.ts
+++ b/src/test-kernel/tools/ArxivDownloadTool.vitest.ts
@@ -17,16 +17,6 @@ import { FileType } from '@platform/interfaces';
 import { ArxivDownloadTool } from '@tools/arxiv/ArxivDownloadTool';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 
-declare module '@latex/arxivProcessor' {
-  interface ArxivSourceProcessor {
-    validateId(id: string): string | null;
-    downloadSource(
-      input: string,
-      options?: DownloadSourceOptions,
-    ): Promise<{ path: string; alreadyExisted: boolean }>;
-  }
-}
-
 describe('ArxivDownloadTool', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/src/test-kernel/tools/DelegationAgentAvailability.vitest.ts
+++ b/src/test-kernel/tools/DelegationAgentAvailability.vitest.ts
@@ -107,12 +107,7 @@ async function resolveDelegateAgent(extraTools: ToolInput[] = []) {
 
 describe('delegation agent availability', () => {
   it('formats an agent list with descriptions and per-agent tools', () => {
-    expect(
-      formatAgentList([
-        { name: 'research', description: 'Derive and verify.' },
-        { name: 'numerics', description: 'Run simulations.', tools: ['bash'] },
-      ]),
-    ).toBe(
+    expect(formatAgentList(RESEARCH_NUMERICS_AGENTS)).toBe(
       [
         '- research: Derive and verify.',
         '- numerics: Run simulations.',

--- a/src/test-kernel/tools/DelegationAgentScope.vitest.ts
+++ b/src/test-kernel/tools/DelegationAgentScope.vitest.ts
@@ -14,6 +14,10 @@ const customReview = {
   name: 'review',
   path: '/agents/custom-review.yaml',
 } as const;
+const remoteReviewScope = {
+  workflow: [],
+  toolUse: ['remote:review'],
+};
 const mocks = vi.hoisted(() => ({
   context: undefined as unknown,
 }));
@@ -55,10 +59,7 @@ describe('execution-scoped delegation agents', () => {
     mocks.context = {
       kind: 'launch',
       runScope: {
-        delegationAgentScope: {
-          workflow: [],
-          toolUse: ['remote:review'],
-        },
+        delegationAgentScope: remoteReviewScope,
       },
     };
   });
@@ -71,15 +72,15 @@ describe('execution-scoped delegation agents', () => {
 
   it('can enforce a captured scope without ambient run context', () => {
     mocks.context = undefined;
-    const scope = {
-      workflow: [],
-      toolUse: ['remote:review'],
-    };
 
-    expect(getDelegationAgents('toolUse', scope)).toEqual([remoteReview]);
-    expect(getDelegationAgent('toolUse', 'review', scope)).toBe(remoteReview);
+    expect(getDelegationAgents('toolUse', remoteReviewScope)).toEqual([
+      remoteReview,
+    ]);
+    expect(getDelegationAgent('toolUse', 'review', remoteReviewScope)).toBe(
+      remoteReview,
+    );
     expect(
-      getDelegationAgent('toolUse', 'custom:review', scope),
+      getDelegationAgent('toolUse', 'custom:review', remoteReviewScope),
     ).toBeUndefined();
   });
 

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -150,6 +150,28 @@ async function registerProcessExecution(
   return { executionId, streamId };
 }
 
+/** Register a multi-agent-workflow execution and return its id. */
+async function registerWorkflowExecution(
+  name: string,
+  model?: string,
+): Promise<string> {
+  const executionId = generateExecutionId();
+  await registerExecution(
+    executionId,
+    {
+      name,
+      instruction: `Workflow script ${name}`,
+      ...(model ? { model } : {}),
+    },
+    name,
+    {
+      streamId: `workflow-script#${executionId}` as StreamTabId,
+      identity: { kind: 'multiAgentWorkflow', workflowName: name },
+    },
+  );
+  return executionId;
+}
+
 describe('ExecutionsTool /executions/{id}/output', () => {
   setupPlatform({
     workspacePath: '/workspace',
@@ -407,19 +429,7 @@ describe('ExecutionsTool /executions/{id}/output', () => {
   });
 
   it('exposes the canonical workflow aggregate without full instructions', async () => {
-    const executionId = generateExecutionId();
-    await registerExecution(
-      executionId,
-      { name: 'observable', instruction: 'Workflow script observable' },
-      'observable',
-      {
-        streamId: `workflow-script#${executionId}` as StreamTabId,
-        identity: {
-          kind: 'multiAgentWorkflow',
-          workflowName: 'observable',
-        },
-      },
-    );
+    const executionId = await registerWorkflowExecution('observable');
     const timestamp = new Date().toISOString();
     const longStageId = `stage-${'s'.repeat(2_500)}-stage-tail`;
     const longCallId = `call-${'i'.repeat(2_500)}-call-tail`;
@@ -517,19 +527,7 @@ describe('ExecutionsTool /executions/{id}/output', () => {
   });
 
   it('keeps a failed call ahead of newer completed current-stage calls when bounded', async () => {
-    const executionId = generateExecutionId();
-    await registerExecution(
-      executionId,
-      { name: 'failed-rank', instruction: 'Workflow script failed-rank' },
-      'failed-rank',
-      {
-        streamId: `workflow-script#${executionId}` as StreamTabId,
-        identity: {
-          kind: 'multiAgentWorkflow',
-          workflowName: 'failed-rank',
-        },
-      },
-    );
+    const executionId = await registerWorkflowExecution('failed-rank');
     const base = Date.parse('2026-04-01T00:00:00.000Z');
     const completedCalls = Array.from({ length: 8 }, (_, index) => {
       const updatedAt = new Date(base + (index + 1) * 1_000).toISOString();
@@ -611,19 +609,7 @@ describe('ExecutionsTool /executions/{id}/output', () => {
   });
 
   it('keeps an earlier-stage live call ahead of current-stage terminal calls when bounded', async () => {
-    const executionId = generateExecutionId();
-    await registerExecution(
-      executionId,
-      { name: 'ranked', instruction: 'Workflow script ranked' },
-      'ranked',
-      {
-        streamId: `workflow-script#${executionId}` as StreamTabId,
-        identity: {
-          kind: 'multiAgentWorkflow',
-          workflowName: 'ranked',
-        },
-      },
-    );
+    const executionId = await registerWorkflowExecution('ranked');
     const timestamp = new Date().toISOString();
     const terminalCalls = Array.from({ length: 8 }, (_, index) => ({
       id: `current-terminal-${index}`,
@@ -694,19 +680,9 @@ describe('ExecutionsTool /executions/{id}/output', () => {
   });
 
   it('shows one model for a workflow run in both the listing and its summary', async () => {
-    const executionId = generateExecutionId();
-    await registerExecution(
-      executionId,
-      {
-        name: 'model-parity',
-        instruction: 'Workflow script model-parity',
-        model: 'parity-model-1',
-      },
+    const executionId = await registerWorkflowExecution(
       'model-parity',
-      {
-        streamId: `workflow-script#${executionId}` as StreamTabId,
-        identity: { kind: 'multiAgentWorkflow', workflowName: 'model-parity' },
-      },
+      'parity-model-1',
     );
 
     const summary = await new ExecutionsTool().call({

--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -6,10 +6,10 @@ import * as logUtils from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import {
   ExternalInquiryPermissionSchema,
+  ToolError,
   type InquiryThreadId,
   type StreamTabId,
 } from '@shared/schemas';
-import { ToolError } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
   getOpenTurnDraft,

--- a/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentProductionPath.vitest.ts
@@ -208,6 +208,13 @@ function childExecutionId(resultOutput: string | undefined): ExecutionId {
   return match[1] as ExecutionId;
 }
 
+function interruptActiveExecutions(session: SessionHandle): void {
+  for (const executionId of session.executions.getActiveIds()) {
+    const handle = session.executions.getHandle(executionId);
+    if (handle instanceof AgentExecutionHandle) handle.interrupt();
+  }
+}
+
 async function waitForCompletedResumes(count: number): Promise<void> {
   await vi.waitFor(() => expect(completedResumes).toHaveLength(count), {
     timeout: 10_000,
@@ -342,10 +349,7 @@ describe('native subagent production delivery path', { retry: 2 }, () => {
   });
 
   afterEach(async () => {
-    for (const executionId of session.executions.getActiveIds()) {
-      const handle = session.executions.getHandle(executionId);
-      if (handle instanceof AgentExecutionHandle) handle.interrupt();
-    }
+    interruptActiveExecutions(session);
     if (childId) await waitForOwnedExecutionLeaseRelease(childId);
     await releaseOwnedExecutionLease(PARENT_EXECUTION_ID);
     session.dispose();
@@ -661,10 +665,7 @@ describe('native subagent production delivery path', { retry: 2 }, () => {
     });
 
     // Interrupt turn 2 before it persists any result.
-    for (const activeId of session.executions.getActiveIds()) {
-      const handle = session.executions.getHandle(activeId);
-      if (handle instanceof AgentExecutionHandle) handle.interrupt();
-    }
+    interruptActiveExecutions(session);
     releaseTurn2(new Error('interrupted before result persistence'));
     await waitForOwnedExecutionLeaseRelease(executionId);
 

--- a/src/test-kernel/tools/ToolAvailabilitySeeding.vitest.ts
+++ b/src/test-kernel/tools/ToolAvailabilitySeeding.vitest.ts
@@ -15,9 +15,7 @@ const EXPECTED_DEFAULTS = EXTERNAL_TOOL_DEFS.filter(
 ).map((def) => def.id);
 
 describe('seedDisabledToolDefaults', () => {
-  afterEach(async () => {
-    await installPlatform();
-  });
+  afterEach(() => installPlatform());
 
   it('seeds every toggleable tool as disabled on a genuinely fresh install', async () => {
     await installPlatform({ globalState: {} });

--- a/src/test-kernel/tools/Wolfram.vitest.ts
+++ b/src/test-kernel/tools/Wolfram.vitest.ts
@@ -14,7 +14,6 @@ import {
   WolframTool,
 } from '@tools/wolfram/WolframTool';
 import * as wolframScriptUtils from '@tools/wolfram/wolframScriptUtils';
-import { executeWolframCode } from '@tools/wolfram/wolframScriptUtils';
 import * as toolUtils from '@utils/system/toolUtils';
 import * as execUtils from '@utils/system/execUtils';
 import {
@@ -157,7 +156,7 @@ describe('wolframScriptUtils', () => {
       .spyOn(execUtils, 'executeCommand')
       .mockResolvedValue({ success: true, stdout: '2', stderr: '' });
 
-    const result = await executeWolframCode('1+1');
+    const result = await wolframScriptUtils.executeWolframCode('1+1');
 
     expect(executeCommand).toHaveBeenCalledWith(
       ['wolframscript', '-code', '1+1'],

--- a/src/test-kernel/tools/codexConfig.vitest.ts
+++ b/src/test-kernel/tools/codexConfig.vitest.ts
@@ -22,10 +22,10 @@ import {
   buildCodexMcpToolLog,
   buildCodexThreadToolLog,
   buildCodexTodoToolLog,
-  CODEX_AGENT_NAME,
-  CODEX_DISPLAY_MODEL,
   buildCodexTurnToolLog,
   buildCodexUsageStats,
+  CODEX_AGENT_NAME,
+  CODEX_DISPLAY_MODEL,
 } from '@tools/codexShared';
 
 describe('buildCodexConfig', () => {

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -278,14 +278,10 @@ describe('completedRunArchive facade', () => {
     await writeSidecarFixture(executionId, streamId);
 
     const store = getExecutionStore(executionId);
-    await store.writeRunRecord(
-      AgentConfigSchema.parse({
-        agent: 'orchestrator',
-        model: 'deepseekproT',
-        agentCategory: AgentCategory.ToolUse,
-        instruction: 'Fix the lemma.',
-      }),
-    );
+    await store.writeRunRecord({
+      ...runConfig('orchestrator'),
+      instruction: 'Fix the lemma.',
+    });
     await stampStreamId(executionId, streamId);
 
     const conversationResult = await readCompletedRunConversation(executionId);

--- a/src/test-kernel/utils/AppendTail.vitest.ts
+++ b/src/test-kernel/utils/AppendTail.vitest.ts
@@ -3,10 +3,6 @@
 import { describe, expect, it } from 'vitest';
 import { appendHead, appendTail } from '@utils/text/appendTail';
 
-// ---------------------------------------------------------------------------
-// AppendTail
-// ---------------------------------------------------------------------------
-
 describe('appendTail', () => {
   it('returns the current string when the chunk is empty', () => {
     expect(appendTail('abc', '', 10)).toBe('abc');
@@ -62,10 +58,6 @@ describe('appendTail', () => {
     expect(out.charCodeAt(0)).toBeLessThan(0xd800);
   });
 });
-
-// ---------------------------------------------------------------------------
-// AppendHead
-// ---------------------------------------------------------------------------
 
 describe('appendHead', () => {
   it('returns the current string when the chunk is empty', () => {


### PR DESCRIPTION
## Summary

A one-shot simplification sweep over the test corpus (`src/test-kernel/` + `packages/desktop/`): **128 `code-simplifier` agents**, one per disjoint LOC-balanced region (~6.8 files / ~1884 LOC each), editing only their assigned files.

**Net −231 LOC** (719 insertions, 950 deletions) across 88 files. Behavior-preserving only — no test deleted, no assertion weakened or strengthened, no coverage-granularity change.

## Verification

- `npm run typecheck` — green across all six sub-projects (workspace, test-kernel, agent, cli, trace-viewer, desktop). One syntax regression introduced by an agent was caught and fixed during the gate.
- `npx vitest run <88 modified files>` — **88 files / 2109 tests passed, 0 failures**.

## Coverage

- 70 regions produced edits; 57 were already clean; **region 111 (8 `tools/` files) was skipped** — its agent was blocked by a safety classifier mid-run.

## Cross-cutting structural findings (not fixed here — they span files)

The sweep's real signal: per-file simplification is largely exhausted; the remaining value is cross-cutting consolidation.

1. **`vi.hoisted` mock-bag + `vi.mock` + reset ritual** duplicated in 40+ files (especially `cli/`) — candidate for a shared mock-factory helper.
2. **Temp-dir boilerplate** in three divergent cleanup idioms — a scoped `withTempDir` registry would collapse ~10+ sites.
3. **`createTestCliContext` re-wrapped per-file** with identical defaults (~23 files).
4. **Small helper duplication** (2–4× each): `outputOf`, `errno`, `pathExists`, `StreamTabId` cast, `fakeClock`, `currentFrame`, fetch-capture, `deferred` (vs `createDeferred`, which lacks `reject`).
5. **Domain fixture duplication**: launch-mock boilerplate (~40 lines × N), `LiveToolUseFlowContext`, resumability fixture, `@shared/hostBridge` postMessage mock, delegation-scope resolver mock.

**Convention decision (per maintainer):** `node:assert` (strict) and Vitest `expect` remain both-supported dual idioms — to be documented, not normalized.

Follow-up PRs for the shared-helper extractions are planned via the 64/32/16 waves.
