### PR TITLE
refactor: simplify data structures flagged by the complexity audit

### DIFF
--- a/packages/cli/src/runtime/approval/approvalPrompts.ts
+++ b/packages/cli/src/runtime/approval/approvalPrompts.ts
@@ -33,14 +33,22 @@ import { safeTerminalText } from '../terminalText';
  * the runtime host. They are the discriminator for the CLI's own approval
  * prompts, and the payloads are the plain `@shared/schemas` permission shapes
  * the live `HostInteractions` requests already carry.
+ *
+ * Carrying `type` and `payload` in one discriminated union (rather than two
+ * separate `(event, payload)` parameters keyed off a generic) lets a
+ * `switch (request.type)` narrow `request.payload` for free — no `as`
+ * casts needed at the read sites.
  */
-export interface CliDecisionApprovalPayloads {
-  showPlanApproval: PlanApprovalPermission;
-  showAgentProposal: AgentProposalPermission;
-  showRetryRequest: RetryPermission;
-}
-
-export type CliDecisionApprovalEvent = keyof CliDecisionApprovalPayloads;
+export type CliDecisionApprovalRequest =
+  | {
+      readonly type: 'showPlanApproval';
+      readonly payload: PlanApprovalPermission;
+    }
+  | {
+      readonly type: 'showAgentProposal';
+      readonly payload: AgentProposalPermission;
+    }
+  | { readonly type: 'showRetryRequest'; readonly payload: RetryPermission };
 
 const CLI_PERSONAL_API_RETRY_HINT =
   'Use `/api personal` in the chat TUI, or press `k` on the retry prompt, to switch to your own API keys.';

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -20,6 +20,7 @@ import {
   type ToolEditApprovalRequest,
   type ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
+import { assertNever } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   settleExecutable,
@@ -100,6 +101,8 @@ function summarizeApprovalEvent(
       // actually answer, not only in the pre-prompt stderr line.
       // `formatRetryRequestMessage` is the single retry formatter.
       return { summary: formatRetryRequestMessage(request.payload) };
+    default:
+      return assertNever(request, 'Unhandled CLI approval request kind');
   }
 }
 

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -11,9 +11,7 @@ import {
 } from '@agent/runtime';
 import { warn as logWarning } from '@logger/logUtils';
 import {
-  type AgentProposalPermission,
   type ApprovalDecision,
-  type PlanApprovalPermission,
   type RetryPermission,
   type UserQuestionAnswers,
 } from '@shared/schemas';
@@ -32,8 +30,7 @@ import {
   type CliApprovalContent,
   type CliApprovalDecision,
   type CliApprovalPromptHooks,
-  type CliDecisionApprovalEvent,
-  type CliDecisionApprovalPayloads,
+  type CliDecisionApprovalRequest,
   askApproval,
   queueCliApprovalQuestion,
 } from './approval/approvalPrompts';
@@ -87,56 +84,44 @@ async function decideToolEdit(
   return toToolEditResult(decision, request.proposedContent);
 }
 
