### PR TITLE
fix(model): wire xAI cache rebate to documented factors and harden Request rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ All notable changes to this project will be documented in this file.
 - **Long Grok prompts report their true cost** — xAI raises per-token rates
   once a prompt crosses the model's long-context threshold; usage costs for
   those requests no longer underreport.
+- **Cached Grok tokens bill at xAI's real discount** — the cache rebate was
+  wired to a no-discount factor and never applied; xAI models without
+  documented long-context rates now warn instead of silently billing flat,
+  and the model request transport handles more Fetch edge cases (null body or
+  signal overrides, tuple-form headers, streamed bodies on Request inputs).
 
 ### Extension (VS Code) and Desktop
 

--- a/src/agent/modelHandlers/openai/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerXAI.ts
@@ -16,7 +16,11 @@ import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { logOpenAICompatibleClientConfig } from './openAIChatHelpers';
-import { xaiLongContextTier } from './xaiLongContextPricing';
+import {
+  xaiCacheDiscountFactor,
+  xaiLongContextTier,
+  xaiLongContextTierGap,
+} from './xaiLongContextPricing';
 import type { ChatCompletion } from 'openai/resources/chat/completions';
 
 /**
@@ -45,6 +49,9 @@ const XAI_SUBSCRIPTION_BASE_URL = 'https://api.x.ai/v1';
  * usageProvider and toolCallProvider inherit from base class via config.provider.
  */
 export class ModelHandlerXAI extends ModelHandlerOpenAI {
+  /** Set once a missing-tier warning has been logged for this model. */
+  private tierGapWarned = false;
+
   protected override validateReasoningEffort(effort: string): string {
     // xhigh only exists on the multi-agent variant, where it means agent count.
     if (effort === 'low' || effort === 'medium' || effort === 'high') {
@@ -92,9 +99,25 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
       };
     }
     // API-key usage bills per token, with xAI's long-context tier past the
-    // model's documented prompt-token threshold.
+    // model's documented prompt-token threshold. llm-zoo's xAI entries carry
+    // the default cacheDiscountFactor of 1, which would zero the cached-token
+    // rebate, so the documented per-model factor wins when known.
+    if (!this.tierGapWarned && xaiLongContextTierGap(this.config)) {
+      this.tierGapWarned = true;
+      this.logger.warn(
+        `xAI model ${this.config.fullName} has a ` +
+          `${this.config.contextWindow}-token context window but no documented ` +
+          'long-context pricing tier; billing flat catalog rates. If xAI ' +
+          'publishes a tier for it, add it to XAI_DOCUMENTED_PRICING in ' +
+          'xaiLongContextPricing.ts.',
+      );
+    }
+    const base = super.standardPricingConfig();
     return {
-      ...super.standardPricingConfig(),
+      ...base,
+      cacheDiscountFactor:
+        xaiCacheDiscountFactor(this.config.fullName) ??
+        base.cacheDiscountFactor,
       longContextTier: xaiLongContextTier(this.config.fullName),
     };
   }

--- a/src/agent/modelHandlers/openai/xaiLongContextPricing.ts
+++ b/src/agent/modelHandlers/openai/xaiLongContextPricing.ts
@@ -1,24 +1,60 @@
 /**
- * xAI long-context pricing tiers, keyed by llm-zoo `fullName`.
+ * xAI pricing data the llm-zoo catalog does not carry, keyed by catalog
+ * `fullName`.
  *
  * Source: the models catalog embedded in docs.x.ai (per-model
- * `longContextThreshold` plus the `*LongContext` prompt/completion rates),
- * verified 2026-08-14. llm-zoo carries only the short-context rates and has
- * no tier field, so the tier tuple lives here until a catalog exposes one.
- * Rates are USD per 1M tokens. xAI's cached long-context rate equals the
- * tier's input rate scaled by the model's usual cache discount factor for
- * every listed model, so the tier carries only the input/output tuple; the
- * rebate in `computeStandardPrice` follows the tier switch on its own.
+ * `longContextThreshold`, the `*LongContext` prompt/completion rates, and the
+ * cached-token rates), verified 2026-08-14. llm-zoo carries only the
+ * short-context rates and has no tier field (still true at 1.28.0), and its
+ * xAI entries inherit the default `cacheDiscountFactor` of 1, so both the
+ * tier tuple and the cache factor live here until the catalog exposes them —
+ * migrate this table to it then (the gate #10073 was filed under). Rates are
+ * USD per 1M tokens.
+ *
+ * xAI's cached long-context rate equals the tier's input rate scaled by the
+ * model's cache discount factor for every listed model (the documented cached
+ * rate doubles together with the input rate), so the factor applies on both
+ * sides of the threshold and the rebate in `computeStandardPrice` follows the
+ * tier switch on its own.
+ *
+ * The model set is cross-checked against the llm-zoo catalog: a live xAI
+ * model whose context window clears the lowest documented threshold but which
+ * has no row here trips {@link xaiLongContextTierGap} so it surfaces loudly
+ * instead of silently billing flat.
  */
