### PR TITLE
refactor(replacement): give replacement engine a single policy owner

### DIFF
--- a/src/agent/implementations/flows/reflection/output/XmlOutputManager.ts
+++ b/src/agent/implementations/flows/reflection/output/XmlOutputManager.ts
@@ -5,8 +5,7 @@ import { XMLParser } from 'fast-xml-parser';
 import { debugInternal, logInternal, type AgentTrace } from '@agent/trace';
 import { reportMissingOutputs } from '@agent/runtime/runFactEvents';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { FENCED_LATEX_BLOCK_REPLACEMENTS } from '@replacement/rulesRegex';
-import replacementEngine, { applyReplacements } from '@replacement/engine';
+import replacementEngine from '@replacement/engine';
 import type { FileLocation, OutputFileInfo } from '@shared/schemas';
 import { OUTPUT_DOCUMENT_TAG, OUTPUT_DOCUMENTS_TAG } from '@shared/schemas';
 import { getExtractedDocOutputFileName } from '@utils/files/outputFileUtils';
@@ -76,10 +75,7 @@ export class XmlOutputManager {
   ) {}
 
   private async processXmlContent(content: string): Promise<string> {
-    // applyNonRegex already applies all enabled non-regex categories
-    // (including latex_xml), so no need to re-apply them.
-    const normalized = replacementEngine.applyNonRegex(content);
-    return applyReplacements(normalized, FENCED_LATEX_BLOCK_REPLACEMENTS);
+    return replacementEngine.applyXmlContent(content);
   }
 
   private extractMultipleDocumentsByRegex(

--- a/src/agent/implementations/flows/reflection/output/XmlOutputManager.ts
+++ b/src/agent/implementations/flows/reflection/output/XmlOutputManager.ts
@@ -74,10 +74,6 @@ export class XmlOutputManager {
     private readonly streamId: string,
   ) {}
 
-  private async processXmlContent(content: string): Promise<string> {
-    return replacementEngine.applyXmlContent(content);
-  }
-
   private extractMultipleDocumentsByRegex(
     outputContent: string,
     preferredName?: string,
@@ -456,7 +452,7 @@ export class XmlOutputManager {
       `Ensuring correct XML structure: ${fileLocation.absolutePath}`,
     );
     const originalContent = await AbsoluteFS.read(fileLocation.absolutePath);
-    let content = await this.processXmlContent(originalContent);
+    let content = replacementEngine.applyXmlContent(originalContent);
 
     const closeTag = `</${OUTPUT_DOCUMENTS_TAG}>`;
     const openTag = `<${OUTPUT_DOCUMENTS_TAG}>`;

--- a/src/agent/implementations/flows/reflection/output/XmlOutputManager.ts
+++ b/src/agent/implementations/flows/reflection/output/XmlOutputManager.ts
@@ -452,7 +452,7 @@ export class XmlOutputManager {
       `Ensuring correct XML structure: ${fileLocation.absolutePath}`,
     );
     const originalContent = await AbsoluteFS.read(fileLocation.absolutePath);
-    let content = replacementEngine.applyXmlContent(originalContent);
+    let content = replacementEngine.applyFor(originalContent, 'xml-content');
 
     const closeTag = `</${OUTPUT_DOCUMENTS_TAG}>`;
     const openTag = `<${OUTPUT_DOCUMENTS_TAG}>`;

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -59,23 +59,50 @@ const log = createLog('ReplacementEngine');
  * these methods instead of composing lower-level rules themselves, so rule
  * selection, ordering, and failure handling stay in this module.
  */
+
+function applyNonRegexPolicy(text: string): string {
+  const processed = applyReplacements(text, getAllReplacements()).trim();
+  return shouldWrapCritiqueInAlign()
+    ? wrapCritiqueInAlign(processed)
+    : processed;
+}
+
+function applyAllPolicy(text: string): string {
+  const replacements = getAllReplacements();
+  const wrapCritique = shouldWrapCritiqueInAlign();
+  const maxStyleEnabled = getConfig<string[]>(
+    'texra.latex.enabledReplacements',
+    DEFAULT_CORE_SETTINGS.latex.enabledReplacements,
+  ).includes('max_style');
+  const maxStyleRegexEnabled = getConfig<string[]>(
+    'texra.latex.enabledReplacementsRegex',
+    DEFAULT_CORE_SETTINGS.latex.enabledReplacementsRegex,
+  ).includes('max_style_regex');
+
+  let result = applyReplacements(text, replacements, {
+    cleanupPasses: false,
+  }).trim();
+  if (wrapCritique) result = wrapCritiqueInAlign(result);
+  result = applyReplacements(result, getAllReplacementsRegex(), {
+    cleanupPasses: false,
+  }).trim();
+  // The legacy unbraced S migration is a compatibility rule, not an
+  // opt-in regex replacement: run it whenever the direct max-style group
+  // produced the persisted output it repairs. When `max_style_regex` is
+  // enabled, MAX_REGEX_REPLACEMENTS already contains the same rule.
+  if (maxStyleEnabled && !maxStyleRegexEnabled) {
+    result = applyReplacements(result, LEGACY_UNBRACED_S_MIGRATION, {
+      cleanupPasses: false,
+    }).trim();
+  }
+  result = applyReplacements(result, replacements).trim();
+  return wrapCritique ? wrapCritiqueInAlign(result) : result;
+}
+
 const replacementEngine = {
   /** Apply all configured non-regex replacement rules. */
   applyNonRegex(text: string): string {
-    const processed = applyReplacements(text, getAllReplacements()).trim();
-    return shouldWrapCritiqueInAlign()
-      ? wrapCritiqueInAlign(processed)
-      : processed;
-  },
-
-  /**
-   * Normalize a raw XML output document before parsing: run the full non-regex
-   * pipeline (which already covers latex_xml and the other enabled categories)
-   * and then the fenced-LaTeX-block regex, in that order.
-   */
-  applyXmlContent(text: string): string {
-    const normalized = this.applyNonRegex(text);
-    return applyReplacements(normalized, FENCED_LATEX_BLOCK_REPLACEMENTS);
+    return applyNonRegexPolicy(text);
   },
 
   /**
@@ -85,43 +112,33 @@ const replacementEngine = {
    * whole-document cleanup runs once at the end instead of after each pass.
    */
   applyAll(text: string): string {
-    const replacements = getAllReplacements();
-    const wrapCritique = shouldWrapCritiqueInAlign();
-    const maxStyleEnabled = getConfig<string[]>(
-      'texra.latex.enabledReplacements',
-      DEFAULT_CORE_SETTINGS.latex.enabledReplacements,
-    ).includes('max_style');
-    const maxStyleRegexEnabled = getConfig<string[]>(
-      'texra.latex.enabledReplacementsRegex',
-      DEFAULT_CORE_SETTINGS.latex.enabledReplacementsRegex,
-    ).includes('max_style_regex');
-
-    let result = applyReplacements(text, replacements, {
-      cleanupPasses: false,
-    }).trim();
-    if (wrapCritique) result = wrapCritiqueInAlign(result);
-    result = applyReplacements(result, getAllReplacementsRegex(), {
-      cleanupPasses: false,
-    }).trim();
-    // The legacy unbraced S migration is a compatibility rule, not an
-    // opt-in regex replacement: run it whenever the direct max-style group
-    // produced the persisted output it repairs. When `max_style_regex` is
-    // enabled, MAX_REGEX_REPLACEMENTS already contains the same rule.
-    if (maxStyleEnabled && !maxStyleRegexEnabled) {
-      result = applyReplacements(result, LEGACY_UNBRACED_S_MIGRATION, {
-        cleanupPasses: false,
-      }).trim();
-    }
-    result = applyReplacements(result, replacements).trim();
-    return wrapCritique ? wrapCritiqueInAlign(result) : result;
+    return applyAllPolicy(text);
   },
 
   /**
-   * Apply the full replacement pipeline to a `.tex` file being written, then
-   * restore the LaTeX built-in section sign from the KaTeX-only destination.
+   * Purpose-specific replacement policy entry point. Call sites request the
+   * exact ordered profile they need instead of composing lower-level rules at
+   * the call site. Both special-purpose profiles have production consumers:
+   * `xml-content` backs XML output normalization and `tex-write` backs
+   * `.tex` file writes.
    */
-  applyTexWrite(text: string): string {
-    return restoreLatexSectionSign(this.applyAll(text));
+  applyFor(text: string, purpose: 'xml-content' | 'tex-write'): string {
+    switch (purpose) {
+      case 'xml-content':
+        // XML output normalization runs the full non-regex pipeline (which
+        // already covers latex_xml) and then the fenced-LaTeX-block regex.
+        // The fenced-block pass is deliberate and unconditional here: it is
+        // part of this purpose's contract, independent of the
+        // `enabledReplacementsRegex` config that gates applyAll's regex pass.
+        return applyReplacements(
+          applyNonRegexPolicy(text),
+          FENCED_LATEX_BLOCK_REPLACEMENTS,
+        );
+      case 'tex-write':
+        // Writing a .tex file runs the full pipeline and then restores the
+        // LaTeX built-in section sign from the KaTeX-only destination.
+        return restoreLatexSectionSign(applyAllPolicy(text));
+    }
   },
 };
 

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -40,6 +40,7 @@ import {
   LEGACY_UNBRACED_S_MIGRATION,
   MAX_STYLE_REPLACEMENTS,
   MAX_REGEX_REPLACEMENTS,
+  restoreLatexSectionSign,
 } from './maxRules';
 import {
   EQUATION_MACRO_REPLACEMENTS,
@@ -54,7 +55,9 @@ import {
 const log = createLog('ReplacementEngine');
 
 /**
- * High-level APIs for applying text replacement rules.
+ * Single policy owner for replacement rules. Call sites route through one of
+ * these methods instead of composing lower-level rules themselves, so rule
+ * selection, ordering, and failure handling stay in this module.
  */
 const replacementEngine = {
   /** Apply all configured non-regex replacement rules. */
@@ -63,6 +66,16 @@ const replacementEngine = {
     return shouldWrapCritiqueInAlign()
       ? wrapCritiqueInAlign(processed)
       : processed;
+  },
+
+  /**
+   * Normalize a raw XML output document before parsing: run the full non-regex
+   * pipeline (which already covers latex_xml and the other enabled categories)
+   * and then the fenced-LaTeX-block regex, in that order.
+   */
+  applyXmlContent(text: string): string {
+    const normalized = this.applyNonRegex(text);
+    return applyReplacements(normalized, FENCED_LATEX_BLOCK_REPLACEMENTS);
   },
 
   /**
@@ -101,6 +114,14 @@ const replacementEngine = {
     }
     result = applyReplacements(result, replacements).trim();
     return wrapCritique ? wrapCritiqueInAlign(result) : result;
+  },
+
+  /**
+   * Apply the full replacement pipeline to a `.tex` file being written, then
+   * restore the LaTeX built-in section sign from the KaTeX-only destination.
+   */
+  applyTexWrite(text: string): string {
+    return restoreLatexSectionSign(this.applyAll(text));
   },
 };
 

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -6,8 +6,9 @@ import { LRUCache } from 'lru-cache';
 
 import { createLog } from '@logger/logUtils';
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+import { assertNever } from '@utils/core';
 import { getConfig } from '@utils/config/configUtils';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
   ReplacementCategory,
@@ -100,11 +101,6 @@ function applyAllPolicy(text: string): string {
 }
 
 const replacementEngine = {
-  /** Apply all configured non-regex replacement rules. */
-  applyNonRegex(text: string): string {
-    return applyNonRegexPolicy(text);
-  },
-
   /**
    * Apply every replacement rule in the recommended order. Non-regex
    * replacements run before and after regex replacements to fix artifacts they
@@ -138,6 +134,8 @@ const replacementEngine = {
         // Writing a .tex file runs the full pipeline and then restores the
         // LaTeX built-in section sign from the KaTeX-only destination.
         return restoreLatexSectionSign(applyAllPolicy(text));
+      default:
+        return assertNever(purpose, 'Unknown replacement purpose');
     }
   },
 };

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 // Local imports - tools
 import { isTexFile } from '@common/files/fileTypeUtils';
 import replacementEngine from '@replacement/engine';
-import { restoreLatexSectionSign } from '@replacement/maxRules';
 import type { ToolResult } from '@shared/schemas';
 import {
   applyApprovedFileEdit,
@@ -40,7 +39,7 @@ export class WriteFileTool extends defineTool({
     }
     const { path, displayPath, exists, originalContent } = prepared.target;
     const proposedContent = isTexFile(path)
-      ? restoreLatexSectionSign(replacementEngine.applyAll(input.content))
+      ? replacementEngine.applyTexWrite(input.content)
       : input.content;
 
     return applyApprovedFileEdit({

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -39,7 +39,7 @@ export class WriteFileTool extends defineTool({
     }
     const { path, displayPath, exists, originalContent } = prepared.target;
     const proposedContent = isTexFile(path)
-      ? replacementEngine.applyTexWrite(input.content)
+      ? replacementEngine.applyFor(input.content, 'tex-write')
       : input.content;
 
     return applyApprovedFileEdit({


### PR DESCRIPTION
Closes #10625

## Summary

`src/replacement/engine.ts` now owns the replacement policy for all four of its call sites. The two call sites that were composing lower-level replacement rules locally now route through one purpose-keyed engine entry point, so rule selection, ordering, and failure handling live in one module.

- `XmlOutputManager` previously called `replacementEngine.applyNonRegex(content)` and then `applyReplacements(normalized, FENCED_LATEX_BLOCK_REPLACEMENTS)`, importing both the low-level helper and the fenced-block rule. It now calls `replacementEngine.applyFor(originalContent, 'xml-content')` directly from `ensureCorrectXmlStructure`; its now-zero-logic async `processXmlContent` wrapper is deleted.
- `WriteTool` previously called `restoreLatexSectionSign(replacementEngine.applyAll(...))`, importing the section-sign rule from `@replacement/maxRules`. It now calls `replacementEngine.applyFor(input.content, 'tex-write')`.
- `texraResponseTextProcessing` and `DiffFileProcessor` already routed through `replacementEngine.applyAll` and are unchanged.

No new abstraction layer was introduced: the existing default `replacementEngine` object is the owner, and the special-purpose compositions are exposed through one `applyFor(text, 'xml-content' | 'tex-write')` method with two production consumers.

## Policy mapping

- **Who decides which rules run:** the engine. Category selection is driven by `texra.latex.enabledReplacements` / `texra.latex.enabledReplacementsRegex` / `texra.latex.customReplacements` / `texra.latex.customReplacementsRegex` / `texra.latex.wrapCritiqueInAlign`, read inside `engine.ts`. Call sites no longer select individual categories.
- **Ordering:**
  - `applyAll`: non-regex → optional `wrapCritiqueInAlign` → regex → conditional `LEGACY_UNBRACED_S_MIGRATION` → non-regex → optional final `wrapCritiqueInAlign` (unchanged).
  - `applyFor(text, 'xml-content')`: `applyNonRegexPolicy` (all enabled non-regex categories, including `latex_xml`) → `FENCED_LATEX_BLOCK_REPLACEMENTS`. This preserves the previous `processXmlContent` order exactly. The fenced-block pass is deliberately unconditional in this profile: it is part of the XML-output contract, independent of the `enabledReplacementsRegex` config that gates `applyAll`'s regex pass.
  - `applyFor(text, 'tex-write')`: `applyAllPolicy` → `restoreLatexSectionSign`. This preserves the previous `WriteTool` composition exactly.
- **Failure behavior:** unchanged for in-contract callers. Regex failures are caught per pattern in `applyReplacements` and logged on the `ReplacementEngine` channel; non-regex `replaceAll` and the section-sign restore do not throw. The profile switch delegates to these existing paths, and an out-of-contract `purpose` now fails loudly via `assertNever` rather than returning `undefined`.

## Net elements (R6)

- Files: 3 changed (`+76/−49`).
  - `src/replacement/engine.ts`: `+73/−37` (hoist `applyNonRegex`/`applyAll` bodies into file-local policy helpers; add two-profile `applyFor` with `assertNever`; remove the now-orphaned `applyNonRegex` object method)
  - `src/agent/implementations/flows/reflection/output/XmlOutputManager.ts`: `+2/−10` (delete `processXmlContent` wrapper; drop `rulesRegex`/`applyReplacements` imports; call `applyFor`)
  - `src/tools/WriteTool.ts`: `+1/−2` (call `applyFor`; drop `maxRules` import)
- Exported symbols: unchanged (`replacementEngine` default, `applyReplacements`, `NON_REGEX_CATEGORIES`, `REGEX_CATEGORIES`). The `applyNonRegex` property on the default object is removed.
- Classes/interfaces/enums: none added or deleted.
- Net LoC: `+27`.

## Consumer counts (R8)

Re-routing two call-site compositions onto the engine owner, no exported symbol or emit path deleted:

- `replacementEngine.applyFor`: 2 production call sites (`XmlOutputManager.ensureCorrectXmlStructure`, `WriteFileTool.execute`).
- `replacementEngine.applyAll`: 2 production call sites unchanged (`texraResponseTextProcessing`, `DiffFileProcessor`) plus existing test consumers.
- `replacementEngine.applyNonRegex`: removed; its logic is the file-local `applyNonRegexPolicy` used by the `xml-content` profile.

## Validation

Production-only per maintainer direction: no test files changed.

- `npm run typecheck` — clean (all six targets, exit 0).
- `npm run lint` — clean.
- `npx prettier --check .` — clean.
- `git diff --check` — clean.
- Ratchets: `check:dead-code-ratchet` OK (8 current = 8 baselined), `check:guidance-refs` OK, `check:browser-safe-utils` OK, `check:tsconfig-paths` OK.
- Vitest:
  - `src/test-kernel/replacement`, `src/test-kernel/latex`, `src/test-kernel/agent/output`, `src/test-kernel/tools`: **128 files / 1125 tests passed**.
  - Write-tool / response-processing-adjacent CLI+extension+desktop suites: **17 files / 1103 tests passed**.
- Deleted scratch probe (2 assertions, not committed) verified `applyFor('xml-content')` and `applyFor('tex-write')` reproduce the old call-site compositions on representative inputs.

## Overlap audit

Open PRs at push time (#10683, #10697, #10699, #10702, #10704, #10712) touch no file in this diff. In particular #10704 (math shielding) is confined to `packages/cli/src/chat/tui/render/*` and `src/shared/markdown/createMarkdownProcessor.ts`, with no overlap.

Refs #10622
