### PR TITLE
fix(retry): complete the Kimi Code fallback retry path

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -39,6 +39,7 @@ import {
   classifyCliRetryAction,
   cliRetryApiSwitchDecision,
   isCliApiSwitchableRetry,
+  isKimiCodeExclusiveRetryModel,
 } from '@cli/runtime/approval/approvalPrompts';
 import {
   denyExternalInquiryIfNoHumanInput,
@@ -61,8 +62,6 @@ import {
   codingPlanSubscriptionRuntimes,
   type CodingPlanSubscriptionRuntime,
 } from '@model/codingPlanSubscriptions';
-import { isKimiCodeExclusiveModel } from '@model/kimiCodeSubscriptionRouting';
-import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import { isPreferCodexSubscription } from '@model/codex/codexPreference';
 import { platform } from '@platform/platform';
 import {
@@ -140,31 +139,16 @@ function maybeAutoSwitchRetry(
 
   // Coding-plan quotas (Kimi Code, GLM Coding Plan) have a fallback route that
   // re-uses an already-stored key, so auto-switch when that key exists.
+  // Kimi Code-exclusive models never reach this branch: the classifier above
+  // gates them to 'none', keeping the modal without an API-key switch.
   if (action.startsWith('disable-coding-plan:')) {
     if (payload.personalApiKeyAvailable !== true) return undefined;
-    // Kimi Code-EXCLUSIVE models are served only by the coding endpoint:
-    // disabling the plan cannot reroute them, so an automatic switch would
-    // just retry the same exhausted credential without a human decision.
-    // They keep the modal (wait for the reset, or cancel).
-    if (isKimiCodeExclusiveRetryModel(payload.model)) return undefined;
     // The switch decision's single owner is the classifier's sibling, so the
     // auto-switch cannot drift from the modal.
     return cliRetryApiSwitchDecision(payload);
   }
 
   return undefined;
-}
-
-/**
- * Whether the retrying model is served ONLY by the Kimi Code coding endpoint
- * (`kimi-for-coding` aliases pin its `baseUrl` in the registry). Unknown or
- * non-Kimi models are not exclusive, so a missing `model` never blocks the
- * GLM/Kimi dual-backend auto-switch.
- */
-function isKimiCodeExclusiveRetryModel(model: string | undefined): boolean {
-  if (model === undefined) return false;
-  const config = getRuntimeModelConfig(model);
-  return config !== undefined && isKimiCodeExclusiveModel(config);
 }
 
 /**
@@ -435,12 +419,6 @@ async function requestRetryInteraction(
       }
       if (autoSwitch) {
         retryDecision.source = 'automatic';
-        // Skipping the modal also skips its quota warning, and the switch
-        // persists the plan preference as disabled — an interactive user
-        // must still get a visible signal that it happened.
-        if (autoSwitch.disableCodingPlan !== undefined) {
-          notify('credentialSwitched');
-        }
         reservation.settle(autoSwitch);
         return;
       }
@@ -477,6 +455,16 @@ async function requestRetryInteraction(
         preparationSignal: reservation.signal,
         commitQueue: attachment.commitQueue,
       });
+      // Skipping the modal also skips its quota warning, and the switch
+      // persists the plan preference as disabled. Announce it only after the
+      // switch commits: a preparation failure rolls the preference back, and
+      // the user must not be told a switch happened that did not.
+      if (
+        retryDecision.source === 'automatic' &&
+        decision.disableCodingPlan !== undefined
+      ) {
+        notify('credentialSwitched');
+      }
     } else if (options?.prepareRetry) {
       await prepareRetryClient(
         options.prepareRetry,
@@ -682,6 +670,117 @@ function throwWithRollbackFailures(
   throw error;
 }
 
+/** Commit the access-mode and subscription writes for a retry switch.
+ *
+ *  Runs while the commit queue already holds its slot. On failure it rolls
+ *  back everything it wrote (plus the already-disabled coding plan, when one
+ *  is supplied) and rethrows; callers then surface the aggregate error.
+ */
+async function applyRetryCredentialCommit(
+  decision: ApprovalDecision,
+  signal: AbortSignal,
+  codingPlanRollback?: RetrySettingRollbackConfig,
+): Promise<void> {
+  signal.throwIfAborted();
+  const previousApiMode = getCliApiMode();
+  const previousOpenRouter = cliOpenRouterEnabled();
+  const previousSubscriptionPreference = isPreferCodexSubscription();
+  let apiModeWriteStarted = false;
+  let subscriptionWriteStarted = false;
+  try {
+    if (decision.apiMode) {
+      const apiMode = decision.apiMode;
+      apiModeWriteStarted = true;
+      await runRetryTask(() => setCliApiMode(apiMode), signal);
+      signal.throwIfAborted();
+    }
+    if (decision.disableChatGptSubscription) {
+      subscriptionWriteStarted = true;
+      const update = await runRetryTask(
+        () => setCliCodexSubscription(false),
+        signal,
+      );
+      if (update.effective) {
+        throw new Error(
+          'ChatGPT subscription remains enabled by a more specific setting.',
+        );
+      }
+      signal.throwIfAborted();
+    }
+    if (decision.apiMode) patchSessionMeta({ apiMode: decision.apiMode });
+    return;
+  } catch (error) {
+    // Each config is evaluated after the previous restore resolved, so a
+    // rollback sees the state its predecessor left behind. Skipped attempts
+    // must not await: this runs while the commit queue still holds its slot,
+    // and the extra turns let a newer queued switch commit ahead of the
+    // restores below. OpenRouter is restored after the mode, because
+    // restoring included access clears the OpenRouter toggle: a switch the
+    // user never got would otherwise leave their routing preference silently
+    // off.
+    let openRouterToPreserve = previousOpenRouter;
+    const rollbackFailures = await rollbackChangedSettings([
+      {
+        writeStarted: subscriptionWriteStarted,
+        needsRollback: () => !isPreferCodexSubscription(),
+        restore: async () => {
+          const update = await setCliCodexSubscription(
+            previousSubscriptionPreference,
+          );
+          if (update.effective !== previousSubscriptionPreference) {
+            throw new Error(
+              `ChatGPT subscription preference remained ${String(update.effective)}.`,
+            );
+          }
+        },
+        restoredInMemory: () =>
+          isPreferCodexSubscription() === previousSubscriptionPreference,
+        memoryRestoredContext:
+          'The previous ChatGPT subscription preference appears restored in memory, but persistence could not be confirmed',
+        restoreFailedContext:
+          'Could not restore the ChatGPT subscription preference',
+      },
+      ...(codingPlanRollback ? [codingPlanRollback] : []),
+      {
+        writeStarted: apiModeWriteStarted,
+        needsRollback: () => getCliApiMode() === decision.apiMode,
+        restore: async () => {
+          // A newer OpenRouter choice may have landed after this retry
+          // changed modes. Restoring included mode clears that choice, so
+          // carry its current value into the final route restore.
+          openRouterToPreserve = cliOpenRouterEnabled();
+          await setCliApiMode(previousApiMode);
+          if (getCliApiMode() !== previousApiMode) {
+            throw new Error(`API mode remained ${getCliApiMode()}.`);
+          }
+        },
+        restoredInMemory: () => getCliApiMode() === previousApiMode,
+        memoryRestoredContext:
+          'The previous API mode appears restored in memory, but persistence could not be confirmed',
+        restoreFailedContext: 'Could not restore API mode',
+      },
+      {
+        writeStarted: apiModeWriteStarted,
+        needsRollback: () => openRouterToPreserve && !cliOpenRouterEnabled(),
+        restore: async () => {
+          await platform().globalState.update(
+            GlobalStateKey.USE_OPENROUTER,
+            true,
+          );
+          if (!cliOpenRouterEnabled()) {
+            throw new Error('OpenRouter routing remained disabled.');
+          }
+        },
+        restoredInMemory: () => cliOpenRouterEnabled(),
+        memoryRestoredContext:
+          'The previous OpenRouter routing preference appears restored in memory, but persistence could not be confirmed',
+        restoreFailedContext: 'Could not restore OpenRouter routing',
+      },
+    ]);
+    throwWithRollbackFailures(error, rollbackFailures);
+  }
+}
+
 async function switchRetryToPersonalCredentials(
   decision: ApprovalDecision,
   request: TuiRetryRequest,
@@ -716,193 +815,93 @@ async function switchRetryToPersonalCredentials(
   if (!options.prepareRetry) {
     throw new Error('The model client cannot be refreshed for this retry.');
   }
+  const prepareRetry = options.prepareRetry;
 
   // A coding-plan switch must take effect BEFORE the client is rebuilt:
   // credential and endpoint resolution read the live plan preference (the GLM
   // coding endpoint is selected from it, and dual-backend Kimi models are
   // rerouted onto the coding endpoint only while it is on), so rebuilding
   // first would prepare the retry against the exhausted coding route. The
-  // disable commits ahead of the preparation; if the preparation then fails,
-  // the preference goes back, so a retry that never ran leaves no settings
-  // behind.
+  // disable, preparation, and rollback all stay inside one commit-queue slot
+  // so a second coding-plan retry cannot interleave: its disable must wait
+  // until this retry's rollback (if any) has finished.
   const codingPlanId = decision.disableCodingPlan;
   const codingPlanRuntime = codingPlanId
     ? codingPlanSubscriptionRuntimes.find(
         (runtime) => runtime.descriptor.id === codingPlanId,
       )
     : undefined;
-  let codingPlanWriteStarted = false;
-  let previousCodingPlanEnabled = false;
   if (codingPlanId && codingPlanRuntime) {
     const runtime = codingPlanRuntime;
     // Wrapped so a cancel settles this retry immediately instead of waiting
     // for an unrelated stream's commit or rollback to drain first. The task
-    // still runs, and stops at the check below.
-    try {
-      await runRetryTask(
-        () =>
-          options.commitQueue.add(async () => {
-            signal.throwIfAborted();
-            previousCodingPlanEnabled = runtime.getEnabled();
+    // still runs, and stops at the checks below.
+    await runRetryTask(
+      () =>
+        options.commitQueue.add(async () => {
+          signal.throwIfAborted();
+          const previousCodingPlanEnabled = runtime.getEnabled();
+          let codingPlanWriteStarted = false;
+          try {
             codingPlanWriteStarted = true;
             await runRetryTask(
               () => setCliCodingPlanSubscription(codingPlanId, false),
               signal,
             );
             signal.throwIfAborted();
-          }),
-        signal,
-      );
-    } catch (error) {
-      throwWithRollbackFailures(
-        error,
-        await rollbackChangedSettings([
-          codingPlanRollbackConfig(
-            runtime,
-            previousCodingPlanEnabled,
-            codingPlanWriteStarted,
-          ),
-        ]),
-      );
-    }
-    try {
-      await prepareRetryClient(options.prepareRetry, 'personal', signal);
-    } catch (error) {
-      throwWithRollbackFailures(
-        error,
-        await rollbackChangedSettings([
-          codingPlanRollbackConfig(
-            runtime,
-            previousCodingPlanEnabled,
-            codingPlanWriteStarted,
-          ),
-        ]),
-      );
-    }
-  } else {
-    await prepareRetryClient(options.prepareRetry, 'personal', signal);
-  }
-
-  // Wrapped so a cancel settles this retry immediately instead of waiting for
-  // an unrelated stream's commit or rollback to drain first. The task still
-  // runs, and stops at the check below.
-  await runRetryTask(
-    () =>
-      options.commitQueue.add(async () => {
-        // The task can wait behind another stream's rollback, so the queue may
-        // have cancelled this retry since it was scheduled.
-        signal.throwIfAborted();
-        const previousApiMode = getCliApiMode();
-        const previousOpenRouter = cliOpenRouterEnabled();
-        const previousSubscriptionPreference = isPreferCodexSubscription();
-        let apiModeWriteStarted = false;
-        let subscriptionWriteStarted = false;
-        try {
-          if (decision.apiMode) {
-            const apiMode = decision.apiMode;
-            apiModeWriteStarted = true;
-            await runRetryTask(() => setCliApiMode(apiMode), signal);
-            signal.throwIfAborted();
-          }
-          if (decision.disableChatGptSubscription) {
-            subscriptionWriteStarted = true;
-            const update = await runRetryTask(
-              () => setCliCodexSubscription(false),
-              signal,
+          } catch (error) {
+            throwWithRollbackFailures(
+              error,
+              await rollbackChangedSettings([
+                codingPlanRollbackConfig(
+                  runtime,
+                  previousCodingPlanEnabled,
+                  codingPlanWriteStarted,
+                ),
+              ]),
             );
-            if (update.effective) {
-              throw new Error(
-                'ChatGPT subscription remains enabled by a more specific setting.',
-              );
-            }
-            signal.throwIfAborted();
           }
-          if (decision.apiMode) patchSessionMeta({ apiMode: decision.apiMode });
-          return;
-        } catch (error) {
-          // Each config is evaluated after the previous restore resolved, so a
-          // rollback sees the state its predecessor left behind. Skipped
-          // attempts must not await: this runs while the commit queue still
-          // holds its slot, and the extra turns let a newer queued switch
-          // commit ahead of the restores below. OpenRouter is restored after
-          // the mode, because restoring included access clears the OpenRouter
-          // toggle: a switch the user never got would otherwise leave their
-          // routing preference silently off.
-          let openRouterToPreserve = previousOpenRouter;
-          const rollbackFailures = await rollbackChangedSettings([
-            {
-              writeStarted: subscriptionWriteStarted,
-              needsRollback: () => !isPreferCodexSubscription(),
-              restore: async () => {
-                const update = await setCliCodexSubscription(
-                  previousSubscriptionPreference,
-                );
-                if (update.effective !== previousSubscriptionPreference) {
-                  throw new Error(
-                    `ChatGPT subscription preference remained ${String(update.effective)}.`,
-                  );
-                }
-              },
-              restoredInMemory: () =>
-                isPreferCodexSubscription() === previousSubscriptionPreference,
-              memoryRestoredContext:
-                'The previous ChatGPT subscription preference appears restored in memory, but persistence could not be confirmed',
-              restoreFailedContext:
-                'Could not restore the ChatGPT subscription preference',
-            },
-            // The coding-plan preference was already disabled before the
-            // client preparation; a failure here restores it too.
-            ...(codingPlanRuntime
-              ? [
-                  codingPlanRollbackConfig(
-                    codingPlanRuntime,
-                    previousCodingPlanEnabled,
-                    codingPlanWriteStarted,
-                  ),
-                ]
-              : []),
-            {
-              writeStarted: apiModeWriteStarted,
-              needsRollback: () => getCliApiMode() === decision.apiMode,
-              restore: async () => {
-                // A newer OpenRouter choice may have landed after this retry
-                // changed modes. Restoring included mode clears that choice,
-                // so carry its current value into the final route restore.
-                openRouterToPreserve = cliOpenRouterEnabled();
-                await setCliApiMode(previousApiMode);
-                if (getCliApiMode() !== previousApiMode) {
-                  throw new Error(`API mode remained ${getCliApiMode()}.`);
-                }
-              },
-              restoredInMemory: () => getCliApiMode() === previousApiMode,
-              memoryRestoredContext:
-                'The previous API mode appears restored in memory, but persistence could not be confirmed',
-              restoreFailedContext: 'Could not restore API mode',
-            },
-            {
-              writeStarted: apiModeWriteStarted,
-              needsRollback: () =>
-                openRouterToPreserve && !cliOpenRouterEnabled(),
-              restore: async () => {
-                await platform().globalState.update(
-                  GlobalStateKey.USE_OPENROUTER,
-                  true,
-                );
-                if (!cliOpenRouterEnabled()) {
-                  throw new Error('OpenRouter routing remained disabled.');
-                }
-              },
-              restoredInMemory: () => cliOpenRouterEnabled(),
-              memoryRestoredContext:
-                'The previous OpenRouter routing preference appears restored in memory, but persistence could not be confirmed',
-              restoreFailedContext: 'Could not restore OpenRouter routing',
-            },
-          ]);
-          throwWithRollbackFailures(error, rollbackFailures);
-        }
-      }),
-    signal,
-  );
+          try {
+            await prepareRetryClient(prepareRetry, 'personal', signal);
+          } catch (error) {
+            throwWithRollbackFailures(
+              error,
+              await rollbackChangedSettings([
+                codingPlanRollbackConfig(
+                  runtime,
+                  previousCodingPlanEnabled,
+                  codingPlanWriteStarted,
+                ),
+              ]),
+            );
+          }
+          await applyRetryCredentialCommit(
+            decision,
+            signal,
+            codingPlanRollbackConfig(
+              runtime,
+              previousCodingPlanEnabled,
+              codingPlanWriteStarted,
+            ),
+          );
+        }),
+      signal,
+    );
+  } else {
+    await prepareRetryClient(prepareRetry, 'personal', signal);
+    // Wrapped so a cancel settles this retry immediately instead of waiting
+    // for an unrelated stream's commit or rollback to drain first. The task
+    // still runs, and stops at the check below.
+    await runRetryTask(
+      () =>
+        options.commitQueue.add(async () => {
+          // The task can wait behind another stream's rollback, so the queue
+          // may have cancelled this retry since it was scheduled.
+          await applyRetryCredentialCommit(decision, signal);
+        }),
+      signal,
+    );
+  }
 }
 
 function handleExternalInquiry(

--- a/packages/cli/src/runtime/approval/approvalPrompts.ts
+++ b/packages/cli/src/runtime/approval/approvalPrompts.ts
@@ -3,6 +3,8 @@ import PQueue from 'p-queue';
 import { defaultSession } from '@agent/runtime';
 import { isRelayMonthlyLimitMessage } from '@common/errors/sdkError/relayDetection';
 import { warn as logWarning } from '@logger/logUtils';
+import { isKimiCodeExclusiveModel } from '@model/kimiCodeSubscriptionRouting';
+import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import {
   isChatGptSubscriptionLimitError,
   isCredentialExhausted,
@@ -108,6 +110,20 @@ export type CliRetryAction =
   | 'switch-to-personal'
   | 'none';
 
+/**
+ * Whether the retrying model is served ONLY by the Kimi Code coding endpoint
+ * (`kimi-for-coding` aliases pin its `baseUrl` in the registry). Unknown or
+ * non-Kimi models are not exclusive, so a missing `model` never blocks the
+ * GLM/Kimi dual-backend switch.
+ */
+export function isKimiCodeExclusiveRetryModel(
+  model: string | undefined,
+): boolean {
+  if (model === undefined) return false;
+  const config = getRuntimeModelConfig(model);
+  return config !== undefined && isKimiCodeExclusiveModel(config);
+}
+
 export function classifyCliRetryAction(
   payload: RetryPermission,
 ): CliRetryAction {
@@ -116,7 +132,19 @@ export function classifyCliRetryAction(
   const codingPlan = CODING_PLAN_SUBSCRIPTIONS.find(
     (plan) => plan.exhaustionReason === details?.exhaustionReason,
   );
-  if (codingPlan) return `disable-coding-plan:${codingPlan.id}`;
+  if (codingPlan) {
+    // Kimi Code-exclusive models are served only by the coding endpoint, so
+    // turning the plan off cannot reroute them to a Moonshot fallback. They
+    // keep the retry modal without an API-key switch, exactly like the
+    // auto-switch gate in the TUI.
+    if (
+      codingPlan.id === 'kimiCode' &&
+      isKimiCodeExclusiveRetryModel(payload.model)
+    ) {
+      return 'none';
+    }
+    return `disable-coding-plan:${codingPlan.id}`;
+  }
   if (
     details != null &&
     isCredentialExhausted(details) &&

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -545,9 +545,10 @@ export class DesktopProgressBridge {
       isRetryPending: (stream, requestId) =>
         this.hostInteractions.isRetryPending(stream, requestId),
       triggerRetry: (stream, requestId) =>
-        this.hostInteractions.submitRetryDecision(stream, requestId, {
-          action: 'retry',
-        }),
+        this.hostInteractions.submitRetryWithPersonalCredentials(
+          stream,
+          requestId,
+        ),
     });
   }
 
@@ -926,10 +927,11 @@ export class DesktopProgressBridge {
             action: 'retry',
             feedback,
           }),
-        cancel: (stream, requestId) =>
+        cancel: (stream, requestId) => {
           this.hostInteractions.submitRetryDecision(stream, requestId, {
             action: 'cancel',
-          }),
+          });
+        },
       },
     };
 

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -212,10 +212,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             action: 'retry',
             feedback,
           }),