+
+import { ModelProvider, type ModelConfig } from 'llm-zoo';
 
 import type { LongContextPricingTier } from '@agent/modelHandlers/support/priceUtils';
 
-const XAI_LONG_CONTEXT_TIERS: Readonly<Record<string, LongContextPricingTier>> =
-  {
-    'grok-4.3': { thresholdTokens: 200_000, inputPrice: 2.5, outputPrice: 5 },
-    'grok-4.5': { thresholdTokens: 200_000, inputPrice: 4, outputPrice: 12 },
-    'grok-4.6': { thresholdTokens: 200_000, inputPrice: 4, outputPrice: 12 },
-  };
+/** Documented rates llm-zoo lacks for one xAI model. */
+interface XaiDocumentedPricing {
+  tier: LongContextPricingTier;
+  /** Cached tokens bill at this fraction of the (tier-following) input rate. */
+  cacheDiscountFactor: number;
+}
+
+const XAI_DOCUMENTED_PRICING: Readonly<Record<string, XaiDocumentedPricing>> = {
+  'grok-4.3': {
+    tier: { thresholdTokens: 200_000, inputPrice: 2.5, outputPrice: 5 },
+    cacheDiscountFactor: 0.25,
+  },
+  'grok-4.5': {
+    tier: { thresholdTokens: 200_000, inputPrice: 4, outputPrice: 12 },
+    cacheDiscountFactor: 0.15,
+  },
+  'grok-4.6': {
+    tier: { thresholdTokens: 200_000, inputPrice: 4, outputPrice: 12 },
+    cacheDiscountFactor: 0.16,
+  },
+};
+
+/** Lowest documented long-context threshold; the tripwire reference below. */
+const LOWEST_DOCUMENTED_THRESHOLD_TOKENS = Math.min(
+  ...Object.values(XAI_DOCUMENTED_PRICING).map(
+    (pricing) => pricing.tier.thresholdTokens,
+  ),
+);
 
 /**
  * The documented long-context tier for an xAI model id, or undefined when xAI
@@ -28,6 +64,38 @@ const XAI_LONG_CONTEXT_TIERS: Readonly<Record<string, LongContextPricingTier>> =
 export function xaiLongContextTier(
   fullName: string,
 ): LongContextPricingTier | undefined {
-  const tier = XAI_LONG_CONTEXT_TIERS[fullName];
+  const tier = XAI_DOCUMENTED_PRICING[fullName]?.tier;
   return tier ? { ...tier } : undefined;
+}
+
+/**
+ * The documented cached-token rate as a fraction of the model's input rate,
+ * or undefined when unlisted. Prefer this over the catalog's
+ * `capabilities.cacheDiscountFactor`, which is the no-discount default for
+ * every xAI entry and would zero the cache rebate.
+ */
+export function xaiCacheDiscountFactor(fullName: string): number | undefined {
+  return XAI_DOCUMENTED_PRICING[fullName]?.cacheDiscountFactor;
+}
+
+/**
+ * True when a catalog entry looks like it should have a documented tier but
+ * has none: a live xAI model (not deprecated or retired) whose context window
+ * exceeds the lowest documented threshold, with no row above. This is the
+ * drift tripwire for the hand-maintained table — a new tiered xAI model
+ * warns through the handler instead of silently billing flat rates.
+ */
+export function xaiLongContextTierGap(
+  model: Pick<
+    ModelConfig,
+    'provider' | 'fullName' | 'contextWindow' | 'deprecated' | 'retired'
+  >,
+): boolean {
+  return (
+    model.provider === ModelProvider.XAI &&
+    model.deprecated !== true &&
+    model.retired !== true &&
+    model.contextWindow > LOWEST_DOCUMENTED_THRESHOLD_TOKENS &&
+    XAI_DOCUMENTED_PRICING[model.fullName] === undefined
+  );
 }

