### PR TITLE
fix(desktop): harden diff temp-dir cleanup across the quit lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,8 +68,7 @@ All notable changes to this project will be documented in this file.
   silently returns the original draft; it now applies the same bundled prompt
   template the extension uses.
 - **Temporary diff files are cleaned up** — viewing a diff in an external
-  editor no longer leaves `texra-desktop-diff` folders behind after the window
-  closes.
+  editor no longer leaves temporary files behind after the window closes.
 
 ### CLI and Desktop
 

--- a/packages/desktop/src/main/desktopDiffHost.ts
+++ b/packages/desktop/src/main/desktopDiffHost.ts
@@ -13,6 +13,7 @@ import {
   computeLineChangeSummary,
   computeUserPatch,
 } from '@tools/approval/toolEditApproval';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { createTexraTempDir } from '@utils/files/tempDir';
 
 import {
@@ -41,6 +42,10 @@ export function createDesktopDiffHost(
   // OS editor may still be reading it, so each fallback run records its
   // directory here and `dispose()` removes them when the window closes.
   const externalPatchDirs = new Set<string>();
+  // Set when dispose() starts. A fallback still in flight checks this before
+  // recording its temp directory: the set has already been snapshotted and
+  // cleared, so recording would leak the directory.
+  let disposed = false;
 
   async function openDiff(
     original: DiffSource,
@@ -79,6 +84,19 @@ export function createDesktopDiffHost(
       computeUserPatch(originalContent, proposedContent) ??
       `No textual changes for ${path.basename(proposed.filePath)}.\n`;
     const tempDir = await createTexraTempDir('texra-desktop-diff-');
+    if (disposed) {
+      // The window closed while this fallback was in flight and dispose() has
+      // already drained the record set, so recording the directory now would
+      // leak it. Remove it immediately and stop instead.
+      try {
+        await rm(tempDir, { recursive: true, force: true });
+      } catch (cleanupError) {
+        console.warn(
+          `[desktop] Failed to remove the temporary diff directory after the window closed: ${toErrorMessage(cleanupError)}`,
+        );
+      }
+      throw new Error('Desktop window closed before the diff could be opened.');
+    }
     externalPatchDirs.add(tempDir);
     const diffPath = path.join(tempDir, `${nanoid()}.diff`);
 
@@ -88,10 +106,16 @@ export function createDesktopDiffHost(
     } catch (error) {
       // The patch never reached an editor: clean it up now instead of waiting
       // for window close, and preserve the original failure for the caller.
-      externalPatchDirs.delete(tempDir);
-      await rm(tempDir, { recursive: true, force: true }).catch(
-        () => undefined,
-      );
+      // Keep the directory recorded when the removal fails so dispose() can
+      // retry it, and log instead of swallowing the failure.
+      try {
+        await rm(tempDir, { recursive: true, force: true });
+        externalPatchDirs.delete(tempDir);
+      } catch (cleanupError) {
+        console.warn(
+          `[desktop] Failed to remove the temporary diff directory; will retry when the window closes: ${toErrorMessage(cleanupError)}`,
+        );
+      }
       throw error;
     }
 
@@ -99,6 +123,7 @@ export function createDesktopDiffHost(
   }
 
   async function dispose(): Promise<void> {
+    disposed = true;
     const tempDirs = [...externalPatchDirs];
     externalPatchDirs.clear();
     await Promise.all(

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -153,6 +153,10 @@ let reopenMainWindow: (() => void) | undefined;
 let pendingWorkspaceRelaunch:
   { selectedPath: string; args: string[] } | undefined;
 let continueQuitAfterWindowClose: (() => void) | undefined;
+// Set by the window's closed handler and awaited by the lifecycle shutdown
+// drain registered below, so recursive temp-dir removals finish before the
+// process exits instead of racing the quit flow.
+let pendingDesktopDiffHostDispose: Promise<void> | undefined;
 
 // Playwright relaunch tests need a deterministic Electron profile so
 // app-scoped stores survive across child processes. Normal desktop launches
@@ -1092,7 +1096,13 @@ function createWindow(options: {
     continueQuitAfterWindowClose = undefined;
     disposeWindowTitle();
     presentationAbort.abort();
-    void desktopDiffHost.dispose().catch(reportAsyncError);
+    // Not fire-and-forget: every quit path (window-all-closed on Windows and
+    // Linux, continueQuit, the workspace relaunch's app.quit()) reaches the
+    // before-quit handler, whose lifecycle drain awaits this promise before
+    // the final quit.
+    pendingDesktopDiffHostDispose = desktopDiffHost
+      .dispose()
+      .catch(reportAsyncError);
     executionsWatcher?.close();
     if (mainWindow === window) {
       mainWindow = null;
@@ -1213,6 +1223,13 @@ if (protocolLifecycle.shouldContinue) {
       // ON-phase language-service disposal.
       lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
         processSession.flushArtifacts(),
+      );
+      // The window's closed handler starts diff temp-dir removal before the
+      // quit lifecycle drains; awaiting it here keeps the process alive until
+      // the directories are actually gone.
+      lifecycle.onShutdown(
+        SHUTDOWN_PHASE.BEFORE,
+        () => pendingDesktopDiffHostDispose,
       );
       lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => {
         disposeAgentResumeHandler();

--- a/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
@@ -1,6 +1,7 @@
 // Standard library imports
-import { existsSync } from 'node:fs';
-import { readFile, writeFile } from 'node:fs/promises';
+import { existsSync, readdirSync } from 'node:fs';
+import { readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 // Third-party imports
@@ -9,6 +10,15 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 // Local imports - test support
 import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 import { loadSourceModule } from './loadSourceModule.ts';
+
+// `rm` keeps its real implementation by default; tests arm one-shot failures
+// with mockRejectedValueOnce to exercise the cleanup-retry path. The source
+// module observes the same mock because loadSourceModule imports it through
+// Vitest's module runner.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...original, rm: vi.fn(original.rm) };
+});
 
 type DesktopDiffHostModule = typeof import('@desktop/main/desktopDiffHost');
 type DiffHostOptions = Parameters<
@@ -48,12 +58,13 @@ afterEach(async () => {
   await cleanupTempDirs(tempDirs);
 });
 
-async function openDiffPair(
-  host: DiffHost,
-  title: string,
+type OpenDiffArgs = Parameters<DiffHost['openDiff']>;
+type OpenDiffSources = [OpenDiffArgs[0], OpenDiffArgs[1]];
+
+async function prepareDiffPair(
   names: [string, string] = ['a.tex', 'b.tex'],
   texts: [string, string] = ['a\n', 'b\n'],
-): Promise<void> {
+): Promise<OpenDiffSources> {
   const tempDir = await makeTempDir('texra-diff-host-test-', tempDirs);
   const originalPath = path.join(tempDir, names[0]);
   const proposedPath = path.join(tempDir, names[1]);
@@ -61,11 +72,24 @@ async function openDiffPair(
     writeFile(originalPath, texts[0], 'utf8'),
     writeFile(proposedPath, texts[1], 'utf8'),
   ]);
-  await host.openDiff(
-    { filePath: originalPath },
-    { filePath: proposedPath },
-    title,
-  );
+  return [{ filePath: originalPath }, { filePath: proposedPath }];
+}
+
+async function openDiffPair(
+  host: DiffHost,
+  title: string,
+  names: [string, string] = ['a.tex', 'b.tex'],
+  texts: [string, string] = ['a\n', 'b\n'],
+): Promise<void> {
+  const [original, proposed] = await prepareDiffPair(names, texts);
+  await host.openDiff(original, proposed, title);
+}
+
+// Sorted so two snapshots compare equal when nothing was created or removed.
+function listDiffTempDirs(): string[] {
+  return readdirSync(tmpdir())
+    .filter((entry) => entry.startsWith('texra-desktop-diff-'))
+    .sort();
 }
 
 describe('createDesktopDiffHost', () => {
@@ -182,5 +206,63 @@ describe('createDesktopDiffHost', () => {
     await host.dispose();
 
     expect(existsSync(diffDir)).toBe(false);
+  });
+
+  it('removes the patch directory immediately when the editor fails to open', async () => {
+    const failure = new Error('editor unavailable');
+    const { host, openPath } = createHost();
+    openPath.mockRejectedValue(failure);
+
+    // The original failure reaches the caller, not a cleanup artifact.
+    await expect(openDiffPair(host, 'Compare')).rejects.toBe(failure);
+
+    expect(openPath).toHaveBeenCalledTimes(1);
+    const diffDir = path.dirname(openPath.mock.calls[0][0]);
+    expect(path.basename(diffDir)).toMatch(/^texra-desktop-diff-/);
+    expect(existsSync(diffDir)).toBe(false);
+  });
+
+  it('keeps a failed immediate cleanup recorded so dispose() retries it', async () => {
+    // The one-shot rm rejection simulates an OS-level removal failure: the
+    // directory must stay recorded (and the failure logged) so the dispose
+    // at window close can retry it instead of leaking it untracked.
+    const consoleSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const { host, openPath } = createHost();
+    openPath.mockRejectedValue(new Error('editor unavailable'));
+    vi.mocked(rm).mockRejectedValueOnce(new Error('simulated removal failure'));
+
+    await expect(openDiffPair(host, 'Compare')).rejects.toThrow(
+      'editor unavailable',
+    );
+
+    const diffDir = path.dirname(openPath.mock.calls[0][0]);
+    expect(existsSync(diffDir)).toBe(true);
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+
+    await host.dispose();
+
+    expect(existsSync(diffDir)).toBe(false);
+    consoleSpy.mockRestore();
+  });
+
+  it('removes a fallback directory created after disposal instead of recording it', async () => {
+    // Destroyed-window-mid-fallback race: dispose() snapshots and clears the
+    // record set while this openDiff is still awaiting its reads, so the temp
+    // directory it creates afterwards must be removed immediately rather than
+    // recorded, where nothing would ever remove it.
+    const { host, openPath } = createHost();
+    const [original, proposed] = await prepareDiffPair();
+    const diffDirsBefore = listDiffTempDirs();
+
+    const openPromise = host.openDiff(original, proposed, 'Compare');
+    await host.dispose();
+
+    await expect(openPromise).rejects.toThrow(
+      'Desktop window closed before the diff could be opened.',
+    );
+    expect(openPath).not.toHaveBeenCalled();
+    expect(listDiffTempDirs()).toEqual(diffDirsBefore);
   });
 });


### PR DESCRIPTION
Follow-ups to #10365, one commit covering four review follow-up issues about `DesktopDiffHost` cleanup.

## Changes

- **#10390 — disposal race guard.** `dispose()` now sets a `disposed` flag at its start, and `openDiff` checks it right after `createTexraTempDir` resolves. A fallback whose window closed mid-flight removes its just-created `texra-desktop-diff-*` directory immediately and throws (`Desktop window closed before the diff could be opened.`) instead of recording it in an already-drained set where nothing would remove it.
- **#10391 — awaited quit cleanup.** The window `closed` handler stores the dispose promise in a module-scope slot instead of `void`-ing it, and a `SHUTDOWN_PHASE.BEFORE` lifecycle handler returns that slot, so the `before-quit` drain (reached by `window-all-closed` on Windows/Linux, `continueQuitAfterWindowClose`, and the workspace relaunch's `app.quit()`) awaits the recursive removals before the final quit.
- **#10392 — retryable error-path cleanup.** The fallback error path now deletes the temp dir from the record set only after `rm` succeeds; a failed removal stays recorded for `dispose()` to retry and is logged via `console.warn` (desktop main convention) before the original error is rethrown.
- **#10393 — changelog wording.** The desktop bug-fix entry now says viewing a diff in an external editor "no longer leaves temporary files behind after the window closes" — user-visible effect only, no internal directory name.

## Tests

Extended `src/test-kernel/desktop/DesktopDiffHost.vitest.ts` along its existing patterns:

- `removes the patch directory immediately when the editor fails to open` — `openPath` rejects; the original error propagates (`rejects.toBe(failure)`) and the `texra-desktop-diff-` directory is gone.
- `keeps a failed immediate cleanup recorded so dispose() retries it` — arms a one-shot `rm` rejection via a passthrough `vi.mock('node:fs/promises')` wrapper; the directory survives, the warn fires once, and a later `dispose()` removes it.
- `removes a fallback directory created after disposal instead of recording it` — starts `openDiff`, disposes mid-flight, and asserts rejection, no `openPath` call, and no new `texra-desktop-diff-` entries in the OS temp dir.

Mutation check: with `desktopDiffHost.ts` reverted to `origin/main`, the retry and disposal-race tests fail (the immediate-cleanup test pins behavior the old code already had).

## Validation

- `npm run typecheck` — clean (workspace, test-kernel, agent, cli, trace-viewer, desktop)
- Targeted eslint on the three changed TS files — clean
- `npx vitest run src/test-kernel/desktop/` — 59 files / 587 tests passed
- `npx prettier --check` on changed files — clean

Closes #10390
Closes #10391
Closes #10392
Closes #10393