### PR TITLE
refactor: retire legacy state normalizers

### DIFF
--- a/src/agent/core/state/AgentWorkspaceState.ts
+++ b/src/agent/core/state/AgentWorkspaceState.ts
@@ -324,15 +324,12 @@ const AgentWorkspaceSnapshotFieldsSchema = z.object({
  * Canonical shape of an `AgentWorkspaceState` snapshot. Persisted workspace
  * state has one supported format; an older record fails its resume parse.
  */
-export const AgentWorkspaceCurrentSnapshotSchema = z
+export const AgentWorkspaceStateSnapshotSchema = z
   .looseObject({ workPlan: z.unknown() })
   .refine(
     (record) => Object.hasOwn(record, 'workPlan') && record.workPlan != null,
   )
   .transform((record) => AgentWorkspaceSnapshotFieldsSchema.parse(record));
-
-export const AgentWorkspaceStateSnapshotSchema =
-  AgentWorkspaceCurrentSnapshotSchema;
 
 export type AgentWorkspaceSnapshot = z.output<
   typeof AgentWorkspaceStateSnapshotSchema
@@ -395,7 +392,7 @@ export class AgentWorkspaceState {
   static fromCanonicalSnapshot(
     snapshot: AgentWorkspaceSnapshot,
   ): AgentWorkspaceState {
-    const parsed = AgentWorkspaceCurrentSnapshotSchema.parse(snapshot);
+    const parsed = AgentWorkspaceStateSnapshotSchema.parse(snapshot);
     return AgentWorkspaceState.fromParsedFields(parsed);
   }
 

--- a/src/agent/core/state/AgentWorkspaceState.ts
+++ b/src/agent/core/state/AgentWorkspaceState.ts
@@ -6,9 +6,7 @@ import type { ServerToolContentBlock } from '@agent/types/ServerTools';
 import {
   FileLocationSchema,
   LineCountSchema,
-  PlanSchema,
   planSummaryLine,
-  TodoItemSchema,
   type EditRecord,
   type FileLocation,
   type LineChanges,
@@ -17,7 +15,6 @@ import {
   type WorkPlanSnapshot,
   WorkPlanSnapshotSchema,
 } from '@shared/schemas';
-import { isObject } from '@utils/core';
 import { pathToLocation } from '@utils/files/fileLocation';
 
 /** Schema for thinking blocks (used by model handlers). */
@@ -324,14 +321,8 @@ const AgentWorkspaceSnapshotFieldsSchema = z.object({
 });
 
 /**
- * Strict canonical shape of an `AgentWorkspaceState` snapshot — the "current
- * format" arm of `AgentWorkspaceStateSnapshotSchema`, with no legacy fallback.
- * Exported for downstream code (e.g. per-round node prep, or a
- * `PersistedFlow`'s repeated defense-in-depth revalidation) that only ever
- * handles a snapshot already produced by `toSnapshot()`/`fromSnapshot()` and
- * must never re-run the legacy-migration arms in `AgentWorkspaceStateSnapshotSchema`.
- * The one-time migration from a persisted/legacy shape belongs solely at the
- * hydration boundary (see `AgentWorkspaceState.fromSnapshot`).
+ * Canonical shape of an `AgentWorkspaceState` snapshot. Persisted workspace
+ * state has one supported format; an older record fails its resume parse.
  */
 export const AgentWorkspaceCurrentSnapshotSchema = z
   .looseObject({ workPlan: z.unknown() })
@@ -340,55 +331,8 @@ export const AgentWorkspaceCurrentSnapshotSchema = z
   )
   .transform((record) => AgentWorkspaceSnapshotFieldsSchema.parse(record));
 
-const LegacyTodosSnapshotValueSchema = z.union([
-  z.undefined(),
-  z.null().transform(() => undefined),
-  z.array(TodoItemSchema),
-  z
-    .looseObject({ todos: z.unknown().optional() })
-    .refine((record) => Object.hasOwn(record, 'todos'))
-    .transform(({ todos }) => todos),
-]);
-
-const LegacyPlanSnapshotValueSchema = z.union([
-  z.undefined(),
-  z
-    .looseObject({ plan: z.unknown().optional() })
-    .refine((record) => Object.hasOwn(record, 'plan'))
-    .transform(({ plan }) => plan),
-  z.unknown(),
-]);
-
-const AgentWorkspaceLegacySnapshotSchema = z
-  .looseObject({
-    todos: LegacyTodosSnapshotValueSchema.optional(),
-    plan: LegacyPlanSnapshotValueSchema.optional(),
-  })
-  .refine(
-    (record) => !Object.hasOwn(record, 'workPlan') || record.workPlan == null,
-  )
-  .transform((record) => {
-    const plan = PlanSchema.nullable().prefault(null).parse(record.plan);
-    return AgentWorkspaceSnapshotFieldsSchema.parse({
-      ...record,
-      workPlan: {
-        todos: record.todos,
-        plan,
-        planSummary: plan ? planSummaryLine(plan.objective) : null,
-      },
-    });
-  });
-
-const EmptyAgentWorkspaceSnapshotSchema = z
-  .unknown()
-  .refine((input) => !isObject(input))
-  .transform(() => AgentWorkspaceSnapshotFieldsSchema.parse({ workPlan: {} }));
-
-export const AgentWorkspaceStateSnapshotSchema = z.union([
-  AgentWorkspaceCurrentSnapshotSchema,
-  AgentWorkspaceLegacySnapshotSchema,
-  EmptyAgentWorkspaceSnapshotSchema,
-]);
+export const AgentWorkspaceStateSnapshotSchema =
+  AgentWorkspaceCurrentSnapshotSchema;
 
 export type AgentWorkspaceSnapshot = z.output<
   typeof AgentWorkspaceStateSnapshotSchema
@@ -421,13 +365,12 @@ export class AgentWorkspaceState {
    * (e.g., constructing initial ReflectionFlowShared).
    */
   static emptySnapshot(): AgentWorkspaceSnapshot {
-    return AgentWorkspaceStateSnapshotSchema.parse({});
+    return AgentWorkspaceStateSnapshotSchema.parse({ workPlan: {} });
   }
 
   /**
-   * Boundary hydration: accepts an untrusted/possibly-legacy persisted
-   * snapshot (union with the `todos`/`plan` fallback arm — see
-   * `AgentWorkspaceStateSnapshotSchema`). Call this exactly once, where a
+   * Boundary hydration: validates an untrusted persisted snapshot. Call this
+   * exactly once, where a
    * persisted snapshot first hydrates into a session (session-init resume in
    * `ToolUsePrepareNode`, a reflection flow's resume read in
    * `runReflectionFlow`, or `runToolUseFlow`'s tool-use resume boundary
@@ -436,7 +379,7 @@ export class AgentWorkspaceState {
    * is already past `ToolUsePrepareNode` never runs that node's own
    * hydration). Everywhere else — per-round node prep re-deriving state from
    * `toSnapshot()` output already produced this run — use
-   * `fromCanonicalSnapshot` instead so the legacy arm is never re-evaluated.
+   * `fromCanonicalSnapshot` instead.
    */
   static fromSnapshot(snapshot: unknown): AgentWorkspaceState {
     const parsed = AgentWorkspaceStateSnapshotSchema.parse(snapshot);
@@ -445,11 +388,9 @@ export class AgentWorkspaceState {
 
   /**
    * Rebuild from a snapshot already known to be canonical (e.g. round-tripped
-   * through this class's own `toSnapshot()`). Validates only the strict
-   * canonical shape — never the legacy `todos`/`plan` fallback arm — so
+   * through this class's own `toSnapshot()`). Validates the canonical shape so
    * repeated per-round calls (tool-use `ToolUseCycleNode`, reflection
-   * `ResponseCycleNode`/`MediaExtractionNode`) don't pay for, or silently
-   * accept, a migration that can only ever apply at first hydration.
+   * `ResponseCycleNode`/`MediaExtractionNode`) have the same validation path.
    */
   static fromCanonicalSnapshot(
     snapshot: AgentWorkspaceSnapshot,

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -62,10 +62,3 @@ export const ReflectionFlowStateSchema = z.object({
 
 /** Shared state type for reflection flow nodes. */
 export type ReflectionFlowShared = z.infer<typeof ReflectionFlowStateSchema>;
-
-/**
- * Alias retained for the per-round persisted-flow contract. Workspace
- * snapshots have one supported schema, so resume and revalidation use the
- * same canonical validation.
- */
-export const ReflectionFlowStateCanonicalSchema = ReflectionFlowStateSchema;

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -6,10 +6,7 @@ import {
   AgentRunStateSnapshotSchema,
   ConversationRoundStateSnapshotSchema,
 } from '@agent/core/state/AgentState';
-import {
-  AgentWorkspaceCurrentSnapshotSchema,
-  AgentWorkspaceStateSnapshotSchema,
-} from '@agent/core/state/AgentWorkspaceState';
+import { AgentWorkspaceStateSnapshotSchema } from '@agent/core/state/AgentWorkspaceState';
 import { ProviderMessageArraySchema } from '@agent/types/ProviderMessage';
 import { ModelHandlerCompatibilityKeySchema } from '@agent/runtime/modelHandlerCompatibilityKey';
 import {
@@ -67,18 +64,8 @@ export const ReflectionFlowStateSchema = z.object({
 export type ReflectionFlowShared = z.infer<typeof ReflectionFlowStateSchema>;
 
 /**
- * Same shape as `ReflectionFlowStateSchema`, but `workspaceSnapshot` is
- * validated against the strict canonical schema instead of the
- * legacy-migrating union. `ReflectionFlowStateSchema` itself stays reserved
- * for the one-time boundary parse of a freshly-read persisted record (see
- * `runReflectionFlow`'s resume check); `RoundPersistedFlow`'s defense-in-depth
- * revalidation runs on every node step against an already-canonical
- * in-memory `shared` (round-tripped through `AgentWorkspaceState.toSnapshot()`),
- * so it uses this variant to avoid re-walking the legacy arm on every step —
- * and to fail loudly, rather than silently migrate, if a mid-flow record
- * were ever corrupted into looking like the legacy shape.
+ * Alias retained for the per-round persisted-flow contract. Workspace
+ * snapshots have one supported schema, so resume and revalidation use the
+ * same canonical validation.
  */
-export const ReflectionFlowStateCanonicalSchema =
-  ReflectionFlowStateSchema.extend({
-    workspaceSnapshot: AgentWorkspaceCurrentSnapshotSchema,
-  });
+export const ReflectionFlowStateCanonicalSchema = ReflectionFlowStateSchema;

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -195,14 +195,9 @@ export async function runReflectionFlow<C = unknown>(
   const flowRecord = await readPersistedFlowRecord(kv, executionId);
 
   if (flowRecord) {
-    // Boundary hydration: the one place a freshly-read persisted record
-    // (possibly written by an older build, hence the legacy todos/plan
-    // fallback in AgentWorkspaceStateSnapshotSchema) is parsed. Downstream,
-    // `RoundPersistedFlow` validates records it re-reads from storage with
-    // ReflectionFlowStateCanonicalSchema (see its constructor call below),
-    // since those are always this run's own canonical toSnapshot() output,
-    // never a legacy shape; records it wrote itself stay trusted per the
-    // boundary-only validation rule.
+    // Validate the freshly-read persisted record before it enters the live
+    // flow. `RoundPersistedFlow` revalidates later writes against the same
+    // canonical schema.
     const validated = ReflectionFlowStateSchema.safeParse(flowRecord.shared);
     if (!validated.success) {
       throw new PersistedFlowStateError(executionId, 'invalid-shared', {

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -46,7 +46,6 @@ import { ResponseCycleNode } from './nodes/ResponseCycleNode';
 import { OutputNode } from './nodes/OutputNode';
 import {
   ReflectionFlowStateSchema,
-  ReflectionFlowStateCanonicalSchema,
   type ReflectionFlowShared,
 } from './ReflectionFlowState';
 import { RoundPersistedFlow } from './RoundPersistedFlow';
@@ -257,7 +256,7 @@ export async function runReflectionFlow<C = unknown>(
     ReflectionServices<C>
   >(prepContextNode, kv, {
     parentStage,
-    sharedSchema: ReflectionFlowStateCanonicalSchema,
+    sharedSchema: ReflectionFlowStateSchema,
     callbacks: {
       createRoundStage: (roundIndex, parent, shared) =>
         logger.openStage(`r${roundIndex}`, {

--- a/src/agent/implementations/flows/tooluse/modelSwitchState.ts
+++ b/src/agent/implementations/flows/tooluse/modelSwitchState.ts
@@ -1,23 +1,10 @@
-import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
 import { USER_VAR_MODEL } from '@agent/prompt/userVars';
-import { isNonEmptyString } from '@utils/core';
 
 import type { ToolUseRunShared } from './nodes/types';
 
-export function currentModelFromUserChannels(
-  channels: UserVariableChannels,
-): string | undefined {
-  const value =
-    channels.transient[USER_VAR_MODEL] ?? channels.input[USER_VAR_MODEL];
-  return isNonEmptyString(value) ? value.trim() : undefined;
-}
-
 /**
- * Record a model switch in persisted shared state: `modelId` is the resume
- * SSOT. The `MODEL` user variable is re-projected alongside it so the
- * pre-`modelId` reader in {@link currentModelFromUserChannels} agrees with it
- * on records this run rewrites; prompts read the live model off the run's
- * `ModelCell`, not from here.
+ * Record a model switch in persisted shared state. `modelId` is the resume
+ * SSOT; `MODEL` remains the prompt-facing user variable for the live run.
  */
 export function setToolUseSharedModel(
   shared: ToolUseRunShared,

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -7,7 +7,6 @@ import {
   type AgentRunStateSnapshot,
 } from '@agent/core/state/AgentState';
 import {
-  AgentWorkspaceCurrentSnapshotSchema,
   AgentWorkspaceStateSnapshotSchema,
   type AgentWorkspaceState,
 } from '@agent/core/state/AgentWorkspaceState';
@@ -23,16 +22,10 @@ import { ModelHandlerCompatibilityKeySchema } from '@agent/runtime/modelHandlerC
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { JsonValueSchema, RetryErrorInfoSchema } from '@shared/schemas';
 
-import { currentModelFromUserChannels } from '../modelSwitchState';
-
 const StateSlicesSchema = z.object({
   runStateSnapshot: AgentRunStateSnapshotSchema,
   workspaceSnapshot: AgentWorkspaceStateSnapshotSchema,
   userChannels: UserVariableChannelsSchema,
-});
-
-const StateSlicesCanonicalSchema = StateSlicesSchema.extend({
-  workspaceSnapshot: AgentWorkspaceCurrentSnapshotSchema,
 });
 
 export type StateSlicesSnapshot = z.output<typeof StateSlicesSchema>;
@@ -57,8 +50,7 @@ const ToolUseRunSharedSchema = z.object({
   continuationGenerationId: z.uuid(),
   /**
    * The model the run is on, mirroring the live `ModelCell`. This is the
-   * resume SSOT for model identity; the `MODEL` user variable is the legacy
-   * record of it, read only when this field is absent.
+   * resume SSOT for model identity.
    */
   modelId: z.string().optional(),
   modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullable()
@@ -77,10 +69,8 @@ const ToolUseRunSharedSchema = z.object({
   structured: JsonValueSchema.optional(),
 });
 
-/** Per-step schema after the one-time legacy workspace migration. */
-export const ToolUseRunSharedCanonicalSchema = ToolUseRunSharedSchema.extend({
-  stateSlices: StateSlicesCanonicalSchema.nullable(),
-});
+/** Per-step schema for the canonical persisted shared state. */
+export const ToolUseRunSharedCanonicalSchema = ToolUseRunSharedSchema;
 
 export type ToolUseRunShared = z.output<typeof ToolUseRunSharedSchema>;
 
@@ -142,16 +132,9 @@ type SharedStateMigrationResult =
   | { success: false; error: z.ZodError };
 
 /**
- * Parse persisted shared state once, normalizing the workspace snapshot and
- * pre-`modelId` model identity before live flow code sees it.
- *
- * Malformed known fields — and workspace-snapshot data a snapshot union
- * arm rejects before its `.transform` runs — come back as
- * `{success: false}`. Only a validation failure reached by the nested
- * `.parse()` inside a union arm's `.transform` (post-discrimination)
- * throws its ZodError through `safeParse`. Both failure modes are loud,
- * and both callers already handle the throw at their existing
- * boundaries.
+ * Parse persisted shared state once before live flow code sees it. Malformed
+ * known fields return `{success: false}` and are handled by the existing
+ * resume boundary.
  */
 export function migrateSharedState(
   shared: unknown,
@@ -159,23 +142,9 @@ export function migrateSharedState(
   const parsed = ToolUseRunSharedSchema.safeParse(shared);
   if (!parsed.success) return parsed;
 
-  // Records written before `modelId` existed carry the run's model only in the
-  // `MODEL` user variable. Lift it here, at the one deserialization boundary,
-  // so no downstream reader has to know the field can be absent. A record with
-  // neither leaves `modelId` unset and the caller falls back to its config.
-  const derivedModelId =
-    parsed.data.modelId ??
-    (parsed.data.stateSlices
-      ? currentModelFromUserChannels(parsed.data.stateSlices.userChannels)
-      : undefined);
-  const data =
-    derivedModelId === undefined
-      ? parsed.data
-      : { ...parsed.data, modelId: derivedModelId };
-
   return {
     success: true,
-    data,
-    migrated: !isDeepStrictEqual(shared, data),
+    data: parsed.data,
+    migrated: !isDeepStrictEqual(shared, parsed.data),
   };
 }

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -44,7 +44,7 @@ export type StateSlicesSnapshot = z.output<typeof StateSlicesSchema>;
  * build carrying keys this build does not know must still resume — and no
  * `.catch`: malformed known fields must keep failing loudly.
  */
-const ToolUseRunSharedSchema = z.object({
+export const ToolUseRunSharedSchema = z.object({
   messages: ProviderMessageArraySchema,
   /** Durable identity of the continuation attempt that owns this flow. */
   continuationGenerationId: z.uuid(),
@@ -68,9 +68,6 @@ const ToolUseRunSharedSchema = z.object({
   /** Validated terminal-tool result retained across interrupt and resume. */
   structured: JsonValueSchema.optional(),
 });
-
-/** Per-step schema for the canonical persisted shared state. */
-export const ToolUseRunSharedCanonicalSchema = ToolUseRunSharedSchema;
 
 export type ToolUseRunShared = z.output<typeof ToolUseRunSharedSchema>;
 
@@ -127,8 +124,8 @@ export type PreparedShared = ToolUseRunShared & {
   stateSlices: StateSlicesSnapshot;
 };
 
-type SharedStateMigrationResult =
-  | { success: true; data: ToolUseRunShared; migrated: boolean }
+type ParsedToolUseSharedResult =
+  | { success: true; data: ToolUseRunShared; changed: boolean }
   | { success: false; error: z.ZodError };
 
 /**
@@ -136,15 +133,13 @@ type SharedStateMigrationResult =
  * known fields return `{success: false}` and are handled by the existing
  * resume boundary.
  */
-export function migrateSharedState(
-  shared: unknown,
-): SharedStateMigrationResult {
+export function parseToolUseShared(shared: unknown): ParsedToolUseSharedResult {
   const parsed = ToolUseRunSharedSchema.safeParse(shared);
   if (!parsed.success) return parsed;
 
   return {
     success: true,
     data: parsed.data,
-    migrated: !isDeepStrictEqual(shared, parsed.data),
+    changed: !isDeepStrictEqual(shared, parsed.data),
   };
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -486,13 +486,12 @@ export async function runToolUseFlow<C = unknown>(
           cause: migrationResult.error,
         });
       }
-      // Defensive fallback only: no resume handoff means the resume
-      // boundary above was never consulted for this call (e.g. a fresh
-      // launch that happens to find a leftover record for its execution
-      // id). Migrate/backfill here so PersistedFlow.ensureRecord never sees
-      // a stale legacy shape. Model-based compatibility inference for
-      // keyless records lives at the resume-retrieval boundary
-      // (SessionResumeRetrieval); this path stamps the active handler's key.
+      // Defensive fallback only: no resume handoff means the resume boundary
+      // above was never consulted for this call (e.g. a fresh launch that
+      // finds a leftover record for its execution id). Normalize the parsed
+      // record before `PersistedFlow.ensureRecord` sees it. Model-based
+      // compatibility inference for keyless records lives at the
+      // resume-retrieval boundary; this path stamps the active handler's key.
       let migratedData = migrationResult.data;
       let shouldWriteShared = migrationResult.migrated;
       if (migratedData.continuationGenerationId !== continuationGenerationId) {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -54,8 +54,8 @@ import { ToolUseCycleNode } from './nodes/ToolUseCycleNode';
 import { ToolUseWaitNode } from './nodes/ToolUseWaitNode';
 import {
   extractTouchedFiles,
-  migrateSharedState,
-  ToolUseRunSharedCanonicalSchema,
+  parseToolUseShared,
+  ToolUseRunSharedSchema,
   type PreparedShared,
   type ToolUseRunShared,
 } from './nodes/types';
@@ -480,10 +480,10 @@ export async function runToolUseFlow<C = unknown>(
         );
       }
     } else if (flowRecord) {
-      const migrationResult = migrateSharedState(flowRecord.shared);
-      if (!migrationResult.success) {
+      const parsedShared = parseToolUseShared(flowRecord.shared);
+      if (!parsedShared.success) {
         throw new PersistedFlowStateError(executionId, 'invalid-shared', {
-          cause: migrationResult.error,
+          cause: parsedShared.error,
         });
       }
       // Defensive fallback only: no resume handoff means the resume boundary
@@ -492,31 +492,31 @@ export async function runToolUseFlow<C = unknown>(
       // record before `PersistedFlow.ensureRecord` sees it. Model-based
       // compatibility inference for keyless records lives at the
       // resume-retrieval boundary; this path stamps the active handler's key.
-      let migratedData = migrationResult.data;
-      let shouldWriteShared = migrationResult.migrated;
-      if (migratedData.continuationGenerationId !== continuationGenerationId) {
+      let sharedData = parsedShared.data;
+      let shouldWriteShared = parsedShared.changed;
+      if (sharedData.continuationGenerationId !== continuationGenerationId) {
         logger.debug(
           'Rebound leftover tool-use flow state to the fresh continuation generation.',
         );
-        migratedData = {
-          ...migratedData,
+        sharedData = {
+          ...sharedData,
           continuationGenerationId,
         };
         shouldWriteShared = true;
       }
-      const backfilled = stampCompatibilityKey(migratedData, compatibilityKey);
-      if (backfilled !== migratedData) {
+      const backfilled = stampCompatibilityKey(sharedData, compatibilityKey);
+      if (backfilled !== sharedData) {
         logger.debug(
           'Backfilled tool-use model-handler compatibility key in shared state.',
         );
-        migratedData = backfilled;
+        sharedData = backfilled;
         shouldWriteShared = true;
       }
       if (shouldWriteShared) {
-        if (migrationResult.migrated) {
+        if (parsedShared.changed) {
           logger.debug('Normalized persisted tool-use shared state');
         }
-        flowRecord.shared = migratedData;
+        flowRecord.shared = sharedData;
         await kv.write(
           flowKey(executionId),
           stampFlowRecordSchemaVersion(flowRecord),
@@ -544,7 +544,7 @@ export async function runToolUseFlow<C = unknown>(
         prepareNode,
         kv,
         executionId,
-        ToolUseRunSharedCanonicalSchema,
+        ToolUseRunSharedSchema,
       );
       activePersistedFlow = pf;
       pf.setServices(services);

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -9,8 +9,6 @@
  * - Workflow: agentConfig + executionId + transcript-format key
  */
 
-import { z } from 'zod';
-
 import {
   deriveResumability,
   RESUMABILITY_CAUSE,
@@ -18,7 +16,7 @@ import {
 } from '@agent/storage';
 import type { FlowRecord } from '@agent/node/persistedFlow';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { ProviderMessageArraySchema } from '@agent/types/ProviderMessage';
+import { ReflectionFlowStateSchema } from '@agent/implementations/flows/reflection/ReflectionFlowState';
 import {
   migrateSharedState,
   type PreparedShared,
@@ -115,17 +113,6 @@ function resumeRetrievalError(
     { cause: error },
   );
 }
-
-/**
- * Minimal schema for validating workflow flow record exists and has resumable state.
- * Full validation happens when the flow actually resumes.
- */
-const WorkflowFlowRecordStateSchema = z.looseObject({
-  currentRound: z.int().nonnegative(),
-  totalRounds: z.int().nonnegative(),
-  conversation: ProviderMessageArraySchema,
-  modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullish(),
-});
 
 /**
  * Retrieve resume data for a WAITING session.
@@ -247,11 +234,7 @@ async function retrieveWorkflowResumeData(
     const flowRecord = await probeResumableFlowRecord(executionId, 'workflow');
     if (!flowRecord) return null;
 
-    // Minimal validation - just verify essential fields exist.
-    // Full state validation happens when the flow actually resumes.
-    const parseResult = WorkflowFlowRecordStateSchema.safeParse(
-      flowRecord.shared,
-    );
+    const parseResult = ReflectionFlowStateSchema.safeParse(flowRecord.shared);
     if (!parseResult.success) {
       logger.warn(`Invalid workflow flow record for execution: ${executionId}`);
       return null;

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -18,7 +18,7 @@ import type { FlowRecord } from '@agent/node/persistedFlow';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { ReflectionFlowStateSchema } from '@agent/implementations/flows/reflection/ReflectionFlowState';
 import {
-  migrateSharedState,
+  parseToolUseShared,
   type PreparedShared,
 } from '@agent/implementations/flows/tooluse/nodes/types';
 import { createLog } from '@logger/logUtils';
@@ -165,18 +165,18 @@ async function retrieveToolUseResumeData(
     const flowRecord = await probeResumableFlowRecord(executionId, 'tool-use');
     if (!flowRecord) return null;
 
-    const migrationResult = migrateSharedState(flowRecord.shared);
-    if (!migrationResult.success) {
+    const parsedShared = parseToolUseShared(flowRecord.shared);
+    if (!parsedShared.success) {
       logger.warn(
         `Invalid flow record structure for execution: ${executionId}`,
         {
-          data: { error: migrationResult.error },
+          data: { error: parsedShared.error },
         },
       );
       return null;
     }
 
-    const { stateSlices } = migrationResult.data;
+    const { stateSlices } = parsedShared.data;
     if (stateSlices === null) {
       logger.warn(
         `Invalid flow record structure for execution: ${executionId}`,
@@ -186,17 +186,17 @@ async function retrieveToolUseResumeData(
 
     const currentConfig = {
       ...agentConfig,
-      model: migrationResult.data.modelId ?? agentConfig.model,
+      model: parsedShared.data.modelId ?? agentConfig.model,
     };
     const modelHandlerCompatibilityKey =
-      migrationResult.data.modelHandlerCompatibilityKey ??
+      parsedShared.data.modelHandlerCompatibilityKey ??
       inferAndLogPersistedModelHandlerCompatibilityKey(
         currentConfig.model,
         logger,
       );
 
     const shared: PreparedShared = {
-      ...migrationResult.data,
+      ...parsedShared.data,
       stateSlices,
       ...(modelHandlerCompatibilityKey !== undefined && {
         modelHandlerCompatibilityKey,

--- a/src/agent/types/NormalizedUsage.ts
+++ b/src/agent/types/NormalizedUsage.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 
 import {
   TokenCountSchema,
-  TokenUsageStatsBaseSchema,
+  TokenUsageStatsSchema,
   UsageProviderSchema,
   UsageRouteSchema,
 } from '@shared/schemas';
@@ -15,13 +15,13 @@ import {
  * Normalized usage statistics from any model provider.
  *
  * Reuses only the required base fields via `.pick()` — the optional cache
- * fields on `TokenUsageStatsBaseSchema` (`cacheReadInputTokens` /
+ * fields on `TokenUsageStatsSchema` (`cacheReadInputTokens` /
  * `cacheCreationInputTokens`) are never populated for a NormalizedUsage; the
  * live cache metrics below (`cachedInputTokens` / `cacheCreationTokens`) are
  * the authoritative names. Extending the full base instead would inherit
  * those dead fields and duplicate `cacheMissInputTokens`.
  */
-const NormalizedUsageBaseSchema = TokenUsageStatsBaseSchema.pick({
+const NormalizedUsageBaseSchema = TokenUsageStatsSchema.pick({
   inputTokens: true,
   outputTokens: true,
   cost: true,

--- a/src/agent/types/NormalizedUsage.ts
+++ b/src/agent/types/NormalizedUsage.ts
@@ -9,7 +9,6 @@ import {
   TokenUsageStatsBaseSchema,
   UsageProviderSchema,
   UsageRouteSchema,
-  withLegacyUsageRoute,
 } from '@shared/schemas';
 
 /**
@@ -53,8 +52,6 @@ const NormalizedUsageBaseSchema = TokenUsageStatsBaseSchema.pick({
   _native: z.unknown().optional(),
 });
 
-export const NormalizedUsageSchema = withLegacyUsageRoute(
-  NormalizedUsageBaseSchema,
-);
+export const NormalizedUsageSchema = NormalizedUsageBaseSchema;
 
 export type NormalizedUsage = z.infer<typeof NormalizedUsageSchema>;

--- a/src/shared/schemas/contextManagement.ts
+++ b/src/shared/schemas/contextManagement.ts
@@ -32,36 +32,10 @@ const TokensFreedDataSchema = ContextManagementDataBaseSchema.extend({
   utilizationAfter: z.number().nonnegative(),
 });
 
-/**
- * Persisted stream-log entries predate this discriminated union, when
- * `tokensAfter`/`utilizationAfter` were merely `.optional()` on every action.
- * Default them from the before-values on read so an older log entry that
- * omitted them still parses (reporting no measured change) instead of
- * silently vanishing from the progress view.
- */
-function fillLegacyTokensFreedFields(raw: unknown): unknown {
-  if (
-    typeof raw !== 'object' ||
-    raw === null ||
-    (raw as { action?: unknown }).action === 'max_tokens_reduced'
-  ) {
-    return raw;
-  }
-  const data = raw as Record<string, unknown>;
-  return {
-    ...data,
-    tokensAfter: data.tokensAfter ?? data.tokensBefore,
-    utilizationAfter: data.utilizationAfter ?? data.utilizationBefore,
-  };
-}
-
-export const ContextManagementDataSchema = z.preprocess(
-  fillLegacyTokensFreedFields,
-  z.discriminatedUnion('action', [
-    MaxTokensReducedDataSchema,
-    TokensFreedDataSchema,
-  ]),
-);
+export const ContextManagementDataSchema = z.discriminatedUnion('action', [
+  MaxTokensReducedDataSchema,
+  TokensFreedDataSchema,
+]);
 
 export type ContextManagementData = z.infer<typeof ContextManagementDataSchema>;
 

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -16,7 +16,7 @@ import { z } from 'zod';
 import { ExecutionIdSchema } from './identifiers';
 import { formatZodIssuesMessage } from './toolResult';
 import {
-  TokenUsageStatsBaseSchema,
+  TokenUsageStatsSchema,
   UsageRouteSchema,
   isEmptyUsage,
   type TokenUsageStats,
@@ -62,7 +62,7 @@ function isNumericUsageField(schema: z.ZodType): boolean {
 }
 
 const numericUsageParsingShape = Object.fromEntries(
-  Object.entries(TokenUsageStatsBaseSchema.shape)
+  Object.entries(TokenUsageStatsSchema.shape)
     .filter(([, schema]) => isNumericUsageField(schema))
     .map(([key, schema]) => [
       key,
@@ -83,7 +83,7 @@ const numericUsageParsingShape = Object.fromEntries(
 export const TokenUsageStatsParsingBaseSchema = z.strictObject({
   ...numericUsageParsingShape,
   usageRoute: UsageRouteSchema.optional(),
-  // The numeric fields are derived from `TokenUsageStatsBaseSchema.shape` above;
+  // The numeric fields are derived from `TokenUsageStatsSchema.shape` above;
   // TypeScript cannot recover the required keys through `Object.fromEntries`.
 }) as unknown as z.ZodType<TokenUsageStats>;
 

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -19,7 +19,6 @@ import {
   TokenUsageStatsBaseSchema,
   UsageRouteSchema,
   isEmptyUsage,
-  withLegacyUsageRoute,
   type TokenUsageStats,
 } from './usage';
 
@@ -81,14 +80,12 @@ const numericUsageParsingShape = Object.fromEntries(
  * loudly on failure, instead of defaulting to zero. Never wrap this in
  * `.catch()` for persisted/cost data — see `parseUsageData`'s docs and #7464.
  */
-export const TokenUsageStatsParsingBaseSchema = withLegacyUsageRoute(
-  z.object({
-    ...numericUsageParsingShape,
-    usageRoute: UsageRouteSchema.optional(),
-    // The numeric fields are derived from `TokenUsageStatsBaseSchema.shape` above;
-    // TypeScript cannot recover the required keys through `Object.fromEntries`.
-  }),
-) as z.ZodType<TokenUsageStats>;
+export const TokenUsageStatsParsingBaseSchema = z.strictObject({
+  ...numericUsageParsingShape,
+  usageRoute: UsageRouteSchema.optional(),
+  // The numeric fields are derived from `TokenUsageStatsBaseSchema.shape` above;
+  // TypeScript cannot recover the required keys through `Object.fromEntries`.
+}) as unknown as z.ZodType<TokenUsageStats>;
 
 export interface ParsedUsageData {
   /** Successfully parsed, non-empty per-run usage. */

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -56,22 +56,6 @@ const FiniteNumber = z.coerce
   .number()
   .transform((n) => (Number.isFinite(n) ? n : 0));
 
-function isNumericUsageField(schema: z.ZodType): boolean {
-  const inner = schema instanceof z.ZodOptional ? schema.unwrap() : schema;
-  return inner instanceof z.ZodNumber;
-}
-
-const numericUsageParsingShape = Object.fromEntries(
-  Object.entries(TokenUsageStatsSchema.shape)
-    .filter(([, schema]) => isNumericUsageField(schema))
-    .map(([key, schema]) => [
-      key,
-      schema instanceof z.ZodOptional
-        ? FiniteNumber.optional().prefault(0)
-        : FiniteNumber,
-    ]),
-);
-
 /**
  * Parsing schema with safe number coercion.
  *
@@ -80,12 +64,16 @@ const numericUsageParsingShape = Object.fromEntries(
  * loudly on failure, instead of defaulting to zero. Never wrap this in
  * `.catch()` for persisted/cost data — see `parseUsageData`'s docs and #7464.
  */
-export const TokenUsageStatsParsingBaseSchema = z.strictObject({
-  ...numericUsageParsingShape,
+export const TokenUsageStatsParsingBaseSchema = TokenUsageStatsSchema.extend({
+  inputTokens: FiniteNumber,
+  outputTokens: FiniteNumber,
+  cost: FiniteNumber,
+  cacheReadInputTokens: FiniteNumber.optional().prefault(0),
+  cacheMissInputTokens: FiniteNumber.optional().prefault(0),
+  cacheCreationInputTokens: FiniteNumber.optional().prefault(0),
+  reasoningTokens: FiniteNumber.optional().prefault(0),
   usageRoute: UsageRouteSchema.optional(),
-  // The numeric fields are derived from `TokenUsageStatsSchema.shape` above;
-  // TypeScript cannot recover the required keys through `Object.fromEntries`.
-}) as unknown as z.ZodType<TokenUsageStats>;
+});
 
 export interface ParsedUsageData {
   /** Successfully parsed, non-empty per-run usage. */

--- a/src/shared/schemas/usage.ts
+++ b/src/shared/schemas/usage.ts
@@ -43,53 +43,7 @@ export const TokenUsageStatsBaseSchema = z.strictObject({
 
 export type TokenUsageStats = z.infer<typeof TokenUsageStatsBaseSchema>;
 
-/**
- * Migrate the retired `viaChatGptSubscription` boolean into the canonical
- * `usageRoute` field. Single source of the mapping for every usage schema
- * that still accepts the legacy flag on parse (`TokenUsageStatsSchema` here,
- * `TokenUsageStatsParsingBaseSchema` in `streamData.ts`) — persisted usage
- * rows written before `usageRoute` existed are reparsed on every load, so
- * the copies must not drift.
- */
-function resolveLegacyUsageRoute<T extends { usageRoute?: UsageRoute }>(
-  usage: T,
-  viaChatGptSubscription: boolean | undefined,
-): T {
-  const usageRoute =
-    usage.usageRoute ??
-    (viaChatGptSubscription === true ? 'chatgpt-subscription' : undefined);
-  return usageRoute == null ? usage : { ...usage, usageRoute };
-}
-
-/**
- * Appends the retired `viaChatGptSubscription` field to an object schema whose
- * output already carries `usageRoute`, then applies the shared legacy-route
- * migration transform. Single home for the migration envelope: every usage
- * schema that still accepts the legacy flag on parse (`TokenUsageStatsSchema`
- * here, `TokenUsageStatsParsingBaseSchema` in `streamData.ts`,
- * `NormalizedUsageSchema` in `@agent/types/NormalizedUsage`) wraps its own base
- * with this, so the field spelling and the transform can't drift — persisted
- * usage rows written before `usageRoute` existed are reparsed on every load,
- * so a silent divergence would corrupt cost data (see #7464).
- */
-export function withLegacyUsageRoute<S extends { usageRoute?: UsageRoute }>(
-  base: z.ZodType<S>,
-): z.ZodType<S> {
-  return (base as z.ZodObject<z.ZodRawShape>)
-    .extend({ viaChatGptSubscription: z.boolean().optional() })
-    .transform(({ viaChatGptSubscription, ...usage }) =>
-      // The `ZodObject<ZodRawShape>` cast widens the added field's output type
-      // to `unknown`; the schema itself guarantees `boolean | undefined`.
-      resolveLegacyUsageRoute(
-        usage as S,
-        viaChatGptSubscription as boolean | undefined,
-      ),
-    );
-}
-
-export const TokenUsageStatsSchema = withLegacyUsageRoute<TokenUsageStats>(
-  TokenUsageStatsBaseSchema,
-);
+export const TokenUsageStatsSchema = TokenUsageStatsBaseSchema;
 
 type EmptyUsageStats = Required<Omit<TokenUsageStats, 'usageRoute'>> &
   Pick<TokenUsageStats, 'usageRoute'>;

--- a/src/shared/schemas/usage.ts
+++ b/src/shared/schemas/usage.ts
@@ -30,7 +30,7 @@ export const UsageRouteSchema = z.enum([
 
 export type UsageRoute = z.infer<typeof UsageRouteSchema>;
 
-export const TokenUsageStatsBaseSchema = z.strictObject({
+export const TokenUsageStatsSchema = z.strictObject({
   inputTokens: TokenCountSchema,
   outputTokens: TokenCountSchema,
   cost: z.number().nonnegative(),
@@ -41,9 +41,7 @@ export const TokenUsageStatsBaseSchema = z.strictObject({
   usageRoute: UsageRouteSchema.optional(),
 });
 
-export type TokenUsageStats = z.infer<typeof TokenUsageStatsBaseSchema>;
-
-export const TokenUsageStatsSchema = TokenUsageStatsBaseSchema;
+export type TokenUsageStats = z.infer<typeof TokenUsageStatsSchema>;
 
 type EmptyUsageStats = Required<Omit<TokenUsageStats, 'usageRoute'>> &
   Pick<TokenUsageStats, 'usageRoute'>;
@@ -114,7 +112,7 @@ export const RunUsageMapSchema = z.record(z.string(), TokenUsageStatsSchema);
  * Extended token usage with per-round deltas. Note: percentageCached is
  * calculated from accumulated session totals for overall caching effectiveness.
  */
-export const ExtendedTokenUsageStatsSchema = TokenUsageStatsBaseSchema.extend({
+export const ExtendedTokenUsageStatsSchema = TokenUsageStatsSchema.extend({
   elapsedTime: z.number().nonnegative().optional(),
   percentageCached: z.number().nonnegative().optional(),
   toolUseTokens: TokenCountSchema.optional(),

--- a/src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts
+++ b/src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts
@@ -5,116 +5,28 @@ import { describe, expect, it } from 'vitest';
 import {
   AgentWorkspaceState,
   FileInteractionState,
-  type AgentWorkspaceSnapshot,
 } from '@agent/core/state/AgentWorkspaceState';
-import type { TodoItem } from '@shared/schemas';
-
-const todo: TodoItem = {
-  content: 'Consolidate plan and todo state',
-  status: 'in_progress',
-  activeForm: 'Consolidating plan and todo state',
-};
-
-const legacyPlan = {
-  summary: 'Use one workspace owner for plan and todo progress.',
-  steps: [
-    {
-      title: 'Introduce owner',
-      description: 'Move plan and todo progress behind WorkPlanState.',
-      status: 'pending',
-      files: ['src/agent/core/AgentWorkspaceState.ts'],
-    },
-  ],
-};
-
-const objectivePlan = {
-  objective: 'Use one workspace owner for plan and todo progress.',
-};
 
 describe('agent workspace work-plan state', () => {
   it.each([
-    {
-      name: 'a retired structured plan',
-      snapshot: { todos: { todos: [todo] }, plan: { plan: legacyPlan } },
-    },
-    {
-      name: 'a retired structured plan hidden behind a null workPlan',
-      snapshot: {
-        workPlan: null,
-        todos: { todos: [todo] },
-        plan: { plan: legacyPlan },
-      },
-    },
-    {
-      name: 'invalid legacy todo entries instead of clearing them',
-      snapshot: {
-        todos: { todos: [{ content: 'Missing status and active form' }] },
-      },
-    },
-    {
-      name: 'a bare legacy todo object without a wrapper key',
-      snapshot: { todos: { content: 'Missing wrapper key' } },
-    },
-    {
-      name: 'invalid current workPlan entries instead of falling back to legacy fields',
-      snapshot: {
-        workPlan: { todos: [{ content: 'Missing status and active form' }] },
-      },
-    },
-  ])('rejects $name', ({ snapshot }) => {
+    ['a snapshot without workPlan', {}],
+    ['a retired todo/plan snapshot', { todos: [], plan: null }],
+    ['a null workPlan', { workPlan: null }],
+    [
+      'invalid current workPlan entries',
+      { workPlan: { todos: [{ content: 'Missing status and active form' }] } },
+    ],
+  ])('rejects %s', (_name, snapshot) => {
     expect(() => AgentWorkspaceState.fromSnapshot(snapshot)).toThrow();
   });
 
-  it('treats legacy null todos as absent', () => {
-    const state = AgentWorkspaceState.fromSnapshot({
-      todos: null,
-    });
+  it('round-trips the canonical work-plan snapshot', () => {
+    const state = AgentWorkspaceState.create();
+    const snapshot = state.toSnapshot();
 
-    expect(state.workPlan.todos).toEqual([]);
-  });
-
-  it('preserves a bare legacy plan document without a wrapper key', () => {
-    const state = AgentWorkspaceState.fromSnapshot({
-      plan: objectivePlan,
-    });
-
-    expect(state.workPlan.plan).toEqual(objectivePlan);
-    expect(state.workPlan.planSummary).toBe(objectivePlan.objective);
-  });
-
-  it('confines legacy todo/plan migration to the boundary hydration path', () => {
-    const legacySnapshot = {
-      todos: { todos: [todo] },
-      plan: { plan: objectivePlan },
-    };
-
-    // Regression: the single hydration boundary (session-init resume in
-    // ToolUsePrepareNode, reflection resume in runReflectionFlow) must keep
-    // migrating a persisted legacy record.
-    const hydrated = AgentWorkspaceState.fromSnapshot(legacySnapshot);
-    expect(hydrated.workPlan.todos).toEqual([todo]);
-    expect(hydrated.workPlan.plan).toEqual(objectivePlan);
-    expect(hydrated.workPlan.planSummary).toBe(objectivePlan.objective);
-
-    // Per-round node prep (ToolUseCycleNode, ResponseCycleNode,
-    // MediaExtractionNode) only ever rehydrates this run's own canonical
-    // toSnapshot() output via fromCanonicalSnapshot, which takes the
-    // canonical type and must never fall back to the legacy shape — a
-    // legacy-shaped record reaching it is corruption, not a format to
-    // silently migrate.
-    expect(() =>
-      AgentWorkspaceState.fromCanonicalSnapshot(
-        legacySnapshot as unknown as AgentWorkspaceSnapshot,
-      ),
-    ).toThrow();
-
-    // The canonical round-trip (toSnapshot -> fromCanonicalSnapshot) that
-    // every subsequent round actually exercises keeps working.
-    const canonicalSnapshot = hydrated.toSnapshot();
-    const rehydrated =
-      AgentWorkspaceState.fromCanonicalSnapshot(canonicalSnapshot);
-    expect(rehydrated.workPlan.todos).toEqual([todo]);
-    expect(rehydrated.workPlan.plan).toEqual(objectivePlan);
+    expect(AgentWorkspaceState.fromSnapshot(snapshot).toSnapshot()).toEqual(
+      snapshot,
+    );
   });
 });
 

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -204,7 +204,7 @@ describe('runReflectionFlow persisted-state recovery', () => {
     expect(await store.read(key)).toEqual(stored);
   });
 
-  it('migrates a valid legacy workspace snapshot before canonical writes', async () => {
+  it('rejects and preserves a retired workspace snapshot', async () => {
     const { key, run, store } = recoveryCase('legacy-workspace');
     const todo = {
       content: 'Preserve legacy workflow state',
@@ -226,13 +226,12 @@ describe('runReflectionFlow persisted-state recovery', () => {
     };
     await store.write(key, flowRecord(legacyShared));
 
-    const result = await run();
-
-    expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
-    const stored = await store.read<FlowRecord>(key);
-    const shared = ReflectionFlowStateCanonicalSchema.parse(stored?.shared);
-    expect(shared.workspaceSnapshot.workPlan.todos).toEqual([todo]);
-    expect(Object.hasOwn(shared.workspaceSnapshot, 'todos')).toBe(false);
+    await expect(run()).rejects.toMatchObject({
+      name: PersistedFlowStateError.name,
+      reason: 'invalid-shared',
+      cause: expect.objectContaining({ name: 'ZodError' }),
+    });
+    expect(await store.read(key)).toEqual(flowRecord(legacyShared));
   });
 
   it('clears a persisted cancellation latch when resuming a workflow', async () => {

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -21,7 +21,7 @@ import {
   runReflectionFlow,
   type RunReflectionFlowInput,
 } from '@agent/implementations/flows/reflection/runReflectionFlow';
-import { ReflectionFlowStateCanonicalSchema } from '@agent/implementations/flows/reflection/ReflectionFlowState';
+import { ReflectionFlowStateSchema } from '@agent/implementations/flows/reflection/ReflectionFlowState';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { createRunScope } from '@agent/runtime/RunScope';
 import {
@@ -129,9 +129,7 @@ describe('runReflectionFlow persisted-state recovery', () => {
 
     expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
     const stored = await store.read<FlowRecord>(key);
-    expect(
-      ReflectionFlowStateCanonicalSchema.parse(stored?.shared),
-    ).toMatchObject({
+    expect(ReflectionFlowStateSchema.parse(stored?.shared)).toMatchObject({
       currentRound: 0,
       totalRounds: 1,
       conversation: [],
@@ -248,8 +246,8 @@ describe('runReflectionFlow persisted-state recovery', () => {
 
     expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
     const stored = await store.read<FlowRecord>(key);
-    expect(
-      ReflectionFlowStateCanonicalSchema.parse(stored?.shared).continueRounds,
-    ).toBe(true);
+    expect(ReflectionFlowStateSchema.parse(stored?.shared).continueRounds).toBe(
+      true,
+    );
   });
 });

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -38,8 +38,7 @@ import {
   type ToolUseFlowAttachment,
 } from '@agent/implementations/flows/tooluse/runToolUseFlow';
 import {
-  migrateSharedState,
-  ToolUseRunSharedCanonicalSchema,
+  parseToolUseShared,
   type StateSlicesSnapshot,
 } from '@agent/implementations/flows/tooluse/nodes/types';
 import {
@@ -402,7 +401,7 @@ describe('retrieveSessionResumeData', () => {
 
   it('rejects malformed fields at the shared-state boundary', () => {
     expect(
-      migrateSharedState({
+      parseToolUseShared({
         messages: [],
         shouldSkipCycle: 'false',
         stateSlices: null,
@@ -414,7 +413,7 @@ describe('retrieveSessionResumeData', () => {
   });
 
   it('rejects a malformed MODEL user variable at the shared-state boundary', () => {
-    const result = migrateSharedState({
+    const result = parseToolUseShared({
       messages: [],
       continuationGenerationId: CONTINUATION_GENERATION_ID,
       shouldSkipCycle: false,
@@ -463,7 +462,7 @@ describe('retrieveSessionResumeData', () => {
 
   it('preserves structured output at the persisted shared-state boundary', () => {
     const continuationGenerationId = '6f2051ec-5169-4fb5-9830-47aba9df665a';
-    const result = migrateSharedState({
+    const result = parseToolUseShared({
       messages: [],
       continuationGenerationId,
       shouldSkipCycle: false,
@@ -477,26 +476,26 @@ describe('retrieveSessionResumeData', () => {
         continuationGenerationId,
         structured: { title: 'Durable result' },
       }),
-      migrated: false,
+      changed: false,
     });
   });
 
   it('does not derive a missing model id from the MODEL user variable', () => {
-    const result = migrateSharedState({
+    const result = parseToolUseShared({
       messages: [],
       continuationGenerationId: CONTINUATION_GENERATION_ID,
       shouldSkipCycle: false,
       stateSlices: defaultStateSlices('gpt54', { MODEL: 'gpt55' }),
     });
 
-    expect(result).toMatchObject({ success: true, migrated: false });
+    expect(result).toMatchObject({ success: true, changed: false });
     if (!result.success) return;
     expect(result.data).not.toHaveProperty('modelId');
   });
 
   it('keeps a persisted model id over the MODEL variable', () => {
     const continuationGenerationId = '8439c273-d7f7-442a-9930-e63e941263d8';
-    const result = migrateSharedState({
+    const result = parseToolUseShared({
       messages: [],
       continuationGenerationId,
       modelId: 'gpt55',
@@ -507,7 +506,7 @@ describe('retrieveSessionResumeData', () => {
     expect(result).toMatchObject({
       success: true,
       data: { continuationGenerationId, modelId: 'gpt55' },
-      migrated: false,
+      changed: false,
     });
   });
 
@@ -515,7 +514,7 @@ describe('retrieveSessionResumeData', () => {
     // The pre-fencing omission reader is retired: intermediate-era records
     // that never persisted a generation id fail the parse loudly instead of
     // being backfilled with a fresh UUID.
-    const result = migrateSharedState({
+    const result = parseToolUseShared({
       messages: [],
       shouldSkipCycle: false,
       stateSlices: null,
@@ -685,12 +684,10 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
 
     expect(result.outcome).toBe(STREAM_PHASE.WAITING);
     const stored = await readFlowRecord(executionId);
-    expect(ToolUseRunSharedCanonicalSchema.parse(stored?.shared)).toMatchObject(
-      {
-        messages: snapshot.shared.messages,
-        stateSlices: snapshot.shared.stateSlices,
-      },
-    );
+    expect(stored?.shared).toMatchObject({
+      messages: snapshot.shared.messages,
+      stateSlices: snapshot.shared.stateSlices,
+    });
   });
 
   it.each([
@@ -1703,7 +1700,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
   });
 
   it('rejects a retired workspace snapshot at the tool-use resume boundary', () => {
-    const result = migrateSharedState({
+    const result = parseToolUseShared({
       ...VALID_TOOL_USE_SHARED,
       stateSlices: {
         runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -53,6 +53,7 @@ import { setupPlatform } from '@test/support/setupPlatform';
 import { createTestSession } from '@test/support/sessionTestUtils';
 
 import { testModelCell } from './modelCellTestUtils';
+import { reflectionFlowShared } from './progressTestUtils';
 import { roundModelHandler } from './toolUseRoundTestUtils';
 
 const CONFIG = AgentConfigSchema.parse({
@@ -412,7 +413,7 @@ describe('retrieveSessionResumeData', () => {
     });
   });
 
-  it('rejects a malformed legacy MODEL user variable at the shared-state boundary', () => {
+  it('rejects a malformed MODEL user variable at the shared-state boundary', () => {
     const result = migrateSharedState({
       messages: [],
       continuationGenerationId: CONTINUATION_GENERATION_ID,
@@ -432,11 +433,13 @@ describe('retrieveSessionResumeData', () => {
     const executionId = 'workflow-current-conversation' as ExecutionId;
     const streamId =
       'reflection@gpt54#workflow-current-conversation' as StreamTabId;
-    await writeFlowRecord(executionId, {
-      currentRound: 1,
-      totalRounds: 2,
-      conversation: [{ role: 'user', content: 'Continue.' }],
-    });
+    await writeFlowRecord(
+      executionId,
+      reflectionFlowShared({
+        currentRound: 1,
+        conversation: [{ role: 'user', content: 'Continue.' }],
+      }),
+    );
 
     await expect(
       retrieveSessionResumeData(streamId, executionId, WORKFLOW_CONFIG),
@@ -478,7 +481,7 @@ describe('retrieveSessionResumeData', () => {
     });
   });
 
-  it('derives a missing model id from the legacy MODEL variable', () => {
+  it('does not derive a missing model id from the MODEL user variable', () => {
     const result = migrateSharedState({
       messages: [],
       continuationGenerationId: CONTINUATION_GENERATION_ID,
@@ -486,12 +489,9 @@ describe('retrieveSessionResumeData', () => {
       stateSlices: defaultStateSlices('gpt54', { MODEL: 'gpt55' }),
     });
 
-    expect(result).toMatchObject({
-      success: true,
-      data: { modelId: 'gpt55' },
-      // The derivation is a migration: the record must be rewritten with it.
-      migrated: true,
-    });
+    expect(result).toMatchObject({ success: true, migrated: false });
+    if (!result.success) return;
+    expect(result.data).not.toHaveProperty('modelId');
   });
 
   it('keeps a persisted model id over the MODEL variable', () => {
@@ -543,7 +543,7 @@ describe('retrieveSessionResumeData', () => {
     expect(resume.agentConfig.model).toBe('gpt55');
   });
 
-  it('lifts the legacy MODEL variable into the model id at the boundary', async () => {
+  it('uses the launch model when only MODEL contains a retired identity', async () => {
     const executionId = 'abc123-legacy-model' as ExecutionId;
     const streamId = 'chat@gpt54#abc123-legacy-model' as StreamTabId;
     await writeFlowRecord(executionId, {
@@ -555,8 +555,8 @@ describe('retrieveSessionResumeData', () => {
 
     const resume = await retrieveToolUseResume(streamId, executionId);
 
-    expect(resume.shared.modelId).toBe('gpt55');
-    expect(resume.agentConfig.model).toBe('gpt55');
+    expect(resume.shared.modelId).toBeUndefined();
+    expect(resume.agentConfig.model).toBe(CONFIG.model);
   });
 
   it('falls back to the launch model when nothing persisted a model', async () => {
@@ -1702,68 +1702,16 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     });
   });
 
-  it.each([
-    { name: 'direct stored-state recovery', withResume: false },
-    { name: 'retrieved canonical resume', withResume: true },
-  ])(
-    'migrates a legacy workspace before strict validation: $name',
-    async ({ withResume }) => {
-      const suffix = withResume ? 'retrieved' : 'stored';
-      const executionId = `abc141-${suffix}` as ExecutionId;
-      const streamId = `chat@gpt54#abc141-${suffix}` as StreamTabId;
-      const legacyWorkspaceSnapshot = {
-        todos: [
-          {
-            content: 'Ship the fix',
-            status: 'in_progress',
-            activeForm: 'Shipping the fix',
-          },
-        ],
-        plan: { objective: 'Migrate legacy workspace snapshots on resume' },
-      };
-      await writeFlowRecord(
-        executionId,
-        {
-          messages: [{ role: 'user', content: 'Continue.' }],
-          continuationGenerationId: CONTINUATION_GENERATION_ID,
-          shouldSkipCycle: true,
-          stateSlices: {
-            runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-            workspaceSnapshot: legacyWorkspaceSnapshot,
-            userChannels: {
-              input: Object.freeze({ MODEL: 'gpt54' }),
-              transient: {},
-            },
-          },
-        },
-        {
-          cursor: { nextNodeId: 'start/default' },
-          nodes: [{ action: 'default', nodeId: 'start' }],
-        },
-      );
+  it('rejects a retired workspace snapshot at the tool-use resume boundary', () => {
+    const result = migrateSharedState({
+      ...VALID_TOOL_USE_SHARED,
+      stateSlices: {
+        runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+        workspaceSnapshot: { todos: [], plan: null },
+        userChannels: { input: Object.freeze({}), transient: {} },
+      },
+    });
 
-      const resume = withResume
-        ? await retrieveToolUseResume(streamId, executionId)
-        : undefined;
-      const result = await runPersistedFlow(executionId, streamId, resume);
-      expect(result.outcome).toBe(STREAM_PHASE.WAITING);
-
-      const healedRecord = await readFlowRecord(executionId);
-      const healedShared = ToolUseRunSharedCanonicalSchema.parse(
-        healedRecord?.shared,
-      );
-      expect(healedShared.modelId).toBe('gpt54');
-      expect(healedShared.stateSlices).not.toBeNull();
-      if (!healedShared.stateSlices) return;
-      const workspaceState = AgentWorkspaceState.fromCanonicalSnapshot(
-        healedShared.stateSlices.workspaceSnapshot,
-      );
-      expect(workspaceState.workPlan.todos).toEqual(
-        legacyWorkspaceSnapshot.todos,
-      );
-      expect(workspaceState.workPlan.plan).toEqual(
-        legacyWorkspaceSnapshot.plan,
-      );
-    },
-  );
+    expect(result.success).toBe(false);
+  });
 });

--- a/src/test-kernel/agent/followUp/ModelSwitchState.vitest.ts
+++ b/src/test-kernel/agent/followUp/ModelSwitchState.vitest.ts
@@ -1,22 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  currentModelFromUserChannels,
-  setToolUseSharedModel,
-} from '@agent/implementations/flows/tooluse/modelSwitchState';
+import { setToolUseSharedModel } from '@agent/implementations/flows/tooluse/modelSwitchState';
 import type { ToolUseRunShared } from '@agent/implementations/flows/tooluse/nodes/types';
 import { toolUseRunShared } from '../progressTestUtils';
 
 describe('tool-use model switch state helpers', () => {
-  it('prefers the transient model over the launch model', () => {
-    expect(
-      currentModelFromUserChannels({
-        input: Object.freeze({ MODEL: 'gpt54' }),
-        transient: { MODEL: 'gpt55' },
-      }),
-    ).toBe('gpt55');
-  });
-
   it('writes the model id and reprojects MODEL without rewriting input variables', () => {
     const input = Object.freeze({ MODEL: 'gpt54' });
     const shared = {

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -7,6 +7,8 @@ import {
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
 import { flowKey } from '@agent/node/persistedFlow';
+import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
+import { ReflectionFlowStateSchema } from '@agent/implementations/flows/reflection/ReflectionFlowState';
 import {
   CLI_HISTORY_RESUMABLE_STATUS,
   formatCliHistoryDetailsText,
@@ -152,11 +154,24 @@ describe('CLI history status formatting', () => {
 
   it('marks workflow flow records as CLI-resumable', async () => {
     const id = 'workflow-with-flow' as ExecutionId;
-    await seedFlowRecord(id, WORKFLOW_CONFIG, 'correct', {
-      currentRound: 1,
-      totalRounds: 2,
-      conversation: [],
-    });
+    await seedFlowRecord(
+      id,
+      WORKFLOW_CONFIG,
+      'correct',
+      ReflectionFlowStateSchema.parse({
+        currentRound: 1,
+        totalRounds: 2,
+        workspaceSnapshot: AgentWorkspaceState.emptySnapshot(),
+        context: null,
+        outputLocation: null,
+        conversation: [],
+        runStateSnapshot: {},
+        roundStateSnapshots: [],
+        roundOutputs: [],
+        continueRounds: false,
+        endTurn: false,
+      }),
+    );
 
     const details = await readCliHistoryDetails(id);
 

--- a/src/test-kernel/common/SdkErrorUtils.vitest.ts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.ts
@@ -1066,7 +1066,7 @@ describe('attachProviderError end-to-end', () => {
     // Simulates a cached error attached before the retryable/exhaustion-flag
     // migration ran — e.g. a resumed tool-use flow's raw persisted
     // `lastError`, which bypasses the schema-level migration on that resume
-    // path (migrateSharedState casts the persisted shape directly).
+    // path (parseToolUseShared parses the persisted shape directly).
     const legacyCached = {
       message: 'legacy relay-limit record',
       retryable: true,

--- a/src/test-kernel/progressView/UsagePanel.vitest.ts
+++ b/src/test-kernel/progressView/UsagePanel.vitest.ts
@@ -3,11 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports
 import type { UsagePanel } from '@progressView/frontend/components/UsagePanel';
-import {
-  TokenUsageStatsSchema,
-  type TokenUsageStats,
-  type UsageRoute,
-} from '@shared/schemas';
+import { type TokenUsageStats, type UsageRoute } from '@shared/schemas';
 
 // Local file imports
 import {
@@ -46,13 +42,9 @@ function usageAriaLabel(element: UsagePanel): string {
 
 describe('usage-panel route badges', () => {
   it('shows subscription-backed usage as Free · ChatGPT', async () => {
-    const legacyUsage = TokenUsageStatsSchema.parse({
-      inputTokens: 1200,
-      outputTokens: 80,
-      cost: 0,
-      viaChatGptSubscription: true,
-    });
-    const element = await mountUsagePanel(legacyUsage);
+    const element = await mountUsagePanel(
+      usage({ cost: 0, usageRoute: 'chatgpt-subscription' }),
+    );
 
     expect(panelText(element)).toContain('Free · ChatGPT');
     expect(usageAriaLabel(element)).toContain('Free via ChatGPT');

--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -84,29 +84,16 @@ describe('OutputXmlSummarySchema — strict shape', () => {
   });
 });
 
-describe('ContextManagementDataSchema — legacy missing tokensAfter/utilizationAfter', () => {
-  const legacyBase = {
+describe('ContextManagementDataSchema', () => {
+  const base = {
     tokensBefore: 1000,
     contextWindow: 200_000,
     utilizationBefore: 5,
   };
 
-  it('defaults tokensAfter/utilizationAfter from the before-values on a pre-union entry', () => {
-    const result = ContextManagementDataSchema.parse({
-      ...legacyBase,
-      action: 'clear_tool_uses',
-    });
-
-    expect(result).toMatchObject({
-      action: 'clear_tool_uses',
-      tokensAfter: 1000,
-      utilizationAfter: 5,
-    });
-  });
-
   it('passes an already-populated tokens-freed entry through unchanged', () => {
     const result = ContextManagementDataSchema.parse({
-      ...legacyBase,
+      ...base,
       action: 'compaction',
       tokensAfter: 400,
       utilizationAfter: 2,
@@ -118,9 +105,15 @@ describe('ContextManagementDataSchema — legacy missing tokensAfter/utilization
   it('still requires originalMaxTokens/reducedMaxTokens for max_tokens_reduced', () => {
     expect(() =>
       ContextManagementDataSchema.parse({
-        ...legacyBase,
+        ...base,
         action: 'max_tokens_reduced',
       }),
+    ).toThrow();
+  });
+
+  it('rejects retired entries missing their completion statistics', () => {
+    expect(() =>
+      ContextManagementDataSchema.parse({ ...base, action: 'clear_tool_uses' }),
     ).toThrow();
   });
 });

--- a/src/test-kernel/schemas/StreamDataUsage.vitest.ts
+++ b/src/test-kernel/schemas/StreamDataUsage.vitest.ts
@@ -95,7 +95,6 @@ describe('stream data usage parsing', () => {
         outputTokens: '2',
         cost: '0',
         cacheReadInputTokens: '3',
-        viaChatGptSubscription: true,
         usageRoute: 'chatgpt-subscription',
       },
     });
@@ -106,30 +105,10 @@ describe('stream data usage parsing', () => {
       cacheCreationInputTokens: 0,
       usageRoute: 'chatgpt-subscription',
     });
-    expect(usage.get('run')).not.toHaveProperty('viaChatGptSubscription');
-  });
-
-  it('normalizes persisted legacy subscription markers to usageRoute', () => {
-    const { usage } = parseUsageData({
-      run: {
-        inputTokens: 10,
-        outputTokens: 2,
-        cost: 0,
-        viaChatGptSubscription: true,
-      },
-    });
-
-    expect(usage.get('run')).toMatchObject({
-      inputTokens: 10,
-      outputTokens: 2,
-      cost: 0,
-      usageRoute: 'chatgpt-subscription',
-    });
-    expect(usage.get('run')).not.toHaveProperty('viaChatGptSubscription');
   });
 
   it.each([
-    ['subscription marker', { viaChatGptSubscription: 'yes' }],
+    ['retired subscription marker', { viaChatGptSubscription: true }],
     ['usage route', { usageRoute: 'unknown-route' }],
   ])('preserves a run with a malformed %s', (_field, malformedField) => {
     const warnSpy = mockWarn();

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -42,6 +42,7 @@ import {
   TokenUsageStatsParsingBaseSchema,
   type CompileFailure,
   type ExecutionId,
+  type ExtendedTokenUsageStats,
   type OutputFileInfo,
   type RunIdentity,
   type Plan,
@@ -983,9 +984,18 @@ export class StreamSnapshotStore {
   private addUsage(
     stream: StreamTabId,
     storageKey: StorageKey,
-    usage: TokenUsageStats,
+    usage: ExtendedTokenUsageStats,
   ): void {
-    const parsed = TokenUsageStatsParsingBaseSchema.safeParse(usage);
+    // UI-only per-round display fields are not part of the durable usage row.
+    // Remove them at this live-event boundary so the strict persisted schema
+    // continues to reject unknown fields from disk.
+    const {
+      elapsedTime: _elapsedTime,
+      percentageCached: _percentageCached,
+      toolUseTokens: _toolUseTokens,
+      ...persistedUsage
+    } = usage;
+    const parsed = TokenUsageStatsParsingBaseSchema.safeParse(persistedUsage);
     if (!parsed.success) {
       log.warn(
         `Discarding malformed usage delta for run ${storageKey} on stream ` +


### PR DESCRIPTION
Closes #10763

## Summary
- remove expired workspace-snapshot, model-identity, usage-route, and context-management normalizers at their sole persisted-data boundaries
- validate full workflow state during resume retrieval so an old workspace snapshot is reported non-resumable before lifecycle execution starts
- retain the explicitly out-of-scope archive, roster, and external-producer compatibility paths
- delete compatibility-only tests and retain focused canonical/rejection coverage

## Validation
- `corepack pnpm exec vitest run src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts src/test-kernel/agent/SessionResumeRetrieval.vitest.ts src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts src/test-kernel/agent/followUp/ModelSwitchState.vitest.ts src/test-kernel/schemas/SchemaMigrations.vitest.ts src/test-kernel/schemas/StreamDataUsage.vitest.ts src/test-kernel/progressView/UsagePanel.vitest.ts` (103 passed)
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- changed-file ESLint
- `git diff --check`

R8: no production references remain to `withLegacyUsageRoute`, `viaChatGptSubscription`, or the retired workspace migration arms.

Production: +48/-265. Tests: +64/-253.