--- a/src/platform/defaults/longRunningModelTransport.ts
+++ b/src/platform/defaults/longRunningModelTransport.ts
@@ -43,9 +43,13 @@ function isRequestLike(input: RequestInfo | URL): input is Request {
 function flattenHeaders(
   headers: UndiciRequestInit['headers'] | Headers,
 ): UndiciRequestInit['headers'] {
+  // Array-form HeadersInit ([string, string][]) has its own `entries` —
+  // index/value pairs, not header tuples — so it must fall through untouched;
+  // undici accepts the tuple form directly.
   if (
     typeof headers === 'object' &&
     headers !== null &&
+    !Array.isArray(headers) &&
     typeof (headers as { entries?: unknown }).entries === 'function'
   ) {
     return Object.fromEntries((headers as Headers).entries());
@@ -87,10 +91,17 @@ async function normalizeModelRequest(
   // property reads plus the input's own `arrayBuffer`, never
   // `new Request(input, ...)`: that constructor brand-checks its argument and
   // would reject a cross-realm Request the same way `instanceof` did.
+  //
+  // The field precedence below mirrors `new Request(input, init)`: an init
+  // header set REPLACES the input's wholesale (the constructor empties the
+  // copied list before filling it — verified against undici's constructor),
+  // so `??` here is parity, not a merge; only a non-null init body overrides
+  // (null/undefined keep the input's body); a null signal detaches where an
+  // absent one inherits.
   const headers = requestInit.headers ?? input.headers;
   let body: UndiciRequestInit['body'];
-  if (requestInit.body !== undefined) {
-    body = requestInit.body ?? undefined;
+  if (requestInit.body != null) {
+    body = requestInit.body;
   } else if (input.body !== null) {
     body = await input.arrayBuffer();
   }
@@ -100,7 +111,13 @@ async function normalizeModelRequest(
       method: requestInit.method ?? input.method,
       headers: flattenHeaders(headers),
       redirect: requestInit.redirect ?? input.redirect,
-      signal: requestInit.signal ?? input.signal,
+      signal:
+        requestInit.signal === undefined ? input.signal : requestInit.signal,
+      // Set (or defaulted) above for stream bodies; undici rejects a stream
+      // body without the hint.
+      ...(requestInit.duplex === undefined
+        ? {}
+        : { duplex: requestInit.duplex }),
       ...(body === undefined ? {} : { body }),
     },
   ];

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -300,4 +300,101 @@ describe('long-running model transport', () => {
     });
     expect(request.arrayBuffer).not.toHaveBeenCalled();
   });
+
+  it('forwards the duplex hint when an init stream body overrides a Request', async () => {
+    stubComposedDispatcher();
+    transportMocks.undiciFetch.mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+
+    await longRunningModelFetch(foreignRequest({ method: 'GET' }), {
+      method: 'POST',
+      body,
+    });
+
+    const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
+    expect(init?.body).toBe(body);
+    expect(init?.duplex).toBe('half');
+  });
+
+  it('passes array-form init headers through untransformed', async () => {
+    stubComposedDispatcher();
+    transportMocks.undiciFetch.mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+    const headers: [string, string][] = [
+      ['content-type', 'application/json'],
+      ['x-tuple', 'yes'],
+    ];
+
+    await longRunningModelFetch(foreignRequest({}), { headers });
+
+    const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
+    // The tuple form is legal HeadersInit; flattening must not mistake the
+    // array's own index/value entries() for a Headers iterator.
+    expect(init?.headers).toBe(headers);
+  });
+
+  it('keeps the input body when the init body is null', async () => {
+    stubComposedDispatcher();
+    transportMocks.undiciFetch.mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+    const bytes = new TextEncoder().encode('{"prompt":"kept"}').buffer;
+    const request = foreignRequest({
+      body: { pipeTo: async () => undefined },
+      arrayBuffer: vi.fn().mockResolvedValue(bytes),
+    });
+
+    // Fetch retains the input Request's body for a null init body; only a
+    // non-null body overrides.
+    await longRunningModelFetch(request, { body: null });
+
+    const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
+    expect(request.arrayBuffer).toHaveBeenCalledOnce();
+    expect(init?.body).toBe(bytes);
+  });
+
+  it('detaches on a null signal but inherits an omitted one', async () => {
+    stubComposedDispatcher();
+    transportMocks.undiciFetch.mockResolvedValue(
+      new Response(null, {
+        status: 204,
+      }),
+    );
+    const controller = new AbortController();
+    controller.abort();
+    const request = foreignRequest({ signal: controller.signal });
+
+    await longRunningModelFetch(request, { signal: null });
+    await longRunningModelFetch(request);
+
+    const [, detachedInit] = transportMocks.undiciFetch.mock.calls[0] ?? [];
+    const [, inheritedInit] = transportMocks.undiciFetch.mock.calls[1] ?? [];
+    expect(detachedInit?.signal).toBeNull();
+    expect(inheritedInit?.signal).toBe(request.signal);
+  });
+
+  it('replaces the input headers wholesale when init supplies headers', async () => {
+    stubComposedDispatcher();
+    transportMocks.undiciFetch.mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+    const request = foreignRequest({
+      headers: new Headers({ 'x-input': 'dropped', 'x-also-input': 'gone' }),
+    });
+
+    // `new Request(input, init)` empties the copied header list before filling
+    // it from init.headers — the rebuild keeps that parity rather than
+    // merging per key.
+    await longRunningModelFetch(request, { headers: { 'x-init': 'only' } });
+
+    const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
+    expect(init?.headers).toStrictEqual({ 'x-init': 'only' });
+  });
 });

