### PR TITLE
refactor(utils): consolidate two duplicate line-split/error-message helpers

### DIFF
--- a/packages/trace-viewer/src/main.ts
+++ b/packages/trace-viewer/src/main.ts
@@ -17,6 +17,7 @@ import {
 } from '@progressView/frontend/eventHandlers';
 
 import type { TraceDocument } from '@transcript';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { recordName, replayTrace } from './replayTrace';
 import { parseTraceData } from './traceDataSchema';
 
@@ -94,7 +95,7 @@ function renderLoadError(err: unknown): void {
   const heading = document.createElement('h1');
   heading.textContent = 'Unable to load trace';
   const detail = document.createElement('p');
-  detail.textContent = err instanceof Error ? err.message : String(err);
+  detail.textContent = toErrorMessage(err);
 
   errorRegion.append(heading, detail);
   // Replace (not append) — the empty <stream-conversation> mounted above has

--- a/src/utils/git/repositoryOverview.ts
+++ b/src/utils/git/repositoryOverview.ts
@@ -18,6 +18,7 @@
 
 import { executeCommand } from '@utils/system/execUtils';
 import { isGitRepository } from '@utils/git/isGitRepository';
+import { splitOutputLines } from '@utils/text/stringUtils';
 
 import { COMMIT_LABEL_FORMAT, splitCommitLines } from './commitLogFormat';
 
@@ -164,7 +165,7 @@ export async function readGitEnvironmentSummary(
       ),
     ]);
   const { additions, deletions } = parseNumstat(numstatOutput);
-  const changedFiles = splitNonEmptyLines(statusOutput).length;
+  const changedFiles = splitOutputLines(statusOutput ?? '').length;
   const branch =
     branchOutput && branchOutput !== 'HEAD' ? branchOutput : undefined;
   const upstream = upstreamOutput || undefined;
@@ -192,17 +193,13 @@ export async function readGitEnvironmentSummary(
   };
 }
 
-function splitNonEmptyLines(output: string | undefined): string[] {
-  return output?.split(/\r?\n/).filter(Boolean) ?? [];
-}
-
 function parseNumstat(output: string | undefined): {
   additions: number;
   deletions: number;
 } {
   let additions = 0;
   let deletions = 0;
-  for (const line of splitNonEmptyLines(output)) {
+  for (const line of splitOutputLines(output ?? '')) {
     const [added = '', deleted = ''] = line.split('\t');
     additions += parseGitCount(added);
     deletions += parseGitCount(deleted);


### PR DESCRIPTION
## Summary

Scheduled codebase sweep for duplicate logic and native-method opportunities. Three parallel research passes covered `src/utils`/`src/shared`, `src/agent`/`src/model`/`src/tools`/`src/controllers`, and the host packages (`extension`, `desktop`, `cli`, `trace-viewer`). The codebase turned out to already be extensively consolidated — most "usual suspect" smells (hand-rolled debounce/retry/deep-clone/UUID/JSON-parse/error-extraction) are already factored into single shared helpers, several with doc comments explaining a prior consolidation pass. Only two findings cleared the bar for a safe, mechanical, behavior-preserving fix; this PR applies both.

1. `src/utils/git/repositoryOverview.ts` defined a private `splitNonEmptyLines` that duplicated the exact split-and-filter shape already exported as `splitOutputLines` in `@utils/text/stringUtils`. Removed the local helper and call the shared one (same pattern already used in `src/tools/grep.ts` and `src/agent/review/reviewDiff.ts`).
2. `packages/trace-viewer/src/main.ts` hand-rolled `err instanceof Error ? err.message : String(err)` instead of the shared `toErrorMessage` helper (`@utils/errors/errorMessage`, used at 86+ other call sites across the codebase).

## Issue acceptance gates

n/a — not filed against an issue; this is a scheduled tech-debt sweep.

## Single source of truth

`splitOutputLines` (`src/utils/text/stringUtils.ts`) is now the sole line-splitting helper in `src/utils/git/`. `toErrorMessage` (`@utils/errors/errorMessage`) is now used at the one remaining call site in `packages/trace-viewer` that had reimplemented it inline.

## Duplication and abstraction budget

Removed: one private duplicate function (`splitNonEmptyLines`, 3 lines) and one duplicate inline error-message expression. No new abstractions added — both fixes route to helpers that already existed and were already used elsewhere in the codebase.

## Net elements (R6)

2 files changed, 5 insertions(+), 7 deletions(-). No exported symbols added or removed (`splitNonEmptyLines` was unexported; `toErrorMessage` already existed).

## Consumer counts (R8)

n/a — no emit path or export re-routed; both changes are internal call-site substitutions with a single caller each.

## Host impact

Extension: none (change is in host-agnostic `src/utils/`).

Desktop: none.

CLI: none.

Trace viewer (static export, built by `packages/trace-viewer`): error message text for a failed trace load now goes through the shared formatter — output is byte-identical for `Error` instances (`.message`) and non-`Error` throws (`String(err)`).

## Scheduled refactoring

None. The sweep also surfaced several lower-confidence "needs judgment" opportunities not applied here (each has a behavioral wrinkle that needs a human call, not a mechanical swap):
- `src/agent/workflowScript/sandbox.ts`: 3 sites with duplicated `JSON.parse` + try/catch + `toErrorMessage` that could route through `common/parsing/safeParseJson.ts`, but two throw and one returns a tagged error object, so it's a control-flow reshape, not a drop-in.
- `glmCodingPlanUsageAdapter.ts` / `kimiCodeUsageAdapter.ts`: repeated array-vs-object iteration idiom that could share a `forEachIndexedOrKeyed` helper, but the two callers assign synthetic names differently.
- `src/utils/git/worktreeInfo.ts` vs the file touched here: both probe git branch/dirty status independently; `worktreeInfo.ts` adds an LRU cache + `coalesceAsync` that a merge would need to preserve.
- `src/utils/config/configUtils.ts` vs `src/shared/config/settingsAccess.ts`: near-identical "validate persisted value, warn, fall back to default" idiom with different warn-gating and default-source semantics.
- `packages/cli/src/tui/useLiveNowMs.ts` vs `usePollingInterval.ts`: `useLiveNowMs` reimplements the shared polling-interval registry as its own 1 Hz special case; folding it in needs to preserve `unref()`/immediate-tick differences.
- `src/shared/utils/clipboardImages.ts`: hard-codes a MIME→extension table that could potentially use the already-installed `mime-types` package, pending verification of bundle-safety and exact extension output in the webview paste path.

None of these are filed as follow-up issues; flagging here for whoever picks up the next sweep.

## Validation

- `npm run typecheck` — full workspace (core, test-kernel, agent package build, cli, trace-viewer, desktop) — clean.
- `npm run lint` — clean.
- `npm test` — 879 test files / 10,733 tests passed (1 file / 6 tests skipped, unrelated to this change).


---
_Generated by [Claude Code](https://claude.ai/code/session_013KxMHuDxgTeNNcKQy11d4C)_