### PR TITLE
fix(desktop): settle diff host cleanup across reopen and removal races

### DIFF
--- a/packages/desktop/src/main/desktopDiffHost.ts
+++ b/packages/desktop/src/main/desktopDiffHost.ts
@@ -42,93 +42,155 @@ export function createDesktopDiffHost(
   // OS editor may still be reading it, so each fallback run records its
   // directory here and `dispose()` removes them when the window closes.
   const externalPatchDirs = new Set<string>();
+  // One removal promise per temp directory. Both the fallback error path and
+  // `dispose()` request removals, and sharing the promise avoids two
+  // concurrent recursive `rm` calls on the same path (which can fail with
+  // `EBUSY`/`EPERM` on Windows). The memo is cleared when the removal settles
+  // so a failed removal can be retried instead of caching a rejection.
+  const pendingRemovals = new Map<string, Promise<void>>();
+  // Fallback setup in flight: the read/compute/temp-dir-creation prefix of
+  // `openDiff`, tracked from the start of the call. `dispose()` awaits these
+  // so the quit lifecycle also waits for the `disposed` branch below, which
+  // can start its removal only after this setup finishes.
+  const inFlightFallbacks = new Set<Promise<void>>();
   // Set when dispose() starts. A fallback still in flight checks this before
   // recording its temp directory: the set has already been snapshotted and
   // cleared, so recording would leak the directory.
   let disposed = false;
+
+  function removeTempDir(tempDir: string): Promise<void> {
+    const pending = pendingRemovals.get(tempDir);
+    if (pending) return pending;
+    const removal = rm(tempDir, { recursive: true, force: true }).finally(
+      () => {
+        pendingRemovals.delete(tempDir);
+      },
+    );
+    pendingRemovals.set(tempDir, removal);
+    return removal;
+  }
+
+  // Returns an idempotent settle function for a promise held in
+  // `inFlightFallbacks`. The promise resolves only, so callers never have to
+  // handle a rejection from the bookkeeping slot.
+  function trackFallbackSetup(): () => void {
+    let settle!: () => void;
+    const setup = new Promise<void>((resolve) => {
+      settle = resolve;
+    });
+    inFlightFallbacks.add(setup);
+    void setup.finally(() => inFlightFallbacks.delete(setup));
+    return settle;
+  }
 
   async function openDiff(
     original: DiffSource,
     proposed: DiffSource,
     title: string,
   ): Promise<DiffSession> {
-    const [originalContent, proposedContent] = await Promise.all([
-      readFile(original.filePath, 'utf8'),
-      readFile(proposed.filePath, 'utf8'),
-    ]);
-    const lineChanges = computeLineChangeSummary(
-      originalContent,
-      proposedContent,
-    );
-
-    // Prefer the in-app Review workbench when wired. A `false` return value or
-    // a thrown error opts into the external-editor fallback (covers the
-    // startup IPC race, destroyed BrowserWindow, and `forceExternal`).
-    const shownInRenderer = tryShowInRenderer(
-      { ...options, source: 'desktopDiffHost', fallback: 'external editor' },
-      {
-        command: DESKTOP_DIFF_COMMANDS.SHOW_DIFF,
-        title,
-        displayPath: title.replace(/^Tool edit:\s*/, ''),
-        originalText: originalContent,
-        proposedText: proposedContent,
-        additions: lineChanges.added,
-        deletions: lineChanges.removed,
-        language: monacoLanguageForPath(proposed.filePath ?? ''),
-      } satisfies DesktopShowDiffMessage,
-    );
-    if (shownInRenderer) return { original, proposed, title };
-
-    // External-editor fallback: write a unified patch file and open it.
-    const patch =
-      computeUserPatch(originalContent, proposedContent) ??
-      `No textual changes for ${path.basename(proposed.filePath)}.\n`;
-    const tempDir = await createTexraTempDir('texra-desktop-diff-');
-    if (disposed) {
-      // The window closed while this fallback was in flight and dispose() has
-      // already drained the record set, so recording the directory now would
-      // leak it. Remove it immediately and stop instead.
-      try {
-        await rm(tempDir, { recursive: true, force: true });
-      } catch (cleanupError) {
-        console.warn(
-          `[desktop] Failed to remove the temporary diff directory after the window closed: ${toErrorMessage(cleanupError)}`,
-        );
-      }
-      throw new Error('Desktop window closed before the diff could be opened.');
-    }
-    externalPatchDirs.add(tempDir);
-    const diffPath = path.join(tempDir, `${nanoid()}.diff`);
-
+    const settleFallbackSetup = trackFallbackSetup();
     try {
-      await writeFile(diffPath, patch, 'utf8');
-      await options.openPath(diffPath);
-    } catch (error) {
-      // The patch never reached an editor: clean it up now instead of waiting
-      // for window close, and preserve the original failure for the caller.
-      // Keep the directory recorded when the removal fails so dispose() can
-      // retry it, and log instead of swallowing the failure.
-      try {
-        await rm(tempDir, { recursive: true, force: true });
-        externalPatchDirs.delete(tempDir);
-      } catch (cleanupError) {
-        console.warn(
-          `[desktop] Failed to remove the temporary diff directory; will retry when the window closes: ${toErrorMessage(cleanupError)}`,
+      const [originalContent, proposedContent] = await Promise.all([
+        readFile(original.filePath, 'utf8'),
+        readFile(proposed.filePath, 'utf8'),
+      ]);
+      const lineChanges = computeLineChangeSummary(
+        originalContent,
+        proposedContent,
+      );
+
+      // Prefer the in-app Review workbench when wired. A `false` return value
+      // or a thrown error opts into the external-editor fallback (covers the
+      // startup IPC race, destroyed BrowserWindow, and `forceExternal`).
+      const shownInRenderer = tryShowInRenderer(
+        { ...options, source: 'desktopDiffHost', fallback: 'external editor' },
+        {
+          command: DESKTOP_DIFF_COMMANDS.SHOW_DIFF,
+          title,
+          displayPath: title.replace(/^Tool edit:\s*/, ''),
+          originalText: originalContent,
+          proposedText: proposedContent,
+          additions: lineChanges.added,
+          deletions: lineChanges.removed,
+          language: monacoLanguageForPath(proposed.filePath ?? ''),
+        } satisfies DesktopShowDiffMessage,
+      );
+      if (shownInRenderer) return { original, proposed, title };
+
+      // External-editor fallback: write a unified patch file and open it.
+      const patch =
+        computeUserPatch(originalContent, proposedContent) ??
+        `No textual changes for ${path.basename(proposed.filePath)}.\n`;
+      const tempDir = await createTexraTempDir('texra-desktop-diff-');
+      if (disposed) {
+        // The window closed while this fallback was in flight and dispose()
+        // has already drained the record set, so recording the directory now
+        // would leak it. Remove it immediately and stop instead.
+        try {
+          await removeTempDir(tempDir);
+        } catch (cleanupError) {
+          console.warn(
+            `[desktop] Failed to remove the temporary diff directory after the window closed: ${toErrorMessage(cleanupError)}`,
+          );
+        }
+        throw new Error(
+          'Desktop window closed before the diff could be opened.',
         );
       }
-      throw error;
-    }
+      externalPatchDirs.add(tempDir);
+      // From here dispose() owns the directory through `externalPatchDirs`,
+      // so the fallback setup no longer needs its own dispose-time wait.
+      settleFallbackSetup();
+      const diffPath = path.join(tempDir, `${nanoid()}.diff`);
 
-    return { original, proposed, title };
+      try {
+        await writeFile(diffPath, patch, 'utf8');
+        await options.openPath(diffPath);
+      } catch (error) {
+        // The patch never reached an editor: clean it up now instead of
+        // waiting for window close, and preserve the original failure for the
+        // caller. Keep the directory recorded when the removal fails so
+        // dispose() can retry it, and log instead of swallowing the failure.
+        try {
+          await removeTempDir(tempDir);
+          externalPatchDirs.delete(tempDir);
+        } catch (cleanupError) {
+          console.warn(
+            `[desktop] Failed to remove the temporary diff directory; will retry when the window closes: ${toErrorMessage(cleanupError)}`,
+          );
+        }
+        throw error;
+      }
+
+      return { original, proposed, title };
+    } finally {
+      settleFallbackSetup();
+    }
   }
 
   async function dispose(): Promise<void> {
     disposed = true;
+    // Wait for every fallback that was still setting up when the window
+    // closed. A setup that had not yet created its temp directory now sees
+    // `disposed` and removes it itself; awaiting the setup here keeps the quit
+    // lifecycle from resolving before that post-disposal removal finishes.
+    await Promise.allSettled([...inFlightFallbacks]);
     const tempDirs = [...externalPatchDirs];
     externalPatchDirs.clear();
-    await Promise.all(
-      tempDirs.map((tempDir) => rm(tempDir, { recursive: true, force: true })),
+    const results = await Promise.allSettled(
+      tempDirs.map((tempDir) => removeTempDir(tempDir)),
     );
+    const failures = results.filter(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
+    );
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures.map((failure) => failure.reason),
+        `Failed to remove ${failures.length} diff temp ${
+          failures.length === 1 ? 'directory' : 'directories'
+        }.`,
+      );
+    }
   }
 
   return { openDiff, dispose };

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1099,9 +1099,12 @@ function createWindow(options: {
     // Not fire-and-forget: every quit path (window-all-closed on Windows and
     // Linux, continueQuit, the workspace relaunch's app.quit()) reaches the
     // before-quit handler, whose lifecycle drain awaits this promise before
-    // the final quit.
-    pendingDesktopDiffHostDispose = desktopDiffHost
-      .dispose()
+    // the final quit. Chaining onto the previous value keeps a macOS
+    // dock-reopen from discarding an earlier window's still-running cleanup.
+    pendingDesktopDiffHostDispose = (
+      pendingDesktopDiffHostDispose ?? Promise.resolve()
+    )
+      .then(() => desktopDiffHost.dispose())
       .catch(reportAsyncError);
     executionsWatcher?.close();
     if (mainWindow === window) {

--- a/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
+++ b/src/test-kernel/desktop/DesktopDiffHost.vitest.ts
@@ -265,4 +265,130 @@ describe('createDesktopDiffHost', () => {
     expect(openPath).not.toHaveBeenCalled();
     expect(listDiffTempDirs()).toEqual(diffDirsBefore);
   });
+
+  it('settles every removal before dispose rejects when one rm fails', async () => {
+    // `Promise.all` would reject at the first failed `rm` while its siblings
+    // are still running; the quit drain could then proceed to `app.quit()`
+    // before those siblings finish. `dispose()` must settle all of them and
+    // only then surface the failure.
+    const { host, openedPaths } = createHost();
+
+    await openDiffPair(host, 'Compare 1', ['a.tex', 'b.tex']);
+    await openDiffPair(host, 'Compare 2', ['c.tex', 'd.tex']);
+    const [firstDir, secondDir] = openedPaths.map((openedPath) =>
+      path.dirname(openedPath),
+    );
+    // Record both so afterEach removes whichever directory dispose() leaves
+    // behind after the one-shot removal failure below.
+    tempDirs.push(firstDir, secondDir);
+
+    vi.mocked(rm).mockRejectedValueOnce(new Error('simulated removal failure'));
+
+    await expect(host.dispose()).rejects.toBeInstanceOf(AggregateError);
+
+    // The failed removal leaves its directory behind (afterEach cleans it
+    // up), but the sibling removal has already settled before dispose() threw.
+    expect(existsSync(firstDir)).toBe(true);
+    expect(existsSync(secondDir)).toBe(false);
+  });
+
+  it('keeps dispose pending until an in-flight fallback removes its post-disposal directory', async () => {
+    // The disposal-race test above awaits `openPromise`, which hides the quit
+    // gap: a normal window close does not await the untracked `openDiff`
+    // promise. `dispose()` must instead await the fallback setup and the
+    // removal its `disposed` branch performs.
+    const { host, openPath } = createHost();
+    const [original, proposed] = await prepareDiffPair();
+    const diffDirsBefore = listDiffTempDirs();
+
+    let releaseRemoval!: () => void;
+    const removalGate = new Promise<void>((resolve) => {
+      releaseRemoval = resolve;
+    });
+    let removalTarget: string | undefined;
+    const actualFs =
+      await vi.importActual<typeof import('node:fs/promises')>(
+        'node:fs/promises',
+      );
+    vi.mocked(rm).mockImplementationOnce(async (target, options) => {
+      removalTarget = String(target);
+      await removalGate;
+      await actualFs.rm(
+        target as string,
+        options as Parameters<typeof actualFs.rm>[1],
+      );
+    });
+
+    const openPromise = host.openDiff(original, proposed, 'Compare');
+    const disposePromise = host.dispose();
+
+    await vi.waitFor(() => {
+      expect(removalTarget).toBeDefined();
+    });
+
+    let disposeSettled = false;
+    void disposePromise.then(() => {
+      disposeSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(disposeSettled).toBe(false);
+
+    releaseRemoval();
+    await expect(openPromise).rejects.toThrow(
+      'Desktop window closed before the diff could be opened.',
+    );
+    await disposePromise;
+
+    expect(openPath).not.toHaveBeenCalled();
+    expect(listDiffTempDirs()).toEqual(diffDirsBefore);
+  });
+
+  it('shares an in-flight error-path removal with dispose instead of double-removing', async () => {
+    // If dispose() runs while the fallback error path is already removing its
+    // directory, both sides must await the same per-path removal promise. Two
+    // concurrent recursive `rm`s on one path can fail on Windows; the second
+    // one could also fail after dispose() has cleared the record set, leaving
+    // the directory untracked.
+    const { host, openPath } = createHost();
+    openPath.mockRejectedValue(new Error('editor unavailable'));
+
+    let releaseRemoval!: () => void;
+    const removalGate = new Promise<void>((resolve) => {
+      releaseRemoval = resolve;
+    });
+    let removalTarget: string | undefined;
+    const actualFs =
+      await vi.importActual<typeof import('node:fs/promises')>(
+        'node:fs/promises',
+      );
+    vi.mocked(rm).mockImplementationOnce(async (target, options) => {
+      removalTarget = String(target);
+      await removalGate;
+      await actualFs.rm(
+        target as string,
+        options as Parameters<typeof actualFs.rm>[1],
+      );
+    });
+
+    const openPromise = openDiffPair(host, 'Compare');
+    await vi.waitFor(() => {
+      expect(removalTarget).toBeDefined();
+    });
+
+    const disposePromise = host.dispose();
+    // Give dispose() time to snapshot the still-recorded directory and request
+    // its removal. The per-path memo must return the gated removal above
+    // instead of issuing a second `rm`.
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const targetCalls = vi
+      .mocked(rm)
+      .mock.calls.filter(([target]) => String(target) === removalTarget);
+    expect(targetCalls).toHaveLength(1);
+
+    releaseRemoval();
+    await expect(openPromise).rejects.toThrow('editor unavailable');
+    await disposePromise;
+
+    expect(existsSync(removalTarget!)).toBe(false);
+  });
 });


### PR DESCRIPTION
Follow-ups to #10437 for `DesktopDiffHost` lifecycle cleanup.

## Changes

- **#10447** — `index.ts` chains each window's `pendingDesktopDiffHostDispose` onto the previous value, so a macOS dock-reopen cannot overwrite an earlier window's still-running disposal and let it race the final quit.
- **#10448** — `desktopDiffHost.dispose()` now uses `Promise.allSettled` and throws an aggregated `AggregateError` only after every removal settles, so the quit drain waits for sibling removals even when one `rm` fails.
- **#10449** — `desktopDiffHost` tracks each fallback's setup prefix (reads through temp-dir creation) and `dispose()` awaits it, so a normal window close waits for the post-disposal cleanup that runs in the `disposed` branch.
- **#10450** — fallback error-path cleanup and `dispose()` share a memoized per-path removal promise, cleared on settlement, so a failed removal can be retried without issuing two concurrent recursive `rm`s on the same directory.

## Tests

Extended `src/test-kernel/desktop/DesktopDiffHost.vitest.ts` along the existing patterns:

- `settles every removal before dispose rejects when one rm fails`
- `keeps dispose pending until an in-flight fallback removes its post-disposal directory`
- `shares an in-flight error-path removal with dispose instead of double-removing`

## Validation

- `npm run typecheck` — clean
- Targeted eslint on the three changed files — clean
- `npx vitest run src/test-kernel/desktop/` — 59 files / 594 tests passed
- `npx prettier --check` on changed files — clean

Closes #10447
Closes #10448
Closes #10449
Closes #10450
