### PR TITLE
refactor(agent): remove dead launch and flow surfaces

### DIFF
--- a/docs/architecture/pocketflow-state.md
+++ b/docs/architecture/pocketflow-state.md
@@ -66,7 +66,7 @@ summing native payloads to compute total cost.
   mutating `run` and `workspace` as the model is invoked and response processed.
 - **Reflection run flow** keeps track of run progress through `AgentRunStateSnapshot`
   and persists round/tool states for later inspection.
-- **Tool-use flows** pass state slices through `shared.state.stateSlices` as
+- **Tool-use flows** pass state slices through `shared.stateSlices` as
   individual snapshots, reconstructing class instances only when needed.
 
 By passing state slices directly (without wrapper classes for round/run state),

--- a/docs/proposals/2026-08-16-services-injection-audit.md
+++ b/docs/proposals/2026-08-16-services-injection-audit.md
@@ -221,3 +221,13 @@ The seams census found 8 seams/families of the "one production impl; seam exists
 **Tail (optional, either PR 2 or 3):** C11 desktop Pick.
 
 Aggregate if all mechanical batches land: ≈ −50 to −60 LoC, ~−25 elements, zero new constructs — before C13/C14, which carry the only remaining upside (−40/−50 and a net-negative seam sweep respectively) and both sit behind explicit gates.
+
+---
+
+## 6. Resolution addendum (2026-08-16)
+
+**C13 — approval trio is resolved; do-not-refile.** Current main post-#10647 already freezes `approvalPromptsUnavailable`, `runtimeUnavailableTools`, and `stopAfterCycle` in the per-launch `ToolPolicy` (`src/agent/core/flows/BaseFlowServices.ts:26-45`, frozen by `createToolPolicy`), carried on `AgentLaunchContext` (`src/agent/runtime/AgentLaunchContext.ts:120`, `:510`) and projected into the ambient context through `withExecutionRunContext` (`:138-154`). That is the accepted single-owner shape: launch-scoped policy frozen at the boundary, never re-derived from mutable session state. `onApprovalPolicyDenial` stays explicit on the projection boundary because it is a caller-injected callback, not a session-derived fact (`:142`, `:154`) — correct and intentional, not residue.
+
+**C12 is not pursued.** Its three-site `userFollowUpSupport` derivation premise is stale on current main: `single-cycle` collapsed into the launch-scoped `stopAfterCycle` (`ToolPolicy`) via #10647, and the remaining derivations are entry-point-specific rather than one shared rule.
+
+**C14 is dropped.** The Tier-3 test-seam house ruling was closed not-planned in #10675 (the test-seam portion is out under the maintainer's no-more-testing direction); the production projection-zero/bandwidth gate is tracked separately under #10672.

--- a/packages/desktop/src/main/desktopAgentLaunch.ts
+++ b/packages/desktop/src/main/desktopAgentLaunch.ts
@@ -1,7 +1,6 @@
 import {
   selectAutoOpenFinalOutput,
-  type AgentRunHandle,
-  type ModelHandlerCompatibilityKey,
+  type RunAgentOptions,
   type SessionHandle,
 } from '@agent/runtime';
 import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
@@ -27,19 +26,13 @@ export interface DesktopAgentLaunchContext {
   readonly canAcquireResumeLease?: () => boolean | Promise<boolean>;
 }
 
