### PR TITLE
refactor(runtime): consolidate cross-host resume failures

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -9,6 +9,7 @@ import { getExecutionStore } from '@agent/storage';
 import {
   AgentConfigSchema,
   attachTerminalResultToast,
+  describeResumeFailure,
   detachSubagentsOnStop,
   resolveAndResumeStream,
   resumeQueuedToolUseFromResumeData,
@@ -326,16 +327,24 @@ export function createChatSessionController(
     // A launch failure already rendered through a targeted presentation
     // (e.g. the model-not-recognized instruction) is marked -- skip the
     // generic transcript line so the TUI doesn't show the same failure twice.
+    const resumeFailure = describeResumeFailure(error);
     if (
       !session.stopRequested &&
       !hasErrorPresentedMarker(error) &&
       !hasErrorPresentationPending(error)
     ) {
-      appendLocalErrorTranscript(toErrorMessage(error));
+      appendLocalErrorTranscript(
+        resumeFailure.kind === 'lease-active'
+          ? resumeFailure.message
+          : toErrorMessage(error),
+      );
     }
-    session.runExitCode = session.stopRequested
-      ? CliExitCode.Success
-      : CliExitCode.AgentError;
+    session.runExitCode = CliExitCode.AgentError;
+    if (session.stopRequested) {
+      session.runExitCode = CliExitCode.Success;
+    } else if (resumeFailure.kind === 'lease-active') {
+      session.runExitCode = CliExitCode.Usage;
+    }
   };
 
   // Build the runtime host shared by start and resume. Root completion marks
@@ -701,9 +710,8 @@ export function createChatSessionController(
               streamStatus: runtimeSession.status,
               isCancellationRequested,
               resolveResumeState: async () => ({
-                runState: config,
-                executionId,
-                parentStreamId,
+                status: 'resolved',
+                state: { runState: config, executionId, parentStreamId },
               }),
               resumeToolUse: (resume, claimedRecovery) =>
                 resumeQueuedToolUseFromResumeData(streamId, resume, {

--- a/packages/cli/src/commands/resumeExecution.ts
+++ b/packages/cli/src/commands/resumeExecution.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { resolveAndResumeStream } from '@agent/runtime';
+import { describeResumeFailure, resolveAndResumeStream } from '@agent/runtime';
 import { getExecutionStore, inspectExecutionLease } from '@agent/storage';
 import { AgentCategory, type ExecutionId } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -157,7 +157,10 @@ export async function runResumeExecution(
   let failureExitCode: CliExitCode = CliExitCode.AgentError;
   const resumed = await resolveAndResumeStream(streamId, {
     streamStatus: session.status,
-    resolveResumeState: async () => ({ runState: config, executionId: id }),
+    resolveResumeState: async () => ({
+      status: 'resolved',
+      state: { runState: config, executionId: id },
+    }),
     resumeToolUse: async (resume) => {
       const { runChat } = await import('../chat/tui/runChatTui');
       const result = await runChat(context, {
@@ -199,7 +202,11 @@ export async function runResumeExecution(
     },
     reportFailure: (_streamId, error) => {
       failed = true;
-      if (error instanceof CliUsageError) {
+      const description = describeResumeFailure(error);
+      if (description.kind === 'lease-active') {
+        failureExitCode = CliExitCode.Usage;
+        writeTextStderr(description.message);
+      } else if (error instanceof CliUsageError) {
         failureExitCode = CliExitCode.Usage;
         writeTextStderr(error.message);
       } else {

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -563,7 +563,6 @@ export async function executeCliRequest(
       primaryRunFailure = { error: err };
     } else if (
       !failurePresented &&
-      !terminalResult.isHandled() &&
       !hasErrorPresentedMarker(err) &&
       !hasErrorPresentationPending(err)
     ) {
@@ -576,9 +575,11 @@ export async function executeCliRequest(
       // error) -- this CLI-local `failurePresented` flag only tracks
       // `requestShowError`, so it would otherwise re-surface that failure a
       // second time here.
-      session.interactions.emit('requestShowError', {
-        message: toErrorMessage(err),
-      });
+      terminalResult.reportUnhandled(() =>
+        session.interactions.emit('requestShowError', {
+          message: toErrorMessage(err),
+        }),
+      );
     }
   }
 

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -419,11 +419,11 @@ export class DesktopProgressBridge {
             logger.error('Desktop merge execution failed', {
               data: toLogData(error),
             });
-            if (!terminalResult.isHandled()) {
+            terminalResult.reportUnhandled(() =>
               this.session.interactions.emit('requestShowError', {
                 message: `Merge failed: ${toErrorMessage(error)}`,
-              });
-            }
+              }),
+            );
           })
           .finally(terminalResult.dispose);
       },

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -2,6 +2,7 @@ import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import {
   describeResumeFailure,
+  describeResumeStateResolution,
   resolveAndResumeStream,
   resolveResumeStateFromSnapshots,
   resumeQueuedToolUseFromResumeData,
@@ -99,7 +100,7 @@ function resumeDesktopStream(
       streamStatus: context.session.status,
       resolveResumeState: (id) =>
         resolveResumeStateFromSnapshots(context.session.snapshots, id),
-      reportResumeStateResolution: async (id, resolution, message) => {
+      reportResumeStateResolution: async (id, resolution) => {
         if (resolution.status === 'read-failed') {
           context.logger.warn(
             `Failed to read persisted resume data for ${id}`,
@@ -108,9 +109,10 @@ function resumeDesktopStream(
             },
           );
         }
-        await context.session.interactions.showInfoMessage(message, {
-          replayWhenAttached: true,
-        });
+        await context.session.interactions.showInfoMessage(
+          describeResumeStateResolution(resolution),
+          { replayWhenAttached: true },
+        );
       },
       resumeToolUse: (snapshot, claimedRecovery) =>
         resumeQueuedToolUseFromResumeData(snapshot.streamId, snapshot, {

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -1,15 +1,16 @@
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import {
+  describeResumeFailure,
   resolveAndResumeStream,
   resolveResumeStateFromSnapshots,
   resumeQueuedToolUseFromResumeData,
+  resumeStreamWithRecovery,
   trackTerminalResultPresentation,
   type SessionHandle,
 } from '@agent/runtime';
 import type { RecoveryContinuation } from '@platform/interfaces';
 import type { StreamTabId } from '@shared/schemas';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   DESKTOP_UNAVAILABLE_TOOLS,
   launchDesktopAgent,
@@ -47,14 +48,12 @@ export class DesktopProcessResumeOwner {
   ): Promise<boolean> {
     const context = this.context;
     if (!context) return Promise.resolve(false);
-    const claimedRecovery = recovery
-      ? context.session.followUps.useRecovery(recovery)
-      : context.session.followUps.claimRecovery(streamId, true);
-    if (!claimedRecovery) return Promise.resolve(false);
-    return resumeDesktopStream(streamId, context, claimedRecovery).finally(
-      () => {
-        context.session.followUps.release(claimedRecovery, 'recoverable');
-      },
+    return resumeStreamWithRecovery(
+      context.session,
+      streamId,
+      (claimedRecovery) =>
+        resumeDesktopStream(streamId, context, claimedRecovery),
+      recovery,
     );
   }
 }
@@ -86,22 +85,21 @@ function resumeDesktopStream(
     context.logger.error(`Failed to resume desktop stream ${id}`, {
       data: toLogData(error),
     });
-    if (terminalResult.isHandled()) return;
-    context.session.interactions.emit(
-      'requestShowError',
-      { message: `Resume failed: ${toErrorMessage(error)}` },
-      { replayWhenAttached: true },
+    terminalResult.reportUnhandled(() =>
+      context.session.interactions.emit(
+        'requestShowError',
+        { message: describeResumeFailure(error).message },
+        { replayWhenAttached: true },
+      ),
     );
   };
   return resolveAndResumeStream(
     streamId,
     {
       streamStatus: context.session.status,
-      resolveResumeState: async (id) => {
-        const resolution = await resolveResumeStateFromSnapshots(
-          context.session.snapshots,
-          id,
-        );
+      resolveResumeState: (id) =>
+        resolveResumeStateFromSnapshots(context.session.snapshots, id),
+      reportResumeStateResolution: async (id, resolution, message) => {
         if (resolution.status === 'read-failed') {
           context.logger.warn(
             `Failed to read persisted resume data for ${id}`,
@@ -109,26 +107,10 @@ function resumeDesktopStream(
               data: toLogData(resolution.error),
             },
           );
-          // A failed read is not proof of absence: falling through would tell
-          // the user no run state exists (a false data-loss diagnosis) when
-          // the state may be intact behind a transient storage error.
-          if (!isResumeInvalidated()) {
-            await context.session.interactions.showInfoMessage(
-              `Persisted run state could not be read (${toErrorMessage(resolution.error)}). The resume was not started; retry once the storage issue is resolved.`,
-              { replayWhenAttached: true },
-            );
-          }
-          return undefined;
         }
-        if (isResumeInvalidated()) return undefined;
-        if (resolution.status === 'resolved') return resolution.state;
-        await context.session.interactions.showInfoMessage(
-          resolution.status === 'incomplete' && resolution.runState
-            ? 'This stream has no persisted execution id. Start a new run instead.'
-            : 'No persisted run state was found for this stream. Start a new run instead.',
-          { replayWhenAttached: true },
-        );
-        return undefined;
+        await context.session.interactions.showInfoMessage(message, {
+          replayWhenAttached: true,
+        });
       },
       resumeToolUse: (snapshot, claimedRecovery) =>
         resumeQueuedToolUseFromResumeData(snapshot.streamId, snapshot, {
@@ -142,14 +124,8 @@ function resumeDesktopStream(
       executeWorkflow: (config, executionId, modelHandlerCompatibilityKey) =>
         launchDesktopAgent(
           { config, executionId },
-          {
-            session: context.session,
-            canAcquireResumeLease,
-          },
-          {
-            modelHandlerCompatibilityKey,
-            suppressErrorNotification: true,
-          },
+          { session: context.session, canAcquireResumeLease },
+          { modelHandlerCompatibilityKey, suppressErrorNotification: true },
         ),
       reportNoResumableSession: () =>
         context.session.interactions.showInfoMessage(

--- a/packages/extension/src/commands/agent/resumeFromResumeData.ts
+++ b/packages/extension/src/commands/agent/resumeFromResumeData.ts
@@ -5,6 +5,7 @@ import { createChannelTrace } from '@agent/trace';
 import {
   defaultSession,
   describeResumeFailure,
+  describeResumeStateResolution,
   resolveAndResumeStream,
   resolveResumeStateFromSnapshots,
   resumeQueuedToolUseFromResumeData,
@@ -46,7 +47,7 @@ export function tryResumeFromResumeData(
           isCancellationRequested: () => !session.transcripts.has(streamId),
           resolveResumeState: (id) =>
             resolveResumeStateFromSnapshots(session.snapshots, id),
-          reportResumeStateResolution: async (id, resolution, message) => {
+          reportResumeStateResolution: async (id, resolution) => {
             if (resolution.status === 'read-failed') {
               logger.warn(`Failed to read persisted resume data for ${id}`, {
                 data: resolution.error,
@@ -58,9 +59,10 @@ export function tryResumeFromResumeData(
                   : `No run config found for stream: ${id}`,
               );
             }
-            await session.interactions.showInfoMessage(message, {
-              replayWhenAttached: true,
-            });
+            await session.interactions.showInfoMessage(
+              describeResumeStateResolution(resolution),
+              { replayWhenAttached: true },
+            );
           },
           resumeToolUse: (resume, claimedRecovery) =>
             resumeQueuedToolUseFromResumeData(resume.streamId, resume, {

--- a/packages/extension/src/commands/agent/resumeFromResumeData.ts
+++ b/packages/extension/src/commands/agent/resumeFromResumeData.ts
@@ -1,109 +1,94 @@
-/**
- * Persisted-state auto-resume entry point for the VS Code host.
- *
- * Used by:
- *   - `texra.sendFollowUp` (auto-resume when a follow-up lands on a
- *     WAITING / children_running stream).
- *   - `AgentResumePort.tryResumeStream` (the progress view's Resume button on
- *     tool-use streams, and the inquiry continuation path).
- *
- * This is a thin adapter: the host-neutral {@link resolveAndResumeStream}
- * orchestrator owns the guard, retrieval, and tool-use/workflow branch; the
- * extension supplies only how it resolves persisted state and launches a run.
- */
+/** Persisted-state auto-resume entry point for the VS Code host. */
 import * as vscode from 'vscode';
 
 import { createChannelTrace } from '@agent/trace';
 import {
   defaultSession,
+  describeResumeFailure,
   resolveAndResumeStream,
   resolveResumeStateFromSnapshots,
   resumeQueuedToolUseFromResumeData,
+  resumeStreamWithRecovery,
+  trackTerminalResultPresentation,
 } from '@agent/runtime';
-import { logErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import type { RecoveryContinuation } from '@platform/interfaces';
 import type { StreamTabId } from '@shared/schemas';
 
 import { runExecuteCommand } from './executeCommand';
 
-const CHANNEL = 'resumeFromResumeData';
-
-const logger = createChannelTrace(CHANNEL);
-
-async function showResumeError(error: unknown): Promise<void> {
-  const message = logErrorMessage(
-    CHANNEL,
-    'Failed to resume tool-use session',
-    error,
-  );
-  await vscode.window.showWarningMessage(message);
-}
+const logger = createChannelTrace('resumeFromResumeData');
 
 export function tryResumeFromResumeData(
   streamId: StreamTabId,
   recovery?: RecoveryContinuation,
 ): Promise<boolean> {
   const session = defaultSession();
-  const claimedRecovery = recovery
-    ? session.followUps.useRecovery(recovery)
-    : session.followUps.claimRecovery(streamId, true);
-  if (!claimedRecovery) return Promise.resolve(false);
-  return resolveAndResumeStream(
+  return resumeStreamWithRecovery(
+    session,
     streamId,
-    {
-      // The extension runs on the default session for this host-path caller
-      // (outside any run ALS), so its status plane is the same one every other
-      // unmigrated default-session caller reads through `defaultSession()`.
-      streamStatus: session.status,
-      // A stream deleted while asynchronous resume preparation runs must not be
-      // resurrected by the resume that was already in flight.
-      isCancellationRequested: () => !session.transcripts.has(streamId),
-      resolveResumeState: async (id) => {
-        const resolution = await resolveResumeStateFromSnapshots(
-          session.snapshots,
-          id,
+    (claimedRecovery) => {
+      const terminalResult = trackTerminalResultPresentation(
+        session,
+        (event) => event.streamId === streamId,
+      );
+      const reportResumeFailure = async (error: unknown): Promise<void> => {
+        logger.error(`Failed to resume stream: ${streamId}`, { data: error });
+        await terminalResult.reportUnhandled(() =>
+          vscode.window.showWarningMessage(
+            describeResumeFailure(error).message,
+          ),
         );
-        if (resolution.status === 'resolved') return resolution.state;
-        if (resolution.status === 'read-failed') {
-          logger.warn(`Failed to read persisted resume data for ${id}`, {
-            data: resolution.error,
-          });
-          return undefined;
-        }
-        logger.warn(
-          resolution.executionId === undefined
-            ? `No execution ID found for stream: ${id}`
-            : `No run config found for stream: ${id}`,
-        );
-        return undefined;
-      },
-      // Extension wrapper around the host-neutral tool-use resume: it
-      // supplies the extension runtime host and surfaces failures as a
-      // warning toast.
-      resumeToolUse: (resume, recovery) =>
-        resumeQueuedToolUseFromResumeData(resume.streamId, resume, {
-          recovery,
-          onError: showResumeError,
-        }),
-      executeWorkflow: (config, executionId, modelHandlerCompatibilityKey) =>
-        runExecuteCommand({
-          config,
-          executionId,
-          modelHandlerCompatibilityKey,
-        }),
-      reportNoResumableSession: async (id) => {
-        logger.warn(`No resumable session state for stream: ${id}`);
-        await session.interactions.showInfoMessage(
-          'This run cannot be resumed. Start a new run instead.',
-          { replayWhenAttached: true },
-        );
-      },
-      reportFailure: (id, error) => {
-        logger.error(`Failed to resume stream: ${id}`, { data: error });
-      },
+      };
+      return resolveAndResumeStream(
+        streamId,
+        {
+          streamStatus: session.status,
+          isCancellationRequested: () => !session.transcripts.has(streamId),
+          resolveResumeState: (id) =>
+            resolveResumeStateFromSnapshots(session.snapshots, id),
+          reportResumeStateResolution: async (id, resolution, message) => {
+            if (resolution.status === 'read-failed') {
+              logger.warn(`Failed to read persisted resume data for ${id}`, {
+                data: resolution.error,
+              });
+            } else {
+              logger.warn(
+                resolution.executionId === undefined
+                  ? `No execution ID found for stream: ${id}`
+                  : `No run config found for stream: ${id}`,
+              );
+            }
+            await session.interactions.showInfoMessage(message, {
+              replayWhenAttached: true,
+            });
+          },
+          resumeToolUse: (resume, claimedRecovery) =>
+            resumeQueuedToolUseFromResumeData(resume.streamId, resume, {
+              recovery: claimedRecovery,
+              onError: reportResumeFailure,
+            }),
+          executeWorkflow: (
+            config,
+            executionId,
+            modelHandlerCompatibilityKey,
+          ) =>
+            runExecuteCommand({
+              config,
+              executionId,
+              modelHandlerCompatibilityKey,
+            }),
+          reportNoResumableSession: async (id) => {
+            logger.warn(`No resumable session state for stream: ${id}`);
+            await session.interactions.showInfoMessage(
+              'This run cannot be resumed. Start a new run instead.',
+              { replayWhenAttached: true },
+            );
+          },
+          reportFailure: (_id, error) => reportResumeFailure(error),
+        },
+        claimedRecovery,
+      ).finally(terminalResult.dispose);
     },
-    claimedRecovery,
-  ).finally(() => {
-    session.followUps.release(claimedRecovery, 'recoverable');
-  });
+    recovery,
+  );
 }

--- a/packages/extension/src/commands/agent/resumeFromResumeData.ts
+++ b/packages/extension/src/commands/agent/resumeFromResumeData.ts
@@ -59,6 +59,9 @@ export function tryResumeFromResumeData(
                   : `No run config found for stream: ${id}`,
               );
             }
+            // Deliberate C3/V4a host parity: unresolved persisted state
+            // (read-failed/incomplete) surfaces here even on the automatic
+            // follow-up resume path, which was previously silent.
             await session.interactions.showInfoMessage(
               describeResumeStateResolution(resolution),
               { replayWhenAttached: true },

--- a/packages/extension/src/commands/agent/resumeFromResumeData.ts
+++ b/packages/extension/src/commands/agent/resumeFromResumeData.ts
@@ -1,7 +1,6 @@
 /** Persisted-state auto-resume entry point for the VS Code host. */
 import * as vscode from 'vscode';
 
-import { createChannelTrace } from '@agent/trace';
 import {
   defaultSession,
   describeResumeFailure,
@@ -12,12 +11,13 @@ import {
   resumeStreamWithRecovery,
   trackTerminalResultPresentation,
 } from '@agent/runtime';
+import { createLog } from '@logger/logUtils';
 import type { RecoveryContinuation } from '@platform/interfaces';
 import type { StreamTabId } from '@shared/schemas';
 
 import { runExecuteCommand } from './executeCommand';
 
-const logger = createChannelTrace('resumeFromResumeData');
+const logger = createLog('resumeFromResumeData');
 
 export function tryResumeFromResumeData(
   streamId: StreamTabId,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -70,8 +70,11 @@ export {
 
 // resolveAndResumeStream
 export {
+  describeResumeFailure,
+  describeResumeStateResolution,
   resolveAndResumeStream,
   resolveResumeStateFromSnapshots,
+  resumeStreamWithRecovery,
 } from './resolveAndResumeStream';
 
 // detachSubagentsOnStop

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -34,7 +34,7 @@ type UnresolvedResumeState = Exclude<
   { readonly status: 'resolved' }
 >;
 
-export interface ResumeFailureDescription {
+interface ResumeFailureDescription {
   readonly kind: 'lease-active' | 'unexpected';
   readonly message: string;
 }
@@ -119,7 +119,6 @@ export interface ResumeStreamPorts {
   reportResumeStateResolution?(
     streamId: StreamTabId,
     resolution: UnresolvedResumeState,
-    message: string,
   ): void | Promise<void>;
   resumeToolUse(
     resume: ToolUseResumeData,
@@ -155,11 +154,7 @@ export async function resolveAndResumeStream(
     const resolution = await ports.resolveResumeState(streamId);
     if (isCancellationRequested()) return false;
     if (resolution.status !== 'resolved') {
-      await ports.reportResumeStateResolution?.(
-        streamId,
-        resolution,
-        describeResumeStateResolution(resolution),
-      );
+      await ports.reportResumeStateResolution?.(streamId, resolution);
       return false;
     }
 
@@ -190,7 +185,11 @@ export async function resolveAndResumeStream(
     return true;
   } catch (error) {
     if (isCancellationRequested()) return false;
-    await ports.reportFailure?.(streamId, error);
+    try {
+      await ports.reportFailure?.(streamId, error);
+    } catch {
+      // Presentation failures must not replace the resume failure they report.
+    }
     return false;
   }
 }

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -81,7 +81,13 @@ export async function resumeStreamWithRecovery(
   }
 }
 
-/** Resolve snapshot-backed metadata without collapsing read failure into absence. */
+/** Resolve snapshot-backed metadata without collapsing read failure into absence.
+ *
+ * Preload-then-read (#9947): a stream whose sidecar record is not resident yet
+ * must be seeded from disk before the synchronous reads can be trusted. Both
+ * fields are re-read after the seed rather than filled in individually, so a
+ * half-invalidated config/execution pair cannot survive into the resume.
+ */
 export async function resolveResumeStateFromSnapshots(
   snapshots: Pick<
     StreamSnapshotStore,
@@ -113,6 +119,12 @@ export async function resolveResumeStateFromSnapshots(
 }
 
 export interface ResumeStreamPorts {
+  /**
+   * The status machine of the session that owns this stream. The active/resuming
+   * guards must read the machine the run actually writes; reading the
+   * process-global default left both guards permanently false in multi-session
+   * hosts.
+   */
   readonly streamStatus: Pick<StreamStatusMachine, 'isActiveOrResuming'>;
   readonly isCancellationRequested?: () => boolean;
   resolveResumeState(streamId: StreamTabId): Promise<ResumeStateResolution>;
@@ -171,12 +183,18 @@ export async function resolveAndResumeStream(
       return false;
     }
 
+    // Re-check after the async retrieval window: `resumeInFlight` blocks only a
+    // second resume entry, not a concurrent non-resume run launch that flips
+    // this stream active/resuming while retrieval is awaited.
     if (ports.streamStatus.isActiveOrResuming(streamId)) return false;
 
     if (resume.type === 'toolUse') {
       return await ports.resumeToolUse(resume, recovery);
     }
 
+    // Workflow launch owns stream acquisition and status transitions through
+    // runAgent/buildAgentLaunchContext. Pre-marking the same stream RESUMING
+    // here would make the launch reject itself as already in flight.
     await ports.executeWorkflow(
       resume.agentConfig,
       resume.executionId,

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -77,6 +77,9 @@ export async function resumeStreamWithRecovery(
   try {
     return await run(claimedRecovery);
   } finally {
+    // The wrapped tool-use resume releases this same lease in its own finally;
+    // release() is ownership-checked and returns false on the second call, so
+    // this outer release is the no-op safety net for workflow/throw paths.
     session.followUps.release(claimedRecovery, 'recoverable');
   }
 }
@@ -166,7 +169,11 @@ export async function resolveAndResumeStream(
     const resolution = await ports.resolveResumeState(streamId);
     if (isCancellationRequested()) return false;
     if (resolution.status !== 'resolved') {
-      await ports.reportResumeStateResolution?.(streamId, resolution);
+      try {
+        await ports.reportResumeStateResolution?.(streamId, resolution);
+      } catch {
+        // An info-presenter failure must not become a resume-failure toast.
+      }
       return false;
     }
 

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -1,22 +1,16 @@
-/**
- * Host-neutral resume orchestrator shared by the VS Code extension and the
- * Electron desktop bridge.
- *
- * Owns the cross-host skeleton — the active/resuming + in-flight guard,
- * resume-data retrieval, and the tool-use vs workflow branch — so hosts collapse
- * to thin injected-port adapters. The forks differ only in how they resolve
- * persisted state, surface failures, and launch the workflow executor; that
- * variation lives entirely in {@link ResumeStreamPorts}.
- */
+/** Host-neutral persisted-state resolution and resume orchestration. */
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { ExecutionLeaseActiveError } from '@agent/storage/executionLease';
 import type { RecoveryContinuation } from '@platform/interfaces';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { StreamSnapshotStore } from '@transcript/StreamSnapshotStore';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
   retrieveSessionResumeData,
   type ToolUseResumeData,
 } from './SessionResumeRetrieval';
+import type { SessionHandle } from './SessionHandle';
 import type { StreamStatusMachine } from './StreamStatusService';
 import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
 
@@ -26,11 +20,6 @@ interface ResolvedResumeState {
   readonly parentStreamId?: StreamTabId;
 }
 
-/**
- * Outcome of {@link resolveResumeStateFromSnapshots}. `incomplete` carries the
- * two fields it did read so each host keeps its own "which half is missing"
- * surface (a log line in the extension, an info message on desktop).
- */
 export type ResumeStateResolution =
   | { readonly status: 'resolved'; readonly state: ResolvedResumeState }
   | { readonly status: 'read-failed'; readonly error: unknown }
@@ -40,19 +29,59 @@ export type ResumeStateResolution =
       readonly executionId: ExecutionId | undefined;
     };
 
-/**
- * The one `resolveResumeState` for hosts whose persisted run metadata lives in
- * a session's {@link StreamSnapshotStore} (extension and desktop; the CLI
- * already holds the config it is resuming). Returns the outcome and never
- * logs — the reporting surface stays host-owned.
- *
- * Preload-then-read (#9947): a stream whose sidecar record is not resident yet
- * must be seeded from disk before the synchronous reads can be trusted. Both
- * fields are re-read after the seed rather than filled in individually —
- * seeding deliberately drops a resident config/execution pair whose sidecar
- * names a different execution, and half of that invalidated pair must not
- * survive into the resume.
- */
+type UnresolvedResumeState = Exclude<
+  ResumeStateResolution,
+  { readonly status: 'resolved' }
+>;
+
+export interface ResumeFailureDescription {
+  readonly kind: 'lease-active' | 'unexpected';
+  readonly message: string;
+}
+
+/** One user-facing diagnosis for the two snapshot-backed GUI hosts. */
+export function describeResumeStateResolution(
+  resolution: UnresolvedResumeState,
+): string {
+  if (resolution.status === 'read-failed') {
+    return `Persisted run state could not be read (${toErrorMessage(resolution.error)}). The resume was not started; retry once the storage issue is resolved.`;
+  }
+  return resolution.runState
+    ? 'This stream has no persisted execution id. Start a new run instead.'
+    : 'No persisted run state was found for this stream. Start a new run instead.';
+}
+
+/** Classify lease contention without making hosts recognize storage errors. */
+export function describeResumeFailure(
+  error: unknown,
+): ResumeFailureDescription {
+  return error instanceof ExecutionLeaseActiveError
+    ? { kind: 'lease-active', message: error.message }
+    : {
+        kind: 'unexpected',
+        message: `Resume failed: ${toErrorMessage(error)}`,
+      };
+}
+
+/** Claim and release the byte-identical GUI recovery ownership triad. */
+export async function resumeStreamWithRecovery(
+  session: Pick<SessionHandle, 'followUps'>,
+  streamId: StreamTabId,
+  run: (recovery: RecoveryContinuation) => Promise<boolean>,
+  recovery?: RecoveryContinuation,
+): Promise<boolean> {
+  const claimedRecovery = recovery
+    ? session.followUps.useRecovery(recovery)
+    : session.followUps.claimRecovery(streamId, true);
+  if (!claimedRecovery) return false;
+  try {
+    return await run(claimedRecovery);
+  } finally {
+    session.followUps.release(claimedRecovery, 'recoverable');
+  }
+}
+
+/** Resolve snapshot-backed metadata without collapsing read failure into absence. */
 export async function resolveResumeStateFromSnapshots(
   snapshots: Pick<
     StreamSnapshotStore,
@@ -84,55 +113,29 @@ export async function resolveResumeStateFromSnapshots(
 }
 
 export interface ResumeStreamPorts {
-  /**
-   * The status machine of the session that owns this stream — process-owned on
-   * desktop, and the default session's machine in the extension/CLI. The
-   * active/resuming guards must read the machine the run actually writes
-   * (`launchSession.status`); reading the process-global default here left
-   * both guards permanently false in multi-session hosts.
-   */
   readonly streamStatus: Pick<StreamStatusMachine, 'isActiveOrResuming'>;
-  /** Host-owned cancellation requested while asynchronous resume preparation runs. */
   readonly isCancellationRequested?: () => boolean;
-  /**
-   * Resolve the persisted run state + execution id for a stream, or `undefined`
-   * when there is nothing to resume. The host owns any "no state" messaging it
-   * surfaces in the `undefined` case (the orchestrator stays silent there).
-   */
-  resolveResumeState(
+  resolveResumeState(streamId: StreamTabId): Promise<ResumeStateResolution>;
+  reportResumeStateResolution?(
     streamId: StreamTabId,
-  ): Promise<ResolvedResumeState | undefined>;
-  /** Resume canonical tool-use state (host injects its failure surface). */
+    resolution: UnresolvedResumeState,
+    message: string,
+  ): void | Promise<void>;
   resumeToolUse(
     resume: ToolUseResumeData,
     recovery?: RecoveryContinuation,
   ): Promise<boolean>;
-  /**
-   * Launch a workflow resume run. The extension re-parses the config and opens
-   * the final output; the desktop runs it directly and opens its own preview —
-   * so this stays host-injected rather than unifying the runAgent options.
-   */
   executeWorkflow(
     config: AgentConfig,
     executionId: ExecutionId | undefined,
     modelHandlerCompatibilityKey:
       ModelHandlerCompatibilityKey | null | undefined,
   ): Promise<void>;
-  /**
-   * Surface "this run has no resumable session state" when retrieval succeeds
-   * but finds nothing to resume (an info message on desktop and in the
-   * extension, a transcript line in the CLI).
-   */
   reportNoResumableSession?(streamId: StreamTabId): void | Promise<void>;
-  /** Surface an unexpected resume failure (desktop dialog; extension log). */
   reportFailure?(streamId: StreamTabId, error: unknown): void | Promise<void>;
 }
 
-/**
- * Attempt to resume a WAITING / children-running stream from its persisted
- * state. Returns `true` when the resume reached the run lifecycle, `false`
- * otherwise (already active/resuming, nothing to resume, or a handled failure).
- */
+/** Attempt to resume a WAITING / children-running stream from persisted state. */
 export async function resolveAndResumeStream(
   streamId: StreamTabId,
   ports: ResumeStreamPorts,
@@ -149,11 +152,18 @@ export async function resolveAndResumeStream(
   }
 
   try {
-    const resolved = await ports.resolveResumeState(streamId);
+    const resolution = await ports.resolveResumeState(streamId);
     if (isCancellationRequested()) return false;
-    // The host's resolveResumeState owns its own "no persisted state" messaging.
-    if (!resolved) return false;
+    if (resolution.status !== 'resolved') {
+      await ports.reportResumeStateResolution?.(
+        streamId,
+        resolution,
+        describeResumeStateResolution(resolution),
+      );
+      return false;
+    }
 
+    const resolved = resolution.state;
     const resume = await retrieveSessionResumeData(
       streamId,
       resolved.executionId,
@@ -166,23 +176,12 @@ export async function resolveAndResumeStream(
       return false;
     }
 
-    // Re-check after the async retrieval window: `resumeInFlight` (held here)
-    // blocks only a second resume entry, not a concurrent non-resume run launch
-    // that flips this stream active/resuming while we awaited retrieval. If that
-    // happened, abandon the resume rather than clobbering the launched run's
-    // status.
-    if (ports.streamStatus.isActiveOrResuming(streamId)) {
-      return false;
-    }
+    if (ports.streamStatus.isActiveOrResuming(streamId)) return false;
 
     if (resume.type === 'toolUse') {
-      // The tool-use helper owns the RESUMING flip + follow-up dance.
       return await ports.resumeToolUse(resume, recovery);
     }
 
-    // Workflow launch owns stream acquisition and status transitions through
-    // runAgent/buildAgentLaunchContext. Pre-marking the same stream RESUMING
-    // here would make the launch reject itself as already in flight.
     await ports.executeWorkflow(
       resume.agentConfig,
       resume.executionId,

--- a/src/agent/runtime/terminalResultToast.ts
+++ b/src/agent/runtime/terminalResultToast.ts
@@ -118,7 +118,11 @@ export function terminalResultToast(
 export function trackTerminalResultPresentation(
   session: SessionHandle,
   matches: (event: ResultEvent) => boolean,
-): { isHandled(): boolean; dispose(): void } {
+): {
+  isHandled(): boolean;
+  reportUnhandled<T>(report: () => T): T | undefined;
+  dispose(): void;
+} {
   let handled = false;
   const dispose = session.onResult((event) => {
     if (!matches(event)) return;
@@ -127,6 +131,7 @@ export function trackTerminalResultPresentation(
   });
   return {
     isHandled: () => handled,
+    reportUnhandled: (report) => (handled ? undefined : report()),
     dispose,
   };
 }

--- a/src/agent/runtime/terminalResultToast.ts
+++ b/src/agent/runtime/terminalResultToast.ts
@@ -119,7 +119,6 @@ export function trackTerminalResultPresentation(
   session: SessionHandle,
   matches: (event: ResultEvent) => boolean,
 ): {
-  isHandled(): boolean;
   reportUnhandled<T>(report: () => T): T | undefined;
   dispose(): void;
 } {
@@ -130,7 +129,6 @@ export function trackTerminalResultPresentation(
       terminalResultToast(event) !== null || event.error?.kind === 'abort';
   });
   return {
-    isHandled: () => handled,
     reportUnhandled: (report) => (handled ? undefined : report()),
     dispose,
   };

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -277,7 +277,6 @@ describe('resolveAndResumeStream', () => {
     expect(ports.reportResumeStateResolution).toHaveBeenCalledWith(
       STREAM,
       resolution,
-      'Persisted run state could not be read (snapshot disk offline). The resume was not started; retry once the storage issue is resolved.',
     );
     expect(retrieveSessionResumeDataMock).not.toHaveBeenCalled();
     expect(ports.reportNoResumableSession).not.toHaveBeenCalled();
@@ -306,6 +305,17 @@ describe('resolveAndResumeStream', () => {
 
     await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
     expect(ports.reportFailure).toHaveBeenCalledWith(STREAM, error);
+  });
+
+  it('does not let presentation failure replace the resume failure', async () => {
+    retrieveSessionResumeDataMock.mockRejectedValue(new Error('kv boom'));
+    const ports = basePorts({
+      reportFailure: vi.fn(async () => {
+        throw new Error('presentation unavailable');
+      }),
+    });
+
+    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
   });
 
   it('keeps the in-flight guard until async failure reporting completes', async () => {

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -11,6 +11,7 @@ vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
 
 import {
   resolveAndResumeStream,
+  resumeStreamWithRecovery,
   type ResumeStreamPorts,
 } from '@agent/runtime/resolveAndResumeStream';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
@@ -27,8 +28,11 @@ import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
 const STREAM = 'stream:resume' as StreamTabId;
 
 const RESOLVED_STATE = {
-  runState: { agent: 'a', model: 'm' } as never,
-  executionId: 'exec-1' as never,
+  status: 'resolved' as const,
+  state: {
+    runState: { agent: 'a', model: 'm' } as never,
+    executionId: 'exec-1' as never,
+  },
 };
 
 function basePorts(
@@ -39,6 +43,7 @@ function basePorts(
     resolveResumeState: vi.fn(async () => RESOLVED_STATE),
     resumeToolUse: vi.fn(async () => true),
     executeWorkflow: vi.fn(async () => {}),
+    reportResumeStateResolution: vi.fn(),
     reportNoResumableSession: vi.fn(),
     reportFailure: vi.fn(),
     ...overrides,
@@ -69,6 +74,30 @@ async function expectGuardHeldThroughAsyncReport(
   await expect(pending).resolves.toBe(false);
 }
 
+describe('resumeStreamWithRecovery', () => {
+  it('releases recovery ownership when the resume callback throws synchronously', async () => {
+    const recovery = { streamId: STREAM } as never;
+    const followUps = {
+      useRecovery: vi.fn(() => recovery),
+      claimRecovery: vi.fn(),
+      release: vi.fn(),
+    };
+    const error = new Error('synchronous resume failure');
+
+    await expect(
+      resumeStreamWithRecovery(
+        { followUps } as never,
+        STREAM,
+        () => {
+          throw error;
+        },
+        recovery,
+      ),
+    ).rejects.toBe(error);
+    expect(followUps.release).toHaveBeenCalledWith(recovery, 'recoverable');
+  });
+});
+
 describe('resolveAndResumeStream', () => {
   beforeEach(() => {
     retrieveSessionResumeDataMock.mockReset();
@@ -98,7 +127,7 @@ describe('resolveAndResumeStream', () => {
     const ports = basePorts({
       resolveResumeState: vi.fn(async () => ({
         ...RESOLVED_STATE,
-        parentStreamId,
+        state: { ...RESOLVED_STATE.state, parentStreamId },
       })),
     });
 
@@ -237,12 +266,19 @@ describe('resolveAndResumeStream', () => {
     expect(ports.resumeToolUse).toHaveBeenCalled();
   });
 
-  it('returns false (host owns its messaging) when no state resolves', async () => {
+  it('reports a persisted-state read failure separately from missing resume data', async () => {
+    const error = new Error('snapshot disk offline');
+    const resolution = { status: 'read-failed' as const, error };
     const ports = basePorts({
-      resolveResumeState: vi.fn(async () => undefined),
+      resolveResumeState: vi.fn(async () => resolution),
     });
 
     await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
+    expect(ports.reportResumeStateResolution).toHaveBeenCalledWith(
+      STREAM,
+      resolution,
+      'Persisted run state could not be read (snapshot disk offline). The resume was not started; retry once the storage issue is resolved.',
+    );
     expect(retrieveSessionResumeDataMock).not.toHaveBeenCalled();
     expect(ports.reportNoResumableSession).not.toHaveBeenCalled();
   });

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -11,7 +11,6 @@ vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
 
 import {
   resolveAndResumeStream,
-  resumeStreamWithRecovery,
   type ResumeStreamPorts,
 } from '@agent/runtime/resolveAndResumeStream';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
@@ -73,30 +72,6 @@ async function expectGuardHeldThroughAsyncReport(
   gate.resolve();
   await expect(pending).resolves.toBe(false);
 }
-
-describe('resumeStreamWithRecovery', () => {
-  it('releases recovery ownership when the resume callback throws synchronously', async () => {
-    const recovery = { streamId: STREAM } as never;
-    const followUps = {
-      useRecovery: vi.fn(() => recovery),
-      claimRecovery: vi.fn(),
-      release: vi.fn(),
-    };
-    const error = new Error('synchronous resume failure');
-
-    await expect(
-      resumeStreamWithRecovery(
-        { followUps } as never,
-        STREAM,
-        () => {
-          throw error;
-        },
-        recovery,
-      ),
-    ).rejects.toBe(error);
-    expect(followUps.release).toHaveBeenCalledWith(recovery, 'recoverable');
-  });
-});
 
 describe('resolveAndResumeStream', () => {
   beforeEach(() => {
@@ -305,17 +280,6 @@ describe('resolveAndResumeStream', () => {
 
     await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
     expect(ports.reportFailure).toHaveBeenCalledWith(STREAM, error);
-  });
-
-  it('does not let presentation failure replace the resume failure', async () => {
-    retrieveSessionResumeDataMock.mockRejectedValue(new Error('kv boom'));
-    const ports = basePorts({
-      reportFailure: vi.fn(async () => {
-        throw new Error('presentation unavailable');
-      }),
-    });
-
-    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
   });
 
   it('keeps the in-flight guard until async failure reporting completes', async () => {

--- a/src/test-kernel/cli/CliInitPlatform.vitest.ts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.ts
@@ -396,8 +396,17 @@ describe('CLI platform init', () => {
 
     const streamId = 'stream:cli-resume' as StreamTabId;
     let releaseResumeState!: () => void;
-    const pendingResumeState = new Promise<undefined>((resolve) => {
-      releaseResumeState = () => resolve(undefined);
+    const pendingResumeState = new Promise<{
+      status: 'incomplete';
+      runState: undefined;
+      executionId: undefined;
+    }>((resolve) => {
+      releaseResumeState = () =>
+        resolve({
+          status: 'incomplete',
+          runState: undefined,
+          executionId: undefined,
+        });
     });
     const pendingResume = resolveAndResumeStream(streamId, {
       streamStatus: { isActiveOrResuming: () => false },

--- a/src/test-kernel/cli/ResumeCommand.vitest.ts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.ts
@@ -8,6 +8,7 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import {
   acquireFreshExecutionLease,
+  ExecutionLeaseActiveError,
   releaseOwnedExecutionLease,
 } from '@agent/storage/executionLease';
 import { CliUsageError, type CliContext } from '@cli/runtime/cliContext';
@@ -404,6 +405,18 @@ describe('runResumeExecution', () => {
     expect(mocks.runChat).not.toHaveBeenCalled();
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
       `Could not load session ${EXECUTION_ID}: KV timeout`,
+    );
+  });
+
+  it('classifies lease contention that races the resume pre-check as usage', async () => {
+    stubWorkflowResume(WORKFLOW_CONFIG);
+    mocks.executeCliWorkflowConfig.mockRejectedValue(
+      new ExecutionLeaseActiveError(EXECUTION_ID, Date.now()),
+    );
+
+    await expect(run(cliContext())).resolves.toBe(CliExitCode.Usage);
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      `Execution ${EXECUTION_ID} is active in TeXRA.`,
     );
   });
 });

--- a/src/test-kernel/cli/ResumeCommand.vitest.ts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.ts
@@ -8,7 +8,6 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import {
   acquireFreshExecutionLease,
-  ExecutionLeaseActiveError,
   releaseOwnedExecutionLease,
 } from '@agent/storage/executionLease';
 import { CliUsageError, type CliContext } from '@cli/runtime/cliContext';
@@ -405,18 +404,6 @@ describe('runResumeExecution', () => {
     expect(mocks.runChat).not.toHaveBeenCalled();
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
       `Could not load session ${EXECUTION_ID}: KV timeout`,
-    );
-  });
-
-  it('classifies lease contention that races the resume pre-check as usage', async () => {
-    stubWorkflowResume(WORKFLOW_CONFIG);
-    mocks.executeCliWorkflowConfig.mockRejectedValue(
-      new ExecutionLeaseActiveError(EXECUTION_ID, Date.now()),
-    );
-
-    await expect(run(cliContext())).resolves.toBe(CliExitCode.Usage);
-    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      `Execution ${EXECUTION_ID} is active in TeXRA.`,
     );
   });
 });

--- a/src/test-kernel/cli/chatSessionController.vitest.ts
+++ b/src/test-kernel/cli/chatSessionController.vitest.ts
@@ -49,7 +49,10 @@ vi.mock('@agent/storage', () => ({
   getExecutionStore: mocks.getExecutionStore,
 }));
 
-vi.mock('@agent/runtime/resolveAndResumeStream', () => ({
+vi.mock('@agent/runtime/resolveAndResumeStream', async (importActual) => ({
+  ...(await importActual<
+    typeof import('@agent/runtime/resolveAndResumeStream')
+  >()),
   resolveAndResumeStream: mocks.resolveAndResumeStream,
 }));
 

--- a/src/test-kernel/commands/agent/ResumeFromResumeData.vitest.ts
+++ b/src/test-kernel/commands/agent/ResumeFromResumeData.vitest.ts
@@ -2,7 +2,6 @@
 import '@test/support/defaultSessionTestSetup';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import * as vscode from 'vscode';
 
 const mocks = vi.hoisted(() => ({
   resolveAndResumeStream: vi.fn(
@@ -53,21 +52,6 @@ describe('tryResumeFromResumeData ports', () => {
 
     expect(ports.isCancellationRequested?.()).toBe(false);
     has.mockRestore();
-  });
-
-  it('presents a pre-lifecycle workflow failure through the guarded warning', async () => {
-    const showWarningMessage = vi
-      .spyOn(vscode.window, 'showWarningMessage')
-      .mockResolvedValue(undefined);
-    const error = new Error('workflow bootstrap failed');
-
-    const ports = await capturePorts();
-    await ports.reportFailure?.(STREAM, error);
-
-    expect(showWarningMessage).toHaveBeenCalledWith(
-      'Resume failed: workflow bootstrap failed',
-    );
-    showWarningMessage.mockRestore();
   });
 
   it('tells the user when there is no resumable session state', async () => {

--- a/src/test-kernel/commands/agent/ResumeFromResumeData.vitest.ts
+++ b/src/test-kernel/commands/agent/ResumeFromResumeData.vitest.ts
@@ -2,6 +2,7 @@
 import '@test/support/defaultSessionTestSetup';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
 
 const mocks = vi.hoisted(() => ({
   resolveAndResumeStream: vi.fn(
@@ -9,7 +10,10 @@ const mocks = vi.hoisted(() => ({
   ),
 }));
 
-vi.mock('@agent/runtime/resolveAndResumeStream', () => ({
+vi.mock('@agent/runtime/resolveAndResumeStream', async (importActual) => ({
+  ...(await importActual<
+    typeof import('@agent/runtime/resolveAndResumeStream')
+  >()),
   resolveAndResumeStream: mocks.resolveAndResumeStream,
 }));
 vi.mock('@commands/agent/executeCommand', () => ({
@@ -49,6 +53,21 @@ describe('tryResumeFromResumeData ports', () => {
 
     expect(ports.isCancellationRequested?.()).toBe(false);
     has.mockRestore();
+  });
+
+  it('presents a pre-lifecycle workflow failure through the guarded warning', async () => {
+    const showWarningMessage = vi
+      .spyOn(vscode.window, 'showWarningMessage')
+      .mockResolvedValue(undefined);
+    const error = new Error('workflow bootstrap failed');
+
+    const ports = await capturePorts();
+    await ports.reportFailure?.(STREAM, error);
+
+    expect(showWarningMessage).toHaveBeenCalledWith(
+      'Resume failed: workflow bootstrap failed',
+    );
+    showWarningMessage.mockRestore();
   });
 
   it('tells the user when there is no resumable session state', async () => {

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -446,8 +446,15 @@ describe('completedRunArchive facade', () => {
       const { config: runState, executionId: resolvedExecutionId } =
         snapshots.getRunMetadata(requestedStreamId);
       return runState && resolvedExecutionId
-        ? { runState, executionId: resolvedExecutionId }
-        : undefined;
+        ? {
+            status: 'resolved' as const,
+            state: { runState, executionId: resolvedExecutionId },
+          }
+        : {
+            status: 'incomplete' as const,
+            runState,
+            executionId: resolvedExecutionId,
+          };
     });
     const reportFailure = vi.fn();
     try {


### PR DESCRIPTION
## Summary

Implements the ungated top-mechanical resume-hardening unit from `2026-08-15-cross-host-consolidation.md` §7 item 2, re-anchored onto current main (including #10712):

- C2: one shared recovery claim/use/release triad for extension and desktop
- C3 / V4a: carry discriminated `resolved | read-failed | incomplete` state resolution end to end, with one shared diagnosis and host-owned presentation
- C11 / V4d: extend the existing terminal-result tracker with a guarded `reportUnhandled` operation and add the missing extension failure guard
- C21: one shared lease-active failure classification across extension, desktop, and CLI

Already-landed prerequisites (`resolveAndResumeStream`, `ResumeStateResolution`, snapshot resolution, terminal presentation tracking) are reused rather than recreated.

Explicitly untouched: V4b atomic extension admission policy, V4c cancellation latching policy, and desktop's process-specific authoritative-stream fence.

## Net elements (R6)

Production TypeScript is net +13 lines (+228/−215):

- deletes two duplicated GUI recovery triads
- deletes host-local state-resolution diagnosis branches
- deletes repeated terminal-result handled checks
- deletes host-local lease-active wording/classification
- adds shared helpers only where each has at least two production consumers
- restores the four load-bearing invariant comments removed during consolidation

Test diff is migrations only: 5 files, +43/−11. No new test cases are added; the four focused regressions added during review were removed per the maintainer zero-new-tests policy, keeping only the mock/shape/replacement migrations required to keep existing suites compiling.

Full diff: 14 files, +271/−226.

## Consumer counts (R8)

- `resumeStreamWithRecovery`: extension + desktop
- `describeResumeStateResolution`: extension + desktop
- `describeResumeFailure`: extension + desktop + two CLI paths
- `reportUnhandled`: extension resume, desktop resume/merge, CLI run failure

## Review fixes

- `describeResumeStateResolution` is consumed by the two GUI host presenters (no dead export); `ResumeFailureDescription` stays private.
- Removed the dead `isHandled()` surface from the terminal-result tracker.
- Reporter rejection is contained so a presentation failure cannot replace the original resume failure.
- The optional `reportResumeStateResolution` callback is now independently swallowed so an info-presenter rejection cannot fall through to `reportFailure` and become a "Resume failed" toast.
- Restored the load-bearing invariant comments: injected status machine, preload-then-read #9947, post-retrieval lease recheck, and workflow RESUMING self-rejection.
- Migrated `resumeFromResumeData.ts` from log-only `createChannelTrace` to `createLog`, preserving channel, levels, messages, and data.
- Documented the outer recovery release as a deliberate no-op safety net (the wrapped tool-use resume releases the same lease in its own finally; `release()` is ownership-checked and returns false on the second call).
- The extension now surfaces unresolved persisted state on the automatic follow-up resume path too. This is deliberate C3/V4a host parity (desktop already did), not accidental noise.
- Rebased onto current `origin/main` after #10712 merged; the shared `@agent/runtime` import blocks preserve both the AgentConfig re-exports from #10712 and this branch's resume helpers.

## Validation

- six affected resume suites: 6 files, 112 tests passed
- `npm run typecheck` passed
- `npm run lint` passed
- `npm run format:check` passed
- `git diff --check` passed
- `npm run check:dead-code-ratchet` passed

Refs #10679
Refs #10013
Refs #10595
