### PR TITLE
docs: record V4 admission-port rationale

### DIFF
--- a/docs/proposals/2026-08-15-cross-host-consolidation.md
+++ b/docs/proposals/2026-08-15-cross-host-consolidation.md
@@ -501,7 +501,10 @@ login` does not sign in the GUI hosts and vice-versa. Ruling: is
   `!session.transcripts.has(streamId)`, so a stream re-created under the
   same id _un-cancelled_ a resume; (d) double-toast (fixed by C11).
   **Ruling + landed shape:** each attempt owns one monotone host-cancellation
-  latch. The extension latches observed transcript absence
+  latch. The proposed shared default was rejected because cancellation is a
+  host-owned lifecycle fact assembled from different signals; a core default
+  would either duplicate host policy or silently weaken it, so the monotone
+  `isCancellationRequested` port remains optional. The extension latches observed transcript absence
   (`resumeFromResumeData.ts:35-46`) and forwards the same latch/guard to both
   resume branches (`:82-102`); desktop latches host detach + transcript
   absence + authoritative-stream absence (`desktopAgentResume.ts:72-94`); the


### PR DESCRIPTION
## Summary

Complete the V4 resume-admission ruling by recording why the proposed shared-default cancellation port was rejected.

Closes #10772.

## Issue acceptance gates

- Record that resume cancellation is a host-owned lifecycle fact assembled from host-specific signals.
- Explain that a core default would duplicate host policy or silently weaken it.
- Preserve the landed optional, monotone `isCancellationRequested` port shape.

## Single source of truth

The V4 ruling in `docs/proposals/2026-08-15-cross-host-consolidation.md` remains the decision record for this cross-host resume-admission shape.

## Duplication and abstraction budget

No implementation or abstraction change. The missing rationale is added directly to the existing ruling.

## Net elements (R6)

- 1 documentation file modified
- +4 / -1 lines
- no runtime elements added

## Consumer counts (R8)

n/a — no export or emit path changes.

## Host impact

Extension: Documentation only.

Desktop: Documentation only.

CLI: Documentation only.

## Scheduled refactoring

None.

## Validation

- `npx prettier --check docs/proposals/2026-08-15-cross-host-consolidation.md`
- `npm run check:guidance-refs`
- `git diff --check`
- Tests not run because this changes only a decision-record paragraph.
