### PR TITLE
docs(agent): document one-way compatibility of the stable-attempt schema

### DIFF
--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -104,10 +104,17 @@ return await parallel(
   gap without repeating model work. Each stable child attempt records a
   reservation before registration and a launch marker before model work, so a
   failed registration can advance safely while an uncertain launched child is
-  never repeated. The parent records the complete attempt sequence, so deleting
-  an earlier child cannot hide a later completed result. A parent execution has
-  one active runtime owner; the execution KV store is durable state, not a
-  cross-process lock. Checkpoints use the strict version-3 schema; malformed or
+  never repeated. A completed child is recovered only through its
+  committed marker, written after the artifact drain and before lease release;
+  lease absence alone never attests durable completion. The parent records the
+  complete attempt sequence, so deleting an earlier child cannot hide a later
+  completed result. A parent execution has one active runtime owner; the
+  execution KV store is durable state, not a cross-process lock. Stable-attempt
+  state is one-way compatible at a fixed schema version: every legacy v1 phase
+  stays readable, but readers predating the committed phase reject newer
+  markers outright, downgrade or mixed-version recovery is unsupported, and
+  unknown present values fail closed rather than being defaulted or coerced.
+  Checkpoints use the strict version-3 schema; malformed or
   older records fail instead of being translated into the current journal.
 - **Cost ownership**: child costs remain in the persisted typed results. The
   future tool surface must aggregate the final journal at its tool-result

--- a/src/tools/delegation/stableSubagentAttempt.ts
+++ b/src/tools/delegation/stableSubagentAttempt.ts
@@ -5,6 +5,11 @@ import { z } from 'zod';
 import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
 import { ExecutionIdSchema, type ExecutionId } from '@shared/schemas';
 
+// Version stays 1 across the `committed` phase addition by decision (#10663):
+// legacy v1 markers (reserved/launched/retryable) remain readable here, while
+// pre-#10646 readers sharing this KV state reject a `committed` marker at
+// parse time — downgrade or mixed-version recovery is unsupported. A present
+// but unknown version or phase fails closed: no defaults, no coercion.
 const STABLE_SUBAGENT_STATE_SCHEMA_VERSION = 1;
 const STABLE_SUBAGENT_ATTEMPT_KV_KEY = 'stable-subagent-attempt';
 const STABLE_SUBAGENT_SEQUENCE_KEY_PREFIX = 'stable-subagent-sequence-';


### PR DESCRIPTION
## Summary

Resolves the #10646 follow-up by taking the issue's second option: document the intentional one-way compatibility of the stable-subagent-attempt KV schema instead of bumping `STABLE_SUBAGENT_STATE_SCHEMA_VERSION`. Downgraded or mixed-version hosts sharing this workspace KV state are not a supported recovery topology, so cross-version reads are a known, intentional rejection rather than a bug.

- `src/tools/delegation/stableSubagentAttempt.ts` — schema-level comment recording the decision: the version stays 1 across the `committed` phase addition; legacy v1 phases (`reserved`/`launched`/`retryable`) remain readable; pre-#10646 readers sharing this KV state reject a `committed` marker at parse time; downgrade/mixed-version recovery is unsupported; a present-but-unknown version or phase fails closed with no defaults and no coercion.
- `src/agent/workflowScript/README.md` — the durable-state ("Restart-safe checkpoints") section now names the committed marker (written after the artifact drain and before lease release; lease absence alone never attests completion), restates the single active runtime owner per parent execution, and records the one-way incompatibility at a fixed schema version.

Documentation-only per maintainer direction (overtesting concern): no test files are touched. The documented behavior is already pinned by the existing `DelegationHeadless.vitest.ts` recovery coverage (committed recovery, retry/reserved advance, reconciliation refusals), and the fail-closed path falls out of the strict `z.literal`/`z.enum` schema with no `.catch`/defaults.

Closes #10663

## Test plan

- `vitest run src/test-kernel/tools/DelegationHeadless.vitest.ts` — 45/45 passed
- `npm run typecheck:workspace` and `npm run typecheck:test-kernel` — clean
- `eslint` on the changed source file — clean; `prettier --check` and `git diff --check` — clean
- Open-PR overlap audit (12 open PRs): none touch the two changed files
