### PR TITLE
fix(hooks): resolve Node package-main file/directory targets in format-staged

### DIFF
--- a/scripts/format-staged.mjs
+++ b/scripts/format-staged.mjs
@@ -279,7 +279,22 @@ function resolveConfigDepPath(configDir, spec, kind) {
 
   if (lstatSync(base, { throwIfNoEntry: false })?.isDirectory()) {
     const main = readPackageMain(base);
-    if (main) push(resolve(base, normalizeSpecifier(main)));
+    if (main) {
+      const mainTarget = resolve(base, normalizeSpecifier(main));
+      // Node applies LOAD_AS_FILE / LOAD_INDEX to the package main target
+      // too, so an extensionless main (`"main": "main"` -> main.js) or a
+      // directory main (`"main": "dist"` -> dist/index.js) resolves to the
+      // real file. Verify that target before the package-level index.*
+      // fallback below; otherwise the hook would check the wrong file and let
+      // an unstaged edit to the real main drive Prettier.
+      push(mainTarget);
+      for (const ext of CJS_FILE_EXTENSIONS) push(`${mainTarget}${ext}`);
+      if (lstatSync(mainTarget, { throwIfNoEntry: false })?.isDirectory()) {
+        for (const indexName of CJS_INDEX_EXTENSIONS) {
+          push(join(mainTarget, indexName));
+        }
+      }
+    }
     for (const indexName of CJS_INDEX_EXTENSIONS) {
       push(join(base, indexName));
     }

--- a/src/test-kernel/scripts/FormatStaged.vitest.ts
+++ b/src/test-kernel/scripts/FormatStaged.vitest.ts
@@ -1260,6 +1260,99 @@ describe('format-staged', () => {
     expect(stagedBlob('a.ts')).toBe('export const x = 1\n');
   });
 
+  it('skips when an extensionless package main target has unstaged edits (#10591)', () => {
+    mkdirSync(join(dir, 'config/opts'), { recursive: true });
+    writeFileSync(join(dir, 'config/opts/package.json'), '{"main":"main"}\n');
+    writeFileSync(
+      join(dir, 'config/opts/main.js'),
+      'module.exports = { semi: true };\n',
+    );
+    writeFileSync(
+      join(dir, 'config/opts/index.js'),
+      'module.exports = { semi: true };\n',
+    );
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'const opts = require("./opts");\nmodule.exports = opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"./config/prettier.cjs"}\n',
+    );
+    git([
+      'add',
+      'config/prettier.cjs',
+      'config/opts/package.json',
+      'config/opts/main.js',
+      'config/opts/index.js',
+      'package.json',
+    ]);
+    git(['commit', '-qm', 'config base']);
+    // The real main target (`main.js`, via Node's LOAD_AS_FILE on the
+    // extensionless main) is edited in the working tree; the package-level
+    // index.js fallback stays clean. The hook must resolve the main target
+    // and skip rather than format with the uncommitted semi:false rules.
+    writeFileSync(
+      join(dir, 'config/opts/main.js'),
+      'module.exports = { semi: false };\n',
+    );
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('config/opts/main.js has unstaged edits');
+    expect(result.stdout).not.toContain('config/opts/index.js has unstaged');
+    expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+  });
+
+  it('skips when a directory package main target has unstaged edits (#10591)', () => {
+    mkdirSync(join(dir, 'config/opts/dist'), { recursive: true });
+    writeFileSync(join(dir, 'config/opts/package.json'), '{"main":"dist"}\n');
+    writeFileSync(
+      join(dir, 'config/opts/dist/index.js'),
+      'module.exports = { semi: true };\n',
+    );
+    writeFileSync(
+      join(dir, 'config/opts/index.js'),
+      'module.exports = { semi: true };\n',
+    );
+    writeFileSync(
+      join(dir, 'config/prettier.cjs'),
+      'const opts = require("./opts");\nmodule.exports = opts;\n',
+    );
+    writeFileSync(
+      join(dir, 'package.json'),
+      '{"prettier":"./config/prettier.cjs"}\n',
+    );
+    git([
+      'add',
+      'config/prettier.cjs',
+      'config/opts/package.json',
+      'config/opts/dist/index.js',
+      'config/opts/index.js',
+      'package.json',
+    ]);
+    git(['commit', '-qm', 'config base']);
+    // The real main target (`dist/index.js`, via Node's LOAD_INDEX on the
+    // directory main) is edited; the package-level index.js stays clean.
+    writeFileSync(
+      join(dir, 'config/opts/dist/index.js'),
+      'module.exports = { semi: false };\n',
+    );
+    writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+    git(['add', 'a.ts']);
+
+    const result = runFormat();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(
+      'config/opts/dist/index.js has unstaged edits',
+    );
+    expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+  });
+
   it('does not append extensions for an extensionless ESM import (#10502)', () => {
     mkdirSync(join(dir, 'config'));
     writeFileSync(


### PR DESCRIPTION
Closes #10591

## Summary

Follow-up to #10577. `resolveConfigDepPath` in `scripts/format-staged.mjs` pushed a CommonJS dependency directory's package `main` as a literal path only, so Node's own resolution of that target was never applied: an extensionless main (`"main": "main"` -> `main.js`) or a directory main (`"main": "dist"` -> `dist/index.js`) never matched the candidate, and the hook fell through to the package-level `index.*` fallback. When that fallback existed and was clean, the hook verified the wrong file and an unstaged edit to the real main target drove Prettier, becoming staged formatting from uncommitted rules — the exact provenance leak the hook exists to prevent.

This change resolves the package `main` target with the same CommonJS `LOAD_AS_FILE` / `LOAD_INDEX` rules Node applies before considering the package-level `index.*` fallback: exact path, then `.js`/`.json`/`.node`, then the target's own `index.*` when it is a directory. `readPackageMain`'s index-only provenance (manifest must be tracked and index-equal before its `main` is trusted) and the `kind === 'cjs'` loader-kind gate are unchanged; ESM imports and plugin paths stay exact.

## Issue acceptance gates

- An extensionless `"main": "main"` directory dependency resolves to `main.js` and skips loudly when that file has unstaged edits (regression test added).
- A directory `"main": "dist"` dependency resolves to `dist/index.js` and skips loudly when that file has unstaged edits (regression test added).
- Package `main` still takes precedence over the package-level `index.*` fallback; the fallback is only consulted when the main target does not resolve.

## Single source of truth

`resolveConfigDepPath` in `scripts/format-staged.mjs` remains the single resolver for relative config dependencies; the new target-resolution logic is inlined there so the main-target rules live beside the specifier rules they mirror.

## Duplication and abstraction budget

No new helper was extracted (single-caller extraction would violate the abstraction guardrails); the target resolution is a short inline block mirroring the existing specifier-resolution loop. No duplication was added.

## Net elements (R6)

n/a — this is a `fix:` change, not a refactor/simplify/consolidate/dedupe/extract PR.

## Consumer counts (R8)

n/a — no export, emit path, or subscriber is deleted or re-routed.

## Host impact

Extension: n/a
Desktop: n/a
CLI: n/a
(Change is confined to the `scripts/format-staged.mjs` git hook and its test-kernel suite.)

## Scheduled refactoring

None.

## Validation

- `npx vitest run --config vitest.config.mjs src/test-kernel/scripts/FormatStaged.vitest.ts --testTimeout=60000 --hookTimeout=60000` → 62/62 passed (60 existing + 2 new #10591 regressions)
- `npm run typecheck` → passed (workspace, test-kernel, agent, cli, trace-viewer, desktop)
- `node --max-old-space-size=6144 ./node_modules/eslint/bin/eslint.js src/test-kernel/scripts/FormatStaged.vitest.ts` → passed
- `npx prettier --check scripts/format-staged.mjs src/test-kernel/scripts/FormatStaged.vitest.ts` → passed
- `node scripts/check-dead-code-ratchet.mjs` → passed (15 current = 15 baselined)
- `git diff --check` → clean

Reproduced before the fix: both new tests failed with `staged Prettier output for a.ts` (the hook formatted instead of skipping); after the fix both pass and the hook reports the real main target's unstaged edits.
