### PR TITLE
fix(desktop): surface async main-process failures

### DIFF
--- a/packages/desktop/src/main/bootstrap.ts
+++ b/packages/desktop/src/main/bootstrap.ts
@@ -1,6 +1,7 @@
 import { installDesktopAppLog } from './desktopAppLog.js';
 import {
   installFatalStartupHandlers,
+  installPostStartupRejectionHandler,
   reportFatalStartupError,
 } from './fatalStartupError.js';
 
@@ -10,6 +11,7 @@ const removeFatalStartupHandlers = installFatalStartupHandlers();
 try {
   await import('./index.js');
   removeFatalStartupHandlers();
+  installPostStartupRejectionHandler();
 } catch (error) {
   reportFatalStartupError(error);
 }

--- a/packages/desktop/src/main/desktopBrowserViews.ts
+++ b/packages/desktop/src/main/desktopBrowserViews.ts
@@ -29,7 +29,7 @@ export interface DesktopBrowserViewsOptions {
   /** Reports the page title so the renderer can rename the browser tab. */
   onNavigated(input: { tabId: string; title: string }): void;
   /** Records a URL rejected by the browser-tab policy. */
-  onBlockedExternalUrl?(error: unknown): void;
+  onBlockedExternalUrl(error: unknown): void;
   /** Records a failure after the host has already surfaced the user-facing error. */
   onExternalOpenError(error: unknown): void;
   onError?(error: unknown): void;
@@ -72,17 +72,10 @@ export function createDesktopBrowserViews(
   let attachedTabId: string | undefined;
 
   const reportError = (error: unknown) => options.onError?.(error);
-  const reportBlockedExternalUrl = (error: unknown): void => {
-    if (options.onBlockedExternalUrl) {
-      options.onBlockedExternalUrl(error);
-      return;
-    }
-    reportError(error);
-  };
 
   function openAllowedExternalUrl(url: string): void {
     if (!isHandOffableUrl(url)) {
-      reportBlockedExternalUrl(
+      options.onBlockedExternalUrl(
         new Error(`Blocked external browser URL: ${url}`),
       );
       return;

--- a/packages/desktop/src/main/desktopBrowserViews.ts
+++ b/packages/desktop/src/main/desktopBrowserViews.ts
@@ -30,6 +30,8 @@ export interface DesktopBrowserViewsOptions {
   onNavigated(input: { tabId: string; title: string }): void;
   /** Records a URL rejected by the browser-tab policy. */
   onBlockedExternalUrl?(error: unknown): void;
+  /** Records a failure after the host has already surfaced the user-facing error. */
+  onExternalOpenError?(error: unknown): void;
   onError?(error: unknown): void;
 }
 
@@ -85,7 +87,13 @@ export function createDesktopBrowserViews(
       );
       return;
     }
-    options.openExternalUrl(url).catch(reportError);
+    options.openExternalUrl(url).catch((error: unknown) => {
+      if (options.onExternalOpenError) {
+        options.onExternalOpenError(error);
+        return;
+      }
+      reportError(error);
+    });
   }
 
   function publishState(tabId: string, view: WebContentsView): void {

--- a/packages/desktop/src/main/desktopBrowserViews.ts
+++ b/packages/desktop/src/main/desktopBrowserViews.ts
@@ -28,6 +28,8 @@ export interface DesktopBrowserViewsOptions {
   openExternalUrl(url: string): Promise<void>;
   /** Reports the page title so the renderer can rename the browser tab. */
   onNavigated(input: { tabId: string; title: string }): void;
+  /** Records a URL rejected by the browser-tab policy. */
+  onBlockedExternalUrl?(error: unknown): void;
   onError?(error: unknown): void;
 }
 
@@ -68,10 +70,19 @@ export function createDesktopBrowserViews(
   let attachedTabId: string | undefined;
 
   const reportError = (error: unknown) => options.onError?.(error);
+  const reportBlockedExternalUrl = (error: unknown): void => {
+    if (options.onBlockedExternalUrl) {
+      options.onBlockedExternalUrl(error);
+      return;
+    }
+    reportError(error);
+  };
 
   function openAllowedExternalUrl(url: string): void {
     if (!isHandOffableUrl(url)) {
-      reportError(new Error(`Blocked external browser URL: ${url}`));
+      reportBlockedExternalUrl(
+        new Error(`Blocked external browser URL: ${url}`),
+      );
       return;
     }
     options.openExternalUrl(url).catch(reportError);

--- a/packages/desktop/src/main/desktopBrowserViews.ts
+++ b/packages/desktop/src/main/desktopBrowserViews.ts
@@ -31,7 +31,7 @@ export interface DesktopBrowserViewsOptions {
   /** Records a URL rejected by the browser-tab policy. */
   onBlockedExternalUrl?(error: unknown): void;
   /** Records a failure after the host has already surfaced the user-facing error. */
-  onExternalOpenError?(error: unknown): void;
+  onExternalOpenError(error: unknown): void;
   onError?(error: unknown): void;
 }
 
@@ -87,13 +87,7 @@ export function createDesktopBrowserViews(
       );
       return;
     }
-    options.openExternalUrl(url).catch((error: unknown) => {
-      if (options.onExternalOpenError) {
-        options.onExternalOpenError(error);
-        return;
-      }
-      reportError(error);
-    });
+    options.openExternalUrl(url).catch(options.onExternalOpenError);
   }
 
   function publishState(tabId: string, view: WebContentsView): void {

--- a/packages/desktop/src/main/fatalStartupError.ts
+++ b/packages/desktop/src/main/fatalStartupError.ts
@@ -41,12 +41,11 @@ function reportFatalDesktopError(
   error: unknown,
   options: { title: string; message: string; forceQuit?: boolean },
 ): void {
-  if (fatalStartupErrorReported) return;
-  fatalStartupErrorReported = true;
-
   const detail =
     error instanceof Error ? (error.stack ?? error.message) : String(error);
   console.error(`Fatal TeXRA desktop error:\n${detail}`);
+  if (fatalStartupErrorReported) return;
+  fatalStartupErrorReported = true;
 
   const showFailureDialog = (): void => {
     if (options.forceQuit) {

--- a/packages/desktop/src/main/fatalStartupError.ts
+++ b/packages/desktop/src/main/fatalStartupError.ts
@@ -1,6 +1,11 @@
 import { app, dialog } from 'electron';
 
 let fatalStartupErrorReported = false;
+let fatalDesktopShutdownRequested = false;
+
+export function isFatalDesktopShutdownRequested(): boolean {
+  return fatalDesktopShutdownRequested;
+}
 
 export function reportFatalStartupError(error: unknown): void {
   reportFatalDesktopError(error, {
@@ -22,7 +27,7 @@ export function installPostStartupRejectionHandler(): () => void {
       message: app.isReady()
         ? 'TeXRA hit an unrecoverable error after startup and must close.'
         : 'TeXRA hit a startup error before the desktop window was ready.',
-      forceExit: app.isReady(),
+      forceQuit: app.isReady(),
     });
   };
   process.on('unhandledRejection', report);
@@ -34,7 +39,7 @@ export function installPostStartupRejectionHandler(): () => void {
 
 function reportFatalDesktopError(
   error: unknown,
-  options: { title: string; message: string; forceExit?: boolean },
+  options: { title: string; message: string; forceQuit?: boolean },
 ): void {
   if (fatalStartupErrorReported) return;
   fatalStartupErrorReported = true;
@@ -44,7 +49,8 @@ function reportFatalDesktopError(
   console.error(`Fatal TeXRA desktop error:\n${detail}`);
 
   const showFailureDialog = (): void => {
-    if (options.forceExit) {
+    if (options.forceQuit) {
+      fatalDesktopShutdownRequested = true;
       void dialog
         .showMessageBox({
           type: 'error',
@@ -55,7 +61,7 @@ function reportFatalDesktopError(
         .catch((dialogError: unknown) => {
           console.error('Failed to display fatal TeXRA error:', dialogError);
         })
-        .finally(() => app.exit(1));
+        .finally(() => app.quit());
       return;
     }
     dialog.showErrorBox(

--- a/packages/desktop/src/main/fatalStartupError.ts
+++ b/packages/desktop/src/main/fatalStartupError.ts
@@ -3,6 +3,34 @@ import { app, dialog } from 'electron';
 let fatalStartupErrorReported = false;
 
 export function reportFatalStartupError(error: unknown): void {
+  reportFatalDesktopError(error, {
+    title: 'TeXRA failed to start',
+    message: 'TeXRA hit a startup error before the desktop window was ready.',
+  });
+}
+
+/**
+ * Installs the fatal post-startup rejection path. Unhandled main-process
+ * failures cannot safely continue with a partially-updated Electron state.
+ */
+export function installPostStartupRejectionHandler(): () => void {
+  const report = (error: unknown) => {
+    reportFatalDesktopError(error, {
+      title: 'TeXRA encountered a fatal error',
+      message: 'TeXRA hit an unrecoverable error after startup and must close.',
+    });
+  };
+  process.on('unhandledRejection', report);
+
+  return () => {
+    process.off('unhandledRejection', report);
+  };
+}
+
+function reportFatalDesktopError(
+  error: unknown,
+  options: { title: string; message: string },
+): void {
   if (fatalStartupErrorReported) return;
   fatalStartupErrorReported = true;
 
@@ -12,12 +40,8 @@ export function reportFatalStartupError(error: unknown): void {
 
   const showFailureDialog = () => {
     dialog.showErrorBox(
-      'TeXRA failed to start',
-      [
-        'TeXRA hit a startup error before the desktop window was ready.',
-        '',
-        detail,
-      ].join('\n'),
+      options.title,
+      [options.message, '', detail].join('\n'),
     );
     app.quit();
   };

--- a/packages/desktop/src/main/fatalStartupError.ts
+++ b/packages/desktop/src/main/fatalStartupError.ts
@@ -43,13 +43,26 @@ function reportFatalDesktopError(
     error instanceof Error ? (error.stack ?? error.message) : String(error);
   console.error(`Fatal TeXRA desktop error:\n${detail}`);
 
-  const showFailureDialog = () => {
+  const showFailureDialog = (): void => {
+    if (options.forceExit) {
+      void dialog
+        .showMessageBox({
+          type: 'error',
+          title: options.title,
+          message: options.message,
+          detail,
+        })
+        .catch((dialogError: unknown) => {
+          console.error('Failed to display fatal TeXRA error:', dialogError);
+        })
+        .finally(() => app.exit(1));
+      return;
+    }
     dialog.showErrorBox(
       options.title,
       [options.message, '', detail].join('\n'),
     );
-    if (options.forceExit) app.exit(1);
-    else app.quit();
+    app.quit();
   };
 
   if (app.isReady()) {

--- a/packages/desktop/src/main/fatalStartupError.ts
+++ b/packages/desktop/src/main/fatalStartupError.ts
@@ -16,8 +16,12 @@ export function reportFatalStartupError(error: unknown): void {
 export function installPostStartupRejectionHandler(): () => void {
   const report = (error: unknown) => {
     reportFatalDesktopError(error, {
-      title: 'TeXRA encountered a fatal error',
-      message: 'TeXRA hit an unrecoverable error after startup and must close.',
+      title: app.isReady()
+        ? 'TeXRA encountered a fatal error'
+        : 'TeXRA failed to start',
+      message: app.isReady()
+        ? 'TeXRA hit an unrecoverable error after startup and must close.'
+        : 'TeXRA hit a startup error before the desktop window was ready.',
     });
   };
   process.on('unhandledRejection', report);

--- a/packages/desktop/src/main/fatalStartupError.ts
+++ b/packages/desktop/src/main/fatalStartupError.ts
@@ -22,6 +22,7 @@ export function installPostStartupRejectionHandler(): () => void {
       message: app.isReady()
         ? 'TeXRA hit an unrecoverable error after startup and must close.'
         : 'TeXRA hit a startup error before the desktop window was ready.',
+      forceExit: app.isReady(),
     });
   };
   process.on('unhandledRejection', report);
@@ -33,7 +34,7 @@ export function installPostStartupRejectionHandler(): () => void {
 
 function reportFatalDesktopError(
   error: unknown,
-  options: { title: string; message: string },
+  options: { title: string; message: string; forceExit?: boolean },
 ): void {
   if (fatalStartupErrorReported) return;
   fatalStartupErrorReported = true;
@@ -47,7 +48,8 @@ function reportFatalDesktopError(
       options.title,
       [options.message, '', detail].join('\n'),
     );
-    app.quit();
+    if (options.forceExit) app.exit(1);
+    else app.quit();
   };
 
   if (app.isReady()) {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -51,8 +51,6 @@ import { normalizePlatform } from '@shared/constants/latexToolchain';
 import { registerAgentShutdownHandlers } from '@tools/agentCliSessionStores';
 import { killActiveRecording } from '@tools/media/audio';
 import { ephemeralTranscriptWarning, StreamLogStore } from '@transcript';
-import { debounce } from '@utils/core';
-import { DEBOUNCE_OPTIONS_MS } from '@utils/config/constants';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   readGitEnvironmentSummary,
@@ -119,7 +117,10 @@ import {
   type DesktopSupabaseAuthHost,
 } from './desktopSupabaseAuth.js';
 import { buildDesktopMenuTemplate } from './desktopMenuTemplate.js';
-import { reportFatalStartupError } from './fatalStartupError.js';
+import {
+  isFatalDesktopShutdownRequested,
+  reportFatalStartupError,
+} from './fatalStartupError.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeDesktopCrashReporting } from './desktopCrashReporting.js';
 import { initializeElectronPlatform } from './platform/index.js';
@@ -508,6 +509,10 @@ function createWindow(options: {
   // observes a dirty Monaco buffer and refuses the unload, so every close path
   // (quit, workspace switch, window close) asks here and nowhere else.
   window.webContents.on('will-prevent-unload', (event) => {
+    if (isFatalDesktopShutdownRequested()) {
+      event.preventDefault();
+      return;
+    }
     const response = dialog.showMessageBoxSync(window, {
       type: 'warning',
       buttons: ['Keep Editing', 'Discard Changes'],
@@ -1083,7 +1088,7 @@ function createWindow(options: {
     // here (so `disposed` flips immediately); the queue only orders when this
     // window's completion promise resolves, keeping a macOS dock-reopen from
     // discarding an earlier window's still-running cleanup.
-    const current = desktopDiffHost.dispose().catch(reportAsyncError);
+    const current = desktopDiffHost.dispose().catch(reportBackgroundError);
     pendingDesktopDiffHostDispose = diffHostDisposeQueue.add(() => current);
     if (mainWindow === window) {
       mainWindow = null;
@@ -1098,7 +1103,7 @@ function createWindow(options: {
         ?.then((execution) => execution.dispose())
         .catch((error: unknown) => {
           if (!(error instanceof Error && error.name === 'AbortError')) {
-            reportAsyncError(error);
+            reportBackgroundError(error);
           }
         });
     }
@@ -1115,7 +1120,7 @@ function createWindow(options: {
             workspaceRelaunch.selectedPath,
           );
         } catch (error) {
-          reportAsyncError(error);
+          reportBackgroundError(error);
         }
         // Consumed. The synchronous `window-all-closed` in this same turn has
         // already seen the pending value and deferred quitting; clearing here

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -432,7 +432,7 @@ function createWindow(options: {
           await shell.openExternal(DESKTOP_RELEASES_PAGE_URL);
         }
       },
-    }).catch(reportAsyncError);
+    }).catch(reportBackgroundError);
   }
   const previewHost = createDesktopPreviewHost({
     shell,
@@ -1000,6 +1000,7 @@ function createWindow(options: {
         ...state,
       }),
     onError: reportAsyncError,
+    onBlockedExternalUrl: reportBackgroundError,
   });
   const workspaceIpc = createDesktopWorkspaceIpc(
     { postToRenderer: postToRendererIfAlive },

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -51,6 +51,9 @@ import { normalizePlatform } from '@shared/constants/latexToolchain';
 import { registerAgentShutdownHandlers } from '@tools/agentCliSessionStores';
 import { killActiveRecording } from '@tools/media/audio';
 import { ephemeralTranscriptWarning, StreamLogStore } from '@transcript';
+import { debounce } from '@utils/core';
+import { DEBOUNCE_OPTIONS_MS } from '@utils/config/constants';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   readGitEnvironmentSummary,
   readRecentCommits,
@@ -301,10 +304,6 @@ function createWindow(options: {
     options.processSession,
     options.workspacePath,
   );
-  const reportAsyncError = (error: unknown) => console.error(error);
-  installDesktopNavigationPolicy(window.webContents, {
-    onAsyncError: reportAsyncError,
-  });
   const ipcRef: {
     current?: ReturnType<typeof installDesktopMainViewIpc>;
   } = {};
@@ -334,6 +333,20 @@ function createWindow(options: {
   const showErrorMessage = async (message: string) => {
     await dialog.showMessageBox(window, { message, type: 'error' });
   };
+  const reportAsyncError = (error: unknown) => {
+    console.error('Desktop asynchronous operation failed:', error);
+    void showErrorMessage(
+      `A desktop operation failed: ${toErrorMessage(error)}`,
+    ).catch((notificationError: unknown) => {
+      console.error(
+        'Failed to display desktop asynchronous operation error:',
+        notificationError,
+      );
+    });
+  };
+  installDesktopNavigationPolicy(window.webContents, {
+    onAsyncError: reportAsyncError,
+  });
   const showInfoMessage = async (message: string) => {
     await dialog.showMessageBox(window, { type: 'info', message });
   };

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -511,7 +511,6 @@ function createWindow(options: {
   window.webContents.on('will-prevent-unload', (event) => {
     if (isFatalDesktopShutdownRequested()) {
       pendingWorkspaceRelaunch = undefined;
-      continueQuitAfterWindowClose = undefined;
       event.preventDefault();
       return;
     }
@@ -574,7 +573,9 @@ function createWindow(options: {
     signInForRemoteAgentCatalog,
     showInfoMessage,
     showWarningMessage,
-    showErrorMessage,
+    showErrorMessage: async (message) => {
+      await showErrorMessage(message).catch(reportBackgroundError);
+    },
     // Recompute the onboarding funnel after a run completes so a user's first
     // successful run leaves the setup card without waiting for a restart
     // (the run lifecycle has already persisted firstRunDone). Mirrors the
@@ -1003,6 +1004,7 @@ function createWindow(options: {
       }),
     onError: reportAsyncError,
     onBlockedExternalUrl: reportBackgroundError,
+    onExternalOpenError: reportBackgroundError,
   });
   const workspaceIpc = createDesktopWorkspaceIpc(
     { postToRenderer: postToRendererIfAlive },

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -989,7 +989,7 @@ function createWindow(options: {
         sessionId,
         exitCode,
       }),
-    onError: reportAsyncError,
+    onError: reportBackgroundError,
   });
   const browserViews = createDesktopBrowserViews({
     getWindow: () => (window.isDestroyed() ? undefined : window),

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -944,7 +944,7 @@ function createWindow(options: {
       return { commits: [] as string[], isGitRepo: false };
     }
     return readRecentCommits(workspacePath, DESKTOP_RECENT_COMMIT_LIMIT, {
-      onError: reportAsyncError,
+      onError: reportBackgroundError,
     });
   };
   const getEnvironmentSummary = async () => {
@@ -954,7 +954,7 @@ function createWindow(options: {
     }
     return (
       (await readGitEnvironmentSummary(workspacePath, {
-        onError: reportAsyncError,
+        onError: reportBackgroundError,
       })) ?? EMPTY_DESKTOP_ENVIRONMENT_SUMMARY
     );
   };

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -344,6 +344,9 @@ function createWindow(options: {
       );
     });
   };
+  const reportBackgroundError = (error: unknown) => {
+    console.error('Desktop background operation failed:', error);
+  };
   installDesktopNavigationPolicy(window.webContents, {
     onAsyncError: reportAsyncError,
   });
@@ -796,7 +799,7 @@ function createWindow(options: {
           outDir: true,
           autoRevealExclude: true,
         }),
-        onDetectionError: reportAsyncError,
+        onDetectionError: reportBackgroundError,
       }),
       latexConfigPersistenceController: new LatexConfigPersistenceController(),
     },
@@ -812,7 +815,7 @@ function createWindow(options: {
         const execution = await getAgentExecution();
         return await execution.revealStream(streamId);
       } catch (error) {
-        if (!presentationAbort.signal.aborted) reportAsyncError(error);
+        if (!presentationAbort.signal.aborted) reportBackgroundError(error);
         return 'unavailable';
       }
     },

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -510,6 +510,8 @@ function createWindow(options: {
   // (quit, workspace switch, window close) asks here and nowhere else.
   window.webContents.on('will-prevent-unload', (event) => {
     if (isFatalDesktopShutdownRequested()) {
+      pendingWorkspaceRelaunch = undefined;
+      continueQuitAfterWindowClose = undefined;
       event.preventDefault();
       return;
     }

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
@@ -161,6 +161,9 @@ describe('desktop composition root and launch environment', () => {
     expect(indexSource).toContain(
       'installDesktopNavigationPolicy(window.webContents',
     );
+    expect(indexSource).toMatch(
+      /if \(isFatalDesktopShutdownRequested\(\)\) \{\s*pendingWorkspaceRelaunch = undefined;\s*continueQuitAfterWindowClose = undefined;\s*event\.preventDefault\(\);/u,
+    );
     expect(bootstrapSource).toMatch(
       /await import\('\.\/index\.js'\);\s*removeFatalStartupHandlers\(\);\s*installPostStartupRejectionHandler\(\);/u,
     );

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
@@ -162,7 +162,7 @@ describe('desktop composition root and launch environment', () => {
       'installDesktopNavigationPolicy(window.webContents',
     );
     expect(indexSource).toMatch(
-      /if \(isFatalDesktopShutdownRequested\(\)\) \{\s*pendingWorkspaceRelaunch = undefined;\s*continueQuitAfterWindowClose = undefined;\s*event\.preventDefault\(\);/u,
+      /if \(isFatalDesktopShutdownRequested\(\)\) \{\s*pendingWorkspaceRelaunch = undefined;\s*event\.preventDefault\(\);/u,
     );
     expect(bootstrapSource).toMatch(
       /await import\('\.\/index\.js'\);\s*removeFatalStartupHandlers\(\);\s*installPostStartupRejectionHandler\(\);/u,

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
@@ -36,6 +36,10 @@ function readDesktopPlatformIndex(): Promise<string> {
   return readFile(desktopSourcePath('main', 'platform', 'index.ts'), 'utf8');
 }
 
+function readDesktopBootstrap(): Promise<string> {
+  return readFile(desktopSourcePath('main', 'bootstrap.ts'), 'utf8');
+}
+
 // Asserts each needle first occurs after the anchor, in the given order.
 function expectOrderedAfter(
   source: string,
@@ -140,6 +144,26 @@ describe('desktop composition root and launch environment', () => {
     expect(initPlatformFiles).toEqual([
       'packages/desktop/src/main/platform/index.ts',
     ]);
+  });
+
+  it('surfaces desktop async failures and terminates after post-startup rejections', async () => {
+    const [indexSource, bootstrapSource] = await Promise.all([
+      readDesktopMainIndex(),
+      readDesktopBootstrap(),
+    ]);
+
+    expect(indexSource).toContain(
+      "console.error('Desktop asynchronous operation failed:', error);",
+    );
+    expect(indexSource).toContain(
+      '`A desktop operation failed: ${toErrorMessage(error)}`',
+    );
+    expect(indexSource).toContain(
+      'installDesktopNavigationPolicy(window.webContents',
+    );
+    expect(bootstrapSource).toMatch(
+      /await import\('\.\/index\.js'\);\s*removeFatalStartupHandlers\(\);\s*installPostStartupRejectionHandler\(\);/u,
+    );
   });
 
   it('repairs PATH before platform services and bundled agents are initialized', async () => {

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
@@ -116,7 +116,7 @@ describe('desktop composition root and launch environment', () => {
     );
     expect(source).not.toContain('createDesktopDiffHostDisposeQueue');
     expectOrderedAfter(source, "window.once('closed'", [
-      'desktopDiffHost.dispose().catch(reportAsyncError)',
+      'desktopDiffHost.dispose().catch(reportBackgroundError)',
       'diffHostDisposeQueue.add(() => current)',
     ]);
   });


### PR DESCRIPTION
## Summary

- surface desktop main-process async failures with the existing user-visible error dialog and desktop log
- terminate after surfacing post-startup unhandled rejections
- retain the injected async-error hooks and cover the composition-root wiring

Closes #10757

## Root cause

Desktop IPC and background rejection hooks converged on `console.error`, leaving users without a visible failure surface. Post-startup unhandled rejections had no explicit Electron fatal path.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts`
- `corepack pnpm run typecheck:desktop`
- `corepack pnpm exec eslint packages/desktop/src/main/bootstrap.ts packages/desktop/src/main/fatalStartupError.ts packages/desktop/src/main/index.ts src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts`

## R6 net-element accounting

Production: +47/-10 lines. The increase is the required loudness gate: one shared fatal reporter plus the user-visible async sink; no new parallel notification abstraction was introduced. Test wiring coverage: +24 lines.