### PR TITLE
refactor(lease): replace heartbeat liveness with proven instance presence

### DIFF
--- a/docs/prds/2026-08-16-prd-execution-liveness-presence.md
+++ b/docs/prds/2026-08-16-prd-execution-liveness-presence.md
@@ -87,19 +87,27 @@ What the old system conflated, and what happens to each job:
 - `probeInstance(owner)` → `'alive' | 'dead' | 'unprovable'`: connect with a
   short timeout, read the banner, verify the instance id, destroy.
   - banner matches → `alive`
-  - `ECONNREFUSED` / `ENOENT`, or a _valid_ banner naming a different instance
-    (path reused by a newer TeXRA process) → `dead`
+  - `ECONNREFUSED`, or a _valid_ banner naming a different instance (path
+    reused by a newer TeXRA process) → `dead`
+  - `ENOENT` (socket file unlinked — graceful exit, or a tmp cleaner racing a
+    live owner) → `dead` only together with a pid proof: `kill(pid, 0)`
+    throwing `ESRCH` is a kernel fact; success proves nothing (pid may be
+    recycled) → `unprovable`
   - timeout, other errors, non-TeXRA banner, or `owner.hostname` differing
-    from `os.hostname()` (shared home directory across machines) →
-    `unprovable` → treated as alive, logged at `warn`
+    (case-insensitively) from `os.hostname()` (shared home directory across
+    machines) → `unprovable` → treated as alive, logged at `warn`. The
+    hostname guard applies on every platform and equally to exit watches.
 - `watchInstanceExit(owner, listener)` → shared per-socket-path held
   connection; the kernel closes it when the owner process dies, firing the
   listeners. This replaces polling entirely: death is pushed, not sampled.
+  Inconclusive outcomes reconnect for a fresh verdict; a repeatedly
+  unprovable owner's watch gives up loudly, leaving a **bounded liveness
+  gap** (no automatic retrigger until the next natural repair pass) — a
+  deliberate fail-safe, never a reclaim hazard.
 - If the socket path would exceed the platform `sun_path` limit (~104 bytes on
-  macOS), fall back to a directory under `os.tmpdir()` with a `warn` log. In
-  that fallback `ENOENT` remains a death verdict; the residual risk (tmp
-  cleanup unlinking a live socket file) is bounded by the retained write
-  fence, and the fallback should be rare enough to be an incident, not a mode.
+  macOS), fall back to a directory under `os.tmpdir()` with a `warn` log; the
+  pid-proof rule above makes a cleaner-unlinked live socket `unprovable`
+  rather than dead.
 
 ### 3.2 Lease record v2
 
@@ -112,7 +120,7 @@ What the old system conflated, and what happens to each job:
   "owner": {
     "instanceId": "…",
     "socketPath": "…",
-    "pid": 12345, // diagnostics only — never a liveness input
+    "pid": 12345, // death-proof-only tiebreak (ESRCH) for unlinked sockets — never an aliveness input
     "hostname": "…", // cross-host guard → unprovable, never a death proof
   },
 }

