### PR TITLE
refactor(ratchets): set-based host-agent deep-import gate; purge stale rows (B3)

### DIFF
--- a/config/ratchets/host-agent-import-baseline.json
+++ b/config/ratchets/host-agent-import-baseline.json
@@ -1,9 +1,8 @@
 {
-  "semantics": "Distinct '@agent/*' deep-import specifiers (past the @agent barrel) reachable from each package (packages/cli/src, packages/desktop/src, packages/extension/src, and the @texra-ai/agent SDK package packages/agent/src), per issue #7684 R-b. Each deep import pins @agent's current internal module layout and freezes the surface a future SDK barrel would be seeded from; 'agent' is the SDK package itself, so its own list is exactly the internal-coupling width a Tier-1 barrel must re-export or seal. The ratchet fails only when a package's distinct-specifier count exceeds this baseline; a decrease (or an @agent restructor that removes the need for a deep import) is welcome and should shrink this file.",
+  "semantics": "Distinct '@agent/*' deep-import specifiers (past the @agent barrel) reachable from each package (packages/cli/src, packages/desktop/src, packages/extension/src, and the @texra-ai/agent SDK package packages/agent/src), per issue #7684 R-b. Each deep import pins @agent's current internal module layout and freezes the surface a future SDK barrel would be seeded from; 'agent' is the SDK package itself, so its own list is exactly the internal-coupling width a Tier-1 barrel must re-export or seal. The ratchet is set-based: a live specifier absent from a package's list is a new edge and fails; a listed specifier with no live import is stale headroom and also fails (remove it here). Removing a deep import (or an @agent restructor that removes the need for one) is welcome and should shrink this file.",
   "hosts": {
     "cli": [
       "@agent/core/definition/AgentConfig",
-      "@agent/core/definition/AgentDataclass",
       "@agent/core/state/executionRequests",
       "@agent/core/state/TaskState",
       "@agent/export/chatExportFormatter",
@@ -33,7 +32,6 @@
     ],
     "extension": [
       "@agent/core/definition/AgentConfig",
-      "@agent/core/definition/AgentDataclass",
       "@agent/core/state/executionRequests",
       "@agent/features",
       "@agent/followUp/ToolUseFollowUp",

--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -32,41 +32,6 @@
       "name": "DESKTOP_COMMAND_IDS"
     },
     {
-      "file": "packages/extension/src/frontend/lean/VscodeIntegration.ts",
-      "category": "exports",
-      "name": "executeFileCommand"
-    },
-    {
-      "file": "packages/extension/src/frontend/lean/VscodeIntegration.ts",
-      "category": "exports",
-      "name": "executeProjectCommand"
-    },
-    {
-      "file": "packages/extension/src/frontend/lean/VscodeIntegration.ts",
-      "category": "exports",
-      "name": "fetchDiagnosticsForFile"
-    },
-    {
-      "file": "packages/extension/src/frontend/lean/VscodeIntegration.ts",
-      "category": "exports",
-      "name": "getGoalState"
-    },
-    {
-      "file": "packages/extension/src/frontend/lean/VscodeIntegration.ts",
-      "category": "exports",
-      "name": "getHoverInfo"
-    },
-    {
-      "file": "packages/extension/src/frontend/lean/VscodeIntegration.ts",
-      "category": "exports",
-      "name": "getTermGoal"
-    },
-    {
-      "file": "packages/extension/src/frontend/lean/VscodeIntegration.ts",
-      "category": "exports",
-      "name": "navigateToFirstError"
-    },
-    {
       "file": "packages/trace-viewer/vite.standalone.config.ts",
       "category": "files",
       "name": "packages/trace-viewer/vite.standalone.config.ts"

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -54,7 +54,10 @@ import { SupabaseUriHandler } from '@frontend/auth/UriHandler';
 import { createLanguageModelPort } from '@frontend/lm/createLanguageModelPort';
 import { registerLanguageModelTools } from '@frontend/lm/registerLanguageModelTools';
 import { onTexraAuthSessionsChanged } from '@frontend/events/onTexraAuthSessionsChanged';
-import * as leanVscodeIntegration from '@frontend/lean/VscodeIntegration';
+import {
+  clearVscodeLeanServerEntries,
+  vscodeLeanLanguageServices,
+} from '@frontend/lean/VscodeIntegration';
 import { applyGitAuthorConfig } from '@frontend/git/gitAuthorSetup';
 import { resolveGitCommonRoot } from '@frontend/git/resolveGitRoot';
 import { registerInlineCriticism } from '@frontend/latex/inlineCriticism';
@@ -546,7 +549,7 @@ export async function activate(context: vscode.ExtensionContext) {
   mainViewProvider.setProgressViewProvider(progressViewProvider);
   registerFileDecorations(context);
 
-  setLeanLanguageServices(leanVscodeIntegration);
+  setLeanLanguageServices(vscodeLeanLanguageServices);
   setSetupPlatform({
     host: 'extension',
     signIn: async () =>
@@ -795,7 +798,7 @@ export async function deactivate() {
   const host = lifecycleHost;
   lifecycleHost = undefined;
   try {
-    leanVscodeIntegration.clearVscodeLeanServerEntries();
+    clearVscodeLeanServerEntries();
     await host?.runShutdown();
   } finally {
     teardownDefaultSession();

--- a/packages/extension/src/frontend/lean/VscodeIntegration.ts
+++ b/packages/extension/src/frontend/lean/VscodeIntegration.ts
@@ -30,6 +30,7 @@ import {
   unregisterLeanServer,
   updateLeanServer,
 } from '@tools/lean/leanServerRegistry';
+import type { LeanLanguageServices } from '@tools/lean/leanLanguageServices';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { isStrictlyWithin } from '@utils/core/pathCore';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -191,7 +192,7 @@ function getDiagnostics(filePath: string): LeanDiagnostic[] {
   return [];
 }
 
-export async function executeFileCommand(
+async function executeFileCommand(
   command: LeanFileCommand,
   filePath: string,
 ): Promise<boolean> {
@@ -303,7 +304,7 @@ async function sendPositionRequest<T>(
  * @param line - 0-indexed line number
  * @param column - 0-indexed column number
  */
-export async function getGoalState(
+async function getGoalState(
   filePath: string,
   line: number,
   column: number,
@@ -321,7 +322,7 @@ export async function getGoalState(
  * @param line - 0-indexed line number
  * @param column - 0-indexed column number
  */
-export async function getTermGoal(
+async function getTermGoal(
   filePath: string,
   line: number,
   column: number,
@@ -339,7 +340,7 @@ export async function getTermGoal(
  * @param line - 0-indexed line number
  * @param column - 0-indexed column number
  */
-export async function getHoverInfo(
+async function getHoverInfo(
   filePath: string,
   line: number,
   column: number,
@@ -356,7 +357,7 @@ export async function getHoverInfo(
  * Open a Lean file, wait for diagnostics, and return them.
  * Returns null if the file could not be opened.
  */
-export async function fetchDiagnosticsForFile(
+async function fetchDiagnosticsForFile(
   file: string,
 ): Promise<FetchDiagnosticsResult> {
   const absolutePath = WorkspaceFS.toAbsolute(file);
@@ -382,7 +383,7 @@ export async function fetchDiagnosticsForFile(
 }
 
 /** Navigate editor to first error location if present. */
-export async function navigateToFirstError(
+async function navigateToFirstError(
   filePath: string,
   diagnostics: LeanDiagnostic[],
 ): Promise<void> {
@@ -394,7 +395,7 @@ export async function navigateToFirstError(
   }
 }
 
-export async function executeProjectCommand(
+async function executeProjectCommand(
   command: LeanProjectCommand,
 ): Promise<void> {
   if (LEAN_FEATURE_PROJECT_COMMANDS.has(command)) {
@@ -410,3 +411,19 @@ export async function executeProjectCommand(
   }
   await vscode.commands.executeCommand(PROJECT_COMMAND_VSCODE_IDS[command]);
 }
+
+/**
+ * The VS Code-mediated `LeanLanguageServices` adapter, installed by
+ * `extension.ts` via `setLeanLanguageServices`. The single exported surface
+ * of this module's language operations: the implementing functions above are
+ * module-private so the export list states exactly what the host consumes.
+ */
+export const vscodeLeanLanguageServices: LeanLanguageServices = {
+  executeFileCommand,
+  getGoalState,
+  getTermGoal,
+  getHoverInfo,
+  fetchDiagnosticsForFile,
+  navigateToFirstError,
+  executeProjectCommand,
+};

--- a/src/test-kernel/architecture/hostAgentDeepImportRatchet.vitest.ts
+++ b/src/test-kernel/architecture/hostAgentDeepImportRatchet.vitest.ts
@@ -149,7 +149,7 @@ describe('R-b host deep-import ratchet', () => {
         added,
         `New ${host} @agent/* deep-import specifier(s) not in ${BASELINE_FILE}:\n` +
           added.map((specifier) => `  + ${specifier}`).join('\n') +
-          `\n\nIf this growth is intentional, update ${BASELINE_FILE} in this PR.`,
+          `\n\nRemove the import or route it through an approved public surface; do not widen ${BASELINE_FILE}.`,
       ).toEqual([]);
     },
   );

--- a/src/test-kernel/architecture/hostAgentDeepImportRatchet.vitest.ts
+++ b/src/test-kernel/architecture/hostAgentDeepImportRatchet.vitest.ts
@@ -1,19 +1,20 @@
-// R-b host deep-import WIDTH ratchet (issue #7684). Each host package (CLI,
+// R-b host deep-import ratchet (issue #7684). Each host package (CLI,
 // desktop, extension) reaches past the `@agent` barrel into `@agent/*`
 // internals, pinning agent's current internal module layout from outside
 // src/agent. `agent` here is the `@texra-ai/agent` SDK package itself
 // (packages/agent/src): it assembles the public run surface from `@agent/*`
-// internals, so its own distinct-specifier width is exactly the surface a
-// Tier-1 barrel would have to re-export or seal, and freezing it here keeps
-// that count from silently widening. Clones the checked-in-baseline +
-// AST-scanning vitest pattern from LAY-1 (subsystemEdgeRatchet.vitest.ts, PR
-// #7774) and QA-2 (hostAgentMockRatchet.vitest.ts, PR #7817): baseline the
-// current set of DISTINCT `@agent/*` deep-import specifiers per package and
-// fail only when a package's specifier count increases; a decrease (or an
-// @agent restructor that removes the need for a deep import) is always welcome
-// and should shrink config/ratchets/host-agent-import-baseline.json. Armed per
-// the issue text pending Stage-5 exit (#6968, closed); this is the deferred
-// execution.
+// internals, so its own distinct-specifier set is exactly the surface a
+// Tier-1 barrel would have to re-export or seal. Clones the
+// checked-in-baseline + AST-scanning vitest pattern from LAY-1
+// (subsystemEdgeRatchet.vitest.ts, PR #7774) and the set-based two-check
+// form from QA-2 (hostAgentMockRatchet.vitest.ts, PR #7817): the baseline
+// is the exact set of DISTINCT `@agent/*` deep-import specifiers per
+// package. A live specifier absent from the baseline is a new edge; a
+// baseline specifier with no live import is stale headroom that could
+// silently absorb a future new edge (under the old count-only form, any
+// specifier could swap for any other). Removing a deep import (or an
+// @agent restructor that removes the need for one) is always welcome and
+// should shrink config/ratchets/host-agent-import-baseline.json.
 
 // Node imports
 import { readFileSync } from 'node:fs';
@@ -130,21 +131,7 @@ function readBaseline(): HostBaseline {
   return JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as HostBaseline;
 }
 
-function reportGrowth(
-  host: Host,
-  baseline: string[],
-  current: string[],
-): string {
-  const baselineSet = new Set(baseline);
-  const added = current.filter((specifier) => !baselineSet.has(specifier));
-  return (
-    `${host} @agent/* deep-import specifiers grew from ${baseline.length} to ${current.length}:\n` +
-    added.map((specifier) => `  + ${specifier}`).join('\n') +
-    `\n\nIf this growth is intentional, update ${BASELINE_FILE} in this PR.`
-  );
-}
-
-describe('R-b host deep-import width ratchet', () => {
+describe('R-b host deep-import ratchet', () => {
   // Scanned once for the whole suite — the per-host cases and the baseline
   // invariants read the same snapshot instead of rescanning three trees per
   // it.each case.
@@ -152,12 +139,34 @@ describe('R-b host deep-import width ratchet', () => {
   const current = collectCurrentHosts();
 
   it.each(HOSTS)(
-    'does not increase the count of distinct @agent/* deep-import specifiers in %s',
+    'rejects any @agent/* deep-import specifier in %s that is not in the baseline',
     (host) => {
+      const baselineSet = new Set(baseline.hosts[host]);
+      const added = current[host].filter(
+        (specifier) => !baselineSet.has(specifier),
+      );
       expect(
-        current[host].length,
-        reportGrowth(host, baseline.hosts[host], current[host]),
-      ).toBeLessThanOrEqual(baseline.hosts[host].length);
+        added,
+        `New ${host} @agent/* deep-import specifier(s) not in ${BASELINE_FILE}:\n` +
+          added.map((specifier) => `  + ${specifier}`).join('\n') +
+          `\n\nIf this growth is intentional, update ${BASELINE_FILE} in this PR.`,
+      ).toEqual([]);
+    },
+  );
+
+  it.each(HOSTS)(
+    'rejects baseline specifiers with no live %s import (stale headroom)',
+    (host) => {
+      const currentSet = new Set(current[host]);
+      const stale = baseline.hosts[host].filter(
+        (specifier) => !currentSet.has(specifier),
+      );
+      expect(
+        stale,
+        `Stale ${host} specifier(s) in ${BASELINE_FILE}:\n` +
+          stale.map((specifier) => `  - ${specifier}`).join('\n') +
+          `\n\nRemove them from ${BASELINE_FILE} so they cannot absorb a future new edge.`,
+      ).toEqual([]);
     },
   );
 


### PR DESCRIPTION
## Summary

Item B3 of `docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md` ("Make the host-agent baseline tell the truth"). Three parts:

1. **Set-based gate.** `hostAgentDeepImportRatchet.vitest.ts` converts from count-only to the set-based two-check form its sibling `hostAgentMockRatchet.vitest.ts` already runs green in the same directory: a live `@agent/*` deep-import specifier absent from the baseline fails as growth, and a baseline specifier with no live import fails as stale headroom. Under the old count-only form any specifier could silently swap for any other — exactly the drift class this PR closes.
2. **Stale-row purge.** `config/ratchets/host-agent-import-baseline.json` drops the two rows with zero live hits (counts below); the semantics string now describes the set-based contract.
3. **Lean export reshape.** `VscodeIntegration.ts`'s seven language operations become module-private members of one exported, `LeanLanguageServices`-typed `vscodeLeanLanguageServices` object (the shape `setLeanLanguageServices` consumes anyway); `extension.ts` swaps its namespace import for named imports. knip now sees the export used, deleting all seven `VscodeIntegration.ts` rows from `config/ratchets/knip-baseline.json` (15 → 8).

**Re-verification deltas vs the proposal text** (written 2026-08-14): the desktop `type AgentEntry` deep import (`@agent/index/agentEntry`) was **already re-routed** through `@agent/index` at HEAD, and only **2** of the claimed 5 stale rows still exist — the other three were cleaned up by intervening merges. Per the proposal's explicit instruction, no `@agent/index/agentEntry` row was added: recording that drift would legitimize the new-distinct-deep-specifier class the ratchet exists to reject (AGENTS.md).

## Issue acceptance gates

Proposal item B3 (no standalone issue). Gates satisfied: avoidable edge deleted (already done upstream), stale rows purged, gate converted to set-based, lean exports reshaped out of knip. The doc pre-approves the ~+15 LoC TS-side cost of the two-check form.

## Single source of truth

`config/ratchets/host-agent-import-baseline.json` is now the exact set (not just the count) of permitted `@agent/*` deep-import specifiers per package; the vitest gate enforces equality in both directions. `vscodeLeanLanguageServices` is the single exported surface for the VS Code Lean adapter.

## Duplication and abstraction budget

No new abstraction. The two-check form is the established sibling pattern (`hostAgentMockRatchet`), not a new one. The services object replaces an implicit namespace-as-interface coupling with the explicit typed shape the consumer already required.

## Net elements (R6)

- Files: 5 modified, 0 added, 0 deleted. Net **−8 LoC** (71+/79−).
- Exported symbols: **−6** — removed 7 exports from `VscodeIntegration.ts` (`executeFileCommand`, `executeProjectCommand`, `fetchDiagnosticsForFile`, `getGoalState`, `getHoverInfo`, `getTermGoal`, `navigateToFirstError`), added 1 (`vscodeLeanLanguageServices`, consumer in same PR: `extension.ts`).
- Baseline rows: −2 host-agent baseline rows, −7 knip baseline rows.
- Classes/interfaces/enums: none added or removed.

## Consumer counts (R8)

Per-specifier grep counts justifying each purged baseline row (string-literal grep over `packages/<host>/src`, confirmed by the AST-based stale check now enforcing it):

- `@agent/core/definition/AgentDataclass` in **cli**: **0** hits in `packages/cli/src`.
- `@agent/core/definition/AgentDataclass` in **extension**: **0** hits in `packages/extension/src`.
- The same specifier stays baselined for **agent** (`packages/agent/src`), where it is live.
- All other rows verified live: cli 14/14, desktop 11/11, extension 15/15, agent 7/7 — baseline sets now match the scanned sets exactly (the stale-check test proves this on every run).
- Re-routed lean functions: each of the 7 had exactly **1** consumer (`extension.ts`, via the namespace object passed to `setLeanLanguageServices`); that single consumer now takes the typed object. `clearVscodeLeanServerEntries` keeps its direct named export (1 consumer, `deactivate()`).

## Host impact

Extension: Lean language services wiring only — same functions, same call sites, now passed as a typed object; no behavior change.

Desktop: none (baseline list unchanged; its `AgentEntry` re-route had already landed).

CLI: none (one stale baseline row removed; no source change).

## Scheduled refactoring

None. Follow-on B-items of the proposal are tracked there.

## Validation

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run check:dead-code-ratchet` — pass, 8 current vs 8 baselined
- `FORCE_COLOR=0 npx vitest run src/test-kernel/architecture/` — 17 files, 102 tests pass (includes the converted gate and its stale check)
- `FORCE_COLOR=0 npx vitest run src/test-kernel/tools/LeanInspectTool.vitest.ts` — pass
- Prettier check on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtxTTx1y9xMJsDNozz4CR1