### PR TITLE
refactor(schemas): derive targeted webview arms from one projection shape

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -37,6 +37,16 @@
       "name": "packages/trace-viewer/vite.standalone.config.ts"
     },
     {
+      "file": "src/shared/schemas/progressView/projectionShape.ts",
+      "category": "exports",
+      "name": "StreamContentProjectionShapeSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/projectionShape.ts",
+      "category": "types",
+      "name": "StreamContentProjectionShape"
+    },
+    {
       "file": "src/test-kernel/support/setupFakePlatform.ts",
       "category": "files",
       "name": "src/test-kernel/support/setupFakePlatform.ts"

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -1,9 +1,17 @@
+import {
+  UpdateCompileFailuresMessageSchema,
+  UpdateConversationProgressMessageSchema,
+  UpdateFilesMessageSchema,
+  UpdateMissingOutputsMessageSchema,
+  UpdateStreamDescriptionMessageSchema,
+  UpdateStreamStatusMessageSchema,
+} from './progressView/outbound';
+import type { z } from 'zod';
+
 import type { AgentCategory } from './agent';
 import type { ExecutionId, StorageKey, StreamTabId } from './identifiers';
-import type { CompileFailure, FileLocation, OutputFileInfo } from './output';
-import type { RoundIndexed } from './roundIndexed';
-import type { ConversationProgress, RoundStage } from './streamState';
-import type { StreamPhase, StreamSubstate } from './stream';
+import type { FileLocation } from './output';
+import type { RoundStage } from './streamState';
 import type { ExtendedTokenUsageStats } from './usage';
 
 /**
@@ -41,7 +49,9 @@ export interface SetActiveStreamPayload {
 
 export interface UpdateStreamDescriptionPayload {
   streamId: StreamTabId;
-  description: string;
+  description: z.infer<
+    typeof UpdateStreamDescriptionMessageSchema
+  >['description'];
 }
 
 export interface SetParentStreamPayload {
@@ -55,25 +65,29 @@ export interface RemoveStreamPayload {
 
 export interface UpdateStreamStatusPayload {
   streamId: StreamTabId;
-  status: StreamPhase;
+  status: z.infer<typeof UpdateStreamStatusMessageSchema>['status'];
   /** Diagnostic transition cause retained for legacy host/public output. */
   cause?: string;
   /** Previous phase before this update, for detecting transitions. */
-  previousStatus?: StreamPhase;
+  previousStatus?: z.infer<typeof UpdateStreamStatusMessageSchema>['status'];
   /** Narrower in-flight display state for launch/resume overlays. */
-  substate?: StreamSubstate;
+  substate?: z.infer<typeof UpdateStreamStatusMessageSchema>['substate'];
 }
 
 export interface AddOutputFilesPayload extends StreamScopedPayload {
-  filesByRound: RoundIndexed<OutputFileInfo>;
+  filesByRound: NonNullable<z.infer<typeof UpdateFilesMessageSchema>['rounds']>;
 }
 
 export interface UpdateMissingOutputsPayload extends StreamScopedPayload {
-  filesByRound: RoundIndexed<string>;
+  filesByRound: NonNullable<
+    z.infer<typeof UpdateMissingOutputsMessageSchema>['rounds']
+  >;
 }
 
 export interface UpdateCompileFailuresPayload extends StreamScopedPayload {
-  filesByRound: RoundIndexed<CompileFailure>;
+  filesByRound: NonNullable<
+    z.infer<typeof UpdateCompileFailuresMessageSchema>['rounds']
+  >;
 }
 
 /**
@@ -96,7 +110,7 @@ export interface UpdateStreamUsagePayload {
 
 export interface UpdateConversationProgressPayload {
   streamId: StreamTabId;
-  progress: ConversationProgress;
+  progress: z.infer<typeof UpdateConversationProgressMessageSchema>['progress'];
 }
 
 /** Round advance within a run, projected from `stage.start` (kind 'round').

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   UpdateCompileFailuresMessageSchema,
   UpdateConversationProgressMessageSchema,
   UpdateFilesMessageSchema,

--- a/src/shared/schemas/progressView/index.ts
+++ b/src/shared/schemas/progressView/index.ts
@@ -6,11 +6,14 @@
  * schemas are split into focused modules; this file re-exports them so import
  * sites stay unchanged.
  *
- * - `./data`     - shared field schemas + tool-use/web-search/web-fetch payloads
- * - `./outbound` - backend → frontend messages (UPDATE_*, SYNC_*) + union
- * - `./inbound`  - frontend → backend messages (actions, follow-ups) +
- *                  union + dispatcher
+ * - `./data`           - shared field schemas + tool-use/web-search/web-fetch payloads
+ * - `./projectionShape` - canonical SYNC_STREAM_CONTENT projection shape +
+ *                         `pickProjection` derivation helper
+ * - `./outbound`       - backend → frontend messages (UPDATE_*, SYNC_*) + union
+ * - `./inbound`        - frontend → backend messages (actions, follow-ups) +
+ *                        union + dispatcher
  */
 export * from './data';
