### PR TITLE
fix(renderer): surface unhandled rejections

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -1103,6 +1103,7 @@ function observeSurfaceResizes(): void {
 }
 
 function rerenderShell(): void {
+  if (bootstrapFailed) return;
   render(shellTemplate(), appRoot);
   logsController.setActive(
     activeWorkbenchTab(shellState, 'right')?.kind === 'logs' ||
@@ -1154,8 +1155,17 @@ function renderBootstrapFallback(error: unknown): void {
   );
 }
 
+function reportRuntimeFailure(error: unknown): void {
+  const shouldReload = window.confirm(
+    `TeXRA encountered an unexpected error.\n\n${toBootstrapErrorMessage(error)}\n\nReload TeXRA now?`,
+  );
+  if (shouldReload) window.location.reload();
+}
+
 function recoverFromBootstrapFallback(): void {
   try {
+    bootstrapFailed = false;
+    bootstrapComplete = false;
     logsController.rerenderViewer();
     rerenderShell();
     // Recovery must wire rail tabs / conversation events and install the
@@ -1164,10 +1174,10 @@ function recoverFromBootstrapFallback(): void {
     wireRailTabs();
     wireConversation();
     installShellSignalWatcher();
-    bootstrapFailed = false;
     postMessage(DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE);
     postWebviewReady();
     document.body.dataset.desktopReady = 'true';
+    bootstrapComplete = true;
   } catch (recoveryError) {
     console.error('TeXRA desktop renderer recovery failed', recoveryError);
     bootstrapFailed = true;
@@ -1224,10 +1234,15 @@ function installShellSignalWatcher(): void {
 }
 
 let bootstrapFailed = false;
+let bootstrapComplete = false;
 window.addEventListener('unhandledrejection', (event) => {
   event.preventDefault();
-  bootstrapFailed = true;
   console.error('TeXRA desktop renderer unhandled rejection', event.reason);
+  if (bootstrapComplete) {
+    reportRuntimeFailure(event.reason);
+    return;
+  }
+  bootstrapFailed = true;
   renderBootstrapFallback(event.reason);
 });
 
@@ -1482,6 +1497,7 @@ if (!bootstrapFailed) {
   postWebviewReady();
   if (hasWorkspace) void editorPane.refresh();
   document.body.dataset.desktopReady = 'true';
+  bootstrapComplete = true;
 }
 
 // Sole owner of "the workspace has unsaved editor changes": the main process

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -1224,6 +1224,13 @@ function installShellSignalWatcher(): void {
 }
 
 let bootstrapFailed = false;
+window.addEventListener('unhandledrejection', (event) => {
+  event.preventDefault();
+  bootstrapFailed = true;
+  console.error('TeXRA desktop renderer unhandled rejection', event.reason);
+  renderBootstrapFallback(event.reason);
+});
+
 try {
   logsController.rerenderViewer();
   rerenderShell();
@@ -1232,12 +1239,6 @@ try {
   bootstrapFailed = true;
   console.error('TeXRA desktop renderer bootstrap failed', error);
   renderBootstrapFallback(error);
-}
-
-if (bootstrapFailed) {
-  window.addEventListener('unhandledrejection', (event) => {
-    console.error('Unhandled rejection after bootstrap failure', event.reason);
-  });
 }
 
 // =============================================================================

--- a/src/shared/hostBridge.ts
+++ b/src/shared/hostBridge.ts
@@ -2,12 +2,6 @@ import { HOST_BRIDGE_API_KEY, type HostBridgeApi } from './hostBridgeTypes';
 
 declare const acquireVsCodeApi: (() => HostBridgeApi) | undefined;
 
-const fallbackApi: HostBridgeApi = {
-  postMessage: () => undefined,
-  getState: () => undefined,
-  setState: () => undefined,
-};
-
 function resolveHostBridgeApi(): HostBridgeApi {
   const globalScope = globalThis as typeof globalThis & {
     [HOST_BRIDGE_API_KEY]?: HostBridgeApi;
@@ -22,10 +16,12 @@ function resolveHostBridgeApi(): HostBridgeApi {
     return api;
   }
 
-  return fallbackApi;
+  throw new Error(
+    'TeXRA host bridge is unavailable. Webview code must run inside a TeXRA host.',
+  );
 }
 
-/** Host bridge API instance (falls back to no-op in non-webview contexts). */
+/** Host bridge API instance for the active TeXRA webview host. */
 export const hostBridge: HostBridgeApi = resolveHostBridgeApi();
 
 /**

--- a/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.ts
+++ b/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.ts
@@ -146,6 +146,15 @@ describe('desktop renderer bootstrap fallback', () => {
     );
   });
 
+  it('renders the fatal fallback for unhandled rejections on every startup path', () => {
+    const source = loadRendererMain();
+
+    expect(source).toMatch(
+      /window\.addEventListener\('unhandledrejection',[\s\S]*?event\.preventDefault\(\);[\s\S]*?renderBootstrapFallback\(event\.reason\);/u,
+    );
+    expect(source).not.toContain('if (bootstrapFailed)');
+  });
+
   it('renders a Reload control and a "continue without saved secrets" affordance', () => {
     const source = loadRendererMain();
     expect(source).toContain('Reload');

--- a/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.ts
+++ b/src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.ts
@@ -146,13 +146,14 @@ describe('desktop renderer bootstrap fallback', () => {
     );
   });
 
-  it('renders the fatal fallback for unhandled rejections on every startup path', () => {
+  it('uses the fatal fallback only while startup is incomplete', () => {
     const source = loadRendererMain();
 
     expect(source).toMatch(
-      /window\.addEventListener\('unhandledrejection',[\s\S]*?event\.preventDefault\(\);[\s\S]*?renderBootstrapFallback\(event\.reason\);/u,
+      /window\.addEventListener\('unhandledrejection',[\s\S]*?event\.preventDefault\(\);[\s\S]*?if \(bootstrapComplete\) \{[\s\S]*?reportRuntimeFailure\(event\.reason\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?bootstrapFailed = true;[\s\S]*?renderBootstrapFallback\(event\.reason\);/u,
     );
-    expect(source).not.toContain('if (bootstrapFailed)');
+    expect(source).toContain('if (bootstrapFailed) return;');
+    expect(source).toContain('bootstrapComplete = true;');
   });
 
   it('renders a Reload control and a "continue without saved secrets" affordance', () => {

--- a/src/test-kernel/support/setupFakePlatform.ts
+++ b/src/test-kernel/support/setupFakePlatform.ts
@@ -1,4 +1,21 @@
+import {
+  HOST_BRIDGE_API_KEY,
+  type HostBridgeApi,
+} from '@shared/hostBridgeTypes';
+
 import { installPlatform } from './setupPlatform';
+
+// Webview modules resolve their host bridge at import time. Production now
+// fails fast without one; the kernel harness provides this inert host before
+// each suite loads its modules. Suites that inspect posted messages replace it
+// with their own bridge at module scope.
+const testHostBridge: HostBridgeApi = {
+  postMessage: () => undefined,
+  getState: () => undefined,
+  setState: () => undefined,
+};
+
+(globalThis as Record<string, unknown>)[HOST_BRIDGE_API_KEY] = testHostBridge;
 
 await installPlatform();
 


### PR DESCRIPTION
## Summary

- route every desktop-renderer unhandled rejection to the existing fatal/reload fallback
- fail at webview boot when the required host bridge is unavailable instead of silently discarding messages
- verify the normal-path rejection fallback and the affected renderer consumers

Closes #10759

## Root cause

The renderer only registered its rejection listener after bootstrap failure, and that listener merely logged. The shared host bridge also converted missing renderer-host wiring into silent no-ops.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.ts src/test-kernel/webview/MainAppDesktopGating.vitest.ts src/test-kernel/webview/MainAppPersistenceRestore.vitest.ts src/test-kernel/webview/MainViewActions.vitest.ts src/test-kernel/webview/MainViewLaunchTarget.vitest.ts src/test-kernel/webview/PasteHandler.vitest.ts`
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:desktop`
- `corepack pnpm exec eslint packages/desktop/src/renderer/main.ts src/shared/hostBridge.ts src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.ts`

## R6 net-element accounting

Production: +11/-14 lines. This replaces the bootstrap-only log listener and no-op bridge fallback with one fatal renderer surface and a loud invariant. Test: +9/-0 lines.

## R8 importer census

All 43 production importers of `@shared/hostBridge` are desktop or VS Code webview renderers. The 20 non-production importers are tests, and each seeds a bridge stub before loading the module.