### PR TITLE
fix(model): detect stream bodies without instanceof

### DIFF
--- a/src/platform/defaults/longRunningModelTransport.ts
+++ b/src/platform/defaults/longRunningModelTransport.ts
@@ -12,6 +12,19 @@ const MODEL_STREAM_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000;
 const MODEL_RESPONSE_HEADERS_TIMEOUT_MS = 10 * 60 * 1000;
 type UploadCompatibleFetch = typeof fetch & { Response: typeof Response };
 
+/**
+ * Detect a WHATWG ReadableStream without `instanceof`. A stream constructed
+ * in another realm (worker_threads, a second vendored `node:stream/web`)
+ * fails the brand check and would otherwise miss the `duplex` hint.
+ */
+function isReadableStreamBody(body: unknown): boolean {
+  return (
+    typeof body === 'object' &&
+    body !== null &&
+    typeof (body as { pipeTo?: unknown }).pipeTo === 'function'
+  );
+}
+
 async function normalizeModelRequest(
   input: RequestInfo | URL,
   init?: RequestInit,
@@ -20,10 +33,7 @@ async function normalizeModelRequest(
   // FormData, and ArrayBuffer bodies must stay free of it; undici tolerates the
   // field on non-stream bodies today, but the Fetch spec does not.
   const requestInit = { ...(init ?? {}) } as UndiciRequestInit;
-  if (
-    requestInit.body instanceof ReadableStream &&
-    requestInit.duplex == null
-  ) {
+  if (isReadableStreamBody(requestInit.body) && requestInit.duplex == null) {
     requestInit.duplex = 'half';
   }
   if (!(input instanceof Request)) {

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -109,6 +109,46 @@ describe('long-running model transport', () => {
     expect(result.text).toBe('transcribed text');
     const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
     expect(init?.body).toBeInstanceOf(UndiciFormData);
+    expect(init?.duplex).toBeUndefined();
+  });
+
+  it('does not set duplex on a direct string body', async () => {
+    stubComposedDispatcher();
+    transportMocks.undiciFetch.mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+
+    await expect(
+      longRunningModelFetch('https://api.example/v1/chat', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{"prompt":"hello"}',
+      }),
+    ).resolves.toBeInstanceOf(Response);
+
+    const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
+    expect(init?.body).toBe('{"prompt":"hello"}');
+    expect(init?.duplex).toBeUndefined();
+  });
+
+  it('does not set duplex on a direct ArrayBuffer body', async () => {
+    stubComposedDispatcher();
+    transportMocks.undiciFetch.mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+    const body = new TextEncoder().encode('{"prompt":"hello"}').buffer;
+
+    await expect(
+      longRunningModelFetch('https://api.example/v1/chat', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body,
+      }),
+    ).resolves.toBeInstanceOf(Response);
+
+    const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
+    expect(init?.body).toBe(body);
+    expect(init?.duplex).toBeUndefined();
   });
 
   it('sets duplex: half when a caller sends a stream body without it', async () => {
@@ -156,5 +196,27 @@ describe('long-running model transport', () => {
 
     const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
     expect(init?.duplex).toBe('half');
+  });
+
+  it('sets duplex: half for a stream-like body that is not a same-realm ReadableStream', async () => {
+    stubComposedDispatcher();
+    transportMocks.undiciFetch.mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+    const body = {
+      pipeTo: async () => undefined,
+    };
+
+    await expect(
+      longRunningModelFetch('https://api.example/v1/chat', {
+        method: 'POST',
+        body: body as unknown as ReadableStream,
+      }),
+    ).resolves.toBeInstanceOf(Response);
+
+    const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
+    expect(init?.body).toBe(body);
+    expect(init?.duplex).toBe('half');
+    expect(body instanceof ReadableStream).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Second batch of open follow-ups — tracking #10297 from #10267.

- **#10298** — `normalizeModelRequest` detects stream bodies via `pipeTo` instead of `instanceof ReadableStream`, so a worker-thread or vendored-stream body still gets `duplex: 'half'`.
- **#10299** — Tests pin that string, `ArrayBuffer`, and FormData bodies do not get `duplex`, and that a duck-typed stream-like body does.

## Issue acceptance gates

- #10298: structural stream check, not a realm-sensitive brand check.
- #10299: direct non-`Request` string and ArrayBuffer cases, plus FormData, assert `duplex` is undefined.

## Single source of truth

`isReadableStreamBody` in `src/platform/defaults/longRunningModelTransport.ts`.

## Duplication and abstraction budget

One file-local helper. No new export.

## Net elements (R6)

n/a.

## Consumer counts (R8)

n/a.

## Host impact

Extension / Desktop / CLI: same fetch transport.

## Scheduled refactoring

None. Completes #10297.

## Validation

- `npx vitest run src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts`
- `npx eslint` on the edited files.