### PR TITLE
refactor(approval): unify tool edit settlement with host interaction map

### DIFF
--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -60,13 +60,13 @@ export function toToolEditResult(
   proposedContent: string,
 ): ToolEditApprovalResult {
   if (decision.accepted) {
-    return { accepted: true, appliedContent: proposedContent };
+    return { action: 'apply', appliedContent: proposedContent };
   }
   if (decision.rejectionCause !== undefined) {
-    return { accepted: false, cause: decision.rejectionCause };
+    return { action: 'reject', cause: decision.rejectionCause };
   }
   return {
-    accepted: false,
+    action: 'reject',
     ...(decision.userMessage ? { feedback: decision.userMessage } : {}),
   };
 }

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -207,6 +207,7 @@ export interface HostInteractionResultByKind {
   readonly planApproval: PlanApprovalResult;
   readonly proposal: ProposalResult;
   readonly retry: RetryResult;
+  readonly toolEdit: ToolEditApprovalResult;
   readonly userQuestion: UserQuestionSettlement;
 }
 
@@ -280,6 +281,7 @@ const cancellationResultFactories: CancellationResultFactories = {
   planApproval: (cause) => ({ action: 'reject', cause }),
   proposal: (cause) => ({ action: 'reject', cause }),
   retry: () => ({ action: 'cancel' }),
+  toolEdit: (cause) => ({ action: 'reject', cause }),
   userQuestion: (cause) => ({ action: 'reject', cause }),
 };
 
@@ -566,7 +568,7 @@ export class SessionHostInteractions implements HostInteractions {
       request.streamId,
       (interactions) =>
         interactions.requestToolEditApproval?.(request, options),
-      (cause) => ({ accepted: false, cause }),
+      (cause) => cancellationResultFor('toolEdit', cause),
     );
   }
 

