### PR TITLE
fix(latexdiff): warn on failed persisted-state output reads; pin the createLog spy seam (#10634, #10635)

### DIFF
--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -191,9 +191,10 @@ export async function scanRunDirForOutputs(
 
     return Object.keys(rounds).length > 0 ? rounds : null;
   } catch (error) {
-    log.debug(
-      `RunDir scan for ${executionId} failed: ${toErrorMessage(error)}`,
-    );
+    // A failed run-storage read degrades a pinned-runId invocation to the
+    // plain workspace scan — a behavior-changing fallback, so fallback
+    // discipline (review checklist §15) forbids logging it below warn.
+    log.warn(`RunDir scan for ${executionId} failed: ${toErrorMessage(error)}`);
     return null;
   }
 }
@@ -271,7 +272,9 @@ export async function discoverLatestExecutionOutputs(
       }
     }
   } catch (error) {
-    log.debug(
+    // Same discipline as scanRunDirForOutputs above: a failed persisted
+    // metadata read drops the invocation to the workspace scan, so warn.
+    log.warn(
       `Metadata-driven latexdiff discovery failed: ${toErrorMessage(error)}`,
     );
   }

--- a/src/test-kernel/auth/SessionAccess.vitest.ts
+++ b/src/test-kernel/auth/SessionAccess.vitest.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getSubscriptionSessionStatus,
+  type SessionAccessCoordinator,
+} from '@auth/oauth/sessionAccess';
+import * as logger from '@logger/logUtils';
+
+function coordinator(
+  overrides: Partial<SessionAccessCoordinator> = {},
+): SessionAccessCoordinator {
+  return {
+    getStatus: async () => ({ signedIn: false }),
+    getFreshAccessToken: async () => 'access-token',
+    loadSession: async () => null,
+    ...overrides,
+  };
+}
+
+describe('getSubscriptionSessionStatus', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('warns on the caller-supplied channel and reports signed-out when the status read fails (#10635)', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const failing = coordinator({
+      getStatus: async () => {
+        throw new Error('secret store unavailable');
+      },
+    });
+
+    const status = await getSubscriptionSessionStatus(
+      () => failing,
+      'subscriptionStatusProbe',
+      'ChatGPT',
+    );
+
+    expect(status).toEqual({ signedIn: false });
+    expect(warn).toHaveBeenCalledWith(
+      'subscriptionStatusProbe',
+      expect.stringContaining(
+        'Failed to read ChatGPT session status: secret store unavailable',
+      ),
+    );
+  });
+
+  it('passes a healthy coordinator status through without logging', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const healthy = coordinator({
+      getStatus: async () => ({ signedIn: true, email: 'user@example.com' }),
+    });
+
+    const status = await getSubscriptionSessionStatus(
+      () => healthy,
+      'subscriptionStatusProbe',
+      'ChatGPT',
+    );
+
+    expect(status).toEqual({ signedIn: true, email: 'user@example.com' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/test-kernel/latex/ArxivProcessor.vitest.ts
+++ b/src/test-kernel/latex/ArxivProcessor.vitest.ts
@@ -7,6 +7,7 @@ import {
   ArxivProcessor,
   resolveArxivPaperDirectoryRelative,
 } from '@latex/arxivProcessor';
+import * as logger from '@logger/logUtils';
 import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 
 const tempDirs: string[] = [];
@@ -14,6 +15,7 @@ const SOURCE_URL = 'https://arxiv.org/src/2404.12175';
 
 afterEach(async () => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
   await cleanupTempDirs(tempDirs);
 });
 
@@ -58,6 +60,57 @@ describe('arXiv processor logger channel', () => {
     // must stay lowercase so log filters keep matching `[arxivProcessor]`.
     const channel = (ArxivProcessor as unknown as { channel: string }).channel;
     expect(channel).toBe('arxivProcessor');
+  });
+
+  // Spy seam (#10635): the owner getter binds `this.channel` through createLog
+  // per call, so a logger-namespace spy must observe the owner channel.
+  it('emits download retry logs through the logger namespace on the owner channel', async () => {
+    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    const destBasePath = await tempSourceBase();
+    let attempt = 0;
+    const fetchMock = vi.fn(async () => {
+      attempt += 1;
+      return attempt === 1
+        ? new Response(null, { status: 429 })
+        : sourceResponse();
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const downloadedPath = await ArxivProcessor.downloadFile(
+      SOURCE_URL,
+      destBasePath,
+      5000,
+    );
+
+    expect(downloadedPath).toBe(destBasePath);
+    expect(debug).toHaveBeenCalledWith(
+      'arxivProcessor',
+      expect.stringContaining('Download attempt failed'),
+    );
+  });
+
+  it('logs extraction failures on the owner channel and honors a channel override', async () => {
+    const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const dir = await makeTempDir('texra-arxiv-', tempDirs);
+    const missingTar = path.join(dir, 'missing.tar');
+
+    const fallback = await ArxivProcessor.extractTarFile(missingTar, dir);
+
+    expect(fallback.success).toBe(false);
+    expect(error).toHaveBeenCalledWith(
+      'arxivProcessor',
+      expect.stringContaining('Failed to extract tar file'),
+    );
+
+    const overridden = await ArxivProcessor.extractTarFile(missingTar, dir, {
+      channel: 'arxivExtractOverride',
+    });
+
+    expect(overridden.success).toBe(false);
+    expect(error).toHaveBeenCalledWith(
+      'arxivExtractOverride',
+      expect.stringContaining('Failed to extract tar file'),
+    );
   });
 });
 

--- a/src/test-kernel/latex/DiffOperations.vitest.ts
+++ b/src/test-kernel/latex/DiffOperations.vitest.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { LaTeXdiffService } from '@latex/latexdiff';
+import {
+  runLatexdiffFromMetadata,
+  runLatexdiffViaWorkspaceScan,
+} from '@latex/latexdiff/diffOperations';
+import type { LatexdiffRuntime } from '@latex/latexdiff/types';
+import * as logger from '@logger/logUtils';
+import type { OutputFileInfo } from '@shared/schemas';
+import { installPlatform } from '@test/support/setupPlatform';
+import { createWorkspaceLocation } from '@utils/files/fileLocation';
+
+// #10635: diffOperations resolves its logger per function from the latexdiff
+// runtime channel — a logger-namespace spy must observe that channel.
+const CHANNEL = 'pinnedDiffChannel';
+
+const progress = { report: () => undefined };
+
+function runtimeWith(service: Partial<LaTeXdiffService>): LatexdiffRuntime {
+  return { channel: CHANNEL, service: service as LaTeXdiffService };
+}
+
+describe('diffOperations logger seam', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs each executed diff on the latexdiff runtime channel', async () => {
+    await installPlatform({
+      workspacePath: '/workspace',
+      files: {
+        '/workspace/paper.tex': '\\documentclass{article}\n',
+        '/workspace/r1/paper.tex': '\\documentclass{article}\n',
+      },
+    });
+    const runDiffForRound = vi.fn(async () => ({
+      success: true,
+      message: 'diff written',
+      diffFileName: 'paper_diff.tex',
+    }));
+    const base = createWorkspaceLocation('/workspace/paper.tex', 'paper.tex');
+    const revised = createWorkspaceLocation(
+      '/workspace/r1/paper.tex',
+      'r1/paper.tex',
+    );
+    const output: OutputFileInfo = {
+      source: 'paper.tex',
+      location: revised,
+      round: 1,
+      lineage: { original: base, diffBase: null, diffFile: null },
+      diff: null,
+    };
+    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+
+    const outcome = await runLatexdiffFromMetadata({
+      rounds: { 1: [output] },
+      generateBetweenRoundDiffs: false,
+      latexdiff: runtimeWith({ runDiffForRound }),
+      progress,
+    });
+
+    expect(outcome.results).toEqual([
+      expect.objectContaining({ success: true, description: 'paper.tex (r1)' }),
+    ]);
+    expect(runDiffForRound).toHaveBeenCalledOnce();
+    expect(debug).toHaveBeenCalledWith(
+      CHANNEL,
+      expect.stringContaining('Running round diff: paper.tex (r1)'),
+    );
+  });
+
+  it('logs workspace-scan progress on the latexdiff runtime channel', async () => {
+    await installPlatform({
+      workspacePath: '/workspace',
+      files: { '/workspace/paper.tex': '\\documentclass{article}\n' },
+    });
+    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+
+    const outcome = await runLatexdiffViaWorkspaceScan({
+      agent: 'revise',
+      model: 'claude-opus-4-8',
+      inputFile: 'paper.tex',
+      generateBetweenRoundDiffs: false,
+      latexdiff: runtimeWith({}),
+      progress,
+    });
+
+    // A bare source name matches no legacy/mid-era round layout, so the scan
+    // reports the empty outcome instead of dispatching diff operations.
+    expect(outcome).toEqual({ results: [] });
+    expect(debug).toHaveBeenCalledWith(
+      CHANNEL,
+      expect.stringContaining('Input files: paper.tex'),
+    );
+    expect(debug).toHaveBeenCalledWith(
+      CHANNEL,
+      expect.stringContaining('No matching outputs found for paper.tex'),
+    );
+  });
+});

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import * as logger from '@logger/logUtils';
 import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
