### PR TITLE
fix(model): structural Request guard and xAI long-context tiered pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file.
 - **A missing helper model falls back to DeepSeek V4 Flash** — disabling or
   removing the helper no longer silently switches auxiliary tasks to the
   first picker model.
+- **Long Grok prompts report their true cost** — xAI raises per-token rates
+  once a prompt crosses the model's long-context threshold; usage costs for
+  those requests no longer underreport.
 
 ### Extension (VS Code) and Desktop
 

--- a/docs/prds/2026-08-04-prd-xai-responses-previous-response-id.md
+++ b/docs/prds/2026-08-04-prd-xai-responses-previous-response-id.md
@@ -295,8 +295,10 @@ catalog changes made — recon only**, per the §2 non-goals.
 
 Candidate next steps, smallest first: (a) ~~refresh §3 for `grok-4.6` and track
 upstream catalogue support for the remaining model IDs~~ (done 2026-08-14;
-remaining IDs still wait on llm-zoo), (b) model long-context
-tiered pricing in `computeStandardPrice` once a rate source exists, (c) ~~revisit
+remaining IDs still wait on llm-zoo), (b) ~~model long-context
+tiered pricing in `computeStandardPrice` once a rate source exists~~ (done
+2026-08-14: tier tuples wired from xAI's documented per-model rates; llm-zoo
+still has no tier field), (c) ~~revisit
 this PRD's default-off timeline given Chat Completions' now-explicit deprecated
 status~~ (done 2026-08-14: one release behind the flag; see §4 decision 3 and
 §11 Q1).

--- a/src/agent/modelHandlers/openai/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerXAI.ts
@@ -16,6 +16,7 @@ import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { logOpenAICompatibleClientConfig } from './openAIChatHelpers';
+import { xaiLongContextTier } from './xaiLongContextPricing';
 import type { ChatCompletion } from 'openai/resources/chat/completions';
 
 /**
@@ -90,7 +91,12 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
         outputPrice: 0,
       };
     }
-    return super.standardPricingConfig();
+    // API-key usage bills per token, with xAI's long-context tier past the
+    // model's documented prompt-token threshold.
+    return {
+      ...super.standardPricingConfig(),
+      longContextTier: xaiLongContextTier(this.config.fullName),
+    };
   }
 
   /**

--- a/src/agent/modelHandlers/openai/xaiLongContextPricing.ts
+++ b/src/agent/modelHandlers/openai/xaiLongContextPricing.ts
@@ -1,0 +1,33 @@
+/**
+ * xAI long-context pricing tiers, keyed by llm-zoo `fullName`.
+ *
+ * Source: the models catalog embedded in docs.x.ai (per-model
+ * `longContextThreshold` plus the `*LongContext` prompt/completion rates),
+ * verified 2026-08-14. llm-zoo carries only the short-context rates and has
+ * no tier field, so the tier tuple lives here until a catalog exposes one.
+ * Rates are USD per 1M tokens. xAI's cached long-context rate equals the
+ * tier's input rate scaled by the model's usual cache discount factor for
+ * every listed model, so the tier carries only the input/output tuple; the
+ * rebate in `computeStandardPrice` follows the tier switch on its own.
+ */
+
+import type { LongContextPricingTier } from '@agent/utils/priceUtils';
+
+const XAI_LONG_CONTEXT_TIERS: Readonly<Record<string, LongContextPricingTier>> =
+  {
+    'grok-4.3': { thresholdTokens: 200_000, inputPrice: 2.5, outputPrice: 5 },
+    'grok-4.5': { thresholdTokens: 200_000, inputPrice: 4, outputPrice: 12 },
+    'grok-4.6': { thresholdTokens: 200_000, inputPrice: 4, outputPrice: 12 },
+  };
+
+/**
+ * The documented long-context tier for an xAI model id, or undefined when xAI
+ * publishes none (including OpenRouter-qualified ids, which bill on
+ * OpenRouter's rates instead).
+ */
+export function xaiLongContextTier(
+  fullName: string,
+): LongContextPricingTier | undefined {
+  const tier = XAI_LONG_CONTEXT_TIERS[fullName];
+  return tier ? { ...tier } : undefined;
+}

