### PR TITLE
refactor(logger): finish namespace-logger migration batch

### DIFF
--- a/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
+++ b/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
@@ -16,9 +16,11 @@ import { Component, type ReactNode } from 'react';
 
 import { COLOR_ERROR } from '@cli/tui/ui/colors';
 import { WARNING } from '@cli/tui/ui/glyphs';
-import * as logUtils from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
+
+const log = createLog('cli.tui');
 
 interface EntryErrorBoundaryProps {
   // Names the failed entry in the inline marker and the log line (e.g. its
@@ -61,8 +63,7 @@ export class EntryErrorBoundary extends Component<
     // so the inline marker below is the primary surfacing. Logging serves the
     // verbose / trace path and must never itself break the error unwind.
     try {
-      logUtils.error(
-        'cli.tui',
+      log.error(
         `transcript entry render failed (${this.props.label ?? 'entry'}): ${
           error instanceof Error
             ? (error.stack ?? error.message)

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -25,10 +25,12 @@ import {
   FREE_TIER,
   type UserTier,
 } from '../config';
-import type { SupabaseSessionLog } from '../supabaseSessionTypes';
 import type { TierService } from './TierService';
 
-const CHANNEL = 'ServerSideKeyService';
+interface ServerSideKeyLogger {
+  error?(message: string, options?: { data?: unknown }): void;
+  info?(message: string, options?: { data?: unknown }): void;
+}
 
 /**
  * When the last access fetch was anonymous (dead session), the authenticated
@@ -143,7 +145,7 @@ export class ServerSideKeyService {
     private readonly baseUrl: string,
     private readonly tierService: TierService,
     private readonly globalState: StateStore | null = null,
-    private readonly logger: SupabaseSessionLog = {},
+    private readonly logger: ServerSideKeyLogger = {},
     private readonly notifyIncludedModelAccessChanged: (
       enabled: boolean,
     ) => void = () => {},
@@ -219,10 +221,7 @@ export class ServerSideKeyService {
       try {
         this.notifyIncludedModelAccessChanged(value);
       } catch (error) {
-        this.logger.error?.(
-          CHANNEL,
-          `Event listener failed: ${toErrorMessage(error)}`,
-        );
+        this.logger.error?.(`Event listener failed: ${toErrorMessage(error)}`);
       }
     }
   }
@@ -271,7 +270,6 @@ export class ServerSideKeyService {
       // Denied by error (auth/network failure), not by policy — log so the two
       // are distinguishable.
       this.logger.error?.(
-        CHANNEL,
         `Access check failed, treating as denied: ${toErrorMessage(error)}`,
       );
       return { hasAccess: false, userTier: null };
@@ -344,11 +342,10 @@ export class ServerSideKeyService {
       let accessGranted = accessStatus.hasAccess && providers.length > 0;
 
       if (this.tierService.isAccessExpired()) {
-        this.logger.info?.(CHANNEL, 'User access has expired');
+        this.logger.info?.('User access has expired');
         accessGranted = false;
       } else if (!hasFullAccess && tierConfig === null) {
         this.logger.info?.(
-          CHANNEL,
           'Tier config unavailable for non-Ultra user, denying access',
         );
         accessGranted = false;
@@ -386,7 +383,6 @@ export class ServerSideKeyService {
       ) {
         this.quotaFlipApplied = true;
         this.logger.info?.(
-          CHANNEL,
           'Relay quota exhausted; switching useIncludedModelAccess off',
         );
         // Await so the persisted toggle state, the cleared cache, and

--- a/src/auth/serverKeys/TierService.ts
+++ b/src/auth/serverKeys/TierService.ts
@@ -36,9 +36,12 @@ import {
   type TierModelsConfig,
   type UserAccessStatus,
 } from './tierTypes';
-import type { SupabaseSessionLog } from '../supabaseSessionTypes';
 
-const CHANNEL = 'TierService';
+interface TierServiceLogger {
+  warn?(message: string, options?: { data?: unknown }): void;
+  error?(message: string, options?: { data?: unknown }): void;
+  info?(message: string, options?: { data?: unknown }): void;
+}
 
 /** Cache slot key — auth and anonymous responses never share a slot. */
 type TierCacheKey = 'auth' | 'anon';
@@ -100,7 +103,7 @@ export class TierService {
    */
   constructor(
     private readonly baseUrl: string,
-    private readonly logger: SupabaseSessionLog = {},
+    private readonly logger: TierServiceLogger = {},
   ) {
     this.configCache = new LRUCache<
       TierCacheKey,
@@ -125,7 +128,7 @@ export class TierService {
           this.spendingStatus = result.spendingStatus;
           this.spendingStatusError = result.spendingStatusError;
           if (result.spendingStatusError) {
-            this.logger.warn?.(CHANNEL, 'Relay spend check failed', {
+            this.logger.warn?.('Relay spend check failed', {
               data: {
                 failureReason:
                   result.spendingStatusError.failureReason ?? 'unknown reason',
@@ -173,7 +176,6 @@ export class TierService {
     const parsed = schema.safeParse(raw);
     if (parsed.success) return parsed.data;
     this.logger.error?.(
-      CHANNEL,
       `Invalid ${label} payload: ${z.prettifyError(parsed.error)}`,
     );
     return null;
@@ -213,7 +215,6 @@ export class TierService {
       // quiet. Genuine network failures keep the previous error log.
       if (!signal.aborted) {
         this.logger.error?.(
-          CHANNEL,
           `Error fetching tier config: ${toErrorMessage(error)}`,
         );
       }
@@ -223,14 +224,10 @@ export class TierService {
     if (!response.ok) {
       if (response.status === 404) {
         this.logger.info?.(
-          CHANNEL,
           'Tier-config endpoint not available, using defaults',
         );
       } else {
-        this.logger.error?.(
-          CHANNEL,
-          `Failed to fetch tier config: ${response.status}`,
-        );
+        this.logger.error?.(`Failed to fetch tier config: ${response.status}`);
       }
       throw new Error(`tier-config request failed: HTTP ${response.status}`);
     }
@@ -240,7 +237,6 @@ export class TierService {
       data = await response.json();
     } catch (error) {
       this.logger.error?.(
-        CHANNEL,
         `Failed to parse tier config JSON: ${toErrorMessage(error)}`,
       );
       throw error;
@@ -270,7 +266,6 @@ export class TierService {
     const parsed = TierModelConfigSchema.safeParse(data);
     if (!parsed.success) {
       this.logger.error?.(
-        CHANNEL,
         `Invalid tier config response: ${z.prettifyError(parsed.error)}`,
       );
       return { config: null, userStatus, spendingStatus, spendingStatusError };

--- a/src/auth/serverKeys/index.ts
+++ b/src/auth/serverKeys/index.ts
@@ -14,7 +14,7 @@
  */
 
 import { appSignals } from '@eventBus/AppSignals';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { tryGlobalState } from '@platform/platform';
 import { SUPABASE_CONFIG } from '../config';
 import { TierService } from './TierService';
@@ -22,6 +22,9 @@ import { ServerSideKeyService } from './ServerSideKeyService';
 
 // Service class
 export { ServerSideKeyService };
+
+const log = createLog('ServerSideKeyService');
+const tierServiceLog = createLog('TierService');
 
 // ==========================================================================
 // Singleton Instance
@@ -54,8 +57,7 @@ export function getServerSideKeyService(): ServerSideKeyService {
   if (_instance && !(_constructedStateless && state)) return _instance;
 
   if (!state) {
-    logger.warn(
-      'ServerSideKeyService',
+    log.warn(
       'No platform state store; included model access is off for this ' +
         'process. Call initPlatform() before the first model call to use ' +
         'relay access, or configure a provider API key.',
@@ -65,9 +67,9 @@ export function getServerSideKeyService(): ServerSideKeyService {
   const baseUrl = SUPABASE_CONFIG.url;
   _instance = new ServerSideKeyService(
     baseUrl,
-    new TierService(baseUrl, logger),
+    new TierService(baseUrl, tierServiceLog),
     state,
-    logger,
+    log,
     (enabled) => appSignals.emit('includedModelAccessChanged', enabled),
   );
   _constructedStateless = !state;

--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -3,7 +3,7 @@ import { globIterate } from 'glob';
 import { MODELS } from 'llm-zoo';
 
 // Internal imports
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { FileOpResult } from '@shared/schemas';
 import { EXCLUDED_DIRS } from '@shared/constants/latexTiming';
 import { unique } from '@utils/core';
@@ -19,6 +19,8 @@ import {
 } from './constants';
 import { findFilesFromPatterns, resolveHousekeepingTargets } from './utils';
 
+const log = createLog(CHANNEL);
+
 function toIgnoreGlobs(dirs: Iterable<string>): string[] {
   return [...dirs].map((dir) => `**/${dir}/**`);
 }
@@ -28,8 +30,7 @@ export async function runCleanSingle(
   inputFile: string,
   agent: string,
 ): Promise<FileOpResult> {
-  logger.info(
-    CHANNEL,
+  log.info(
     `Starting cleanup with model=${model}, inputFile=${inputFile}, agent=${agent}`,
   );
 
@@ -40,7 +41,7 @@ export async function runCleanSingle(
   const { inputDir, filePatterns } = targets;
 
   const extensions = [...TEMP_EXTENSIONS, ...PACK_EXTENSIONS];
-  logger.debug(CHANNEL, `Using extensions: ${extensions}`);
+  log.debug(`Using extensions: ${extensions}`);
 
   try {
     let foundFile = false;
@@ -49,21 +50,21 @@ export async function runCleanSingle(
       filePatterns,
       extensions,
     )) {
-      logger.debug(CHANNEL, `Deleting file: ${filePath}`);
+      log.debug(`Deleting file: ${filePath}`);
       await WorkspaceFS.delete(filePath);
       foundFile = true;
     }
 
     if (!foundFile) {
-      logger.warn(CHANNEL, `No matching files found to clean for ${inputFile}`);
+      log.warn(`No matching files found to clean for ${inputFile}`);
       return { status: 'noFiles' };
     }
 
-    logger.info(CHANNEL, `Cleanup complete for ${inputFile}`);
+    log.info(`Cleanup complete for ${inputFile}`);
     return { status: 'success' };
   } catch (err) {
     const message = toErrorMessage(err);
-    logger.error(CHANNEL, `Error during cleanup of ${inputFile}: ${message}`);
+    log.error(`Error during cleanup of ${inputFile}: ${message}`);
     return { status: 'error', error: message };
   }
 }
@@ -74,11 +75,10 @@ export async function runCleanMultiple(
   agent: string,
   inputFiles: string[],
 ): Promise<FileOpResult> {
-  logger.debug(
-    CHANNEL,
+  log.debug(
     `Starting multiple cleanup with model=${model}, inputFile=${inputFile}, agent=${agent}`,
   );
-  logger.debug(CHANNEL, `Additional files: ${inputFiles.join(', ')}`);
+  log.debug(`Additional files: ${inputFiles.join(', ')}`);
 
   const firstResult = await runCleanSingle(model, inputFile, agent);
   if (
@@ -97,12 +97,12 @@ export async function runCleanMultiple(
     anyCleaned ||= res.status === 'success';
   }
 
-  logger.info(CHANNEL, 'Cleanup complete for multiple files.');
+  log.info('Cleanup complete for multiple files.');
   return anyCleaned ? { status: 'success' } : { status: 'noFiles' };
 }
 
 export async function runCleanBuild(): Promise<void> {
-  logger.debug(CHANNEL, 'Starting build directory cleanup');
+  log.debug('Starting build directory cleanup');
 
   const workspacePath = WorkspaceFS.getPath();
   if (!workspacePath) {
@@ -120,20 +120,19 @@ export async function runCleanBuild(): Promise<void> {
   })) {
     try {
       await WorkspaceFS.delete(dir, { recursive: true, useTrash: false });
-      logger.debug(CHANNEL, `Removed build directory: ${dir}`);
+      log.debug(`Removed build directory: ${dir}`);
     } catch (err) {
-      logger.error(
-        CHANNEL,
+      log.error(
         `Error removing build directory ${dir}: ${toErrorMessage(err)}`,
       );
     }
   }
 
-  logger.info(CHANNEL, 'Build directories cleaned');
+  log.info('Build directories cleaned');
 }
 
 export async function runCleanOutput(): Promise<void> {
-  logger.debug(CHANNEL, 'Starting output directory cleanup');
+  log.debug('Starting output directory cleanup');
 
   const workspacePath = WorkspaceFS.getPath();
   if (!workspacePath) {
@@ -158,5 +157,5 @@ export async function runCleanOutput(): Promise<void> {
     await WorkspaceFS.delete(file);
   }
 
-  logger.info(CHANNEL, 'All AI Generated Output files cleaned');
+  log.info('All AI Generated Output files cleaned');
 }

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -2,7 +2,7 @@
 import * as path from 'node:path';
 
 // Internal imports
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { FileOpResult } from '@shared/schemas';
 import { getCleanAgentName } from '@shared/schemas';
 import {
@@ -30,14 +30,15 @@ import {
   resolveHousekeepingTargets,
 } from './utils';
 
+const log = createLog(CHANNEL);
+
 export async function runPackSingle(
   model: string,
   inputFile: string,
   agent: string,
   outputFolder?: string,
 ): Promise<FileOpResult> {
-  logger.info(
-    CHANNEL,
+  log.info(
     `Starting packing with model=${model}, inputFile=${inputFile}, agent=${agent}, outputFolder=${outputFolder}`,
   );
 
@@ -72,11 +73,11 @@ export async function runPackSingle(
       (copiedFiles.length === 1 && copiedFiles[0] === inputFile));
 
   if (noFilesToPack) {
-    logger.warn(CHANNEL, `No files found to pack for ${inputFile}`);
+    log.warn(`No files found to pack for ${inputFile}`);
     return { status: 'noFiles' };
   }
 
-  logger.debug(CHANNEL, buildFileListLog(movedFiles, copiedFiles));
+  log.debug(buildFileListLog(movedFiles, copiedFiles));
 
   const resolvedOutputFolder =
     outputFolder ||
@@ -85,11 +86,11 @@ export async function runPackSingle(
       HISTORY_DIR,
       `${generateTimestamp()}_${baseName}_${agent}_${model}`,
     );
-  logger.debug(CHANNEL, `Output folder: ${resolvedOutputFolder}`);
+  log.debug(`Output folder: ${resolvedOutputFolder}`);
 
   try {
     await WorkspaceFS.createDir(resolvedOutputFolder);
-    logger.debug(CHANNEL, `Created output directory: ${resolvedOutputFolder}`);
+    log.debug(`Created output directory: ${resolvedOutputFolder}`);
 
     const operations = await moveAndCopyFiles(
       movedFiles,
@@ -98,8 +99,8 @@ export async function runPackSingle(
     );
 
     if (operations.length > 0) {
-      logger.info(CHANNEL, `Files packed into ${resolvedOutputFolder}`);
-      logger.debug(CHANNEL, `File operations:\n${operations.join('\n')}`);
+      log.info(`Files packed into ${resolvedOutputFolder}`);
+      log.debug(`File operations:\n${operations.join('\n')}`);
     }
 
     await cleanupTempFiles(inputDir, filePatterns, movedFiles, copiedFiles);
@@ -107,7 +108,7 @@ export async function runPackSingle(
     return { status: 'success', outputFolder: resolvedOutputFolder };
   } catch (err) {
     const message = toErrorMessage(err);
-    logger.error(CHANNEL, `Error during file operations: ${message}`);
+    log.error(`Error during file operations: ${message}`);
     return { status: 'error', error: message };
   }
 }
@@ -118,11 +119,10 @@ export async function runPackMultiple(
   agent: string,
   inputFiles: string[],
 ): Promise<FileOpResult> {
-  logger.debug(
-    CHANNEL,
+  log.debug(
     `Starting multiple packing with model=${model}, inputFile=${inputFile}, agent=${agent}`,
   );
-  logger.debug(CHANNEL, `Additional files: ${inputFiles.join(', ')}`);
+  log.debug(`Additional files: ${inputFiles.join(', ')}`);
 
   const baseName = path.parse(inputFile).name;
   const outputDir = path.dirname(inputFile);
@@ -131,7 +131,7 @@ export async function runPackMultiple(
     HISTORY_DIR,
     `${generateTimestamp()}_${baseName}_multiple_${agent}_${model}`,
   );
-  logger.debug(CHANNEL, `Common output folder: ${commonOutputFolder}`);
+  log.debug(`Common output folder: ${commonOutputFolder}`);
 
   try {
     const allFilesToPack = [inputFile, ...inputFiles];
@@ -157,15 +157,15 @@ export async function runPackMultiple(
     );
 
     if (anyFilesPacked || xmlFilesPacked) {
-      logger.info(CHANNEL, `All files packed into ${commonOutputFolder}`);
+      log.info(`All files packed into ${commonOutputFolder}`);
       return { status: 'success', outputFolder: commonOutputFolder };
     }
 
-    logger.warn(CHANNEL, `No files found to pack for ${inputFile}`);
+    log.warn(`No files found to pack for ${inputFile}`);
     return { status: 'noFiles' };
   } catch (err) {
     const message = toErrorMessage(err);
-    logger.error(CHANNEL, `Error during multiple pack operation: ${message}`);
+    log.error(`Error during multiple pack operation: ${message}`);
     return { status: 'error', error: message };
   }
 }
@@ -284,8 +284,7 @@ async function packAdditionalXmlFiles(
         // The two layouts can yield identical destination names (when the
         // agent's first-name chunk equals its clean name). Skip the second
         // candidate rather than failing the rename onto an existing file.
-        logger.debug(
-          CHANNEL,
+        log.debug(
           `Skipping ${filePath}: destination ${destPath} already exists`,
         );
         continue;
@@ -294,7 +293,7 @@ async function packAdditionalXmlFiles(
       if (!outputFolderExists && !anyPacked) {
         await WorkspaceFS.createDir(commonOutputFolder);
       }
-      logger.debug(CHANNEL, `Found additional XML file: ${filePath}`);
+      log.debug(`Found additional XML file: ${filePath}`);
       await WorkspaceFS.rename(filePath, destPath);
       anyPacked = true;
     }

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -1,5 +1,5 @@
 // Internal imports
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { ExecResult } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { executeCommand } from '@utils/system/execUtils';
@@ -72,6 +72,10 @@ export class DiffCommandExecutor {
     private readonly channel: string,
     private readonly getTimeoutMs: () => number,
   ) {}
+
+  private get log() {
+    return createLog(this.channel);
+  }
 
   async executeDiff(
     inputFile: string,
@@ -175,14 +179,11 @@ export class DiffCommandExecutor {
       cwd,
     };
 
-    logger.debug(this.channel, `Attempting ${commandType} with --flatten flag`);
+    this.log.debug(`Attempting ${commandType} with --flatten flag`);
     const result = await executeCommand(commandBuilder(true), execOptions);
 
     if (result.success) {
-      logger.debug(
-        this.channel,
-        `${commandType} completed successfully (with --flatten)`,
-      );
+      this.log.debug(`${commandType} completed successfully (with --flatten)`);
       return result;
     }
 
@@ -208,14 +209,10 @@ export class DiffCommandExecutor {
     commandType: string,
     execOptions: CommandExecOptions,
   ): Promise<ExecResult> {
-    logger.warn(
-      this.channel,
+    this.log.warn(
       'Bibliography compilation failed with --flatten, retrying without --flatten',
     );
-    logger.debug(
-      this.channel,
-      `Retrying ${commandType} without --flatten flag`,
-    );
+    this.log.debug(`Retrying ${commandType} without --flatten flag`);
 
     const result = await executeCommand(commandBuilder(false), execOptions);
 
@@ -231,10 +228,7 @@ export class DiffCommandExecutor {
       );
     }
 
-    logger.debug(
-      this.channel,
-      `${commandType} completed successfully (without --flatten)`,
-    );
+    this.log.debug(`${commandType} completed successfully (without --flatten)`);
     return result;
   }
 

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -61,6 +61,8 @@ interface DiffExecutionOptions {
 type CommandExecOptions = { channel: string; timeout: number; cwd?: string };
 
 export class DiffCommandExecutor {
+  private readonly log = createLog(this.channel);
+
   /**
    * `getTimeoutMs` is read fresh on every diff invocation so user updates to
    * `LATEXDIFF_TIMEOUT_MS` propagate to the next diff without rebuilding the
@@ -72,10 +74,6 @@ export class DiffCommandExecutor {
     private readonly channel: string,
     private readonly getTimeoutMs: () => number,
   ) {}
-
-  private get log() {
-    return createLog(this.channel);
-  }
 
   async executeDiff(
     inputFile: string,

--- a/src/test-kernel/auth/TierService.vitest.ts
+++ b/src/test-kernel/auth/TierService.vitest.ts
@@ -278,10 +278,8 @@ describe('TierService', () => {
       failureReason: 'usage query unavailable',
       limit: 300,
     });
-    expect(warn).toHaveBeenCalledWith(
-      'TierService',
-      'Relay spend check failed',
-      { data: { failureReason: 'usage query unavailable' } },
-    );
+    expect(warn).toHaveBeenCalledWith('Relay spend check failed', {
+      data: { failureReason: 'usage query unavailable' },
+    });
   });
 });

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -15,7 +15,7 @@ import { quote as shellQuote } from 'shell-quote';
 import treeKill from 'tree-kill';
 
 // Internal imports
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { ExecResult } from '@shared/schemas';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -136,8 +136,7 @@ function logExecutionErrorAndBuildResult(
   options: { quiet?: boolean; channel?: string },
 ): ExecResult {
   if (!options.quiet) {
-    logger.error(
-      options.channel ?? CHANNEL,
+    createLog(options.channel ?? CHANNEL).error(
       `Error executing command: ${toErrorMessage(err)}`,
     );
   }
@@ -156,7 +155,7 @@ function logCommandStderr(
     truncate && normalizedStderr.length > MAX_OUTPUT_LENGTH
       ? `...${normalizedStderr.slice(-MAX_OUTPUT_LENGTH)}`
       : normalizedStderr;
-  logger.debug(channel, `Command stderr: ${stderrForLog}`);
+  createLog(channel).debug(`Command stderr: ${stderrForLog}`);
 }
 
 function workspacePathOrProcessCwd(): string {
@@ -193,8 +192,7 @@ function signalProcessGroup(pid: number, signal: NodeJS.Signals): void {
   if (IS_WINDOWS) {
     treeKill(pid, signal, (error) => {
       if (error) {
-        logger.debug(
-          CHANNEL,
+        createLog(CHANNEL).debug(
           `tree-kill failed for pid ${pid} (${signal}): ${toErrorMessage(error)}`,
         );
       }
@@ -363,8 +361,7 @@ export async function executeCommand(
     if (mode === 'process') {
       const [cmd, ...args] = command;
       if (!options.quiet) {
-        logger.debug(
-          logChannel,
+        createLog(logChannel).debug(
           `Running command: ${shellQuote([cmd, ...args])}`,
         );
       }
@@ -375,7 +372,7 @@ export async function executeCommand(
       });
     } else {
       if (!options.quiet) {
-        logger.debug(logChannel, `Running command: ${command}`);
+        createLog(logChannel).debug(`Running command: ${command}`);
       }
       // Shell commands with pipes (e.g. "find / | head -2") create child
       // processes that inherit stdout.  execa's built-in timeout only kills
@@ -522,8 +519,7 @@ export function executeCommandSync(
     };
     const logChannel = options.channel ?? CHANNEL;
     if (!options.quiet) {
-      logger.debug(
-        logChannel,
+      createLog(logChannel).debug(
         `Running command: ${shellQuote([cmd, ...args])}`,
       );
     }


### PR DESCRIPTION
## Summary

Final collision-free `src/` namespace-logger batch for #10013, unblocked now that #10609 has merged, plus the broader-census CLI miss found in local review. Migrates every remaining non-excluded production namespace logger to `createLog`, preserving each site's exact channel, level, args/data, lazy/evaluation timing, and the per-call `loggerSelf` namespace seam that `vi.spyOn(logger, ...)` relies on.

For `serverKeys/index.ts`, the two injected service logger contracts are narrowed from the channel-first `SupabaseSessionLog` to the channel-bound methods each service actually uses:

- `TierService`: `warn` / `error` / `info`
- `ServerSideKeyService`: `error` / `info`

`index.ts` now binds `createLog('ServerSideKeyService')` for its own warning and passes `createLog('TierService')` / `createLog('ServerSideKeyService')` into the constructors, so emitted channels are unchanged. These constructors are internal `src/` wiring: no `packages/*` entry point re-exports `TierService` or `ServerSideKeyService` (packages only consume `getServerSideKeyService` / `setServerSideKeyService`).

`DiffCommandExecutor` binds its log once as a field initializer (safe under the repo's `useDefineForClassFields: false`, which emits parameter-property assignments before field initializers); the bound methods still resolve `loggerSelf` per call, so the spy seam is unchanged.

## Files

- `src/housekeeping/clean.ts` — fixed `CHANNEL` → module `createLog(CHANNEL)`
- `src/housekeeping/pack.ts` — fixed `CHANNEL` → module `createLog(CHANNEL)`
- `src/latex/latexdiff/diffCommandExecutor.ts` — readonly `this.channel` → `createLog(this.channel)` bound once
- `src/utils/system/execUtils.ts` — fixed `CHANNEL` and dynamic `options.channel ?? CHANNEL` sites → per-call `createLog(...)`; no import-time binding
- `src/auth/serverKeys/index.ts` — own `ServerSideKeyService` warning + constructor injection → channel-bound `createLog`
- `src/auth/serverKeys/TierService.ts` — narrow logger contract to `warn/error/info` and drop per-call `CHANNEL`
- `src/auth/serverKeys/ServerSideKeyService.ts` — narrow logger contract to `error/info` and drop per-call `CHANNEL`
- `packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx` — `logUtils` namespace → module `createLog('cli.tui')`
- `src/test-kernel/auth/TierService.vitest.ts` — one required existing mock assertion migrated to the narrowed channel-bound arity

Excluded as instructed: `src/agent/runtime/agentToolResolution.ts` and `packages/extension/src/webview/managers/FileManager.ts` (owned by open #10688), plus the two intentional namespace seams in `BaseViewMessageHandler.ts` and `SupabaseAuthProvider.ts`.

## R6

`9 files changed, 81 insertions(+), 103 deletions(-)` — net **−22 LoC**.

- Exported-symbol delta (`^[+-]export`): **0**.
- Class/interface declarations added: **2** module-local logger interfaces (`TierServiceLogger`, `ServerSideKeyLogger`), no exported surface change.
- Namespace logger bindings removed: **6** (`clean.ts`, `pack.ts`, `diffCommandExecutor.ts`, `execUtils.ts`, `serverKeys/index.ts`, `EntryErrorBoundary.tsx`).

## R8 (post-change census)

`import * as (logger|logUtils) from '@logger/logUtils'` remaining in production code (excluding `src/test-kernel`):

- `src/`: **1** — `src/agent/runtime/agentToolResolution.ts` (`import * as logUtils`), excluded, blocked on open #10688
- `packages/*`: **3**, all in `packages/extension`:
  - `src/common/webview/BaseViewMessageHandler.ts` — intentional seam
  - `src/frontend/auth/SupabaseAuthProvider.ts` — intentional seam
  - `src/webview/managers/FileManager.ts` — blocked on open #10688

Remaining migration candidates for #10013: `agentToolResolution.ts` + `FileManager.ts`, both blocked on #10688.

(`logUtils.ts`'s permanent self-import uses `loggerSelf`, not `logger`/`logUtils`, and is not counted.)

## Overlap audit

Audited all 7 open PRs (`#10709`, `#10704`, `#10702`, `#10699`, `#10697`, `#10688`, `#10683`). None touch the six production target files or the two required serverKeys files. `EntryErrorBoundary.tsx` is disjoint from `#10697`, which touches its consumer `StaticConversationTranscript.tsx` but not the boundary file itself. #10688 owns the two deliberately excluded files.

## Validation

- `npm run typecheck` (all 6 targets: workspace, test-kernel, agent, cli, trace-viewer, desktop): **green**
- `npm run lint`: **green**
- `npm run format:check`: **green**
- `git diff --check`: **green**
- Final affected CLI/latexdiff/architecture focus: **6 files / 115 tests passed**
- Architecture gate `src/test-kernel/architecture`: **17 files / 101 tests passed** (rerun after final changes)
- Broader area runs (green before the final follow-up; final changed files re-covered above): housekeeping/latexdiff/system/auth **42 files / 338 tests passed**; serverKeys-importing boundary **10 files / 138 tests passed**
- `npm run check:dead-code-ratchet`: **OK** (8 current vs 8 baselined)
- `npm run check:guidance-refs`: **OK**
- `npm run check:browser-safe-utils`: **OK**
- `npm run check:tsconfig-paths`: **OK**

No new test coverage; the only test change is the required existing `TierService.vitest.ts` mock assertion migration.

Refs #10013
