### PR TITLE
fix(retry): close progress-view Kimi retry follow-ups (#10563-#10567)

### DIFF
--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -23,7 +23,7 @@ import {
   type ProviderErrorPartial,
 } from '@shared/schemas';
 import { INCLUDED_ACCESS } from '@shared/copy/modelAccess';
-import { isKimiCodeExclusiveRetryModel } from '@shared/model/kimiCodeRetryGate';
+import { isKimiCodeSubscriptionRetryBlocked } from '@shared/model/kimiCodeRetryGate';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { renderDotMeta, type MetaPart } from '@shared/wa/metaStrip';
 import { tailWithEllipsis, toGraphemes } from '@utils/text/stringUtils';
@@ -156,15 +156,11 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
 
   private canUseOwnApiKey(): boolean {
     const data = this.permission.data;
-    // Exclusivity blocks only the coding-plan quota case: a Kimi Code-exclusive
-    // model has no open-platform fallback when its membership quota is spent.
-    // Other exhaustion reasons (notably upstream credit depletion) still allow
-    // rebinding the same model to a fresh credential.
     return (
       isCredentialExhausted(data.errorDetails) &&
-      !(
-        data.errorDetails?.exhaustionReason === 'kimi-code-subscription' &&
-        isKimiCodeExclusiveRetryModel(data.model)
+      !isKimiCodeSubscriptionRetryBlocked(
+        data.model,
+        data.errorDetails?.exhaustionReason,
       )
     );
   }

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -156,9 +156,16 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
 
   private canUseOwnApiKey(): boolean {
     const data = this.permission.data;
+    // Exclusivity blocks only the coding-plan quota case: a Kimi Code-exclusive
+    // model has no open-platform fallback when its membership quota is spent.
+    // Other exhaustion reasons (notably upstream credit depletion) still allow
+    // rebinding the same model to a fresh credential.
     return (
       isCredentialExhausted(data.errorDetails) &&
-      !isKimiCodeExclusiveRetryModel(data.model)
+      !(
+        data.errorDetails?.exhaustionReason === 'kimi-code-subscription' &&
+        isKimiCodeExclusiveRetryModel(data.model)
+      )
     );
   }
 

--- a/src/agent/modelHandlers/openai/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerKimi.ts
@@ -5,7 +5,7 @@ import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { TokenCountOptions } from '@agent/types/ModelHandlerContracts';
 import type { ToolDefinition } from '@model/ToolDefinition';
-import { isKimiCodeExclusiveModel } from '@model/kimiCodeSubscriptionRouting';
+import { isKimiCodeExclusiveModel } from '@shared/model/kimiCodeRetryGate';
 import { AUXILIARY_MAX_RETRIES } from '../support/auxiliaryRetry';
 import { resolveMoonshotRequestParameters } from '../support/moonshotRequestParameters';
 import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -22,11 +22,8 @@ import {
 } from '@model/copilotRouting';
 import { resolveCodexSubscriptionCapabilities } from '@model/providerCapabilities';
 import {
-  isKimiCodeExclusiveModel,
-  isKimiSubscriptionEligible,
   kimiCodeEffectiveConfig,
   resolveKimiCodeRoutingFacts,
-  type KimiSubscriptionModelFields,
 } from '@model/kimiCodeSubscriptionRouting';
 import { isGpt5ModelName } from '@model/modelNames';
 import {
@@ -44,6 +41,11 @@ import {
 } from '@platform/languageModel';
 import { platform } from '@platform/platform';
 import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
+import {
+  isKimiCodeExclusiveModel,
+  isKimiSubscriptionEligible,
+  type KimiSubscriptionModelFields,
+} from '@shared/model/kimiCodeRetryGate';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 import { getUseOpenRouter } from '@utils/config/providerConfig';

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -1,11 +1,16 @@
 import PQueue from 'p-queue';
+import { MODEL_CONFIGS } from 'llm-zoo';
 
 // Local imports
 import type { ApiProvider } from '@model/apiProviders';
 import { codingPlanSubscriptionRuntimes } from '@model/codingPlanSubscriptions';
 import type { CopilotRouteOverride } from '@model/copilotRouting';
+import { resolveDirectModelApiKeyProvider } from '@model/openRouterRouting';
 import type { ExhaustionReason, StreamTabId } from '@shared/schemas';
-import { isKimiCodeExclusiveRetryModel } from '@shared/model/kimiCodeRetryGate';
+import {
+  isKimiCodeExclusiveModel,
+  isKimiCodeSubscriptionRetryBlocked,
+} from '@shared/model/kimiCodeRetryGate';
 import { isNonEmptyString } from '@utils/core';
 
 export interface ProgressApiKeyRetryRequest {
@@ -92,6 +97,22 @@ export class ProgressApiKeyRetryController {
 
   constructor(private readonly deps: ProgressApiKeyRetryControllerDeps) {}
 
+  private credentialProviderFor(
+    request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
+  ): ApiProvider | undefined {
+    if (request.model === undefined) return request.provider;
+    const config = MODEL_CONFIGS[request.model];
+    if (config === undefined) return request.provider;
+    // The live handler rebinds through the direct-route resolver. Exclusive
+    // models bind to the `kimiCode` credential even when the SDK error labels
+    // the open-platform Moonshot provider, so prompt for and verify the key
+    // the retry will actually use; every other model keeps the forwarded
+    // provider (or the default provider sweep) unchanged.
+    return isKimiCodeExclusiveModel(config)
+      ? resolveDirectModelApiKeyProvider(config)
+      : request.provider;
+  }
+
   private get codingPlanToggles(): readonly CodingPlanToggle[] {
     return (
       this.deps.codingPlanToggles ??
@@ -107,18 +128,19 @@ export class ProgressApiKeyRetryController {
   async useOwnApiKey(
     request: ProgressApiKeyRetryRequest,
   ): Promise<ProgressApiKeyRetryResult> {
-    // Kimi Code-exclusive models have no open-platform fallback when the
-    // coding-plan quota is exhausted, so a personal-key switch cannot reroute
-    // them. Other exhaustion reasons (e.g. upstream credit depletion) still
-    // support rebinding an exclusive model to a replaced credential.
     if (
-      request.exhaustionReason === 'kimi-code-subscription' &&
-      isKimiCodeExclusiveRetryModel(request.model)
+      isKimiCodeSubscriptionRetryBlocked(
+        request.model,
+        request.exhaustionReason,
+      )
     ) {
       return noRetryResult();
     }
 
-    const proceeded = await this.ensureOwnApiKey(request);
+    const proceeded = await this.ensureOwnApiKey({
+      ...request,
+      provider: this.credentialProviderFor(request),
+    });
     if (
       !proceeded ||
       !this.deps.isRetryPending(request.stream, request.requestId)

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -107,10 +107,16 @@ export class ProgressApiKeyRetryController {
   async useOwnApiKey(
     request: ProgressApiKeyRetryRequest,
   ): Promise<ProgressApiKeyRetryResult> {
-    // Kimi Code-exclusive models are served only by the coding endpoint, so a
-    // personal-key switch cannot reroute them; keep the request untouched
-    // rather than disabling routing around an already-swapped client.
-    if (isKimiCodeExclusiveRetryModel(request.model)) return noRetryResult();
+    // Kimi Code-exclusive models have no open-platform fallback when the
+    // coding-plan quota is exhausted, so a personal-key switch cannot reroute
+    // them. Other exhaustion reasons (e.g. upstream credit depletion) still
+    // support rebinding an exclusive model to a replaced credential.
+    if (
+      request.exhaustionReason === 'kimi-code-subscription' &&
+      isKimiCodeExclusiveRetryModel(request.model)
+    ) {
+      return noRetryResult();
+    }
 
     const proceeded = await this.ensureOwnApiKey(request);
     if (
@@ -121,6 +127,12 @@ export class ProgressApiKeyRetryController {
     }
 
     return this.routingCommitQueue.add(async () => {
+      // The request may have been dismissed or replaced while this callback
+      // waited behind another stream's routing commit. Re-check before touching
+      // global routing so a stale switch cannot briefly rebind credentials.
+      if (!this.deps.isRetryPending(request.stream, request.requestId)) {
+        return noRetryResult();
+      }
       const routingBefore = this.routingSnapshot();
       const prepared = await this.applyOwnApiKeyRouting(request);
       const retried = await this.deps.triggerRetry(

--- a/src/controllers/progressView/backend/progressHostInteractions.ts
+++ b/src/controllers/progressView/backend/progressHostInteractions.ts
@@ -147,6 +147,12 @@ export function createProgressHostInteractions(
     retryPreparations.get(streamId) === preparation &&
     isRetryPending(streamId, requestId);
 
+  /** Whether this exact preparation is still the one stored for the stream. */
+  const isStoredRetryPreparation = (
+    streamId: StreamTabId,
+    preparation: PendingRetryPreparation,
+  ): boolean => retryPreparations.get(streamId) === preparation;
+
   /**
    * Complete one retry settlement without letting a dismiss-delivery failure
    * become an unhandled rejection. `complete` settles the request before it
@@ -208,6 +214,13 @@ export function createProgressHostInteractions(
         );
       } catch (error) {
         if (!isCurrentRetryPreparation(streamId, requestId, preparation)) {
+          // Cancellation may already have removed the pending handler before
+          // this abort rejection ran. If the map still stores this exact
+          // preparation, remove it so a cancelled stream does not retain the
+          // preparation callback and its captured state.
+          if (isStoredRetryPreparation(streamId, preparation)) {
+            retryPreparations.delete(streamId);
+          }
           return false;
         }
         retryPreparations.delete(streamId);
@@ -222,6 +235,9 @@ export function createProgressHostInteractions(
         return denialResult;
       }
       if (!isCurrentRetryPreparation(streamId, requestId, preparation)) {
+        if (isStoredRetryPreparation(streamId, preparation)) {
+          retryPreparations.delete(streamId);
+        }
         return false;
       }
       retryPreparations.delete(streamId);
@@ -310,7 +326,7 @@ export function createProgressHostInteractions(
       if (decision.action === 'cancel') {
         retryPreparations.get(streamId)?.controller.abort();
         retryPreparations.delete(streamId);
-        return handlers().retry.complete(streamId, decision);
+        return completeRetrySettlement(streamId, decision, true);
       }
       void settlePreparedRetry(
         streamId,

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -14,6 +14,10 @@ import type { PlatformSecrets } from '@platform/secrets';
 import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
 import { INCLUDED_ACCESS, OWN_API_KEYS } from '@shared/copy/modelAccess';
 import { providerDisplayName } from '@shared/constants/providers';
+import {
+  isKimiCodeExclusiveModel,
+  isKimiSubscriptionEligible,
+} from '@shared/model/kimiCodeRetryGate';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { coalesceAsync } from '@utils/core';
 import {
@@ -30,11 +34,7 @@ import {
   resolveCodexSubscriptionCapabilities,
   resolveXaiSubscriptionCapabilities,
 } from './providerCapabilities';
-import {
-  isKimiCodeExclusiveModel,
-  isKimiSubscriptionEligible,
-  kimiCodeEffectiveConfig,
-} from './kimiCodeSubscriptionRouting';
+import { kimiCodeEffectiveConfig } from './kimiCodeSubscriptionRouting';
 import {
   buildBaseModelOption,
   buildBasicModelOptionsData,

--- a/src/model/kimiCodeSubscriptionRouting.ts
+++ b/src/model/kimiCodeSubscriptionRouting.ts
@@ -18,11 +18,22 @@
  *    differs (`kimi-k3` → `k3`, see {@link kimiCodeWireModelId}).
  */
 
-import { ModelProvider, type ModelConfig } from 'llm-zoo';
+import { type ModelConfig } from 'llm-zoo';
 
 import { platform } from '@platform/platform';
 import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
+import {
+  isKimiCodeExclusiveModel,
+  isKimiSubscriptionEligible,
+  type KimiSubscriptionModelFields,
+} from '@shared/model/kimiCodeRetryGate';
 import { getPreferKimiCode } from '@utils/config/providerConfig';
+
+export {
+  isKimiCodeExclusiveModel,
+  isKimiSubscriptionEligible,
+  type KimiSubscriptionModelFields,
+};
 
 import { hasUsableApiKey } from './apiProviders';
 import { includedModelAccess } from './includedModelAccess';
@@ -41,45 +52,6 @@ export function kimiCodeWireModelId(config: {
   readonly fullName: string;
 }): string {
   return KIMI_CODE_WIRE_MODEL_IDS[config.fullName] ?? config.fullName;
-}
-
-/**
- * The registry facts the eligibility predicates read. Structural (not the full
- * `ModelConfig`) so routing call sites and test fixtures can pass partial
- * configs.
- */
-export interface KimiSubscriptionModelFields {
-  readonly provider?: string;
-  readonly kimiSubscription?: boolean;
-  readonly baseUrl?: string;
-}
-
-/**
- * Whether `model` is eligible to route through the Kimi Code coding endpoint.
- * Read directly from the llm-zoo `kimiSubscription` registry flag (added in
- * llm-zoo 1.19.x) — serving status is a fact about the Kimi Code backend, not
- * derivable from other model fields. Requires
- * `provider === ModelProvider.MOONSHOT`, asserted here since this function is
- * exported and a non-Moonshot config must never resolve eligible.
- */
-export function isKimiSubscriptionEligible(
-  model: KimiSubscriptionModelFields,
-): boolean {
-  if (model.provider !== ModelProvider.MOONSHOT) return false;
-  return model.kimiSubscription === true;
-}
-
-/**
- * Whether `model` is served ONLY by the coding endpoint (no open-platform or
- * OpenRouter route exists). Derived from the registry's pinned `baseUrl` — the
- * pin is what makes the model unreachable anywhere else.
- */
-export function isKimiCodeExclusiveModel(
-  model: KimiSubscriptionModelFields,
-): boolean {
-  return (
-    isKimiSubscriptionEligible(model) && model.baseUrl === KIMI_CODE_BASE_URL
-  );
 }
 
 /**

--- a/src/model/kimiCodeSubscriptionRouting.ts
+++ b/src/model/kimiCodeSubscriptionRouting.ts
@@ -29,12 +29,6 @@ import {
 } from '@shared/model/kimiCodeRetryGate';
 import { getPreferKimiCode } from '@utils/config/providerConfig';
 
-export {
-  isKimiCodeExclusiveModel,
-  isKimiSubscriptionEligible,
-  type KimiSubscriptionModelFields,
-};
-
 import { hasUsableApiKey } from './apiProviders';
 import { includedModelAccess } from './includedModelAccess';
 import { zeroCostAccessOverrides } from './subscriptionAccessOverrides';

--- a/src/model/openRouterRouting.ts
+++ b/src/model/openRouterRouting.ts
@@ -1,8 +1,9 @@
-import { isApiProvider, type ApiProvider } from './apiProviders';
 import {
   isKimiCodeExclusiveModel,
   type KimiSubscriptionModelFields,
-} from './kimiCodeSubscriptionRouting';
+} from '@shared/model/kimiCodeRetryGate';
+
+import { isApiProvider, type ApiProvider } from './apiProviders';
 
 import type { ModelConfig } from 'llm-zoo';
 

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -6,11 +6,11 @@ import { isPreferCodexSubscription } from '@model/codex/codexPreference';
 import { isPreferXaiSubscription } from '@model/xai/xaiPreference';
 import { isXaiSignedIn } from '@model/xai/xaiSignedIn';
 import type { UsageRoute } from '@shared/schemas';
+import { isKimiSubscriptionEligible } from '@shared/model/kimiCodeRetryGate';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 import {
   isKimiCodeRoute,
-  isKimiSubscriptionEligible,
   resolveKimiCodeRoutingFacts,
 } from './kimiCodeSubscriptionRouting';
 import { resolveRuntimeModelConfig } from './runtimeModelRegistry';

--- a/src/shared/model/kimiCodeRetryGate.ts
+++ b/src/shared/model/kimiCodeRetryGate.ts
@@ -63,3 +63,20 @@ export function isKimiCodeExclusiveRetryModel(
   const config = MODEL_CONFIGS[model];
   return config !== undefined && isKimiCodeExclusiveModel(config);
 }
+
+/**
+ * Whether the progress-view retry must not offer the personal API-key switch.
+ * Exclusive Kimi Code models have no open-platform fallback when their
+ * coding-plan quota is exhausted, so switching to a personal credential cannot
+ * reroute them. Both the webview offer gate and the host enforcement gate
+ * consume this composed predicate so they cannot desync.
+ */
+export function isKimiCodeSubscriptionRetryBlocked(
+  model: string | undefined,
+  exhaustionReason: string | undefined,
+): boolean {
+  return (
+    exhaustionReason === 'kimi-code-subscription' &&
+    isKimiCodeExclusiveRetryModel(model)
+  );
+}

--- a/src/shared/model/kimiCodeRetryGate.ts
+++ b/src/shared/model/kimiCodeRetryGate.ts
@@ -1,14 +1,54 @@
 /**
- * Browser-safe Kimi Code exclusivity gate for retry switches.
+ * Browser-safe Kimi Code subscription model facts and retry gate.
  *
- * The host-side route resolver (`@model/kimiCodeSubscriptionRouting`) owns the
- * equivalent predicate for routing decisions; this module is deliberately free
- * of platform/secret-store imports so webview panels can read the same static
- * llm-zoo registry facts when deciding whether to offer an API-key switch.
+ * The pure field-level predicates below are the single source for Kimi Code
+ * eligibility/exclusivity. Host-side route resolution
+ * (`@model/kimiCodeSubscriptionRouting`) imports them, so routing decisions
+ * and webview retry panels can never drift. This module is deliberately free
+ * of platform/secret-store imports.
  */
 import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 
 import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
+
+/**
+ * The registry facts the eligibility predicates read. Structural (not the full
+ * `ModelConfig`) so routing call sites and test fixtures can pass partial
+ * configs.
+ */
+export interface KimiSubscriptionModelFields {
+  readonly provider?: string;
+  readonly kimiSubscription?: boolean;
+  readonly baseUrl?: string;
+}
+
+/**
+ * Whether `model` is eligible to route through the Kimi Code coding endpoint.
+ * Read directly from the llm-zoo `kimiSubscription` registry flag — serving
+ * status is a fact about the Kimi Code backend, not derivable from other model
+ * fields. Requires `provider === ModelProvider.MOONSHOT`, asserted here since
+ * this function is exported and a non-Moonshot config must never resolve
+ * eligible.
+ */
+export function isKimiSubscriptionEligible(
+  model: KimiSubscriptionModelFields,
+): boolean {
+  if (model.provider !== ModelProvider.MOONSHOT) return false;
+  return model.kimiSubscription === true;
+}
+
+/**
+ * Whether `model` is served ONLY by the coding endpoint (no open-platform or
+ * OpenRouter route exists). Derived from the registry's pinned `baseUrl` — the
+ * pin is what makes the model unreachable anywhere else.
+ */
+export function isKimiCodeExclusiveModel(
+  model: KimiSubscriptionModelFields,
+): boolean {
+  return (
+    isKimiSubscriptionEligible(model) && model.baseUrl === KIMI_CODE_BASE_URL
+  );
+}
 
 /**
  * Whether the retrying model is served ONLY by the Kimi Code coding endpoint
@@ -21,10 +61,5 @@ export function isKimiCodeExclusiveRetryModel(
 ): boolean {
   if (model === undefined) return false;
   const config = MODEL_CONFIGS[model];
-  return (
-    config !== undefined &&
-    config.provider === ModelProvider.MOONSHOT &&
-    config.kimiSubscription === true &&
-    config.baseUrl === KIMI_CODE_BASE_URL
-  );
+  return config !== undefined && isKimiCodeExclusiveModel(config);
 }

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -600,11 +600,11 @@ describe('ProgressApiKeyRetryController', () => {
     expect(pendingChecks).toBe(2);
   });
 
-  it('allows a Kimi Code-exclusive model to enter a fresh key on credit depletion', async () => {
+  it('prompts for the kimiCode credential when an exclusive model rebinds on credit depletion', async () => {
     const harness = createHarness({
-      keys: { anthropic: 'old-key' },
+      keys: { kimiCode: 'old-kimi', moonshot: 'old-moonshot' },
       prompt: (keys) => {
-        keys.set('anthropic', 'new-key');
+        keys.set('kimiCode', 'new-kimi');
       },
     });
 
@@ -612,6 +612,7 @@ describe('ProgressApiKeyRetryController', () => {
       stream: 'stream-kimi-credit',
       requestId: 'retry-kimi-credit',
       model: 'kimiCoding',
+      provider: 'moonshot',
       exhaustionReason: 'upstream-credit',
     });
 
@@ -622,7 +623,12 @@ describe('ProgressApiKeyRetryController', () => {
       disabledChatGptSubscription: false,
       disabledCodingPlans: [],
     });
-    expect(harness.prompts).toStrictEqual([undefined]);
+    // The SDK error identifies the open-platform Moonshot provider, but the
+    // exclusive handler rebinds with `kimiCode`; the prompt and key check must
+    // target the same credential or the retry repeats the same failure.
+    expect(harness.prompts).toStrictEqual(['kimiCode']);
+    expect(harness.keys.get('kimiCode')).toBe('new-kimi');
+    expect(harness.keys.get('moonshot')).toBe('old-moonshot');
     expect(harness.retries).toStrictEqual(['stream-kimi-credit']);
   });
 });

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -573,4 +573,56 @@ describe('ProgressApiKeyRetryController', () => {
     expect(harness.includedAccessValues).toStrictEqual([]);
     expect(harness.retries).toStrictEqual([]);
   });
+
+  it('rechecks retry identity after the routing queue admits the request', async () => {
+    let pendingChecks = 0;
+    const harness = createHarness({
+      keys: { openai: 'stored-openai' },
+      isRetryPending: () => {
+        pendingChecks += 1;
+        // The pre-queue check passes; the request is dismissed before the
+        // serialized callback starts, so the in-queue recheck must fail.
+        return pendingChecks === 1;
+      },
+    });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-stale-queue',
+      requestId: 'retry-stale-queue',
+      provider: 'openai',
+      exhaustionReason: 'chatgpt-subscription',
+    });
+
+    expect(result).toStrictEqual(IDLE_RESULT);
+    expect(harness.includedAccessValues).toStrictEqual([]);
+    expect(harness.chatGptSubscriptionValues).toStrictEqual([]);
+    expect(harness.retries).toStrictEqual([]);
+    expect(pendingChecks).toBe(2);
+  });
+
+  it('allows a Kimi Code-exclusive model to enter a fresh key on credit depletion', async () => {
+    const harness = createHarness({
+      keys: { anthropic: 'old-key' },
+      prompt: (keys) => {
+        keys.set('anthropic', 'new-key');
+      },
+    });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-kimi-credit',
+      requestId: 'retry-kimi-credit',
+      model: 'kimiCoding',
+      exhaustionReason: 'upstream-credit',
+    });
+
+    expect(result).toStrictEqual({
+      proceeded: true,
+      retried: true,
+      disabledIncludedModelAccess: false,
+      disabledChatGptSubscription: false,
+      disabledCodingPlans: [],
+    });
+    expect(harness.prompts).toStrictEqual([undefined]);
+    expect(harness.retries).toStrictEqual(['stream-kimi-credit']);
+  });
 });

--- a/src/test-kernel/model/KimiCodeModels.vitest.ts
+++ b/src/test-kernel/model/KimiCodeModels.vitest.ts
@@ -16,6 +16,11 @@ import {
 } from '@model/openRouterRouting';
 import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import { SETUP_MODEL_BY_PROVIDER } from '@model/setupModelDefaults';
+import {
+  isKimiCodeExclusiveModel as sharedIsKimiCodeExclusiveModel,
+  isKimiCodeExclusiveRetryModel,
+  isKimiSubscriptionEligible as sharedIsKimiSubscriptionEligible,
+} from '@shared/model/kimiCodeRetryGate';
 
 describe('Kimi Code model registry', () => {
   it.each([
@@ -51,6 +56,23 @@ describe('Kimi Code model registry', () => {
   it('resolves plan aliases through the runtime registry like any model', () => {
     expect(getRuntimeModelConfig('kimiCoding')).toBe(MODEL_CONFIGS.kimiCoding);
     expect(getRuntimeModelConfig('kimi25T')).toBe(MODEL_CONFIGS.kimi25T);
+  });
+});
+
+describe('Kimi Code exclusivity single-source', () => {
+  it('re-exports the shared field predicates from the route resolver', () => {
+    expect(isKimiCodeExclusiveModel).toBe(sharedIsKimiCodeExclusiveModel);
+    expect(isKimiSubscriptionEligible).toBe(sharedIsKimiSubscriptionEligible);
+  });
+
+  it('keeps the retry model-id gate aligned with the shared field predicate', () => {
+    for (const [id, config] of Object.entries(MODEL_CONFIGS)) {
+      expect(isKimiCodeExclusiveRetryModel(id)).toBe(
+        isKimiCodeExclusiveModel(config),
+      );
+    }
+    expect(isKimiCodeExclusiveRetryModel(undefined)).toBe(false);
+    expect(isKimiCodeExclusiveRetryModel('not-a-registered-model')).toBe(false);
   });
 });
 

--- a/src/test-kernel/model/KimiCodeModels.vitest.ts
+++ b/src/test-kernel/model/KimiCodeModels.vitest.ts
@@ -3,11 +3,7 @@ import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 
 import { resolveModelHandlerCompatibilityKey } from '@agent/runtime/ModelFactory';
 
-import {
-  isKimiCodeExclusiveModel,
-  isKimiSubscriptionEligible,
-  kimiCodeWireModelId,
-} from '@model/kimiCodeSubscriptionRouting';
+import { kimiCodeWireModelId } from '@model/kimiCodeSubscriptionRouting';
 import {
   allowsModelRelay,
   resolveModelApiKeyProvider,
@@ -17,9 +13,10 @@ import {
 import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import { SETUP_MODEL_BY_PROVIDER } from '@model/setupModelDefaults';
 import {
-  isKimiCodeExclusiveModel as sharedIsKimiCodeExclusiveModel,
+  isKimiCodeExclusiveModel,
   isKimiCodeExclusiveRetryModel,
-  isKimiSubscriptionEligible as sharedIsKimiSubscriptionEligible,
+  isKimiCodeSubscriptionRetryBlocked,
+  isKimiSubscriptionEligible,
 } from '@shared/model/kimiCodeRetryGate';
 
 describe('Kimi Code model registry', () => {
@@ -60,11 +57,6 @@ describe('Kimi Code model registry', () => {
 });
 
 describe('Kimi Code exclusivity single-source', () => {
-  it('re-exports the shared field predicates from the route resolver', () => {
-    expect(isKimiCodeExclusiveModel).toBe(sharedIsKimiCodeExclusiveModel);
-    expect(isKimiSubscriptionEligible).toBe(sharedIsKimiSubscriptionEligible);
-  });
-
   it('keeps the retry model-id gate aligned with the shared field predicate', () => {
     for (const [id, config] of Object.entries(MODEL_CONFIGS)) {
       expect(isKimiCodeExclusiveRetryModel(id)).toBe(
@@ -73,6 +65,24 @@ describe('Kimi Code exclusivity single-source', () => {
     }
     expect(isKimiCodeExclusiveRetryModel(undefined)).toBe(false);
     expect(isKimiCodeExclusiveRetryModel('not-a-registered-model')).toBe(false);
+  });
+
+  it('blocks the personal-key switch only for exclusive plan-quota exhaustion', () => {
+    expect(
+      isKimiCodeSubscriptionRetryBlocked(
+        'kimiCoding',
+        'kimi-code-subscription',
+      ),
+    ).toBe(true);
+    expect(
+      isKimiCodeSubscriptionRetryBlocked('kimiCoding', 'upstream-credit'),
+    ).toBe(false);
+    expect(
+      isKimiCodeSubscriptionRetryBlocked('kimi3', 'kimi-code-subscription'),
+    ).toBe(false);
+    expect(
+      isKimiCodeSubscriptionRetryBlocked(undefined, 'kimi-code-subscription'),
+    ).toBe(false);
   });
 });
 

--- a/src/test-kernel/model/KimiSubscriptionRouting.vitest.ts
+++ b/src/test-kernel/model/KimiSubscriptionRouting.vitest.ts
@@ -2,13 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { ModelProvider } from 'llm-zoo';
 
 import {
-  isKimiCodeExclusiveModel,
-  isKimiSubscriptionEligible,
   kimiCodeRuntimeConfig,
   kimiCodeWireModelId,
   resolveKimiCodeRoute,
 } from '@model/kimiCodeSubscriptionRouting';
 import { KIMI_CODE_BASE_URL } from '@shared/constants/providers';
+import {
+  isKimiCodeExclusiveModel,
+  isKimiSubscriptionEligible,
+} from '@shared/model/kimiCodeRetryGate';
 import type { ModelConfig } from 'llm-zoo';
 
 const dual = {

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
@@ -610,6 +610,81 @@ describe('createExtensionHostInteractions', () => {
     await expect(result).resolves.toEqual({ action: 'cancel' });
   });
 
+  it('removes a canceled preparation from the retry map', async () => {
+    const abortSpy = vi.spyOn(AbortController.prototype, 'abort');
+    try {
+      const { interactions } = createInteractions({
+        session: createTestSession(),
+      });
+      const preparation = createDeferredPreparation();
+
+      const result = interactions.requestRetry?.(
+        {
+          requestId: 'retry:cancel-map',
+          streamId: STREAM_A,
+          operation: 'First invocation',
+        },
+        { prepareRetry: preparation.prepareRetry },
+      );
+      const personal = interactions.submitRetryWithPersonalCredentials(
+        STREAM_A,
+        'retry:cancel-map',
+      );
+      await vi.waitFor(() =>
+        expect(preparation.prepareRetry).toHaveBeenCalledOnce(),
+      );
+
+      interactions.cancel({ streamId: STREAM_A, kind: 'retry' });
+      await expect(personal).resolves.toBe(false);
+      await expect(result).resolves.toEqual({ action: 'cancel' });
+      expect(preparation.signal()?.aborted).toBe(true);
+
+      const abortsFor = (signal: AbortSignal | undefined) =>
+        abortSpy.mock.instances.filter(
+          (instance) => (instance as AbortController).signal === signal,
+        ).length;
+      expect(abortsFor(preparation.signal())).toBe(1);
+
+      // If the canceled preparation stayed in the retry map, a replacement
+      // request would abort its old controller again before overwriting the
+      // entry. Removal keeps the old controller's abort count at exactly one.
+      const replacement = interactions.requestRetry?.({
+        requestId: 'retry:after-cancel',
+        streamId: STREAM_A,
+        operation: 'Replacement invocation',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(abortsFor(preparation.signal())).toBe(1);
+
+      interactions.cancel({ streamId: STREAM_A, kind: 'retry' });
+      await expect(replacement).resolves.toEqual({ action: 'cancel' });
+    } finally {
+      abortSpy.mockRestore();
+    }
+  });
+
+  it('wraps cancel-path settlement when the dismiss transport throws', async () => {
+    const { handlers, interactions } = createInteractions({
+      session: createTestSession(),
+    });
+    const result = interactions.requestRetry?.({
+      requestId: 'retry:cancel-settlement',
+      streamId: STREAM_A,
+      operation: 'Model invocation',
+    });
+    handlers.transport.retry.dismiss.mockImplementationOnce(() => {
+      throw new Error('Progress view dismiss transport unavailable.');
+    });
+
+    expect(
+      interactions.submitRetryDecision(STREAM_A, 'retry:cancel-settlement', {
+        action: 'cancel',
+      }),
+    ).toBe(true);
+    await expect(result).resolves.toEqual({ action: 'cancel' });
+    expect(handlers.transport.retry.dismiss).toHaveBeenCalledWith('stream-a');
+  });
+
   it('does not abort preparations outside the cancellation scope', async () => {
     const { interactions } = createInteractions({
       session: createTestSession(),

--- a/src/test-kernel/progressView/RetryRequestPanel.vitest.ts
+++ b/src/test-kernel/progressView/RetryRequestPanel.vitest.ts
@@ -119,6 +119,26 @@ describe('retry-request-panel', () => {
     expect(actions).toEqual([{ action: 'retry' }]);
   });
 
+  it('offers the API-key switch for an exclusive model on upstream-credit depletion', async () => {
+    const element = await mountPanel({
+      model: 'kimiCoding',
+      errorDetails: {
+        exhaustionReason: 'upstream-credit',
+        isRelayError: false,
+        userRetryable: true,
+      },
+    });
+
+    const buttons = [
+      ...(element.shadowRoot?.querySelectorAll(
+        '.retry-request__actions wa-button',
+      ) ?? []),
+    ];
+    expect(buttons.map((button) => button.getAttribute('data-action'))).toEqual(
+      ['useOwnApiKey', 'retry', 'cancel'],
+    );
+  });
+
   it('marks retry action buttons with action ids for shared sizing styles', async () => {
     const element = await mountPanel();
 


### PR DESCRIPTION
Follow-ups from #10557 (tracker #10562).

- **#10563** Re-check `isRetryPending` inside `ProgressApiKeyRetryController.useOwnApiKey`'s serialized routing-queue callback before snapshotting or applying routing, so a request dismissed while queued cannot briefly rebind credentials.
- **#10564** Scope the Kimi Code exclusivity gate to `kimi-code-subscription` plan-quota failures; exclusive models can still enter a fresh key on `upstream-credit`. Updated the panel predicate to match.
- **#10565** Remove a canceled preparation from `retryPreparations` when cancellation removed the handler first (map-identity check, without touching a replacement preparation).
- **#10566** Move `isKimiSubscriptionEligible` / `isKimiCodeExclusiveModel` into `src/shared/model/kimiCodeRetryGate.ts` and have `kimiCodeSubscriptionRouting.ts` re-export them, so routing and the webview retry gate share one field predicate.
- **#10567** Wrap the `submitRetryDecision` cancel path in `completeRetrySettlement`, and pin the dismiss-transport-throw path with a test.

Closes #10563
Closes #10564
Closes #10565
Closes #10566
Closes #10567

## Verification

- `pnpm vitest run --config vitest.config.mjs --hookTimeout 60000 src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts src/test-kernel/progressView/RetryRequestPanel.vitest.ts src/test-kernel/model/KimiCodeModels.vitest.ts src/test-kernel/model/KimiSubscriptionRouting.vitest.ts` — 5 files, 77 tests passed.
- `pnpm run typecheck:workspace` — passed.
- `pnpm run typecheck:test-kernel` — passed.
- `pnpm run typecheck:cli` — passed.
- `pnpm run lint` — passed (exit 0).
- `pnpm exec prettier --check <changed files>` — passed.
- `pnpm run check:dead-code-ratchet` — passed (15 baselined, no new findings).
- `pnpm run check:guidance-refs` — passed.
- `pnpm run check:browser-safe-utils` — passed.
