### PR TITLE
refactor(session): reuse canonical run identity label

### DIFF
--- a/src/controllers/session/streamTabInfo.ts
+++ b/src/controllers/session/streamTabInfo.ts
@@ -3,7 +3,7 @@ import { getStreamTabDisplayName } from '@agent/runtime/streamTab';
 import type { SessionStreamMetadata } from '@controllers/session/SessionState';
 import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import type { StreamTabInfo, WorktreeInfo } from '@shared/schemas';
-import { getCleanAgentName, runIdentityName } from '@shared/schemas';
+import { getCleanAgentName, runIdentityDisplayName } from '@shared/schemas';
 
 export interface StreamTabInfoInputs {
   streamId: string;
@@ -40,7 +40,7 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   // exactly the same label as a resolved run: the agent name, with the full
   // id on `name` for tooltips and parallel-run disambiguation.
   const identityName = identity
-    ? getCleanAgentName(runIdentityName(identity))
+    ? runIdentityDisplayName(identity)
     : getStreamTabDisplayName(streamId);
 
   // Surface the full untruncated command for process streams (description


### PR DESCRIPTION
## Summary

Reuse `runIdentityDisplayName` in `buildStreamTabInfo` instead of restating the same `getCleanAgentName(runIdentityName(...))` label rule. This removes the second producer of resolved run labels without changing pending-tab fallback or remote detection.

Refs #10670

## Net elements (R6)

- 1 production file changed; no test files changed
- 1 import binding replaced and 1 duplicate expression removed
- no exports, classes, interfaces, enums, schemas, adapters, or compatibility paths added
- net production LoC: 0 (one line replaced by one line)

## Consumer counts (R8)

`runIdentityDisplayName` gains one existing production consumer (`buildStreamTabInfo`); the inline duplicate label producer has one consumer and is removed. No emit path or export is deleted or rerouted.

## Validation

- `pnpm vitest run src/test-kernel/progressView/streamInfoUtils.vitest.ts` — 12 passed
- `pnpm exec eslint src/controllers/session/streamTabInfo.ts`
- `pnpm exec prettier --check src/controllers/session/streamTabInfo.ts`
- `git diff --check`
