### PR TITLE
docs(agent): sync @agent/storage barrel docs with its host-boundary role

### DIFF
--- a/docs/proposals/2026-08-04-agent-sdk-readiness-review.md
+++ b/docs/proposals/2026-08-04-agent-sdk-readiness-review.md
@@ -188,10 +188,11 @@ These are small and independent of the strategic Tier-1 program:
    intended path — they are. Module-level barrels are the proving ground;
    promotion through `packages/agent/src/index.ts` is deferred until the
    host-boundary surface has proven stable. One cluster per PR still applies.
-   `@agent/storage` was already a module-level barrel; #10531 folded its
-   remaining host deep-imports (`executionLease` lifecycle and
-   `conversationFormat`) behind it, leaving `followUp` and
-   `core/definition/AgentConfig` as the open clusters under #10024.
+   `@agent/storage` was already a module-level barrel that exposed execution
+   lifecycle/listing and resumability; #10531 folded the remaining host
+   deep-imports (CLI's `executionLease` and `conversationFormat`) behind it,
+   leaving `followUp` and `core/definition/AgentConfig` as the open clusters
+   under #10024.
 
 2. **Stabilize the withheld interaction contract.** The `HostInteractions`
    docstring (`index.ts:42-47`) and the hard-deny `requestRetry`

--- a/docs/proposals/2026-08-04-agent-sdk-readiness-review.md
+++ b/docs/proposals/2026-08-04-agent-sdk-readiness-review.md
@@ -188,6 +188,10 @@ These are small and independent of the strategic Tier-1 program:
    intended path — they are. Module-level barrels are the proving ground;
    promotion through `packages/agent/src/index.ts` is deferred until the
    host-boundary surface has proven stable. One cluster per PR still applies.
+   `@agent/storage` was already a module-level barrel; #10531 folded its
+   remaining host deep-imports (`executionLease` lifecycle and
+   `conversationFormat`) behind it, leaving `followUp` and
+   `core/definition/AgentConfig` as the open clusters under #10024.
 
 2. **Stabilize the withheld interaction contract.** The `HostInteractions`
    docstring (`index.ts:42-47`) and the hard-deny `requestRetry`
@@ -216,4 +220,5 @@ as the baseline to shrink.
 **Reconciliation (2026-08).** #10011 began the §5.1 fold-in at the module-level
 `@agent/runtime` barrel rather than `packages/agent/src/index.ts`, deferring
 package promotion until the module-level barrels have proven the host-boundary
-surface; see §5.1 and review `pullrequestreview-4918028384`.
+surface; see §5.1 and review `pullrequestreview-4918028384`. #10531 continued
+the fold-in behind the pre-existing module-level `@agent/storage` barrel.

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -1,7 +1,15 @@
 /**
- * Execution storage module.
+ * Agent storage — the cross-host public surface of `src/agent/storage`.
  *
- * Provides unified key-value storage for all execution-scoped data.
+ * One curated barrel the hosts (CLI, desktop, extension) import instead of
+ * deep-reaching each storage module by path. Beyond unified key-value storage
+ * for execution-scoped data, this is the curated host boundary for execution
+ * lifecycle and listing, resumability, the `executionLease` lifecycle, and
+ * conversation formatting — decoupling host code from the storage internals'
+ * file layout, per the module-level barrel pattern set by `@agent/runtime`
+ * (#10011). The R-b deep-import width ratchet
+ * (`config/ratchets/host-agent-import-baseline.json`) collapses each host's
+ * many `@agent/storage/*` specifiers to this single door.
  */
 
 export {

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -8,8 +8,9 @@
  * conversation formatting — decoupling host code from the storage internals'
  * file layout, per the module-level barrel pattern set by `@agent/runtime`
  * (#10011). The R-b deep-import width ratchet
- * (`config/ratchets/host-agent-import-baseline.json`) collapses each host's
- * many `@agent/storage/*` specifiers to this single door.
+ * (`config/ratchets/host-agent-import-baseline.json`) records the remaining
+ * host `@agent/storage/*` specifiers — CLI's `conversationFormat` and
+ * `executionLease` — collapsed to this single door.
  */
 
 export {


### PR DESCRIPTION
Follow-up from #10531. Two doc surfaces under-described the widened barrel:

1. `src/agent/storage/index.ts` docstring now states the curated host-boundary role (execution lifecycle/listing, resumability, lease lifecycle, conversation formatting), matching the `@agent/runtime` precedent (#10011).
2. Readiness review §5.1/§6 reconciliation notes now record that `@agent/storage` was already a module-level barrel and #10531 folded its remaining host deep-imports (`executionLease` lifecycle and `conversationFormat`) behind it, leaving `followUp` and `core/definition/AgentConfig` as the open clusters under #10024.

Closes #10538

## Verification

- `corepack pnpm exec prettier --check src/agent/storage/index.ts docs/proposals/2026-08-04-agent-sdk-readiness-review.md` — pass
- `node docs/scripts/check-root-docs.mjs` — pass
- `corepack pnpm run check:guidance-refs` — pass
- `corepack pnpm exec vitest run src/test-kernel/architecture/hostAgentDeepImportRatchet.vitest.ts --config vitest.config.mjs` — 5/5 pass
- `git diff --check` — pass
