### PR TITLE
feat(settings): expose child-run concurrency budget in Multi-Agent tab

### DIFF
--- a/docs/proposals/2026-08-15-child-run-concurrency-budget.md
+++ b/docs/proposals/2026-08-15-child-run-concurrency-budget.md
@@ -1,7 +1,7 @@
 # One child-run concurrency budget
 
-Status: design note (Wave-4 prerequisite for item 4 of
-`2026-08-14-delegation-flow-substrate-consolidation.md`)
+Status: landed (see #10640). Originally a design note / Wave-4 prerequisite
+for item 4 of `2026-08-14-delegation-flow-substrate-consolidation.md`.
 Date: 2026-08-15
 
 ## The resource being budgeted
@@ -39,9 +39,9 @@ ruling is:
 - **Count-based, default 16.** High enough that real concurrent-workflow
   usage (double-digit simultaneous detached runs is normal operating
   practice here) never queues, low enough to stop a runaway recursive
-  fan-out from opening unbounded model conversations. v1 ships this as a
-  module constant; the user-facing core setting (Zod schema + native
-  settings view wiring) is recorded follow-up, not part of this change.
+  fan-out from opening unbounded model conversations. v1 shipped this as a
+  module constant; the user-facing core setting (Zod schema + native settings
+  view wiring) landed as follow-up #10640 (see "Landed implementation" below).
   Per-provider-key partitioning is **rejected** (maintainer ruling,
   2026-08-15: overengineering). The per-session count budget is the final
   shape; do not re-propose provider-key partitioning.
@@ -111,3 +111,23 @@ execution, and a queued launch aborts cleanly if its parent is cancelled
   overengineering; see the scope ruling above).
 - No cap on root runs or agent-CLI children.
 - No change to engine semaphore, lifetime call cap, or fan-out caps.
