### PR TITLE
refactor: remove dead editedFiles schema and localize file-edit snapshot

### DIFF
--- a/src/agent/core/state/AgentWorkspaceState.ts
+++ b/src/agent/core/state/AgentWorkspaceState.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import type { ServerToolContentBlock } from '@agent/types/ServerTools';
 import {
   FileLocationSchema,
-  FlattenedEditRecordSchema,
+  LineCountSchema,
   PlanSchema,
   planSummaryLine,
   TodoItemSchema,
@@ -38,10 +38,17 @@ const ResponseAssemblyStateSchema = z.object({
 
 type ResponseAssemblyState = z.output<typeof ResponseAssemblyStateSchema>;
 
+/** File-local snapshot schema for flattened file-edit records. */
+const FileEditSnapshotSchema = z.object({
+  path: z.string(),
+  added: LineCountSchema.prefault(0),
+  removed: LineCountSchema.prefault(0),
+});
+
 /** Internal schema for file interaction state snapshot. */
 const FileInteractionStateSnapshotSchema = z.object({
   readFiles: z.array(z.string()).prefault([]),
-  edits: z.array(FlattenedEditRecordSchema).prefault([]),
+  edits: z.array(FileEditSnapshotSchema).prefault([]),
   toolCallCount: z.int().nonnegative().prefault(0),
 });
 

--- a/src/agent/core/tools/toolAttachmentExtraction.ts
+++ b/src/agent/core/tools/toolAttachmentExtraction.ts
@@ -14,7 +14,6 @@ const ERROR_PAYLOAD_STRIPPED_KEYS = new Set([
   'lineChanges',
   'edits',
   'files',
-  'editedFiles',
 ]);
 
 /**

--- a/src/shared/schemas/toolResult.ts
+++ b/src/shared/schemas/toolResult.ts
@@ -1,6 +1,6 @@
 import { z, type ZodIssue } from 'zod';
 
-import { LineChangesSchema, LineCountSchema } from './lineChanges';
+import { LineChangesSchema } from './lineChanges';
 
 /**
  * Base schema for file references (metadata only, no binary data).
@@ -38,26 +38,6 @@ const EditRecordSchema = z.object({
   startLine: z.int().positive().optional(),
 });
 export type EditRecord = z.infer<typeof EditRecordSchema>;
-
-const EditedFileRecordSchema = z.object({
-  path: z.string(),
-  ok: z.boolean(),
-  source: z.string(),
-  sourceDisplay: z.string(),
-});
-
-/**
- * Schema for flattened edit records used in state snapshots.
- * Unlike EditRecordSchema (which nests lineChanges), this schema flattens
- * added/removed directly on the object for simpler serialization.
- *
- * Used by: FileInteractionStateSnapshotSchema in AgentWorkspaceState.ts
- */
-export const FlattenedEditRecordSchema = z.object({
-  path: z.string(),
-  added: LineCountSchema.prefault(0),
-  removed: LineCountSchema.prefault(0),
-});
 
 // ============================================================================
 // Diagnostics Types (not Zod - these are complex unions with external types)
@@ -180,8 +160,6 @@ const ExecutedToolResultSchema = z.object({
   edits: z.array(EditRecordSchema).optional(),
   /** File attachments (may contain binary data) */
   files: z.array(ToolFileAttachmentSchema).optional(),
-  /** Files edited during tool execution (for logging/tracking) */
-  editedFiles: z.array(EditedFileRecordSchema).optional(),
   ...ToolResultSharedFields,
 });
 
@@ -195,7 +173,6 @@ const ErrorToolResultSchema = z.object({
   lineChanges: z.undefined().optional(),
   edits: z.undefined().optional(),
   files: z.undefined().optional(),
-  editedFiles: z.undefined().optional(),
   ...ToolResultSharedFields,
 });
 

--- a/src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts
+++ b/src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 // Local imports
 import {
   AgentWorkspaceState,
+  FileInteractionState,
   type AgentWorkspaceSnapshot,
 } from '@agent/core/state/AgentWorkspaceState';
 import type { TodoItem } from '@shared/schemas';
@@ -114,5 +115,49 @@ describe('agent workspace work-plan state', () => {
       AgentWorkspaceState.fromCanonicalSnapshot(canonicalSnapshot);
     expect(rehydrated.workPlan.todos).toEqual([todo]);
     expect(rehydrated.workPlan.plan).toEqual(objectivePlan);
+  });
+});
+
+describe('agent workspace file-interaction state', () => {
+  it('round-trips edit paths and line counts through the workspace snapshot', () => {
+    const state = AgentWorkspaceState.create();
+    state.interactions.recordEdits([
+      { path: 'paper.tex', lineChanges: { added: 3, removed: 1 } },
+      { path: 'notes.md', lineChanges: { added: 2, removed: 5 } },
+    ]);
+
+    const snapshot = state.toSnapshot();
+    expect(snapshot.interactions.edits).toEqual([
+      { path: 'paper.tex', added: 3, removed: 1 },
+      { path: 'notes.md', added: 2, removed: 5 },
+    ]);
+
+    const rehydrated = AgentWorkspaceState.fromCanonicalSnapshot(snapshot);
+    expect(rehydrated.interactions.editedFilePaths).toEqual([
+      'paper.tex',
+      'notes.md',
+    ]);
+
+    const merged = rehydrated.interactions.recordEdits([
+      { path: 'paper.tex', lineChanges: { added: 1, removed: 0 } },
+    ]);
+    expect(merged.lineChanges).toEqual({ added: 1, removed: 0 });
+    expect(rehydrated.interactions.toSnapshot().edits).toEqual([
+      { path: 'paper.tex', added: 4, removed: 1 },
+      { path: 'notes.md', added: 2, removed: 5 },
+    ]);
+  });
+
+  it('prefaults missing added/removed on persisted file-edit snapshots', () => {
+    const state = FileInteractionState.fromSnapshot({
+      edits: [{ path: 'legacy.md' }],
+    });
+
+    expect(state.editedFilePaths).toEqual(['legacy.md']);
+    expect(state.toSnapshot()).toEqual({
+      readFiles: [],
+      edits: [{ path: 'legacy.md', added: 0, removed: 0 }],
+      toolCallCount: 0,
+    });
   });
 });

--- a/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
@@ -264,4 +264,41 @@ describe('extractToolAttachments', () => {
     );
     expect(Object.hasOwn(sanitizedResult, 'summary')).toBe(false);
   });
