### PR TITLE
fix(hooks): close format-staged config-sourcing and mixed-EOL follow-ups

### DIFF
--- a/scripts/format-staged.mjs
+++ b/scripts/format-staged.mjs
@@ -61,7 +61,8 @@ const NOTICE = '[format-staged]';
 
 const CRLF = Buffer.from('\r\n');
 
-const JS_CONFIG_EXTENSIONS = ['.js', '.cjs', '.mjs'];
+const CJS_FILE_EXTENSIONS = ['.js', '.json', '.node'];
+const CJS_INDEX_EXTENSIONS = ['index.js', 'index.json', 'index.node'];
 
 /** Intentional skip: logged loudly as a notice and never treated as a crash. */
 class SkipError extends Error {}
@@ -82,9 +83,11 @@ function git(args, { input } = {}) {
 /** True when `core.autocrlf=true`, so Git checks out the index's LF blobs
  * as CRLF and a CRLF worktree convention must be preserved. */
 function isAutocrlfCheckout() {
-  const result = spawnSync('git', ['config', '--get', 'core.autocrlf'], {
-    encoding: 'utf8',
-  });
+  const result = spawnSync(
+    'git',
+    ['config', '--bool', '--get', 'core.autocrlf'],
+    { encoding: 'utf8' },
+  );
   return result.status === 0 && result.stdout.trim() === 'true';
 }
 
@@ -205,15 +208,14 @@ function isWorktreeFile(path) {
   return lstatSync(path, { throwIfNoEntry: false })?.isFile() === true;
 }
 
-/** Return the `main` entry of a dependency directory's package.json,
- * preferring the staged index blob so an unstaged manifest cannot redirect
- * extensionless resolution. Returns null when there is no usable manifest. */
+/** Return the `main` entry of a dependency directory's package.json from
+ * the index only. An untracked worktree manifest is never consulted: index
+ * resolution must reflect the committed state, not an uncommitted redirect. */
 function readPackageMain(dir) {
   const pkgPath = join(dir, 'package.json');
   const pkgRel = relToCwd(pkgPath);
   if (!pkgRel) return null;
-  let blob = readIndexFile(pkgRel);
-  if (!blob && existsSync(pkgPath)) blob = readFileSync(pkgPath);
+  const blob = readIndexFile(pkgRel);
   if (!blob) return null;
   try {
     const main = JSON.parse(stripBom(blob.toString('utf8'))).main;
@@ -223,55 +225,51 @@ function readPackageMain(dir) {
   }
 }
 
+/** True when `path` is tracked in the index. */
+function isIndexTracked(path) {
+  const rel = relToCwd(path);
+  return rel !== null && readIndexFile(rel) !== null;
+}
+
 /** Resolve a relative config dependency specifier to the tracked file
- * Node/Prettier would load, without executing any config. Exact specifiers
- * (anything with an extension) are kept verbatim. Extensionless specifiers
- * follow Node-style precedence: the literal path, then the supported config
- * extensions (`.js`/`.cjs`/`.mjs`), then a directory's package.json `main`,
- * then `index.js`/`index.cjs`/`index.mjs`. Multiple existing candidates are
- * treated as ambiguous and skipped rather than guessing which module system
- * Prettier will use. */
-function resolveConfigDepPath(configDir, spec) {
+ * Node/Prettier would load, without executing any config. `kind` is `cjs`
+ * for `require()`/CommonJS resolution; every other kind (ESM `import`,
+ * `export ... from`, dynamic `import()`, and Prettier plugin paths) is exact
+ * and gets no extension or directory-index fallback, matching the loaders. */
+function resolveConfigDepPath(configDir, spec, kind) {
   const normalized = normalizeSpecifier(spec);
   const base = resolve(configDir, normalized);
-  if (parse(normalized).ext !== '') return base;
+  if (kind !== 'cjs' || parse(normalized).ext !== '') return base;
 
+  // Node's CommonJS LOAD_AS_FILE order: exact path, then .js, .json, .node.
+  // LOAD_AS_DIRECTORY follows with package.json `main` (index-sourced only),
+  // then index.js/index.json/index.node. First present candidate wins; the
+  // subsequent verifyConfigDep check reports it as untracked/diverged if the
+  // winning candidate is not the committed dependency.
   const candidates = [];
   const push = (candidate) => {
-    const candidateRel = relToCwd(candidate);
-    const present =
-      isWorktreeFile(candidate) ||
-      (candidateRel !== null && readIndexFile(candidateRel) !== null);
-    if (present && !candidates.includes(candidate)) candidates.push(candidate);
+    if (isWorktreeFile(candidate) || isIndexTracked(candidate)) {
+      candidates.push(candidate);
+    }
   };
 
   push(base);
-  for (const ext of JS_CONFIG_EXTENSIONS) push(`${base}${ext}`);
+  for (const ext of CJS_FILE_EXTENSIONS) push(`${base}${ext}`);
 
   if (lstatSync(base, { throwIfNoEntry: false })?.isDirectory()) {
     const main = readPackageMain(base);
     if (main) push(resolve(base, normalizeSpecifier(main)));
-    for (const ext of JS_CONFIG_EXTENSIONS) {
-      push(join(base, `index${ext}`));
+    for (const indexName of CJS_INDEX_EXTENSIONS) {
+      push(join(base, indexName));
     }
   }
 
-  if (candidates.length === 1) return candidates[0];
-  if (candidates.length > 1) {
-    const listed = candidates
-      .map((candidate) => relToCwd(candidate) ?? candidate)
-      .join(', ');
-    throw new SkipError(
-      `config dependency ${normalized} is ambiguous (${listed}); skipped ` +
-        'auto-staging.',
-    );
-  }
-  return base;
+  return candidates[0] ?? base;
 }
 
 /** Verify one relative config dependency against its index blob. */
-function verifyConfigDep(configDir, spec) {
-  const depPath = resolveConfigDepPath(configDir, spec);
+function verifyConfigDep(configDir, spec, kind = 'exact') {
+  const depPath = resolveConfigDepPath(configDir, spec, kind);
   const depRel = relToCwd(depPath);
   if (!depRel) {
     throw new SkipError(
@@ -320,31 +318,40 @@ function verifyDepSpecs(config, configDir) {
   for (const dep of deps) verifyConfigDep(configDir, dep);
 }
 
-/** Collect relative import/require/plugin specifiers from a JavaScript config.
- * This is intentionally conservative: it verifies statically-written relative
- * module specifiers, which is the surface a prettier config normally uses. */
+/** Collect relative JS config specifiers with the loader that consumes them.
+ * `cjs` means Node's CommonJS `require()` resolution; `esm` and `plugin` are
+ * exact path loads (Prettier plugins and Node ESM do not append extensions). */
 function collectJsRelativeDeps(source) {
-  const deps = new Set();
-  const addSpec = (spec) => {
-    if (isRelativeSpecifier(spec)) deps.add(spec);
+  const deps = new Map();
+  const addSpec = (spec, kind) => {
+    if (!isRelativeSpecifier(spec)) return;
+    if (!deps.has(spec)) deps.set(spec, new Set());
+    deps.get(spec).add(kind);
   };
-  const patterns = [
+
+  const esmPatterns = [
     /\bimport\s+[\s\S]*?\s+from\s*['"]([^'"]+)['"]/g,
     /\bimport\s+['"]([^'"]+)['"]/g,
     /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
     /\bexport\s+[\s\S]*?\s+from\s*['"]([^'"]+)['"]/g,
-    /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
   ];
-  for (const pattern of patterns) {
+  for (const pattern of esmPatterns) {
     let match;
-    while ((match = pattern.exec(source))) addSpec(match[1]);
+    while ((match = pattern.exec(source))) addSpec(match[1], 'esm');
   }
+
+  const requirePattern = /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+  let requireMatch;
+  while ((requireMatch = requirePattern.exec(source))) {
+    addSpec(requireMatch[1], 'cjs');
+  }
+
   const pluginsPattern = /\bplugins\s*:\s*\[([^\]]*)\]/g;
   let block;
   while ((block = pluginsPattern.exec(source))) {
     const stringPattern = /['"]([^'"]+)['"]/g;
     let match;
-    while ((match = stringPattern.exec(block[1]))) addSpec(match[1]);
+    while ((match = stringPattern.exec(block[1]))) addSpec(match[1], 'plugin');
   }
   return deps;
 }
@@ -352,8 +359,9 @@ function collectJsRelativeDeps(source) {
 /** Verify a JavaScript config's statically-visible relative dependencies. */
 function verifyJsConfigDeps(configPath, configBlob) {
   const source = stripBom(configBlob.toString('utf8'));
-  for (const dep of collectJsRelativeDeps(source)) {
-    verifyConfigDep(dirname(configPath), dep);
+  const configDir = dirname(configPath);
+  for (const [dep, kinds] of collectJsRelativeDeps(source)) {
+    verifyConfigDep(configDir, dep, kinds.has('cjs') ? 'cjs' : 'exact');
   }
 }
 

--- a/scripts/format-staged.mjs
+++ b/scripts/format-staged.mjs
@@ -61,6 +61,8 @@ const NOTICE = '[format-staged]';
 
 const CRLF = Buffer.from('\r\n');
 
+const JS_CONFIG_EXTENSIONS = ['.js', '.cjs', '.mjs'];
+
 /** Intentional skip: logged loudly as a notice and never treated as a crash. */
 class SkipError extends Error {}
 
@@ -75,6 +77,15 @@ function git(args, { input } = {}) {
     throw new Error(`git ${args.join(' ')} failed: ${result.stderr}`);
   }
   return result.stdout;
+}
+
+/** True when `core.autocrlf=true`, so Git checks out the index's LF blobs
+ * as CRLF and a CRLF worktree convention must be preserved. */
+function isAutocrlfCheckout() {
+  const result = spawnSync('git', ['config', '--get', 'core.autocrlf'], {
+    encoding: 'utf8',
+  });
+  return result.status === 0 && result.stdout.trim() === 'true';
 }
 
 /** Return a tracked path's index blob, or null when it is not tracked. */
@@ -169,9 +180,17 @@ function isJsConfig(path) {
   return /\.(?:c?js|mjs)$/.test(path);
 }
 
-/** True for `./x` and `../x` dependency specifiers. */
+/** Normalize Windows-style separator backslashes in a config specifier to
+ * forward slashes, so `./x`/`../x` and `.\x`/`..\x` classify the same way and
+ * POSIX path resolution treats them identically. */
+function normalizeSpecifier(spec) {
+  return spec.replace(/\\/g, '/');
+}
+
+/** True for `./x` and `../x` dependency specifiers, in either slash style. */
 function isRelativeSpecifier(spec) {
-  return spec.startsWith('./') || spec.startsWith('../');
+  const normalized = normalizeSpecifier(spec);
+  return normalized.startsWith('./') || normalized.startsWith('../');
 }
 
 /** True for filesystem paths Prettier accepts as a package.json `prettier`
@@ -181,9 +200,78 @@ function isConfigPointerPath(spec) {
   return isRelativeSpecifier(spec) || isAbsolute(spec);
 }
 
+/** True when `path` is a regular file in the working tree. */
+function isWorktreeFile(path) {
+  return lstatSync(path, { throwIfNoEntry: false })?.isFile() === true;
+}
+
+/** Return the `main` entry of a dependency directory's package.json,
+ * preferring the staged index blob so an unstaged manifest cannot redirect
+ * extensionless resolution. Returns null when there is no usable manifest. */
+function readPackageMain(dir) {
+  const pkgPath = join(dir, 'package.json');
+  const pkgRel = relToCwd(pkgPath);
+  if (!pkgRel) return null;
+  let blob = readIndexFile(pkgRel);
+  if (!blob && existsSync(pkgPath)) blob = readFileSync(pkgPath);
+  if (!blob) return null;
+  try {
+    const main = JSON.parse(stripBom(blob.toString('utf8'))).main;
+    return typeof main === 'string' ? main : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve a relative config dependency specifier to the tracked file
+ * Node/Prettier would load, without executing any config. Exact specifiers
+ * (anything with an extension) are kept verbatim. Extensionless specifiers
+ * follow Node-style precedence: the literal path, then the supported config
+ * extensions (`.js`/`.cjs`/`.mjs`), then a directory's package.json `main`,
+ * then `index.js`/`index.cjs`/`index.mjs`. Multiple existing candidates are
+ * treated as ambiguous and skipped rather than guessing which module system
+ * Prettier will use. */
+function resolveConfigDepPath(configDir, spec) {
+  const normalized = normalizeSpecifier(spec);
+  const base = resolve(configDir, normalized);
+  if (parse(normalized).ext !== '') return base;
+
+  const candidates = [];
+  const push = (candidate) => {
+    const candidateRel = relToCwd(candidate);
+    const present =
+      isWorktreeFile(candidate) ||
+      (candidateRel !== null && readIndexFile(candidateRel) !== null);
+    if (present && !candidates.includes(candidate)) candidates.push(candidate);
+  };
+
+  push(base);
+  for (const ext of JS_CONFIG_EXTENSIONS) push(`${base}${ext}`);
+
+  if (lstatSync(base, { throwIfNoEntry: false })?.isDirectory()) {
+    const main = readPackageMain(base);
+    if (main) push(resolve(base, normalizeSpecifier(main)));
+    for (const ext of JS_CONFIG_EXTENSIONS) {
+      push(join(base, `index${ext}`));
+    }
+  }
+
+  if (candidates.length === 1) return candidates[0];
+  if (candidates.length > 1) {
+    const listed = candidates
+      .map((candidate) => relToCwd(candidate) ?? candidate)
+      .join(', ');
+    throw new SkipError(
+      `config dependency ${normalized} is ambiguous (${listed}); skipped ` +
+        'auto-staging.',
+    );
+  }
+  return base;
+}
+
 /** Verify one relative config dependency against its index blob. */
 function verifyConfigDep(configDir, spec) {
-  const depPath = resolve(configDir, spec);
+  const depPath = resolveConfigDepPath(configDir, spec);
   const depRel = relToCwd(depPath);
   if (!depRel) {
     throw new SkipError(
@@ -292,18 +380,13 @@ function verifyConfigDeps(configPath, configBlob, strict) {
       return;
     }
   } else if (ext === '') {
-    // Prettier's extensionless loader accepts YAML as well as JSON; mirror
-    // that order (JSON first, then YAML) so a diverged YAML `.prettierrc` is
-    // still verified/snapshotted instead of declared unparsable.
+    // Prettier parses an extensionless `.prettierrc` with its YAML loader,
+    // and JSON is a YAML subset, so one YAML parse covers both forms.
     try {
-      value = JSON.parse(text);
+      value = parseYaml(text);
     } catch {
-      try {
-        value = parseYaml(text);
-      } catch {
-        if (strict) unparsable();
-        return;
-      }
+      if (strict) unparsable();
+      return;
     }
   } else if (ext === '.yaml' || ext === '.yml') {
     try {
@@ -323,17 +406,6 @@ function verifyConfigDeps(configPath, configBlob, strict) {
   verifyDepSpecs(value, dirname(configPath));
 }
 
-/** Verify relative dependencies of a config reached through a package.json
- * `prettier` string pointer. JavaScript targets need the JS import scan;
- * other shapes go through the generic verifier. */
-function verifyConfigTargetDeps(configPath, configBlob) {
-  if (isJsConfig(configPath)) {
-    verifyJsConfigDeps(configPath, configBlob);
-    return;
-  }
-  verifyConfigDeps(configPath, configBlob, false);
-}
-
 /** Fold the staged→formatted rewrite into the working tree, if safe. */
 function mergeWorktree(path, stagedBlob, formatted) {
   const stat = lstatSync(path, { throwIfNoEntry: false });
@@ -346,12 +418,15 @@ function mergeWorktree(path, stagedBlob, formatted) {
   // the tree's newlines are mixed. With no unstaged lines to protect, write
   // the formatted output back so the commit doesn't leave the whole file as a
   // new unstaged change. The index has just been staged with `formatted`
-  // verbatim, so a mixed-EOL tree gets that same blob; a uniform tree keeps
-  // its own line-ending convention.
+  // verbatim, so write those exact bytes back — even when Prettier chose a
+  // different EOL than the worktree's uniform convention. The one exception
+  // is an autocrlf=true checkout, where Git checks the index's LF blob out as
+  // CRLF; preserve the tree's CRLF convention there.
   if (worktreeLf.equals(stagedLf)) {
-    const content = hasMixedEol(worktree)
-      ? formatted
-      : withWorktreeEol(formatted, worktree);
+    const content =
+      isAutocrlfCheckout() && worktree.includes(CRLF)
+        ? withWorktreeEol(formatted, worktree)
+        : formatted;
     writeIfUnchanged(path, worktree, content);
     return;
   }
@@ -452,6 +527,14 @@ function configSnapshotFor(worktreeConfigPath, stagedConfig, depth = 0) {
   const worktreeConfig = readFileSync(worktreeConfigPath);
   const configEqualsIndex = normalizedEquals(worktreeConfig, stagedConfig);
 
+  // Provenance policy for config dependencies: verify relative
+  // plugins/extends/imports only when this function is about to hand Prettier
+  // a config path it derived from index content — a snapshot, or a pointer
+  // target resolved from a staged package.json/package.yaml. Clean configs
+  // returned as `null` are deliberately left to Prettier's own working-tree
+  // loader (#10504), except package.yaml object configs, which can never be
+  // snapshotted and are verified before being returned as `null`.
+
   if (base === 'package.json') {
     const stagedValue =
       JSON.parse(stripBom(stagedConfig.toString('utf8'))).prettier ?? null;
@@ -475,8 +558,12 @@ function configSnapshotFor(worktreeConfigPath, stagedConfig, depth = 0) {
 
       // `"prettier": "<path>"` points at another config file. Follow the
       // pointer with the same index-snapshot rules instead of letting
-      // Prettier load the worktree copy of the pointed-to file.
-      const targetPath = resolve(dirname(worktreeConfigPath), stagedValue);
+      // Prettier load the worktree copy of the pointed-to file. Normalize
+      // Windows-style backslash separators before resolution.
+      const targetPath = resolve(
+        dirname(worktreeConfigPath),
+        normalizeSpecifier(stagedValue),
+      );
       const targetRel = relToCwd(targetPath);
       if (!targetRel) {
         throw new SkipError(
@@ -500,7 +587,11 @@ function configSnapshotFor(worktreeConfigPath, stagedConfig, depth = 0) {
       if (!normalizedEquals(readFileSync(targetPath), stagedTarget)) {
         return configSnapshotFor(targetPath, stagedTarget, depth + 1);
       }
-      verifyConfigTargetDeps(targetPath, stagedTarget);
+      if (isJsConfig(targetPath)) {
+        verifyJsConfigDeps(targetPath, stagedTarget);
+      } else {
+        verifyConfigDeps(targetPath, stagedTarget, false);
+      }
       return { config: targetPath, snapshotPath: null };
     }
 
@@ -511,22 +602,82 @@ function configSnapshotFor(worktreeConfigPath, stagedConfig, depth = 0) {
   }
 
   if (base === 'package.yaml') {
+    let stagedValue = null;
+    try {
+      stagedValue =
+        parseYaml(stripBom(stagedConfig.toString('utf8')))?.prettier ?? null;
+    } catch {
+      if (!configEqualsIndex) {
+        throw new SkipError(
+          `staged ${configRel} differs from the worktree copy and package.yaml ` +
+            'configs cannot be snapshotted; skipped auto-staging.',
+        );
+      }
+      // Prettier will report the YAML error when it loads the clean file.
+      return { config: null, snapshotPath: null };
+    }
+
+    if (typeof stagedValue === 'string') {
+      if (!isConfigPointerPath(stagedValue)) {
+        // Bare package name (e.g. `@company/prettier-config`): Prettier
+        // resolves it from node_modules. A clean manifest is left alone; a
+        // diverged manifest cannot be snapshotted, so skip loudly.
+        if (!configEqualsIndex) {
+          throw new SkipError(
+            `package.yaml's prettier key names the shareable config ` +
+              `"${stagedValue}" but package.yaml has unstaged edits; skipped ` +
+              'auto-staging so the uncommitted pointer stays out of the commit.',
+          );
+        }
+        return { config: null, snapshotPath: null };
+      }
+
+      // Mirror the package.json string-pointer path: resolve the pointer
+      // against the staged package.yaml, then source the pointed-to config
+      // from the index (snapshotting it when it diverges).
+      const targetPath = resolve(
+        dirname(worktreeConfigPath),
+        normalizeSpecifier(stagedValue),
+      );
+      const targetRel = relToCwd(targetPath);
+      if (!targetRel) {
+        throw new SkipError(
+          `package.yaml's prettier key points outside the repository ` +
+            `(${stagedValue}); skipped auto-staging.`,
+        );
+      }
+      const stagedTarget = readIndexFile(targetRel);
+      if (!stagedTarget) {
+        throw new SkipError(
+          `${targetRel} is not staged but package.yaml's prettier key ` +
+            'points to it; skipped auto-staging so its uncommitted rules ' +
+            'stay out of the commit. Stage or remove it and retry.',
+        );
+      }
+      if (!existsSync(targetPath)) {
+        throw new SkipError(
+          `${targetRel} vanished from the working tree; skipped auto-staging.`,
+        );
+      }
+      if (!normalizedEquals(readFileSync(targetPath), stagedTarget)) {
+        return configSnapshotFor(targetPath, stagedTarget, depth + 1);
+      }
+      if (isJsConfig(targetPath)) {
+        verifyJsConfigDeps(targetPath, stagedTarget);
+      } else {
+        verifyConfigDeps(targetPath, stagedTarget, false);
+      }
+      return { config: targetPath, snapshotPath: null };
+    }
+
     if (!configEqualsIndex) {
       throw new SkipError(
         `staged ${configRel} differs from the worktree copy and package.yaml ` +
           'configs cannot be snapshotted; skipped auto-staging.',
       );
     }
-    // package.yaml has no snapshot path, so verify its relative dependencies
-    // before handing the working-tree copy back to Prettier. Parse errors are
-    // left to Prettier's own loader (this check is non-strict).
-    let stagedValue = null;
-    try {
-      stagedValue =
-        parseYaml(stripBom(stagedConfig.toString('utf8')))?.prettier ?? null;
-    } catch {
-      // ignored: Prettier will report the YAML error when it loads the file.
-    }
+    // Object-valued package.yaml has no snapshot path, so verify its relative
+    // dependencies before handing the working-tree copy back to Prettier.
     verifyDepSpecs(stagedValue, dirname(worktreeConfigPath));
     return { config: null, snapshotPath: null };
   }

--- a/scripts/format-staged.mjs
+++ b/scripts/format-staged.mjs
@@ -208,17 +208,38 @@ function isWorktreeFile(path) {
   return lstatSync(path, { throwIfNoEntry: false })?.isFile() === true;
 }
 
-/** Return the `main` entry of a dependency directory's package.json from
- * the index only. An untracked worktree manifest is never consulted: index
- * resolution must reflect the committed state, not an uncommitted redirect. */
+/** Return the `main` entry of a dependency directory's package.json. The
+ * manifest itself must be tracked and equal to its index blob before its
+ * redirect is trusted; otherwise an untracked or unstaged `main` edit could
+ * route Prettier to uncommitted rules. Throws when the manifest is present in
+ * only one of the index/worktree or differs between them. */
 function readPackageMain(dir) {
   const pkgPath = join(dir, 'package.json');
   const pkgRel = relToCwd(pkgPath);
   if (!pkgRel) return null;
-  const blob = readIndexFile(pkgRel);
-  if (!blob) return null;
+  const stagedPkg = readIndexFile(pkgRel);
+  if (!stagedPkg) {
+    if (existsSync(pkgPath)) {
+      throw new SkipError(
+        `${pkgRel} is not staged but the config depends on it; skipped ` +
+          'auto-staging so its uncommitted manifest stays out of the commit.',
+      );
+    }
+    return null;
+  }
+  if (!existsSync(pkgPath)) {
+    throw new SkipError(
+      `${pkgRel} vanished from the working tree; skipped auto-staging.`,
+    );
+  }
+  if (!normalizedEquals(readFileSync(pkgPath), stagedPkg)) {
+    throw new SkipError(
+      `${pkgRel} has unstaged edits while the config depends on it; ` +
+        'skipped auto-staging so the uncommitted manifest stays out of the commit.',
+    );
+  }
   try {
-    const main = JSON.parse(stripBom(blob.toString('utf8'))).main;
+    const main = JSON.parse(stripBom(stagedPkg.toString('utf8'))).main;
     return typeof main === 'string' ? main : null;
   } catch {
     return null;
@@ -429,8 +450,13 @@ function mergeWorktree(path, stagedBlob, formatted) {
   // verbatim, so write those exact bytes back — even when Prettier chose a
   // different EOL than the worktree's uniform convention. The one exception
   // is an autocrlf=true checkout, where Git checks the index's LF blob out as
-  // CRLF; preserve the tree's CRLF convention there.
-  if (worktreeLf.equals(stagedLf)) {
+  // CRLF; preserve the tree's CRLF convention there. A normalized-equal but
+  // byte-different worktree without that checkout conversion is an unstaged
+  // EOL edit, so it falls through to the merge path below.
+  const fullyStaged =
+    worktree.equals(stagedBlob) ||
+    (isAutocrlfCheckout() && worktreeLf.equals(stagedLf));
+  if (fullyStaged) {
     const content =
       isAutocrlfCheckout() && worktree.includes(CRLF)
         ? withWorktreeEol(formatted, worktree)

--- a/scripts/format-staged.mjs
+++ b/scripts/format-staged.mjs
@@ -43,7 +43,15 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { basename, dirname, join, parse, relative, resolve } from 'node:path';
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  parse,
+  relative,
+  resolve,
+} from 'node:path';
 
 import ignore from 'ignore';
 import prettier from 'prettier';
@@ -166,6 +174,13 @@ function isRelativeSpecifier(spec) {
   return spec.startsWith('./') || spec.startsWith('../');
 }
 
+/** True for filesystem paths Prettier accepts as a package.json `prettier`
+ * pointer (`./x`, `../x`, or an absolute path), as opposed to a shareable
+ * config package name resolved from node_modules. */
+function isConfigPointerPath(spec) {
+  return isRelativeSpecifier(spec) || isAbsolute(spec);
+}
+
 /** Verify one relative config dependency against its index blob. */
 function verifyConfigDep(configDir, spec) {
   const depPath = resolve(configDir, spec);
@@ -254,36 +269,47 @@ function verifyJsConfigDeps(configPath, configBlob) {
   }
 }
 
-/** Verify relative dependencies of a full config blob. `strict` only controls
- * whether an unparsable/unsupported config forces a skip: when the config is
- * clean we leave it to Prettier's own loader, and when it is being snapshotted
- * we must not write a snapshot whose dependencies we cannot source. */
+/** Verify relative dependencies of a full config blob. `strict` controls
+ * whether an unparsable/unsupported config forces a skip. Callers use this
+ * only when the hook is about to hand Prettier index-sourced config content
+ * (a snapshot or an explicitly resolved pointer target): clean configs that
+ * Prettier resolves from the working tree are left to Prettier's own loader. */
 function verifyConfigDeps(configPath, configBlob, strict) {
   const ext = parse(configPath).ext.toLowerCase();
   const text = stripBom(configBlob.toString('utf8'));
+  const unparsable = () => {
+    throw new SkipError(
+      `cannot parse ${relToCwd(configPath)} to verify its relative ` +
+        'dependencies; skipped auto-staging.',
+    );
+  };
   let value;
-  if (ext === '' || ext === '.json') {
+  if (ext === '.json') {
     try {
       value = JSON.parse(text);
     } catch {
-      if (strict) {
-        throw new SkipError(
-          `cannot parse ${relToCwd(configPath)} to verify its relative ` +
-            'dependencies; skipped auto-staging.',
-        );
-      }
+      if (strict) unparsable();
       return;
+    }
+  } else if (ext === '') {
+    // Prettier's extensionless loader accepts YAML as well as JSON; mirror
+    // that order (JSON first, then YAML) so a diverged YAML `.prettierrc` is
+    // still verified/snapshotted instead of declared unparsable.
+    try {
+      value = JSON.parse(text);
+    } catch {
+      try {
+        value = parseYaml(text);
+      } catch {
+        if (strict) unparsable();
+        return;
+      }
     }
   } else if (ext === '.yaml' || ext === '.yml') {
     try {
       value = parseYaml(text);
     } catch {
-      if (strict) {
-        throw new SkipError(
-          `cannot parse ${relToCwd(configPath)} to verify its relative ` +
-            'dependencies; skipped auto-staging.',
-        );
-      }
+      if (strict) unparsable();
       return;
     }
   } else if (strict) {
@@ -297,6 +323,17 @@ function verifyConfigDeps(configPath, configBlob, strict) {
   verifyDepSpecs(value, dirname(configPath));
 }
 
+/** Verify relative dependencies of a config reached through a package.json
+ * `prettier` string pointer. JavaScript targets need the JS import scan;
+ * other shapes go through the generic verifier. */
+function verifyConfigTargetDeps(configPath, configBlob) {
+  if (isJsConfig(configPath)) {
+    verifyJsConfigDeps(configPath, configBlob);
+    return;
+  }
+  verifyConfigDeps(configPath, configBlob, false);
+}
+
 /** Fold the staged→formatted rewrite into the working tree, if safe. */
 function mergeWorktree(path, stagedBlob, formatted) {
   const stat = lstatSync(path, { throwIfNoEntry: false });
@@ -308,12 +345,12 @@ function mergeWorktree(path, stagedBlob, formatted) {
   // Fully staged file: the rewrite applies cleanly by construction, even when
   // the tree's newlines are mixed. With no unstaged lines to protect, write
   // the formatted output back so the commit doesn't leave the whole file as a
-  // new unstaged change. Prettier emits LF, so a mixed-EOL tree gets the LF
-  // output directly (matching the newly staged blob); a uniform tree keeps its
-  // own line-ending convention.
+  // new unstaged change. The index has just been staged with `formatted`
+  // verbatim, so a mixed-EOL tree gets that same blob; a uniform tree keeps
+  // its own line-ending convention.
   if (worktreeLf.equals(stagedLf)) {
     const content = hasMixedEol(worktree)
-      ? normalizeLf(formatted)
+      ? formatted
       : withWorktreeEol(formatted, worktree);
     writeIfUnchanged(path, worktree, content);
     return;
@@ -420,9 +457,25 @@ function configSnapshotFor(worktreeConfigPath, stagedConfig, depth = 0) {
       JSON.parse(stripBom(stagedConfig.toString('utf8'))).prettier ?? null;
 
     if (typeof stagedValue === 'string') {
-      // `"prettier": "<path>"` points at another config. Follow the pointer
-      // with the same index-snapshot rules instead of letting Prettier load
-      // the worktree copy of the pointed-to file.
+      if (!isConfigPointerPath(stagedValue)) {
+        // `"prettier": "@company/prettier-config"` names a shareable config
+        // package resolved from node_modules, not a file in this repository.
+        // When package.json is clean Prettier resolves it exactly as before;
+        // when the manifest diverges there is no index snapshot to hand
+        // Prettier, so skip loudly instead of guessing a resolution.
+        if (!configEqualsIndex) {
+          throw new SkipError(
+            `package.json's prettier key names the shareable config ` +
+              `"${stagedValue}" but package.json has unstaged edits; skipped ` +
+              'auto-staging so the uncommitted pointer stays out of the commit.',
+          );
+        }
+        return { config: null, snapshotPath: null };
+      }
+
+      // `"prettier": "<path>"` points at another config file. Follow the
+      // pointer with the same index-snapshot rules instead of letting
+      // Prettier load the worktree copy of the pointed-to file.
       const targetPath = resolve(dirname(worktreeConfigPath), stagedValue);
       const targetRel = relToCwd(targetPath);
       if (!targetRel) {
@@ -447,12 +500,12 @@ function configSnapshotFor(worktreeConfigPath, stagedConfig, depth = 0) {
       if (!normalizedEquals(readFileSync(targetPath), stagedTarget)) {
         return configSnapshotFor(targetPath, stagedTarget, depth + 1);
       }
-      verifyConfigDeps(targetPath, stagedTarget, false);
+      verifyConfigTargetDeps(targetPath, stagedTarget);
       return { config: targetPath, snapshotPath: null };
     }
 
-    verifyDepSpecs(stagedValue, dirname(worktreeConfigPath));
     if (configEqualsIndex) return { config: null, snapshotPath: null };
+    verifyDepSpecs(stagedValue, dirname(worktreeConfigPath));
     const snapshotPath = writeConfigSnapshot(worktreeConfigPath, stagedConfig);
     return { config: snapshotPath, snapshotPath };
   }
@@ -464,18 +517,29 @@ function configSnapshotFor(worktreeConfigPath, stagedConfig, depth = 0) {
           'configs cannot be snapshotted; skipped auto-staging.',
       );
     }
+    // package.yaml has no snapshot path, so verify its relative dependencies
+    // before handing the working-tree copy back to Prettier. Parse errors are
+    // left to Prettier's own loader (this check is non-strict).
+    let stagedValue = null;
+    try {
+      stagedValue =
+        parseYaml(stripBom(stagedConfig.toString('utf8')))?.prettier ?? null;
+    } catch {
+      // ignored: Prettier will report the YAML error when it loads the file.
+    }
+    verifyDepSpecs(stagedValue, dirname(worktreeConfigPath));
     return { config: null, snapshotPath: null };
   }
 
   if (isJsConfig(worktreeConfigPath)) {
-    verifyJsConfigDeps(worktreeConfigPath, stagedConfig);
     if (configEqualsIndex) return { config: null, snapshotPath: null };
+    verifyJsConfigDeps(worktreeConfigPath, stagedConfig);
     const snapshotPath = writeConfigSnapshot(worktreeConfigPath, stagedConfig);
     return { config: snapshotPath, snapshotPath };
   }
 
-  verifyConfigDeps(worktreeConfigPath, stagedConfig, !configEqualsIndex);
   if (configEqualsIndex) return { config: null, snapshotPath: null };
+  verifyConfigDeps(worktreeConfigPath, stagedConfig, true);
   const snapshotPath = writeConfigSnapshot(worktreeConfigPath, stagedConfig);
   return { config: snapshotPath, snapshotPath };
 }

--- a/src/test-kernel/scripts/FormatStaged.vitest.ts
+++ b/src/test-kernel/scripts/FormatStaged.vitest.ts
@@ -729,6 +729,24 @@ describe('format-staged', () => {
     expect(git(['diff', '--name-only', '--', 'a.ts'])).toBe('');
   });
 
+  it('keeps an unstaged CRLF conversion when the index blob is LF (#10505)', () => {
+    writeFileSync(join(dir, 'a.ts'), BASE);
+    git(['add', 'a.ts']);
+    git(['commit', '-qm', 'base']);
+    writeFileSync(join(dir, 'a.ts'), STAGED);
+    git(['add', 'a.ts']);
+    // Byte-different but normalized-equal worktree: this is an unstaged
+    // line-ending conversion, not a fully staged file, and must survive.
+    writeFileSync(join(dir, 'a.ts'), toCrlf(STAGED));
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(stagedBlob('a.ts')).toBe(FORMATTED);
+    expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe(toCrlf(FORMATTED));
+  });
+
   it('does not treat an autocrlf package.yaml checkout as divergent (#10433)', () => {
     git(['config', 'core.autocrlf', 'true']);
     writeFileSync(
@@ -1154,9 +1172,92 @@ describe('format-staged', () => {
     const result = runFormat();
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain('config/opts is not staged');
+    expect(result.stdout).toContain('config/opts/package.json is not staged');
     expect(result.stdout).not.toContain('config/evil.cjs');
     expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+  });
+
+  it('skips when a directory package main manifest has unstaged edits (#10502)', () => {
+    mkdirSync(join(dir, 'config/opts'), { recursive: true });
+    writeFileSync(
+      join(dir, 'config/opts/package.json'),
+      '{"main":"./good.cjs"}\n',
+    );
+    writeFileSync(
+      join(dir, 'config/opts/good.cjs'),
+      'module.exports = { semi: false };\n',
+    );
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'const opts = require("./opts");\nmodule.exports = opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"./config/prettier.cjs"}\n',
+    );
+    git([
+      'add',
+      'config/prettier.cjs',
+      'config/opts/package.json',
+      'config/opts/good.cjs',
+      'package.json',
+    ]);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(
+      join(dir, 'config/opts/package.json'),
+      '{"main":"./good.cjs","x":1}\n',
+    );
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(
+      'config/opts/package.json has unstaged edits',
+    );
+    expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+  });
+
+  it('honors package main over index fallback for extensionless require (#10502)', () => {
+    mkdirSync(join(dir, 'config/opts'), { recursive: true });
+    writeFileSync(
+      join(dir, 'config/opts/package.json'),
+      '{"main":"main.cjs"}\n',
+    );
+    writeFileSync(
+      join(dir, 'config/opts/main.cjs'),
+      'module.exports = { semi: false };\n',
+    );
+    writeFileSync(
+      join(dir, 'config/opts/index.js'),
+      'module.exports = { semi: true };\n',
+    );
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'const opts = require("./opts");\nmodule.exports = opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"./config/prettier.cjs"}\n',
+    );
+    git([
+      'add',
+      'config/prettier.cjs',
+      'config/opts/package.json',
+      'config/opts/main.cjs',
+      'config/opts/index.js',
+      'package.json',
+    ]);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1\n');
   });
 
   it('does not append extensions for an extensionless ESM import (#10502)', () => {

--- a/src/test-kernel/scripts/FormatStaged.vitest.ts
+++ b/src/test-kernel/scripts/FormatStaged.vitest.ts
@@ -288,6 +288,20 @@ describe('format-staged', () => {
     expect(stagedBlob('a.ts')).toBe("const x = 'a';\n");
   });
 
+  it('snapshots a diverged extensionless YAML .prettierrc (#10500)', () => {
+    writeFileSync(join(dir, '.prettierrc'), 'singleQuote: true\n');
+    git(['add', '.prettierrc']);
+    writeFileSync(join(dir, '.prettierrc'), 'singleQuote: false\n');
+    writeFileSync(join(dir, 'a.ts'), 'const x = "a";\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(stagedBlob('a.ts')).toBe("const x = 'a';\n");
+  });
+
   it('uses the staged .prettierignore when the worktree copy has unstaged edits', () => {
     writeFileSync(join(dir, '.prettierignore'), 'ignored.ts\n');
     git(['add', '.prettierignore']);
@@ -532,6 +546,28 @@ describe('format-staged', () => {
     expect(stagedBlob('a.ts')).toBe('const x = "a";\n');
   });
 
+  it('skips a clean package.yaml whose relative plugin has unstaged edits (#10501)', () => {
+    writeFileSync(join(dir, 'fake-plugin.mjs'), 'export default {};\n');
+    writeFileSync(
+      join(dir, 'package.yaml'),
+      'prettier:\n  plugins:\n    - "./fake-plugin.mjs"\n',
+    );
+    git(['add', 'fake-plugin.mjs', 'package.yaml']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(
+      join(dir, 'fake-plugin.mjs'),
+      'export default {};\n// edit\n',
+    );
+    writeFileSync(join(dir, 'a.ts'), STAGED);
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('fake-plugin.mjs has unstaged edits');
+    expect(stagedBlob('a.ts')).toBe(STAGED);
+  });
+
   it('updates a fully staged mixed-EOL file in the working tree (#10432)', () => {
     const mixed = MULTI_STAGED.replace(
       'const a={x:1,y:2};\n',
@@ -546,6 +582,28 @@ describe('format-staged', () => {
     expect(result.stdout).toContain('staged Prettier output for a.ts');
     expect(stagedBlob('a.ts')).toBe(MULTI_FORMATTED);
     expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe(MULTI_FORMATTED);
+    expect(git(['diff', '--name-only', '--', 'a.ts'])).toBe('');
+  });
+
+  it('writes formatted output verbatim for a fully staged mixed-EOL CRLF file (#10505)', () => {
+    writeFileSync(join(dir, '.prettierrc'), '{"endOfLine":"crlf"}\n');
+    git(['add', '.prettierrc']);
+    git(['commit', '-qm', 'crlf config']);
+    const mixed = MULTI_STAGED.replace(
+      'const a={x:1,y:2};\n',
+      'const a={x:1,y:2};\r\n',
+    );
+    writeFileSync(join(dir, 'a.ts'), mixed);
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(stagedBlob('a.ts')).toBe(toCrlf(MULTI_FORMATTED));
+    expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe(
+      toCrlf(MULTI_FORMATTED),
+    );
     expect(git(['diff', '--name-only', '--', 'a.ts'])).toBe('');
   });
 
@@ -623,6 +681,35 @@ describe('format-staged', () => {
     expect(stagedBlob('src/a.ts')).toBe('export const x = 1;\n');
   });
 
+  it('leaves a clean JavaScript config with an unstaged dependency to Prettier (#10504)', () => {
+    mkdirSync(join(dir, 'src'));
+    writeFileSync(
+      join(dir, 'src/.prettierrc.mjs'),
+      'import opts from "./opts.mjs";\nexport default opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'src/opts.mjs'),
+      'export default { semi: false };\n',
+    );
+    git(['add', 'src/.prettierrc.mjs', 'src/opts.mjs']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(
+      join(dir, 'src/opts.mjs'),
+      'export default { semi: true };\n',
+    );
+    writeFileSync(join(dir, 'src/a.ts'), STAGED);
+    git(['add', 'src/a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for src/a.ts');
+    expect(result.stdout).not.toContain('src/opts.mjs has unstaged edits');
+    // Prettier resolves the clean config from the working tree, so the
+    // unstaged semi:true dependency wins; the hook must not skip the commit.
+    expect(stagedBlob('src/a.ts')).toBe(FORMATTED);
+  });
+
   it('sources a string-pointer prettier config from the index (#10435)', () => {
     mkdirSync(join(dir, 'config'));
     writeFileSync(
@@ -645,6 +732,64 @@ describe('format-staged', () => {
       join(dir, 'config/prettier.cjs'),
       'module.exports = { semi: true };\n',
     );
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1\n');
+  });
+
+  it('skips a clean JS pointer target whose relative dependency is unstaged (#10502)', () => {
+    mkdirSync(join(dir, 'config'));
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'const opts = require("./opts.cjs");\nmodule.exports = opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'config/opts.cjs'),
+      'module.exports = { semi: false };\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"./config/prettier.cjs"}\n',
+    );
+    git(['add', 'config/prettier.cjs', 'config/opts.cjs', 'package.json']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(
+      join(dir, 'config/opts.cjs'),
+      'module.exports = { semi: true };\n',
+    );
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('config/opts.cjs has unstaged edits');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+  });
+
+  it('resolves a package-name shareable config from node_modules (#10503)', () => {
+    mkdirSync(join(dir, 'node_modules/@company/prettier-config'), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(dir, 'node_modules/@company/prettier-config/package.json'),
+      '{"name":"@company/prettier-config","main":"index.cjs"}\n',
+    );
+    writeFileSync(
+      join(dir, 'node_modules/@company/prettier-config/index.cjs'),
+      'module.exports = { semi: false };\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"@company/prettier-config"}\n',
+    );
+    git(['add', 'package.json']);
+    git(['commit', '-qm', 'config base']);
     writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
     git(['add', 'a.ts']);
 

--- a/src/test-kernel/scripts/FormatStaged.vitest.ts
+++ b/src/test-kernel/scripts/FormatStaged.vitest.ts
@@ -175,6 +175,21 @@ describe('format-staged', () => {
     expect(git(['diff', '--name-only', '--', 'a.ts'])).toBe('');
   });
 
+  it('treats core.autocrlf=1 as a CRLF checkout (#10505)', () => {
+    git(['config', 'core.autocrlf', '1']);
+    writeFileSync(join(dir, 'a.ts'), toCrlf(STAGED));
+    git(['add', 'a.ts']);
+    expect(stagedBlob('a.ts')).toBe(STAGED);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(stagedBlob('a.ts')).toBe(FORMATTED);
+    expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe(toCrlf(FORMATTED));
+    expect(git(['diff', '--name-only', '--', 'a.ts'])).toBe('');
+  });
+
   it('folds non-overlapping CRLF edits without a spurious merge conflict', () => {
     git(['config', 'core.autocrlf', 'true']);
     writeFileSync(
@@ -591,7 +606,7 @@ describe('format-staged', () => {
     expect(stagedBlob('a.ts')).toBe(STAGED);
   });
 
-  it('does not false-skip an extensionless package.yaml plugin backed by .mjs (#10501)', () => {
+  it('does not append extensions for an extensionless package.yaml plugin (#10501)', () => {
     writeFileSync(join(dir, 'fake-plugin.mjs'), 'export default {};\n');
     writeFileSync(
       join(dir, 'package.yaml'),
@@ -605,12 +620,9 @@ describe('format-staged', () => {
     const result = runFormat();
 
     expect(result.status, result.stderr).toBe(0);
-    // The hook must resolve the staged dependency to fake-plugin.mjs for its
-    // index comparison; Prettier itself cannot load an extensionless plugin
-    // path, so the remaining skip is a real loader error, not the false
-    // "not staged" provenance skip.
-    expect(result.stdout).not.toContain('fake-plugin is not staged');
-    expect(result.stderr).toContain('Cannot find module');
+    // Prettier's plugin loader does not append extensions, so the hook must
+    // verify the literal specifier rather than invent a .mjs fallback.
+    expect(result.stdout).toContain('fake-plugin is not staged');
     expect(stagedBlob('a.ts')).toBe(STAGED);
   });
 
@@ -618,7 +630,7 @@ describe('format-staged', () => {
     mkdirSync(join(dir, 'config'));
     writeFileSync(
       join(dir, 'config/prettier.cjs'),
-      'const opts = require("./opts");\nmodule.exports = opts;\n',
+      'const opts = require("./opts.cjs");\nmodule.exports = opts;\n',
     );
     writeFileSync(
       join(dir, 'config/opts.cjs'),
@@ -973,7 +985,7 @@ describe('format-staged', () => {
     expect(stagedBlob('a.ts')).toBe('export const x = 1\n');
   });
 
-  it('does not false-skip an extensionless CommonJS dependency backed by .cjs (#10502)', () => {
+  it('does not append .cjs for an extensionless CommonJS require (#10502)', () => {
     mkdirSync(join(dir, 'config'));
     writeFileSync(
       join(dir, 'config/prettier.cjs'),
@@ -995,11 +1007,9 @@ describe('format-staged', () => {
     const result = runFormat();
 
     expect(result.status, result.stderr).toBe(0);
-    // Node's CommonJS loader does not add a .cjs extension for require(),
-    // so Prettier still reports a real loader error. The hook's resolution
-    // must remove the false "not staged" provenance skip for that path.
-    expect(result.stdout).not.toContain('config/opts is not staged');
-    expect(result.stderr).toContain("Cannot find module './opts'");
+    // Node's CJS LOAD_AS_FILE does not try .cjs for require('./opts'), so the
+    // literal dependency path is not staged and the hook skips accordingly.
+    expect(result.stdout).toContain('config/opts is not staged');
     expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
   });
 
@@ -1018,6 +1028,30 @@ describe('format-staged', () => {
       '{"prettier":"./config/prettier.cjs"}\n',
     );
     git(['add', 'config/prettier.cjs', 'config/opts.js', 'package.json']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(result.stdout).not.toContain('config/opts is not staged');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1\n');
+  });
+
+  it('resolves an extensionless CommonJS require to its .json file (#10502)', () => {
+    mkdirSync(join(dir, 'config'));
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'const opts = require("./opts");\nmodule.exports = opts;\n',
+    );
+    writeFileSync(join(dir, 'config/opts.json'), '{ "semi": false }\n');
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"./config/prettier.cjs"}\n',
+    );
+    git(['add', 'config/prettier.cjs', 'config/opts.json', 'package.json']);
     git(['commit', '-qm', 'config base']);
     writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
     git(['add', 'a.ts']);
@@ -1092,6 +1126,67 @@ describe('format-staged', () => {
     expect(stagedBlob('a.ts')).toBe('export const x = 1\n');
   });
 
+  it('does not follow an untracked directory package.json redirect (#10502)', () => {
+    mkdirSync(join(dir, 'config/opts'), { recursive: true });
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'const opts = require("./opts");\nmodule.exports = opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'config/evil.cjs'),
+      'module.exports = { semi: true };\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"./config/prettier.cjs"}\n',
+    );
+    git(['add', 'config/prettier.cjs', 'config/evil.cjs', 'package.json']);
+    git(['commit', '-qm', 'config base']);
+    // The redirect manifest exists only in the worktree, so index resolution
+    // must ignore it instead of resolving ./opts to the tracked evil.cjs.
+    writeFileSync(
+      join(dir, 'config/opts/package.json'),
+      '{"main":"./evil.cjs"}\n',
+    );
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('config/opts is not staged');
+    expect(result.stdout).not.toContain('config/evil.cjs');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+  });
+
+  it('does not append extensions for an extensionless ESM import (#10502)', () => {
+    mkdirSync(join(dir, 'config'));
+    writeFileSync(
+      join(dir, 'config/prettier.mjs'),
+      'import opts from "./opts";\nexport default opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'config/opts.js'),
+      'export default { semi: false };\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"./config/prettier.mjs"}\n',
+    );
+    git(['add', 'config/prettier.mjs', 'config/opts.js', 'package.json']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    // Node ESM does not append .js to a relative import, so the literal
+    // dependency path is not staged and the hook skips.
+    expect(result.stdout).toContain('config/opts is not staged');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+  });
+
   it('reports the literal path when an extensionless dependency has no candidate (#10502)', () => {
     mkdirSync(join(dir, 'config'));
     writeFileSync(
@@ -1114,7 +1209,7 @@ describe('format-staged', () => {
     expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
   });
 
-  it('skips an ambiguous extensionless dependency instead of guessing (#10502)', () => {
+  it('uses deterministic CJS first-match when .js and .cjs both exist (#10502)', () => {
     mkdirSync(join(dir, 'config'));
     writeFileSync(
       join(dir, 'config/prettier.cjs'),
@@ -1126,7 +1221,7 @@ describe('format-staged', () => {
     );
     writeFileSync(
       join(dir, 'config/opts.cjs'),
-      'module.exports = { semi: false };\n',
+      'module.exports = { semi: true };\n',
     );
     writeFileSync(
       join(dir, 'package.json'),
@@ -1146,8 +1241,9 @@ describe('format-staged', () => {
     const result = runFormat();
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain('config dependency ./opts is ambiguous');
-    expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+    // Node's CJS LOAD_AS_FILE order picks opts.js before any other candidate.
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1\n');
   });
 
   it('resolves a package-name shareable config from node_modules (#10503)', () => {

--- a/src/test-kernel/scripts/FormatStaged.vitest.ts
+++ b/src/test-kernel/scripts/FormatStaged.vitest.ts
@@ -302,6 +302,29 @@ describe('format-staged', () => {
     expect(stagedBlob('a.ts')).toBe("const x = 'a';\n");
   });
 
+  it('leaves a clean extensionless YAML config with an unstaged dependency to Prettier (#10504)', () => {
+    writeFileSync(join(dir, 'fake-plugin.mjs'), 'export default {};\n');
+    writeFileSync(
+      join(dir, '.prettierrc'),
+      'plugins:\n  - "./fake-plugin.mjs"\n',
+    );
+    git(['add', '.prettierrc', 'fake-plugin.mjs']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(
+      join(dir, 'fake-plugin.mjs'),
+      'export default {};\n// edit\n',
+    );
+    writeFileSync(join(dir, 'a.ts'), STAGED);
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(result.stdout).not.toContain('fake-plugin.mjs has unstaged edits');
+    expect(stagedBlob('a.ts')).toBe(FORMATTED);
+  });
+
   it('uses the staged .prettierignore when the worktree copy has unstaged edits', () => {
     writeFileSync(join(dir, '.prettierignore'), 'ignored.ts\n');
     git(['add', '.prettierignore']);
@@ -568,6 +591,59 @@ describe('format-staged', () => {
     expect(stagedBlob('a.ts')).toBe(STAGED);
   });
 
+  it('does not false-skip an extensionless package.yaml plugin backed by .mjs (#10501)', () => {
+    writeFileSync(join(dir, 'fake-plugin.mjs'), 'export default {};\n');
+    writeFileSync(
+      join(dir, 'package.yaml'),
+      'prettier:\n  plugins:\n    - "./fake-plugin"\n',
+    );
+    git(['add', 'fake-plugin.mjs', 'package.yaml']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(join(dir, 'a.ts'), STAGED);
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    // The hook must resolve the staged dependency to fake-plugin.mjs for its
+    // index comparison; Prettier itself cannot load an extensionless plugin
+    // path, so the remaining skip is a real loader error, not the false
+    // "not staged" provenance skip.
+    expect(result.stdout).not.toContain('fake-plugin is not staged');
+    expect(result.stderr).toContain('Cannot find module');
+    expect(stagedBlob('a.ts')).toBe(STAGED);
+  });
+
+  it('skips a clean package.yaml pointer target whose dependency is unstaged (#10502)', () => {
+    mkdirSync(join(dir, 'config'));
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'const opts = require("./opts");\nmodule.exports = opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'config/opts.cjs'),
+      'module.exports = { semi: false };\n',
+    );
+    writeFileSync(
+      join(dir, 'package.yaml'),
+      'prettier: "./config/prettier.cjs"\n',
+    );
+    git(['add', 'config/prettier.cjs', 'config/opts.cjs', 'package.yaml']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(
+      join(dir, 'config/opts.cjs'),
+      'module.exports = { semi: true };\n',
+    );
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('config/opts.cjs has unstaged edits');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+  });
+
   it('updates a fully staged mixed-EOL file in the working tree (#10432)', () => {
     const mixed = MULTI_STAGED.replace(
       'const a={x:1,y:2};\n',
@@ -604,6 +680,40 @@ describe('format-staged', () => {
     expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe(
       toCrlf(MULTI_FORMATTED),
     );
+    expect(git(['diff', '--name-only', '--', 'a.ts'])).toBe('');
+  });
+
+  it('writes CRLF formatted output verbatim for a fully staged LF file (#10505)', () => {
+    writeFileSync(join(dir, '.prettierrc'), '{"endOfLine":"crlf"}\n');
+    git(['add', '.prettierrc']);
+    git(['commit', '-qm', 'crlf config']);
+    writeFileSync(join(dir, 'a.ts'), MULTI_STAGED);
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(stagedBlob('a.ts')).toBe(toCrlf(MULTI_FORMATTED));
+    expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe(
+      toCrlf(MULTI_FORMATTED),
+    );
+    expect(git(['diff', '--name-only', '--', 'a.ts'])).toBe('');
+  });
+
+  it('writes LF formatted output verbatim for a fully staged CRLF file (#10505)', () => {
+    writeFileSync(join(dir, '.prettierrc'), '{"endOfLine":"lf"}\n');
+    git(['add', '.prettierrc']);
+    git(['commit', '-qm', 'lf config']);
+    writeFileSync(join(dir, 'a.ts'), toCrlf(MULTI_STAGED));
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(stagedBlob('a.ts')).toBe(MULTI_FORMATTED);
+    expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe(MULTI_FORMATTED);
     expect(git(['diff', '--name-only', '--', 'a.ts'])).toBe('');
   });
 
@@ -710,6 +820,52 @@ describe('format-staged', () => {
     expect(stagedBlob('src/a.ts')).toBe(FORMATTED);
   });
 
+  it('leaves a clean package.json object config with an unstaged dependency to Prettier (#10504)', () => {
+    writeFileSync(join(dir, 'fake-plugin.mjs'), 'export default {};\n');
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":{"plugins":["./fake-plugin.mjs"]}}\n',
+    );
+    git(['add', 'package.json', 'fake-plugin.mjs']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(
+      join(dir, 'fake-plugin.mjs'),
+      'export default {};\n// edit\n',
+    );
+    writeFileSync(join(dir, 'a.ts'), STAGED);
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(result.stdout).not.toContain('fake-plugin.mjs has unstaged edits');
+    expect(stagedBlob('a.ts')).toBe(FORMATTED);
+  });
+
+  it('leaves a clean JSON .prettierrc with an unstaged dependency to Prettier (#10504)', () => {
+    writeFileSync(join(dir, 'fake-plugin.mjs'), 'export default {};\n');
+    writeFileSync(
+      join(dir, '.prettierrc'),
+      '{"plugins":["./fake-plugin.mjs"]}\n',
+    );
+    git(['add', '.prettierrc', 'fake-plugin.mjs']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(
+      join(dir, 'fake-plugin.mjs'),
+      'export default {};\n// edit\n',
+    );
+    writeFileSync(join(dir, 'a.ts'), STAGED);
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(result.stdout).not.toContain('fake-plugin.mjs has unstaged edits');
+    expect(stagedBlob('a.ts')).toBe(FORMATTED);
+  });
+
   it('sources a string-pointer prettier config from the index (#10435)', () => {
     mkdirSync(join(dir, 'config'));
     writeFileSync(
@@ -769,6 +925,228 @@ describe('format-staged', () => {
 
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain('config/opts.cjs has unstaged edits');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+  });
+
+  it('skips a diverged package.json bare package-name pointer (#10503)', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"@company/prettier-config"}\n',
+    );
+    git(['add', 'package.json']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"@company/prettier-config","name":"x"}\n',
+    );
+    writeFileSync(join(dir, 'a.ts'), STAGED);
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(
+      "package.json's prettier key names the shareable config",
+    );
+    expect(stagedBlob('a.ts')).toBe(STAGED);
+  });
+
+  it('resolves a Windows-style package.json prettier pointer (#10503)', () => {
+    mkdirSync(join(dir, 'config'));
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'module.exports = { semi: false };\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      `${JSON.stringify({ prettier: '.\\config\\prettier.cjs' })}\n`,
+    );
+    git(['add', 'config/prettier.cjs', 'package.json']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1\n');
+  });
+
+  it('does not false-skip an extensionless CommonJS dependency backed by .cjs (#10502)', () => {
+    mkdirSync(join(dir, 'config'));
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'const opts = require("./opts");\nmodule.exports = opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'config/opts.cjs'),
+      'module.exports = { semi: false };\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"./config/prettier.cjs"}\n',
+    );
+    git(['add', 'config/prettier.cjs', 'config/opts.cjs', 'package.json']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    // Node's CommonJS loader does not add a .cjs extension for require(),
+    // so Prettier still reports a real loader error. The hook's resolution
+    // must remove the false "not staged" provenance skip for that path.
+    expect(result.stdout).not.toContain('config/opts is not staged');
+    expect(result.stderr).toContain("Cannot find module './opts'");
+    expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+  });
+
+  it('resolves an extensionless CommonJS dependency to its .js file (#10502)', () => {
+    mkdirSync(join(dir, 'config'));
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'const opts = require("./opts");\nmodule.exports = opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'config/opts.js'),
+      'module.exports = { semi: false };\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"./config/prettier.cjs"}\n',
+    );
+    git(['add', 'config/prettier.cjs', 'config/opts.js', 'package.json']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(result.stdout).not.toContain('config/opts is not staged');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1\n');
+  });
+
+  it('resolves an extensionless CommonJS dependency through directory package main (#10502)', () => {
+    mkdirSync(join(dir, 'config/opts'), { recursive: true });
+    writeFileSync(
+      join(dir, 'config/opts/package.json'),
+      '{"main":"main.cjs"}\n',
+    );
+    writeFileSync(
+      join(dir, 'config/opts/main.cjs'),
+      'module.exports = { semi: false };\n',
+    );
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'const opts = require("./opts");\nmodule.exports = opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"./config/prettier.cjs"}\n',
+    );
+    git([
+      'add',
+      'config/prettier.cjs',
+      'config/opts/package.json',
+      'config/opts/main.cjs',
+      'package.json',
+    ]);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1\n');
+  });
+
+  it('resolves an extensionless CommonJS dependency through directory index (#10502)', () => {
+    mkdirSync(join(dir, 'config/opts'), { recursive: true });
+    writeFileSync(
+      join(dir, 'config/opts/index.js'),
+      'module.exports = { semi: false };\n',
+    );
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'const opts = require("./opts");\nmodule.exports = opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"./config/prettier.cjs"}\n',
+    );
+    git(['add', 'config/prettier.cjs', 'config/opts/index.js', 'package.json']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('staged Prettier output for a.ts');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1\n');
+  });
+
+  it('reports the literal path when an extensionless dependency has no candidate (#10502)', () => {
+    mkdirSync(join(dir, 'config'));
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'const opts = require("./missing");\nmodule.exports = opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"./config/prettier.cjs"}\n',
+    );
+    git(['add', 'config/prettier.cjs', 'package.json']);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('config/missing is not staged');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+  });
+
+  it('skips an ambiguous extensionless dependency instead of guessing (#10502)', () => {
+    mkdirSync(join(dir, 'config'));
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'const opts = require("./opts");\nmodule.exports = opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'config/opts.js'),
+      'module.exports = { semi: false };\n',
+    );
+    writeFileSync(
+      join(dir, 'config/opts.cjs'),
+      'module.exports = { semi: false };\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"./config/prettier.cjs"}\n',
+    );
+    git([
+      'add',
+      'config/prettier.cjs',
+      'config/opts.js',
+      'config/opts.cjs',
+      'package.json',
+    ]);
+    git(['commit', '-qm', 'config base']);
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('config dependency ./opts is ambiguous');
     expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
   });
 


### PR DESCRIPTION
Closes #10500
Closes #10501
Closes #10502
Closes #10503
Closes #10504
Closes #10505

Six narrow follow-ups to `scripts/format-staged.mjs` from #10482, plus follow-up review fixes.

- #10500: extensionless `.prettierrc` parses with Prettier's YAML loader (JSON subset).
- #10501: package.yaml object configs verify relative dependencies; package.yaml string pointers mirror package.json pointer handling.
- #10502: JS configs reached through package.json/package.yaml pointers run the dependency scan with Node-accurate loader semantics.
- #10503: package-name shareable configs are left to Prettier when the manifest is clean, and skip loudly only when it diverges.
- #10504: relative-dependency verification only runs when a snapshot is needed; clean direct configs are left to Prettier's own loader.
- #10505: fully staged files write the formatted blob verbatim, except autocrlf checkouts.

Additional review fixes:
- CJS `require()` resolution matches Node order (exact, `.js`, `.json`, `.node`, then directory package main, then `index.js`/`.json`/`.node`); ESM imports and plugin paths stay exact.
- Directory package manifests must be tracked and index-equal before their `main` is trusted.
- Unstaged EOL-only conversions are preserved instead of being treated as fully staged.
- `core.autocrlf` is parsed as a Git boolean.

Verification (local, macOS arm64):

- `npx vitest run --config vitest.config.mjs src/test-kernel/scripts/FormatStaged.vitest.ts --testTimeout=60000 --hookTimeout=60000` → 60/60 passed
- `npm run typecheck` → passed
- `node --max-old-space-size=6144 ./node_modules/eslint/bin/eslint.js src` → passed
- `npx prettier --check scripts/format-staged.mjs src/test-kernel/scripts/FormatStaged.vitest.ts` → passed
- `npm run check:dead-code-ratchet` → passed (15 current = 15 baselined)
- `git diff --check` → clean