### PR TITLE
fix: contain tool attachment failures

### DIFF
--- a/src/agent/core/tools/toolAttachmentExtraction.ts
+++ b/src/agent/core/tools/toolAttachmentExtraction.ts
@@ -2,7 +2,6 @@
 import {
   type FileReference,
   type ToolFileAttachment,
-  ToolFileAttachmentSchema,
   type ToolResult,
   ToolResultSchema,
   ValidationErrorDiagnosticsSchema,
@@ -28,14 +27,6 @@ export interface ExtractedToolAttachments {
 }
 
 /**
- * Type guard to check if a value is a valid ToolFileAttachment.
- * Uses Zod schema for validation.
- */
-function isToolFileAttachment(value: unknown): value is ToolFileAttachment {
-  return ToolFileAttachmentSchema.safeParse(value).success;
-}
-
-/**
  * Extracts file attachments from a tool result and returns a typed payload.
  * Binary data (base64Data, bytes) is stripped from the result.
  *
@@ -48,13 +39,10 @@ function isToolFileAttachment(value: unknown): value is ToolFileAttachment {
 export function extractToolAttachments(
   result: ToolResult,
 ): ExtractedToolAttachments {
-  const attachmentsCandidate = result.files;
-  const attachments: ToolFileAttachment[] = Array.isArray(attachmentsCandidate)
-    ? attachmentsCandidate.filter(isToolFileAttachment)
-    : [];
-
   const parsed = ToolResultSchema.parse(result);
   const status = parsed.status;
+  const attachments: ToolFileAttachment[] =
+    status === 'executed' ? (parsed.files ?? []) : [];
   const sanitizedResult: Record<string, unknown> = { status };
 
   for (const [key, value] of Object.entries(parsed)) {
@@ -96,6 +84,6 @@ export function extractToolAttachments(
 
   return {
     attachments,
-    sanitizedResult: ToolResultSchema.parse(sanitizedResult),
+    sanitizedResult: sanitizedResult as ToolResult,
   };
 }

--- a/src/agent/implementations/flows/tooluse/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/implementations/flows/tooluse/toolUseRound/ToolUseDispatchNode.ts
@@ -67,6 +67,11 @@ interface ToolExecutionResult {
   logRef: { logId: string | undefined; groupId: string | undefined };
 }
 
+interface SafeToolInvocation {
+  result: ToolResult;
+  extracted: ExtractedToolAttachments;
+}
+
 function endsToolUseTurn(result: ToolExecutionResult | null): boolean {
   return result?.result.status === 'executed' && result.result.endTurn === true;
 }
@@ -279,17 +284,18 @@ export class ToolUseDispatchNode<C> extends Node<
     onExecutionReady: (() => void) | undefined,
     onToolOutput: ((chunk: string) => void) | undefined,
     signal: AbortSignal,
-  ): Promise<ToolResult> {
+  ): Promise<SafeToolInvocation> {
     if (!tool) {
-      return {
+      const result: ToolResult = {
         status: 'error',
         error: `Unknown tool ${call.name}`,
       };
+      return { result, extracted: extractToolAttachments(result) };
     }
 
     const options = this.services;
     try {
-      return await withToolFileInteractionContext(
+      const result = await withToolFileInteractionContext(
         {
           tracker: options.workspace.interactions,
           workPlanState: options.workspace.workPlan,
@@ -313,13 +319,15 @@ export class ToolUseDispatchNode<C> extends Node<
         },
         () => tool.call(parsedInput),
       );
+      return { result, extracted: extractToolAttachments(result) };
     } catch (err) {
       const { message, diagnostics } = normalizeToolCallError(call.name, err);
-      return {
+      const result: ToolResult = {
         status: 'error',
         error: message.trim() || 'Tool execution failed.',
         ...(diagnostics ? { diagnostics } : {}),
       };
+      return { result, extracted: extractToolAttachments(result) };
     }
   }
 
@@ -379,7 +387,7 @@ export class ToolUseDispatchNode<C> extends Node<
 
     // Every call runs under the run's one signal, so a single interrupt
     // cancels the whole in-flight batch.
-    const result = await this.invokeToolSafely(
+    const { result, extracted } = await this.invokeToolSafely(
       call,
       tool,
       parsedInput,
@@ -419,7 +427,6 @@ export class ToolUseDispatchNode<C> extends Node<
       result.lineChanges = trackedEdits.lineChanges;
     }
 
-    const extracted = extractToolAttachments(result);
     const editedFiles = trackedEdits.paths.map((path) => ({
       path,
       ok: true,

--- a/src/agent/implementations/flows/tooluse/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/implementations/flows/tooluse/toolUseRound/ToolUseDispatchNode.ts
@@ -23,6 +23,7 @@ import {
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
 import type { FileLocation, ToolResult } from '@shared/schemas';
 import { isNonEmptyString } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { pathToLocation } from '@utils/files/fileLocation';
 
@@ -294,8 +295,9 @@ export class ToolUseDispatchNode<C> extends Node<
     }
 
     const options = this.services;
+    let result: ToolResult;
     try {
-      const result = await withToolFileInteractionContext(
+      result = await withToolFileInteractionContext(
         {
           tracker: options.workspace.interactions,
           workPlanState: options.workspace.workPlan,
@@ -319,13 +321,22 @@ export class ToolUseDispatchNode<C> extends Node<
         },
         () => tool.call(parsedInput),
       );
-      return { result, extracted: extractToolAttachments(result) };
     } catch (err) {
       const { message, diagnostics } = normalizeToolCallError(call.name, err);
-      const result: ToolResult = {
+      result = {
         status: 'error',
         error: message.trim() || 'Tool execution failed.',
         ...(diagnostics ? { diagnostics } : {}),
+      };
+      return { result, extracted: extractToolAttachments(result) };
+    }
+
+    try {
+      return { result, extracted: extractToolAttachments(result) };
+    } catch (err) {
+      result = {
+        status: 'error',
+        error: `${call.name}: Tool returned an invalid result (${toErrorMessage(err)})`,
       };
       return { result, extracted: extractToolAttachments(result) };
     }
@@ -425,6 +436,7 @@ export class ToolUseDispatchNode<C> extends Node<
       trackedEdits.lineChanges
     ) {
       result.lineChanges = trackedEdits.lineChanges;
+      extracted.sanitizedResult.lineChanges = trackedEdits.lineChanges;
     }
 
     const editedFiles = trackedEdits.paths.map((path) => ({

--- a/src/shared/schemas/toolResult.ts
+++ b/src/shared/schemas/toolResult.ts
@@ -20,7 +20,7 @@ export type FileReference = z.infer<typeof FileReferenceSchema>;
  * Schema for file attachments with optional binary data.
  * Extends FileReferenceSchema with binary payload fields.
  */
-export const ToolFileAttachmentSchema = FileReferenceSchema.extend({
+const ToolFileAttachmentSchema = FileReferenceSchema.extend({
   /** Base64 encoded payload when inline transport is supported */
   base64Data: z.string().optional(),
   /** Raw bytes for providers that require binary uploads */

--- a/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
+++ b/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
@@ -213,7 +213,7 @@ describe('ToolUseDispatchNode parallel dispatch', () => {
         assert.equal(execution?.result.status, 'error');
         assert.match(
           execution?.result.status === 'error' ? execution.result.error : '',
-          /malformed_attachment/i,
+          /malformed_attachment: Tool returned an invalid result/i,
         );
       },
     );

--- a/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
+++ b/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
@@ -187,6 +187,38 @@ function assertDuplicateInheritsOutput(results: ExecResult[]): void {
 describe('ToolUseDispatchNode parallel dispatch', () => {
   beforeAll(() => installPlatform({ workspacePath: '/workspace' }));
 
+  it('converts a malformed attachment result into a tool error', async () => {
+    const malformedAttachmentTool: ITool = {
+      definition: {
+        name: 'malformed_attachment',
+        description: 'malformed_attachment',
+        parameters: {},
+      },
+      async call(): Promise<ToolResult> {
+        return {
+          status: 'executed',
+          output: 'not accepted',
+          files: [{ path: 42, mimeType: 'image/png' }],
+        } as unknown as ToolResult;
+      },
+    } as ITool;
+
+    await withDispatchHarness(
+      { tools: { malformed_attachment: malformedAttachmentTool } },
+      async ({ node }) => {
+        const [execution] = (await runDispatch(node, [
+          makeCall('c1', 'malformed_attachment', {}),
+        ])) as ExecResult[];
+
+        assert.equal(execution?.result.status, 'error');
+        assert.match(
+          execution?.result.status === 'error' ? execution.result.error : '',
+          /malformed_attachment/i,
+        );
+      },
+    );
+  });
+
   it('preserves the unwrapped root instruction across nested delegation', async () => {
     let observedInstruction: string | undefined;
     let observedTrace: unknown;


### PR DESCRIPTION
Part of #10764

## Summary
- validate tool attachments once through the source tool-result schema, removing the silent per-file filter
- move attachment extraction under the existing tool invocation error boundary
- convert malformed runtime attachment results into ordinary tool errors instead of letting them escape the run
- remove the redundant re-parse of the constructed sanitized result

## Validation
- `corepack pnpm exec vitest run src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts` (40 passed)
- `corepack pnpm run typecheck:workspace`
- `corepack pnpm run typecheck:test-kernel`
- changed-file ESLint
- `git diff --check`

Production: +15/-20. Tests: +33/-1.