### PR TITLE
fix(retry): pair the Kimi Code routing flag with the live retry model (#10606, #10607)

### DIFF
--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -209,9 +209,7 @@ export class ModelInvocationNode<
    * the failed model's registry config and swap it in (the mid-run replacement
    * the model switcher also uses); the next attempt then builds its client
    * against the Moonshot fallback. Both the rebuild probe and the swap id come
-   * from the `failedModel` pair captured when the panel opened, so the
-   * replacement still describes the handler that failed even if the panel
-   * outlived a mid-run `switchModel`.
+   * from the `failedModel` pair captured when the panel opened.
    */
   private async prepareRetryForCredentialSelection(
     selection: ModelCredentialSelection,
@@ -228,6 +226,18 @@ export class ModelInvocationNode<
       failedModel.modelId,
       this.services.runScope.session.responseTextProcessing,
     );
+    // A model switch is allowed while the retry panel waits, and the fallback
+    // build above is async: if the cell no longer holds the captured pair,
+    // swapping would silently undo the user's newer switch. Dispose the
+    // stale fallback and prepare the handler that is actually live instead.
+    if (
+      modelCell.handler.config !== failedModel.config ||
+      modelCell.modelId !== failedModel.modelId
+    ) {
+      fallback?.dispose();
+      await modelCell.rebind(selection, signal);
+      return;
+    }
     if (!fallback) {
       await modelCell.rebind(selection, signal);
       return;

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -32,6 +32,7 @@ import {
   type ModelRouteVerdict,
 } from '@common/errors/sdkError/providerErrorFormat';
 import { includedModelAccess } from '@model/includedModelAccess';
+import type { ResolvedModelConfig } from '@model/openRouterRouting';
 import type { ToolDefinition } from '@model/ToolDefinition';
 import {
   DEFAULT_CORE_SETTINGS,
@@ -78,6 +79,13 @@ interface ManualRetryPromptResult {
   userCancelled: boolean;
   clientPrepared?: boolean;
   retrySource?: RetryAttemptSource;
+}
+
+/** The failed handler's effective config and model id, captured from the
+ *  live cell as one pair when the retry panel opens. */
+interface FailedModelIdentity {
+  readonly config: ResolvedModelConfig;
+  readonly modelId: string;
 }
 
 type RetryAttemptSource = 'automatic' | 'human';
@@ -198,13 +206,17 @@ export class ModelInvocationNode<
    * config pins the coding `baseUrl` and wire id, so a rebind would resolve the
    * same exhausted Kimi Code credential again. For a 'personal' selection the
    * host has already disabled the plan preference, so rebuild the handler from
-   * the registry config and swap it in (the mid-run replacement the model
-   * switcher also uses); the next attempt then builds its client against the
-   * Moonshot fallback.
+   * the failed model's registry config and swap it in (the mid-run replacement
+   * the model switcher also uses); the next attempt then builds its client
+   * against the Moonshot fallback. Both the rebuild probe and the swap id come
+   * from the `failedModel` pair captured when the panel opened, so the
+   * replacement still describes the handler that failed even if the panel
+   * outlived a mid-run `switchModel`.
    */
   private async prepareRetryForCredentialSelection(
     selection: ModelCredentialSelection,
     signal: AbortSignal | undefined,
+    failedModel: FailedModelIdentity,
   ): Promise<void> {
     const { modelCell } = this.services;
     if (selection !== 'personal') {
@@ -212,8 +224,8 @@ export class ModelInvocationNode<
       return;
     }
     const fallback = await createKimiCodeFallbackHandler(
-      modelCell.handler.config,
-      this.services.config.model,
+      failedModel.config,
+      failedModel.modelId,
       this.services.runScope.session.responseTextProcessing,
     );
     if (!fallback) {
@@ -228,7 +240,7 @@ export class ModelInvocationNode<
       fallback.dispose();
       throw error;
     }
-    modelCell.swap(fallback, this.services.config.model);
+    modelCell.swap(fallback, failedModel.modelId);
   }
 
   /** Emit compact diagnostic data for durable, non-presentational recording. */
@@ -528,27 +540,41 @@ export class ModelInvocationNode<
     });
     // No timeout: the retry panel waits indefinitely for the user's decision.
     let clientPrepared = false;
