### PR TITLE
fix(ratchet): land the B1 post-merge final-review corrections

### DIFF
--- a/config/ratchets/shared-schemas-deep-import-baseline.json
+++ b/config/ratchets/shared-schemas-deep-import-baseline.json
@@ -1,27 +1,13 @@
 {
-  "semantics": "Production and test-kernel statements that reach past the published '@shared/schemas' barrel into a leaf module, keyed by specifier, valued by the importing file ('(type-only)' marks an `import type` statement, so a file that splits its value and type imports contributes two distinct entries). 'forced' statements name at least one symbol the barrel does not re-export: they are a report that a leaf module is missing from the published surface, and only a NEW off-surface specifier fails the ratchet. 'gratuitous' statements could have used the barrel verbatim; their per-specifier count may not grow. Classification is computed against src/shared/schemas/index.ts at test time, so widening the barrel reclassifies statements automatically (and requires regenerating this file in the same PR). The leaf-aware published-surface snapshot preserves the exact type/value bindings used by baseline gratuitous imports, so those bindings may not contract even if their importers move. Scan covers repo-root src/ and every packages/*/src directory, excluding only the surface interior src/shared/schemas/ (test-kernel files are ratcheted like production).",
+  "semantics": "Production and test-kernel statements that reach past the published '@shared/schemas' barrel into a leaf module, keyed by specifier, valued by the importing file ('(type-only)' marks an `import type` statement, so a file that splits its value and type imports contributes two distinct entries). 'forced' statements either name a symbol the barrel does not re-export, or are exact documented layering-floor entries that cannot use the barrel without creating a cycle. A new off-surface specifier or layering-floor entry fails the ratchet. 'gratuitous' statements could use the barrel verbatim and have no documented layering constraint; any new entry fails. Classification is computed against src/shared/schemas/index.ts at test time, so widening the barrel reclassifies statements automatically (and requires regenerating this file in the same PR). The leaf-aware published-surface snapshot preserves the exact type/value bindings used by published deep imports, so those bindings may not contract even if their importers move. Scan covers repo-root src/ and every packages/*/src directory, excluding only the surface interior src/shared/schemas/ (test-kernel files are ratcheted like production).",
   "surface": {
     "@shared/schemas/log": {
       "type": ["LogLevel"],
       "value": ["LOG_LEVELS"]
-    },
-    "@shared/schemas/todo": {
-      "type": [],
-      "value": ["TODO_STATUS"]
-    },
-    "@shared/schemas/todoDisplay": {
-      "type": [],
-      "value": ["STATUS_DISPLAY", "STATUS_ICONS"]
     }
   },
-  "forced": {},
-  "gratuitous": {
-    "@shared/schemas/log": ["src/logger/logUtils.ts"],
-    "@shared/schemas/todo": [
-      "src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts"
-    ],
-    "@shared/schemas/todoDisplay": [
-      "src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts"
-    ]
-  }
+  "forced": {
+    "@shared/schemas/log": ["src/logger/logUtils.ts"]
+  },
+  "gratuitous": {}
 }

--- a/config/ratchets/shared-schemas-deep-import-baseline.json
+++ b/config/ratchets/shared-schemas-deep-import-baseline.json
@@ -1,13 +1,14 @@
 {
-  "semantics": "Production and test-kernel statements that reach past the published '@shared/schemas' barrel into a leaf module, keyed by specifier, valued by the importing file ('(type-only)' marks an `import type` statement, so a file that splits its value and type imports contributes two distinct entries). 'forced' statements either name a symbol the barrel does not re-export, or are exact documented layering-floor entries that cannot use the barrel without creating a cycle. A new off-surface specifier or layering-floor entry fails the ratchet. 'gratuitous' statements could use the barrel verbatim and have no documented layering constraint; any new entry fails. Classification is computed against src/shared/schemas/index.ts at test time, so widening the barrel reclassifies statements automatically (and requires regenerating this file in the same PR). The leaf-aware published-surface snapshot preserves the exact type/value bindings used by published deep imports, so those bindings may not contract even if their importers move. Scan covers repo-root src/ and every packages/*/src directory, excluding only the surface interior src/shared/schemas/ (test-kernel files are ratcheted like production).",
+  "semantics": "Production and test-kernel statements that reach past the published '@shared/schemas' barrel into a leaf module, keyed by specifier, valued by the importing file ('(type-only)' marks an `import type` statement, so a file that splits its value and type imports contributes two distinct entries). 'floors' are exact published statements that cannot use the barrel without creating a dependency cycle. 'forced' statements name a symbol the barrel does not re-export. 'gratuitous' statements could use the barrel verbatim and have no documented layering constraint. Any new entry in any class fails. Classification is computed against src/shared/schemas/index.ts at test time, so widening the barrel reclassifies statements automatically (and requires regenerating this file in the same PR). The leaf-aware published-surface snapshot preserves the exact type/value bindings used by published deep imports, so those bindings may not contract even if their importers move. Scan covers repo-root src/ and every packages/*/src directory, excluding only the surface interior src/shared/schemas/ (test-kernel files are ratcheted like production).",
   "surface": {
     "@shared/schemas/log": {
       "type": ["LogLevel"],
       "value": ["LOG_LEVELS"]
     }
   },
-  "forced": {
+  "floors": {
     "@shared/schemas/log": ["src/logger/logUtils.ts"]
   },
+  "forced": {},
   "gratuitous": {}
 }

--- a/docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md
+++ b/docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md
@@ -743,18 +743,20 @@ fold-rejection annotations), and most controller `*Deps` interfaces
 
 The repo's largest frozen list
 (`config/ratchets/shared-schemas-deep-import-baseline.json`) records imports
