### PR TITLE
refactor(logger): migrate the post-#10475 runtime/delegation subset to createLog

### DIFF
--- a/src/agent/runtime/agentSettingTools.ts
+++ b/src/agent/runtime/agentSettingTools.ts
@@ -9,7 +9,7 @@
  * module adds nothing to either one's module closure.
  */
 import type { AgentSettingInput } from '@agent/core/definition/AgentDataclass';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { AgentCategory } from '@shared/schemas';
 import { resolveToolDefinitions } from '@tools/registry';
 
@@ -18,6 +18,9 @@ export function resolveAgentSettingTools(
   channel: string,
 ): AgentSettingInput {
   if (!Array.isArray(settings.tools)) return settings;
+  // The channel is caller-threaded (local and remote loaders report on their
+  // own), so bind at call scope rather than freezing one at module load.
+  const log = createLog(channel);
   // Latent silent-failure trap: the shared settings schema accepts `tools:`
   // for every category, but a workflow (reflection) run only *sends* the
   // definitions to the provider — a returned tool call is never dispatched.
@@ -27,8 +30,7 @@ export function resolveAgentSettingTools(
     settings.agentCategory === AgentCategory.Workflow &&
     settings.tools.length > 0
   ) {
-    logger.warn(
-      channel,
+    log.warn(
       `Workflow-category agent declares tools: [${settings.tools
         .map((tool) => (typeof tool === 'string' ? tool : tool.name))
         .join(
@@ -39,7 +41,7 @@ export function resolveAgentSettingTools(
   return {
     ...settings,
     tools: resolveToolDefinitions(settings.tools, (name, reason) =>
-      logger.warn(channel, `Tool "${name}" ${reason}`),
+      log.warn(`Tool "${name}" ${reason}`),
     ),
   };
 }

--- a/src/agent/runtime/bundledPrompts.ts
+++ b/src/agent/runtime/bundledPrompts.ts
@@ -28,10 +28,12 @@ import { z } from 'zod';
 
 // Local imports
 import { parseYamlWith } from '@common/parsing/safeParseYaml';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { createTexraNunjucksEnvironment } from '@utils/prompt';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
+
+const log = createLog('BundledPrompts');
 
 const GoalPromptsSchema = z.object({
   continuation: z.object({ template: z.string().min(1) }),
@@ -155,8 +157,7 @@ async function readBundledPrompt<T>(
     if (row.whenUnavailable.kind === 'required') throw error;
     // Warn so a broken or missing bundled file is detectable rather than
     // silently masked by the inline copy.
-    logger.warn(
-      'BundledPrompts',
+    log.warn(
       `Failed to load bundled ${name} prompts from ${filePath}; using inline templates: ${toErrorMessage(error)}`,
     );
     return row.whenUnavailable.inline;

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -27,7 +27,7 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
 import { getStreamTabId } from '@agent/runtime/streamTab';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import {
   RUN_OUTCOME,
   USER_FOLLOW_UP_SUPPORT,
@@ -58,6 +58,7 @@ import {
 } from './nativeSubagentStrategy';
 
 const LOG_CHANNEL = 'inBandSubagentExecution';
+const log = createLog(LOG_CHANNEL);
 
 interface InBandSubagentExecutionBaseOptions extends ChildRunLaunchOptions {
   readonly configPayload: AgentConfigPayload;
@@ -320,14 +321,13 @@ async function throwRetryableDurabilityError(
       const repair = await runWithInactiveExecutionLease(executionId, () =>
         writeStableSubagentAttempt(getExecutionStore(executionId), marker),
       ).catch((repairError: unknown) => {
-        logger.warn(LOG_CHANNEL, 'Retryable-marker repair write failed', {
+        log.warn('Retryable-marker repair write failed', {
           data: { executionId, error: repairError },
         });
         return undefined;
       });
       if (repair?.status !== 'performed') {
-        logger.warn(
-          LOG_CHANNEL,
+        log.warn(
           'Deferred retryable marker to resume-time reconciliation: the child lease is still held',
           { data: { executionId } },
         );
@@ -354,12 +354,12 @@ function recordCost(
   try {
     const observed = onCost?.(totalCostUsd);
     void Promise.resolve(observed).catch((error: unknown) => {
-      logger.warn(LOG_CHANNEL, 'Subagent cost observer rejected', {
+      log.warn('Subagent cost observer rejected', {
         data: error,
       });
     });
   } catch (error) {
-    logger.warn(LOG_CHANNEL, 'Subagent cost observer failed', {
+    log.warn('Subagent cost observer failed', {
       data: error,
     });
   }

--- a/src/tools/delegation/subagentResults.ts
+++ b/src/tools/delegation/subagentResults.ts
@@ -22,7 +22,7 @@ import {
   type ResultDiffSummary,
 } from '@agent/runtime/AgentFinalResult';
 import { normalizeProviderError } from '@common/errors/sdkError/providerErrorFormat';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
 import type { OutputFileSummary } from '@shared/schemas/output';
@@ -370,9 +370,11 @@ const LARGE_CHANGE_DIFF_LINES = 80;
 const LARGE_CHANGE_RATIO = 0.4;
 
 const LOG_CHANNEL = 'subagentDiffs';
+const log = createLog(LOG_CHANNEL);
 // The boundary warn in `buildSubagentResult` predates the A4 file merge and
 // stays on its historical channel so log ingestion keyed on it keeps seeing it.
 const DELIVERY_LOG_CHANNEL = 'subagentDelivery';
+const deliveryLog = createLog(DELIVERY_LOG_CHANNEL);
 
 const DIFF_LINE_PREFIX: Readonly<Record<number, string>> = Object.freeze({
   [DIFF_INSERT]: '+',
@@ -483,8 +485,7 @@ export async function computeAndWriteWorkflowDiffs(
         // surface the skip so a missing diff is not indistinguishable from an
         // unchanged file (matching the loud diff-unavailable note the caller
         // boundary logs).
-        logger.warn(
-          LOG_CHANNEL,
+        log.warn(
           `Skipping diff for ${o.absolutePath}: ${toErrorMessage(error)}`,
         );
       }
@@ -546,8 +547,7 @@ export async function buildSubagentResult(
       // Diff computation failure is non-fatal: deliver without diffs, but tell
       // the orchestrator to read the output files directly.
       diffsUnavailable = toErrorMessage(err);
-      logger.warn(
-        DELIVERY_LOG_CHANNEL,
+      deliveryLog.warn(
         `Diff computation failed for ${executionId}: ${diffsUnavailable}`,
       );
     }

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -23,7 +23,7 @@ import type { ExecutionKVStore } from '@agent/storage';
 import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
 import type { WorkflowControlRegistry } from '@agent/runtime/workflowControlRegistry';
 import { AgentFinalResultSchema } from '@agent/runtime/AgentFinalResult';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { ExecutionId, WorkflowExecutionSnapshot } from '@shared/schemas';
 import {
   deriveWorkflowCounts,
@@ -50,6 +50,7 @@ import { fingerprintWorkflowAgentDependencies } from './workflowScriptAgentRunne
 const RUN_LOG_MAX_LINES = 80;
 const RUN_LOG_MAX_LINE_LENGTH = 500;
 const SUMMARY_CHANNEL = 'WorkflowDeliverySummary';
+const summaryLog = createLog(SUMMARY_CHANNEL);
 
 /**
  * What the delivery line needs from a settled run: the canonical execution
@@ -192,8 +193,7 @@ export function createWorkflowScriptStrategy(
         // a mis-billed run is a correctness fault, while a delivery line that
         // omits one entry's files is merely incomplete. Loud either way — a
         // silently short file list is how corruption goes unreported.
-        logger.warn(
-          SUMMARY_CHANNEL,
+        summaryLog.warn(
           `Workflow '${params.name}' journal entry ${entry.index} is not an agent final result; its delivered files are omitted from the summary: ${toErrorMessage(parsed.error)}`,
           { data: parsed.error },
         );


### PR DESCRIPTION
## Summary

Post-#10475 subset of #10013. With the delegation/flow substrate consolidation
merged, the five namespace-import modules it introduced/retained are now
collision-free; this converts them following the #10005/#10616/#10627 pattern.
Each site binds `createLog` at the narrow scope where its channel value is
known, so every call still funnels through `createLog` → `loggerSelf` → the
shared `writeLine` sink and `vi.spyOn(logger, 'warn')` intercepts keep working.

Re-audited every open PR diff (#10601, #10609, #10612, #10638, #10636,
#10347): only #10646 also touches `inBandSubagentExecution.ts`; its hunks are disjoint and merge-tree clean, and it adds no logger calls. #10600/#10608/#10611 are merged and in
this branch's base. `src/auth/serverKeys/index.ts` and everything #10609
touches are deliberately excluded.

## Converted to `createLog` (5 files)

- `src/agent/runtime/agentSettingTools.ts` — channel is threaded per call by
  the local (`agentLoad`) and remote (`RemoteAgentLoader`) definition loaders,
  so bind `const log = createLog(channel)` at call scope (the #10627
  dynamic-channel idiom); never frozen at module load.
- `src/agent/runtime/bundledPrompts.ts` — single fixed `'BundledPrompts'`
  channel bound at module scope.
- `src/tools/delegation/inBandSubagentExecution.ts` — keeps `LOG_CHANNEL =
  'inBandSubagentExecution'` and binds `createLog(LOG_CHANNEL)`, matching the
  sibling `DelegationTools.ts` idiom; 4 warn sites converted.
- `src/tools/delegation/subagentResults.ts` — two fixed channels, both strings
  preserved verbatim: `subagentDiffs` (diff-skip warn) and `subagentDelivery`
  (boundary warn whose historical channel is pinned for log ingestion — the
  load-bearing comment stays attached to the constant).
- `src/tools/delegation/workflowScriptStrategy.ts` — binds the fixed
  `'WorkflowDeliverySummary'` summary channel as `summaryLog`. The
  `params.logger: AgentTrace` field (the run's child-stream trace, incl. the
  cost-settlement warn in `launch`) is **not** a logUtils consumer and is
  deliberately untouched.

## Remaining `import * as logger` modules

Non-test `src/` (8):

- `src/auth/serverKeys/index.ts` (excluded per scope)
- `src/housekeeping/clean.ts`
- `src/housekeeping/pack.ts`
- `src/housekeeping/runDirOps.ts`
- `src/latex/latexdiff/diffCommandExecutor.ts`
- `src/logger/logUtils.ts` (the `loggerSelf` seam itself — permanent)
- `src/tools/claudeAgentConfig.ts`
- `src/utils/system/execUtils.ts`

<details><summary><code>src/test-kernel/</code> (16 — test-side spies, separate judgment)</summary>

- `src/test-kernel/agent/AgentRegistry.vitest.ts`
- `src/test-kernel/agent/PocketFlowNode.vitest.ts`
- `src/test-kernel/agent/runtime/SessionDescription.vitest.ts`
- `src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts`
- `src/test-kernel/agent/storage/ExecutionListing.vitest.ts`
- `src/test-kernel/auth/SupabaseClient.vitest.ts`
- `src/test-kernel/auth/XaiSessionCoordinator.vitest.ts`
- `src/test-kernel/logger/LogUtils.vitest.ts`
- `src/test-kernel/progressView/AgentPresentationHostReplayGate.vitest.ts`
- `src/test-kernel/progressView/ProgressBackendCleanup.vitest.ts`
- `src/test-kernel/progressView/ProgressBackendStreamLifecycle.vitest.ts`
- `src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.ts`
- `src/test-kernel/settings/ExecutionHistoryWatcher.vitest.ts`
- `src/test-kernel/shared/stateSettings.vitest.ts`
- `src/test-kernel/telemetry/UsageLogService.vitest.ts`
- `src/test-kernel/utils/config/ConfigUtils.vitest.ts`

</details>

<details><summary><code>packages/extension/</code> (32)</summary>

- `packages/extension/src/commands/files/fileSelectionCommands.ts`
- `packages/extension/src/commands/git/gitCommands.ts`
- `packages/extension/src/commands/housekeeping/cleanCommands.ts`
- `packages/extension/src/commands/latex/arXivCommands.ts`
- `packages/extension/src/commands/latex/compareCommands.ts`
- `packages/extension/src/commands/latex/figCommands.ts`
- `packages/extension/src/commands/latex/latexCommands.ts`
- `packages/extension/src/commands/latex/latexdiffCommands.ts`
- `packages/extension/src/commands/setup/setupAssistantCommand.ts`
- `packages/extension/src/commands/taskFormState/stateRestoreCommand.ts`
- `packages/extension/src/common/webview/BaseViewContentProvider.ts`
- `packages/extension/src/common/webview/BaseViewMessageHandler.ts`
- `packages/extension/src/extension.ts`
- `packages/extension/src/frontend/agents/AgentDirectoryManager.ts`
- `packages/extension/src/frontend/auth/SupabaseAuthProvider.ts`
- `packages/extension/src/frontend/editor/activeFileGuards.ts`
- `packages/extension/src/frontend/events/agentEventListeners.ts`
- `packages/extension/src/frontend/git/resolveGitRoot.ts`
- `packages/extension/src/frontend/latex/openBuild.ts`
- `packages/extension/src/frontend/media/RecordingManager.ts`
- `packages/extension/src/frontend/review/AgentReviewService.ts`
- `packages/extension/src/frontend/setup.ts`
- `packages/extension/src/frontend/ui/errorHandlingUtils.ts`
- `packages/extension/src/frontend/ui/instruction.ts`
- `packages/extension/src/frontend/vscode/sharedStorageRoot.ts`
- `packages/extension/src/frontend/vscode/texraConfig.ts`
- `packages/extension/src/webview/mainViewInboundContext.ts`
- `packages/extension/src/webview/managers/DiffManager.ts`
- `packages/extension/src/webview/managers/executionHandlers.ts`
- `packages/extension/src/webview/managers/FileManager.ts`
- `packages/extension/src/webview/managers/InstructionManager.ts`

</details>

## Net elements (R6)

- Diffstat: **5 files, 24 insertions, 21 deletions; net +3 lines**.
- `import * as logger` non-test modules under `src/`: **13 → 8** (12 → 7
  excluding the permanent `logUtils.ts` `loggerSelf` self-import).
- Converted to `createLog`: **5** (4 module-scope bindings across 5 sites —
  `subagentResults` binds two — plus 1 function-scope binding in
  `agentSettingTools`).
- `createLog` module-level call sites under `src/` (non-test, excluding
  `logUtils.ts`): **80 → 85** (the `agentSettingTools` conversion is
  function-scoped by design and adds no module-level site).
- Exported symbols/classes/interfaces/enums added: **0**.

## Consumer counts (R8)

No event or emit path is added or rerouted. All six runtime channel strings
are preserved verbatim (`inBandSubagentExecution`, `BundledPrompts`,
`subagentDiffs`, `subagentDelivery`, `WorkflowDeliverySummary`, and the
loader-threaded `channel` parameter in `resolveAgentSettingTools`, whose 4
callers — `agentLoad` ×3, `RemoteAgentLoader` ×1 — are unchanged). The
`AgentTrace`-typed `params.logger` field of `WorkflowScriptStrategyParams`
keeps its name, type, and both consumers (`launch`'s settlement warn and the
`runPersistedWorkflowScriptWithProgress` pass-through). Module consumers are
unchanged: `bundledPrompts` still serves the three host composition roots,
and the delegation trio's importers (`DelegationTools`,
`nativeSubagentStrategy`, `workflowScriptTool`, `workflowScriptAgentRunner`)
import the same bindings. Test-spy seams: no test mocks or spies on
`@logger/logUtils` for these five modules; the one wholesale mock on an
affected path (`CliInitPlatform.vitest.ts`) already stubs `createLog`.

## Test plan

- Focused vitest: 15 suites covering all five modules and their callers —
  `BundledPrompts`, `agentLoad`, `RemoteAgentLoader`, `SubagentResults`,
  `SubagentResultMeta`, `WorkflowScriptStrategy`, `WorkflowScriptTool`,
  `DelegationHeadless`, `NativeSubagentStrategy`, `WorkflowScriptAgentRunner`,
  `TextEnhancementSession`, `CliInitPlatform`, `ElectronCompositionRoot`,
  `ToolStatusFormatting`, `TextDiffCallers` — **228 passed**.
- Broad sweep `src/test-kernel/{logger,tools,agent/runtime,agent/remote}`:
  **1349 passed** (4 pre-existing 10s-timeout flakes under parallel load all
  pass in isolation; none touch these modules).
- Architecture: 17/17 suites pass (`subsystemEdgeRatchet` is a ~9s test that
  flakes past its 10s timeout only under concurrent load; passes solo).
- Full `npm run typecheck` (all six sub-projects), full `npm run lint`,
  prettier `--check` on changed files: clean.
- `check:dead-code-ratchet` (8 vs 8 baselined), `check:guidance-refs`,
  `check:browser-safe-utils`, `check:tsconfig-paths`: clean.
- `git diff --check`: clean.

