### PR TITLE
test(kernel): harden shared support mocks and restore host-agent ratchet coverage

### DIFF
--- a/config/ratchets/host-agent-mock-baseline.json
+++ b/config/ratchets/host-agent-mock-baseline.json
@@ -1,5 +1,5 @@
 {
-  "semantics": "Distinct (file, form, specifier) mock() and doMock() call sites (on vi or on a createModuleMocks() recorder) in host-side (CLI + desktop) test-kernel suites (src/test-kernel/cli/**, src/test-kernel/desktop/**) that mock an internal @agent/* module specifier. Each site pins @agent's current internal module layout from outside src/agent, per issue #7684 QA-2 / #9731. The ratchet fails on any live tuple absent from this baseline (new edge) and on any baseline tuple with no live site (stale headroom); regenerating to remove stale entries is welcome and should shrink this file.",
+  "semantics": "Distinct (file, form, specifier) mock() and doMock() call sites (on vi or on a createModuleMocks() recorder) in host-side (CLI + desktop) test-kernel suites and the shared support modules they import (src/test-kernel/cli/**, src/test-kernel/desktop/**, src/test-kernel/support/**) that mock an internal @agent/* module specifier. Each site pins @agent's current internal module layout from outside src/agent, per issue #7684 QA-2 / #9731. The ratchet fails on any live tuple absent from this baseline (new edge) and on any baseline tuple with no live site (stale headroom); regenerating to remove stale entries is welcome and should shrink this file.",
   "sites": [
     {
       "file": "src/test-kernel/cli/ChatDefaults.vitest.ts",
@@ -160,6 +160,16 @@
       "file": "src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts",
       "form": "doMock",
       "specifier": "@agent/runtime/RunContext"
+    },
+    {
+      "file": "src/test-kernel/support/agentCatalogMock.ts",
+      "form": "mock",
+      "specifier": "@agent/index"
+    },
+    {
+      "file": "src/test-kernel/support/agentStorageFinalizationMock.ts",
+      "form": "mock",
+      "specifier": "@agent/storage"
     }
   ]
 }

--- a/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
+++ b/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
@@ -1,6 +1,8 @@
 // QA-2 host-side mock ratchet (issue #7684, entry-based check #9731). Host
 // suites (CLI + desktop, in src/test-kernel/cli and src/test-kernel/desktop)
-// reach into `@agent/*` internals via `mock('@agent/...')` or
+// and the shared support modules extracted from them (#10361, in
+// src/test-kernel/support) reach into `@agent/*` internals via
+// `mock('@agent/...')` or
 // `doMock('@agent/...')` — on `vi` or on a suite's `createModuleMocks()`
 // recorder — pinning agent's current internal module layout from outside
 // src/agent.
@@ -58,6 +60,9 @@ const BASELINE_PATH = resolve(REPO_ROOT, BASELINE_FILE);
 const HOST_DIRS = [
   resolve(REPO_ROOT, 'src/test-kernel/cli'),
   resolve(REPO_ROOT, 'src/test-kernel/desktop'),
+  // The shared mock modules the host suites import; #10361 moved the last
+  // live `@agent/*` registrations here, out of the per-host dirs (#10376).
+  resolve(REPO_ROOT, 'src/test-kernel/support'),
 ];
 
 const AGENT_SPECIFIER = /^@agent(?:\/|$)/;

