### PR TITLE
fix(model-handlers): restore processThinkingBlock-before-extract ordering in finalizeProgressStreams

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -439,16 +439,22 @@ export abstract class ModelHandler<
    * closes with the provider-extracted final text. Each provider keeps
    * extracting that text itself (every response shape reads differently);
    * what shares is the finalize ordering.
+   *
+   * `extractFinalText` is a callback (not a precomputed string) so extraction
+   * runs AFTER `processThinkingBlock` has committed the processed reasoning:
+   * if extraction throws, the thinking stream keeps the processed reasoning
+   * (`finalize` is idempotent) instead of falling back to the raw streamed
+   * chunks via the error path (#10372).
    */
   protected finalizeProgressStreams(
     thinking: StreamHandle,
     output: StreamHandle,
     response: Resp,
-    finalText: string,
+    extractFinalText: () => string,
   ): void {
     const finalReasoning = this.processThinkingBlock(response);
     thinking.finalize(finalReasoning ?? undefined);
-    output.finalize(finalText);
+    output.finalize(extractFinalText());
   }
 
   /**

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -2155,7 +2155,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
         thinking,
         output,
         response,
-        this.extractResponse(response, endTag ?? '').text,
+        () => this.extractResponse(response, endTag ?? '').text,
       );
       streamsFinalized = true;
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -432,7 +432,7 @@ export class ModelHandlerOpenAI<
         thinking,
         output,
         finalResponse,
-        finalResponse.choices?.[0]?.message?.content ?? '',
+        () => finalResponse.choices?.[0]?.message?.content ?? '',
       );
       return finalResponse;
     } catch (streamError) {

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -272,13 +272,10 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         }
 
         const response = aggregator.buildResponse();
-        const finalOutput = response.choices?.[0]?.message?.content ?? '';
-        this.finalizeProgressStreams(
-          thinking,
-          output,
-          response,
-          typeof finalOutput === 'string' ? finalOutput : '',
-        );
+        this.finalizeProgressStreams(thinking, output, response, () => {
+          const finalOutput = response.choices?.[0]?.message?.content ?? '';
+          return typeof finalOutput === 'string' ? finalOutput : '';
+        });
 
         this.trackInputTokens(response.usage, 'streaming response');
         return { response, updatedMessages };

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsStreaming.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsStreaming.vitest.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { noopTrace, type AgentTrace } from '@agent/trace';
@@ -33,9 +33,11 @@ function createStreamRecorder(records: StreamRecord[]): AgentTrace {
       return {
         id: `stream-${counter}`,
         append: (text: string) => record.appends.push(text),
+        // First finalize wins, mirroring StreamHandle's idempotent finalize.
         finalize: (text?: string) => {
-          record.finalized = text;
-          return text ?? record.appends.join('');
+          record.finalized ??=
+            typeof text === 'string' ? text : record.appends.join('');
+          return record.finalized;
         },
       };
     },
@@ -174,6 +176,74 @@ describe('ModelHandlerGoogleInteractions streaming', () => {
     expect(result.response.usage?.total_input_tokens).toBe(10);
     expect(result.response.usage?.total_output_tokens).toBe(3);
     expect(result.response.status).toBe('completed');
+  });
+
+  // Regression for #10372: finalizeProgressStreams must run
+  // processThinkingBlock (committing the processed reasoning to the thinking
+  // stream) BEFORE the extract step. If extraction throws, the thinking
+  // stream must already hold the processed reasoning — not fall through to
+  // the error-path finalize with only the raw streamed chunks.
+  it('commits processed reasoning before extractResponse runs on the streaming finalize', async () => {
+    const records: StreamRecord[] = [];
+    const handler = createHandler(records);
+
+    const callOrder: string[] = [];
+    const originalProcess = handler.processThinkingBlock.bind(handler);
+    vi.spyOn(handler, 'processThinkingBlock').mockImplementation(
+      (response, workspaceState) => {
+        callOrder.push('processThinkingBlock');
+        originalProcess(response, workspaceState);
+        // Distinct from the raw streamed chunk ('plan') so the finalize
+        // assertion below can tell processed reasoning apart from it.
+        return 'PROCESSED_REASONING';
+      },
+    );
+    vi.spyOn(handler, 'extractResponse').mockImplementation(() => {
+      callOrder.push('extractResponse');
+      throw new Error('extractResponse failed');
+    });
+
+    const events: Interactions.InteractionSSEEvent[] = [
+      {
+        event_type: 'interaction.created',
+        interaction: { id: 'int_err', status: 'in_progress' },
+      },
+      { event_type: 'step.start', index: 0, step: { type: 'thought' } },
+      {
+        event_type: 'step.delta',
+        index: 0,
+        delta: {
+          type: 'thought_summary',
+          content: { type: 'text', text: 'plan' },
+        },
+      },
+      { event_type: 'step.stop', index: 0 },
+      {
+        event_type: 'step.start',
+        index: 1,
+        step: { type: 'model_output' },
+      },
+      {
+        event_type: 'step.delta',
+        index: 1,
+        delta: { type: 'text', text: 'partial output' },
+      },
+      { event_type: 'step.stop', index: 1 },
+      {
+        event_type: 'interaction.completed',
+        interaction: { id: 'int_err', status: 'completed' },
+      },
+    ];
+
+    await expect(runPrompt(handler, events, 'Hi')).rejects.toThrow(
+      'extractResponse failed',
+    );
+
+    expect(callOrder).toEqual(['processThinkingBlock', 'extractResponse']);
+    const thinkingRecord = records.find(
+      (r) => r.type === MESSAGE_TYPES.THINKING,
+    );
+    expect(thinkingRecord?.finalized).toBe('PROCESSED_REASONING');
   });
 
   it('reports incomplete when the stream ends without an interaction.completed event', async () => {


### PR DESCRIPTION
## Regression

#10359 extracted the shared `finalizeProgressStreams` helper with the final text as a plain `string` parameter. Because arguments are evaluated before the call, every call site now runs its extract step **before** the helper body runs `processThinkingBlock(response)` — inverting the pre-refactor sequence:

```
processThinkingBlock → thinking.finalize → extract → output.finalize
```

Consequence (flagged in the post-merge review of #10359): on the Google streaming path, if `extractResponse` throws at that call site, the old code had already committed the processed reasoning to the thinking stream; the refactored code falls through to `finalizeProgressStreamsOnError`, which finalizes the thinking stream with only the raw streamed chunks.

## Fix

`finalizeProgressStreams` now takes an `extractFinalText: () => string` callback and invokes it **after** `processThinkingBlock` + `thinking.finalize`, restoring the original ordering in the shared scaffolding for all handlers at once:

- `modelHandlerGoogleInteractions`: `() => this.extractResponse(response, endTag ?? '').text`
- `modelHandlerOpenAI`: `() => finalResponse.choices?.[0]?.message?.content ?? ''`
- `modelHandlerOpenRouterNative`: the `finalOutput` read moved inside the callback (it was likewise computed ahead of `processThinkingBlock`)

With the restored ordering, a throwing extractor leaves the thinking stream finalized with the processed reasoning (`StreamHandle.finalize` is idempotent, so the error-path finalize is a no-op for thinking) and only the output stream falls back to raw chunks.

## Regression test

New test in `GoogleInteractionsStreaming.vitest.ts` spies on `processThinkingBlock` (call-through, returning a sentinel distinct from the raw chunk) and `extractResponse` (throwing), drives the streaming path, and asserts:

1. call sequence is exactly `['processThinkingBlock', 'extractResponse']`;
2. the thinking stream finalized with the processed reasoning, not the raw streamed chunks.

The suite's stream recorder `finalize` is now idempotent (first call wins) to mirror the real `StreamHandle` in `TraceEmitter`. Verified the test fails on the unfixed code (`['extractResponse']` only — `processThinkingBlock` never runs).

## Validation

- `npm run typecheck` — all targets pass
- `npx eslint` on the 5 changed files — clean
- `npx prettier --check` on the 5 changed files — clean
- `npx vitest run src/test-kernel/agent/modelHandlers/` — 62 files passed, 745 tests passed, 4 skipped

Closes #10372