### PR TITLE
refactor(logger): narrow package createChannelTrace defaults onto createLog

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5,7 +5,7 @@
 // pinning the runtime's internal file layout — the same fold-in the three hosts
 // took in #10011. These never reach the emitted declarations, so they carry no
 // provider-type leak risk.
-import { createChannelTrace, type AgentEvent } from '@agent/trace';
+import type { AgentEvent } from '@agent/trace';
 import { loadAgents, resolveAgent } from '@agent/index';
 import {
   runAgent as runValidatedAgent,
@@ -26,6 +26,7 @@ import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 
 // Local imports - config and host services
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import { createLog } from '@logger/logUtils';
 import { initPlatform, tryPlatform, type Platform } from '@platform/platform';
 import { initNodeAgentRuntime } from '@platform/defaults/nodeHost';
 import type { ProgressPermissionKind as PendingInteractionKind } from '@shared/schemas';
@@ -88,7 +89,7 @@ export interface AgentRun extends AsyncIterable<AgentEvent> {
 }
 
 let runtimeInitialized = false;
-const logger = createChannelTrace('agentPackage');
+const logger = createLog('agentPackage');
 
 function releaseOrWarn(message: string, release: () => void): void {
   try {

--- a/packages/cli/src/runtime/toolUseResumeData.ts
+++ b/packages/cli/src/runtime/toolUseResumeData.ts
@@ -1,15 +1,15 @@
-import { createChannelTrace } from '@agent/trace';
 import { getExecutionStore } from '@agent/storage';
 import {
   retrieveSessionResumeData,
   type ToolUseResumeData,
 } from '@agent/runtime';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { createLog } from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-const logger = createChannelTrace('CliToolUseResumeData');
+const logger = createLog('CliToolUseResumeData');
 type CliSessionResumeData = NonNullable<
   Awaited<ReturnType<typeof retrieveSessionResumeData>>
 >;

--- a/packages/desktop/src/main/desktopFileSelection.ts
+++ b/packages/desktop/src/main/desktopFileSelection.ts
@@ -24,6 +24,8 @@ import type {
   DesktopMessageHandler,
 } from './desktopIpcTypes.js';
 
+const logger = createLog('DesktopFileSelection');
+
 type MessageFor<C extends MainViewInboundMessage['command']> = Extract<
   MainViewInboundMessage,
   { command: C }
@@ -192,9 +194,7 @@ export function createDesktopFileSelection(
       // The shared webview posts this for 'output' too, which the desktop has
       // no picker for. Say so rather than dropping it: handleMessage already
       // reported the message as handled.
-      createLog('DesktopFileSelection').warn(
-        `Unsupported multiple file selection: ${message.fileType}`,
-      );
+      logger.warn(`Unsupported multiple file selection: ${message.fileType}`);
       return;
     }
     const workspacePath = getWorkspacePath();

--- a/packages/desktop/src/main/desktopFileSelection.ts
+++ b/packages/desktop/src/main/desktopFileSelection.ts
@@ -1,6 +1,5 @@
 import { isAbsolute, resolve } from 'node:path';
 
-import { createChannelTrace } from '@agent/trace';
 import {
   getEditedFileListConfig,
   getFileListConfig,
@@ -10,6 +9,7 @@ import {
   type ListableFileType,
 } from '@common/files/fileListingRules';
 import { listWorkspaceFiles } from '@common/files/workspaceFileListing';
+import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import { relativeToRoot } from '@platform/defaults/nodeWorkspace';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
@@ -192,7 +192,7 @@ export function createDesktopFileSelection(
       // The shared webview posts this for 'output' too, which the desktop has
       // no picker for. Say so rather than dropping it: handleMessage already
       // reported the message as handled.
-      createChannelTrace('DesktopFileSelection').warn(
+      createLog('DesktopFileSelection').warn(
         `Unsupported multiple file selection: ${message.fileType}`,
       );
       return;

--- a/packages/desktop/src/main/desktopProcessStores.ts
+++ b/packages/desktop/src/main/desktopProcessStores.ts
@@ -1,13 +1,13 @@
-import { createChannelTrace } from '@agent/trace';
 import type { SessionHandle } from '@agent/runtime';
 import { createSessionStores } from '@controllers/session/sessionStores';
+import { createLog } from '@logger/logUtils';
 import { toLogData } from './desktopLogUtils.js';
 
 /**
  * Load the process-owned desktop stores and attach their lifecycle hooks.
  */
 export async function initializeDesktopProcessStores(session: SessionHandle) {
-  const logger = createChannelTrace('DesktopProcessStores');
+  const logger = createLog('DesktopProcessStores');
   const stores = createSessionStores(session);
   await stores.sweepLeftoverStreams();
 

--- a/src/test-kernel/agent/AgentPackage.vitest.ts
+++ b/src/test-kernel/agent/AgentPackage.vitest.ts
@@ -40,8 +40,8 @@ vi.mock('@agent/core/definition/AgentConfig', () => ({
   AgentConfigSchema: { parse: (value: unknown) => value },
 }));
 
-vi.mock('@agent/trace', () => ({
-  createChannelTrace: () => ({ warn: mocks.warn }),
+vi.mock('@logger/logUtils', () => ({
+  createLog: () => ({ warn: mocks.warn }),
 }));
 
 vi.mock('@agent/index', () => ({

--- a/src/test-kernel/agent/AgentPackage.vitest.ts
+++ b/src/test-kernel/agent/AgentPackage.vitest.ts
@@ -40,9 +40,18 @@ vi.mock('@agent/core/definition/AgentConfig', () => ({
   AgentConfigSchema: { parse: (value: unknown) => value },
 }));
 
-vi.mock('@logger/logUtils', () => ({
-  createLog: () => ({ warn: mocks.warn }),
-}));
+vi.mock('@logger/logUtils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@logger/logUtils')>();
+  return {
+    ...actual,
+    createLog: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: mocks.warn,
+      error: vi.fn(),
+    }),
+  };
+});
 
 vi.mock('@agent/index', () => ({
   loadAgents: mocks.loadAgents,

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
 import { KVStore } from '@common/storage/KVStore';
 import { KVStoreCache } from '@common/storage/KVStoreCache';
-import * as log from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import {
   AgentCategorySchema,
   END_GROUP_STATUS,
@@ -44,6 +44,7 @@ export const STREAM_LOG_SUMMARIES_DIR =
   WORKSPACE_STORAGE_LAYOUT.streamLogSummaries;
 const STREAM_LOG_LOAD_CONCURRENCY = 8;
 const LOG_TAG = 'StreamLogStore';
+const log = createLog(LOG_TAG);
 
 type StreamLogListener = (streamId: StreamTabId, delta: StreamLogDelta) => void;
 
@@ -456,7 +457,7 @@ export class StreamLogStore {
       return await open();
     } catch (error) {
       const reason = `Persistent transcript opening failed: ${toErrorMessage(error)}`;
-      log.warn(LOG_TAG, reason);
+      log.warn(reason);
       return StreamLogStore.ephemeral(reason);
     }
   }
@@ -865,7 +866,6 @@ export class StreamLogStore {
         // retry succeeds and reunites the in-memory view with persisted data.
         this.ensureStreamState(streamId).loadFailed = true;
         log.warn(
-          LOG_TAG,
           `Failed to reload stream ${streamId} from disk: ` +
             toErrorMessage(err),
         );
@@ -949,11 +949,11 @@ export class StreamLogStore {
     first: number | undefined;
     last: number | undefined;
   } {
-    const log = this.streams.get(streamId)?.log;
+    const residentLog = this.streams.get(streamId)?.log;
     const summary = this.summaries.get(streamId);
     return {
-      first: log?.firstTimestamp ?? summary?.firstTimestamp,
-      last: log?.lastTimestamp ?? summary?.lastTimestamp,
+      first: residentLog?.firstTimestamp ?? summary?.firstTimestamp,
+      last: residentLog?.lastTimestamp ?? summary?.lastTimestamp,
     };
   }
 
@@ -965,7 +965,7 @@ export class StreamLogStore {
     try {
       await this.executeWrite();
       if (this.mode.kind !== 'ephemeral') {
-        log.info(LOG_TAG, `Deleting stream: ${streamId}`);
+        log.info(`Deleting stream: ${streamId}`);
         await this.kv().delete(streamId);
         await this.deleteSummaryCache(streamId);
       }
@@ -999,7 +999,7 @@ export class StreamLogStore {
       this.forgetAllStreamState();
       if (this.mode.kind === 'ephemeral') return;
 
-      log.info(LOG_TAG, `Clearing all ${count} streams`);
+      log.info(`Clearing all ${count} streams`);
       await this.kv().deleteDir();
       await this.clearSummaryCache();
     } finally {
@@ -1329,10 +1329,7 @@ export class StreamLogStore {
     this.clearing = false;
     this.stateRevision += 1;
 
-    log.info(
-      LOG_TAG,
-      `Loaded ${this.summaries.size} stream summaries (file-backed)`,
-    );
+    log.info(`Loaded ${this.summaries.size} stream summaries (file-backed)`);
   }
 
   private async loadStreamSummary(
@@ -1386,7 +1383,6 @@ export class StreamLogStore {
       const condition =
         error instanceof SyntaxError ? 'corrupt' : 'unavailable';
       log.warn(
-        LOG_TAG,
         `Ignoring ${condition} summary cache for ${streamId}; rebuilding from the stream log: ${toErrorMessage(error)}`,
       );
       return undefined;
@@ -1416,7 +1412,6 @@ export class StreamLogStore {
       // Derived tier (#9434): discard the stale-shaped cache loudly and
       // rebuild from the authoritative stream log — never migrate in place.
       log.warn(
-        LOG_TAG,
         `Discarding a stale-shaped summary cache entry; rebuilding from the stream log: ${result.error.issues
           .map(
             (issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`,
@@ -1556,7 +1551,7 @@ export class StreamLogStore {
   private disableSummaryCacheMaintenance(message: string): void {
     if (!this.summaryCacheMaintenanceEnabled) return;
     this.summaryCacheMaintenanceEnabled = false;
-    log.warn(LOG_TAG, message);
+    log.warn(message);
   }
 
   private markDirty(streamId: StreamTabId): void {
@@ -1673,7 +1668,6 @@ export class StreamLogStore {
     if (parsed.preservedRawEntries.length > 0) {
       const count = parsed.preservedRawEntries.length;
       log.warn(
-        LOG_TAG,
         `Stream ${streamId}: ${formatResultCount(count, 'persisted transcript entry')} did not parse; ` +
           `preserving raw for round-trip on save.`,
       );
@@ -1712,7 +1706,7 @@ export class StreamLogStore {
 
     if (toWrite.length === 0) return;
 
-    log.debug(LOG_TAG, `Writing ${toWrite.length} dirty stream(s)`);
+    log.debug(`Writing ${toWrite.length} dirty stream(s)`);
     const writeGeneration = this.writeGeneration;
 
     // Write streams one at a time. Each KV write serializes the stream's full


### PR DESCRIPTION
## Summary

Follow-up to the src-only #10595 census: five package `createChannelTrace`
defaults are log-only and can be narrowed onto `createLog` without changing
their channel, level, arguments, or injectable logger contracts. This PR
migrates the four currently disjoint sites:

- `packages/agent/src/index.ts` (`agentPackage`)
- `packages/cli/src/runtime/toolUseResumeData.ts` (`CliToolUseResumeData`)
- `packages/desktop/src/main/desktopFileSelection.ts` (`DesktopFileSelection`)
- `packages/desktop/src/main/desktopProcessStores.ts` (`DesktopProcessStores`)

It also converts `src/transcript/StreamLogStore.ts` from the `import * as log`
namespace alias to channel-bound `createLog(LOG_TAG)`, keeping the exact
`StreamLogStore` channel and the `loggerSelf` spy seam. The one method-local
`const log` (`getTimestampRange`) is renamed to `residentLog` so the module
logger is no longer shadowed; behavior is unchanged.

Final review feedback is incorporated at head `d59ba3b9`:
`DesktopFileSelection` now binds its logger once at module scope, and the
`AgentPackage` test mock spreads the real `@logger/logUtils` module and
overrides only `createLog` with a complete `Log` object.

The fifth package site,
`packages/extension/src/commands/agent/resumeFromResumeData.ts`, is deliberately
**not** touched in this PR: open PR #10699 (`refactor/cross-host-resume-hardening`)
already owns that file, and the batch only migrates files that are still disjoint.

## Issue acceptance gates

- Narrow log-only `createChannelTrace` callers onto `createLog` where the
  caller never needs the `AgentTrace` surface.
- Preserve exact channels, levels, message/data arguments, injectable logger
  fallbacks, and the `loggerSelf`-based spy seam.
- Do not narrow unrelated `AgentTrace` contracts (e.g. `childRunLoop`,
  `AgentRunLifecycle`, `executionRegistry`, `AgentLaunchResources`).
- Refs #10013 (not Closes): this is one batch of the remaining-module
  migration; later batches remain.

## Single source of truth

`createLog(channel)` in `src/logger/logUtils.ts` remains the one channel-bound
logging primitive. These callers now bind directly to it instead of routing
through `createChannelTrace`'s `createChannelWriter` wrapper for a log-only
`AgentTrace`.

## Duplication and abstraction budget

Removed five log-only `createChannelTrace` default sites (four in this PR, one
left to #10699) that duplicated the same shared sink path already reached by
`createLog`. No new abstraction, pass-through layer, or exported surface added.

## Net elements (R6)

- Files changed: 6 (5 production, 1 existing test mock)
- Diffstat: 6 files changed, 34 insertions(+), 30 deletions(-)
- Exported symbols changed (`^[+-]export`): 0
- Classes/interfaces/enums added/deleted: 0
- Net LoC: +4

## Consumer counts (R8)

n/a — no exported symbol, emit path, or key is deleted or re-routed. The
per-caller logger wiring changes internally; `createChannelTrace` retains its
genuine `AgentTrace` consumers elsewhere.

The final follow-up changes at head `d59ba3b9` keep this count unchanged:
- `DesktopFileSelection` hoists `const logger = createLog('DesktopFileSelection')`
  to module scope and calls `logger.warn(...)` with the same channel, message,
  and data.
- `AgentPackage.vitest.ts` now spreads the real `@logger/logUtils` module via
  `importOriginal` and overrides only `createLog` with a complete
  `{ debug, info, warn, error }` Log, preserving the `warn: mocks.warn`
  assertion seam.

## Host impact

Extension:
- None in this batch; `resumeFromResumeData.ts` is intentionally left to
  #10699 to avoid an overlapping-file edit.

Desktop:
- `desktopFileSelection.ts` and `desktopProcessStores.ts` now emit through
  `createLog`; channel names and message/data arguments are unchanged.
  `desktopFileSelection.ts` binds its logger once at module scope.

CLI:
- `toolUseResumeData.ts` now emits through `createLog('CliToolUseResumeData')`.

Agent package:
- `index.ts` now emits through `createLog('agentPackage')`; the package's
  public surface and injectable logger contract are unchanged.

## Scheduled refactoring

- None in this batch. Remaining genuine `AgentTrace` `createChannelTrace`
  callers stay on `createChannelTrace` by design.

## Validation

Final head `d59ba3b9` local validation:

- `npx vitest run --config vitest.config.mjs` focused suites (all passed):
  - `src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts`
  - `src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts`
  - `src/test-kernel/agent/AgentPackage.vitest.ts`
  - `src/test-kernel/cli/ResumeCommand.vitest.ts`
  - `src/test-kernel/cli/History.vitest.ts`
  - `src/test-kernel/desktop/ElectronFileSelection.vitest.ts`
  - `src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.ts`
  - `src/test-kernel/architecture/dependencyDirection.vitest.ts`
- `npm run typecheck:workspace` — passed
- `npm run typecheck:test-kernel` — passed
- `npm run typecheck:agent` — passed (build + declaration validation)
- `npm run typecheck:cli` — passed
- `npm run typecheck:desktop` — passed
- Scoped `eslint` over the six changed files — passed
- `prettier --check` over the six changed files — passed
- `git diff --check` — passed
- `npm run check:dead-code-ratchet` — passed (8 current vs 8 baselined)

Review-feedback changes validated locally:
- `DesktopFileSelection` hoist covered by `ElectronFileSelection.vitest.ts`
  and `typecheck:desktop`.
- `AgentPackage` `importOriginal` spread + full-`Log` mock covered by
  `AgentPackage.vitest.ts` and `typecheck:test-kernel`.

CI on head `d59ba3b9` is green (all completed jobs SUCCESS or appropriately
SKIPPED): `detect changes`, `guidance references`, `static checks (linux)`,
`kernel tests (linux, shard 1/2)`, `kernel tests (linux, shard 2/2)`,
`build artifacts (linux)`, `webview smoke (macOS)`, and `validate`.

No new test coverage was added; the single existing `AgentPackage` mock was
migrated to the `importOriginal` spread + complete-`Log` override shape.