-        cancel: (stream, requestId) =>
+        cancel: (stream, requestId) => {
           this.interactions.submitRetryDecision(stream, requestId, {
             action: 'cancel',
-          }),
+          });
+        },
       },
     };
 
@@ -563,9 +564,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       isRetryPending: (stream, requestId) =>
         this.interactions.isRetryPending(stream, requestId),
       triggerRetry: (stream, requestId) =>
-        this.interactions.submitRetryDecision(stream, requestId, {
-          action: 'retry',
-        }),
+        this.interactions.submitRetryWithPersonalCredentials(stream, requestId),
     });
   }
 

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -72,7 +72,10 @@ export interface ProgressApiKeyRetryControllerDeps {
   codingPlanToggles?: readonly CodingPlanToggle[];
   invalidateModelOptionsCache(): void;
   isRetryPending(stream: StreamTabId, requestId: string): boolean;
-  triggerRetry(stream: StreamTabId, requestId: string): boolean;
+  triggerRetry(
+    stream: StreamTabId,
+    requestId: string,
+  ): boolean | Promise<boolean>;
 }
 
 /**
@@ -109,7 +112,10 @@ export class ProgressApiKeyRetryController {
 
     const routingBefore = this.routingSnapshot();
     const prepared = await this.applyOwnApiKeyRouting(request);
-    const retried = this.deps.triggerRetry(request.stream, request.requestId);
+    const retried = await this.deps.triggerRetry(
+      request.stream,
+      request.requestId,
+    );
     if (!retried) {
       await this.restoreOwnApiKeyRouting(routingBefore, prepared);
       return noRetryResult();

--- a/src/controllers/progressView/backend/progressHostInteractions.ts
+++ b/src/controllers/progressView/backend/progressHostInteractions.ts
@@ -13,6 +13,7 @@ import {
   type HostInteractionOptions,
   type HostInteractions,
   type HostPlanApprovalRequest,
+  type HostRetryInteractionOptions,
   type HostRetryRequest,
   type PlanApprovalResult,
   type ProposalResult,
@@ -30,6 +31,7 @@ import type {
   ToolEditApprovalRequest,
   ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
   cancelApprovalRequestHandlers,
@@ -63,6 +65,12 @@ export interface ProgressHostInteractions extends HostInteractions {
     requestId: string,
     decision: RetrySettlement,
   ): boolean;
+  /** Settle a retry after switching routing onto the user's own API key. */
+  submitRetryWithPersonalCredentials(
+    streamId: StreamTabId,
+    requestId: string,
+    feedback?: string,
+  ): Promise<boolean>;
   submitUserQuestionDecision(
     requestId: string,
     decision: UserQuestionSettlement,
@@ -104,9 +112,72 @@ export function createProgressHostInteractions(
     }
   };
 
