### PR TITLE
refactor(model-handlers): extract shared createResponseImpl scaffolding

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -8,7 +8,7 @@ import {
   ReasoningEffort,
 } from 'llm-zoo';
 // Local imports
-import type { AgentTrace } from '@agent/trace';
+import type { AgentTrace, StreamHandle } from '@agent/trace';
 import {
   attachChannelSubscriber,
   logContextManagementEvent,
@@ -430,6 +430,40 @@ export abstract class ModelHandler<
       deferStart: !options?.atPhaseSignal,
       phaseOnly: !this.outputStreaming,
     });
+  }
+
+  /**
+   * Success-path close of the thinking/output stream pair opened via
+   * {@link createThinkingStream}/{@link createOutputStream}: the thinking
+   * stream closes with the processed thinking block, then the output stream
+   * closes with the provider-extracted final text. Each provider keeps
+   * extracting that text itself (every response shape reads differently);
+   * what shares is the finalize ordering.
+   */
+  protected finalizeProgressStreams(
+    thinking: StreamHandle,
+    output: StreamHandle,
+    response: Resp,
+    finalText: string,
+  ): void {
+    const finalReasoning = this.processThinkingBlock(response);
+    thinking.finalize(finalReasoning ?? undefined);
+    output.finalize(finalText);
+  }
+
+  /**
+   * Error-path close of the thinking/output stream pair so the progress view
+   * does not hang in a loading state. No explicit final text, so chunks
+   * already streamed are preserved (passing `''` would overwrite the visible
+   * partial output). `finalize` is idempotent, so this is safe even after a
+   * partial finalize already ran.
+   */
+  protected finalizeProgressStreamsOnError(
+    thinking: StreamHandle | undefined,
+    output: StreamHandle | undefined,
+  ): void {
+    thinking?.finalize(undefined);
+    output?.finalize();
   }
 
   /**
@@ -871,6 +905,16 @@ export abstract class ModelHandler<
     sourceFingerprint: string;
     result: ClientCompactionResult<M>;
   };
+
+  /**
+   * Prompt-token total from the most recent API response, for handlers whose
+   * client-side compaction trigger keys off API-reported usage. Fed by
+   * {@link trackLastKnownInputTokens}; read by
+   * {@link maybeCompactByLastKnownInputTokens} and by the handlers'
+   * `compactConversation` as the `tokensBefore` figure. Handlers with
+   * server-side chain state key off the chain's cumulative count instead.
+   */
+  protected lastKnownInputTokens = 0;
 
   /** Cheap mutation detector for a messages array reused across attempts:
    *  follow-ups either push (length changes) or merge into the last message
@@ -1426,6 +1470,42 @@ export abstract class ModelHandler<
       };
     }
     return result;
+  }
+
+  /**
+   * COMPACT-phase prologue for handlers that compact client-side off the last
+   * API-reported prompt-token count: run the shared threshold trigger
+   * ({@link maybeCompactByInputTokens}) against {@link lastKnownInputTokens}
+   * and reshape the result into the {@link CreateResponseResult.updatedMessages}
+   * contract — `undefined` unless this call actually compacted. The provider
+   * supplies only its SDK-specific summarization call via {@link compact}.
+   */
+  protected async maybeCompactByLastKnownInputTokens(
+    messages: M[],
+    compact: () => Promise<ClientCompactionResult<M>>,
+  ): Promise<{ messagesToUse: M[]; updatedMessages: M[] | undefined }> {
+    const { compactedMessages, didCompact } =
+      await this.maybeCompactByInputTokens(
+        messages,
+        this.lastKnownInputTokens,
+        compact,
+      );
+    const updatedMessages = didCompact ? compactedMessages : undefined;
+    return { messagesToUse: updatedMessages ?? messages, updatedMessages };
+  }
+
+  /**
+   * TRACK-phase companion to {@link maybeCompactByLastKnownInputTokens}:
+   * record the prompt-token total from a completed response. Reports whether
+   * a total was present so the handler keeps its own missing-usage
+   * diagnostics.
+   */
+  protected trackLastKnownInputTokens(
+    promptTokens: number | null | undefined,
+  ): boolean {
+    if (!promptTokens) return false;
+    this.lastKnownInputTokens = promptTokens;
+    return true;
   }
 
   /**

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -2151,23 +2151,21 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
             : (completedInteraction?.steps ?? []),
       };
 
-      const finalReasoning = this.processThinkingBlock(response);
-      thinking.finalize(finalReasoning ?? undefined);
-
-      const finalText = this.extractResponse(response, endTag ?? '').text;
-      output.finalize(finalText);
+      this.finalizeProgressStreams(
+        thinking,
+        output,
+        response,
+        this.extractResponse(response, endTag ?? '').text,
+      );
       streamsFinalized = true;
 
       return { response };
     } finally {
       // Finalize the progress streams on a mid-stream failure so the progress
       // view does not hang in a loading state. Guarded so the success-path
-      // finalize above (with the real content) is not overwritten. No explicit
-      // final text so any chunks already streamed are preserved (passing `''`
-      // would overwrite the visible partial output).
+      // finalize above (with the real content) is not overwritten.
       if (!streamsFinalized) {
-        thinking.finalize(undefined);
-        output.finalize();
+        this.finalizeProgressStreamsOnError(thinking, output);
       }
     }
   }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -72,7 +72,6 @@ import {
 } from './openAIChatHelpers';
 import { toOpenAITools } from '../toolConversion';
 import { formatToolResultTextWithAttachments } from '../utils/toolAttachmentUtils';
-import { ModelHandler } from '../ModelHandler';
 import { OpenAICompatibleModelHandler } from './OpenAICompatibleModelHandler';
 import { ReasoningStreamAggregator } from './ReasoningStreamAggregator';
 import { CLIENT_COMPACTION_SUMMARY_MAX_TOKENS } from '../contextManagementConstants';
@@ -173,10 +172,6 @@ export class ModelHandlerOpenAI<
   ChatCompletion,
   ChatCompletionContentPart
 > {
-  // ── Client-side compaction state ──────────────────────────────────────
-  /** Tracks prompt_tokens from the last API response for compaction threshold checks. */
-  private lastKnownInputTokens = 0;
-
   protected useReasoningStreamAggregator: boolean = false;
 
   // ── Compaction interface overrides ────────────────────────────────────
