### PR TITLE
fix(lifecycle): release poller shutdown registration on dispose

### DIFF
--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -229,6 +229,10 @@ export abstract class PollingSourceBase<
   disposeAll(): void {
     this.subscriptions.clear();
     this.stopTimer();
+    // Release before notifying: a synchronous listener may re-subscribe, and
+    // that fresh subscription must register with the active lifecycle. The
+    // disposable's dispose is idempotent and never re-enters disposeAll.
+    this.clearShutdownRegistration();
     this.notifyKeysChanged();
   }
 
@@ -409,23 +413,26 @@ export abstract class PollingSourceBase<
    * first subscription so the shared singletons (constructed at module load,
    * before `initPlatform()`) still register once the platform exists.
    *
-   * Keyed on the lifecycle instance rather than the disposable because
-   * extension reactivation (and the test harness) replaces the whole
-   * `LifecycleHost`; a stale registration must be swapped for one on the new
-   * host instead of skipping the re-registration. The callback also clears the
-   * marker so a drained lifecycle can never satisfy the idempotency guard on a
-   * later subscribe.
+   * Re-checked on every subscribe, so a lifecycle replacement (extension
+   * reactivation or test-harness reinstall) is picked up on the next
+   * subscription. A live poller whose lifecycle is replaced without a
+   * subsequent subscribe is intentionally not self-healed: no production host
+   * installs a new lifecycle while the previous one is still live.
    */
   private registerShutdownIfNeeded(): void {
     const lifecycle = tryPlatform()?.lifecycle;
     if (!lifecycle || this.shutdownLifecycle === lifecycle) return;
-    this.shutdownRegistration?.dispose();
-    this.shutdownRegistration = lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => {
-      this.shutdownRegistration = undefined;
-      this.shutdownLifecycle = undefined;
-      this.disposeAll();
-    });
+    this.clearShutdownRegistration();
+    this.shutdownRegistration = lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
+      this.disposeAll(),
+    );
     this.shutdownLifecycle = lifecycle;
+  }
+
+  private clearShutdownRegistration(): void {
+    this.shutdownRegistration?.dispose();
+    this.shutdownRegistration = undefined;
+    this.shutdownLifecycle = undefined;
   }
 
   private async tick(): Promise<void> {


### PR DESCRIPTION
Refs #10676

## Summary

- release a `PollingSourceBase` shutdown registration whenever `disposeAll()` drains the poller
- centralize registration cleanup so manual disposal, lifecycle replacement, and shutdown callback disposal reset the same state
- clear registration state before notifying listeners, allowing a synchronous re-subscription to register against the active lifecycle

## Why

PR #10716 made each poller own its lifecycle shutdown registration, but `disposeAll()` only reset the registration fields when invoked by the shutdown callback. A manual drain left the old registration attached until lifecycle shutdown and made disposal/re-subscription behavior depend on the caller path.

The cleanup is safe during shutdown because `createLifecycleHost()` removes the phase's registrations before invoking callbacks, and each registration disposable is idempotent.

## Scope

Production-only one-file follow-up found by code inspection, not a reproduced failure. No new tests or abstractions beyond one private helper that owns the paired registration fields. The existing suite run below is a regression smoke check; it does not directly exercise lifecycle registration.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/tools/PollingSourceBase.vitest.ts` — 5 passed
- `corepack pnpm run typecheck` — all workspace targets passed
- `corepack pnpm exec eslint src/tools/github/PollingSourceBase.ts` — clean
- `corepack pnpm exec prettier --check src/tools/github/PollingSourceBase.ts` — clean
- `git diff --check` — clean
- independent code review completed; notification reentrancy finding fixed before push