--- a/src/agent/utils/priceUtils.ts
+++ b/src/agent/utils/priceUtils.ts
@@ -18,6 +18,21 @@ export interface StandardPricingConfig {
   inputPrice: number;
   outputPrice: number;
   cacheDiscountFactor: number;
+  /**
+   * Long-context billing tier (xAI). Once a request's total prompt tokens —
+   * cached included — exceed the model's threshold, the provider bills every
+   * token of that request at the tier's rates, output tokens included, so the
+   * complete tuple switches, not just the input rate.
+   */
+  longContextTier?: LongContextPricingTier;
+}
+
+/** Rates that apply to the whole request past `thresholdTokens` prompt tokens. */
+export interface LongContextPricingTier {
+  /** Total prompt tokens above which the tier applies (exclusive boundary). */
+  thresholdTokens: number;
+  inputPrice: number;
+  outputPrice: number;
 }
 
 export interface StandardPriceTokens {
@@ -43,14 +58,25 @@ export function computeStandardPrice(
   const reasoningTokens = tokens.reasoningTokens ?? 0;
   const cachedTokens = tokens.cachedTokens ?? 0;
 
+  // `inputTokens` is the total prompt (cached included) — the quantity xAI's
+  // long-context threshold compares against. The cache rebate follows the
+  // tier: providers scale the cached rate by the same discount factor.
+  const tier =
+    config.longContextTier &&
+    tokens.inputTokens > config.longContextTier.thresholdTokens
+      ? config.longContextTier
+      : undefined;
+  const inputPrice = tier?.inputPrice ?? config.inputPrice;
+  const outputPrice = tier?.outputPrice ?? config.outputPrice;
+
   return (
     calculateTokenPrice(
       tokens.inputTokens,
       tokens.outputTokens,
-      config.inputPrice,
-      config.outputPrice,
+      inputPrice,
+      outputPrice,
     ) +
-    (reasoningTokens * config.outputPrice) / 1e6 -
-    (cachedTokens * config.inputPrice * (1 - config.cacheDiscountFactor)) / 1e6
+    (reasoningTokens * outputPrice) / 1e6 -
+    (cachedTokens * inputPrice * (1 - config.cacheDiscountFactor)) / 1e6
   );
 }

--- a/src/platform/defaults/longRunningModelTransport.ts
+++ b/src/platform/defaults/longRunningModelTransport.ts
@@ -25,6 +25,34 @@ function isReadableStreamBody(body: unknown): boolean {
   );
 }
 
