### PR TITLE
fix(ui): use dedicated tokens for the Progress terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to this project will be documented in this file.
   nested run no longer opens the parent row; expand it to inspect children.
   Selecting a child, or a pending approval on one, still reveals the ancestor
   path.
+- **The Progress terminal uses the editor terminal colors** — background and
+  text follow the dedicated terminal tokens instead of the generic surface
+  palette.
 - **Remote agent prompts are available to every signed-in account** — Settings
   → Agents no longer hides View prompt behind an Ultra plan, and remote agents
   no longer show a Remote badge or access-group labels.

--- a/src/shared/wa/xtermTheme.ts
+++ b/src/shared/wa/xtermTheme.ts
@@ -3,10 +3,9 @@
  * Extension and desktop both call this with their own DOM target so the
  * terminal matches the active theme instead of a second hardcoded palette.
  *
- * Background and foreground keep the surface/text tokens the two hosts
- * already used. Dedicated `--wa-color-terminal-background` /
- * `--wa-color-terminal-foreground` exist on both sheets; switching would
- * change the progress-view palette and is out of this extraction's scope.
+ * Background and foreground prefer the dedicated terminal tokens so the
+ * progress-view terminal matches the host integrated terminal. Surface and
+ * text tokens remain fallbacks when a host omits the terminal pair.
  */
 
 const XTERM_THEME_FALLBACKS = {
@@ -47,9 +46,13 @@ export function resolveXtermTheme(target: Element): ResolvedXtermTheme {
 
   const theme: Record<string, string> = {
     background:
-      token('--wa-color-surface-default') || XTERM_THEME_FALLBACKS.background,
+      token('--wa-color-terminal-background') ||
+      token('--wa-color-surface-default') ||
+      XTERM_THEME_FALLBACKS.background,
     foreground:
-      token('--wa-color-text-normal') || XTERM_THEME_FALLBACKS.foreground,
+      token('--wa-color-terminal-foreground') ||
+      token('--wa-color-text-normal') ||
+      XTERM_THEME_FALLBACKS.foreground,
   };
 
   for (const [key, cssVar] of XTERM_ANSI_COLOR_TOKENS) {

--- a/src/test-kernel/shared/XtermTheme.vitest.ts
+++ b/src/test-kernel/shared/XtermTheme.vitest.ts
@@ -28,8 +28,10 @@ const ANSI_TOKENS = [
 describe('resolveXtermTheme', () => {
   it('reads the full token map from the supplied target', () => {
     const target = document.createElement('div');
-    target.style.setProperty('--wa-color-surface-default', '#111111');
-    target.style.setProperty('--wa-color-text-normal', '#eeeeee');
+    target.style.setProperty('--wa-color-terminal-background', '#111111');
+    target.style.setProperty('--wa-color-terminal-foreground', '#eeeeee');
+    target.style.setProperty('--wa-color-surface-default', '#222222');
+    target.style.setProperty('--wa-color-text-normal', '#dddddd');
     target.style.setProperty('--wa-color-terminal-cursor', '#00aa00');
     target.style.setProperty('--wa-color-terminal-selection-bg', '#264f78');
     target.style.setProperty('--wa-font-family-mono', '"JetBrains Mono"');
@@ -59,6 +61,23 @@ describe('resolveXtermTheme', () => {
 
     target.style.removeProperty('--wa-color-text-normal');
     expect(resolveXtermTheme(target).theme.cursor).toBe('#cccccc');
+  });
+
+  it('falls background and foreground back to surface tokens, then hardcoded', () => {
+    const target = document.createElement('div');
+    target.style.setProperty('--wa-color-surface-default', '#111111');
+    target.style.setProperty('--wa-color-text-normal', '#eeeeee');
+    document.body.append(target);
+
+    const themed = resolveXtermTheme(target).theme;
+    expect(themed.background).toBe('#111111');
+    expect(themed.foreground).toBe('#eeeeee');
+
+    target.style.removeProperty('--wa-color-surface-default');
+    target.style.removeProperty('--wa-color-text-normal');
+    const fallback = resolveXtermTheme(target).theme;
+    expect(fallback.background).toBe('#1e1e1e');
+    expect(fallback.foreground).toBe('#cccccc');
   });
 
   it('uses hardcoded fallbacks when surface tokens are unset', () => {


### PR DESCRIPTION
## Summary

Batch of remaining open follow-ups — #10303 from #10264.

`resolveXtermTheme` now prefers `--wa-color-terminal-background` / `--wa-color-terminal-foreground`, falling back to the surface/text tokens and then the hardcoded palette.

## Issue acceptance gates

#10303: dedicated terminal tokens drive background and foreground.

## Single source of truth

`src/shared/wa/xtermTheme.ts`.

## Duplication and abstraction budget

n/a.

## Net elements (R6)

n/a.

## Consumer counts (R8)

n/a.

## Host impact

Extension and desktop Progress terminals. CLI unchanged.

## Scheduled refactoring

None.

## Validation

- `npx vitest run src/test-kernel/shared/XtermTheme.vitest.ts`
- `npx eslint` on the edited TypeScript files.