### PR TITLE
fix(cli): shield LaTeX environments and align inline-dollar adjacency with texmath

### DIFF
--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -507,8 +507,9 @@ function processorFor(
     formatLatexReference: (refType, label) =>
       style.dim(style.underline(`\\${refType}{${label}}`)),
     // The CLI shows LaTeX source verbatim (math rendering is disabled), so
-    // shield `$…$` / `$$…$$` / `\(…\)` / `\[…\]` spans from markdown-it, which
-    // would otherwise strip `\(`→`(`, `\;`→`;` and eat `_{…}` subscripts.
+    // shield `$…$` / `$$…$$` / `\(…\)` / `\[…\]` spans and
+    // `\begin{env}…\end{env}` environments from markdown-it, which would
+    // otherwise strip `\(`→`(`, `\;`→`;` and eat `_{…}` subscripts.
     protectLatexMath: true,
   });
   processorCache.set(key, processor);

--- a/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
+++ b/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
@@ -1,5 +1,8 @@
 import { summarizeEmbeddedSubagentFollowups } from '@shared/subagentFollowup';
-import { protectLatexMathSpansForNormalize } from '@shared/markdown/createMarkdownProcessor';
+import {
+  protectLatexMathSpansForNormalize,
+  protectLatexMathSpansForNormalizeInline,
+} from '@shared/markdown/createMarkdownProcessor';
 import { clamp } from '@utils/core';
 
 // Only exact supported tag names enter the presentation grammar. Suffixes such
@@ -113,26 +116,98 @@ function quoteHtmlBlock(body: string): string {
     .join('\n');
 }
 
