### PR TITLE
refactor(agent): make provider-message-block category switches compile-time exhaustive (#10686)

### DIFF
--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -24,13 +24,14 @@ import {
 import {
   classifyProviderMessageBlockType,
   CONVERSATION_BLOCK_TYPES,
+  type ProviderMessageBlockCategory,
 } from '@agent/types/ConversationBlockTypes';
 import {
   ANTHROPIC_SERVER_TOOL_BLOCK_TYPES,
   extractWebFetchResultFields,
   WebSearchResultEntrySchema,
 } from '@agent/types/ServerTools';
-import { isObject } from '@utils/core';
+import { assertNever, isObject } from '@utils/core';
 import type { Part } from '@google/genai';
 import type {
   ChatCompletionMessageParam,
@@ -246,15 +247,28 @@ function blocksToUserParts(blocks: ContentBlock[]): UserPart[] {
       if (b.text) parts.push({ type: 'text', text: b.text });
       continue;
     }
-    switch (classifyProviderMessageBlockType(b.type)) {
+    const category: ProviderMessageBlockCategory | undefined =
+      classifyProviderMessageBlockType(b.type);
+    switch (category) {
       case 'image-attachment':
         parts.push({ type: 'attachment', attachmentType: 'image' });
         break;
       case 'document-attachment':
         parts.push({ type: 'attachment', attachmentType: 'document' });
         break;
-      default:
+      // Every other recognized block carries no user part — thinking and the
+      // tool blocks are assistant-side (tool results reach the export via
+      // `extractToolResultText`); `undefined` covers unrecognized tags.
+      case 'thinking':
+      case 'tool-use':
+      case 'tool-result':
+      case 'server-tool-use':
+      case 'web-search-tool-result':
+      case 'web-fetch-tool-result':
+      case undefined:
         break;
+      default:
+        assertNever(category, 'Unhandled provider message block category');
     }
   }
   return parts;
@@ -291,7 +305,10 @@ function asClassifiedBlock<T extends ContentBlock['type']>(
 // `@agent/storage/conversationFormat` via `classifyProviderMessageBlockType`
 // (`@agent/types/ConversationBlockTypes`) — one switch recognizes the tags;
 // each module maps the category into its own output shape (a structured
-// `ExportNode` here vs. a truncated marker string there).
+// `ExportNode` here vs. a truncated marker string there). Both category
+// switches in this module are exhaustive over `ProviderMessageBlockCategory`
+// (`default: assertNever`), so a category added to the classifier fails at
+// compile time here instead of silently dropping the block.
 function assistantBlockToNode(block: ContentBlock): ExportNode | null {
   // Anthropic: 'text', OpenAI Response API: 'output_text'. Text tags stay
   // per-literal (see `blocksToUserParts` for the user-side split).
@@ -301,7 +318,9 @@ function assistantBlockToNode(block: ContentBlock): ExportNode | null {
       : null;
   }
 
-  switch (classifyProviderMessageBlockType(block.type)) {
+  const category: ProviderMessageBlockCategory | undefined =
+    classifyProviderMessageBlockType(block.type);
+  switch (category) {
     case 'thinking':
       return null;
 
@@ -365,8 +384,15 @@ function assistantBlockToNode(block: ContentBlock): ExportNode | null {
       };
     }
 
-    default:
+    // Attachment blocks belong to user messages (`blocksToUserParts`); on the
+    // assistant side they — like unrecognized tags (`undefined`) — produce no
+    // export node.
+    case 'image-attachment':
+    case 'document-attachment':
+    case undefined:
       return null;
+    default:
+      return assertNever(category, 'Unhandled provider message block category');
   }
 }
 

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -25,9 +25,10 @@
 import {
   classifyProviderMessageBlockType,
   CONVERSATION_BLOCK_TYPES,
+  type ProviderMessageBlockCategory,
 } from '@agent/types/ConversationBlockTypes';
 import { extractWebFetchResultFields } from '@agent/types/ServerTools';
-import { isObject } from '@utils/core';
+import { assertNever, isObject } from '@utils/core';
 
 const DEFAULT_TRUNCATION_MARKER = '...';
 
@@ -273,8 +274,13 @@ function formatConversationBlock(
   // `@agent/export/normalizeConversation` via `classifyProviderMessageBlockType`
   // (`@agent/types/ConversationBlockTypes`) — one switch recognizes the tags;
   // each module maps the category into its own output shape (a truncated
-  // marker string here vs. a structured `ExportNode` there).
-  switch (classifyProviderMessageBlockType(block.type)) {
+  // marker string here vs. a structured `ExportNode` there). The switch is
+  // exhaustive over `ProviderMessageBlockCategory` (`default: assertNever`),
+  // so a category added to the classifier fails here at compile time instead
+  // of silently falling into the JSON dump.
+  const category: ProviderMessageBlockCategory | undefined =
+    classifyProviderMessageBlockType(block.type);
+  switch (category) {
     case 'image-attachment':
       return '[image attachment]';
     case 'document-attachment':
@@ -307,12 +313,17 @@ function formatConversationBlock(
       return formatWebSearchResultMarker(block.content, options);
     case 'web-fetch-tool-result':
       return formatWebFetchResultMarker(block, options);
-    default:
+    // Unrecognized tags — including the deliberately unclassified
+    // `input_text`/`output_text` literals (see the classifier's docstring) —
+    // keep the JSON-dump fallback.
+    case undefined:
       return truncate(
         stringifyConversationValue(block),
         options.toolBlockLimit,
         options,
       );
+    default:
+      return assertNever(category, 'Unhandled provider message block category');
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up from #10681: `ProviderMessageBlockCategory` was exported from `@agent/types/ConversationBlockTypes` with zero consumers outside that module — both consumer switches matched bare string literals, so adding a category to the classifier (or renaming one) compiled clean and silently routed the tag into each consumer's catch-all `default` arm (JSON dump in storage views, dropped/`null` in export). That's the drift mode #10681 exists to kill, moved one hop away.

This PR takes the issue's first option: both consumers now import the type and all three category switches are compile-time exhaustive over it. Each site binds the classifier result as `ProviderMessageBlockCategory | undefined`, cases the fallbacks explicitly, and ends in `default: assertNever(category, ...)` (the repo's exhaustiveness helper from `@utils/core`). A category added to the classifier without updating a consumer now fails that consumer's compile (`TS2345` at the `assertNever` arm) — verified by mutation probe (see Validation).

Runtime behavior is unchanged — production-only, no test changes (maintainer direction):

- `formatConversationBlock` (`@agent/storage/conversationFormat`): all 8 category arms keep their exact expressions; the pre-existing JSON-dump fallback moves verbatim from `default` to `case undefined` — unrecognized tags and the deliberately unclassified `input_text`/`output_text` literals render exactly as before. The new `default` is unreachable at runtime (the classifier returns only the 8 categories or `undefined`).
- `blocksToUserParts` (`@agent/export/normalizeConversation`): the two attachment arms are unchanged; the six non-attachment categories and `undefined` move from the catch-all `default: break` to explicit grouped no-op cases — same drop behavior.
- `assistantBlockToNode` (`@agent/export/normalizeConversation`): the six existing arms are unchanged; assistant-side `image-attachment`/`document-attachment` and `undefined` move from `default: return null` to explicit `return null` cases — same drop behavior.
- `extractToolResultText` is intentionally untouched: its `!== 'tool-result'` predicate is not a switch, a category rename already fails there at compile time (literal no longer comparable), and a category addition keeps correct semantics (a non-tool-result block has no tool-result text).

Closes #10686

## Issue acceptance gates

- [x] Both consumers import `ProviderMessageBlockCategory` and their category switches are exhaustive over it (`default: assertNever(category)` after handling `undefined`), so classifier↔consumer drift fails at compile time.
- [x] Runtime behavior and the default malformed handling (JSON dump in storage views, dropped/`null` in export) are unchanged.

## Net elements (R6)

- Files: 2 modified, 0 added, 0 deleted. Production-only; no test changes.
- Exported symbols: +0 / -0. `ProviderMessageBlockCategory` gains its first consumers outside its defining module (type annotations at the three switch sites), resolving the zero-consumer observation.
- Net LoC (`git diff --numstat`): +47 / -10 = **+37**, the majority being the grouped explicit fallback cases and comments.

## Consumer counts (R8)

- `ProviderMessageBlockCategory`: 2 new importing modules (`@agent/storage/conversationFormat`, `@agent/export/normalizeConversation`), 3 annotation sites.
- `assertNever` (`@utils/core`): +3 call sites across the 2 modules; both modules already imported from `@utils/core`, so no new dependency edges (agent-internal, no subsystem-edge ratchet impact).

## Host impact

Extension: none (the `/executions/{id}/conversation` endpoint renders identically).

Desktop: none.

CLI: none (`texra history` / resume previews consume `formatConversationMessage`, unchanged output).

## Validation

- Mutation probe: temporarily added a `'mutation-probe'` member to `ProviderMessageBlockCategory`; `typecheck:workspace` failed with exactly three `TS2345` errors, one at each `assertNever` default arm (`normalizeConversation.ts` ×2, `conversationFormat.ts` ×1). Reverted; no such probe is committed.
- Existing unmodified suites: `normalizeConversation` (39), `ExecutionsConversationFormat` (16), `ConversationBlockTypeParity` (11) — 66/66 pass; full `src/test-kernel/agent` + the tools conversation-format suite — 204 files / 3132 tests pass (4 pre-existing skips).
- `typecheck` (workspace, test-kernel, agent, cli, trace-viewer, desktop) — pass.
- Architecture suite `src/test-kernel/architecture/` — 17 files / 102 tests, pass.
- Full ESLint (`pnpm lint`), repo-wide Prettier (`format:check`), `git diff --check` — clean.
- `check:dead-code-ratchet` (8=8 baseline), `check:guidance-refs`, `check:browser-safe-utils`, `check:tsconfig-paths` — pass.
