### PR TITLE
fix(hooks): harden format-staged config, EOL, and SHA-256 handling

### DIFF
--- a/scripts/format-staged.mjs
+++ b/scripts/format-staged.mjs
@@ -43,7 +43,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { basename, join, relative } from 'node:path';
+import { basename, dirname, join, parse, relative } from 'node:path';
 
 import ignore from 'ignore';
 import prettier from 'prettier';
@@ -117,12 +117,29 @@ function withWorktreeEol(content, worktree) {
   return Buffer.from(lf.toString('utf8').replace(/\n/g, '\r\n'), 'utf8');
 }
 
+/** True when `buffer` mixes CRLF and bare-LF newlines. */
+function hasMixedEol(buffer) {
+  if (!buffer.includes(CRLF)) return false;
+  const text = buffer.toString('utf8');
+  return text.replace(/\r\n/g, '').includes('\n');
+}
+
 /** Fold the staged→formatted rewrite into the working tree, if safe. */
 function mergeWorktree(path, stagedBlob, formatted) {
   const stat = lstatSync(path, { throwIfNoEntry: false });
   // Unstaged deletion or a symlink replacing the file: leave the tree alone.
   if (!stat?.isFile()) return;
   const worktree = readFileSync(path);
+  // A mixed-EOL working tree has no single convention to re-apply, and
+  // rewriting every newline would flip the bytes of unrelated unstaged
+  // lines. Leave it byte-identical; the staged output is already staged.
+  if (hasMixedEol(worktree)) {
+    console.log(
+      `${NOTICE} ${path}: mixed LF/CRLF line endings; kept the working-tree ` +
+        'copy. Run `npm run format` after committing to sync.',
+    );
+    return;
+  }
   // autocrlf checks out CRLF files whose index blobs are LF. Normalize both
   // sides before comparing/merging, then re-apply the tree's EOL on write so
   // CRLF worktrees don't take a spurious conflict and don't get flipped to LF.
@@ -166,6 +183,29 @@ function mergeWorktree(path, stagedBlob, formatted) {
   }
 }
 
