### PR TITLE
test(desktop): pin desktop log path-prefix redaction contract

### DIFF
--- a/src/test-kernel/desktop/DesktopAppLog.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAppLog.vitest.ts
@@ -131,4 +131,129 @@ describe('desktop app log', () => {
 
     expect(snapshot.text).toBe('Opened [path]/paper.tex');
   });
+
+  // Guard tests for the redactPathPrefixes contract (issue #10613). The
+  // function stays module-private, so these exercise it through
+  // readDesktopLogSnapshot, its only production call path: log text is
+  // scrubbed with (workspacePath, homedir()) and then redactSecrets.
+  describe('path prefix redaction', () => {
+    it('redacts the longest nested prefix first so workspace contents stay hidden', async () => {
+      const workspacePath = join(homedir(), 'texra-project');
+      await writeDesktopLog(
+        `Opened ${workspacePath}/paper.tex; also ${homedir()}/.config/texra/settings.json`,
+      );
+      const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
+
+      const snapshot = readDesktopLogSnapshot({ workspacePath });
+
+      // Shortest-first would leak the project directory name as
+      // '[path]/texra-project/paper.tex'.
+      expect(snapshot.text).toBe(
+        'Opened [path]/paper.tex; also [path]/.config/texra/settings.json',
+      );
+      expect(snapshot.text).not.toContain('texra-project');
+    });
+
+    it('redacts home paths before a shorter workspace prefix that contains them', async () => {
+      await writeDesktopLog(`home ${homedir()}/a.txt; other /Users/bob/b.txt`);
+      const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
+
+      const snapshot = readDesktopLogSnapshot({ workspacePath: '/Users' });
+
+      // Shortest-first would leak the account name as '[path]/<user>/a.txt'
+      // on hosts whose home directory sits under /Users.
+      expect(snapshot.text).toBe('home [path]/a.txt; other [path]/bob/b.txt');
+    });
+
+    it('treats regex metacharacters in a Windows workspace path literally', async () => {
+      const workspacePath = 'C:\\work\\proj.ec';
+      await writeDesktopLog(
+        `dir ${workspacePath}\\a.tex and C:\\work\\projXec\\b.tex`,
+      );
+      const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
+
+      const snapshot = readDesktopLogSnapshot({ workspacePath });
+
+      // An unescaped pattern would let '.' match 'X' and redact the sibling.
+      expect(snapshot.text).toBe(
+        'dir [path]\\a.tex and C:\\work\\projXec\\b.tex',
+      );
+    });
+
+    it('redacts Windows paths at end of string and before mixed separators', async () => {
+      const workspacePath = 'C:\\work\\project';
+      await writeDesktopLog(
+        `copy ${workspacePath}/src/main.tex; cd ${workspacePath}`,
+      );
+      const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
+
+      const snapshot = readDesktopLogSnapshot({ workspacePath });
+
+      expect(snapshot.text).toBe('copy [path]/src/main.tex; cd [path]');
+    });
+
+    it('redacts descendants of a trailing-backslash Windows prefix without requiring a boundary', async () => {
+      const workspacePath = 'D:\\build\\out\\';
+      await writeDesktopLog(
+        `wrote ${workspacePath}app.log; list ${workspacePath}`,
+      );
+      const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
+
+      const snapshot = readDesktopLogSnapshot({ workspacePath });
+
+      // A boundary lookahead after the trailing separator would reject the
+      // 'app.log' follower and leave the prefix visible.
+      expect(snapshot.text).toBe('wrote [path]app.log; list [path]');
+    });
+
+    it('redacts repeated descendants of a trailing-slash POSIX prefix only', async () => {
+      const workspacePath = '/Users/alice/';
+      await writeDesktopLog(
+        `a ${workspacePath}docs/one.tex; b ${workspacePath}drafts/two.tex; keep /Users/alice-other/c.tex`,
+      );
+      const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
+
+      const snapshot = readDesktopLogSnapshot({ workspacePath });
+
+      expect(snapshot.text).toBe(
+        'a [path]docs/one.tex; b [path]drafts/two.tex; keep /Users/alice-other/c.tex',
+      );
+    });
+
+    it('redacts a POSIX-root workspace at string start and after quotes, preserving drive and URL separators', async () => {
+      await writeDesktopLog(
+        `/Users/alice/x.tex; ("C:/work/project"); fetch https://example.com/a; log "/etc/hosts"`,
+      );
+      const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
+
+      const snapshot = readDesktopLogSnapshot({ workspacePath: '/' });
+
+      expect(snapshot.text).toBe(
+        `[path]Users/alice/x.tex; ("C:/work/project"); fetch https://example.com/a; log "[path]etc/hosts"`,
+      );
+    });
+
+    it('still redacts secrets after scrubbing path prefixes', async () => {
+      const workspacePath = 'C:\\work\\project';
+      await writeDesktopLog(
+        `OPENAI_API_KEY=sk-1234567890abcdef saved to ${workspacePath}\\config.env`,
+      );
+      const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
+
+      const snapshot = readDesktopLogSnapshot({ workspacePath });
+
+      expect(snapshot.text).toBe(
+        'OPENAI_API_KEY=[redacted] saved to [path]\\config.env',
+      );
+    });
+
+    it('scrubs the home directory when no workspace path is provided', async () => {
+      await writeDesktopLog(`config ${homedir()}/.config/texra/app.json`);
+      const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
+
+      const snapshot = readDesktopLogSnapshot({});
+
+      expect(snapshot.text).toBe('config [path]/.config/texra/app.json');
+    });
+  });
 });

