### PR TITLE
refactor(desktop): use shared loading/empty-state helpers in editor and logs panes

### DIFF
--- a/packages/desktop/src/renderer/editorPane.ts
+++ b/packages/desktop/src/renderer/editorPane.ts
@@ -141,7 +141,10 @@ export function createEditorPane(callbacks: EditorPaneCallbacks): EditorPane {
       return renderEmptyState({
         icon: 'folder-open',
         title: 'No files found in this workspace.',
-        headingTag: 'h3',
+        // h2, not h3: the surrounding "Project" label (taskShell.ts) is a
+        // plain div, not a heading, so there's no h1/h2 in this sidebar
+        // subtree to nest under.
+        headingTag: 'h2',
         className: 'desktop-editor-tree-empty desktop-editor-tree-empty-state',
       });
     }

--- a/packages/desktop/src/renderer/editorPane.ts
+++ b/packages/desktop/src/renderer/editorPane.ts
@@ -19,6 +19,8 @@ import { html, nothing, render, type TemplateResult } from 'lit';
 
 import type { DesktopThemeKind } from '@shared/schemas';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
+import { renderEmptyState } from '@shared/wa/emptyState';
+import { renderLoadingState } from '@shared/wa/loadingState';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { monacoLanguageForPath } from '@shared/monaco/monacoLanguage';
 import {
@@ -133,18 +135,15 @@ export function createEditorPane(callbacks: EditorPaneCallbacks): EditorPane {
       `;
     }
     if (treeLoading) {
-      return html`
-        <div class="desktop-editor-tree-empty" role="status">
-          <p>Loading project files…</p>
-        </div>
-      `;
+      return renderLoadingState('Loading project files…');
     }
     if (treeNodes.length === 0) {
-      return html`
-        <div class="desktop-editor-tree-empty">
-          <p>No files found in this workspace.</p>
-        </div>
-      `;
+      return renderEmptyState({
+        icon: 'folder-open',
+        title: 'No files found in this workspace.',
+        headingTag: 'h3',
+        className: 'desktop-editor-tree-empty',
+      });
     }
     return html`
       <div class="desktop-editor-tree-header">

--- a/packages/desktop/src/renderer/editorPane.ts
+++ b/packages/desktop/src/renderer/editorPane.ts
@@ -142,7 +142,7 @@ export function createEditorPane(callbacks: EditorPaneCallbacks): EditorPane {
         icon: 'folder-open',
         title: 'No files found in this workspace.',
         headingTag: 'h3',
-        className: 'desktop-editor-tree-empty',
+        className: 'desktop-editor-tree-empty desktop-editor-tree-empty-state',
       });
     }
     return html`

--- a/packages/desktop/src/renderer/logsPane.ts
+++ b/packages/desktop/src/renderer/logsPane.ts
@@ -3,7 +3,9 @@ import { html, render, type TemplateResult } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { postMessage } from '@shared/hostBridge';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
+import { renderEmptyState } from '@shared/wa/emptyState';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
+import { renderLoadingState } from '@shared/wa/loadingState';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { formatTimestamp, truncateSummary } from '@utils/text/stringUtils';
 import { DESKTOP_LOCAL_COMMANDS } from '../shared/desktopCommandSurface';
@@ -27,7 +29,7 @@ export interface DesktopLogEntry {
 
 interface LogViewerState {
   entries: readonly DesktopLogEntry[];
-  emptyMessage: string;
+  status: 'loading' | 'ready';
   meta: string;
 }
 
@@ -174,7 +176,7 @@ export function createLogsPane(
 
   let state: LogViewerState = {
     entries: [],
-    emptyMessage: 'Loading recent entries…',
+    status: 'loading',
     meta: 'Recent redacted log entries appear here.',
   };
   let active = false;
@@ -208,6 +210,24 @@ export function createLogsPane(
         <pre class="desktop-log-entry-content">${entry.raw}</pre>
       </wa-details>
     `;