-export interface DesktopAgentLaunchOptions {
-  readonly modelHandlerCompatibilityKey?: ModelHandlerCompatibilityKey | null;
-  /**
-   * Run on the configured helper model instead of the request's own model. Only
-   * the compile-fixer action opts in, matching the extension, where the same
-   * flag rides on the `texra.execute` payload.
-   */
-  readonly preferHelperModel?: boolean;
-  /** Observe the concrete run identity used by process-session result events. */
-  readonly onRun?: (handle: AgentRunHandle) => void | Promise<void>;
-  /** The caller owns presentation for failures before the run lifecycle. */
-  readonly suppressErrorNotification?: boolean;
-}
+export type DesktopAgentLaunchOptions = Pick<
+  RunAgentOptions,
+  | 'modelHandlerCompatibilityKey'
+  | 'preferHelperModel'
+  | 'onRun'
+  | 'suppressErrorNotification'
+>;
 
 /** Start a desktop run with process-owned dependencies only. */
 export async function launchDesktopAgent(

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -150,10 +150,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private readonly subscriptionUsage: SubscriptionUsageReader;
   public readonly signInChatGpt: () => Promise<void>;
 
-  constructor(
-    context: vscode.ExtensionContext,
-    subscriptionUsage: SubscriptionUsageReader = new SubscriptionUsageService(),
-  ) {
+  constructor(context: vscode.ExtensionContext) {
     super('SettingsView');
 
     const ctx: SettingsHandlerContext = {
@@ -188,7 +185,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       refreshSpendingStatus: () =>
         getServerSideKeyService().refreshSpendingStatus(),
     });
-    this.subscriptionUsage = subscriptionUsage;
+    this.subscriptionUsage = new SubscriptionUsageService();
     this.profileKeyController = new SettingsProfileKeyController({
       prompt: new VscodePromptHost(),
       externalOpener: new VscodeExternalOpener(),

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -74,10 +74,6 @@ export interface RunReflectionFlowInput<
   setting: AgentWorkflowSetting;
   storageKey: StorageKey;
   parentStage: StageHandle;
-  getOutputFileLocation?: (
-    round: number,
-  ) => AgentFileLocation | Promise<AgentFileLocation>;
-  workflowOutputPolicy?: WorkflowOutputPolicy;
 }
 
 export interface RunReflectionFlowResult {
@@ -148,36 +144,35 @@ export async function runReflectionFlow<C = unknown>(
     userRequestTemplateCount(prompt.userRequest),
   );
 
-  const getOutputFileLocation =
-    input.getOutputFileLocation ??
-    (async (round: number): Promise<AgentFileLocation> => {
-      const canonical = fileService.createLocation(
-        workflowOutputPath({ ext: WORKFLOW_RAW_OUTPUT_EXT, round }),
+  const getOutputFileLocation = async (
+    round: number,
+  ): Promise<AgentFileLocation> => {
+    const canonical = fileService.createLocation(
+      workflowOutputPath({ ext: WORKFLOW_RAW_OUTPUT_EXT, round }),
+    ) as AgentFileLocation;
+    // Resume-from-pre-refactor compat: if a round was partially written on an
+    // older build that used `.tex` for non-scratchpad agents, keep using that
+    // file on resume so initializeOutputAndPrefill sees the existing content
+    // instead of starting a fresh round at output.xml.
+    if (!(await AbsoluteFS.exists(canonical.absolutePath))) {
+      const legacy = fileService.createLocation(
+        workflowOutputPath({ ext: WORKFLOW_DOCUMENT_OUTPUT_EXT, round }),
       ) as AgentFileLocation;
-      // Resume-from-pre-refactor compat: if a round was partially written on an
-      // older build that used `.tex` for non-scratchpad agents, keep using that
-      // file on resume so initializeOutputAndPrefill sees the existing content
-      // instead of starting a fresh round at output.xml.
-      if (!(await AbsoluteFS.exists(canonical.absolutePath))) {
-        const legacy = fileService.createLocation(
-          workflowOutputPath({ ext: WORKFLOW_DOCUMENT_OUTPUT_EXT, round }),
-        ) as AgentFileLocation;
-        if (await AbsoluteFS.exists(legacy.absolutePath)) {
-          return legacy;
-        }
+      if (await AbsoluteFS.exists(legacy.absolutePath)) {
+        return legacy;
       }
-      return canonical;
-    });
+    }
+    return canonical;
+  };
 
-  const workflowOutputPolicy: WorkflowOutputPolicy =
-    input.workflowOutputPolicy ?? {
-      shouldAutoOpenPdfOrLog: () =>
-        readPlatformSetting<boolean>(WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF),
-      shouldRejectOnCompileFailure: () =>
-        readPlatformSetting<boolean>(
-          WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
-        ),
-    };
+  const workflowOutputPolicy: WorkflowOutputPolicy = {
+    shouldAutoOpenPdfOrLog: () =>
+      readPlatformSetting<boolean>(WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF),
+    shouldRejectOnCompileFailure: () =>
+      readPlatformSetting<boolean>(
+        WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
+      ),
+  };
 
   const services: ReflectionServices<C> = {
     ...input,

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -14,7 +14,6 @@ import {
 } from '@agent/runtime/ModelFactory';
 import type { RunModelHandler } from '@agent/runtime/ModelCell';
 import { type SessionHandle } from '@agent/runtime/SessionHandle';
-import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import {
   PersistedFlow,
   PersistedFlowStateError,
@@ -81,11 +80,11 @@ export interface RunToolUseFlowInput<
    */
   takePendingFollowUps?: () => readonly FollowUpQueueBatchItem[];
   onFollowUpConsumed?: () => void;
-  /** When true, delegation tools are filtered out to prevent nesting, and
-   *  every completed model cycle suspends at WAITING (see `ToolUseWaitNode`)
-   *  instead of blocking in-flow for the next follow-up. A resumed flow may
-   *  first consume `drainedFollowUps`; the child-run loop still owns
-   *  delivery and every later turn boundary. */
+  /** When true, the subagent prompt variant is used and every completed model
+   *  cycle suspends at WAITING (see `ToolUseWaitNode`) instead of blocking
+   *  in-flow for the next follow-up. A resumed flow may first consume
+   *  `drainedFollowUps`; the child-run loop still owns delivery and every later
+   *  turn boundary. */
   isSubagent?: boolean;
   /** Fires on meaningful progress: todo changes, tool call milestones. */
   onProgress?: (update: SubagentProgressUpdate) => void;
@@ -136,8 +135,6 @@ export interface ToolUseFlowContext {
   readonly ownerSession: SessionHandle;
   readonly session: ToolUseSessionLifecycle;
   readonly modelHandler: RunModelHandler;
-  readonly interactions: SessionHostInteractions;
-  readonly model: string;
   interrupt(): void;
   requestImmediateCompaction(): void;
   modelSwitchDisabledReason(model: string): string | undefined;
@@ -366,10 +363,6 @@ export async function runToolUseFlow<C = unknown>(
     session: sessionLifecycle,
     get modelHandler() {
       return services.modelCell.handler;
-    },
-    interactions: runSession.interactions,
-    get model() {
-      return services.modelCell.modelId;
     },
     interrupt(): void {
       input.interrupt();

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -409,7 +409,6 @@ export function createWorkspaceAgentRosterController(): AgentRosterController<Ag
         workspaceState.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, []),
       ),
     resolveAgent: getRosterAgent,
-    fallbackTeamId: null,
   });
 }
 

--- a/src/agent/roster/AgentRosterController.ts
+++ b/src/agent/roster/AgentRosterController.ts
@@ -46,8 +46,6 @@ export interface AgentRosterControllerDeps<
     category: AgentCategory,
     identifier: string,
   ) => Entry | undefined;
-  /** Host policy used only when an inherited roster has no user default. */
-  readonly fallbackTeamId?: string | null;
 }
 
 const workspaceWriteMutex = new KeyedMutex<StateStore>();
@@ -266,7 +264,7 @@ export class AgentRosterController<
   /** Team identity a selection resolves to, following inherit to the default. */
   private teamIdOf(selection: AgentRosterSelection): string | null | undefined {
     if (selection.kind === 'inherit') {
-      return this.getDefaultTeamId() ?? this.deps.fallbackTeamId;
+      return this.getDefaultTeamId();
     }
     return selection.kind === 'team' ? selection.teamId : undefined;
   }

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -63,7 +63,6 @@ import {
 } from '@shared/schemas';
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
 import { createRunTrace, type RunTrace } from '@transcript';
-import { generateExecutionId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { createRunContext, withRunContext } from './RunContext';
@@ -99,7 +98,7 @@ export interface AgentLaunchContext extends AgentCore {
 
 export interface AgentLaunchInput {
   config: AgentConfig;
-  executionId?: ExecutionId;
+  executionId: ExecutionId;
   streamTabIdOverride?: StreamTabId;
   /** Fires after streamId is assigned but before setActiveStream is emitted. */
   onBeforeActivation?: (streamId: StreamTabId) => void;
@@ -289,12 +288,12 @@ function beginRunStage(
 async function assembleAgentLaunchContext(
   input: AgentLaunchInput & { session: SessionHandle },
   executionId: ExecutionId,
-  interactions: SessionHostInteractions,
   streamId: StreamTabId,
   resources: AgentLaunchResources,
 ): Promise<AgentLaunchContext> {
   input.signal?.throwIfAborted();
   const fullConfig = input.config;
+  const interactions = input.session.interactions;
   // Resolve by the source the delegation captured at validation time, so launch
   // lands on the exact entry validation/display resolved. When no source is
   // pinned (direct launches, restored records), resolution falls to the
@@ -625,7 +624,7 @@ export async function buildAgentLaunchContext(
   const launchSession = input.session ?? currentSession();
   const interactions = launchSession.interactions;
   const streamStatus = launchSession.status;
-  const executionId = input.executionId ?? generateExecutionId();
+  const executionId = input.executionId;
   // One mint of this run's stream id: an override is used as-is (resume
   // paths pass the streamId stamped on execution metadata), and otherwise
   // the freshly minted id is both the reservation and the run's identity.
@@ -641,7 +640,6 @@ export async function buildAgentLaunchContext(
     const ctx = await assembleAgentLaunchContext(
       { ...input, session: launchSession },
       executionId,
-      interactions,
       streamId,
       resources,
     );

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -122,6 +122,7 @@ async function launchToolUseRun(
   lifecycle: FlowLifecycleControl,
   shared: SubagentRunOptions & {
     readonly setting: AgentToolUseSetting;
+    readonly onFollowUpConsumed?: () => void;
     /**
      * Fresh launches take this from the caller; resume derives it from
      * persisted lineage, because the rebuilt system prompt would otherwise drop
@@ -293,8 +294,6 @@ export interface SubagentRunOptions {
   readonly tools?: readonly ITool[];
   /** Parent stream ID for subagent lineage tracking. Defaults to own streamId. */
   parentStreamId?: StreamTabId;
-  /** Fires when a tool-use session consumes queued follow-up instructions. */
-  onFollowUpConsumed?: () => void;
   /** Fires on meaningful progress: todo changes and tool call milestones. */
   onProgress?: (update: SubagentProgressUpdate) => void;
   /** Hide tools whose approval prompts cannot be answered in this host mode. */
@@ -345,7 +344,10 @@ export interface ExecuteAgentOptions extends SubagentRunOptions {
   streamTabIdOverride?: StreamTabId;
   /** The caller owns presentation for failures before the run lifecycle. */
   suppressErrorNotification?: boolean;
-  /** When true, proposal tools are filtered out to prevent nesting. */
+  /**
+   * Selects subagent prompt and presentation defaults and allows tool-use
+   * cycles to suspend at WAITING for the child-run loop.
+   */
   isSubagent?: boolean;
   /**
    * When true, enforce that an explicitly supplied category matches the
@@ -507,6 +509,8 @@ export async function executeAgent(
 }
 
 export interface ResumeToolUseFromResumeDataOptions extends SubagentRunOptions {
+  /** Fires when the resumed tool-use session consumes queued follow-ups. */
+  readonly onFollowUpConsumed?: () => void;
   /** Recheck canonical admission atomically while acquiring the resumed lease. */
   readonly canAcquireResumeLease?: () => boolean | Promise<boolean>;
   /**

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -21,7 +21,14 @@ import {
 import { defaultSession } from './SessionHandle';
 import type { ToolUseResumeData } from './SessionResumeRetrieval';
 
-export interface ResumeQueuedToolUseOptions extends SubagentRunOptions {
+export interface ResumeQueuedToolUseOptions extends Pick<
+  SubagentRunOptions,
+  | 'session'
+  | 'tools'
+  | 'approvalPromptsUnavailable'
+  | 'onApprovalPolicyDenial'
+  | 'runtimeUnavailableTools'
+> {
   /** Recovery ownership synchronously claimed by the submission boundary. */
   readonly recovery?: RecoveryContinuation;
   /** Recheck canonical admission atomically while acquiring the resumed lease. */
@@ -137,15 +144,10 @@ export async function resumeQueuedToolUseFromResumeData(
       approvalPromptsUnavailable: options.approvalPromptsUnavailable,
       onApprovalPolicyDenial: options.onApprovalPolicyDenial,
       runtimeUnavailableTools: options.runtimeUnavailableTools,
-      parentStreamId: options.parentStreamId ?? resume.parentStreamId,
-      workflowPhase: options.workflowPhase,
+      parentStreamId: resume.parentStreamId,
       onFollowUpConsumed: () => {
         followUps = [];
-        options.onFollowUpConsumed?.();
       },
-      onProgress: options.onProgress,
-      onRunError: options.onRunError,
-      onRun: options.onRun,
       ...(options.canAcquireResumeLease && {
         canAcquireResumeLease: options.canAcquireResumeLease,
       }),

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -37,9 +37,8 @@ export interface ResumeQueuedToolUseOptions extends Pick<
   readonly isCancellationRequested?: () => boolean;
   /**
    * Fires with the resumed run's raw outcome — terminal or WAITING — right
-   * after the call returns successfully. Additive to `onRunError`, which only
-   * covers the terminal branch; native child-run strategies use this to
-   * recover the WAITING result value that would otherwise be discarded by
+   * after the call returns successfully. Native child-run strategies use this
+   * to recover the WAITING result value that would otherwise be discarded by
    * this function's own boolean return.
    */
   readonly onResult?: (result: AgentRuntimeFlowResult) => void;

--- a/src/controllers/settingsView/SettingsAgentControllerFactory.ts
+++ b/src/controllers/settingsView/SettingsAgentControllerFactory.ts
@@ -65,7 +65,6 @@ export function createSettingsAgentControllers(
         workspaceState.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, []),
       ),
     resolveAgent: getRosterAgent,
-    fallbackTeamId: null,
   });
 
   const state: SettingsAgentCatalogState = {

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -42,10 +42,17 @@ import {
   hasErrorPresentationPending,
   hasErrorPresentedMarker,
 } from '@common/errors/sdkError/errorMetadata';
-import { RUN_OUTCOME, STREAM_PHASE, AgentCategory } from '@shared/schemas';
+import {
+  RUN_OUTCOME,
+  STREAM_PHASE,
+  AgentCategory,
+  type ExecutionId,
+} from '@shared/schemas';
 import { createTestSession } from '@test/support/sessionTestUtils';
 import { testModelCell } from '../modelCellTestUtils';
 import { createRecordingHost } from '../progressTestUtils';
+
+const EXECUTION_ID = 'launch-context-test' as ExecutionId;
 
 describe('AgentLaunchContext', () => {
   it('still rejects empty canonical values, now at agent resolution', async () => {
@@ -57,6 +64,7 @@ describe('AgentLaunchContext', () => {
       await expect(
         buildAgentLaunchContext({
           config: AgentConfigSchema.parse({ agent: '', model: '' }),
+          executionId: EXECUTION_ID,
           session,
         }),
       ).rejects.toThrow('Could not find agent');
@@ -96,6 +104,7 @@ describe('AgentLaunchContext', () => {
       await expect(
         buildAgentLaunchContext({
           config: AgentConfigSchema.parse({ agent: '', model: '' }),
+          executionId: EXECUTION_ID,
           session,
         }),
       ).rejects.toThrow('Could not find agent');
@@ -123,6 +132,7 @@ describe('AgentLaunchContext', () => {
       await expect(
         buildAgentLaunchContext({
           config: AgentConfigSchema.parse({ agent: '', model: '' }),
+          executionId: EXECUTION_ID,
           session,
         }),
       ).rejects.toThrow('Could not find agent');
@@ -270,6 +280,7 @@ describe('AgentLaunchContext', () => {
     try {
       await buildAgentLaunchContext({
         config: AgentConfigSchema.parse({ agent: '', model: '' }),
+        executionId: EXECUTION_ID,
         session,
       }).catch((error: unknown) => {
         thrown = error;
@@ -296,6 +307,7 @@ describe('AgentLaunchContext', () => {
       await expect(
         buildAgentLaunchContext({
           config: AgentConfigSchema.parse({ agent: '', model: '' }),
+          executionId: EXECUTION_ID,
           session,
         }),
       ).rejects.toThrow('Could not find agent');
@@ -340,6 +352,7 @@ describe('AgentLaunchContext', () => {
             agent: 'chat',
             model: '__unregistered_model_for_launch_context_test__',
           }),
+          executionId: EXECUTION_ID,
           session,
         }),
       ).rejects.toThrow('is not registered');
@@ -495,6 +508,7 @@ describe('AgentLaunchContext', () => {
             agentCategory: AgentCategory.ToolUse,
             delegationAgentScope,
           }),
+          executionId: EXECUTION_ID,
           session,
           streamTabIdOverride: 'late-assembly-stream',
           suppressErrorNotification: true,

--- a/src/test-kernel/controllers/AgentRosterController.vitest.ts
+++ b/src/test-kernel/controllers/AgentRosterController.vitest.ts
@@ -41,7 +41,6 @@ function controller(
     globalState: new FakeStateStore(),
     getAgents: (category) => agents[category],
     getPresets: () => [preset],
-    fallbackTeamId: null,
     ...overrides,
   });
 }


### PR DESCRIPTION
## Summary

Implements the ungated agent-runtime dead-surface sweep from `2026-08-16-services-injection-audit.md`, re-verified against current main, plus the PR-2 periphery deletions and the C11 desktop `Pick` in one reviewable surface:

- C1: narrow `ResumeQueuedToolUseOptions` to fields with real passers (retaining `tools`, which has a current test consumer)
- C2: remove zero-passer reflection input injection ports
- C3: remove unread `ToolUseFlowContext.model` and `.interactions`
- C4: delete `AgentRosterControllerDeps.fallbackTeamId`
- C5: require the upstream-owned execution ID and delete the second mint
- C7: remove the duplicate interactions assembly parameter
- C8: narrow `onFollowUpConsumed` to resume-only options
- C9: delete the zero-passer `SettingsViewMessageHandler` constructor seam
- C10: correct stale `isSubagent` and PocketFlow state-path documentation
- C11: model `DesktopAgentLaunchOptions` as a `Pick` of the forwarded runtime contract

Preserves the explicit `modelSwitchDisabledReason` fence row and all `ReflectionServices` seams. The stale `onResult` doc reference to the removed `onRunError` option was corrected (see the review thread).

## Issue traceability

Closes #10677. C6 landed in main via #10691; this PR lands PR 1 (C1/C2/C3/C5/C7/C8/C10), PR 2 (C4/C9), and the C11 tail; the C13 design-note obligation is resolved in the `docs/proposals/2026-08-16-services-injection-audit.md` addendum below; C14 was dropped via #10675 (closed not-planned, with the projection-zero/bandwidth gate tracked separately under #10672).

## Net diff

- 13-file implementation surface: **+79/−89** (the pre-review +77/−86 plus the `onResult` doc correction, +2/−3)
- production TypeScript: **−23 lines** (63 insertions / 86 deletions across 10 files)
- C13 resolution addendum: 1 documentation file, +10 lines
- total: **14 files, +89/−89**

## Net elements (R6)

Removals negative, additions positive:

- C1: −7 queued-resume option fields/forwards
- C2: −2 zero-passer reflection input ports
- C3: −2 unread live-flow fields
- C4: −2 (`fallbackTeamId` field + fallback read)
- C5: −1 execution-ID fallback mint
- C7: −1 duplicate interactions parameter
- C8: 0 (callback relocated `SubagentRunOptions` → `ResumeToolUseFromResumeDataOptions`)
- C9: −1 `SettingsViewMessageHandler` constructor seam
- C10: 0 (docs)
- C11: 0 (`DesktopAgentLaunchOptions` interface → shape-equivalent `Pick`; the same four members remain exposed)

Net strict element delta: **−16**; no production abstraction added. The source field-declaration count also drops by four, but those are not removed API elements because the `Pick` preserves them.

## Consumer counts (R8)

Repository-wide caller tracing confirmed:

- all `buildAgentLaunchContext` production callers already provide `executionId`
- `tools` has a current queued-resume test passer and remains supported
- removed reflection input ports have zero passers; the multi-consumer `ReflectionServices` fields remain
- `fallbackTeamId` and the `SettingsViewMessageHandler` second constructor argument have zero production passers
- `modelSwitchDisabledReason` has a live CLI consumer and remains
- fresh-launch callers do not produce `onFollowUpConsumed`; resumed tool-use owns the callback

## Tests

No new tests. Existing affected suites were only mechanically updated (required `executionId`, deleted `fallbackTeamId`). Zero behavior change.

## Checks

- `npm run typecheck` (workspace, test-kernel, agent, CLI, trace-viewer, desktop)
- focused suites: `AgentLaunchContext`, `AgentRosterController`, `resumeQueuedToolUse`, `ReflectionFlowStateRecovery`, `RunScopedToolOverlay`, tool-use follow-up/cancellation, resume/execution-registry/lifecycle, settings handlers — 17 files / 239 tests
- affected architectural ratchets: `hostAgentDeepImportRatchet`, `sharedSchemasDeepImportRatchet`, `subsystemEdgeRatchet`, `approvalPolicyAuthorityRatchet` — 4 files / 23 tests
- `check:dead-code-ratchet`, `check:guidance-refs`
- ESLint on changed TypeScript
- Prettier on changed files
- `git diff --check`

