### PR TITLE
fix(retry): reroute dual-backend Kimi Code credit retries and recheck fallback identity

### DIFF
--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -12,7 +12,6 @@ import {
 import { warn as logWarning } from '@logger/logUtils';
 import {
   type ApprovalDecision,
-  type RetryPermission,
   type UserQuestionAnswers,
 } from '@shared/schemas';
 import { handleExternalInquiryAction } from '@tools/inquiry/inquiryActions';
@@ -293,19 +292,8 @@ export function createHeadlessCliHostInteractions(
       });
     },
     async requestRetry(request: HostRetryRequest) {
-      const payload: RetryPermission = {
-        requestId: request.requestId,
-        streamId: request.streamId,
-        operation: request.operation,
-        ...(request.model ? { model: request.model } : {}),
-        ...(request.errorMessage ? { errorMessage: request.errorMessage } : {}),
-        ...(request.errorDetails ? { errorDetails: request.errorDetails } : {}),
-        ...(request.kimiCodeRoutedOnFailure !== undefined
-          ? { kimiCodeRoutedOnFailure: request.kimiCodeRoutedOnFailure }
-          : {}),
-      };
       const { decision, prompted } = await decideApprovalEvent(
-        { type: 'showRetryRequest', payload },
+        { type: 'showRetryRequest', payload: request },
         context,
         hooks,
         { writeRejectionToStderr: true },

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -300,6 +300,9 @@ export function createHeadlessCliHostInteractions(
         ...(request.model ? { model: request.model } : {}),
         ...(request.errorMessage ? { errorMessage: request.errorMessage } : {}),
         ...(request.errorDetails ? { errorDetails: request.errorDetails } : {}),
+        ...(request.kimiCodeRoutedOnFailure !== undefined
+          ? { kimiCodeRoutedOnFailure: request.kimiCodeRoutedOnFailure }
+          : {}),
       };
       const { decision, prompted } = await decideApprovalEvent(
         { type: 'showRetryRequest', payload },

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -720,6 +720,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const started =
       await this.apiKeyRetryController.runCopilotFallbackWithRouting(
         {
+          stream: data.stream,
+          requestId: data.requestId,
           provider: fallback.provider,
           model: fallback.model,
           exhaustionReason: data.exhaustionReason,

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -313,6 +313,7 @@ export function handlePermissionAction(
               ? 'openai'
               : data.errorDetails?.provider,
           viaRelay: data.errorDetails?.isRelayError === true || undefined,
+          kimiCodeRoutedOnFailure: data.kimiCodeRoutedOnFailure,
         });
         break;
       }

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -23,6 +23,7 @@ import {
   toRetryErrorInfo,
   type RetryErrorInfo,
 } from '@shared/schemas';
+import { isKimiCodeExclusiveModel } from '@shared/model/kimiCodeRetryGate';
 import {
   DEFAULT_CORE_SETTINGS,
   ModelRetryMaxAttemptsSchema,
@@ -505,6 +506,14 @@ export abstract class RetryableInvocationNode<
     });
     // No timeout: the retry panel waits indefinitely for the user's decision.
     let clientPrepared = false;
+    // Capture the failed handler's effective route before the retry panel can
+    // be outlived by routing-preference changes. A dual-backend Kimi handler
+    // dispatched onto the coding endpoint carries the pinned Kimi Code
+    // `baseUrl`, so the shared field predicate is true for that runtime config
+    // even though the registry entry itself is not coding-exclusive.
+    const kimiCodeRoutedOnFailure = isKimiCodeExclusiveModel(
+      this.services.modelCell.handler.config,
+    );
     const interaction = session.interactions.requestRetry(
       {
         requestId: `retry-${generateShortId()}`,
@@ -513,6 +522,7 @@ export abstract class RetryableInvocationNode<
         model: this.services.config.model,
         errorMessage: formatted.message,
         errorDetails: formatted,
+        kimiCodeRoutedOnFailure,
       },
       {
         prepareRetry: async (selection, signal) => {

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -6,7 +6,7 @@ import type {
   FileLocation,
   Plan,
   ProgressPermissionKind as PendingInteractionKind,
-  ProviderErrorPartial,
+  RetryPermission,
   StreamTabId,
   UserQuestionAnswers,
   ExternalInquiryPermission,
@@ -187,17 +187,13 @@ export type HostAgentProposalRequest = AgentProposal & {
   readonly streamId: StreamTabId;
 };
 
-export interface HostRetryRequest {
-  readonly requestId: string;
-  readonly streamId: StreamTabId;
-  readonly operation: string;
-  readonly model?: string;
-  readonly errorMessage?: string;
-  readonly errorDetails?: ProviderErrorPartial;
-  /** True when the failed handler was dispatched onto the Kimi Code coding
-   * endpoint, captured before the retry panel opened. */
-  readonly kimiCodeRoutedOnFailure?: boolean;
-}
+/**
+ * The retry payload the runtime hands to hosts. This is deliberately an alias
+ * of the shared {@link RetryPermission} schema so the runtime and every host
+ * render the same contract; a field added to the permission payload is
+ * available here without a hand-maintained mirror.
+ */
+export type HostRetryRequest = RetryPermission;
 
 export type HostUserQuestionRequest = UserQuestionPermission;
 

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -194,6 +194,9 @@ export interface HostRetryRequest {
   readonly model?: string;
   readonly errorMessage?: string;
   readonly errorDetails?: ProviderErrorPartial;
+  /** True when the failed handler was dispatched onto the Kimi Code coding
+   * endpoint, captured before the retry panel opened. */
+  readonly kimiCodeRoutedOnFailure?: boolean;
 }
 
 export type HostUserQuestionRequest = UserQuestionPermission;

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -10,6 +10,7 @@ import type { ExhaustionReason, StreamTabId } from '@shared/schemas';
 import {
   isKimiCodeExclusiveModel,
   isKimiCodeSubscriptionRetryBlocked,
+  isKimiSubscriptionEligible,
 } from '@shared/model/kimiCodeRetryGate';
 import { isNonEmptyString } from '@utils/core';
 
@@ -37,6 +38,8 @@ interface CodingPlanToggle {
   readonly getEnabled: () => boolean;
   readonly setEnabled: (enabled: boolean) => Promise<void>;
   readonly restoreEnabled?: (enabled: boolean) => Promise<void>;
+  /** Resolve whether this plan currently serves `modelId`, when available. */
+  readonly isActiveForModel?: (modelId: string) => Promise<boolean>;
 }
 
 interface ProgressApiKeyPreparationResult {
@@ -113,6 +116,22 @@ export class ProgressApiKeyRetryController {
       : request.provider;
   }
 
+  /**
+   * Whether `model` is a dual-backend Kimi model (`kimi3`): eligible for the
+   * Kimi Code coding endpoint but also served by the Moonshot open platform.
+   * Exclusive coding-only aliases pin their `baseUrl`, so they must be kept
+   * out of this branch.
+   */
+  private isDualBackendKimiCodeModel(model: string | undefined): boolean {
+    if (model === undefined) return false;
+    const config = MODEL_CONFIGS[model];
+    return (
+      config !== undefined &&
+      isKimiSubscriptionEligible(config) &&
+      !isKimiCodeExclusiveModel(config)
+    );
+  }
+
   private get codingPlanToggles(): readonly CodingPlanToggle[] {
     return (
       this.deps.codingPlanToggles ??
@@ -121,6 +140,7 @@ export class ProgressApiKeyRetryController {
         getEnabled: runtime.getEnabled,
         setEnabled: runtime.setEnabled,
         restoreEnabled: runtime.restoreEnabled,
+        isActiveForModel: runtime.isActiveForModel,
       }))
     );
   }
@@ -257,10 +277,22 @@ export class ProgressApiKeyRetryController {
     // the regular pay-as-you-go endpoint on retry.
     const disabledCodingPlans: ExhaustionReason[] = [];
     for (const toggle of this.codingPlanToggles) {
-      if (
-        toggle.getEnabled() &&
-        request.exhaustionReason === toggle.exhaustionReason
-      ) {
+      const planExhaustion =
+        request.exhaustionReason === toggle.exhaustionReason;
+      // An `upstream-credit` failure on a dual-backend Kimi model currently
+      // routed through the coding endpoint means the broken credential is the
+      // `kimiCode` key, but the forwarded SDK provider is `moonshot`. The
+      // coding-plan quota reason does not match, so without this branch the
+      // "Prefer Kimi Code" switch would stay on and the retry rebuild would
+      // re-select the exhausted coding endpoint instead of the newly entered
+      // Moonshot key.
+      const kimiCodeCreditReroute =
+        toggle.exhaustionReason === 'kimi-code-subscription' &&
+        request.exhaustionReason === 'upstream-credit' &&
+        this.isDualBackendKimiCodeModel(request.model) &&
+        request.model !== undefined &&
+        ((await toggle.isActiveForModel?.(request.model)) ?? false);
+      if (toggle.getEnabled() && (planExhaustion || kimiCodeCreditReroute)) {
         await toggle.setEnabled(false);
         this.deps.invalidateModelOptionsCache();
         disabledCodingPlans.push(toggle.exhaustionReason);
@@ -277,10 +309,17 @@ export class ProgressApiKeyRetryController {
 
   /** Apply Copilot fallback routing only for the duration of a launch attempt. */
   async runCopilotFallbackWithRouting(
-    request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
+    request: ProgressApiKeyRetryRequest,
     start: (copilotRouteOverride: CopilotRouteOverride) => Promise<boolean>,
   ): Promise<boolean> {
     return this.routingCommitQueue.add(async () => {
+      // Mirror `useOwnApiKey`: this callback may have waited behind another
+      // stream's routing commit. Re-check the exact retry identity before
+      // touching global routing so a dismissed/replaced request cannot apply
+      // a stale switch.
+      if (!this.deps.isRetryPending(request.stream, request.requestId)) {
+        return false;
+      }
       const before = this.routingSnapshot();
       const prepared = await this.applyOwnApiKeyRouting(request);
       // The user chose "use own API key" for this retry. The direct-route

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -21,6 +21,10 @@ export interface ProgressApiKeyRetryRequest {
   /** Canonical base model the fallback run will launch with, when known. */
   model?: string;
   exhaustionReason?: ExhaustionReason;
+  /** True when the failed handler's effective config was pinned to the Kimi
+   * Code coding endpoint, captured from the persisted handler before the
+   * retry panel opened. */
+  kimiCodeRoutedOnFailure?: boolean;
   chatGptSubscriptionEligible?: boolean;
   viaRelay?: boolean;
 }
@@ -287,10 +291,14 @@ export class ProgressApiKeyRetryController {
       // here. The failed handler was dispatched under the persisted
       // `ModelHandlerKimi` compatibility key, and the retry rebuild pins that
       // same key, so a later OpenRouter preference change cannot make the
-      // rebuild take a non-coding route.
+      // rebuild take a non-coding route. The request's
+      // `kimiCodeRoutedOnFailure` flag is captured from that failed handler,
+      // so unrelated `kimi3` failures through OpenRouter, Moonshot, or the
+      // relay leave the preference untouched.
       const kimiCodeCreditReroute =
         toggle.exhaustionReason === 'kimi-code-subscription' &&
         request.exhaustionReason === 'upstream-credit' &&
+        request.kimiCodeRoutedOnFailure === true &&
         this.isDualBackendKimiCodeModel(request.model);
       if (toggle.getEnabled() && (planExhaustion || kimiCodeCreditReroute)) {
         await toggle.setEnabled(false);

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -38,8 +38,6 @@ interface CodingPlanToggle {
   readonly getEnabled: () => boolean;
   readonly setEnabled: (enabled: boolean) => Promise<void>;
   readonly restoreEnabled?: (enabled: boolean) => Promise<void>;
-  /** Resolve whether this plan currently serves `modelId`, when available. */
-  readonly isActiveForModel?: (modelId: string) => Promise<boolean>;
 }
 
 interface ProgressApiKeyPreparationResult {
@@ -140,7 +138,6 @@ export class ProgressApiKeyRetryController {
         getEnabled: runtime.getEnabled,
         setEnabled: runtime.setEnabled,
         restoreEnabled: runtime.restoreEnabled,
-        isActiveForModel: runtime.isActiveForModel,
       }))
     );
   }
@@ -279,19 +276,22 @@ export class ProgressApiKeyRetryController {
     for (const toggle of this.codingPlanToggles) {
       const planExhaustion =
         request.exhaustionReason === toggle.exhaustionReason;
-      // An `upstream-credit` failure on a dual-backend Kimi model currently
-      // routed through the coding endpoint means the broken credential is the
-      // `kimiCode` key, but the forwarded SDK provider is `moonshot`. The
-      // coding-plan quota reason does not match, so without this branch the
-      // "Prefer Kimi Code" switch would stay on and the retry rebuild would
-      // re-select the exhausted coding endpoint instead of the newly entered
-      // Moonshot key.
+      // An `upstream-credit` failure on a dual-backend Kimi model means the
+      // broken credential is the `kimiCode` key, but the forwarded SDK
+      // provider is `moonshot`. The coding-plan quota reason does not match,
+      // so without this branch the "Prefer Kimi Code" switch would stay on
+      // and the retry rebuild would re-select the exhausted coding endpoint
+      // instead of the newly entered Moonshot key.
+      //
+      // Deliberately conservative: do not consult the live route resolver
+      // here. The failed handler was dispatched under the persisted
+      // `ModelHandlerKimi` compatibility key, and the retry rebuild pins that
+      // same key, so a later OpenRouter preference change cannot make the
+      // rebuild take a non-coding route.
       const kimiCodeCreditReroute =
         toggle.exhaustionReason === 'kimi-code-subscription' &&
         request.exhaustionReason === 'upstream-credit' &&
-        this.isDualBackendKimiCodeModel(request.model) &&
-        request.model !== undefined &&
-        ((await toggle.isActiveForModel?.(request.model)) ?? false);
+        this.isDualBackendKimiCodeModel(request.model);
       if (toggle.getEnabled() && (planExhaustion || kimiCodeCreditReroute)) {
         await toggle.setEnabled(false);
         this.deps.invalidateModelOptionsCache();

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -459,6 +459,7 @@ export function createProgressViewSecondTierHandlers(
         provider: providerArg,
         exhaustionReason: data.exhaustionReason,
         viaRelay: data.viaRelay,
+        kimiCodeRoutedOnFailure: data.kimiCodeRoutedOnFailure,
       });
       if (result.proceeded && !result.retried) {
         await deps.host.showInfo(

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -60,6 +60,9 @@ const UseOwnApiKeyMessageSchema = StreamScopedBaseSchema.extend({
    *  must not globally disable relay access — other providers may still
    *  be served successfully by relay. */
   viaRelay: z.boolean().optional(),
+  /** True when the failed handler was dispatched onto the Kimi Code coding
+   * endpoint, captured before the retry panel opened. */
+  kimiCodeRoutedOnFailure: z.boolean().optional(),
 });
 
 /** Set-on (idempotent) delegated-work approval. */

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -50,6 +50,9 @@ export const RetryPermissionSchema = z.strictObject({
   model: z.string().optional(),
   errorMessage: z.string().optional(),
   errorDetails: ProviderErrorPartialSchema.optional(),
+  /** True when the failed handler was dispatched onto the Kimi Code coding
+   * endpoint, captured before the retry panel opened. */
+  kimiCodeRoutedOnFailure: z.boolean().optional(),
 });
 export type RetryPermission = z.infer<typeof RetryPermissionSchema>;
 

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -108,6 +108,7 @@ interface TestRetryServices {
 function testRetryModelCell(
   rebind: TestRebind = async () => undefined,
   route?: ModelCredentialRoute,
+  handlerConfig: object = {},
 ): TestRetryServices['modelCell'] {
   // The handler stub only feeds the Kimi Code fallback probe, which reads
   // `config` and finds no Kimi fields on it, so a swap never fires here.
@@ -115,7 +116,9 @@ function testRetryModelCell(
     getClient: async () => ({}),
     rebind,
     route,
-    handler: { config: {} } as TestRetryServices['modelCell']['handler'],
+    handler: {
+      config: handlerConfig,
+    } as TestRetryServices['modelCell']['handler'],
     swap: () => {},
   };
 }
@@ -188,6 +191,7 @@ function createRetryNode(
   // The node reads its session from `services.runScope`, so a test driving a
   // real session's host interactions must hand that same session in here.
   sessionOverride?: SessionHandle,
+  handlerConfig?: object,
 ): RetryNodeKit {
   const requestRetry = vi.fn<RetryNodeKit['requestRetry']>();
   const session =
@@ -201,7 +205,7 @@ function createRetryNode(
     retryServices(streamId, {
       config: { model: 'sonnet46', agentCategory: AgentCategory.ToolUse },
       session,
-      modelCell: testRetryModelCell(rebind, route),
+      modelCell: testRetryModelCell(rebind, route, handlerConfig),
     }),
   );
   return { node, session, streamStatus, requestRetry };
@@ -1381,6 +1385,68 @@ describe('RetryState', () => {
         // Every run carries a model cell, so the host is always offered the
         // credential-selecting retry preparation.
         expect.objectContaining({ prepareRetry: expect.any(Function) }),
+      );
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
+  it('marks a Kimi Code-routed failed handler on the retry request', async () => {
+    const streamId = 'retry-state-kimi-code-routed' as StreamTabId;
+    const { node, session, streamStatus, requestRetry } = createRetryNode(
+      streamId,
+      undefined,
+      undefined,
+      undefined,
+      {
+        provider: 'moonshot',
+        kimiSubscription: true,
+        baseUrl: KIMI_CODE_BASE_URL,
+      },
+    );
+    requestRetry.mockResolvedValueOnce({ action: 'retry' });
+
+    try {
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
+
+      await withRetryRunContext(streamId, session, () =>
+        node.promptFor(new Error('temporary provider failure')),
+      );
+
+      expect(requestRetry).toHaveBeenCalledWith(
+        expect.objectContaining({ kimiCodeRoutedOnFailure: true }),
+        expect.anything(),
+      );
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
+  it('marks a non-Kimi-Code kimi3 failed handler as not routed', async () => {
+    const streamId = 'retry-state-kimi3-open-platform' as StreamTabId;
+    const { node, session, streamStatus, requestRetry } = createRetryNode(
+      streamId,
+      undefined,
+      undefined,
+      undefined,
+      { provider: 'moonshot', kimiSubscription: true },
+    );
+    requestRetry.mockResolvedValueOnce({ action: 'retry' });
+
+    try {
+      seedStreamStatusForTest(streamStatus, streamId, {
+        phase: STREAM_PHASE.RUNNING,
+      });
+
+      await withRetryRunContext(streamId, session, () =>
+        node.promptFor(new Error('temporary provider failure')),
+      );
+
+      expect(requestRetry).toHaveBeenCalledWith(
+        expect.objectContaining({ kimiCodeRoutedOnFailure: false }),
+        expect.anything(),
       );
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -416,18 +416,23 @@ describe('requestRetry classification (#7331)', () => {
     },
   );
 
-  it('preserves the failed handler Kimi Code route flag on the CLI retry payload', async () => {
+  it('passes the retry request payload through to the CLI retry presenter unchanged', async () => {
     const ctx = context({ approvalPolicy: 'never', mode: 'headless' });
+    const routed = {
+      ...retryRequest,
+      kimiCodeRoutedOnFailure: true,
+    };
+    const notRouted = {
+      ...retryRequest,
+      kimiCodeRoutedOnFailure: false,
+    };
 
-    await requestHeadlessRetry(ctx, { kimiCodeRoutedOnFailure: true });
-    expect(formatRetryRequestMessageMock).toHaveBeenCalledWith(
-      expect.objectContaining({ kimiCodeRoutedOnFailure: true }),
-    );
+    await createHeadlessCliHostInteractions(ctx).requestRetry?.(routed);
+    await createHeadlessCliHostInteractions(ctx).requestRetry?.(notRouted);
 
-    await requestHeadlessRetry(ctx, { kimiCodeRoutedOnFailure: false });
-    expect(formatRetryRequestMessageMock).toHaveBeenCalledWith(
-      expect.objectContaining({ kimiCodeRoutedOnFailure: false }),
-    );
+    // The payload is the exact runtime request object, not a re-built copy.
+    expect(formatRetryRequestMessageMock).toHaveBeenCalledWith(routed);
+    expect(formatRetryRequestMessageMock).toHaveBeenCalledWith(notRouted);
   });
 
   it('cancels a retry the interactive user explicitly rejects', async () => {

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -4,11 +4,23 @@ import '@test/support/defaultSessionTestSetup';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const handleExternalInquiryActionMock = vi.hoisted(() => vi.fn());
+const formatRetryRequestMessageMock = vi.hoisted(() => vi.fn());
 let detachHostInteractions = (): void => {};
 
 vi.mock('@tools/inquiry/inquiryActions', () => ({
   handleExternalInquiryAction: handleExternalInquiryActionMock,
 }));
+
+vi.mock('@cli/runtime/approval/approvalSummaries', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@cli/runtime/approval/approvalSummaries')
+    >();
+  return {
+    ...actual,
+    formatRetryRequestMessage: formatRetryRequestMessageMock,
+  };
+});
 
 import { Node } from '@agent/node';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
@@ -154,12 +166,19 @@ beforeEach(async () => {
   const { initPlatform: init } = await import('@platform/platform');
   const { createFakePlatform } = await import('@test/support/FakePlatform');
   init(createFakePlatform());
+  const actual = await vi.importActual<
+    typeof import('@cli/runtime/approval/approvalSummaries')
+  >('@cli/runtime/approval/approvalSummaries');
+  formatRetryRequestMessageMock.mockImplementation(
+    actual.formatRetryRequestMessage,
+  );
 });
 
 afterEach(() => {
   detachHostInteractions();
   detachHostInteractions = () => {};
   handleExternalInquiryActionMock.mockClear();
+  formatRetryRequestMessageMock.mockReset();
   vi.restoreAllMocks();
 });
 
@@ -396,6 +415,20 @@ describe('requestRetry classification (#7331)', () => {
       });
     },
   );
+
+  it('preserves the failed handler Kimi Code route flag on the CLI retry payload', async () => {
+    const ctx = context({ approvalPolicy: 'never', mode: 'headless' });
+
+    await requestHeadlessRetry(ctx, { kimiCodeRoutedOnFailure: true });
+    expect(formatRetryRequestMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ kimiCodeRoutedOnFailure: true }),
+    );
+
+    await requestHeadlessRetry(ctx, { kimiCodeRoutedOnFailure: false });
+    expect(formatRetryRequestMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ kimiCodeRoutedOnFailure: false }),
+    );
+  });
 
   it('cancels a retry the interactive user explicitly rejects', async () => {
     const result = await requestHeadlessRetry(

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -650,6 +650,7 @@ describe('ProgressApiKeyRetryController', () => {
       model: 'kimiCoding',
       provider: 'moonshot',
       exhaustionReason: 'upstream-credit',
+      kimiCodeRoutedOnFailure: true,
     });
 
     expect(result).toStrictEqual({
@@ -684,6 +685,7 @@ describe('ProgressApiKeyRetryController', () => {
       model: 'kimi3',
       provider: 'moonshot',
       exhaustionReason: 'upstream-credit',
+      kimiCodeRoutedOnFailure: true,
     });
 
     expect(result).toStrictEqual({
@@ -706,6 +708,42 @@ describe('ProgressApiKeyRetryController', () => {
     expect(harness.kimiCodeValues).toStrictEqual([false]);
     expect(harness.invalidations).toBe(1);
     expect(harness.retries).toStrictEqual(['stream-kimi-dual']);
+  });
+
+  it('leaves the Kimi Code preference untouched for a non-Kimi-Code kimi3 credit retry', async () => {
+    const harness = createHarness({
+      keys: { moonshot: 'old-moonshot', kimiCode: 'old-kimi' },
+      prompt: (keys) => {
+        keys.set('moonshot', 'new-moonshot');
+      },
+      kimiCode: true,
+    });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-kimi-moonshot',
+      requestId: 'retry-kimi-moonshot',
+      model: 'kimi3',
+      provider: 'moonshot',
+      exhaustionReason: 'upstream-credit',
+      kimiCodeRoutedOnFailure: false,
+    });
+
+    expect(result).toStrictEqual({
+      proceeded: true,
+      retried: true,
+      disabledIncludedModelAccess: false,
+      disabledChatGptSubscription: false,
+      disabledCodingPlans: [],
+    });
+    // A canonical `kimi3` can also fail through OpenRouter, Moonshot, or the
+    // relay. Those failed handlers were not dispatched onto the Kimi Code
+    // endpoint, so the retry must not turn off the user's coding preference.
+    expect(harness.prompts).toStrictEqual(['moonshot']);
+    expect(harness.keys.get('moonshot')).toBe('new-moonshot');
+    expect(harness.keys.get('kimiCode')).toBe('old-kimi');
+    expect(harness.kimiCodeValues).toStrictEqual([]);
+    expect(harness.invalidations).toBe(0);
+    expect(harness.retries).toStrictEqual(['stream-kimi-moonshot']);
   });
 
   it('rechecks Copilot fallback retry identity after the routing queue admits it', async () => {

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -35,6 +35,8 @@ interface HarnessOptions {
   keys?: Partial<Record<ApiProvider, string | undefined>>;
   prompt?(keys: Map<ApiProvider, string | undefined>): void;
   glmCodingPlan?: boolean;
+  kimiCode?: boolean;
+  kimiCodeActiveForModel?: (modelId: string) => boolean;
   retryAvailable?: boolean;
   retryPending?: boolean;
   triggerRetry?: ProgressApiKeyRetryControllerDeps['triggerRetry'];
@@ -48,6 +50,7 @@ function createHarness(options: HarnessOptions = {}): {
   includedAccessValues: boolean[];
   chatGptSubscriptionValues: boolean[];
   glmCodingPlanValues: boolean[];
+  kimiCodeValues: boolean[];
   invalidations: number;
   retries: string[];
 } {
@@ -60,8 +63,12 @@ function createHarness(options: HarnessOptions = {}): {
   const includedAccessValues: boolean[] = [];
   const chatGptSubscriptionValues: boolean[] = [];
   const glmCodingPlanValues: boolean[] = [];
+  const kimiCodeValues: boolean[] = [];
+  const kimiCodeActiveForModel =
+    options.kimiCodeActiveForModel ?? (() => false);
   let preferChatGptSubscription = true;
   let glmCodingPlan = options.glmCodingPlan ?? true;
+  let kimiCode = options.kimiCode ?? true;
   let invalidations = 0;
   const retries: string[] = [];
 
@@ -71,6 +78,7 @@ function createHarness(options: HarnessOptions = {}): {
     includedAccessValues,
     chatGptSubscriptionValues,
     glmCodingPlanValues,
+    kimiCodeValues,
     get invalidations() {
       return invalidations;
     },
@@ -101,6 +109,15 @@ function createHarness(options: HarnessOptions = {}): {
             glmCodingPlan = enabled;
             glmCodingPlanValues.push(enabled);
           },
+        },
+        {
+          exhaustionReason: 'kimi-code-subscription',
+          getEnabled: () => kimiCode,
+          setEnabled: async (enabled) => {
+            kimiCode = enabled;
+            kimiCodeValues.push(enabled);
+          },
+          isActiveForModel: async (modelId) => kimiCodeActiveForModel(modelId),
         },
       ],
       invalidateModelOptionsCache: () => {
@@ -396,7 +413,12 @@ describe('ProgressApiKeyRetryController', () => {
     expect(harness.includedAccessValues).toStrictEqual([]);
 
     const started = await harness.controller.runCopilotFallbackWithRouting(
-      { provider: 'anthropic', exhaustionReason: 'copilot-subscription' },
+      {
+        stream: 'stream-a',
+        requestId: 'retry-a',
+        provider: 'anthropic',
+        exhaustionReason: 'copilot-subscription',
+      },
       async () => true,
     );
 
@@ -413,7 +435,11 @@ describe('ProgressApiKeyRetryController', () => {
     const harness = createHarness();
 
     const started = await harness.controller.runCopilotFallbackWithRouting(
-      { exhaustionReason: 'copilot-subscription' },
+      {
+        stream: 'stream-a',
+        requestId: 'retry-a',
+        exhaustionReason: 'copilot-subscription',
+      },
       async () => false,
     );
 
@@ -427,6 +453,8 @@ describe('ProgressApiKeyRetryController', () => {
 
     const started = await harness.controller.runCopilotFallbackWithRouting(
       {
+        stream: 'stream-a',
+        requestId: 'retry-a',
         exhaustionReason: 'copilot-subscription',
         chatGptSubscriptionEligible: true,
       },
@@ -444,6 +472,8 @@ describe('ProgressApiKeyRetryController', () => {
 
     const started = await harness.controller.runCopilotFallbackWithRouting(
       {
+        stream: 'stream-a',
+        requestId: 'retry-a',
         exhaustionReason: 'copilot-subscription',
         chatGptSubscriptionEligible: true,
       },
@@ -460,7 +490,11 @@ describe('ProgressApiKeyRetryController', () => {
     const harness = createHarness();
 
     const started = await harness.controller.runCopilotFallbackWithRouting(
-      { exhaustionReason: 'copilot-subscription' },
+      {
+        stream: 'stream-a',
+        requestId: 'retry-a',
+        exhaustionReason: 'copilot-subscription',
+      },
       async () => true,
     );
 
@@ -485,7 +519,12 @@ describe('ProgressApiKeyRetryController', () => {
 
     expect(prefersCopilotRoute('sonnet46')).toBe(true);
     const started = await harness.controller.runCopilotFallbackWithRouting(
-      { model: 'sonnet46', exhaustionReason: 'copilot-subscription' },
+      {
+        stream: 'stream-a',
+        requestId: 'retry-a',
+        model: 'sonnet46',
+        exhaustionReason: 'copilot-subscription',
+      },
       async (copilotRouteOverride) => {
         expect(copilotRouteOverride).toBe('direct');
         // A concurrent launch still sees the user's standing preference; only
@@ -606,6 +645,8 @@ describe('ProgressApiKeyRetryController', () => {
       prompt: (keys) => {
         keys.set('kimiCode', 'new-kimi');
       },
+      kimiCode: true,
+      kimiCodeActiveForModel: () => true,
     });
 
     const result = await harness.controller.useOwnApiKey({
@@ -629,6 +670,93 @@ describe('ProgressApiKeyRetryController', () => {
     expect(harness.prompts).toStrictEqual(['kimiCode']);
     expect(harness.keys.get('kimiCode')).toBe('new-kimi');
     expect(harness.keys.get('moonshot')).toBe('old-moonshot');
+    expect(harness.kimiCodeValues).toStrictEqual([]);
     expect(harness.retries).toStrictEqual(['stream-kimi-credit']);
+  });
+
+  it('disables the Kimi Code preference when a dual-backend Kimi model credit-retries from the coding route', async () => {
+    const harness = createHarness({
+      keys: { moonshot: 'old-moonshot', kimiCode: 'old-kimi' },
+      prompt: (keys) => {
+        keys.set('moonshot', 'new-moonshot');
+      },
+      kimiCode: true,
+      kimiCodeActiveForModel: (modelId) => modelId === 'kimi3',
+    });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-kimi-dual',
+      requestId: 'retry-kimi-dual',
+      model: 'kimi3',
+      provider: 'moonshot',
+      exhaustionReason: 'upstream-credit',
+    });
+
+    expect(result).toStrictEqual({
+      proceeded: true,
+      retried: true,
+      disabledIncludedModelAccess: false,
+      disabledChatGptSubscription: false,
+      disabledCodingPlans: ['kimi-code-subscription'],
+    });
+    // The forwarded SDK provider is `moonshot`, so that is the credential the
+    // panel asks to replace; the routing step then turns off "Prefer Kimi
+    // Code" so the rebuilt handler actually uses the new Moonshot key.
+    expect(harness.prompts).toStrictEqual(['moonshot']);
+    expect(harness.keys.get('moonshot')).toBe('new-moonshot');
+    expect(harness.keys.get('kimiCode')).toBe('old-kimi');
+    expect(harness.kimiCodeValues).toStrictEqual([false]);
+    expect(harness.invalidations).toBe(1);
+    expect(harness.retries).toStrictEqual(['stream-kimi-dual']);
+  });
+
+  it('rechecks Copilot fallback retry identity after the routing queue admits it', async () => {
+    const firstStart = pDefer<boolean>();
+    let stalePending = true;
+    const startCalls: string[] = [];
+    const harness = createHarness({
+      isRetryPending: (_stream, requestId) =>
+        requestId === 'retry-stale' ? stalePending : true,
+    });
+
+    const holder = harness.controller.runCopilotFallbackWithRouting(
+      {
+        stream: 'stream-holder',
+        requestId: 'retry-holder',
+        exhaustionReason: 'copilot-subscription',
+      },
+      async () => {
+        startCalls.push('holder');
+        return firstStart.promise;
+      },
+    );
+    await vi.waitFor(() =>
+      expect(harness.includedAccessValues).toStrictEqual([false]),
+    );
+    await vi.waitFor(() => expect(startCalls).toStrictEqual(['holder']));
+
+    const stale = harness.controller.runCopilotFallbackWithRouting(
+      {
+        stream: 'stream-stale',
+        requestId: 'retry-stale',
+        exhaustionReason: 'copilot-subscription',
+      },
+      async () => {
+        startCalls.push('stale');
+        return true;
+      },
+    );
+
+    // The stale request is queued behind the holder; dismissing it before the
+    // queue admits it must make the in-queue recheck fail and prevent any
+    // routing write or launch from the stale request.
+    stalePending = false;
+    firstStart.resolve(true);
+
+    await expect(holder).resolves.toBe(true);
+    await expect(stale).resolves.toBe(false);
+    expect(startCalls).toStrictEqual(['holder']);
+    expect(harness.includedAccessValues).toStrictEqual([false]);
+    expect(harness.invalidations).toBe(1);
   });
 });

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -36,7 +36,6 @@ interface HarnessOptions {
   prompt?(keys: Map<ApiProvider, string | undefined>): void;
   glmCodingPlan?: boolean;
   kimiCode?: boolean;
-  kimiCodeActiveForModel?: (modelId: string) => boolean;
   retryAvailable?: boolean;
   retryPending?: boolean;
   triggerRetry?: ProgressApiKeyRetryControllerDeps['triggerRetry'];
@@ -64,8 +63,6 @@ function createHarness(options: HarnessOptions = {}): {
   const chatGptSubscriptionValues: boolean[] = [];
   const glmCodingPlanValues: boolean[] = [];
   const kimiCodeValues: boolean[] = [];
-  const kimiCodeActiveForModel =
-    options.kimiCodeActiveForModel ?? (() => false);
   let preferChatGptSubscription = true;
   let glmCodingPlan = options.glmCodingPlan ?? true;
   let kimiCode = options.kimiCode ?? true;
@@ -117,7 +114,6 @@ function createHarness(options: HarnessOptions = {}): {
             kimiCode = enabled;
             kimiCodeValues.push(enabled);
           },
-          isActiveForModel: async (modelId) => kimiCodeActiveForModel(modelId),
         },
       ],
       invalidateModelOptionsCache: () => {
@@ -646,7 +642,6 @@ describe('ProgressApiKeyRetryController', () => {
         keys.set('kimiCode', 'new-kimi');
       },
       kimiCode: true,
-      kimiCodeActiveForModel: () => true,
     });
 
     const result = await harness.controller.useOwnApiKey({
@@ -674,14 +669,13 @@ describe('ProgressApiKeyRetryController', () => {
     expect(harness.retries).toStrictEqual(['stream-kimi-credit']);
   });
 
-  it('disables the Kimi Code preference when a dual-backend Kimi model credit-retries from the coding route', async () => {
+  it('disables the Kimi Code preference for a dual-backend Kimi credit retry even when live routing would say not coding', async () => {
     const harness = createHarness({
       keys: { moonshot: 'old-moonshot', kimiCode: 'old-kimi' },
       prompt: (keys) => {
         keys.set('moonshot', 'new-moonshot');
       },
       kimiCode: true,
-      kimiCodeActiveForModel: (modelId) => modelId === 'kimi3',
     });
 
     const result = await harness.controller.useOwnApiKey({
@@ -701,7 +695,11 @@ describe('ProgressApiKeyRetryController', () => {
     });
     // The forwarded SDK provider is `moonshot`, so that is the credential the
     // panel asks to replace; the routing step then turns off "Prefer Kimi
-    // Code" so the rebuilt handler actually uses the new Moonshot key.
+    // Code" so the rebuilt handler actually uses the new Moonshot key. The
+    // controller does not consult the live route resolver here: the failed
+    // handler was dispatched under `ModelHandlerKimi`, and the rebuild pins
+    // that key, so a later OpenRouter preference change must not keep the
+    // exhausted coding route selected.
     expect(harness.prompts).toStrictEqual(['moonshot']);
     expect(harness.keys.get('moonshot')).toBe('new-moonshot');
     expect(harness.keys.get('kimiCode')).toBe('old-kimi');


### PR DESCRIPTION
Closes #10586
Closes #10587

## Summary

- **#10586**: `RetryState` captures `kimiCodeRoutedOnFailure` from the failed handler's effective config when the retry panel is requested — a dual-backend Kimi handler dispatched onto the coding endpoint carries the pinned Kimi Code `baseUrl`, so this identifies the actual failed route without consulting the live OpenRouter preference. The flag travels through `HostRetryRequest` → `RetryPermission` → the `USE_OWN_API_KEY` payload. `applyOwnApiKeyRouting` then disables the Kimi Code preference only for an `upstream-credit` retry where that flag is true and the model is dual-backend, so unrelated `kimi3` failures through OpenRouter, Moonshot, or relay leave the preference untouched. Exclusive coding-only models stay on the `kimiCode` credential path.
- **#10587**: `runCopilotFallbackWithRouting` now receives the full retry identity and rechecks `isRetryPending` inside its serialized routing-queue callback before calling `applyOwnApiKeyRouting`, mirroring `useOwnApiKey`. The existing `finally` rollback remains for the dismiss-landed-during-`start` case.

## Verification

- `pnpm vitest run --config vitest.config.mjs --hookTimeout 60000 src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts src/test-kernel/agent/runtime/RetryState.vitest.ts src/test-kernel/model/KimiCodeModels.vitest.ts src/test-kernel/model/KimiSubscriptionRouting.vitest.ts src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts src/test-kernel/progressView/RetryRequestPanel.vitest.ts` — 7 files, 195 tests passed.
- `pnpm run typecheck:workspace` — passed.
- `pnpm run typecheck:test-kernel` — passed.
- `pnpm run typecheck:cli` — passed.
- `pnpm run lint` — passed.
- `pnpm exec prettier --check <changed files>` — passed.
- `corepack pnpm install --frozen-lockfile --prefer-offline` — passed.
- `pnpm run check:browser-safe-utils` — passed.
- `pnpm run check:dead-code-ratchet` — passed (15 baselined, no new findings).
- `pnpm run check:guidance-refs` — passed.
