### PR TITLE
refactor(logger): migrate extension's six special namespace-logger contracts

### DIFF
--- a/packages/extension/src/common/webview/BaseViewMessageHandler.ts
+++ b/packages/extension/src/common/webview/BaseViewMessageHandler.ts
@@ -10,6 +10,30 @@ import {
   type HandlerRegistry,
 } from '@shared/utils/dispatcher';
 
+/** The channel-first logging surface this view and its subclasses use. */
+type ViewMessageLogger = {
+  debug: (
+    channel: string,
+    message: string,
+    options?: logger.LogUtilsOptions,
+  ) => void;
+  info: (
+    channel: string,
+    message: string,
+    options?: logger.LogUtilsOptions,
+  ) => void;
+  warn: (
+    channel: string,
+    message: string,
+    options?: logger.LogUtilsOptions,
+  ) => void;
+  error: (
+    channel: string,
+    message: string,
+    options?: logger.LogUtilsOptions,
+  ) => void;
+};
+
 type CommandMessage = { command: string };
 
 /** Type guard to check if a message has a command field */
@@ -32,7 +56,7 @@ function isCommandMessage(
 export abstract class BaseViewMessageHandler<
   T extends vscode.WebviewView | vscode.WebviewPanel = vscode.WebviewView,
 > {
-  protected readonly logger: typeof logger;
+  protected readonly logger: ViewMessageLogger;
   protected readonly channel: string;
 
   /**
@@ -44,6 +68,11 @@ export abstract class BaseViewMessageHandler<
   constructor(protected readonly viewName: string) {
     this.logger = logger;
     this.channel = `${viewName}MessageHandler`;
+  }
+
+  /** Channel-bound log for this handler's own inbound diagnostics. */
+  private get log() {
+    return logger.createLog(this.channel);
   }
 
   /**
@@ -107,24 +136,24 @@ export abstract class BaseViewMessageHandler<
     let unsupported = false;
     const handled = dispatcher(message, handlers, (error) => {
       if (error instanceof ZodError) {
-        this.logger.debug(this.channel, 'Message validation failed', {
+        this.log.debug('Message validation failed', {
           data: error,
         });
       } else if (error instanceof UnsupportedCommandError) {
         // Declared `unsupported(...)` in this host's registry: visible
         // feedback (toast), not a silent drop or an error-level log.
         unsupported = true;
-        this.logger.debug(this.channel, error.message);
+        this.log.debug(error.message);
         void vscode.window.showInformationMessage(error.reason);
       } else {
-        this.logger.error(this.channel, 'Error handling message', {
+        this.log.error('Error handling message', {
           data: error,
         });
       }
     });
 
     if (!handled && !unsupported && isCommandMessage(message)) {
-      this.logger.warn(this.channel, `Unhandled command: ${message.command}`);
+      this.log.warn(`Unhandled command: ${message.command}`);
     }
   }
 

--- a/packages/extension/src/common/webview/BaseViewMessageHandler.ts
+++ b/packages/extension/src/common/webview/BaseViewMessageHandler.ts
@@ -58,6 +58,7 @@ export abstract class BaseViewMessageHandler<
 > {
   protected readonly logger: ViewMessageLogger;
   protected readonly channel: string;
+  private readonly log: ReturnType<typeof logger.createLog>;
 
   /**
    * Active webview reference, tracked on every dispatch. Subclasses access it
@@ -68,11 +69,7 @@ export abstract class BaseViewMessageHandler<
   constructor(protected readonly viewName: string) {
     this.logger = logger;
     this.channel = `${viewName}MessageHandler`;
-  }
-
-  /** Channel-bound log for this handler's own inbound diagnostics. */
-  private get log() {
-    return logger.createLog(this.channel);
+    this.log = logger.createLog(this.channel);
   }
 
   /**

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -68,7 +68,7 @@ import { migrateLegacyVscodeStorage } from '@frontend/vscode/sharedStorageRoot';
 import { VscodeSecrets } from '@frontend/vscode/vscodeSecrets';
 import { createExtensionTexraConfig } from '@frontend/vscode/texraConfig';
 import { createTexraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
-import * as logger from '@logger/logUtils';
+import { createLog, setOutputChannelFactory } from '@logger/logUtils';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
 import { invalidateRuntimeModelRegistry } from '@model/runtimeModelRegistry';
@@ -113,6 +113,9 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 // Local file imports
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
 import { registerCommands } from './commands';
+
+const log = createLog('extension');
+const authLog = createLog('SupabaseAuthProvider');
 
 let statusBarItem: vscode.StatusBarItem | undefined;
 let apiKeyStatusBarItem: vscode.StatusBarItem | undefined;
@@ -181,14 +184,12 @@ export async function activate(context: vscode.ExtensionContext) {
   const gitRepoRoot = await resolveGitCommonRoot(workspaceRoot);
 
   agentDirectories.initialize(context);
-  logger.setOutputChannelFactory((name) =>
-    vscode.window.createOutputChannel(name),
-  );
+  setOutputChannelFactory((name) => vscode.window.createOutputChannel(name));
   initializeBundledPrompts(path.join(context.extensionPath, 'resources'));
   initializeStateManagers(context, gitRepoRoot);
   const lifecycle = createLifecycleHost({
     onError: (phase, error) =>
-      logger.error('extension', `Lifecycle ${phase} handler failed`, {
+      log.error(`Lifecycle ${phase} handler failed`, {
         data: error,
       }),
   });
@@ -230,7 +231,7 @@ export async function activate(context: vscode.ExtensionContext) {
     languageModel,
     toolMissingHandler: async (message, openDocsCommand) => {
       const actions = openDocsCommand ? ['View Installation Guide'] : [];
-      logger.error('extension', message);
+      log.error(message);
       const choice = await vscode.window.showErrorMessage(message, ...actions);
       if (choice === 'View Installation Guide' && openDocsCommand) {
         const [command, ...args] = openDocsCommand.split(',');
@@ -345,8 +346,7 @@ export async function activate(context: vscode.ExtensionContext) {
         hasRunHistory,
       });
     } catch (err) {
-      logger.warn(
-        'extension',
+      log.warn(
         `Onboarding firstRunDone backfill failed: ${toErrorMessage(err)}`,
       );
     }
@@ -363,16 +363,10 @@ export async function activate(context: vscode.ExtensionContext) {
       try {
         await loadAgents({ includeRemote: false });
         void loadAgents().catch((err) => {
-          logger.warn(
-            'extension',
-            `Remote agent refresh failed: ${toErrorMessage(err)}`,
-          );
+          log.warn(`Remote agent refresh failed: ${toErrorMessage(err)}`);
         });
       } catch (err) {
-        logger.error(
-          'extension',
-          `Failed to initialize agent index: ${toErrorMessage(err)}`,
-        );
+        log.error(`Failed to initialize agent index: ${toErrorMessage(err)}`);
       }
     })(),
     (async () => {
@@ -388,12 +382,11 @@ export async function activate(context: vscode.ExtensionContext) {
         } = await refreshModelListStateIfNeeded(globalSM);
         if (!skipped) {
           if (previousVersion !== currentVersion) {
-            logger.info(
-              'extension',
+            log.info(
               `Model list version changed (${previousVersion ?? 'none'} -> ${currentVersion}), updating model list`,
             );
           }
-          logger.info('extension', 'Model list refresh completed successfully');
+          log.info('Model list refresh completed successfully');
           if (
             added.length > 0 ||
             removed.length > 0 ||
@@ -402,24 +395,19 @@ export async function activate(context: vscode.ExtensionContext) {
           ) {
             invalidateModelOptionsCache();
             if (added.length > 0 || removed.length > 0 || reordered) {
-              logger.info(
-                'extension',
+              log.info(
                 `Refreshed enabled models: added [${added.join(', ')}], removed [${removed.join(', ')}]${reordered ? ', reordered' : ''}`,
               );
             }
             if (routePreferencesCleared.length > 0) {
-              logger.info(
-                'extension',
+              log.info(
                 `Cleared stale Copilot route preferences: [${routePreferencesCleared.join(', ')}]`,
               );
             }
           }
         }
       } catch (err) {
-        logger.error(
-          'extension',
-          `Failed to refresh model list: ${toErrorMessage(err)}`,
-        );
+        log.error(`Failed to refresh model list: ${toErrorMessage(err)}`);
       }
     })(),
   ]);
@@ -442,8 +430,7 @@ export async function activate(context: vscode.ExtensionContext) {
     });
 
     if (!isSupabaseConfigured()) {
-      logger.warn(
-        'extension',
+      log.warn(
         'Supabase authentication is enabled but credentials are not configured. Please configure credentials in src/auth/config.ts before building.',
       );
     } else {
@@ -463,8 +450,7 @@ export async function activate(context: vscode.ExtensionContext) {
             await vscode.commands
               .executeCommand('texra.auth.signIn')
               .then(undefined, (err: unknown) =>
-                logger.error(
-                  'SupabaseAuthProvider',
+                authLog.error(
                   `Failed to trigger sign-in: ${toErrorMessage(err)}`,
                 ),
               );
@@ -484,7 +470,7 @@ export async function activate(context: vscode.ExtensionContext) {
       context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
       authProvider.setUriHandler(uriHandler);
 
-      logger.info('extension', 'Supabase authentication provider registered');
+      log.info('Supabase authentication provider registered');
 
       try {
         const extensionVersion =
@@ -499,8 +485,7 @@ export async function activate(context: vscode.ExtensionContext) {
           dispose: () => void UsageLogService.dispose(),
         });
       } catch (usageError) {
-        logger.warn(
-          'extension',
+        log.warn(
           `Usage logging service failed to initialize: ${toErrorMessage(usageError)}`,
         );
       }
@@ -509,8 +494,7 @@ export async function activate(context: vscode.ExtensionContext) {
     const initError =
       error instanceof Error ? error : new Error(toErrorMessage(error));
     SupabaseClient.setInitError(initError);
-    logger.error(
-      'extension',
+    log.error(
       `Failed to initialize Supabase authentication: ${toErrorMessage(error)}`,
     );
   }
@@ -522,7 +506,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   await progressViewProvider.initialize();
 
-  logger.info('extension', 'TeXRA extension activated');
+  log.info('TeXRA extension activated');
 
   // Deferred off the activation tick: extendEnvPath() inside performs
   // synchronous glob probes of TeX install directories, which would
@@ -565,8 +549,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // fire-and-forget async work through this helper to log rejections
   // instead of letting them become unhandled promise rejections.
   const logRefreshFailure = (trigger: string) => (err: unknown) => {
-    logger.error(
-      'extension',
+    log.error(
       `Tool availability refresh failed (${trigger}): ${toErrorMessage(err)}`,
     );
   };
@@ -597,7 +580,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const disposeGitHubAuthListener = appSignals.on(
     'githubTokenInvalid',
     ({ message }) => {
-      logger.error('extension', `GitHub token rejected: ${message}`);
+      log.error(`GitHub token rejected: ${message}`);
       void vscode.window
         .showErrorMessage(
           `GitHub token rejected: ${message}`,
@@ -644,10 +627,7 @@ export async function activate(context: vscode.ExtensionContext) {
     apiKeyStatusRefreshQueue.add(refreshApiKeyStatus) as Promise<void>;
   const safeRefreshApiKeyStatus = () =>
     queueApiKeyStatusRefresh().catch((err) =>
-      logger.error(
-        'extension',
-        `API key status refresh failed: ${toErrorMessage(err)}`,
-      ),
+      log.error(`API key status refresh failed: ${toErrorMessage(err)}`),
     );
   void safeRefreshApiKeyStatus();
   // Without these listeners the pill stayed on "Get Started" forever after
@@ -754,10 +734,7 @@ export async function activate(context: vscode.ExtensionContext) {
       // recompute too: the State 0 card has no other signal when a key is
       // added outside the main view's own round-trip.
       await mainViewProvider.refreshOnboardingFunnel().catch((err) => {
-        logger.warn(
-          'extension',
-          `Onboarding funnel refresh failed: ${toErrorMessage(err)}`,
-        );
+        log.warn(`Onboarding funnel refresh failed: ${toErrorMessage(err)}`);
       });
     }),
   );

--- a/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
+++ b/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
@@ -67,11 +67,17 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       },
       log: {
         warn: (source, message, options) =>
-          logger.warn(source, message, options),
+          options === undefined
+            ? logger.warn(source, message)
+            : logger.warn(source, message, options),
         error: (source, message, options) =>
-          logger.error(source, message, options),
+          options === undefined
+            ? logger.error(source, message)
+            : logger.error(source, message, options),
         info: (source, message, options) =>
-          logger.info(source, message, options),
+          options === undefined
+            ? logger.info(source, message)
+            : logger.info(source, message, options),
       },
     });
     SupabaseAuthProvider.instance = this;

--- a/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
+++ b/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
@@ -25,6 +25,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { SupabaseUriHandler } from './UriHandler';
 
 const CHANNEL = 'SupabaseAuthProvider';
+const log = logger.createLog(CHANNEL);
 
 const AUTH_URI_HANDLER_NOT_INITIALIZED =
   'OAuth handler not initialized. Restart the extension.';
@@ -64,7 +65,14 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
           throw new Error(AUTH_URI_HANDLER_NOT_INITIALIZED);
         }
       },
-      log: logger,
+      log: {
+        warn: (source, message, options) =>
+          logger.warn(source, message, options),
+        error: (source, message, options) =>
+          logger.error(source, message, options),
+        info: (source, message, options) =>
+          logger.info(source, message, options),
+      },
     });
     SupabaseAuthProvider.instance = this;
   }
@@ -140,25 +148,19 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
       if (!result.success) {
         if (result.isAuthError) {
-          logger.error(CHANNEL, `Sign-in failed: ${result.error}`);
+          log.error(`Sign-in failed: ${result.error}`);
           this.notifier.showError(`Sign-in failed: ${result.error}`);
         } else {
-          logger.debug(CHANNEL, `Auth callback ignored: ${result.error}`);
+          log.debug(`Auth callback ignored: ${result.error}`);
         }
         return;
       }
 
       await this.storeSession(result.session);
       this.notifier.showInfo(`Signed in as ${result.session.account.label}`);
-      logger.info(
-        CHANNEL,
-        `Late sign-in successful for ${result.session.account.label}`,
-      );
+      log.info(`Late sign-in successful for ${result.session.account.label}`);
     } catch (error) {
-      logger.error(
-        CHANNEL,
-        `Error processing auth callback: ${toErrorMessage(error)}`,
-      );
+      log.error(`Error processing auth callback: ${toErrorMessage(error)}`);
       this.notifier.showError(`Sign-in failed: ${toErrorMessage(error)}`);
     } finally {
       this.isProcessingCallback = false;
@@ -202,7 +204,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
       return [this.toVSCodeSession(session)];
     } catch (error) {
-      logger.error(CHANNEL, `Error loading session: ${toErrorMessage(error)}`);
+      log.error(`Error loading session: ${toErrorMessage(error)}`);
       return [];
     }
   }
@@ -227,7 +229,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   private async buildOAuthOptions(): Promise<{ redirectTo: string }> {
     if (vscode.env.uiKind === vscode.UIKind.Web) {
       const callbackInfo = await getExternalAuthCallbackInfo();
-      logger.info(CHANNEL, `OAuth callback URI (web): ${callbackInfo.fullUrl}`);
+      log.info(`OAuth callback URI (web): ${callbackInfo.fullUrl}`);
       // In Codespaces/web the tunnel routing token must ride on redirect_to
       // (fullUrl already carries ?state=TUNNEL). Passing it as queryParams.state
       // instead overwrites GoTrue's own OAuth state on /authorize, which makes
@@ -248,7 +250,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     const redirectTo =
       `${AUTH_BRIDGE_URL}/${encodeURIComponent(vscode.env.uriScheme)}` +
       `/${encodeURIComponent(getExtensionId())}`;
-    logger.info(CHANNEL, `OAuth callback URI (desktop): ${redirectTo}`);
+    log.info(`OAuth callback URI (desktop): ${redirectTo}`);
     return { redirectTo };
   }
 
@@ -389,7 +391,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     invalidateModelOptionsCache();
     await refreshRemoteAgentCatalogAfterSignOut(
       invalidateRemoteAgentsAfterSignOut,
-      (message) => logger.warn(CHANNEL, message),
+      (message) => log.warn(message),
     );
     this._onDidChangeSessions.fire({
       added: [],
@@ -443,8 +445,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
           if (!result.success) {
             if (result.error === 'Missing authorization code in callback') {
-              logger.error(
-                CHANNEL,
+              log.error(
                 `Missing authorization code in OAuth callback. Has query: ${!!uri.query}`,
               );
             }
@@ -454,8 +455,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
           resolve(result.session);
         } catch (error) {
-          logger.error(
-            CHANNEL,
+          log.error(
             `Error processing OAuth callback: ${toErrorMessage(error)}`,
           );
           reject(error);

--- a/packages/extension/src/frontend/setup.ts
+++ b/packages/extension/src/frontend/setup.ts
@@ -10,12 +10,14 @@ import {
 import { globalSM } from '@common/state';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { promptExtensionInstall } from '@frontend/ui/instruction';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latexToolchain';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { registerExternalRoot } from '@utils/files/externalRoots';
 import { extendEnvPath } from '@utils/system/platformPaths';
+
+const log = createLog('extension');
 
 /**
  * Reconciles bundled agents in global storage from packaged resources.
@@ -39,18 +41,15 @@ export async function copyDefaultAgents(
         globalSM.update(GlobalStateKey.LAST_KNOWN_VERSION, version),
     },
     logger: {
-      info: (message, data) => logger.info('extension', message, { data }),
-      warn: (message, data) => logger.warn('extension', message, { data }),
+      info: (message, data) => log.info(message, { data }),
+      warn: (message, data) => log.warn(message, { data }),
     },
   });
 
   try {
     await sync.reconcile(currentVersion);
   } catch (err) {
-    logger.error(
-      'extension',
-      `Error copying default agents: ${toErrorMessage(err)}`,
-    );
+    log.error(`Error copying default agents: ${toErrorMessage(err)}`);
   }
 }
 
@@ -108,8 +107,7 @@ export async function registerAgentDirectoryRoots(
       try {
         await register();
       } catch (err) {
-        logger.error(
-          'extension',
+        log.error(
           `Failed to register agent directory root: ${toErrorMessage(err)}`,
         );
       }
@@ -127,10 +125,7 @@ export async function refreshCustomAgentRoot(): Promise<void> {
     const custom = await agentDirectories.custom();
     registerExternalRoot(custom, CUSTOM_AGENT_ROOT_OPTIONS);
   } catch (err) {
-    logger.error(
-      'extension',
-      `Failed to refresh custom agents root: ${toErrorMessage(err)}`,
-    );
+    log.error(`Failed to refresh custom agents root: ${toErrorMessage(err)}`);
   }
 }
 
@@ -145,11 +140,10 @@ export async function initializeLatexSupport(): Promise<void> {
     const extendedPath = extendEnvPath(process.env.PATH);
     if (extendedPath !== process.env.PATH) {
       process.env.PATH = extendedPath;
-      logger.info('extension', 'Extended process PATH with TeX directories');
+      log.info('Extended process PATH with TeX directories');
     }
   } catch (err) {
-    logger.warn(
-      'extension',
+    log.warn(
       `Failed to extend PATH with TeX directories: ${toErrorMessage(err)}`,
     );
   }
@@ -163,10 +157,7 @@ export async function initializeLatexSupport(): Promise<void> {
       // prompted to install a TeX extension they don't need. They'll still
       // discover it via the LaTeX settings tab or compile errors later.
       if (await workspaceContainsLatexFiles()) {
-        logger.info(
-          'extension',
-          'LaTeX Workshop extension not found, prompting installation',
-        );
+        log.info('LaTeX Workshop extension not found, prompting installation');
         await promptExtensionInstall({
           suppressKey: 'latex-workshop-install',
           message:
@@ -177,10 +168,7 @@ export async function initializeLatexSupport(): Promise<void> {
       }
     }
   } catch (err) {
-    logger.error(
-      'extension',
-      `Error initializing LaTeX support: ${toErrorMessage(err)}`,
-    );
+    log.error(`Error initializing LaTeX support: ${toErrorMessage(err)}`);
   }
 }
 

--- a/packages/extension/src/frontend/vscode/sharedStorageRoot.ts
+++ b/packages/extension/src/frontend/vscode/sharedStorageRoot.ts
@@ -57,10 +57,7 @@ export async function migrateLegacyVscodeStorage(
   context: vscode.ExtensionContext,
   storage: StorageProvider,
 ): Promise<void> {
-  const migrationLogger = {
-    info: (message: string) => log.info(message),
-    warn: (message: string) => log.warn(message),
-  };
+  const migrationLogger = { info: log.info, warn: log.warn };
   async function migrateBucket(
     getSourcePath: () => string | undefined,
     getTargetPath: () => string,

--- a/packages/extension/src/frontend/vscode/sharedStorageRoot.ts
+++ b/packages/extension/src/frontend/vscode/sharedStorageRoot.ts
@@ -21,7 +21,7 @@ import {
   EXTERNAL_INQUIRY_THREADS_DIR,
   WORKSPACE_STORAGE_LAYOUT,
 } from '@common/storage/storageLayout';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { StorageProvider } from '@platform/interfaces';
 import {
   mergeLegacyStorageBucket,
@@ -38,6 +38,8 @@ type BucketMigration = (
     readonly logger: LegacyDataMigrationLogger;
   },
 ) => Promise<void>;
+
+const log = createLog('extension');
 
 const mergeTaskRuns: BucketMigration = (sourcePath, targetPath, options) =>
   mergeLegacyStorageBucket(sourcePath, targetPath, {
@@ -56,8 +58,8 @@ export async function migrateLegacyVscodeStorage(
   storage: StorageProvider,
 ): Promise<void> {
   const migrationLogger = {
-    info: (message: string) => logger.info('extension', message),
-    warn: (message: string) => logger.warn('extension', message),
+    info: (message: string) => log.info(message),
+    warn: (message: string) => log.warn(message),
   };
   async function migrateBucket(
     getSourcePath: () => string | undefined,

--- a/packages/extension/src/webview/mainViewInboundContext.ts
+++ b/packages/extension/src/webview/mainViewInboundContext.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 import { RecordingManager } from '@frontend/media/RecordingManager';
-import * as logger from '@logger/logUtils';
+import type { LogUtilsOptions } from '@logger/logUtils';
 
 import type { DiffManager } from './managers/DiffManager';
 import type { FileManager } from './managers/FileManager';
@@ -16,7 +16,13 @@ import type { InstructionManager } from './managers/InstructionManager';
 export interface MainViewInboundHost {
   readonly viewName: string;
   readonly channel: string;
-  readonly logger: typeof logger;
+  readonly logger: {
+    debug: (
+      channel: string,
+      message: string,
+      options?: LogUtilsOptions,
+    ) => void;
+  };
   readonly context: vscode.ExtensionContext;
   /**
    * Recompute and re-push the onboarding funnel (owned by

--- a/src/test-kernel/frontend/SharedStorageRoot.vitest.ts
+++ b/src/test-kernel/frontend/SharedStorageRoot.vitest.ts
@@ -16,8 +16,10 @@ vi.mock('@platform/defaults/legacyDataMigration', () => ({
   mergeLegacyWorkspaceStorageBucket: mocks.mergeLegacyWorkspaceStorageBucket,
 }));
 vi.mock('@logger/logUtils', () => ({
-  info: vi.fn(),
-  warn: mocks.warn,
+  createLog: (channel: string) => ({
+    info: vi.fn(),
+    warn: (message: string) => mocks.warn(channel, message),
+  }),
 }));
 
 // Local imports - extension


### PR DESCRIPTION
## Summary

Special wave of #10013 for `packages/extension`: migrates the six files that #10707 deferred because they store or pass the logger namespace as a value. Each module's own diagnostics now bind `createLog(channel)` once; the two remaining `import * as logger` namespace imports stay only as the channel-first value source for injectable/passed contracts, and those contracts are narrowed to the methods actually used instead of `typeof logger`.

Follow-up commit addresses all four review threads: the base handler's own `createLog` is bound once, the shared-storage migration logger uses direct `createLog` references, and the Supabase coordinator adapter keeps per-call namespace lookup while preserving exact call arity.

## Files and exact contracts

- `packages/extension/src/common/webview/BaseViewMessageHandler.ts`
  - `protected readonly logger: typeof logger` → `ViewMessageLogger` (channel-first `debug`/`info`/`warn`/`error`, matching the methods all three subclasses actually use).
  - The base's own `dispatchInbound` diagnostics now use a `private readonly log: ReturnType<typeof logger.createLog>` bound once in the constructor after `this.channel` is assigned.
  - The injectable `logger` field remains the namespace object only for subclasses that thread the channel (`MainViewMessageHandler`, `SettingsViewMessageHandler`, `ProgressViewMessageHandler`), so the `vi.spyOn(logger, 'warn')` namespace seam still intercepts.
- `packages/extension/src/webview/mainViewInboundContext.ts`
  - `readonly logger: typeof logger` → structural `{ debug(channel, message, options?) }`; the only methods main-view slices actually call are `debug` on `host.logger.debug(host.channel, ...)`.
  - `channel` is retained for the onboarding slice's `signInWithChatGptSubscription(host.channel)`.
- `packages/extension/src/frontend/auth/SupabaseAuthProvider.ts`
  - Own calls move from `logger.X(CHANNEL, ...)` to `const log = createLog('SupabaseAuthProvider')`.
  - The coordinator's `log: logger` value becomes a narrow `{ warn, error, info }` adapter. Each entry keeps the per-call namespace lookup (`logger.warn/error/info`) so a later `vi.spyOn(logger, ...)` still intercepts, and omits `options` when it is `undefined`, so the coordinator's two-argument calls remain exactly two-argument rather than gaining a trailing `undefined`. `debug` is omitted because the coordinator never calls it.
- `packages/extension/src/frontend/setup.ts`
  - `import * as logger` → `const log = createLog('extension')`; the `AgentDirectorySyncLogger` adapter (`info`/`warn` with `{ data }`) now delegates to `log.info`/`log.warn`, keeping identical options forwarding.
- `packages/extension/src/frontend/vscode/sharedStorageRoot.ts`
  - `import * as logger` → `const log = createLog('extension')`; the `LegacyDataMigrationLogger` adapter is now direct `{ info: log.info, warn: log.warn }` (the `createLog` closures resolve `loggerSelf` per call, so the spy seam is unchanged).
- `packages/extension/src/extension.ts`
  - `import { createLog, setOutputChannelFactory } from '@logger/logUtils'`; `const log = createLog('extension')` plus `const authLog = createLog('SupabaseAuthProvider')` for the one sign-in-prompt error that previously used that channel.
  - `setOutputChannelFactory` stays a named import and the activation-time factory call is unchanged.

## Exclusion

- `packages/extension/src/webview/managers/FileManager.ts` is intentionally left untouched: open PR #10688 already modifies it, and this wave stays disjoint from that PR.

## Open-PR overlap audit

All 8 open PRs were audited against the six targets. None touch these six files. The only `packages/extension` overlaps are #10707 (24 files + 5 tests, none of these six), #10699 (`resumeFromResumeData.ts`), #10688 (`FileManager.ts` + two non-extension files), and #10683 (`SettingsViewMessageHandler.ts`). No file touched by an open PR is modified here.

## Net elements (R6)

- Files changed: **7** (6 production, 1 existing test mock minimally migrated)
- Diffstat: **7 files changed, 109 insertions(+), 105 deletions(-), net +4**
- Exported symbols changed: **0**
- One protected member type narrowed: `BaseViewMessageHandler.logger` from `typeof logger` to `ViewMessageLogger` (plus the private `log` field and the private `type ViewMessageLogger` inside that file)
- Classes/interfaces/enums added/deleted: **0**
- New test cases added: **0** (the one test edit migrates the existing `@logger/logUtils` mock to provide `createLog` while preserving the same channel-first `warn` assertion)

## Consumer counts (R8)

No exported symbol, emit path, or key is deleted or re-routed. The six modules re-wire their own logging onto `createLog`, which still delegates through the shared `writeLine` sink and the `loggerSelf` per-call namespace seam that existing spies rely on. The Supabase coordinator adapter preserves exact call arity (two-argument calls stay two-argument) while keeping the per-call namespace lookup; the shared-storage migration logger uses direct `createLog` references whose closures resolve `loggerSelf` per call. The one migrated test mock keeps its `mocks.warn` assertion receiving `('extension', message)` by binding the mocked channel inside `createLog` — a one-for-one mock-shape migration, not new coverage.

## Validation

- Post-follow-up focused affected suites: **4 files / 38 tests passed** (`SharedStorageRoot`, `SupabaseAuthProvider`, `MainViewMessageHandler`, `ProgressViewOnboardingRefresh`).
- Earlier full affected sweep (pre-follow-up): **161 files / 1190 tests passed** (`src/test-kernel/{auth,frontend,webview,progressView,settings,commands}`).
- Architecture suites (rerun post-follow-up): **17 files / 101 tests passed**.
- `typecheck:workspace` — passed.
- `typecheck:test-kernel` — passed.
- `eslint` over the 7 changed files — passed.
- `prettier --check` over the 7 changed files — passed.
- `git diff --check` — passed.
- `check:dead-code-ratchet` — passed (8 current vs 8 baselined; no new dead code).
- `check:guidance-refs` — passed.
- `check:extension-package-invariants` — passed.

`check:dead-code` (raw knip) still reports the pre-existing 2 unused files and 6 unused exports (all in `packages/desktop` / `packages/trace-viewer`; none in this PR) plus the environment `VITE_WEBVIEW` error, and exits non-zero; the ratchet confirms this PR adds none.

## Caveats

- The two remaining `import * as logger` sites (`BaseViewMessageHandler.ts`, `SupabaseAuthProvider.ts`) are deliberate: they are the only way to keep a channel-first value that resolves through the module namespace at call time, preserving both the coordinator's `SupabaseSession` channel semantics and the existing `vi.spyOn(logger, ...)` seam. Removing them entirely would require either capturing named-import references (breaking the spy seam) or widening the shared/coordinator contracts (out of scope and touching non-extension hosts).
- External-worktree validation reused the main checkout's `node_modules` (root + `packages/{agent,cli,desktop,extension,trace-viewer}` symlinks) because the fresh worktree has no installed dependencies; no dependency or lockfile changes were made.

Refs #10013
