### PR TITLE
refactor(logger): narrow the wave-2 log-only createChannelTrace callers onto createLog

### DIFF
--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -1,7 +1,6 @@
 /** Tool-use follow-up routing and continuation ownership. */
 import { z } from 'zod';
 
-import { createChannelTrace } from '@agent/trace';
 import { deriveResumability } from '@agent/storage/resumability';
 import { type ToolUseFollowUpQueueReason } from '@agent/runtime/executionRegistry';
 import {
@@ -10,6 +9,7 @@ import {
   resolveEmitSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
+import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import type { AgentResumePort } from '@platform/interfaces';
 import type { StreamTabId } from '@shared/schemas';
@@ -75,7 +75,7 @@ export function presentFollowUpResult(
   return { severity: 'none' };
 }
 
-const logger = createChannelTrace('ToolUseFollowUp');
+const logger = createLog('ToolUseFollowUp');
 const PersistedContinuationGenerationSchema = z.looseObject({
   continuationGenerationId: z.uuid(),
 });

--- a/src/agent/followUp/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/followUp/ToolUseFollowUpQueueManager.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { LRUCache } from 'lru-cache';
-import { createChannelTrace } from '@agent/trace';
+import { createLog } from '@logger/logUtils';
 import type { RecoveryContinuation } from '@platform/interfaces';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { KeyedMutex } from '@utils/core/keyedMutex';
@@ -11,7 +11,7 @@ import {
 } from '@utils/core/boundedIdSet';
 import { FollowUpQueue, type FollowUpQueueInput } from './FollowUpQueue';
 
-const logger = createChannelTrace('ToolUseFollowUpQueue');
+const logger = createLog('ToolUseFollowUpQueue');
 
 type QueueLifecycle = 'live' | 'recoverable' | 'recovering';
 export type FollowUpConsumerKind = 'flow' | 'child' | 'recovery';

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -9,7 +9,6 @@ import {
   type ResolvedAgent,
 } from '@agent/index';
 import {
-  createChannelTrace,
   logSdkError,
   logUserMessage,
   type AgentTrace,
@@ -47,6 +46,7 @@ import {
   hasErrorPresentedMarker,
 } from '@common/errors/sdkError/errorMetadata';
 import { getSdkErrorMessage } from '@common/errors/sdkError/providerErrorFormat';
+import { createLog } from '@logger/logUtils';
 import type { CopilotRouteOverride } from '@model/copilotRouting';
 import { resolveRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import {
@@ -76,7 +76,7 @@ import { AgentLaunchResources } from './AgentLaunchResources';
 import type { StreamStatusMachine } from './StreamStatusService';
 import type { SessionHostInteractions } from './HostInteractions';
 
-const logger = createChannelTrace('AgentLaunchContext');
+const logger = createLog('AgentLaunchContext');
 
 export interface AgentLaunchContext extends AgentCore {
   usageMonitor: UsageMonitor;

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -11,19 +11,19 @@
  * from the registry) and when the subscriber stream's queue is released.
  */
 
-import { createChannelTrace } from '@agent/trace';
 import type {
   AgentExecutionHandle,
   ExecutionStatusInfo,
 } from '@agent/runtime/ExecutionHandle';
 import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
 import { deliverLiveNotification } from '@agent/followUp/liveNotification';
+import { createLog } from '@logger/logUtils';
 import type { StreamTabId } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
 import { wrapAndSanitizeTag } from '@utils/text/sanitizeTag';
 import { currentSession, type SessionHandle } from './SessionHandle';
 
-const logger = createChannelTrace('ExecutionSubscriptionBinder');
+const logger = createLog('ExecutionSubscriptionBinder');
 
 const TAG = DELIVERY_TAG.executionActivity;
 

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -1,6 +1,6 @@
-import { createChannelTrace } from '@agent/trace';
 import type { ReviewIssueReport } from '@agent/review/reviewIssues';
 import type { ModelCredentialSelection } from '@agent/types/ModelHandlerContracts';
+import { createLog } from '@logger/logUtils';
 import type {
   AgentProposal,
   FileLocation,
@@ -28,7 +28,7 @@ import type {
 
 export type { ProgressPermissionKind as PendingInteractionKind } from '@shared/schemas';
 
-const logger = createChannelTrace('SessionHostInteractions');
+const logger = createLog('SessionHostInteractions');
 
 /**
  * Ceiling on presentation notices queued while no host is attached. A session

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -1,7 +1,6 @@
 import * as path from 'node:path';
 
 import { logConversationProgress } from '@agent/trace';
-import { createChannelTrace } from '@agent/trace';
 import { runToolUseFlow } from '@agent/implementations/flows/tooluse/runToolUseFlow';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { runReflectionFlow } from '@agent/implementations/flows/reflection/runReflectionFlow';
@@ -23,6 +22,7 @@ import {
   releaseOwnedExecutionLeaseAfterFailure,
 } from '@agent/storage/executionLease';
 import { AgentError } from '@common/errors';
+import { createLog } from '@logger/logUtils';
 import type { CopilotRouteOverride } from '@model/copilotRouting';
 import {
   type RequestEnsureProgressViewPayload,
@@ -66,7 +66,7 @@ import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKe
 import type { ToolUseResumeData } from './SessionResumeRetrieval';
 
 const CHANNEL = 'executeAgent';
-const logger = createChannelTrace(CHANNEL);
+const logger = createLog(CHANNEL);
 
 /** A resumed execution lost its canonical admission race with deletion. */
 export class ResumeAdmissionCancelledError extends Error {

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -91,7 +91,7 @@ vi.mock('@frontend/secretManager', () => ({
 // The guard's sole touchpoint is `defaultSession().executions.getAgentHandles()`
 // — a full stub replacement (not `importOriginal`) keeps this suite's
 // isolation: the real module eagerly constructs a `createChannelTrace`
-// logger at import time (`ToolUseFollowUpQueueManager.ts`), which needs more
+// logger at import time (`SessionHandle.ts`), which needs more
 // of `@logger/logUtils` than this suite's minimal mock provides. No other
 // module in this test's import graph (all deps otherwise mocked away, and
 // `apiKeyCommands`/`codexSubscriptionSignIn` don't import SessionHandle)

--- a/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
+++ b/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
@@ -24,9 +24,22 @@ vi.mock('@agent/runtime/childRunLoop', () => ({
   startChildRunLoop: mocks.startChildRunLoop,
 }));
 
-vi.mock('@agent/trace', () => ({
-  createChannelTrace: () => ({ error: mocks.childLoopError }),
-}));
+// `executeSubagent` reports a late detached-loop failure through an inline
+// `createLog('childRunLoop')` call; spread the real module so the graph's
+// other `createLog` consumers (e.g. `executionLifecycle`,
+// `inBandSubagentExecution`) keep working loggers.
+vi.mock('@logger/logUtils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@logger/logUtils')>();
+  return {
+    ...actual,
+    createLog: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: mocks.childLoopError,
+    }),
+  };
+});
 
 vi.mock('@agent/storage', () => ({
   registerExecution: mocks.registerExecution,
@@ -176,7 +189,7 @@ describe('executeSubagent childStreamId derivation', () => {
     );
   });
 
-  it('logs a detached run-loop rejection through the runtime trace', async () => {
+  it('logs a detached run-loop rejection through the childRunLoop channel log', async () => {
     const lateFailure = new Error('late subagent finalization failed');
     mocks.startChildRunLoop.mockReturnValue({
       completion: Promise.reject(lateFailure),

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -8,7 +8,6 @@
  */
 
 // Local imports
-import { createChannelTrace } from '@agent/trace';
 import { registerOwnedExecution } from '@agent/storage/executionLifecycle';
 import {
   AgentConfigSchema,
@@ -21,6 +20,7 @@ import {
 } from '@agent/runtime/RunContext';
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { getStreamTabId } from '@agent/runtime/streamTab';
+import { createLog } from '@logger/logUtils';
 import {
   AgentCategory,
   TODO_STATUS,
@@ -234,7 +234,7 @@ export async function executeSubagent(
       buildLaunch: async () => ({
         strategy: createNativeSubagentStrategy(strategyParams),
         onLoopFailed: (error: unknown): void => {
-          createChannelTrace('childRunLoop').error(
+          createLog('childRunLoop').error(
             `Subagent '${agentName}' run loop failed after launch`,
             { data: error },
           );


### PR DESCRIPTION
## Summary

Wave 2 of #10595 (audit: `docs/proposals/2026-08-15-agent-sdk-readiness-reverify.md` §4 L-1, §7). Converts the seven remaining log-method-only `createChannelTrace` call sites onto `createLog`, now that the #10475/#10541 collisions wave 1 deferred have landed. Both factories funnel through `createChannelWriter` → `writeLine` to the same shared sink, so per-caller narrowing is behavior-preserving for these sites; channel strings, levels, and options are preserved verbatim, and `createLog`'s module-namespace routing keeps the test spy seam working.

Re-audited every open PR diff for overlap before cutting: #10601 owns `PollingSourceBase.ts`/`StreamSubscriptionRegistry.ts` (untouched); #10646 (`SessionHandle.ts`/`childRunLoop.ts`, untouched) and #10653 are merged and in this branch's base; the other open PRs (#10664, #10660, #10659, #10658, #10657, #10656, #10636, #10612, #10609, #10347) share no files with this diff.

## Changes

**Converted to `createLog` (7 sites, 6 module singletons + 1 inline):**

- `src/agent/runtime/executeAgent.ts` — module singleton, channel `'executeAgent'` (`CHANNEL` const kept).
- `src/agent/runtime/AgentLaunchContext.ts` — module singleton, channel `'AgentLaunchContext'`; the file's other `@agent/trace` imports (`logSdkError`, `logUserMessage`, types) stay.
- `src/agent/runtime/HostInteractions.ts` — module singleton, channel `'SessionHostInteractions'`.
- `src/agent/runtime/ExecutionSubscriptionBinder.ts` — module singleton, channel `'ExecutionSubscriptionBinder'`; the `BinderLogger` structural interface (the injection seam into `ExecutionSubscription` and `deliverLiveNotification`) is unchanged and satisfied by `createLog`'s `Log`.
- `src/agent/followUp/ToolUseFollowUp.ts` — module singleton, channel `'ToolUseFollowUp'`.
- `src/agent/followUp/ToolUseFollowUpQueueManager.ts` — module singleton, channel `'ToolUseFollowUpQueue'`.
- `src/tools/delegation/subagentExecution.ts` — inline `createChannelTrace('childRunLoop').error(...)` in the `onLoopFailed` callback becomes `createLog('childRunLoop').error(...)`; channel string preserved.

**Test seam retargeted (1 file):**

- `src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts` — the detached-loop rejection assertion now mocks `@logger/logUtils.createLog` (with `importOriginal` spread so the graph's real `createLog` consumers — `executionLifecycle`, `inBandSubagentExecution` — keep working loggers) instead of fully replacing `@agent/trace`. After the conversion nothing in this suite's import graph imports a runtime value from `@agent/trace` (verified by grep: the remaining delegation/runtime/storage trace imports are type-only), so the old trace mock is removed rather than retained. Test title updated to name the `childRunLoop` channel log.

**Comment refreshed (1 file):**

- `src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts` — the full-stub rationale cited `ToolUseFollowUpQueueManager.ts`'s eager import-time `createChannelTrace`; that module now binds `createLog`, so the citation moves to `SessionHandle.ts`, which still eagerly constructs `createChannelTrace('sessionHandle')` at import time.

## Net elements (R6)

- Diffstat: 9 files, 32 insertions, 19 deletions; net **+13 lines** (the test mock grows from a 3-line full-module `@agent/trace` stub to a 16-line `importOriginal`-spread `createLog` mock plus its rationale comment; the seven src conversions are line-neutral import/factory swaps).
- `createChannelTrace` non-test callers: **14 → 7**.
- Exported symbols/classes/interfaces/enums added or deleted: **0** (verified: no `^[+-]export` or declaration lines in the diff).

## Consumer counts (R8)

No event or emit path is added, deleted, or re-routed. Every converted site keeps its channel string and level, and both factories write through the same `createChannelWriter` → `writeLine` sink, so host output-channel subscribers see byte-identical lines (focused tests print the preserved `[SessionHostInteractions]` channel tag). The `ExecutionSubscriptionBinder` module logger has exactly **2** structural consumers (`ExecutionSubscription` via constructor injection, `deliverLiveNotification` via the `logger:` option), both behind the unchanged `BinderLogger` interface. The `subagentExecution.ts` inline site's sole consumer is the `onLoopFailed` callback exercised by `SubagentExecutionChildStreamId.vitest.ts`. **0** consumers read any of these loggers as an `AgentTrace` (no `.event`/`.stage`/`.subscribe` usage on any converted site — that is what makes them log-only).

## Remaining `createChannelTrace` callers (7) and closure path

- `src/agent/runtime/SessionHandle.ts` — log-only singleton; was collision-owned by #10646, which has now merged without touching it, so it is unblocked for a trivial follow-up.
- `src/tools/github/PollingSourceBase.ts`, `src/tools/github/StreamSubscriptionRegistry.ts` — collision-owned by #10601 (open).
- `src/agent/runtime/childRunLoop.ts` (`childStream?.logger ?? createChannelTrace('childRunLoop')`), `src/agent/runtime/AgentRunLifecycle.ts`, `src/agent/runtime/executionRegistry.ts`, `src/agent/runtime/AgentLaunchResources.ts` — genuine `AgentTrace` contract sites; permanent `createChannelTrace` users by design (the audit rules out a factory merge).

Once the SessionHandle follow-up lands and #10601 merges its two files, the log-only narrowing is complete and #10595 can close; the four `AgentTrace` contract sites are the intended terminal state for the factory.

## Host impact

None. No `packages/` files touched; extension, desktop, and CLI log surfaces render the same channel names through the same sink wiring (`setOutputChannelFactory` untouched). No settings, commands, or contributed surfaces change.

## Validation

- Focused Vitest (changed modules + #10646-adjacent suites): 12 files / 167 tests passed; broad runtime + followUp + delegation sweep: 68 files / 812 tests passed; `ResumeCommand.vitest.ts` standalone: 22/22 passed.
- Full Vitest suite run as two CI shards: 871 files passed; 8 files failed under full-parallelism load (per-test 10s timeouts in `DesktopAgentExecution`/`RunExecution` and five jsdom suites skipped at the file-setup timeout). All 8 re-run standalone on this branch: **171/171 passed** — load flakes, not regressions; the same files' tests pass at ~3-8s each uncontended.
- Workspace, test-kernel, agent, CLI, desktop, and trace-viewer typechecks passed.
- ESLint and Prettier passed on all changed files.
- Dead-code ratchet, guidance-reference check, browser-safe-utils drift guard, tsconfig-paths, package-contributes, and extension-package-invariants checks passed.
- `git diff --check` clean.

Refs #10595