+export * from './projectionShape';
 export * from './outbound';
 export * from './inbound';

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -14,7 +14,7 @@ import {
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { SetThemeMessageSchema } from '../commonViewMessages';
 import { commandOnly } from '../messageFactories';
-import { GoalStateSchema, GoalStatusSchema } from '../goal';
+import { GoalStatusSchema } from '../goal';
 import { AgentCategory } from '../agent';
 
 import { StreamTabIdSchema } from '../identifiers';
@@ -23,8 +23,6 @@ import {
   AgentOptionDataSchema,
   ModelOptionDataSchema,
 } from '../mainView/state';
-import { CompileFailureSchema, OutputFileInfoSchema } from '../output';
-import { roundIndexedRecord } from '../roundIndexed';
 import { InquiryThreadUpdatedEventSchema } from '../inquiry';
 import {
   AgentProposalPermissionSchema,
@@ -40,15 +38,8 @@ import {
   StreamSubstateSchema,
   StreamTabInfoSchema,
 } from '../stream';
-import {
-  ActiveChildInfoSchema,
-  ConversationProgressSchema,
-  StreamStageSchema,
-  StreamMetadataSchema,
-} from '../streamState';
-import { PlanSchema } from '../plan';
-import { TodoItemSchema } from '../todo';
-import { RunUsageMapSchema, TokenUsageStatsSchema } from '../usage';
+import { StreamMetadataSchema } from '../streamState';
+import { pickProjection } from './projectionShape';
 import {
   ProgressViewPlacementSchema,
   StreamScopedBaseSchema,
@@ -94,27 +85,29 @@ const ReleaseStreamContentMessageSchema = z.strictObject({
   stream: StreamTabIdSchema,
 });
 
-const UpdateConversationProgressMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_CONVERSATION_PROGRESS),
-  progress: ConversationProgressSchema,
-});
+export const UpdateConversationProgressMessageSchema =
+  StreamScopedBaseSchema.extend({
+    command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_CONVERSATION_PROGRESS),
+    progress: pickProjection('conversationProgress'),
+  });
 
 const UpdateStageMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STAGE),
-  stage: StreamStageSchema,
+  stage: pickProjection('stage'),
 });
 
 const UpdateStreamBadgesMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES),
-  subagents: z.array(ActiveChildInfoSchema),
+  subagents: pickProjection('subagents'),
 });
 
-const UpdateStreamDescriptionMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_DESCRIPTION),
-  description: z.string(),
-});
+export const UpdateStreamDescriptionMessageSchema =
+  StreamScopedBaseSchema.extend({
+    command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_DESCRIPTION),
+    description: z.string(),
+  });
 