+
+## Landed implementation
+
+Issue #10640 lands the previously-cut user-facing setting:
+
+- Canonical key: `texra.childRunConcurrencyBudget`.
+- Default: 16; allowed range 1–100 (integer), validated by
+  `ChildRunConcurrencyBudgetSchema`.
+- Persistence: workspace-scoped `.texra/config.json` (the settings-view catalog
+  row omits `configTarget`, so the write path uses the workspace target).
+- Surface: the native VS Code/desktop settings view Multi-Agent tab only. The
+  CLI `/config` panel does not surface it, but the CLI still recognizes and
+  honors the key because the runtime reads it.
+- Runtime: `childRunBudgetFor` re-reads the configured value on every call and
+  live re-pins the session queue unless the caller explicitly pinned it with an
+  explicit `concurrency` argument (tracked by a `WeakSet`, so the existing
+  explicit test seams stay authoritative). Absent and invalid persisted values
+  both resolve to 16.
+- Provider-key partitioning remains rejected (maintainer ruling) — this
+  implementation is per-session count-based only.

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -156,6 +156,7 @@ export function createDesktopSettingsIpc(
       buildReliabilityAndOrchestrationMessage({
         workspaceState,
         globalState,
+        config: options.config,
         getReliabilitySettings: () => [],
       }),
     );

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -699,6 +699,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       buildReliabilityAndOrchestrationMessage({
         workspaceState: workspaceSM,
         globalState: globalSM,
+        config: platform().config,
         getReliabilitySettings: () =>
           this.profileController.getReliabilitySettings(),
       }),

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -68,6 +68,7 @@ import {
   bashApprovalEnabled,
   chatgptAuth,
   grokAuth,
+  childRunConcurrencyBudget,
   claudeAgentEffort,
   claudeAgentModel,
   claudeAgentPermissionMode,
@@ -79,6 +80,7 @@ import {
   customAgentDirIsDefault,
   customPresets,
   detachSubagentsOnStop,
+  multiAgentSettingsRevision,
   editApprovalEnabled,
   gitAuthorEmail,
   gitAuthorName,
@@ -429,16 +431,23 @@ export class SettingsApp extends SettingsAppBase {
             .unsupportedCommands=${unsupportedCommands.get()}
           ></agents-tab>
         `;
-      case 'multi-agent':
+      case 'multi-agent': {
+        // Touch the acknowledgement generation so a same-value rebroadcast
+        // after a rejected/failed write still re-renders this branch and lets
+        // live() restore the committed number-row value.
+        multiAgentSettingsRevision.get();
         return html`
           <multi-agent-tab
             .customPresets=${customPresets.get()}
             .orchestratorAgents=${orchestratorAgents.get()}
             .allowOrchestratorKill=${allowOrchestratorKill.get()}
             .detachSubagentsOnStop=${detachSubagentsOnStop.get()}
+            .childRunConcurrencyBudget=${childRunConcurrencyBudget.get()}
             .worktreeSupport=${gitWorktreeSupport.get()}
+            .ackGeneration=${multiAgentSettingsRevision.get()}
           ></multi-agent-tab>
         `;
+      }
       case 'tools':
         return html`
           <tools-tab

--- a/packages/extension/src/settingsView/frontend/components/profile/ReliabilitySettingsSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ReliabilitySettingsSection.ts
@@ -1,6 +1,5 @@
 /** Numeric reliability controls for long-running model sessions. */
 
-import '@awesome.me/webawesome/dist/components/input/input.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
@@ -11,11 +10,10 @@ import { commonViewStyles, designTokens } from '@shared/styles';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
 import type { NumberSetting } from '@shared/schemas';
-import { renderSettingsSectionHeading } from '@shared/wa/settingsSection';
-import { clampOptional } from '@utils/core';
-
-// Local imports - shared schemas
-import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
+import {
+  renderSettingsNumberRow,
+  renderSettingsSectionHeading,
+} from '@shared/wa/settingsSection';
 
 @customElement('reliability-settings-section')
 export class ReliabilitySettingsSection extends LitElement {
@@ -27,7 +25,7 @@ export class ReliabilitySettingsSection extends LitElement {
         display: block;
       }
 
-      .setting-input {
+      .setting-number-input {
         width: 80px;
       }
 
@@ -40,59 +38,25 @@ export class ReliabilitySettingsSection extends LitElement {
 
   @property({ attribute: false }) settings: NumberSetting[] = [];
 
-  private handleSettingChange(setting: NumberSetting, input: WaInput): void {
-    const parsed = Number(input.value);
-    if (Number.isNaN(parsed)) {
-      input.value = String(setting.value);
-      return;
-    }
-    const stepOrigin = setting.min ?? 0;
-    const stepped =
-      setting.step === undefined
-        ? parsed
-        : stepOrigin +
-          Math.round((parsed - stepOrigin) / setting.step) * setting.step;
-    const value = clampOptional(stepped, setting.min, setting.max);
-    if (value !== parsed) input.value = String(value);
-    postMessage(SETTINGS_VIEW_COMMANDS.SET_PROVIDER_SETTING, {
-      key: setting.key,
-      value,
-    });
-  }
-
   private renderSetting(setting: NumberSetting): TemplateResult {
-    // Real `<label for>` + host id: an aria-label on the wa-input host names
-    // the custom element, not the inner number control (see
-    // settingsSection.ts). `setting.key` is unique within this section.
-    const controlId = `reliability-setting-${setting.key}`;
-    return html`
-      <div class="settings-row">
-        <div class="settings-row-text">
-          <label class="settings-row-label" for=${controlId}
-            >${setting.label}</label
-          >
-          <span class="settings-row-help">${setting.description}</span>
-        </div>
-        <div class="settings-row-control">
-          <wa-input
-            id=${controlId}
-            class="setting-input"
-            type="number"
-            .value=${String(setting.value)}
-            min=${setting.min ?? nothing}
-            max=${setting.max ?? nothing}
-            step=${setting.step ?? nothing}
-            @change=${(event: Event) =>
-              this.handleSettingChange(setting, event.target as WaInput)}
-          ></wa-input>
-          ${
-            setting.unit
-              ? html`<span class="setting-unit">${setting.unit}</span>`
-              : nothing
-          }
-        </div>
-      </div>
-    `;
+    return renderSettingsNumberRow({
+      label: setting.label,
+      description: setting.description,
+      value: setting.value,
+      min: setting.min,
+      max: setting.max,
+      step: setting.step,
+      unit: setting.unit,
+      // Preserve this section's historical cleared-field behavior: an empty
+      // input is `Number('')` (0), then the shared step/clamp math runs and
+      // posts the resulting value rather than reverting.
+      revertOnEmpty: false,
+      onChange: (value) =>
+        postMessage(SETTINGS_VIEW_COMMANDS.SET_PROVIDER_SETTING, {
+          key: setting.key,
+          value,
+        }),
+    });
   }
 
   override render(): TemplateResult | typeof nothing {

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -54,6 +54,7 @@ import type {
 } from '@shared/schemas';
 import {
   AGENT_SKILLS_ENABLED_DEFAULT,
+  CHILD_RUN_CONCURRENCY_BUDGET_SETTING,
   byCategory,
   CLAUDE_AGENT_DEFAULT_EFFORT,
   CLAUDE_AGENT_DEFAULT_MODEL,
@@ -185,6 +186,17 @@ export const orchestratorAgents = trackedSignal<string[]>(() => []);
 export const reliabilitySettings = trackedSignal<NumberSetting[]>(() => []);
 export const allowOrchestratorKill = trackedSignal(() => true);
 export const detachSubagentsOnStop = trackedSignal(() => false);
+export const childRunConcurrencyBudget = trackedSignal<number>(
+  () => CHILD_RUN_CONCURRENCY_BUDGET_SETTING.defaultValue,
+);
+/**
+ * Monotonic acknowledgement generation for the multi-agent payload. Incremented
+ * on every outbound multi-agent settings message — including a rebroadcast that
+ * carries the same values after a rejected/failed write — so SettingsApp
+ * re-renders the Multi-Agent branch and `live()` can restore the acknowledged
+ * committed value on the number input.
+ */
+export const multiAgentSettingsRevision = trackedSignal<number>(() => 0);
 
 // ---------------------------------------------------------------------------
 // Approval and tool-safety settings state

--- a/packages/extension/src/settingsView/frontend/slices/miscSettingsSlice.ts
+++ b/packages/extension/src/settingsView/frontend/slices/miscSettingsSlice.ts
@@ -11,9 +11,11 @@ import type { SettingsViewOutboundHandlerRegistry } from '@shared/schemas';
 import {
   agentSkillsEnabled,
   allowOrchestratorKill,
+  childRunConcurrencyBudget,
   customPresets,
   detachSubagentsOnStop,
   goalItems,
+  multiAgentSettingsRevision,
   orchestratorAgents,
   reliabilitySettings,
   telemetryEnabled,
@@ -58,5 +60,7 @@ export const multiAgentHandlers = {
     reliabilitySettings.set(data.reliabilitySettings);
     allowOrchestratorKill.set(data.allowOrchestratorKill);
     detachSubagentsOnStop.set(data.detachSubagentsOnStop);
+    childRunConcurrencyBudget.set(data.childRunConcurrencyBudget);
+    multiAgentSettingsRevision.set(multiAgentSettingsRevision.get() + 1);
   },
 } satisfies Partial<SettingsViewOutboundHandlerRegistry>;

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -14,16 +14,27 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 // Local imports - shared webview
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
-import { AGENT_MODE_PRESETS, type AgentModePreset } from '@shared/schemas';
+import {
+  AGENT_MODE_PRESETS,
+  CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY,
+  CHILD_RUN_CONCURRENCY_BUDGET_SETTING,
+  type AgentModePreset,
+} from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
-import { renderSettingsSectionHeading } from '@shared/wa/settingsSection';
+import {
+  renderSettingsNumberRow,
+  renderSettingsSectionHeading,
+} from '@shared/wa/settingsSection';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - shared schemas
 
 // Local imports - catalog-driven settings rows
-import { renderStateSettingToggleRow } from '../components/shared/stateSettingRows';
+import {
+  postStateSetting,
+  renderStateSettingToggleRow,
+} from '../components/shared/stateSettingRows';
 
 @customElement('multi-agent-tab')
 export class MultiAgentTab extends LitElement {
@@ -39,6 +50,10 @@ export class MultiAgentTab extends LitElement {
         display: flex;
         flex-direction: column;
         gap: var(--wa-space-xs);
+      }
+
+      .setting-number-input {
+        width: 80px;
       }
 
       /* Team cards */
@@ -177,6 +192,10 @@ export class MultiAgentTab extends LitElement {
   @property({ attribute: false }) allowOrchestratorKill = true;
   @property({ attribute: false }) detachSubagentsOnStop = false;
   @property({ attribute: false }) worktreeSupport = false;
+  @property({ attribute: false }) childRunConcurrencyBudget =
+    CHILD_RUN_CONCURRENCY_BUDGET_SETTING.defaultValue;
+  /** Parent-owned acknowledgement generation; changes force a re-render even when all field values are unchanged. */
+  @property({ attribute: false }) ackGeneration = 0;
   @property({ attribute: false }) customPresets: AgentModePreset[] = [];
   /** Agent names that carry delegation tools, computed backend-side from the registry. */
   @property({ attribute: false }) orchestratorAgents: string[] = [];
@@ -305,7 +324,10 @@ export class MultiAgentTab extends LitElement {
 
   override render(): TemplateResult {
     return html`
-      <div class="multi-agent-container tab-content-container">
+      <div
+        class="multi-agent-container tab-content-container"
+        data-ack-generation=${this.ackGeneration}
+      >
         ${renderSettingsSectionHeading({
           title: 'Available teams',
           description: 'Select a team to activate it.',
@@ -345,6 +367,16 @@ export class MultiAgentTab extends LitElement {
             description:
               'Delegated agents can use isolated worktrees, with every tool call rooted in that worktree.',
             checked: this.worktreeSupport,
+          })}
+          ${renderSettingsNumberRow({
+            label: 'Child-run concurrency budget',
+            description: CHILD_RUN_CONCURRENCY_BUDGET_SETTING.description,
+            value: this.childRunConcurrencyBudget,
+            min: CHILD_RUN_CONCURRENCY_BUDGET_SETTING.min,
+            max: CHILD_RUN_CONCURRENCY_BUDGET_SETTING.max,
+            step: 1,
+            onChange: (value) =>
+              postStateSetting(CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY, value),
           })}
         </div>
       </div>

--- a/src/agent/runtime/childRunBudget.ts
+++ b/src/agent/runtime/childRunBudget.ts
@@ -12,34 +12,75 @@
  */
 import PQueue from 'p-queue';
 
+import {
+  CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY,
+  CHILD_RUN_CONCURRENCY_BUDGET_SETTING,
+  ChildRunConcurrencyBudgetSchema,
+} from '@shared/schemas';
+import { getValidatedConfig } from '@utils/config/configUtils';
+
 import type { SessionHandle } from './SessionHandle';
 
 /**
  * High enough that deliberate double-digit concurrent fan-out never queues,
  * low enough to stop a runaway recursive fan-out from opening unbounded
- * model conversations. The user-facing setting is recorded follow-up work.
+ * model conversations. The canonical value now lives in
+ * `CHILD_RUN_CONCURRENCY_BUDGET_SETTING`; this re-export keeps the original
+ * seam (and existing explicit-pin tests) authoritative.
  */
-export const DEFAULT_CHILD_RUN_BUDGET = 16;
+export const DEFAULT_CHILD_RUN_BUDGET =
+  CHILD_RUN_CONCURRENCY_BUDGET_SETTING.defaultValue;
 
 const budgets = new WeakMap<SessionHandle, PQueue>();
 
 /**
- * The session's shared child-run budget. Passing `concurrency` re-pins the
- * live queue's limit — the seam a future user-facing setting (and today's
- * tests) adjust the budget through without replacing queued work.
+ * Queues whose limit was pinned by an explicit `concurrency` argument. Live
+ * config reads must not re-pin these — the caller (today: the existing
+ * explicit test seams) remains authoritative until it passes a new value.
+ */
+const callerPinned = new WeakSet<PQueue>();
+
+function readConfiguredChildRunBudget(): number {
+  return getValidatedConfig(
+    CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY,
+    ChildRunConcurrencyBudgetSchema,
+    CHILD_RUN_CONCURRENCY_BUDGET_SETTING.defaultValue,
+  );
+}
+
+/**
+ * The session's shared child-run budget.
+ *
+ * - First call: creates the queue at the configured value, or at `concurrency`
+ *   when a caller explicitly pins it.
+ * - Later call with `concurrency`: re-pins the live queue's limit.
+ * - Later call without `concurrency`: re-reads the configured value and
+ *   re-pins only queues the caller has not explicitly pinned. A mid-session
+ *   settings change therefore takes effect on the next call to
+ *   `childRunBudgetFor` (the next child-run launch for that session); existing
+ *   loops sharing that queue then pick up the new limit on their subsequent
+ *   turns, without replacing queued work or overriding an authoritative caller
+ *   pin.
  */
 export function childRunBudgetFor(
   session: SessionHandle,
   concurrency?: number,
 ): PQueue {
+  const configured = readConfiguredChildRunBudget();
   let queue = budgets.get(session);
   if (!queue) {
     queue = new PQueue({
-      concurrency: concurrency ?? DEFAULT_CHILD_RUN_BUDGET,
+      concurrency: concurrency ?? configured,
     });
     budgets.set(session, queue);
+    if (concurrency !== undefined) {
+      callerPinned.add(queue);
+    }
   } else if (concurrency !== undefined) {
     queue.concurrency = concurrency;
+    callerPinned.add(queue);
+  } else if (!callerPinned.has(queue)) {
+    queue.concurrency = configured;
   }
   return queue;
 }

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -36,6 +36,10 @@ export const LATEXDIFF_TEMP_FILE_LOCATIONS = [
 export const TOOL_EDIT_APPROVAL_CONFIG_KEY =
   'texra.toolUse.requireEditApproval';
 
+/** Canonical config key for the per-session child-run concurrency budget. */
+export const CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY =
+  'texra.childRunConcurrencyBudget';
+
 export type LatexdiffTempFileLocation =
   (typeof LATEXDIFF_TEMP_FILE_LOCATIONS)[number];
 
@@ -52,6 +56,21 @@ export const MODEL_RETRY_MAX_ATTEMPTS_SETTING = {
   description:
     'Additional automatic retries after the initial model request (0–5). Long-running background requests retain at least two recovery retries.',
 } as const;
+
+/**
+ * Bounds, default, and copy for `childRunConcurrencyBudget`. The value caps the
+ * number of live native child model conversations one session runs at once.
+ * Shared by {@link ChildRunConcurrencyBudgetSchema}, the runtime reader, and the
+ * settings-view Multi-Agent tab so the schema, runtime, and UI cannot disagree
+ * about the range.
+ */
+export const CHILD_RUN_CONCURRENCY_BUDGET_SETTING = Object.freeze({
+  defaultValue: 16,
+  min: 1,
+  max: 100,
+  description:
+    'Maximum number of live native child model conversations one session may run at once. Detached subagents beyond this wait for a slot to free.',
+} as const);
 
 export const DEFAULT_CORE_SETTINGS = {
   agentOutputs: {
@@ -132,6 +151,7 @@ export const DEFAULT_CORE_SETTINGS = {
     requireEditApproval: true,
     requireBashApproval: true,
   },
+  childRunConcurrencyBudget: CHILD_RUN_CONCURRENCY_BUDGET_SETTING.defaultValue,
 };
 
 const stringRecord = (
@@ -163,6 +183,13 @@ export const ModelRetryMaxAttemptsSchema = z
   .max(MODEL_RETRY_MAX_ATTEMPTS_SETTING.max)
   .describe(MODEL_RETRY_MAX_ATTEMPTS_SETTING.description)
   .prefault(MODEL_RETRY_MAX_ATTEMPTS_SETTING.defaultValue);
+
+export const ChildRunConcurrencyBudgetSchema = z
+  .int()
+  .min(CHILD_RUN_CONCURRENCY_BUDGET_SETTING.min)
+  .max(CHILD_RUN_CONCURRENCY_BUDGET_SETTING.max)
+  .describe(CHILD_RUN_CONCURRENCY_BUDGET_SETTING.description)
+  .prefault(CHILD_RUN_CONCURRENCY_BUDGET_SETTING.defaultValue);
 
 /**
  * Field shape for {@link CoreSettingsSchema}.
@@ -239,6 +266,7 @@ export const CoreSettingsShape = {
       ),
     })
     .prefault(DEFAULT_CORE_SETTINGS.xaiGrok),
+  childRunConcurrencyBudget: ChildRunConcurrencyBudgetSchema,
   maxImageDimension: numberField(
     DEFAULT_CORE_SETTINGS.maxImageDimension,
     'Maximum dimension (width or height) in pixels for images before resizing. Images larger than this will be resized to fit within this dimension while maintaining aspect ratio.',
@@ -429,6 +457,7 @@ type AssertNever<T extends never> = T;
  */
 export const CORE_SETTING_PATHS = [
   'agentOutputs.autoOpenFinal',
+  'childRunConcurrencyBudget',
   'goal.enabled',
   'model.useOpenAIResponsesAPI',
   'model.useGoogleInteractionsServerState',
@@ -506,6 +535,7 @@ type _AssertCorePathsExhaustive = AssertNever<
  */
 export const CLI_CORE_SETTING_PATHS = [
   'agentOutputs.autoOpenFinal',
+  'childRunConcurrencyBudget',
   'goal.enabled',
   'model.useOpenAIResponsesAPI',
   'model.useGoogleInteractionsServerState',

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -33,6 +33,7 @@ import {
 } from './agent';
 import { AgentModePresetSchema } from './agentPresets';
 import { AgentSkillsEnabledSchema } from './agentSkills';
+import { ChildRunConcurrencyBudgetSchema } from './coreSettings';
 import { ModelAvailabilityFieldsSchema } from './mainView/state';
 import {
   NumberSettingSchema,
@@ -373,6 +374,7 @@ const UpdateReliabilityAndOrchestrationMessageSchema = z.object({
   reliabilitySettings: z.array(NumberSettingSchema).prefault([]),
   allowOrchestratorKill: z.boolean().prefault(true),
   detachSubagentsOnStop: z.boolean().prefault(false),
+  childRunConcurrencyBudget: ChildRunConcurrencyBudgetSchema,
 });
 export type UpdateReliabilityAndOrchestrationMessage = z.infer<
   typeof UpdateReliabilityAndOrchestrationMessageSchema

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -41,6 +41,8 @@ import {
 } from '@shared/schemas/agentCliSettings';
 import { AGENT_SKILLS_CONFIG_KEY } from '@shared/schemas/agentSkills';
 import {
+  CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY,
+  CHILD_RUN_CONCURRENCY_BUDGET_SETTING,
   CoreSettingsShape,
   TOOL_EDIT_APPROVAL_CONFIG_KEY,
 } from '@shared/schemas/coreSettings';
@@ -878,6 +880,16 @@ export const SETTINGS_VIEW_CORE_SETTINGS: readonly StateSettingEntry[] = [
     cliConsumer: 'src/agent/prompt/userVars.ts',
     cliRuntimeReachability: AGENT_SKILLS_RUNTIME_REACHABILITY,
     settingsViewSnapshot: 'agent-skills',
+  },
+  {
+    key: CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY,
+    schema: CoreSettingsShape.childRunConcurrencyBudget,
+    title: 'Child-run concurrency budget',
+    description: CHILD_RUN_CONCURRENCY_BUDGET_SETTING.description,
+    category: 'multi-agent',
+    store: 'config',
+    hosts: ['vscode', 'desktop'],
+    settingsViewSnapshot: 'multi-agent',
   },
   {
     key: 'texra.telemetry.enabled',

--- a/src/shared/settingsView/handlers/superYoloHandlers.ts
+++ b/src/shared/settingsView/handlers/superYoloHandlers.ts
@@ -8,18 +8,49 @@
  * Reliability settings are host-specific (VS Code config-backed in the
  * extension; absent in the desktop build), so callers supply them.
  */
+import { createLog } from '@logger/logUtils';
+import type { ConfigProvider } from '@platform/interfaces';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import type {
-  NumberSetting,
-  UpdateReliabilityAndOrchestrationMessage,
+import {
+  CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY,
+  CHILD_RUN_CONCURRENCY_BUDGET_SETTING,
+  ChildRunConcurrencyBudgetSchema,
+  type NumberSetting,
+  type UpdateReliabilityAndOrchestrationMessage,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-
 import type { SettingsStatePorts } from '@shared/settingsView/types';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+const log = createLog('superYoloHandlers');
 
 export interface ReliabilityAndOrchestrationHandlerPorts extends SettingsStatePorts {
+  readonly config: ConfigProvider;
   /** Host-provided reliability settings (extension only — desktop returns []). */
   readonly getReliabilitySettings: () => NumberSetting[];
+}
+
+function readChildRunConcurrencyBudget(config: ConfigProvider): number {
+  const parsed = ChildRunConcurrencyBudgetSchema.safeParse(
+    config.get<unknown>(CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY),
+  );
+  if (parsed.success) return parsed.data;
+  // Loud-read policy: a hand-edited persisted value that fails validation
+  // must not silently fall back without a warning, matching the runtime
+  // reader (`getValidatedConfig`). An absent key parses to the prefault and
+  // never reaches this branch.
+  if (config.isExplicitlySet(CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY)) {
+    log.warn(
+      'Ignoring invalid value for child-run concurrency budget setting',
+      {
+        data: {
+          key: CHILD_RUN_CONCURRENCY_BUDGET_CONFIG_KEY,
+          error: toErrorMessage(parsed.error),
+        },
+      },
+    );
+  }
+  return CHILD_RUN_CONCURRENCY_BUDGET_SETTING.defaultValue;
 }
 
 export function buildReliabilityAndOrchestrationMessage(
@@ -38,5 +69,6 @@ export function buildReliabilityAndOrchestrationMessage(
       WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
       false,
     ),
+    childRunConcurrencyBudget: readChildRunConcurrencyBudget(ports.config),
   };
 }

--- a/src/shared/wa/settingsSection.ts
+++ b/src/shared/wa/settingsSection.ts
@@ -1,12 +1,20 @@
 // Third-party imports
 import { html, nothing, type TemplateResult } from 'lit';
+import { live } from 'lit/directives/live.js';
 
-// Web Awesome switch (side-effect import — the toggle row renders one)
+// Web Awesome switch + input (side-effect imports — the rows render them)
 import '@awesome.me/webawesome/dist/components/switch/switch.js';
+import '@awesome.me/webawesome/dist/components/input/input.js';
+
+// Local imports - utils
+import { clampOptional } from '@utils/core';
 
 // Local imports - Web Awesome
 import { waIcon } from './webAwesomeIcons';
 import type { TeXRAIconName } from './iconNames';
+
+// Web Awesome input element type (kept after local imports per import/order)
+import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
 export interface SettingsSectionHeadingOptions {
   readonly title: string;
@@ -104,6 +112,106 @@ export function renderSettingsToggleRow(
           ?disabled=${options.disabled}
           @change=${options.onChange}
         ></wa-switch>
+      </div>
+    </div>
+  `;
+}
+
+function numberRowId(label: string): string {
+  return `settings-number-${label
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-|-$/g, '')}`;
+}
+
+export interface SettingsNumberRowOptions {
+  readonly label: string;
+  readonly description: string;
+  readonly value: number;
+  readonly min?: number;
+  readonly max?: number;
+  readonly step?: number;
+  readonly disabled?: boolean;
+  /** Optional unit text rendered beside the input. */
+  readonly unit?: string;
+  /**
+   * What a cleared field means. Defaults to `true` (revert to the last
+   * committed value). Pass `false` for the provider reliability section's
+   * legacy behavior: `Number('')` is 0, then the normal step/clamp math runs
+   * and posts that value.
+   */
+  readonly revertOnEmpty?: boolean;
+  readonly onChange: (value: number) => void;
+}
+
+/**
+ * Shared numeric settings row used by the catalog-bound rows and the provider
+ * reliability section. Cleared input reverts to the last committed value by
+ * default; `revertOnEmpty: false` opts into the legacy commit-zero/min path.
+ * `onChange` receives the parsed, stepped, and clamped value. The visible label
+ * is a real `<label for>` (see the toggle row for the accessibility rationale).
+ */
+export function renderSettingsNumberRow(
+  options: SettingsNumberRowOptions,
+): TemplateResult {
+  const id = numberRowId(options.label);
+
+  const commit = (input: WaInput, raw: string): void => {
+    const parsed = Number(raw);
+    if (Number.isNaN(parsed)) {
+      input.value = String(options.value);
+      return;
+    }
+    const stepOrigin = options.min ?? 0;
+    const stepped =
+      options.step === undefined
+        ? parsed
+        : stepOrigin +
+          Math.round((parsed - stepOrigin) / options.step) * options.step;
+    const value = clampOptional(stepped, options.min, options.max);
+    if (value !== parsed) input.value = String(value);
+    options.onChange(value);
+  };
+
+  const handleChange = (event: Event): void => {
+    const input = event.target as WaInput;
+    const raw = input.value;
+    if (typeof raw !== 'string' || raw.trim() === '') {
+      if (options.revertOnEmpty === false) {
+        commit(input, '0');
+        return;
+      }
+      // Treat a cleared field as "no change" — `Number('')` would silently
+      // coerce to 0/min and overwrite the saved value.
+      input.value = String(options.value);
+      return;
+    }
+    commit(input, raw);
+  };
+
+  return html`
+    <div class="settings-row">
+      <div class="settings-row-text">
+        <label class="settings-row-label" for=${id}>${options.label}</label>
+        <span class="settings-row-help">${options.description}</span>
+      </div>
+      <div class="settings-row-control">
+        <wa-input
+          id=${id}
+          class="setting-number-input"
+          type="number"
+          .value=${live(String(options.value))}
+          min=${options.min ?? nothing}
+          max=${options.max ?? nothing}
+          step=${options.step ?? nothing}
+          ?disabled=${options.disabled}
+          @change=${handleChange}
+        ></wa-input>
+        ${
+          options.unit
+            ? html`<span class="setting-unit">${options.unit}</span>`
+            : nothing
+        }
       </div>
     </div>
   `;

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -456,6 +456,7 @@ const CLI_CORE_SETTING_READER_FILES = {
   'src/agent/runtime/selectAutoOpenFinalOutput.ts': [
     'agentOutputs.autoOpenFinal',
   ],
+  'src/agent/runtime/childRunBudget.ts': ['childRunConcurrencyBudget'],
   'src/tools/goal/goalFeatureFlag.ts': ['goal.enabled'],
   'src/agent/runtime/ModelFactory.ts': ['model.useOpenAIResponsesAPI'],
   'src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts': [


### PR DESCRIPTION
Closes #10640

## Summary

Lands the child-run concurrency budget as a user-facing core setting instead of a bare module constant.

- Canonical key: `texra.childRunConcurrencyBudget` (integer 1–100, default 16).
- Workspace-scoped `.texra/config.json` (the settings-view catalog row omits `configTarget`).
- Surfaced only in the native VS Code/desktop settings Multi-Agent tab; not in the CLI `/config` panel.
- `childRunBudgetFor` re-reads config on every call and live re-pins only queues that were not explicitly caller-pinned (WeakSet), so the existing explicit test seams stay authoritative.
- Absent and invalid persisted values both resolve to 16. Provider-key partitioning remains rejected (maintainer ruling).

## R6 (behavioral delta)

- New setting is additive; runtime behavior is unchanged at the default 16.
- Existing `childRunBudgetFor(session, N)` explicit-pin seam is preserved; only non-pinned queues follow later config reads.
- The settings-view Multi-Agent payload gains one number field (`childRunConcurrencyBudget`) behind the existing `UPDATE_SUPER_YOLO_ENABLED` wire command; the field is `.prefault(16)`-backed so older payloads still parse.
- `ReliabilitySettingsSection` is migrated onto the shared `renderSettingsNumberRow` as a second caller, preserving its unit suffix and legacy cleared-input behavior via `revertOnEmpty: false`.
- `MultiAgentTab` binds the same shared `renderSettingsNumberRow` directly through `postStateSetting`; the single-caller catalog-bound number-row wrapper was removed.
- The shared number row binds the committed value with Lit `live()`.
- A frontend-only `multiAgentSettingsRevision` acknowledgement generation increments on every multi-agent payload (including same-value rebroadcasts) and is passed into `multi-agent-tab` as `ackGeneration`, so a rejected/failed write restores the acknowledged value even when every field signal is unchanged. Payload/wire format is unchanged.

## R8 (negative space / invariants)

- No provider-key partitioning added.
- No changes to package contributes, ToolUseDispatchNode queues, engine semaphore, root/agent-CLI caps.
- No new test cases; the only test-file change is the minimal existing `stateSettings.vitest.ts` reader-fixture row required by the architecture guard.

## Validation (final head)

- `pnpm run typecheck` (workspace, test-kernel, agent, cli, trace-viewer, desktop): green.
- `pnpm run lint`: green.
- `prettier --check <changed files>`: green.
- `pnpm run check:package-contributes`: green.
- `pnpm run check:dead-code-ratchet`: green (8 current vs 8 baselined).
- `pnpm run check:guidance-refs`: green.
- `pnpm run check:browser-safe-utils`: green.
- Focused vitest suites on final head: 11 files / 146 tests green (MultiAgentTab, ReliabilitySettingsSection, SettingsStyleContracts, SettingsNavigation, SettingsNavGroups, stateSettings, StateSettingWrite, DesktopSettingsIpc, DesktopSettingsCapabilityMarkers, SharedSchemas, ChildRunLoop).
- Scratch probes (deleted after run): childRunBudget absent/invalid/live-repin/explicit-pin (4/4), LitElement `live()` value-restore (1/1), SettingsApp/slice acknowledgement lifecycle (1/1).

## Overlap audit

- Open #10683 touches `SettingsViewMessageHandler.ts` only in the constructor region; this PR touches the `buildReliabilityAndOrchestrationMessage` call site. Either landing order needs a trivial rebase.
- Open #10688 touches `settingsViewMessages.ts` only in the history re-export block; disjoint from this PR's payload field. No other open PR touches these files.