+/**
+ * Detect a WHATWG Request without `instanceof`, which a Request constructed
+ * in another realm (the worker-thread scenario above) fails. Probing `url`
+ * plus `arrayBuffer` also excludes the `string` and `URL` inputs.
+ */
+function isRequestLike(input: RequestInfo | URL): input is Request {
+  return (
+    typeof input === 'object' &&
+    input !== null &&
+    typeof (input as { url?: unknown }).url === 'string' &&
+    typeof (input as { arrayBuffer?: unknown }).arrayBuffer === 'function'
+  );
+}
+
+/** Headers from any realm flatten through their own `entries` iterator. */
+function flattenHeaders(
+  headers: UndiciRequestInit['headers'] | Headers,
+): UndiciRequestInit['headers'] {
+  if (
+    typeof headers === 'object' &&
+    headers !== null &&
+    typeof (headers as { entries?: unknown }).entries === 'function'
+  ) {
+    return Object.fromEntries((headers as Headers).entries());
+  }
+  return headers as UndiciRequestInit['headers'];
+}
+
 async function normalizeModelRequest(
   input: RequestInfo | URL,
   init?: RequestInit,
@@ -36,40 +64,43 @@ async function normalizeModelRequest(
   if (isReadableStreamBody(requestInit.body) && requestInit.duplex == null) {
     requestInit.duplex = 'half';
   }
-  if (!(input instanceof Request)) {
-    if (init?.body instanceof FormData) {
-      // OpenAI builds multipart bodies with the host-global FormData, while
-      // package Undici recognizes only its own FormData implementation.
-      const body = new UndiciFormData();
-      for (const [name, value] of init.body.entries()) {
-        if (typeof value === 'string') {
-          body.append(name, value);
-        } else {
-          body.append(name, value, value.name);
-        }
+  const initBody = init?.body;
+  if (initBody instanceof FormData) {
+    // OpenAI builds multipart bodies with the host-global FormData, while
+    // package Undici recognizes only its own FormData implementation.
+    const body = new UndiciFormData();
+    for (const [name, value] of initBody.entries()) {
+      if (typeof value === 'string') {
+        body.append(name, value);
+      } else {
+        body.append(name, value, value.name);
       }
-      return [
-        input as UndiciRequestInfo,
-        {
-          ...requestInit,
-          body,
-        },
-      ];
     }
+    requestInit.body = body;
+  }
+  if (!isRequestLike(input)) {
     return [input as UndiciRequestInfo, requestInit];
   }
 
   // OpenRouter supplies Node's native Request, while package Undici expects
-  // its own branded Request. Rebuild it from interoperable primitives here.
-  const request = new Request(input, requestInit as RequestInit);
-  const body = request.body === null ? undefined : await request.arrayBuffer();
+  // its own branded Request. Rebuild it from interoperable primitives here —
+  // property reads plus the input's own `arrayBuffer`, never
+  // `new Request(input, ...)`: that constructor brand-checks its argument and
+  // would reject a cross-realm Request the same way `instanceof` did.
+  const headers = requestInit.headers ?? input.headers;
+  let body: UndiciRequestInit['body'];
+  if (requestInit.body !== undefined) {
+    body = requestInit.body ?? undefined;
+  } else if (input.body !== null) {
+    body = await input.arrayBuffer();
+  }
   return [
-    request.url,
+    input.url,
     {
-      method: request.method,
-      headers: Object.fromEntries(request.headers.entries()),
-      redirect: request.redirect,
-      signal: request.signal,
+      method: requestInit.method ?? input.method,
+      headers: flattenHeaders(headers),
+      redirect: requestInit.redirect ?? input.redirect,
+      signal: requestInit.signal ?? input.signal,
       ...(body === undefined ? {} : { body }),
     },
   ];

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -219,4 +219,85 @@ describe('long-running model transport', () => {
     expect(init?.duplex).toBe('half');
     expect(body instanceof ReadableStream).toBe(false);
   });
+
+  // A Request built in a worker thread fails `instanceof Request`; these
+  // duck-typed stand-ins share no brand with the global and so exercise the
+  // same structural path (#10298's stream scenario, one check up).
+  function foreignRequest(overrides: Record<string, unknown>): Request {
+    return {
+      url: 'https://openrouter.example/v1/chat',
+      method: 'POST',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      redirect: 'follow',
+      signal: new AbortController().signal,
+      body: null,
+      arrayBuffer: vi.fn(),
+      ...overrides,
+    } as unknown as Request;
+  }
+
+  it('rebuilds a cross-realm Request from primitives instead of forwarding it', async () => {
+    stubComposedDispatcher();
+    transportMocks.undiciFetch.mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+    const request = foreignRequest({});
+    expect(request instanceof Request).toBe(false);
+
+    await expect(longRunningModelFetch(request)).resolves.toBeInstanceOf(
+      Response,
+    );
+
+    const [input, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
+    expect(input).toBe('https://openrouter.example/v1/chat');
+    expect(init).toMatchObject({
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      redirect: 'follow',
+    });
+    expect(init?.body).toBeUndefined();
+    expect(request.arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it('reads a cross-realm Request body through its own arrayBuffer', async () => {
+    stubComposedDispatcher();
+    transportMocks.undiciFetch.mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+    const bytes = new TextEncoder().encode('{"prompt":"hello"}').buffer;
+    const request = foreignRequest({
+      // The foreign stream itself cannot cross realms; its bytes can.
+      body: { pipeTo: async () => undefined },
+      arrayBuffer: vi.fn().mockResolvedValue(bytes),
+    });
+
+    await longRunningModelFetch(request);
+
+    const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
+    expect(request.arrayBuffer).toHaveBeenCalledOnce();
+    expect(init?.body).toBe(bytes);
+    expect(init?.duplex).toBeUndefined();
+  });
+
+  it('lets init fields win over a cross-realm Request', async () => {
+    stubComposedDispatcher();
+    transportMocks.undiciFetch.mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+    const request = foreignRequest({ method: 'GET' });
+
+    await longRunningModelFetch(request, {
+      method: 'PUT',
+      headers: new Headers({ 'x-override': 'yes' }),
+      body: '{"prompt":"override"}',
+    });
+
+    const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
+    expect(init).toMatchObject({
+      method: 'PUT',
+      headers: { 'x-override': 'yes' },
+      body: '{"prompt":"override"}',
+    });
+    expect(request.arrayBuffer).not.toHaveBeenCalled();
+  });
 });

--- a/src/test-kernel/agent/modelHandlers/XaiLongContextPricing.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/XaiLongContextPricing.vitest.ts
@@ -1,0 +1,87 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+import { ModelProvider } from 'llm-zoo';
+
+// Local imports
+import { ModelHandlerXAI } from '@agent/modelHandlers/openai/modelHandlerXAI';
+import { xaiLongContextTier } from '@agent/modelHandlers/openai/xaiLongContextPricing';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
+
+function createXaiHandler(fullName: string): ModelHandlerXAI {
+  return new ModelHandlerXAI(
+    buildTestModelConfig({
+      provider: ModelProvider.XAI,
+      name: fullName,
+      fullName,
+      shortName: fullName,
+      inputPrice: 2,
+      outputPrice: 6,
+      capabilities: { cacheDiscountFactor: 0.25 },
+    }),
+  );
+}
+
+describe('xaiLongContextTier', () => {
+  it('carries the documented tier tuple for each current xAI model', () => {
+    expect(xaiLongContextTier('grok-4.6')).toStrictEqual({
+      thresholdTokens: 200_000,
+      inputPrice: 4,
+      outputPrice: 12,
+    });
+    expect(xaiLongContextTier('grok-4.5')).toStrictEqual({
+      thresholdTokens: 200_000,
+      inputPrice: 4,
+      outputPrice: 12,
+    });
+    expect(xaiLongContextTier('grok-4.3')).toStrictEqual({
+      thresholdTokens: 200_000,
+      inputPrice: 2.5,
+      outputPrice: 5,
+    });
+  });
+
+  it('has no tier for undocumented or OpenRouter-qualified ids', () => {
+    expect(xaiLongContextTier('grok-4-0709')).toBeUndefined();
+    expect(xaiLongContextTier('x-ai/grok-4.6')).toBeUndefined();
+    expect(xaiLongContextTier('gpt-5.5')).toBeUndefined();
+  });
+
+  it('returns a fresh tier object per call', () => {
+    expect(xaiLongContextTier('grok-4.6')).not.toBe(
+      xaiLongContextTier('grok-4.6'),
+    );
+  });
+});
+
+describe('ModelHandlerXAI long-context pricing', () => {
+  it('bills flat rates at the threshold and tier rates past it', () => {
+    const handler = createXaiHandler('grok-4.6');
+
+    expect(
+      handler.computePrice({
+        prompt_tokens: 200_000,
+        completion_tokens: 1_000,
+        total_tokens: 201_000,
+      }),
+    ).toBeCloseTo((200_000 * 2 + 1_000 * 6) / 1e6, 12);
+    expect(
+      handler.computePrice({
+        prompt_tokens: 200_001,
+        completion_tokens: 1_000,
+        total_tokens: 201_001,
+      }),
+    ).toBeCloseTo((200_001 * 4 + 1_000 * 12) / 1e6, 12);
+  });
+
+  it('keeps flat rates for xAI models without a documented tier', () => {
+    const handler = createXaiHandler('grok-4-0709');
+
+    expect(
+      handler.computePrice({
+        prompt_tokens: 500_000,
+        completion_tokens: 1_000,
+        total_tokens: 501_000,
+      }),
+    ).toBeCloseTo((500_000 * 2 + 1_000 * 6) / 1e6, 12);
+  });
+});

--- a/src/test-kernel/agent/utils/priceUtils.vitest.ts
+++ b/src/test-kernel/agent/utils/priceUtils.vitest.ts
@@ -1,0 +1,74 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - agent utils
+import {
+  computeStandardPrice,
+  type StandardPricingConfig,
+} from '@agent/utils/priceUtils';
+
+// grok-4.6's documented rates: $2/$6 flat, doubling to $4/$12 past 200k
+// prompt tokens, with cached tokens at 25% of the input rate in both tiers.
+const TIERED_CONFIG: StandardPricingConfig = {
+  inputPrice: 2,
+  outputPrice: 6,
+  cacheDiscountFactor: 0.25,
+  longContextTier: { thresholdTokens: 200_000, inputPrice: 4, outputPrice: 12 },
+};
+
+describe('computeStandardPrice long-context tier', () => {
+  it('bills the flat rates when the prompt ends exactly at the threshold', () => {
+    const price = computeStandardPrice(
+      {
+        inputTokens: 200_000,
+        outputTokens: 1_000,
+        cachedTokens: 50_000,
+        reasoningTokens: 500,
+      },
+      TIERED_CONFIG,
+    );
+
+    expect(price).toBeCloseTo(
+      (200_000 * 2 + 1_000 * 6 + 500 * 6 - 50_000 * 2 * 0.75) / 1e6,
+      12,
+    );
+  });
+
+  it('switches the complete pricing tuple once the prompt crosses the threshold', () => {
+    const price = computeStandardPrice(
+      {
+        inputTokens: 200_001,
+        outputTokens: 1_000,
+        cachedTokens: 50_000,
+        reasoningTokens: 500,
+      },
+      TIERED_CONFIG,
+    );
+
+    // Every prompt token rebills at $4 (not just the excess), output and
+    // reasoning rise to $12, and the cache rebate follows the tier's rate.
+    expect(price).toBeCloseTo(
+      (200_001 * 4 + 1_000 * 12 + 500 * 12 - 50_000 * 4 * 0.75) / 1e6,
+      12,
+    );
+  });
+
+  it('counts cached tokens toward the threshold', () => {
+    // 150k uncached + 60k cached = 210k total prompt tokens.
+    const price = computeStandardPrice(
+      { inputTokens: 210_000, outputTokens: 0, cachedTokens: 60_000 },
+      TIERED_CONFIG,
+    );
+
+    expect(price).toBeCloseTo((210_000 * 4 - 60_000 * 4 * 0.75) / 1e6, 12);
+  });
+
+  it('keeps flat rates for a config without a tier, however long the prompt', () => {
+    const price = computeStandardPrice(
+      { inputTokens: 500_000, outputTokens: 1_000 },
+      { inputPrice: 2, outputPrice: 6, cacheDiscountFactor: 0.25 },
+    );
+
+    expect(price).toBeCloseTo((500_000 * 2 + 1_000 * 6) / 1e6, 12);
+  });
+});


### PR DESCRIPTION
## #10311 — cross-realm Request brand check

- `normalizeModelRequest` now detects Requests structurally (`url` + own `arrayBuffer`) instead of `instanceof Request`, so a Request built in a worker thread is recognized and rebuilt from interoperable primitives rather than forwarded to package undici.
- Headers are flattened through the input's own `entries` iterator, and `new Request(input, ...)` is no longer used because it brand-checks its argument just like `instanceof`.
- Added duck-typed Request tests covering rebuild, body read through `arrayBuffer`, and `init` overrides.

## #10073 — xAI long-context tiered pricing

- `StandardPricingConfig` now carries an optional `longContextTier`; `computeStandardPrice` switches the complete input/output tuple when total prompt tokens (cached included) cross the threshold, including the output and reasoning rates and the cache rebate.
- `ModelHandlerXAI` wires per-model tier tuples for `grok-4.3`, `grok-4.5`, and `grok-4.6` from xAI's documented rates; other xAI ids and OpenRouter-qualified ids stay on flat pricing.
- Added unit coverage for the tier boundary, cached-token threshold accounting, and no-tier fallback.

Closes #10311
Closes #10073