### PR TITLE
refactor(auth): bind complete service loggers

### DIFF
--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -52,6 +52,13 @@ export interface SupabaseSessionCoordinatorOptions {
   log?: SupabaseSessionLog;
 }
 
+const NOOP_SUPABASE_SESSION_LOG: Required<SupabaseSessionLog> = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
 interface StableSessionSnapshot {
   session: SupabaseSession | null;
   version: number;
@@ -68,6 +75,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   private lastStoredSessionVersion = 0;
   private lastRefreshFailure: SessionRefreshFailure | null = null;
   private readonly sessionMutex = new Mutex();
+  private readonly log: Required<SupabaseSessionLog>;
 
   /**
    * Expiry (ms since epoch) of the session this coordinator last read or
@@ -77,7 +85,14 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
    */
   private tokenExpiresAt: number | null = null;
 
-  constructor(private readonly options: SupabaseSessionCoordinatorOptions) {}
+  constructor(private readonly options: SupabaseSessionCoordinatorOptions) {
+    this.log = {
+      debug: options.log?.debug ?? NOOP_SUPABASE_SESSION_LOG.debug,
+      info: options.log?.info ?? NOOP_SUPABASE_SESSION_LOG.info,
+      warn: options.log?.warn ?? NOOP_SUPABASE_SESSION_LOG.warn,
+      error: options.log?.error ?? NOOP_SUPABASE_SESSION_LOG.error,
+    };
+  }
 
   async whenReady(): Promise<void> {
     await this.options.whenReady();
@@ -87,7 +102,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     const versionBeforeLoad = this.sessionMutationVersion;
     const session = parseStoredSupabaseSession(
       await this.options.storage.get(),
-      { logSource: 'SupabaseSession', warn: this.options.log?.warn },
+      { logSource: 'SupabaseSession', warn: this.log.warn },
     );
     // A mutation that committed during the read owns the newer expiry; this
     // read observed the superseded session and must not overwrite it.
@@ -179,7 +194,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
         return this.lastRefreshFailure === 'invalid' ? 'invalid' : 'transient';
       }
     } catch (error) {
-      this.options.log?.error?.(
+      this.log.error(
         'SupabaseSession',
         `Error classifying stored session: ${toErrorMessage(error)}`,
       );
@@ -275,7 +290,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
       )
       .catch((error) => {
         this.lastRefreshFailure = 'transient';
-        this.options.log?.error?.(
+        this.log.error(
           'SupabaseSession',
           `Error refreshing session: ${toErrorMessage(error)}`,
         );
@@ -319,14 +334,14 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
         forceRefresh ||
         timeUntilExpiry < this.options.tokenRefreshThresholdMs
       ) {
-        this.options.log?.info?.(
+        this.log.info(
           'SupabaseSession',
           `Token expires in ${Math.round(timeUntilExpiry / 1000)}s, refreshing proactively`,
         );
         const refreshed = await this.refreshSession(session, version);
         if (refreshed) return refreshed;
         if (forceRefresh || timeUntilExpiry <= 0) {
-          this.options.log?.warn?.(
+          this.log.warn(
             'SupabaseSession',
             forceRefresh
               ? 'Force refresh requested but refresh failed, returning null'
@@ -340,7 +355,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
       return session;
     } catch (error) {
       this.lastRefreshFailure = 'transient';
-      this.options.log?.error?.(
+      this.log.error(
         'SupabaseSession',
         `Error loading fresh session: ${toErrorMessage(error)}`,
       );
@@ -393,10 +408,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
 
     await this.storeSession(refreshed);
     if (refreshed.useCustomRefresh) {
-      this.options.log?.info?.(
-        'SupabaseSession',
-        'Token refreshed via custom endpoint',
-      );
+      this.log.info('SupabaseSession', 'Token refreshed via custom endpoint');
     }
     return this.isCurrentStoredSession(refreshed)
       ? refreshed
@@ -429,14 +441,14 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
 
     if (!response.ok) {
       this.lastRefreshFailure = classifyAuthFailureStatus(response.status);
-      this.options.log?.warn?.(
+      this.log.warn(
         'SupabaseSession',
         `Token refresh failed: ${response.status}`,
       );
       return null;
     }
 
-    const data = await parseTokenExchangeResponse(response, this.options.log);
+    const data = await parseTokenExchangeResponse(response, this.log);
     this.lastRefreshFailure = null;
     return toStorableSupabaseSession(data, {
       fallbackLabel: session.account.label,

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -28,9 +28,14 @@ import {
 import type { TierService } from './TierService';
 
 interface ServerSideKeyLogger {
-  error?(message: string, options?: { data?: unknown }): void;
-  info?(message: string, options?: { data?: unknown }): void;
+  error(message: string, options?: { data?: unknown }): void;
+  info(message: string, options?: { data?: unknown }): void;
 }
+
+const NOOP_SERVER_SIDE_KEY_LOGGER: ServerSideKeyLogger = {
+  error: () => undefined,
+  info: () => undefined,
+};
 
 /**
  * When the last access fetch was anonymous (dead session), the authenticated
@@ -145,7 +150,7 @@ export class ServerSideKeyService {
     private readonly baseUrl: string,
     private readonly tierService: TierService,
     private readonly globalState: StateStore | null = null,
-    private readonly logger: ServerSideKeyLogger = {},
+    private readonly logger: ServerSideKeyLogger = NOOP_SERVER_SIDE_KEY_LOGGER,
     private readonly notifyIncludedModelAccessChanged: (
       enabled: boolean,
     ) => void = () => {},
@@ -221,7 +226,7 @@ export class ServerSideKeyService {
       try {
         this.notifyIncludedModelAccessChanged(value);
       } catch (error) {
-        this.logger.error?.(`Event listener failed: ${toErrorMessage(error)}`);
+        this.logger.error(`Event listener failed: ${toErrorMessage(error)}`);
       }
     }
   }
@@ -269,7 +274,7 @@ export class ServerSideKeyService {
     } catch (error) {
       // Denied by error (auth/network failure), not by policy — log so the two
       // are distinguishable.
-      this.logger.error?.(
+      this.logger.error(
         `Access check failed, treating as denied: ${toErrorMessage(error)}`,
       );
       return { hasAccess: false, userTier: null };
@@ -342,10 +347,10 @@ export class ServerSideKeyService {
       let accessGranted = accessStatus.hasAccess && providers.length > 0;
 
       if (this.tierService.isAccessExpired()) {
-        this.logger.info?.('User access has expired');
+        this.logger.info('User access has expired');
         accessGranted = false;
       } else if (!hasFullAccess && tierConfig === null) {
-        this.logger.info?.(
+        this.logger.info(
           'Tier config unavailable for non-Ultra user, denying access',
         );
         accessGranted = false;
@@ -382,7 +387,7 @@ export class ServerSideKeyService {
         this.tierService.isQuotaExceeded()
       ) {
         this.quotaFlipApplied = true;
-        this.logger.info?.(
+        this.logger.info(
           'Relay quota exhausted; switching useIncludedModelAccess off',
         );
         // Await so the persisted toggle state, the cleared cache, and

--- a/src/auth/serverKeys/TierService.ts
+++ b/src/auth/serverKeys/TierService.ts
@@ -38,10 +38,16 @@ import {
 } from './tierTypes';
 
 interface TierServiceLogger {
-  warn?(message: string, options?: { data?: unknown }): void;
-  error?(message: string, options?: { data?: unknown }): void;
-  info?(message: string, options?: { data?: unknown }): void;
+  warn(message: string, options?: { data?: unknown }): void;
+  error(message: string, options?: { data?: unknown }): void;
+  info(message: string, options?: { data?: unknown }): void;
 }
+
+const NOOP_TIER_SERVICE_LOGGER: TierServiceLogger = {
+  warn: () => undefined,
+  error: () => undefined,
+  info: () => undefined,
+};
 
 /** Cache slot key — auth and anonymous responses never share a slot. */
 type TierCacheKey = 'auth' | 'anon';
@@ -103,7 +109,7 @@ export class TierService {
    */
   constructor(
     private readonly baseUrl: string,
-    private readonly logger: TierServiceLogger = {},
+    private readonly logger: TierServiceLogger = NOOP_TIER_SERVICE_LOGGER,
   ) {
     this.configCache = new LRUCache<
       TierCacheKey,
@@ -128,7 +134,7 @@ export class TierService {
           this.spendingStatus = result.spendingStatus;
           this.spendingStatusError = result.spendingStatusError;
           if (result.spendingStatusError) {
-            this.logger.warn?.('Relay spend check failed', {
+            this.logger.warn('Relay spend check failed', {
               data: {
                 failureReason:
                   result.spendingStatusError.failureReason ?? 'unknown reason',
@@ -175,7 +181,7 @@ export class TierService {
     if (raw == null) return null;
     const parsed = schema.safeParse(raw);
     if (parsed.success) return parsed.data;
-    this.logger.error?.(
+    this.logger.error(
       `Invalid ${label} payload: ${z.prettifyError(parsed.error)}`,
     );
     return null;
@@ -214,7 +220,7 @@ export class TierService {
       // A sign-out (clearCache) aborts the request; that is expected, so stay
       // quiet. Genuine network failures keep the previous error log.
       if (!signal.aborted) {
-        this.logger.error?.(
+        this.logger.error(
           `Error fetching tier config: ${toErrorMessage(error)}`,
         );
       }
@@ -223,11 +229,9 @@ export class TierService {
 
     if (!response.ok) {
       if (response.status === 404) {
-        this.logger.info?.(
-          'Tier-config endpoint not available, using defaults',
-        );
+        this.logger.info('Tier-config endpoint not available, using defaults');
       } else {
-        this.logger.error?.(`Failed to fetch tier config: ${response.status}`);
+        this.logger.error(`Failed to fetch tier config: ${response.status}`);
       }
       throw new Error(`tier-config request failed: HTTP ${response.status}`);
     }
@@ -236,7 +240,7 @@ export class TierService {
     try {
       data = await response.json();
     } catch (error) {
-      this.logger.error?.(
+      this.logger.error(
         `Failed to parse tier config JSON: ${toErrorMessage(error)}`,
       );
       throw error;
@@ -265,7 +269,7 @@ export class TierService {
 
     const parsed = TierModelConfigSchema.safeParse(data);
     if (!parsed.success) {
-      this.logger.error?.(
+      this.logger.error(
         `Invalid tier config response: ${z.prettifyError(parsed.error)}`,
       );
       return { config: null, userStatus, spendingStatus, spendingStatusError };

--- a/src/test-kernel/auth/TierService.vitest.ts
+++ b/src/test-kernel/auth/TierService.vitest.ts
@@ -268,7 +268,11 @@ describe('TierService', () => {
       }),
     );
     const warn = vi.fn();
-    const service = new TierService('https://example.test', { warn });
+    const service = new TierService('https://example.test', {
+      warn,
+      error: vi.fn(),
+      info: vi.fn(),
+    });
 
     expect(await service.getConfig('token')).not.toBeNull();
 


### PR DESCRIPTION
## Summary

- bind complete no-op or host loggers once when auth services are constructed
- remove optional logger dispatch throughout server-key, tier, and Supabase session services
- preserve optional public host logger inputs by normalizing partial loggers at the boundary

Closes #10766

## Validation

- `corepack pnpm exec vitest run src/test-kernel/auth/ServerSideKeyService.vitest.ts src/test-kernel/auth/TierService.vitest.ts src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts`
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm exec eslint src/auth/serverKeys/ServerSideKeyService.ts src/auth/serverKeys/TierService.ts src/auth/SupabaseSession.ts`

## R6 net-element accounting

Production: +55/-34 lines. The additions are three construction-time no-op bindings plus a partial-logger normalization; they eliminate 21 optional dispatch branches without widening public host interfaces.

## R8

Confirmed no remaining `this.logger?.` or `this.options.log?.` method dispatches in the three service implementations.