### PR TITLE
docs(agent): update stale createChannelTrace ownership comment in ModelHandler

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -287,7 +287,8 @@ export abstract class ModelHandler<
     this.maxOutputTokensFactor = DEFAULT_OUTPUT_TOKEN_LIMIT_FACTOR;
     // Initialize with default channel, will be overwritten by agent. Log-only
     // module singletons now use `createLog`; remaining `createChannelTrace`
-    // sites are `AgentTrace`-typed fallbacks or singletons still being
+    // sites are genuine `AgentTrace`-typed fallbacks plus log-only callers
+    // (singletons, per-instance defaults, inline one-offs) still being
     // narrowed under #10595. Unlike those, this default is exercised through
     // `createThinkingStream`/`createOutputStream` (`this.logger.openStream(...)`)
     // before `setLogger` swaps in the real per-run trace in some paths, so it

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -285,12 +285,13 @@ export abstract class ModelHandler<
     this.continueLimit = DEFAULT_CONTINUE_LIMIT;
     this.inputTokenLimit = DEFAULT_INPUT_TOKEN_LIMIT;
     this.maxOutputTokensFactor = DEFAULT_OUTPUT_TOKEN_LIMIT_FACTOR;
-    // Initialize with default channel, will be overwritten by agent. Unlike
-    // the other ~25 log-only `createChannelTrace` singletons, this default
-    // is exercised through `createThinkingStream`/`createOutputStream`
-    // (`this.logger.openStream(...)`) before `setLogger` swaps in the real
-    // per-run trace in some paths, so it needs the full `TraceEmitter`, not
-    // the log-only closure `createChannelTrace` now returns.
+    // Initialize with default channel, will be overwritten by agent. Log-only
+    // module singletons now use `createLog`; remaining `createChannelTrace`
+    // sites are `AgentTrace`-typed fallbacks or singletons still being
+    // narrowed under #10595. Unlike those, this default is exercised through
+    // `createThinkingStream`/`createOutputStream` (`this.logger.openStream(...)`)
+    // before `setLogger` swaps in the real per-run trace in some paths, so it
+    // needs the full `TraceEmitter`, not a log-only closure.
     this.logger = new TraceEmitter();
     attachChannelSubscriber(this.logger, { channel: 'Agent', isAgent: false });
     this.mediaProcessor = new MediaAttachmentProcessor(this.logger, {


### PR DESCRIPTION
Follow-up from #10610. The comment above `this.logger = new TraceEmitter()` in `src/agent/modelHandlers/ModelHandler.ts` still justified the `TraceEmitter` default by contrast with "the other ~25 log-only `createChannelTrace` singletons" — those log-only singletons were narrowed onto `createLog` by #10610 and the post-#10475 subset by #10648.

The comment now describes the current ownership split:

- log-only module singletons use `createLog`;
- the remaining `createChannelTrace` sites are genuine `AgentTrace`-typed fallbacks plus log-only callers — singletons, per-instance defaults, inline one-offs — still being narrowed under #10595;
- this default differs from both: it is exercised through `createThinkingStream`/`createOutputStream` (`this.logger.openStream(...)`) before `setLogger` swaps in the real per-run trace in some paths, so it needs the full `TraceEmitter`.

Comment-only change; the `TraceEmitter` justification itself is unchanged and no behavior changes.

Closes #10615

## Verification

- `corepack pnpm exec prettier --check src/agent/modelHandlers/ModelHandler.ts` — pass
- `corepack pnpm exec eslint src/agent/modelHandlers/ModelHandler.ts` — pass
- `git diff --check` — pass
- Typecheck/tests not run: comment-only diff, no code paths touched
