### PR TITLE
refactor(logger): migrate platformAgentDirectories and textConnection to createLog

### DIFF
--- a/src/agent/index/platformAgentDirectories.ts
+++ b/src/agent/index/platformAgentDirectories.ts
@@ -2,7 +2,7 @@ import {
   isFileNotFoundError,
   isNotADirectoryError,
 } from '@common/errors/errorPredicates';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import {
   AgentDirectoryService,
@@ -33,6 +33,7 @@ export interface PlatformAgentDirectoryBootstrapOptions {
 export function createPlatformAgentDirectories(
   options: PlatformAgentDirectoryOptions,
 ): AgentDirectoryService {
+  const log = createLog(options.channel);
   return new AgentDirectoryService({
     storage: new GlobalStorageAgentDirectoryStorage(),
     customDirectoryStore: options.customDirectoryStore,
@@ -55,16 +56,11 @@ export function createPlatformAgentDirectories(
     },
     issueReporter: options.issueReporter ?? {
       report: async (message, docsId) =>
-        logger.warn(
-          options.channel,
-          `${message}. See documentation: ${docsId}`,
-        ),
+        log.warn(`${message}. See documentation: ${docsId}`),
     },
     logger: {
-      debug: (message, data) =>
-        logger.debug(options.channel, message, { data }),
-      error: (message, data) =>
-        logger.error(options.channel, message, { data }),
+      debug: (message, data) => log.debug(message, { data }),
+      error: (message, data) => log.error(message, { data }),
     },
   });
 }
@@ -72,13 +68,14 @@ export function createPlatformAgentDirectories(
 export async function bootstrapPlatformAgentDirectories(
   options: PlatformAgentDirectoryBootstrapOptions,
 ): Promise<void> {
+  const log = createLog(options.channel);
   const sync = new BundledAgentDirectorySync({
     bundleSource: options.bundleSource,
     storage: new GlobalStorageAgentDirectoryStorage(),
     versionStore: options.versionStore,
     logger: {
-      info: (message, data) => logger.info(options.channel, message, { data }),
-      warn: (message, data) => logger.warn(options.channel, message, { data }),
+      info: (message, data) => log.info(message, { data }),
+      warn: (message, data) => log.warn(message, { data }),
     },
   });
 

--- a/src/agent/runtime/textConnection.ts
+++ b/src/agent/runtime/textConnection.ts
@@ -6,7 +6,7 @@ import { classifyAgentError } from '@common/errors';
 import { getSdkErrorMessage } from '@common/errors/sdkError/providerErrorFormat';
 import { LATEX_COMMANDS_CHANNEL as CHANNEL } from '@latex/latexLogging';
 import type { ResponseTextConnector } from '@latex/texraResponseTextProcessing';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 
 interface ConnectionResult {
   connector: string;
@@ -23,6 +23,8 @@ const DEFAULT_RESULT: ConnectionResult = {
   connector: CASE_CONNECTORS.B,
   choice: 'B',
 };
+
+const log = createLog(CHANNEL);
 
 function buildPrompt(str1: string, str2: string): string {
   return (
@@ -48,8 +50,7 @@ export async function bestConnectionMethod(
   try {
     const helperResult = await createHelperModelKit();
     if (!helperResult.kit) {
-      logger.debug(
-        CHANNEL,
+      log.debug(
         `Skipping bestConnectionMethod helper call: ${helperResult.reason}`,
       );
       return DEFAULT_RESULT;
@@ -62,16 +63,14 @@ export async function bestConnectionMethod(
     const choice = text.trim();
     const connector = CASE_CONNECTORS[choice];
     if (connector === undefined) {
-      logger.debug(CHANNEL, `Invalid choice: ${choice}. Defaulting to space.`);
+      log.debug(`Invalid choice: ${choice}. Defaulting to space.`);
       return DEFAULT_RESULT;
     }
     return { connector, choice };
   } catch (err) {
-    const log =
-      classifyAgentError(err) === 'missing-api-key'
-        ? logger.debug
-        : logger.error;
-    log(CHANNEL, `Error in bestConnectionMethod: ${getSdkErrorMessage(err)}`);
+    const write =
+      classifyAgentError(err) === 'missing-api-key' ? log.debug : log.error;
+    write(`Error in bestConnectionMethod: ${getSdkErrorMessage(err)}`);
     return DEFAULT_RESULT;
   }
 }


### PR DESCRIPTION
## Summary

Migrates two of the remaining special/manual `import * as logger` modules from #10013 to `createLog(channel)`:

- `src/agent/index/platformAgentDirectories.ts` — the channel arrives at runtime via `options.channel`, so each entry point binds `const log = createLog(options.channel)` at the narrow call scope and forwards `log.{debug,info,warn,error}(message, { data })` into the `AgentDirectoryService` / `BundledAgentDirectorySync` logger contracts.
- `src/agent/runtime/textConnection.ts` — binds `const log = createLog(CHANNEL)` once at module scope (the channel is a module-level constant) and keeps the existing missing-api-key → debug / otherwise → error selection, extracting the arrow-function-bound methods so no unbound `this` is introduced.

## Issue acceptance gates

Refs #10013 (does not close — the 78-module migration is far from complete). Migrates 2 of the assigned 3 special/manual files. The third, `src/auth/serverKeys/index.ts`, is intentionally left untouched: converting it requires narrowing the `TierService`/`ServerSideKeyService` constructor logger types from channel-threaded `SupabaseSessionLog` to a channel-bound `createLog` contract, and both of those files are in fleet PR #10609 (`refactor/b1-empty-shared-schemas-baseline`), which this PR must not touch.

## Single source of truth

No new source of truth. Logging continues to route through `createLog`'s per-call `loggerSelf` delegation in `src/logger/logUtils.ts`, preserving test-spy interception.

## Duplication and abstraction budget

Removes the repeated `options.channel` / `CHANNEL` threading at every call site by binding the channel once via `createLog`. No new abstraction or pass-through layer.

## Net elements (R6)

- Files: 2 modified (`src/agent/index/platformAgentDirectories.ts`, `src/agent/runtime/textConnection.ts`).
- Exported symbols added/removed: 0 / 0.
- Classes/interfaces/enums added/removed: 0 / 0.
- Net LoC: 16 insertions / 20 deletions (−4).

## Consumer counts (R8)

n/a — no emit path or export is deleted or re-routed; only logging call sites change.

## Host impact

Extension / Desktop / CLI: none — no exported signatures change; log output is byte-identical (same channel, same level, same message/data).

## Scheduled refactoring

`src/auth/serverKeys/index.ts` (and the `TierService`/`ServerSideKeyService` type narrowing it needs) remains for #10013, blocked on fleet PR #10609.

## Remaining `import * as logger` in this PR's scope

- `src/auth/serverKeys/index.ts` — `import * as logger from '@logger/logUtils';` (not converted; see acceptance gates).

## Validation

- `git diff --check` clean.
- Focused tests: `TextConnectionHelperModel`, `AgentDirectoryWatchers`, `ElectronAgentDirectories`, `CliInitPlatform` (26 passed); plus the 8 frontend/webview/shared/commands suites that mock `@logger/logUtils` without `createLog` (60 passed) to confirm no import-time breakage.
- Typechecks: `typecheck:workspace`, `typecheck:test-kernel`, `typecheck:agent`, `typecheck:cli`, `typecheck:desktop` — all clean.
- `eslint` on both files — clean; `prettier --check` — clean.
- Architecture suites (17 files / 98 tests) — all pass.
- `check:dead-code-ratchet` (knip 15 vs 15), `check:guidance-refs`, `check:browser-safe-utils` — all OK.

