### PR TITLE
ci: fix remote-agents apply ref, docs, and test helper follow-ups

### DIFF
--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -589,7 +589,7 @@ npm run sync:remote-agents -- --apply
 
 Needs a `supabase link`ed checkout, or `SUPABASE_DB_URL`, or `SUPABASE_ACCESS_TOKEN` plus `SUPABASE_PROJECT_REF`. With `SUPABASE_PROJECT_REF` the script passes that ref to the CLI through `SUPABASE_PROJECT_ID`, leaving the checkout's linked project untouched.
 
-`--apply` requires Supabase CLI **v2.79.0 or newer**: v2.79.0 added `supabase db query`, whose `--linked` mode resolves the target project from `SUPABASE_PROJECT_ID` before the checkout's link file. A CLI too old to honor `SUPABASE_PROJECT_ID` would silently run against the checkout's linked project instead of `SUPABASE_PROJECT_REF`. Check your local version with `supabase --version`; CI pins 2.106.0 (`.github/workflows/remote-agents-sync.yml`).
+`--apply` requires Supabase CLI **v2.79.0 or newer**: v2.79.0 added `supabase db query`, whose `--linked` mode resolves the target project from `SUPABASE_PROJECT_ID` before the checkout's link file. Older CLIs lack `db query` entirely, so a too-old CLI fails loudly with an `unknown command` error before touching any project instead of silently retargeting the run. Check your local version with `supabase --version`; CI pins 2.106.0 (`.github/workflows/remote-agents-sync.yml`).
 
 Before writing any metadata, `--apply` verifies that every catalog `storage_path` already exists as an object in the `agent-configs` bucket; if any are missing it aborts and lists them, and no metadata is published. The preflight checks object existence, not freshness, so a green preflight does not prove the uploaded bodies are current. YAML bodies are still uploaded separately from metadata, so upload new, moved, or changed agents **before** applying (or before merging to `main`):
 

