### PR TITLE
docs(agent): document migrateSharedState throw-vs-result divergence

### DIFF
--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -145,10 +145,12 @@ type SharedStateMigrationResult =
  * Parse persisted shared state once, normalizing the workspace snapshot and
  * pre-`modelId` model identity before live flow code sees it.
  *
- * Malformed known fields come back as `{success: false}`; invalid nested
- * workspace-snapshot data instead throws its ZodError through `safeParse`
- * (the snapshot union migrates via `.transform`). Both failure modes are
- * loud, and both callers already handle the throw at their existing
+ * Malformed known fields — and workspace-snapshot data a snapshot union
+ * arm rejects before its `.transform` runs — come back as
+ * `{success: false}`. Only a validation failure reached by the nested
+ * `.parse()` inside a union arm's `.transform` (post-discrimination)
+ * throws its ZodError through `safeParse`. Both failure modes are loud,
+ * and both callers already handle the throw at their existing
  * boundaries.
  */
 export function migrateSharedState(

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -144,6 +144,12 @@ type SharedStateMigrationResult =
 /**
  * Parse persisted shared state once, normalizing the workspace snapshot and
  * pre-`modelId` model identity before live flow code sees it.
+ *
+ * Malformed known fields come back as `{success: false}`; invalid nested
+ * workspace-snapshot data instead throws its ZodError through `safeParse`
+ * (the snapshot union migrates via `.transform`). Both failure modes are
+ * loud, and both callers already handle the throw at their existing
+ * boundaries.
  */
 export function migrateSharedState(
   shared: unknown,


### PR DESCRIPTION
## Summary

`migrateSharedState` has two loud failure modes, but only one is visible in its contract. Malformed known fields — and workspace-snapshot data a snapshot union arm rejects before its `.transform` runs — come back as `{success: false}`. Only a validation failure reached by the nested `.parse()` inside a union arm's `.transform` (post-discrimination, e.g. a current-format snapshot whose `workPlan` contents fail `AgentWorkspaceSnapshotFieldsSchema`) throws its ZodError through the outer `safeParse`, because a throw inside a transform is not captured by the safe parse. The declared result type `SharedStateMigrationResult` and the `success: false` handling arms in both callers only describe the result path, so a future refactor could "fix" the parse handling and silently change resume semantics.

This PR adds one JSDoc paragraph at the contract site on `migrateSharedState` recording the divergence and that both failure modes are loud and already handled — the note reviewed in #10664 (landed in 53dce63e5d, removed in feb3fcc8b0 as out of scope there, deferred to this standalone issue), narrowed per review so only post-discrimination transform failures are described as throwing. Documentation only, no behavior change.

## Issue acceptance gates

Closes #10690

- [x] Note added at the contract site in `src/agent/implementations/flows/tooluse/nodes/types.ts` (on `migrateSharedState`) documenting that post-discrimination transform failures in the workspace-snapshot union throw instead of returning `{success: false}`.
- [x] Documentation only, no behavior change — comment lines only; schemas, runtime code, and tests untouched.

## Single source of truth

`migrateSharedState` in `src/agent/implementations/flows/tooluse/nodes/types.ts` remains the one normalization/self-heal decision point; the divergence note lives on its JSDoc next to the declared result type.

## Duplication and abstraction budget

None added or removed — one comment paragraph, no code.

## Net elements (R6)

Not a refactor/simplify PR; reported anyway. Files: 0 added, 0 deleted, 1 modified. Exported symbols (`^[+-]export` over the diff): 0 added, 0 deleted. Net LoC: +8 (+8/−0 vs. main), all JSDoc comment lines.

## Consumer counts (R8)

n/a — comment-only change; no emit path or export touched. Both consumers (`runToolUseFlow.ts`, `SessionResumeRetrieval.ts`) already handle the throw at their existing boundaries, as the note records.

## Host impact

Extension: none — documentation only.

Desktop: none — documentation only.

CLI: none — documentation only.

## Scheduled refactoring

None.

## Validation

Comment-only change; no new tests per maintainer direction (overtesting) and the issue's documentation-only scope. Verified on the head commit:

- `prettier --check src/agent/implementations/flows/tooluse/nodes/types.ts` — clean.
- `eslint src/agent/implementations/flows/tooluse/nodes/types.ts` — clean.
- `typecheck:workspace` (`tsc --noEmit`) — clean.
- Both failure modes probed through `migrateSharedState` with a scratch vitest file (not committed): `{todos: 123}` (pre-transform arm rejection) returns `{success: false}`; `{workPlan: {todos: 123}}` (post-discrimination nested `.parse()` failure) throws a ZodError; a valid snapshot succeeds.
