### PR TITLE
refactor(logger): migrate final two namespace-logger imports to createLog

### DIFF
--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -21,7 +21,7 @@ import {
 } from '@frontend/files/fileSelectionRegistry';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { parseVersionControlDiffFilename } from '@latex/latexdiff/diffFileNameManager';
-import * as logger from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import type {
   CurrentFileType,
@@ -62,6 +62,7 @@ type GetCurrentFileMessage = MessageFor<
 >;
 
 const CHANNEL = 'FileManager';
+const log = createLog(CHANNEL);
 
 export class FileManager extends BaseWebviewManager {
   async handleRequestEditedFile(
@@ -71,7 +72,7 @@ export class FileManager extends BaseWebviewManager {
       ? await getFileLister().listEditedFiles(getFileStem(message.baseFile))
       : [];
     if (message.notifyWhenEmpty && files.length === 0) {
-      logger.debug(CHANNEL, 'No edited files were found during refresh.');
+      log.debug('No edited files were found during refresh.');
     }
     this.postMessage({ command: MAIN_VIEW_COMMANDS.SET_EDITED_FILE, files });
   }
@@ -93,7 +94,7 @@ export class FileManager extends BaseWebviewManager {
       ? MULTIPLE_FILE_COMMANDS.get(fileType)
       : undefined;
     if (!commands) {
-      logger.warn(CHANNEL, `Unsupported multiple file selection: ${fileType}`);
+      log.warn(`Unsupported multiple file selection: ${fileType}`);
       return;
     }
     try {
@@ -176,8 +177,8 @@ export class FileManager extends BaseWebviewManager {
     currentOpenFile: string,
   ): Promise<void> {
     if (plan.log) {
-      const logFn = plan.log.level === 'info' ? logger.info : logger.warn;
-      logFn(CHANNEL, plan.log.message);
+      const logFn = plan.log.level === 'info' ? log.info : log.warn;
+      logFn(plan.log.message);
     }
 
     if (plan.notification) {
@@ -221,8 +222,7 @@ export class FileManager extends BaseWebviewManager {
         commitLabel,
       });
     } else {
-      logger.info(
-        CHANNEL,
+      log.info(
         `Commit ${commitHash} from ${fileName} was not found in repository history`,
       );
       vscode.window.showInformationMessage(
@@ -285,7 +285,7 @@ export class FileManager extends BaseWebviewManager {
     options: { notifyWhenEmpty?: boolean; preserveBaseFile?: boolean } = {},
   ): void {
     if (options.notifyWhenEmpty && files.length === 0) {
-      logger.debug(CHANNEL, 'No base files were found during refresh.');
+      log.debug('No base files were found during refresh.');
     }
     this.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_BASE_FILE,
@@ -305,7 +305,7 @@ export class FileManager extends BaseWebviewManager {
 
   private getOpenedFiles(): string[] {
     if (!WorkspaceFS.getPath()) {
-      logger.warn(CHANNEL, 'No workspace path found for opened files');
+      log.warn('No workspace path found for opened files');
       return [];
     }
 
@@ -324,7 +324,7 @@ export class FileManager extends BaseWebviewManager {
       ...new Set(fileUris.map((uri) => WorkspaceFS.relativePath(uri.fsPath))),
     ];
 
-    logger.debug(CHANNEL, `Found opened files: ${relevantFiles.join(', ')}`);
+    log.debug(`Found opened files: ${relevantFiles.join(', ')}`);
     return relevantFiles;
   }
 
@@ -342,8 +342,7 @@ export class FileManager extends BaseWebviewManager {
       if ((stat.type & vscode.FileType.File) === 0) return null;
       return resolved.relativePath;
     } catch (error) {
-      logger.debug(
-        CHANNEL,
+      log.debug(
         `Dropped file could not be read: ${decodedPath}: ${toErrorMessage(error)}`,
       );
       return null;

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -24,7 +24,7 @@
 
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass';
-import * as logUtils from '@logger/logUtils';
+import { createLog } from '@logger/logUtils';
 import type { ToolDefinition } from '@model/ToolDefinition';
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
@@ -45,6 +45,8 @@ import {
   SharedToolInjectionRegistry,
   type ToolInjectionRegistry,
 } from './toolInjection';
+
+const log = createLog('AgentToolResolution');
 
 export interface ResolveAgentToolsInput {
   tools: AgentToolUseSetting['tools'];
@@ -84,8 +86,7 @@ async function availableDelegationModelNamesForTools(
   } catch (err) {
     // Couldn't load model options — skip the delegation annotation rather than
     // fail the run, but log so the missing "Available models:" line is traceable.
-    logUtils.warn(
-      'AgentToolResolution',
+    log.warn(
       `Could not load model options for delegation annotation: ${toErrorMessage(
         err,
       )}`,


### PR DESCRIPTION
## Summary

Final collision-free batch of #10013, unblocked now that #10688 has merged.
Migrates the last two actionable production namespace-logger imports to
`createLog`:

- `src/agent/runtime/agentToolResolution.ts` — `import * as logUtils` →
  `const log = createLog('AgentToolResolution')`. The model-options failure
  warning keeps the exact `AgentToolResolution` channel, `warn` level, and
  message interpolation (`toErrorMessage(err)`); the caller-injected
  `logger.warn` contract for tool-not-found diagnostics is untouched.
- `packages/extension/src/webview/managers/FileManager.ts` —
  `import * as logger` → `const log = createLog(CHANNEL)`. Every
  `logger.{debug,info,warn}(CHANNEL, …)` call keeps the same channel, level,
  message, and (where present) `data`. The method-reference selection in
  `applyBaseFileSelectionPlan` stays a ternary between `log.info` and
  `log.warn`, then invokes the selected reference with the message — same
  reference semantics and evaluation timing as before.

Both bindings use `createLog`, which resolves the exported level writers
through `loggerSelf` on every call, so the existing
`vi.spyOn(logger, 'warn')` namespace spy seam still intercepts calls made
through these module-level bindings.

Closes #10013

## Issue acceptance gates

- Migrate the remaining `import * as logger/logUtils` production namespace
  consumers onto `createLog`.
- Preserve exact channels, levels, messages/data, method-reference behavior,
  evaluation timing, and the `loggerSelf`-based spy seam.
- Leave the two intentional live namespace injection seams in place and
  document why they are outside eligible migration.

## Single source of truth

`createLog(channel)` in `src/logger/logUtils.ts` remains the one channel-bound
logging primitive. These two final consumers now bind directly to it instead of
importing the whole logger namespace for their own diagnostics.

## Duplication and abstraction budget

No new abstraction, pass-through layer, or exported surface. The two files
drop a namespace import each and keep their local logger bindings.

## Net elements (R6)

- Files changed: **2** (both production, zero tests)
- Diffstat: **2 files changed, 15 insertions(+), 15 deletions(-), net 0 LoC**
- Exported-symbol delta (`^[+-]export`): **0**
- Classes/interfaces/enums added/deleted: **0**
- Namespace logger bindings removed: **2**
- New test cases added: **0**; no existing mock/expectation migration was
  required (the only `FileManager`-adjacent suite already mocks `FileManager`
  away, and the tool-resolution suites inject `logger: { warn }` directly).

## Consumer counts (R8 / exact final census)

Post-change production census (excluding `src/test-kernel` and build output):

`import * as (logger|logUtils) from '@logger/logUtils'` remaining — **3**:

- `src/logger/logUtils.ts` — `loggerSelf`, the factory's own per-call
  delegation seam; not a migration candidate.
- `packages/extension/src/common/webview/BaseViewMessageHandler.ts` —
  **intentional live namespace seam**.
- `packages/extension/src/frontend/auth/SupabaseAuthProvider.ts` —
  **intentional live namespace seam**.

Remaining #10013 migration candidates: **0**.

Production `createChannelTrace` re-audit (separate from #10013's
namespace-import scope; #10595 is already closed):

- 5 genuine `AgentTrace` contracts in `src/`:
  `AgentLaunchResources.ts:6`, `AgentRunLifecycle.ts:62`,
  `childRunLoop.ts:739`, `executionRegistry.ts:42`,
  `PollingSourceBase.ts:186`.
- 3 package `AgentTrace`/typed-option contracts:
  `desktopAgentExecution.ts:207`, `desktopAgentResume.ts:34`,
  `ProgressViewProvider.ts:101`.
- 1 log-only site, `packages/extension/src/commands/agent/resumeFromResumeData.ts:31`,
  remains owned by open PR #10699 and is deliberately not touched here.

## Intentional namespace seams (why they stay outside eligible migration)

- `BaseViewMessageHandler.ts` assigns `this.logger = logger` so subclasses
  (`MainViewMessageHandler`, `SettingsViewMessageHandler`,
  `ProgressViewMessageHandler`) can keep calling channel-first
  `this.logger.warn(channel, …)`. That channel-first value must resolve
  through the module namespace at call time to preserve the
  `vi.spyOn(logger, 'warn')` seam; replacing it with named imports or
  channel-bound methods would break either the subclass call shape or the spy
  seam.
- `SupabaseAuthProvider.ts` passes `logger.warn/error/info` as a value into
  the host auth coordinator, whose `log` contract is channel-first
  `(source, message, options)`. Keeping the per-call namespace lookup is the
  only way to keep exact two-argument call arity (`options` omitted when
  `undefined`) while still letting `vi.spyOn(logger, …)` intercept; removing
  it would widen a cross-host contract outside #10013's scope.

## Overlap audit

Audited all 5 currently open PRs (`#10704`, `#10702`, `#10699`, `#10697`,
`#10683`). None touch `src/agent/runtime/agentToolResolution.ts` or
`packages/extension/src/webview/managers/FileManager.ts`. #10699 touches the
separate `resumeFromResumeData.ts` createChannelTrace site noted above, which
this PR does not modify.

## Host impact

- Agent runtime: `agentToolResolution`'s model-options warning now emits
  through `createLog('AgentToolResolution')`; channel/level/message unchanged.
- Extension: `FileManager`'s own diagnostics now emit through
  `createLog('FileManager')`; channel/level/message unchanged, and the
  `plan.log.level === 'info' ? log.info : log.warn` method-reference selection
  is preserved exactly.
- Desktop/CLI/agent package: none.

## Scheduled refactoring

None. #10013 is complete under its carve-outs; the `resumeFromResumeData.ts`
log-only `createChannelTrace` site is the only remaining log-only trace caller
and is tracked by open #10699.

## Validation

All run on fresh external worktree at head `66aa5d1a0e` from `origin/main`
(`a6cc06c811`), after `corepack pnpm install --prefer-offline`.

- Focused affected suites: **4 files / 37 tests passed**
  (`DelegationAgentAvailability`, `DelegationWorktreeAvailability`,
  `ToolUseToolResolution`, `MainViewMessageHandler`).
- Broader affected area suites: **131 files / 1099 tests passed**
  (`src/test-kernel/tools`, `src/test-kernel/agent/followUp`,
  `src/test-kernel/webview`).
- Architecture suites: **17 files / 101 tests passed**.
- `npm run typecheck` (all six targets: workspace, test-kernel, agent, cli,
  trace-viewer, desktop): **green**.
- `npm run lint`: **green**.
- `npm run format:check`: **green** (repo-wide).
- `git diff --check`: **green**.
- `npm run check:dead-code-ratchet`: **OK** (8 current vs 8 baselined).
- `npm run check:guidance-refs`: **OK**.
- `npm run check:browser-safe-utils`: **OK**.
- `npm run check:tsconfig-paths`: **OK**.
- `npm run check:extension-package-invariants`: **OK**.

No new test coverage; no existing mock/expectation migration was needed.