-// Convert innermost `<blockquote>` wrappers that contain an environment opener
-// into markdown blockquote prefixes, iterating so nested wrappers are handled
-// outside-in after their inner wrappers are converted. Blockquotes without an
-// environment stay for the existing normalization pass.
-function quoteBlockquoteEnvironmentWrappers(content: string): string {
-  const innerBlockquoteEnvironment = new RegExp(
-    `<blockquote${HTML_ATTRIBUTES}${HTML_TAG_END}((?:(?!<blockquote)[\\s\\S])*?)<\\/blockquote>`,
-    'gi',
-  );
+const BLOCKQUOTE_OPEN_CAPTURE_RE = new RegExp(
+  `<(blockquote)${HTML_ATTRIBUTES}${HTML_TAG_END}`,
+  'gi',
+);
+const BLOCKQUOTE_CLOSE_CAPTURE_RE = /<\/(blockquote)>/gi;
+
+interface HtmlTagEvent {
+  readonly index: number;
+  readonly end: number;
+  readonly name: string;
+  readonly closing: boolean;
+}
+
+interface HtmlTagPair {
+  readonly start: number;
+  readonly end: number;
+  readonly bodyStart: number;
+  readonly bodyEnd: number;
+  readonly name: string;
+}
+
+function findBlockquotePairs(content: string): HtmlTagPair[] {
+  const events: HtmlTagEvent[] = [];
+  for (const match of content.matchAll(BLOCKQUOTE_OPEN_CAPTURE_RE)) {
+    const index = match.index ?? 0;
+    events.push({
+      index,
+      end: index + match[0].length,
+      name: match[1]!.toLowerCase(),
+      closing: false,
+    });
+  }
+  for (const match of content.matchAll(BLOCKQUOTE_CLOSE_CAPTURE_RE)) {
+    const index = match.index ?? 0;
+    events.push({
+      index,
+      end: index + match[0].length,
+      name: match[1]!.toLowerCase(),
+      closing: true,
+    });
+  }
+  events.sort((a, b) => a.index - b.index);
+
+  const stack: Array<{ name: string; start: number; bodyStart: number }> = [];
+  const pairs: HtmlTagPair[] = [];
+  for (const event of events) {
+    if (!event.closing) {
+      stack.push({
+        name: event.name,
+        start: event.index,
+        bodyStart: event.end,
+      });
+      continue;
+    }
+    for (let index = stack.length - 1; index >= 0; index--) {
+      if (stack[index]!.name !== event.name) continue;
+      const open = stack[index]!;
+      stack.splice(index, 1);
+      pairs.push({
+        start: open.start,
+        end: event.end,
+        bodyStart: open.bodyStart,
+        bodyEnd: event.index,
+        name: event.name,
+      });
+      break;
+    }
+  }
+  return pairs.sort((a, b) => a.start - b.start);
+}
+
+function convertEnvironmentBlockquotes(content: string): string {
   let out = content;
   for (;;) {
-    let changed = false;
-    out = out.replaceAll(innerBlockquoteEnvironment, (match, body: string) => {
-      if (!/\\begin\{[a-z]+\}/.test(body)) return match;
-      changed = true;
-      return quoteHtmlBlock(body);
-    });
-    if (!changed) break;
+    const pair = findBlockquotePairs(out).find((candidate) =>
+      /\\begin\{[a-z]+\}/.test(
+        out.slice(candidate.bodyStart, candidate.bodyEnd),
+      ),
+    );
+    if (pair === undefined) break;
+    out =
+      out.slice(0, pair.start) +
+      quoteHtmlBlock(out.slice(pair.bodyStart, pair.bodyEnd)) +
+      out.slice(pair.end);
   }
   return out;
+}
+
+function removeParagraphDivWrappers(content: string): string {
+  return content
+    .replaceAll(PARAGRAPH_OPEN_TAG_RE, '')
+    .replaceAll(/<\/(?:p|div)>/gi, '\n\n');
 }
 
 const MARKDOWN_BLOCKQUOTE_PREFIX_RE = /^(?:(?:[ \t]*>[ \t]?))+/u;
@@ -141,42 +216,34 @@ function markdownBlockquotePrefix(prefix: string): string {
   return MARKDOWN_BLOCKQUOTE_PREFIX_RE.exec(prefix)?.[0] ?? '';
 }
 
-function replaceBrWithQuotePrefix(source: string, offset: number): string {
-  const lineStart = source.lastIndexOf('\n', offset - 1) + 1;
+function computeLineStarts(content: string): number[] {
+  const lineStarts = [0];
+  for (let index = 0; index < content.length; index++) {
+    if (content.charCodeAt(index) === 10) lineStarts.push(index + 1);
+  }
+  return lineStarts;
+}
+
+function lineStartAt(lineStarts: readonly number[], offset: number): number {
+  let low = 0;
+  let high = lineStarts.length;
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    if (lineStarts[mid]! <= offset) low = mid + 1;
+    else high = mid;
+  }
+  return lineStarts[low - 1] ?? 0;
+}
+
+function replaceBrWithQuotePrefixAt(
+  lineStarts: readonly number[],
+  source: string,
+  offset: number,
+): string {
+  const lineStart = lineStartAt(lineStarts, offset);
   const linePrefix = source.slice(lineStart, offset);
   const quotePrefix = markdownBlockquotePrefix(linePrefix);
   return quotePrefix === '' ? '\n' : `\n${quotePrefix}`;
-}
-
-const HEADING_ENV_RE = new RegExp(
-  `<h([1-6])${HTML_ATTRIBUTES}${HTML_TAG_END}([\\s\\S]*?)<\\/h\\1>`,
-  'gi',
-);
-
-// Expose environments inside the block containers this normalizer otherwise
-// converts, before math shielding. Paragraph/div wrappers are removed (the
-// same output the normalizer produces later), and heading wrappers that
-// contain an environment become temporary structural markers so their body
-// starts at a block line for the probe and can be re-marked after shielding.
-const PARAGRAPH_ENV_RE = new RegExp(
-  `<(p|div)${HTML_ATTRIBUTES}${HTML_TAG_END}([\\s\\S]*?)<\\/\\1>`,
-  'gi',
-);
-
-function exposeHtmlBlockEnvironments(content: string): string {
-  const blockquoted = quoteBlockquoteEnvironmentWrappers(content);
-  const paragraphEnvironmentsRemoved = blockquoted.replaceAll(
-    PARAGRAPH_ENV_RE,
-    (match, _tag: string, body: string) =>
-      /\\begin\{[a-z]+\}/.test(body) ? `\n\n${body.trim()}\n\n` : match,
-  );
-  return paragraphEnvironmentsRemoved.replaceAll(
-    HEADING_ENV_RE,
-    (match, level: string, body: string) =>
-      /\\begin\{[a-z]+\}/.test(body)
-        ? `\n\n@@HTML-HEADING-${level}@@\n${body.trim()}\n@@/HTML-HEADING-${level}@@\n\n`
-        : match,
-  );
 }
 
 function headingMarker(level: string): string {
@@ -389,50 +456,39 @@ export function normalizeKnownHtmlForCliMarkdown(content: string): string {
   if (!KNOWN_HTML_TAG_RE.test(summarized)) return summarized;
 
   const literalDollarProtection = protectLiteralMathSyntax(summarized);
-  // Expose environments inside every supported block container before math
-  // shielding: blockquotes become `>` prefixes, paragraph/div wrappers are
-  // removed, and heading wrappers containing an environment become temporary
-  // structural markers. Bodies are only re-prefixed or un-wrapped, never text-
-  // mutated here.
-  const blockContainerExposed = exposeHtmlBlockEnvironments(
+  // First shield inline/display math so paragraph/div wrapper removal cannot
+  // touch HTML-shaped LaTeX, then remove those wrappers and convert
+  // environment-containing blockquotes, then shield environments.
+  const inlineMathProtection = protectLatexMathSpansForNormalizeInline(
     literalDollarProtection.content,
   );
-  const mathProtection = protectLatexMathSpansForNormalize(
-    blockContainerExposed,
+  const structural = removeParagraphDivWrappers(
+    convertEnvironmentBlockquotes(inlineMathProtection.content),
   );
-  const mathProtected = literalDollarProtection.restore(mathProtection.content);
-  const hasHeadingMarkers = /@@HTML-HEADING-\d@@/.test(mathProtected);
-  if (!KNOWN_HTML_TAG_RE.test(mathProtected) && !hasHeadingMarkers) {
-    return literalDollarProtection.restore(
-      mathProtection.restore(mathProtection.content),
-    );
-  }
+  const envMathProtection = protectLatexMathSpansForNormalize(structural);
+  const protectedContent = envMathProtection.content;
+  const restoreMath = (value: string): string =>
+    inlineMathProtection.restore(envMathProtection.restore(value));
 
-  const normalized = mathProtected
+  const lineStarts = computeLineStarts(protectedContent);
+  const normalized = protectedContent
+    .replaceAll(/<br\s*\/?\s*>/gi, (_match, offset: number) =>
+      replaceBrWithQuotePrefixAt(lineStarts, protectedContent, offset),
+    )
     .replaceAll(
       HEADING_TAG_RE,
       (_match, level: string, body: string) =>
         `\n\n${headingMarker(level)} ${body.trim()}\n\n`,
     )
-    .replaceAll(/<br\s*\/?\s*>/gi, (_match, offset: number, source: string) =>
-      replaceBrWithQuotePrefix(source, offset),
-    )
-    .replaceAll(/<\/(?:p|div)>/gi, '\n\n')
-    .replaceAll(PARAGRAPH_OPEN_TAG_RE, '')
     .replaceAll(STRONG_OPEN_TAG_RE, '**')
     .replaceAll(/<\/(?:strong|b)>/gi, '**')
     .replaceAll(EMPHASIS_OPEN_TAG_RE, '_')
     .replaceAll(/<\/(?:em|i)>/gi, '_')
     .replaceAll(CODE_OPEN_TAG_RE, '`')
     .replaceAll(/<\/code>/gi, '`')
-    .replaceAll(
-      /@@HTML-HEADING-(\d)@@\n([\s\S]*?)\n@@\/HTML-HEADING-\1@@/g,
-      (_match, level: string, body: string) =>
-        `\n\n${headingMarker(level)} ${body.trim()}\n\n`,
-    )
     .replaceAll(BLOCKQUOTE_TAG_RE, (_match, body: string) =>
-      quoteHtmlBlock(mathProtection.restore(body)),
+      quoteHtmlBlock(restoreMath(body)),
     )
     .trim();
-  return literalDollarProtection.restore(mathProtection.restore(normalized));
+  return literalDollarProtection.restore(restoreMath(normalized));
 }

--- a/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
+++ b/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
@@ -323,11 +323,21 @@ export function normalizeKnownHtmlForCliMarkdown(content: string): string {
   if (!KNOWN_HTML_TAG_RE.test(summarized)) return summarized;
 
   const literalDollarProtection = protectLiteralMathSyntax(summarized);
-  const mathProtection = protectLatexMathSpansForNormalize(
-    literalDollarProtection.content,
+  // Convert supported blockquote wrappers to markdown prefixes before math
+  // shielding so an environment immediately inside `<blockquote>` is seen at a
+  // `> \begin{...}` block start. The body is only re-prefixed, never mutated.
+  const blockquotePrefixed = literalDollarProtection.content.replaceAll(
+    BLOCKQUOTE_TAG_RE,
+    (match, body: string) =>
+      /^\s*\\begin\{[a-z]+\}/.test(body) ? quoteHtmlBlock(body) : match,
   );
+  const mathProtection = protectLatexMathSpansForNormalize(blockquotePrefixed);
   const mathProtected = literalDollarProtection.restore(mathProtection.content);
-  if (!KNOWN_HTML_TAG_RE.test(mathProtected)) return summarized;
+  if (!KNOWN_HTML_TAG_RE.test(mathProtected)) {
+    return literalDollarProtection.restore(
+      mathProtection.restore(mathProtection.content),
+    );
+  }
 
   const normalized = mathProtected
     .replaceAll(

--- a/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
+++ b/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
@@ -113,6 +113,28 @@ function quoteHtmlBlock(body: string): string {
     .join('\n');
 }
 
+// Convert innermost `<blockquote>` wrappers that contain an environment opener
+// into markdown blockquote prefixes, iterating so nested wrappers are handled
+// outside-in after their inner wrappers are converted. Blockquotes without an
+// environment stay for the existing normalization pass.
+function quoteBlockquoteEnvironmentWrappers(content: string): string {
+  const innerBlockquoteEnvironment = new RegExp(
+    `<blockquote${HTML_ATTRIBUTES}${HTML_TAG_END}((?:(?!<blockquote)[\\s\\S])*?)<\\/blockquote>`,
+    'gi',
+  );
+  let out = content;
+  for (;;) {
+    let changed = false;
+    out = out.replaceAll(innerBlockquoteEnvironment, (match, body: string) => {
+      if (!/\\begin\{[a-z]+\}/.test(body)) return match;
+      changed = true;
+      return quoteHtmlBlock(body);
+    });
+    if (!changed) break;
+  }
+  return out;
+}
+
 function headingMarker(level: string): string {
   const parsed = Number.parseInt(level, 10);
   const depth = Number.isFinite(parsed) ? clamp(parsed, 1, 6) : 3;
@@ -324,12 +346,11 @@ export function normalizeKnownHtmlForCliMarkdown(content: string): string {
 
   const literalDollarProtection = protectLiteralMathSyntax(summarized);
   // Convert supported blockquote wrappers to markdown prefixes before math
-  // shielding so an environment immediately inside `<blockquote>` is seen at a
-  // `> \begin{...}` block start. The body is only re-prefixed, never mutated.
-  const blockquotePrefixed = literalDollarProtection.content.replaceAll(
-    BLOCKQUOTE_TAG_RE,
-    (match, body: string) =>
-      /^\s*\\begin\{[a-z]+\}/.test(body) ? quoteHtmlBlock(body) : match,
+  // shielding so an environment inside `<blockquote>` (including nested
+  // wrappers) is seen at a `> \begin{...}` block start. The body is only
+  // re-prefixed, never mutated.
+  const blockquotePrefixed = quoteBlockquoteEnvironmentWrappers(
+    literalDollarProtection.content,
   );
   const mathProtection = protectLatexMathSpansForNormalize(blockquotePrefixed);
   const mathProtected = literalDollarProtection.restore(mathProtection.content);

--- a/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
+++ b/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
@@ -135,6 +135,50 @@ function quoteBlockquoteEnvironmentWrappers(content: string): string {
   return out;
 }
 
+const MARKDOWN_BLOCKQUOTE_PREFIX_RE = /^(?:(?:[ \t]*>[ \t]?))+/u;
+
+function markdownBlockquotePrefix(prefix: string): string {
+  return MARKDOWN_BLOCKQUOTE_PREFIX_RE.exec(prefix)?.[0] ?? '';
+}
+
+function replaceBrWithQuotePrefix(source: string, offset: number): string {
+  const lineStart = source.lastIndexOf('\n', offset - 1) + 1;
+  const linePrefix = source.slice(lineStart, offset);
+  const quotePrefix = markdownBlockquotePrefix(linePrefix);
+  return quotePrefix === '' ? '\n' : `\n${quotePrefix}`;
+}
+
+const HEADING_ENV_RE = new RegExp(
+  `<h([1-6])${HTML_ATTRIBUTES}${HTML_TAG_END}([\\s\\S]*?)<\\/h\\1>`,
+  'gi',
+);
+
+// Expose environments inside the block containers this normalizer otherwise
+// converts, before math shielding. Paragraph/div wrappers are removed (the
+// same output the normalizer produces later), and heading wrappers that
+// contain an environment become temporary structural markers so their body
+// starts at a block line for the probe and can be re-marked after shielding.
+const PARAGRAPH_ENV_RE = new RegExp(
+  `<(p|div)${HTML_ATTRIBUTES}${HTML_TAG_END}([\\s\\S]*?)<\\/\\1>`,
+  'gi',
+);
+
+function exposeHtmlBlockEnvironments(content: string): string {
+  const blockquoted = quoteBlockquoteEnvironmentWrappers(content);
+  const paragraphEnvironmentsRemoved = blockquoted.replaceAll(
+    PARAGRAPH_ENV_RE,
+    (match, _tag: string, body: string) =>
+      /\\begin\{[a-z]+\}/.test(body) ? `\n\n${body.trim()}\n\n` : match,
+  );
+  return paragraphEnvironmentsRemoved.replaceAll(
+    HEADING_ENV_RE,
+    (match, level: string, body: string) =>
+      /\\begin\{[a-z]+\}/.test(body)
+        ? `\n\n@@HTML-HEADING-${level}@@\n${body.trim()}\n@@/HTML-HEADING-${level}@@\n\n`
+        : match,
+  );
+}
+
 function headingMarker(level: string): string {
   const parsed = Number.parseInt(level, 10);
   const depth = Number.isFinite(parsed) ? clamp(parsed, 1, 6) : 3;
@@ -345,16 +389,20 @@ export function normalizeKnownHtmlForCliMarkdown(content: string): string {
   if (!KNOWN_HTML_TAG_RE.test(summarized)) return summarized;
 
   const literalDollarProtection = protectLiteralMathSyntax(summarized);
-  // Convert supported blockquote wrappers to markdown prefixes before math
-  // shielding so an environment inside `<blockquote>` (including nested
-  // wrappers) is seen at a `> \begin{...}` block start. The body is only
-  // re-prefixed, never mutated.
-  const blockquotePrefixed = quoteBlockquoteEnvironmentWrappers(
+  // Expose environments inside every supported block container before math
+  // shielding: blockquotes become `>` prefixes, paragraph/div wrappers are
+  // removed, and heading wrappers containing an environment become temporary
+  // structural markers. Bodies are only re-prefixed or un-wrapped, never text-
+  // mutated here.
+  const blockContainerExposed = exposeHtmlBlockEnvironments(
     literalDollarProtection.content,
   );
-  const mathProtection = protectLatexMathSpansForNormalize(blockquotePrefixed);
+  const mathProtection = protectLatexMathSpansForNormalize(
+    blockContainerExposed,
+  );
   const mathProtected = literalDollarProtection.restore(mathProtection.content);
-  if (!KNOWN_HTML_TAG_RE.test(mathProtected)) {
+  const hasHeadingMarkers = /@@HTML-HEADING-\d@@/.test(mathProtected);
+  if (!KNOWN_HTML_TAG_RE.test(mathProtected) && !hasHeadingMarkers) {
     return literalDollarProtection.restore(
       mathProtection.restore(mathProtection.content),
     );
@@ -366,7 +414,9 @@ export function normalizeKnownHtmlForCliMarkdown(content: string): string {
       (_match, level: string, body: string) =>
         `\n\n${headingMarker(level)} ${body.trim()}\n\n`,
     )
-    .replaceAll(/<br\s*\/?\s*>/gi, '\n')
+    .replaceAll(/<br\s*\/?\s*>/gi, (_match, offset: number, source: string) =>
+      replaceBrWithQuotePrefix(source, offset),
+    )
     .replaceAll(/<\/(?:p|div)>/gi, '\n\n')
     .replaceAll(PARAGRAPH_OPEN_TAG_RE, '')
     .replaceAll(STRONG_OPEN_TAG_RE, '**')
@@ -375,6 +425,11 @@ export function normalizeKnownHtmlForCliMarkdown(content: string): string {
     .replaceAll(/<\/(?:em|i)>/gi, '_')
     .replaceAll(CODE_OPEN_TAG_RE, '`')
     .replaceAll(/<\/code>/gi, '`')
+    .replaceAll(
+      /@@HTML-HEADING-(\d)@@\n([\s\S]*?)\n@@\/HTML-HEADING-\1@@/g,
+      (_match, level: string, body: string) =>
+        `\n\n${headingMarker(level)} ${body.trim()}\n\n`,
+    )
     .replaceAll(BLOCKQUOTE_TAG_RE, (_match, body: string) =>
       quoteHtmlBlock(mathProtection.restore(body)),
     )

--- a/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
+++ b/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
@@ -1,5 +1,5 @@
 import { summarizeEmbeddedSubagentFollowups } from '@shared/subagentFollowup';
-import { protectLatexMathSpans } from '@shared/markdown/createMarkdownProcessor';
+import { protectLatexMathSpansForNormalize } from '@shared/markdown/createMarkdownProcessor';
 import { clamp } from '@utils/core';
 
 // Only exact supported tag names enter the presentation grammar. Suffixes such
@@ -314,11 +314,18 @@ function protectLiteralMathSyntax(content: string): {
 }
 
 export function normalizeKnownHtmlForCliMarkdown(content: string): string {
-  const summarized = summarizeEmbeddedSubagentFollowups(content);
+  // Normalize once so the container-aware math shield and the later renderer
+  // both slice the same LF string markdown-it will parse.
+  const summarized = summarizeEmbeddedSubagentFollowups(content).replaceAll(
+    /\r\n?/g,
+    '\n',
+  );
   if (!KNOWN_HTML_TAG_RE.test(summarized)) return summarized;
 
   const literalDollarProtection = protectLiteralMathSyntax(summarized);
-  const mathProtection = protectLatexMathSpans(literalDollarProtection.content);
+  const mathProtection = protectLatexMathSpansForNormalize(
+    literalDollarProtection.content,
+  );
   const mathProtected = literalDollarProtection.restore(mathProtection.content);
   if (!KNOWN_HTML_TAG_RE.test(mathProtected)) return summarized;
 

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -6,6 +6,7 @@
 // isolated — the cached values are not interchangeable between renderers.
 
 import { LRUCache } from 'lru-cache';
+import MarkdownIt, { type StateBlock } from 'markdown-it';
 
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 
@@ -123,39 +124,34 @@ function restoreLatexReferences(
 const INLINE_MATH_SPAN_PATTERN =
   /(?<!\\)\$(?!\$)[^\n$]+?(?<![\\$])\$(?:\$(?!\$)[^\n$]+?(?<![\\$])\$)*/g;
 
-// Render-time inline `$…$` adds the adjacency guards the webview's texmath
-// applies to its `dollars` inline rule (`$_pre`/`$_post`): no digit before
-// the opener, no whitespace just inside either delimiter, and no digit after
-// the closer. `Cost $5 then *ten* $10` is prose to texmath (its emphasis
-// stays live), so the CLI renderer must not shield it as math either. The
-// HTML normalizer keeps the lax form above: there a math-shaped span's tags
-// deliberately stay literal — the conservative choice while deciding which
-// HTML to convert — pinned by the "preserves complete inline math beside
-// token characters" suite.
+// Render-time inline `$…$` mirrors texmath's `dollars` inline rule exactly:
+// the same `$_pre`/`$_post` adjacency guards (no digit before the opener, no
+// whitespace just inside either delimiter, no digit after the closer) and the
+// same single-span body. texmath's body is `(?:[^\s\\]|\S.*?[^\s\\])`,
+// whose first alternative lets a one-character body match and whose second
+// permits interior `$` — so `Cost $5 then *ten* $x$` is one math span whose
+// body ends at the *last* dollar, while `Cost $5 then *ten* $10` is prose
+// (the only closer is preceded by whitespace). Adjacent spans are matched
+// back-to-back by the global scan, keeping `$a$$b$` verbatim.
 const RENDER_INLINE_MATH_SPAN_PATTERN =
-  /(?<![\\\d])\$(?!\$)(?!\s)[^\n$]+?(?<![\\$\s])\$(?!\d)(?:\$(?!\$)(?!\s)[^\n$]+?(?<![\\$\s])\$(?!\d))*/g;
+  /(?<![\\\d])\$((?:[^\s\\]|\S[^\n]*?[^\s\\]))\$(?!\d)/g;
 
-// Environment spans mirror texmath's `beg_end` block rule, so the opener is
-// only recognized where that rule can start one: at a block line start, after
-// optional blockquote/list container prefixes and up to three spaces of
-// indentation. An inline `prefix \begin{…}` stays prose, an escaped `\\begin`
-// never opens (the anchor admits no preceding backslash), four-space
-// indentation stays a code block, and starred variants like `align*` remain
-// unshielded in both hosts (texmath's `[a-z]+` name class excludes them). The
-// closer must be an unescaped `\end` naming the same environment, and a span
-// that would cross a fenced-code boundary is declined: texmath never sees
-// fenced content, so an opener inside one fence pairing a closer inside
-// another would swallow the intervening prose into the placeholder —
-// declining under-shields to the pre-fix rendering instead. Unmatched here,
-// markdown-it eats `\\` row breaks as escapes and turns `*…*` inside the
-// body into emphasis.
+// Lax environment shielding used by `htmlMarkdownNormalize`: that path has no
+// markdown-it block state to consult, so it keeps the previous line-anchored
+// regex. It recognizes a `\\begin{env}…\\end{env}` only where a texmath block
+// could start at top level (line start, optional blockquote/list prefix, up to
+// three spaces) and declines any span that would cross a fenced-code boundary
+// rather than swallowing the intervening prose into a placeholder. The render
+// shield below does not use this regex; it delegates to the container/fence-
+// aware probe so list-continuation offsets and fenced interiors match
+// markdown-it exactly.
 const BEG_END_MATH_SPAN_PATTERN =
   /(?<=^(?:(?:[ \t]*>[ \t]?)|(?:[ \t]*(?:[-+*]|\d+[.)])[ \t]+))*[ ]{0,3})\\begin\{([a-z]+)\}(?:(?!^(?:(?:[ \t]*>[ \t]?)|(?:[ \t]*(?:[-+*]|\d+[.)])[ \t]+))*[ ]{0,3}(?:`{3,}|~{3,}))[\s\S])+?(?<!\\)\\end\{\1\}/gm;
 
-// Math spans whose body must reach the renderer verbatim. Order matters: the
-// display fences are matched before the inline ones so `$…$` never splits a
-// `$$…$$`, and the environment rule comes last so a `\begin{…}…\end{…}`
-// nested inside a fence is consumed with its fence.
+// Math spans whose body must reach the renderer verbatim in the lax
+// (htmlMarkdownNormalize) path. Order matters: display fences before inline
+// ones so `$…$` never splits a `$$…$$`, and the environment rule last so a
+// `\begin{…}…\end{…}` nested inside a fence is consumed with its fence.
 const MATH_SPAN_PATTERNS: readonly RegExp[] = [
   /\$\$[\s\S]+?\$\$/g, // $$ … $$  (display, may span lines)
   /(?<!\\)\\\[[\s\S]+?(?<!\\)\\\]/g, // \[ … \]  (display)
@@ -164,13 +160,16 @@ const MATH_SPAN_PATTERNS: readonly RegExp[] = [
   BEG_END_MATH_SPAN_PATTERN, // \begin{env} … \end{env}  (texmath beg_end)
 ];
 
-// The processor's render shield swaps in the texmath-adjacent inline pattern;
-// htmlMarkdownNormalize keeps the lax default set above.
-const RENDER_MATH_SPAN_PATTERNS: readonly RegExp[] = MATH_SPAN_PATTERNS.map(
-  (pattern) =>
-    pattern === INLINE_MATH_SPAN_PATTERN
-      ? RENDER_INLINE_MATH_SPAN_PATTERN
-      : pattern,
+// The render shield swaps in the texmath-adjacent inline pattern and drops
+// the lax environment regex; environments are shielded by the block-state
+// probe instead (see protectLatexMathSpansForRender). htmlMarkdownNormalize
+// keeps the lax default set above.
+const RENDER_MATH_SPAN_PATTERNS: readonly RegExp[] = MATH_SPAN_PATTERNS.filter(
+  (pattern) => pattern !== BEG_END_MATH_SPAN_PATTERN,
+).map((pattern) =>
+  pattern === INLINE_MATH_SPAN_PATTERN
+    ? RENDER_INLINE_MATH_SPAN_PATTERN
+    : pattern,
 );
 // Fail loud rather than silently render-shield with the lax inline pattern if
 // MATH_SPAN_PATTERNS ever drops or renames the inline entry.
@@ -181,15 +180,15 @@ if (!RENDER_MATH_SPAN_PATTERNS.includes(RENDER_INLINE_MATH_SPAN_PATTERN)) {
 }
 
 // Replace every match of `patterns` with an indexed `@@<tag>-N@@` placeholder,
-// returning the captured matches so restorePlaceholders can reinstate them.
-function protectByPatterns(
+// appending the captured matches to `items` so later shields share one restore
+// pass. `tag` must already be collision-free (see selectPlaceholderTag).
+function protectPatternsInto(
   content: string,
   patterns: readonly RegExp[],
   tag: string,
-  preserveBlockquotePrefixes = false,
-): { content: string; items: string[]; placeholder: RegExp } {
-  const items: string[] = [];
-  const selectedTag = selectPlaceholderTag(content, tag);
+  items: string[],
+  preserveBlockquotePrefixes: boolean,
+): string {
   let out = content;
   for (const pattern of patterns) {
     out = out.replaceAll(pattern, (match, ...args: unknown[]) => {
@@ -233,7 +232,7 @@ function protectByPatterns(
           );
         if (!isQuotedSpan) {
           const index = items.push(match) - 1;
-          return `@@${selectedTag}-${index}@@`;
+          return `@@${tag}-${index}@@`;
         }
         return lines
           .map((line, lineIndex) => {
@@ -242,18 +241,276 @@ function protectByPatterns(
             const contentPrefix =
               lineIndex === 0 ? '' : (availablePrefixes[lineIndex - 1] ?? '');
             const index = items.push(line.slice(contentPrefix.length)) - 1;
-            return `${retainedPrefix}@@${selectedTag}-${index}@@`;
+            return `${retainedPrefix}@@${tag}-${index}@@`;
           })
           .join('\n');
       }
       const index = items.push(match) - 1;
-      return `@@${selectedTag}-${index}@@`;
+      return `@@${tag}-${index}@@`;
     });
   }
+  return out;
+}
+
+function protectByPatterns(
+  content: string,
+  patterns: readonly RegExp[],
+  tag: string,
+  preserveBlockquotePrefixes = false,
+): { content: string; items: string[]; placeholder: RegExp } {
+  const items: string[] = [];
+  const selectedTag = selectPlaceholderTag(content, tag);
+  const protectedContent = protectPatternsInto(
+    content,
+    patterns,
+    selectedTag,
+    items,
+    preserveBlockquotePrefixes,
+  );
   return {
-    content: out,
+    content: protectedContent,
     items,
     placeholder: new RegExp(`@@${selectedTag}-(\\d+)@@`, 'g'),
+  };
+}
+
+interface BegEndEnvironmentMatch {
+  readonly start: number;
+  readonly end: number;
+  readonly startLine: number;
+  readonly endLine: number;
+  readonly lineContentStarts: readonly number[];
+}
+
+interface BegEndEnvironmentProbe {
+  collect(content: string): readonly BegEndEnvironmentMatch[];
+}
+
+// A tiny markdown-it block probe that records exactly where texmath's
+// `beg_end` rule would open an environment. It is a faithful container/fence-
+// aware replacement for the source-level regex: it runs inside markdown-it's
+// block parser, so it inherits bMarks/tShift, container prefix stripping, lazy
+// list continuations, and fence consumption for free. It also installs the
+// same paragraph-interruption rule the webview's texmath plugin uses, which is
+// what lets `10. Formula:\n    \begin{align}` open an environment on the
+// indented continuation line. The probe returns true to consume a match (but
+// pushes no token), so the recorded match set follows texmath's parse exactly.
+function createBegEndEnvironmentProbe(
+  renderer: MarkdownItInstance,
+): BegEndEnvironmentProbe {
+  const probe = new MarkdownIt({
+    breaks: renderer.options.breaks,
+    linkify: renderer.options.linkify,
+    html: renderer.options.html,
+  });
+  if (renderer.options.linkify) {
+    probe.linkify.set({ fuzzyLink: true, urlAuth: true });
+  }
+
+  let active = false;
+  let matches: BegEndEnvironmentMatch[] = [];
+  let closersByEnv = new Map<string, number[]>();
+  const beginEnvPattern = /\\begin\{([a-z]+)\}/y;
+
+  const firstCloserAfter = (closers: readonly number[], openEnd: number) => {
+    let low = 0;
+    let high = closers.length;
+    while (low < high) {
+      const mid = (low + high) >> 1;
+      if (closers[mid]! > openEnd) high = mid;
+      else low = mid + 1;
+    }
+    return low < closers.length ? closers[low]! : undefined;
+  };
+
+  const rule = (
+    state: StateBlock,
+    startLine: number,
+    _endLine: number,
+    silent: boolean,
+  ): boolean => {
+    if (!active) return false;
+    const pos = state.bMarks[startLine]! + state.tShift[startLine]!;
+    const source = state.src;
+    if (source.charCodeAt(pos) !== 0x5c) return false;
+    beginEnvPattern.lastIndex = pos;
+    const opener = beginEnvPattern.exec(source);
+    if (opener === null) return false;
+    const name = opener[1]!;
+    const openEnd = beginEnvPattern.lastIndex;
+    const closers = closersByEnv.get(name);
+    if (closers === undefined) return false;
+    const closeStart = firstCloserAfter(closers, openEnd);
+    if (closeStart === undefined) return false;
+    const closeEnd = closeStart + 4 + name.length + 2; // \end{name}
+    let low = 0;
+    let high = state.bMarks.length - 1;
+    while (low < high) {
+      const mid = (low + high + 1) >> 1;
+      if (state.bMarks[mid]! <= closeStart) low = mid;
+      else high = mid - 1;
+    }
+    const closerLine = low;
+    if (silent) return true;
+
+    const lineContentStarts: number[] = [];
+    for (let line = startLine; line <= closerLine; line++) {
+      lineContentStarts.push(state.bMarks[line]! + state.tShift[line]!);
+    }
+    matches.push({
+      start: pos,
+      end: closeEnd,
+      startLine,
+      endLine: closerLine,
+      lineContentStarts,
+    });
+    state.line = closerLine + 1;
+    return true;
+  };
+
+  probe.block.ruler.before('fence', 'texra_beg_end_probe', rule, {});
+  probe.block.ruler.before('paragraph', 'texra_beg_end_probe_interrupt', rule, {
+    alt: ['paragraph', 'reference', 'blockquote', 'list'],
+  });
+
+  return {
+    collect(content: string): readonly BegEndEnvironmentMatch[] {
+      matches = [];
+      closersByEnv = new Map();
+      const closerPattern = /\\(?:end)\{([a-z]+)\}/g;
+      for (const closer of content.matchAll(closerPattern)) {
+        const name = closer[1]!;
+        const positions = closersByEnv.get(name) ?? [];
+        positions.push(closer.index);
+        closersByEnv.set(name, positions);
+      }
+
+      active = false;
+      const fenceTokens = probe.parse(content, {});
+      const fenceRanges: Array<readonly [number, number]> = [];
+      for (const token of fenceTokens) {
+        if (token.type === 'fence' && token.map !== null) {
+          fenceRanges.push([token.map[0], token.map[1]]);
+        }
+      }
+
+      active = true;
+      probe.parse(content, {});
+      active = false;
+
+      // Keep the earlier deliberate fence-decline: texmath would match across
+      // a fenced-code boundary, but shielding that would swallow the fence and
+      // its prose into a math placeholder. Under-shield instead. This is the
+      // one documented divergence from the webview's beg_end parse.
+      return matches.filter(
+        (match) =>
+          !fenceRanges.some(
+            ([start, end]) => match.startLine < end && match.endLine >= start,
+          ),
+      );
+    },
+  };
+}
+
+// Blockquote markers markdown-it will still need to see after an environment
+// is shielded. The leading indentation before each `>` and the marker itself
+// stay visible; any extra whitespace after the marker is list/continuation
+// indent and is restored from the placeholder instead, matching the existing
+// `\[…\]` blockquote-prefix behaviour.
+function retainedBlockquotePrefix(prefix: string): string {
+  return /^(?:(?:[ \t]*>[ \t]?))+/u.exec(prefix)?.[0] ?? '';
+}
+
+const LIST_MARKER_PREFIX_RE = /^(?:[ \t]*(?:[-+*]|\d+[.)])[ \t]+)/u;
+
+function lineBoundaries(content: string): {
+  readonly lineStarts: number[];
+  readonly lineEnds: number[];
+} {
+  const lineStarts = [0];
+  const lineEnds: number[] = [];
+  for (let index = 0; index < content.length; index++) {
+    if (content.charCodeAt(index) === 10) {
+      lineEnds.push(index);
+      lineStarts.push(index + 1);
+    }
+  }
+  lineEnds.push(content.length);
+  return { lineStarts, lineEnds };
+}
+
+function applyEnvironmentShields(
+  content: string,
+  matches: readonly BegEndEnvironmentMatch[],
+  tag: string,
+  items: string[],
+): string {
+  if (matches.length === 0) return content;
+  const { lineStarts, lineEnds } = lineBoundaries(content);
+  const sorted = [...matches].sort((a, b) => a.start - b.start);
+  const pieces: string[] = [];
+  let copiedUntil = 0;
+  for (const match of sorted) {
+    if (match.start < copiedUntil) continue;
+    pieces.push(content.slice(copiedUntil, lineStarts[match.startLine]!));
+    for (let line = match.startLine; line <= match.endLine; line++) {
+      const contentStart = match.lineContentStarts[line - match.startLine]!;
+      const lineStart = lineStarts[line]!;
+      const lineEnd = lineEnds[line]!;
+      const fullPrefix = content.slice(lineStart, contentStart);
+      const retained = retainedBlockquotePrefix(fullPrefix);
+      const remainder = fullPrefix.slice(retained.length);
+      const hasListMarker = LIST_MARKER_PREFIX_RE.test(remainder);
+      // Keep list markers visible on the line; move extra blockquote-
+      // continuation indent into the item so markdown-it does not strip it
+      // when it builds the list-item paragraph content.
+      const moveIndentIntoItem = retained.length > 0 && !hasListMarker;
+      pieces.push(moveIndentIntoItem ? retained : fullPrefix);
+      const isLast = line === match.endLine;
+      const contentEnd = isLast ? match.end : lineEnd;
+      const item =
+        (moveIndentIntoItem ? remainder : '') +
+        content.slice(contentStart, contentEnd);
+      if (item.length > 0) {
+        const index = items.push(item) - 1;
+        pieces.push(`@@${tag}-${index}@@`);
+      }
+      if (!isLast) pieces.push(content.slice(lineEnd, lineStarts[line + 1]!));
+    }
+    copiedUntil = match.end;
+  }
+  pieces.push(content.slice(copiedUntil));
+  return pieces.join('');
+}
+
+function protectLatexMathSpansForRender(
+  content: string,
+  patterns: readonly RegExp[],
+  environmentProbe: BegEndEnvironmentProbe,
+): {
+  content: string;
+  restore: (value: string) => string;
+} {
+  const items: string[] = [];
+  const selectedTag = selectPlaceholderTag(content, 'LATEX-MATH');
+  const patternProtected = protectPatternsInto(
+    content,
+    patterns,
+    selectedTag,
+    items,
+    true,
+  );
+  const matches = environmentProbe.collect(patternProtected);
+  const envProtected = applyEnvironmentShields(
+    patternProtected,
+    matches,
+    selectedTag,
+    items,
+  );
+  const placeholder = new RegExp(`@@${selectedTag}-(\\d+)@@`, 'g');
+  return {
+    content: envProtected,
+    restore: (value) => restorePlaceholders(value, placeholder, items),
   };
 }
 
@@ -340,6 +597,7 @@ export function createMarkdownProcessor(
   });
   let hitCount = 0;
   let missCount = 0;
+  let environmentProbe: BegEndEnvironmentProbe | undefined;
 
   const processor = ((content: string): string => {
     const key = hashContent(content);
@@ -359,7 +617,11 @@ export function createMarkdownProcessor(
       placeholder: refPlaceholder,
     } = protectLatexReferences(content);
     const mathProtection = config.protectLatexMath
-      ? protectLatexMathSpans(refProtected, RENDER_MATH_SPAN_PATTERNS)
+      ? protectLatexMathSpansForRender(
+          refProtected,
+          RENDER_MATH_SPAN_PATTERNS,
+          (environmentProbe ??= createBegEndEnvironmentProbe(config.renderer)),
+        )
       : { content: refProtected, restore: (value: string) => value };
     const mathProtected = mathProtection.content;
     const macroProtection = config.protectLatexMath

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -124,44 +124,20 @@ function restoreLatexReferences(
 const INLINE_MATH_SPAN_PATTERN =
   /(?<!\\)\$(?!\$)[^\n$]+?(?<![\\$])\$(?:\$(?!\$)[^\n$]+?(?<![\\$])\$)*/g;
 
-// Render-time inline `$…$` mirrors texmath's `dollars` inline rule exactly:
-// the same `$_pre`/`$_post` adjacency guards (no digit before the opener, no
-// whitespace just inside either delimiter, no digit after the closer) and the
-// same single-span body. texmath's body is `(?:[^\s\\]|\S.*?[^\s\\])`,
-// whose first alternative lets a one-character body match and whose second
-// permits interior `$` — so `Cost $5 then *ten* $x$` is one math span whose
-// body ends at the *last* dollar, while `Cost $5 then *ten* $10` is prose
-// (the only closer is preceded by whitespace). Adjacent spans are matched
-// back-to-back by the global scan, keeping `$a$$b$` verbatim.
-const RENDER_INLINE_MATH_SPAN_PATTERN =
-  /(?<![\\\d])\$((?:[^\s\\]|\S[^\n\r\u2028\u2029]*?[^\s\\]))\$(?!\d)/g;
-
-// Shared pattern vocabulary. Order matters: display fences before inline ones
-// so `$…$` never splits a `$$…$$`. Environments are shielded separately by the
-// container/fence-aware probe, never by a source-level regex.
-const MATH_SPAN_PATTERNS: readonly RegExp[] = [
+// Display and inline delimiter regexes used by the render shield before the
+// bounded inline-dollar scanner runs, and by the lax HTML-normalize shield.
+const DISPLAY_MATH_SPAN_PATTERNS: readonly RegExp[] = [
   /\$\$[\s\S]+?\$\$/g, // $$ … $$  (display, may span lines)
   /(?<!\\)\\\[[\s\S]+?(?<!\\)\\\]/g, // \[ … \]  (display)
   /(?<!\\)\\\([\s\S]+?(?<!\\)\\\)/g, // \( … \)  (inline)
-  INLINE_MATH_SPAN_PATTERN, // $ … $  (one or more adjacent inline spans, single line)
 ];
 
-// The render shield swaps in the texmath-adjacent inline pattern. The HTML
-// normalizer keeps the lax inline set above and shields environments through
-// the same block probe.
-const RENDER_MATH_SPAN_PATTERNS: readonly RegExp[] = MATH_SPAN_PATTERNS.map(
-  (pattern) =>
-    pattern === INLINE_MATH_SPAN_PATTERN
-      ? RENDER_INLINE_MATH_SPAN_PATTERN
-      : pattern,
-);
-// Fail loud rather than silently render-shield with the lax inline pattern if
-// MATH_SPAN_PATTERNS ever drops or renames the inline entry.
-if (!RENDER_MATH_SPAN_PATTERNS.includes(RENDER_INLINE_MATH_SPAN_PATTERN)) {
-  throw new Error(
-    'MATH_SPAN_PATTERNS no longer carries the inline $…$ entry to swap',
-  );
-}
+// Lax HTML-normalize math pattern set: display fences first so `$…$` never
+// splits a `$$…$$`, then the intentionally lax inline `$…$` regex.
+const MATH_SPAN_PATTERNS: readonly RegExp[] = [
+  ...DISPLAY_MATH_SPAN_PATTERNS,
+  INLINE_MATH_SPAN_PATTERN,
+];
 
 // Replace every match of `patterns` with an indexed `@@<tag>-N@@` placeholder,
 // appending the captured matches to `items` so later shields share one restore
@@ -373,6 +349,14 @@ function createBegEndEnvironmentProbe(
         return matches;
       }
 
+      // Cheap compatibility precheck: only pay for a markdown parse when at
+      // least one lowercase opener name also has a lowercase closer.
+      const openerNames = new Set<string>();
+      for (const opener of content.matchAll(/\\begin\{([a-z]+)\}/g)) {
+        openerNames.add(opener[1]!);
+      }
+      if (openerNames.size === 0) return matches;
+
       closersByEnv = new Map();
       const closerPattern = /\\(?:end)\{([a-z]+)\}/g;
       for (const closer of content.matchAll(closerPattern)) {
@@ -380,6 +364,9 @@ function createBegEndEnvironmentProbe(
         const positions = closersByEnv.get(name) ?? [];
         positions.push(closer.index);
         closersByEnv.set(name, positions);
+      }
+      if (![...openerNames].some((name) => closersByEnv.has(name))) {
+        return matches;
       }
 
       active = true;
@@ -487,10 +474,110 @@ function applyEnvironmentShields(
   return pieces.join('');
 }
 
+type InlineDollarProtector = (
+  content: string,
+  tag: string,
+  items: string[],
+) => string;
+
+const REGEX_SPACE_RE = /\s/u;
+
+function isAsciiDigitCode(code: number): boolean {
+  return code >= 0x30 && code <= 0x39;
+}
+
+function isLineTerminatorCode(code: number): boolean {
+  return code === 0x0a || code === 0x0d || code === 0x2028 || code === 0x2029;
+}
+
+// Bounded linear replacement for a render-time inline-dollar regex. The
+// texmath body allows interior `$`, which makes a regex backtrack over the
+// rest of the line for every currency token. Precompute the next valid closer
+// per offset (a `$` preceded by a non-space, non-backslash character), then
+// scan openers once.
+function protectRenderInlineDollarSpans(
+  content: string,
+  tag: string,
+  items: string[],
+): string {
+  const nextValidDollar = new Int32Array(content.length);
+  let next = -1;
+  for (let index = content.length - 1; index >= 0; index--) {
+    if (isLineTerminatorCode(content.charCodeAt(index))) {
+      nextValidDollar[index] = -1;
+      next = -1;
+      continue;
+    }
+    if (content[index] === '$' && index > 0) {
+      const previous = content[index - 1];
+      if (previous !== '\\' && !REGEX_SPACE_RE.test(previous)) {
+        next = index;
+        nextValidDollar[index] = index;
+        continue;
+      }
+    }
+    nextValidDollar[index] = next;
+  }
+
+  const pieces: string[] = [];
+  let copiedUntil = 0;
+  let matched = false;
+  let index = 0;
+  while (index < content.length) {
+    if (content[index] !== '$') {
+      index++;
+      continue;
+    }
+    // texmath's `$_pre`: no backslash and no ASCII digit before the opener.
+    if (
+      index > 0 &&
+      (content[index - 1] === '\\' ||
+        isAsciiDigitCode(content.charCodeAt(index - 1)))
+    ) {
+      index++;
+      continue;
+    }
+    if (index + 1 >= content.length) break;
+    const first = content[index + 1];
+    // texmath's body starts with `\S` — a backslash is allowed as the first
+    // body character (e.g. `$\{…\}$`); only whitespace/line terminators are not.
+    if (REGEX_SPACE_RE.test(first)) {
+      index++;
+      continue;
+    }
+    const closer =
+      index + 2 < content.length ? nextValidDollar[index + 2]! : -1;
+    if (closer === -1) {
+      index++;
+      continue;
+    }
+    // texmath's `$_post`: no ASCII digit after the closer (end is allowed).
+    if (
+      closer + 1 < content.length &&
+      isAsciiDigitCode(content.charCodeAt(closer + 1))
+    ) {
+      index++;
+      continue;
+    }
+
+    pieces.push(content.slice(copiedUntil, index));
+    const itemIndex = items.push(content.slice(index, closer + 1)) - 1;
+    pieces.push(`@@${tag}-${itemIndex}@@`);
+    copiedUntil = closer + 1;
+    matched = true;
+    index = closer + 1;
+  }
+
+  if (!matched) return content;
+  pieces.push(content.slice(copiedUntil));
+  return pieces.join('');
+}
+
 function protectLatexMathSpansWithEnvironment(
   content: string,
-  patterns: readonly RegExp[],
   environmentProbe: BegEndEnvironmentProbe,
+  patterns: readonly RegExp[],
+  protectInlineDollars?: InlineDollarProtector,
 ): {
   content: string;
   restore: (value: string) => string;
@@ -516,9 +603,12 @@ function protectLatexMathSpansWithEnvironment(
     items,
     true,
   );
+  const final = protectInlineDollars
+    ? protectInlineDollars(patternProtected, selectedTag, items)
+    : patternProtected;
   const placeholder = new RegExp(`@@${selectedTag}-(\\d+)@@`, 'g');
   return {
-    content: patternProtected,
+    content: final,
     restore: (value) => restorePlaceholders(value, placeholder, items),
   };
 }
@@ -574,8 +664,8 @@ export function protectLatexMathSpansForNormalize(content: string): {
   );
   return protectLatexMathSpansWithEnvironment(
     source,
-    MATH_SPAN_PATTERNS,
     normalizeEnvironmentProbe,
+    MATH_SPAN_PATTERNS,
   );
 }
 
@@ -638,7 +728,6 @@ export function createMarkdownProcessor(
     const mathProtection = config.protectLatexMath
       ? protectLatexMathSpansWithEnvironment(
           refProtected,
-          RENDER_MATH_SPAN_PATTERNS,
           (environmentProbe ??= createBegEndEnvironmentProbe(
             createProbeMarkdownIt({
               breaks: config.renderer.options.breaks,
@@ -646,6 +735,8 @@ export function createMarkdownProcessor(
               html: config.renderer.options.html,
             }),
           )),
+          DISPLAY_MATH_SPAN_PATTERNS,
+          protectRenderInlineDollarSpans,
         )
       : { content: refProtected, restore: (value: string) => value };
     const mathProtected = mathProtection.content;

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -552,6 +552,10 @@ function protectRenderInlineDollarSpans(
       continue;
     }
     // texmath's `$_post`: no ASCII digit after the closer (end is allowed).
+    // When the first valid closer fails this guard, texmath's inline rule
+    // returns false for the current opener; it does not retry a later closer.
+    // Advance one character so the failed closer can be reconsidered as a new
+    // opener on the next iteration.
     if (
       closer + 1 < content.length &&
       isAsciiDigitCode(content.charCodeAt(closer + 1))

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -148,10 +148,11 @@ const RENDER_INLINE_MATH_SPAN_PATTERN =
 const BEG_END_MATH_SPAN_PATTERN =
   /(?<=^(?:(?:[ \t]*>[ \t]?)|(?:[ \t]*(?:[-+*]|\d+[.)])[ \t]+))*[ ]{0,3})\\begin\{([a-z]+)\}(?:(?!^(?:(?:[ \t]*>[ \t]?)|(?:[ \t]*(?:[-+*]|\d+[.)])[ \t]+))*[ ]{0,3}(?:`{3,}|~{3,}))[\s\S])+?(?<!\\)\\end\{\1\}/gm;
 
-// Math spans whose body must reach the renderer verbatim in the lax
-// (htmlMarkdownNormalize) path. Order matters: display fences before inline
-// ones so `$…$` never splits a `$$…$$`, and the environment rule last so a
-// `\begin{…}…\end{…}` nested inside a fence is consumed with its fence.
+// Shared pattern vocabulary. Order matters: display fences before inline ones
+// so `$…$` never splits a `$$…$$`, and the legacy environment regex stays last
+// for the fail-loud identity swap below. The render and HTML-normalize shields
+// both derive their active sets from this list and drop the environment regex
+// in favour of the container/fence-aware probe.
 const MATH_SPAN_PATTERNS: readonly RegExp[] = [
   /\$\$[\s\S]+?\$\$/g, // $$ … $$  (display, may span lines)
   /(?<!\\)\\\[[\s\S]+?(?<!\\)\\\]/g, // \[ … \]  (display)
@@ -161,9 +162,9 @@ const MATH_SPAN_PATTERNS: readonly RegExp[] = [
 ];
 
 // The render shield swaps in the texmath-adjacent inline pattern and drops
-// the lax environment regex; environments are shielded by the block-state
-// probe instead (see protectLatexMathSpansForRender). htmlMarkdownNormalize
-// keeps the lax default set above.
+// the legacy environment regex; environments are shielded by the block-state
+// probe instead. The HTML normalizer keeps the lax inline pattern but likewise
+// drops the environment regex (see NORMALIZE_MATH_SPAN_PATTERNS).
 const RENDER_MATH_SPAN_PATTERNS: readonly RegExp[] = MATH_SPAN_PATTERNS.filter(
   (pattern) => pattern !== BEG_END_MATH_SPAN_PATTERN,
 ).map((pattern) =>
@@ -556,31 +557,6 @@ function restorePlaceholders(
     if (next === restored) return restored;
     restored = next;
   }
-}
-
-/** Shields complete LaTeX math spans while another transform runs. */
-export function protectLatexMathSpans(
-  content: string,
-  patterns: readonly RegExp[] = MATH_SPAN_PATTERNS,
-): {
-  content: string;
-  restore: (value: string) => string;
-} {
-  const protectedMath = protectByPatterns(
-    content,
-    patterns,
-    'LATEX-MATH',
-    true,
-  );
-  return {
-    content: protectedMath.content,
-    restore: (value) =>
-      restorePlaceholders(
-        value,
-        protectedMath.placeholder,
-        protectedMath.items,
-      ),
-  };
 }
 
 let normalizeEnvironmentProbe: BegEndEnvironmentProbe | undefined;

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -242,8 +242,16 @@ interface BegEndEnvironmentMatch {
   readonly lineContentStarts: readonly number[];
 }
 
+interface SourceRange {
+  readonly start: number;
+  readonly end: number;
+}
+
 interface BegEndEnvironmentProbe {
-  collect(content: string): readonly BegEndEnvironmentMatch[];
+  collect(
+    content: string,
+    excludedRanges?: readonly SourceRange[],
+  ): readonly BegEndEnvironmentMatch[];
 }
 
 // A tiny markdown-it block probe that records exactly where texmath's
@@ -277,7 +285,20 @@ function createBegEndEnvironmentProbe(
   let active = false;
   let matches: BegEndEnvironmentMatch[] = [];
   let closersByEnv = new Map<string, number[]>();
+  let excludedRanges: readonly SourceRange[] = [];
   const beginEnvPattern = /\\begin\{([a-z]+)\}/y;
+
+  const isInsideExcludedRange = (position: number): boolean => {
+    let low = 0;
+    let high = excludedRanges.length;
+    while (low < high) {
+      const mid = (low + high) >> 1;
+      if (excludedRanges[mid]!.start <= position) low = mid + 1;
+      else high = mid;
+    }
+    const range = excludedRanges[low - 1];
+    return range !== undefined && position < range.end;
+  };
 
   const firstCloserAfter = (closers: readonly number[], openEnd: number) => {
     let low = 0;
@@ -298,6 +319,7 @@ function createBegEndEnvironmentProbe(
   ): boolean => {
     if (!active) return false;
     const pos = state.bMarks[startLine]! + state.tShift[startLine]!;
+    if (isInsideExcludedRange(pos)) return false;
     const source = state.src;
     if (source.charCodeAt(pos) !== 0x5c) return false;
     beginEnvPattern.lastIndex = pos;
@@ -341,8 +363,12 @@ function createBegEndEnvironmentProbe(
   });
 
   return {
-    collect(content: string): readonly BegEndEnvironmentMatch[] {
+    collect(
+      content: string,
+      ranges: readonly SourceRange[] = [],
+    ): readonly BegEndEnvironmentMatch[] {
       matches = [];
+      excludedRanges = ranges;
       // Most messages have no environment delimiters; skip both markdown
       // parses entirely in that case.
       if (!content.includes('\\begin{') || !content.includes('\\end{')) {
@@ -577,6 +603,21 @@ function protectRenderInlineDollarSpans(
   return pieces.join('');
 }
 
+// Display-math ranges texmath would consume before its `beg_end` block rule
+// runs. The render/normalize shields apply these same display patterns after
+// environment shielding, so an environment opener inside one of these ranges
+// must not be shielded first.
+function findDisplayMathRanges(content: string): SourceRange[] {
+  const ranges: SourceRange[] = [];
+  for (const pattern of DISPLAY_MATH_SPAN_PATTERNS) {
+    for (const match of content.matchAll(pattern)) {
+      const start = match.index ?? 0;
+      ranges.push({ start, end: start + match[0].length });
+    }
+  }
+  return ranges.sort((a, b) => a.start - b.start);
+}
+
 function protectLatexMathSpansWithEnvironment(
   content: string,
   environmentProbe: BegEndEnvironmentProbe,
@@ -593,7 +634,10 @@ function protectLatexMathSpansWithEnvironment(
   // regex sees. Inline/display spans are shielded afterwards; the shared
   // fixpoint restore still resolves a `\begin{…}…\end{…}` placeholder nested
   // inside a later `$$…$$` / `\[…\]` fence.
-  const matches = environmentProbe.collect(content);
+  const matches = environmentProbe.collect(
+    content,
+    findDisplayMathRanges(content),
+  );
   const envProtected = applyEnvironmentShields(
     content,
     matches,

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -172,6 +172,13 @@ const RENDER_MATH_SPAN_PATTERNS: readonly RegExp[] = MATH_SPAN_PATTERNS.map(
       ? RENDER_INLINE_MATH_SPAN_PATTERN
       : pattern,
 );
+// Fail loud rather than silently render-shield with the lax inline pattern if
+// MATH_SPAN_PATTERNS ever drops or renames the inline entry.
+if (!RENDER_MATH_SPAN_PATTERNS.includes(RENDER_INLINE_MATH_SPAN_PATTERN)) {
+  throw new Error(
+    'MATH_SPAN_PATTERNS no longer carries the inline $…$ entry to swap',
+  );
+}
 
 // Replace every match of `patterns` with an indexed `@@<tag>-N@@` placeholder,
 // returning the captured matches so restorePlaceholders can reinstate them.

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -134,43 +134,26 @@ const INLINE_MATH_SPAN_PATTERN =
 // (the only closer is preceded by whitespace). Adjacent spans are matched
 // back-to-back by the global scan, keeping `$a$$b$` verbatim.
 const RENDER_INLINE_MATH_SPAN_PATTERN =
-  /(?<![\\\d])\$((?:[^\s\\]|\S[^\n]*?[^\s\\]))\$(?!\d)/g;
-
-// Lax environment shielding used by `htmlMarkdownNormalize`: that path has no
-// markdown-it block state to consult, so it keeps the previous line-anchored
-// regex. It recognizes a `\\begin{env}…\\end{env}` only where a texmath block
-// could start at top level (line start, optional blockquote/list prefix, up to
-// three spaces) and declines any span that would cross a fenced-code boundary
-// rather than swallowing the intervening prose into a placeholder. The render
-// shield below does not use this regex; it delegates to the container/fence-
-// aware probe so list-continuation offsets and fenced interiors match
-// markdown-it exactly.
-const BEG_END_MATH_SPAN_PATTERN =
-  /(?<=^(?:(?:[ \t]*>[ \t]?)|(?:[ \t]*(?:[-+*]|\d+[.)])[ \t]+))*[ ]{0,3})\\begin\{([a-z]+)\}(?:(?!^(?:(?:[ \t]*>[ \t]?)|(?:[ \t]*(?:[-+*]|\d+[.)])[ \t]+))*[ ]{0,3}(?:`{3,}|~{3,}))[\s\S])+?(?<!\\)\\end\{\1\}/gm;
+  /(?<![\\\d])\$((?:[^\s\\]|\S[^\n\r\u2028\u2029]*?[^\s\\]))\$(?!\d)/g;
 
 // Shared pattern vocabulary. Order matters: display fences before inline ones
-// so `$…$` never splits a `$$…$$`, and the legacy environment regex stays last
-// for the fail-loud identity swap below. The render and HTML-normalize shields
-// both derive their active sets from this list and drop the environment regex
-// in favour of the container/fence-aware probe.
+// so `$…$` never splits a `$$…$$`. Environments are shielded separately by the
+// container/fence-aware probe, never by a source-level regex.
 const MATH_SPAN_PATTERNS: readonly RegExp[] = [
   /\$\$[\s\S]+?\$\$/g, // $$ … $$  (display, may span lines)
   /(?<!\\)\\\[[\s\S]+?(?<!\\)\\\]/g, // \[ … \]  (display)
   /(?<!\\)\\\([\s\S]+?(?<!\\)\\\)/g, // \( … \)  (inline)
   INLINE_MATH_SPAN_PATTERN, // $ … $  (one or more adjacent inline spans, single line)
-  BEG_END_MATH_SPAN_PATTERN, // \begin{env} … \end{env}  (texmath beg_end)
 ];
 
-// The render shield swaps in the texmath-adjacent inline pattern and drops
-// the legacy environment regex; environments are shielded by the block-state
-// probe instead. The HTML normalizer keeps the lax inline pattern but likewise
-// drops the environment regex (see NORMALIZE_MATH_SPAN_PATTERNS).
-const RENDER_MATH_SPAN_PATTERNS: readonly RegExp[] = MATH_SPAN_PATTERNS.filter(
-  (pattern) => pattern !== BEG_END_MATH_SPAN_PATTERN,
-).map((pattern) =>
-  pattern === INLINE_MATH_SPAN_PATTERN
-    ? RENDER_INLINE_MATH_SPAN_PATTERN
-    : pattern,
+// The render shield swaps in the texmath-adjacent inline pattern. The HTML
+// normalizer keeps the lax inline set above and shields environments through
+// the same block probe.
+const RENDER_MATH_SPAN_PATTERNS: readonly RegExp[] = MATH_SPAN_PATTERNS.map(
+  (pattern) =>
+    pattern === INLINE_MATH_SPAN_PATTERN
+      ? RENDER_INLINE_MATH_SPAN_PATTERN
+      : pattern,
 );
 // Fail loud rather than silently render-shield with the lax inline pattern if
 // MATH_SPAN_PATTERNS ever drops or renames the inline entry.
@@ -179,12 +162,6 @@ if (!RENDER_MATH_SPAN_PATTERNS.includes(RENDER_INLINE_MATH_SPAN_PATTERN)) {
     'MATH_SPAN_PATTERNS no longer carries the inline $…$ entry to swap',
   );
 }
-
-// The HTML normalizer keeps the lax inline `$…$` contract but drops the lax
-// environment regex: its environments are container-aware too, so a continued
-// ordered-list environment is shielded before tag normalization can touch it.
-const NORMALIZE_MATH_SPAN_PATTERNS: readonly RegExp[] =
-  MATH_SPAN_PATTERNS.filter((pattern) => pattern !== BEG_END_MATH_SPAN_PATTERN);
 
 // Replace every match of `patterns` with an indexed `@@<tag>-N@@` placeholder,
 // appending the captured matches to `items` so later shields share one restore
@@ -390,6 +367,12 @@ function createBegEndEnvironmentProbe(
   return {
     collect(content: string): readonly BegEndEnvironmentMatch[] {
       matches = [];
+      // Most messages have no environment delimiters; skip both markdown
+      // parses entirely in that case.
+      if (!content.includes('\\begin{') || !content.includes('\\end{')) {
+        return matches;
+      }
+
       closersByEnv = new Map();
       const closerPattern = /\\(?:end)\{([a-z]+)\}/g;
       for (const closer of content.matchAll(closerPattern)) {
@@ -399,6 +382,17 @@ function createBegEndEnvironmentProbe(
         closersByEnv.set(name, positions);
       }
 
+      active = true;
+      try {
+        probe.parse(content, {});
+      } finally {
+        active = false;
+      }
+      if (matches.length === 0) return matches;
+
+      // Only pay for a second (plain) parse when a candidate match could cross
+      // a fence; the probe parse consumed math blocks, so it cannot enumerate
+      // fences for the decline check.
       active = false;
       const fenceTokens = probe.parse(content, {});
       const fenceRanges: Array<readonly [number, number]> = [];
@@ -406,13 +400,6 @@ function createBegEndEnvironmentProbe(
         if (token.type === 'fence' && token.map !== null) {
           fenceRanges.push([token.map[0], token.map[1]]);
         }
-      }
-
-      active = true;
-      try {
-        probe.parse(content, {});
-      } finally {
-        active = false;
       }
 
       // Keep the earlier deliberate fence-decline: texmath would match across
@@ -510,23 +497,28 @@ function protectLatexMathSpansWithEnvironment(
 } {
   const items: string[] = [];
   const selectedTag = selectPlaceholderTag(content, 'LATEX-MATH');
-  const patternProtected = protectPatternsInto(
+  // Probe and shield environments against the pre-inline-shield content so the
+  // closer search sees the same literal `\end{name}` texmath's lazy block
+  // regex sees. Inline/display spans are shielded afterwards; the shared
+  // fixpoint restore still resolves a `\begin{…}…\end{…}` placeholder nested
+  // inside a later `$$…$$` / `\[…\]` fence.
+  const matches = environmentProbe.collect(content);
+  const envProtected = applyEnvironmentShields(
     content,
+    matches,
+    selectedTag,
+    items,
+  );
+  const patternProtected = protectPatternsInto(
+    envProtected,
     patterns,
     selectedTag,
     items,
     true,
   );
-  const matches = environmentProbe.collect(patternProtected);
-  const envProtected = applyEnvironmentShields(
-    patternProtected,
-    matches,
-    selectedTag,
-    items,
-  );
   const placeholder = new RegExp(`@@${selectedTag}-(\\d+)@@`, 'g');
   return {
-    content: envProtected,
+    content: patternProtected,
     restore: (value) => restorePlaceholders(value, placeholder, items),
   };
 }
@@ -543,11 +535,11 @@ function restorePlaceholders(
   items: string[],
 ): string {
   // An item can itself carry a placeholder when spans nest across patterns
-  // (an inline `$…$` inside a `\begin{…}…\end{…}` body), so run to a
-  // fixpoint instead of a single pass. Nesting is acyclic — a pattern's
-  // matches can capture earlier patterns' placeholders but never their own —
-  // and selectPlaceholderTag keeps placeholder-shaped user text out of the
-  // items, so the loop terminates.
+  // (a `\begin{…}…\end{…}` placeholder inside a later `$$…$$` / `\[…\]`
+  // fence), so run to a fixpoint instead of a single pass. Nesting is acyclic
+  // — a pattern's matches can capture earlier patterns' placeholders but never
+  // their own — and selectPlaceholderTag keeps placeholder-shaped user text
+  // out of the items, so the loop terminates.
   let restored = content;
   for (;;) {
     const next = restored.replaceAll(placeholder, (match, rawIndex) => {
@@ -567,17 +559,22 @@ let normalizeEnvironmentProbe: BegEndEnvironmentProbe | undefined;
  * renderer, so it needs the same list-continuation/blockquote awareness or a
  * `<br>` inside `10. Formula:\n    \begin{align}` would be mutated before the
  * render shield can protect it.
+ *
+ * CRLF / bare CR are normalized here defensively, and the caller normalizes
+ * too: the probe and `applyEnvironmentShields` must always slice the same LF
+ * string markdown-it's block parser sees.
  */
 export function protectLatexMathSpansForNormalize(content: string): {
   content: string;
   restore: (value: string) => string;
 } {
+  const source = content.replaceAll(/\r\n?/g, '\n');
   normalizeEnvironmentProbe ??= createBegEndEnvironmentProbe(
     createProbeMarkdownIt({ breaks: false, linkify: true, html: false }),
   );
   return protectLatexMathSpansWithEnvironment(
-    content,
-    NORMALIZE_MATH_SPAN_PATTERNS,
+    source,
+    MATH_SPAN_PATTERNS,
     normalizeEnvironmentProbe,
   );
 }

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -135,19 +135,33 @@ const INLINE_MATH_SPAN_PATTERN =
 const RENDER_INLINE_MATH_SPAN_PATTERN =
   /(?<![\\\d])\$(?!\$)(?!\s)[^\n$]+?(?<![\\$\s])\$(?!\d)(?:\$(?!\$)(?!\s)[^\n$]+?(?<![\\$\s])\$(?!\d))*/g;
 
+// Environment spans mirror texmath's `beg_end` block rule, so the opener is
+// only recognized where that rule can start one: at a block line start, after
+// optional blockquote/list container prefixes and up to three spaces of
+// indentation. An inline `prefix \begin{…}` stays prose, an escaped `\\begin`
+// never opens (the anchor admits no preceding backslash), four-space
+// indentation stays a code block, and starred variants like `align*` remain
+// unshielded in both hosts (texmath's `[a-z]+` name class excludes them). The
+// closer must be an unescaped `\end` naming the same environment, and a span
+// that would cross a fenced-code boundary is declined: texmath never sees
+// fenced content, so an opener inside one fence pairing a closer inside
+// another would swallow the intervening prose into the placeholder —
+// declining under-shields to the pre-fix rendering instead. Unmatched here,
+// markdown-it eats `\\` row breaks as escapes and turns `*…*` inside the
+// body into emphasis.
+const BEG_END_MATH_SPAN_PATTERN =
+  /(?<=^(?:(?:[ \t]*>[ \t]?)|(?:[ \t]*(?:[-+*]|\d+[.)])[ \t]+))*[ ]{0,3})\\begin\{([a-z]+)\}(?:(?!^(?:(?:[ \t]*>[ \t]?)|(?:[ \t]*(?:[-+*]|\d+[.)])[ \t]+))*[ ]{0,3}(?:`{3,}|~{3,}))[\s\S])+?(?<!\\)\\end\{\1\}/gm;
+
 // Math spans whose body must reach the renderer verbatim. Order matters: the
 // display fences are matched before the inline ones so `$…$` never splits a
 // `$$…$$`, and the environment rule comes last so a `\begin{…}…\end{…}`
-// nested inside a fence is consumed with its fence. The environment rule
-// mirrors texmath's `beg_end` block rule (lowercase-letter names, same-name
-// close), which the webview enables; unmatched here, markdown-it eats `\\`
-// row breaks as escapes and turns `*…*` inside the body into emphasis.
+// nested inside a fence is consumed with its fence.
 const MATH_SPAN_PATTERNS: readonly RegExp[] = [
   /\$\$[\s\S]+?\$\$/g, // $$ … $$  (display, may span lines)
   /(?<!\\)\\\[[\s\S]+?(?<!\\)\\\]/g, // \[ … \]  (display)
   /(?<!\\)\\\([\s\S]+?(?<!\\)\\\)/g, // \( … \)  (inline)
   INLINE_MATH_SPAN_PATTERN, // $ … $  (one or more adjacent inline spans, single line)
-  /\\begin\{([a-z]+)\}[\s\S]+?\\end\{\1\}/g, // \begin{env} … \end{env}  (texmath beg_end)
+  BEG_END_MATH_SPAN_PATTERN, // \begin{env} … \end{env}  (texmath beg_end)
 ];
 
 // The processor's render shield swaps in the texmath-adjacent inline pattern;

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -179,6 +179,12 @@ if (!RENDER_MATH_SPAN_PATTERNS.includes(RENDER_INLINE_MATH_SPAN_PATTERN)) {
   );
 }
 
+// The HTML normalizer keeps the lax inline `$…$` contract but drops the lax
+// environment regex: its environments are container-aware too, so a continued
+// ordered-list environment is shielded before tag normalization can touch it.
+const NORMALIZE_MATH_SPAN_PATTERNS: readonly RegExp[] =
+  MATH_SPAN_PATTERNS.filter((pattern) => pattern !== BEG_END_MATH_SPAN_PATTERN);
+
 // Replace every match of `patterns` with an indexed `@@<tag>-N@@` placeholder,
 // appending the captured matches to `items` so later shields share one restore
 // pass. `tag` must already be collision-free (see selectPlaceholderTag).
@@ -295,18 +301,25 @@ interface BegEndEnvironmentProbe {
 // what lets `10. Formula:\n    \begin{align}` open an environment on the
 // indented continuation line. The probe returns true to consume a match (but
 // pushes no token), so the recorded match set follows texmath's parse exactly.
-function createBegEndEnvironmentProbe(
-  renderer: MarkdownItInstance,
-): BegEndEnvironmentProbe {
+function createProbeMarkdownIt(options: {
+  readonly breaks: boolean;
+  readonly linkify: boolean;
+  readonly html: boolean;
+}): MarkdownItInstance {
   const probe = new MarkdownIt({
-    breaks: renderer.options.breaks,
-    linkify: renderer.options.linkify,
-    html: renderer.options.html,
+    breaks: options.breaks,
+    linkify: options.linkify,
+    html: options.html,
   });
-  if (renderer.options.linkify) {
+  if (options.linkify) {
     probe.linkify.set({ fuzzyLink: true, urlAuth: true });
   }
+  return probe;
+}
 
+function createBegEndEnvironmentProbe(
+  probe: MarkdownItInstance,
+): BegEndEnvironmentProbe {
   let active = false;
   let matches: BegEndEnvironmentMatch[] = [];
   let closersByEnv = new Map<string, number[]>();
@@ -395,8 +408,11 @@ function createBegEndEnvironmentProbe(
       }
 
       active = true;
-      probe.parse(content, {});
-      active = false;
+      try {
+        probe.parse(content, {});
+      } finally {
+        active = false;
+      }
 
       // Keep the earlier deliberate fence-decline: texmath would match across
       // a fenced-code boundary, but shielding that would swallow the fence and
@@ -483,7 +499,7 @@ function applyEnvironmentShields(
   return pieces.join('');
 }
 
-function protectLatexMathSpansForRender(
+function protectLatexMathSpansWithEnvironment(
   content: string,
   patterns: readonly RegExp[],
   environmentProbe: BegEndEnvironmentProbe,
@@ -567,6 +583,29 @@ export function protectLatexMathSpans(
   };
 }
 
+let normalizeEnvironmentProbe: BegEndEnvironmentProbe | undefined;
+
+/**
+ * `htmlMarkdownNormalize`'s math shield: the lax inline `$…$` set plus the
+ * container/fence-aware environment probe. The normalize pass runs before the
+ * renderer, so it needs the same list-continuation/blockquote awareness or a
+ * `<br>` inside `10. Formula:\n    \begin{align}` would be mutated before the
+ * render shield can protect it.
+ */
+export function protectLatexMathSpansForNormalize(content: string): {
+  content: string;
+  restore: (value: string) => string;
+} {
+  normalizeEnvironmentProbe ??= createBegEndEnvironmentProbe(
+    createProbeMarkdownIt({ breaks: false, linkify: true, html: false }),
+  );
+  return protectLatexMathSpansWithEnvironment(
+    content,
+    NORMALIZE_MATH_SPAN_PATTERNS,
+    normalizeEnvironmentProbe,
+  );
+}
+
 // LaTeX backslash-macros whose trailing character is CommonMark-escapable
 // punctuation, so markdown-it's parser strips the backslash (`\;`→`;`,
 // `\(`→`(`, …). These are the math spacing macros (`\,` `\;` `\:` `\!`), the
@@ -608,6 +647,13 @@ export function createMarkdownProcessor(
     }
     missCount += 1;
 
+    // The CLI shield records offsets against the string markdown-it parses.
+    // markdown-it core normalizes CRLF / bare CR to LF before block rules run,
+    // so normalize once here and let the whole render pipeline operate on LF.
+    const source = config.protectLatexMath
+      ? content.replaceAll(/\r\n?/g, '\n')
+      : content;
+
     // Protect in widening order (refs → math spans → stray macros); restore in
     // reverse so a ref placeholder revealed inside a restored span is still
     // formatted. After span protection, only out-of-span macros remain to net.
@@ -615,12 +661,18 @@ export function createMarkdownProcessor(
       content: refProtected,
       refs,
       placeholder: refPlaceholder,
-    } = protectLatexReferences(content);
+    } = protectLatexReferences(source);
     const mathProtection = config.protectLatexMath
-      ? protectLatexMathSpansForRender(
+      ? protectLatexMathSpansWithEnvironment(
           refProtected,
           RENDER_MATH_SPAN_PATTERNS,
-          (environmentProbe ??= createBegEndEnvironmentProbe(config.renderer)),
+          (environmentProbe ??= createBegEndEnvironmentProbe(
+            createProbeMarkdownIt({
+              breaks: config.renderer.options.breaks,
+              linkify: config.renderer.options.linkify,
+              html: config.renderer.options.html,
+            }),
+          )),
         )
       : { content: refProtected, restore: (value: string) => value };
     const mathProtected = mathProtection.content;

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -35,12 +35,13 @@ interface MarkdownProcessorConfig {
   /**
    * When true, shield LaTeX math from markdown-it so it reaches the renderer
    * verbatim. Without a math plugin, markdown-it treats the body of `$…$` /
-   * `$$…$$` / `\(…\)` / `\[…\]` spans as ordinary markdown and corrupts it two
-   * ways: its CommonMark escape rule strips the backslash before escapable
-   * punctuation (`\(`→`(`, `\;`→`;`, `\{`→`{`, `\,`→`,`), and its emphasis rule
-   * eats `_{…}` subscripts (`a_{i}b_{j}` → `a<em>i</em>b_{j}`). We protect the
-   * whole span, plus a safety net for stray spacing/brace macros (`\,` `\;`
-   * `\:` `\!` `\(` `\)` `\[` `\]` `\{` `\}`) outside any span.
+   * `$$…$$` / `\(…\)` / `\[…\]` spans and `\begin{env}…\end{env}` environments
+   * as ordinary markdown and corrupts it two ways: its CommonMark escape rule
+   * strips the backslash before escapable punctuation (`\(`→`(`, `\;`→`;`,
+   * `\{`→`{`, `\,`→`,`), and its emphasis rule eats `_{…}` subscripts
+   * (`a_{i}b_{j}` → `a<em>i</em>b_{j}`). We protect the whole span, plus a
+   * safety net for stray spacing/brace macros (`\,` `\;` `\:` `\!` `\(` `\)`
+   * `\[` `\]` `\{` `\}`) outside any span.
    *
    * Enabled by the CLI host, which deliberately shows LaTeX *source* verbatim
    * (terminal math rendering is disabled). The webview / HTML-export leave this
@@ -115,17 +116,48 @@ function restoreLatexReferences(
   });
 }
 
+// Inline `$…$` requires both delimiters to be unescaped (`\$` is a literal
+// dollar in LaTeX, not a delimiter) and on the same line, which keeps stray
+// currency `$` from being captured and avoids cascading mis-splits. One or
+// more adjacent spans chain so `$a$$b$` shields as a single unit.
+const INLINE_MATH_SPAN_PATTERN =
+  /(?<!\\)\$(?!\$)[^\n$]+?(?<![\\$])\$(?:\$(?!\$)[^\n$]+?(?<![\\$])\$)*/g;
+
+// Render-time inline `$…$` adds the adjacency guards the webview's texmath
+// applies to its `dollars` inline rule (`$_pre`/`$_post`): no digit before
+// the opener, no whitespace just inside either delimiter, and no digit after
+// the closer. `Cost $5 then *ten* $10` is prose to texmath (its emphasis
+// stays live), so the CLI renderer must not shield it as math either. The
+// HTML normalizer keeps the lax form above: there a math-shaped span's tags
+// deliberately stay literal — the conservative choice while deciding which
+// HTML to convert — pinned by the "preserves complete inline math beside
+// token characters" suite.
+const RENDER_INLINE_MATH_SPAN_PATTERN =
+  /(?<![\\\d])\$(?!\$)(?!\s)[^\n$]+?(?<![\\$\s])\$(?!\d)(?:\$(?!\$)(?!\s)[^\n$]+?(?<![\\$\s])\$(?!\d))*/g;
+
 // Math spans whose body must reach the renderer verbatim. Order matters: the
 // display fences are matched before the inline ones so `$…$` never splits a
-// `$$…$$`. Inline `$…$` requires both delimiters to be unescaped (`\$` is a
-// literal dollar in LaTeX, not a delimiter) and on the same line, which keeps
-// stray currency `$` from being captured and avoids cascading mis-splits.
+// `$$…$$`, and the environment rule comes last so a `\begin{…}…\end{…}`
+// nested inside a fence is consumed with its fence. The environment rule
+// mirrors texmath's `beg_end` block rule (lowercase-letter names, same-name
+// close), which the webview enables; unmatched here, markdown-it eats `\\`
+// row breaks as escapes and turns `*…*` inside the body into emphasis.
 const MATH_SPAN_PATTERNS: readonly RegExp[] = [
   /\$\$[\s\S]+?\$\$/g, // $$ … $$  (display, may span lines)
   /(?<!\\)\\\[[\s\S]+?(?<!\\)\\\]/g, // \[ … \]  (display)
   /(?<!\\)\\\([\s\S]+?(?<!\\)\\\)/g, // \( … \)  (inline)
-  /(?<!\\)\$(?!\$)[^\n$]+?(?<![\\$])\$(?:\$(?!\$)[^\n$]+?(?<![\\$])\$)*/g, // $ … $  (one or more adjacent inline spans, single line)
+  INLINE_MATH_SPAN_PATTERN, // $ … $  (one or more adjacent inline spans, single line)
+  /\\begin\{([a-z]+)\}[\s\S]+?\\end\{\1\}/g, // \begin{env} … \end{env}  (texmath beg_end)
 ];
+
+// The processor's render shield swaps in the texmath-adjacent inline pattern;
+// htmlMarkdownNormalize keeps the lax default set above.
+const RENDER_MATH_SPAN_PATTERNS: readonly RegExp[] = MATH_SPAN_PATTERNS.map(
+  (pattern) =>
+    pattern === INLINE_MATH_SPAN_PATTERN
+      ? RENDER_INLINE_MATH_SPAN_PATTERN
+      : pattern,
+);
 
 // Replace every match of `patterns` with an indexed `@@<tag>-N@@` placeholder,
 // returning the captured matches so restorePlaceholders can reinstate them.
@@ -215,20 +247,34 @@ function restorePlaceholders(
   placeholder: RegExp,
   items: string[],
 ): string {
-  return content.replaceAll(placeholder, (match, rawIndex) => {
-    const item = items[Number(rawIndex)];
-    return item ?? match;
-  });
+  // An item can itself carry a placeholder when spans nest across patterns
+  // (an inline `$…$` inside a `\begin{…}…\end{…}` body), so run to a
+  // fixpoint instead of a single pass. Nesting is acyclic — a pattern's
+  // matches can capture earlier patterns' placeholders but never their own —
+  // and selectPlaceholderTag keeps placeholder-shaped user text out of the
+  // items, so the loop terminates.
+  let restored = content;
+  for (;;) {
+    const next = restored.replaceAll(placeholder, (match, rawIndex) => {
+      const item = items[Number(rawIndex)];
+      return item ?? match;
+    });
+    if (next === restored) return restored;
+    restored = next;
+  }
 }
 
 /** Shields complete LaTeX math spans while another transform runs. */
-export function protectLatexMathSpans(content: string): {
+export function protectLatexMathSpans(
+  content: string,
+  patterns: readonly RegExp[] = MATH_SPAN_PATTERNS,
+): {
   content: string;
   restore: (value: string) => string;
 } {
   const protectedMath = protectByPatterns(
     content,
-    MATH_SPAN_PATTERNS,
+    patterns,
     'LATEX-MATH',
     true,
   );
@@ -292,7 +338,7 @@ export function createMarkdownProcessor(
       placeholder: refPlaceholder,
     } = protectLatexReferences(content);
     const mathProtection = config.protectLatexMath
-      ? protectLatexMathSpans(refProtected)
+      ? protectLatexMathSpans(refProtected, RENDER_MATH_SPAN_PATTERNS)
       : { content: refProtected, restore: (value: string) => value };
     const mathProtected = mathProtection.content;
     const macroProtection = config.protectLatexMath

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -702,6 +702,32 @@ let normalizeEnvironmentProbe: BegEndEnvironmentProbe | undefined;
  * too: the probe and `applyEnvironmentShields` must always slice the same LF
  * string markdown-it's block parser sees.
  */
+/**
+ * Inline/display math shield for the HTML normalizer's first pass. It keeps
+ * the lax inline `$…$` contract but leaves environments for the second,
+ * structural pass so HTML block containers can be unwrapped in between.
+ */
+export function protectLatexMathSpansForNormalizeInline(content: string): {
+  content: string;
+  restore: (value: string) => string;
+} {
+  const protectedMath = protectByPatterns(
+    content,
+    MATH_SPAN_PATTERNS,
+    'LATEX-MATH',
+    true,
+  );
+  return {
+    content: protectedMath.content,
+    restore: (value) =>
+      restorePlaceholders(
+        value,
+        protectedMath.placeholder,
+        protectedMath.items,
+      ),
+  };
+}
+
 export function protectLatexMathSpansForNormalize(content: string): {
   content: string;
   restore: (value: string) => string;

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.ts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.ts
@@ -1023,10 +1023,11 @@ describe('renderAnsiMarkdown', () => {
   // part of the texmath body, not a closing delimiter. texmath's `dollars`
   // rule spans `$a = \$5$` as one math block (its body permits interior `$`),
   // so the CLI shield must keep the whole span verbatim instead of letting
-  // markdown turn `\$` into `$` and mis-splitting later dollars.
-  it('keeps an escaped \$ inside an inline math span verbatim', () => {
-    const plain = renderPlain('A price $a = \$5$ here');
-    expect(plain).toContain('$a = \$5$');
+  // markdown turn `\$` into `$` and mis-splitting later dollars. The fixture
+  // uses a doubled backslash so the runtime string contains a real `\$`.
+  it('keeps an escaped \\$ inside an inline math span verbatim', () => {
+    const plain = renderPlain('A price $a = \\$5$ here');
+    expect(plain).toContain('$a = \\$5$');
     expect(plain).toContain('here');
   });
 });

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.ts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.ts
@@ -1019,13 +1019,14 @@ describe('renderAnsiMarkdown', () => {
     expect(plain).not.toContain('\\*');
   });
 
-  // Regression for the Cursor Bugbot finding: an escaped `\$` (a literal dollar
-  // in LaTeX) must not be treated as a closing `$` delimiter, or it mis-splits
-  // the span and cascades into later `$`. With both delimiters guarded, the
-  // fragment isn't protected — markdown handles `\$` → `$` instead.
-  it('does not treat an escaped \\$ as a closing math delimiter', () => {
-    const plain = renderPlain('A price $a = \\$5$ here');
-    expect(plain).not.toContain('$a = \\$');
+  // Regression for the Cursor Bugbot finding: an escaped `\$` inside a span is
+  // part of the texmath body, not a closing delimiter. texmath's `dollars`
+  // rule spans `$a = \$5$` as one math block (its body permits interior `$`),
+  // so the CLI shield must keep the whole span verbatim instead of letting
+  // markdown turn `\$` into `$` and mis-splitting later dollars.
+  it('keeps an escaped \$ inside an inline math span verbatim', () => {
+    const plain = renderPlain('A price $a = \$5$ here');
+    expect(plain).toContain('$a = \$5$');
     expect(plain).toContain('here');
   });
 });


### PR DESCRIPTION
## Summary

Fixes the independent production half of #10678 (cross-host consolidation audit §4k): the CLI's LaTeX math shielding diverged from the webview's texmath in two ways. The malformed-payload policy half (§4i) is deliberately untouched — it needs a product ruling, not a pattern fix.

- **`\begin{env}…\end{env}` shielding via a markdown-it block probe.** The render shield records exactly where texmath's `beg_end` rule opens an environment, inheriting `bMarks`/`tShift`, containers, lazy continuations, and fences. It also installs the webview's paragraph-interruption rule.
- **Display math runs before environments, like texmath.** Display ranges are computed from pre-shield LF text and passed to the probe, which declines environment openers inside them.
- **Bounded probe work.** `collect` returns before either markdown parse unless a cheap substring + compatible opener/closer precheck passes.
- **Closer order matches texmath.** Environments are probed against pre-inline-shield content, so the closer search sees the first literal `\end{name}`. Closers are binary-searched.
- **Two-phase HTML normalization.** `normalizeKnownHtmlForCliMarkdown` first shields inline/display math, then removes `<p>`/`<div>` wrappers and converts environment-containing `<blockquote>` wrappers with a stack parser before the environment shield. Nested/mixed wrappers no longer hide environments, and ordinary HTML/inline-math preservation contracts stay green. `<br>`-generated lines reapply existing blockquote prefixes via binary line-start lookup.
- **Fenced environments stay visible to the fence renderer.** Cross-fence spans keep the deliberate documented decline.
- **Bounded inline-dollar scan.** Render inline `$…$` is a linear precompute/scan with texmath's guards, interior `$`, and CR/U+2028/U+2029 exclusion.
- **Lax HTML-normalize inline contract preserved.**

Known limitations (documented rather than overclaimed):
- Heading-wrapped environments are intentionally descoped: `### \begin{align}` is heading content, so the render probe cannot see the opener as a block start. Heading-wrapped environments are not shielded before `<br>` normalization.
- Plain non-blockquote lazy list-continuation lines render at column 0 because that is the existing ANSI renderer `softbreak` behavior for any list paragraph.
- Nested same-name and unclosed environments follow texmath's literal/lazy behavior rather than nesting-aware balancing.

Production-only: no new test cases. One existing assertion was migrated (not added) and its fixture corrected so the runtime string actually contains an escaped `\$`.

Refs #10678

## Validation

- Deleted scratch probes: display-span repros; nested `<div>/<p>` wrappers; mixed nested blockquote; env after removed `<p>`; blockquote `<br>` after a shielded environment; continued-list HTML; CRLF/bare CR; escaped `\$`; closer-order parity; U+2028/U+2029; `$*a*$1+b$`; 48k `$1 ` stream ~7 ms.
- Existing suites: `src/test-kernel/cli/` — **151 files / 2701 passed / 1 skipped**. Related markdown/latex suites — **93 passed** in a combined run; the focused re-run totalled **269 passed**.
- `typecheck:workspace`, `typecheck:cli`, `typecheck:test-kernel` clean; eslint clean on touched files; prettier clean; `git diff --check` clean; `check:dead-code-ratchet` clean.
