### PR TITLE
fix: surface point-defect residue

### DIFF
--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -54,7 +54,6 @@ import {
   type CliModelAccess,
 } from '../runtime/modelAccess';
 
-const log = createLog('orchestrate');
 import { effectiveCliApiMode } from '../runtime/apiAccessMode';
 import { loadCliApiStatus } from '../runtime/apiStatus';
 import { notifyCliUpdate } from '../runtime/updateChecker';
@@ -89,6 +88,8 @@ import {
 import { runResumeExecution } from './resumeExecution';
 import { type CliContext } from '../runtime/cliContext';
 import type { CliSubscriptionSignOutResult } from '../runtime/subscriptionLogin';
+
+const log = createLog('orchestrate');
 
 /**
  * Sign-out bindings for the subscription providers the launcher's `account`

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -8,6 +8,7 @@ import {
   teamTexraHostedMissingNames,
 } from '@common/teams/TeamPlan';
 import { teamHostedNamesForPreflight } from '@common/teams/TeamRoster';
+import { createLog } from '@logger/logUtils';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { platform } from '@platform/platform';
 import type { ApiAccessMode } from '@shared/schemas';
@@ -52,6 +53,8 @@ import {
   selectCliRunnableModel,
   type CliModelAccess,
 } from '../runtime/modelAccess';
+
+const log = createLog('orchestrate');
 import { effectiveCliApiMode } from '../runtime/apiAccessMode';
 import { loadCliApiStatus } from '../runtime/apiStatus';
 import { notifyCliUpdate } from '../runtime/updateChecker';
@@ -129,7 +132,10 @@ async function canLaunchWithDefaultModel(
       accessList: models,
     });
     return true;
-  } catch {
+  } catch (error) {
+    log.warn(
+      `Unable to select the default CLI model: ${error instanceof Error ? error.message : String(error)}`,
+    );
     return false;
   }
 }

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -459,9 +459,9 @@ function formatCliModelRecovery(
     case 'copilot-access':
       return undefined;
     case 'copilot-consent-required':
-      return 'Grant GitHub Copilot access, or choose another model.';
+      return 'Use this model in VS Code through GitHub Copilot, or choose another model.';
     case 'copilot-unavailable':
-      return 'Enable GitHub Copilot access, or choose another model.';
+      return 'Use this model in VS Code through GitHub Copilot, or choose another model.';
     case 'unknown-model':
       return 'Choose a model that is available in the current registry.';
     case undefined:

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -12,7 +12,7 @@ import type {
 } from '@shared/schemas';
 import { isModelOptionAvailable } from '@shared/schemas';
 import { INCLUDED_ACCESS, OWN_API_KEYS } from '@shared/copy/modelAccess';
-import { unique } from '@utils/core';
+import { assertNever, unique } from '@utils/core';
 import { getGLMCodingPlan } from '@utils/config/providerConfig';
 
 // Local file imports
@@ -455,8 +455,19 @@ function formatCliModelRecovery(
       return 'Choose an active model.';
     case 'provider-unavailable':
       return 'Choose a supported provider route or another model.';
-    default:
+    case 'subscription-access':
+    case 'copilot-access':
       return undefined;
+    case 'copilot-consent-required':
+      return 'Grant GitHub Copilot access, or choose another model.';
+    case 'copilot-unavailable':
+      return 'Enable GitHub Copilot access, or choose another model.';
+    case 'unknown-model':
+      return 'Choose a model that is available in the current registry.';
+    case undefined:
+      return undefined;
+    default:
+      return assertNever(availability, 'Unhandled model availability');
   }
 }
 

--- a/src/agent/implementations/flows/reflection/output/diffComputation.ts
+++ b/src/agent/implementations/flows/reflection/output/diffComputation.ts
@@ -5,6 +5,7 @@
  * using the diff-match-patch library.
  */
 
+import { isFileNotFoundError } from '@common/errors';
 import { createLog } from '@logger/logUtils';
 import type { DiffStats, FileLocation, OutputFileInfo } from '@shared/schemas';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
@@ -46,7 +47,12 @@ async function computeDiffStats(
     // Preserve diff-match-patch's omitted-argument default: checkLines=true.
     return diffLineChanges(baseContent, outContent, { checkLines: true });
   } catch (err) {
-    log.warn(`Failed to compute diff stats: ${toErrorMessage(err)}`);
+    const message = `Failed to compute diff stats: ${toErrorMessage(err)}`;
+    if (isFileNotFoundError(err)) {
+      log.debug(message);
+    } else {
+      log.warn(message);
+    }
     return {};
   }
 }