+  }
+
+  function logListContent(): TemplateResult {
+    if (state.entries.length > 0) {
+      return html`${repeat(
+        state.entries.toReversed(),
+        (entry) => entry.id,
+        entryTemplate,
+      )}`;
+    }
+    if (state.status === 'loading') {
+      return renderLoadingState('Loading recent entries…');
+    }
+    return renderEmptyState({
+      icon: 'file-lines',
+      title: 'No desktop log entries yet.',
+      className: 'desktop-log-viewer-empty',
+    });
   }
 
   function viewerTemplate(): TemplateResult {
@@ -248,17 +268,7 @@ export function createLogsPane(
           role="list"
           aria-label="Recent desktop log entries"
         >
-          ${
-            state.entries.length === 0
-              ? html`<div class="desktop-log-viewer-empty" role="status">
-                  ${state.emptyMessage}
-                </div>`
-              : repeat(
-                  state.entries.toReversed(),
-                  (entry) => entry.id,
-                  entryTemplate,
-                )
-          }
+          ${logListContent()}
         </div>
       </section>
     `;
@@ -293,7 +303,7 @@ export function createLogsPane(
     const entries = parseDesktopLogEntries(message.log.text);
     state = {
       entries,
-      emptyMessage: 'No desktop log entries yet.',
+      status: 'ready',
       meta: message.log.truncated
         ? `Showing the most recent redacted entries from ${path}.`
         : `Showing redacted entries from ${path}.`,

--- a/packages/desktop/src/renderer/logsPane.ts
+++ b/packages/desktop/src/renderer/logsPane.ts
@@ -230,6 +230,7 @@ export function createLogsPane(
       ${renderEmptyState({
         icon: 'file-lines',
         title: 'No desktop log entries yet.',
+        headingTag: 'h3',
         className: 'desktop-log-viewer-empty',
       })}
     </div>`;

--- a/packages/desktop/src/renderer/logsPane.ts
+++ b/packages/desktop/src/renderer/logsPane.ts
@@ -223,11 +223,16 @@ export function createLogsPane(
     if (state.status === 'loading') {
       return renderLoadingState('Loading recent entries…');
     }
-    return renderEmptyState({
-      icon: 'file-lines',
-      title: 'No desktop log entries yet.',
-      className: 'desktop-log-viewer-empty',
-    });
+    // role="status" keeps the previous div's behavior: announce to screen
+    // readers that the requested snapshot finished loading with no entries,
+    // not just that it's still loading.
+    return html`<div role="status">
+      ${renderEmptyState({
+        icon: 'file-lines',
+        title: 'No desktop log entries yet.',
+        className: 'desktop-log-viewer-empty',
+      })}
+    </div>`;
   }
 
   function viewerTemplate(): TemplateResult {

--- a/packages/desktop/src/renderer/logsPane.ts
+++ b/packages/desktop/src/renderer/logsPane.ts
@@ -1,5 +1,5 @@
 import '@awesome.me/webawesome/dist/components/details/details.js';
-import { html, render, type TemplateResult } from 'lit';
+import { html, nothing, render, type TemplateResult } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { postMessage } from '@shared/hostBridge';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
@@ -212,28 +212,21 @@ export function createLogsPane(
     `;
   }
 
-  function logListContent(): TemplateResult {
-    if (state.entries.length > 0) {
-      return html`${repeat(
-        state.entries.toReversed(),
-        (entry) => entry.id,
-        entryTemplate,
-      )}`;
-    }
+  // role="status" lives on this permanently mounted wrapper — not on a node
+  // that's created fresh per state — because assistive tech only reliably
+  // announces content changing inside an already-present live region, not a
+  // brand-new node that arrives with its content already populated.
+  function logStatusContent(): TemplateResult | typeof nothing {
+    if (state.entries.length > 0) return nothing;
     if (state.status === 'loading') {
       return renderLoadingState('Loading recent entries…');
     }
-    // role="status" keeps the previous div's behavior: announce to screen
-    // readers that the requested snapshot finished loading with no entries,
-    // not just that it's still loading.
-    return html`<div role="status">
-      ${renderEmptyState({
-        icon: 'file-lines',
-        title: 'No desktop log entries yet.',
-        headingTag: 'h3',
-        className: 'desktop-log-viewer-empty',
-      })}
-    </div>`;
+    return renderEmptyState({
+      icon: 'file-lines',
+      title: 'No desktop log entries yet.',
+      headingTag: 'h3',
+      className: 'desktop-log-viewer-empty',
+    });
   }
 
   function viewerTemplate(): TemplateResult {
@@ -274,7 +267,16 @@ export function createLogsPane(
           role="list"
           aria-label="Recent desktop log entries"
         >
-          ${logListContent()}
+          <div role="status">${logStatusContent()}</div>
+          ${
+            state.entries.length > 0
+              ? repeat(
+                  state.entries.toReversed(),
+                  (entry) => entry.id,
+                  entryTemplate,
+                )
+              : nothing
+          }
         </div>
       </section>
     `;

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -1198,6 +1198,16 @@ wa-input.desktop-command-palette-input::part(input) {
   text-align: center;
 }
 
+.desktop-log-viewer-empty .empty-state-icon {
+  font-size: var(--font-size-h1);
+}
+
+.desktop-log-viewer-empty .empty-state-title {
+  margin: 0;
+  font-size: inherit;
+  font-weight: var(--wa-font-weight-regular, normal);
+}
+
 @container (max-width: 720px) {
   .desktop-log-viewer-header {
     grid-template-columns: minmax(0, 1fr);
@@ -1613,10 +1623,37 @@ wa-card.desktop-onboarding::part(footer) {
   background: var(--wa-color-brand-fill-loud, currentColor);
 }
 
+/* Structure owned by the shared renderLoadingState helper (@shared/wa) — light-DOM
+   mirror of the `.loading-state` rule in src/shared/styles/commonViewStyles.ts,
+   since this tree can't adopt that shadow-DOM stylesheet. Shared by the editor
+   tree panel and the desktop log viewer. */
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--wa-space-xs);
+  padding: var(--wa-space-m);
+  color: var(--wa-color-text-quiet);
+  font-size: var(--font-size-sm);
+}
+
+.desktop-log-viewer-list .loading-state {
+  min-height: 8rem;
+}
+
 .desktop-editor-tree-empty {
   padding: var(--wa-space-m);
   color: var(--wa-color-text-quiet);
   font-size: var(--font-size-sm);
+}
+
+/* Class hook consumed by the shared renderEmptyState() helper (@shared/wa/emptyState).
+   Neutralizes the UA heading chrome so it reads like the plain text this panel used
+   before adopting the helper. */
+.desktop-editor-tree-empty .empty-state-title {
+  margin: 0;
+  font-size: inherit;
+  font-weight: var(--wa-font-weight-regular, normal);
 }
 
 .desktop-editor-surface {

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -1625,20 +1625,29 @@ wa-card.desktop-onboarding::part(footer) {
 
 /* Structure owned by the shared renderLoadingState helper (@shared/wa) — light-DOM
    mirror of the `.loading-state` rule in src/shared/styles/commonViewStyles.ts,
-   since this tree can't adopt that shadow-DOM stylesheet. Shared by the editor
-   tree panel and the desktop log viewer. */
+   since this tree can't adopt that shadow-DOM stylesheet. Same tokens as the
+   canonical rule (padding: --wa-space-l, no font-size override) so it doesn't
+   reintroduce the per-consumer mismatch this file's header warns against.
+   Shared by the editor tree panel and the desktop log viewer. */
 .loading-state {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: var(--wa-space-xs);
-  padding: var(--wa-space-m);
+  padding: var(--wa-space-l);
   color: var(--wa-color-text-quiet);
-  font-size: var(--font-size-sm);
 }
 
 .desktop-log-viewer-list .loading-state {
   min-height: 8rem;
+}
+
+/* The editor tree is a narrow sidebar, not the roomier canonical panel — keep
+   its loading state's footprint matching its own .desktop-editor-tree-empty
+   rather than the larger canonical padding/font-size. */
+.desktop-editor-tree .loading-state {
+  padding: var(--wa-space-m);
+  font-size: var(--font-size-sm);
 }
 
 .desktop-editor-tree-empty {
@@ -1654,6 +1663,16 @@ wa-card.desktop-onboarding::part(footer) {
   margin: 0;
   font-size: inherit;
   font-weight: var(--wa-font-weight-regular, normal);
+}
+
+/* Second class carried only by the empty-state render (not the wa-callout error
+   state, which shares .desktop-editor-tree-empty alone) — lays out the helper's
+   icon and title without restyling the callout. */
+.desktop-editor-tree-empty-state {
+  display: grid;
+  justify-items: center;
+  gap: var(--wa-space-2xs);
+  text-align: center;
 }
 
 .desktop-editor-surface {

--- a/src/test-kernel/desktop/DesktopLogsPane.vitest.ts
+++ b/src/test-kernel/desktop/DesktopLogsPane.vitest.ts
@@ -101,6 +101,34 @@ describe('desktop logs pane', () => {
     });
   });
 
+  it('shows a status-announced loading state before the first snapshot arrives', async () => {
+    const { createLogsPane } = await loadLogsPane();
+    const controller = createLogsPane({ sendCommand: vi.fn() });
+    document.body.append(controller.element);
+
+    const loading = controller.element.querySelector('.loading-state');
+    expect(loading).not.toBeNull();
+    expect(loading?.getAttribute('role')).toBe('status');
+    expect(loading?.textContent).toContain('Loading recent entries…');
+  });
+
+  it('shows a status-announced empty state when a snapshot has no entries', async () => {
+    const { createLogsPane } = await loadLogsPane();
+    const controller = createLogsPane({ sendCommand: vi.fn() });
+    document.body.append(controller.element);
+
+    controller.applySnapshot({
+      command: DESKTOP_LOG_COMMANDS.SET_LOG,
+      log: { path: '/redacted/texra-desktop.log', text: '', truncated: false },
+    });
+
+    expect(controller.element.querySelector('.loading-state')).toBeNull();
+    const empty = controller.element.querySelector('.desktop-log-viewer-empty');
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toContain('No desktop log entries yet.');
+    expect(empty?.closest('[role="status"]')).not.toBeNull();
+  });
+
   it('renders one expandable Web Awesome details row per parsed entry', async () => {
     const { createLogsPane } = await loadLogsPane();
     const controller = createLogsPane({ sendCommand: vi.fn() });


### PR DESCRIPTION
## Summary

A scheduled UI-consistency audit flagged three spots in the desktop app that hand-rolled their own loading/empty-state markup instead of using the shared `renderLoadingState()`/`renderEmptyState()` helpers (`src/shared/wa/loadingState.ts`, `src/shared/wa/emptyState.ts`) that `reviewPane.ts`, `TexraDiffView.ts`, and `main.ts`'s task workbench placeholder already use consistently. This PR brings `editorPane.ts` and `logsPane.ts` in line with that standard.

- `editorPane.ts`'s file-tree "loading" state was a bare `<div role="status"><p>...</p></div>`, missing the spinner and `aria-busy` that the shared helper provides — every other loading state in the app looked and behaved differently from this one.
- `editorPane.ts`'s file-tree "no files" empty state was a bare `<div><p>...</p></div>` instead of the shared icon/title/body empty-state structure.
- `logsPane.ts`'s log list conflated loading and empty into one untyped `emptyMessage` string reused for two different states (`'Loading recent entries…'` vs `'No desktop log entries yet.'`), rendered through one ad-hoc div.

## Issue acceptance gates

No tracked issue — this PR implements the findings from a scheduled UI-consistency scan (webview frontends and the CLI Ink TUI were also scanned and found already consistent; the desktop app was the only host with concrete deviations).

## Single source of truth

`logsPane.ts`'s `LogViewerState.status: 'loading' | 'ready'` now owns whether the pane is loading or has an empty result — replacing the previous untyped `emptyMessage` string that conflated both states into freeform text.

## Duplication and abstraction budget

Removed three ad-hoc loading/empty-state templates in favor of the existing shared `renderLoadingState()`/`renderEmptyState()` helpers — no new abstraction was added. Added one shared light-DOM CSS mirror of `commonViewStyles.ts`'s `.loading-state` rule (`packages/desktop/src/renderer/styles.css`), consistent with that file's documented convention of mirroring shadow-DOM shared styles for the light-DOM tree; it's now reused by both `editorPane.ts` and `logsPane.ts` rather than duplicated per-consumer.

## Net elements (R6)

3 files changed, 70 insertions(+), 24 deletions(-). No exported symbols added or removed (`git diff -- '*.ts' | grep -E '^[+-].*export'` is empty) — one new private helper function (`logListContent`) extracted in `logsPane.ts` to avoid a nested ternary, no new files.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed; this only changes internal rendering in two files with no external consumers of the changed internals (confirmed no references to `LogViewerState`/`emptyMessage` outside `logsPane.ts`).

## Host impact

Extension: none — unaffected.

Desktop: `editorPane.ts` (file-tree loading/empty states) and `logsPane.ts` (log list loading/empty states) now render via the shared helpers; three small CSS additions in `styles.css` support the new markup structure.

CLI: none — unaffected.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` (full workspace, including `typecheck:desktop`) — passes
- `npx eslint packages/desktop/src/renderer/editorPane.ts packages/desktop/src/renderer/logsPane.ts` — passes (fixed one `no-nested-ternary` violation by extracting `logListContent()`)
- `npx vitest run src/test-kernel/desktop/` — 59 files / 581 tests passing, including `DesktopLogsPane.vitest.ts`
- `npm run check:dead-code-ratchet` — no new dead code
- `npx prettier --write` on changed files — already formatted
- Not run: the Electron Playwright e2e suite (`test:e2e`), which needs a display/Electron runtime not available in this sandbox. The one e2e assertion that touches this code (`workspaceTabs.spec.ts`'s check that `.desktop-editor-tree-empty:has-text("No files found")` disappears once files load) is preserved: the empty-state title text and wrapper class are unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GonRXnb9gZLZ9y7Z8J77nX)_