### PR TITLE
test(agent): cover no-ALS tool dispatch

### DIFF
--- a/src/test-kernel/agent/RunScopedToolOverlay.vitest.ts
+++ b/src/test-kernel/agent/RunScopedToolOverlay.vitest.ts
@@ -9,8 +9,15 @@ import {
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { MapToolRegistry, type ITool } from '@agent/core/tools/ToolTypes';
 import { runToolUseFlow } from '@agent/implementations/flows/tooluse/runToolUseFlow';
-import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import {
+  createRunContext,
+  tryUseRunContext,
+  useRunContext,
+  withRunContext,
+} from '@agent/runtime/RunContext';
 import { createRunScope } from '@agent/runtime/RunScope';
+import { tryDefaultSession } from '@agent/runtime/SessionHandle';
+import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 import {
   AgentCategory,
   type ExecutionId,
@@ -18,7 +25,9 @@ import {
 } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { createTestSession } from '@test/support/sessionTestUtils';
+import { TodoWriteTool } from '@tools/todo/TodoTool';
 import { testModelCell } from './modelCellTestUtils';
+import { roundModelHandler } from './toolUseRoundTestUtils';
 
 const CONFIG = AgentConfigSchema.parse({
   agent: 'chat',
@@ -132,6 +141,168 @@ describe('run-scoped tool overlay', () => {
       expect(warn).toHaveBeenCalledWith(
         'Run-scoped tool "first" shadows an existing tool.',
       );
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('dispatches and completes a real tool without an ambient run context', async () => {
+    const executionId = '9329abcf' as ExecutionId;
+    const streamId = `chat#${executionId}` as StreamTabId;
+    const session = createTestSession();
+    const runScope = createRunScope({
+      executionId,
+      streamId,
+      agentName: 'chat',
+      session,
+      signal: new AbortController().signal,
+    });
+    const toolCall: SdkToolCall = {
+      provider: 'deepseek',
+      callId: 'call-todo-write',
+      name: 'todo_write',
+      input: {
+        todos: [
+          {
+            content: 'Exercise dispatch',
+            activeForm: 'Exercising dispatch',
+            status: 'completed',
+          },
+        ],
+      },
+      raw: {} as never,
+    };
+    const responses = [
+      { text: '', toolCalls: [toolCall] },
+      { text: 'Tool dispatch completed.', toolCalls: [] },
+    ];
+    const observedToolLists: string[][] = [];
+    const observedToolResults: unknown[] = [];
+    const progressUpdates: unknown[] = [];
+    const dispatchRunContexts: unknown[] = [];
+    const modelHandler = roundModelHandler({
+      capabilities: { supportsFunctionCalling: true, supportsVision: false },
+      requiresPerCallSystemPrompt: false,
+      supportsForcedToolChoice: false,
+      initializeMessages: async () => [
+        { role: 'user', content: 'Update the todo list.' },
+      ],
+      consumeInsertedAttachmentKinds: () => [],
+      createResponse: vi.fn(async (options: { tools?: { name: string }[] }) => {
+        observedToolLists.push((options.tools ?? []).map(({ name }) => name));
+        const response = responses.shift();
+        if (!response) throw new Error('Unexpected model invocation');
+        return { response };
+      }),
+      extractResponse: (response: unknown) => {
+        const turn = response as { text: string; toolCalls: SdkToolCall[] };
+        return {
+          text: turn.text,
+          usage: null,
+          stopReason: turn.toolCalls.length ? 'tool_use' : 'stop',
+        };
+      },
+      extractToolUse: (response: unknown) =>
+        (response as { toolCalls: SdkToolCall[] }).toolCalls,
+      createToolUseFollowUpMessages: async (
+        _client: unknown,
+        call: SdkToolCall,
+        result: unknown,
+      ) => {
+        observedToolResults.push(result);
+        return [
+          {
+            role: 'tool',
+            tool_call_id: call.callId,
+            content: JSON.stringify(result),
+          },
+        ];
+      },
+    });
+    const modelCell = testModelCell(modelHandler, 'test-model');
+    const config = AgentConfigSchema.parse({
+      agent: 'chat',
+      model: 'test-model',
+      agentCategory: AgentCategory.ToolUse,
+      workingDirectory: process.cwd(),
+    });
+    let attachedOwner: unknown;
+
+    try {
+      // The test process has no default session, so any currentSession()
+      // fallback during dispatch fails instead of silently using another owner.
+      expect(tryDefaultSession()).toBeUndefined();
+      expect(tryUseRunContext()).toBeUndefined();
+      expect(() => useRunContext()).toThrow(/outside withRunContext/);
+
+      const result = await runToolUseFlow(
+        {
+          config,
+          runScope,
+          setting: AgentToolUseSettingSchema.parse({
+            tools: [{ name: 'bash' }, { name: 'todo_write' }],
+          }),
+          prompt: AgentPromptSchema.parse({}),
+          logger: noopTrace,
+          userVarChannels: {
+            input: Object.freeze({ MODEL: config.model }),
+            transient: {},
+          },
+          modelCell,
+          toolPolicy: createToolPolicy({
+            approvalPromptsUnavailable: true,
+            stopAfterCycle: true,
+          }),
+          onModelChanged: () => {},
+          interrupt: () => {},
+          onRoundFinalized: () => {},
+          onProgress: (update) => {
+            progressUpdates.push(update);
+            if (update.kind === 'todos') {
+              // TodoWriteTool emits this synchronously from inside call(), so
+              // this observation is made in the real dispatch window.
+              dispatchRunContexts.push(tryUseRunContext());
+            }
+          },
+        },
+        new MapToolRegistry({
+          bash: approvalGatedTool('bash'),
+          todo_write: new TodoWriteTool(),
+        }),
+        {
+          attach: ({ ownerSession }) => {
+            attachedOwner = ownerSession;
+          },
+          detach: () => {},
+        },
+      );
+
+      expect(result).toMatchObject({
+        outcome: 'completed',
+        response: 'Tool dispatch completed.',
+      });
+      expect(attachedOwner).toBe(session);
+      expect(observedToolLists).toEqual([['todo_write'], ['todo_write']]);
+      expect(observedToolResults).toEqual([
+        expect.objectContaining({
+          status: 'executed',
+          output: 'OK',
+        }),
+      ]);
+      expect(dispatchRunContexts).toEqual([undefined]);
+      expect(progressUpdates).toContainEqual({
+        kind: 'todos',
+        todos: [
+          {
+            content: 'Exercise dispatch',
+            activeForm: 'Exercising dispatch',
+            status: 'completed',
+          },
+        ],
+      });
+      expect(responses).toHaveLength(0);
+      expect(tryUseRunContext()).toBeUndefined();
+      expect(tryDefaultSession()).toBeUndefined();
     } finally {
       session.dispose();
     }


### PR DESCRIPTION
## Summary

Adds the missing end-to-end no-ALS regression for `runToolUseFlow`: a real `TodoWriteTool` call now dispatches, updates the live work-plan state, returns its tool result to the model, and reaches normal flow completion without a `RunContext` frame or process-default session.

The test also pins the two injected authorities at this boundary:

- the model-facing tool list follows the supplied `ToolPolicy` by filtering an approval-gated `bash` tool;
- the attached flow context exposes the supplied `runScope.session` as its owner.

No production change was needed; the existing tools-layer contract supports this no-ALS dispatch path.

Closes #10652

## Regression coverage

- Asserts there is no default session and no ambient `RunContext` before or after the flow.
- Observes `tryUseRunContext() === undefined` synchronously from `TodoWriteTool.call()` via its todo progress callback, covering the actual dispatch window.
- Asserts the real tool completes with `status: executed`, its todo update reaches progress state, the model receives the tool result, and the flow completes on the second model turn.
- Negative control: removing `approvalPromptsUnavailable` makes the test fail because `bash` reappears in the model-facing list.

## Net elements (R6)

- Files: 1 modified, 0 added, 0 deleted.
- Exported symbols: 0 added, 0 removed.
- Classes/interfaces/enums: 0 added, 0 removed.
- Net LoC: +172 / -1 = +171 (test-only).

## Consumer counts (R8)

No exports or emit paths were added, removed, or rerouted; consumer-count analysis is not applicable.

## Host impact

- Extension: none (test-only).
- Desktop: none (test-only).
- CLI: none (test-only).

## Validation

- Focused/surrounding Vitest: 4 files, 39 tests passed (run-scoped overlay, dispatch parallelism, wait node, response-cycle tools).
- Final focused Vitest after rebase: 1 file, 3 tests passed.
- Full typecheck matrix: workspace, test-kernel, agent, CLI, trace-viewer, desktop passed.
- Architecture suite: 17 files, 102 tests passed (serial worker; parallel run hit the existing 10s scan timeout in `subsystemEdgeRatchet`, while the test passed standalone and in the serial full suite).
- ESLint and Prettier for the changed file passed; `git diff --check` passed.
- `check:dead-code-ratchet`, `check:guidance-refs`, and `check:browser-safe-utils` passed.

<!-- verification:texra-10652-1786834882-10481 -->
