### PR TITLE
refactor(transcript): extract shared per-stream KV-store base

### DIFF
--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -6,7 +6,6 @@
  * and generic read/write for arbitrary keys.
  */
 
-import { LRUCache } from 'lru-cache';
 import { z } from 'zod';
 
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
@@ -16,6 +15,7 @@ import {
   type RunRecord,
 } from '@agent/core/definition/RunRecord';
 import { KVStore } from '@common/storage/KVStore';
+import { KVStoreCache } from '@common/storage/KVStoreCache';
 import { createLog } from '@logger/logUtils';
 import { resolveRunStoragePath } from '@platform/defaults/workspaceStorage';
 import {
@@ -388,18 +388,16 @@ function normalizeWorkspaceFilePaths(paths: readonly string[]): string[] {
 
 // LRU-capped store cache. StorageFSKVStore is stateless (file-backed),
 // so eviction is lossless — re-creation just makes a new thin wrapper.
-const storeCache = new LRUCache<ExecutionId, ExecutionKVStore>({ max: 50 });
+const storeCache = new KVStoreCache<ExecutionId, StorageFSKVStore>(
+  (executionId) => new StorageFSKVStore(executionId),
+  { max: 50 },
+);
 
 export function getExecutionStore(executionId: ExecutionId): ExecutionKVStore {
-  const cached = storeCache.get(executionId);
-  if (cached) return cached;
-
-  const store = new StorageFSKVStore(executionId);
-  storeCache.set(executionId, store);
-  return store;
+  return storeCache.get(executionId);
 }
 
 /** Clear the in-memory store cache. Called during extension deactivation. */
 export function clearStoreCache(): void {
-  storeCache.clear();
+  storeCache.invalidateAll();
 }

--- a/src/common/storage/KVStoreCache.ts
+++ b/src/common/storage/KVStoreCache.ts
@@ -1,0 +1,62 @@
+/**
+ * Keyed cache of lazily-created {@link KVStore} handles.
+ *
+ * Per-stream and per-execution stores all hand-rolled the same thin
+ * lifecycle over KVStore: resolve the key's backing directory, create the
+ * handle on first access, and drop the cached handle when the directory it
+ * resolved may have moved (staged-deletion rollback, storage-root
+ * replacement) so the next access re-resolves. This cache owns that
+ * lifecycle so each store routes through one implementation instead of
+ * re-deriving get-or-create plus invalidation per site.
+ *
+ * Handles are stateless wrappers over a directory path, so dropping one is
+ * lossless: an invalidated or LRU-evicted handle is recreated identically on
+ * the next {@link get}. `max` exists only to bound the cache over an
+ * unbounded key space (e.g. execution ids); key spaces already bounded by
+ * their owners leave it unset.
+ */
+
+import { LRUCache } from 'lru-cache';
+
+import { KVStore } from '@common/storage/KVStore';
+
+export class KVStoreCache<
+  TId extends NonNullable<unknown>,
+  TStore extends KVStore = KVStore,
+> {
+  private readonly handles: Map<TId, TStore> | LRUCache<TId, TStore>;
+
+  /**
+   * @param create Resolve `id`'s directory and construct its store.
+   * @param max Cap on cached handles; the least-recently-used handle is
+   *   evicted (losslessly) once exceeded. Unset means unbounded — LRUCache
+   *   preallocates per-cap index structures, so an unbounded cache is a
+   *   plain Map rather than an LRUCache with a fake-infinite cap.
+   */
+  constructor(
+    private readonly create: (id: TId) => TStore,
+    { max }: { max?: number } = {},
+  ) {
+    this.handles = max === undefined ? new Map() : new LRUCache({ max });
+  }
+
+  /** The id's handle, created and cached on first access. */
+  get(id: TId): TStore {
+    let handle = this.handles.get(id);
+    if (!handle) {
+      handle = this.create(id);
+      this.handles.set(id, handle);
+    }
+    return handle;
+  }
+
+  /** Drop the id's cached handle so the next {@link get} re-resolves it. */
+  invalidate(id: TId): void {
+    this.handles.delete(id);
+  }
+
+  /** Drop every cached handle, e.g. after a storage-root replacement. */
+  invalidateAll(): void {
+    this.handles.clear();
+  }
+}

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 
 import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
 import { KVStore } from '@common/storage/KVStore';
+import { KVStoreCache } from '@common/storage/KVStoreCache';
 import * as log from '@logger/logUtils';
 import {
   AgentCategorySchema,
@@ -43,14 +44,6 @@ export const STREAM_LOG_SUMMARIES_DIR =
   WORKSPACE_STORAGE_LAYOUT.streamLogSummaries;
 const STREAM_LOG_LOAD_CONCURRENCY = 8;
 const LOG_TAG = 'StreamLogStore';
-
-function createLogKv(): KVStore {
-  return new KVStore(STREAM_LOGS_DIR, { compactJson: true });
-}
-
-function createSummaryKv(): KVStore {
-  return new KVStore(STREAM_LOG_SUMMARIES_DIR, { compactJson: true });
-}
 
 type StreamLogListener = (streamId: StreamTabId, delta: StreamLogDelta) => void;
 
@@ -297,8 +290,14 @@ export class StreamLogStore {
    */
   private readonly releaseRequests = new Set<StreamTabId>();
   private readonly listeners = createListenerSet<StreamLogListener>();
-  private kv = createLogKv();
-  private summaryKv = createSummaryKv();
+  /**
+   * Lazily-created handles over the two fixed transcript directories, keyed
+   * by directory. Dropped wholesale on storage-root reload so the next
+   * access re-resolves against the new root.
+   */
+  private readonly kvHandles = new KVStoreCache<string>(
+    (dir) => new KVStore(dir, { compactJson: true }),
+  );
 
   /**
    * Lightweight summary per stream (first/last timestamp). Populated at open
@@ -344,6 +343,16 @@ export class StreamLogStore {
 
   private constructor(mode: StreamLogStoreMode) {
     this.mode = Object.freeze(mode);
+  }
+
+  /** Handle over `STREAM_LOGS_DIR`; re-resolved after a storage-root reload. */
+  private kv(): KVStore {
+    return this.kvHandles.get(STREAM_LOGS_DIR);
+  }
+
+  /** Handle over `STREAM_LOG_SUMMARIES_DIR`; same lifecycle as `kv()`. */
+  private summaryKv(): KVStore {
+    return this.kvHandles.get(STREAM_LOG_SUMMARIES_DIR);
   }
 
   // -- StreamState record access -------------------------------------------
@@ -479,7 +488,7 @@ export class StreamLogStore {
     if (this.mode.kind === 'ephemeral' || !this.summaries.has(streamId)) {
       return [];
     }
-    const raw = await this.kv.read<unknown[]>(streamId);
+    const raw = await this.kv().read<unknown[]>(streamId);
     const parsed = this.parsePersistedEntries(streamId, raw);
     return new StreamLog(parsed.entries, parsed.preservedRawEntries).toJSON();
   }
@@ -500,7 +509,7 @@ export class StreamLogStore {
    */
   async hasAuthoritativeStream(streamId: StreamTabId): Promise<boolean> {
     if (this.mode.kind === 'ephemeral') return this.has(streamId);
-    return this.kv.exists(streamId);
+    return this.kv().exists(streamId);
   }
 
   keys(): StreamTabId[] {
@@ -801,7 +810,7 @@ export class StreamLogStore {
     if (state?.pendingLoad) return state.pendingLoad;
     const work = (async () => {
       try {
-        const raw = await this.kv.read<unknown[]>(streamId);
+        const raw = await this.kv().read<unknown[]>(streamId);
         // If `delete` or `clear` ran during the read, don't resurrect it.
         if (
           this.clearing ||
@@ -957,7 +966,7 @@ export class StreamLogStore {
       await this.executeWrite();
       if (this.mode.kind !== 'ephemeral') {
         log.info(LOG_TAG, `Deleting stream: ${streamId}`);
-        await this.kv.delete(streamId);
+        await this.kv().delete(streamId);
         await this.deleteSummaryCache(streamId);
       }
       // The summaries map is the progress tab registry. Commit its removal
@@ -991,7 +1000,7 @@ export class StreamLogStore {
       if (this.mode.kind === 'ephemeral') return;
 
       log.info(LOG_TAG, `Clearing all ${count} streams`);
-      await this.kv.deleteDir();
+      await this.kv().deleteDir();
       await this.clearSummaryCache();
     } finally {
       this.writeTombstones.clear();
@@ -1251,11 +1260,10 @@ export class StreamLogStore {
       );
     }
 
-    // KV adapters cache successful directory creation. A workspace-root
-    // replacement changes what these relative directories resolve to, so new
-    // adapters must own the new root before its first write.
-    this.kv = createLogKv();
-    this.summaryKv = createSummaryKv();
+    // A workspace-root replacement changes what these relative directories
+    // resolve to, so the cached KV handles are dropped and re-resolve
+    // against the new root on next access, before its first write.
+    this.kvHandles.invalidateAll();
     this.summaryCacheMaintenanceEnabled = true;
     if (this.mode.kind === 'persistent') await this.prepareSummaryCache();
 
@@ -1271,7 +1279,7 @@ export class StreamLogStore {
   private async readPersistentSummaries(): Promise<
     Map<StreamTabId, StreamLogSummary>
   > {
-    const streamIds = await this.kv.listKeys();
+    const streamIds = await this.kv().listKeys();
     const results = await pMap(
       streamIds,
       (streamId) => this.loadStreamSummary(streamId as StreamTabId),
@@ -1335,7 +1343,7 @@ export class StreamLogStore {
       return { streamId, summary: persistedSummary };
     }
 
-    const raw = await this.kv.read<unknown[]>(streamId);
+    const raw = await this.kv().read<unknown[]>(streamId);
     // `listKeys()` found the stream, but it may have been deleted before the
     // read completed. Only an existing authoritative `[]` is registration
     // evidence; KVStore's missing-file `undefined` is not.
@@ -1354,13 +1362,13 @@ export class StreamLogStore {
     streamId: StreamTabId,
   ): Promise<StreamLogSummary | undefined> {
     try {
-      const persisted = await this.summaryKv.read<unknown>(streamId);
+      const persisted = await this.summaryKv().read<unknown>(streamId);
       const summary = this.parsePersistedSummary(persisted);
       if (!summary) return undefined;
 
       const [summaryMtime, logMtime] = await Promise.all([
-        this.summaryKv.modifiedAt(streamId),
-        this.kv.modifiedAt(streamId),
+        this.summaryKv().modifiedAt(streamId),
+        this.kv().modifiedAt(streamId),
       ]);
       // A missing log mtime means the authoritative log is gone (deleted, or
       // never written) — orphaned summary, not merely stale. Trusting it here
@@ -1432,9 +1440,9 @@ export class StreamLogStore {
     expectedGeneration: number = this.writeGeneration,
   ): Promise<void> {
     if (this.shouldSkipWrite(streamId, expectedGeneration)) return;
-    await this.kv.write(streamId, logInstance.toPersistedEntries());
+    await this.kv().write(streamId, logInstance.toPersistedEntries());
     if (this.shouldSkipWrite(streamId, expectedGeneration)) {
-      await this.kv.delete(streamId);
+      await this.kv().delete(streamId);
       await this.deleteSummaryCache(streamId);
       return;
     }
@@ -1448,7 +1456,7 @@ export class StreamLogStore {
       ...(meta !== undefined && { meta }),
     });
     if (this.shouldSkipWrite(streamId, expectedGeneration)) {
-      await this.kv.delete(streamId);
+      await this.kv().delete(streamId);
       await this.deleteSummaryCache(streamId);
     }
   }
@@ -1515,7 +1523,7 @@ export class StreamLogStore {
       return;
     }
     try {
-      await this.summaryKv.write(streamId, summary);
+      await this.summaryKv().write(streamId, summary);
     } catch (error) {
       this.disableSummaryCacheMaintenance(
         `Failed to write transcript summary cache for ${streamId}: ${toErrorMessage(error)}`,
@@ -1526,7 +1534,7 @@ export class StreamLogStore {
   private async deleteSummaryCache(streamId: StreamTabId): Promise<void> {
     if (!this.summaryCacheMaintenanceEnabled) return;
     try {
-      await this.summaryKv.delete(streamId);
+      await this.summaryKv().delete(streamId);
     } catch (error) {
       this.disableSummaryCacheMaintenance(
         `Failed to delete transcript summary cache for ${streamId}: ${toErrorMessage(error)}`,
@@ -1537,7 +1545,7 @@ export class StreamLogStore {
   private async clearSummaryCache(): Promise<void> {
     if (!this.summaryCacheMaintenanceEnabled) return;
     try {
-      await this.summaryKv.deleteDir();
+      await this.summaryKv().deleteDir();
     } catch (error) {
       this.disableSummaryCacheMaintenance(
         `Failed to clear transcript summary cache: ${toErrorMessage(error)}`,

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -26,6 +26,7 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { isFileNotFoundError } from '@common/errors';
 import { KVStore } from '@common/storage/KVStore';
+import { KVStoreCache } from '@common/storage/KVStoreCache';
 import { createLog } from '@logger/logUtils';
 import {
   CompileFailureSchema,
@@ -290,7 +291,7 @@ type DiskState = 'unknown' | 'verified-absent' | 'loaded';
 /**
  * Every per-stream field this store tracks, keyed by stream id in ONE map
  * (`records`): the accumulators, the `diskState`/`seedChain` seeding
- * bookkeeping, the overlay patches, and the cached `KVStore` handles. Because every field
+ * bookkeeping, and the overlay patches. Because every field
  * for a stream lives on the same object, dropping a stream's memory is one
  * `records.delete(stream)` — every field disappears with it BY CONSTRUCTION,
  * so `evict()`/`evictAll()` cannot drift from the field list.
@@ -360,9 +361,6 @@ interface StreamRecord {
   // is never clobbered by that seed's raw disk read. See `mutateWithOverlay`.
   metaOverlay: boolean;
   overlays: Partial<OverlayPatches>;
-
-  // -- Cached KVStore handle for this stream's sidecar directory. ----------
-  kv: KVStore | undefined;
 }
 
 interface DirtySidecarWrite {
@@ -395,8 +393,18 @@ export class StreamSnapshotStore {
     seedRefreshBaseline: undefined,
     metaOverlay: false,
     overlays: {},
-    kv: undefined,
   }));
+  /**
+   * Lazily-created per-stream handles over `streamDataDir(streamId)`. A
+   * handle is a stateless wrapper, so dropping one is lossless:
+   * `evict()`/`evictAll()` drop handles alongside the records, and
+   * {@link invalidateKvHandles} forces re-resolution after a stream's
+   * directory may have moved (staged-deletion rollback, storage-root
+   * refresh).
+   */
+  private readonly kvHandles = new KVStoreCache<StreamTabId>(
+    (streamId) => new KVStore(streamDataDir(streamId)),
+  );
   /**
    * The crash-safe staged-deletion + rollback-recovery machine. It owns which
    * namespace holds a staged stream's data and the sidecar writes buffered
@@ -507,19 +515,15 @@ export class StreamSnapshotStore {
   }
 
   private kv(streamId: StreamTabId): KVStore {
-    const record = this.getOrCreateRecord(streamId);
-    if (!record.kv) {
-      record.kv = new KVStore(streamDataDir(streamId));
-    }
-    return record.kv;
+    // Record creation on read-only access stays deliberate (see
+    // clearMissingOutputs): hasDiskProvenance() keys off record presence.
+    this.getOrCreateRecord(streamId);
+    return this.kvHandles.get(streamId);
   }
 
   /** Drop the cached KV handle so the next access re-resolves against the stream's current directory. */
   private invalidateKvHandles(stream: StreamTabId): void {
-    const record = this.records.get(stream);
-    if (record) {
-      record.kv = undefined;
-    }
+    this.kvHandles.invalidate(stream);
   }
 
   private async listStreamsUnder(root: string): Promise<StreamTabId[]> {
@@ -1117,6 +1121,7 @@ export class StreamSnapshotStore {
   /** Drop a stream's in-memory state. Disk cleanup is the caller's job. */
   private evict(stream: StreamTabId): void {
     this.records.evict(stream);
+    this.kvHandles.invalidate(stream);
     for (const key of [...this.writeMutexes.keys()]) {
       if (!key.startsWith(`${stream}::`)) continue;
       this.writeMutexes.delete(key);
@@ -1129,6 +1134,7 @@ export class StreamSnapshotStore {
 
   evictAll(): void {
     this.records.evictAll();
+    this.kvHandles.invalidateAll();
     this.writeMutexes.clear();
     this.dirtyWrites.clear();
     this.unseededReadWarned.clear();


### PR DESCRIPTION
## Summary

Closes #10200. Per-stream stores each hand-rolled the same directory-backed `KVStore` wrapper lifecycle — per-key directory resolution, lazy handle creation, and handle invalidation after directory moves or storage-root replacement. This extracts one shared keyed cache, `KVStoreCache` (`src/common/storage/KVStoreCache.ts`), over `src/common/storage/KVStore` and routes the three cited sites through it:

- `src/transcript/StreamSnapshotStore.ts` — the `StreamRecord.kv` field + `kv()` + `invalidateKvHandles()` hand-roll moves into a store-level `KVStoreCache<StreamTabId>` (`streamDataDir(streamId)` as the resolver). `evict()`/`evictAll()` now drop handles alongside records (same discipline as the existing `writeMutexes`/`dirtyWrites` cleanup); `invalidateKvHandles()` stays the staged-deletion/refresh hook. `kv()` keeps its deliberate record-creation side effect (`hasDiskProvenance()` keys off record presence; documented at `clearMissingOutputs`).
- `src/transcript/StreamLogStore.ts` — `createLogKv()`/`createSummaryKv()` fold into one directory-keyed cache; `kv`/`summaryKv` become zero-arg accessors, and `executeReload()` calls `invalidateAll()` instead of re-creating adapters (KVStore construction is side-effect-free, so lazy re-resolution is unobservable). The stale "KV adapters cache successful directory creation" comment (contradicted by KVStore's ensure-on-every-write contract) is reworded to state the live requirement.
- `src/agent/storage/ExecutionKVStore.ts` — `getExecutionStore()`'s hand-rolled `LRUCache({max: 50})` get-or-create and `clearStoreCache()` become `new KVStoreCache(id => new StorageFSKVStore(id), { max: 50 })`; public surface unchanged.

Design choice: a composed container, not a base class or mixin — that is how sibling stores already share per-key lifecycle code (`ResidentStreamRegistry`); nothing here needs inheritance. Internally it is a plain `Map` when unbounded and `LRUCache` only when `max` is set, because lru-cache v11 preallocates per-cap index structures (`new Array(max)`), so a fake-infinite cap throws `RangeError` at construction.

## Issue acceptance gates

- [x] Shared per-stream KV-store base extracted over `src/common/storage/KVStore`, capturing directory resolution, lazy handle creation, invalidation
- [x] Transcript-layer stores routed through it (StreamSnapshotStore, StreamLogStore)
- [x] Execution-layer store routed through it (ExecutionKVStore)
- [x] Behavior-preserving; no storage-format changes (handles are stateless thin wrappers; eviction/re-creation is lossless)
- [x] Validated with transcript/stream-store suites and `npm run typecheck`

## Single source of truth

`src/common/storage/KVStoreCache.ts` now owns the per-key lazy KV-handle lifecycle (resolve → create-on-first-access → invalidate). `KVStore` itself is unchanged.

## Duplication and abstraction budget

Removes three hand-rolled copies of get-or-create + invalidation (`StreamSnapshotStore.kv()`/`invalidateKvHandles()` record-field juggling, `StreamLogStore.createLogKv`/`createSummaryKv` + reload reassignment, `ExecutionKVStore`'s LRU get-or-create). The new abstraction owns one invariant: a cached handle never survives an event that may have moved its directory. Three consumers in this PR (no single-caller extraction).

## Net elements (R6)

- Files: +1 (`src/common/storage/KVStoreCache.ts`, 62 LoC), 3 modified; diffstat 128 insertions / 54 deletions (net +74 LoC, of which ~45 are doc comments)
- Exported symbols (`^[+-]export` over the diff): +1 (`KVStoreCache`), −0
- Classes/interfaces/enums: +1 class, 0 interfaces, 0 enums
- Deleted: `createLogKv`/`createSummaryKv` (module-private), `StreamRecord.kv` field, `LRUCache` import in ExecutionKVStore

## Consumer counts (R8)

No export or emit path deleted or re-routed: `getExecutionStore` (92 grepped references, signature unchanged), `clearStoreCache` (1 production caller, `packages/extension/src/extension.ts:303`, signature unchanged), `invalidateKvHandles` (store-private; `StagedDeletionHost` interface method unchanged). `KVStoreCache` consumers: 3 (all in this PR).

## Host impact

Extension: none (behavior-preserving; shutdown still clears the execution store cache).
Desktop: none.
CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` (all six sub-checks incl. agent build) — pass
- `npm run lint` — pass, 0 problems
- `npm run compile:fast` — pass
- `npm run check:dead-code-ratchet` — pass (15 findings vs 15 baselined)
- Vitest: all 20 suites referencing `StreamSnapshotStore`/`StreamLogStore` (per issue validation recipe) + all of `src/test-kernel/transcript/` and `src/test-kernel/agent/storage/` — 359/359 pass in the transcript+storage run
- Pre-existing flake note: the two desktop suites (`DesktopAgentExecution.vitest.ts`, `DesktopAgentExecutionFactory.vitest.ts`) contain 10s-threshold timing tests that time out under parallel load on this machine — the same suites fail the same way on unmodified `origin/main` (9 timeouts baseline vs 2 with this change under identical load), and each implicated test passes in isolation with this change (e.g. "never attaches a presentation…" ✓ 9.3s).