### PR TITLE
fix: bound KVStoreCache max, pin LRU recency, and align xAI long-context threshold

### DIFF
--- a/src/agent/modelHandlers/support/priceUtils.ts
+++ b/src/agent/modelHandlers/support/priceUtils.ts
@@ -20,16 +20,16 @@ export interface StandardPricingConfig {
   cacheDiscountFactor: number;
   /**
    * Long-context billing tier (xAI). Once a request's total prompt tokens —
-   * cached included — exceed the model's threshold, the provider bills every
+   * cached included — reach the model's threshold, the provider bills every
    * token of that request at the tier's rates, output tokens included, so the
    * complete tuple switches, not just the input rate.
    */
   longContextTier?: LongContextPricingTier;
 }
 
-/** Rates that apply to the whole request past `thresholdTokens` prompt tokens. */
+/** Rates that apply to the whole request once the prompt reaches `thresholdTokens`. */
 export interface LongContextPricingTier {
-  /** Total prompt tokens above which the tier applies (exclusive boundary). */
+  /** Total prompt tokens at which the tier applies (inclusive boundary). */
   thresholdTokens: number;
   inputPrice: number;
   outputPrice: number;
@@ -63,7 +63,7 @@ export function computeStandardPrice(
   // tier: providers scale the cached rate by the same discount factor.
   const tier =
     config.longContextTier &&
-    tokens.inputTokens > config.longContextTier.thresholdTokens
+    tokens.inputTokens >= config.longContextTier.thresholdTokens
       ? config.longContextTier
       : undefined;
   const inputPrice = tier?.inputPrice ?? config.inputPrice;

--- a/src/common/storage/KVStoreCache.ts
+++ b/src/common/storage/KVStoreCache.ts
@@ -20,6 +20,16 @@ import { LRUCache } from 'lru-cache';
 
 import { KVStore } from '@common/storage/KVStore';
 
+/**
+ * Largest `max` the cache accepts. lru-cache preallocates its key/val lists
+ * with `Array.from({ length: max })`, which throws `RangeError: Invalid array
+ * length` once `max` reaches 2**32 and still attempts a ~4.3B-element
+ * allocation at 2**32 - 1 (the largest valid array length). Cap one below
+ * that so an unsizable `max` fails early with the KVStoreCache-scoped
+ * RangeError instead of inside lru-cache.
+ */
+const MAX_BOUNDED_HANDLES = 2 ** 32 - 2;
+
 export class KVStoreCache<
   TId extends NonNullable<unknown>,
   TStore extends KVStore = KVStore,
@@ -37,15 +47,20 @@ export class KVStoreCache<
     private readonly create: (id: TId) => TStore,
     { max }: { max?: number } = {},
   ) {
-    if (max !== undefined && (!Number.isSafeInteger(max) || max < 1)) {
+    if (
+      max !== undefined &&
+      (!Number.isSafeInteger(max) || max < 1 || max > MAX_BOUNDED_HANDLES)
+    ) {
       // lru-cache already rejects every invalid max at construction, so
       // there is no silent no-cache mode to prevent — but with its own
-      // TypeError (0, -1, 1.5, NaN, Infinity) or a generic Error (integers
-      // beyond the safe range, whose per-cap index array it cannot size).
+      // TypeError (0, -1, 1.5, NaN, Infinity), a generic Error (integers
+      // beyond the safe range, whose per-cap index array it cannot size),
+      // or an array-length RangeError (safe integers larger than
+      // MAX_BOUNDED_HANDLES, whose key/val lists it cannot preallocate).
       // Guard here so every invalid max fails early with one
       // KVStoreCache-scoped RangeError.
       throw new RangeError(
-        `KVStoreCache max must be a positive safe integer (got ${max}); omit it for an unbounded cache`,
+        `KVStoreCache max must be a positive safe integer no larger than ${MAX_BOUNDED_HANDLES} (got ${max}); omit it for an unbounded cache`,
       );
     }
     this.handles = max === undefined ? new Map() : new LRUCache({ max });

--- a/src/test-kernel/agent/modelHandlers/XaiLongContextPricing.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/XaiLongContextPricing.vitest.ts
@@ -161,23 +161,23 @@ describe('xaiLongContextTierGap', () => {
 });
 
 describe('ModelHandlerXAI long-context pricing', () => {
-  it('bills flat rates at the threshold and tier rates past it', () => {
+  it('bills flat rates below the threshold and tier rates once reached', () => {
     const handler = new ModelHandlerXAI(catalogXaiConfig('grok-4.6'));
 
+    expect(
+      handler.computePrice({
+        prompt_tokens: 199_999,
+        completion_tokens: 1_000,
+        total_tokens: 200_999,
+      }),
+    ).toBeCloseTo((199_999 * 2 + 1_000 * 6) / 1e6, 12);
     expect(
       handler.computePrice({
         prompt_tokens: 200_000,
         completion_tokens: 1_000,
         total_tokens: 201_000,
       }),
-    ).toBeCloseTo((200_000 * 2 + 1_000 * 6) / 1e6, 12);
-    expect(
-      handler.computePrice({
-        prompt_tokens: 200_001,
-        completion_tokens: 1_000,
-        total_tokens: 201_001,
-      }),
-    ).toBeCloseTo((200_001 * 4 + 1_000 * 12) / 1e6, 12);
+    ).toBeCloseTo((200_000 * 4 + 1_000 * 12) / 1e6, 12);
   });
 
   it('keeps flat rates for xAI models without a documented tier', () => {

--- a/src/test-kernel/agent/modelHandlers/support/priceUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/support/priceUtils.vitest.ts
@@ -7,8 +7,8 @@ import {
   type StandardPricingConfig,
 } from '@agent/modelHandlers/support/priceUtils';
 
-// grok-4.6's documented rates: $2/$6 flat, doubling to $4/$12 past 200k
-// prompt tokens, with cached tokens at 25% of the input rate in both tiers.
+// grok-4.6's documented rates: $2/$6 flat, doubling to $4/$12 once the prompt
+// reaches 200k tokens, with cached tokens at 25% of the input rate in both tiers.
 const TIERED_CONFIG: StandardPricingConfig = {
   inputPrice: 2,
   outputPrice: 6,
@@ -17,7 +17,24 @@ const TIERED_CONFIG: StandardPricingConfig = {
 };
 
 describe('computeStandardPrice long-context tier', () => {
-  it('bills the flat rates when the prompt ends exactly at the threshold', () => {
+  it('bills the flat rates when the prompt ends one token below the threshold', () => {
+    const price = computeStandardPrice(
+      {
+        inputTokens: 199_999,
+        outputTokens: 1_000,
+        cachedTokens: 50_000,
+        reasoningTokens: 500,
+      },
+      TIERED_CONFIG,
+    );
+
+    expect(price).toBeCloseTo(
+      (199_999 * 2 + 1_000 * 6 + 500 * 6 - 50_000 * 2 * 0.75) / 1e6,
+      12,
+    );
+  });
+
+  it('switches the complete pricing tuple once the prompt reaches the threshold', () => {
     const price = computeStandardPrice(
       {
         inputTokens: 200_000,
@@ -28,27 +45,10 @@ describe('computeStandardPrice long-context tier', () => {
       TIERED_CONFIG,
     );
 
-    expect(price).toBeCloseTo(
-      (200_000 * 2 + 1_000 * 6 + 500 * 6 - 50_000 * 2 * 0.75) / 1e6,
-      12,
-    );
-  });
-
-  it('switches the complete pricing tuple once the prompt crosses the threshold', () => {
-    const price = computeStandardPrice(
-      {
-        inputTokens: 200_001,
-        outputTokens: 1_000,
-        cachedTokens: 50_000,
-        reasoningTokens: 500,
-      },
-      TIERED_CONFIG,
-    );
-
     // Every prompt token rebills at $4 (not just the excess), output and
     // reasoning rise to $12, and the cache rebate follows the tier's rate.
     expect(price).toBeCloseTo(
-      (200_001 * 4 + 1_000 * 12 + 500 * 12 - 50_000 * 4 * 0.75) / 1e6,
+      (200_000 * 4 + 1_000 * 12 + 500 * 12 - 50_000 * 4 * 0.75) / 1e6,
       12,
     );
   });

--- a/src/test-kernel/common/KVStoreCache.vitest.ts
+++ b/src/test-kernel/common/KVStoreCache.vitest.ts
@@ -6,12 +6,27 @@ import { KVStore } from '@common/storage/KVStore';
 describe('KVStoreCache', () => {
   const create = () => new KVStore('/tmp/unused');
 
-  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2 ** 53])(
-    'throws RangeError for max=%s',
-    (max) => {
-      expect(() => new KVStoreCache(create, { max })).toThrow(RangeError);
-    },
-  );
+  it.each([
+    0,
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    2 ** 53,
+    2 ** 32 - 1,
+    2 ** 32,
+  ])('throws the KVStoreCache RangeError for max=%s', (max) => {
+    let caught: unknown;
+    try {
+      new KVStoreCache(create, { max });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(RangeError);
+    expect((caught as RangeError).message).toMatch(
+      /^KVStoreCache max must be a positive safe integer/,
+    );
+  });
 
   it('keeps every cached handle when max is unset (unbounded)', () => {
     const cache = new KVStoreCache(create);
@@ -26,9 +41,11 @@ describe('KVStoreCache', () => {
     const cache = new KVStoreCache(create, { max: 2 });
     const a = cache.get('a');
     const b = cache.get('b');
+    // Refresh `a` so `b`, not `a`, is now the least-recently-used handle.
+    expect(cache.get('a')).toBe(a);
     const c = cache.get('c');
     expect(cache.get('c')).toBe(c);
-    expect(cache.get('b')).toBe(b);
-    expect(cache.get('a')).not.toBe(a);
+    expect(cache.get('a')).toBe(a);
+    expect(cache.get('b')).not.toBe(b);
   });
 });


### PR DESCRIPTION
Follow-up fixes from #10427 and #10360:

- Bound the KVStoreCache max guard so safe integers that lru-cache cannot preallocate fail early with the KVStoreCache-scoped RangeError instead of inside lru-cache.
- Pin recency in the KVStoreCache LRU eviction test (refresh `a` before inserting `c` and assert `b` is evicted).
- Switch the xAI long-context tier at the inclusive threshold (`>= 200_000`), matching the docs.x.ai `Long context ≥ 200k` catalog.

Merged `origin/main` first and re-verified #10380 still applies after #10464. The docs.x.ai catalog carries `longContextThreshold: 200000` uniformly for grok-4.3/4.5/4.6, so the existing 200k table rows remain correct.

Closes #10443
Closes #10444
Closes #10380