### PR TITLE
fix(hooks): follow symlinks when classifying package main targets in format-staged

### DIFF
--- a/scripts/format-staged.mjs
+++ b/scripts/format-staged.mjs
@@ -257,6 +257,24 @@ function isIndexTracked(path) {
   return rel !== null && readIndexFile(rel) !== null;
 }
 
+/** True when any component of `path`, from the repository root down to the
+ * path itself, is a worktree symlink. Node loads a module by realpath and
+ * resolves its own relative dependencies from the real directory, so an
+ * index blob at the lexical path proves nothing about the dependency context
+ * Node actually sees; such a path must fail loudly rather than verify. */
+function pathTraversesSymlink(path) {
+  const rel = relToCwd(path);
+  if (rel === null) return false;
+  let current = process.cwd();
+  for (const segment of rel.split('/')) {
+    current = join(current, segment);
+    if (lstatSync(current, { throwIfNoEntry: false })?.isSymbolicLink()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Resolve a relative config dependency specifier to the tracked file
  * Node/Prettier would load, without executing any config. `kind` is `cjs`
  * for `require()`/CommonJS resolution; every other kind (ESM `import`,
@@ -282,7 +300,11 @@ function resolveConfigDepPath(configDir, spec, kind) {
   push(base);
   for (const ext of CJS_FILE_EXTENSIONS) push(`${base}${ext}`);
 
-  if (lstatSync(base, { throwIfNoEntry: false })?.isDirectory()) {
+  // stat, not lstat: Node's LOAD_AS_DIRECTORY follows a symlinked
+  // dependency directory too. Candidates reached through the link traverse
+  // a worktree symlink, which verifyConfigDep rejects loudly, so following
+  // the link here can never verify the wrong file.
+  if (statSync(base, { throwIfNoEntry: false })?.isDirectory()) {
     const main = readPackageMain(base);
     if (main) {
       const mainTarget = resolve(base, normalizeSpecifier(main));
@@ -320,6 +342,13 @@ function verifyConfigDep(configDir, spec, kind = 'exact') {
     throw new SkipError(
       `config dependency ${spec} resolves outside the repository; skipped ` +
         'auto-staging.',
+    );
+  }
+  if (pathTraversesSymlink(depPath)) {
+    throw new SkipError(
+      `${depRel} resolves through a worktree symlink while the staged config ` +
+        'depends on it; skipped auto-staging so the realpath target and its ' +
+        'uncommitted dependencies stay out of the commit.',
     );
   }
   const stagedDep = readIndexFile(depRel);

--- a/scripts/format-staged.mjs
+++ b/scripts/format-staged.mjs
@@ -40,6 +40,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -203,9 +204,13 @@ function isConfigPointerPath(spec) {
   return isRelativeSpecifier(spec) || isAbsolute(spec);
 }
 
-/** True when `path` is a regular file in the working tree. */
+/** True when `path` is a regular file in the working tree. Node's
+ * LOAD_AS_FILE/tryExtensions classify with stat, so a symlink to a file
+ * counts: admitting the link as a candidate makes an untracked one a loud
+ * "not staged" skip instead of a silent fall-through to a fallback Node
+ * would never load. */
 function isWorktreeFile(path) {
-  return lstatSync(path, { throwIfNoEntry: false })?.isFile() === true;
+  return statSync(path, { throwIfNoEntry: false })?.isFile() === true;
 }
 
 /** Return the `main` entry of a dependency directory's package.json. The
@@ -289,7 +294,11 @@ function resolveConfigDepPath(configDir, spec, kind) {
       // an unstaged edit to the real main drive Prettier.
       push(mainTarget);
       for (const ext of CJS_FILE_EXTENSIONS) push(`${mainTarget}${ext}`);
-      if (lstatSync(mainTarget, { throwIfNoEntry: false })?.isDirectory()) {
+      // stat, not lstat: Node's LOAD_AS_DIRECTORY follows symlinks, so a
+      // main target that links to a directory resolves to its index.*.
+      // Classifying the link itself would skip those candidates and verify
+      // the package-level index.* fallback Node never loads (#10602).
+      if (statSync(mainTarget, { throwIfNoEntry: false })?.isDirectory()) {
         for (const indexName of CJS_INDEX_EXTENSIONS) {
           push(join(mainTarget, indexName));
         }

--- a/scripts/format-staged.mjs
+++ b/scripts/format-staged.mjs
@@ -204,13 +204,25 @@ function isConfigPointerPath(spec) {
   return isRelativeSpecifier(spec) || isAbsolute(spec);
 }
 
+/** Stat `path` the way Node's module loader probes candidates: any
+ * filesystem error (ELOOP, ENOTDIR, EACCES, ...) is a non-match, not an
+ * exception, so a bad probe never aborts resolution of the later candidates
+ * Node would still try. Returns undefined when the probe fails. */
+function statProbe(path) {
+  try {
+    return statSync(path);
+  } catch {
+    return undefined;
+  }
+}
+
 /** True when `path` is a regular file in the working tree. Node's
  * LOAD_AS_FILE/tryExtensions classify with stat, so a symlink to a file
  * counts: admitting the link as a candidate makes an untracked one a loud
  * "not staged" skip instead of a silent fall-through to a fallback Node
  * would never load. */
 function isWorktreeFile(path) {
-  return statSync(path, { throwIfNoEntry: false })?.isFile() === true;
+  return statProbe(path)?.isFile() === true;
 }
 
 /** Return the `main` entry of a dependency directory's package.json. The
@@ -268,9 +280,13 @@ function pathTraversesSymlink(path) {
   let current = process.cwd();
   for (const segment of rel.split('/')) {
     current = join(current, segment);
-    if (lstatSync(current, { throwIfNoEntry: false })?.isSymbolicLink()) {
-      return true;
+    let stat;
+    try {
+      stat = lstatSync(current);
+    } catch {
+      return false;
     }
+    if (stat.isSymbolicLink()) return true;
   }
   return false;
 }
@@ -308,10 +324,7 @@ function resolveConfigDepPath(configDir, spec, kind) {
   // symlinked dependency directory too. Candidates reached through the link
   // traverse a worktree symlink, which verifyConfigDep rejects loudly, so
   // following the link here can never verify the wrong file.
-  if (
-    candidates.length === 0 &&
-    statSync(base, { throwIfNoEntry: false })?.isDirectory()
-  ) {
+  if (candidates.length === 0 && statProbe(base)?.isDirectory()) {
     const main = readPackageMain(base);
     if (main) {
       const mainTarget = resolve(base, normalizeSpecifier(main));
@@ -327,7 +340,7 @@ function resolveConfigDepPath(configDir, spec, kind) {
       // main target that links to a directory resolves to its index.*.
       // Classifying the link itself would skip those candidates and verify
       // the package-level index.* fallback Node never loads (#10602).
-      if (statSync(mainTarget, { throwIfNoEntry: false })?.isDirectory()) {
+      if (statProbe(mainTarget)?.isDirectory()) {
         for (const indexName of CJS_INDEX_EXTENSIONS) {
           push(join(mainTarget, indexName));
         }

--- a/scripts/format-staged.mjs
+++ b/scripts/format-staged.mjs
@@ -300,11 +300,18 @@ function resolveConfigDepPath(configDir, spec, kind) {
   push(base);
   for (const ext of CJS_FILE_EXTENSIONS) push(`${base}${ext}`);
 
-  // stat, not lstat: Node's LOAD_AS_DIRECTORY follows a symlinked
-  // dependency directory too. Candidates reached through the link traverse
-  // a worktree symlink, which verifyConfigDep rejects loudly, so following
-  // the link here can never verify the wrong file.
-  if (statSync(base, { throwIfNoEntry: false })?.isDirectory()) {
+  // Node applies LOAD_AS_DIRECTORY only when LOAD_AS_FILE found no file:
+  // an admitted file candidate wins outright and the directory's package
+  // main/index.* are never inspected, so an irrelevant directory beside the
+  // winner (for example an untracked symlinked package) must not force a
+  // skip either. stat, not lstat: Node's LOAD_AS_DIRECTORY follows a
+  // symlinked dependency directory too. Candidates reached through the link
+  // traverse a worktree symlink, which verifyConfigDep rejects loudly, so
+  // following the link here can never verify the wrong file.
+  if (
+    candidates.length === 0 &&
+    statSync(base, { throwIfNoEntry: false })?.isDirectory()
+  ) {
     const main = readPackageMain(base);
     if (main) {
       const mainTarget = resolve(base, normalizeSpecifier(main));

--- a/scripts/format-staged.mjs
+++ b/scripts/format-staged.mjs
@@ -269,28 +269,6 @@ function isIndexTracked(path) {
   return rel !== null && readIndexFile(rel) !== null;
 }
 
-/** True when any component of `path`, from the repository root down to the
- * path itself, is a worktree symlink. Node loads a module by realpath and
- * resolves its own relative dependencies from the real directory, so an
- * index blob at the lexical path proves nothing about the dependency context
- * Node actually sees; such a path must fail loudly rather than verify. */
-function pathTraversesSymlink(path) {
-  const rel = relToCwd(path);
-  if (rel === null) return false;
-  let current = process.cwd();
-  for (const segment of rel.split('/')) {
-    current = join(current, segment);
-    let stat;
-    try {
-      stat = lstatSync(current);
-    } catch {
-      return false;
-    }
-    if (stat.isSymbolicLink()) return true;
-  }
-  return false;
-}
-
 /** Resolve a relative config dependency specifier to the tracked file
  * Node/Prettier would load, without executing any config. `kind` is `cjs`
  * for `require()`/CommonJS resolution; every other kind (ESM `import`,
@@ -364,12 +342,28 @@ function verifyConfigDep(configDir, spec, kind = 'exact') {
         'auto-staging.',
     );
   }
-  if (pathTraversesSymlink(depPath)) {
-    throw new SkipError(
-      `${depRel} resolves through a worktree symlink while the staged config ` +
-        'depends on it; skipped auto-staging so the realpath target and its ' +
-        'uncommitted dependencies stay out of the commit.',
-    );
+  // Node loads a module by realpath and resolves its own relative
+  // dependencies from the real directory, so an index blob at a lexical path
+  // passing through a worktree symlink proves nothing about the dependency
+  // context Node actually sees: walk the components from the repository root
+  // down and reject the dependency when any of them is a symlink.
+  let current = process.cwd();
+  for (const segment of depRel.split('/')) {
+    current = join(current, segment);
+    let stat;
+    try {
+      stat = lstatSync(current);
+    } catch {
+      // Does not resolve in the worktree; the existence checks below skip.
+      break;
+    }
+    if (stat.isSymbolicLink()) {
+      throw new SkipError(
+        `${depRel} resolves through a worktree symlink while the staged ` +
+          'config depends on it; skipped auto-staging so the realpath ' +
+          'target and its uncommitted dependencies stay out of the commit.',
+      );
+    }
   }
   const stagedDep = readIndexFile(depRel);
   if (!stagedDep) {

--- a/src/test-kernel/scripts/FormatStaged.vitest.ts
+++ b/src/test-kernel/scripts/FormatStaged.vitest.ts
@@ -13,7 +13,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { delimiter, dirname, join, resolve } from 'node:path';
+import { delimiter, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -104,35 +104,6 @@ function runFormat(env = gitEnv) {
 
 function stagedBlob(path: string): string {
   return git(['show', `:${path}`]);
-}
-
-// Stage and commit a CommonJS `config/opts` package (package.json `main`
-// plus any extra repo-relative `files`) consumed by the fixture config via
-// `require("./opts")`, so each resolver test only spells out the files its
-// own scenario needs.
-function stageOptsPackage(main: string, files: Record<string, string>) {
-  mkdirSync(join(dir, 'config/opts'), { recursive: true });
-  writeFileSync(join(dir, 'config/opts/package.json'), `{"main":"${main}"}\n`);
-  for (const [path, text] of Object.entries(files)) {
-    mkdirSync(dirname(join(dir, path)), { recursive: true });
-    writeFileSync(join(dir, path), text);
-  }
-  writeFileSync(
-    join(dir, 'config/prettier.cjs'),
-    'const opts = require("./opts");\nmodule.exports = opts;\n',
-  );
-  writeFileSync(
-    join(dir, 'package.json'),
-    '{"prettier":"./config/prettier.cjs"}\n',
-  );
-  git([
-    'add',
-    'config/prettier.cjs',
-    'config/opts/package.json',
-    ...Object.keys(files),
-    'package.json',
-  ]);
-  git(['commit', '-qm', 'config base']);
 }
 
 describe('format-staged', () => {
@@ -1381,163 +1352,6 @@ describe('format-staged', () => {
     );
     expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
   });
-
-  it.skipIf(process.platform === 'win32')(
-    'skips when a directory package main is an untracked symlink to a directory (#10602)',
-    () => {
-      stageOptsPackage('dist', {
-        'config/opts/dist-target/index.js':
-          'module.exports = { semi: true };\n',
-        'config/opts/index.js': 'module.exports = { semi: true };\n',
-      });
-      // `dist` is an untracked symlink to a directory whose index.js has
-      // uncommitted edits. Node's LOAD_AS_DIRECTORY follows the link and
-      // loads `dist/index.js` by realpath, so the lexical candidate must be
-      // rejected, not verified against the clean package-level index.js
-      // fallback.
-      writeFileSync(
-        join(dir, 'config/opts/dist-target/index.js'),
-        'module.exports = { semi: false };\n',
-      );
-      symlinkSync('dist-target', join(dir, 'config/opts/dist'), 'dir');
-      writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
-      git(['add', 'a.ts']);
-
-      const result = runFormat();
-
-      expect(result.status, result.stderr).toBe(0);
-      expect(result.stdout).toContain(
-        'config/opts/dist/index.js resolves through a worktree symlink',
-      );
-      expect(result.stdout).not.toContain('staged Prettier output for a.ts');
-      expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
-    },
-  );
-
-  it.skipIf(process.platform === 'win32')(
-    'skips when a package main target is an untracked symlink to a file (#10602)',
-    () => {
-      stageOptsPackage('main', {
-        'config/opts/index.js': 'module.exports = { semi: true };\n',
-      });
-      // `main` is an untracked symlink to a file holding uncommitted rules.
-      // Node's tryFile follows the link and loads the realpath, so the
-      // lexical candidate must be rejected rather than verified against the
-      // clean package-level index.js fallback.
-      writeFileSync(
-        join(dir, 'config/opts/main-real.js'),
-        'module.exports = { semi: false };\n',
-      );
-      symlinkSync('main-real.js', join(dir, 'config/opts/main'), 'file');
-      writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
-      git(['add', 'a.ts']);
-
-      const result = runFormat();
-
-      expect(result.status, result.stderr).toBe(0);
-      expect(result.stdout).toContain(
-        'config/opts/main resolves through a worktree symlink',
-      );
-      expect(result.stdout).not.toContain('staged Prettier output for a.ts');
-      expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
-    },
-  );
-
-  it.skipIf(process.platform === 'win32')(
-    'falls back to the package index when a package main symlink is broken (#10602)',
-    () => {
-      stageOptsPackage('dist', {
-        'config/opts/index.js': 'module.exports = { semi: true };\n',
-      });
-      // A broken main symlink resolves nowhere: Node's stat-based
-      // LOAD_AS_FILE/LOAD_AS_DIRECTORY both fail, so resolution falls
-      // through to the package-level index.js. Its own path traverses no
-      // symlink and it is tracked and clean, so the hook verifies it and
-      // formats.
-      symlinkSync('no-such-target', join(dir, 'config/opts/dist'), 'dir');
-      writeFileSync(join(dir, 'a.ts'), STAGED);
-      git(['add', 'a.ts']);
-
-      const result = runFormat();
-
-      expect(result.status, result.stderr).toBe(0);
-      expect(result.stdout).toContain('staged Prettier output for a.ts');
-      expect(stagedBlob('a.ts')).toBe(FORMATTED);
-    },
-  );
-
-  it.skipIf(process.platform === 'win32')(
-    'skips when a directory package main symlink escapes the repository (#10602)',
-    () => {
-      const outside = mkdtempSync(join(tmpdir(), 'format-staged-outside-'));
-      try {
-        stageOptsPackage('dist', {
-          'config/opts/index.js': 'module.exports = { semi: true };\n',
-        });
-        // `dist` links to a directory outside the repository. Node loads
-        // `dist/index.js` by realpath; the lexical candidate traverses the
-        // link, so it must be rejected rather than verified against the
-        // clean package-level index.js fallback.
-        writeFileSync(
-          join(outside, 'index.js'),
-          'module.exports = { semi: false };\n',
-        );
-        symlinkSync(outside, join(dir, 'config/opts/dist'), 'dir');
-        writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
-        git(['add', 'a.ts']);
-
-        const result = runFormat();
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stdout).toContain(
-          'config/opts/dist/index.js resolves through a worktree symlink',
-        );
-        expect(result.stdout).not.toContain('staged Prettier output for a.ts');
-        expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
-      } finally {
-        rmSync(outside, { recursive: true, force: true });
-      }
-    },
-  );
-
-  it.skipIf(process.platform === 'win32')(
-    'skips when an indexed package main tree is replaced by a worktree symlink (#10602)',
-    () => {
-      stageOptsPackage('dist', {
-        'config/opts/dist/index.js': 'module.exports = require("./rules");\n',
-        'config/opts/dist/rules.js': 'module.exports = { semi: true };\n',
-        'config/opts/index.js': 'module.exports = { semi: true };\n',
-      });
-      // The tracked dist/ stays in the index, but the worktree dist is
-      // replaced by a symlink to an untracked directory whose index.js is
-      // byte-identical while its ./rules carries uncommitted rules. Node
-      // loads dist/index.js by realpath and resolves ./rules from the link
-      // target, so the lexical staged blob proves nothing about the
-      // dependency context that actually drives Prettier.
-      rmSync(join(dir, 'config/opts/dist'), { recursive: true });
-      mkdirSync(join(dir, 'config/opts/dist-evil'));
-      writeFileSync(
-        join(dir, 'config/opts/dist-evil/index.js'),
-        'module.exports = require("./rules");\n',
-      );
-      writeFileSync(
-        join(dir, 'config/opts/dist-evil/rules.js'),
-        'module.exports = { semi: false };\n',
-      );
-      symlinkSync('dist-evil', join(dir, 'config/opts/dist'), 'dir');
-      writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
-      git(['add', 'a.ts']);
-
-      const result = runFormat();
-
-      expect(result.status, result.stderr).toBe(0);
-      expect(result.stdout).toContain(
-        'config/opts/dist/index.js resolves through a worktree symlink',
-      );
-      expect(result.stdout).not.toContain('staged Prettier output for a.ts');
-      expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
-    },
-  );
 
   it('does not append extensions for an extensionless ESM import (#10502)', () => {
     mkdirSync(join(dir, 'config'));

--- a/src/test-kernel/scripts/FormatStaged.vitest.ts
+++ b/src/test-kernel/scripts/FormatStaged.vitest.ts
@@ -1353,6 +1353,203 @@ describe('format-staged', () => {
     expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
   });
 
+  it.skipIf(process.platform === 'win32')(
+    'skips when a directory package main is an untracked symlink to a directory (#10602)',
+    () => {
+      mkdirSync(join(dir, 'config/opts/dist-target'), { recursive: true });
+      writeFileSync(join(dir, 'config/opts/package.json'), '{"main":"dist"}\n');
+      writeFileSync(
+        join(dir, 'config/opts/dist-target/index.js'),
+        'module.exports = { semi: true };\n',
+      );
+      writeFileSync(
+        join(dir, 'config/opts/index.js'),
+        'module.exports = { semi: true };\n',
+      );
+      writeFileSync(
+        join(dir, 'config/prettier.cjs'),
+        'const opts = require("./opts");\nmodule.exports = opts;\n',
+      );
+      writeFileSync(
+        join(dir, 'package.json'),
+        '{"prettier":"./config/prettier.cjs"}\n',
+      );
+      git([
+        'add',
+        'config/prettier.cjs',
+        'config/opts/package.json',
+        'config/opts/dist-target/index.js',
+        'config/opts/index.js',
+        'package.json',
+      ]);
+      git(['commit', '-qm', 'config base']);
+      // `dist` is an untracked symlink to a directory whose index.js has
+      // uncommitted edits. Node's LOAD_AS_DIRECTORY follows the link (stat)
+      // and loads `dist/index.js`; classifying the link itself (lstat) falls
+      // through to the clean package-level index.js fallback and lets the
+      // uncommitted rules drive Prettier.
+      writeFileSync(
+        join(dir, 'config/opts/dist-target/index.js'),
+        'module.exports = { semi: false };\n',
+      );
+      symlinkSync('dist-target', join(dir, 'config/opts/dist'), 'dir');
+      writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+      git(['add', 'a.ts']);
+
+      const result = runFormat();
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain(
+        'config/opts/dist/index.js is not staged',
+      );
+      expect(result.stdout).not.toContain('staged Prettier output for a.ts');
+      expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'skips when a package main target is an untracked symlink to a file (#10602)',
+    () => {
+      mkdirSync(join(dir, 'config/opts'), { recursive: true });
+      writeFileSync(join(dir, 'config/opts/package.json'), '{"main":"main"}\n');
+      writeFileSync(
+        join(dir, 'config/opts/index.js'),
+        'module.exports = { semi: true };\n',
+      );
+      writeFileSync(
+        join(dir, 'config/prettier.cjs'),
+        'const opts = require("./opts");\nmodule.exports = opts;\n',
+      );
+      writeFileSync(
+        join(dir, 'package.json'),
+        '{"prettier":"./config/prettier.cjs"}\n',
+      );
+      git([
+        'add',
+        'config/prettier.cjs',
+        'config/opts/package.json',
+        'config/opts/index.js',
+        'package.json',
+      ]);
+      git(['commit', '-qm', 'config base']);
+      // `main` is an untracked symlink to a file holding uncommitted rules.
+      // Node's tryFile follows the link (stat) and loads it, so the hook must
+      // admit the link itself as a candidate and skip loudly rather than
+      // verify the clean package-level index.js fallback.
+      writeFileSync(
+        join(dir, 'config/opts/main-real.js'),
+        'module.exports = { semi: false };\n',
+      );
+      symlinkSync('main-real.js', join(dir, 'config/opts/main'), 'file');
+      writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+      git(['add', 'a.ts']);
+
+      const result = runFormat();
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('config/opts/main is not staged');
+      expect(result.stdout).not.toContain('staged Prettier output for a.ts');
+      expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'falls back to the package index when a package main symlink is broken (#10602)',
+    () => {
+      mkdirSync(join(dir, 'config/opts'), { recursive: true });
+      writeFileSync(join(dir, 'config/opts/package.json'), '{"main":"dist"}\n');
+      writeFileSync(
+        join(dir, 'config/opts/index.js'),
+        'module.exports = { semi: true };\n',
+      );
+      writeFileSync(
+        join(dir, 'config/prettier.cjs'),
+        'const opts = require("./opts");\nmodule.exports = opts;\n',
+      );
+      writeFileSync(
+        join(dir, 'package.json'),
+        '{"prettier":"./config/prettier.cjs"}\n',
+      );
+      git([
+        'add',
+        'config/prettier.cjs',
+        'config/opts/package.json',
+        'config/opts/index.js',
+        'package.json',
+      ]);
+      git(['commit', '-qm', 'config base']);
+      // A broken main symlink resolves nowhere: Node's stat-based
+      // LOAD_AS_FILE/LOAD_AS_DIRECTORY both fail, so resolution falls through
+      // to the package-level index.js — which is tracked and clean here, so
+      // the hook verifies that same file and formats.
+      symlinkSync('no-such-target', join(dir, 'config/opts/dist'), 'dir');
+      writeFileSync(join(dir, 'a.ts'), STAGED);
+      git(['add', 'a.ts']);
+
+      const result = runFormat();
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('staged Prettier output for a.ts');
+      expect(stagedBlob('a.ts')).toBe(FORMATTED);
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'skips when a directory package main symlink escapes the repository (#10602)',
+    () => {
+      const outside = mkdtempSync(join(tmpdir(), 'format-staged-outside-'));
+      try {
+        mkdirSync(join(dir, 'config/opts'), { recursive: true });
+        writeFileSync(
+          join(dir, 'config/opts/package.json'),
+          '{"main":"dist"}\n',
+        );
+        writeFileSync(
+          join(dir, 'config/opts/index.js'),
+          'module.exports = { semi: true };\n',
+        );
+        writeFileSync(
+          join(dir, 'config/prettier.cjs'),
+          'const opts = require("./opts");\nmodule.exports = opts;\n',
+        );
+        writeFileSync(
+          join(dir, 'package.json'),
+          '{"prettier":"./config/prettier.cjs"}\n',
+        );
+        git([
+          'add',
+          'config/prettier.cjs',
+          'config/opts/package.json',
+          'config/opts/index.js',
+          'package.json',
+        ]);
+        git(['commit', '-qm', 'config base']);
+        // `dist` links to a directory outside the repository. Node loads
+        // `dist/index.js` through the link; the hook must classify the link
+        // target as a directory and skip loudly on the unstaged candidate
+        // instead of verifying the clean package-level index.js fallback.
+        writeFileSync(
+          join(outside, 'index.js'),
+          'module.exports = { semi: false };\n',
+        );
+        symlinkSync(outside, join(dir, 'config/opts/dist'), 'dir');
+        writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+        git(['add', 'a.ts']);
+
+        const result = runFormat();
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain(
+          'config/opts/dist/index.js is not staged',
+        );
+        expect(result.stdout).not.toContain('staged Prettier output for a.ts');
+        expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
+    },
+  );
+
   it('does not append extensions for an extensionless ESM import (#10502)', () => {
     mkdirSync(join(dir, 'config'));
     writeFileSync(

--- a/src/test-kernel/scripts/FormatStaged.vitest.ts
+++ b/src/test-kernel/scripts/FormatStaged.vitest.ts
@@ -13,7 +13,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { delimiter, join, resolve } from 'node:path';
+import { delimiter, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -104,6 +104,35 @@ function runFormat(env = gitEnv) {
 
 function stagedBlob(path: string): string {
   return git(['show', `:${path}`]);
+}
+
+// Stage and commit a CommonJS `config/opts` package (package.json `main`
+// plus any extra repo-relative `files`) consumed by the fixture config via
+// `require("./opts")`, so each resolver test only spells out the files its
+// own scenario needs.
+function stageOptsPackage(main: string, files: Record<string, string>) {
+  mkdirSync(join(dir, 'config/opts'), { recursive: true });
+  writeFileSync(join(dir, 'config/opts/package.json'), `{"main":"${main}"}\n`);
+  for (const [path, text] of Object.entries(files)) {
+    mkdirSync(dirname(join(dir, path)), { recursive: true });
+    writeFileSync(join(dir, path), text);
+  }
+  writeFileSync(
+    join(dir, 'config/prettier.cjs'),
+    'const opts = require("./opts");\nmodule.exports = opts;\n',
+  );
+  writeFileSync(
+    join(dir, 'package.json'),
+    '{"prettier":"./config/prettier.cjs"}\n',
+  );
+  git([
+    'add',
+    'config/prettier.cjs',
+    'config/opts/package.json',
+    ...Object.keys(files),
+    'package.json',
+  ]);
+  git(['commit', '-qm', 'config base']);
 }
 
 describe('format-staged', () => {
@@ -1356,38 +1385,16 @@ describe('format-staged', () => {
   it.skipIf(process.platform === 'win32')(
     'skips when a directory package main is an untracked symlink to a directory (#10602)',
     () => {
-      mkdirSync(join(dir, 'config/opts/dist-target'), { recursive: true });
-      writeFileSync(join(dir, 'config/opts/package.json'), '{"main":"dist"}\n');
-      writeFileSync(
-        join(dir, 'config/opts/dist-target/index.js'),
-        'module.exports = { semi: true };\n',
-      );
-      writeFileSync(
-        join(dir, 'config/opts/index.js'),
-        'module.exports = { semi: true };\n',
-      );
-      writeFileSync(
-        join(dir, 'config/prettier.cjs'),
-        'const opts = require("./opts");\nmodule.exports = opts;\n',
-      );
-      writeFileSync(
-        join(dir, 'package.json'),
-        '{"prettier":"./config/prettier.cjs"}\n',
-      );
-      git([
-        'add',
-        'config/prettier.cjs',
-        'config/opts/package.json',
-        'config/opts/dist-target/index.js',
-        'config/opts/index.js',
-        'package.json',
-      ]);
-      git(['commit', '-qm', 'config base']);
+      stageOptsPackage('dist', {
+        'config/opts/dist-target/index.js':
+          'module.exports = { semi: true };\n',
+        'config/opts/index.js': 'module.exports = { semi: true };\n',
+      });
       // `dist` is an untracked symlink to a directory whose index.js has
-      // uncommitted edits. Node's LOAD_AS_DIRECTORY follows the link (stat)
-      // and loads `dist/index.js`; classifying the link itself (lstat) falls
-      // through to the clean package-level index.js fallback and lets the
-      // uncommitted rules drive Prettier.
+      // uncommitted edits. Node's LOAD_AS_DIRECTORY follows the link and
+      // loads `dist/index.js` by realpath, so the lexical candidate must be
+      // rejected, not verified against the clean package-level index.js
+      // fallback.
       writeFileSync(
         join(dir, 'config/opts/dist-target/index.js'),
         'module.exports = { semi: false };\n',
@@ -1400,7 +1407,7 @@ describe('format-staged', () => {
 
       expect(result.status, result.stderr).toBe(0);
       expect(result.stdout).toContain(
-        'config/opts/dist/index.js is not staged',
+        'config/opts/dist/index.js resolves through a worktree symlink',
       );
       expect(result.stdout).not.toContain('staged Prettier output for a.ts');
       expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
@@ -1410,32 +1417,13 @@ describe('format-staged', () => {
   it.skipIf(process.platform === 'win32')(
     'skips when a package main target is an untracked symlink to a file (#10602)',
     () => {
-      mkdirSync(join(dir, 'config/opts'), { recursive: true });
-      writeFileSync(join(dir, 'config/opts/package.json'), '{"main":"main"}\n');
-      writeFileSync(
-        join(dir, 'config/opts/index.js'),
-        'module.exports = { semi: true };\n',
-      );
-      writeFileSync(
-        join(dir, 'config/prettier.cjs'),
-        'const opts = require("./opts");\nmodule.exports = opts;\n',
-      );
-      writeFileSync(
-        join(dir, 'package.json'),
-        '{"prettier":"./config/prettier.cjs"}\n',
-      );
-      git([
-        'add',
-        'config/prettier.cjs',
-        'config/opts/package.json',
-        'config/opts/index.js',
-        'package.json',
-      ]);
-      git(['commit', '-qm', 'config base']);
+      stageOptsPackage('main', {
+        'config/opts/index.js': 'module.exports = { semi: true };\n',
+      });
       // `main` is an untracked symlink to a file holding uncommitted rules.
-      // Node's tryFile follows the link (stat) and loads it, so the hook must
-      // admit the link itself as a candidate and skip loudly rather than
-      // verify the clean package-level index.js fallback.
+      // Node's tryFile follows the link and loads the realpath, so the
+      // lexical candidate must be rejected rather than verified against the
+      // clean package-level index.js fallback.
       writeFileSync(
         join(dir, 'config/opts/main-real.js'),
         'module.exports = { semi: false };\n',
@@ -1447,7 +1435,9 @@ describe('format-staged', () => {
       const result = runFormat();
 
       expect(result.status, result.stderr).toBe(0);
-      expect(result.stdout).toContain('config/opts/main is not staged');
+      expect(result.stdout).toContain(
+        'config/opts/main resolves through a worktree symlink',
+      );
       expect(result.stdout).not.toContain('staged Prettier output for a.ts');
       expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
     },
@@ -1456,32 +1446,14 @@ describe('format-staged', () => {
   it.skipIf(process.platform === 'win32')(
     'falls back to the package index when a package main symlink is broken (#10602)',
     () => {
-      mkdirSync(join(dir, 'config/opts'), { recursive: true });
-      writeFileSync(join(dir, 'config/opts/package.json'), '{"main":"dist"}\n');
-      writeFileSync(
-        join(dir, 'config/opts/index.js'),
-        'module.exports = { semi: true };\n',
-      );
-      writeFileSync(
-        join(dir, 'config/prettier.cjs'),
-        'const opts = require("./opts");\nmodule.exports = opts;\n',
-      );
-      writeFileSync(
-        join(dir, 'package.json'),
-        '{"prettier":"./config/prettier.cjs"}\n',
-      );
-      git([
-        'add',
-        'config/prettier.cjs',
-        'config/opts/package.json',
-        'config/opts/index.js',
-        'package.json',
-      ]);
-      git(['commit', '-qm', 'config base']);
+      stageOptsPackage('dist', {
+        'config/opts/index.js': 'module.exports = { semi: true };\n',
+      });
       // A broken main symlink resolves nowhere: Node's stat-based
-      // LOAD_AS_FILE/LOAD_AS_DIRECTORY both fail, so resolution falls through
-      // to the package-level index.js — which is tracked and clean here, so
-      // the hook verifies that same file and formats.
+      // LOAD_AS_FILE/LOAD_AS_DIRECTORY both fail, so resolution falls
+      // through to the package-level index.js. Its own path traverses no
+      // symlink and it is tracked and clean, so the hook verifies it and
+      // formats.
       symlinkSync('no-such-target', join(dir, 'config/opts/dist'), 'dir');
       writeFileSync(join(dir, 'a.ts'), STAGED);
       git(['add', 'a.ts']);
@@ -1499,35 +1471,13 @@ describe('format-staged', () => {
     () => {
       const outside = mkdtempSync(join(tmpdir(), 'format-staged-outside-'));
       try {
-        mkdirSync(join(dir, 'config/opts'), { recursive: true });
-        writeFileSync(
-          join(dir, 'config/opts/package.json'),
-          '{"main":"dist"}\n',
-        );
-        writeFileSync(
-          join(dir, 'config/opts/index.js'),
-          'module.exports = { semi: true };\n',
-        );
-        writeFileSync(
-          join(dir, 'config/prettier.cjs'),
-          'const opts = require("./opts");\nmodule.exports = opts;\n',
-        );
-        writeFileSync(
-          join(dir, 'package.json'),
-          '{"prettier":"./config/prettier.cjs"}\n',
-        );
-        git([
-          'add',
-          'config/prettier.cjs',
-          'config/opts/package.json',
-          'config/opts/index.js',
-          'package.json',
-        ]);
-        git(['commit', '-qm', 'config base']);
+        stageOptsPackage('dist', {
+          'config/opts/index.js': 'module.exports = { semi: true };\n',
+        });
         // `dist` links to a directory outside the repository. Node loads
-        // `dist/index.js` through the link; the hook must classify the link
-        // target as a directory and skip loudly on the unstaged candidate
-        // instead of verifying the clean package-level index.js fallback.
+        // `dist/index.js` by realpath; the lexical candidate traverses the
+        // link, so it must be rejected rather than verified against the
+        // clean package-level index.js fallback.
         writeFileSync(
           join(outside, 'index.js'),
           'module.exports = { semi: false };\n',
@@ -1540,13 +1490,52 @@ describe('format-staged', () => {
 
         expect(result.status, result.stderr).toBe(0);
         expect(result.stdout).toContain(
-          'config/opts/dist/index.js is not staged',
+          'config/opts/dist/index.js resolves through a worktree symlink',
         );
         expect(result.stdout).not.toContain('staged Prettier output for a.ts');
         expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
       } finally {
         rmSync(outside, { recursive: true, force: true });
       }
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'skips when an indexed package main tree is replaced by a worktree symlink (#10602)',
+    () => {
+      stageOptsPackage('dist', {
+        'config/opts/dist/index.js': 'module.exports = require("./rules");\n',
+        'config/opts/dist/rules.js': 'module.exports = { semi: true };\n',
+        'config/opts/index.js': 'module.exports = { semi: true };\n',
+      });
+      // The tracked dist/ stays in the index, but the worktree dist is
+      // replaced by a symlink to an untracked directory whose index.js is
+      // byte-identical while its ./rules carries uncommitted rules. Node
+      // loads dist/index.js by realpath and resolves ./rules from the link
+      // target, so the lexical staged blob proves nothing about the
+      // dependency context that actually drives Prettier.
+      rmSync(join(dir, 'config/opts/dist'), { recursive: true });
+      mkdirSync(join(dir, 'config/opts/dist-evil'));
+      writeFileSync(
+        join(dir, 'config/opts/dist-evil/index.js'),
+        'module.exports = require("./rules");\n',
+      );
+      writeFileSync(
+        join(dir, 'config/opts/dist-evil/rules.js'),
+        'module.exports = { semi: false };\n',
+      );
+      symlinkSync('dist-evil', join(dir, 'config/opts/dist'), 'dir');
+      writeFileSync(join(dir, 'a.ts'), 'export const x = 1;\n');
+      git(['add', 'a.ts']);
+
+      const result = runFormat();
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain(
+        'config/opts/dist/index.js resolves through a worktree symlink',
+      );
+      expect(result.stdout).not.toContain('staged Prettier output for a.ts');
+      expect(stagedBlob('a.ts')).toBe('export const x = 1;\n');
     },
   );
 


### PR DESCRIPTION
Closes #10602

## Summary

Follow-up to #10599. `resolveConfigDepPath` classified a CommonJS package `main` target with `lstatSync`, which reports the link itself, while Node's CommonJS loader (`tryFile`/`tryExtensions`/`LOAD_AS_DIRECTORY`) classifies with `stat` and follows links. With `"main": "dist"` and `dist` an untracked symlink to a directory, the target was never seen as a directory, its `index.*` candidates were never pushed, and the hook verified the clean package-level `index.*` fallback instead — a file Node never loads — so Prettier resolved through the link and uncommitted rules in the symlinked target could still drive staged formatting: the #10591 provenance leak in symlinked-directory-main form.

This PR is production-only (`scripts/format-staged.mjs`); regression coverage was verified locally with scratch fixtures and is not landed, per maintainer direction. Three resolver corrections, all matching Node's loader semantics:

1. **Classification follows symlinks (stat, not lstat) at both sites.** The dependency directory and the package-main target are classified with `statSync`, so a symlinked-directory main resolves to its `index.*` candidates and a symlinked-file main is admitted as a file candidate — exactly what Node's `LOAD_AS_FILE`/`LOAD_AS_DIRECTORY` would load.
2. **Symlink-traversing dependencies fail loudly instead of verifying.** Node loads a module by realpath and resolves that module's own relative dependencies from the real directory, so an index blob at a lexical path passing through a worktree symlink proves nothing about the dependency context Node actually sees. `verifyConfigDep` rejects any resolved dependency whose repo-rooted path traverses a worktree symlink (an `lstatSync` walk over each component from the repository root down, inlined at the guard) with a loud "resolves through a worktree symlink" skip. This covers the untracked-symlink report and the indexed-descendant case where a tracked `dist/index.js` remains in the index while worktree `dist` is replaced by a symlink carrying byte-identical top-level text (e.g. `module.exports = require('./rules')`) but uncommitted `./rules`.
3. **LOAD_AS_FILE precedence.** Node applies `LOAD_AS_DIRECTORY` only when `LOAD_AS_FILE` produced no file candidate; the resolver now runs the directory block (package `main`, package-level `index.*`) only when no file candidate was admitted, so an irrelevant directory beside a winning file — for example a tracked `opts.js` next to an `opts` symlink to a directory with an untracked `package.json` — no longer trips `readPackageMain`'s manifest provenance skip for a file Node never reads.
4. **Failed stat probes are misses, matching Node.** `statSync` with `throwIfNoEntry: false` still throws ELOOP/ENOTDIR/EACCES; Node's loader treats a failed probe as a non-match and continues to the next candidate. All classification probes now go through a `statProbe` helper that returns undefined on any filesystem error, so a self-referential symlink at an extensionless dependency's exact path no longer aborts resolution before a valid tracked `base.js` is probed (and the same holds for a loop at the main target, where Node falls back to the package `index.*`). The symlink-traversal guard is unchanged: a symlinked path that actually wins is still rejected loudly, and the guard's component walk treats an unstatable component as non-resolving so the existence checks emit the loud skip rather than a raw probe error.

The policy is stricter-only: classification always follows links exactly like Node, anything reached through a link fails loudly rather than verifying, and the directory inspection happens only when Node would perform it. Containment stays lexical, `readPackageMain`'s index-only manifest provenance is unchanged, the `kind === 'cjs'` loader-kind gate and fallback order are unchanged, and `mergeWorktree`'s deliberate `lstatSync` (symlink-replacement write guard) is untouched. A broken main symlink still resolves nowhere — exactly like Node — so resolution falls through to the package-level `index.*` fallback, which verifies normally when tracked and clean.

## Issue acceptance gates (verified locally with scratch fixtures, not landed)

- `"main": "dist"` with `dist` an untracked symlink to a directory whose `index.js` has uncommitted edits: skips loudly (`config/opts/dist/index.js resolves through a worktree symlink`), staged blob untouched.
- `"main": "main"` with `main` an untracked symlink to a file: skips loudly the same way instead of verifying the clean package-level fallback.
- `dist` symlink escaping the repository: skips loudly. Broken `dist` symlink: falls back to the package-level `index.*` exactly like Node and formats when that fallback is tracked and clean.
- Tracked `dist/index.js` in the index while worktree `dist` is replaced by a symlink with identical top-level text but uncommitted `./rules`: skips loudly rather than trusting the indexed descendant.
- Tracked `opts.js` beside an `opts` symlink to a directory with an untracked `package.json`: formats via `opts.js`; the irrelevant directory is never inspected.
- Self-referential `opts` symlink beside a tracked `opts.js`: formats via `opts.js` (pre-fix the ELOOP aborted resolution and the outer catch skipped formatting). Loop at a `dist` main target with a clean tracked package `index.js`: formats via the fallback, matching Node's own behavior (Node emits DEP0128 and loads `index.js`).

## Single source of truth

`resolveConfigDepPath` in `scripts/format-staged.mjs` remains the single resolver for relative config dependencies; the two classification call sites, the LOAD_AS_FILE precedence gate, and the symlink-traversal guard in `verifyConfigDep` are the only logic touched.

## Duplication and abstraction budget

One new file-local helper (`statProbe` for probe-failure tolerance, three call sites); the symlink-traversal walk is inlined at its single guard site in `verifyConfigDep` per the repository's extract-only-when-repeated rule. No resolution paths duplicated.

## Net elements (R6)

n/a — this is a `fix:` change, not a refactor/simplify/consolidate/dedupe/extract PR.

## Consumer counts (R8)

n/a — no export, emit path, or subscriber is deleted or re-routed.

## Host impact

Extension: n/a
Desktop: n/a
CLI: n/a
(Change is confined to the `scripts/format-staged.mjs` git hook.)

## Scheduled refactoring

None.

## Validation

- Existing suite, unmodified: `npx vitest run --config vitest.config.mjs src/test-kernel/scripts/FormatStaged.vitest.ts --testTimeout=60000 --hookTimeout=60000` → 62/62 passed on the production-only head.
- Scratch fixtures for the probe-failure morphologies (executed against a scratch git repo, removed after): ELOOP at the exact base path with a valid tracked `base.js` skipped pre-fix (`skipping a.ts: ELOOP`) and formats post-fix; ELOOP at the main target with a clean tracked package `index.js` skips pre-fix and formats via the fallback post-fix (behavior identical to Node, DEP0128 included); the untracked symlinked-directory-main fixture still skips loudly with `resolves through a worktree symlink`; the broken-main-symlink fixture still formats via the package index.
- Local reproduction with scratch fixtures (specs written, executed, and removed uncommitted per maintainer direction): each leak morphology reproduced against the pre-fix code — the directory-symlink, file-symlink, and escaping-symlink fixtures formatted via the clean fallback on the pre-PR script; the indexed-descendant fixture formatted through the link on this branch's first commit; the precedence fixture skipped on the untracked manifest on the second commit. With the final production code all six fixtures behaved correctly (four loud skips with staged blobs untouched, broken-symlink fallback formats, file-candidate precedence formats), and the full suite with the scratch specs present passed 68/68.
- `npm run typecheck` → passed (exit 0)
- `node --max-old-space-size=6144 ./node_modules/eslint/bin/eslint.js src/test-kernel/scripts/FormatStaged.vitest.ts` → passed (file now unmodified from main)
- `npx prettier --check scripts/format-staged.mjs` → passed
- `node scripts/check-dead-code-ratchet.mjs` → passed (8 current = 8 baselined)
- `git diff --check` → clean
