### PR TITLE
fix(agent): strip unknown top-level keys in ToolUseRunSharedSchema

### DIFF
--- a/docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md
+++ b/docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md
@@ -435,8 +435,20 @@ action to say so instead of returning nothing.
   fine. Rejection, if ever, is an explicit behavior-changing decision with
   its own validation and release treatment — not a rider on item 9's
   mechanical relocation.
-- `ToolUseRunSharedSchema` is a `z.looseObject` while reflection's shared
-  schema is strict.
+- `ToolUseRunSharedSchema` was a `z.looseObject` while reflection's shared
+  schema parses with default `z.object` semantics — resolved (#10641):
+  tooluse now matches reflection, accepting but stripping unknown top-level
+  keys at the `migrateSharedState` boundary; the existing deep-equal
+  self-heal checks on both resume paths rewrite the healed record (the
+  direct stored fallback consults `migrationResult.migrated`; the
+  retrieved handoff rewrites when the re-read record differs from the
+  stripped resume copy), so a record carrying a newer build's keys is
+  normalized on first resume instead of round-tripping them forever. The
+  heal is one-directional: an upgrade → resume-on-older-build → upgrade
+  cycle erases the newer build's unknown keys for good. Deliberately not
+  `z.strictObject` (a newer build's unknown keys must not break resume),
+  no `.catch` (malformed known fields keep failing loudly), no duplicate
+  legacy schema.
 - The `max(configuredRounds, userRequestTemplateCount)` rule duplicated
   between `agentYamlScanner` and `runReflectionFlow` — rated LOW in
   `2026-07-09-tech-debt-audit-runtime-ui.md` (B15); leave unless touched.

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -37,8 +37,21 @@ const StateSlicesCanonicalSchema = StateSlicesSchema.extend({
 
 export type StateSlicesSnapshot = z.output<typeof StateSlicesSchema>;
 
-/** Full persisted and live shared state for one tool-use flow. */
-const ToolUseRunSharedSchema = z.looseObject({
+/**
+ * Full persisted and live shared state for one tool-use flow.
+ *
+ * Default `z.object` semantics by decision (#10641), matching reflection's
+ * shared schema: unknown top-level keys in a persisted record are accepted
+ * but stripped at this parse boundary, and the existing deep-equal
+ * self-heal checks on both resume paths then rewrite the healed record.
+ * The heal is one-directional: an upgrade → resume-on-older-build →
+ * upgrade cycle permanently erases the newer build's unknown keys, so a
+ * future load-bearing top-level field must be added with that erasure in
+ * mind. Deliberately not `z.strictObject` — a record written by a newer
+ * build carrying keys this build does not know must still resume — and no
+ * `.catch`: malformed known fields must keep failing loudly.
+ */
+const ToolUseRunSharedSchema = z.object({
   messages: ProviderMessageArraySchema,
   /** Durable identity of the continuation attempt that owns this flow. */
   continuationGenerationId: z.uuid(),


### PR DESCRIPTION
## Summary

`ToolUseRunSharedSchema` (the persisted/live shared state for every tool-use flow) was a `z.looseObject`, so unknown top-level keys in a persisted flow record passed through the `migrateSharedState` boundary parse and round-tripped forever — the asymmetry the delegation/flow substrate plan recorded as an unresolved honorable mention after #10475. Reflection's shared schema (`ReflectionFlowStateSchema`) already parses with default `z.object` semantics.

This PR switches tooluse to the same default `z.object` semantics: unknown top-level keys are **accepted but stripped** at the one deserialization boundary, and the existing deep-equal self-heal checks then persist the healed record — no new write path, no migration code:

- Direct stored fallback (`runToolUseFlow` leftover-record branch): stripping makes `migrationResult.migrated` true, so the existing normalized-state write fires.
- Retrieved handoff (`SessionResumeRetrieval` → `runToolUseFlow` resume branch): the re-read `flowRecord.shared` differs from the stripped `resume.shared`, so the existing repair write fires (after the unchanged `sourceShared` drift check).

Deliberately **not** `z.strictObject` (a record written by a newer build carrying keys this build does not know must still resume), **no** `.catch` (malformed known fields keep failing loudly per the durable-state schema rule), and **no** duplicate legacy schema. The schema comment records that the heal is one-directional (an upgrade → resume-on-older-build → upgrade cycle permanently erases the newer build's unknown keys). The plan doc's honorable-mentions entry records the decision with the per-path write attribution.

## Issue acceptance gates

Closes #10641

- [x] Decide the strictness question: accept-and-strip (default `z.object`), matching reflection.
- [x] Zod v4 persisted-data rules honored: no `.catch` default; the persisted todo-status enum keeps failing loudly on read (unchanged `TodoItemSchema` path; existing workspace-state suites pin it).
- [x] Read-compat preserved: records with unknown keys still parse; recognized fields survive; the healed canonical record is persisted by both resume paths' existing self-heal checks.
- [x] Decision recorded in `docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md` honorable mentions.

## Single source of truth

`ToolUseRunSharedSchema` in `src/agent/implementations/flows/tooluse/nodes/types.ts` remains the one boundary schema; `migrateSharedState` remains the one normalization/self-heal decision point. No parallel or legacy schema added.

## Duplication and abstraction budget

None added. The fix reuses the existing migration flag and both existing self-heal writes; the behavior change is one keyword, the rest is decision/contract comments.

## Net elements (R6)

Not a refactor/simplify PR; reported anyway. Files: 0 added, 0 deleted, 2 modified (1 production, 1 proposal doc). Exported symbols (`^[+-]export` over the diff): 0 added, 0 deleted. Classes/interfaces/enums: 0. Net LoC: +25 (+29/−4): production +13 (one keyword plus the decision comment), docs +12. No test changes — maintainer direction: existing coverage suffices.

## Consumer counts (R8)

n/a — no emit path or export deleted or re-routed. The changed schema is module-private; `ToolUseRunSharedCanonicalSchema` (extends it) and `migrateSharedState` keep their signatures, and its only consumers (`runToolUseFlow`'s per-step revalidation and the migration boundary) are unchanged.

## Host impact

Extension: no host-specific change. A persisted tool-use flow record carrying unknown top-level keys is normalized (stripped + one self-heal rewrite) on first resume instead of round-tripping them; malformed records still fail loudly.

Desktop: same as extension (shared agent-runtime boundary).

CLI: same as extension (shared agent-runtime boundary).

## Scheduled refactoring

None.

## Validation

No new tests land per maintainer direction (overtesting). Verified against the existing unmodified suites on the final head:

- `vitest run src/test-kernel/agent/SessionResumeRetrieval.vitest.ts src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts src/test-kernel/agent/PersistedFlow.vitest.ts` — 69/69 passed.
- Full `src/test-kernel/agent/` — 3116 passed, 4 skipped (pre-existing skips), 0 failures.
- Architecture suites (`src/test-kernel/architecture/`) — 102 passed; `check:dead-code-ratchet`, `check:guidance-refs` — OK.
- `typecheck:workspace`, `typecheck:test-kernel`, eslint on the changed production file, `prettier --check` on both changed files — clean.

During development the strip/migration/self-heal behavior was additionally probed with a scratch vitest file and mutation-checked against a `z.looseObject` revert (strip detection and both heal writes fail without the change); that scaffolding was not landed per the maintainer direction above.
