### PR TITLE
fix(ui): finish max-style KaTeX shadowing follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,9 @@ All notable changes to this project will be documented in this file.
   differential shortcuts render as intended instead of unknown commands.
 - **Max-style shortcuts no longer shadow KaTeX built-ins** — the section
   sign and the legacy bold switch render as intended, `\label` no longer
-  errors in rendered math, and decorated-H effective-Hamiltonian plus
-  equilibrium/steady-state forms compact to their intended shortcuts.
+  errors in rendered math, decorated-H effective-Hamiltonian forms keep
+  their accents, equilibrium/steady-state subscripts no longer turn into
+  superscripts, and written documents with the plain-S shortcut compile.
 
 #### Features
 

--- a/packages/extension/resources/templates/chatExport.tex
+++ b/packages/extension/resources/templates/chatExport.tex
@@ -12,6 +12,11 @@
 \usepackage{xcolor}
 \geometry{margin=2.5cm}
 
+% TeXRA max-style replacements use \sS for the plain-S subscript/superscript
+% shortcut; define it here so exported LaTeX compiles when max-style output
+% is present.
+\providecommand{\sS}{S}
+
 \lstset{
   basicstyle=\ttfamily\small,
   breaklines=true,

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -176,9 +176,7 @@ const MAX_AUTO_PATTERNS: Record<string, string> = (() => {
     'p^{\\text{st}}': '\\pst',
     'q^{\\text{st}}': '\\qst',
     '\\rho^{\\text{eq}}': '\\rhoeq',
-    '\\rho_{\\text{eq}}': '\\rhoeq',
     '\\rho^{\\text{st}}': '\\rhost',
-    '\\rho_{\\text{st}}': '\\rhost',
     // Text Commands: \text{cmd} -> \cmd
     ...createPatterns(textCommands, (cmd) => [
       [`\\text{${cmd}}`, `\\${cmd}`],
@@ -235,6 +233,10 @@ const MAX_AUTO_PATTERNS: Record<string, string> = (() => {
     '\\cH^{\\text{eff}}': '\\ceffH',
     '\\hat{H}^{\\text{eff}}': '\\hat{\\effH}',
     '\\hH^{\\text{eff}}': '\\hat{\\effH}',
+    '\\tilde{\\mathcal{H}}^{\\text{eff}}': '\\tilde{\\ceffH}',
+    '\\tcH^{\\text{eff}}': '\\tilde{\\ceffH}',
+    '\\bar{H}^{\\text{eff}}': '\\bar{\\effH}',
+    '\\barH^{\\text{eff}}': '\\bar{\\effH}',
     // Mathcal: \mathcal{X} -> \cX
     ...generateDecoratorShortcuts('mathcal', upperLetters, 'c'),
     // Mathbb: \mathbb{X} -> \eX
@@ -396,6 +398,12 @@ const MAX_MANUAL_PATTERNS: Record<string, string> = {
   '\\tau_f': '\\tauf',
 
   // Equilibrium and steady state notation
+  // Subscript rho eq/st stay manual: the AUTO \text{eq}/\text{st} rules
+  // consume the fragment first (preserving \rho_\eq / \rho_\st), so
+  // these entries are inert for bare sources but document the intended
+  // compaction destinations.
+  '\\rho_{\\text{eq}}': '\\rhoeq',
+  '\\rho_{\\text{st}}': '\\rhost',
   '\\rho^{\\text{ss}}': '\\rhost',
   '\\rho^{\\text{sst}}': '\\rhost',
   '\\rho_{\\text{ss}}': '\\rhost',
@@ -571,6 +579,12 @@ export const MAX_REGEX_REPLACEMENTS: RegexReplacementCategory = {
     // '([+\\-*\\/])\\s*\\.\\.\\.\\s*([+\\-*\\/])': '$1\\cdots$2',
     // '([,;])\\s*\\.\\.\\.\\s*([,;])': '$1\\ldots$2',
     // Max like ,..,
+
+    // Legacy unbraced '\S' plain-S shortcut migration. The non-regex
+    // table handles the braced source forms; these boundary-aware rules
+    // catch the pre-rename persisted unbraced output without turning
+    // '\Strat'/'\Sig' into '\sStrat'/'\sSig'.
+    '([_^])\\\\S(?![A-Za-z])': '$1\\sS',
 
     // PUNCTUATION AND SPACING
 

--- a/src/test-kernel/progressView/MarkdownRendererSecurity.vitest.ts
+++ b/src/test-kernel/progressView/MarkdownRendererSecurity.vitest.ts
@@ -60,6 +60,21 @@ describe('processMarkdownContent renders math and code', () => {
     expect(doc.querySelector('.katex')).not.toBeNull();
   });
 
+  it('renders the max-style macro fixes without unknown-command errors', () => {
+    const label = renderToDocument('$\\label{eqn:e}$');
+    expect(label.querySelector('.katex')).not.toBeNull();
+    expect(label.querySelector('.katex-error')).toBeNull();
+
+    const section = renderToDocument('$\\text{\\S}$');
+    expect(section.querySelector('.katex')).not.toBeNull();
+    expect(section.querySelector('.katex-error')).toBeNull();
+    expect(section.querySelector('.katex')?.textContent).toContain('§');
+
+    const bold = renderToDocument('${\\bf x}$');
+    expect(bold.querySelector('.katex')).not.toBeNull();
+    expect(bold.querySelector('.katex-error')).toBeNull();
+  });
+
   const CRITERION_FORMULA =
     'c_{\\alpha\\beta}^{\\gamma}(L)=\\operatorname{Tr}(\\chi^L).';
 

--- a/src/test-kernel/shared/KatexMacroDrift.vitest.ts
+++ b/src/test-kernel/shared/KatexMacroDrift.vitest.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import { applyReplacements } from '@replacement/engine';
-import { MAX_STYLE_REPLACEMENTS } from '@replacement/maxRules';
+import {
+  MAX_REGEX_REPLACEMENTS,
+  MAX_STYLE_REPLACEMENTS,
+} from '@replacement/maxRules';
 import { katexMacros } from '@shared/markdown/katexMacros';
 
 const MAX_COMMAND = /\\[A-Za-z][A-Za-z0-9]*/g;
@@ -54,6 +57,7 @@ const KATEX_ONLY_SHORTCUTS = [
  * unnoticed.
  */
 const MAX_ONLY_SHORTCUTS = [
+  '\\bar',
   '\\beta',
   '\\cref',
   '\\frac',
@@ -68,6 +72,7 @@ const MAX_ONLY_SHORTCUTS = [
   '\\ref',
   '\\tau',
   '\\text',
+  '\\tilde',
   '\\top',
 ] as const;
 
@@ -179,6 +184,22 @@ describe('katexMacros vs maxRules shortcuts', () => {
   it('maps built-in-colliding sources to safe destinations at runtime', () => {
     expect(applyReplacements('_{\\S}', MAX_STYLE_REPLACEMENTS)).toBe('_\\sS');
     expect(applyReplacements('^{\\S}', MAX_STYLE_REPLACEMENTS)).toBe('^\\sS');
+    expect(applyReplacements('_\\S', MAX_REGEX_REPLACEMENTS)).toBe('_\\sS');
+    expect(applyReplacements('^\\S', MAX_REGEX_REPLACEMENTS)).toBe('^\\sS');
+    // The boundary-aware migration must not turn S-prefixed shortcuts such
+    // as '\Strat'/'\\Sig' into '\sStrat'/'\\sSig'.
+    expect(
+      applyReplacements('_\\Strat', [
+        MAX_STYLE_REPLACEMENTS,
+        MAX_REGEX_REPLACEMENTS,
+      ]),
+    ).toBe('_\\Strat');
+    expect(
+      applyReplacements('^\\Sig', [
+        MAX_STYLE_REPLACEMENTS,
+        MAX_REGEX_REPLACEMENTS,
+      ]),
+    ).toBe('^\\Sig');
     expect(applyReplacements('\\mathbf{f}', MAX_STYLE_REPLACEMENTS)).toBe(
       '\\bbf',
     );
@@ -198,6 +219,21 @@ describe('katexMacros vs maxRules shortcuts', () => {
     expect(
       applyReplacements('\\hH^{\\text{eff}}', MAX_STYLE_REPLACEMENTS),
     ).toBe('\\hat{\\effH}');
+    expect(
+      applyReplacements(
+        '\\tilde{\\mathcal{H}}^{\\text{eff}}',
+        MAX_STYLE_REPLACEMENTS,
+      ),
+    ).toBe('\\tilde{\\ceffH}');
+    expect(
+      applyReplacements('\\tcH^{\\text{eff}}', MAX_STYLE_REPLACEMENTS),
+    ).toBe('\\tilde{\\ceffH}');
+    expect(
+      applyReplacements('\\bar{H}^{\\text{eff}}', MAX_STYLE_REPLACEMENTS),
+    ).toBe('\\bar{\\effH}');
+    expect(
+      applyReplacements('\\barH^{\\text{eff}}', MAX_STYLE_REPLACEMENTS),
+    ).toBe('\\bar{\\effH}');
   });
 
   it('fires the eq/st compaction family at runtime', () => {
@@ -218,13 +254,13 @@ describe('katexMacros vs maxRules shortcuts', () => {
     ).toBe('\\rhoeq');
     expect(
       applyReplacements('\\rho_{\\text{eq}}', MAX_STYLE_REPLACEMENTS),
-    ).toBe('\\rhoeq');
+    ).toBe('\\rho_\\eq');
     expect(
       applyReplacements('\\rho^{\\text{st}}', MAX_STYLE_REPLACEMENTS),
     ).toBe('\\rhost');
     expect(
       applyReplacements('\\rho_{\\text{st}}', MAX_STYLE_REPLACEMENTS),
-    ).toBe('\\rhost');
+    ).toBe('\\rho_\\st');
   });
 
   it('keeps runtime max-style output resolvable by the renderer macros', () => {


### PR DESCRIPTION
Follow-up to #10439 for the remaining max-style KaTeX shadowing gaps.

- Keep the rho eq/st subscript forms out of the hoisted superscript compaction block so `\rho_{\text{eq}}`/`\rho_{\text{st}}` preserve their subscript position instead of flipping to superscripts.
- Migrate legacy unbraced `_\S`/`^\S` output with boundary-aware regex rules, so persisted pre-rename forms become `_\sS`/`^\sS` without corrupting S-prefixed shortcuts such as `\Strat`/`\Sig`.
- Add combined max-style rules for tilde/mathcal and bar decorated-H eff combinations so `effH` cannot fire inside the accent argument.
- Add render-level KaTeX assertions for `\label`, `\text{\S}`, and `{\bf x}` through the progress-view markdown renderer.
- Define `\sS` in the shipped LaTeX preamble so written documents with the plain-S shortcut compile.

Closes #10460
Closes #10461
Closes #10462
Closes #10463