### PR TITLE
fix(github): scope subscription release to session owner

### DIFF
--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -202,15 +202,16 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
   }
 
   private ensureHooks(session: SessionHandle): void {
+    if (!this.sourceHooksRegistered) {
+      // The polling source can detach subscriptions unilaterally (PR closed,
+      // auth failure, 24 h unreachable). Listen to the source directly; the
+      // progress event is for UI refresh, not for internal bookkeeping.
+      this.opts.source.onKeysChanged((keys) => {
+        this.pruneMissingSourceKeys(keys);
+      });
+      this.sourceHooksRegistered = true;
+    }
     this.ensureReleaseHook(session);
-    if (this.sourceHooksRegistered) return;
-    // The polling source can detach subscriptions unilaterally (PR closed,
-    // auth failure, 24 h unreachable). Listen to the source directly; the
-    // progress event is for UI refresh, not for internal bookkeeping.
-    this.opts.source.onKeysChanged((keys) => {
-      this.pruneMissingSourceKeys(keys);
-    });
-    this.sourceHooksRegistered = true;
   }
 
   private ensureReleaseHook(session: SessionHandle): void {
@@ -248,9 +249,9 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     const removedOwners = new Set<SessionHandle>();
     let removed = false;
     for (const [streamId, bound] of [...this.perStream]) {
-      for (const key of [...bound.keys()]) {
+      for (const [key, binding] of [...bound]) {
         if (!active.has(key)) {
-          removedOwners.add(bound.get(key)!.owner);
+          removedOwners.add(binding.owner);
           bound.delete(key);
           removed = true;
         }

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -7,14 +7,13 @@
  * Event callbacks route through `deliverLiveNotification` so events land in
  * the same follow-up queue user-typed messages use; the agent consumes them
  * via the normal `waitForFollowUp` mechanism. When a stream's queue is released
- * (orchestrator disposed, user deleted the stream) every subscription
- * bound to that stream is auto-disposed.
+ * (orchestrator disposed, user deleted the stream) subscriptions owned by
+ * that queue's session are auto-disposed.
  */
 
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import { deliverLiveNotification } from '@agent/followUp/liveNotification';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import {
   currentSession,
   type SessionHandle,
@@ -52,25 +51,29 @@ interface BoundSubscription {
   disposable: Disposable;
   onEvent: (text: string) => void;
   /**
-   * Session captured at bind() time (inside the run's AsyncLocalStorage).
+   * Owning session captured at bind() time (inside the run's AsyncLocalStorage).
    * onEvent fires later from a detached polling timer where the ALS is empty, so
    * it must travel with the notification — otherwise submitFollowUp falls back
    * to defaultSession() and the follow-up is misrouted/dropped on a non-default
    * session (for example, the desktop process session).
    */
-  session: SessionHandle;
+  owner: SessionHandle;
   /** Continuation generation in which this detached producer was bound. */
   expectedGenerationId: string | undefined;
 }
 
-export class StreamSubscriptionRegistry<K extends string, Input> {
+export class StreamSubscriptionRegistry<
+  K extends string,
+  Input,
+> implements Disposable {
   private readonly logger: Pick<AgentTrace, 'info' | 'warn'>;
   private readonly perStream = new Map<
     StreamTabId,
     Map<K, BoundSubscription>
   >();
-  private sourceHooksRegistered = false;
-  private readonly hookedReleaseQueues = new WeakSet<ToolUseFollowUpQueue>();
+  private sourceHook: Disposable | undefined;
+  private readonly releaseHooks = new Map<SessionHandle, () => void>();
+  private disposed = false;
 
   constructor(
     private readonly opts: StreamSubscriptionRegistryOptions<K, Input>,
@@ -80,6 +83,9 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
 
   /** Returns true if a new subscription was created, false if it already existed. */
   bind(streamId: StreamTabId, input: Input): boolean {
+    if (this.disposed) {
+      throw new Error(`${this.opts.name} has been disposed.`);
+    }
     const key = this.opts.keyOf(input);
     // Capture the session HERE: bind() runs inside the run's AsyncLocalStorage
     // (the github tool's execute()), but onEvent fires later from a detached
@@ -93,9 +99,13 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     }
     const existing = bound.get(key);
     if (existing) {
-      existing.session = session;
+      const previousOwner = existing.owner;
+      existing.owner = session;
       existing.expectedGenerationId =
         session.followUps.currentGenerationId(streamId);
+      if (previousOwner !== session) {
+        this.detachReleaseHookIfUnused(previousOwner);
+      }
       this.opts.source.updateSubscription?.(input, existing.onEvent);
       return false;
     }
@@ -105,14 +115,14 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     const subscription: BoundSubscription = {
       disposable: { dispose: () => {} },
       onEvent: () => {},
-      session,
+      owner: session,
       expectedGenerationId: session.followUps.currentGenerationId(streamId),
     };
     subscription.onEvent = (text: string) => {
       deliverLiveNotification({
         streamId,
         followUp: text,
-        session: subscription.session,
+        session: subscription.owner,
         expectedGenerationId: subscription.expectedGenerationId,
         logger: this.logger,
         failure: {
@@ -131,6 +141,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
       disposable = this.opts.source.subscribe(input, subscription.onEvent);
     } catch (err) {
       this.removeBoundKey(streamId, bound, key);
+      this.detachReleaseHookIfUnused(session);
       throw err;
     }
     subscription.disposable = disposable;
@@ -146,6 +157,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     const binding = bound?.get(key);
     if (!bound || !binding) return false;
     this.removeBoundKey(streamId, bound, key);
+    this.detachReleaseHookIfUnused(binding.owner);
     this.disposeSafe(binding.disposable, 'explicit unsubscribe');
     this.emitBindingsChanged();
     return true;
@@ -158,13 +170,16 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
    */
   unbindAll(key: string): number {
     const removedBindings: BoundSubscription[] = [];
+    const owners = new Set<SessionHandle>();
     for (const [streamId, bound] of [...this.perStream]) {
       const binding = bound.get(key as K);
       if (!binding) continue;
       removedBindings.push(binding);
+      owners.add(binding.owner);
       this.removeBoundKey(streamId, bound, key as K);
     }
     if (removedBindings.length > 0) {
+      for (const owner of owners) this.detachReleaseHookIfUnused(owner);
       for (const binding of removedBindings) {
         this.disposeSafe(binding.disposable, 'unbindAll');
       }
@@ -193,44 +208,83 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     }));
   }
 
+  /** Dispose every binding and stop observing the polling source. */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.sourceHook) {
+      this.disposeSafe(this.sourceHook, 'source hook disposal');
+      this.sourceHook = undefined;
+    }
+    for (const detach of this.releaseHooks.values()) detach();
+    this.releaseHooks.clear();
+    const bindings = [...this.perStream.values()].flatMap((bound) => [
+      ...bound.values(),
+    ]);
+    this.perStream.clear();
+    for (const binding of bindings) {
+      this.disposeSafe(binding.disposable, 'registry disposal');
+    }
+    if (bindings.length > 0) this.emitBindingsChanged();
+  }
+
   private ensureHooks(session: SessionHandle): void {
-    this.ensureReleaseHook(session.followUps);
-    if (this.sourceHooksRegistered) return;
+    this.ensureReleaseHook(session);
+    if (this.sourceHook) return;
     // The polling source can detach subscriptions unilaterally (PR closed,
     // auth failure, 24 h unreachable). Listen to the source directly; the
     // progress event is for UI refresh, not for internal bookkeeping.
-    this.opts.source.onKeysChanged((keys) => {
+    this.sourceHook = this.opts.source.onKeysChanged((keys) => {
       this.pruneMissingSourceKeys(keys);
     });
-    this.sourceHooksRegistered = true;
   }
 
-  private ensureReleaseHook(queue: ToolUseFollowUpQueue): void {
-    if (this.hookedReleaseQueues.has(queue)) return;
-    this.hookedReleaseQueues.add(queue);
-    queue.onRelease((streamId) => {
+  private ensureReleaseHook(session: SessionHandle): void {
+    if (this.releaseHooks.has(session)) return;
+    const detach = session.followUps.onRelease((streamId) => {
+      if (this.disposed) return;
       const bound = this.perStream.get(streamId);
       if (!bound) return;
-      this.perStream.delete(streamId);
-      for (const binding of bound.values()) {
+      const owned = [...bound].filter(([, binding]) => {
+        return binding.owner === session;
+      });
+      if (owned.length === 0) return;
+      for (const [key] of owned) bound.delete(key);
+      if (bound.size === 0) this.perStream.delete(streamId);
+      this.detachReleaseHookIfUnused(session);
+      for (const [, binding] of owned) {
         this.disposeSafe(binding.disposable, 'release');
       }
       this.emitBindingsChanged();
     });
+    this.releaseHooks.set(session, detach);
+  }
+
+  private detachReleaseHookIfUnused(session: SessionHandle): void {
+    for (const bound of this.perStream.values()) {
+      for (const binding of bound.values()) {
+        if (binding.owner === session) return;
+      }
+    }
+    this.releaseHooks.get(session)?.();
+    this.releaseHooks.delete(session);
   }
 
   private pruneMissingSourceKeys(keys: readonly K[]): void {
     const active = new Set<string>(keys);
+    const removedOwners = new Set<SessionHandle>();
     let removed = false;
     for (const [streamId, bound] of [...this.perStream]) {
       for (const key of [...bound.keys()]) {
         if (!active.has(key)) {
+          removedOwners.add(bound.get(key)!.owner);
           bound.delete(key);
           removed = true;
         }
       }
       if (bound.size === 0) this.perStream.delete(streamId);
     }
+    for (const owner of removedOwners) this.detachReleaseHookIfUnused(owner);
     if (removed) this.emitBindingsChanged();
   }
 

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -62,18 +62,14 @@ interface BoundSubscription {
   expectedGenerationId: string | undefined;
 }
 
-export class StreamSubscriptionRegistry<
-  K extends string,
-  Input,
-> implements Disposable {
+export class StreamSubscriptionRegistry<K extends string, Input> {
   private readonly logger: Pick<AgentTrace, 'info' | 'warn'>;
   private readonly perStream = new Map<
     StreamTabId,
     Map<K, BoundSubscription>
   >();
-  private sourceHook: Disposable | undefined;
+  private sourceHooksRegistered = false;
   private readonly releaseHooks = new Map<SessionHandle, () => void>();
-  private disposed = false;
 
   constructor(
     private readonly opts: StreamSubscriptionRegistryOptions<K, Input>,
@@ -83,9 +79,6 @@ export class StreamSubscriptionRegistry<
 
   /** Returns true if a new subscription was created, false if it already existed. */
   bind(streamId: StreamTabId, input: Input): boolean {
-    if (this.disposed) {
-      throw new Error(`${this.opts.name} has been disposed.`);
-    }
     const key = this.opts.keyOf(input);
     // Capture the session HERE: bind() runs inside the run's AsyncLocalStorage
     // (the github tool's execute()), but onEvent fires later from a detached
@@ -208,41 +201,21 @@ export class StreamSubscriptionRegistry<
     }));
   }
 
-  /** Dispose every binding and stop observing the polling source. */
-  dispose(): void {
-    if (this.disposed) return;
-    this.disposed = true;
-    if (this.sourceHook) {
-      this.disposeSafe(this.sourceHook, 'source hook disposal');
-      this.sourceHook = undefined;
-    }
-    for (const detach of this.releaseHooks.values()) detach();
-    this.releaseHooks.clear();
-    const bindings = [...this.perStream.values()].flatMap((bound) => [
-      ...bound.values(),
-    ]);
-    this.perStream.clear();
-    for (const binding of bindings) {
-      this.disposeSafe(binding.disposable, 'registry disposal');
-    }
-    if (bindings.length > 0) this.emitBindingsChanged();
-  }
-
   private ensureHooks(session: SessionHandle): void {
     this.ensureReleaseHook(session);
-    if (this.sourceHook) return;
+    if (this.sourceHooksRegistered) return;
     // The polling source can detach subscriptions unilaterally (PR closed,
     // auth failure, 24 h unreachable). Listen to the source directly; the
     // progress event is for UI refresh, not for internal bookkeeping.
-    this.sourceHook = this.opts.source.onKeysChanged((keys) => {
+    this.opts.source.onKeysChanged((keys) => {
       this.pruneMissingSourceKeys(keys);
     });
+    this.sourceHooksRegistered = true;
   }
 
   private ensureReleaseHook(session: SessionHandle): void {
     if (this.releaseHooks.has(session)) return;
     const detach = session.followUps.onRelease((streamId) => {
-      if (this.disposed) return;
       const bound = this.perStream.get(streamId);
       if (!bound) return;
       const owned = [...bound].filter(([, binding]) => {


### PR DESCRIPTION
## Summary

- record the owning `SessionHandle` on each stream subscription binding
- release only bindings owned by the session whose follow-up queue released the shared `StreamTabId`
- detach per-session release observers automatically once that session owns no remaining bindings
- preserve single-binding re-pointing, process-lifetime source-listener ownership, and the keyless `githubSubscriptionsChanged` emission path

## Validation

- `CI=true npm run typecheck`
- `CI=true npm run lint`
- existing GitHub subscription and follow-up queue suites (28 tests)
- local cross-session scratch probe for shared and re-pointed bindings

Closes #10645