+  /**
+   * The client-preparation callback carried by one pending retry request.
+   * Keyed by stream because the shared retry handler only keeps one pending
+   * request per stream; the request id guards against a stale settlement.
+   */
+  interface PendingRetryPreparation {
+    readonly requestId: string;
+    readonly prepareRetry: NonNullable<
+      HostRetryInteractionOptions['prepareRetry']
+    >;
+    readonly controller: AbortController;
+    settling: boolean;
+  }
+  const retryPreparations = new Map<StreamTabId, PendingRetryPreparation>();
+
+  const settlePreparedRetry = async (
+    streamId: StreamTabId,
+    requestId: string,
+    selection: 'configured' | 'personal',
+    feedback?: string,
+    denialResult = true,
+  ): Promise<boolean> => {
+    const preparation = retryPreparations.get(streamId);
+    if (!preparation || preparation.requestId !== requestId) {
+      // No host-side preparation callback is attached, so the caller's normal
+      // retry path (rebind) stays responsible for refreshing the client.
+      retryPreparations.delete(streamId);
+      return handlers().retry.complete(streamId, {
+        action: 'retry',
+        ...(feedback !== undefined ? { feedback } : {}),
+      });
+    }
+    if (preparation.settling) return true;
+    preparation.settling = true;
+    try {
+      await preparation.prepareRetry(selection, preparation.controller.signal);
+    } catch (error) {
+      retryPreparations.delete(streamId);
+      handlers().retry.complete(streamId, {
+        action: 'deny',
+        reason: toErrorMessage(error),
+      });
+      // The API-key switch path reports a denied preparation as false so its
+      // controller can roll the routing changes back; a plain retry has no
+      // routing changes to undo, so it still reports that the request settled.
+      return denialResult;
+    }
+    retryPreparations.delete(streamId);
+    return handlers().retry.complete(streamId, {
+      action: 'retry',
+      ...(feedback !== undefined ? { feedback } : {}),
+    });
+  };
+
   const cancel = (selector: HostInteractionCancelSelector = {}): void => {
     if (selector.kind == null || selector.kind === 'toolEdit') {
       options.getToolEditApprovals().cancel(selector);
+    }
+    if (selector.kind == null || selector.kind === 'retry') {
+      if (selector.streamId === undefined) {
+        for (const preparation of retryPreparations.values()) {
+          preparation.controller.abort();
+        }
+      } else if (selector.streamId !== null) {
+        retryPreparations.get(selector.streamId)?.controller.abort();
+      }
     }
     cancelApprovalRequestHandlers(
       handlers(),
@@ -154,7 +225,9 @@ export function createProgressHostInteractions(
     /**
      * Settle a pending retry request. Returns false when the request is no
      * longer the pending one for that stream, so a stale renderer click cannot
-     * resolve a newer request.
+     * resolve a newer request. A retry action runs any forwarded client
+     * preparation before the request actually settles; a preparation failure
+     * settles the request as a denial instead of retrying with a stale client.
      */
     submitRetryDecision(
       streamId: StreamTabId,
@@ -162,7 +235,38 @@ export function createProgressHostInteractions(
       decision: RetrySettlement,
     ): boolean {
       if (!isRetryPending(streamId, requestId)) return false;
-      return handlers().retry.complete(streamId, decision);
+      if (decision.action === 'cancel') {
+        retryPreparations.delete(streamId);
+        return handlers().retry.complete(streamId, decision);
+      }
+      void settlePreparedRetry(
+        streamId,
+        requestId,
+        'configured',
+        decision.feedback,
+      );
+      return true;
+    },
+
+    /**
+     * Settle a retry after the host has switched routing onto the user's own
+     * API key. The personal-credential preparation must run before the retry
+     * settles; a failure returns false so the API-key controller can roll its
+     * routing changes back.
+     */
+    async submitRetryWithPersonalCredentials(
+      streamId: StreamTabId,
+      requestId: string,
+      feedback?: string,
+    ): Promise<boolean> {
+      if (!isRetryPending(streamId, requestId)) return false;
+      return settlePreparedRetry(
+        streamId,
+        requestId,
+        'personal',
+        feedback,
+        false,
+      );
     },
 
     submitBashDecision: (requestId, decision) =>
@@ -234,9 +338,23 @@ export function createProgressHostInteractions(
      */
     requestRetry(
       request: HostRetryRequest,
-      interactionOptions?: HostInteractionOptions,
+      interactionOptions?: HostRetryInteractionOptions,
     ): Promise<RetryResult> {
       revealStream(request.streamId);
+      // A replacement retry on the same stream cancels any preparation still
+      // in flight for the request it replaces; the shared handler does the same
+      // for its pending entry below.
+      retryPreparations.get(request.streamId)?.controller.abort();
+      if (interactionOptions?.prepareRetry) {
+        retryPreparations.set(request.streamId, {
+          requestId: request.requestId,
+          prepareRetry: interactionOptions.prepareRetry,
+          controller: new AbortController(),
+          settling: false,
+        });
+      } else {
+        retryPreparations.delete(request.streamId);
+      }
       return handlers().retry.request(request, {
         cancellationScope: interactionOptions?.cancellationScope,
         cancellationResult: (cause) => cancellationResultFor('retry', cause),
@@ -265,6 +383,7 @@ export function createProgressHostInteractions(
 
     dispose(): void {
       cancel({ cause: SESSION_DISPOSED_CAUSE });
+      retryPreparations.clear();
     },
   };
 }

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -892,7 +892,34 @@ describe('TUI retry approvals', () => {
     // The modal's quota warning was skipped, so the terminal notification is
     // the only signal that a persisted preference was flipped.
     expect(mocks.notify).toHaveBeenCalledWith('credentialSwitched');
+    expect(prepareRetry.mock.invocationCallOrder[0] ?? 0).toBeLessThan(
+      mocks.notify.mock.invocationCallOrder[0] ?? 0,
+    );
     expect(currentApproval.get()).toBeUndefined();
+  });
+
+  it('announces the credential switch only after the personal client is prepared', async () => {
+    mocks.preferKimiCode = true;
+    mocks.hasUsableApiKey.mockImplementation(
+      async (_secrets, provider: ApiProvider) => provider === 'moonshot',
+    );
+    const prepareRetry = vi.fn(async () => {
+      throw new Error('Moonshot client construction failed');
+    });
+
+    const { interactions } = tui();
+    const result = interactions.requestRetry?.(
+      kimiCodeSubscriptionRetry('kimi-notify-failure'),
+      { prepareRetry },
+    );
+
+    await expect(result).resolves.toEqual({
+      action: 'deny',
+      reason: 'Moonshot client construction failed',
+    });
+    // The automatic decision must not announce a switch that then rolled back.
+    expect(mocks.notify).not.toHaveBeenCalled();
+    expect(mocks.preferKimiCode).toBe(true);
   });
 
   it('keeps the modal for a Kimi Code-exclusive model with no Moonshot fallback', async () => {
@@ -908,11 +935,20 @@ describe('TUI retry approvals', () => {
 
     // A stored Moonshot key must not auto-switch a kimi-for-coding model:
     // the coding endpoint is its only route, so the switch would retry the
-    // same exhausted credential without a human decision.
-    await waitForApproval('retry', {
-      streamId: 'kimi-exclusive',
-      personalApiKeyAvailable: true,
-    });
+    // same exhausted credential without a human decision. The modal is shown
+    // without the API-key switch affordance, so the key availability lookup is
+    // skipped as well.
+    await waitForApproval('retry', { streamId: 'kimi-exclusive' });
+    expect(
+      (
+        currentApproval.get()?.payload as
+          | {
+              personalApiKeyAvailable?: boolean;
+            }
+          | undefined
+      )?.personalApiKeyAvailable,
+    ).toBeUndefined();
+    expect(mocks.hasUsableApiKey).not.toHaveBeenCalled();
     decideRetry({ accepted: false });
 
     await expect(result).resolves.toEqual({ action: 'cancel' });
@@ -1030,6 +1066,55 @@ describe('TUI retry approvals', () => {
       preserveOpenRouter: true,
     });
     expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+  });
+
+  it('serializes coding-plan rollback ahead of a newer coding-plan switch', async () => {
+    mocks.preferKimiCode = true;
+    mocks.hasUsableApiKey.mockImplementation(
+      async (_secrets, provider: ApiProvider) => provider === 'moonshot',
+    );
+    const firstPreparation = pDefer<void>();
+    const firstPrepare = vi.fn(async () => firstPreparation.promise);
+    const secondPrepare = vi.fn(async () => undefined);
+
+    const { interactions } = tui();
+    const first = interactions.requestRetry?.(
+      kimiCodeSubscriptionRetry('plan-race-first'),
+      { prepareRetry: firstPrepare },
+    );
+    await vi.waitFor(() => expect(firstPrepare).toHaveBeenCalledOnce());
+    expect(mocks.preferKimiCode).toBe(false);
+
+    const second = interactions.requestRetry?.(
+      kimiCodeSubscriptionRetry('plan-race-second'),
+      { prepareRetry: secondPrepare },
+    );
+    await settleRetryContinuation();
+    // The second switch must wait behind the first switch's rollback: only
+    // the first disable has committed so far.
+    expect(mocks.setCliCodingPlanSubscription).toHaveBeenCalledTimes(1);
+
+    firstPreparation.reject(new Error('first fallback failed'));
+    await expect(first).resolves.toEqual({
+      action: 'deny',
+      reason: 'first fallback failed',
+    });
+    await expect(second).resolves.toEqual({
+      action: 'retry',
+      decisionSource: 'automatic',
+      feedback: undefined,
+    });
+    expect(mocks.setPreferKimiCode).toHaveBeenCalledWith(true, undefined, {
+      preserveOpenRouter: true,
+    });
+    // The stale rollback restores the plan before the newer switch disables it
+    // again, so the second retry still runs on the personal route.
+    expect(
+      mocks.setPreferKimiCode.mock.invocationCallOrder[0] ?? 0,
+    ).toBeLessThan(
+      mocks.setCliCodingPlanSubscription.mock.invocationCallOrder[1] ?? 0,
+    );
+    expect(mocks.preferKimiCode).toBe(false);
   });
 
   it('restores Kimi without overwriting a newer OpenRouter choice', async () => {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -96,6 +96,11 @@ type TestableBridge = {
       requestId: string,
       decision: { action: 'retry' | 'cancel'; feedback?: string },
     ): boolean;
+    submitRetryWithPersonalCredentials(
+      streamId: StreamTabId,
+      requestId: string,
+      feedback?: string,
+    ): Promise<boolean>;
   };
   waitUntilReady(): Promise<void>;
   interactions: {

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
@@ -392,6 +392,85 @@ describe('createExtensionHostInteractions', () => {
     await expect(replacement).resolves.toEqual({ action: 'retry' });
   });
 
+  it('prepares a progress-view retry before settling it', async () => {
+    const { interactions } = createInteractions({
+      session: createTestSession(),
+    });
+    const prepareRetry = vi.fn(async () => undefined);
+    const result = interactions.requestRetry?.(
+      {
+        requestId: 'retry:prepared',
+        streamId: STREAM_A,
+        operation: 'Model invocation',
+      },
+      { prepareRetry },
+    );
+
+    expect(
+      interactions.submitRetryDecision(STREAM_A, 'retry:prepared', {
+        action: 'retry',
+      }),
+    ).toBe(true);
+    await expect(result).resolves.toEqual({ action: 'retry' });
+    expect(prepareRetry).toHaveBeenCalledWith('configured', expect.anything());
+  });
+
+  it('prepares the personal route for the API-key retry switch', async () => {
+    const { interactions } = createInteractions({
+      session: createTestSession(),
+    });
+    const prepareRetry = vi.fn(async () => undefined);
+    const result = interactions.requestRetry?.(
+      {
+        requestId: 'retry:personal',
+        streamId: STREAM_A,
+        operation: 'Model invocation',
+      },
+      { prepareRetry },
+    );
+
+    await expect(
+      interactions.submitRetryWithPersonalCredentials(
+        STREAM_A,
+        'retry:personal',
+        'switched to the stored key',
+      ),
+    ).resolves.toBe(true);
+    await expect(result).resolves.toEqual({
+      action: 'retry',
+      feedback: 'switched to the stored key',
+    });
+    expect(prepareRetry).toHaveBeenCalledWith('personal', expect.anything());
+  });
+
+  it('denies a personal-credential retry when client preparation fails', async () => {
+    const { interactions } = createInteractions({
+      session: createTestSession(),
+    });
+    const prepareRetry = vi.fn(async () => {
+      throw new Error('replacement client failed');
+    });
+    const result = interactions.requestRetry?.(
+      {
+        requestId: 'retry:prepare-failure',
+        streamId: STREAM_A,
+        operation: 'Model invocation',
+      },
+      { prepareRetry },
+    );
+
+    await expect(
+      interactions.submitRetryWithPersonalCredentials(
+        STREAM_A,
+        'retry:prepare-failure',
+      ),
+    ).resolves.toBe(false);
+    await expect(result).resolves.toEqual({
+      action: 'deny',
+      reason: 'replacement client failed',
+    });
+  });
+
   it('cancels pending retry requests for a removed stream', async () => {
     const presentationSink = createPresentationSink();
     const { handlers, interactions } = createInteractions({

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts
@@ -48,6 +48,7 @@ function createHostInteractions(
     submitPlanDecision: vi.fn(() => false),
     submitProposalDecision: vi.fn(() => false),
     submitRetryDecision: vi.fn(() => false),
+    submitRetryWithPersonalCredentials: vi.fn(async () => false),
     submitUserQuestionDecision: vi.fn(() => false),
     dismissExternalInquiry: vi.fn(),
     cancel: vi.fn(),


### PR DESCRIPTION
Follow-ups to #10363.

- Route progress-view key retries through the Kimi Code fallback handler.
- Notify the TUI credential switch only after it succeeds.
- Serialize coding-plan rollback with concurrent retry switches.
- Hide the API-key switch for Kimi Code-exclusive models in the retry modal.

Closes #10470
Closes #10471
Closes #10472
Closes #10473