### PR TITLE
refactor(approval): alias plan approval request and drop zombie schema

### DIFF
--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -178,7 +178,7 @@ export type RetryResult =
  * and every host render the same contract; a field added to the permission
  * payload is available here without a hand-maintained mirror.
  */
-export type HostPlanApprovalRequest = PlanApprovalPermission;
+export type HostPlanApprovalRequest = Readonly<PlanApprovalPermission>;
 
 export interface HostBashApprovalRequest {
   readonly command: string;

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -174,9 +174,9 @@ export type RetryResult =
 
 /**
  * The plan-approval payload the runtime hands to hosts. This is deliberately
- * an alias of the shared {@link PlanApprovalPermission} schema so the runtime
- * and every host render the same contract; a field added to the permission
- * payload is available here without a hand-maintained mirror.
+ * an alias of the type inferred from `PlanApprovalPermissionSchema` so the
+ * runtime and every host render the same contract; a field added to the
+ * permission payload is available here without a hand-maintained mirror.
  */
 export type HostPlanApprovalRequest = Readonly<PlanApprovalPermission>;
 

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -4,7 +4,7 @@ import { createLog } from '@logger/logUtils';
 import type {
   AgentProposal,
   FileLocation,
-  Plan,
+  PlanApprovalPermission,
   ProgressPermissionKind as PendingInteractionKind,
   RetryPermission,
   StreamTabId,
@@ -172,12 +172,13 @@ export type RetryResult =
   // the `failed` fallback (→ RUN_OUTCOME.FAILED) instead of `cancelled`. See #7331.
   | { action: 'deny'; reason?: string; feedback?: never };
 
-export interface HostPlanApprovalRequest {
-  readonly approvalId: string;
-  readonly streamId: StreamTabId;
-  readonly plan: Plan;
-  readonly goalEnabled: boolean;
-}
+/**
+ * The plan-approval payload the runtime hands to hosts. This is deliberately
+ * an alias of the shared {@link PlanApprovalPermission} schema so the runtime
+ * and every host render the same contract; a field added to the permission
+ * payload is available here without a hand-maintained mirror.
+ */
+export type HostPlanApprovalRequest = PlanApprovalPermission;
 
 export interface HostBashApprovalRequest {
   readonly command: string;
@@ -561,7 +562,7 @@ export class SessionHostInteractions implements HostInteractions {
   ): Promise<ToolEditApprovalResult> {
     return this.enqueue<ToolEditApprovalResult>(
       'toolEdit',
-      request.streamId as StreamTabId | null | undefined,
+      request.streamId,
       (interactions) =>
         interactions.requestToolEditApproval?.(request, options),
       (cause) => ({ accepted: false, cause }),

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -185,18 +185,17 @@ export type UserQuestionAnswers = z.infer<typeof UserQuestionAnswersSchema>;
  * has a single source of truth. See docs/proposals/2026-05-31-tui-extension-sharing.md
  * (Rung 1).
  */
-const ApprovalDecisionSchema = z.object({
-  accepted: z.boolean(),
+export type ApprovalDecision = {
+  accepted: boolean;
   /**
    * Free-text payload carried with the decision. For rejections this is the
    * user's reject-with-feedback note; for an ExternalInquiry accept it is the
    * answer the agent gets back.
    */
-  userMessage: z.string().optional(),
+  userMessage?: string | undefined;
   /** Structured answers for an AskUserQuestion request. */
-  userQuestionAnswers: UserQuestionAnswersSchema.optional(),
-});
-export type ApprovalDecision = z.infer<typeof ApprovalDecisionSchema>;
+  userQuestionAnswers?: UserQuestionAnswers | undefined;
+};
 
 export const UserQuestionPermissionSchema = PermissionBaseSchema.extend({
   questions: z.array(UserQuestionPromptSchema).min(1).max(3),

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -51,7 +51,7 @@ export interface ToolEditApprovalRequest {
   readonly originalContent: string;
   readonly proposedContent: string;
   readonly sourceTool: string;
-  readonly streamId?: string | null;
+  readonly streamId?: StreamTabId | null;
 }
 
 /**


### PR DESCRIPTION
Refs #10674

## Summary

Smallest ruling-free slice of the §2.2 approval-plane aliasing, production-only:

- `HostPlanApprovalRequest` is now a type alias of the canonical
  `PlanApprovalPermissionSchema` inferred type (`Readonly<PlanApprovalPermission>`)
  instead of a hand-written mirror, preserving the removed interface's `readonly`
  field modifiers.
- `ToolEditApprovalRequest.streamId` is typed `StreamTabId | null`; the
  now-redundant cast in `SessionHostInteractions.requestToolEditApproval` is gone.
- The unparsed, unexported `ApprovalDecisionSchema` const is deleted; the
  exported `ApprovalDecision` type is preserved with the same shape.

No test files changed (zero-new-tests). No runtime schema, wire literal, or
public declaration shape change: `Readonly<PlanApprovalPermission>` restores the
old `readonly` modifiers, and `StreamTabId` is `z.string().min(1)` (a plain
`string`).

## Issue acceptance gates

Satisfies §2.2 items 1 (plan-approval mirror only, plus the `toolEdit`
`streamId` typing) and 5 (zombie `ApprovalDecisionSchema` deletion). Items 2–4,
the proposal half of item 1, and the ruling-gated catalog families remain open —
see Remaining gates below.

## Single source of truth

`src/shared/schemas/prompts.ts` remains the approval-permission SSOT.
`HostPlanApprovalRequest` now derives from the type inferred by
`PlanApprovalPermissionSchema` via `Readonly<PlanApprovalPermission>` instead of
re-declaring its fields.

## Duplication and abstraction budget

Removes one hand-maintained four-field mirror and one unparsed schema const. No
new abstraction, wrapper, or factory added.

## Net elements (R6)

```
 src/agent/runtime/HostInteractions.ts  | 17 +++++++++--------
 src/shared/schemas/prompts.ts          | 11 +++++------
 src/tools/approval/toolEditApproval.ts |  2 +-
 3 files changed, 15 insertions(+), 15 deletions(-)
```

- Files: 0 added, 0 deleted, 3 modified.
- Exported symbols (`^[+-]export` over the diff): 2 removed / 2 added, net 0
  (`HostPlanApprovalRequest` interface → type alias; `ApprovalDecision` type
  re-declared).
- Interfaces: 1 removed (`HostPlanApprovalRequest`), 0 added.
- Type aliases: 1 added (`HostPlanApprovalRequest`), 0 removed.
- Schema consts: 1 removed (`ApprovalDecisionSchema`), 0 added.
- Net LoC: 0 (+15 / −15).

## Consumer counts (R8)

- `HostPlanApprovalRequest` (re-routed declaration): 6 consumers —
  `src/agent/runtime/HostInteractions.ts:377,585`,
  `src/controllers/progressView/backend/progressHostInteractions.ts:400`,
  `src/test-kernel/agent/runtime/SessionInteractions.vitest.ts:9,165,169`.
  Grep across `src/` and `packages/*/src`: no others.
- `ApprovalDecisionSchema` (deleted): 0 consumers — grep `src/ packages/`
  (excl. generated `dist`) returns nothing; the type was never `.parse()`d.
- `ApprovalDecision` (kept exported type): live consumers include
  `packages/cli/src/chat/tui/state/approvalQueue.ts:23,62`,
  `packages/cli/src/runtime/approval/approvalPrompts.ts:64`,
  `src/test-kernel/cli/TuiApprovalRetry.vitest.ts:126,288,325`.
- `ToolEditApprovalRequest.streamId` (narrowed type, no emit/export removed):
  construction sites `src/tools/AcceptRunFilesTool.ts:217` and
  `src/tools/approval/toolEditApproval.ts:454` (both omit `streamId`, leaving
  run-context inference); consumers/transformers
  `src/tools/approval/toolEditApproval.ts:115,236,292`,
  `src/agent/runtime/HostInteractions.ts:565`,
  `src/controllers/approval/ToolEditApprovalController.ts:252,274`.
  `StreamTabId = z.infer<typeof StreamTabIdSchema>` (`z.string().min(1)`) is
  `string`, so every call site compiles unchanged.

## Host impact

Extension: none (type-only; no wire/IPC change).

Desktop: none.

CLI: none.

## Scheduled refactoring

`Refs #10674` — this PR is a slice, not a full close. Remaining §2.2 gates below.

## Remaining gates (not in this PR)

- §2.2 item 1 proposal half: `HostAgentProposalRequest` is still a hand-written
  composition (`AgentProposal & { proposalId; streamId }`), intentionally
  untouched by this slice.
- §2.2 item 2 approval-id rename (`requestId` everywhere, atomic rename).
- §2.2 item 3 CLI `ApprovalPayload` → shared `PermissionPayload`.
- §2.2 item 4 `ToolEditApprovalResult` `{accepted}` → `{action}` +
  `HostInteractionResultByKind` join.
- Ruling-gated catalog families from the tracker.

## Validation

- `npm run typecheck` all six targets: pass (workspace, test-kernel, agent with
  716-declaration validation, cli, trace-viewer, desktop). This is the readonly
  preservation evidence: `Readonly<PlanApprovalPermission>` keeps the old
  read-only port contract, so no regression test is added per the zero-new-tests
  policy.
- Affected suites: 13 approval/HostInteractions files, 217 tests pass; 6
  additional approval/session files, 46 tests pass.
- Architecture ratchets: 17 files, 101 tests pass.
- `npm run lint`: pass. `npm run format:check`: pass. `git diff --check`: pass.
- `check:dead-code-ratchet`: 8=8 baselined, OK. `check:guidance-refs`: OK.
  `check:browser-safe-utils`: 62 total / 7 reachable, OK.