@@ -318,5 +319,30 @@ describe('LaTeXdiffService shadow output', () => {
         'utf8',
       ),
     ).resolves.toBe('\\newcommand{\\RR}{\\mathbb{R}}\n');
+  });
+});
+
+describe('LaTeXdiffService logger channel', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Spy seam (#10635): the owner getter binds the constructor channel through
+  // createLog per call, so a logger-namespace spy must observe that channel.
+  it('binds log lines to the constructor channel', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const { LaTeXdiffService } = await import('@latex/latexdiff');
+    const service = new LaTeXdiffService('pinnedLatexdiffChannel');
+
+    const result = await service.runDiff(
+      createExternalLocation('/missing/base.tex'),
+      createExternalLocation('/missing/revised.tex'),
+    );
+
+    expect(result.success).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      'pinnedLatexdiffChannel',
+      expect.stringContaining('One or both files do not exist'),
+    );
   });
 });

--- a/src/test-kernel/latex/OutputDiscovery.vitest.ts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.ts
@@ -158,6 +158,9 @@ describe('outputDiscovery logger seam', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    // clearAllMocks keeps mockRejectedValue implementations — reset so a
+    // rejection pinned by one test cannot leak into the next.
+    mocks.findRunDir.mockReset();
     await installPlatform({}, { fs: nodeFilesystem });
   });
 
