### PR TITLE
fix(storage): reject unsafe-integer KVStoreCache max and pin the bounded contract

### DIFF
--- a/src/common/storage/KVStoreCache.ts
+++ b/src/common/storage/KVStoreCache.ts
@@ -37,12 +37,15 @@ export class KVStoreCache<
     private readonly create: (id: TId) => TStore,
     { max }: { max?: number } = {},
   ) {
-    if (max !== undefined && (!Number.isInteger(max) || max < 1)) {
-      // `max: 0` would construct a zero-capacity LRUCache whose every get()
-      // recreates and immediately discards the handle — a silent no-cache
-      // mode. Fail loudly instead of degrading silently.
+    if (max !== undefined && (!Number.isSafeInteger(max) || max < 1)) {
+      // lru-cache already rejects every invalid max at construction, so
+      // there is no silent no-cache mode to prevent — but with its own
+      // TypeError (0, -1, 1.5, NaN, Infinity) or a generic Error (integers
+      // beyond the safe range, whose per-cap index array it cannot size).
+      // Guard here so every invalid max fails early with one
+      // KVStoreCache-scoped RangeError.
       throw new RangeError(
-        `KVStoreCache max must be a positive integer (got ${max}); omit it for an unbounded cache`,
+        `KVStoreCache max must be a positive safe integer (got ${max}); omit it for an unbounded cache`,
       );
     }
     this.handles = max === undefined ? new Map() : new LRUCache({ max });

--- a/src/test-kernel/common/KVStoreCache.vitest.ts
+++ b/src/test-kernel/common/KVStoreCache.vitest.ts
@@ -3,20 +3,32 @@ import { describe, expect, it } from 'vitest';
 import { KVStoreCache } from '@common/storage/KVStoreCache';
 import { KVStore } from '@common/storage/KVStore';
 
-describe('KVStoreCache max validation', () => {
+describe('KVStoreCache', () => {
   const create = () => new KVStore('/tmp/unused');
 
-  it.each([0, -1, 1.5, Number.NaN])('throws RangeError for max=%s', (max) => {
-    expect(() => new KVStoreCache(create, { max })).toThrow(RangeError);
-  });
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2 ** 53])(
+    'throws RangeError for max=%s',
+    (max) => {
+      expect(() => new KVStoreCache(create, { max })).toThrow(RangeError);
+    },
+  );
 
-  it('accepts an unset max as unbounded', () => {
+  it('keeps every cached handle when max is unset (unbounded)', () => {
     const cache = new KVStoreCache(create);
-    expect(cache.get('a')).toBe(cache.get('a'));
+    const ids = ['a', 'b', 'c', 'd', 'e'];
+    const handles = ids.map((id) => cache.get(id));
+    for (const [index, id] of ids.entries()) {
+      expect(cache.get(id)).toBe(handles[index]);
+    }
   });
 
-  it('accepts a positive integer max', () => {
+  it('evicts the least-recently-used handle once max is exceeded', () => {
     const cache = new KVStoreCache(create, { max: 2 });
-    expect(cache.get('a')).toBe(cache.get('a'));
+    const a = cache.get('a');
+    const b = cache.get('b');
+    const c = cache.get('c');
+    expect(cache.get('c')).toBe(c);
+    expect(cache.get('b')).toBe(b);
+    expect(cache.get('a')).not.toBe(a);
   });
 });


### PR DESCRIPTION
Follow-ups to #10364 (KVStoreCache max guard), one commit covering three review follow-ups.

## Changes (`src/common/storage/KVStoreCache.ts`)

- **#10386 — comment reworded to the actual mechanism.** Verified against the pinned lru-cache@11.5.2: `new LRUCache({ max: 0 })` throws `TypeError: At least one of max, maxSize, or ttl is required` at construction, so no silent no-cache mode ever existed. The comment now states the guard's real value: every invalid `max` fails early with one KVStoreCache-scoped `RangeError` instead of lru-cache's `TypeError` (`0`, `-1`, `1.5`, `NaN`, `Infinity`) or generic `Error` (unsafe integers).
- **#10387 — `Number.isInteger` → `Number.isSafeInteger`.** Unsafe integers such as `2**53` previously passed the guard and then failed inside lru-cache with a generic `Error('invalid max value: ...')`; now every invalid `max` fails with the KVStoreCache `RangeError`. Message updated to "positive safe integer" to match. Public API unchanged.

## Test pins (`src/test-kernel/common/KVStoreCache.vitest.ts`)

- **#10387** — `2 ** 53` added to the invalid `it.each` cases.
- **#10388** — `Infinity` added to the invalid cases; the two weak identity assertions replaced with behavioral pins of the bounded-vs-unbounded split: unset `max` keeps five distinct ids all cached (plain `Map` path), and `max: 2` evicts the least-recently-used handle once exceeded (`LRUCache` path).

## Validation

- `npm run typecheck` — clean
- eslint on both changed files — clean
- `vitest run src/test-kernel/common/KVStoreCache.vitest.ts` — 8/8 pass
- `vitest run src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts` (consumer) — 24/24 pass
- `prettier --check` on changed files — clean
- No CHANGELOG bullet: internal guard diagnostics only, not user-visible.

Closes #10386
Closes #10387
Closes #10388