### PR TITLE
refactor(logger): narrow SessionHandle's log-only createChannelTrace onto createLog

### DIFF
--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -34,7 +34,6 @@ import pMap from 'p-map';
 import PQueue from 'p-queue';
 
 import type { AgentEvent, AgentTrace, ResultEvent } from '@agent/trace';
-import { createChannelTrace } from '@agent/trace';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { detectWaitingStreams } from '@agent/storage/detectWaitingStreams';
 import {
@@ -46,6 +45,7 @@ import {
 } from '@agent/storage/executionLease';
 import { deriveResumability } from '@agent/storage/resumability';
 import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing';
+import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import {
   TEXRA_APPROVAL_POLICY_DEFAULT,
@@ -85,7 +85,7 @@ import {
 } from './restartRepair';
 import { createNeutralResponseTextProcessing } from './responseTextProcessing';
 
-const logger = createChannelTrace('sessionHandle');
+const logger = createLog('sessionHandle');
 
 /** Bounded fan-out for restart repair's sidecar ownership/preload sweeps. */
 const RESTART_REPAIR_IO_CONCURRENCY = 8;

--- a/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
@@ -15,6 +15,28 @@ vi.mock('@agent/trace', async (importOriginal) => {
   };
 });
 
+// SessionHandle now binds `createLog('sessionHandle')` at import time, so
+// the warn spy intercepts that factory for the `sessionHandle` channel
+// only; the graph's other `createLog` consumers keep the real factory, and
+// the `@agent/trace` mock above still covers the remaining
+// `createChannelTrace` singletons (e.g. `executionRegistry`).
+vi.mock('@logger/logUtils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@logger/logUtils')>();
+  return {
+    ...actual,
+    createLog: vi.fn((channel: string) =>
+      channel === 'sessionHandle'
+        ? {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: channelTraceMocks.warn,
+            error: vi.fn(),
+          }
+        : actual.createLog(channel),
+    ),
+  };
+});
+
 beforeEach(() => {
   vi.resetModules();
   channelTraceMocks.warn.mockReset();

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -90,12 +90,12 @@ vi.mock('@frontend/secretManager', () => ({
 
 // The guard's sole touchpoint is `defaultSession().executions.getAgentHandles()`
 // — a full stub replacement (not `importOriginal`) keeps this suite's
-// isolation: the real module eagerly constructs a `createChannelTrace`
-// logger at import time (`SessionHandle.ts`), which needs more
-// of `@logger/logUtils` than this suite's minimal mock provides. No other
-// module in this test's import graph (all deps otherwise mocked away, and
-// `apiKeyCommands`/`codexSubscriptionSignIn` don't import SessionHandle)
-// touches this module's other exports.
+// isolation: the real module eagerly binds a `createLog` logger at import
+// time (`SessionHandle.ts`) and later calls `debug`/`warn` on it, while this
+// suite's minimal `@logger/logUtils` mock gives `createLog` a warn-only
+// return. No other module in this test's import graph (all deps otherwise
+// mocked away, and `apiKeyCommands`/`codexSubscriptionSignIn` don't import
+// SessionHandle) touches this module's other exports.
 vi.mock('@agent/runtime/SessionHandle', () => ({
   defaultSession: () => ({
     executions: { getAgentHandles: () => agentHandles() },


### PR DESCRIPTION
## Summary

Follow-up from #10682 (wave 2), closing the gap that wave tracked under the #10595 audit: `src/agent/runtime/SessionHandle.ts` held the last unowned log-only `createChannelTrace` caller — previously collision-owned by #10646, which merged without touching it.

The module-level singleton (bound eagerly at import time) is log-only: its 11 call sites use only `debug`/`warn` (bare message or `{ data }`), and the sole pass-through hands it to `restartRepair` as the narrow `RestartRepairLogger { debug, warn }`. It never touches the `AgentTrace` contract (`.event`/`.stage`/`.subscribe`), so it now binds `createLog('sessionHandle')` — channel string preserved verbatim.

Behavior is unchanged:

- Both factories route through the same `writeLine` sink with `isAgent = false` (`createChannelTrace` via `createChannelWriter`, `createLog` via the level-bound free functions) — same channel name, same `[channel]` prefix format, same lazy `ensureChannel` per write.
- The only semantic delta between the factories is `createChannelTrace`'s `messageType === INTERNAL` filter; no SessionHandle call site passes `messageType`, so the filter is unobservable here.
- Real-path evidence: `SessionHandle.vitest.ts` stdout shows `[TeXRA] WARN [ts] [sessionHandle] defaultSession() resolved while a non-default SessionHandle was live…` emitted through the real `createLog` path.

Closes #10687

## Issue acceptance gates

- [x] `createChannelTrace('sessionHandle')` → `createLog('sessionHandle')` at the module-level singleton, channel string preserved.
- [x] Site verified log-only (`debug`/`warn` + `RestartRepairLogger` pass-through); no `AgentTrace` contract usage.
- [x] `SetupAssistantRouting.vitest.ts` full-stub rationale re-verified and its citation retargeted (comment-only, mirroring wave 2's edit in this same file): the full stub stays — the suite's minimal `@logger/logUtils` mock gives `createLog` a warn-only return while the real module also calls `debug`.
- [x] Wave-2 test-seam pattern followed where a test intercepts this logger: `importOriginal`-spread `createLog` mock, channels/levels/options verbatim (see below).

## Test seams (mock migration only — no new tests, no coverage changes)

- `DefaultSessionLifecycle.vitest.ts`: its warn spy intercepted SessionHandle's logger through the `@agent/trace` `createChannelTrace` mock, so the production swap required moving that interception to keep the existing suite green. The spy now sits on an `importOriginal`-spread `@logger/logUtils` mock's `createLog`, scoped to the `sessionHandle` channel only; other channels delegate to the real factory (the suite's import graph already runs wave-2 `createLog` consumers unmocked). The `@agent/trace` mock stays — the graph still contains `createChannelTrace` singletons (e.g. `executionRegistry`), and its interception surface is unchanged.
- No other suite needs changes: the remaining `createChannelTrace`-mocking suites either fully stub `@agent/runtime/SessionHandle` (`ExtensionWorkspaceTransition`, `AgentPackage`, `ProgressThemeSync`), import it type-only (`ExecutionRegistry`), or assert on another module's channel (`AgentRunLifecycle` pins `agentRunLifecycle`'s own finalize warn). Suites whose minimal `@logger/logUtils` factories lack `createLog` provably never load the real SessionHandle (they pass today without providing `createChannelWriter`/`disposeAgentChannel` either) — all verified green below.

## Net elements (R6)

- Files: 3 modified (1 production, 2 test-seam), 0 added, 0 deleted.
- Exported symbols: +0 / −0. No API surface change.
- Net LoC (`git diff --numstat`): +30 / −8 = **+22** — the production diff is 2 lines (import swap + factory swap); the rest is the test-mock interception block and the retargeted rationale comment.

## Consumer counts (R8)

- `createLog` (`@logger/logUtils`): +1 importing module (`@agent/runtime/SessionHandle`), 1 bind site.
- `createChannelTrace` (`@agent/trace`): −1 call site; 6 production callers remain (`AgentLaunchResources`, `AgentRunLifecycle`, `executionRegistry`, `childRunLoop` fallback, `StreamSubscriptionRegistry`, `PollingSourceBase`) — the contested remainder tracked by #10595. SessionHandle's `import type { AgentEvent, AgentTrace, ResultEvent }` from `@agent/trace` is unchanged (run-scoped trace APIs still used).

## Host impact

Extension/Desktop/CLI: none — same channel, same sink routing, same log output; restart repair receives the same `debug`/`warn` shape.

## Validation

- Focused existing suites (unmodified except the one required mock migration): `DefaultSessionLifecycle` (6), `SessionHandle` (14), `SetupAssistantRouting` (5) — 25/25 pass.
- Other `createChannelTrace`-mocking suites: `AgentRunLifecycle`, `ExecutionRegistry`, `ExtensionWorkspaceTransition`, `AgentPackage`, `ProgressThemeSync` — 98/98 pass.
- Minimal-`logUtils`-mock suites lacking `createLog`: `OpenBuildDisplay`, `RecordingManager`, `AgentDirectoryWatchers`, `SharedStorageRoot`, `createLanguageModelPort`, `ExecutionHandlers`, `ApprovalPolicy`, `LatexdiffRunPreparation` — 65/65 pass.
- Full `src/test-kernel/agent` + `src/test-kernel/commands` trees: 214 files / 3218 tests pass. Candid flake note: two earlier full-tree runs on a heavily loaded machine (concurrent `tsc --checkers 8`, fleet agents active) reported timeout-style failures in `DefaultSessionLifecycle` ("warns once…" re-imports the whole session graph per test; 3.5–7.1s standalone against the 10s local timeout) plus `TextConnectionHelperModel`/`WorkflowScriptProgressBridge`/`helperModelPreference`, which this change does not touch; every one passes in isolation and on rerun, and three subsequent full-tree runs are fully green.
- `typecheck` (workspace, test-kernel, agent, cli, trace-viewer, desktop) — pass.
- Full ESLint — clean. Prettier on changed files — clean (repo-wide `format:check` verified green at the base). `git diff --check` — clean.
- Architecture suite — 17 files / 102 tests pass. `check:dead-code-ratchet` (8 = 8 baseline), `check:guidance-refs`, `check:browser-safe-utils`, `check:tsconfig-paths` — pass.

Refs #10682 (wave-2 pattern), #10595 (audit), #10593 (tracker).
