### PR TITLE
refactor(progressView): retire the ProgressBackend applySessionFact/applyRunFact test seeds

### DIFF
--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -418,27 +418,16 @@ export class ProgressBackend {
     }
   }
 
-  /** Awaitable status application for tests and hosts that cannot fire-and-forget. */
+  /**
+   * Awaitable status application for tests and hosts that cannot
+   * fire-and-forget. The only fact-seed surface left on the backend: every
+   * other fact arrives through the session-event hub, whose synchronous emit
+   * cannot hand back the handler promise `setStreamStatus` callers need.
+   */
   applyStreamStatus(
     ...args: Parameters<SessionFactApplier['setStreamStatus']>
   ): ReturnType<SessionFactApplier['setStreamStatus']> {
     return this.factApplier.setStreamStatus(...args);
-  }
-
-  /** Inject a session fact (tests / rare host seeds). Prefer the hub in production. */
-  applySessionFact(
-    ...args: Parameters<SessionFactApplier['handleSessionFact']>
-  ): void {
-    this.factApplier.handleSessionFact(...args);
-    const [fact] = args;
-    if (fact.type === 'setActiveStream') {
-      this.handleStreamPresentationRequest(fact.payload);
-    }
-  }
-
-  /** Inject a run fact (tests / rare host seeds). Prefer the hub in production. */
-  applyRunFact(...args: Parameters<SessionFactApplier['handleRunFact']>): void {
-    this.factApplier.handleRunFact(...args);
   }
 
   async stopStream(stream: StreamTabId): Promise<void> {

--- a/src/test-kernel/architecture/progressBackendFactSeedRetirement.vitest.ts
+++ b/src/test-kernel/architecture/progressBackendFactSeedRetirement.vitest.ts
@@ -1,0 +1,30 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+import { REPO_ROOT, stripComments } from '../support/repoScan';
+
+const PROGRESS_BACKEND =
+  'src/controllers/progressView/backend/ProgressBackend.ts';
+
+const RETIRED_FACT_SEED = /\bapply(?:Session|Run)Fact\b/;
+const DOCUMENTED_STATUS_SEED = /\bapplyStreamStatus\b/;
+
+function progressBackendSource(): string {
+  return stripComments(
+    readFileSync(resolve(REPO_ROOT, PROGRESS_BACKEND), 'utf8'),
+  );
+}
+
+describe('ProgressBackend fact-seed retirement', () => {
+  it('keeps the retired applySessionFact/applyRunFact test seeds off ProgressBackend', () => {
+    expect(RETIRED_FACT_SEED.test(progressBackendSource())).toBe(false);
+  });
+
+  it('keeps applyStreamStatus, the documented awaitable status seed', () => {
+    expect(DOCUMENTED_STATUS_SEED.test(progressBackendSource())).toBe(true);
+  });
+});

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -44,6 +44,7 @@ import {
   emitActiveStream,
   emitRunConfig,
   emitRunEvent,
+  emitSessionFact,
   emitStreamDescription,
   toolUseConfig,
 } from './progressBackendHarness';
@@ -1027,8 +1028,8 @@ describe('ProgressBackend', () => {
 
   it('drops buffered conversation progress when an existing stream re-enters running', async () => {
     vi.useFakeTimers();
-    const { backend, messages } = createRecordingBackend();
-    backend.setupEventListeners();
+    const target = createListeningBackend();
+    const { backend, messages } = target;
     const stream = 'tool-stream' as StreamTabId;
 
     try {
@@ -1045,7 +1046,7 @@ describe('ProgressBackend', () => {
       });
       backend.state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
 
-      backend.applyRunFact(stream, {
+      emitRunEvent(target, stream, {
         type: 'conversation.progress',
         progress: { toolCallCount: 7 },
       });
@@ -1096,7 +1097,7 @@ describe('ProgressBackend', () => {
       },
     }));
     try {
-      const { backend } = createRecordingBackend();
+      const target = createListeningBackend();
       const stream = 'tool-stream' as StreamTabId;
       const failure = new Error('status application exploded');
       vi.spyOn(
@@ -1104,7 +1105,7 @@ describe('ProgressBackend', () => {
         'setStreamStatus',
       ).mockRejectedValue(failure);
 
-      backend.applySessionFact({
+      emitSessionFact(target, {
         type: 'status',
         streamId: stream,
         phase: STREAM_PHASE.RUNNING,

--- a/src/test-kernel/progressView/ProgressBackendRetainedChildren.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendRetainedChildren.vitest.ts
@@ -9,6 +9,7 @@ import '@test/support/defaultSessionTestSetup';
 
 import { describe, expect, it, vi } from 'vitest';
 
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ProgressBackend } from '@controllers/progressView/backend/ProgressBackend';
 import {
   AgentCategory,
@@ -25,18 +26,28 @@ import { testExecutionHandle } from '@test/support/executionHandleFixtures';
 import { snapshotFacts } from '@test/support/storeTestDrivers';
 import {
   createIsolatedRecordingBackend,
-  createRecordingBackend,
+  emitRunEvent,
+  emitSessionFact,
 } from './progressBackendHarness';
 
 describe('retained finished children', () => {
   const PARENT = 'parent-stream' as StreamTabId;
 
+  /** An isolated recording backend already wired to its session events. */
+  function createListeningBackend(): ReturnType<
+    typeof createIsolatedRecordingBackend
+  > {
+    const target = createIsolatedRecordingBackend();
+    target.backend.setupEventListeners();
+    return target;
+  }
+
   function applyRoster(
-    backend: ProgressBackend,
+    target: { session: SessionHandle },
     parent: StreamTabId,
     items: ActiveChildInfo[],
   ): void {
-    backend.applyRunFact(parent, {
+    emitRunEvent(target, parent, {
       type: 'child.activity',
       parentStreamId: parent,
       items,
@@ -77,11 +88,12 @@ describe('retained finished children', () => {
   }
 
   it('keeps a vanished child as a row stamped with finishedAt', () => {
-    const { backend } = createRecordingBackend();
+    const target = createListeningBackend();
+    const { backend } = target;
     seedParent(backend);
 
-    applyRoster(backend, PARENT, [subagent('a'), subagent('b')]);
-    applyRoster(backend, PARENT, [subagent('a')]);
+    applyRoster(target, PARENT, [subagent('a'), subagent('b')]);
+    applyRoster(target, PARENT, [subagent('a')]);
 
     const roster = parentRoster(backend);
     expect(roster).toHaveLength(2);
@@ -98,9 +110,10 @@ describe('retained finished children', () => {
     // it cannot ride the active-stream gate: a child that finishes while the
     // user is looking at another tab (clicking its own row is enough to move
     // the active stream) must still retire its row.
-    const { backend, messages } = createRecordingBackend();
+    const target = createListeningBackend();
+    const { backend, messages } = target;
     seedParent(backend);
-    applyRoster(backend, PARENT, [subagent('bg')]);
+    applyRoster(target, PARENT, [subagent('bg')]);
 
     const other = 'other-stream' as StreamTabId;
     backend.state.streamLogs.ensureStream(other);
@@ -108,7 +121,7 @@ describe('retained finished children', () => {
     backend.presentation.select(other);
     messages.length = 0;
 
-    applyRoster(backend, PARENT, []);
+    applyRoster(target, PARENT, []);
 
     const badgeMessages = badgePushes(messages);
     expect(badgeMessages).toHaveLength(1);
@@ -116,7 +129,8 @@ describe('retained finished children', () => {
   });
 
   it('promotes a retained child back to one live row when it reappears', () => {
-    const { backend } = createRecordingBackend();
+    const target = createListeningBackend();
+    const { backend } = target;
     seedParent(backend);
     const child = subagent('resumed');
 
@@ -131,25 +145,26 @@ describe('retained finished children', () => {
       return roster;
     };
 
-    applyRoster(backend, PARENT, [child]);
+    applyRoster(target, PARENT, [child]);
     expectSingleRow(false);
 
-    applyRoster(backend, PARENT, []);
+    applyRoster(target, PARENT, []);
     expectSingleRow(true);
 
-    applyRoster(backend, PARENT, [child]);
+    applyRoster(target, PARENT, [child]);
     expectSingleRow(false);
 
-    applyRoster(backend, PARENT, []);
+    applyRoster(target, PARENT, []);
     const roster = expectSingleRow(true);
     expect(new Set(roster.map((entry) => entry.executionId)).size).toBe(1);
   });
 
   it('never marks anything finished from a first roster', () => {
-    const { backend } = createRecordingBackend();
+    const target = createListeningBackend();
+    const { backend } = target;
     seedParent(backend);
 
-    applyRoster(backend, PARENT, [subagent('a')]);
+    applyRoster(target, PARENT, [subagent('a')]);
 
     const roster = parentRoster(backend);
     expect(roster.map((c) => c.executionId)).toEqual(['a']);
@@ -157,11 +172,12 @@ describe('retained finished children', () => {
   });
 
   it('keeps a roster-first child when the parent category is later corrected', () => {
-    const { backend } = createRecordingBackend();
+    const target = createListeningBackend();
+    const { backend } = target;
     backend.state.streamLogs.ensureStream(PARENT);
 
     // Roster arrives before RUNNING/config; applier provisions a ToolUse bucket.
-    applyRoster(backend, PARENT, [subagent('early')]);
+    applyRoster(target, PARENT, [subagent('early')]);
     expect(backend.state.getStreamState(PARENT)?.category).toBe(
       AgentCategory.ToolUse,
     );
@@ -178,7 +194,8 @@ describe('retained finished children', () => {
   });
 
   it('shows a terminal status that lands after the roster drop', async () => {
-    const { backend, messages } = createRecordingBackend();
+    const target = createListeningBackend();
+    const { backend, messages } = target;
     seedParent(backend);
     const child = subagent('late');
     const childStreamId = 'late-stream' as StreamTabId;
@@ -188,8 +205,8 @@ describe('retained finished children', () => {
     );
 
     // Roster drop first — the child is still `running` at this point.
-    applyRoster(backend, PARENT, [child]);
-    applyRoster(backend, PARENT, []);
+    applyRoster(target, PARENT, [child]);
+    applyRoster(target, PARENT, []);
     messages.length = 0;
 
     // Terminal status arrives afterwards.
@@ -213,8 +230,8 @@ describe('retained finished children', () => {
   });
 
   it('keeps the resolved terminal status on a later structural sync', async () => {
-    const { backend, messages } = createIsolatedRecordingBackend();
-    backend.setupEventListeners();
+    const target = createListeningBackend();
+    const { backend, messages } = target;
     seedParent(backend);
     const childStreamId = 'doomed-stream' as StreamTabId;
     snapshotFacts(backend.state.snapshots).setParentStream(
@@ -223,8 +240,8 @@ describe('retained finished children', () => {
     );
 
     // Roster drop first, so the retained row is stamped `running`.
-    applyRoster(backend, PARENT, [subagent('doomed', { childStreamId })]);
-    applyRoster(backend, PARENT, []);
+    applyRoster(target, PARENT, [subagent('doomed', { childStreamId })]);
+    applyRoster(target, PARENT, []);
     // Transition the status machine and nothing else: its fact is the single
     // owner of a roster row's phase, so the retained row must be written by
     // this call alone, with no read-time repair on the send paths.
@@ -275,18 +292,19 @@ describe('retained finished children', () => {
   });
 
   it('keeps a recorded terminal phase when a stale roster still says running', async () => {
-    const { backend, messages } = createRecordingBackend();
+    const target = createListeningBackend();
+    const { backend, messages } = target;
     seedParent(backend);
     const childStreamId = 'stale-stream' as StreamTabId;
     const live = subagent('stale', { childStreamId });
 
-    applyRoster(backend, PARENT, [live]);
+    applyRoster(target, PARENT, [live]);
     await backend.applyStreamStatus(childStreamId, STREAM_PHASE.FAILED);
     messages.length = 0;
 
     // A roster snapshot stamped before the transition, delivered after it: the
     // child is still tracked, so it arrives as a live row carrying `running`.
-    applyRoster(backend, PARENT, [live]);
+    applyRoster(target, PARENT, [live]);
 
     const roster = parentRoster(backend);
     expect(roster).toEqual([
@@ -310,15 +328,16 @@ describe('retained finished children', () => {
   });
 
   it('takes the emitted phase when a retained child goes live again', () => {
-    const { backend } = createRecordingBackend();
+    const target = createListeningBackend();
+    const { backend } = target;
     seedParent(backend);
     const childStreamId = 'requeued-stream' as StreamTabId;
 
-    applyRoster(backend, PARENT, [
+    applyRoster(target, PARENT, [
       subagent('requeued', { childStreamId, status: STREAM_PHASE.WAITING }),
     ]);
-    applyRoster(backend, PARENT, []);
-    applyRoster(backend, PARENT, [
+    applyRoster(target, PARENT, []);
+    applyRoster(target, PARENT, [
       subagent('requeued', { childStreamId, status: STREAM_PHASE.RUNNING }),
     ]);
 
@@ -337,8 +356,8 @@ describe('retained finished children', () => {
     // its terminal phase lands, and a roster stamped before that transition is
     // applied afterwards. With the send-time projection gone, an older stamp
     // that reached the row would freeze this badge at `running` forever.
-    const { backend, session } = createIsolatedRecordingBackend();
-    backend.setupEventListeners();
+    const target = createListeningBackend();
+    const { backend, session } = target;
     seedParent(backend);
     const executionId = 'c0ffee01' as ExecutionId;
     const childStreamId = 'restamped-stream' as StreamTabId;
@@ -354,7 +373,7 @@ describe('retained finished children', () => {
     });
     const rosterStampedWhileRunning =
       session.executions.getActiveChildren(PARENT);
-    applyRoster(backend, PARENT, rosterStampedWhileRunning);
+    applyRoster(target, PARENT, rosterStampedWhileRunning);
     expect(backend.state.getStreamState(PARENT)?.subagents?.[0]?.status).toBe(
       STREAM_PHASE.RUNNING,
     );
@@ -368,7 +387,7 @@ describe('retained finished children', () => {
       STREAM_PHASE.FAILED,
     );
 
-    applyRoster(backend, PARENT, rosterStampedWhileRunning);
+    applyRoster(target, PARENT, rosterStampedWhileRunning);
     expect(backend.state.getStreamState(PARENT)?.subagents).toEqual([
       expect.objectContaining({
         executionId,
@@ -378,7 +397,7 @@ describe('retained finished children', () => {
 
     // A roster the emitter stamps now carries the resolved phase too, so the
     // row is written from the same owner on both paths.
-    applyRoster(backend, PARENT, session.executions.getActiveChildren(PARENT));
+    applyRoster(target, PARENT, session.executions.getActiveChildren(PARENT));
     expect(backend.state.getStreamState(PARENT)?.subagents).toEqual([
       expect.objectContaining({
         executionId,
@@ -389,20 +408,21 @@ describe('retained finished children', () => {
   });
 
   it('writes the terminal status of a child detached from its parent', async () => {
-    const { backend } = createRecordingBackend();
+    const target = createListeningBackend();
+    const { backend } = target;
     seedParent(backend);
     const childStreamId = 'detached-stream' as StreamTabId;
 
-    applyRoster(backend, PARENT, [subagent('detached', { childStreamId })]);
+    applyRoster(target, PARENT, [subagent('detached', { childStreamId })]);
     // Detaching promotes a running subagent to top-level: the parent link goes
     // away and the roster drops the row, but the child keeps running and
     // finishes later. The row is found by its own childStreamId, so the phase
     // still lands.
-    backend.applySessionFact({
+    emitSessionFact(target, {
       type: 'setParentStream',
       payload: { childStreamId, parentStreamId: null },
     });
-    applyRoster(backend, PARENT, []);
+    applyRoster(target, PARENT, []);
 
     await backend.applyStreamStatus(childStreamId, STREAM_PHASE.COMPLETED);
 
@@ -415,7 +435,8 @@ describe('retained finished children', () => {
   });
 
   it('caps retained rows, evicting the oldest and keeping every live one', () => {
-    const { backend } = createRecordingBackend();
+    const target = createListeningBackend();
+    const { backend } = target;
     // Mirrors RETAINED_FINISHED_CHILDREN_CAP in SessionFactApplier.
     const cap = 200;
     const overflow = 5;
@@ -424,8 +445,8 @@ describe('retained finished children', () => {
 
     for (let i = 0; i < cap + overflow; i += 1) {
       vi.spyOn(Date, 'now').mockReturnValue(1_000 + i);
-      applyRoster(backend, PARENT, [live, subagent(`child-${i}`)]);
-      applyRoster(backend, PARENT, [live]);
+      applyRoster(target, PARENT, [live, subagent(`child-${i}`)]);
+      applyRoster(target, PARENT, [live]);
     }
     vi.restoreAllMocks();
 
@@ -442,12 +463,13 @@ describe('retained finished children', () => {
   });
 
   it('clears retained rows when the stream re-enters running', async () => {
-    const { backend } = createRecordingBackend();
+    const target = createListeningBackend();
+    const { backend } = target;
     seedParent(backend);
     const live = subagent('live');
 
-    applyRoster(backend, PARENT, [live, subagent('done')]);
-    applyRoster(backend, PARENT, [live]);
+    applyRoster(target, PARENT, [live, subagent('done')]);
+    applyRoster(target, PARENT, [live]);
     expect(backend.state.getStreamState(PARENT)?.subagents).toHaveLength(2);
 
     await backend.applyStreamStatus(
@@ -460,7 +482,8 @@ describe('retained finished children', () => {
   });
 
   it('does not retain vanished process children — they are ephemeral', () => {
-    const { backend } = createRecordingBackend();
+    const target = createListeningBackend();
+    const { backend } = target;
     seedParent(backend);
     const agent = subagent('reviewer', {
       identity: { kind: 'agent', agent: 'reviewer' },
@@ -470,8 +493,8 @@ describe('retained finished children', () => {
       identity: { kind: 'process', tool: 'bash' },
     });
 
-    applyRoster(backend, PARENT, [agent, bash]);
-    applyRoster(backend, PARENT, []);
+    applyRoster(target, PARENT, [agent, bash]);
+    applyRoster(target, PARENT, []);
 
     const roster = parentRoster(backend);
     expect(roster).toHaveLength(1);

--- a/src/test-kernel/progressView/progressBackendHarness.ts
+++ b/src/test-kernel/progressView/progressBackendHarness.ts
@@ -14,6 +14,7 @@ import type {
   DeleteExecutionResult,
 } from '@agent/storage/executionListing';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import type { SessionFact } from '@agent/runtime/SessionEventHub';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   ProgressBackend,
@@ -167,6 +168,13 @@ export function emitRunEvent(
   event: AgentEvent,
 ): void {
   target.session.events.emit({ scope: 'run', streamId, event });
+}
+
+export function emitSessionFact(
+  target: { session: SessionHandle },
+  event: SessionFact,
+): void {
+  target.session.events.emit({ scope: 'session', event });
 }
 
 export function emitActiveStream(


### PR DESCRIPTION
Closes #10619

## Summary

The B4 follow-up decision from #10611: convert, don't keep. `ProgressBackend.applySessionFact` and `applyRunFact` were the last two test-only fact seeds (zero production callers, verified by grep at the merge base); both suites that consumed them now drive facts through the same synchronous `SessionEventHub` rail production uses, and both methods are deleted. `applyStreamStatus` stays as the documented awaitable status seed — hub emit is fire-and-forget and cannot hand back the `setStreamStatus` promise (the failure mode that protected it in #10611).

- `progressBackendHarness.ts`: new `emitSessionFact(target, fact)` helper next to `emitRunEvent` — a typed session-scope emission over `session.events`.
- `ProgressBackendRetainedChildren.vitest.ts`: every test now builds an isolated listening backend (suite-local `createListeningBackend()`, mirroring the FactProjection idiom); `applyRoster` emits `child.activity` through the hub (30 call sites); the `setParentStream` seed becomes `emitSessionFact`.
- `ProgressBackendFactProjection.vitest.ts`: the `conversation.progress` buffer-drop test and the rejecting-`status` logging test emit through the hub via `createListeningBackend()` + `emitRunEvent`/`emitSessionFact`.
- `ProgressBackend.ts`: `applySessionFact`/`applyRunFact` deleted; the `applyStreamStatus` docstring now records why it is the only remaining seed.
- New `progressBackendFactSeedRetirement.vitest.ts` architecture pin: the retired seed names stay off `ProgressBackend` while the documented `applyStreamStatus` remains.

No waits were added anywhere: hub `emit` is synchronous and all four exercised handlers (`child.activity`, `conversation.progress`, `setParentStream`, `status`) dispatch synchronously through the same `withEventErrorHandling` wrapper the seeds invoked directly, so converted tests assert exactly what they asserted before (the status-rejection test keeps its pre-existing `vi.waitFor`). The #10611 flaky hub-wait hazard is specific to awaiting `setStreamStatus` under fake timers and does not transfer.

## Net elements (R6)

**Files**: 0 deleted, 1 added (`src/test-kernel/architecture/progressBackendFactSeedRetirement.vitest.ts`).

**Exported symbols**: `git diff | grep -E '^[+-]export'` → **1 added, 0 deleted**
- `export function emitSessionFact` (test-kernel harness; no production export touched)

**Methods that cease to exist** (2 elements):

| # | Element | Kind |
|---|---|---|
| 1 | `ProgressBackend.applySessionFact` | test-only seed method (its mirrored `handleStreamPresentationRequest` branch was test-dead: neither remaining seed call was `setActiveStream`) |
| 2 | `ProgressBackend.applyRunFact` | test-only pass-through method |

**Net LoC**: `git diff --numstat origin/main...HEAD`

| Scope | + | − | net |
|---|---|---|---|
| Production (`src/controllers`) | 6 | 17 | **−11** |
| Tests (`src/test-kernel`) | 117 | 55 | **+62** |
| **Total** | **123** | **72** | **−51** |

The test-side growth is the migration itself: each RetainedChildren test now names its hub `target`, matching the existing FactProjection idiom.

## Consumer counts (R8)

No emit path changed; the production listener bodies in `setupEventListeners()` are untouched. Grepped consumer counts per deleted surface at the merge base:

| Deleted surface | Consumers before | Where they went |
|---|---|---|
| `ProgressBackend.applyRunFact` | **0 production**; 31 test calls (30 through the `applyRoster` helper in `ProgressBackendRetainedChildren.vitest.ts`, 1 direct in `ProgressBackendFactProjection.vitest.ts:1048`) | `applyRoster` now emits `child.activity` via `emitRunEvent`; the direct site emits `conversation.progress` the same way |
| `ProgressBackend.applySessionFact` | **0 production**; 2 test calls (`setParentStream` in `ProgressBackendRetainedChildren.vitest.ts:401`, rejecting-`status` in `ProgressBackendFactProjection.vitest.ts:1107`) | both now `emitSessionFact` through the hub |

Kept surface: `ProgressBackend.applyStreamStatus` — 9 test calls (5 FactProjection, 4 RetainedChildren), 0 production; the documented awaitable seed for callers that cannot fire-and-forget.

## Host impact

None. Extension (`ProgressViewProvider`) and desktop (`desktopAgentExecution`) already attach the hub listeners via `setupEventListeners()` and never called either seed (verified: zero `applySessionFact`/`applyRunFact` references in `packages/**` at the merge base). CLI does not consume these surfaces.

## Test impact

Same assertions, same count: both converted suites pass 35/35, matching the pre-change baseline at the merge base. The new architecture pin adds 2 tests. Full `src/test-kernel/progressView/` directory: 59 files, 556/556 green.

## Verification

- `vitest run src/test-kernel/progressView/` — 556/556 (59 files)
- `vitest run src/test-kernel/architecture/` — 104/104 (18 files, incl. the new pin)
- `npm run typecheck` — all six legs (workspace, test-kernel, agent, cli, trace-viewer, desktop)
- eslint on all five changed files — clean
- `prettier --check` on all five changed files — clean
- `check:dead-code-ratchet` — 8 findings vs 8 baselined, no new
- `check:tsconfig-paths`, `check:browser-safe-utils`, `check:guidance-refs` — green
- Final grep: no `applySessionFact`/`applyRunFact` references remain in `src/`, `packages/`, `config/`, or `scripts/` (one mention survives in the dated 2026-08-07 triage doc, a point-in-time historical record)
