### PR TITLE
refactor(test): consolidate deferred + temp-dir helpers (64-wave)

### DIFF
--- a/src/test-kernel/agent/AgentCategoryResolution.vitest.ts
+++ b/src/test-kernel/agent/AgentCategoryResolution.vitest.ts
@@ -1,10 +1,9 @@
 // Node imports
-import { mkdtemp, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 // Third-party imports
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports
 import {
@@ -22,6 +21,7 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { AgentCategory } from '@shared/schemas';
 import { REPO_ROOT } from '@test/support/repoScan';
 import { installPlatform } from '@test/support/setupPlatform';
+import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 
 /** Resolve exactly as launch does: through the single launch resolver, by the
  * source the delegation captured at validation time (see `getAgentPath`). */
@@ -41,6 +41,8 @@ function launchAs(category: AgentCategory, entry: AgentEntry | undefined) {
  * it cannot diverge from what validation accepted.
  */
 describe('cross-category agent resolution', () => {
+  const tempDirs: string[] = [];
+
   beforeAll(async () => {
     const customAgents: Record<string, string[]> = {
       'assistant.yaml': [
@@ -60,7 +62,7 @@ describe('cross-category agent resolution', () => {
         '  systemPrompt: Custom review agent.',
       ],
     };
-    const customDir = await mkdtemp(resolve(tmpdir(), 'texra-custom-agent-'));
+    const customDir = await makeTempDir('texra-custom-agent-', tempDirs);
     for (const [fileName, lines] of Object.entries(customAgents)) {
       await writeFile(resolve(customDir, fileName), `${lines.join('\n')}\n`);
     }
@@ -80,6 +82,10 @@ describe('cross-category agent resolution', () => {
     );
 
     await refresh({ includeRemote: false });
+  });
+
+  afterAll(async () => {
+    await cleanupTempDirs(tempDirs);
   });
 
   it('demonstrates the divergence the category-scoped resolver closes', () => {

--- a/src/test-kernel/agent/AgentYamlScanner.vitest.ts
+++ b/src/test-kernel/agent/AgentYamlScanner.vitest.ts
@@ -1,21 +1,23 @@
 // Node imports
-import { mkdtemp, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 // Third-party imports
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports
 import { scanDirectory } from '@agent/index/agentYamlScanner';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { installPlatform } from '@test/support/setupPlatform';
+import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
+
+const tempDirs: string[] = [];
 
 /** Create a temp agent directory holding the given YAML files, given as lines. */
 async function createAgentDir(
   files: Record<string, readonly string[]>,
 ): Promise<string> {
-  const agentDir = await mkdtemp(resolve(tmpdir(), 'texra-agent-scan-'));
+  const agentDir = await makeTempDir('texra-agent-scan-', tempDirs);
   for (const [fileName, lines] of Object.entries(files)) {
     await writeFile(resolve(agentDir, fileName), `${lines.join('\n')}\n`);
   }
@@ -34,6 +36,10 @@ function toolUseAgent(name: string, systemPrompt: string): string[] {
 
 describe('agent YAML scanner', () => {
   beforeAll(() => installPlatform({}, { fs: nodeFilesystem }));
+
+  afterEach(async () => {
+    await cleanupTempDirs(tempDirs);
+  });
 
   it('derives workflow round counts from inherited settings and prompts', async () => {
     const agentDir = await createAgentDir({

--- a/src/test-kernel/agent/GoalPromptParity.vitest.ts
+++ b/src/test-kernel/agent/GoalPromptParity.vitest.ts
@@ -1,9 +1,8 @@
 import { readFileSync } from 'node:fs';
-import { mkdtemp, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import * as yaml from 'yaml';
 
 import {
@@ -13,6 +12,7 @@ import {
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { REPO_ROOT } from '@test/support/repoScan';
 import { setupPlatform } from '@test/support/setupPlatform';
+import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 
 interface GoalPromptsYaml {
   continuation: { template: string };
@@ -33,6 +33,12 @@ const goalYaml = yaml.parse(
 // completion-audit discipline. Both must render the same template.
 describe('Goal prompt parity (YAML ↔ inline fallback)', () => {
   setupPlatform({}, { fs: nodeFilesystem });
+
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await cleanupTempDirs(tempDirs);
+  });
 
   it('continuation template in YAML is fully reflected in the inline fallback', () => {
     const loader = readFileSync(
@@ -63,7 +69,7 @@ describe('Goal prompt parity (YAML ↔ inline fallback)', () => {
   });
 
   it('falls back to the inline template instead of throwing on malformed goal YAML', async () => {
-    const dir = await mkdtemp(resolve(tmpdir(), 'texra-goal-'));
+    const dir = await makeTempDir('texra-goal-', tempDirs);
     const brokenPath = resolve(dir, 'broken.yaml');
     await writeFile(brokenPath, 'continuation:\n  template: "unterminated\n');
     initializeGoalPrompts(brokenPath);

--- a/src/test-kernel/agent/PolishPromptLoader.vitest.ts
+++ b/src/test-kernel/agent/PolishPromptLoader.vitest.ts
@@ -1,10 +1,9 @@
 // Node imports
-import { mkdtemp, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 // Local imports
 import {
@@ -14,9 +13,16 @@ import {
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { REPO_ROOT } from '@test/support/repoScan';
 import { setupPlatform } from '@test/support/setupPlatform';
+import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 
 describe('polish prompt loader', () => {
   setupPlatform({}, { fs: nodeFilesystem });
+
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await cleanupTempDirs(tempDirs);
+  });
 
   it('loads the host-provided polish YAML path directly', async () => {
     initializePolishModel(
@@ -34,7 +40,7 @@ describe('polish prompt loader', () => {
   });
 
   it('rejects with a wrapped error for malformed polish prompt YAML', async () => {
-    const dir = await mkdtemp(resolve(tmpdir(), 'texra-polish-'));
+    const dir = await makeTempDir('texra-polish-', tempDirs);
     const brokenPath = resolve(dir, 'broken.yaml');
     await writeFile(brokenPath, 'prompts:\n  userRequest: "unterminated\n');
     initializePolishModel(brokenPath);

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -10,14 +10,7 @@ import type { ToolUseFollowUpTarget } from '@agent/runtime/executionRegistry';
 import type { LiveToolUseFlowContext } from '@agent/runtime/ExecutionHandle';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
+import { createDeferred } from '@test/support/asyncTestUtils';
 
 function mockTryResume(): Mock<() => Promise<boolean>> {
   return vi.fn(async () => true);
@@ -191,7 +184,7 @@ describe('submitFollowUp', () => {
   it('claims one recovery and orders repeated submissions once', async () => {
     const streamId = id('stream:recovery');
     const session = fakeSession({ kind: 'queue', reason: 'waiting' });
-    const barrier = deferred<boolean>();
+    const barrier = createDeferred<boolean>();
     const claimed: unknown[] = [];
     const tryResumeStream = vi.fn((_: StreamTabId, recovery: unknown) => {
       claimed.push(recovery);
@@ -441,11 +434,11 @@ describe('submitFollowUp', () => {
     const generationId = '5038fe96-7113-449a-82a9-3e58f292d1ba';
     mockPersistedExecution(session);
     const lookup =
-      deferred<Awaited<ReturnType<typeof resumability.deriveResumability>>>();
+      createDeferred<Awaited<ReturnType<typeof resumability.deriveResumability>>>();
     const deriveResumability = vi
       .spyOn(resumability, 'deriveResumability')
       .mockReturnValueOnce(lookup.promise);
-    const resumeBarrier = deferred<boolean>();
+    const resumeBarrier = createDeferred<boolean>();
     const tryResumeStream = vi.fn(() => resumeBarrier.promise);
 
     const first = submitFollowUp(streamId, 'durable inquiry', {

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -434,7 +434,9 @@ describe('submitFollowUp', () => {
     const generationId = '5038fe96-7113-449a-82a9-3e58f292d1ba';
     mockPersistedExecution(session);
     const lookup =
-      createDeferred<Awaited<ReturnType<typeof resumability.deriveResumability>>>();
+      createDeferred<
+        Awaited<ReturnType<typeof resumability.deriveResumability>>
+      >();
     const deriveResumability = vi
       .spyOn(resumability, 'deriveResumability')
       .mockReturnValueOnce(lookup.promise);

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -1,5 +1,4 @@
 import * as fs from 'node:fs/promises';
-import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -45,6 +44,7 @@ import {
 } from '@platform/languageModel';
 import { installPlatform } from '@test/support/setupPlatform';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
+import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 
 // This file calls vi.resetModules(), which desyncs the statically-imported
 // factory from a freshly-imported @platform copy. Blocks that must agree with
@@ -92,6 +92,12 @@ async function inspectHandler<T>(
     handler.dispose();
   }
 }
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await cleanupTempDirs(tempDirs);
+});
 
 describe('Copilot model handler routing', () => {
   const copilotConfig = modelConfig(ModelProvider.COPILOT, {
@@ -744,9 +750,7 @@ describe('OpenAI model handler routing', () => {
   });
 
   it('uses the validation compatibility key only after the validation gate passes', async () => {
-    const flagRoot = await fs.mkdtemp(
-      path.join(os.tmpdir(), 'texra-validation-handler-'),
-    );
+    const flagRoot = await makeTempDir('texra-validation-handler-', tempDirs);
     const flagPath = path.join(flagRoot, 'flag');
     await fs.writeFile(flagPath, 'texra-cli-run-validation\n');
 

--- a/src/test-kernel/agent/runtime/agentLoad.vitest.ts
+++ b/src/test-kernel/agent/runtime/agentLoad.vitest.ts
@@ -1,8 +1,7 @@
 import { strict as assert } from 'node:assert';
-import { mkdtemp, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
-import { beforeAll, describe, it, beforeEach, afterEach, vi } from 'vitest';
+import { afterAll, beforeAll, describe, it, beforeEach, afterEach, vi } from 'vitest';
 import { z } from 'zod';
 
 import {
@@ -24,12 +23,19 @@ import type { AgentDirectoriesPort } from '@platform/interfaces';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { AgentCategory } from '@shared/schemas';
 import { installPlatform } from '@test/support/setupPlatform';
+import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 
 vi.mock('@agent/index', async () => {
   const actual =
     await vi.importActual<typeof import('@agent/index')>('@agent/index');
   return { ...actual, resolveAgent: vi.fn(actual.resolveAgent) };
+});
+
+const tempDirs: string[] = [];
+
+afterAll(async () => {
+  await cleanupTempDirs(tempDirs);
 });
 
 describe('validateAgentYamlContent', () => {
@@ -238,7 +244,7 @@ describe('inline agent definitions', () => {
     // Every agent directory points at an empty folder: nothing the registry
     // returns below can have come from YAML on disk.
     await useAgentDirectories(
-      await mkdtemp(path.join(tmpdir(), 'texra-empty-agents-')),
+      await makeTempDir('texra-empty-agents-', tempDirs),
     );
     registerInlineAgents([SCRATCHPAD]);
     await loadAgents({ includeRemote: false });
@@ -470,7 +476,7 @@ describe('inline agent definitions', () => {
   });
 
   it('keys inline agents apart from a same-named custom agent', async () => {
-    const customDir = await mkdtemp(path.join(tmpdir(), 'texra-custom-'));
+    const customDir = await makeTempDir('texra-custom-', tempDirs);
     await writeFile(
       path.join(customDir, 'scratchpad.yaml'),
       [
@@ -524,7 +530,7 @@ describe('agent registry load state', () => {
   }
 
   beforeAll(async () => {
-    agentDir = await mkdtemp(path.join(tmpdir(), 'texra-load-state-'));
+    agentDir = await makeTempDir('texra-load-state-', tempDirs);
     await writeFile(
       path.join(agentDir, 'stateProbe.yaml'),
       [

--- a/src/test-kernel/agent/runtime/agentLoad.vitest.ts
+++ b/src/test-kernel/agent/runtime/agentLoad.vitest.ts
@@ -1,7 +1,15 @@
 import { strict as assert } from 'node:assert';
 import { writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
-import { afterAll, beforeAll, describe, it, beforeEach, afterEach, vi } from 'vitest';
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  vi,
+} from 'vitest';
 import { z } from 'zod';
 
 import {

--- a/src/test-kernel/cli/ChatDefaults.vitest.ts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.ts
@@ -1,8 +1,7 @@
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 import { listExecutions } from '@agent/storage';
@@ -16,6 +15,7 @@ import { BUILTIN_DEFAULT_CHAT_AGENT } from '@cli/runtime/defaultAgents';
 import * as logSinks from '@cli/runtime/logSinks';
 import type { ExecutionId } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
+import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 
 /** A cwd with no `.texra` directory, so the workspace tier finds nothing. */
@@ -87,8 +87,14 @@ beforeEach(() => {
   mockedReadJson.mockRejectedValue(enoentError());
 });
 
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await cleanupTempDirs(tempDirs);
+});
+
 async function workspaceWithConfig(config: unknown): Promise<string> {
-  const workspace = await mkdtemp(join(tmpdir(), 'texra-chat-defaults-'));
+  const workspace = await makeTempDir('texra-chat-defaults-', tempDirs);
   await mkdir(join(workspace, '.texra'), { recursive: true });
   await writeFile(
     join(workspace, '.texra', 'config.json'),

--- a/src/test-kernel/cli/CliAgentShadow.vitest.ts
+++ b/src/test-kernel/cli/CliAgentShadow.vitest.ts
@@ -1,10 +1,9 @@
 // Node imports
-import { mkdtemp, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 // Third-party imports
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports
 import { refresh } from '@agent/index/agentRegistry';
@@ -18,6 +17,7 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { AgentCategory } from '@shared/schemas';
 import { REPO_ROOT } from '@test/support/repoScan';
 import { installPlatform } from '@test/support/setupPlatform';
+import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 
 /**
  * A custom *workflow* agent named `assistant` shadows the bundled *tool-use*
@@ -28,8 +28,10 @@ import { installPlatform } from '@test/support/setupPlatform';
  * category-scoped launch resolver the run itself uses.
  */
 describe('CLI agent validation with a shadowed name', () => {
+  const tempDirs: string[] = [];
+
   beforeAll(async () => {
-    const customDir = await mkdtemp(resolve(tmpdir(), 'texra-cli-shadow-'));
+    const customDir = await makeTempDir('texra-cli-shadow-', tempDirs);
     await writeFile(
       resolve(customDir, 'assistant.yaml'),
       [
@@ -58,6 +60,10 @@ describe('CLI agent validation with a shadowed name', () => {
     );
 
     await refresh({ includeRemote: false });
+  });
+
+  afterAll(async () => {
+    await cleanupTempDirs(tempDirs);
   });
 
   it('validates the shadowed name against the tool-use entry launch will run', () => {

--- a/src/test-kernel/cli/CliContext.vitest.ts
+++ b/src/test-kernel/cli/CliContext.vitest.ts
@@ -1,8 +1,8 @@
-import { mkdir, mkdtemp, realpath, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, realpath, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   buildCliContext,
@@ -18,6 +18,7 @@ import {
 } from '@cli/runtime/cliContext';
 import { loadWorkspaceCliConfig } from '@cli/runtime/cliConfig';
 import { canonicalizeWorkspacePath } from '@platform/defaults/nodeWorkspace';
+import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 
 const ambient = {
   isCi: true,
@@ -40,8 +41,14 @@ function ttyAmbient(overrides: Partial<CliAmbientState> = {}): CliAmbientState {
   };
 }
 
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await cleanupTempDirs(tempDirs);
+});
+
 async function workspaceWithConfig(config: string): Promise<string> {
-  const workspace = await mkdtemp(join(tmpdir(), 'texra-cli-context-'));
+  const workspace = await makeTempDir('texra-cli-context-', tempDirs);
   await mkdir(join(workspace, '.texra'), { recursive: true });
   await writeFile(join(workspace, '.texra', 'config.json'), config);
   return workspace;
@@ -190,7 +197,7 @@ describe('CLI context config defaults', () => {
   });
 
   it('canonicalizes existing workspace paths before reading config', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'texra-cli-context-link-'));
+    const root = await makeTempDir('texra-cli-context-link-', tempDirs);
     const workspace = join(root, 'workspace');
     const link = join(root, 'linked-workspace');
     await mkdir(join(workspace, '.texra'), { recursive: true });
@@ -221,7 +228,7 @@ describe('CLI context config defaults', () => {
   });
 
   it('reports unreadable workspace config files without treating them as absent', async () => {
-    const workspace = await mkdtemp(join(tmpdir(), 'texra-cli-context-'));
+    const workspace = await makeTempDir('texra-cli-context-', tempDirs);
     await mkdir(join(workspace, '.texra', 'config.json'), {
       recursive: true,
     });
@@ -294,7 +301,7 @@ describe('CLI context config defaults', () => {
 
 describe('CLI --cwd validation', () => {
   it('accepts an existing directory and returns its realpath', async () => {
-    const workspace = await mkdtemp(join(tmpdir(), 'texra-cli-cwd-'));
+    const workspace = await makeTempDir('texra-cli-cwd-', tempDirs);
 
     await expect(resolveCliCwd(workspace)).resolves.toBe(
       canonicalizeWorkspacePath(workspace),
@@ -302,7 +309,7 @@ describe('CLI --cwd validation', () => {
   });
 
   it('preserves whitespace in an explicit workspace path', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'texra-cli-cwd-root-'));
+    const root = await makeTempDir('texra-cli-cwd-root-', tempDirs);
     const workspace = join(root, 'workspace ');
     await mkdir(workspace);
 
@@ -319,7 +326,7 @@ describe('CLI --cwd validation', () => {
   });
 
   it('rejects a --cwd path that points at a file', async () => {
-    const workspace = await mkdtemp(join(tmpdir(), 'texra-cli-cwd-'));
+    const workspace = await makeTempDir('texra-cli-cwd-', tempDirs);
     const filePath = join(workspace, 'config.json');
     await writeFile(filePath, '{}');
 

--- a/src/test-kernel/cli/ConfigForm.vitest.ts
+++ b/src/test-kernel/cli/ConfigForm.vitest.ts
@@ -54,7 +54,10 @@ import {
   STATE_SETTINGS,
   type StateSettingEntry,
 } from '@shared/schemas/stateSettings';
-import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
+import {
+  createDeferred,
+  waitForCondition as waitFor,
+} from '@test/support/asyncTestUtils';
 import {
   loadInk,
   renderInteractive,
@@ -91,20 +94,6 @@ function apiKeyStatuses(
       overrides[provider] ?? 'not-set',
     ]),
   ) as Record<ApiProvider, ApiKeyStatus>;
-}
-
-function deferred<T>(): {
-  readonly promise: Promise<T>;
-  readonly resolve: (value: T) => void;
-  readonly reject: (error: unknown) => void;
-} {
-  let resolve!: (value: T) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
 }
 
 beforeEach(() => {
@@ -461,7 +450,7 @@ describe('ConfigForm helpers', () => {
 
 describe('CliConfigForm API-key status lifecycle', () => {
   it('renders initial loading and then configured status from the resolved request', async () => {
-    const initial = deferred<Record<ApiProvider, ApiKeyStatus>>();
+    const initial = createDeferred<Record<ApiProvider, ApiKeyStatus>>();
     providerApiKeyRuntime.load.mockReturnValueOnce(initial.promise);
     const rendered = await renderCliConfigForm();
 
@@ -480,7 +469,7 @@ describe('CliConfigForm API-key status lifecycle', () => {
   });
 
   it('settles a failed initial load to a stable unavailable state', async () => {
-    const initial = deferred<Record<ApiProvider, ApiKeyStatus>>();
+    const initial = createDeferred<Record<ApiProvider, ApiKeyStatus>>();
     const onError = vi.fn();
     providerApiKeyRuntime.load.mockReturnValueOnce(initial.promise);
     const rendered = await renderCliConfigForm(onError);
@@ -502,7 +491,7 @@ describe('CliConfigForm API-key status lifecycle', () => {
   });
 
   it('refreshes provider status after saving without rendering the secret', async () => {
-    const refreshed = deferred<Record<ApiProvider, ApiKeyStatus>>();
+    const refreshed = createDeferred<Record<ApiProvider, ApiKeyStatus>>();
     providerApiKeyRuntime.load
       .mockResolvedValueOnce(apiKeyStatuses())
       .mockReturnValueOnce(refreshed.promise);
@@ -530,7 +519,7 @@ describe('CliConfigForm API-key status lifecycle', () => {
   });
 
   it('keeps a successfully saved key configured when its refresh fails', async () => {
-    const refreshed = deferred<Record<ApiProvider, ApiKeyStatus>>();
+    const refreshed = createDeferred<Record<ApiProvider, ApiKeyStatus>>();
     const onError = vi.fn();
     providerApiKeyRuntime.load
       .mockResolvedValueOnce(apiKeyStatuses({ openai: 'not-set' }))
@@ -565,8 +554,8 @@ describe('CliConfigForm API-key status lifecycle', () => {
   });
 
   it('suppresses a stale mount response after the post-save refresh wins', async () => {
-    const initial = deferred<Record<ApiProvider, ApiKeyStatus>>();
-    const refreshed = deferred<Record<ApiProvider, ApiKeyStatus>>();
+    const initial = createDeferred<Record<ApiProvider, ApiKeyStatus>>();
+    const refreshed = createDeferred<Record<ApiProvider, ApiKeyStatus>>();
     providerApiKeyRuntime.load
       .mockReturnValueOnce(initial.promise)
       .mockReturnValueOnce(refreshed.promise);
@@ -592,7 +581,7 @@ describe('CliConfigForm API-key status lifecycle', () => {
   });
 
   it('ignores a pending status response after unmount', async () => {
-    const initial = deferred<Record<ApiProvider, ApiKeyStatus>>();
+    const initial = createDeferred<Record<ApiProvider, ApiKeyStatus>>();
     const onError = vi.fn();
     providerApiKeyRuntime.load.mockReturnValueOnce(initial.promise);
     const rendered = await renderCliConfigForm(onError);

--- a/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
@@ -1,12 +1,12 @@
 // Standard library imports
-import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 // Third-party imports
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 // Local imports - test support
+import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 import { loadSourceModule } from './loadSourceModule.ts';
 
 type DesktopDiffHostModule = typeof import('@desktop/main/desktopDiffHost');
@@ -36,13 +36,19 @@ function expectOpenedPatchFile(openedPaths: readonly string[]): void {
   expect(path.extname(openedPaths[0])).toBe('.diff');
 }
 
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await cleanupTempDirs(tempDirs);
+});
+
 async function openDiffPair(
   host: DiffHost,
   title: string,
   names: [string, string] = ['a.tex', 'b.tex'],
   texts: [string, string] = ['a\n', 'b\n'],
 ): Promise<void> {
-  const tempDir = await mkdtemp(path.join(tmpdir(), 'texra-diff-host-test-'));
+  const tempDir = await makeTempDir('texra-diff-host-test-', tempDirs);
   const originalPath = path.join(tempDir, names[0]);
   const proposedPath = path.join(tempDir, names[1]);
   await Promise.all([

--- a/src/test-kernel/desktop/DesktopPtyHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopPtyHost.vitest.ts
@@ -6,6 +6,7 @@ import {
   createDesktopPtyHost,
   type DesktopPtyHostOptions,
 } from '@desktop/main/desktopPtyHost';
+import { createDeferred } from '@test/support/asyncTestUtils';
 
 type LoadPty = NonNullable<DesktopPtyHostOptions['loadPty']>;
 type PtyModule = Awaited<ReturnType<LoadPty>>;
@@ -38,20 +39,6 @@ function createFakePty(pid: number): FakePty & PtyProcess {
 
 function loadFakePty(spawn: SpawnPty): LoadPty {
   return async () => ({ spawn });
-}
-
-function deferred<T>(): {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (error: unknown) => void;
-} {
-  let resolve = (_value: T): void => {};
-  let reject = (_error: unknown): void => {};
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
 }
 
 const TERMINAL_ID = 'workbench:terminal:1';
@@ -114,7 +101,7 @@ describe('desktop pty host', () => {
   it('abandons a session creation invalidated while its module loads', async () => {
     const pty = createFakePty(201);
     const spawnPty = vi.fn<SpawnPty>(() => pty);
-    const firstLoad = deferred<PtyModule>();
+    const firstLoad = createDeferred<PtyModule>();
     const loadPty = vi
       .fn<LoadPty>()
       .mockReturnValueOnce(firstLoad.promise)
@@ -144,7 +131,7 @@ describe('desktop pty host', () => {
   });
 
   it('ignores a module-load failure from an invalidated creation', async () => {
-    const loadFailure = deferred<PtyModule>();
+    const loadFailure = createDeferred<PtyModule>();
     const host = createHost({
       loadPty: vi.fn<LoadPty>().mockReturnValue(loadFailure.promise),
     });

--- a/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
+++ b/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
@@ -26,6 +26,7 @@ import type {
   LanguageModelPort,
 } from '@platform/languageModel';
 import { GlobalStateKey } from '@shared/state/stateKeys';
+import { createDeferred } from '@test/support/asyncTestUtils';
 import { FakeSecrets } from '@test/support/FakePlatform';
 import { installPlatform } from '@test/support/setupPlatform';
 
@@ -86,14 +87,6 @@ function failingDiscoveryPort(): LanguageModelPort {
       throw new Error('native discovery failed');
     },
   };
-}
-
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((r) => {
-    resolve = r;
-  });
-  return { promise, resolve };
 }
 
 function resetModelCaches(): void {
@@ -261,7 +254,7 @@ describe('runtime model registry', () => {
     const port = await installModels(GEMINI_FLASH);
     await refreshRuntimeModelRegistry();
 
-    const forced = deferred<readonly LanguageModelInfo[]>();
+    const forced = createDeferred<readonly LanguageModelInfo[]>();
     vi.mocked(port.selectModels)
       .mockReturnValueOnce(forced.promise)
       .mockResolvedValueOnce([{ ...GEMINI_FLASH, access: 'unavailable' }]);
@@ -280,9 +273,9 @@ describe('runtime model registry', () => {
     const port = await installModels(GEMINI_FLASH);
     await refreshRuntimeModelRegistry();
 
-    const forced = deferred<readonly LanguageModelInfo[]>();
-    const retry = deferred<readonly LanguageModelInfo[]>();
-    const retryStarted = deferred<void>();
+    const forced = createDeferred<readonly LanguageModelInfo[]>();
+    const retry = createDeferred<readonly LanguageModelInfo[]>();
+    const retryStarted = createDeferred<void>();
     vi.mocked(port.selectModels)
       .mockReturnValueOnce(forced.promise)
       .mockImplementationOnce(() => {
@@ -304,8 +297,8 @@ describe('runtime model registry', () => {
   });
 
   it('does not let a superseded ordinary discovery overwrite forced access state', async () => {
-    const ordinary = deferred<readonly LanguageModelInfo[]>();
-    const forced = deferred<readonly LanguageModelInfo[]>();
+    const ordinary = createDeferred<readonly LanguageModelInfo[]>();
+    const forced = createDeferred<readonly LanguageModelInfo[]>();
     const port = {
       ...languageModelPort([]),
       selectModels: vi
@@ -336,7 +329,7 @@ describe('runtime model registry', () => {
     const port = await installModels(GEMINI_FLASH);
     await refreshRuntimeModelRegistry();
 
-    const discovery = deferred<readonly LanguageModelInfo[]>();
+    const discovery = createDeferred<readonly LanguageModelInfo[]>();
     vi.mocked(port.selectModels).mockReturnValueOnce(discovery.promise);
 
     const first = requestRuntimeModelAccess('gemini36f');
@@ -431,7 +424,7 @@ describe('runtime model registry', () => {
   });
 
   it('discards a discovery that an invalidation superseded mid-flight', async () => {
-    const discovery = deferred<readonly LanguageModelInfo[]>();
+    const discovery = createDeferred<readonly LanguageModelInfo[]>();
     await installPlatform(
       {},
       {

--- a/src/test-kernel/support/asyncTestUtils.ts
+++ b/src/test-kernel/support/asyncTestUtils.ts
@@ -52,14 +52,17 @@ export async function waitForRecordedEvent<TEvent extends string>(
   throw new Error(`Timed out waiting for ${eventName}`);
 }
 
-/** Create a promise together with the resolver that settles it, for tests that need to control timing externally. */
+/** Create a promise together with the resolvers that settle it, for tests that need to control timing externally. */
 export function createDeferred<T = void>(): {
   promise: Promise<T>;
   resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
 } {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
     resolve = done;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }


### PR DESCRIPTION
## Summary

Second wave of the test-code simplification campaign — the "64-round" pass that follows up on the 128-wave structural findings (#10287). The first-round report surfaced 5 cross-cutting themes; most turned out to be already-solved or non-mechanical on closer inspection. This PR lands the two real, verifiable wins:

### 1. Deferred-helper consolidation (net −35 LOC)

Four test files each defined a local `function deferred<T>()` with slightly divergent shapes (`{promise, resolve}`, `{promise, resolve, reject}`, `readonly {…}`). Consolidated them onto the shared `createDeferred` helper.

- Extend `createDeferred<T>()` in `src/test-kernel/support/asyncTestUtils.ts` to also return `reject` (additive — existing resolve-only call sites unaffected).
- Migrate `DesktopPtyHost.vitest.ts`, `ToolUseFollowUp.vitest.ts`, `ConfigForm.vitest.ts`, `RuntimeModelRegistry.vitest.ts` to import `createDeferred` from `@test/support/asyncTestUtils` and delete their local helpers.

### 2. Temp-dir leak fixes (10 files)

Ten test files called `mkdtemp(...)` from `node:fs/promises` and never cleaned up, leaking temp directories on every run. Migrated each to the canonical helpers (`makeTempDir` + `cleanupTempDirs` from `@test/support/tempDirPlatform`), adding a `tempDirs` registry and `afterEach`/`afterAll` cleanup. This is a correctness fix (slightly net-positive LOC by nature — cleanup boilerplate), not a pure simplification.

Affected: `AgentCategoryResolution`, `AgentYamlScanner`, `GoalPromptParity`, `PolishPromptLoader`, `modelHandlers/ModelFactoryRouting`, `runtime/agentLoad`, `cli/ChatDefaults`, `cli/CliAgentShadow`, `cli/CliContext`, `desktop/DesktopDiffHost`.

## What was deliberately *not* touched

The other first-round themes didn't survive scrutiny:
- `createTestCliContext` re-wrapping — already a clean shared helper in `src/test-kernel/cli/fixtures/cliContext.ts`.
- `vi.hoisted` mock-bag / reset ritual — duplicated 40+× but non-mechanical to unify (varies per file's mock surface).
- e2e `mkdtemp` sites — already cleaned up via `cleanupDirectory()` from `workspaceStorageFixture.js` (verified, not leaks).

## Net elements (R6)

15 files changed, 148 insertions / 114 deletions, **net +34 LOC**. Zero exported-symbol delta (`export` add/remove count: 0/0) — no files, classes, interfaces, or enums added or removed. Existing `createDeferred` is widened additively with `reject` (not a new export). Four file-local `deferred()` helpers deleted. The net-positive LoC is the temp-dir cleanup registry/hooks; the deferred consolidation is net −35.

## Consumer counts (R8)

n/a — no emit path or export is deleted. The one surface widening (`createDeferred` gaining `reject`) has in-PR consumers at `src/test-kernel/desktop/DesktopPtyHost.vitest.ts` and `src/test-kernel/cli/ConfigForm.vitest.ts`.

## Validation

- `npm run typecheck:test-kernel` — green
- 14 affected test files — **271 passed / 14 files**

Rebased onto latest `origin/main` (which moved 11 commits during this work, including #10287).