### PR TITLE
ci: distinguish type-named imports in the utils walk

### DIFF
--- a/scripts/check-browser-safe-utils.mjs
+++ b/scripts/check-browser-safe-utils.mjs
@@ -130,8 +130,11 @@ function insideRanges(index, ranges) {
  * Mixed `{ type X, y }` stays reachable because `y` is a value import.
  * A binding named `type` (`import { type }` / `import { type as value }`) is
  * a value import — TypeScript treats `type` followed by `as` as the name.
+ * `type as as Alias` is type-only: `type` is the modifier and `as` is the name.
  */
 function isTypeOnlyBinding(binding) {
+  // `type as as Alias` is a type-only import of the name `as`.
+  if (/^type\s+as\s+as\s+[A-Za-z_$]/.test(binding)) return true;
   // `type as value` imports a runtime binding named `type`.
   // `type as` / `type as,` is a type-only import of the name `as`.
   if (/^type\s+as\s+[A-Za-z_$]/.test(binding)) return false;
@@ -189,7 +192,12 @@ function isTypeOnlySpecifier(text, match, ranges) {
     precedingUnmaskedClause(text, match.index, ranges),
   );
   if (clause.length === 0) return false;
-  if (/^(?:import|export)\s+type\b/.test(clause)) return true;
+  // `import type from` is a default binding named `type`. Type-only needs a
+  // specifier after `type` (`{`, `*`, or a name). Blanked comments are spaces,
+  // so `import /* c */ type from` stays a value import.
+  if (/^(?:import|export)\s+type(?:\s+[A-Za-z_$]|\s*[{*])/.test(clause)) {
+    return true;
+  }
   const named = clause.match(/^(?:import|export)\s*\{([^}]*)\}\s*$/);
   if (named == null) return false;
   const bindings = named[1]
@@ -263,6 +271,18 @@ function selfTestImportSpecifiers() {
     {
       text: "import { type as } from './typeOnly';\n",
       expected: [],
+    },
+    {
+      text: "import { type as as Value } from './typeOnly';\n",
+      expected: [],
+    },
+    {
+      text: "import type from './value';\n",
+      expected: ['./value'],
+    },
+    {
+      text: "import /* note */ type from './value';\n",
+      expected: ['./value'],
     },
     {
       text: "import /* note */ type { X } from './typeOnly';\n",

--- a/scripts/check-browser-safe-utils.mjs
+++ b/scripts/check-browser-safe-utils.mjs
@@ -131,14 +131,16 @@ function insideRanges(index, ranges) {
  * A binding named `type` (`import { type }` / `import { type as value }`) is
  * a value import — TypeScript treats `type` followed by `as` as the name.
  * `type as as Alias` is type-only: `type` is the modifier and `as` is the name.
+ * `binding` is escape-decoded, so an identifier may start with any Unicode
+ * ID_Start code point (`É`, `\u00c9` decoded, ...), not only ASCII.
  */
 function isTypeOnlyBinding(binding) {
   // `type as as Alias` is a type-only import of the name `as`.
-  if (/^type\s+as\s+as\s+[A-Za-z_$]/.test(binding)) return true;
+  if (/^type\s+as\s+as\s+[\p{ID_Start}$_]/u.test(binding)) return true;
   // `type as value` imports a runtime binding named `type`.
   // `type as` / `type as,` is a type-only import of the name `as`.
-  if (/^type\s+as\s+[A-Za-z_$]/.test(binding)) return false;
-  return /^type\s+[A-Za-z_$]/.test(binding);
+  if (/^type\s+as\s+[\p{ID_Start}$_]/u.test(binding)) return false;
+  return /^type\s+[\p{ID_Start}$_]/u.test(binding);
 }
 
 /** Blank comment ranges so they cannot change binding classification. */
@@ -156,6 +158,23 @@ function withoutComments(text) {
   return result + text.slice(cursor);
 }
 
+/**
+ * Decode `\uXXXX` / `\u{...}` identifier escapes. TypeScript decodes these
+ * before parsing, so `\u00c9` and `É` are the same identifier and an escaped
+ * `\u0074ype` / `\u0061s` still acts as the `type` / `as` keyword. Out-of-
+ * range escapes are kept verbatim; that code does not compile anyway.
+ */
+function decodeIdentifierEscapes(text) {
+  return text
+    .replace(/\\u\{([0-9A-Fa-f]+)\}/g, (sequence, hex) => {
+      const codePoint = Number.parseInt(hex, 16);
+      return codePoint <= 0x10ffff ? String.fromCodePoint(codePoint) : sequence;
+    })
+    .replace(/\\u([0-9A-Fa-f]{4})/g, (_sequence, hex) =>
+      String.fromCharCode(Number.parseInt(hex, 16)),
+    );
+}
+
 function precedingUnmaskedClause(text, matchIndex, ranges) {
   const before = text.slice(0, matchIndex);
   let keywordIndex = -1;
@@ -171,10 +190,12 @@ function isTypeOnlySpecifier(text, match, ranges) {
   const matched = match[0];
   // `import type X = require('...')` is erased. A bare require() is not.
   if (/^require/.test(matched)) {
-    const clause = withoutComments(
-      precedingUnmaskedClause(text, match.index, ranges),
+    const clause = decodeIdentifierEscapes(
+      withoutComments(precedingUnmaskedClause(text, match.index, ranges)),
     );
-    return /^(?:import|export)\s+type\s+[A-Za-z_$][\w$]*\s*=\s*$/.test(clause);
+    return /^(?:import|export)\s+type\s+[\p{ID_Start}$_][\p{ID_Continue}$\u200c\u200d]*\s*=\s*$/u.test(
+      clause,
+    );
   }
   if (/^(?:import\s*\(|import\.meta\.resolve)/.test(matched)) {
     return false;
@@ -188,14 +209,17 @@ function isTypeOnlySpecifier(text, match, ranges) {
     return false;
   }
 
-  const clause = withoutComments(
-    precedingUnmaskedClause(text, match.index, ranges),
+  const clause = decodeIdentifierEscapes(
+    withoutComments(precedingUnmaskedClause(text, match.index, ranges)),
   );
   if (clause.length === 0) return false;
   // `import type from` is a default binding named `type`. Type-only needs a
   // specifier after `type` (`{`, `*`, or a name). Blanked comments are spaces,
-  // so `import /* c */ type from` stays a value import.
-  if (/^(?:import|export)\s+type(?:\s+[A-Za-z_$]|\s*[{*])/.test(clause)) {
+  // so `import /* c */ type from` stays a value import. The name check uses
+  // ID_Start on escape-decoded text, so `import type É from` stays type-only.
+  if (
+    /^(?:import|export)\s+type(?:\s+[\p{ID_Start}$_]|\s*[{*])/u.test(clause)
+  ) {
     return true;
   }
   const named = clause.match(/^(?:import|export)\s*\{([^}]*)\}\s*$/);
@@ -226,6 +250,18 @@ function selfTestImportSpecifiers() {
   const cases = [
     {
       text: "import type { X } from './typeOnly';\n",
+      expected: [],
+    },
+    {
+      text: "import type X from './typeOnly';\n",
+      expected: [],
+    },
+    {
+      text: "import type * as ns from './typeOnly';\n",
+      expected: [],
+    },
+    {
+      text: "export type * from './typeOnly';\n",
       expected: [],
     },
     {
@@ -275,6 +311,34 @@ function selfTestImportSpecifiers() {
     {
       text: "import { type as as Value } from './typeOnly';\n",
       expected: [],
+    },
+    {
+      text: "import type É from './typeOnly';\n",
+      expected: [],
+    },
+    {
+      text: "import type \\u00C9 from './typeOnly';\n",
+      expected: [],
+    },
+    {
+      text: "import { type É } from './typeOnly';\n",
+      expected: [],
+    },
+    {
+      text: "import { \\u0074ype X } from './typeOnly';\n",
+      expected: [],
+    },
+    {
+      text: "import type É = require('./typeOnly');\n",
+      expected: [],
+    },
+    {
+      text: "import { type as É } from './value';\n",
+      expected: ['./value'],
+    },
+    {
+      text: "import { type \\u0061s value } from './value';\n",
+      expected: ['./value'],
     },
     {
       text: "import type from './value';\n",


### PR DESCRIPTION
## Summary

Two residual false classifications in the browser-safe utils type-only detector would either fail CI on a valid erased import or hide a Node-only edge:

- `{ type as as Value }` was treated as a runtime binding named `type`. TypeScript reads this as a type-only import of the name `as`, aliased to `Value`.
- `import /* note */ type from './value'` (and the uncommented `import type from`) is a runtime default import whose binding is named `type`. After comments are blanked, the clause reads `import type` and was classified as erased.

The detector now distinguishes `type as <value>` from `type as as <alias>`, and requires a specifier after clause-level `import type` / `export type`. Self-tests pin both forms.

## Issue acceptance gates

- #10274: `{ type as as Value }` stays type-only; `{ type as value }` stays reachable; `{ type as }` stays type-only.
- #10275: `import type from` and `import /* note */ type from` stay reachable; `import type { X }` stays type-only.

## Single source of truth

`scripts/check-browser-safe-utils.mjs` remains the only reachability walker. Type-only detection still lives next to `importSpecifiers()`.

## Duplication and abstraction budget

No new file or helper. The two existing classifiers (`isTypeOnlyBinding`, the clause-level `import type` check) now cover the remaining `type`/`as` disambiguation.

## Net elements (R6)

n/a (CI script)

## Consumer counts (R8)

n/a — no emit path or export was added, deleted, or re-routed.

## Host impact

Extension: none

Desktop: none

CLI: none

## Scheduled refactoring

#10213 still tracks replacing the lexical scanner entirely.

## Validation

- `node scripts/check-browser-safe-utils.mjs` (self-tests + live walk: 61 total, 7 reachable)
- `npm run check:browser-safe-utils`