### PR TITLE
fix(cli): stop dropping retained finished children from the TUI roster

### DIFF
--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -23,6 +23,12 @@ interface RetainedParent {
   readonly streamId: StreamTabId;
   /** One-based, first-seen order within `streamId`. */
   readonly order: number;
+  /** The shared roster's retention stamp: set once the roster for
+   *  `streamId` lists this row as retained (`finishedAt`), cleared if the
+   *  row goes live again. Membership of a marked placement follows that
+   *  roster exactly — omission (cap eviction) drops the placement. Absent
+   *  for rows only ever seen live, whose placement survives omission. */
+  readonly finishedAt?: number;
 }
 
 type ParentProvenance =
@@ -282,7 +288,10 @@ function subagentEntryUnchanged(
  * child it never retains (or a direct unit-level projection). A late roster
  * from an incompatible (explicitly edged-elsewhere, or promoted) child
  * cannot resurrect active membership or overwrite a newer parent's summary
- * metadata.
+ * metadata — but a *retained* row still refreshes the historical
+ * placement's marker when that placement names this parent (post-promotion
+ * roster refreshes land here, e.g. "keep subagents running"), because
+ * retained membership follows the shared roster, not current topology.
  */
 export function projectChildRoster(
   parentStreamId: StreamTabId,
@@ -294,16 +303,22 @@ export function projectChildRoster(
   const snapshotIds = new Set<StreamTabId>();
   const live = new Map<StreamTabId, ActiveChildInfo>();
   const retainedRows = new Map<StreamTabId, ActiveChildInfo>();
+  const incompatibleRetainedRows = new Map<StreamTabId, ActiveChildInfo>();
   for (const child of children) {
     snapshotIds.add(child.childStreamId);
     const entry = current.get(child.childStreamId);
     if (entry?.kind === 'removed') continue;
     const parent = currentParent(entry);
-    if (parent !== undefined && parent !== parentStreamId) continue;
-    (child.finishedAt === undefined ? live : retainedRows).set(
-      child.childStreamId,
-      child,
-    );
+    const compatible = parent === undefined || parent === parentStreamId;
+    if (child.finishedAt === undefined) {
+      // Incompatible live rows are rejected outright.
+      if (!compatible) continue;
+      live.set(child.childStreamId, child);
+    } else if (compatible) {
+      retainedRows.set(child.childStreamId, child);
+    } else {
+      incompatibleRetainedRows.set(child.childStreamId, child);
+    }
   }
 
   let maxRetainedOrder = 0;
@@ -349,17 +364,36 @@ export function projectChildRoster(
         ...summary
       } = child;
       const existingRetained = retainedParent(entry);
-      const retained =
-        existingRetained ??
-        ({
+      // The placement's `finishedAt` marker tracks the shared roster's view
+      // of the row: a retained row stamps it, a live row clears it
+      // (re-live). Only placements naming THIS parent are marked — history
+      // retained from an earlier parent stays that parent's to sync.
+      const marker = active ? undefined : child.finishedAt;
+      let retained = existingRetained;
+      if (!retained) {
+        retained = {
           streamId: parentStreamId,
           order: ++maxRetainedOrder,
-        } satisfies RetainedParent);
+          ...(marker !== undefined ? { finishedAt: marker } : {}),
+        } satisfies RetainedParent;
+      } else if (
+        retained.streamId === parentStreamId &&
+        retained.finishedAt !== marker
+      ) {
+        retained = {
+          streamId: retained.streamId,
+          order: retained.order,
+          ...(marker !== undefined ? { finishedAt: marker } : {}),
+        };
+      }
       let parent = entry?.parent;
       if (!parent) {
         parent = { kind: 'roster', retained };
-      } else if (parent.kind === 'explicit' && !parent.retained) {
-        parent = { ...parent, retained };
+      } else if (!parent.retained || parent.retained !== retained) {
+        parent =
+          parent.kind === 'roster'
+            ? { kind: 'roster', retained }
+            : { ...parent, retained };
       }
       const nextEntry: LiveChildStreamEntry = {
         ...(entry ?? { kind: 'live' as const }),
@@ -373,18 +407,45 @@ export function projectChildRoster(
     }
   }
 
-  // Retained-membership sync: once a stored row carries `finishedAt` (the
-  // shared roster had retained it), its placement is dropped as soon as the
-  // roster stops listing the row — the applier only drops retained rows via
-  // its cap, so this propagates cap evictions exactly. Live-only rows are
-  // untouched (see the contract above). A roster-kind parent whose placement
-  // is dropped degrades to an explicit top-level edge, mirroring
-  // `applyChildStreamRemoval`'s conversion.
+  // Retained rows under an incompatible current topology (promoted or
+  // explicitly edged elsewhere) still refresh the historical placement's
+  // marker when that placement names this parent. Only the marker moves:
+  // active membership stays untouched and summary metadata is never
+  // overwritten from a stale parent's roster.
+  for (const [childStreamId, child] of incompatibleRetainedRows) {
+    const entry = out.get(childStreamId);
+    if (entry?.kind !== 'live') continue;
+    // Incompatible current topology with a placement naming this parent is
+    // always an explicit edge (a roster-kind placement naming this parent
+    // IS the compatible case).
+    const parent = entry.parent;
+    if (parent?.kind !== 'explicit') continue;
+    const retained = parent.retained;
+    if (retained?.streamId !== parentStreamId) continue;
+    if (retained.finishedAt === child.finishedAt) continue;
+    out.set(childStreamId, {
+      ...entry,
+      parent: {
+        ...parent,
+        retained: { ...retained, finishedAt: child.finishedAt },
+      },
+    });
+    changed = true;
+  }
+
+  // Retained-membership sync: once a placement carries the roster's
+  // retention stamp, it is dropped as soon as the roster stops listing the
+  // row — the applier only drops retained rows via its cap, so this
+  // propagates cap evictions exactly, including for rows promoted before
+  // the roster refresh. Live-only rows are untouched (see the contract
+  // above). A roster-kind parent whose placement is dropped degrades to an
+  // explicit top-level edge, mirroring `applyChildStreamRemoval`'s
+  // conversion.
   for (const [childStreamId, entry] of out) {
     if (entry.kind === 'removed') continue;
-    if (entry.summary?.finishedAt === undefined) continue;
     const retained = retainedParent(entry);
     if (retained?.streamId !== parentStreamId) continue;
+    if (retained.finishedAt === undefined) continue;
     if (snapshotIds.has(childStreamId)) continue;
     const parent: ParentProvenance =
       entry.parent?.kind === 'explicit'
@@ -527,9 +588,10 @@ export function activeSubagentsFor(
 /**
  * Retained child-stream history for a parent, in first-seen order. Survives
  * terminal status, and — for rows only ever seen live — roster omission;
- * once a row is recorded as retained (`finishedAt`), its membership mirrors
- * the parent's shared roster exactly, so cap eviction erases the
- * association, as does explicit removal of the child or this parent.
+ * once the placement carries the roster's retention stamp (`finishedAt`),
+ * membership mirrors the parent's shared roster exactly, so cap eviction
+ * erases the association, as does explicit removal of the child or this
+ * parent.
  */
 export function retainedChildStreamsFor(
   parentStreamId: StreamTabId,

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -232,6 +232,10 @@ function summaryUnchanged(
     a.executionId === b.executionId &&
     a.startedAt === b.startedAt &&
     a.elapsed === b.elapsed &&
+    // `finishedAt` is stamped once and frozen, but it is the retention
+    // marker: without comparing it, the live -> retained transition of an
+    // otherwise-identical row would read as a no-op.
+    a.finishedAt === b.finishedAt &&
     sameIdentity(a.identity, b.identity) &&
     a.workflowPhase === b.workflowPhase
   );
@@ -266,11 +270,19 @@ function subagentEntryUnchanged(
 }
 
 /**
- * `child.activity` roster snapshot for one parent: the
- * accepted children become the complete active-membership snapshot for that
- * parent at this hub position. A late roster from an incompatible (explicitly
- * edged-elsewhere, or promoted) child cannot resurrect active membership or
- * overwrite a newer parent's summary metadata.
+ * `child.activity` roster snapshot for one parent. The applier's roster is
+ * complete for that parent at this hub position and splits by `finishedAt`
+ * presence (the schema contract): rows without it are the active-membership
+ * snapshot; rows with it are finished children retained for display —
+ * history, never active membership. A placement whose row was recorded as
+ * retained is dropped exactly when the roster stops listing it (the
+ * applier's retained-cap eviction); a row only ever seen live keeps its
+ * placement on omission — the applier never emits a finished non-process
+ * child without `finishedAt`, so an omitted live-only row is a process
+ * child it never retains (or a direct unit-level projection). A late roster
+ * from an incompatible (explicitly edged-elsewhere, or promoted) child
+ * cannot resurrect active membership or overwrite a newer parent's summary
+ * metadata.
  */
 export function projectChildRoster(
   parentStreamId: StreamTabId,
@@ -279,13 +291,19 @@ export function projectChildRoster(
   const current = CHILD_STREAMS.get();
   if (current.get(parentStreamId)?.kind === 'removed') return;
 
-  const accepted = new Map<StreamTabId, ActiveChildInfo>();
+  const snapshotIds = new Set<StreamTabId>();
+  const live = new Map<StreamTabId, ActiveChildInfo>();
+  const retainedRows = new Map<StreamTabId, ActiveChildInfo>();
   for (const child of children) {
+    snapshotIds.add(child.childStreamId);
     const entry = current.get(child.childStreamId);
     if (entry?.kind === 'removed') continue;
     const parent = currentParent(entry);
     if (parent !== undefined && parent !== parentStreamId) continue;
-    accepted.set(child.childStreamId, child);
+    (child.finishedAt === undefined ? live : retainedRows).set(
+      child.childStreamId,
+      child,
+    );
   }
 
   let maxRetainedOrder = 0;
@@ -301,7 +319,8 @@ export function projectChildRoster(
   let changed = false;
 
   // Clear active membership for entries previously active under this parent
-  // but absent or incompatible with this snapshot.
+  // but absent or incompatible with this snapshot — including rows that
+  // arrived as retained history this time.
   for (const [childStreamId, entry] of current) {
     if (
       entry.kind === 'removed' ||
@@ -310,40 +329,68 @@ export function projectChildRoster(
     ) {
       continue;
     }
-    if (accepted.has(childStreamId)) continue;
+    if (live.has(childStreamId)) continue;
     out.set(childStreamId, { ...entry, active: false });
     changed = true;
   }
 
-  for (const [childStreamId, child] of accepted) {
-    const currentEntry = out.get(childStreamId);
-    const entry = currentEntry?.kind === 'live' ? currentEntry : undefined;
-    const {
-      childStreamId: _childStreamId,
-      status: _status,
-      ...summary
-    } = child;
-    const existingRetained = retainedParent(entry);
-    const retained =
-      existingRetained ??
-      ({
-        streamId: parentStreamId,
-        order: ++maxRetainedOrder,
-      } satisfies RetainedParent);
-    let parent = entry?.parent;
-    if (!parent) {
-      parent = { kind: 'roster', retained };
-    } else if (parent.kind === 'explicit' && !parent.retained) {
-      parent = { ...parent, retained };
+  // Live rows first, then retained history: the applier's emission order, so
+  // first-seen retained order matches the roster.
+  for (const [rows, active] of [
+    [live, true],
+    [retainedRows, false],
+  ] as const) {
+    for (const [childStreamId, child] of rows) {
+      const currentEntry = out.get(childStreamId);
+      const entry = currentEntry?.kind === 'live' ? currentEntry : undefined;
+      const {
+        childStreamId: _childStreamId,
+        status: _status,
+        ...summary
+      } = child;
+      const existingRetained = retainedParent(entry);
+      const retained =
+        existingRetained ??
+        ({
+          streamId: parentStreamId,
+          order: ++maxRetainedOrder,
+        } satisfies RetainedParent);
+      let parent = entry?.parent;
+      if (!parent) {
+        parent = { kind: 'roster', retained };
+      } else if (parent.kind === 'explicit' && !parent.retained) {
+        parent = { ...parent, retained };
+      }
+      const nextEntry: LiveChildStreamEntry = {
+        ...(entry ?? { kind: 'live' as const }),
+        summary,
+        active,
+        parent,
+      };
+      if (subagentEntryUnchanged(entry, nextEntry)) continue;
+      out.set(childStreamId, nextEntry);
+      changed = true;
     }
-    const nextEntry: LiveChildStreamEntry = {
-      ...(entry ?? { kind: 'live' as const }),
-      summary,
-      active: true,
-      parent,
-    };
-    if (subagentEntryUnchanged(entry, nextEntry)) continue;
-    out.set(childStreamId, nextEntry);
+  }
+
+  // Retained-membership sync: once a stored row carries `finishedAt` (the
+  // shared roster had retained it), its placement is dropped as soon as the
+  // roster stops listing the row — the applier only drops retained rows via
+  // its cap, so this propagates cap evictions exactly. Live-only rows are
+  // untouched (see the contract above). A roster-kind parent whose placement
+  // is dropped degrades to an explicit top-level edge, mirroring
+  // `applyChildStreamRemoval`'s conversion.
+  for (const [childStreamId, entry] of out) {
+    if (entry.kind === 'removed') continue;
+    if (entry.summary?.finishedAt === undefined) continue;
+    const retained = retainedParent(entry);
+    if (retained?.streamId !== parentStreamId) continue;
+    if (snapshotIds.has(childStreamId)) continue;
+    const parent: ParentProvenance =
+      entry.parent?.kind === 'explicit'
+        ? { kind: 'explicit', streamId: entry.parent.streamId }
+        : { kind: 'explicit', streamId: null };
+    out.set(childStreamId, { ...entry, parent });
     changed = true;
   }
 
@@ -479,8 +526,10 @@ export function activeSubagentsFor(
 
 /**
  * Retained child-stream history for a parent, in first-seen order. Survives
- * roster omission and terminal status; only explicit removal of the child or
- * this parent erases the association.
+ * terminal status, and — for rows only ever seen live — roster omission;
+ * once a row is recorded as retained (`finishedAt`), its membership mirrors
+ * the parent's shared roster exactly, so cap eviction erases the
+ * association, as does explicit removal of the child or this parent.
  */
 export function retainedChildStreamsFor(
   parentStreamId: StreamTabId,

--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -203,10 +203,12 @@ class TuiSessionRenderer implements SessionRendererPort {
     badges: Parameters<SessionRendererPort['onBadgesChanged']>[1],
   ): void {
     if (this.isStaleDispatch(streamId)) return;
-    projectChildRoster(
-      streamId,
-      badges.subagents.filter((child) => child.finishedAt === undefined),
-    );
+    // The shared applier already computed this roster — live rows plus the
+    // finished children it retains for display (phase-merged, 200-capped) —
+    // so project it whole. `finishedAt` presence alone marks a retained row
+    // (schema contract); dropping those rows here was the #9021-class bug
+    // (single-substrate plan, U1).
+    projectChildRoster(streamId, badges.subagents);
   }
 
   onFilesChanged(streamId: StreamTabId): void {

--- a/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
+++ b/packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts
@@ -205,9 +205,11 @@ class TuiSessionRenderer implements SessionRendererPort {
     if (this.isStaleDispatch(streamId)) return;
     // The shared applier already computed this roster — live rows plus the
     // finished children it retains for display (phase-merged, 200-capped) —
-    // so project it whole. `finishedAt` presence alone marks a retained row
-    // (schema contract); dropping those rows here was the #9021-class bug
-    // (single-substrate plan, U1).
+    // so project it whole; filtering retained rows out here was the
+    // #9021-class bug (single-substrate plan, U1). `projectChildRoster`
+    // splits by `finishedAt` presence (schema contract): live rows are
+    // active membership, retained rows are display history whose membership
+    // follows the shared roster (cap evictions included).
     projectChildRoster(streamId, badges.subagents);
   }
 


### PR DESCRIPTION
Refs #10668

## Summary

First A0 unlock (U1) of the single-substrate plan (`docs/proposals/2026-08-15-single-substrate-hosts-as-renderers.md` §3, §10.1): the CLI renderer now consumes the roster exactly as `SessionFactApplier.updateChildRoster` computed it — live rows plus finished children retained for display, phase-merged and capped at 200.

Production-only, two files (+93/−42, mostly contract comments):

- `packages/cli/src/chat/tui/state/sessionSignalsAdapter.ts`: the `finishedAt === undefined` filter in `TuiSessionRenderer.onBadgesChanged` is deleted; the roster passes through whole.
- `packages/cli/src/chat/tui/state/childExecutions.ts`: `projectChildRoster` is now `finishedAt`-aware (the schema contract: presence alone marks a retained finished row):
  - **Live rows** (`finishedAt` undefined) remain the complete active-membership snapshot — unchanged semantics.
  - **Retained rows** (`finishedAt` set) are projected as display history and are **never marked active** — so `activeSubagentsFor` (the killability/action selector) and everything derived from it exclude finished children.
  - **The retention stamp lives on the historical placement** (`RetainedParent.finishedAt`), not only the summary. A retained row arriving under an *incompatible* current topology — e.g. "keep subagents running" detaches the child (`setParentStream(child, null)`) before the retained roster refresh — still refreshes the placement's marker, while incompatible **live** rows stay rejected and summary metadata is never overwritten from a stale parent's roster.
  - **Retained-membership sync:** once a placement carries the stamp, it is dropped exactly when the shared roster stops listing the row, so the applier's 200-cap evictions propagate to the CLI — for promoted rows too. A row only ever seen *live* keeps its placement on omission: the applier never emits a finished non-process child without `finishedAt`, so such an omission is a process child it never retains (or a direct unit-level projection) — precisely the semantics the existing transition-matrix suites pin.
  - `summaryUnchanged` now compares `finishedAt`; otherwise the live→retained transition of an otherwise-identical row read as a no-op and the marker never landed in CLI state.

## Why

- Audit doc §4a (the #9021-class instance "retained finished subagent rows"): the adapter filtered retained rows out one line after the shared code computed them; the webview consumes the full roster via the same contract.
- First-round review (codex/claude/texra-ai, 5 threads) found the bare filter deletion left retained rows `active: true` and `finishedAt` never landing; both fixed by the split above. Final review (codex P2) found the promotion-ordering hole — `setParentStream(child, null)` before the retained refresh made the topology guard reject the retained row, so the marker never landed and eviction could never clean it; fixed by moving the stamp onto the historical placement.

### Boundary note (exactness limit, verified by scratch probe)

Cap eviction propagates exactly for every row that was listed as retained at least once — i.e. all incremental finish/eviction paths, including rows promoted before the refresh. The one unsyncable shape is a same-tick first retained emission with N>200 (more than 200 children vanishing in a *single* roster tick): rows evicted before ever being listed as retained are indistinguishable from process-child omissions at the CLI boundary, and the existing unmodified suites pin omission-survival for live-only rows. Consequence in that pathological case: up to N−200 legacy history rows persist — bounded by main's current behavior for the same input (which keeps all N), and with no route to killability (the rows are never active).

## Explicitly not in this PR

- The `SessionState` removal-tombstone promotion (second half of U1) and the U2 stable-identity metadata reads/invalidation are separate A0 steps per the plan and are untouched.
- No test changes per maintainer direction; validation below runs existing, unmodified suites (plus a scratch probe, run and deleted, described under Validation).

## Validation (at head `f5cbeb6ec7`)

- `vitest run src/test-kernel/cli/` — 151 files, 2701 passed / 1 skipped / 0 failed at `3b244e12c2`; after the placement-marker commit, the focused roster/action suites re-run green at `f5cbeb6ec7` (TuiStateAndFocus transition matrix, ChildControls, ChildListInteraction/Selection, SessionExitLease, CliStateStores, AppEscapeRouting, SlashCommandDispatch — 323/323), per the anti-overtesting budget.
- `vitest run src/test-kernel/progressView/ProgressBackendRetainedChildren.vitest.ts src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts` — 35/35 (shared applier semantics untouched).
- `npm run typecheck` — all six projects green (workspace, test-kernel, agent, cli, trace-viewer, desktop).
- eslint + prettier + `git diff --check` on the changed files — green.
- Scratch probe (deleted, never committed; re-run green on the final head) drove the real hub → adapter → applier → renderer path and asserted: finished child leaves `activeSubagentsFor` and lands in history with `finishedAt`; gradual 200-cap eviction removes the evicted row (exact 200-row history); identical re-emitted rosters cause no signal write; a directly-projected retained row loses its placement when omitted while a live-only row keeps its own; a child promoted before the retained refresh (`setParentStream(child, null)` ordering) keeps its history row, gets evicted cleanly when the roster stops listing it, and never has its summary overwritten by the stale parent's retained row.
- `TranscriptSessionPolicy.vitest.ts` "fails a headless execution before runtime construction when opening fails" timed out once during triage on this machine at the *previous* head (without these changes) and passes at base and in the final full run — a pre-existing load-sensitive flake, unrelated.
- Open-PR overlap audit: #10657, #10660, #10667, #10683, #10688, #10689 — none touch the session roster path.