--- a/scripts/sync-remote-agents.mjs
+++ b/scripts/sync-remote-agents.mjs
@@ -405,7 +405,9 @@ function runSupabaseQuery(args, options = {}) {
 
 function applyRemoteAgentsSql() {
   const dbUrl = process.env.SUPABASE_DB_URL;
-  const projectRef = process.env.SUPABASE_PROJECT_REF;
+  // Normalize once here and reject a set-but-blank ref before it can reach the
+  // CLI as an empty SUPABASE_PROJECT_ID (#10452).
+  const projectRef = process.env.SUPABASE_PROJECT_REF?.trim();
   const projectRefFile = resolve(rootDir, 'supabase/.temp/project-ref');
   const args = ['--yes', 'db', 'query', '-o', 'table'];
   const queryEnv = {};
@@ -413,14 +415,22 @@ function applyRemoteAgentsSql() {
   if (dbUrl) {
     args.push('--db-url', dbUrl);
   } else {
+    if (process.env.SUPABASE_PROJECT_REF !== undefined && !projectRef) {
+      console.error(
+        'sync-remote-agents: SUPABASE_PROJECT_REF is set but empty after trimming. ' +
+          'Set a non-empty SUPABASE_PROJECT_REF, set SUPABASE_DB_URL, or run ' +
+          '`supabase link` in this checkout.',
+      );
+      return 1;
+    }
     if (projectRef) {
       // `supabase db query --linked` reads its target from
       // supabase/.temp/project-ref unless SUPABASE_PROJECT_ID is set. Pass the
       // requested ref through that env var instead of rewriting the checkout's
       // link file, so there is nothing to restore even if the process is
       // killed mid-query (#10316, #10329). The CLI trims the link file but
-      // validates the env var as-is, so normalize padding here (#10408).
-      queryEnv.SUPABASE_PROJECT_ID = projectRef.trim();
+      // validates the env var as-is, so padding was normalized above (#10408).
+      queryEnv.SUPABASE_PROJECT_ID = projectRef;
     } else if (!existsSync(projectRefFile)) {
       console.error(
         'sync-remote-agents: set SUPABASE_DB_URL or SUPABASE_PROJECT_REF, ' +

--- a/src/test-kernel/scripts/SyncRemoteAgents.vitest.ts
+++ b/src/test-kernel/scripts/SyncRemoteAgents.vitest.ts
@@ -113,6 +113,12 @@ function readStubLog(root: string) {
   return readFileSync(join(root, 'stub.log'), 'utf8');
 }
 
+function capturedArgs(root: string): string[] {
+  return readStubLog(root)
+    .split('\n')
+    .filter((line) => line.startsWith('args:'));
+}
+
 function readStubSql(root: string, filename: string) {
   const log = readStubLog(root);
   const marker = `sql-file: ${filename}\n`;
@@ -170,9 +176,7 @@ describe.skipIf(process.platform === 'win32')(
         // SUPABASE_PROJECT_ID only steers the CLI in combination with
         // --linked; without the flag the CLI would silently fall back to
         // --local (#10412).
-        const invocations = log
-          .split('\n')
-          .filter((line) => line.startsWith('args:'));
+        const invocations = capturedArgs(root);
         expect(invocations).toHaveLength(2);
         for (const invocation of invocations) {
           expect(invocation).toContain('--linked');
@@ -201,6 +205,24 @@ describe.skipIf(process.platform === 'win32')(
       }
     });
 
+    it('rejects a whitespace-only SUPABASE_PROJECT_REF instead of spawning the CLI', () => {
+      const root = createFixtureCheckout('proj-a');
+      try {
+        const result = runSync(root, ['--apply'], {
+          SUPABASE_PROJECT_REF: '  ',
+        });
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(result.stderr).toContain(
+          'SUPABASE_PROJECT_REF is set but empty after trimming',
+        );
+        expect(existsSync(join(root, 'stub.log'))).toBe(false);
+        expect(readFileSync(projectRefPath(root), 'utf8')).toBe('proj-a\n');
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
     it('never creates a project-ref file when the checkout has no link state', () => {
       const root = createFixtureCheckout();
       try {
@@ -215,9 +237,7 @@ describe.skipIf(process.platform === 'win32')(
         // the post-run existsSync checks alone would also pass if the file
         // were created and then cleaned up mid-run (#10412).
         expect(log).toContain('observed-ref: <absent>');
-        const invocations = log
-          .split('\n')
-          .filter((line) => line.startsWith('args:'));
+        const invocations = capturedArgs(root);
         expect(invocations).toHaveLength(2);
         for (const invocation of invocations) {
           expect(invocation).toContain('--linked');
@@ -322,9 +342,7 @@ describe.skipIf(process.platform === 'win32')(
           'Upload the missing YAML prompt bodies to the agent-configs bucket',
         );
         // The catalog SQL itself was never sent to the CLI.
-        const invocations = readStubLog(root)
-          .split('\n')
-          .filter((line) => line.startsWith('args:'));
+        const invocations = capturedArgs(root);
         expect(invocations).toHaveLength(1);
         expect(invocations[0]).toContain('remote-agents-preflight.sql');
         // The failed run still left the checkout's link state untouched.
@@ -356,9 +374,7 @@ describe.skipIf(process.platform === 'win32')(
         expect(result.stderr).not.toContain(
           'Upload the missing YAML prompt bodies to the agent-configs bucket',
         );
-        const invocations = readStubLog(root)
-          .split('\n')
-          .filter((line) => line.startsWith('args:'));
+        const invocations = capturedArgs(root);
         expect(invocations).toHaveLength(1);
         expect(invocations[0]).toContain('remote-agents-preflight.sql');
       } finally {
@@ -380,9 +396,7 @@ describe.skipIf(process.platform === 'win32')(
         expect(result.stderr).not.toContain(
           'Upload the missing YAML prompt bodies to the agent-configs bucket',
         );
-        const invocations = readStubLog(root)
-          .split('\n')
-          .filter((line) => line.startsWith('args:'));
+        const invocations = capturedArgs(root);
         expect(invocations).toHaveLength(1);
         expect(invocations[0]).toContain('remote-agents-preflight.sql');
         expect(readFileSync(projectRefPath(root), 'utf8')).toBe('proj-a\n');


### PR DESCRIPTION
Follow-ups to #10438.

- Treat a whitespace-only `SUPABASE_PROJECT_REF` as unset in the apply path instead of forwarding an empty `SUPABASE_PROJECT_ID` to the CLI.
- Correct the `SUPABASE_SETUP.md` minimum-version failure-mode sentence: older CLIs lack `db query` and abort loudly, rather than silently retargeting.
- Extract a file-local `capturedArgs(root)` helper in `SyncRemoteAgents.vitest.ts` and collapse all five call sites.

Closes #10452
Closes #10453
Closes #10454
