### PR TITLE
fix(agent): harden delegation recovery lifecycle

### DIFF
--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -40,6 +40,7 @@ import { detectWaitingStreams } from '@agent/storage/detectWaitingStreams';
 import {
   abandonOwnedExecutionLease,
   completeOwnedExecutionLease,
+  isOwnedExecutionLeaseDurable,
   renewOwnedExecutionLease,
   runWithOwnedExecutionLeaseQuiescence,
 } from '@agent/storage/executionLease';
@@ -886,9 +887,9 @@ export class SessionHandle {
    * snapshot I/O. An optional post-drain operation may publish lifecycle state
    * that is valid only once those artifacts are durable; it still runs before
    * the lease record is deleted. A drain or post-drain failure abandons the
-   * lease (record retained, renewal stopped) and rethrows; a poisoned lease
-   * completes as abandon. This is the one exit choreography every run driver
-   * calls.
+   * lease (record retained, renewal stopped) and rethrows. A poisoned lease or
+   * failed lease deletion also retains the record and rejects this boundary.
+   * This is the one exit choreography every run driver calls.
    */
   async releaseExecutionLease(
     executionId: ExecutionId,
@@ -898,12 +899,19 @@ export class SessionHandle {
       await renewOwnedExecutionLease(executionId);
       await this.flushArtifacts(executionId);
       await renewOwnedExecutionLease(executionId);
-      await afterArtifactsDrained?.();
+      if (afterArtifactsDrained && isOwnedExecutionLeaseDurable(executionId)) {
+        await afterArtifactsDrained();
+      }
     } catch (error) {
       abandonOwnedExecutionLease(executionId);
       throw error;
     }
-    await completeOwnedExecutionLease(executionId);
+    const completion = await completeOwnedExecutionLease(executionId);
+    if (completion.status === 'released') return;
+    if (completion.reason === 'release-failed') throw completion.error;
+    throw new Error(
+      `Execution ${executionId} retained its lease because required artifacts are not durable.`,
+    );
   }
 
   /** Persist one execution's trace plus the session's shared artifact stores. */

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -883,15 +883,22 @@ export class SessionHandle {
    * writer has drained. Session artifacts persist between two short
    * owner-token validations — the durable lease remains fresh while the
    * session drains, so no file lock needs to cover unrelated transcript and
-   * snapshot I/O. A drain failure abandons the lease (record retained,
-   * renewal stopped) and rethrows; a poisoned lease completes as abandon.
-   * This is the one exit choreography every run driver calls.
+   * snapshot I/O. An optional post-drain operation may publish lifecycle state
+   * that is valid only once those artifacts are durable; it still runs before
+   * the lease record is deleted. A drain or post-drain failure abandons the
+   * lease (record retained, renewal stopped) and rethrows; a poisoned lease
+   * completes as abandon. This is the one exit choreography every run driver
+   * calls.
    */
-  async releaseExecutionLease(executionId: ExecutionId): Promise<void> {
+  async releaseExecutionLease(
+    executionId: ExecutionId,
+    afterArtifactsDrained?: () => void | Promise<void>,
+  ): Promise<void> {
     try {
       await renewOwnedExecutionLease(executionId);
       await this.flushArtifacts(executionId);
       await renewOwnedExecutionLease(executionId);
+      await afterArtifactsDrained?.();
     } catch (error) {
       abandonOwnedExecutionLease(executionId);
       throw error;

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -325,6 +325,8 @@ export interface ChildRunLoopParams<TTurn> {
     readonly isError: boolean;
     readonly error?: unknown;
   }) => void;
+  /** Publish caller-owned state after final artifacts drain, before lease release. */
+  readonly afterArtifactsDrained?: () => void | Promise<void>;
 }
 
 export interface ChildRunLoopHandle {
@@ -1147,7 +1149,10 @@ export function startChildRunLoop<TTurn>(
         );
       } finally {
         try {
-          await runSession.releaseExecutionLease(executionId);
+          await runSession.releaseExecutionLease(
+            executionId,
+            params.afterArtifactsDrained,
+          );
         } catch (error) {
           logger.warn('Failed to persist final child-run artifacts', {
             data: { executionId, error },

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -58,6 +58,15 @@ export type ExecutionLeasePresence =
   | { readonly status: 'owned'; readonly heartbeatAt: number }
   | { readonly status: 'foreign'; readonly heartbeatAt: number };
 
+export type OwnedExecutionLeaseCompletion =
+  | { readonly status: 'released' }
+  | { readonly status: 'retained'; readonly reason: 'undurable' }
+  | {
+      readonly status: 'retained';
+      readonly reason: 'release-failed';
+      readonly error: unknown;
+    };
+
 export type OwnedExecutionLeaseScope = <T>(
   operation: () => T | Promise<T>,
 ) => T | Promise<T>;
@@ -702,21 +711,32 @@ export function markOwnedExecutionLeaseUndurable(
   }
 }
 
+/** Whether the current owned generation may publish post-drain durable state. */
+export function isOwnedExecutionLeaseDurable(
+  executionId: ExecutionId,
+): boolean {
+  const leases = currentOwnedLeases(executionId);
+  if (leases.length === 0) throw new ExecutionLeaseLostError(executionId);
+  return leases.every((lease) => !lease.durabilityFailed);
+}
+
 /** Release a durable execution; otherwise stop renewal and retain its record. */
 export async function completeOwnedExecutionLease(
   executionId: ExecutionId,
-): Promise<void> {
+): Promise<OwnedExecutionLeaseCompletion> {
   if (currentOwnedLeases(executionId).some((lease) => lease.durabilityFailed)) {
     abandonOwnedExecutionLease(executionId);
-    return;
+    return { status: 'retained', reason: 'undurable' };
   }
   try {
     await releaseOwnedExecutionLease(executionId);
+    return { status: 'released' };
   } catch (error) {
     log.warn(
       `Failed to release execution ${executionId}; its lease will expire after the stale horizon: ${toErrorMessage(error)}`,
       { data: error },
     );
+    return { status: 'retained', reason: 'release-failed', error };
   }
 }
 

--- a/src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressProjectionFailure.vitest.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AgentTrace } from '@agent/trace';
+import type { PersistedWorkflowScriptRunOptions } from '@agent/workflowScript';
+import type { WorkflowExecutionSnapshot } from '@shared/schemas';
+import { runPersistedWorkflowScriptWithProgress } from '@tools/delegation/workflowScriptRun';
+
+const mocks = vi.hoisted(() => ({
+  runPersistedWorkflowScript: vi.fn(),
+}));
+
+vi.mock('@agent/workflowScript', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@agent/workflowScript')>()),
+  runPersistedWorkflowScript: mocks.runPersistedWorkflowScript,
+}));
+
+function snapshot(
+  lifecycle: 'waiting' | 'active',
+  status: 'planned' | 'starting',
+): WorkflowExecutionSnapshot {
+  return {
+    stages: [
+      {
+        id: 'stage-review',
+        title: 'Review',
+        order: 0,
+        lifecycle,
+      },
+    ],
+    calls: [
+      {
+        id: 'retry-review',
+        label: 'Retry review',
+        stageId: 'stage-review',
+        stageTitle: 'Review',
+        status,
+        attempts: [{}],
+        files: {},
+        timestamps: {
+          createdAt: '2026-08-15T20:00:00.000Z',
+          updatedAt: '2026-08-15T20:00:01.000Z',
+        },
+      },
+    ],
+  } as WorkflowExecutionSnapshot;
+}
+
+describe('workflow-script projection failure recovery', () => {
+  it('retains call-issued admission when that fold fails before projection', async () => {
+    const construction = snapshot('waiting', 'planned');
+    const issued = snapshot('active', 'planned');
+    const running = snapshot('active', 'starting');
+    mocks.runPersistedWorkflowScript.mockImplementationOnce(
+      async (options: PersistedWorkflowScriptRunOptions) => {
+        options.onTransition?.(construction);
+        options.onTransition?.(issued, {
+          type: 'call-issued',
+          callId: 'retry-review',
+        });
+        options.onTransition?.(running);
+        await options.onSnapshot?.(running);
+        return { snapshot: running } as never;
+      },
+    );
+
+    const emit = vi.fn();
+    const warn = vi.fn();
+    const openStage = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error('trace projection unavailable');
+      })
+      .mockReturnValue({ id: 'trace-review', end: vi.fn() });
+    const trace = {
+      activeStageId: vi.fn(),
+      emit,
+      info: vi.fn(),
+      warn,
+      openStage,
+    } as unknown as AgentTrace;
+
+    await runPersistedWorkflowScriptWithProgress(trace, {
+      store: {} as never,
+      checkpointId: 'projection-failure',
+      script: 'return await agent("Retry review")',
+      runAgent: vi.fn(),
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('trace projection unavailable'),
+      expect.anything(),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'workflow.call',
+        call: expect.objectContaining({
+          id: 'retry-review',
+          status: 'running',
+        }),
+      }),
+    );
+  });
+});

