### PR TITLE
refactor(agent): inject tool-policy fields into cycle flows (#10594)

### DIFF
--- a/docs/proposals/2026-08-15-agent-sdk-readiness-reverify.md
+++ b/docs/proposals/2026-08-15-agent-sdk-readiness-reverify.md
@@ -122,8 +122,10 @@ a change this pass makes.
   injecting those specific launch-context values as explicit immutable service
   fields (or a small injected tool-policy function), which would make the core
   cycle flow drivable without an ALS frame — the property an SDK embedder wants.
-  **Disposition:** the one core item worth scheduling; small, but a real port
-  addition, not a one-line substitution.
+  **Disposition:** landed — #10594 injected the three tool-policy values
+  (`approvalPromptsUnavailable`, `runtimeUnavailableTools`, `stopAfterCycle`) as
+  an immutable `ToolPolicy` service field (`AgentCore.toolPolicy`), making both
+  the response-cycle and tool-use cycle flows drivable without an ALS frame.
 - **C-2: persisted-flow layer is storage-coupled.** The generic node engine
   (`node/index.ts`) is host-clean, but `node/persistedFlow.ts:8-9` imports the
   concrete `@agent/storage/ExecutionKVStore` and a `FlowTransition` enum value.
@@ -364,12 +366,13 @@ executionId)`. **Residual coupling:** it hard-imports and calls `submitFollowUp`
    shape.
 
 The genuine small candidates a future pass can pick up one at a time — in the
-same land-one-increment cadence this pass followed with §3 — are **C-1** (inject
-the launch-context tool-policy fields so the cycle flow — and the tool-use flow's
-own ALS reads — run without an ALS frame), **L-1** (narrow the individual
-log-only `createChannelTrace` callers onto `createLog` — a per-caller change, not
-a factory merge, since the two have different return contracts), and **L-3**
-(wire or delete the dead redaction-options branch — the one small defect).
+same land-one-increment cadence this pass followed with §3 — are **L-1** (narrow
+the individual log-only `createChannelTrace` callers onto `createLog` — a
+per-caller change, not a factory merge, since the two have different return
+contracts) and **L-3** (wire or delete the dead redaction-options branch — the
+one small defect). **C-1** is closed: #10594 injected the three launch-context
+tool-policy values as an immutable `ToolPolicy` service field, so the cycle flow
+and the tool-use flow's own ALS reads now run without an ALS frame.
 **S-1 and T-1 were retracted on inspection** (§4): S-1 would be a banned
 single-use extraction, and T-1 misread an already-composed schema. The two
 structural blockers (§6) — the delegation-layer cycle and the process-wide

--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -14,6 +14,29 @@ export type RoundFinalizedCallback = (
   run: AgentRunStateSnapshot,
 ) => void | Promise<void>;
 
+/**
+ * Immutable per-run tool policy the cycle flows read directly from services.
+ *
+ * These are the launch-context tool-policy values that previously rode the
+ * ambient `RunContext` (`approvalPromptsUnavailable`, `runtimeUnavailableTools`,
+ * `stopAfterCycle`). Injecting them as an explicit frozen service field lets
+ * the response-cycle and tool-use cycle flows run without an
+ * `AsyncLocalStorage` frame — the property an SDK embedder wants.
+ */
+export interface ToolPolicy {
+  /** Hide tools whose approval prompts cannot be answered in this host mode. */
+  readonly approvalPromptsUnavailable?: boolean;
+  /** Hide tools unavailable because the current host/runtime cannot support them. */
+  readonly runtimeUnavailableTools?: readonly string[];
+  /** Stop a tool-use execution after one model/tool cycle instead of waiting. */
+  readonly stopAfterCycle?: boolean;
+}
+
+/** Freeze a tool policy so flows cannot mutate it mid-run. */
+export function createToolPolicy(policy: ToolPolicy = {}): ToolPolicy {
+  return Object.freeze({ ...policy });
+}
+
 export interface AgentCore<C = unknown> {
   /** Run identity and owning session; the same frozen object the ambient `RunContext` carries. */
   readonly runScope: RunScope;
@@ -22,6 +45,8 @@ export interface AgentCore<C = unknown> {
    * launch context, so a mid-run switch is visible here without a mirror.
    */
   readonly modelCell: ModelCell<C>;
+  /** Immutable per-run tool policy; read by cycle flows instead of the ambient RunContext. */
+  readonly toolPolicy: ToolPolicy;
   config: AgentConfig;
   setting: AgentSetting;
   prompt: AgentPrompt;

--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -34,7 +34,15 @@ export interface ToolPolicy {
 
 /** Freeze a tool policy so flows cannot mutate it mid-run. */
 export function createToolPolicy(policy: ToolPolicy = {}): ToolPolicy {
-  return Object.freeze({ ...policy });
+  // `Object.freeze` is shallow, so the nested tool-name array gets its own
+  // frozen copy rather than aliasing the caller's (still mutable) array.
+  return Object.freeze({
+    approvalPromptsUnavailable: policy.approvalPromptsUnavailable,
+    runtimeUnavailableTools: policy.runtimeUnavailableTools
+      ? Object.freeze([...policy.runtimeUnavailableTools])
+      : undefined,
+    stopAfterCycle: policy.stopAfterCycle,
+  });
 }
 
 export interface AgentCore<C = unknown> {

--- a/src/agent/implementations/flows/reflection/ResponseCycleFlow.ts
+++ b/src/agent/implementations/flows/reflection/ResponseCycleFlow.ts
@@ -22,7 +22,6 @@ import {
 } from '@agent/types/StopReasonTypes';
 import type { ProviderUsage } from '@agent/core/usage/ResponseUsage';
 import { K_SLICE } from '@agent/core/constants';
-import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
 import type { ResponseCycleServices } from '@agent/core/flows/CycleServices';
@@ -207,18 +206,19 @@ type ContinuationNodeResult = SkippableNodeResult<{
 export function responseCycleToolsForModel<C>(
   services: Pick<
     ResponseCycleServices<C>,
-    'modelCell' | 'setting' | 'toolRegistry'
+    'modelCell' | 'setting' | 'toolRegistry' | 'toolPolicy'
   >,
 ): ToolDefinition[] | undefined {
   if (!services.modelCell.handler.capabilities.supportsFunctionCalling) {
     return undefined;
   }
-  const runContext = useLaunchRunContext();
-  const runtimeUnavailable = new Set(runContext.runtimeUnavailableTools ?? []);
+  const runtimeUnavailable = new Set(
+    services.toolPolicy.runtimeUnavailableTools ?? [],
+  );
   return services.setting.tools.filter(
     (tool) =>
       !runtimeUnavailable.has(tool.name) &&
-      (runContext.approvalPromptsUnavailable !== true ||
+      (services.toolPolicy.approvalPromptsUnavailable !== true ||
         services.toolRegistry.get(tool.name)?.requiresApproval !== true),
   );
 }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -1,7 +1,6 @@
 import { Node } from '@agent/node';
 import { maybeBuildGoalContinuation } from '@agent/goal/maybeBuildGoalContinuation';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
 import {
   applyFollowUpBatch,
@@ -54,9 +53,9 @@ export class ToolUseWaitNode<C> extends Node<
   }
 
   async exec(prepRes: WaitPrepResult): Promise<WaitExecResult> {
-    const { session, isSubagent, runScope } = this.services;
+    const { session, isSubagent, runScope, toolPolicy } = this.services;
     const { streamId, session: ownerSession, signal } = runScope;
-    const { stopAfterCycle } = useLaunchRunContext();
+    const { stopAfterCycle } = toolPolicy;
     const hasDrainedFollowUps = Boolean(this.drainedFollowUps?.length);
 
     if (signal.aborted) {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -222,7 +222,12 @@ export class ToolUseWaitNode<C> extends Node<
     }
 
     await GoalStore.setStatus(streamId, 'paused');
-    await setGoalSessionBashAutoApproval(streamId, false);
+    // Route the bypass mutation through the session this flow already owns
+    // (`runScope.session`) rather than `currentSession()`, so the goal-pause
+    // path stays drivable without an ambient RunContext/ALS frame.
+    await setGoalSessionBashAutoApproval(streamId, false, {
+      session: this.services.runScope.session,
+    });
     emitRunFact(this.services.logger, 'goalPaused', { streamId });
   }
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -14,7 +14,6 @@ import {
 } from '@agent/runtime/ModelFactory';
 import type { RunModelHandler } from '@agent/runtime/ModelCell';
 import { type SessionHandle } from '@agent/runtime/SessionHandle';
-import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import {
   PersistedFlow,
@@ -177,9 +176,7 @@ export async function runToolUseFlow<C = unknown>(
   toolRegistry?: IToolRegistry,
   attachment?: ToolUseFlowAttachment,
 ): Promise<RunToolUseFlowResult> {
-  const { logger, setting } = input;
-  const runContext = useLaunchRunContext();
-  const { runScope } = runContext;
+  const { logger, setting, runScope, toolPolicy } = input;
   const { streamId, executionId, session: runSession, signal } = runScope;
   const continuationGenerationId =
     runSession.followUps.currentChildGenerationId(streamId) ??
@@ -198,8 +195,8 @@ export async function runToolUseFlow<C = unknown>(
     tools: setting.tools,
     registry: baseRegistry,
     logger,
-    approvalPromptsUnavailable: runContext.approvalPromptsUnavailable,
-    runtimeUnavailableTools: runContext.runtimeUnavailableTools,
+    approvalPromptsUnavailable: toolPolicy.approvalPromptsUnavailable,
+    runtimeUnavailableTools: toolPolicy.runtimeUnavailableTools,
     toolInjections: input.toolInjections,
   });
   const overlayTools: ITool[] = [];

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -16,7 +16,11 @@ import {
   type StageHandle,
 } from '@agent/trace';
 import { getExecutionStore } from '@agent/storage';
-import type { AgentCore } from '@agent/core/flows/BaseFlowServices';
+import {
+  createToolPolicy,
+  type AgentCore,
+  type ToolPolicy,
+} from '@agent/core/flows/BaseFlowServices';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
 import {
@@ -114,6 +118,8 @@ export interface AgentLaunchInput {
   copilotRouteOverride?: CopilotRouteOverride;
   /** Cancel launch preparation and the resulting live run. */
   signal?: AbortSignal;
+  /** Immutable per-run tool policy carried on the launch context for cycle flows. */
+  toolPolicy?: ToolPolicy;
 }
 
 const STATUS_MESSAGES: Record<string, string> = {
@@ -504,6 +510,7 @@ async function assembleAgentLaunchContext(
     setting,
     prompt,
     modelCell,
+    toolPolicy: createToolPolicy(input.toolPolicy),
     logger: agentLogger,
     parentStage,
     storageKey,

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -63,11 +63,7 @@ import { createRunTrace, type RunTrace } from '@transcript';
 import { generateExecutionId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-import {
-  createRunContext,
-  withRunContext,
-  type CreateLaunchRunContextOptions,
-} from './RunContext';
+import { createRunContext, withRunContext } from './RunContext';
 import { createRunScope } from './RunScope';
 import {
   countMediaFilesNeedingVision,
@@ -134,27 +130,26 @@ const STATUS_MESSAGES: Record<string, string> = {
 
 export async function withExecutionRunContext<T>(
   ctx: AgentLaunchContext,
-  options: Pick<
-    CreateLaunchRunContextOptions,
-    | 'approvalPromptsUnavailable'
-    | 'onApprovalPolicyDenial'
-    | 'runtimeUnavailableTools'
-    | 'stopAfterCycle'
-  >,
+  options: { onApprovalPolicyDenial?: () => void } = {},
   fn: () => T | Promise<T>,
 ): Promise<T> {
-  // Single owner of the launch-context → ambient-context mapping, so new
-  // per-run flags (e.g. `stopAfterCycle`, `approvalPromptsUnavailable`,
-  // `runtimeUnavailableTools`) live in one place and are never silently
-  // dropped. Run identity (`streamId`/`executionId`/`agentName`/
-  // `workingDirectory`) travels via `ctx.runScope` unchanged, and the model
-  // via the run's `ModelCell`, so tools observe a mid-session model switch
-  // without depending on the `AgentConfig.model` mirror.
+  // Single owner of the launch-context → ambient-context mapping. The
+  // tool-policy fields (`approvalPromptsUnavailable`, `runtimeUnavailableTools`,
+  // `stopAfterCycle`) are projected straight from `ctx.toolPolicy` so callers
+  // can't drift a hand-maintained copy of the same values; only
+  // `onApprovalPolicyDenial` (a callback that is not part of ToolPolicy) is
+  // still supplied explicitly. Run identity (`streamId`/`executionId`/
+  // `agentName`/`workingDirectory`) travels via `ctx.runScope` unchanged, and
+  // the model via the run's `ModelCell`, so tools observe a mid-session model
+  // switch without depending on the `AgentConfig.model` mirror.
   return await withRunContext(
     createRunContext({
       runScope: ctx.runScope,
       modelCell: ctx.modelCell,
-      ...options,
+      approvalPromptsUnavailable: ctx.toolPolicy.approvalPromptsUnavailable,
+      runtimeUnavailableTools: ctx.toolPolicy.runtimeUnavailableTools,
+      stopAfterCycle: ctx.toolPolicy.stopAfterCycle,
+      onApprovalPolicyDenial: options.onApprovalPolicyDenial,
     }),
     fn,
   );

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -224,24 +224,3 @@ export function getRunContextSession(
 ): SessionHandle | undefined {
   return getRunContextField('session', context);
 }
-
-/**
- * Return the active run context, asserting it is a `launch` context (i.e.
- * `streamId`/`executionId`/`session` are guaranteed present).
- *
- * Flow nodes only ever execute inside `withExecutionRunContext` (in
- * `AgentLaunchContext.ts`), which always projects a `launch` context — the
- * `bare` variant of `createRunContext` is exclusively for manually
- * constructed test/one-shot tool contexts.
- *
- * Code holding a flow-service bag reads `services.runScope` directly (the same
- * frozen object, declared on `AgentCore`); this accessor is the fallback for
- * code that holds no bag, chiefly the `src/tools/` layer.
- */
-export function useLaunchRunContext(): LaunchRunContext {
-  const context = useRunContext();
-  if (context.kind !== 'launch') {
-    throw new Error('useLaunchRunContext() called outside a launch RunContext');
-  }
-  return context;
-}

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -68,7 +68,7 @@ interface CreateBareRunContextOptions
   runScope?: undefined;
 }
 
-export interface CreateLaunchRunContextOptions extends CreateRunContextCommon {
+interface CreateLaunchRunContextOptions extends CreateRunContextCommon {
   runScope: RunScope;
 }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -6,7 +6,10 @@ import { runToolUseFlow } from '@agent/implementations/flows/tooluse/runToolUseF
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { runReflectionFlow } from '@agent/implementations/flows/reflection/runReflectionFlow';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import type { RoundFinalizedCallback } from '@agent/core/flows/BaseFlowServices';
+import {
+  createToolPolicy,
+  type RoundFinalizedCallback,
+} from '@agent/core/flows/BaseFlowServices';
 import {
   type AgentToolUseSetting,
   type AgentWorkflowSetting,
@@ -401,6 +404,11 @@ export async function executeAgent(
 ): Promise<AgentRuntimeFlowResult> {
   const runWithOwnership = captureOwnedExecutionLease(executionId);
   return await runWithOwnership(async () => {
+    const toolPolicy = createToolPolicy({
+      approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+      runtimeUnavailableTools: options.runtimeUnavailableTools,
+      stopAfterCycle: options.stopAfterCycle,
+    });
     const ctx = await buildAgentLaunchContext({
       config,
       executionId,
@@ -414,12 +422,11 @@ export async function executeAgent(
       modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
       copilotRouteOverride: options.copilotRouteOverride,
       signal: options.launchSignal,
+      toolPolicy,
     });
     const runContextOptions = {
-      approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+      ...toolPolicy,
       onApprovalPolicyDenial: options.onApprovalPolicyDenial,
-      runtimeUnavailableTools: options.runtimeUnavailableTools,
-      stopAfterCycle: options.stopAfterCycle,
     };
     return withExecutionRunContext(ctx, runContextOptions, async () => {
       const { setting, config } = ctx;
@@ -547,6 +554,10 @@ export async function resumeToolUseFromResumeData(
     let isSubagent: boolean;
     let userFollowUpSupport: UserFollowUpSupport;
     let ctx: AgentLaunchContext;
+    const toolPolicy = createToolPolicy({
+      approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+      runtimeUnavailableTools: options.runtimeUnavailableTools,
+    });
     try {
       // This execution is running again, so the terminal facts its previous
       // run left behind stop describing it here, before any turn of the
@@ -569,6 +580,7 @@ export async function resumeToolUseFromResumeData(
         // skip the bus-level error to avoid double-notifying.
         suppressErrorNotification: true,
         session: options.session,
+        toolPolicy,
       });
     } catch (error) {
       throw await releaseOwnedExecutionLeaseAfterFailure(
@@ -577,9 +589,8 @@ export async function resumeToolUseFromResumeData(
       );
     }
     const runContextOptions = {
-      approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+      ...toolPolicy,
       onApprovalPolicyDenial: options.onApprovalPolicyDenial,
-      runtimeUnavailableTools: options.runtimeUnavailableTools,
     };
     const { setting } = ctx;
     const { streamId: runStreamId, session: runSession } = ctx.runScope;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -6,10 +6,7 @@ import { runToolUseFlow } from '@agent/implementations/flows/tooluse/runToolUseF
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { runReflectionFlow } from '@agent/implementations/flows/reflection/runReflectionFlow';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import {
-  createToolPolicy,
-  type RoundFinalizedCallback,
-} from '@agent/core/flows/BaseFlowServices';
+import type { RoundFinalizedCallback } from '@agent/core/flows/BaseFlowServices';
 import {
   type AgentToolUseSetting,
   type AgentWorkflowSetting,
@@ -404,11 +401,6 @@ export async function executeAgent(
 ): Promise<AgentRuntimeFlowResult> {
   const runWithOwnership = captureOwnedExecutionLease(executionId);
   return await runWithOwnership(async () => {
-    const toolPolicy = createToolPolicy({
-      approvalPromptsUnavailable: options.approvalPromptsUnavailable,
-      runtimeUnavailableTools: options.runtimeUnavailableTools,
-      stopAfterCycle: options.stopAfterCycle,
-    });
     const ctx = await buildAgentLaunchContext({
       config,
       executionId,
@@ -422,91 +414,95 @@ export async function executeAgent(
       modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
       copilotRouteOverride: options.copilotRouteOverride,
       signal: options.launchSignal,
-      toolPolicy,
+      toolPolicy: {
+        approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+        runtimeUnavailableTools: options.runtimeUnavailableTools,
+        stopAfterCycle: options.stopAfterCycle,
+      },
     });
-    const runContextOptions = {
-      ...toolPolicy,
-      onApprovalPolicyDenial: options.onApprovalPolicyDenial,
-    };
-    return withExecutionRunContext(ctx, runContextOptions, async () => {
-      const { setting, config } = ctx;
-      const {
-        streamId: runStreamId,
-        executionId: runExecutionId,
-        session: runSession,
-      } = ctx.runScope;
-      const { isSubagent } = options;
+    return withExecutionRunContext(
+      ctx,
+      { onApprovalPolicyDenial: options.onApprovalPolicyDenial },
+      async () => {
+        const { setting, config } = ctx;
+        const {
+          streamId: runStreamId,
+          executionId: runExecutionId,
+          session: runSession,
+        } = ctx.runScope;
+        const { isSubagent } = options;
 
-      // Start description generation concurrently with the run, but join it
-      // before the owner can release its execution lease. This prevents the
-      // metadata write from recreating an execution deleted by another host.
-      const sessionDescription = generateSessionDescription(
-        runExecutionId,
-        runStreamId,
-        config,
-        runSession,
-        ctx.runScope.signal,
-      );
-      try {
-        const result = await runFlowWithLifecycle(
-          ctx,
-          async (handle, lifecycle) => {
-            // Pre-execution UI setup (RUNNING is set by runFlowWithLifecycle)
-            await ensureRunDir(executionId);
-            logger.info(`Starting task execution (streamId: ${runStreamId})`);
-            logger.info(`Input file: ${config.inputFiles[0] ?? '(none)'}`);
-            logger.debug('Task execution details', {
-              data: {
-                streamId: runStreamId,
-                agent: config.agent,
-                model: config.model,
-              },
-            });
-            logger.debug(`Output files: ${config.outputFiles?.length ?? 0}`);
-            // Subagents don't need to force-open the progress board or show notifications —
-            // the orchestrator's stream is already visible.
-            if (!isSubagent) {
-              runSession.interactions.emit(
-                'requestEnsureProgressView',
-                { fallbackNotification: buildFallbackNotification(config) },
-                { replayWhenAttached: true },
-              );
-            }
-            logger.info('Executing agent', {
-              data: { agent: config.agent, model: config.model },
-            });
-
-            if (setting.agentCategory === AgentCategory.ToolUse) {
-              return launchToolUseRun(
-                ctx,
-                handle,
-                lifecycle,
-                { ...options, setting, isSubagent },
-                { kind: 'fresh', onIdle: options.onIdle },
-              );
-            }
-            const result = await runReflectionAgent(ctx, setting);
-            if (result.error) return result;
-            const outputOutcome = await options.openWorkflowOutput?.(result);
-            return outputOutcome === undefined
-              ? result
-              : { ...result, outcome: outputOutcome };
-          },
-          buildLifecycleOptions(options, isSubagent),
+        // Start description generation concurrently with the run, but join it
+        // before the owner can release its execution lease. This prevents the
+        // metadata write from recreating an execution deleted by another host.
+        const sessionDescription = generateSessionDescription(
+          runExecutionId,
+          runStreamId,
+          config,
+          runSession,
+          ctx.runScope.signal,
         );
-        if (
-          isWaitingFlowResult(result) &&
-          options.allowWaitingResult !== true
-        ) {
-          throw new Error(
-            'executeAgent received a non-terminal WAITING result without allowWaitingResult.',
+        try {
+          const result = await runFlowWithLifecycle(
+            ctx,
+            async (handle, lifecycle) => {
+              // Pre-execution UI setup (RUNNING is set by runFlowWithLifecycle)
+              await ensureRunDir(executionId);
+              logger.info(`Starting task execution (streamId: ${runStreamId})`);
+              logger.info(`Input file: ${config.inputFiles[0] ?? '(none)'}`);
+              logger.debug('Task execution details', {
+                data: {
+                  streamId: runStreamId,
+                  agent: config.agent,
+                  model: config.model,
+                },
+              });
+              logger.debug(`Output files: ${config.outputFiles?.length ?? 0}`);
+              // Subagents don't need to force-open the progress board or show notifications —
+              // the orchestrator's stream is already visible.
+              if (!isSubagent) {
+                runSession.interactions.emit(
+                  'requestEnsureProgressView',
+                  { fallbackNotification: buildFallbackNotification(config) },
+                  { replayWhenAttached: true },
+                );
+              }
+              logger.info('Executing agent', {
+                data: { agent: config.agent, model: config.model },
+              });
+
+              if (setting.agentCategory === AgentCategory.ToolUse) {
+                return launchToolUseRun(
+                  ctx,
+                  handle,
+                  lifecycle,
+                  { ...options, setting, isSubagent },
+                  { kind: 'fresh', onIdle: options.onIdle },
+                );
+              }
+              const result = await runReflectionAgent(ctx, setting);
+              if (result.error) return result;
+              const outputOutcome = await options.openWorkflowOutput?.(result);
+              return outputOutcome === undefined
+                ? result
+                : { ...result, outcome: outputOutcome };
+            },
+            buildLifecycleOptions(options, isSubagent),
           );
+          if (
+            isWaitingFlowResult(result) &&
+            options.allowWaitingResult !== true
+          ) {
+            throw new Error(
+              'executeAgent received a non-terminal WAITING result without allowWaitingResult.',
+            );
+          }
+          return result;
+        } finally {
+          await sessionDescription;
         }
-        return result;
-      } finally {
-        await sessionDescription;
-      }
-    });
+      },
+    );
   });
 }
 
@@ -554,10 +550,6 @@ export async function resumeToolUseFromResumeData(
     let isSubagent: boolean;
     let userFollowUpSupport: UserFollowUpSupport;
     let ctx: AgentLaunchContext;
-    const toolPolicy = createToolPolicy({
-      approvalPromptsUnavailable: options.approvalPromptsUnavailable,
-      runtimeUnavailableTools: options.runtimeUnavailableTools,
-    });
     try {
       // This execution is running again, so the terminal facts its previous
       // run left behind stop describing it here, before any turn of the
@@ -580,7 +572,10 @@ export async function resumeToolUseFromResumeData(
         // skip the bus-level error to avoid double-notifying.
         suppressErrorNotification: true,
         session: options.session,
-        toolPolicy,
+        toolPolicy: {
+          approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+          runtimeUnavailableTools: options.runtimeUnavailableTools,
+        },
       });
     } catch (error) {
       throw await releaseOwnedExecutionLeaseAfterFailure(
@@ -588,10 +583,6 @@ export async function resumeToolUseFromResumeData(
         error,
       );
     }
-    const runContextOptions = {
-      ...toolPolicy,
-      onApprovalPolicyDenial: options.onApprovalPolicyDenial,
-    };
     const { setting } = ctx;
     const { streamId: runStreamId, session: runSession } = ctx.runScope;
 
@@ -601,7 +592,7 @@ export async function resumeToolUseFromResumeData(
     try {
       result = await withExecutionRunContext(
         ctx,
-        runContextOptions,
+        { onApprovalPolicyDenial: options.onApprovalPolicyDenial },
         async () => {
           if (setting.agentCategory !== AgentCategory.ToolUse) {
             // Keep this historical diagnostic byte-for-byte for external monitors.

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -88,6 +88,7 @@ async function runPersistedReflectionFlow(
           transient: {},
         },
         modelCell,
+        toolPolicy: {},
         onRoundFinalized: () => {},
       }),
     );

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Local imports
 import { getExecutionStore } from '@agent/storage';
 import { noopTrace } from '@agent/trace';
+import { createToolPolicy } from '@agent/core/flows/BaseFlowServices';
 import {
   AgentPromptSchema,
   AgentWorkflowSettingSchema,
@@ -88,7 +89,7 @@ async function runPersistedReflectionFlow(
           transient: {},
         },
         modelCell,
-        toolPolicy: {},
+        toolPolicy: createToolPolicy(),
         onRoundFinalized: () => {},
       }),
     );

--- a/src/test-kernel/agent/ResponseCycleTools.vitest.ts
+++ b/src/test-kernel/agent/ResponseCycleTools.vitest.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { noopTrace } from '@agent/trace';
-import type { AgentCore, ToolPolicy } from '@agent/core/flows/BaseFlowServices';
+import {
+  createToolPolicy,
+  type AgentCore,
+  type ToolPolicy,
+} from '@agent/core/flows/BaseFlowServices';
 import type { BaseCycleFields } from '@agent/core/flows/CommonCycleTypes';
 import type { ResponseCycleServices } from '@agent/core/flows/CycleServices';
 import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
@@ -16,7 +20,7 @@ function toolNames(tools: readonly { name: string }[] | undefined): string[] {
 
 function responseServices({
   supportsFunctionCalling = true,
-  toolPolicy = {},
+  toolPolicy = createToolPolicy(),
 }: {
   supportsFunctionCalling?: boolean;
   toolPolicy?: ToolPolicy;
@@ -48,20 +52,20 @@ describe('response cycle tool visibility', () => {
   it.each([
     {
       name: 'filters approval-gated workflow tools when prompts are unavailable',
-      toolPolicy: { approvalPromptsUnavailable: true },
+      toolPolicy: createToolPolicy({ approvalPromptsUnavailable: true }),
       expected: ['grep'],
     },
     {
       name: 'keeps workflow tools when approval prompts are available',
-      toolPolicy: { approvalPromptsUnavailable: false },
+      toolPolicy: createToolPolicy({ approvalPromptsUnavailable: false }),
       expected: ['bash', 'grep', 'inquiry', 'write_file', 'wolfram'],
     },
     {
       name: 'filters runtime-unavailable workflow tools without hiding approvals',
-      toolPolicy: {
+      toolPolicy: createToolPolicy({
         approvalPromptsUnavailable: false,
         runtimeUnavailableTools: ['inquiry'],
-      },
+      }),
       expected: ['bash', 'grep', 'write_file', 'wolfram'],
     },
   ])('$name', ({ toolPolicy, expected }) => {

--- a/src/test-kernel/agent/ResponseCycleTools.vitest.ts
+++ b/src/test-kernel/agent/ResponseCycleTools.vitest.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { noopTrace } from '@agent/trace';
-import type { AgentCore } from '@agent/core/flows/BaseFlowServices';
+import type { AgentCore, ToolPolicy } from '@agent/core/flows/BaseFlowServices';
 import type { BaseCycleFields } from '@agent/core/flows/CommonCycleTypes';
 import type { ResponseCycleServices } from '@agent/core/flows/CycleServices';
 import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
@@ -16,11 +16,14 @@ function toolNames(tools: readonly { name: string }[] | undefined): string[] {
 
 function responseServices({
   supportsFunctionCalling = true,
+  toolPolicy = {},
 }: {
   supportsFunctionCalling?: boolean;
+  toolPolicy?: ToolPolicy;
 } = {}): Parameters<typeof responseCycleToolsForModel>[0] {
   return {
     toolRegistry: getDefaultToolRegistry(),
+    toolPolicy,
     modelCell: testModelCell({
       config: { provider: 'openai', fullName: 'test-model' },
       getClient: async () => ({}),
@@ -45,39 +48,33 @@ describe('response cycle tool visibility', () => {
   it.each([
     {
       name: 'filters approval-gated workflow tools when prompts are unavailable',
-      services: { approvalPromptsUnavailable: true },
+      toolPolicy: { approvalPromptsUnavailable: true },
       expected: ['grep'],
     },
     {
       name: 'keeps workflow tools when approval prompts are available',
-      services: { approvalPromptsUnavailable: false },
+      toolPolicy: { approvalPromptsUnavailable: false },
       expected: ['bash', 'grep', 'inquiry', 'write_file', 'wolfram'],
     },
     {
       name: 'filters runtime-unavailable workflow tools without hiding approvals',
-      services: {
+      toolPolicy: {
         approvalPromptsUnavailable: false,
         runtimeUnavailableTools: ['inquiry'],
       },
       expected: ['bash', 'grep', 'write_file', 'wolfram'],
     },
-  ])('$name', async ({ services, expected }) => {
-    const tools = await withTestRunContext(
-      testRunScope('response-cycle-stream'),
-      async () => responseCycleToolsForModel(responseServices()),
-      services,
-    );
+  ])('$name', ({ toolPolicy, expected }) => {
+    // No AsyncLocalStorage frame is installed: the tool policy is read from
+    // the injected `services.toolPolicy`, not from the ambient RunContext.
+    const tools = responseCycleToolsForModel(responseServices({ toolPolicy }));
 
     expect(toolNames(tools)).toEqual(expected);
   });
 
-  it('omits workflow tools when the model handler cannot call functions', async () => {
-    const tools = await withTestRunContext(
-      testRunScope('response-cycle-stream'),
-      async () =>
-        responseCycleToolsForModel(
-          responseServices({ supportsFunctionCalling: false }),
-        ),
+  it('omits workflow tools when the model handler cannot call functions', () => {
+    const tools = responseCycleToolsForModel(
+      responseServices({ supportsFunctionCalling: false }),
     );
 
     expect(tools).toBeUndefined();

--- a/src/test-kernel/agent/RunScopedToolOverlay.vitest.ts
+++ b/src/test-kernel/agent/RunScopedToolOverlay.vitest.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { noopTrace } from '@agent/trace';
+import { createToolPolicy } from '@agent/core/flows/BaseFlowServices';
 import {
   AgentPromptSchema,
   AgentToolUseSettingSchema,
@@ -37,6 +38,10 @@ function tool(name: string): ITool {
     definition: { name, description: name, parameters: {} },
     call: vi.fn(),
   };
+}
+
+function approvalGatedTool(name: string): ITool {
+  return { ...tool(name), requiresApproval: true };
 }
 
 describe('run-scoped tool overlay', () => {
@@ -102,6 +107,7 @@ describe('run-scoped tool overlay', () => {
               transient: {},
             },
             modelCell,
+            toolPolicy: createToolPolicy(),
             onModelChanged: () => {},
             interrupt: () => {},
             onRoundFinalized: () => {},
@@ -126,6 +132,96 @@ describe('run-scoped tool overlay', () => {
       expect(warn).toHaveBeenCalledWith(
         'Run-scoped tool "first" shadows an existing tool.',
       );
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('filters approval-gated and runtime-unavailable declared tools without a run context', async () => {
+    const executionId = '9329abce' as ExecutionId;
+    const streamId = `chat#${executionId}` as StreamTabId;
+    const session = createTestSession();
+    const runScope = createRunScope({
+      executionId,
+      streamId,
+      agentName: 'chat',
+      session,
+      signal: new AbortController().signal,
+    });
+    const observedTools: { name: string }[][] = [];
+    const stopAfterObservation = Object.assign(
+      new Error('Tool list observed'),
+      { status: 401 },
+    );
+    const modelHandler = {
+      capabilities: { supportsFunctionCalling: true, supportsVision: false },
+      config: { provider: 'test' },
+      supportsForcedToolChoice: false,
+      requiresPerCallSystemPrompt: false,
+      initializeMessages: async () => [{ role: 'user', content: 'test' }],
+      consumeInsertedAttachmentKinds: () => [],
+      getClient: async () => ({}),
+      getCredentialRouteForClient: () => undefined,
+      setOutputStreaming: () => {},
+      getWireRouteKey: () => 'test',
+      getModelRetryRouteKey: () => 'test:model',
+      extractAssistantText: () => undefined,
+      createResponse: async (options: { tools?: { name: string }[] }) => {
+        observedTools.push(options.tools ?? []);
+        throw stopAfterObservation;
+      },
+    };
+    const modelCell = testModelCell(modelHandler, 'test-model');
+    const config = AgentConfigSchema.parse({
+      agent: 'chat',
+      model: 'test-model',
+      agentCategory: AgentCategory.ToolUse,
+      workingDirectory: process.cwd(),
+    });
+
+    try {
+      // No `withRunContext` frame: `runToolUseFlow` reads `approvalPromptsUnavailable`
+      // and `runtimeUnavailableTools` from the injected `toolPolicy`, not the ALS.
+      const result = await runToolUseFlow(
+        {
+          config,
+          runScope,
+          setting: AgentToolUseSettingSchema.parse({
+            tools: [
+              { name: 'bash' },
+              { name: 'grep' },
+              { name: 'inquiry' },
+              { name: 'write_file' },
+              { name: 'wolfram' },
+            ],
+          }),
+          prompt: AgentPromptSchema.parse({}),
+          logger: noopTrace,
+          userVarChannels: {
+            input: Object.freeze({ MODEL: config.model }),
+            transient: {},
+          },
+          modelCell,
+          toolPolicy: {
+            approvalPromptsUnavailable: true,
+            runtimeUnavailableTools: ['inquiry'],
+          },
+          onModelChanged: () => {},
+          interrupt: () => {},
+          onRoundFinalized: () => {},
+          isSubagent: true,
+        },
+        new MapToolRegistry({
+          bash: approvalGatedTool('bash'),
+          grep: tool('grep'),
+          inquiry: approvalGatedTool('inquiry'),
+          write_file: approvalGatedTool('write_file'),
+          wolfram: approvalGatedTool('wolfram'),
+        }),
+      );
+
+      expect(result.outcome).toBe('failed');
+      expect(observedTools[0]?.map(({ name }) => name)).toEqual(['grep']);
     } finally {
       session.dispose();
     }