--- a/docs/prds/2026-08-16-prd-execution-liveness-presence.md
+++ b/docs/prds/2026-08-16-prd-execution-liveness-presence.md
@@ -1,0 +1,214 @@
+# PRD: Proven execution liveness (presence sockets), full retirement of heartbeat leases
+
+**Date:** 2026-08-16
+**Status:** Approved for implementation
+**Owner:** Ray
+**Replaces:** the wall-clock heartbeat/staleness layer of `src/agent/storage/executionLease.ts`
+
+## 1. Problem
+
+Live runs are being killed by their own gating system. Observed repeatedly as:
+a run "suddenly disconnects", then every follow-up fails with
+`No active session for follow-up on stream <id>. Status: failed`.
+
+Root cause, confirmed in code and on an affected machine:
+
+- Execution ownership is a lease file renewed by a 15 s heartbeat
+  (`EXECUTION_LEASE_HEARTBEAT_MS`); any observer treats
+  `Date.now() - heartbeatAt > 120_000` (`EXECUTION_LEASE_STALE_MS`) as proof
+  the owner is dead and may reclaim (restart repair marks the stream FAILED,
+  finalizes the execution, deletes the lease).
+- **System sleep freezes every process's heartbeats while wall-clock time keeps
+  advancing.** After any sleep longer than the stale horizon, every live owner
+  looks dead at the moment of wake — precisely when reaper timers queued during
+  sleep (`RestartRepairRetryScheduler`, scheduled at `heartbeatAt + 120s + 1`)
+  all fire. Whoever wins the file lock decides whether a live run is destroyed.
+- A second kill path needs no reaper: `handleHeartbeatFailure` declares
+  ownership lost when one heartbeat errors while
+  `Date.now() - lastConfirmedHeartbeatAt > 120s`. After any >2 min sleep that
+  delta is always exceeded, so a single transient error at wake (e.g. lock
+  contention from the wake stampede of all owned leases renewing at once) is an
+  instant, retry-free self-kill.
+- Two hosts sharing one workspace (two TUIs, or TUI + extension) each run
+  restart repair over the other's RUNNING streams, so a reaper timer is always
+  pending across any sleep. Confirmed on the affected machine: two `texra`
+  processes per workspace, `pmset` sleep windows of 522–939 s, and one
+  workspace with 115 concurrently heartbeated leases.
+
+The failure is not a bug in the implementation of the heartbeat protocol. The
+protocol's core inference — _"heartbeat older than the horizon ⇒ owner is
+dead"_ — is false on a machine that suspends. No tuning of the horizon fixes
+that; it only moves the race.
+
+## 2. Principle
+
+**Liveness is proven, never inferred.** No wall-clock (or monotonic-clock)
+reading anywhere in any liveness decision. Every verdict is one of:
+
+- **Alive — proven** by a kernel fact (an accepted connection to the owner's
+  presence socket carrying the owner's instance banner).
+- **Dead — proven** by a kernel fact (`ECONNREFUSED`/`ENOENT` on the recorded
+  socket path: the kernel states no such listener exists; a crashed or
+  SIGKILLed process cannot keep a socket listening, and suspend does not stop
+  one from listening).
+- **Unprovable** (probe timeout, permission error, banner mismatch beyond the
+  known-stale-file case, foreign hostname): **fail safe — treat as alive,
+  refuse reclamation, log loud.** We never destroy on ambiguity.
+
+Heartbeat leases are the tested pattern for _distributed_ systems (Chubby,
+ZooKeeper, Kubernetes Leases) because across machines nothing better exists —
+and even there they are known to be unsafe against pauses without fencing.
+TeXRA's coordination is same-machine by construction (mtime file locks on the
+local data root), where the kernel offers an exact oracle. Prior art for the
+oracle chosen here: tmux server sockets, ssh-agent, the Docker daemon socket,
+and Electron's `app.requestSingleInstanceLock()` — which the TeXRA desktop
+already relies on (`desktopProtocolCallbacks.ts`).
+
+What the old system conflated, and what happens to each job:
+
+| Job                        | Old mechanism                                  | New mechanism                             |
+| -------------------------- | ---------------------------------------------- | ----------------------------------------- |
+| Mutual exclusion + fencing | file lock + `ownerToken` compare-on-write      | **unchanged** (this part was correct)     |
+| Failure detection          | wall-clock heartbeat age                       | presence-socket probe (kernel fact)       |
+| Reclamation trigger        | reaper retry timer at `heartbeatAt + 120s + 1` | owner-exit event (watch connection close) |
+
+## 3. Design
+
+### 3.1 Instance presence (`src/agent/storage/instancePresence.ts`, new)
+
+- Each TeXRA process lazily binds **one** Unix domain socket (Windows: named
+  pipe `\\.\pipe\texra-<instanceId>`) the first time it acquires any execution
+  lease: `<globalStoragePath>/instances/<instanceId>.sock`, dir mode 0700,
+  `instanceId` random (12+ hex chars). The `net.Server` is `unref()`ed; on
+  graceful exit the socket is closed and unlinked; after a crash the stale
+  file yields `ECONNREFUSED` (a death proof), and reboot removes it entirely.
+- On every accepted connection the server writes a banner
+  `texra-presence:<instanceId>\n` and **holds the connection open**.
+- `probeInstance(owner)` → `'alive' | 'dead' | 'unprovable'`: connect with a
+  short timeout, read the banner, verify the instance id, destroy.
+  - banner matches → `alive`
+  - `ECONNREFUSED` / `ENOENT`, or a _valid_ banner naming a different instance
+    (path reused by a newer TeXRA process) → `dead`
+  - timeout, other errors, non-TeXRA banner, or `owner.hostname` differing
+    from `os.hostname()` (shared home directory across machines) →
+    `unprovable` → treated as alive, logged at `warn`
+- `watchInstanceExit(owner, listener)` → shared per-socket-path held
+  connection; the kernel closes it when the owner process dies, firing the
+  listeners. This replaces polling entirely: death is pushed, not sampled.
+- If the socket path would exceed the platform `sun_path` limit (~104 bytes on
+  macOS), fall back to a directory under `os.tmpdir()` with a `warn` log. In
+  that fallback `ENOENT` remains a death verdict; the residual risk (tmp
+  cleanup unlinking a live socket file) is bounded by the retained write
+  fence, and the fallback should be rare enough to be an incident, not a mode.
+
+### 3.2 Lease record v2
+
+```jsonc
+{
+  "version": 2,
+  "executionId": "…",
+  "ownerToken": "<uuid>", // fencing token, unchanged role
+  "acquiredAt": 1786868997829, // display/diagnostics only — never a liveness input
+  "owner": {
+    "instanceId": "…",
+    "socketPath": "…",
+    "pid": 12345, // diagnostics only — never a liveness input
+    "hostname": "…", // cross-host guard → unprovable, never a death proof
+  },
+}
+```
+
+Written once at acquisition. **Never renewed.** Deleted at release. A process
+that owned 115 executions previously rewrote 115 files every 15 s; it now
+maintains one socket and zero renewals.
+
+### 3.3 Consumer semantics
+
+- `acquireFreshExecutionLease` / `acquireResumedExecutionLease`: under the
+  existing file lock, read the record; probe; `alive`/`unprovable` →
+  `ExecutionLeaseActiveError`; `dead`/missing → overwrite and own. The
+  in-process resume fast path keeps its local-ownership check, minus the
+  heartbeat dance.
+- `runWithInactiveExecutionLease`: probe instead of freshness; `alive`/
+  `unprovable` → `{status:'active'}` (now carrying owner diagnostics instead
+  of `heartbeatAt`); proven dead → perform maintenance and delete the record.
+- `inspectExecutionLease` presence taxonomy becomes
+  `missing | owned | foreign | orphaned` (`orphaned` = record present, owner
+  proven dead). Reported metadata: `acquiredAt` + owner diagnostics.
+- `renewOwnedExecutionLease` → renamed `validateOwnedExecutionLease`: a pure
+  fencing check (read under lock, compare `ownerToken`), no write. Its two
+  call sites in `SessionHandle.releaseExecutionLease` keep their positions as
+  durability-boundary validations.
+- Restart repair: on `active` skip, register `watchInstanceExit`; on owner
+  exit, re-run repair for those streams immediately. `nextLeaseCheckAt` and
+  `RestartRepairRetryScheduler` are deleted. Repair actions on a proven-dead
+  owner are unchanged in this PRD (the FAILED verdict is now accurate by
+  construction).
+- `onOwnedExecutionLeaseLost` remains, as the fencing backstop only: it fires
+  when a write-boundary validation finds a foreign or missing record (manual
+  file deletion, tmp-fallback edge, bugs). Nothing fires it on a schedule.
+
+### 3.4 Deliberate consequence: no automatic takeover of live owners
+
+Previously a hung-but-alive owner could be displaced after 120 s. Now a live
+owner can never be displaced automatically — `ExecutionLeaseActiveError` is
+returned for as long as the owner process exists. The user's recourse for a
+wedged owner is to quit that process; the kernel then closes its sockets and
+every verdict flips to proven-dead instantly. Cooperative handoff ("ask the
+owner to yield") is a natural future use of the presence channel and an
+explicit non-goal here.
+
+## 4. Complete retirement — nothing survives
+
+Per the decision to retire the previous system outright, with no compatibility
+arms:
+
+**Deleted:** `EXECUTION_LEASE_STALE_MS`, `EXECUTION_LEASE_HEARTBEAT_MS`, the
+heartbeat interval timer, `renewHeartbeat`/`heartbeat`, `heartbeatInFlight`,
+`lastConfirmedHeartbeatAt`, `handleHeartbeatFailure` and the ECOMPROMISED
+self-kill, `isFresh`, the `heartbeatAt` field and every consumer of it
+(`DeleteExecutionResult`, restart-repair results, presence results),
+`RestartRepairRetryScheduler` and `nextLeaseCheckAt`, and the v1 record
+schema.
+
+**Version-1 lease records are not recognized at all.** The schema knows only
+version 2; a leftover v1 file falls under the pre-existing policy that a
+malformed present record rejects deliberately and loudly. No freshness
+fallback, no orphan-classification arm, no transition reader. Release note:
+restart every TeXRA host after upgrading, and clear leftover
+`executionLeases/` directories once (`rm <storage>/executionLeases/*.json`) —
+until cleared, those executions refuse resume with a loud parse error rather
+than a silent guess. (Consistent with the standing ruling that
+intermediate-era data gets deleted early and loudly rather than age-gated.)
+
+**Kept:** `withLeaseLock` (proper-lockfile mutual exclusion for record
+read-modify-write), `ownerToken` fencing and `runWithExecutionLeaseWriteFence`,
+the `AsyncLocalStorage` ownership-generation scoping
+(`captureOwnedExecutionLease`), durability retention
+(`markOwnedExecutionLeaseUndurable` / abandon / complete), and the
+acquisition/maintenance quiescence coordination.
+
+## 5. Non-goals
+
+- Cooperative handoff / force-takeover of live owners (future presence-channel
+  work).
+- The broker/daemon architecture (runs living in a per-workspace daemon,
+  UIs as attaching clients). It remains the endpoint that eliminates the
+  multi-UI category entirely; this PRD's presence socket is a stepping stone,
+  not a substitute decision.
+- Non-destructive restart repair (reap to _resumable_ instead of FAILED +
+  flow-record delete). Worth doing; separate change.
+- The lease-release leak observed in the wild (115 still-owned records for
+  executions acquired over three days). Orthogonal bug in the release path;
+  under the new system it is inert load but still wrongly blocks resume of
+  those executions while the owner lives. Needs its own investigation.
+
+## 6. Testing
+
+Rewrite `src/test-kernel/agent/storage/ExecutionLease.vitest.ts` and
+`executionLeaseFixtures.ts` against the new oracle (real sockets on a temp
+root: alive/refused/missing/banner-mismatch/foreign-hostname verdicts,
+watch-fires-on-close, fencing unchanged). Restart-repair suites lose their
+staleness-clock cases and gain one owner-exit-event case. No new test files;
+existing suites are adapted. The sleep race itself needs no simulation — the
+design contains no clock to race.

--- a/docs/prds/2026-08-16-prd-execution-liveness-presence.md
+++ b/docs/prds/2026-08-16-prd-execution-liveness-presence.md
@@ -171,15 +171,19 @@ self-kill, `isFresh`, the `heartbeatAt` field and every consumer of it
 `RestartRepairRetryScheduler` and `nextLeaseCheckAt`, and the v1 record
 schema.
 
-**Version-1 lease records are not recognized at all.** The schema knows only
-version 2; a leftover v1 file falls under the pre-existing policy that a
-malformed present record rejects deliberately and loudly. No freshness
-fallback, no orphan-classification arm, no transition reader. Release note:
-restart every TeXRA host after upgrading, and clear leftover
-`executionLeases/` directories once (`rm <storage>/executionLeases/*.json`) —
-until cleared, those executions refuse resume with a loud parse error rather
-than a silent guess. (Consistent with the standing ruling that
-intermediate-era data gets deleted early and loudly rather than age-gated.)
+**Version-1 lease records are tombstones.** No v1 semantics survive — no
+freshness fallback, no classification logic, no transition reader. The only
+recognition that remains is `{version: 1} ⇒ garbage from the retired
+protocol`: any locked code path deletes such a file on contact and proceeds
+as if it were absent, logged at `warn`, so upgrades self-heal without asking
+users to clean lease directories by hand. The unlocked classifier
+(`inspectExecutionLease`) reports a tombstone as `orphaned` and leaves the
+delete to the next locked path — an unlocked delete could race a concurrent
+acquisition that just replaced the file. Release note: restart every TeXRA
+host after upgrading (a still-running pre-upgrade host's live lease is a
+tombstone to the new code and will be reclaimed). (Consistent with the
+standing ruling that intermediate-era data gets deleted early and loudly
+rather than age-gated.)
 
 **Kept:** `withLeaseLock` (proper-lockfile mutual exclusion for record
 read-modify-write), `ownerToken` fencing and `runWithExecutionLeaseWriteFence`,

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -378,7 +378,7 @@ export async function executeCliRequest(
         }
         if (
           canAdvertiseRecovery &&
-          (lease?.status === 'missing' || lease?.status === 'stale')
+          (lease?.status === 'missing' || lease?.status === 'orphaned')
         ) {
           settleRecoveryNoticeStarted();
           await options.onInterruptedExecutionFinalized(executionId);

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -844,11 +844,14 @@ export class SessionHandle {
     // re-run for its streams.
     this.disposeRestartRepairWatches();
     for (const skipped of result.activeOwners) {
-      if (this.restartRepairWatches.has(skipped.executionId)) continue;
+      // One watch per owner instance, not per execution: an owner holding
+      // many executions must trigger exactly one repair pass when it exits.
+      const watchKey = skipped.owner.socketPath;
+      if (this.restartRepairWatches.has(watchKey)) continue;
       this.restartRepairWatches.set(
-        skipped.executionId,
+        watchKey,
         watchInstanceExit(skipped.owner, () => {
-          this.restartRepairWatches.delete(skipped.executionId);
+          this.restartRepairWatches.delete(watchKey);
           if (this.restartRepairAbort.signal.aborted) return;
           void this.enqueueRestartRepair(() =>
             this.runRestartRepair(generation),

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -40,9 +40,10 @@ import {
   abandonOwnedExecutionLease,
   completeOwnedExecutionLease,
   isOwnedExecutionLeaseDurable,
-  renewOwnedExecutionLease,
   runWithOwnedExecutionLeaseQuiescence,
+  validateOwnedExecutionLease,
 } from '@agent/storage/executionLease';
+import { watchInstanceExit } from '@agent/storage/instancePresence';
 import { deriveResumability } from '@agent/storage/resumability';
 import type { ResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { createLog } from '@logger/logUtils';
@@ -79,10 +80,7 @@ import {
   type SessionApprovals,
 } from './streamApprovalQueue';
 import { WorkflowControlRegistry } from './workflowControlRegistry';
-import {
-  repairRestartedStreams,
-  RestartRepairRetryScheduler,
-} from './restartRepair';
+import { repairRestartedStreams } from './restartRepair';
 import { createNeutralResponseTextProcessing } from './responseTextProcessing';
 
 const logger = createLog('sessionHandle');
@@ -183,7 +181,7 @@ export class SessionHandle {
     WaitingRepairProbe
   >();
   private readonly restartRepairQueue = new PQueue({ concurrency: 1 });
-  private readonly restartRepairRetry = new RestartRepairRetryScheduler();
+  private readonly restartRepairWatches = new Map<string, () => void>();
   private readonly restartRepairAbort = new AbortController();
   private storageGeneration = 0;
   constructor(init: SessionHandleInit) {
@@ -302,7 +300,7 @@ export class SessionHandle {
     if (hasPendingStorageChange === false) return Promise.resolve(false);
     this.storageGeneration += 1;
     const generation = this.storageGeneration;
-    this.restartRepairRetry.cancel();
+    this.disposeRestartRepairWatches();
     const repair = this.enqueueRestartRepair(() =>
       this.repairStoresAfterRestart(generation, true, hooks),
     );
@@ -841,13 +839,30 @@ export class SessionHandle {
       signal: this.restartRepairAbort.signal,
     });
     if (this.restartRepairAbort.signal.aborted) return;
-    this.restartRepairRetry.schedule(result.nextLeaseCheckAt, () => {
-      void this.enqueueRestartRepair(() =>
-        this.runRestartRepair(generation),
-      ).catch((error: unknown) => {
-        logger.warn('Failed delayed restart repair', { data: error });
-      });
-    });
+    // A live foreign owner is never revisited on a clock: the kernel closes
+    // the presence watch when that process exits, and only then does repair
+    // re-run for its streams.
+    this.disposeRestartRepairWatches();
+    for (const skipped of result.activeOwners) {
+      if (this.restartRepairWatches.has(skipped.executionId)) continue;
+      this.restartRepairWatches.set(
+        skipped.executionId,
+        watchInstanceExit(skipped.owner, () => {
+          this.restartRepairWatches.delete(skipped.executionId);
+          if (this.restartRepairAbort.signal.aborted) return;
+          void this.enqueueRestartRepair(() =>
+            this.runRestartRepair(generation),
+          ).catch((error: unknown) => {
+            logger.warn('Failed owner-exit restart repair', { data: error });
+          });
+        }),
+      );
+    }
+  }
+
+  private disposeRestartRepairWatches(): void {
+    for (const dispose of this.restartRepairWatches.values()) dispose();
+    this.restartRepairWatches.clear();
   }
 
   useHostInteractions(interactions: HostInteractions): () => void {
@@ -882,13 +897,14 @@ export class SessionHandle {
   /**
    * End ownership of one execution only after every session-owned durable
    * writer has drained. Session artifacts persist between two short
-   * owner-token validations — the durable lease remains fresh while the
-   * session drains, so no file lock needs to cover unrelated transcript and
-   * snapshot I/O. An optional post-drain operation may publish lifecycle state
+   * owner-token validations — the persisted record and this process's
+   * presence already prove ownership while the session drains, so no file
+   * lock needs to cover unrelated transcript and snapshot I/O. An optional post-drain operation may publish lifecycle state
    * that is valid only once those artifacts are durable; it still runs before
    * the lease record is deleted. A drain or post-drain failure abandons the
-   * lease (record retained, renewal stopped) and rethrows. A poisoned lease or
-   * failed lease deletion also retains the record and rejects this boundary.
+   * lease (record retained until this process exits) and rethrows. A poisoned
+   * lease or failed lease deletion also retains the record and rejects this
+   * boundary.
    * This is the one exit choreography every run driver calls.
    */
   async releaseExecutionLease(
@@ -896,9 +912,9 @@ export class SessionHandle {
     afterArtifactsDrained?: () => void | Promise<void>,
   ): Promise<void> {
     try {
-      await renewOwnedExecutionLease(executionId);
+      await validateOwnedExecutionLease(executionId);
       await this.flushArtifacts(executionId);
-      await renewOwnedExecutionLease(executionId);
+      await validateOwnedExecutionLease(executionId);
       if (afterArtifactsDrained && isOwnedExecutionLeaseDurable(executionId)) {
         await afterArtifactsDrained();
       }
@@ -1108,7 +1124,7 @@ export class SessionHandle {
   /** Dispose the runtime owners and drop result listeners. */
   private teardownOwners(): void {
     this.restartRepairAbort.abort();
-    this.restartRepairRetry.dispose();
+    this.disposeRestartRepairWatches();
     this.subscriptions.dispose();
     this.executions.dispose();
     // Drop bypass state before the interaction slot settles pending approvals.

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -807,7 +807,6 @@ export class SessionHandle {
       waitingStreams,
       executionIds,
       repairStreams,
-      expectedStatusGenerations: statusGenerationsAtScan,
       isRepairCandidateCurrent: (streamId, expectedExecutionId) => {
         if (
           this.status.getGeneration(streamId) !==
@@ -843,14 +842,14 @@ export class SessionHandle {
     // the presence watch when that process exits, and only then does repair
     // re-run for its streams.
     this.disposeRestartRepairWatches();
-    for (const skipped of result.activeOwners) {
+    for (const { owner } of result.activeOwners) {
       // One watch per owner instance, not per execution: an owner holding
       // many executions must trigger exactly one repair pass when it exits.
-      const watchKey = skipped.owner.socketPath;
+      const watchKey = owner.socketPath;
       if (this.restartRepairWatches.has(watchKey)) continue;
       this.restartRepairWatches.set(
         watchKey,
-        watchInstanceExit(skipped.owner, () => {
+        watchInstanceExit(owner, () => {
           this.restartRepairWatches.delete(watchKey);
           if (this.restartRepairAbort.signal.aborted) return;
           void this.enqueueRestartRepair(() =>

--- a/src/agent/runtime/restartRepair.ts
+++ b/src/agent/runtime/restartRepair.ts
@@ -51,14 +51,11 @@ export interface RestartRepairOptions {
   /** Stop before beginning another repair mutation after session teardown. */
   signal?: AbortSignal;
   /**
-   * Status generation captured before the async ownership/detection pass.
-   * Used with {@link isRepairCandidateCurrent} to drop candidates reused after
-   * discovery but before their turn in this sequential repair loop.
-   */
-  expectedStatusGenerations?: ReadonlyMap<StreamTabId, object | undefined>;
-  /**
    * Revalidate one candidate under its execution lease, immediately before
-   * settlement/mutation. Return `false` to skip the stale candidate.
+   * settlement/mutation. Return `false` to skip the stale candidate — the
+   * caller compares the status generation it captured before the async
+   * ownership/detection pass, so a stream reused after discovery but before
+   * its turn in this sequential loop is dropped.
    */
   isRepairCandidateCurrent?: (
     streamId: StreamTabId,

--- a/src/agent/runtime/restartRepair.ts
+++ b/src/agent/runtime/restartRepair.ts
@@ -3,10 +3,8 @@ import {
   type FinalizeExecutionInput,
   type FinalizeExecutionResult,
 } from '@agent/storage/executionLifecycle';
-import {
-  EXECUTION_LEASE_STALE_MS,
-  runWithInactiveExecutionLease as defaultRunWithInactiveExecutionLease,
-} from '@agent/storage/executionLease';
+import { runWithInactiveExecutionLease as defaultRunWithInactiveExecutionLease } from '@agent/storage/executionLease';
+import type { InstanceOwnerRecord } from '@agent/storage/instancePresence';
 import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
 import { deriveResumability } from '@agent/storage/resumability';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
@@ -45,7 +43,7 @@ export interface RestartRepairOptions {
     executionId: ExecutionId,
     operation: () => Promise<T>,
   ) => Promise<
-    | { readonly status: 'active'; readonly heartbeatAt: number }
+    | { readonly status: 'active'; readonly owner: InstanceOwnerRecord }
     | { readonly status: 'performed'; readonly value: T }
   >;
   logger?: RestartRepairLogger;
@@ -68,39 +66,20 @@ export interface RestartRepairOptions {
   ) => boolean;
 }
 
-export interface RestartRepairResult {
-  /** Earliest time a fresh lease skipped at startup can be checked again. */
-  nextLeaseCheckAt?: number;
+/** One stream skipped because its execution's owner is provably alive. */
+export interface ActiveOwnerSkip {
+  readonly streamId: StreamTabId;
+  readonly executionId: ExecutionId;
+  readonly owner: InstanceOwnerRecord;
 }
 
-/** Owns the single delayed retry used to revisit leases left fresh by a crash. */
-export class RestartRepairRetryScheduler {
-  private timer: ReturnType<typeof setTimeout> | undefined;
-  private disposed = false;
-
-  schedule(nextLeaseCheckAt: number | undefined, retry: () => void): void {
-    this.cancel();
-    if (this.disposed || nextLeaseCheckAt === undefined) return;
-    this.timer = setTimeout(
-      () => {
-        this.timer = undefined;
-        if (this.disposed) return;
-        retry();
-      },
-      Math.max(0, nextLeaseCheckAt - Date.now()),
-    );
-    this.timer.unref();
-  }
-
-  dispose(): void {
-    this.disposed = true;
-    this.cancel();
-  }
-
-  cancel(): void {
-    if (this.timer) clearTimeout(this.timer);
-    this.timer = undefined;
-  }
+export interface RestartRepairResult {
+  /**
+   * Streams left untouched because a live owner holds their execution. The
+   * caller watches each owner's instance exit and re-runs repair on that
+   * kernel-pushed event; nothing here is ever revisited on a clock.
+   */
+  readonly activeOwners: ActiveOwnerSkip[];
 }
 
 const RESTART_REPAIR_PHASES: ReadonlySet<StreamPhase> = new Set([
@@ -231,7 +210,7 @@ async function writeFailedOutcome(
 export async function repairRestartedStreams(
   options: RestartRepairOptions,
 ): Promise<RestartRepairResult> {
-  const result: RestartRepairResult = {};
+  const result: RestartRepairResult = { activeOwners: [] };
   const now = options.now ?? Date.now();
 
   for (const streamId of repairCandidates(
@@ -285,12 +264,13 @@ export async function repairRestartedStreams(
           )(executionId, repair)
         : { status: 'performed' as const, value: await repair() };
       if (repaired.status === 'active') {
-        const nextLeaseCheckAt =
-          repaired.heartbeatAt + EXECUTION_LEASE_STALE_MS + 1;
-        result.nextLeaseCheckAt = Math.min(
-          result.nextLeaseCheckAt ?? Number.POSITIVE_INFINITY,
-          nextLeaseCheckAt,
-        );
+        if (executionId) {
+          result.activeOwners.push({
+            streamId,
+            executionId,
+            owner: repaired.owner,
+          });
+        }
         options.logger?.debug(
           `Skipped restart repair for active execution ${executionId}`,
         );

--- a/src/agent/runtime/restartRepair.ts
+++ b/src/agent/runtime/restartRepair.ts
@@ -3,8 +3,15 @@ import {
   type FinalizeExecutionInput,
   type FinalizeExecutionResult,
 } from '@agent/storage/executionLifecycle';
-import { runWithInactiveExecutionLease as defaultRunWithInactiveExecutionLease } from '@agent/storage/executionLease';
-import type { InstanceOwnerRecord } from '@agent/storage/instancePresence';
+import {
+  runWithInactiveExecutionLease as defaultRunWithInactiveExecutionLease,
+  type InactiveExecutionLeaseOptions,
+} from '@agent/storage/executionLease';
+import {
+  probeInstance,
+  type InstanceLiveness,
+  type InstanceOwnerRecord,
+} from '@agent/storage/instancePresence';
 import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
 import { deriveResumability } from '@agent/storage/resumability';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
@@ -42,10 +49,13 @@ export interface RestartRepairOptions {
   runWithInactiveExecutionLease?: <T>(
     executionId: ExecutionId,
     operation: () => Promise<T>,
+    options?: InactiveExecutionLeaseOptions,
   ) => Promise<
     | { readonly status: 'active'; readonly owner: InstanceOwnerRecord }
     | { readonly status: 'performed'; readonly value: T }
   >;
+  /** Override liveness reads in focused tests. */
+  probeOwner?: (owner: InstanceOwnerRecord) => Promise<InstanceLiveness>;
   logger?: RestartRepairLogger;
   now?: number;
   /** Stop before beginning another repair mutation after session teardown. */
@@ -92,6 +102,10 @@ function repairCandidates(
   return [...streamStatus.entries()]
     .filter(([, phase]) => phase === STREAM_PHASE.RUNNING)
     .map(([streamId]) => streamId);
+}
+
+function livenessCacheKey(owner: InstanceOwnerRecord): string {
+  return `${owner.hostname}\0${owner.instanceId}\0${owner.socketPath}`;
 }
 
 type ExecutionSettlement =
@@ -209,6 +223,19 @@ export async function repairRestartedStreams(
 ): Promise<RestartRepairResult> {
   const result: RestartRepairResult = { activeOwners: [] };
   const now = options.now ?? Date.now();
+  const probeOwner = options.probeOwner ?? probeInstance;
+  const ownerLiveness = new Map<string, Promise<InstanceLiveness>>();
+  const inactiveLeaseOptions: InactiveExecutionLeaseOptions = {
+    probeOwner: (owner) => {
+      const key = livenessCacheKey(owner);
+      let liveness = ownerLiveness.get(key);
+      if (!liveness) {
+        liveness = probeOwner(owner);
+        ownerLiveness.set(key, liveness);
+      }
+      return liveness;
+    },
+  };
 
   for (const streamId of repairCandidates(
     options.streamStatus,
@@ -258,7 +285,7 @@ export async function repairRestartedStreams(
         ? await (
             options.runWithInactiveExecutionLease ??
             defaultRunWithInactiveExecutionLease
-          )(executionId, repair)
+          )(executionId, repair, inactiveLeaseOptions)
         : { status: 'performed' as const, value: await repair() };
       if (repaired.status === 'active') {
         if (executionId) {

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -310,16 +310,6 @@ async function withLeaseLock<T>(
   );
 }
 
-type PersistedExecutionLiveness =
-  | {
-      readonly status: 'active';
-      readonly currentLease: ExecutionLeaseRecord;
-    }
-  | {
-      readonly status: 'inactive';
-      readonly currentLease: ExecutionLeaseRecord | undefined;
-    };
-
 /** Probe a lease's owner; unprovable verdicts classify as active. */
 async function leaseOwnerIsActive(
   executionId: ExecutionId,
@@ -333,23 +323,6 @@ async function leaseOwnerIsActive(
     );
   }
   return liveness !== 'dead';
-}
-
-/**
- * Classify a persisted lease by proving its owner's liveness. Reclamation
- * requires a death proof.
- */
-async function readPersistedExecutionLiveness(
-  executionId: ExecutionId,
-  root: string,
-): Promise<PersistedExecutionLiveness> {
-  const currentLease = await readLease(executionId, root);
-  if (!currentLease) {
-    return { status: 'inactive', currentLease: undefined };
-  }
-  return (await leaseOwnerIsActive(executionId, currentLease))
-    ? { status: 'active', currentLease }
-    : { status: 'inactive', currentLease };
 }
 
 function forgetOwnedLease(
@@ -433,11 +406,11 @@ async function runWithValidatedOwnership<T>(
 }
 
 /**
- * Carry this process's exact lease generation through asynchronous run work.
- * A continuation from a displaced owner keeps its original token and cannot
- * borrow a later local owner's lease for the same execution id.
+ * Carry this process's exact lease generation through asynchronous run work,
+ * so a delayed lifecycle root cannot borrow its successor. A continuation from
+ * a displaced owner keeps its original token and cannot borrow a later local
+ * owner's lease for the same execution id.
  */
-/** Capture the current generation so a delayed lifecycle root cannot borrow its successor. */
 export function captureOwnedExecutionLease(
   executionId: ExecutionId,
 ): OwnedExecutionLeaseScope {
@@ -584,15 +557,14 @@ async function acquireExecutionLease(
     return await withLeaseLock(
       executionId,
       async () => {
-        const liveness = await readPersistedExecutionLiveness(
-          executionId,
-          root,
-        );
-        if (liveness.status === 'active') {
-          throw new ExecutionLeaseActiveError(
-            executionId,
-            liveness.currentLease.owner,
-          );
+        // Reclamation requires a death proof: a lease whose owner is alive or
+        // merely unprovable refuses acquisition.
+        const currentLease = await readLease(executionId, root);
+        if (
+          currentLease &&
+          (await leaseOwnerIsActive(executionId, currentLease))
+        ) {
+          throw new ExecutionLeaseActiveError(executionId, currentLease.owner);
         }
         if ((await canAcquire?.()) === false) return 'cancelled' as const;
         const owner = await ensureInstancePresence();

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -43,23 +43,15 @@ export const ExecutionLeaseSchema = z.strictObject({
 type ExecutionLeaseRecord = z.infer<typeof ExecutionLeaseSchema>;
 
 /**
- * A record from the retired heartbeat-era protocol is a tombstone: none of
- * its semantics survive, and locked code paths delete it on contact and
- * proceed as if it were absent, so upgrades self-heal without manual cleanup.
+ * The only surviving recognition of the retired heartbeat protocol: a
+ * `{version: 1}` file is a tombstone with no semantics.
  */
-const RetiredLeaseTombstoneSchema = z.looseObject({ version: z.literal(1) });
-
 const StoredLeaseSchema = z.union([
-  ExecutionLeaseSchema.transform((record) => ({
-    kind: 'v2' as const,
-    record,
-  })),
-  RetiredLeaseTombstoneSchema.transform(() => ({
-    kind: 'tombstone' as const,
-  })),
+  ExecutionLeaseSchema,
+  z
+    .looseObject({ version: z.literal(1) })
+    .transform(() => 'tombstone' as const),
 ]);
-
-type StoredLease = z.infer<typeof StoredLeaseSchema>;
 
 interface OwnedExecutionLease {
   readonly executionId: ExecutionId;
@@ -255,8 +247,8 @@ function coordinationPath(root: string, executionId: ExecutionId): string {
 async function readStoredLease(
   executionId: ExecutionId,
   root: string,
-): Promise<StoredLease | undefined> {
-  let stored: StoredLease;
+): Promise<ExecutionLeaseRecord | 'tombstone' | undefined> {
+  let stored: ExecutionLeaseRecord | 'tombstone';
   try {
     stored = await StorageFS.readJson(
       leasePath(root, executionId),
@@ -266,32 +258,31 @@ async function readStoredLease(
     if (isFileNotFoundError(error)) return undefined;
     throw error;
   }
-  if (stored.kind === 'v2' && stored.record.executionId !== executionId) {
+  if (stored !== 'tombstone' && stored.executionId !== executionId) {
     throw new Error(
-      `Execution lease identity mismatch: expected ${executionId}, found ${stored.record.executionId}.`,
+      `Execution lease identity mismatch: expected ${executionId}, found ${stored.executionId}.`,
     );
   }
   return stored;
 }
 
 /**
- * Read the lease record inside a locked code path, deleting a retired-era
- * tombstone on contact. Only lock holders may call this: an unlocked delete
- * could race a concurrent acquisition that just replaced the file.
+ * Locked read that deletes a retired tombstone on contact, so upgrades
+ * self-heal. Only lock holders may call this — an unlocked delete could race
+ * a concurrent acquisition that just replaced the file — so the unlocked
+ * classifier (inspectExecutionLease) reads without healing instead.
  */
-async function readLeaseHealingTombstone(
+async function readLease(
   executionId: ExecutionId,
   root: string,
 ): Promise<ExecutionLeaseRecord | undefined> {
   const stored = await readStoredLease(executionId, root);
-  if (stored?.kind === 'tombstone') {
-    log.warn(
-      `Deleted retired heartbeat-era lease record for execution ${executionId}`,
-    );
-    await StorageFS.delete(leasePath(root, executionId));
-    return undefined;
-  }
-  return stored?.record;
+  if (stored !== 'tombstone') return stored;
+  log.warn(
+    `Deleted retired heartbeat-era lease record for execution ${executionId}`,
+  );
+  await StorageFS.delete(leasePath(root, executionId));
+  return undefined;
 }
 
 async function writeLease(
@@ -352,7 +343,7 @@ async function readPersistedExecutionLiveness(
   executionId: ExecutionId,
   root: string,
 ): Promise<PersistedExecutionLiveness> {
-  const currentLease = await readLeaseHealingTombstone(executionId, root);
+  const currentLease = await readLease(executionId, root);
   if (!currentLease) {
     return { status: 'inactive', currentLease: undefined };
   }
@@ -430,10 +421,7 @@ async function runWithValidatedOwnership<T>(
   return withLeaseLock(
     lease.executionId,
     async () => {
-      const current = await readLeaseHealingTombstone(
-        lease.executionId,
-        lease.storageRoot,
-      );
+      const current = await readLease(lease.executionId, lease.storageRoot);
       if (current?.ownerToken !== lease.ownerToken) {
         forgetOwnedLease(lease, { notifyLoss: true });
         throw new ExecutionLeaseLostError(lease.executionId);
@@ -537,7 +525,7 @@ export async function runWithExecutionLeaseWriteFence<T>(
   return withLeaseLock(
     executionId,
     async () => {
-      if (await readLeaseHealingTombstone(executionId, root)) {
+      if (await readLease(executionId, root)) {
         throw new ExecutionLeaseLostError(executionId);
       }
       return operation();
@@ -579,7 +567,7 @@ async function acquireExecutionLease(
         const validated = await withLeaseLock(
           executionId,
           async () => {
-            const current = await readLeaseHealingTombstone(executionId, root);
+            const current = await readLease(executionId, root);
             if (current?.ownerToken !== existingOwnership.ownerToken) {
               forgetOwnedLease(existingOwnership, { notifyLoss: true });
               return 'lost' as const;
@@ -767,7 +755,7 @@ async function releaseOwnership(ownership: OwnedExecutionLease): Promise<void> {
     await withLeaseLock(
       executionId,
       async () => {
-        const current = await readLeaseHealingTombstone(executionId, root);
+        const current = await readLease(executionId, root);
         if (current?.ownerToken !== ownership.ownerToken) {
           return;
         }
@@ -791,10 +779,9 @@ export async function inspectExecutionLease(
   const root = storageRoot();
   // Classification runs without the lease lock, so a retired-era tombstone is
   // reported as orphaned here and deleted by the next locked path instead.
-  const stored = await readStoredLease(executionId, root);
-  if (!stored) return { status: 'missing' };
-  if (stored.kind === 'tombstone') return { status: 'orphaned' };
-  const record = stored.record;
+  const record = await readStoredLease(executionId, root);
+  if (!record) return { status: 'missing' };
+  if (record === 'tombstone') return { status: 'orphaned' };
   const local = ownedLeases.get(ownershipKey(root, executionId));
   if (local?.ownerToken === record.ownerToken) {
     return {
@@ -828,12 +815,15 @@ export async function runWithInactiveExecutionLease<T>(
   return withLeaseLock(
     executionId,
     async () => {
-      const currentLease = await readLeaseHealingTombstone(executionId, root);
+      const currentLease = await readLease(executionId, root);
       const local = ownedLeases.get(ownershipKey(root, executionId));
       if (local && currentLease?.ownerToken === local.ownerToken) {
         // The record names this live process; no probe is needed. A local
         // owner is protected by its own existence, never by any clock.
-        return { status: 'active', owner: currentLease.owner };
+        // Report our own presence identity, not the record's copy: a record
+        // whose owner field was tampered to name a dead instance must not
+        // seed an exit watch that fires while this live owner still runs.
+        return { status: 'active', owner: await ensureInstancePresence() };
       }
       if (local) {
         forgetOwnedLease(local, { notifyLoss: true });

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -16,6 +16,7 @@ import { StorageFS } from '@utils/files/storageFS';
 import {
   ensureInstancePresence,
   probeInstance,
+  type InstanceLiveness,
   InstanceOwnerSchema,
   type InstanceOwnerRecord,
 } from './instancePresence';
@@ -41,6 +42,16 @@ export const ExecutionLeaseSchema = z.strictObject({
 });
 
 type ExecutionLeaseRecord = z.infer<typeof ExecutionLeaseSchema>;
+
+export interface InactiveExecutionLeaseOptions {
+  /**
+   * Per-operation liveness reader. Restart repair shares this between
+   * executions owned by the same instance, avoiding repeated socket probes.
+   */
+  readonly probeOwner?: (
+    owner: InstanceOwnerRecord,
+  ) => Promise<InstanceLiveness>;
+}
 
 /**
  * The only surviving recognition of the retired heartbeat protocol: a
@@ -314,8 +325,9 @@ async function withLeaseLock<T>(
 async function leaseOwnerIsActive(
   executionId: ExecutionId,
   record: ExecutionLeaseRecord,
+  options: InactiveExecutionLeaseOptions = {},
 ): Promise<boolean> {
-  const liveness = await probeInstance(record.owner);
+  const liveness = await (options.probeOwner ?? probeInstance)(record.owner);
   if (liveness === 'unprovable') {
     log.warn(
       `Liveness of execution ${executionId}'s owner is unprovable; treating it as active`,
@@ -779,6 +791,7 @@ export async function inspectExecutionLease(
 export async function runWithInactiveExecutionLease<T>(
   executionId: ExecutionId,
   operation: () => Promise<T>,
+  options: InactiveExecutionLeaseOptions = {},
 ): Promise<
   | { readonly status: 'active'; readonly owner: InstanceOwnerRecord }
   | { readonly status: 'performed'; readonly value: T }
@@ -802,7 +815,7 @@ export async function runWithInactiveExecutionLease<T>(
       }
       if (
         currentLease &&
-        (await leaseOwnerIsActive(executionId, currentLease))
+        (await leaseOwnerIsActive(executionId, currentLease, options))
       ) {
         return { status: 'active', owner: currentLease.owner };
       }

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -12,30 +12,33 @@ import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import type { ExecutionId } from '@shared/schemas';
 import { StorageFS } from '@utils/files/storageFS';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+
+import {
+  ensureInstancePresence,
+  probeInstance,
+  InstanceOwnerSchema,
+  type InstanceOwnerRecord,
+} from './instancePresence';
 
 const log = createLog('ExecutionLease');
-/** A host that misses eight heartbeats is no longer considered live. */
-export const EXECUTION_LEASE_STALE_MS = 120_000;
-const EXECUTION_LEASE_HEARTBEAT_MS = 15_000;
 
 const LeaseExecutionIdSchema = z
   .string()
   .min(1)
   .regex(/^[^/\\]+$/);
 
-export const ExecutionLeaseSchema = z
-  .strictObject({
-    version: z.literal(1),
-    executionId: LeaseExecutionIdSchema,
-    ownerToken: z.uuid(),
-    acquiredAt: z.int().nonnegative(),
-    heartbeatAt: z.int().nonnegative(),
-  })
-  .refine((lease) => lease.heartbeatAt >= lease.acquiredAt, {
-    message: 'Execution lease heartbeat precedes acquisition.',
-    path: ['heartbeatAt'],
-  });
+/**
+ * Ownership record for one execution. Written once at acquisition, deleted at
+ * release — never renewed. Liveness of `owner` is proven by probing its
+ * presence socket; no field here is ever compared against a clock.
+ */
+export const ExecutionLeaseSchema = z.strictObject({
+  version: z.literal(2),
+  executionId: LeaseExecutionIdSchema,
+  ownerToken: z.uuid(),
+  acquiredAt: z.int().nonnegative(),
+  owner: InstanceOwnerSchema,
+});
 
 type ExecutionLeaseRecord = z.infer<typeof ExecutionLeaseSchema>;
 
@@ -46,17 +49,23 @@ interface OwnedExecutionLease {
   readonly released: Promise<void>;
   readonly resolveReleased: () => void;
   readonly lossListeners: Set<() => void>;
-  heartbeatInFlight: Promise<void> | undefined;
-  lastConfirmedHeartbeatAt: number;
   releasing: boolean;
   durabilityFailed: boolean;
 }
 
 export type ExecutionLeasePresence =
   | { readonly status: 'missing' }
-  | { readonly status: 'stale'; readonly heartbeatAt: number }
-  | { readonly status: 'owned'; readonly heartbeatAt: number }
-  | { readonly status: 'foreign'; readonly heartbeatAt: number };
+  | { readonly status: 'orphaned' }
+  | {
+      readonly status: 'owned';
+      readonly acquiredAt: number;
+      readonly owner: InstanceOwnerRecord;
+    }
+  | {
+      readonly status: 'foreign';
+      readonly acquiredAt: number;
+      readonly owner: InstanceOwnerRecord;
+    };
 
 export type OwnedExecutionLeaseCompletion =
   | { readonly status: 'released' }
@@ -74,7 +83,7 @@ export type OwnedExecutionLeaseScope = <T>(
 export class ExecutionLeaseActiveError extends Error {
   constructor(
     readonly executionId: ExecutionId,
-    readonly heartbeatAt: number,
+    readonly owner: InstanceOwnerRecord,
   ) {
     super(`Execution ${executionId} is active in TeXRA.`);
     this.name = 'ExecutionLeaseActiveError';
@@ -91,7 +100,6 @@ export class ExecutionLeaseLostError extends Error {
 const ownedLeases = new Map<string, OwnedExecutionLease>();
 const executionOwnership = new AsyncLocalStorage<ReadonlyMap<string, string>>();
 const maintenanceExecutions = new AsyncLocalStorage<ReadonlySet<string>>();
-let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
 
 class ExecutionLeaseCoordination {
   private acquisitionsInFlight = 0;
@@ -271,40 +279,46 @@ async function withLeaseLock<T>(
   );
 }
 
-function isFresh(record: ExecutionLeaseRecord, now: number): boolean {
-  return now - record.heartbeatAt <= EXECUTION_LEASE_STALE_MS;
-}
-
 type PersistedExecutionLiveness =
   | {
       readonly status: 'active';
-      readonly heartbeatAt: number;
       readonly currentLease: ExecutionLeaseRecord;
     }
   | {
       readonly status: 'inactive';
-      readonly staleHeartbeatAt: number | undefined;
       readonly currentLease: ExecutionLeaseRecord | undefined;
     };
 
+/** Probe a lease's owner; unprovable verdicts classify as active. */
+async function leaseOwnerIsActive(
+  executionId: ExecutionId,
+  record: ExecutionLeaseRecord,
+): Promise<boolean> {
+  const liveness = await probeInstance(record.owner);
+  if (liveness === 'unprovable') {
+    log.warn(
+      `Liveness of execution ${executionId}'s owner is unprovable; treating it as active`,
+      { data: { owner: record.owner } },
+    );
+  }
+  return liveness !== 'dead';
+}
+
+/**
+ * Classify a persisted lease by proving its owner's liveness. Reclamation
+ * requires a death proof.
+ */
 async function readPersistedExecutionLiveness(
   executionId: ExecutionId,
   root: string,
-  now: number,
 ): Promise<PersistedExecutionLiveness> {
   const currentLease = await readLease(executionId, root);
-  if (currentLease && isFresh(currentLease, now)) {
-    return {
-      status: 'active',
-      heartbeatAt: currentLease.heartbeatAt,
-      currentLease,
-    };
+  if (!currentLease) {
+    return { status: 'inactive', currentLease: undefined };
   }
-  return {
-    status: 'inactive',
-    staleHeartbeatAt: currentLease?.heartbeatAt,
-    currentLease,
-  };
+  return (await leaseOwnerIsActive(executionId, currentLease))
+    ? { status: 'active', currentLease }
+    : { status: 'inactive', currentLease };
 }
 
 function forgetOwnedLease(
@@ -328,84 +342,6 @@ function forgetOwnedLease(
     }
     lease.lossListeners.clear();
   }
-  if (ownedLeases.size === 0 && heartbeatTimer) {
-    clearInterval(heartbeatTimer);
-    heartbeatTimer = undefined;
-  }
-}
-
-async function heartbeat(
-  lease: OwnedExecutionLease,
-  canContinue?: () => boolean | Promise<boolean>,
-): Promise<'owned' | 'lost' | 'cancelled'> {
-  return withLeaseLock(
-    lease.executionId,
-    async () => {
-      const current = await readLease(lease.executionId, lease.storageRoot);
-      if (current?.ownerToken !== lease.ownerToken) {
-        forgetOwnedLease(lease, { notifyLoss: true });
-        return 'lost';
-      }
-      if ((await canContinue?.()) === false) return 'cancelled';
-      await writeLease(
-        { ...current, heartbeatAt: Date.now() },
-        lease.storageRoot,
-      );
-      lease.lastConfirmedHeartbeatAt = Date.now();
-      return 'owned';
-    },
-    lease.storageRoot,
-  );
-}
-
-function renewHeartbeat(lease: OwnedExecutionLease): Promise<void> {
-  if (lease.releasing) return Promise.resolve();
-  if (lease.heartbeatInFlight) return lease.heartbeatInFlight;
-
-  const work = heartbeat(lease)
-    .then(() => undefined)
-    .catch((error: unknown) => {
-      if (handleHeartbeatFailure(lease, error)) throw error;
-    })
-    .finally(() => {
-      if (lease.heartbeatInFlight === work) {
-        lease.heartbeatInFlight = undefined;
-      }
-    });
-  lease.heartbeatInFlight = work;
-  return work;
-}
-
-function hasErrorCode(error: unknown, code: string): boolean {
-  if (error && typeof error === 'object') {
-    if ('code' in error && error.code === code) return true;
-    if (error instanceof AggregateError) {
-      return error.errors.some((nested) => hasErrorCode(nested, code));
-    }
-  }
-  return false;
-}
-
-function handleHeartbeatFailure(
-  lease: OwnedExecutionLease,
-  error: unknown,
-): boolean {
-  const ownershipUnprovable =
-    hasErrorCode(error, 'ECOMPROMISED') ||
-    Date.now() - lease.lastConfirmedHeartbeatAt > EXECUTION_LEASE_STALE_MS;
-  if (ownershipUnprovable) {
-    forgetOwnedLease(lease, { notifyLoss: true });
-  }
-  log.warn(
-    `Failed to heartbeat execution ${lease.executionId}: ${toErrorMessage(error)}`,
-    {
-      data: {
-        error,
-        ownershipLost: ownershipUnprovable,
-      },
-    },
-  );
-  return ownershipUnprovable;
 }
 
 function rememberOwnership(
@@ -414,32 +350,19 @@ function rememberOwnership(
   root: string,
 ): void {
   const { promise: released, resolve: resolveReleased } = pDefer<void>();
-  const lease: OwnedExecutionLease = {
+  ownedLeases.set(ownershipKey(root, executionId), {
     executionId,
     ownerToken,
     storageRoot: root,
     released,
     resolveReleased,
     lossListeners: new Set(),
-    heartbeatInFlight: undefined,
-    lastConfirmedHeartbeatAt: Date.now(),
     releasing: false,
     durabilityFailed: false,
-  };
-  ownedLeases.set(ownershipKey(root, executionId), lease);
-  if (!heartbeatTimer) {
-    heartbeatTimer = setInterval(() => {
-      for (const owned of ownedLeases.values()) {
-        // heartbeat() records and classifies its own failure before rejecting;
-        // the interval consumes that rejection because it has no caller.
-        void renewHeartbeat(owned).catch(() => undefined);
-      }
-    }, EXECUTION_LEASE_HEARTBEAT_MS);
-    heartbeatTimer.unref();
-  }
+  });
 }
 
-/** Interrupt a live runtime if another process takes over this owned lease. */
+/** Interrupt a live runtime if its ownership record is found displaced. */
 export function onOwnedExecutionLeaseLost(
   executionId: ExecutionId,
   listener: () => void,
@@ -524,8 +447,11 @@ export function captureOwnedExecutionLeaseIfPresent(
     : undefined;
 }
 
-/** Refresh and validate local ownership at a short durability boundary. */
-export async function renewOwnedExecutionLease(
+/**
+ * Validate local ownership against the persisted record at a durability
+ * boundary. A pure fencing check: nothing is written and no clock is read.
+ */
+export async function validateOwnedExecutionLease(
   executionId: ExecutionId,
 ): Promise<void> {
   const key = ownershipKey(storageRoot(), executionId);
@@ -533,11 +459,10 @@ export async function renewOwnedExecutionLease(
   if (!lease || lease.releasing || !currentScopeOwnsLease(lease)) {
     throw new ExecutionLeaseLostError(executionId);
   }
-  await renewHeartbeat(lease);
-  if (
-    lease.releasing ||
-    ownedLeases.get(ownershipKey(lease.storageRoot, executionId)) !== lease
-  ) {
+  await runWithValidatedOwnership(lease, async () => undefined);
+  // A release that started while the disk check was in flight wins: this
+  // boundary must not report ownership the process is already giving up.
+  if (lease.releasing || ownedLeases.get(key) !== lease) {
     throw new ExecutionLeaseLostError(executionId);
   }
 }
@@ -603,53 +528,53 @@ async function acquireExecutionLease(
     const key = ownershipKey(root, executionId);
     const existingOwnership = ownedLeases.get(key);
     if (mode === 'resume' && existingOwnership) {
-      let heartbeatResult: 'owned' | 'lost' | 'cancelled' | undefined;
-      try {
-        heartbeatResult = await heartbeat(existingOwnership, canAcquire);
-      } catch (error) {
-        if (handleHeartbeatFailure(existingOwnership, error)) throw error;
-        if (
-          ownedLeases.get(key) === existingOwnership &&
-          !existingOwnership.releasing
-        ) {
-          const admitted = await withLeaseLock(
-            executionId,
-            async () => (await canAcquire?.()) !== false,
-            root,
-          );
-          return admitted ? 'existing' : 'cancelled';
-        }
+      if (existingOwnership.releasing) {
+        // A release in flight settles the record either way; re-acquire from
+        // persisted state below instead of resurrecting the closing lease.
+        await existingOwnership.released;
+      } else {
+        const validated = await withLeaseLock(
+          executionId,
+          async () => {
+            const current = await readLease(executionId, root);
+            if (current?.ownerToken !== existingOwnership.ownerToken) {
+              forgetOwnedLease(existingOwnership, { notifyLoss: true });
+              return 'lost' as const;
+            }
+            if ((await canAcquire?.()) === false) return 'cancelled' as const;
+            return 'existing' as const;
+          },
+          root,
+        );
+        if (validated !== 'lost') return validated;
       }
-      if (heartbeatResult === 'cancelled') return 'cancelled';
-      if (heartbeatResult === 'owned') return 'existing';
     }
 
     return await withLeaseLock(
       executionId,
       async () => {
-        const now = Date.now();
         const liveness = await readPersistedExecutionLiveness(
           executionId,
           root,
-          now,
         );
         if (liveness.status === 'active') {
           throw new ExecutionLeaseActiveError(
             executionId,
-            liveness.heartbeatAt,
+            liveness.currentLease.owner,
           );
         }
         if ((await canAcquire?.()) === false) return 'cancelled' as const;
-        const acquiredAt = Date.now();
+        const owner = await ensureInstancePresence();
+        const stale = ownedLeases.get(key);
+        if (stale) forgetOwnedLease(stale);
         const ownerToken = randomUUID();
-        if (existingOwnership) forgetOwnedLease(existingOwnership);
         await writeLease(
           {
-            version: 1,
+            version: 2,
             executionId,
             ownerToken,
-            acquiredAt,
-            heartbeatAt: acquiredAt,
+            acquiredAt: Date.now(),
+            owner,
           },
           root,
         );
@@ -694,9 +619,9 @@ function currentOwnedLeases(executionId: ExecutionId): OwnedExecutionLease[] {
 }
 
 /**
- * Stop renewing ownership without deleting its persisted lease. Used when
- * terminal artifacts are not durable: peers remain blocked until the stale
- * horizon, but a long-lived host cannot keep the failed lease fresh forever.
+ * Stop claiming ownership without deleting the persisted record. Used when
+ * terminal artifacts are not durable: peers keep refusing the execution while
+ * this process lives, and reclaim it the moment this process exits.
  */
 export function abandonOwnedExecutionLease(executionId: ExecutionId): void {
   for (const lease of currentOwnedLeases(executionId)) forgetOwnedLease(lease);
@@ -720,7 +645,7 @@ export function isOwnedExecutionLeaseDurable(
   return leases.every((lease) => !lease.durabilityFailed);
 }
 
-/** Release a durable execution; otherwise stop renewal and retain its record. */
+/** Release a durable execution; otherwise stop claiming and retain its record. */
 export async function completeOwnedExecutionLease(
   executionId: ExecutionId,
 ): Promise<OwnedExecutionLeaseCompletion> {
@@ -733,7 +658,7 @@ export async function completeOwnedExecutionLease(
     return { status: 'released' };
   } catch (error) {
     log.warn(
-      `Failed to release execution ${executionId}; its lease will expire after the stale horizon: ${toErrorMessage(error)}`,
+      `Failed to release execution ${executionId}; peers reclaim its record once this process exits`,
       { data: error },
     );
     return { status: 'retained', reason: 'release-failed', error };
@@ -759,10 +684,10 @@ export async function releaseOwnedExecutionLeaseAfterFailure(
 /**
  * Run pre-handoff launch work under one failure policy: if the operation
  * throws before the child run loop has taken over the execution, release the
- * fresh lease before the error propagates — a failed launch must not strand
- * the lease until its stale horizon and refuse a prompt relaunch. Post-handoff
- * work must stay outside this guard: once the run loop owns the lease,
- * releasing it would yank ownership from a live child.
+ * fresh lease before the error propagates — a failed launch must not leave a
+ * record that refuses a prompt relaunch for this process's whole lifetime.
+ * Post-handoff work must stay outside this guard: once the run loop owns the
+ * lease, releasing it would yank ownership from a live child.
  */
 export async function runWithOwnedExecutionLeaseLaunchGuard<T>(
   executionId: ExecutionId,
@@ -792,7 +717,6 @@ async function releaseOwnership(ownership: OwnedExecutionLease): Promise<void> {
   const root = ownership.storageRoot;
   const { executionId } = ownership;
   ownership.releasing = true;
-  await ownership.heartbeatInFlight?.catch(() => undefined);
   if (ownedLeases.get(ownershipKey(root, executionId)) !== ownership) {
     return;
   }
@@ -817,63 +741,66 @@ async function releaseOwnership(ownership: OwnedExecutionLease): Promise<void> {
   }
 }
 
-/** Classify persisted liveness. Malformed present state rejects deliberately. */
+/** Classify persisted ownership. Malformed present state rejects deliberately. */
 export async function inspectExecutionLease(
   executionId: ExecutionId,
-  now: number = Date.now(),
 ): Promise<ExecutionLeasePresence> {
   const root = storageRoot();
-  const liveness = await readPersistedExecutionLiveness(executionId, root, now);
-  if (liveness.status === 'active') {
-    const local = ownedLeases.get(ownershipKey(root, executionId));
+  const record = await readLease(executionId, root);
+  if (!record) return { status: 'missing' };
+  const local = ownedLeases.get(ownershipKey(root, executionId));
+  if (local?.ownerToken === record.ownerToken) {
     return {
-      status:
-        local?.ownerToken === liveness.currentLease.ownerToken
-          ? 'owned'
-          : 'foreign',
-      heartbeatAt: liveness.heartbeatAt,
+      status: 'owned',
+      acquiredAt: record.acquiredAt,
+      owner: record.owner,
     };
   }
-  return liveness.staleHeartbeatAt === undefined
-    ? { status: 'missing' }
-    : { status: 'stale', heartbeatAt: liveness.staleHeartbeatAt };
+  const liveness = await probeInstance(record.owner);
+  if (liveness === 'dead') return { status: 'orphaned' };
+  return {
+    status: 'foreign',
+    acquiredAt: record.acquiredAt,
+    owner: record.owner,
+  };
 }
 
 /**
- * Run maintenance only while no fresh owner exists. Inspection and mutation
- * share the same cross-process lock, so a host cannot acquire between them.
+ * Run maintenance only while the owner is provably absent. Inspection and
+ * mutation share the same cross-process lock, so a host cannot acquire
+ * between them, and an unprovable owner refuses maintenance outright.
  */
 export async function runWithInactiveExecutionLease<T>(
   executionId: ExecutionId,
   operation: () => Promise<T>,
 ): Promise<
-  | { readonly status: 'active'; readonly heartbeatAt: number }
+  | { readonly status: 'active'; readonly owner: InstanceOwnerRecord }
   | { readonly status: 'performed'; readonly value: T }
 > {
   const root = storageRoot();
   return withLeaseLock(
     executionId,
     async () => {
-      const liveness = await readPersistedExecutionLiveness(
-        executionId,
-        root,
-        Date.now(),
-      );
-      const current = liveness.currentLease;
+      const currentLease = await readLease(executionId, root);
       const local = ownedLeases.get(ownershipKey(root, executionId));
-      if (local && current?.ownerToken === local.ownerToken) {
-        return { status: 'active', heartbeatAt: current.heartbeatAt };
+      if (local && currentLease?.ownerToken === local.ownerToken) {
+        // The record names this live process; no probe is needed. A local
+        // owner is protected by its own existence, never by any clock.
+        return { status: 'active', owner: currentLease.owner };
       }
       if (local) {
         forgetOwnedLease(local, { notifyLoss: true });
       }
-      if (liveness.status === 'active') {
-        return { status: 'active', heartbeatAt: liveness.heartbeatAt };
+      if (
+        currentLease &&
+        (await leaseOwnerIsActive(executionId, currentLease))
+      ) {
+        return { status: 'active', owner: currentLease.owner };
       }
       const maintenanceKeys = new Set(maintenanceExecutions.getStore());
       maintenanceKeys.add(ownershipKey(root, executionId));
       const value = await maintenanceExecutions.run(maintenanceKeys, operation);
-      if (liveness.currentLease) {
+      if (currentLease) {
         await StorageFS.delete(leasePath(root, executionId));
       }
       return { status: 'performed', value };

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -42,6 +42,25 @@ export const ExecutionLeaseSchema = z.strictObject({
 
 type ExecutionLeaseRecord = z.infer<typeof ExecutionLeaseSchema>;
 
+/**
+ * A record from the retired heartbeat-era protocol is a tombstone: none of
+ * its semantics survive, and locked code paths delete it on contact and
+ * proceed as if it were absent, so upgrades self-heal without manual cleanup.
+ */
+const RetiredLeaseTombstoneSchema = z.looseObject({ version: z.literal(1) });
+
+const StoredLeaseSchema = z.union([
+  ExecutionLeaseSchema.transform((record) => ({
+    kind: 'v2' as const,
+    record,
+  })),
+  RetiredLeaseTombstoneSchema.transform(() => ({
+    kind: 'tombstone' as const,
+  })),
+]);
+
+type StoredLease = z.infer<typeof StoredLeaseSchema>;
+
 interface OwnedExecutionLease {
   readonly executionId: ExecutionId;
   readonly ownerToken: string;
@@ -233,25 +252,46 @@ function coordinationPath(root: string, executionId: ExecutionId): string {
   );
 }
 
-async function readLease(
+async function readStoredLease(
   executionId: ExecutionId,
   root: string,
-): Promise<ExecutionLeaseRecord | undefined> {
+): Promise<StoredLease | undefined> {
+  let stored: StoredLease;
   try {
-    const record = await StorageFS.readJson(
+    stored = await StorageFS.readJson(
       leasePath(root, executionId),
-      ExecutionLeaseSchema,
+      StoredLeaseSchema,
     );
-    if (record.executionId !== executionId) {
-      throw new Error(
-        `Execution lease identity mismatch: expected ${executionId}, found ${record.executionId}.`,
-      );
-    }
-    return record;
   } catch (error) {
     if (isFileNotFoundError(error)) return undefined;
     throw error;
   }
+  if (stored.kind === 'v2' && stored.record.executionId !== executionId) {
+    throw new Error(
+      `Execution lease identity mismatch: expected ${executionId}, found ${stored.record.executionId}.`,
+    );
+  }
+  return stored;
+}
+
+/**
+ * Read the lease record inside a locked code path, deleting a retired-era
+ * tombstone on contact. Only lock holders may call this: an unlocked delete
+ * could race a concurrent acquisition that just replaced the file.
+ */
+async function readLeaseHealingTombstone(
+  executionId: ExecutionId,
+  root: string,
+): Promise<ExecutionLeaseRecord | undefined> {
+  const stored = await readStoredLease(executionId, root);
+  if (stored?.kind === 'tombstone') {
+    log.warn(
+      `Deleted retired heartbeat-era lease record for execution ${executionId}`,
+    );
+    await StorageFS.delete(leasePath(root, executionId));
+    return undefined;
+  }
+  return stored?.record;
 }
 
 async function writeLease(
@@ -312,7 +352,7 @@ async function readPersistedExecutionLiveness(
   executionId: ExecutionId,
   root: string,
 ): Promise<PersistedExecutionLiveness> {
-  const currentLease = await readLease(executionId, root);
+  const currentLease = await readLeaseHealingTombstone(executionId, root);
   if (!currentLease) {
     return { status: 'inactive', currentLease: undefined };
   }
@@ -390,7 +430,10 @@ async function runWithValidatedOwnership<T>(
   return withLeaseLock(
     lease.executionId,
     async () => {
-      const current = await readLease(lease.executionId, lease.storageRoot);
+      const current = await readLeaseHealingTombstone(
+        lease.executionId,
+        lease.storageRoot,
+      );
       if (current?.ownerToken !== lease.ownerToken) {
         forgetOwnedLease(lease, { notifyLoss: true });
         throw new ExecutionLeaseLostError(lease.executionId);
@@ -494,7 +537,7 @@ export async function runWithExecutionLeaseWriteFence<T>(
   return withLeaseLock(
     executionId,
     async () => {
-      if (await readLease(executionId, root)) {
+      if (await readLeaseHealingTombstone(executionId, root)) {
         throw new ExecutionLeaseLostError(executionId);
       }
       return operation();
@@ -536,7 +579,7 @@ async function acquireExecutionLease(
         const validated = await withLeaseLock(
           executionId,
           async () => {
-            const current = await readLease(executionId, root);
+            const current = await readLeaseHealingTombstone(executionId, root);
             if (current?.ownerToken !== existingOwnership.ownerToken) {
               forgetOwnedLease(existingOwnership, { notifyLoss: true });
               return 'lost' as const;
@@ -724,7 +767,7 @@ async function releaseOwnership(ownership: OwnedExecutionLease): Promise<void> {
     await withLeaseLock(
       executionId,
       async () => {
-        const current = await readLease(executionId, root);
+        const current = await readLeaseHealingTombstone(executionId, root);
         if (current?.ownerToken !== ownership.ownerToken) {
           return;
         }
@@ -746,8 +789,12 @@ export async function inspectExecutionLease(
   executionId: ExecutionId,
 ): Promise<ExecutionLeasePresence> {
   const root = storageRoot();
-  const record = await readLease(executionId, root);
-  if (!record) return { status: 'missing' };
+  // Classification runs without the lease lock, so a retired-era tombstone is
+  // reported as orphaned here and deleted by the next locked path instead.
+  const stored = await readStoredLease(executionId, root);
+  if (!stored) return { status: 'missing' };
+  if (stored.kind === 'tombstone') return { status: 'orphaned' };
+  const record = stored.record;
   const local = ownedLeases.get(ownershipKey(root, executionId));
   if (local?.ownerToken === record.ownerToken) {
     return {
@@ -781,7 +828,7 @@ export async function runWithInactiveExecutionLease<T>(
   return withLeaseLock(
     executionId,
     async () => {
-      const currentLease = await readLease(executionId, root);
+      const currentLease = await readLeaseHealingTombstone(executionId, root);
       const local = ownedLeases.get(ownershipKey(root, executionId));
       if (local && currentLease?.ownerToken === local.ownerToken) {
         // The record names this live process; no probe is needed. A local

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -294,7 +294,6 @@ export type DeleteExecutionResult =
   | {
       readonly status: 'active';
       readonly executionId: ExecutionId;
-      readonly heartbeatAt: number;
     };
 
 export interface DeleteAllExecutionsResult {
@@ -336,7 +335,7 @@ export async function deleteExecution(
     },
   );
   if (guarded.status === 'active') {
-    return { status: 'active', executionId, heartbeatAt: guarded.heartbeatAt };
+    return { status: 'active', executionId };
   }
   return guarded.value;
 }

--- a/src/agent/storage/instancePresence.ts
+++ b/src/agent/storage/instancePresence.ts
@@ -1,0 +1,306 @@
+import { randomBytes } from 'node:crypto';
+import { mkdir } from 'node:fs/promises';
+import { unlinkSync } from 'node:fs';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { z } from 'zod';
+
+import { createLog } from '@logger/logUtils';
+import { platform } from '@platform/platform';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+const log = createLog('InstancePresence');
+
+const BANNER_PREFIX = 'texra-presence:';
+const PROBE_TIMEOUT_MS = 1_500;
+const MAX_BANNER_BYTES = 256;
+/** macOS caps `sun_path` at 104 bytes; keep margin below it. */
+const MAX_SOCKET_PATH_BYTES = 96;
+
+/**
+ * Identity of the process that owns an execution lease. Liveness verdicts come
+ * exclusively from probing `socketPath`; `pid` is a diagnostic breadcrumb for
+ * humans reading a record, never a liveness input, and `hostname` only guards
+ * against cross-machine probes of a shared home directory.
+ */
+export const InstanceOwnerSchema = z.strictObject({
+  instanceId: z.string().min(1),
+  socketPath: z.string().min(1),
+  pid: z.int().nonnegative(),
+  hostname: z.string().min(1),
+});
+
+export type InstanceOwnerRecord = z.infer<typeof InstanceOwnerSchema>;
+
+/**
+ * A liveness verdict is a proof or an admission that no proof exists:
+ * - `alive`: the owner's socket accepted and answered with its own banner.
+ * - `dead`: the kernel states no such listener exists (`ECONNREFUSED` /
+ *   `ENOENT`), or a *newer TeXRA instance* answered on a reused path.
+ * - `unprovable`: anything else (timeout, permission error, foreign hostname,
+ *   non-TeXRA banner). Callers must treat this as alive: we never reclaim on
+ *   ambiguity.
+ */
+export type InstanceLiveness = 'alive' | 'dead' | 'unprovable';
+
+interface PresenceServer {
+  readonly record: InstanceOwnerRecord;
+  readonly server: net.Server;
+}
+
+let presenceServer: Promise<PresenceServer> | undefined;
+let cleanupRegistered = false;
+
+function isWindows(): boolean {
+  return process.platform === 'win32';
+}
+
+function newInstanceId(): string {
+  return randomBytes(8).toString('hex');
+}
+
+function socketPathFor(instanceId: string): string {
+  if (isWindows()) return `\\\\.\\pipe\\texra-${instanceId}`;
+  const preferred = path.join(
+    platform().storage.getGlobalStoragePath(),
+    'instances',
+    `${instanceId}.sock`,
+  );
+  if (Buffer.byteLength(preferred) <= MAX_SOCKET_PATH_BYTES) return preferred;
+  // In the tmpdir fallback a cleaned-up socket file makes a live owner read as
+  // dead; the ownerToken write fence bounds that residual risk. Loud so a user
+  // hitting it can shorten their storage root.
+  const fallback = path.join(os.tmpdir(), `texra-${instanceId}.sock`);
+  log.warn(
+    `Instance presence socket path exceeds the platform limit; falling back to ${fallback}`,
+    { data: { preferred } },
+  );
+  return fallback;
+}
+
+async function startPresenceServer(): Promise<PresenceServer> {
+  const instanceId = newInstanceId();
+  const socketPath = socketPathFor(instanceId);
+  if (!isWindows()) {
+    await mkdir(path.dirname(socketPath), { recursive: true, mode: 0o700 });
+  }
+  const server = net.createServer((socket) => {
+    // Answer with our identity, then hold the connection open: the kernel
+    // closes it when this process dies, which is the exit signal watchers
+    // subscribe to. Watchers disconnecting is routine.
+    socket.on('error', () => undefined);
+    socket.write(`${BANNER_PREFIX}${instanceId}\n`);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, resolve);
+  });
+  // Presence must never keep the process alive on its own.
+  server.unref();
+  if (!cleanupRegistered && !isWindows()) {
+    cleanupRegistered = true;
+    process.once('exit', () => {
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // Crash-path cleanup is best effort; a leftover file yields
+        // ECONNREFUSED, which is itself a death proof.
+      }
+    });
+  }
+  return {
+    record: {
+      instanceId,
+      socketPath,
+      pid: process.pid,
+      hostname: os.hostname(),
+    },
+    server,
+  };
+}
+
+/**
+ * The identity this process stamps into execution leases it acquires. Binds
+ * the presence socket on first use and keeps it for the process lifetime.
+ */
+export function ensureInstancePresence(): Promise<InstanceOwnerRecord> {
+  presenceServer ??= startPresenceServer().catch((error: unknown) => {
+    presenceServer = undefined;
+    throw error;
+  });
+  return presenceServer.then((running) => running.record);
+}
+
+function isNoListenerError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    (error.code === 'ECONNREFUSED' || error.code === 'ENOENT')
+  );
+}
+
+interface BannerConnection {
+  readonly socket: net.Socket;
+  /** Resolves once, with the probe verdict for `owner`. */
+  readonly verdict: Promise<InstanceLiveness>;
+}
+
+function connectForBanner(owner: InstanceOwnerRecord): BannerConnection {
+  const socket = net.connect(owner.socketPath);
+  const verdict = new Promise<InstanceLiveness>((resolve) => {
+    let settled = false;
+    const finish = (liveness: InstanceLiveness): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(liveness);
+    };
+    const timer = setTimeout(() => finish('unprovable'), PROBE_TIMEOUT_MS);
+    timer.unref();
+    let buffered = '';
+    socket.on('data', (chunk: Buffer) => {
+      buffered += chunk.toString('utf8');
+      const newline = buffered.indexOf('\n');
+      if (newline === -1) {
+        if (Buffer.byteLength(buffered) > MAX_BANNER_BYTES) {
+          finish('unprovable');
+        }
+        return;
+      }
+      const banner = buffered.slice(0, newline);
+      if (banner === `${BANNER_PREFIX}${owner.instanceId}`) {
+        finish('alive');
+      } else if (banner.startsWith(BANNER_PREFIX)) {
+        // A different TeXRA instance answering on this path proves the
+        // recorded owner is gone: the path was released and reused.
+        finish('dead');
+      } else {
+        finish('unprovable');
+      }
+    });
+    socket.on('error', (error: unknown) => {
+      finish(isNoListenerError(error) ? 'dead' : 'unprovable');
+    });
+    socket.on('close', () => finish('unprovable'));
+  });
+  return { socket, verdict };
+}
+
+/**
+ * Prove whether the process identified by `owner` is alive. `unprovable`
+ * means exactly that; callers treat it as alive and must not reclaim.
+ */
+export async function probeInstance(
+  owner: InstanceOwnerRecord,
+): Promise<InstanceLiveness> {
+  if (!isWindows() && owner.hostname !== os.hostname()) {
+    log.warn(
+      `Execution lease owner lives on host ${owner.hostname}; liveness is unprovable from ${os.hostname()}`,
+    );
+    return 'unprovable';
+  }
+  const connection = connectForBanner(owner);
+  const verdict = await connection.verdict;
+  connection.socket.destroy();
+  return verdict;
+}
+
+interface InstanceExitWatch {
+  readonly listeners: Set<() => void>;
+  socket: net.Socket | undefined;
+}
+
+const exitWatches = new Map<string, InstanceExitWatch>();
+
+function fireExitWatch(socketPath: string): void {
+  const watch = exitWatches.get(socketPath);
+  if (!watch) return;
+  exitWatches.delete(socketPath);
+  watch.socket?.destroy();
+  for (const listener of watch.listeners) {
+    try {
+      listener();
+    } catch (error) {
+      log.warn(
+        `Instance-exit listener failed for ${socketPath}: ${toErrorMessage(error)}`,
+      );
+    }
+  }
+}
+
+async function runExitWatch(
+  owner: InstanceOwnerRecord,
+  watch: InstanceExitWatch,
+): Promise<void> {
+  let unprovableStreak = 0;
+  while (unprovableStreak < 2) {
+    const connection = connectForBanner(owner);
+    watch.socket = connection.socket;
+    // Watch connections are held open; they must not keep the process alive.
+    connection.socket.unref();
+    const liveness = await connection.verdict;
+    if (exitWatches.get(owner.socketPath) !== watch) {
+      connection.socket.destroy();
+      return;
+    }
+    if (liveness === 'dead') {
+      fireExitWatch(owner.socketPath);
+      return;
+    }
+    if (liveness === 'alive') {
+      unprovableStreak = 0;
+      await new Promise<void>((resolve) =>
+        connection.socket.once('close', () => resolve()),
+      );
+      if (exitWatches.get(owner.socketPath) !== watch) return;
+      // The held connection closed: usually the owner's death, occasionally a
+      // disturbed connection. Reconnect for the actual verdict either way.
+      continue;
+    }
+    unprovableStreak += 1;
+    connection.socket.destroy();
+  }
+  exitWatches.delete(owner.socketPath);
+  log.warn(
+    `Liveness of execution lease owner ${owner.instanceId} is repeatedly unprovable; its executions stay untouched until a later repair trigger`,
+    { data: { socketPath: owner.socketPath } },
+  );
+}
+
+/**
+ * Invoke `listener` when the owner process exits. The kernel closes the held
+ * connection on process death, so exit is pushed, never polled; every
+ * inconclusive outcome reconnects for a fresh verdict. An owner that is
+ * already dead fires immediately; a repeatedly unprovable owner is logged and
+ * never fires (we neither poll on a clock nor reclaim on ambiguity — the next
+ * natural repair trigger re-encounters it). The returned disposer detaches
+ * the listener.
+ */
+export function watchInstanceExit(
+  owner: InstanceOwnerRecord,
+  listener: () => void,
+): () => void {
+  const existing = exitWatches.get(owner.socketPath);
+  if (existing) {
+    existing.listeners.add(listener);
+    return () => existing.listeners.delete(listener);
+  }
+  const watch: InstanceExitWatch = {
+    listeners: new Set([listener]),
+    socket: undefined,
+  };
+  exitWatches.set(owner.socketPath, watch);
+  void runExitWatch(owner, watch);
+  return () => {
+    watch.listeners.delete(listener);
+    if (
+      watch.listeners.size === 0 &&
+      exitWatches.get(owner.socketPath) === watch
+    ) {
+      exitWatches.delete(owner.socketPath);
+      watch.socket?.destroy();
+    }
+  };
+}

--- a/src/agent/storage/instancePresence.ts
+++ b/src/agent/storage/instancePresence.ts
@@ -11,6 +11,12 @@ import { createLog } from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
+// This module deliberately bypasses the Platform ports: presence is made of
+// kernel facts — real sockets, a 0o700 socket directory, a synchronous unlink
+// on process exit — that no host abstraction can virtualize without breaking
+// the proofs. A port here would be a single-caller wrapper over Node-only
+// primitives, which the factory guardrails forbid.
+
 const log = createLog('InstancePresence');
 
 const BANNER_PREFIX = 'texra-presence:';
@@ -20,10 +26,11 @@ const MAX_BANNER_BYTES = 256;
 const MAX_SOCKET_PATH_BYTES = 96;
 
 /**
- * Identity of the process that owns an execution lease. Liveness verdicts come
- * exclusively from probing `socketPath`; `pid` is a diagnostic breadcrumb for
- * humans reading a record, never a liveness input, and `hostname` only guards
- * against cross-machine probes of a shared home directory.
+ * Identity of the process that owns an execution lease. Liveness verdicts
+ * come from probing `socketPath`. `pid` is a diagnostic breadcrumb plus a
+ * death-proof-only tiebreak (ESRCH) where the socket file itself may have
+ * been unlinked from under a live owner — never an aliveness input. The
+ * `hostname` guards against cross-machine probes of a shared home directory.
  */
 export const InstanceOwnerSchema = z.strictObject({
   instanceId: z.string().min(1),
@@ -69,9 +76,9 @@ function socketPathFor(instanceId: string): string {
     `${instanceId}.sock`,
   );
   if (Buffer.byteLength(preferred) <= MAX_SOCKET_PATH_BYTES) return preferred;
-  // In the tmpdir fallback a cleaned-up socket file makes a live owner read as
-  // dead; the ownerToken write fence bounds that residual risk. Loud so a user
-  // hitting it can shorten their storage root.
+  // A tmp cleaner may unlink a live owner's socket file here; probes treat a
+  // missing file as death only with a pid proof (isDeathProofError). Loud so
+  // a user hitting it can shorten their storage root.
   const fallback = path.join(os.tmpdir(), `texra-${instanceId}.sock`);
   log.warn(
     `Instance presence socket path exceeds the platform limit; falling back to ${fallback}`,
@@ -133,12 +140,36 @@ export function ensureInstancePresence(): Promise<InstanceOwnerRecord> {
   return presenceServer.then((running) => running.record);
 }
 
-function isNoListenerError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    'code' in error &&
-    (error.code === 'ECONNREFUSED' || error.code === 'ENOENT')
-  );
+/** Hostnames are case-insensitive on every platform TeXRA supports. */
+function isSameHost(owner: InstanceOwnerRecord): boolean {
+  return owner.hostname.toLowerCase() === os.hostname().toLowerCase();
+}
+
+/**
+ * `kill(pid, 0)` throwing ESRCH is a kernel proof that no such process
+ * exists. Success proves nothing (the pid may be recycled), so this is a
+ * death-proof-only oracle.
+ */
+function pidProvablyDead(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return false;
+  } catch (error) {
+    return error instanceof Error && 'code' in error && error.code === 'ESRCH';
+  }
+}
+
+function isDeathProofError(
+  error: unknown,
+  owner: InstanceOwnerRecord,
+): boolean {
+  if (!(error instanceof Error) || !('code' in error)) return false;
+  if (error.code === 'ECONNREFUSED') return true;
+  // A crashed owner leaves its socket file behind (ECONNREFUSED above), so a
+  // missing file means it was unlinked — by graceful exit, or from under a
+  // live owner (e.g. a tmp cleaner in the fallback directory). Death then
+  // additionally requires the recorded pid to be provably gone.
+  return error.code === 'ENOENT' && pidProvablyDead(owner.pid);
 }
 
 interface BannerConnection {
@@ -181,7 +212,7 @@ function connectForBanner(owner: InstanceOwnerRecord): BannerConnection {
       }
     });
     socket.on('error', (error: unknown) => {
-      finish(isNoListenerError(error) ? 'dead' : 'unprovable');
+      finish(isDeathProofError(error, owner) ? 'dead' : 'unprovable');
     });
     socket.on('close', () => finish('unprovable'));
   });
@@ -195,7 +226,7 @@ function connectForBanner(owner: InstanceOwnerRecord): BannerConnection {
 export async function probeInstance(
   owner: InstanceOwnerRecord,
 ): Promise<InstanceLiveness> {
-  if (!isWindows() && owner.hostname !== os.hostname()) {
+  if (!isSameHost(owner)) {
     log.warn(
       `Execution lease owner lives on host ${owner.hostname}; liveness is unprovable from ${os.hostname()}`,
     );
@@ -282,6 +313,14 @@ export function watchInstanceExit(
   owner: InstanceOwnerRecord,
   listener: () => void,
 ): () => void {
+  // Mirror probeInstance's cross-host guard: a local connect failure says
+  // nothing about an owner on another machine, so the watch must never fire.
+  if (!isSameHost(owner)) {
+    log.warn(
+      `Execution lease owner lives on host ${owner.hostname}; its exit cannot be watched from ${os.hostname()}`,
+    );
+    return () => undefined;
+  }
   const existing = exitWatches.get(owner.socketPath);
   if (existing) {
     existing.listeners.add(listener);

--- a/src/agent/storage/instancePresence.ts
+++ b/src/agent/storage/instancePresence.ts
@@ -42,30 +42,16 @@ export const InstanceOwnerSchema = z.strictObject({
 export type InstanceOwnerRecord = z.infer<typeof InstanceOwnerSchema>;
 
 /**
- * A liveness verdict is a proof or an admission that no proof exists:
- * - `alive`: the owner's socket accepted and answered with its own banner.
- * - `dead`: the kernel states no such listener exists (`ECONNREFUSED` /
- *   `ENOENT`), or a *newer TeXRA instance* answered on a reused path.
- * - `unprovable`: anything else (timeout, permission error, foreign hostname,
- *   non-TeXRA banner). Callers must treat this as alive: we never reclaim on
- *   ambiguity.
+ * A liveness verdict is a proof or an admission that no proof exists. Callers
+ * must treat `unprovable` as alive: we never reclaim on ambiguity. Which
+ * observation yields which verdict is stated once, in {@link classifyPresence}.
  */
 export type InstanceLiveness = 'alive' | 'dead' | 'unprovable';
 
-interface PresenceServer {
-  readonly record: InstanceOwnerRecord;
-  readonly server: net.Server;
-}
-
-let presenceServer: Promise<PresenceServer> | undefined;
-let cleanupRegistered = false;
+let presenceRecord: Promise<InstanceOwnerRecord> | undefined;
 
 function isWindows(): boolean {
   return process.platform === 'win32';
-}
-
-function newInstanceId(): string {
-  return randomBytes(8).toString('hex');
 }
 
 function socketPathFor(instanceId: string): string {
@@ -77,7 +63,7 @@ function socketPathFor(instanceId: string): string {
   );
   if (Buffer.byteLength(preferred) <= MAX_SOCKET_PATH_BYTES) return preferred;
   // A tmp cleaner may unlink a live owner's socket file here; probes treat a
-  // missing file as death only with a pid proof (isDeathProofError). Loud so
+  // missing file as death only with a pid proof (classifyPresence). Loud so
   // a user hitting it can shorten their storage root.
   const fallback = path.join(os.tmpdir(), `texra-${instanceId}.sock`);
   log.warn(
@@ -87,8 +73,8 @@ function socketPathFor(instanceId: string): string {
   return fallback;
 }
 
-async function startPresenceServer(): Promise<PresenceServer> {
-  const instanceId = newInstanceId();
+async function startPresenceServer(): Promise<InstanceOwnerRecord> {
+  const instanceId = randomBytes(8).toString('hex');
   const socketPath = socketPathFor(instanceId);
   if (!isWindows()) {
     await mkdir(path.dirname(socketPath), { recursive: true, mode: 0o700 });
@@ -104,10 +90,11 @@ async function startPresenceServer(): Promise<PresenceServer> {
     server.once('error', reject);
     server.listen(socketPath, resolve);
   });
-  // Presence must never keep the process alive on its own.
+  // Presence must never keep the process alive on its own. The listening
+  // server stays rooted by the event loop's handle list, so nothing here needs
+  // to hold a reference to it.
   server.unref();
-  if (!cleanupRegistered && !isWindows()) {
-    cleanupRegistered = true;
+  if (!isWindows()) {
     process.once('exit', () => {
       try {
         unlinkSync(socketPath);
@@ -118,13 +105,10 @@ async function startPresenceServer(): Promise<PresenceServer> {
     });
   }
   return {
-    record: {
-      instanceId,
-      socketPath,
-      pid: process.pid,
-      hostname: os.hostname(),
-    },
-    server,
+    instanceId,
+    socketPath,
+    pid: process.pid,
+    hostname: os.hostname(),
   };
 }
 
@@ -133,16 +117,29 @@ async function startPresenceServer(): Promise<PresenceServer> {
  * the presence socket on first use and keeps it for the process lifetime.
  */
 export function ensureInstancePresence(): Promise<InstanceOwnerRecord> {
-  presenceServer ??= startPresenceServer().catch((error: unknown) => {
-    presenceServer = undefined;
+  presenceRecord ??= startPresenceServer().catch((error: unknown) => {
+    presenceRecord = undefined;
     throw error;
   });
-  return presenceServer.then((running) => running.record);
+  return presenceRecord;
 }
 
-/** Hostnames are case-insensitive on every platform TeXRA supports. */
-function isSameHost(owner: InstanceOwnerRecord): boolean {
-  return owner.hostname.toLowerCase() === os.hostname().toLowerCase();
+/**
+ * Hostnames are case-insensitive on every platform TeXRA supports. A cross-host
+ * owner is unprovable by construction — a local connect failure says nothing
+ * about a process on another machine — so both the probe and the exit watch
+ * refuse it here, loudly, before any socket is opened. `consequence` completes
+ * the warning: "…host <owner>; <consequence> from <this host>".
+ */
+function ownerIsOnThisHost(
+  owner: InstanceOwnerRecord,
+  consequence: string,
+): boolean {
+  if (owner.hostname.toLowerCase() === os.hostname().toLowerCase()) return true;
+  log.warn(
+    `Execution lease owner lives on host ${owner.hostname}; ${consequence} from ${os.hostname()}`,
+  );
+  return false;
 }
 
 /**
@@ -159,36 +156,86 @@ function pidProvablyDead(pid: number): boolean {
   }
 }
 
-function isDeathProofError(
-  error: unknown,
+/**
+ * Everything one presence connection can observe. The socket mechanics only
+ * *produce* these; {@link classifyPresence} alone decides what they mean.
+ */
+type PresenceOutcome =
+  | { readonly kind: 'banner'; readonly banner: string }
+  | { readonly kind: 'error'; readonly error: unknown }
+  | { readonly kind: 'timeout' }
+  | { readonly kind: 'closed' }
+  | { readonly kind: 'oversized' };
+
+/**
+ * The single source of liveness truth — every verdict in this module comes
+ * from this table, and nothing outside it decides alive/dead:
+ *
+ * | observed                            | verdict    | proof                            |
+ * | ----------------------------------- | ---------- | -------------------------------- |
+ * | our owner's own banner              | alive      | the owner answered on its socket |
+ * | another TeXRA banner                | dead       | the path was released and reused |
+ * | `ECONNREFUSED`                      | dead       | the kernel knows no listener     |
+ * | `ENOENT` + `kill(pid, 0)` => ESRCH  | dead       | socket gone *and* process gone   |
+ * | timeout / close / oversized / other | unprovable | no proof either way              |
+ *
+ * A cross-host owner never reaches here: {@link ownerIsOnThisHost} refuses it
+ * as unprovable before a socket is opened. `unprovable` is never reclaimed —
+ * callers must treat it as alive. The switch is exhaustive on purpose: a new
+ * outcome must be classified explicitly rather than defaulting.
+ */
+function classifyPresence(
+  outcome: PresenceOutcome,
   owner: InstanceOwnerRecord,
-): boolean {
-  if (!(error instanceof Error) || !('code' in error)) return false;
-  if (error.code === 'ECONNREFUSED') return true;
-  // A crashed owner leaves its socket file behind (ECONNREFUSED above), so a
-  // missing file means it was unlinked — by graceful exit, or from under a
-  // live owner (e.g. a tmp cleaner in the fallback directory). Death then
-  // additionally requires the recorded pid to be provably gone.
-  return error.code === 'ENOENT' && pidProvablyDead(owner.pid);
+): InstanceLiveness {
+  switch (outcome.kind) {
+    case 'banner':
+      if (outcome.banner === `${BANNER_PREFIX}${owner.instanceId}`) {
+        return 'alive';
+      }
+      // A different TeXRA instance answering on this path proves the recorded
+      // owner is gone: the path was released and reused.
+      return outcome.banner.startsWith(BANNER_PREFIX) ? 'dead' : 'unprovable';
+    case 'error': {
+      const { error } = outcome;
+      if (!(error instanceof Error) || !('code' in error)) return 'unprovable';
+      if (error.code === 'ECONNREFUSED') return 'dead';
+      // A crashed owner leaves its socket file behind (ECONNREFUSED above), so
+      // a missing file means it was unlinked — by graceful exit, or from under
+      // a live owner (e.g. a tmp cleaner in the fallback directory). Death then
+      // additionally requires the recorded pid to be provably gone.
+      return error.code === 'ENOENT' && pidProvablyDead(owner.pid)
+        ? 'dead'
+        : 'unprovable';
+    }
+    case 'timeout':
+    case 'closed':
+    case 'oversized':
+      return 'unprovable';
+  }
 }
 
-interface BannerConnection {
+interface PresenceConnection {
   readonly socket: net.Socket;
-  /** Resolves once, with the probe verdict for `owner`. */
-  readonly verdict: Promise<InstanceLiveness>;
+  /** Resolves once, with the first thing this connection observed. */
+  readonly outcome: Promise<PresenceOutcome>;
 }
 
-function connectForBanner(owner: InstanceOwnerRecord): BannerConnection {
+/** Transport only: connect and report what happened. No verdict lives here. */
+function connectForBanner(owner: InstanceOwnerRecord): PresenceConnection {
   const socket = net.connect(owner.socketPath);
-  const verdict = new Promise<InstanceLiveness>((resolve) => {
+  const outcome = new Promise<PresenceOutcome>((resolve) => {
     let settled = false;
-    const finish = (liveness: InstanceLiveness): void => {
+    const finish = (observed: PresenceOutcome): void => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      resolve(liveness);
+      resolve(observed);
     };
-    const timer = setTimeout(() => finish('unprovable'), PROBE_TIMEOUT_MS);
+    const timer = setTimeout(
+      () => finish({ kind: 'timeout' }),
+      PROBE_TIMEOUT_MS,
+    );
     timer.unref();
     let buffered = '';
     socket.on('data', (chunk: Buffer) => {
@@ -196,27 +243,16 @@ function connectForBanner(owner: InstanceOwnerRecord): BannerConnection {
       const newline = buffered.indexOf('\n');
       if (newline === -1) {
         if (Buffer.byteLength(buffered) > MAX_BANNER_BYTES) {
-          finish('unprovable');
+          finish({ kind: 'oversized' });
         }
         return;
       }
-      const banner = buffered.slice(0, newline);
-      if (banner === `${BANNER_PREFIX}${owner.instanceId}`) {
-        finish('alive');
-      } else if (banner.startsWith(BANNER_PREFIX)) {
-        // A different TeXRA instance answering on this path proves the
-        // recorded owner is gone: the path was released and reused.
-        finish('dead');
-      } else {
-        finish('unprovable');
-      }
+      finish({ kind: 'banner', banner: buffered.slice(0, newline) });
     });
-    socket.on('error', (error: unknown) => {
-      finish(isDeathProofError(error, owner) ? 'dead' : 'unprovable');
-    });
-    socket.on('close', () => finish('unprovable'));
+    socket.on('error', (error: unknown) => finish({ kind: 'error', error }));
+    socket.on('close', () => finish({ kind: 'closed' }));
   });
-  return { socket, verdict };
+  return { socket, outcome };
 }
 
 /**
@@ -226,14 +262,9 @@ function connectForBanner(owner: InstanceOwnerRecord): BannerConnection {
 export async function probeInstance(
   owner: InstanceOwnerRecord,
 ): Promise<InstanceLiveness> {
-  if (!isSameHost(owner)) {
-    log.warn(
-      `Execution lease owner lives on host ${owner.hostname}; liveness is unprovable from ${os.hostname()}`,
-    );
-    return 'unprovable';
-  }
+  if (!ownerIsOnThisHost(owner, 'liveness is unprovable')) return 'unprovable';
   const connection = connectForBanner(owner);
-  const verdict = await connection.verdict;
+  const verdict = classifyPresence(await connection.outcome, owner);
   connection.socket.destroy();
   return verdict;
 }
@@ -245,9 +276,8 @@ interface InstanceExitWatch {
 
 const exitWatches = new Map<string, InstanceExitWatch>();
 
-function fireExitWatch(socketPath: string): void {
-  const watch = exitWatches.get(socketPath);
-  if (!watch) return;
+/** Callers must have just confirmed `watch` is the registered one for the path. */
+function fireExitWatch(socketPath: string, watch: InstanceExitWatch): void {
   exitWatches.delete(socketPath);
   watch.socket?.destroy();
   for (const listener of watch.listeners) {
@@ -271,13 +301,13 @@ async function runExitWatch(
     watch.socket = connection.socket;
     // Watch connections are held open; they must not keep the process alive.
     connection.socket.unref();
-    const liveness = await connection.verdict;
+    const liveness = classifyPresence(await connection.outcome, owner);
     if (exitWatches.get(owner.socketPath) !== watch) {
       connection.socket.destroy();
       return;
     }
     if (liveness === 'dead') {
-      fireExitWatch(owner.socketPath);
+      fireExitWatch(owner.socketPath, watch);
       return;
     }
     if (liveness === 'alive') {
@@ -313,12 +343,7 @@ export function watchInstanceExit(
   owner: InstanceOwnerRecord,
   listener: () => void,
 ): () => void {
-  // Mirror probeInstance's cross-host guard: a local connect failure says
-  // nothing about an owner on another machine, so the watch must never fire.
-  if (!isSameHost(owner)) {
-    log.warn(
-      `Execution lease owner lives on host ${owner.hostname}; its exit cannot be watched from ${os.hostname()}`,
-    );
+  if (!ownerIsOnThisHost(owner, 'its exit cannot be watched')) {
     return () => undefined;
   }
   const existing = exitWatches.get(owner.socketPath);

--- a/src/test-kernel/agent/DeleteExecution.vitest.ts
+++ b/src/test-kernel/agent/DeleteExecution.vitest.ts
@@ -22,9 +22,6 @@ vi.mock('@agent/storage/ExecutionKVStore', () => ({
 }));
 
 vi.mock('@agent/storage/executionLease', () => ({
-  // `executionListing`'s entrance stamper reads this constant at module load;
-  // keep it defined when the lease module is mocked.
-  EXECUTION_LEASE_STALE_MS: 120_000,
   runWithInactiveExecutionLease: vi.fn(
     async (_executionId: ExecutionId, operation: () => Promise<unknown>) => ({
       status: 'performed',

--- a/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
@@ -36,9 +36,6 @@ vi.mock('@agent/storage/executionLifecycle', () => ({
   hasPersistedParent: mocks.hasPersistedParent,
 }));
 vi.mock('@agent/storage/executionLease', () => ({
-  // `executionListing`'s entrance stamper reads this constant at module
-  // load; keep it defined when the lease module is mocked.
-  EXECUTION_LEASE_STALE_MS: 120_000,
   abandonOwnedExecutionLease: vi.fn(),
   acquireResumedExecutionLease: mocks.acquireResumedExecutionLease,
   captureOwnedExecutionLease:

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -6,8 +6,10 @@ import type { FinalizeExecutionResult } from '@agent/storage';
 import { noopTrace, TraceEmitter, type StatusEvent } from '@agent/trace';
 import {
   acquireResumedExecutionLease,
+  ExecutionLeaseLostError,
   inspectExecutionLease,
   releaseOwnedExecutionLease,
+  validateOwnedExecutionLease,
 } from '@agent/storage/executionLease';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
@@ -238,7 +240,6 @@ function seedOpenRunGroup(
 
 describe('runFlowWithLifecycle', () => {
   it('interrupts and suppresses terminal persistence after lease takeover', async () => {
-    vi.useFakeTimers();
     const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
       'lifecycle-lease-takeover',
     );
@@ -247,7 +248,11 @@ describe('runFlowWithLifecycle', () => {
     try {
       const result = await runFlowWithLifecycle(ctx, async (handle) => {
         await writeForeignLease(executionId);
-        await vi.advanceTimersByTimeAsync(15_000);
+        // Displacement is discovered at the next fencing boundary, not on a
+        // clock: the failed validation notifies loss and interrupts the run.
+        await expect(
+          validateOwnedExecutionLease(executionId),
+        ).rejects.toBeInstanceOf(ExecutionLeaseLostError);
 
         expect(handle.executionLeaseLost).toBe(true);
         expect(ctx.runScope.signal.aborted).toBe(true);
@@ -260,7 +265,6 @@ describe('runFlowWithLifecycle', () => {
       await releaseOwnedExecutionLease(executionId);
       await StorageFS.delete(executionLeasePath(executionId)).catch(() => {});
       clearStreamStatusForTest(streamStatus, streamId);
-      vi.useRealTimers();
     }
   });
 

--- a/src/test-kernel/agent/runtime/RestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/RestartRepair.vitest.ts
@@ -139,6 +139,40 @@ describe('repairRestartedStreams', () => {
     expect(finalizeExecution).not.toHaveBeenCalled();
   });
 
+  it('probes one shared active owner once per repair pass', async () => {
+    const first = setupRunningStream('shared-owner-first');
+    const second = setupRunningStream('shared-owner-second');
+    const owner = {
+      instanceId: 'shared-instance',
+      socketPath: '/tmp/texra-shared.sock',
+      pid: 1,
+      hostname: 'test-host',
+    };
+    const probeOwner = vi.fn(async () => 'alive' as const);
+    const runWithInactiveExecutionLease = vi.fn(
+      async (_executionId, _operation, leaseOptions) => {
+        expect(await leaseOptions?.probeOwner?.(owner)).toBe('alive');
+        return { status: 'active' as const, owner };
+      },
+    );
+
+    const result = await repairRestartedStreams({
+      streamStatus: first.streamStatus,
+      waitingStreams: new Set(),
+      executionIds: new Map([
+        [first.streamId, first.executionId],
+        [second.streamId, second.executionId],
+      ]),
+      repairStreams: [first.streamId, second.streamId],
+      closeRunningGroups: vi.fn(async () => [] as StreamTabId[]),
+      probeOwner,
+      runWithInactiveExecutionLease,
+    });
+
+    expect(probeOwner).toHaveBeenCalledOnce();
+    expect(result.activeOwners).toHaveLength(2);
+  });
+
   it('preserves an execution that completed before a delayed lease retry', async () => {
     const setup = setupRunningStream('completed-before-retry');
     const { streamId, executionId, streamStatus } = setup;

--- a/src/test-kernel/agent/runtime/RestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/RestartRepair.vitest.ts
@@ -5,7 +5,6 @@ import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
   repairRestartedStreams,
-  RestartRepairRetryScheduler,
   type RestartRepairOptions,
 } from '@agent/runtime/restartRepair';
 import {
@@ -110,54 +109,32 @@ async function failGroupClose(): Promise<StreamTabId[]> {
 }
 
 describe('repairRestartedStreams', () => {
-  it('keeps only one delayed lease retry and cancels it on disposal', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(1_000);
-    const scheduler = new RestartRepairRetryScheduler();
-    const superseded = vi.fn();
-    const retry = vi.fn();
-    const disposed = vi.fn();
-
-    try {
-      scheduler.schedule(1_010, superseded);
-      scheduler.schedule(1_020, retry);
-      vi.advanceTimersByTime(19);
-      expect(superseded).not.toHaveBeenCalled();
-      expect(retry).not.toHaveBeenCalled();
-      vi.advanceTimersByTime(1);
-      expect(retry).toHaveBeenCalledOnce();
-
-      scheduler.schedule(1_030, disposed);
-      scheduler.dispose();
-      vi.advanceTimersByTime(10);
-      expect(disposed).not.toHaveBeenCalled();
-
-      const rearmedAfterDispose = vi.fn();
-      scheduler.schedule(1_040, rearmedAfterDispose);
-      vi.advanceTimersByTime(10);
-      expect(rearmedAfterDispose).not.toHaveBeenCalled();
-    } finally {
-      scheduler.dispose();
-      vi.useRealTimers();
-    }
-  });
-
-  it('skips every repair mutation for a fresh foreign lease', async () => {
+  it('skips every repair mutation for a live foreign owner', async () => {
     const setup = setupRunningStream('foreign-active');
     const closeRunningGroups = vi.fn(async () => [] as StreamTabId[]);
     const finalizeExecution = createDurableFinalizer();
+    const owner = {
+      instanceId: 'test-instance',
+      socketPath: '/tmp/texra-test.sock',
+      pid: 1,
+      hostname: 'test-host',
+    };
 
     const result = await runRepair(setup, {
       closeRunningGroups,
       finalizeExecution,
       runWithInactiveExecutionLease: vi.fn(async () => ({
         status: 'active' as const,
-        heartbeatAt: 123,
+        owner,
       })),
     });
 
     expect(setup.streamStatus.get(setup.streamId)).toBe(STREAM_PHASE.RUNNING);
-    expect(result).toEqual({ nextLeaseCheckAt: 120_124 });
+    expect(result).toEqual({
+      activeOwners: [
+        { streamId: setup.streamId, executionId: setup.executionId, owner },
+      ],
+    });
     expect(closeRunningGroups).not.toHaveBeenCalled();
     expect(finalizeExecution).not.toHaveBeenCalled();
   });

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   runFlowWithLifecycle: vi.fn(),
   runToolUseFlow: vi.fn(),
   acquireResumedExecutionLease: vi.fn(),
-  renewOwnedExecutionLease: vi.fn(),
+  validateOwnedExecutionLease: vi.fn(),
   runWithExecutionLeaseWriteFence: vi.fn(
     async (_executionId: ExecutionId, operation: () => Promise<unknown>) =>
       operation(),
@@ -21,16 +21,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@agent/storage/executionLease', () => ({
-  // `executionListing`'s entrance stamper reads this constant at module
-  // load; keep it defined when the lease module is mocked.
-  EXECUTION_LEASE_STALE_MS: 120_000,
   abandonOwnedExecutionLease: mocks.abandonOwnedExecutionLease,
   acquireResumedExecutionLease: mocks.acquireResumedExecutionLease,
   captureOwnedExecutionLease:
     (_executionId: ExecutionId) => (operation: () => unknown) =>
       operation(),
   completeOwnedExecutionLease: mocks.completeOwnedExecutionLease,
-  renewOwnedExecutionLease: mocks.renewOwnedExecutionLease,
+  validateOwnedExecutionLease: mocks.validateOwnedExecutionLease,
   runWithExecutionLeaseWriteFence: mocks.runWithExecutionLeaseWriteFence,
   releaseOwnedExecutionLeaseAfterFailure:
     mocks.releaseOwnedExecutionLeaseAfterFailure,

--- a/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   abandonOwnedExecutionLease: vi.fn(),
-  renewOwnedExecutionLease: vi.fn(),
+  validateOwnedExecutionLease: vi.fn(),
   acquireResumedExecutionLease: vi.fn(),
   clearTerminalExecutionState: vi.fn(),
   executeAgent: vi.fn(),
@@ -18,7 +18,6 @@ vi.mock('@agent/storage', () => ({
 }));
 
 vi.mock('@agent/storage/executionLease', () => ({
-  EXECUTION_LEASE_STALE_MS: 120_000,
   abandonOwnedExecutionLease: mocks.abandonOwnedExecutionLease,
   acquireResumedExecutionLease: mocks.acquireResumedExecutionLease,
   completeOwnedExecutionLease: mocks.completeOwnedExecutionLease,
@@ -26,7 +25,7 @@ vi.mock('@agent/storage/executionLease', () => ({
     (_executionId: ExecutionId) => (operation: () => unknown) =>
       operation(),
   markOwnedExecutionLeaseUndurable: mocks.markOwnedExecutionLeaseUndurable,
-  renewOwnedExecutionLease: mocks.renewOwnedExecutionLease,
+  validateOwnedExecutionLease: mocks.validateOwnedExecutionLease,
 }));
 
 vi.mock('@agent/storage/executionLifecycle', () => ({
@@ -90,7 +89,7 @@ describe('runAgent execution ownership', () => {
       streamId: 'assistant#run-agent-owner',
     });
     mocks.completeOwnedExecutionLease.mockResolvedValue({ status: 'released' });
-    mocks.renewOwnedExecutionLease.mockResolvedValue(undefined);
+    mocks.validateOwnedExecutionLease.mockResolvedValue(undefined);
     flushArtifacts.mockResolvedValue(undefined);
     mocks.finalizeExecution.mockResolvedValue(FINALIZE_RESULT);
     mocks.executeAgent.mockResolvedValue(EXECUTE_RESULT);

--- a/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
@@ -5,7 +5,6 @@ import { flowKey } from '@agent/node/persistedFlow';
 import {
   acquireFreshExecutionLease,
   completeOwnedExecutionLease,
-  EXECUTION_LEASE_STALE_MS,
   resetExecutionLeaseCoordinationForTests,
 } from '@agent/storage/executionLease';
 import * as waitingDetection from '@agent/storage/detectWaitingStreams';
@@ -22,7 +21,11 @@ import {
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
-import { writeForeignLease } from '@test/support/executionLeaseFixtures';
+import {
+  startForeignInstance,
+  writeForeignLease,
+  writeOrphanedLease,
+} from '@test/support/executionLeaseFixtures';
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
   appendTranscriptEntry,
@@ -180,10 +183,7 @@ describe('SessionHandle restart repair', () => {
     await executionStore.writeMeta({ timestamp: META_TIMESTAMP });
     await executionStore.write(flowKey(executionId), { invalid: true });
 
-    await writeForeignLease(
-      executionId,
-      Date.now() - EXECUTION_LEASE_STALE_MS - 1,
-    );
+    await writeOrphanedLease(executionId);
 
     const session = openDeferredSession(transcripts);
     await session.waitUntilReady();
@@ -913,10 +913,11 @@ describe('SessionHandle restart repair', () => {
     expect(transitionHooks.afterStorageFinalize).toHaveBeenCalledOnce();
   });
 
-  it('restores delayed lease repair after a root replacement rolls back', async () => {
+  it('restores owner-exit lease repair after a root replacement rolls back', async () => {
     vi.useFakeTimers({
       now: new Date('2026-07-28T12:00:00.000Z'),
     });
+    const foreign = await startForeignInstance();
     const rollbackExecutionId = '9355abcd' as ExecutionId;
     const rollbackStreamId = `crashed#${rollbackExecutionId}` as StreamTabId;
     const storage = platform().storage;
@@ -948,7 +949,7 @@ describe('SessionHandle restart repair', () => {
     await executionStore.write(flowKey(rollbackExecutionId), {
       invalid: true,
     });
-    await writeForeignLease(rollbackExecutionId);
+    await writeForeignLease(rollbackExecutionId, undefined, foreign.owner);
 
     const session = openDeferredSession(transcripts);
 
@@ -968,7 +969,7 @@ describe('SessionHandle restart repair', () => {
       expect(activeRoot).toBe('old');
       expect(session.status.get(rollbackStreamId)).toBe(STREAM_PHASE.RUNNING);
 
-      await vi.advanceTimersByTimeAsync(EXECUTION_LEASE_STALE_MS + 1);
+      await foreign.shutdown();
       await vi.waitFor(() => {
         expect(session.status.get(rollbackStreamId)).toBe(STREAM_PHASE.FAILED);
       });

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -108,13 +108,31 @@ describe('cross-process execution leases', () => {
     await StorageFS.ensureDir(WORKSPACE_STORAGE_LAYOUT.executionLeases);
     await StorageFS.writeAtomic(
       executionLeasePath(executionId),
-      '{"version":1}',
+      '{"version":2}',
     );
 
     await expect(deleteExecution(executionId)).rejects.toThrow(
       'Failed to parse JSON',
     );
     expect(await StorageFS.exists(`executions/${executionId}`)).toBe(true);
+  });
+
+  it('self-heals a retired heartbeat-era lease record on contact', async () => {
+    const executionId = 'c8644d' as ExecutionId;
+    await writeExecution(executionId);
+    await StorageFS.ensureDir(WORKSPACE_STORAGE_LAYOUT.executionLeases);
+    await StorageFS.writeAtomic(
+      executionLeasePath(executionId),
+      '{"version":1,"executionId":"c8644d","ownerToken":"00000000-0000-4000-8000-000000000009","acquiredAt":1,"heartbeatAt":1}',
+    );
+
+    await expect(inspectExecutionLease(executionId)).resolves.toEqual({
+      status: 'orphaned',
+    });
+    await expect(deleteExecution(executionId)).resolves.toMatchObject({
+      status: 'deleted',
+    });
+    expect(await StorageFS.exists(executionLeasePath(executionId))).toBe(false);
   });
 
   it('rejects resume while another live owner holds the lease', async () => {
@@ -506,7 +524,7 @@ describe('cross-process execution leases', () => {
     await StorageFS.ensureDir(WORKSPACE_STORAGE_LAYOUT.executionLeases);
     await StorageFS.writeAtomic(
       executionLeasePath(malformedId),
-      '{"version":1}',
+      '{"version":2}',
     );
 
     await expect(deleteAllExecutions()).rejects.toThrow('Failed to parse JSON');

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -36,6 +36,7 @@ import { RUN_OUTCOME, type ExecutionId } from '@shared/schemas';
 import { createDeferred } from '@test/support/asyncTestUtils';
 import {
   executionLeasePath,
+  startForeignInstance,
   writeForeignLease,
   writeOrphanedLease,
 } from '@test/support/executionLeaseFixtures';
@@ -133,6 +134,39 @@ describe('cross-process execution leases', () => {
       status: 'deleted',
     });
     expect(await StorageFS.exists(executionLeasePath(executionId))).toBe(false);
+  });
+
+  it('classifies a reused socket path answered by another instance as orphaned', async () => {
+    const executionId = 'b8644e' as ExecutionId;
+    const foreign = await startForeignInstance();
+    await writeForeignLease(executionId, undefined, {
+      ...foreign.owner,
+      instanceId: 'displaced-instance',
+    });
+
+    await expect(inspectExecutionLease(executionId)).resolves.toEqual({
+      status: 'orphaned',
+    });
+    await foreign.shutdown();
+  });
+
+  it('treats a cross-host owner as unprovable and never reclaims it', async () => {
+    const executionId = 'b8644f' as ExecutionId;
+    await writeForeignLease(executionId, undefined, {
+      instanceId: 'other-host-instance',
+      socketPath: '/nonexistent/texra-other.sock',
+      pid: 1,
+      hostname: 'texra-some-other-host',
+    });
+    const operation = vi.fn(async () => 'removed');
+
+    await expect(inspectExecutionLease(executionId)).resolves.toMatchObject({
+      status: 'foreign',
+    });
+    await expect(
+      runWithInactiveExecutionLease(executionId, operation),
+    ).resolves.toMatchObject({ status: 'active' });
+    expect(operation).not.toHaveBeenCalled();
   });
 
   it('rejects resume while another live owner holds the lease', async () => {

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -12,7 +12,6 @@ import {
   deleteExecution,
 } from '@agent/storage/executionListing';
 import {
-  EXECUTION_LEASE_STALE_MS,
   ExecutionLeaseActiveError,
   ExecutionLeaseLostError,
   abandonOwnedExecutionLease,
@@ -26,9 +25,9 @@ import {
   ownsExecutionLease,
   releaseOwnedExecutionLease,
   resetExecutionLeaseCoordinationForTests,
-  renewOwnedExecutionLease,
   runWithInactiveExecutionLease,
   captureOwnedExecutionLeaseIfPresent,
+  validateOwnedExecutionLease,
   waitForOwnedExecutionLeaseRelease,
 } from '@agent/storage/executionLease';
 import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
@@ -38,6 +37,7 @@ import { createDeferred } from '@test/support/asyncTestUtils';
 import {
   executionLeasePath,
   writeForeignLease,
+  writeOrphanedLease,
 } from '@test/support/executionLeaseFixtures';
 import { StorageFS } from '@utils/files/storageFS';
 
@@ -52,17 +52,6 @@ async function writeExecution(executionId: ExecutionId): Promise<void> {
 async function acquire(executionId: ExecutionId): Promise<void> {
   ownedExecutionIds.add(executionId);
   await acquireResumedExecutionLease(executionId);
-}
-
-async function writeStaleForeignLease(
-  executionId: ExecutionId,
-  ownerToken?: string,
-): Promise<void> {
-  await writeForeignLease(
-    executionId,
-    Date.now() - EXECUTION_LEASE_STALE_MS - 1,
-    ownerToken,
-  );
 }
 
 function bindRunExclusive() {
@@ -90,7 +79,7 @@ describe('cross-process execution leases', () => {
   it('protects a freshly leased execution from single deletion', async () => {
     const executionId = 'a8644a' as ExecutionId;
     await writeExecution(executionId);
-    await writeForeignLease(executionId, Date.now());
+    await writeForeignLease(executionId);
 
     await expect(deleteExecution(executionId)).resolves.toMatchObject({
       status: 'active',
@@ -99,16 +88,18 @@ describe('cross-process execution leases', () => {
     expect(await StorageFS.exists(`executions/${executionId}`)).toBe(true);
   });
 
-  it('takes over a stale lease after the explicit horizon', async () => {
+  it('takes over an orphaned lease whose owner is provably dead', async () => {
     const executionId = 'b8644b' as ExecutionId;
-    const now = Date.now();
-    await writeForeignLease(executionId, now - EXECUTION_LEASE_STALE_MS - 1);
+    await writeOrphanedLease(executionId);
 
+    await expect(inspectExecutionLease(executionId)).resolves.toEqual({
+      status: 'orphaned',
+    });
     await acquire(executionId);
 
-    await expect(
-      inspectExecutionLease(executionId, now),
-    ).resolves.toMatchObject({ status: 'owned' });
+    await expect(inspectExecutionLease(executionId)).resolves.toMatchObject({
+      status: 'owned',
+    });
   });
 
   it('fails closed when present lease state is malformed', async () => {
@@ -126,9 +117,9 @@ describe('cross-process execution leases', () => {
     expect(await StorageFS.exists(`executions/${executionId}`)).toBe(true);
   });
 
-  it('rejects resume while another owner has a fresh lease', async () => {
+  it('rejects resume while another live owner holds the lease', async () => {
     const executionId = 'd8644d' as ExecutionId;
-    await writeForeignLease(executionId, Date.now());
+    await writeForeignLease(executionId);
 
     await expect(
       acquireResumedExecutionLease(executionId),
@@ -172,13 +163,14 @@ describe('cross-process execution leases', () => {
 
   it('timestamps a resumed lease after asynchronous admission completes', async () => {
     vi.useFakeTimers({ now: new Date('2026-07-25T12:00:00.000Z') });
+    const admissionDelayMs = 90_000;
     const executionId = 'd86450' as ExecutionId;
-    const expectedHeartbeat = Date.now() + EXECUTION_LEASE_STALE_MS + 1_000;
+    const expectedAcquiredAt = Date.now() + admissionDelayMs;
 
     try {
       await expect(
         acquireResumedExecutionLease(executionId, async () => {
-          await vi.advanceTimersByTimeAsync(EXECUTION_LEASE_STALE_MS + 1_000);
+          await vi.advanceTimersByTimeAsync(admissionDelayMs);
           return true;
         }),
       ).resolves.toBe('acquired');
@@ -186,17 +178,14 @@ describe('cross-process execution leases', () => {
 
       const persisted = JSON.parse(
         await StorageFS.read(executionLeasePath(executionId)),
-      ) as { acquiredAt: number; heartbeatAt: number };
-      expect(persisted).toMatchObject({
-        acquiredAt: expectedHeartbeat,
-        heartbeatAt: expectedHeartbeat,
-      });
+      ) as { acquiredAt: number };
+      expect(persisted).toMatchObject({ acquiredAt: expectedAcquiredAt });
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it('retains existing ownership through a transient resume heartbeat failure', async () => {
+  it('surfaces a transient resume validation failure without dropping ownership', async () => {
     const executionId = 'd86451' as ExecutionId;
     await acquire(executionId);
     vi.spyOn(platform().fileLocks, 'runExclusive').mockRejectedValueOnce(
@@ -205,7 +194,7 @@ describe('cross-process execution leases', () => {
 
     await expect(
       acquireResumedExecutionLease(executionId, () => true),
-    ).resolves.toBe('existing');
+    ).rejects.toThrow('temporary filesystem failure');
     expect(ownsExecutionLease(executionId)).toBe(true);
   });
 
@@ -247,7 +236,7 @@ describe('cross-process execution leases', () => {
     expect(settled).toBe(true);
   });
 
-  it('stops heartbeats but preserves the lease after durability failure', async () => {
+  it('stops claiming but preserves the lease after durability failure', async () => {
     const executionId = 'd86442' as ExecutionId;
     await acquire(executionId);
 
@@ -303,7 +292,6 @@ describe('cross-process execution leases', () => {
     await acquire(executionId);
     await writeForeignLease(
       executionId,
-      Date.now(),
       '00000000-0000-4000-8000-000000000002',
     );
 
@@ -315,29 +303,6 @@ describe('cross-process execution leases', () => {
     });
   });
 
-  it('fences the former owner when a heartbeat observes takeover', async () => {
-    vi.useFakeTimers();
-    const executionId = 'e8644f' as ExecutionId;
-    try {
-      await acquire(executionId);
-      const onLeaseLost = vi.fn();
-      onOwnedExecutionLeaseLost(executionId, onLeaseLost);
-      await writeForeignLease(
-        executionId,
-        Date.now(),
-        '00000000-0000-4000-8000-000000000003',
-      );
-
-      await vi.advanceTimersByTimeAsync(15_000);
-
-      expect(onLeaseLost).toHaveBeenCalledOnce();
-      expect(ownsExecutionLease(executionId)).toBe(false);
-      ownedExecutionIds.delete(executionId);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   it('fences an execution-store write immediately after takeover', async () => {
     const executionId = 'e86440' as ExecutionId;
     await acquire(executionId);
@@ -346,7 +311,6 @@ describe('cross-process execution leases', () => {
     await captureOwnedExecutionLease(executionId)(async () => {
       await writeForeignLease(
         executionId,
-        Date.now(),
         '00000000-0000-4000-8000-000000000004',
       );
 
@@ -382,7 +346,7 @@ describe('cross-process execution leases', () => {
         await writeExecution(executionId);
       }),
     );
-    await writeStaleForeignLease(
+    await writeOrphanedLease(
       executionId,
       '00000000-0000-4000-8000-000000000006',
     );
@@ -414,7 +378,7 @@ describe('cross-process execution leases', () => {
         return captureOwnedExecutionLeaseIfPresent(executionId);
       }),
     );
-    await writeStaleForeignLease(
+    await writeOrphanedLease(
       executionId,
       '00000000-0000-4000-8000-000000000007',
     );
@@ -429,72 +393,33 @@ describe('cross-process execution leases', () => {
 
   it('rejects unscoped writes while another owner has a lease', async () => {
     const executionId = 'e86446' as ExecutionId;
-    await writeForeignLease(executionId, Date.now());
+    await writeForeignLease(executionId);
 
     await expect(writeExecution(executionId)).rejects.toBeInstanceOf(
       ExecutionLeaseLostError,
     );
   });
 
-  it('never overlaps heartbeat work for the same execution', async () => {
-    const executionId = 'e86441' as ExecutionId;
-    vi.useFakeTimers();
-    const heartbeatGate = createDeferred();
-    try {
-      await acquire(executionId);
-      const originalRunExclusive = bindRunExclusive();
-      const runExclusive = vi
-        .spyOn(platform().fileLocks, 'runExclusive')
-        .mockImplementation(async (lockPath, operation) => {
-          await heartbeatGate.promise;
-          return originalRunExclusive(lockPath, operation);
-        });
-
-      await vi.advanceTimersByTimeAsync(15_000);
-      for (let index = 0; index < 5; index += 1) await Promise.resolve();
-      expect(runExclusive).toHaveBeenCalledOnce();
-
-      await vi.advanceTimersByTimeAsync(45_000);
-      expect(runExclusive).toHaveBeenCalledOnce();
-    } finally {
-      heartbeatGate.resolve();
-      vi.useRealTimers();
-    }
-  });
-
-  it('retains recent ownership through a transient heartbeat failure', async () => {
-    const executionId = 'e86442' as ExecutionId;
-    await acquire(executionId);
-    vi.spyOn(platform().fileLocks, 'runExclusive').mockRejectedValueOnce(
-      new Error('temporary filesystem failure'),
-    );
-
-    await expect(
-      renewOwnedExecutionLease(executionId),
-    ).resolves.toBeUndefined();
-    expect(ownsExecutionLease(executionId)).toBe(true);
-  });
-
-  it('rejects renewal when release starts during its heartbeat', async () => {
+  it('rejects validation when release starts during its lock wait', async () => {
     const executionId = 'e86443' as ExecutionId;
     await acquire(executionId);
     const originalRunExclusive = bindRunExclusive();
-    const heartbeatStarted = createDeferred();
-    const heartbeatGate = createDeferred();
+    const validationStarted = createDeferred();
+    const validationGate = createDeferred();
     vi.spyOn(platform().fileLocks, 'runExclusive').mockImplementationOnce(
       async (lockPath, operation) => {
-        heartbeatStarted.resolve();
-        await heartbeatGate.promise;
+        validationStarted.resolve();
+        await validationGate.promise;
         return originalRunExclusive(lockPath, operation);
       },
     );
 
-    const renewal = renewOwnedExecutionLease(executionId);
-    await heartbeatStarted.promise;
+    const validation = validateOwnedExecutionLease(executionId);
+    await validationStarted.promise;
     const release = releaseOwnedExecutionLease(executionId);
-    heartbeatGate.resolve();
+    validationGate.resolve();
 
-    await expect(renewal).rejects.toBeInstanceOf(ExecutionLeaseLostError);
+    await expect(validation).rejects.toBeInstanceOf(ExecutionLeaseLostError);
     await release;
     ownedExecutionIds.delete(executionId);
   });
@@ -525,13 +450,15 @@ describe('cross-process execution leases', () => {
     });
   });
 
-  it('keeps locally owned execution active even when its heartbeat is old', async () => {
+  it('keeps a locally owned execution active whatever its record claims', async () => {
     const executionId = 'f86440' as ExecutionId;
     await acquire(executionId);
     const persisted = JSON.parse(
       await StorageFS.read(executionLeasePath(executionId)),
     ) as { ownerToken: string };
-    await writeStaleForeignLease(executionId, persisted.ownerToken);
+    // Even a record naming a dead instance never lets maintenance reap the
+    // live local owner: token identity short-circuits before any probe.
+    await writeOrphanedLease(executionId, persisted.ownerToken);
     const operation = vi.fn(async () => 'removed');
 
     await expect(
@@ -540,11 +467,11 @@ describe('cross-process execution leases', () => {
     expect(operation).not.toHaveBeenCalled();
   });
 
-  it('lets locked maintenance clear a stale displaced local owner', async () => {
+  it('lets locked maintenance clear an orphaned displaced local owner', async () => {
     const executionId = 'f86441' as ExecutionId;
     await writeExecution(executionId);
     await acquire(executionId);
-    await writeStaleForeignLease(
+    await writeOrphanedLease(
       executionId,
       '00000000-0000-4000-8000-000000000005',
     );
@@ -561,7 +488,7 @@ describe('cross-process execution leases', () => {
     const activeId = 'a86441' as ExecutionId;
     await writeExecution(deletedId);
     await writeExecution(activeId);
-    await writeForeignLease(activeId, Date.now());
+    await writeForeignLease(activeId);
 
     await expect(deleteAllExecutions()).resolves.toEqual({
       deleted: [deletedId],

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -321,7 +321,6 @@ describe('SessionStores deletion coordination', () => {
         deleteExecution: async (executionId) => ({
           status: 'active',
           executionId,
-          heartbeatAt: Date.now(),
         }),
         onCanonicalStreamDeleted: (stream) =>
           releaseStreamResources(stream, session),
@@ -686,7 +685,6 @@ describe('SessionStores orphan sweep', () => {
     const deleteExecution = vi.fn(async () => ({
       status: 'active' as const,
       executionId,
-      heartbeatAt: Date.now(),
     }));
     const stores = new SessionStores({
       streamLogs: await StreamLogStore.open(),

--- a/src/test-kernel/cli/RunExecution.vitest.ts
+++ b/src/test-kernel/cli/RunExecution.vitest.ts
@@ -1005,7 +1005,16 @@ describe('executeCliRequest', () => {
   it.each([
     {
       label: 'a fresh lease remains',
-      inspection: { status: 'foreign' as const, heartbeatAt: 1 },
+      inspection: {
+        status: 'foreign' as const,
+        acquiredAt: 1,
+        owner: {
+          instanceId: 'test-instance',
+          socketPath: '/tmp/texra-test.sock',
+          pid: 1,
+          hostname: 'test-host',
+        },
+      },
     },
     {
       label: 'lease inspection fails',

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -529,14 +529,16 @@ class FakeWorkspaceProvider implements WorkspaceProvider {
   }
 }
 
+// A real directory: instance-presence sockets are genuine OS objects that
+// live under the global storage root even when everything else is faked.
+// Lazy and worker-shared so the thousands of per-test FakePlatform instances
+// that never touch presence do not litter os.tmpdir() with empty directories.
+let sharedFakeGlobalStoragePath: string | undefined;
+
 class FakeStorageProvider implements StorageProvider {
   constructor(
     private readonly storagePath = '/workspace/.texra/storage',
-    // A real directory: instance-presence sockets are genuine OS objects that
-    // live under the global storage root even when everything else is faked.
-    private readonly globalStoragePath = mkdtempSync(
-      path.join(os.tmpdir(), 'texra-fake-global-'),
-    ),
+    private globalStoragePath?: string,
   ) {}
 
   getStoragePath(): string {
@@ -544,6 +546,9 @@ class FakeStorageProvider implements StorageProvider {
   }
 
   getGlobalStoragePath(): string {
+    this.globalStoragePath ??= sharedFakeGlobalStoragePath ??= mkdtempSync(
+      path.join(os.tmpdir(), 'texra-fake-global-'),
+    );
     return this.globalStoragePath;
   }
 }

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -1,4 +1,6 @@
 // Node imports
+import { mkdtempSync } from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 // Third-party imports
@@ -530,7 +532,11 @@ class FakeWorkspaceProvider implements WorkspaceProvider {
 class FakeStorageProvider implements StorageProvider {
   constructor(
     private readonly storagePath = '/workspace/.texra/storage',
-    private readonly globalStoragePath = '/global/.texra/storage',
+    // A real directory: instance-presence sockets are genuine OS objects that
+    // live under the global storage root even when everything else is faked.
+    private readonly globalStoragePath = mkdtempSync(
+      path.join(os.tmpdir(), 'texra-fake-global-'),
+    ),
   ) {}
 
   getStoragePath(): string {

--- a/src/test-kernel/support/executionLeaseFixtures.ts
+++ b/src/test-kernel/support/executionLeaseFixtures.ts
@@ -75,17 +75,12 @@ export async function startForeignInstance(): Promise<ForeignInstance> {
   };
 }
 
-let sharedForeignInstance: Promise<ForeignInstance> | undefined;
-
 /**
  * One shared live listener serves every plain fixture lease in a worker; it
  * is unref'd so it never holds the process open, and worker exit is its
  * shutdown. Tests that need to *kill* the owner start their own instance.
  */
-function ensureLiveForeignInstance(): Promise<InstanceOwnerRecord> {
-  sharedForeignInstance ??= startForeignInstance();
-  return sharedForeignInstance.then((instance) => instance.owner);
-}
+let sharedForeignInstance: Promise<ForeignInstance> | undefined;
 
 let exitedChildPid: number | undefined;
 
@@ -97,17 +92,6 @@ let exitedChildPid: number | undefined;
 function provablyDeadPid(): number {
   exitedChildPid ??= spawnSync(process.execPath, ['-e', '']).pid;
   return exitedChildPid;
-}
-
-/** An owner identity whose socket provably has no listener. */
-function deadInstanceOwner(): InstanceOwnerRecord {
-  const instanceId = `test-dead-${randomUUID().slice(0, 8)}`;
-  return {
-    instanceId,
-    socketPath: fixtureSocketPath(instanceId),
-    pid: provablyDeadPid(),
-    hostname: os.hostname(),
-  };
 }
 
 async function writeLeaseFixture(
@@ -141,7 +125,7 @@ export async function writeForeignLease(
 ): Promise<void> {
   await writeLeaseFixture(
     executionId,
-    owner ?? (await ensureLiveForeignInstance()),
+    owner ?? (await (sharedForeignInstance ??= startForeignInstance())).owner,
     ownerToken,
   );
 }
@@ -154,5 +138,15 @@ export async function writeOrphanedLease(
   executionId: string,
   ownerToken: string = FOREIGN_OWNER_TOKEN,
 ): Promise<void> {
-  await writeLeaseFixture(executionId, deadInstanceOwner(), ownerToken);
+  const instanceId = `test-dead-${randomUUID().slice(0, 8)}`;
+  await writeLeaseFixture(
+    executionId,
+    {
+      instanceId,
+      socketPath: fixtureSocketPath(instanceId),
+      pid: provablyDeadPid(),
+      hostname: os.hostname(),
+    },
+    ownerToken,
+  );
 }

--- a/src/test-kernel/support/executionLeaseFixtures.ts
+++ b/src/test-kernel/support/executionLeaseFixtures.ts
@@ -1,5 +1,13 @@
+// Node imports
+import { randomUUID } from 'node:crypto';
+import { mkdtempSync } from 'node:fs';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 // Local imports
 import { ExecutionLeaseSchema } from '@agent/storage/executionLease';
+import type { InstanceOwnerRecord } from '@agent/storage/instancePresence';
 import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
 import { StorageFS } from '@utils/files/storageFS';
 
@@ -14,25 +22,121 @@ export function executionLeasePath(executionId: string): string {
   return `${WORKSPACE_STORAGE_LAYOUT.executionLeases}/${executionId}.json`;
 }
 
+function fixtureSocketPath(instanceId: string): string {
+  if (process.platform === 'win32') {
+    return `\\\\.\\pipe\\texra-test-${instanceId}`;
+  }
+  return path.join(
+    mkdtempSync(path.join(os.tmpdir(), 'texra-lease-')),
+    'i.sock',
+  );
+}
+
+export interface ForeignInstance {
+  readonly owner: InstanceOwnerRecord;
+  /** Kill the "other process": watchers observe its exit for real. */
+  readonly shutdown: () => Promise<void>;
+}
+
 /**
- * Persist a lease held by another process, validated against the production
- * lease schema so a schema change breaks every fixture in one place.
+ * A real, listening presence socket owned by "another process". Its liveness
+ * is proven the production way: probes connect and read its banner.
  */
-export async function writeForeignLease(
+export async function startForeignInstance(): Promise<ForeignInstance> {
+  const instanceId = `test-foreign-${randomUUID().slice(0, 8)}`;
+  const socketPath = fixtureSocketPath(instanceId);
+  const connections = new Set<net.Socket>();
+  const server = net.createServer((socket) => {
+    connections.add(socket);
+    socket.on('close', () => connections.delete(socket));
+    socket.on('error', () => undefined);
+    socket.write(`texra-presence:${instanceId}\n`);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, resolve);
+  });
+  server.unref();
+  return {
+    owner: {
+      instanceId,
+      socketPath,
+      pid: process.pid,
+      hostname: os.hostname(),
+    },
+    shutdown: async () => {
+      for (const socket of connections) socket.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+let sharedForeignInstance: Promise<ForeignInstance> | undefined;
+
+/**
+ * One shared live listener serves every plain fixture lease in a worker; it
+ * is unref'd so it never holds the process open, and worker exit is its
+ * shutdown. Tests that need to *kill* the owner start their own instance.
+ */
+function ensureLiveForeignInstance(): Promise<InstanceOwnerRecord> {
+  sharedForeignInstance ??= startForeignInstance();
+  return sharedForeignInstance.then((instance) => instance.owner);
+}
+
+/** An owner identity whose socket provably has no listener. */
+function deadInstanceOwner(): InstanceOwnerRecord {
+  const instanceId = `test-dead-${randomUUID().slice(0, 8)}`;
+  return {
+    instanceId,
+    socketPath: fixtureSocketPath(instanceId),
+    pid: 0,
+    hostname: os.hostname(),
+  };
+}
+
+async function writeLeaseFixture(
   executionId: string,
-  heartbeatAt: number = Date.now(),
-  ownerToken: string = FOREIGN_OWNER_TOKEN,
+  owner: InstanceOwnerRecord,
+  ownerToken: string,
 ): Promise<void> {
   const lease = ExecutionLeaseSchema.parse({
-    version: 1,
+    version: 2,
     executionId,
     ownerToken,
-    acquiredAt: heartbeatAt,
-    heartbeatAt,
+    acquiredAt: Date.now(),
+    owner,
   });
   await StorageFS.ensureDir(WORKSPACE_STORAGE_LAYOUT.executionLeases);
   await StorageFS.writeAtomic(
     executionLeasePath(executionId),
     JSON.stringify(lease),
   );
+}
+
+/**
+ * Persist a lease held by another live process, validated against the
+ * production lease schema so a schema change breaks every fixture in one
+ * place. The recorded owner answers liveness probes for real.
+ */
+export async function writeForeignLease(
+  executionId: string,
+  ownerToken: string = FOREIGN_OWNER_TOKEN,
+  owner?: InstanceOwnerRecord,
+): Promise<void> {
+  await writeLeaseFixture(
+    executionId,
+    owner ?? (await ensureLiveForeignInstance()),
+    ownerToken,
+  );
+}
+
+/**
+ * Persist a lease whose owner is provably dead: its socket path has no
+ * listener, so probes return a death verdict and the record is reclaimable.
+ */
+export async function writeOrphanedLease(
+  executionId: string,
+  ownerToken: string = FOREIGN_OWNER_TOKEN,
+): Promise<void> {
+  await writeLeaseFixture(executionId, deadInstanceOwner(), ownerToken);
 }

--- a/src/test-kernel/support/executionLeaseFixtures.ts
+++ b/src/test-kernel/support/executionLeaseFixtures.ts
@@ -1,4 +1,5 @@
 // Node imports
+import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { mkdtempSync } from 'node:fs';
 import * as net from 'node:net';
@@ -58,10 +59,13 @@ export async function startForeignInstance(): Promise<ForeignInstance> {
   });
   server.unref();
   return {
+    // The pid is a death-proof-only input consulted on ENOENT: recording an
+    // already-exited pid makes shutdown() (which unlinks the socket file)
+    // read as process death, while the live listener still probes alive.
     owner: {
       instanceId,
       socketPath,
-      pid: process.pid,
+      pid: provablyDeadPid(),
       hostname: os.hostname(),
     },
     shutdown: async () => {
@@ -83,13 +87,25 @@ function ensureLiveForeignInstance(): Promise<InstanceOwnerRecord> {
   return sharedForeignInstance.then((instance) => instance.owner);
 }
 
+let exitedChildPid: number | undefined;
+
+/**
+ * A pid the kernel proves dead (ESRCH): a child spawned and already exited.
+ * Needed because a missing socket file is a death proof only together with a
+ * provably dead pid.
+ */
+function provablyDeadPid(): number {
+  exitedChildPid ??= spawnSync(process.execPath, ['-e', '']).pid;
+  return exitedChildPid;
+}
+
 /** An owner identity whose socket provably has no listener. */
 function deadInstanceOwner(): InstanceOwnerRecord {
   const instanceId = `test-dead-${randomUUID().slice(0, 8)}`;
   return {
     instanceId,
     socketPath: fixtureSocketPath(instanceId),
-    pid: 0,
+    pid: provablyDeadPid(),
     hostname: os.hostname(),
   };
 }

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -61,7 +61,6 @@ vi.mock('@agent/storage', () => ({
 }));
 
 vi.mock('@agent/storage/executionLease', () => ({
-  EXECUTION_LEASE_STALE_MS: 120_000,
   captureOwnedExecutionLease:
     (_executionId: ExecutionId) => (operation: () => unknown) =>
       operation(),

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -55,7 +55,6 @@ vi.mock('@agent/storage', () => ({
 }));
 
 vi.mock('@agent/storage/executionLease', () => ({
-  EXECUTION_LEASE_STALE_MS: 120_000,
   captureOwnedExecutionLease:
     (_executionId: ExecutionId) => (operation: () => unknown) =>
       operation(),

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -105,7 +105,7 @@ vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
   ownsExecutionLease: vi.fn(() => true),
   // The session's one exit choreography runs for real over these inert lease
   // verbs; completion mirrors production's explicit released/retained outcome.
-  renewOwnedExecutionLease: vi.fn(async () => {}),
+  validateOwnedExecutionLease: vi.fn(async () => {}),
   abandonOwnedExecutionLease: mocks.abandonOwnedExecutionLease,
   completeOwnedExecutionLease: vi.fn(async (executionId: ExecutionId) => {
     if (mocks.undurableExecutionIds.has(executionId)) {

--- a/src/test-kernel/tools/DelegationHeadless.vitest.ts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.ts
@@ -1082,7 +1082,13 @@ describe('headless delegation', () => {
     }
     mocks.inspectExecutionLease.mockResolvedValueOnce({
       status: 'foreign',
-      heartbeatAt: Date.now(),
+      acquiredAt: Date.now(),
+      owner: {
+        instanceId: 'test-instance',
+        socketPath: '/tmp/texra-test.sock',
+        pid: 1,
+        hostname: 'test-host',
+      },
     });
 
     await expect(

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -68,7 +68,7 @@ vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
   captureOwnedExecutionLease:
     (_executionId: ExecutionId) => (operation: () => unknown) =>
       operation(),
-  renewOwnedExecutionLease: vi.fn(async () => {}),
+  validateOwnedExecutionLease: vi.fn(async () => {}),
   abandonOwnedExecutionLease: vi.fn(),
   completeOwnedExecutionLease: vi.fn(async () => ({
     status: 'released' as const,

--- a/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
+++ b/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
@@ -60,7 +60,6 @@ vi.mock('@agent/storage/executionLifecycle', async (importOriginal) => {
 });
 
 vi.mock('@agent/storage/executionLease', () => ({
-  EXECUTION_LEASE_STALE_MS: 120_000,
   captureOwnedExecutionLease:
     (_executionId: string) => (operation: () => unknown) =>
       operation(),

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -982,7 +982,12 @@ return null`;
   it('reports already-running when the deterministic id is still leased', async () => {
     const runExecutionId = runExecutionIdFor('tool-test');
     mocks.registerExecution.mockRejectedValueOnce(
-      new ExecutionLeaseActiveError(runExecutionId, Date.now()),
+      new ExecutionLeaseActiveError(runExecutionId, {
+        instanceId: 'test-instance',
+        socketPath: '/tmp/texra-test.sock',
+        pid: 1,
+        hostname: 'test-host',
+      }),
     );
 
     const result = await callTool();

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -492,8 +492,8 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
     const runResult = runWithOwnership(async () => {
       // Attempt-scoped setup runs inside the lease launch guard: it runs after
       // the deterministic run lease is held, so a throw here must release the
-      // lease - otherwise it survives to its heartbeat timeout and a prompt
-      // relaunch is refused.
+      // lease - otherwise the record survives for this process's lifetime and
+      // a prompt relaunch is refused.
       const { childStreamId: runChildStreamId, completion: runCompletion } =
         await startDetachedChildRunLoop({
           executionId: runExecutionId,


### PR DESCRIPTION
## Problem

Live runs were killed by their own gating: a run "suddenly disconnects", then every follow-up fails with `No active session for follow-up on stream <id>`. Root cause (confirmed in code and on an affected machine): execution-lease liveness was **inferred from wall-clock heartbeat age** (`Date.now() - heartbeatAt > 120s ⇒ owner dead`). System sleep freezes heartbeats while wall-clock advances, so on every wake all live owners looked dead — exactly when `RestartRepairRetryScheduler` timers queued during sleep fired and reclaimed their executions (mark FAILED + delete flow record + delete lease). A second path (`handleHeartbeatFailure`) self-declared loss on a single transient heartbeat error after any >2 min sleep. Two TUIs sharing a workspace made a reaper timer pending across every sleep.

Observed in the wild as:

```
! Error executing agent leanOrchestrator: Execution add97114dcbe is no longer owned by this TeXRA process.
! Execution add97114dcbe failed and its final artifacts could not be persisted
```

## Design: liveness is proven, never inferred

PRD: `docs/prds/2026-08-16-prd-execution-liveness-presence.md`

- Each process binds **one presence socket** (Unix domain socket / Windows named pipe) under `<globalStorage>/instances/`; every lease record it writes points at that instance (`{instanceId, socketPath, pid, hostname}`), written once, never renewed.
- **Death is a kernel fact**: `ECONNREFUSED`/`ENOENT` on the recorded socket, or a different TeXRA instance answering on a reused path. **Alive** = connected with matching banner. Everything else is **unprovable → treated as alive, loud** — we never reclaim on ambiguity.
- **Reclamation is event-driven**: restart repair skips a live foreign owner and holds a watch connection; the kernel closes it when the owner dies, which re-triggers repair. No clock anywhere.
- The `ownerToken` **write fence is unchanged** (that layer was correct).
- Consequence: a live owner can never be displaced automatically; `ExecutionLeaseActiveError` now carries the owner identity. A hung owner is reclaimed the moment its process exits.

## Retired completely (no compat arms)

Heartbeat timer/renewals, `EXECUTION_LEASE_STALE_MS`, `handleHeartbeatFailure` self-kill, `renewOwnedExecutionLease` (→ `validateOwnedExecutionLease`, a pure fencing check), `RestartRepairRetryScheduler` + `nextLeaseCheckAt`, wall-clock freshness, and the v1 record schema. Leftover v1 lease files are **tombstones**: any locked code path deletes one on contact and proceeds as if it were absent (loud warn), so upgrades self-heal — no manual cleanup. The unlocked classifier reports them as orphaned and leaves the delete to the next locked path. **Restart all TeXRA hosts after upgrading** (a still-running pre-upgrade host's live lease is a tombstone to the new code and will be reclaimed).

## Verified

- `npm run typecheck` clean (incl. `@texra-ai/agent` build), `npm run lint` clean, dead-code ratchet OK.
- Lease/repair/lifecycle/delegation suites rewritten against the new oracle with real sockets (alive / refused / banner-mismatch / owner-killed-mid-watch); all pass.
- Full vitest suite: green except unrelated files that also fail under machine contention (worker-start timeouts); those 18 files pass in a clean rerun.
- The lease-release leak observed on the affected machine (115 still-owned records spanning 3 days) is orthogonal and tracked separately; under this design it is inert load rather than a heartbeat stampede.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhUVea8MCbiKyDe9esF4kK
