### PR TITLE
test(agent,latex): pin latex discovery adapter and consume LatexTrace

### DIFF
--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -241,14 +241,30 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
   );
 }
 
+interface LatexExecutionDiscoveryDependencies {
+  readonly listExecutions: typeof listExecutions;
+  readonly getExecutionStore: typeof getExecutionStore;
+}
+
+const DEFAULT_LATEX_EXECUTION_DISCOVERY_DEPENDENCIES: LatexExecutionDiscoveryDependencies =
+  {
+    listExecutions,
+    getExecutionStore,
+  };
+
 /**
  * Adapter from the agent storage surface to the latex-owned execution
  * discovery port. Hosts inject this into latexdiff orchestration.
+ *
+ * Dependencies are injectable so the projection/filter contract can be unit
+ * tested without scanning real execution storage.
  */
-export function createLatexExecutionDiscovery(): LatexExecutionDiscoveryPort {
+export function createLatexExecutionDiscovery(
+  dependencies: LatexExecutionDiscoveryDependencies = DEFAULT_LATEX_EXECUTION_DISCOVERY_DEPENDENCIES,
+): LatexExecutionDiscoveryPort {
   return {
     async listAgentRuns(): Promise<readonly LatexAgentRunEntry[]> {
-      const executions = await listExecutions();
+      const executions = await dependencies.listExecutions();
       return executions.filter(isAgentRunEntry).map((entry) => ({
         id: entry.id,
         timestamp: entry.timestamp,
@@ -258,7 +274,8 @@ export function createLatexExecutionDiscovery(): LatexExecutionDiscoveryPort {
       }));
     },
     async readStreamId(executionId) {
-      return (await getExecutionStore(executionId).readMeta())?.streamId;
+      return (await dependencies.getExecutionStore(executionId).readMeta())
+        ?.streamId;
     },
   };
 }

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -21,6 +21,7 @@ import { createLog } from '@logger/logUtils';
 import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import type {
   ExecutionId,
+  ExecutionMeta,
   RunIdentity,
   RunOutcome,
   StreamTabId,
@@ -243,14 +244,16 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
 
 interface LatexExecutionDiscoveryDependencies {
   readonly listExecutions: typeof listExecutions;
-  readonly getExecutionStore: typeof getExecutionStore;
+  readonly readStreamMeta: (
+    executionId: ExecutionId,
+  ) => Promise<ExecutionMeta | null>;
 }
 
-const DEFAULT_LATEX_EXECUTION_DISCOVERY_DEPENDENCIES: LatexExecutionDiscoveryDependencies =
-  {
-    listExecutions,
-    getExecutionStore,
-  };
+const DEFAULT_LATEX_EXECUTION_DISCOVERY_DEPENDENCIES = Object.freeze({
+  listExecutions,
+  readStreamMeta: (executionId: ExecutionId) =>
+    getExecutionStore(executionId).readMeta(),
+} as const satisfies LatexExecutionDiscoveryDependencies);
 
 /**
  * Adapter from the agent storage surface to the latex-owned execution
@@ -274,8 +277,7 @@ export function createLatexExecutionDiscovery(
       }));
     },
     async readStreamId(executionId) {
-      return (await dependencies.getExecutionStore(executionId).readMeta())
-        ?.streamId;
+      return (await dependencies.readStreamMeta(executionId))?.streamId;
     },
   };
 }

--- a/src/test-kernel/agent/storage/LatexExecutionDiscovery.vitest.ts
+++ b/src/test-kernel/agent/storage/LatexExecutionDiscovery.vitest.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  AgentExecutionListingEntry,
+  ExecutionListingEntry,
+} from '@agent/storage';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { createLatexExecutionDiscovery } from '@agent/storage/executionListing';
+import type { ExecutionId } from '@shared/schemas';
+
+const mocks = vi.hoisted(() => ({
+  listExecutions: vi.fn(),
+  getExecutionStore: vi.fn(),
+  readMeta: vi.fn(),
+}));
+
+function agentEntry(
+  overrides: Partial<AgentConfig> = {},
+): AgentExecutionListingEntry {
+  return {
+    kind: 'run',
+    id: 'aaa111' as ExecutionId,
+    timestamp: '2026-07-15T10:00:00.000Z',
+    identity: { kind: 'agent', agent: overrides.agent ?? 'assistant' },
+    record: {
+      agent: 'assistant',
+      model: 'deepseek',
+      inputFiles: ['main.tex', 'figures.tex'],
+      ...overrides,
+    } as AgentConfig,
+  };
+}
+
+function processEntry(
+  id: ExecutionId = 'bbb222' as ExecutionId,
+): ExecutionListingEntry {
+  return {
+    kind: 'run',
+    id,
+    timestamp: '2026-07-15T09:00:00.000Z',
+    identity: { kind: 'process', tool: 'bash' },
+    record: { name: 'bash', instruction: 'ls -la' },
+  };
+}
+
+function incompleteEntry(
+  id: ExecutionId = 'ccc333' as ExecutionId,
+): ExecutionListingEntry {
+  return {
+    kind: 'incomplete',
+    id,
+    timestamp: '2026-07-15T08:00:00.000Z',
+  };
+}
+
+function discoveryWithStubbedStorage(): ReturnType<
+  typeof createLatexExecutionDiscovery
+> {
+  return createLatexExecutionDiscovery({
+    listExecutions: mocks.listExecutions,
+    getExecutionStore: mocks.getExecutionStore,
+  });
+}
+
+describe('createLatexExecutionDiscovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getExecutionStore.mockReturnValue({ readMeta: mocks.readMeta });
+  });
+
+  it('projects only agent runs with the expected latex discovery fields', async () => {
+    const run = agentEntry({
+      model: 'deepseek',
+      inputFiles: ['main.tex', 'figures.tex'],
+    });
+    mocks.listExecutions.mockResolvedValue([
+      processEntry(),
+      run,
+      incompleteEntry(),
+    ]);
+
+    await expect(
+      discoveryWithStubbedStorage().listAgentRuns(),
+    ).resolves.toEqual([
+      {
+        id: run.id,
+        timestamp: run.timestamp,
+        agent: 'assistant',
+        model: 'deepseek',
+        inputFiles: ['main.tex', 'figures.tex'],
+      },
+    ]);
+    expect(mocks.listExecutions).toHaveBeenCalledOnce();
+  });
+
+  it('reads the registered stream id from execution metadata', async () => {
+    mocks.readMeta.mockResolvedValue({
+      streamId: 'polish@earlierModel#exec-agent',
+    });
+
+    await expect(
+      discoveryWithStubbedStorage().readStreamId('exec-agent' as ExecutionId),
+    ).resolves.toBe('polish@earlierModel#exec-agent');
+    expect(mocks.getExecutionStore).toHaveBeenCalledWith('exec-agent');
+  });
+
+  it('returns undefined for an execution without a registered stream', async () => {
+    mocks.readMeta.mockResolvedValue(null);
+
+    await expect(
+      discoveryWithStubbedStorage().readStreamId(
+        'exec-unregistered' as ExecutionId,
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/test-kernel/agent/storage/LatexExecutionDiscovery.vitest.ts
+++ b/src/test-kernel/agent/storage/LatexExecutionDiscovery.vitest.ts
@@ -4,30 +4,55 @@ import type {
   AgentExecutionListingEntry,
   ExecutionListingEntry,
 } from '@agent/storage';
-import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import {
+  AgentConfigSchema,
+  type AgentConfig,
+} from '@agent/core/definition/AgentConfig';
 import { createLatexExecutionDiscovery } from '@agent/storage/executionListing';
-import type { ExecutionId } from '@shared/schemas';
+import type { ExecutionId, ExecutionMeta } from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
-  listExecutions: vi.fn(),
-  getExecutionStore: vi.fn(),
-  readMeta: vi.fn(),
+  listExecutions: vi.fn<() => Promise<ExecutionListingEntry[]>>(),
+  readStreamMeta:
+    vi.fn<(executionId: ExecutionId) => Promise<ExecutionMeta | null>>(),
 }));
 
+function agentConfig(
+  agent: string,
+  model: string,
+  inputFiles: readonly string[],
+): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent,
+    model,
+    instruction: 'Test latex execution discovery.',
+    agentCategory: AgentCategory.ToolUse,
+    workingDirectory: '/workspace',
+    inputFiles,
+  });
+}
+
 function agentEntry(
-  overrides: Partial<AgentConfig> = {},
+  id: ExecutionId,
+  agent: string,
+  model: string,
+  inputFiles: readonly string[],
+  options: {
+    readonly timestamp?: string;
+    readonly parentExecutionId?: ExecutionId;
+  } = {},
 ): AgentExecutionListingEntry {
+  const record = agentConfig(agent, model, inputFiles);
   return {
     kind: 'run',
-    id: 'aaa111' as ExecutionId,
-    timestamp: '2026-07-15T10:00:00.000Z',
-    identity: { kind: 'agent', agent: overrides.agent ?? 'assistant' },
-    record: {
-      agent: 'assistant',
-      model: 'deepseek',
-      inputFiles: ['main.tex', 'figures.tex'],
-      ...overrides,
-    } as AgentConfig,
+    id,
+    timestamp: options.timestamp ?? '2026-07-15T10:00:00.000Z',
+    ...(options.parentExecutionId === undefined
+      ? {}
+      : { parentExecutionId: options.parentExecutionId }),
+    identity: { kind: 'agent', agent },
+    record,
   };
 }
 
@@ -53,64 +78,96 @@ function incompleteEntry(
   };
 }
 
+function executionMeta(streamId?: ExecutionMeta['streamId']): ExecutionMeta {
+  return {
+    schemaVersion: 1,
+    timestamp: '2026-07-15T10:00:00.000Z',
+    ...(streamId === undefined ? {} : { streamId }),
+  };
+}
+
 function discoveryWithStubbedStorage(): ReturnType<
   typeof createLatexExecutionDiscovery
 > {
   return createLatexExecutionDiscovery({
     listExecutions: mocks.listExecutions,
-    getExecutionStore: mocks.getExecutionStore,
+    readStreamMeta: mocks.readStreamMeta,
   });
 }
 
 describe('createLatexExecutionDiscovery', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getExecutionStore.mockReturnValue({ readMeta: mocks.readMeta });
   });
 
-  it('projects only agent runs with the expected latex discovery fields', async () => {
-    const run = agentEntry({
-      model: 'deepseek',
-      inputFiles: ['main.tex', 'figures.tex'],
-    });
+  it('projects agent runs, including delegated children, through the latex discovery filter', async () => {
+    const root = agentEntry(
+      'root-run' as ExecutionId,
+      'assistant',
+      'deepseek',
+      ['main.tex', 'figures.tex'],
+    );
+    const delegatedChild = agentEntry(
+      'child-run' as ExecutionId,
+      'delegated',
+      'deepseek',
+      ['child.tex'],
+      { parentExecutionId: root.id },
+    );
     mocks.listExecutions.mockResolvedValue([
       processEntry(),
-      run,
+      root,
       incompleteEntry(),
+      delegatedChild,
     ]);
 
     await expect(
       discoveryWithStubbedStorage().listAgentRuns(),
     ).resolves.toEqual([
       {
-        id: run.id,
-        timestamp: run.timestamp,
+        id: root.id,
+        timestamp: root.timestamp,
         agent: 'assistant',
         model: 'deepseek',
         inputFiles: ['main.tex', 'figures.tex'],
+      },
+      {
+        id: delegatedChild.id,
+        timestamp: delegatedChild.timestamp,
+        agent: 'delegated',
+        model: 'deepseek',
+        inputFiles: ['child.tex'],
       },
     ]);
     expect(mocks.listExecutions).toHaveBeenCalledOnce();
   });
 
   it('reads the registered stream id from execution metadata', async () => {
-    mocks.readMeta.mockResolvedValue({
-      streamId: 'polish@earlierModel#exec-agent',
-    });
+    mocks.readStreamMeta.mockResolvedValue(
+      executionMeta('polish@earlierModel#exec-agent'),
+    );
 
     await expect(
       discoveryWithStubbedStorage().readStreamId('exec-agent' as ExecutionId),
     ).resolves.toBe('polish@earlierModel#exec-agent');
-    expect(mocks.getExecutionStore).toHaveBeenCalledWith('exec-agent');
+    expect(mocks.readStreamMeta).toHaveBeenCalledWith('exec-agent');
   });
 
-  it('returns undefined for an execution without a registered stream', async () => {
-    mocks.readMeta.mockResolvedValue(null);
+  it('returns undefined when execution metadata has no registered stream', async () => {
+    mocks.readStreamMeta.mockResolvedValue(executionMeta());
 
     await expect(
       discoveryWithStubbedStorage().readStreamId(
-        'exec-unregistered' as ExecutionId,
+        'exec-no-stream' as ExecutionId,
       ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when execution metadata is absent', async () => {
+    mocks.readStreamMeta.mockResolvedValue(null);
+
+    await expect(
+      discoveryWithStubbedStorage().readStreamId('exec-no-meta' as ExecutionId),
     ).resolves.toBeUndefined();
   });
 });

--- a/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
+++ b/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import {
   LatexMediaManager,
+  type LatexTrace,
   type MediaWorkspaceState,
 } from '@latex/LatexMediaManager';
 import { DiffFileProcessor } from '@latex/latexdiff/diffFileProcessor';
@@ -56,7 +57,7 @@ const compilePdfConfig: ToolConfig = {
   autoCompileInputPdf: true,
 };
 
-const logger = spiedTrace();
+const logger: LatexTrace = spiedTrace();
 
 const tempDirs: string[] = [];
 


### PR DESCRIPTION
## Summary

Resolves the two actionable follow-ups tracked by #10559 from #10558.

- `createLatexExecutionDiscovery` now takes its storage dependencies (`listExecutions`/`readStreamMeta`) as an optional injectable object, defaulting to the real implementations (`readStreamMeta(id) = getExecutionStore(id).readMeta()`), with the default object frozen. The new `LatexExecutionDiscovery.vitest.ts` unit-tests the adapter contract directly: the `isAgentRunEntry` filter (including delegated child runs) and the `id/timestamp/agent/model/inputFiles` projection are behavior-tested instead of only typechecked, and `readStreamId()` is pinned to `readMeta()?.streamId` for registered-stream, no-stream, and absent-meta cases.
- `LatexTrace` now has a consumer: the existing `spiedTrace()` fake in `LatexProcessingHelpers.vitest.ts` is typed as `LatexTrace`, pinning the structural logging slice `LatexMediaManager` actually calls (mirroring the sibling `MediaWorkspaceState` consumer).

## R7 note

`LatexExecutionDiscovery.vitest.ts` is the named cross-module scenario: `executionListing.ts` already has integration coverage in `ExecutionListing.vitest.ts` (real platform/storage writes); this new suite is the pure-mock unit test of the latex-owned adapter contract that the DI seam exposes, so it intentionally lives alongside rather than folding into the integration suite.

## Validation

- `npx vitest run src/test-kernel/agent/storage/LatexExecutionDiscovery.vitest.ts src/test-kernel/latex/LatexProcessingHelpers.vitest.ts src/test-kernel/agent/storage/ExecutionListing.vitest.ts src/test-kernel/latex/OutputDiscovery.vitest.ts` → 20 tests passed
- `npx vitest run src/test-kernel/agent/storage/ src/test-kernel/latex/` → 26 files / 222 tests passed
- `npx vitest run src/test-kernel/architecture/dependencyDirection.vitest.ts` → 18 tests passed
- `npm run typecheck:test-kernel`
- `npm run typecheck:agent`
- `npm run typecheck:workspace`
- `node --max-old-space-size=6144 ./node_modules/eslint/bin/eslint.js src/agent/storage/executionListing.ts src/test-kernel/latex/LatexProcessingHelpers.vitest.ts src/test-kernel/agent/storage/LatexExecutionDiscovery.vitest.ts`
- `npx prettier --check src/agent/storage/executionListing.ts src/test-kernel/latex/LatexProcessingHelpers.vitest.ts src/test-kernel/agent/storage/LatexExecutionDiscovery.vitest.ts`
- `git diff --check`
- `npm run check:dead-code-ratchet`

Closes #10560
Closes #10561
