### PR TITLE
docs(prompts): stop review bots from demanding tests beyond the budget

### DIFF
--- a/.github/prompts/claude-code-review-prompt.md
+++ b/.github/prompts/claude-code-review-prompt.md
@@ -15,7 +15,10 @@ irrelevant TypeScript findings.
 Prioritize correctness, security, platform decoupling, type safety, Zod v4
 schema correctness, PocketFlow invariants, webview lifecycle issues,
 configuration and storage correctness, and CI/toolchain hygiene. Do not run
-`npm test`, and do not ask the author to add speculative abstractions.
+`npm test`, and do not ask the author to add speculative abstractions. Do not
+ask the author to add tests beyond the bar in `AGENTS.md` "Testing discipline":
+flag a missing test only when the PR fixes a reproduced defect and ships
+without its regression test.
 
 Conversely, flag pass-through layers this pull request newly introduces — wrapper
 functions that only forward to a single callee, single-use two-layer factories,

--- a/.github/prompts/texra-code-review-prompt.md
+++ b/.github/prompts/texra-code-review-prompt.md
@@ -40,8 +40,8 @@ that affect the truth, scope, or reproducibility of the scientific content:
   explanation.
 - Scientific computing and coding correctness when it bears on the above:
   API/schema mismatches, race conditions, data loss, command-execution risks,
-  numerical instability, missing tests for changed behavior, and code paths that
-  silently change a derivation, experiment, figure, table, or formal statement.
+  numerical instability, and code paths that silently change a derivation,
+  experiment, figure, table, or formal statement.
 - LaTeX and exposition correctness: when the pull request changes `.tex`,
   `.bib`, `.sty`, `.cls`, or related manuscript files, inspect the changed
   source. Check whether equations, references, labels, theorem statements,
@@ -49,7 +49,11 @@ that affect the truth, scope, or reproducibility of the scientific content:
   and consistent with the surrounding text.
 
 Avoid style nits unless they obscure correctness or make future changes
-substantially harder. Do not invent issues merely to have comments. One
+substantially harder. Do not invent issues merely to have comments. Do not ask
+the author to add tests: the repository deliberately keeps its test surface
+small because internal interfaces change often (`AGENTS.md` "Testing
+discipline"). Flag a missing test only when the pull request fixes a
+reproduced defect and ships without its regression test. One
 repository convention is worth enforcing on changed TypeScript lines: the
 modern-TypeScript patterns in `AGENTS.md` ("ES2023+ Patterns") — `node:`
 prefixed builtin imports, `.toSorted()` over spread-then-sort, `for...of`
@@ -118,7 +122,7 @@ Return exactly one JSON object and no Markdown fence. Use this schema:
 The `body` string must start with `## TeXRA Code Review`. If there are
 findings, list them in order of severity. For each finding, explain the issue
 and the smallest reasonable fix. If no actionable issues are found, say so
-plainly and mention any residual risk or test gap. Mathematical and physical
+plainly and mention any residual risk. Mathematical and physical
 claims should be stated precisely; name the theorem, definition, equation,
 lemma, model, approximation, or manuscript section involved.
 


### PR DESCRIPTION
## Why

Follow-up to #10667 (the anti-over-testing budget). The two PR-review prompts were still pushing reviewers toward test demands, which is exactly where over-testing shows up as PR friction:

- `texra-code-review-prompt.md` listed **"missing tests for changed behavior"** as a scientific-computing review priority, and told clean reviews to "mention any residual risk or test gap".
- `claude-code-review-prompt.md` had no test bar at all, so the bot fell back to generic ask-for-tests instincts.

## What

- Drop "missing tests for changed behavior" from the theorist prompt's priority list and "test gap" from its clean-review instruction; add an explicit rule: do not ask the author for tests — flag a missing test only when the PR fixes a reproduced defect and ships without its regression test.
- Add the same bar to `claude-code-review-prompt.md`, next to its existing "do not ask for speculative abstractions" rule, pointing at `AGENTS.md` "Testing discipline".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcABH4LXmXTw5952fnLr8E