+    // The failed handler's config and model id, captured as one pair from
+    // the live cell: the cell keeps handler and id coherent, while
+    // `services.config.model` is the immutable launch config a mid-run
+    // `switchModel` leaves stale. The request below — and a fallback rebuild
+    // if the user accepts with personal credentials — must describe the
+    // handler that actually failed, so all of them read this pair.
+    const failedModel: FailedModelIdentity = {
+      config: this.services.modelCell.handler.config,
+      modelId: this.services.modelCell.modelId,
+    };
     // Capture the failed handler's effective route before the retry panel can
     // be outlived by routing-preference changes. A dual-backend Kimi handler
     // dispatched onto the coding endpoint carries the pinned Kimi Code
     // `baseUrl`, so the shared field predicate is true for that runtime config
     // even though the registry entry itself is not coding-exclusive.
     const kimiCodeRoutedOnFailure = isKimiCodeExclusiveModel(
-      this.services.modelCell.handler.config,
+      failedModel.config,
     );
     const interaction = session.interactions.requestRetry(
       {
         requestId: `retry-${generateShortId()}`,
         streamId,
         operation: operationName,
-        model: this.services.config.model,
+        model: failedModel.modelId,
         errorMessage: formatted.message,
         errorDetails: formatted,
         kimiCodeRoutedOnFailure,
       },
       {
         prepareRetry: async (selection, signal) => {
-          await this.prepareRetryForCredentialSelection(selection, signal);
+          await this.prepareRetryForCredentialSelection(
+            selection,
+            signal,
+            failedModel,
+          );
           clientPrepared = true;
         },
       },

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -263,9 +263,10 @@ export class ProgressApiKeyRetryController {
     request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
     before: ProgressApiRoutingSnapshot,
   ): Promise<ProgressApiKeyPreparationResult> {
-    // Each switch is recorded right after its setter lands, so a setter that
-    // throws midway rolls back exactly the prefix that succeeded instead of
-    // stranding global toggles the retry will never use.
+    // Each attempted switch is registered for compensation before its setter
+    // is awaited: a setter can mutate in memory and then reject on
+    // persistence, so a throw midway must roll back every switch that may
+    // have landed instead of stranding global toggles the retry never uses.
     let disabledIncludedModelAccess = false;
     let disabledChatGptSubscription = false;
     const disabledCodingPlans: ExhaustionReason[] = [];
@@ -276,8 +277,8 @@ export class ProgressApiKeyRetryController {
       // which otherwise may still prefer included access over the stored key.
       // A direct-key failure leaves relay untouched for other providers.
       if (this.shouldDisableIncludedModelAccess(request)) {
-        await this.deps.setUseIncludedModelAccess(false);
         disabledIncludedModelAccess = true;
+        await this.deps.setUseIncludedModelAccess(false);
         this.deps.invalidateModelOptionsCache();
       }
 
@@ -289,8 +290,8 @@ export class ProgressApiKeyRetryController {
         this.deps.getPreferChatGptSubscription() &&
         this.isSubscriptionExhausted(request)
       ) {
-        await this.deps.setPreferChatGptSubscription(false);
         disabledChatGptSubscription = true;
+        await this.deps.setPreferChatGptSubscription(false);
         this.deps.invalidateModelOptionsCache();
       }
 
@@ -321,8 +322,8 @@ export class ProgressApiKeyRetryController {
           request.kimiCodeRoutedOnFailure === true &&
           this.isDualBackendKimiCodeModel(request.model);
         if (toggle.getEnabled() && (planExhaustion || kimiCodeCreditReroute)) {
-          await toggle.setEnabled(false);
           disabledCodingPlans.push(toggle.exhaustionReason);
+          await toggle.setEnabled(false);
           this.deps.invalidateModelOptionsCache();
         }
       }
@@ -427,8 +428,18 @@ export class ProgressApiKeyRetryController {
         firstFailure ??= error;
       }
     }
+    // Invalidate whenever a rollback was scheduled, even after a restore
+    // failure: a setter that mutated in memory before rejecting leaves the
+    // cached options describing the wrong routing. A failed invalidation
+    // must not replace the restore failure the caller can act on.
+    if (restores.length > 0) {
+      try {
+        this.deps.invalidateModelOptionsCache();
+      } catch (error) {
+        firstFailure ??= error;
+      }
+    }
     if (firstFailure !== undefined) throw firstFailure;
-    if (restores.length > 0) this.deps.invalidateModelOptionsCache();
   }
 
   /**

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -177,11 +177,17 @@ export class ProgressApiKeyRetryController {
         return noRetryResult();
       }
       const routingBefore = this.routingSnapshot();
-      const prepared = await this.applyOwnApiKeyRouting(request);
-      const retried = await this.deps.triggerRetry(
-        request.stream,
-        request.requestId,
-      );
+      const prepared = await this.applyOwnApiKeyRouting(request, routingBefore);
+      let retried = false;
+      try {
+        retried = await this.deps.triggerRetry(
+          request.stream,
+          request.requestId,
+        );
+      } catch (error) {
+        await this.restoreAfterError(routingBefore, prepared);
+        throw error;
+      }
       if (!retried) {
         await this.restoreOwnApiKeyRouting(routingBefore, prepared);
         return noRetryResult();
@@ -255,73 +261,87 @@ export class ProgressApiKeyRetryController {
 
   private async applyOwnApiKeyRouting(
     request: Omit<ProgressApiKeyRetryRequest, 'stream' | 'requestId'>,
+    before: ProgressApiRoutingSnapshot,
   ): Promise<ProgressApiKeyPreparationResult> {
-    // Disable relay (included access) so the retry uses the user's own key,
-    // not the relay JWT, whenever the switch promises "your own API key".
-    // Both relay and subscription exhaustion fall through to a direct handler,
-    // which otherwise may still prefer included access over the stored key.
-    // A direct-key failure leaves relay untouched for other providers.
+    // Each switch is recorded right after its setter lands, so a setter that
+    // throws midway rolls back exactly the prefix that succeeded instead of
+    // stranding global toggles the retry will never use.
     let disabledIncludedModelAccess = false;
-    if (this.shouldDisableIncludedModelAccess(request)) {
-      await this.deps.setUseIncludedModelAccess(false);
-      this.deps.invalidateModelOptionsCache();
-      disabledIncludedModelAccess = true;
-    }
-
-    // The subscription quota is exhausted, so turn off the preference and let
-    // Codex-eligible models route through the now-usable OpenAI key on retry.
-    // Remark: prefer-off sticks after the quota resets — users may forget to
-    // re-enable it. A temporary / resume-on-reset override would be kinder.
     let disabledChatGptSubscription = false;
-    if (
-      this.deps.getPreferChatGptSubscription() &&
-      this.isSubscriptionExhausted(request)
-    ) {
-      await this.deps.setPreferChatGptSubscription(false);
-      this.deps.invalidateModelOptionsCache();
-      disabledChatGptSubscription = true;
-    }
-
-    // Any API-key-based coding-plan subscription (GLM Coding Plan, Kimi Code)
-    // whose quota is exhausted: turn off its toggle so requests re-route through
-    // the regular pay-as-you-go endpoint on retry.
     const disabledCodingPlans: ExhaustionReason[] = [];
-    for (const toggle of this.codingPlanToggles) {
-      const planExhaustion =
-        request.exhaustionReason === toggle.exhaustionReason;
-      // An `upstream-credit` failure on a dual-backend Kimi model means the
-      // broken credential is the `kimiCode` key, but the forwarded SDK
-      // provider is `moonshot`. The coding-plan quota reason does not match,
-      // so without this branch the "Prefer Kimi Code" switch would stay on
-      // and the retry rebuild would re-select the exhausted coding endpoint
-      // instead of the newly entered Moonshot key.
-      //
-      // Deliberately conservative: do not consult the live route resolver
-      // here. The failed handler was dispatched under the persisted
-      // `ModelHandlerKimi` compatibility key, and the retry rebuild pins that
-      // same key, so a later OpenRouter preference change cannot make the
-      // rebuild take a non-coding route. The request's
-      // `kimiCodeRoutedOnFailure` flag is captured from that failed handler,
-      // so unrelated `kimi3` failures through OpenRouter, Moonshot, or the
-      // relay leave the preference untouched.
-      const kimiCodeCreditReroute =
-        toggle.exhaustionReason === 'kimi-code-subscription' &&
-        request.exhaustionReason === 'upstream-credit' &&
-        request.kimiCodeRoutedOnFailure === true &&
-        this.isDualBackendKimiCodeModel(request.model);
-      if (toggle.getEnabled() && (planExhaustion || kimiCodeCreditReroute)) {
-        await toggle.setEnabled(false);
+    try {
+      // Disable relay (included access) so the retry uses the user's own key,
+      // not the relay JWT, whenever the switch promises "your own API key".
+      // Both relay and subscription exhaustion fall through to a direct handler,
+      // which otherwise may still prefer included access over the stored key.
+      // A direct-key failure leaves relay untouched for other providers.
+      if (this.shouldDisableIncludedModelAccess(request)) {
+        await this.deps.setUseIncludedModelAccess(false);
+        disabledIncludedModelAccess = true;
         this.deps.invalidateModelOptionsCache();
-        disabledCodingPlans.push(toggle.exhaustionReason);
       }
-    }
 
-    return {
-      proceeded: true,
-      disabledIncludedModelAccess,
-      disabledChatGptSubscription,
-      disabledCodingPlans,
-    };
+      // The subscription quota is exhausted, so turn off the preference and let
+      // Codex-eligible models route through the now-usable OpenAI key on retry.
+      // Remark: prefer-off sticks after the quota resets — users may forget to
+      // re-enable it. A temporary / resume-on-reset override would be kinder.
+      if (
+        this.deps.getPreferChatGptSubscription() &&
+        this.isSubscriptionExhausted(request)
+      ) {
+        await this.deps.setPreferChatGptSubscription(false);
+        disabledChatGptSubscription = true;
+        this.deps.invalidateModelOptionsCache();
+      }
+
+      // Any API-key-based coding-plan subscription (GLM Coding Plan, Kimi Code)
+      // whose quota is exhausted: turn off its toggle so requests re-route through
+      // the regular pay-as-you-go endpoint on retry.
+      for (const toggle of this.codingPlanToggles) {
+        const planExhaustion =
+          request.exhaustionReason === toggle.exhaustionReason;
+        // An `upstream-credit` failure on a dual-backend Kimi model means the
+        // broken credential is the `kimiCode` key, but the forwarded SDK
+        // provider is `moonshot`. The coding-plan quota reason does not match,
+        // so without this branch the "Prefer Kimi Code" switch would stay on
+        // and the retry rebuild would re-select the exhausted coding endpoint
+        // instead of the newly entered Moonshot key.
+        //
+        // Deliberately conservative: do not consult the live route resolver
+        // here. The failed handler was dispatched under the persisted
+        // `ModelHandlerKimi` compatibility key, and the retry rebuild pins that
+        // same key, so a later OpenRouter preference change cannot make the
+        // rebuild take a non-coding route. The request's
+        // `kimiCodeRoutedOnFailure` flag is captured from that failed handler,
+        // so unrelated `kimi3` failures through OpenRouter, Moonshot, or the
+        // relay leave the preference untouched.
+        const kimiCodeCreditReroute =
+          toggle.exhaustionReason === 'kimi-code-subscription' &&
+          request.exhaustionReason === 'upstream-credit' &&
+          request.kimiCodeRoutedOnFailure === true &&
+          this.isDualBackendKimiCodeModel(request.model);
+        if (toggle.getEnabled() && (planExhaustion || kimiCodeCreditReroute)) {
+          await toggle.setEnabled(false);
+          disabledCodingPlans.push(toggle.exhaustionReason);
+          this.deps.invalidateModelOptionsCache();
+        }
+      }
+
+      return {
+        proceeded: true,
+        disabledIncludedModelAccess,
+        disabledChatGptSubscription,
+        disabledCodingPlans,
+      };
+    } catch (error) {
+      await this.restoreAfterError(before, {
+        proceeded: true,
+        disabledIncludedModelAccess,
+        disabledChatGptSubscription,
+        disabledCodingPlans,
+      });
+      throw error;
+    }
   }
 
   /** Apply Copilot fallback routing only for the duration of a launch attempt. */
@@ -338,17 +358,19 @@ export class ProgressApiKeyRetryController {
         return false;
       }
       const before = this.routingSnapshot();
-      const prepared = await this.applyOwnApiKeyRouting(request);
+      const prepared = await this.applyOwnApiKeyRouting(request, before);
       // The user chose "use own API key" for this retry. The direct-route
       // override travels only with the replacement launch; the standing
       // preference remains visible to concurrent and future runs.
       let started = false;
       try {
         started = await start('direct');
-        return started;
-      } finally {
-        if (!started) await this.restoreOwnApiKeyRouting(before, prepared);
+      } catch (error) {
+        await this.restoreAfterError(before, prepared);
+        throw error;
       }
+      if (!started) await this.restoreOwnApiKeyRouting(before, prepared);
+      return started;
     });
   }
 
