### PR TITLE
fix(agent): forward the resolved run session into the launch context (C6)

### DIFF
--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -155,6 +155,11 @@ export async function runAgent(
       }
       const result = await executeAgent(config, executionId, {
         ...executeAgentOptions,
+        // Forward the session resolved above: without it the launch context
+        // redefaults to the ambient `currentSession()`, which can disagree
+        // with the lease handling's `runSession` inside another run's async
+        // context.
+        session: runSession,
         streamTabIdOverride: resumedStreamId,
         userFollowUpSupport,
         onRun: async (handle) => {


### PR DESCRIPTION
## Summary

Implements finding **C6** ("one session default per chain") of the services-injection audit (`docs/proposals/2026-08-16-services-injection-audit.md`), the correctness-flavored core of #10677's PR 3. C12, C13, C14 and the remaining batches are intentionally out of scope.

`runAgent` resolves `runSession = options.session ?? defaultSession()` for lease release, but spread the unresolved `executeAgentOptions` into `executeAgent`, so `buildAgentLaunchContext` redefaulted via `?? currentSession()` — which is ambient-else-default. Inside another run's async context with no explicit session, the launch context and the lease handling could target two different sessions. Verified latent in the audit (no current production caller hits the divergence); this deletes the divergence itself.

Fix, exactly as the audit prescribes: forward the already-resolved `runSession` explicitly in the same call, with a comment pinning why the redundant-looking forward must stay.

Production-only; no test changes.

## Net LoC / elements (R6)

- `src/agent/runtime/runAgent.ts`: +5 (one forwarding line + four comment lines), −0. Net **+5 LoC** against **−1 fallback divergence** on the launch chain; element delta **0** (no construct added — one existing fact now carried explicitly, §15 "decide once, carry as data").

## Overlap audit

Open PRs checked: #10683 (#10677 PR 1 dead-surface sweep — touches `AgentLaunchContext.ts`/`executeAgent.ts` but leaves `launchSession = input.session ?? currentSession()` unchanged and does not touch `runAgent.ts`; no textual or semantic conflict in either landing order), #10667 (docs), #10660 (Kimi retry), #10657 (format-staged). No conflicts.

## Validation

- `src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts`: 13/13 pass (unmodified)
- `src/test-kernel/agent/runtime/` + `RunExecution` + `DesktopAgentExecution`/`Factory`/`Resume` suites: 45 files, 680/680 pass (unmodified)
- `npm run typecheck` (workspace, test-kernel, agent, cli, trace-viewer, desktop): clean
- eslint on the changed file, `prettier --check`, `git diff --check`: clean

Refs #10677
