### PR TITLE
fix(model): correct grok-4.3/4.6 cache factors and address #10441 review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,10 @@ All notable changes to this project will be documented in this file.
 - **Long Grok prompts report their true cost** — xAI raises per-token rates
   once a prompt crosses the model's long-context threshold; usage costs for
   those requests no longer underreport.
-- **Cached Grok tokens bill at xAI's real discount** — the cache rebate was
-  wired to a no-discount factor and never applied; xAI models without
-  documented long-context rates now warn instead of silently billing flat,
-  and the model request transport handles more Fetch edge cases (null body or
-  signal overrides, tuple-form headers, streamed bodies on Request inputs).
+- **Cached Grok tokens bill at xAI's real discount** — the cache rebate
+  previously never applied, and xAI models without documented long-context
+  rates now warn instead of silently billing flat. Rare request edge cases
+  also no longer drop a request's body, headers, or cancellation.
 
 ### Extension (VS Code) and Desktop
 

--- a/src/agent/modelHandlers/openai/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerXAI.ts
@@ -105,11 +105,15 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
     if (!this.tierGapWarned && xaiLongContextTierGap(this.config)) {
       this.tierGapWarned = true;
       this.logger.warn(
-        `xAI model ${this.config.fullName} has a ` +
-          `${this.config.contextWindow}-token context window but no documented ` +
-          'long-context pricing tier; billing flat catalog rates. If xAI ' +
-          'publishes a tier for it, add it to XAI_DOCUMENTED_PRICING in ' +
-          'xaiLongContextPricing.ts.',
+        'xAI model has no documented long-context pricing tier; billing ' +
+          'flat catalog rates. If xAI publishes a tier for it, add it to ' +
+          'XAI_DOCUMENTED_PRICING in xaiLongContextPricing.ts.',
+        {
+          data: {
+            fullName: this.config.fullName,
+            contextWindow: this.config.contextWindow,
+          },
+        },
       );
     }
     const base = super.standardPricingConfig();

--- a/src/agent/modelHandlers/openai/xaiLongContextPricing.ts
+++ b/src/agent/modelHandlers/openai/xaiLongContextPricing.ts
@@ -23,8 +23,10 @@
  * instead of silently billing flat.
  */
 
+// Third-party imports
 import { ModelProvider, type ModelConfig } from 'llm-zoo';
 
+// Local imports
 import type { LongContextPricingTier } from '@agent/modelHandlers/support/priceUtils';
 
 /** Documented rates llm-zoo lacks for one xAI model. */
