### PR TITLE
fix(retry): harden progress-view Kimi Code retry fallbacks

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -39,7 +39,6 @@ import {
   classifyCliRetryAction,
   cliRetryApiSwitchDecision,
   isCliApiSwitchableRetry,
-  isKimiCodeExclusiveRetryModel,
 } from '@cli/runtime/approval/approvalPrompts';
 import {
   denyExternalInquiryIfNoHumanInput,

--- a/packages/cli/src/runtime/approval/approvalPrompts.ts
+++ b/packages/cli/src/runtime/approval/approvalPrompts.ts
@@ -3,8 +3,6 @@ import PQueue from 'p-queue';
 import { defaultSession } from '@agent/runtime';
 import { isRelayMonthlyLimitMessage } from '@common/errors/sdkError/relayDetection';
 import { warn as logWarning } from '@logger/logUtils';
-import { isKimiCodeExclusiveModel } from '@model/kimiCodeSubscriptionRouting';
-import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import {
   isChatGptSubscriptionLimitError,
   isCredentialExhausted,
@@ -18,6 +16,7 @@ import {
   CODING_PLAN_SUBSCRIPTIONS,
   type CodingPlanSubscriptionId,
 } from '@shared/codingPlanSubscriptions';
+import { isKimiCodeExclusiveRetryModel } from '@shared/model/kimiCodeRetryGate';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { type CliContext, type CliPromptRequest } from '../cliContext';
@@ -109,20 +108,6 @@ export type CliRetryAction =
   | `disable-coding-plan:${CodingPlanSubscriptionId}`
   | 'switch-to-personal'
   | 'none';
-
-/**
- * Whether the retrying model is served ONLY by the Kimi Code coding endpoint
- * (`kimi-for-coding` aliases pin its `baseUrl` in the registry). Unknown or
- * non-Kimi models are not exclusive, so a missing `model` never blocks the
- * GLM/Kimi dual-backend switch.
- */
-export function isKimiCodeExclusiveRetryModel(
-  model: string | undefined,
-): boolean {
-  if (model === undefined) return false;
-  const config = getRuntimeModelConfig(model);
-  return config !== undefined && isKimiCodeExclusiveModel(config);
-}
 
 export function classifyCliRetryAction(
   payload: RetryPermission,

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -23,6 +23,7 @@ import {
   type ProviderErrorPartial,
 } from '@shared/schemas';
 import { INCLUDED_ACCESS } from '@shared/copy/modelAccess';
+import { isKimiCodeExclusiveRetryModel } from '@shared/model/kimiCodeRetryGate';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { renderDotMeta, type MetaPart } from '@shared/wa/metaStrip';
 import { tailWithEllipsis, toGraphemes } from '@utils/text/stringUtils';
@@ -50,7 +51,7 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
         this.emitAction({ action: 'retry' });
         return true;
       case 'k':
-        if (isCredentialExhausted(data.errorDetails)) {
+        if (this.canUseOwnApiKey()) {
           this.emitAction({ action: 'useOwnApiKey' });
           return true;
         }
@@ -66,7 +67,7 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
   override render(): TemplateResult {
     const data = this.permission.data;
     const isRelay = data.errorDetails?.isRelayError === true;
-    const credentialExhausted = isCredentialExhausted(data.errorDetails);
+    const canUseOwnApiKey = this.canUseOwnApiKey();
     const copilotQuotaExhausted =
       data.errorDetails?.exhaustionReason === 'copilot-subscription';
     const userRetryable = data.errorDetails?.userRetryable !== false;
@@ -114,7 +115,7 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
           }
         </div>
         <div class="retry-request__actions">
-          ${when(credentialExhausted, () =>
+          ${when(canUseOwnApiKey, () =>
             renderLabeledActionButton({
               icon: 'key',
               text: copilotQuotaExhausted
@@ -152,6 +153,14 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
   // ===========================================================================
   // Utilities
   // ===========================================================================
+
+  private canUseOwnApiKey(): boolean {
+    const data = this.permission.data;
+    return (
+      isCredentialExhausted(data.errorDetails) &&
+      !isKimiCodeExclusiveRetryModel(data.model)
+    );
+  }
 
   private formatRetryDetails(
     details: ProviderErrorPartial | undefined,

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -1,8 +1,11 @@
+import PQueue from 'p-queue';
+
 // Local imports
 import type { ApiProvider } from '@model/apiProviders';
 import { codingPlanSubscriptionRuntimes } from '@model/codingPlanSubscriptions';
 import type { CopilotRouteOverride } from '@model/copilotRouting';
 import type { ExhaustionReason, StreamTabId } from '@shared/schemas';
+import { isKimiCodeExclusiveRetryModel } from '@shared/model/kimiCodeRetryGate';
 import { isNonEmptyString } from '@utils/core';
 
 export interface ProgressApiKeyRetryRequest {
@@ -85,6 +88,8 @@ export interface ProgressApiKeyRetryControllerDeps {
  * the credential/retry rules testable without depending on VS Code APIs.
  */
 export class ProgressApiKeyRetryController {
+  private readonly routingCommitQueue = new PQueue({ concurrency: 1 });
+
   constructor(private readonly deps: ProgressApiKeyRetryControllerDeps) {}
 
   private get codingPlanToggles(): readonly CodingPlanToggle[] {
@@ -102,6 +107,11 @@ export class ProgressApiKeyRetryController {
   async useOwnApiKey(
     request: ProgressApiKeyRetryRequest,
   ): Promise<ProgressApiKeyRetryResult> {
+    // Kimi Code-exclusive models are served only by the coding endpoint, so a
+    // personal-key switch cannot reroute them; keep the request untouched
+    // rather than disabling routing around an already-swapped client.
+    if (isKimiCodeExclusiveRetryModel(request.model)) return noRetryResult();
+
     const proceeded = await this.ensureOwnApiKey(request);
     if (
       !proceeded ||
@@ -110,20 +120,22 @@ export class ProgressApiKeyRetryController {
       return noRetryResult();
     }
 
-    const routingBefore = this.routingSnapshot();
-    const prepared = await this.applyOwnApiKeyRouting(request);
-    const retried = await this.deps.triggerRetry(
-      request.stream,
-      request.requestId,
-    );
-    if (!retried) {
-      await this.restoreOwnApiKeyRouting(routingBefore, prepared);
-      return noRetryResult();
-    }
-    return {
-      ...prepared,
-      retried: true,
-    };
+    return this.routingCommitQueue.add(async () => {
+      const routingBefore = this.routingSnapshot();
+      const prepared = await this.applyOwnApiKeyRouting(request);
+      const retried = await this.deps.triggerRetry(
+        request.stream,
+        request.requestId,
+      );
+      if (!retried) {
+        await this.restoreOwnApiKeyRouting(routingBefore, prepared);
+        return noRetryResult();
+      }
+      return {
+        ...prepared,
+        retried: true,
+      };
+    });
   }
 
   async ensureOwnApiKey(
@@ -234,18 +246,20 @@ export class ProgressApiKeyRetryController {
     request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
     start: (copilotRouteOverride: CopilotRouteOverride) => Promise<boolean>,
   ): Promise<boolean> {
-    const before = this.routingSnapshot();
-    const prepared = await this.applyOwnApiKeyRouting(request);
-    // The user chose "use own API key" for this retry. The direct-route
-    // override travels only with the replacement launch; the standing
-    // preference remains visible to concurrent and future runs.
-    let started = false;
-    try {
-      started = await start('direct');
-      return started;
-    } finally {
-      if (!started) await this.restoreOwnApiKeyRouting(before, prepared);
-    }
+    return this.routingCommitQueue.add(async () => {
+      const before = this.routingSnapshot();
+      const prepared = await this.applyOwnApiKeyRouting(request);
+      // The user chose "use own API key" for this retry. The direct-route
+      // override travels only with the replacement launch; the standing
+      // preference remains visible to concurrent and future runs.
+      let started = false;
+      try {
+        started = await start('direct');
+        return started;
+      } finally {
+        if (!started) await this.restoreOwnApiKeyRouting(before, prepared);
+      }
+    });
   }
 
   private routingSnapshot(): ProgressApiRoutingSnapshot {

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -455,6 +455,7 @@ export function createProgressViewSecondTierHandlers(
       const result = await deps.apiKeyRetry.useOwnApiKey({
         stream: data.stream,
         requestId: data.requestId,
+        model: data.model,
         provider: providerArg,
         exhaustionReason: data.exhaustionReason,
         viaRelay: data.viaRelay,

--- a/src/controllers/progressView/backend/progressHostInteractions.ts
+++ b/src/controllers/progressView/backend/progressHostInteractions.ts
@@ -6,6 +6,7 @@ import type {
 } from '@agent/runtime/runtimePresentationEvents';
 import {
   cancellationResultFor,
+  matchesCancelSelector,
   type BashSettlement,
   type HostApprovalBypassStateUpdate,
   type HostBashApprovalRequest,
@@ -24,6 +25,7 @@ import {
 } from '@agent/runtime/HostInteractions';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ToolEditApprovalController } from '@controllers/approval/ToolEditApprovalController';
+import { warn as logWarning } from '@logger/logUtils';
 import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
 import { SESSION_DISPOSED_CAUSE } from '@shared/copy/interactionCancellation';
 import { prepareBashApprovalPrompt } from '@tools/approval/bashApproval';
@@ -123,9 +125,48 @@ export function createProgressHostInteractions(
       HostRetryInteractionOptions['prepareRetry']
     >;
     readonly controller: AbortController;
+    readonly cancellationScope?: object;
     settling: boolean;
+    selection?: 'configured' | 'personal';
+    settlement?: Promise<boolean>;
   }
   const retryPreparations = new Map<StreamTabId, PendingRetryPreparation>();
+
+  const isRetryPending = (
+    streamId: StreamTabId,
+    requestId: string,
+  ): boolean => {
+    return handlers().retry.get(streamId)?.requestId === requestId;
+  };
+
+  const isCurrentRetryPreparation = (
+    streamId: StreamTabId,
+    requestId: string,
+    preparation: PendingRetryPreparation,
+  ): boolean =>
+    retryPreparations.get(streamId) === preparation &&
+    isRetryPending(streamId, requestId);
+
+  /**
+   * Complete one retry settlement without letting a dismiss-delivery failure
+   * become an unhandled rejection. `complete` settles the request before it
+   * dismisses, so `fallback` reports the settlement the caller already made.
+   */
+  const completeRetrySettlement = (
+    streamId: StreamTabId,
+    settlement: RetryResult,
+    fallback: boolean,
+  ): boolean => {
+    try {
+      return handlers().retry.complete(streamId, settlement);
+    } catch (error) {
+      logWarning(
+        'progressView',
+        `The retry settlement could not be delivered: ${toErrorMessage(error)}`,
+      );
+      return fallback;
+    }
+  };
 
   const settlePreparedRetry = async (
     streamId: StreamTabId,
@@ -137,33 +178,64 @@ export function createProgressHostInteractions(
     const preparation = retryPreparations.get(streamId);
     if (!preparation || preparation.requestId !== requestId) {
       // No host-side preparation callback is attached, so the caller's normal
-      // retry path (rebind) stays responsible for refreshing the client.
-      retryPreparations.delete(streamId);
-      return handlers().retry.complete(streamId, {
-        action: 'retry',
-        ...(feedback !== undefined ? { feedback } : {}),
-      });
+      // retry path (rebind) stays responsible for refreshing the client. When
+      // a newer preparation exists, leave it alone: settling it here would
+      // resolve a request this caller no longer owns.
+      if (preparation) return false;
+      return completeRetrySettlement(
+        streamId,
+        {
+          action: 'retry',
+          ...(feedback !== undefined ? { feedback } : {}),
+        },
+        true,
+      );
     }
-    if (preparation.settling) return true;
+    if (preparation.settling) {
+      // A conflicting second selection (plain retry vs. personal-credential
+      // switch) cannot adopt the in-flight preparation's result, so reject it
+      // instead of pretending it settled.
+      if (preparation.selection !== selection) return false;
+      return preparation.settlement ?? true;
+    }
     preparation.settling = true;
-    try {
-      await preparation.prepareRetry(selection, preparation.controller.signal);
-    } catch (error) {
+    preparation.selection = selection;
+    const settlement = (async (): Promise<boolean> => {
+      try {
+        await preparation.prepareRetry(
+          selection,
+          preparation.controller.signal,
+        );
+      } catch (error) {
+        if (!isCurrentRetryPreparation(streamId, requestId, preparation)) {
+          return false;
+        }
+        retryPreparations.delete(streamId);
+        completeRetrySettlement(
+          streamId,
+          { action: 'deny', reason: toErrorMessage(error) },
+          denialResult,
+        );
+        // The API-key switch path reports a denied preparation as false so its
+        // controller can roll the routing changes back; a plain retry has no
+        // routing changes to undo, so it still reports that the request settled.
+        return denialResult;
+      }
+      if (!isCurrentRetryPreparation(streamId, requestId, preparation)) {
+        return false;
+      }
       retryPreparations.delete(streamId);
-      handlers().retry.complete(streamId, {
-        action: 'deny',
-        reason: toErrorMessage(error),
-      });
-      // The API-key switch path reports a denied preparation as false so its
-      // controller can roll the routing changes back; a plain retry has no
-      // routing changes to undo, so it still reports that the request settled.
-      return denialResult;
-    }
-    retryPreparations.delete(streamId);
-    return handlers().retry.complete(streamId, {
-      action: 'retry',
-      ...(feedback !== undefined ? { feedback } : {}),
-    });
+      return completeRetrySettlement(
+        streamId,
+        {
+          action: 'retry',
+          ...(feedback !== undefined ? { feedback } : {}),
+        },
+        true,
+      );
+    })();
+    preparation.settlement = settlement;
+    return settlement;
   };
 
   const cancel = (selector: HostInteractionCancelSelector = {}): void => {
@@ -171,12 +243,19 @@ export function createProgressHostInteractions(
       options.getToolEditApprovals().cancel(selector);
     }
     if (selector.kind == null || selector.kind === 'retry') {
-      if (selector.streamId === undefined) {
-        for (const preparation of retryPreparations.values()) {
+      for (const [streamId, preparation] of retryPreparations) {
+        if (
+          matchesCancelSelector(
+            {
+              kind: 'retry',
+              streamId,
+              cancellationScope: preparation.cancellationScope,
+            },
+            selector,
+          )
+        ) {
           preparation.controller.abort();
         }
-      } else if (selector.streamId !== null) {
-        retryPreparations.get(selector.streamId)?.controller.abort();
       }
     }
     cancelApprovalRequestHandlers(
@@ -184,13 +263,6 @@ export function createProgressHostInteractions(
       PROGRESS_INTERACTION_KINDS,
       selector,
     );
-  };
-
-  const isRetryPending = (
-    streamId: StreamTabId,
-    requestId: string,
-  ): boolean => {
-    return handlers().retry.get(streamId)?.requestId === requestId;
   };
 
   return {
@@ -236,6 +308,7 @@ export function createProgressHostInteractions(
     ): boolean {
       if (!isRetryPending(streamId, requestId)) return false;
       if (decision.action === 'cancel') {
+        retryPreparations.get(streamId)?.controller.abort();
         retryPreparations.delete(streamId);
         return handlers().retry.complete(streamId, decision);
       }
@@ -350,6 +423,7 @@ export function createProgressHostInteractions(
           requestId: request.requestId,
           prepareRetry: interactionOptions.prepareRetry,
           controller: new AbortController(),
+          cancellationScope: interactionOptions.cancellationScope,
           settling: false,
         });
       } else {

--- a/src/shared/model/kimiCodeRetryGate.ts
+++ b/src/shared/model/kimiCodeRetryGate.ts
@@ -1,0 +1,30 @@
+/**
+ * Browser-safe Kimi Code exclusivity gate for retry switches.
+ *
+ * The host-side route resolver (`@model/kimiCodeSubscriptionRouting`) owns the
+ * equivalent predicate for routing decisions; this module is deliberately free
+ * of platform/secret-store imports so webview panels can read the same static
+ * llm-zoo registry facts when deciding whether to offer an API-key switch.
+ */
+import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
+
+import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
+
+/**
+ * Whether the retrying model is served ONLY by the Kimi Code coding endpoint
+ * (`kimi-for-coding` aliases pin their `baseUrl` in the registry). Unknown or
+ * non-Kimi models are not exclusive, so a missing `model` never blocks the
+ * GLM/Kimi dual-backend switch.
+ */
+export function isKimiCodeExclusiveRetryModel(
+  model: string | undefined,
+): boolean {
+  if (model === undefined) return false;
+  const config = MODEL_CONFIGS[model];
+  return (
+    config !== undefined &&
+    config.provider === ModelProvider.MOONSHOT &&
+    config.kimiSubscription === true &&
+    config.baseUrl === KIMI_CODE_BASE_URL
+  );
+}

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import pDefer from 'p-defer';
+import { describe, expect, it, vi } from 'vitest';
 
-import { ProgressApiKeyRetryController } from '@controllers/progressView/ProgressApiKeyRetryController';
+import {
+  ProgressApiKeyRetryController,
+  type ProgressApiKeyRetryControllerDeps,
+} from '@controllers/progressView/ProgressApiKeyRetryController';
 import type { ApiProvider } from '@model/apiProviders';
 import { prefersCopilotRoute } from '@model/copilotRouting';
 import { installPlatform } from '@test/support/setupPlatform';
@@ -33,6 +37,8 @@ interface HarnessOptions {
   glmCodingPlan?: boolean;
   retryAvailable?: boolean;
   retryPending?: boolean;
+  triggerRetry?: ProgressApiKeyRetryControllerDeps['triggerRetry'];
+  isRetryPending?: ProgressApiKeyRetryControllerDeps['isRetryPending'];
 }
 
 function createHarness(options: HarnessOptions = {}): {
@@ -100,11 +106,14 @@ function createHarness(options: HarnessOptions = {}): {
       invalidateModelOptionsCache: () => {
         invalidations += 1;
       },
-      isRetryPending: () => options.retryPending ?? true,
-      triggerRetry: (stream) => {
-        retries.push(stream);
-        return options.retryAvailable ?? true;
-      },
+      isRetryPending:
+        options.isRetryPending ?? (() => options.retryPending ?? true),
+      triggerRetry:
+        options.triggerRetry ??
+        ((stream) => {
+          retries.push(stream);
+          return options.retryAvailable ?? true;
+        }),
     }),
   };
 }
@@ -491,5 +500,77 @@ describe('ProgressApiKeyRetryController', () => {
     // preference is never written, so a crash mid-launch cannot drop it.
     expect(persistedWrites).toEqual([]);
     expect(prefersCopilotRoute('sonnet46')).toBe(true);
+  });
+
+  it('serializes routing rollback across concurrent stream retries', async () => {
+    const firstTrigger = pDefer<boolean>();
+    let retryBPendingCheck = false;
+    const triggerOrder: string[] = [];
+    const harness = createHarness({
+      keys: { openai: 'stored-openai' },
+      isRetryPending: (_stream, requestId) => {
+        if (requestId === 'retry-b') retryBPendingCheck = true;
+        return true;
+      },
+      triggerRetry: (stream) => {
+        triggerOrder.push(stream);
+        return stream === 'stream-a' ? firstTrigger.promise : true;
+      },
+    });
+
+    const first = harness.controller.useOwnApiKey({
+      stream: 'stream-a',
+      requestId: 'retry-a',
+      provider: 'openai',
+      exhaustionReason: 'chatgpt-subscription',
+    });
+    await vi.waitFor(() =>
+      expect(harness.includedAccessValues).toStrictEqual([false]),
+    );
+    const second = harness.controller.useOwnApiKey({
+      stream: 'stream-b',
+      requestId: 'retry-b',
+      provider: 'openai',
+      exhaustionReason: 'chatgpt-subscription',
+    });
+    await vi.waitFor(() => expect(retryBPendingCheck).toBe(true));
+
+    // Retry B is queued behind retry A; its routing transaction must not start
+    // while A's trigger is still pending.
+    expect(harness.chatGptSubscriptionValues).toStrictEqual([false]);
+    expect(triggerOrder).toStrictEqual(['stream-a']);
+
+    firstTrigger.resolve(false);
+    await expect(first).resolves.toStrictEqual(IDLE_RESULT);
+    await expect(second).resolves.toStrictEqual({
+      proceeded: true,
+      retried: true,
+      disabledIncludedModelAccess: true,
+      disabledChatGptSubscription: true,
+      disabledCodingPlans: [],
+    });
+    expect(harness.includedAccessValues).toStrictEqual([false, true, false]);
+    expect(harness.chatGptSubscriptionValues).toStrictEqual([
+      false,
+      true,
+      false,
+    ]);
+    expect(triggerOrder).toStrictEqual(['stream-a', 'stream-b']);
+  });
+
+  it('refuses the API-key switch for a Kimi Code-exclusive model', async () => {
+    const harness = createHarness({ keys: { openai: 'stored-openai' } });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-kimi-exclusive',
+      requestId: 'retry-kimi-exclusive',
+      model: 'kimiCoding',
+      exhaustionReason: 'kimi-code-subscription',
+    });
+
+    expect(result).toStrictEqual(IDLE_RESULT);
+    expect(harness.prompts).toStrictEqual([]);
+    expect(harness.includedAccessValues).toStrictEqual([]);
+    expect(harness.retries).toStrictEqual([]);
   });
 });

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import pDefer from 'p-defer';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
@@ -102,6 +103,25 @@ function recordSessionEvents(session: SessionHandle): SessionEvent[] {
     scope: 'session',
   });
   return events;
+}
+
+/** A deferred retry preparation that rejects when its AbortSignal fires. */
+function createDeferredPreparation() {
+  const deferred = pDefer<void>();
+  let signal: AbortSignal | undefined;
+  const prepareRetry = vi.fn(
+    async (_selection: string, abortSignal?: AbortSignal) => {
+      if (!abortSignal) return;
+      signal = abortSignal;
+      abortSignal.addEventListener(
+        'abort',
+        () => deferred.reject(abortSignal.reason ?? new Error('aborted')),
+        { once: true },
+      );
+      return deferred.promise;
+    },
+  );
+  return { deferred, prepareRetry, signal: () => signal };
 }
 
 describe('createExtensionHostInteractions', () => {
@@ -469,6 +489,177 @@ describe('createExtensionHostInteractions', () => {
       action: 'deny',
       reason: 'replacement client failed',
     });
+  });
+
+  it('does not let a stale preparation settle its replacement request', async () => {
+    const { interactions } = createInteractions({
+      session: createTestSession(),
+    });
+    const first = createDeferredPreparation();
+    const replacement = createDeferredPreparation();
+
+    const firstResult = interactions.requestRetry?.(
+      {
+        requestId: 'retry:stale-prep',
+        streamId: STREAM_A,
+        operation: 'First invocation',
+      },
+      { prepareRetry: first.prepareRetry },
+    );
+    expect(
+      interactions.submitRetryDecision(STREAM_A, 'retry:stale-prep', {
+        action: 'retry',
+      }),
+    ).toBe(true);
+    await vi.waitFor(() => expect(first.prepareRetry).toHaveBeenCalledOnce());
+
+    const replacementResult = interactions.requestRetry?.(
+      {
+        requestId: 'retry:replacement-prep',
+        streamId: STREAM_A,
+        operation: 'Replacement invocation',
+      },
+      { prepareRetry: replacement.prepareRetry },
+    );
+    await expect(firstResult).resolves.toEqual({ action: 'cancel' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The stale settle saw the abort, but must not delete or deny the newer
+    // request's preparation.
+    expect(
+      interactions.isRetryPending(STREAM_A, 'retry:replacement-prep'),
+    ).toBe(true);
+    expect(
+      interactions.submitRetryDecision(STREAM_A, 'retry:replacement-prep', {
+        action: 'retry',
+      }),
+    ).toBe(true);
+    replacement.deferred.resolve();
+    await expect(replacementResult).resolves.toEqual({ action: 'retry' });
+  });
+
+  it('rejects a conflicting personal-credential selection while a plain retry prepares', async () => {
+    const { interactions } = createInteractions({
+      session: createTestSession(),
+    });
+    const preparation = createDeferredPreparation();
+
+    const result = interactions.requestRetry?.(
+      {
+        requestId: 'retry:conflict',
+        streamId: STREAM_A,
+        operation: 'First invocation',
+      },
+      { prepareRetry: preparation.prepareRetry },
+    );
+    expect(
+      interactions.submitRetryDecision(STREAM_A, 'retry:conflict', {
+        action: 'retry',
+      }),
+    ).toBe(true);
+    await vi.waitFor(() =>
+      expect(preparation.prepareRetry).toHaveBeenCalledOnce(),
+    );
+
+    await expect(
+      interactions.submitRetryWithPersonalCredentials(
+        STREAM_A,
+        'retry:conflict',
+      ),
+    ).resolves.toBe(false);
+
+    expect(preparation.prepareRetry).toHaveBeenCalledTimes(1);
+    expect(preparation.prepareRetry).toHaveBeenCalledWith(
+      'configured',
+      expect.anything(),
+    );
+
+    preparation.deferred.resolve();
+    await expect(result).resolves.toEqual({ action: 'retry' });
+  });
+
+  it('aborts an in-flight personal preparation when the retry is dismissed', async () => {
+    const { interactions } = createInteractions({
+      session: createTestSession(),
+    });
+    const preparation = createDeferredPreparation();
+
+    const result = interactions.requestRetry?.(
+      {
+        requestId: 'retry:cancel-prep',
+        streamId: STREAM_A,
+        operation: 'First invocation',
+      },
+      { prepareRetry: preparation.prepareRetry },
+    );
+    const personal = interactions.submitRetryWithPersonalCredentials(
+      STREAM_A,
+      'retry:cancel-prep',
+    );
+    await vi.waitFor(() =>
+      expect(preparation.prepareRetry).toHaveBeenCalledOnce(),
+    );
+
+    expect(
+      interactions.submitRetryDecision(STREAM_A, 'retry:cancel-prep', {
+        action: 'cancel',
+      }),
+    ).toBe(true);
+    expect(preparation.signal()?.aborted).toBe(true);
+    await expect(personal).resolves.toBe(false);
+    await expect(result).resolves.toEqual({ action: 'cancel' });
+  });
+
+  it('does not abort preparations outside the cancellation scope', async () => {
+    const { interactions } = createInteractions({
+      session: createTestSession(),
+    });
+    const scopeA = {};
+    const scopeB = {};
+    const preparationA = createDeferredPreparation();
+    const preparationB = createDeferredPreparation();
+
+    const resultA = interactions.requestRetry?.(
+      {
+        requestId: 'retry:scope-a',
+        streamId: STREAM_A,
+        operation: 'Scoped A',
+      },
+      { prepareRetry: preparationA.prepareRetry, cancellationScope: scopeA },
+    );
+    const resultB = interactions.requestRetry?.(
+      {
+        requestId: 'retry:scope-b',
+        streamId: STREAM_B,
+        operation: 'Scoped B',
+      },
+      { prepareRetry: preparationB.prepareRetry, cancellationScope: scopeB },
+    );
+    expect(
+      interactions.submitRetryDecision(STREAM_A, 'retry:scope-a', {
+        action: 'retry',
+      }),
+    ).toBe(true);
+    expect(
+      interactions.submitRetryDecision(STREAM_B, 'retry:scope-b', {
+        action: 'retry',
+      }),
+    ).toBe(true);
+    await vi.waitFor(() =>
+      expect(preparationA.prepareRetry).toHaveBeenCalledOnce(),
+    );
+    await vi.waitFor(() =>
+      expect(preparationB.prepareRetry).toHaveBeenCalledOnce(),
+    );
+
+    interactions.cancel({ cancellationScope: scopeA });
+
+    await expect(resultA).resolves.toEqual({ action: 'cancel' });
+    expect(preparationA.signal()?.aborted).toBe(true);
+    expect(preparationB.signal()?.aborted).toBe(false);
+
+    preparationB.deferred.resolve();
+    await expect(resultB).resolves.toEqual({ action: 'retry' });
   });
 
   it('cancels pending retry requests for a removed stream', async () => {

--- a/src/test-kernel/progressView/RetryRequestPanel.vitest.ts
+++ b/src/test-kernel/progressView/RetryRequestPanel.vitest.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import type { RetryRequestPanel } from '@progressView/frontend/components/RetryRequestPanel';
 import type { ProviderErrorPartial } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+import { recordPermissionActions } from '@test/support/permissionPanelEvents';
 
 // Local file imports
 import {
@@ -81,6 +82,43 @@ function tailLine(text: string): string {
 }
 
 describe('retry-request-panel', () => {
+  it('does not offer the API-key switch for a Kimi Code-exclusive model', async () => {
+    const element = await mountPanel({
+      model: 'kimiCoding',
+      errorDetails: {
+        exhaustionReason: 'kimi-code-subscription',
+        isRelayError: false,
+        userRetryable: true,
+      },
+    });
+
+    const buttons = [
+      ...(element.shadowRoot?.querySelectorAll(
+        '.retry-request__actions wa-button',
+      ) ?? []),
+    ];
+    expect(buttons.map((button) => button.getAttribute('data-action'))).toEqual(
+      ['retry', 'cancel'],
+    );
+  });
+
+  it('does not map the k shortcut to the API-key switch for exclusive models', async () => {
+    const element = await mountPanel({
+      model: 'kimiCoding',
+      errorDetails: {
+        exhaustionReason: 'kimi-code-subscription',
+        isRelayError: false,
+        userRetryable: true,
+      },
+    });
+    const actions = recordPermissionActions(element);
+
+    expect(element.handleKeyboardShortcut('k')).toBe(false);
+    expect(element.handleKeyboardShortcut('r')).toBe(true);
+
+    expect(actions).toEqual([{ action: 'retry' }]);
+  });
+
   it('marks retry action buttons with action ids for shared sizing styles', async () => {
     const element = await mountPanel();
 


### PR DESCRIPTION
Follow-up to #10510.

- Remove the dead `isKimiCodeExclusiveRetryModel` import and move the exclusivity gate to a browser-safe shared module so both the CLI retry classifier and the progress-view panel/controller reuse it.
- Harden `settlePreparedRetry` against concurrent retry activity: stale settlements no longer delete or settle replacement requests, conflicting selections are rejected instead of silently dropped, and settlement delivery failures are caught.
- Abort the in-flight retry preparation on dismiss and honor the preparation's cancellation scope in `cancel`.
- Serialize progress-view routing apply/prepare/rollback transactions across concurrent stream retries with a `p-queue`.
- Gate the progress-view API-key switch for Kimi Code-exclusive models, mirroring the TUI gate from #10473.

Closes #10523
Closes #10524
Closes #10525
Closes #10526
Closes #10527