@@ -227,6 +230,8 @@ describe('outputDiscovery logger seam', () => {
       '\\documentclass{article}\\begin{document}x\\end{document}',
     );
     const unreadable = path.join(runDir, 'r0');
+    // Hand-rolled because FakeFileSystemProvider cannot inject a per-path
+    // readDirectory failure — it seeds files, not fault rules.
     await installPlatform(
       {},
       {

--- a/src/test-kernel/latex/OutputDiscovery.vitest.ts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.ts
@@ -7,6 +7,7 @@ import type {
   LatexAgentRunEntry,
   LatexExecutionDiscoveryPort,
 } from '@latex/latexdiff/executionDiscovery';
+import * as logger from '@logger/logUtils';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { installPlatform } from '@test/support/setupPlatform';
 import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
@@ -38,7 +39,7 @@ vi.mock('@transcript', async (importActual) => {
   };
 });
 
-const { discoverLatestExecutionOutputs } =
+const { discoverLatestExecutionOutputs, scanRunDirForOutputs } =
   await import('@latex/latexdiff/outputDiscovery');
 
 function matchingExecution(id: string): LatexAgentRunEntry {
@@ -81,6 +82,7 @@ describe('discoverLatestExecutionOutputs', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await cleanupTempDirs(tempDirs);
   });
 
@@ -148,5 +150,111 @@ describe('discoverLatestExecutionOutputs', () => {
     );
 
     expect(result).toBeNull();
+  });
+});
+
+describe('outputDiscovery logger seam', () => {
+  const tempDirs: string[] = [];
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await installPlatform({}, { fs: nodeFilesystem });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await cleanupTempDirs(tempDirs);
+  });
+
+  // #10634: a failed persisted-state read degrades the invocation to the
+  // workspace scan — fallback discipline requires warn, not debug.
+  it('warns on the pinned channel when the run-dir scan cannot read run storage', async () => {
+    mocks.findRunDir.mockRejectedValue(new Error('storage index corrupt'));
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+
+    const result = await scanRunDirForOutputs(
+      'abc123',
+      'paper.tex',
+      undefined,
+      'test',
+    );
+
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      'test',
+      expect.stringContaining(
+        'RunDir scan for abc123 failed: storage index corrupt',
+      ),
+    );
+    expect(debug).not.toHaveBeenCalled();
+  });
+
+  it('warns on the pinned channel when persisted execution metadata cannot be read', async () => {
+    const discovery: LatexExecutionDiscoveryPort = {
+      listAgentRuns: async () => {
+        throw new Error('execution index unreadable');
+      },
+      readStreamId: async () => undefined,
+    };
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+
+    const result = await discoverLatestExecutionOutputs(
+      discovery,
+      MATCHING_QUERY,
+      'test',
+    );
+
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      'test',
+      expect.stringContaining(
+        'Metadata-driven latexdiff discovery failed: execution index unreadable',
+      ),
+    );
+    expect(debug).not.toHaveBeenCalled();
+  });
+
+  // #10635: collectTexFiles keeps its own per-function createLog(channel) —
+  // an unreadable round subtree warns while the remaining rounds still scan.
+  it('warns on the pinned channel for an unreadable round dir and keeps the readable rounds', async () => {
+    const runDir = await makeTempDir('texra-latexdiff-', tempDirs);
+    await mkdir(path.join(runDir, 'r0'), { recursive: true });
+    await mkdir(path.join(runDir, 'r1'), { recursive: true });
+    await writeFile(
+      path.join(runDir, 'r1', 'paper.tex'),
+      '\\documentclass{article}\\begin{document}x\\end{document}',
+    );
+    const unreadable = path.join(runDir, 'r0');
+    await installPlatform(
+      {},
+      {
+        fs: {
+          ...nodeFilesystem,
+          readDirectory: async (target: string) => {
+            if (target === unreadable) {
+              throw new Error('EACCES: permission denied');
+            }
+            return nodeFilesystem.readDirectory(target);
+          },
+        },
+      },
+    );
+    mocks.findRunDir.mockResolvedValue(runDir);
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const result = await scanRunDirForOutputs(
+      'abc123',
+      'paper.tex',
+      undefined,
+      'test',
+    );
+
+    expect(Object.keys(result ?? {}).map(Number)).toEqual([1]);
+    expect(warn).toHaveBeenCalledWith(
+      'test',
+      expect.stringContaining(`Skipping unreadable directory '${unreadable}'`),
+    );
   });
 });

