### PR TITLE
Move chatgpt-subscription fallback provider policy into ProgressApiKeyRetryController

### DIFF
--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -306,12 +306,7 @@ export function handlePermissionAction(
           requestId: data.requestId,
           model: data.model,
           exhaustionReason,
-          // Subscription quota exhaustion always means the OpenAI key is the
-          // fallback credential, regardless of how the error tagged provider.
-          provider:
-            exhaustionReason === 'chatgpt-subscription'
-              ? 'openai'
-              : data.errorDetails?.provider,
+          provider: data.errorDetails?.provider,
           viaRelay: data.errorDetails?.isRelayError === true || undefined,
         });
         break;

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -123,9 +123,8 @@ export class ProgressApiKeyRetryController {
   async ensureOwnApiKey(
     request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
   ): Promise<boolean> {
-    const providersToCheck = request.provider
-      ? [request.provider]
-      : this.deps.providers;
+    const provider = this.resolveProvider(request);
+    const providersToCheck = provider ? [provider] : this.deps.providers;
     const requireChange = request.exhaustionReason === 'upstream-credit';
 
     // The gate depends on which credential failed:
@@ -137,7 +136,7 @@ export class ProgressApiKeyRetryController {
     // credential, which would allow retrying without a usable direct key.
     if (requireChange) {
       const before = await this.readKeys(providersToCheck);
-      await this.deps.promptForApiKey(request.provider);
+      await this.deps.promptForApiKey(provider);
       return this.hasChangedUsableKey(providersToCheck, before);
     }
 
@@ -147,8 +146,21 @@ export class ProgressApiKeyRetryController {
     // none exists yet, and only re-check the keys after that prompt (so the
     // common already-set path reads the secret store once, not twice).
     if (await this.hasAnyUsableKey(providersToCheck)) return true;
-    await this.deps.promptForApiKey(request.provider);
+    await this.deps.promptForApiKey(provider);
     return this.hasAnyUsableKey(providersToCheck);
+  }
+
+  /**
+   * ChatGPT/Codex subscription exhaustion always means the OpenAI key is the
+   * fallback credential — that auth mode is OpenAI-only (see
+   * `providerCapabilities.ts`) — regardless of how the error tagged provider.
+   */
+  private resolveProvider(
+    request: Pick<ProgressApiKeyRetryRequest, 'provider' | 'exhaustionReason'>,
+  ): ApiProvider | undefined {
+    return request.exhaustionReason === 'chatgpt-subscription'
+      ? 'openai'
+      : request.provider;
   }
 
   private shouldDisableIncludedModelAccess(

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -150,11 +150,8 @@ export class ProgressApiKeyRetryController {
     return this.hasAnyUsableKey(providersToCheck);
   }
 
-  /**
-   * ChatGPT/Codex subscription exhaustion always means the OpenAI key is the
-   * fallback credential — that auth mode is OpenAI-only (see
-   * `providerCapabilities.ts`) — regardless of how the error tagged provider.
-   */
+  // chatgpt-subscription auth is OpenAI-only (providerCapabilities.ts), so
+  // that exhaustion reason always means the OpenAI key, regardless of provider.
   private resolveProvider(
     request: Pick<ProgressApiKeyRetryRequest, 'provider' | 'exhaustionReason'>,
   ): ApiProvider | undefined {

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -304,6 +304,31 @@ describe('ProgressApiKeyRetryController', () => {
     expect(harness.retries).toStrictEqual(['stream-d']);
   });
 
+  it('resolves the OpenAI key from the exhaustion reason when no provider is given', async () => {
+    const harness = createHarness({
+      keys: { openai: 'stored-openai' },
+    });
+
+    // The caller (webview) forwards whatever provider the error was tagged
+    // with, which may be absent — the controller, not the caller, owns the
+    // chatgpt-subscription-always-means-openai policy.
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-f',
+      requestId: 'retry-f',
+      exhaustionReason: 'chatgpt-subscription',
+    });
+
+    expect(result).toStrictEqual({
+      proceeded: true,
+      retried: true,
+      disabledIncludedModelAccess: true,
+      disabledChatGptSubscription: true,
+      disabledCodingPlans: [],
+    });
+    expect(harness.prompts).toStrictEqual([]);
+    expect(harness.retries).toStrictEqual(['stream-f']);
+  });
+
   it('does not disable the subscription when no usable OpenAI key is available', async () => {
     const harness = createHarness({ keys: {} });
 

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -305,8 +305,12 @@ describe('ProgressApiKeyRetryController', () => {
   });
 
   it('resolves the OpenAI key from the exhaustion reason when no provider is given', async () => {
+    // Only an Anthropic key is usable. If the controller fell back to
+    // checking every provider (the pre-fix behavior when `provider` is
+    // absent), it would find this key and retry on it, which is wrong for a
+    // ChatGPT-subscription exhaustion that specifically requires OpenAI.
     const harness = createHarness({
-      keys: { openai: 'stored-openai' },
+      keys: { anthropic: 'stored-anthropic' },
     });
 
     // The caller (webview) forwards whatever provider the error was tagged
@@ -318,15 +322,9 @@ describe('ProgressApiKeyRetryController', () => {
       exhaustionReason: 'chatgpt-subscription',
     });
 
-    expect(result).toStrictEqual({
-      proceeded: true,
-      retried: true,
-      disabledIncludedModelAccess: true,
-      disabledChatGptSubscription: true,
-      disabledCodingPlans: [],
-    });
-    expect(harness.prompts).toStrictEqual([]);
-    expect(harness.retries).toStrictEqual(['stream-f']);
+    expect(result).toStrictEqual(IDLE_RESULT);
+    expect(harness.prompts).toStrictEqual(['openai']);
+    expect(harness.retries).toStrictEqual([]);
   });
 
   it('does not disable the subscription when no usable OpenAI key is available', async () => {

--- a/src/test-kernel/progressView/PermissionActionEventHandlers.vitest.ts
+++ b/src/test-kernel/progressView/PermissionActionEventHandlers.vitest.ts
@@ -246,6 +246,34 @@ const actionCases: PermissionCase[] = [
     remains: true,
   },
   {
+    name: 'retry API-key selection forwards the raw tagged provider unchanged',
+    detail: {
+      kind: PERMISSION_KIND.RETRY,
+      data: {
+        ...retryData,
+        errorDetails: {
+          provider: 'anthropic',
+          exhaustionReason: 'chatgpt-subscription',
+        },
+      },
+      decision: { action: 'useOwnApiKey' },
+    } as const,
+    calls: [
+      call(PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY, {
+        stream: 'stream-1',
+        requestId: 'retry-1',
+        model: 'claude-sonnet',
+        exhaustionReason: 'chatgpt-subscription',
+        // The chatgpt-subscription -> openai fallback mapping is the
+        // controller's policy now (ProgressApiKeyRetryController), not the
+        // webview's — this must pass the tagged provider through untouched.
+        provider: 'anthropic',
+        viaRelay: undefined,
+      }),
+    ],
+    remains: true,
+  },
+  {
     name: 'proposal approve',
     detail: detail.proposal({
       action: 'approve',


### PR DESCRIPTION
## Summary

An abstraction-layer audit found that `packages/extension/src/progressView/frontend/eventHandlers.ts` (a UI/render-layer webview handler) was computing credential-routing *policy* inline: mapping `exhaustionReason === 'chatgpt-subscription'` to the `'openai'` fallback provider before sending the `USE_OWN_API_KEY` message. That decision belongs to `ProgressApiKeyRetryController` (`src/controllers/progressView/`), which already owns the rest of this retry/credential policy (`shouldDisableIncludedModelAccess`, `isSubscriptionExhausted`). Because `packages/desktop/src/renderer/main.ts` imports this exact webview file, both the extension and desktop hosts shared the drift risk: if a new exhaustion reason were added, only the controller would get updated and the webview's copy would silently go stale.

This PR moves the mapping into the controller and simplifies the webview to a pure pass-through of the raw provider hint, matching the pattern it already uses for `viaRelay`.

## Issue acceptance gates

No tracked issue — found and fixed during a scheduled abstraction-layer audit. Gate: the `chatgpt-subscription` → `openai` fallback-provider decision has exactly one owner, and both retry entry points (generic webview retry and the Copilot-fallback path) resolve it consistently.

## Single source of truth

`ProgressApiKeyRetryController.resolveProvider` (new private method) is now the sole place that maps `exhaustionReason: 'chatgpt-subscription'` to the `'openai'` fallback provider. It is used inside `ensureOwnApiKey`, the single choke point both `useOwnApiKey` (generic webview retry) and `runCopilotFallbackWithRouting`'s caller (`ProgressViewMessageHandler.startCopilotFallbackRun`) route through before checking/prompting for a key.

## Duplication and abstraction budget

Removed the duplicate copy of the provider-fallback mapping from the webview render layer; no new abstraction layer was added — `resolveProvider` is a private helper on the existing policy-owning class, not a new module.

## Net elements (R6)

Diffstat: 3 files changed, 43 insertions(+), 11 deletions(-) (includes a new regression test). Net new exported symbols: 0 (`resolveProvider` is `private`). No new files, classes, or interfaces.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed; this only relocates where an existing value is computed.

## Host impact

Extension: `progressView/frontend/eventHandlers.ts` no longer computes the fallback provider; behavior unchanged (controller resolves it instead).

Desktop: shares the same webview file (`packages/desktop/src/renderer/main.ts` imports it verbatim) and the same controller, so it gets the same fix with no separate change needed.

CLI: unaffected — the CLI's parallel retry flow already resolves this in `packages/cli/src/runtime/approval/approvalPrompts.ts`, not in a render component.

## Scheduled refactoring

None.

## Validation

- `npx vitest run src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts src/test-kernel/progressView/PermissionActionEventHandlers.vitest.ts` — 41 passed, including a new test asserting the controller resolves `openai` from `exhaustionReason` alone when `provider` is omitted.
- `npm run typecheck` — full workspace typecheck (workspace, test-kernel, agent, cli, trace-viewer, desktop) passes clean.
- `npx eslint` on the three changed files — no errors.
- `npx prettier --check` on the three changed files — formatted correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KA9tVd2ALake7Fmyw1AhRa)_