### PR TITLE
fix(ui): harden wa-spinner reduced-motion adoption

### DIFF
--- a/src/shared/wa/spinner.ts
+++ b/src/shared/wa/spinner.ts
@@ -16,12 +16,16 @@ const REDUCED_MOTION_CSS = `@media (prefers-reduced-motion: reduce) {
   }
 }`;
 
+function hasReducedMotionStyle(host: Element): boolean {
+  return (
+    host.shadowRoot?.querySelector(`style[${REDUCED_MOTION_STYLE_ATTR}]`) !=
+    null
+  );
+}
+
 function adoptReducedMotion(host: Element): void {
   const root = host.shadowRoot;
-  if (
-    root == null ||
-    root.querySelector(`style[${REDUCED_MOTION_STYLE_ATTR}]`)
-  ) {
+  if (root == null || hasReducedMotionStyle(host)) {
     return;
   }
   const style = document.createElement('style');
@@ -34,7 +38,15 @@ function scheduleAdopt(host: Element): void {
   const pending = (host as { updateComplete?: Promise<unknown> })
     .updateComplete;
   if (pending) {
-    void pending.then(() => adoptReducedMotion(host));
+    void pending.then(
+      () => adoptReducedMotion(host),
+      (error: unknown) => {
+        console.warn(
+          'Failed to adopt reduced-motion style for wa-spinner',
+          error,
+        );
+      },
+    );
     return;
   }
   queueMicrotask(() => adoptReducedMotion(host));
@@ -46,7 +58,12 @@ class StopSpinnerMotionDirective extends Directive {
   }
 
   override update(part: ElementPart): typeof nothing {
-    scheduleAdopt(part.element);
+    // The style marker is visible as soon as it is adopted. Skip the
+    // updateComplete hop on later host commits so we do not request a
+    // fresh spinner update on every progress-view re-render.
+    if (!hasReducedMotionStyle(part.element)) {
+      scheduleAdopt(part.element);
+    }
     return nothing;
   }
 }

--- a/src/test-kernel/progressView/CompactionActivityRender.vitest.ts
+++ b/src/test-kernel/progressView/CompactionActivityRender.vitest.ts
@@ -65,6 +65,14 @@ describe('compaction-activity render branches', () => {
     );
     expect(reducedMotion?.textContent).toContain('.indicator');
     expect(reducedMotion?.textContent).toMatch(/animation:\s*none/);
+    expect(
+      spinner?.shadowRoot?.querySelector('.indicator'),
+      'Web Awesome still paints the dash on .indicator',
+    ).not.toBeNull();
+    expect(
+      spinner?.shadowRoot?.querySelector('svg'),
+      'Web Awesome still paints the spin on svg',
+    ).not.toBeNull();
   });
 
   it('keeps the reduced-motion override on the shared spinner', async () => {


### PR DESCRIPTION
## Summary

Third batch of open follow-ups — tracking #10268 from #10262.

- **#10269** — `stopSpinnerMotion` checks the adopted-style marker synchronously and does not poke `updateComplete` on later host commits.
- **#10270** — The `updateComplete` chain logs a warning if the spinner update rejects.
- **#10271** — The compaction-activity test asserts the spinner shadow still contains `.indicator` and `svg`.

## Issue acceptance gates

All three children of #10268.

## Single source of truth

`src/shared/wa/spinner.ts`.

## Duplication and abstraction budget

File-local `hasReducedMotionStyle` shared by `update()` and `adoptReducedMotion`.

## Net elements (R6)

n/a.

## Consumer counts (R8)

n/a.

## Host impact

Extension / Desktop progress UI. CLI unchanged.

## Scheduled refactoring

None. Completes #10268.

## Validation

- `npx vitest run src/test-kernel/progressView/CompactionActivityRender.vitest.ts`
- `npx eslint` on the edited files.