-that reach past the published `@shared/schemas` barrel. Re-verification at
-implementation time found 281 migratable statements rather than the original
-387 estimate. A mechanical codemod plus the built-in baseline regen removes
-all of them, while folding `schemas/settingsView/{data,inbound}` (1,138 LoC)
-into the re-export shim all external consumers already use deletes the dual
-organizational scheme.
+that reach past the published `@shared/schemas` barrel. The baseline at
+#10609's merge base contained 278 statements rather than the original 387
+estimate: dependency review found 277 migratable statements and one
+cycle-constrained floor. (An earlier 281 count preceded three intervening
+baseline removals.) A mechanical codemod plus the built-in baseline regen
+removes all 277 migratable rows, while folding
+`schemas/settingsView/{data,inbound}` (1,138 LoC) into the re-export shim all
+external consumers already use deletes the dual organizational scheme.
 
 The measured low-layer scope cut is one statement, not ~20:
 `src/logger/logUtils.ts` must import `@shared/schemas/log` directly because the
 barrel reaches `logUtils` through `stateSettings` → `@shared/approvalPolicy` →
 `@logger/logUtils`; using the barrel would create a cycle. The ratchet records
-that exact row as its forced layering floor and rejects every new migratable
+that exact row as its documented cycle floor and rejects every new migratable
 entry, including a new import of the same leaf. Because the baseline therefore
 remains nonempty, its `totals > 0` sanity assertion stays in place.
 
@@ -882,7 +884,8 @@ assigned), `ProcessingContext`'s members are one-line forwards. Then
 relocate the directory under `implementations/flows/reflection/` (the same
 move as item 9's `ResponseCycleFlow`). Verifier correction: the relocation
 _does_ touch the shared-schemas ratchet (three files are listed in the
-baseline) — regenerate in the same PR, or land after B1 empties it.
+baseline) — regenerate in the same PR, or land after B1 removes its migratable
+rows.
 
 ### B8. BLOCKED — do not delete the "orphaned" inline-agent machinery or the legacy-storage migrations
 

--- a/docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md
+++ b/docs/proposals/2026-08-14-delegation-flow-substrate-consolidation.md
@@ -739,20 +739,24 @@ polling verticals (real divergence, not copy-shape), the storage core
 fold-rejection annotations), and most controller `*Deps` interfaces
 (genuine two-host seams) all survive scrutiny as designed, not as debt.
 
-### B1. Empty the shared-schemas deep-import baseline (−880 LoC, −80 elements)
+### B1. Eliminate migratable shared-schemas deep imports (−880 LoC, −80 elements)
 
