### PR TITLE
refactor(runtime)!: one error channel for terminal and child-run persistence (A3)

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import {
   buildCliWorkflowResultMeta,
   deriveResumability,
-  getExecutionStore,
+  persistChildRunResultMeta,
   type ResumabilityDecision,
 } from '@agent/storage';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
@@ -308,11 +308,10 @@ async function persistWorkflowResultMeta(
   executionId: string,
   resultMeta: ReturnType<typeof buildCliWorkflowResultMeta>,
 ): Promise<void> {
-  try {
-    await getExecutionStore(executionId).writeResultMeta(resultMeta);
-  } catch (error) {
+  const result = await persistChildRunResultMeta(executionId, resultMeta);
+  if (result.kind === 'failed') {
     writeTextStderr(
-      `Warning: could not persist workflow result metadata: ${toErrorMessage(error)}`,
+      `Warning: could not persist workflow result metadata: ${toErrorMessage(result.err)}`,
     );
   }
 }

--- a/packages/cli/src/runtime/executionFinalization.ts
+++ b/packages/cli/src/runtime/executionFinalization.ts
@@ -38,23 +38,13 @@ export async function finalizeCliExecution(
   flowRecord: FinalizeExecutionInput['flowRecord'],
   reportFailure: CliFinalizationFailureReporter,
 ): Promise<boolean> {
-  let result: Awaited<ReturnType<typeof finalizeExecution>>;
-  try {
-    result = await finalizeExecution({
-      executionId,
-      outcome,
-      flowRecord,
-    });
-  } catch (error) {
-    markOwnedExecutionLeaseUndurable(executionId);
-    reportFailure(
-      new Error(
-        `Execution finalization failed unexpectedly for ${executionId}: ${toErrorMessage(error)}`,
-        { cause: error },
-      ),
-    );
-    return false;
-  }
+  // finalizeExecution never throws: every persistence failure comes back as a
+  // 'failed' result, so this call site carries no catch arm.
+  const result = await finalizeExecution({
+    executionId,
+    outcome,
+    flowRecord,
+  });
   if (result.status === 'durable') return true;
   markOwnedExecutionLeaseUndurable(executionId);
 

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -211,7 +211,6 @@ export async function finalizeRunTerminal(
         typeof flowRecord === 'function' ? flowRecord(outcome) : flowRecord,
       logger,
       failedMessage: 'Failed to finalize durable execution state',
-      rejectedMessage: 'Execution finalizer rejected unexpectedly',
     });
     outcomePersisted = persisted.outcomePersisted;
   }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -856,7 +856,6 @@ export class ExecutionRegistry {
           flowRecord: 'delete',
           logger,
           failedMessage: 'Failed to finalize stopped waiting execution',
-          rejectedMessage: 'Waiting-execution finalizer rejected unexpectedly',
         });
       } finally {
         if (!handle.isChildExecution) {

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -177,16 +177,10 @@ export async function runAgent(
           outcome: restoredOutcome,
           flowRecord: shouldRegister ? 'delete' : 'preserve',
         });
-        let finalizationError: unknown;
-        if ('thrownError' in finalization) {
-          finalizationError = finalization.thrownError;
-        } else if (finalization.finalization.status === 'failed') {
-          finalizationError = finalization.finalization.error;
-        }
-        if (finalizationError !== undefined) {
+        if (finalization.status === 'failed') {
           runFailure = {
             error: new AggregateError(
-              [error, finalizationError],
+              [error, finalization.error],
               `Execution ${executionId} failed before lifecycle startup and its terminal status could not be persisted`,
             ),
           };

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -53,6 +53,7 @@ export {
   markOwnedExecutionLeaseUndurable,
   type OwnedExecutionLeaseScope,
 } from './executionLease';
+export { persistChildRunResultMeta } from './childRunPersistence';
 export { resolveChildRunOutput } from './childRunOutput';
 export {
   SessionStores,

--- a/src/agent/storage/terminalPersistence.ts
+++ b/src/agent/storage/terminalPersistence.ts
@@ -16,34 +16,26 @@ import {
   type FinalizeExecutionResult,
 } from './executionLifecycle';
 
-export type FinalizeExecutionWithLeaseResult =
-  | { readonly finalization: FinalizeExecutionResult }
-  | { readonly thrownError: unknown };
-
 /**
  * Calls `finalizeExecution` and marks the owned lease undurable whenever the
- * terminal status did not reach disk: a `'failed'` result (which carries the
- * underlying error) or a thrown error. This is the shared step both
- * `persistTerminalExecution` and `runAgent`'s pre-lifecycle finalize arm used
- * to duplicate inline, so the mark-undurable decision lives in one place.
- * Callers own their failure reporting: `persistTerminalExecution` warns,
- * `runAgent` folds the error into its AggregateError. Never throws.
+ * terminal status did not reach disk — a `'failed'` result, which carries the
+ * underlying error. This is the shared step both `persistTerminalExecution`
+ * and `runAgent`'s pre-lifecycle finalize arm used to duplicate inline, so
+ * the mark-undurable decision lives in one place. Callers own their failure
+ * reporting: `persistTerminalExecution` warns, `runAgent` folds the error
+ * into its AggregateError. Never throws: `finalizeExecution` converts every
+ * persistence failure into a `'failed'` result.
  */
 export async function finalizeExecutionWithLease(params: {
   executionId: ExecutionId;
   outcome: RunOutcome;
   flowRecord: FinalizeExecutionInput['flowRecord'];
-}): Promise<FinalizeExecutionWithLeaseResult> {
-  try {
-    const finalization = await finalizeExecution(params);
-    if (finalization.status === 'failed') {
-      markOwnedExecutionLeaseUndurable(params.executionId);
-    }
-    return { finalization };
-  } catch (error) {
+}): Promise<FinalizeExecutionResult> {
+  const finalization = await finalizeExecution(params);
+  if (finalization.status === 'failed') {
     markOwnedExecutionLeaseUndurable(params.executionId);
-    return { thrownError: error };
   }
+  return finalization;
 }
 
 export interface PersistTerminalExecutionParams {
@@ -56,7 +48,6 @@ export interface PersistTerminalExecutionParams {
   readonly logger: AgentTrace;
   /** Message text differs per call site and is asserted verbatim by existing tests. */
   readonly failedMessage: string;
-  readonly rejectedMessage: string;
 }
 
 export interface PersistTerminalExecutionResult {
@@ -64,12 +55,12 @@ export interface PersistTerminalExecutionResult {
 }
 
 /**
- * Shared `finalizeExecution` try/catch used by both terminal-persistence
+ * Shared `finalizeExecution` tail used by both terminal-persistence
  * sites: `AgentRunLifecycle.finalizeRunTerminal`'s finalize arm and
  * `ExecutionRegistry.finishWaitingTermination`'s waiting-stop arm. Both sides
  * previously duplicated this exactly: call `finalizeExecution`, mark the
- * owned lease undurable and warn on either a `'failed'` result or a rejected
- * promise, and hand back whether the terminal status reached disk. The
+ * owned lease undurable and warn on a `'failed'` result, and hand back
+ * whether the terminal status reached disk. The
  * caller keeps everything this helper does not own: the registry keeps its
  * root-lease release in its own `finally`; this function never throws, so a
  * caller-side `catch` is unnecessary and would be dead code.
@@ -84,35 +75,24 @@ export async function persistTerminalExecution(
     flowRecord,
     logger: callerLogger,
     failedMessage,
-    rejectedMessage,
   } = params;
   const agentData =
     agentName !== undefined ? { agentIdentifier: agentName } : {};
-  const result = await finalizeExecutionWithLease({
+  const finalization = await finalizeExecutionWithLease({
     executionId,
     outcome,
     flowRecord,
   });
-  if ('thrownError' in result) {
-    callerLogger.warn(rejectedMessage, {
-      data: {
-        ...agentData,
-        executionId,
-        error: result.thrownError,
-      },
-    });
-    return { outcomePersisted: false };
-  }
-  if (result.finalization.status === 'failed') {
+  if (finalization.status === 'failed') {
     callerLogger.warn(failedMessage, {
       data: {
         ...agentData,
         executionId,
-        stage: result.finalization.stage,
-        outcomePersisted: result.finalization.outcomePersisted,
-        error: result.finalization.error,
+        stage: finalization.stage,
+        outcomePersisted: finalization.outcomePersisted,
+        error: finalization.error,
       },
     });
   }
-  return { outcomePersisted: result.finalization.outcomePersisted };
+  return { outcomePersisted: finalization.outcomePersisted };
 }

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.ts
@@ -46,6 +46,18 @@ vi.mock('@agent/storage', async (importOriginal) => {
     ),
     deriveResumability: mocks.deriveResumability,
     finalizeExecution: mocks.finalizeExecution,
+    // Mirrors the real result-object conversion over the same writeResultMeta
+    // fake, so failure injection keeps flowing through mocks.writeResultMeta.
+    persistChildRunResultMeta: vi.fn(
+      async (_executionId: ExecutionId, meta: unknown) => {
+        try {
+          await mocks.writeResultMeta(meta);
+          return { kind: 'persisted' as const };
+        } catch (err) {
+          return { kind: 'failed' as const, err };
+        }
+      },
+    ),
   };
 });
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -2,7 +2,8 @@
 import { z } from 'zod';
 
 // Local imports
-import { getExecutionStore, registerExecution } from '@agent/storage';
+import { registerExecution } from '@agent/storage';
+import { persistChildRunDeliveryBestEffort } from '@agent/storage/childRunDeliveryPersistence';
 import {
   captureOwnedExecutionLease,
   markOwnedExecutionLeaseUndurable,
@@ -525,14 +526,6 @@ export class BashTool extends defineTool({
       logBackgroundFailure(action, err);
     };
 
-    const persistReport = async (msg: string): Promise<void> => {
-      try {
-        await getExecutionStore(executionId).writeReport(msg);
-      } catch (err: unknown) {
-        logDurabilityFailure('persist report', err);
-      }
-    };
-
     let childFinalized = false;
     const finalizeChild = async (
       finalizeOptions: Parameters<typeof childStream.finalize>[0],
@@ -594,20 +587,19 @@ export class BashTool extends defineTool({
             toDeliveryExcerpt(stderr),
           );
 
-          const store = getExecutionStore(executionId);
-          try {
-            await store.writeResultMeta({
+          await persistChildRunDeliveryBestEffort(
+            executionId,
+            msg,
+            {
               producer: 'backgroundBash',
               exitCode: result.exitCode ?? (result.success ? 0 : 1),
               wallTimeMs,
               success: result.success,
               timedOut: result.timedOut ?? false,
               command,
-            });
-          } catch (err: unknown) {
-            logDurabilityFailure('persist result metadata', err);
-          }
-          await persistReport(msg);
+            },
+            (kind, err) => logBackgroundFailure(`persist ${kind}`, err),
+          );
 
           await deliverAndFinalize(msg, {
             wallTimeMs,
@@ -620,7 +612,12 @@ export class BashTool extends defineTool({
 
         const { error } = outcome;
         const msg = formatBashError(executionId, command, error);
-        await persistReport(msg);
+        await persistChildRunDeliveryBestEffort(
+          executionId,
+          msg,
+          undefined,
+          (kind, err) => logBackgroundFailure(`persist ${kind}`, err),
+        );
 
         await deliverAndFinalize(msg, {
           outcome: { kind: 'failed', error },


### PR DESCRIPTION
**STACKED on #10475** — based on `refactor/delegation-substrate-wave1`; after #10475 merges, retarget this PR to `main`.

## Summary

Implements **A3** of `docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md`: one error channel for child-run/terminal persistence.

`finalizeExecution` (`src/agent/storage/executionLifecycle.ts:258-319`) provably never throws — both awaits and every synchronous store call sit inside a `try` whose `catch` returns `{status:'failed'}` (re-verified on this base). The defensive thrown-error arms at its call sites were therefore dead code:

- `finalizeExecutionWithLease` loses the `{thrownError}` result variant and its own try/catch; it now returns `FinalizeExecutionResult` directly. `persistTerminalExecution` drops the unreachable rejected branch and the `rejectedMessage` param; the two call sites (`AgentRunLifecycle`, `executionRegistry`) drop the argument.
- `runAgent`'s pre-lifecycle finalize arm now folds only a `'failed'` result error into its `AggregateError` (the `'thrownError' in` branch was unreachable).
- The CLI's `finalizeCliExecution` drops the catch that reported an "unexpected" thrown failure that cannot occur. The per-stage `finalizationFailureMessage` reporting surface is **kept** (headless-parity, per the proposal's binding verifier correction).

The hand-rolled copies of the delivery-persistence policy now route through the shared owners, and the result-object layer is kept so the best-effort consumer never starts throwing:

- `bash.ts` background completion: both the success and failure paths use `persistChildRunDeliveryBestEffort` (same policy: each write inspected independently, lease marked undurable per failure, loud `logger.error` per failure via the `onFailure` callback).
- CLI `workflow.ts` `persistWorkflowResultMeta`: uses the result-object `persistChildRunResultMeta` (newly re-exported from the `@agent/storage` barrel), keeping its existing stderr warning and its existing no-lease-marking semantics.

### Stale premises found while re-verifying (recorded, not forced)

- The proposal's "required consumer" `persistResultMetaRequired` (`inBandSubagentExecution.ts`) **no longer exists on the wave1 base** — that file was rewritten. `childRunPersistence.ts`'s surviving consumers are `childRunDeliveryPersistence.ts` and (now) the CLI workflow command.
- The proposal's claim that no test asserts nothing / "rejectedMessage warn strings are asserted verbatim by tests" is **stale on this base**: no test asserts those strings anymore (grepped `rejected unexpectedly` / `unexpectedly` across `src/test-kernel` and `packages`), so no test updates were needed for that part.
- The proposal says `restartRepair.ts:185` has no defensive arm; on wave1 it **does** have a catch (`restartRepair.ts:202-207`) — but it guards an **injected** `finalizeExecution` port (`options.finalizeExecution ?? default`), whose contract is not provably non-throwing. Left in place as out of A3's scope.

## Issue acceptance gates

Proposal item A3 (no standalone issue): dead throw/catch arms deleted at all three named sites; bash/CLI routed through the surviving owners; result-object layer kept; `finalizationFailureMessage` kept.

## Single source of truth

- Thrown-vs-failed policy: `finalizeExecution` is the one converter of persistence failures into `'failed'` results; `finalizeExecutionWithLease` is the one place that marks the owned lease undurable for terminal-status failures.
- Child-run delivery persistence: `childRunDeliveryPersistence.ts` (best-effort pair) and `childRunPersistence.ts` (result-object writes) own the policy for all three former copies (childRunLoop, bash, CLI workflow).

## Duplication and abstraction budget

Removed: the duplicate thrown-error channel (result-variant + 3 dead arms), bash's private `persistReport` helper and inline result-meta try/catch, the CLI workflow's private try/catch copy. Added abstractions: none — one barrel re-export of an existing function.

## Net elements (R6)

- Files: 9 changed, 0 added, 0 deleted; **net −29 LoC** (+61/−90; production −41, test +12 for the mock shim)
- Diffstat: `packages/cli/src/commands/workflow.ts` +4/−5, `packages/cli/src/runtime/executionFinalization.ts` +8/−16, `src/agent/runtime/AgentRunLifecycle.ts` −1, `src/agent/runtime/executionRegistry.ts` −1, `src/agent/runtime/runAgent.ts` +2/−8, `src/agent/storage/index.ts` +1, `src/agent/storage/terminalPersistence.ts` +21/−39, `src/tools/bash.ts` +14/−19, `src/test-kernel/cli/WorkflowRunCommand.vitest.ts` +12
- Exported symbols: −1 (`FinalizeExecutionWithLeaseResult` type), +1 barrel re-export of the existing `persistChildRunResultMeta` (consumer in this PR: CLI workflow command)
- Interface fields: −1 (`PersistTerminalExecutionParams.rejectedMessage`)
- Classes/enums: 0

## Consumer counts (R8)

Grepped over `src/` + `packages/` (excluding `dist/`), after the change:

- `FinalizeExecutionWithLeaseResult` / `thrownError`: **0** remaining references (was 2 files: definition + `runAgent`).
- `rejectedMessage`: **0** remaining (was: 1 definition + 2 call-site args; **0 tests** asserted the strings `'Execution finalizer rejected unexpectedly'` / `'Waiting-execution finalizer rejected unexpectedly'`).
- CLI catch message `finalization failed unexpectedly`: **0** remaining, **0** tests asserted it.
- Direct `getExecutionStore(...).writeReport/writeResultMeta` production call sites outside `src/agent/storage/`: **0** remaining (was 3: bash.ts ×2, workflow.ts ×1). Remaining `writeResultMeta`/`writeReport` callers: `ExecutionKVStore` (definition) and `childRunPersistence.ts` (owner).
- `persistChildRunDeliveryBestEffort` consumers: **2 files / 3 call sites** (`childRunLoop.ts`, `bash.ts` ×2).
- `persistChildRunResultMeta` consumers: **2** (`childRunDeliveryPersistence.ts` internal, `packages/cli/src/commands/workflow.ts` via barrel).

## Host impact

Extension: no behavior change — `persistTerminalExecution` warns identically on `'failed'` results; the deleted branch was unreachable.

Desktop: same as extension (shared runtime paths only).

CLI: same user-visible messages; `finalizeCliExecution` keeps per-stage failure reporting; workflow result-meta persistence keeps its stderr warning. Background bash failure logs change wording only in the manifest case: `persist result metadata` → `persist result manifest` (no test asserted the old string).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — green (all workspaces)
- `npm run lint` — green
- `npm run check:dead-code-ratchet` — green (15 vs 15 baselined)
- `npx prettier --check` on all changed files — green
- `FORCE_COLOR=0` vitest: `ExecutionLease`, `RunAgentOwnership`, `ChildRunLoop`, `AgentRunLifecycle`, `ExecutionRegistry` (144 tests), `RunExecution`, `WorkflowRunCommand`, `BashTool`, `ChildRunDelivery`, `DelegationHeadless`, `NativeSubagentStrategy`, `RestartRepair`, `ExecutionMetaWrites` (183 tests), full `src/test-kernel/architecture` ratchet suite (97 tests) — all green

### Verified

- Read `finalizeExecution` in full on this base and confirmed every await and synchronous store call is inside a try whose catch returns `{status:'failed'}` — it cannot reject.
- Confirmed the `host-agent-mock` ratchet forbids a new deep `vi.mock` tuple; the `WorkflowRunCommand.vitest.ts` update overrides `persistChildRunResultMeta` inside the **existing** `@agent/storage` mock (no new tuple), delegating to the same `writeResultMeta` fake so failure injection and all `toHaveBeenCalledWith` assertions are unchanged.
- Confirmed `getExecutionStore` caches store instances (`KVStoreCache`, max 50), so `BashTool.vitest.ts`'s instance `spyOn(store, 'writeResultMeta')` still intercepts through the shared helper.
- Confirmed `ExecutionId` is an unbranded string (no type friction at the CLI call site).
- Excluded an unrelated `pnpm-lock.yaml` format rewrite produced by the local pnpm version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtxTTx1y9xMJsDNozz4CR1
