### PR TITLE
fix(model): pin helper fallback and expose enabled-list reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to this project will be documented in this file.
 - **Lean Project remotes are available after sign-in** — the hosted Lean
   agents no longer need a special access group.
 
+#### Bug Fixes
+
+- **A missing helper model falls back to DeepSeek V4 Flash** — disabling or
+  removing the helper no longer silently switches auxiliary tasks to the
+  first picker model.
+
 ### Extension (VS Code) and Desktop
 
 #### Features

--- a/packages/cli/src/runtime/enabledModels.ts
+++ b/packages/cli/src/runtime/enabledModels.ts
@@ -117,15 +117,16 @@ export async function setCliModelEnabled(
 
   await persistEnabledModels(next);
 
-  // If the helper model was just removed, pin a still-enabled one (matches
-  // Settings → Models behavior).
+  // If the helper model was just removed, pin the built-in default (matches
+  // Settings → Models behavior). Do not fall back to the first remaining
+  // picker model — that is a premium default, not the cheap auxiliary.
   const helper = platform().globalState.get<string>(
     GlobalStateKey.HELPER_MODEL,
   );
   if (!enabled && resolveEffectiveHelperModel(helper, current) === model) {
     await platform().globalState.update(
       GlobalStateKey.HELPER_MODEL,
-      next[0] ?? DEFAULT_HELPER_MODEL,
+      DEFAULT_HELPER_MODEL,
     );
   }
 

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -291,15 +291,15 @@ export async function initCliPlatform(
     // lives in shared `~/.texra` state. Preferred defaults reconcile when
     // MODEL_LIST_VERSION changes; retired entries are swept on every startup.
     try {
-      const { added, removed } = await refreshModelListStateIfNeeded(
+      const { added, removed, reordered } = await refreshModelListStateIfNeeded(
         stateStores.globalState,
       );
-      if (added.length > 0 || removed.length > 0) {
+      if (added.length > 0 || removed.length > 0 || reordered) {
         invalidateModelOptionsCache();
         logAt(
           'info',
           'cli.models',
-          `Refreshed enabled models: added [${added.join(', ')}], removed [${removed.join(', ')}]`,
+          `Refreshed enabled models: added [${added.join(', ')}], removed [${removed.join(', ')}]${reordered ? ', reordered' : ''}`,
         );
       }
     } catch (error) {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -382,8 +382,14 @@ export async function activate(context: vscode.ExtensionContext) {
     })(),
     (async () => {
       try {
-        const { added, currentVersion, previousVersion, removed, skipped } =
-          await refreshModelListStateIfNeeded(globalSM);
+        const {
+          added,
+          currentVersion,
+          previousVersion,
+          removed,
+          reordered,
+          skipped,
+        } = await refreshModelListStateIfNeeded(globalSM);
         if (!skipped) {
           if (previousVersion !== currentVersion) {
             logger.info(
@@ -392,11 +398,11 @@ export async function activate(context: vscode.ExtensionContext) {
             );
           }
           logger.info('extension', 'Model list refresh completed successfully');
-          if (added.length > 0 || removed.length > 0) {
+          if (added.length > 0 || removed.length > 0 || reordered) {
             invalidateModelOptionsCache();
             logger.info(
               'extension',
-              `Refreshed enabled models: added [${added.join(', ')}], removed [${removed.join(', ')}]`,
+              `Refreshed enabled models: added [${added.join(', ')}], removed [${removed.join(', ')}]${reordered ? ', reordered' : ''}`,
             );
           }
         }

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -338,6 +338,19 @@ export class ModelSelectionList extends LitElement {
 
   private renderHelperModelDropdown(): TemplateResult {
     const enabledModels = this.models.filter((m) => m.enabled);
+    // The pinned default (`DEFAULT_HELPER_MODEL`) is valid even when it is
+    // not an enabled picker row. Keep it selectable so wa-select is not blank.
+    const selectedHelper =
+      this.helperModel !== '' &&
+      !enabledModels.some((m) => m.name === this.helperModel)
+        ? (this.models.find((m) => m.name === this.helperModel) ?? {
+            name: this.helperModel,
+            label: this.helperModel,
+          })
+        : undefined;
+    const helperOptions = selectedHelper
+      ? [selectedHelper, ...enabledModels]
+      : enabledModels;
 
     return html`
       <div class="helper-model-row">
@@ -348,7 +361,7 @@ export class ModelSelectionList extends LitElement {
           .value=${this.helperModel}
           @change=${this.handleHelperModelChange}
         >
-          ${enabledModels.map(
+          ${helperOptions.map(
             (m) => html`
               <wa-option value=${m.name}>
                 ${m.label === m.name ? m.name : `${m.label} (${m.name})`}

--- a/src/agent/runtime/helperModelName.ts
+++ b/src/agent/runtime/helperModelName.ts
@@ -7,7 +7,7 @@ import { isNonEmptyString } from '@utils/core';
  * Resolve the configured helper model name from global state.
  *
  * When the user has explicitly configured a helper model, validate it against
- * the enabled model list and fall back to the first enabled model if the
+ * the enabled model list and fall back to the built-in default if the
  * configured one was removed. The built-in default is always accepted because
  * it is used for internal auxiliary tasks, not user-facing generation.
  */

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -146,7 +146,7 @@ export class SettingsModelSelectionController {
 
     await this.deps.state.setEnabledModels(updated);
     if (wasHelper) {
-      await this.deps.state.setHelperModel(updated[0] ?? DEFAULT_HELPER_MODEL);
+      await this.deps.state.setHelperModel(DEFAULT_HELPER_MODEL);
     }
   }
 

--- a/src/model/helperModelSelection.ts
+++ b/src/model/helperModelSelection.ts
@@ -3,10 +3,10 @@ import { isNonEmptyString } from '@utils/core';
 
 /**
  * Validate a configured helper-model choice against a candidate list, falling
- * back to the candidate list's first entry, and finally to the built-in
- * default, when the configured model isn't present in the list. The built-in
- * default is always accepted as-is because it is used for internal auxiliary
- * tasks, not user-facing generation.
+ * back to the built-in default when the configured model isn't present. The
+ * built-in default is always accepted as-is because it is used for internal
+ * auxiliary tasks, not user-facing generation — do not fall back to the
+ * first picker model, which is a premium default.
  *
  * Single source of truth for the "validate against candidates, else fall
  * back" precedence chain shared by {@link getHelperModelName} (agent runtime)
@@ -29,5 +29,5 @@ export function resolveEffectiveHelperModel(
   if (candidateModels.includes(resolved)) {
     return resolved;
   }
-  return candidateModels[0] ?? DEFAULT_HELPER_MODEL;
+  return DEFAULT_HELPER_MODEL;
 }

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -126,7 +126,10 @@ export async function refreshModelListStateIfNeeded(
     );
     added = reconciliation.added;
     removed = reconciliation.removed;
-    reordered = !sameModelList(currentModels, reconciliation.models);
+    reordered =
+      added.length === 0 &&
+      removed.length === 0 &&
+      !sameModelList(currentModels, reconciliation.models);
     if (added.length > 0 || removed.length > 0 || reordered) {
       await state.update(GlobalStateKey.ENABLED_MODELS, reconciliation.models);
     }

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -24,6 +24,8 @@ export interface ModelListRefreshResult {
   currentVersion: number;
   added: string[];
   removed: string[];
+  /** True when the persisted enabled list was rewritten only to change order. */
+  reordered: boolean;
 }
 
 /**
@@ -143,5 +145,6 @@ export async function refreshModelListStateIfNeeded(
     currentVersion: MODEL_LIST_VERSION,
     added,
     removed,
+    reordered,
   };
 }

--- a/src/test-kernel/agent/runtime/helperModelName.vitest.ts
+++ b/src/test-kernel/agent/runtime/helperModelName.vitest.ts
@@ -15,10 +15,10 @@ describe('resolveEffectiveHelperModel', () => {
     );
   });
 
-  it('falls back to the first candidate when the configured model is not in the list', () => {
+  it('falls back to the built-in default when the configured model is not in the list', () => {
     expect(
       resolveEffectiveHelperModel('retired-model', ['gpt55', 'opus']),
-    ).toBe('gpt55');
+    ).toBe(DEFAULT_HELPER_MODEL);
   });
 
   it('falls back to the built-in default when the candidate list is empty', () => {
@@ -53,7 +53,7 @@ describe('getHelperModelName', () => {
     expect(getHelperModelName()).toBe('legacy-helper-model');
   });
 
-  it('falls back to the first enabled model when the configured model is not enabled', async () => {
+  it('falls back to the built-in default when the configured model is not enabled', async () => {
     await installPlatform({
       globalState: {
         [GlobalStateKey.HELPER_MODEL]: 'retired-model',
@@ -61,7 +61,7 @@ describe('getHelperModelName', () => {
       },
     });
 
-    expect(getHelperModelName()).toBe('gpt55');
+    expect(getHelperModelName()).toBe(DEFAULT_HELPER_MODEL);
   });
 });
 
@@ -108,6 +108,6 @@ describe('#7582 runtime vs Settings UI helper-model divergence', () => {
 
     const { helperModel } = await controller.buildSelectionData();
     expect(helperModel).not.toBe(configuredModel);
-    expect(helperModel).toBe(DEFAULT_MODELS[0]);
+    expect(helperModel).toBe(DEFAULT_HELPER_MODEL);
   });
 });

--- a/src/test-kernel/cli/EnabledModels.vitest.ts
+++ b/src/test-kernel/cli/EnabledModels.vitest.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DEFAULT_MODELS } from '@model/modelOptionsBasic';
+import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 const state = new Map<string, unknown>();
@@ -42,6 +43,16 @@ describe('CLI enabled models catalog', () => {
     expect(result.enabled).toBe(true);
     expect(result.list).toEqual(['deepseekproT', 'grok45']);
     expect(getCliEnabledModels()).toContain('grok45');
+  });
+
+  it('pins a disabled helper to the built-in default', async () => {
+    state.set(GlobalStateKey.ENABLED_MODELS, ['deepseekproT', 'grok45']);
+    state.set(GlobalStateKey.HELPER_MODEL, 'deepseekproT');
+
+    await setCliModelEnabled('deepseekproT', false);
+
+    expect(state.get(GlobalStateKey.HELPER_MODEL)).toBe(DEFAULT_HELPER_MODEL);
+    expect(getCliEnabledModels()).toEqual(['grok45']);
   });
 
   it('refuses to disable the last remaining model', async () => {

--- a/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
@@ -162,10 +162,10 @@ describe('SettingsModelSelectionController', () => {
     });
   });
 
-  it('moves a stale helper fallback when disabling the effective helper model', async () => {
+  it('pins a disabled helper to the built-in default', async () => {
     const state = createState({
       enabledModels: ['gpt55', 'sonnet46T'],
-      helperModel: 'removed-model',
+      helperModel: 'gpt55',
     });
     const controller = createController({ state });
 
@@ -174,7 +174,7 @@ describe('SettingsModelSelectionController', () => {
     await controller.setModelEnabled({ modelName: 'gpt55', enabled: false });
 
     expect(state.getEnabledModels()).toEqual(['sonnet46T']);
-    expect(state.getHelperModel()).toBe('sonnet46T');
+    expect(state.getHelperModel()).toBe(DEFAULT_HELPER_MODEL);
   });
 
   it('falls back to default models when the persisted enabled list is empty', async () => {

--- a/src/test-kernel/controllers/SettingsViewHost.vitest.ts
+++ b/src/test-kernel/controllers/SettingsViewHost.vitest.ts
@@ -5,6 +5,7 @@ import { SettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import { buildBasicModelOptionsData } from '@model/modelOptionsBasic';
 import type { ModelOptionData } from '@shared/schemas';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { FakeStateStore } from '@test/support/FakePlatform';
 
@@ -99,7 +100,7 @@ describe('SettingsViewHost', () => {
     });
     expect(messages.at(3)).toMatchObject({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,
-      helperModel: 'sonnet46T',
+      helperModel: DEFAULT_HELPER_MODEL,
     });
     expect(modelSelection.state.enabledModels).toEqual(['sonnet46T']);
     expect(beforeModelSelectionMessage).toHaveBeenCalledTimes(2);

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.ts
@@ -9,6 +9,7 @@ import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { StreamTabId } from '@shared/schemas';
 import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 import { AGENT_SKILLS_CONFIG_KEY } from '@shared/schemas/agentSkills';
+import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { DEFAULT_GIT_MARK_COMMITS } from '@shared/schemas/stateSettings';
 import {
@@ -790,7 +791,9 @@ describe('desktop settings IPC', () => {
     expect(globalState.get(GlobalStateKey.ENABLED_MODELS)).toEqual([
       'sonnet46T',
     ]);
-    expect(globalState.get(GlobalStateKey.HELPER_MODEL)).toBe('sonnet46T');
+    expect(globalState.get(GlobalStateKey.HELPER_MODEL)).toBe(
+      DEFAULT_HELPER_MODEL,
+    );
     expect(errors).toEqual([]);
     expect(
       posted.findLast(
@@ -799,7 +802,7 @@ describe('desktop settings IPC', () => {
       ),
     ).toMatchObject({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,
-      helperModel: 'sonnet46T',
+      helperModel: DEFAULT_HELPER_MODEL,
     });
     expect(postMainModelOptionsData).toHaveBeenCalledOnce();
 

--- a/src/test-kernel/model/ModelListRefresh.vitest.ts
+++ b/src/test-kernel/model/ModelListRefresh.vitest.ts
@@ -81,6 +81,9 @@ describe('refreshModelListStateIfNeeded', () => {
     const result = await refreshModelListStateIfNeeded(state);
 
     expect(result.skipped).toBe(false);
+    expect(result.reordered).toBe(true);
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
     expect(enabledModels(state)).toEqual(['sonnet5T', 'gemini31p', 'custom']);
   });
 });

--- a/src/test-kernel/model/ModelListRefresh.vitest.ts
+++ b/src/test-kernel/model/ModelListRefresh.vitest.ts
@@ -54,6 +54,7 @@ describe('refreshModelListStateIfNeeded', () => {
     expect(result.skipped).toBe(false);
     expect(result.added).toEqual([]);
     expect(result.removed).toContain('kimi2');
+    expect(result.reordered).toBe(false);
     expect(enabledModels(state)).toEqual(['opus5T']);
   });
 
@@ -69,6 +70,7 @@ describe('refreshModelListStateIfNeeded', () => {
 
     expect(result.skipped).toBe(false);
     expect(result.removed).toContain('grok4');
+    expect(result.reordered).toBe(false);
     expect(enabledModels(state)).not.toContain('grok4');
   });
 

--- a/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
+++ b/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
@@ -86,6 +86,32 @@ describe('ModelSelectionList provider key status', () => {
     );
   });
 
+  it('keeps the pinned helper visible when it is not enabled', async () => {
+    const list = await renderModelSelectionList({
+      models: [
+        { ...deepseekModel, enabled: false },
+        {
+          ...deepseekModel,
+          name: 'sonnet5T',
+          label: 'Sonnet 5 (Thinking)',
+          provider: 'anthropic',
+          enabled: true,
+        },
+      ],
+      helperModel: 'deepseek',
+    });
+
+    const helperOptions = [
+      ...list.shadowRoot!.querySelectorAll('.helper-model-select wa-option'),
+    ];
+    expect(helperOptions.map((option) => option.getAttribute('value'))).toEqual(
+      ['deepseek', 'sonnet5T'],
+    );
+    expect(helperOptions[0]?.textContent?.trim()).toBe(
+      'DeepSeek V4 Flash (deepseek)',
+    );
+  });
+
   it('renders the per-model enabled toggle as wa-switch and posts setModelEnabled on change', async () => {
     const list = await renderModelSelectionList();
 


### PR DESCRIPTION
## Summary

Implements the two follow-ups from #10266 / tracking #10280.

- **#10281** — A missing or disabled helper model now falls back to `DEFAULT_HELPER_MODEL` (DeepSeek V4 Flash) instead of the first enabled picker model (`sonnet5T` after #10266). Auxiliary work stays cheap.
- **#10282** — `ModelListRefreshResult` now includes `reordered`. The CLI and extension invalidate the model-options cache and log when the enabled list is rewritten for order only.

## Issue acceptance gates

- #10281: helper fallback is the built-in default, not `candidateModels[0]` / `updated[0]`.
- #10282: `reordered` is on the result type; CLI `initPlatform` (and the matching extension startup path) invalidates on it.

## Single source of truth

- Helper fallback: `resolveEffectiveHelperModel` in `src/model/helperModelSelection.ts`. Settings disable path writes the same default.
- Reorder: `refreshModelListStateIfNeeded` returns `reordered`; hosts consume that flag.

## Duplication and abstraction budget

No new abstraction. Hosts already logged add/remove; they now include reorder on the same path.

## Net elements (R6)

n/a — not a refactor/simplify PR.

## Consumer counts (R8)

n/a — added a field on an existing result type; no emit path deleted.

## Host impact

Extension: helper fallback; cache invalidation on reorder-only refresh.

Desktop: helper fallback via the shared settings controller.

CLI: helper fallback; cache invalidation on reorder-only refresh.

## Scheduled refactoring

None. Completes #10280.

## Validation

- `npx vitest run` on helperModelName, SettingsModelSelectionController, SettingsViewHost, ModelListRefresh, DesktopSettingsIpc.
- `npx eslint` on the edited TypeScript files.