-The repo's largest frozen list (878 lines,
-`config/ratchets/shared-schemas-deep-import-baseline.json`) is certified
-100% gratuitous by its own classifier: `forced={}` — every one of the 387
-deep-import statements rewrites verbatim to the `@shared/schemas` barrel
-that 1,016 statements already use. A mechanical codemod plus the built-in
-baseline regen deletes the committed duplicate knowledge while the ratchet
-stays armed at zero. Folding `schemas/settingsView/{data,inbound}`
-(1,138 LoC) into the 49-line pure re-export shim that all ~81 importers
-already use deletes the dual organizational scheme. Verifier corrections:
-the ratchet's own sanity assertion (`totals > 0`) needs a ~5-line edit; a
-~20-statement scope cut in the low layers (logger/utils/transcript/…) where
-the barrel would invert layering.
+The repo's largest frozen list
+(`config/ratchets/shared-schemas-deep-import-baseline.json`) records imports
+that reach past the published `@shared/schemas` barrel. Re-verification at
+implementation time found 281 migratable statements rather than the original
+387 estimate. A mechanical codemod plus the built-in baseline regen removes
+all of them, while folding `schemas/settingsView/{data,inbound}` (1,138 LoC)
+into the re-export shim all external consumers already use deletes the dual
+organizational scheme.
+
+The measured low-layer scope cut is one statement, not ~20:
+`src/logger/logUtils.ts` must import `@shared/schemas/log` directly because the
+barrel reaches `logUtils` through `stateSettings` → `@shared/approvalPolicy` →
+`@logger/logUtils`; using the barrel would create a cycle. The ratchet records
+that exact row as its forced layering floor and rejects every new migratable
+entry, including a new import of the same leaf. Because the baseline therefore
+remains nonempty, its `totals > 0` sanity assertion stays in place.
 
 ### B2. Single-caller extraction sweep (−190 LoC, −24 elements)
 

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -23,7 +23,7 @@ import { redactSecrets } from '@logger/redaction';
 // Deliberate deep import: the '@shared/schemas' barrel transitively imports
 // this module (stateSettings → '@shared/approvalPolicy' → here), so importing
 // the barrel would create an import cycle. Recorded in the shared-schemas
-// deep-import baseline as its forced layering floor.
+// deep-import baseline as its documented cycle floor.
 import { LOG_LEVELS, type LogLevel } from '@shared/schemas/log';
 import { serializeError } from '@utils/core';
 import { getConfig } from '@utils/config/configUtils';

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -23,7 +23,7 @@ import { redactSecrets } from '@logger/redaction';
 // Deliberate deep import: the '@shared/schemas' barrel transitively imports
 // this module (stateSettings → '@shared/approvalPolicy' → here), so importing
 // the barrel would create an import cycle. Recorded in the shared-schemas
-// deep-import baseline.
+// deep-import baseline as its forced layering floor.
 import { LOG_LEVELS, type LogLevel } from '@shared/schemas/log';
 import { serializeError } from '@utils/core';
 import { getConfig } from '@utils/config/configUtils';

--- a/src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts
+++ b/src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts
@@ -5,16 +5,12 @@ import { describe, expect, it } from 'vitest';
 import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
 import { LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS } from '@latex/latexdiff/diffCommandExecutor';
 import { MATH_MARKUP_OPTIONS } from '@latex/latexdiff/mathMarkup';
+import { STATUS_DISPLAY, STATUS_ICONS, TODO_STATUS } from '@shared/schemas';
 import {
   CORE_LATEX_TOOLS,
   IMAGE_TOOLS,
 } from '@shared/constants/latexToolchain';
 import { API_KEY_PROVIDER_IDS } from '@shared/constants/providers';
-// Deliberate deep imports: sharedSchemasDeepImportRatchet.vitest.ts pins the
-// '@shared/schemas/todo' entry below as proof that its scan covers test-kernel
-// files. Do not rewrite these two to the barrel without moving that pin.
-import { STATUS_DISPLAY, STATUS_ICONS } from '@shared/schemas/todoDisplay';
-import { TODO_STATUS } from '@shared/schemas/todo';
 import { TOOL_JSON_SCHEMA_OPTIONS } from '@shared/tools/toolJsonSchema';
 import { ARXIV_CONSTANTS, CROSSREF_CONSTANTS } from '@tools/citation/constants';
 import { DEFAULT_POLLING_BACKOFF_CONFIG } from '@tools/github/PollingSourceBase';

--- a/src/test-kernel/architecture/sharedSchemasDeepImportRatchet.vitest.ts
+++ b/src/test-kernel/architecture/sharedSchemasDeepImportRatchet.vitest.ts
@@ -7,15 +7,12 @@
 // The one design requirement: deep imports are recorded in TWO classes, and
 // they are gated differently, because they mean opposite things.
 //
-//   forced     — the statement names at least one symbol the barrel does not
-//                re-export. The author had no barrel path to use, so this is a
-//                report that a leaf module is missing from the published
-//                surface, NOT a contributor error. Gated only on the SET of
-//                off-surface specifiers: another statement against an
-//                already-off-surface module passes; pushing a *new* module off
-//                the surface fails.
-//   gratuitous — every name is reachable through `@shared/schemas`. The barrel
-//                was simply not used. Gated hard, per specifier, on count.
+//   forced     — either the statement names a symbol the barrel does not
+//                re-export, or the exact statement is a documented layering
+//                floor that cannot use the barrel without creating a cycle.
+//                New off-surface modules and new floor entries fail.
+//   gratuitous — every name is reachable through `@shared/schemas`, with no
+//                documented layering constraint. Any new statement fails.
 //
 // Collapsing the two into one number would peg the total at the forced floor
 // forever, which reads as a broken ratchet (cf. #8900) and gets it deleted.
