### PR TITLE
refactor(exec): normalize output to strings

### DIFF
--- a/packages/cli/src/commands/installGithubAction.ts
+++ b/packages/cli/src/commands/installGithubAction.ts
@@ -210,7 +210,7 @@ async function runInstallGithubAction(
   }
   if (!checkout.success) {
     writeTextStderr(
-      `Failed to check out branch "${branch}": ${checkout.stderr ?? ''}`,
+      `Failed to check out branch "${branch}": ${checkout.stderr}`,
     );
     return CliExitCode.AgentError;
   }
@@ -234,7 +234,7 @@ async function runInstallGithubAction(
 
   const add = git(root, 'add', '--', WORKFLOW_RELATIVE_PATH);
   if (!add.success) {
-    return abort(`Failed to stage the workflow: ${add.stderr ?? ''}`);
+    return abort(`Failed to stage the workflow: ${add.stderr}`);
   }
 
   const diff = git(
@@ -246,9 +246,7 @@ async function runInstallGithubAction(
     WORKFLOW_RELATIVE_PATH,
   );
   if (diff.exitCode !== 0 && diff.exitCode !== 1) {
-    return abort(
-      `Failed to inspect staged workflow changes: ${diff.stderr ?? ''}`,
-    );
+    return abort(`Failed to inspect staged workflow changes: ${diff.stderr}`);
   }
 
   const hasWorkflowChanges = diff.exitCode === 1;
@@ -262,7 +260,7 @@ async function runInstallGithubAction(
       WORKFLOW_RELATIVE_PATH,
     );
     if (!commit.success) {
-      return abort(`Failed to commit the workflow: ${commit.stderr ?? ''}`);
+      return abort(`Failed to commit the workflow: ${commit.stderr}`);
     }
     writeTextStdout(`Created ${WORKFLOW_RELATIVE_PATH} on branch "${branch}".`);
   } else {
@@ -297,7 +295,7 @@ async function runInstallGithubAction(
 
   const push = git(root, 'push', '-u', 'origin', branch);
   if (!push.success) {
-    writeTextStderr(`Failed to push "${branch}": ${push.stderr ?? ''}`);
+    writeTextStderr(`Failed to push "${branch}": ${push.stderr}`);
     writeTextStdout(
       `Once pushed, open ${compareUrl(slug, base, branch)} to propose the PR.`,
     );
@@ -328,7 +326,7 @@ async function runInstallGithubAction(
     );
     opened = pr.success;
     if (!pr.success) {
-      const diagnostic = pr.stderr ?? pr.stdout ?? '';
+      const diagnostic = pr.stderr || pr.stdout;
       writeTextStderr(
         diagnostic
           ? `gh pr create --web failed: ${diagnostic}`

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -165,7 +165,7 @@ async function readCommandStdout(
     cwd: cwd ?? (await resolveCliCwd(undefined)),
     quiet: true,
   });
-  return result.success ? (result.stdout ?? '') : undefined;
+  return result.success ? result.stdout : undefined;
 }
 
 /**

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -191,7 +191,7 @@ export class DiffCommandExecutor {
       );
     }
 
-    if (!this.isBibliographyError(result.stderr ?? '')) {
+    if (!this.isBibliographyError(result.stderr)) {
       throw new Error(
         result.stderr
           ? `Failed to run ${commandType}: ${result.stderr}`

--- a/src/shared/schemas/opResults.ts
+++ b/src/shared/schemas/opResults.ts
@@ -8,18 +8,15 @@ const ExecResultSchema = z.strictObject({
   /** Indicates whether the command succeeded */
   success: z.boolean(),
   /**
-   * Standard output from the command, if available. Empty or whitespace-only
-   * output is normalized to `null` by execUtils.normalizeOutput, so a clean
-   * `git status --porcelain` yields `null` — consumers distinguish "no
-   * output" from "had output" via `stdout !== null`, never via truthiness of
-   * the string (which would always be true after normalization).
+   * Standard output from the command. Empty or whitespace-only output is
+   * normalized to the empty string by execUtils.normalizeOutput.
    */
-  stdout: z.string().nullable(),
+  stdout: z.string(),
   /**
-   * Standard error from the command, if available. Empty or whitespace-only
-   * stderr is normalized to `null`, matching {@link ExecResult.stdout}.
+   * Standard error from the command. Empty or whitespace-only stderr is
+   * normalized to the empty string, matching {@link ExecResult.stdout}.
    */
-  stderr: z.string().nullable(),
+  stderr: z.string(),
   /** True if the command timed out */
   timedOut: z.boolean().optional(),
   /** Exit code from the command (undefined if not available) */

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -224,8 +224,8 @@ function mockStreamingCommand(
       stream(options);
       return {
         success: true,
-        stdout: null,
-        stderr: null,
+        stdout: '',
+        stderr: '',
         timedOut: false,
         exitCode: 0,
         ...result,
@@ -322,7 +322,7 @@ describe('BashTool', () => {
       success: true,
       // executeCommand trims trailing whitespace before returning stdout
       stdout: `${longOutput}\n`.trim(),
-      stderr: null,
+      stderr: '',
       timedOut: false,
     };
 

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -135,7 +135,7 @@ describe('BashTool error feedback', () => {
       stubBashApprovalDisabled();
       vi.spyOn(execUtils, 'executeCommand').mockResolvedValueOnce({
         success: false,
-        stdout: null,
+        stdout: '',
         stderr,
         timedOut: false,
         exitCode,

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -103,8 +103,8 @@ async function launchBackgroundRun(
     finish: async () => {
       release({
         success: true,
-        stdout: null,
-        stderr: null,
+        stdout: '',
+        stderr: '',
         timedOut: false,
         exitCode: 0,
       });

--- a/src/test-kernel/tools/grep.vitest.ts
+++ b/src/test-kernel/tools/grep.vitest.ts
@@ -55,7 +55,7 @@ describe('GrepTool execution', () => {
     const executeSpy = vi.spyOn(execUtils, 'executeCommand').mockResolvedValue({
       success: true,
       stdout: 'one\n\ntwo\nthree\nfour\n',
-      stderr: null,
+      stderr: '',
       timedOut: false,
       exitCode: 0,
     });
@@ -106,7 +106,7 @@ describe('GrepTool execution', () => {
   it('preserves ripgrep error classification', async () => {
     vi.spyOn(execUtils, 'executeCommand').mockResolvedValue({
       success: false,
-      stdout: null,
+      stdout: '',
       stderr: 'regex parse error: unclosed group',
       timedOut: false,
       exitCode: 2,
@@ -127,7 +127,7 @@ describe('GrepTool execution', () => {
     const executeSpy = vi.spyOn(execUtils, 'executeCommand').mockResolvedValue({
       success: true,
       stdout: '/outside/dist/external.tex:external\n',
-      stderr: null,
+      stderr: '',
       timedOut: false,
       exitCode: 0,
     });
@@ -158,8 +158,8 @@ describe('GrepTool execution', () => {
     mockWorkspaceGitignore();
     const executeSpy = vi.spyOn(execUtils, 'executeCommand').mockResolvedValue({
       success: true,
-      stdout: null,
-      stderr: null,
+      stdout: '',
+      stderr: '',
       timedOut: false,
       exitCode: 1,
     });

--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -132,7 +132,7 @@ describe('executeCommand', () => {
 
     assert.ok(result.success);
     assert.equal(result.stdout, stdout);
-    assert.equal(result.stderr, null);
+    assert.equal(result.stderr, '');
   });
 
   it('keeps stderr empty for ordinary nonzero exits with stdout only', async () => {
@@ -145,7 +145,7 @@ describe('executeCommand', () => {
     assert.equal(result.success, false);
     assert.equal(result.exitCode, 7);
     assert.equal(result.stdout, 'failure details');
-    assert.equal(result.stderr, null);
+    assert.equal(result.stderr, '');
     assert.equal(result.outputLimitExceeded, undefined);
   });
 
@@ -167,7 +167,7 @@ describe('executeCommand', () => {
     );
 
     assert.equal(result.success, true);
-    assert.equal(result.stdout, null);
+    assert.equal(result.stdout, '');
     assert.equal(streamed, '🙂');
   });
 
@@ -218,7 +218,7 @@ describe('executeCommand', () => {
     );
 
     assert.equal(result.success, true);
-    assert.equal(result.stdout, null);
+    assert.equal(result.stdout, '');
     assert.equal(streamedChars, outputChars);
     assert.equal(result.outputLimitExceeded, undefined);
   });
@@ -366,7 +366,7 @@ describe('executeCommandSync', () => {
     expect(result).toMatchObject({
       success: true,
       stdout: 'ok',
-      stderr: null,
+      stderr: '',
       timedOut: false,
       exitCode: 0,
     });
@@ -381,7 +381,7 @@ describe('executeCommandSync', () => {
 
     expect(result).toMatchObject({
       success: false,
-      stdout: null,
+      stdout: '',
       stderr: 'bad',
       timedOut: false,
       exitCode: 7,

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -345,7 +345,7 @@ async function gitInDir(args: string[], cwd: string): Promise<string> {
   });
   if (!result.success) {
     throw new ToolError(
-      result.stderr ?? `git ${args.join(' ')} failed with no stderr.`,
+      result.stderr || `git ${args.join(' ')} failed with no stderr.`,
     );
   }
   return result.stdout.trim();

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -348,7 +348,7 @@ async function gitInDir(args: string[], cwd: string): Promise<string> {
       result.stderr ?? `git ${args.join(' ')} failed with no stderr.`,
     );
   }
-  return (result.stdout ?? '').trim();
+  return result.stdout.trim();
 }
 
 interface OpenPullSummary {

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -177,7 +177,7 @@ export class GrepTool extends defineTool({
     }
 
     // Filter empty lines consistently for counting and pagination
-    const allLines = splitOutputLines(result.stdout ?? '');
+    const allLines = splitOutputLines(result.stdout);
     const totalCount = allLines.length;
 
     if (totalCount === 0) {

--- a/src/tools/lean/direct/lakeCommands.ts
+++ b/src/tools/lean/direct/lakeCommands.ts
@@ -76,8 +76,7 @@ async function executeLake(
     windowsHide: true,
     stdin: 'ignore',
   });
-  const stdout = result.stdout ?? '';
-  const stderr = result.stderr ?? '';
+  const { stdout, stderr } = result;
   const shouldUseShortMessage =
     result.isMaxBuffer ||
     result.exitCode === undefined ||

--- a/src/tools/support/externalBinaryUtils.ts
+++ b/src/tools/support/externalBinaryUtils.ts
@@ -183,7 +183,7 @@ async function resolveBinary(
       },
     );
     const pathHits = lookupResult.success
-      ? (lookupResult.stdout ?? '').split(/\r?\n/)
+      ? lookupResult.stdout.split(/\r?\n/)
       : [];
 
     for (const hit of pathHits) {

--- a/src/utils/git/repositoryOverview.ts
+++ b/src/utils/git/repositoryOverview.ts
@@ -61,7 +61,7 @@ async function readGit(
   if (reportFailure) {
     options.onError?.(
       new Error(
-        result.stderr ?? `git ${args[0] ?? 'command'} exited unsuccessfully`,
+        result.stderr || `git ${args[0] ?? 'command'} exited unsuccessfully`,
       ),
     );
   }

--- a/src/utils/git/repositoryOverview.ts
+++ b/src/utils/git/repositoryOverview.ts
@@ -57,7 +57,7 @@ async function readGit(
     maxBuffer: MAX_BUFFER_BYTES,
     quiet: !reportFailure,
   });
-  if (result.success) return result.stdout ?? '';
+  if (result.success) return result.stdout;
   if (reportFailure) {
     options.onError?.(
       new Error(

--- a/src/utils/git/worktreeInfo.ts
+++ b/src/utils/git/worktreeInfo.ts
@@ -85,5 +85,5 @@ async function readDirty(cwd: string): Promise<boolean | undefined> {
     timeout: GIT_TIMEOUT_MS,
     channel: 'worktreeInfo',
   });
-  return result.success ? (result.stdout ?? '').trim().length > 0 : undefined;
+  return result.success ? result.stdout.trim().length > 0 : undefined;
 }

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -34,8 +34,8 @@ type ExecOutput = Extract<StdoutStderrOption, string>;
 const MAX_OUTPUT_LENGTH = 150;
 const FORCE_KILL_DELAY_MS = 5_000;
 
-function normalizeOutput(text: string | null | undefined): string | null {
-  return text?.trim() || null;
+function normalizeOutput(text: string | null | undefined): string {
+  return text?.trim() ?? '';
 }
 
 /**
@@ -124,7 +124,7 @@ function resultFromExecutionError(err: unknown): ExecResult {
 
   return {
     success: false,
-    stdout: null,
+    stdout: '',
     stderr: normalizeOutput(toErrorMessage(err)),
     timedOut: false,
     exitCode: 127,

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -82,11 +82,11 @@ async function getGitInfo(workspacePath: string): Promise<GitInfo | null> {
   if (branchResult.timedOut || statusResult.timedOut) return null;
 
   const branch = branchResult.success ? branchResult.stdout : null;
-  // execUtils normalizes empty/whitespace-only output to null (see the
+  // execUtils normalizes empty/whitespace-only output to the empty string (see the
   // ExecResult.stdout contract in src/shared/schemas/opResults.ts), so a
-  // clean `git status --porcelain` yields null and the null test is what
+  // clean `git status --porcelain` yields an empty string and that test is what
   // distinguishes clean from dirty.
-  const dirty = statusResult.success && statusResult.stdout !== null;
+  const dirty = statusResult.success && statusResult.stdout !== '';
 
   return { branch, dirty };
 }


### PR DESCRIPTION
## Summary

- make `ExecResult.stdout` and `stderr` always strings, with empty output represented by `''`
- migrate production consumers and test fixtures away from redundant null fallbacks
- retain explicit empty-output semantics for workspace dirty-state detection

Closes #10767

## Validation

- `corepack pnpm exec vitest run src/test-kernel/utils/system/SystemUtils.vitest.ts src/test-kernel/tools/BashTool.vitest.ts src/test-kernel/tools/BashToolErrorFeedback.vitest.ts src/test-kernel/tools/ExecutionsToolOutput.vitest.ts src/test-kernel/tools/grep.vitest.ts src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts`
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- targeted ESLint over changed production and fixture files

## R6 net-element accounting

Production and fixtures: +43/-49 lines (net -6).

## R8

Removed all production `ExecResult` consumer `stdout ?? ''` and `stderr ?? ''` fallbacks. Remaining fallbacks are at the execa error boundary and an unrelated optional probe-result shape.