@@ -37,7 +39,7 @@ interface XaiDocumentedPricing {
 const XAI_DOCUMENTED_PRICING: Readonly<Record<string, XaiDocumentedPricing>> = {
   'grok-4.3': {
     tier: { thresholdTokens: 200_000, inputPrice: 2.5, outputPrice: 5 },
-    cacheDiscountFactor: 0.25,
+    cacheDiscountFactor: 0.16,
   },
   'grok-4.5': {
     tier: { thresholdTokens: 200_000, inputPrice: 4, outputPrice: 12 },
@@ -45,7 +47,7 @@ const XAI_DOCUMENTED_PRICING: Readonly<Record<string, XaiDocumentedPricing>> = {
   },
   'grok-4.6': {
     tier: { thresholdTokens: 200_000, inputPrice: 4, outputPrice: 12 },
-    cacheDiscountFactor: 0.16,
+    cacheDiscountFactor: 0.25,
   },
 };
 

--- a/src/test-kernel/agent/modelHandlers/XaiLongContextPricing.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/XaiLongContextPricing.vitest.ts
@@ -56,9 +56,9 @@ describe('xaiLongContextTier', () => {
 
 describe('xaiCacheDiscountFactor', () => {
   it('carries the documented per-model cache factor', () => {
-    expect(xaiCacheDiscountFactor('grok-4.3')).toBe(0.25);
+    expect(xaiCacheDiscountFactor('grok-4.3')).toBe(0.16);
     expect(xaiCacheDiscountFactor('grok-4.5')).toBe(0.15);
-    expect(xaiCacheDiscountFactor('grok-4.6')).toBe(0.16);
+    expect(xaiCacheDiscountFactor('grok-4.6')).toBe(0.25);
   });
 
   it('has no factor for undocumented or OpenRouter-qualified ids', () => {
@@ -89,7 +89,7 @@ describe('llm-zoo catalog cross-check', () => {
         model.provider === ModelProvider.XAI &&
         xaiLongContextTier(model.fullName) !== undefined,
     );
-    expect(tiered.map((model) => model.fullName).sort()).toEqual([
+    expect(tiered.map((model) => model.fullName).toSorted()).toEqual([
       'grok-4.3',
       'grok-4.5',
       'grok-4.6',
@@ -98,6 +98,22 @@ describe('llm-zoo catalog cross-check', () => {
       const tier = xaiLongContextTier(model.fullName);
       expect(tier?.inputPrice).toBe(2 * model.inputPrice);
       expect(tier?.outputPrice).toBe(2 * model.outputPrice);
+    }
+  });
+});
+
+describe('catalog cache-factor pin', () => {
+  it('reports the no-discount default for every served xAI model', () => {
+    // llm-zoo's xAI entries inherit the default factor of 1 — the reason the
+    // handler override exists. If upstream ever ships real factors (a short
+    // window would not trip the tier sweep above), prefer the catalog and
+    // drop the override table and this pin.
+    const served = Object.values(MODEL_CONFIGS).filter(
+      (model) => model.provider === ModelProvider.XAI && !model.retired,
+    );
+    expect(served.length).toBeGreaterThan(0);
+    for (const model of served) {
+      expect(model.capabilities.cacheDiscountFactor).toBe(1);
     }
   });
 });
@@ -179,9 +195,9 @@ describe('ModelHandlerXAI long-context pricing', () => {
 
 describe('ModelHandlerXAI cache rebate wiring', () => {
   it.each([
-    ['grok-4.3', 1.25, 2.5, 0.25],
+    ['grok-4.3', 1.25, 2.5, 0.16],
     ['grok-4.5', 2, 6, 0.15],
-    ['grok-4.6', 2, 6, 0.16],
+    ['grok-4.6', 2, 6, 0.25],
   ] as const)(
     'rebates %s cached tokens at its documented factor on the real catalog config',
     (fullName, inputPrice, outputPrice, factor) => {
@@ -205,12 +221,6 @@ describe('ModelHandlerXAI cache rebate wiring', () => {
   );
 
   it('follows the tier input rate for the rebate past the threshold', () => {
-    // llm-zoo's xAI entries inherit the default factor of 1 — the reason the
-    // handler override exists. If upstream ever ships the real factor, drop
-    // the override table and this pin with it.
-    expect(catalogXaiConfig('grok-4.6').capabilities.cacheDiscountFactor).toBe(
-      1,
-    );
     const handler = new ModelHandlerXAI(catalogXaiConfig('grok-4.6'));
 
     expect(
@@ -220,7 +230,7 @@ describe('ModelHandlerXAI cache rebate wiring', () => {
         total_tokens: 251_000,
         prompt_tokens_details: { cached_tokens: 40_000 },
       }),
-    ).toBeCloseTo((250_000 * 4 + 1_000 * 12 - 40_000 * 4 * 0.84) / 1e6, 12);
+    ).toBeCloseTo((250_000 * 4 + 1_000 * 12 - 40_000 * 4 * 0.75) / 1e6, 12);
   });
 });
 
@@ -245,7 +255,9 @@ describe('ModelHandlerXAI tier-gap warning', () => {
     handler.computePrice(usage);
 
     expect(warn).toHaveBeenCalledOnce();
-    expect(warn.mock.calls[0]?.[0]).toContain('grok-9');
+    expect(warn.mock.calls[0]?.[1]).toMatchObject({
+      data: { fullName: 'grok-9', contextWindow: 1_000_000 },
+    });
   });
 
   it('stays quiet for models the table covers', () => {

--- a/src/test-kernel/agent/modelHandlers/support/priceUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/support/priceUtils.vitest.ts
@@ -8,11 +8,11 @@ import {
 } from '@agent/modelHandlers/support/priceUtils';
 
 // grok-4.6's documented rates: $2/$6 flat, doubling to $4/$12 past 200k
-// prompt tokens, with cached tokens at 16% of the input rate in both tiers.
+// prompt tokens, with cached tokens at 25% of the input rate in both tiers.
 const TIERED_CONFIG: StandardPricingConfig = {
   inputPrice: 2,
   outputPrice: 6,
-  cacheDiscountFactor: 0.16,
+  cacheDiscountFactor: 0.25,
   longContextTier: { thresholdTokens: 200_000, inputPrice: 4, outputPrice: 12 },
 };
 
@@ -29,7 +29,7 @@ describe('computeStandardPrice long-context tier', () => {
     );
 
     expect(price).toBeCloseTo(
-      (200_000 * 2 + 1_000 * 6 + 500 * 6 - 50_000 * 2 * 0.84) / 1e6,
+      (200_000 * 2 + 1_000 * 6 + 500 * 6 - 50_000 * 2 * 0.75) / 1e6,
       12,
     );
   });
@@ -48,7 +48,7 @@ describe('computeStandardPrice long-context tier', () => {
     // Every prompt token rebills at $4 (not just the excess), output and
     // reasoning rise to $12, and the cache rebate follows the tier's rate.
     expect(price).toBeCloseTo(
-      (200_001 * 4 + 1_000 * 12 + 500 * 12 - 50_000 * 4 * 0.84) / 1e6,
+      (200_001 * 4 + 1_000 * 12 + 500 * 12 - 50_000 * 4 * 0.75) / 1e6,
       12,
     );
   });
@@ -60,13 +60,13 @@ describe('computeStandardPrice long-context tier', () => {
       TIERED_CONFIG,
     );
 
-    expect(price).toBeCloseTo((210_000 * 4 - 60_000 * 4 * 0.84) / 1e6, 12);
+    expect(price).toBeCloseTo((210_000 * 4 - 60_000 * 4 * 0.75) / 1e6, 12);
   });
 
   it('keeps flat rates for a config without a tier, however long the prompt', () => {
     const price = computeStandardPrice(
       { inputTokens: 500_000, outputTokens: 1_000 },
-      { inputPrice: 2, outputPrice: 6, cacheDiscountFactor: 0.16 },
+      { inputPrice: 2, outputPrice: 6, cacheDiscountFactor: 0.25 },
     );
 
     expect(price).toBeCloseTo((500_000 * 2 + 1_000 * 6) / 1e6, 12);


### PR DESCRIPTION
## Summary

#10441 was squash-merged from its first commit before the review-fix commit (`0260930eb6`) landed, so main currently has the grok-4.3/grok-4.6 cache factors **swapped** plus several unaddressed review fixes. This PR re-applies that commit (cherry-picked clean as `c8dca30da2`); #10382 and #10383 landed in full via #10441 and are unaffected.

### Corrected factors (texra-ai review on #10441, High)

docs.x.ai cached rates — grok-4.3: $0.20/M vs $1.25/M input → **0.16**; grok-4.5: $0.30/$2.00 → **0.15**; grok-4.6: $0.50/$2.00 → **0.25**. The first commit assigned 0.25 to grok-4.3 and 0.16 to grok-4.6 (following the issue text's parenthetical); the dollar figures pin the opposite rows. Until this lands, main overbills grok-4.3 cached tokens ($0.3125/M net instead of $0.20/M) and underbills grok-4.6 ($0.32/M instead of $0.50/M; $0.64/M instead of $1.00/M past the 200k tier threshold).

### Review nits from #10441 (codex P1s, claude suggestion)

- Tier-gap warning now passes the model id and context window through the logger's structured `data` argument instead of embedding them in prose.
- The catalog no-discount pin now covers every served xAI entry, not just grok-4.6, so short-window cache-factor drift (below the tier tripwire) is caught too.
- Changelog bullet reworded in product terms (no Fetch internals); `.toSorted()`; import-group labels.

The claude note on warn scope (per handler instance, i.e. once per session using the model — not once per process) is intentionally kept as-is: it still satisfies the "loud instead of silently billing flat" intent and avoids module-level mutable state in the pricing module.

## Validation

- `npx vitest run` on the XaiLongContextPricing + priceUtils suites: 22 passed.
- `npx prettier --check` on the five touched files: clean.
- eslint + workspace/test-kernel typecheck: clean on the source branch before cherry-pick (identical diff).

Closes #10381