### PR TITLE
fix(agent,extension): harden presentation delivery truthfulness follow-ups (#10466-10469)

### DIFF
--- a/packages/extension/src/frontend/approval/VscodeToolEditApprovalHost.ts
+++ b/packages/extension/src/frontend/approval/VscodeToolEditApprovalHost.ts
@@ -23,6 +23,7 @@ import {
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import type { DiffSession, DiffViewHost } from '@hosts/uiHosts';
+import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import type { ApprovalTempFiles } from '@tools/approval/tempFileManager';
 import { writeApprovalTempFiles } from '@tools/approval/tempFileManager';
 import {
@@ -37,7 +38,9 @@ const CHANNEL = 'ToolEditApproval';
 
 export class VscodeToolEditApprovalHost implements ToolEditApprovalHost {
   private readonly diffViewHost: DiffViewHost = new VscodeDiffViewHost();
-  readonly openBuildDisplay = openBuildDisplayIfTex;
+  readonly openBuildDisplay: BuildDisplayFn = async (location, options) => {
+    await openBuildDisplayIfTex(location, options);
+  };
 
   constructor(private readonly storageDirectory: string) {}
 

--- a/packages/extension/src/frontend/events/agentEventListeners.ts
+++ b/packages/extension/src/frontend/events/agentEventListeners.ts
@@ -42,16 +42,13 @@ function handleRequestOpenFile(
 ): Promise<boolean> {
   return openBuildDisplayIfTex(payload.location, {
     preserveFocus: payload.preserveFocus,
-  }).then(
-    () => true,
-    (err) => {
-      logger.warn(
-        CHANNEL,
-        `Failed to open file ${payload.location.absolutePath}: ${toErrorMessage(err)}`,
-      );
-      return false;
-    },
-  );
+  }).catch((err) => {
+    logger.warn(
+      CHANNEL,
+      `Failed to open file ${payload.location.absolutePath}: ${toErrorMessage(err)}`,
+    );
+    return false;
+  });
 }
 
 /**
@@ -145,8 +142,16 @@ function handleRequestShowError({ message }: RequestShowErrorPayload): boolean {
   try {
     // Delivery is the toast handoff: `showErrorMessage` resolves only on
     // dismissal, which no caller should wait on, so report once VS Code has
-    // accepted the request.
-    void vscode.window.showErrorMessage(message);
+    // accepted the request. The returned Thenable is still observed so a
+    // post-handoff rejection (e.g. while the extension host is tearing down)
+    // is logged instead of becoming an unhandled rejection.
+    const toast = vscode.window.showErrorMessage(message);
+    void Promise.resolve(toast).catch((err: unknown) => {
+      logger.warn(
+        CHANNEL,
+        `Error toast failed after handoff: ${toErrorMessage(err)}`,
+      );
+    });
     return true;
   } catch (err) {
     logger.warn(
@@ -160,16 +165,23 @@ function handleRequestShowError({ message }: RequestShowErrorPayload): boolean {
 async function handleRequestEnsureProgressView(
   payload: RequestEnsureProgressViewPayload,
   progressViewProvider: ProgressViewProvider,
-): Promise<void> {
-  if (progressViewProvider.isViewVisible()) return;
+): Promise<boolean> {
+  if (progressViewProvider.isViewVisible()) return true;
 
   await vscode.commands.executeCommand('texra.showProgressView');
 
-  // If the view is still not visible after attempting to open it and a
-  // fallback notification was provided, show a toast as a last resort.
-  // This preserves the original two-check semantics that relied on await.
+  // Delivery is the reveal actually becoming visible, not the reveal command
+  // resolving. Re-check after the command before treating the event as
+  // presented.
+  if (progressViewProvider.isViewVisible()) return true;
+
   const fb = payload.fallbackNotification;
-  if (fb && !progressViewProvider.isViewVisible()) {
+  if (fb) {
+    // If the view is still not visible after attempting to open it and a
+    // fallback notification was provided, show a toast as a last resort.
+    // The toast itself is the delivered surface when the view cannot be made
+    // visible: a successful handoff means the event was presented even if
+    // the user dismisses it without retrying the reveal.
     const outputPart = fb.outputInfo ? ` (${fb.outputInfo})` : '';
     const selection = await vscode.window.showInformationMessage(
       `"${fb.agentName}" is processing ${fb.inputName} with ${fb.modelName}${outputPart}.`,
@@ -183,7 +195,10 @@ async function handleRequestEnsureProgressView(
     if (selection) {
       await vscode.commands.executeCommand('texra.showProgressView');
     }
+    return true;
   }
+
+  return false;
 }
 
 /**
@@ -207,8 +222,7 @@ function createPresentationEventHandlers(
     showAgentConfigBanner: handleShowAgentConfigBanner,
     requestShowError: handleRequestShowError,
     requestEnsureProgressView: (payload) =>
-      handleRequestEnsureProgressView(payload, progressViewProvider).then(
-        () => true,
+      handleRequestEnsureProgressView(payload, progressViewProvider).catch(
         (err) => {
           logger.warn(
             CHANNEL,

--- a/packages/extension/src/frontend/latex/openBuild.ts
+++ b/packages/extension/src/frontend/latex/openBuild.ts
@@ -90,17 +90,21 @@ export async function invokeLatexWorkshopBuild(
 /**
  * Open a file, compile if it is TeX, and display the resulting PDF.
  * The PDF viewer is refreshed if already loaded.
+ *
+ * Resolves `true` when a surface was actually opened, and `false` when the
+ * path is missing or the internal LaTeX compilation failed, so presentation
+ * callers can report non-delivery truthfully.
  */
 export async function openBuildDisplayIfTex(
   fileLocation: FileLocation,
   options: { preserveFocus?: boolean } = {},
-): Promise<void> {
+): Promise<boolean> {
   const absolutePath = fileLocation.absolutePath;
 
   const exists = await AbsoluteFS.exists(absolutePath);
   if (!exists) {
     void showLoggedMessage(CHANNEL, `File not found: ${absolutePath}`);
-    return;
+    return false;
   }
 
   const uri = vscode.Uri.file(absolutePath);
@@ -109,10 +113,10 @@ export async function openBuildDisplayIfTex(
     await vscode.commands.executeCommand('vscode.open', uri, {
       preserveFocus: options.preserveFocus ?? false,
     } satisfies vscode.TextDocumentShowOptions);
-    return;
+    return true;
   }
 
-  await openAndBuildLatex(uri, fileLocation, options.preserveFocus ?? false);
+  return openAndBuildLatex(uri, fileLocation, options.preserveFocus ?? false);
 }
 
 /**
@@ -129,7 +133,7 @@ async function openAndBuildLatex(
   uri: vscode.Uri,
   fileLocation: FileLocation,
   preserveFocus: boolean,
-): Promise<void> {
+): Promise<boolean> {
   const doc = await vscode.workspace.openTextDocument(uri);
   await vscode.window.showTextDocument(doc, { preview: true, preserveFocus });
 
@@ -153,10 +157,12 @@ async function openAndBuildLatex(
         `Internal LaTeX compilation failed for ${uri.fsPath}:\n${compiled.logTail}`,
         { data: { sourceFile: uri.fsPath, logTail: compiled.logTail } },
       );
+      return false;
     }
   }
 
   scheduleViewerDisplay();
+  return true;
 }
 
 /**

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -184,7 +184,10 @@ export async function getAgentPath(
   // Mark "presented" only when a live host confirmed it rendered the
   // targeted banner. A queued replay instead marks the error as presentation
   // pending; the replay either attaches the presented marker on confirmed
-  // delivery or emits the generic fallback on non-delivery.
+  // delivery or emits the generic fallback on non-delivery. A live-host emit
+  // that throws synchronously is normalized to `false` by
+  // `SessionHostInteractions.emit`, so that path leaves the marker unset and
+  // lets the launch catch emit the generic fallback on the same host.
   if (delivered) attachErrorPresented(err);
   throw err;
 }
@@ -216,11 +219,13 @@ async function validateModelExists(
   );
   // As with `getAgentPath`: mark only after a live host confirms the
   // instruction was rendered (or let the queued replay settle the marker and
-  // fallback itself). The extension resolves its emit when the instruction is
-  // handed off to VS Code, not when the dialog is dismissed, so launch
-  // cleanup no longer waits on user interaction there. Desktop resolves with
-  // its window-modal dialog (#10399) — a wait bounded by the modal itself,
-  // since the user must dismiss it to keep using the window.
+  // fallback itself). A live-host emit that throws synchronously is likewise
+  // normalized to `false`, leaving the marker unset for the launch catch.
+  // The extension resolves its emit when the instruction is handed off to VS
+  // Code, not when the dialog is dismissed, so launch cleanup no longer waits
+  // on user interaction there. Desktop resolves with its window-modal dialog
+  // (#10399) — a wait bounded by the modal itself, since the user must
+  // dismiss it to keep using the window.
   if (delivered) attachErrorPresented(err);
   throw err;
 }

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -470,7 +470,12 @@ export class SessionHostInteractions implements HostInteractions {
   ): boolean | Promise<boolean> {
     const active = this.activeAttachment;
     if (active) {
-      return active.interactions.emit?.(event, payload) ?? false;
+      try {
+        return active.interactions.emit?.(event, payload) ?? false;
+      } catch (error) {
+        logger.warn('Live presentation emit failed', { data: error });
+        return false;
+      }
     }
     if (options.replayWhenAttached && !this.disposed) {
       // A retained replay is not delivery: nothing has been rendered yet, so

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -246,6 +246,46 @@ describe('AgentLaunchContext', () => {
     owner.dispose();
   });
 
+  it('normalizes a live-host synchronous banner throw into the generic toast fallback', async () => {
+    // A live (already attached) host whose emit throws synchronously is
+    // normalized to `false` by `SessionHostInteractions.emit`, leaving the
+    // error unmarked so the launch catch emits the generic fallback on the
+    // same host (#10466).
+    const events: Array<{ event: string; payload: unknown }> = [];
+    const owner = new SessionHostInteractions();
+    owner.use({
+      emit: (event, payload) => {
+        if (event === 'showAgentConfigBanner') {
+          throw new Error('renderer torn down mid-post');
+        }
+        events.push({ event, payload });
+        return false;
+      },
+      cancel: () => {},
+    });
+    const session = createTestSession({ interactions: owner });
+    let thrown: unknown;
+
+    try {
+      await buildAgentLaunchContext({
+        config: AgentConfigSchema.parse({ agent: '', model: '' }),
+        session,
+      }).catch((error: unknown) => {
+        thrown = error;
+      });
+    } finally {
+      session.dispose();
+    }
+
+    expect(String(thrown)).toContain('Could not find agent');
+    expect(hasErrorPresentedMarker(thrown)).toBe(false);
+    expect(hasErrorPresentationPending(thrown)).toBe(false);
+    expect(
+      events.filter((entry) => entry.event === 'requestShowError'),
+    ).toHaveLength(1);
+    owner.dispose();
+  });
+
   it('does not queue a second generic toast while a missing-agent banner replay is pending', async () => {
     const recording = createRecordingHost({ emitDelivery: false });
     const owner = new SessionHostInteractions();

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -439,6 +439,25 @@ describe('session.interactions immediate capabilities', () => {
     session.dispose();
   });
 
+  it('reports a synchronously throwing live-host emit as not delivered', () => {
+    // The live-host immediate-attachment branch must apply the same guard as
+    // the queued replay path: a host adapter whose emit throws synchronously
+    // (a desktop renderer post during teardown) must read as not delivered,
+    // not escape as an arbitrary host exception (#10466).
+    const session = createTestSession();
+    session.useHostInteractions({
+      emit: () => {
+        throw new Error('renderer torn down mid-post');
+      },
+      cancel: vi.fn(),
+    });
+
+    expect(
+      session.interactions.emit('requestShowError', { message: 'boom' }),
+    ).toBe(false);
+    session.dispose();
+  });
+
   it('reports a synchronously throwing replayed emit through onReplayNotDelivered', async () => {
     // A host adapter whose emit throws synchronously (a desktop renderer
     // post during teardown) escapes the replay closure's promise chain; the

--- a/src/test-kernel/progressView/AgentPresentationHostReplayGate.vitest.ts
+++ b/src/test-kernel/progressView/AgentPresentationHostReplayGate.vitest.ts
@@ -6,6 +6,7 @@ import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { ApprovalRequestHandler } from '@controllers/progressView/backend/ApprovalRequestHandler';
 import type { ProgressHostInteractionsOptions } from '@controllers/progressView/backend/progressHostInteractions';
 import { createAgentPresentationHost } from '@frontend/events/agentEventListeners';
+import * as logger from '@logger/logUtils';
 import { createExtensionHostInteractions } from '@progressView/extensionHostInteractions';
 import type { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import type { ToolEditPermission } from '@shared/schemas';
@@ -32,7 +33,7 @@ import { createRecordingApprovalHandlers } from './approvalHandlerSetHarness';
 const mocks = vi.hoisted(() => ({
   getLinterMessages: vi.fn(async () => []),
   pushManualCriticism: vi.fn(() => true),
-  openBuildDisplayIfTex: vi.fn(async () => undefined),
+  openBuildDisplayIfTex: vi.fn(async () => true),
   instructionMemento: new Map<string, unknown>(),
 }));
 
@@ -202,7 +203,34 @@ describe('extension presentation delivery truthfulness (#10400)', () => {
     }
   });
 
-  it('reports file-open delivery from the open promise', async () => {
+  it('observes an error-toast handoff rejection without reporting non-delivery', async () => {
+    // `showErrorMessage` resolves on dismissal, which callers must not wait
+    // on, so the handoff remains the delivery signal. The returned Thenable
+    // is still observed: a post-handoff rejection is warn-logged instead of
+    // surfacing as an unhandled rejection (#10467).
+    const showErrorMessage = vi
+      .spyOn(vscode.window, 'showErrorMessage')
+      .mockRejectedValueOnce(new Error('host gone'));
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      const host = presentationHost();
+      expect(await host.emit('requestShowError', { message: 'Boom' })).toBe(
+        true,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(showErrorMessage).toHaveBeenCalledWith('Boom');
+      expect(warn).toHaveBeenCalledWith(
+        'agentEventListeners',
+        expect.stringContaining('toast'),
+      );
+    } finally {
+      showErrorMessage.mockRestore();
+      warn.mockRestore();
+    }
+  });
+
+  it('reports file-open delivery from the open outcome', async () => {
     const host = presentationHost();
     const payload = {
       location: {
@@ -213,8 +241,11 @@ describe('extension presentation delivery truthfulness (#10400)', () => {
       preserveFocus: true,
     };
 
-    mocks.openBuildDisplayIfTex.mockResolvedValueOnce(undefined);
+    mocks.openBuildDisplayIfTex.mockResolvedValueOnce(true);
     await expect(host.emit('requestOpenFile', payload)).resolves.toBe(true);
+
+    mocks.openBuildDisplayIfTex.mockResolvedValueOnce(false);
+    await expect(host.emit('requestOpenFile', payload)).resolves.toBe(false);
 
     mocks.openBuildDisplayIfTex.mockRejectedValueOnce(new Error('no viewer'));
     await expect(host.emit('requestOpenFile', payload)).resolves.toBe(false);
@@ -236,6 +267,49 @@ describe('extension presentation delivery truthfulness (#10400)', () => {
       ).resolves.toBe(false);
     } finally {
       executeCommand.mockRestore();
+    }
+  });
+
+  it('reports progress-view non-delivery when the reveal settles without making the view visible', async () => {
+    // The reveal command resolving is not delivery: nothing was presented if
+    // the view remains hidden after it (#10468).
+    const executeCommand = vi
+      .spyOn(vscode.commands, 'executeCommand')
+      .mockResolvedValue(undefined);
+    try {
+      const host = presentationHost({ isViewVisible: () => false });
+      await expect(host.emit('requestEnsureProgressView', {})).resolves.toBe(
+        false,
+      );
+      expect(executeCommand).toHaveBeenCalledWith('texra.showProgressView');
+    } finally {
+      executeCommand.mockRestore();
+    }
+  });
+
+  it('reports the fallback notification as delivered when the view stays hidden', async () => {
+    const executeCommand = vi
+      .spyOn(vscode.commands, 'executeCommand')
+      .mockResolvedValue(undefined);
+    const showInformationMessage = vi
+      .spyOn(vscode.window, 'showInformationMessage')
+      .mockResolvedValue(undefined);
+    try {
+      const host = presentationHost({ isViewVisible: () => false });
+      await expect(
+        host.emit('requestEnsureProgressView', {
+          fallbackNotification: {
+            agentName: 'writer',
+            modelName: 'test-model',
+            inputName: 'paper.tex',
+            outputInfo: 'to paper.out.tex',
+          },
+        }),
+      ).resolves.toBe(true);
+      expect(showInformationMessage).toHaveBeenCalledOnce();
+    } finally {
+      executeCommand.mockRestore();
+      showInformationMessage.mockRestore();
     }
   });
 


### PR DESCRIPTION
Follow-ups to #10445 (presentation delivery truthfulness), rebased onto current main after #10498.

- `#10466`: guard the live-host immediate-attachment emit against synchronous throws; a sync host emit throw now warn-logs and reports `false` like the queued replay path. Launch-error markers stay unset, so `buildAgentLaunchContext` emits the generic `requestShowError` fallback on the same host.
- `#10467`: observe the extension error-toast handoff Thenable so a post-handoff rejection is warn-logged instead of becoming an unhandled rejection; handoff delivery semantics are unchanged.
- `#10468`: `handleRequestEnsureProgressView` re-checks `isViewVisible()` after the reveal command and reports that (or the fallback toast outcome) instead of treating bare promise settlement as delivery.
- `#10469`: `openBuildDisplayIfTex` now resolves an explicit boolean; missing paths and internal LaTeX compile failures report `false`, and `handleRequestOpenFile` propagates it. `VscodeToolEditApprovalHost` adapts the new return to the existing `BuildDisplayFn` void contract.

Tests: extended `SessionInteractions`, `AgentLaunchContext`, and `AgentPresentationHostReplayGate`.

Closes #10466
Closes #10467
Closes #10468
Closes #10469