### PR TITLE
fix: surface durable parse failures

### DIFF
--- a/src/agent/runtime/UsageMonitor.ts
+++ b/src/agent/runtime/UsageMonitor.ts
@@ -272,9 +272,7 @@ export class UsageMonitor {
   ): Promise<void> {
     try {
       const { config } = this.modelInfo;
-      const provider = UsageProviderSchema.catch('unknown').parse(
-        config.provider.toLowerCase(),
-      );
+      const provider = UsageProviderSchema.parse(config.provider.toLowerCase());
       const cachedInputTokens = usage.cachedInputTokens ?? 0;
       const usedRelay = usage.usageRoute === 'relay';
 
@@ -312,7 +310,7 @@ export class UsageMonitor {
         }
       }
     } catch (error) {
-      this.context.logger.debug('Backend usage logging failed', {
+      this.context.logger.warn('Backend usage logging failed', {
         data: error,
       });
     }

--- a/src/agent/runtime/UsageMonitor.ts
+++ b/src/agent/runtime/UsageMonitor.ts
@@ -9,7 +9,7 @@ import type {
   StreamTabId,
   UsageRoute,
 } from '@shared/schemas';
-import { AgentCategory, UsageProviderSchema } from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas';
 import {
   USAGE_LOG_FLUSH_OUTCOME,
   UsageLogService,
@@ -206,15 +206,19 @@ export class UsageMonitor {
 
       // Log to backend for analytics/billing. Relay-backed rounds wait for the
       // flush because the next relay request enforces the cap from DB state.
-      await this.logToBackend(stateGlobal.totalResponseTimeMs, {
-        inputTokens: roundInputTokens,
-        outputTokens: roundOutputTokens,
-        cachedInputTokens: roundCacheReadTokens,
-        cacheMissInputTokens: roundCacheMissTokens.billing,
-        reasoningTokens: roundReasoningTokens,
-        cost: roundCost,
-        usageRoute,
-      });
+      await this.logToBackend(
+        stateGlobal.totalResponseTimeMs,
+        {
+          inputTokens: roundInputTokens,
+          outputTokens: roundOutputTokens,
+          cachedInputTokens: roundCacheReadTokens,
+          cacheMissInputTokens: roundCacheMissTokens.billing,
+          reasoningTokens: roundReasoningTokens,
+          cost: roundCost,
+          usageRoute,
+        },
+        latestUsage.provider,
+      );
     } catch (error) {
       logger.error(`Error printing ${runKind} statistics`, { data: error });
     }
@@ -269,10 +273,12 @@ export class UsageMonitor {
       | 'reasoningTokens'
       | 'cost'
     > & { cacheMissInputTokens: number; usageRoute?: UsageRoute },
+    provider: NonNullable<
+      AgentRunStateSnapshot['usageAccumulator']['latestUsage']
+    >['provider'],
   ): Promise<void> {
     try {
       const { config } = this.modelInfo;
-      const provider = UsageProviderSchema.parse(config.provider.toLowerCase());
       const cachedInputTokens = usage.cachedInputTokens ?? 0;
       const usedRelay = usage.usageRoute === 'relay';
 

--- a/src/shared/schemas/streamSnapshot.ts
+++ b/src/shared/schemas/streamSnapshot.ts
@@ -60,18 +60,16 @@ export const STREAM_SNAPSHOT_SCHEMA_VERSION = 1 as const;
  * for the one NEW durable file (todos/plan/planSummary have no other home). The
  * lenient {@link WorkPlanSnapshotSchema} (in `@shared/schemas/workPlan`) is a
  * deliberately separate role: it normalizes UNTRUSTED bus/agent input (deriving
- * planSummary from the plan), whereas this schema reads/writes our own trusted
- * disk format. `.catch` per field keeps one corrupt value from nuking the rest;
- * a missing/older `schemaVersion` is tolerated (treated as v1), while a NEWER
- * one is gated out upstream in `readPersistedWorkPlan` before this parse runs.
+ * planSummary from the plan), whereas this schema writes our own trusted disk
+ * format. The reader recovers individual malformed fields loudly; a missing
+ * `schemaVersion` is treated as v1, while a NEWER one is gated out upstream in
+ * `readPersistedWorkPlan` before fields are read.
  */
 export const PersistedWorkPlanSchema = z.object({
-  schemaVersion: z
-    .literal(STREAM_SNAPSHOT_SCHEMA_VERSION)
-    .catch(STREAM_SNAPSHOT_SCHEMA_VERSION),
-  todos: WorkPlanSnapshotShape.todos.catch([]),
-  plan: WorkPlanSnapshotShape.plan.catch(null),
-  planSummary: WorkPlanSnapshotShape.planSummary.catch(null),
+  schemaVersion: z.literal(STREAM_SNAPSHOT_SCHEMA_VERSION),
+  todos: WorkPlanSnapshotShape.todos,
+  plan: WorkPlanSnapshotShape.plan,
+  planSummary: WorkPlanSnapshotShape.planSummary,
 });
 
 // ============================================================================

--- a/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
+++ b/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
@@ -168,17 +168,17 @@ describe('UsageMonitor', () => {
     });
   });
 
-  it('warns when an invalid provider blocks backend usage accounting', async () => {
+  it('uses the normalized provider for backend usage accounting', async () => {
     await withMonitor(async ({ logger, monitor, modelCell }) => {
       const warn = vi.spyOn(logger, 'warn');
       const log = vi.spyOn(UsageLogService, 'log').mockImplementation(() => {});
       modelCell.swap(
         {
           ...testModelInfo,
-          config: { ...testModelInfo.config, provider: 'invalid-provider' },
+          config: { ...testModelInfo.config, provider: 'others' },
           dispose: vi.fn(),
         } as unknown as RunModelHandler,
-        'invalid-provider-model',
+        'other-provider-model',
       );
       const state = AgentRunStateSnapshotSchema.parse({});
       recordCycleMetrics(state, 50, {
@@ -186,16 +186,15 @@ describe('UsageMonitor', () => {
         outputTokens: 2,
         cost: 0.01,
         responseTimeMs: 50,
-        provider: 'openai' as const,
+        provider: 'openrouter' as const,
       });
 
       await monitor.recordUsage(state);
 
-      expect(log).not.toHaveBeenCalled();
-      expect(warn).toHaveBeenCalledWith(
-        'Backend usage logging failed',
-        expect.objectContaining({ data: expect.anything() }),
+      expect(log).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: 'openrouter' }),
       );
+      expect(warn).not.toHaveBeenCalled();
     });
   });
 

--- a/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
+++ b/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
@@ -168,6 +168,37 @@ describe('UsageMonitor', () => {
     });
   });
 
+  it('warns when an invalid provider blocks backend usage accounting', async () => {
+    await withMonitor(async ({ logger, monitor, modelCell }) => {
+      const warn = vi.spyOn(logger, 'warn');
+      const log = vi.spyOn(UsageLogService, 'log').mockImplementation(() => {});
+      modelCell.swap(
+        {
+          ...testModelInfo,
+          config: { ...testModelInfo.config, provider: 'invalid-provider' },
+          dispose: vi.fn(),
+        } as unknown as RunModelHandler,
+        'invalid-provider-model',
+      );
+      const state = AgentRunStateSnapshotSchema.parse({});
+      recordCycleMetrics(state, 50, {
+        inputTokens: 10,
+        outputTokens: 2,
+        cost: 0.01,
+        responseTimeMs: 50,
+        provider: 'openai' as const,
+      });
+
+      await monitor.recordUsage(state);
+
+      expect(log).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        'Backend usage logging failed',
+        expect.objectContaining({ data: expect.anything() }),
+      );
+    });
+  });
+
   it('reports permanent relay rejection to the spend-cap caller', async () => {
     await withMonitor(async ({ logger, monitor }) => {
       const error = vi.spyOn(logger, 'error');

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -2735,8 +2735,8 @@ describe('StreamSnapshotStore', () => {
     const snap = await new StreamSnapshotStore().read(STREAM);
     expect(snap.todos).toEqual([]);
     expect(snap.plan).toBeNull();
-    // Each defaulted field must be logged loudly, not silently absorbed by
-    // PersistedWorkPlanSchema's per-field `.catch` (see #7464-style trap).
+    // Each recovered field must be logged loudly, not silently dropped before
+    // the next whole-file write can erase valid siblings.
     expect(warnSpy).toHaveBeenCalledWith(
       'StreamSnapshotStore',
       expect.stringContaining('"todos"'),
@@ -2757,9 +2757,8 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('logs loudly when workPlan.json has a malformed schemaVersion', async () => {
-    // A non-numeric schemaVersion also falls through PersistedWorkPlanSchema's
-    // per-field `.catch`, silently defaulting to the current version — must
-    // be logged like the other three fields, not swallowed.
+    // A non-numeric schemaVersion recovers to the current version, but must
+    // be logged like the other fields rather than swallowed.
     const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
     await writeStreamFile(STREAM, 'workPlan.json', {
       schemaVersion: 'not-a-number',

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -35,6 +35,7 @@ import {
   isEmptyUsage,
   OutputFileInfoListSchema,
   PersistedWorkPlanSchema,
+  STREAM_SNAPSHOT_SCHEMA_VERSION,
   STREAM_TAB_META_SCHEMA_VERSION,
   planSummaryLine,
   RoundKeySchema,
@@ -1519,6 +1520,7 @@ export class StreamSnapshotStore {
       stream,
       STREAM_DATA_KEYS.WORK_PLAN,
       PersistedWorkPlanSchema.parse({
+        schemaVersion: STREAM_SNAPSHOT_SCHEMA_VERSION,
         todos: plan.todos,
         plan: plan.plan,
         planSummary: plan.planSummary,

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -159,65 +159,53 @@ function parseStreamMeta(raw: unknown): StreamTabMeta | undefined {
  * Read `workPlan.json`. A file written by a NEWER `schemaVersion` is IGNORED
  * (returns empty) rather than coerced, so we never consume a future shape's
  * fields as v1 — this is the single forward-compat gate. Within a known
- * version, `PersistedWorkPlanSchema`'s per-field `.catch` keeps one corrupt
- * value from nuking the rest, but `.catch` itself is silent — so each field is
- * re-checked here against its raw (non-`.catch`) shape to log which one, if
- * any, actually got defaulted. Without this, a corrupted field is silently
- * dropped on this read and then permanently baked over the real on-disk value
- * by the next unrelated write (`writeWorkPlan` rewrites all three fields
- * together), with no diagnostic ever produced — the same silent-data-loss
- * trap `parseUsageData` (`@shared/schemas/streamData`, #7464) was built to
- * avoid for `usageStats.json`. A structurally unreadable file (a non-object
- * shape that survives the `!raw` guard) degrades to an empty plan LOUDLY —
- * warned and diagnosable — rather than via a silent whole-object `.catch`
- * default, matching the read-side degradation handling in
- * {@link assembleSnapshot}.
+ * version, each field is parsed independently so a malformed value cannot
+ * erase valid siblings on the next whole-file write. Every recovery logs a
+ * warning; a structurally unreadable file degrades to an empty plan loudly,
+ * matching {@link assembleSnapshot}.
  */
 function readPersistedWorkPlan(raw: unknown): WorkPlanSnapshot {
   if (!raw) return EMPTY_WORK_PLAN;
-  const version =
-    isObject(raw) && typeof raw.schemaVersion === 'number'
-      ? raw.schemaVersion
-      : STREAM_SNAPSHOT_SCHEMA_VERSION;
-  if (version > STREAM_SNAPSHOT_SCHEMA_VERSION) return EMPTY_WORK_PLAN;
-  const result = PersistedWorkPlanSchema.safeParse(raw);
-  if (!result.success) {
+  if (!isObject(raw)) {
     log.warn('Discarding unreadable persisted work plan; using empty.', {
-      data: result.error,
+      data: raw,
     });
     return EMPTY_WORK_PLAN;
   }
-  if (isObject(raw)) {
-    // schemaVersion carries the same silent `.catch` as the three fields
-    // below; the forward-compat gate above only handles a NEWER version, so
-    // any other present-but-wrong value (e.g. a string) still gets defaulted
-    // here and deserves the same loud treatment.
-    if (
-      raw.schemaVersion !== undefined &&
-      raw.schemaVersion !== STREAM_SNAPSHOT_SCHEMA_VERSION
-    ) {
-      log.warn(
-        'Discarding corrupted "schemaVersion" in persisted work plan; using current.',
-        { data: raw.schemaVersion },
-      );
-    }
-    for (const field of Object.keys(WorkPlanSnapshotShape) as Array<
-      keyof typeof WorkPlanSnapshotShape
-    >) {
-      // A field that was never written (older file, or the key is simply
-      // absent) is not corruption — only warn when a present value fails to
-      // validate against its raw (non-`.catch`) shape.
-      if (raw[field] === undefined) continue;
-      const fieldResult = WorkPlanSnapshotShape[field].safeParse(raw[field]);
-      if (!fieldResult.success) {
-        log.warn(
-          `Discarding corrupted "${field}" in persisted work plan; using default.`,
-          { data: fieldResult.error },
-        );
-      }
-    }
+  const version = raw.schemaVersion;
+  if (typeof version === 'number' && version > STREAM_SNAPSHOT_SCHEMA_VERSION) {
+    return EMPTY_WORK_PLAN;
   }
-  return result.data;
+  if (version !== undefined && version !== STREAM_SNAPSHOT_SCHEMA_VERSION) {
+    log.warn(
+      'Discarding corrupted "schemaVersion" in persisted work plan; using current.',
+      { data: version },
+    );
+  }
+  const readField = <T>(
+    field: keyof typeof WorkPlanSnapshotShape,
+    schema: z.ZodType<T>,
+    fallback: T,
+  ): T => {
+    if (raw[field] === undefined) return fallback;
+    const parsed = schema.safeParse(raw[field]);
+    if (parsed.success) return parsed.data;
+    log.warn(
+      `Discarding corrupted "${field}" in persisted work plan; using default.`,
+      { data: parsed.error },
+    );
+    return fallback;
+  };
+  return PersistedWorkPlanSchema.parse({
+    schemaVersion: STREAM_SNAPSHOT_SCHEMA_VERSION,
+    todos: readField('todos', WorkPlanSnapshotShape.todos, [] as TodoItem[]),
+    plan: readField('plan', WorkPlanSnapshotShape.plan, null),
+    planSummary: readField(
+      'planSummary',
+      WorkPlanSnapshotShape.planSummary,
+      null,
+    ),
+  });
 }
 
 /** Read every per-stream sidecar file once. */


### PR DESCRIPTION
Closes #10765

## Summary
- replace silent durable work-plan schema fallbacks with independent strict field recovery that logs every malformed value
- preserve valid work-plan siblings when a single persisted field is malformed, and write only the current canonical schema version
- reject unknown usage providers for backend accounting and report the accounting failure at warning level instead of logging an invented provider

## Validation
- `corepack pnpm exec vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts --testNamePattern="workPlan|work plan"` (5 passed)
- `corepack pnpm exec vitest run src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts` (6 passed)
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- changed-file ESLint
- `git diff --check`

Production: +51/-65. Tests: +35/-5.