### PR TITLE
fix(model): clear deprecated Copilot route preferences during reconciliation

### DIFF
--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -311,7 +311,7 @@ export async function initCliPlatform(
           logAt(
             'info',
             'cli.models',
-            `Cleared deprecated Copilot route preferences: [${routePreferencesCleared.join(', ')}]`,
+            `Cleared stale Copilot route preferences: [${routePreferencesCleared.join(', ')}]`,
           );
         }
       }

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -291,16 +291,29 @@ export async function initCliPlatform(
     // lives in shared `~/.texra` state. Preferred defaults reconcile when
     // MODEL_LIST_VERSION changes; retired entries are swept on every startup.
     try {
-      const { added, removed, reordered } = await refreshModelListStateIfNeeded(
-        stateStores.globalState,
-      );
-      if (added.length > 0 || removed.length > 0 || reordered) {
+      const { added, removed, reordered, routePreferencesCleared } =
+        await refreshModelListStateIfNeeded(stateStores.globalState);
+      if (
+        added.length > 0 ||
+        removed.length > 0 ||
+        reordered ||
+        routePreferencesCleared.length > 0
+      ) {
         invalidateModelOptionsCache();
-        logAt(
-          'info',
-          'cli.models',
-          `Refreshed enabled models: added [${added.join(', ')}], removed [${removed.join(', ')}]${reordered ? ', reordered' : ''}`,
-        );
+        if (added.length > 0 || removed.length > 0 || reordered) {
+          logAt(
+            'info',
+            'cli.models',
+            `Refreshed enabled models: added [${added.join(', ')}], removed [${removed.join(', ')}]${reordered ? ', reordered' : ''}`,
+          );
+        }
+        if (routePreferencesCleared.length > 0) {
+          logAt(
+            'info',
+            'cli.models',
+            `Cleared deprecated Copilot route preferences: [${routePreferencesCleared.join(', ')}]`,
+          );
+        }
       }
     } catch (error) {
       logAt(

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -418,7 +418,7 @@ export async function activate(context: vscode.ExtensionContext) {
             if (routePreferencesCleared.length > 0) {
               logger.info(
                 'extension',
-                `Cleared deprecated Copilot route preferences: [${routePreferencesCleared.join(', ')}]`,
+                `Cleared stale Copilot route preferences: [${routePreferencesCleared.join(', ')}]`,
               );
             }
           }

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -391,6 +391,7 @@ export async function activate(context: vscode.ExtensionContext) {
           previousVersion,
           removed,
           reordered,
+          routePreferencesCleared,
           skipped,
         } = await refreshModelListStateIfNeeded(globalSM);
         if (!skipped) {
@@ -401,12 +402,25 @@ export async function activate(context: vscode.ExtensionContext) {
             );
           }
           logger.info('extension', 'Model list refresh completed successfully');
-          if (added.length > 0 || removed.length > 0 || reordered) {
+          if (
+            added.length > 0 ||
+            removed.length > 0 ||
+            reordered ||
+            routePreferencesCleared.length > 0
+          ) {
             invalidateModelOptionsCache();
-            logger.info(
-              'extension',
-              `Refreshed enabled models: added [${added.join(', ')}], removed [${removed.join(', ')}]${reordered ? ', reordered' : ''}`,
-            );
+            if (added.length > 0 || removed.length > 0 || reordered) {
+              logger.info(
+                'extension',
+                `Refreshed enabled models: added [${added.join(', ')}], removed [${removed.join(', ')}]${reordered ? ', reordered' : ''}`,
+              );
+            }
+            if (routePreferencesCleared.length > 0) {
+              logger.info(
+                'extension',
+                `Cleared deprecated Copilot route preferences: [${routePreferencesCleared.join(', ')}]`,
+              );
+            }
           }
         }
       } catch (err) {

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -18,6 +18,11 @@ interface EnabledModelReconciliation {
   removed: string[];
 }
 
+interface CopilotRouteReconciliation {
+  models: string[];
+  cleared: string[];
+}
+
 export interface ModelListRefreshResult {
   skipped: boolean;
   previousVersion: number | undefined;
@@ -26,6 +31,8 @@ export interface ModelListRefreshResult {
   removed: string[];
   /** True when the persisted enabled list was rewritten only to change order. */
   reordered: boolean;
+  /** Copilot route preferences cleared because their base model is deprecated. */
+  routePreferencesCleared: string[];
 }
 
 /**
@@ -99,6 +106,27 @@ function reconcileEnabledModels(
   };
 }
 
+/**
+ * Clear persisted Copilot route preferences whose base model is deprecated.
+ * Copilot discovery deliberately excludes deprecated configs
+ * (`matchingBaseModel` in runtimeModelRegistry.ts), so a route preference for
+ * one can never resolve to a route. Leaving it persisted would strand the
+ * model behind the hard no-fallthrough error (#9635) on every launch. Unlike
+ * the enabled-list deprecated sweep above, this runs unconditionally:
+ * affected users may already have persisted the current MODEL_LIST_VERSION
+ * before this migration shipped.
+ */
+function reconcileCopilotRoutePreferences(
+  currentModels: readonly string[],
+): CopilotRouteReconciliation {
+  const cleared = currentModels.filter((model) => isDeprecatedModel(model));
+  const clearedSet = new Set(cleared);
+  return {
+    models: currentModels.filter((model) => !clearedSet.has(model)),
+    cleared,
+  };
+}
+
 function sameModelList(
   left: readonly string[],
   right: readonly string[],
@@ -115,9 +143,25 @@ export async function refreshModelListStateIfNeeded(
   const previousVersion = state.get<number>(GlobalStateKey.MODEL_LIST_VERSION);
   const versionChanged = previousVersion !== MODEL_LIST_VERSION;
   const currentModels = state.get<string[]>(GlobalStateKey.ENABLED_MODELS);
+  const currentRoutePreferences = state.get<string[]>(
+    GlobalStateKey.COPILOT_ROUTE_MODELS,
+  );
   let added: string[] = [];
   let removed: string[] = [];
   let reordered = false;
+  let routePreferencesCleared: string[] = [];
+  if (currentRoutePreferences) {
+    const reconciliation = reconcileCopilotRoutePreferences(
+      currentRoutePreferences,
+    );
+    routePreferencesCleared = reconciliation.cleared;
+    if (routePreferencesCleared.length > 0) {
+      await state.update(
+        GlobalStateKey.COPILOT_ROUTE_MODELS,
+        reconciliation.models,
+      );
+    }
+  }
   if (currentModels) {
     const reconciliation = reconcileEnabledModels(
       currentModels,
@@ -143,11 +187,13 @@ export async function refreshModelListStateIfNeeded(
       !versionChanged &&
       added.length === 0 &&
       removed.length === 0 &&
-      !reordered,
+      !reordered &&
+      routePreferencesCleared.length === 0,
     previousVersion,
     currentVersion: MODEL_LIST_VERSION,
     added,
     removed,
     reordered,
+    routePreferencesCleared,
   };
 }

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -31,7 +31,7 @@ export interface ModelListRefreshResult {
   removed: string[];
   /** True when the persisted enabled list was rewritten only to change order. */
   reordered: boolean;
-  /** Copilot route preferences cleared because their base model is deprecated. */
+  /** Copilot route preferences cleared because their base model is retired or deprecated. */
   routePreferencesCleared: string[];
 }
 
@@ -107,19 +107,30 @@ function reconcileEnabledModels(
 }
 
 /**
- * Clear persisted Copilot route preferences whose base model is deprecated.
- * Copilot discovery deliberately excludes deprecated configs
+ * Whether a persisted Copilot route preference can no longer resolve. Aligned
+ * with `matchingBaseModel` in runtimeModelRegistry.ts, which excludes both
+ * retired and deprecated configs from Copilot discovery.
+ */
+function isStaleCopilotRouteModel(model: string): boolean {
+  return isRetiredModel(model) || isDeprecatedModel(model);
+}
+
+/**
+ * Clear persisted Copilot route preferences whose base model is retired or
+ * deprecated. Copilot discovery deliberately excludes both kinds of config
  * (`matchingBaseModel` in runtimeModelRegistry.ts), so a route preference for
  * one can never resolve to a route. Leaving it persisted would strand the
  * model behind the hard no-fallthrough error (#9635) on every launch. Unlike
- * the enabled-list deprecated sweep above, this runs unconditionally:
- * affected users may already have persisted the current MODEL_LIST_VERSION
- * before this migration shipped.
+ * the version-gated enabled-list deprecated sweep above, this runs
+ * unconditionally: affected users may already have persisted the current
+ * MODEL_LIST_VERSION before this migration shipped.
  */
 function reconcileCopilotRoutePreferences(
   currentModels: readonly string[],
 ): CopilotRouteReconciliation {
-  const cleared = currentModels.filter((model) => isDeprecatedModel(model));
+  const cleared = currentModels.filter((model) =>
+    isStaleCopilotRouteModel(model),
+  );
   const clearedSet = new Set(cleared);
   return {
     models: currentModels.filter((model) => !clearedSet.has(model)),
@@ -136,7 +147,12 @@ function sameModelList(
   );
 }
 
-/** Sweep retired entries and reconcile defaults when MODEL_LIST_VERSION changes. */
+/**
+ * Reconcile persisted model-list state. The enabled list keeps its retired
+ * sweep and version-gated default reconciliation; Copilot route preferences
+ * are swept unconditionally so stale retired/deprecated routes are cleared
+ * even when MODEL_LIST_VERSION is already current.
+ */
 export async function refreshModelListStateIfNeeded(
   state: ModelListState,
 ): Promise<ModelListRefreshResult> {
@@ -150,18 +166,6 @@ export async function refreshModelListStateIfNeeded(
   let removed: string[] = [];
   let reordered = false;
   let routePreferencesCleared: string[] = [];
-  if (currentRoutePreferences) {
-    const reconciliation = reconcileCopilotRoutePreferences(
-      currentRoutePreferences,
-    );
-    routePreferencesCleared = reconciliation.cleared;
-    if (routePreferencesCleared.length > 0) {
-      await state.update(
-        GlobalStateKey.COPILOT_ROUTE_MODELS,
-        reconciliation.models,
-      );
-    }
-  }
   if (currentModels) {
     const reconciliation = reconcileEnabledModels(
       currentModels,
@@ -181,6 +185,22 @@ export async function refreshModelListStateIfNeeded(
 
   if (versionChanged) {
     await state.update(GlobalStateKey.MODEL_LIST_VERSION, MODEL_LIST_VERSION);
+  }
+  // Sweep route preferences last so a rejected write here cannot prevent the
+  // pre-existing enabled-list/version reconciliation above. A transient write
+  // failure retries on the next startup, where the earlier writes are already
+  // idempotent.
+  if (currentRoutePreferences) {
+    const reconciliation = reconcileCopilotRoutePreferences(
+      currentRoutePreferences,
+    );
+    routePreferencesCleared = reconciliation.cleared;
+    if (routePreferencesCleared.length > 0) {
+      await state.update(
+        GlobalStateKey.COPILOT_ROUTE_MODELS,
+        reconciliation.models,
+      );
+    }
   }
   return {
     skipped:

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MODEL_CONFIGS } from 'llm-zoo';
 
 // Local imports
 import { resolveAndResumeStream } from '@agent/runtime/resolveAndResumeStream';
@@ -327,6 +328,45 @@ describe('CLI platform init', () => {
       GlobalStateKey.MODEL_LIST_VERSION,
       MODEL_LIST_VERSION,
     );
+  });
+
+  it('invalidates and logs when only Copilot route preferences are cleared', async () => {
+    expect(MODEL_CONFIGS.gemini36f?.deprecated).toBe(true);
+    mocks.tryPlatform.mockReturnValueOnce(undefined);
+    mocks.cliGlobalState.get.mockImplementation((key: string) => {
+      if (key === GlobalStateKey.MODEL_LIST_VERSION) return MODEL_LIST_VERSION;
+      if (key === GlobalStateKey.ENABLED_MODELS) return ['sonnet5T'];
+      if (key === GlobalStateKey.COPILOT_ROUTE_MODELS) {
+        return ['gemini36f', 'gemini31p'];
+      }
+      return undefined;
+    });
+    mocks.cliGlobalState.update.mockResolvedValue(undefined);
+    const stderrWrite = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+
+    try {
+      await initCliPlatform(
+        cliContext({ quietLogs: false, installSignalHandlers: false }),
+      );
+
+      expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
+      expect(mocks.cliGlobalState.update).toHaveBeenCalledWith(
+        GlobalStateKey.COPILOT_ROUTE_MODELS,
+        ['gemini31p'],
+      );
+      expect(stderrWrite).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Cleared stale Copilot route preferences: [gemini36f]',
+        ),
+        expect.any(Function),
+      );
+    } finally {
+      stderrWrite.mockRestore();
+      mocks.cliGlobalState.get.mockReset();
+      mocks.cliGlobalState.update.mockReset();
+    }
   });
 
   it('marks the operator-terminal console sink as trusted', async () => {

--- a/src/test-kernel/model/ModelListRefresh.vitest.ts
+++ b/src/test-kernel/model/ModelListRefresh.vitest.ts
@@ -4,6 +4,7 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
 import {
   computeModelListVersion,
+  DEFAULT_MODELS,
   MODEL_LIST_VERSION,
   PREFERRED_DEFAULT_MODELS,
 } from '@model/modelOptionsBasic';
@@ -111,6 +112,24 @@ describe('refreshModelListStateIfNeeded', () => {
     expect(enabledModels(state)).toContain('gemini36f');
   });
 
+  it('clears a retired Copilot route preference', async () => {
+    expect(MODEL_CONFIGS.kimi2?.retired).toBe(true);
+    const state = new FakeStateStore({
+      [GlobalStateKey.MODEL_LIST_VERSION]: MODEL_LIST_VERSION,
+      [GlobalStateKey.ENABLED_MODELS]: ['sonnet5T'],
+      [GlobalStateKey.COPILOT_ROUTE_MODELS]: ['kimi2', 'gemini31p'],
+    });
+
+    const result = await refreshModelListStateIfNeeded(state);
+
+    expect(result.skipped).toBe(false);
+    expect(result.routePreferencesCleared).toEqual(['kimi2']);
+    expect(state.get<string[]>(GlobalStateKey.COPILOT_ROUTE_MODELS)).toEqual([
+      'gemini31p',
+    ]);
+    expect(enabledModels(state)).toEqual(['sonnet5T']);
+  });
+
   it('is idempotent once the stale Copilot route preference is cleared', async () => {
     expect(MODEL_CONFIGS.gemini36f?.deprecated).toBe(true);
     const state = new FakeStateStore({
@@ -130,6 +149,39 @@ describe('refreshModelListStateIfNeeded', () => {
       'gemini31p',
     ]);
     expect(enabledModels(state)).toContain('gemini36f');
+  });
+
+  it('still reconciles enabled models and version when the route write fails', async () => {
+    expect(MODEL_CONFIGS.grok4?.retired).toBe(true);
+    expect(MODEL_CONFIGS.kimi2?.retired).toBe(true);
+    const state = new FakeStateStore({
+      [GlobalStateKey.MODEL_LIST_VERSION]: MODEL_LIST_VERSION - 1,
+      [GlobalStateKey.ENABLED_MODELS]: ['grok4'],
+      [GlobalStateKey.COPILOT_ROUTE_MODELS]: ['kimi2'],
+    });
+    const failingState = {
+      get: <T>(key: string): T | undefined => state.get<T>(key),
+      update: async (key: string, value: unknown): Promise<void> => {
+        if (key === GlobalStateKey.COPILOT_ROUTE_MODELS) {
+          throw new Error('route write failed');
+        }
+        await state.update(key, value);
+      },
+    };
+
+    await expect(refreshModelListStateIfNeeded(failingState)).rejects.toThrow(
+      'route write failed',
+    );
+
+    expect(state.get<string[]>(GlobalStateKey.ENABLED_MODELS)).toEqual([
+      ...DEFAULT_MODELS,
+    ]);
+    expect(state.get(GlobalStateKey.MODEL_LIST_VERSION)).toBe(
+      MODEL_LIST_VERSION,
+    );
+    expect(state.get<string[]>(GlobalStateKey.COPILOT_ROUTE_MODELS)).toEqual([
+      'kimi2',
+    ]);
   });
 
   it('keeps active Copilot route preferences untouched', async () => {

--- a/src/test-kernel/model/ModelListRefresh.vitest.ts
+++ b/src/test-kernel/model/ModelListRefresh.vitest.ts
@@ -93,6 +93,61 @@ describe('refreshModelListStateIfNeeded', () => {
     );
   });
 
+  it('clears a deprecated Copilot route preference while preserving the enabled model', async () => {
+    expect(MODEL_CONFIGS.gemini36f?.deprecated).toBe(true);
+    const state = new FakeStateStore({
+      [GlobalStateKey.MODEL_LIST_VERSION]: MODEL_LIST_VERSION,
+      [GlobalStateKey.ENABLED_MODELS]: ['gemini36f'],
+      [GlobalStateKey.COPILOT_ROUTE_MODELS]: ['gemini36f', 'gemini31p'],
+    });
+
+    const result = await refreshModelListStateIfNeeded(state);
+
+    expect(result.skipped).toBe(false);
+    expect(result.routePreferencesCleared).toEqual(['gemini36f']);
+    expect(state.get<string[]>(GlobalStateKey.COPILOT_ROUTE_MODELS)).toEqual([
+      'gemini31p',
+    ]);
+    expect(enabledModels(state)).toContain('gemini36f');
+  });
+
+  it('is idempotent once the stale Copilot route preference is cleared', async () => {
+    expect(MODEL_CONFIGS.gemini36f?.deprecated).toBe(true);
+    const state = new FakeStateStore({
+      [GlobalStateKey.MODEL_LIST_VERSION]: MODEL_LIST_VERSION,
+      [GlobalStateKey.ENABLED_MODELS]: ['gemini36f'],
+      [GlobalStateKey.COPILOT_ROUTE_MODELS]: ['gemini36f', 'gemini31p'],
+    });
+
+    const first = await refreshModelListStateIfNeeded(state);
+    const second = await refreshModelListStateIfNeeded(state);
+
+    expect(first.skipped).toBe(false);
+    expect(first.routePreferencesCleared).toEqual(['gemini36f']);
+    expect(second.skipped).toBe(true);
+    expect(second.routePreferencesCleared).toEqual([]);
+    expect(state.get<string[]>(GlobalStateKey.COPILOT_ROUTE_MODELS)).toEqual([
+      'gemini31p',
+    ]);
+    expect(enabledModels(state)).toContain('gemini36f');
+  });
+
+  it('keeps active Copilot route preferences untouched', async () => {
+    const state = new FakeStateStore({
+      [GlobalStateKey.MODEL_LIST_VERSION]: MODEL_LIST_VERSION,
+      [GlobalStateKey.ENABLED_MODELS]: ['sonnet5T'],
+      [GlobalStateKey.COPILOT_ROUTE_MODELS]: ['gemini31p'],
+    });
+
+    const result = await refreshModelListStateIfNeeded(state);
+
+    expect(result.skipped).toBe(true);
+    expect(result.routePreferencesCleared).toEqual([]);
+    expect(state.get<string[]>(GlobalStateKey.COPILOT_ROUTE_MODELS)).toEqual([
+      'gemini31p',
+    ]);
+  });
+
   it('restabilizes a Gemini-first list so the curated default leads', async () => {
     const state = new FakeStateStore({
       [GlobalStateKey.MODEL_LIST_VERSION]: MODEL_LIST_VERSION,


### PR DESCRIPTION
## Summary

llm-zoo 1.28.0 deprecates `gemini36f`, and Copilot discovery excludes retired and deprecated configs (`matchingBaseModel` in `runtimeModelRegistry.ts`). Users who persisted a stale entry such as `gemini36f` in `COPILOT_ROUTE_MODELS` therefore hit `copilotRouteUnavailableReason()`'s hard no-fallthrough path (#9635) on every launch, even though VS Code still offers the model.

This PR adds a shared reconciliation pass in `refreshModelListStateIfNeeded` that removes retired/deprecated Copilot route preferences. The migration lives in the same single-source reconciliation already shared by CLI and extension startup, so the two hosts do not get parallel ad hoc implementations. It only clears `COPILOT_ROUTE_MODELS`; it never touches the ordinary `ENABLED_MODELS` selection, so a user's enabled Gemini 3.6 Flash stays in the picker. The route-preference write runs after the pre-existing enabled-list/version reconciliation so its failure cannot delay those older sweeps.

## Verification

- Targeted vitest: `ModelListRefresh`, `ModelOptionsBasic`, `RuntimeModelRegistry`, `CliInitPlatform`, `CopilotRoutePreferenceHandler` — 70 passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npm run format:check` — passed.
- Guards: `check:guidance-refs`, `check:browser-safe-utils`, `check:tsconfig-paths`, `check:dead-code-ratchet` — passed.

Closes #10506