--- a/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
@@ -141,7 +141,7 @@ describe('native agent launch activation', () => {
     mocks.releaseOwnedExecutionLeaseAfterFailure.mockImplementation(
       async (_executionId: ExecutionId, error: unknown) => error,
     );
-    mocks.completeOwnedExecutionLease.mockResolvedValue(undefined);
+    mocks.completeOwnedExecutionLease.mockResolvedValue({ status: 'released' });
   });
 
   it.each([

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -152,7 +152,7 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
     mocks.releaseOwnedExecutionLeaseAfterFailure.mockImplementation(
       async (_executionId: ExecutionId, error: unknown) => error,
     );
-    mocks.completeOwnedExecutionLease.mockResolvedValue(undefined);
+    mocks.completeOwnedExecutionLease.mockResolvedValue({ status: 'released' });
     // Default: the lifecycle wrapper just runs the flow against a no-op
     // handle. Tests that need a real handle override with
     // mockImplementationOnce, which takes precedence for their single call.

--- a/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
@@ -89,7 +89,7 @@ describe('runAgent execution ownership', () => {
       previousOutcome: undefined,
       streamId: 'assistant#run-agent-owner',
     });
-    mocks.completeOwnedExecutionLease.mockResolvedValue(undefined);
+    mocks.completeOwnedExecutionLease.mockResolvedValue({ status: 'released' });
     mocks.renewOwnedExecutionLease.mockResolvedValue(undefined);
     flushArtifacts.mockResolvedValue(undefined);
     mocks.finalizeExecution.mockResolvedValue(FINALIZE_RESULT);
@@ -203,6 +203,7 @@ describe('runAgent execution ownership', () => {
     });
     mocks.completeOwnedExecutionLease.mockImplementationOnce(async () => {
       order.push('release');
+      return { status: 'released' } as const;
     });
     await expect(launch({ registerExecution: true })).rejects.toBe(launchError);
 
@@ -278,6 +279,7 @@ describe('runAgent execution ownership', () => {
     });
     mocks.completeOwnedExecutionLease.mockImplementationOnce(async () => {
       order.push('release');
+      return { status: 'released' } as const;
     });
     flushArtifacts.mockImplementationOnce(async () => {
       order.push('session-artifacts');

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -20,6 +20,7 @@ import {
   captureOwnedExecutionLease,
   completeOwnedExecutionLease,
   inspectExecutionLease,
+  isOwnedExecutionLeaseDurable,
   markOwnedExecutionLeaseUndurable,
   onOwnedExecutionLeaseLost,
   ownsExecutionLease,
@@ -263,8 +264,32 @@ describe('cross-process execution leases', () => {
     const executionId = 'd86443' as ExecutionId;
     await acquire(executionId);
 
+    expect(isOwnedExecutionLeaseDurable(executionId)).toBe(true);
     markOwnedExecutionLeaseUndurable(executionId);
-    await completeOwnedExecutionLease(executionId);
+    expect(isOwnedExecutionLeaseDurable(executionId)).toBe(false);
+    await expect(completeOwnedExecutionLease(executionId)).resolves.toEqual({
+      status: 'retained',
+      reason: 'undurable',
+    });
+    ownedExecutionIds.delete(executionId);
+
+    expect(ownsExecutionLease(executionId)).toBe(false);
+    await expect(inspectExecutionLease(executionId)).resolves.toMatchObject({
+      status: 'foreign',
+    });
+  });
+
+  it('reports lease deletion failure while retaining its persisted record', async () => {
+    const executionId = 'd86444' as ExecutionId;
+    const deletionError = new Error('lease deletion failed');
+    await acquire(executionId);
+    vi.spyOn(StorageFS, 'delete').mockRejectedValueOnce(deletionError);
+
+    await expect(completeOwnedExecutionLease(executionId)).resolves.toEqual({
+      status: 'retained',
+      reason: 'release-failed',
+      error: deletionError,
+    });
     ownedExecutionIds.delete(executionId);
 
     expect(ownsExecutionLease(executionId)).toBe(false);

--- a/src/test-kernel/cli/SessionExitLease.vitest.ts
+++ b/src/test-kernel/cli/SessionExitLease.vitest.ts
@@ -49,7 +49,7 @@ describe('CLI session exit lease ownership', () => {
     mocks.runCliPlatformShutdownSequence.mockResolvedValue(undefined);
     completeLeaseSpy = vi
       .spyOn(executionLease, 'completeOwnedExecutionLease')
-      .mockResolvedValue(undefined);
+      .mockResolvedValue({ status: 'released' });
     exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
       throw new Error('process.exit');
     }) as typeof process.exit);
@@ -104,7 +104,10 @@ describe('CLI session exit lease ownership', () => {
       resumableIdle: true,
       flushArtifacts: pushes(order, 'flush'),
     });
-    completeLeaseSpy.mockImplementation(pushes(order, 'release'));
+    completeLeaseSpy.mockImplementation(async () => {
+      order.push('release');
+      return { status: 'released' };
+    });
 
     await expect(exitController.gracefulTeardown()).rejects.toThrow(
       'process.exit',
@@ -127,7 +130,10 @@ describe('CLI session exit lease ownership', () => {
       resumableIdle: true,
       flushArtifacts: pushes(order, 'flush'),
     });
-    completeLeaseSpy.mockImplementation(pushes(order, 'release'));
+    completeLeaseSpy.mockImplementation(async () => {
+      order.push('release');
+      return { status: 'released' };
+    });
     mocks.runCliPlatformShutdownSequence.mockImplementation(
       pushes(order, 'shutdown'),
     );

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -48,6 +48,7 @@ const mocks = vi.hoisted(() => ({
   getVisibleAgents: vi.fn(),
   inspectExecutionLease: vi.fn(),
   abandonOwnedExecutionLease: vi.fn(),
+  undurableExecutionIds: new Set<ExecutionId>(),
   isApprovalBypassedForStream: vi.fn(),
   isProposalBypassed: vi.fn(),
   registerExecution: vi.fn(),
@@ -95,15 +96,29 @@ vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
     (_executionId: ExecutionId) => (operation: () => unknown) =>
       operation(),
   inspectExecutionLease: mocks.inspectExecutionLease,
-  markOwnedExecutionLeaseUndurable: vi.fn(),
+  markOwnedExecutionLeaseUndurable: vi.fn((executionId: ExecutionId) => {
+    mocks.undurableExecutionIds.add(executionId);
+  }),
+  isOwnedExecutionLeaseDurable: vi.fn(
+    (executionId: ExecutionId) => !mocks.undurableExecutionIds.has(executionId),
+  ),
   ownsExecutionLease: vi.fn(() => true),
   // The session's one exit choreography runs for real over these inert lease
-  // verbs; the release spy observes its terminal step.
+  // verbs; completion mirrors production's explicit released/retained outcome.
   renewOwnedExecutionLease: vi.fn(async () => {}),
   abandonOwnedExecutionLease: mocks.abandonOwnedExecutionLease,
-  completeOwnedExecutionLease: vi.fn(async (executionId: ExecutionId) =>
-    mocks.releaseOwnedExecutionLease(executionId),
-  ),
+  completeOwnedExecutionLease: vi.fn(async (executionId: ExecutionId) => {
+    if (mocks.undurableExecutionIds.has(executionId)) {
+      mocks.abandonOwnedExecutionLease(executionId);
+      return { status: 'retained', reason: 'undurable' } as const;
+    }
+    try {
+      await mocks.releaseOwnedExecutionLease(executionId);
+      return { status: 'released' } as const;
+    } catch (error) {
+      return { status: 'retained', reason: 'release-failed', error } as const;
+    }
+  }),
 }));
 
 // `persistChildRun*` moved to `@agent/storage/childRunPersistence`, which
@@ -394,6 +409,7 @@ describe('headless delegation', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.undurableExecutionIds.clear();
     restoreAgentEngine = provideAgentEngine({
       executeAgent: mocks.executeAgent,
       resumeToolUseFromResumeData: mocks.resumeToolUseFromResumeData,
@@ -644,8 +660,28 @@ describe('headless delegation', () => {
     );
   });
 
-  it('recovers committed success when lease deletion fails', async () => {
+  it('does not commit or recover when required report persistence poisons the lease', async () => {
     const logicalExecutionId = 'cccccc888888' as ExecutionId;
+    const childStore = memoryExecutionStore();
+    useStableStores(stableSequenceStore(logicalExecutionId), childStore);
+    mocks.writeReport.mockRejectedValueOnce(new Error('report write failed'));
+
+    await expect(
+      runInBand(delegationOptions(), logicalExecutionId),
+    ).rejects.toBeInstanceOf(SubagentDurabilityError);
+    await expect(
+      runInBand(delegationOptions(), logicalExecutionId),
+    ).rejects.toBeInstanceOf(SubagentReconciliationError);
+
+    expect(mocks.executeAgent).toHaveBeenCalledOnce();
+    expect(childStore.write).not.toHaveBeenCalledWith(
+      'stable-subagent-attempt',
+      expect.objectContaining({ phase: 'committed' }),
+    );
+  });
+
+  it('recovers committed success when lease deletion fails', async () => {
+    const logicalExecutionId = 'cccccc999999' as ExecutionId;
     const childStore = memoryExecutionStore();
     const releaseError = new Error('lease deletion failed');
     useStableStores(stableSequenceStore(logicalExecutionId), childStore);

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -301,7 +301,7 @@ function mockWaitingChildOnce(
 
 function stableAttempt(
   logicalExecutionId: ExecutionId,
-  phase: 'reserved' | 'launched' | 'retryable' = 'launched',
+  phase: 'reserved' | 'launched' | 'committed' | 'retryable' = 'launched',
 ) {
   return {
     schemaVersion: 1,
@@ -350,7 +350,9 @@ function completedChildStore(
     listKeys: vi
       .fn()
       .mockResolvedValue(['stable-subagent-attempt', 'result-meta']),
-    read: vi.fn().mockResolvedValue(stableAttempt(logicalExecutionId)),
+    read: vi
+      .fn()
+      .mockResolvedValue(stableAttempt(logicalExecutionId, 'committed')),
     readResultMeta: vi.fn().mockResolvedValue({
       producer: 'subagent',
       agentName: 'review',
@@ -573,6 +575,32 @@ describe('headless delegation', () => {
     );
     expect(mocks.writeResultMeta.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.releaseOwnedExecutionLease.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('commits stable success only after final artifact release', async () => {
+    const logicalExecutionId = 'cccccc666666' as ExecutionId;
+    const childStore = memoryExecutionStore();
+    useStableStores(stableSequenceStore(logicalExecutionId), childStore);
+
+    await runInBand(delegationOptions(), logicalExecutionId);
+
+    const launchedWrite = childStore.write.mock.calls.findIndex(
+      ([key, value]) =>
+        key === 'stable-subagent-attempt' &&
+        (value as { phase?: string }).phase === 'launched',
+    );
+    const committedWrite = childStore.write.mock.calls.findIndex(
+      ([key, value]) =>
+        key === 'stable-subagent-attempt' &&
+        (value as { phase?: string }).phase === 'committed',
+    );
+    expect(launchedWrite).toBeGreaterThanOrEqual(0);
+    expect(committedWrite).toBeGreaterThan(launchedWrite);
+    expect(
+      childStore.write.mock.invocationCallOrder[committedWrite],
+    ).toBeGreaterThan(
+      mocks.releaseOwnedExecutionLease.mock.invocationCallOrder[0] ?? 0,
     );
   });
 
@@ -909,6 +937,40 @@ describe('headless delegation', () => {
     ).rejects.toBeInstanceOf(SubagentReconciliationError);
     expect(mocks.executeAgent).toHaveBeenCalledOnce();
     expect(mocks.releaseOwnedExecutionLease).toHaveBeenCalledOnce();
+  });
+
+  it('does not recover a completed manifest after restart repair removes an abandoned lease', async () => {
+    const cleanupFailure = new Error('artifact flush failed');
+    const logicalExecutionId = 'dddddd888888' as ExecutionId;
+    const childStore = memoryExecutionStore();
+    const write = childStore.write.getMockImplementation();
+    childStore.write.mockImplementation(async (key, value) => {
+      if (
+        key === 'stable-subagent-attempt' &&
+        (value as { phase?: string }).phase === 'retryable'
+      ) {
+        throw new ExecutionLeaseLostError(logicalExecutionId);
+      }
+      return await write?.(key, value);
+    });
+    useStableStores(stableSequenceStore(logicalExecutionId), childStore);
+    mocks.releaseOwnedExecutionLease.mockRejectedValueOnce(cleanupFailure);
+
+    await expect(
+      runInBand(delegationOptions(), logicalExecutionId),
+    ).rejects.toMatchObject({
+      name: 'SubagentDurabilityError',
+      cause: cleanupFailure,
+    });
+
+    // Restart repair has removed the stale abandoned lease before the stable
+    // call resumes. Missing lease state must not attest that artifact release
+    // succeeded; only the explicit post-release commit marker can do that.
+    mocks.inspectExecutionLease.mockResolvedValue({ status: 'missing' });
+    await expect(
+      runInBand(delegationOptions(), logicalExecutionId),
+    ).rejects.toBeInstanceOf(SubagentReconciliationError);
+    expect(mocks.executeAgent).toHaveBeenCalledOnce();
   });
 
   it('preserves the child failure when its failure manifest cannot be written', async () => {

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -597,6 +597,7 @@ describe('headless delegation', () => {
     );
     expect(launchedWrite).toBeGreaterThanOrEqual(0);
     expect(committedWrite).toBeGreaterThan(launchedWrite);
+    expect(mocks.releaseOwnedExecutionLease).toHaveBeenCalledOnce();
     expect(
       childStore.write.mock.invocationCallOrder[committedWrite],
     ).toBeGreaterThan(
@@ -762,6 +763,26 @@ describe('headless delegation', () => {
     expect(mocks.executeAgent).not.toHaveBeenCalled();
   });
 
+  it('refuses to repeat a committed child whose result manifest is missing', async () => {
+    const logicalExecutionId = 'cccccc777777' as ExecutionId;
+    const sequenceStore = stableSequenceStore(logicalExecutionId, 1);
+    useStableStores(sequenceStore, {
+      ...emptyChildStore(),
+      listKeys: vi
+        .fn()
+        .mockResolvedValue(['stable-subagent-attempt', 'config']),
+      read: vi
+        .fn()
+        .mockResolvedValue(stableAttempt(logicalExecutionId, 'committed')),
+    });
+
+    await expect(
+      runInBand(delegationOptions(), logicalExecutionId),
+    ).rejects.toBeInstanceOf(SubagentReconciliationError);
+    expect(mocks.registerExecution).not.toHaveBeenCalled();
+    expect(mocks.executeAgent).not.toHaveBeenCalled();
+  });
+
   it('refuses to repeat an incomplete stable child', async () => {
     const logicalExecutionId = 'dddddd444444' as ExecutionId;
     const sequenceStore = stableSequenceStore(logicalExecutionId, 1);
@@ -880,6 +901,28 @@ describe('headless delegation', () => {
         parentExecutionId: STABLE_PARENT_EXECUTION_ID,
         streamId: expect.stringContaining(`#${completed.executionId}`),
       }),
+    );
+  });
+
+  it('does not commit a cancelled stable child as successful', async () => {
+    const logicalExecutionId = 'eeeeee666666' as ExecutionId;
+    const childStore = memoryExecutionStore();
+    useStableStores(stableSequenceStore(logicalExecutionId), childStore);
+    mocks.executeAgent.mockResolvedValueOnce({
+      category: 'toolUse',
+      outcome: 'cancelled',
+      executionId: logicalExecutionId,
+      streamId: 'child-stream',
+      response: '',
+      files: [],
+    });
+
+    const completed = await runInBand(delegationOptions(), logicalExecutionId);
+
+    expect(completed.result.outcome).toBe('cancelled');
+    expect(childStore.write).not.toHaveBeenCalledWith(
+      'stable-subagent-attempt',
+      expect.objectContaining({ phase: 'committed' }),
     );
   });
 

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -47,6 +47,7 @@ const mocks = vi.hoisted(() => ({
   getExecutionStore: vi.fn(),
   getVisibleAgents: vi.fn(),
   inspectExecutionLease: vi.fn(),
+  abandonOwnedExecutionLease: vi.fn(),
   isApprovalBypassedForStream: vi.fn(),
   isProposalBypassed: vi.fn(),
   registerExecution: vi.fn(),
@@ -99,7 +100,7 @@ vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
   // The session's one exit choreography runs for real over these inert lease
   // verbs; the release spy observes its terminal step.
   renewOwnedExecutionLease: vi.fn(async () => {}),
-  abandonOwnedExecutionLease: vi.fn(),
+  abandonOwnedExecutionLease: mocks.abandonOwnedExecutionLease,
   completeOwnedExecutionLease: vi.fn(async (executionId: ExecutionId) =>
     mocks.releaseOwnedExecutionLease(executionId),
   ),
@@ -578,30 +579,97 @@ describe('headless delegation', () => {
     );
   });
 
-  it('commits stable success only after final artifact release', async () => {
+  it('commits stable success after artifact drain but before lease release', async () => {
     const logicalExecutionId = 'cccccc666666' as ExecutionId;
     const childStore = memoryExecutionStore();
+    const order: string[] = [];
+    const originalWrite = childStore.write.getMockImplementation();
+    childStore.write.mockImplementation(async (key, value) => {
+      await originalWrite?.(key, value);
+      const phase = (value as { phase?: string }).phase;
+      if (phase) order.push(phase);
+    });
+    const detachFlusher = defaultSession().useArtifactFlusher(async () => {
+      order.push('drain');
+    });
+    mocks.releaseOwnedExecutionLease.mockImplementationOnce(async () => {
+      order.push('release');
+    });
     useStableStores(stableSequenceStore(logicalExecutionId), childStore);
 
-    await runInBand(delegationOptions(), logicalExecutionId);
+    try {
+      await runInBand(delegationOptions(), logicalExecutionId);
+    } finally {
+      detachFlusher();
+    }
 
-    const launchedWrite = childStore.write.mock.calls.findIndex(
-      ([key, value]) =>
-        key === 'stable-subagent-attempt' &&
-        (value as { phase?: string }).phase === 'launched',
-    );
-    const committedWrite = childStore.write.mock.calls.findIndex(
-      ([key, value]) =>
-        key === 'stable-subagent-attempt' &&
-        (value as { phase?: string }).phase === 'committed',
-    );
-    expect(launchedWrite).toBeGreaterThanOrEqual(0);
-    expect(committedWrite).toBeGreaterThan(launchedWrite);
+    expect(order).toContain('launched');
+    expect(order.lastIndexOf('drain')).toBeLessThan(order.indexOf('committed'));
+    expect(order.indexOf('committed')).toBeLessThan(order.indexOf('release'));
     expect(mocks.releaseOwnedExecutionLease).toHaveBeenCalledOnce();
-    expect(
-      childStore.write.mock.invocationCallOrder[committedWrite],
-    ).toBeGreaterThan(
-      mocks.releaseOwnedExecutionLease.mock.invocationCallOrder[0] ?? 0,
+  });
+
+  it('abandons the lease when the post-drain stable commit fails', async () => {
+    const logicalExecutionId = 'cccccc777777' as ExecutionId;
+    const childStore = memoryExecutionStore();
+    const commitError = new Error('commit write failed');
+    const originalWrite = childStore.write.getMockImplementation();
+    childStore.write.mockImplementation(async (key, value) => {
+      if ((value as { phase?: string }).phase === 'committed') {
+        throw commitError;
+      }
+      await originalWrite?.(key, value);
+    });
+    useStableStores(stableSequenceStore(logicalExecutionId), childStore);
+
+    await expect(
+      runInBand(delegationOptions(), logicalExecutionId),
+    ).rejects.toMatchObject({
+      name: 'SubagentCommitError',
+      message: expect.stringContaining('Failed to commit durable completion'),
+      cause: commitError,
+    });
+
+    expect(mocks.abandonOwnedExecutionLease).toHaveBeenCalledWith(
+      logicalExecutionId,
+    );
+    expect(mocks.releaseOwnedExecutionLease).not.toHaveBeenCalled();
+    expect(childStore.write).toHaveBeenCalledWith(
+      'stable-subagent-attempt',
+      expect.objectContaining({ phase: 'launched' }),
+    );
+    expect(childStore.write).not.toHaveBeenCalledWith(
+      'stable-subagent-attempt',
+      expect.objectContaining({ phase: 'retryable' }),
+    );
+  });
+
+  it('recovers committed success when lease deletion fails', async () => {
+    const logicalExecutionId = 'cccccc888888' as ExecutionId;
+    const childStore = memoryExecutionStore();
+    const releaseError = new Error('lease deletion failed');
+    useStableStores(stableSequenceStore(logicalExecutionId), childStore);
+    mocks.releaseOwnedExecutionLease.mockRejectedValueOnce(releaseError);
+
+    await expect(
+      runInBand(delegationOptions(), logicalExecutionId),
+    ).rejects.toMatchObject({
+      name: 'SubagentDurabilityError',
+      message: expect.stringContaining('committed durable completion'),
+      cause: releaseError,
+    });
+    await expect(
+      runInBand(delegationOptions(), logicalExecutionId),
+    ).resolves.toMatchObject({ executionId: logicalExecutionId });
+
+    expect(mocks.executeAgent).toHaveBeenCalledOnce();
+    expect(childStore.write).toHaveBeenCalledWith(
+      'stable-subagent-attempt',
+      expect.objectContaining({ phase: 'committed' }),
+    );
+    expect(childStore.write).not.toHaveBeenCalledWith(
+      'stable-subagent-attempt',
+      expect.objectContaining({ phase: 'retryable' }),
     );
   });
 
@@ -962,14 +1030,20 @@ describe('headless delegation', () => {
       return await write?.(key, value);
     });
     useStableStores(stableSequenceStore(logicalExecutionId), childStore);
-    mocks.releaseOwnedExecutionLease.mockRejectedValueOnce(cleanupFailure);
-
-    await expect(
-      runInBand(delegationOptions(), logicalExecutionId),
-    ).rejects.toMatchObject({
-      name: 'SubagentDurabilityError',
-      cause: cleanupFailure,
+    const detachFlusher = defaultSession().useArtifactFlusher(async () => {
+      throw cleanupFailure;
     });
+
+    try {
+      await expect(
+        runInBand(delegationOptions(), logicalExecutionId),
+      ).rejects.toMatchObject({
+        name: 'SubagentDurabilityError',
+        cause: cleanupFailure,
+      });
+    } finally {
+      detachFlusher();
+    }
     mocks.inspectExecutionLease.mockResolvedValueOnce({
       status: 'foreign',
       heartbeatAt: Date.now(),
@@ -979,7 +1053,7 @@ describe('headless delegation', () => {
       runInBand(delegationOptions(), logicalExecutionId),
     ).rejects.toBeInstanceOf(SubagentReconciliationError);
     expect(mocks.executeAgent).toHaveBeenCalledOnce();
-    expect(mocks.releaseOwnedExecutionLease).toHaveBeenCalledOnce();
+    expect(mocks.releaseOwnedExecutionLease).not.toHaveBeenCalled();
   });
 
   it('does not recover a completed manifest after restart repair removes an abandoned lease', async () => {
@@ -999,19 +1073,25 @@ describe('headless delegation', () => {
       return await write?.(key, value);
     });
     useStableStores(stableSequenceStore(logicalExecutionId), childStore);
-    mocks.releaseOwnedExecutionLease.mockRejectedValueOnce(cleanupFailure);
-
-    await expect(
-      runInBand(delegationOptions(), logicalExecutionId),
-    ).rejects.toMatchObject({
-      name: 'SubagentDurabilityError',
-      cause: cleanupFailure,
+    const detachFlusher = defaultSession().useArtifactFlusher(async () => {
+      throw cleanupFailure;
     });
+
+    try {
+      await expect(
+        runInBand(delegationOptions(), logicalExecutionId),
+      ).rejects.toMatchObject({
+        name: 'SubagentDurabilityError',
+        cause: cleanupFailure,
+      });
+    } finally {
+      detachFlusher();
+    }
 
     // Perform the restart repair's observable lease transition before the
     // stable call resumes: the abandoned lease no longer fences store writes.
     // That absence must not attest artifact-release success; only the explicit
-    // post-release commit marker can do that.
+    // post-drain commit marker can do that.
     abandonedLeasePresent = false;
     await expect(
       runInBand(delegationOptions(), logicalExecutionId),

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -944,8 +944,10 @@ describe('headless delegation', () => {
     const logicalExecutionId = 'dddddd888888' as ExecutionId;
     const childStore = memoryExecutionStore();
     const write = childStore.write.getMockImplementation();
+    let abandonedLeasePresent = true;
     childStore.write.mockImplementation(async (key, value) => {
       if (
+        abandonedLeasePresent &&
         key === 'stable-subagent-attempt' &&
         (value as { phase?: string }).phase === 'retryable'
       ) {
@@ -963,10 +965,11 @@ describe('headless delegation', () => {
       cause: cleanupFailure,
     });
 
-    // Restart repair has removed the stale abandoned lease before the stable
-    // call resumes. Missing lease state must not attest that artifact release
-    // succeeded; only the explicit post-release commit marker can do that.
-    mocks.inspectExecutionLease.mockResolvedValue({ status: 'missing' });
+    // Perform the restart repair's observable lease transition before the
+    // stable call resumes: the abandoned lease no longer fences store writes.
+    // That absence must not attest artifact-release success; only the explicit
+    // post-release commit marker can do that.
+    abandonedLeasePresent = false;
     await expect(
       runInBand(delegationOptions(), logicalExecutionId),
     ).rejects.toBeInstanceOf(SubagentReconciliationError);

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -70,7 +70,9 @@ vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
       operation(),
   renewOwnedExecutionLease: vi.fn(async () => {}),
   abandonOwnedExecutionLease: vi.fn(),
-  completeOwnedExecutionLease: vi.fn(async () => {}),
+  completeOwnedExecutionLease: vi.fn(async () => ({
+    status: 'released' as const,
+  })),
 }));
 
 vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({

--- a/src/tools/delegation/detachedChildRun.ts
+++ b/src/tools/delegation/detachedChildRun.ts
@@ -57,6 +57,8 @@ export interface DetachedChildRunInput<TTurn> {
   readonly notify?: ChildRunLoopParams<never>['notify'];
   /** In-memory settled-turn facts for awaiting persist-only callers. */
   readonly onTurnSettled?: ChildRunLoopParams<never>['onTurnSettled'];
+  /** Publish caller-owned state after final artifacts drain, before lease release. */
+  readonly afterArtifactsDrained?: ChildRunLoopParams<never>['afterArtifactsDrained'];
   /**
    * Build the strategy (and any attempt-scoped setup) INSIDE the lease launch
    * guard: a throw here must release the owned-execution lease. A function
@@ -87,6 +89,9 @@ export async function startDetachedChildRunLoop<TTurn>(
       ...(input.notify !== undefined && { notify: input.notify }),
       ...(input.onTurnSettled !== undefined && {
         onTurnSettled: input.onTurnSettled,
+      }),
+      ...(input.afterArtifactsDrained !== undefined && {
+        afterArtifactsDrained: input.afterArtifactsDrained,
       }),
       // Every detached native/workflow child takes one shared-budget slot per
       // turn; an awaited in-band child rides its idle parent's slot instead.

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -260,7 +260,8 @@ async function inspectStableAttempt(
     // additionally requires the post-release marker written after the child
     // loop and its artifact drain both returned successfully. Lease absence
     // is not an attestation: restart repair may already have removed an
-    // abandoned lease from a failed drain.
+    // abandoned lease from a failed drain. This ambiguity deliberately stays
+    // irreconcilable rather than risking repeated side-effectful work.
     throw new SubagentReconciliationError(
       `Cannot attest durable completion for persisted subagent ${executionId}; refusing to recover its result.`,
     );

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -17,7 +17,6 @@ import { getExecutionStore, type ResultMeta } from '@agent/storage';
 import { registerOwnedExecution } from '@agent/storage/executionLifecycle';
 import {
   ExecutionLeaseLostError,
-  inspectExecutionLease,
   runWithInactiveExecutionLease,
   type OwnedExecutionLeaseScope,
 } from '@agent/storage/executionLease';
@@ -256,43 +255,15 @@ async function inspectStableAttempt(
   }
   if (attempt.phase === 'retryable') return { kind: 'advance' };
   if (resultMeta.result.outcome !== 'completed') return { kind: 'advance' };
-  if (attempt.phase === 'launched') {
-    // A clean terminal release deletes the lease before recovery. A final
-    // artifact-drain failure instead abandons its persisted lease, so a fresh
-    // record means the parent's retryable-marker write was deferred. Never
-    // accept that manifest as durable success: wait while the lease is fresh,
-    // then repair the attempt once the abandoned record becomes stale.
-    let lease: Awaited<ReturnType<typeof inspectExecutionLease>>;
-    try {
-      lease = await inspectExecutionLease(executionId);
-    } catch (error) {
-      throw new SubagentReconciliationError(
-        `Failed to inspect the lease for persisted subagent ${executionId}.`,
-        { cause: error },
-      );
-    }
-    if (lease.status === 'owned' || lease.status === 'foreign') {
-      throw new SubagentReconciliationError(
-        `Subagent ${executionId} still has a live lease; refusing to recover its result.`,
-      );
-    }
-    if (lease.status === 'stale') {
-      const repair = await runWithInactiveExecutionLease(executionId, () =>
-        writeStableSubagentAttempt(store, {
-          ...attempt,
-          phase: 'retryable',
-        }),
-      ).catch((error: unknown) => {
-        throw new SubagentReconciliationError(
-          `Failed to repair the abandoned subagent ${executionId}.`,
-          { cause: error },
-        );
-      });
-      if (repair.status === 'performed') return { kind: 'advance' };
-      throw new SubagentReconciliationError(
-        `Subagent ${executionId} regained a live lease; refusing to recover its result.`,
-      );
-    }
+  if (attempt.phase !== 'committed') {
+    // A completed manifest proves only that the child turn settled. Recovery
+    // additionally requires the post-release marker written after the child
+    // loop and its artifact drain both returned successfully. Lease absence
+    // is not an attestation: restart repair may already have removed an
+    // abandoned lease from a failed drain.
+    throw new SubagentReconciliationError(
+      `Cannot attest durable completion for persisted subagent ${executionId}; refusing to recover its result.`,
+    );
   }
   options.signal?.throwIfAborted();
   return {
@@ -416,7 +387,7 @@ async function executeInBand(
     }
     throw cause;
   }
-  return await runWithOwnership(async () => {
+  const completed = await runWithOwnership(async () => {
     let settledTurn: SettledInBandTurn | undefined;
     const { completion } = await startDetachedChildRunLoop({
       executionId,
@@ -563,15 +534,31 @@ async function executeInBand(
       );
     }
 
-    // Post-run cancellation deliberately observes a terminal record:
-    // rejecting here fails the awaiting caller without rewriting the child.
-    options.signal?.throwIfAborted();
     return {
       executionId,
       result,
       ...(mode === 'best-effort-delivery' && { delivery: settledTurn.message }),
     };
   });
+
+  if (stableAttempt) {
+    try {
+      await writeStableSubagentAttempt(getExecutionStore(executionId), {
+        ...stableAttempt,
+        phase: 'committed',
+      });
+    } catch (cause) {
+      throw new SubagentDurabilityError(
+        `Failed to commit durable completion for subagent ${executionId}.`,
+        { cause },
+      );
+    }
+  }
+  // Post-run cancellation deliberately observes a terminal record: stable
+  // success is committed first, then the awaiting caller rejects without
+  // rewriting the child.
+  options.signal?.throwIfAborted();
+  return completed;
 }
 
 /** Recover a logical child first; resolve launch-only state only when needed. */

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -524,21 +524,6 @@ async function executeInBand(
       );
     }
 
-    if (
-      mode === 'required-result' &&
-      loopFailure !== undefined &&
-      !childFailed
-    ) {
-      await throwRetryableDurabilityError(
-        executionId,
-        stableAttempt,
-        new SubagentDurabilityError(
-          `Subagent ${executionId} failed to persist its final artifacts.`,
-          { cause: loopFailure },
-        ),
-      );
-    }
-
     if (mode === 'required-result') {
       // The ledger recovers restarts by inspecting the persisted manifest, so
       // the in-memory copy is not enough here: verify the write landed. A
@@ -579,6 +564,21 @@ async function executeInBand(
           `Failed to persist result for subagent ${executionId}.`,
         );
       }
+    }
+
+    if (
+      mode === 'required-result' &&
+      loopFailure !== undefined &&
+      !childFailed
+    ) {
+      await throwRetryableDurabilityError(
+        executionId,
+        stableAttempt,
+        new SubagentDurabilityError(
+          `Subagent ${executionId} failed to persist its final artifacts.`,
+          { cause: loopFailure },
+        ),
+      );
     }
 
     if (childFailed) {

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -193,6 +193,11 @@ async function inspectStableAttempt(
     );
   }
   if (!resultMeta) {
+    if (attempt.phase === 'committed') {
+      throw new SubagentReconciliationError(
+        `Committed subagent ${executionId} is missing its result manifest; refusing to repeat it.`,
+      );
+    }
     if (attempt.phase !== 'launched') return { kind: 'advance' };
     // A launched attempt without a manifest is unsafe to repeat only if the
     // child may have finished side-effectful work whose manifest was lost:
@@ -542,7 +547,7 @@ async function executeInBand(
     };
   });
 
-  if (stableAttempt) {
+  if (stableAttempt && completed.result.outcome === RUN_OUTCOME.COMPLETED) {
     try {
       await writeStableSubagentAttempt(getExecutionStore(executionId), {
         ...stableAttempt,

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -146,6 +146,13 @@ export class SubagentReconciliationError extends SubagentDurabilityError {
   }
 }
 
+class SubagentCommitError extends SubagentDurabilityError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'SubagentCommitError';
+  }
+}
+
 const MAX_STABLE_ATTEMPTS = 1_024;
 
 // Parent execution ownership is process-local. Serialize duplicate dispatches
@@ -262,9 +269,9 @@ async function inspectStableAttempt(
   if (resultMeta.result.outcome !== 'completed') return { kind: 'advance' };
   if (attempt.phase !== 'committed') {
     // A completed manifest proves only that the child turn settled. Recovery
-    // additionally requires the post-release marker written after the child
-    // loop and its artifact drain both returned successfully. Lease absence
-    // is not an attestation: restart repair may already have removed an
+    // additionally requires the marker written after the child artifact drain
+    // and before its lease record is deleted. Lease absence is not an
+    // attestation: restart repair may already have removed an
     // abandoned lease from a failed drain. This ambiguity deliberately stays
     // irreconcilable rather than risking repeated side-effectful work.
     throw new SubagentReconciliationError(
@@ -393,6 +400,7 @@ async function executeInBand(
     }
     throw cause;
   }
+  let stableCompletionCommitted = false;
   const completed = await runWithOwnership(async () => {
     let settledTurn: SettledInBandTurn | undefined;
     const { completion } = await startDetachedChildRunLoop({
@@ -407,6 +415,43 @@ async function executeInBand(
       ...(options.notify !== undefined && { notify: options.notify }),
       onTurnSettled: (settled) => {
         settledTurn = settled;
+      },
+      afterArtifactsDrained: async () => {
+        const settledResultMeta = settledTurn?.resultMeta;
+        if (
+          !stableAttempt ||
+          settledTurn?.isError === true ||
+          settledResultMeta?.producer !== 'subagent' ||
+          settledResultMeta.result.outcome !== RUN_OUTCOME.COMPLETED
+        ) {
+          return;
+        }
+        let persisted: ResultMeta | null;
+        try {
+          persisted = await getExecutionStore(executionId).readResultMeta();
+        } catch (cause) {
+          throw new SubagentCommitError(
+            `Failed to verify durable completion for subagent ${executionId}.`,
+            { cause },
+          );
+        }
+        if (!persisted || persisted.producer !== 'subagent') {
+          throw new SubagentCommitError(
+            `Failed to persist result for subagent ${executionId}.`,
+          );
+        }
+        try {
+          await writeStableSubagentAttempt(getExecutionStore(executionId), {
+            ...stableAttempt,
+            phase: 'committed',
+          });
+          stableCompletionCommitted = true;
+        } catch (cause) {
+          throw new SubagentCommitError(
+            `Failed to commit durable completion for subagent ${executionId}.`,
+            { cause },
+          );
+        }
       },
       buildLaunch: async () => {
         // Inside the loop's lease launch guard, like every attempt-scoped
@@ -470,6 +515,14 @@ async function executeInBand(
     const result = resultMeta.result;
     const childFailed =
       settledTurn.isError || result.outcome === RUN_OUTCOME.FAILED;
+
+    if (loopFailure instanceof SubagentCommitError) throw loopFailure;
+    if (loopFailure !== undefined && stableCompletionCommitted) {
+      throw new SubagentDurabilityError(
+        `Subagent ${executionId} committed durable completion but failed to release its execution lease.`,
+        { cause: loopFailure },
+      );
+    }
 
     if (
       mode === 'required-result' &&
@@ -547,22 +600,9 @@ async function executeInBand(
     };
   });
 
-  if (stableAttempt && completed.result.outcome === RUN_OUTCOME.COMPLETED) {
-    try {
-      await writeStableSubagentAttempt(getExecutionStore(executionId), {
-        ...stableAttempt,
-        phase: 'committed',
-      });
-    } catch (cause) {
-      throw new SubagentDurabilityError(
-        `Failed to commit durable completion for subagent ${executionId}.`,
-        { cause },
-      );
-    }
-  }
   // Post-run cancellation deliberately observes a terminal record: stable
-  // success is committed first, then the awaiting caller rejects without
-  // rewriting the child.
+  // success was committed inside the post-drain/pre-release lease boundary,
+  // then the awaiting caller rejects without rewriting the child.
   options.signal?.throwIfAborted();
   return completed;
 }

--- a/src/tools/delegation/stableSubagentAttempt.ts
+++ b/src/tools/delegation/stableSubagentAttempt.ts
@@ -13,7 +13,7 @@ const StableSubagentAttemptSchema = z.strictObject({
   schemaVersion: z.literal(STABLE_SUBAGENT_STATE_SCHEMA_VERSION),
   logicalExecutionId: ExecutionIdSchema,
   parentExecutionId: ExecutionIdSchema,
-  phase: z.enum(['reserved', 'launched', 'retryable']),
+  phase: z.enum(['reserved', 'launched', 'committed', 'retryable']),
 });
 
 export type StableSubagentAttempt = z.infer<typeof StableSubagentAttemptSchema>;
@@ -76,7 +76,7 @@ export async function readStableSubagentAttempt(
   return raw === undefined ? null : StableSubagentAttemptSchema.parse(raw);
 }
 
-/** Atomically replace the stable-call marker before crossing a launch edge. */
+/** Atomically replace the stable-call marker at a durable lifecycle edge. */
 export async function writeStableSubagentAttempt(
   store: ExecutionKVStore,
   attempt: StableSubagentAttempt,

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -224,6 +224,7 @@ export async function runPersistedWorkflowScriptWithProgress(
     }
   >();
   let constructionEmissionSeen = false;
+  const issuedCallIds = new Set<WorkflowCallProgress['id']>();
   let runOutcome: RunOutcome = RUN_OUTCOME.FAILED;
 
   /**
@@ -427,6 +428,9 @@ export async function runPersistedWorkflowScriptWithProgress(
     transition?: WorkflowExecutionTransition,
   ): void => {
     if (closed) return;
+    if (transition?.type === 'call-issued') {
+      issuedCallIds.add(transition.callId);
+    }
     try {
       declaredStageTotal ??= snapshot.stages.length;
       for (const stage of snapshot.stages) {
@@ -477,10 +481,7 @@ export async function runPersistedWorkflowScriptWithProgress(
           // hydration and reissue occur within the same clock tick. Sweep-only
           // terminalization of an omitted call therefore stays silent.
           if (baseline.status === 'planned') {
-            const reissued =
-              transition?.type === 'call-issued' &&
-              transition.callId === call.id;
-            if (!reissued) continue;
+            if (!issuedCallIds.has(call.id)) continue;
           } else if (
             baseline.status === status &&
             baseline.childStreamId === call.childStreamId
@@ -488,6 +489,7 @@ export async function runPersistedWorkflowScriptWithProgress(
             continue;
           }
           hydratedBaseline.delete(call.id);
+          issuedCallIds.delete(call.id);
         }
         const streamChanged =
           call.childStreamId !== undefined &&


### PR DESCRIPTION
## Summary

Follow-up to #10475 for two post-merge lifecycle defects found during independent review:

- require an explicit stable-attempt `committed` marker before recovering a completed subagent manifest; write it only after the child loop's final artifact release succeeds, so lease absence after stale restart repair cannot attest success
- latch `call-issued` identities at workflow projection fold entry and retain them until hydrated-baseline admission, so a fallible earlier projection step cannot permanently suppress a reissued call

## Regression coverage

- artifact-drain failure followed by restart repair removing the abandoned lease still rejects the ambiguous completed manifest
- stable success marker ordering is after final artifact release
- one failed `call-issued` fold followed by a later transition still projects the reissued hydrated call

## Verification

- targeted and surrounding delegation/workflow tests: 7 files, 168 tests passed
- focused final delegation tests: 40 passed
- `npm run typecheck:workspace`
- `npm run typecheck:test-kernel`
- changed-file ESLint
- changed-file Prettier check
- `git diff --check`
