### PR TITLE
refactor(logger): migrate 25 mechanical modules to createLog

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -41,7 +41,7 @@ import {
   codexCoordinator,
   formatCodexAuthUnavailableMessage,
 } from '@auth/codex';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import {
   codexBackendModelId,
   resolveCodexSubscriptionProfile,
@@ -55,6 +55,7 @@ import { ModelHandlerOpenAIResponse } from './modelHandlerOpenAIResponse';
 import type { ResponseCreateParamsBase } from 'openai/resources/responses/responses';
 
 const CHANNEL = 'ModelHandlerCodex';
+const log = createLog(CHANNEL);
 
 function requestUrl(input: RequestInfo | URL): string {
   if (typeof input === 'string') return input;
@@ -185,10 +186,7 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
     } catch (error) {
       // Body is not JSON we can edit; the backend will reject it because the
       // required stream and instruction fields could not be installed.
-      logger.warn(
-        CHANNEL,
-        `Could not adapt Codex request body: ${toErrorMessage(error)}`,
-      );
+      log.warn(`Could not adapt Codex request body: ${toErrorMessage(error)}`);
     }
 
     return this.longRunningModelFetch(input, init);

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -16,12 +16,14 @@ import { extractToolNames } from '@agent/index/agentYamlScanner';
 import { resolveAgentSettingTools } from '@agent/runtime/agentSettingTools';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { parseYamlWith } from '@common/parsing/safeParseYaml';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { ensureError } from '@utils/errors/errorMessage';
 
 import { fetchRemoteAgentConfigYaml } from './remoteAgentConfigClient';
 import { CHANNEL } from './remoteAgentList';
 import type { RemoteAgentConfig } from './types';
+
+const log = createLog(CHANNEL);
 
 /** Load a remote agent configuration by name. */
 export async function loadRemoteAgent(
@@ -33,7 +35,7 @@ export async function loadRemoteAgent(
     );
   }
 
-  logger.info(CHANNEL, `Loading remote agent: ${agentName}`);
+  log.info(`Loading remote agent: ${agentName}`);
 
   try {
     const token = await SupabaseClient.getAccessToken();
@@ -45,7 +47,7 @@ export async function loadRemoteAgent(
 
     const configYaml = await fetchRemoteAgentConfigYaml(agentName, token);
 
-    logger.debug(CHANNEL, `Parsing YAML for remote agent: ${agentName}`);
+    log.debug(`Parsing YAML for remote agent: ${agentName}`);
     const parsedYaml = parseYamlWith(configYaml, AgentDefinitionSchema);
     if (parsedYaml.isErr()) {
       throw new Error(
@@ -76,13 +78,12 @@ export async function loadRemoteAgent(
         : undefined,
     });
 
-    logger.info(CHANNEL, `Successfully loaded remote agent: ${agentName}`);
+    log.info(`Successfully loaded remote agent: ${agentName}`);
 
     return config;
   } catch (error) {
     const lastError = ensureError(error);
-    logger.error(
-      CHANNEL,
+    log.error(
       `Failed to load remote agent "${agentName}": ${lastError.message}`,
     );
     throw lastError;

--- a/src/agent/remote/remoteAgentList.ts
+++ b/src/agent/remote/remoteAgentList.ts
@@ -17,7 +17,7 @@ import { z } from 'zod';
 import { SUPABASE_CONFIG } from '@auth/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { parseJsonWith } from '@common/parsing/safeParseJson';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { filterNotNull } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -25,6 +25,7 @@ import { errorDataToString, FETCH_TIMEOUT_MS } from './errorData';
 import { RemoteAgentListItemSchema, type RemoteAgentListItem } from './types';
 
 export const CHANNEL = 'RemoteAgentLoader';
+const log = createLog(CHANNEL);
 
 const REMOTE_AGENT_LIST_COLUMNS =
   'id, name, description, tools, agent_category';
@@ -63,8 +64,7 @@ function parseListItemRow(row: RemoteAgentListRow): RemoteAgentListItem | null {
   });
 
   if (!result.success) {
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Invalid metadata for agent "${row.name}": ${z.prettifyError(result.error)}`,
     );
     return null;
@@ -82,16 +82,13 @@ export async function listRemoteAgents(): Promise<RemoteAgentListItem[]> {
     const { data, error } = await fetchRemoteAgentListRows(token);
 
     if (error) {
-      logger.debug(CHANNEL, `Failed to list remote agents: ${error.message}`);
+      log.debug(`Failed to list remote agents: ${error.message}`);
       return [];
     }
 
     return (data ?? []).map(parseListItemRow).filter(filterNotNull);
   } catch (error) {
-    logger.debug(
-      CHANNEL,
-      `Error listing remote agents: ${toErrorMessage(error)}`,
-    );
+    log.debug(`Error listing remote agents: ${toErrorMessage(error)}`);
     return [];
   }
 }

--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -11,7 +11,7 @@
 // Third-party imports
 import simpleGit, { type SimpleGit } from 'simple-git';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { unique } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { makeMachineGitEnv } from '@utils/system/gitEnv';
@@ -19,6 +19,8 @@ import { splitOutputLines } from '@utils/text/stringUtils';
 
 // Local file imports
 import { normalizeReviewFilePath } from './reviewIssues';
+
+const log = createLog('reviewDiff');
 
 const GIT_TIMEOUT_MS = 30_000;
 
@@ -78,10 +80,7 @@ async function rawGit(sg: SimpleGit, args: string[]): Promise<string | null> {
   try {
     return await sg.raw(args);
   } catch (err) {
-    logger.debug(
-      'reviewDiff',
-      `git ${args.join(' ')} failed: ${toErrorMessage(err)}`,
-    );
+    log.debug(`git ${args.join(' ')} failed: ${toErrorMessage(err)}`);
     return null;
   }
 }

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -12,7 +12,7 @@
  */
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import {
   RUN_OUTCOME,
   type RunOutcome,
@@ -40,6 +40,8 @@ import type {
   StreamOptions,
   UsageEmitOptions,
 } from './AgentTrace';
+
+const log = createLog('TraceEmitter');
 
 export class TraceEmitter implements AgentTrace {
   private readonly subscribers = createListenerSet<AgentTraceSubscriber>();
@@ -87,8 +89,7 @@ export class TraceEmitter implements AgentTrace {
         // the quiet-degradation shape the guardrail forbids, and it matches the
         // sibling fan-out bus (`SessionEventHub.emit`). `AppSignals.emit`
         // deliberately re-throws instead — a different, documented contract.
-        logger.warn(
-          'TraceEmitter',
+        log.warn(
           `Trace subscriber threw while handling event: ${toErrorMessage(err)}`,
         );
       }

--- a/src/agent/types/ServerTools.ts
+++ b/src/agent/types/ServerTools.ts
@@ -10,7 +10,7 @@
 
 import { z } from 'zod';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { isObject, tryParseUrl } from '@utils/core';
 
 // SDK type imports - using native types for better type safety
@@ -28,6 +28,8 @@ import type {
   ResponseFunctionWebSearch,
   ResponseReasoningItem,
 } from 'openai/resources/responses/responses';
+
+const log = createLog('ServerTools');
 
 // ============================================================================
 // Web Search Result Schemas - Single Source of Truth
@@ -560,6 +562,6 @@ function extractDomain(url: string): string {
   if (parsed) return parsed.hostname;
   // Contract: return '' for unparseable URLs. Log so malformed source data
   // isn't silently rendered as an empty domain.
-  logger.debug('ServerTools', `extractDomain: unparseable URL "${url}"`);
+  log.debug(`extractDomain: unparseable URL "${url}"`);
   return '';
 }

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -4,7 +4,7 @@ import {
   User,
   type SupportedStorage,
 } from '@supabase/supabase-js';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 import {
   SUPABASE_GOTRUE_STORAGE_KEY,
@@ -23,6 +23,8 @@ import type {
   SessionTokens,
   StoredSessionState,
 } from './TokenProvider';
+
+const log = createLog('SupabaseClient');
 
 /**
  * GoTrue storage for the shared client.
@@ -71,8 +73,7 @@ function gotrueStorage(secrets: SessionSecretStore): SupportedStorage {
     try {
       return await run();
     } catch (error) {
-      logger.warn(
-        'SupabaseClient',
+      log.warn(
         `Could not ${action} PKCE flow state (${key}); sign-in will only be ` +
           `completable in this window: ${toErrorMessage(error)}`,
       );
@@ -175,10 +176,7 @@ export class SupabaseClient {
       return true;
     } catch (error) {
       this.readinessError = ensureError(error);
-      logger.error(
-        'SupabaseClient',
-        `Auth provider not ready: ${toErrorMessage(error)}`,
-      );
+      log.error(`Auth provider not ready: ${toErrorMessage(error)}`);
       return false;
     }
   }
@@ -251,10 +249,7 @@ export class SupabaseClient {
     try {
       return await this.authProvider.ensureFreshToken(forceRefresh);
     } catch (error) {
-      logger.error(
-        'SupabaseClient',
-        `Error getting access token: ${toErrorMessage(error)}`,
-      );
+      log.error(`Error getting access token: ${toErrorMessage(error)}`);
       return null;
     }
   }
@@ -299,10 +294,7 @@ export class SupabaseClient {
     try {
       return await this.authProvider.getSessionTokens();
     } catch (error) {
-      logger.error(
-        'SupabaseClient',
-        `Error getting session tokens: ${toErrorMessage(error)}`,
-      );
+      log.error(`Error getting session tokens: ${toErrorMessage(error)}`);
       return null;
     }
   }
@@ -319,10 +311,7 @@ export class SupabaseClient {
       if (error || !data.user) return null;
       return data.user;
     } catch (error) {
-      logger.error(
-        'SupabaseClient',
-        `Error getting user: ${toErrorMessage(error)}`,
-      );
+      log.error(`Error getting user: ${toErrorMessage(error)}`);
       return null;
     }
   }
@@ -375,10 +364,7 @@ export class SupabaseClient {
         .single();
 
       if (error || !data) {
-        logger.error(
-          'SupabaseClient',
-          `Error fetching profile: ${error?.message || 'No data'}`,
-        );
+        log.error(`Error fetching profile: ${error?.message || 'No data'}`);
         return defaultTier;
       }
 
@@ -387,10 +373,7 @@ export class SupabaseClient {
       // it before conservatively returning the default tier.
       return UserTierSchema.parse(data.tier ?? defaultTier);
     } catch (error) {
-      logger.error(
-        'SupabaseClient',
-        `Error getting user tier: ${toErrorMessage(error)}`,
-      );
+      log.error(`Error getting user tier: ${toErrorMessage(error)}`);
       return defaultTier;
     }
   }
@@ -452,10 +435,7 @@ export class SupabaseClient {
     } catch (error) {
       // Callers render "N/A" for null, so a failed read would otherwise be
       // indistinguishable from "no session stored".
-      logger.warn(
-        'SupabaseClient',
-        `Error reading stored account label: ${toErrorMessage(error)}`,
-      );
+      log.warn(`Error reading stored account label: ${toErrorMessage(error)}`);
       return null;
     }
   }

--- a/src/auth/oauth/SubscriptionOAuthCoordinator.ts
+++ b/src/auth/oauth/SubscriptionOAuthCoordinator.ts
@@ -11,7 +11,7 @@ import PQueue from 'p-queue';
 
 // Local imports
 import { safeParseJson } from '@common/parsing/safeParseJson';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { generateOAuthState, generatePkcePair } from './pkce';
@@ -21,6 +21,8 @@ import {
 } from './providerAuthBridge';
 import { SubscriptionOAuthError } from './subscriptionOAuthError';
 import type { z } from 'zod';
+
+const log = createLog('SubscriptionOAuth');
 
 /** Secret-backed persistence for one session bundle. */
 export interface SubscriptionSessionStorage {
@@ -145,16 +147,14 @@ export class SubscriptionOAuthCoordinator<S extends SubscriptionSession> {
     const parsedJson = safeParseJson(raw);
     if (parsedJson.isErr()) {
       // Present-but-corrupt is not the same as never signed in.
-      logger.warn(
-        'SubscriptionOAuth',
+      log.warn(
         `Stored subscription session is not valid JSON; treating as signed out: ${toErrorMessage(parsedJson.error)}`,
       );
       return null;
     }
     const parsed = this.policy.sessionSchema.safeParse(parsedJson.value);
     if (!parsed.success) {
-      logger.warn(
-        'SubscriptionOAuth',
+      log.warn(
         `Stored subscription session failed schema validation; treating as signed out: ${toErrorMessage(parsed.error)}`,
       );
       return null;

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -2,7 +2,7 @@
 import path from 'node:path';
 
 // Local imports
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type {
   AcceptCopyMeta,
   OutputFileInfo,
@@ -12,6 +12,8 @@ import type {
 import { ensureRunDir, findRunDir, getRunDir } from '@utils/files/runStorageFs';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { StreamOutputsSource } from './streamOutputs';
+
+const log = createLog('ProgressWorkflowFileActions');
 
 interface ProgressWorkflowFileActionsState extends StreamOutputsSource {
   getActiveStream(): StreamTabId | '';
@@ -122,11 +124,9 @@ export class ProgressWorkflowFileActionsController {
       try {
         currentContent = await this.deps.host.readFile(file);
       } catch (error) {
-        logger.debug(
-          'ProgressWorkflowFileActions',
-          `Could not read current content of ${file} before accept`,
-          { data: error },
-        );
+        log.debug(`Could not read current content of ${file} before accept`, {
+          data: error,
+        });
       }
     }
 

--- a/src/housekeeping/packLatexdiffvc.ts
+++ b/src/housekeeping/packLatexdiffvc.ts
@@ -1,10 +1,12 @@
 import * as path from 'node:path';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 
 import { CHANNEL, TEMP_EXTENSIONS } from './constants';
 import { collectFilesFromPatterns, generateTimestamp } from './utils';
+
+const log = createLog(CHANNEL);
 
 export type LatexdiffPackResult =
   | {
@@ -45,7 +47,7 @@ export async function runPackLatexdiffvc(
   );
 
   if (mainFiles.size === 0 && tempFiles.size === 0) {
-    logger.warn(CHANNEL, 'No LaTeX diff files found to process');
+    log.warn('No LaTeX diff files found to process');
     return { status: 'no-files', inputFile };
   }
 
@@ -53,7 +55,7 @@ export async function runPackLatexdiffvc(
     for (const file of [...mainFiles, ...tempFiles]) {
       await WorkspaceFS.delete(file);
     }
-    logger.info(CHANNEL, 'Cleanup complete.');
+    log.info('Cleanup complete.');
     return { status: 'cleaned', inputFile };
   }
 
@@ -79,7 +81,7 @@ export async function runPackLatexdiffvc(
   }
 
   if (mainFiles.size > 0) {
-    logger.info(CHANNEL, `Files packed into ${outputFolder}`);
+    log.info(`Files packed into ${outputFolder}`);
     return { status: 'packed', inputFile, outputFolder };
   }
 

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -6,7 +6,7 @@ import { globIterate } from 'glob';
 
 // Local imports
 import { buildBetweenRoundDiffSuffix } from '@latex/latexdiff/diffFileNameManager';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import {
   workflowOutputCopyStem,
   midEraWorkflowOutputStem,
@@ -16,6 +16,8 @@ import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { getConfig } from '@utils/config/configUtils';
 
 import { CHANNEL, DEFAULT_MAX_ROUNDS } from './constants';
+
+const log = createLog(CHANNEL);
 
 /**
  * Produce an ISO-8601 timestamp stripped of separators, suitable for use in
@@ -119,8 +121,7 @@ export function resolveHousekeepingTargets(
   agent: string,
 ): HousekeepingTargets | null {
   if (!inputFile || !model || !agent) {
-    logger.error(
-      CHANNEL,
+    log.error(
       `Missing required parameters: model=${model}, inputFile=${inputFile}, agent=${agent}`,
     );
     return null;
@@ -128,16 +129,13 @@ export function resolveHousekeepingTargets(
 
   const baseName = path.parse(inputFile).name;
   const inputDir = path.dirname(inputFile);
-  logger.debug(
-    CHANNEL,
-    `Parsed paths: baseName=${baseName}, inputDir=${inputDir}`,
-  );
+  log.debug(`Parsed paths: baseName=${baseName}, inputDir=${inputDir}`);
 
   const maxRounds = getConfig<number>('texra.agent.rounds', DEFAULT_MAX_ROUNDS);
   // Pass the raw agent; getFilePatterns derives both the legacy chunk and
   // the new clean-agent forms internally so both disk layouts are matched.
   const filePatterns = getFilePatterns(baseName, model, agent, maxRounds);
-  logger.debug(CHANNEL, `Generated patterns: ${filePatterns}`);
+  log.debug(`Generated patterns: ${filePatterns}`);
 
   return { baseName, inputDir, filePatterns };
 }
@@ -154,8 +152,7 @@ export async function* findFilesFromPatterns(
   patterns: string[],
   extensions: string[],
 ): AsyncGenerator<string, void, void> {
-  logger.debug(
-    CHANNEL,
+  log.debug(
     `Finding files in ${inputDir} using patterns ${patterns} and extensions ${extensions}`,
   );
 
@@ -179,7 +176,7 @@ export async function* findFilesFromPatterns(
           { nodir: true },
         )) {
           const relativePath = WorkspaceFS.relativePath(match);
-          logger.debug(CHANNEL, `Found file: ${relativePath}`);
+          log.debug(`Found file: ${relativePath}`);
           yield relativePath;
 
           if (!isGlob) {

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -2,7 +2,7 @@
 import * as path from 'node:path';
 
 // Local imports - log
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
 import { renderPrompt } from '@utils/prompt';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
@@ -12,6 +12,8 @@ import { getConfig } from '@utils/config/configUtils';
 // Local imports - latex utils
 import { compileLatex2Pdf } from './texTools';
 import { LATEX_COMMANDS_CHANNEL as CHANNEL } from './latexLogging';
+
+const log = createLog(CHANNEL);
 
 /**
  * Get the TikZ template from configuration or use default
@@ -58,10 +60,7 @@ async function createStandalone(
   const texLocation = pathToLocation(path.join(buildDir, filename));
 
   await AbsoluteFS.write(texLocation.absolutePath, standaloneContent);
-  logger.debug(
-    CHANNEL,
-    `Created standalone LaTeX file: ${texLocation.absolutePath}`,
-  );
+  log.debug(`Created standalone LaTeX file: ${texLocation.absolutePath}`);
 
   return texLocation;
 }
@@ -104,7 +103,7 @@ export const TikzPictureManager = {
 
       if (tikzMatches.length > 0) {
         labeledTikzPictures.push([label, tikzMatches]);
-        logger.debug(CHANNEL, `Found TikZ picture with label: ${label}`);
+        log.debug(`Found TikZ picture with label: ${label}`);
       }
     }
 
@@ -126,15 +125,9 @@ export const TikzPictureManager = {
 
     await AbsoluteFS.ensureDir(buildDir);
 
-    logger.debug(
-      CHANNEL,
-      `Extracting TikZ pictures from ${latexFile.absolutePath}`,
-    );
+    log.debug(`Extracting TikZ pictures from ${latexFile.absolutePath}`);
     const labeledTikzPictures = await this.extract(latexFile);
-    logger.debug(
-      CHANNEL,
-      `Found ${labeledTikzPictures.length} labeled TikZ pictures`,
-    );
+    log.debug(`Found ${labeledTikzPictures.length} labeled TikZ pictures`);
 
     const compiledFiles: FileLocation[] = [];
 
@@ -156,8 +149,7 @@ export const TikzPictureManager = {
           compiler: 'pdflatex',
         });
         if (!compiled.ok) {
-          logger.warn(
-            CHANNEL,
+          log.warn(
             `Failed to compile TikZ picture ${texLocation.absolutePath}:\n${compiled.logTail}`,
             {
               data: {
@@ -175,10 +167,7 @@ export const TikzPictureManager = {
 
         if (await AbsoluteFS.exists(pdfLocation.absolutePath)) {
           compiledFiles.push(pdfLocation);
-          logger.debug(
-            CHANNEL,
-            `Successfully compiled: ${pdfLocation.absolutePath}`,
-          );
+          log.debug(`Successfully compiled: ${pdfLocation.absolutePath}`);
         }
       }
     }

--- a/src/latex/formatter/indentDirectory.ts
+++ b/src/latex/formatter/indentDirectory.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { EXCLUDED_DIRS } from '@shared/constants/latexTiming';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
@@ -11,6 +11,8 @@ import { hasExtension } from '@utils/core/pathCore';
 
 import { resolveLatexFormatter } from './texFormatter';
 import { LATEX_COMMANDS_CHANNEL as CHANNEL } from '../latexLogging';
+
+const log = createLog(CHANNEL);
 
 export type IndentLatexResult =
   | {
@@ -46,22 +48,19 @@ export async function indentLatexFilesInDirectory(
   directory: string = '.',
   progressCallback?: (message: string, increment?: number) => void,
 ): Promise<IndentLatexResult> {
-  logger.debug(
-    CHANNEL,
-    `Starting LaTeX indentation process for directory: ${directory}`,
-  );
+  log.debug(`Starting LaTeX indentation process for directory: ${directory}`);
 
   const formatter = resolveLatexFormatter();
   if (!formatter) {
-    logger.debug(CHANNEL, 'LaTeX formatter disabled; skipping indentation');
+    log.debug('LaTeX formatter disabled; skipping indentation');
     return { status: 'disabled', directory, count: 0 };
   }
   const { id, configKey, run: runFormatter } = formatter;
   const config = getConfig<string>(configKey, '');
-  logger.debug(CHANNEL, `Formatter: ${id}, Config: ${config}`);
+  log.debug(`Formatter: ${id}, Config: ${config}`);
 
   if (config && !(await AbsoluteFS.exists(config))) {
-    logger.error(CHANNEL, `Formatter config file not found at ${config}`);
+    log.error(`Formatter config file not found at ${config}`);
     return {
       status: 'missing-config',
       directory,
@@ -96,20 +95,17 @@ export async function indentLatexFilesInDirectory(
       }
 
       progressCallback?.(`Indenting ${path.basename(fullPath)}...`, 0);
-      logger.debug(CHANNEL, `Processing file: ${fullPath}`);
+      log.debug(`Processing file: ${fullPath}`);
 
       try {
         if (await runFormatter(fullPath)) {
-          logger.info(CHANNEL, `Successfully formatted: ${fullPath}`);
+          log.info(`Successfully formatted: ${fullPath}`);
           indentedCount++;
         } else {
-          logger.error(CHANNEL, `Failed to format ${fullPath}`);
+          log.error(`Failed to format ${fullPath}`);
         }
       } catch (err) {
-        logger.error(
-          CHANNEL,
-          `Error formatting file ${fullPath}: ${toErrorMessage(err)}`,
-        );
+        log.error(`Error formatting file ${fullPath}: ${toErrorMessage(err)}`);
       }
     }
   }
@@ -117,16 +113,10 @@ export async function indentLatexFilesInDirectory(
   try {
     await walkDirectory(directory);
 
-    logger.info(
-      CHANNEL,
-      `${indentedCount} .tex files have been formatted in ${directory}`,
-    );
+    log.info(`${indentedCount} .tex files have been formatted in ${directory}`);
     return { status: 'formatted', directory, count: indentedCount };
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error during indentation process: ${toErrorMessage(err)}`,
-    );
+    log.error(`Error during indentation process: ${toErrorMessage(err)}`);
     return { status: 'error', directory, count: 0, error: err };
   }
 }

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import { sync as globSync } from 'glob';
 
 import { isFileNotFoundError } from '@common/errors';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { delay } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
@@ -11,6 +11,8 @@ import { runToolWithCheck } from '@utils/system/toolUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig } from '@utils/config/configUtils';
 import { LATEX_COMMANDS_CHANNEL as CHANNEL } from '../latexLogging';
+
+const log = createLog(CHANNEL);
 
 export const LATEXINDENT_CONFIG_KEY = 'texra.latex.latexindentConfig';
 
@@ -25,12 +27,12 @@ let missingLatexindentReported = false;
 async function cleanupIndentLog(logPath: string): Promise<void> {
   try {
     await AbsoluteFS.delete(logPath);
-    logger.debug(CHANNEL, `Removed ${logPath}`);
+    log.debug(`Removed ${logPath}`);
   } catch (err) {
     if (isFileNotFoundError(err)) {
-      logger.debug(CHANNEL, `No indent.log to remove at ${logPath}`);
+      log.debug(`No indent.log to remove at ${logPath}`);
     } else {
-      logger.warn(CHANNEL, `Error removing indent.log: ${toErrorMessage(err)}`);
+      log.warn(`Error removing indent.log: ${toErrorMessage(err)}`);
     }
   }
 }
@@ -52,11 +54,10 @@ async function cleanupBackupFiles(
   for (const backupFile of backupFiles) {
     try {
       await AbsoluteFS.delete(backupFile);
-      logger.debug(CHANNEL, `Removed backup file: ${backupFile}`);
+      log.debug(`Removed backup file: ${backupFile}`);
     } catch (err) {
       if (!isFileNotFoundError(err)) {
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Error removing backup file ${backupFile}: ${toErrorMessage(err)}`,
         );
       }
@@ -106,11 +107,11 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
     }
 
     if (success) {
-      logger.info(CHANNEL, `Indented ${absolutePath}`);
+      log.info(`Indented ${absolutePath}`);
     }
     return success;
   } catch (err) {
-    logger.error(CHANNEL, `Error running LaTeX indent: ${toErrorMessage(err)}`);
+    log.error(`Error running LaTeX indent: ${toErrorMessage(err)}`);
     return false;
   }
 }

--- a/src/latex/formatter/texfmt.ts
+++ b/src/latex/formatter/texfmt.ts
@@ -1,9 +1,11 @@
 // Local imports - log
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { runToolWithCheck } from '@utils/system/toolUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig } from '@utils/config/configUtils';
 import { LATEX_COMMANDS_CHANNEL as CHANNEL } from '../latexLogging';
+
+const log = createLog(CHANNEL);
 
 export const TEXFMT_CONFIG_KEY = 'texra.latex.texfmtConfig';
 
@@ -27,10 +29,10 @@ export async function runTexFmt(filePath: string): Promise<boolean> {
       return false;
     }
 
-    logger.info(CHANNEL, `Formatted ${filePath}`);
+    log.info(`Formatted ${filePath}`);
     return true;
   } catch (err) {
-    logger.error(CHANNEL, `Error running tex-fmt: ${toErrorMessage(err)}`);
+    log.error(`Error running tex-fmt: ${toErrorMessage(err)}`);
     return false;
   }
 }

--- a/src/latex/latexParsingUtils.ts
+++ b/src/latex/latexParsingUtils.ts
@@ -8,10 +8,12 @@
 
 import * as path from 'node:path';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
+
+const log = createLog('LatexParsing');
 
 /** Strips everything after an unescaped % on each line. */
 const COMMENT_PATTERN = /(^|[^\\])%.*$/gm;
@@ -38,8 +40,7 @@ export async function resolveLatexDir(absolutePath: string): Promise<string> {
   const resolved = await platform()
     .fs.realPath(absolutePath)
     .catch((error: unknown) => {
-      logger.debug(
-        'LatexParsing',
+      log.debug(
         `realPath failed for ${absolutePath}; falling back to literal dirname`,
         { data: error },
       );

--- a/src/platform/defaults/workspaceStorage.ts
+++ b/src/platform/defaults/workspaceStorage.ts
@@ -6,7 +6,7 @@ import {
   WORKSPACE_SIDECAR_FILE,
   WORKSPACE_STORAGE_LAYOUT,
 } from '@common/storage/storageLayout';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { truncatedHexId } from '@utils/core/idHash';
 import { isPathWithin } from '@utils/core/pathCore';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -14,6 +14,8 @@ import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
 
 // Local imports - platform
 import type { StorageProvider } from '../interfaces';
+
+const log = createLog('WorkspaceStorage');
 
 const STORAGE_LAYOUT = {
   global: 'global-storage',
@@ -157,8 +159,7 @@ function migrateLegacyWorkspaceStorage(
   try {
     renameSync(legacyPath, currentPath);
   } catch (error) {
-    logger.warn(
-      'WorkspaceStorage',
+    log.warn(
       `Could not migrate legacy workspace storage; continuing with the current storage directory. Cause: ${toErrorMessage(error)}`,
     );
   }

--- a/src/tools/delegation/DelegationTools.ts
+++ b/src/tools/delegation/DelegationTools.ts
@@ -24,7 +24,7 @@ import {
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { deliverChildRunFollowUp } from '@agent/followUp/childRunDelivery';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import {
   AgentCategory,
   DEFAULT_TOOL_CONFIG,
@@ -60,6 +60,7 @@ import {
 } from './inputFields';
 
 const LOG_CHANNEL = 'delegation';
+const log = createLog(LOG_CHANNEL);
 
 /**
  * Deliver a terminal error to the orchestrator when a resumed subagent's wake
@@ -76,8 +77,7 @@ async function deliverResumeWakeFailure(
   err: unknown,
   expectedGenerationId?: string,
 ): Promise<void> {
-  logger.warn(
-    LOG_CHANNEL,
+  log.warn(
     `Failed to wake resumed subagent '${executionId}': ${toErrorMessage(err)}`,
   );
   const msg = formatSubagentError(executionId, handle.agentName, err);
@@ -88,8 +88,7 @@ async function deliverResumeWakeFailure(
     ...(expectedGenerationId !== undefined ? { expectedGenerationId } : {}),
   });
   if (delivery.kind !== 'delivered') {
-    logger.warn(
-      LOG_CHANNEL,
+    log.warn(
       `Also failed to deliver the wake-failure error for '${executionId}' to the parent (${delivery.kind}).`,
     );
   }

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -9,7 +9,7 @@ import { AbortError } from 'p-retry';
 import { z } from 'zod';
 
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { ToolResult } from '@shared/schemas';
 import {
   isTimeoutError,
@@ -28,6 +28,7 @@ import {
 
 const LOOGLE_TIMEOUT_MS = 10_000; // 10 s
 const LOOGLE_CHANNEL = 'lean_loogle';
+const log = createLog(LOOGLE_CHANNEL);
 /** Retry transient Loogle failures (timeouts, 5xx, dropped connections). */
 const LOOGLE_RETRIES = 2;
 
@@ -174,8 +175,7 @@ Useful for finding the right lemma when you know roughly what type it should hav
         minTimeout: 1000,
         cancelSignal,
         onFailedAttempt: ({ error, retriesLeft }) => {
-          logger.debug(
-            LOOGLE_CHANNEL,
+          log.debug(
             `Loogle query "${query}" failed (${retriesLeft} retries left): ${toErrorMessage(error)}`,
           );
         },

--- a/src/tools/lean/direct/jsonRpc.ts
+++ b/src/tools/lean/direct/jsonRpc.ts
@@ -16,8 +16,10 @@ import {
   type MessageConnection,
 } from 'vscode-jsonrpc/node';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+
+const log = createLog('JsonRpcConnection');
 
 type NotificationHandler = (params: unknown) => void;
 type ServerRequestHandler = (params: unknown) => Promise<unknown>;
@@ -128,7 +130,7 @@ export class JsonRpcConnection {
 
   private logLiveError(context: string, err: unknown): void {
     if (this.disposed || !err) return;
-    logger.debug('JsonRpcConnection', `${context}: ${toErrorMessage(err)}`);
+    log.debug(`${context}: ${toErrorMessage(err)}`);
   }
 }
 

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -15,12 +15,14 @@
 
 // Local imports
 import { appSignals } from '@eventBus/AppSignals';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { tryGlobalState } from '@platform/platform';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import type { RegisteredToolName } from '@tools/registry';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
 import { getDisabledToolIds } from '@utils/config/constants';
+
+const log = createLog('toolAvailability');
 
 // ============================================================
 // Result type
@@ -86,8 +88,7 @@ export async function seedDisabledToolDefaults(
     (def) => def.id,
   );
   await state.update(GlobalStateKey.DISABLED_TOOLS, defaults);
-  logger.info(
-    'toolAvailability',
+  log.info(
     `First install: default-disabled toggleable tools: ${defaults.join(', ')}`,
   );
 }

--- a/src/utils/files/runStorageFs.ts
+++ b/src/utils/files/runStorageFs.ts
@@ -5,7 +5,7 @@ import { promises as fs } from 'node:fs';
 // Local imports
 import { isFileNotFoundError } from '@common/errors';
 import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import {
   resolveRunOriginalSnapshotPath,
   resolveRunStoragePath,
@@ -26,6 +26,7 @@ import { isDirectory, isFile, isSymlink } from './fsEntryType';
 import { StorageFS } from './storageFS';
 
 export const CHANNEL = 'taskRunStorage';
+const log = createLog(CHANNEL);
 
 export function getRunDir(id: ExecutionId): string {
   return StorageFS.fullPath(resolveRunStoragePath(id));
@@ -239,8 +240,7 @@ export async function createSymlink(
       return;
     }
     if (err.code && SYMLINK_UNSUPPORTED_CODES.has(err.code)) {
-      logger.warn(
-        CHANNEL,
+      log.warn(
         `Falling back to copy ${sourceAbsolute} -> ${destination} due to ${err.code}`,
       );
       const stats = await fs.lstat(sourceAbsolute);

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import { promises as fs } from 'node:fs';
 
 import { isFileNotFoundError } from '@common/errors';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { type ExecutionId, type FileLocation } from '@shared/schemas';
 import {
   WORKFLOW_OUTPUT_BASENAME,
@@ -28,6 +28,8 @@ import {
   snapshotExists,
 } from './runStorageFs';
 import { WorkspaceFS } from './workspaceFS';
+
+const log = createLog(CHANNEL);
 
 export class TaskRunFileService {
   public readonly runDirectory: string;
@@ -78,8 +80,7 @@ export class TaskRunFileService {
         try {
           await this.mirrorWorkspaceFile(candidate);
         } catch (error) {
-          logger.warn(
-            CHANNEL,
+          log.warn(
             `Failed to mirror workspace dependency ${candidate.absolutePath}: ${toErrorMessage(error)}`,
           );
         }
@@ -246,8 +247,7 @@ export class TaskRunFileService {
           depDir === '' &&
           depName === WORKFLOW_OUTPUT_BASENAME
         ) {
-          logger.debug(
-            CHANNEL,
+          log.debug(
             `Skipping run-dir mirror of ${relativePath}: would clobber primary output in ${relativeDirectory}`,
           );
           return;
@@ -273,8 +273,7 @@ export class TaskRunFileService {
           sourceAbsolute = snapshotAbsolute;
         } catch (error) {
           if (!isFileNotFoundError(error)) {
-            logger.debug(
-              CHANNEL,
+            log.debug(
               `Unable to stat snapshot ${snapshotAbsolute}: ${toErrorMessage(error)}`,
             );
           }
@@ -292,16 +291,14 @@ export class TaskRunFileService {
         try {
           const stat = await fs.lstat(destinationAbsolute);
           if (!stat.isSymbolicLink()) {
-            logger.debug(
-              CHANNEL,
+            log.debug(
               `Skipping run-dir mirror of ${relativePath}: destination in ${relativeDirectory} is an existing real file`,
             );
             return;
           }
         } catch (error) {
           if (!isFileNotFoundError(error)) {
-            logger.debug(
-              CHANNEL,
+            log.debug(
               `Unable to stat ${destinationAbsolute}: ${toErrorMessage(error)}`,
             );
           }
@@ -311,8 +308,7 @@ export class TaskRunFileService {
         try {
           await createSymlink(sourceAbsolute, destinationAbsolute);
         } catch (error) {
-          logger.debug(
-            CHANNEL,
+          log.debug(
             `Unable to mirror ${relativePath} into ${relativeDirectory}: ${toErrorMessage(error)}`,
           );
         }

--- a/src/utils/files/varsUtils.ts
+++ b/src/utils/files/varsUtils.ts
@@ -1,7 +1,9 @@
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 
 import { AbsoluteFS } from './absoluteFS';
 import { WorkspaceFS } from './workspaceFS';
+
+const log = createLog('VarsUtils');
 
 /**
  * Reads a file and populates user variable fields with its path and content.
@@ -21,11 +23,9 @@ export async function setVarFromFile(
     userVars[`${varName}_CONTENT`] = fileContent;
     return true;
   } catch (error) {
-    logger.debug(
-      'VarsUtils',
-      `Failed to read ${varName} from file ${filePath}`,
-      { data: error },
-    );
+    log.debug(`Failed to read ${varName} from file ${filePath}`, {
+      data: error,
+    });
     return false;
   }
 }

--- a/src/utils/media/img.ts
+++ b/src/utils/media/img.ts
@@ -7,7 +7,7 @@ import { imageSize } from 'image-size';
 import { fromPath } from 'pdf2pic';
 
 // Local imports - log
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { generateShortId } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { getMimeType } from '@utils/files/mimeUtils';
@@ -21,6 +21,7 @@ import { executeCommand } from '@utils/system/execUtils';
 import { countPdfPagesInBuffer } from './pdfPageCount';
 
 const CHANNEL = 'ImgUtils';
+const log = createLog(CHANNEL);
 
 /** DPI/density used when rasterizing a PDF page to PNG. */
 const PDF_RASTER_DENSITY = 300;
@@ -40,8 +41,7 @@ async function removeConversionTempDir(tempDir: string): Promise<void> {
   try {
     await AbsoluteFS.delete(tempDir, { recursive: true });
   } catch (err) {
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Failed to remove temporary directory ${tempDir}: ${toErrorMessage(err)}`,
     );
   }
@@ -102,8 +102,7 @@ async function resizeImageIfNeeded(imagePath: string): Promise<string> {
     throw new Error(result.stderr || 'Failed to resize image');
   }
 
-  logger.debug(
-    CHANNEL,
+  log.debug(
     `Resized image ${imagePath} (${width}x${height}) to fit within ${maxDimension}px`,
   );
   return tempPath;
@@ -134,15 +133,14 @@ export async function getBase64EncodedMedia(
       throw new Error(`File is empty: ${mediaPath}`);
     }
 
-    logger.debug(CHANNEL, `Successfully encoded image: ${mediaPath}`);
+    log.debug(`Successfully encoded image: ${mediaPath}`);
     return mediaBytes.toString('base64');
   } finally {
     if (tempPath) {
       try {
         AbsoluteFS.deleteSync(tempPath);
       } catch (err) {
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Failed to remove temporary file ${tempPath}: ${toErrorMessage(err)}`,
         );
       }
@@ -155,12 +153,12 @@ export async function countPdfPages(pdfPath: string): Promise<number> {
   try {
     const absolutePath = await resolveFile(pdfPath);
     if (!absolutePath) {
-      logger.debug(CHANNEL, `PDF file not found: ${pdfPath}`);
+      log.debug(`PDF file not found: ${pdfPath}`);
       return 0;
     }
     return await countPdfPagesInBuffer(AbsoluteFS.readBytesSync(absolutePath));
   } catch (err) {
-    logger.error(CHANNEL, `Error counting PDF pages: ${toErrorMessage(err)}`);
+    log.error(`Error counting PDF pages: ${toErrorMessage(err)}`);
     return 0;
   }
 }
@@ -195,10 +193,7 @@ async function singlePagePdf2Png(
   }
 
   const imageBuffer = AbsoluteFS.readBytesSync(result.path);
-  logger.debug(
-    CHANNEL,
-    `Successfully converted page ${pageNum} of ${absolutePath} to PNG`,
-  );
+  log.debug(`Successfully converted page ${pageNum} of ${absolutePath} to PNG`);
   return imageBuffer.toString('base64');
 }
 
@@ -212,7 +207,7 @@ export async function processPdf2Png(
   try {
     const absolutePath = await resolveFile(pdfPath);
     if (!absolutePath) {
-      logger.debug(CHANNEL, `PDF file not found: ${pdfPath}`);
+      log.debug(`PDF file not found: ${pdfPath}`);
       return null;
     }
 
@@ -238,8 +233,7 @@ export async function processPdf2Png(
           await singlePagePdf2Png(absolutePath, pageNum, tempDir),
         );
       }
-      logger.debug(
-        CHANNEL,
+      log.debug(
         `Successfully converted ${base64Images.length} pages from ${pdfPath}`,
       );
       return base64Images;
@@ -247,7 +241,7 @@ export async function processPdf2Png(
       await removeConversionTempDir(tempDir);
     }
   } catch (err) {
-    logger.error(CHANNEL, `Error processing PDF input: ${toErrorMessage(err)}`);
+    log.error(`Error processing PDF input: ${toErrorMessage(err)}`);
     return null;
   }
 }


### PR DESCRIPTION
## Summary

Collision-free mechanical subset of #10013. Re-audited every non-test
`import * as logger` under `src/` and all open PR diffs, then converted the
25 modules whose channel is a single module-local constant (or a single
literal) to `const log = createLog(channel)` plus `log.debug/info/warn/error`.
No dynamic-channel module was touched, no #10475/#10608/#10609-overlapping
file was modified, and the four special/manual sites were left alone.

Each converted module funnels through `createLog` → `loggerSelf` →
`debug/info/warn/error` → the shared `writeLine` sink, so the module-namespace
spy seam (`vi.spyOn(logger, 'warn')`) still intercepts calls made by these
module-level `log.*` bindings.

## Converted to `createLog` (25 files)

- `src/agent/modelHandlers/openai/modelHandlerCodex.ts`
- `src/agent/remote/remoteAgentList.ts` (kept `export const CHANNEL`)
- `src/agent/remote/RemoteAgentLoader.ts`
- `src/agent/review/reviewDiff.ts`
- `src/agent/trace/TraceEmitter.ts`
- `src/agent/types/ServerTools.ts`
- `src/auth/oauth/SubscriptionOAuthCoordinator.ts`
- `src/auth/SupabaseClient.ts`
- `src/controllers/progressView/ProgressWorkflowFileActionsController.ts`
- `src/housekeeping/packLatexdiffvc.ts`
- `src/housekeeping/utils.ts`
- `src/latex/formatter/indentDirectory.ts`
- `src/latex/formatter/latexindentpt.ts`
- `src/latex/formatter/texfmt.ts`
- `src/latex/latexParsingUtils.ts`
- `src/latex/TikzPictureManager.ts`
- `src/platform/defaults/workspaceStorage.ts`
- `src/tools/delegation/DelegationTools.ts`
- `src/tools/lean/direct/jsonRpc.ts`
- `src/tools/lean/LoogleTool.ts`
- `src/tools/toolAvailability.ts`
- `src/utils/files/runStorageFs.ts` (kept `export const CHANNEL`)
- `src/utils/files/taskRunStorage.ts`
- `src/utils/files/varsUtils.ts`
- `src/utils/media/img.ts`

## Exact remaining `import * as logger` modules (non-test, `src/`) — 23

**#10475 overlap (6):**
- `src/agent/goal/promptLoader.ts`
- `src/agent/runtime/agentSettingTools.ts`
- `src/tools/delegation/inBandSubagentExecution.ts`
- `src/tools/delegation/subagentDeliveryFormat.ts`
- `src/tools/delegation/subagentDiffs.ts`
- `src/tools/delegation/workflowScriptStrategy.ts`

**Special / manual (3, beyond the #10475-listed one):**
- `src/agent/index/platformAgentDirectories.ts`
- `src/agent/runtime/textConnection.ts`
- `src/auth/serverKeys/index.ts`

**Dynamic channel (8) — channel threaded as a value, not mechanical:**
- `src/auth/oauth/sessionAccess.ts`
- `src/latex/arxivProcessor.ts`
- `src/latex/latexdiff.ts`
- `src/latex/latexdiff/diffOperations.ts`
- `src/latex/latexdiff/outputDiscovery.ts`
- `src/latex/latexdiff/runLatexdiff.ts`
- `src/latex/texcount.ts`
- `src/latex/texTools.ts`

**Open-PR collision (6):**
- `src/tools/claudeAgentConfig.ts` — #10608
- `src/housekeeping/clean.ts` — #10609
- `src/housekeeping/pack.ts` — #10609
- `src/housekeeping/runDirOps.ts` — #10609
- `src/latex/latexdiff/diffCommandExecutor.ts` — #10609
- `src/utils/system/execUtils.ts` — #10609

## Net elements (R6)

- Diffstat: **25 files, 153 insertions, 200 deletions; net −47 lines**.
- `import * as logger` non-test modules under `src/`: **48 → 23**.
- Converted to `createLog`: **25**.
- `createLog` module-level call sites under `src/` (non-test, excluding `logUtils.ts`): **60 → 85**.
- Exported symbols/classes/interfaces/enums added: **0**.

## Consumer counts (R8)

No event or emit path is added or rerouted. Each converted module keeps its
existing module-local consumers and the shared `writeLine` sink; the two
`export const CHANNEL` bindings (`remoteAgentList.ts`, `runStorageFs.ts`) are
unchanged and remain consumed by `RemoteAgentLoader.ts` / `taskRunStorage.ts`
respectively. No wrappers were added — `createLog`'s `loggerSelf` delegation is
the spy seam.

## Validation

- Focused Vitest: **21 files / 190 tests passed** (incl. `SupabaseClient.vitest.ts`
  and `AgentRegistry.vitest.ts`, which spy on `logger.warn`/`logger.error`).
- Architecture suites: **17 files / 98 tests passed**.
- Typechecks: workspace, test-kernel, CLI, desktop, trace-viewer, and agent all passed.
- ESLint and Prettier clean on changed files.
- Dead-code ratchet, guidance-refs, and browser-safe-utils gates passed.
- `git diff --check` clean.

Refs #10013

