### PR TITLE
fix(ui): pair terminal tokens and verify extension fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,15 @@ All notable changes to this project will be documented in this file.
   nested run no longer opens the parent row; expand it to inspect children.
   Selecting a child, or a pending approval on one, still reveals the ancestor
   path.
-- **The Progress terminal uses the editor terminal colors** — background and
-  text follow the dedicated terminal tokens instead of the generic surface
-  palette.
 - **Remote agent prompts are available to every signed-in account** — Settings
   → Agents no longer hides View prompt behind an Ultra plan, and remote agents
   no longer show a Remote badge or access-group labels.
+
+#### Bug Fixes
+
+- **The Progress terminal uses the host integrated terminal colors** —
+  background and text follow the dedicated terminal tokens instead of the
+  generic surface palette.
 
 #### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ All notable changes to this project will be documented in this file.
 - **Bold Greek letters render in the progress view** — shortcuts such as
   bold alpha, eta, and sigma now display as the intended symbols instead of
   unknown commands.
+- **The Progress terminal uses the host integrated terminal colors** —
+  background and text follow the dedicated terminal tokens instead of the
+  generic surface palette.
 
 #### Features
 
@@ -37,12 +40,6 @@ All notable changes to this project will be documented in this file.
 - **Remote agent prompts are available to every signed-in account** — Settings
   → Agents no longer hides View prompt behind an Ultra plan, and remote agents
   no longer show a Remote badge or access-group labels.
-
-#### Bug Fixes
-
-- **The Progress terminal uses the host integrated terminal colors** —
-  background and text follow the dedicated terminal tokens instead of the
-  generic surface palette.
 
 #### Improvements
 

--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -508,11 +508,15 @@
   --wa-color-testing-passed: var(--desktop-color-success);
   --wa-color-testing-failed: var(--desktop-color-error);
 
-  /* Terminal — full palette, no WA equivalent. */
+  /* Terminal — full palette, no WA equivalent. Foreground and cursor read
+     the canvas pair rather than the Field/FieldText input pair: high-contrast
+     themes map the two pairs to independently configurable system colors, so
+     an input-sourced foreground can be unreadable on the canvas background.
+     Light and dark resolve both pairs to the same values. */
   --wa-color-terminal-background: var(--desktop-color-background);
-  --wa-color-terminal-foreground: var(--desktop-color-input-foreground);
+  --wa-color-terminal-foreground: var(--desktop-color-foreground);
   --wa-color-terminal-selection-bg: var(--desktop-color-terminal-selection);
