### PR TITLE
refactor(logger): migrate 8 dynamic-channel modules to createLog

### DIFF
--- a/src/auth/oauth/sessionAccess.ts
+++ b/src/auth/oauth/sessionAccess.ts
@@ -5,7 +5,7 @@
  * here (with the status + routability probes) so a provider does not re-copy
  * the platform dance.
  */
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { tryPlatform } from '@platform/platform';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -77,11 +77,11 @@ export async function getSubscriptionSessionStatus(
   displayName: string,
 ): Promise<SubscriptionSessionStatus> {
   if (!tryPlatform()) return { signedIn: false };
+  const log = createLog(channel);
   try {
     return await getCoordinator().getStatus();
   } catch (error) {
-    logger.warn(
-      channel,
+    log.warn(
       `Failed to read ${displayName} session status: ${toErrorMessage(error)}`,
     );
     return { signedIn: false };

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -9,7 +9,7 @@ import pRetry, { AbortError } from 'p-retry';
 import pTimeout from 'p-timeout';
 import * as tar from 'tar';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { isTransientHttpStatus } from '@utils/core/httpStatus';
@@ -64,6 +64,10 @@ class ArxivSourceProcessor {
   // channel name — a class-identifier rename must not change this value.
   private readonly channel = 'arxivProcessor';
 
+  private get log() {
+    return createLog(this.channel);
+  }
+
   /** Best-effort delete that logs failures at debug level instead of throwing. */
   private async cleanUpBestEffort(
     target: string,
@@ -71,13 +75,9 @@ class ArxivSourceProcessor {
     options?: { recursive?: boolean },
   ): Promise<void> {
     await AbsoluteFS.delete(target, options).catch((error: unknown) => {
-      logger.debug(
-        this.channel,
-        `Failed to clean up ${description} ${target}`,
-        {
-          data: error,
-        },
-      );
+      this.log.debug(`Failed to clean up ${description} ${target}`, {
+        data: error,
+      });
     });
   }
 
@@ -147,8 +147,7 @@ class ArxivSourceProcessor {
       // Jitter the backoff so concurrent clients don't retry in lockstep.
       randomize: true,
       onFailedAttempt: ({ error, retriesLeft }) => {
-        logger.debug(
-          this.channel,
+        this.log.debug(
           `Download attempt failed (${retriesLeft} retries left): ${toErrorMessage(error)}`,
         );
       },
@@ -190,8 +189,7 @@ class ArxivSourceProcessor {
           filename = parseContentDisposition(disposition).parameters.filename;
         } catch (error) {
           // Malformed header; the content-type fallback below handles it.
-          logger.debug(
-            this.channel,
+          this.log.debug(
             'Ignoring malformed Content-Disposition header from arXiv source download',
             {
               data: {
@@ -239,7 +237,8 @@ class ArxivSourceProcessor {
     options: ExtractOptions = {},
   ): Promise<ExtractResult> {
     const channel = options.channel ?? this.channel;
-    logger.debug(channel, `Extracting tar file: ${tarPath} to ${destDir}`);
+    const log = createLog(channel);
+    log.debug(`Extracting tar file: ${tarPath} to ${destDir}`);
 
     try {
       const extraction = tar.x({ file: tarPath, cwd: destDir });
@@ -254,7 +253,7 @@ class ArxivSourceProcessor {
       return { success: true };
     } catch (err) {
       const errorMsg = toErrorMessage(err);
-      logger.error(channel, `Failed to extract tar file: ${errorMsg}`);
+      log.error(`Failed to extract tar file: ${errorMsg}`);
       return { success: false, error: errorMsg };
     }
   }
@@ -275,7 +274,7 @@ class ArxivSourceProcessor {
       throw new Error(INVALID_ARXIV_INPUT_ERROR);
     }
 
-    logger.info(this.channel, `Downloading arXiv source for ID: ${id}`);
+    this.log.info(`Downloading arXiv source for ID: ${id}`);
 
     if (!WorkspaceFS.getPath()) {
       throw new Error('No workspace folder is open');
@@ -316,7 +315,7 @@ class ArxivSourceProcessor {
 
     progressCallback?.('arXiv source downloaded successfully!', 100);
 
-    logger.info(this.channel, `arXiv source downloaded to: ${paperDirFull}`);
+    this.log.info(`arXiv source downloaded to: ${paperDirFull}`);
 
     return { path: paperDirFull, alreadyExisted: !needsDownload };
   }
@@ -337,10 +336,7 @@ class ArxivSourceProcessor {
     const entries = await WorkspaceFS.readDir(paperDirRelative);
     const hasTexFiles = entries.some(([name]) => hasExtension(name, '.tex'));
     if (hasTexFiles) {
-      logger.info(
-        this.channel,
-        `arXiv source already exists at: ${paperDirFull}`,
-      );
+      this.log.info(`arXiv source already exists at: ${paperDirFull}`);
     }
     return hasTexFiles;
   }

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 
 import { formatError } from '@common/errors';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
@@ -32,6 +32,10 @@ export class LaTeXdiffService {
   private readonly fileProcessor: DiffFileProcessor;
   private readonly commandExecutor: DiffCommandExecutor;
 
+  private get log() {
+    return createLog(this.channel);
+  }
+
   constructor(private readonly channel: string) {
     this.fileProcessor = new DiffFileProcessor();
     // Pass a thunk so DiffCommandExecutor reads the current workspace value
@@ -60,7 +64,7 @@ export class LaTeXdiffService {
 
   private logDiffError(context: string, err: unknown): LaTeXdiffResult {
     const message = formatError(context, err);
-    logger.error(this.channel, message);
+    this.log.error(message);
     return { success: false, message };
   }
 
@@ -91,7 +95,7 @@ export class LaTeXdiffService {
       const editedFile = editedLocation.absolutePath;
 
       if (!inputFile) {
-        logger.warn(this.channel, 'Input file is empty or undefined');
+        this.log.warn('Input file is empty or undefined');
         return { success: false, message: 'Input file is empty or undefined' };
       }
 
@@ -101,7 +105,7 @@ export class LaTeXdiffService {
       const contents = await this.readDiffInputs(inputLocation, editedLocation);
       if (!contents) {
         const message = `One or both files do not exist. Input: ${inputFile}, Edited: ${editedFile}`;
-        logger.warn(this.channel, message);
+        this.log.warn(message);
         return { success: false, message };
       }
       if (!contents.every(hasDocumentEnvironment)) {
@@ -116,8 +120,7 @@ export class LaTeXdiffService {
         options?.outputDirectory ?? path.dirname(inputFile);
       const outputPath = path.join(outputDirectory, diffFileName);
 
-      logger.debug(
-        this.channel,
+      this.log.debug(
         `Running latexdiff for ${inputLocation.absolutePath} and ${editedLocation.absolutePath}`,
       );
 
@@ -137,8 +140,7 @@ export class LaTeXdiffService {
       await AbsoluteFS.write(outputLocation.absolutePath, result.stdout);
       await this.fileProcessor.processDiffFile(outputLocation, editedLocation);
 
-      logger.debug(
-        this.channel,
+      this.log.debug(
         `Latexdiff succeeded: ${inputLocation.absolutePath} -> ${editedLocation.absolutePath}`,
       );
 
@@ -148,8 +150,7 @@ export class LaTeXdiffService {
         message: `LaTeXdiff completed successfully: ${diffFileName}`,
       };
     } catch (err) {
-      logger.debug(
-        this.channel,
+      this.log.debug(
         `Latexdiff failed: ${inputLocation.absolutePath} -> ${editedLocation.absolutePath}`,
       );
       return this.logDiffError('Error running LaTeX diff', err);
@@ -166,7 +167,7 @@ export class LaTeXdiffService {
       if (!(await this.validateDocumentStructure(inputLocation))) {
         const message =
           'File missing document environment (must contain \\begin{document} and \\end{document})';
-        logger.error(this.channel, message);
+        this.log.error(message);
         return { success: false, message };
       }
 
@@ -215,7 +216,7 @@ export class LaTeXdiffService {
     try {
       if (!(await this.bothFilesExist(baseLocation, outputLocation))) {
         const message = `Could not generate latexdiff for round ${round}. Files not found: ${baseLocation.absolutePath} or ${outputLocation.absolutePath}`;
-        logger.warn(this.channel, message);
+        this.log.warn(message);
         return { success: false, message };
       }
 
@@ -242,7 +243,7 @@ export class LaTeXdiffService {
     try {
       if (!(await this.bothFilesExist(firstLocation, secondLocation))) {
         const message = `Could not generate latexdiff between rounds. Files not found: ${firstLocation.absolutePath} or ${secondLocation.absolutePath}`;
-        logger.warn(this.channel, message);
+        this.log.warn(message);
         return { success: false, message };
       }
 

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -8,7 +8,7 @@ import * as path from 'node:path';
 
 // Local imports
 import type { MathMarkupOption } from '@latex/latexdiff/mathMarkup';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import {
   getEffectiveDiffBase,
@@ -50,6 +50,7 @@ async function executeDiffOperations(
 ): Promise<DiffRunOutcome> {
   const results: DiffRunResult[] = [...immediateResults];
   const incrementPct = operations.length > 0 ? 100 / operations.length : 0;
+  const log = createLog(latexdiff.channel);
 
   for (const operation of operations) {
     progress.report({
@@ -71,10 +72,7 @@ async function executeDiffOperations(
       continue;
     }
 
-    logger.debug(
-      latexdiff.channel,
-      `Running ${operation.type} diff: ${operation.description}`,
-    );
+    log.debug(`Running ${operation.type} diff: ${operation.description}`);
 
     const diffResult =
       operation.type === 'round'
@@ -205,6 +203,7 @@ export async function runLatexdiffViaWorkspaceScan(params: {
     latexdiff,
     progress,
   } = params;
+  const log = createLog(latexdiff.channel);
 
   const workspacePath = WorkspaceFS.getPath();
   if (!workspacePath) {
@@ -218,10 +217,7 @@ export async function runLatexdiffViaWorkspaceScan(params: {
   const configuredInputFiles =
     outputFiles && outputFiles.length > 0 ? outputFiles : [inputFile];
 
-  logger.debug(
-    latexdiff.channel,
-    `Input files: ${configuredInputFiles.join(', ')}`,
-  );
+  log.debug(`Input files: ${configuredInputFiles.join(', ')}`);
 
   // Per input file: round number → workspace-relative output path. A round
   // matched more than once (e.g. two legacy files matching the same round
@@ -287,10 +283,7 @@ export async function runLatexdiffViaWorkspaceScan(params: {
       } catch (error) {
         // Skip unreadable round dirs but record which one so a missing
         // round output isn't silently invisible during diagnosis.
-        logger.debug(
-          latexdiff.channel,
-          `Skipping round dir '${roundAbsoluteDir}': ${error}`,
-        );
+        log.debug(`Skipping round dir '${roundAbsoluteDir}': ${error}`);
         continue;
       }
       const match = roundEntries.find(
@@ -314,15 +307,11 @@ export async function runLatexdiffViaWorkspaceScan(params: {
 
     if (roundOutputs.size > 0) {
       inputToOutputsMap.set(candidateInput, roundOutputs);
-      logger.debug(
-        latexdiff.channel,
+      log.debug(
         `Found ${roundOutputs.size} matching outputs for ${candidateInput}`,
       );
     } else {
-      logger.debug(
-        latexdiff.channel,
-        `No matching outputs found for ${candidateInput}`,
-      );
+      log.debug(`No matching outputs found for ${candidateInput}`);
     }
   }
 

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -9,7 +9,7 @@ import * as path from 'node:path';
 
 // Local imports
 import { isFileNotFoundError } from '@common/errors';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import {
   type ExecutionId,
@@ -47,6 +47,7 @@ async function collectTexFiles(
   prefix = '',
 ): Promise<string[]> {
   const fs = platform().fs;
+  const log = createLog(channel);
   let entries: [string, number][];
   try {
     entries = await fs.readDirectory(dir);
@@ -54,7 +55,7 @@ async function collectTexFiles(
     // This is a recovery scan: a missing/unreadable subtree means this subtree
     // contributes no outputs, but other rounds/subtrees may still be useful.
     if (isFileNotFoundError(error)) return [];
-    logger.warn(channel, `Skipping unreadable directory '${dir}': ${error}`);
+    log.warn(`Skipping unreadable directory '${dir}': ${error}`);
     return [];
   }
   const results: string[] = [];
@@ -89,6 +90,7 @@ export async function scanRunDirForOutputs(
   extraBaseFiles: string[] | undefined,
   channel: string,
 ): Promise<RoundIndexed<OutputFileInfo> | null> {
+  const log = createLog(channel);
   try {
     const runDirAbsolute = await findRunDir(executionId);
     if (!runDirAbsolute) return null;
@@ -189,8 +191,7 @@ export async function scanRunDirForOutputs(
 
     return Object.keys(rounds).length > 0 ? rounds : null;
   } catch (error) {
-    logger.debug(
-      channel,
+    log.debug(
       `RunDir scan for ${executionId} failed: ${toErrorMessage(error)}`,
     );
     return null;
@@ -215,6 +216,7 @@ export async function discoverLatestExecutionOutputs(
   executionId: ExecutionId;
   rounds: RoundIndexed<OutputFileInfo>;
 } | null> {
+  const log = createLog(channel);
   try {
     const executions = await discovery.listAgentRuns();
     // Normalize both sides so trivial path-format differences (duplicate
@@ -269,8 +271,7 @@ export async function discoverLatestExecutionOutputs(
       }
     }
   } catch (error) {
-    logger.debug(
-      channel,
+    log.debug(
       `Metadata-driven latexdiff discovery failed: ${toErrorMessage(error)}`,
     );
   }

--- a/src/latex/latexdiff/runLatexdiff.ts
+++ b/src/latex/latexdiff/runLatexdiff.ts
@@ -9,7 +9,7 @@
  * rendering) and calls this with a {@link DiffProgressReporter}.
  */
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import {
   ExecutionIdSchema,
   OutputFileInfoSchema,
@@ -101,6 +101,7 @@ export async function runLatexdiffForExecution(
     progress,
   } = params;
   const runId = params.runId ?? undefined;
+  const log = createLog(latexdiff.channel);
 
   let outputsByRound = params.outputsByRound ?? null;
   let source: LatexdiffOutputsSource = outputsByRound
@@ -125,8 +126,7 @@ export async function runLatexdiffForExecution(
         outputsByRound = scanned;
         source = 'run-dir-scan';
         discoveredExecutionId = parsedRunId.data;
-        logger.debug(
-          latexdiff.channel,
+        log.debug(
           `Using run-dir scan outputs from execution ${parsedRunId.data}`,
         );
       }
@@ -152,8 +152,7 @@ export async function runLatexdiffForExecution(
       outputsByRound = discovered.rounds;
       source = 'metadata';
       discoveredExecutionId = discovered.executionId;
-      logger.debug(
-        latexdiff.channel,
+      log.debug(
         `Using metadata outputs from execution ${discovered.executionId}`,
       );
     }

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import { z } from 'zod';
 
 // Local imports
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { ExecResult, FileLocation } from '@shared/schemas';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
@@ -163,6 +163,7 @@ export async function compileLatex2Pdf(
   // Schema provides compiler default; channel defaults to module constant
   const parsed = LaTeXCompileOptionsSchema.parse(options);
   const channel = parsed.channel ?? CHANNEL;
+  const log = createLog(channel);
   const { outputDirectory, compiler, timeout, extraInputDirs } = parsed;
   const latexFile = latexLocation.absolutePath;
   const outDir = outputDirectory ?? path.dirname(latexFile);
@@ -198,7 +199,7 @@ export async function compileLatex2Pdf(
     // any inherited values. `path.delimiter` keeps it cross-platform.
     const env = buildLatexInputEnv(texInputParts, bibSearchParts);
     for (const [key, value] of Object.entries(env)) {
-      logger.debug(channel, `Setting ${key} to: ${value}`);
+      log.debug(`Setting ${key} to: ${value}`);
     }
 
     const latexmkArgs = [
@@ -233,8 +234,7 @@ export async function compileLatex2Pdf(
         showError: false, // Suppress error for latexmk to try pdflatex as fallback
       });
       if (!result) {
-        logger.warn(
-          channel,
+        log.warn(
           'latexmk not found, falling back to single-pass pdflatex — ' +
             'bibliography, cross-references, and index may be incomplete',
         );
@@ -245,13 +245,13 @@ export async function compileLatex2Pdf(
     }
 
     if (result && result.success) {
-      logger.debug(channel, `Successfully compiled ${latexFile}`);
+      log.debug(`Successfully compiled ${latexFile}`);
       return { ok: true };
     }
     return { ok: false, logTail: await readCompileLogTail(outDir, latexFile) };
   } catch (err) {
     const message = toErrorMessage(err);
-    logger.error(channel, `Error compiling LaTeX: ${message}`);
+    log.error(`Error compiling LaTeX: ${message}`);
     const tail = await readCompileLogTail(outDir, latexFile);
     return {
       ok: false,

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -1,4 +1,4 @@
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
 import { filterNotNull, filterNotNullish, ensureArray } from '@utils/core';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
@@ -7,6 +7,8 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { hasExtension } from '@utils/core/pathCore';
 import { runToolWithCheck } from '@utils/system/toolUtils';
 import { LATEX_COMMANDS_CHANNEL as CHANNEL } from './latexLogging';
+
+const log = createLog(CHANNEL);
 
 const CHINESE_PACKAGES = [
   'xeCJK',
@@ -28,10 +30,7 @@ async function hasChinesePackages(
         content.includes(`\\documentclass{${pkg}}`),
     );
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error checking Chinese packages: ${toErrorMessage(err)}`,
-    );
+    log.error(`Error checking Chinese packages: ${toErrorMessage(err)}`);
     return false;
   }
 }
@@ -54,15 +53,16 @@ async function rejectionReason(
   channel: string,
 ): Promise<string | null> {
   const filePath = fileLocation.absolutePath;
+  const log = createLog(channel);
   if (!(await AbsoluteFS.exists(filePath))) {
     const reason = `File ${filePath} does not exist.`;
-    logger.warn(channel, reason);
+    log.warn(reason);
     return reason;
   }
 
   if (!hasExtension(filePath, '.tex')) {
     const reason = `Error: File ${filePath} is not a LaTeX file. Skipping.`;
-    logger.warn(channel, reason);
+    log.warn(reason);
     return reason;
   }
 
@@ -75,6 +75,7 @@ async function runTexcount(
   context: string,
   signal?: AbortSignal,
 ): Promise<{ stdout: string | null; error?: string }> {
+  const log = createLog(channel);
   const result = await runToolWithCheck('texcount', args, {
     channel,
     truncate: false,
@@ -90,16 +91,16 @@ async function runTexcount(
   }
 
   if (result.success && result.stdout) {
-    logger.debug(channel, `Successfully counted ${context}`);
+    log.debug(`Successfully counted ${context}`);
     return { stdout: result.stdout };
   }
 
-  logger.error(channel, `Error getting tex count for ${context}`);
+  log.error(`Error getting tex count for ${context}`);
   if (result.stdout) {
-    logger.error(channel, `Stdout: ${result.stdout}`);
+    log.error(`Stdout: ${result.stdout}`);
   }
   if (result.stderr) {
-    logger.error(channel, `Stderr: ${result.stderr}`);
+    log.error(`Stderr: ${result.stderr}`);
   }
 
   return {
@@ -156,6 +157,7 @@ async function getSummedCount(
   channel: string,
   signal?: AbortSignal,
 ): Promise<{ output: string | null; errors: string[] }> {
+  const log = createLog(channel);
   const validPaths: string[] = [];
   const errors: string[] = [];
   let enableChineseMode = false;
@@ -172,8 +174,7 @@ async function getSummedCount(
 
     if (!enableChineseMode && (await hasChinesePackages(fileLocation))) {
       enableChineseMode = true;
-      logger.debug(
-        channel,
+      log.debug(
         `Chinese packages detected in ${filePath}, enabling Chinese character counting`,
       );
     }
@@ -225,6 +226,7 @@ export async function getTeXCount(
   }: TexcountOptions & { signal?: AbortSignal } = {},
 ): Promise<TexcountResult> {
   const resolvedChannel = channel ?? CHANNEL;
+  const log = createLog(resolvedChannel);
 
   try {
     const paths = ensureArray(filePaths);
@@ -234,7 +236,7 @@ export async function getTeXCount(
 
     if (trimmedPaths.length === 0) {
       const message = 'No LaTeX files provided for texcount.';
-      logger.warn(resolvedChannel, message);
+      log.warn(message);
       return { output: null, errors: [message] };
     }
 
@@ -245,7 +247,7 @@ export async function getTeXCount(
         signal,
       );
       if (output) {
-        logger.info(resolvedChannel, `Combined TeX Count Results:\n${output}`);
+        log.info(`Combined TeX Count Results:\n${output}`);
       }
       return { output, errors };
     }
@@ -265,14 +267,11 @@ export async function getTeXCount(
     }
 
     const combinedOutput = outputs.join('\n\n');
-    logger.info(
-      resolvedChannel,
-      `Combined TeX Count Results:\n${combinedOutput}`,
-    );
+    log.info(`Combined TeX Count Results:\n${combinedOutput}`);
     return { output: combinedOutput, errors };
   } catch (err) {
     const errorMessage = `Error in getTeXCount: ${toErrorMessage(err)}`;
-    logger.error(resolvedChannel, errorMessage);
+    log.error(errorMessage);
     return { output: null, errors: [errorMessage] };
   }
 }


### PR DESCRIPTION
## Summary

Collision-free dynamic-channel subset of #10013, on top of the now-merged
mechanical sweep (#10616). Converts the eight modules whose logger channel is
threaded as a value (function/constructor parameter, class field, or
`latexdiff.channel`) rather than a module-local constant — the case #10616
deliberately left for per-file judgment. Each conversion instantiates
`createLog` at the narrow scope where the channel value is known (function
entry, the class owner getter, or the resolved channel local), so a
mutable/dynamic channel is never frozen at module load. No wrappers or caching
added; every call funnels through `createLog` → `loggerSelf` → the shared
`writeLine` sink, so `vi.spyOn(logger, 'warn')` intercepts still work.

Re-audited every open PR diff (#10475, #10600, #10601, #10608, #10609, #10612,
#10347) and the merged #10616: none touch these eight files.

## Converted to `createLog` (8 files)

- `src/auth/oauth/sessionAccess.ts` — `const log = createLog(channel)` at the
  top of `getSubscriptionSessionStatus`.
- `src/latex/arxivProcessor.ts` — `private get log()` on the `ArxivSourceProcessor`
  owner; `extractTarFile` keeps its `options.channel ?? this.channel` override
  via a local `createLog(channel)`.
- `src/latex/latexdiff.ts` — `private get log()` on `LaTeXdiffService`.
- `src/latex/latexdiff/diffOperations.ts` — `const log = createLog(latexdiff.channel)`
  in `executeDiffOperations` and `runLatexdiffViaWorkspaceScan`.
- `src/latex/latexdiff/outputDiscovery.ts` — per-function `createLog(channel)` in
  `collectTexFiles`, `scanRunDirForOutputs`, `discoverLatestExecutionOutputs`.
- `src/latex/latexdiff/runLatexdiff.ts` — `const log = createLog(latexdiff.channel)`
  in `runLatexdiffForExecution`.
- `src/latex/texcount.ts` — module-level `const log = createLog(CHANNEL)` for the
  fixed-channel `hasChinesePackages`; per-function `createLog(channel)` /
  `createLog(resolvedChannel)` for the threaded helpers.
- `src/latex/texTools.ts` — `const log = createLog(channel)` in `compileLatex2Pdf`.

## Remaining `import * as logger` modules (non-test, `src/`) — 15

- `src/agent/goal/promptLoader.ts`
- `src/agent/index/platformAgentDirectories.ts`
- `src/agent/runtime/agentSettingTools.ts`
- `src/agent/runtime/textConnection.ts`
- `src/auth/serverKeys/index.ts`
- `src/housekeeping/clean.ts`
- `src/housekeeping/pack.ts`
- `src/housekeeping/runDirOps.ts`
- `src/latex/latexdiff/diffCommandExecutor.ts`
- `src/tools/claudeAgentConfig.ts`
- `src/tools/delegation/inBandSubagentExecution.ts`
- `src/tools/delegation/subagentDeliveryFormat.ts`
- `src/tools/delegation/subagentDiffs.ts`
- `src/tools/delegation/workflowScriptStrategy.ts`
- `src/utils/system/execUtils.ts`

## Net elements (R6)

- Diffstat: **8 files, 77 insertions, 92 deletions; net −15 lines**.
- `import * as logger` non-test modules under `src/`: **23 → 15**.
- Converted to `createLog`: **8**.
- `createLog` module-level call sites under `src/` (non-test, excluding
  `logUtils.ts`): **78 → 79** (the other seven conversions are function/class-scoped
  by design, so they do not add module-level sites).
- Exported symbols/classes/interfaces/enums added: **0**.

## Consumer counts (R8)

No event or emit path is added or rerouted. Each converted module keeps its
existing consumers and the shared `writeLine` sink; the `arxivProcessor` and
`LaTeXdiffService` channel fields, and the `LATEX_COMMANDS_CHANNEL` import in
`texcount.ts`/`texTools.ts`, are unchanged (the `ArxivProcessor` test still reads
the private lowercase `channel` field). No wrappers added — `createLog`'s
`loggerSelf` delegation is the spy seam.

## Validation

- Focused Vitest: **26 files / 173 tests passed** (incl. `ArxivProcessor`,
  `TexTools`, `OutputDiscovery`, `RunLatexdiff`, `TexcountTool`, `ArxivDownloadTool`,
  `SupabaseClient` spy suite, and the compile/texcount command tests).
- Architecture suites: **17 files / 98 tests passed**.
- Typechecks: workspace (src + extension), test-kernel, and desktop passed;
  agent/cli/trace-viewer do not import these modules.
- ESLint and Prettier clean on changed files.
- Dead-code ratchet, guidance-refs, and browser-safe-utils gates passed.
- `git diff --check` clean.

Refs #10013
