### PR TITLE
refactor(logger): narrow StreamSubscriptionRegistry's log-only createChannelTrace onto createLog

### DIFF
--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -12,7 +12,6 @@
  */
 
 import type { AgentTrace } from '@agent/trace';
-import { createChannelTrace } from '@agent/trace';
 import { deliverLiveNotification } from '@agent/followUp/liveNotification';
 import {
   currentSession,
@@ -20,6 +19,7 @@ import {
 } from '@agent/runtime/SessionHandle';
 
 import { appSignals } from '@eventBus/AppSignals';
+import { createLog } from '@logger/logUtils';
 import type { Disposable } from '@platform/interfaces';
 import type { StreamTabId } from '@shared/schemas';
 
@@ -74,7 +74,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
   constructor(
     private readonly opts: StreamSubscriptionRegistryOptions<K, Input>,
   ) {
-    this.logger = opts.logger ?? createChannelTrace(opts.name);
+    this.logger = opts.logger ?? createLog(opts.name);
   }
 
   /** Returns true if a new subscription was created, false if it already existed. */


### PR DESCRIPTION
## Summary

`StreamSubscriptionRegistry` was the final eligible log-only `createChannelTrace` caller in `src/` under #10595. Its logger is a narrow `Pick<AgentTrace, 'info' | 'warn'>` with only two direct uses (`info` on bind, `warn` in `disposeSafe`) and one structural pass-through (`deliverLiveNotification`, whose parameter is `{ warn(message, options?) }`). This PR converts the default factory to `createLog` — same shared sink via `createChannelWriter`, plus spy-able namespace routing — with no other change:

- The channel names are preserved exactly: the default is still keyed on `opts.name` (`PRStreamSubscriptionRegistry` / `RepoStreamSubscriptionRegistry` / `IssueStreamSubscriptionRegistry` in `subscriptionBindings.ts`).
- The `logger?: Pick<AgentTrace, 'info' | 'warn'>` override contract is unchanged, so existing callers and the injected mock logger in the registry's suite are unaffected.

**Intentional remaining `createChannelTrace` sites** (enumerated so `Closes #10595` is honest):

- `src/agent/runtime/childRunLoop.ts:739` — `childStream?.logger ?? createChannelTrace('childRunLoop')` is coalesced with an `AgentTrace`-typed logger and flows into `AgentTrace`-typed parameters (`:395`, `:425`).
- `src/agent/runtime/AgentRunLifecycle.ts:62` — passed at `:214` to `persistTerminalExecution`, whose contract is `logger: AgentTrace` (`terminalPersistence.ts:48`).
- `src/agent/runtime/executionRegistry.ts:42` — passed at `:895` to the same `AgentTrace`-typed `persistTerminalExecution` contract.
- `src/agent/runtime/AgentLaunchResources.ts:6` — fallback coalesced with `runTrace?.trace` (an `AgentTrace`) at `:93`.
- Out of scope here: `src/tools/github/PollingSourceBase.ts:186` (`protected readonly logger: AgentTrace` — full-trace contract for subclasses) and `src/agent/runtime/SessionHandle.ts:88` (log-only; landing independently via #10703 / #10687, kept untouched to avoid collision).

## Issue acceptance gates

Closes #10595

- Gate: narrow the log-only `createChannelTrace` callers onto `createLog`. Satisfied for the last eligible `src/` caller; every remaining production site is either an `AgentTrace`-contract fallback enumerated above or separately tracked (#10687).

## Single source of truth

The channel sink (`createChannelWriter` per channel name) remains the single owner of log output; the registry's default logger now reaches it through `createLog`'s module-namespace routing instead of a full `AgentTrace`.

## Duplication and abstraction budget

Removes one of the "two doors to one sink" call sites from the #10595 audit. No new abstraction; the existing `logger?:` option keeps its exact type.

## Net elements (R6)

- Files: 1 changed (`src/tools/github/StreamSubscriptionRegistry.ts`), +2/−2, net 0 LoC.
- Exported symbols: 0 added / 0 deleted (no `^[+-]export` lines in the diff).
- Classes/interfaces/enums: 0 added / 0 deleted.
- Tests: none added, none modified (existing suites run unchanged).

## Consumer counts (R8)

No emit path or export is deleted. The re-routed path is the default logger's `info`/`warn` output, which still lands in the same per-name channel sink. Grep over `src/` for the three channel names (`PRStreamSubscriptionRegistry`, `RepoStreamSubscriptionRegistry`, `IssueStreamSubscriptionRegistry`) finds 0 subscribers outside their definitions in `subscriptionBindings.ts`; the only logger consumer seam is the registry suite's injected mock via the unchanged `logger?:` option.

## Host impact

Extension: none — same sink, same channels, same option contract.

Desktop: none — same sink, same channels, same option contract.

CLI: none — same sink, same channels, same option contract.

## Scheduled refactoring

None. `SessionHandle`'s equivalent narrowing lands via #10703 (#10687).

## Validation

- Targeted unchanged GitHub subscription suites: `GitHubSubscriptionProgressEvents`, `GitHubSubscriptionTool`, `PollingSourceBase`, `PRPollingSource`, `PRPollingSourceAnnotationPages`, `PRPollingSourceCiStarted` — 6 files / 28 tests passed.
- Architecture suites (`src/test-kernel/architecture/`): 17 files / 101 tests passed.
- `npm run typecheck` (all six parts): pass.
- `eslint` on the changed file: clean. `prettier --check` on the changed file: clean. `git diff --check`: clean.
- Ratchets: `check:dead-code-ratchet` (8 current = 8 baselined), `check:guidance-refs`, `check:browser-safe-utils`, `check:tsconfig-paths`: all pass.
- Full repo vitest not run (production-only 2-line factory swap; targeted + architecture coverage above).
