### PR TITLE
ci: polish remote-agents env targeting and preflight classification

### DIFF
--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -589,6 +589,8 @@ npm run sync:remote-agents -- --apply
 
 Needs a `supabase link`ed checkout, or `SUPABASE_DB_URL`, or `SUPABASE_ACCESS_TOKEN` plus `SUPABASE_PROJECT_REF`. With `SUPABASE_PROJECT_REF` the script passes that ref to the CLI through `SUPABASE_PROJECT_ID`, leaving the checkout's linked project untouched.
 
+`--apply` requires Supabase CLI **v2.79.0 or newer**: v2.79.0 added `supabase db query`, whose `--linked` mode resolves the target project from `SUPABASE_PROJECT_ID` before the checkout's link file. A CLI too old to honor `SUPABASE_PROJECT_ID` would silently run against the checkout's linked project instead of `SUPABASE_PROJECT_REF`. Check your local version with `supabase --version`; CI pins 2.106.0 (`.github/workflows/remote-agents-sync.yml`).
+
 Before writing any metadata, `--apply` verifies that every catalog `storage_path` already exists as an object in the `agent-configs` bucket; if any are missing it aborts and lists them, and no metadata is published. The preflight checks object existence, not freshness, so a green preflight does not prove the uploaded bodies are current. YAML bodies are still uploaded separately from metadata, so upload new, moved, or changed agents **before** applying (or before merging to `main`):
 
 ```bash

--- a/scripts/sync-remote-agents.mjs
+++ b/scripts/sync-remote-agents.mjs
@@ -403,10 +403,6 @@ function runSupabaseQuery(args, options = {}) {
   return { status: result.status ?? 1, output };
 }
 
-function isMissingStoragePreflightFailure(output) {
-  return output.includes(STORAGE_PREFLIGHT_MISSING_MARKER);
-}
-
 function applyRemoteAgentsSql() {
   const dbUrl = process.env.SUPABASE_DB_URL;
   const projectRef = process.env.SUPABASE_PROJECT_REF;
@@ -422,14 +418,21 @@ function applyRemoteAgentsSql() {
       // supabase/.temp/project-ref unless SUPABASE_PROJECT_ID is set. Pass the
       // requested ref through that env var instead of rewriting the checkout's
       // link file, so there is nothing to restore even if the process is
-      // killed mid-query (#10316, #10329).
-      queryEnv.SUPABASE_PROJECT_ID = projectRef;
+      // killed mid-query (#10316, #10329). The CLI trims the link file but
+      // validates the env var as-is, so normalize padding here (#10408).
+      queryEnv.SUPABASE_PROJECT_ID = projectRef.trim();
     } else if (!existsSync(projectRefFile)) {
       console.error(
         'sync-remote-agents: set SUPABASE_DB_URL or SUPABASE_PROJECT_REF, ' +
           'or run `supabase link` in this checkout.',
       );
       return 1;
+    } else {
+      // Falling back to the checkout's link file: the CLI ranks
+      // SUPABASE_PROJECT_ID above supabase/.temp/project-ref, so scrub any
+      // ambient value from the inherited env to keep the link file
+      // authoritative (#10407). spawnSync drops env keys set to undefined.
+      queryEnv.SUPABASE_PROJECT_ID = undefined;
     }
     args.push('--linked');
   }
@@ -446,7 +449,21 @@ function applyRemoteAgentsSql() {
         env: queryEnv,
       });
       if (preflight.status !== 0) {
-        if (isMissingStoragePreflightFailure(preflight.output)) {
+        // The marker text is embedded verbatim in the generated SQL (it is
+        // the RAISE string literal), so a bare substring match over the
+        // combined output could fire on an echoed query instead of the
+        // raised exception. Only classify when the marker appears on a line
+        // that also carries the Postgres ERROR: severity prefix, which is
+        // how both the pgx path and the Management API report the RAISE
+        // (#10409).
+        const raisedMissingStorage = preflight.output
+          .split('\n')
+          .some(
+            (line) =>
+              line.includes('ERROR:') &&
+              line.includes(STORAGE_PREFLIGHT_MISSING_MARKER),
+          );
+        if (raisedMissingStorage) {
           console.error(
             'sync-remote-agents: Storage preflight failed; catalog metadata was NOT applied. ' +
               'Upload the missing YAML prompt bodies to the agent-configs bucket ' +

--- a/src/test-kernel/scripts/SyncRemoteAgents.vitest.ts
+++ b/src/test-kernel/scripts/SyncRemoteAgents.vitest.ts
@@ -121,8 +121,12 @@ function readStubSql(root: string, filename: string) {
     throw new Error(`Stub log does not contain sql-file: ${filename}`);
   }
   const contentStart = start + marker.length;
-  const nextMarker = log.indexOf('\nsql-file: ', contentStart);
-  const end = nextMarker === -1 ? log.length : nextMarker + 1;
+  // Each stub invocation logs its args:/observed-* lines before the sql-file
+  // body, so the next '\nargs: ' marks the end of this file's SQL. Slicing
+  // there keeps the following invocation's log lines out of the result
+  // (#10411).
+  const nextInvocation = log.indexOf('\nargs: ', contentStart);
+  const end = nextInvocation === -1 ? log.length : nextInvocation;
   return log.slice(contentStart, end);
 }
 
@@ -159,11 +163,39 @@ describe.skipIf(process.platform === 'win32')(
         });
 
         expect(result.status, result.stderr).toBe(0);
+        const log = readStubLog(root);
         // The CLI was pointed at proj-b without rewriting the checkout file.
-        expect(readStubLog(root)).toContain('observed-project-id: proj-b');
-        expect(readStubLog(root)).toContain('observed-ref: proj-a');
+        expect(log).toContain('observed-project-id: proj-b');
+        expect(log).toContain('observed-ref: proj-a');
+        // SUPABASE_PROJECT_ID only steers the CLI in combination with
+        // --linked; without the flag the CLI would silently fall back to
+        // --local (#10412).
+        const invocations = log
+          .split('\n')
+          .filter((line) => line.startsWith('args:'));
+        expect(invocations).toHaveLength(2);
+        for (const invocation of invocations) {
+          expect(invocation).toContain('--linked');
+        }
         expect(readFileSync(projectRefPath(root), 'utf8')).toBe('proj-a\n');
         expect(result.stderr).not.toContain('substituting');
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('trims SUPABASE_PROJECT_REF before passing it through as SUPABASE_PROJECT_ID', () => {
+      const root = createFixtureCheckout('proj-a');
+      try {
+        const result = runSync(root, ['--apply'], {
+          SUPABASE_PROJECT_REF: '  proj-b  ',
+        });
+
+        expect(result.status, result.stderr).toBe(0);
+        // The CLI validates the env var without trimming, so the script must
+        // hand it the unpadded ref (#10408).
+        expect(readStubLog(root)).toContain('observed-project-id: proj-b\n');
+        expect(readFileSync(projectRefPath(root), 'utf8')).toBe('proj-a\n');
       } finally {
         rmSync(root, { recursive: true, force: true });
       }
@@ -177,9 +209,39 @@ describe.skipIf(process.platform === 'win32')(
         });
 
         expect(result.status, result.stderr).toBe(0);
-        expect(readStubLog(root)).toContain('observed-project-id: proj-b');
+        const log = readStubLog(root);
+        expect(log).toContain('observed-project-id: proj-b');
+        // The ref file was absent *while the CLI ran*, not just afterwards:
+        // the post-run existsSync checks alone would also pass if the file
+        // were created and then cleaned up mid-run (#10412).
+        expect(log).toContain('observed-ref: <absent>');
+        const invocations = log
+          .split('\n')
+          .filter((line) => line.startsWith('args:'));
+        expect(invocations).toHaveLength(2);
+        for (const invocation of invocations) {
+          expect(invocation).toContain('--linked');
+        }
         expect(existsSync(projectRefPath(root))).toBe(false);
         expect(existsSync(join(root, 'supabase/.temp'))).toBe(false);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('scrubs an ambient SUPABASE_PROJECT_ID when falling back to the linked checkout', () => {
+      const root = createFixtureCheckout('proj-a');
+      try {
+        const result = runSync(root, ['--apply'], {
+          SUPABASE_PROJECT_ID: 'proj-ambient',
+        });
+
+        expect(result.status, result.stderr).toBe(0);
+        // The CLI ranks SUPABASE_PROJECT_ID above the link file, so the
+        // script must hide the ambient value from the spawned CLI to keep
+        // the checkout's linked project authoritative (#10407).
+        expect(readStubLog(root)).toContain('observed-project-id: <absent>');
+        expect(readStubLog(root)).toContain('observed-ref: proj-a');
       } finally {
         rmSync(root, { recursive: true, force: true });
       }
@@ -233,6 +295,10 @@ describe.skipIf(process.platform === 'win32')(
         expect(preflightSql).toContain('storage.objects');
         expect(preflightSql).toContain("bucket_id = 'agent-configs'");
         expect(preflightSql).toContain('researcher/apply.yaml');
+        // The slice stops at the apply invocation: only the SQL body, ending
+        // with the preflight's final line, no trailing stub-log lines.
+        expect(preflightSql).not.toContain('observed-');
+        expect(preflightSql.endsWith('$$;\n')).toBe(true);
       } finally {
         rmSync(root, { recursive: true, force: true });
       }
@@ -245,9 +311,9 @@ describe.skipIf(process.platform === 'win32')(
           SUPABASE_PROJECT_REF: 'proj-b',
           TEXRA_STUB_FAIL: 'preflight',
           TEXRA_STUB_FAIL_OUTPUT:
-            'sync-remote-agents: 1 catalog storage path(s) missing from the agent-configs bucket: ' +
+            'ERROR: sync-remote-agents: 1 catalog storage path(s) missing from the agent-configs bucket: ' +
             'researcher/apply.yaml. Upload the YAML prompt bodies first ' +
-            '(docs/supabase/SUPABASE_SETUP.md, Part 7).',
+            '(docs/supabase/SUPABASE_SETUP.md, Part 7). (SQLSTATE P0001)',
         });
 
         expect(result.status).toBe(1);
@@ -263,6 +329,38 @@ describe.skipIf(process.platform === 'win32')(
         expect(invocations[0]).toContain('remote-agents-preflight.sql');
         // The failed run still left the checkout's link state untouched.
         expect(readFileSync(projectRefPath(root), 'utf8')).toBe('proj-a\n');
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('ignores the marker text when no ERROR: line carries it', () => {
+      const root = createFixtureCheckout('proj-a');
+      try {
+        const result = runSync(root, ['--apply'], {
+          SUPABASE_PROJECT_REF: 'proj-b',
+          TEXRA_STUB_FAIL: 'preflight',
+          // A non-RAISE failure whose output echoes the submitted SQL: the
+          // marker appears verbatim in the RAISE source line but no
+          // ERROR:-prefixed line carries it, so this is not the
+          // missing-storage case and must not print upload guidance
+          // (#10409).
+          TEXRA_STUB_FAIL_OUTPUT:
+            'ERROR: connection to server at "db.proj-b.supabase.co" failed: Connection refused\n' +
+            "query context:     RAISE EXCEPTION 'sync-remote-agents: % catalog storage path(s) missing from the agent-configs bucket: %. " +
+            "Upload the YAML prompt bodies first (docs/supabase/SUPABASE_SETUP.md, Part 7).',",
+        });
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('Storage preflight failed');
+        expect(result.stderr).not.toContain(
+          'Upload the missing YAML prompt bodies to the agent-configs bucket',
+        );
+        const invocations = readStubLog(root)
+          .split('\n')
+          .filter((line) => line.startsWith('args:'));
+        expect(invocations).toHaveLength(1);
+        expect(invocations[0]).toContain('remote-agents-preflight.sql');
       } finally {
         rmSync(root, { recursive: true, force: true });
       }


### PR DESCRIPTION
Follow-up batch to #10373 for the remote-agents `--apply` path, its stub-harness tests, and the setup docs.

- #10407: when neither `SUPABASE_DB_URL` nor `SUPABASE_PROJECT_REF` is set, `--apply` falls back to the checkout's `supabase link` state — but the spawned CLI inherited an ambient `SUPABASE_PROJECT_ID`, which the CLI ranks above `supabase/.temp/project-ref`, silently retargeting the run. The linked-checkout branch now scrubs it from the child env (`spawnSync` drops env keys set to `undefined`), pinned by a test that sets the var in the parent env and asserts the stub observes `<absent>`.
- #10408: `SUPABASE_PROJECT_REF` is now trimmed before being passed through as `SUPABASE_PROJECT_ID`. The old path wrote the ref to the link file, which the CLI trims; the env var is validated (`^[a-z]{20}$`) without trimming, so a padded ref that used to work now failed. Pinned with a padded-ref test asserting the stub observes the trimmed value.
- #10409: the missing-storage classifier no longer substring-matches the combined output. The marker text is embedded verbatim in the generated SQL (it is the `RAISE EXCEPTION` literal), so an echoed query could be misdiagnosed as missing storage. Verified at the pinned CLI (2.106.0) that `db query -f` never echoes the submitted SQL on failure (`RunLinked` prints `unexpected status <code>: <api body>`; the pgx path prints the wrapped pg error), and that both report the RAISE with the Postgres `ERROR:` severity prefix on the message line (pg-meta's `formattedError` is `ERROR:  <code>: <message>`). The classifier now requires the marker on a line that also carries `ERROR:`; pinned by a stub-output test whose marker appears only on an echoed (non-`ERROR:`) line.
- #10410: `isMissingStoragePreflightFailure` (single call site) is inlined at the preflight error branch; `STORAGE_PREFLIGHT_MISSING_MARKER` stays, still in sync with `buildStoragePreflightSql`.
- #10411: `readStubSql` ends its slice at the next invocation's `args:` line instead of the next `sql-file:` marker, so it returns only the SQL body (previously it trailed the following invocation's `args:`/`observed-*` lines). Added exact-boundary assertions (`not.toContain('observed-')`, ends with `$$;\n`).
- #10412: the env-targeting tests now assert every captured stub invocation includes `--linked` (the env var only steers the CLI in combination with the flag), and the no-link-state test asserts `observed-ref: <absent>` in the stub log, proving the ref file was absent mid-run rather than cleaned up afterwards.
- #10413: SUPABASE_SETUP.md Part 7 now states the minimum CLI version: **v2.79.0** — the release that added `supabase db query` (supabase/cli#4955), whose `--linked` mode has resolved `SUPABASE_PROJECT_ID` ahead of the link file from day one (env-var support itself dates to v1.111.0). CI pins 2.106.0.

Validation:
- `npm run typecheck` passes.
- `npx eslint src/test-kernel/scripts/SyncRemoteAgents.vitest.ts` passes (root `scripts/*.mjs` are outside the `npm run lint` scope).
- `npx vitest run src/test-kernel/scripts/` passes (77 tests; SyncRemoteAgents 10 → 13).
- `npx prettier --check` passes on all changed files.
- `node scripts/sync-remote-agents.mjs` output is byte-identical to the pre-change generated SQL (16211 bytes, diffed against `origin/main`'s script run over the same YAML).
- Mutation check: the three new behavior tests (trim, ambient scrub, `ERROR:`-line anchor) fail against `origin/main`'s script and pass against this one.

Closes #10407
Closes #10408
Closes #10409
Closes #10410
Closes #10411
Closes #10412
Closes #10413