--- a/src/test-kernel/latex/RunLatexdiff.vitest.ts
+++ b/src/test-kernel/latex/RunLatexdiff.vitest.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LaTeXdiffService } from '@latex/latexdiff';
 import type { LatexExecutionDiscoveryPort } from '@latex/latexdiff/executionDiscovery';
 import { normalizeRunLatexdiffOutputsByRound } from '@latex/latexdiff/runLatexdiff';
+import * as logger from '@logger/logUtils';
 import type { OutputFileInfo, RoundIndexed } from '@shared/schemas';
 import { createOutputFile } from '../support/ProgressControllerHarnesses';
 
@@ -153,6 +154,54 @@ describe('runLatexdiffForExecution', () => {
         model: 'claude-opus-4-8',
         inputFile: 'paper.tex',
       }),
+    );
+  });
+});
+
+// #10635: runLatexdiffForExecution resolves its logger per call from the
+// latexdiff runtime channel — a logger-namespace spy must observe that channel.
+describe('runLatexdiffForExecution logger seam', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.runLatexdiffFromMetadata.mockResolvedValue(METADATA_OUTCOME);
+    mocks.runLatexdiffViaWorkspaceScan.mockResolvedValue(SCAN_OUTCOME);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs the run-dir scan resolution on the latexdiff runtime channel', async () => {
+    mocks.scanRunDirForOutputs.mockResolvedValue(roundMap());
+    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+
+    const result = await runLatexdiffForExecution({
+      ...baseRequest,
+      runId: 'abc123',
+    });
+
+    expect(result.source).toBe('run-dir-scan');
+    expect(debug).toHaveBeenCalledWith(
+      'test',
+      expect.stringContaining(
+        'Using run-dir scan outputs from execution abc123',
+      ),
+    );
+  });
+
+  it('logs the metadata discovery resolution on the latexdiff runtime channel', async () => {
+    mocks.discoverLatestExecutionOutputs.mockResolvedValue({
+      executionId: 'def456',
+      rounds: roundMap(),
+    });
+    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+
+    const result = await runLatexdiffForExecution({ ...baseRequest });
+
+    expect(result.source).toBe('metadata');
+    expect(debug).toHaveBeenCalledWith(
+      'test',
+      expect.stringContaining('Using metadata outputs from execution def456'),
     );
   });
 });

