### PR TITLE
fix(ui): finish katex-4 max-style follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,8 @@ All notable changes to this project will be documented in this file.
 - **Max-style shortcuts no longer shadow KaTeX built-ins** — the section
   sign and the legacy bold switch render as intended, `\label` no longer
   errors in rendered math, decorated-H effective-Hamiltonian forms keep
-  their accents, equilibrium/steady-state subscripts no longer turn into
-  superscripts, and written documents with the plain-S shortcut compile.
+  their accents, and equilibrium/steady-state eq/st subscripts no longer turn
+  into superscripts.
 
 #### Features
 

--- a/packages/extension/resources/templates/chatExport.tex
+++ b/packages/extension/resources/templates/chatExport.tex
@@ -12,11 +12,6 @@
 \usepackage{xcolor}
 \geometry{margin=2.5cm}
 
-% TeXRA max-style replacements use \sS for the plain-S subscript/superscript
-% shortcut; define it here so exported LaTeX compiles when max-style output
-% is present.
-\providecommand{\sS}{S}
-
 \lstset{
   basicstyle=\ttfamily\small,
   breaklines=true,

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -36,7 +36,11 @@ import {
   PERSONAL_STYLE_REPLACEMENTS,
   LATEXDIFF_REPLACEMENTS,
 } from './rules';
-import { MAX_STYLE_REPLACEMENTS, MAX_REGEX_REPLACEMENTS } from './maxRules';
+import {
+  LEGACY_UNBRACED_S_MIGRATION,
+  MAX_STYLE_REPLACEMENTS,
+  MAX_REGEX_REPLACEMENTS,
+} from './maxRules';
 import {
   EQUATION_MACRO_REPLACEMENTS,
   PARENTHESES_REPLACEMENTS,
@@ -70,6 +74,14 @@ const replacementEngine = {
   applyAll(text: string): string {
     const replacements = getAllReplacements();
     const wrapCritique = shouldWrapCritiqueInAlign();
+    const maxStyleEnabled = getConfig<string[]>(
+      'texra.latex.enabledReplacements',
+      DEFAULT_CORE_SETTINGS.latex.enabledReplacements,
+    ).includes('max_style');
+    const maxStyleRegexEnabled = getConfig<string[]>(
+      'texra.latex.enabledReplacementsRegex',
+      DEFAULT_CORE_SETTINGS.latex.enabledReplacementsRegex,
+    ).includes('max_style_regex');
 
     let result = applyReplacements(text, replacements, {
       cleanupPasses: false,
@@ -78,6 +90,15 @@ const replacementEngine = {
     result = applyReplacements(result, getAllReplacementsRegex(), {
       cleanupPasses: false,
     }).trim();
+    // The legacy unbraced S migration is a compatibility rule, not an
+    // opt-in regex replacement: run it whenever the direct max-style group
+    // produced the persisted output it repairs. When `max_style_regex` is
+    // enabled, MAX_REGEX_REPLACEMENTS already contains the same rule.
+    if (maxStyleEnabled && !maxStyleRegexEnabled) {
+      result = applyReplacements(result, LEGACY_UNBRACED_S_MIGRATION, {
+        cleanupPasses: false,
+      }).trim();
+    }
     result = applyReplacements(result, replacements).trim();
     return wrapCritique ? wrapCritiqueInAlign(result) : result;
   },

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -557,6 +557,45 @@ const PAREN_CREF_EQN = `\\(${CREF_EQN}\\)`;
 const PAREN_EQREF_EQN = `\\(${EQREF_EQN}\\)`;
 const CREF_FIG = '\\\\cref\\{(fig:[^,}]+)\\}';
 
+/**
+ * Legacy unbraced `_\S`/`^\S` plain-S shortcut migration.
+ *
+ * Introduced 2026-08-15 (#10507) to migrate persisted pre-#10439
+ * `symbolOperators` output, which used the unbraced S destination before the
+ * plain-S shortcut was renamed to `\sS`. Retire after 2026-11-15, three
+ * months after the replacement shipped; delete the MAX_REGEX spread below,
+ * the max-style-gated engine call in `applyAll`, and the drift assertions
+ * together.
+ *
+ * The negative lookbehind keeps escaped script markers (`\_\S`, `\^\S`)
+ * intact, and the right-side boundary keeps S-prefixed commands such as
+ * `\Strat`/`\Sig` intact. A `\S` followed by a digit remains ambiguous —
+ * legacy `\S0` migration versus a genuine `^\S2` — and is still migrated.
+ */
+export const LEGACY_UNBRACED_S_MIGRATION: RegexReplacementCategory = {
+  name: 'legacy_unbraced_s_migration',
+  description:
+    'Legacy unbraced plain-S shortcut migration for persisted pre-rename output',
+  isRegex: true,
+  flags: 'gms',
+  patterns: {
+    '(?<!\\\\)([_^])\\\\S(?![A-Za-z])': '$1\\sS',
+  },
+};
+
+/**
+ * Convert the KaTeX-only `\sS` plain-S destination back to LaTeX's built-in
+ * `\S` section sign when writing `.tex` files. `\sS` is defined only by the
+ * progress-view KaTeX macro table; project documents compile against the
+ * user's own preamble, where `\sS` is undefined. `\S` compiles everywhere.
+ *
+ * Boundary-aware for the same reason as the migration rule: a literal
+ * `_\sS` prefix replacement would corrupt `_\sStrat`-style commands.
+ */
+export function restoreLatexSectionSign(text: string): string {
+  return text.replaceAll(/([_^])\\sS(?![A-Za-z])/g, '$1\\S');
+}
+
 export const MAX_REGEX_REPLACEMENTS: RegexReplacementCategory = {
   name: 'max_style_regex' satisfies RegexReplacementCategoryName,
   description:
@@ -580,11 +619,11 @@ export const MAX_REGEX_REPLACEMENTS: RegexReplacementCategory = {
     // '([,;])\\s*\\.\\.\\.\\s*([,;])': '$1\\ldots$2',
     // Max like ,..,
 
-    // Legacy unbraced '\S' plain-S shortcut migration. The non-regex
-    // table handles the braced source forms; these boundary-aware rules
-    // catch the pre-rename persisted unbraced output without turning
-    // '\Strat'/'\Sig' into '\sStrat'/'\sSig'.
-    '([_^])\\\\S(?![A-Za-z])': '$1\\sS',
+    // Legacy unbraced '\S' plain-S shortcut migration: introduced
+    // 2026-08-15 (#10507), retire after 2026-11-15 (three months after the
+    // replacement shipped). See LEGACY_UNBRACED_S_MIGRATION for the
+    // boundary-aware details and remaining digit ambiguity.
+    ...LEGACY_UNBRACED_S_MIGRATION.patterns,
 
     // PUNCTUATION AND SPACING
 

--- a/src/test-kernel/replacement/MaxStyleLegacySMigration.vitest.ts
+++ b/src/test-kernel/replacement/MaxStyleLegacySMigration.vitest.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import replacementEngine, { applyReplacements } from '@replacement/engine';
+import {
+  MAX_REGEX_REPLACEMENTS,
+  restoreLatexSectionSign,
+} from '@replacement/maxRules';
+
+const configState = vi.hoisted(() => ({
+  enabledReplacements: [] as string[],
+  enabledReplacementsRegex: [] as string[],
+}));
+
+vi.mock('@utils/config/configUtils', () => ({
+  getConfig: <T>(key: string, fallback: T): T => {
+    if (key === 'texra.latex.enabledReplacements') {
+      return configState.enabledReplacements as T;
+    }
+    if (key === 'texra.latex.enabledReplacementsRegex') {
+      return configState.enabledReplacementsRegex as T;
+    }
+    return fallback;
+  },
+}));
+
+describe('legacy unbraced S migration gating', () => {
+  beforeEach(() => {
+    configState.enabledReplacements = [];
+    configState.enabledReplacementsRegex = [];
+  });
+
+  it('runs the migration when max_style is enabled without max_style_regex', () => {
+    configState.enabledReplacements = ['max_style'];
+
+    expect(replacementEngine.applyAll('_\\S')).toBe('_\\sS');
+    expect(replacementEngine.applyAll('^\\S')).toBe('^\\sS');
+  });
+
+  it('still runs the migration through max_style_regex when it is enabled', () => {
+    configState.enabledReplacementsRegex = ['max_style_regex'];
+
+    expect(replacementEngine.applyAll('_\\S')).toBe('_\\sS');
+    expect(replacementEngine.applyAll('^\\S')).toBe('^\\sS');
+  });
+
+  it('does not run the migration when neither max-style group is enabled', () => {
+    expect(replacementEngine.applyAll('_\\S')).toBe('_\\S');
+    expect(replacementEngine.applyAll('^\\S')).toBe('^\\S');
+  });
+
+  it('keeps the migration boundary-aware under the max_style gate', () => {
+    configState.enabledReplacements = ['max_style'];
+
+    expect(replacementEngine.applyAll('_\\Strat')).toBe('_\\Strat');
+    expect(replacementEngine.applyAll('^\\Sig')).toBe('^\\Sig');
+    expect(replacementEngine.applyAll('\\_\\S')).toBe('\\_\\S');
+    expect(replacementEngine.applyAll('\\^\\S')).toBe('\\^\\S');
+    // The documented digit ambiguity is still migrated.
+    expect(replacementEngine.applyAll('x^\\S2')).toBe('x^\\sS2');
+  });
+});
+
+describe('restoreLatexSectionSign', () => {
+  it('converts the KaTeX-only destination back to the LaTeX built-in', () => {
+    expect(restoreLatexSectionSign('_\\sS')).toBe('_\\S');
+    expect(restoreLatexSectionSign('^\\sS')).toBe('^\\S');
+    expect(restoreLatexSectionSign('x^\\sS2')).toBe('x^\\S2');
+  });
+
+  it('keeps the boundary-aware behavior for S-prefixed commands', () => {
+    expect(restoreLatexSectionSign('_\\sStrat')).toBe('_\\sStrat');
+    expect(restoreLatexSectionSign('^\\sSig')).toBe('^\\sSig');
+    expect(restoreLatexSectionSign('\\sS')).toBe('\\sS');
+  });
+
+  it('leaves max-style braced sources for the replacement engine', () => {
+    expect(restoreLatexSectionSign('_{\\S}')).toBe('_{\\S}');
+    expect(restoreLatexSectionSign('^{\\S}')).toBe('^{\\S}');
+  });
+});
+
+// Keep the direct category pins explicit: MAX_REGEX still carries the same
+// migration rule through the shared pattern spread.
+describe('MAX_REGEX direct migration', () => {
+  it('migrates the legacy unbraced forms through the regex category', () => {
+    expect(applyReplacements('_\\S', MAX_REGEX_REPLACEMENTS)).toBe('_\\sS');
+    expect(applyReplacements('^\\S', MAX_REGEX_REPLACEMENTS)).toBe('^\\sS');
+  });
+});

--- a/src/test-kernel/shared/KatexMacroDrift.vitest.ts
+++ b/src/test-kernel/shared/KatexMacroDrift.vitest.ts
@@ -200,6 +200,29 @@ describe('katexMacros vs maxRules shortcuts', () => {
         MAX_REGEX_REPLACEMENTS,
       ]),
     ).toBe('^\\Sig');
+    // Escaped script markers (`\_\S`, `\^\S`) are not legacy unbraced
+    // output; the migration's negative lookbehind must leave them intact.
+    expect(
+      applyReplacements('\\_\\S', [
+        MAX_STYLE_REPLACEMENTS,
+        MAX_REGEX_REPLACEMENTS,
+      ]),
+    ).toBe('\\_\\S');
+    expect(
+      applyReplacements('\\^\\S', [
+        MAX_STYLE_REPLACEMENTS,
+        MAX_REGEX_REPLACEMENTS,
+      ]),
+    ).toBe('\\^\\S');
+    // `\S` followed by a digit is the documented remaining ambiguity: the
+    // migration still rewrites it because legacy `\S0` output is
+    // indistinguishable from a genuine section sign in `x^\S2`.
+    expect(
+      applyReplacements('x^\\S2', [
+        MAX_STYLE_REPLACEMENTS,
+        MAX_REGEX_REPLACEMENTS,
+      ]),
+    ).toBe('x^\\sS2');
     expect(applyReplacements('\\mathbf{f}', MAX_STYLE_REPLACEMENTS)).toBe(
       '\\bbf',
     );

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 // Local imports - tools
 import { isTexFile } from '@common/files/fileTypeUtils';
 import replacementEngine from '@replacement/engine';
+import { restoreLatexSectionSign } from '@replacement/maxRules';
 import type { ToolResult } from '@shared/schemas';
 import {
   applyApprovedFileEdit,
@@ -39,7 +40,7 @@ export class WriteFileTool extends defineTool({
     }
     const { path, displayPath, exists, originalContent } = prepared.target;
     const proposedContent = isTexFile(path)
-      ? replacementEngine.applyAll(input.content)
+      ? restoreLatexSectionSign(replacementEngine.applyAll(input.content))
       : input.content;
 
     return applyApprovedFileEdit({


### PR DESCRIPTION
Follow-up to #10507.

- #10512: remove the unreachable `\sS` definition from `chatExport.tex` (chat-export messages are escaped and tool output is in `lstlisting`) and restore the KaTeX-only `\sS` destination to LaTeX's built-in `\S` when `WriteTool` writes `.tex` files.
- #10513: narrow the changelog bullet to the eq/st subscript forms; `ss`/`sst` forms still compact to superscript `\rhost`.
- #10514: record the introduction date and three-month retirement condition on the legacy `_\S`/`^\S` migration.
- #10515: add a negative lookbehind so escaped script markers (`\_\S`, `\^\S`) are not migrated, and document the remaining `\S`-followed-by-digit ambiguity.
- #10516: run the legacy migration whenever `max_style` is enabled (not only with `max_style_regex`), while keeping it boundary-aware.

Closes #10512
Closes #10513
Closes #10514
Closes #10515
Closes #10516