@@ -48,15 +45,16 @@ const SEMANTICS =
   'barrel into a leaf module, keyed by specifier, valued by the importing ' +
   "file ('(type-only)' marks an `import type` statement, so a file that " +
   'splits its value and type imports contributes two distinct entries). ' +
-  "'forced' statements name at least one symbol the barrel does not " +
-  're-export: they are a report that a leaf module is missing from the ' +
-  'published surface, and only a NEW off-surface specifier fails the ratchet. ' +
-  "'gratuitous' statements could have used the barrel verbatim; their per-" +
-  'specifier count may not grow. Classification is computed against ' +
+  "'forced' statements either name a symbol the barrel does not re-export, " +
+  'or are exact documented layering-floor entries that cannot use the barrel ' +
+  'without creating a cycle. A new off-surface specifier or layering-floor ' +
+  "entry fails the ratchet. 'gratuitous' statements could use the barrel " +
+  'verbatim and have no documented layering constraint; any new entry fails. ' +
+  'Classification is computed against ' +
   'src/shared/schemas/index.ts at test time, so widening the barrel ' +
   'reclassifies statements automatically (and requires regenerating this ' +
   'file in the same PR). The leaf-aware published-surface snapshot preserves ' +
-  'the exact type/value bindings used by baseline gratuitous imports, so those ' +
+  'the exact type/value bindings used by published deep imports, so those ' +
   'bindings may not contract even if their importers move. Scan covers ' +
   'repo-root src/ and every packages/*/src directory, excluding only the ' +
   'surface interior src/shared/schemas/ (test-kernel files are ratcheted ' +
@@ -546,10 +544,9 @@ function isLeafFullyPublished(
   );
 }
 
-function collectCurrent(): Pick<
-  SchemasBaseline,
-  'surface' | 'forced' | 'gratuitous'
-> {
+function collectCurrent(
+  documentedForced: DeepImports = {},
+): Pick<SchemasBaseline, 'surface' | 'forced' | 'gratuitous'> {
   const moduleMemo = new Map<string, ModuleExports>();
   const fullSurface = publishedSurface(moduleMemo);
   const referencedSurface: MutablePublishedSurface = new Map();
@@ -574,7 +571,7 @@ function collectCurrent(): Pick<
         const resolvedSpaces = reference.bindings?.map((binding) =>
           reachableSpace(fullSurface, reference.specifier, binding, moduleMemo),
         );
-        const isGratuitous =
+        const isPublished =
           reference.bindings == null
             ? isLeafFullyPublished(
                 fullSurface,
@@ -583,8 +580,12 @@ function collectCurrent(): Pick<
                 reference.typeOnly,
               )
             : resolvedSpaces?.every((space) => space != null) === true;
-        const bucket = isGratuitous ? gratuitous : forced;
-        if (isGratuitous) {
+        const entry = reference.typeOnly ? `${repoPath} (type-only)` : repoPath;
+        const isDocumentedFloor =
+          isPublished &&
+          documentedForced[reference.specifier]?.includes(entry) === true;
+        const bucket = isPublished && !isDocumentedFloor ? gratuitous : forced;
+        if (isPublished) {
           if (reference.bindings == null) {
             const published = fullSurface[reference.specifier];
             for (const space of ['type', 'value'] as const) {
@@ -611,9 +612,7 @@ function collectCurrent(): Pick<
             }
           }
         }
-        (bucket[reference.specifier] ??= []).push(
-          reference.typeOnly ? `${repoPath} (type-only)` : repoPath,
-        );
+        (bucket[reference.specifier] ??= []).push(entry);
       }
     }
   }
@@ -794,55 +793,34 @@ describe('@shared/schemas deep-import ratchet', () => {
     ).toBe('value');
   });
 
-  // One scan for the whole suite; every case reads the same snapshot.
-  const current = collectCurrent();
+  const baseline = JSON.parse(
+    readFileSync(BASELINE_PATH, 'utf8'),
+  ) as SchemasBaseline;
+  // One scan for the whole suite; every case reads the same snapshot. Exact
+  // published entries in `forced` are documented layering floors.
+  const current = collectCurrent(baseline.forced);
   if (process.env.TEXRA_UPDATE_SHARED_SCHEMAS_BASELINE === '1') {
     writeFileSync(
       BASELINE_PATH,
       `${JSON.stringify({ semantics: SEMANTICS, ...current }, null, 2)}\n`,
     );
   }
