### PR TITLE
docs(agent): correct stale switch-arm comments from the exhaustive-category refactor

### DIFF
--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -257,8 +257,10 @@ function blocksToUserParts(blocks: ContentBlock[]): UserPart[] {
         parts.push({ type: 'attachment', attachmentType: 'document' });
         break;
       // Every other recognized block carries no user part — thinking and the
-      // tool blocks are assistant-side (tool results reach the export via
-      // `extractToolResultText`); `undefined` covers unrecognized tags.
+      // tool blocks are assistant-side. A tool-result tag only reaches this
+      // switch inside a plain user message (results answering an assistant
+      // tool use go through `extractToolResultText` instead), so it is
+      // dropped here; `undefined` covers unrecognized tags.
       case 'thinking':
       case 'tool-use':
       case 'tool-result':

--- a/src/test-kernel/agent/ConversationBlockTypeParity.vitest.ts
+++ b/src/test-kernel/agent/ConversationBlockTypeParity.vitest.ts
@@ -11,10 +11,10 @@
  *
  * Known blind spot, documented rather than hidden: for the thinking tags the
  * export side is vacuous — `assistantBlockToNode` suppresses them (returns
- * null), which is also what its `default` arm does, so no behavioral probe
- * can distinguish "recognized and suppressed" from "unrecognized". The
- * format side distinguishes them (suppressed vs. JSON dump), so drift there
- * is still caught.
+ * null), which is also what its `case undefined` arm does with
+ * unrecognized tags, so no behavioral probe can distinguish "recognized and
+ * suppressed" from "unrecognized". The format side distinguishes them
+ * (suppressed vs. JSON dump), so drift there is still caught.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -54,9 +54,9 @@ function probeBlock(tag: string): Record<string, unknown> {
 /**
  * Bucket assigned by `formatConversationBlock` (via the exported
  * `formatConversationContent`). `hideProviderReasoning` collapses the
- * thinking arm to `''`, which the default arm (a JSON dump) can never
- * produce for a non-empty probe block — so every recognized tag lands in a
- * bucket and every unrecognized one returns undefined.
+ * thinking arm to `''`, which the `case undefined` arm (a JSON dump) can
+ * never produce for a non-empty probe block — so every recognized tag lands
+ * in a bucket and every unrecognized one returns undefined.
  */
 function formatBucket(tag: string): BlockBucket | undefined {
   const out = formatConversationContent([probeBlock(tag)], {

--- a/src/test-kernel/agent/export/normalizeConversation.vitest.ts
+++ b/src/test-kernel/agent/export/normalizeConversation.vitest.ts
@@ -693,9 +693,9 @@ describe('Edge cases', () => {
   // code_execution_tool_result / bash_code_execution_tool_result /
   // text_editor_code_execution_tool_result are not emitted by any model
   // handler in this codebase (only server_tool_use, web_search_tool_result,
-  // and web_fetch_tool_result are — see AnthropicStreamHandler) and fall
-  // through to the switch's `default: return null`, same as any other
-  // unrecognized block type.
+  // and web_fetch_tool_result are — see AnthropicStreamHandler) and land
+  // in the switch's `case undefined` arm, same as any other unrecognized
+  // block type.
   it('does not map unused code-execution block types to a node', () => {
     const nodes = normalize([
       {


### PR DESCRIPTION
## Summary

Follow-up from #10692 (which made the three `ProviderMessageBlockCategory` switches compile-time exhaustive: unrecognized/`undefined` tags route through explicit `case undefined` arms and `default` throws via `assertNever`). Four comments — three in the test suites, one added by that PR itself — still described the pre-PR catch-all `default`, i.e. the silent-drift mode the refactor exists to eliminate. This PR corrects exactly those comments; nothing else.

- `src/test-kernel/agent/ConversationBlockTypeParity.vitest.ts` module doc: `assistantBlockToNode` suppresses thinking blocks via `case 'thinking': return null`, and the arm unrecognized tags now land in is `case undefined` (which also returns null) — the `default` arm throws, so the blind-spot explanation now names the real arms. The blind spot itself is unchanged and still documented.
- Same file, `formatBucket` doc: the JSON dump that can never produce `''` for a non-empty probe block lives in `formatConversationBlock`'s `case undefined` arm, not its `default`.
- `src/test-kernel/agent/export/normalizeConversation.vitest.ts` edge-case note: the unused code-execution tags land in `assistantBlockToNode`'s `case undefined` arm like any other unrecognized tag — the `default: return null` they supposedly fell through to no longer exists.
- `src/agent/export/normalizeConversation.ts` (`blocksToUserParts` grouped cases): the old parenthetical ("tool results reach the export via `extractToolResultText`") describes the normal `lastAssistantHadToolUse` path, not this switch. This switch is only reached from a plain user message, so a `tool-result`-tagged block here is simply dropped; the comment now says that and points at `extractToolResultText` as the contrasting normal path.

Comment-only: no logic, assertions, schemas, or runtime behavior changes; no new tests (consistent with the no-test-changes direction).

Closes #10698

## Open-PR overlap audit

Checked every open PR (#10697, #10696, #10695, #10694, #10693, #10689, #10688, #10683, #10660): none touches any of the three files. (#10688 touches `src/agent/storage/conversationFormat.ts`, which this PR does not modify.)

## Net elements

- Files: 3 modified (1 production comment block, 2 test-file comment blocks), 0 added, 0 deleted.
- `git diff --numstat`: +14 / -12; every changed line is inside a `//` or JSDoc comment — no executable line, assertion, or schema touched.

## Validation

- Existing unmodified suites: `normalizeConversation` (39) + `ConversationBlockTypeParity` (11) — 50/50 pass, same counts as before the change.
- `tsc --noEmit` (workspace) and `tsc --noEmit -p tsconfig.test-kernel.json` — pass.
- ESLint on the three changed files — clean; Prettier `--check` on the three changed files — clean.