### PR TITLE
refactor(agent): deduplicate provider-message-block switch logic behind shared classifier (#10624)

### DIFF
--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -21,7 +21,10 @@ import {
   isFunctionCallOutputItem,
   isResponseFunctionToolCallItem,
 } from '@agent/modelHandlers/openai/responsesShapeGuards';
-import { CONVERSATION_BLOCK_TYPES } from '@agent/types/ConversationBlockTypes';
+import {
+  classifyProviderMessageBlockType,
+  CONVERSATION_BLOCK_TYPES,
+} from '@agent/types/ConversationBlockTypes';
 import {
   ANTHROPIC_SERVER_TOOL_BLOCK_TYPES,
   extractWebFetchResultFields,
@@ -235,20 +238,19 @@ function googlePartToBlocks(part: Part): ContentBlock[] {
 function blocksToUserParts(blocks: ContentBlock[]): UserPart[] {
   const parts: UserPart[] = [];
   for (const b of blocks) {
-    switch (b.type) {
-      // Anthropic: 'text', OpenAI Response API: 'input_text'
-      case 'text':
-      case 'input_text':
-        if (b.text) parts.push({ type: 'text', text: b.text });
-        break;
-      case CONVERSATION_BLOCK_TYPES.image:
-      case CONVERSATION_BLOCK_TYPES.inputImage:
-      case CONVERSATION_BLOCK_TYPES.imageUrl:
+    // Anthropic: 'text', OpenAI Response API: 'input_text'. Text tags stay
+    // per-literal (user text is 'text'/'input_text' here but assistant text
+    // is 'text'/'output_text' in `assistantBlockToNode`), so they are not in
+    // the shared classifier — see `@agent/types/ConversationBlockTypes`.
+    if (b.type === 'text' || b.type === 'input_text') {
+      if (b.text) parts.push({ type: 'text', text: b.text });
+      continue;
+    }
+    switch (classifyProviderMessageBlockType(b.type)) {
+      case 'image-attachment':
         parts.push({ type: 'attachment', attachmentType: 'image' });
         break;
-      case CONVERSATION_BLOCK_TYPES.document:
-      case CONVERSATION_BLOCK_TYPES.inputFile:
-      case CONVERSATION_BLOCK_TYPES.file:
+      case 'document-attachment':
         parts.push({ type: 'attachment', attachmentType: 'document' });
         break;
       default:
@@ -259,76 +261,102 @@ function blocksToUserParts(blocks: ContentBlock[]): UserPart[] {
 }
 
 function extractToolResultText(block: ContentBlock): string | undefined {
-  switch (block.type) {
-    case CONVERSATION_BLOCK_TYPES.toolResult:
-      return typeof block.content === 'string'
-        ? block.content
-        : prettyJson(block.content);
-    // Anthropic: 'text', OpenAI Response API: 'input_text'
-    case 'text':
-    case 'input_text':
-      return block.text || undefined;
-    default:
-      return undefined;
+  // Anthropic: 'text', OpenAI Response API: 'input_text'
+  if (block.type === 'text' || block.type === 'input_text') {
+    return block.text || undefined;
   }
+  if (classifyProviderMessageBlockType(block.type) !== 'tool-result') {
+    return undefined;
+  }
+  const toolResult =
+    asClassifiedBlock<typeof CONVERSATION_BLOCK_TYPES.toolResult>(block);
+  return typeof toolResult.content === 'string'
+    ? toolResult.content
+    : prettyJson(toolResult.content);
 }
 
-// Non-text tags are shared with the `formatConversationBlock` switch in
-// `@agent/storage/conversationFormat` via `CONVERSATION_BLOCK_TYPES`
-// (`@agent/types/ConversationBlockTypes`) and `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES`
-// (`@agent/types/ServerTools`) — both switches must recognize the same
-// tags, just into different output shapes (a structured `ExportNode` here
-// vs. a truncated marker string there).
+/**
+ * Re-narrow a `ContentBlock` to the variant behind a tag the shared
+ * classifier recognized. The classifier establishes tag → category; inside a
+ * category case the tag is known, but TypeScript cannot propagate that back
+ * to the block's variant, so each case re-anchors it here.
+ */
+function asClassifiedBlock<T extends ContentBlock['type']>(
+  block: ContentBlock,
+): Extract<ContentBlock, { type: T }> {
+  return block as Extract<ContentBlock, { type: T }>;
+}
+
+// Non-text tag classification is shared with `formatConversationBlock` in
+// `@agent/storage/conversationFormat` via `classifyProviderMessageBlockType`
+// (`@agent/types/ConversationBlockTypes`) — one switch recognizes the tags;
+// each module maps the category into its own output shape (a structured
+// `ExportNode` here vs. a truncated marker string there).
 function assistantBlockToNode(block: ContentBlock): ExportNode | null {
-  switch (block.type) {
-    case CONVERSATION_BLOCK_TYPES.thinking:
-    case CONVERSATION_BLOCK_TYPES.redactedThinking:
+  // Anthropic: 'text', OpenAI Response API: 'output_text'. Text tags stay
+  // per-literal (see `blocksToUserParts` for the user-side split).
+  if (block.type === 'text' || block.type === 'output_text') {
+    return block.text?.trim()
+      ? { kind: 'assistant-text', text: block.text }
+      : null;
+  }
+
+  switch (classifyProviderMessageBlockType(block.type)) {
+    case 'thinking':
       return null;
 
-    // Anthropic: 'text', OpenAI Response API: 'output_text'
-    case 'text':
-    case 'output_text':
-      return block.text?.trim()
-        ? { kind: 'assistant-text', text: block.text }
-        : null;
-
-    case CONVERSATION_BLOCK_TYPES.toolUse:
+    case 'tool-use': {
+      const toolUse =
+        asClassifiedBlock<typeof CONVERSATION_BLOCK_TYPES.toolUse>(block);
       return {
         kind: 'tool-call',
-        name: block.name ?? 'unknown',
-        input: prettyJson(block.input ?? {}),
+        name: toolUse.name ?? 'unknown',
+        input: prettyJson(toolUse.input ?? {}),
       };
+    }
 
-    case CONVERSATION_BLOCK_TYPES.toolResult:
+    case 'tool-result': {
+      const toolResult =
+        asClassifiedBlock<typeof CONVERSATION_BLOCK_TYPES.toolResult>(block);
       return {
         kind: 'tool-result',
         text:
-          typeof block.content === 'string'
-            ? block.content
-            : prettyJson(block.content ?? ''),
+          typeof toolResult.content === 'string'
+            ? toolResult.content
+            : prettyJson(toolResult.content ?? ''),
       };
+    }
 
     // Anthropic server-side tool blocks (the provider executes these, not a
     // local tool handler).
-    case ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.serverToolUse:
-      if (block.name === 'web_search') {
+    case 'server-tool-use': {
+      const serverToolUse =
+        asClassifiedBlock<
+          typeof ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.serverToolUse
+        >(block);
+      if (serverToolUse.name === 'web_search') {
         const query =
-          block.input && typeof block.input === 'object'
-            ? (block.input as { query?: string }).query
+          serverToolUse.input && typeof serverToolUse.input === 'object'
+            ? (serverToolUse.input as { query?: string }).query
             : undefined;
         return query ? { kind: 'web-search', query } : null;
       }
       return null;
+    }
 
-    case ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webSearchToolResult: {
-      if (!Array.isArray(block.content)) return null;
-      const results = block.content
+    case 'web-search-tool-result': {
+      const webSearchResult =
+        asClassifiedBlock<
+          typeof ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webSearchToolResult
+        >(block);
+      if (!Array.isArray(webSearchResult.content)) return null;
+      const results = webSearchResult.content
         .filter((e) => e.type === 'web_search_result' && e.url)
         .map((e) => ({ title: e.title ?? e.url!, url: e.url! }));
       return results.length ? { kind: 'web-search-results', results } : null;
     }
 
-    case ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webFetchToolResult: {
+    case 'web-fetch-tool-result': {
       const result = extractWebFetchResultFields(block);
       if (!result) return null;
       return {

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -22,11 +22,11 @@
  * truncation for the CLI). Provider-native message and content recognition is
  * shared here.
  */
-import { CONVERSATION_BLOCK_TYPES } from '@agent/types/ConversationBlockTypes';
 import {
-  ANTHROPIC_SERVER_TOOL_BLOCK_TYPES,
-  extractWebFetchResultFields,
-} from '@agent/types/ServerTools';
+  classifyProviderMessageBlockType,
+  CONVERSATION_BLOCK_TYPES,
+} from '@agent/types/ConversationBlockTypes';
+import { extractWebFetchResultFields } from '@agent/types/ServerTools';
 import { isObject } from '@utils/core';
 
 const DEFAULT_TRUNCATION_MARKER = '...';
@@ -260,29 +260,26 @@ function formatConversationBlock(
     );
   }
 
-  // Non-text tags are shared with the `assistantBlockToNode` switch in
-  // `@agent/export/normalizeConversation` via `CONVERSATION_BLOCK_TYPES`
-  // (`@agent/types/ConversationBlockTypes`) and `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES`
-  // (`@agent/types/ServerTools`) — both switches must recognize the same
-  // tags, just into different output shapes (a truncated marker string here
-  // vs. a structured `ExportNode` there). `text`/`input_text`/`output_text`
-  // are the exception: they're caught by the duck-typed `block.text` check
-  // above, not by an explicit case here.
-  switch (block.type) {
-    case 'text':
-      // A recognized text block whose `text` failed the duck-type check
-      // above (missing/non-string) — render empty, not its JSON form.
-      return truncate(asText(block.text), options.textLimit, options);
-    case CONVERSATION_BLOCK_TYPES.image:
-    case CONVERSATION_BLOCK_TYPES.imageUrl:
-    case CONVERSATION_BLOCK_TYPES.inputImage:
+  // A recognized text block whose `text` failed the duck-type check above
+  // (missing/non-string) — render empty, not its JSON form. Only the literal
+  // `text` tag gets this treatment: `input_text`/`output_text` are not
+  // classified (see `@agent/types/ConversationBlockTypes`) and fall through
+  // to the JSON dump below.
+  if (block.type === 'text') {
+    return truncate(asText(block.text), options.textLimit, options);
+  }
+
+  // Non-text tag classification is shared with `assistantBlockToNode` in
+  // `@agent/export/normalizeConversation` via `classifyProviderMessageBlockType`
+  // (`@agent/types/ConversationBlockTypes`) — one switch recognizes the tags;
+  // each module maps the category into its own output shape (a truncated
+  // marker string here vs. a structured `ExportNode` there).
+  switch (classifyProviderMessageBlockType(block.type)) {
+    case 'image-attachment':
       return '[image attachment]';
-    case CONVERSATION_BLOCK_TYPES.document:
-    case CONVERSATION_BLOCK_TYPES.file:
-    case CONVERSATION_BLOCK_TYPES.inputFile:
+    case 'document-attachment':
       return '[document attachment]';
-    case CONVERSATION_BLOCK_TYPES.thinking:
-    case CONVERSATION_BLOCK_TYPES.redactedThinking:
+    case 'thinking':
       return options.hideProviderReasoning
         ? ''
         : truncate(
@@ -290,25 +287,25 @@ function formatConversationBlock(
             options.toolBlockLimit,
             options,
           );
-    case CONVERSATION_BLOCK_TYPES.toolUse:
+    case 'tool-use':
       return formatToolUseMarker(
         asText(block.name) || 'unknown',
         block.input,
         options,
       );
-    case CONVERSATION_BLOCK_TYPES.toolResult:
+    case 'tool-result':
       return formatToolResultMarker(block.content, options);
     // Anthropic server-side tool blocks (the provider executes these, not a
     // local tool handler).
-    case ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.serverToolUse:
+    case 'server-tool-use':
       return formatToolUseMarker(
         asText(block.name) || 'unknown',
         block.input,
         options,
       );
-    case ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webSearchToolResult:
+    case 'web-search-tool-result':
       return formatWebSearchResultMarker(block.content, options);
-    case ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webFetchToolResult:
+    case 'web-fetch-tool-result':
       return formatWebFetchResultMarker(block, options);
     default:
       return truncate(

--- a/src/agent/types/ConversationBlockTypes.ts
+++ b/src/agent/types/ConversationBlockTypes.ts
@@ -1,5 +1,5 @@
 /**
- * Shared provider content-block `type` tag vocabulary.
+ * Shared provider content-block `type` tag vocabulary and classification.
  *
  * Single source of truth for the non-server-tool block-type literals that
  * both `assistantBlockToNode`/`ContentBlockSchema`
@@ -13,19 +13,30 @@
  * instead of at compile time. Importing from here instead of repeating the
  * strings turns that drift into a single edit site.
  *
+ * `classifyProviderMessageBlockType` below is the one switch that maps each
+ * of those tags (and the three server-tool tags) to its canonical
+ * {@link ProviderMessageBlockCategory}; both consumers switch on the
+ * category and differ only in how they RENDER it (a truncated marker string
+ * in conversationFormat vs. a structured `ExportNode` in
+ * normalizeConversation).
+ *
  * `text`/`input_text`/`output_text` are deliberately NOT included: those are
  * genuinely handled differently in the two consumers (normalizeConversation
  * distinguishes user vs. assistant text roles per literal; conversationFormat
  * recognizes them structurally via a `typeof block.text === 'string'` check
  * that runs before its `type` switch, not via an explicit case per literal),
  * so unifying them here would encode a symmetry that doesn't actually hold.
+ * For the same reason the classifier returns `undefined` for them (and for
+ * any unrecognized tag), leaving each consumer's own fallback in place.
  *
  * The three Anthropic server-tool block types (`server_tool_use`,
  * `web_search_tool_result`, `web_fetch_tool_result`) are the same kind of
  * shared vocabulary but already live in
  * `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES` (`@agent/types/ServerTools`) —
- * not duplicated here.
+ * imported here for classification, not duplicated.
  */
+import { ANTHROPIC_SERVER_TOOL_BLOCK_TYPES } from '@agent/types/ServerTools';
+
 export const CONVERSATION_BLOCK_TYPES = Object.freeze({
   // Anthropic and Google GenAI extended-thinking / thought blocks.
   thinking: 'thinking',
@@ -48,3 +59,59 @@ export const CONVERSATION_BLOCK_TYPES = Object.freeze({
   inputFile: 'input_file',
   file: 'file',
 } as const);
+
+/**
+ * Canonical classification of a provider message block's non-text `type`
+ * tag. Both consumer switches — `formatConversationBlock`
+ * (`@agent/storage/conversationFormat`) and
+ * `assistantBlockToNode`/`blocksToUserParts`/`extractToolResultText`
+ * (`@agent/export/normalizeConversation`) — must recognize the same tags;
+ * this is the one place that maps each tag to its category, and each
+ * consumer maps the category into its own output shape (a truncated marker
+ * string vs. a structured `ExportNode`).
+ */
+export type ProviderMessageBlockCategory =
+  | 'image-attachment'
+  | 'document-attachment'
+  | 'thinking'
+  | 'tool-use'
+  | 'tool-result'
+  | 'server-tool-use'
+  | 'web-search-tool-result'
+  | 'web-fetch-tool-result';
+
+/**
+ * Map a raw provider message block's `type` tag to its
+ * {@link ProviderMessageBlockCategory}, or `undefined` when the tag is a
+ * text literal (`text`/`input_text`/`output_text` — deliberately handled
+ * per-consumer, see the module docstring) or is unrecognized.
+ */
+export function classifyProviderMessageBlockType(
+  type: unknown,
+): ProviderMessageBlockCategory | undefined {
+  switch (type) {
+    case CONVERSATION_BLOCK_TYPES.image:
+    case CONVERSATION_BLOCK_TYPES.imageUrl:
+    case CONVERSATION_BLOCK_TYPES.inputImage:
+      return 'image-attachment';
+    case CONVERSATION_BLOCK_TYPES.document:
+    case CONVERSATION_BLOCK_TYPES.file:
+    case CONVERSATION_BLOCK_TYPES.inputFile:
+      return 'document-attachment';
+    case CONVERSATION_BLOCK_TYPES.thinking:
+    case CONVERSATION_BLOCK_TYPES.redactedThinking:
+      return 'thinking';
+    case CONVERSATION_BLOCK_TYPES.toolUse:
+      return 'tool-use';
+    case CONVERSATION_BLOCK_TYPES.toolResult:
+      return 'tool-result';
+    case ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.serverToolUse:
+      return 'server-tool-use';
+    case ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webSearchToolResult:
+      return 'web-search-tool-result';
+    case ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webFetchToolResult:
+      return 'web-fetch-tool-result';
+    default:
+      return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up from #10348's structural-debt audit: the provider-message-block `type`-tag switch was duplicated between `formatConversationBlock` (`src/agent/storage/conversationFormat.ts`) and `assistantBlockToNode` / `blocksToUserParts` / `extractToolResultText` (`src/agent/export/normalizeConversation.ts`) — the same 13 tag literals (10 `CONVERSATION_BLOCK_TYPES` + 3 `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES`) grouped into the same buckets in both files, cross-documented as a known coupling but never consolidated.

This PR extracts the tag → category mapping as `classifyProviderMessageBlockType` in `@agent/types/ConversationBlockTypes` — the module that already owns the shared tag vocabulary for exactly these two consumers, and the only module both already imported. Both consumers now switch on the returned `ProviderMessageBlockCategory` and keep only their own rendering: truncated marker strings for storage/conversation views, structured `ExportNode`s for chat export.

Behavior is preserved byte-for-byte (storage serialization) and shape-for-shape (export normalization):

- Every case body keeps its original expression verbatim; only the dispatch changed (13-literal tag switch → 8-category switch).
- The literal `'text'` arm is hoisted ahead of the classifier in both consumers, because `text`/`input_text`/`output_text` deliberately stay unclassified — they are role-split per literal (user text is `'text'`/`'input_text'`, assistant text is `'text'`/`'output_text'`) and `conversationFormat` recognizes them structurally via its duck-typed `block.text` check. Unifying them would encode a symmetry that doesn't hold (already documented in the module).
- Each consumer's provider-specific pre-passes are untouched: the VS Code LM `kind` switch, the duck-typed `text` check, attachment mime sniffing (`inlineData`/`fileData`/`image_url`/`source`), and Google `functionCall`/`functionResponse`/`thought` handling. Several of these deliberately diverge between the two modules (e.g. a Google `thought` part renders as text in storage views but is suppressed in export; a `{type: 'image'}` block with no mime fields mime-sniffs to `[document attachment]` in storage views but exports as an image attachment) — a scratch equivalence corpus confirmed each divergence survives the refactor (see Validation).

Closes #10624

## Issue acceptance gates

- [x] Extract the duplicated per-provider message-block logic into one shared implementation and have both modules consume it.
- [x] Storage serialization and export normalization behavior remain identical (behavior-preserving refactor).

## Single source of truth

`classifyProviderMessageBlockType` (`src/agent/types/ConversationBlockTypes`) is the one switch that knows which non-text `type` tags exist and how they group. Adding a member to `CONVERSATION_BLOCK_TYPES` without classifying it there fails the existing `ConversationBlockTypeParity` coverage guard (unmodified in this PR). That guard spans only the ten `CONVERSATION_BLOCK_TYPES` members, though — it does not iterate `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES`, so a new server-tool tag added there without a classifier arm would not fail any test today; it would silently hit both consumers' default arms (JSON dump in storage views, dropped in export). The three current server-tool tags' rendering is pinned on both sides by the unmodified consumer suites (`ExecutionsConversationFormat`'s `server_tool_use`/`web_search_tool_result`/`web_fetch_tool_result` marker tests, `normalizeConversation`'s web-search/web-fetch/server-tool tests).

## Duplication and abstraction budget

Removed: the duplicated 13-tag grouping across the two consumer switches (and the drift-prone cross-file comments describing it). Added: one function + one type alias in an existing module — no new file, no new abstraction layer, no new dependency edge (`ConversationBlockTypes` now imports the sibling `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES` table from `@agent/types/ServerTools`; one direction only, no cycle, both files stay inside the `agent` subsystem).

Deliberately NOT unified: the text tags (role-split, above); the 3-literal VS Code LM `kind` switch, whose field extraction genuinely differs per consumer (`asText(name) || 'unknown'` marker rendering vs. `ContentBlock` synthesis for the IR); and the per-consumer pre-passes listed in the Summary.

## Net elements (R6)

- Files: 3 modified, 0 added, 0 deleted. Production-only; no test changes (maintainer direction: existing suites already cover this surface).
- Exported symbols: +2 (`classifyProviderMessageBlockType`, `ProviderMessageBlockCategory`), -0 → net +2; both are consumed immediately by the two existing call-site modules.
- Classes/interfaces/enums: +0 (one function, one type alias).
- Net LoC (source, `git diff --numstat`): +179 / -87 = **+92**, of which +69 is the shared module (majority docstrings). `conversationFormat.ts` nets -3; `normalizeConversation.ts` nets +28 (the variant re-narrowing casts, see below).

One implementation note: `normalizeConversation`'s `ContentBlock` is a zod-inferred discriminated union that switch-narrowing drove before. Switching on the category loses that narrowing, so each field-reading case re-anchors its variant via a small local `asClassifiedBlock<T>` helper (`Extract<ContentBlock, { type: T }>` keyed by the same frozen tag constants). No runtime change; the cast expresses what the classifier already established.

## Consumer counts (R8)

- `classifyProviderMessageBlockType`: 4 call sites across 2 modules — `formatConversationBlock` (`@agent/storage/conversationFormat`), and `assistantBlockToNode` / `blocksToUserParts` / `extractToolResultText` (`@agent/export/normalizeConversation`). Both modules imported `CONVERSATION_BLOCK_TYPES` from this module already, so no import-graph change beyond the one sibling import noted above.
- `ProviderMessageBlockCategory`: referenced by the classifier's return annotation; consumers switch on its literals.
- No exports removed; no call sites deleted.

## Host impact

Extension: none (behavior-preserving; the `/executions/{id}/conversation` endpoint renders identically).

Desktop: none.

CLI: none (`texra history` / resume previews consume `formatConversationMessage` via the `@agent/storage` barrel, unchanged API and output).

## Validation

- Equivalence evidence: a 54-case scratch characterization corpus (every provider arm — Anthropic typed blocks, OpenAI Response API + Chat Completions tags, Google `parts`, VS Code LM `kind` parts, Anthropic server-tool blocks — plus malformed/optional-field blocks and the deliberate cross-consumer divergences listed above) was run against the pre-refactor code (all green, hand-derived expectations) and re-run against the post-refactor code (all green, byte-identical expectations). Not committed, per maintainer direction on overtesting.
- Existing unmodified suites on the final tree: `ConversationBlockTypeParity`, `normalizeConversation`, `ExecutionsConversationFormat`, plus the full `agent/export`, `agent/storage`, and `transcript` suites — 25 files / 456 tests, pass.
- `typecheck:workspace`, `typecheck:test-kernel`, `typecheck:agent`, `typecheck:cli`, `typecheck:trace-viewer`, `typecheck:desktop` — pass.
- Architecture suite `src/test-kernel/architecture/` — 17 files / 102 tests, pass (no new subsystem edges; the new import is agent-internal).
- `check:dead-code-ratchet` (8=8), `check:browser-safe-utils`, `check:guidance-refs` — pass.
- ESLint (3 changed files), Prettier, `git diff --check` — clean.
- Note: `src/test-kernel/cli/TranscriptSessionPolicy.vitest.ts` and `ResumeCommand.vitest.ts` time out intermittently under full-suite parallel load on this machine (10s default timeout; they pass in isolation and don't touch these modules) — pre-existing flake, unrelated.