-const UpdateStreamStatusMessageSchema = StreamScopedBaseSchema.extend({
+export const UpdateStreamStatusMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS),
   status: StreamPhaseSchema,
   substate: StreamSubstateSchema.optional(),
@@ -132,53 +125,54 @@ const LogDeltaMessageSchema = z.object({
 
 // Round-keyed update messages share one shape: a stream id, an optional
 // `rounds` record of per-round arrays, and an optional `reset` flag. The
-// generic `command`/element params keep each `command` literal distinct so the
-// outbound discriminated union still narrows.
+// generic `command`/`rounds` params keep each `command` literal distinct so the
+// outbound discriminated union still narrows; the `rounds` schema itself comes
+// from the canonical projection shape.
 function RoundUpdateMessageSchema<C extends string, T extends z.ZodType>(
   command: C,
-  elementSchema: T,
+  roundsSchema: T,
 ) {
   return StreamScopedBaseSchema.extend({
     command: z.literal(command),
-    rounds: roundIndexedRecord(elementSchema).optional(),
+    rounds: roundsSchema.optional(),
     reset: z.boolean().optional(),
   });
 }
 
-const UpdateFilesMessageSchema = RoundUpdateMessageSchema(
+export const UpdateFilesMessageSchema = RoundUpdateMessageSchema(
   PROGRESS_VIEW_COMMANDS.UPDATE_FILES,
-  OutputFileInfoSchema,
+  pickProjection('files'),
 );
 
-const UpdateMissingOutputsMessageSchema = RoundUpdateMessageSchema(
+export const UpdateMissingOutputsMessageSchema = RoundUpdateMessageSchema(
   PROGRESS_VIEW_COMMANDS.UPDATE_MISSING_OUTPUTS,
-  z.string(),
+  pickProjection('missing'),
 );
 
-const UpdateCompileFailuresMessageSchema = RoundUpdateMessageSchema(
+export const UpdateCompileFailuresMessageSchema = RoundUpdateMessageSchema(
   PROGRESS_VIEW_COMMANDS.UPDATE_COMPILE_FAILURES,
-  CompileFailureSchema,
+  pickProjection('compileFailures'),
 );
 
 const UpdateTodosMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_TODOS),
-  todos: z.array(TodoItemSchema),
+  todos: pickProjection('todos'),
 });
 
 const UpdatePlanMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_PLAN),
-  plan: PlanSchema.nullable(),
+  plan: pickProjection('plan'),
 });
 
 const UpdateRunUsageMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_RUN_USAGE),
   runId: z.string(),
-  usage: TokenUsageStatsSchema,
+  usage: pickProjection('runUsage').valueType,
 });
 
 const UpdateQueuedFollowUpsMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_QUEUED_FOLLOW_UPS),
-  messages: z.array(z.string()),
+  messages: pickProjection('queuedFollowUps'),
 });
 
 const PermissionKindSchema = z.enum(PERMISSION_KIND);
@@ -241,7 +235,9 @@ const BypassTypeSchema = z.enum(APPROVAL_BYPASS_KINDS);
 const UpdateBypassMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_BYPASS),
   type: BypassTypeSchema,
-  bypassActive: z.boolean(),
+  // The three bypass flags share one boolean schema on the projection;
+  // the envelope maps `type` to the matching flag.
+  bypassActive: pickProjection('bashBypass'),
 });
 
 // `error` is only ever populated (and only ever read) on the `polishError`
