### PR TITLE
fix(ui): keep max-style KaTeX macros from shadowing KaTeX built-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ All notable changes to this project will be documented in this file.
 - **Every max-style shortcut now resolves in the progress view** — math
   operators, text labels, mathcal/mathbb letters, and tilde/hat/
   differential shortcuts render as intended instead of unknown commands.
+- **Max-style shortcuts no longer shadow KaTeX built-ins** — the section
+  sign and the legacy bold switch render as intended, `\label` no longer
+  errors in rendered math, and decorated-H effective-Hamiltonian plus
+  equilibrium/steady-state forms compact to their intended shortcuts.
 
 #### Features
 

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -83,7 +83,7 @@ const MAX_AUTO_PATTERNS: Record<string, string> = (() => {
   // prettier-ignore
   const symbolOperators = [
       'infty', 'top',
-      'N', 'M', 'S',
+      'N', 'M',
       '0','1','2',
       'tit', 'wtit', 'tif', 'ttf', 'ttauf', 'tze', 'tzero', 'tone', 'tauf', 'tf', 'ttau', 'tau',
       'bu', 'ta'
@@ -130,7 +130,10 @@ const MAX_AUTO_PATTERNS: Record<string, string> = (() => {
   // Math font letter sets
   const upperLetters = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'];
   const mathbbLetters = [...'CEINPQRTV'];
-  const lowerLetters = [...'abcdefghjnpqrsuvwxyz'];
+  // 'f' stays out of lowerLetters: the MANUAL '\mathbf{f}' -> '\bbf'
+  // special case keeps '\bf' (KaTeX's legacy bold switch) out of max-style
+  // output.
+  const lowerLetters = [...'abcdeghjnpqrsuvwxyz'];
   const mathbfUpperLetters = [...'ABCDEFGIJKMQRUVWXYZ'];
   const alphabetLetters = [
     ...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
@@ -165,6 +168,17 @@ const MAX_AUTO_PATTERNS: Record<string, string> = (() => {
       [`_\\op`, `_{\\${op}}`],
       [`^\\op`, `^{\\${op}}`],
     ]),
+    // Combined eq/st shortcuts: keep these before the textCommands block so
+    // the AUTO \text{eq} -> \eq / \text{st} -> \st rules cannot consume
+    // the fragment first (same shadowing class as \mathcal{H}^{\text{eff}}).
+    'p^{\\text{eq}}': '\\peq',
+    'q^{\\text{eq}}': '\\qeq',
+    'p^{\\text{st}}': '\\pst',
+    'q^{\\text{st}}': '\\qst',
+    '\\rho^{\\text{eq}}': '\\rhoeq',
+    '\\rho_{\\text{eq}}': '\\rhoeq',
+    '\\rho^{\\text{st}}': '\\rhost',
+    '\\rho_{\\text{st}}': '\\rhost',
     // Text Commands: \text{cmd} -> \cmd
     ...createPatterns(textCommands, (cmd) => [
       [`\\text{${cmd}}`, `\\${cmd}`],
@@ -182,6 +196,10 @@ const MAX_AUTO_PATTERNS: Record<string, string> = (() => {
       [`_{\\${op}}`, `_\\${op}`],
       [`^{\\${op}}`, `^\\${op}`],
     ]),
+    // '\S' is KaTeX's built-in section sign, so the plain-S shortcut lands
+    // on the non-conflicting '\sS' destination instead of '_\S'/'^\S'.
+    '_{\\S}': '_\\sS',
+    '^{\\S}': '^\\sS',
     ...generateDifferentialSpacing(differentialVariables, '~'),
     ...createPatterns(fractionDiffVariables, (variable) => [
       // Handle cases like {dx} -> {\\dd x}
@@ -208,9 +226,15 @@ const MAX_AUTO_PATTERNS: Record<string, string> = (() => {
       ],
     ]),
     ...generateCommandShortcuts(GREEK_LETTER_SHORTCUTS),
-    // Combined shortcut: keep this before the \mathcal and effH component rules so
-    // \mathcal{H}^{\text{eff}} reaches \ceffH at runtime.
+    // Combined shortcuts: keep these before the \mathcal, \hat, and effH
+    // component rules so the decorated-H combinations are not consumed
+    // piecemeal first (AUTO \hat{H} -> \hH would otherwise turn
+    // \hat{H}^{\text{eff}} into \hH^{\text{eff}} and the effH rule would
+    // then fire inside it, corrupting to \h\effH).
     '\\mathcal{H}^{\\text{eff}}': '\\ceffH',
+    '\\cH^{\\text{eff}}': '\\ceffH',
+    '\\hat{H}^{\\text{eff}}': '\\hat{\\effH}',
+    '\\hH^{\\text{eff}}': '\\hat{\\effH}',
     // Mathcal: \mathcal{X} -> \cX
     ...generateDecoratorShortcuts('mathcal', upperLetters, 'c'),
     // Mathbb: \mathbb{X} -> \eX
@@ -345,10 +369,6 @@ const MAX_MANUAL_PATTERNS: Record<string, string> = {
 
   // Physics and Statistical Mechanics
   'H^{\\text{eff}}': '\\effH',
-  'p^{\\text{eq}}': '\\peq',
-  'q^{\\text{eq}}': '\\qeq',
-  'p^{\\text{st}}': '\\pst',
-  'q^{\\text{st}}': '\\qst',
   'p^{\\text{ss}}': '\\pst',
   'q^{\\text{ss}}': '\\qst',
 
@@ -376,13 +396,9 @@ const MAX_MANUAL_PATTERNS: Record<string, string> = {
   '\\tau_f': '\\tauf',
 
   // Equilibrium and steady state notation
-  '\\rho^{\\text{eq}}': '\\rhoeq',
-  '\\rho^{\\text{st}}': '\\rhost',
   '\\rho^{\\text{ss}}': '\\rhost',
   '\\rho^{\\text{sst}}': '\\rhost',
-  '\\rho_{\\text{eq}}': '\\rhoeq',
   '\\rho_{\\text{ss}}': '\\rhost',
-  '\\rho_{\\text{st}}': '\\rhost',
   '\\rho_{\\text{sst}}': '\\rhost',
   '{\\text{ss}}': '{\\text{st}}',
   '{\\text{sst}}': '{\\text{st}}',

--- a/src/shared/markdown/katexMacros.ts
+++ b/src/shared/markdown/katexMacros.ts
@@ -42,7 +42,8 @@ export const katexMacros = {
   // Single-letter shortcut variables
   '\\M': 'M',
   '\\N': 'N',
-  '\\S': 'S',
+  // '\S' would override KaTeX's built-in section sign, so S uses '\sS'.
+  '\\sS': 'S',
   '\\t': 't',
   '\\x': 'x',
   // Common math operators
@@ -138,7 +139,10 @@ export const katexMacros = {
   '\\bc': '\\mathbf{c}',
   '\\bd': '\\mathbf{d}',
   '\\be': '\\mathbf{e}',
-  '\\bf': '\\mathbf{f}',
+  // Keep '\bf' off: as a settings macro it overrides KaTeX's legacy bold
+  // switch globally (`{\bf x}` would expand to `\mathbf{f}x`). Max-style
+  // never emits '\bf'; bold f goes through '\bbf' below.
+  // '\\bf': '\\mathbf{f}',
   '\\bg': '\\mathbf{g}',
   '\\bh': '\\mathbf{h}',
   '\\bj': '\\mathbf{j}',
@@ -345,4 +349,13 @@ export const katexMacros = {
   '\\argmin': '\\operatorname{argmin}',
   '\\argsort': '\\operatorname{argsort}',
   '\\sort': '\\operatorname{sort}',
+
+  // Manuscript structure
+  // KaTeX has no '\label' function; consume the argument and emit nothing
+  // so the max-style '\label{eqn:}' destination renders like LaTeX (labels
+  // produce no visible output) instead of erroring as an unknown command.
+  '\\label': (context: { consumeArg: () => unknown }) => {
+    context.consumeArg();
+    return '';
+  },
 };

--- a/src/test-kernel/shared/KatexMacroDrift.vitest.ts
+++ b/src/test-kernel/shared/KatexMacroDrift.vitest.ts
@@ -57,9 +57,9 @@ const MAX_ONLY_SHORTCUTS = [
   '\\beta',
   '\\cref',
   '\\frac',
+  '\\hat',
   '\\infty',
   '\\int',
-  '\\label',
   '\\log',
   '\\mathbf',
   '\\mathcal',
@@ -85,7 +85,6 @@ const RUNTIME_ONLY_SHORTCUTS = [
   '\\hat',
   '\\infty',
   '\\int',
-  '\\label',
   '\\log',
   '\\mathbf',
   '\\mathcal',
@@ -161,6 +160,71 @@ describe('katexMacros vs maxRules shortcuts', () => {
     expect(
       applyReplacements('\\boldsymbol{\\varphi}', MAX_STYLE_REPLACEMENTS),
     ).toBe('\\bvphi');
+  });
+
+  it('keeps KaTeX built-ins out of the macro table', () => {
+    // '\S' (section sign) and '\bf' (legacy bold switch) are KaTeX
+    // built-ins; as settings macros they would override the built-ins on
+    // every rendering surface, not just max-style output.
+    expect(Object.hasOwn(katexMacros, '\\S')).toBe(false);
+    expect(Object.hasOwn(katexMacros, '\\bf')).toBe(false);
+    expect(Object.hasOwn(katexMacros, '\\sS')).toBe(true);
+    expect(Object.hasOwn(katexMacros, '\\bbf')).toBe(true);
+    const { patterns } = MAX_STYLE_REPLACEMENTS;
+    expect(patterns['_{\\S}']).toBe('_\\sS');
+    expect(patterns['^{\\S}']).toBe('^\\sS');
+    expect(patterns['\\mathbf{f}']).toBe('\\bbf');
+  });
+
+  it('maps built-in-colliding sources to safe destinations at runtime', () => {
+    expect(applyReplacements('_{\\S}', MAX_STYLE_REPLACEMENTS)).toBe('_\\sS');
+    expect(applyReplacements('^{\\S}', MAX_STYLE_REPLACEMENTS)).toBe('^\\sS');
+    expect(applyReplacements('\\mathbf{f}', MAX_STYLE_REPLACEMENTS)).toBe(
+      '\\bbf',
+    );
+    expect(applyReplacements('{\\bf f}', MAX_STYLE_REPLACEMENTS)).toBe('\\bbf');
+  });
+
+  it('keeps decorated-H eff combinations intact at runtime', () => {
+    expect(
+      applyReplacements('\\mathcal{H}^{\\text{eff}}', MAX_STYLE_REPLACEMENTS),
+    ).toBe('\\ceffH');
+    expect(
+      applyReplacements('\\cH^{\\text{eff}}', MAX_STYLE_REPLACEMENTS),
+    ).toBe('\\ceffH');
+    expect(
+      applyReplacements('\\hat{H}^{\\text{eff}}', MAX_STYLE_REPLACEMENTS),
+    ).toBe('\\hat{\\effH}');
+    expect(
+      applyReplacements('\\hH^{\\text{eff}}', MAX_STYLE_REPLACEMENTS),
+    ).toBe('\\hat{\\effH}');
+  });
+
+  it('fires the eq/st compaction family at runtime', () => {
+    expect(applyReplacements('p^{\\text{eq}}', MAX_STYLE_REPLACEMENTS)).toBe(
+      '\\peq',
+    );
+    expect(applyReplacements('q^{\\text{eq}}', MAX_STYLE_REPLACEMENTS)).toBe(
+      '\\qeq',
+    );
+    expect(applyReplacements('p^{\\text{st}}', MAX_STYLE_REPLACEMENTS)).toBe(
+      '\\pst',
+    );
+    expect(applyReplacements('q^{\\text{st}}', MAX_STYLE_REPLACEMENTS)).toBe(
+      '\\qst',
+    );
+    expect(
+      applyReplacements('\\rho^{\\text{eq}}', MAX_STYLE_REPLACEMENTS),
+    ).toBe('\\rhoeq');
+    expect(
+      applyReplacements('\\rho_{\\text{eq}}', MAX_STYLE_REPLACEMENTS),
+    ).toBe('\\rhoeq');
+    expect(
+      applyReplacements('\\rho^{\\text{st}}', MAX_STYLE_REPLACEMENTS),
+    ).toBe('\\rhost');
+    expect(
+      applyReplacements('\\rho_{\\text{st}}', MAX_STYLE_REPLACEMENTS),
+    ).toBe('\\rhost');
   });
 
   it('keeps runtime max-style output resolvable by the renderer macros', () => {


### PR DESCRIPTION
Follow-ups to #10384, one commit covering the five KaTeX-macro review findings.

## Per-issue changes

- **#10416 (`\S` vs section sign)** — the plain-S shortcut destination moves from `\S` (KaTeX's built-in §) to the non-conflicting `\sS`: `_{\S}`/`^{\S}` now compact to `_\sS`/`^\sS` in `maxRules.ts`, and the macro table defines `\sS` instead of `\S`. `\text{\S}` renders § again on every surface.
- **#10417 (`\bf` vs legacy bold switch)** — per the reviewer's preferred fix: `f` is dropped from `lowerLetters` so the MANUAL `\mathbf{f}` → `\bbf` special case fires as intended (also fixing `{\bf f}` → `\bbf`), the `\\bf` → `\bf` backslash-fix destination disappears, and the `\bf` macro is commented out again with the rationale recorded. `{\bf x}` and `\text{\bf x}` now use KaTeX's built-in legacy switch. `\be` stays: it has no KaTeX built-in collision and `\mathbf{e}` → `\be` is genuine max-style output.
- **#10418 (decorated-H eff corruption)** — combined rules hoisted ahead of the component rules, same pattern as `\mathcal{H}^{\text{eff}}`: `\cH^{\text{eff}}` → `\ceffH`, and `\hat{H}^{\text{eff}}` / pre-shortened `\hH^{\text{eff}}` → `\hat{\effH}` (the form the reviewer suggested). No more `\c\effH`/`\h\effH` unknown commands.
- **#10419 (`p^{\text{eq}}` family shadowed)** — the eight `^{\text{eq}}`/`^{\text{st}}`/`_{\text{eq}}`/`_{\text{st}}` compaction patterns for `p`/`q`/`\rho` move from MANUAL into `MAX_AUTO_PATTERNS` ahead of the `textCommands` block, so AUTO `\text{eq}` → `\eq` can no longer consume the fragment first. The `\text{ss}`/`\text{sst}` variants stay in MANUAL (`ss`/`sst` are not in `textCommands`, they already fire).
- **#10420 (`\label` unresolvable)** — `\label` is now a function macro that consumes its argument and emits nothing, mirroring LaTeX (labels produce no visible output); `$$E=mc^2 \label{eqn:e}$$` renders without the error-coloured unknown command. `\label` leaves `MAX_ONLY_SHORTCUTS`/`RUNTIME_ONLY_SHORTCUTS` since it is now genuinely resolvable rather than an allowlisted gap. (`protectLatexReferences` was not extended: inside math its placeholder only survives in the MathML annotation, so protecting `\label` there would mangle the visible rendering.)

## Drift-test changes

- `\label` removed from both allowlists; `\hat` added to `MAX_ONLY_SHORTCUTS` (new static destination token from `\hat{\effH}`).
- New engine-level assertions mirroring the existing shadowing tests: built-ins stay out of the macro table, built-in-colliding sources map to safe destinations at runtime, decorated-H eff combinations stay intact at runtime, and the eq/st compaction family fires at runtime. All runtime token-resolution pins stay green.

## Validation

- `npm run typecheck` ✅
- targeted `eslint` on the three source files ✅
- `npx vitest run src/test-kernel/shared/KatexMacroDrift.vitest.ts` — 8/8 ✅
- `npx vitest run src/test-kernel/replacement/ReplacementRules.vitest.ts` — 65/65 ✅; `src/test-kernel/shared` + `src/test-kernel/progressView` — 880/880 ✅
- `npm run compile:fast` ✅
- `npx prettier --check` on changed files ✅

Closes #10416
Closes #10417
Closes #10418
Closes #10419
Closes #10420