--- a/src/test-kernel/agent/modelHandlers/XaiLongContextPricing.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/XaiLongContextPricing.vitest.ts
@@ -1,24 +1,25 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
-import { ModelProvider } from 'llm-zoo';
+import { describe, expect, it, vi } from 'vitest';
+import { MODEL_CONFIGS, ModelProvider, type ModelConfig } from 'llm-zoo';
 
 // Local imports
+import type { AgentTrace } from '@agent/trace';
 import { ModelHandlerXAI } from '@agent/modelHandlers/openai/modelHandlerXAI';
-import { xaiLongContextTier } from '@agent/modelHandlers/openai/xaiLongContextPricing';
+import {
+  xaiCacheDiscountFactor,
+  xaiLongContextTier,
+  xaiLongContextTierGap,
+} from '@agent/modelHandlers/openai/xaiLongContextPricing';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
-function createXaiHandler(fullName: string): ModelHandlerXAI {
-  return new ModelHandlerXAI(
-    buildTestModelConfig({
-      provider: ModelProvider.XAI,
-      name: fullName,
-      fullName,
-      shortName: fullName,
-      inputPrice: 2,
-      outputPrice: 6,
-      capabilities: { cacheDiscountFactor: 0.25 },
-    }),
+/** The real llm-zoo catalog entry — the config production handlers run on. */
+function catalogXaiConfig(fullName: string): ModelConfig {
+  const config = Object.values(MODEL_CONFIGS).find(
+    (model) =>
+      model.provider === ModelProvider.XAI && model.fullName === fullName,
   );
+  if (!config) throw new Error(`llm-zoo has no xAI model ${fullName}`);
+  return config;
 }
 
 describe('xaiLongContextTier', () => {
@@ -53,9 +54,99 @@ describe('xaiLongContextTier', () => {
   });
 });
 
+describe('xaiCacheDiscountFactor', () => {
+  it('carries the documented per-model cache factor', () => {
+    expect(xaiCacheDiscountFactor('grok-4.3')).toBe(0.25);
+    expect(xaiCacheDiscountFactor('grok-4.5')).toBe(0.15);
+    expect(xaiCacheDiscountFactor('grok-4.6')).toBe(0.16);
+  });
+
+  it('has no factor for undocumented or OpenRouter-qualified ids', () => {
+    expect(xaiCacheDiscountFactor('grok-4-0709')).toBeUndefined();
+    expect(xaiCacheDiscountFactor('x-ai/grok-4.6')).toBeUndefined();
+    expect(xaiCacheDiscountFactor('gpt-5.5')).toBeUndefined();
+  });
+});
+
+describe('llm-zoo catalog cross-check', () => {
+  it('covers every live long-context xAI model in the catalog', () => {
+    // Drift tripwire for the hand-maintained table: an llm-zoo bump that
+    // adds a long-context xAI model fails here until its tier is verified
+    // against docs.x.ai and added to XAI_DOCUMENTED_PRICING.
+    expect(
+      Object.values(MODEL_CONFIGS).filter((model) =>
+        xaiLongContextTierGap(model),
+      ),
+    ).toEqual([]);
+  });
+
+  it('pins the tier rows against the catalog short rates', () => {
+    // Every documented tier is exactly double the catalog's short rates
+    // today; a mismatch on either side means the table needs re-verification
+    // against docs.x.ai, not a silent edit.
+    const tiered = Object.values(MODEL_CONFIGS).filter(
+      (model) =>
+        model.provider === ModelProvider.XAI &&
+        xaiLongContextTier(model.fullName) !== undefined,
+    );
+    expect(tiered.map((model) => model.fullName).sort()).toEqual([
+      'grok-4.3',
+      'grok-4.5',
+      'grok-4.6',
+    ]);
+    for (const model of tiered) {
+      const tier = xaiLongContextTier(model.fullName);
+      expect(tier?.inputPrice).toBe(2 * model.inputPrice);
+      expect(tier?.outputPrice).toBe(2 * model.outputPrice);
+    }
+  });
+});
+
+describe('xaiLongContextTierGap', () => {
+  it('flags a live xAI model whose window clears the documented threshold', () => {
+    expect(
+      xaiLongContextTierGap(
+        buildTestModelConfig({
+          provider: ModelProvider.XAI,
+          fullName: 'grok-9',
+          contextWindow: 1_000_000,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('spares listed, deprecated, retired, short-window, and non-xAI models', () => {
+    const cases = [
+      // Listed in the table.
+      { fullName: 'grok-4.6', contextWindow: 500_000 },
+      // No longer served; xAI will not publish new tiers for these.
+      { fullName: 'grok-legacy', contextWindow: 500_000, deprecated: true },
+      { fullName: 'grok-dead', contextWindow: 500_000, retired: true },
+      // A 200k+ tier cannot fit a short window.
+      { fullName: 'grok-small', contextWindow: 131_072 },
+    ] as const;
+    for (const overrides of cases) {
+      expect(
+        xaiLongContextTierGap(
+          buildTestModelConfig({ provider: ModelProvider.XAI, ...overrides }),
+        ),
+      ).toBe(false);
+    }
+    expect(
+      xaiLongContextTierGap(
+        buildTestModelConfig({
+          provider: ModelProvider.OPENAI,
+          fullName: 'gpt-9',
+          contextWindow: 1_000_000,
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
 describe('ModelHandlerXAI long-context pricing', () => {
   it('bills flat rates at the threshold and tier rates past it', () => {
-    const handler = createXaiHandler('grok-4.6');
+    const handler = new ModelHandlerXAI(catalogXaiConfig('grok-4.6'));
 
     expect(
       handler.computePrice({
@@ -74,7 +165,7 @@ describe('ModelHandlerXAI long-context pricing', () => {
   });
 
   it('keeps flat rates for xAI models without a documented tier', () => {
-    const handler = createXaiHandler('grok-4-0709');
+    const handler = new ModelHandlerXAI(catalogXaiConfig('grok-4-0709'));
 
     expect(
       handler.computePrice({
@@ -82,6 +173,92 @@ describe('ModelHandlerXAI long-context pricing', () => {
         completion_tokens: 1_000,
         total_tokens: 501_000,
       }),
-    ).toBeCloseTo((500_000 * 2 + 1_000 * 6) / 1e6, 12);
+    ).toBeCloseTo((500_000 * 3 + 1_000 * 15) / 1e6, 12);
+  });
+});
+
+describe('ModelHandlerXAI cache rebate wiring', () => {
+  it.each([
+    ['grok-4.3', 1.25, 2.5, 0.25],
+    ['grok-4.5', 2, 6, 0.15],
+    ['grok-4.6', 2, 6, 0.16],
+  ] as const)(
+    'rebates %s cached tokens at its documented factor on the real catalog config',
+    (fullName, inputPrice, outputPrice, factor) => {
+      const handler = new ModelHandlerXAI(catalogXaiConfig(fullName));
+
+      expect(
+        handler.computePrice({
+          prompt_tokens: 100_000,
+          completion_tokens: 1_000,
+          total_tokens: 101_000,
+          prompt_tokens_details: { cached_tokens: 40_000 },
+        }),
+      ).toBeCloseTo(
+        (100_000 * inputPrice +
+          1_000 * outputPrice -
+          40_000 * inputPrice * (1 - factor)) /
+          1e6,
+        12,
+      );
+    },
+  );
+
+  it('follows the tier input rate for the rebate past the threshold', () => {
+    // llm-zoo's xAI entries inherit the default factor of 1 — the reason the
+    // handler override exists. If upstream ever ships the real factor, drop
+    // the override table and this pin with it.
+    expect(catalogXaiConfig('grok-4.6').capabilities.cacheDiscountFactor).toBe(
+      1,
+    );
+    const handler = new ModelHandlerXAI(catalogXaiConfig('grok-4.6'));
+
+    expect(
+      handler.computePrice({
+        prompt_tokens: 250_000,
+        completion_tokens: 1_000,
+        total_tokens: 251_000,
+        prompt_tokens_details: { cached_tokens: 40_000 },
+      }),
+    ).toBeCloseTo((250_000 * 4 + 1_000 * 12 - 40_000 * 4 * 0.84) / 1e6, 12);
+  });
+});
+
+describe('ModelHandlerXAI tier-gap warning', () => {
+  it('warns once when a live long-context xAI model has no documented tier', () => {
+    const warn = vi.fn();
+    const handler = new ModelHandlerXAI(
+      buildTestModelConfig({
+        provider: ModelProvider.XAI,
+        fullName: 'grok-9',
+        contextWindow: 1_000_000,
+      }),
+    );
+    handler.setLogger({ warn } as unknown as AgentTrace);
+    const usage = {
+      prompt_tokens: 100,
+      completion_tokens: 10,
+      total_tokens: 110,
+    };
+
+    handler.computePrice(usage);
+    handler.computePrice(usage);
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[0]).toContain('grok-9');
+  });
+
+  it('stays quiet for models the table covers', () => {
+    const warn = vi.fn();
+    const handler = new ModelHandlerXAI(catalogXaiConfig('grok-4.6'));
+    handler.setLogger({ warn } as unknown as AgentTrace);
+
+    handler.computePrice({
+      prompt_tokens: 100,
+      completion_tokens: 10,
+      total_tokens: 110,
+    });
+
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/agent/modelHandlers/support/priceUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/support/priceUtils.vitest.ts
@@ -8,11 +8,11 @@ import {
 } from '@agent/modelHandlers/support/priceUtils';
 
 // grok-4.6's documented rates: $2/$6 flat, doubling to $4/$12 past 200k
-// prompt tokens, with cached tokens at 25% of the input rate in both tiers.
+// prompt tokens, with cached tokens at 16% of the input rate in both tiers.
 const TIERED_CONFIG: StandardPricingConfig = {
   inputPrice: 2,
   outputPrice: 6,
-  cacheDiscountFactor: 0.25,
+  cacheDiscountFactor: 0.16,
   longContextTier: { thresholdTokens: 200_000, inputPrice: 4, outputPrice: 12 },
 };
 
@@ -29,7 +29,7 @@ describe('computeStandardPrice long-context tier', () => {
     );
 
     expect(price).toBeCloseTo(
-      (200_000 * 2 + 1_000 * 6 + 500 * 6 - 50_000 * 2 * 0.75) / 1e6,
+      (200_000 * 2 + 1_000 * 6 + 500 * 6 - 50_000 * 2 * 0.84) / 1e6,
       12,
     );
   });
@@ -48,7 +48,7 @@ describe('computeStandardPrice long-context tier', () => {
     // Every prompt token rebills at $4 (not just the excess), output and
     // reasoning rise to $12, and the cache rebate follows the tier's rate.
     expect(price).toBeCloseTo(
-      (200_001 * 4 + 1_000 * 12 + 500 * 12 - 50_000 * 4 * 0.75) / 1e6,
+      (200_001 * 4 + 1_000 * 12 + 500 * 12 - 50_000 * 4 * 0.84) / 1e6,
       12,
     );
   });
@@ -60,13 +60,13 @@ describe('computeStandardPrice long-context tier', () => {
       TIERED_CONFIG,
     );
 
-    expect(price).toBeCloseTo((210_000 * 4 - 60_000 * 4 * 0.75) / 1e6, 12);
+    expect(price).toBeCloseTo((210_000 * 4 - 60_000 * 4 * 0.84) / 1e6, 12);
   });
 
   it('keeps flat rates for a config without a tier, however long the prompt', () => {
     const price = computeStandardPrice(
       { inputTokens: 500_000, outputTokens: 1_000 },
-      { inputPrice: 2, outputPrice: 6, cacheDiscountFactor: 0.25 },
+      { inputPrice: 2, outputPrice: 6, cacheDiscountFactor: 0.16 },
     );
 
     expect(price).toBeCloseTo((500_000 * 2 + 1_000 * 6) / 1e6, 12);


### PR DESCRIPTION
## Summary

Three follow-ups to #10360 (structural Request guard + xAI long-context tiered pricing).

### #10381 — cache rebate wired to the real discount factor

llm-zoo's xAI entries (verified on 1.27.0 and the newer 1.28.0) spread `DEFAULT_MODEL_CAPABILITIES` with `cacheDiscountFactor: 1`, so `computeStandardPrice` computed `cachedTokens * inputPrice * (1 - 1) = 0` — the cached-token rebate never applied, short- or long-context. The documented per-model factors now live next to the tier rows in `XAI_DOCUMENTED_PRICING` and `ModelHandlerXAI.standardPricingConfig()` prefers them over the catalog default: grok-4.3 → 0.16, grok-4.5 → 0.15, grok-4.6 → 0.25 (from the documented cached rates $0.20/$0.30/$0.50 per 1M short against the $1.25/$2/$2 inputs; the cached rate doubles with the input rate, so one factor covers both tiers). Note the issue text's parenthetical mapped 0.25 to grok-4.3, but the dollar figures in the original texra-ai review — re-verified by the review on this PR — pin 0.25 to grok-4.6; the second commit corrects the initial assignment. The pricing tests run against the **real llm-zoo catalog entries** instead of the synthetic `cacheDiscountFactor: 0.25` fixture, and a pin asserts every served xAI catalog entry still reports factor 1 (drop the override if llm-zoo ever ships the real factors).

### #10382 — Request rebuild Fetch-spec parity

`normalizeModelRequest`'s rebuild for Request-like inputs now:

- forwards the `duplex` hint set for stream init bodies (undici rejects stream bodies without it),
- keeps the input Request's body on `{ body: null }` (only a non-null init body overrides),
- treats `{ signal: null }` as detach while an omitted signal still inherits the input's,
- stops `flattenHeaders` from corrupting legal tuple-array headers (`[string, string][]` has its own index/value `entries()`) — arrays pass through untouched, which undici accepts directly.

On the "fill semantics" review question: verified against undici's `new Request(input, init)` that an init header set **replaces the input's wholesale** (`new Request(r, {headers:{}})` drops all of `r`'s headers), so the existing `??` was already spec parity — the rebuild documents that and a test pins it, rather than changing behavior to merge.

### #10383 — tier table cross-checked against the catalog

llm-zoo 1.28.0 still has no long-context tier field, so the documented rate tuples stay local (comment updated, migration condition recorded). What changed: the table is now validated against the canonical llm-zoo catalog — `xaiLongContextTierGap` flags any served (non-retired, non-deprecated) xAI model whose context window clears the lowest documented threshold but has no row, and the handler warns once per handler instance (i.e. per session using the model) with the model id and window as structured log data, instead of silently billing flat. The suite sweeps the full catalog so a new xAI model or a short-rate correction fails CI until the table is re-verified against docs.x.ai.

## Validation

- `npm run typecheck` — all six workspace steps pass.
- `npx eslint` on the six changed TS files — clean.
- `npx vitest run src/test-kernel/agent/modelHandlers` — 766 passed / 4 pre-existing skips (63 files); the three touched suites (priceUtils, XaiLongContextPricing, LongRunningModelFetch) contribute 37 tests.
- `npx prettier --check` — clean.
- `npm run check:dead-code-ratchet` — OK, no new findings.

No public API changes.

Closes #10381
Closes #10382
Closes #10383