### PR TITLE
fix(agent,extension,test-kernel): close delivery and hoisting follow-ups (#10534, #10535, #10536, #10530)

### DIFF
--- a/packages/extension/src/frontend/events/agentEventListeners.ts
+++ b/packages/extension/src/frontend/events/agentEventListeners.ts
@@ -193,7 +193,16 @@ async function handleRequestEnsureProgressView(
       'Show Progress View',
     );
     if (selection) {
-      await vscode.commands.executeCommand('texra.showProgressView');
+      try {
+        await vscode.commands.executeCommand('texra.showProgressView');
+      } catch (err) {
+        // The toast handoff already established delivery; a failed retry is
+        // a diagnostic, not non-delivery, so it must not downgrade the event.
+        logger.warn(
+          CHANNEL,
+          `Failed to retry the progress-view reveal: ${toErrorMessage(err)}`,
+        );
+      }
     }
     return true;
   }

--- a/packages/extension/src/frontend/latex/openBuild.ts
+++ b/packages/extension/src/frontend/latex/openBuild.ts
@@ -91,9 +91,16 @@ export async function invokeLatexWorkshopBuild(
  * Open a file, compile if it is TeX, and display the resulting PDF.
  * The PDF viewer is refreshed if already loaded.
  *
- * Resolves `true` when a surface was actually opened, and `false` when the
- * path is missing or the internal LaTeX compilation failed, so presentation
- * callers can report non-delivery truthfully.
+ * Resolves `true` when a surface was actually presented, and `false` when
+ * the path is missing, the internal LaTeX compilation failed, or the PDF
+ * viewer command rejected, so presentation callers can report non-delivery
+ * truthfully.
+ *
+ * Workspace TeX files are built through LaTeX Workshop rather than the
+ * internal compiler. A `latex-workshop.build` failure is warn-logged but does
+ * not by itself make this resolve `false`: LaTeX Workshop surfaces its own
+ * build-failure UI in the editor, so the returned boolean reports the
+ * viewer-open outcome that follows the build attempt.
  */
 export async function openBuildDisplayIfTex(
   fileLocation: FileLocation,
@@ -128,6 +135,8 @@ export async function openBuildDisplayIfTex(
  * Files outside the workspace (e.g. in run-storage) are compiled with the
  * internal `compileLatex2Pdf` helper which sets TEXINPUTS to include the
  * workspace root, ensuring project-local .sty / .cls / .bib files are found.
+ *
+ * Returns the viewer-open outcome after the build path completes.
  */
 async function openAndBuildLatex(
   uri: vscode.Uri,
@@ -161,24 +170,37 @@ async function openAndBuildLatex(
     }
   }
 
-  scheduleViewerDisplay();
-  return true;
+  return scheduleViewerDisplay();
 }
 
 /**
- * Schedule PDF viewer display and refresh after build.
+ * Open the PDF viewer after the build, then refresh it once it is visible.
+ *
+ * Resolves `true` when `latex-workshop.view` accepts the open request, and
+ * `false` when it rejects, so the caller can report viewer non-delivery.
  */
-function scheduleViewerDisplay(): void {
-  setTimeout(() => {
-    vscode.commands.executeCommand('latex-workshop.view').then(
-      () => {
-        setTimeout(() => {
-          vscode.commands.executeCommand('latex-workshop.refresh-viewer');
-        }, LATEX_VIEWER_REFRESH_DELAY_MS);
-      },
-      (err) => {
-        logger.warn(CHANNEL, `Viewer display failed: ${toErrorMessage(err)}`);
-      },
-    );
-  }, LATEX_VIEWER_OPEN_DELAY_MS);
+function scheduleViewerDisplay(): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    setTimeout(() => {
+      void vscode.commands.executeCommand('latex-workshop.view').then(
+        () => {
+          setTimeout(() => {
+            void vscode.commands
+              .executeCommand('latex-workshop.refresh-viewer')
+              .then(undefined, (err: unknown) => {
+                logger.warn(
+                  CHANNEL,
+                  `Viewer refresh failed: ${toErrorMessage(err)}`,
+                );
+              });
+          }, LATEX_VIEWER_REFRESH_DELAY_MS);
+          resolve(true);
+        },
+        (err: unknown) => {
+          logger.warn(CHANNEL, `Viewer display failed: ${toErrorMessage(err)}`);
+          resolve(false);
+        },
+      );
+    }, LATEX_VIEWER_OPEN_DELAY_MS);
+  });
 }

