### PR TITLE
refactor(lean): freeze the exported vscodeLeanLanguageServices adapter object

### DIFF
--- a/packages/extension/src/frontend/lean/VscodeIntegration.ts
+++ b/packages/extension/src/frontend/lean/VscodeIntegration.ts
@@ -417,8 +417,10 @@ async function executeProjectCommand(
  * `extension.ts` via `setLeanLanguageServices`. The single exported surface
  * of this module's language operations: the implementing functions above are
  * module-private so the export list states exactly what the host consumes.
+ * Frozen because the object is a shared module-level singleton handed across
+ * a package boundary — no consumer may reassign a member.
  */
-export const vscodeLeanLanguageServices: LeanLanguageServices = {
+export const vscodeLeanLanguageServices = Object.freeze({
   executeFileCommand,
   getGoalState,
   getTermGoal,
@@ -426,4 +428,4 @@ export const vscodeLeanLanguageServices: LeanLanguageServices = {
   fetchDiagnosticsForFile,
   navigateToFirstError,
   executeProjectCommand,
-};
+} satisfies LeanLanguageServices);

--- a/src/test-kernel/frontend/VscodeIntegration.vitest.ts
+++ b/src/test-kernel/frontend/VscodeIntegration.vitest.ts
@@ -15,7 +15,7 @@ const EXPECTED_MEMBERS = [
 describe('vscodeLeanLanguageServices', () => {
   it('exposes exactly the LeanLanguageServices operations as functions', () => {
     expect(Object.keys(vscodeLeanLanguageServices).sort()).toEqual(
-      [...EXPECTED_MEMBERS].sort(),
+      EXPECTED_MEMBERS.toSorted(),
     );
     for (const member of EXPECTED_MEMBERS) {
       expect(typeof vscodeLeanLanguageServices[member]).toBe('function');

--- a/src/test-kernel/frontend/VscodeIntegration.vitest.ts
+++ b/src/test-kernel/frontend/VscodeIntegration.vitest.ts
@@ -2,26 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { vscodeLeanLanguageServices } from '@frontend/lean/VscodeIntegration';
 
-const EXPECTED_MEMBERS = [
-  'executeFileCommand',
-  'getGoalState',
-  'getTermGoal',
-  'getHoverInfo',
-  'fetchDiagnosticsForFile',
-  'navigateToFirstError',
-  'executeProjectCommand',
-] as const;
-
 describe('vscodeLeanLanguageServices', () => {
-  it('exposes exactly the LeanLanguageServices operations as functions', () => {
-    expect(Object.keys(vscodeLeanLanguageServices).sort()).toEqual(
-      EXPECTED_MEMBERS.toSorted(),
-    );
-    for (const member of EXPECTED_MEMBERS) {
-      expect(typeof vscodeLeanLanguageServices[member]).toBe('function');
-    }
-  });
-
   it('is frozen so no consumer can reassign a member', () => {
     expect(Object.isFrozen(vscodeLeanLanguageServices)).toBe(true);
     const original = vscodeLeanLanguageServices.getGoalState;

--- a/src/test-kernel/frontend/VscodeIntegration.vitest.ts
+++ b/src/test-kernel/frontend/VscodeIntegration.vitest.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { vscodeLeanLanguageServices } from '@frontend/lean/VscodeIntegration';
+
+const EXPECTED_MEMBERS = [
+  'executeFileCommand',
+  'getGoalState',
+  'getTermGoal',
+  'getHoverInfo',
+  'fetchDiagnosticsForFile',
+  'navigateToFirstError',
+  'executeProjectCommand',
+] as const;
+
+describe('vscodeLeanLanguageServices', () => {
+  it('exposes exactly the LeanLanguageServices operations as functions', () => {
+    expect(Object.keys(vscodeLeanLanguageServices).sort()).toEqual(
+      [...EXPECTED_MEMBERS].sort(),
+    );
+    for (const member of EXPECTED_MEMBERS) {
+      expect(typeof vscodeLeanLanguageServices[member]).toBe('function');
+    }
+  });
+
+  it('is frozen so no consumer can reassign a member', () => {
+    expect(Object.isFrozen(vscodeLeanLanguageServices)).toBe(true);
+    const original = vscodeLeanLanguageServices.getGoalState;
+    expect(() => {
+      Object.assign(vscodeLeanLanguageServices, {
+        getGoalState: async () => undefined,
+      });
+    }).toThrow(TypeError);
+    expect(vscodeLeanLanguageServices.getGoalState).toBe(original);
+  });
+});


### PR DESCRIPTION
## Summary

- Freeze the exported `vscodeLeanLanguageServices` adapter in `packages/extension/src/frontend/lean/VscodeIntegration.ts` as `Object.freeze({ ... } satisfies LeanLanguageServices)`, so no consumer of the cross-boundary singleton can reassign a member (shared-mutable-literal rule, review checklist §16). Same pattern as `GROK_SUBSCRIPTION_PROVIDER` in `subscriptionHandlers.ts`.
- Behavior-preserving: the implementing functions, the object shape, and the `setLeanLanguageServices(vscodeLeanLanguageServices)` wiring in `extension.ts` are unchanged.
- Add a focused behavioral test (`src/test-kernel/frontend/VscodeIntegration.vitest.ts`) pinning the frozen identity: member reassignment throws and leaves the member intact. No member-list test — the compile-time `satisfies LeanLanguageServices` already pins the member contract.

## Testing

- `vitest run src/test-kernel/frontend/VscodeIntegration.vitest.ts` — 1/1 pass (new)
- `vitest run src/test-kernel/tools/lean/ src/test-kernel/frontend/` — 22 files, 139 tests pass
- `vitest run src/test-kernel/architecture/` — 17 files, 102 tests pass
- `npm run typecheck` (workspace, test-kernel, agent, cli, trace-viewer, desktop) — clean
- `npm run lint` — clean; `prettier --check` on changed files — clean
- `check:dead-code-ratchet`, `check:browser-safe-utils`, `check:guidance-refs` — OK

Closes #10637
