### PR TITLE
refactor(lifecycle): leak-triage polling unref + self-registration and desktop recording backstop

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -50,6 +50,7 @@ import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import { AgentCategory, agentKeyOf, type AgentSource } from '@shared/schemas';
 import { normalizePlatform } from '@shared/constants/latexToolchain';
 import { registerAgentShutdownHandlers } from '@tools/agentCliSessionStores';
+import { killActiveRecording } from '@tools/media/audio';
 import { ephemeralTranscriptWarning, StreamLogStore } from '@transcript';
 import { debounce } from '@utils/core';
 import { DEBOUNCE_OPTIONS_MS } from '@utils/config/constants';
@@ -1228,6 +1229,7 @@ if (protocolLifecycle.shouldContinue) {
         disposeAgentResumeHandler();
       });
       registerAgentShutdownHandlers(lifecycle);
+      lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => killActiveRecording());
       // Agent shutdown runs first so its final events enter the process-owned
       // stores. Flush in BEFORE so persistence cannot be delayed by a later
       // ON-phase language-service disposal.

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -100,9 +100,6 @@ import {
   refreshToolAvailability,
   seedDisabledToolDefaults,
 } from '@tools/toolAvailability';
-import { SharedIssuePollingSource } from '@tools/github/IssuePollingSource';
-import { SharedPRPollingSource } from '@tools/github/PRPollingSource';
-import { SharedRepoPollingSource } from '@tools/github/RepoPollingSource';
 import { killActiveRecording } from '@tools/media/audio';
 import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 import { setInlineCommentProvider } from '@tools/comment/InlineCommentTool';
@@ -297,15 +294,6 @@ export async function activate(context: vscode.ExtensionContext) {
     runtimeSession.flushArtifacts(),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => clearStoreCache());
-  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
-    SharedPRPollingSource.disposeAll(),
-  );
-  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
-    SharedRepoPollingSource.disposeAll(),
-  );
-  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
-    SharedIssuePollingSource.disposeAll(),
-  );
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
     appSignals.emit('extensionDeactivating', undefined),
   );

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -17,7 +17,11 @@ import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import { appSignals } from '@eventBus/AppSignals';
 
-import { SHUTDOWN_PHASE, type Disposable } from '@platform/interfaces';
+import {
+  SHUTDOWN_PHASE,
+  type Disposable,
+  type LifecycleHost,
+} from '@platform/interfaces';
 import { tryPlatform } from '@platform/platform';
 import { jitteredExponentialBackoffMs } from '@utils/core';
 import {
@@ -182,6 +186,7 @@ export abstract class PollingSourceBase<
   >();
   private timer: ReturnType<typeof setInterval> | undefined;
   private shutdownRegistration: Disposable | undefined;
+  private shutdownLifecycle: LifecycleHost | undefined;
   private tickInFlight = false;
 
   constructor(protected readonly config: PollingSourceConfig) {
@@ -398,19 +403,25 @@ export abstract class PollingSourceBase<
   }
 
   /**
-   * Register `disposeAll` with the platform shutdown registry exactly once.
-   * Uses `tryPlatform()` so the base stays usable in browser/test contexts
-   * where no platform is installed, and defers to the first subscription so
-   * the shared singletons (constructed at module load, before `initPlatform()`)
-   * still register once the platform exists.
+   * Register `disposeAll` with the platform shutdown registry exactly once per
+   * lifecycle instance. Uses `tryPlatform()` so the base stays usable in
+   * browser/test contexts where no platform is installed, and defers to the
+   * first subscription so the shared singletons (constructed at module load,
+   * before `initPlatform()`) still register once the platform exists.
+   *
+   * Keyed on the lifecycle instance rather than the disposable because
+   * extension reactivation (and the test harness) replaces the whole
+   * `LifecycleHost`; a stale registration must be swapped for one on the new
+   * host instead of skipping the re-registration.
    */
   private registerShutdownIfNeeded(): void {
-    if (this.shutdownRegistration) return;
     const lifecycle = tryPlatform()?.lifecycle;
-    if (!lifecycle) return;
+    if (!lifecycle || this.shutdownLifecycle === lifecycle) return;
+    this.shutdownRegistration?.dispose();
     this.shutdownRegistration = lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
       this.disposeAll(),
     );
+    this.shutdownLifecycle = lifecycle;
   }
 
   private async tick(): Promise<void> {

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -412,15 +412,19 @@ export abstract class PollingSourceBase<
    * Keyed on the lifecycle instance rather than the disposable because
    * extension reactivation (and the test harness) replaces the whole
    * `LifecycleHost`; a stale registration must be swapped for one on the new
-   * host instead of skipping the re-registration.
+   * host instead of skipping the re-registration. The callback also clears the
+   * marker so a drained lifecycle can never satisfy the idempotency guard on a
+   * later subscribe.
    */
   private registerShutdownIfNeeded(): void {
     const lifecycle = tryPlatform()?.lifecycle;
     if (!lifecycle || this.shutdownLifecycle === lifecycle) return;
     this.shutdownRegistration?.dispose();
-    this.shutdownRegistration = lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
-      this.disposeAll(),
-    );
+    this.shutdownRegistration = lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => {
+      this.shutdownRegistration = undefined;
+      this.shutdownLifecycle = undefined;
+      this.disposeAll();
+    });
     this.shutdownLifecycle = lifecycle;
   }
 

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -17,7 +17,8 @@ import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import { appSignals } from '@eventBus/AppSignals';
 
