### PR TITLE
docs(runtime): clarify resume admission fallback

### DIFF
--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -212,9 +212,10 @@ export async function resolveAndResumeStream(
     return true;
   } catch (error) {
     if (isCancellationRequested()) return false;
-    // A workflow resume that loses the admission race is an expected
-    // cancellation, not a resume failure. Tool-use already classifies this
-    // same error as a silent `false`; the workflow branch must match it.
+    // Shipped hosts derive admission and cancellation from the same latch, so
+    // the check above is their active path when a workflow loses the race.
+    // Keep the explicit classification as defense in depth for a future host
+    // that supplies admission without the optional cancellation port.
     if (error instanceof ResumeAdmissionCancelledError) return false;
     try {
       await ports.reportFailure?.(streamId, error);


### PR DESCRIPTION
## Summary

Clarify the workflow-resume catch comment so it accurately distinguishes the shipped-host cancellation latch from the explicit exception guard.

Closes #10771.

## Issue acceptance gates

- State that shipped hosts use the shared admission/cancellation latch as the active mechanism.
- State that `ResumeAdmissionCancelledError` classification is defense in depth for a future host that omits the optional cancellation port.
- Preserve runtime behavior unchanged.

## Single source of truth

`resolveAndResumeStream` remains the sole workflow-resume classification boundary; this PR only corrects its local explanation.

## Duplication and abstraction budget

No new abstraction or duplication. One inaccurate three-line comment is replaced in place.

## Net elements (R6)

- 1 file modified
- +4 / -3 lines
- no exports, classes, interfaces, enums, or runtime elements added

## Consumer counts (R8)

n/a — no emit path, export, or runtime behavior changes.

## Host impact

Extension: Documentation-only clarification; no behavior change.

Desktop: Documentation-only clarification; no behavior change.

CLI: Documentation-only clarification; no behavior change.

## Scheduled refactoring

None.

## Validation

- `npx prettier --check src/agent/runtime/resolveAndResumeStream.ts`
- `git diff --check`
- `npm run typecheck:workspace`
- `npm run lint`
- Tests not run because only a source comment changed.