--- a/src/test-kernel/architecture/supportMockHoisting.vitest.ts
+++ b/src/test-kernel/architecture/supportMockHoisting.vitest.ts
@@ -12,7 +12,8 @@ import {
  * shared `@test/support/*Mock` modules rely on this so their `vi.mock`
  * factories can close over a bag that is initialized before the mock is
  * registered. If a future Vitest version stops hoisting imported modules,
- * this test fails with `['before', 'hoisted-factory', 'after']` instead of
+ * in-place evaluation resets the pre-hoisted `'before'` marker inside the
+ * factory, so this test fails with `['hoisted-factory', 'after']` instead of
  * hoisting the factory ahead of the module body.
  */
 describe('shared test-kernel mock hoisting', () => {

--- a/src/test-kernel/architecture/supportMockHoistingFixture.ts
+++ b/src/test-kernel/architecture/supportMockHoistingFixture.ts
@@ -1,12 +1,33 @@
 // Third-party imports
 import { vi } from 'vitest';
 
+type SupportMockHoistingProbeHolder = {
+  __texraSupportMockHoistingProbe?: string[];
+};
+
+function getSupportMockHoistingProbe(): string[] {
+  const holder = globalThis as SupportMockHoistingProbeHolder;
+  holder.__texraSupportMockHoistingProbe ??= [];
+  return holder.__texraSupportMockHoistingProbe;
+}
+
+// The pre-hoisted push must sit ahead of the `vi.hoisted` call in source
+// order. True hoisting runs the factory first, so the shared mutable array
+// records `['hoisted-factory', 'before', 'after']`; in-place execution of
+// `vi.hoisted` resets that pre-hoisted marker inside the factory and yields a
+// different order, which is the regression signal
+// `supportMockHoisting.vitest.ts` depends on.
+getSupportMockHoistingProbe().push('before');
+
 const supportMockHoistingBag = vi.hoisted(() => {
-  const order: string[] = ['hoisted-factory'];
+  const order = getSupportMockHoistingProbe();
+  // Reset the shared holder at the start of every evaluation so watch-mode
+  // re-runs and `vi.resetModules()` consumers still get a fresh array.
+  order.length = 0;
+  order.push('hoisted-factory');
   return { order, value: 1 };
 });
 
-supportMockHoistingBag.order.push('before');
 supportMockHoistingBag.order.push('after');
 
 export function supportMockHoistingValue(): number {

--- a/src/test-kernel/frontend/OpenBuildDisplay.vitest.ts
+++ b/src/test-kernel/frontend/OpenBuildDisplay.vitest.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
+import { LATEX_VIEWER_OPEN_DELAY_MS } from '@shared/constants/latexTiming';
+
+const mocks = vi.hoisted(() => ({
+  exists: vi.fn(async (_path: string) => true),
+  isLatexFile: vi.fn((_path: string) => true),
+  compileLatex2Pdf: vi.fn(async () => ({ ok: true as const, logTail: '' })),
+  pathToLocation: vi.fn((absolutePath: string) => ({
+    kind: 'workspace' as const,
+    absolutePath,
+    relativePath: 'paper.tex',
+  })),
+  executeCommand: vi.fn(
+    async (_command: string, ..._args: unknown[]) => undefined,
+  ),
+  openTextDocument: vi.fn(async (uri: unknown) => ({ uri })),
+  showTextDocument: vi.fn(async () => undefined),
+  showErrorMessage: vi.fn(async () => undefined),
+  warn: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  showLoggedMessage: vi.fn(async (_channel: string, _message: string) => ''),
+}));
+
+vi.mock('@utils/files/absoluteFS', () => ({
+  AbsoluteFS: { exists: mocks.exists },
+}));
+
+vi.mock('@common/files/fileTypeUtils', () => ({
+  isLatexFile: mocks.isLatexFile,
+}));
+
+vi.mock('@utils/files/fileLocation', () => ({
+  pathToLocation: mocks.pathToLocation,
+}));
+
+vi.mock('@latex/texTools', () => ({
+  compileLatex2Pdf: mocks.compileLatex2Pdf,
+}));
+
+vi.mock('@frontend/ui/errorHandlingUtils', () => ({
+  showLoggedMessage: mocks.showLoggedMessage,
+}));
+
+vi.mock('@logger/logUtils', () => ({
+  warn: mocks.warn,
+  error: mocks.error,
+  info: mocks.info,
+}));
+
+vi.mock('vscode', () => ({
+  Uri: {
+    file: (filePath: string) => ({
+      fsPath: filePath,
+      path: filePath,
+      toString: () => filePath,
+    }),
+  },
+  commands: { executeCommand: mocks.executeCommand },
+  window: {
+    showTextDocument: mocks.showTextDocument,
+    showErrorMessage: mocks.showErrorMessage,
+  },
+  workspace: {
+    openTextDocument: mocks.openTextDocument,
+    getConfiguration: (_section?: string) => ({
+      get: <T>(_key: string, defaultValue?: T) => defaultValue,
+    }),
+    workspaceFolders: [{ uri: { fsPath: '/workspace' } }],
+  },
+}));
+
+const workspaceTex = {
+  kind: 'workspace' as const,
+  absolutePath: '/workspace/paper.tex',
+  relativePath: 'paper.tex',
+};
+
+describe('openBuildDisplayIfTex viewer delivery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.exists.mockResolvedValue(true);
+    mocks.isLatexFile.mockReturnValue(true);
+    mocks.executeCommand.mockImplementation(async () => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports non-delivery when the PDF viewer open rejects', async () => {
+    mocks.executeCommand.mockImplementation(async (command: string) => {
+      if (command === 'latex-workshop.view') {
+        throw new Error('viewer unavailable');
+      }
+      return undefined;
+    });
+
+    const delivery = openBuildDisplayIfTex(workspaceTex);
+    await vi.advanceTimersByTimeAsync(LATEX_VIEWER_OPEN_DELAY_MS);
+
+    await expect(delivery).resolves.toBe(false);
+    expect(mocks.warn).toHaveBeenCalledWith(
+      'OpenBuildUtils',
+      expect.stringContaining('Viewer display failed'),
+    );
+  });
+
+  it('reports delivery only once the viewer-open command has settled', async () => {
+    let settled = false;
+    const delivery = openBuildDisplayIfTex(workspaceTex).then((delivered) => {
+      settled = true;
+      return delivered;
+    });
+
+    await vi.advanceTimersByTimeAsync(LATEX_VIEWER_OPEN_DELAY_MS - 1);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(delivery).resolves.toBe(true);
+    expect(mocks.executeCommand).toHaveBeenCalledWith('latex-workshop.view');
+  });
+
+  it('keeps workspace LaTeX Workshop build failures out of the delivery boolean', async () => {
+    mocks.executeCommand.mockImplementation(async (command: string) => {
+      if (command === 'latex-workshop.build') {
+        throw new Error('build failed');
+      }
+      return undefined;
+    });
+
+    const delivery = openBuildDisplayIfTex(workspaceTex);
+    await vi.advanceTimersByTimeAsync(LATEX_VIEWER_OPEN_DELAY_MS);
+
+    await expect(delivery).resolves.toBe(true);
+    expect(mocks.warn).toHaveBeenCalledWith(
+      'OpenBuildUtils',
+      expect.stringContaining('LaTeX Workshop build failed'),
+    );
+  });
+});

--- a/src/test-kernel/progressView/AgentPresentationHostReplayGate.vitest.ts
+++ b/src/test-kernel/progressView/AgentPresentationHostReplayGate.vitest.ts
@@ -313,6 +313,41 @@ describe('extension presentation delivery truthfulness (#10400)', () => {
     }
   });
 
+  it('keeps the fallback notification delivered when the retry reveal throws', async () => {
+    // The toast handoff is already the delivered surface, so a failed retry
+    // is warn-logged without downgrading the event (#10535).
+    const executeCommand = vi
+      .spyOn(vscode.commands, 'executeCommand')
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('no view container'));
+    const showInformationMessage = vi
+      .spyOn(vscode.window, 'showInformationMessage')
+      .mockImplementation(async () => 'Show Progress View' as never);
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      const host = presentationHost({ isViewVisible: () => false });
+      await expect(
+        host.emit('requestEnsureProgressView', {
+          fallbackNotification: {
+            agentName: 'writer',
+            modelName: 'test-model',
+            inputName: 'paper.tex',
+            outputInfo: 'to paper.out.tex',
+          },
+        }),
+      ).resolves.toBe(true);
+      expect(showInformationMessage).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledWith(
+        'agentEventListeners',
+        expect.stringContaining('retry the progress-view reveal'),
+      );
+    } finally {
+      executeCommand.mockRestore();
+      showInformationMessage.mockRestore();
+      warn.mockRestore();
+    }
+  });
+
   it('reports a rendered instruction as delivered once VS Code accepts it', async () => {
     const showInformationMessage = vi
       .spyOn(vscode.window, 'showInformationMessage')


### PR DESCRIPTION
Follow-ups to #10528 and #10521.

- #10534: `openBuildDisplayIfTex` now awaits the `latex-workshop.view` outcome before resolving, and reports non-delivery when the viewer-open command rejects. The post-open `refresh-viewer` rejection is still warn-logged without changing the delivery result.
- #10535: `handleRequestEnsureProgressView` catches a failed retry reveal in place and warns, keeping the fallback-toast handoff delivered.
- #10536: documented the in-workspace LaTeX Workshop build-failure semantics on `openBuildDisplayIfTex`.
- #10530: restored the source-order hoisting probe by keeping a pre-`vi.hoisted` `'before'` push in an evaluation-local `globalThis` holder the hoisted factory resets at the start of each evaluation.

Tests: extended `AgentPresentationHostReplayGate`, added `OpenBuildDisplay` extension suite, updated the hoisting fixture doc.

Closes #10534
Closes #10535
Closes #10536
Closes #10530