### PR TITLE
fix(tui): finish static-transcript ring follow-ups

### DIFF
--- a/.claude/skills/texra-cli/SKILL.md
+++ b/.claude/skills/texra-cli/SKILL.md
@@ -29,7 +29,8 @@ search, and mouse-scroll for finalized history, so don't reinvent them.
   mouse-scroll keep working. Never render a finalized root turn in the root live
   region, and never reprint root `<Static>` items unless the repaint starts from
   a known origin — dedupe by the entry's own stable id, not a stream-scoped key
-  (see `appendStaticTranscriptItems`). Focused child streams are separate
+  (see `buildStaticTranscriptItems` for the rebuild oracle and
+  `advanceStaticTranscriptState` for the incremental path). Focused child streams are separate
   viewports that temporarily select the child as the `<Static>` scrollback
   owner; root and child histories must not share append-only Static state.
 

--- a/docs/proposals/2026-07-03-ink-practices-from-claude-code.md
+++ b/docs/proposals/2026-07-03-ink-practices-from-claude-code.md
@@ -336,8 +336,9 @@ one ~60fps frame and the microtask defer ensures layout effects commit first (cu
 a keystroke).
 Evidence: `ink/ink.tsx:203-216,237-238`, `ink/constants.ts:1-2`, `ink/reconciler.ts:303-315`.
 **TeXRA:** Inherited from Ink's scheduler; TeXRA additionally avoids unnecessary ticks
-(`useLiveNowMs.ts:1-14` ticks 1s only when needed; `appendStaticTranscriptItems` returns the
-same array ref when nothing appended — `StaticConversationTranscript.tsx:220-222`). TeXRA's
+(`useLiveNowMs.ts:1-14` ticks 1s only when needed; `buildStaticTranscriptItems` /
+`advanceStaticTranscriptState` keep the retained items stable when nothing appended —
+`StaticConversationTranscript.tsx`). TeXRA's
 instinct here is correct.
 
 **Peephole-optimize the patch stream before writing (merge cursor moves, dedupe hyperlinks, cancel hide/show).**

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -11,6 +11,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
 
 import { render } from 'ink';
 import { nanoid } from 'nanoid';
@@ -1926,7 +1927,7 @@ if (SHOW_EDIT_APPROVAL) {
     );
 
   if (EDIT_APPROVAL_DELAY_MS > 0) {
-    setTimeout(showApproval, EDIT_APPROVAL_DELAY_MS);
+    globalThis.setTimeout(showApproval, EDIT_APPROVAL_DELAY_MS);
   } else {
     showApproval();
   }
