### PR TITLE
refactor(schemas): collapse repeated reject/skip action arms in progressView inbound

### DIFF
--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -49,6 +49,23 @@ function fileWithBaseCommand<T extends string>(command: T) {
   });
 }
 
+/**
+ * One arm of an `action`-discriminated union: the base fields plus a single
+ * literal `action` and an optional `feedback` string. Shared shape for every
+ * "reject" (and "skip") arm below — each differs only in its base fields and
+ * discriminator literal.
+ */
+function actionWithFeedback<Base extends z.ZodRawShape, Action extends string>(
+  base: Base,
+  action: Action,
+) {
+  return z.strictObject({
+    ...base,
+    action: z.literal(action),
+    feedback: z.string().optional(),
+  });
+}
+
 const UseOwnApiKeyMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY),
   requestId: z.string(),
@@ -129,11 +146,7 @@ const ToolEditApprovalActionMessageSchema = z.discriminatedUnion('action', [
     ...ToolEditActionMessageBase,
     action: z.enum(['approve', 'openDiff', 'showLatexdiff', 'previewProposed']),
   }),
-  z.strictObject({
-    ...ToolEditActionMessageBase,
-    action: z.literal('reject'),
-    feedback: z.string().optional(),
-  }),
+  actionWithFeedback(ToolEditActionMessageBase, 'reject'),
 ]);
 
 const BashActionMessageBase = {
@@ -145,11 +158,7 @@ const BashApprovalActionMessageSchema = z.discriminatedUnion('action', [
     ...BashActionMessageBase,
     action: z.literal('approve'),
   }),
-  z.strictObject({
-    ...BashActionMessageBase,
-    action: z.literal('reject'),
-    feedback: z.string().optional(),
-  }),
+  actionWithFeedback(BashActionMessageBase, 'reject'),
 ]);
 
 const ProposalActionMessageBase = {
@@ -163,11 +172,7 @@ const AgentProposalActionMessageSchema = z.discriminatedUnion('action', [
     model: z.string().optional(),
     agent: z.string().optional(),
   }),
-  z.strictObject({
-    ...ProposalActionMessageBase,
-    action: z.literal('reject'),
-    feedback: z.string().optional(),
-  }),
+  actionWithFeedback(ProposalActionMessageBase, 'reject'),
   z.strictObject({
     ...ProposalActionMessageBase,
     action: z.literal('setup'),
@@ -186,11 +191,7 @@ const PlanApprovalActionMessageSchema = z.discriminatedUnion('action', [
     ...PlanActionMessageBase,
     action: z.enum(['approve', 'approve_and_goal']),
   }),
-  z.strictObject({
-    ...PlanActionMessageBase,
-    action: z.literal('reject'),
-    feedback: z.string().optional(),
-  }),
+  actionWithFeedback(PlanActionMessageBase, 'reject'),
 ]);
 
 const ExternalInquiryActionMessageSchema = z.discriminatedUnion('action', [
@@ -219,16 +220,8 @@ const UserQuestionActionMessageSchema = z.discriminatedUnion('action', [
     action: z.literal('submit'),
     answers: UserQuestionAnswersSchema,
   }),
-  z.strictObject({
-    ...UserQuestionActionMessageBase,
-    action: z.literal('reject'),
-    feedback: z.string().optional(),
-  }),
-  z.strictObject({
-    ...UserQuestionActionMessageBase,
-    action: z.literal('skip'),
-    feedback: z.string().optional(),
-  }),
+  actionWithFeedback(UserQuestionActionMessageBase, 'reject'),
+  actionWithFeedback(UserQuestionActionMessageBase, 'skip'),
 ]);
 
 const RestoreProposalConfigMessageSchema = z.object({

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -49,12 +49,7 @@ function fileWithBaseCommand<T extends string>(command: T) {
   });
 }
 
-/**
- * One arm of an `action`-discriminated union: the base fields plus a single
- * literal `action` and an optional `feedback` string. Shared shape for every
- * "reject" (and "skip") arm below — each differs only in its base fields and
- * discriminator literal.
- */
+/** Shared reject/skip arm: base fields + literal action + optional feedback. */
 function actionWithFeedback<Base extends z.ZodRawShape, Action extends string>(
   base: Base,
   action: Action,


### PR DESCRIPTION
## Summary

A prior audit pass (scanning `src/agent/`, `src/tools/`, `src/shared/`/`src/controllers/`/`src/transcript/`, and repo-wide anti-patterns) proposed five candidate refactor areas. Before touching anything, each candidate was re-verified against the actual code and against this repo's existing tech-debt review history (`docs/proposals/*`). Four of the five did not survive that verification — this PR contains only the one that did.

**What's included:** `src/shared/schemas/progressView/inbound.ts` had six near-identical discriminated-union arms — the `reject` arm of `ToolEditApprovalActionMessageSchema`, `BashApprovalActionMessageSchema`, `AgentProposalActionMessageSchema`, `PlanApprovalActionMessageSchema`, `UserQuestionActionMessageSchema`, plus that last schema's `skip` arm — each hand-writing `{ ...base, action: literal(X), feedback: z.string().optional() }`. Extracted a local `actionWithFeedback(base, action)` helper and routed all six call sites through it. Purely additive/mechanical; no schema shape, validation behavior, or discriminator literal changed.

**What was investigated and deliberately excluded**, with the reason each was dropped:

| Candidate | Verdict |
|---|---|
| `src/agent/modelHandlers/` — unify the per-provider request-execution pipeline | Already reviewed and rejected by this repo's own tech-debt process multiple times (`docs/proposals/2026-07-03-tech-debt-audit.md`, `2026-08-04-agent-sdk-readiness-review.md`, `2026-08-14-delegation-flow-substrate-consolidation.md`) as "correct polymorphism, not indirection." |
| `StreamSnapshotStore`/`StreamLogStore` — unify their two write-serialization mechanisms | Explicitly deferred (`docs/proposals/2026-08-07-prod-structural-leads-triage.md`): "Decline unless flush semantics are formally unified." `StreamSnapshotStore` is cited elsewhere as the "house model" to keep as-is. |
| `ExecutionsTool.ts` — collapse the `show*` resource handlers | On full read, each handler has genuinely different data sources, fallback logic, and documented edge cases (turn-attribution notes, pre-identity-row compatibility, old-format readers) — not copy-paste boilerplate. Forcing a generic combinator here would be exactly the kind of cross-divergent abstraction this repo's review culture rejects elsewhere. |
| Duplicated `switch(event.type)` across `TexraTranscriptRecorder`/`StreamSnapshotStore`/`SessionFactApplier`/`completedRunArchive` | Doesn't hold up: `StreamSnapshotStore` already has hand-built exhaustiveness checks, `SessionFactApplier` already uses a typed dispatch table for the overlapping event subset, and `completedRunArchive`'s switch is over an unrelated union (`MessageType`, not `AgentEvent`). |
| `truncate`/`clamp` "duplication" | Each apparent duplicate turned out to be either already composed from the shared primitive (`clampCursor` already calls `clamp`) or intentionally divergent with a documented reason (ASCII vs. Unicode-grapheme truncation, head vs. tail, line-based vs. char-based). |

## Issue acceptance gates

No tracked issue — this PR originates from a codebase-wide ad hoc tech-debt scan, scoped down to the one finding that survived verification.

## Single source of truth

`actionWithFeedback` in `src/shared/schemas/progressView/inbound.ts` is now the single definition of the "base fields + literal action + optional feedback" arm shape; each of the six call sites states only its base fields and discriminator literal.

## Duplication and abstraction budget

Removed: 6 near-identical ~4-5 line object literals (24 duplicated lines) collapsed to 6 one-line calls plus one 10-line helper. Net: -7 lines, and the duplicated shape can no longer drift between the six unions. No new cross-file abstraction was added — the helper is local to this one file, which is the only place this exact pattern recurs (verified via grep across `src/shared/schemas/`).

## Net elements (R6)

1 file changed, 23 insertions(+), 30 deletions(-) (net -7 LoC). +1 local function (`actionWithFeedback`), 0 new exports, 0 new classes/interfaces/enums, 0 files added/removed.

## Consumer counts (R8)

n/a — no export, emit path, or public symbol was deleted or re-routed; the six discriminated-union arms keep identical runtime shape and discriminator literals.

## Host impact

Extension: none (schema-only, wire-compatible; `ProgressViewInboundMessageSchema`'s validated shape is unchanged).

Desktop: none.

CLI: none.

## Scheduled refactoring

None. The four excluded candidates are not follow-up work — they were investigated and are documented above as deliberately out of scope (three already settled by prior review, one found not to be real duplication on inspection).

## Validation

- `npm run typecheck` (workspace) — passes
- `npm run lint` (full repo, all packages) — passes
- `npx prettier --check` on the changed file — passes
- `npm run check:dead-code-ratchet` — no new unused exports/files (8 baselined, 8 current)
- `npx vitest run src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts` — 63/63 passing (exercises this schema's dispatch)
- `npx vitest run src/test-kernel/shared` — 348/348 passing
- `npm test` (full suite) — 10733 passed, 6 skipped, 0 failed (879 files)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DSgeiwoneajuZ26uyDTzx9)_