### PR TITLE
refactor(schemas): deduplicate divergent same-name zod schemas

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
@@ -46,7 +46,7 @@ export function formatWebSearchTemplate(message: LogMessageData): FormatResult {
   const { data } = message;
   if (!data || typeof data !== 'object') return null;
 
-  // Parsed (not merely cast) so `WebSearchResultItemSchema` actually
+  // Parsed (not merely cast) so `WebSearchPayloadItemSchema` actually
   // sanitizes each result's `url` — a `javascript:`/`data:` scheme from a
   // web_search tool result must never reach the `<a href>` below.
   const { query, results, provider, status } =
@@ -67,7 +67,7 @@ export function formatWebSearchTemplate(message: LogMessageData): FormatResult {
   const sections: TemplateResult[] = [];
 
   if (resultCount > 0) {
-    // `r.url` is already schema-sanitized (`WebSearchResultItemSchema`) to
+    // `r.url` is already schema-sanitized (`WebSearchPayloadItemSchema`) to
     // either a safe URL or `undefined` — never render an `<a>` without a
     // real href (an empty/missing href is not itself dangerous, but a
     // result with no safe URL should read as inert text, not a dead link).

--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -25,6 +25,7 @@ import { CONVERSATION_BLOCK_TYPES } from '@agent/types/ConversationBlockTypes';
 import {
   ANTHROPIC_SERVER_TOOL_BLOCK_TYPES,
   extractWebFetchResultFields,
+  WebSearchResultEntrySchema,
 } from '@agent/types/ServerTools';
 import { isObject } from '@utils/core';
 import type { Part } from '@google/genai';
@@ -39,12 +40,18 @@ import type { ExportNode, UserPart } from './schemas';
 // Input schemas (implementation detail — not exported publicly)
 // ============================================================
 
-/** One entry inside a `web_search_tool_result` block's `content` array. */
-const WebSearchResultItemSchema = z.object({
-  type: z.string(),
-  title: z.string().optional(),
-  url: z.string().optional(),
-});
+/**
+ * One entry inside a `web_search_tool_result` block's `content` array: the
+ * provider wire shape of the canonical {@link WebSearchResultEntrySchema},
+ * read permissively (`title`/`url` optional on the wire) and tagged with the
+ * block's `type` string.
+ */
+const WebSearchResultItemSchema = WebSearchResultEntrySchema.pick({
+  title: true,
+  url: true,
+})
+  .partial()
+  .extend({ type: z.string() });
 
 /**
  * Discriminated union of API content blocks across the four provider shapes

--- a/src/agent/export/schemas.ts
+++ b/src/agent/export/schemas.ts
@@ -8,10 +8,14 @@
  * `@google/genai`.
  *
  * Zod schemas are the single source of truth; types are derived with `z.infer`.
+ * The one cross-module dependency is the canonical web-search entry schema
+ * from `@agent/types/ServerTools`, whose provider SDK imports are type-only,
+ * so the neutrality note above still holds.
  */
 
 import { z } from 'zod';
 
+import { WebSearchResultEntrySchema } from '@agent/types/ServerTools';
 import type { MediaAttachmentKind } from '@shared/schemas';
 
 // ============================================================
@@ -41,9 +45,15 @@ export type ChatExportInput = z.infer<typeof ChatExportInputSchema>;
 // Intermediate representation — format-agnostic
 // ============================================================
 
-const WebSearchResultSchema = z.object({
-  title: z.string(),
-  url: z.string(),
+/**
+ * One rendered search hit in the exported document: the title/url projection
+ * of the canonical provider result entry ({@link WebSearchResultEntrySchema}
+ * in `@agent/types/ServerTools`). Snippet, domain, and page age never reach
+ * the export IR.
+ */
+const ExportWebSearchResultSchema = WebSearchResultEntrySchema.pick({
+  title: true,
+  url: true,
 });
 
 /**
@@ -80,7 +90,7 @@ const ExportNodeSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('web-search'), query: z.string() }),
   z.object({
     kind: z.literal('web-search-results'),
-    results: z.array(WebSearchResultSchema),
+    results: z.array(ExportWebSearchResultSchema),
   }),
   z.object({
     kind: z.literal('web-fetch'),

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -21,7 +21,7 @@ import {
 } from '@agent/types/ProviderMessage';
 import { ModelHandlerCompatibilityKeySchema } from '@agent/runtime/modelHandlerCompatibilityKey';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
-import { RetryErrorInfoSchema } from '@shared/schemas';
+import { JsonValueSchema, RetryErrorInfoSchema } from '@shared/schemas';
 
 import { currentModelFromUserChannels } from '../modelSwitchState';
 
@@ -61,7 +61,7 @@ const ToolUseRunSharedSchema = z.looseObject({
   /** Last assistant response without the full assembly buffers. */
   lastResponse: z.string().optional(),
   /** Validated terminal-tool result retained across interrupt and resume. */
-  structured: z.json().optional(),
+  structured: JsonValueSchema.optional(),
 });
 
 /** Per-step schema after the one-time legacy workspace migration. */

--- a/src/agent/runtime/AgentFinalResult.ts
+++ b/src/agent/runtime/AgentFinalResult.ts
@@ -7,7 +7,7 @@ import {
   type AgentFlowResult,
   type WorkflowFlowResult,
 } from '@agent/runtime/AgentFlowResult';
-import type { RunOutcome } from '@shared/schemas';
+import { JsonValueSchema, type RunOutcome } from '@shared/schemas';
 
 /** Reference to one persisted workflow diff. */
 const ResultDiffSummarySchema = z.strictObject({
@@ -37,7 +37,7 @@ export const WorkflowAgentFinalResultSchema = WorkflowFlowResultSchema.pick({
     diffs: z.array(ResultDiffSummarySchema).prefault(() => []),
     cost: CostSchema,
     diffsUnavailable: z.string().optional(),
-    structured: z.json().optional(),
+    structured: JsonValueSchema.optional(),
   })
   .strict();
 
@@ -51,7 +51,7 @@ const ToolUseAgentFinalResultSchema = ToolUseFlowResultSchema.pick({
     response: ToolUseFlowResultSchema.shape.response.unwrap().prefault(''),
     files: ToolUseFlowResultSchema.shape.files.unwrap().prefault(() => []),
     cost: CostSchema,
-    structured: z.json().optional(),
+    structured: JsonValueSchema.optional(),
   })
   .strict();
 

--- a/src/agent/types/ServerTools.ts
+++ b/src/agent/types/ServerTools.ts
@@ -37,7 +37,7 @@ import type {
  * Schema for a single web search result entry.
  * Normalized across all providers.
  */
-const WebSearchResultEntrySchema = z.object({
+export const WebSearchResultEntrySchema = z.object({
   /** URL of the search result */
   url: z.string(),
   /** Title of the page */

--- a/src/agent/workflowScript/persistence.ts
+++ b/src/agent/workflowScript/persistence.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 // Local imports - storage
 import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
+import { JsonValueSchema } from '@shared/schemas';
 import {
   WorkflowScriptFilesSchema,
   type WorkflowScriptFiles,
@@ -21,7 +22,6 @@ import {
 } from './types';
 
 const WORKFLOW_SCRIPT_CHECKPOINT_SCHEMA_VERSION = 3;
-const JsonValueSchema = z.json();
 
 const PersistedJsonValueSchema = z.discriminatedUnion('kind', [
   z.strictObject({ kind: z.literal('undefined') }),

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -1,5 +1,6 @@
 // Layer 1: Base types (no dependencies on other schema files)
 export * from './identifiers';
+export * from './jsonValue';
 export * from './agent';
 export * from './runIdentity';
 export * from './agentRoster';

--- a/src/shared/schemas/jsonValue.ts
+++ b/src/shared/schemas/jsonValue.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+/**
+ * Any JSON-serializable value. Shared home for `z.json()` so structured tool
+ * output, workflow-script persistence, and agent run results validate the
+ * same contract instead of re-declaring it per module (#10279).
+ */
+export const JsonValueSchema = z.json();
+export type JsonValue = z.infer<typeof JsonValueSchema>;

--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -114,7 +114,16 @@ export type NormalizedToolUse = {
 /** URL field for tool payloads that will be rendered as live links. */
 const SafeUrlSchema = z.string().transform(sanitizeLiveLinkUrl);
 
-const WebSearchResultItemSchema = z.object({
+/**
+ * Render-boundary projection of the canonical provider web-search entry
+ * (`WebSearchResultEntrySchema` in `@agent/types/ServerTools` — not imported
+ * here because the shared layer must not depend on the agent layer). Keeps
+ * only the rendered fields, all optional because persisted archives may be
+ * partial, and applies the SafeUrl sanitization transform to `url` at this
+ * boundary (#7230). Named for its payload so it no longer collides with the
+ * agent layer's same-name schemas (#10279).
+ */
+const WebSearchPayloadItemSchema = z.object({
   url: SafeUrlSchema.optional(),
   title: z.string().optional(),
   domain: z.string().optional(),
@@ -122,7 +131,7 @@ const WebSearchResultItemSchema = z.object({
 
 export const WebSearchPayloadSchema = z.object({
   query: z.string().optional(),
-  results: z.array(WebSearchResultItemSchema).optional(),
+  results: z.array(WebSearchPayloadItemSchema).optional(),
   provider: z.string().optional(),
   status: z.string().optional(),
 });

--- a/src/test-kernel/schemas/SharedSchemas.vitest.ts
+++ b/src/test-kernel/schemas/SharedSchemas.vitest.ts
@@ -64,7 +64,7 @@ describe('MainView housekeeping messages', () => {
  * Regression coverage for issue #7230: `web_search`/`web_fetch` `url` fields
  * are LLM/tool-controlled and must never carry a dangerous scheme through to
  * a rendered `<a href>` in the live webview or the exported HTML. Sanitization
- * lives in the shared schemas (`WebSearchResultItemSchema` /
+ * lives in the shared schemas (`WebSearchPayloadItemSchema` /
  * `WebFetchPayloadSchema`) so both render paths are protected by one fix.
  * Only `http:`/`https:`/`mailto:` and anchor-only (`#foo`) URLs survive;
  * empty, protocol-relative, root-relative, and dangerous schemes collapse to

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -24,6 +24,7 @@ import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionConte
 import {
   AgentCategory,
   DEFAULT_TOOL_CONFIG,
+  JsonValueSchema,
   RUN_OUTCOME,
   ToolError,
   type ToolResult,
@@ -96,7 +97,7 @@ const WorkflowScriptToolInputSchema = z
       ),
   })
   .superRefine((input, ctx) => {
-    if (input.args != null && !z.json().safeParse(input.args).success) {
+    if (input.args != null && !JsonValueSchema.safeParse(input.args).success) {
       ctx.addIssue({
         code: 'custom',
         message: 'Workflow arguments must contain valid JSON values.',

--- a/src/tools/structuredOutput.ts
+++ b/src/tools/structuredOutput.ts
@@ -4,7 +4,11 @@ import { z } from 'zod';
 // Internal imports
 import type { ITool, IToolRegistry } from '@agent/core/tools/ToolTypes';
 import { convertToolSchema } from '@agent/modelHandlers/toolConversion';
-import type { ToolResult } from '@shared/schemas';
+import {
+  JsonValueSchema,
+  type JsonValue,
+  type ToolResult,
+} from '@shared/schemas';
 
 // Local file imports
 import { defineTool } from './core/define';
@@ -13,9 +17,6 @@ type StructuredOutputSchema<TSchema extends z.ZodType = z.ZodType> = {
   readonly jsonSchema: Record<string, unknown>;
   readonly zodSchema: TSchema;
 };
-
-const JsonValueSchema = z.json();
-type JsonValue = z.infer<typeof JsonValueSchema>;
 
 /** Name of the synthetic tool the model calls to submit its final result. */
 const SUBMIT_OUTPUT_TOOL_NAME = 'submit_output';


### PR DESCRIPTION
## What

Addresses the divergent same-name Zod schema duplicates from #10279 by designating one canonical web-search entry schema and one shared JSON-value schema, then composing the per-layer consumers instead of re-declaring their shapes.

## Per-finding changes

1. **`WebSearchResultSchema` duplicated with divergent shapes**
   - Exported the canonical `WebSearchResultEntrySchema` from `@agent/types/ServerTools`.
   - Replaced the export IR's local `WebSearchResultSchema` with `ExportWebSearchResultSchema = WebSearchResultEntrySchema.pick({ title, url })` in `src/agent/export/schemas.ts`.

2. **`WebSearchResultItemSchema` duplicated with divergent shapes**
   - Renamed the progress-view payload item to `WebSearchPayloadItemSchema` in `src/shared/schemas/progressView/data.ts`, documenting its render-boundary mapping to the canonical entry and keeping the SafeUrl sanitization transform (#7230) at that boundary.
   - `src/agent/export/normalizeConversation.ts` now composes its `web_search_tool_result` content item from the canonical entry via `.pick(...).partial().extend({ type: z.string() })`.
   - Updated references in `webFormatters.ts` and the shared-schemas regression test.

3. **`JsonValueSchema = z.json()` duplicated plus four inline literals**
   - Added one shared `JsonValueSchema` in `src/shared/schemas/jsonValue.ts` and re-exported it from `@shared/schemas`.
   - Replaced the two local definitions in `src/tools/structuredOutput.ts` and `src/agent/workflowScript/persistence.ts`, and the four inline `z.json()` uses in `src/tools/delegation/WorkflowScriptTool.ts`, `src/agent/implementations/flows/tooluse/nodes/types.ts`, and `src/agent/runtime/AgentFinalResult.ts`.

No validation-shape or wire-format changes.

## Validation

- `npm run typecheck` — passed
- `npm run lint` — passed
- Targeted vitest suites for touched modules — 13 files / 208 tests passed
- `npx vitest run src/test-kernel/architecture/` — 15 files / 93 tests passed
- `npm run compile:fast` — passed
- `config/ratchets/shared-schemas-deep-import-baseline.json` — unchanged (0-line diff); the deep-import ratchet passes without regeneration

Closes #10279
