### PR TITLE
fix(resume): resolve V4 admission-shape ruling and land V4b/V4c + desktop fence

### DIFF
--- a/docs/proposals/2026-08-15-cross-host-consolidation.md
+++ b/docs/proposals/2026-08-15-cross-host-consolidation.md
@@ -491,25 +491,26 @@ login` does not sign in the GUI hosts and vice-versa. Ruling: is
   `DETACH_SUBAGENTS_ON_STOP` — which is also the CP2 gap,
   `WORKFLOW_AUTO_OPEN_PDF`, `LATEXDIFF_*`, `LATEX_FORMATTER`,
   `telemetry.enabled`).
-- **V4. Extension resume is the weak sibling.** (a) silent `read-failed`
-  (fixed by C3); (b) passes no `canAcquireResumeLease`
-  (`resumeFromResumeData.ts:83-87`), so
-  `acquireResumedExecutionLease(id, undefined)`
-  (`executionLease.ts:665,631`) skips the atomic re-admission check inside
-  the lease lock — a stream deleted or relaunched during the async retrieval
-  window can still have its lease acquired; desktop and CLI both pass the
-  guard; (c) its cancellation is non-monotone — recomputed live from
-  `!session.transcripts.has(streamId)` (`:60`), so a stream re-created under
-  the same id _un-cancels_ a resume, where desktop latches
-  (`isResumeInvalidated`, `desktopAgentResume.ts:72-84`) and the CLI latches
-  with an explicit monotonicity comment
-  (`chatSessionController.ts:295-299,668-672`); (d) double-toast (fixed by
-  C11). Also: desktop is the sole non-core caller of
-  `hasAuthoritativeStream` (`desktopAgentResume.ts:79-82`) — plausibly a
-  multi-window concern, but nothing says so; either port it into the shared
-  admission shape or fence it. → Pick one admission-guard shape
-  (`canAcquireResumeLease` + latched cancellation) and make it the **ports
-  default** rather than an optional every host re-decides.
+- **V4. Extension resume was the weak sibling — V4b/c ruled + landed.** (a)
+  silent `read-failed` (fixed by C3); (b) the extension passed no
+  `canAcquireResumeLease`, so `acquireResumedExecutionLease(id, undefined)`
+  skipped the atomic re-admission check inside the lease lock
+  (`executionLease.ts:674-678,642`) — a stream deleted or relaunched during
+  the async retrieval window could still have its lease acquired; (c) its
+  cancellation was non-monotone — recomputed live from
+  `!session.transcripts.has(streamId)`, so a stream re-created under the
+  same id _un-cancelled_ a resume; (d) double-toast (fixed by C11).
+  **Ruling + landed shape:** each attempt owns one monotone host-cancellation
+  latch. The extension latches observed transcript absence
+  (`resumeFromResumeData.ts:35-46`) and forwards the same latch/guard to both
+  resume branches (`:82-102`); desktop latches host detach + transcript
+  absence + authoritative-stream absence (`desktopAgentResume.ts:72-94`); the
+  CLI already latched the same (`chatSessionController.ts:657-660,739`). The
+  same latch reaches `resolveAndResumeStream` and queued tool-use;
+  `canAcquireResumeLease` rechecks it under the lease lock. Desktop alone
+  also checks the durable authoritative stream identity
+  (`desktopAgentResume.ts:84-94`), fenced as desktop-only — extension/CLI
+  must not copy it.
 - **V5. Only the CLI settles executions at exit.** CLI shutdown
   (`runExecution.ts:344-399`) kills, persists `CANCELLED` with `'preserve'`,
   releases the lease, derives resumability, then advertises recovery.
@@ -786,9 +787,9 @@ needing none). Suggested order:
 4. **Rulings, then mechanics** — the CLI-transcript parity charter (§4, one
    decision unlocking a–h and C16), settings-store unification (V1, needs a
    migration design note), catalog SSOT (V3), lease-at-quit (V5),
-   `enforceCategory` (V6), AppSignals wiring scope (V7), resume admission
-   default (V4b/c), resumable truth source (V9/DR13), callback-binding bar
-   (V11b), approval-policy default fence (V12).
+   `enforceCategory` (V6), AppSignals wiring scope (V7), resumable truth
+   source (V9/DR13), callback-binding bar (V11b), approval-policy default
+   fence (V12). Resume admission (V4b/c) is no longer pending: ruled + landed.
 
 Everything here was found by scoped sweeps, not adjudicated line-by-line the
 way the 2026-07-09 audit was; treat each row as _verified-at-citation_ but

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -81,9 +81,9 @@ function resumeDesktopStream(
       authoritativeStreamMissing
     );
   };
-  // Desktop-only durable multi-window fence: extension/CLI must not copy this
-  // check because only desktop reads the authoritative stream identity across
-  // windows/processes. Their in-process `transcripts.has()` is not durable.
+  // Desktop-only durable multi-window resume fence: extension/CLI must not copy
+  // it because their resume admission is owned by one in-process transcript
+  // store, while desktop must fence stream identity across windows/processes.
   const canAcquireResumeLease = async (): Promise<boolean> => {
     if (isResumeInvalidated()) return false;
     if (!(await context.session.transcripts.hasAuthoritativeStream(streamId))) {

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -69,11 +69,21 @@ function resumeDesktopStream(
     context.session,
     (event) => event.streamId === streamId,
   );
+  let transcriptMissing = false;
   let authoritativeStreamMissing = false;
-  const isResumeInvalidated = (): boolean =>
-    context.isCancellationRequested() ||
-    authoritativeStreamMissing ||
-    !context.session.transcripts.has(streamId);
+  const isResumeInvalidated = (): boolean => {
+    if (!transcriptMissing && !context.session.transcripts.has(streamId)) {
+      transcriptMissing = true;
+    }
+    return (
+      context.isCancellationRequested() ||
+      transcriptMissing ||
+      authoritativeStreamMissing
+    );
+  };
+  // Desktop-only durable multi-window fence: extension/CLI must not copy this
+  // check because only desktop reads the authoritative stream identity across
+  // windows/processes. Their in-process `transcripts.has()` is not durable.
   const canAcquireResumeLease = async (): Promise<boolean> => {
     if (isResumeInvalidated()) return false;
     if (!(await context.session.transcripts.hasAuthoritativeStream(streamId))) {

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -7,6 +7,7 @@ import {
   AgentConfigSchema,
   ModelHandlerCompatibilityKeySchema,
   runAgent,
+  type RunAgentOptions,
 } from '@agent/runtime';
 import { openFinalOutputIfAvailable } from '@frontend/agents/finalOutputOpener';
 import { createLog } from '@logger/logUtils';
@@ -32,7 +33,10 @@ interface WrappedExecuteInput {
  *
  * Tool-use sessions resume through `tryResumeFromResumeData` instead.
  */
-export async function runExecuteCommand(input: unknown): Promise<void> {
+export async function runExecuteCommand(
+  input: unknown,
+  options: Pick<RunAgentOptions, 'canAcquireResumeLease'> = {},
+): Promise<void> {
   try {
     const wrapped =
       input !== null && typeof input === 'object' && 'config' in input
@@ -59,6 +63,12 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
         modelHandlerCompatibilityKey,
         copilotRouteOverride,
         onRun: wrapped?.onRun,
+        // In-process-only resume admission guard. It is never serialized: the
+        // VS Code command action still receives a single `input` argument
+        // across the registry/dispatch boundary.
+        ...(options.canAcquireResumeLease && {
+          canAcquireResumeLease: options.canAcquireResumeLease,
+        }),
       },
     );
   } catch (error) {

--- a/packages/extension/src/commands/agent/resumeFromResumeData.ts
+++ b/packages/extension/src/commands/agent/resumeFromResumeData.ts
@@ -32,6 +32,18 @@ export function tryResumeFromResumeData(
         session,
         (event) => event.streamId === streamId,
       );
+      // Per-attempt monotone cancellation latch: once an observed transcript
+      // absence invalidates the attempt, re-creating the same stream id cannot
+      // make it admissible again. `canAcquireResumeLease` rechecks the same
+      // latch under the execution-lease lock.
+      let cancellationRequested = false;
+      const isCancellationRequested = (): boolean => {
+        if (!cancellationRequested && !session.transcripts.has(streamId)) {
+          cancellationRequested = true;
+        }
+        return cancellationRequested;
+      };
+      const canAcquireResumeLease = () => !isCancellationRequested();
       const reportResumeFailure = async (error: unknown): Promise<void> => {
         logger.error(`Failed to resume stream: ${streamId}`, { data: error });
         await terminalResult.reportUnhandled(() =>
@@ -44,7 +56,7 @@ export function tryResumeFromResumeData(
         streamId,
         {
           streamStatus: session.status,
-          isCancellationRequested: () => !session.transcripts.has(streamId),
+          isCancellationRequested,
           resolveResumeState: (id) =>
             resolveResumeStateFromSnapshots(session.snapshots, id),
           reportResumeStateResolution: async (id, resolution) => {
@@ -69,7 +81,10 @@ export function tryResumeFromResumeData(
           },
           resumeToolUse: (resume, claimedRecovery) =>
             resumeQueuedToolUseFromResumeData(resume.streamId, resume, {
+              session,
               recovery: claimedRecovery,
+              canAcquireResumeLease,
+              isCancellationRequested,
               onError: reportResumeFailure,
             }),
           executeWorkflow: (
@@ -77,11 +92,14 @@ export function tryResumeFromResumeData(
             executionId,
             modelHandlerCompatibilityKey,
           ) =>
-            runExecuteCommand({
-              config,
-              executionId,
-              modelHandlerCompatibilityKey,
-            }),
+            runExecuteCommand(
+              {
+                config,
+                executionId,
+                modelHandlerCompatibilityKey,
+              },
+              { canAcquireResumeLease },
+            ),
           reportNoResumableSession: async (id) => {
             logger.warn(`No resumable session state for stream: ${id}`);
             await session.interactions.showInfoMessage(

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -129,6 +129,7 @@ export interface ResumeStreamPorts {
    * hosts.
    */
   readonly streamStatus: Pick<StreamStatusMachine, 'isActiveOrResuming'>;
+  /** Monotone per-attempt cancellation signal: once true it stays true. */
   readonly isCancellationRequested?: () => boolean;
   resolveResumeState(streamId: StreamTabId): Promise<ResumeStateResolution>;
   reportResumeStateResolution?(

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -10,6 +10,7 @@ import {
   retrieveSessionResumeData,
   type ToolUseResumeData,
 } from './SessionResumeRetrieval';
+import { ResumeAdmissionCancelledError } from './executeAgent';
 import type { SessionHandle } from './SessionHandle';
 import type { StreamStatusMachine } from './StreamStatusService';
 import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
@@ -211,6 +212,10 @@ export async function resolveAndResumeStream(
     return true;
   } catch (error) {
     if (isCancellationRequested()) return false;
+    // A workflow resume that loses the admission race is an expected
+    // cancellation, not a resume failure. Tool-use already classifies this
+    // same error as a silent `false`; the workflow branch must match it.
+    if (error instanceof ResumeAdmissionCancelledError) return false;
     try {
       await ports.reportFailure?.(streamId, error);
     } catch {


### PR DESCRIPTION
Closes #10725

## Summary

Resolves the V4 admission-shape ruling from
`docs/proposals/2026-08-15-cross-host-consolidation.md`: each resume attempt owns
one monotone host-cancellation latch. The extension now latches observed
transcript absence and forwards the same `isCancellationRequested` /
`canAcquireResumeLease` pair to both the queued tool-use resume and the workflow
resume; desktop latches transcript absence separately from host detach and keeps
its durable authoritative-stream fence desktop-only. The audit doc is updated so
V4b/c is recorded as ruled + landed rather than a pending decision.

Additionally, a workflow resume that loses the admission race now returns `false`
silently instead of reporting a resume failure: `resolveAndResumeStream` classifies
the thrown `ResumeAdmissionCancelledError` as expected cancellation, matching the
queued tool-use branch's existing handling.

## Issue acceptance gates

- V4 admission-shape ruling written and recorded (§3 V4 + §7 item 4).
- V4b: the extension resume path now passes `canAcquireResumeLease` into
  `runExecuteCommand` / `runAgent` (and into queued tool-use), so
  `acquireResumedExecutionLease` rechecks admission under the lease lock.
- V4c: the extension's live `!session.transcripts.has(streamId)` predicate is
  replaced with a per-attempt monotone latch; once absence is observed, same-id
  stream recreation cannot un-cancel the attempt.
- Desktop authoritative-stream fence: kept as a desktop-only durable multi-window
  check, now explicitly fenced with a comment that extension/CLI must not copy it.
- Workflow admission cancellation: `ResumeAdmissionCancelledError` from the
  workflow launch is suppressed as a silent `false`, not a resume failure.

Out of scope, intentionally: CLI explicit interactive resume and manual
progress-view workflow resume. No command-boundary machinery was added for those
paths.

## Single source of truth

The per-attempt latch in each host owns admission cancellation. The shared
`resolveAndResumeStream` port contract now documents `isCancellationRequested` as
monotone; `canAcquireResumeLease` rechecks the same latch atomically under the
execution-lease lock via `runAgent` / `resumeToolUseFromResumeData`.

## Duplication and abstraction budget

No new abstraction or pass-through layer. The extension reuses the existing
`RunAgentOptions.canAcquireResumeLease` slot instead of minting a parallel
option; the desktop change only makes an existing latch explicit; the workflow
cancellation classification reuses the existing `ResumeAdmissionCancelledError`
type rather than a new sentinel.

## Net elements (R6)

- Files: 5 changed, 0 added/removed.
  - `packages/extension/src/commands/agent/resumeFromResumeData.ts` +24/−6
  - `packages/extension/src/commands/agent/executeCommand.ts` +11/−1
  - `packages/desktop/src/main/desktopAgentResume.ts` +14/−4
  - `src/agent/runtime/resolveAndResumeStream.ts` +6/−0
  - `docs/proposals/2026-08-15-cross-host-consolidation.md` +23/−22
- Total: +78/−33, net +45 LoC (code-only net +44).
- Exported symbols: none added/removed; `runExecuteCommand` signature widens with
  an optional trailing `Pick<RunAgentOptions, 'canAcquireResumeLease'>` parameter
  (default `{}`).
- Classes/interfaces/enums: none added/removed.

## Consumer counts (R8)

No deleted or re-routed exports. `runExecuteCommand` (signature widened, backward
compatible) has 3 in-repo consumers:
- `packages/extension/src/commands/extensionCommandSurface.ts:149` (VS Code
  command action `execute`) — still one argument.
- `packages/extension/src/settingsView/handlers/historyHandlers.ts:36` — still
  one argument.
- `packages/extension/src/commands/agent/resumeFromResumeData.ts:95` — now passes
  the in-process guard as the second, in-process-only argument.

## Host impact

Extension: workflow/tool-use auto-resume now latches cancellation and passes the
lease-admission guard; the VS Code command boundary remains one-argument; an
admission-cancelled workflow resume is silent `false`.

Desktop: transcript absence is latched alongside host detach and the durable
authoritative-stream fence; the fence stays desktop-only.

CLI: none (already latches; unchanged).

## Scheduled refactoring

None. CLI explicit interactive resume and manual progress-view workflow resume
remain open follow-ups and are deliberately out of this change.

## Validation

- `vitest run` on
  `src/test-kernel/commands/agent/ResumeFromResumeData.vitest.ts`,
  `src/test-kernel/desktop/DesktopAgentResume.vitest.ts`,
  `src/test-kernel/cli/chatSessionController.vitest.ts` — 3 files, 59 tests passed.
- `vitest run` on the related `resolveAndResumeStream` importers
  (`src/test-kernel/transcript/completedRunArchive.vitest.ts`,
  `src/test-kernel/cli/CliInitPlatform.vitest.ts`) — 2 files, 27 tests passed.
- Temporary scratch probe at the extension boundary (written locally, run, then
  deleted): observed transcript absence (`isCancellationRequested()` → true),
  recreated the same stream id via `transcripts.ensureStream`, and confirmed
  `isCancellationRequested()` stayed true and the workflow/tool-use branches'
  forwarded `canAcquireResumeLease()` stayed false. Not committed, per the
  maintainer's no-new-tests preference.
- `npm run typecheck:workspace` + `npm run typecheck:test-kernel` — passed.
- CLI `tsc --noEmit` (tsconfig.json + tsconfig.scripts.json) and desktop
  `tsc --noEmit` (tsconfig.json / main / preload / renderer) — passed.
- `npm run lint` — passed (no output).
- `npm run format:check` — passed.
- `git diff --check` — clean.
- Rebased onto current `origin/main` (includes #10733/#10737/#10738); no file
  overlap. #10702 (open) also has no file overlap with this change.
