### PR TITLE
test(kernel): harden shared support mock guards and document finalization reset

### DIFF
--- a/src/test-kernel/architecture/supportMockHoisting.vitest.ts
+++ b/src/test-kernel/architecture/supportMockHoisting.vitest.ts
@@ -1,0 +1,27 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+import {
+  supportMockHoistingOrder,
+  supportMockHoistingValue,
+} from './supportMockHoistingFixture';
+
+/**
+ * Runtime proof that Vitest hoists `vi.hoisted` bags in ordinary imported
+ * support modules (not just `.vitest.ts` test files or setup files). The
+ * shared `@test/support/*Mock` modules rely on this so their `vi.mock`
+ * factories can close over a bag that is initialized before the mock is
+ * registered. If a future Vitest version stops hoisting imported modules,
+ * this test fails with `['before', 'hoisted-factory', 'after']` instead of
+ * hoisting the factory ahead of the module body.
+ */
+describe('shared test-kernel mock hoisting', () => {
+  it('hoists vi.hoisted bags ahead of the importing support module body', () => {
+    expect(supportMockHoistingValue()).toBe(1);
+    expect(supportMockHoistingOrder()).toEqual([
+      'hoisted-factory',
+      'before',
+      'after',
+    ]);
+  });
+});

--- a/src/test-kernel/architecture/supportMockHoistingFixture.ts
+++ b/src/test-kernel/architecture/supportMockHoistingFixture.ts
@@ -1,0 +1,28 @@
+// Third-party imports
+import { vi } from 'vitest';
+
+interface HoistingProbeGlobal {
+  __texraSupportMockHoistingOrder?: string[];
+}
+
+function probeOrder(): string[] {
+  const global = globalThis as HoistingProbeGlobal;
+  return (global.__texraSupportMockHoistingOrder ??= []);
+}
+
+probeOrder().push('before');
+
+const supportMockHoistingBag = vi.hoisted(() => {
+  probeOrder().push('hoisted-factory');
+  return { value: 1 };
+});
+
+probeOrder().push('after');
+
+export function supportMockHoistingValue(): number {
+  return supportMockHoistingBag.value;
+}
+
+export function supportMockHoistingOrder(): readonly string[] {
+  return probeOrder();
+}

--- a/src/test-kernel/architecture/supportMockImportOrder.vitest.ts
+++ b/src/test-kernel/architecture/supportMockImportOrder.vitest.ts
@@ -47,8 +47,22 @@ interface ImportSite {
   isTypeOnly: boolean;
 }
 
