### PR TITLE
docs: trim the stale CommonJS-tsconfig rationale in the CommandCatalog comment

### DIFF
--- a/src/test-kernel/commands/CommandCatalog.vitest.ts
+++ b/src/test-kernel/commands/CommandCatalog.vitest.ts
@@ -20,9 +20,7 @@ interface PackageJson {
   };
 }
 
-// Anchor on the repo root (vitest runs from it) rather than import.meta.url:
-// this file is type-checked under the CommonJS tsconfig as well, which
-// rejects import.meta.
+// Anchor on the repo root (vitest runs from it) rather than import.meta.url.
 const packageRequire = createRequire(`${process.cwd()}/package.json`);
 const packageJson = packageRequire(
   './packages/extension/package.json',


### PR DESCRIPTION
The comment's remaining clause claimed this file is type-checked under a CommonJS tsconfig that rejects import.meta; that is false against the current tree (verified in the issue). The repo-root anchor rationale stands on its own.

Closes #10337