### PR TITLE
fix(extension): surface unhandled host failures

### DIFF
--- a/packages/extension/src/common/webview/BaseViewMessageHandler.ts
+++ b/packages/extension/src/common/webview/BaseViewMessageHandler.ts
@@ -146,6 +146,9 @@ export abstract class BaseViewMessageHandler<
         this.log.error('Error handling message', {
           data: error,
         });
+        void vscode.window.showErrorMessage(
+          `TeXRA could not handle a ${this.viewName} message. See the TeXRA output for details.`,
+        );
       }
     });
 

--- a/packages/extension/src/common/webview/BaseViewMessageHandler.ts
+++ b/packages/extension/src/common/webview/BaseViewMessageHandler.ts
@@ -94,6 +94,15 @@ export abstract class BaseViewMessageHandler<
     this._activeView = webviewView;
   }
 
+  /** Keep a failed notification from becoming an unhandled host rejection. */
+  private reportNotificationFailure(notification: PromiseLike<unknown>): void {
+    void notification.then(undefined, (error: unknown) => {
+      this.log.error('Failed to display message notification', {
+        data: error,
+      });
+    });
+  }
+
   /** Post a message to the tracked active view, if one is available. */
   protected postToActiveView(message: unknown): void {
     this.getActiveView()?.webview.postMessage(message);
@@ -141,13 +150,17 @@ export abstract class BaseViewMessageHandler<
         // feedback (toast), not a silent drop or an error-level log.
         unsupported = true;
         this.log.debug(error.message);
-        void vscode.window.showInformationMessage(error.reason);
+        this.reportNotificationFailure(
+          vscode.window.showInformationMessage(error.reason),
+        );
       } else {
         this.log.error('Error handling message', {
           data: error,
         });
-        void vscode.window.showErrorMessage(
-          `TeXRA could not handle a ${this.viewName} message. See the TeXRA output for details.`,
+        this.reportNotificationFailure(
+          vscode.window.showErrorMessage(
+            `TeXRA could not handle a ${this.viewName} message. See the TeXRA output for details.`,
+          ),
         );
       }
     });

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -121,6 +121,32 @@ let apiKeyStatusBarItem: vscode.StatusBarItem | undefined;
 // handlers registered by a second activate() in the same process.
 let lifecycleHost: LifecycleHost | undefined;
 
