### PR TITLE
fix(desktop): clean up diff temp dirs and initialize the follow-up polish prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,17 @@ All notable changes to this project will be documented in this file.
   the clipboard as plain text, to paste into whichever chat you want. Running
   latexFixer on a compile failure is unchanged.
 
+### Desktop
+
+#### Bug Fixes
+
+- **Follow-up polish revises text again** — the desktop polish action no longer
+  silently returns the original draft; it now applies the same bundled prompt
+  template the extension uses.
+- **Temporary diff files are cleaned up** — viewing a diff in an external
+  editor no longer leaves `texra-desktop-diff` folders behind after the window
+  closes.
+
 ### CLI and Desktop
 
 #### Bug Fixes

--- a/packages/cli/scripts/copy-resources.mjs
+++ b/packages/cli/scripts/copy-resources.mjs
@@ -20,7 +20,6 @@ const runtimeResourceEntries = [
   'templates/agentCreatorWorkflow.yaml',
   'templates/agentTemplate-toolUse.yaml',
   'templates/agentTemplate-workflowSingle.yaml',
-  'templates/instructionPolish.yaml',
   'tool_use_agents',
 ];
 

--- a/packages/desktop/src/main/desktopDiffHost.ts
+++ b/packages/desktop/src/main/desktopDiffHost.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { nanoid } from 'nanoid';
@@ -35,7 +35,13 @@ export interface DesktopDiffHostOptions extends DesktopOverlayPostOptions {
 
 export function createDesktopDiffHost(
   options: DesktopDiffHostOptions,
-): Pick<DiffViewHost, 'openDiff'> {
+): Pick<DiffViewHost, 'openDiff'> & { dispose(): Promise<void> } {
+  // External-editor patch files live under a fresh temp directory per diff.
+  // That directory cannot be removed as soon as `openPath` settles because the
+  // OS editor may still be reading it, so each fallback run records its
+  // directory here and `dispose()` removes them when the window closes.
+  const externalPatchDirs = new Set<string>();
+
   async function openDiff(
     original: DiffSource,
     proposed: DiffSource,
@@ -73,13 +79,32 @@ export function createDesktopDiffHost(
       computeUserPatch(originalContent, proposedContent) ??
       `No textual changes for ${path.basename(proposed.filePath)}.\n`;
     const tempDir = await createTexraTempDir('texra-desktop-diff-');
+    externalPatchDirs.add(tempDir);
     const diffPath = path.join(tempDir, `${nanoid()}.diff`);
 
-    await writeFile(diffPath, patch, 'utf8');
-    await options.openPath(diffPath);
+    try {
+      await writeFile(diffPath, patch, 'utf8');
+      await options.openPath(diffPath);
+    } catch (error) {
+      // The patch never reached an editor: clean it up now instead of waiting
+      // for window close, and preserve the original failure for the caller.
+      externalPatchDirs.delete(tempDir);
+      await rm(tempDir, { recursive: true, force: true }).catch(
+        () => undefined,
+      );
+      throw error;
+    }
 
     return { original, proposed, title };
   }
 
-  return { openDiff };
+  async function dispose(): Promise<void> {
+    const tempDirs = [...externalPatchDirs];
+    externalPatchDirs.clear();
+    await Promise.all(
+      tempDirs.map((tempDir) => rm(tempDir, { recursive: true, force: true })),
+    );
+  }
+
+  return { openDiff, dispose };
 }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -521,22 +521,23 @@ function createWindow(options: {
     window.close();
   };
   attachRendererConsoleLog(window.webContents);
+  const desktopDiffHost = createDesktopDiffHost({
+    openPath: previewHost.openPath,
+    // Prefer the in-app overlay (<texra-diff-view> inside a wa-dialog).
+    // Returning `false` when the IPC bridge is not yet wired (startup race)
+    // or the BrowserWindow has been destroyed falls the host back to the
+    // external-editor flow, so diffs never silently disappear.
+    postToRenderer: (message) => {
+      const ipc = ipcRef.current;
+      if (!ipc || window.isDestroyed()) return false;
+      ipc.postToRenderer(message);
+      return true;
+    },
+  });
   const agentExecutionHost: DesktopAgentExecutionHost = {
     openPath: previewHost.openPath,
     openBuildDisplay: previewHost.openBuildDisplay,
-    openDiff: createDesktopDiffHost({
-      openPath: previewHost.openPath,
-      // Prefer the in-app overlay (<texra-diff-view> inside a wa-dialog).
-      // Returning `false` when the IPC bridge is not yet wired (startup race)
-      // or the BrowserWindow has been destroyed falls the host back to the
-      // external-editor flow, so diffs never silently disappear.
-      postToRenderer: (message) => {
-        const ipc = ipcRef.current;
-        if (!ipc || window.isDestroyed()) return false;
-        ipc.postToRenderer(message);
-        return true;
-      },
-    }).openDiff,
+    openDiff: desktopDiffHost.openDiff,
     confirmAcceptFile: (message) =>
       confirmDialog({ message, confirmLabel: 'Replace file' }),
     chooseTeamAvailability,
@@ -1091,6 +1092,7 @@ function createWindow(options: {
     continueQuitAfterWindowClose = undefined;
     disposeWindowTitle();
     presentationAbort.abort();
+    void desktopDiffHost.dispose().catch(reportAsyncError);
     executionsWatcher?.close();
     if (mainWindow === window) {
       mainWindow = null;

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -1,6 +1,7 @@
 import { access, constants } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { app } from 'electron';
+import { initializePolishModel } from '@agent/runtime';
 import { createPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
 import { isFileNotFoundError } from '@common/errors';
 import { installTexraModelAccess } from '@controllers/modelAccess/installTexraModelAccess';
@@ -163,6 +164,11 @@ export async function initializeElectronPlatform(
   // and the direct Lean language services (lake env lean --server).
   initNodeAgentRuntime(lifecycle);
   initializeNodeGoalPrompts(resourcesPath);
+  // Follow-up polish uses the same bundled template as the extension; desktop
+  // previously wired `polishTextWithAI` without setting this path.
+  initializePolishModel(
+    join(resourcesPath, 'templates', 'instructionPolish.yaml'),
+  );
   initializeNodeRuntimeSkills({
     cwd: workspacePath ?? app.getPath('home'),
     resourcesPath,

--- a/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
@@ -1,4 +1,5 @@
 // Standard library imports
+import { existsSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -24,8 +25,10 @@ function createHost(overrides: Partial<DiffHostOptions> = {}) {
   const openPath = vi.fn(async (filePath: string) => {
     openedPaths.push(filePath);
   });
+  const host = createDesktopDiffHost({ openPath, ...overrides });
+  hosts.push(host);
   return {
-    host: createDesktopDiffHost({ openPath, ...overrides }),
+    host,
     openPath,
     openedPaths,
   };
@@ -37,8 +40,11 @@ function expectOpenedPatchFile(openedPaths: readonly string[]): void {
 }
 
 const tempDirs: string[] = [];
+const hosts: DiffHost[] = [];
 
 afterEach(async () => {
+  await Promise.all(hosts.map((host) => host.dispose()));
+  hosts.length = 0;
   await cleanupTempDirs(tempDirs);
 });
 
@@ -161,5 +167,20 @@ describe('createDesktopDiffHost', () => {
 
     expect(posted).toHaveLength(0);
     expectOpenedPatchFile(openedPaths);
+  });
+
+  it('removes external-editor patch directories when the host is disposed', async () => {
+    const { host, openedPaths } = createHost();
+
+    await openDiffPair(host, 'Compare');
+    const diffPath = openedPaths[0];
+    const diffDir = path.dirname(diffPath);
+
+    expect(existsSync(diffPath)).toBe(true);
+    expect(path.basename(diffDir)).toMatch(/^texra-desktop-diff-/);
+
+    await host.dispose();
+
+    expect(existsSync(diffDir)).toBe(false);
   });
 });

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
@@ -147,6 +147,22 @@ describe('desktop composition root and launch environment', () => {
     ]);
   });
 
+  it('initializes the bundled follow-up polish prompt from the resource bundle', async () => {
+    const source = await readDesktopPlatformIndex();
+
+    expect(namedImportSources(source, 'initializePolishModel')).toContain(
+      '@agent/runtime',
+    );
+    expect(source).toContain('initializePolishModel(');
+    expect(source).toContain(
+      "join(resourcesPath, 'templates', 'instructionPolish.yaml')",
+    );
+    expectOrderedAfter(source, 'const resourcesPath = resolveResourcesPath', [
+      'initializePolishModel(',
+      "join(resourcesPath, 'templates', 'instructionPolish.yaml')",
+    ]);
+  });
+
   it('uses the home directory as the no-workspace skill discovery fallback', async () => {
     const source = await readDesktopPlatformIndex();
 


### PR DESCRIPTION
## #10314 — Clean up `texra-desktop-diff` temp dirs leaked by the desktop diff fallback

- `DesktopDiffHost.openDiff` now records every external-editor patch directory and exposes a `dispose()` that removes them.
- The window `closed` handler calls `dispose()`, so fallback diff dirs are cleaned up when the window goes away; a fallback that fails before the editor opens cleans up immediately.
- Pinned by a `DesktopDiffHost` vitest case asserting the generated `texra-desktop-diff-*` directory is removed on dispose.

Closes #10314

## #10344 — Initialize the bundled follow-up polish prompt on desktop

- `initializeElectronPlatform` now calls `initializePolishModel` with the bundled `templates/instructionPolish.yaml` from the resolved desktop resource tree, matching the extension.
- The CLI's `copy-resources.mjs` no longer bundles the unused polish template.
- Pinned by an `ElectronCompositionRoot` vitest case asserting the desktop composition root wires the bundled polish prompt after resolving resources.

Closes #10344
