### PR TITLE
fix(progress): render malformed tool payloads as visible failures

### DIFF
--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -35,10 +35,7 @@ import {
   hasIncompleteEmbeddedSubagentFollowup,
   summarizeFollowupMessage,
 } from '@shared/subagentFollowup';
-import {
-  malformedToolUseFallback,
-  normalizeToolUseData,
-} from '@shared/toolUse';
+import { normalizeToolUseForRender } from '@shared/toolUse';
 import {
   applyCompactionActivityEntries,
   COMPACTION_ACTIVITY_LABEL,
@@ -303,8 +300,7 @@ function renderLogEntryFresh(
     // Malformed tool payloads render as a visible failed tool row instead of
     // being dropped. Both hosts share this fallback so a bad payload cannot
     // silently vanish from the transcript or fall through to default text.
-    const toolUse =
-      normalizeToolUseData(entry.data) ?? malformedToolUseFallback(entry.data);
+    const toolUse = normalizeToolUseForRender(entry.data);
     // Never finalize here. The settled-prefix promotion advances over a tool
     // row only once it completes AND every entry before it has promoted, so a
     // fast tool can't jump ahead of still-streaming assistant text in

--- a/packages/cli/src/chat/tui/state/transcriptFold.ts
+++ b/packages/cli/src/chat/tui/state/transcriptFold.ts
@@ -35,7 +35,10 @@ import {
   hasIncompleteEmbeddedSubagentFollowup,
   summarizeFollowupMessage,
 } from '@shared/subagentFollowup';
-import { normalizeToolUseData } from '@shared/toolUse';
+import {
+  malformedToolUseFallback,
+  normalizeToolUseData,
+} from '@shared/toolUse';
 import {
   applyCompactionActivityEntries,
   COMPACTION_ACTIVITY_LABEL,
@@ -297,10 +300,11 @@ function renderLogEntryFresh(
   }
 
   if (entry.messageType === MESSAGE_TYPES.TOOL_USE) {
-    const toolUse = normalizeToolUseData(entry.data);
-    // Drop malformed tool entries rather than crash. The progress view
-    // does the same — a bad payload shouldn't take down the transcript.
-    if (!toolUse) return null;
+    // Malformed tool payloads render as a visible failed tool row instead of
+    // being dropped. Both hosts share this fallback so a bad payload cannot
+    // silently vanish from the transcript or fall through to default text.
+    const toolUse =
+      normalizeToolUseData(entry.data) ?? malformedToolUseFallback(entry.data);
     // Never finalize here. The settled-prefix promotion advances over a tool
     // row only once it completes AND every entry before it has promoted, so a
     // fast tool can't jump ahead of still-streaming assistant text in

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -15,7 +15,10 @@ import { html, nothing, type TemplateResult } from 'lit';
 
 // Local imports - shared utilities
 import type { LogMessageData } from '@shared/schemas';
-import { normalizeToolUseData } from '@shared/toolUse';
+import {
+  malformedToolUseFallback,
+  normalizeToolUseData,
+} from '@shared/toolUse';
 import {
   DELEGATE_MULTI_AGENTS_TOOL_NAME,
   DELEGATION_TOOL_CATEGORY,
@@ -73,11 +76,13 @@ export function formatToolUseTemplate(
   options?: { executionLabels?: ExecutionLabels },
 ): FormatResult {
   const { timestamp, data } = message;
-  const normalizedToolLog = normalizeToolUseData(data);
-  if (!normalizedToolLog) return null;
-  // Normalization has already established that this is an object. Keep the
-  // raw value local to this render so fallback sections can include fields
-  // outside the common schema without retaining a second copy in UI state.
+  const normalizedToolLog =
+    normalizeToolUseData(data) ?? malformedToolUseFallback(data);
+  // Malformed payloads still produce a visible failed tool row through the
+  // shared fallback, instead of falling through to the default log template.
+  // Keep the raw value local to this render so fallback sections can include
+  // fields outside the common schema without retaining a second copy in UI
+  // state.
   const parsed = isObject(data) ? data : {};
 
   const {

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -15,10 +15,7 @@ import { html, nothing, type TemplateResult } from 'lit';
 
 // Local imports - shared utilities
 import type { LogMessageData } from '@shared/schemas';
-import {
-  malformedToolUseFallback,
-  normalizeToolUseData,
-} from '@shared/toolUse';
+import { normalizeToolUseForRender } from '@shared/toolUse';
 import {
   DELEGATE_MULTI_AGENTS_TOOL_NAME,
   DELEGATION_TOOL_CATEGORY,
@@ -76,8 +73,7 @@ export function formatToolUseTemplate(
   options?: { executionLabels?: ExecutionLabels },
 ): FormatResult {
   const { timestamp, data } = message;
-  const normalizedToolLog =
-    normalizeToolUseData(data) ?? malformedToolUseFallback(data);
+  const normalizedToolLog = normalizeToolUseForRender(data);
   // Malformed payloads still produce a visible failed tool row through the
   // shared fallback, instead of falling through to the default log template.
   // Keep the raw value local to this render so fallback sections can include

--- a/src/shared/toolUse.ts
+++ b/src/shared/toolUse.ts
@@ -128,6 +128,35 @@ export function normalizeToolUseData(data: unknown): NormalizedToolUse | null {
   };
 }
 
+/**
+ * Visible failure text both hosts render when a `toolUse` payload cannot be
+ * parsed. Kept beside {@link normalizeToolUseData} so the CLI and progress
+ * view can't drift on the wording of the shared malformed-payload policy.
+ */
+const MALFORMED_TOOL_USE_TEXT = 'Malformed tool payload';
+
+/**
+ * Host-neutral fallback for a `toolUse` row whose payload `safeParse` fails.
+ * Both renderers substitute this normalized view instead of dropping the row
+ * (CLI) or falling through to the default log template (webview). The raw
+ * payload is retained as `input` so a non-object value still has a visible
+ * body; unknown tool names and unstructured object outputs never reach this
+ * path because they still parse through {@link ToolUseLogSchema}.
+ */
+export function malformedToolUseFallback(data: unknown): NormalizedToolUse {
+  return {
+    toolName: '',
+    errorText: MALFORMED_TOOL_USE_TEXT,
+    outputText: '',
+    userInstructionText: '',
+    input: data,
+    isError: true,
+    isUserFeedback: false,
+    headerSummary: MALFORMED_TOOL_USE_TEXT,
+    status: TOOL_USE_STATUS.FAILED,
+  };
+}
+
 // ============================================================================
 // Shared tool limits
 // ============================================================================

--- a/src/shared/toolUse.ts
+++ b/src/shared/toolUse.ts
@@ -12,8 +12,10 @@ import {
   TOOL_USE_STATUS,
   ToolUseLogSchema,
   type NormalizedToolUse,
+  type ToolUseStatus,
 } from '@shared/schemas';
 import { isObject } from '@utils/core';
+import { truncateSummary } from '@utils/text/stringUtils';
 
 function trimmedOrNull(value: unknown): string | null {
   if (typeof value !== 'string') return null;
@@ -135,32 +137,88 @@ export function normalizeToolUseData(data: unknown): NormalizedToolUse | null {
  */
 const MALFORMED_TOOL_USE_TEXT = 'Malformed tool payload';
 
+const TOOL_USE_STATUS_VALUES = new Set<string>(Object.values(TOOL_USE_STATUS));
+
+/** Recover a source-owned status without accepting an invalid enum member. */
+function validSourceToolUseStatus(data: unknown): ToolUseStatus | undefined {
+  if (!isObject(data)) return undefined;
+  const status = data.status;
+  return typeof status === 'string' && TOOL_USE_STATUS_VALUES.has(status)
+    ? (status as ToolUseStatus)
+    : undefined;
+}
+
 /**
- * Host-neutral fallback for a `toolUse` row whose payload `safeParse` fails.
- * Both renderers substitute this normalized view instead of dropping the row
- * (CLI) or falling through to the default log template (webview). The row is
- * kept live (no `status`) until the source settles, so a temporarily
- * malformed payload can still be replaced by a later corrected one in the
- * append-only transcript. Only independently usable fields are preserved:
- * `input` is re-read from `data.input`, never the whole payload, so a
- * partially valid `read`/`bash` row cannot dump output the valid renderer
- * would have suppressed. Unknown tool names and unstructured object outputs
- * never reach this path because they still parse through
+ * Bounded, value-safe reason for a failed `toolUse` parse. Primitive payloads
+ * get a short type/preview; object payloads report only the invalid field
+ * *paths*, never field values, so a partially valid `read`/`bash` row cannot
+ * leak its full output into the diagnostic.
+ */
+function malformedToolUseDiagnostic(data: unknown): string {
+  const reason = isObject(data)
+    ? malformedObjectReason(data)
+    : malformedPrimitiveReason(data);
+  return truncateSummary(`${MALFORMED_TOOL_USE_TEXT} (${reason})`, 160);
+}
+
+function malformedObjectReason(data: Record<string, unknown>): string {
+  const parsed = ToolUseLogSchema.safeParse(data);
+  if (parsed.success) return 'unparseable payload';
+  const fields = [
+    ...new Set(
+      parsed.error.issues
+        .map((issue) => issue.path.join('.'))
+        .filter((path) => path.length > 0),
+    ),
+  ];
+  return fields.length > 0
+    ? `invalid ${fields.join(', ')}`
+    : 'unparseable payload';
+}
+
+function malformedPrimitiveReason(data: unknown): string {
+  if (data === null) return 'received null';
+  if (typeof data === 'string') {
+    return `received string ${JSON.stringify(truncateSummary(data, 40))}`;
+  }
+  if (typeof data === 'number') return `received number ${String(data)}`;
+  if (typeof data === 'boolean') return `received boolean ${String(data)}`;
+  if (Array.isArray(data)) return `received array of length ${data.length}`;
+  return `received ${typeof data}`;
+}
+
+/**
+ * Single render-boundary normalization shared by both hosts. A parse failure
+ * becomes a visible failed tool row instead of being dropped (CLI) or falling
+ * through to the default log template (webview).
+ *
+ * The fallback keeps the row live unless the source itself carries a valid
+ * terminal `status`, so a temporarily malformed in-progress row can still be
+ * replaced by a later corrected payload in the append-only transcript. It
+ * preserves only independently usable fields (`toolName` when a string,
+ * `input` from `data.input`) and keeps the bounded diagnostic out of the
+ * normal tool input/output sections. Unknown tool names and unstructured
+ * object outputs never reach the fallback because they still parse through
  * {@link ToolUseLogSchema}.
  */
-export function malformedToolUseFallback(data: unknown): NormalizedToolUse {
-  const toolName =
-    isObject(data) && typeof data.toolName === 'string' ? data.toolName : '';
-  const input = isObject(data) && 'input' in data ? data.input : undefined;
+export function normalizeToolUseForRender(data: unknown): NormalizedToolUse {
+  return normalizeToolUseData(data) ?? malformedToolUseFallback(data);
+}
+
+function malformedToolUseFallback(data: unknown): NormalizedToolUse {
+  const diagnostic = malformedToolUseDiagnostic(data);
+  const status = validSourceToolUseStatus(data);
   return {
-    toolName,
-    errorText: MALFORMED_TOOL_USE_TEXT,
+    toolName:
+      isObject(data) && typeof data.toolName === 'string' ? data.toolName : '',
+    errorText: diagnostic,
     outputText: '',
     userInstructionText: '',
-    input,
+    input: isObject(data) && 'input' in data ? data.input : undefined,
     isError: true,
     isUserFeedback: false,
-    headerSummary: MALFORMED_TOOL_USE_TEXT,
+    headerSummary: diagnostic,
+    ...(status !== undefined ? { status } : {}),
   };
 }
 

--- a/src/shared/toolUse.ts
+++ b/src/shared/toolUse.ts
@@ -138,22 +138,29 @@ const MALFORMED_TOOL_USE_TEXT = 'Malformed tool payload';
 /**
  * Host-neutral fallback for a `toolUse` row whose payload `safeParse` fails.
  * Both renderers substitute this normalized view instead of dropping the row
- * (CLI) or falling through to the default log template (webview). The raw
- * payload is retained as `input` so a non-object value still has a visible
- * body; unknown tool names and unstructured object outputs never reach this
- * path because they still parse through {@link ToolUseLogSchema}.
+ * (CLI) or falling through to the default log template (webview). The row is
+ * kept live (no `status`) until the source settles, so a temporarily
+ * malformed payload can still be replaced by a later corrected one in the
+ * append-only transcript. Only independently usable fields are preserved:
+ * `input` is re-read from `data.input`, never the whole payload, so a
+ * partially valid `read`/`bash` row cannot dump output the valid renderer
+ * would have suppressed. Unknown tool names and unstructured object outputs
+ * never reach this path because they still parse through
+ * {@link ToolUseLogSchema}.
  */
 export function malformedToolUseFallback(data: unknown): NormalizedToolUse {
+  const toolName =
+    isObject(data) && typeof data.toolName === 'string' ? data.toolName : '';
+  const input = isObject(data) && 'input' in data ? data.input : undefined;
   return {
-    toolName: '',
+    toolName,
     errorText: MALFORMED_TOOL_USE_TEXT,
     outputText: '',
     userInstructionText: '',
-    input: data,
+    input,
     isError: true,
     isUserFeedback: false,
     headerSummary: MALFORMED_TOOL_USE_TEXT,
-    status: TOOL_USE_STATUS.FAILED,
   };
 }
 


### PR DESCRIPTION
Refs #10678

## Semantics

Implements the malformed-payload half of #10678 (§4i) as the policy choice **visible failure row**, shared across both hosts.

`normalizeToolUseData` keeps its `NormalizedToolUse | null` contract. Both renderers now call a single shared `normalizeToolUseForRender(data)`, which returns the normal normalized view on `safeParse` success and otherwise substitutes a malformed-tool fallback, so a malformed `toolUse` payload renders as an explicit failed tool row instead of:

- **webview**: silently falling through to the default log template, and
- **CLI**: silently dropping the row.

The fallback:
- is a normal `NormalizedToolUse` with `isError: true`, so existing renderers style it as an error row;
- preserves a **valid source `status`** when the object payload carries one, and otherwise leaves `status` unset — it never synthesizes `failed`, so an unsettled in-progress row stays live and can be replaced by a later corrected payload in append-only scrollback;
- preserves only independently usable fields: `toolName` when it is a valid string, and `input` re-read from `data.input` — never the whole payload, so a partially valid `read`/`bash` row cannot dump output the valid renderer would have suppressed;
- renders a **bounded, value-safe diagnostic** (`Malformed tool payload (invalid status)` / `Malformed tool payload (received string "…")`) via the existing `errorText`/`headerSummary` fields, kept separate from the normal tool input/output sections. Object payloads report only invalid field paths, never field values; primitive previews are truncated.

Because both hosts already render `NormalizedToolUse`, this reuses the existing shared result structure rather than adding a new error/result abstraction.

Compatibility preserved:
- unknown tool names still parse through `ToolUseLogSchema` (`toolName` is an optional string) and render as normal tool rows;
- legitimate unstructured *outputs* still parse (all fields optional, `output: unknown`) and are formatted by the existing `formatOutputText` path.

## Net diff

- `src/shared/toolUse.ts`: +94/−0 (single `normalizeToolUseForRender`, safe diagnostic, source-status recovery)
- `packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts`: +7/−6 (call the shared entry point)
- `packages/cli/src/chat/tui/state/transcriptFold.ts`: +5/−5 (call the shared entry point)

3 files, +106/−11 across three commits.

## Caveats

- The malformed row renders through the existing tool card (`tool` role in CLI, `wa-details.tool-use-details` in webview), not the webview's thrown-error "Failed to render X" fallback.
- The diagnostic is fixed-shape and bounded to 160 chars; for object payloads it names the invalid field path(s) only and intentionally does not echo field values (so a malformed `read` row cannot leak its output). For primitive payloads it shows a truncated type/preview.
- If a malformed object payload carries a valid source `status: 'completed' | 'failed'`, that status is preserved and the row is terminal, matching the source; otherwise the row remains live until source settlement.
- The math-environment half (§4k) is intentionally untouched and remains covered by #10704.

## Validation

- Focused suites (unmodified): `NormalizeToolUse.vitest.ts` (12), `ToolUseFormatter.vitest.ts` (22), `StreamLogDeltaFold.vitest.ts` (10) — 44/44 green.
- Deleted scratch probes verified:
  - malformed in-progress row stays live (`status: in_progress`, not finalized) and a later corrected same-id payload replaces it;
  - a malformed `read_file` payload with invalid `status` and full output preserves `toolName`/`input`, emits `outputText: ''`, and its diagnostic names `invalid status` without containing the output text;
  - a primitive malformed payload produces a bounded `received string` diagnostic and no synthesized status;
  - webview renders a `wa-details.tool-use-details` failure card with the diagnostic instead of the default template.
- `npm run typecheck` (all six targets) green.
- `npm run lint` green.
- `corepack pnpm exec prettier --check .` green.
- `git diff --check` green.
- Ratchets: dead-code, guidance-refs, browser-safe-utils, tsconfig-paths all green.