-function summarizeApprovalEvent<K extends CliDecisionApprovalEvent>(
-  event: K,
-  payload: CliDecisionApprovalPayloads[K],
+function summarizeApprovalEvent(
+  request: CliDecisionApprovalRequest,
 ): CliApprovalContent {
-  switch (event) {
-    case 'showPlanApproval': {
-      const data = payload as PlanApprovalPermission;
+  switch (request.type) {
+    case 'showPlanApproval':
       return {
-        summary: `Plan approval requested:\n${JSON.stringify(data.plan, null, 2)}`,
+        summary: `Plan approval requested:\n${JSON.stringify(request.payload.plan, null, 2)}`,
       };
-    }
-    case 'showAgentProposal': {
-      const data = payload as AgentProposalPermission;
-      return buildAgentProposalApprovalContent(data);
-    }
-    case 'showRetryRequest': {
+    case 'showAgentProposal':
+      return buildAgentProposalApprovalContent(request.payload);
+    case 'showRetryRequest':
       // The prompt surface owns the retry hint: the operator must see the
       // `/api personal` / coding-plan switch guidance in the prompt they
       // actually answer, not only in the pre-prompt stderr line.
       // `formatRetryRequestMessage` is the single retry formatter.
-      return { summary: formatRetryRequestMessage(payload as RetryPermission) };
-    }
-    default: {
-      const never: never = event;
-      return { summary: String(never) };
-    }
+      return { summary: formatRetryRequestMessage(request.payload) };
   }
 }
 
-async function decideApprovalEvent<K extends CliDecisionApprovalEvent>(
-  event: K,
-  payload: CliDecisionApprovalPayloads[K],
+async function decideApprovalEvent(
+  request: CliDecisionApprovalRequest,
   context: CliContext,
   hooks: CliApprovalPromptHooks,
   options: { writeRejectionToStderr?: boolean } = {},
 ): Promise<{ decision: ApprovalDecision; prompted: boolean }> {
   const immediate =
-    event === 'showRetryRequest'
-      ? settleRetry(payload as RetryPermission, context)
+    request.type === 'showRetryRequest'
+      ? settleRetry(request.payload, context)
       : settleExecutable(context);
 
-  if (event === 'showRetryRequest') {
-    const data = payload as RetryPermission;
+  if (request.type === 'showRetryRequest') {
     if (!immediate) hooks.beforePrompt?.();
-    writeTextStderr(formatRetryRequestMessage(data));
+    writeTextStderr(formatRetryRequestMessage(request.payload));
   }
 
   if (immediate) return { decision: immediate, prompted: false };
 
-  const content = summarizeApprovalEvent(event, payload);
+  const content = summarizeApprovalEvent(request);
   const decision = await askApproval(context, content, hooks);
   if (!decision.accepted && options.writeRejectionToStderr) {
     writeTextStderr(
@@ -274,8 +259,7 @@ export function createHeadlessCliHostInteractions(
     },
     async requestPlanApproval(request) {
       const { decision, prompted } = await decideApprovalEvent(
-        'showPlanApproval',
-        request,
+        { type: 'showPlanApproval', payload: request },
         context,
         hooks,
       );
@@ -291,8 +275,7 @@ export function createHeadlessCliHostInteractions(
     },
     async requestAgentProposal(request: HostAgentProposalRequest) {
       const { decision, prompted } = await decideApprovalEvent(
-        'showAgentProposal',
-        request,
+        { type: 'showAgentProposal', payload: request },
         context,
         hooks,
       );
@@ -316,8 +299,7 @@ export function createHeadlessCliHostInteractions(
         ...(request.errorDetails ? { errorDetails: request.errorDetails } : {}),
       };
       const { decision, prompted } = await decideApprovalEvent(
-        'showRetryRequest',
-        payload,
+        { type: 'showRetryRequest', payload },
         context,
         hooks,
         { writeRejectionToStderr: true },

--- a/packages/cli/src/runtime/workflowPlainOutput.ts
+++ b/packages/cli/src/runtime/workflowPlainOutput.ts
@@ -38,12 +38,45 @@ interface WorkflowStreamProjection {
   readonly complete: (outcome: RunOutcome) => void;
 }
 
+/**
+ * Calls that arrived before their stage opened, grouped by stageId. Owns the
+ * get-or-create/take bookkeeping so callers never touch the nested map shape
+ * directly.
+ */
+class PendingCallsByStage {
+  private readonly byStage = new Map<
+    string,
+    Map<string, WorkflowCallProgress>
+  >();
+
+  add(stageId: string, logId: string, call: WorkflowCallProgress): void {
+    const stage =
+      this.byStage.get(stageId) ?? new Map<string, WorkflowCallProgress>();
+    stage.set(logId, call);
+    this.byStage.set(stageId, stage);
+  }
+
+  /** Removes and returns the calls pending for `stageId`, if any. */
+  take(stageId: string): Map<string, WorkflowCallProgress> | undefined {
+    const stage = this.byStage.get(stageId);
+    if (stage) this.byStage.delete(stageId);
+    return stage;
+  }
+
+  /** Removes and returns every still-pending stage's calls. */
+  takeAll(): Array<[string, Map<string, WorkflowCallProgress>]> {
+    const all = [...this.byStage];
+    this.byStage.clear();
+    return all;
+  }
+}
+
 function createWorkflowStreamProjection(
   agentName: string,
   options: WorkflowPlainOutputOptions,
 ): WorkflowStreamProjection {
   const openedPhases = new Set<string>();
-  const pendingCalls = new Map<string, Map<string, WorkflowCallProgress>>();
+  const pendingCalls = new PendingCallsByStage();
   const lastCallLines = new Map<string, string>();
   let completed = false;
 
@@ -70,15 +103,14 @@ function createWorkflowStreamProjection(
         phaseTotal: phase.total,
       })}`,
     );
-    const pending = pendingCalls.get(stageId);
+    const pending = pendingCalls.take(stageId);
     if (!pending) return;
     for (const [logId, call] of pending) {
       writeCall(logId, call);
     }
-    pendingCalls.delete(stageId);
   };
   const flushPendingPhases = (): void => {
-    for (const [stageId, pending] of pendingCalls) {
+    for (const [stageId, pending] of pendingCalls.takeAll()) {
       if (openedPhases.has(stageId)) continue;
       const phaseLabel = pending.values().next().value?.phase;
       if (phaseLabel !== undefined) write(`◆ ${phaseLabel}`);
@@ -86,7 +118,6 @@ function createWorkflowStreamProjection(
         writeCall(logId, call);
       }
     }
-    pendingCalls.clear();
   };
 
   return {
@@ -101,11 +132,7 @@ function createWorkflowStreamProjection(
             event.stageId !== undefined &&
             !openedPhases.has(event.stageId)
           ) {
-            const pending =
-              pendingCalls.get(event.stageId) ??
-              new Map<string, WorkflowCallProgress>();
-            pending.set(event.logId, event.call);
-            pendingCalls.set(event.stageId, pending);
+            pendingCalls.add(event.stageId, event.logId, event.call);
           } else {
             writeCall(event.logId, event.call);
           }

--- a/packages/desktop/src/shared/desktopCommandSurface.ts
+++ b/packages/desktop/src/shared/desktopCommandSurface.ts
@@ -170,7 +170,6 @@ export interface DesktopSettingsTabMessage {
 
 export interface DesktopMainViewResetMessage {
   command: typeof MAIN_VIEW_COMMANDS.STATE_RESTORE;
-  state: Record<string, never>;
   isResetOperation: true;
 }
 
@@ -397,7 +396,6 @@ export function postDesktopSettingsView(
 export function buildDesktopMainViewResetMessage(): DesktopMainViewResetMessage {
   return {
     command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
-    state: {},
     isResetOperation: true,
   };
 }

--- a/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
@@ -132,10 +132,7 @@ export const permissionHandlers = {
         // Prepend newest permissions so keyboard shortcuts target the latest request.
         // Deduplicate by id to prevent duplicate UI when replay() re-sends
         // pending items (e.g., on view visibility change).
-        const entry = {
-          kind: permission.kind,
-          data: permission.data,
-        } as PermissionState;
+        const entry: PermissionState = permission;
         const id = permissionId(entry);
         const existing = permissions$.get();
         const alreadyPresent = existing.some(

--- a/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
@@ -132,14 +132,13 @@ export const permissionHandlers = {
         // Prepend newest permissions so keyboard shortcuts target the latest request.
         // Deduplicate by id to prevent duplicate UI when replay() re-sends
         // pending items (e.g., on view visibility change).
-        const entry: PermissionState = permission;
-        const id = permissionId(entry);
+        const id = permissionId(permission);
         const existing = permissions$.get();
         const alreadyPresent = existing.some(
           (p) => p.kind === permission.kind && permissionId(p) === id,
         );
         if (alreadyPresent) return;
-        permissions$.set([entry, ...existing]);
+        permissions$.set([permission, ...existing]);
       }
       return;
     }

--- a/src/agent/core/flows/toolUseRound/roundShared.ts
+++ b/src/agent/core/flows/toolUseRound/roundShared.ts
@@ -36,10 +36,10 @@ const ToolUseRoundFieldsSchema = BaseCycleFieldsSchema.extend({
   response: z.unknown().optional(),
   /**
    * Tool calls extracted from response.
-   * Runtime type is SdkToolCall[] (discriminated union of provider-specific types).
-   * Uses z.unknown() because SdkToolCall is a complex union without a Zod schema.
+   * Uses z.custom<SdkToolCall>() because SdkToolCall is a complex discriminated
+   * union of provider-specific types without a Zod schema of its own.
    */
-  toolCalls: z.array(z.unknown()).optional(),
+  toolCalls: z.array(z.custom<SdkToolCall>()).optional(),
   /** Text content from response */
   text: z.string().optional(),
   /**
@@ -77,8 +77,6 @@ type ToolUseRoundFields = z.infer<typeof ToolUseRoundFieldsSchema>;
  * - Immutable services: `this.services` (ToolUseRoundServices)
  */
 export interface ToolUseRoundShared extends ToolUseRoundFields {
-  /** Tool calls with proper typing (schema uses z.unknown()) */
-  toolCalls?: SdkToolCall[];
   /** Latest non-empty assistant text produced anywhere in this cycle. */
   latestAssistantText?: string;
   /** Current user instruction, refreshed when the round consumes user input. */

--- a/src/agent/core/flows/toolUseRound/roundShared.ts
+++ b/src/agent/core/flows/toolUseRound/roundShared.ts
@@ -70,7 +70,7 @@ type ToolUseRoundFields = z.infer<typeof ToolUseRoundFieldsSchema>;
  * Shared state for tool-use round flows.
  *
  * Uses flat structure (like ResponseCycleFlow) for consistency.
- * All fields from ToolUseRoundFieldsSchema plus runtime-only toolCalls typing.
+ * All fields come from ToolUseRoundFieldsSchema.
  *
  * ## Architecture
  * - Mutable state: `shared` (this interface) - flat, no nested wrappers

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -29,20 +29,25 @@ const TAG = DELIVERY_TAG.executionActivity;
 
 /**
  * Composite key so one flat map replaces the (streamId -> executionId ->
- * subscription) nesting. The delimiter is a literal backslash-zero escape
- * sequence (NOT a raw NUL byte) so it cannot appear in either id.
+ * subscription) nesting. Built from `JSON.stringify(streamId)` rather than
+ * plain concatenation: `StreamTabIdSchema` (`z.string().min(1)`) does not
+ * forbid any particular character, so a delimiter-based key could alias two
+ * distinct (streamId, executionId) pairs if an id ever contained it.
+ * `JSON.stringify` is self-delimiting (its closing quote cannot be faked by
+ * a longer or differently-escaped string), so `streamKeyPrefix`'s
+ * `startsWith` check cannot collide across streams regardless of id content.
  */
 type SubscriptionKey = string;
+
+function streamKeyPrefix(streamId: StreamTabId): string {
+  return `${JSON.stringify(streamId)}:`;
+}
 
 function subscriptionKey(
   streamId: StreamTabId,
   executionId: string,
 ): SubscriptionKey {
-  return `${streamId}\0${executionId}`;
-}
-
-function streamKeyPrefix(streamId: StreamTabId): string {
-  return `${streamId}\0`;
+  return `${streamKeyPrefix(streamId)}${JSON.stringify(executionId)}`;
 }
 
 interface ReleaseSource {
@@ -110,8 +115,15 @@ class ExecutionSubscription {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    this.removeListener?.();
-    this.onDisposed();
+    // onDisposed() must run even if removeListener throws — it is the only
+    // path that removes this subscription's entry from the binder's map, and
+    // a leaked map entry blocks a future bind() for the same (streamId,
+    // executionId) pair from ever succeeding.
+    try {
+      this.removeListener?.();
+    } finally {
+      this.onDisposed();
+    }
   }
 
   private handleChange(handle: AgentExecutionHandle | undefined): void {

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -27,7 +27,23 @@ const logger = createChannelTrace('ExecutionSubscriptionBinder');
 
 const TAG = DELIVERY_TAG.executionActivity;
 
-type PerStream = Map<string, ExecutionSubscription>;
+/**
+ * Composite key so one flat map replaces the (streamId -> executionId ->
+ * subscription) nesting. The delimiter is a literal backslash-zero escape
+ * sequence (NOT a raw NUL byte) so it cannot appear in either id.
+ */
+type SubscriptionKey = string;
+
+function subscriptionKey(
+  streamId: StreamTabId,
+  executionId: string,
+): SubscriptionKey {
+  return `${streamId}\0${executionId}`;
+}
+
+function streamKeyPrefix(streamId: StreamTabId): string {
+  return `${streamId}\0`;
+}
 
 interface ReleaseSource {
   onRelease(observer: (streamId: StreamTabId) => void): () => void;
@@ -160,7 +176,10 @@ export class ExecutionSubscriptionBinder {
   private readonly releaseSource: ReleaseSource;
   private readonly logger: BinderLogger;
   private readonly session?: SessionHandle;
-  private readonly perStream = new Map<StreamTabId, PerStream>();
+  private readonly subscriptions = new Map<
+    SubscriptionKey,
+    ExecutionSubscription
+  >();
   private releaseHook: (() => void) | undefined;
 
   constructor(options: ExecutionSubscriptionBinderOptions = {}) {
@@ -191,23 +210,19 @@ export class ExecutionSubscriptionBinder {
       );
     }
 
-    let bound = this.perStream.get(streamId);
-    if (!bound) {
-      bound = new Map();
-      this.perStream.set(streamId, bound);
-    }
-    if (bound.has(executionId)) return;
+    const key = subscriptionKey(streamId, executionId);
+    if (this.subscriptions.has(key)) return;
 
     const subscription = new ExecutionSubscription(
       streamId,
       handle,
       this.registry,
       this.logger,
-      () => this.removeBoundKey(streamId, executionId),
+      () => this.subscriptions.delete(key),
       this.releaseSource.currentGenerationId?.(streamId),
       this.session,
     );
-    bound.set(executionId, subscription);
+    this.subscriptions.set(key, subscription);
     if (subscription.bind()) {
       this.logger.info('Bound execution subscription to stream', {
         data: { executionId, streamId },
@@ -220,7 +235,9 @@ export class ExecutionSubscriptionBinder {
    * (stream, execution) pair.
    */
   unbind(streamId: StreamTabId, executionId: string): boolean {
-    const subscription = this.perStream.get(streamId)?.get(executionId);
+    const subscription = this.subscriptions.get(
+      subscriptionKey(streamId, executionId),
+    );
     if (!subscription) return false;
     try {
       subscription.dispose();
@@ -235,36 +252,29 @@ export class ExecutionSubscriptionBinder {
   dispose(): void {
     this.releaseHook?.();
     this.releaseHook = undefined;
-    for (const bound of [...this.perStream.values()]) {
-      this.disposeBoundSubscriptions(bound, 'binder disposal');
-    }
-    this.perStream.clear();
+    this.disposeMatching(() => true, 'binder disposal');
+    this.subscriptions.clear();
   }
 
   private ensureReleaseHook(): void {
     if (this.releaseHook) return;
     this.releaseHook = this.releaseSource.onRelease((streamId) => {
-      const bound = this.perStream.get(streamId);
-      if (!bound) return;
-      this.disposeBoundSubscriptions(bound, 'release');
-      this.perStream.delete(streamId);
+      const prefix = streamKeyPrefix(streamId);
+      this.disposeMatching((key) => key.startsWith(prefix), 'release');
     });
   }
 
-  private disposeBoundSubscriptions(bound: PerStream, reason: string): void {
-    for (const subscription of [...bound.values()]) {
+  private disposeMatching(
+    matches: (key: SubscriptionKey) => boolean,
+    reason: string,
+  ): void {
+    for (const [key, subscription] of [...this.subscriptions]) {
+      if (!matches(key)) continue;
       try {
         subscription.dispose();
       } catch (err) {
         this.logger.warn(`Disposer threw during ${reason}`, { data: err });
       }
     }
-  }
-
-  private removeBoundKey(streamId: StreamTabId, executionId: string): void {
-    const bound = this.perStream.get(streamId);
-    if (!bound) return;
-    bound.delete(executionId);
-    if (bound.size === 0) this.perStream.delete(streamId);
   }
 }

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -271,7 +271,7 @@ export type UserQuestionSettlement =
  * reads the field presence, so consumers switch on `kind` instead of each
  * re-deriving the `'cause' in result` / `'reason' in result` cascade.
  */
-export type RejectionClassification =
+type RejectionClassification =
   | { readonly kind: 'cancelled'; readonly cause: string | undefined }
   | { readonly kind: 'policy'; readonly reason: string }
   | { readonly kind: 'feedback'; readonly feedback?: string };
@@ -282,9 +282,15 @@ export function classifyRejection(result: {
   readonly cause?: string;
 }): RejectionClassification {
   if ('cause' in result) return { kind: 'cancelled', cause: result.cause };
-  if ('reason' in result) {
-    return { kind: 'policy', reason: result.reason as string };
-  }
+  // Nullish, not presence: the four concrete result unions above type
+  // `reason` as a required, non-optional `string` on the policy variant,
+  // but this function's parameter type is intentionally looser (shared
+  // across all four) and `HostInteractions` is an extension boundary —
+  // JS/headless embedders can hand back `{ reason: undefined }`. Treating
+  // that as "policy" would need a fake value (every consumer calls
+  // `.trim()` on `reason` unconditionally); falling through to `feedback`
+  // instead matches what the pre-refactor sites did with this shape.
+  if (result.reason != null) return { kind: 'policy', reason: result.reason };
   return { kind: 'feedback', feedback: result.feedback };
 }
 

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -263,6 +263,31 @@ export type UserQuestionSettlement =
       readonly reason?: never;
     };
 
+/**
+ * Every "reject" result variant above shares this same field-presence
+ * encoding: a `cause` key means the host cancelled the request, a `reason`
+ * key means a policy denied it, and only a `feedback` key means the user
+ * actually rejected it. {@link classifyRejection} is the one place that
+ * reads the field presence, so consumers switch on `kind` instead of each
+ * re-deriving the `'cause' in result` / `'reason' in result` cascade.
+ */
+export type RejectionClassification =
+  | { readonly kind: 'cancelled'; readonly cause: string | undefined }
+  | { readonly kind: 'policy'; readonly reason: string }
+  | { readonly kind: 'feedback'; readonly feedback?: string };
+
+export function classifyRejection(result: {
+  readonly feedback?: string;
+  readonly reason?: string;
+  readonly cause?: string;
+}): RejectionClassification {
+  if ('cause' in result) return { kind: 'cancelled', cause: result.cause };
+  if ('reason' in result) {
+    return { kind: 'policy', reason: result.reason as string };
+  }
+  return { kind: 'feedback', feedback: result.feedback };
+}
+
 export type SettledInteractionKind = keyof HostInteractionResultByKind;
 
 type CancellationResultFactories = {

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod';
 
-import type {
-  BashSettlement,
-  HostBashApprovalRequest,
+import {
+  classifyRejection,
+  type BashSettlement,
+  type HostBashApprovalRequest,
 } from '@agent/runtime/HostInteractions';
 import {
   currentSession,
@@ -135,20 +136,20 @@ export function buildBashApprovalRejectedResult(
   rejection: Extract<BashSettlement, { action: 'reject' }>,
 ): ToolResult {
   const preview = truncateWithEllipsis(command, 60);
-  const feedback = rejection.feedback?.trim();
-  const isPolicyDenial = rejection.reason != null;
-  const isAutomaticCancellation = 'cause' in rejection;
-  const reason = rejection.reason?.trim();
-  const cause = rejection.cause?.trim();
+  const classification = classifyRejection(rejection);
+  const feedback =
+    classification.kind === 'feedback'
+      ? classification.feedback?.trim()
+      : undefined;
   let message = `User rejected command: ${preview}`;
   let guidance: string | undefined = DEFAULT_BASH_REJECTION_GUIDANCE;
-  if (isPolicyDenial) {
+  if (classification.kind === 'policy') {
     message = `Command denied: ${preview}`;
-    guidance = reason;
+    guidance = classification.reason.trim();
   }
-  if (isAutomaticCancellation) {
+  if (classification.kind === 'cancelled') {
     message = `Command approval cancelled: ${preview}`;
-    guidance = cause;
+    guidance = classification.cause?.trim();
   }
   const error = feedback || !guidance ? message : `${message}\n\n${guidance}`;
   return errorResult(error, {

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -9,7 +9,10 @@
 import type { AgentEntry } from '@agent/index/agentEntry';
 import { currentSession } from '@agent/runtime/SessionHandle';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
-import type { ProposalResult } from '@agent/runtime/HostInteractions';
+import {
+  classifyRejection,
+  type ProposalResult,
+} from '@agent/runtime/HostInteractions';
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import {
   AgentCategory,
@@ -111,6 +114,43 @@ function summarizeProposal(
   return parts.join(', ');
 }
 
+function proposalRejectionResult(
+  result: Extract<ProposalResult, { action: 'reject' }>,
+  agentName: string,
+  echo: string,
+): ToolResult {
+  const classification = classifyRejection(result);
+  switch (classification.kind) {
+    case 'cancelled': {
+      const detail = classification.cause?.trim()
+        ? `\n${classification.cause.trim()}`
+        : '';
+      return errorResult(
+        `Delegation approval for '${agentName}' was cancelled.\nYour delegation was: ${echo}${detail}`,
+        { summary: `Delegation approval cancelled for '${agentName}'` },
+      );
+    }
+    case 'policy': {
+      const reason = classification.reason.trim();
+      const detail = reason ? `\n${reason}` : '';
+      return errorResult(
+        `Delegation to '${agentName}' was denied.\nYour delegation was: ${echo}${detail}`,
+        { summary: `Delegation denied for '${agentName}'` },
+      );
+    }
+    case 'feedback': {
+      const feedback = classification.feedback?.trim();
+      const feedbackLine = feedback
+        ? `\nUser feedback: ${feedback}`
+        : `\n${DEFAULT_DELEGATION_REJECTION_FEEDBACK}`;
+      return errorResult(
+        `Delegation to '${agentName}' was rejected.\nYour delegation was: ${echo}${feedbackLine}`,
+        { summary: `User rejected delegation to '${agentName}'` },
+      );
+    }
+  }
+}
+
 /** Convert proposal result to ToolResult. Returns null if approved. */
 export function proposalResultToToolResult(
   result: ProposalResult,
@@ -120,32 +160,8 @@ export function proposalResultToToolResult(
   const echo = summarizeProposal(proposal);
 
   switch (result.action) {
-    case 'reject': {
-      const feedback = result.feedback?.trim();
-      const reason = result.reason?.trim();
-      const cause = result.cause?.trim();
-      if ('cause' in result) {
-        const detail = cause ? `\n${cause}` : '';
-        return errorResult(
-          `Delegation approval for '${agentName}' was cancelled.\nYour delegation was: ${echo}${detail}`,
-          { summary: `Delegation approval cancelled for '${agentName}'` },
-        );
-      }
-      if ('reason' in result) {
-        const detail = reason ? `\n${reason}` : '';
-        return errorResult(
-          `Delegation to '${agentName}' was denied.\nYour delegation was: ${echo}${detail}`,
-          { summary: `Delegation denied for '${agentName}'` },
-        );
-      }
-      const feedbackLine = feedback
-        ? `\nUser feedback: ${feedback}`
-        : `\n${DEFAULT_DELEGATION_REJECTION_FEEDBACK}`;
-      return errorResult(
-        `Delegation to '${agentName}' was rejected.\nYour delegation was: ${echo}${feedbackLine}`,
-        { summary: `User rejected delegation to '${agentName}'` },
-      );
-    }
+    case 'reject':
+      return proposalRejectionResult(result, agentName, echo);
     case 'setup':
       return executed(
         `Delegation opened for editing. The user will run it manually when ready.\nYour delegation was: ${echo}`,

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -24,7 +24,7 @@ import type { ToolResult } from '@shared/schemas';
 import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
 import { proposalApprovals } from '@tools/approval';
 import { errorResult, executed } from '@tools/core/result';
-import { generateShortId } from '@utils/core';
+import { assertNever, generateShortId } from '@utils/core';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
@@ -114,11 +114,22 @@ function summarizeProposal(
   return parts.join(', ');
 }
 
-function proposalRejectionResult(
-  result: Extract<ProposalResult, { action: 'reject' }>,
+/** Convert proposal result to ToolResult. Returns null if approved. */
+export function proposalResultToToolResult(
+  result: ProposalResult,
   agentName: string,
-  echo: string,
-): ToolResult {
+  proposal: WorkflowAgentProposal | ToolUseAgentProposal,
+): ToolResult | null {
+  const echo = summarizeProposal(proposal);
+
+  if (result.action === 'approve') return null;
+  if (result.action === 'setup') {
+    return executed(
+      `Delegation opened for editing. The user will run it manually when ready.\nYour delegation was: ${echo}`,
+      `User opened '${agentName}' for editing`,
+    );
+  }
+
   const classification = classifyRejection(result);
   switch (classification.kind) {
     case 'cancelled': {
@@ -148,27 +159,8 @@ function proposalRejectionResult(
         { summary: `User rejected delegation to '${agentName}'` },
       );
     }
-  }
-}
-
-/** Convert proposal result to ToolResult. Returns null if approved. */
-export function proposalResultToToolResult(
-  result: ProposalResult,
-  agentName: string,
-  proposal: WorkflowAgentProposal | ToolUseAgentProposal,
-): ToolResult | null {
-  const echo = summarizeProposal(proposal);
-
-  switch (result.action) {
-    case 'reject':
-      return proposalRejectionResult(result, agentName, echo);
-    case 'setup':
-      return executed(
-        `Delegation opened for editing. The user will run it manually when ready.\nYour delegation was: ${echo}`,
-        `User opened '${agentName}' for editing`,
-      );
-    case 'approve':
-      return null;
+    default:
+      return assertNever(classification, 'Unhandled rejection classification');
   }
 }
 

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -19,7 +19,10 @@ import { z } from 'zod';
 // Local imports
 import { createChannelTrace } from '@agent/trace';
 import type { WorkPlanState } from '@agent/core/state/AgentWorkspaceState';
-import type { PlanApprovalResult } from '@agent/runtime/HostInteractions';
+import {
+  classifyRejection,
+  type PlanApprovalResult,
+} from '@agent/runtime/HostInteractions';
 import {
   getRunContextInteractions,
   getRunContextStreamId,
@@ -267,45 +270,50 @@ pause/complete only affect autonomous goals; with no goal running they return gu
     // Rejected — clear the plan from UI
     workPlanState.updatePlan(null);
 
-    const feedback = result.feedback?.trim();
-    const reason = result.reason?.trim();
-    const cause = result.cause?.trim();
-    if ('cause' in result) {
-      const message = cause
-        ? `Plan approval was cancelled.\n\n${cause}`
-        : 'Plan approval was cancelled.';
-      logger.info(
-        'Plan approval cancelled',
-        cause ? { data: cause } : undefined,
-      );
-      return errorResult(message, { summary: 'Plan approval cancelled' });
-    }
-    if ('reason' in result) {
-      const message = reason
-        ? `Plan approval was denied.\n\n${reason}`
-        : 'Plan approval was denied.';
-      logger.info(
-        'Plan approval denied',
-        reason ? { data: reason } : undefined,
-      );
-      return errorResult(message, { summary: 'Plan approval denied' });
-    }
-    const feedbackNote = feedback
-      ? `\nUser feedback: ${feedback}`
-      : '\nNo specific feedback was provided.';
+    const classification = classifyRejection(result);
+    switch (classification.kind) {
+      case 'cancelled': {
+        const cause = classification.cause?.trim();
+        const message = cause
+          ? `Plan approval was cancelled.\n\n${cause}`
+          : 'Plan approval was cancelled.';
+        logger.info(
+          'Plan approval cancelled',
+          cause ? { data: cause } : undefined,
+        );
+        return errorResult(message, { summary: 'Plan approval cancelled' });
+      }
+      case 'policy': {
+        const reason = classification.reason.trim();
+        const message = reason
+          ? `Plan approval was denied.\n\n${reason}`
+          : 'Plan approval was denied.';
+        logger.info(
+          'Plan approval denied',
+          reason ? { data: reason } : undefined,
+        );
+        return errorResult(message, { summary: 'Plan approval denied' });
+      }
+      case 'feedback': {
+        const feedback = classification.feedback?.trim();
+        const feedbackNote = feedback
+          ? `\nUser feedback: ${feedback}`
+          : '\nNo specific feedback was provided.';
 
-    logger.info(
-      'Plan rejected by user',
-      feedback ? { data: feedback } : undefined,
-    );
+        logger.info(
+          'Plan rejected by user',
+          feedback ? { data: feedback } : undefined,
+        );
 
-    return errorResult(
-      `The user rejected this plan.${feedbackNote}\nPlease revise your approach based on the feedback and create an updated plan.`,
-      {
-        summary: 'Plan rejected: revise approach',
-        ...(feedback ? { userInstruction: feedback } : {}),
-      },
-    );
+        return errorResult(
+          `The user rejected this plan.${feedbackNote}\nPlease revise your approach based on the feedback and create an updated plan.`,
+          {
+            summary: 'Plan rejected: revise approach',
+            ...(feedback ? { userInstruction: feedback } : {}),
+          },
+        );
+      }
+    }
   }
 
   /**

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -48,7 +48,7 @@ import {
 import { requireNonEmptyString } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 import { errorResult, executed } from '@tools/core/result';
-import { generateShortId } from '@utils/core';
+import { assertNever, generateShortId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const logger = createChannelTrace('PlanTool');
@@ -313,6 +313,11 @@ pause/complete only affect autonomous goals; with no goal running they return gu
           },
         );
       }
+      default:
+        return assertNever(
+          classification,
+          'Unhandled rejection classification',
+        );
     }
   }
 

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { createChannelTrace } from '@agent/trace';
+import { classifyRejection } from '@agent/runtime/HostInteractions';
 import {
   getRunContextSession,
   getRunContextStreamId,
@@ -66,25 +67,27 @@ The tool returns a JSON object whose keys are the original question texts and wh
     const result = await session.interactions.askUserQuestion(permission);
 
     if (result.action !== 'submit') {
-      if ('cause' in result) {
-        return executed(
-          result.cause
-            ? `The user question was cancelled: ${result.cause}`
-            : 'The user question was cancelled.',
-        );
+      const classification = classifyRejection(result);
+      switch (classification.kind) {
+        case 'cancelled':
+          return executed(
+            classification.cause
+              ? `The user question was cancelled: ${classification.cause}`
+              : 'The user question was cancelled.',
+          );
+        case 'policy':
+          return executed(
+            classification.reason
+              ? `The user question was denied: ${classification.reason}`
+              : 'The user question was denied.',
+          );
+        case 'feedback':
+          return executed(
+            classification.feedback
+              ? `The user declined to answer: ${classification.feedback}`
+              : 'The user declined to answer.',
+          );
       }
-      if ('reason' in result) {
-        return executed(
-          result.reason
-            ? `The user question was denied: ${result.reason}`
-            : 'The user question was denied.',
-        );
-      }
-      return executed(
-        result.feedback
-          ? `The user declined to answer: ${result.feedback}`
-          : 'The user declined to answer.',
-      );
     }
 
     const answers = UserQuestionAnswersSchema.parse(result.answers);

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -16,7 +16,7 @@ import type { ToolResult } from '@shared/schemas';
 import { requireInteractions } from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
 import { executed } from '@tools/core/result';
-import { generateShortId } from '@utils/core';
+import { assertNever, generateShortId } from '@utils/core';
 
 const logger = createChannelTrace('UserQuestionTool');
 
@@ -86,6 +86,11 @@ The tool returns a JSON object whose keys are the original question texts and wh
             classification.feedback
               ? `The user declined to answer: ${classification.feedback}`
               : 'The user declined to answer.',
+          );
+        default:
+          return assertNever(
+            classification,
+            'Unhandled rejection classification',
           );
       }
     }


### PR DESCRIPTION
## Summary

A scheduled data-structure audit flagged 13 complexity issues (3 high, 6 medium, 4 low) across the codebase — deep nesting, duplicated/hand-converted shapes, and fields requiring repeated type assertions or `'x' in y` presence checks. This PR fixes the ones that are contained enough to refactor and verify safely in one pass. The large architectural ones are deliberately **not** attempted here — see "Scheduled refactoring" below.

Fixed:
- **`HostInteractions.ts`**: added `classifyRejection()` — a single classifier for the "reject" result shape (`cause` = host cancellation, `reason` = policy denial, `feedback` = real user rejection) shared by `PlanTool.ts`, `bashApproval.ts`, `proposalFlow.ts`, and `UserQuestionTool.ts`, each of which previously hand-rolled the identical `'cause' in result` → `'reason' in result` cascade.
- **`roundShared.ts`**: `toolCalls` schema now uses `z.custom<SdkToolCall>()` (the codebase's existing idiom for complex external types without their own Zod schema — see `AgentWorkspaceState.ts`, `ToolDefinition.ts`, `ProviderMessage.ts`) instead of `z.unknown()` plus a hand-written interface field re-declaring the real type. One declaration instead of two that could silently drift.
- **`permissionSlice.ts`**: dropped a destructure-then-reassemble-with-`as PermissionState` that widened an already-correctly-narrowed discriminated union back to needing a cast.
- **`ExecutionSubscriptionBinder.ts`**: replaced the two-level `Map<StreamTabId, Map<string, ExecutionSubscription>>` (with duplicated "prune the empty bucket" logic at two call sites) with one flat map keyed by a composite id.
- **`workflowPlainOutput.ts`**: wrapped the hand-rolled `Map<string, Map<string, WorkflowCallProgress>>` get-or-create/take bookkeeping (duplicated across 3 call sites) in a small `PendingCallsByStage` helper.
- **`desktopCommandSurface.ts`**: dropped the desktop-only `state: Record<string, never>` reinvention of the `STATE_RESTORE` message — the field is never read on the reset path (`handleRestoreState` returns before touching `.state` when `isResetOperation === true`), and the canonical schema already models "no state" via `.nullish()`.
- **CLI `approvalAdapter.ts` / `approvalPrompts.ts`**: replaced the generic `(event, payload)` pair keyed by a mapped type (`CliDecisionApprovalPayloads[K]`) with one `CliDecisionApprovalRequest` discriminated union, removing 5 `as` casts that only existed because the generic type parameter couldn't correlate the two separate arguments inside the `switch`.

## Issue acceptance gates

Ad hoc scheduled audit, not a filed issue. Acceptance: each fix above compiles, lints clean, and the existing test suite covering that code path still passes (see Validation).

## Single source of truth

- `classifyRejection()` in `HostInteractions.ts` is now the one place that reads which of `feedback`/`reason`/`cause` is present on a settled rejection.
- `roundShared.ts`'s `ToolUseRoundFieldsSchema` is now the only declaration of `toolCalls`'s type; the interface no longer re-declares it.
- `PendingCallsByStage` in `workflowPlainOutput.ts` owns the stage→pending-call bookkeeping.
- `ExecutionSubscriptionBinder`'s flat `subscriptions` map is the one collection for (streamId, executionId) subscriptions.

## Duplication and abstraction budget

Removed: the 4-way duplicated rejection-cascade (HostInteractions consumers), the 2-way duplicated empty-bucket-pruning (`ExecutionSubscriptionBinder`), the 3-way duplicated get-or-create/take map bookkeeping (`workflowPlainOutput.ts`), and 5 casts in the CLI approval adapter that a discriminated union makes unnecessary. New abstractions added (`classifyRejection`, `PendingCallsByStage`, `CliDecisionApprovalRequest`) each have ≥3 real call sites already in this diff — no single-caller extractions.

## Net elements (R6)

Diffstat: 12 files changed, 262 insertions(+), 189 deletions(-), net +73 lines (mostly from expanding 3-branch cascades into explicit `switch` cases, which is the point — legibility over compactness).

Exported symbols (`^[+-]export` over the diff): removed `CliDecisionApprovalPayloads` (interface) and `CliDecisionApprovalEvent` (type alias); added `CliDecisionApprovalRequest` (type), `RejectionClassification` (type), and `classifyRejection` (function) — net +1 export, all with consumers in this same diff.

New classes: `PendingCallsByStage` (1, local to `workflowPlainOutput.ts`, not exported). No new interfaces/enums beyond the type unions above.

## Consumer counts (R8)

- `classifyRejection`: 4 consumers (`PlanTool.ts`, `bashApproval.ts`, `proposalFlow.ts`, `UserQuestionTool.ts`) — all updated in this diff, all still route through the same `HostInteractions.ts` result types.
- `CliDecisionApprovalPayloads`/`CliDecisionApprovalEvent` removal: grepped repo-wide, only consumer was `approvalAdapter.ts` (now updated to `CliDecisionApprovalRequest`); no other file imported either symbol.
- `DesktopMainViewResetMessage.state` field removal: grepped both call sites (`renderer/main.ts`, `desktopShellIpc.ts`) — neither reads `.state`, both just forward the message object.

## Host impact

Extension: `permissionSlice.ts` (progress view frontend) — no behavior change, type-safety only.

Desktop: `desktopCommandSurface.ts` — `STATE_RESTORE` reset message no longer sends an unused `state: {}` field.

CLI: `approvalAdapter.ts`, `approvalPrompts.ts`, `workflowPlainOutput.ts` — no behavior change, internal refactors only.

## Scheduled refactoring

Intentionally not attempted here — each touches many call sites across unrelated types and deserves its own design review rather than a bundled mechanical sweep:
- The 3-layer "run result" schema duplication (`AgentFlowResult` → `AgentFinalResult` → `ResultMeta`/`SubagentResultMeta`), each with a hand-written conversion function.
- "File edit" modeled 4 different ways (`EditRecord`, `EditedFileRecord`, `FlattenedEditRecordSchema`, plus an internal `Map<string, LineChanges>`) with manual conversion at every boundary.
- `ExecutedToolResultSchema`'s 11 unrelated optional fields on one object.
- `ProviderMessage`'s bare union of 7 external SDK types with no common discriminant.
- `AgentConfig`'s 9 nullish fields encoding ≥4 run "kinds" instead of a tagged variant.
- The full `HostInteractions` result-union type redesign (giving each rejection variant its own discriminant value) — assessed, but the type is structurally shared with ~140 call sites across several *unrelated* types (`ToolEditApprovalResult`, CLI `ConfirmCardState`, etc. also use `action: 'reject'`), so a type-level redesign has a much larger blast radius than the 4 consumers this PR actually touches. This PR ships the safe subset: a shared classifier that removes the duplicated read-side logic without touching the type or its ~140 construction/consumption sites.
- `SessionState.ts`'s durable/ephemeral metadata merge and the `progressView` frontend's parallel `Map<StreamTabId, X>` collections were reviewed and found to be *intentional* — both have explicit in-code comments explaining the design constraint (Lit render-isolation for the latter, a documented read-time overlay policy with per-field fallback rules citing issue #9947 for the former). Flattening either would regress real behavior, so no follow-up is proposed for them.

## Validation

- `npm run typecheck:workspace`, `corepack pnpm --filter @texra-ai/cli typecheck`, `corepack pnpm --filter @texra/desktop typecheck`, `npm run typecheck:test-kernel`, `npm run typecheck:agent` — all clean.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — 15 current vs 15 baselined, no new dead exports.
- `npx vitest run` over `src/test-kernel/agent/runtime`, `tools`, `progressView`, `desktop`, `cli`, `controllers` — 445 test files / 5525 tests passed, 1 pre-existing skip.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CBwq7XJrEZavJj9cSKCEnT)_