### PR TITLE
refactor(logger): migrate 24 packages/extension modules to createLog

### DIFF
--- a/packages/extension/src/commands/files/fileSelectionCommands.ts
+++ b/packages/extension/src/commands/files/fileSelectionCommands.ts
@@ -7,10 +7,11 @@ import { getFilterExtensions } from '@common/files/fileTypeUtils';
 import { FILE_SELECTION_COMMAND_IDS } from '@frontend/files/fileSelectionRegistry';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { selectFiles } from '@frontend/ui/dialogs';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 
 const CHANNEL = 'fileSelectionCommands';
+const log = createLog(CHANNEL);
 
 interface PickerOptions {
   openLabel: string;
@@ -31,7 +32,7 @@ async function announceSelection<T extends string | string[]>(
       ? `Selected files: ${result.join(', ')}`
       : `Selected file: ${result}`;
     vscode.window.showInformationMessage(message);
-    logger.info(CHANNEL, message);
+    log.info(message);
     return result;
   } catch (err) {
     await showLoggedErrorMessage(

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -15,7 +15,7 @@ import {
   parseLatexGitUrl,
   type OverleafRemote,
 } from '@latex/overleafProject';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { getConfig } from '@utils/config/configUtils';
@@ -28,6 +28,7 @@ import { extendEnvPath } from '@utils/system/platformPaths';
 import { isGitRepository } from '@utils/git/isGitRepository';
 
 const CHANNEL = 'gitCommands';
+const log = createLog(CHANNEL);
 
 export function registerGitCommands(context: vscode.ExtensionContext): void {
   // `isGitRepository`, `getRecentCommits`, and `findCommitInHistory`
@@ -164,7 +165,7 @@ async function promptGitMissing(): Promise<void> {
     ? (['Copy Command', 'Run in Terminal', 'Open git-scm.com'] as const)
     : (['Open git-scm.com'] as const);
 
-  logger.error(CHANNEL, message);
+  log.error(message);
   const selected = await vscode.window.showErrorMessage(message, ...actions);
   if (selected === 'Copy Command' && command) {
     await vscode.env.clipboard.writeText(command);
@@ -198,7 +199,7 @@ function buildOverleafClonePorts(
         true,
       ),
     showInvalidToken: async (spec, message) => {
-      logger.error(CHANNEL, message);
+      log.error(message);
       const action = await vscode.window.showErrorMessage(
         message,
         ...(spec.tokenHint ? (['How to get a token'] as const) : []),
@@ -213,7 +214,7 @@ function buildOverleafClonePorts(
     listWorkspaceEntries: async (workspacePath) =>
       (await WorkspaceFS.readDir(workspacePath)).map(([name]) => name),
     showWorkspaceUnreadable: (e) => {
-      logger.error(CHANNEL, `readDir failed: ${toErrorMessage(e)}`);
+      log.error(`readDir failed: ${toErrorMessage(e)}`);
       void vscode.window.showErrorMessage('Cannot read workspace folder.');
     },
     showWorkspaceNotEmpty: () => {
@@ -260,7 +261,7 @@ function buildOverleafClonePorts(
       void vscode.window.showErrorMessage(message);
     },
     logCloneError: (message) => {
-      logger.error(CHANNEL, `Clone failed: ${message}`);
+      log.error(`Clone failed: ${message}`);
     },
   };
 }

--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -5,13 +5,14 @@ import * as vscode from 'vscode';
 import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import { runCleanSingle, runCleanMultiple } from '@housekeeping/clean';
 import { runCleanRunDir } from '@housekeeping/runDirOps';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 
 import type { FileOpResult } from '@shared/schemas';
 import { type CleanConfig } from './fileOpSchemas';
 import { runFileOp } from './fileOpRunner';
 
 const CHANNEL = 'cleanCommands';
+const log = createLog(CHANNEL);
 
 function showCleanResult(result: FileOpResult, inputFile: string): void {
   switch (result.status) {
@@ -50,7 +51,7 @@ export async function handleCleanMultiple(
   inputFiles: string[] = [],
 ): Promise<void> {
   if (inputFiles.length > 0) {
-    logger.debug(CHANNEL, `Additional files: ${inputFiles.join(', ')}`);
+    log.debug(`Additional files: ${inputFiles.join(', ')}`);
   }
   const result =
     inputFiles.length > 0
@@ -62,10 +63,7 @@ export async function handleCleanMultiple(
 }
 
 export async function handleClean(config: CleanConfig): Promise<void> {
-  logger.debug(
-    CHANNEL,
-    `Clean command called with config: ${JSON.stringify(config)}`,
-  );
+  log.debug(`Clean command called with config: ${JSON.stringify(config)}`);
   await runFileOp(config, {
     runSingle: runCleanSingle,
     runMultiple: runCleanMultiple,

--- a/packages/extension/src/commands/latex/arXivCommands.ts
+++ b/packages/extension/src/commands/latex/arXivCommands.ts
@@ -8,9 +8,10 @@ import {
   ArxivProcessor,
   type ArxivDownloadDestination,
 } from '@latex/arxivProcessor';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 
 const CHANNEL = 'arXivCommands';
+const log = createLog(CHANNEL);
 
 export async function downloadArXivSource(): Promise<void> {
   try {
@@ -66,7 +67,7 @@ export async function downloadArXivSource(): Promise<void> {
       },
       async (progress, token) => {
         token.onCancellationRequested(() => {
-          logger.info(CHANNEL, 'User cancelled the download');
+          log.info('User cancelled the download');
         });
 
         const downloadResult = await ArxivProcessor.downloadSource(arxivId, {

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -19,7 +19,7 @@ import {
   siblingLocation,
   type CommitAcceptedFilePorts,
 } from '@latex/acceptedFileTarget';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { AcceptCopyMeta, FileLocation } from '@shared/schemas';
 import { DIFF_REGISTRATION_DELAY_MS } from '@shared/constants/latexTiming';
 import { workflowOutputCopyStem } from '@shared/constants/workflowOutput';
@@ -27,6 +27,7 @@ import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const CHANNEL = 'CompareCommands';
+const log = createLog(CHANNEL);
 
 function validateFileLocations(
   inputLocation: FileLocation | null | undefined,
@@ -62,7 +63,7 @@ const COMMIT_PORTS: CommitAcceptedFilePorts = {
     appSignals.emit('workspaceFilesWritten', { absolutePaths: [absolutePath] }),
   showInfo: (message) => {
     vscode.window.showInformationMessage(message);
-    logger.info(CHANNEL, message);
+    log.info(message);
   },
   deleteFile: deleteDiffFileNonFatal,
 };
@@ -127,8 +128,7 @@ export async function handleCompare(
     } catch (err) {
       const message = toErrorMessage(err);
       if (message.includes(`command '${contextKeyCommandId}' not found`)) {
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Could not check Progress view location: command '${contextKeyCommandId}' not found`,
         );
       } else {
@@ -147,8 +147,7 @@ export async function handleCompare(
       registerDiffRefresh(editedUri, baseUri, title);
     }, DIFF_REGISTRATION_DELAY_MS);
 
-    logger.info(
-      CHANNEL,
+    log.info(
       `Opened diff comparison between ${baseFileName} and ${editedFileName}`,
     );
   } catch (err) {

--- a/packages/extension/src/commands/latex/figCommands.ts
+++ b/packages/extension/src/commands/latex/figCommands.ts
@@ -8,11 +8,12 @@ import * as vscode from 'vscode';
 import { runGuardedLatexCommand } from '@frontend/editor/activeFileGuards';
 import { showLoggedInfoMessage } from '@frontend/ui/errorHandlingUtils';
 import { TikzPictureManager } from '@latex/TikzPictureManager';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { pathToLocation } from '@utils/files/fileLocation';
 import { pluralize, truncateWithEllipsis } from '@utils/text/stringUtils';
 
 const CHANNEL = 'FigCommands';
+const log = createLog(CHANNEL);
 
 export async function handleExtractTikzFigures(): Promise<void> {
   await runGuardedLatexCommand(
@@ -22,10 +23,7 @@ export async function handleExtractTikzFigures(): Promise<void> {
       errorMessage: 'extractTikzFigures command failed',
     },
     async ({ relativePath: filePath }) => {
-      logger.debug(
-        CHANNEL,
-        `Processing LaTeX file for TikZ figures: ${filePath}`,
-      );
+      log.debug(`Processing LaTeX file for TikZ figures: ${filePath}`);
 
       const labeledTikzPictures = await TikzPictureManager.extract(
         pathToLocation(filePath),
@@ -67,10 +65,7 @@ export async function handleCompileTikzFigures(): Promise<void> {
       errorMessage: 'compileTikzFigures command failed',
     },
     async ({ relativePath: filePath }) => {
-      logger.debug(
-        CHANNEL,
-        `Processing LaTeX file for TikZ compilation: ${filePath}`,
-      );
+      log.debug(`Processing LaTeX file for TikZ compilation: ${filePath}`);
 
       await vscode.window.withProgress(
         {

--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -17,7 +17,7 @@ import { LATEX_COMMANDS_CHANNEL as CHANNEL } from '@latex/latexLogging';
 import { runLatexFormatter } from '@latex/formatter/texFormatter';
 import { indentLatexFilesInDirectory } from '@latex/formatter/indentDirectory';
 import { buildLatexdiffAwareFixInstruction } from '@latex/latexdiff/diffFileNameManager';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { AgentCategory } from '@shared/schemas';
 import { delay } from '@utils/core';
 
@@ -25,6 +25,8 @@ import {
   getIndentTeXNotification,
   showLatexHousekeepingNotification,
 } from './latexHousekeepingNotifications';
+
+const log = createLog(CHANNEL);
 
 export async function handleIndentTeX(): Promise<void> {
   try {
@@ -47,8 +49,7 @@ export async function handleFixCompilation(): Promise<void> {
       errorMessage: 'Error launching LaTeX compilation fixer',
     },
     async ({ editor, relativePath }) => {
-      logger.info(
-        CHANNEL,
+      log.info(
         `Launching tool-use agent to fix compilation for: ${relativePath}`,
       );
 
@@ -79,7 +80,7 @@ export async function handleIndentCurrentTeX(): Promise<void> {
       errorMessage: 'Error in indentTeX command',
     },
     async ({ relativePath }) => {
-      logger.debug(CHANNEL, `Indenting LaTeX file: ${relativePath}`);
+      log.debug(`Indenting LaTeX file: ${relativePath}`);
 
       const success = await runLatexFormatter(relativePath);
 
@@ -104,7 +105,7 @@ export async function handleGetTeXCount(): Promise<void> {
       errorMessage: 'Error getting tex count',
     },
     async ({ relativePath }) => {
-      logger.debug(CHANNEL, `Getting tex count for: ${relativePath}`);
+      log.debug(`Getting tex count for: ${relativePath}`);
 
       const countingMode = await vscode.window.showQuickPick<
         vscode.QuickPickItem & { value: TexcountMode }

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -37,7 +37,7 @@ import {
   describeMathMarkupOption,
   type MathMarkupOption,
 } from '@latex/latexdiff/mathMarkup';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latexConfig';
@@ -51,6 +51,8 @@ import {
   getLatexdiffPackNotifications,
   showLatexHousekeepingNotification,
 } from './latexHousekeepingNotifications';
+
+const log = createLog(CHANNEL);
 
 type LatexdiffTool = 'latexdiff' | 'latexdiff-vc';
 
@@ -66,7 +68,7 @@ async function withLatexdiffTool<T>(
 ): Promise<T | undefined> {
   try {
     if (!(await checkToolInstalled(tool))) {
-      logger.warn(CHANNEL, `${tool} is not installed; command will not run.`);
+      log.warn(`${tool} is not installed; command will not run.`);
       return undefined;
     }
     return await action();
@@ -106,7 +108,7 @@ async function promptForLatexdiffMathMarkup(): Promise<
     prompt: `Saved default: ${configuredMode} — press Enter to accept, or pick another`,
   });
   if (!pick) {
-    logger.debug(CHANNEL, 'Math markup selection cancelled by user');
+    log.debug('Math markup selection cancelled by user');
   }
   return pick?.value;
 }
@@ -177,8 +179,7 @@ async function restorePreparedViewerTarget(
   } catch (err) {
     // The original setup error still propagates; a failed restore is a reason
     // to skip the argument-free viewer rather than open a stale/unrelated PDF.
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Failed to restore the last prepared diff before viewer handoff: ${toErrorMessage(err)}`,
     );
     return false;
@@ -214,8 +215,7 @@ async function prepareLatexdiffResultsAndScheduleViewer(
         );
         if (opened) {
           lastProcessedLocation = opened.diffLocation;
-          logger.debug(
-            CHANNEL,
+          log.debug(
             `Successfully generated diff: ${opened.diffFilePath}${suffix}`,
           );
           if (opened.viewerReady) {
@@ -224,8 +224,7 @@ async function prepareLatexdiffResultsAndScheduleViewer(
           }
         }
       } else if (!result.success) {
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Failed to generate diff${suffix}: ${result.message ?? 'Unknown error'}`,
         );
       }
@@ -261,10 +260,7 @@ async function runDiffAndOpen(
 ): Promise<void> {
   const mathMarkup = await promptForLatexdiffMathMarkup();
   if (!mathMarkup) return;
-  logger.info(
-    CHANNEL,
-    `Running ${toolLabel} with math markup mode: ${mathMarkup}`,
-  );
+  log.info(`Running ${toolLabel} with math markup mode: ${mathMarkup}`);
 
   const result = await runDiff(mathMarkup);
   if (!result.success || !result.diffFileName) {
@@ -356,8 +352,7 @@ async function handlePackLatexdiffvc(
     'latexdiff-vc',
     'Error packing LaTeX diff',
     async () => {
-      logger.debug(
-        CHANNEL,
+      log.debug(
         `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}, clean=${clean}`,
       );
       const fileToUse = baseFile ?? inputFile;
@@ -375,8 +370,7 @@ async function handleCleanLatexdiffvc(
     'latexdiff-vc',
     'Error cleaning LaTeX diff',
     async () => {
-      logger.debug(
-        CHANNEL,
+      log.debug(
         `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}`,
       );
       const fileToUse = baseFile ?? inputFile;
@@ -392,10 +386,7 @@ async function handleRunLatexdiff(
     'latexdiff',
     'Error running LaTeX diffs',
     async () => {
-      logger.debug(
-        CHANNEL,
-        `Command called with config: ${JSON.stringify(config)}`,
-      );
+      log.debug(`Command called with config: ${JSON.stringify(config)}`);
 
       const { agent, model, inputFile } = config;
 
@@ -410,19 +401,13 @@ async function handleRunLatexdiff(
       const mathMarkup = await promptForLatexdiffMathMarkup();
       if (!mathMarkup) return;
 
-      logger.info(
-        CHANNEL,
-        `Running latexdiff with math markup mode: ${mathMarkup}`,
-      );
+      log.info(`Running latexdiff with math markup mode: ${mathMarkup}`);
 
       const generateBetweenRoundDiffs = workspaceSM.get<boolean>(
         WorkspaceStateKey.LATEXDIFF_BETWEEN_ROUNDS,
         LATEX_CONFIG_DEFAULTS.latexdiffBetweenRounds,
       );
-      logger.debug(
-        CHANNEL,
-        `Between-round diffs enabled: ${generateBetweenRoundDiffs}`,
-      );
+      log.debug(`Between-round diffs enabled: ${generateBetweenRoundDiffs}`);
 
       const outputsByRound = normalizeRunLatexdiffOutputsByRound(
         config.outputsByRound,

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -14,7 +14,7 @@ import {
   SETUP_INSTRUCTION,
 } from '@controllers/onboarding/setupLaunch';
 import { signInWithChatGptSubscription } from '@frontend/auth/codexSubscriptionSignIn';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { hasUsableSetupCredential } from '@model/setupCredentialAccess';
 import { platform } from '@platform/platform';
 import { agentName } from '@shared/schemas';
@@ -29,6 +29,7 @@ import { getUseOpenRouter } from '@utils/config/providerConfig';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const CHANNEL = 'SetupAssistant';
+const log = createLog(CHANNEL);
 
 interface LaunchModelResolution {
   model: string;
@@ -66,7 +67,7 @@ async function withOpenRouterFlagOn<T>(fn: () => Promise<T>): Promise<T> {
     await globalSM
       .update(GlobalStateKey.USE_OPENROUTER, false)
       .then(undefined, (err) => {
-        logger.error(CHANNEL, 'Failed to restore useOpenRouter flag.', {
+        log.error('Failed to restore useOpenRouter flag.', {
           data: err,
         });
       });
@@ -262,7 +263,7 @@ export async function launchSetupAssistant(): Promise<
     }
     return 'launched';
   } catch (error) {
-    logger.error(CHANNEL, 'Setup assistant failed to launch.', { data: error });
+    log.error('Setup assistant failed to launch.', { data: error });
     void vscode.window.showErrorMessage(
       `Failed to launch setup assistant: ${toErrorMessage(error)}`,
     );

--- a/packages/extension/src/commands/taskFormState/stateRestoreCommand.ts
+++ b/packages/extension/src/commands/taskFormState/stateRestoreCommand.ts
@@ -10,9 +10,10 @@ import {
   RestoreRunConfigInputSchema,
 } from '@controllers/mainView/MainViewStateRestoreController';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 
 const CHANNEL = 'stateRestoreCommand';
+const log = createLog(CHANNEL);
 
 const RESTORE_MALFORMED_MESSAGE =
   'Cannot restore state: persisted task data is malformed or from an incompatible version';
@@ -29,13 +30,13 @@ async function restoreState(
   state: unknown,
   executeImmediately?: boolean,
 ): Promise<boolean> {
-  logger.debug(CHANNEL, 'Restoring main webview state', {
+  log.debug('Restoring main webview state', {
     data: { executeImmediately },
   });
 
   const parsed = RestoreRunConfigInputSchema.safeParse(state);
   if (!parsed.success) {
-    logger.info(CHANNEL, RESTORE_MALFORMED_MESSAGE, {
+    log.info(RESTORE_MALFORMED_MESSAGE, {
       data: { validationError: z.prettifyError(parsed.error) },
     });
     await vscode.window.showErrorMessage(RESTORE_MALFORMED_MESSAGE);
@@ -51,7 +52,7 @@ async function restoreState(
     // probe for a live webview here or to invoke showMainView twice.
     setPendingState(nextState, executeImmediately);
     await vscode.commands.executeCommand('texra.showMainView');
-    logger.info(CHANNEL, 'State stored for restoration', {
+    log.info('State stored for restoration', {
       data: { executeImmediately },
     });
     return true;

--- a/packages/extension/src/common/webview/BaseViewContentProvider.ts
+++ b/packages/extension/src/common/webview/BaseViewContentProvider.ts
@@ -48,10 +48,7 @@ export interface ViewBundle {
 export class BundledViewContentProvider {
   private readonly channel: string;
   private readonly viewPath: string;
-
-  private get log() {
-    return createLog(this.channel);
-  }
+  private readonly log: ReturnType<typeof createLog>;
 
   constructor(
     private readonly context: vscode.ExtensionContext,
@@ -63,6 +60,7 @@ export class BundledViewContentProvider {
     // Default: convert 'HistoryView' to 'historyView'
     this.viewPath =
       viewPath ?? viewName.charAt(0).toLowerCase() + viewName.slice(1);
+    this.log = createLog(this.channel);
   }
 
   public getHtmlContent(webview: vscode.Webview): string {

--- a/packages/extension/src/common/webview/BaseViewContentProvider.ts
+++ b/packages/extension/src/common/webview/BaseViewContentProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { nanoid } from 'nanoid';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -49,6 +49,10 @@ export class BundledViewContentProvider {
   private readonly channel: string;
   private readonly viewPath: string;
 
+  private get log() {
+    return createLog(this.channel);
+  }
+
   constructor(
     private readonly context: vscode.ExtensionContext,
     private readonly viewName: string,
@@ -70,7 +74,7 @@ export class BundledViewContentProvider {
         'index.html',
       );
 
-      logger.debug(this.channel, `Generated HTML content for ${this.viewName}`);
+      this.log.debug(`Generated HTML content for ${this.viewName}`);
 
       return buildWebviewHtml(webview, htmlPath, {
         commonStyleUri: this.buildUri(webview, [
@@ -90,10 +94,7 @@ export class BundledViewContentProvider {
         ]),
       });
     } catch (err) {
-      logger.error(
-        this.channel,
-        `Error generating HTML content: ${toErrorMessage(err)}`,
-      );
+      this.log.error(`Error generating HTML content: ${toErrorMessage(err)}`);
       return '<html><body>Error loading content</body></html>';
     }
   }

--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -17,13 +17,14 @@ import { createPlatformAgentDirectories } from '@agent/index/platformAgentDirect
 import { globalSM } from '@common/state';
 import { showLoggedMessageWithDocs } from '@frontend/ui/errorHandlingUtils';
 import { selectFolder } from '@frontend/ui/dialogs';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { AGENT_SOURCE } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const CHANNEL = 'AgentLoad';
+const log = createLog(CHANNEL);
 
 type AgentDirectoryEventType = 'create' | 'change' | 'delete';
 
@@ -242,14 +243,12 @@ class AgentDirectoryManager {
       watchedDirectories.push(entry.directory);
     }
 
-    logger.info(
-      CHANNEL,
+    log.info(
       `Agent directory watchers enabled: ${watchedDirectories.join(', ')}`,
     );
 
     if (skippedDirectories.length > 0) {
-      logger.debug(
-        CHANNEL,
+      log.debug(
         `Skipped external built-in agent directory watchers: ${skippedDirectories.join(', ')}`,
       );
     }
@@ -327,8 +326,7 @@ class AgentDirectoryManager {
       try {
         entries = await vscode.workspace.fs.readDirectory(uri);
       } catch (error) {
-        logger.debug(
-          CHANNEL,
+        log.debug(
           `Unable to scan agent directory ${uri.fsPath}: ${toErrorMessage(error)}`,
         );
         continue;
@@ -382,8 +380,7 @@ class AgentDirectoryManager {
       try {
         files = await vscode.workspace.fs.readDirectory(directory);
       } catch (error) {
-        logger.debug(
-          CHANNEL,
+        log.debug(
           `Unable to scan new agent directory ${directory.fsPath}: ${toErrorMessage(error)}`,
         );
         continue;
@@ -403,8 +400,7 @@ class AgentDirectoryManager {
 
   private scheduleAgentWatcherSetup(): void {
     void this.ensureAgentWatchers().catch((error) => {
-      logger.error(
-        CHANNEL,
+      log.error(
         `Failed to refresh agent directory watchers: ${toErrorMessage(error)}`,
       );
     });

--- a/packages/extension/src/frontend/editor/activeFileGuards.ts
+++ b/packages/extension/src/frontend/editor/activeFileGuards.ts
@@ -6,7 +6,7 @@ import {
   showLoggedErrorMessage,
   showLoggedMessage,
 } from '@frontend/ui/errorHandlingUtils';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 
 const CHANNEL = 'ActiveFileGuards';
@@ -112,6 +112,8 @@ export async function runGuardedLatexCommand(
 ): Promise<void> {
   const { channel, action, saveDocument = false, errorMessage } = options;
 
+  const log = createLog(channel);
+
   try {
     const guardResult = await getActiveLatexEditor(saveDocument);
 
@@ -119,9 +121,9 @@ export async function runGuardedLatexCommand(
       const failure = GUARD_FAILURE_MESSAGES[guardResult.status];
       const logLine = `Cannot ${action}: ${failure.logTail}`;
       if (failure.level === 'error') {
-        logger.error(channel, logLine);
+        log.error(logLine);
       } else {
-        logger.warn(channel, logLine);
+        log.warn(logLine);
       }
       return;
     }

--- a/packages/extension/src/frontend/events/agentEventListeners.ts
+++ b/packages/extension/src/frontend/events/agentEventListeners.ts
@@ -21,7 +21,7 @@ import {
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import {
   INSTRUCTION_ACTION,
@@ -36,6 +36,7 @@ import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const CHANNEL = 'agentEventListeners';
+const log = createLog(CHANNEL);
 
 function handleRequestOpenFile(
   payload: RequestOpenFilePayload,
@@ -43,8 +44,7 @@ function handleRequestOpenFile(
   return openBuildDisplayIfTex(payload.location, {
     preserveFocus: payload.preserveFocus,
   }).catch((err) => {
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Failed to open file ${payload.location.absolutePath}: ${toErrorMessage(err)}`,
     );
     return false;
@@ -108,8 +108,7 @@ async function handleRequestShowInstruction(
     // failed run.
     return true;
   } catch (err) {
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Failed to show instruction "${payload.key}": ${toErrorMessage(err)}`,
     );
     return false;
@@ -130,8 +129,7 @@ async function handleShowAgentConfigBanner(
       })) !== false
     );
   } catch (err) {
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Failed to show agent config banner for "${payload.agentName}": ${toErrorMessage(err)}`,
     );
     return false;
@@ -147,17 +145,11 @@ function handleRequestShowError({ message }: RequestShowErrorPayload): boolean {
     // is logged instead of becoming an unhandled rejection.
     const toast = vscode.window.showErrorMessage(message);
     void Promise.resolve(toast).catch((err: unknown) => {
-      logger.warn(
-        CHANNEL,
-        `Error toast failed after handoff: ${toErrorMessage(err)}`,
-      );
+      log.warn(`Error toast failed after handoff: ${toErrorMessage(err)}`);
     });
     return true;
   } catch (err) {
-    logger.warn(
-      CHANNEL,
-      `Failed to show the error toast: ${toErrorMessage(err)}`,
-    );
+    log.warn(`Failed to show the error toast: ${toErrorMessage(err)}`);
     return false;
   }
 }
@@ -173,10 +165,7 @@ async function handleRequestEnsureProgressView(
   } catch (err) {
     // A failed reveal is a diagnostic, not non-delivery: fall through to the
     // visibility re-check and, when provided, the toast handoff below (#10554).
-    logger.warn(
-      CHANNEL,
-      `Failed to reveal the progress view: ${toErrorMessage(err)}`,
-    );
+    log.warn(`Failed to reveal the progress view: ${toErrorMessage(err)}`);
   }
 
   // Delivery is the reveal actually becoming visible, not the reveal command
@@ -207,8 +196,7 @@ async function handleRequestEnsureProgressView(
       } catch (err) {
         // The toast handoff already established delivery; a failed retry is
         // a diagnostic, not non-delivery, so it must not downgrade the event.
-        logger.warn(
-          CHANNEL,
+        log.warn(
           `Failed to retry the progress-view reveal: ${toErrorMessage(err)}`,
         );
       }
@@ -242,8 +230,7 @@ function createPresentationEventHandlers(
     requestEnsureProgressView: (payload) =>
       handleRequestEnsureProgressView(payload, progressViewProvider).catch(
         (err) => {
-          logger.warn(
-            CHANNEL,
+          log.warn(
             `Failed to reveal the progress view: ${toErrorMessage(err)}`,
           );
           return false;

--- a/packages/extension/src/frontend/git/resolveGitRoot.ts
+++ b/packages/extension/src/frontend/git/resolveGitRoot.ts
@@ -5,12 +5,14 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 // Local imports
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { normalizeFilePath } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { isDirectory, isFile } from '@utils/files/fsEntryType';
 
 import { getGitAPI } from './gitExtensionTypes';
+
+const log = createLog('extension');
 
 export function resolveCommonRootFromGitdir(
   repoRoot: string,
@@ -89,8 +91,7 @@ export async function resolveGitCommonRoot(
     ) {
       return undefined;
     }
-    logger.warn(
-      'extension',
+    log.warn(
       `Failed to resolve git common root for ${workspacePath}: ${toErrorMessage(error)}`,
     );
     return undefined;

--- a/packages/extension/src/frontend/latex/openBuild.ts
+++ b/packages/extension/src/frontend/latex/openBuild.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 import { isLatexFile } from '@common/files/fileTypeUtils';
 import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import { compileLatex2Pdf } from '@latex/texTools';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
 import {
   LATEX_VIEWER_OPEN_DELAY_MS,
@@ -20,6 +20,7 @@ import { pathToLocation } from '@utils/files/fileLocation';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const CHANNEL = 'OpenBuildUtils';
+const log = createLog(CHANNEL);
 
 /**
  * Resolve `latex-workshop.latex.outDir` by expanding all LaTeX Workshop
@@ -83,7 +84,8 @@ export async function invokeLatexWorkshopBuild(
   try {
     await vscode.commands.executeCommand('latex-workshop.build', uri);
   } catch (err) {
-    logger.warn(channel, `${warnLabel}: ${toErrorMessage(err)}`);
+    const log = createLog(channel);
+    log.warn(`${warnLabel}: ${toErrorMessage(err)}`);
   }
 }
 
@@ -209,8 +211,7 @@ async function prepareLatexBuild(
     // writeLine only shows `data` when texra.logger.debugMode is on
     // (default off), and this failure's whole point is to be visible
     // without needing to enable debug logging.
-    logger.warn(
-      CHANNEL,
+    log.warn(
       `Internal LaTeX compilation failed for ${uri.fsPath}:\n${compiled.logTail}`,
       { data: { sourceFile: uri.fsPath, logTail: compiled.logTail } },
     );
@@ -251,19 +252,13 @@ export function scheduleViewerDisplay(): Promise<boolean> {
                   ),
                 )
                 .then(undefined, (err: unknown) => {
-                  logger.warn(
-                    CHANNEL,
-                    `Viewer refresh failed: ${toErrorMessage(err)}`,
-                  );
+                  log.warn(`Viewer refresh failed: ${toErrorMessage(err)}`);
                 });
             }, LATEX_VIEWER_REFRESH_DELAY_MS);
             resolve(true);
           },
           (err: unknown) => {
-            logger.warn(
-              CHANNEL,
-              `Viewer display failed: ${toErrorMessage(err)}`,
-            );
+            log.warn(`Viewer display failed: ${toErrorMessage(err)}`);
             resolve(false);
           },
         );

--- a/packages/extension/src/frontend/media/RecordingManager.ts
+++ b/packages/extension/src/frontend/media/RecordingManager.ts
@@ -3,11 +3,12 @@ import * as vscode from 'vscode';
 
 // Local imports - media utilities
 import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { startRecording, stopRecordingAndTranscribe } from '@tools/media/audio';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const CHANNEL = 'RecordingManager';
+const log = createLog(CHANNEL);
 
 type RecordingMessageInput =
   { status: 'started' | 'stopped' } | { status: 'error'; error: string };
@@ -47,7 +48,7 @@ export class RecordingManager {
       }
     } catch (error) {
       const errorMsg = toErrorMessage(error);
-      logger.error(CHANNEL, `Error starting recording: ${errorMsg}`);
+      log.error(`Error starting recording: ${errorMsg}`);
       this.notifyError(webviewView.webview, errorMsg);
     }
   }
@@ -86,7 +87,7 @@ export class RecordingManager {
       );
     } catch (error) {
       const errorMsg = toErrorMessage(error);
-      logger.error(CHANNEL, `Error stopping recording: ${errorMsg}`);
+      log.error(`Error stopping recording: ${errorMsg}`);
       this.notifyError(webviewView.webview, errorMsg);
       acknowledgeStop();
     }

--- a/packages/extension/src/frontend/review/AgentReviewService.ts
+++ b/packages/extension/src/frontend/review/AgentReviewService.ts
@@ -35,7 +35,7 @@ import {
   showLoggedMessage,
 } from '@frontend/ui/errorHandlingUtils';
 import { lineToRange } from '@frontend/vscode/vscodeEditor';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { RUN_OUTCOME, type RunOutcome, AgentCategory } from '@shared/schemas';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -46,6 +46,7 @@ import {
 } from './AgentReviewRunController';
 
 const CHANNEL = 'AgentReview';
+const log = createLog(CHANNEL);
 const COLLECTION_NAME = 'texra-agent-review';
 const SOURCE_LABEL = 'TeXRA Agent Review';
 /** Tool-use agent that performs the review and reports issues via the tool sink. */
@@ -195,10 +196,7 @@ class AgentReviewServiceImpl {
       // Backstop for anything executeReview's own handling missed — the
       // summary must never stay stuck on "Reviewing changes…".
       this.summary = `Review failed: ${toErrorMessage(err)}`;
-      logger.warn(
-        CHANNEL,
-        `Agent review failed unexpectedly: ${toErrorMessage(err)}`,
-      );
+      log.warn(`Agent review failed unexpectedly: ${toErrorMessage(err)}`);
     } finally {
       if (this.reviewRuns.finish(run)) {
         const pending = this.pendingCommitReview;
@@ -244,7 +242,7 @@ class AgentReviewServiceImpl {
           collected.reason,
         );
       } else {
-        logger.warn(CHANNEL, `Agent review failed: ${collected.reason}`);
+        log.warn(`Agent review failed: ${collected.reason}`);
       }
       return;
     }
@@ -329,16 +327,12 @@ class AgentReviewServiceImpl {
       // panel state honest without a second notification.
       const restored = this.restorePreviousResults(previous);
       this.summary = `Review failed: ${toErrorMessage(err)}${restored ? ' · showing previous results' : ''}`;
-      logger.warn(
-        CHANNEL,
-        `Agent review session failed: ${toErrorMessage(err)}`,
-      );
+      log.warn(`Agent review session failed: ${toErrorMessage(err)}`);
       return;
     }
 
     if (!this.reviewRuns.isCurrent(run)) {
-      logger.info(
-        CHANNEL,
+      log.info(
         'Agent review results were cleared while the session ran; discarding its outcome',
       );
       return;
@@ -358,7 +352,7 @@ class AgentReviewServiceImpl {
         suffix = ` · showing the ${formatResultCount(this.issues.length, 'issue')} reported before the session ended`;
       }
       this.summary = `Review ${verb}${suffix}`;
-      logger.warn(CHANNEL, `Agent review session ${verb}`);
+      log.warn(`Agent review session ${verb}`);
       return;
     }
 
@@ -367,8 +361,7 @@ class AgentReviewServiceImpl {
       count === 0
         ? `No issues found (diff with ${baseDescription})`
         : `Found ${formatResultCount(count, 'potential issue')} (diff with ${baseDescription})${truncated ? ' · diff truncated' : ''}`;
-    logger.info(
-      CHANNEL,
+    log.info(
       `Agent review (${trigger}): ${count} issue(s) across ${changedFiles.length} changed file(s)`,
     );
   }

--- a/packages/extension/src/frontend/ui/errorHandlingUtils.ts
+++ b/packages/extension/src/frontend/ui/errorHandlingUtils.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 import { formatError } from '@common/errors';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 /** Valid documentation identifiers for error messages. */
@@ -13,8 +13,9 @@ export function logErrorMessage(
   prefix: string,
   err: unknown,
 ): string {
+  const log = createLog(channel);
   const message = formatError(prefix, err);
-  logger.error(channel, message);
+  log.error(message);
   return message;
 }
 
@@ -34,7 +35,8 @@ export async function showLoggedMessage(
   channel: string,
   message: string,
 ): Promise<string> {
-  logger.error(channel, message);
+  const log = createLog(channel);
+  log.error(message);
   await vscode.window.showErrorMessage(message);
   return message;
 }
@@ -44,7 +46,8 @@ export async function showLoggedInfoMessage(
   channel: string,
   message: string,
 ): Promise<string> {
-  logger.info(channel, message);
+  const log = createLog(channel);
+  log.info(message);
   await vscode.window.showInformationMessage(message);
   return message;
 }
@@ -56,16 +59,14 @@ export async function showLoggedMessageWithDocs(
   docId: DocId,
   actionLabel = 'View Docs',
 ): Promise<void> {
-  logger.error(channel, message);
+  const log = createLog(channel);
+  log.error(message);
   const selection = await vscode.window.showErrorMessage(message, actionLabel);
   if (selection !== actionLabel) return;
 
   try {
     await vscode.commands.executeCommand('texra.openDoc', docId);
   } catch (err) {
-    logger.error(
-      channel,
-      `Failed to open documentation: ${toErrorMessage(err)}`,
-    );
+    log.error(`Failed to open documentation: ${toErrorMessage(err)}`);
   }
 }

--- a/packages/extension/src/frontend/ui/instruction.ts
+++ b/packages/extension/src/frontend/ui/instruction.ts
@@ -4,11 +4,12 @@ import * as vscode from 'vscode';
 // Local imports
 import { globalSM } from '@common/state';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { INSTRUCTION_PREFIX } from '@shared/state/stateKeys';
 
 const NEVER_REMIND = 'Never remind again';
 const CHANNEL = 'instruction';
+const log = createLog(CHANNEL);
 
 async function handleInstructionChoice(
   stateKey: string,
@@ -52,7 +53,7 @@ export async function showInstructionWithSuppress(
         handleInstructionChoice(stateKey, showSuppress, actions, choice),
       )
       .catch((error: unknown) => {
-        logger.warn(CHANNEL, `Failed to settle instruction "${key}"`, {
+        log.warn(`Failed to settle instruction "${key}"`, {
           data: error,
         });
       });

--- a/packages/extension/src/frontend/vscode/texraConfig.ts
+++ b/packages/extension/src/frontend/vscode/texraConfig.ts
@@ -18,7 +18,7 @@ import { isFileNotFoundError } from '@common/errors';
 import { appSignals } from '@eventBus/AppSignals';
 
 // Local imports - logging
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 
 // Local imports - platform
 import type { ConfigTarget, StorageProvider } from '@platform/interfaces';
@@ -32,6 +32,8 @@ import { readPersistedTexraApprovalPolicy } from '@shared/approvalPolicy';
 
 // Local imports - utilities
 import { toErrorMessage } from '@utils/errors/errorMessage';
+
+const log = createLog('extension');
 
 /** Whether JsonStore can create its file beneath the deepest existing directory. */
 async function canCreateOrWrite(filePath: string): Promise<boolean> {
@@ -63,8 +65,7 @@ async function openWorkspaceConfigStore(
         return projectStore;
       }
     } catch (error) {
-      logger.warn(
-        'extension',
+      log.warn(
         `Cannot open project .texra/config.json; using the internal workspace config store. Cause: ${toErrorMessage(error)}`,
       );
     }

--- a/packages/extension/src/webview/managers/DiffManager.ts
+++ b/packages/extension/src/webview/managers/DiffManager.ts
@@ -12,10 +12,7 @@ import { BaseWebviewManager } from './BaseWebviewManager';
 
 export class DiffManager extends BaseWebviewManager {
   private readonly channel = 'DiffManager';
-
-  private get log() {
-    return createLog(this.channel);
-  }
+  private readonly log = createLog(this.channel);
 
   handleLatexdiff(message: LatexdiffMessage): void {
     void vscode.commands.executeCommand(

--- a/packages/extension/src/webview/managers/DiffManager.ts
+++ b/packages/extension/src/webview/managers/DiffManager.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import type {
   LatexdiffMessage,
@@ -12,6 +12,10 @@ import { BaseWebviewManager } from './BaseWebviewManager';
 
 export class DiffManager extends BaseWebviewManager {
   private readonly channel = 'DiffManager';
+
+  private get log() {
+    return createLog(this.channel);
+  }
 
   handleLatexdiff(message: LatexdiffMessage): void {
     void vscode.commands.executeCommand(
@@ -56,7 +60,7 @@ export class DiffManager extends BaseWebviewManager {
       const infoMessage = isGitRepo
         ? 'No recent commits found for this repository.'
         : 'This workspace is not a Git repository.';
-      logger.info(this.channel, infoMessage);
+      this.log.info(infoMessage);
       void vscode.window.showInformationMessage(infoMessage);
     }
 

--- a/packages/extension/src/webview/managers/InstructionManager.ts
+++ b/packages/extension/src/webview/managers/InstructionManager.ts
@@ -1,6 +1,6 @@
 import { polishTextWithAI, FileContext } from '@agent/runtime';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import type { MainViewInboundMessage } from '@shared/schemas';
 import { filterNotNull } from '@utils/core';
@@ -12,6 +12,7 @@ import { savePastedImageBase64 } from '@utils/files/pastedImageUtils';
 import { BaseWebviewManager } from './BaseWebviewManager';
 
 const CHANNEL = 'InstructionManager';
+const log = createLog(CHANNEL);
 
 type PolishInstructionMessage = Extract<
   MainViewInboundMessage,
@@ -31,10 +32,7 @@ export class InstructionManager extends BaseWebviewManager {
         await StorageFS.ensureDir(PASTED_DIR);
         await StorageFS.cleanupOldFiles(PASTED_DIR, THREE_DAYS_MS);
       } catch (e) {
-        logger.warn(
-          CHANNEL,
-          `Error during initial cleanup: ${toErrorMessage(e)}`,
-        );
+        log.warn(`Error during initial cleanup: ${toErrorMessage(e)}`);
       }
     }, 100);
   }
@@ -64,8 +62,7 @@ export class InstructionManager extends BaseWebviewManager {
         command: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISH_ERROR,
         error: toErrorMessage(error),
       });
-      logger.error(
-        CHANNEL,
+      log.error(
         `Error in handlePolishInstructionText: ${toErrorMessage(error)}`,
       );
     }

--- a/packages/extension/src/webview/managers/executionHandlers.ts
+++ b/packages/extension/src/webview/managers/executionHandlers.ts
@@ -11,7 +11,7 @@ import {
 } from '@common/teams/TeamPlan';
 import { prepareMainViewExecutionLaunch } from '@controllers/mainView/backend/MainViewExecutionLaunchController';
 import { logErrorMessage } from '@frontend/ui/errorHandlingUtils';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import type {
   FileOperationMessage,
@@ -21,6 +21,7 @@ import type {
 import { pathToLocation } from '@utils/files/fileLocation';
 
 const CHANNEL = 'ExecutionHandlers';
+const log = createLog(CHANNEL);
 
 type MessageFor<C extends MainViewInboundMessage['command']> = Extract<
   MainViewInboundMessage,
@@ -145,8 +146,7 @@ export function handleMultipleOperation(
 ): void {
   const inputFiles = message.inputFiles ?? [];
   const label = message.command.startsWith('pack') ? 'Packing' : 'Cleaning';
-  logger.info(
-    CHANNEL,
+  log.info(
     `${label} multiple files: ${message.inputFile}, ${inputFiles.join(', ')}`,
   );
   void vscode.commands.executeCommand(

--- a/src/test-kernel/commands/LatexdiffRunPreparation.vitest.ts
+++ b/src/test-kernel/commands/LatexdiffRunPreparation.vitest.ts
@@ -91,6 +91,12 @@ vi.mock('@latex/latexdiff/mathMarkup', () => ({
 }));
 
 vi.mock('@logger/logUtils', () => ({
+  createLog: (channel: string) => ({
+    warn: (message: string) => mocks.warn(channel, message),
+    debug: (message: string) => mocks.debug(channel, message),
+    info: (message: string) => mocks.info(channel, message),
+    error: (message: string) => mocks.error(channel, message),
+  }),
   warn: mocks.warn,
   debug: mocks.debug,
   info: mocks.info,

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -194,7 +194,12 @@ vi.mock('@agent/runtime/runAgent', () => ({
 
 vi.mock('@logger/logUtils', () => ({
   createChannelWriter: () => () => {},
-  createLog: () => ({ warn: () => {} }),
+  createLog: () => ({
+    warn: () => {},
+    error: mocks.logError,
+    info: () => {},
+    debug: () => {},
+  }),
   initialize: () => {},
   error: mocks.logError,
   warn: () => {},

--- a/src/test-kernel/frontend/OpenBuildDisplay.vitest.ts
+++ b/src/test-kernel/frontend/OpenBuildDisplay.vitest.ts
@@ -57,6 +57,12 @@ vi.mock('@frontend/ui/errorHandlingUtils', () => ({
 }));
 
 vi.mock('@logger/logUtils', () => ({
+  createLog: (channel: string) => ({
+    debug: vi.fn(),
+    info: (message: string) => mocks.info(channel, message),
+    warn: (message: string) => mocks.warn(channel, message),
+    error: (message: string) => mocks.error(channel, message),
+  }),
   warn: mocks.warn,
   error: mocks.error,
   info: mocks.info,

--- a/src/test-kernel/frontend/RecordingManager.vitest.ts
+++ b/src/test-kernel/frontend/RecordingManager.vitest.ts
@@ -25,6 +25,12 @@ vi.mock('@frontend/ui/errorHandlingUtils', () => ({
 }));
 
 vi.mock('@logger/logUtils', () => ({
+  createLog: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
   error: vi.fn(),
   initialize: vi.fn(),
 }));

--- a/src/test-kernel/frontend/agents/AgentDirectoryWatchers.vitest.ts
+++ b/src/test-kernel/frontend/agents/AgentDirectoryWatchers.vitest.ts
@@ -100,6 +100,12 @@ vi.mock('@frontend/ui/dialogs', () => ({
 }));
 
 vi.mock('@logger/logUtils', () => ({
+  createLog: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
   debug: vi.fn(),
   info: vi.fn(),
   warn: vi.fn(),

--- a/src/test-kernel/webview/ExecutionHandlers.vitest.ts
+++ b/src/test-kernel/webview/ExecutionHandlers.vitest.ts
@@ -56,7 +56,15 @@ vi.mock(
 vi.mock('@frontend/ui/errorHandlingUtils', () => ({
   logErrorMessage: vi.fn(),
 }));
-vi.mock('@logger/logUtils', () => ({ info: vi.fn() }));
+vi.mock('@logger/logUtils', () => ({
+  createLog: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+  info: vi.fn(),
+}));
 vi.mock('@utils/files/fileLocation', () => ({
   pathToLocation: mocks.pathToLocation,
 }));


### PR DESCRIPTION
## Summary

Collision-free mechanical subset of #10013 for `packages/extension`. Re-audited every currently open PR and enumerated the 31 production `packages/extension` files with `import * as logger from '@logger/logUtils'`; this PR converts the 24 files whose logger channel is a module constant, a narrow function parameter, or an instance channel, while explicitly leaving the 7 special/manual files for a later wave.

Each converted site binds `createLog(channel)` once and calls `log.debug/info/warn/error(...)` with the same level, message, `data`, and evaluation timing as before. The binding shape follows the channel's ownership: module-level `const log` for fixed channels, function-entry `const log` for threaded channels, a readonly field for a literal instance channel, or a constructor-bound readonly field for a constructor-derived instance channel. `createLog` still delegates through `loggerSelf`, so the module-namespace spy seam (`vi.spyOn(logger, 'warn')`) keeps intercepting calls made through these bindings.

Refs #10013 (not Closes — this is one batch; the special/manual files remain).

## Converted to `createLog` (24 files)

- `packages/extension/src/commands/files/fileSelectionCommands.ts`
- `packages/extension/src/commands/git/gitCommands.ts`
- `packages/extension/src/commands/housekeeping/cleanCommands.ts`
- `packages/extension/src/commands/latex/arXivCommands.ts`
- `packages/extension/src/commands/latex/compareCommands.ts`
- `packages/extension/src/commands/latex/figCommands.ts`
- `packages/extension/src/commands/latex/latexCommands.ts`
- `packages/extension/src/commands/latex/latexdiffCommands.ts`
- `packages/extension/src/commands/setup/setupAssistantCommand.ts`
- `packages/extension/src/commands/taskFormState/stateRestoreCommand.ts`
- `packages/extension/src/common/webview/BaseViewContentProvider.ts`
- `packages/extension/src/frontend/agents/AgentDirectoryManager.ts`
- `packages/extension/src/frontend/editor/activeFileGuards.ts`
- `packages/extension/src/frontend/events/agentEventListeners.ts`
- `packages/extension/src/frontend/git/resolveGitRoot.ts`
- `packages/extension/src/frontend/latex/openBuild.ts`
- `packages/extension/src/frontend/media/RecordingManager.ts`
- `packages/extension/src/frontend/review/AgentReviewService.ts`
- `packages/extension/src/frontend/ui/errorHandlingUtils.ts`
- `packages/extension/src/frontend/ui/instruction.ts`
- `packages/extension/src/frontend/vscode/texraConfig.ts`
- `packages/extension/src/webview/managers/DiffManager.ts`
- `packages/extension/src/webview/managers/InstructionManager.ts`
- `packages/extension/src/webview/managers/executionHandlers.ts`

## Exact exclusions (later special wave)

- `packages/extension/src/common/webview/BaseViewMessageHandler.ts` — stores `typeof logger` as an injectable field.
- `packages/extension/src/webview/mainViewInboundContext.ts` — stores `typeof logger`.
- `packages/extension/src/frontend/auth/SupabaseAuthProvider.ts` — passes `logger` namespace as `log` value.
- `packages/extension/src/frontend/setup.ts` — passes level writers into a logger object.
- `packages/extension/src/frontend/vscode/sharedStorageRoot.ts` — passes `logger` into a migration logger.
- `packages/extension/src/extension.ts` — owns `setOutputChannelFactory`.
- `packages/extension/src/webview/managers/FileManager.ts` — method-reference `logFn = logger.info/warn`; also overlaps open PR #10688.

Open-PR overlap audit (6 open PRs at time of audit): #10699 touches `packages/extension/src/commands/agent/resumeFromResumeData.ts` (not in the 31); #10688 touches `packages/extension/src/webview/managers/FileManager.ts` (already excluded) plus two non-31 files; #10683 touches `packages/extension/src/settingsView/SettingsViewMessageHandler.ts` (not in the 31); #10704/#10702/#10697 have no `packages/extension` overlap. No file touched by an open PR is modified here.

## Remaining `import * as logger` in `packages/extension` after this wave

The 7 exclusions above (7 files). Census before: 31; converted: 24; remaining: 7.

## Net elements (R6)

- Files changed: **30** (24 production, 6 existing test mocks minimally migrated)
- Diffstat: **30 files changed, 170 insertions(+), 175 deletions(-), net −5**
- Exported symbols changed: **0**
- Classes/interfaces/enums added/deleted: **0**
- New test cases added: **0**

## Consumer counts (R8)

n/a — no exported symbol, emit path, or key is deleted or re-routed. The only change is per-module logger wiring onto `createLog`, which keeps the shared `writeLine` sink and the `loggerSelf` per-call namespace delegation that existing spies rely on. Six existing `vi.mock('@logger/logUtils', ...)` factories were minimally migrated to provide `createLog` (and, where an assertion pinned the channel-first namespace shape or a migrated module needs the error level, forward the bound channel/levels), preserving the same spy and channel assertions without adding coverage.

## Validation

- Affected extension suites: 10 files / 54 tests passed
  (`OpenBuildDisplay`, `RecordingManager`, `AgentDirectoryWatchers`, `ResolveGitRoot`, `ExecutionHandlers`, `MainViewMessageHandler`, `LatexdiffRunPreparation`, `SetupAssistantRouting`, `AgentPresentationHostReplayGate`, `ExtensionTexraConfig`).
- Follow-up focused suite after mock completion: `SetupAssistantRouting` 5/5 passed.
- Architecture suites: 17 files / 101 tests passed.
- `typecheck:workspace` — passed.
- `typecheck:test-kernel` — passed.
- `eslint` over the branch-changed files — passed.
- `prettier --check` over the branch-changed files — passed.
- `git diff --check` — passed.
- `check:dead-code-ratchet` — passed (8 current vs 8 baselined; no new dead code).
- `check:guidance-refs` — passed.
- `check:extension-package-invariants` — passed.
- Review-fix follow-ups: `DiffManager` field-bound log, `BaseViewContentProvider` constructor-bound log, and `SetupAssistantRouting` `createLog` error-level mock were each re-validated with focused typecheck/eslint/prettier plus the relevant suite.

`check:dead-code` (raw knip) still reports the pre-existing 2 unused files and 6 unused exports (all in `packages/desktop` / `packages/trace-viewer`; none in this PR) and exits non-zero; the ratchet confirms this PR adds none.