--- a/src/agent/implementations/flows/reflection/output/diffComputation.ts
+++ b/src/agent/implementations/flows/reflection/output/diffComputation.ts
@@ -46,7 +46,7 @@ async function computeDiffStats(
     // Preserve diff-match-patch's omitted-argument default: checkLines=true.
     return diffLineChanges(baseContent, outContent, { checkLines: true });
   } catch (err) {
-    log.debug(`Failed to compute diff stats: ${toErrorMessage(err)}`);
+    log.warn(`Failed to compute diff stats: ${toErrorMessage(err)}`);
     return {};
   }
 }

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -111,6 +111,9 @@ class Node<S = unknown, Svc = unknown> extends BaseNode<S, Svc> {
   signal?: AbortSignal;
   constructor(maxRetries: number = 1, wait: number = 0) {
     super();
+    if (maxRetries < 1) {
+      throw new RangeError(`Node maxRetries must be >= 1, got ${maxRetries}.`);
+    }
     this.maxRetries = maxRetries;
     this.wait = wait;
   }
@@ -169,12 +172,7 @@ class Node<S = unknown, Svc = unknown> extends BaseNode<S, Svc> {
     return cloned;
   }
   async _exec(prepRes: unknown): Promise<unknown> {
-    if (this.maxRetries < 1) {
-      log.warn(
-        `Node maxRetries must be >= 1, got ${this.maxRetries}. Using 1.`,
-      );
-    }
-    const effectiveMaxRetries = Math.max(1, this.maxRetries);
+    const effectiveMaxRetries = this.maxRetries;
 
     // Track the last exec error so we can forward it to execFallback when
     // the abort signal fires during the inter-retry delay (p-retry would

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 
-import { formatError } from '@common/errors';
+import { formatError, isFileNotFoundError } from '@common/errors';
 import { createLog } from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
@@ -68,7 +68,7 @@ export class LaTeXdiffService {
     return { success: false, message };
   }
 
-  /** Read both diff inputs, returning their contents or null if either read fails. */
+  /** Read both diff inputs, returning null when either input no longer exists. */
   private async readDiffInputs(
     inputLocation: FileLocation,
     editedLocation: FileLocation,
@@ -78,8 +78,9 @@ export class LaTeXdiffService {
         AbsoluteFS.read(inputLocation.absolutePath),
         AbsoluteFS.read(editedLocation.absolutePath),
       ]);
-    } catch {
-      return null;
+    } catch (error) {
+      if (isFileNotFoundError(error)) return null;
+      throw error;
     }
   }
 

--- a/src/shared/copy/modelAccess.ts
+++ b/src/shared/copy/modelAccess.ts
@@ -15,6 +15,7 @@
 
 import type { UsageRoute } from '@shared/schemas';
 import { codingPlanForUsageRoute } from '@shared/codingPlanSubscriptions';
+import { assertNever } from '@utils/core';
 
 /** Model calls paid for by your TeXRA plan. */
 export const INCLUDED_ACCESS = {
@@ -94,7 +95,12 @@ export function usageRouteBadge(
         compactLabel: OWN_API_KEYS.compactLabel,
         subscription: false,
       };
-    default:
+    case 'kimi-code-subscription':
+    case 'glm-coding-plan-subscription':
+      throw new Error(`Missing coding-plan copy for usage route: ${route}`);
+    case undefined:
       return undefined;
+    default:
+      return assertNever(route, 'Unhandled usage route');
   }
 }

--- a/src/test-kernel/agent/PocketFlowNode.vitest.ts
+++ b/src/test-kernel/agent/PocketFlowNode.vitest.ts
@@ -114,6 +114,11 @@ class ScriptedRetryNode extends Node {
 }
 
 describe('Node manual retry', () => {
+  it('rejects an invalid retry limit at construction', () => {
+    expect(() => new ScriptedRetryNode(0, [], [])).toThrow(RangeError);
+    expect(() => new ScriptedRetryNode(-1, [], [])).toThrow(RangeError);
+  });
+
   it('grants one attempt after an exhausted automatic retry batch', async () => {
     const node = new ScriptedRetryNode(3, failureSequence(4), [true, false]);
 

--- a/src/utils/files/rulesUtils.ts
+++ b/src/utils/files/rulesUtils.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 
+import { isFileNotFoundError } from '@common/errors';
 import { createLog } from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { safeHomedir } from '@utils/system/platformPaths';
@@ -39,6 +40,7 @@ export async function loadTexraRules(): Promise<string> {
       }
     }
   } catch (err) {
+    if (isFileNotFoundError(err)) return '';
     log.warn(`Failed to load ${RULES_FILE}: ${toErrorMessage(err)}`);
   }
   return '';


### PR DESCRIPTION
Closes #10769

## Summary
- rethrow unexpected latexdiff input failures while retaining the normal missing-file outcome
- make usage-route and CLI model-availability copy exhaustive, so newly added variants cannot fall through silently
- reject invalid PocketFlow retry limits before execution, with a focused regression test
- make expected CLI model-selection and diff-stat recovery visible at warning level
- keep missing `.texrarules` quiet while warning on other read failures

## Validation
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- `corepack pnpm exec vitest run src/test-kernel/agent/PocketFlowNode.vitest.ts src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts` (21 passed)
- changed-file ESLint
- `git diff --check`

Production: +37/-15. Tests: +5/-0.