--- a/src/test-kernel/desktop/DesktopAppLog.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAppLog.vitest.ts
@@ -3,7 +3,7 @@ import { Buffer } from 'node:buffer';
 import { randomUUID } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -101,24 +101,30 @@ describe('desktop app log', () => {
   });
 
   it('redacts descendants of a separator-terminated workspace root', async () => {
-    await writeDesktopLog('Opened C:\\Users\\alice\\paper.tex');
+    // Derived account name: a real home of C:\Users\<name> must not
+    // redact this path before the separator-terminated workspace prefix.
+    const account = `texra-redact-${basename(homedir())}`;
+    await writeDesktopLog(`Opened C:\\Users\\${account}\\paper.tex`);
     const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
 
     const snapshot = readDesktopLogSnapshot({ workspacePath: 'C:\\' });
 
-    expect(snapshot.text).toBe('Opened [path]Users\\alice\\paper.tex');
+    expect(snapshot.text).toBe(`Opened [path]Users\\${account}\\paper.tex`);
   });
 
   it('redacts a POSIX-root path without rewriting URLs or relative separators', async () => {
+    // Derived non-home path: a real home of /Users/<name> must not rewrite
+    // this first and double-redact through the '/' branch.
+    const nonHomePath = `/Users/${basename(homedir())}-other/paper.tex`;
     await writeDesktopLog(
-      'Opened /Users/alice/paper.tex; fetched https://example.com; read src/file.ts',
+      `Opened ${nonHomePath}; fetched https://example.com; read src/file.ts`,
     );
     const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
 
     const snapshot = readDesktopLogSnapshot({ workspacePath: '/' });
 
     expect(snapshot.text).toBe(
-      'Opened [path]Users/alice/paper.tex; fetched https://example.com; read src/file.ts',
+      `Opened [path]${nonHomePath.slice(1)}; fetched https://example.com; read src/file.ts`,
     );
   });
 
