### PR TITLE
test(agent): pin finalizeExecution's never-throws contract (#10614)

### DIFF
--- a/src/test-kernel/agent/storage/FinalizeExecutionNeverThrows.vitest.ts
+++ b/src/test-kernel/agent/storage/FinalizeExecutionNeverThrows.vitest.ts
@@ -1,0 +1,238 @@
+/* eslint-disable import/order -- Vitest mocks must be declared before importing the runtime under test. */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { flowKey } from '@agent/node/persistedFlow';
+import { RUN_OUTCOME, type ExecutionId } from '@shared/schemas';
+
+const mocks = vi.hoisted(() => ({
+  getExecutionStore: vi.fn(),
+  delete: vi.fn(),
+  readMeta: vi.fn(),
+  writeMeta: vi.fn(),
+}));
+
+vi.mock('@agent/storage/ExecutionKVStore', () => ({
+  getExecutionStore: mocks.getExecutionStore,
+}));
+
+import { finalizeExecution } from '@agent/storage/executionLifecycle';
+import { setupPlatform } from '@test/support/setupPlatform';
+
+const executionId = 'finalize-never-throws' as ExecutionId;
+
+function registeredMeta() {
+  return {
+    schemaVersion: 1,
+    timestamp: '2026-08-15T00:00:00.000Z',
+  };
+}
+
+/**
+ * Guard for the never-throws contract #10603 made load-bearing: the catchless
+ * callers in `terminalPersistence`, `runAgent`, and the CLI's
+ * `executionFinalization` await `finalizeExecution` with no catch arm, so a
+ * rejection would escape as an unhandled failure instead of being reported as
+ * a durability failure. Every test injects a rejecting or throwing store
+ * dependency — the terminal-status write, the flow-record cleanup delete, or
+ * store resolution itself — and asserts the call still RESOLVES a 'failed'
+ * result carrying the underlying error (#10614).
+ */
+describe('finalizeExecution never-throws contract (#10614)', () => {
+  setupPlatform({ workspacePath: '/workspace' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getExecutionStore.mockReturnValue({
+      delete: mocks.delete,
+      readMeta: mocks.readMeta,
+      writeMeta: mocks.writeMeta,
+    });
+    mocks.readMeta.mockResolvedValue(registeredMeta());
+    mocks.writeMeta.mockResolvedValue(undefined);
+    mocks.delete.mockResolvedValue(undefined);
+  });
+
+  it('resolves durable when every store write succeeds', async () => {
+    await expect(
+      finalizeExecution({
+        executionId,
+        outcome: RUN_OUTCOME.COMPLETED,
+        flowRecord: 'preserve',
+      }),
+    ).resolves.toEqual({
+      status: 'durable',
+      outcomePersisted: true,
+      flowRecord: 'preserved',
+    });
+    expect(mocks.delete).not.toHaveBeenCalled();
+  });
+
+  it('resolves failed when the terminal-status write rejects under a delete policy', async () => {
+    const writeError = new Error('meta write rejected');
+    mocks.writeMeta.mockRejectedValueOnce(writeError);
+
+    await expect(
+      finalizeExecution({
+        executionId,
+        outcome: RUN_OUTCOME.CANCELLED,
+        flowRecord: 'delete',
+      }),
+    ).resolves.toEqual({
+      status: 'failed',
+      error: writeError,
+      stage: 'terminal-status',
+      outcomePersisted: false,
+    });
+    // The requested flow-record delete still ran, failing closed.
+    expect(mocks.delete).toHaveBeenCalledWith(flowKey(executionId));
+  });
+
+  it('resolves failed without touching the flow record for a preserved non-terminal outcome', async () => {
+    const writeError = new Error('meta write rejected');
+    mocks.writeMeta.mockRejectedValueOnce(writeError);
+
+    await expect(
+      finalizeExecution({
+        executionId,
+        outcome: RUN_OUTCOME.CANCELLED,
+        flowRecord: 'preserve',
+      }),
+    ).resolves.toEqual({
+      status: 'failed',
+      error: writeError,
+      stage: 'terminal-status',
+      outcomePersisted: false,
+    });
+    expect(mocks.delete).not.toHaveBeenCalled();
+  });
+
+  it('resolves failed and still deletes fail-closed for a preserved terminal outcome', async () => {
+    const writeError = new Error('meta write rejected');
+    mocks.writeMeta.mockRejectedValueOnce(writeError);
+
+    await expect(
+      finalizeExecution({
+        executionId,
+        outcome: RUN_OUTCOME.COMPLETED,
+        flowRecord: 'preserve',
+      }),
+    ).resolves.toEqual({
+      status: 'failed',
+      error: writeError,
+      stage: 'terminal-status',
+      outcomePersisted: false,
+    });
+    // A terminal COMPLETED/FAILED outcome must never retain a resumable flow,
+    // so the cleanup delete runs even though the caller asked to preserve.
+    expect(mocks.delete).toHaveBeenCalledWith(flowKey(executionId));
+  });
+
+  it('resolves failed with an AggregateError when the fail-closed delete also rejects', async () => {
+    const writeError = new Error('meta write rejected');
+    const deleteError = new Error('flow delete rejected');
+    mocks.writeMeta.mockRejectedValueOnce(writeError);
+    mocks.delete.mockRejectedValueOnce(deleteError);
+
+    const finalization = finalizeExecution({
+      executionId,
+      outcome: RUN_OUTCOME.FAILED,
+      flowRecord: 'preserve',
+    });
+    await expect(finalization).resolves.toMatchObject({
+      status: 'failed',
+      stage: 'terminal-status-and-flow-record-delete',
+      outcomePersisted: false,
+      error: expect.any(AggregateError),
+    });
+    const result = await finalization;
+    if (result.status === 'durable') {
+      throw new Error('expected a failed finalization result');
+    }
+    expect((result.error as AggregateError).errors).toEqual([
+      writeError,
+      deleteError,
+    ]);
+  });
+
+  it('resolves failed when store resolution itself throws under a delete policy', async () => {
+    mocks.getExecutionStore.mockImplementation(() => {
+      throw new Error('store construction failed');
+    });
+
+    await expect(
+      finalizeExecution({
+        executionId,
+        outcome: RUN_OUTCOME.FAILED,
+        flowRecord: 'delete',
+      }),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      stage: 'terminal-status-and-flow-record-delete',
+      outcomePersisted: false,
+      error: expect.any(AggregateError),
+    });
+  });
+
+  it('resolves failed when store resolution itself throws under a preserve policy', async () => {
+    const constructionError = new Error('store construction failed');
+    mocks.getExecutionStore.mockImplementation(() => {
+      throw constructionError;
+    });
+
+    await expect(
+      finalizeExecution({
+        executionId,
+        outcome: RUN_OUTCOME.CANCELLED,
+        flowRecord: 'preserve',
+      }),
+    ).resolves.toEqual({
+      status: 'failed',
+      error: constructionError,
+      stage: 'terminal-status',
+      outcomePersisted: false,
+    });
+    expect(mocks.delete).not.toHaveBeenCalled();
+  });
+
+  it('resolves failed with the outcome persisted when only the flow-record delete rejects', async () => {
+    const deleteError = new Error('flow delete rejected');
+    mocks.delete.mockRejectedValueOnce(deleteError);
+
+    await expect(
+      finalizeExecution({
+        executionId,
+        outcome: RUN_OUTCOME.COMPLETED,
+        flowRecord: 'delete',
+      }),
+    ).resolves.toEqual({
+      status: 'failed',
+      error: deleteError,
+      stage: 'flow-record-delete',
+      outcomePersisted: true,
+    });
+    expect(mocks.writeMeta).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: RUN_OUTCOME.COMPLETED }),
+    );
+  });
+
+  it('resolves failed when the execution has no persisted metadata', async () => {
+    mocks.readMeta.mockResolvedValue(null);
+
+    await expect(
+      finalizeExecution({
+        executionId,
+        outcome: RUN_OUTCOME.CANCELLED,
+        flowRecord: 'preserve',
+      }),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      stage: 'terminal-status',
+      outcomePersisted: false,
+      error: expect.objectContaining({
+        message: expect.stringContaining('metadata not found'),
+      }),
+    });
+    expect(mocks.writeMeta).not.toHaveBeenCalled();
+    expect(mocks.delete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

#10603 deleted every defensive throw/catch arm around `finalizeExecution` because the function provably never throws — every store await sits inside a `try` whose `catch` returns a `{status:'failed'}` result. That contract is now load-bearing for the catchless callers in `src/agent/storage/terminalPersistence.ts`, `src/agent/runtime/runAgent.ts`, and `packages/cli/src/runtime/executionFinalization.ts`, but nothing regression-pinned it: a future change adding a throwing await to `finalizeExecution` would turn a durability failure into an unhandled rejection at those call sites.

This PR adds the guard test the issue asks for — a focused suite, `src/test-kernel/agent/storage/FinalizeExecutionNeverThrows.vitest.ts` (9 tests), that mocks `@agent/storage/ExecutionKVStore` (the same injection idiom as `RegisterExecutionWorkspaceDirectory.vitest.ts`) so the real `finalizeExecution` runs against a store whose writes reject, and asserts the call **resolves** the documented `'failed'` result instead of rejecting. Every failing path is pinned:

- terminal-status write rejects — under a `delete` policy (fail-closed delete still runs), under `preserve` with a non-terminal outcome (no delete), and under `preserve` with a terminal `COMPLETED` outcome (fail-closed delete must still run so no resumable flow is retained);
- terminal-status write rejects **and** the fail-closed delete rejects — resolves the `terminal-status-and-flow-record-delete` result whose `AggregateError` carries both causes, in order;
- store resolution itself throws (`getExecutionStore`) — under both `delete` (aggregated double failure) and `preserve` (verbatim construction error) policies;
- the flow-record delete rejects after the terminal write succeeded — resolves `flow-record-delete` with `outcomePersisted: true`;
- the execution has no persisted metadata — the read-modify-write lock fails closed and resolves `terminal-status`;
- a durable-path control proves the harness itself is not trivially failing.

Guard quality was verified by mutation: rethrowing from the terminal-status `catch` arm fails exactly the 5 tests pinning that arm ("promise rejected instead of resolving"), and rethrowing from the flow-delete `catch` fails exactly its 1 test; reverting restores 9/9 green.

## Issue acceptance gates

Closes #10614

- Gate: "a guard test asserting `finalizeExecution` resolves to a `'failed'` result (rather than rejecting) when an injected execution-store write rejects" — satisfied: 8 failure-path tests assert `.resolves` on injected rejections/throws across the terminal-status write, both flow-record delete arms, and store resolution; each failed result is asserted field-for-field (`stage`, `outcomePersisted`, `error`).

## Single source of truth

No ownership change. `finalizeExecution` in `src/agent/storage/executionLifecycle.ts` remains the single owner of the never-throws finalization contract; the new suite is its regression pin.

## Duplication and abstraction budget

No new abstraction. The suite reuses the established `vi.hoisted` + `vi.mock('@agent/storage/ExecutionKVStore')` injection idiom from `RegisterExecutionWorkspaceDirectory.vitest.ts` and adds no shared helpers. Existing finalize failure-path tests in that older suite assert on awaited results; this suite makes the resolves-rather-than-rejects contract explicit per the issue.

## Net elements (R6)

Diffstat: 1 file added, +238/−0 (`src/test-kernel/agent/storage/FinalizeExecutionNeverThrows.vitest.ts`). Exported symbols added: 0. Classes/interfaces/enums: 0. Production code: untouched.

## Consumer counts (R8)

n/a — test-only addition; no emit path, export, or module was deleted or re-routed.

## Host impact

Extension: none (test-only; the pinned contract protects the shared agent runtime this host calls).
Desktop: none (test-only; same shared runtime).
CLI: none (test-only; pins the contract `packages/cli/src/runtime/executionFinalization.ts` relies on).

## Scheduled refactoring

None.

## Validation

- `vitest run src/test-kernel/agent/storage/FinalizeExecutionNeverThrows.vitest.ts` — 9/9 pass; mutation check (rethrow in each catch arm) fails exactly the arm's tests, revert restores green.
- `vitest run src/test-kernel/agent/storage/ src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts src/test-kernel/agent/DeleteExecution.vitest.ts src/test-kernel/tools/ChildRunDelivery.vitest.ts` — 14 files, 144/144 pass.
- `npm run typecheck:test-kernel` and `npm run typecheck:workspace` — clean.
- `eslint` and `prettier --check` on the new file — clean.
- `vitest run src/test-kernel/architecture/` — 17 files, 102/102 pass (mock/import ratchets unaffected: the suite lives outside the host-mock ratchet's scanned dirs).
- `npm run check:dead-code-ratchet` — 8 current vs 8 baselined, no new findings.
- Full `npm test` not run: change is one additive test file; the affected directory, its mock-idiom siblings, and all ratchet suites are green.
