### PR TITLE
test(latex): pin the sum-mode getSummedCount logger seam (#10649)

### DIFF
--- a/src/test-kernel/latex/Texcount.vitest.ts
+++ b/src/test-kernel/latex/Texcount.vitest.ts
@@ -122,4 +122,40 @@ describe('texcount logger seam', () => {
       expect.stringContaining('Stderr: texcount exploded'),
     );
   });
+
+  // #10649: getSummedCount also resolves its logger per call from the
+  // threaded channel. Its one emission of its own is the Chinese-package
+  // debug line, so a Chinese-package file in sum mode must reach the spied
+  // namespace on both the threaded and the default channel.
+  it('emits the sum-mode Chinese-package debug line on the resolved channel', async () => {
+    await installPlatform({
+      workspacePath: '/workspace',
+      files: { '/workspace/main.tex': '\\documentclass{ctexart}\n' },
+    });
+    mocks.runToolWithCheck.mockResolvedValue({
+      success: true,
+      stdout: 'Words in text: 5',
+      stderr: '',
+      exitCode: 0,
+    });
+    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+
+    const pinned = await getTeXCount('main.tex', {
+      mode: 'sum',
+      channel: 'pinnedTexcount',
+    });
+    const defaulted = await getTeXCount('main.tex', { mode: 'sum' });
+
+    // The (sum) prefix proves the summed path, not the per-file path, ran.
+    expect(pinned.output).toContain('Combined TeX Count Results (sum):');
+    expect(defaulted).toEqual(pinned);
+    expect(debug).toHaveBeenCalledWith(
+      'pinnedTexcount',
+      'Chinese packages detected in main.tex, enabling Chinese character counting',
+    );
+    expect(debug).toHaveBeenCalledWith(
+      LATEX_COMMANDS_CHANNEL,
+      'Chinese packages detected in main.tex, enabling Chinese character counting',
+    );
+  });
 });

--- a/src/test-kernel/latex/Texcount.vitest.ts
+++ b/src/test-kernel/latex/Texcount.vitest.ts
@@ -123,10 +123,13 @@ describe('texcount logger seam', () => {
     );
   });
 
-  // #10649: getSummedCount also resolves its logger per call from the
-  // threaded channel. Its one emission of its own is the Chinese-package
-  // debug line, so a Chinese-package file in sum mode must reach the spied
-  // namespace on both the threaded and the default channel.
+  // #10649: pins the sum-mode path's own log emission: getSummedCount's
+  // Chinese-package debug line reaches the spied namespace at debug level
+  // with its exact message, on both the threaded channel and the default
+  // LATEX_COMMANDS_CHANNEL. The spy is installed before the per-call
+  // createLog runs, so this test does not prove call-time loggerSelf
+  // delegation; that bind-time-vs-call-time seam is guarded by the
+  // import-time hasChinesePackages test above.
   it('emits the sum-mode Chinese-package debug line on the resolved channel', async () => {
     await installPlatform({
       workspacePath: '/workspace',


### PR DESCRIPTION
## Summary

Closes #10649

Follow-up to #10638 (which pinned the `createLog` spy seam for the per-call sites in `getTeXCount`, `rejectionReason`, and `runTexcount`, plus the import-time module binding used by `hasChinesePackages`). The sum-mode `getSummedCount` path in `src/latex/texcount.ts` had no coverage of its own log emission.

This PR adds the single missing focused test to `src/test-kernel/latex/Texcount.vitest.ts`, reusing the existing `@logger/logUtils` namespace spy seam. No production code changes.

The new test exercises the sum-mode path end to end and asserts:

- the run actually takes the summed path (`Combined TeX Count Results (sum):` output prefix);
- `getSummedCount`'s only emission of its own — the "Chinese packages detected" debug line — reaches the spied `@logger/logUtils` namespace at debug level with its exact message, on the threaded channel option (`pinnedTexcount`);
- the same emission reaches the spy on the default `LATEX_COMMANDS_CHANNEL` when no channel is threaded.

Scope note (per review): because the spy is installed before the per-call `createLog(channel)` inside `getSummedCount` executes, this test pins the emission itself — message, level, and channel threading (threaded + default) — but does not by itself prove call-time `loggerSelf` delegation: a bind-time-capturing `createLog` would capture the already-spied function here. That bind-time-vs-call-time seam is guarded by this suite's existing import-time `hasChinesePackages` test, where the module-level `const log = createLog(CHANNEL)` is bound before any spy exists.

## Test plan

- `npx vitest run src/test-kernel/latex/Texcount.vitest.ts` — 5/5 pass (4 existing + 1 new)
- Mutation check: removing the `log.debug` emission from `getSummedCount` makes the new test fail (`expected "Mock" to be called with arguments: [ 'pinnedTexcount', … ]`); production file restored afterwards
- `npx vitest run src/test-kernel/latex/` — 128/128 pass
- `npm run typecheck:test-kernel` — clean
- `eslint src/test-kernel/latex/Texcount.vitest.ts` — clean
- `prettier --check` + `git diff --check` — clean