--- a/src/test-kernel/agent/RunScopedToolOverlay.vitest.ts
+++ b/src/test-kernel/agent/RunScopedToolOverlay.vitest.ts
@@ -202,10 +202,10 @@ describe('run-scoped tool overlay', () => {
             transient: {},
           },
           modelCell,
-          toolPolicy: {
+          toolPolicy: createToolPolicy({
             approvalPromptsUnavailable: true,
             runtimeUnavailableTools: ['inquiry'],
-          },
+          }),
           onModelChanged: () => {},
           interrupt: () => {},
           onRoundFinalized: () => {},

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { noopTrace } from '@agent/trace';
 import { getExecutionStore } from '@agent/storage';
+import { createToolPolicy } from '@agent/core/flows/BaseFlowServices';
 import { MapToolRegistry, type ITool } from '@agent/core/tools/ToolTypes';
 import {
   AgentPromptSchema,
@@ -362,7 +363,9 @@ async function runPersistedFlow(
           logger: noopTrace,
           userVarChannels,
           modelCell,
-          toolPolicy: { stopAfterCycle: options.stopAfterCycle },
+          toolPolicy: createToolPolicy({
+            stopAfterCycle: options.stopAfterCycle,
+          }),
           onModelChanged: () => {},
           interrupt: () => abortController.abort(),
           onRoundFinalized: () => {},

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -362,6 +362,7 @@ async function runPersistedFlow(
           logger: noopTrace,
           userVarChannels,
           modelCell,
+          toolPolicy: { stopAfterCycle: options.stopAfterCycle },
           onModelChanged: () => {},
           interrupt: () => abortController.abort(),
           onRoundFinalized: () => {},

--- a/src/test-kernel/agent/core/ToolPolicy.vitest.ts
+++ b/src/test-kernel/agent/core/ToolPolicy.vitest.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { createToolPolicy } from '@agent/core/flows/BaseFlowServices';
+
+describe('createToolPolicy', () => {
+  it('freezes the policy and its runtimeUnavailableTools array', () => {
+    const policy = createToolPolicy({
+      approvalPromptsUnavailable: true,
+      runtimeUnavailableTools: ['inquiry', 'bash'],
+      stopAfterCycle: true,
+    });
+
+    expect(Object.isFrozen(policy)).toBe(true);
+    expect(Object.isFrozen(policy.runtimeUnavailableTools)).toBe(true);
+  });
+
+  it('copies runtimeUnavailableTools so later source mutation cannot leak in', () => {
+    const source = ['inquiry'];
+    const policy = createToolPolicy({ runtimeUnavailableTools: source });
+
+    source.push('bash');
+
+    expect(policy.runtimeUnavailableTools).toEqual(['inquiry']);
+    // The policy holds its own frozen copy, not the caller's array.
+    expect(policy.runtimeUnavailableTools).not.toBe(source);
+  });
+
+  it('defaults to an empty frozen policy', () => {
+    const policy = createToolPolicy();
+
+    expect(Object.isFrozen(policy)).toBe(true);
+    expect(policy.runtimeUnavailableTools).toBeUndefined();
+    expect(policy.approvalPromptsUnavailable).toBeUndefined();
+    expect(policy.stopAfterCycle).toBeUndefined();
+  });
+});

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -62,6 +62,8 @@ type WaitNodeServiceOverrides = Partial<
   /** Session owning this run's status machine and approvals. */
   ownerSession?: SessionHandle;
   signal?: AbortSignal;
+  /** Injected tool policy the wait node reads instead of the ambient RunContext. */
+  stopAfterCycle?: boolean;
 };
 
 function createWaitNodeServices(
@@ -73,12 +75,14 @@ function createWaitNodeServices(
     ownerSession,
     session,
     signal,
+    stopAfterCycle,
     streamId = 'test-stream',
     ...topLevel
   } = overrides;
   const { capabilities, ...modelHandlerOverrides } = modelHandler ?? {};
   return {
     runScope: testRunScope(streamId, { session: ownerSession, signal }),
+    toolPolicy: { stopAfterCycle },
     fileService: {
       createLocation: (filePath: string) => ({ absolutePath: filePath }),
       ...fileService,
@@ -252,21 +256,18 @@ describe('ToolUseWaitNode', () => {
   it('stops instead of suspending when stopAfterCycle is set (headless in-band subagent)', async () => {
     const shared = toolUseRunShared();
 
+    // `stopAfterCycle` is injected through `services.toolPolicy`; no
+    // AsyncLocalStorage frame is installed for this cycle.
     const services = createWaitNodeServices({
       isSubagent: true,
+      stopAfterCycle: true,
     });
 
     const node = new ToolUseWaitNode().setServices(services);
     const prep = await node.prep(shared);
-    const transition = await withTestRunContext(
-      services.runScope,
-      async () => {
-        const exec = await node.exec(prep);
-        expect(exec.kind).toBe('stop');
-        return node.post(shared, prep, exec);
-      },
-      { stopAfterCycle: true },
-    );
+    const exec = await node.exec(prep);
+    expect(exec.kind).toBe('stop');
+    const transition = await node.post(shared, prep, exec);
 
     expect(transition).toBe(FlowTransition.COMPLETE);
   });
@@ -416,6 +417,7 @@ describe('ToolUseWaitNode', () => {
       logger,
       ownerSession,
       streamId,
+      stopAfterCycle: true,
       session: {
         waitForFollowUp,
       },
@@ -423,10 +425,11 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      const exec = await withTestRunContext(
-        services.runScope,
-        () => node.exec(waitPrep(true)),
-        { stopAfterCycle: true },
+      // `pauseActiveGoal` resolves `currentSession()` through the active run
+      // context, so the ALS frame stays (stopAfterCycle is still read from
+      // `services.toolPolicy`, not from the ambient context).
+      const exec = await withTestRunContext(services.runScope, () =>
+        node.exec(waitPrep(true)),
       );
 
       const goal = GoalStore.getForStream(streamId);

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { TraceEmitter, type AgentTrace } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import { createToolPolicy } from '@agent/core/flows/BaseFlowServices';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ToolUseWaitNode } from '@agent/implementations/flows/tooluse/nodes/ToolUseWaitNode';
@@ -82,7 +83,7 @@ function createWaitNodeServices(
   const { capabilities, ...modelHandlerOverrides } = modelHandler ?? {};
   return {
     runScope: testRunScope(streamId, { session: ownerSession, signal }),
-    toolPolicy: { stopAfterCycle },
+    toolPolicy: createToolPolicy({ stopAfterCycle }),
     fileService: {
       createLocation: (filePath: string) => ({ absolutePath: filePath }),
       ...fileService,
@@ -425,12 +426,10 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      // `pauseActiveGoal` resolves `currentSession()` through the active run
-      // context, so the ALS frame stays (stopAfterCycle is still read from
-      // `services.toolPolicy`, not from the ambient context).
-      const exec = await withTestRunContext(services.runScope, () =>
-        node.exec(waitPrep(true)),
-      );
+      // No AsyncLocalStorage frame: `pauseActiveGoal` routes the bash bypass
+      // mutation through `services.runScope.session` (the owner session), never
+      // through `currentSession()`/`defaultSession()`.
+      const exec = await node.exec(waitPrep(true));
 
       const goal = GoalStore.getForStream(streamId);
       expect(exec.kind).toBe('stop');

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -30,6 +30,7 @@ import { createRunScope } from '@agent/runtime/RunScope';
 import { useRunContext } from '@agent/runtime/RunContext';
 import { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import { createToolPolicy } from '@agent/core/flows/BaseFlowServices';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   buildAgentLaunchContext,
@@ -369,42 +370,73 @@ describe('AgentLaunchContext', () => {
       signal: new AbortController().signal,
     });
     const modelCell = testModelCell({ dispose: vi.fn() }, 'deepseekT');
+    const onApprovalPolicyDenial = vi.fn();
     const ctx = {
       runScope,
       logger: noopTrace,
       modelCell,
+      toolPolicy: createToolPolicy({
+        approvalPromptsUnavailable: true,
+        runtimeUnavailableTools: ['inquiry'],
+        stopAfterCycle: true,
+      }),
       config: {
         agent: runScope.agentName,
         model: 'deepseekT',
       },
     } as unknown as AgentLaunchContext;
 
-    await withExecutionRunContext(
-      ctx,
-      {
-        approvalPromptsUnavailable: true,
-        runtimeUnavailableTools: ['inquiry'],
-        stopAfterCycle: true,
-      },
-      async () => {
-        const context = useRunContext();
-        expect(context.model).toBe('deepseekT');
-        expect(context.kind).toBe('launch');
-        if (context.kind !== 'launch') {
-          throw new Error('expected launch context');
-        }
-        expect(context.runScope).toBe(runScope);
-        expect(context.approvalPromptsUnavailable).toBe(true);
-        expect(context.runtimeUnavailableTools).toEqual(['inquiry']);
-        expect(context.stopAfterCycle).toBe(true);
+    await withExecutionRunContext(ctx, { onApprovalPolicyDenial }, async () => {
+      const context = useRunContext();
+      expect(context.model).toBe('deepseekT');
+      expect(context.kind).toBe('launch');
+      if (context.kind !== 'launch') {
+        throw new Error('expected launch context');
+      }
+      expect(context.runScope).toBe(runScope);
+      // `withExecutionRunContext` projects `ctx.toolPolicy` into the ambient
+      // RunContext; the only explicit option left is `onApprovalPolicyDenial`.
+      expect(context.approvalPromptsUnavailable).toBe(true);
+      expect(context.runtimeUnavailableTools).toEqual(['inquiry']);
+      expect(context.stopAfterCycle).toBe(true);
+      expect(context.onApprovalPolicyDenial).toBe(onApprovalPolicyDenial);
 
-        // The cell is the run's live model, so a swap alone moves the run
-        // context; the `AgentConfig.model` mirror does not drive it.
-        modelCell.swap({ dispose: vi.fn() } as never, 'sonnet46T');
+      // The cell is the run's live model, so a swap alone moves the run
+      // context; the `AgentConfig.model` mirror does not drive it.
+      modelCell.swap({ dispose: vi.fn() } as never, 'sonnet46T');
 
-        expect(useRunContext().model).toBe('sonnet46T');
-      },
-    );
+      expect(useRunContext().model).toBe('sonnet46T');
+    });
+  });
+
+  it('projects an empty tool policy as absent ambient fields', async () => {
+    const session = {} as SessionHandle;
+    const runScope = createRunScope({
+      streamId: 'launch-context-defaults',
+      executionId: 'launch-context-defaults-execution',
+      agentName: 'chat',
+      session,
+      signal: new AbortController().signal,
+    });
+    const modelCell = testModelCell({ dispose: vi.fn() }, 'deepseekT');
+    const ctx = {
+      runScope,
+      logger: noopTrace,
+      modelCell,
+      toolPolicy: createToolPolicy(),
+      config: { agent: runScope.agentName, model: 'deepseekT' },
+    } as unknown as AgentLaunchContext;
+
+    await withExecutionRunContext(ctx, {}, async () => {
+      const context = useRunContext();
+      if (context.kind !== 'launch') {
+        throw new Error('expected launch context');
+      }
+      expect(context.approvalPromptsUnavailable).toBeUndefined();
+      expect(context.runtimeUnavailableTools).toBeUndefined();
+      expect(context.stopAfterCycle).toBeUndefined();
+      expect(context.onApprovalPolicyDenial).toBeUndefined();
+    });
   });
 
   it('compensates a late launch-assembly failure before trace disposal', async () => {

--- a/src/test-kernel/agent/runtime/launchContextTestUtils.ts
+++ b/src/test-kernel/agent/runtime/launchContextTestUtils.ts
@@ -4,6 +4,7 @@ import { vi } from 'vitest';
 
 // Local imports
 import { noopTrace } from '@agent/trace';
+import { createToolPolicy } from '@agent/core/flows/BaseFlowServices';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import {
   AgentPromptSchema,
@@ -91,7 +92,7 @@ export function createTestLaunchContext({
     parentStage: logger.openStage(`Run: ${config.agent}`),
     storageKey,
     userVarChannels: { input: Object.freeze({}), transient: {} },
-    toolPolicy: {},
+    toolPolicy: createToolPolicy(),
     attachedMemoryMisses: [],
     usageMonitor: new UsageMonitor(
       modelCell,

--- a/src/test-kernel/agent/runtime/launchContextTestUtils.ts
+++ b/src/test-kernel/agent/runtime/launchContextTestUtils.ts
@@ -91,6 +91,7 @@ export function createTestLaunchContext({
     parentStage: logger.openStage(`Run: ${config.agent}`),
     storageKey,
     userVarChannels: { input: Object.freeze({}), transient: {} },
+    toolPolicy: {},
     attachedMemoryMisses: [],
     usageMonitor: new UsageMonitor(
       modelCell,

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -178,6 +178,7 @@ function roundServices(opts: {
       userRequest: '',
     } satisfies AgentPrompt,
     userVarChannels: { input: {}, transient: {} },
+    toolPolicy: {},
     logger: opts.logger,
     fileService: new TaskRunFileService('deadbeef'),
     toolRegistry: opts.toolRegistry,

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -15,6 +15,7 @@ import {
 // Local imports
 import type { AgentEvent } from '@agent/trace';
 import { getExecutionStore } from '@agent/storage';
+import { createToolPolicy } from '@agent/core/flows/BaseFlowServices';
 import type {
   AgentPrompt,
   AgentSetting,
@@ -178,7 +179,7 @@ function roundServices(opts: {
       userRequest: '',
     } satisfies AgentPrompt,
     userVarChannels: { input: {}, transient: {} },
-    toolPolicy: {},
+    toolPolicy: createToolPolicy(),
     logger: opts.logger,
     fileService: new TaskRunFileService('deadbeef'),
     toolRegistry: opts.toolRegistry,

--- a/src/tools/goal/goalAutoApproval.ts
+++ b/src/tools/goal/goalAutoApproval.ts
@@ -1,3 +1,4 @@
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas/identifiers';
 
 /**
@@ -23,8 +24,9 @@ import type { StreamTabId } from '@shared/schemas/identifiers';
 export async function setGoalSessionBashAutoApproval(
   streamId: StreamTabId,
   enabled: boolean,
+  options?: { session?: SessionHandle },
 ): Promise<void> {
   const { setBashApprovalSessionBypass } =
     await import('@tools/approval/bashApproval');
-  setBashApprovalSessionBypass(streamId, enabled);
+  setBashApprovalSessionBypass(streamId, enabled, options);
 }


### PR DESCRIPTION
## Summary

Removes the last residual ambient `AsyncLocalStorage` reads from the response-cycle and tool-use cycle flows, so both can run without a `useLaunchRunContext()`/ALS frame. The three launch-context tool-policy values (`approvalPromptsUnavailable`, `runtimeUnavailableTools`, `stopAfterCycle`) are now injected as an immutable `ToolPolicy` service field carried on `AgentCore` / `AgentLaunchContext`, instead of being read off the ambient `RunContext`.

- `responseCycleToolsForModel` reads `services.toolPolicy` (response-cycle path).
- `runToolUseFlow` reads `input.runScope` + `input.toolPolicy`.
- `ToolUseWaitNode` reads `services.toolPolicy.stopAfterCycle`.
- The now-unused `useLaunchRunContext` accessor is deleted.

Rebased onto the post-#10475 tree: `ResponseCycleFlow.ts` is re-anchored at `src/agent/implementations/flows/reflection/ResponseCycleFlow.ts`, and #10475's delegation/flow substrate consolidation is preserved (absolute `@agent/core/flows/*` imports, `provideAgentEngine`, `ResumeAdmissionCancelledError`, `runSession.releaseExecutionLease`).

Closes #10594

## Issue acceptance gates

- Response-cycle flow runs without an ALS frame: `responseCycleToolsForModel` no longer calls `useLaunchRunContext()`; it reads the injected `toolPolicy`.
- Tool-use flow runs without an ALS frame: `runToolUseFlow` no longer calls `useLaunchRunContext()`; `ToolUseWaitNode` no longer calls `useLaunchRunContext()`.
- All three policy values are injected as immutable service fields and pinned by tests that drive the flows without an ALS frame (`ResponseCycleTools`, `ToolUseWaitNode`, `RunScopedToolOverlay`).

## Single source of truth

`ToolPolicy` (in `src/agent/core/flows/BaseFlowServices.ts`) is the injected tool-policy shape; `AgentLaunchContext` freezes it via `createToolPolicy()` and carries it through the existing `...ctx` flow-service spreads. The ambient `RunContext` still carries the same values for the `src/tools/` layer, but the cycle flows no longer read it.

## Duplication and abstraction budget

No new abstraction layer: `ToolPolicy` is a plain immutable value object, not a wrapper. One duplication removed — three separate `useLaunchRunContext()` reads are replaced by one injected field read each, with a single `createToolPolicy` freeze point.

## Net elements (R6)

- Files: 17 modified, 1 added, 0 deleted.
- Exported symbols: -2 (`useLaunchRunContext`, `CreateLaunchRunContextOptions`), +2 (`ToolPolicy`, `createToolPolicy`) → net 0.
- Classes/interfaces/enums: +1 (`ToolPolicy`), -1 (`CreateLaunchRunContextOptions`) → net 0.
- Net LoC: +409 / -210 = +199.

## Consumer counts (R8)

- Removed export `useLaunchRunContext`: 3 prior consumers (`ResponseCycleFlow.ts`, `runToolUseFlow.ts`, `ToolUseWaitNode.ts`) all migrated to `services.toolPolicy`; 0 consumers remain (grep over `src/` and `packages/` returns only the gitignored `packages/agent/dist` .d.ts, regenerated on build).
- `createToolPolicy` / `ToolPolicy`: no deleted or re-routed emit path → n/a.

## Host impact

Extension: none (flow-internal DI change).

Desktop: none.

CLI: none.

## Scheduled refactoring

None — this closes the C-1 item named in `docs/proposals/2026-08-15-agent-sdk-readiness-reverify.md` §4/§7.

## Validation

- `typecheck:workspace`, `typecheck:test-kernel`, `typecheck:agent`, `typecheck:cli`, `typecheck:trace-viewer`, `typecheck:desktop` — pass.
- Focused vitest: 16 files / 188 tests (ToolPolicy, response-cycle tools/continuation/cancellation, tool-use wait/overlay, resume retrieval, reflection recovery, launch context, run context, transcript-log suites, bash tool, plan tool) — pass.
- Architecture suite `src/test-kernel/architecture/`: 17 files / 102 tests — pass.
- `check:dead-code-ratchet` (8=8), `check:guidance-refs`, `check:browser-safe-utils` — pass.
- ESLint (all changed source/test files), Prettier, `git diff --check` — clean.