+
+  it('drops editedFiles from executed payloads', () => {
+    const { sanitizedResult } = extractToolAttachments({
+      status: 'executed',
+      output: 'done',
+      editedFiles: [
+        {
+          path: 'paper.tex',
+          ok: true,
+          source: 'tool',
+          sourceDisplay: 'Tool use',
+        },
+      ],
+    } as never);
+
+    expect(sanitizedResult.status).toBe('executed');
+    expect(sanitizedResult.output).toBe('done');
+    expect(Object.hasOwn(sanitizedResult, 'editedFiles')).toBe(false);
+  });
+
+  it('drops editedFiles from error payloads', () => {
+    const { sanitizedResult } = extractToolAttachments({
+      status: 'error',
+      error: 'The operation failed.',
+      editedFiles: [
+        {
+          path: 'paper.tex',
+          ok: false,
+          source: 'tool',
+          sourceDisplay: 'Tool use',
+        },
+      ],
+    } as never);
+
+    expect(sanitizedResult.status).toBe('error');
+    expect(Object.hasOwn(sanitizedResult, 'editedFiles')).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #10580

## Summary

Follow-up from #10570 / #10578 for the file-edit shape audit. The audit found that the issue’s four purported duplicates serve different lifecycle contracts; this resolves #10580 by removing the two accidental/dead shared representations rather than forcing incompatible wire and runtime shapes together: it removes the dead `EditedFileRecordSchema` and the `editedFiles` fields from the tool-result schemas, drops the now-unused `editedFiles` key from error-payload sanitization, and moves the single-consumer flattened snapshot schema out of `@shared/schemas/toolResult` into `AgentWorkspaceState` as a file-local `FileEditSnapshotSchema`.

Deliberately unchanged: `ToolUseDispatchNode`'s internal `ToolExecutionResult.editedFiles` log/tracking shape stays, and the historical `edits[].lineChanges` wire/render shape is preserved. No nested edit records are flattened and no persisted/log wire formats change.

## Issue acceptance gates

For #10580, the audited resolution:
- `EditedFileRecordSchema` removed; `editedFiles` removed from `ExecutedToolResultSchema` and `ErrorToolResultSchema`.
- `editedFiles` removed from `ERROR_PAYLOAD_STRIPPED_KEYS`.
- `FlattenedEditRecordSchema` removed from `@shared/schemas/toolResult` and replaced in `AgentWorkspaceState` by the file-local `FileEditSnapshotSchema`, composed from the existing `LineCountSchema`.
- Snapshot round-trip coverage pins `path`/`added`/`removed` (including `prefault(0)` hydration), and attachment-extraction tests confirm `editedFiles` is stripped from executed and error payloads.

## Single source of truth

`AgentWorkspaceState.ts` now owns the flattened file-edit snapshot shape via `FileEditSnapshotSchema`; `toolResult.ts` owns only the model-facing `EditRecord`/`lineChanges` shape. `ToolUseDispatchNode.ts` remains the sole owner of its internal log/tracking `editedFiles` record.

## Duplication and abstraction budget

Removed the exported flattened-edit schema from shared tool-result schemas (one dead schema and one single-consumer schema relocated). No new abstraction; the local schema is one `z.object` used by exactly one consumer.

## Net elements (R6)

Diffstat: 5 files changed, 92 insertions(+), 27 deletions(-), net +65 lines: production code −17 lines and tests +82 lines.

Exported symbols (`^[+-]export` over the diff): removed `FlattenedEditRecordSchema`; no exports added. `FileEditSnapshotSchema` is file-local; `EditedFileRecordSchema` is deleted.

New classes/interfaces/enums: none.

## Consumer counts (R8)

`FlattenedEditRecordSchema`: 1 consumer (`AgentWorkspaceState.ts`), moved into the file that consumes it. `EditedFileRecordSchema`: 0 consumers (only the removed `editedFiles` fields). `editedFiles` on `ToolResult`: 0 production consumers after this diff (`ToolUseDispatchNode`'s internal field is separately typed). Grepped repo-wide.

## Host impact

Extension: none.

Desktop: none.

CLI: none.

## Scheduled refactoring

None for #10580. The audit established that internal `ToolExecutionResult.editedFiles`, runtime `Map<string, LineChanges>`, workspace snapshot records, and historical `edits[].lineChanges` are intentionally distinct lifecycle/wire contracts; coercing them into one schema would change behavior. The accidental shared-schema duplication is removed here.

## Validation

- `npx vitest run src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts src/test-kernel/tools/AgentWorkspaceOptions.vitest.ts src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts src/test-kernel/tools/FileEditFlow.vitest.ts src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts` — 6 files / 87 tests passed.
- `npm run typecheck` — clean (workspace, test-kernel, agent, cli, trace-viewer, desktop).
- `npm run lint` — clean.
- `npm run format:check` — clean.
- `npm run check:dead-code-ratchet` — 15 current vs 15 baselined, OK.
- `npm run check:guidance-refs` — OK.
- `npm run check:browser-safe-utils` — OK.
- `npx vitest run src/test-kernel/architecture` — 17 files / 98 tests passed.
- `git diff --check` — clean.