-import type { Disposable } from '@platform/interfaces';
+import { SHUTDOWN_PHASE, type Disposable } from '@platform/interfaces';
+import { tryPlatform } from '@platform/platform';
 import { jitteredExponentialBackoffMs } from '@utils/core';
 import {
   createBoundedIdSet,
@@ -180,6 +181,7 @@ export abstract class PollingSourceBase<
     (keys: readonly K[]) => void
   >();
   private timer: ReturnType<typeof setInterval> | undefined;
+  private shutdownRegistration: Disposable | undefined;
   private tickInFlight = false;
 
   constructor(protected readonly config: PollingSourceConfig) {
@@ -378,10 +380,13 @@ export abstract class PollingSourceBase<
   }
 
   private ensureTimer(): void {
+    this.registerShutdownIfNeeded();
     if (this.timer) return;
     this.timer = setInterval(() => {
       void this.tick();
     }, this.config.pollIntervalMs);
+    // A polling timer must never keep a host process alive on its own.
+    this.timer.unref?.();
     // Fire an immediate tick so first-subscribe doesn't wait a full interval.
     void this.tick();
   }
@@ -390,6 +395,22 @@ export abstract class PollingSourceBase<
     if (!this.timer) return;
     clearInterval(this.timer);
     this.timer = undefined;
+  }
+
+  /**
+   * Register `disposeAll` with the platform shutdown registry exactly once.
+   * Uses `tryPlatform()` so the base stays usable in browser/test contexts
+   * where no platform is installed, and defers to the first subscription so
+   * the shared singletons (constructed at module load, before `initPlatform()`)
+   * still register once the platform exists.
+   */
+  private registerShutdownIfNeeded(): void {
+    if (this.shutdownRegistration) return;
+    const lifecycle = tryPlatform()?.lifecycle;
+    if (!lifecycle) return;
+    this.shutdownRegistration = lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
+      this.disposeAll(),
+    );
   }
 
   private async tick(): Promise<void> {


### PR DESCRIPTION
## Summary

Lifecycle PR 1 (leak triage) slice for #10676, per
`docs/proposals/2026-08-15-lifecycle-ownership.md` §6 step 1. Production-only;
no `DisposableStore`, no Lean/UsageLog/lease/follow-up migration, no new tests.

## Issue acceptance gates

- Polling interval: `unref()` + self-registered `disposeAll` at the process
  root in `PollingSourceBase` itself; extension-only manual registrations
  deleted (doc §3 fix 1, §6 step 1).
- Desktop recording kill: `killActiveRecording` backstop in desktop main
  shutdown block, not `desktopAgentExecution.ts` (doc §3 fix 3, §6 step 1).
- Out of scope (later PRs): `DisposableStore`, Lean/UsageLog/lease/follow-up
  migration, committed test additions.

## Single source of truth

`src/platform/defaults/lifecycleHost.ts` remains the shutdown registry; each
`PollingSourceBase` instance is the owner of its own `disposeAll()` shutdown
registration, keyed on the active `LifecycleHost`.

## Duplication and abstraction budget

Deletes three hand-registered extension callbacks in favor of one
self-registration in the shared poller base. No new abstraction or
pass-through layer; the guard is the existing `tryPlatform()?.lifecycle`.

## Lifecycle ownership changes

- `src/tools/github/PollingSourceBase.ts`: `setInterval` timer now `unref()`s,
  and `registerShutdownIfNeeded()` registers `disposeAll()` with the active
  `LifecycleHost` (`SHUTDOWN_PHASE.ON`) on first subscribe. The guard is keyed
  on the lifecycle instance, disposes a stale registration when the platform
  lifecycle is replaced, and clears the marker when the callback drains.
- `packages/extension/src/extension.ts`: removes the three
  `SharedPRPollingSource` / `SharedRepoPollingSource` /
  `SharedIssuePollingSource` `disposeAll()` ON-phase registrations and their
  now-unused imports.
- `packages/desktop/src/main/index.ts`: registers `killActiveRecording()` in
  the desktop main shutdown block (`SHUTDOWN_PHASE.BEFORE`), mirroring the
  extension.

## Files

- `src/tools/github/PollingSourceBase.ts` +37/−1
- `packages/extension/src/extension.ts` 0/−12
- `packages/desktop/src/main/index.ts` +2/0

## Net elements (R6)

- Files: 0 added, 0 removed, 3 modified.
- Exported symbols: 0 added, 0 removed, 0 renamed
  (`git diff -U0 | grep '^[+-]export '` is empty).
- Classes/interfaces/enums: 0 added, 0 removed, 0 renamed.
- Net LoC: +39/−13 = +26.
- Lifecycle `onShutdown` call sites: −3 extension ON-phase manual poller
  registrations, +1 `PollingSourceBase` self-registration (covers the three
  process singletons), +1 desktop BEFORE-phase recording backstop = net −1
  static call site with the same per-process poller disposal count.

## Consumer counts (R8)

- `PollingSourceBase.disposeAll()` production callers: 1 (the new
  self-registration callback in `PollingSourceBase.ts`); the three removed
  extension.ts call sites were the only manual external production callers.
- `killActiveRecording()` shutdown callers: 2 (extension.ts:291 existing,
  desktop main index.ts:1232 new); `startRecording` / `stopRecordingAndTranscribe`
  callers unchanged.
- No `appSignals` emit path or exported symbol is severed; the
  `githubSubscriptionsChanged` emit inside `notifyKeysChanged` is untouched.

## Host impact

- Extension: poller teardown ownership moves from three activation-time
  ON-phase callbacks to first-subscribe self-registration; verified no
  load-bearing ON-phase ordering dependency.
- Desktop: recording process now killed on graceful quit / startup-failure
  shutdown, matching the extension.
- CLI: inherits poller `unref()` + self-registration; no CLI code changes.

## Scheduled refactoring

Lifecycle PRs 2–9 remain as listed in
`docs/proposals/2026-08-15-lifecycle-ownership.md` §6.

## Validation

- `corepack pnpm run typecheck` (workspace, test-kernel, agent, cli,
  trace-viewer, desktop): green.
- `corepack pnpm run lint`: green.
- `corepack pnpm run format:check`: green.
- `git diff --check`: clean.
- `corepack pnpm run check:dead-code-ratchet`: green (8/8).
- `corepack pnpm run check:guidance-refs`: green (51 files).
- `corepack pnpm run check:browser-safe-utils`: green (62 total, 7 reachable).
- Targeted vitest (167 tests total):
  - GitHub poller / lifecycle batch (53 tests):
    `tools/PollingSourceBase`, `tools/PRPollingSource`,
    `tools/PRPollingSourceAnnotationPages`, `tools/PRPollingSourceCiStarted`,
    `tools/GitHubSubscriptionTool`,
    `agent/followUp/GitHubSubscriptionProgressEvents`,
    `platform/LifecycleHost`, `architecture/SharedLiteralImmutability`.
  - Extension/desktop shutdown batch (114 tests):
    `agent/runtime/AgentShutdown`, `desktop/ElectronCompositionRoot`,
    `desktop/DesktopAgentExecution`, `desktop/DesktopAgentExecutionFactory`,
    `frontend/RecordingManager`, `commands/ExtensionCommandSurface`,
    `desktop/DesktopWorkspaceIpc`, `desktop/DesktopPtyHost`.
- Deleted scratch probes verified `PollingSourceBase` registers
  `disposeAll` with the platform lifecycle ON phase on first subscribe,
  re-registers when the platform lifecycle is replaced, and clears its marker
  when the lifecycle drains.

Refs #10676
