### PR TITLE
refactor(logger): narrow log-only createChannelTrace callers onto createLog

### DIFF
--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -1,7 +1,7 @@
 import process from 'node:process';
 
 import type { AgentEvent, StatusEvent } from '@agent/trace';
-import { createChannelTrace } from '@agent/trace';
+import { createLog } from '@logger/logUtils';
 import type {
   ClearMissingOutputsPayload,
   FollowUpSentPayload,
@@ -15,7 +15,7 @@ import type {
   UpdateStreamDescriptionPayload,
 } from '@shared/schemas';
 
-const logger = createChannelTrace('SessionEventHub');
+const logger = createLog('SessionEventHub');
 
 /**
  * Session-scoped fact vocabulary. Payload-bearing arms use fact-native named

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -16,7 +16,6 @@ import {
   RESUMABILITY_CAUSE,
   type ResumabilityDecision,
 } from '@agent/storage';
-import { createChannelTrace } from '@agent/trace';
 import type { FlowRecord } from '@agent/node/persistedFlow';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { ProviderMessageArraySchema } from '@agent/types/ProviderMessage';
@@ -24,6 +23,7 @@ import {
   migrateSharedState,
   type PreparedShared,
 } from '@agent/implementations/flows/tooluse/nodes/types';
+import { createLog } from '@logger/logUtils';
 import type { StreamTabId, ExecutionId } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
 import {
@@ -35,7 +35,7 @@ import {
   type ModelHandlerCompatibilityKey,
 } from './modelHandlerCompatibilityKey';
 
-const logger = createChannelTrace('SessionResumeRetrieval');
+const logger = createLog('SessionResumeRetrieval');
 
 /** Canonical tool-use shared state plus the identity needed to resume it. */
 export interface ToolUseResumeData {

--- a/src/controllers/session/SessionFactApplier.ts
+++ b/src/controllers/session/SessionFactApplier.ts
@@ -1,9 +1,4 @@
-import {
-  createChannelTrace,
-  RUN_FACT_EVENT_TYPES,
-  type AgentEvent,
-  type AgentTrace,
-} from '@agent/trace';
+import { RUN_FACT_EVENT_TYPES, type AgentEvent } from '@agent/trace';
 import type { SessionFact } from '@agent/runtime/SessionEventHub';
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
 import type { SessionRendererPort } from '@controllers/session/SessionRendererPort';
@@ -68,8 +63,6 @@ export type SessionFactApplierOptions = {
  * before this host's in-memory tab map exists).
  */
 export class SessionFactApplier {
-  private readonly logger: AgentTrace;
-
   /** Streams this renderer has already received metadata for. Not reset when
    * a webview closes and reopens — `ProgressViewProvider.markWebviewReady`'s
    * resolve-time full metadata resync (`syncFullView`) re-registers every
@@ -123,9 +116,7 @@ export class SessionFactApplier {
     private readonly state: SessionState,
     private readonly renderer: SessionRendererPort,
     private readonly options: SessionFactApplierOptions,
-  ) {
-    this.logger = createChannelTrace('SessionFactApplier');
-  }
+  ) {}
 
   private handleRunningTransition(
     streamId: StreamTabId,

--- a/src/controllers/session/SessionState.ts
+++ b/src/controllers/session/SessionState.ts
@@ -1,5 +1,3 @@
-import type { AgentTrace } from '@agent/trace';
-import { createChannelTrace } from '@agent/trace';
 import {
   SessionStores,
   type DeleteAllStreamsResult,
@@ -12,6 +10,7 @@ import {
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
 import { createSessionStores } from '@controllers/session/sessionStores';
+import { createLog } from '@logger/logUtils';
 import {
   type ActiveChildInfo,
   type ConversationProgress,
@@ -117,14 +116,14 @@ export class SessionState {
   readonly streamStatus: StreamStatusMachine;
   readonly followUps: ToolUseFollowUpQueue;
 
-  private readonly logger: AgentTrace;
+  private readonly logger: ReturnType<typeof createLog>;
   private readonly session: SessionHandle;
 
   constructor(
     session: SessionHandle = defaultSession(),
     stores?: SessionStores,
   ) {
-    this.logger = createChannelTrace('SessionState');
+    this.logger = createLog('SessionState');
     this.session = session;
     this.streamStatus = session.status;
     this.streamLogs = session.transcripts;

--- a/src/controllers/session/eventErrorHandling.ts
+++ b/src/controllers/session/eventErrorHandling.ts
@@ -1,9 +1,9 @@
 // Local imports - logger
-import { createChannelTrace } from '@agent/trace';
+import { createLog } from '@logger/logUtils';
 import { isThenable, serializeError } from '@utils/core';
 
 // Shared logger for all event handlers
-const eventLogger = createChannelTrace('SessionEvents');
+const eventLogger = createLog('SessionEvents');
 
 /** Log an error with module context, preserving the original error reference. */
 function logError(moduleName: string, context: string, error: unknown): void {

--- a/src/controllers/settingsView/SettingsProfileController.ts
+++ b/src/controllers/settingsView/SettingsProfileController.ts
@@ -1,4 +1,4 @@
-import { createChannelTrace } from '@agent/trace';
+import { createLog } from '@logger/logUtils';
 import { API_PROVIDERS } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import type { StateStore } from '@platform/interfaces';
@@ -31,7 +31,7 @@ import {
 } from '@utils/config/providerConfig';
 import { buildProfileMessage } from './ProfileMessageBuilder';
 
-const logger = createChannelTrace('SettingsProfileController');
+const logger = createLog('SettingsProfileController');
 
 type SettingsReliabilitySetting = Omit<NumberSetting, 'value'> & {
   defaultValue: number;

--- a/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
@@ -29,14 +29,15 @@ const traceMocks = vi.hoisted(() => ({
   warn: vi.fn(),
 }));
 
-vi.mock('@agent/trace', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@agent/trace')>();
+vi.mock('@logger/logUtils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@logger/logUtils')>();
   return {
     ...actual,
-    createChannelTrace: () => ({
-      ...actual.noopTrace,
+    createLog: () => ({
+      debug: vi.fn(),
       info: traceMocks.info,
       warn: traceMocks.warn,
+      error: vi.fn(),
     }),
   };
 });

--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -27,10 +27,10 @@ const STREAM_B = 'stream:b' as StreamTabId;
 const GENERATION_A = 'f9de9269-9198-4103-a248-6a3bd78bd4eb';
 
 /**
- * Capture per-channel log lines. The storage module logs through a channel
- * trace that binds `logUtils.warn` at module init, so a `vi.spyOn` installed
- * inside a test can't intercept it — observe the output sink instead (same
- * pattern as ChannelTrace.vitest.ts).
+ * Capture per-channel log lines. The storage module logs through `createLog`,
+ * which routes through the module namespace and lands in the output sink;
+ * observe the sink so these assertions pin the sink path without coupling to
+ * the namespace seam (same capture pattern as ChannelTrace.vitest.ts).
  */
 function captureLogLines(): string[] {
   const lines: string[] = [];

--- a/src/tools/agentCliSessionRegistry.ts
+++ b/src/tools/agentCliSessionRegistry.ts
@@ -1,9 +1,9 @@
 import { getExecutionStore } from '@agent/storage';
-import { createChannelTrace } from '@agent/trace';
 import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
+import { createLog } from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
-const logger = createChannelTrace('AgentCliSessionRegistry');
+const logger = createLog('AgentCliSessionRegistry');
 
 interface AgentCliSessionRegistryDependencies {
   persistSessionId(

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -17,7 +17,6 @@
 
 import { z } from 'zod';
 
-import { createChannelTrace } from '@agent/trace';
 import {
   getRunContextExecutionId,
   getRunContextSession,
@@ -28,6 +27,7 @@ import {
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
+import { createLog } from '@logger/logUtils';
 import {
   InquiryThreadIdSchema,
   ToolError,
@@ -53,7 +53,7 @@ import {
   type ExternalInquiryThreadManifest,
 } from './externalInquiryStorage';
 
-const logger = createChannelTrace('InquiryTool');
+const logger = createLog('InquiryTool');
 
 // ============================================================================
 // Schemas

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -2,9 +2,9 @@ import * as path from 'node:path';
 
 import { z } from 'zod';
 
-import { createChannelTrace } from '@agent/trace';
 import { isFileNotFoundError } from '@common/errors';
 import { EXTERNAL_INQUIRY_THREADS_DIR } from '@common/storage/storageLayout';
+import { createLog } from '@logger/logUtils';
 import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import {
@@ -33,7 +33,7 @@ import { isDirectory, isFile } from '@utils/files/fsEntryType';
 const THREADS_DIR = EXTERNAL_INQUIRY_THREADS_DIR;
 const EXEC_DIR = 'ei';
 const QUESTION_PREVIEW_CHARS = 200;
-const logger = createChannelTrace('ExternalInquiryStorage');
+const logger = createLog('ExternalInquiryStorage');
 
 // ============================================================================
 // Schemas

--- a/src/tools/inquiry/inquiryActions.ts
+++ b/src/tools/inquiry/inquiryActions.ts
@@ -9,8 +9,8 @@
  */
 
 // Local imports - agent
-import { createChannelTrace } from '@agent/trace';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { createLog } from '@logger/logUtils';
 
 // Local imports - shared
 import type { InquiryActionMessage } from '@shared/schemas';
@@ -26,7 +26,7 @@ import {
   injectContinuationForDroppedThread,
 } from './inquiryContinuation';
 
-const logger = createChannelTrace('InquiryTool');
+const logger = createLog('InquiryTool');
 
 type InquirySubmitAction = Extract<
   InquiryActionMessage,

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -12,7 +12,6 @@
  * forward it to the UI via the `inquiryThreadUpdated` event.
  */
 
-import { createChannelTrace } from '@agent/trace';
 import {
   submitFollowUp,
   type SubmitFollowUpResult,
@@ -22,6 +21,7 @@ import {
   resolveEmitSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
+import { createLog } from '@logger/logUtils';
 import type {
   InquiryThreadId,
   InquiryThreadSummary,
@@ -42,7 +42,7 @@ import {
   type ExternalInquiryThreadManifest,
 } from './externalInquiryStorage';
 
-const logger = createChannelTrace('inquiryContinuation');
+const logger = createLog('inquiryContinuation');
 
 export type InjectionOutcome = 'sent' | 'queued' | 'resumed' | 'archived';
 

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -17,7 +17,6 @@
 import { z } from 'zod';
 
 // Local imports
-import { createChannelTrace } from '@agent/trace';
 import type { WorkPlanState } from '@agent/core/state/AgentWorkspaceState';
 import {
   classifyRejection,
@@ -32,6 +31,7 @@ import {
   getCurrentToolContexts,
   type CurrentToolContexts,
 } from '@agent/followUp/ToolFileInteractionContext';
+import { createLog } from '@logger/logUtils';
 import type { Plan, ToolResult } from '@shared/schemas';
 import {
   formatGoalTime,
@@ -51,7 +51,7 @@ import { errorResult, executed } from '@tools/core/result';
 import { assertNever, generateShortId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-const logger = createChannelTrace('PlanTool');
+const logger = createLog('PlanTool');
 
 function formatGoalView(goal: Goal): string {
   return [

--- a/src/tools/todo/TodoTool.ts
+++ b/src/tools/todo/TodoTool.ts
@@ -10,8 +10,8 @@
 import { z } from 'zod';
 
 // Local imports - tools
-import { createChannelTrace } from '@agent/trace';
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
+import { createLog } from '@logger/logUtils';
 import {
   TODO_STATUS,
   STATUS_DISPLAY,
@@ -23,7 +23,7 @@ import { type ToolResult } from '@shared/schemas';
 import { defineTool } from '@tools/core/define';
 import { executed } from '@tools/core/result';
 
-const logger = createChannelTrace('TodoWriteTool');
+const logger = createLog('TodoWriteTool');
 
 /**
  * Schema for the todo_write tool input.

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 
-import { createChannelTrace } from '@agent/trace';
 import { classifyRejection } from '@agent/runtime/HostInteractions';
 import {
   getRunContextSession,
@@ -8,6 +7,7 @@ import {
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import { defaultSession } from '@agent/runtime/SessionHandle';
+import { createLog } from '@logger/logUtils';
 import {
   UserQuestionAnswersSchema,
   UserQuestionPromptSchema,
@@ -18,7 +18,7 @@ import { defineTool } from '@tools/core/define';
 import { executed } from '@tools/core/result';
 import { assertNever, generateShortId } from '@utils/core';
 
-const logger = createChannelTrace('UserQuestionTool');
+const logger = createLog('UserQuestionTool');
 
 const AskUserQuestionInputSchema = z.strictObject({
   questions: z


### PR DESCRIPTION
## Summary

Implements the clean, uncontested subset of #10595: narrow the log-only
`createChannelTrace` module singletons onto `createLog`, leaving genuine
`AgentTrace` fallbacks and callers overlapping #10475/#10541 untouched.

`createLog` and `createChannelTrace` funnel through the same shared sink
(`createChannelWriter` → `writeLine`), so per-caller narrowing is
behavior-preserving for these log-only sites; `createLog` additionally routes
through the module namespace, which is the spy-able seam tests already rely on.

## Changes

**Converted to `createLog` (13 files):**

- `src/agent/runtime/SessionEventHub.ts`
- `src/agent/runtime/SessionResumeRetrieval.ts`
- `src/controllers/session/eventErrorHandling.ts`
- `src/controllers/session/SessionState.ts` (field retyped `ReturnType<typeof createLog>`)
- `src/controllers/settingsView/SettingsProfileController.ts`
- `src/tools/agentCliSessionRegistry.ts`
- `src/tools/inquiry/externalInquiryStorage.ts`
- `src/tools/inquiry/ExternalInquiryTool.ts`
- `src/tools/inquiry/inquiryActions.ts`
- `src/tools/inquiry/inquiryContinuation.ts`
- `src/tools/plan/PlanTool.ts`
- `src/tools/todo/TodoTool.ts`
- `src/tools/userQuestion/UserQuestionTool.ts`

**Dead logger removed (1 file):**

- `src/controllers/session/SessionFactApplier.ts` — dropped the unused
  `logger` field, its `AgentTrace` type import, and the constructor assignment.

**Test seam updated (2 files):**

- `src/test-kernel/tools/ExternalInquiryAction.vitest.ts` — mock
  `@logger/logUtils.createLog` (with `importOriginal` spread) instead of
  `@agent/trace.createChannelTrace`, preserving the `info`/`warn` assertions.
- `src/test-kernel/tools/InquiryStorage.vitest.ts` — corrected the capture
  comment to reflect the `createLog` seam (sink observation still valid).

## Net elements (R6)

- Diffstat: 16 files, 38 insertions, 47 deletions; net **−9 lines**.
- `createChannelTrace` non-test callers: **28 → 14**.
- Converted to `createLog`: **13**; dead logger removed: **1**.
- `createLog` module-level call sites under `src/` (non-test, excluding `logUtils.ts`): **54** after this PR.
- Exported symbols/classes/interfaces/enums added: **0**.

## Consumer counts (R8)

No event or emit path is added or rerouted. Each converted singleton keeps its existing module-local consumers and shared `writeLine` sink. The deleted `SessionFactApplier.logger` field had **0 reads**. The 14 remaining `createChannelTrace` callers are enumerated below and retain either genuine `AgentTrace` semantics or deferred collision ownership.

## Remaining `createChannelTrace` callers (contested remainder — not touched)

Genuine `AgentTrace` fallbacks and/or files overlapping #10475/#10541:

- `src/agent/followUp/ToolUseFollowUp.ts`
- `src/agent/followUp/ToolUseFollowUpQueueManager.ts`
- `src/agent/runtime/AgentLaunchContext.ts`
- `src/agent/runtime/AgentLaunchResources.ts`
- `src/agent/runtime/AgentRunLifecycle.ts`
- `src/agent/runtime/childRunLoop.ts` (AgentTrace fallback)
- `src/agent/runtime/executeAgent.ts`
- `src/agent/runtime/executionRegistry.ts`
- `src/agent/runtime/ExecutionSubscriptionBinder.ts`
- `src/agent/runtime/HostInteractions.ts`
- `src/agent/runtime/SessionHandle.ts`
- `src/tools/delegation/subagentExecution.ts`
- `src/tools/github/PollingSourceBase.ts`
- `src/tools/github/StreamSubscriptionRegistry.ts`

(`src/agent/trace/channelTrace.ts` is the factory definition and
`src/agent/trace/index.ts` re-exports it; `src/agent/modelHandlers/ModelHandler.ts`
only mentions `createChannelTrace` in a comment.)

## Validation

- Focused Vitest: 18 files / 184 tests passed.
- Workspace, test-kernel, CLI, and desktop typechecks passed.
- ESLint and Prettier passed on changed files.
- Browser-safety, guidance-reference, and dead-code ratchets passed.
- `git diff --check` clean.

Refs #10595