@@ -369,32 +391,57 @@ export class ProgressApiKeyRetryController {
     before: ProgressApiRoutingSnapshot,
     prepared: ProgressApiKeyPreparationResult,
   ): Promise<void> {
-    const restores: Promise<void>[] = [];
-    if (prepared.disabledIncludedModelAccess) {
-      restores.push(
-        this.deps.setUseIncludedModelAccess(before.useIncludedModelAccess),
-      );
-    }
-    if (prepared.disabledChatGptSubscription) {
-      restores.push(
-        this.deps.setPreferChatGptSubscription(
-          before.preferChatGptSubscription,
-        ),
-      );
-    }
-    for (const reason of prepared.disabledCodingPlans) {
+    // Roll back in reverse application order: the coding-plan toggles
+    // switched last, so they come back first. Every restore is attempted
+    // even when an earlier one fails; the first failure rethrows once the
+    // rest have run (compensation per the error-handling checklist's L2).
+    const restores: Array<() => Promise<void>> = [];
+    for (const reason of [...prepared.disabledCodingPlans].reverse()) {
       const toggle = this.codingPlanToggles.find(
         (candidate) => candidate.exhaustionReason === reason,
       );
       if (toggle)
-        restores.push(
+        restores.push(() =>
           (toggle.restoreEnabled ?? toggle.setEnabled)(
             before.codingPlans.get(reason) ?? false,
           ),
         );
     }
-    await Promise.all(restores);
+    if (prepared.disabledChatGptSubscription) {
+      restores.push(() =>
+        this.deps.setPreferChatGptSubscription(
+          before.preferChatGptSubscription,
+        ),
+      );
+    }
+    if (prepared.disabledIncludedModelAccess) {
+      restores.push(() =>
+        this.deps.setUseIncludedModelAccess(before.useIncludedModelAccess),
+      );
+    }
+    let firstFailure: unknown;
+    for (const restore of restores) {
+      try {
+        await restore();
+      } catch (error) {
+        firstFailure ??= error;
+      }
+    }
+    if (firstFailure !== undefined) throw firstFailure;
     if (restores.length > 0) this.deps.invalidateModelOptionsCache();
+  }
+
+  /**
+   * Roll back a routing switch that an in-flight failure already doomed.
+   * The toggle restore is best-effort here: its failure must not mask the
+   * original error the caller can act on, and the state a failed rollback
+   * leaves is the same stranded one an unguarded throw would have left.
+   */
+  private async restoreAfterError(
+    before: ProgressApiRoutingSnapshot,
+    prepared: ProgressApiKeyPreparationResult,
+  ): Promise<void> {
+    await this.restoreOwnApiKeyRouting(before, prepared).catch(() => {});
   }
 
   private async hasAnyUsableKey(

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -111,7 +111,7 @@ interface TestRetryServices {
   setting: { temperature: number };
   modelCell: Pick<
     ModelCell,
-    'getClient' | 'rebind' | 'route' | 'handler' | 'swap'
+    'getClient' | 'rebind' | 'route' | 'handler' | 'swap' | 'modelId'
   >;
 }
 
@@ -120,6 +120,8 @@ function testRetryModelCell(
   rebind: TestRebind = async () => undefined,
   route?: ModelCredentialRoute,
   handlerConfig: object = {},
+  // `createRetryNode`'s config model, so the cell and run config agree.
+  modelId = 'sonnet46',
 ): TestRetryServices['modelCell'] {
   // The handler stub only feeds the Kimi Code fallback probe, which reads
   // `config` and finds no Kimi fields on it, so a swap never fires here.
@@ -127,6 +129,7 @@ function testRetryModelCell(
     getClient: async () => ({}),
     rebind,
     route,
+    modelId,
     handler: {
       config: handlerConfig,
     } as TestRetryServices['modelCell']['handler'],

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -326,29 +326,6 @@ describe('ProgressApiKeyRetryController', () => {
     expect(harness.retries).toStrictEqual(['stream-d']);
   });
 
-  it('resolves the OpenAI key from the exhaustion reason when no provider is given', async () => {
-    // Only an Anthropic key is usable. If the controller fell back to
-    // checking every provider (the pre-fix behavior when `provider` is
-    // absent), it would find this key and retry on it, which is wrong for a
-    // ChatGPT-subscription exhaustion that specifically requires OpenAI.
-    const harness = createHarness({
-      keys: { anthropic: 'stored-anthropic' },
-    });
-
-    // The caller (webview) forwards whatever provider the error was tagged
-    // with, which may be absent — the controller, not the caller, owns the
-    // chatgpt-subscription-always-means-openai policy.
-    const result = await harness.controller.useOwnApiKey({
-      stream: 'stream-f',
-      requestId: 'retry-f',
-      exhaustionReason: 'chatgpt-subscription',
-    });
-
-    expect(result).toStrictEqual(IDLE_RESULT);
-    expect(harness.prompts).toStrictEqual(['openai']);
-    expect(harness.retries).toStrictEqual([]);
-  });
-
   it('does not disable the subscription when no usable OpenAI key is available', async () => {
     const harness = createHarness({ keys: {} });
 

--- a/src/test-kernel/progressView/PermissionActionEventHandlers.vitest.ts
+++ b/src/test-kernel/progressView/PermissionActionEventHandlers.vitest.ts
@@ -246,34 +246,6 @@ const actionCases: PermissionCase[] = [
     remains: true,
   },
   {
-    name: 'retry API-key selection forwards the raw tagged provider unchanged',
-    detail: {
-      kind: PERMISSION_KIND.RETRY,
-      data: {
-        ...retryData,
-        errorDetails: {
-          provider: 'anthropic',
-          exhaustionReason: 'chatgpt-subscription',
-        },
-      },
-      decision: { action: 'useOwnApiKey' },
-    } as const,
-    calls: [
-      call(PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY, {
-        stream: 'stream-1',
-        requestId: 'retry-1',
-        model: 'claude-sonnet',
-        exhaustionReason: 'chatgpt-subscription',
-        // The chatgpt-subscription -> openai fallback mapping is the
-        // controller's policy now (ProgressApiKeyRetryController), not the
-        // webview's — this must pass the tagged provider through untouched.
-        provider: 'anthropic',
-        viaRelay: undefined,
-      }),
-    ],
-    remains: true,
-  },
-  {
     name: 'proposal approve',
     detail: detail.proposal({
       action: 'approve',


### PR DESCRIPTION
Closes #10606
Closes #10607

Builds on #10347 (merged 2026-08-15 as ba40cdc920): this PR keeps its controller-owned provider policy unchanged and removes exactly the two test cases it added, per the maintainer's overtesting direction.

## Summary

- **#10606 (payload pairing)**: The retry request carried two Kimi routing facts captured from different sources: `kimiCodeRoutedOnFailure` from the live `modelCell.handler.config`, but `model` from `services.config.model` — the immutable run config. `switchModel` swaps the cell (handler and id move together in `ModelCell.swap`) but never rewrites `services.config`, so after a mid-run switch the two facts described different handlers: a run that switched into a Kimi Code-exclusive alias still reported the stale `kimi3` (dual-backend reroute applied to a model with no Moonshot fallback), and a run that switched into `kimi3` reported the stale origin model (reroute missed). `handleManualRetryPrompt` now captures the failed handler's config and the live model id **as one pair** from the cell before the panel opens, and the request's `model`, the routing flag, and the `'personal'` preparation all read that pair.
- **Same identity through preparation + mid-wait switch race**: `prepareRetryForCredentialSelection` previously passed the stale `services.config.model` to `createKimiCodeFallbackHandler` and `modelCell.swap` (post-switch the probe resolved a non-Kimi entry and degraded to a rebind that re-selects the exhausted Kimi Code credential). Both sites now use the captured failed-model identity. And because a model switch is permitted while the retry panel waits, the async fallback build can race one: before publishing, the cell is verified to still hold the captured pair — on a mismatch the stale fallback is disposed and the live handler is rebound, so the user's newer switch is never silently undone.
- **Exception-safe routing rollback**: the routing transaction only restored when `triggerRetry` returned false. `applyOwnApiKeyRouting` now registers each attempted switch for compensation **before** awaiting its setter (a setter can mutate in memory and then reject on persistence), so a throw midway rolls back every switch that may have landed; rejections from `triggerRetry` or the Copilot fallback launch reject through a guarded rollback (`restoreAfterError`, L2 compensation) that cannot mask the original error; restores run in reverse application order, attempt every toggle, invalidate the model-options cache whenever restores were scheduled (a half-landed write leaves the cache describing the wrong routing), and rethrow the first restore failure — a failed invalidation never replaces it.
- **#10607**: pinned locally — a declined dual-backend `kimi3` credit retry with `kimiCodeRoutedOnFailure: true` restores the `kimi-code-subscription` toggle to its pre-switch value through the same `restoreOwnApiKeyRouting` path (see Validation for why the test is not committed).
- **Test removals**: deletes exactly the two test cases the merged #10347 added — the controller provider-resolution case in `ProgressApiKeyRetryController.vitest.ts` and the webview raw-provider pass-through case in `PermissionActionEventHandlers.vitest.ts`. Its production policy (`resolveProvider` in the controller, raw tagged provider from the webview) is on main and untouched here.

## Issue acceptance gates

- #10606: retry request `model` populated from the live failed model (`modelCell.modelId`, captured with the failed handler config as one pair) so both routing facts identify the same failed handler; the fallback rebuild and swap use the same live id, and a switch landing while the panel waits is preserved. Verified by local ad-hoc regression tests (post-`switchModel` dual-backend credit failure: payload pairs `model: 'kimi3'` with `kimiCodeRoutedOnFailure: true`; accepted personal preparation swaps the pinned handler onto the live model's Moonshot config and keeps `modelCell.modelId === 'kimi3'`; mid-wait switch race: stale fallback disposed, replacement handler and id preserved), each confirmed to fail pre-fix. Tests not committed per maintainer direction (overtesting); the only test-file addition is the 4-line mock-cell repair described below.
- #10607: decline-path restoration of the `kimi-code-subscription` toggle verified by a local ad-hoc test (`triggerRetry` → false ⇒ toggle writes `[false, true]`, idle result), confirmed to exercise the previously uncovered branch. Not committed per maintainer direction.

## Single source of truth

- The retry payload is still constructed once, in `ModelInvocationNode.handleManualRetryPrompt`, and travels through the shared `HostRetryRequest`/`RetryPermission` contract from #10597 unchanged — no schema or host-forwarding edits, and no second payload assembly anywhere (CLI and webview hosts keep passing the request through untouched).
- The `chatgpt-subscription` → `openai` mapping has exactly one owner — `ProgressApiKeyRetryController.resolveProvider`, from merged #10347; this PR neither moves nor duplicates it.

## Duplication and abstraction budget

No new abstraction and no duplicated retry-payload reconstruction: the fix reads the live `ModelCell` the run already holds rather than re-deriving the failed model. `restoreAfterError` is the single guarded-rollback owner for the three error paths (partial apply, `triggerRetry` rejection, Copilot launch rejection) — it exists so a rollback failure can never mask the error the caller can act on.

## Net elements (R6)

Files: 5 modified, 0 added/deleted (diffstat). Exported symbols: 0 added, 0 deleted (`^[+-]export` over the diff is empty). Classes/interfaces/enums: one non-exported `FailedModelIdentity` interface added (the captured pair type); no exported surface change. Net LoC: +46 (+192/−146): production +94 (`ModelInvocationNode.ts` +45/−9, `ProgressApiKeyRetryController.ts` +143/−85), test files −48 net (`RetryState.vitest.ts` +4/−1 mock repair; the two #10347 case deletions −23/−28).

## Consumer counts (R8)

No emit path or export deleted or re-routed in this diff (the provider-mapping move landed with #10347 on main). `RetryPermission.model` keeps name and type; after a mid-run switch its value changes from the stale launch model to the live one — grepped consumers (`ProgressApiKeyRetryController.credentialProviderFor` / `isDualBackendKimiCodeModel` / `isKimiCodeSubscriptionRetryBlocked`, webview `RetryRequestPanel` display + offer gate, CLI `classifyCliRetryAction`) all resolve the registry entry for the named model, so each becomes more accurate; none depends on the stale value.

## Host impact

Extension: retry panel and "use own API key" routing see the live post-switch model; no extension code changes in this PR (#10347 already owns the webview pass-through on main).
Desktop: same as the extension through the shared progress-view handlers; no desktop code changes.
CLI: `classifyCliRetryAction`'s exclusive-Kimi gate now reads the live model; no CLI code changes (headless and TUI adapters pass the payload through unchanged).

## Scheduled refactoring

None.

## Validation

- Full kernel suite (`npm test`, sharded 1/2 + 2/2 as in CI) on the final head: green at the pre-rebase base of this head (shard 1: 5,752 passed; shard 2: 4,984 passed; 0 failures). The only file-level failures observed in any run were JSDOM `beforeAll` hook timeouts under machine load in nine DOM-heavy suites (zero assertion failures); all nine files pass in isolation (48/48) and none is plausibly related to this diff. Per maintainer direction the full suite was not re-run again after the final rebase (base delta: two main commits, neither touching these files); gates below all ran at the final head.
- Focused unmodified suites: 298 tests green across `RetryState` (57/57, including the assertion that the payload model matches the launch model when no switch occurred), `ProgressApiKeyRetryController` (25/25), `PermissionActionEventHandlers` (22/22), `ApprovalAdapter`, `TuiApprovalRetry`, `ExtensionHostInteractions`, `RetryRequestPanel`, `ProgressViewCommandHandlers`.
- Ad-hoc verification (scratch worktrees, test patches applied locally and discarded, per maintainer direction): earlier round 114/114 across the three affected suites covering post-switch payload pairing, post-switch personal-preparation fallback identity, declined dual-backend toggle restoration, setter-throw rollback, `triggerRetry`-rejection rollback, Copilot-launch-cancellation rollback, double-failure original-error-wins, and #10347's provider-resolution behavior. This round's 4 probes: mid-wait switch race (stale fallback disposed, replacement preserved), mutate-then-reject setter compensated (`[false, true]`), rollback invalidates after failed restores (3 invalidations), invalidation failure never masks the restore failure. Every behavioral scenario was confirmed to fail against the pre-fix production code (e.g., race probe: fallback overwrote the user's replacement handler; mutate-then-reject probe: `[false]` stranded; invalidation probe: 2 invalidations instead of 3).
- `npm run typecheck` (workspace, test-kernel, agent, cli, trace-viewer, desktop) — passed.
- `eslint` and `prettier --check` on all changed files — passed.
- `check:dead-code-ratchet` (8 findings vs 8 baselined), `check:guidance-refs`, `check:browser-safe-utils`, `check:tsconfig-paths`, `check:package-contributes` — passed.
- Committed test-file changes are exactly: the 4-line `testRetryModelCell` mock repair (the mock now exposes the `modelId` every real `ModelCell` carries; default matches `createRetryNode`'s config model — a mock-interface migration required by the payload fix, no test cases or assertions added) and the two #10347 case deletions.