--- a/src/test-kernel/latex/TexTools.vitest.ts
+++ b/src/test-kernel/latex/TexTools.vitest.ts
@@ -1,11 +1,13 @@
 import * as path from 'node:path';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LATEX_COMMANDS_CHANNEL } from '@latex/latexLogging';
 import {
   buildKpathseaSearchPath,
   buildLatexInputEnv,
   buildLatexSearchParts,
   compileLatex2Pdf,
 } from '@latex/texTools';
+import * as logger from '@logger/logUtils';
 import type { ExecResult } from '@shared/schemas';
 import { installPlatform } from '@test/support/setupPlatform';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
@@ -126,6 +128,74 @@ describe('compileLatex2Pdf structured return', () => {
     const logTail = failedLogTail(await compile());
 
     expect(logTail).toContain('boom: pdflatex crashed');
+  });
+});
+
+// #10635: compileLatex2Pdf resolves its logger per call from the threaded
+// channel option (defaulting to the module channel) — a logger-namespace spy
+// must observe the resolved channel.
+describe('compileLatex2Pdf logger seam', () => {
+  beforeEach(async () => {
+    mocks.runToolWithCheck.mockReset();
+    await installPlatform({ workspacePath });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('warns on the module channel when latexmk is missing and pdflatex takes over', async () => {
+    mocks.runToolWithCheck
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(execResult(true));
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const result = await compile();
+
+    expect(result).toEqual({ ok: true });
+    expect(warn).toHaveBeenCalledWith(
+      LATEX_COMMANDS_CHANNEL,
+      expect.stringContaining('latexmk not found'),
+    );
+  });
+
+  it('resolves the channel from the threaded option when one is supplied', async () => {
+    mocks.runToolWithCheck
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(execResult(true));
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const result = await compileLatex2Pdf(
+      pathToLocation(path.join(workspacePath, 'main.tex')),
+      {
+        channel: 'pinnedCompile',
+        outputDirectory: path.join(workspacePath, 'build'),
+      },
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(warn).toHaveBeenCalledWith(
+      'pinnedCompile',
+      expect.stringContaining('latexmk not found'),
+    );
+    expect(
+      warn.mock.calls.filter(([channel]) => channel === LATEX_COMMANDS_CHANNEL),
+    ).toHaveLength(0);
+  });
+
+  it('logs a throwing compiler invocation at error level on the resolved channel', async () => {
+    mocks.runToolWithCheck.mockRejectedValue(
+      new Error('boom: pdflatex crashed'),
+    );
+    const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    const result = await compile();
+
+    expect(result.ok).toBe(false);
+    expect(error).toHaveBeenCalledWith(
+      LATEX_COMMANDS_CHANNEL,
+      expect.stringContaining('Error compiling LaTeX: boom: pdflatex crashed'),
+    );
   });
 });
 

--- a/src/test-kernel/latex/Texcount.vitest.ts
+++ b/src/test-kernel/latex/Texcount.vitest.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LATEX_COMMANDS_CHANNEL } from '@latex/latexLogging';
+import { getTeXCount } from '@latex/texcount';
+import * as logger from '@logger/logUtils';
+import { installPlatform } from '@test/support/setupPlatform';
+
+const mocks = vi.hoisted(() => ({
+  runToolWithCheck: vi.fn(),
+}));
+
+vi.mock('@utils/system/toolUtils', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@utils/system/toolUtils')>();
+  return { ...actual, runToolWithCheck: mocks.runToolWithCheck };
+});
+
+// #10635: texcount's helpers resolve their logger per function from the
+// threaded channel — a logger-namespace spy must observe the resolved channel.
+describe('texcount logger seam', () => {
+  beforeEach(() => {
+    mocks.runToolWithCheck.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('warns on the resolved channel when no files are provided', async () => {
+    await installPlatform({ workspacePath: '/workspace' });
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const pinned = await getTeXCount('   ', { channel: 'pinnedTexcount' });
+    const defaulted = await getTeXCount('');
+
+    expect(pinned).toEqual({
+      output: null,
+      errors: ['No LaTeX files provided for texcount.'],
+    });
+    expect(defaulted).toEqual(pinned);
+    expect(warn).toHaveBeenCalledWith(
+      'pinnedTexcount',
+      'No LaTeX files provided for texcount.',
+    );
+    expect(warn).toHaveBeenCalledWith(
+      LATEX_COMMANDS_CHANNEL,
+      'No LaTeX files provided for texcount.',
+    );
+  });
+
+  it('warns on the resolved channel when a file does not exist', async () => {
+    await installPlatform({ workspacePath: '/workspace' });
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const result = await getTeXCount('missing.tex', {
+      channel: 'pinnedTexcount',
+    });
+
+    expect(result.output).toBeNull();
+    expect(result.errors).toHaveLength(1);
+    expect(warn).toHaveBeenCalledWith(
+      'pinnedTexcount',
+      expect.stringContaining('does not exist'),
+    );
+  });
+
+  it('logs a failing texcount invocation at error level on the resolved channel', async () => {
+    await installPlatform({
+      workspacePath: '/workspace',
+      files: { '/workspace/main.tex': '\\documentclass{article}\n' },
+    });
+    mocks.runToolWithCheck.mockResolvedValue({
+      success: false,
+      stdout: 'partial output',
+      stderr: 'texcount exploded',
+      exitCode: 1,
+    });
+    const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    const result = await getTeXCount('main.tex', { channel: 'pinnedTexcount' });
+
+    expect(result.output).toBeNull();
+    expect(result.errors.join('\n')).toContain('texcount exploded');
+    expect(error).toHaveBeenCalledWith(
+      'pinnedTexcount',
+      expect.stringContaining('Error getting tex count for'),
+    );
+    expect(error).toHaveBeenCalledWith(
+      'pinnedTexcount',
+      expect.stringContaining('Stderr: texcount exploded'),
+    );
+  });
+});

--- a/src/test-kernel/latex/Texcount.vitest.ts
+++ b/src/test-kernel/latex/Texcount.vitest.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LATEX_COMMANDS_CHANNEL } from '@latex/latexLogging';
 import { getTeXCount } from '@latex/texcount';
 import * as logger from '@logger/logUtils';
+import { platform } from '@platform/platform';
 import { installPlatform } from '@test/support/setupPlatform';
 
 const mocks = vi.hoisted(() => ({
@@ -61,6 +62,37 @@ describe('texcount logger seam', () => {
     expect(warn).toHaveBeenCalledWith(
       'pinnedTexcount',
       expect.stringContaining('does not exist'),
+    );
+  });
+
+  // The module-level `const log = createLog(CHANNEL)` in texcount.ts is bound
+  // at import time, before this suite's spy exists — exactly the case
+  // createLog's per-call loggerSelf lookup exists for. A read failure inside
+  // hasChinesePackages must still reach the spied namespace.
+  it('emits through the import-time module binding when the Chinese-package check fails', async () => {
+    await installPlatform({
+      workspacePath: '/workspace',
+      files: { '/workspace/main.tex': '\\documentclass{article}\n' },
+    });
+    // The first (and only) AbsoluteFS.read in this flow is hasChinesePackages'.
+    vi.spyOn(platform().fs, 'readFile').mockRejectedValueOnce(
+      new Error('disk flutter'),
+    );
+    mocks.runToolWithCheck.mockResolvedValue({
+      success: true,
+      stdout: 'Words in text: 5',
+      stderr: '',
+      exitCode: 0,
+    });
+    const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    const result = await getTeXCount('main.tex');
+
+    // The failed Chinese-package probe is best-effort: the count still runs.
+    expect(result.output).toContain('Words in text: 5');
+    expect(error).toHaveBeenCalledWith(
+      LATEX_COMMANDS_CHANNEL,
+      expect.stringContaining('Error checking Chinese packages: disk flutter'),
     );
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #10627 (the 8-module dynamic-channel `createLog` migration), addressing its two review follow-ups together:

- **#10634**: `scanRunDirForOutputs` and `discoverLatestExecutionOutputs` logged a failed persisted-state read at `debug` and returned `null`, after which the invocation silently degrades to the plain workspace scan. Review checklist §15 (fallback discipline) forbids logging a behavior-changing persisted-state fallback below `warn`, so both catches now log at `warn` via the local `createLog(channel)`. The sibling catch qualifies for the same bump: a failed execution-list / stream-tab-metadata read drops the invocation to the *same* workspace-scan fallback. The `collectTexFiles` unreadable-subtree catch and the `diffOperations.ts` mid-era round-dir skip are best-effort recovery scans that do not trigger a meaningful fallback — deliberately left as-is per the issue's scope note.
- **#10635**: focused tests now spy on the `@logger/logUtils` namespace and pin level + dynamic channel for every call site #10627 migrated, so a future change to `createLog`'s `loggerSelf` delegation cannot silently regress these paths. Cases are grouped through the existing suites and their helpers; only the three modules without an existing home got new mirrored suites.

## Issue acceptance gates

Closes #10634
Closes #10635

- #10634: `scanRunDirForOutputs` catch bumped `debug` → `warn` ✓; sibling `discoverLatestExecutionOutputs` catch bumped under the same §15 reasoning ✓; recovery-scan noise (`collectTexFiles`, `diffOperations.ts` round-dir skip) untouched ✓; otherwise behavior-preserving ✓ (pinned by warn-not-debug assertions).
- #10635 minimum coverage, all exercised through the real modules:
  - `getSubscriptionSessionStatus` failure path — new `auth/SessionAccess.vitest.ts` (warn on the caller-supplied channel + signed-out fallback; healthy pass-through logs nothing).
  - `ArxivSourceProcessor` owner getter — `ArxivProcessor.vitest.ts` (download-retry `debug` on `arxivProcessor`; tar-extract `error` on the owner channel plus the `options.channel` override).
  - `LaTeXdiffService` owner getter — `LatexdiffShadowStorage.vitest.ts` (`runDiff` warn bound to the constructor channel).
  - `outputDiscovery.ts` per-function sites — `OutputDiscovery.vitest.ts` (both catch sites warn-not-debug on the pinned channel; `collectTexFiles` unreadable-round warn while readable rounds still scan).
  - `diffOperations.ts` — new `latex/DiffOperations.vitest.ts` (metadata-path per-diff `debug`; workspace-scan entry/empty `debug`, both on the latexdiff runtime channel, real in-memory FS).
  - `runLatexdiff.ts` — `RunLatexdiff.vitest.ts` (run-dir-scan and metadata resolution `debug` on the runtime channel).
  - `texTools.ts` — `TexTools.vitest.ts` (latexmk-fallback warn on the default and threaded channels; compiler-throw `error`).
  - `texcount.ts` — new `latex/Texcount.vitest.ts` (no-files warn on pinned + default channels; missing-file warn; failing-invocation `error`).

## Single source of truth

No new owner introduced: `createLog`'s per-call `loggerSelf` delegation remains the single spy seam — every new test spies the `@logger/logUtils` namespace (no module re-mocks), which is exactly the indirection #10627 documented.

## Duplication and abstraction budget

New assertions reuse each suite's existing harness (ArxivProcessor temp-dir/fetch helpers, RunLatexdiff's hoisted discovery mocks + `baseRequest`, TexTools' `runToolWithCheck` mock + `compile()` helper, OutputDiscovery's discovery fakes + `installPlatform`). No production abstraction added; no one-test-per-line bloat (multiple seams pinned per realistic scenario, e.g. one compile covers default-vs-threaded channel resolution).

## Net elements (R6)

- Diffstat: **9 files, +610/−7** (production: 1 file, +7/−4 — two level bumps plus their rationale comments).
- Exported symbols/classes/interfaces added: **0**.
- New test files: **3** (`SessionAccess.vitest.ts`, `DiffOperations.vitest.ts`, `Texcount.vitest.ts`); extended suites: **5** (`ArxivProcessor`, `LatexdiffShadowStorage`, `OutputDiscovery`, `RunLatexdiff`, `TexTools`).

## Consumer counts (R8)

n/a — no event, emit path, or export added/deleted/rerouted. The two level changes keep the same channel string, message text, and `writeLine` sink; only the severity tag changes, so `[channel]` log filters see identical lines.

## Host impact

Extension: none (host-neutral latex modules; identical behavior except a warn-level trace where a debug trace fired).

Desktop: same.

CLI: same.

## Scheduled refactoring

None beyond the standing logger migration (#10013), which continues to own the remaining `import * as logger` modules.

## Validation

- Focused Vitest (the 8 touched/new suites): **8 files / 59 tests passed**.
- Neighborhood sweep (`src/test-kernel/latex`, `auth`, `logger` + texcount/arxiv tool suites + latexdiff command/webview suites): **46 files / 320 tests passed**.
- Architecture suites: **17 files / 98 tests passed**.
- `pnpm typecheck` (workspace, test-kernel, agent, cli, trace-viewer, desktop): clean.
- ESLint on all 9 changed files: clean; `prettier --check`: clean.
- `check:dead-code-ratchet`: OK (15 current vs 15 baselined); `check:guidance-refs`: OK; `check:browser-safe-utils`: OK.
- `git diff --check`: clean. Import-time mock safety preserved (existing `vi.hoisted` + `importOriginal` patterns reused; new suites follow the same convention).

