### PR TITLE
fix(storage): validate KVStoreCache max against silent no-cache mode

### DIFF
--- a/src/common/storage/KVStoreCache.ts
+++ b/src/common/storage/KVStoreCache.ts
@@ -37,6 +37,14 @@ export class KVStoreCache<
     private readonly create: (id: TId) => TStore,
     { max }: { max?: number } = {},
   ) {
+    if (max !== undefined && (!Number.isInteger(max) || max < 1)) {
+      // `max: 0` would construct a zero-capacity LRUCache whose every get()
+      // recreates and immediately discards the handle — a silent no-cache
+      // mode. Fail loudly instead of degrading silently.
+      throw new RangeError(
+        `KVStoreCache max must be a positive integer (got ${max}); omit it for an unbounded cache`,
+      );
+    }
     this.handles = max === undefined ? new Map() : new LRUCache({ max });
   }
 

--- a/src/test-kernel/common/KVStoreCache.vitest.ts
+++ b/src/test-kernel/common/KVStoreCache.vitest.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { KVStoreCache } from '@common/storage/KVStoreCache';
+import { KVStore } from '@common/storage/KVStore';
+
+describe('KVStoreCache max validation', () => {
+  const create = () => new KVStore('/tmp/unused');
+
+  it.each([0, -1, 1.5, Number.NaN])('throws RangeError for max=%s', (max) => {
+    expect(() => new KVStoreCache(create, { max })).toThrow(RangeError);
+  });
+
+  it('accepts an unset max as unbounded', () => {
+    const cache = new KVStoreCache(create);
+    expect(cache.get('a')).toBe(cache.get('a'));
+  });
+
+  it('accepts a positive integer max', () => {
+    const cache = new KVStoreCache(create, { max: 2 });
+    expect(cache.get('a')).toBe(cache.get('a'));
+  });
+});


### PR DESCRIPTION
`max: 0` built a zero-capacity LRUCache whose every `get()` recreated and discarded the handle. The constructor now throws a RangeError for non-positive or non-integer `max`; unset stays unbounded (plain Map). New suite pins the contract.

Closes #10345