### PR TITLE
docs(guidance): make the anti-over-testing budget explicit for agents

### DIFF
--- a/.github/prompts/issue-tracker-prompt.md
+++ b/.github/prompts/issue-tracker-prompt.md
@@ -65,6 +65,13 @@ Do not create issues for:
 - Nitpick-level comments.
 - Speculative future work not discussed in the pull request.
 - Bot suggestions already addressed or dismissed.
+- Test-coverage suggestions ("add tests for X", "increase coverage", missing
+  test remarks from reviewers or bots). This repository deliberately keeps its
+  test surface small because internal interfaces break often — see `AGENTS.md`
+  "Testing discipline". File a test follow-up only for a gap the pull request
+  acknowledged and deferred: a reproduced defect that merged without its
+  regression test, or a consequential contract (wire, schema, user-visible
+  output) the diff leaves unprotected.
 
 For each genuine follow-up, create an issue with:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,13 +170,34 @@ frozen deep-import lists, not another lint rule.
 
 ### Testing discipline
 
-Tests are production maintenance work. Add them when they protect a consequential
-current contract, a difficult invariant, or a reproduced defect. Do not create
-tests for speculative abstractions, trivial data plumbing, implementation details,
-or compatibility behavior that the product does not intend to preserve. Prefer a
-small behavioral test at the true boundary over repeated unit tests of pass-through
-layers. When code or a historical format is retired, delete tests and fixtures that
-exist only for that retired behavior instead of rewriting them around the new
+Tests are production maintenance work, and this project breaks internal
+interfaces often and on purpose. A test pinned to a seam that is about to churn
+is not safety — it is merge friction the next refactor has to pay down. The
+default for a PR is **zero new tests**; a test must earn its place — protecting
+a consequential current contract, a difficult invariant, or a reproduced
+defect — and is never proof of work or PR padding. Concretely:
+
+- A behavior-preserving refactor adds no new tests; the existing suite passing
+  is the evidence.
+- A bug fix gets at most one regression test that reproduces the defect, at the
+  narrowest boundary that exhibits it.
+- A new feature gets a small number of behavioral tests at its durable
+  boundary — the wire contract, the schema, the user-visible output — not a
+  unit test for each internal layer the data passes through.
+- Extend the module's existing suite rather than adding a new test file. Add
+  one only when the module has no existing suite (one suite per module,
+  path-mirrored under `src/test-kernel/`) or for one named cross-module
+  scenario, stated in the PR body. Collapse 4+ structurally identical cases
+  into `test.each`.
+- Do not test what `npm run typecheck` or a Zod schema already guarantees, and
+  do not create tests for speculative abstractions, trivial data plumbing,
+  implementation details, or compatibility behavior that the product does not
+  intend to preserve.
+
+The same discipline applies in review: do not ask an author to add tests unless
+the diff leaves a consequential contract or reproduced defect unprotected. When
+code or a historical format is retired, delete tests and fixtures that exist
+only for that retired behavior instead of rewriting them around the new
 implementation.
 
 ### Zod v4 Schema Patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,13 @@ not exist here — read the file rather than upstream docs.
 - **Exports are contracts.** A new export needs a consumer in the same PR;
   `npm run check:dead-code-ratchet` enforces it against
   `config/ratchets/knip-baseline.json`.
+- **Tests are a budget, not proof of work.** Internal interfaces here break
+  often by design, so every test pinned to a churning seam is merge friction,
+  not safety. Default for a PR is zero new tests: a behavior-preserving
+  refactor adds none, a bug fix gets at most one regression test and only if
+  it earns its place, a feature gets a few at its durable boundary. Extend
+  existing suites instead of adding files, and don't demand tests in review
+  beyond this bar. Full rules: AGENTS.md "Testing discipline".
 - **Serialize async work with `p-queue`**, never a hand-rolled promise chain.
 
 Full rationale and the evidence behind each: AGENTS.md "Design and


### PR DESCRIPTION
## Why

Agents over-test: PRs arrive padded with tests as proof of work, review bots ask for more, and the follow-up tracker turns "add tests for X" remarks into issues that agents then implement. In this repo internal interfaces break often and on purpose, so tests pinned to churning seams are merge friction, not safety — they slow PR review and get rewritten or deleted on the next refactor.

## What

- **AGENTS.md "Testing discipline"** — keeps the existing rules but makes the budget explicit: the default for a PR is **zero new tests**; a behavior-preserving refactor adds none, a bug fix gets at most one regression test at the narrowest boundary, a feature gets a few behavioral tests at its durable boundary (wire contract / schema / user-visible output). Extend existing suites; a new suite is allowed only when the module has none (one suite per module, path-mirrored under `src/test-kernel/`) or for one named cross-module scenario, stated in the PR body — mirroring R7. Don't re-test what typecheck or a Zod schema guarantees. Adds the review-side bar: don't ask authors for tests beyond this.
- **CLAUDE.md** — new design guardrail "Tests are a budget, not proof of work" pointing at the full AGENTS.md rules, keeping the conditional budget ("a bug fix gets at most one regression test and only if it earns its place"). CLAUDE.md is the file every agent actually loads; testing discipline previously lived only in AGENTS.md.
- **.github/prompts/issue-tracker-prompt.md** (Playbook B2) — adds routine test-coverage suggestions ("add tests for X", "increase coverage") to the "do not create issues for" list. A test follow-up is filed only for a gap the PR acknowledged and deferred: a reproduced defect that merged without its regression test, or a consequential contract (wire, schema, user-visible output) the diff leaves unprotected.

Consistent with the existing R7 test budget in the code-review checklist (`.claude/skills/code-review/references/review-checklist.md` §14); this makes the same discipline visible at authoring time, not just review time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcABH4LXmXTw5952fnLr8E