@@ -2476,12 +2477,17 @@ if (SHOW_TERMINAL_RESUME_REPAINT) {
     // Let the first static-transcript commit flush, then exercise the same
     // SIGCONT repair path the real session-exit controller uses. The epoch
     // remounts <Static> and repaints with replace semantics.
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await setTimeout(0);
     await ink.waitUntilRenderFlush();
     viewportController.repaintAfterTerminalResume();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await setTimeout(0);
     await ink.waitUntilRenderFlush();
-  })();
+  })().catch((error) => {
+    process.stderr.write(
+      `[tui-harness] HARNESS_TERMINAL_RESUME_REPAINT failed: ${toErrorMessage(error)}\n`,
+    );
+    void exitHarness(1);
+  });
 }
 
 if (CHILD_EVENT_ORDER || SHOW_WORKFLOW_TIMELINE || SHOW_WORKFLOW_RUNNING) {

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -32,7 +32,6 @@ import { streamViewForId } from '../state/streamViews';
 import { useSignal } from '../state/useSignal';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
 import {
-  EMPTY_TRANSCRIPT_ENTRIES,
   incrementalStaticTranscriptEntries,
   orderedStaticTranscriptEntries,
   type StaticTranscriptScanCursor,
@@ -58,13 +57,17 @@ export type StaticTranscriptItem =
       readonly entry: ConversationEntry;
     };
 
-interface StaticTranscriptState {
+export interface StaticTranscriptState {
   readonly ownerKey: string;
   readonly items: readonly StaticTranscriptItem[];
   /** Cumulative row/byte estimates for `items`, maintained incrementally. */
   readonly rowCount: number;
   readonly byteCount: number;
   readonly scan: StaticTranscriptScanCursor;
+  /** The layout width `rowCount`/`byteCount` were measured under. */
+  readonly layoutWidth: number | undefined;
+  /** The execution labels `rowCount`/`byteCount` were measured under. */
+  readonly executionLabels: ExecutionLabels | undefined;
   /** Incremented whenever items change non-append-only (trim, header insert,
    *  hard reset, fold rebuild) so the `<Static>` identity remounts and
    *  `onRenderKeyChange` repaints the bounded tail with replace semantics. */
@@ -223,9 +226,13 @@ interface StaticTranscriptItemMetrics {
   readonly bytes: number;
 }
 
-/** Row count plus a conservative UTF-8 byte estimate for one static item.
- *  Entry metrics come from the same `scrollback-budget` layout the row budget
- *  uses, so the ring never pays for a second full layout pass. */
+/** Row count plus an estimated UTF-8 byte footprint for one static item.
+ *  Assistant rows include the ANSI Markdown wrappers `<Static>` will render;
+ *  the other roles sum plain layout lines without those wrappers, so the byte
+ *  figure is an estimate rather than an upper bound. The header's fixed `+64`
+ *  is a floor for its chrome, not a bound. Entry metrics come from the same
+ *  `scrollback-budget` layout the row budget uses, so the ring never pays for
+ *  a second full layout pass. */
 function staticTranscriptItemMetrics(
   item: StaticTranscriptItem,
   width?: number,
@@ -318,6 +325,7 @@ export function trimStaticTranscriptItems(
   const nextItems = [...items];
   const totals = { ...options.totals };
   const headerCount = nextItems[0]?.kind === 'header' ? 1 : 0;
+  let removedAny = false;
   while (
     nextItems.length > headerCount + 1 &&
     (totals.rows > budgets.rowLowWater || totals.bytes > budgets.byteLowWater)
@@ -358,9 +366,123 @@ export function trimStaticTranscriptItems(
     } else {
       nextItems.splice(removedIndex, 1);
     }
+    removedAny = true;
   }
 
-  return { items: nextItems, totals, trimmed: true };
+  return { items: nextItems, totals, trimmed: removedAny };
+}
+
+/**
+ * Retained ring tail for a fresh rebuild without laying out the discarded
+ * prefix. Walk backward from the newest item until the candidate tail crosses
+ * the high-water mark (proving a trim is needed), then hand that bounded tail
+ * to {@link trimStaticTranscriptItems} for the low-water pass. When the whole
+ * list already fits the high-water mark this returns it unchanged and pays
+ * for its full layout, which the caller needs for the retained totals anyway.
+ */
+function retainedStaticTranscriptTail(
+  items: readonly StaticTranscriptItem[],
+  options: {
+    readonly budgets?: StaticTranscriptRingBudgets;
+    readonly executionLabels?: ExecutionLabels;
+    readonly width?: number;
+  },
+): {
+  readonly items: readonly StaticTranscriptItem[];
+  readonly totals: StaticTranscriptTotals;
+  readonly trimmed: boolean;
+} {
+  if (items.length === 0) {
+    return { items, totals: { rows: 0, bytes: 0 }, trimmed: false };
+  }
+  const budgets = options.budgets ?? DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS;
+  const headerCount = items[0]?.kind === 'header' ? 1 : 0;
+  if (items.length <= headerCount) {
+    const totals = staticTranscriptItemsTotals(
+      items,
+      options.width,
+      options.executionLabels,
+    );
+    return { items, totals, trimmed: false };
+  }
+
+  const headerItem = headerCount > 0 ? items[0] : undefined;
+  const headerMetrics =
+    headerItem !== undefined
+      ? staticTranscriptItemMetrics(
+          headerItem,
+          options.width,
+          options.executionLabels,
+        )
+      : { rows: 0, bytes: 0 };
+  let start = items.length - 1;
+  const newest = items[start];
+  let firstMetrics =
+    newest === undefined
+      ? { rows: 0, bytes: 0 }
+      : staticTranscriptItemMetrics(
+          newest,
+          options.width,
+          options.executionLabels,
+          headerItem,
+        );
+  let totals = {
+    rows: headerMetrics.rows + firstMetrics.rows,
+    bytes: headerMetrics.bytes + firstMetrics.bytes,
+  };
+  let trimNeeded =
+    totals.rows > budgets.rowHighWater || totals.bytes > budgets.byteHighWater;
+
+  while (!trimNeeded && start > headerCount) {
+    const candidate = items[start - 1];
+    if (candidate === undefined) break;
+    const candidateMetrics = staticTranscriptItemMetrics(
+      candidate,
+      options.width,
+      options.executionLabels,
+      headerItem,
+    );
+    const oldFirst = items[start];
+    if (oldFirst === undefined) break;
+    const oldFirstAfterCandidate = staticTranscriptItemMetrics(
+      oldFirst,
+      options.width,
+      options.executionLabels,
+      candidate,
+    );
+    totals = {
+      rows:
+        totals.rows -
+        firstMetrics.rows +
+        oldFirstAfterCandidate.rows +
+        candidateMetrics.rows,
+      bytes:
+        totals.bytes -
+        firstMetrics.bytes +
+        oldFirstAfterCandidate.bytes +
+        candidateMetrics.bytes,
+    };
+    firstMetrics = candidateMetrics;
+    start -= 1;
+    trimNeeded =
+      totals.rows > budgets.rowHighWater ||
+      totals.bytes > budgets.byteHighWater;
+  }
+
+  if (!trimNeeded) {
+    return { items, totals, trimmed: false };
+  }
+
+  const candidateItems =
+    headerItem !== undefined
+      ? [headerItem, ...items.slice(start)]
+      : items.slice(start);
+  return trimStaticTranscriptItems(candidateItems, {
+    budgets,
+    executionLabels: options.executionLabels,
+    totals,
+    width: options.width,
+  });
 }
 
 function shouldWaitForChildIdentity({
@@ -629,25 +751,17 @@ export function buildStaticTranscriptItems(
   }
 
   const items = nextItems ?? currentItems;
-  const totals = staticTranscriptItemsTotals(items, width, executionLabels);
-  const trimmed = trimStaticTranscriptItems(items, {
+  const retained = retainedStaticTranscriptTail(items, {
     budgets: ringBudgets,
     executionLabels,
-    totals,
     width,
   });
   return {
-    items: trimmed.items,
-    rowCount: trimmed.totals.rows,
-    byteCount: trimmed.totals.bytes,
-    trimmed: trimmed.trimmed,
+    items: retained.items,
+    rowCount: retained.totals.rows,
+    byteCount: retained.totals.bytes,
+    trimmed: retained.trimmed,
   };
-}
-
-export function appendStaticTranscriptItems(
-  options: AppendStaticTranscriptItemsOptions,
-): readonly StaticTranscriptItem[] {
-  return buildStaticTranscriptItems(options).items;
 }
 
 function StaticTranscriptItemContent({
@@ -702,7 +816,7 @@ function scanStaticTranscriptFromStart(
   }).cursor;
 }
 
-function buildStaticTranscriptState({
+export function buildStaticTranscriptState({
   childStreamEntries,
   executionLabels,
   maxRows,
@@ -710,6 +824,7 @@ function buildStaticTranscriptState({
   ownerKey,
   parentStream,
   repaintEpoch,
+  ringBudgets = DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS,
   scrollbackStreamId,
   streams,
   width,
@@ -721,6 +836,7 @@ function buildStaticTranscriptState({
   readonly ownerKey: string;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly repaintEpoch: number;
+  readonly ringBudgets?: StaticTranscriptRingBudgets;
   readonly scrollbackStreamId: StreamTabId | undefined;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly width?: number;
@@ -733,16 +849,18 @@ function buildStaticTranscriptState({
     meta,
     maxRows,
     parentStream,
+    ringBudgets,
     scrollbackStreamId,
     width,
   });
   const slice = scrollbackStreamId
     ? streams.get(scrollbackStreamId)
     : undefined;
-  // While a focused child has no model yet, appendStaticTranscriptItems
-  // intentionally holds both the header and entries. Keep the scan cursor at
-  // zero in that state so the entries are still pending when the model
-  // arrives; scanning them now would mark them consumed and drop them later.
+  // While a focused child has no model yet, buildStaticTranscriptItems
+  // intentionally holds neither the header nor entries. Keep the scan cursor
+  // at zero with the current entries reference so the entries are still
+  // pending when the model arrives; scanning them now would mark them
+  // consumed and drop them later.
   const waitingForChildIdentity = shouldWaitForChildIdentity({
     currentItems: [],
     parentStream,
@@ -762,7 +880,215 @@ function buildStaticTranscriptState({
     rowCount: built.rowCount,
     byteCount: built.byteCount,
     scan,
+    layoutWidth: width,
+    executionLabels,
     repaintEpoch,
+  };
+}
+
+export function advanceStaticTranscriptState(
+  current: StaticTranscriptState,
+  {
+    childStreamEntries,
+    executionLabels,
+    maxRows,
+    meta,
+    ownerKey,
+    parentStream,
+    ringBudgets = DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS,
+    scrollbackStreamId,
+    streams,
+    width,
+  }: {
+    readonly childStreamEntries: ChildStreamEntries;
+    readonly executionLabels?: ExecutionLabels;
+    readonly maxRows?: number;
+    readonly meta: SessionMeta;
+    readonly ownerKey: string;
+    readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+    readonly ringBudgets?: StaticTranscriptRingBudgets;
+    readonly scrollbackStreamId: StreamTabId | undefined;
+    readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+    readonly width: number;
+  },
+): StaticTranscriptState {
+  const isHardReset = streams.size === 0 && scrollbackStreamId === undefined;
+  const slice = scrollbackStreamId
+    ? streams.get(scrollbackStreamId)
+    : undefined;
+  const entries: readonly ConversationEntry[] = slice?.entries ?? [];
+  const status = slice?.status;
+
+  if (isHardReset) {
+    return buildStaticTranscriptState({
+      childStreamEntries,
+      executionLabels,
+      maxRows,
+      meta,
+      ownerKey,
+      parentStream,
+      repaintEpoch: current.repaintEpoch + 1,
+      ringBudgets,
+      scrollbackStreamId,
+      streams,
+      width,
+    });
+  }
+
+  if (current.ownerKey !== ownerKey) {
+    return buildStaticTranscriptState({
+      childStreamEntries,
+      executionLabels,
+      maxRows,
+      meta,
+      ownerKey,
+      parentStream,
+      repaintEpoch: current.repaintEpoch,
+      ringBudgets,
+      scrollbackStreamId,
+      streams,
+      width,
+    });
+  }
+
+  if (
+    shouldWaitForChildIdentity({
+      currentItems: current.items,
+      parentStream,
+      scrollbackStreamId,
+      streams,
+    })
+  ) {
+    return current;
+  }
+
+  const layoutChanged =
+    width !== current.layoutWidth ||
+    executionLabels !== current.executionLabels;
+  let nextItems = current.items;
+  let nextRowCount = current.rowCount;
+  let nextByteCount = current.byteCount;
+  let nextRepaintEpoch = current.repaintEpoch;
+  let changed = layoutChanged;
+
+  if (layoutChanged) {
+    const recomputed = staticTranscriptItemsTotals(
+      nextItems,
+      width,
+      executionLabels,
+    );
+    const trimmed = trimStaticTranscriptItems(nextItems, {
+      budgets: ringBudgets,
+      executionLabels,
+      totals: recomputed,
+      width,
+    });
+    nextItems = trimmed.items;
+    nextRowCount = trimmed.totals.rows;
+    nextByteCount = trimmed.totals.bytes;
+    if (trimmed.trimmed) {
+      nextRepaintEpoch += 1;
+    }
+  }
+
+  const plan = incrementalStaticTranscriptEntries(
+    entries,
+    status,
+    current.scan,
+  );
+  if (plan.rebuild) {
+    return buildStaticTranscriptState({
+      childStreamEntries,
+      executionLabels,
+      maxRows,
+      meta,
+      ownerKey,
+      parentStream,
+      repaintEpoch: current.repaintEpoch + 1,
+      ringBudgets,
+      scrollbackStreamId,
+      streams,
+      width,
+    });
+  }
+
+  const header = ensureStaticSessionHeader({
+    byteCount: nextByteCount,
+    childStreamEntries,
+    executionLabels,
+    items: nextItems,
+    maxRows,
+    meta,
+    parentStream,
+    rowCount: nextRowCount,
+    scrollbackStreamId,
+    streams,
+    width,
+  });
+  if (header.inserted) {
+    nextItems = header.items;
+    nextRowCount = header.rowCount;
+    nextByteCount = header.byteCount;
+    nextRepaintEpoch += 1;
+    changed = true;
+  }
+
+  let previousItem = nextItems.at(-1);
+  if (plan.appended.length > 0) {
+    const seenIds = new Set(nextItems.map((item) => item.id));
+    for (const entry of plan.appended) {
+      if (seenIds.has(entry.id)) continue;
+      const item: StaticTranscriptItem = {
+        id: entry.id,
+        kind: 'entry',
+        entry,
+      };
+      const metrics = staticTranscriptItemMetrics(
+        item,
+        width,
+        executionLabels,
+        previousItem,
+      );
+      nextRowCount += metrics.rows;
+      nextByteCount += metrics.bytes;
+      nextItems = [...nextItems, item];
+      previousItem = item;
+      seenIds.add(entry.id);
+      changed = true;
+    }
+  }
+
+  const trimmed = trimStaticTranscriptItems(nextItems, {
+    budgets: ringBudgets,
+    executionLabels,
+    totals: { rows: nextRowCount, bytes: nextByteCount },
+    width,
+  });
+  if (trimmed.trimmed) {
+    nextItems = trimmed.items;
+    nextRowCount = trimmed.totals.rows;
+    nextByteCount = trimmed.totals.bytes;
+    nextRepaintEpoch += 1;
+    changed = true;
+  }
+
+  const cursor = plan.cursor;
+  const cursorChanged =
+    cursor.entriesRef !== current.scan.entriesRef ||
+    cursor.scannedIndex !== current.scan.scannedIndex ||
+    cursor.lastScannedEntry !== current.scan.lastScannedEntry ||
+    cursor.status !== current.scan.status;
+  if (!changed && !cursorChanged) return current;
+
+  return {
+    ownerKey,
+    items: nextItems,
+    rowCount: nextRowCount,
+    byteCount: nextByteCount,
+    scan: cursor,
+    layoutWidth: width,
+    executionLabels,
+    repaintEpoch: nextRepaintEpoch,
   };
 }
 
@@ -822,144 +1148,20 @@ export function StaticConversationTranscript({
   const items = state.ownerKey === ownerKey ? state.items : buildFreshItems();
 
   useEffect(() => {
-    // On a hard reset (e.g. /clear, picker-to-chat handoff) start the
-    // items list from scratch so the header is the first thing the user
-    // sees after the scrollback was wiped. A scrollback-owner switch also
-    // starts from scratch because root and child histories must not share
-    // append-only Static state.
-    const isHardReset = streams.size === 0 && scrollbackStreamId === undefined;
-    const slice = scrollbackStreamId
-      ? streams.get(scrollbackStreamId)
-      : undefined;
-    const entries = slice?.entries ?? EMPTY_TRANSCRIPT_ENTRIES;
-    const status = slice?.status;
-
-    setState((current) => {
-      const ownerChanged = current.ownerKey !== ownerKey;
-      if (isHardReset || ownerChanged) {
-        return buildStaticTranscriptState({
-          childStreamEntries,
-          executionLabels: subagentExecutionLabels,
-          maxRows,
-          meta: sessionMeta,
-          ownerKey,
-          parentStream,
-          repaintEpoch: current.repaintEpoch + 1,
-          scrollbackStreamId,
-          streams,
-          width: normalizedWidth,
-        });
-      }
-
-      if (
-        shouldWaitForChildIdentity({
-          currentItems: current.items,
-          parentStream,
-          scrollbackStreamId,
-          streams,
-        })
-      ) {
-        return current;
-      }
-
-      const plan = incrementalStaticTranscriptEntries(
-        entries,
-        status,
-        current.scan,
-      );
-      if (plan.rebuild) {
-        return buildStaticTranscriptState({
-          childStreamEntries,
-          executionLabels: subagentExecutionLabels,
-          maxRows,
-          meta: sessionMeta,
-          ownerKey,
-          parentStream,
-          repaintEpoch: current.repaintEpoch + 1,
-          scrollbackStreamId,
-          streams,
-          width: normalizedWidth,
-        });
-      }
-
-      let nextItems = current.items;
-      let nextRowCount = current.rowCount;
-      let nextByteCount = current.byteCount;
-      let nextRepaintEpoch = current.repaintEpoch;
-      let changed = false;
-
-      const header = ensureStaticSessionHeader({
-        byteCount: nextByteCount,
+    setState((current) =>
+      advanceStaticTranscriptState(current, {
         childStreamEntries,
         executionLabels: subagentExecutionLabels,
-        items: nextItems,
         maxRows,
         meta: sessionMeta,
+        ownerKey,
         parentStream,
-        rowCount: nextRowCount,
+        ringBudgets: DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS,
         scrollbackStreamId,
         streams,
         width: normalizedWidth,
-      });
-      if (header.inserted) {
-        nextItems = header.items;
-        nextRowCount = header.rowCount;
-        nextByteCount = header.byteCount;
-        nextRepaintEpoch += 1;
-        changed = true;
-      }
-
-      let previousItem = nextItems.at(-1);
-      for (const entry of plan.appended) {
-        const item: StaticTranscriptItem = {
-          id: entry.id,
-          kind: 'entry',
-          entry,
-        };
-        const metrics = staticTranscriptItemMetrics(
-          item,
-          normalizedWidth,
-          subagentExecutionLabels,
-          previousItem,
-        );
-        nextRowCount += metrics.rows;
-        nextByteCount += metrics.bytes;
-        nextItems = [...nextItems, item];
-        previousItem = item;
-        changed = true;
-      }
-
-      const trimmed = trimStaticTranscriptItems(nextItems, {
-        budgets: DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS,
-        executionLabels: subagentExecutionLabels,
-        totals: { rows: nextRowCount, bytes: nextByteCount },
-        width: normalizedWidth,
-      });
-      if (trimmed.trimmed) {
-        nextItems = trimmed.items;
-        nextRowCount = trimmed.totals.rows;
-        nextByteCount = trimmed.totals.bytes;
-        nextRepaintEpoch += 1;
-        changed = true;
-      }
-
-      const cursor = plan.cursor;
-      const cursorChanged =
-        cursor.entriesRef !== current.scan.entriesRef ||
-        cursor.scannedIndex !== current.scan.scannedIndex ||
-        cursor.lastScannedEntry !== current.scan.lastScannedEntry ||
-        cursor.status !== current.scan.status;
-      if (!changed && !cursorChanged) return current;
-
-      return {
-        ownerKey,
-        items: nextItems,
-        rowCount: nextRowCount,
-        byteCount: nextByteCount,
-        scan: cursor,
-        repaintEpoch: nextRepaintEpoch,
-      };
-    });
+      }),
+    );
   }, [
     childStreamEntries,
     maxRows,

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -485,6 +485,23 @@ function retainedStaticTranscriptTail(
   });
 }
 
+/** The execution-label map is a `computed()` signal that can return a fresh
+ *  `Map` for unrelated child-roster churn (elapsed timers, active/inactive
+ *  flips). Only a content change affects transcript layout, so compare the
+ *  label projection semantically instead of by reference. */
+function executionLabelsEqual(
+  left: ExecutionLabels | undefined,
+  right: ExecutionLabels | undefined,
+): boolean {
+  if (left === right) return true;
+  if (left === undefined || right === undefined) return false;
+  if (left.size !== right.size) return false;
+  for (const [key, value] of left) {
+    if (right.get(key) !== value) return false;
+  }
+  return true;
+}
+
 function shouldWaitForChildIdentity({
   currentItems,
   parentStream,
@@ -964,7 +981,7 @@ export function advanceStaticTranscriptState(
 
   const layoutChanged =
     width !== current.layoutWidth ||
-    executionLabels !== current.executionLabels;
+    !executionLabelsEqual(executionLabels, current.executionLabels);
   let nextItems = current.items;
   let nextRowCount = current.rowCount;
   let nextByteCount = current.byteCount;

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -707,7 +707,7 @@ function ensureStaticSessionHeader({
   };
 }
 
-interface AppendStaticTranscriptItemsOptions {
+interface BuildStaticTranscriptItemsOptions {
   readonly currentItems: readonly StaticTranscriptItem[];
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly childStreamEntries?: ChildStreamEntries;
@@ -731,7 +731,7 @@ interface StaticTranscriptBuildResult {
  *  hard reset, and fold rebuild; ordinary ticks use the incremental scan in
  *  {@link incrementalStaticTranscriptEntries}. */
 export function buildStaticTranscriptItems(
-  options: AppendStaticTranscriptItemsOptions,
+  options: BuildStaticTranscriptItemsOptions,
 ): StaticTranscriptBuildResult {
   const {
     currentItems,

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -41,6 +41,7 @@ import {
   transcriptColumns,
   transcriptEntryLayout,
   transcriptEntryLayoutRows,
+  transcriptEntryMarginBottomRows,
 } from './transcriptEntryLayout';
 
 export type StaticTranscriptItem =
@@ -224,6 +225,10 @@ function entryAbove(
 interface StaticTranscriptItemMetrics {
   readonly rows: number;
   readonly bytes: number;
+  /** Rows without margin collapse against a previous item. */
+  readonly contentRows: number;
+  readonly declaredTopRows: number;
+  readonly marginBottomRows: number;
 }
 
 /** Row count plus an estimated UTF-8 byte footprint for one static item.
@@ -233,17 +238,17 @@ interface StaticTranscriptItemMetrics {
  *  is a floor for its chrome, not a bound. Entry metrics come from the same
  *  `scrollback-budget` layout the row budget uses, so the ring never pays for
  *  a second full layout pass. */
-function staticTranscriptItemMetrics(
+function staticTranscriptItemBaseMetrics(
   item: StaticTranscriptItem,
   width?: number,
   executionLabels?: ExecutionLabels,
-  previousItem?: StaticTranscriptItem,
 ): StaticTranscriptItemMetrics {
   if (item.kind === 'header') {
+    const rows = item.compact
+      ? COMPACT_SESSION_HEADER_ROWS
+      : FULL_SESSION_HEADER_ROWS;
     return {
-      rows: item.compact
-        ? COMPACT_SESSION_HEADER_ROWS
-        : FULL_SESSION_HEADER_ROWS,
+      rows,
       bytes:
         Buffer.byteLength(item.identityLine, 'utf8') +
         Buffer.byteLength(item.meta.version, 'utf8') +
@@ -251,17 +256,72 @@ function staticTranscriptItemMetrics(
         Buffer.byteLength(item.meta.agent, 'utf8') +
         Buffer.byteLength(item.meta.cwd, 'utf8') +
         64,
+      contentRows: rows,
+      declaredTopRows: 0,
+      marginBottomRows: 0,
     };
   }
+
   const layout = transcriptEntryLayout(item.entry, {
     executionLabels,
     mode: 'scrollback-budget',
-    previousEntry: entryAbove(previousItem),
+    previousEntry: undefined,
     width,
   });
   let bytes = 0;
   for (const line of layout.lines) bytes += Buffer.byteLength(line, 'utf8');
-  return { rows: transcriptEntryLayoutRows(layout), bytes };
+  return {
+    rows: transcriptEntryLayoutRows(layout),
+    bytes,
+    contentRows: Math.max(1, layout.lines.length),
+    declaredTopRows: layout.marginTopRows,
+    marginBottomRows: layout.marginBottomRows,
+  };
+}
+
+function staticTranscriptItemMetricsForPrevious(
+  base: StaticTranscriptItemMetrics,
+  previousBase: StaticTranscriptItemMetrics | undefined,
+): StaticTranscriptItemMetrics {
+  const marginTopRows =
+    previousBase === undefined
+      ? base.declaredTopRows
+      : Math.max(0, base.declaredTopRows - previousBase.marginBottomRows);
+  return {
+    ...base,
+    rows: base.contentRows + marginTopRows + base.marginBottomRows,
+  };
+}
+
+function staticTranscriptPreviousBase(
+  previousItem: StaticTranscriptItem | undefined,
+): StaticTranscriptItemMetrics | undefined {
+  const previousEntry =
+    previousItem === undefined ? undefined : entryAbove(previousItem);
+  if (previousEntry === undefined) return undefined;
+  // Only the previous entry's bottom margin participates in collapse; laying
+  // out the whole previous item here would duplicate its layout cost.
+  return {
+    rows: 0,
+    bytes: 0,
+    contentRows: 0,
+    declaredTopRows: 0,
+    marginBottomRows: transcriptEntryMarginBottomRows(previousEntry),
+  };
+}
+
+function staticTranscriptItemMetrics(
+  item: StaticTranscriptItem,
+  width?: number,
+  executionLabels?: ExecutionLabels,
+  previousItem?: StaticTranscriptItem,
+): StaticTranscriptItemMetrics {
+  const base = staticTranscriptItemBaseMetrics(item, width, executionLabels);
+  if (item.kind === 'header') return base;
+  return staticTranscriptItemMetricsForPrevious(
+    base,
+    staticTranscriptPreviousBase(previousItem),
+  );
 }
 
 function staticTranscriptItemRowCount(
@@ -369,7 +429,9 @@ export function trimStaticTranscriptItems(
     removedAny = true;
   }
 
-  return { items: nextItems, totals, trimmed: removedAny };
+  return removedAny
+    ? { items: nextItems, totals, trimmed: true }
+    : { items, totals: options.totals, trimmed: false };
 }
 
 /**
@@ -407,28 +469,38 @@ function retainedStaticTranscriptTail(
   }
 
   const headerItem = headerCount > 0 ? items[0] : undefined;
-  const headerMetrics =
+  const headerBase =
     headerItem !== undefined
-      ? staticTranscriptItemMetrics(
+      ? staticTranscriptItemBaseMetrics(
           headerItem,
           options.width,
           options.executionLabels,
         )
-      : { rows: 0, bytes: 0 };
+      : undefined;
+
+  // Layout each item at most once in the backward walk. `previousBase` only
+  // supplies the previous entry's bottom margin, so row-collapse adjustments
+  // never trigger a second layout pass for an item that is already measured.
+  const baseFor = (item: StaticTranscriptItem): StaticTranscriptItemMetrics =>
+    staticTranscriptItemBaseMetrics(
+      item,
+      options.width,
+      options.executionLabels,
+    );
+
   let start = items.length - 1;
   const newest = items[start];
-  let firstMetrics =
-    newest === undefined
-      ? { rows: 0, bytes: 0 }
-      : staticTranscriptItemMetrics(
-          newest,
-          options.width,
-          options.executionLabels,
-          headerItem,
-        );
+  let firstBase = newest === undefined ? undefined : baseFor(newest);
+  if (firstBase === undefined) {
+    return { items, totals: { rows: 0, bytes: 0 }, trimmed: false };
+  }
+  const firstMetrics = staticTranscriptItemMetricsForPrevious(
+    firstBase,
+    headerBase,
+  );
   let totals = {
-    rows: headerMetrics.rows + firstMetrics.rows,
-    bytes: headerMetrics.bytes + firstMetrics.bytes,
+    rows: (headerBase?.rows ?? 0) + firstMetrics.rows,
+    bytes: (headerBase?.bytes ?? 0) + firstMetrics.bytes,
   };
   let trimNeeded =
     totals.rows > budgets.rowHighWater || totals.bytes > budgets.byteHighWater;
@@ -436,33 +508,31 @@ function retainedStaticTranscriptTail(
   while (!trimNeeded && start > headerCount) {
     const candidate = items[start - 1];
     if (candidate === undefined) break;
-    const candidateMetrics = staticTranscriptItemMetrics(
-      candidate,
-      options.width,
-      options.executionLabels,
-      headerItem,
-    );
+    const candidateBase = baseFor(candidate);
     const oldFirst = items[start];
     if (oldFirst === undefined) break;
-    const oldFirstAfterCandidate = staticTranscriptItemMetrics(
-      oldFirst,
-      options.width,
-      options.executionLabels,
-      candidate,
+    const oldFirstBase = firstBase;
+    const oldFirstBefore = staticTranscriptItemMetricsForPrevious(
+      oldFirstBase,
+      headerBase,
+    );
+    const candidateMetrics = staticTranscriptItemMetricsForPrevious(
+      candidateBase,
+      headerBase,
+    );
+    const oldFirstAfter = staticTranscriptItemMetricsForPrevious(
+      oldFirstBase,
+      candidateBase,
     );
     totals = {
       rows:
         totals.rows -
-        firstMetrics.rows +
-        oldFirstAfterCandidate.rows +
-        candidateMetrics.rows,
-      bytes:
-        totals.bytes -
-        firstMetrics.bytes +
-        oldFirstAfterCandidate.bytes +
-        candidateMetrics.bytes,
+        oldFirstBefore.rows +
+        candidateMetrics.rows +
+        oldFirstAfter.rows,
+      bytes: totals.bytes + candidateBase.bytes,
     };
-    firstMetrics = candidateMetrics;
+    firstBase = candidateBase;
     start -= 1;
     trimNeeded =
       totals.rows > budgets.rowHighWater ||
@@ -477,12 +547,17 @@ function retainedStaticTranscriptTail(
     headerItem !== undefined
       ? [headerItem, ...items.slice(start)]
       : items.slice(start);
-  return trimStaticTranscriptItems(candidateItems, {
+  const retained = trimStaticTranscriptItems(candidateItems, {
     budgets,
     executionLabels: options.executionLabels,
     totals,
     width: options.width,
   });
+  return {
+    items: retained.items,
+    totals: retained.totals,
+    trimmed: candidateItems.length < items.length || retained.trimmed,
+  };
 }
 
 /** The execution-label map is a `computed()` signal that can return a fresh

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -157,7 +157,7 @@ export function orderedStaticTranscriptEntries(
     key: readonly [number, number];
   }> = [];
   for (const [index, entry] of entries.entries()) {
-    if (entry.role === 'activity' && !entry.finalized) break;
+    if (!entry.finalized) break;
     if (!isStaticTranscriptEntryAt(entries, index, status)) continue;
     candidates.push({ entry, index, key: transcriptOrderKey(entry, index) });
   }
@@ -225,7 +225,9 @@ export function splitTranscriptEntries(
   return { finalized, pending };
 }
 
-export const EMPTY_TRANSCRIPT_ENTRIES: readonly ConversationEntry[] = [];
+const EMPTY_TRANSCRIPT_ENTRIES: readonly ConversationEntry[] = Object.freeze(
+  [],
+);
 
 /** Cursor over the settled prefix of a stream's projected entries. The static
  *  transcript appends only entries after this cursor on ordinary syncs; a
@@ -292,7 +294,11 @@ export function incrementalStaticTranscriptEntries(
   }
 
   const sameEntries = previous.entriesRef === source;
-  if (sameEntries && previous.status === status) {
+  if (
+    sameEntries &&
+    previous.status === status &&
+    previous.scannedIndex >= source.length
+  ) {
     return { appended: [], cursor: previous, rebuild: false };
   }
 
@@ -327,7 +333,6 @@ export function incrementalStaticTranscriptEntries(
   for (let index = 0; index < suffix.length; index += 1) {
     const entry = suffix[index];
     if (entry === undefined) break;
-    if (entry.role === 'activity' && !entry.finalized) break;
     if (!entry.finalized) break;
     if (!isRenderableTranscriptEntry(entry)) {
       scannedIndex = start + index + 1;

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -198,7 +198,10 @@ export function splitTranscriptEntries(
   const pending: ConversationEntry[] = [];
   let canPromoteToStatic = true;
   for (const [index, entry] of entries.entries()) {
-    if (entry.role === 'activity' && !entry.finalized) {
+    // Mirror the static-ring settled-prefix barrier: any unfinished entry
+    // blocks later finalized rows from static promotion, so they stay visible
+    // in the live pending pane instead of disappearing between the two panes.
+    if (!entry.finalized) {
       canPromoteToStatic = false;
     }
     if (!isRenderableTranscriptEntry(entry)) continue;

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -312,6 +312,15 @@ function entryMarginBottomRows(entry: ConversationEntry): number {
   return ROLE_GEOMETRY[entry.role].marginBottomRows;
 }
 
+/** Exposed for the static-scrollback budget walk, which needs the bottom
+ *  margin of a previous entry to collapse the next entry's top margin without
+ *  laying out that next entry a second time. */
+export function transcriptEntryMarginBottomRows(
+  entry: ConversationEntry,
+): number {
+  return entryMarginBottomRows(entry);
+}
+
 export function transcriptEntryLayout(
   entry: ConversationEntry,
   {

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -1068,6 +1068,39 @@ describe('CLI conversation transcript', () => {
     expect(built.trimmed).toBe(false);
   });
 
+  it('reports a trim when the newest oversized entry forces a prefix drop', () => {
+    const budgets: StaticTranscriptRingBudgets = {
+      rowHighWater: 1,
+      rowLowWater: 1,
+      byteHighWater: 1024 * 1024,
+      byteLowWater: 1024 * 1024,
+    };
+    const built = buildStaticTranscriptItems({
+      currentItems: [],
+      streams: new Map([
+        [
+          STREAM_ID,
+          sliceWithEntries(STREAM_ID, [
+            entry('e0', 'assistant', 'first', true),
+            entry('e1', 'assistant', 'second', true),
+            entry('e2', 'assistant', 'x'.repeat(80), true),
+          ]),
+        ],
+      ]),
+      maxRows: 1,
+      meta: SESSION_META,
+      scrollbackStreamId: STREAM_ID,
+      width: 80,
+      ringBudgets: budgets,
+    });
+
+    expect(built.items.map((item) => item.id)).toEqual([
+      'session-header',
+      'e2',
+    ]);
+    expect(built.trimmed).toBe(true);
+  });
+
   it('trims a static tail with margin-collapse-aware row accounting', () => {
     const header: StaticTranscriptItem = {
       id: 'session-header',

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -16,13 +16,15 @@ import { formatRenderError } from '@cli/chat/tui/panes/EntryErrorBoundary';
 import {
   incrementalStaticTranscriptEntries,
   isInquiryContinuationText,
+  orderedStaticTranscriptEntries,
   splitTranscriptEntries,
   terminalVisibleTranscriptText,
   trimAssistantTranscriptLead,
 } from '@cli/chat/tui/panes/transcriptEntries';
 import {
-  appendStaticTranscriptItems,
+  advanceStaticTranscriptState,
   buildStaticTranscriptItems,
+  buildStaticTranscriptState,
   DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS,
   sessionHeaderIdentityLine,
   trimStaticTranscriptItems,
@@ -682,12 +684,12 @@ describe('CLI conversation transcript', () => {
     expect(split.finalized).toEqual([]);
     expect(split.pending.map((item) => item.id)).toEqual(['u1']);
 
-    const items = appendStaticTranscriptItems({
+    const items = buildStaticTranscriptItems({
       scrollbackStreamId: STREAM_ID,
       currentItems: [],
       streams,
       meta: SESSION_META,
-    });
+    }).items;
     expect(items.map((item) => item.id)).toEqual(['session-header']);
   });
 
@@ -707,12 +709,12 @@ describe('CLI conversation transcript', () => {
     expect(split.finalized.map((item) => item.id)).toEqual(['u1']);
     expect(split.pending.map((item) => item.id)).toEqual(['t1']);
 
-    const items = appendStaticTranscriptItems({
+    const items = buildStaticTranscriptItems({
       scrollbackStreamId: STREAM_ID,
       currentItems: [],
       streams,
       meta: SESSION_META,
-    });
+    }).items;
     expect(items.map((item) => item.id)).toEqual(['session-header', 'u1']);
     expect(items[1]).toMatchObject({ kind: 'entry' });
   });
@@ -799,20 +801,20 @@ describe('CLI conversation transcript', () => {
   });
 
   it('shows the session header exactly once', () => {
-    const first = appendStaticTranscriptItems({
+    const first = buildStaticTranscriptItems({
       scrollbackStreamId: undefined,
       currentItems: [],
       streams: new Map(),
       meta: SESSION_META,
-    });
+    }).items;
     expect(first).toHaveLength(1);
 
-    const again = appendStaticTranscriptItems({
+    const again = buildStaticTranscriptItems({
       scrollbackStreamId: undefined,
       currentItems: first,
       streams: new Map(),
       meta: { ...SESSION_META, model: 'sonnet' },
-    });
+    }).items;
     expect(again).toHaveLength(1);
   });
 
@@ -1008,6 +1010,7 @@ describe('CLI conversation transcript', () => {
       'session-header',
       'e0',
     ]);
+    expect(built.trimmed).toBe(false);
   });
 
   it('trims a static tail with margin-collapse-aware row accounting', () => {
@@ -1055,6 +1058,331 @@ describe('CLI conversation transcript', () => {
       'u2',
     ]);
     expect(trimmed.totals.rows).toBeLessThanOrEqual(beforeRows);
+  });
+
+  it('keeps a finalized tool behind an unfinalized assistant out of the settled prefix', () => {
+    const user = entry('u1', 'user', 'go', true);
+    const assistant = entry('a1', 'assistant', 'working', false);
+    const tool = {
+      ...toolEntry('t1', TOOL_USE_STATUS.COMPLETED),
+      finalized: true,
+    };
+    const settledAssistant = { ...assistant, finalized: true };
+    const emptyCursor = {
+      entriesRef: undefined,
+      scannedIndex: 0,
+      lastScannedEntry: undefined,
+      status: undefined,
+    } as const;
+
+    expect(
+      orderedStaticTranscriptEntries(
+        [user, assistant, tool],
+        STREAM_PHASE.RUNNING,
+      ).map((item) => item.id),
+    ).toEqual(['u1']);
+
+    const first = incrementalStaticTranscriptEntries(
+      [user, assistant, tool],
+      STREAM_PHASE.RUNNING,
+      emptyCursor,
+    );
+    expect(first.appended.map((item) => item.id)).toEqual(['u1']);
+    expect(first.cursor.scannedIndex).toBe(1);
+
+    const second = incrementalStaticTranscriptEntries(
+      [user, settledAssistant, tool],
+      STREAM_PHASE.RUNNING,
+      first.cursor,
+    );
+    expect(second.appended.map((item) => item.id)).toEqual(['a1', 't1']);
+    expect(second.cursor.scannedIndex).toBe(3);
+  });
+
+  it('rescans pending child entries when the child model identity arrives', () => {
+    const CHILD = 'search-stream' as StreamTabId;
+    const parentStream = new Map<StreamTabId, StreamTabId>([
+      [CHILD, ROOT_STREAM],
+    ]);
+    const childEntry = entry('a1', 'assistant', 'checking', true);
+    const streamsWithoutChildModel = new Map<StreamTabId, StreamSlice>([
+      [ROOT_STREAM, sliceWithEntries(ROOT_STREAM, [])],
+      [CHILD, sliceWithEntries(CHILD, [childEntry])],
+    ]);
+    const initial = buildStaticTranscriptState({
+      childStreamEntries: new Map(),
+      maxRows: undefined,
+      meta: SESSION_META,
+      ownerKey: `stream:${CHILD}`,
+      parentStream,
+      repaintEpoch: 0,
+      scrollbackStreamId: CHILD,
+      streams: streamsWithoutChildModel,
+      width: 80,
+    });
+
+    expect(initial.items).toEqual([]);
+    expect(initial.scan.entriesRef).toBe(
+      streamsWithoutChildModel.get(CHILD)?.entries,
+    );
+    expect(initial.scan.scannedIndex).toBe(0);
+
+    const streamsWithChildModel = new Map<StreamTabId, StreamSlice>([
+      [ROOT_STREAM, sliceWithEntries(ROOT_STREAM, [])],
+      [CHILD, sliceWithEntries(CHILD, [childEntry], { model: 'kimi26T' })],
+    ]);
+    const advanced = advanceStaticTranscriptState(initial, {
+      childStreamEntries: new Map(),
+      maxRows: undefined,
+      meta: SESSION_META,
+      ownerKey: `stream:${CHILD}`,
+      parentStream,
+      scrollbackStreamId: CHILD,
+      streams: streamsWithChildModel,
+      width: 80,
+    });
+
+    expect(advanced.items.map((item) => item.id)).toEqual([
+      'session-header',
+      'a1',
+    ]);
+    expect(advanced.scan.scannedIndex).toBe(1);
+  });
+
+  it('recomputes ring totals and trims when the layout width shrinks', () => {
+    const budgets: StaticTranscriptRingBudgets = {
+      rowHighWater: 6,
+      rowLowWater: 4,
+      byteHighWater: 1024 * 1024,
+      byteLowWater: 1024 * 1024,
+    };
+    const entries = Array.from({ length: 4 }, (_, index) =>
+      entry(`e${index}`, 'assistant', 'x'.repeat(10), true),
+    );
+    const wideStreams = new Map<StreamTabId, StreamSlice>([
+      [STREAM_ID, sliceWithEntries(STREAM_ID, entries)],
+    ]);
+    const wide = buildStaticTranscriptState({
+      childStreamEntries: new Map(),
+      maxRows: 1,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      repaintEpoch: 0,
+      ringBudgets: budgets,
+      scrollbackStreamId: STREAM_ID,
+      streams: wideStreams,
+      width: 40,
+    });
+
+    expect(wide.items.map((item) => item.id)).toEqual([
+      'session-header',
+      'e0',
+      'e1',
+      'e2',
+      'e3',
+    ]);
+    expect(wide.rowCount).toBeLessThanOrEqual(budgets.rowHighWater);
+    expect(wide.repaintEpoch).toBe(0);
+
+    const narrow = advanceStaticTranscriptState(wide, {
+      childStreamEntries: new Map(),
+      maxRows: 1,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      ringBudgets: budgets,
+      scrollbackStreamId: STREAM_ID,
+      streams: wideStreams,
+      width: 8,
+    });
+
+    expect(narrow.items.map((item) => item.id)).toEqual([
+      'session-header',
+      'e3',
+    ]);
+    expect(narrow.rowCount).toBeLessThanOrEqual(budgets.rowLowWater);
+    expect(narrow.repaintEpoch).toBe(1);
+    expect(narrow.layoutWidth).toBe(8);
+  });
+
+  it('recomputes ring byte totals and trims when execution labels change', () => {
+    const budgets: StaticTranscriptRingBudgets = {
+      rowHighWater: 10,
+      rowLowWater: 1,
+      byteHighWater: 250,
+      byteLowWater: 1,
+    };
+    const shortLabels = new Map<string, string>([['sub', 'A']]);
+    const longLabels = new Map<string, string>([['sub', 'A'.repeat(60)]]);
+    const entries = [
+      compactExecutionsEntry('t1', '/executions/sub/report'),
+      compactExecutionsEntry('t2', '/executions/sub/report'),
+    ];
+    const streamMap = new Map<StreamTabId, StreamSlice>([
+      [STREAM_ID, sliceWithEntries(STREAM_ID, entries)],
+    ]);
+    const initial = buildStaticTranscriptState({
+      childStreamEntries: new Map(),
+      executionLabels: shortLabels,
+      maxRows: 1,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      repaintEpoch: 0,
+      ringBudgets: budgets,
+      scrollbackStreamId: STREAM_ID,
+      streams: streamMap,
+      width: 80,
+    });
+
+    expect(initial.items.map((item) => item.id)).toEqual([
+      'session-header',
+      't1',
+      't2',
+    ]);
+    expect(initial.byteCount).toBeLessThanOrEqual(budgets.byteHighWater);
+    expect(initial.repaintEpoch).toBe(0);
+
+    const advanced = advanceStaticTranscriptState(initial, {
+      childStreamEntries: new Map(),
+      executionLabels: longLabels,
+      maxRows: 1,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      ringBudgets: budgets,
+      scrollbackStreamId: STREAM_ID,
+      streams: streamMap,
+      width: 80,
+    });
+
+    expect(advanced.items.map((item) => item.id)).toEqual([
+      'session-header',
+      't2',
+    ]);
+    expect(advanced.byteCount).toBeGreaterThan(initial.byteCount);
+    expect(advanced.repaintEpoch).toBe(1);
+    expect(advanced.executionLabels).toBe(longLabels);
+  });
+
+  it('trims and bumps the repaint epoch when incremental appends exceed a small budget', () => {
+    const budgets: StaticTranscriptRingBudgets = {
+      rowHighWater: 2,
+      rowLowWater: 1,
+      byteHighWater: 1024 * 1024,
+      byteLowWater: 1024 * 1024,
+    };
+    const firstEntry = entry('e0', 'assistant', 'x', true);
+    const firstStreams = new Map<StreamTabId, StreamSlice>([
+      [STREAM_ID, sliceWithEntries(STREAM_ID, [firstEntry])],
+    ]);
+    const initial = buildStaticTranscriptState({
+      childStreamEntries: new Map(),
+      maxRows: 1,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      repaintEpoch: 0,
+      ringBudgets: budgets,
+      scrollbackStreamId: STREAM_ID,
+      streams: firstStreams,
+      width: 80,
+    });
+
+    expect(initial.items.map((item) => item.id)).toEqual([
+      'session-header',
+      'e0',
+    ]);
+    expect(initial.repaintEpoch).toBe(0);
+
+    const secondEntry = entry('e1', 'assistant', 'y', true);
+    const appendedStreams = new Map<StreamTabId, StreamSlice>([
+      [STREAM_ID, sliceWithEntries(STREAM_ID, [firstEntry, secondEntry])],
+    ]);
+    const advanced = advanceStaticTranscriptState(initial, {
+      childStreamEntries: new Map(),
+      maxRows: 1,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      ringBudgets: budgets,
+      scrollbackStreamId: STREAM_ID,
+      streams: appendedStreams,
+      width: 80,
+    });
+
+    expect(advanced.items.map((item) => item.id)).toEqual([
+      'session-header',
+      'e1',
+    ]);
+    expect(advanced.repaintEpoch).toBe(1);
+  });
+
+  it('does not report a trim when only the header and one oversized entry remain', () => {
+    const header: StaticTranscriptItem = {
+      id: 'session-header',
+      kind: 'header',
+      compact: true,
+      identityLine: 'agent: research · model: test',
+      meta: SESSION_META,
+    };
+    const oversized: StaticTranscriptItem = {
+      id: 'e0',
+      kind: 'entry',
+      entry: entry('e0', 'assistant', 'x'.repeat(80), true),
+    };
+    const trimmed = trimStaticTranscriptItems([header, oversized], {
+      budgets: {
+        rowHighWater: 1,
+        rowLowWater: 1,
+        byteHighWater: 1,
+        byteLowWater: 1,
+      },
+      totals: { rows: 20, bytes: 500 },
+      width: 80,
+    });
+
+    expect(trimmed.items.map((item) => item.id)).toEqual([
+      'session-header',
+      'e0',
+    ]);
+    expect(trimmed.trimmed).toBe(false);
+  });
+
+  it('does not bump the repaint epoch on a scrollback owner switch', () => {
+    const rootStreams = new Map<StreamTabId, StreamSlice>([
+      [
+        STREAM_ID,
+        sliceWithEntries(STREAM_ID, [entry('e0', 'assistant', 'root', true)]),
+      ],
+    ]);
+    const initial = buildStaticTranscriptState({
+      childStreamEntries: new Map(),
+      maxRows: 1,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      repaintEpoch: 5,
+      scrollbackStreamId: STREAM_ID,
+      streams: rootStreams,
+      width: 80,
+    });
+    expect(initial.repaintEpoch).toBe(5);
+
+    const switched = advanceStaticTranscriptState(initial, {
+      childStreamEntries: new Map(),
+      maxRows: 1,
+      meta: SESSION_META,
+      ownerKey: 'stream:other',
+      parentStream: new Map(),
+      scrollbackStreamId: STREAM_ID,
+      streams: rootStreams,
+      width: 80,
+    });
+
+    expect(switched.ownerKey).toBe('stream:other');
+    expect(switched.repaintEpoch).toBe(5);
   });
 
   it('appends settled entries incrementally and resumes a deferred live prompt', () => {
@@ -1175,14 +1503,14 @@ describe('CLI conversation transcript', () => {
     ).toBe('subagent: search · parent: main · model: Kimi K2.6 (Thinking)');
 
     expect(
-      appendStaticTranscriptItems({
+      buildStaticTranscriptItems({
         scrollbackStreamId: CHILD,
         currentItems: [],
         streams,
         childStreamEntries,
         meta: SESSION_META,
         parentStream: new Map([[CHILD, ROOT_STREAM]]),
-      })[0],
+      }).items[0],
     ).toMatchObject({
       kind: 'header',
       identityLine:
@@ -1202,13 +1530,13 @@ describe('CLI conversation transcript', () => {
     ]);
 
     expect(
-      appendStaticTranscriptItems({
+      buildStaticTranscriptItems({
         scrollbackStreamId: CHILD,
         currentItems: [],
         streams: streamsWithoutChildModel,
         meta: SESSION_META,
         parentStream,
-      }),
+      }).items,
     ).toEqual([]);
 
     const streamsWithChildModel = new Map<StreamTabId, StreamSlice>([
@@ -1222,23 +1550,23 @@ describe('CLI conversation transcript', () => {
     ]);
 
     expect(
-      appendStaticTranscriptItems({
+      buildStaticTranscriptItems({
         scrollbackStreamId: CHILD,
         currentItems: [],
         streams: streamsWithChildModel,
         meta: SESSION_META,
         parentStream,
-      }).map((item) => item.id),
+      }).items.map((item) => item.id),
     ).toEqual(['session-header', 'a1']);
   });
 
   it('only feeds the root scrollback stream, not background subagents', () => {
-    const items = appendStaticTranscriptItems({
+    const items = buildStaticTranscriptItems({
       scrollbackStreamId: ROOT_STREAM,
       currentItems: [],
       streams: rootChildStreams('do x', 'done'),
       meta: SESSION_META,
-    });
+    }).items;
 
     expect(items.slice(1).map((item) => item.id)).toEqual(['u1']);
   });
@@ -1249,12 +1577,12 @@ describe('CLI conversation transcript', () => {
       rootStreamId: ROOT_STREAM,
       scopedTranscript: false,
     });
-    const items = appendStaticTranscriptItems({
+    const items = buildStaticTranscriptItems({
       scrollbackStreamId: scrollbackTarget.streamId,
       currentItems: [],
       streams: rootChildStreams('root prompt', 'child detail'),
       meta: SESSION_META,
-    });
+    }).items;
 
     expect(scrollbackTarget).toEqual({
       ownerKey: 'root',
@@ -1269,12 +1597,12 @@ describe('CLI conversation transcript', () => {
       rootStreamId: ROOT_STREAM,
       scopedTranscript: true,
     });
-    const items = appendStaticTranscriptItems({
+    const items = buildStaticTranscriptItems({
       scrollbackStreamId: scrollbackTarget.streamId,
       currentItems: [],
       streams: rootChildStreams('root prompt', 'child detail'),
       meta: SESSION_META,
-    });
+    }).items;
 
     expect(scrollbackTarget).toEqual({
       ownerKey: `stream:${CHILD_STREAM}`,
@@ -1464,14 +1792,14 @@ function staticItems(
     readonly width?: number;
   } = {},
 ): readonly StaticTranscriptItem[] {
-  return appendStaticTranscriptItems({
+  return buildStaticTranscriptItems({
     currentItems: options.currentItems ?? [],
     maxRows: options.maxRows,
     meta: SESSION_META,
     scrollbackStreamId: STREAM_ID,
     streams: new Map([[STREAM_ID, sliceWithEntries(STREAM_ID, entries)]]),
     width: options.width,
-  });
+  }).items;
 }
 
 function staticItemIds(

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -182,6 +182,61 @@ describe('CLI conversation transcript', () => {
     expect(waitingBeforeFinalize.pending).toEqual([]);
   });
 
+  it('keeps finalized rows behind an unfinished assistant live in the pending pane', () => {
+    const user = entry('u1', 'user', 'go', true);
+    const assistant = entry('a1', 'assistant', 'working', false);
+    const tool = {
+      ...toolEntry('t1', TOOL_USE_STATUS.COMPLETED),
+      finalized: true,
+    };
+
+    const split = splitTranscriptEntries(
+      [user, assistant, tool],
+      STREAM_PHASE.RUNNING,
+    );
+    expect(split.finalized.map((item) => item.id)).toEqual(['u1']);
+    expect(split.pending.map((item) => item.id)).toEqual(['a1', 't1']);
+  });
+
+  it('keeps finalized rows behind unfinished tool and workflow rows live', () => {
+    const tool = toolEntry('t1', 'in_progress');
+    const toolPhase: ConversationEntry = {
+      id: 'p1',
+      role: 'phase',
+      text: 'After tool',
+      finalized: true,
+      phaseLabel: 'After tool',
+    };
+    const workflowTask: ConversationEntry = {
+      id: 'w1',
+      role: 'workflowTask',
+      text: 'Planned: Task',
+      finalized: false,
+      task: { id: 'w1', label: 'Task', status: 'planned' },
+    };
+    const workflowPhase: ConversationEntry = {
+      id: 'p2',
+      role: 'phase',
+      text: 'After workflow task',
+      finalized: true,
+      phaseLabel: 'After workflow task',
+    };
+
+    const toolSplit = splitTranscriptEntries(
+      [tool, toolPhase],
+      STREAM_PHASE.RUNNING,
+    );
+    expect(toolSplit.finalized).toEqual([]);
+    expect(toolSplit.pending.map((item) => item.id)).toEqual(['t1', 'p1']);
+
+    const workflowSplit = splitTranscriptEntries(
+      [workflowTask, workflowPhase],
+      STREAM_PHASE.RUNNING,
+    );
+    expect(workflowSplit.finalized).toEqual([]);
+    expect(workflowSplit.pending.map((item) => item.id)).toEqual(['w1', 'p2']);
+  });
+
   it('keeps running compaction live and promotes its terminal update once', () => {
     const running = compactionEntry('running');
     expect(
@@ -1105,9 +1160,13 @@ describe('CLI conversation transcript', () => {
       [CHILD, ROOT_STREAM],
     ]);
     const childEntry = entry('a1', 'assistant', 'checking', true);
+    // Keep one shared entries array so the model patch reuses the same
+    // `entriesRef` and exercises the `sameEntries && scannedIndex < length`
+    // rescan guard rather than falling through to the new-array path.
+    const childEntries = [childEntry];
     const streamsWithoutChildModel = new Map<StreamTabId, StreamSlice>([
       [ROOT_STREAM, sliceWithEntries(ROOT_STREAM, [])],
-      [CHILD, sliceWithEntries(CHILD, [childEntry])],
+      [CHILD, sliceWithEntries(CHILD, childEntries)],
     ]);
     const initial = buildStaticTranscriptState({
       childStreamEntries: new Map(),
@@ -1122,14 +1181,12 @@ describe('CLI conversation transcript', () => {
     });
 
     expect(initial.items).toEqual([]);
-    expect(initial.scan.entriesRef).toBe(
-      streamsWithoutChildModel.get(CHILD)?.entries,
-    );
+    expect(initial.scan.entriesRef).toBe(childEntries);
     expect(initial.scan.scannedIndex).toBe(0);
 
     const streamsWithChildModel = new Map<StreamTabId, StreamSlice>([
       [ROOT_STREAM, sliceWithEntries(ROOT_STREAM, [])],
-      [CHILD, sliceWithEntries(CHILD, [childEntry], { model: 'kimi26T' })],
+      [CHILD, sliceWithEntries(CHILD, childEntries, { model: 'kimi26T' })],
     ]);
     const advanced = advanceStaticTranscriptState(initial, {
       childStreamEntries: new Map(),
@@ -1264,6 +1321,44 @@ describe('CLI conversation transcript', () => {
     expect(advanced.byteCount).toBeGreaterThan(initial.byteCount);
     expect(advanced.repaintEpoch).toBe(1);
     expect(advanced.executionLabels).toBe(longLabels);
+  });
+
+  it('does not relayout or repaint for semantically equal fresh execution labels', () => {
+    const labels = new Map<string, string>([['sub', 'A']]);
+    const entries = [compactExecutionsEntry('t1', '/executions/sub/report')];
+    const streamMap = new Map<StreamTabId, StreamSlice>([
+      [STREAM_ID, sliceWithEntries(STREAM_ID, entries)],
+    ]);
+    const initial = buildStaticTranscriptState({
+      childStreamEntries: new Map(),
+      executionLabels: labels,
+      maxRows: 1,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      repaintEpoch: 0,
+      ringBudgets: DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS,
+      scrollbackStreamId: STREAM_ID,
+      streams: streamMap,
+      width: 80,
+    });
+    // Same projection contents in a fresh Map — the signal allocates these on
+    // unrelated child-roster churn, so they must not read as a layout change.
+    const sameLabelsFreshMap = new Map<string, string>([['sub', 'A']]);
+    const unchanged = advanceStaticTranscriptState(initial, {
+      childStreamEntries: new Map(),
+      executionLabels: sameLabelsFreshMap,
+      maxRows: 1,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      ringBudgets: DEFAULT_STATIC_TRANSCRIPT_RING_BUDGETS,
+      scrollbackStreamId: STREAM_ID,
+      streams: streamMap,
+      width: 80,
+    });
+    expect(unchanged).toBe(initial);
+    expect(unchanged.repaintEpoch).toBe(initial.repaintEpoch);
   });
 
   it('trims and bumps the repaint epoch when incremental appends exceed a small budget', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.ts
@@ -3036,7 +3036,7 @@ describe('CLI transcript state', () => {
     ).toEqual(['Available commands: /help', 'Available commands: /help']);
   });
 
-  it('keeps a model response live when local output follows it', () => {
+  it('keeps local output live behind an unfinished model response', () => {
     const { finalized, pending } = splitTranscriptEntries(
       [
         {
@@ -3056,8 +3056,11 @@ describe('CLI transcript state', () => {
       STREAM_PHASE.RUNNING,
     );
 
-    expect(pending.map((entry) => entry.id)).toEqual(['model-response']);
-    expect(finalized.map((entry) => entry.id)).toEqual(['local-help']);
+    expect(pending.map((entry) => entry.id)).toEqual([
+      'model-response',
+      'local-help',
+    ]);
+    expect(finalized).toEqual([]);
   });
 
   it('estimates finalized assistant rows from rendered markdown', () => {

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -15,7 +15,9 @@ import '@test/support/defaultSessionTestSetup';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 
 import {
+  advanceStaticTranscriptState,
   buildStaticTranscriptItems,
+  buildStaticTranscriptState,
   StaticConversationTranscript,
 } from '@cli/chat/tui/panes/StaticConversationTranscript';
 import { splitTranscriptEntries } from '@cli/chat/tui/panes/transcriptEntries';
@@ -558,8 +560,34 @@ describe('CLI workflow-script child-stream transcript', () => {
     });
     syncStreamLog(STREAM_ID);
 
-    let incrementalItems = appendItems();
-    expect(entryIds(incrementalItems)).toEqual([]);
+    const buildState = (repaintEpoch = 0) =>
+      buildStaticTranscriptState({
+        childStreamEntries: new Map(),
+        maxRows: undefined,
+        meta: SESSION_META,
+        ownerKey: 'root',
+        parentStream: new Map(),
+        repaintEpoch,
+        scrollbackStreamId: STREAM_ID,
+        streams: streams.get(),
+        width: 80,
+      });
+    const advance = (
+      current: ReturnType<typeof buildStaticTranscriptState>,
+    ): ReturnType<typeof buildStaticTranscriptState> =>
+      advanceStaticTranscriptState(current, {
+        childStreamEntries: new Map(),
+        maxRows: undefined,
+        meta: SESSION_META,
+        ownerKey: 'root',
+        parentStream: new Map(),
+        scrollbackStreamId: STREAM_ID,
+        streams: streams.get(),
+        width: 80,
+      });
+
+    let state = buildState();
+    expect(entryIds(state.items)).toEqual([]);
     const initialOutput = await renderStaticTranscript();
     expect(initialOutput).not.toContain('Preparing repository audit');
     expect(initialOutput).not.toContain('Local audit checkpoint');
@@ -577,8 +605,8 @@ describe('CLI workflow-script child-stream transcript', () => {
       },
     });
     syncStreamLog(STREAM_ID);
-    incrementalItems = appendItems(incrementalItems);
-    expect(entryIds(incrementalItems)).toEqual(['core-task']);
+    state = advance(state);
+    expect(entryIds(state.items)).toEqual(['core-task']);
     const liveOutput = await renderStaticTranscript();
     expect(liveOutput).toContain('Finished: Audit core');
     expect(liveOutput).not.toContain('Preparing repository audit');
@@ -587,20 +615,53 @@ describe('CLI workflow-script child-stream transcript', () => {
 
     phase.end('completed');
     syncStreamLog(STREAM_ID);
-    incrementalItems = appendItems(incrementalItems);
+    state = advance(state);
+    expect(entryIds(state.items)).toEqual(['core-task']);
+
+    for (const id of ['extension', 'cli', 'desktop', 'scripts'] as const) {
+      runTrace.trace.emit({
+        type: 'workflow.call',
+        logId: `${id}-task`,
+        call: {
+          id,
+          label: `Audit ${id}`,
+          phase: 'Repository audit',
+          status: 'completed',
+          model: 'deepseekT',
+        },
+      });
+    }
+    syncStreamLog(STREAM_ID);
+    state = advance(state);
 
     const settledSlice = streamSlice();
     expect(settledSlice?.entries.findLast((entry) => entry.finalized)?.id).toBe(
       'audit-phase',
     );
 
-    const incrementalEntryIds = entryIds(incrementalItems);
-    expect(incrementalEntryIds).toEqual(['core-task']);
+    const incrementalEntryIds = entryIds(state.items);
+    expect(incrementalEntryIds).toEqual([
+      expect.stringMatching(/.+/),
+      expect.stringMatching(/^local:/),
+      'audit-phase',
+      'core-task',
+      'extension-task',
+      'cli-task',
+      'desktop-task',
+      'scripts-task',
+    ]);
     expect(entryIds(appendItems([]))).toEqual(incrementalEntryIds);
     const coldOutput = await renderStaticTranscript();
-    expect(coldOutput).toContain('Finished: Audit core');
-    expect(coldOutput).not.toContain('Preparing repository audit');
-    expect(coldOutput).not.toContain('Repository audit');
+    expectOutputOrder(coldOutput, [
+      'Preparing repository audit',
+      'Local audit checkpoint',
+      '◆ Repository audit',
+      'Finished: Audit core',
+      'Finished: Audit extension',
+      'Finished: Audit cli',
+      'Finished: Audit desktop',
+      'Finished: Audit scripts',
+    ]);
   });
 
   it('keeps a dynamic phase header above tasks introduced inside it', async () => {
@@ -786,6 +847,16 @@ describe('CLI workflow-script child-stream transcript', () => {
       },
     });
     syncStreamLog(STREAM_ID);
+
+    const heldSplit = splitTranscriptEntries(
+      streamEntries(),
+      STREAM_PHASE.RUNNING,
+    );
+    expect(heldSplit.finalized).toEqual([]);
+    expect(heldSplit.pending.map((entry) => entry.role)).toEqual([
+      'tool',
+      'media',
+    ]);
 
     let incrementalItems = appendItems();
     expect(staticEntries(incrementalItems).map((entry) => entry.role)).toEqual(

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts
@@ -15,8 +15,8 @@ import '@test/support/defaultSessionTestSetup';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 
 import {
+  buildStaticTranscriptItems,
   StaticConversationTranscript,
-  appendStaticTranscriptItems,
 } from '@cli/chat/tui/panes/StaticConversationTranscript';
 import { splitTranscriptEntries } from '@cli/chat/tui/panes/transcriptEntries';
 import {
@@ -85,19 +85,19 @@ async function renderStaticTranscript(): Promise<string> {
   );
 }
 
-type StaticItems = ReturnType<typeof appendStaticTranscriptItems>;
+type StaticItems = ReturnType<typeof buildStaticTranscriptItems>['items'];
 
 function appendItems(
   currentItems: StaticItems = [],
-  overrides: Partial<Parameters<typeof appendStaticTranscriptItems>[0]> = {},
+  overrides: Partial<Parameters<typeof buildStaticTranscriptItems>[0]> = {},
 ): StaticItems {
-  return appendStaticTranscriptItems({
+  return buildStaticTranscriptItems({
     currentItems,
     meta: SESSION_META,
     scrollbackStreamId: STREAM_ID,
     streams: streams.get(),
     ...overrides,
-  });
+  }).items;
 }
 
 function staticEntries(items: StaticItems): readonly ConversationEntry[] {
@@ -526,7 +526,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     ]);
   });
 
-  it('keeps declared-plan phase-task ordering identical live and cold', async () => {
+  it('holds later settled rows behind pending declared-plan tasks', async () => {
     const runTrace = openRunTrace(STREAM_ID);
     for (const [id, label] of [
       ['core', 'Audit core'],
@@ -559,17 +559,11 @@ describe('CLI workflow-script child-stream transcript', () => {
     syncStreamLog(STREAM_ID);
 
     let incrementalItems = appendItems();
-    expect(entryIds(incrementalItems)).toEqual([
-      expect.stringMatching(/.+/),
-      expect.stringMatching(/^local:/),
-      'audit-phase',
-    ]);
+    expect(entryIds(incrementalItems)).toEqual([]);
     const initialOutput = await renderStaticTranscript();
-    expectOutputOrder(initialOutput, [
-      'Preparing repository audit',
-      'Local audit checkpoint',
-      '◆ Repository audit',
-    ]);
+    expect(initialOutput).not.toContain('Preparing repository audit');
+    expect(initialOutput).not.toContain('Local audit checkpoint');
+    expect(initialOutput).not.toContain('Repository audit');
 
     runTrace.trace.emit({
       type: 'workflow.call',
@@ -584,19 +578,12 @@ describe('CLI workflow-script child-stream transcript', () => {
     });
     syncStreamLog(STREAM_ID);
     incrementalItems = appendItems(incrementalItems);
-    expect(entryIds(incrementalItems)).toEqual([
-      expect.stringMatching(/.+/),
-      expect.stringMatching(/^local:/),
-      'audit-phase',
-      'core-task',
-    ]);
+    expect(entryIds(incrementalItems)).toEqual(['core-task']);
     const liveOutput = await renderStaticTranscript();
-    expectOutputOrder(liveOutput, [
-      'Preparing repository audit',
-      'Local audit checkpoint',
-      '◆ Repository audit',
-      'Finished: Audit core',
-    ]);
+    expect(liveOutput).toContain('Finished: Audit core');
+    expect(liveOutput).not.toContain('Preparing repository audit');
+    expect(liveOutput).not.toContain('Local audit checkpoint');
+    expect(liveOutput).not.toContain('Repository audit');
 
     phase.end('completed');
     syncStreamLog(STREAM_ID);
@@ -608,16 +595,12 @@ describe('CLI workflow-script child-stream transcript', () => {
     );
 
     const incrementalEntryIds = entryIds(incrementalItems);
-    expect(incrementalEntryIds.at(-2)).toBe('audit-phase');
-    expect(incrementalEntryIds.at(-1)).toBe('core-task');
+    expect(incrementalEntryIds).toEqual(['core-task']);
     expect(entryIds(appendItems([]))).toEqual(incrementalEntryIds);
     const coldOutput = await renderStaticTranscript();
-    expectOutputOrder(coldOutput, [
-      'Preparing repository audit',
-      'Local audit checkpoint',
-      '◆ Repository audit',
-      'Finished: Audit core',
-    ]);
+    expect(coldOutput).toContain('Finished: Audit core');
+    expect(coldOutput).not.toContain('Preparing repository audit');
+    expect(coldOutput).not.toContain('Repository audit');
   });
 
   it('keeps a dynamic phase header above tasks introduced inside it', async () => {
@@ -805,9 +788,9 @@ describe('CLI workflow-script child-stream transcript', () => {
     syncStreamLog(STREAM_ID);
 
     let incrementalItems = appendItems();
-    expect(staticEntries(incrementalItems).map((entry) => entry.role)).toEqual([
-      'media',
-    ]);
+    expect(staticEntries(incrementalItems).map((entry) => entry.role)).toEqual(
+      [],
+    );
 
     runTrace.trace.toolEnd({
       logId: 'audit-tool',


### PR DESCRIPTION
## Summary

Finishes the static-transcript ring follow-ups from #10539:

- **#10543** — record layout width and execution labels in `StaticTranscriptState`; recompute totals and trim when either changes.
- **#10544** — unify the incremental scan and rebuild oracle to stop at the first non-finalized entry, and dedupe appended ids.
- **#10545** — keep the scan cursor pending while a focused child has no model, and rescan when the model identity arrives.
- **#10546** — bump `repaintEpoch` only when a trim actually removes an item; owner switches no longer double-bump.
- **#10547** — bound rebuild layout to the retained tail by walking backward until the candidate tail crosses the high-water mark.
- **#10548** — plumb `ringBudgets` through the incremental path and cover trim + epoch bump with a small-budget test.
- **#10549** — delete the `appendStaticTranscriptItems` shim and freeze/localize `EMPTY_TRANSCRIPT_ENTRIES`.
- **#10550** — correct the waiting-branch comment and the byte-estimate/`+64` docstring.
- **#10551** — use `node:timers/promises` `setTimeout` and add the catch-and-exit path to the terminal-resume fixture.

## Verification

- `vitest run` `ConversationTranscript.vitest.ts` + `WorkflowScriptStreamTranscript.vitest.ts`: **77 passed**
- `pnpm --filter @texra-ai/cli validate:tui static-transcript-terminal-resume`: **all 2 scenarios passed**
- `pnpm run typecheck`: **passed** (workspace, test-kernel, agent, cli, trace-viewer, desktop)
- `eslint` on all modified files: **passed**
- `prettier --check` on all modified files: **passed**
- `check:dead-code-ratchet`, `check:guidance-refs`, `check:browser-safe-utils`: **passed**

Closes #10543
Closes #10544
Closes #10545
Closes #10546
Closes #10547
Closes #10548
Closes #10549
Closes #10550
Closes #10551
