### PR TITLE
fix(logger): remove dead path-scrubbing branch from redactSecrets (#10596)

### DIFF
--- a/src/logger/redaction.ts
+++ b/src/logger/redaction.ts
@@ -78,19 +78,7 @@ const PROVIDER_KEY_PATTERNS = [
   ),
 ];
 
-export interface LogRedactionOptions {
-  readonly homeDir?: string | undefined;
-  readonly workspacePath?: string | undefined;
-}
-
-export function redactSecrets(
-  text: string,
-  options: LogRedactionOptions = {},
-): string {
-  const prefixes = [options.workspacePath, options.homeDir]
-    .filter((prefix): prefix is string => Boolean(prefix))
-    .sort((a, b) => b.length - a.length);
-
+export function redactSecrets(text: string): string {
   let redacted = text
     .replaceAll(
       JSON_STRING_PROPERTY_PATTERN,
@@ -107,10 +95,6 @@ export function redactSecrets(
 
   for (const pattern of PROVIDER_KEY_PATTERNS) {
     redacted = redacted.replaceAll(pattern, REDACTED);
-  }
-
-  for (const prefix of prefixes) {
-    redacted = redacted.replaceAll(prefix, '[path]');
   }
 
   return redacted;

--- a/src/test-kernel/desktop/DesktopLogRedaction.vitest.ts
+++ b/src/test-kernel/desktop/DesktopLogRedaction.vitest.ts
@@ -4,7 +4,7 @@ import { PROVIDER_KEY_REDACTION_RULES, redactSecrets } from '@logger/redaction';
 import { API_KEY_PROVIDER_IDS } from '@shared/constants/providers';
 
 describe('desktop log redaction', () => {
-  it('redacts obvious secrets and sensitive path prefixes', () => {
+  it('redacts secret patterns and leaves ordinary paths intact', () => {
     const redacted = redactSecrets(
       [
         'OPENAI_API_KEY=sk-1234567890abcdef',
@@ -12,19 +12,18 @@ describe('desktop log redaction', () => {
         '/Users/alice/private-paper/main.tex',
         '/Users/alice/.config/texra',
       ].join('\n'),
-      {
-        homeDir: '/Users/alice',
-        workspacePath: '/Users/alice/private-paper',
-      },
     );
 
     expect(redacted).not.toContain('sk-1234567890abcdef');
     expect(redacted).not.toContain('ghp_1234567890abcdef');
-    expect(redacted).not.toContain('/Users/alice/private-paper');
-    expect(redacted).not.toContain('/Users/alice/.config');
     expect(redacted).toContain('OPENAI_API_KEY=[redacted]');
     expect(redacted).toContain('Bearer [redacted]');
-    expect(redacted).toContain('[path]/main.tex');
+    // No in-repo call site ever passed LogRedactionOptions, so the old
+    // homeDir/workspacePath path-scrubbing branch was dead. Desktop hosts scrub
+    // paths separately via redactPathPrefixes before redactSecrets. Pin the
+    // actual redactSecrets contract: secret patterns redact, paths do not.
+    expect(redacted).toContain('/Users/alice/private-paper/main.tex');
+    expect(redacted).toContain('/Users/alice/.config/texra');
   });
 
   it('redacts complete quoted secret assignments', () => {

--- a/src/test-kernel/desktop/DesktopLogRedaction.vitest.ts
+++ b/src/test-kernel/desktop/DesktopLogRedaction.vitest.ts
@@ -18,7 +18,7 @@ describe('desktop log redaction', () => {
     expect(redacted).not.toContain('ghp_1234567890abcdef');
     expect(redacted).toContain('OPENAI_API_KEY=[redacted]');
     expect(redacted).toContain('Bearer [redacted]');
-    // No in-repo call site ever passed LogRedactionOptions, so the old
+    // No production call site ever passed LogRedactionOptions, so the old
     // homeDir/workspacePath path-scrubbing branch was dead. Desktop hosts scrub
     // paths separately via redactPathPrefixes before redactSecrets. Pin the
     // actual redactSecrets contract: secret patterns redact, paths do not.


### PR DESCRIPTION
## Summary

Deletes the dead `homeDir`/`workspacePath` path-scrubbing branch of `redactSecrets`. No in-repo call site ever passed `LogRedactionOptions`: `createRedactingSink` (`logUtils.ts:63`) and every transcript path call `redactSecrets(message)` with a single argument, and desktop hosts already scrub paths separately via `redactPathPrefixes` in `desktopAppLog.ts` before delegating to `redactSecrets`. The branch was therefore unreachable, and wiring it through would re-introduce stale host-dependent workspace state that the sink already lacks. This is the "silent degradation is a defect" honesty fix, not a secret leak: all secret-pattern redaction is unchanged.

## Issue acceptance gates

Closes #10596

- Delete the unreachable `homeDir`/`workspacePath` path-prefix branch rather than wiring options through the sink/transcript call sites.
- Remove the now-dead `LogRedactionOptions` type/API cleanly (no remaining code or test imports it).
- Preserve every secret-pattern redaction rule (`SECRET_ASSIGNMENT_PATTERN`, `JSON_STRING_PROPERTY_PATTERN`, `BEARER_PATTERN`, and all `PROVIDER_KEY_PATTERNS`).
- Update `DesktopLogRedaction.vitest.ts` to pin the actual production contract: secret patterns redact, ordinary paths pass through unchanged.

## Single source of truth

`redactSecrets` (`src/logger/redaction.ts`) owns secret-pattern redaction only. Desktop file/path scrubbing remains the responsibility of `redactPathPrefixes` in `packages/desktop/src/main/desktopAppLog.ts`, which already wraps `redactSecrets`.

## Duplication and abstraction budget

None added or removed. The change deletes a redundant in-function path loop that duplicated the desktop host's own `redactPathPrefixes` logic.

## Net elements (R6)

- **Files:** 2 modified (`src/logger/redaction.ts`, `src/test-kernel/desktop/DesktopLogRedaction.vitest.ts`)
- **Exported symbols:** −1 (`export interface LogRedactionOptions` removed; `redactSecrets` export retained with a narrowed single-parameter signature)
- **Classes/interfaces/enums:** −1 (`LogRedactionOptions`)
- **Net LoC:** −17 (8 insertions, 25 deletions)

## Consumer counts (R8)

- `LogRedactionOptions` (deleted export): **0 consumers** — grep across the repo shows it referenced only by its definition in `redaction.ts`; the removed test usage passed an inline object literal and never imported the type.
- `redactSecrets(text, options?)` → `redactSecrets(text)`: **19 production call sites** (plus 3 in the focused test), all already single-argument; **0** passed options, so the removed parameter had no consumers.
- `[path]` scrubbing emitted by the deleted branch: **0 consumers** — desktop path scrubbing is supplied independently by `redactPathPrefixes` and is unaffected.

## Host impact

Extension: None

Desktop: None (`redactDesktopLogText`/`redactDesktopLogPath` continue to scrub paths via `redactPathPrefixes` before `redactSecrets`)

CLI: None

## Scheduled refactoring

None.

## Validation

- `npx vitest run src/test-kernel/desktop/DesktopLogRedaction.vitest.ts` — 4 passed
- `npm run typecheck:workspace` — clean
- `npm run typecheck:test-kernel` — clean
- `npm run typecheck:desktop` — clean
- `npm run typecheck:cli` — clean
- `node ./node_modules/eslint/bin/eslint.js src/logger/redaction.ts src/test-kernel/desktop/DesktopLogRedaction.vitest.ts` — clean
- `npx prettier --check src/logger/redaction.ts src/test-kernel/desktop/DesktopLogRedaction.vitest.ts` — clean
- `npm run check:dead-code-ratchet` — OK (15 findings = 15 baselined)
- `npm run check:guidance-refs` — OK
- `git diff --check` — clean
