### PR TITLE
fix(tui): keep static transcript cursor and held media visible

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -105,6 +105,7 @@ function renderConversationPaneEntry({
     if (
       entry.role === 'activity' ||
       entry.role === 'error' ||
+      entry.role === 'media' ||
       entry.role === 'workflowTask'
     ) {
       return (

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -102,6 +102,15 @@ function renderConversationPaneEntry({
         />
       );
     }
+    if (entry.role === 'phase') {
+      return (
+        <TranscriptEntry
+          colorEnabled={colorEnabled}
+          entry={entry}
+          width={width}
+        />
+      );
+    }
     if (
       entry.role === 'activity' ||
       entry.role === 'error' ||

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -1008,7 +1008,11 @@ export function advanceStaticTranscriptState(
   const slice = scrollbackStreamId
     ? streams.get(scrollbackStreamId)
     : undefined;
-  const entries: readonly ConversationEntry[] = slice?.entries ?? [];
+  // Pass `slice?.entries` through unchanged. `incrementalStaticTranscriptEntries`
+  // normalizes a missing slice to its frozen empty entries array; a fresh `[]`
+  // here would break cursor identity on every dependency tick while the
+  // scrollback slice is absent.
+  const entries = slice?.entries;
   const status = slice?.status;
 
   if (isHardReset) {

--- a/src/test-kernel/cli/ConversationTranscript.vitest.ts
+++ b/src/test-kernel/cli/ConversationTranscript.vitest.ts
@@ -1239,6 +1239,93 @@ describe('CLI conversation transcript', () => {
     expect(advanced.scan.scannedIndex).toBe(1);
   });
 
+  it('keeps the scan cursor and state identical while the scrollback slice is missing', () => {
+    const initial = buildStaticTranscriptState({
+      childStreamEntries: new Map(),
+      maxRows: undefined,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      repaintEpoch: 0,
+      scrollbackStreamId: STREAM_ID,
+      streams: new Map(),
+      width: 80,
+    });
+
+    const advanced = advanceStaticTranscriptState(initial, {
+      childStreamEntries: new Map(),
+      maxRows: undefined,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      scrollbackStreamId: STREAM_ID,
+      streams: new Map(),
+      width: 80,
+    });
+
+    expect(advanced).toBe(initial);
+    expect(advanced.scan).toBe(initial.scan);
+    expect(advanced.repaintEpoch).toBe(initial.repaintEpoch);
+  });
+
+  it('rebuilds once, then stays stable, when the scrollback slice disappears', () => {
+    const settled = entry('a1', 'assistant', 'ok', true);
+    const present = new Map<StreamTabId, StreamSlice>([
+      [STREAM_ID, sliceWithEntries(STREAM_ID, [settled])],
+    ]);
+    const initial = buildStaticTranscriptState({
+      childStreamEntries: new Map(),
+      maxRows: undefined,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      repaintEpoch: 0,
+      scrollbackStreamId: STREAM_ID,
+      streams: present,
+      width: 80,
+    });
+    const advancedOnce = advanceStaticTranscriptState(initial, {
+      childStreamEntries: new Map(),
+      maxRows: undefined,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      scrollbackStreamId: STREAM_ID,
+      streams: present,
+      width: 80,
+    });
+
+    expect(advancedOnce.scan.scannedIndex).toBe(1);
+
+    const missing = advanceStaticTranscriptState(advancedOnce, {
+      childStreamEntries: new Map(),
+      maxRows: undefined,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      scrollbackStreamId: STREAM_ID,
+      streams: new Map(),
+      width: 80,
+    });
+
+    expect(missing.repaintEpoch).toBe(advancedOnce.repaintEpoch + 1);
+
+    const missingAgain = advanceStaticTranscriptState(missing, {
+      childStreamEntries: new Map(),
+      maxRows: undefined,
+      meta: SESSION_META,
+      ownerKey: 'root',
+      parentStream: new Map(),
+      scrollbackStreamId: STREAM_ID,
+      streams: new Map(),
+      width: 80,
+    });
+
+    expect(missingAgain).toBe(missing);
+    expect(missingAgain.scan).toBe(missing.scan);
+    expect(missingAgain.repaintEpoch).toBe(missing.repaintEpoch);
+  });
+
   it('recomputes ring totals and trims when the layout width shrinks', () => {
     const budgets: StaticTranscriptRingBudgets = {
       rowHighWater: 6,

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -615,6 +615,55 @@ describe('CLI child list display model', () => {
     },
   );
 
+  it('renders held media in the live pending pane behind an unfinished tool', async () => {
+    const { ink, React } = await loadInk();
+    const streamId = 'media-holder' as StreamTabId;
+    const slice: StreamSlice = {
+      ...emptySlice(streamId),
+      status: STREAM_PHASE.RUNNING,
+      entries: [
+        {
+          id: 'blocking-tool',
+          role: 'tool',
+          text: '',
+          finalized: false,
+          toolUse: {
+            toolName: 'write_file',
+            errorText: '',
+            outputText: '',
+            userInstructionText: '',
+            input: { path: 'paper.tex' },
+            isError: false,
+            isUserFeedback: false,
+            headerSummary: 'Drafting paper.tex',
+            status: 'in_progress',
+          },
+        },
+        {
+          id: 'held-media',
+          role: 'media',
+          text: '',
+          finalized: true,
+          images: [{ path: '/tmp/held-plot.png', sizeBytes: 8704 }],
+        },
+      ],
+    };
+    activeStreamId.set(streamId);
+    streamsSignal.set(new Map([[streamId, slice]]));
+
+    try {
+      const output = ink.renderToString(
+        React.createElement(ConversationPane, { maxRows: 4, width: 80 }),
+        { columns: 80 },
+      );
+      expect(output).toContain('[image]');
+      expect(output).toContain('/tmp/held-plot.png');
+    } finally {
+      activeStreamId.set(undefined);
+      streamsSignal.set(new Map());
+    }
+  });
+
   it('keeps status markers steady and status colors independent of focus', () => {
     expect(CHILD_STATUS_MARKER).toBe('● ');
     expect(childStatusColor('running')).toBe('cyan');

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.ts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.ts
@@ -664,6 +664,51 @@ describe('CLI child list display model', () => {
     }
   });
 
+  it('renders held workflow phases in the live pending pane behind an unfinished tool', async () => {
+    const { ink, React } = await loadInk();
+    const streamId = 'phase-holder' as StreamTabId;
+    const slice: StreamSlice = {
+      ...emptySlice(streamId),
+      status: STREAM_PHASE.RUNNING,
+      entries: [
+        {
+          id: 'blocking-tool',
+          role: 'tool',
+          text: '',
+          finalized: false,
+          toolUse: {
+            toolName: 'write_file',
+            errorText: '',
+            outputText: '',
+            userInstructionText: '',
+            input: { path: 'paper.tex' },
+            isError: false,
+            isUserFeedback: false,
+            headerSummary: 'Drafting paper.tex',
+            status: 'in_progress',
+          },
+        },
+        phaseEntry('held-phase', 'Verify', {
+          phaseIndex: 0,
+          phaseTotal: 2,
+        }),
+      ],
+    };
+    activeStreamId.set(streamId);
+    streamsSignal.set(new Map([[streamId, slice]]));
+
+    try {
+      const output = ink.renderToString(
+        React.createElement(ConversationPane, { maxRows: 4, width: 80 }),
+        { columns: 80 },
+      );
+      expect(output).toContain('◆ Verify (1/2)');
+    } finally {
+      activeStreamId.set(undefined);
+      streamsSignal.set(new Map());
+    }
+  });
+
   it('keeps status markers steady and status colors independent of focus', () => {
     expect(CHILD_STATUS_MARKER).toBe('● ');
     expect(childStatusColor('running')).toBe('cyan');


### PR DESCRIPTION
Closes #10589
Closes #10590

## Summary

- `advanceStaticTranscriptState` now passes `slice?.entries` through unchanged. A missing scrollback slice reuses the frozen empty-entries cursor identity instead of allocating a fresh `[]` per dependency tick, so repeated advances return the same state object and do not bump the repaint epoch.
- `renderConversationPaneEntry` now routes held media entries through `BoundedTranscriptEntry`, matching the existing `activity`/`error`/`workflowTask` live branches, so finalized media behind an unfinished tool stays visible in the live pending pane.
- `renderConversationPaneEntry` now also renders held `phase` entries through `TranscriptEntry`, preserving the bold `◆` divider styling instead of dropping them from the live pending pane.

## Validation

- `vitest run src/test-kernel/cli/ConversationTranscript.vitest.ts src/test-kernel/cli/SubagentListDisplay.vitest.ts src/test-kernel/cli/WorkflowRunDetails.vitest.ts src/test-kernel/cli/TuiStateAndFocus.vitest.ts src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.ts` — 341 passed
- `npm run typecheck:cli`, `npm run typecheck:workspace`, `npm run typecheck:test-kernel`
- `npm run lint`
- `corepack pnpm prettier --check` on changed files
- `node scripts/validate-tui.mjs transcript static-transcript-repaint-canonical static-transcript-repaint-reflow static-transcript-terminal-resume workflow-running workflow-timeline` — all 6 scenarios passed
- `npm run check:dead-code-ratchet`, `corepack pnpm --filter @texra-ai/cli check:architecture`, `git diff --check`