@@ -364,18 +359,6 @@ export class ModelHandlerOpenAI<
     return baseParams;
   }
 
-  protected finalizeStreams(
-    thinking: ReturnType<ModelHandler['createThinkingStream']>,
-    output: ReturnType<ModelHandler['createOutputStream']>,
-    finalResponse: ChatCompletion,
-  ): void {
-    const finalReasoning = this.processThinkingBlock(finalResponse);
-    thinking.finalize(finalReasoning ?? undefined);
-
-    const finalOutput = finalResponse.choices?.[0]?.message?.content ?? '';
-    output.finalize(finalOutput);
-  }
-
   protected async executeStreamingChat(
     client: OpenAI,
     baseParams: ChatCompletionRequestBase,
@@ -445,20 +428,17 @@ export class ModelHandlerOpenAI<
         }
       }
 
-      this.finalizeStreams(thinking, output, finalResponse);
+      this.finalizeProgressStreams(
+        thinking,
+        output,
+        finalResponse,
+        finalResponse.choices?.[0]?.message?.content ?? '',
+      );
       return finalResponse;
     } catch (streamError) {
       return handleStreamingFailure(streamError, {
-        // Finalize the progress streams on error so the progress view does
-        // not hang in a loading state (parity with the OpenRouter streaming
-        // path). No explicit final text so any chunks already streamed are
-        // preserved (passing `''` would overwrite the visible partial
-        // output). `finalize` is idempotent, so this is safe even if a
-        // partial finalize already ran.
-        finalizeOnError: () => {
-          thinking.finalize(undefined);
-          output.finalize();
-        },
+        finalizeOnError: () =>
+          this.finalizeProgressStreamsOnError(thinking, output),
         // On mid-stream failure, lift the partial content the SDK already
         // accumulated (currentChatCompletionSnapshot) onto the error so the
         // retry UI can show it and future continuation logic can reference
@@ -605,14 +585,10 @@ export class ModelHandlerOpenAI<
     } = options;
 
     // Phase 0: COMPACT - Apply the shared trigger before building the request.
-    const { compactedMessages, didCompact } =
-      await this.maybeCompactByInputTokens(
-        rawMessages,
-        this.lastKnownInputTokens,
-        () => this.compactConversation(client, rawMessages, signal),
+    const { messagesToUse, updatedMessages } =
+      await this.maybeCompactByLastKnownInputTokens(rawMessages, () =>
+        this.compactConversation(client, rawMessages, signal),
       );
-    const updatedMessages = didCompact ? compactedMessages : undefined;
-    const messagesToUse = updatedMessages ?? rawMessages;
 
     // Apply message normalization if subclass specifies options
     const messages = this.prepareNormalizedMessages(messagesToUse);
@@ -656,9 +632,7 @@ export class ModelHandlerOpenAI<
       : await this.executeNonStreamingChat(client, baseParams, signal);
 
     // Phase 5: TRACK - Record prompt_tokens for compaction threshold checks
-    if (response.usage?.prompt_tokens) {
-      this.lastKnownInputTokens = response.usage.prompt_tokens;
-    }
+    this.trackLastKnownInputTokens(response.usage?.prompt_tokens);
 
     return { response, updatedMessages };
   }

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -102,9 +102,6 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   ChatResult,
   ChatContentItems
 > {
-  // ── Client-side compaction state ──────────────────────────────────────
-  private lastKnownInputTokens = 0;
-
   /** Client-side compaction is implemented for tool-use sessions regardless of the routed-through provider. */
   override get supportsManualCompaction(): boolean {
     return this.isToolUseMode();
@@ -197,14 +194,10 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     } = options;
 
     // Phase 0: COMPACT - Apply the shared trigger before building the request.
-    const { compactedMessages, didCompact } =
-      await this.maybeCompactByInputTokens(
-        rawMessages,
-        this.lastKnownInputTokens,
-        () => this.compactConversation(client, rawMessages, signal),
+    const { messagesToUse, updatedMessages } =
+      await this.maybeCompactByLastKnownInputTokens(rawMessages, () =>
+        this.compactConversation(client, rawMessages, signal),
       );
-    const updatedMessages = didCompact ? compactedMessages : undefined;
-    const messagesToUse = updatedMessages ?? rawMessages;
 
     const useStreaming = this.getStreamingConfig();
 
@@ -279,23 +272,20 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         }
 
         const response = aggregator.buildResponse();
-        const finalReasoning = this.processThinkingBlock(response);
-        thinking.finalize(finalReasoning ?? undefined);
         const finalOutput = response.choices?.[0]?.message?.content ?? '';
-        output.finalize(typeof finalOutput === 'string' ? finalOutput : '');
+        this.finalizeProgressStreams(
+          thinking,
+          output,
+          response,
+          typeof finalOutput === 'string' ? finalOutput : '',
+        );
 
         this.trackInputTokens(response.usage, 'streaming response');
         return { response, updatedMessages };
       } catch (err) {
         return handleStreamingFailure(err, {
-          // Ensure progress streams are finalized on error to prevent the
-          // progress view from being stuck in a loading state. No explicit
-          // final text so any chunks already streamed are preserved (passing
-          // `''` would overwrite the visible partial output).
-          finalizeOnError: () => {
-            thinking?.finalize(undefined);
-            output?.finalize();
-          },
+          finalizeOnError: () =>
+            this.finalizeProgressStreamsOnError(thinking, output),
           // Lift the accumulated partial text onto the error so the retry UI
           // can show the tail (parity with the other streaming providers).
           partialTail: () =>
@@ -328,10 +318,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     usage: ChatUsage | undefined,
     responseLabel: string,
   ): void {
-    if (usage?.promptTokens) {
-      this.lastKnownInputTokens = usage.promptTokens;
-      return;
-    }
+    if (this.trackLastKnownInputTokens(usage?.promptTokens)) return;
     this.logger.warn(
       `No usage data in ${responseLabel}: token tracking and compaction may be affected`,
     );


### PR DESCRIPTION
Closes #10199

Extracts the two pieces of scaffolding that were genuinely repeated across `createResponseImpl` overrides into protected base hooks, and wires the applicable overrides through them. Behavior-preserving; no public API changes.

## Moved to `ModelHandler`
- `finalizeProgressStreams` / `finalizeProgressStreamsOnError`: the success/error close ordering for a thinking/output stream pair, including the shared `processThinkingBlock` call and the no-overwrite error finalization.
- `lastKnownInputTokens` plus `maybeCompactByLastKnownInputTokens` / `trackLastKnownInputTokens`: client-side compaction trigger state and its COMPACT/TRACK phase prologue, shared by handlers that key compaction off API-reported prompt tokens.

## Overrides updated
- `modelHandlerGoogleInteractions`: streaming success/error stream finalization now uses the base pair helpers.
- `modelHandlerOpenAI`: streaming finalization now uses the base pair helpers; COMPACT/TRACK phases now use the base token-tracked helpers.
- `modelHandlerOpenRouterNative`: same streaming finalization and COMPACT/TRACK extraction.

## Deliberately left in place
- `modelHandlerOpenAIResponse` uses `ResponseStreamProcessor`, which finalizes phase-aware streams (web-search/tool boundaries) and already encapsulates this behavior.
- `modelHandlerAnthropic` uses `AnthropicStreamHandler` for its event-state machine and already has equivalent finalization there.
- `modelHandlerVscodeLm` has a single output stream (no thinking stream), so the pair-oriented finalization helper does not apply; its one-line finalize remains provider-specific.

## Validation
- `npm run typecheck` (all six targets)
- `npm run lint` (full repo; run with a larger local Node heap because the stock `--max-old-space-size=6144` invocation OOMs when all packages are linted in one process)
- `npx vitest run src/test-kernel/agent/modelHandlers/` — 61 files passed, 736 tests passed, 4 skipped
- `npm run compile:fast`