### PR TITLE
refactor(runtime): type internal carriers

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -2294,7 +2294,7 @@ function appendHarnessStatus(): void {
       }),
       approval: formatTexraApprovalPolicy(harnessRuntimeSession.approvalPolicy),
       approvalBypasses: slice?.bypass,
-      status: slice?.status ?? 'not started',
+      status: slice?.status,
       goal: GoalStore.getForStream(streamId),
       queuedFollowUpMessages: defaultSession().followUps.getAll(streamId),
     }),

--- a/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/sessionCommands.ts
@@ -150,7 +150,7 @@ export async function showCliSessionStatus(
       }),
       approval: formatTexraApprovalPolicy(context.getApprovalPolicy()),
       approvalBypasses: slice?.bypass,
-      status: slice?.status ?? 'not started',
+      status: slice?.status,
       substate: slice?.substate,
       activeChildSessions,
       goal: activeStreamId ? GoalStore.getForStream(activeStreamId) : undefined,

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -4,7 +4,7 @@ import {
 } from '@cli/runtime/modelAccessRoute';
 import { getRuntimeModelLabel } from '@model/runtimeModelRegistry';
 import type { TexraApprovalPolicy } from '@shared/approvalPolicy';
-import type { StreamSubstate } from '@shared/schemas';
+import type { StreamPhase, StreamSubstate } from '@shared/schemas';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
 import { BACKGROUND_TASK } from '@shared/copy/nestedRuns';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