--- a/src/controllers/approval/ToolEditApprovalController.ts
+++ b/src/controllers/approval/ToolEditApprovalController.ts
@@ -9,6 +9,7 @@
 
 import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import {
+  cancellationResultFor,
   matchesCancelSelector,
   type HostInteractionCancelSelector,
   type HostInteractionOptions,
@@ -222,7 +223,7 @@ export class ToolEditApprovalController {
         return;
       case 'reject':
         this.settle(payload.requestId, {
-          accepted: false,
+          action: 'reject',
           feedback: payload.feedback?.trim() || undefined,
         });
         return;
@@ -252,7 +253,7 @@ export class ToolEditApprovalController {
       if (state.request.streamId !== streamId) continue;
       if (state.phase === 'initializing') {
         state.resolution ??= {
-          accepted: true,
+          action: 'apply',
           appliedContent: state.request.proposedContent,
         };
         continue;
@@ -279,10 +280,7 @@ export class ToolEditApprovalController {
       ) {
         continue;
       }
-      const rejection: ToolEditApprovalResult = {
-        accepted: false,
-        cause: selector.cause,
-      };
+      const rejection = cancellationResultFor('toolEdit', selector.cause);
       if (state.phase === 'initializing') {
         state.resolution ??= rejection;
         continue;
@@ -306,10 +304,10 @@ export class ToolEditApprovalController {
   private discard(requestId: string): void {
     const state = this.requests.get(requestId);
     if (state?.phase === 'initializing') {
-      state.resolution ??= { accepted: false };
+      state.resolution ??= { action: 'reject' };
       return;
     }
-    this.settle(requestId, { accepted: false });
+    this.settle(requestId, { action: 'reject' });
   }
 
   private settle(requestId: string, result: ToolEditApprovalResult): void {
@@ -363,7 +361,7 @@ export class ToolEditApprovalController {
       this.publishPrompt(entry);
       return;
     }
-    this.settle(entry.requestId, { accepted: true, appliedContent });
+    this.settle(entry.requestId, { action: 'apply', appliedContent });
   }
 
   private async publishPromptWhenVisible(

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -111,7 +111,7 @@ function runAccept(
 async function acceptAll(
   request: ToolEditApprovalRequest,
 ): Promise<ToolEditApprovalResult> {
-  return { accepted: true, appliedContent: request.proposedContent };
+  return { action: 'apply', appliedContent: request.proposedContent };
 }
 
 /** Collects workspaceFilesWritten payloads until disposed. */
@@ -189,7 +189,7 @@ describe('accept_run_files progress events', () => {
     stubWorkspaceFiles(false, '');
     vi.spyOn(AbsoluteFS, 'read').mockResolvedValue('proposed content');
     testApprovalHandler = async () => ({
-      accepted: false,
+      action: 'reject',
       feedback: 'keep the original normalization',
     });
 
@@ -213,7 +213,7 @@ describe('accept_run_files progress events', () => {
     });
     stubWorkspaceFiles(false, '');
     vi.spyOn(AbsoluteFS, 'read').mockResolvedValue('proposed content');
-    testApprovalHandler = async () => ({ accepted: false, cause: undefined });
+    testApprovalHandler = async () => ({ action: 'reject', cause: undefined });
 
     const result = await runAccept(tool, [
       { path: 'output.tex', original: 'paper.tex' },
@@ -236,8 +236,8 @@ describe('accept_run_files progress events', () => {
     vi.spyOn(AbsoluteFS, 'read').mockResolvedValue('proposed content');
     testApprovalHandler = async (request) =>
       request.path === 'first.tex'
-        ? { accepted: false, reason: 'Denied by approval policy.' }
-        : { accepted: false, cause: 'Session disposed.' };
+        ? { action: 'reject', reason: 'Denied by approval policy.' }
+        : { action: 'reject', cause: 'Session disposed.' };
 
     const result = await runAccept(tool, [
       { path: 'first.tex', original: 'first.tex' },
@@ -292,7 +292,7 @@ describe('accept_run_files progress events', () => {
     testApprovalHandler = async (request) => {
       approvalOriginal = request.originalContent;
       approvalProposed = request.proposedContent;
-      return { accepted: true, appliedContent: request.proposedContent };
+      return { action: 'apply', appliedContent: request.proposedContent };
     };
 
     const result = await runAccept(tool, [
@@ -320,7 +320,7 @@ describe('accept_run_files progress events', () => {
     vi.spyOn(AbsoluteFS, 'read').mockResolvedValue('same content');
     testApprovalHandler = async (request) => {
       approvals++;
-      return { accepted: true, appliedContent: request.proposedContent };
+      return { action: 'apply', appliedContent: request.proposedContent };
     };
 
     const result = await runAccept(tool, [
@@ -347,7 +347,7 @@ describe('accept_run_files progress events', () => {
     const write = stubWorkspaceFiles(true, '');
     testApprovalHandler = async (request) => {
       approvals++;
-      return { accepted: true, appliedContent: request.proposedContent };
+      return { action: 'apply', appliedContent: request.proposedContent };
     };
 
     const result = await runAccept(tool, [

--- a/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
@@ -288,7 +288,7 @@ describe('human prompt progress events', () => {
       testApprovalHandler = async (request) => {
         editApprovalRequests += 1;
         return {
-          accepted: true,
+          action: 'apply',
           appliedContent: request.proposedContent,
         };
       };
@@ -306,7 +306,7 @@ describe('human prompt progress events', () => {
 
       expect(editApprovalRequests).toBe(1);
       expect(editApproval).toMatchObject({
-        accepted: true,
+        action: 'apply',
         appliedContent: 'new',
       });
     } finally {

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.ts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.ts
@@ -230,7 +230,7 @@ describe('human input approval policy', () => {
       }),
       requestNewProofEdit,
     );
-    expect(result).toMatchObject({ accepted: false });
+    expect(result).toMatchObject({ action: 'reject' });
     expect(policyDenials).toBe(1);
     // The model routes around the denial, so the run's exit code is untouched.
     expect(runOutcomeExitCode(RUN_OUTCOME.COMPLETED)).toBe(CliExitCode.Success);
@@ -523,7 +523,7 @@ describe('buildToolEditApprovalContent', () => {
 
     const result = await requestNewProofEdit();
 
-    expect(result.accepted).toBe(false);
+    expect(result.action).toBe('reject');
     expect(promptSummary).toContain('Tool edit requested by write_file');
     expect(promptSummary).toContain('+\\section{Proof}');
     expect(promptSummary).toContain('+A concise proof.');
@@ -538,7 +538,7 @@ describe('buildToolEditApprovalContent', () => {
 
     const result = await requestNewProofEdit();
 
-    expect(result.accepted).toBe(true);
+    expect(result.action).toBe('apply');
     expect(tracker.events).toEqual(['before', 'prompt']);
   });
 
@@ -552,7 +552,7 @@ describe('buildToolEditApprovalContent', () => {
     const result = await requestNewProofEdit();
 
     expect(result).toMatchObject({
-      accepted: false,
+      action: 'reject',
       feedback: 'proof misses the p = 5 case',
     });
   });
@@ -566,7 +566,7 @@ describe('buildToolEditApprovalContent', () => {
 
     const result = await requestNewProofEdit();
 
-    expect(result).toEqual({ accepted: false });
+    expect(result).toEqual({ action: 'reject' });
   });
 
   it('preserves a failed edit prompt as an automatic cancellation', async () => {
@@ -581,7 +581,7 @@ describe('buildToolEditApprovalContent', () => {
     const result = await requestNewProofEdit();
 
     expect(result).toEqual({
-      accepted: false,
+      action: 'reject',
       cause: 'CLI approval prompt failed.',
     });
   });
@@ -628,7 +628,7 @@ describe('buildToolEditApprovalContent', () => {
     expect(summaries[0]).toContain('Tool edit requested by write_file');
     expect(summaries[1]).toBe('');
     expect(result).toMatchObject({
-      accepted: false,
+      action: 'reject',
       feedback: 'use the workspace-local file path',
     });
   });
@@ -790,7 +790,7 @@ describe('buildToolEditApprovalContent', () => {
     });
 
     expect(result).toMatchObject({
-      accepted: true,
+      action: 'apply',
       appliedContent: '\\section{Auto-approved}\n',
     });
   });

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.ts
@@ -563,7 +563,7 @@ describe('TUI retry approvals', () => {
     currentApproval.get()?.decide({ accepted: true, bypass: 'toolEdit' });
 
     await expect(result).resolves.toEqual({
-      accepted: true,
+      action: 'apply',
       appliedContent: 'new',
     });
     expect(streams.get().get('edit-bypass-stream')?.bypass.toolEdit).toBe(true);
@@ -704,7 +704,7 @@ describe('TUI retry approvals', () => {
 
     await expect(proposal).resolves.toEqual({ action: 'approve' });
     await expect(edit).resolves.toEqual({
-      accepted: true,
+      action: 'apply',
       appliedContent: 'new',
     });
     await expect(bash).resolves.toEqual({ action: 'approve' });

--- a/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.ts
+++ b/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.ts
@@ -198,7 +198,7 @@ describe('createTuiHostInteractions', () => {
     interactions.cancel({ streamId: 'stream-a' });
 
     await expect(editResult).resolves.toEqual({
-      accepted: false,
+      action: 'reject',
       cause: 'Session interrupted.',
     });
     expect(currentApproval.get()).toBeUndefined();

--- a/src/test-kernel/controllers/ToolEditApprovalController.vitest.ts
+++ b/src/test-kernel/controllers/ToolEditApprovalController.vitest.ts
@@ -94,7 +94,7 @@ describe('tool edit approval controller', () => {
     testHost.staging.resolve();
 
     await expect(approval).resolves.toEqual({
-      accepted: false,
+      action: 'reject',
       cause: 'Stream resources released.',
     });
     // No prompt is ever published for a request that never reached the user,
@@ -115,7 +115,7 @@ describe('tool edit approval controller', () => {
     testHost.staging.resolve();
 
     await expect(approval).resolves.toEqual({
-      accepted: true,
+      action: 'apply',
       appliedContent: 'new',
     });
     expect(testHost.preview.readProposedContent).not.toHaveBeenCalled();
@@ -137,7 +137,7 @@ describe('tool edit approval controller', () => {
 
     controller.handleAction({ requestId, action: 'approve' });
     await expect(approval).resolves.toEqual({
-      accepted: true,
+      action: 'apply',
       appliedContent: 'edited by the user',
     });
 

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.ts
@@ -3148,7 +3148,7 @@ describe('DesktopProgressBridge', () => {
         });
 
         await expect(approvalPromise).resolves.toMatchObject({
-          accepted: false,
+          action: 'reject',
           feedback: 'Not this edit.',
         });
       } finally {

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.ts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.ts
@@ -215,7 +215,10 @@ async function createInteractions(handlers = createHandlers()) {
   const toolEditApprovals = {
     approvePendingForStream: vi.fn(async (): Promise<void> => {}),
     cancel: vi.fn(),
-    requestApproval: vi.fn(async () => ({ action: 'apply' })),
+    requestApproval: vi.fn(async () => ({
+      action: 'apply' as const,
+      appliedContent: 'new',
+    })),
   };
   const sessionEvents: SessionEvent[] = [];
   session.events.subscribe((event) => sessionEvents.push(event), {
@@ -318,7 +321,7 @@ describe('createDesktopHostInteractions', () => {
 
     await expect(
       interactions.requestToolEditApproval(request),
-    ).resolves.toEqual({ action: 'apply' });
+    ).resolves.toEqual({ action: 'apply', appliedContent: 'new' });
     // The controller owns its window session (options.session), so the call
     // carries only the request and the caller's interaction options.
     expect(toolEditApprovals.requestApproval).toHaveBeenCalledWith(

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.ts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.ts
@@ -23,6 +23,7 @@ import type {
 } from '@shared/schemas';
 import { SESSION_DISPOSED_CAUSE } from '@shared/copy/interactionCancellation';
 import { createTestSession } from '@test/support/sessionTestUtils';
+import type { ToolEditApprovalResult } from '@tools/approval/toolEditApproval';
 
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.ts';
 
@@ -37,7 +38,7 @@ interface DesktopHostInteractions {
     proposedContent: string;
     sourceTool: string;
     streamId?: StreamTabId;
-  }): Promise<{ accepted: boolean }>;
+  }): Promise<ToolEditApprovalResult>;
   requestBashApproval(request: {
     command: string;
     streamId?: StreamTabId;
@@ -214,7 +215,7 @@ async function createInteractions(handlers = createHandlers()) {
   const toolEditApprovals = {
     approvePendingForStream: vi.fn(async (): Promise<void> => {}),
     cancel: vi.fn(),
-    requestApproval: vi.fn(async () => ({ accepted: true })),
+    requestApproval: vi.fn(async () => ({ action: 'apply' })),
   };
   const sessionEvents: SessionEvent[] = [];
   session.events.subscribe((event) => sessionEvents.push(event), {
@@ -317,7 +318,7 @@ describe('createDesktopHostInteractions', () => {
 
     await expect(
       interactions.requestToolEditApproval(request),
-    ).resolves.toEqual({ accepted: true });
+    ).resolves.toEqual({ action: 'apply' });
     // The controller owns its window session (options.session), so the call
     // carries only the request and the caller's interaction options.
     expect(toolEditApprovals.requestApproval).toHaveBeenCalledWith(

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.ts
@@ -312,7 +312,7 @@ describe('desktop tool edit approval', () => {
       });
       await controller.approvePendingForStream('stream-target');
       await expect(target).resolves.toMatchObject({
-        accepted: true,
+        action: 'apply',
         appliedContent: 'new target\n',
       });
       expect(targetSettled).toBe(true);
@@ -325,7 +325,7 @@ describe('desktop tool edit approval', () => {
         requestId: otherRequest!.requestId,
         action: 'reject',
       });
-      await expect(other).resolves.toMatchObject({ accepted: false });
+      await expect(other).resolves.toMatchObject({ action: 'reject' });
     },
   );
 
@@ -359,7 +359,7 @@ describe('desktop tool edit approval', () => {
         action: 'reject',
       });
 
-      await expect(approval).resolves.toMatchObject({ accepted: false });
+      await expect(approval).resolves.toMatchObject({ action: 'reject' });
     },
   );
 
@@ -423,7 +423,7 @@ describe('desktop tool edit approval', () => {
         feedback: 'not yet',
       });
       await expect(resultPromise).resolves.toMatchObject({
-        accepted: false,
+        action: 'reject',
         feedback: 'not yet',
       });
       await vi.waitFor(async () => {
@@ -476,7 +476,7 @@ describe('desktop tool edit approval', () => {
         requestId: shown[0].requestId,
         action: 'reject',
       });
-      await expect(resultPromise).resolves.toMatchObject({ accepted: false });
+      await expect(resultPromise).resolves.toMatchObject({ action: 'reject' });
     },
   );
 
@@ -516,7 +516,7 @@ describe('desktop tool edit approval', () => {
       });
 
       await expect(resultPromise).resolves.toMatchObject({
-        accepted: true,
+        action: 'apply',
         appliedContent: 'beta\nwith user edits\nand more\n',
         lineChanges: { added: 3, removed: 1 },
       });
@@ -573,7 +573,7 @@ describe('desktop tool edit approval', () => {
       controller.handleAction({ requestId, action: 'approve' });
 
       await expect(resultPromise).resolves.toMatchObject({
-        accepted: true,
+        action: 'apply',
         appliedContent: 'beta after retry\n',
       });
       expect(resolved).toEqual([{ requestId }, { requestId }]);
@@ -629,7 +629,7 @@ describe('desktop tool edit approval', () => {
         requestId: shown[0].requestId,
         action: 'reject',
       });
-      await expect(resultPromise).resolves.toMatchObject({ accepted: false });
+      await expect(resultPromise).resolves.toMatchObject({ action: 'reject' });
     },
   );
 
@@ -682,7 +682,7 @@ describe('desktop tool edit approval', () => {
       await expect(pathExists(displayed[0].absolutePath)).resolves.toBe(true);
 
       controller.dispose();
-      await expect(resultPromise).resolves.toMatchObject({ accepted: false });
+      await expect(resultPromise).resolves.toMatchObject({ action: 'reject' });
       await vi.waitFor(async () => {
         await expect(pathExists(displayed[0].absolutePath)).resolves.toBe(
           false,
@@ -711,7 +711,7 @@ describe('desktop tool edit approval', () => {
       });
 
       await expect(resultPromise).resolves.toMatchObject({
-        accepted: false,
+        action: 'reject',
         cause: 'Owning execution ended.',
       });
       expect(interactions.shownToolEditPermissions).toEqual([]);
@@ -736,7 +736,7 @@ describe('desktop tool edit approval', () => {
       controller.dispose();
 
       await expect(resultPromise).resolves.toMatchObject({
-        accepted: false,
+        action: 'reject',
         cause: SESSION_DISPOSED_CAUSE,
       });
       expect(interactions.shownToolEditPermissions).toEqual([]);
@@ -787,7 +787,7 @@ describe('desktop tool edit approval', () => {
       });
 
       await expect(cancelledPromise).resolves.toMatchObject({
-        accepted: false,
+        action: 'reject',
         cause: 'Owning execution ended.',
       });
       expect(resolved).toEqual([{ requestId: cancelledRequest.requestId }]);
@@ -798,7 +798,7 @@ describe('desktop tool edit approval', () => {
         feedback: 'Retained request resolved normally.',
       });
       await expect(retainedPromise).resolves.toMatchObject({
-        accepted: false,
+        action: 'reject',
         feedback: 'Retained request resolved normally.',
       });
       await waitForEmptyDir(tempRoot);
@@ -838,7 +838,7 @@ describe('desktop tool edit approval', () => {
       cleanupApprovalsForStream('stream-cleanup', session);
 
       await expect(resultPromise).resolves.toMatchObject({
-        accepted: false,
+        action: 'reject',
         cause: 'Stream resources released.',
       });
       expect(resolved).toEqual([{ requestId: shown[0].requestId }]);

--- a/src/test-kernel/frontend/VscodeToolEditApproval.vitest.ts
+++ b/src/test-kernel/frontend/VscodeToolEditApproval.vitest.ts
@@ -252,7 +252,7 @@ describe('VS Code tool edit approval', () => {
       controller.approvePendingForStream('stream-initializing'),
     ).resolves.toBeUndefined();
     await expect(approval).resolves.toMatchObject({
-      accepted: true,
+      action: 'apply',
       appliedContent: 'new\n',
     });
     expect(interactions.shown).toEqual([]);
@@ -274,7 +274,7 @@ describe('VS Code tool edit approval', () => {
     });
 
     controller.handleAction({ requestId, action: 'reject' });
-    await expect(approval).resolves.toMatchObject({ accepted: false });
+    await expect(approval).resolves.toMatchObject({ action: 'reject' });
   });
 
   it('approves a matching edit whose preview is already pending', async () => {
@@ -284,7 +284,7 @@ describe('VS Code tool edit approval', () => {
       controller.approvePendingForStream('stream-approval'),
     ).resolves.toBeUndefined();
     await expect(approval).resolves.toMatchObject({
-      accepted: true,
+      action: 'apply',
       appliedContent: 'new\n',
     });
   });
@@ -311,13 +311,13 @@ describe('VS Code tool edit approval', () => {
     await vi.waitFor(() => expect(other.interactions.shown).toHaveLength(1));
 
     await target.controller.approvePendingForStream('stream-target');
-    await expect(targetStream).resolves.toMatchObject({ accepted: true });
+    await expect(targetStream).resolves.toMatchObject({ action: 'apply' });
 
     target.controller.cancel({ streamId: 'stream-other' });
     other.controller.cancel({ streamId: 'stream-target' });
-    await expect(otherStream).resolves.toMatchObject({ accepted: false });
+    await expect(otherStream).resolves.toMatchObject({ action: 'reject' });
     await expect(otherSessionRequest).resolves.toMatchObject({
-      accepted: false,
+      action: 'reject',
     });
   });
 
@@ -336,7 +336,7 @@ describe('VS Code tool edit approval', () => {
     });
 
     await expect(approval).resolves.toMatchObject({
-      accepted: false,
+      action: 'reject',
       cause: 'Run ended.',
     });
     expect(interactions.shown).toEqual([]);
@@ -369,7 +369,7 @@ describe('VS Code tool edit approval', () => {
     });
     revealProgress?.();
 
-    await expect(approval).resolves.toMatchObject({ accepted: false });
+    await expect(approval).resolves.toMatchObject({ action: 'reject' });
     await Promise.resolve();
     expect(interactions.shown).toEqual([]);
   });
@@ -385,7 +385,7 @@ describe('VS Code tool edit approval', () => {
     });
 
     await expect(approval).resolves.toMatchObject({
-      accepted: false,
+      action: 'reject',
       cause: 'Stream resources released.',
     });
     expect(interactions.resolved).toEqual([{ requestId }]);
@@ -412,7 +412,7 @@ describe('VS Code tool edit approval', () => {
       action: 'reject',
     });
 
-    await expect(approval).resolves.toMatchObject({ accepted: false });
+    await expect(approval).resolves.toMatchObject({ action: 'reject' });
   });
 
   it('restores a failed approval prompt and accepts a later retry', async () => {
@@ -436,7 +436,7 @@ describe('VS Code tool edit approval', () => {
     controller.handleAction({ requestId, action: 'approve' });
 
     await expect(approval).resolves.toMatchObject({
-      accepted: true,
+      action: 'apply',
       appliedContent: 'beta after retry\n',
     });
     expect(getText).toHaveBeenCalledOnce();
@@ -455,7 +455,7 @@ describe('VS Code tool edit approval', () => {
     controller.handleAction({ requestId, action: 'approve' });
 
     await expect(approval).resolves.toMatchObject({
-      accepted: true,
+      action: 'apply',
       appliedContent: 'beta edited\n',
     });
     expect(getText).toHaveBeenCalledOnce();
@@ -478,6 +478,6 @@ describe('VS Code tool edit approval', () => {
     expect(vscodeMocks.showErrorMessage).not.toHaveBeenCalled();
 
     controller.handleAction({ requestId, action: 'reject' });
-    await expect(approval).resolves.toMatchObject({ accepted: false });
+    await expect(approval).resolves.toMatchObject({ action: 'reject' });
   });
 });

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
@@ -950,7 +950,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('delegates tool edit approval to the session approval controller', async () => {
-    const approvalResult = { accepted: true };
+    const approvalResult = { action: 'apply' };
     const session = createTestSession();
     const { interactions, toolEditApprovals } = createInteractions({ session });
     toolEditApprovals.requestApproval.mockResolvedValue(approvalResult);

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.ts
@@ -950,7 +950,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('delegates tool edit approval to the session approval controller', async () => {
-    const approvalResult = { action: 'apply' };
+    const approvalResult = { action: 'apply', appliedContent: 'B' } as const;
     const session = createTestSession();
     const { interactions, toolEditApprovals } = createInteractions({ session });
     toolEditApprovals.requestApproval.mockResolvedValue(approvalResult);

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -72,7 +72,7 @@ describe('approval cleanup scope', () => {
     try {
       cleanupApprovalsForStream(streamId, session);
       await expect(pending).resolves.toEqual({
-        accepted: false,
+        action: 'reject',
         cause: 'Stream resources released.',
       });
       expect(cancel).toHaveBeenCalledWith({
@@ -101,7 +101,7 @@ describe('approval cleanup scope', () => {
     });
     const streamlessCleanupSettlements = [
       {
-        accepted: false,
+        action: 'reject',
         cause: 'Streamless approval cleanup.',
       },
       {
@@ -246,7 +246,7 @@ describe('session-owned approval state (#8144)', () => {
     session.dispose();
 
     await expect(pending).resolves.toEqual({
-      accepted: false,
+      action: 'reject',
       cause: 'Session disposed.',
     });
     expect(isBashApprovalBypassedForStream(streamId, session)).toBe(false);

--- a/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
+++ b/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
@@ -53,7 +53,7 @@ describe('Concurrent session tool edit approval handlers', () => {
         request: ToolEditApprovalRequest,
       ): Promise<ToolEditApprovalResult> => {
         seen.push(request);
-        return { accepted: true, appliedContent };
+        return { action: 'apply', appliedContent };
       };
     }
 
@@ -107,7 +107,13 @@ describe('Concurrent session tool edit approval handlers', () => {
     expect(seenByA.map((request) => request.path)).toEqual(['a.tex']);
     expect(seenByB.map((request) => request.path)).toEqual(['b.tex']);
 
-    expect(resultA).toMatchObject({ accepted: true, appliedContent: 'from-a' });
-    expect(resultB).toMatchObject({ accepted: true, appliedContent: 'from-b' });
+    expect(resultA).toMatchObject({
+      action: 'apply',
+      appliedContent: 'from-a',
+    });
+    expect(resultB).toMatchObject({
+      action: 'apply',
+      appliedContent: 'from-b',
+    });
   });
 });

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -43,7 +43,7 @@ async function installPlatform(
   approvalRequests = [];
   testApprovalHandler = async (request) => {
     approvalRequests.push(request);
-    return { accepted: true, appliedContent: request.proposedContent };
+    return { action: 'apply', appliedContent: request.proposedContent };
   };
   await installFakePlatform({ workspacePath: '/workspace', config, files });
   detachHostInteractions();
@@ -110,7 +110,7 @@ describe('Tool edit approval gating', () => {
     const tool = new WriteFileTool();
     const write = stubWorkspaceFile({ exists: true, content: 'old content' });
     testApprovalHandler = async () => ({
-      accepted: true,
+      action: 'apply',
       appliedContent: 'reviewed content',
     });
 
@@ -128,7 +128,7 @@ describe('Tool edit approval gating', () => {
     const write = stubWorkspaceFile({ exists: true, content: 'base' });
 
     testApprovalHandler = async () => ({
-      accepted: false,
+      action: 'reject',
       feedback: 'Rejected by user',
     });
 
@@ -150,7 +150,7 @@ describe('Tool edit approval gating', () => {
     const tool = new WriteFileTool();
     const write = stubWorkspaceFile({ exists: true, content: 'base' });
     testApprovalHandler = async () => ({
-      accepted: false,
+      action: 'reject',
       cause: 'Session disposed.',
     });
 
@@ -169,7 +169,7 @@ describe('Tool edit approval gating', () => {
     const tool = new WriteFileTool();
     const write = stubWorkspaceFile({ exists: true, content: 'base' });
     testApprovalHandler = async () => ({
-      accepted: false,
+      action: 'reject',
       cause: undefined,
     });
 
@@ -271,12 +271,12 @@ describe('Tool edit approval gating', () => {
 
     assert.strictEqual(handlerCalls, 1);
     setToolEditApprovalSessionBypass(TEST_STREAM_ID, true, { silent: true });
-    firstApproval.resolve({ accepted: true, appliedContent: 'first.txt' });
+    firstApproval.resolve({ action: 'apply', appliedContent: 'first.txt' });
 
     const results = await Promise.all([firstRequest, secondRequest]);
     assert.deepStrictEqual(
-      results.map((result) => result.accepted),
-      [true, true],
+      results.map((result) => result.action),
+      ['apply', 'apply'],
     );
     assert.strictEqual(handlerCalls, 1);
   });

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -221,7 +221,7 @@ Parameters map directly to subagent-result delivery attributes:
         sourceTool: 'accept_run_files',
       });
 
-      if (!approval.accepted) {
+      if (approval.action !== 'apply') {
         rejected++;
         firstRejectedPath ??= entry.original;
         if ('cause' in approval) {

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -61,7 +61,7 @@ export interface ToolEditApprovalRequest {
  */
 export type ToolEditApprovalResult =
   | {
-      readonly accepted: true;
+      readonly action: 'apply';
       readonly appliedContent: string;
       readonly userPatch?: string;
       readonly lineChanges?: {
@@ -70,7 +70,7 @@ export type ToolEditApprovalResult =
       };
       readonly startLine?: number;
     }
-  | ({ readonly accepted: false } & RejectionProvenance);
+  | ({ readonly action: 'reject' } & RejectionProvenance);
 
 const TOOL_EDIT_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireEditApproval';
 
@@ -254,7 +254,7 @@ export async function requestToolEditApproval(
   );
   const acceptProposedAsIs = (): ToolEditApprovalResult =>
     finalizeApprovalResult(
-      { accepted: true, appliedContent: preparedRequest.proposedContent },
+      { action: 'apply', appliedContent: preparedRequest.proposedContent },
       preparedRequest,
     );
   const decision = decideTexraApproval({
@@ -267,7 +267,7 @@ export async function requestToolEditApproval(
   if (isTexraApprovalDenied(decision)) {
     context?.onApprovalPolicyDenial?.();
     return {
-      accepted: false,
+      action: 'reject',
       reason: texraApprovalDenialMessage(decision),
     };
   }
@@ -291,7 +291,7 @@ function finalizeApprovalResult(
   result: ToolEditApprovalResult,
   request: ToolEditApprovalRequest,
 ): ToolEditApprovalResult {
-  if (!result.accepted) {
+  if (result.action !== 'apply') {
     return result;
   }
 
@@ -315,10 +315,10 @@ function finalizeApprovalResult(
   };
 }
 
-/** The `accepted: true` branch of {@link ToolEditApprovalResult}. */
+/** The `action: 'apply'` branch of {@link ToolEditApprovalResult}. */
 export type AcceptedToolEditApprovalResult = Extract<
   ToolEditApprovalResult,
-  { accepted: true }
+  { action: 'apply' }
 >;
 
 interface WriteApprovedContentResult {
@@ -458,7 +458,7 @@ export async function requestAndWriteApprovedEdit(request: {
     sourceTool,
   });
 
-  if (!approval.accepted) {
+  if (approval.action !== 'apply') {
     return {
       rejected: buildApprovalRejectedResult(displayPath, sourceTool, approval),
     };


### PR DESCRIPTION
Refs #10674

Implements the §2.2 item 4 slice of the shared-contracts retirement wave:
`ToolEditApprovalResult` now speaks the same `{action}` vocabulary as its
five host-interaction siblings, `toolEdit` joins `HostInteractionResultByKind`,
and the two hand-written tool-edit cancellation literals are replaced by
`cancellationResultFor('toolEdit', cause)`.

Result shape (owner `src/tools/approval/toolEditApproval.ts:62-73`):

```ts
type ToolEditApprovalResult =
  | { action: 'apply'; appliedContent: string; userPatch?; lineChanges?; startLine? }
  | ({ action: 'reject' } & RejectionProvenance);
```

`apply`/`reject` preserve the previous accepted/apply vs rejected/cancelled
semantics exactly: `reject` still carries `feedback` (user declined),
`reason` (policy/headless denial), or `cause` (automatic cancellation), and
the apply branch still requires `appliedContent`.

No wire/IPC literals change: this is the in-memory host-interaction
settlement only. `TOOL_EDIT_APPROVAL_ACTION`, `ToolEditPermission`, and
progress-view IPC literals are untouched.

## Replacement verdict (§5b)

N/A — this slice introduces no new concept or compatibility path. It replaces
the old `{ accepted }` result vocabulary with the existing host-interaction
`{ action }` vocabulary and reuses the existing `cancellationResultFor` owner.

## Net elements (R6)

Final diffstat (`origin/main` `9597e367ec` → head `66af35be8a`):

- **19 files changed, +102 / −92, net +10.**
- Production: **5 files, +22 / −22, net 0** — the vocabulary swap is a
  one-for-one field rename with no added machinery.
- Fixture migration: **14 files, +80 / −70, net +10** — the `action: 'apply'`
  key is longer than `accepted: true`, so a handful of one-line
  `toMatchObject`/`toEqual` assertions re-wrap across two lines; no new
  coverage was added.

Production sites that construct the two variants:

- `src/tools/approval/toolEditApproval.ts:257` auto-approve `apply`
- `src/tools/approval/toolEditApproval.ts:270` policy denial `reject`
- `src/controllers/approval/ToolEditApprovalController.ts:226` user reject
- `src/controllers/approval/ToolEditApprovalController.ts:256` stream auto-approve
- `src/controllers/approval/ToolEditApprovalController.ts:283` cancellation via `cancellationResultFor`
- `src/controllers/approval/ToolEditApprovalController.ts:307` init discard
- `src/controllers/approval/ToolEditApprovalController.ts:310` pending discard
- `src/controllers/approval/ToolEditApprovalController.ts:364` user apply
- `src/agent/runtime/HostInteractions.ts:284` cancellation factory (`toolEdit`)
- `packages/cli/src/runtime/approvalAdapter.ts:63,66,69` CLI `toToolEditResult`

Production sites that read the discriminant:

- `src/tools/approval/toolEditApproval.ts:294` finalize approval guard
- `src/tools/approval/toolEditApproval.ts:461` approve-then-write guard
- `src/tools/AcceptRunFilesTool.ts:224` all-changed rejection aggregation

Apply-branch type consumers:

- `src/tools/fileEditFlow.ts:14,214` (`AcceptedToolEditApprovalResult`)
- `src/tools/approval/toolEditApproval.ts:319,430`

Pass-through / type-only surfaces:

- `src/controllers/progressView/backend/progressHostInteractions.ts:376-383`
- `packages/cli/src/chat/tui/state/subscribeApprovals.ts:167-176` (via `toToolEditResult`)
- `src/tools/approval/index.ts:137` barrel re-export

## Consumer counts (R8)

- 8 production files reference `ToolEditApprovalResult`:
  `toolEditApproval.ts`, `HostInteractions.ts`, `ToolEditApprovalController.ts`,
  `progressHostInteractions.ts`, `approvalAdapter.ts`, `subscribeApprovals.ts`,
  `fileEditFlow.ts`, and the `@tools/approval` barrel `index.ts`.
- 10 production construction sites and 3 production discriminant-read sites,
  all listed above; no dual-system resting state remains (repo-wide grep finds
  no remaining `.accepted`/`accepted:` typed as `ToolEditApprovalResult`).

Looks-orphaned-but-isn't:

- `AcceptedToolEditApprovalResult` stays: it is consumed by
  `fileEditFlow.ts:214` and `toolEditApproval.ts:430`.
- `cancellationResultFor('toolEdit', cause)` has exactly two callers:
  `HostInteractions.ts:571` and `ToolEditApprovalController.ts:283`.
- `HostInteractionResultByKind.toolEdit` is not dead: it is consumed by
  `SettledInteractionKind` (`keyof`) and the typed
  `cancellationResultFactories` record.
- `ToolEditApprovalResult` remains re-exported from the `@tools/approval`
  barrel (`src/tools/approval/index.ts:137`) and is still imported by
  test mocks that type host adapters; the type owner is retained, not split.

## Validation

No new tests; existing fixtures/assertions migrated one-for-one to the new
shape (per maintainer no-new-coverage policy).

- Full typecheck: `npm run typecheck` — green (workspace, test-kernel, agent,
  cli, trace-viewer, desktop)
- Lint: `npm run lint` — green
- Format: `npm run format:check` — green
- `git diff --check` — clean
- Architecture suites: `npx vitest run src/test-kernel/architecture` —
  17 files / 101 tests green
- Ratchet gates: `check:dead-code-ratchet` (10 current vs 10 baselined),
  `check:guidance-refs`, `check:browser-safe-utils` — all green
- Affected suites (15 files / 302 tests) green:
  ToolEditApprovalGate, ConcurrentToolEditApprovalHandlers,
  ApprovalCleanupScope, ToolEditApprovalController, VscodeToolEditApproval,
  DesktopToolEditApproval, DesktopHostInteractions, DesktopAgentExecution,
  ExtensionHostInteractions, HumanPromptProgressEvents,
  AcceptRunFilesProgressEvents, SessionInteractions, ApprovalAdapter,
  TuiHostInteractionsCancelForStream, TuiApprovalRetry