+/** Write the staged config blob beside the worktree config it shadows,
+ * under a scratch name that keeps the config's own directory and extension.
+ * Overrides, relative plugins, and relative imports in the staged config then
+ * resolve exactly as they do for the worktree file. */
+function writeConfigSnapshot(worktreeConfigPath, stagedConfig) {
+  const base = basename(worktreeConfigPath);
+  // package.json contributes only its `prettier` key, so the snapshot holds
+  // just that key; every other config file is its own config.
+  const content =
+    base === 'package.json'
+      ? JSON.stringify(
+          JSON.parse(stagedConfig.toString('utf8')).prettier ?? null,
+        )
+      : stagedConfig;
+  const { name, ext } = parse(base);
+  const snapshotPath = join(
+    dirname(worktreeConfigPath),
+    `${name}-format-staged-${process.pid}${ext}`,
+  );
+  writeFileSync(snapshotPath, content);
+  return snapshotPath;
+}
+
 /** Format one staged path's index blob and stage the result. */
 async function formatStagedFile(path) {
   const entries = git(['ls-files', '-s', '-z', '--', path])
@@ -173,7 +213,8 @@ async function formatStagedFile(path) {
     .split('\0')
     .filter(Boolean);
   if (entries.length !== 1) return; // unmerged or otherwise unusual state
-  const match = /^(\d{6}) ([0-9a-f]{40}) (\d)\t/.exec(entries[0]);
+  // 40-hex (SHA-1) or 64-hex (SHA-256) object names; git validates the rest.
+  const match = /^(\d{6}) ([0-9a-f]{40}|[0-9a-f]{64}) (\d)\t/.exec(entries[0]);
   if (!match) return;
   const [, mode, sha, stage] = match;
   if (stage !== '0') return; // unmerged
@@ -185,11 +226,15 @@ async function formatStagedFile(path) {
 
   if (isIgnored(path)) return;
 
-  // Prettier reads .prettierrc/.prettierignore from the working tree, but the
-  // content being formatted comes from the index. When those config files are
-  // tracked, use their index blobs so unstaged edits to them don't change how
-  // the staged content is formatted (or whether it is ignored).
-  const snapDir = mkdtempSync(join(tmpdir(), 'format-staged-config-'));
+  // Prettier reads .prettierrc/.prettierignore from the working tree, but
+  // the content being formatted comes from the index. The applicable config
+  // must come from the index too: an untracked worktree config is not part of
+  // the commit, so skip loudly rather than let its rules shape the staged
+  // blob. When the tracked config has unstaged edits, resolve against a
+  // snapshot of its index blob written beside the worktree copy, so
+  // directory-relative overrides, plugins, and imports keep resolving against
+  // the config's real location.
+  let configSnapshot = null;
   try {
     let resolveConfigOptions = {};
     const worktreeConfigPath = await prettier.resolveConfigFile(path);
@@ -200,10 +245,28 @@ async function formatStagedFile(path) {
       );
       if (!configRel.startsWith('../') && configRel !== '..') {
         const stagedConfig = readIndexFile(configRel);
-        if (stagedConfig) {
-          const configFile = join(snapDir, basename(configRel));
-          writeFileSync(configFile, stagedConfig);
-          resolveConfigOptions = { config: configFile };
+        if (!stagedConfig) {
+          console.log(
+            `${NOTICE} ${path}: ${configRel} is not staged; skipped ` +
+              'auto-staging so its uncommitted rules stay out of the commit. ' +
+              'Stage or remove it and retry.',
+          );
+          return;
+        }
+        if (!readFileSync(worktreeConfigPath).equals(stagedConfig)) {
+          if (basename(worktreeConfigPath) === 'package.yaml') {
+            console.log(
+              `${NOTICE} ${path}: staged ${configRel} differs from the ` +
+                'worktree copy and package.yaml configs cannot be ' +
+                'snapshotted; skipped auto-staging.',
+            );
+            return;
+          }
+          configSnapshot = writeConfigSnapshot(
+            worktreeConfigPath,
+            stagedConfig,
+          );
+          resolveConfigOptions = { config: configSnapshot };
         }
       }
     }
@@ -224,7 +287,7 @@ async function formatStagedFile(path) {
 
     mergeWorktree(path, stagedBlob, formatted);
   } finally {
-    rmSync(snapDir, { recursive: true, force: true });
+    if (configSnapshot) rmSync(configSnapshot, { force: true });
   }
 }
 

--- a/src/test-kernel/scripts/FormatStaged.vitest.ts
+++ b/src/test-kernel/scripts/FormatStaged.vitest.ts
@@ -73,6 +73,10 @@ beforeEach(() => {
   git(['config', 'user.name', 'test']);
   git(['config', 'commit.gpgsign', 'false']);
   writeFileSync(join(dir, '.prettierrc'), '{}\n');
+  // The hook skips files whose worktree-selected config is untracked
+  // (#10367), so the fixture config starts out committed.
+  git(['add', '.prettierrc']);
+  git(['commit', '-qm', 'init']);
 });
 
 afterEach(() => {
@@ -190,6 +194,32 @@ describe('format-staged', () => {
     expect(git(['diff', '--stat', 'c.ts'])).toContain('1 insertion');
   });
 
+  it('leaves a mixed-EOL working tree byte-identical (#10369)', () => {
+    writeFileSync(
+      join(dir, 'c.ts'),
+      MULTI_STAGED.replace('{x:1,y:2}', '{x:1}'),
+    );
+    git(['add', 'c.ts']);
+    git(['commit', '-qm', 'base']);
+    writeFileSync(join(dir, 'c.ts'), MULTI_STAGED);
+    git(['add', 'c.ts']);
+    // Unstaged edit with mixed endings: one CRLF line among LF lines.
+    const mixed = MULTI_UNSTAGED.replace(
+      'const a={x:1,y:2};\n',
+      'const a={x:1,y:2};\r\n',
+    );
+    writeFileSync(join(dir, 'c.ts'), mixed);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('mixed LF/CRLF line endings');
+    // The staged blob is still formatted...
+    expect(stagedBlob('c.ts')).toBe(MULTI_FORMATTED);
+    // ...but no unstaged line's bytes are rewritten.
+    expect(readFileSync(join(dir, 'c.ts'), 'utf8')).toBe(mixed);
+  });
+
   it.skipIf(process.platform === 'win32')(
     'keeps newer worktree content if it appears during the merge-file write',
     () => {
@@ -271,6 +301,58 @@ describe('format-staged', () => {
     expect(stagedBlob('ignored.ts')).toBe(STAGED);
   });
 
+  it('skips auto-staging when the nearest config is untracked (#10367)', () => {
+    mkdirSync(join(dir, 'src'));
+    // A nearer, untracked config must not shape the staged blob.
+    writeFileSync(join(dir, 'src/.prettierrc'), '{"semi":false}\n');
+    writeFileSync(join(dir, 'src/a.ts'), STAGED);
+    git(['add', 'src/a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('src/.prettierrc is not staged');
+    expect(stagedBlob('src/a.ts')).toBe(STAGED);
+  });
+
+  it('applies overrides relative to a staged config with unstaged edits (#10368)', () => {
+    writeFileSync(
+      join(dir, '.prettierrc'),
+      '{"overrides":[{"files":"src/**","options":{"semi":false}}]}\n',
+    );
+    git(['add', '.prettierrc']);
+    // Unstaged edit drops the override; the staged config must still win,
+    // resolved against the config's own directory.
+    writeFileSync(join(dir, '.prettierrc'), '{}\n');
+    mkdirSync(join(dir, 'src'));
+    writeFileSync(join(dir, 'src/a.ts'), 'export const x = 1;\n');
+    git(['add', 'src/a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for src/a.ts');
+    expect(stagedBlob('src/a.ts')).toBe('export const x = 1\n');
+  });
+
+  it('resolves plugins relative to a staged config with unstaged edits (#10368)', () => {
+    writeFileSync(join(dir, 'fake-plugin.mjs'), 'export default {};\n');
+    writeFileSync(
+      join(dir, '.prettierrc'),
+      '{"plugins":["./fake-plugin.mjs"]}\n',
+    );
+    git(['add', 'fake-plugin.mjs', '.prettierrc']);
+    writeFileSync(join(dir, '.prettierrc'), '{}\n');
+    writeFileSync(join(dir, 'a.ts'), STAGED);
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(stagedBlob('a.ts')).toBe(FORMATTED);
+  });
+
   it('leaves ignored, unknown, and already-formatted files untouched', () => {
     writeFileSync(join(dir, '.prettierignore'), 'ignored.ts\n');
     writeFileSync(join(dir, 'ignored.ts'), STAGED);
@@ -308,6 +390,26 @@ describe('format-staged', () => {
 
     expect(result.status, result.stderr).toBe(0);
     expect(stagedBlob('a.ts')).toBe(STAGED);
+  });
+
+  it('stages Prettier output in a SHA-256 object-format repo (#10370)', () => {
+    rmSync(join(dir, '.git'), { recursive: true, force: true });
+    git(['init', '-q', '-b', 'main', '--object-format=sha256']);
+    git(['config', 'user.email', 'test@example.com']);
+    git(['config', 'user.name', 'test']);
+    git(['config', 'commit.gpgsign', 'false']);
+    git(['add', '.prettierrc']);
+    git(['commit', '-qm', 'init']);
+    writeFileSync(join(dir, 'a.ts'), STAGED);
+    git(['add', 'a.ts']);
+    // SHA-256 repos carry 64-hex object names in the index.
+    expect(git(['ls-files', '-s', '--', 'a.ts'])).toMatch(/ [0-9a-f]{64} /);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(stagedBlob('a.ts')).toBe(FORMATTED);
   });
 });
 


### PR DESCRIPTION
Follow-up fixes from the #10327 review, all in the chained pre-commit format-staged hook (`scripts/format-staged.mjs`).

## Per-issue changes

- **#10367 — untracked Prettier configs excluded from resolution.** When `prettier.resolveConfigFile` selects a worktree config that has no index blob (e.g. an untracked `src/.prettierrc` beside a staged `src/a.ts`), the hook now skips auto-staging loudly (`... is not staged; skipped auto-staging ...`) instead of letting `resolveConfig` re-read the untracked file and format staged content by rules that are not part of the commit. The write-and-fail `npm-format` hook then surfaces the situation on commit.
- **#10368 — staged config keeps its resolution directory.** A staged config that diverges from the worktree copy is now snapshotted *beside the worktree file* under a scratch name (`<name>-format-staged-<pid><ext>`) that preserves the original directory and loader extension, so `overrides.files` slash-globs, relative `plugins`, and relative imports in JS configs resolve exactly as they do for the worktree file (Prettier resolves all three against `dirname(configFile)`). Configs whose worktree copy matches the staged blob resolve naturally with no snapshot at all. `package.json` snapshots carry only the extracted `prettier` key; `package.yaml` divergence is skipped loudly (cannot extract without a YAML parser). This replaces the old bare-temp-dir copy that broke all directory-relative references.
- **#10369 — mixed line endings preserved.** `mergeWorktree` now detects a working-tree file mixing CRLF and bare-LF newlines and leaves it byte-identical (staged output is still staged; a notice explains how to sync), instead of rewriting every newline in the merge result — including unrelated unstaged lines — to CRLF.
- **#10370 — SHA-256 repos supported** (implementing was cheap, so no doc limitation needed): the `ls-files -s` entry regex accepts 40- or 64-hex object names; `cat-file`/`hash-object`/`update-index` are object-format agnostic and validate the rest. Previously every staged file in a `--object-format=sha256` repo was silently skipped.

## Tests

`src/test-kernel/scripts/FormatStaged.vitest.ts` reuses the #10327 temp-repo harness:

- New pins: untracked-config skip (#10367), overrides relative to a diverged staged config (#10368), relative plugin resolution from a diverged staged config (#10368), mixed-EOL worktree left byte-identical (#10369), end-to-end staging in a `--object-format=sha256` repo (#10370). All five fail against the pre-fix script and pass with it (verified by stashing the script change).
- `beforeEach` now commits the fixture `.prettierrc`, since the #10367 skip would otherwise (correctly) fire on the untracked fixture config in every test.
- Full suite: 21/21 pass. `npx prettier --check` clean on both changed files; `npm run typecheck` clean; `npx eslint` clean on the changed test file.

Closes #10367
Closes #10368
Closes #10369
Closes #10370