### PR TITLE
fix(storage,model): cap KVStoreCache ceiling, align xAI tier-gap boundary

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerXAI.ts
@@ -105,9 +105,10 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
     if (!this.tierGapWarned && xaiLongContextTierGap(this.config)) {
       this.tierGapWarned = true;
       this.logger.warn(
-        'xAI model has no documented long-context pricing tier; billing ' +
-          'flat catalog rates. If xAI publishes a tier for it, add it to ' +
-          'XAI_DOCUMENTED_PRICING in xaiLongContextPricing.ts.',
+        `xAI model ${this.config.fullName} has no documented long-context ` +
+          'pricing tier; billing flat catalog rates. If xAI publishes a tier ' +
+          'for it, add it to XAI_DOCUMENTED_PRICING in ' +
+          'xaiLongContextPricing.ts.',
         {
           data: {
             fullName: this.config.fullName,

--- a/src/agent/modelHandlers/openai/xaiLongContextPricing.ts
+++ b/src/agent/modelHandlers/openai/xaiLongContextPricing.ts
@@ -18,7 +18,7 @@
  * tier switch on its own.
  *
  * The model set is cross-checked against the llm-zoo catalog: a live xAI
- * model whose context window clears the lowest documented threshold but which
+ * model whose context window reaches the lowest documented threshold but which
  * has no row here trips {@link xaiLongContextTierGap} so it surfaces loudly
  * instead of silently billing flat.
  */
@@ -83,7 +83,7 @@ export function xaiCacheDiscountFactor(fullName: string): number | undefined {
 /**
  * True when a catalog entry looks like it should have a documented tier but
  * has none: a live xAI model (not deprecated or retired) whose context window
- * exceeds the lowest documented threshold, with no row above. This is the
+ * reaches the lowest documented threshold, with no row above. This is the
  * drift tripwire for the hand-maintained table — a new tiered xAI model
  * warns through the handler instead of silently billing flat rates.
  */
@@ -97,7 +97,7 @@ export function xaiLongContextTierGap(
     model.provider === ModelProvider.XAI &&
     model.deprecated !== true &&
     model.retired !== true &&
-    model.contextWindow > LOWEST_DOCUMENTED_THRESHOLD_TOKENS &&
+    model.contextWindow >= LOWEST_DOCUMENTED_THRESHOLD_TOKENS &&
     XAI_DOCUMENTED_PRICING[model.fullName] === undefined
   );
 }

--- a/src/common/storage/KVStoreCache.ts
+++ b/src/common/storage/KVStoreCache.ts
@@ -22,13 +22,14 @@ import { KVStore } from '@common/storage/KVStore';
 
 /**
  * Largest `max` the cache accepts. lru-cache preallocates its key/val lists
- * with `Array.from({ length: max })`, which throws `RangeError: Invalid array
- * length` once `max` reaches 2**32 and still attempts a ~4.3B-element
- * allocation at 2**32 - 1 (the largest valid array length). Cap one below
- * that so an unsizable `max` fails early with the KVStoreCache-scoped
- * RangeError instead of inside lru-cache.
+ * with `Array.from({ length: max })`, so a max anywhere near the array-length
+ * limit (2**32 - 1) attempts a ~4.3B-element dense allocation and can exhaust
+ * the process heap before the cache is ever usable. Cap far below that at an
+ * application-level ceiling: no KVStoreCache owner keeps anywhere near 100k
+ * live handles (the only bounded owner uses 50), and the bound keeps the
+ * preallocation to ~1.6 MB so the boundary stays testable.
  */
-const MAX_BOUNDED_HANDLES = 2 ** 32 - 2;
+const MAX_BOUNDED_HANDLES = 100_000;
 
 export class KVStoreCache<
   TId extends NonNullable<unknown>,
@@ -55,10 +56,9 @@ export class KVStoreCache<
       // there is no silent no-cache mode to prevent — but with its own
       // TypeError (0, -1, 1.5, NaN, Infinity), a generic Error (integers
       // beyond the safe range, whose per-cap index array it cannot size),
-      // or an array-length RangeError (safe integers larger than
-      // MAX_BOUNDED_HANDLES, whose key/val lists it cannot preallocate).
-      // Guard here so every invalid max fails early with one
-      // KVStoreCache-scoped RangeError.
+      // or an array-length RangeError (max >= 2**32, which the ceiling
+      // here already rejects before lru-cache sees it). Guard so every
+      // invalid max fails early with one KVStoreCache-scoped RangeError.
       throw new RangeError(
         `KVStoreCache max must be a positive safe integer no larger than ${MAX_BOUNDED_HANDLES} (got ${max}); omit it for an unbounded cache`,
       );

--- a/src/test-kernel/agent/modelHandlers/XaiLongContextPricing.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/XaiLongContextPricing.vitest.ts
@@ -119,13 +119,16 @@ describe('catalog cache-factor pin', () => {
 });
 
 describe('xaiLongContextTierGap', () => {
-  it('flags a live xAI model whose window clears the documented threshold', () => {
+  it('flags a live unlisted xAI model at exactly the documented threshold', () => {
+    // The pricing switch is inclusive at 200_000, so the drift tripwire must
+    // trip on equality too — a 200_000-window model bills tiered but has no
+    // row here.
     expect(
       xaiLongContextTierGap(
         buildTestModelConfig({
           provider: ModelProvider.XAI,
           fullName: 'grok-9',
-          contextWindow: 1_000_000,
+          contextWindow: 200_000,
         }),
       ),
     ).toBe(true);
@@ -138,8 +141,8 @@ describe('xaiLongContextTierGap', () => {
       // No longer served; xAI will not publish new tiers for these.
       { fullName: 'grok-legacy', contextWindow: 500_000, deprecated: true },
       { fullName: 'grok-dead', contextWindow: 500_000, retired: true },
-      // A 200k+ tier cannot fit a short window.
-      { fullName: 'grok-small', contextWindow: 131_072 },
+      // One token below the inclusive threshold.
+      { fullName: 'grok-small', contextWindow: 199_999 },
     ] as const;
     for (const overrides of cases) {
       expect(
@@ -255,6 +258,7 @@ describe('ModelHandlerXAI tier-gap warning', () => {
     handler.computePrice(usage);
 
     expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[0]).toContain('grok-9');
     expect(warn.mock.calls[0]?.[1]).toMatchObject({
       data: { fullName: 'grok-9', contextWindow: 1_000_000 },
     });

--- a/src/test-kernel/common/KVStoreCache.vitest.ts
+++ b/src/test-kernel/common/KVStoreCache.vitest.ts
@@ -15,6 +15,9 @@ describe('KVStoreCache', () => {
     2 ** 53,
     2 ** 32 - 1,
     2 ** 32,
+    // One past the application ceiling. Keep in sync with
+    // MAX_BOUNDED_HANDLES in KVStoreCache.ts.
+    100_001,
   ])('throws the KVStoreCache RangeError for max=%s', (max) => {
     let caught: unknown;
     try {
@@ -26,6 +29,12 @@ describe('KVStoreCache', () => {
     expect((caught as RangeError).message).toMatch(
       /^KVStoreCache max must be a positive safe integer/,
     );
+  });
+
+  it('accepts the largest bounded max without preallocating OOM-sized lists', () => {
+    // The ceiling is the boundary pin on the accepted side; keep this literal
+    // in sync with MAX_BOUNDED_HANDLES in KVStoreCache.ts.
+    expect(() => new KVStoreCache(create, { max: 100_000 })).not.toThrow();
   });
 
   it('keeps every cached handle when max is unset (unbounded)', () => {


### PR DESCRIPTION
## Summary

Three small follow-ups to #10477 and #10464.

- **KVStoreCache (#10484):** lower `MAX_BOUNDED_HANDLES` from `2**32 - 2` to `100_000`, an application-level ceiling far below the lru-cache preallocation OOM threshold. The guard still throws the KVStoreCache-scoped `RangeError` for every value above it, and boundary tests pin both sides (`100_000` accepted, `100_001` rejected).
- **xAI tier-gap tripwire (#10485):** `xaiLongContextTierGap` now tests `contextWindow >= LOWEST_DOCUMENTED_THRESHOLD_TOKENS`, matching the inclusive `>=` long-context billing switch. Doc comments and tests are updated, with boundary pins at exactly `200_000` (gaps) and `199_999` (spared).
- **Tier-gap warning prose (#10476):** `ModelHandlerXAI` keeps the model id in the default-visible warning message (`xAI model grok-9 has no documented long-context pricing tier; ...`) while still passing `{ data: { fullName, contextWindow } }` for structured consumers.

## Validation

- `npm run typecheck` — all six workspace steps pass.
- `npx eslint` on the five changed files — clean.
- `npx vitest run src/test-kernel/common/KVStoreCache.vitest.ts src/test-kernel/agent/modelHandlers/` — 785 passed / 4 skipped.
- `npx prettier --check` on the five changed files — clean.

Closes #10484
Closes #10485
Closes #10476