### PR TITLE
refactor(agent): fold resume/stream reattach behind the runtime barrel

### DIFF
--- a/config/ratchets/host-agent-import-baseline.json
+++ b/config/ratchets/host-agent-import-baseline.json
@@ -32,7 +32,6 @@
       "@agent/remote/remoteAgentConfigClient",
       "@agent/runtime",
       "@agent/storage",
-      "@agent/storage/detectWaitingStreams",
       "@agent/templates/agentTemplateRenderer",
       "@agent/trace"
     ],


### PR DESCRIPTION
## Summary

Finishes the first of the four cross-host clusters from #10024: the
resume/stream reattach surface (`resolveAndResumeStream`,
`resumeQueuedToolUse`, `SessionResumeRetrieval`).

#10011 already did the code migration for this cluster: it created the curated
`@agent/runtime` barrel and moved every host runtime deep-import onto it,
including `resolveAndResumeStream`, `resumeQueuedToolUseFromResumeData`,
`retrieveSessionResumeData`, and `resumeToolUseFromResumeData`. The only
remaining cluster pin in the host deep-import baseline was desktop's
`@agent/storage/detectWaitingStreams` entry, which was stale — desktop stopped
importing it in #9273/#9312 and no host imports it today.

This PR removes that stale baseline entry. The barrel is intentionally
unchanged: `detectWaitingStreams` has no host importer left to migrate, so
adding it to the barrel would be a consumer-less export.

**This is cluster 1 of 4.** Remaining clusters are `@agent/storage`,
`followUp`, and `core/definition/AgentConfig`.

Refs #10024

## Issue acceptance gates

- Fold the resume/stream reattach cluster behind a curated barrel surface: the
  runtime side is behind `@agent/runtime` (done in #10011); the last baseline
  pin for the cluster is removed here.
- Host migration off deep imports: already complete — grep finds no
  `@agent/runtime/resolveAndResumeStream`, `@agent/runtime/resumeQueuedToolUse`,
  or `@agent/runtime/SessionResumeRetrieval` in `packages/{cli,desktop,extension}/src`.
- Shrink `config/ratchets/host-agent-import-baseline.json` with no baseline
  widened: desktop 13 -> 12.

## Single source of truth

`src/agent/runtime/index.ts` — the curated `@agent/runtime` barrel remains the
host-facing door for the resume/stream reattach cluster.

## Duplication and abstraction budget

No new abstraction. One dead baseline entry deleted; no production code changed.

## Net elements (R6)

- Files changed: 1 (`config/ratchets/host-agent-import-baseline.json`)
- Exported symbols: 0
- Classes/interfaces/enums: 0
- Net LoC: -1

## Consumer counts (R8)

- `@agent/runtime` barrel: consumed by CLI, desktop, and extension (counts
  unchanged by this PR; the barrel surface is unchanged).
- `@agent/storage/detectWaitingStreams`: 0 host consumers (verified via grep of
  `packages/cli/src`, `packages/desktop/src`, `packages/extension/src`).

## Host impact

Extension: none.

Desktop: baseline entry removed (no import changes).

CLI: none.

## Scheduled refactoring

Remaining #10024 clusters: `@agent/storage`, `followUp`,
`core/definition/AgentConfig`.

## Validation

- `corepack pnpm install --prefer-offline` — up to date
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx vitest run src/test-kernel/architecture/` — 15 files / 93 tests passed
- Resume/reattach suites — 9 files / 189 tests passed
- `npm run compile:fast` — clean