+function installUnhandledRejectionSurface(
+  subscriptions: vscode.Disposable[],
+): void {
+  const report = (error: unknown) => {
+    log.error('Unhandled extension-host rejection', { data: error });
+    void vscode.window
+      .showErrorMessage(
+        `TeXRA encountered an unrecoverable error: ${toErrorMessage(error)}`,
+      )
+      .then(undefined, (notificationError: unknown) => {
+        log.error('Failed to display unhandled rejection error', {
+          data: notificationError,
+        });
+      });
+    // Installing an unhandled-rejection listener otherwise suppresses Node's
+    // default fatal path. The host must not continue after an unowned failure.
+    setImmediate(() => {
+      throw error;
+    });
+  };
+  process.on('unhandledRejection', report);
+  subscriptions.push({
+    dispose: () => process.off('unhandledRejection', report),
+  });
+}
+
 async function refreshApiKeyStatus() {
   if (!apiKeyStatusBarItem) {
     return;
@@ -147,6 +173,7 @@ async function refreshApiKeyStatus() {
 }
 
 export async function activate(context: vscode.ExtensionContext) {
+  installUnhandledRejectionSurface(context.subscriptions);
   const workspaceFolders = vscode.workspace.workspaceFolders;
 
   if (!workspaceFolders || workspaceFolders.length !== 1) {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -69,6 +69,7 @@ import { VscodeSecrets } from '@frontend/vscode/vscodeSecrets';
 import { createExtensionTexraConfig } from '@frontend/vscode/texraConfig';
 import { createTexraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { createLog, setOutputChannelFactory } from '@logger/logUtils';
+import { redactSecrets } from '@logger/redaction';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
 import { invalidateRuntimeModelRegistry } from '@model/runtimeModelRegistry';
@@ -105,7 +106,7 @@ import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 import { setInlineCommentProvider } from '@tools/comment/InlineCommentTool';
 import { ephemeralTranscriptWarning, StreamLogStore } from '@transcript';
 import { StorageFS } from '@utils/files/storageFS';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local file imports
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
@@ -128,7 +129,7 @@ function installUnhandledRejectionSurface(
     log.error('Unhandled extension-host rejection', { data: error });
     void vscode.window
       .showErrorMessage(
-        `TeXRA encountered an unrecoverable error: ${toErrorMessage(error)}`,
+        `The extension host encountered an unrecoverable error: ${redactSecrets(toErrorMessage(error))}`,
       )
       .then(undefined, (notificationError: unknown) => {
         log.error('Failed to display unhandled rejection error', {
@@ -138,7 +139,7 @@ function installUnhandledRejectionSurface(
     // Installing an unhandled-rejection listener otherwise suppresses Node's
     // default fatal path. The host must not continue after an unowned failure.
     setImmediate(() => {
-      throw error;
+      throw ensureError(error);
     });
   };
   process.on('unhandledRejection', report);

--- a/src/test-kernel/webview/BaseViewMessageHandler.vitest.ts
+++ b/src/test-kernel/webview/BaseViewMessageHandler.vitest.ts
@@ -8,7 +8,7 @@ import { BaseViewMessageHandler } from '@common/webview/BaseViewMessageHandler';
 import type * as vscode from 'vscode';
 
 const mocks = vi.hoisted(() => ({
-  showErrorMessage: vi.fn(),
+  showErrorMessage: vi.fn(async () => undefined),
   logError: vi.fn(),
 }));
 
@@ -31,7 +31,7 @@ class TestMessageHandler extends BaseViewMessageHandler {
       { command: 'test' },
       { webview: {} } as vscode.WebviewView,
       (_message, _handlers, onError) => {
-        onError(new Error('handler failure'));
+        onError?.(new Error('handler failure'));
         return true;
       },
       {},

--- a/src/test-kernel/webview/BaseViewMessageHandler.vitest.ts
+++ b/src/test-kernel/webview/BaseViewMessageHandler.vitest.ts
@@ -1,0 +1,56 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - webview base class
+import { BaseViewMessageHandler } from '@common/webview/BaseViewMessageHandler';
+
+// Type imports
+import type * as vscode from 'vscode';
+
+const mocks = vi.hoisted(() => ({
+  showErrorMessage: vi.fn(),
+  logError: vi.fn(),
+}));
+
+vi.mock('vscode', () => ({
+  window: { showErrorMessage: mocks.showErrorMessage },
+}));
+
+vi.mock('@logger/logUtils', () => ({
+  createLog: vi.fn(() => ({
+    debug: vi.fn(),
+    error: mocks.logError,
+    info: vi.fn(),
+    warn: vi.fn(),
+  })),
+}));
+
+class TestMessageHandler extends BaseViewMessageHandler {
+  public async handleMessage(): Promise<void> {
+    await this.dispatchInbound(
+      { command: 'test' },
+      { webview: {} } as vscode.WebviewView,
+      (_message, _handlers, onError) => {
+        onError(new Error('handler failure'));
+        return true;
+      },
+      {},
+    );
+  }
+}
+
+describe('BaseViewMessageHandler', () => {
+  it('surfaces unexpected inbound-message failures to the user', async () => {
+    const handler = new TestMessageHandler('TestView');
+
+    await handler.handleMessage();
+
+    expect(mocks.logError).toHaveBeenCalledWith(
+      'Error handling message',
+      expect.objectContaining({ data: expect.any(Error) }),
+    );
+    expect(mocks.showErrorMessage).toHaveBeenCalledWith(
+      'TeXRA could not handle a TestView message. See the TeXRA output for details.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- show a VS Code error notification for unexpected webview-dispatch failures while retaining structured log details
- surface extension-host unhandled rejections, then rethrow so the listener does not suppress Node’s fatal path
- add narrow coverage for the view-dispatch error surface

Closes #10758

## Root cause

The shared webview dispatcher logged unexpected handler failures without notifying the user, and the extension host had no explicit unhandled-rejection behavior. A notification-only process listener would be worse because it suppresses Node’s default fatal behavior.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/webview/BaseViewMessageHandler.vitest.ts`
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm exec eslint packages/extension/src/common/webview/BaseViewMessageHandler.ts packages/extension/src/extension.ts src/test-kernel/webview/BaseViewMessageHandler.vitest.ts`

## R6 net-element accounting

Production: +30/-0 lines. The increase is the required loudness gate: one process-level rejection surface and one existing VS Code error notification call; no parallel error framework was added. Test coverage: +56/-0 lines for the durable shared-dispatch contract.