@@ -291,21 +287,13 @@ const UpdateInquiryThreadMessageSchema = z.object({
 const StreamContentRenderFields = {
   command: z.literal(PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT),
   action: z.literal('render'),
-  stream: StreamTabIdSchema,
+  stream: pickProjection('stream'),
   // Per-run usage is shared by both stream kinds. The frontend derives the
   // cumulative session total from this canonical map.
-  runUsage: RunUsageMapSchema,
+  runUsage: pickProjection('runUsage'),
   // Active state is all-or-nothing. Partial tab-activation snapshots would
   // preserve unrelated stale fields in the frontend.
-  activeState: z
-    .strictObject({
-      conversationProgress: ConversationProgressSchema,
-      stage: StreamStageSchema.nullable(),
-      badges: z.strictObject({
-        subagents: z.array(ActiveChildInfoSchema),
-      }),
-    })
-    .optional(),
+  activeState: pickProjection('activeState').optional(),
 };
 
 const ClearStreamContentMessageSchema = z.strictObject({
@@ -316,27 +304,14 @@ const ClearStreamContentMessageSchema = z.strictObject({
 const WorkflowStreamContentMessageSchema = z.strictObject({
   ...StreamContentRenderFields,
   category: z.literal(AgentCategory.Workflow),
-  outputs: z.strictObject({
-    files: roundIndexedRecord(OutputFileInfoSchema),
-    missing: roundIndexedRecord(z.string()),
-    compileFailures: roundIndexedRecord(CompileFailureSchema),
-  }),
+  outputs: pickProjection('outputs'),
 });
 
 const ToolUseStreamContentMessageSchema = z.strictObject({
   ...StreamContentRenderFields,
   category: z.literal(AgentCategory.ToolUse),
-  workPlan: z.strictObject({
-    todos: z.array(TodoItemSchema),
-    plan: PlanSchema.nullable(),
-    queuedFollowUps: z.array(z.string()),
-  }),
-  controls: z.strictObject({
-    bashBypass: z.boolean(),
-    toolEditBypass: z.boolean(),
-    superYoloBypass: z.boolean(),
-    goal: GoalStateSchema,
-  }),
+  workPlan: pickProjection('workPlan'),
+  controls: pickProjection('controls'),
 });
 
 /** Full tab snapshots, one branch per stream category. */
@@ -364,6 +339,8 @@ export type StreamContentRenderPayload = Extract<
 
 const GoalActiveUpdatedMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.GOAL_ACTIVE_UPDATED),
+  // Flattened envelope over the projection's `controls.goal`
+  // (`GoalStateSchema`); the flattening is this arm's wire contract.
   active: z.boolean(),
   status: GoalStatusSchema.optional(),
   objective: z.string().optional(),

--- a/src/shared/schemas/progressView/projectionShape.ts
+++ b/src/shared/schemas/progressView/projectionShape.ts
@@ -1,0 +1,113 @@
+/**
+ * Canonical browser-safe projection shape for the webview content path.
+ *
+ * The full SYNC_STREAM_CONTENT render snapshot (the clear arm excluded) and
+ * every targeted single-field outbound arm read the same value schemas from
+ * here. Nothing in this module imports Node built-ins: the trace-viewer and
+ * the extension both load it from a browser-safe bundle, so a runtime Node
+ * import in this graph would break `file://` replay.
+ */
+import { z } from 'zod';
+
+import { GoalStateSchema } from '../goal';
+import { StreamTabIdSchema } from '../identifiers';
+import { CompileFailureSchema, OutputFileInfoSchema } from '../output';
+import { PlanSchema } from '../plan';
+import { roundIndexedRecord } from '../roundIndexed';
+import {
+  ActiveChildInfoSchema,
+  ConversationProgressSchema,
+  StreamStageSchema,
+} from '../streamState';
+import { TodoItemSchema } from '../todo';
+import { RunUsageMapSchema } from '../usage';
+
+/** Leaf value schemas: declared once, referenced by every envelope below. */
+const StreamContentProjectionLeaves = {
+  stream: StreamTabIdSchema,
+  runUsage: RunUsageMapSchema,
+  conversationProgress: ConversationProgressSchema,
+  stage: StreamStageSchema,
+  subagents: z.array(ActiveChildInfoSchema),
+  files: roundIndexedRecord(OutputFileInfoSchema),
+  missing: roundIndexedRecord(z.string()),
+  compileFailures: roundIndexedRecord(CompileFailureSchema),
+  todos: z.array(TodoItemSchema),
+  plan: PlanSchema.nullable(),
+  queuedFollowUps: z.array(z.string()),
+  bashBypass: z.boolean(),
+  toolEditBypass: z.boolean(),
+  superYoloBypass: z.boolean(),
+  goal: GoalStateSchema,
+};
+
+const ActiveStateSectionSchema = z.strictObject({
+  conversationProgress: StreamContentProjectionLeaves.conversationProgress,
+  stage: StreamContentProjectionLeaves.stage.nullable(),
+  badges: z.strictObject({
+    subagents: StreamContentProjectionLeaves.subagents,
+  }),
+});
+
+const OutputsSectionSchema = z.strictObject({
+  files: StreamContentProjectionLeaves.files,
+  missing: StreamContentProjectionLeaves.missing,
+  compileFailures: StreamContentProjectionLeaves.compileFailures,
+});
+
+const WorkPlanSectionSchema = z.strictObject({
+  todos: StreamContentProjectionLeaves.todos,
+  plan: StreamContentProjectionLeaves.plan,
+  queuedFollowUps: StreamContentProjectionLeaves.queuedFollowUps,
+});
+
+const ControlsSectionSchema = z.strictObject({
+  bashBypass: StreamContentProjectionLeaves.bashBypass,
+  toolEditBypass: StreamContentProjectionLeaves.toolEditBypass,
+  superYoloBypass: StreamContentProjectionLeaves.superYoloBypass,
+  goal: StreamContentProjectionLeaves.goal,
+});
+
+/**
+ * The one place the projection field schemas are declared. Envelopes (SYNC
+ * render and targeted arms) apply their own optionality/nullability at the
+ * field boundary; this registry never restates a leaf or section type.
+ */
+const StreamContentProjectionValues = {
+  ...StreamContentProjectionLeaves,
+  activeState: ActiveStateSectionSchema,
+  outputs: OutputsSectionSchema,
+  workPlan: WorkPlanSectionSchema,
+  controls: ControlsSectionSchema,
+};
+
+/**
+ * Pick one projection value schema by its field name. Targeted outbound arms
+ * derive their value schema here instead of re-declaring it, so a field added
+ * to (or renamed in) the projection shape reaches every targeted arm at
+ * compile time — the same factory idiom `RoundUpdateMessageSchema` proves for
+ * the round-keyed arms.
+ */
+export function pickProjection<
+  K extends keyof typeof StreamContentProjectionValues,
+>(key: K): (typeof StreamContentProjectionValues)[K] {
+  return StreamContentProjectionValues[key];
+}
+
+/**
+ * The canonical browser-safe projection DTO: every field the SYNC render
+ * snapshot and the targeted arms read, with the SYNC wire's envelope
+ * optionality applied.
+ */
+export const StreamContentProjectionShapeSchema = z.object({
+  stream: pickProjection('stream'),
+  runUsage: pickProjection('runUsage'),
+  activeState: pickProjection('activeState').optional(),
+  outputs: pickProjection('outputs').optional(),
+  workPlan: pickProjection('workPlan').optional(),
+  controls: pickProjection('controls').optional(),
+});
+
+export type StreamContentProjectionShape = z.infer<
+  typeof StreamContentProjectionShapeSchema
+>;


### PR DESCRIPTION
Refs #10672 — Wave C first slice: canonical projection shape + derived targeted outbound arms, plus the non-overlapping schema-inference part of step 3.

## Scope

Only step 1 and the schema-inference part of step 3 from #10672. No change to `SessionRendererPort`, `ProgressStreamProjectionBuilder`, the replay hydrator, `contentStore`, or projection-zero.

- `src/shared/schemas/progressView/projectionShape.ts` (new): the canonical browser-safe projection shape (`StreamContentProjectionShapeSchema` / `StreamContentProjectionShape`) and `pickProjection`. No Node imports in this graph.
- `src/shared/schemas/progressView/outbound.ts`: the 12 targeted single-field arms derive their value schemas through `pickProjection`; the SYNC render snapshot composes the same shape. Every wire literal and both delivery paths are preserved.
- `src/shared/schemas/progressEvents.ts`: the six value payloads that duplicated outbound schemas now use `z.infer` of the outbound message schemas.
- `src/shared/schemas/progressView/index.ts`: publishes the new shape module through the barrel.
- `config/ratchets/knip-baseline.json`: two intentional new public-surface entries for the projection shape, reserved for the later 6d hydrator recorded in `docs/proposals/2026-08-15-shared-contracts-and-retirement.md` §2.3 / §7.5.

## Census (verified against current tree, not stale docs)

12 targeted arms, all present and linked:

`UPDATE_TODOS`, `UPDATE_PLAN`, `UPDATE_FILES`, `UPDATE_MISSING_OUTPUTS`, `UPDATE_COMPILE_FAILURES`, `UPDATE_RUN_USAGE`, `UPDATE_CONVERSATION_PROGRESS`, `UPDATE_STAGE`, `UPDATE_STREAM_BADGES`, `UPDATE_QUEUED_FOLLOW_UPS`, `UPDATE_BYPASS`, `GOAL_ACTIVE_UPDATED`.

`GOAL_ACTIVE_UPDATED` keeps its flattening envelope (`controls.goal` is the projection leaf); `UPDATE_BYPASS` maps `type` to the shared boolean leaf.

progressEvents step-3 census:

- Converted to `z.infer` here: `UpdateStreamDescriptionPayload`, `UpdateStreamStatusPayload`, `AddOutputFilesPayload`, `UpdateMissingOutputsPayload`, `UpdateCompileFailuresPayload`, `UpdateConversationProgressPayload` (6).
- Already `z.infer` on main: `UpdateTodosPayload` (`todo.ts`), `UpdatePlanPayload` (`plan.ts`) (2) → 8 value-bearing fact payloads total.
- Intentionally left fact-native: `UpdateStreamUsagePayload` (extended usage vs base wire usage) and `UpdateRoundStagePayload` (frozen public NDJSON), so the "~8" becomes 6 in this slice.

## Net elements (R6)

- `+198 / −81` across 5 files; no test files changed.
- Exported symbols: +9 / −0 (canonical projection shape/type/helper plus derived schema surfaces); no classes/interfaces/enums added.
- The two currently zero-consumer projection-shape exports are explicitly reserved by the 6d retirement-ledger row cited above; no other dead surface is added.

## Consumer counts (R8)

- `pickProjection` now owns 12 targeted outbound arms and the SYNC render sections.
- Six progress-event payload types derive from outbound message schemas; two were already inferred and two fact-native exceptions remain documented.
- `StreamContentProjectionShapeSchema` / `StreamContentProjectionShape`: 0 current production consumers, with the named 6d replay-hydrator consumer scheduled by the ledger.
- No event emit path, wire literal, or delivery path is added or removed in this slice.

## Validation

- `pnpm typecheck:workspace`, `typecheck:test-kernel`, `typecheck:trace-viewer`, `typecheck:desktop`, `typecheck:agent`, `typecheck:cli` — pass.
- `pnpm check:browser-safe-utils` — pass.
- Ratchets: `sharedSchemasDeepImportRatchet`, `subsystemEdgeRatchet`, `storePublicSurfaceRatchet` (14 tests) and `check:dead-code-ratchet` — pass.
- `pnpm lint` and `pnpm format:check` — pass; `git diff --check` clean.
- Existing parity suites (unmodified): `WorkflowScriptProgressBridge`, `ProgressViewMessageDispatcher`, `ProgressBackendFactProjection`, `ProgressBackendStreamLifecycle`, `StreamContentSync`, `StreamMetaState`, `WebviewBridge`, `traceViewer/replayTrace` — 8 files, 152 tests pass.

## Remaining #10672 items

- Step 2: `SessionRendererPort.invalidate(streamId, slice)` + collapse the four payload-free methods and the dead second argument.
- Step 4: fold `ProgressStreamProjectionBuilder` away, tighten the renderer band, delete `streamMetaSlice` re-derivations (contentStore stays out of this wave).
- Step 5 / 6d: retarget the replay hydrator onto this browser-safe projection DTO.

