### PR TITLE
docs: record B2 landed actuals and three cut surfaces in the substrate plan

### DIFF
--- a/docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md
+++ b/docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md
@@ -755,6 +755,35 @@ single-caller premise failed (the inquiry formatter and the goal directory
 have multiple real consumers; `executionKvFiles.ts` is a genuine
 cross-package SSOT — keep).
 
+**Landed 2026-08-15 (PR #10608) at −91 LoC, ~27 elements.** The shortfall
+against the −190 estimate is honest: inlining a helper moves its body
+rather than deleting it, so the recovered lines are module headers,
+imports, exports, and re-export rows; the element count still lands above
+the estimate because the write-only-field item deletes more type-level
+constructs than the estimate credited. Three of the nine surfaces failed
+re-verification at PR time and were cut; each is recorded here with the
+premise that failed, as a standing negative result — do not re-propose:
+
+- `detectWaitingStreams` — the one-production-consumer premise held, but
+  the module path itself is a live mock seam: `vi.doMock` in
+  `DesktopAgentExecution.vitest.ts` and
+  `DesktopAgentExecutionFactory.vitest.ts`, `vi.spyOn` in
+  `SessionRestartRepair.vitest.ts`, a direct functional test in
+  `Resumability.vitest.ts`, and two rows in
+  `config/ratchets/host-agent-mock-baseline.json`. Inlining it into
+  `SessionHandle` would force those desktop restart-timing tests onto a
+  different gate — a mock-path hazard not worth 29 LoC.
+- `src/shared/streams/streamMetadata.ts` — `buildStreamMetadata` is a Zod
+  parse boundary owning the `UPDATE_STREAMS` wire shape
+  (`StreamMetadataSchema.parse`, prefault semantics documented in-file),
+  and `src/shared/` is the documented home for wire contracts. Moving it
+  into `controllers/progressView/backend/` would relocate a wire-shape
+  owner out of its layer and strand its 67-line unit test.
+- `src/shared/streams/childActivityReducer.ts` — a pure tested algorithm
+  with its own 53-line `describe` block; inlining trades a tested pure
+  function for an untested inline block — element count drops by 2,
+  coverage drops with it.
+
 ### B3. Make the host-agent baseline tell the truth (−25 LoC net, −18 elements)
 
 `host-agent-import-baseline.json` carries **5 stale rows** (specifiers with

--- a/docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md
+++ b/docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md
@@ -773,16 +773,23 @@ premise that failed, as a standing negative result — do not re-propose:
   `config/ratchets/host-agent-mock-baseline.json`. Inlining it into
   `SessionHandle` would force those desktop restart-timing tests onto a
   different gate — a mock-path hazard not worth 29 LoC.
-- `src/shared/streams/streamMetadata.ts` — `buildStreamMetadata` is a Zod
-  parse boundary owning the `UPDATE_STREAMS` wire shape
-  (`StreamMetadataSchema.parse`, prefault semantics documented in-file),
-  and `src/shared/` is the documented home for wire contracts. Moving it
-  into `controllers/progressView/backend/` would relocate a wire-shape
-  owner out of its layer and strand its 67-line unit test.
-- `src/shared/streams/childActivityReducer.ts` — a pure tested algorithm
-  with its own 53-line `describe` block; inlining trades a tested pure
-  function for an untested inline block — element count drops by 2,
-  coverage drops with it.
+- `src/shared/streams/streamMetadata.ts` — review correction (#10654):
+  the `UPDATE_STREAMS` wire shape is owned by `StreamMetadataSchema`
+  (`src/shared/schemas/streamState.ts`, consumed via
+  `UpdateStreamsMessageSchema`), which stays in `src/shared/` regardless;
+  `buildStreamMetadata` is the sole-consumer projection helper
+  (`ProgressStreamProjectionBuilder`) that parses through the schema so a
+  prefault added there cannot silently miss its output. The cut stands on
+  the net-gain bar: relocating a 42-line helper beside its only caller
+  moves the body, strands its 67-line unit test, and recovers only module
+  chrome.
+- `src/shared/streams/childActivityReducer.ts` — review correction
+  (#10654): the coverage is not hostage to the extraction — the
+  vanished-child behavior is exercised at the `SessionFactApplier`
+  boundary (`ProgressBackendRetainedChildren.vitest.ts`), where the
+  53-line direct `describe` block could be re-pointed. The cut stands
+  because the honest net is a 31-line pure module traded for an inline
+  block plus a test rewrite — ~2 elements for churn, not a sweep win.
 
 ### B3. Make the host-agent baseline tell the truth (−25 LoC net, −18 elements)
 

--- a/docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md
+++ b/docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md
@@ -762,7 +762,9 @@ imports, exports, and re-export rows; the element count still lands above
 the estimate because the write-only-field item deletes more type-level
 constructs than the estimate credited. Three of the nine surfaces failed
 re-verification at PR time and were cut; each is recorded here with the
-premise that failed, as a standing negative result — do not re-propose:
+premise that failed, as a measured negative result: do not re-propose them
+as the same mechanical B2 deletion absent new net benefit — a separately
+justified refactor is not frozen by this record:
 
 - `detectWaitingStreams` — the one-production-consumer premise held, but
   the module path itself is a live mock seam: `vi.doMock` in
@@ -773,23 +775,29 @@ premise that failed, as a standing negative result — do not re-propose:
   `config/ratchets/host-agent-mock-baseline.json`. Inlining it into
   `SessionHandle` would force those desktop restart-timing tests onto a
   different gate — a mock-path hazard not worth 29 LoC.
-- `src/shared/streams/streamMetadata.ts` — review correction (#10654):
+- `src/shared/streams/streamMetadata.ts` — review corrections (#10654):
   the `UPDATE_STREAMS` wire shape is owned by `StreamMetadataSchema`
   (`src/shared/schemas/streamState.ts`, consumed via
-  `UpdateStreamsMessageSchema`), which stays in `src/shared/` regardless;
-  `buildStreamMetadata` is the sole-consumer projection helper
-  (`ProgressStreamProjectionBuilder`) that parses through the schema so a
-  prefault added there cannot silently miss its output. The cut stands on
-  the net-gain bar: relocating a 42-line helper beside its only caller
-  moves the body, strands its 67-line unit test, and recovers only module
-  chrome.
+  `UpdateStreamsMessageSchema`) and stays in `src/shared/` regardless;
+  `buildStreamMetadata` is the 42-line sole-consumer projection helper
+  behind the public `ProgressStreamProjectionBuilder.streamMetadata()`
+  boundary. Its parse-through keeps backend-owned prefaults honest only
+  partially: `substate`, `userFollowUpSupport`, `lastTimestamp`, and
+  `category` are overwritten after the spread with possibly-undefined
+  inputs, so a prefault later added to one of those four would be
+  silently missed. Its 67-line direct test is likewise an
+  implementation-detail test that could be retargeted through the
+  projection boundary or dropped, not stranded. The cut stands on the
+  measured net alone: the move recovers only module chrome, no LoC or
+  element win.
 - `src/shared/streams/childActivityReducer.ts` — review correction
   (#10654): the coverage is not hostage to the extraction — the
   vanished-child behavior is exercised at the `SessionFactApplier`
-  boundary (`ProgressBackendRetainedChildren.vitest.ts`), where the
-  53-line direct `describe` block could be re-pointed. The cut stands
-  because the honest net is a 31-line pure module traded for an inline
-  block plus a test rewrite — ~2 elements for churn, not a sweep win.
+  boundary (`ProgressBackendRetainedChildren.vitest.ts`), and the 53-line
+  direct `describe` block is an implementation-detail test that could be
+  re-pointed there or dropped. The cut stands on the measured net alone:
+  a 31-line pure module traded for an inline block, ~2 elements for the
+  churn.
 
 ### B3. Make the host-agent baseline tell the truth (−25 LoC net, −18 elements)
 


### PR DESCRIPTION
## Summary

One plan-doc maintenance edit closing out item **B2 — Single-caller
extraction sweep** in
`docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md`,
per the merged #10608 body's instruction that the three cut surfaces
"should be recorded against B2 in the proposal rather than re-proposed."

- **§B2 now records the outcome**: landed 2026-08-15 (PR #10608) at
  **−91 LoC, ~27 elements** against the −190 LoC / −24 elements estimate,
  with the honest reason for the shortfall (inlining moves a helper's body;
  the recovered lines are module headers, imports, exports, and re-export
  rows).
- **§B2 now records the three surfaces cut at PR-time re-verification,
  each with the premise that failed**, as a *measured* negative result —
  do not re-propose them as the same mechanical B2 deletion absent new
  net benefit; a separately justified refactor is not frozen:
  - `detectWaitingStreams` — consumer-count premise held, but the module
    path is a live mock seam (`vi.doMock` in two desktop execution tests,
    `vi.spyOn` in `SessionRestartRepair.vitest.ts`, a functional test in
    `Resumability.vitest.ts`, two rows in
    `config/ratchets/host-agent-mock-baseline.json`); inlining into
    `SessionHandle` would force desktop restart-timing tests onto a
    different gate.
  - `src/shared/streams/streamMetadata.ts` — the `UPDATE_STREAMS` wire
    shape is owned by `StreamMetadataSchema`
    (`src/shared/schemas/streamState.ts`, via `UpdateStreamsMessageSchema`)
    and stays in `src/shared/` regardless; `buildStreamMetadata` is the
    42-line sole-consumer projection helper behind the public
    `ProgressStreamProjectionBuilder.streamMetadata()` boundary. Its
    parse-through protects prefaults only partially (four passthrough
    fields are overwritten post-spread with possibly-undefined inputs),
    and its 67-line direct test is retargetable through that boundary,
    not stranded. The cut stands on the measured net: module chrome only.
  - `src/shared/streams/childActivityReducer.ts` — coverage is not
    hostage to the extraction: the vanished-child behavior is exercised
    at the `SessionFactApplier` boundary
    (`ProgressBackendRetainedChildren.vitest.ts`); the 53-line direct
    `describe` block is an implementation-detail test that could be
    re-pointed or dropped. The cut stands on the measured net: ~2
    elements for the churn.
- Both premises were corrected across two review rounds on this PR (all
  four Codex threads addressed and resolved); the cut decisions themselves
  were never disputed. No other content changed; the plan's remaining
  technical conclusions are untouched.

**#10626 note:** the reported prettier failure no longer reproduces at
this HEAD — the doc was reformatted by #10362 and kept clean through the
#10475 amendments. This PR's edit is prettier-normalized, and the
repo-wide `prettier --check .` gate requested by the issue now passes over
every doc (evidence below), so main's static checks stay green.

## Net elements (R6)

Docs-only: one Markdown file. No production or test elements added,
removed, or renamed; no exports, interfaces, or fields touched.

## Consumer counts (R8)

No code surface touched, so no consumer counts change. The edit only adds
prose to the proposal; every file/test/ratchet path it names was verified
against the tree at this HEAD and against #10608's merged diff and body.

## Docs impact

Internal proposals dir — not published; no docs-root boundary impact. The
plan of record now prevents a future wave from re-proposing the three cut
B2 surfaces as the same mechanical deletion, without forbidding a
separately justified refactor.

## Validation

- `npm run format:check` (`prettier --check .`, repo-wide) — green; all
  matched files pass, confirming no other repo doc fails formatting.
- `npm run check:guidance-refs` — green (51 files).
- `git diff --check` — clean.

Closes #10626
Closes #10631
