### PR TITLE
docs: drop the retired workflow Follow-up controls

### DIFF
--- a/docs/.vitepress/components/StreamHeaderActions.vue
+++ b/docs/.vitepress/components/StreamHeaderActions.vue
@@ -16,6 +16,7 @@ const actions = [
   { icon: 'forward-step', label: 'Resume', desc: 'Continue saved outputs' },
   { icon: 'reply', label: 'Restore', desc: 'Load config into Launcher' },
   { icon: 'folder-open', label: 'Open', desc: 'Reveal task storage' },
+  { icon: 'copy', label: 'Copy', desc: 'Run context to clipboard' },
   { icon: 'code-compare', label: 'Diff', desc: 'latexdiff vs. base' },
   { icon: 'trash', label: 'Clean', desc: 'Delete task storage' },
   { icon: 'box-archive', label: 'Pack', desc: 'Archive to History' },

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -67,7 +67,7 @@ The header provides a summary and actions for the selected stream:
 <p class="hero-caption">The status dot: green while running, blue while waiting for input, grey once finished, red on error.</p>
 
 - **Token & Cost Summary**: Displays the combined input and output token counts from all completed rounds (e.g., `r0`, `r1`, `r2`, …) along with the estimated cost.
-- **Stream Header Actions**: A toolbar of icon buttons acting on the selected stream. Workflow streams get Stop, Run New, Resume, Restore, Open in task storage, Diff, Clean, and Pack; tool-use streams get Stop, YOLO, agent-work approval, Compact, Restore, and Open in task storage.
+- **Stream Header Actions**: A toolbar of icon buttons acting on the selected stream. Workflow streams get Stop, Run New, Resume, Restore, Open in task storage, Copy run context, Diff, Clean, and Pack; tool-use streams get Stop, YOLO, agent-work approval, Compact, Restore, and Open in task storage.
 
 <StreamHeaderActions />
 
@@ -84,6 +84,10 @@ Each action in detail:
   Reveals the run folder under task-run storage so you can browse generated
   files, compile logs, mirrored dependencies, and intermediate artifacts
   manually.
+- <wa-icon library="texra" name="copy"></wa-icon> **Copy run context**: Copies the
+  run identity, output paths, and compile failures to the clipboard as plain
+  text, so you can paste them into a new tool-use chat. The button is disabled
+  when the run has neither outputs nor compile failures.
 - <wa-icon library="texra" name="box-archive"></wa-icon> **Pack**: Archives the output files and log for this stream into the `History` folder. See [File Management](./file-management.md).
 - <wa-icon library="texra" name="trash"></wa-icon> **Clean**: Deletes the task storage folder associated with this stream.
 
@@ -108,9 +112,13 @@ When a tool-use agent tackles a multi-step task, it shows a **live checklist** r
 
 ### After a workflow run
 
-The Progress board no longer starts a new chat from a finished workflow. Copy
-the run from the header toolbar if you want its output paths and compile
-failures, then start a tool-use chat from the **New** view.
+The ProgressBoard no longer starts a general-purpose chat from a finished
+workflow. Use **Copy run context** in the header toolbar to put the run's
+output paths and compile failures on the clipboard, then start a tool-use chat
+from the **New** view and paste that text into the instruction box.
+
+When a run recorded a compile failure, **Run latexFixer** still appears under
+**Generated Files** and starts a repair chat from those logs.
 
 ### Memory
 

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -106,14 +106,11 @@ When a tool-use agent tackles a multi-step task, it shows a **live checklist** r
 
 <p class="hero-caption">A live checklist: completed items are checked and struck through, the active item spins, pending items wait.</p>
 
-### Followup Tasks
+### After a workflow run
 
-Finished a polish run and want to discuss the results or merge the outputs? Instead of setting everything up again, use the **Followup** controls that appear after a workflow completes:
-
-- **Chat** about what the agent changed
-- **Run another agent** (like `merge`) on the output files
-
-The followup picks up right where the previous run left off - no need to re-select files or re-enter your instruction.
+The Progress board no longer starts a new chat from a finished workflow. Copy
+the run from the header toolbar if you want its output paths and compile
+failures, then start a tool-use chat from the **New** view.
 
 ### Memory
 


### PR DESCRIPTION
## Summary

Fourth batch — #10302 from #10292.

The published progress-board guide still described Follow-up controls that #10292 removed. Replace that section with the current flow: copy the run, then start a tool-use chat from New.

## Issue acceptance gates

#10302: dead Followup Tasks section gone; replacement flow documented.

## Single source of truth

`docs/guide/progress-board.md`.

## Duplication and abstraction budget

n/a.

## Net elements (R6)

n/a.

## Consumer counts (R8)

n/a.

## Host impact

Docs only.

## Scheduled refactoring

None.

## Validation

Guide section rewritten to match the #10292 changelog.