### PR TITLE
refactor(approval): alias proposal request to canonical permission

### DIFF
--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -2,7 +2,7 @@ import type { ReviewIssueReport } from '@agent/review/reviewIssues';
 import type { ModelCredentialSelection } from '@agent/types/ModelHandlerContracts';
 import { createLog } from '@logger/logUtils';
 import type {
-  AgentProposal,
+  AgentProposalPermission,
   FileLocation,
   PlanApprovalPermission,
   ProgressPermissionKind as PendingInteractionKind,
@@ -186,10 +186,11 @@ export interface HostBashApprovalRequest {
   readonly streamId?: StreamTabId | null;
 }
 
-export type HostAgentProposalRequest = AgentProposal & {
-  readonly proposalId: string;
-  readonly streamId: StreamTabId;
-};
+/**
+ * Host-facing proposal request. Reuses the canonical permission payload while
+ * preserving the readonly host-interaction contract.
+ */
+export type HostAgentProposalRequest = Readonly<AgentProposalPermission>;
 
 /**
  * The retry payload the runtime hands to hosts. This is deliberately an alias


### PR DESCRIPTION
## Summary

Replace the hand-written `HostAgentProposalRequest` composition with a readonly alias of canonical `AgentProposalPermission`, matching the plan-approval alias landed in #10715. Runtime shape, producer behavior, and host fields are unchanged.

Refs #10674

## Replacement verdict

This is the ruling-free proposal half of §2.2 item 1 / §5b `HostInteractionRequestByKind aliases — REPLACEMENT`: one canonical permission type now owns the proposal request shape; the duplicate host composition is deleted.

## Net elements (R6)

- 1 production file changed; no tests changed
- 1 hand-written intersection type deleted and replaced by 1 alias to an existing exported type
- no exports, runtime schemas, adapters, wire literals, persisted fields, classes, interfaces, or enums added
- no compatibility path added

## Consumer counts (R8)

The deleted host composition had one exported declaration owner and existing read-only consumers. `AgentProposalPermission` already has production producers/consumers and now also owns `HostAgentProposalRequest`; no emit path or export is deleted or rerouted.

## Validation

- `npm run typecheck` — all six targets passed
- `npm run lint`
- `npm run format:check`
- `git diff --check`
