### PR TITLE
ci: harden remote-agents apply paths and preflight diagnostics

### DIFF
--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -587,13 +587,15 @@ Apply it with:
 npm run sync:remote-agents -- --apply
 ```
 
-Needs a `supabase link`ed checkout, or `SUPABASE_DB_URL`, or `SUPABASE_ACCESS_TOKEN` plus `SUPABASE_PROJECT_REF`. With `SUPABASE_PROJECT_REF` the script substitutes that ref for the checkout's linked project only while it runs and restores the previous link state afterwards.
+Needs a `supabase link`ed checkout, or `SUPABASE_DB_URL`, or `SUPABASE_ACCESS_TOKEN` plus `SUPABASE_PROJECT_REF`. With `SUPABASE_PROJECT_REF` the script passes that ref to the CLI through `SUPABASE_PROJECT_ID`, leaving the checkout's linked project untouched.
 
-Before writing any metadata, `--apply` verifies that every catalog `storage_path` already exists as an object in the `agent-configs` bucket; if any are missing it aborts and lists them, and no metadata is published. YAML bodies are still uploaded separately from metadata, so upload new or moved agents **before** applying (or before merging to `main`):
+Before writing any metadata, `--apply` verifies that every catalog `storage_path` already exists as an object in the `agent-configs` bucket; if any are missing it aborts and lists them, and no metadata is published. The preflight checks object existence, not freshness, so a green preflight does not prove the uploaded bodies are current. YAML bodies are still uploaded separately from metadata, so upload new, moved, or changed agents **before** applying (or before merging to `main`):
 
 ```bash
