### PR TITLE
refactor(cli): pin the deliberate headless-shutdown cascade; correct V8 stopStream prescription

### DIFF
--- a/docs/proposals/2026-08-15-cross-host-consolidation.md
+++ b/docs/proposals/2026-08-15-cross-host-consolidation.md
@@ -550,19 +550,23 @@ login` does not sign in the GUI hosts and vice-versa. Ruling: is
   tool-availability/token/model-access half is **new**. → Wire desktop (and
   where sensible CLI TUI) subscriptions; where a host deliberately won't
   react, fence it at the signal declaration.
-- **V8. `detachActiveChildren` bypasses its own SSOT — 1 bug + 2 sites to
-  document.** `detachSubagentsOnStop.ts:17` documents itself as "shared by
-  every host" and is honored at 4 sites; `chatSessionController.ts:856-858`
-  (`stopStream`) hardcodes `true` — that is the plain bug (the same TUI
-  applies two policies depending on which surface the user stops from).
-  _(Narrowed after review:)_ the `runExecution.ts:409,505` optionless
-  `kill(id)` sites are on the **process-shutdown path**, where cascade-kill
-  is correct — a detached child cannot outlive the exiting CLI process, and
-  applying the toggle there would strand children without finalization. Fix:
-  `stopStream` consults the SSOT; the shutdown sites pass an explicit
-  `{detachActiveChildren: false}` with a comment declaring the deliberate
-  cascade (per the lifecycle doc §4). (CP2's "CLI has no setter" half
-  remains a separate decision.)
+- **V8. `detachActiveChildren` "SSOT bypass" — ruled deliberate divergence;
+  2 shutdown sites documented.** `detachSubagentsOnStop.ts:17` documents
+  itself as "shared by every host" and is honored at 4 sites;
+  `chatSessionController.ts:856-858` (`stopStream`) hardcodes `true`.
+  _(Corrected after re-audit against #9009:)_ the hardcode is deliberate
+  action-semantic divergence, not a bypass — bare Escape is the
+  focus-scoped gesture ("Stop only the focused stream", `App.tsx:149-150`)
+  and always detaches descendants, while the configured stop surfaces
+  (root stop, extension/desktop stop, orchestrator kill) consult the
+  setting. The `runExecution.ts:409,505` `kill(id)` sites are on the
+  **process-shutdown path**, where cascade-kill is correct — a detached
+  child cannot outlive the exiting CLI process, and applying the toggle
+  there would strand children without finalization. Landed: the shutdown
+  sites pass an explicit `{detachActiveChildren: false}` with a comment
+  declaring the deliberate cascade (per the lifecycle doc §4); `stopStream`
+  keeps its #9009 contract. (CP2's "CLI has no setter" half remains a
+  separate decision.)
 - **V9. "Resumable" has two truth sources.** GUI hosts:
   `deriveResumability(id)` with typed causes
   (`HistoryMessageBuilder.ts:36-42`, `resumability.ts:82`). CLI:
@@ -718,8 +722,9 @@ Re-checked at this HEAD during the sweep:
   truth-source facet with current line numbers.
 - **DR8 (usage totals):** still open; §2 C13's predicate row is a smaller,
   independent slice.
-- **CP2 (detach policy):** the SSOT-bypass half is now §3 V8 (plain bug,
-  2 sites); the CLI-setter half remains CP2's decision.
+- **CP2 (detach policy):** the stream-stop half is now §3 V8 (ruled
+  deliberate divergence, 2 shutdown sites documented); the CLI-setter half
+  remains CP2's decision.
 - **CP4/CP5 (headless vocabularies):** unchanged; reaffirmed by the
   projection sweep (three hand-maintained run-fact filter arrays,
   `RUN_PROGRESS_RUN_FACT_TYPES` at `runProgressRenderer.ts:43-48`).
@@ -767,7 +772,7 @@ Band 1 items are independent, PR-sized, and net-negative; Band 2 items each
 start with a one-paragraph ruling (several are recorded above as plain bugs
 needing none). Suggested order:
 
-1. **Plain bugs, no ruling** — V8 (detach bypass, 2 sites), V2 (desktop
+1. **Plain bugs, no ruling** — V2 (desktop
    `UsageLogService.initialize` + `refreshModelListStateIfNeeded`), §4i
    (silent CLI render failures), §4k (math patterns + tests), V1a's missing
    host argument at `desktopSettingsIpc.ts:258`.

--- a/docs/proposals/2026-08-15-lifecycle-ownership.md
+++ b/docs/proposals/2026-08-15-lifecycle-ownership.md
@@ -185,29 +185,28 @@ codex/claude process kill paths uniform, crash-swept process rows uniform.
 **The ad-hoc layer is stop/quit _policy_** — which events consult the
 detach SSOT and what quitting means for children:
 
-| Event                      | extension                         | desktop             | CLI                                                                     |
-| -------------------------- | --------------------------------- | ------------------- | ----------------------------------------------------------------------- |
-| user stop (active)         | detach toggle                     | detach toggle       | detach toggle                                                           |
-| stop specific stream       | toggle                            | toggle              | **hardcoded detach** (`stopStream`) — same TUI, two policies by surface |
-| headless shutdown          | —                                 | —                   | **hardcoded cascade-kill** (optionless `kill`)                          |
-| host quit, native children | abandon → repair                  | abandon → repair    | headless: kill+await; TUI: interrupt on ^C, abandon on ^C^C             |
-| host quit, foreground bash | orphans (deliberate resume-first) | orphans             | **killed** on normal quit gestures (verifier-caught asymmetry)          |
-| toggle backing store       | Memento (worktree-shared)         | shared `state.json` | same `state.json`; **no CLI surface to set either toggle**              |
-| detached-child approvals   | always-attached UI                | always-attached UI  | explicit `interactionOwnership` (sole writer)                           |
+| Event                      | extension                         | desktop             | CLI                                                                                                  |
+| -------------------------- | --------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------- |
+| user stop (active)         | detach toggle                     | detach toggle       | detach toggle                                                                                        |
+| stop specific stream       | toggle                            | toggle              | **hardcoded detach** (`stopStream`) — deliberate: focused Escape always detaches descendants (#9009) |
+| headless shutdown          | —                                 | —                   | **explicit cascade-kill** (`kill` with `{detachActiveChildren: false}`)                              |
+| host quit, native children | abandon → repair                  | abandon → repair    | headless: kill+await; TUI: interrupt on ^C, abandon on ^C^C                                          |
+| host quit, foreground bash | orphans (deliberate resume-first) | orphans             | **killed** on normal quit gestures (verifier-caught asymmetry)                                       |
+| toggle backing store       | Memento (worktree-shared)         | shared `state.json` | same `state.json`; **no CLI surface to set either toggle**                                           |
+| detached-child approvals   | always-attached UI                | always-attached UI  | explicit `interactionOwnership` (sole writer)                                                        |
 
 **The fix — no new concept.** The SSOT already exists
 (`detachSubagentsOnStop()`); a policy-event table beside it would be an
 invented concept wearing a consolidation costume (the reward-hack the
 maintainer flagged: "cleaner" by adding vocabulary). The actual fix is
-three call-site repairs and one sentence of documentation:
+two headless call-site repairs and one sentence of documentation:
 
-1. `stopStream` calls the SSOT like its siblings (the audit doc's V8).
-2. The two optionless headless `kill` sites pass an explicit
+1. The two optionless headless `kill` sites pass an explicit
    `{detachActiveChildren: false}` with a comment stating headless
    shutdown deliberately cascades — the behavior is probably correct;
    what's wrong is that it's an _accident of a default_ instead of a
    written decision.
-3. The quit asymmetry (GUI abandon-to-repair vs CLI kill) gets one
+2. The quit asymmetry (GUI abandon-to-repair vs CLI kill) gets one
    paragraph at `detachSubagentsOnStop`'s declaration — the existing
    documentation home — not a new contract object.
 
@@ -265,8 +264,8 @@ split avoids), `signal-exit` (Ink already embeds it; keep one exit matrix).
    keyed; recording view/window-scoped; delete-or-wire `clearInlineAgents`;
    collapse the duplicated stream→execution resolver).
 9. **The §4 stop/quit call-site repairs (no table — §4's rework is the
-   spec: `stopStream` → SSOT, explicit documented options at the two
-   shutdown sites, one doc paragraph at the SSOT declaration) + LaTeX
+   spec: explicit documented options at the two shutdown sites, one doc
+   paragraph at the SSOT declaration) + LaTeX
    signal threading + `using` adoption in tests/new scopes + Lean
    single-owner registration.**
 

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -404,9 +404,14 @@ export async function executeCliRequest(
       launchAbortController.abort();
       // Paired with tryCommitWorkflowOutputPublication: keep this flag read
       // and the shutdownInterrupted assignment below in one synchronous turn.
+      // Headless shutdown deliberately cascades into active children: a
+      // detached child cannot outlive the exiting CLI process, so the
+      // detach-on-stop toggle is not consulted on this path.
       const interruptionAccepted =
         !workflowOutputPublicationCommitted && ownedExecutionId
-          ? session.executions.kill(ownedExecutionId)
+          ? session.executions.kill(ownedExecutionId, {
+              detachActiveChildren: false,
+            })
           : false;
       // Before lifecycle registration, the launch signal is the cancellation
       // authority. Afterwards, only an accepted registry stop may replace the
@@ -501,8 +506,11 @@ export async function executeCliRequest(
           // Acquisition precedes registry tracking. If shutdown landed in
           // between, interrupt as soon as the canonical handle becomes live.
           if (shutdownRequested && ownedExecutionId) {
+            // Same deliberate cascade as the shutdown-phase kill above.
             shutdownInterrupted =
-              session.executions.kill(ownedExecutionId) || shutdownInterrupted;
+              session.executions.kill(ownedExecutionId, {
+                detachActiveChildren: false,
+              }) || shutdownInterrupted;
           }
         },
         stopAfterCycle: options.stopAfterCycle,

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -880,7 +880,9 @@ describe('executeCliRequest', () => {
       publishLeaseScope?.(runWithOwnership, 'exec-1' as ExecutionId);
       publishRun?.();
       await Promise.resolve();
-      expect(killSpy).toHaveBeenCalledExactlyOnceWith('exec-1');
+      expect(killSpy).toHaveBeenCalledExactlyOnceWith('exec-1', {
+        detachActiveChildren: false,
+      });
       expect(mocks.releaseExecutionLeaseAfterArtifacts).not.toHaveBeenCalled();
 
       mocks.readCliRunOutcomeState.mockResolvedValueOnce({


### PR DESCRIPTION
## What

Re-audit against #9009 ruled that `stopStream`'s hardcoded `detachActiveChildren: true` is **deliberate action-semantic divergence, not an SSOT bypass**: bare Escape is the focus-scoped "stop only the focused stream" gesture (`App.tsx:149-150`, contract from #9009) and always detaches descendants, while the configured stop surfaces (root `stop()`, extension/desktop stop, orchestrator kill tool) consult `detachSubagentsOnStop()`. The earlier revision of this PR routed `stopStream` through the SSOT; that premise was wrong for bare Escape and has been reverted, restoring the #9009 pinned behavior.

What remains from the audit's V8 is the headless half:

- The two process-shutdown `kill` call sites in `runExecution` pass an explicit `{ detachActiveChildren: false }` with a comment at each site declaring the deliberate cascade: a detached child cannot outlive the exiting CLI process, so the detach-on-stop toggle is intentionally not consulted on the process-shutdown path.
- The lifecycle §4 table/fix-list and the cross-host audit's V8/CP2/§7 wording are corrected to record the deliberate divergence: focused Escape always detaches descendants; configured stops consult the setting; process shutdown cascades explicitly.

## Scope

- Production change: `runExecution` only — explicit option plus documentation comments (behavior-identical; the calls already cascaded by default). `chatSessionController.ts` is byte-identical to `main` again.
- Tests: only the one exact-argument `kill` assertion is updated to expect the explicit option; the three focused-stream `stopStream` tests keep their original #9009 pins. No new coverage.
- The broader five-roots / `DisposableStore` migration stays with the parent issue.

## Validation

- `chatSessionController.vitest.ts` + `RunExecution.vitest.ts`: 90/90 pass; each suite also passes in isolation on the pushed commit (one combined run flaked in the unrelated progress-projection tests — same non-repeating environmental flake previously observed, green on isolated re-run).
- `prettier --check` and `eslint` on all changed files: clean.
- `typecheck:cli`, test-kernel `tsc --noEmit`: clean.
- Branch rebased onto current `origin/main` (`e10f1f718a`).

Refs #10676