@@ -28,7 +28,7 @@ export interface CliSessionStatusInput {
   readonly modelAccess: CliModelAccessRoute;
   readonly approval: string;
   readonly approvalBypasses?: Partial<BypassState>;
-  readonly status: string;
+  readonly status: StreamPhase | undefined;
   readonly substate?: StreamSubstate;
   readonly activeChildSessions?: number;
   readonly goal?: CliSessionGoalStatus | null;
@@ -43,7 +43,7 @@ export interface CliSessionStatusInput {
 }
 
 export function formatCliStatusLabel(
-  status: string | undefined,
+  status: StreamPhase | undefined,
   substate?: StreamSubstate,
   isChildStream?: boolean,
 ): string {
@@ -96,7 +96,11 @@ export function formatCliSessionStatus(input: CliSessionStatusInput): string {
     ...(bypassLabels.length > 0
       ? [`auto-approvals: ${bypassLabels.join(', ')}`]
       : []),
-    `status: ${formatCliStatusLabel(input.status, input.substate)}`,
+    `status: ${
+      input.status === undefined
+        ? 'not started'
+        : formatCliStatusLabel(input.status, input.substate)
+    }`,
     ...(input.activeChildSessions && input.activeChildSessions > 0
       ? [`active ${BACKGROUND_TASK.inlinePlural}: ${input.activeChildSessions}`]
       : []),

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -17,17 +17,14 @@ import type { AgentConfig } from '@agent/runtime';
 import { loadChatExportInput } from '@agent/export/loadChatExportInput';
 import type { ChatExportInput } from '@agent/export/schemas';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
-import type {
-  ExecutionId,
-  ExecutionMeta,
-  HistoryRunStatus,
-} from '@shared/schemas';
+import type { ExecutionId, ExecutionMeta } from '@shared/schemas';
+import { ExecutionIdSchema, RunOutcomeSchema } from '@shared/schemas';
 import {
-  ExecutionIdSchema,
   HISTORY_RUN_STATUS,
   HISTORY_RUN_STATUS_LABEL,
   resolveHistoryRunStatus,
-} from '@shared/schemas';
+  type HistoryRunStatus,
+} from '@shared/schemas/historyRunStatus';
 import { runOutcomeToExecutionStatus } from '@shared/streams/streamStatus';
 import { GoalStore } from '@tools/goal';
 import {
@@ -421,7 +418,7 @@ function toNdjsonHistoryStatus(status: HistoryRunStatus): string {
   ) {
     return status;
   }
-  return runOutcomeToExecutionStatus(status);
+  return runOutcomeToExecutionStatus(RunOutcomeSchema.parse(status));
 }
 
 export function cliHistoryNdjsonRecords(

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -24,9 +24,9 @@ import type {
 } from '@shared/schemas';
 import {
   ExecutionIdSchema,
+  HISTORY_RUN_STATUS,
   HISTORY_RUN_STATUS_LABEL,
   resolveHistoryRunStatus,
-  RunOutcomeSchema,
 } from '@shared/schemas';
 import { runOutcomeToExecutionStatus } from '@shared/streams/streamStatus';
 import { GoalStore } from '@tools/goal';
@@ -414,9 +414,14 @@ export function formatInvalidExportFormatText(raw: string): string {
  * 'resumable'/'unknown' pass through unchanged. Internal and human-readable
  * output keeps `HistoryRunStatus`.
  */
-function toNdjsonHistoryStatus(status: string): string {
-  const outcome = RunOutcomeSchema.safeParse(status);
-  return outcome.success ? runOutcomeToExecutionStatus(outcome.data) : status;
+function toNdjsonHistoryStatus(status: HistoryRunStatus): string {
+  if (
+    status === HISTORY_RUN_STATUS.RESUMABLE ||
+    status === HISTORY_RUN_STATUS.UNKNOWN
+  ) {
+    return status;
+  }
+  return runOutcomeToExecutionStatus(status);
 }
 
 export function cliHistoryNdjsonRecords(

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -29,7 +29,11 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 // Local imports
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import '@shared/wa/spinner';
-import type { LogMessageData, TaskGroup } from '@shared/schemas';
+import type {
+  LogMessageData,
+  StreamLifecycleStatus,
+  TaskGroup,
+} from '@shared/schemas';
 import { designTokens } from '@shared/styles';
 import { postMessage } from '@shared/hostBridge';
 import { PersistedState } from '@shared/state/PersistedState';
@@ -68,7 +72,7 @@ interface CachedStream {
   messageGeneration: number;
   toggleStates: ToggleStateStore;
   ref: Ref<TaskGroupList>;
-  status: string | null;
+  status: StreamLifecycleStatus | null;
   /** Whether this cached stream is tool-use. */
   isToolUse: boolean;
   /** Whether to render this stream's logs in terminal style. */

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -17,6 +17,7 @@ import {
   STREAM_PHASE,
   STREAM_SUBSTATE,
   runIdentityDisplayName,
+  type StreamLifecycleStatus,
   type StreamState,
   type StreamSubstate,
   type StreamTabId,
@@ -129,7 +130,8 @@ class StreamTab extends LitElement {
   static override styles = [designTokens, streamTabStyles];
 
   @property({ attribute: false }) info!: StreamTabInfo;
-  @property({ type: String }) status: string = DEFAULT_STREAM_METADATA_STATUS;
+  @property({ attribute: false }) status: StreamLifecycleStatus =
+    DEFAULT_STREAM_METADATA_STATUS;
   @property({ attribute: false }) substate: StreamSubstate | undefined;
   @property({ attribute: false }) lastTimestamp: number | undefined = undefined;
   @property({ type: Boolean }) active = false;
@@ -156,7 +158,7 @@ class StreamTab extends LitElement {
 
   override render(): TemplateResult {
     const stream = this.info;
-    const status = this.status || DEFAULT_STREAM_METADATA_STATUS;
+    const status = this.status;
     const { label, displayKey } = progressHeaderStatus(status, this.substate);
     const statusKey = displayKey ?? status;
     const lifecycleStatusLabel = label ?? status;

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -13,10 +13,11 @@ import {
   GettingStartedActionSchema,
   MESSAGE_TYPES,
   STREAM_PHASE,
-  StreamPhaseSchema,
+  STREAM_STATUS,
   WorkflowCallProgressSchema,
   type GettingStartedAction,
   type LogMessageData,
+  type StreamLifecycleStatus,
   type TaskGroup,
 } from '@shared/schemas';
 import { designTokens } from '@shared/styles';
@@ -118,7 +119,8 @@ export class TaskGroupList extends LitElement {
   @property({ type: Boolean }) isToolUse = false;
 
   /** Status for the active stream, used while a run exists before logs arrive. */
-  @property({ attribute: false }) streamStatus: string | null = null;
+  @property({ attribute: false }) streamStatus: StreamLifecycleStatus | null =
+    null;
 
   /** Toggle state store for persistence */
   @property({ attribute: false }) toggleStates: ToggleStateStore | null = null;
@@ -592,8 +594,9 @@ export class TaskGroupList extends LitElement {
     // with no messages the terminal buffer is empty and would render a blank
     // <pre>, so show the same "Run is starting" / idle text instead.
     if (this.messages.length === 0 && this.groups.length === 0) {
-      const parsedPhase = StreamPhaseSchema.safeParse(this.streamStatus);
-      const active = parsedPhase.success && isInFlightPhase(parsedPhase.data);
+      const active =
+        this.streamStatus !== STREAM_STATUS.READY &&
+        isInFlightPhase(this.streamStatus ?? undefined);
       return html`
         <div class="log-placeholder">
           ${

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -22,10 +22,7 @@ import {
 } from '@agent/core/flows/BaseFlowServices';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
-import {
-  AttachedMemoryMissesSchema,
-  type AttachedMemoryMiss,
-} from '@agent/types/AttachedMemory';
+import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 import {
   createModelHandler,
@@ -490,9 +487,7 @@ async function assembleAgentLaunchContext(
     input: Object.freeze(baseVars),
     transient: { ...baseVars },
   };
-  const attachedMemoryMisses = AttachedMemoryMissesSchema.parse(
-    baseVars.ATTACHED_MEMORY_MISSES,
-  );
+  const attachedMemoryMisses = baseVars.ATTACHED_MEMORY_MISSES;
 
   const usageMonitor = new UsageMonitor(
     modelCell,

--- a/src/agent/runtime/UsageMonitor.ts
+++ b/src/agent/runtime/UsageMonitor.ts
@@ -9,7 +9,7 @@ import type {
   StreamTabId,
   UsageRoute,
 } from '@shared/schemas';
-import { AgentCategory } from '@shared/schemas';
+import { AgentCategory, UsageProviderSchema } from '@shared/schemas';
 import {
   USAGE_LOG_FLUSH_OUTCOME,
   UsageLogService,
@@ -217,7 +217,6 @@ export class UsageMonitor {
           cost: roundCost,
           usageRoute,
         },
-        latestUsage.provider,
       );
     } catch (error) {
       logger.error(`Error printing ${runKind} statistics`, { data: error });
@@ -273,12 +272,12 @@ export class UsageMonitor {
       | 'reasoningTokens'
       | 'cost'
     > & { cacheMissInputTokens: number; usageRoute?: UsageRoute },
-    provider: NonNullable<
-      AgentRunStateSnapshot['usageAccumulator']['latestUsage']
-    >['provider'],
   ): Promise<void> {
     try {
       const { config } = this.modelInfo;
+      const provider = UsageProviderSchema.catch('unknown').parse(
+        config.provider,
+      );
       const cachedInputTokens = usage.cachedInputTokens ?? 0;
       const usedRelay = usage.usageRoute === 'relay';
 

--- a/src/agent/runtime/UsageMonitor.ts
+++ b/src/agent/runtime/UsageMonitor.ts
@@ -206,18 +206,15 @@ export class UsageMonitor {
 
       // Log to backend for analytics/billing. Relay-backed rounds wait for the
       // flush because the next relay request enforces the cap from DB state.
-      await this.logToBackend(
-        stateGlobal.totalResponseTimeMs,
-        {
-          inputTokens: roundInputTokens,
-          outputTokens: roundOutputTokens,
-          cachedInputTokens: roundCacheReadTokens,
-          cacheMissInputTokens: roundCacheMissTokens.billing,
-          reasoningTokens: roundReasoningTokens,
-          cost: roundCost,
-          usageRoute,
-        },
-      );
+      await this.logToBackend(stateGlobal.totalResponseTimeMs, {
+        inputTokens: roundInputTokens,
+        outputTokens: roundOutputTokens,
+        cachedInputTokens: roundCacheReadTokens,
+        cacheMissInputTokens: roundCacheMissTokens.billing,
+        reasoningTokens: roundReasoningTokens,
+        cost: roundCost,
+        usageRoute,
+      });
     } catch (error) {
       logger.error(`Error printing ${runKind} statistics`, { data: error });
     }

--- a/src/agent/types/AttachedMemory.ts
+++ b/src/agent/types/AttachedMemory.ts
@@ -6,8 +6,3 @@ export const AttachedMemoryMissSchema = z.object({
 });
 
 export type AttachedMemoryMiss = z.infer<typeof AttachedMemoryMissSchema>;
-
-/** Tolerant: malformed or missing input parses to an empty list. */
-export const AttachedMemoryMissesSchema = z
-  .array(AttachedMemoryMissSchema)
-  .catch([]);

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -14,8 +14,6 @@
  * - free tier: Included non-premium models (up to $3/M input)
  */
 
-import type { ModelProvider } from 'llm-zoo';
-
 import type { StateStore } from '@platform/interfaces';
 import type { SpendingStatus, SpendingStatusError } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -26,6 +24,7 @@ import {
   FREE_TIER,
   type UserTier,
 } from '../config';
+import type { ModelProvider } from 'llm-zoo';
 import type { TierService } from './TierService';
 
 interface ServerSideKeyLogger {

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -14,9 +14,10 @@
  * - free tier: Included non-premium models (up to $3/M input)
  */
 
+import type { ModelProvider } from 'llm-zoo';
+
 import type { StateStore } from '@platform/interfaces';
 import type { SpendingStatus, SpendingStatusError } from '@shared/schemas';
-import type { ServerSideProvider } from '@shared/constants/providers';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { SupabaseClient } from '../SupabaseClient';
 import {
@@ -42,7 +43,7 @@ interface ServerSideKeyLogger {
 const ANONYMOUS_FETCH_BACKOFF_MS = 30_000;
 
 /** Path suffixes for relay URLs, matching SDK expectations. */
-const RELAY_PATH_SUFFIXES: Partial<Record<ServerSideProvider, string>> = {
+const RELAY_PATH_SUFFIXES: Partial<Record<ModelProvider, string>> = {
   openai: '/v1',
   xai: '/v1',
   deepseek: '/v1',
@@ -240,8 +241,8 @@ export class ServerSideKeyService {
     if (!options.preserveTierCache) this.tierService.clearCache();
   }
 
-  isProviderOnServer(provider: string): boolean {
-    return this.tierService.getProviders().includes(provider.toLowerCase());
+  isProviderOnServer(provider: ModelProvider): boolean {
+    return this.tierService.getProviders().includes(provider);
   }
 
   private isAccessCacheValid(): boolean {
@@ -413,7 +414,10 @@ export class ServerSideKeyService {
     return this.tierService.isModelAvailable(userTier, modelName);
   }
 
-  shouldUseServerSideKeysSync(provider: string, modelName?: string): boolean {
+  shouldUseServerSideKeysSync(
+    provider: ModelProvider,
+    modelName?: string,
+  ): boolean {
     if (
       !this.useIncludedModelAccess ||
       !this.isProviderOnServer(provider) ||
@@ -428,9 +432,8 @@ export class ServerSideKeyService {
     return this.tierService.getExpirationDate();
   }
 
-  getRelayBaseUrl(provider: string): string {
-    const normalizedProvider = provider.toLowerCase() as ServerSideProvider;
-    const suffix = RELAY_PATH_SUFFIXES[normalizedProvider] ?? '';
-    return `${this.baseUrl}/functions/v1/relay/${normalizedProvider}${suffix}`;
+  getRelayBaseUrl(provider: ModelProvider): string {
+    const suffix = RELAY_PATH_SUFFIXES[provider] ?? '';
+    return `${this.baseUrl}/functions/v1/relay/${provider}${suffix}`;
   }
 }

--- a/src/model/includedModelAccess.ts
+++ b/src/model/includedModelAccess.ts
@@ -18,7 +18,7 @@
  * has said so by installing a provider.
  */
 
-import type { ReasoningEffort } from 'llm-zoo';
+import type { ModelProvider, ReasoningEffort } from 'llm-zoo';
 
 /**
  * The relay plane as the model layer consults it. Every member is a question
@@ -39,15 +39,18 @@ export interface IncludedModelAccess {
   /** Whether the primed tier cache covers this model. */
   canUseModelSync(modelName: string): boolean;
   /** Whether included access serves this provider at all. */
-  isProviderOnServer(provider: string): boolean;
+  isProviderOnServer(provider: ModelProvider): boolean;
   /** Combined sync gate: switched on, provider served, model in tier. */
-  shouldUseServerSideKeysSync(provider: string, modelName?: string): boolean;
+  shouldUseServerSideKeysSync(
+    provider: ModelProvider,
+    modelName?: string,
+  ): boolean;
   /** Whether included access was just switched off by quota exhaustion. */
   wasQuotaAutoSwitched(): boolean;
   /** Whether the account's included-access quota is exhausted. */
   isRelayQuotaExceeded(): boolean;
   /** Base URL for this provider's requests through included access. */
-  getRelayBaseUrl(provider: string): string;
+  getRelayBaseUrl(provider: ModelProvider): string;
   /** Bearer credential for an included-access request, or `null` if unavailable. */
   getAccessToken(forceRefresh?: boolean): Promise<string | null>;
   /** Whether that credential is close enough to expiry to warrant a refresh. */

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -205,9 +205,6 @@ export const MODEL_SOURCE_ORDER = [
 /**
  * All providers that support server-side API keys.
  * Derived from PROVIDER_REGISTRY — no manual sync needed.
- *
- * Note: We use a type-level extraction so ServerSideProvider is a proper
- * union of literal ModelProvider values, not just `ModelProvider`.
  */
 type ServerKeyEntry = Extract<
   (typeof PROVIDER_REGISTRY)[number],
@@ -215,9 +212,6 @@ type ServerKeyEntry = Extract<
 >;
 export const SERVER_SIDE_PROVIDER_IDS: readonly ServerKeyEntry['id'][] =
   PROVIDER_REGISTRY.filter((p) => p.hasServerKey).map((p) => p.id);
-
-/** Type for providers that support server-side keys (narrow union, not just ModelProvider). */
-export type ServerSideProvider = ServerKeyEntry['id'];
 
 /** Consolidated provider display names used across settings UI and model selection. */
 export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -16,9 +16,6 @@ import { WorkflowExecutionSnapshotSchema } from './workflowExecutionSnapshot';
  *    `StreamLifecycleStatusSchema` and `StreamSnapshot.status` (§8.3's
  *    permanent boundary — a static exported file stays legacy-shaped
  *    forever).
- * 2. Display tolerance for that input
- *    (`@shared/streams/streamStatusDisplay`).
- *
  * The trait table that used to hang off this enum is gone: membership
  * questions are answered by the `StreamPhase` predicates in
  * `@shared/streams/streamStatus` (`isActivePhase`, `isInFlightPhase`,
@@ -164,21 +161,17 @@ export const StreamSubstateSchema = z.enum(STREAM_SUBSTATE);
 export type StreamSubstate = z.infer<typeof StreamSubstateSchema>;
 
 export function executionStatusToRunOutcome(
-  status: string | undefined,
+  status: ExecutionStatus | undefined,
 ): RunOutcome | undefined {
-  const runOutcome = RunOutcomeSchema.safeParse(status);
-  if (runOutcome.success) return runOutcome.data;
-
-  const parsed = ExecutionStatusSchema.safeParse(status);
-  if (!parsed.success) return undefined;
-
-  switch (parsed.data) {
+  switch (status) {
     case EXECUTION_STATUS.COMPLETED:
       return RUN_OUTCOME.COMPLETED;
     case EXECUTION_STATUS.INTERRUPTED:
       return RUN_OUTCOME.CANCELLED;
     case EXECUTION_STATUS.ERROR:
       return RUN_OUTCOME.FAILED;
+    case undefined:
+      return undefined;
   }
 }
 

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -9,7 +9,7 @@ import { WorkflowExecutionSnapshotSchema } from './workflowExecutionSnapshot';
  * The retired 7-value live-status vocabulary. **Read-only residue** — no
  * production code decides anything from it any more (#7993 steps 2-3 moved
  * every live producer and host reader to `StreamPhase` + `StreamSubstate`).
- * It survives for exactly two reasons:
+ * It survives for one reason:
  *
  * 1. The standalone trace-viewer's file import (`replayTrace.ts`) parses
  *    externally-authored `trace.json` exports through

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -2,35 +2,43 @@ import {
   STREAM_PHASE,
   STREAM_STATUS,
   STREAM_SUBSTATE,
-  StreamPhaseSchema,
   type PhaseStage,
   type RoundStage,
-  type StreamPhase,
+  type StreamLifecycleStatus,
   type StreamStage,
   type StreamSubstate,
 } from '@shared/schemas';
 
-export type StreamStatusDisplayKey = StreamPhase | StreamSubstate | 'ready';
+export type StreamStatusDisplayKey =
+  | Exclude<StreamLifecycleStatus, typeof STREAM_STATUS.READY>
+  | StreamSubstate
+  | 'ready';
 
 /**
  * Display key for a `StreamLifecycleStatus` (a `StreamPhase`, or the `ready`
- * idle sentinel every host defaults an unstarted stream to). Anything else —
- * including the retired 7-value `StreamStatus` vocabulary, which no live
- * producer emits and which every read boundary normalizes before it reaches a
- * renderer — has no key, and callers fall back to showing the raw string.
+ * idle sentinel every host defaults an unstarted stream to).
  */
 export function streamStatusDisplayKey(
-  status: string | undefined,
+  status: StreamLifecycleStatus,
+  substate?: StreamSubstate,
+): StreamStatusDisplayKey;
+
+export function streamStatusDisplayKey(
+  status: StreamLifecycleStatus | undefined,
+  substate?: StreamSubstate,
+): StreamStatusDisplayKey | undefined;
+
+export function streamStatusDisplayKey(
+  status: StreamLifecycleStatus | undefined,
   substate?: StreamSubstate,
 ): StreamStatusDisplayKey | undefined {
+  if (status === undefined) return undefined;
   if (status === STREAM_STATUS.READY) return 'ready';
-  const phase = StreamPhaseSchema.safeParse(status);
-  if (!phase.success) return undefined;
-  return substate ?? phase.data;
+  return substate ?? status;
 }
 
 export function streamStatusIndicatorClass(
-  status: string | undefined,
+  status: StreamLifecycleStatus | undefined,
   substate?: StreamSubstate,
 ): string | undefined {
   const key = streamStatusDisplayKey(status, substate);
@@ -77,28 +85,27 @@ interface FormatStreamStatusLabelOptions {
 }
 
 export function formatStreamStatusLabel(
-  status: string | undefined,
+  status: StreamLifecycleStatus | undefined,
   options: FormatStreamStatusLabelOptions & { readonly missingLabel: string },
 ): string;
 
 export function formatStreamStatusLabel(
-  status: string,
+  status: StreamLifecycleStatus,
   options?: FormatStreamStatusLabelOptions,
 ): string;
 
 export function formatStreamStatusLabel(
-  status: string | undefined,
+  status: StreamLifecycleStatus | undefined,
   options?: FormatStreamStatusLabelOptions,
 ): string | undefined;
 
 export function formatStreamStatusLabel(
-  status: string | undefined,
+  status: StreamLifecycleStatus | undefined,
   options: FormatStreamStatusLabelOptions = {},
 ): string | undefined {
   if (status == null) return options.missingLabel;
   const style = options.style ?? 'progressHeader';
   const key = streamStatusDisplayKey(status, options.substate);
-  if (!key) return status;
   return STREAM_STATUS_LABELS[style][key];
 }
 
@@ -108,11 +115,9 @@ export function formatStreamStatusLabel(
  * `streamStatusDisplayKey` are the same status→vocabulary lookup seen from
  * two sides (a label and the key that drives icon/state styling), so callers
  * that need both compute them together instead of double-parsing the status.
- * A status with no display key (unknown/legacy vocabulary) falls back to the
- * raw string as the label, matching `formatStreamStatusLabel`.
  */
 export function progressHeaderStatus(
-  status: string | undefined,
+  status: StreamLifecycleStatus | undefined,
   substate?: StreamSubstate,
 ): {
   label: string | undefined;

--- a/src/test-kernel/auth/ServerSideKeyService.vitest.ts
+++ b/src/test-kernel/auth/ServerSideKeyService.vitest.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ModelProvider } from 'llm-zoo';
 
 // Local imports
 import { ULTRA_TIER } from '@auth/config';
@@ -269,13 +270,17 @@ describe('ServerSideKeyService anonymous access cache', () => {
 
     expect(await authenticatedFetch).toBe(true);
     expect(service.getUserTier()).toBe(ULTRA_TIER);
-    expect(service.shouldUseServerSideKeysSync('openai')).toBe(true);
+    expect(service.shouldUseServerSideKeysSync(ModelProvider.OPENAI)).toBe(
+      true,
+    );
 
     firstAuthentication.resolve(false);
     expect(await anonymousFetch).toBe(false);
 
     expect(service.getUserTier()).toBe(ULTRA_TIER);
-    expect(service.shouldUseServerSideKeysSync('openai')).toBe(true);
+    expect(service.shouldUseServerSideKeysSync(ModelProvider.OPENAI)).toBe(
+      true,
+    );
   });
 
   it('retries an authenticated Ultra check after a config fetch fails', async () => {

--- a/src/test-kernel/cli/SessionStatus.vitest.ts
+++ b/src/test-kernel/cli/SessionStatus.vitest.ts
@@ -13,7 +13,7 @@ function sessionStatus(overrides: Partial<CliSessionStatusInput> = {}): string {
     model: 'harness-model',
     modelAccess: 'personal',
     approval: 'ask',
-    status: 'running',
+    status: STREAM_PHASE.RUNNING,
     queuedFollowUpMessages: [],
     ...overrides,
   });
@@ -134,7 +134,7 @@ describe('CLI session status formatter', () => {
 
   it('omits session lines before the first run starts', () => {
     const status = sessionStatus({
-      status: 'not started',
+      status: undefined,
     });
 
     expect(status).not.toContain('session:');
@@ -144,7 +144,7 @@ describe('CLI session status formatter', () => {
   it('reports an empty follow-up queue explicitly', () => {
     expect(
       sessionStatus({
-        status: 'waiting',
+        status: STREAM_PHASE.WAITING,
       }),
     ).toContain('queued follow-ups: 0');
   });
@@ -163,7 +163,7 @@ describe('CLI session status formatter', () => {
     const status = sessionStatus({
       approval: 'ask before privileged actions',
       approvalBypasses: { superYolo: true, bash: true, toolEdit: true },
-      status: 'waiting',
+      status: STREAM_PHASE.WAITING,
     });
 
     expect(status).toContain(
@@ -176,7 +176,7 @@ describe('CLI session status formatter', () => {
     const status = sessionStatus({
       modelAccess: 'included',
       approval: 'ask before privileged actions',
-      status: 'stopped',
+      status: STREAM_PHASE.CANCELLED,
       goal: {
         status: 'active',
         objective:
@@ -226,7 +226,6 @@ describe('CLI session status formatter', () => {
   it('uses the footer label for an idle waiting stream', () => {
     expect(formatCliStatusLabel(STREAM_PHASE.WAITING)).toBe('idle');
     expect(formatCliStatusLabel(undefined, undefined, true)).toBe('');
-    expect(formatCliStatusLabel('stopped', undefined, true)).toBe('stopped');
     expect(
       sessionStatus({
         agent: 'research',

--- a/src/test-kernel/model/IncludedModelAccessDefault.vitest.ts
+++ b/src/test-kernel/model/IncludedModelAccessDefault.vitest.ts
@@ -106,7 +106,7 @@ describe('bring-your-own-key is the model layer default', () => {
 
   it('refuses to fabricate a relay URL when nothing is installed', () => {
     assert.throws(
-      () => includedModelAccess().getRelayBaseUrl('openai'),
+      () => includedModelAccess().getRelayBaseUrl(ModelProvider.OPENAI),
       /No included model access is installed/,
     );
   });
@@ -128,7 +128,7 @@ describe('bring-your-own-key is the model layer default', () => {
     const access = includedModelAccess();
     assert.equal(access.getUseIncludedModelAccess(), false);
     assert.equal(
-      access.shouldUseServerSideKeysSync('openai', 'gpt-5.5'),
+      access.shouldUseServerSideKeysSync(ModelProvider.OPENAI, 'gpt-5.5'),
       false,
     );
     assert.equal(await access.canUseServerSideKeys(), false);

--- a/src/test-kernel/shared/SharedStreams.vitest.ts
+++ b/src/test-kernel/shared/SharedStreams.vitest.ts
@@ -8,6 +8,7 @@ import {
   STREAM_PHASE,
   STREAM_STATUS,
   STREAM_SUBSTATE,
+  type StreamLifecycleStatus,
 } from '@shared/schemas';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import { buildStreamMetadata } from '@shared/streams/streamMetadata';
@@ -200,7 +201,9 @@ describe('formatStageLabel', () => {
 });
 
 describe('stream status display labels', () => {
-  const wordingCases: Array<[StreamStatusLabelStyle, string, string]> = [
+  const wordingCases: Array<
+    [StreamStatusLabelStyle, StreamLifecycleStatus, string]
+  > = [
     ['cli', STREAM_PHASE.WAITING, 'idle'],
     ['cliCompact', STREAM_PHASE.WAITING, 'idle'],
     ['progressHeader', STREAM_PHASE.WAITING, 'Idle'],
@@ -237,9 +240,7 @@ describe('stream status display labels', () => {
     },
   );
 
-  it('passes through unknown statuses and supports an explicit missing label', () => {
-    expect(formatStreamStatusLabel('custom')).toBe('custom');
-    expect(formatStreamStatusLabel('')).toBe('');
+  it('supports an explicit missing label', () => {
     expect(formatStreamStatusLabel(undefined, { missingLabel: '-' })).toBe('-');
   });
 
@@ -275,17 +276,4 @@ describe('stream status display labels', () => {
       expect(streamStatusIndicatorClass(status)).toBe(className);
     },
   );
-
-  // The retired 7-value StreamStatus vocabulary no longer has a display
-  // branch (v0.41 cut): no live producer emits it, and both permanent read
-  // boundaries — StreamLogStore.parsePersistedEntries and the trace-viewer's
-  // file import — normalize to StreamPhase before a renderer sees it. An
-  // unnormalized legacy value now falls through as an unknown status: the raw
-  // string is shown rather than a silently wrong canonical label.
-  it('treats a retired legacy status as unknown', () => {
-    const status = STREAM_STATUS.INITIALIZING;
-    expect(streamStatusDisplayKey(status)).toBeUndefined();
-    expect(streamStatusIndicatorClass(status)).toBeUndefined();
-    expect(formatStreamStatusLabel(status)).toBe(status);
-  });
 });

--- a/src/test-kernel/utils/config/ConfigUtils.vitest.ts
+++ b/src/test-kernel/utils/config/ConfigUtils.vitest.ts
@@ -10,7 +10,9 @@ import { getValidatedConfig } from '@utils/config/configUtils';
 import {
   getProviderEndpoint,
   getProviderKeyUrl,
+  getProviderStreaming,
   getUseOpenRouter,
+  setProviderStreaming,
 } from '@utils/config/providerConfig';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 
@@ -173,6 +175,18 @@ describe('getProviderEndpoint', () => {
 
   it('returns empty string for a provider with no endpoint key', () => {
     expect(getProviderEndpoint('not-a-real-provider')).toBe('');
+  });
+});
+
+describe('OpenRouter streaming', () => {
+  it('uses the same setting for API-key and model-dispatch spellings', async () => {
+    await installPlatform({
+      globalState: { [GlobalStateKey.STREAMING_OPENROUTER]: false },
+    });
+
+    expect(getProviderStreaming('openRouter')).toBe(false);
+    await setProviderStreaming('openRouter', true);
+    expect(getProviderStreaming('openrouter')).toBe(true);
   });
 });
 

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -25,14 +25,11 @@ import { GlobalStateKey } from '@shared/state/stateKeys';
 import { readPlatformSetting } from './platformSettings';
 
 const PROVIDERS: ReadonlyMap<string, ProviderStateEntry> = new Map(
-  PROVIDER_STATE_ENTRIES.map((provider) => [
-    provider.id.toLowerCase(),
-    provider,
-  ]),
+  PROVIDER_STATE_ENTRIES.map((provider) => [provider.id, provider]),
 );
 
 function entry(provider: string): ProviderStateEntry | undefined {
-  return PROVIDERS.get(provider.toLowerCase());
+  return PROVIDERS.get(provider);
 }
 
 /** Non-catalog fallback — see the module-level "Canonical read path" note. */

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -29,7 +29,7 @@ const PROVIDERS: ReadonlyMap<string, ProviderStateEntry> = new Map(
 );
 
 function entry(provider: string): ProviderStateEntry | undefined {
-  return PROVIDERS.get(provider);
+  return PROVIDERS.get(provider) ?? PROVIDERS.get(provider.toLowerCase());
 }
 
 /** Non-catalog fallback — see the module-level "Canonical read path" note. */


### PR DESCRIPTION
## Summary

- Carry canonical stream phases and run outcomes through CLI and progress-view renderers instead of reparsing strings.
- Preserve attached-memory misses as their producer-owned typed value instead of laundering them through a fallback schema.
- Carry canonical `ModelProvider` values through included-access routing and provider configuration instead of lowercasing at each consumer.

## Issue acceptance gates

Closes #10768.

- Retypes the status carriers and keeps narrowing at persisted/trace boundaries.
- Removes the `ATTACHED_MEMORY_MISSES` reparsing path and its corruption-to-empty fallback.
- Removes all four audited production `provider.toLowerCase()` sites.
- Covers all three carriers in one coherent batch, per the requested larger-PR workflow.

## Single source of truth

`StreamLifecycleStatus`/`StreamPhase`, `BuiltUserVars.ATTACHED_MEMORY_MISSES`, and llm-zoo's `ModelProvider` now own their respective internal facts. Zod schemas remain at storage and wire boundaries.

## Duplication and abstraction budget

Removed repeated status parsing, one compatibility schema, and four provider normalization calls. Added no new abstraction or pass-through layer.

## Net elements (R6)

- Files: 19 changed, 0 added, 0 deleted.
- Exported symbols: -1 (`AttachedMemoryMissesSchema`); no new exported symbol.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Net LoC: +1 (108 additions, 107 deletions), primarily type signatures and overload declarations replacing runtime parsers.

## Consumer counts (R8)

No emit path or event key changed. The deleted `AttachedMemoryMissesSchema` had one production consumer, replaced by the typed producer value. Residue greps found no remaining production `AttachedMemoryMissesSchema`, downstream status `safeParse`, or audited `provider.toLowerCase()` site.

## Host impact

Extension: progress-view stream status properties now carry `StreamLifecycleStatus` directly; rendering is unchanged.

Desktop: no desktop-specific behavior change; shared included-access provider types become canonical.

CLI: session/history status formatting consumes typed phases/outcomes; an absent pre-run phase still renders as `not started`.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `corepack pnpm exec prettier --check <19 changed files>`
- `npm run typecheck`
- `npm run lint`
- Focused Vitest: 11 files, 196 tests passed
- Full `npm test`: 878 files passed, 1 skipped; 10,727 tests passed, 5 skipped
- `git diff --check`
