### PR TITLE
refactor(logger): migrate the collision-free src/ remainder to createLog

### DIFF
--- a/src/housekeeping/runDirOps.ts
+++ b/src/housekeeping/runDirOps.ts
@@ -2,7 +2,7 @@
 import * as path from 'node:path';
 
 // Local imports
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import type { ExecutionId } from '@shared/schemas';
 import type { FileOpResult } from '@shared/schemas/opResults';
@@ -15,6 +15,8 @@ import { findRunDir } from '@utils/files/runStorageFs';
 import { CHANNEL, HISTORY_DIR } from './constants';
 import { generateTimestamp } from './utils';
 
+const log = createLog(CHANNEL);
+
 /**
  * Snapshot a completed run's runDir into `workspace/History/`. Symlinks
  * are dereferenced so the snapshot is a self-contained copy.
@@ -25,17 +27,13 @@ export async function runPackRunDir(
   model: string,
   inputFile: string,
 ): Promise<FileOpResult> {
-  logger.info(
-    CHANNEL,
+  log.info(
     `Packing runDir for execution ${executionId} (agent=${agent}, model=${model}, inputFile=${inputFile})`,
   );
 
   const runDirAbsolute = await findRunDir(executionId);
   if (!runDirAbsolute) {
-    logger.warn(
-      CHANNEL,
-      `Run directory not found for execution ${executionId}`,
-    );
+    log.warn(`Run directory not found for execution ${executionId}`);
     return { status: 'noFiles' };
   }
 
@@ -57,14 +55,11 @@ export async function runPackRunDir(
       overwrite: true,
       dereference: true,
     });
-    logger.info(
-      CHANNEL,
-      `Packed runDir ${runDirAbsolute} -> ${destinationAbsolute}`,
-    );
+    log.info(`Packed runDir ${runDirAbsolute} -> ${destinationAbsolute}`);
     return { status: 'success', outputFolder: destinationRelative };
   } catch (error) {
     const message = toErrorMessage(error);
-    logger.error(CHANNEL, `Pack runDir failed: ${message}`, { data: error });
+    log.error(`Pack runDir failed: ${message}`, { data: error });
     return { status: 'error', error: message };
   }
 }
@@ -78,24 +73,18 @@ export async function runCleanRunDir(
 ): Promise<FileOpResult> {
   const runDirAbsolute = await findRunDir(executionId);
   if (!runDirAbsolute) {
-    logger.warn(
-      CHANNEL,
-      `Run directory not found for execution ${executionId}`,
-    );
+    log.warn(`Run directory not found for execution ${executionId}`);
     return { status: 'noFiles' };
   }
 
-  logger.info(
-    CHANNEL,
-    `Removing runDir for execution ${executionId}: ${runDirAbsolute}`,
-  );
+  log.info(`Removing runDir for execution ${executionId}: ${runDirAbsolute}`);
 
   try {
     await platform().fs.delete(runDirAbsolute, { recursive: true });
     return { status: 'success' };
   } catch (error) {
     const message = toErrorMessage(error);
-    logger.error(CHANNEL, `Clean runDir failed: ${message}`, { data: error });
+    log.error(`Clean runDir failed: ${message}`, { data: error });
     return { status: 'error', error: message };
   }
 }

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -11,7 +11,7 @@ import {
   AgentConfigSchema,
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { lookupApiKey, apiKeyEnvName } from '@model/apiProviders';
 import { platform } from '@platform/platform';
 import { AgentCategory } from '@shared/schemas';
@@ -35,6 +35,7 @@ import { createEnumStateGetter } from './support/enumConfig';
 import { CLAUDE_AGENT_NAME } from './claudeAgentShared';
 
 const LOG_CHANNEL = 'claudeAgent';
+const log = createLog(LOG_CHANNEL);
 
 // ============================================================================
 // Model — defaults to Sonnet 5; users can override per-call or via workspace state
@@ -224,8 +225,7 @@ export async function buildClaudeAgentEnv(
   //    letting it surface as an opaque "Invalid API key" from Claude Code.
   const managed = await lookupApiKey(platform().secrets, 'anthropic').catch(
     (error: unknown) => {
-      logger.warn(
-        LOG_CHANNEL,
+      log.warn(
         `Failed to read the managed Anthropic API key: ${toErrorMessage(error)}`,
       );
       return undefined;


### PR DESCRIPTION
## Summary

Collision-free remainder subset of #10013 for non-test `src/` namespace
logger imports, following the merged #10616 / #10627 / #10632 / #10648
pattern. Every open PR diff was audited before editing; each of the six
candidates was evaluated individually and probed for merge cleanliness with
`git merge-tree --write-tree` against open fleet PR #10609 (head
`66491f22`). Only the two provably collision-free modules are converted;
each conversion binds `createLog` once at module scope, so every call still
funnels through `createLog` → `loggerSelf` → the shared `writeLine` sink and
`vi.spyOn(logger, 'warn')`-style namespace interception keeps working.

## Converted to `createLog` (2 files)

- `src/housekeeping/runDirOps.ts` — binds `const log = createLog(CHANNEL)`
  for the shared `'Housekeeping'` channel from `./constants`; all 7
  `logger.{info,warn,error}` sites converted, `{ data: error }` options
  preserved verbatim.
- `src/tools/claudeAgentConfig.ts` — keeps `LOG_CHANNEL = 'claudeAgent'`
  and binds `const log = createLog(LOG_CHANNEL)`, matching the #10648
  `inBandSubagentExecution.ts` idiom; the single managed-key `warn` site
  converted.

Both are fixed-channel module-scope bindings — the same mechanical shape as
the 25 #10616 conversions and #10648's `inBandSubagentExecution.ts`, none of
which required new seam tests.

## Candidates left out (per-file evaluation)

Per the open-PR audit, any candidate that overlaps an open PR is excluded:

- `src/housekeeping/clean.ts` — mechanically convertible, but #10609
  rewrites the `@shared/schemas/opResults` import on the line immediately
  adjacent to `import * as logger`; replacing the logger import line is
  unavoidable in any conversion, and `git merge-tree` confirms a real
  content conflict. Excluded until #10609 lands.
- `src/housekeeping/pack.ts` — same adjacent-import conflict with #10609
  (lines 5 vs 6–7). Excluded.
- `src/latex/latexdiff/diffCommandExecutor.ts` — convertible via the #10627
  `private get log()` idiom (channel arrives via constructor), but its
  logger import (line 2) is adjacent to #10609's `ExecResult` import rewrite
  (line 3); merge-tree conflict confirmed. Excluded.
- `src/utils/system/execUtils.ts` — convertible via the #10627 `texcount.ts`
  mixed idiom (module `log` + function-scoped `createLog(resolvedChannel)`),
  but the logger import (line 18) is adjacent to #10609's `ExecResult`
  import rewrite (line 19); merge-tree conflict confirmed. Excluded.
- `src/auth/serverKeys/index.ts` — excluded per scope until fleet #10609
  lands (its `TierService`/`ServerSideKeyService` logger contracts are in
  that PR).
- `src/logger/logUtils.ts` — the `loggerSelf` seam itself; permanent.

Merge-tree probe matrix vs #10609 head `66491f22` (import-line edit):
`clean` CONFLICT, `pack` CONFLICT, `diffCommandExecutor` CONFLICT,
`execUtils` CONFLICT, `runDirOps` CLEAN, `claudeAgentConfig` CLEAN. The
full committed diff was additionally verified merge-tree CLEAN against
#10609, and no other open PR (#10658/#10657/#10656/#10654/#10653/#10651/
#10646/#10636/#10612/#10601/#10347) touches either converted file.

## Remaining `import * as logger` census (non-test `src/`)

**8 → 6** (7 → 5 excluding the permanent `logUtils.ts` self-import):

- `src/auth/serverKeys/index.ts` (blocked on #10609)
- `src/housekeeping/clean.ts` (blocked on #10609)
- `src/housekeeping/pack.ts` (blocked on #10609)
- `src/latex/latexdiff/diffCommandExecutor.ts` (blocked on #10609)
- `src/logger/logUtils.ts` (permanent `loggerSelf` seam)
- `src/utils/system/execUtils.ts` (blocked on #10609)

Unchanged from #10648's census, outside this PR's scope: `src/test-kernel/`
(16 test-side spies) and `packages/extension/` (32).

## Tests

No new tests: both conversions are fixed-channel module-scope bindings (the
#10616/#10648 mechanical idiom, which added none), and no existing suite
spies or mocks logger output for these two modules. Namespace-spy
interception is preserved by `createLog`'s `loggerSelf` delegation, pinned
by `src/test-kernel/logger/LogUtils.vitest.ts`. The two dynamic-channel
candidates that would have warranted focused seam pins
(`diffCommandExecutor`, `execUtils`) are the collision-excluded ones.

## Net elements (R6)

- Diffstat: **2 files, 13 insertions, 24 deletions; net −11 lines**.
- Non-test `src/` namespace imports: **8 → 6** (7 → 5 excluding
  `logUtils.ts`).
- `createLog` module-level call sites under `src/` (non-test, excluding
  `logUtils.ts`, same top-level-statement metric as #10648): **85 → 87**.
- Exported symbols/classes/interfaces/enums added or removed: **0**.

## Consumer counts (R8)

No event or emit path is added or rerouted. Both channel strings are
preserved verbatim: `'Housekeeping'` (shared `CHANNEL` from
`./constants`, also consumed by `clean.ts`/`pack.ts`/`utils.ts`/
`packLatexdiffvc.ts`, all untouched) and `'claudeAgent'` (`LOG_CHANNEL`).
Module consumers are unchanged: `runDirOps` still serves
`packCommands.ts`/`cleanCommands.ts` (extension) and
`desktopAgentExecution.ts` (desktop); `claudeAgentConfig` still serves
`claudeAgent.ts`, `externalToolDefs.ts`, `skillSources.ts`, and
`stateSettings.ts`.

## Host impact

Extension / Desktop / CLI: none — no exported signatures change; log output
is byte-identical (same channels, levels, messages, and options objects).

## Test plan

- Focused vitest (suites covering both modules and their callers):
  `HousekeepingStreaming`, `LatexHousekeepingNotifications`,
  `LegacyWorkflowOutput`, `ClaudeAgentConfig`, `ClaudeAgentResumeFallback` —
  **42 passed**.
- Broad sweep (`housekeeping/`, `logger/`, `commands/`,
  `shared/stateSettings`, Claude adapter/schema/session-registry):
  **164 passed**.
- Architecture: **17/17 suites, 102 passed**.
- Full `npm run typecheck` (all six sub-projects) and full `npm run lint`:
  clean.
- Prettier `--check` on changed files, `git diff --check`: clean.
- `check:dead-code-ratchet` (8 vs 8 baselined), `check:guidance-refs`,
  `check:browser-safe-utils`, `check:tsconfig-paths`: clean.
- `git merge-tree --write-tree` of this branch vs #10609 head `66491f22`:
  no conflicts.

Refs #10013