--- a/src/test-kernel/architecture/supportMockImportOrder.vitest.ts
+++ b/src/test-kernel/architecture/supportMockImportOrder.vitest.ts
@@ -1,0 +1,176 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Third-party imports
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+import { REPO_ROOT, sourceFilesUnder, toRepoPath } from '../support/repoScan';
+
+/**
+ * Architecture guard for the shared mock modules extracted by #10361.
+ *
+ * Those modules register `vi.mock(...)` when they evaluate, and their factories
+ * close over `vi.hoisted` bags, so a suite must evaluate each shared-mock
+ * import before anything that could load the mocked module. The mechanical
+ * convention is: shared `@test/support/*Mock` imports sit immediately after
+ * the `vitest` import (node builtins may still precede vitest), before any
+ * other project import. This test pins that ordering and fails on type-only
+ * shared-mock imports, which would not register the mock.
+ */
+
+const SUPPORT_MOCK_SPECIFIERS = new Set([
+  '@test/support/agentCatalogMock',
+  '@test/support/agentStorageFinalizationMock',
+  '@test/support/cliInitPlatformMock',
+  '@test/support/cliLogSinksMock',
+  '@test/support/cliOutputMock',
+]);
+
+const HOST_SUITE_DIRS = [
+  'src/test-kernel/cli',
+  'src/test-kernel/desktop',
+] as const;
+
+/** The five suites #10361 migrated to the shared mock modules. */
+const MIGRATED_SUITES = [
+  'src/test-kernel/cli/AgentResolution.vitest.ts',
+  'src/test-kernel/cli/AgentsCommand.vitest.ts',
+  'src/test-kernel/cli/AgentsRunCommand.vitest.ts',
+  'src/test-kernel/cli/MultiAgentRunCommand.vitest.ts',
+  'src/test-kernel/cli/WorkflowRunCommand.vitest.ts',
+] as const;
+
+interface ImportSite {
+  specifier: string;
+  isTypeOnly: boolean;
+}
+
+function collectImports(file: string): ImportSite[] {
+  const source = readFileSync(file, 'utf8');
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+
+  const imports: ImportSite[] = [];
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    const specifier = statement.moduleSpecifier;
+    if (specifier == null || !ts.isStringLiteralLike(specifier)) continue;
+    imports.push({
+      specifier: specifier.text,
+      isTypeOnly: statement.importClause?.isTypeOnly ?? false,
+    });
+  }
+  return imports;
+}
+
+function violation(file: string, message: string): string {
+  return `${file}: ${message}`;
+}
+
+interface SuiteAudit {
+  readonly hasSharedMockImport: boolean;
+  readonly violations: string[];
+}
+
+function auditSuite(file: string, imports: readonly ImportSite[]): SuiteAudit {
+  const shared = imports.filter((site) =>
+    SUPPORT_MOCK_SPECIFIERS.has(site.specifier),
+  );
+  if (shared.length === 0) {
+    return { hasSharedMockImport: false, violations: [] };
+  }
+
+  const repoPath = toRepoPath(file);
+  const vitestIndex = imports.findIndex((site) => site.specifier === 'vitest');
+  if (vitestIndex === -1) {
+    return {
+      hasSharedMockImport: true,
+      violations: [
+        violation(
+          repoPath,
+          `imports ${shared.map((site) => `'${site.specifier}'`).join(', ')} without a 'vitest' import`,
+        ),
+      ],
+    };
+  }
+
+  const violations: string[] = [];
+  for (const before of imports.slice(0, vitestIndex)) {
+    if (!before.specifier.startsWith('node:')) {
+      violations.push(
+        violation(
+          repoPath,
+          `non-node import '${before.specifier}' precedes the vitest import`,
+        ),
+      );
+    }
+  }
+
+  const firstAfterVitest = imports[vitestIndex + 1];
+  if (
+    firstAfterVitest == null ||
+    !SUPPORT_MOCK_SPECIFIERS.has(firstAfterVitest.specifier)
+  ) {
+    violations.push(
+      violation(
+        repoPath,
+        `first import after vitest is '${firstAfterVitest?.specifier ?? 'none'}', not a shared @test/support/*Mock import`,
+      ),
+    );
+  }
+
+  for (let offset = 0; offset < shared.length; offset += 1) {
+    const site = imports[vitestIndex + 1 + offset];
+    if (site == null || !SUPPORT_MOCK_SPECIFIERS.has(site.specifier)) {
+      violations.push(
+        violation(
+          repoPath,
+          'shared @test/support/*Mock imports must form one contiguous block immediately after the vitest import',
+        ),
+      );
+      break;
+    }
+    if (site.isTypeOnly) {
+      violations.push(
+        violation(
+          repoPath,
+          `shared mock import '${site.specifier}' is type-only and would not register the mock`,
+        ),
+      );
+    }
+  }
+
+  return { hasSharedMockImport: true, violations };
+}
+
+describe('shared test-kernel mock import order', () => {
+  const checkedSuites: string[] = [];
+  const violations: string[] = [];
+
+  for (const dir of HOST_SUITE_DIRS) {
+    for (const file of sourceFilesUnder(resolve(REPO_ROOT, dir))) {
+      const imports = collectImports(file);
+      const audit = auditSuite(file, imports);
+      if (audit.hasSharedMockImport) checkedSuites.push(toRepoPath(file));
+      violations.push(...audit.violations);
+    }
+  }
+
+  it('keeps shared @test/support/*Mock imports immediately after the vitest import', () => {
+    expect(
+      violations,
+      'Shared mock import-order violations:\n' + violations.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('covers the #10361 migrated suites', () => {
+    expect(checkedSuites).toEqual(expect.arrayContaining([...MIGRATED_SUITES]));
+  });
+});

--- a/src/test-kernel/cli/AgentResolution.vitest.ts
+++ b/src/test-kernel/cli/AgentResolution.vitest.ts
@@ -1,10 +1,7 @@
 /* eslint-disable import/order -- Vitest mocks must be declared before importing the runtime under test. */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  agentCatalogMock,
-  resetAgentCatalogMock,
-} from '@test/support/agentCatalogMock';
+import { agentCatalogMock } from '@test/support/agentCatalogMock';
 import type { AgentEntry, ResolvedAgent } from '@agent/index';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
@@ -39,7 +36,7 @@ function resolution(entry: AgentEntry): ResolvedAgent {
 
 describe('CLI agent resolution', () => {
   beforeEach(() => {
-    resetAgentCatalogMock();
+    for (const mock of Object.values(agentCatalogMock)) mock.mockReset();
     isAuthenticatedSpy.mockReset().mockResolvedValue(false);
     canAccessRemoteAgentCatalogSpy.mockReset().mockResolvedValue(false);
   });

--- a/src/test-kernel/cli/AgentsCommand.vitest.ts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.ts
@@ -1,12 +1,16 @@
+/* eslint-disable import/order -- Vitest mocks must be declared before importing the runtime under test. */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { CliContext } from '@cli/runtime/cliContext';
-import { AgentCategory } from '@shared/schemas';
-import { createRunCommandCliContext } from '@test/cli/fixtures/cliContext';
+// Shared mock registrations must evaluate before anything that loads
+// the mocked modules — keep these imports immediately after the vitest
+// import (enforced by architecture/supportMockImportOrder.vitest.ts).
 import { agentCatalogMock } from '@test/support/agentCatalogMock';
 import { cliInitPlatformMock } from '@test/support/cliInitPlatformMock';
 import { cliLogSinksMock } from '@test/support/cliLogSinksMock';
 import { cliOutputMock } from '@test/support/cliOutputMock';
+
+import { AgentCategory } from '@shared/schemas';
+import { createRunCommandCliContext } from '@test/cli/fixtures/cliContext';
 
 const mocks = vi.hoisted(() => ({
   resolveCliAgent: vi.fn(),

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.ts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.ts
@@ -1,14 +1,19 @@
+/* eslint-disable import/order -- Vitest mocks must be declared before importing the runtime under test. */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { CliContext } from '@cli/runtime/cliContext';
-import { CliExitCode } from '@cli/runtime/exitCodes';
-import { RUN_OUTCOME, AgentCategory } from '@shared/schemas';
-import { createRunCommandCliContext } from '@test/cli/fixtures/cliContext';
+// Shared mock registrations must evaluate before anything that loads
+// the mocked modules — keep these imports immediately after the vitest
+// import (enforced by architecture/supportMockImportOrder.vitest.ts).
 import '@test/support/agentCatalogMock';
 import '@test/support/agentStorageFinalizationMock';
 import { cliInitPlatformMock } from '@test/support/cliInitPlatformMock';
 import { cliLogSinksMock } from '@test/support/cliLogSinksMock';
 import { cliOutputMock } from '@test/support/cliOutputMock';
+
+import type { CliContext } from '@cli/runtime/cliContext';
+import { CliExitCode } from '@cli/runtime/exitCodes';
+import { RUN_OUTCOME, AgentCategory } from '@shared/schemas';
+import { createRunCommandCliContext } from '@test/cli/fixtures/cliContext';
 
 const mocks = vi.hoisted(() => ({
   executeCliToolUseConfig: vi.fn(),

--- a/src/test-kernel/cli/CliRootArgs.vitest.ts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.ts
@@ -47,7 +47,6 @@ import {
   knownCliModelIds,
   resolveKnownCliModelId,
 } from '@cli/runtime/cliConfig';
-import type { CliContext } from '@cli/runtime/cliContext';
 import { pickGlobalArgs } from '@cli/runtime/globalArgs';
 import { RUN_OUTCOME, AgentCategory } from '@shared/schemas';
 import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.ts
@@ -1,18 +1,23 @@
+/* eslint-disable import/order -- Vitest mocks must be declared before importing the runtime under test. */
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { SupabaseClient } from '@auth/SupabaseClient';
-import type { CliContext } from '@cli/runtime/cliContext';
-import { RUN_OUTCOME } from '@shared/schemas';
-import { createRunCommandCliContext } from '@test/cli/fixtures/cliContext';
+// Shared mock registrations must evaluate before anything that loads
+// the mocked modules — keep these imports immediately after the vitest
+// import (enforced by architecture/supportMockImportOrder.vitest.ts).
 import { agentCatalogMock } from '@test/support/agentCatalogMock';
 import '@test/support/agentStorageFinalizationMock';
 import { cliInitPlatformMock } from '@test/support/cliInitPlatformMock';
 import { cliLogSinksMock } from '@test/support/cliLogSinksMock';
 import { cliOutputMock } from '@test/support/cliOutputMock';
+
+import { SupabaseClient } from '@auth/SupabaseClient';
+import type { CliContext } from '@cli/runtime/cliContext';
+import { RUN_OUTCOME } from '@shared/schemas';
+import { createRunCommandCliContext } from '@test/cli/fixtures/cliContext';
 
 const mocks = vi.hoisted(() => ({
   executeCliToolUseConfig: vi.fn(),

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
@@ -1,7 +1,15 @@
+/* eslint-disable import/order -- Vitest mocks must be declared before importing the runtime under test. */
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Shared mock registrations must evaluate before anything that loads
+// the mocked modules — keep these imports immediately after the vitest
+// import (enforced by architecture/supportMockImportOrder.vitest.ts).
+import '@test/support/agentCatalogMock';
+import { cliInitPlatformMock } from '@test/support/cliInitPlatformMock';
+import { cliLogSinksMock } from '@test/support/cliLogSinksMock';
 
 import type { runWorkflowAgent } from '@cli/commands/workflow';
 import { formatResumeCommand } from '@cli/chat/tui/state/resumeHint';
@@ -13,10 +21,7 @@ import type {
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { RUN_OUTCOME, type ExecutionId, AgentCategory } from '@shared/schemas';
 import { createRunCommandCliContext } from '@test/cli/fixtures/cliContext';
-import '@test/support/agentCatalogMock';
 import { durableFinalizationResult } from '@test/support/agentStorageFixtures';
-import { cliInitPlatformMock } from '@test/support/cliInitPlatformMock';
-import { cliLogSinksMock } from '@test/support/cliLogSinksMock';
 import { withTempDir } from '@test/support/tempDirPlatform';
 
 const mocks = vi.hoisted(() => {

--- a/src/test-kernel/support/agentCatalogMock.ts
+++ b/src/test-kernel/support/agentCatalogMock.ts
@@ -3,8 +3,8 @@ import { vi } from 'vitest';
 
 /**
  * Shared mock for the `@agent/index` agent-catalog surface that CLI command
- * suites stub identically: the mock bag, the `vi.mock` registration, and the
- * reset ritual live here instead of being re-declared per suite.
+ * suites stub identically: the mock bag and the `vi.mock` registration live
+ * here instead of being re-declared per suite.
  *
  * Importing this module registers the mock for the importing suite. The bag
  * is the union of the members the migrated suites stub; members a suite never
@@ -12,23 +12,23 @@ import { vi } from 'vitest';
  * graph, so the singleton bag is per-suite at runtime — reset it in the
  * suite's own `beforeEach` (or via `vi.clearAllMocks()`) like a local bag.
  *
- * Ordering: this module must evaluate before anything that loads
- * `@agent/index`. Suites that `await import()` the command under test get
- * that for free; suites that import the module under test statically must
- * import this module first (see `defaultSessionTestSetup` for the idiom).
+ * Ordering: the `vi.mock` below registers when this module evaluates, so the
+ * import must precede anything that could load `@agent/index`. Suites that
+ * `await import()` the command under test get that for free; suites with
+ * static imports keep this import immediately after the vitest import (see
+ * `AgentResolution.vitest.ts`) — a convention the
+ * `supportMockImportOrder.vitest.ts` architecture test enforces. The bag is
+ * `vi.hoisted`, so the mock factory can never observe it uninitialized.
  */
-export const agentCatalogMock = {
+const agentCatalogMock = vi.hoisted(() => ({
   getAgent: vi.fn(),
   getAgentsByCategory: vi.fn(),
   getVisibleAgents: vi.fn(),
   loadAgents: vi.fn(),
   refresh: vi.fn(),
   resolveAgentForLaunch: vi.fn(),
-};
+}));
 
 vi.mock('@agent/index', () => ({ ...agentCatalogMock }));
 
-/** Resets every catalog mock — implementations included — for test isolation. */
-export function resetAgentCatalogMock(): void {
-  for (const mock of Object.values(agentCatalogMock)) mock.mockReset();
-}
+export { agentCatalogMock };

--- a/src/test-kernel/support/agentStorageFinalizationMock.ts
+++ b/src/test-kernel/support/agentStorageFinalizationMock.ts
@@ -10,22 +10,31 @@ import { durableFinalizationResult } from './agentStorageFixtures';
  * bag and the `vi.mock` registration live here instead of being re-declared
  * per suite.
  *
- * Importing this module registers the mock for the importing suite — do not
- * combine it with a suite-local `vi.mock('@agent/storage', ...)` (the two
- * registrations would race). The bag is module-local: suites use the
- * side-effect import and assert through their own `@agent/storage` doubles.
- * Suites needing more than the finalization edge (e.g. `getExecutionStore`)
- * keep their own local mock and use {@link durableFinalizationResult}
- * directly. Vitest gives each test file a
+ * Importing this module registers the mock for the importing suite. Suites
+ * needing only the default durable result use the side-effect import; suites
+ * asserting on `finalizeExecution` — or needing more than the finalization
+ * edge, e.g. `getExecutionStore` — keep a local `vi.mock('@agent/storage',
+ * ...)` (the `WorkflowRunCommand` pattern, using
+ * {@link durableFinalizationResult} for the default) and must not import this
+ * module: the two registrations would race. Vitest gives each test file a
  * fresh module graph, so the singleton bag is per-suite at runtime; the
  * default implementation survives `vi.clearAllMocks()`.
  *
- * Ordering: this module must evaluate before anything that loads
- * `@agent/storage` (see `agentCatalogMock` for the idiom).
+ * Ordering: the `vi.mock` below registers when this module evaluates, so the
+ * import must precede anything that could load `@agent/storage` (see
+ * `agentCatalogMock` for the idiom). The bag is `vi.hoisted`, so the mock
+ * factory can never observe it uninitialized.
  */
-const agentStorageFinalizationMock = {
-  finalizeExecution: vi.fn(async () => durableFinalizationResult()),
-};
+const agentStorageFinalizationMock = vi.hoisted(() => ({
+  finalizeExecution: vi.fn(),
+}));
+
+// A hoisted factory cannot close over the imported fixture, so the default
+// durable implementation is installed here instead — mockClear (and hence
+// vi.clearAllMocks()) preserves it.
+agentStorageFinalizationMock.finalizeExecution.mockImplementation(async () =>
+  durableFinalizationResult(),
+);
 
 vi.mock('@agent/storage', () => ({
   finalizeExecution: agentStorageFinalizationMock.finalizeExecution,

--- a/src/test-kernel/support/cliInitPlatformMock.ts
+++ b/src/test-kernel/support/cliInitPlatformMock.ts
@@ -11,12 +11,16 @@ import { vi } from 'vitest';
  * per-suite at runtime — clear it in the suite's own `beforeEach`
  * (`vi.clearAllMocks()` covers it).
  *
- * Ordering: this module must evaluate before anything that loads
- * `@cli/runtime/initPlatform` (see `agentCatalogMock` for the idiom).
+ * Ordering: the `vi.mock` below registers when this module evaluates, so the
+ * import must precede anything that could load `@cli/runtime/initPlatform`
+ * (see `agentCatalogMock` for the idiom). The bag is `vi.hoisted`, so the
+ * mock factory can never observe it uninitialized.
  */
-export const cliInitPlatformMock = {
+const cliInitPlatformMock = vi.hoisted(() => ({
   initCliPlatform: vi.fn(),
   initLocalCliPlatform: vi.fn(),
-};
+}));
 
 vi.mock('@cli/runtime/initPlatform', () => ({ ...cliInitPlatformMock }));
+
+export { cliInitPlatformMock };

--- a/src/test-kernel/support/cliLogSinksMock.ts
+++ b/src/test-kernel/support/cliLogSinksMock.ts
@@ -13,15 +13,19 @@ import { vi } from 'vitest';
  * suite's own `beforeEach` (`vi.clearAllMocks()` covers it, and preserves the
  * `writeTextStderrAndWait` default implementation).
  *
- * Ordering: this module must evaluate before anything that loads
- * `@cli/runtime/logSinks` (see `agentCatalogMock` for the idiom).
+ * Ordering: the `vi.mock` below registers when this module evaluates, so the
+ * import must precede anything that could load `@cli/runtime/logSinks` (see
+ * `agentCatalogMock` for the idiom). The bag is `vi.hoisted`, so the mock
+ * factory can never observe it uninitialized.
  */
-export const cliLogSinksMock = {
+const cliLogSinksMock = vi.hoisted(() => ({
   writeErrorStderr: vi.fn(),
   writeNdjsonStdout: vi.fn(),
   writeTextStderr: vi.fn(),
   writeTextStderrAndWait: vi.fn(async () => undefined),
   writeTextStdout: vi.fn(),
-};
+}));
 
 vi.mock('@cli/runtime/logSinks', () => ({ ...cliLogSinksMock }));
+
+export { cliLogSinksMock };

--- a/src/test-kernel/support/cliOutputMock.ts
+++ b/src/test-kernel/support/cliOutputMock.ts
@@ -11,11 +11,16 @@ import { vi } from 'vitest';
  * per-suite at runtime — clear it in the suite's own `beforeEach`
  * (`vi.clearAllMocks()` covers it).
  *
- * Ordering: this module must evaluate before anything that loads
- * `@cli/commands/_helpers/output` (see `agentCatalogMock` for the idiom).
+ * Ordering: the `vi.mock` below registers when this module evaluates, so the
+ * import must precede anything that could load
+ * `@cli/commands/_helpers/output` (see `agentCatalogMock` for the idiom). The
+ * bag is `vi.hoisted`, so the mock factory can never observe it
+ * uninitialized.
  */
-export const cliOutputMock = {
+const cliOutputMock = vi.hoisted(() => ({
   emitCliResult: vi.fn(),
-};
+}));
 
 vi.mock('@cli/commands/_helpers/output', () => ({ ...cliOutputMock }));
+
+export { cliOutputMock };


### PR DESCRIPTION
Three follow-ups to #10361 on the shared test-kernel support mocks.

- #10376: extend the host-agent-mock ratchet scan to `src/test-kernel/support` and baseline the two `@agent/*` registrations moved there.
- #10377: wrap the five shared mock bags in `vi.hoisted`, move shared-mock imports directly after the vitest import in the migrated suites, and add `supportMockImportOrder.vitest.ts` to enforce that ordering.
- #10378: inline `resetAgentCatalogMock` at its single call site, drop the now-unused `CliContext` imports, and reword the `agentStorageFinalizationMock` contract doc.

Local validation: `npm run typecheck`, targeted eslint, `npx vitest run src/test-kernel/architecture/` + the five migrated CLI suites + `CliRootArgs.vitest.ts`, `npx prettier --check` on touched files, and `npm run check:dead-code-ratchet` all pass.

Closes #10376
Closes #10377
Closes #10378