### PR TITLE
fix(transcript): shrink dead overlay read-back arm in StreamSnapshotStore (#9961)

### DIFF
--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -620,12 +620,7 @@ describe('StreamSnapshotStore', () => {
     const store = new StreamSnapshotStore();
     // Force a seed + a write for an unrelated run so writeUsage() actually
     // rewrites usageStats.json from the in-memory accumulators.
-    const pending = snapshotFacts(store).addUsage(
-      STREAM,
-      RUN_2,
-      usage(50, 10, 0.25),
-    );
-    await Promise.resolve(pending);
+    snapshotFacts(store).addUsage(STREAM, RUN_2, usage(50, 10, 0.25));
     await store.flush();
 
     expect(warnSpy).toHaveBeenCalled();

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -128,8 +128,6 @@ function isSnapshotRunFact(event: AgentEvent): event is SnapshotRunFact {
 }
 
 type OutputFilesPatch = Map<number, OutputFileInfo[] | null>;
-type UsageUpdateResult =
-  TokenUsageStats | undefined | Promise<TokenUsageStats | undefined>;
 interface HydratedRunState {
   authorityReadComplete: boolean;
   config?: AgentConfig;
@@ -864,7 +862,7 @@ export class StreamSnapshotStore {
    * mutator goes through here, so a new one inherits that guarantee instead
    * of needing its own overlay block.
    */
-  private mutateWithOverlay<T, K extends keyof OverlayPatches>(
+  private mutateWithOverlay<K extends keyof OverlayPatches>(
     stream: StreamTabId,
     overlayKey: K,
     overlayPatch: OverlayPatches[K] | undefined,
@@ -872,14 +870,14 @@ export class StreamSnapshotStore {
       existing: OverlayPatches[K] | undefined,
       patch: OverlayPatches[K],
     ) => OverlayPatches[K],
-    applyToMemory: () => T,
+    applyToMemory: () => void,
     persist: () => void,
-  ): { result: T; pending: Promise<void> | undefined } {
-    const result = applyToMemory();
+  ): void {
+    applyToMemory();
 
     if (this.hasDiskProvenance(stream)) {
       persist();
-      return { result, pending: undefined };
+      return;
     }
 
     const version = this.streamVersion(stream);
@@ -887,10 +885,7 @@ export class StreamSnapshotStore {
       const { overlays } = this.getOrCreateRecord(stream);
       overlays[overlayKey] = mergePatch(overlays[overlayKey], overlayPatch);
     }
-    return {
-      result,
-      pending: this.queueAfterSeed(stream, version, () => undefined),
-    };
+    this.queueAfterSeed(stream, version, () => undefined);
   }
 
   private addOutputFiles(
@@ -978,14 +973,13 @@ export class StreamSnapshotStore {
   }
 
   /**
-   * Accumulate usage per run. Returns the accumulated value for the run so
-   * callers can forward it to the UI.
+   * Accumulate usage per run.
    */
   private addUsage(
     stream: StreamTabId,
     storageKey: StorageKey,
     usage: TokenUsageStats,
-  ): UsageUpdateResult {
+  ): void {
     const parsed = TokenUsageStatsParsingBaseSchema.safeParse(usage);
     if (!parsed.success) {
       log.warn(
@@ -997,12 +991,11 @@ export class StreamSnapshotStore {
       );
     }
     const delta = parsed.success ? parsed.data : emptyUsageStats();
-    const version = this.streamVersion(stream);
     const overlayPatch = isEmptyUsage(delta)
       ? undefined
       : new Map<StorageKey, TokenUsageStats>([[storageKey, delta]]);
 
-    const { result: accumulated, pending } = this.mutateWithOverlay(
+    this.mutateWithOverlay(
       stream,
       'usage',
       overlayPatch,
@@ -1017,17 +1010,6 @@ export class StreamSnapshotStore {
         if (!isEmptyUsage(delta)) this.writeUsage(stream);
       },
     );
-
-    if (!pending) return accumulated;
-    return pending.then(() => {
-      if (
-        this.streamVersion(stream) !== version ||
-        !this.hasDiskProvenance(stream)
-      ) {
-        return undefined;
-      }
-      return this.records.get(stream)?.usage.get(storageKey);
-    });
   }
 
   // ==========================================================================


### PR DESCRIPTION
## What

Shrinks the dead read-back arm of the overlay mutation path in `src/transcript/StreamSnapshotStore.ts`:

- Deletes the unused `UsageUpdateResult` type.
- Makes `mutateWithOverlay` return `void` instead of `{ result, pending }`; the eager `applyToMemory()` and the unseeded-branch `queueAfterSeed(...)` side effect are kept, so overlays still seed and persist.
- Makes `addUsage` return `void`, dropping the `version` capture, the `{ result, pending }` destructuring, and the dead `pending.then(...)` read-back block.
- Updates the stale `addUsage` doc comment.
- Tidies a now-meaningless `const pending = ...` / `await Promise.resolve(pending)` in `StreamSnapshotStore.vitest.ts`.

No test-behavior change is required: `snapshotFacts(...).addUsage` is already typed as returning `void` by `storeTestDrivers.ts`.

Closes #9961

## Validation

- `npm run typecheck`
- targeted eslint on changed files
- `npx vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/architecture/` (185 passed)
- `npx prettier --check` on changed files
- `npm run check:dead-code-ratchet` (no new findings; deleted type was not baselined)