-  const baseline = JSON.parse(
-    readFileSync(BASELINE_PATH, 'utf8'),
-  ) as SchemasBaseline;
 
   it('does not add gratuitous @shared/schemas deep imports', () => {
-    const specifiers = [
-      ...new Set([
-        ...Object.keys(baseline.gratuitous),
-        ...Object.keys(current.gratuitous),
-      ]),
-    ].toSorted((a, b) => a.localeCompare(b));
-    const grown = specifiers.filter(
-      (specifier) =>
-        (current.gratuitous[specifier]?.length ?? 0) >
-        (baseline.gratuitous[specifier]?.length ?? 0),
-    );
-    const report = grown
-      .map((specifier) => {
+    const added = Object.entries(current.gratuitous).flatMap(
+      ([specifier, entries]) => {
         const allowed = new Set(baseline.gratuitous[specifier] ?? []);
-        const added = (current.gratuitous[specifier] ?? []).filter(
-          (entry) => !allowed.has(entry),
-        );
-        return `  ${specifier}: ${allowed.size} -> ${current.gratuitous[specifier]?.length ?? 0}\n${added
-          .map((entry) => `    + ${entry}`)
-          .join('\n')}`;
-      })
-      .join('\n');
-    expect(
-      grown,
-      `Every name in these statements is already exported by '@shared/schemas'; import the barrel instead.\n${report}\n\n` +
-        `If the growth is intentional (e.g. the barrel was widened, reclassifying forced statements), regenerate ${BASELINE_FILE} in this PR.`,
-    ).toEqual([]);
-  });
-
-  it('scans test-kernel files so their deep imports stay ratcheted', () => {
-    // The scan must actually cover src/test-kernel. A revert of
-    // `excludeTestKernel: false` would still pass the count-growth cases below
-    // (they only fail on growth, never shrinkage), so pin one known entry.
-    expect(current.gratuitous['@shared/schemas/todo']).toContain(
-      'src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts',
+        return entries
+          .filter((entry) => !allowed.has(entry))
+          .map((entry) => `${specifier}: ${entry}`);
+      },
     );
+    expect(
+      added,
+      `Every name in these statements is already exported by '@shared/schemas'; import the barrel instead.\n` +
+        added.map((entry) => `  + ${entry}`).join('\n') +
+        `\n\nIf the growth is intentional (e.g. the barrel was widened, reclassifying forced statements), regenerate ${BASELINE_FILE} in this PR.`,
+    ).toEqual([]);
   });
 
   it('does not push a new module off the published @shared/schemas surface', () => {

--- a/src/test-kernel/architecture/sharedSchemasDeepImportRatchet.vitest.ts
+++ b/src/test-kernel/architecture/sharedSchemasDeepImportRatchet.vitest.ts
@@ -4,18 +4,17 @@
 // past it into `@shared/schemas/<leaf>` are. Clones the checked-in-baseline +
 // AST-scanning vitest pattern from hostAgentDeepImportRatchet.vitest.ts.
 //
-// The one design requirement: deep imports are recorded in TWO classes, and
-// they are gated differently, because they mean opposite things.
+// Deep imports are recorded in three classes with distinct semantics.
 //
-//   forced     — either the statement names a symbol the barrel does not
-//                re-export, or the exact statement is a documented layering
-//                floor that cannot use the barrel without creating a cycle.
-//                New off-surface modules and new floor entries fail.
-//   gratuitous — every name is reachable through `@shared/schemas`, with no
-//                documented layering constraint. Any new statement fails.
+//   floors      — exact published statements that cannot use the barrel without
+//                 creating a dependency cycle. Any new statement fails.
+//   forced      — the statement names a symbol the barrel does not re-export.
+//                 Any new off-surface statement fails.
+//   gratuitous  — every name is reachable through `@shared/schemas`, with no
+//                 documented layering constraint. Any new statement fails.
 //
-// Collapsing the two into one number would peg the total at the forced floor
-// forever, which reads as a broken ratchet (cf. #8900) and gets it deleted.
+// Keeping floors separate lets a later barrel widening reclassify an ordinary
+// forced import as gratuitous instead of silently grandfathering it.
 //
 // Regenerate after an intentional change:
 //   TEXRA_UPDATE_SHARED_SCHEMAS_BASELINE=1 npx vitest run \
@@ -45,11 +44,11 @@ const SEMANTICS =
   'barrel into a leaf module, keyed by specifier, valued by the importing ' +
   "file ('(type-only)' marks an `import type` statement, so a file that " +
   'splits its value and type imports contributes two distinct entries). ' +
-  "'forced' statements either name a symbol the barrel does not re-export, " +
-  'or are exact documented layering-floor entries that cannot use the barrel ' +
-  'without creating a cycle. A new off-surface specifier or layering-floor ' +
-  "entry fails the ratchet. 'gratuitous' statements could use the barrel " +
-  'verbatim and have no documented layering constraint; any new entry fails. ' +
+  "'floors' are exact published statements that cannot use the barrel " +
+  "without creating a dependency cycle. 'forced' statements name a symbol " +
+  "the barrel does not re-export. 'gratuitous' statements could use the " +
+  'barrel verbatim and have no documented layering constraint. Any new entry ' +
+  'in any class fails. ' +
   'Classification is computed against ' +
   'src/shared/schemas/index.ts at test time, so widening the barrel ' +
   'reclassifies statements automatically (and requires regenerating this ' +
@@ -73,6 +72,7 @@ type PublishedSurface = Record<string, PublishedLeafSurface>;
 interface SchemasBaseline {
   semantics: string;
   surface: PublishedSurface;
+  floors: DeepImports;
   forced: DeepImports;
   gratuitous: DeepImports;
 }
@@ -544,14 +544,21 @@ function isLeafFullyPublished(
   );
 }
 
-function collectCurrent(
-  documentedForced: DeepImports = {},
-): Pick<SchemasBaseline, 'surface' | 'forced' | 'gratuitous'> {
+interface CollectedSchemas extends Pick<
+  SchemasBaseline,
+  'surface' | 'floors' | 'forced' | 'gratuitous'
+> {
+  scannedTestKernelFiles: number;
+}
+
+function collectCurrent(documentedFloors: DeepImports = {}): CollectedSchemas {
   const moduleMemo = new Map<string, ModuleExports>();
   const fullSurface = publishedSurface(moduleMemo);
   const referencedSurface: MutablePublishedSurface = new Map();
+  const floors: DeepImports = {};
   const forced: DeepImports = {};
   const gratuitous: DeepImports = {};
+  let scannedTestKernelFiles = 0;
 
   for (const root of scanRoots()) {
     for (const file of sourceFilesUnder(resolve(REPO_ROOT, root), {
@@ -559,6 +566,7 @@ function collectCurrent(
       missingDirReturnsEmpty: true,
     })) {
       const repoPath = toRepoPath(file);
+      if (repoPath.startsWith('src/test-kernel/')) scannedTestKernelFiles += 1;
       if (repoPath.startsWith(SURFACE_INTERIOR)) continue;
       // Cheap text gate before the parser: only ~300 of ~2k files can match,
       // and parsing the rest is what makes this ratchet slow enough to starve
@@ -583,8 +591,9 @@ function collectCurrent(
         const entry = reference.typeOnly ? `${repoPath} (type-only)` : repoPath;
         const isDocumentedFloor =
           isPublished &&
-          documentedForced[reference.specifier]?.includes(entry) === true;
-        const bucket = isPublished && !isDocumentedFloor ? gratuitous : forced;
+          documentedFloors[reference.specifier]?.includes(entry) === true;
+        let bucket = forced;
+        if (isPublished) bucket = isDocumentedFloor ? floors : gratuitous;
         if (isPublished) {
           if (reference.bindings == null) {
             const published = fullSurface[reference.specifier];
@@ -627,8 +636,10 @@ function collectCurrent(
     );
   return {
     surface: sortPublishedSurface(referencedSurface),
+    floors: sorted(floors),
     forced: sorted(forced),
     gratuitous: sorted(gratuitous),
+    scannedTestKernelFiles,
   };
 }
 
@@ -637,6 +648,15 @@ function total(imports: DeepImports): number {
     (sum, entries) => sum + entries.length,
     0,
   );
+}
+
+function addedEntries(current: DeepImports, baseline: DeepImports): string[] {
+  return Object.entries(current).flatMap(([specifier, entries]) => {
+    const allowed = new Set(baseline[specifier] ?? []);
+    return entries
+      .filter((entry) => !allowed.has(entry))
+      .map((entry) => `${specifier}: ${entry}`);
+  });
 }
 
 function contractedSurface(
@@ -722,6 +742,7 @@ describe('@shared/schemas deep-import ratchet', () => {
           value: ['RuntimeSchema'],
         },
       },
+      floors: {},
       forced: { [specifier]: ['src/already-forced.ts'] },
       gratuitous: { [specifier]: ['src/old.ts'] },
     };
@@ -793,28 +814,28 @@ describe('@shared/schemas deep-import ratchet', () => {
     ).toBe('value');
   });
 
+  const baselineBeforeUpdate = JSON.parse(
+    readFileSync(BASELINE_PATH, 'utf8'),
+  ) as SchemasBaseline;
+  // Use the pre-write snapshot only to classify explicitly documented floors.
+  const current = collectCurrent(baselineBeforeUpdate.floors);
+  if (process.env.TEXRA_UPDATE_SHARED_SCHEMAS_BASELINE === '1') {
+    const snapshot: SchemasBaseline = {
+      semantics: SEMANTICS,
+      surface: current.surface,
+      floors: current.floors,
+      forced: current.forced,
+      gratuitous: current.gratuitous,
+    };
+    writeFileSync(BASELINE_PATH, `${JSON.stringify(snapshot, null, 2)}\n`);
+  }
+  // Regen runs gate against what they just wrote, not the stale input snapshot.
   const baseline = JSON.parse(
     readFileSync(BASELINE_PATH, 'utf8'),
   ) as SchemasBaseline;
-  // One scan for the whole suite; every case reads the same snapshot. Exact
-  // published entries in `forced` are documented layering floors.
-  const current = collectCurrent(baseline.forced);
-  if (process.env.TEXRA_UPDATE_SHARED_SCHEMAS_BASELINE === '1') {
-    writeFileSync(
-      BASELINE_PATH,
-      `${JSON.stringify({ semantics: SEMANTICS, ...current }, null, 2)}\n`,
-    );
-  }
 
   it('does not add gratuitous @shared/schemas deep imports', () => {
-    const added = Object.entries(current.gratuitous).flatMap(
-      ([specifier, entries]) => {
-        const allowed = new Set(baseline.gratuitous[specifier] ?? []);
-        return entries
-          .filter((entry) => !allowed.has(entry))
-          .map((entry) => `${specifier}: ${entry}`);
-      },
-    );
+    const added = addedEntries(current.gratuitous, baseline.gratuitous);
     expect(
       added,
       `Every name in these statements is already exported by '@shared/schemas'; import the barrel instead.\n` +
@@ -823,18 +844,13 @@ describe('@shared/schemas deep-import ratchet', () => {
     ).toEqual([]);
   });
 
-  it('does not push a new module off the published @shared/schemas surface', () => {
-    // A forced statement against an already-off-surface module is allowed: the
-    // author has no barrel path. A NEW off-surface specifier is a widening of
-    // the gap and needs the surface-membership decision, not a silent baseline.
-    const newlyForced = Object.keys(current.forced)
-      .filter((specifier) => !(specifier in baseline.forced))
-      .toSorted((a, b) => a.localeCompare(b));
+  it('does not add off-surface @shared/schemas deep imports', () => {
+    const added = addedEntries(current.forced, baseline.forced);
     expect(
-      newlyForced,
-      `These statements name symbols '@shared/schemas' does not re-export, from modules that were not previously off-surface:\n` +
-        newlyForced.map((specifier) => `  + ${specifier}`).join('\n') +
-        `\n\nEither import a symbol the barrel publishes, or land the surface-membership decision and regenerate ${BASELINE_FILE}.`,
+      added,
+      `These statements name symbols '@shared/schemas' does not re-export:\n` +
+        added.map((entry) => `  + ${entry}`).join('\n') +
+        `\n\nEither publish and import the symbol through the barrel, or land the surface-membership decision and regenerate ${BASELINE_FILE}.`,
     ).toEqual([]);
   });
 
@@ -848,12 +864,12 @@ describe('@shared/schemas deep-import ratchet', () => {
     ).toEqual([]);
   });
 
-  it('keeps forced and gratuitous separate, sorted, and duplicate-free', () => {
-    // Separation is the point of this ratchet: a combined count could never
-    // fall below the forced floor and would be read as permanently stuck.
+  it('keeps floors, forced, and gratuitous sorted and duplicate-free', () => {
+    // Separate keys preserve each class's distinct migration policy.
     expect(Object.keys(baseline)).toEqual([
       'semantics',
       'surface',
+      'floors',
       'forced',
       'gratuitous',
     ]);
@@ -867,7 +883,7 @@ describe('@shared/schemas deep-import ratchet', () => {
         );
       }
     }
-    for (const key of ['forced', 'gratuitous'] as const) {
+    for (const key of ['floors', 'forced', 'gratuitous'] as const) {
       for (const [specifier, entries] of Object.entries(baseline[key])) {
         // Sorted AND distinct: a duplicated entry would inflate the allowed
         // count and silently weaken the ratchet.
@@ -876,8 +892,13 @@ describe('@shared/schemas deep-import ratchet', () => {
         );
       }
     }
-    expect(total(baseline.forced) + total(baseline.gratuitous)).toBeGreaterThan(
-      0,
-    );
+    // Pin collectCurrent's scope: excluding test-kernel again must fail even
+    // though no test-kernel deep import remains in the baseline.
+    expect(current.scannedTestKernelFiles).toBeGreaterThan(0);
+    expect(
+      total(baseline.floors) +
+        total(baseline.forced) +
+        total(baseline.gratuitous),
+    ).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Post-merge correction to #10609. That PR was merged at `72fb2b38` while its
final review was still in progress, leaving three baseline rows and stale B1
premises behind. This follow-up applies only the missed final-review delta on
top of current `main`.

Closes #10684

Refs #10642

- Migrates the two test-file leaf imports in
  `SharedLiteralImmutability.vitest.ts` to the published `@shared/schemas`
  barrel. No standalone test or regression suite is added.
- Keeps `src/logger/logUtils.ts` on `@shared/schemas/log`: importing the barrel
  there would create `logUtils → schemas barrel → stateSettings →
  approvalPolicy → logUtils`.
- Records that exact logger statement under a dedicated `floors` key, leaving
  both ordinary off-surface `forced` and migratable `gratuitous` empty.
- Gates gratuitous and off-surface statements by exact entry rather than only
  specifier count/key. A new off-surface statement under the floor's
  `@shared/schemas/log` specifier therefore fails too.
- Keeps ordinary `forced` entries separate from cycle floors, so widening the
  barrel later reclassifies an ordinary forced entry as gratuitous instead of
  grandfathering it as a floor.
- Preserves baseline regeneration: the pre-write snapshot is used only to
  recognize documented floors; all gates read the post-write baseline.
- Retains test-kernel scan coverage without a pinned deep import by asserting,
  inside the existing ratchet case, that `collectCurrent` scanned test-kernel
  files.
- Corrects B1 history and B7 wording. At #10609's merge base the baseline had
  278 rows: 277 migratable and one cycle floor. The earlier 281 count preceded
  three intervening baseline removals.

## Exact baseline semantics

The 14-line baseline contains three unambiguous classes:

- `floors`: one exact published cycle exception,
  `@shared/schemas/log` → `src/logger/logUtils.ts`;
- `forced: {}`: zero ordinary off-surface rows;
- `gratuitous: {}`: zero migratable rows.

Any new entry in any class fails. A floor is recognized only through the
pre-existing `floors` entry. Ordinary forced imports continue to be classified
from current barrel exports, so barrel widening moves them to `gratuitous` and
requires migration/regeneration.

## Net elements (R6)

Against current `main`:

- **5 files modified**, 0 added, 0 deleted;
- **+113 / −124 LoC, net −11**;
- no exported symbols, classes, interfaces, or enums added or removed;
- no new standalone tests or test files.

## Consumer counts (R8)

- `SharedLiteralImmutability.vitest.ts`: one test consumer remains; its three
  symbols (`STATUS_DISPLAY`, `STATUS_ICONS`, `TODO_STATUS`) move from two leaf
  import statements to one barrel statement.
- `logUtils.ts`: one retained leaf-import consumer with the same two bindings
  (`LOG_LEVELS`, `LogLevel`) and unchanged runtime dependency direction.
- Ratchet and proposal edits affect architecture enforcement/documentation
  only; they add no production consumers or emit paths.

## Host impact

Extension / Desktop / CLI: none. The only source import retained in production
is unchanged; the other import migration is test-only.

## Validation

- Focused architecture/literal suites: **2 files, 30 tests passed**.
- Mutation checks:
  - a new off-surface import under the existing floor specifier is rejected;
  - a published row placed in ordinary `forced` reclassifies to gratuitous and
    is rejected;
  - regen with a real new entry writes it and passes against the post-write
    baseline.
- Normal baseline regeneration followed by Prettier is idempotent.
- `npm run typecheck` — all six subprojects clean.
- `npm run lint` — clean.
- Prettier check over all changed files — clean.
- `npm run check:dead-code-ratchet` — **8 current vs 8 baselined**.
- `git diff --check` — clean.
