### PR TITLE
test(extension): pin the terminal CSS fallback chain (#10371)

### DIFF
--- a/src/test-kernel/progressView/TerminalCssFallback.vitest.ts
+++ b/src/test-kernel/progressView/TerminalCssFallback.vitest.ts
@@ -1,0 +1,45 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - test support
+import { REPO_ROOT } from '@test/support/repoScan';
+
+const COMMON_CSS = 'packages/extension/src/common/styles/common.css';
+
+function readCommonCss(): string {
+  return readFileSync(join(REPO_ROOT, COMMON_CSS), 'utf8');
+}
+
+/** Strip CSS block comments so prose references can't satisfy token matches. */
+function stripCssComments(text: string): string {
+  return text.replaceAll(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/**
+ * Extract the --wa-color-terminal-background value with all whitespace
+ * removed: formatting stays a style choice, while the variable chain and its
+ * order are the pinned contract.
+ */
+function terminalBackgroundValue(css: string): string | undefined {
+  return /--wa-color-terminal-background\s*:\s*(?<value>[^;]+);/
+    .exec(stripCssComments(css))
+    ?.groups?.value.replaceAll(/\s+/g, '');
+}
+
+describe('extension terminal CSS fallback chain', () => {
+  it('keeps the panel-background fallback on the terminal background token', () => {
+    // VS Code registers terminal.background without a default, so themes that
+    // don't set it inject no --vscode-terminal-background into the webview;
+    // the chain mirrors the integrated terminal by falling back to
+    // --vscode-panel-background instead of silently dropping the token
+    // (#10321). jsdom's custom-property var() substitution is too limited for
+    // a computed-style assertion here, so pin the source text.
+    expect(terminalBackgroundValue(readCommonCss())).toBe(
+      'var(--vscode-terminal-background,var(--vscode-panel-background))',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #10358. `packages/extension/src/common/styles/common.css` maps `--wa-color-terminal-background` to `var(--vscode-terminal-background, var(--vscode-panel-background))` so themes that don't set `terminal.background` fall back to the panel background instead of silently dropping the token. `XtermTheme.vitest.ts` pins the JS warning and the surface/built-in fallback in `resolveXtermTheme`, but nothing pinned the CSS `var()` chain itself — a future edit that dropped or reordered the `--vscode-panel-background` fallback would pass CI and silently regress the fix.

Adds `src/test-kernel/progressView/TerminalCssFallback.vitest.ts`, a text-level check of `common.css` that pins the exact chain `--vscode-terminal-background` → `--vscode-panel-background` on the terminal-background token:

- Reads the CSS as source text (jsdom's custom-property `var()` substitution is too limited for a computed-style assertion, per the #10358 review).
- Strips block comments first so the prose above the declaration (which names `--vscode-terminal-background`) can't satisfy the match, mirroring `DesktopThemeTokens.vitest.ts`.
- Compares whitespace-insensitively: reformatting the declaration stays free; the variables and their order are the pinned contract.

Verified by mutation: dropping the fallback and reordering the chain each fail the new test; the unmodified source passes.

## Test plan

- `npx vitest run src/test-kernel/progressView/TerminalCssFallback.vitest.ts` — 1 passed
- `npx vitest run src/test-kernel/progressView src/test-kernel/shared/XtermTheme.vitest.ts src/test-kernel/desktop/DesktopThemeTokens.vitest.ts src/test-kernel/settings/SettingsStyleContracts.vitest.ts src/test-kernel/shared/WebAwesomeSizeContracts.vitest.ts src/test-kernel/shared/BadgeStyleContracts.vitest.ts` — 64 files / 557 tests passed
- `npx prettier --check` and targeted `eslint` on the new file — clean
- `npm run typecheck:test-kernel` — clean

Closes #10371