-  --wa-color-terminal-cursor: var(--desktop-color-input-foreground);
+  --wa-color-terminal-cursor: var(--desktop-color-foreground);
   --wa-color-terminal-ansi-black: light-dark(#24292f, #6e7681);
   --wa-color-terminal-ansi-blue: var(--desktop-color-accent);
   --wa-color-terminal-ansi-cyan: light-dark(#1b7c83, #4ec9b0);

--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -273,8 +273,15 @@
     var(--vscode-editorError-foreground)
   );
 
-  /* Terminal — full palette, no WA equivalent. */
-  --wa-color-terminal-background: var(--vscode-terminal-background);
+  /* Terminal — full palette, no WA equivalent. VS Code registers
+     terminal.background without a default, so themes that don't set it
+     inject no --vscode-terminal-background into the webview; the integrated
+     terminal itself falls back to the panel background in that case, so the
+     chain below mirrors the host instead of silently dropping the token. */
+  --wa-color-terminal-background: var(
+    --vscode-terminal-background,
+    var(--vscode-panel-background)
+  );
   --wa-color-terminal-foreground: var(--vscode-terminal-foreground);
   --wa-color-terminal-selection-bg: var(--vscode-terminal-selectionBackground);
   --wa-color-terminal-cursor: var(--vscode-terminalCursor-foreground);

--- a/src/shared/wa/xtermTheme.ts
+++ b/src/shared/wa/xtermTheme.ts
@@ -5,7 +5,10 @@
  *
  * Background and foreground prefer the dedicated terminal tokens so the
  * progress-view terminal matches the host integrated terminal. Surface and
- * text tokens remain fallbacks when a host omits the terminal pair.
+ * text tokens remain fallbacks when a host omits the terminal pair, but the
+ * fallback is loud: a token mapped to a variable the host never injects
+ * resolves to '', and silently keeping the surface palette would mask that
+ * broken mapping.
  */
 
 const XTERM_THEME_FALLBACKS = {
@@ -44,13 +47,31 @@ export function resolveXtermTheme(target: Element): ResolvedXtermTheme {
   const styles = getComputedStyle(target);
   const token = (name: string): string => styles.getPropertyValue(name).trim();
 
+  const terminalBackground = token('--wa-color-terminal-background');
+  const terminalForeground = token('--wa-color-terminal-foreground');
+  // Both hosts define the terminal pair, so an empty value means the mapping
+  // points at a variable the host never injected (e.g. a --vscode-terminal-*
+  // color absent from the webview). Name the missing tokens rather than let
+  // the surface-palette fallback silently mask the broken mapping.
+  const unresolved = [
+    [terminalBackground, '--wa-color-terminal-background'],
+    [terminalForeground, '--wa-color-terminal-foreground'],
+  ]
+    .filter(([value]) => !value)
+    .map(([, name]) => name);
+  if (unresolved.length > 0) {
+    console.warn(
+      `[xtermTheme] ${unresolved.join(', ')} did not resolve; falling back to the surface palette or built-in defaults.`,
+    );
+  }
+
   const theme: Record<string, string> = {
     background:
-      token('--wa-color-terminal-background') ||
+      terminalBackground ||
       token('--wa-color-surface-default') ||
       XTERM_THEME_FALLBACKS.background,
     foreground:
-      token('--wa-color-terminal-foreground') ||
+      terminalForeground ||
       token('--wa-color-text-normal') ||
       XTERM_THEME_FALLBACKS.foreground,
   };

--- a/src/test-kernel/desktop/DesktopThemeTokens.vitest.ts
+++ b/src/test-kernel/desktop/DesktopThemeTokens.vitest.ts
@@ -74,6 +74,24 @@ describe('desktop theme tokens', () => {
     );
   });
 
+  it('pairs the terminal foreground and cursor with the terminal background', () => {
+    // In the high-contrast themes the background/foreground palette entries
+    // resolve to the Canvas/CanvasText system pair while the input entries
+    // resolve to Field/FieldText, and users can configure those pairs
+    // independently — an input-sourced terminal foreground can be unreadable
+    // on the terminal background. Assert the indirection, not the color
+    // values, which are a design choice and free to change.
+    expect(tokenValue('--wa-color-terminal-background')).toBe(
+      `var(${paletteToken('background')})`,
+    );
+    expect(tokenValue('--wa-color-terminal-foreground')).toBe(
+      `var(${paletteToken('foreground')})`,
+    );
+    expect(tokenValue('--wa-color-terminal-cursor')).toBe(
+      `var(${paletteToken('foreground')})`,
+    );
+  });
+
   it('keeps light and dark palettes in one semantic token layer', () => {
     const css = readThemeTokens();
     const darkBlock = css.match(

--- a/src/test-kernel/shared/XtermTheme.vitest.ts
+++ b/src/test-kernel/shared/XtermTheme.vitest.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from 'vitest';
 
 import { resolveXtermTheme } from '@shared/wa/xtermTheme';
 
@@ -26,6 +34,16 @@ const ANSI_TOKENS = [
 ] as const;
 
 describe('resolveXtermTheme', () => {
+  let warn: MockInstance<typeof console.warn>;
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
   it('reads the full token map from the supplied target', () => {
     const target = document.createElement('div');
     target.style.setProperty('--wa-color-terminal-background', '#111111');
@@ -50,6 +68,7 @@ describe('resolveXtermTheme', () => {
     for (const [key, , value] of ANSI_TOKENS) {
       expect(theme[key]).toBe(value);
     }
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it('falls cursor back to text-normal, then to foreground', () => {
@@ -72,12 +91,35 @@ describe('resolveXtermTheme', () => {
     const themed = resolveXtermTheme(target).theme;
     expect(themed.background).toBe('#111111');
     expect(themed.foreground).toBe('#eeeeee');
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('--wa-color-terminal-background'),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('--wa-color-terminal-foreground'),
+    );
 
     target.style.removeProperty('--wa-color-surface-default');
     target.style.removeProperty('--wa-color-text-normal');
     const fallback = resolveXtermTheme(target).theme;
     expect(fallback.background).toBe('#1e1e1e');
     expect(fallback.foreground).toBe('#cccccc');
+  });
+
+  it('names each unresolved terminal token in a console warning', () => {
+    // A host that maps the terminal pair to variables it never injects
+    // resolves them to ''; the warning is what keeps that broken mapping
+    // visible instead of silently keeping the surface palette.
+    const target = document.createElement('div');
+    target.style.setProperty('--wa-color-terminal-background', '#111111');
+    document.body.append(target);
+
+    const { theme } = resolveXtermTheme(target);
+
+    expect(theme.background).toBe('#111111');
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = warn.mock.calls[0]?.[0];
+    expect(message).toContain('--wa-color-terminal-foreground');
+    expect(message).not.toContain('--wa-color-terminal-background');
   });
 
   it('uses hardcoded fallbacks when surface tokens are unset', () => {


### PR DESCRIPTION
Follow-up batch for #10319 (Progress terminal tokens).

- **#10320** — desktop high-contrast terminal foreground and cursor now read `--desktop-color-foreground` (CanvasText) instead of `--desktop-color-input-foreground` (FieldText), pairing them with the Canvas background. Light/dark values are unchanged; the indirection is pinned in `DesktopThemeTokens.vitest.ts`.
- **#10321** — the extension terminal background falls back to `--vscode-panel-background` when the host doesn't inject `--vscode-terminal-background`, mirroring the integrated terminal. `resolveXtermTheme` now logs a `console.warn` naming any unresolved terminal token before the surface/built-in fallback, so a broken mapping can't silently pass. `XtermTheme.vitest.ts` pins the loud fallback.
- **#10322** — the Progress terminal changelog entry moved under `#### Bug Fixes` and reworded to "host integrated terminal colors".

Closes #10320
Closes #10321
Closes #10322
