### PR TITLE
fix(tui): bound static scrollback tail and regenerate ANSI on repaint

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -195,6 +195,8 @@ const PLAN_APPROVAL_OBJECTIVE =
   ].join('\n');
 const SHOW_SUBAGENT_FOLLOWUPS = process.env.HARNESS_SUBAGENT_FOLLOWUPS === '1';
 const SHOW_LONG_TOOL_OUTPUT = process.env.HARNESS_LONG_TOOL_OUTPUT === '1';
+const SHOW_TERMINAL_RESUME_REPAINT =
+  process.env.HARNESS_TERMINAL_RESUME_REPAINT === '1';
 const SHOW_ASSISTANT_TOOL_PREAMBLE =
   process.env.HARNESS_ASSISTANT_TOOL_PREAMBLE === '1';
 const SHOW_LIVE_TOOL_ONLY = process.env.HARNESS_LIVE_TOOL_ONLY === '1';
@@ -2465,6 +2467,19 @@ const ink = render(renderHarnessApp(), {
   exitOnCtrlC: false,
 });
 inkRef.current = ink;
+
+if (SHOW_TERMINAL_RESUME_REPAINT) {
+  void (async () => {
+    // Let the first static-transcript commit flush, then exercise the same
+    // SIGCONT repair path the real session-exit controller uses. The epoch
+    // remounts <Static> and repaints with replace semantics.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await ink.waitUntilRenderFlush();
+    viewportController.repaintAfterTerminalResume();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await ink.waitUntilRenderFlush();
+  })();
+}
 
 if (CHILD_EVENT_ORDER || SHOW_WORKFLOW_TIMELINE || SHOW_WORKFLOW_RUNNING) {
   // Mirror real CLI startup: `runChatTui.tsx` installs

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -127,6 +127,15 @@ const CHILD_EVENT_ORDER_CWD = mkdtempSync(
 process.on('exit', () => {
   rmSync(CHILD_EVENT_ORDER_CWD, { recursive: true, force: true });
 });
+// The static-transcript repaint scenarios compare a resize/resume repaint
+// against a from-scratch render of the same retained tail, so they too need a
+// byte-stable cwd across the canonical/reflow pair.
+const STATIC_TRANSCRIPT_CWD = mkdtempSync(
+  path.join(tmpdir(), 'texra-tui-static-transcript-'),
+);
+process.on('exit', () => {
+  rmSync(STATIC_TRANSCRIPT_CWD, { recursive: true, force: true });
+});
 const CHILD_EVENT_ORDER_MARKER_OSC = 777;
 const CHILD_EVENT_ORDER_MARKER_PREFIX = 'texra-harness-child-event-order:';
 
@@ -143,6 +152,44 @@ const SCENARIOS = [
       '◆',
       'Ctrl-C exit',
     ],
+  },
+
+  {
+    name: 'static-transcript-repaint-canonical',
+    frame: 'scrollback',
+    rows: 24,
+    cols: 80,
+    env: {
+      HARNESS_ENTRIES: '12',
+      HARNESS_CWD: STATIC_TRANSCRIPT_CWD,
+    },
+    expect: ['TeXRA', 'chat history line to grow the transcript pane'],
+  },
+  {
+    name: 'static-transcript-repaint-reflow',
+    equivalentFrameTo: 'static-transcript-repaint-canonical',
+    frame: 'scrollback',
+    rows: 24,
+    cols: 40,
+    env: {
+      HARNESS_ENTRIES: '12',
+      HARNESS_CWD: STATIC_TRANSCRIPT_CWD,
+    },
+    resizes: [{ cols: 80, rows: 24 }],
+    expect: ['TeXRA', 'chat history line to grow the transcript pane'],
+  },
+  {
+    name: 'static-transcript-terminal-resume',
+    equivalentFrameTo: 'static-transcript-repaint-canonical',
+    frame: 'scrollback',
+    rows: 24,
+    cols: 80,
+    env: {
+      HARNESS_ENTRIES: '12',
+      HARNESS_CWD: STATIC_TRANSCRIPT_CWD,
+      HARNESS_TERMINAL_RESUME_REPAINT: '1',
+    },
+    expect: ['TeXRA', 'chat history line to grow the transcript pane'],
   },
   {
     name: 'workflow-timeline',

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -35,6 +35,7 @@ import { SubagentList } from './SubagentList';
 import { TodosPlanPanel, todosPlanPanelRowCount } from './TodosPlanPanel';
 import { type ChildListValue } from '../state/childListSelection';
 import { inputBarContentRows } from '../state/cliState';
+import { staticTranscriptRepaintEpoch } from '../state/staticTranscriptRepaint';
 import {
   workflowDashboardPanelItemCount,
   type WorkflowDashboardModel,
@@ -124,7 +125,8 @@ export function ConversationRegion({
     () => JSON.stringify([...snapshot.subagentExecutionLabels]),
     [snapshot.subagentExecutionLabels],
   );
-  const staticTranscriptKey = `${scrollbackTarget.ownerKey}:${executionLabelsKey}`;
+  const staticTranscriptRepaint = useSignal(staticTranscriptRepaintEpoch);
+  const staticTranscriptKey = `${scrollbackTarget.ownerKey}:${executionLabelsKey}:${staticTranscriptRepaint}`;
 
   const activeSlice = snapshot.activeStreamId
     ? snapshot.streams.get(snapshot.activeStreamId)

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -12,7 +12,7 @@ import { Box, Static, Text } from 'ink';
 import { shortCliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
 import { COLOR_HINT } from '@cli/tui/ui/colors';
 import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
-import type { StreamTabId } from '@shared/schemas';
+import type { StreamPhase, StreamTabId } from '@shared/schemas';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { safeHomedir } from '@utils/system/platformPaths';
 
@@ -31,7 +31,12 @@ import {
 import { streamViewForId } from '../state/streamViews';
 import { useSignal } from '../state/useSignal';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
-import { orderedStaticTranscriptEntries } from './transcriptEntries';
+import {
+  EMPTY_TRANSCRIPT_ENTRIES,
+  incrementalStaticTranscriptEntries,
+  orderedStaticTranscriptEntries,
+  type StaticTranscriptScanCursor,
+} from './transcriptEntries';
 import { TranscriptEntry } from './TranscriptEntry';
 import {
   transcriptColumns,
@@ -56,6 +61,37 @@ export type StaticTranscriptItem =
 interface StaticTranscriptState {
   readonly ownerKey: string;
   readonly items: readonly StaticTranscriptItem[];
+  /** Cumulative row/byte estimates for `items`, maintained incrementally. */
+  readonly rowCount: number;
+  readonly byteCount: number;
+  readonly scan: StaticTranscriptScanCursor;
+  /** Incremented whenever items change non-append-only (trim, header insert,
+   *  hard reset, fold rebuild) so the `<Static>` identity remounts and
+   *  `onRenderKeyChange` repaints the bounded tail with replace semantics. */
+  readonly repaintEpoch: number;
+}
+
+export interface StaticTranscriptRingBudgets {
+  readonly rowHighWater: number;
+  readonly rowLowWater: number;
+  readonly byteHighWater: number;
+  readonly byteLowWater: number;
+}
+
+/** Bounded tail at native-terminal-scrollback scale. The high/low split is
+ *  hysteresis: a burst can overflow the high-water mark, then trim once down
+ *  to the low-water mark instead of trimming on every subsequent append. */
+export const DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS: StaticTranscriptRingBudgets =
+  Object.freeze({
+    rowHighWater: 2_000,
+    rowLowWater: 1_500,
+    byteHighWater: 1024 * 1024,
+    byteLowWater: 768 * 1024,
+  });
+
+interface StaticTranscriptTotals {
+  readonly rows: number;
+  readonly bytes: number;
 }
 
 function shortenCwd(cwd: string): string {
@@ -173,27 +209,6 @@ const SESSION_HEADER_ID = 'session-header';
 const FULL_SESSION_HEADER_ROWS = 4;
 const COMPACT_SESSION_HEADER_ROWS = 1;
 
-function staticTranscriptItemRowCount(
-  item: StaticTranscriptItem,
-  width?: number,
-  executionLabels?: ExecutionLabels,
-  previousItem?: StaticTranscriptItem,
-): number {
-  if (item.kind === 'header') {
-    return item.compact
-      ? COMPACT_SESSION_HEADER_ROWS
-      : FULL_SESSION_HEADER_ROWS;
-  }
-  return transcriptEntryLayoutRows(
-    transcriptEntryLayout(item.entry, {
-      executionLabels,
-      mode: 'scrollback-budget',
-      previousEntry: entryAbove(previousItem),
-      width,
-    }),
-  );
-}
-
 /** The transcript entry an item sits directly below, when that neighbor is
  *  itself an entry. A header above carries no margin for the next entry to
  *  collapse against. */
@@ -203,57 +218,282 @@ function entryAbove(
   return item?.kind === 'entry' ? item.entry : undefined;
 }
 
-function StaticTranscriptItemContent({
-  colorEnabled,
-  executionLabels,
-  item,
-  previousItem,
-  width,
-}: {
-  readonly colorEnabled?: boolean;
-  readonly executionLabels?: ExecutionLabels;
-  readonly item: StaticTranscriptItem;
-  readonly previousItem?: StaticTranscriptItem;
-  readonly width: number;
-}): React.JSX.Element {
-  switch (item.kind) {
-    case 'header':
-      return (
-        <EntryErrorBoundary label="session header">
-          <SessionHeaderBlock
-            compact={item.compact}
-            identityLine={item.identityLine}
-            meta={item.meta}
-            width={width}
-          />
-        </EntryErrorBoundary>
-      );
-    case 'entry':
-      return (
-        <EntryErrorBoundary label={item.entry.role}>
-          <TranscriptEntry
-            entry={item.entry}
-            previousEntry={entryAbove(previousItem)}
-            subagentExecutionLabels={executionLabels}
-            width={width}
-            colorEnabled={colorEnabled}
-          />
-        </EntryErrorBoundary>
-      );
-  }
+interface StaticTranscriptItemMetrics {
+  readonly rows: number;
+  readonly bytes: number;
 }
 
-export function appendStaticTranscriptItems({
+/** Row count plus a conservative UTF-8 byte estimate for one static item.
+ *  Entry metrics come from the same `scrollback-budget` layout the row budget
+ *  uses, so the ring never pays for a second full layout pass. */
+function staticTranscriptItemMetrics(
+  item: StaticTranscriptItem,
+  width?: number,
+  executionLabels?: ExecutionLabels,
+  previousItem?: StaticTranscriptItem,
+): StaticTranscriptItemMetrics {
+  if (item.kind === 'header') {
+    return {
+      rows: item.compact
+        ? COMPACT_SESSION_HEADER_ROWS
+        : FULL_SESSION_HEADER_ROWS,
+      bytes:
+        Buffer.byteLength(item.identityLine, 'utf8') +
+        Buffer.byteLength(item.meta.version, 'utf8') +
+        Buffer.byteLength(item.meta.apiMode, 'utf8') +
+        Buffer.byteLength(item.meta.agent, 'utf8') +
+        Buffer.byteLength(item.meta.cwd, 'utf8') +
+        64,
+    };
+  }
+  const layout = transcriptEntryLayout(item.entry, {
+    executionLabels,
+    mode: 'scrollback-budget',
+    previousEntry: entryAbove(previousItem),
+    width,
+  });
+  let bytes = 0;
+  for (const line of layout.lines) bytes += Buffer.byteLength(line, 'utf8');
+  return { rows: transcriptEntryLayoutRows(layout), bytes };
+}
+
+function staticTranscriptItemRowCount(
+  item: StaticTranscriptItem,
+  width?: number,
+  executionLabels?: ExecutionLabels,
+  previousItem?: StaticTranscriptItem,
+): number {
+  return staticTranscriptItemMetrics(item, width, executionLabels, previousItem)
+    .rows;
+}
+
+function staticTranscriptItemsTotals(
+  items: readonly StaticTranscriptItem[],
+  width?: number,
+  executionLabels?: ExecutionLabels,
+): StaticTranscriptTotals {
+  let rows = 0;
+  let bytes = 0;
+  let previousItem: StaticTranscriptItem | undefined;
+  for (const item of items) {
+    const metrics = staticTranscriptItemMetrics(
+      item,
+      width,
+      executionLabels,
+      previousItem,
+    );
+    rows += metrics.rows;
+    bytes += metrics.bytes;
+    previousItem = item;
+  }
+  return { rows, bytes };
+}
+
+/**
+ * Trim the oldest non-header items until the retained tail is at or below
+ * both low-water marks. A single oversized newest entry is kept even when it
+ * still exceeds a low-water mark; the header is never trimmed.
+ */
+export function trimStaticTranscriptItems(
+  items: readonly StaticTranscriptItem[],
+  options: {
+    readonly budgets?: StaticTranscriptRingBudgets;
+    readonly executionLabels?: ExecutionLabels;
+    readonly totals: StaticTranscriptTotals;
+    readonly width?: number;
+  },
+): {
+  readonly items: readonly StaticTranscriptItem[];
+  readonly totals: StaticTranscriptTotals;
+  readonly trimmed: boolean;
+} {
+  const budgets = options.budgets ?? DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS;
+  if (
+    options.totals.rows <= budgets.rowHighWater &&
+    options.totals.bytes <= budgets.byteHighWater
+  ) {
+    return { items, totals: options.totals, trimmed: false };
+  }
+
+  const nextItems = [...items];
+  const totals = { ...options.totals };
+  const headerCount = nextItems[0]?.kind === 'header' ? 1 : 0;
+  while (
+    nextItems.length > headerCount + 1 &&
+    (totals.rows > budgets.rowLowWater || totals.bytes > budgets.byteLowWater)
+  ) {
+    const removedIndex = headerCount;
+    const removed = nextItems[removedIndex];
+    if (removed === undefined) break;
+    const previousItem =
+      removedIndex > 0 ? nextItems[removedIndex - 1] : undefined;
+    const removedMetrics = staticTranscriptItemMetrics(
+      removed,
+      options.width,
+      options.executionLabels,
+      previousItem,
+    );
+    totals.rows -= removedMetrics.rows;
+    totals.bytes -= removedMetrics.bytes;
+
+    const nextRetained = nextItems[removedIndex + 1];
+    if (nextRetained !== undefined) {
+      const oldNextMetrics = staticTranscriptItemMetrics(
+        nextRetained,
+        options.width,
+        options.executionLabels,
+        removed,
+      );
+      nextItems.splice(removedIndex, 1);
+      const newPrevious =
+        removedIndex > 0 ? nextItems[removedIndex - 1] : undefined;
+      const newNextMetrics = staticTranscriptItemMetrics(
+        nextRetained,
+        options.width,
+        options.executionLabels,
+        newPrevious,
+      );
+      totals.rows += newNextMetrics.rows - oldNextMetrics.rows;
+      totals.bytes += newNextMetrics.bytes - oldNextMetrics.bytes;
+    } else {
+      nextItems.splice(removedIndex, 1);
+    }
+  }
+
+  return { items: nextItems, totals, trimmed: true };
+}
+
+function shouldWaitForChildIdentity({
   currentItems,
-  streams,
-  childStreamEntries = new Map(),
-  executionLabels,
-  meta,
-  maxRows,
-  parentStream = new Map(),
+  parentStream,
   scrollbackStreamId,
+  streams,
+}: {
+  readonly currentItems: readonly StaticTranscriptItem[];
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly scrollbackStreamId: StreamTabId | undefined;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+}): boolean {
+  return (
+    !currentItems.some((item) => item.id === SESSION_HEADER_ID) &&
+    scrollbackStreamId !== undefined &&
+    parentStream.has(scrollbackStreamId) &&
+    !streams.get(scrollbackStreamId)?.model
+  );
+}
+
+function ensureStaticSessionHeader({
+  byteCount,
+  childStreamEntries,
+  executionLabels,
+  items,
+  maxRows,
+  meta,
+  parentStream,
+  rowCount,
+  scrollbackStreamId,
+  streams,
   width,
 }: {
+  readonly byteCount: number;
+  readonly childStreamEntries: ChildStreamEntries;
+  readonly executionLabels?: ExecutionLabels;
+  readonly items: readonly StaticTranscriptItem[];
+  readonly maxRows?: number;
+  readonly meta: SessionMeta;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly rowCount: number;
+  readonly scrollbackStreamId: StreamTabId | undefined;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+  readonly width?: number;
+}): {
+  readonly items: readonly StaticTranscriptItem[];
+  readonly rowCount: number;
+  readonly byteCount: number;
+  readonly inserted: boolean;
+} {
+  if (items.some((item) => item.id === SESSION_HEADER_ID)) {
+    return { items, rowCount, byteCount, inserted: false };
+  }
+  if (
+    shouldWaitForChildIdentity({
+      currentItems: items,
+      parentStream,
+      scrollbackStreamId,
+      streams,
+    })
+  ) {
+    return { items, rowCount, byteCount, inserted: false };
+  }
+
+  const compact = maxRows !== undefined && maxRows < FULL_SESSION_HEADER_ROWS;
+  const header: StaticTranscriptItem = {
+    id: SESSION_HEADER_ID,
+    kind: 'header',
+    compact,
+    identityLine: sessionHeaderIdentityLine(meta, {
+      childStreamEntries,
+      parentStream,
+      streamId: scrollbackStreamId,
+      streams,
+    }),
+    meta,
+  };
+  const headerMetrics = staticTranscriptItemMetrics(
+    header,
+    width,
+    executionLabels,
+  );
+  const firstItem = items.find((item) => item.kind !== 'header');
+  let nextRowCount: number;
+  let nextByteCount: number;
+  if (firstItem === undefined) {
+    nextRowCount = rowCount + headerMetrics.rows;
+    nextByteCount = byteCount + headerMetrics.bytes;
+  } else {
+    const oldFirstMetrics = staticTranscriptItemMetrics(
+      firstItem,
+      width,
+      executionLabels,
+    );
+    const newFirstMetrics = staticTranscriptItemMetrics(
+      firstItem,
+      width,
+      executionLabels,
+      header,
+    );
+    nextRowCount =
+      rowCount -
+      oldFirstMetrics.rows +
+      newFirstMetrics.rows +
+      headerMetrics.rows;
+    nextByteCount =
+      byteCount -
+      oldFirstMetrics.bytes +
+      newFirstMetrics.bytes +
+      headerMetrics.bytes;
+  }
+  const fitsBudget = maxRows === undefined || nextRowCount <= maxRows;
+  if (!fitsBudget) {
+    return { items, rowCount, byteCount, inserted: false };
+  }
+
+  const firstEntryIndex = items.findIndex((item) => item.kind !== 'header');
+  const nextItems = [...items];
+  nextItems.splice(
+    firstEntryIndex < 0 ? nextItems.length : firstEntryIndex,
+    0,
+    header,
+  );
+  return {
+    items: nextItems,
+    rowCount: nextRowCount,
+    byteCount: nextByteCount,
+    inserted: true,
+  };
+}
+
+interface AppendStaticTranscriptItemsOptions {
   readonly currentItems: readonly StaticTranscriptItem[];
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly childStreamEntries?: ChildStreamEntries;
@@ -263,17 +503,64 @@ export function appendStaticTranscriptItems({
   readonly parentStream?: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly scrollbackStreamId: StreamTabId | undefined;
   readonly width?: number;
-}): readonly StaticTranscriptItem[] {
+  readonly ringBudgets?: StaticTranscriptRingBudgets;
+}
+
+interface StaticTranscriptBuildResult {
+  readonly items: readonly StaticTranscriptItem[];
+  readonly rowCount: number;
+  readonly byteCount: number;
+  readonly trimmed: boolean;
+}
+
+/** Full rebuild path. This is the from-scratch oracle used on owner switch,
+ *  hard reset, and fold rebuild; ordinary ticks use the incremental scan in
+ *  {@link incrementalStaticTranscriptEntries}. */
+export function buildStaticTranscriptItems(
+  options: AppendStaticTranscriptItemsOptions,
+): StaticTranscriptBuildResult {
+  const {
+    currentItems,
+    streams,
+    childStreamEntries = new Map(),
+    executionLabels,
+    meta,
+    maxRows,
+    parentStream = new Map(),
+    scrollbackStreamId,
+    width,
+    ringBudgets = DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS,
+  } = options;
   const seen = new Set(currentItems.map((item) => item.id));
   // Copied lazily: this runs on every stream-sync tick and most ticks append
   // nothing.
   let nextItems: StaticTranscriptItem[] | undefined;
-  const shouldWaitForChildIdentity =
-    !seen.has(SESSION_HEADER_ID) &&
-    scrollbackStreamId !== undefined &&
-    parentStream.has(scrollbackStreamId) &&
-    !streams.get(scrollbackStreamId)?.model;
-  if (shouldWaitForChildIdentity) return currentItems;
+  if (
+    shouldWaitForChildIdentity({
+      currentItems,
+      parentStream,
+      scrollbackStreamId,
+      streams,
+    })
+  ) {
+    const totals = staticTranscriptItemsTotals(
+      currentItems,
+      width,
+      executionLabels,
+    );
+    const trimmed = trimStaticTranscriptItems(currentItems, {
+      budgets: ringBudgets,
+      executionLabels,
+      totals,
+      width,
+    });
+    return {
+      items: trimmed.items,
+      rowCount: trimmed.totals.rows,
+      byteCount: trimmed.totals.bytes,
+      trimmed: trimmed.trimmed,
+    };
+  }
 
   if (!seen.has(SESSION_HEADER_ID)) {
     const header: StaticTranscriptItem = {
@@ -340,9 +627,143 @@ export function appendStaticTranscriptItems({
       appendItem({ id: entry.id, kind: 'entry', entry });
     }
   }
-  // Same reference when nothing was appended so the `setItems` functional
-  // update doesn't schedule a re-render on every stream-sync tick.
-  return nextItems ?? currentItems;
+
+  const items = nextItems ?? currentItems;
+  const totals = staticTranscriptItemsTotals(items, width, executionLabels);
+  const trimmed = trimStaticTranscriptItems(items, {
+    budgets: ringBudgets,
+    executionLabels,
+    totals,
+    width,
+  });
+  return {
+    items: trimmed.items,
+    rowCount: trimmed.totals.rows,
+    byteCount: trimmed.totals.bytes,
+    trimmed: trimmed.trimmed,
+  };
+}
+
+export function appendStaticTranscriptItems(
+  options: AppendStaticTranscriptItemsOptions,
+): readonly StaticTranscriptItem[] {
+  return buildStaticTranscriptItems(options).items;
+}
+
+function StaticTranscriptItemContent({
+  colorEnabled,
+  executionLabels,
+  item,
+  previousItem,
+  width,
+}: {
+  readonly colorEnabled?: boolean;
+  readonly executionLabels?: ExecutionLabels;
+  readonly item: StaticTranscriptItem;
+  readonly previousItem?: StaticTranscriptItem;
+  readonly width: number;
+}): React.JSX.Element {
+  switch (item.kind) {
+    case 'header':
+      return (
+        <EntryErrorBoundary label="session header">
+          <SessionHeaderBlock
+            compact={item.compact}
+            identityLine={item.identityLine}
+            meta={item.meta}
+            width={width}
+          />
+        </EntryErrorBoundary>
+      );
+    case 'entry':
+      return (
+        <EntryErrorBoundary label={item.entry.role}>
+          <TranscriptEntry
+            entry={item.entry}
+            previousEntry={entryAbove(previousItem)}
+            subagentExecutionLabels={executionLabels}
+            width={width}
+            colorEnabled={colorEnabled}
+          />
+        </EntryErrorBoundary>
+      );
+  }
+}
+
+function scanStaticTranscriptFromStart(
+  entries: readonly ConversationEntry[] | undefined,
+  status: StreamPhase | undefined,
+): StaticTranscriptScanCursor {
+  return incrementalStaticTranscriptEntries(entries, status, {
+    entriesRef: undefined,
+    scannedIndex: 0,
+    lastScannedEntry: undefined,
+    status: undefined,
+  }).cursor;
+}
+
+function buildStaticTranscriptState({
+  childStreamEntries,
+  executionLabels,
+  maxRows,
+  meta,
+  ownerKey,
+  parentStream,
+  repaintEpoch,
+  scrollbackStreamId,
+  streams,
+  width,
+}: {
+  readonly childStreamEntries: ChildStreamEntries;
+  readonly executionLabels?: ExecutionLabels;
+  readonly maxRows?: number;
+  readonly meta: SessionMeta;
+  readonly ownerKey: string;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly repaintEpoch: number;
+  readonly scrollbackStreamId: StreamTabId | undefined;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+  readonly width?: number;
+}): StaticTranscriptState {
+  const built = buildStaticTranscriptItems({
+    currentItems: [],
+    streams,
+    childStreamEntries,
+    executionLabels,
+    meta,
+    maxRows,
+    parentStream,
+    scrollbackStreamId,
+    width,
+  });
+  const slice = scrollbackStreamId
+    ? streams.get(scrollbackStreamId)
+    : undefined;
+  // While a focused child has no model yet, appendStaticTranscriptItems
+  // intentionally holds both the header and entries. Keep the scan cursor at
+  // zero in that state so the entries are still pending when the model
+  // arrives; scanning them now would mark them consumed and drop them later.
+  const waitingForChildIdentity = shouldWaitForChildIdentity({
+    currentItems: [],
+    parentStream,
+    scrollbackStreamId,
+    streams,
+  });
+  const scan = waitingForChildIdentity
+    ? incrementalStaticTranscriptEntries(
+        slice?.entries,
+        slice?.status,
+        undefined,
+      ).cursor
+    : scanStaticTranscriptFromStart(slice?.entries, slice?.status);
+  return {
+    ownerKey,
+    items: built.items,
+    rowCount: built.rowCount,
+    byteCount: built.byteCount,
+    scan,
+    repaintEpoch,
+  };
 }
 
 export function StaticConversationTranscript({
@@ -365,20 +786,13 @@ export function StaticConversationTranscript({
   readonly width?: number;
 }): React.JSX.Element {
   const normalizedWidth = transcriptColumns(width);
-  const previousRenderKey = useRef<string | undefined>(undefined);
-  useLayoutEffect(() => {
-    const previous = previousRenderKey.current;
-    previousRenderKey.current = renderKey;
-    if (previous !== undefined && previous !== renderKey) {
-      onRenderKeyChange?.();
-    }
-  }, [onRenderKeyChange, renderKey]);
   const streams = useSignal(streamsSignal);
   const sessionMeta = useSignal(sessionMetaSignal);
   const parentStream = useSignal(parentStreamSignal);
   const childStreamEntries = useSignal(childStreamEntriesSignal);
+
   const buildFreshItems = (): readonly StaticTranscriptItem[] =>
-    appendStaticTranscriptItems({
+    buildStaticTranscriptItems({
       currentItems: [],
       streams,
       childStreamEntries,
@@ -388,11 +802,22 @@ export function StaticConversationTranscript({
       parentStream,
       scrollbackStreamId,
       width: normalizedWidth,
-    });
-  const [state, setState] = useState<StaticTranscriptState>(() => ({
-    ownerKey,
-    items: buildFreshItems(),
-  }));
+    }).items;
+
+  const [state, setState] = useState<StaticTranscriptState>(() =>
+    buildStaticTranscriptState({
+      childStreamEntries,
+      executionLabels: subagentExecutionLabels,
+      maxRows,
+      meta: sessionMeta,
+      ownerKey,
+      parentStream,
+      repaintEpoch: 0,
+      scrollbackStreamId,
+      streams,
+      width: normalizedWidth,
+    }),
+  );
 
   const items = state.ownerKey === ownerKey ? state.items : buildFreshItems();
 
@@ -403,23 +828,137 @@ export function StaticConversationTranscript({
     // starts from scratch because root and child histories must not share
     // append-only Static state.
     const isHardReset = streams.size === 0 && scrollbackStreamId === undefined;
+    const slice = scrollbackStreamId
+      ? streams.get(scrollbackStreamId)
+      : undefined;
+    const entries = slice?.entries ?? EMPTY_TRANSCRIPT_ENTRIES;
+    const status = slice?.status;
+
     setState((current) => {
       const ownerChanged = current.ownerKey !== ownerKey;
-      const nextItems = appendStaticTranscriptItems({
-        currentItems: isHardReset || ownerChanged ? [] : current.items,
-        streams,
-        childStreamEntries,
-        executionLabels: subagentExecutionLabels,
-        meta: sessionMeta,
-        maxRows,
-        parentStream,
-        scrollbackStreamId,
-        width: normalizedWidth,
-      });
-      if (current.ownerKey === ownerKey && current.items === nextItems) {
+      if (isHardReset || ownerChanged) {
+        return buildStaticTranscriptState({
+          childStreamEntries,
+          executionLabels: subagentExecutionLabels,
+          maxRows,
+          meta: sessionMeta,
+          ownerKey,
+          parentStream,
+          repaintEpoch: current.repaintEpoch + 1,
+          scrollbackStreamId,
+          streams,
+          width: normalizedWidth,
+        });
+      }
+
+      if (
+        shouldWaitForChildIdentity({
+          currentItems: current.items,
+          parentStream,
+          scrollbackStreamId,
+          streams,
+        })
+      ) {
         return current;
       }
-      return { ownerKey, items: nextItems };
+
+      const plan = incrementalStaticTranscriptEntries(
+        entries,
+        status,
+        current.scan,
+      );
+      if (plan.rebuild) {
+        return buildStaticTranscriptState({
+          childStreamEntries,
+          executionLabels: subagentExecutionLabels,
+          maxRows,
+          meta: sessionMeta,
+          ownerKey,
+          parentStream,
+          repaintEpoch: current.repaintEpoch + 1,
+          scrollbackStreamId,
+          streams,
+          width: normalizedWidth,
+        });
+      }
+
+      let nextItems = current.items;
+      let nextRowCount = current.rowCount;
+      let nextByteCount = current.byteCount;
+      let nextRepaintEpoch = current.repaintEpoch;
+      let changed = false;
+
+      const header = ensureStaticSessionHeader({
+        byteCount: nextByteCount,
+        childStreamEntries,
+        executionLabels: subagentExecutionLabels,
+        items: nextItems,
+        maxRows,
+        meta: sessionMeta,
+        parentStream,
+        rowCount: nextRowCount,
+        scrollbackStreamId,
+        streams,
+        width: normalizedWidth,
+      });
+      if (header.inserted) {
+        nextItems = header.items;
+        nextRowCount = header.rowCount;
+        nextByteCount = header.byteCount;
+        nextRepaintEpoch += 1;
+        changed = true;
+      }
+
+      let previousItem = nextItems.at(-1);
+      for (const entry of plan.appended) {
+        const item: StaticTranscriptItem = {
+          id: entry.id,
+          kind: 'entry',
+          entry,
+        };
+        const metrics = staticTranscriptItemMetrics(
+          item,
+          normalizedWidth,
+          subagentExecutionLabels,
+          previousItem,
+        );
+        nextRowCount += metrics.rows;
+        nextByteCount += metrics.bytes;
+        nextItems = [...nextItems, item];
+        previousItem = item;
+        changed = true;
+      }
+
+      const trimmed = trimStaticTranscriptItems(nextItems, {
+        budgets: DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS,
+        executionLabels: subagentExecutionLabels,
+        totals: { rows: nextRowCount, bytes: nextByteCount },
+        width: normalizedWidth,
+      });
+      if (trimmed.trimmed) {
+        nextItems = trimmed.items;
+        nextRowCount = trimmed.totals.rows;
+        nextByteCount = trimmed.totals.bytes;
+        nextRepaintEpoch += 1;
+        changed = true;
+      }
+
+      const cursor = plan.cursor;
+      const cursorChanged =
+        cursor.entriesRef !== current.scan.entriesRef ||
+        cursor.scannedIndex !== current.scan.scannedIndex ||
+        cursor.lastScannedEntry !== current.scan.lastScannedEntry ||
+        cursor.status !== current.scan.status;
+      if (!changed && !cursorChanged) return current;
+
+      return {
+        ownerKey,
+        items: nextItems,
+        rowCount: nextRowCount,
+        byteCount: nextByteCount,
+        scan: cursor,
+        repaintEpoch: nextRepaintEpoch,
+      };
     });
   }, [
     childStreamEntries,
@@ -433,6 +972,16 @@ export function StaticConversationTranscript({
     normalizedWidth,
   ]);
 
+  const repaintKey = `${renderKey}:${state.repaintEpoch}`;
+  const previousRenderKey = useRef<string | undefined>(undefined);
+  useLayoutEffect(() => {
+    const previous = previousRenderKey.current;
+    previousRenderKey.current = repaintKey;
+    if (previous !== undefined && previous !== repaintKey) {
+      onRenderKeyChange?.();
+    }
+  }, [onRenderKeyChange, repaintKey]);
+
   // Keep our scrollback state readonly and adapt once at the Ink boundary.
   // `<Static>` declares `items: T[]`; memoizing the defensive copy avoids the
   // old O(history) spread on unrelated renders without exposing state to a
@@ -441,7 +990,7 @@ export function StaticConversationTranscript({
 
   return (
     <Static
-      key={`transcript:${renderKey}:${normalizedWidth}`}
+      key={`transcript:${renderKey}:${normalizedWidth}:${state.repaintEpoch}`}
       items={staticItems}
     >
       {(item: StaticTranscriptItem, index: number) => (

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -224,3 +224,128 @@ export function splitTranscriptEntries(
   }
   return { finalized, pending };
 }
+
+export const EMPTY_TRANSCRIPT_ENTRIES: readonly ConversationEntry[] = [];
+
+/** Cursor over the settled prefix of a stream's projected entries. The static
+ *  transcript appends only entries after this cursor on ordinary syncs; a
+ *  cursor mismatch (fold rebuild, owner switch, hard reset) forces a full
+ *  rebuild through {@link orderedStaticTranscriptEntries}. */
+export interface StaticTranscriptScanCursor {
+  /** The `slice.entries` array the cursor was advanced against. */
+  readonly entriesRef: readonly ConversationEntry[] | undefined;
+  /** Number of leading entries already consumed by a previous scan. */
+  readonly scannedIndex: number;
+  /** Reference to `entriesRef[scannedIndex - 1]`, used to detect append-only
+   *  extensions without rescanning the whole history. */
+  readonly lastScannedEntry: ConversationEntry | undefined;
+  /** Stream phase at scan time; a phase change forces a rescan of the tail. */
+  readonly status: StreamPhase | undefined;
+}
+
+export interface StaticTranscriptScanResult {
+  readonly appended: readonly ConversationEntry[];
+  readonly cursor: StaticTranscriptScanCursor;
+  /** True when the caller must rebuild from scratch instead of using the
+   *  returned suffix (owner switch, hard reset, or non-append-only change). */
+  readonly rebuild: boolean;
+}
+
+function makeStaticTranscriptScanCursor(
+  entriesRef: readonly ConversationEntry[] | undefined,
+  scannedIndex: number,
+  status: StreamPhase | undefined,
+): StaticTranscriptScanCursor {
+  return {
+    entriesRef,
+    scannedIndex,
+    lastScannedEntry:
+      entriesRef !== undefined && scannedIndex > 0
+        ? entriesRef[scannedIndex - 1]
+        : undefined,
+    status,
+  };
+}
+
+/**
+ * The settled-prefix scan used by the live static transcript. Unlike
+ * {@link orderedStaticTranscriptEntries} (the full rebuild path), this walks
+ * only the suffix after `previous.scannedIndex`, so ordinary stream-sync ticks
+ * cost O(delta) instead of O(history).
+ *
+ * The suffix is exact: `hasLaterRenderable` is computed backward over just
+ * the suffix, which is all that is needed to resolve the live-user-prompt
+ * deferral rule (`userPromptAwaitsLiveContinuation`).
+ */
+export function incrementalStaticTranscriptEntries(
+  entries: readonly ConversationEntry[] | undefined,
+  status: StreamPhase | undefined,
+  previous: StaticTranscriptScanCursor | undefined,
+): StaticTranscriptScanResult {
+  const source = entries ?? EMPTY_TRANSCRIPT_ENTRIES;
+  if (previous === undefined) {
+    return {
+      appended: [],
+      cursor: makeStaticTranscriptScanCursor(source, 0, status),
+      rebuild: true,
+    };
+  }
+
+  const sameEntries = previous.entriesRef === source;
+  if (sameEntries && previous.status === status) {
+    return { appended: [], cursor: previous, rebuild: false };
+  }
+
+  const canContinue =
+    sameEntries ||
+    (source.length >= previous.scannedIndex &&
+      (previous.scannedIndex === 0 ||
+        (previous.entriesRef !== undefined &&
+          source[previous.scannedIndex - 1] === previous.lastScannedEntry)));
+  if (!canContinue) {
+    return {
+      appended: [],
+      cursor: makeStaticTranscriptScanCursor(source, 0, status),
+      rebuild: true,
+    };
+  }
+
+  const start = previous.scannedIndex;
+  const suffix = source.slice(start);
+  const hasLaterRenderable = new Array<boolean>(suffix.length);
+  let laterRenderable = false;
+  for (let index = suffix.length - 1; index >= 0; index -= 1) {
+    hasLaterRenderable[index] = laterRenderable;
+    const entry = suffix[index];
+    if (entry !== undefined && isRenderableTranscriptEntry(entry)) {
+      laterRenderable = true;
+    }
+  }
+
+  const appended: ConversationEntry[] = [];
+  let scannedIndex = start;
+  for (let index = 0; index < suffix.length; index += 1) {
+    const entry = suffix[index];
+    if (entry === undefined) break;
+    if (entry.role === 'activity' && !entry.finalized) break;
+    if (!entry.finalized) break;
+    if (!isRenderableTranscriptEntry(entry)) {
+      scannedIndex = start + index + 1;
+      continue;
+    }
+    const defersLiveUserPrompt =
+      isActivePhase(status) &&
+      entry.role === 'user' &&
+      !isInquiryContinuationText(entry.text) &&
+      !hasLaterRenderable[index];
+    if (defersLiveUserPrompt) break;
+    appended.push(entry);
+    scannedIndex = start + index + 1;
+  }
+
+  return {
+    appended,
+    cursor: makeStaticTranscriptScanCursor(source, scannedIndex, status),
+    rebuild: false,
+  };
+}

--- a/packages/cli/src/chat/tui/render/tuiViewportController.ts
+++ b/packages/cli/src/chat/tui/render/tuiViewportController.ts
@@ -1,3 +1,5 @@
+import { invalidateStaticTranscriptForRepaint } from '../state/staticTranscriptRepaint';
+
 export interface TuiRepaintOptions {
   readonly clearScrollback?: boolean;
   readonly preserveStatic?: boolean;
@@ -7,13 +9,14 @@ export interface TuiRepaintTarget {
   repaint(options: TuiRepaintOptions): void;
 }
 
+/** Every static-transcript invalidation uses replace semantics: clear the
+ *  terminal (viewport + scrollback) and set Ink's `fullStaticOutput` to the
+ *  freshly rendered bounded tail. Callers must have remounted `<Static>` via
+ *  a render-key change first; otherwise `staticOutput` is empty and the tail
+ *  would be dropped. */
 const TRANSCRIPT_VIEWPORT_REPAINT_OPTIONS = {
   clearScrollback: true,
   preserveStatic: false,
-} satisfies TuiRepaintOptions;
-
-const TERMINAL_RESUME_REPAINT_OPTIONS = {
-  clearScrollback: true,
 } satisfies TuiRepaintOptions;
 
 export interface TuiViewportController {
@@ -29,7 +32,14 @@ export function createTuiViewportController(inkRef: {
       inkRef.current?.repaint(TRANSCRIPT_VIEWPORT_REPAINT_OPTIONS);
     },
     repaintAfterTerminalResume(): void {
-      inkRef.current?.repaint(TERMINAL_RESUME_REPAINT_OPTIONS);
+      // Terminal resume cannot safely call repaint(TRANSCRIPT_VIEWPORT_REPAINT_OPTIONS)
+      // directly: the static-transcript epoch signal notifies through a
+      // microtask, so the remounted `<Static>` is not committed yet and
+      // preserveStatic:false would drop the retained tail. Bumping the epoch
+      // makes StaticConversationTranscript remount `<Static>` and its
+      // onRenderKeyChange handler apply the same replace-semantics repaint
+      // after commit. There is no append-style resume repaint anymore.
+      invalidateStaticTranscriptForRepaint();
     },
   };
 }

--- a/packages/cli/src/chat/tui/state/staticTranscriptRepaint.ts
+++ b/packages/cli/src/chat/tui/state/staticTranscriptRepaint.ts
@@ -1,0 +1,14 @@
+// One monotonically increasing epoch shared by the session-exit controller and
+// the conversation region. A terminal resume (SIGCONT) bumps it so the static
+// transcript's render key changes, remounting `<Static>` and routing through
+// `onRenderKeyChange`'s replace-semantics repaint (clear scrollback +
+// preserveStatic:false) instead of replaying Ink's accumulated
+// `fullStaticOutput`.
+
+import { signal } from '@lit-labs/signals';
+
+export const staticTranscriptRepaintEpoch = signal(0);
+
+export function invalidateStaticTranscriptForRepaint(): void {
+  staticTranscriptRepaintEpoch.set(staticTranscriptRepaintEpoch.get() + 1);
+}

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -14,6 +14,7 @@ import {
 } from '@cli/chat/tui/panes/transcriptEntryLayout';
 import { formatRenderError } from '@cli/chat/tui/panes/EntryErrorBoundary';
 import {
+  incrementalStaticTranscriptEntries,
   isInquiryContinuationText,
   splitTranscriptEntries,
   terminalVisibleTranscriptText,
@@ -21,10 +22,15 @@ import {
 } from '@cli/chat/tui/panes/transcriptEntries';
 import {
   appendStaticTranscriptItems,
+  buildStaticTranscriptItems,
+  DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS,
   sessionHeaderIdentityLine,
+  trimStaticTranscriptItems,
   type StaticTranscriptItem,
+  type StaticTranscriptRingBudgets,
 } from '@cli/chat/tui/panes/StaticConversationTranscript';
 import { staticScrollbackTarget } from '@cli/chat/tui/appLayout';
+import { staticTranscriptRepaintEpoch } from '@cli/chat/tui/state/staticTranscriptRepaint';
 import { transcriptViewportKey } from '@cli/chat/tui/state/transcriptViewportMode';
 import {
   createTuiViewportController,
@@ -927,6 +933,166 @@ describe('CLI conversation transcript', () => {
     ).toEqual(['session-header', 'u1', 'a1', 'u2']);
   });
 
+  it('bounds the static transcript ring by rows without trimming the header', () => {
+    const entries = Array.from({ length: 20 }, (_, index) =>
+      entry(`e${index}`, 'assistant', 'x', true),
+    );
+    const budgets: StaticTranscriptRingBudgets = {
+      rowHighWater: 12,
+      rowLowWater: 8,
+      byteHighWater: 1024 * 1024,
+      byteLowWater: 1024 * 1024,
+    };
+    const built = buildStaticTranscriptItems({
+      currentItems: [],
+      streams: new Map([[STREAM_ID, sliceWithEntries(STREAM_ID, entries)]]),
+      meta: SESSION_META,
+      scrollbackStreamId: STREAM_ID,
+      width: 80,
+      ringBudgets: budgets,
+    });
+
+    expect(built.items.map((item) => item.id)).toEqual([
+      'session-header',
+      'e16',
+      'e17',
+      'e18',
+      'e19',
+    ]);
+    expect(built.rowCount).toBeLessThanOrEqual(budgets.rowLowWater);
+  });
+
+  it('bounds the static transcript ring by bytes and drops oldest non-header items', () => {
+    const entries = Array.from({ length: 3 }, (_, index) =>
+      entry(`e${index}`, 'assistant', 'x'.repeat(80), true),
+    );
+    const budgets: StaticTranscriptRingBudgets = {
+      rowHighWater: 10_000,
+      rowLowWater: 10_000,
+      byteHighWater: 160,
+      byteLowWater: 64,
+    };
+    const built = buildStaticTranscriptItems({
+      currentItems: [],
+      streams: new Map([[STREAM_ID, sliceWithEntries(STREAM_ID, entries)]]),
+      meta: SESSION_META,
+      scrollbackStreamId: STREAM_ID,
+      width: 80,
+      ringBudgets: budgets,
+    });
+
+    expect(built.items.map((item) => item.id)).toEqual([
+      'session-header',
+      'e2',
+    ]);
+  });
+
+  it('keeps a single oversized finalized entry even when it exceeds the budget', () => {
+    const oversized = entry('e0', 'assistant', 'x'.repeat(80), true);
+    const budgets: StaticTranscriptRingBudgets = {
+      rowHighWater: 2,
+      rowLowWater: 1,
+      byteHighWater: 10,
+      byteLowWater: 5,
+    };
+    const built = buildStaticTranscriptItems({
+      currentItems: [],
+      streams: new Map([[STREAM_ID, sliceWithEntries(STREAM_ID, [oversized])]]),
+      meta: SESSION_META,
+      scrollbackStreamId: STREAM_ID,
+      width: 80,
+      ringBudgets: budgets,
+    });
+
+    expect(built.items.map((item) => item.id)).toEqual([
+      'session-header',
+      'e0',
+    ]);
+  });
+
+  it('trims a static tail with margin-collapse-aware row accounting', () => {
+    const header: StaticTranscriptItem = {
+      id: 'session-header',
+      kind: 'header',
+      compact: false,
+      identityLine: 'agent: research · model: test',
+      meta: SESSION_META,
+    };
+    const user1: StaticTranscriptItem = {
+      id: 'u1',
+      kind: 'entry',
+      entry: entry('u1', 'user', 'first', true),
+    };
+    const user2: StaticTranscriptItem = {
+      id: 'u2',
+      kind: 'entry',
+      entry: entry('u2', 'user', 'second', true),
+    };
+    const beforeRows =
+      4 +
+      transcriptEntryLayoutRows(
+        transcriptEntryLayout(user1.entry, { width: 80 }),
+      ) +
+      transcriptEntryLayoutRows(
+        transcriptEntryLayout(user2.entry, {
+          previousEntry: user1.entry,
+          width: 80,
+        }),
+      );
+    const trimmed = trimStaticTranscriptItems([header, user1, user2], {
+      budgets: {
+        rowHighWater: beforeRows - 1,
+        rowLowWater: beforeRows - 1,
+        byteHighWater: Number.MAX_SAFE_INTEGER,
+        byteLowWater: Number.MAX_SAFE_INTEGER,
+      },
+      totals: { rows: beforeRows, bytes: 0 },
+      width: 80,
+    });
+
+    expect(trimmed.items.map((item) => item.id)).toEqual([
+      'session-header',
+      'u2',
+    ]);
+    expect(trimmed.totals.rows).toBeLessThanOrEqual(beforeRows);
+  });
+
+  it('appends settled entries incrementally and resumes a deferred live prompt', () => {
+    const user = entry('u1', 'user', 'what is this repo about', true);
+    const assistantPending = entry('a1', 'assistant', 'working', false);
+    const assistantSettled = { ...assistantPending, finalized: true };
+    const emptyCursor = {
+      entriesRef: undefined,
+      scannedIndex: 0,
+      lastScannedEntry: undefined,
+      status: undefined,
+    } as const;
+
+    const first = incrementalStaticTranscriptEntries(
+      [user],
+      STREAM_PHASE.RUNNING,
+      emptyCursor,
+    );
+    expect(first.appended).toEqual([]);
+    expect(first.cursor.scannedIndex).toBe(0);
+
+    const second = incrementalStaticTranscriptEntries(
+      [user, assistantPending],
+      STREAM_PHASE.RUNNING,
+      first.cursor,
+    );
+    expect(second.appended.map((item) => item.id)).toEqual(['u1']);
+    expect(second.cursor.scannedIndex).toBe(1);
+
+    const third = incrementalStaticTranscriptEntries(
+      [user, assistantSettled],
+      STREAM_PHASE.RUNNING,
+      second.cursor,
+    );
+    expect(third.appended.map((item) => item.id)).toEqual(['a1']);
+    expect(third.cursor.scannedIndex).toBe(2);
+  });
+
   it('labels preset-launched sessions with team and root identity', () => {
     expect(
       sessionHeaderIdentityLine({
@@ -1165,13 +1331,12 @@ describe('CLI conversation transcript', () => {
       },
     });
 
+    staticTranscriptRepaintEpoch.set(0);
     controller.repaintTranscript();
     controller.repaintAfterTerminalResume();
 
-    expect(calls).toEqual([
-      { clearScrollback: true, preserveStatic: false },
-      { clearScrollback: true },
-    ]);
+    expect(calls).toEqual([{ clearScrollback: true, preserveStatic: false }]);
+    expect(staticTranscriptRepaintEpoch.get()).toBe(1);
   });
 
   it('detects generated inquiry continuation rows only', () => {


### PR DESCRIPTION
Closes #9958

Bounded static scrollback tail + regenerate-ANSI repaint for CLI TUI memory.

- Ring buffer in StaticTranscriptState with row/byte hysteresis (2000/1500 rows, 1 MiB/768 KiB); header never trimmed.
- Incremental settled append via a scan cursor over `slice.entries`; full rebuild only on owner switch, hard reset, or fold rebuild.
- Terminal resume repaint now remounts `<Static>` via a repaint epoch and regenerates the bounded tail with `preserveStatic:false` instead of replaying Ink's accumulated `fullStaticOutput`.
- Added validate-tui byte-equivalence scenarios for resize reflow and terminal resume.
- Tests: ring invariants, incremental append, repaint semantics.