@@ -155,14 +161,22 @@ describe('desktop app log', () => {
     });
 
     it('redacts home paths before a shorter workspace prefix that contains them', async () => {
-      await writeDesktopLog(`home ${homedir()}/a.txt; other /Users/bob/b.txt`);
+      const home = homedir();
+      const root = dirname(home);
+      const homeFile = join(home, 'a.txt');
+      // The sibling extends basename(home), so the '-' follower defeats a
+      // home-prefix boundary match and it can never equal the real home.
+      const siblingFile = join(root, `${basename(home)}-sibling`, 'b.txt');
+      await writeDesktopLog(`home ${homeFile}; other ${siblingFile}`);
       const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
 
-      const snapshot = readDesktopLogSnapshot({ workspacePath: '/Users' });
+      const snapshot = readDesktopLogSnapshot({ workspacePath: root });
 
-      // Shortest-first would leak the account name as '[path]/<user>/a.txt'
-      // on hosts whose home directory sits under /Users.
-      expect(snapshot.text).toBe('home [path]/a.txt; other [path]/bob/b.txt');
+      // home is always nested under dirname(home), so shortest-first ordering
+      // leaks the account name as '[path]/<user>/a.txt' on every POSIX host.
+      expect(snapshot.text).toBe(
+        `home [path]${homeFile.slice(home.length)}; other [path]${siblingFile.slice(root.length)}`,
+      );
     });
 
     it('treats regex metacharacters in a Windows workspace path literally', async () => {
@@ -174,7 +188,9 @@ describe('desktop app log', () => {
 
       const snapshot = readDesktopLogSnapshot({ workspacePath });
 
-      // An unescaped pattern would let '.' match 'X' and redact the sibling.
+      // Pins escapeRegExp both ways: unescaped, '\w' becomes a character
+      // class that cannot match the literal backslash (the real prefix stops
+      // redacting), and a bare '.' would also match the sibling's 'X'.
       expect(snapshot.text).toBe(
         'dir [path]\\a.tex and C:\\work\\projXec\\b.tex',
       );
@@ -207,29 +223,36 @@ describe('desktop app log', () => {
     });
 
     it('redacts repeated descendants of a trailing-slash POSIX prefix only', async () => {
-      const workspacePath = '/Users/alice/';
+      // Derived from basename(home) so neither path can equal or contain the
+      // real home directory on any host.
+      const account = `texra-redact-${basename(homedir())}`;
+      const workspacePath = `/Users/${account}/`;
       await writeDesktopLog(
-        `a ${workspacePath}docs/one.tex; b ${workspacePath}drafts/two.tex; keep /Users/alice-other/c.tex`,
+        `a ${workspacePath}docs/one.tex; b ${workspacePath}drafts/two.tex; keep /Users/${account}-other/c.tex`,
       );
       const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
 
       const snapshot = readDesktopLogSnapshot({ workspacePath });
 
       expect(snapshot.text).toBe(
-        'a [path]docs/one.tex; b [path]drafts/two.tex; keep /Users/alice-other/c.tex',
+        `a [path]docs/one.tex; b [path]drafts/two.tex; keep /Users/${account}-other/c.tex`,
       );
     });
 
     it('redacts a POSIX-root workspace at string start and after quotes, preserving drive and URL separators', async () => {
+      // Extends basename(home) with '-other', so the real home prefix never
+      // boundary-matches it (a '/Users/alice' home would otherwise rewrite it
+      // first and the '/' branch would double-redact the remainder).
+      const nonHomePath = `/Users/${basename(homedir())}-other/x.tex`;
       await writeDesktopLog(
-        `/Users/alice/x.tex; ("C:/work/project"); fetch https://example.com/a; log "/etc/hosts"`,
+        `${nonHomePath}; ("C:/work/project"); fetch https://example.com/a; log "/etc/hosts"`,
       );
       const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
 
       const snapshot = readDesktopLogSnapshot({ workspacePath: '/' });
 
       expect(snapshot.text).toBe(
-        `[path]Users/alice/x.tex; ("C:/work/project"); fetch https://example.com/a; log "[path]etc/hosts"`,
+        `[path]${nonHomePath.slice(1)}; ("C:/work/project"); fetch https://example.com/a; log "[path]etc/hosts"`,
       );
     });
 


### PR DESCRIPTION
## Summary

Closes #10613

Test-only follow-up to #10604, which deleted the dead `LogRedactionOptions` path branch of `redactSecrets` and made `redactPathPrefixes` (`packages/desktop/src/main/desktopAppLog.ts`) the sole production path-scrubbing mechanism with zero direct coverage. This PR pins that contract with nine guard tests in `src/test-kernel/desktop/DesktopAppLog.vitest.ts`. No production code changes.

`redactPathPrefixes` stays module-private, so the tests exercise it through `readDesktopLogSnapshot` — its only production call path — reusing the file's existing electron-stub/temp-log harness. Log text is scrubbed with `(workspacePath, homedir())` and then `redactSecrets`, exactly as in production.

All fixtures that mention absolute paths derive from `homedir()` (`dirname`/`basename`), so no fixture can collide with the actual home directory of the host running the suite.

## Issue acceptance gates

- Nested prefixes, longest prefix wins: pinned from both directions (workspace nested under home; home nested under a shorter workspace root derived from `dirname(homedir())`, so real nesting holds on every POSIX host). The reversed-sort mutation fails both nested-prefix tests (plus the pre-existing nested test) under macOS and simulated-Linux homes alike — shortest-first leaks the project directory / account name everywhere.
- Windows backslash path variants: regex metacharacters in the prefix match literally (pins `escapeRegExp` both ways — unescaped `\w` stops matching the real prefix, a bare `.` would also match a sibling's `X`), end-of-string and mixed-separator (`/` after `\` prefix) boundaries, and adjacent-suffix non-matches.
- Trailing-slash prefixes: separator-terminated prefixes (`D:\build\out\`, derived `/Users/<account>/`) redact descendants with no boundary requirement, all occurrences, without touching `-other` sibling paths.
- The `prefix === '/'` branch: root-anchored slashes at string start and after quotes redact; drive-letter (`C:/...`) and URL (`https://...`) separators are preserved. Both POSIX-root tests use a guaranteed non-home path (`/Users/<basename(home)>-other/...`), so a home of `/Users/alice` no longer double-redacts them.
- Additionally pinned (the residual risk both review bots flagged on #10604): home-directory scrubbing still applies when no workspace path is provided, and `redactSecrets` still runs after path scrubbing (`OPENAI_API_KEY=sk-...` next to a workspace path yields both `[redacted]` and `[path]`).

Review-round 2 also hardened two pre-existing tests with the same host-fragility class (proven via `HOME` overrides): the POSIX-root `/` test and the separator-terminated `C:\` test, and corrected the `escapeRegExp` test comment.

Each new test was verified to fail against a targeted mutation of `desktopAppLog.ts` (reversed sort — including under a simulated Linux home, dropped `escapeRegExp`, forced boundary lookahead, removed `'/'` branch — including under a simulated `/Users/alice` home, dropped `redactSecrets` call). Production file restored byte-identical afterwards.

## Single source of truth

`redactPathPrefixes` in `packages/desktop/src/main/desktopAppLog.ts` remains the single owner of desktop log path scrubbing; these tests document its contract at its only call path rather than adding a test-only export (which the knip dead-code ratchet would flag).

## Duplication and abstraction budget

No new abstractions or helpers; the tests reuse the existing `writeDesktopLog` / `loadDesktopAppLogModule` harness already in this file.

## Net elements (R6)

1 file changed, +153/-5 vs the merge base with main (`src/test-kernel/desktop/DesktopAppLog.vitest.ts`). Exported symbols added/removed: none. Classes/interfaces/enums: none. Production LoC: unchanged.

## Consumer counts (R8)

n/a — test-only change; no exports, emit paths, or subscribers affected.

## Host impact

Extension: none.
Desktop: test coverage only; runtime behavior unchanged.
CLI: none.

## Scheduled refactoring

None.

## Validation

- `vitest run src/test-kernel/desktop/DesktopAppLog.vitest.ts src/test-kernel/desktop/DesktopLogRedaction.vitest.ts` — 19 passed
- HOME-override matrix on `DesktopAppLog.vitest.ts` (`/Users/siruilu`, `/Users/alice`, `/Users/bob`, `/home/runner`) — 15/15 passed under each
- `vitest run src/test-kernel/desktop/` — 59 files / 609 tests passed
- `vitest run src/test-kernel/architecture/` — 17 files / 102 tests passed
- Mutation checks after fixture correction: reversed sort fails both nested-prefix tests under macOS and `HOME=/home/runner`; removed `'/'` branch fails both POSIX-root tests under `HOME=/Users/alice`; forced boundary lookahead fails the separator-terminated/trailing-slash tests; dropped `escapeRegExp` fails the Windows tests; dropped `redactSecrets` fails the combined test
- `npm run typecheck:test-kernel`, `npm run typecheck:desktop`, `npm run typecheck:workspace` — clean
- `npm run lint` (full) — clean
- `npm run format:check` — clean
- `npm run check:dead-code-ratchet` — 8 findings vs 8 baselined, no new entries
