### PR TITLE
docs: drop stale settingsConfiguration reference in CommandCatalog comment

### DIFF
--- a/src/test-kernel/commands/CommandCatalog.vitest.ts
+++ b/src/test-kernel/commands/CommandCatalog.vitest.ts
@@ -22,7 +22,7 @@ interface PackageJson {
 
 // Anchor on the repo root (vitest runs from it) rather than import.meta.url:
 // this file is type-checked under the CommonJS tsconfig as well, which
-// rejects import.meta (matches settingsConfiguration.vitest.ts).
+// rejects import.meta.
 const packageRequire = createRequire(`${process.cwd()}/package.json`);
 const packageJson = packageRequire(
   './packages/extension/package.json',


### PR DESCRIPTION
The comment cited the deleted `shared/settingsConfiguration.vitest.ts` suite (removed in e7f0a008a) as precedent; the anchor-on-repo-root rationale stands on its own.

Closes #10325