### PR TITLE
refactor(webview): order transcript by wire seqNo with shared comparator

### DIFF
--- a/packages/extension/src/progressView/frontend/components/messageIndex.ts
+++ b/packages/extension/src/progressView/frontend/components/messageIndex.ts
@@ -1,6 +1,7 @@
 /** Group tree, ungrouped messages, and chronological timeline indices. */
 
 import type { LogMessageData, TaskGroup } from '@shared/schemas';
+import { compareBySeqNo } from '@shared/streams/streamOrdering';
 
 export interface GroupTree {
   group: TaskGroup;
@@ -9,8 +10,8 @@ export interface GroupTree {
 }
 
 export type TimelineEntry =
-  | { key: string; time: number; msg: LogMessageData }
-  | { key: string; time: number; tree: GroupTree };
+  | { key: string; time: number; seqNo?: number; msg: LogMessageData }
+  | { key: string; time: number; seqNo?: number; tree: GroupTree };
 
 type MessageTimelineEntry = Extract<TimelineEntry, { msg: LogMessageData }>;
 
@@ -19,32 +20,55 @@ interface MessageLocation {
   timelineEntry?: MessageTimelineEntry;
 }
 
+/** The wall-clock fallback order key for a log message. */
+function messageTime(message: LogMessageData): number {
+  return message.timestamp ?? 0;
+}
+
+/** The wall-clock fallback order key for a task group. */
+function groupTime(group: TaskGroup): number {
+  return group.startTime ?? Number.MAX_SAFE_INTEGER;
+}
+
+function compareMessages(a: LogMessageData, b: LogMessageData): number {
+  return compareBySeqNo(a, b, (message) => message.seqNo, messageTime);
+}
+
+function compareGroups(a: TaskGroup, b: TaskGroup): number {
+  return compareBySeqNo(a, b, () => undefined, groupTime);
+}
+
+function compareTimeline(a: TimelineEntry, b: TimelineEntry): number {
+  return compareBySeqNo(
+    a,
+    b,
+    (entry) => entry.seqNo,
+    (entry) => entry.time,
+  );
+}
+
 /**
- * Insert into a time-sorted array in place and return the insertion index.
- * O(1) push when appending (common case — times increase), O(n) splice
- * otherwise.
+ * Insert into a comparator-sorted array in place and return the insertion
+ * index. O(1) push when appending (common case — order increases), O(n)
+ * splice otherwise.
  */
-function insertByTime<T>(
+function insertByOrder<T>(
   target: T[],
   entry: T,
-  timeOf: (item: T) => number,
+  compare: (a: T, b: T) => number,
 ): number {
-  const time = timeOf(entry);
-  const lastTime = target.length > 0 ? timeOf(target.at(-1)!) : -Infinity;
-  if (time >= lastTime) {
+  const last = target.length > 0 ? target.at(-1)! : undefined;
+  if (last !== undefined && compare(last, entry) <= 0) {
     target.push(entry);
     return target.length - 1;
   }
-  // findIndex always returns >= 0 here: we only reach this point when the
-  // target is non-empty and time < lastTime, so the last element satisfies
-  // the predicate.
-  const idx = target.findIndex((item) => timeOf(item) > time);
+  const idx = target.findIndex((item) => compare(entry, item) < 0);
+  if (idx < 0) {
+    target.push(entry);
+    return target.length - 1;
+  }
   target.splice(idx, 0, entry);
   return idx;
-}
-
-function messageTime(message: LogMessageData): number {
-  return message.timestamp ?? 0;
 }
 
 /** One reactive update of `groups` / `messages` / `terminal`. */
@@ -214,13 +238,10 @@ export class MessageIndex {
       }
     }
 
-    // Sort messages by timestamp and classify by groupId.
-    // JS engines use stable sort, so equal timestamps preserve original order.
-    const sortedMessages = messages.toSorted(
-      (a, b) =>
-        (a.timestamp ?? Number.MAX_SAFE_INTEGER) -
-        (b.timestamp ?? Number.MAX_SAFE_INTEGER),
-    );
+    // Sort messages by wire append sequence and classify by groupId. Rows
+    // without a usable sequence (archived/compat) fall back to timestamp.
+    // JS engines use stable sort, so equal order keys preserve original order.
+    const sortedMessages = messages.toSorted(compareMessages);
     const messagesByGroup = new Map<string, LogMessageData[]>();
     const ungrouped: LogMessageData[] = [];
     this.messageLocations.clear();
@@ -244,7 +265,7 @@ export class MessageIndex {
       const node: GroupTree = {
         group,
         children: (childrenMap.get(group.id) ?? [])
-          .sort((a, b) => a.startTime - b.startTime)
+          .sort(compareGroups)
           .map(buildNode),
         messages: messagesByGroup.get(group.id) ?? [],
       };
@@ -258,14 +279,10 @@ export class MessageIndex {
     // makes them degrade gracefully (rendered un-nested at the timeline top)
     // instead of vanishing silently along with their whole subtree and messages.
     // See docs/proposals/2026-05-30-progress-grouping-refactor.md (R2).
-    // Stable sort preserves original order for equal timestamps.
+    // Stable sort preserves original order for equal order keys.
     this.tree = groups
       .filter((g) => !g.parentGroupId || !groupMap.has(g.parentGroupId))
-      .sort(
-        (a, b) =>
-          (a.startTime ?? Number.MAX_SAFE_INTEGER) -
-          (b.startTime ?? Number.MAX_SAFE_INTEGER),
-      )
+      .sort(compareGroups)
       .map(buildNode);
     this.ungrouped = ungrouped;
   }
@@ -276,6 +293,7 @@ export class MessageIndex {
       ...this.ungrouped.map((m) => ({
         key: m.id,
         time: m.timestamp ?? 0,
+        seqNo: m.seqNo,
         msg: m,
       })),
       ...this.tree.map((t) => ({
@@ -283,7 +301,7 @@ export class MessageIndex {
         time: t.group.startTime ?? 0,
         tree: t,
       })),
-    ].sort((a, b) => a.time - b.time);
+    ].sort(compareTimeline);
     this.timeline = timeline;
     for (const item of timeline) {
       if ('msg' in item) {
@@ -295,7 +313,7 @@ export class MessageIndex {
   /**
    * Incrementally classify messages appended since `startIndex`.
    * Avoids full tree rebuilds by classifying only new messages and inserting
-   * by timestamp.
+   * by append-sequence order (timestamp fallback).
    */
   appendNewMessages(
     messages: readonly LogMessageData[],
@@ -306,9 +324,9 @@ export class MessageIndex {
       const node = msg.groupId ? this.groupNodeIndex.get(msg.groupId) : null;
       if (node) {
         this.removeUngroupedEntry(msg.id);
-        insertByTime(node.messages, msg, messageTime);
+        insertByOrder(node.messages, msg, compareMessages);
       } else {
-        const index = insertByTime(this.ungrouped, msg, messageTime);
+        const index = insertByOrder(this.ungrouped, msg, compareMessages);
         this.reindexUngroupedFrom(index);
       }
     }
@@ -319,7 +337,7 @@ export class MessageIndex {
    * Grouped messages are already referenced via their tree node in timeline,
    * so we skip them here. Iterating the messages slice — rather than the
    * ungrouped array — keeps this correct when a message with an earlier
-   * timestamp gets spliced into the middle of `ungrouped` by
+   * order key gets spliced into the middle of `ungrouped` by
    * `appendNewMessages`.
    */
   appendToTimeline(
@@ -332,9 +350,10 @@ export class MessageIndex {
       const entry: MessageTimelineEntry = {
         key: m.id,
         time: messageTime(m),
+        seqNo: m.seqNo,
         msg: m,
       };
-      insertByTime(this.timeline, entry, (item) => item.time);
+      insertByOrder(this.timeline, entry, compareTimeline);
       this.locationFor(entry.key).timelineEntry = entry;
     }
   }

--- a/packages/extension/src/progressView/frontend/components/messageIndex.ts
+++ b/packages/extension/src/progressView/frontend/components/messageIndex.ts
@@ -10,8 +10,8 @@ export interface GroupTree {
 }
 
 export type TimelineEntry =
-  | { key: string; time: number; seqNo?: number; msg: LogMessageData }
-  | { key: string; time: number; seqNo?: number; tree: GroupTree };
+  | { key: string; time: number; msg: LogMessageData }
+  | { key: string; time: number; tree: GroupTree };
 
 type MessageTimelineEntry = Extract<TimelineEntry, { msg: LogMessageData }>;
 
@@ -25,8 +25,18 @@ function messageTime(message: LogMessageData): number {
   return message.timestamp ?? 0;
 }
 
-/** The wall-clock fallback order key for a task group. */
-function groupTime(group: TaskGroup): number {
+/** Full-rebuild fallback: messages missing a timestamp sort last. */
+function messageTimeForRebuild(message: LogMessageData): number {
+  return message.timestamp ?? Number.MAX_SAFE_INTEGER;
+}
+
+/** The wall-clock fallback order key for a task-group child. */
+function groupStartTime(group: TaskGroup): number {
+  return group.startTime;
+}
+
+/** Full-rebuild fallback: root groups missing a start time sort last. */
+function groupStartTimeForRebuild(group: TaskGroup): number {
   return group.startTime ?? Number.MAX_SAFE_INTEGER;
 }
 
@@ -34,17 +44,28 @@ function compareMessages(a: LogMessageData, b: LogMessageData): number {
   return compareBySeqNo(a, b, (message) => message.seqNo, messageTime);
 }
 
-function compareGroups(a: TaskGroup, b: TaskGroup): number {
-  return compareBySeqNo(a, b, () => undefined, groupTime);
-}
-
-function compareTimeline(a: TimelineEntry, b: TimelineEntry): number {
+function compareMessagesForRebuild(
+  a: LogMessageData,
+  b: LogMessageData,
+): number {
   return compareBySeqNo(
     a,
     b,
-    (entry) => entry.seqNo,
-    (entry) => entry.time,
+    (message) => message.seqNo,
+    messageTimeForRebuild,
   );
+}
+
+function compareGroups(a: TaskGroup, b: TaskGroup): number {
+  return compareBySeqNo(a, b, () => undefined, groupStartTime);
+}
+
+function compareRootGroups(a: TaskGroup, b: TaskGroup): number {
+  return compareBySeqNo(a, b, () => undefined, groupStartTimeForRebuild);
+}
+
+function compareTimeline(a: TimelineEntry, b: TimelineEntry): number {
+  return a.time - b.time;
 }
 
 /**
@@ -241,7 +262,7 @@ export class MessageIndex {
     // Sort messages by wire append sequence and classify by groupId. Rows
     // without a usable sequence (archived/compat) fall back to timestamp.
     // JS engines use stable sort, so equal order keys preserve original order.
-    const sortedMessages = messages.toSorted(compareMessages);
+    const sortedMessages = messages.toSorted(compareMessagesForRebuild);
     const messagesByGroup = new Map<string, LogMessageData[]>();
     const ungrouped: LogMessageData[] = [];
     this.messageLocations.clear();
@@ -282,7 +303,7 @@ export class MessageIndex {
     // Stable sort preserves original order for equal order keys.
     this.tree = groups
       .filter((g) => !g.parentGroupId || !groupMap.has(g.parentGroupId))
-      .sort(compareGroups)
+      .sort(compareRootGroups)
       .map(buildNode);
     this.ungrouped = ungrouped;
   }
@@ -293,7 +314,6 @@ export class MessageIndex {
       ...this.ungrouped.map((m) => ({
         key: m.id,
         time: m.timestamp ?? 0,
-        seqNo: m.seqNo,
         msg: m,
       })),
       ...this.tree.map((t) => ({
@@ -350,7 +370,6 @@ export class MessageIndex {
       const entry: MessageTimelineEntry = {
         key: m.id,
         time: messageTime(m),
-        seqNo: m.seqNo,
         msg: m,
       };
       insertByOrder(this.timeline, entry, compareTimeline);

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -26,6 +26,7 @@ import { ensureStreamState, type StreamLogs } from '../store';
 function toLogMessage(entry: StreamLogEntry): LogMessageData {
   return {
     id: entry.id,
+    seqNo: entry.seqNo,
     text: entry.text ?? '',
     level: entry.level,
     timestamp: entry.timestamp,
@@ -56,6 +57,7 @@ function syncCompactionProjectionChanges(
     const id = `compaction:${block.operationId}`;
     const nextLog: LogMessageData = {
       id,
+      seqNo: block.startPosition,
       text: '',
       level: 'info',
       timestamp: block.startedAt,

--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -139,6 +139,13 @@ export type StreamLogTextDelta = z.infer<typeof StreamLogTextDeltaSchema>;
 
 const LogMessageDataSchema = z.strictObject({
   id: z.string().min(1),
+  /**
+   * Wire append sequence of the source `StreamLogEntry`, carried through so
+   * the frontend can order live rows by `seqNo` instead of wall-clock
+   * `timestamp`. Optional for archived/compat rows predating sequence
+   * tracking; ordering falls back to `timestamp` when it is absent.
+   */
+  seqNo: z.int().positive().optional(),
   text: z.string(),
   level: LogLevelSchema,
   timestamp: z.number(),

--- a/src/shared/streams/streamOrdering.ts
+++ b/src/shared/streams/streamOrdering.ts
@@ -1,5 +1,7 @@
 import type { StreamTabInfo } from '@shared/schemas';
 
+/** Ordering helpers shared by stream tabs and transcript rows. */
+
 /** The two fields tab order depends on, so name-only sorts can reuse this rule. */
 type StreamOrderingFields = Pick<StreamTabInfo, 'name' | 'creationTimestamp'>;
 
@@ -11,4 +13,34 @@ export function compareByNewestCreationTime(
   return (
     b.creationTimestamp - a.creationTimestamp || a.name.localeCompare(b.name)
   );
+}
+
+/**
+ * Compare transcript rows by their wire append sequence (`seqNo`), falling
+ * back to a wall-clock key when either row predates sequence tracking.
+ *
+ * Live rows (both carrying a usable positive `seqNo`) sort by that sequence —
+ * immune to clock skew and timestamp ties — with the fallback key as the
+ * tie-break. Archived/compat rows, or a mix of row generations, keep the
+ * caller's fallback chronology. `seqNoOf` and `fallbackTimeOf` let the same
+ * rule serve message rows (`timestamp`) and group rows (`startTime`).
+ */
+export function compareBySeqNo<T>(
+  a: T,
+  b: T,
+  seqNoOf: (item: T) => number | undefined,
+  fallbackTimeOf: (item: T) => number,
+): number {
+  const aSeq = usableSequence(seqNoOf(a));
+  const bSeq = usableSequence(seqNoOf(b));
+  if (aSeq !== undefined && bSeq !== undefined) {
+    return aSeq - bSeq || fallbackTimeOf(a) - fallbackTimeOf(b);
+  }
+  return fallbackTimeOf(a) - fallbackTimeOf(b);
+}
+
+function usableSequence(seqNo: number | undefined): number | undefined {
+  return seqNo !== undefined && Number.isSafeInteger(seqNo) && seqNo > 0
+    ? seqNo
+    : undefined;
 }


### PR DESCRIPTION
## Summary

Wave B-1 of #10671, production-only. Homogeneous webview message arrays now order by the wire append sequence already carried on every `StreamLogEntry` and previously discarded at `toLogMessage`, instead of wall-clock `timestamp`. The interleaved timeline stays time-sorted (see caveat below) because group rows do not yet carry a sequence; homogeneous message arrays are `seqNo`-ordered.

## Issue acceptance gates

- B-1 ordering slice implemented; B-2 row-model work remains out of scope (`Refs`, not `Closes`).
- Wire field is `seqNo`, not the issue/plan wording `sourceSeqNo` (corrected audit below).
- No CLI settlement ordering changes.

## Single source of truth

- Wire sequence: `StreamLogEntrySchema.seqNo` (`src/shared/schemas/log.ts:114`) — carried, not re-derived.
- Webview ordering rule: `compareBySeqNo` in `src/shared/streams/streamOrdering.ts` — the one comparator every homogeneous message/group ordering path delegates to.

## Duplication and abstraction budget

- Removed independent timestamp/startTime comparator callbacks; message and group arrays now share one comparator.
- No new abstraction layer: `compareBySeqNo` is a single function in the existing ordering-helper module, parameterized only by the two accessors that differ per row shape (`seqNo` / wall-clock fallback).

## Net elements (R6)

- Files changed: 4 (`messageIndex.ts`, `logSlice.ts`, `src/shared/schemas/log.ts`, `src/shared/streams/streamOrdering.ts`).
- Exported symbols: **+1** `compareBySeqNo`; no exports deleted.
- Classes/interfaces/enums: **+0 / −0** (one optional field added to `LogMessageData`; `TimelineEntry` shape unchanged).
- Net LoC: **+115 / −36**. Not the plan's −40..−49: that estimate predated the four-comparator census and the `seqNo` carry through `LogMessageData`.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed. `compareBySeqNo` is a new exported helper with one production consumer module (`messageIndex.ts`).

## Host impact

Extension: log messages order by `seqNo` within their homogeneous arrays; archived/compat rows fall back to `timestamp`/`startTime`.

Desktop: same webview ordering path.

CLI: untouched — settlement/scrollback ordering remains in `packages/cli/src/chat/tui/panes/transcriptEntries.ts` / `transcriptFold.ts`.

## Scheduled refactoring

B-2 of #10671 (shared `projectTranscriptRow` row model, which can carry group sequence and let the timeline use one comparable key).

## Validation

Zero new tests; existing suites unmodified.

- `vitest run --config vitest.config.mjs src/test-kernel/progressView src/test-kernel/webview src/test-kernel/traceViewer` → **73 files / 685 tests passed** on the final head.
- Focused affected suites: `TaskGroupListIndex` (15), `LogDeltaTextDeltas`, `CompactionActivityRender` (3), `traceViewer/replayTrace` (9), `shared/TaskGroupProjection` → **50 passed**.
- Full 6-part `npm run typecheck` → exit 0 (re-run on final head).
- `npm run lint` → exit 0 (re-run on final head).
- `npm run format:check` → exit 0.
- `git diff --check` → exit 0.
- Ratchets: `check:dead-code-ratchet` (8 current vs 8 baselined), `check:guidance-refs`, `check:browser-safe-utils` → all exit 0.
- Scratch probe (deleted, not committed) verified: `seqNo` beats skewed/equal timestamps; timestamp fallback for missing/mixed generations; `MessageIndex` rebuild/incremental message insertion order by `seqNo`; timeline remains time-sorted.

## Corrected current-tree audit

- Canonical wire field is **`seqNo`** (`src/shared/schemas/log.ts:114`). `sourceSeqNo` is a CLI transcriptFold-internal derived field (`packages/cli/src/chat/tui/state/transcriptFold.ts:267`), not the wire field.
- The plan's "three `timestamp` comparators" was an undercount. `messageIndex.ts` at `f085b4ada5` had **four** comparator callbacks plus incremental `insertByTime`:
  1. `insertByTime` (`:27`) — numeric-time insertion, called from `:309`, `:311`, `:337`.
  2. `messageTime` (`:46`) — `timestamp ?? 0`.
  3. `rebuildTree` message sort (`:219–223`) — `(a.timestamp ?? MAX) - (b.timestamp ?? MAX)`.
  4. `rebuildTree` children sort (`:247`) — `a.startTime - b.startTime`.
  5. `rebuildTree` roots sort (`:264–268`) — `(a.startTime ?? MAX) - (b.startTime ?? MAX)`.
  6. `rebuildTimeline` sort (`:286`) — `a.time - b.time`.

After this branch: `messageTime` (`:24`), `messageTimeForRebuild` (`:29`), `groupStartTime` (`:34`), `groupStartTimeForRebuild` (`:39`), `compareMessages` (`:43`), `compareMessagesForRebuild` (`:47`), `compareGroups` (`:59`), `compareRootGroups` (`:63`), `compareTimeline` (`:67`), `insertByOrder` (`:76`); sort/insertion sites `:265`, `:289`, `:306`, `:324`, `:347`, `:349`, `:375`.

## Caveats

- **Timeline interleaving remains time-sorted.** `TaskGroup` does not carry `seqNo`, so a mixed message/group comparator would not be a strict weak ordering under clock skew (message-message would use `seqNo`, message-group would use time, allowing cycles). Following the review's smallest fix, the interleaved timeline stays `a.time - b.time` and `seqNo` ordering is reserved for the homogeneous message arrays until B-2 carries group sequence.
- **Group arrays use the shared comparator's fallback path** (`seqNoOf` is currently `() => undefined`), so their behavior is unchanged; adding `TaskGroup.seqNo` later only changes that accessor.
- **Fallback compatibility.** Rows lacking a usable positive-integer `seqNo` keep the prior `timestamp`/`startTime` chronology; mixed-generation comparisons fall back to wall-clock time.
- Open PRs #10714, #10713, #10712, #10704, #10702, #10699, #10697, #10683 touch none of the four changed files.

Refs #10671

