### PR TITLE
fix(agent): guard required-file names against fixed UserVars collisions

### DIFF
--- a/src/agent/core/definition/AgentCycleOptions.ts
+++ b/src/agent/core/definition/AgentCycleOptions.ts
@@ -96,6 +96,15 @@ export type UserVars = {
 export type TemplateVars = Partial<UserVars> & Record<string, unknown>;
 
 /**
+ * `buildUserVars`' product: the complete fixed {@link UserVars} vocabulary
+ * plus the agent-defined `requiredFilesInternal` `X_FILE`/`X_CONTENT` string
+ * pairs beside it. TypeScript has no index signature that excludes the fixed
+ * keys, so the custom keys are admitted as unknown — the same view
+ * {@link TemplateVars} gives render-boundary readers.
+ */
+export type BuiltUserVars = UserVars & Record<string, unknown>;
+
+/**
  * Runtime validators for the fixed {@link UserVars} keys. Known keys are
  * optional here because persisted checkpoints may have dropped variables; the
  * `satisfies` clause keeps this map in lockstep with the vocabulary. Custom

--- a/src/agent/prompt/userVars.ts
+++ b/src/agent/prompt/userVars.ts
@@ -8,7 +8,10 @@ import {
 } from '@agent/core/definition/AgentDataclass';
 import { userRequestTemplateCount } from '@agent/index/agentYamlScanner';
 import { shouldSaveModelIO } from '@agent/debug/debugMessageSaver';
-import type { UserVars } from '@agent/core/definition/AgentCycleOptions';
+import type {
+  BuiltUserVars,
+  UserVars,
+} from '@agent/core/definition/AgentCycleOptions';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { FileListEntry } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
@@ -113,6 +116,11 @@ type _UserVarsStayInRuntimeTokens = AssertNever<
   Exclude<keyof UserVars, (typeof USER_VAR_RUNTIME_TOKENS)[number]>
 >;
 
+/** Runtime view of the fixed vocabulary for the required-file collision guard. */
+const FIXED_USER_VAR_KEYS: ReadonlySet<string> = new Set(
+  USER_VAR_RUNTIME_TOKENS,
+);
+
 export function buildUserVarPassthrough(): Readonly<Record<string, string>> {
   return Object.freeze(
     Object.fromEntries(
@@ -180,7 +188,7 @@ export async function buildUserVars(
   providerFlags: ModelProviderFlags,
   logger: AgentTrace,
   options: BuildUserVarsOptions = {},
-): Promise<UserVars> {
+): Promise<BuiltUserVars> {
   // Parallelize independent I/O: required files, rules, and memories
   const [
     { vars: requiredVars, files: requiredFiles },
@@ -217,7 +225,9 @@ export async function buildUserVars(
 
   // Merge all variable sources using spread operator.
   // LATEX_STYLE_RULES is placed last to prevent silent overrides from spreads.
-  const userVars: UserVars = {
+  // The custom `requiredFilesInternal` keys ride beside the fixed vocabulary
+  // (BuiltUserVars) and reach templates through the channel boundary.
+  const userVars: BuiltUserVars = {
     ...getBasicVars(agentConfig, providerFlags, options),
     ...(await getFileVars(agentConfig, agentSetting, logger)),
     ...requiredVars,
@@ -379,9 +389,29 @@ async function getFileVars(
   agentSetting: AgentSetting,
   logger: AgentTrace,
 ): Promise<FileVars> {
-  // Filled incrementally in the loop below; every key is assigned on every
-  // path, either by `setVarFromFile` or by an explicit null/empty fallback.
-  const userVars = {} as FileVars;
+  // Compiler-checked completeness: every FileVars key starts at its
+  // empty-file default here, so a future FileVars key without a matching
+  // default is a type error at this literal. The loop below only overwrites
+  // the defaults, and a failed `setVarFromFile` leaves the null pair standing.
+  const userVars: FileVars = {
+    INPUT_FILE: null,
+    INPUT_CONTENT: null,
+    CONTEXT_FILE: null,
+    CONTEXT_CONTENT: null,
+    EDITED_FILE: null,
+    EDITED_CONTENT: null,
+    INPUT_FILES: [],
+    CONTEXT_FILES: [],
+    EDITED_FILES: [],
+    ALL_INPUTS: null,
+    ALL_CONTEXTS: null,
+    ALL_EDITEDS: null,
+    LIST_OF_ALL_INPUTS: '',
+    LIST_OF_ALL_CONTEXTS: '',
+    LIST_OF_ALL_EDITEDS: '',
+    MEDIA_FILE: null,
+    MEDIA_CONTENT: null,
+  };
 
   const contextFiles = getCategoryFiles(agentConfig, 'CONTEXT');
 
@@ -402,13 +432,8 @@ async function getFileVars(
         ? await getXmlFormatFromReadableFiles(allFiles)
         : { xml: null, readableFiles: [] };
     const primaryFile = readableFiles[0];
-
-    const loaded =
-      primaryFile != null &&
-      (await setVarFromFile(primaryFile, prefix, userVars));
-    if (!loaded) {
-      userVars[`${prefix}_FILE`] = null;
-      userVars[`${prefix}_CONTENT`] = null;
+    if (primaryFile != null) {
+      await setVarFromFile(primaryFile, prefix, userVars);
     }
 
     userVars[`ALL_${prefix}S`] = xml;
@@ -420,7 +445,6 @@ async function getFileVars(
 
   const mediaFiles = getCategoryFiles(agentConfig, 'MEDIA');
   userVars.MEDIA_FILE = mediaFiles[0] ?? null;
-  userVars.MEDIA_CONTENT = null;
 
   return userVars;
 }
@@ -467,6 +491,24 @@ async function logFileCategoriesWithExistence(
 }
 
 /**
+ * A required-file variable `X` generates the `X_FILE`/`X_CONTENT` pair, which
+ * `buildUserVars` spreads after the fixed variables — so a name like `MEDIA`
+ * would silently override the fixed `MEDIA_CONTENT: null`, and the persisted
+ * channel schema's `z.null()` validator would then reject checkpoints the
+ * application itself produced, making the session impossible to resume. Fail
+ * loudly when the variables are built instead.
+ */
+function assertNoFixedVarCollision(varName: string): void {
+  for (const generatedKey of [`${varName}_FILE`, `${varName}_CONTENT`]) {
+    if (FIXED_USER_VAR_KEYS.has(generatedKey)) {
+      throw new Error(
+        `requiredFilesInternal name "${varName}" generates "${generatedKey}", which collides with a fixed template variable. Rename the required-file variable.`,
+      );
+    }
+  }
+}
+
+/**
  * Load the files an agent bundles next to its YAML. Paths are resolved against
  * the agent's directory; an absolute path is used as written.
  */
@@ -482,6 +524,7 @@ async function getRequiredFileVars(
   )) {
     if (!filePath) continue;
 
+    assertNoFixedVarCollision(varName);
     const fullPath = path.resolve(agentPath, filePath);
     const ok = await setVarFromFile(fullPath, varName, vars, true);
     files.push({

--- a/src/test-kernel/agent/core/AgentCycleOptions.vitest.ts
+++ b/src/test-kernel/agent/core/AgentCycleOptions.vitest.ts
@@ -2,11 +2,16 @@
 import { strict as assert } from 'node:assert';
 
 // Third-party imports
-import { describe, it } from 'vitest';
+import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod';
 
 // Local imports
-import { UserVariableChannelsSchema } from '@agent/core/definition/AgentCycleOptions';
+import {
+  UserVariableChannelsSchema,
+  type BuiltUserVars,
+  type TemplateVars,
+  type UserVariableChannels,
+} from '@agent/core/definition/AgentCycleOptions';
 
 describe('UserVariableChannelsSchema', () => {
   it('validates known fixed keys while preserving custom keys', () => {
@@ -49,5 +54,26 @@ describe('UserVariableChannelsSchema', () => {
         }),
       z.ZodError,
     );
+  });
+
+  // A custom required file named MEDIA generates a string MEDIA_CONTENT;
+  // getRequiredFileVars rejects that name at variable-build time, and this
+  // boundary keeps rejecting such checkpoints.
+  it('rejects a string MEDIA_CONTENT — the collision shape the required-file guard prevents', () => {
+    assert.throws(
+      () =>
+        UserVariableChannelsSchema.parse({
+          input: {},
+          transient: { MEDIA_CONTENT: 'custom file content' },
+        }),
+      z.ZodError,
+    );
+  });
+
+  it('accepts the buildUserVars product at the channel boundary', () => {
+    expectTypeOf<BuiltUserVars>().toMatchTypeOf<TemplateVars>();
+    expectTypeOf<BuiltUserVars>().toMatchTypeOf<
+      UserVariableChannels['input']
+    >();
   });
 });

--- a/src/test-kernel/agent/prompt/userVars.vitest.ts
+++ b/src/test-kernel/agent/prompt/userVars.vitest.ts
@@ -1,10 +1,22 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from 'vitest';
 
 import { noopTrace } from '@agent/trace';
 import {
   AgentConfigSchema,
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
+import type {
+  BuiltUserVars,
+  TemplateVars,
+} from '@agent/core/definition/AgentCycleOptions';
 import {
   AgentPromptSchema,
   AgentWorkflowSettingSchema,
@@ -235,13 +247,34 @@ describe('output file prompt variables', () => {
   });
 });
 
-// Replaces the whole global platform in its own beforeEach and never restores
-// it — MUST stay the last describe in this file.
+// Compile-time pins for the buildUserVars contract: no runtime I/O, so this
+// describe does not touch the platform.
+describe('buildUserVars declared type', () => {
+  it('admits custom required-file keys beside the precisely typed fixed vocabulary', () => {
+    type BuiltResult = Awaited<ReturnType<typeof buildUserVars>>;
+
+    expectTypeOf<BuiltResult>().toEqualTypeOf<BuiltUserVars>();
+    // Fixed keys keep their precise types.
+    expectTypeOf<BuiltUserVars['MEDIA_CONTENT']>().toEqualTypeOf<null>();
+    expectTypeOf<BuiltUserVars['IS_OPENAI_MODEL']>().toEqualTypeOf<boolean>();
+    expectTypeOf<BuiltUserVars['INPUT_FILES']>().toEqualTypeOf<string[]>();
+    // Custom required-file keys are admitted beside the fixed vocabulary.
+    expectTypeOf<BuiltUserVars['CUSTOM_CONTENT']>().toEqualTypeOf<unknown>();
+    // The render/channel boundary accepts the builder's product as-is.
+    expectTypeOf<BuiltUserVars>().toMatchTypeOf<TemplateVars>();
+  });
+});
+
+// The describes below replace the whole global platform in their own
+// beforeEach and never restore it — they MUST stay the last describes in
+// this file.
 function buildVars(
   agentConfig: ReturnType<typeof AgentConfigSchema.parse>,
+  requiredFilesInternal: Record<string, string> = {},
 ): ReturnType<typeof buildUserVars> {
   const agentSetting = AgentWorkflowSettingSchema.parse({
     agentCategory: AgentCategory.Workflow,
+    requiredFilesInternal,
   });
   const agentPrompt = AgentPromptSchema.parse({});
   return buildUserVars(
@@ -299,6 +332,32 @@ describe('buildUserVars with missing configured files', () => {
     expect(vars.CONTEXT_CONTENT).toBe('present context');
   });
 
+  it('returns every file variable at its empty default when no files are configured', async () => {
+    const vars = await buildVars(
+      AgentConfigSchema.parse({ agent: 'generic', model: 'test-model' }),
+    );
+
+    expect(vars).toMatchObject({
+      INPUT_FILE: null,
+      INPUT_CONTENT: null,
+      CONTEXT_FILE: null,
+      CONTEXT_CONTENT: null,
+      EDITED_FILE: null,
+      EDITED_CONTENT: null,
+      INPUT_FILES: [],
+      CONTEXT_FILES: [],
+      EDITED_FILES: [],
+      ALL_INPUTS: null,
+      ALL_CONTEXTS: null,
+      ALL_EDITEDS: null,
+      LIST_OF_ALL_INPUTS: '',
+      LIST_OF_ALL_CONTEXTS: '',
+      LIST_OF_ALL_EDITEDS: '',
+      MEDIA_FILE: null,
+      MEDIA_CONTENT: null,
+    });
+  });
+
   it('records attached memory read misses from the prompt-load pass', async () => {
     const vars = await buildVars(
       AgentConfigSchema.parse({
@@ -314,5 +373,59 @@ describe('buildUserVars with missing configured files', () => {
     expect(vars.ATTACHED_MEMORY_MISSES).toEqual([
       expect.objectContaining({ path: '/memories/missing.md' }),
     ]);
+  });
+});
+
+describe('requiredFilesInternal custom variables', () => {
+  beforeEach(async () => {
+    const { initPlatform } = await import('@platform/platform');
+
+    initPlatform(
+      createFakePlatform({
+        workspacePath: '/workspace',
+        files: { '/agents/generic/brief.txt': 'briefing notes' },
+      }),
+    );
+  });
+
+  // A required file named after a file category generates the fixed X_FILE /
+  // X_CONTENT variables and would silently override them — and, for
+  // validators like MEDIA_CONTENT's z.null(), produce checkpoints the
+  // persisted channel schema rejects, making the session impossible to
+  // resume. The guard fails loudly at variable-build time instead.
+  it.each(['INPUT', 'CONTEXT', 'EDITED', 'MEDIA'])(
+    'rejects a required file named %s whose generated variables collide with the fixed vocabulary',
+    async (varName) => {
+      await expect(
+        buildVars(
+          AgentConfigSchema.parse({ agent: 'generic', model: 'test-model' }),
+          { [varName]: 'brief.txt' },
+        ),
+      ).rejects.toThrow('collides with a fixed template variable');
+    },
+  );
+
+  it('names the offending generated key in the collision error', async () => {
+    await expect(
+      buildVars(
+        AgentConfigSchema.parse({ agent: 'generic', model: 'test-model' }),
+        { MEDIA: 'brief.txt' },
+      ),
+    ).rejects.toThrow(
+      'requiredFilesInternal name "MEDIA" generates "MEDIA_FILE", which collides with a fixed template variable. Rename the required-file variable.',
+    );
+  });
+
+  it('passes custom required-file variables through beside the fixed vocabulary', async () => {
+    const vars = await buildVars(
+      AgentConfigSchema.parse({ agent: 'generic', model: 'test-model' }),
+      { BRIEF: 'brief.txt' },
+    );
+
+    expect(vars['BRIEF_FILE']).toBe('/agents/generic/brief.txt');
+    expect(vars['BRIEF_CONTENT']).toBe('briefing notes');
+    // The fixed slots the collision guard protects keep their built values.
+    expect(vars.MEDIA_CONTENT).toBeNull();
+    expect(vars.MODEL).toBe('test-model');
   });
 });


### PR DESCRIPTION
## Summary

Three follow-ups from #10346 (tracked under #10402):

1. **#10403 — collision guard.** A `requiredFilesInternal` name `X` generates the `X_FILE`/`X_CONTENT` pair, which `buildUserVars` spreads *after* the fixed variables. A name like `MEDIA` therefore silently overrode the fixed `MEDIA_CONTENT: null`, and the persisted channel schema's `z.null()` validator then rejected checkpoints the application itself produced, making those tool-use sessions impossible to resume. `getRequiredFileVars` now rejects any name whose generated keys collide with the fixed vocabulary, so such agents fail loudly at variable-build time. (The definition layer cannot host the guard: `AgentDataclass` may not import the prompt layer's runtime token list, and duplicating the list would drift.)
2. **#10404 — declared return type.** `buildUserVars` is now declared `Promise<BuiltUserVars>` (`UserVars & Record<string, unknown>`) so the signature admits the dynamic required-file keys the function actually returns instead of hiding them behind the closed `UserVars` type. TypeScript has no index signature that excludes the fixed keys (a `Record<string, string>` intersection does not compile against the boolean/array/null fixed slots), so the custom keys are admitted as `unknown` — the same view `TemplateVars` gives render-boundary readers. `AgentLaunchContext`'s channel assignment needed no change: the contract is expressed once, in `AgentCycleOptions.ts`.
3. **#10405 — compiler-checked initialization.** `getFileVars` now initializes every `FileVars` key with its empty-file default in a typed literal instead of `{} as FileVars`, so a future key added to `FileVars` without a matching default is a compile error at the literal. The loop only overwrites defaults; a failed `setVarFromFile` leaves the null pair standing, identical to the old fallback branch.

Runtime parse behavior from #10346 is unchanged: known fixed keys are still validated per key, custom keys still pass through as unknown.

## Issue acceptance gates

- #10403: an agent YAML declaring `requiredFilesInternal: { MEDIA: ... }` (or `INPUT`/`CONTEXT`/`EDITED`) fails loudly at variable-build time with an error naming the offending generated key — pinned by `requiredFilesInternal custom variables` tests (all four colliding names + exact message + custom-key passthrough) and by a schema-side test showing `MEDIA_CONTENT: string` checkpoints stay rejected.
- #10404: the declared return type admits the dynamic keys — pinned by compile-time `expectTypeOf` assertions (fixed keys stay precise, custom keys are admitted, the product is assignable to `TemplateVars` and the channel input type).
- #10405: the `{} as FileVars` assertion is gone; the every-key-assigned invariant is compiler-checked — pinned by the existing `getFileVars`-covering suite plus a new empty-defaults test asserting all 17 file keys.

## Single source of truth

The fixed vocabulary stays owned by `UserVars` / `USER_VAR_RUNTIME_TOKENS` (kept in exact sync by the two existing compile-time guards). The guard's runtime `FIXED_USER_VAR_KEYS` set derives from the tokens; `BuiltUserVars` derives from `UserVars`. No second copy of the key list was introduced.

## Duplication and abstraction budget

One new exported type alias (`BuiltUserVars`) beside `UserVars`/`TemplateVars` in `AgentCycleOptions.ts`, where the variable-contract family already lives; it owns the "fixed vocabulary plus custom keys beside it" invariant. The collision guard reuses `USER_VAR_RUNTIME_TOKENS` rather than duplicating the fixed list. No pass-through layers added.

## Net elements (R6)

- Files: 2 source + 2 test modified, 0 added/deleted.
- Exported symbols: +1 (`BuiltUserVars`, type-only).
- Classes/interfaces/enums: 0 added, 0 deleted.
- Net LoC: +210 / -19.

## Consumer counts (R8)

No export deleted or re-routed. `buildUserVars` has exactly one production consumer (`AgentLaunchContext`, grepped), which needed no change; `TemplateVars` readers (`PromptBuilder`) are untouched.

## Host impact

Extension: an agent YAML whose `requiredFilesInternal` names a file category (`INPUT`/`CONTEXT`/`EDITED`/`MEDIA`) now fails at run build with a clear rename instruction instead of producing an unresumable checkpoint. No built-in agent YAML uses such a name (grepped: only `TEMPLATE_*` names in presenter/paper2slide/paper2poster).

Desktop: none (shared agent runtime only, no host surface change).

CLI: none.

## Scheduled refactoring

None — this closes the three tracked follow-ups under #10402.

## Validation

- `npm run typecheck` (workspace, test-kernel, agent, cli, trace-viewer, desktop): pass.
- Targeted eslint on the 4 changed files: pass.
- `userVars.vitest.ts` (19 tests) + `AgentCycleOptions.vitest.ts` (5 tests): pass.
- `SessionResumeRetrieval.vitest.ts` (53 tests): pass.
- Neighboring consumer suites `AgentLaunchContext` / `AgentPromptContracts` / `AgentLaunchActivation` (746 tests): pass.
- `npx prettier --check` on changed files: pass.
- `npm run check:dead-code-ratchet`: pass (15 current vs 15 baselined, no new findings).

Closes #10403
Closes #10404
Closes #10405