-# <folder> must match the agent's "folder" in docs/supabase/remote-agents.config.json
-supabase storage cp "prompts/agents/remote/<agent>.yaml" "ss:///agent-configs/<folder>/<agent>.yaml" --project-ref <PROJECT-REF>
+# <source> is the YAML path under prompts/agents/remote/, including any
+# subdirectory (for example "apply.yaml" or "Lean4/lean.yaml").
+# <folder> must match the agent's "folder" in docs/supabase/remote-agents.config.json.
+supabase storage cp "prompts/agents/remote/<source>" "ss:///agent-configs/<folder>/<agent>.yaml" --project-ref <PROJECT-REF>
 ```
 
 The same apply command (including the storage check) runs on merge to `main` when those files change (`.github/workflows/remote-agents-sync.yml`). PRs run `npm run sync:remote-agents` (generate only) and do not write production.

--- a/scripts/sync-remote-agents.mjs
+++ b/scripts/sync-remote-agents.mjs
@@ -9,11 +9,9 @@ import { spawnSync } from 'node:child_process';
 import {
   existsSync,
   mkdtempSync,
-  mkdirSync,
   readdirSync,
   readFileSync,
   rmSync,
-  rmdirSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -320,6 +318,12 @@ function generateRemoteAgentsSql() {
 // agent-configs bucket, so --apply refuses to publish while any storage_path
 // is missing (#10317). The check runs as SQL over the same connection as the
 // apply itself; the RAISE makes the CLI exit non-zero.
+// Distinctive text in the preflight RAISE when catalog storage paths are
+// missing. The apply error path matches this marker so it can tell missing
+// objects apart from every other preflight failure (#10332).
+const STORAGE_PREFLIGHT_MISSING_MARKER =
+  'catalog storage path(s) missing from the agent-configs bucket';
+
 function buildStoragePreflightSql(agents) {
   const values = agents
     .map((agent) => `    (${sqlString(agent.storagePath)})`)
@@ -346,7 +350,7 @@ function buildStoragePreflightSql(agents) {
     '  );',
     '',
     '  IF missing IS NOT NULL THEN',
-    "    RAISE EXCEPTION 'sync-remote-agents: % catalog storage path(s) missing from the agent-configs bucket: %. Upload the YAML prompt bodies first (docs/supabase/SUPABASE_SETUP.md, Part 7).',",
+    `    RAISE EXCEPTION 'sync-remote-agents: % ${STORAGE_PREFLIGHT_MISSING_MARKER}: %. Upload the YAML prompt bodies first (docs/supabase/SUPABASE_SETUP.md, Part 7).',`,
     "      array_length(missing, 1), array_to_string(missing, ', ');",
     '  END IF;',
     'END;',
@@ -355,11 +359,27 @@ function buildStoragePreflightSql(agents) {
   ].join('\n');
 }
 
-function runSupabaseQuery(args) {
+function runSupabaseQuery(args, options = {}) {
+  const { captureOutput = false, env = {} } = options;
   const result = spawnSync('supabase', args, {
-    stdio: 'inherit',
+    stdio: captureOutput ? ['inherit', 'pipe', 'pipe'] : 'inherit',
     cwd: rootDir,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
   });
+
+  const output = captureOutput
+    ? `${result.stdout ?? ''}${result.stderr ?? ''}`
+    : '';
+
+  if (captureOutput) {
+    if (result.stdout) {
+      process.stdout.write(result.stdout);
+    }
+    if (result.stderr) {
+      process.stderr.write(result.stderr);
+    }
+  }
 
   if (result.error) {
     if (result.error.code === 'ENOENT') {
@@ -372,15 +392,19 @@ function runSupabaseQuery(args) {
         result.error,
       );
     }
-    return 1;
+    return { status: 1, output };
   }
   if (result.signal) {
     console.error(
       `sync-remote-agents: supabase CLI was killed by signal ${result.signal}`,
     );
-    return 1;
+    return { status: 1, output };
   }
-  return result.status ?? 1;
+  return { status: result.status ?? 1, output };
+}
+
+function isMissingStoragePreflightFailure(output) {
+  return output.includes(STORAGE_PREFLIGHT_MISSING_MARKER);
 }
 
 function applyRemoteAgentsSql() {
@@ -388,44 +412,18 @@ function applyRemoteAgentsSql() {
   const projectRef = process.env.SUPABASE_PROJECT_REF;
   const projectRefFile = resolve(rootDir, 'supabase/.temp/project-ref');
   const args = ['--yes', 'db', 'query', '-o', 'table'];
-  // `supabase db query --linked` reads its target from
-  // supabase/.temp/project-ref. When SUPABASE_PROJECT_REF is set we overwrite
-  // that file, so back up the prior link state first and restore it on the way
-  // out, leaving the checkout as we found it (#10316).
-  let restoreProjectRef;
+  const queryEnv = {};
 
   if (dbUrl) {
     args.push('--db-url', dbUrl);
   } else {
     if (projectRef) {
-      const previousContents = existsSync(projectRefFile)
-        ? readFileSync(projectRefFile)
-        : null;
-      const previousRef = previousContents?.toString('utf8').trim();
-      if (previousRef && previousRef !== projectRef) {
-        console.error(
-          `sync-remote-agents: substituting SUPABASE_PROJECT_REF=${projectRef} ` +
-            `over this checkout's linked project (${previousRef}); ` +
-            'the link state is restored when the run ends.',
-        );
-      }
-      const tempDirExisted = existsSync(dirname(projectRefFile));
-      mkdirSync(dirname(projectRefFile), { recursive: true });
-      writeFileSync(projectRefFile, `${projectRef}\n`);
-      restoreProjectRef = () => {
-        if (previousContents !== null) {
-          writeFileSync(projectRefFile, previousContents);
-          return;
-        }
-        rmSync(projectRefFile, { force: true });
-        if (!tempDirExisted) {
-          try {
-            rmdirSync(dirname(projectRefFile));
-          } catch {
-            // The CLI left its own cache files behind; keep them.
-          }
-        }
-      };
+      // `supabase db query --linked` reads its target from
+      // supabase/.temp/project-ref unless SUPABASE_PROJECT_ID is set. Pass the
+      // requested ref through that env var instead of rewriting the checkout's
+      // link file, so there is nothing to restore even if the process is
+      // killed mid-query (#10316, #10329).
+      queryEnv.SUPABASE_PROJECT_ID = projectRef;
     } else if (!existsSync(projectRefFile)) {
       console.error(
         'sync-remote-agents: set SUPABASE_DB_URL or SUPABASE_PROJECT_REF, ' +
@@ -443,23 +441,32 @@ function applyRemoteAgentsSql() {
     if (agents.length > 0) {
       const preflightPath = join(sqlDir, 'remote-agents-preflight.sql');
       writeFileSync(preflightPath, buildStoragePreflightSql(agents));
-      const preflightStatus = runSupabaseQuery([...args, '-f', preflightPath]);
-      if (preflightStatus !== 0) {
-        console.error(
-          'sync-remote-agents: Storage preflight failed; catalog metadata was NOT applied. ' +
-            'Upload the missing YAML prompt bodies to the agent-configs bucket ' +
-            'first (docs/supabase/SUPABASE_SETUP.md, Part 7).',
-        );
-        return preflightStatus;
+      const preflight = runSupabaseQuery([...args, '-f', preflightPath], {
+        captureOutput: true,
+        env: queryEnv,
+      });
+      if (preflight.status !== 0) {
+        if (isMissingStoragePreflightFailure(preflight.output)) {
+          console.error(
+            'sync-remote-agents: Storage preflight failed; catalog metadata was NOT applied. ' +
+              'Upload the missing YAML prompt bodies to the agent-configs bucket ' +
+              'first (docs/supabase/SUPABASE_SETUP.md, Part 7).',
+          );
+        } else {
+          console.error(
+            'sync-remote-agents: Storage preflight failed; catalog metadata was NOT applied. ' +
+              'The error above describes the failure.',
+          );
+        }
+        return preflight.status;
       }
     }
 
     const sqlPath = join(sqlDir, 'remote-agents.sql');
     writeFileSync(sqlPath, buildSql(agents));
-    return runSupabaseQuery([...args, '-f', sqlPath]);
+    return runSupabaseQuery([...args, '-f', sqlPath], { env: queryEnv }).status;
   } finally {
     rmSync(sqlDir, { recursive: true, force: true });
-    restoreProjectRef?.();
   }
 }
 

--- a/src/test-kernel/scripts/SyncRemoteAgents.vitest.ts
+++ b/src/test-kernel/scripts/SyncRemoteAgents.vitest.ts
@@ -31,7 +31,8 @@ const PLACEMENT_CONFIG = JSON.stringify({
 });
 
 // Fake `supabase` CLI: logs every invocation plus the link state it observes,
-// and exits 1 when the SQL file passed via -f matches $TEXRA_STUB_FAIL.
+// optionally logs the SQL file it received, and exits 1 when the SQL file
+// passed via -f matches $TEXRA_STUB_FAIL.
 const SUPABASE_STUB = `#!/bin/sh
 file=""
 prev=""
@@ -48,10 +49,21 @@ done
   else
     printf 'observed-ref: <absent>\\n'
   fi
+  printf 'observed-project-id: %s\\n' "\${SUPABASE_PROJECT_ID:-<absent>}"
+  if [ -n "$TEXRA_STUB_LOG_SQL" ] && [ -n "$file" ] && [ -f "$file" ]; then
+    printf 'sql-file: %s\\n' "$(basename "$file")"
+    cat "$file"
+    printf '\\n'
+  fi
 } >> "$TEXRA_STUB_LOG"
 if [ -n "$TEXRA_STUB_FAIL" ]; then
   case "$file" in
-    *"$TEXRA_STUB_FAIL"*) exit 1 ;;
+    *"$TEXRA_STUB_FAIL"*)
+      if [ -n "$TEXRA_STUB_FAIL_OUTPUT" ]; then
+        printf '%s\\n' "$TEXRA_STUB_FAIL_OUTPUT"
+      fi
+      exit 1
+      ;;
   esac
 fi
 exit 0
@@ -83,7 +95,10 @@ function runSync(
   const env: NodeJS.ProcessEnv = { ...process.env };
   delete env.SUPABASE_DB_URL;
   delete env.SUPABASE_PROJECT_REF;
+  delete env.SUPABASE_PROJECT_ID;
   delete env.TEXRA_STUB_FAIL;
+  delete env.TEXRA_STUB_FAIL_OUTPUT;
+  delete env.TEXRA_STUB_LOG_SQL;
   env.TEXRA_REMOTE_AGENTS_ROOT = root;
   env.TEXRA_STUB_LOG = join(root, 'stub.log');
   env.PATH = `${join(root, 'bin')}${delimiter}${env.PATH ?? ''}`;
@@ -96,6 +111,19 @@ function runSync(
 
 function readStubLog(root: string) {
   return readFileSync(join(root, 'stub.log'), 'utf8');
+}
+
+function readStubSql(root: string, filename: string) {
+  const log = readStubLog(root);
+  const marker = `sql-file: ${filename}\n`;
+  const start = log.indexOf(marker);
+  if (start === -1) {
+    throw new Error(`Stub log does not contain sql-file: ${filename}`);
+  }
+  const contentStart = start + marker.length;
+  const nextMarker = log.indexOf('\nsql-file: ', contentStart);
+  const end = nextMarker === -1 ? log.length : nextMarker + 1;
+  return log.slice(contentStart, end);
 }
 
 function projectRefPath(root: string) {
@@ -123,7 +151,7 @@ describe('sync-remote-agents script (generate mode)', () => {
 describe.skipIf(process.platform === 'win32')(
   'sync-remote-agents script (--apply)',
   () => {
-    it('restores a previously linked project-ref after a successful run', () => {
+    it('targets SUPABASE_PROJECT_REF through the CLI env without mutating the linked ref', () => {
       const root = createFixtureCheckout('proj-a');
       try {
         const result = runSync(root, ['--apply'], {
@@ -131,19 +159,17 @@ describe.skipIf(process.platform === 'win32')(
         });
 
         expect(result.status, result.stderr).toBe(0);
-        // The CLI observed the substituted ref during the run...
-        expect(readStubLog(root)).toContain('observed-ref: proj-b');
-        // ...and the checkout's link state is back to proj-a afterwards.
+        // The CLI was pointed at proj-b without rewriting the checkout file.
+        expect(readStubLog(root)).toContain('observed-project-id: proj-b');
+        expect(readStubLog(root)).toContain('observed-ref: proj-a');
         expect(readFileSync(projectRefPath(root), 'utf8')).toBe('proj-a\n');
-        expect(result.stderr).toContain(
-          'substituting SUPABASE_PROJECT_REF=proj-b',
-        );
+        expect(result.stderr).not.toContain('substituting');
       } finally {
         rmSync(root, { recursive: true, force: true });
       }
     });
 
-    it('removes the project-ref it created when the checkout had no link state', () => {
+    it('never creates a project-ref file when the checkout has no link state', () => {
       const root = createFixtureCheckout();
       try {
         const result = runSync(root, ['--apply'], {
@@ -151,7 +177,7 @@ describe.skipIf(process.platform === 'win32')(
         });
 
         expect(result.status, result.stderr).toBe(0);
-        expect(readStubLog(root)).toContain('observed-ref: proj-b');
+        expect(readStubLog(root)).toContain('observed-project-id: proj-b');
         expect(existsSync(projectRefPath(root))).toBe(false);
         expect(existsSync(join(root, 'supabase/.temp'))).toBe(false);
       } finally {
@@ -159,7 +185,7 @@ describe.skipIf(process.platform === 'win32')(
       }
     });
 
-    it('restores the link state when the apply itself fails', () => {
+    it('leaves the link state untouched when the apply itself fails', () => {
       const root = createFixtureCheckout('proj-a');
       try {
         const result = runSync(root, ['--apply'], {
@@ -169,6 +195,7 @@ describe.skipIf(process.platform === 'win32')(
 
         expect(result.status).toBe(1);
         expect(readFileSync(projectRefPath(root), 'utf8')).toBe('proj-a\n');
+        expect(readStubLog(root)).toContain('observed-project-id: proj-b');
       } finally {
         rmSync(root, { recursive: true, force: true });
       }
@@ -192,23 +219,74 @@ describe.skipIf(process.platform === 'win32')(
       }
     });
 
-    it('refuses to publish metadata when the storage preflight fails', () => {
+    it('generates a storage preflight that checks the agent-configs bucket', () => {
+      const root = createFixtureCheckout('proj-a');
+      try {
+        const result = runSync(root, ['--apply'], {
+          SUPABASE_PROJECT_REF: 'proj-b',
+          TEXRA_STUB_LOG_SQL: '1',
+        });
+
+        expect(result.status, result.stderr).toBe(0);
+        const preflightSql = readStubSql(root, 'remote-agents-preflight.sql');
+        expect(preflightSql).toContain('DO $$');
+        expect(preflightSql).toContain('storage.objects');
+        expect(preflightSql).toContain("bucket_id = 'agent-configs'");
+        expect(preflightSql).toContain('researcher/apply.yaml');
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('refuses to publish metadata when the storage preflight reports missing objects', () => {
       const root = createFixtureCheckout('proj-a');
       try {
         const result = runSync(root, ['--apply'], {
           SUPABASE_PROJECT_REF: 'proj-b',
           TEXRA_STUB_FAIL: 'preflight',
+          TEXRA_STUB_FAIL_OUTPUT:
+            'sync-remote-agents: 1 catalog storage path(s) missing from the agent-configs bucket: ' +
+            'researcher/apply.yaml. Upload the YAML prompt bodies first ' +
+            '(docs/supabase/SUPABASE_SETUP.md, Part 7).',
         });
 
         expect(result.status).toBe(1);
         expect(result.stderr).toContain('Storage preflight failed');
+        expect(result.stderr).toContain(
+          'Upload the missing YAML prompt bodies to the agent-configs bucket',
+        );
         // The catalog SQL itself was never sent to the CLI.
         const invocations = readStubLog(root)
           .split('\n')
           .filter((line) => line.startsWith('args:'));
         expect(invocations).toHaveLength(1);
         expect(invocations[0]).toContain('remote-agents-preflight.sql');
-        // The failed run still restored the checkout's link state.
+        // The failed run still left the checkout's link state untouched.
+        expect(readFileSync(projectRefPath(root), 'utf8')).toBe('proj-a\n');
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('reports other preflight failures without upload guidance', () => {
+      const root = createFixtureCheckout('proj-a');
+      try {
+        const result = runSync(root, ['--apply'], {
+          SUPABASE_PROJECT_REF: 'proj-b',
+          TEXRA_STUB_FAIL: 'preflight',
+          TEXRA_STUB_FAIL_OUTPUT: 'ERROR: connection refused',
+        });
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('Storage preflight failed');
+        expect(result.stderr).not.toContain(
+          'Upload the missing YAML prompt bodies to the agent-configs bucket',
+        );
+        const invocations = readStubLog(root)
+          .split('\n')
+          .filter((line) => line.startsWith('args:'));
+        expect(invocations).toHaveLength(1);
+        expect(invocations[0]).toContain('remote-agents-preflight.sql');
         expect(readFileSync(projectRefPath(root), 'utf8')).toBe('proj-a\n');
       } finally {
         rmSync(root, { recursive: true, force: true });
@@ -226,6 +304,7 @@ describe.skipIf(process.platform === 'win32')(
         expect(result.stderr).not.toContain('substituting');
         expect(readFileSync(projectRefPath(root), 'utf8')).toBe('proj-a\n');
         expect(readStubLog(root)).toContain('observed-ref: proj-a');
+        expect(readStubLog(root)).toContain('observed-project-id: <absent>');
       } finally {
         rmSync(root, { recursive: true, force: true });
       }


### PR DESCRIPTION
Follow-up batch to #10326 for the remote-agents `--apply` path and its tests/docs.

- #10329: `--apply` no longer rewrites `supabase/.temp/project-ref`. It passes `SUPABASE_PROJECT_REF` through the CLI's `SUPABASE_PROJECT_ID` env instead, so the checkout link state is never mutated and the remaining exit-path gaps (temp-dir creation, signals) disappear.
- #10330: SyncRemoteAgents tests now capture the `-f` file the stub receives and assert the preflight SQL references `storage.objects`, `bucket_id = 'agent-configs'`, and `researcher/apply.yaml`.
- #10331: SUPABASE_SETUP.md Part 7 now says new, moved, or changed agents, documents freshness vs existence, and shows a subdirectory-aware source placeholder (`apply.yaml` or `Lean4/lean.yaml`).
- #10332: the preflight failure path matches the generated `RAISE EXCEPTION` marker and only prints upload guidance for missing objects; other failures get a generic error with no upload instruction.

Validation:
- `npm run typecheck` passes.
- `npx eslint src/test-kernel/scripts/SyncRemoteAgents.vitest.ts` passes (root `scripts/*.mjs` are outside the `npm run lint` scope).
- `npx vitest run src/test-kernel/scripts/` passes (58 tests).
- `node scripts/sync-remote-agents.mjs | head -20` output is byte-identical to the pre-change generated SQL.

Closes #10329
Closes #10330
Closes #10331
Closes #10332
