### PR TITLE
refactor(latex): narrow the three latex→agent coupling sites

### DIFF
--- a/config/ratchets/architecture-edges-baseline.json
+++ b/config/ratchets/architecture-edges-baseline.json
@@ -39,7 +39,6 @@
     { "from": "housekeeping", "to": "platform", "kind": "value" },
     { "from": "housekeeping", "to": "shared", "kind": "value" },
     { "from": "housekeeping", "to": "utils", "kind": "value" },
-    { "from": "latex", "to": "agent", "kind": "value" },
     { "from": "latex", "to": "common", "kind": "value" },
     { "from": "latex", "to": "logger", "kind": "value" },
     { "from": "latex", "to": "platform", "kind": "value" },

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -21,6 +21,7 @@ import {
   getVisibleAgents,
   loadAgents,
 } from '@agent/index';
+import { agentResponseTextConnector } from '@agent/runtime';
 import type { RetryResult } from '@agent/runtime/HostInteractions';
 import {
   defaultSession,
@@ -29,7 +30,7 @@ import {
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { tuiOutputStreamForColor } from '@cli/tui/noColorOutput';
 import { planTeamRuns, teamPresets } from '@common/teams/TeamPlan';
-import { texraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
+import { createTexraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { platform, tryPlatform } from '@platform/platform';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import {
@@ -442,7 +443,9 @@ if (HARNESS_MEMORY_FILES.length > 0) {
 }
 const harnessRuntimeSession = initializeDefaultSession({
   transcripts: await StreamLogStore.open(),
-  responseTextProcessing: texraResponseTextProcessing,
+  responseTextProcessing: createTexraResponseTextProcessing(
+    agentResponseTextConnector,
+  ),
 });
 harnessRuntimeSession.setApprovalPolicy(HARNESS_INITIAL_APPROVAL_POLICY);
 const harnessFollowUpLease = defaultSession().followUps.claimLive(

--- a/packages/cli/src/runtime/transcriptSession.ts
+++ b/packages/cli/src/runtime/transcriptSession.ts
@@ -1,10 +1,11 @@
 import {
+  agentResponseTextConnector,
   initializeDefaultSession,
   tryDefaultSession,
   type SessionHandle,
 } from '@agent/runtime';
 import { createSessionStores } from '@controllers/session/sessionStores';
-import { texraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
+import { createTexraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { ephemeralTranscriptWarning, StreamLogStore } from '@transcript';
 
 export type InteractiveTranscriptPolicy =
@@ -44,7 +45,9 @@ async function initializePersistentSession(
   const result = await persistentSession(
     initializeDefaultSession({
       transcripts,
-      responseTextProcessing: texraResponseTextProcessing,
+      responseTextProcessing: createTexraResponseTextProcessing(
+        agentResponseTextConnector,
+      ),
     }),
   );
   await createSessionStores(result.session).sweepLeftoverStreams();
@@ -107,7 +110,9 @@ export async function initializeInteractiveTranscriptSession(
 
   const session = initializeDefaultSession({
     transcripts,
-    responseTextProcessing: texraResponseTextProcessing,
+    responseTextProcessing: createTexraResponseTextProcessing(
+      agentResponseTextConnector,
+    ),
   });
   await session.waitUntilReady();
   return ephemeralSession(

--- a/packages/desktop/src/main/desktopProgressFileActions.ts
+++ b/packages/desktop/src/main/desktopProgressFileActions.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { createLatexExecutionDiscovery } from '@agent/storage';
 import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
 import { acceptEditedFileReplace } from '@latex/acceptedFileTarget';
 import { openFirstLabelMatch } from '@latex/labelSearch';
@@ -219,6 +220,7 @@ export class DesktopProgressFileActions {
         outputsByRound: hasOutputs ? runContext.outputsByRound : null,
         mathMarkup: DEFAULT_MATH_MARKUP,
         generateBetweenRoundDiffs: true,
+        executionDiscovery: createLatexExecutionDiscovery(),
         latexdiff: {
           channel: DESKTOP_LATEXDIFF_CHANNEL,
           service: new LaTeXdiffService(DESKTOP_LATEXDIFF_CHANNEL),

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -14,7 +14,11 @@ import {
 } from 'electron';
 
 import type { SessionStores } from '@agent/storage';
-import { attachTerminalResultToast, SessionHandle } from '@agent/runtime';
+import {
+  agentResponseTextConnector,
+  attachTerminalResultToast,
+  SessionHandle,
+} from '@agent/runtime';
 import {
   computeAgentOptionsData,
   getAgent,
@@ -35,7 +39,7 @@ import { LatexConfigPersistenceController } from '@controllers/settingsView/Late
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
 import { prepareMainViewExecutionRequest } from '@controllers/mainView/MainViewExecutionController';
 import { SubscriptionUsageService } from '@controllers/modelAccess/subscriptionUsage/SubscriptionUsageService';
-import { texraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
+import { createTexraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { hasUsableSetupCredential } from '@model/setupCredentialAccess';
 import { platform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
@@ -1207,7 +1211,9 @@ if (protocolLifecycle.shouldContinue) {
       const processSession = new SessionHandle({
         transcripts,
         restartRepair: 'deferred',
-        responseTextProcessing: texraResponseTextProcessing,
+        responseTextProcessing: createTexraResponseTextProcessing(
+          agentResponseTextConnector,
+        ),
       });
       const detachTerminalResultToast = attachTerminalResultToast(
         processSession,

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 // Local imports
+import { createLatexExecutionDiscovery } from '@agent/storage';
 import { registerCommandEntries } from '@commands/_shared/registerCommands';
 import { workspaceSM } from '@common/state';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
@@ -321,6 +322,7 @@ async function handleRunLatexdiff(
             outputsByRound,
             mathMarkup,
             generateBetweenRoundDiffs,
+            executionDiscovery: createLatexExecutionDiscovery(),
             latexdiff: { channel: CHANNEL, service: latexdiffService },
             progress,
           });

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -11,6 +11,7 @@ import { loadAgents } from '@agent/index';
 import { clearStoreCache, listExecutions } from '@agent/storage';
 import { registerAgentFeatures } from '@agent/features';
 import {
+  agentResponseTextConnector,
   defaultSession,
   initializeDefaultSession,
   initializePolishModel,
@@ -64,7 +65,7 @@ import {
 import { migrateLegacyVscodeStorage } from '@frontend/vscode/sharedStorageRoot';
 import { VscodeSecrets } from '@frontend/vscode/vscodeSecrets';
 import { createExtensionTexraConfig } from '@frontend/vscode/texraConfig';
-import { texraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
+import { createTexraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import * as logger from '@logger/logUtils';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
@@ -269,7 +270,9 @@ export async function activate(context: vscode.ExtensionContext) {
   }
   const runtimeSession = initializeDefaultSession({
     transcripts,
-    responseTextProcessing: texraResponseTextProcessing,
+    responseTextProcessing: createTexraResponseTextProcessing(
+      agentResponseTextConnector,
+    ),
   });
   await runtimeSession.waitUntilReady();
   runtimeSession.setApprovalPolicy(

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -49,10 +49,7 @@ import type {
   TokenCountOptions,
   TokenValidationResult,
 } from '@agent/types/ModelHandlerContracts';
-import {
-  createNeutralResponseTextProcessing,
-  type ResponseTextProcessing,
-} from '@agent/runtime/responseTextProcessing';
+import { createNeutralResponseTextProcessing } from '@agent/runtime/responseTextProcessing';
 import { hasConfigurableReasoningEffort } from '@agent/modelHandlers/support/reasoningEffort';
 import type { ServerToolExtractionResult } from '@agent/types/ServerTools';
 import {
@@ -64,6 +61,7 @@ import {
   isUserAbort,
 } from '@common/errors/sdkError/errorPatterns';
 import { getSdkErrorMessage } from '@common/errors/sdkError/providerErrorFormat';
+import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import {
   allowsModelRelay,
   resolveDirectModelApiKeyProvider,

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -11,8 +11,8 @@ import type {
   ExtractResponseResult,
   SdkToolCall,
 } from '@agent/types/ModelHandlerContracts';
-import type { ResponseTextProcessing } from '@agent/runtime/responseTextProcessing';
 import type { ProviderStopReason } from '@agent/types/StopReasonTypes';
+import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import type {
   FileLocation,
   MediaAttachmentKind,

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -11,7 +11,6 @@ import type {
   TokenCountOptions,
   VscodeLmToolCall,
 } from '@agent/types/ModelHandlerContracts';
-import type { ResponseTextProcessing } from '@agent/runtime/responseTextProcessing';
 import { OPENAI_CHAT_FINISH } from '@agent/types/StopReasonTypes';
 import type { MediaEntry } from '@agent/types/mediaTypes';
 import { AgentError } from '@common/errors';
@@ -22,6 +21,7 @@ import {
   takeTail,
 } from '@common/errors/sdkError/errorPatterns';
 import { handleStreamingFailure } from '@common/errors/sdkError/streamFailure';
+import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import type { ToolDefinition } from '@model/ToolDefinition';
 import { copilotRouteForModel } from '@model/runtimeModelRegistry';
 import { platform } from '@platform/platform';

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -7,13 +7,13 @@ import {
   internalValidationModelHandlerEnvName,
   shouldUseInternalValidationModelHandler,
 } from '@agent/runtime/internalValidationOverride';
-import type { ResponseTextProcessing } from '@agent/runtime/responseTextProcessing';
 import {
   CodexAuthError,
   formatCodexAuthUnavailableMessage,
   isCodexSessionRoutable,
 } from '@auth/codex';
 import { AgentError } from '@common/errors';
+import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { createLog } from '@logger/logUtils';
 import {
   copilotRouteUnavailableReason,

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -38,6 +38,7 @@ import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManage
 import { detectWaitingStreams } from '@agent/storage/detectWaitingStreams';
 import { runWithOwnedExecutionLeaseQuiescence } from '@agent/storage/executionLease';
 import { deriveResumability } from '@agent/storage/resumability';
+import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { platform } from '@platform/platform';
 import {
   TEXRA_APPROVAL_POLICY_DEFAULT,
@@ -72,10 +73,7 @@ import {
   repairRestartedStreams,
   RestartRepairRetryScheduler,
 } from './restartRepair';
-import {
-  createNeutralResponseTextProcessing,
-  type ResponseTextProcessing,
-} from './responseTextProcessing';
+import { createNeutralResponseTextProcessing } from './responseTextProcessing';
 
 const logger = createChannelTrace('sessionHandle');
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -110,6 +110,9 @@ export type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKe
 // helperModelName
 export { getHelperModelName } from './helperModelName';
 
+// textConnection
+export { agentResponseTextConnector } from './textConnection';
+
 // ExecutionHandle
 export type { AgentRunHandle } from './ExecutionHandle';
 

--- a/src/agent/runtime/responseTextProcessing.ts
+++ b/src/agent/runtime/responseTextProcessing.ts
@@ -1,22 +1,13 @@
-/** Optional host policy for text returned by a provider. */
-type ResponseTextPostProcessor = (text: string) => string;
+import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 
 /**
- * Host policy for provider-output cleanup and joining continued responses.
+ * Optional host policy for text returned by a provider.
  *
  * The package defaults are deliberately neutral and deterministic: provider
  * text is returned unchanged, and adjacent non-whitespace text is separated
- * by one space. TeXRA hosts may inject their LaTeX-specific behavior.
+ * by one space. TeXRA hosts may inject their LaTeX-specific behavior via
+ * the latex-owned factory.
  */
-export interface ResponseTextProcessing {
-  /** Normalize provider text only when the host explicitly requests it. */
-  readonly normalizeResponseText: ResponseTextPostProcessor;
-  readonly postProcessResponse: ResponseTextPostProcessor;
-  readonly connectResponseText: (
-    previous: string,
-    next: string,
-  ) => Promise<string>;
-}
 
 /** Preserve provider text when no host-specific post-processor is supplied. */
 function preserveResponseText(text: string): string {

--- a/src/agent/runtime/textConnection.ts
+++ b/src/agent/runtime/textConnection.ts
@@ -5,6 +5,7 @@ import {
 import { classifyAgentError } from '@common/errors';
 import { getSdkErrorMessage } from '@common/errors/sdkError/providerErrorFormat';
 import { LATEX_COMMANDS_CHANNEL as CHANNEL } from '@latex/latexLogging';
+import type { ResponseTextConnector } from '@latex/texraResponseTextProcessing';
 import * as logger from '@logger/logUtils';
 
 interface ConnectionResult {
@@ -74,3 +75,13 @@ export async function bestConnectionMethod(
     return DEFAULT_RESULT;
   }
 }
+
+/**
+ * Agent-owned connector strategy for the latex response-text policy. Hosts
+ * inject this through the latex-owned factory; it keeps the helper-model call
+ * out of the latex layer.
+ */
+export const agentResponseTextConnector: ResponseTextConnector = async (
+  previous,
+  next,
+) => (await bestConnectionMethod(previous, next)).connector;

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -13,6 +13,10 @@ import {
   type RunRecord,
 } from '@agent/core/definition/RunRecord';
 import { isFileNotFoundError } from '@common/errors';
+import type {
+  LatexAgentRunEntry,
+  LatexExecutionDiscoveryPort,
+} from '@latex/latexdiff/executionDiscovery';
 import { createLog } from '@logger/logUtils';
 import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import type {
@@ -74,7 +78,7 @@ export type ExecutionListingEntry =
 
 /** Narrow to the agent arm; nested `identity.kind` cannot discriminate the
  *  entry union for TypeScript, so this is the one spelled-out guard. */
-export function isAgentRunEntry(
+function isAgentRunEntry(
   entry: ExecutionListingEntry,
 ): entry is AgentExecutionListingEntry {
   return entry.kind === 'run' && entry.identity.kind === 'agent';
@@ -235,6 +239,28 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
     results.filter(filterNotNull),
     (item) => item.timestamp,
   );
+}
+
+/**
+ * Adapter from the agent storage surface to the latex-owned execution
+ * discovery port. Hosts inject this into latexdiff orchestration.
+ */
+export function createLatexExecutionDiscovery(): LatexExecutionDiscoveryPort {
+  return {
+    async listAgentRuns(): Promise<readonly LatexAgentRunEntry[]> {
+      const executions = await listExecutions();
+      return executions.filter(isAgentRunEntry).map((entry) => ({
+        id: entry.id,
+        timestamp: entry.timestamp,
+        agent: entry.record.agent,
+        model: entry.record.model,
+        inputFiles: entry.record.inputFiles,
+      }));
+    },
+    async readStreamId(executionId) {
+      return (await getExecutionStore(executionId).readMeta())?.streamId;
+    },
+  };
 }
 
 /**

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -34,10 +34,10 @@ export {
 export {
   type AgentExecutionListingEntry,
   type ExecutionListingEntry,
+  createLatexExecutionDiscovery,
   listExecutions,
   deleteExecution,
   deleteAllExecutions,
-  isAgentRunEntry,
   isUserVisibleExecution,
 } from './executionListing';
 export {

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -5,7 +5,6 @@ import * as path from 'node:path';
 import pMap from 'p-map';
 
 // Local imports
-import type { AgentTrace } from '@agent/trace/AgentTrace';
 import { platform } from '@platform/platform';
 import type { FileLocation } from '@shared/schemas';
 import { ToolConfig } from '@shared/schemas/toolConfig';
@@ -51,12 +50,29 @@ export interface MediaWorkspaceState {
   media: { addMediaFiles(locations: readonly FileLocation[]): void };
 }
 
+/** Options accepted by the logging slice of {@link LatexTrace}. */
+interface LatexLogOptions {
+  readonly data?: unknown;
+}
+
+/**
+ * The logging slice `LatexMediaManager` actually calls. Structurally
+ * satisfied by `AgentTrace`; declared here so LaTeX processing stays
+ * independent of agent execution internals.
+ */
+export interface LatexTrace {
+  debug(message: string, options?: LatexLogOptions): void;
+  info(message: string, options?: LatexLogOptions): void;
+  warn(message: string, options?: LatexLogOptions): void;
+  error(message: string, options?: LatexLogOptions): void;
+}
+
 /**
  * Handles LaTeX related media extraction and compilation for agents.
  */
 export class LatexMediaManager {
   constructor(
-    private readonly logger: AgentTrace,
+    private readonly logger: LatexTrace,
     private readonly fileService?: TaskRunFileService,
   ) {}
 

--- a/src/latex/latexdiff/executionDiscovery.ts
+++ b/src/latex/latexdiff/executionDiscovery.ts
@@ -1,0 +1,19 @@
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+
+/**
+ * The agent-run listing slice latexdiff discovery needs. Agent owns the
+ * implementation and hosts inject it; latex owns the narrow contract so
+ * `outputDiscovery.ts` never reaches into `@agent/storage` itself.
+ */
+export interface LatexAgentRunEntry {
+  readonly id: ExecutionId;
+  readonly timestamp: string;
+  readonly agent: string;
+  readonly model: string;
+  readonly inputFiles: readonly string[];
+}
+
+export interface LatexExecutionDiscoveryPort {
+  listAgentRuns(): Promise<readonly LatexAgentRunEntry[]>;
+  readStreamId(executionId: ExecutionId): Promise<StreamTabId | undefined>;
+}

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -8,12 +8,6 @@
 import * as path from 'node:path';
 
 // Local imports
-import {
-  getExecutionStore,
-  isAgentRunEntry,
-  listExecutions,
-  type AgentExecutionListingEntry,
-} from '@agent/storage';
 import { isFileNotFoundError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { platform } from '@platform/platform';
@@ -41,6 +35,7 @@ import { isDirectory, isFile } from '@utils/files/fsEntryType';
 
 // Local file imports
 import { hasBetweenRoundDiffSuffix } from './diffFileNameManager';
+import type { LatexExecutionDiscoveryPort } from './executionDiscovery';
 
 /**
  * Recursively collect all `.tex` file paths under `dir`, returned as paths
@@ -209,6 +204,7 @@ export async function scanRunDirForOutputs(
  * when no matching execution exists.
  */
 export async function discoverLatestExecutionOutputs(
+  discovery: LatexExecutionDiscoveryPort,
   query: {
     agent: string;
     model: string;
@@ -220,22 +216,18 @@ export async function discoverLatestExecutionOutputs(
   rounds: RoundIndexed<OutputFileInfo>;
 } | null> {
   try {
-    const executions = await listExecutions();
+    const executions = await discovery.listAgentRuns();
     // Normalize both sides so trivial path-format differences (duplicate
     // separators, `./`, mixed forward/backslash) don't silently miss a
     // matching execution.
     const normalizedInput = path.normalize(query.inputFile);
 
     const candidates = toNewestFirstByTimestamp(
-      executions.filter((entry): entry is AgentExecutionListingEntry => {
-        if (
-          !isAgentRunEntry(entry) ||
-          entry.record.agent !== query.agent ||
-          entry.record.model !== query.model
-        ) {
+      executions.filter((entry) => {
+        if (entry.agent !== query.agent || entry.model !== query.model) {
           return false;
         }
-        const entryInput = entry.record.inputFiles[0];
+        const entryInput = entry.inputFiles[0];
         return (
           typeof entryInput === 'string' &&
           path.normalize(entryInput) === normalizedInput
@@ -249,8 +241,7 @@ export async function discoverLatestExecutionOutputs(
       // The stream stamped on execution metadata addresses its snapshot
       // directly; identity is never rebuilt from agent/model configuration.
       // Records without one go straight to the run-directory scan below.
-      const streamId = (await getExecutionStore(candidate.id).readMeta())
-        ?.streamId;
+      const streamId = await discovery.readStreamId(candidate.id);
       if (streamId !== undefined) {
         const rounds = await snapshots.readOutputFiles(streamId);
         if (rounds && Object.keys(rounds).length > 0) {
@@ -270,7 +261,7 @@ export async function discoverLatestExecutionOutputs(
       const scanned = await scanRunDirForOutputs(
         candidate.id,
         query.inputFile,
-        candidate.record.inputFiles.slice(1),
+        candidate.inputFiles.slice(1),
         channel,
       );
       if (scanned) {

--- a/src/latex/latexdiff/runLatexdiff.ts
+++ b/src/latex/latexdiff/runLatexdiff.ts
@@ -29,6 +29,7 @@ import {
   discoverLatestExecutionOutputs,
   scanRunDirForOutputs,
 } from './outputDiscovery';
+import type { LatexExecutionDiscoveryPort } from './executionDiscovery';
 import type { MathMarkupOption } from './mathMarkup';
 import type {
   DiffProgressReporter,
@@ -61,6 +62,8 @@ export interface RunLatexdiffForExecutionParams {
   readonly agent: string;
   readonly model: string;
   readonly inputFile: string;
+  /** Agent-owned execution listing injected by hosts (metadata auto-discovery). */
+  readonly executionDiscovery: LatexExecutionDiscoveryPort;
   readonly outputFiles?: string[];
   /** Execution to scope output discovery to (progress-toolbar invocations). */
   readonly runId?: string | null;
@@ -90,6 +93,7 @@ export async function runLatexdiffForExecution(
     agent,
     model,
     inputFile,
+    executionDiscovery,
     outputFiles,
     mathMarkup,
     generateBetweenRoundDiffs,
@@ -136,6 +140,7 @@ export async function runLatexdiffForExecution(
   // newer) execution with the same agent/model/input.
   if (!outputsByRound && !runId) {
     const discovered = await discoverLatestExecutionOutputs(
+      executionDiscovery,
       {
         agent,
         model,

--- a/src/latex/texraResponseTextProcessing.ts
+++ b/src/latex/texraResponseTextProcessing.ts
@@ -1,14 +1,31 @@
-import type { ResponseTextProcessing } from '@agent/runtime/responseTextProcessing';
 import replacementEngine from '@replacement/engine';
 
-/** TeXRA's LaTeX-aware provider-output policy, injected by application hosts. */
-export const texraResponseTextProcessing: ResponseTextProcessing =
-  Object.freeze<ResponseTextProcessing>({
-    normalizeResponseText: (text) => text.trim(),
-    postProcessResponse: (text) => replacementEngine.applyAll(text),
-    connectResponseText: async (previous, next) => {
-      const { bestConnectionMethod } =
-        await import('@agent/runtime/textConnection');
-      return (await bestConnectionMethod(previous, next)).connector;
-    },
+type ResponseTextPostProcessor = (text: string) => string;
+
+export type ResponseTextConnector = (
+  previous: string,
+  next: string,
+) => Promise<string>;
+
+/**
+ * Latex-owned policy contract for provider-output cleanup and joining
+ * continued responses. The agent runtime supplies only the connector
+ * strategy; latex owns the type and the TeXRA-specific factory.
+ */
+export interface ResponseTextProcessing {
+  readonly normalizeResponseText: ResponseTextPostProcessor;
+  readonly postProcessResponse: ResponseTextPostProcessor;
+  readonly connectResponseText: ResponseTextConnector;
+}
+
+/** Create TeXRA's LaTeX-aware provider-output policy, injected by hosts. */
+export function createTexraResponseTextProcessing(
+  connectResponseText: ResponseTextConnector,
+): ResponseTextProcessing {
+  return Object.freeze({
+    normalizeResponseText: (text: string): string => text.trim(),
+    postProcessResponse: (text: string): string =>
+      replacementEngine.applyAll(text),
+    connectResponseText,
   });
+}

--- a/src/test-kernel/agent/modelHandlers/ResponseTextProcessing.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ResponseTextProcessing.vitest.ts
@@ -7,7 +7,7 @@ import { noopTrace } from '@agent/trace';
 import { ModelHandlerValidation } from '@agent/modelHandlers/modelHandlerValidation';
 import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
 import { createNeutralResponseTextProcessing } from '@agent/runtime/responseTextProcessing';
-import { texraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
+import { createTexraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 const RAW_PROVIDER_TEXT = '$\\mathrm{Tr}$ remains provider text.';
@@ -84,12 +84,14 @@ describe('response text processing', () => {
   );
 
   it('keeps TeXRA replacement behavior in the application adapter', () => {
-    expect(Object.isFrozen(texraResponseTextProcessing)).toBe(true);
+    const processing = createTexraResponseTextProcessing(async () => ' ');
 
-    const normalized = texraResponseTextProcessing.normalizeResponseText(
+    expect(Object.isFrozen(processing)).toBe(true);
+
+    const normalized = processing.normalizeResponseText(
       ` ${RAW_PROVIDER_TEXT}\n`,
     );
-    expect(texraResponseTextProcessing.postProcessResponse(normalized)).toBe(
+    expect(processing.postProcessResponse(normalized)).toBe(
       '$\\Tr$ remains provider text.',
     );
   });

--- a/src/test-kernel/architecture/dependencyDirection.vitest.ts
+++ b/src/test-kernel/architecture/dependencyDirection.vitest.ts
@@ -171,6 +171,17 @@ describe('Shared layer dependency direction', () => {
   });
 });
 
+describe('Latex layer dependency direction', () => {
+  it('does not grow latex-to-agent imports', () => {
+    const offenders = sourceFilesUnder('src/latex')
+      .filter((file) => importsMatching(file, AGENT_IMPORT_PATTERNS))
+      .map(toRepoPath)
+      .toSorted();
+
+    expect(offenders).toEqual([]);
+  });
+});
+
 describe('Production core never imports host layers', () => {
   it('has no imports from extension, CLI, or desktop aliases', () => {
     const offenders = productionSrcFiles()

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.ts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.ts
@@ -70,11 +70,11 @@ vi.doMock(cliRequire.resolve('ink'), () => ({
 }));
 
 vi.mock('@latex/texraResponseTextProcessing', () => ({
-  texraResponseTextProcessing: {
+  createTexraResponseTextProcessing: () => ({
     normalizeResponseText: (text: string) => text,
     postProcessResponse: (text: string) => text,
     connectResponseText: async () => ' ',
-  },
+  }),
 }));
 
 vi.mock('@cli/runtime/initPlatform', () => ({

--- a/src/test-kernel/latex/OutputDiscovery.vitest.ts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.ts
@@ -3,6 +3,10 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type {
+  LatexAgentRunEntry,
+  LatexExecutionDiscoveryPort,
+} from '@latex/latexdiff/executionDiscovery';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { installPlatform } from '@test/support/setupPlatform';
 import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
@@ -10,20 +14,12 @@ import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 // `discoverLatestExecutionOutputs` matches a run by agent/model/input and then
 // reads its per-round outputs. Headless `texra run` executions persist those
 // outputs on disk but never write the progress-view stream-tab snapshot, so the
-// snapshot read comes back empty. These mocks reproduce that case: a matching
+// snapshot read comes back empty. These fakes reproduce that case: a matching
 // execution whose stream-tab snapshot is empty while its run directory holds
 // r0/r1 outputs on disk (the same source the `--run-id` path scans).
 const mocks = vi.hoisted(() => ({
-  listExecutions: vi.fn(),
-  getExecutionStore: vi.fn(),
   findRunDir: vi.fn(),
   readOutputFiles: vi.fn(),
-}));
-
-vi.mock('@agent/storage', async (importActual) => ({
-  ...(await importActual<typeof import('@agent/storage')>()),
-  listExecutions: mocks.listExecutions,
-  getExecutionStore: mocks.getExecutionStore,
 }));
 
 vi.mock('@utils/files/runStorageFs', async (importActual) => ({
@@ -45,17 +41,27 @@ vi.mock('@transcript', async (importActual) => {
 const { discoverLatestExecutionOutputs } =
   await import('@latex/latexdiff/outputDiscovery');
 
-function matchingExecution(id: string) {
+function matchingExecution(id: string): LatexAgentRunEntry {
   return {
-    kind: 'run',
-    identity: { kind: 'agent', agent: 'polish' },
     id,
     timestamp: '2026-01-01T00:00:00.000Z',
-    record: {
-      agent: 'polish',
-      model: 'deepseek',
-      inputFiles: ['paper.tex'],
+    agent: 'polish',
+    model: 'deepseek',
+    inputFiles: ['paper.tex'],
+  };
+}
+
+function discoveryWith(entries: readonly LatexAgentRunEntry[]): {
+  discovery: LatexExecutionDiscoveryPort;
+  readStreamId: ReturnType<typeof vi.fn>;
+} {
+  const readStreamId = vi.fn(async () => undefined);
+  return {
+    discovery: {
+      listAgentRuns: async () => entries,
+      readStreamId,
     },
+    readStreamId,
   };
 }
 
@@ -71,9 +77,6 @@ describe('discoverLatestExecutionOutputs', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     await installPlatform({}, { fs: nodeFilesystem });
-    mocks.getExecutionStore.mockReturnValue({
-      readMeta: async () => null,
-    } as never);
     mocks.readOutputFiles.mockResolvedValue(undefined);
   });
 
@@ -91,12 +94,14 @@ describe('discoverLatestExecutionOutputs', () => {
       );
     }
 
-    mocks.listExecutions.mockResolvedValue([
-      matchingExecution('exec-headless'),
-    ]);
+    const { discovery } = discoveryWith([matchingExecution('exec-headless')]);
     mocks.findRunDir.mockResolvedValue(runDir);
 
-    const result = await discoverLatestExecutionOutputs(MATCHING_QUERY, 'test');
+    const result = await discoverLatestExecutionOutputs(
+      discovery,
+      MATCHING_QUERY,
+      'test',
+    );
 
     expect(result?.executionId).toBe('exec-headless');
     expect(
@@ -108,21 +113,21 @@ describe('discoverLatestExecutionOutputs', () => {
   });
 
   it('reads outputs under the registered stream identity instead of rebuilding it from configuration (#9590 A1)', async () => {
-    mocks.listExecutions.mockResolvedValue([
+    const { discovery, readStreamId } = discoveryWith([
       matchingExecution('exec-registered'),
     ]);
     // Registered under a stream the agent/model config would NOT derive.
-    mocks.getExecutionStore.mockReturnValue({
-      readMeta: async () => ({
-        timestamp: '2026-01-01T00:00:00.000Z',
-        streamId: 'polish@earlierModel#exec-registered',
-      }),
-    } as never);
+    readStreamId.mockResolvedValue('polish@earlierModel#exec-registered');
     const rounds = { 0: [] };
     mocks.readOutputFiles.mockResolvedValue(rounds);
 
-    const result = await discoverLatestExecutionOutputs(MATCHING_QUERY, 'test');
+    const result = await discoverLatestExecutionOutputs(
+      discovery,
+      MATCHING_QUERY,
+      'test',
+    );
 
+    expect(readStreamId).toHaveBeenCalledWith('exec-registered');
     expect(mocks.readOutputFiles).toHaveBeenCalledWith(
       'polish@earlierModel#exec-registered',
     );
@@ -133,10 +138,14 @@ describe('discoverLatestExecutionOutputs', () => {
   it('returns null when neither the snapshot nor the run directory has outputs', async () => {
     const emptyDir = await makeTempDir('texra-latexdiff-', tempDirs);
 
-    mocks.listExecutions.mockResolvedValue([matchingExecution('exec-empty')]);
+    const { discovery } = discoveryWith([matchingExecution('exec-empty')]);
     mocks.findRunDir.mockResolvedValue(emptyDir);
 
-    const result = await discoverLatestExecutionOutputs(MATCHING_QUERY, 'test');
+    const result = await discoverLatestExecutionOutputs(
+      discovery,
+      MATCHING_QUERY,
+      'test',
+    );
 
     expect(result).toBeNull();
   });

--- a/src/test-kernel/latex/RunLatexdiff.vitest.ts
+++ b/src/test-kernel/latex/RunLatexdiff.vitest.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LaTeXdiffService } from '@latex/latexdiff';
+import type { LatexExecutionDiscoveryPort } from '@latex/latexdiff/executionDiscovery';
 import { normalizeRunLatexdiffOutputsByRound } from '@latex/latexdiff/runLatexdiff';
 import type { OutputFileInfo, RoundIndexed } from '@shared/schemas';
 import { createOutputFile } from '../support/ProgressControllerHarnesses';
@@ -36,10 +37,16 @@ function roundMap(): RoundIndexed<OutputFileInfo> {
   return { 1: [] as OutputFileInfo[] };
 }
 
+const executionDiscovery: LatexExecutionDiscoveryPort = {
+  listAgentRuns: async () => [],
+  readStreamId: async () => undefined,
+};
+
 const baseRequest = {
   agent: 'revise',
   model: 'claude-opus-4-8',
   inputFile: 'paper.tex',
+  executionDiscovery,
   generateBetweenRoundDiffs: false,
   latexdiff,
   progress: { report: () => undefined },
@@ -123,6 +130,7 @@ describe('runLatexdiffForExecution', () => {
     expect(result.source).toBe('metadata');
     expect(result.executionId).toBe('def456');
     expect(mocks.discoverLatestExecutionOutputs).toHaveBeenCalledWith(
+      executionDiscovery,
       {
         agent: 'revise',
         model: 'claude-opus-4-8',


### PR DESCRIPTION
## Summary

Implements the latex→agent port migration designed in `docs/proposals/2026-08-15-latex-agent-port-design.md` (#10532).

- `LatexMediaManager` now declares its own `LatexTrace` logging slice instead of importing `AgentTrace`.
- `ResponseTextProcessing` moves to latex; `createTexraResponseTextProcessing` composes with `agentResponseTextConnector` (re-exported from `@agent/runtime`). CLI/desktop/extension session roots use the factory.
- `outputDiscovery` consumes the new latex-owned `LatexExecutionDiscoveryPort`; `createLatexExecutionDiscovery` lives in `@agent/storage` and is injected by the extension/desktop latexdiff call sites. `executionDiscovery` stays **required** on `RunLatexdiffForExecutionParams` (the open question from the design).

## Ratchets

- Deleted the `{ "from": "latex", "to": "agent", "kind": "value" }` row from `config/ratchets/architecture-edges-baseline.json` (96 → 95 edges).
- `config/ratchets/host-agent-import-baseline.json` unchanged.
- Added the `src/latex` no-`@agent` gate to `dependencyDirection.vitest.ts`.

## Validation

- `npm run typecheck`
- targeted eslint on all changed files
- `npx vitest run src/test-kernel/architecture/ src/test-kernel/latex/ src/test-kernel/desktop/DesktopProgressFileActions.vitest.ts src/test-kernel/cli/TranscriptSessionPolicy.vitest.ts src/test-kernel/cli/RunChatSignalOwnership.vitest.ts src/test-kernel/agent/modelHandlers/ResponseTextProcessing.vitest.ts` → 37 files / 227 tests
- `npx prettier --check` on changed files
- `npm run check:dead-code-ratchet`

Closes #10537