-function collectImports(file: string): ImportSite[] {
-  const source = readFileSync(file, 'utf8');
+function declarationIsTypeOnly(
+  importClause: ts.ImportClause | undefined,
+): boolean {
+  if (importClause?.isTypeOnly) return true;
+  if (importClause == null || importClause.name != null) return false;
+
+  const { namedBindings } = importClause;
+  return (
+    namedBindings != null &&
+    ts.isNamedImports(namedBindings) &&
+    namedBindings.elements.length > 0 &&
+    namedBindings.elements.every((element) => element.isTypeOnly)
+  );
+}
+
+function collectImportsFromSource(file: string, source: string): ImportSite[] {
   const sourceFile = ts.createSourceFile(
     file,
     source,
@@ -64,10 +78,14 @@ function collectImports(file: string): ImportSite[] {
     if (specifier == null || !ts.isStringLiteralLike(specifier)) continue;
     imports.push({
       specifier: specifier.text,
-      isTypeOnly: statement.importClause?.isTypeOnly ?? false,
+      isTypeOnly: declarationIsTypeOnly(statement.importClause),
     });
   }
   return imports;
+}
+
+function collectImports(file: string): ImportSite[] {
+  return collectImportsFromSource(file, readFileSync(file, 'utf8'));
 }
 
 function violation(file: string, message: string): string {
@@ -172,5 +190,20 @@ describe('shared test-kernel mock import order', () => {
 
   it('covers the #10361 migrated suites', () => {
     expect(checkedSuites).toEqual(expect.arrayContaining([...MIGRATED_SUITES]));
+  });
+
+  it('detects inline type-only shared mock imports as type-only', () => {
+    const source = `
+      import { type agentCatalogMock } from '@test/support/agentCatalogMock';
+      import { getAgent, type refresh } from '@test/support/agentCatalogMock';
+      import type { cliOutputMock } from '@test/support/cliOutputMock';
+    `;
+    const imports = collectImportsFromSource('inline-type-only.ts', source);
+
+    expect(imports).toEqual([
+      { specifier: '@test/support/agentCatalogMock', isTypeOnly: true },
+      { specifier: '@test/support/agentCatalogMock', isTypeOnly: false },
+      { specifier: '@test/support/cliOutputMock', isTypeOnly: true },
+    ]);
   });
 });

--- a/src/test-kernel/support/agentStorageFinalizationMock.ts
+++ b/src/test-kernel/support/agentStorageFinalizationMock.ts
@@ -18,7 +18,9 @@ import { durableFinalizationResult } from './agentStorageFixtures';
  * {@link durableFinalizationResult} for the default) and must not import this
  * module: the two registrations would race. Vitest gives each test file a
  * fresh module graph, so the singleton bag is per-suite at runtime; the
- * default implementation survives `vi.clearAllMocks()`.
+ * default implementation survives `vi.clearAllMocks()` but not
+ * `mockReset()`/`vi.resetAllMocks()` — a resetting suite must reinstall
+ * `mockImplementation(async () => durableFinalizationResult())` first.
  *
  * Ordering: the `vi.mock` below registers when this module evaluates, so the
  * import must precede anything that could load `@agent/storage` (see
@@ -31,7 +33,8 @@ const agentStorageFinalizationMock = vi.hoisted(() => ({
 
 // A hoisted factory cannot close over the imported fixture, so the default
 // durable implementation is installed here instead — mockClear (and hence
-// vi.clearAllMocks()) preserves it.
+// vi.clearAllMocks()) preserves it, but mockReset/vi.resetAllMocks() clears
+// it; resetting suites must reinstall the implementation above.
 agentStorageFinalizationMock.finalizeExecution.mockImplementation(async () =>
   durableFinalizationResult(),
 );


### PR DESCRIPTION
Follow-ups to #10478.

## Changes

- **#10487**: `supportMockImportOrder.vitest.ts` now treats an import declaration as type-only when its named specifiers are non-empty and all `isTypeOnly`, so `import { type agentCatalogMock }` is caught like `import type`. Added a parser-level regression case for the inline spelling (and a mixed value/type import stays non-type-only).
- **#10488**: Confirmed empirically that Vitest's `vi.hoisted` transform does apply to ordinary imported support modules (the Vite `vitest:mocks` plugin transforms all files, not just test/setup files). Added a runtime probe (`supportMockHoisting.vitest.ts` + fixture) that fails if a future Vitest version stops hoisting these bags ahead of the module body.
- **#10489**: Documented on `agentStorageFinalizationMock` that `mockReset()`/`vi.resetAllMocks()` clears the durable default and a resetting suite must reinstall the `mockImplementation`.

## Validation

- `npm run typecheck` — pass
- targeted eslint on changed files — pass
- `npx vitest run src/test-kernel/architecture/ src/test-kernel/cli/AgentResolution.vitest.ts src/test-kernel/cli/AgentsCommand.vitest.ts src/test-kernel/cli/AgentsRunCommand.vitest.ts src/test-kernel/cli/MultiAgentRunCommand.vitest.ts src/test-kernel/cli/WorkflowRunCommand.vitest.ts` — 22 files / 176 tests pass
- `npx prettier --check .` — pass
- `npm run check:dead-code-ratchet` — pass

Closes #10487
Closes #10488
Closes #10489
